### PR TITLE
Update UmiProcessor default fps to 10

### DIFF
--- a/lerobot/common/datasets/push_dataset_to_hub/umi_processor.py
+++ b/lerobot/common/datasets/push_dataset_to_hub/umi_processor.py
@@ -30,8 +30,8 @@ class UmiProcessor:
     def __init__(self, folder_path: str, fps: int | None = None):
         self.zarr_path = folder_path
         if fps is None:
-            # TODO (azouitine): Add reference to the paper
-            fps = 15
+            # https://arxiv.org/pdf/2402.10329#table.caption.16
+            fps = 10  # For umi cup in the wild
         self._fps = fps
         register_codecs()
 


### PR DESCRIPTION
# What does this PR do?
- Fixes the default FPS setting for `UmiProcessor`.

The default value merged in PR #95 is inconsistent with the value reported in the [UMI Cup in the Wild paper](https://arxiv.org/pdf/2402.10329#table.caption.16) and the version published on the Hugging Face Hub. For reference, see the metadata here: [Hugging Face Hub metadata](https://huggingface.co/datasets/lerobot/umi_cup_in_the_wild/blob/main/meta_data/info.json).
