### PR TITLE
Fix issue with saving freshly computed stats

### DIFF
--- a/lerobot/common/datasets/factory.py
+++ b/lerobot/common/datasets/factory.py
@@ -70,7 +70,7 @@ def make_dataset(
                     transform=Prod(in_keys=clsfunc.image_keys, prod=1 / 255.0),
                 )
                 stats = compute_stats(stats_dataset)
-                os.makedirs(precomputed_stats_path.parent, exist_ok=True)
+                precomputed_stats_path.parent.mkdir(parents=True, exist_ok=True)
                 torch.save(stats, precomputed_stats_path)
         else:
             stats = torch.load(stats_path)


### PR DESCRIPTION
The dataset factory path where there are no precomputed stats was attempting to save the stats in the wrong location. I know stats are going to be moved to the policy soon, so this is a temporary fix whereby the stats are saved in `data/`.