### PR TITLE
Add precision param to format_big_number

### DIFF
--- a/lerobot/common/utils/utils.py
+++ b/lerobot/common/utils/utils.py
@@ -120,13 +120,13 @@ def init_logging():
     logging.getLogger().addHandler(console_handler)
 
 
-def format_big_number(num):
+def format_big_number(num, precision=0):
     suffixes = ["", "K", "M", "B", "T", "Q"]
     divisor = 1000.0
 
     for suffix in suffixes:
         if abs(num) < divisor:
-            return f"{num:.0f}{suffix}"
+            return f"{num:.{precision}f}{suffix}"
         num /= divisor
 
     return num


### PR DESCRIPTION
Just a tiny addition to make the `format_big_number` more flexible.

Doesn't change default behavior but allows the caller to specify the precision of the returned value. Quite handy, as for millions or especially billion of params we might want to have that additional digit or two after the decimal point.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/huggingface/lerobot/232)
<!-- Reviewable:end -->
