### PR TITLE
fix(calibrate): fix calibrate arms option type. should be str not int

### DIFF
--- a/lerobot/scripts/control_robot.py
+++ b/lerobot/scripts/control_robot.py
@@ -739,7 +739,7 @@ if __name__ == "__main__":
     parser_calib = subparsers.add_parser("calibrate", parents=[base_parser])
     parser_calib.add_argument(
         "--arms",
-        type=int,
+        type=str,
         nargs="*",
         help="List of arms to calibrate (e.g. `--arms left_follower right_follower left_leader`)",
     )


### PR DESCRIPTION
## What this does
Fixes calibrate arms option type. should be str not int.

Was getting the following error when pass `--arms` option to calibrate
```
(venv) jack@jackml:~/code/rl/lerobot (jv/fix-control-robot-ams-type)$ python lerobot/scripts/control_robot.py calibrate --robot-path lerobot/configs/robot/koch_jack.yaml --robot-overrides '~cameras' --arms main_follower main_leader
usage: control_robot.py calibrate [-h] [--robot-path ROBOT_PATH] [--robot-overrides [ROBOT_OVERRIDES ...]]
                                  [--arms [ARMS ...]]
control_robot.py calibrate: error: argument --arms: invalid int value: 'main_follower'
```

## How it was tested
Ran calibrate and confirmed I was no longer getting the error and that calibration succeeded. Further confirmed that teleoperation was working as expected after calibration.

Here's the calibrate output after fixing `--arms` type

```
(venv) jack@jackml:~/code/rl/lerobot (jv/fix-control-robot-ams-type)$ python lerobot/scripts/control_robot.py calibrate --robot-path lerobot/configs/robot/koch_jack.yaml --robot-overrides '~cameras' --arms main_follower main_leader
Removing '.cache/calibration/koch/main_follower.json'
Removing '.cache/calibration/koch/main_leader.json'
Connecting main follower arm.
Connecting main leader arm.
Missing calibration file '.cache/calibration/koch/main_follower.json'

Running calibration of koch main follower...

Move arm to zero position
See: https://raw.githubusercontent.com/huggingface/lerobot/main/media/koch/follower_zero.webp
Press Enter to continue...

Move arm to rotated target position
See: https://raw.githubusercontent.com/huggingface/lerobot/main/media/koch/follower_rotated.webp
Press Enter to continue...

Move arm to rest position
See: https://raw.githubusercontent.com/huggingface/lerobot/main/media/koch/follower_rest.webp
Press Enter to continue...

Calibration is done! Saving calibration file '.cache/calibration/koch/main_follower.json'
Missing calibration file '.cache/calibration/koch/main_leader.json'

Running calibration of koch main leader...

Move arm to zero position
See: https://raw.githubusercontent.com/huggingface/lerobot/main/media/koch/leader_zero.webp
Press Enter to continue...

Move arm to rotated target position
See: https://raw.githubusercontent.com/huggingface/lerobot/main/media/koch/leader_rotated.webp
Press Enter to continue...

Move arm to rest position
See: https://raw.githubusercontent.com/huggingface/lerobot/main/media/koch/leader_rest.webp
Press Enter to continue...

Calibration is done! Saving calibration file '.cache/calibration/koch/main_leader.json'
Activating torque on main follower arm.
Calibration is done! You can now teleoperate and record datasets!
````

## How to checkout & try? (for the reviewer)
```
python lerobot/scripts/control_robot.py calibrate --robot-path lerobot/configs/robot/koch.yaml --robot-overrides '~cameras' --arms main_follower main_leader
```
