### PR TITLE
Raise ValueError if horizon is incompatible with downsampling

### DIFF
--- a/lerobot/common/policies/diffusion/configuration_diffusion.py
+++ b/lerobot/common/policies/diffusion/configuration_diffusion.py
@@ -196,3 +196,12 @@ class DiffusionConfig:
                 f"`noise_scheduler_type` must be one of {supported_noise_schedulers}. "
                 f"Got {self.noise_scheduler_type}."
             )
+
+        # Check that the horizon size and U-Net downsampling is compatible.
+        # U-Net downsamples by 2 with each stage.
+        downsampling_factor = 2 ** len(self.down_dims)
+        if self.horizon % downsampling_factor != 0:
+            raise ValueError(
+                "The horizon should be an integer multiple of the downsampling factor (which is determined "
+                f"by `len(down_dims)`). Got {self.horizon=} and {self.down_dims=}"
+            )


### PR DESCRIPTION
## What this does

Does this

```python
# Check that the horizon size and U-Net downsampling is compatible.
# U-Net downsamples by 2 with each stage.
downsampling_factor = 2 ** len(self.down_dims)
if self.horizon % downsampling_factor != 0:
    raise ValueError(
        "The horizon should be an integer multiple of the downsampling factor (which is determined "
        f"by `len(down_dims)`). Got {self.horizon=} and {self.down_dims=}"
    )
```

Without this input validation we end up getting an obscure error during the forward pass:

`RuntimeError: Sizes of tensors must match except in dimension 1. Expected size 10 but got size 9 for tensor number 1 in the list.`

## How it was tested

No CI added. I just tried running training with various values of `horizon` and checked that that the `ValueError` is raised where the `RuntimeError` would have otherwise been raised.

## How to checkout & try? (for the reviewer)

This should raise the error.

`python lerobot/scripts/train.py policy=diffusion policy.horizon=18`

This won't

`python lerobot/scripts/train.py policy=diffusion policy.horizon=16`