### PR TITLE
FIx make_dataset to match transforms config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,7 @@ on:
       - "examples/**"
       - ".github/**"
       - "poetry.lock"
+      - "Makefile"
   push:
     branches:
       - main
@@ -19,6 +20,7 @@ on:
       - "examples/**"
       - ".github/**"
       - "poetry.lock"
+      - "Makefile"
 
 jobs:
   pytest:

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ test-act-ete-train:
 		policy.n_action_steps=20 \
 		policy.chunk_size=20 \
 		training.batch_size=2 \
-    	training.image_transforms.enable=true \
+    	        training.image_transforms.enable=true \
 		hydra.run.dir=tests/outputs/act/
 
 test-act-ete-eval:
@@ -74,7 +74,7 @@ test-act-ete-train-amp:
 		policy.chunk_size=20 \
 		training.batch_size=2 \
 		hydra.run.dir=tests/outputs/act_amp/ \
-    	training.image_transforms.enable=true \
+    	        training.image_transforms.enable=true \
 		use_amp=true
 
 test-act-ete-eval-amp:
@@ -102,7 +102,7 @@ test-diffusion-ete-train:
 		training.save_checkpoint=true \
 		training.save_freq=2 \
 		training.batch_size=2 \
-    	training.image_transforms.enable=true \
+    	        training.image_transforms.enable=true \
 		hydra.run.dir=tests/outputs/diffusion/
 
 test-diffusion-ete-eval:
@@ -130,7 +130,7 @@ test-tdmpc-ete-train:
 		training.save_checkpoint=true \
 		training.save_freq=2 \
 		training.batch_size=2 \
-    	training.image_transforms.enable=true \
+    	        training.image_transforms.enable=true \
 		hydra.run.dir=tests/outputs/tdmpc/
 
 test-tdmpc-ete-eval:

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ PYTHON_PATH := $(shell which python)
 # If Poetry is installed, redefine PYTHON_PATH to use the Poetry-managed Python
 POETRY_CHECK := $(shell command -v poetry)
 ifneq ($(POETRY_CHECK),)
-    PYTHON_PATH := $(shell poetry run which python)
+	PYTHON_PATH := $(shell poetry run which python)
 endif
 
 export PATH := $(dir $(PYTHON_PATH)):$(PATH)
@@ -46,7 +46,7 @@ test-act-ete-train:
 		policy.n_action_steps=20 \
 		policy.chunk_size=20 \
 		training.batch_size=2 \
-    	        training.image_transforms.enable=true \
+		training.image_transforms.enable=true \
 		hydra.run.dir=tests/outputs/act/
 
 test-act-ete-eval:
@@ -74,7 +74,7 @@ test-act-ete-train-amp:
 		policy.chunk_size=20 \
 		training.batch_size=2 \
 		hydra.run.dir=tests/outputs/act_amp/ \
-    	        training.image_transforms.enable=true \
+		training.image_transforms.enable=true \
 		use_amp=true
 
 test-act-ete-eval-amp:
@@ -102,7 +102,7 @@ test-diffusion-ete-train:
 		training.save_checkpoint=true \
 		training.save_freq=2 \
 		training.batch_size=2 \
-    	        training.image_transforms.enable=true \
+		training.image_transforms.enable=true \
 		hydra.run.dir=tests/outputs/diffusion/
 
 test-diffusion-ete-eval:
@@ -130,7 +130,7 @@ test-tdmpc-ete-train:
 		training.save_checkpoint=true \
 		training.save_freq=2 \
 		training.batch_size=2 \
-    	        training.image_transforms.enable=true \
+		training.image_transforms.enable=true \
 		hydra.run.dir=tests/outputs/tdmpc/
 
 test-tdmpc-ete-eval:
@@ -163,5 +163,6 @@ test-act-pusht-tutorial:
 		training.save_model=true \
 		training.save_freq=2 \
 		training.batch_size=2 \
+		training.image_transforms.enable=true \
 		hydra.run.dir=tests/outputs/act_pusht/
 	rm lerobot/configs/policy/created_by_Makefile.yaml

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ test-act-ete-train:
 		policy.n_action_steps=20 \
 		policy.chunk_size=20 \
 		training.batch_size=2 \
+    	training.image_transforms.enable=true \
 		hydra.run.dir=tests/outputs/act/
 
 test-act-ete-eval:
@@ -73,6 +74,7 @@ test-act-ete-train-amp:
 		policy.chunk_size=20 \
 		training.batch_size=2 \
 		hydra.run.dir=tests/outputs/act_amp/ \
+    	training.image_transforms.enable=true \
 		use_amp=true
 
 test-act-ete-eval-amp:
@@ -100,6 +102,7 @@ test-diffusion-ete-train:
 		training.save_checkpoint=true \
 		training.save_freq=2 \
 		training.batch_size=2 \
+    	training.image_transforms.enable=true \
 		hydra.run.dir=tests/outputs/diffusion/
 
 test-diffusion-ete-eval:
@@ -127,6 +130,7 @@ test-tdmpc-ete-train:
 		training.save_checkpoint=true \
 		training.save_freq=2 \
 		training.batch_size=2 \
