### PR TITLE
Fix nightly builds

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -34,6 +34,8 @@ jobs:
 
       - name: Check out code
         uses: actions/checkout@v4
+        with:
+          lfs: true
 
       - name: Login to DockerHub
         uses: docker/login-action@v3
@@ -72,6 +74,8 @@ jobs:
 
       - name: Check out code
         uses: actions/checkout@v4
+        with:
+          lfs: true
 
       - name: Login to DockerHub
         uses: docker/login-action@v3


### PR DESCRIPTION
## What this does
Test artifacts were not `git lfs` pulled when building docker images and instead only the reference files were present — which obviously fails when trying to read them. This adds git lfs when checking out code to fix it.

## How it was tested
Manually built & tested images on this branch successfully
- [Build run](https://github.com/huggingface/lerobot/actions/runs/9265632432)
- [Test run](https://github.com/huggingface/lerobot/actions/runs/9265859867)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/huggingface/lerobot/216)
<!-- Reviewable:end -->
