### PR TITLE
Bug fix: fix setting different learning rates between backbone and main model in ACT policy

### DIFF
--- a/lerobot/scripts/train.py
+++ b/lerobot/scripts/train.py
@@ -53,12 +53,14 @@ def make_optimizer_and_scheduler(cfg, policy):
                 "params": [
                     p
                     for n, p in policy.named_parameters()
-                    if not n.startswith("backbone") and p.requires_grad
+                    if not n.startswith("model.backbone") and p.requires_grad
                 ]
             },
             {
                 "params": [
-                    p for n, p in policy.named_parameters() if n.startswith("backbone") and p.requires_grad
+                    p
+                    for n, p in policy.named_parameters()
+                    if n.startswith("model.backbone") and p.requires_grad
                 ],
                 "lr": cfg.training.lr_backbone,
             },


### PR DESCRIPTION
## What this does
This pull request fix a bug where we were not identifying the backbone in the filtering of the parameters when specifying the learning rate for the backbone and for the main model.

As a result we were always assigning the main model LR for the back bone instead of the backbone specific LR, `lr_backbone`.

## How it was tested
- Added `./tests/test_policies.py::test_act_backbone_lr`.

## How to checkout & try? (for the reviewer)
It can be tested with `pytest ./tests/test_policies.py::test_act_backbone_lr`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/huggingface/lerobot/280)
<!-- Reviewable:end -->
