### PR TITLE
Make `delta_timestamps` in the policy

### DIFF
--- a/lerobot/common/datasets/factory.py
+++ b/lerobot/common/datasets/factory.py
@@ -16,19 +16,9 @@ def make_dataset(
             f"environment ({cfg.env.name=})."
         )
 
-    delta_timestamps = cfg.training.get("delta_timestamps")
-    if delta_timestamps is not None:
-        for key in delta_timestamps:
-            if isinstance(delta_timestamps[key], str):
-                delta_timestamps[key] = eval(delta_timestamps[key])
-
     # TODO(rcadene): add data augmentations
 
-    dataset = LeRobotDataset(
-        cfg.dataset_repo_id,
-        split=split,
-        delta_timestamps=delta_timestamps,
-    )
+    dataset = LeRobotDataset(cfg.dataset_repo_id, split=split)
 
     if cfg.get("override_dataset_stats"):
         for key, stats_dict in cfg.override_dataset_stats.items():

--- a/lerobot/common/policies/diffusion/modeling_diffusion.py
+++ b/lerobot/common/policies/diffusion/modeling_diffusion.py
@@ -126,6 +126,17 @@ class DiffusionPolicy(nn.Module, PyTorchModelHubMixin):
         loss = self.diffusion.compute_loss(batch)
         return {"loss": loss}
 
+    def make_delta_timestamps(self, fps: float):
+        """Makes delta_timestamps dictionary need for LeRobotDataset to return sequences of frames."""
+        return {
+            "observation.image": [i / fps for i in range(1 - self.config.n_obs_steps, 1)],
+            "observation.state": [i / fps for i in range(1 - self.config.n_obs_steps, 1)],
+            "action": [
+                i / fps
+                for i in range(1 - self.config.n_obs_steps, 1 - self.config.n_obs_steps + self.config.horizon)
+            ],
+        }
+
 
 def _make_noise_scheduler(name: str, **kwargs: dict) -> DDPMScheduler | DDIMScheduler:
     """

--- a/lerobot/common/policies/policy_protocol.py
+++ b/lerobot/common/policies/policy_protocol.py
@@ -48,6 +48,9 @@ class Policy(Protocol):
         with caching.
         """
 
+    def make_delta_timestamps(self, fps: float) -> dict[str, list[float]]:
+        """Makes delta_timestamps dictionary need for LeRobotDataset to return sequences of frames."""
+
 
 @runtime_checkable
 class PolicyWithUpdate(Policy, Protocol):

--- a/lerobot/configs/policy/diffusion.yaml
+++ b/lerobot/configs/policy/diffusion.yaml
@@ -25,11 +25,6 @@ training:
   adam_weight_decay: 1.0e-6
   online_steps_between_rollouts: 1
 
-  delta_timestamps:
-    observation.image: "[i / ${fps} for i in range(1 - ${policy.n_obs_steps}, 1)]"
-    observation.state: "[i / ${fps} for i in range(1 - ${policy.n_obs_steps}, 1)]"
-    action: "[i / ${fps} for i in range(1 - ${policy.n_obs_steps}, 1 - ${policy.n_obs_steps} + ${policy.horizon})]"
-
 eval:
   n_episodes: 50
   batch_size: 50

--- a/lerobot/scripts/train.py
+++ b/lerobot/scripts/train.py
@@ -316,6 +316,7 @@ def train(cfg: dict, out_dir=None, job_name=None):
 
     logging.info("make_policy")
     policy = make_policy(hydra_cfg=cfg, dataset_stats=offline_dataset.stats)
+    offline_dataset.delta_timestamps = policy.make_delta_timestamps(eval_env.fps)
 
     # Create optimizer and scheduler
     # Temporary hack to move optimizer out of policy


### PR DESCRIPTION
## What this does
This PR is a moves the `delta_timestamps` logic to the policy. The reasons for doing so are:

1. We don't want to use an `eval` for dynamically evaluating a config expression.
2. The policy should really own this logic as it almost entirely depends on policy hyperparameters (apart from fps).
3. There are no hyperparameters dedicated to `delta_timestamps` alone, so it should be made at runtime. 

## How it was tested
Explain/show how you tested your changes.

Examples:
- Added `test_something` in `tests/test_stuff.py`.
- Added `new_feature` and checked that training converges with policy X on dataset/environment Y.
- Optimized `some_function`, it now runs X times faster than previously.

## How to checkout & try? (for the reviewer)
Provide a simple way for the reviewer to try out your changes.

Examples:
```bash
DATA_DIR=tests/data pytest -sx tests/test_stuff.py::test_something
```
```bash
python lerobot/scripts/train.py --some.option=true
```

## SECTION TO REMOVE BEFORE SUBMITTING YOUR PR
**Note**: Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR. Try to avoid tagging more than 3 people.

**Note**: Before submitting this PR, please read the [contributor guideline](https://github.com/huggingface/lerobot/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr).
