### PR TITLE
fix(tdmpc): Add missing save_freq to tdmpc policy config

### DIFF
--- a/lerobot/configs/policy/tdmpc.yaml
+++ b/lerobot/configs/policy/tdmpc.yaml
@@ -12,6 +12,7 @@ training:
   grad_clip_norm: 10.0
   lr: 3e-4
 
+  save_freq: 10000
   eval_freq: 5000
   log_freq: 100
 


### PR DESCRIPTION
## What this does
Add missing `save_freq` key to `lerobot/configs/policy/tdmpc.yaml`

Without `save_freq` set I get the following error
```
Exception has occurred: MissingMandatoryValue
Missing mandatory value: training.save_freq
    full_key: training.save_freq
    object_type=dict
omegaconf.errors.MissingMandatoryValue: Missing mandatory value: $FULL_KEY

The above exception was the direct cause of the following exception:

  File "/home/jack/code/rl/lerobot/lerobot/scripts/train.py", line 380, in evaluate_and_checkpoint_if_needed
    step % cfg.training.save_freq == 0
  File "/home/jack/code/rl/lerobot/lerobot/scripts/train.py", line 447, in train
    evaluate_and_checkpoint_if_needed(step + 1, is_online=False)
  File "/home/jack/code/rl/lerobot/lerobot/scripts/train.py", line 652, in train_cli
    train(
  File "/home/jack/code/rl/lerobot/lerobot/scripts/train.py", line 669, in <module>
```
![Screenshot 2024-09-02 at 11 16 36 AM](https://github.com/user-attachments/assets/9970e475-55e0-429f-9f1f-519f39089303)

## How it was tested
Set `save_freq` to 10 and ran training and confirmed I was no longer seeing the error and checkpoints were saved

![Screenshot 2024-09-02 at 11 18 52 AM](https://github.com/user-attachments/assets/f3a0fe24-bb87-4bbb-ba9e-05043bc9fb6a)

![Screenshot 2024-09-02 at 11 26 10 AM](https://github.com/user-attachments/assets/a53801c3-3409-4068-849d-9d0e4e0fe6cd)

## How to checkout & try? (for the reviewer)
- `pip install -e ."[xarm, test]"`
- Set `save_freq: 10` in `lerobot/lerobot/configs/policy/tdmpc.yaml`
- Run `python lerobot/scripts/train.py dataset_repo_id=lerobot/xarm_lift_medium policy=tdmpc env=xarm hydra.run.dir=outputs/train/tdmpc_xarm_lift_medium_0 hydra.job.name=tdmpc_xarm_lift_medium_0 device=cuda wandb.enable=true`
- Or run with `.vscode/launch.json`
```
{
    "version": "0.2.0",
    "configurations": [
        {
            "name": "Debug Train",
            "type": "debugpy",
            "request": "launch",
            "program": "${workspaceFolder}/lerobot/scripts/train.py",
            "args": [
                "dataset_repo_id=lerobot/xarm_lift_medium",
                "policy=tdmpc",
                "env=xarm",
                "hydra.run.dir=outputs/train/tdmpc_xarm_lift_medium_0",
                "hydra.job.name=tdmpc_xarm_lift_medium_0",
                "device=cuda",
                "wandb.enable=true"
            ],
            "console": "integratedTerminal",
            "python": "${workspaceFolder}/venv/bin/python3.10",
        }
    ]
}
```
