### PR TITLE
Adding parameter dataloading_s to console logs and wandb for tracking…

### DIFF
--- a/lerobot/scripts/train.py
+++ b/lerobot/scripts/train.py
@@ -171,7 +171,7 @@ def log_train_info(logger: Logger, info, step, cfg, dataset, is_offline):
         f"lr:{lr:0.1e}",
         # in seconds
         f"updt_s:{update_s:.3f}",
-        f"dataloading_s:{dataloading_s:.3f}",
+        f"data_s:{dataloading_s:.3f}",  # if not ~0, you are bottlenecked by cpu or io
     ]
     logging.info(" ".join(log_items))
 

--- a/lerobot/scripts/train.py
+++ b/lerobot/scripts/train.py
@@ -171,7 +171,7 @@ def log_train_info(logger: Logger, info, step, cfg, dataset, is_offline):
         f"lr:{lr:0.1e}",
         # in seconds
         f"updt_s:{update_s:.3f}",
-        f"dloading_s:{dataloading_s:.3f}",
+        f"dataloading_s:{dataloading_s:.3f}",
     ]
     logging.info(" ".join(log_items))
 

--- a/lerobot/scripts/train.py
+++ b/lerobot/scripts/train.py
@@ -150,6 +150,7 @@ def log_train_info(logger: Logger, info, step, cfg, dataset, is_offline):
     grad_norm = info["grad_norm"]
     lr = info["lr"]
     update_s = info["update_s"]
+    dataloading_s = info["dataloading_s"]
 
     # A sample is an (observation,action) pair, where observation and action
     # can be on multiple timestamps. In a batch, we have `batch_size`` number of samples.
@@ -170,6 +171,7 @@ def log_train_info(logger: Logger, info, step, cfg, dataset, is_offline):
         f"lr:{lr:0.1e}",
         # in seconds
         f"updt_s:{update_s:.3f}",
+        f"dloading_s:{dataloading_s:.3f}",
     ]
     logging.info(" ".join(log_items))
 
@@ -382,7 +384,10 @@ def train(cfg: DictConfig, out_dir: str | None = None, job_name: str | None = No
     for _ in range(step, cfg.training.offline_steps):
         if step == 0:
             logging.info("Start offline training on a fixed dataset")
+
+        start_time = time.perf_counter()
         batch = next(dl_iter)
+        dataloading_s = time.perf_counter() - start_time
 
         for key in batch:
             batch[key] = batch[key].to(device, non_blocking=True)
@@ -396,6 +401,8 @@ def train(cfg: DictConfig, out_dir: str | None = None, job_name: str | None = No
             lr_scheduler=lr_scheduler,
             use_amp=cfg.use_amp,
         )
+
+        train_info["dataloading_s"] = dataloading_s
 
         if step % cfg.training.log_freq == 0:
             log_train_info(logger, train_info, step, cfg, offline_dataset, is_offline=True)


### PR DESCRIPTION
… the time it takes to load each batch of data while training

## What this does
Adds parameter dataloading_s to wandb logs and console logs. This implements the changes required for [this item](https://github.com/orgs/huggingface/projects/46/views/1?pane=issue&itemId=64693357)

## How it was tested
train.py run along with INFO logging was used to verify the new parameter's presence in wandb and console logs

## How to checkout & try? (for the reviewer)
command used to run : python lerobot/scripts/train.py wandb.enable=true training.offline_steps=10000 training.log_freq=10 training.eval_freq=25 training.save_freq=250

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/huggingface/lerobot/243)
<!-- Reviewable:end -->
