### PR TITLE
Fixes issue #152 - error with creating wandb artifact

### DIFF
--- a/lerobot/common/logger.py
+++ b/lerobot/common/logger.py
@@ -98,7 +98,7 @@ class Logger:
         self._buffer_dir.mkdir(parents=True, exist_ok=True)
         fp = self._buffer_dir / f"{str(identifier)}.pkl"
         buffer.save(fp)
-        if self._wandb:
+        if self._wandb and not self._disable_wandb_artifact:
             # note wandb artifact does not accept ":" or "/" in its name
             artifact = self._wandb.Artifact(
                 self._group.replace(":", "_").replace("/", "_")

--- a/lerobot/common/logger.py
+++ b/lerobot/common/logger.py
@@ -84,8 +84,7 @@ class Logger:
             if self._wandb and not self._disable_wandb_artifact:
                 # note wandb artifact does not accept ":" or "/" in its name
                 artifact = self._wandb.Artifact(
-                    self._group.replace(":", "_").replace("/", "_")
-                    + f"-{self._seed}-{identifier}",
+                    f"{self._group.replace(':', '_').replace('/', '_')}-{self._seed}-{identifier}",
                     type="model",
                 )
                 artifact.add_file(save_dir / SAFETENSORS_SINGLE_FILE)
@@ -98,8 +97,7 @@ class Logger:
         if self._wandb and not self._disable_wandb_artifact:
             # note wandb artifact does not accept ":" or "/" in its name
             artifact = self._wandb.Artifact(
-                self._group.replace(":", "_").replace("/", "_")
-                + f"-{self._seed}-{identifier}",
+                f"{self._group.replace(':', '_').replace('/', '_')}-{self._seed}-{identifier}",
                 type="buffer",
             )
             artifact.add_file(fp)

--- a/lerobot/common/logger.py
+++ b/lerobot/common/logger.py
@@ -102,10 +102,7 @@ class Logger:
             # note wandb artifact does not accept ":" or "/" in its name
             artifact = self._wandb.Artifact(
                 self._group.replace(":", "_").replace("/", "_")
-                + "-"
-                + str(self._seed)
-                + "-"
-                + str(identifier),
+                + f"-{self._seed}-{identifier}",
                 type="buffer",
             )
             artifact.add_file(fp)

--- a/lerobot/common/logger.py
+++ b/lerobot/common/logger.py
@@ -85,10 +85,7 @@ class Logger:
                 # note wandb artifact does not accept ":" or "/" in its name
                 artifact = self._wandb.Artifact(
                     self._group.replace(":", "_").replace("/", "_")
-                    + "-"
-                    + str(self._seed)
-                    + "-"
-                    + str(identifier),
+                    + f"-{self._seed}-{identifier}",
                     type="model",
                 )
                 artifact.add_file(save_dir / SAFETENSORS_SINGLE_FILE)

--- a/lerobot/common/logger.py
+++ b/lerobot/common/logger.py
@@ -82,9 +82,13 @@ class Logger:
             # Also save the full Hydra config for the env configuration.
             OmegaConf.save(self._cfg, save_dir / "config.yaml")
             if self._wandb and not self._disable_wandb_artifact:
-                # note wandb artifact does not accept ":" in its name
+                # note wandb artifact does not accept ":" or "/" in its name
                 artifact = self._wandb.Artifact(
-                    self._group.replace(":", "_") + "-" + str(self._seed) + "-" + str(identifier),
+                    self._group.replace(":", "_").replace("/", "_")
+                    + "-"
+                    + str(self._seed)
+                    + "-"
+                    + str(identifier),
                     type="model",
                 )
                 artifact.add_file(save_dir / SAFETENSORS_SINGLE_FILE)
@@ -95,8 +99,13 @@ class Logger:
         fp = self._buffer_dir / f"{str(identifier)}.pkl"
         buffer.save(fp)
         if self._wandb:
+            # note wandb artifact does not accept ":" or "/" in its name
             artifact = self._wandb.Artifact(
-                self._group + "-" + str(self._seed) + "-" + str(identifier),
+                self._group.replace(":", "_").replace("/", "_")
+                + "-"
+                + str(self._seed)
+                + "-"
+                + str(identifier),
                 type="buffer",
             )
             artifact.add_file(fp)


### PR DESCRIPTION
## What this does
Quick fix for #152. 

Unnecessary if the string name for the datasets change. More discussion here: f80902b 

## How it was tested
Ran training with a dataset with `/` in the string. Confirmed not to error. 

Run all tests except `test_examples_3_and_2`. Passed.


## How to checkout & try?
Run training with a dataset with `/` in the string. E.g.:
```
python lerobot/scripts/train.py     policy=act     env=aloha     env.task=AlohaInsertion-v0     dataset_repo_id=lerobot/aloha_sim_insertion_human
```