### PR TITLE
Fix nightlies & untrack json files from git lfs

### DIFF
--- a/.cache/calibration/aloha_default/left_follower.json
+++ b/.cache/calibration/aloha_default/left_follower.json
@@ -1,1 +1,68 @@
-{"homing_offset": [2048, 3072, 3072, -1024, -1024, 2048, -2048, 2048, -2048], "drive_mode": [1, 1, 1, 0, 0, 1, 0, 1, 0], "start_pos": [2015, 3058, 3061, 1071, 1071, 2035, 2152, 2029, 2499], "end_pos": [-1008, -1963, -1966, 2141, 2143, -971, 3043, -1077, 3144], "calib_mode": ["DEGREE", "DEGREE", "DEGREE", "DEGREE", "DEGREE", "DEGREE", "DEGREE", "DEGREE", "LINEAR"], "motor_names": ["waist", "shoulder", "shoulder_shadow", "elbow", "elbow_shadow", "forearm_roll", "wrist_angle", "wrist_rotate", "gripper"]}
+{
+    "homing_offset": [
+        2048,
+        3072,
+        3072,
+        -1024,
+        -1024,
+        2048,
+        -2048,
+        2048,
+        -2048
+    ],
+    "drive_mode": [
+        1,
+        1,
+        1,
+        0,
+        0,
+        1,
+        0,
+        1,
+        0
+    ],
+    "start_pos": [
+        2015,
+        3058,
+        3061,
+        1071,
+        1071,
+        2035,
+        2152,
+        2029,
+        2499
+    ],
+    "end_pos": [
+        -1008,
+        -1963,
+        -1966,
+        2141,
+        2143,
+        -971,
+        3043,
+        -1077,
+        3144
+    ],
+    "calib_mode": [
+        "DEGREE",
+        "DEGREE",
+        "DEGREE",
+        "DEGREE",
+        "DEGREE",
+        "DEGREE",
+        "DEGREE",
+        "DEGREE",
+        "LINEAR"
+    ],
+    "motor_names": [
+        "waist",
+        "shoulder",
+        "shoulder_shadow",
+        "elbow",
+        "elbow_shadow",
+        "forearm_roll",
+        "wrist_angle",
+        "wrist_rotate",
+        "gripper"
+    ]
+}

--- a/.cache/calibration/aloha_default/left_leader.json
+++ b/.cache/calibration/aloha_default/left_leader.json
@@ -1,1 +1,68 @@
-{"homing_offset": [2048, 3072, 3072, -1024, -1024, 2048, -2048, 2048, -1024], "drive_mode": [1, 1, 1, 0, 0, 1, 0, 1, 0], "start_pos": [2035, 3024, 3019, 979, 981, 1982, 2166, 2124, 1968], "end_pos": [-990, -2017, -2015, 2078, 2076, -1030, 3117, -1016, 2556], "calib_mode": ["DEGREE", "DEGREE", "DEGREE", "DEGREE", "DEGREE", "DEGREE", "DEGREE", "DEGREE", "LINEAR"], "motor_names": ["waist", "shoulder", "shoulder_shadow", "elbow", "elbow_shadow", "forearm_roll", "wrist_angle", "wrist_rotate", "gripper"]}
+{
+    "homing_offset": [
+        2048,
+        3072,
+        3072,
+        -1024,
+        -1024,
+        2048,
+        -2048,
+        2048,
+        -1024
+    ],
+    "drive_mode": [
+        1,
+        1,
+        1,
+        0,
+        0,
+        1,
+        0,
+        1,
+        0
+    ],
+    "start_pos": [
+        2035,
+        3024,
+        3019,
+        979,
+        981,
+        1982,
+        2166,
+        2124,
+        1968
+    ],
+    "end_pos": [
+        -990,
+        -2017,
+        -2015,
+        2078,
+        2076,
+        -1030,
+        3117,
+        -1016,
+        2556
+    ],
+    "calib_mode": [
+        "DEGREE",
+        "DEGREE",
+        "DEGREE",
+        "DEGREE",
+        "DEGREE",
+        "DEGREE",
+        "DEGREE",
+        "DEGREE",
+        "LINEAR"
+    ],
+    "motor_names": [
+        "waist",
+        "shoulder",
+        "shoulder_shadow",
+        "elbow",
+        "elbow_shadow",
+        "forearm_roll",
+        "wrist_angle",
+        "wrist_rotate",
+        "gripper"
+    ]
+}

--- a/.cache/calibration/aloha_default/right_follower.json
+++ b/.cache/calibration/aloha_default/right_follower.json
@@ -1,1 +1,68 @@
-{"homing_offset": [2048, 3072, 3072, -1024, -1024, 2048, -2048, 2048, -2048], "drive_mode": [1, 1, 1, 0, 0, 1, 0, 1, 0], "start_pos": [2056, 2895, 2896, 1191, 1190, 2018, 2051, 2056, 2509], "end_pos": [-1040, -2004, -2006, 2126, 2127, -1010, 3050, -1117, 3143], "calib_mode": ["DEGREE", "DEGREE", "DEGREE", "DEGREE", "DEGREE", "DEGREE", "DEGREE", "DEGREE", "LINEAR"], "motor_names": ["waist", "shoulder", "shoulder_shadow", "elbow", "elbow_shadow", "forearm_roll", "wrist_angle", "wrist_rotate", "gripper"]}
+{
+    "homing_offset": [
+        2048,
+        3072,
+        3072,
+        -1024,
+        -1024,
+        2048,
+        -2048,
+        2048,
+        -2048
+    ],
+    "drive_mode": [
+        1,
+        1,
+        1,
+        0,
+        0,
+        1,
+        0,
+        1,
+        0
+    ],
+    "start_pos": [
+        2056,
+        2895,
+        2896,
+        1191,
+        1190,
+        2018,
+        2051,
+        2056,
+        2509
+    ],
+    "end_pos": [
+        -1040,
+        -2004,
+        -2006,
+        2126,
+        2127,
+        -1010,
+        3050,
+        -1117,
+        3143
+    ],
+    "calib_mode": [
+        "DEGREE",
+        "DEGREE",
+        "DEGREE",
+        "DEGREE",
+        "DEGREE",
+        "DEGREE",
+        "DEGREE",
+        "DEGREE",
+        "LINEAR"
+    ],
+    "motor_names": [
+        "waist",
+        "shoulder",
+        "shoulder_shadow",
+        "elbow",
+        "elbow_shadow",
+        "forearm_roll",
+        "wrist_angle",
+        "wrist_rotate",
+        "gripper"
+    ]
+}

