### PR TITLE
Fix memory leakage cause by permanent storage of decoded video frame

### DIFF
--- a/lerobot/common/datasets/lerobot_dataset.py
+++ b/lerobot/common/datasets/lerobot_dataset.py
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from copy import deepcopy
 import logging
 import os
 from pathlib import Path
@@ -133,7 +134,7 @@ class LeRobotDataset(torch.utils.data.Dataset):
         return self.num_samples
 
     def __getitem__(self, idx):
-        item = self.hf_dataset[idx]
+        item = deepcopy(self.hf_dataset[idx])
 
         if self.delta_timestamps is not None:
             item = load_previous_and_future_frames(


### PR DESCRIPTION
## What this does

`load_from_videos` will storage decoded image to internal `self.hf_dataset` array, which will cause memory leakage specifically with large size of image.

https://github.com/huggingface/lerobot/blob/97086cdcdf46e2b2663447ba16de2c9b09ceef29/lerobot/common/datasets/lerobot_dataset.py#L136

## How to checkout & try? (for the reviewer)
Provide a simple way for the reviewer to try out your changes.

Examples:
```bash
htop
```