### PR TITLE
Adds MultiEpochsDataLoader to optimize first batch loading perfomance

### DIFF
--- a/lerobot/scripts/train.py
+++ b/lerobot/scripts/train.py
@@ -46,6 +46,40 @@ from lerobot.common.utils.utils import (
 from lerobot.scripts.eval import eval_policy
 
 
+class MultiEpochsDataLoader(torch.utils.data.DataLoader):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._DataLoader__initialized = False
+        if self.batch_sampler is None:
+            self.sampler = _RepeatSampler(self.sampler)
+        else:
+            self.batch_sampler = _RepeatSampler(self.batch_sampler)
+        self._DataLoader__initialized = True
+        self.iterator = super().__iter__()
+
+    def __len__(self):
+        return len(self.sampler) if self.batch_sampler is None else len(self.batch_sampler.sampler)
+
+    def __iter__(self):
+        for _ in range(len(self)):
+            yield next(self.iterator)
+
+
+class _RepeatSampler:
+    """Sampler that repeats forever.
+
+    Args:
+        sampler (Sampler)
+    """
+
+    def __init__(self, sampler):
+        self.sampler = sampler
+
+    def __iter__(self):
+        while True:
+            yield from iter(self.sampler)
+
+
 def make_optimizer_and_scheduler(cfg, policy):
     if cfg.policy.name == "act":
         optimizer_params_dicts = [
@@ -384,7 +418,7 @@ def train(cfg: DictConfig, out_dir: str | None = None, job_name: str | None = No
     else:
         shuffle = True
         sampler = None
-    dataloader = torch.utils.data.DataLoader(
+    dataloader = MultiEpochsDataLoader(
         offline_dataset,
         num_workers=cfg.training.num_workers,
         batch_size=cfg.training.batch_size,


### PR DESCRIPTION
## What this does

This pull request introduces a custom `DataLoader` class, `MultiEpochsDataLoader`, along with a supporting sampler class, `_RepeatSampler`, to address the issue of lag when obtaining the first batch during each epoch in PyTorch training loops.

Closes #324 

## How it was tested

By running the training loop and watching loading time

## How to checkout & try? (for the reviewer)

Add the line to the https://github.com/rakhimovv/lerobot/blob/multi_epoch_dataloader/lerobot/scripts/train.py#L440
`logging.info(f"Step: {i}, dataloading_s: {dataloading_s:.3f}")`

and run training loop:

```bash
python lerobot/scripts/train.py \
    policy=act \
    env=aloha \
    env.task=AlohaInsertion-v0 \
    dataset_repo_id=lerobot/aloha_sim_insertion_human \
```
