### PR TITLE
feat: add dataset_version as arg

### DIFF
--- a/lerobot/common/datasets/factory.py
+++ b/lerobot/common/datasets/factory.py
@@ -26,6 +26,7 @@ def make_dataset(
 
     dataset = LeRobotDataset(
         cfg.dataset_repo_id,
+        version=cfg.dataset_version,
         split=split,
         delta_timestamps=delta_timestamps,
     )

--- a/lerobot/configs/default.yaml
+++ b/lerobot/configs/default.yaml
@@ -14,6 +14,7 @@ device: cuda  # cpu
 # AND for the evaluation environments.
 seed: ???
 dataset_repo_id: lerobot/pusht
+dataset_version: "v1.3"
 
 training:
   offline_steps: ???


### PR DESCRIPTION
## What this does

Datasets on huggingface don't have uniform tags. Default is set to `v1.3` in `lerobot_dataset.py`. This exposes the dataset version as an arg.

Example use:
```
python lerobot/scripts/train.py \
policy=act \
env=aloha \
env.task=AlohaInsertion-v0 \
dataset_repo_id=lerobot/aloha_sim_insertion_human_image \
dataset_version=v1.4
```


## How it was tested
```
python lerobot/scripts/train.py \
policy=act \
env=aloha \
env.task=AlohaInsertion-v0 \
dataset_repo_id=lerobot/aloha_sim_insertion_human_image \
dataset_version=v1.4
```

## How to checkout & try? (for the reviewer)
Checkout branch and try above command. 