### PR TITLE
Log locally with tensorbaord when wandb is disabled.

### DIFF
--- a/lerobot/common/logger.py
+++ b/lerobot/common/logger.py
@@ -51,7 +51,6 @@ class Logger:
         entity = cfg.get("wandb", {}).get("entity")
         enable_wandb = cfg.get("wandb", {}).get("enable", False)
         run_offline = not enable_wandb or not project
-        self.run_offline = run_offline
         if run_offline:
             logging.info(colored("Logs will be saved locally.", "yellow", attrs=["bold"]))
             self._local_writer = SummaryWriter(log_dir=self._log_dir)

--- a/lerobot/scripts/train.py
+++ b/lerobot/scripts/train.py
@@ -349,8 +349,7 @@ def train(cfg: dict, out_dir=None, job_name=None):
                 start_seed=cfg.seed,
             )
             log_eval_info(logger, eval_info["aggregated"], step, cfg, offline_dataset, is_offline)
-            if cfg.wandb.enable:
-                logger.log_video(eval_info["video_paths"][0], step, mode="eval")
+            logger.log_video(eval_info["video_paths"][0], step, mode="eval")
             logging.info("Resume training")
 
         if cfg.training.save_model and step % cfg.training.save_freq == 0:


### PR DESCRIPTION
## What this does
This PR adds support for locally logging metrics and videos using tensorboard when wandb is disabled.

## How it was tested
- Ran with a short eval_freq and log_freq to ensure metric and video logging worked through multiple periods. 
- ran pytests (passed)

## How to checkout & try? (for the reviewer)
Run with wandb.enable=false and short eval / log freqs. e.g.
python lerobot/scripts/train.py policy=diffusion env=pusht env.task=PushT-v0 dataset_repo_id=lerobot/pusht training.log_freq=10 training.eval_freq=100 wandb.enable=false
