### PR TITLE
Add koch bimanual

### DIFF
--- a/lerobot/configs/robot/koch_bimanual.yaml
+++ b/lerobot/configs/robot/koch_bimanual.yaml
@@ -59,3 +59,10 @@ cameras:
     fps: 30
     width: 640
     height: 480
+# `max_relative_target` limits the magnitude of the relative positional target vector for safety purposes.
+# Set this to a positive scalar to have the same value for all motors, or a list that is the same length as
+# the number of motors in your follower arms.
+max_relative_target: null
+# Sets the leader arm in torque mode with the gripper motor set to this angle. This makes it possible
+# to squeeze the gripper and have it spring back to an open position on its own.
+gripper_open_degree: 35.156

--- a/lerobot/configs/robot/koch_bimanual.yaml
+++ b/lerobot/configs/robot/koch_bimanual.yaml
@@ -1,0 +1,61 @@
+_target_: lerobot.common.robot_devices.robots.koch.KochRobot
+calibration_path: .cache/calibration/koch_bimanual.pkl
+leader_arms:
+  left:
+    _target_: lerobot.common.robot_devices.motors.dynamixel.DynamixelMotorsBus
+    port: /dev/tty.usbmodem585A0085511
+    motors:
+      # name: (index, model)
+      shoulder_pan: [1, "xl330-m077"]
+      shoulder_lift: [2, "xl330-m077"]
+      elbow_flex: [3, "xl330-m077"]
+      wrist_flex: [4, "xl330-m077"]
+      wrist_roll: [5, "xl330-m077"]
+      gripper: [6, "xl330-m077"]
+  right:
+    _target_: lerobot.common.robot_devices.motors.dynamixel.DynamixelMotorsBus
+    port: /dev/tty.usbmodem575E0031751
+    motors:
+      # name: (index, model)
+      shoulder_pan: [1, "xl330-m077"]
+      shoulder_lift: [2, "xl330-m077"]
+      elbow_flex: [3, "xl330-m077"]
+      wrist_flex: [4, "xl330-m077"]
+      wrist_roll: [5, "xl330-m077"]
+      gripper: [6, "xl330-m077"]
+follower_arms:
+  left:
+    _target_: lerobot.common.robot_devices.motors.dynamixel.DynamixelMotorsBus
+    port: /dev/tty.usbmodem585A0076891
+    motors:
+      # name: (index, model)
+      shoulder_pan: [1, "xl430-w250"]
+      shoulder_lift: [2, "xl430-w250"]
+      elbow_flex: [3, "xl330-m288"]
+      wrist_flex: [4, "xl330-m288"]
+      wrist_roll: [5, "xl330-m288"]
+      gripper: [6, "xl330-m288"]
+  right:
+    _target_: lerobot.common.robot_devices.motors.dynamixel.DynamixelMotorsBus
+    port: /dev/tty.usbmodem575E0032081
+    motors:
+      # name: (index, model)
+      shoulder_pan: [1, "xl430-w250"]
+      shoulder_lift: [2, "xl430-w250"]
+      elbow_flex: [3, "xl330-m288"]
+      wrist_flex: [4, "xl330-m288"]
+      wrist_roll: [5, "xl330-m288"]
+      gripper: [6, "xl330-m288"]
+cameras:
+  laptop:
+    _target_: lerobot.common.robot_devices.cameras.opencv.OpenCVCamera
+    camera_index: 1
+    fps: 30
+    width: 640
+    height: 480
+  phone:
+    _target_: lerobot.common.robot_devices.cameras.opencv.OpenCVCamera
+    camera_index: 2
+    fps: 30
+    width: 640
+    height: 480

--- a/lerobot/configs/robot/koch_bimanual.yaml
+++ b/lerobot/configs/robot/koch_bimanual.yaml
@@ -49,13 +49,13 @@ follower_arms:
 cameras:
   laptop:
     _target_: lerobot.common.robot_devices.cameras.opencv.OpenCVCamera
-    camera_index: 1
+    camera_index: 0
     fps: 30
     width: 640
     height: 480
   phone:
     _target_: lerobot.common.robot_devices.cameras.opencv.OpenCVCamera
-    camera_index: 2
+    camera_index: 1
     fps: 30
     width: 640
     height: 480


### PR DESCRIPTION
## What this does

Title

## How it was tested

Folded some shirts: https://x.com/RemiCadene/status/1828006677528137977

Visualized the dataset
https://huggingface.co/spaces/cadene/visualize_dataset_koch_bimanual_folding

## How to checkout & try? (for the reviewer)

```bash
python lerobot/scripts/control_robot.py teleoperate \
  --robot-path lerobot/configs/robot/koch_bimanual.yaml 

python lerobot/scripts/train.py \
  dataset_repo_id=cadene/koch_bimanual_folding \
  policy=act_koch_real \
  env=koch_real \
  hydra.run.dir=outputs/train/act_koch_bimanual_folding \
  hydra.job.name=act_koch_bimanual_folding \
  device=cuda \
  wandb.enable=true \
  env.state_dim=12 \
  env.action_dim=12 \
  training.num_workers=8 \
  training.batch_size=32 \
  policy.n_decoder_layers=4

huggingface-cli upload cadene/act_koch_bimanual_folding \
  outputs/train/act_koch_bimanual_folding/checkpoints/last/pretrained_model

python lerobot/scripts/control_robot.py record \
  --robot-path lerobot/configs/robot/koch_bimanual.yaml \
  --fps 30 \
  --root data \
  --repo-id cadene/eval_act_koch_bimanual_folding_080000 \
  --num-episodes 4 \
  --run-compute-stats 0 \
  --warmup-time-s 10 \
  --episode-time-s 360 \
  --reset-time-s 360 \
  --force-override 0 \
  -p cadene/act_koch_bimanual_folding_080000 \
  --policy-overrides device=mps

python lerobot/scripts/visualize_dataset_html.py \
  --root data \
  --repo-id cadene/eval_act_koch_bimanual_folding_080000
  ```
