### PR TITLE
Add the possibility to visualize language instructions in visualize_dataset_html.py

### DIFF
--- a/lerobot/scripts/visualize_dataset_html.py
+++ b/lerobot/scripts/visualize_dataset_html.py
@@ -201,10 +201,7 @@ def get_episode_language_instruction(dataset: LeRobotDataset, ep_index: int) -> 
     language_instruction = dataset.hf_dataset[first_frame_idx]["language_instruction"]
     # TODO (michel-aractingi) hack to get the sentence, some strings in openx are badly stored
     # with the tf.tensor appearing in the string
-    language_instruction = language_instruction \
-                .removeprefix("tf.Tensor(b'") \
-                .removesuffix("', shape=(), dtype=string)")
-    return language_instruction
+    return language_instruction.removeprefix("tf.Tensor(b'").removesuffix("', shape=(), dtype=string)")
 
 
 def visualize_dataset_html(

--- a/lerobot/scripts/visualize_dataset_html.py
+++ b/lerobot/scripts/visualize_dataset_html.py
@@ -199,10 +199,11 @@ def get_episode_language_instruction(dataset: LeRobotDataset, ep_index: int) -> 
     first_frame_idx = dataset.episode_data_index["from"][ep_index].item()
 
     language_instruction = dataset.hf_dataset[first_frame_idx]["language_instruction"]
-    # hack to remove the prefix and suffix in open x that were badly stored
-    language_instruction = language_instruction.removeprefix("tf.Tensor(b'").removesuffix(
-        "', shape=(), dtype=string)"
-    )
+    # TODO (michel-aractingi) hack to get the sentence, some strings in openx are badly stored
+    # with the tf.tensor appearing in the string
+    language_instruction = language_instruction \
+                .removeprefix("tf.Tensor(b'") \
+                .removesuffix("', shape=(), dtype=string)")
     return language_instruction
 
 

--- a/lerobot/templates/visualize_dataset_template.html
+++ b/lerobot/templates/visualize_dataset_template.html
@@ -96,6 +96,13 @@
                     <source src="{{ video_info.url }}">
                     Your browser does not support the video tag.
                 </video>
+                <!-- Language Instruction (only if it exists) -->
+                {% if video_info.language_instruction %}
+                <p class="text-sm font-bold mt-2">
+                    Language Instruction: <em>{{ video_info.language_instruction }}</em>
+                </p>
+                <hr class="my-4 border-gray-600">
+                {% endif %}
             </div>
             {% endfor %}
         </div>

--- a/lerobot/templates/visualize_dataset_template.html
+++ b/lerobot/templates/visualize_dataset_template.html
@@ -96,16 +96,17 @@
                     <source src="{{ video_info.url }}">
                     Your browser does not support the video tag.
                 </video>
-                <!-- Language Instruction (only if it exists) -->
-                {% if video_info.language_instruction %}
-                <p class="text-sm font-bold mt-2">
-                    Language Instruction: <em>{{ video_info.language_instruction }}</em>
-                </p>
-                <hr class="my-4 border-gray-600">
-                {% endif %}
             </div>
             {% endfor %}
         </div>
+
+        <!-- Language instruction -->
+        {% if videos_info[0].language_instruction %}
+        <div class="text-sm font-bold mt-2">
+            Language Instruction: <em>{{ videos_info[0].language_instruction }}</em>
+        </div>
+        <hr class="my-4 border-gray-600">
+        {% endif %}
 
         <!-- Shortcuts info -->
         <div class="text-sm hidden md:block">

--- a/lerobot/templates/visualize_dataset_template.html
+++ b/lerobot/templates/visualize_dataset_template.html
@@ -102,10 +102,9 @@
 
         <!-- Language instruction -->
         {% if videos_info[0].language_instruction %}
-        <div class="text-sm font-bold mt-2">
-            Language Instruction: <em>{{ videos_info[0].language_instruction }}</em>
-        </div>
-        <hr class="my-4 border-gray-600">
+        <p class="font-medium mt-2">
+            Language Instruction: <span class="italic">{{ videos_info[0].language_instruction }}</span>
+        </p>
         {% endif %}
 
         <!-- Shortcuts info -->


### PR DESCRIPTION
## What this does
Adds a line under the video visualization in `visualize_dataset_html.py` to print the language instuction if it exists in the dataset.

Example from the `nyu_franka_play_dataset`:
<img width="985" alt="Screenshot 2024-08-28 at 08 58 20" src="https://github.com/user-attachments/assets/1d431957-69fd-4052-88df-d3fdbb638c57">


## How it was tested
I tested it by running `python lerobot/scripts/visualize_dataset_html.py` with several datasets from OpenX  and other datasets that don't contain language instruction like pusht.

To test it yourself:
NYU Franka play dataset
```
python lerobot/scripts/visualize_dataset_html.py --repo-id lerobot/nyu_franka_play_dataset --episodes 0
```
CMU Stretch dataset
```
python lerobot/scripts/visualize_dataset_html.py --repo-id lerobot/cmu_stretch --episodes 0 1 2 3
```
Imperial College Sawyer dataset
```
python lerobot/scripts/visualize_dataset_html.py --repo-id lerobot/imperialcollege_sawyer_wrist_cam --episodes 0 1 2 3
```

For a sanity check, try it with a dataset that doesn't have language instruction pusht:
```
python lerobot/scripts/visualize_dataset_html.py --repo-id lerobot/pusht --episodes 0 1 2 3
```