### PR TITLE
Make `display_sys_info.py` install-agnostic

### DIFF
--- a/lerobot/scripts/display_sys_info.py
+++ b/lerobot/scripts/display_sys_info.py
@@ -13,39 +13,71 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+"""Use this script to get a quick summary of your system config.
+It should be able to run without any of LeRobot's dependencies or LeRobot itself installed.
+"""
+
 import platform
 
-import huggingface_hub
+HAS_HF_HUB = True
+HAS_HF_DATASETS = True
+HAS_NP = True
+HAS_TORCH = True
+HAS_LEROBOT = True
 
-# import dataset
-import numpy as np
-import torch
+try:
+    import huggingface_hub
+except ImportError:
+    HAS_HF_HUB = False
 
-from lerobot import __version__ as version
+try:
+    import datasets
+except ImportError:
+    HAS_HF_DATASETS = False
 
-pt_version = torch.__version__
-pt_cuda_available = torch.cuda.is_available()
-pt_cuda_available = torch.cuda.is_available()
-cuda_version = torch._C._cuda_getCompiledVersion() if torch.version.cuda is not None else "N/A"
+try:
+    import numpy as np
+except ImportError:
+    HAS_NP = False
+
+try:
+    import torch
+except ImportError:
+    HAS_TORCH = False
+
+try:
+    import lerobot
+except ImportError:
+    HAS_LEROBOT = False
+
+
+lerobot_version = lerobot.__version__ if HAS_LEROBOT else "N/A"
+hf_hub_version = huggingface_hub.__version__ if HAS_HF_HUB else "N/A"
+hf_datasets_version = datasets.__version__ if HAS_HF_DATASETS else "N/A"
+np_version = np.__version__ if HAS_NP else "N/A"
+
+torch_version = torch.__version__ if HAS_TORCH else "N/A"
+torch_cuda_available = torch.cuda.is_available() if HAS_TORCH else "N/A"
+cuda_version = torch._C._cuda_getCompiledVersion() if HAS_TORCH and torch.version.cuda is not None else "N/A"
 
 
 # TODO(aliberts): refactor into an actual command `lerobot env`
 def display_sys_info() -> dict:
     """Run this to get basic system info to help for tracking issues & bugs."""
     info = {
-        "`lerobot` version": version,
+        "`lerobot` version": lerobot_version,
         "Platform": platform.platform(),
         "Python version": platform.python_version(),
-        "Huggingface_hub version": huggingface_hub.__version__,
-        # TODO(aliberts): Add dataset when https://github.com/huggingface/lerobot/pull/73 is merged
-        # "Dataset version": dataset.__version__,
-        "Numpy version": np.__version__,
-        "PyTorch version (GPU?)": f"{pt_version} ({pt_cuda_available})",
+        "Huggingface_hub version": hf_hub_version,
+        "Dataset version": hf_datasets_version,
+        "Numpy version": np_version,
+        "PyTorch version (GPU?)": f"{torch_version} ({torch_cuda_available})",
         "Cuda version": cuda_version,
         "Using GPU in script?": "<fill in>",
-        "Using distributed or parallel set-up in script?": "<fill in>",
+        # "Using distributed or parallel set-up in script?": "<fill in>",
     }
-    print("\nCopy-and-paste the text below in your GitHub issue and FILL OUT the two last points.\n")
+    print("\nCopy-and-paste the text below in your GitHub issue and FILL OUT the last point.\n")
     print(format_dict(info))
     return info
 


### PR DESCRIPTION
## What this does
Make `display_sys_info.py` install-agnostic so that any user can run it without having installed lerobot (usefull if one have issues installing the library and needs help).

## How it was tested
Ran it successfully on a fresh conda env with nothing but python installed.

## How to checkout & try? (for the reviewer)
```bash
python lerobot/scripts/display_sys_info.py
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/huggingface/lerobot/253)
<!-- Reviewable:end -->
