### PR TITLE
Detect secrets in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,11 +14,11 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.15.2
+    rev: v3.16.0
     hooks:
     -   id: pyupgrade
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.3
+    rev: v0.5.2
     hooks:
       - id: ruff
         args: [--fix]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,3 +31,7 @@ repos:
         args:
           - "--check"
           - "--no-update"
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.18.4
+    hooks:
+      - id: gitleaks


### PR DESCRIPTION
## What this does
While we already do have a [Trufflehog workflow](https://github.com/huggingface/lerobot/blob/main/.github/workflows/trufflehog.yml) in CI to check that we don't add secrets to the codebase, this is far from ideal as potential secrets are already committed & pushed when the CI runs.

This adds a [gitleaks](https://github.com/gitleaks/gitleaks) pre-commit which will check that no secret is added to the codebase _before_ they're even committed.

Other changes:
- `pre-commit autoupdate`

## How it was tested
Staged this file:
```python
# definitely_no_secrets_here.py
some_data = {
    "ThisMightBeAKey": "AKIAIOSFODNN7EXAMPLE"
}
```
Ran the pre-commit:
```bash
Detect hardcoded secrets.................................................Failed
- hook id: gitleaks
- exit code: 1

○
    │╲
    │ ○
    ○ ░
    ░    gitleaks

Finding:     "ThisMightBeAKey": "REDACTED
Secret:      REDACTED
RuleID:      aws-access-token
Entropy:     3.684184
File:        definitely_no_secrets_here.py
Line:        3
Fingerprint: definitely_no_secrets_here.py:aws-access-token:3

6:32PM INF 1 commits scanned.
6:32PM INF scan completed in 9.19ms
6:32PM WRN leaks found: 1
```

## How to checkout & try? (for the reviewer)
```bash
pre-commit install
```
Then try to reproduce the test I did above.