### PR TITLE
Fix `visualize_dataset.py --help`

### DIFF
--- a/lerobot/scripts/visualize_dataset.py
+++ b/lerobot/scripts/visualize_dataset.py
@@ -224,7 +224,8 @@ def main():
         help=(
             "Mode of viewing between 'local' or 'distant'. "
             "'local' requires data to be on a local machine. It spawns a viewer to visualize the data locally. "
-            "'distant' creates a server on the distant machine where the data is stored. Visualize the data by connecting to the server with `rerun ws://localhost:PORT` on the local machine."
+            "'distant' creates a server on the distant machine where the data is stored. "
+            "Visualize the data by connecting to the server with `rerun ws://localhost:PORT` on the local machine."
         ),
     )
     parser.add_argument(
@@ -245,8 +246,8 @@ def main():
         default=0,
         help=(
             "Save a .rrd file in the directory provided by `--output-dir`. "
-            "It also deactivates the spawning of a viewer. ",
-            "Visualize the data by running `rerun path/to/file.rrd` on your local machine.",
+            "It also deactivates the spawning of a viewer. "
+            "Visualize the data by running `rerun path/to/file.rrd` on your local machine."
         ),
     )
     parser.add_argument(


### PR DESCRIPTION
## What this does
Fixes
```bash
python lerobot/scripts/visualize_dataset.py --help
```
which returned
```bash
AttributeError: 'tuple' object has no attribute 'strip'
```

## How it was tested
N/A

## How to checkout & try? (for the reviewer)
N/A

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/huggingface/lerobot/241)
<!-- Reviewable:end -->
