### PR TITLE
fix(act): n_vae_encoder_layers config parameter wasn't being used

### DIFF
--- a/lerobot/common/policies/act/modeling_act.py
+++ b/lerobot/common/policies/act/modeling_act.py
@@ -296,7 +296,7 @@ class ACT(nn.Module):
         self.use_images = any(k.startswith("observation.image") for k in config.input_shapes)
         self.use_env_state = "observation.environment_state" in config.input_shapes
         if self.config.use_vae:
-            self.vae_encoder = ACTEncoder(config, is_vae_encoder = True)
+            self.vae_encoder = ACTEncoder(config, is_vae_encoder=True)
             self.vae_encoder_cls_embed = nn.Embedding(1, config.dim_model)
             # Projection layer for joint-space configuration to hidden dimension.
             if self.use_robot_state:
@@ -523,7 +523,8 @@ class ACTEncoder(nn.Module):
 
     def __init__(self, config: ACTConfig, is_vae_encoder: bool = False):
         super().__init__()
-        num_layers = config.n_vae_encoder_layers if is_vae_encoder else config.n_encoder_layers
+        self.is_vae_encoder = is_vae_encoder
+        num_layers = config.n_vae_encoder_layers if self.is_vae_encoder else config.n_encoder_layers
         self.layers = nn.ModuleList([ACTEncoderLayer(config) for _ in range(num_layers)])
         self.norm = nn.LayerNorm(config.dim_model) if config.pre_norm else nn.Identity()
 

--- a/lerobot/common/policies/act/modeling_act.py
+++ b/lerobot/common/policies/act/modeling_act.py
@@ -296,7 +296,7 @@ class ACT(nn.Module):
         self.use_images = any(k.startswith("observation.image") for k in config.input_shapes)
         self.use_env_state = "observation.environment_state" in config.input_shapes
         if self.config.use_vae:
-            self.vae_encoder = ACTEncoder(config)
+            self.vae_encoder = ACTEncoder(config, is_vae_encoder = True)
             self.vae_encoder_cls_embed = nn.Embedding(1, config.dim_model)
             # Projection layer for joint-space configuration to hidden dimension.
             if self.use_robot_state:
@@ -521,9 +521,10 @@ class ACT(nn.Module):
 class ACTEncoder(nn.Module):
     """Convenience module for running multiple encoder layers, maybe followed by normalization."""
 
-    def __init__(self, config: ACTConfig):
+    def __init__(self, config: ACTConfig, is_vae_encoder: bool = False):
         super().__init__()
