### PR TITLE
Cleanup config defaults

### DIFF
--- a/lerobot/configs/default.yaml
+++ b/lerobot/configs/default.yaml
@@ -39,7 +39,7 @@ training:
   # `online_env_seed` is used for environments for online training data rollouts.
   online_env_seed: ???
   eval_freq: ???
-  log_freq: 250
+  log_freq: 200
   save_checkpoint: true
   # Checkpoint is saved every `save_freq` training iterations and after the last training step.
   save_freq: ???

--- a/lerobot/configs/policy/act.yaml
+++ b/lerobot/configs/policy/act.yaml
@@ -10,11 +10,10 @@ override_dataset_stats:
     std: [[[0.229]], [[0.224]], [[0.225]]]  # (c,1,1)
 
 training:
-  offline_steps: 80000
+  offline_steps: 100000
   online_steps: 0
-  eval_freq: 10000
-  save_freq: 100000
-  log_freq: 250
+  eval_freq: 20000
+  save_freq: 20000
   save_checkpoint: true
 
   batch_size: 8

--- a/lerobot/configs/policy/act_real.yaml
+++ b/lerobot/configs/policy/act_real.yaml
@@ -36,11 +36,10 @@ override_dataset_stats:
     std: [[[0.229]], [[0.224]], [[0.225]]]  # (c,1,1)
 
 training:
-  offline_steps: 80000
+  offline_steps: 100000
   online_steps: 0
   eval_freq: -1
-  save_freq: 10000
-  log_freq: 100
+  save_freq: 20000
   save_checkpoint: true
 
   batch_size: 8

--- a/lerobot/configs/policy/act_real_no_state.yaml
+++ b/lerobot/configs/policy/act_real_no_state.yaml
@@ -34,11 +34,10 @@ override_dataset_stats:
     std: [[[0.229]], [[0.224]], [[0.225]]]  # (c,1,1)
 
 training:
-  offline_steps: 80000
+  offline_steps: 100000
   online_steps: 0
   eval_freq: -1
-  save_freq: 10000
-  log_freq: 100
+  save_freq: 20000
   save_checkpoint: true
 
   batch_size: 8

--- a/lerobot/configs/policy/diffusion.yaml
+++ b/lerobot/configs/policy/diffusion.yaml
@@ -24,9 +24,8 @@ override_dataset_stats:
 training:
   offline_steps: 200000
   online_steps: 0
-  eval_freq: 5000
-  save_freq: 5000
-  log_freq: 250
+  eval_freq: 10000
+  save_freq: 10000
   save_checkpoint: true
 
   batch_size: 64

--- a/lerobot/configs/policy/diffusion.yaml
+++ b/lerobot/configs/policy/diffusion.yaml
@@ -24,8 +24,8 @@ override_dataset_stats:
 training:
   offline_steps: 200000
   online_steps: 0
-  eval_freq: 10000
-  save_freq: 10000
+  eval_freq: 25000
+  save_freq: 25000
   save_checkpoint: true
 
   batch_size: 64

--- a/lerobot/configs/policy/tdmpc.yaml
+++ b/lerobot/configs/policy/tdmpc.yaml
@@ -11,6 +11,7 @@ training:
   online_steps_between_rollouts: 1
   online_sampling_ratio: 0.5
   online_env_seed: 10000
+  log_freq: 100
 
   batch_size: 256
   grad_clip_norm: 10.0

--- a/lerobot/configs/policy/vqbet.yaml
+++ b/lerobot/configs/policy/vqbet.yaml
@@ -22,9 +22,8 @@ override_dataset_stats:
 training:
   offline_steps: 250000
   online_steps: 0
-  eval_freq: 20000
-  save_freq: 20000
-  log_freq: 250
+  eval_freq: 25000
+  save_freq: 25000
   save_checkpoint: true
 
   batch_size: 64


### PR DESCRIPTION
## What this does
This addresses some inconsistencies found in the current config defaults. It also simplifies configs wherever possible.

For example, on `act.yaml`:
```diff
training:
  online_steps: 0
- offline_steps: 80000
- save_freq: 100000
+ offline_steps: 100000
+ save_freq: 20000
```

## How it was tested
N/A

## How to checkout & try? (for the reviewer)
N/A