### PR TITLE
[Vizualization] Fix video layout

### DIFF
--- a/lerobot/templates/visualize_dataset_template.html
+++ b/lerobot/templates/visualize_dataset_template.html
@@ -88,7 +88,7 @@
             {% for video_info in videos_info %}
             <div x-show="!videoCodecError" class="max-w-96">
                 <p class="text-sm text-gray-300 bg-gray-800 px-2 rounded-t-xl truncate">{{ video_info.filename }}</p>
-                <video muted loop type="video/mp4" class="min-w-64" @canplaythrough="videoCanPlay" @timeupdate="() => {
+                <video muted loop type="video/mp4" class="object-contain w-full h-full" @canplaythrough="videoCanPlay" @timeupdate="() => {
                     if (video.duration) {
                       const time = video.currentTime;
                       const pc = (100 / video.duration) * time;


### PR DESCRIPTION
Fixes a bug noticed by @aliberts. The bug is: some videos were getting clipped when video sizes were different.
This PR fixes the issue

![image](https://github.com/user-attachments/assets/30ebdc46-e7ed-4e15-9e9d-9444a347efd4)
