### PR TITLE
Fix bug in normalize to avoid divide by zero

### DIFF
--- a/lerobot/common/policies/normalize.py
+++ b/lerobot/common/policies/normalize.py
@@ -147,7 +147,7 @@ class Normalize(nn.Module):
                 assert not torch.isinf(min).any(), _no_stats_error_str("min")
                 assert not torch.isinf(max).any(), _no_stats_error_str("max")
                 # normalize to [0,1]
-                batch[key] = (batch[key] - min) / (max - min)
+                batch[key] = (batch[key] - min) / (max - min + 1e-8)
                 # normalize to [-1, 1]
                 batch[key] = batch[key] * 2 - 1
             else:


### PR DESCRIPTION
## What this does
Fixes #211. Normalize class could have a divide by 0 problem, e.g. when some of the states or actions have a fixed value. 

## How it was tested
Tested after extending push T / Diffusion policy to a real robot and fixing the non-XY states / actions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/huggingface/lerobot/239)
<!-- Reviewable:end -->
