### PR TITLE
Checkpoint on final step of training even when it doesn't coincide with `save_freq`.

### DIFF
--- a/lerobot/configs/default.yaml
+++ b/lerobot/configs/default.yaml
@@ -39,9 +39,10 @@ training:
   # `online_env_seed` is used for environments for online training data rollouts.
   online_env_seed: ???
   eval_freq: ???
-  save_freq: ???
   log_freq: 250
   save_checkpoint: true
+  # Checkpoint is saved every `save_freq` training iterations and after the last training step.
+  save_freq: ???
   num_workers: 4
   batch_size: ???
   image_transforms:

--- a/lerobot/scripts/train.py
+++ b/lerobot/scripts/train.py
@@ -351,7 +351,10 @@ def train(cfg: DictConfig, out_dir: str | None = None, job_name: str | None = No
                 logger.log_video(eval_info["video_paths"][0], step, mode="eval")
             logging.info("Resume training")
 
-        if cfg.training.save_checkpoint and step % cfg.training.save_freq == 0:
+        if cfg.training.save_checkpoint and (
+            step % cfg.training.save_freq == 0
+            or step == cfg.training.offline_steps + cfg.training.online_steps
+        ):
             logging.info(f"Checkpoint policy after step {step}")
             # Note: Save with step as the identifier, and format it to have at least 6 digits but more if
             # needed (choose 6 as a minimum for consistency without being overkill).


### PR DESCRIPTION
## What this does

^

## How it was tested / how to checkout and try

I ran training with 10 offline steps (and save_freq > 10) and verified that the checkpoint was saved.

```bash
JOB_NAME=test

python lerobot/scripts/train.py \
    hydra.job.name=$JOB_NAME \
    hydra.run.dir=outputs/train/$(date +'%Y-%m-%d/%H-%M-%S')_${JOB_NAME} \
    env=pusht \
    policy=diffusion \
    training.save_checkpoint=true \
    training.offline_steps=10 \
    training.save_freq=20000 \
    training.eval_freq=10000 \
    training.log_freq=50 \
    eval.n_episodes=50 \
    eval.batch_size=50 \
    wandb.enable=false \
    wandb.disable_artifact=true \
    device=cuda \
    use_amp=true
```