-        self.layers = nn.ModuleList([ACTEncoderLayer(config) for _ in range(config.n_encoder_layers)])
+        num_layers = config.n_vae_encoder_layers if is_vae_encoder else config.n_encoder_layers
+        self.layers = nn.ModuleList([ACTEncoderLayer(config) for _ in range(num_layers)])
         self.norm = nn.LayerNorm(config.dim_model) if config.pre_norm else nn.Identity()
 
     def forward(


### PR DESCRIPTION
## What this does

`n_vae_encoder_layers` configuration parameter was not being used In `lerobot/common/policies/act/modeling_act.py`. This PR updates the `ACTEncoder` class used for both the VAE and Transformer encoder to take a boolean argument `is_vae_encoder` and use `n_vae_encoder_layers` if true, else it will use `n_encoder_layers`.

## How it was tested
- Trained an ACT model for 1000 steps after making the change and with `n_vae_encoder_layers=8` . Instructions to reproduce below
Conditional checkpoint to inspect number of layers created for VAE ACTEncoder 
![Screenshot 2024-09-01 at 5 46 14 PM](https://github.com/user-attachments/assets/17de4eac-7da6-4e38-bbf7-9f16273755a4)
Conditional checkpoint to in
![Screenshot 2024-09-01 at 5 47 00 PM](https://github.com/user-attachments/assets/b2044005-83cf-4c6c-b221-9310fecdf600)
spect number of layers created for Transformer ACTEncoder

- Currently running the pytest test suite...

## How to checkout & try? (for the reviewer)
- `pip install -e .[koch, test]`
- Update `lerobot/configs/policy/act_koch_real.yaml` to
```
# @package _global_

# Use `act_koch_real.yaml` to train on real-world datasets collected on Alexander Koch's robots.
# Compared to `act.yaml`, it contains 2 cameras (i.e. laptop, phone) instead of 1 camera (i.e. top).
# Also, `training.eval_freq` is set to -1. This config is used to evaluate checkpoints at a certain frequency of training steps.
# When it is set to -1, it deactivates evaluation. This is because real-world evaluation is done through our `control_robot.py` script.
# Look at the documentation in header of `control_robot.py` for more information on how to collect data , train and evaluate a policy.
#
# Example of usage for training:
# ```bash
# python lerobot/scripts/train.py \
#   policy=act_koch_real \
#   env=koch_real
# ```

seed: 1000
# dataset_repo_id: lerobot/koch_pick_place_lego
dataset_repo_id: [jackvial/koch_pick_and_place_pistachio_8_e100, jackvial/koch_pick_and_place_pistachio_10_e20, jackvial/koch_pick_and_place_pistachio_11_e20]

override_dataset_stats:
  # observation.images.laptop:
  observation.images.elp0:
    # stats from imagenet, since we use a pretrained vision model
    mean: [[[0.485]], [[0.456]], [[0.406]]]  # (c,1,1)
    std: [[[0.229]], [[0.224]], [[0.225]]]  # (c,1,1)
  # observation.images.phone:
  observation.images.elp1:
    # stats from imagenet, since we use a pretrained vision model
    mean: [[[0.485]], [[0.456]], [[0.406]]]  # (c,1,1)
    std: [[[0.229]], [[0.224]], [[0.225]]]  # (c,1,1)

training:
  offline_steps: 1000
  online_steps: 0
  eval_freq: -1
  save_freq: 100
  log_freq: 100
  save_checkpoint: true

  batch_size: 8
  lr: 1e-5
  lr_backbone: 1e-5
  weight_decay: 1e-4
  grad_clip_norm: 10
  online_steps_between_rollouts: 1

  delta_timestamps:
    action: "[i / ${fps} for i in range(${policy.chunk_size})]"

eval:
  n_episodes: 50
  batch_size: 50

# See `configuration_act.py` for more details.
policy:
  name: act

  # Input / output structure.
  n_obs_steps: 1
  chunk_size: 100
  n_action_steps: 100

  input_shapes:
    # TODO(rcadene, alexander-soare): add variables for height and width from the dataset/env?
    # observation.images.laptop: [3, 480, 640]
    # observation.images.phone: [3, 480, 640]
    observation.images.elp1: [3, 600, 800]
    observation.images.elp0: [3, 600, 800]
    observation.state: ["${env.state_dim}"]
  output_shapes:
    action: ["${env.action_dim}"]

  # Normalization / Unnormalization
  input_normalization_modes:
    # observation.images.laptop: mean_std
    # observation.images.phone: mean_std
    observation.images.elp1: mean_std
    observation.images.elp0: mean_std
    observation.state: mean_std
  output_normalization_modes:
    action: mean_std

  # Architecture.
  # Vision backbone.
  vision_backbone: resnet18
  pretrained_backbone_weights: ResNet18_Weights.IMAGENET1K_V1
  replace_final_stride_with_dilation: false
  # Transformer layers.
  pre_norm: false
  dim_model: 512
  n_heads: 8
  dim_feedforward: 3200
  feedforward_activation: relu
  n_encoder_layers: 4
  # Note: Although the original ACT implementation has 7 for `n_decoder_layers`, there is a bug in the code
  # that means only the first layer is used. Here we match the original implementation by setting this to 1.
  # See this issue https://github.com/tonyzhaozh/act/issues/25#issue-2258740521.
  n_decoder_layers: 1
  # VAE.
  use_vae: true
  latent_dim: 32
  n_vae_encoder_layers: 8

  # Inference.
  temporal_ensemble_momentum: null

  # Training and loss computation.
  dropout: 0.1
  kl_weight: 10.0
```
- Train ACT model for 1000 steps by running:
`python lerobot/scripts/train.py dataset_repo_id=jackvial/koch_pick_and_place_pistachio_8_e100 policy=act_koch_real env=koch_real hydra.run.dir=outputs/train/koch_pick_and_place_pistachio_8_e100_fix_vae_config_test_2 hydra.job.name=koch_pick_and_place_pistachio_8_e100_fix_vae_config_test_2 device=cuda wandb.enable=true`

or using this `.vscode/launch.json`
```
{
    "version": "0.2.0",
    "configurations": [
        {
            "name": "Debug Train",
            "type": "debugpy",
            "request": "launch",
            "program": "${workspaceFolder}/lerobot/scripts/train.py",
            "args": [
                "dataset_repo_id=jackvial/koch_pick_and_place_pistachio_8_e100",
                "policy=act_koch_real",
                "env=koch_real",
                "hydra.run.dir=outputs/train/koch_pick_and_place_pistachio_8_e100_fix_vae_config_test_2",
                "hydra.job.name=koch_pick_and_place_pistachio_8_e100_fix_vae_config_test_2",
                "device=cuda",
                "wandb.enable=true"
            ],
            "console": "integratedTerminal",
            "python": "${workspaceFolder}/venv/bin/python3.10"
        }
    ]
}
```