### PR TITLE
feat(dataset): allow overriding tolerance_s

### DIFF
--- a/lerobot/common/datasets/lerobot_dataset.py
+++ b/lerobot/common/datasets/lerobot_dataset.py
@@ -49,6 +49,7 @@ class LeRobotDataset(torch.utils.data.Dataset):
         image_transforms: Callable | None = None,
         delta_timestamps: dict[list[float]] | None = None,
         video_backend: str | None = None,
+        tolerance_s: float | None = None,
     ):
         super().__init__()
         self.repo_id = repo_id
@@ -56,6 +57,7 @@ class LeRobotDataset(torch.utils.data.Dataset):
         self.split = split
         self.image_transforms = image_transforms
         self.delta_timestamps = delta_timestamps
+        self.tolerance_s = tolerance_s
         # load data from hub or locally when root is provided
         # TODO(rcadene, aliberts): implement faster transfer
         # https://huggingface.co/docs/huggingface_hub/en/guides/download#faster-downloads
@@ -126,6 +128,9 @@ class LeRobotDataset(torch.utils.data.Dataset):
         are not close enough from the requested frames. It is only used when `delta_timestamps`
         is provided or when loading video frames from mp4 files.
         """
+        if self.tolerance_s is not None:
+            return self.tolerance_s
+
         # 1e-4 to account for possible numerical error
         return 1 / self.fps - 1e-4
 
@@ -190,6 +195,7 @@ class LeRobotDataset(torch.utils.data.Dataset):
         info=None,
         videos_dir=None,
         video_backend=None,
+        tolerance_s: float | None = None,
     ) -> "LeRobotDataset":
         """Create a LeRobot Dataset from existing data and attributes instead of loading from the filesystem.
 
@@ -212,6 +218,7 @@ class LeRobotDataset(torch.utils.data.Dataset):
         obj.info = info if info is not None else {}
         obj.videos_dir = videos_dir
         obj.video_backend = video_backend if video_backend is not None else "pyav"
+        obj.tolerance_s = tolerance_s
         return obj
 
 

--- a/lerobot/common/datasets/lerobot_dataset.py
+++ b/lerobot/common/datasets/lerobot_dataset.py
@@ -57,7 +57,7 @@ class LeRobotDataset(torch.utils.data.Dataset):
         self.split = split
         self.image_transforms = image_transforms
         self.delta_timestamps = delta_timestamps
-        self.tolerance_s = tolerance_s
+        self.default_tolerance_s = tolerance_s
         # load data from hub or locally when root is provided
         # TODO(rcadene, aliberts): implement faster transfer
         # https://huggingface.co/docs/huggingface_hub/en/guides/download#faster-downloads
@@ -128,8 +128,8 @@ class LeRobotDataset(torch.utils.data.Dataset):
         are not close enough from the requested frames. It is only used when `delta_timestamps`
         is provided or when loading video frames from mp4 files.
         """
-        if self.tolerance_s is not None:
-            return self.tolerance_s
+        if self.default_tolerance_s is not None:
+            return self.default_tolerance_s
 
         # 1e-4 to account for possible numerical error
         return 1 / self.fps - 1e-4
@@ -218,7 +218,7 @@ class LeRobotDataset(torch.utils.data.Dataset):
         obj.info = info if info is not None else {}
         obj.videos_dir = videos_dir
         obj.video_backend = video_backend if video_backend is not None else "pyav"
-        obj.tolerance_s = tolerance_s
+        obj.default_tolerance_s = tolerance_s
         return obj
 
 
@@ -237,6 +237,7 @@ class MultiLeRobotDataset(torch.utils.data.Dataset):
         image_transforms: Callable | None = None,
         delta_timestamps: dict[list[float]] | None = None,
         video_backend: str | None = None,
+        tolerance_s: float | None = None,
     ):
         super().__init__()
         self.repo_ids = repo_ids
@@ -250,6 +251,7 @@ class MultiLeRobotDataset(torch.utils.data.Dataset):
                 delta_timestamps=delta_timestamps,
                 image_transforms=image_transforms,
                 video_backend=video_backend,
+                tolerance_s=tolerance_s,
             )
             for repo_id in repo_ids
         ]
@@ -285,6 +287,7 @@ class MultiLeRobotDataset(torch.utils.data.Dataset):
         self.split = split
         self.image_transforms = image_transforms
         self.delta_timestamps = delta_timestamps
+        self.default_tolerance_s = tolerance_s
         self.stats = aggregate_stats(self._datasets)
 
     @property
@@ -364,6 +367,9 @@ class MultiLeRobotDataset(torch.utils.data.Dataset):
         are not close enough from the requested frames. It is only used when `delta_timestamps`
         is provided or when loading video frames from mp4 files.
         """
+        if self.default_tolerance_s is not None:
+            return self.default_tolerance_s
+        
         # 1e-4 to account for possible numerical error
         return 1 / self.fps - 1e-4
 

--- a/lerobot/scripts/control_robot.py
+++ b/lerobot/scripts/control_robot.py
@@ -300,10 +300,10 @@ def record(
     tags=None,
     num_image_writers=8,
     force_override=False,
+    dataset_sync_tolerance_s=None,
 ):
     # TODO(rcadene): Add option to record logs
     # TODO(rcadene): Clean this function via decomposition in higher level functions
-
     _, dataset_name = repo_id.split("/")
     if dataset_name.startswith("eval_") and policy is None:
         raise ValueError(
@@ -634,6 +634,7 @@ def record(
         episode_data_index=episode_data_index,
         info=info,
         videos_dir=videos_dir,
+        tolerance_s=dataset_sync_tolerance_s,
     )
     if run_compute_stats:
         logging.info("Computing dataset statistics")
@@ -798,7 +799,13 @@ if __name__ == "__main__":
         nargs="*",
         help="Any key=value arguments to override config values (use dots for.nested=overrides)",
     )
-
+    parser_record.add_argument(
+        "--dataset-sync-tolerance-s",
+        type=float,
+        default=None,
+        help="Override the maximum syncronisation tolerance (in seconds) between frames allowed by the LeRobot Dataset. Not passing an argument means we use FPS settings to infer the tolerance.",
+    )
+    
     parser_replay = subparsers.add_parser("replay", parents=[base_parser])
     parser_replay.add_argument(
         "--fps", type=none_or_int, default=None, help="Frames per second (set to None to disable)"


### PR DESCRIPTION
## What this does

My cameras can do maximum 30 FPS while I would like to record the joint states at higher FPS. In addition, occasional interrupts might cause an individual frame to be dropped or delayed, and having to drop the whole episode because of these may not be worth it.

This simply adds an option to override the tolerance_s constant in LeRobotDataset, and passes the value from data recording command line args. 

## How it was tested

Tested locally when recording data

## How to checkout & try? (for the reviewer)

Record some episodes with a real robot. Test with the command line arg turned on and off.
