### PR TITLE
split dataset into train and val, and log val loss during training

### DIFF
--- a/lerobot/common/logger.py
+++ b/lerobot/common/logger.py
@@ -228,7 +228,7 @@ class Logger:
         return training_state["step"]
 
     def log_dict(self, d, step, mode="train"):
-        assert mode in {"train", "eval"}
+        assert mode in {"train", "eval", "validation"}
         # TODO(alexander-soare): Add local text log.
         if self._wandb is not None:
             for k, v in d.items():

--- a/lerobot/configs/env/ur5e.yaml
+++ b/lerobot/configs/env/ur5e.yaml
@@ -1,0 +1,13 @@
+# @package _global_
+
+fps: 10
+
+env:
+  name: ur5e
+  task: ur5e-v0
+  state_dim: 7
+  action_dim: 7
+  fps: ${fps}
+  episode_length: 400
+  gym:
+    fps: ${fps}

--- a/lerobot/configs/experiment/gello-coffee-handle-act.yaml
+++ b/lerobot/configs/experiment/gello-coffee-handle-act.yaml
@@ -1,23 +1,43 @@
-# @package _global_
+#@package _global_
+
+# Use `act_real_no_state.yaml` to train on real-world Aloha/Aloha2 datasets when cameras are moving (e.g. wrist cameras)
+# Compared to `act_real.yaml`, it is camera only and does not use the state as input which is vector of robot joint positions.
+# We validated experimentaly that not using state reaches better success rate. Our hypothesis is that `act_real.yaml` might
+# overfits to the state, because the images are more complex to learn from since they are moving.
+#
+# Example of usage for training:
+# ```bash
+# python lerobot/scripts/train.py \
+#   policy=act_real_no_state \
+#   env=dora_aloha_real
+# ```
+
+defaults:
+  - override /policy: act
+  - override /env: ur5e.yaml
 
 seed: 1000
-dataset_repo_id: lerobot/aloha_sim_insertion_human
+dataset_repo_id: tlpss/open-coffee-handle-no-tactile
+
 
 override_dataset_stats:
-  observation.images.top:
+  observation.images.wrist.rgb:
+    # stats from imagenet, since we use a pretrained vision model
+    mean: [[[0.485]], [[0.456]], [[0.406]]]  # (c,1,1)
+    std: [[[0.229]], [[0.224]], [[0.225]]]  # (c,1,1)
+  observation.images.base.rgb:
     # stats from imagenet, since we use a pretrained vision model
     mean: [[[0.485]], [[0.456]], [[0.406]]]  # (c,1,1)
     std: [[[0.229]], [[0.224]], [[0.225]]]  # (c,1,1)
 
+
 training:
   offline_steps: 80000
   online_steps: 0
-  eval_freq: 5000
-  validation_freq: 250
-  validation_split_ratio: 0.2
-  save_freq: 100000
-  log_freq: 250
-  save_checkpoint: false
+  eval_freq: -1
+  save_freq: 10000
+  log_freq: 500
+  save_checkpoint: true
 
   batch_size: 8
   lr: 1e-5
@@ -39,19 +59,21 @@ policy:
 
   # Input / output structure.
   n_obs_steps: 1
-  chunk_size: 100 # chunk_size
-  n_action_steps: 100
+  chunk_size: 60 # chunk_size
+  n_action_steps: 20
 
   input_shapes:
     # TODO(rcadene, alexander-soare): add variables for height and width from the dataset/env?
-    observation.images.top: [3, 480, 640]
-    observation.state: ["${env.state_dim}"]
+    observation.images.wrist.rgb: [3, 480, 640]
+    #observation.images.base.rgb: [3, 480, 640]
+    observation.state: [40]
   output_shapes:
     action: ["${env.action_dim}"]
 
   # Normalization / Unnormalization
   input_normalization_modes:
-    observation.images.top: mean_std
+    observation.images.wrist.rgb: mean_std
+    #observation.images.base.rgb: mean_std
     observation.state: mean_std
   output_normalization_modes:
     action: mean_std
@@ -65,13 +87,13 @@ policy:
   pre_norm: false
   dim_model: 512
   n_heads: 8
-  dim_feedforward: 3200
+  dim_feedforward: 1024
   feedforward_activation: relu
   n_encoder_layers: 4
   # Note: Although the original ACT implementation has 7 for `n_decoder_layers`, there is a bug in the code
   # that means only the first layer is used. Here we match the original implementation by setting this to 1.
   # See this issue https://github.com/tonyzhaozh/act/issues/25#issue-2258740521.
-  n_decoder_layers: 1
+  n_decoder_layers: 2
   # VAE.
   use_vae: true
   latent_dim: 32
@@ -88,3 +110,8 @@ policy:
 wandb:
   enable: true
   disable_artifact: true
+
+# project name
+hydra:
+  job:
+    name: ur5e-coffee-handle-no-tactile-act

--- a/lerobot/configs/policy/diffusion.yaml
+++ b/lerobot/configs/policy/diffusion.yaml
@@ -25,7 +25,7 @@ training:
   offline_steps: 200000
   online_steps: 0
   eval_freq: 5000
-  validation_freq: 100
+  validation_freq: 250
   validation_split_ratio: 0.2
   save_freq: 5000
   log_freq: 250
@@ -105,3 +105,9 @@ policy:
 
   # Loss computation
   do_mask_loss_for_padding: false
+
+
+
+wandb:
+  enable: true
+  disable_artifact: true

--- a/lerobot/configs/policy/diffusion.yaml
+++ b/lerobot/configs/policy/diffusion.yaml
@@ -25,6 +25,8 @@ training:
   offline_steps: 200000
   online_steps: 0
   eval_freq: 5000
