### PR TITLE
force-override should use store_true

### DIFF
--- a/lerobot/scripts/visualize_dataset_html.py
+++ b/lerobot/scripts/visualize_dataset_html.py
@@ -404,8 +404,7 @@ def main():
     )
     parser.add_argument(
         "--force-override",
-        type=int,
-        default=0,
+        action="store_true",
         help="Delete the output directory if it exists already.",
     )
 


### PR DESCRIPTION
For boolean command arguments, that default to either true or false, it is better to use [store_true or strore_false](https://docs.python.org/3/library/argparse.html).

With this change, instead of calling:
```
python visualize_dataset_html.py --repo-id lerobot/koch_v2 --force-override 1
```

You will call:
```
python visualize_dataset_html.py --repo-id lerobot/koch_v2 --force-override
```
without supplying `0` or `1`