### PR TITLE
Adds bridgedatav2 dataset

### DIFF
--- a/lerobot/__init__.py
+++ b/lerobot/__init__.py
@@ -69,6 +69,7 @@ available_datasets_per_env = {
         "lerobot/aloha_sim_insertion_scripted_image",
         "lerobot/aloha_sim_transfer_cube_human_image",
         "lerobot/aloha_sim_transfer_cube_scripted_image",
+        "lerobot/bridgedatav2_scripted",
     ],
     "pusht": ["lerobot/pusht", "lerobot/pusht_image"],
     "xarm": [

--- a/lerobot/common/datasets/push_dataset_to_hub/bridgedatav2_format.py
+++ b/lerobot/common/datasets/push_dataset_to_hub/bridgedatav2_format.py
@@ -19,27 +19,48 @@ import gc
 import os
 import pickle
 import shutil
+from datetime import datetime
 from pathlib import Path
 
 import torch
 import tqdm
+from datasets import Dataset, Features, Image, Sequence, Value
 from PIL import Image as PILImage
 
 from lerobot.common.datasets.push_dataset_to_hub.utils import concatenate_episodes, save_images_concurrently
-from lerobot.common.datasets.video_utils import encode_video_frames
+from lerobot.common.datasets.utils import (
+    hf_transform_to_torch,
+)
+from lerobot.common.datasets.video_utils import VideoFrame, encode_video_frames
 
 
 def check_format(raw_dir) -> bool:
     traj_search_path = os.path.join("**", "traj_group*", "traj*")
     traj_folders = list(raw_dir.glob(traj_search_path))
+
     assert len(traj_folders) != 0
     for traj in traj_folders:
-        if len(list(traj.glob("*.pkl"))) == 2:
+        # Data collected prior to 7-23 has a delay of 1, otherwise a delay of 0
+        date_time = datetime.strptime(str(traj).split("/")[-4], "%Y-%m-%d_%H-%M-%S")
+        latency_shift = date_time < datetime(2021, 7, 23)
+        is_in_scripted_raw = "scripted_raw" in str(traj)
+        if len(list(traj.glob("*.pkl"))) == 2:  # ~30 trajectories dont have both files
             actions = load_actions(traj)
             num_frames = len(list(traj.glob(os.path.join("images0", "*.jpg"))))
-            assert len(actions) == num_frames - 1
-            state = load_state(traj)
-            assert len(state) == num_frames
+            state, time_stamp = load_state_timestamp(traj)
+            if is_in_scripted_raw:
+                assert len(actions) == num_frames - 1
+                assert len(state) == num_frames
+                assert len(time_stamp) == num_frames
+            else:
+                if latency_shift:
+                    assert len(actions) == num_frames - 1
+                    assert len(state) == num_frames - 1
+                    assert len(time_stamp) == num_frames - 1
+                else:
+                    assert len(actions) == num_frames - 1
+                    assert len(state) == num_frames
+                    assert len(time_stamp) == num_frames
 
 
 def load_actions(path):
@@ -51,11 +72,11 @@ def load_actions(path):
     return act_list
 
 
-def load_state(path):
+def load_state_timestamp(path):
     fp = os.path.join(path, "obs_dict.pkl")
     with open(fp, "rb") as f:
         x = pickle.load(f)
-    return x["full_state"]
+    return x["full_state"], x["time_stamp"]
 
 
 def load_from_raw(raw_dir, out_dir, fps, video, debug):
@@ -69,6 +90,12 @@ def load_from_raw(raw_dir, out_dir, fps, video, debug):
         if len(list(ep_path.glob("*.pkl"))) != 2:
             continue
 
+        is_in_scripted_raw = "scripted_raw" in str(ep_path)
+
+        if not is_in_scripted_raw:
+            date_time = datetime.strptime(str(ep_path).split("/")[-4], "%Y-%m-%d_%H-%M-%S")
+            latency_shift = date_time < datetime(2021, 7, 23)
+
         image_paths = list(ep_path.glob(os.path.join("images0", "*.jpg")))
         num_frames = len(image_paths)
 
@@ -76,10 +103,18 @@ def load_from_raw(raw_dir, out_dir, fps, video, debug):
         done[-1] = True
 
         actions = load_actions(ep_path)
-        state = load_state(ep_path)
+        state, time_stamp = load_state_timestamp(ep_path)
         ep_dict = {}
         img_key = "observation.image"
         imgs_array = [PILImage.open(x) for x in image_paths]
+
+        if is_in_scripted_raw:
+            actions = [actions[0]] + actions  # duplicate first action to compensate for extra frame
+        else:
+            if latency_shift:
+                state = state[1:]
+                actions = actions[1:]
+                time_stamp = time_stamp[1:]
 
         if video:
             # save png images in temporary directory
@@ -103,8 +138,12 @@ def load_from_raw(raw_dir, out_dir, fps, video, debug):
         ep_dict["observation.state"] = state
         ep_dict["episode_index"] = torch.tensor([ep_idx] * num_frames)
         ep_dict["frame_index"] = torch.arange(0, num_frames, 1)
-        ep_dict["timestamp"] = torch.arange(0, num_frames, 1) / fps
+        ep_dict["timestamp"] = torch.tensor(time_stamp)
         ep_dict["next.done"] = done
+
+        if len(actions) != len(state):
+            print(str(len(actions)) + " " + str(len(state)) + " " + str(num_frames))
+            print(ep_path)
 
         assert isinstance(ep_idx, int)
         ep_dicts.append(ep_dict)
@@ -123,11 +162,38 @@ def load_from_raw(raw_dir, out_dir, fps, video, debug):
     return data_dict, episode_data_index
 
 
+def to_hf_dataset(data_dict, video) -> Dataset:
+    features = {}
+    if video:
+        features["observation.image"] = VideoFrame()
+    else:
+        features["observation.image"] = Image()
+    features["observation.state"] = Sequence(
+        length=len(data_dict["observation.state"][0]), feature=Value(dtype="float32", id=None)
+    )
+    features["action"] = Sequence(length=len(data_dict["action"][0]), feature=Value(dtype="float32", id=None))
+    features["episode_index"] = Value(dtype="int64", id=None)
+    features["frame_index"] = Value(dtype="int64", id=None)
+    features["timestamp"] = Value(dtype="float32", id=None)
+    features["next.done"] = Value(dtype="bool", id=None)
+    features["index"] = Value(dtype="int64", id=None)
+
+    hf_dataset = Dataset.from_dict(data_dict, features=Features(features))
+    hf_dataset.set_transform(hf_transform_to_torch)
+    return hf_dataset
+
+
 def from_raw_to_lerobot_format(raw_dir: Path, out_dir: Path, fps=None, video=True, debug=False):
     # sanity check
     check_format(raw_dir)
 
     if fps is None:
-        fps = 12
+        fps = 30
 
     data_dir, episode_data_index = load_from_raw(raw_dir, out_dir, fps, video, debug)
+    hf_dataset = to_hf_dataset(data_dir, video)
+    info = {
+        "fps": fps,
+        "video": video,
+    }
+    return hf_dataset, episode_data_index, info

--- a/lerobot/common/datasets/push_dataset_to_hub/bridgedatav2_format.py
+++ b/lerobot/common/datasets/push_dataset_to_hub/bridgedatav2_format.py
@@ -15,9 +15,18 @@
 # limitations under the License.
 """Process BridgeData V2 files"""
 
+import gc
 import os
 import pickle
+import shutil
 from pathlib import Path
+
+import torch
+import tqdm
+from PIL import Image as PILImage
+
+from lerobot.common.datasets.push_dataset_to_hub.utils import concatenate_episodes, save_images_concurrently
+from lerobot.common.datasets.video_utils import encode_video_frames
 
 
 def check_format(raw_dir) -> bool:
@@ -49,6 +58,76 @@ def load_state(path):
     return x["full_state"]
 
 
+def load_from_raw(raw_dir, out_dir, fps, video, debug):
+    traj_search_path = os.path.join("**", "traj_group*", "traj*")
+    traj_folders = list(raw_dir.glob(traj_search_path))
+    ep_dicts = []
+    episode_data_index = {"from": [], "to": []}
+
+    id_from = 0
+    for ep_idx, ep_path in tqdm.tqdm(enumerate(traj_folders), total=len(traj_folders)):
+        if len(list(ep_path.glob("*.pkl"))) != 2:
+            continue
+
+        image_paths = list(ep_path.glob(os.path.join("images0", "*.jpg")))
+        num_frames = len(image_paths)
+
+        done = torch.zeros(num_frames, dtype=torch.bool)
+        done[-1] = True
+
+        actions = load_actions(ep_path)
+        state = load_state(ep_path)
+        ep_dict = {}
+        img_key = "observation.image"
+        imgs_array = [PILImage.open(x) for x in image_paths]
+
+        if video:
+            # save png images in temporary directory
+            tmp_imgs_dir = out_dir / "tmp_images"
+            save_images_concurrently(imgs_array, tmp_imgs_dir)  # TODO: this isn't working
+
+            # encode images to a mp4 video
+            fname = f"{img_key}_episode_{ep_idx:06d}.mp4"
+            video_path = out_dir / "videos" / fname
+            encode_video_frames(tmp_imgs_dir, video_path, fps)
+
+            # clean temporary images directory
+            shutil.rmtree(tmp_imgs_dir)
+
+            # store the reference to the video frame
+            ep_dict[img_key] = [{"path": f"videos/{fname}", "timestamp": i / fps} for i in range(num_frames)]
+        else:
+            ep_dict[img_key] = imgs_array
+
+        ep_dict["action"] = actions
+        ep_dict["observation.state"] = state
+        ep_dict["episode_index"] = torch.tensor([ep_idx] * num_frames)
+        ep_dict["frame_index"] = torch.arange(0, num_frames, 1)
+        ep_dict["timestamp"] = torch.arange(0, num_frames, 1) / fps
+        ep_dict["next.done"] = done
+
+        assert isinstance(ep_idx, int)
+        ep_dicts.append(ep_dict)
+
+        episode_data_index["from"].append(id_from)
+        episode_data_index["to"].append(id_from + num_frames)
+
+        id_from += num_frames
+
+        gc.collect()
+
+        # process first episode only
+        if debug:
+            break
+    data_dict = concatenate_episodes(ep_dicts)
+    return data_dict, episode_data_index
+
+
 def from_raw_to_lerobot_format(raw_dir: Path, out_dir: Path, fps=None, video=True, debug=False):
     # sanity check
     check_format(raw_dir)
+
+    if fps is None:
+        fps = 12
+
+    data_dir, episode_data_index = load_from_raw(raw_dir, out_dir, fps, video, debug)

--- a/lerobot/common/datasets/push_dataset_to_hub/bridgedatav2_format.py
+++ b/lerobot/common/datasets/push_dataset_to_hub/bridgedatav2_format.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+
+# Copyright 2024 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Process BridgeData V2 files"""
+
+import os
+import pickle
+from pathlib import Path
+
+
+def check_format(raw_dir) -> bool:
+    traj_search_path = os.path.join("**", "traj_group*", "traj*")
+    traj_folders = list(raw_dir.glob(traj_search_path))
+    assert len(traj_folders) != 0
+    for traj in traj_folders:
+        if len(list(traj.glob("*.pkl"))) == 2:
+            actions = load_actions(traj)
+            num_frames = len(list(traj.glob(os.path.join("images0", "*.jpg"))))
+            assert len(actions) == num_frames - 1
+            state = load_state(traj)
+            assert len(state) == num_frames
+
+
+def load_actions(path):
+    fp = os.path.join(path, "policy_out.pkl")
+    with open(fp, "rb") as f:
+        act_list = pickle.load(f)
+    if isinstance(act_list[0], dict):
+        act_list = [x["actions"] for x in act_list]
+    return act_list
+
+
+def load_state(path):
+    fp = os.path.join(path, "obs_dict.pkl")
+    with open(fp, "rb") as f:
+        x = pickle.load(f)
+    return x["full_state"]
+
+
+def from_raw_to_lerobot_format(raw_dir: Path, out_dir: Path, fps=None, video=True, debug=False):
+    # sanity check
+    check_format(raw_dir)

--- a/lerobot/scripts/push_dataset_to_hub.py
+++ b/lerobot/scripts/push_dataset_to_hub.py
@@ -71,6 +71,8 @@ def get_from_raw_to_lerobot_format_fn(raw_format: str):
         from lerobot.common.datasets.push_dataset_to_hub.xarm_pkl_format import from_raw_to_lerobot_format
     elif raw_format == "cam_png":
         from lerobot.common.datasets.push_dataset_to_hub.cam_png_format import from_raw_to_lerobot_format
+    elif raw_format == "bridgedatav2":
+        from lerobot.common.datasets.push_dataset_to_hub.bridgedatav2_format import from_raw_to_lerobot_format
     else:
         raise ValueError(
             f"The selected {raw_format} can't be found. Did you add it to `lerobot/scripts/push_dataset_to_hub.py::get_from_raw_to_lerobot_format_fn`?"


### PR DESCRIPTION
## What this does
Adds bridgedatav2 format. Currently supports scripted_raw directory
[Data set link](https://rail.eecs.berkeley.edu/datasets/bridge_release/data/)

## How to checkout & try? (for the reviewer)
run the from_raw_to_lerobot_format in bridgedatav2_format.py with files in ./data
example main function:
```
if __name__ == "__main__":
    dataset, _, _ = from_raw_to_lerobot_format(Path("./data"), Path("./out"), 30, False, True)
    print(dataset)
```
testing using scripts

```
python lerobot/scripts/push_dataset_to_hub.py --raw-dir data/bridge_data_v2 --repo-id lerobot/bridgedatav2_scripted --raw-format bridgedatav2 --dry-run 1 --local-dir data/lerobot/bridgedatav2_scripted --push-to-hub 0 --debug 1 --video 0 

export DATA_DIR='data/bridge_data_v2'
python lerobot/scripts/visualize_dataset.py --repo-id lerobot/bridgedatav2_scripted  --episode-index 0
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/huggingface/lerobot/210)
<!-- Reviewable:end -->