+    	training.image_transforms.enable=true \
 		hydra.run.dir=tests/outputs/tdmpc/
 
 test-tdmpc-ete-eval:

--- a/lerobot/common/datasets/factory.py
+++ b/lerobot/common/datasets/factory.py
@@ -75,18 +75,18 @@ def make_dataset(cfg, split: str = "train") -> LeRobotDataset | MultiLeRobotData
     image_transforms = None
     if cfg.training.image_transforms.enable:
         image_transforms = get_image_transforms(
-            brightness_weight=cfg.brightness.weight,
-            brightness_min_max=cfg.brightness.min_max,
-            contrast_weight=cfg.contrast.weight,
-            contrast_min_max=cfg.contrast.min_max,
-            saturation_weight=cfg.saturation.weight,
-            saturation_min_max=cfg.saturation.min_max,
-            hue_weight=cfg.hue.weight,
-            hue_min_max=cfg.hue.min_max,
-            sharpness_weight=cfg.sharpness.weight,
-            sharpness_min_max=cfg.sharpness.min_max,
-            max_num_transforms=cfg.max_num_transforms,
-            random_order=cfg.random_order,
+            brightness_weight=cfg.training.image_transforms.brightness.weight,
+            brightness_min_max=cfg.training.image_transforms.brightness.min_max,
+            contrast_weight=cfg.training.image_transforms.contrast.weight,
+            contrast_min_max=cfg.training.image_transforms.contrast.min_max,
+            saturation_weight=cfg.training.image_transforms.saturation.weight,
+            saturation_min_max=cfg.training.image_transforms.saturation.min_max,
+            hue_weight=cfg.training.image_transforms.hue.weight,
+            hue_min_max=cfg.training.image_transforms.hue.min_max,
+            sharpness_weight=cfg.training.image_transforms.sharpness.weight,
+            sharpness_min_max=cfg.training.image_transforms.sharpness.min_max,
+            max_num_transforms=cfg.training.image_transforms.max_num_transforms,
+            random_order=cfg.training.image_transforms.random_order,
         )
 
     if isinstance(cfg.dataset_repo_id, str):

--- a/lerobot/common/datasets/factory.py
+++ b/lerobot/common/datasets/factory.py
@@ -74,19 +74,20 @@ def make_dataset(cfg, split: str = "train") -> LeRobotDataset | MultiLeRobotData
 
     image_transforms = None
     if cfg.training.image_transforms.enable:
+        cfg_tf = cfg.training.image_transforms
         image_transforms = get_image_transforms(
-            brightness_weight=cfg.training.image_transforms.brightness.weight,
-            brightness_min_max=cfg.training.image_transforms.brightness.min_max,
-            contrast_weight=cfg.training.image_transforms.contrast.weight,
-            contrast_min_max=cfg.training.image_transforms.contrast.min_max,
-            saturation_weight=cfg.training.image_transforms.saturation.weight,
-            saturation_min_max=cfg.training.image_transforms.saturation.min_max,
-            hue_weight=cfg.training.image_transforms.hue.weight,
-            hue_min_max=cfg.training.image_transforms.hue.min_max,
-            sharpness_weight=cfg.training.image_transforms.sharpness.weight,
-            sharpness_min_max=cfg.training.image_transforms.sharpness.min_max,
-            max_num_transforms=cfg.training.image_transforms.max_num_transforms,
-            random_order=cfg.training.image_transforms.random_order,
+            brightness_weight=cfg_tf.brightness.weight,
+            brightness_min_max=cfg_tf.brightness.min_max,
+            contrast_weight=cfg_tf.contrast.weight,
+            contrast_min_max=cfg_tf.contrast.min_max,
+            saturation_weight=cfg_tf.saturation.weight,
+            saturation_min_max=cfg_tf.saturation.min_max,
+            hue_weight=cfg_tf.hue.weight,
+            hue_min_max=cfg_tf.hue.min_max,
+            sharpness_weight=cfg_tf.sharpness.weight,
+            sharpness_min_max=cfg_tf.sharpness.min_max,
+            max_num_transforms=cfg_tf.max_num_transforms,
+            random_order=cfg_tf.random_order,
         )
 
     if isinstance(cfg.dataset_repo_id, str):


### PR DESCRIPTION
## What this does
- Fixes a mismatch between the format of the transforms parameter in `factory.py` when calling `get_image_transforms` and the configuration structure.
- Add `training.image_transforms.enable=true` in end-to-end tests as this issue passed CI unnoticed.

## How it was tested
Newly modified CI end-to-end train test [failed](https://github.com/huggingface/lerobot/actions/runs/9483797227/job/26131760645) before modification. Test does [pass](https://github.com/huggingface/lerobot/actions/runs/9484987861/job/26135849139) after the fix.

## How to checkout & try? (for the reviewer)
You can run the test yourself, or run 
```bash
python lerobot/scripts/train.py device=cuda \
    env=aloha \
    env.task=AlohaTransferCube-v0 \
    dataset_repo_id=lerobot/aloha_sim_transfer_cube_human \
    policy=act \
    training.offline_steps=1000 \
    training.image_transforms.enable=true
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/huggingface/lerobot/264)
<!-- Reviewable:end -->
