### PR TITLE
feat for the GPU poors : Add GPU availability check in evaluate_pretr…

### DIFF
--- a/examples/2_evaluate_pretrained_policy.py
+++ b/examples/2_evaluate_pretrained_policy.py
@@ -18,7 +18,13 @@ from lerobot.common.policies.diffusion.modeling_diffusion import DiffusionPolicy
 output_directory = Path("outputs/eval/example_pusht_diffusion")
 output_directory.mkdir(parents=True, exist_ok=True)
 
-device = torch.device("cuda")
+# Check if GPU is available
+if torch.cuda.is_available():
+    device = torch.device("cuda")
+    print("GPU is available. Device set to:", device)
+else:
+    device = torch.device("cpu")
+    print("GPU is not available. Device set to:", device)
 
 # Download the diffusion policy for pusht environment
 pretrained_policy_path = Path(snapshot_download("lerobot/diffusion_pusht"))

--- a/examples/2_evaluate_pretrained_policy.py
+++ b/examples/2_evaluate_pretrained_policy.py
@@ -24,7 +24,9 @@ if torch.cuda.is_available():
     print("GPU is available. Device set to:", device)
 else:
     device = torch.device("cpu")
-    print("GPU is not available. Device set to:", device)
+    print(f"GPU is not available. Device set to: {device}. Inference will be slower than on GPU.")
+    # Decrease the number of reverse-diffusion steps (trades off a bit of quality for 10x speed)
+    policy.diffusion.num_inference_steps = 10
 
 # Download the diffusion policy for pusht environment
 pretrained_policy_path = Path(snapshot_download("lerobot/diffusion_pusht"))


### PR DESCRIPTION
…ained_policy.py

## What this does
Enable policy evaluation without GPUs.

## How it was tested
Run the script, verify the video was effectively produced.

## How to checkout & try? (for the reviewer)
Produce and check the video produced during the evaluation of the pretrained policy on a laptop or VM without GPU access.

Examples:
```bash
python -m examples.2_evaluate_pretrained_policy
```
