### PR TITLE
Remove redundant slicing operation in Diffusion Policy

### DIFF
--- a/lerobot/common/policies/diffusion/modeling_diffusion.py
+++ b/lerobot/common/policies/diffusion/modeling_diffusion.py
@@ -239,10 +239,8 @@ class DiffusionModel(nn.Module):
         global_cond = torch.cat([batch["observation.state"], img_features], dim=-1).flatten(start_dim=1)
 
         # run sampling
-        sample = self.conditional_sample(batch_size, global_cond=global_cond)
+        actions = self.conditional_sample(batch_size, global_cond=global_cond)
 
-        # `horizon` steps worth of actions (from the first observation).
-        actions = sample[..., : self.config.output_shapes["action"][0]]
         # Extract `n_action_steps` steps worth of actions (from the current observation).
         start = n_obs_steps - 1
         end = start + self.config.n_action_steps


### PR DESCRIPTION
## What this does

Removes `actions = sample[..., : self.config.output_shapes["action"][0]]` because given the logic in `conditional_sample` we are already guaranteed that `sample.shape[-1] == self.config.output_shapes["action"][0]`, and also because we end up making a smaller slice on the same dimension immediately after.

This was an artifact of the original DP code which has the same redundancy. Here, we remove it to avoid confusion (someone asked!)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/huggingface/lerobot/240)
<!-- Reviewable:end -->
