### PR TITLE
Make gripper_open_degree a config param

### DIFF
--- a/lerobot/configs/robot/koch.yaml
+++ b/lerobot/configs/robot/koch.yaml
@@ -37,3 +37,6 @@ cameras:
     fps: 30
     width: 640
     height: 480
+# Sets the leader arm in torque mode with the gripper motor set to this angle. This makes it possible
+# to squeeze the gripper and have it spring back to an open position on its own.
+gripper_open_degree: 35.156


### PR DESCRIPTION
## What this does

Moves `GRIPPER_OPEN_DEGREE` to `gripper_open_degree` in `KochRobotConfig`. This makes it possible to:

1. Not torque the leader arm's gripper if you want.
2. Set the gripper to be shut by default for tasks where gripping is not needed (eg pushing a block).
3. Set the gripper open to wider/narrower default actions to tailor to the task you want to do.

## How it was tested

I ran this script:

```python
import tqdm

from lerobot.common.robot_devices.robots.factory import make_robot
from lerobot.common.robot_devices.robots.koch import KochRobot
from lerobot.common.utils.utils import init_hydra_config

robot_cfg = init_hydra_config("lerobot/configs/robot/koch_.yaml")
robot: KochRobot = make_robot(robot_cfg)

robot.connect()

seconds = 3000
frequency = 200
for _ in tqdm.tqdm(range(seconds*frequency)):
    robot.teleop_step()
```

With `gripper_open_degree` as `null`, as `0` and as various positive values.