--- a/.cache/calibration/aloha_default/right_leader.json
+++ b/.cache/calibration/aloha_default/right_leader.json
@@ -1,1 +1,68 @@
-{"homing_offset": [2048, 3072, 3072, -1024, -1024, 2048, -2048, 2048, -2048], "drive_mode": [1, 1, 1, 0, 0, 1, 0, 1, 0], "start_pos": [2068, 3034, 3030, 1038, 1041, 1991, 1948, 2090, 1985], "end_pos": [-1025, -2014, -2015, 2058, 2060, -955, 3091, -940, 2576], "calib_mode": ["DEGREE", "DEGREE", "DEGREE", "DEGREE", "DEGREE", "DEGREE", "DEGREE", "DEGREE", "LINEAR"], "motor_names": ["waist", "shoulder", "shoulder_shadow", "elbow", "elbow_shadow", "forearm_roll", "wrist_angle", "wrist_rotate", "gripper"]}
+{
+    "homing_offset": [
+        2048,
+        3072,
+        3072,
+        -1024,
+        -1024,
+        2048,
+        -2048,
+        2048,
+        -2048
+    ],
+    "drive_mode": [
+        1,
+        1,
+        1,
+        0,
+        0,
+        1,
+        0,
+        1,
+        0
+    ],
+    "start_pos": [
+        2068,
+        3034,
+        3030,
+        1038,
+        1041,
+        1991,
+        1948,
+        2090,
+        1985
+    ],
+    "end_pos": [
+        -1025,
+        -2014,
+        -2015,
+        2058,
+        2060,
+        -955,
+        3091,
+        -940,
+        2576
+    ],
+    "calib_mode": [
+        "DEGREE",
+        "DEGREE",
+        "DEGREE",
+        "DEGREE",
+        "DEGREE",
+        "DEGREE",
+        "DEGREE",
+        "DEGREE",
+        "LINEAR"
+    ],
+    "motor_names": [
+        "waist",
+        "shoulder",
+        "shoulder_shadow",
+        "elbow",
+        "elbow_shadow",
+        "forearm_roll",
+        "wrist_angle",
+        "wrist_rotate",
+        "gripper"
+    ]
+}

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,6 @@
-.cache/calibration/aloha_default/*.json -filter -diff -merge text
 *.memmap filter=lfs diff=lfs merge=lfs -text
 *.stl filter=lfs diff=lfs merge=lfs -text
 *.safetensors filter=lfs diff=lfs merge=lfs -text
 *.mp4 filter=lfs diff=lfs merge=lfs -text
 *.arrow filter=lfs diff=lfs merge=lfs -text
-*.json filter=lfs diff=lfs merge=lfs -text
+*.json !text !filter !merge !diff

--- a/.gitignore
+++ b/.gitignore
@@ -66,13 +66,17 @@ htmlcov/
 .nox/
 .coverage
 .coverage.*
-.cache
 nosetests.xml
 coverage.xml
 *.cover
 *.py,cover
 .hypothesis/
 .pytest_cache/
+
+# Ignore .cache except calibration
+.cache/*
+!.cache/calibration/
+!.cache/calibration/**
 
 # Translations
 *.mo

--- a/examples/4_train_policy_with_script.md
+++ b/examples/4_train_policy_with_script.md
@@ -196,7 +196,7 @@ These logs will also be saved in wandb if `wandb.enable` is set to `true`. Here 
 - `success`: average success rate of eval episodes. Reward and success are usually different except for the sparsing reward setting, where reward=1 only when the task is completed successfully.
 - `eval_s`: time to evaluate the policy in the environment, in second.
 - `updt_s`: time to update the network parameters, in second.
-- `data_s`: time to load a batch of data, in second. 
+- `data_s`: time to load a batch of data, in second.
 
 Some metrics are useful for initial performance profiling. For example, if you find the current GPU utilization is low via the `nvidia-smi` command and `data_s` sometimes is too high, you may need to modify batch size or number of dataloading workers to accelerate dataloading. We also recommend [pytorch profiler](https://github.com/huggingface/lerobot?tab=readme-ov-file#improve-your-code-with-profiling) for detailed performance probing.
 

--- a/lerobot/common/datasets/push_dataset_to_hub/openx/configs.yaml
+++ b/lerobot/common/datasets/push_dataset_to_hub/openx/configs.yaml
@@ -8,7 +8,7 @@ OPENX_DATASET_CONFIGS:
       - base_pose_tool_reached
       - gripper_closed
     fps: 3
-  
+
   kuka:
     image_obs_keys:
       - image
@@ -18,7 +18,7 @@ OPENX_DATASET_CONFIGS:
       - clip_function_input/base_pose_tool_reached
       - gripper_closed
     fps: 10
-  
+
   bridge_openx:
     image_obs_keys:
       - image
@@ -28,7 +28,7 @@ OPENX_DATASET_CONFIGS:
       - EEF_state
       - gripper_state
     fps: 5
-  
+
   taco_play:
     image_obs_keys:
       - rgb_static
@@ -40,7 +40,7 @@ OPENX_DATASET_CONFIGS:
       - state_eef
       - state_gripper
     fps: 15
-  
+
   jaco_play:
     image_obs_keys:
       - image
@@ -51,7 +51,7 @@ OPENX_DATASET_CONFIGS:
       - state_eef
       - state_gripper
     fps: 10
-  
+
   berkeley_cable_routing:
     image_obs_keys:
       - image
@@ -72,7 +72,7 @@ OPENX_DATASET_CONFIGS:
     state_obs_keys:
       - null
     fps: 10
-  
+
   nyu_door_opening_surprising_effectiveness:
     image_obs_keys:
       - image
@@ -221,7 +221,7 @@ OPENX_DATASET_CONFIGS:
     image_obs_keys:
       - highres_image
     depth_obs_keys:
-      - null  
+      - null
     state_obs_keys:
       - null
     fps: 10
@@ -234,7 +234,7 @@ OPENX_DATASET_CONFIGS:
     state_obs_keys:
       - joint_state
     fps: 2
-  
+
   ucsd_pick_and_place_dataset_converted_externally_to_rlds:
     image_obs_keys:
       - image
@@ -244,7 +244,7 @@ OPENX_DATASET_CONFIGS:
       - eef_state
       - gripper_state
     fps: 3
-  
+
   spoc:
     image_obs_keys:
       - image
@@ -254,7 +254,7 @@ OPENX_DATASET_CONFIGS:
     state_obs_keys:
       - null
     fps: 3
-  
+
   austin_sailor_dataset_converted_externally_to_rlds:
     image_obs_keys:
       - image
@@ -264,7 +264,7 @@ OPENX_DATASET_CONFIGS:
     state_obs_keys:
       - state
     fps: 20
-  
+
   austin_sirius_dataset_converted_externally_to_rlds:
     image_obs_keys:
       - image
@@ -274,7 +274,7 @@ OPENX_DATASET_CONFIGS:
     state_obs_keys:
       - state
     fps: 20
-  
+
   bc_z:
     image_obs_keys:
       - image
@@ -285,7 +285,7 @@ OPENX_DATASET_CONFIGS:
       - present/axis_angle
       - present/sensed_close
     fps: 10
-  
+
   utokyo_pr2_opening_fridge_converted_externally_to_rlds:
     image_obs_keys:
       - image
@@ -295,7 +295,7 @@ OPENX_DATASET_CONFIGS:
       - eef_state
       - gripper_state
     fps: 10
-  
+
   utokyo_pr2_tabletop_manipulation_converted_externally_to_rlds:
     image_obs_keys:
       - image
@@ -305,7 +305,7 @@ OPENX_DATASET_CONFIGS:
       - eef_state
       - gripper_state
     fps: 10
-  
+
   utokyo_xarm_pick_and_place_converted_externally_to_rlds:
     image_obs_keys:
       - image
@@ -316,7 +316,7 @@ OPENX_DATASET_CONFIGS:
     state_obs_keys:
       - end_effector_pose
     fps: 10
-  
+
   utokyo_xarm_bimanual_converted_externally_to_rlds:
     image_obs_keys:
       - image
@@ -325,7 +325,7 @@ OPENX_DATASET_CONFIGS:
     state_obs_keys:
       - pose_r
     fps: 10
-  
+
   robo_net:
     image_obs_keys:
       - image
@@ -336,7 +336,7 @@ OPENX_DATASET_CONFIGS:
       - eef_state
       - gripper_state
     fps: 1
-  
+
   robo_set:
     image_obs_keys:
       - image_left
@@ -348,7 +348,7 @@ OPENX_DATASET_CONFIGS:
       - state
       - state_velocity
     fps: 5
-  
+
   berkeley_mvp_converted_externally_to_rlds:
     image_obs_keys:
       - hand_image
@@ -359,7 +359,7 @@ OPENX_DATASET_CONFIGS:
       - pose
       - joint_pos
     fps: 5
-  
+
   berkeley_rpt_converted_externally_to_rlds:
     image_obs_keys:
       - hand_image
@@ -369,7 +369,7 @@ OPENX_DATASET_CONFIGS:
       - joint_pos
       - gripper
     fps: 30
-  
+
   kaist_nonprehensile_converted_externally_to_rlds:
     image_obs_keys:
       - image
@@ -378,7 +378,7 @@ OPENX_DATASET_CONFIGS:
     state_obs_keys:
       - state
     fps: 10
-  
+
   stanford_mask_vit_converted_externally_to_rlds:
     image_obs_keys:
       - image
@@ -387,7 +387,7 @@ OPENX_DATASET_CONFIGS:
     state_obs_keys:
       - eef_state
       - gripper_state
-  
+
   tokyo_u_lsmo_converted_externally_to_rlds:
     image_obs_keys:
       - image
@@ -397,7 +397,7 @@ OPENX_DATASET_CONFIGS:
       - eef_state
       - gripper_state
     fps: 10
-  
+
   dlr_sara_pour_converted_externally_to_rlds:
     image_obs_keys:
       - image
@@ -406,16 +406,16 @@ OPENX_DATASET_CONFIGS:
     state_obs_keys:
       - state
     fps: 10
-  
+
   dlr_sara_grid_clamp_converted_externally_to_rlds:
     image_obs_keys:
       - image
     depth_obs_keys:
       - null
     state_obs_keys:
-      - state  
+      - state
     fps: 10
-  
+
   dlr_edan_shared_control_converted_externally_to_rlds:
     image_obs_keys:
       - image
@@ -424,7 +424,7 @@ OPENX_DATASET_CONFIGS:
     state_obs_keys:
       - state
     fps: 5
-  
+
   asu_table_top_converted_externally_to_rlds:
     image_obs_keys:
       - image
@@ -478,7 +478,7 @@ OPENX_DATASET_CONFIGS:
     state_obs_keys:
       - null
     fps: 1
-  
+
   utaustin_mutex:
     image_obs_keys:
       - image
@@ -488,7 +488,7 @@ OPENX_DATASET_CONFIGS:
     state_obs_keys:
       - state
     fps: 20
-  
+
   berkeley_fanuc_manipulation:
     image_obs_keys:
       - image
@@ -499,7 +499,7 @@ OPENX_DATASET_CONFIGS:
       - joint_state
       - gripper_state
     fps: 10
-  
+
   cmu_playing_with_food:
     image_obs_keys:
       - image
@@ -509,7 +509,7 @@ OPENX_DATASET_CONFIGS:
     state_obs_keys:
       - state
     fps: 10
-  
+
   cmu_play_fusion:
     image_obs_keys:
       - image
@@ -518,7 +518,7 @@ OPENX_DATASET_CONFIGS:
     state_obs_keys:
       - state
     fps: 5
-  
+
   cmu_stretch:
     image_obs_keys:
       - image
@@ -528,7 +528,7 @@ OPENX_DATASET_CONFIGS:
       - eef_state
       - gripper_state
     fps: 10
-  
+
   berkeley_gnm_recon:
     image_obs_keys:
       - image
@@ -539,7 +539,7 @@ OPENX_DATASET_CONFIGS:
       - position
       - yaw
     fps: 3
- 
+
   berkeley_gnm_cory_hall:
     image_obs_keys:
       - image
@@ -550,7 +550,7 @@ OPENX_DATASET_CONFIGS:
       - position
       - yaw
     fps: 5
- 
+
   berkeley_gnm_sac_son:
     image_obs_keys:
       - image
@@ -561,7 +561,7 @@ OPENX_DATASET_CONFIGS:
       - position
       - yaw
     fps: 10
-  
+
   droid:
     image_obs_keys:
       - exterior_image_1_left
@@ -572,7 +572,7 @@ OPENX_DATASET_CONFIGS:
     state_obs_keys:
       - proprio
     fps: 15
-  
+
   droid_100:
     image_obs_keys:
       - exterior_image_1_left
@@ -583,7 +583,7 @@ OPENX_DATASET_CONFIGS:
     state_obs_keys:
       - proprio
     fps: 15
-  
+
   fmb:
     image_obs_keys:
       - image_side_1
@@ -598,7 +598,7 @@ OPENX_DATASET_CONFIGS:
     state_obs_keys:
       - proprio
     fps: 10
-  
+
   dobbe:
     image_obs_keys:
       - wrist_image
@@ -607,7 +607,7 @@ OPENX_DATASET_CONFIGS:
     state_obs_keys:
       - proprio
     fps: 3.75
-  
+
   usc_cloth_sim_converted_externally_to_rlds:
     image_obs_keys:
       - image
@@ -616,7 +616,7 @@ OPENX_DATASET_CONFIGS:
     state_obs_keys:
       - null
     fps: 10
-  
+
   plex_robosuite:
     image_obs_keys:
       - image
@@ -626,7 +626,7 @@ OPENX_DATASET_CONFIGS:
     state_obs_keys:
       - state
     fps: 20
-  
+
   conq_hose_manipulation:
     image_obs_keys:
       - frontleft_fisheye_image
@@ -637,4 +637,3 @@ OPENX_DATASET_CONFIGS:
     state_obs_keys:
       - state
     fps: 30
-  

--- a/lerobot/common/datasets/push_dataset_to_hub/openx_rlds_format.py
+++ b/lerobot/common/datasets/push_dataset_to_hub/openx_rlds_format.py
@@ -52,7 +52,7 @@ from lerobot.common.datasets.utils import (
 )
 from lerobot.common.datasets.video_utils import VideoFrame, encode_video_frames
 
-with open("lerobot/common/datasets/push_dataset_to_hub/openx/configs.yaml", "r") as f:
+with open("lerobot/common/datasets/push_dataset_to_hub/openx/configs.yaml") as f:
     _openx_list = yaml.safe_load(f)
 
 OPENX_DATASET_CONFIGS = _openx_list["OPENX_DATASET_CONFIGS"]

--- a/tests/data/lerobot/aloha_mobile_cabinet/meta_data/info.json
+++ b/tests/data/lerobot/aloha_mobile_cabinet/meta_data/info.json
@@ -1,3 +1,11 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:50e40e4c2bb523fca0b54e9a9635281312e9c6f9d757db03c06a0865c5508f29
-size 188
+{
+    "codebase_version": "v1.6",
+    "fps": 50,
+    "video": true,
+    "encoding": {
+        "vcodec": "libsvtav1",
+        "pix_fmt": "yuv420p",
+        "g": 2,
+        "crf": 30
+    }
+}

--- a/tests/data/lerobot/aloha_mobile_cabinet/train/dataset_info.json
+++ b/tests/data/lerobot/aloha_mobile_cabinet/train/dataset_info.json
@@ -1,3 +1,61 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8b7fbedfdb3d536847bc6fadf2cbabb9f2b5492edf3e2c274a3e8ffb447105e8
-size 1166
+{
+  "citation": "",
+  "description": "",
+  "features": {
+    "observation.images.cam_high": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_left_wrist": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_right_wrist": {
+      "_type": "VideoFrame"
+    },
+    "observation.state": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "observation.effort": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "action": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "episode_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "frame_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "timestamp": {
+      "dtype": "float32",
+      "_type": "Value"
+    },
+    "next.done": {
+      "dtype": "bool",
+      "_type": "Value"
+    },
+    "index": {
+      "dtype": "int64",
+      "_type": "Value"
+    }
+  },
+  "homepage": "",
+  "license": ""
+}

--- a/tests/data/lerobot/aloha_mobile_cabinet/train/state.json
+++ b/tests/data/lerobot/aloha_mobile_cabinet/train/state.json
@@ -1,3 +1,13 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:34ece24fb6b302db0b68987858509f31713fb299faa9a9d34b8fd68f10bc3100
-size 247
+{
+  "_data_files": [
+    {
+      "filename": "data-00000-of-00001.arrow"
+    }
+  ],
+  "_fingerprint": "3e76021c95d21c4d",
+  "_format_columns": null,
+  "_format_kwargs": {},
+  "_format_type": null,
+  "_output_all_columns": false,
+  "_split": null
+}

--- a/tests/data/lerobot/aloha_mobile_chair/meta_data/info.json
+++ b/tests/data/lerobot/aloha_mobile_chair/meta_data/info.json
@@ -1,3 +1,11 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:50e40e4c2bb523fca0b54e9a9635281312e9c6f9d757db03c06a0865c5508f29
-size 188
+{
+    "codebase_version": "v1.6",
+    "fps": 50,
+    "video": true,
+    "encoding": {
+        "vcodec": "libsvtav1",
+        "pix_fmt": "yuv420p",
+        "g": 2,
+        "crf": 30
+    }
+}

--- a/tests/data/lerobot/aloha_mobile_chair/train/dataset_info.json
+++ b/tests/data/lerobot/aloha_mobile_chair/train/dataset_info.json
@@ -1,3 +1,61 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8b7fbedfdb3d536847bc6fadf2cbabb9f2b5492edf3e2c274a3e8ffb447105e8
-size 1166
+{
+  "citation": "",
+  "description": "",
+  "features": {
+    "observation.images.cam_high": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_left_wrist": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_right_wrist": {
+      "_type": "VideoFrame"
+    },
+    "observation.state": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "observation.effort": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "action": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "episode_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "frame_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "timestamp": {
+      "dtype": "float32",
+      "_type": "Value"
+    },
+    "next.done": {
+      "dtype": "bool",
+      "_type": "Value"
+    },
+    "index": {
+      "dtype": "int64",
+      "_type": "Value"
+    }
+  },
+  "homepage": "",
+  "license": ""
+}

--- a/tests/data/lerobot/aloha_mobile_chair/train/state.json
+++ b/tests/data/lerobot/aloha_mobile_chair/train/state.json
@@ -1,3 +1,13 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:38cf4116a65cb92a5c43f9b9da7a7b81cfa9168b17605c8c456f7d3a3a23b77a
-size 247
+{
+  "_data_files": [
+    {
+      "filename": "data-00000-of-00001.arrow"
+    }
+  ],
+  "_fingerprint": "872117944c4ecdff",
+  "_format_columns": null,
+  "_format_kwargs": {},
+  "_format_type": null,
+  "_output_all_columns": false,
+  "_split": null
+}

--- a/tests/data/lerobot/aloha_mobile_elevator/meta_data/info.json
+++ b/tests/data/lerobot/aloha_mobile_elevator/meta_data/info.json
@@ -1,3 +1,11 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:50e40e4c2bb523fca0b54e9a9635281312e9c6f9d757db03c06a0865c5508f29
-size 188
+{
+    "codebase_version": "v1.6",
+    "fps": 50,
+    "video": true,
+    "encoding": {
+        "vcodec": "libsvtav1",
+        "pix_fmt": "yuv420p",
+        "g": 2,
+        "crf": 30
+    }
+}

--- a/tests/data/lerobot/aloha_mobile_elevator/train/dataset_info.json
+++ b/tests/data/lerobot/aloha_mobile_elevator/train/dataset_info.json
@@ -1,3 +1,61 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8b7fbedfdb3d536847bc6fadf2cbabb9f2b5492edf3e2c274a3e8ffb447105e8
-size 1166
+{
+  "citation": "",
+  "description": "",
+  "features": {
+    "observation.images.cam_high": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_left_wrist": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_right_wrist": {
+      "_type": "VideoFrame"
+    },
+    "observation.state": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "observation.effort": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "action": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "episode_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "frame_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "timestamp": {
+      "dtype": "float32",
+      "_type": "Value"
+    },
+    "next.done": {
+      "dtype": "bool",
+      "_type": "Value"
+    },
+    "index": {
+      "dtype": "int64",
+      "_type": "Value"
+    }
+  },
+  "homepage": "",
+  "license": ""
+}

--- a/tests/data/lerobot/aloha_mobile_elevator/train/state.json
+++ b/tests/data/lerobot/aloha_mobile_elevator/train/state.json
@@ -1,3 +1,13 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d394d451929b805f2d94f9fc5b12d15c31cfc494df76d7d642b63378b8ba0131
-size 247
+{
+  "_data_files": [
+    {
+      "filename": "data-00000-of-00001.arrow"
+    }
+  ],
+  "_fingerprint": "ba1d9dc6ea5a9717",
+  "_format_columns": null,
+  "_format_kwargs": {},
+  "_format_type": null,
+  "_output_all_columns": false,
+  "_split": null
+}

--- a/tests/data/lerobot/aloha_mobile_shrimp/meta_data/info.json
+++ b/tests/data/lerobot/aloha_mobile_shrimp/meta_data/info.json
@@ -1,3 +1,11 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:50e40e4c2bb523fca0b54e9a9635281312e9c6f9d757db03c06a0865c5508f29
-size 188
+{
+    "codebase_version": "v1.6",
+    "fps": 50,
+    "video": true,
+    "encoding": {
+        "vcodec": "libsvtav1",
+        "pix_fmt": "yuv420p",
+        "g": 2,
+        "crf": 30
+    }
+}

--- a/tests/data/lerobot/aloha_mobile_shrimp/train/dataset_info.json
+++ b/tests/data/lerobot/aloha_mobile_shrimp/train/dataset_info.json
@@ -1,3 +1,61 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8b7fbedfdb3d536847bc6fadf2cbabb9f2b5492edf3e2c274a3e8ffb447105e8
-size 1166
+{
+  "citation": "",
+  "description": "",
+  "features": {
+    "observation.images.cam_high": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_left_wrist": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_right_wrist": {
+      "_type": "VideoFrame"
+    },
+    "observation.state": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "observation.effort": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "action": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "episode_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "frame_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "timestamp": {
+      "dtype": "float32",
+      "_type": "Value"
+    },
+    "next.done": {
+      "dtype": "bool",
+      "_type": "Value"
+    },
+    "index": {
+      "dtype": "int64",
+      "_type": "Value"
+    }
+  },
+  "homepage": "",
+  "license": ""
+}

--- a/tests/data/lerobot/aloha_mobile_shrimp/train/state.json
+++ b/tests/data/lerobot/aloha_mobile_shrimp/train/state.json
@@ -1,3 +1,13 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:69435f30146a309c8d7d0eb01216555bf0547095db1fc9c20218d481d6fe62c8
-size 247
+{
+  "_data_files": [
+    {
+      "filename": "data-00000-of-00001.arrow"
+    }
+  ],
+  "_fingerprint": "d95a3a7eae59566d",
+  "_format_columns": null,
+  "_format_kwargs": {},
+  "_format_type": null,
+  "_output_all_columns": false,
+  "_split": null
+}

--- a/tests/data/lerobot/aloha_mobile_wash_pan/meta_data/info.json
+++ b/tests/data/lerobot/aloha_mobile_wash_pan/meta_data/info.json
@@ -1,3 +1,11 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:50e40e4c2bb523fca0b54e9a9635281312e9c6f9d757db03c06a0865c5508f29
-size 188
+{
+    "codebase_version": "v1.6",
+    "fps": 50,
+    "video": true,
+    "encoding": {
+        "vcodec": "libsvtav1",
+        "pix_fmt": "yuv420p",
+        "g": 2,
+        "crf": 30
+    }
+}

--- a/tests/data/lerobot/aloha_mobile_wash_pan/train/dataset_info.json
+++ b/tests/data/lerobot/aloha_mobile_wash_pan/train/dataset_info.json
@@ -1,3 +1,61 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8b7fbedfdb3d536847bc6fadf2cbabb9f2b5492edf3e2c274a3e8ffb447105e8
-size 1166
+{
+  "citation": "",
+  "description": "",
+  "features": {
+    "observation.images.cam_high": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_left_wrist": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_right_wrist": {
+      "_type": "VideoFrame"
+    },
+    "observation.state": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "observation.effort": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "action": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "episode_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "frame_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "timestamp": {
+      "dtype": "float32",
+      "_type": "Value"
+    },
+    "next.done": {
+      "dtype": "bool",
+      "_type": "Value"
+    },
+    "index": {
+      "dtype": "int64",
+      "_type": "Value"
+    }
+  },
+  "homepage": "",
+  "license": ""
+}

--- a/tests/data/lerobot/aloha_mobile_wash_pan/train/state.json
+++ b/tests/data/lerobot/aloha_mobile_wash_pan/train/state.json
@@ -1,3 +1,13 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:921505133c62906bd53034a613a827996994875d84c8b26d69d188df9a7ffeba
-size 247
+{
+  "_data_files": [
+    {
+      "filename": "data-00000-of-00001.arrow"
+    }
+  ],
+  "_fingerprint": "09ba9b66b7f468bc",
+  "_format_columns": null,
+  "_format_kwargs": {},
+  "_format_type": null,
+  "_output_all_columns": false,
+  "_split": null
+}

--- a/tests/data/lerobot/aloha_mobile_wipe_wine/meta_data/info.json
+++ b/tests/data/lerobot/aloha_mobile_wipe_wine/meta_data/info.json
@@ -1,3 +1,11 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:50e40e4c2bb523fca0b54e9a9635281312e9c6f9d757db03c06a0865c5508f29
-size 188
+{
+    "codebase_version": "v1.6",
+    "fps": 50,
+    "video": true,
+    "encoding": {
+        "vcodec": "libsvtav1",
+        "pix_fmt": "yuv420p",
+        "g": 2,
+        "crf": 30
+    }
+}

--- a/tests/data/lerobot/aloha_mobile_wipe_wine/train/dataset_info.json
+++ b/tests/data/lerobot/aloha_mobile_wipe_wine/train/dataset_info.json
@@ -1,3 +1,61 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8b7fbedfdb3d536847bc6fadf2cbabb9f2b5492edf3e2c274a3e8ffb447105e8
-size 1166
+{
+  "citation": "",
+  "description": "",
+  "features": {
+    "observation.images.cam_high": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_left_wrist": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_right_wrist": {
+      "_type": "VideoFrame"
+    },
+    "observation.state": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "observation.effort": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "action": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "episode_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "frame_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "timestamp": {
+      "dtype": "float32",
+      "_type": "Value"
+    },
+    "next.done": {
+      "dtype": "bool",
+      "_type": "Value"
+    },
+    "index": {
+      "dtype": "int64",
+      "_type": "Value"
+    }
+  },
+  "homepage": "",
+  "license": ""
+}

--- a/tests/data/lerobot/aloha_mobile_wipe_wine/train/state.json
+++ b/tests/data/lerobot/aloha_mobile_wipe_wine/train/state.json
@@ -1,3 +1,13 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:505a42c408d56c8a7d3e2367280b41e27667b58334f32e84c937c44c38217bd6
-size 247
+{
+  "_data_files": [
+    {
+      "filename": "data-00000-of-00001.arrow"
+    }
+  ],
+  "_fingerprint": "5a33376149b4e966",
+  "_format_columns": null,
+  "_format_kwargs": {},
+  "_format_type": null,
+  "_output_all_columns": false,
+  "_split": null
+}

--- a/tests/data/lerobot/aloha_sim_insertion_human/meta_data/info.json
+++ b/tests/data/lerobot/aloha_sim_insertion_human/meta_data/info.json
@@ -1,3 +1,11 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:50e40e4c2bb523fca0b54e9a9635281312e9c6f9d757db03c06a0865c5508f29
-size 188
+{
+    "codebase_version": "v1.6",
+    "fps": 50,
+    "video": true,
+    "encoding": {
+        "vcodec": "libsvtav1",
+        "pix_fmt": "yuv420p",
+        "g": 2,
+        "crf": 30
+    }
+}

--- a/tests/data/lerobot/aloha_sim_insertion_human/train/dataset_info.json
+++ b/tests/data/lerobot/aloha_sim_insertion_human/train/dataset_info.json
@@ -1,3 +1,47 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3f44d13de5d5a417263bbd4984942ed42ed3fa0633405aa14d9a969a45274944
-size 842
+{
+  "citation": "",
+  "description": "",
+  "features": {
+    "observation.images.top": {
+      "_type": "VideoFrame"
+    },
+    "observation.state": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "action": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "episode_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "frame_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "timestamp": {
+      "dtype": "float32",
+      "_type": "Value"
+    },
+    "next.done": {
+      "dtype": "bool",
+      "_type": "Value"
+    },
+    "index": {
+      "dtype": "int64",
+      "_type": "Value"
+    }
+  },
+  "homepage": "",
+  "license": ""
+}

--- a/tests/data/lerobot/aloha_sim_insertion_human/train/state.json
+++ b/tests/data/lerobot/aloha_sim_insertion_human/train/state.json
@@ -1,3 +1,13 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c0b18566cbf59e399ea40f1630df12ffbbb9f73bbc733d1d4eba62d675b1fda5
-size 247
+{
+  "_data_files": [
+    {
+      "filename": "data-00000-of-00001.arrow"
+    }
+  ],
+  "_fingerprint": "3aa08798f073758b",
+  "_format_columns": null,
+  "_format_kwargs": {},
+  "_format_type": null,
+  "_output_all_columns": false,
+  "_split": null
+}

--- a/tests/data/lerobot/aloha_sim_insertion_human_image/meta_data/info.json
+++ b/tests/data/lerobot/aloha_sim_insertion_human_image/meta_data/info.json
@@ -1,3 +1,5 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e7ab5c2bd7d176d4d7902a600240318c2828b7d75f4a888d0887327e4eff089d
-size 65
+{
+    "codebase_version": "v1.6",
+    "fps": 50,
+    "video": 0
+}

--- a/tests/data/lerobot/aloha_sim_insertion_human_image/train/dataset_info.json
+++ b/tests/data/lerobot/aloha_sim_insertion_human_image/train/dataset_info.json
@@ -1,3 +1,47 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4c9545525dc1f4d550591bd5efb63b55c15b983ae0510fefda5a16d77c78b6ef
-size 837
+{
+  "citation": "",
+  "description": "",
+  "features": {
+    "observation.images.top": {
+      "_type": "Image"
+    },
+    "observation.state": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "action": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "episode_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "frame_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "timestamp": {
+      "dtype": "float32",
+      "_type": "Value"
+    },
+    "next.done": {
+      "dtype": "bool",
+      "_type": "Value"
+    },
+    "index": {
+      "dtype": "int64",
+      "_type": "Value"
+    }
+  },
+  "homepage": "",
+  "license": ""
+}

--- a/tests/data/lerobot/aloha_sim_insertion_human_image/train/state.json
+++ b/tests/data/lerobot/aloha_sim_insertion_human_image/train/state.json
@@ -1,3 +1,13 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d7aa033603dc90582516dbcdf3e71e4d3113b70ad49098535def0b282135b5f3
-size 247
+{
+  "_data_files": [
+    {
+      "filename": "data-00000-of-00001.arrow"
+    }
+  ],
+  "_fingerprint": "9fe3a4bf575a8a67",
+  "_format_columns": null,
+  "_format_kwargs": {},
+  "_format_type": null,
+  "_output_all_columns": false,
+  "_split": null
+}

--- a/tests/data/lerobot/aloha_sim_insertion_scripted/meta_data/info.json
+++ b/tests/data/lerobot/aloha_sim_insertion_scripted/meta_data/info.json
@@ -1,3 +1,11 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:50e40e4c2bb523fca0b54e9a9635281312e9c6f9d757db03c06a0865c5508f29
-size 188
+{
+    "codebase_version": "v1.6",
+    "fps": 50,
+    "video": true,
+    "encoding": {
+        "vcodec": "libsvtav1",
+        "pix_fmt": "yuv420p",
+        "g": 2,
+        "crf": 30
+    }
+}

--- a/tests/data/lerobot/aloha_sim_insertion_scripted/train/dataset_info.json
+++ b/tests/data/lerobot/aloha_sim_insertion_scripted/train/dataset_info.json
@@ -1,3 +1,47 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3f44d13de5d5a417263bbd4984942ed42ed3fa0633405aa14d9a969a45274944
-size 842
+{
+  "citation": "",
+  "description": "",
+  "features": {
+    "observation.images.top": {
+      "_type": "VideoFrame"
+    },
+    "observation.state": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "action": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "episode_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "frame_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "timestamp": {
+      "dtype": "float32",
+      "_type": "Value"
+    },
+    "next.done": {
+      "dtype": "bool",
+      "_type": "Value"
+    },
+    "index": {
+      "dtype": "int64",
+      "_type": "Value"
+    }
+  },
+  "homepage": "",
+  "license": ""
+}

--- a/tests/data/lerobot/aloha_sim_insertion_scripted/train/state.json
+++ b/tests/data/lerobot/aloha_sim_insertion_scripted/train/state.json
@@ -1,3 +1,13 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5fd5fe80657788d044cdc8a1baf1456c7695cc951049347a469165002a83c6c7
-size 247
+{
+  "_data_files": [
+    {
+      "filename": "data-00000-of-00001.arrow"
+    }
+  ],
+  "_fingerprint": "e7db591f2ec3eeec",
+  "_format_columns": null,
+  "_format_kwargs": {},
+  "_format_type": null,
+  "_output_all_columns": false,
+  "_split": null
+}

--- a/tests/data/lerobot/aloha_sim_insertion_scripted_image/meta_data/info.json
+++ b/tests/data/lerobot/aloha_sim_insertion_scripted_image/meta_data/info.json
@@ -1,3 +1,5 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e7ab5c2bd7d176d4d7902a600240318c2828b7d75f4a888d0887327e4eff089d
-size 65
+{
+    "codebase_version": "v1.6",
+    "fps": 50,
+    "video": 0
+}

--- a/tests/data/lerobot/aloha_sim_insertion_scripted_image/train/dataset_info.json
+++ b/tests/data/lerobot/aloha_sim_insertion_scripted_image/train/dataset_info.json
@@ -1,3 +1,47 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4c9545525dc1f4d550591bd5efb63b55c15b983ae0510fefda5a16d77c78b6ef
-size 837
+{
+  "citation": "",
+  "description": "",
+  "features": {
+    "observation.images.top": {
+      "_type": "Image"
+    },
+    "observation.state": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "action": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "episode_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "frame_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "timestamp": {
+      "dtype": "float32",
+      "_type": "Value"
+    },
+    "next.done": {
+      "dtype": "bool",
+      "_type": "Value"
+    },
+    "index": {
+      "dtype": "int64",
+      "_type": "Value"
+    }
+  },
+  "homepage": "",
+  "license": ""
+}

--- a/tests/data/lerobot/aloha_sim_insertion_scripted_image/train/state.json
+++ b/tests/data/lerobot/aloha_sim_insertion_scripted_image/train/state.json
@@ -1,3 +1,13 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:752660d8fd884b33b7302a4a42ec7c680de2a3e5022d7d007586f4c6337ce08a
-size 247
+{
+  "_data_files": [
+    {
+      "filename": "data-00000-of-00001.arrow"
+    }
+  ],
+  "_fingerprint": "9be74ce70441e055",
+  "_format_columns": null,
+  "_format_kwargs": {},
+  "_format_type": null,
+  "_output_all_columns": false,
+  "_split": null
+}

--- a/tests/data/lerobot/aloha_sim_transfer_cube_human/meta_data/info.json
+++ b/tests/data/lerobot/aloha_sim_transfer_cube_human/meta_data/info.json
@@ -1,3 +1,11 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:50e40e4c2bb523fca0b54e9a9635281312e9c6f9d757db03c06a0865c5508f29
-size 188
+{
+    "codebase_version": "v1.6",
+    "fps": 50,
+    "video": true,
+    "encoding": {
+        "vcodec": "libsvtav1",
+        "pix_fmt": "yuv420p",
+        "g": 2,
+        "crf": 30
+    }
+}

--- a/tests/data/lerobot/aloha_sim_transfer_cube_human/train/dataset_info.json
+++ b/tests/data/lerobot/aloha_sim_transfer_cube_human/train/dataset_info.json
@@ -1,3 +1,47 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3f44d13de5d5a417263bbd4984942ed42ed3fa0633405aa14d9a969a45274944
-size 842
+{
+  "citation": "",
+  "description": "",
+  "features": {
+    "observation.images.top": {
+      "_type": "VideoFrame"
+    },
+    "observation.state": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "action": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "episode_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "frame_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "timestamp": {
+      "dtype": "float32",
+      "_type": "Value"
+    },
+    "next.done": {
+      "dtype": "bool",
+      "_type": "Value"
+    },
+    "index": {
+      "dtype": "int64",
+      "_type": "Value"
+    }
+  },
+  "homepage": "",
+  "license": ""
+}

--- a/tests/data/lerobot/aloha_sim_transfer_cube_human/train/state.json
+++ b/tests/data/lerobot/aloha_sim_transfer_cube_human/train/state.json
@@ -1,3 +1,13 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bf10e41f2df8c5dc1c19ba8e2d2256ec9d81bdbe28b95079d28039fe2a28504c
-size 247
+{
+  "_data_files": [
+    {
+      "filename": "data-00000-of-00001.arrow"
+    }
+  ],
+  "_fingerprint": "fe4ace534342bfad",
+  "_format_columns": null,
+  "_format_kwargs": {},
+  "_format_type": null,
+  "_output_all_columns": false,
+  "_split": null
+}

--- a/tests/data/lerobot/aloha_sim_transfer_cube_human_image/meta_data/info.json
+++ b/tests/data/lerobot/aloha_sim_transfer_cube_human_image/meta_data/info.json
@@ -1,3 +1,5 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e7ab5c2bd7d176d4d7902a600240318c2828b7d75f4a888d0887327e4eff089d
-size 65
+{
+    "codebase_version": "v1.6",
+    "fps": 50,
+    "video": 0
+}

--- a/tests/data/lerobot/aloha_sim_transfer_cube_human_image/train/dataset_info.json
+++ b/tests/data/lerobot/aloha_sim_transfer_cube_human_image/train/dataset_info.json
@@ -1,3 +1,47 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4c9545525dc1f4d550591bd5efb63b55c15b983ae0510fefda5a16d77c78b6ef
-size 837
+{
+  "citation": "",
+  "description": "",
+  "features": {
+    "observation.images.top": {
+      "_type": "Image"
+    },
+    "observation.state": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "action": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "episode_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "frame_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "timestamp": {
+      "dtype": "float32",
+      "_type": "Value"
+    },
+    "next.done": {
+      "dtype": "bool",
+      "_type": "Value"
+    },
+    "index": {
+      "dtype": "int64",
+      "_type": "Value"
+    }
+  },
+  "homepage": "",
+  "license": ""
+}

--- a/tests/data/lerobot/aloha_sim_transfer_cube_human_image/train/state.json
+++ b/tests/data/lerobot/aloha_sim_transfer_cube_human_image/train/state.json
@@ -1,3 +1,13 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ec153065a4e52f7d55a7f026d804c57a3ce05dc1faa255a1947369f83c70f1e7
-size 247
+{
+  "_data_files": [
+    {
+      "filename": "data-00000-of-00001.arrow"
+    }
+  ],
+  "_fingerprint": "d7e89e41d66a244c",
+  "_format_columns": null,
+  "_format_kwargs": {},
+  "_format_type": null,
+  "_output_all_columns": false,
+  "_split": null
+}

--- a/tests/data/lerobot/aloha_sim_transfer_cube_scripted/meta_data/info.json
+++ b/tests/data/lerobot/aloha_sim_transfer_cube_scripted/meta_data/info.json
@@ -1,3 +1,11 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:50e40e4c2bb523fca0b54e9a9635281312e9c6f9d757db03c06a0865c5508f29
-size 188
+{
+    "codebase_version": "v1.6",
+    "fps": 50,
+    "video": true,
+    "encoding": {
+        "vcodec": "libsvtav1",
+        "pix_fmt": "yuv420p",
+        "g": 2,
+        "crf": 30
+    }
+}

--- a/tests/data/lerobot/aloha_sim_transfer_cube_scripted/train/dataset_info.json
+++ b/tests/data/lerobot/aloha_sim_transfer_cube_scripted/train/dataset_info.json
@@ -1,3 +1,47 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3f44d13de5d5a417263bbd4984942ed42ed3fa0633405aa14d9a969a45274944
-size 842
+{
+  "citation": "",
+  "description": "",
+  "features": {
+    "observation.images.top": {
+      "_type": "VideoFrame"
+    },
+    "observation.state": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "action": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "episode_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "frame_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "timestamp": {
+      "dtype": "float32",
+      "_type": "Value"
+    },
+    "next.done": {
+      "dtype": "bool",
+      "_type": "Value"
+    },
+    "index": {
+      "dtype": "int64",
+      "_type": "Value"
+    }
+  },
+  "homepage": "",
+  "license": ""
+}

--- a/tests/data/lerobot/aloha_sim_transfer_cube_scripted/train/state.json
+++ b/tests/data/lerobot/aloha_sim_transfer_cube_scripted/train/state.json
@@ -1,3 +1,13 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8f3dc6a1e423b8cd007396a0261664f364d330d350e569a6a0958b834ee1619b
-size 247
+{
+  "_data_files": [
+    {
+      "filename": "data-00000-of-00001.arrow"
+    }
+  ],
+  "_fingerprint": "88443018205d3133",
+  "_format_columns": null,
+  "_format_kwargs": {},
+  "_format_type": null,
+  "_output_all_columns": false,
+  "_split": null
+}

--- a/tests/data/lerobot/aloha_sim_transfer_cube_scripted_image/meta_data/info.json
+++ b/tests/data/lerobot/aloha_sim_transfer_cube_scripted_image/meta_data/info.json
@@ -1,3 +1,5 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e7ab5c2bd7d176d4d7902a600240318c2828b7d75f4a888d0887327e4eff089d
-size 65
+{
+    "codebase_version": "v1.6",
+    "fps": 50,
+    "video": 0
+}

--- a/tests/data/lerobot/aloha_sim_transfer_cube_scripted_image/train/dataset_info.json
+++ b/tests/data/lerobot/aloha_sim_transfer_cube_scripted_image/train/dataset_info.json
@@ -1,3 +1,47 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4c9545525dc1f4d550591bd5efb63b55c15b983ae0510fefda5a16d77c78b6ef
-size 837
+{
+  "citation": "",
+  "description": "",
+  "features": {
+    "observation.images.top": {
+      "_type": "Image"
+    },
+    "observation.state": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "action": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "episode_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "frame_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "timestamp": {
+      "dtype": "float32",
+      "_type": "Value"
+    },
+    "next.done": {
+      "dtype": "bool",
+      "_type": "Value"
+    },
+    "index": {
+      "dtype": "int64",
+      "_type": "Value"
+    }
+  },
+  "homepage": "",
+  "license": ""
+}

--- a/tests/data/lerobot/aloha_sim_transfer_cube_scripted_image/train/state.json
+++ b/tests/data/lerobot/aloha_sim_transfer_cube_scripted_image/train/state.json
@@ -1,3 +1,13 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fda1fe75c9f987c065d4244594e4f6456b7ac6efd7fae2a7952fb48b044dbd30
-size 247
+{
+  "_data_files": [
+    {
+      "filename": "data-00000-of-00001.arrow"
+    }
+  ],
+  "_fingerprint": "b9455593efc2e547",
+  "_format_columns": null,
+  "_format_kwargs": {},
+  "_format_type": null,
+  "_output_all_columns": false,
+  "_split": null
+}

--- a/tests/data/lerobot/aloha_static_battery/meta_data/info.json
+++ b/tests/data/lerobot/aloha_static_battery/meta_data/info.json
@@ -1,3 +1,11 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:50e40e4c2bb523fca0b54e9a9635281312e9c6f9d757db03c06a0865c5508f29
-size 188
+{
+    "codebase_version": "v1.6",
+    "fps": 50,
+    "video": true,
+    "encoding": {
+        "vcodec": "libsvtav1",
+        "pix_fmt": "yuv420p",
+        "g": 2,
+        "crf": 30
+    }
+}

--- a/tests/data/lerobot/aloha_static_battery/train/dataset_info.json
+++ b/tests/data/lerobot/aloha_static_battery/train/dataset_info.json
@@ -1,3 +1,56 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e2e066afefdee57f3bc534085ab7af54e62d3ab2736d42863a89deb743cd0d04
-size 1075
+{
+  "citation": "",
+  "description": "",
+  "features": {
+    "observation.images.cam_high": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_left_wrist": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_low": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_right_wrist": {
+      "_type": "VideoFrame"
+    },
+    "observation.state": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "action": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "episode_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "frame_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "timestamp": {
+      "dtype": "float32",
+      "_type": "Value"
+    },
+    "next.done": {
+      "dtype": "bool",
+      "_type": "Value"
+    },
+    "index": {
+      "dtype": "int64",
+      "_type": "Value"
+    }
+  },
+  "homepage": "",
+  "license": ""
+}

--- a/tests/data/lerobot/aloha_static_battery/train/state.json
+++ b/tests/data/lerobot/aloha_static_battery/train/state.json
@@ -1,3 +1,13 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:722e0ba30e6f4ddce2d31166bfca753bf3c45c507a0f911e1635f0ec2521569e
-size 247
+{
+  "_data_files": [
+    {
+      "filename": "data-00000-of-00001.arrow"
+    }
+  ],
+  "_fingerprint": "a10d9c386f0a87b8",
+  "_format_columns": null,
+  "_format_kwargs": {},
+  "_format_type": null,
+  "_output_all_columns": false,
+  "_split": null
+}

--- a/tests/data/lerobot/aloha_static_candy/meta_data/info.json
+++ b/tests/data/lerobot/aloha_static_candy/meta_data/info.json
@@ -1,3 +1,11 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:50e40e4c2bb523fca0b54e9a9635281312e9c6f9d757db03c06a0865c5508f29
-size 188
+{
+    "codebase_version": "v1.6",
+    "fps": 50,
+    "video": true,
+    "encoding": {
+        "vcodec": "libsvtav1",
+        "pix_fmt": "yuv420p",
+        "g": 2,
+        "crf": 30
+    }
+}

--- a/tests/data/lerobot/aloha_static_candy/train/dataset_info.json
+++ b/tests/data/lerobot/aloha_static_candy/train/dataset_info.json
@@ -1,3 +1,56 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e2e066afefdee57f3bc534085ab7af54e62d3ab2736d42863a89deb743cd0d04
-size 1075
+{
+  "citation": "",
+  "description": "",
+  "features": {
+    "observation.images.cam_high": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_left_wrist": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_low": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_right_wrist": {
+      "_type": "VideoFrame"
+    },
+    "observation.state": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "action": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "episode_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "frame_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "timestamp": {
+      "dtype": "float32",
+      "_type": "Value"
+    },
+    "next.done": {
+      "dtype": "bool",
+      "_type": "Value"
+    },
+    "index": {
+      "dtype": "int64",
+      "_type": "Value"
+    }
+  },
+  "homepage": "",
+  "license": ""
+}

--- a/tests/data/lerobot/aloha_static_candy/train/state.json
+++ b/tests/data/lerobot/aloha_static_candy/train/state.json
@@ -1,3 +1,13 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:08343c525b04a96a2c21b6929616dac092e2ece9789f9c15830241ae0e1ad020
-size 247
+{
+  "_data_files": [
+    {
+      "filename": "data-00000-of-00001.arrow"
+    }
+  ],
+  "_fingerprint": "b091c4b1ab66df72",
+  "_format_columns": null,
+  "_format_kwargs": {},
+  "_format_type": null,
+  "_output_all_columns": false,
+  "_split": null
+}

--- a/tests/data/lerobot/aloha_static_coffee/meta_data/info.json
+++ b/tests/data/lerobot/aloha_static_coffee/meta_data/info.json
@@ -1,3 +1,11 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:50e40e4c2bb523fca0b54e9a9635281312e9c6f9d757db03c06a0865c5508f29
-size 188
+{
+    "codebase_version": "v1.6",
+    "fps": 50,
+    "video": true,
+    "encoding": {
+        "vcodec": "libsvtav1",
+        "pix_fmt": "yuv420p",
+        "g": 2,
+        "crf": 30
+    }
+}

--- a/tests/data/lerobot/aloha_static_coffee/train/dataset_info.json
+++ b/tests/data/lerobot/aloha_static_coffee/train/dataset_info.json
@@ -1,3 +1,64 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:55969ea876fc62b17afca0777816d93c1c90f23207a3562c907cfbd6502858f9
-size 1237
+{
+  "citation": "",
+  "description": "",
+  "features": {
+    "observation.images.cam_high": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_left_wrist": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_low": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_right_wrist": {
+      "_type": "VideoFrame"
+    },
+    "observation.state": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "observation.effort": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "action": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "episode_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "frame_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "timestamp": {
+      "dtype": "float32",
+      "_type": "Value"
+    },
+    "next.done": {
+      "dtype": "bool",
+      "_type": "Value"
+    },
+    "index": {
+      "dtype": "int64",
+      "_type": "Value"
+    }
+  },
+  "homepage": "",
+  "license": ""
+}

--- a/tests/data/lerobot/aloha_static_coffee/train/state.json
+++ b/tests/data/lerobot/aloha_static_coffee/train/state.json
@@ -1,3 +1,13 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:35b4cf253f3b1342ae6cc151554b12e674e34631e1337e3ba8c0cadedda9ef34
-size 247
+{
+  "_data_files": [
+    {
+      "filename": "data-00000-of-00001.arrow"
+    }
+  ],
+  "_fingerprint": "422b8bf71785665b",
+  "_format_columns": null,
+  "_format_kwargs": {},
+  "_format_type": null,
+  "_output_all_columns": false,
+  "_split": null
+}

--- a/tests/data/lerobot/aloha_static_coffee_new/meta_data/info.json
+++ b/tests/data/lerobot/aloha_static_coffee_new/meta_data/info.json
@@ -1,3 +1,11 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:50e40e4c2bb523fca0b54e9a9635281312e9c6f9d757db03c06a0865c5508f29
-size 188
+{
+    "codebase_version": "v1.6",
+    "fps": 50,
+    "video": true,
+    "encoding": {
+        "vcodec": "libsvtav1",
+        "pix_fmt": "yuv420p",
+        "g": 2,
+        "crf": 30
+    }
+}

--- a/tests/data/lerobot/aloha_static_coffee_new/train/dataset_info.json
+++ b/tests/data/lerobot/aloha_static_coffee_new/train/dataset_info.json
@@ -1,3 +1,64 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:55969ea876fc62b17afca0777816d93c1c90f23207a3562c907cfbd6502858f9
-size 1237
+{
+  "citation": "",
+  "description": "",
+  "features": {
+    "observation.images.cam_high": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_left_wrist": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_low": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_right_wrist": {
+      "_type": "VideoFrame"
+    },
+    "observation.state": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "observation.effort": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "action": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "episode_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "frame_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "timestamp": {
+      "dtype": "float32",
+      "_type": "Value"
+    },
+    "next.done": {
+      "dtype": "bool",
+      "_type": "Value"
+    },
+    "index": {
+      "dtype": "int64",
+      "_type": "Value"
+    }
+  },
+  "homepage": "",
+  "license": ""
+}

--- a/tests/data/lerobot/aloha_static_coffee_new/train/state.json
+++ b/tests/data/lerobot/aloha_static_coffee_new/train/state.json
@@ -1,3 +1,13 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:da24e040756173b9ea74666c8d43198105e305bcb2a579da065935c3e94797a6
-size 247
+{
+  "_data_files": [
+    {
+      "filename": "data-00000-of-00001.arrow"
+    }
+  ],
+  "_fingerprint": "c454546244fc6490",
+  "_format_columns": null,
+  "_format_kwargs": {},
+  "_format_type": null,
+  "_output_all_columns": false,
+  "_split": null
+}

--- a/tests/data/lerobot/aloha_static_cups_open/meta_data/info.json
+++ b/tests/data/lerobot/aloha_static_cups_open/meta_data/info.json
@@ -1,3 +1,11 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:50e40e4c2bb523fca0b54e9a9635281312e9c6f9d757db03c06a0865c5508f29
-size 188
+{
+    "codebase_version": "v1.6",
+    "fps": 50,
+    "video": true,
+    "encoding": {
+        "vcodec": "libsvtav1",
+        "pix_fmt": "yuv420p",
+        "g": 2,
+        "crf": 30
+    }
+}

--- a/tests/data/lerobot/aloha_static_cups_open/train/dataset_info.json
+++ b/tests/data/lerobot/aloha_static_cups_open/train/dataset_info.json
@@ -1,3 +1,56 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e2e066afefdee57f3bc534085ab7af54e62d3ab2736d42863a89deb743cd0d04
-size 1075
+{
+  "citation": "",
+  "description": "",
+  "features": {
+    "observation.images.cam_high": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_left_wrist": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_low": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_right_wrist": {
+      "_type": "VideoFrame"
+    },
+    "observation.state": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "action": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "episode_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "frame_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "timestamp": {
+      "dtype": "float32",
+      "_type": "Value"
+    },
+    "next.done": {
+      "dtype": "bool",
+      "_type": "Value"
+    },
+    "index": {
+      "dtype": "int64",
+      "_type": "Value"
+    }
+  },
+  "homepage": "",
+  "license": ""
+}

--- a/tests/data/lerobot/aloha_static_cups_open/train/state.json
+++ b/tests/data/lerobot/aloha_static_cups_open/train/state.json
@@ -1,3 +1,13 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8d97986c8775f069c508fee38129b9707c6ad8bf44dda7de54829e3685c1c0cb
-size 247
+{
+  "_data_files": [
+    {
+      "filename": "data-00000-of-00001.arrow"
+    }
+  ],
+  "_fingerprint": "11da1e334acff95f",
+  "_format_columns": null,
+  "_format_kwargs": {},
+  "_format_type": null,
+  "_output_all_columns": false,
+  "_split": null
+}

--- a/tests/data/lerobot/aloha_static_fork_pick_up/meta_data/info.json
+++ b/tests/data/lerobot/aloha_static_fork_pick_up/meta_data/info.json
@@ -1,3 +1,11 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:50e40e4c2bb523fca0b54e9a9635281312e9c6f9d757db03c06a0865c5508f29
-size 188
+{
+    "codebase_version": "v1.6",
+    "fps": 50,
+    "video": true,
+    "encoding": {
+        "vcodec": "libsvtav1",
+        "pix_fmt": "yuv420p",
+        "g": 2,
+        "crf": 30
+    }
+}

--- a/tests/data/lerobot/aloha_static_fork_pick_up/train/dataset_info.json
+++ b/tests/data/lerobot/aloha_static_fork_pick_up/train/dataset_info.json
@@ -1,3 +1,64 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:55969ea876fc62b17afca0777816d93c1c90f23207a3562c907cfbd6502858f9
-size 1237
+{
+  "citation": "",
+  "description": "",
+  "features": {
+    "observation.images.cam_high": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_left_wrist": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_low": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_right_wrist": {
+      "_type": "VideoFrame"
+    },
+    "observation.state": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "observation.effort": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "action": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "episode_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "frame_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "timestamp": {
+      "dtype": "float32",
+      "_type": "Value"
+    },
+    "next.done": {
+      "dtype": "bool",
+      "_type": "Value"
+    },
+    "index": {
+      "dtype": "int64",
+      "_type": "Value"
+    }
+  },
+  "homepage": "",
+  "license": ""
+}

--- a/tests/data/lerobot/aloha_static_fork_pick_up/train/state.json
+++ b/tests/data/lerobot/aloha_static_fork_pick_up/train/state.json
@@ -1,3 +1,13 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1bde721d645959783d50753d277f91b435a06b5494ab16d1a21af159cce18421
-size 247
+{
+  "_data_files": [
+    {
+      "filename": "data-00000-of-00001.arrow"
+    }
+  ],
+  "_fingerprint": "81e59c9658f08c8f",
+  "_format_columns": null,
+  "_format_kwargs": {},
+  "_format_type": null,
+  "_output_all_columns": false,
+  "_split": null
+}

--- a/tests/data/lerobot/aloha_static_pingpong_test/meta_data/info.json
+++ b/tests/data/lerobot/aloha_static_pingpong_test/meta_data/info.json
@@ -1,3 +1,11 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:50e40e4c2bb523fca0b54e9a9635281312e9c6f9d757db03c06a0865c5508f29
-size 188
+{
+    "codebase_version": "v1.6",
+    "fps": 50,
+    "video": true,
+    "encoding": {
+        "vcodec": "libsvtav1",
+        "pix_fmt": "yuv420p",
+        "g": 2,
+        "crf": 30
+    }
+}

--- a/tests/data/lerobot/aloha_static_pingpong_test/train/dataset_info.json
+++ b/tests/data/lerobot/aloha_static_pingpong_test/train/dataset_info.json
@@ -1,3 +1,64 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:55969ea876fc62b17afca0777816d93c1c90f23207a3562c907cfbd6502858f9
-size 1237
+{
+  "citation": "",
+  "description": "",
+  "features": {
+    "observation.images.cam_high": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_left_wrist": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_low": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_right_wrist": {
+      "_type": "VideoFrame"
+    },
+    "observation.state": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "observation.effort": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "action": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "episode_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "frame_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "timestamp": {
+      "dtype": "float32",
+      "_type": "Value"
+    },
+    "next.done": {
+      "dtype": "bool",
+      "_type": "Value"
+    },
+    "index": {
+      "dtype": "int64",
+      "_type": "Value"
+    }
+  },
+  "homepage": "",
+  "license": ""
+}

--- a/tests/data/lerobot/aloha_static_pingpong_test/train/state.json
+++ b/tests/data/lerobot/aloha_static_pingpong_test/train/state.json
@@ -1,3 +1,13 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:23f51e88465074299890c19fe7567d43774ea95392672600fa16252dc36058d8
-size 247
+{
+  "_data_files": [
+    {
+      "filename": "data-00000-of-00001.arrow"
+    }
+  ],
+  "_fingerprint": "3a42b420b837d94c",
+  "_format_columns": null,
+  "_format_kwargs": {},
+  "_format_type": null,
+  "_output_all_columns": false,
+  "_split": null
+}

--- a/tests/data/lerobot/aloha_static_pro_pencil/meta_data/info.json
+++ b/tests/data/lerobot/aloha_static_pro_pencil/meta_data/info.json
@@ -1,3 +1,11 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:50e40e4c2bb523fca0b54e9a9635281312e9c6f9d757db03c06a0865c5508f29
-size 188
+{
+    "codebase_version": "v1.6",
+    "fps": 50,
+    "video": true,
+    "encoding": {
+        "vcodec": "libsvtav1",
+        "pix_fmt": "yuv420p",
+        "g": 2,
+        "crf": 30
+    }
+}

--- a/tests/data/lerobot/aloha_static_pro_pencil/train/dataset_info.json
+++ b/tests/data/lerobot/aloha_static_pro_pencil/train/dataset_info.json
@@ -1,3 +1,64 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:55969ea876fc62b17afca0777816d93c1c90f23207a3562c907cfbd6502858f9
-size 1237
+{
+  "citation": "",
+  "description": "",
+  "features": {
+    "observation.images.cam_high": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_left_wrist": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_low": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_right_wrist": {
+      "_type": "VideoFrame"
+    },
+    "observation.state": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "observation.effort": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "action": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "episode_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "frame_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "timestamp": {
+      "dtype": "float32",
+      "_type": "Value"
+    },
+    "next.done": {
+      "dtype": "bool",
+      "_type": "Value"
+    },
+    "index": {
+      "dtype": "int64",
+      "_type": "Value"
+    }
+  },
+  "homepage": "",
+  "license": ""
+}

--- a/tests/data/lerobot/aloha_static_pro_pencil/train/state.json
+++ b/tests/data/lerobot/aloha_static_pro_pencil/train/state.json
@@ -1,3 +1,13 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fd72ad4c52fe15cc22c82cbdf4d9799ed0279c275272c9df146cf7dbada364aa
-size 247
+{
+  "_data_files": [
+    {
+      "filename": "data-00000-of-00001.arrow"
+    }
+  ],
+  "_fingerprint": "9a507636d8075334",
+  "_format_columns": null,
+  "_format_kwargs": {},
+  "_format_type": null,
+  "_output_all_columns": false,
+  "_split": null
+}

--- a/tests/data/lerobot/aloha_static_screw_driver/meta_data/info.json
+++ b/tests/data/lerobot/aloha_static_screw_driver/meta_data/info.json
@@ -1,3 +1,11 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:50e40e4c2bb523fca0b54e9a9635281312e9c6f9d757db03c06a0865c5508f29
-size 188
+{
+    "codebase_version": "v1.6",
+    "fps": 50,
+    "video": true,
+    "encoding": {
+        "vcodec": "libsvtav1",
+        "pix_fmt": "yuv420p",
+        "g": 2,
+        "crf": 30
+    }
+}

--- a/tests/data/lerobot/aloha_static_screw_driver/train/dataset_info.json
+++ b/tests/data/lerobot/aloha_static_screw_driver/train/dataset_info.json
@@ -1,3 +1,64 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:55969ea876fc62b17afca0777816d93c1c90f23207a3562c907cfbd6502858f9
-size 1237
+{
+  "citation": "",
+  "description": "",
+  "features": {
+    "observation.images.cam_high": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_left_wrist": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_low": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_right_wrist": {
+      "_type": "VideoFrame"
+    },
+    "observation.state": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "observation.effort": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "action": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "episode_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "frame_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "timestamp": {
+      "dtype": "float32",
+      "_type": "Value"
+    },
+    "next.done": {
+      "dtype": "bool",
+      "_type": "Value"
+    },
+    "index": {
+      "dtype": "int64",
+      "_type": "Value"
+    }
+  },
+  "homepage": "",
+  "license": ""
+}

--- a/tests/data/lerobot/aloha_static_screw_driver/train/state.json
+++ b/tests/data/lerobot/aloha_static_screw_driver/train/state.json
@@ -1,3 +1,13 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:45a49afe14cdea805fb5fd1954d01b1299fcb3310faceec23128dd84706e117a
-size 247
+{
+  "_data_files": [
+    {
+      "filename": "data-00000-of-00001.arrow"
+    }
+  ],
+  "_fingerprint": "10262592ed99720b",
+  "_format_columns": null,
+  "_format_kwargs": {},
+  "_format_type": null,
+  "_output_all_columns": false,
+  "_split": null
+}

--- a/tests/data/lerobot/aloha_static_tape/meta_data/info.json
+++ b/tests/data/lerobot/aloha_static_tape/meta_data/info.json
@@ -1,3 +1,11 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:50e40e4c2bb523fca0b54e9a9635281312e9c6f9d757db03c06a0865c5508f29
-size 188
+{
+    "codebase_version": "v1.6",
+    "fps": 50,
+    "video": true,
+    "encoding": {
+        "vcodec": "libsvtav1",
+        "pix_fmt": "yuv420p",
+        "g": 2,
+        "crf": 30
+    }
+}

--- a/tests/data/lerobot/aloha_static_tape/train/dataset_info.json
+++ b/tests/data/lerobot/aloha_static_tape/train/dataset_info.json
@@ -1,3 +1,56 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e2e066afefdee57f3bc534085ab7af54e62d3ab2736d42863a89deb743cd0d04
-size 1075
+{
+  "citation": "",
+  "description": "",
+  "features": {
+    "observation.images.cam_high": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_left_wrist": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_low": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_right_wrist": {
+      "_type": "VideoFrame"
+    },
+    "observation.state": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "action": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "episode_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "frame_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "timestamp": {
+      "dtype": "float32",
+      "_type": "Value"
+    },
+    "next.done": {
+      "dtype": "bool",
+      "_type": "Value"
+    },
+    "index": {
+      "dtype": "int64",
+      "_type": "Value"
+    }
+  },
+  "homepage": "",
+  "license": ""
+}

--- a/tests/data/lerobot/aloha_static_tape/train/state.json
+++ b/tests/data/lerobot/aloha_static_tape/train/state.json
@@ -1,3 +1,13 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0a6e2d2ebfca08420a2aafec744f99939f58ee0cc12a8f4a53bfe71381c9846a
-size 247
+{
+  "_data_files": [
+    {
+      "filename": "data-00000-of-00001.arrow"
+    }
+  ],
+  "_fingerprint": "21220fdf37e62ff3",
+  "_format_columns": null,
+  "_format_kwargs": {},
+  "_format_type": null,
+  "_output_all_columns": false,
+  "_split": null
+}

--- a/tests/data/lerobot/aloha_static_thread_velcro/meta_data/info.json
+++ b/tests/data/lerobot/aloha_static_thread_velcro/meta_data/info.json
@@ -1,3 +1,11 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:50e40e4c2bb523fca0b54e9a9635281312e9c6f9d757db03c06a0865c5508f29
-size 188
+{
+    "codebase_version": "v1.6",
+    "fps": 50,
+    "video": true,
+    "encoding": {
+        "vcodec": "libsvtav1",
+        "pix_fmt": "yuv420p",
+        "g": 2,
+        "crf": 30
+    }
+}

--- a/tests/data/lerobot/aloha_static_thread_velcro/train/dataset_info.json
+++ b/tests/data/lerobot/aloha_static_thread_velcro/train/dataset_info.json
@@ -1,3 +1,56 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e2e066afefdee57f3bc534085ab7af54e62d3ab2736d42863a89deb743cd0d04
-size 1075
+{
+  "citation": "",
+  "description": "",
+  "features": {
+    "observation.images.cam_high": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_left_wrist": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_low": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_right_wrist": {
+      "_type": "VideoFrame"
+    },
+    "observation.state": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "action": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "episode_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "frame_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "timestamp": {
+      "dtype": "float32",
+      "_type": "Value"
+    },
+    "next.done": {
+      "dtype": "bool",
+      "_type": "Value"
+    },
+    "index": {
+      "dtype": "int64",
+      "_type": "Value"
+    }
+  },
+  "homepage": "",
+  "license": ""
+}

--- a/tests/data/lerobot/aloha_static_thread_velcro/train/state.json
+++ b/tests/data/lerobot/aloha_static_thread_velcro/train/state.json
@@ -1,3 +1,13 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:abc5e8f3d5baa0fa439e0804c1c6486881864847712e533336a162c0fff37184
-size 247
+{
+  "_data_files": [
+    {
+      "filename": "data-00000-of-00001.arrow"
+    }
+  ],
+  "_fingerprint": "14c58a05250fea1e",
+  "_format_columns": null,
+  "_format_kwargs": {},
+  "_format_type": null,
+  "_output_all_columns": false,
+  "_split": null
+}

--- a/tests/data/lerobot/aloha_static_towel/meta_data/info.json
+++ b/tests/data/lerobot/aloha_static_towel/meta_data/info.json
@@ -1,3 +1,11 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:50e40e4c2bb523fca0b54e9a9635281312e9c6f9d757db03c06a0865c5508f29
-size 188
+{
+    "codebase_version": "v1.6",
+    "fps": 50,
+    "video": true,
+    "encoding": {
+        "vcodec": "libsvtav1",
+        "pix_fmt": "yuv420p",
+        "g": 2,
+        "crf": 30
+    }
+}

--- a/tests/data/lerobot/aloha_static_towel/train/dataset_info.json
+++ b/tests/data/lerobot/aloha_static_towel/train/dataset_info.json
@@ -1,3 +1,64 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:55969ea876fc62b17afca0777816d93c1c90f23207a3562c907cfbd6502858f9
-size 1237
+{
+  "citation": "",
+  "description": "",
+  "features": {
+    "observation.images.cam_high": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_left_wrist": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_low": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_right_wrist": {
+      "_type": "VideoFrame"
+    },
+    "observation.state": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "observation.effort": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "action": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "episode_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "frame_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "timestamp": {
+      "dtype": "float32",
+      "_type": "Value"
+    },
+    "next.done": {
+      "dtype": "bool",
+      "_type": "Value"
+    },
+    "index": {
+      "dtype": "int64",
+      "_type": "Value"
+    }
+  },
+  "homepage": "",
+  "license": ""
+}

--- a/tests/data/lerobot/aloha_static_towel/train/state.json
+++ b/tests/data/lerobot/aloha_static_towel/train/state.json
@@ -1,3 +1,13 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:76cb2d6220e4febdf2a64b4cb0890941efc08922556b7b56155187684bae2053
-size 247
+{
+  "_data_files": [
+    {
+      "filename": "data-00000-of-00001.arrow"
+    }
+  ],
+  "_fingerprint": "8486b80b237882b4",
+  "_format_columns": null,
+  "_format_kwargs": {},
+  "_format_type": null,
+  "_output_all_columns": false,
+  "_split": null
+}

--- a/tests/data/lerobot/aloha_static_vinh_cup/meta_data/info.json
+++ b/tests/data/lerobot/aloha_static_vinh_cup/meta_data/info.json
@@ -1,3 +1,11 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:50e40e4c2bb523fca0b54e9a9635281312e9c6f9d757db03c06a0865c5508f29
-size 188
+{
+    "codebase_version": "v1.6",
+    "fps": 50,
+    "video": true,
+    "encoding": {
+        "vcodec": "libsvtav1",
+        "pix_fmt": "yuv420p",
+        "g": 2,
+        "crf": 30
+    }
+}

--- a/tests/data/lerobot/aloha_static_vinh_cup/train/dataset_info.json
+++ b/tests/data/lerobot/aloha_static_vinh_cup/train/dataset_info.json
@@ -1,3 +1,64 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:55969ea876fc62b17afca0777816d93c1c90f23207a3562c907cfbd6502858f9
-size 1237
+{
+  "citation": "",
+  "description": "",
+  "features": {
+    "observation.images.cam_high": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_left_wrist": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_low": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_right_wrist": {
+      "_type": "VideoFrame"
+    },
+    "observation.state": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "observation.effort": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "action": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "episode_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "frame_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "timestamp": {
+      "dtype": "float32",
+      "_type": "Value"
+    },
+    "next.done": {
+      "dtype": "bool",
+      "_type": "Value"
+    },
+    "index": {
+      "dtype": "int64",
+      "_type": "Value"
+    }
+  },
+  "homepage": "",
+  "license": ""
+}

--- a/tests/data/lerobot/aloha_static_vinh_cup/train/state.json
+++ b/tests/data/lerobot/aloha_static_vinh_cup/train/state.json
@@ -1,3 +1,13 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4834bb81b3d4df7ac98037e4fe44dab2645521c2fbc320746f69995535259c5b
-size 247
+{
+  "_data_files": [
+    {
+      "filename": "data-00000-of-00001.arrow"
+    }
+  ],
+  "_fingerprint": "6ff6a3ee1d8aaeb1",
+  "_format_columns": null,
+  "_format_kwargs": {},
+  "_format_type": null,
+  "_output_all_columns": false,
+  "_split": null
+}

--- a/tests/data/lerobot/aloha_static_vinh_cup_left/meta_data/info.json
+++ b/tests/data/lerobot/aloha_static_vinh_cup_left/meta_data/info.json
@@ -1,3 +1,11 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:50e40e4c2bb523fca0b54e9a9635281312e9c6f9d757db03c06a0865c5508f29
-size 188
+{
+    "codebase_version": "v1.6",
+    "fps": 50,
+    "video": true,
+    "encoding": {
+        "vcodec": "libsvtav1",
+        "pix_fmt": "yuv420p",
+        "g": 2,
+        "crf": 30
+    }
+}

--- a/tests/data/lerobot/aloha_static_vinh_cup_left/train/dataset_info.json
+++ b/tests/data/lerobot/aloha_static_vinh_cup_left/train/dataset_info.json
@@ -1,3 +1,64 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:55969ea876fc62b17afca0777816d93c1c90f23207a3562c907cfbd6502858f9
-size 1237
+{
+  "citation": "",
+  "description": "",
+  "features": {
+    "observation.images.cam_high": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_left_wrist": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_low": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_right_wrist": {
+      "_type": "VideoFrame"
+    },
+    "observation.state": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "observation.effort": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "action": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "episode_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "frame_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "timestamp": {
+      "dtype": "float32",
+      "_type": "Value"
+    },
+    "next.done": {
+      "dtype": "bool",
+      "_type": "Value"
+    },
+    "index": {
+      "dtype": "int64",
+      "_type": "Value"
+    }
+  },
+  "homepage": "",
+  "license": ""
+}

--- a/tests/data/lerobot/aloha_static_vinh_cup_left/train/state.json
+++ b/tests/data/lerobot/aloha_static_vinh_cup_left/train/state.json
@@ -1,3 +1,13 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1af8d36fca4fc62d47c2cfe8829e6d341e08c7667ca9bed1da63bf66c4f0f81d
-size 247
+{
+  "_data_files": [
+    {
+      "filename": "data-00000-of-00001.arrow"
+    }
+  ],
+  "_fingerprint": "bddb2bdfc74a09b6",
+  "_format_columns": null,
+  "_format_kwargs": {},
+  "_format_type": null,
+  "_output_all_columns": false,
+  "_split": null
+}

--- a/tests/data/lerobot/aloha_static_ziploc_slide/meta_data/info.json
+++ b/tests/data/lerobot/aloha_static_ziploc_slide/meta_data/info.json
@@ -1,3 +1,11 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:50e40e4c2bb523fca0b54e9a9635281312e9c6f9d757db03c06a0865c5508f29
-size 188
+{
+    "codebase_version": "v1.6",
+    "fps": 50,
+    "video": true,
+    "encoding": {
+        "vcodec": "libsvtav1",
+        "pix_fmt": "yuv420p",
+        "g": 2,
+        "crf": 30
+    }
+}

--- a/tests/data/lerobot/aloha_static_ziploc_slide/train/dataset_info.json
+++ b/tests/data/lerobot/aloha_static_ziploc_slide/train/dataset_info.json
@@ -1,3 +1,56 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e2e066afefdee57f3bc534085ab7af54e62d3ab2736d42863a89deb743cd0d04
-size 1075
+{
+  "citation": "",
+  "description": "",
+  "features": {
+    "observation.images.cam_high": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_left_wrist": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_low": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_right_wrist": {
+      "_type": "VideoFrame"
+    },
+    "observation.state": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "action": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 14,
+      "_type": "Sequence"
+    },
+    "episode_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "frame_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "timestamp": {
+      "dtype": "float32",
+      "_type": "Value"
+    },
+    "next.done": {
+      "dtype": "bool",
+      "_type": "Value"
+    },
+    "index": {
+      "dtype": "int64",
+      "_type": "Value"
+    }
+  },
+  "homepage": "",
+  "license": ""
+}

--- a/tests/data/lerobot/aloha_static_ziploc_slide/train/state.json
+++ b/tests/data/lerobot/aloha_static_ziploc_slide/train/state.json
@@ -1,3 +1,13 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:42babeebfead80d670923535b29adfa09a198949ee7045a7e85720985d34c8b1
-size 247
+{
+  "_data_files": [
+    {
+      "filename": "data-00000-of-00001.arrow"
+    }
+  ],
+  "_fingerprint": "615d90b41d20e95f",
+  "_format_columns": null,
+  "_format_kwargs": {},
+  "_format_type": null,
+  "_output_all_columns": false,
+  "_split": null
+}

--- a/tests/data/lerobot/pusht/meta_data/info.json
+++ b/tests/data/lerobot/pusht/meta_data/info.json
@@ -1,3 +1,11 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1e737caa14a3aa1d81986faae579f81fe6b39ebc91e1ad1256c17c7e1b75e9da
-size 188
+{
+    "codebase_version": "v1.6",
+    "fps": 10,
+    "video": true,
+    "encoding": {
+        "vcodec": "libsvtav1",
+        "pix_fmt": "yuv420p",
+        "g": 2,
+        "crf": 30
+    }
+}

--- a/tests/data/lerobot/pusht/train/dataset_info.json
+++ b/tests/data/lerobot/pusht/train/dataset_info.json
@@ -1,3 +1,55 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:30d9830b3ef9fc452a1988cd8bcc9ccac35cf8a8081e2a33049369224053cc1b
-size 987
+{
+  "citation": "",
+  "description": "",
+  "features": {
+    "observation.image": {
+      "_type": "VideoFrame"
+    },
+    "observation.state": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 2,
+      "_type": "Sequence"
+    },
+    "action": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 2,
+      "_type": "Sequence"
+    },
+    "episode_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "frame_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "timestamp": {
+      "dtype": "float32",
+      "_type": "Value"
+    },
+    "next.reward": {
+      "dtype": "float32",
+      "_type": "Value"
+    },
+    "next.done": {
+      "dtype": "bool",
+      "_type": "Value"
+    },
+    "next.success": {
+      "dtype": "bool",
+      "_type": "Value"
+    },
+    "index": {
+      "dtype": "int64",
+      "_type": "Value"
+    }
+  },
+  "homepage": "",
+  "license": ""
+}

--- a/tests/data/lerobot/pusht/train/state.json
+++ b/tests/data/lerobot/pusht/train/state.json
@@ -1,3 +1,13 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a522c7815565f1f81a8bb5a853263405ab8c3b087ecbc7a3b004848891d77342
-size 247
+{
+  "_data_files": [
+    {
+      "filename": "data-00000-of-00001.arrow"
+    }
+  ],
+  "_fingerprint": "9882ae9a28bdcc9c",
+  "_format_columns": null,
+  "_format_kwargs": {},
+  "_format_type": null,
+  "_output_all_columns": false,
+  "_split": null
+}

--- a/tests/data/lerobot/pusht_image/meta_data/info.json
+++ b/tests/data/lerobot/pusht_image/meta_data/info.json
@@ -1,3 +1,5 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cf348d2c6a5cdca1f53f2df3ebce0c88230bf0b40870347f5a871c36b039c4de
-size 65
+{
+    "codebase_version": "v1.6",
+    "fps": 10,
+    "video": 0
+}

--- a/tests/data/lerobot/pusht_image/train/dataset_info.json
+++ b/tests/data/lerobot/pusht_image/train/dataset_info.json
@@ -1,3 +1,55 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:af0c9dfe9d1e8caa0f9b85ea64895ac7898d6a39414b00b6ced19955e8eceef6
-size 982
+{
+  "citation": "",
+  "description": "",
+  "features": {
+    "observation.image": {
+      "_type": "Image"
+    },
+    "observation.state": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 2,
+      "_type": "Sequence"
+    },
+    "action": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 2,
+      "_type": "Sequence"
+    },
+    "episode_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "frame_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "timestamp": {
+      "dtype": "float32",
+      "_type": "Value"
+    },
+    "next.reward": {
+      "dtype": "float32",
+      "_type": "Value"
+    },
+    "next.done": {
+      "dtype": "bool",
+      "_type": "Value"
+    },
+    "next.success": {
+      "dtype": "bool",
+      "_type": "Value"
+    },
+    "index": {
+      "dtype": "int64",
+      "_type": "Value"
+    }
+  },
+  "homepage": "",
+  "license": ""
+}

--- a/tests/data/lerobot/pusht_image/train/state.json
+++ b/tests/data/lerobot/pusht_image/train/state.json
@@ -1,3 +1,13 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:87d7942da6c4fe7c7a6caefa9a170c0929ac1c57a08889dec8edfe1904e85d42
-size 247
+{
+  "_data_files": [
+    {
+      "filename": "data-00000-of-00001.arrow"
+    }
+  ],
+  "_fingerprint": "41a92a413a11b522",
+  "_format_columns": null,
+  "_format_kwargs": {},
+  "_format_type": null,
+  "_output_all_columns": false,
+  "_split": null
+}

--- a/tests/data/lerobot/pusht_keypoints/meta_data/info.json
+++ b/tests/data/lerobot/pusht_keypoints/meta_data/info.json
@@ -1,3 +1,5 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cf348d2c6a5cdca1f53f2df3ebce0c88230bf0b40870347f5a871c36b039c4de
-size 65
+{
+    "codebase_version": "v1.6",
+    "fps": 10,
+    "video": 0
+}

--- a/tests/data/lerobot/pusht_keypoints/train/dataset_info.json
+++ b/tests/data/lerobot/pusht_keypoints/train/dataset_info.json
@@ -1,3 +1,60 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:686d9d9bad8815d67597b997058d9853a04e5bdbe4eed038f4da9806f867af3d
-size 1098
+{
+  "citation": "",
+  "description": "",
+  "features": {
+    "observation.state": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 2,
+      "_type": "Sequence"
+    },
+    "observation.environment_state": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 16,
+      "_type": "Sequence"
+    },
+    "action": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 2,
+      "_type": "Sequence"
+    },
+    "episode_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "frame_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "timestamp": {
+      "dtype": "float32",
+      "_type": "Value"
+    },
+    "next.reward": {
+      "dtype": "float32",
+      "_type": "Value"
+    },
+    "next.done": {
+      "dtype": "bool",
+      "_type": "Value"
+    },
+    "next.success": {
+      "dtype": "bool",
+      "_type": "Value"
+    },
+    "index": {
+      "dtype": "int64",
+      "_type": "Value"
+    }
+  },
+  "homepage": "",
+  "license": ""
+}

--- a/tests/data/lerobot/pusht_keypoints/train/state.json
+++ b/tests/data/lerobot/pusht_keypoints/train/state.json
@@ -1,3 +1,13 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f22ee3500aca1bea0afdda429e841c57a3278dfea92c79bbbf5dac5f984ed648
-size 247
+{
+  "_data_files": [
+    {
+      "filename": "data-00000-of-00001.arrow"
+    }
+  ],
+  "_fingerprint": "a84d00dab0d2d820",
+  "_format_columns": null,
+  "_format_kwargs": {},
+  "_format_type": null,
+  "_output_all_columns": false,
+  "_split": null
+}

--- a/tests/data/lerobot/umi_cup_in_the_wild/meta_data/info.json
+++ b/tests/data/lerobot/umi_cup_in_the_wild/meta_data/info.json
@@ -1,3 +1,11 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1e737caa14a3aa1d81986faae579f81fe6b39ebc91e1ad1256c17c7e1b75e9da
-size 188
+{
+    "codebase_version": "v1.6",
+    "fps": 10,
+    "video": true,
+    "encoding": {
+        "vcodec": "libsvtav1",
+        "pix_fmt": "yuv420p",
+        "g": 2,
+        "crf": 30
+    }
+}

--- a/tests/data/lerobot/umi_cup_in_the_wild/train/dataset_info.json
+++ b/tests/data/lerobot/umi_cup_in_the_wild/train/dataset_info.json
@@ -1,3 +1,67 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ffb9f0f0c5001460cfe1d49ba84ad2722be5ee7885de97dd733cf9b36104a702
-size 1245
+{
+  "citation": "",
+  "description": "",
+  "features": {
+    "observation.image": {
+      "_type": "VideoFrame"
+    },
+    "observation.state": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 7,
+      "_type": "Sequence"
+    },
+    "episode_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "frame_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "timestamp": {
+      "dtype": "float32",
+      "_type": "Value"
+    },
+    "episode_data_index_from": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "episode_data_index_to": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "end_pose": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 6,
+      "_type": "Sequence"
+    },
+    "start_pos": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 6,
+      "_type": "Sequence"
+    },
+    "gripper_width": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 1,
+      "_type": "Sequence"
+    },
+    "index": {
+      "dtype": "int64",
+      "_type": "Value"
+    }
+  },
+  "homepage": "",
+  "license": ""
+}

--- a/tests/data/lerobot/umi_cup_in_the_wild/train/state.json
+++ b/tests/data/lerobot/umi_cup_in_the_wild/train/state.json
@@ -1,3 +1,13 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:96a44ecf236a7f2eb5f7ffca4dc8ac5e65f0dd2a1c55e35a55cbd364dfbe733d
-size 247
+{
+  "_data_files": [
+    {
+      "filename": "data-00000-of-00001.arrow"
+    }
+  ],
+  "_fingerprint": "617374e490089953",
+  "_format_columns": null,
+  "_format_kwargs": {},
+  "_format_type": null,
+  "_output_all_columns": false,
+  "_split": null
+}

--- a/tests/data/lerobot/unitreeh1_fold_clothes/meta_data/info.json
+++ b/tests/data/lerobot/unitreeh1_fold_clothes/meta_data/info.json
@@ -1,3 +1,11 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:50e40e4c2bb523fca0b54e9a9635281312e9c6f9d757db03c06a0865c5508f29
-size 188
+{
+    "codebase_version": "v1.6",
+    "fps": 50,
+    "video": true,
+    "encoding": {
+        "vcodec": "libsvtav1",
+        "pix_fmt": "yuv420p",
+        "g": 2,
+        "crf": 30
+    }
+}

--- a/tests/data/lerobot/unitreeh1_fold_clothes/train/dataset_info.json
+++ b/tests/data/lerobot/unitreeh1_fold_clothes/train/dataset_info.json
@@ -1,3 +1,50 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3decb709c24854fa7d18d790bb6f7ed9eabd3cadedbcd775d8c7ea805231a44b
-size 920
+{
+  "citation": "",
+  "description": "",
+  "features": {
+    "observation.images.cam_left": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_right": {
+      "_type": "VideoFrame"
+    },
+    "observation.state": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 19,
+      "_type": "Sequence"
+    },
+    "action": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 40,
+      "_type": "Sequence"
+    },
+    "episode_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "frame_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "timestamp": {
+      "dtype": "float32",
+      "_type": "Value"
+    },
+    "next.done": {
+      "dtype": "bool",
+      "_type": "Value"
+    },
+    "index": {
+      "dtype": "int64",
+      "_type": "Value"
+    }
+  },
+  "homepage": "",
+  "license": ""
+}

--- a/tests/data/lerobot/unitreeh1_fold_clothes/train/state.json
+++ b/tests/data/lerobot/unitreeh1_fold_clothes/train/state.json
@@ -1,3 +1,13 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7b39a1f8b0b7fe33a136ba39ae861503f55abbe90f7e0340a2efb824c9eefd12
-size 247
+{
+  "_data_files": [
+    {
+      "filename": "data-00000-of-00001.arrow"
+    }
+  ],
+  "_fingerprint": "2b5a5bbfcd509fcf",
+  "_format_columns": null,
+  "_format_kwargs": {},
+  "_format_type": null,
+  "_output_all_columns": false,
+  "_split": null
+}

--- a/tests/data/lerobot/unitreeh1_rearrange_objects/meta_data/info.json
+++ b/tests/data/lerobot/unitreeh1_rearrange_objects/meta_data/info.json
@@ -1,3 +1,11 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:50e40e4c2bb523fca0b54e9a9635281312e9c6f9d757db03c06a0865c5508f29
-size 188
+{
+    "codebase_version": "v1.6",
+    "fps": 50,
+    "video": true,
+    "encoding": {
+        "vcodec": "libsvtav1",
+        "pix_fmt": "yuv420p",
+        "g": 2,
+        "crf": 30
+    }
+}

--- a/tests/data/lerobot/unitreeh1_rearrange_objects/train/dataset_info.json
+++ b/tests/data/lerobot/unitreeh1_rearrange_objects/train/dataset_info.json
@@ -1,3 +1,50 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3decb709c24854fa7d18d790bb6f7ed9eabd3cadedbcd775d8c7ea805231a44b
-size 920
+{
+  "citation": "",
+  "description": "",
+  "features": {
+    "observation.images.cam_left": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_right": {
+      "_type": "VideoFrame"
+    },
+    "observation.state": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 19,
+      "_type": "Sequence"
+    },
+    "action": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 40,
+      "_type": "Sequence"
+    },
+    "episode_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "frame_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "timestamp": {
+      "dtype": "float32",
+      "_type": "Value"
+    },
+    "next.done": {
+      "dtype": "bool",
+      "_type": "Value"
+    },
+    "index": {
+      "dtype": "int64",
+      "_type": "Value"
+    }
+  },
+  "homepage": "",
+  "license": ""
+}

--- a/tests/data/lerobot/unitreeh1_rearrange_objects/train/state.json
+++ b/tests/data/lerobot/unitreeh1_rearrange_objects/train/state.json
@@ -1,3 +1,13 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8482843a10f1a86ca0a830af609f141612b4c69fbce9f33d67090a754695e638
-size 247
+{
+  "_data_files": [
+    {
+      "filename": "data-00000-of-00001.arrow"
+    }
+  ],
+  "_fingerprint": "2580ac955af54458",
+  "_format_columns": null,
+  "_format_kwargs": {},
+  "_format_type": null,
+  "_output_all_columns": false,
+  "_split": null
+}

--- a/tests/data/lerobot/unitreeh1_two_robot_greeting/meta_data/info.json
+++ b/tests/data/lerobot/unitreeh1_two_robot_greeting/meta_data/info.json
@@ -1,3 +1,11 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:50e40e4c2bb523fca0b54e9a9635281312e9c6f9d757db03c06a0865c5508f29
-size 188
+{
+    "codebase_version": "v1.6",
+    "fps": 50,
+    "video": true,
+    "encoding": {
+        "vcodec": "libsvtav1",
+        "pix_fmt": "yuv420p",
+        "g": 2,
+        "crf": 30
+    }
+}

--- a/tests/data/lerobot/unitreeh1_two_robot_greeting/train/dataset_info.json
+++ b/tests/data/lerobot/unitreeh1_two_robot_greeting/train/dataset_info.json
@@ -1,3 +1,50 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3decb709c24854fa7d18d790bb6f7ed9eabd3cadedbcd775d8c7ea805231a44b
-size 920
+{
+  "citation": "",
+  "description": "",
+  "features": {
+    "observation.images.cam_left": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_right": {
+      "_type": "VideoFrame"
+    },
+    "observation.state": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 19,
+      "_type": "Sequence"
+    },
+    "action": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 40,
+      "_type": "Sequence"
+    },
+    "episode_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "frame_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "timestamp": {
+      "dtype": "float32",
+      "_type": "Value"
+    },
+    "next.done": {
+      "dtype": "bool",
+      "_type": "Value"
+    },
+    "index": {
+      "dtype": "int64",
+      "_type": "Value"
+    }
+  },
+  "homepage": "",
+  "license": ""
+}

--- a/tests/data/lerobot/unitreeh1_two_robot_greeting/train/state.json
+++ b/tests/data/lerobot/unitreeh1_two_robot_greeting/train/state.json
@@ -1,3 +1,13 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1d1eef601c6c29ba5a9797b20fd332f5acc1b0a885434aacf90822450a1203ba
-size 247
+{
+  "_data_files": [
+    {
+      "filename": "data-00000-of-00001.arrow"
+    }
+  ],
+  "_fingerprint": "1cb506c885902b4a",
+  "_format_columns": null,
+  "_format_kwargs": {},
+  "_format_type": null,
+  "_output_all_columns": false,
+  "_split": null
+}

--- a/tests/data/lerobot/unitreeh1_warehouse/meta_data/info.json
+++ b/tests/data/lerobot/unitreeh1_warehouse/meta_data/info.json
@@ -1,3 +1,11 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:50e40e4c2bb523fca0b54e9a9635281312e9c6f9d757db03c06a0865c5508f29
-size 188
+{
+    "codebase_version": "v1.6",
+    "fps": 50,
+    "video": true,
+    "encoding": {
+        "vcodec": "libsvtav1",
+        "pix_fmt": "yuv420p",
+        "g": 2,
+        "crf": 30
+    }
+}

--- a/tests/data/lerobot/unitreeh1_warehouse/train/dataset_info.json
+++ b/tests/data/lerobot/unitreeh1_warehouse/train/dataset_info.json
@@ -1,3 +1,50 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3decb709c24854fa7d18d790bb6f7ed9eabd3cadedbcd775d8c7ea805231a44b
-size 920
+{
+  "citation": "",
+  "description": "",
+  "features": {
+    "observation.images.cam_left": {
+      "_type": "VideoFrame"
+    },
+    "observation.images.cam_right": {
+      "_type": "VideoFrame"
+    },
+    "observation.state": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 19,
+      "_type": "Sequence"
+    },
+    "action": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 40,
+      "_type": "Sequence"
+    },
+    "episode_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "frame_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "timestamp": {
+      "dtype": "float32",
+      "_type": "Value"
+    },
+    "next.done": {
+      "dtype": "bool",
+      "_type": "Value"
+    },
+    "index": {
+      "dtype": "int64",
+      "_type": "Value"
+    }
+  },
+  "homepage": "",
+  "license": ""
+}

--- a/tests/data/lerobot/unitreeh1_warehouse/train/state.json
+++ b/tests/data/lerobot/unitreeh1_warehouse/train/state.json
@@ -1,3 +1,13 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d64b1eb134ac0181f39ed628ca53406f2edda449a48c7a396267fe13e6afdf56
-size 247
+{
+  "_data_files": [
+    {
+      "filename": "data-00000-of-00001.arrow"
+    }
+  ],
+  "_fingerprint": "61217525b383c122",
+  "_format_columns": null,
+  "_format_kwargs": {},
+  "_format_type": null,
+  "_output_all_columns": false,
+  "_split": null
+}

--- a/tests/data/lerobot/xarm_lift_medium/meta_data/info.json
+++ b/tests/data/lerobot/xarm_lift_medium/meta_data/info.json
@@ -1,3 +1,11 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2153fc436001739e5a8bda7b59231b1d7a5082bafb5982564822c9da04de7673
-size 188
+{
+    "codebase_version": "v1.6",
+    "fps": 15,
+    "video": true,
+    "encoding": {
+        "vcodec": "libsvtav1",
+        "pix_fmt": "yuv420p",
+        "g": 2,
+        "crf": 30
+    }
+}

--- a/tests/data/lerobot/xarm_lift_medium/train/dataset_info.json
+++ b/tests/data/lerobot/xarm_lift_medium/train/dataset_info.json
@@ -1,3 +1,51 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a219f973d6535f40737265fd15d81944aabf8eb7527384d28c507926bfa89f25
-size 912
+{
+  "citation": "",
+  "description": "",
+  "features": {
+    "observation.image": {
+      "_type": "VideoFrame"
+    },
+    "observation.state": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 4,
+      "_type": "Sequence"
+    },
+    "action": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 4,
+      "_type": "Sequence"
+    },
+    "episode_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "frame_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "timestamp": {
+      "dtype": "float32",
+      "_type": "Value"
+    },
+    "next.reward": {
+      "dtype": "float32",
+      "_type": "Value"
+    },
+    "next.done": {
+      "dtype": "bool",
+      "_type": "Value"
+    },
+    "index": {
+      "dtype": "int64",
+      "_type": "Value"
+    }
+  },
+  "homepage": "",
+  "license": ""
+}

--- a/tests/data/lerobot/xarm_lift_medium/train/state.json
+++ b/tests/data/lerobot/xarm_lift_medium/train/state.json
@@ -1,3 +1,13 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3d9730fc28721f4a928b027541f36f5e6310aca4b06f39030ed2e340fbb04d43
-size 247
+{
+  "_data_files": [
+    {
+      "filename": "data-00000-of-00001.arrow"
+    }
+  ],
+  "_fingerprint": "eef17b5ce177712a",
+  "_format_columns": null,
+  "_format_kwargs": {},
+  "_format_type": null,
+  "_output_all_columns": false,
+  "_split": null
+}

--- a/tests/data/lerobot/xarm_lift_medium_image/meta_data/info.json
+++ b/tests/data/lerobot/xarm_lift_medium_image/meta_data/info.json
@@ -1,3 +1,5 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:24722873fa5260e960f2c64b1decb02e7bcf31ba44849347e34ea2a268c458e8
-size 65
+{
+    "codebase_version": "v1.6",
+    "fps": 15,
+    "video": 0
+}

--- a/tests/data/lerobot/xarm_lift_medium_image/train/dataset_info.json
+++ b/tests/data/lerobot/xarm_lift_medium_image/train/dataset_info.json
@@ -1,3 +1,51 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ba5e9fec857b85adfa021d06c8679f6f7e030c2bfc5d3be3f6590fb250a17d7c
-size 907
+{
+  "citation": "",
+  "description": "",
+  "features": {
+    "observation.image": {
+      "_type": "Image"
+    },
+    "observation.state": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 4,
+      "_type": "Sequence"
+    },
+    "action": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 3,
+      "_type": "Sequence"
+    },
+    "episode_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "frame_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "timestamp": {
+      "dtype": "float32",
+      "_type": "Value"
+    },
+    "next.reward": {
+      "dtype": "float32",
+      "_type": "Value"
+    },
+    "next.done": {
+      "dtype": "bool",
+      "_type": "Value"
+    },
+    "index": {
+      "dtype": "int64",
+      "_type": "Value"
+    }
+  },
+  "homepage": "",
+  "license": ""
+}

--- a/tests/data/lerobot/xarm_lift_medium_image/train/state.json
+++ b/tests/data/lerobot/xarm_lift_medium_image/train/state.json
@@ -1,3 +1,13 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:939e376b61bed55ef489fdb209444bc22e7e220a3390faa5415b2b39a2612cb5
-size 247
+{
+  "_data_files": [
+    {
+      "filename": "data-00000-of-00001.arrow"
+    }
+  ],
+  "_fingerprint": "e70528672ed7674c",
+  "_format_columns": null,
+  "_format_kwargs": {},
+  "_format_type": null,
+  "_output_all_columns": false,
+  "_split": null
+}

--- a/tests/data/lerobot/xarm_lift_medium_replay/meta_data/info.json
+++ b/tests/data/lerobot/xarm_lift_medium_replay/meta_data/info.json
@@ -1,3 +1,11 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2153fc436001739e5a8bda7b59231b1d7a5082bafb5982564822c9da04de7673
-size 188
+{
+    "codebase_version": "v1.6",
+    "fps": 15,
+    "video": true,
+    "encoding": {
+        "vcodec": "libsvtav1",
+        "pix_fmt": "yuv420p",
+        "g": 2,
+        "crf": 30
+    }
+}

--- a/tests/data/lerobot/xarm_lift_medium_replay/train/dataset_info.json
+++ b/tests/data/lerobot/xarm_lift_medium_replay/train/dataset_info.json
@@ -1,3 +1,51 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a219f973d6535f40737265fd15d81944aabf8eb7527384d28c507926bfa89f25
-size 912
+{
+  "citation": "",
+  "description": "",
+  "features": {
+    "observation.image": {
+      "_type": "VideoFrame"
+    },
+    "observation.state": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 4,
+      "_type": "Sequence"
+    },
+    "action": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 4,
+      "_type": "Sequence"
+    },
+    "episode_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "frame_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "timestamp": {
+      "dtype": "float32",
+      "_type": "Value"
+    },
+    "next.reward": {
+      "dtype": "float32",
+      "_type": "Value"
+    },
+    "next.done": {
+      "dtype": "bool",
+      "_type": "Value"
+    },
+    "index": {
+      "dtype": "int64",
+      "_type": "Value"
+    }
+  },
+  "homepage": "",
+  "license": ""
+}

--- a/tests/data/lerobot/xarm_lift_medium_replay/train/state.json
+++ b/tests/data/lerobot/xarm_lift_medium_replay/train/state.json
@@ -1,3 +1,13 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2fe3dd3ea15dfe189dda76cc7706123ff3acd70ec1e3190a07ef5fc5e9e7aeb7
-size 247
+{
+  "_data_files": [
+    {
+      "filename": "data-00000-of-00001.arrow"
+    }
+  ],
+  "_fingerprint": "cacbf70769444959",
+  "_format_columns": null,
+  "_format_kwargs": {},
+  "_format_type": null,
+  "_output_all_columns": false,
+  "_split": null
+}

--- a/tests/data/lerobot/xarm_lift_medium_replay_image/meta_data/info.json
+++ b/tests/data/lerobot/xarm_lift_medium_replay_image/meta_data/info.json
@@ -1,3 +1,5 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:24722873fa5260e960f2c64b1decb02e7bcf31ba44849347e34ea2a268c458e8
-size 65
+{
+    "codebase_version": "v1.6",
+    "fps": 15,
+    "video": 0
+}

--- a/tests/data/lerobot/xarm_lift_medium_replay_image/train/dataset_info.json
+++ b/tests/data/lerobot/xarm_lift_medium_replay_image/train/dataset_info.json
@@ -1,3 +1,51 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ba5e9fec857b85adfa021d06c8679f6f7e030c2bfc5d3be3f6590fb250a17d7c
-size 907
+{
+  "citation": "",
+  "description": "",
+  "features": {
+    "observation.image": {
+      "_type": "Image"
+    },
+    "observation.state": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 4,
+      "_type": "Sequence"
+    },
+    "action": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 3,
+      "_type": "Sequence"
+    },
+    "episode_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "frame_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "timestamp": {
+      "dtype": "float32",
+      "_type": "Value"
+    },
+    "next.reward": {
+      "dtype": "float32",
+      "_type": "Value"
+    },
+    "next.done": {
+      "dtype": "bool",
+      "_type": "Value"
+    },
+    "index": {
+      "dtype": "int64",
+      "_type": "Value"
+    }
+  },
+  "homepage": "",
+  "license": ""
+}

--- a/tests/data/lerobot/xarm_lift_medium_replay_image/train/state.json
+++ b/tests/data/lerobot/xarm_lift_medium_replay_image/train/state.json
@@ -1,3 +1,13 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:939e376b61bed55ef489fdb209444bc22e7e220a3390faa5415b2b39a2612cb5
-size 247
+{
+  "_data_files": [
+    {
+      "filename": "data-00000-of-00001.arrow"
+    }
+  ],
+  "_fingerprint": "e70528672ed7674c",
+  "_format_columns": null,
+  "_format_kwargs": {},
+  "_format_type": null,
+  "_output_all_columns": false,
+  "_split": null
+}

--- a/tests/data/lerobot/xarm_push_medium/meta_data/info.json
+++ b/tests/data/lerobot/xarm_push_medium/meta_data/info.json
@@ -1,3 +1,11 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2153fc436001739e5a8bda7b59231b1d7a5082bafb5982564822c9da04de7673
-size 188
+{
+    "codebase_version": "v1.6",
+    "fps": 15,
+    "video": true,
+    "encoding": {
+        "vcodec": "libsvtav1",
+        "pix_fmt": "yuv420p",
+        "g": 2,
+        "crf": 30
+    }
+}

--- a/tests/data/lerobot/xarm_push_medium/train/dataset_info.json
+++ b/tests/data/lerobot/xarm_push_medium/train/dataset_info.json
@@ -1,3 +1,51 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8133fe105b6e35182c4e24d8ac092730cb8f684f6591e4f1b3a4a2adaf224c46
-size 912
+{
+  "citation": "",
+  "description": "",
+  "features": {
+    "observation.image": {
+      "_type": "VideoFrame"
+    },
+    "observation.state": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 4,
+      "_type": "Sequence"
+    },
+    "action": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 3,
+      "_type": "Sequence"
+    },
+    "episode_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "frame_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "timestamp": {
+      "dtype": "float32",
+      "_type": "Value"
+    },
+    "next.reward": {
+      "dtype": "float32",
+      "_type": "Value"
+    },
+    "next.done": {
+      "dtype": "bool",
+      "_type": "Value"
+    },
+    "index": {
+      "dtype": "int64",
+      "_type": "Value"
+    }
+  },
+  "homepage": "",
+  "license": ""
+}

--- a/tests/data/lerobot/xarm_push_medium/train/state.json
+++ b/tests/data/lerobot/xarm_push_medium/train/state.json
@@ -1,3 +1,13 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3ca324435b18abab8956aaac43bdac463e8881f654f7a851a39a7eb190e7e040
-size 247
+{
+  "_data_files": [
+    {
+      "filename": "data-00000-of-00001.arrow"
+    }
+  ],
+  "_fingerprint": "29f9b4c0ed32b18a",
+  "_format_columns": null,
+  "_format_kwargs": {},
+  "_format_type": null,
+  "_output_all_columns": false,
+  "_split": null
+}

--- a/tests/data/lerobot/xarm_push_medium_image/meta_data/info.json
+++ b/tests/data/lerobot/xarm_push_medium_image/meta_data/info.json
@@ -1,3 +1,5 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:24722873fa5260e960f2c64b1decb02e7bcf31ba44849347e34ea2a268c458e8
-size 65
+{
+    "codebase_version": "v1.6",
+    "fps": 15,
+    "video": 0
+}

--- a/tests/data/lerobot/xarm_push_medium_image/train/dataset_info.json
+++ b/tests/data/lerobot/xarm_push_medium_image/train/dataset_info.json
@@ -1,3 +1,51 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ba5e9fec857b85adfa021d06c8679f6f7e030c2bfc5d3be3f6590fb250a17d7c
-size 907
+{
+  "citation": "",
+  "description": "",
+  "features": {
+    "observation.image": {
+      "_type": "Image"
+    },
+    "observation.state": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 4,
+      "_type": "Sequence"
+    },
+    "action": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 3,
+      "_type": "Sequence"
+    },
+    "episode_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "frame_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "timestamp": {
+      "dtype": "float32",
+      "_type": "Value"
+    },
+    "next.reward": {
+      "dtype": "float32",
+      "_type": "Value"
+    },
+    "next.done": {
+      "dtype": "bool",
+      "_type": "Value"
+    },
+    "index": {
+      "dtype": "int64",
+      "_type": "Value"
+    }
+  },
+  "homepage": "",
+  "license": ""
+}

--- a/tests/data/lerobot/xarm_push_medium_image/train/state.json
+++ b/tests/data/lerobot/xarm_push_medium_image/train/state.json
@@ -1,3 +1,13 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:939e376b61bed55ef489fdb209444bc22e7e220a3390faa5415b2b39a2612cb5
-size 247
+{
+  "_data_files": [
+    {
+      "filename": "data-00000-of-00001.arrow"
+    }
+  ],
+  "_fingerprint": "e70528672ed7674c",
+  "_format_columns": null,
+  "_format_kwargs": {},
+  "_format_type": null,
+  "_output_all_columns": false,
+  "_split": null
+}

--- a/tests/data/lerobot/xarm_push_medium_replay/meta_data/info.json
+++ b/tests/data/lerobot/xarm_push_medium_replay/meta_data/info.json
@@ -1,3 +1,11 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2153fc436001739e5a8bda7b59231b1d7a5082bafb5982564822c9da04de7673
-size 188
+{
+    "codebase_version": "v1.6",
+    "fps": 15,
+    "video": true,
+    "encoding": {
+        "vcodec": "libsvtav1",
+        "pix_fmt": "yuv420p",
+        "g": 2,
+        "crf": 30
+    }
+}

--- a/tests/data/lerobot/xarm_push_medium_replay/train/dataset_info.json
+++ b/tests/data/lerobot/xarm_push_medium_replay/train/dataset_info.json
@@ -1,3 +1,51 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8133fe105b6e35182c4e24d8ac092730cb8f684f6591e4f1b3a4a2adaf224c46
-size 912
+{
+  "citation": "",
+  "description": "",
+  "features": {
+    "observation.image": {
+      "_type": "VideoFrame"
+    },
+    "observation.state": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 4,
+      "_type": "Sequence"
+    },
+    "action": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 3,
+      "_type": "Sequence"
+    },
+    "episode_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "frame_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "timestamp": {
+      "dtype": "float32",
+      "_type": "Value"
+    },
+    "next.reward": {
+      "dtype": "float32",
+      "_type": "Value"
+    },
+    "next.done": {
+      "dtype": "bool",
+      "_type": "Value"
+    },
+    "index": {
+      "dtype": "int64",
+      "_type": "Value"
+    }
+  },
+  "homepage": "",
+  "license": ""
+}

--- a/tests/data/lerobot/xarm_push_medium_replay/train/state.json
+++ b/tests/data/lerobot/xarm_push_medium_replay/train/state.json
@@ -1,3 +1,13 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:cf61fce75c792d066f692cbec48b049f064cbc0389564be94048dfebec2d14d9
-size 247
+{
+  "_data_files": [
+    {
+      "filename": "data-00000-of-00001.arrow"
+    }
+  ],
+  "_fingerprint": "c610e979e9f89905",
+  "_format_columns": null,
+  "_format_kwargs": {},
+  "_format_type": null,
+  "_output_all_columns": false,
+  "_split": null
+}

--- a/tests/data/lerobot/xarm_push_medium_replay_image/meta_data/info.json
+++ b/tests/data/lerobot/xarm_push_medium_replay_image/meta_data/info.json
@@ -1,3 +1,5 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:24722873fa5260e960f2c64b1decb02e7bcf31ba44849347e34ea2a268c458e8
-size 65
+{
+    "codebase_version": "v1.6",
+    "fps": 15,
+    "video": 0
+}

--- a/tests/data/lerobot/xarm_push_medium_replay_image/train/dataset_info.json
+++ b/tests/data/lerobot/xarm_push_medium_replay_image/train/dataset_info.json
@@ -1,3 +1,51 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ba5e9fec857b85adfa021d06c8679f6f7e030c2bfc5d3be3f6590fb250a17d7c
-size 907
+{
+  "citation": "",
+  "description": "",
+  "features": {
+    "observation.image": {
+      "_type": "Image"
+    },
+    "observation.state": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 4,
+      "_type": "Sequence"
+    },
+    "action": {
+      "feature": {
+        "dtype": "float32",
+        "_type": "Value"
+      },
+      "length": 3,
+      "_type": "Sequence"
+    },
+    "episode_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "frame_index": {
+      "dtype": "int64",
+      "_type": "Value"
+    },
+    "timestamp": {
+      "dtype": "float32",
+      "_type": "Value"
+    },
+    "next.reward": {
+      "dtype": "float32",
+      "_type": "Value"
+    },
+    "next.done": {
+      "dtype": "bool",
+      "_type": "Value"
+    },
+    "index": {
+      "dtype": "int64",
+      "_type": "Value"
+    }
+  },
+  "homepage": "",
+  "license": ""
+}

--- a/tests/data/lerobot/xarm_push_medium_replay_image/train/state.json
+++ b/tests/data/lerobot/xarm_push_medium_replay_image/train/state.json
@@ -1,3 +1,13 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:939e376b61bed55ef489fdb209444bc22e7e220a3390faa5415b2b39a2612cb5
-size 247
+{
+  "_data_files": [
+    {
+      "filename": "data-00000-of-00001.arrow"
+    }
+  ],
+  "_fingerprint": "e70528672ed7674c",
+  "_format_columns": null,
+  "_format_kwargs": {},
+  "_format_type": null,
+  "_output_all_columns": false,
+  "_split": null
+}


### PR DESCRIPTION
## What this does
- After reverting 150a292795123468b907eb7f0000c8d321394d46 directly on main, I've removed tracking of json files by git lfs by doing:
```diff
# .gitattributes
- .cache/calibration/aloha_default/*.json -filter -diff -merge text
*.memmap filter=lfs diff=lfs merge=lfs -text
*.stl filter=lfs diff=lfs merge=lfs -text
*.safetensors filter=lfs diff=lfs merge=lfs -text
*.mp4 filter=lfs diff=lfs merge=lfs -text
*.arrow filter=lfs diff=lfs merge=lfs -text
- *.json filter=lfs diff=lfs merge=lfs -text
```
then
```bash
git lfs untrack '*.json'
git lfs migrate export --include="*.json"
git push origin user/aliberts/2024_09_05_fix_nightlies
git lfs push origin user/aliberts/2024_09_05_fix_nightlies
```

- Prettify calibration json files
- `pre-commit run -a` (somehow theses changes were not picked up by the CI)

## How it was tested
Tests are passing. Also successfully ran a [build](https://github.com/huggingface/lerobot/actions/runs/10719808233) and a [nightly](https://github.com/huggingface/lerobot/actions/runs/10719939448) job on current branch.

## How to checkout & try? (for the reviewer)
N/A