### PR TITLE
Fix bug ACT layers with no VAE

### DIFF
--- a/lerobot/common/policies/act/modeling_act.py
+++ b/lerobot/common/policies/act/modeling_act.py
@@ -343,7 +343,9 @@ class ACT(nn.Module):
                 backbone_model.fc.in_features, config.dim_model, kernel_size=1
             )
         # Transformer encoder positional embeddings.
-        n_1d_tokens = 1  # for the latent
+        n_1d_tokens = 0
+        if self.config.use_vae:
+            n_1d_tokens += 1
         if self.use_robot_state:
             n_1d_tokens += 1
         if self.use_env_state:
@@ -452,8 +454,12 @@ class ACT(nn.Module):
             )
 
         # Prepare transformer encoder inputs.
-        encoder_in_tokens = [self.encoder_latent_input_proj(latent_sample)]
+        encoder_in_tokens = []
         encoder_in_pos_embed = list(self.encoder_1d_feature_pos_embed.weight.unsqueeze(1))
+
+        # Latent token.
+        if self.config.use_vae:
+            encoder_in_tokens.append(self.encoder_latent_input_proj(latent_sample))
         # Robot state token.
         if self.use_robot_state:
             encoder_in_tokens.append(self.encoder_robot_state_input_proj(batch["observation.state"]))


### PR DESCRIPTION
## What this does
There was a bug in the forward of ACT when `use_vae` was set to `False`.
This fix conditions ACT encoding layers on whether or not VAE is used.
