### PR TITLE
small fix: assertion error message in envs/utils.py

### DIFF
--- a/lerobot/common/envs/utils.py
+++ b/lerobot/common/envs/utils.py
@@ -39,7 +39,7 @@ def preprocess_observation(observations: dict[str, np.ndarray]) -> dict[str, Ten
 
             # sanity check that images are channel last
             _, h, w, c = img.shape
-            assert c < h and c < w, f"expect channel last images, but instead {img.shape}"
+            assert c < h and c < w, f"expect channel last images, but instead got {img.shape=}"
 
             # sanity check that images are uint8
             assert img.dtype == torch.uint8, f"expect torch.uint8, but instead {img.dtype=}"

--- a/lerobot/common/envs/utils.py
+++ b/lerobot/common/envs/utils.py
@@ -39,7 +39,7 @@ def preprocess_observation(observations: dict[str, np.ndarray]) -> dict[str, Ten
 
             # sanity check that images are channel last
             _, h, w, c = img.shape
-            assert c < h and c < w, f"expect channel first images, but instead {img.shape}"
+            assert c < h and c < w, f"expect channel last images, but instead {img.shape}"
 
             # sanity check that images are uint8
             assert img.dtype == torch.uint8, f"expect torch.uint8, but instead {img.dtype=}"


### PR DESCRIPTION
just a small fix in the assertion error message in the envs/utils.py. Seems the last and first channel was confused. The expected input image should have the channel dimension to be the last one not the first one. 