### PR TITLE
Fix opencv segmentation fault

### DIFF
--- a/lerobot/common/robot_devices/cameras/opencv.py
+++ b/lerobot/common/robot_devices/cameras/opencv.py
@@ -219,6 +219,13 @@ class OpenCVCamera:
         self.camera = None
         self.is_connected = False
         self.thread = None
+        # Using Lock to avoid race condition and segfault when multiple threads
+        # access the same camera. This is not one of our use case, but we add this
+        # for safety if users want to use this class with threads. As a result, threads
+        # will go sequentially through the code logic protected by a lock, instead of 
+        # in parallel. Also, we use Recursive Lock to avoid deadlock by allowing each
+        # thread to acquire the lock multiple times.
+        # TODO(rcadene, aliberts): Add RLock on every robot devices where it makes sense?
         self.lock = threading.RLock()
         self.stop_event = None
         self.color_image = None

--- a/lerobot/common/robot_devices/cameras/opencv.py
+++ b/lerobot/common/robot_devices/cameras/opencv.py
@@ -283,9 +283,9 @@ class OpenCVCamera:
                     f"Can't set {self.height=} for OpenCVCamera({self.camera_index}). Actual value is {actual_height}."
                 )
 
-            self.fps = actual_fps
-            self.width = actual_width
-            self.height = actual_height
+            self.fps = int(actual_fps)
+            self.width = int(actual_width)
+            self.height = int(actual_height)
 
             self.is_connected = True
 

--- a/tests/mock_opencv.py
+++ b/tests/mock_opencv.py
@@ -19,7 +19,7 @@ class MockVideoCapture:
         self._is_opened = True
 
     def isOpened(self):  # noqa: N802
-        return True
+        return self._is_opened
 
     def set(self, propId: int, value: float) -> bool:  # noqa: N803
         if not self._is_opened:

--- a/tests/mock_opencv.py
+++ b/tests/mock_opencv.py
@@ -1,13 +1,15 @@
+from functools import cache
+
 import cv2
 import numpy as np
 
 
-class MockVideoCapture(cv2.VideoCapture):
-    image = {
-        "480x640": np.random.randint(0, 256, size=(480, 640, 3), dtype=np.uint8),
-        "720x1280": np.random.randint(0, 256, size=(720, 1280, 3), dtype=np.uint8),
-    }
+@cache
+def _generate_image(width: int, height: int):
+    return np.random.randint(0, 256, size=(height, width, 3), dtype=np.uint8)
 
+
+class MockVideoCapture:
     def __init__(self, *args, **kwargs):
         self._mock_dict = {
             cv2.CAP_PROP_FPS: 30,
@@ -42,7 +44,7 @@ class MockVideoCapture(cv2.VideoCapture):
         h = self.get(cv2.CAP_PROP_FRAME_HEIGHT)
         w = self.get(cv2.CAP_PROP_FRAME_WIDTH)
         ret = True
-        return ret, self.image[f"{h}x{w}"]
+        return ret, _generate_image(width=w, height=h)
 
     def release(self):
         self._is_opened = False

--- a/tests/mock_opencv.py
+++ b/tests/mock_opencv.py
@@ -14,15 +14,20 @@ class MockVideoCapture(cv2.VideoCapture):
             cv2.CAP_PROP_FRAME_WIDTH: 640,
             cv2.CAP_PROP_FRAME_HEIGHT: 480,
         }
+        self._is_opened = True
 
     def isOpened(self):  # noqa: N802
         return True
 
     def set(self, propId: int, value: float) -> bool:  # noqa: N803
+        if not self._is_opened:
+            raise RuntimeError("Camera is not opened")
         self._mock_dict[propId] = value
         return True
 
     def get(self, propId: int) -> float:  # noqa: N803
+        if not self._is_opened:
+            raise RuntimeError("Camera is not opened")
         value = self._mock_dict[propId]
         if value == 0:
             if propId == cv2.CAP_PROP_FRAME_HEIGHT:
@@ -32,10 +37,16 @@ class MockVideoCapture(cv2.VideoCapture):
         return value
 
     def read(self):
+        if not self._is_opened:
+            raise RuntimeError("Camera is not opened")
         h = self.get(cv2.CAP_PROP_FRAME_HEIGHT)
         w = self.get(cv2.CAP_PROP_FRAME_WIDTH)
         ret = True
         return ret, self.image[f"{h}x{w}"]
 
     def release(self):
-        pass
+        self._is_opened = False
+
+    def __del__(self):
+        if self._is_opened:
+            self.release()

--- a/tests/test_cameras.py
+++ b/tests/test_cameras.py
@@ -116,7 +116,9 @@ def test_camera(request, camera_type, mock):
         compute_max_pixel_difference(color_image, async_color_image),
     )
     # TODO(rcadene): properly set `rtol`
-    assert np.allclose(color_image, async_color_image, rtol=1e-5, atol=MAX_PIXEL_DIFFERENCE), error_msg
+    np.testing.assert_allclose(
+        color_image, async_color_image, rtol=1e-5, atol=MAX_PIXEL_DIFFERENCE, err_msg=error_msg
+    )
 
     # Test disconnecting
     camera.disconnect()
@@ -133,7 +135,9 @@ def test_camera(request, camera_type, mock):
     camera.connect()
     assert camera.color_mode == "bgr"
     bgr_color_image = camera.read()
-    assert np.allclose(color_image, bgr_color_image[:, :, [2, 1, 0]], rtol=1e-5, atol=MAX_PIXEL_DIFFERENCE)
+    np.testing.assert_allclose(
+        color_image, bgr_color_image[:, :, [2, 1, 0]], rtol=1e-5, atol=MAX_PIXEL_DIFFERENCE, err_msg=error_msg
+    )
     del camera
 
     # TODO(rcadene): Add a test for a camera that doesnt support fps=60 and raises an OSError

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -319,10 +319,6 @@ def mock_cameras(request):
     except ImportError:
         traceback.print_exc()
 
-    # yield ensures that any setup and teardown (like releasing resources)
-    # happens automatically after each test
-    yield
-
 
 def mock_motors(request):
     monkeypatch = request.getfixturevalue("monkeypatch")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -319,6 +319,10 @@ def mock_cameras(request):
     except ImportError:
         traceback.print_exc()
 
+    # yield ensures that any setup and teardown (like releasing resources)
+    # happens automatically after each test
+    yield
+
 
 def mock_motors(request):
     monkeypatch = request.getfixturevalue("monkeypatch")


### PR DESCRIPTION
## What this does
- Adds lock mechanism in `OpenCVCamera` for thread safe operation
- ~Adds `yield` in pytest monkeypatching fixture for cameras~ (actually doesn't work)
- Removes inheritance of `MockVideoCapture` from `cv2.VideoCapture`, which was causing ugly errors when trying to monkeypatch `cv2.VideoCapture` with it.
- Improve `MockVideoCapture` for more accurate behavior
- Use `np.testing.assert_allclose` instead of `assert np.allclose` for displaying errors nicely

TODO (this PR or another one):
- [ ] Will probably need to add the same logic to motors and realsense

## How it was tested
Running `pytest -v -k "opencv" tests/test_cameras.py` doesn't raise any segmentation fault anymore, but does still raise assert errors on `np.allclose` (separate issue)

EDIT: For `mock=True` this is now fixed. It was caused by the monkeypatch not actually being applied and therefore was using the real camera instead of the mock one.

## How to checkout & try? (for the reviewer)
```bash
pytest -v -k "opencv" tests/test_cameras.py
```