### PR TITLE
Remove mask check key in XarmProcessor

### DIFF
--- a/lerobot/common/datasets/push_dataset_to_hub/xarm_processor.py
+++ b/lerobot/common/datasets/push_dataset_to_hub/xarm_processor.py
@@ -18,7 +18,7 @@ class XarmProcessor:
 
     def __init__(self, folder_path: str, fps: int | None = None):
         self.folder_path = Path(folder_path)
-        self.keys = {"actions", "rewards", "dones", "masks"}
+        self.keys = {"actions", "rewards", "dones"}
         self.nested_keys = {"observations": {"rgb", "state"}, "next_observations": {"rgb", "state"}}
         if fps is None:
             fps = 15


### PR DESCRIPTION
When I experimented with all the dataset processors, I discovered that the mask key could result in an invalid format, even in the Xarm dataset. I removed the check for the mask key (since this key is never used in the preprocessing part).