### PR TITLE
add root argument to the dataset visualizer to visualize local datasets

### DIFF
--- a/lerobot/scripts/visualize_dataset.py
+++ b/lerobot/scripts/visualize_dataset.py
@@ -106,6 +106,7 @@ def visualize_dataset(
     ws_port: int = 9087,
     save: bool = False,
     output_dir: Path | None = None,
+    root: Path | None = None,
 ) -> Path | None:
     if save:
         assert (
@@ -113,7 +114,7 @@ def visualize_dataset(
         ), "Set an output directory where to write .rrd files with `--output-dir path/to/directory`."
 
     logging.info("Loading dataset")
-    dataset = LeRobotDataset(repo_id)
+    dataset = LeRobotDataset(repo_id, root=root)
 
     logging.info("Loading dataloader")
     episode_sampler = EpisodeSampler(dataset, episode_index)
@@ -254,6 +255,12 @@ def main():
         "--output-dir",
         type=str,
         help="Directory path to write a .rrd file when `--save 1` is set.",
+    )
+
+    parser.add_argument(
+        "--root",
+        type=str,
+        help="Root directory for a dataset stored on a local machine.",
     )
 
     args = parser.parse_args()

--- a/tests/test_visualize_dataset.py
+++ b/tests/test_visualize_dataset.py
@@ -13,6 +13,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from pathlib import Path
+
 import pytest
 
 from lerobot.scripts.visualize_dataset import visualize_dataset
@@ -29,5 +31,22 @@ def test_visualize_dataset(tmpdir, repo_id):
         batch_size=32,
         save=True,
         output_dir=tmpdir,
+    )
+    assert rrd_path.exists()
+
+
+@pytest.mark.parametrize(
+    "repo_id",
+    ["lerobot/pusht"],
+)
+@pytest.mark.parametrize("root", [Path(__file__).parent / "data"])
+def test_visualize_local_dataset(tmpdir, repo_id, root):
+    rrd_path = visualize_dataset(
+        repo_id,
+        episode_index=0,
+        batch_size=32,
+        save=True,
+        output_dir=tmpdir,
+        root=root,
     )
     assert rrd_path.exists()


### PR DESCRIPTION
## What this does

This PR adds the `root` argument to the dataset visualizer. This parameter is passed to `LeRobotDataset.__init__`,  which enables visualizing local datasets, as an alternative to setting the `DATA_DIR` env variable.


closes #248 

## How it was tested
Explain/show how you tested your changes.

- added a unit test to `tests/test_visualize_dataset` that visualizes the local copy of the `lerobot/pusht` dataset 

## How to checkout & try? (for the reviewer)

Examples:
```
python lerobot/scripts/visualize_dataset.py --repo-id lerobot/pusht --root tests/data/ --episode-index 0 --mode distant
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/huggingface/lerobot/249)
<!-- Reviewable:end -->
