### PR TITLE
set n_encoder_layers for ACT to 7

### DIFF
--- a/lerobot/common/policies/act/configuration_act.py
+++ b/lerobot/common/policies/act/configuration_act.py
@@ -115,7 +115,7 @@ class ACTConfig:
     dim_feedforward: int = 3200
     feedforward_activation: str = "relu"
     n_encoder_layers: int = 4
-    n_decoder_layers: int = 1
+    n_decoder_layers: int = 7
     # VAE.
     use_vae: bool = True
     latent_dim: int = 32


### PR DESCRIPTION
## What this does

According to the paper (and ACT code) there were 7 decoder layers in the encoder-decoder transformer.

![image](https://github.com/huggingface/lerobot/assets/2444926/ce042757-83d3-4397-9762-13d7a75af5b0)


## How to checkout & try? (for the reviewer)

I haven't :slightly_smiling_face: yet at least

But will verify once I instantiate the arch and check parameter count (ACT had ~84 million params)