### PR TITLE
throw an error if config.do_maks_loss and action_is_pad not provided in batch

### DIFF
--- a/lerobot/common/policies/diffusion/modeling_diffusion.py
+++ b/lerobot/common/policies/diffusion/modeling_diffusion.py
@@ -307,7 +307,7 @@ class DiffusionModel(nn.Module):
         if self.config.do_mask_loss_for_padding:
             if "action_is_pad" not in batch:
                 raise ValueError(
-                    "You need to provide 'action_is_pad' in the batch when config.do_mask_loss is set."
+                    f"You need to provide 'action_is_pad' in the batch when {self.config.do_mask_loss_for_padding=}."
                 )
             in_episode_bound = ~batch["action_is_pad"]
             loss = loss * in_episode_bound.unsqueeze(-1)

--- a/lerobot/common/policies/diffusion/modeling_diffusion.py
+++ b/lerobot/common/policies/diffusion/modeling_diffusion.py
@@ -304,7 +304,11 @@ class DiffusionModel(nn.Module):
         loss = F.mse_loss(pred, target, reduction="none")
 
         # Mask loss wherever the action is padded with copies (edges of the dataset trajectory).
-        if self.config.do_mask_loss_for_padding and "action_is_pad" in batch:
+        if self.config.do_mask_loss_for_padding:
+            if "action_is_pad" not in batch:
+                raise ValueError(
+                    "You need to provide 'action_is_pad' in the batch when config.do_mask_loss is set."
+                )
             in_episode_bound = ~batch["action_is_pad"]
             loss = loss * in_episode_bound.unsqueeze(-1)
 


### PR DESCRIPTION
## What this does

This is a tiny change but might save someone a lot of hassle.

In the original implementation, we were saying: "oh cool, you want to mask the loss (that is what you set in the config) but well, if you didn't provide the `action_is_pad` in the batch, guess we will just ignore what you really wanted and just do something else".

I believe that the `config` should always take primacy and the user should not be ever saved like this, it is much better to throw an error

If we ignore the config this might lead to subtle bugs where the user expects some behavior, but gets something else, and troubleshooting this can be quite hard.

In fact, I would probably prefer this version even with the `ValueError` raised explicitly as it will be the same effect and as slightly more concise
``` 
        if self.config.do_mask_loss_for_padding:
            in_episode_bound = ~batch["action_is_pad"]
            loss = loss * in_episode_bound.unsqueeze(-1)
```

But maybe being more informative for the user via those extra two lines has its merits too :slightly_smiling_face: 

Anyhow, completely up to you. Also, fully understood if your take on this might be different!