+  validation_freq: 100
+  validation_split_ratio: 0.2
   save_freq: 5000
   log_freq: 250
   save_checkpoint: true

--- a/lerobot/scripts/train.py
+++ b/lerobot/scripts/train.py
@@ -320,7 +320,7 @@ def train(cfg: DictConfig, out_dir: str | None = None, job_name: str | None = No
         offline_dataset = make_dataset(cfg, split=f"train[:{round((1-split_ratio)*100)}%]")
         offline_val_dataset = make_dataset(cfg, split=f"train[{round((1-split_ratio)*100)}%:]")
         logging.info(
-            f"using {len(offline_dataset)} episodes for training and {len(offline_val_dataset)} episodes for validation"
+            f"using {offline_dataset.num_episodes} episodes for training and {offline_val_dataset.num_episodes} episodes for validation"
         )
 
     else:

--- a/lerobot/scripts/train.py
+++ b/lerobot/scripts/train.py
@@ -375,7 +375,7 @@ def train(cfg: DictConfig, out_dir: str | None = None, job_name: str | None = No
         if cfg.training.validation_freq > 0 and step % cfg.training.validation_freq == 0:
             # Run validation loop
             with torch.inference_mode():
-                policy.eval()
+                #policy.eval()
                 loss_cumsum = 0
                 for batch in val_dataloader:
                     batch = {k: v.to(device, non_blocking=True) for k, v in batch.items()}
@@ -388,7 +388,7 @@ def train(cfg: DictConfig, out_dir: str | None = None, job_name: str | None = No
             info = {"val_loss": average_loss}
 
             log_validation_info(logger, info, step, cfg, offline_dataset, is_offline=True)
-            policy.train()
+            #policy.train()
 
         if cfg.training.eval_freq > 0 and step % cfg.training.eval_freq == 0:
             logging.info(f"Eval policy at step {step}")

--- a/wandb-val-plots.ipynb
+++ b/wandb-val-plots.ipynb
@@ -1,0 +1,129 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import wandb \n",
+    "import pandas as pd \n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "\n",
+    "# get metrics from run online \n",
+    "api = wandb.Api()\n",
+    "run = api.run(\"tlips/lerobot/rynf40po\")\n",
+    "run = api.run(\"tlips/lerobot/7dhx23nf\")\n",
+    "\n",
+    "# get the data from the run\n",
+    "\n",
+    "data = run.history(samples=1000)\n",
+    "data.columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# count numer of non-nan entries\n",
+    "data.count()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train_loss = data[\"train/loss\"]\n",
+    "val_loss = data[\"validation/val_loss\"]\n",
+    "train_steps = data[\"train/step\"]\n",
+    "val_steps = data[\"validation/step\"]\n",
+    "eval_steps = data[\"eval/step\"]\n",
+    "eval_success_rate = data[\"eval/pc_success\"]\n",
+    "\n",
+    "# filter out nan values\n",
+    "train_loss = train_loss.dropna()\n",
+    "val_loss = val_loss.dropna()\n",
+    "train_steps = train_steps.dropna()\n",
+    "val_steps = val_steps.dropna()\n",
+    "eval_steps = eval_steps.dropna()\n",
+    "eval_success_rate = eval_success_rate.dropna()\n",
+    "\n",
+    "print(eval_steps.count())\n",
+    "print(eval_success_rate.count())\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# plot train and validation loss on left y axis and success rate on right y axis\n",
+    "fig, ax1 = plt.subplots()\n",
+    "\n",
+    "ax1.set_xlabel('steps')\n",
+    "ax1.set_ylabel('loss')\n",
+    "ax1.set_ylim(0, 1)\n",
+    "# format x axis ticks as N k \n",
+    "ax1.xaxis.set_major_formatter(plt.FuncFormatter(lambda x, _: f'{int(x/1000):,}k'))\n",
+    "\n",
+    "ax1.plot(train_steps, train_loss, color=\"blue\", label=\"train loss\")\n",
+    "ax1.plot(val_steps, val_loss, color=\"red\", label=\"validation loss\")\n",
+    "ax1.legend(loc=\"upper left\")\n",
+    "ax2 = ax1.twinx()\n",
+    "ax2.set_ylabel('success rate')\n",
+    "ax2.set_ylim(0,100)\n",
+    "ax2.plot(eval_steps,eval_success_rate, color=\"green\", label=\"success rate\")\n",
+    "ax2.legend(loc=\"upper right\")\n",
+    "plt.title(f\"val loss - {run.tags}\")\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# get correlation between the val loss and the success rate\n",
+    "correlation = val_loss.corr(eval_success_rate)\n",
+    "print(correlation)\n",
+    "\n",
+    "time_correlation = val_steps.corr(eval_success_rate)\n",
+    "print(time_correlation)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# get a table of the val loss compared to the success rate\n",
+    "import pandas as pd\n",
+    "table = pd.concat([val_loss, eval_success_rate], axis=1)\n",
+    "\n",
+    "# drop entries with nan values\n",
+    "table = table.dropna()\n",
+    "table\n",
+    "\n",
+    "# for each validaiton loss, get the rank of the success rate\n",
+    "table[\"success_rank\"] = table[\"eval/pc_success\"].rank(ascending=False)\n",
+    "table = table.sort_values(by=\"validation/val_loss\")\n",
+    "table"
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
## What this does

Modifies train script to split dataset into train and val datasets and logs validation loss during training.


Based on #158 

closes #250 


## How it was tested

running the train script with the default settings

`python scripts/train.py`

## How to checkout & try? (for the reviewer)
Provide a simple way for the reviewer to try out your changes.

`python scripts/train.py`


@alexander-soare : feel free to provide feedback on this initial draft!


## TODOs

- [ ]  modify all policy configurations to add the new parameters
- [ ] document feature