### PR TITLE
Fix CI builds

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -17,6 +17,12 @@ jobs:
     runs-on:
       group: aws-general-8-plus
     steps:
+      - name: Install Git LFS
+        run: |
+          sudo apt-get update
+          sudo apt-get install git-lfs
+          git lfs install
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -46,6 +52,12 @@ jobs:
     runs-on:
       group: aws-general-8-plus
     steps:
+      - name: Install Git LFS
+        run: |
+          sudo apt-get update
+          sudo apt-get install git-lfs
+          git lfs install
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 


### PR DESCRIPTION
## What this does
Fix Docker builds in CI

Due to changing the runners in #351, git lfs is not installed on `aws-general-8-plus` runners. This fixes that by installing git lfs before checking out the repo.

## How it was tested
Successfully built the images on this branch ([run](https://github.com/huggingface/lerobot/actions/runs/10354990797)).

## How to checkout & try? (for the reviewer)
N/A