### PR TITLE
Minor improvments to busy_wait

### DIFF
--- a/lerobot/common/robot_devices/cameras/intelrealsense.py
+++ b/lerobot/common/robot_devices/cameras/intelrealsense.py
@@ -23,7 +23,7 @@ from lerobot.common.robot_devices.utils import (
     RobotDeviceNotConnectedError,
 )
 from lerobot.common.utils.utils import capture_timestamp_utc
-from lerobot.scripts.control_robot import busy_wait
+from lerobot.scripts.control_robot import precise_sleep
 
 SERIAL_NUMBER_INDEX = 1
 
@@ -115,7 +115,7 @@ def save_images_from_cameras(
 
                 if fps is not None:
                     dt_s = time.perf_counter() - now
-                    busy_wait(1 / fps - dt_s)
+                    precise_sleep(1 / fps - dt_s)
 
                 if time.perf_counter() - start_time > record_time_s:
                     break

--- a/lerobot/common/robot_devices/cameras/opencv.py
+++ b/lerobot/common/robot_devices/cameras/opencv.py
@@ -20,7 +20,7 @@ from PIL import Image
 from lerobot.common.robot_devices.utils import (
     RobotDeviceAlreadyConnectedError,
     RobotDeviceNotConnectedError,
-    busy_wait,
+    precise_sleep,
 )
 from lerobot.common.utils.utils import capture_timestamp_utc
 
@@ -127,7 +127,7 @@ def save_images_from_cameras(
 
             if fps is not None:
                 dt_s = time.perf_counter() - now
-                busy_wait(1 / fps - dt_s)
+                precise_sleep(1 / fps - dt_s)
 
             if time.perf_counter() - start_time > record_time_s:
                 break

--- a/lerobot/common/robot_devices/utils.py
+++ b/lerobot/common/robot_devices/utils.py
@@ -1,19 +1,34 @@
-import platform
 import time
 
 
-def busy_wait(seconds):
-    if platform.system() == "Darwin":
-        # On Mac, `time.sleep` is not accurate and we need to use this while loop trick,
-        # but it consumes CPU cycles.
-        # TODO(rcadene): find an alternative: from python 11, time.sleep is precise
-        end_time = time.perf_counter() + seconds
-        while time.perf_counter() < end_time:
+def precise_sleep(seconds: float):
+    """A more precise sleep than time.sleep
+
+    There are several factors that influence the precision of time.sleep. They basically boil down to the OS
+    timer granularity (see https://docs.python.org/3.11/whatsnew/3.11.html#time), and the system load which
+    influences CPU scheduling.
+
+    In all cases, nothing much can be done about issues with CPU scheduling. To be as precise as possible,
+    we need to use a while-loop with a `pass`. This unfortunately keeps the CPU busy the whole time.
+
+    The trick we use here, is to sleep most of the requested time, but switch to blocking the CPU towards the
+    end of the requested time.
+
+    NOTE: See the benchmarking script at the bottom of the source file.
+
+    Args:
+        seconds: Amount of time to sleep for in seconds.
+    """
+    end_time = time.perf_counter() + seconds
+    # 20 ms buffer is usually enough to account for an overly-long last sleep, even with heavy system load.
+    end_time_with_buffer = end_time - 0.02
+    while (now := time.perf_counter()) < end_time:
+        if now < end_time_with_buffer:
+            # 100 microsec is faster than any control loop frequency we expect, but long enough to not hog
+            # the CPU.
+            time.sleep(0.0001)
+        else:
             pass
-    else:
-        # On Linux time.sleep is accurate
-        if seconds > 0:
-            time.sleep(seconds)
 
 
 class RobotDeviceNotConnectedError(Exception):
@@ -35,3 +50,44 @@ class RobotDeviceAlreadyConnectedError(Exception):
     ):
         self.message = message
         super().__init__(self.message)
+
+
+if __name__ == "__main__":
+    """
+    Simply run this benchmark with:
+
+    ```bash
+    python lerobot/common/robot_devices/utils.py
+    ```
+
+    OR, to test it in the presence of high system load, set N_CORES to the number of cores you want running
+    at 100%:
+
+    ```bash
+    N_CORES=16; for i in $(seq 1 $N_CORES); do yes > /dev/null & done
+    python lerobot/common/robot_devices/utils.py
+    killall yes
+    ```
+
+    `precise_sleep` should be better than `sleep` even up to maximal core usage.
+    """
+
+    import math
+
+    from tqdm import trange
+
+    sleep_time = 1 / 50  # 50 Hz like Aloha
+
+    for fn in [time.sleep, precise_sleep]:
+        times = []
+        for _ in trange(1000):
+            start = time.perf_counter()
+            fn(sleep_time)
+            times.append(time.perf_counter() - start)
+        print(fn.__name__)
+        print("Max time:", max(times))
+        print("Min time:", min(times))
+        mean_time = sum(times) / len(times)
+        print("Mean:", mean_time)
+        print("Std:", math.sqrt(sum((t - mean_time) ** 2 for t in times) / len(times)))
+        print("===")

--- a/lerobot/common/robot_devices/utils.py
+++ b/lerobot/common/robot_devices/utils.py
@@ -1,7 +1,7 @@
 import time
 
 
-def precise_sleep(seconds: float):
+def precise_sleep(seconds: float, blocking: bool = False):
     """A more precise sleep than time.sleep
 
     There are several factors that influence the precision of time.sleep. They basically boil down to the OS
@@ -18,12 +18,15 @@ def precise_sleep(seconds: float):
 
     Args:
         seconds: Amount of time to sleep for in seconds.
+        blocking: If set to True, just does a while-loop with `pass` making the sleep as precise as possible
+            but using the CPU the whole time. Set this to True, if you don't need to parallelize with other
+            work.
     """
     end_time = time.perf_counter() + seconds
     # 20 ms buffer is usually enough to account for an overly-long last sleep, even with heavy system load.
     end_time_with_buffer = end_time - 0.02
     while (now := time.perf_counter()) < end_time:
-        if now < end_time_with_buffer:
+        if now < end_time_with_buffer and not blocking:
             # 100 microsec is faster than any control loop frequency we expect, but long enough to not hog
             # the CPU.
             time.sleep(0.0001)

--- a/lerobot/scripts/control_robot.py
+++ b/lerobot/scripts/control_robot.py
@@ -128,7 +128,7 @@ from lerobot.common.datasets.video_utils import encode_video_frames
 from lerobot.common.policies.factory import make_policy
 from lerobot.common.robot_devices.robots.factory import make_robot
 from lerobot.common.robot_devices.robots.utils import Robot, get_arm_id
-from lerobot.common.robot_devices.utils import busy_wait
+from lerobot.common.robot_devices.utils import precise_sleep
 from lerobot.common.utils.utils import get_safe_torch_device, init_hydra_config, init_logging, set_global_seed
 from lerobot.scripts.eval import get_pretrained_policy_path
 from lerobot.scripts.push_dataset_to_hub import (
@@ -297,7 +297,7 @@ def teleoperate(robot: Robot, fps: int | None = None, teleop_time_s: float | Non
 
         if fps is not None:
             dt_s = time.perf_counter() - start_loop_t
-            busy_wait(1 / fps - dt_s)
+            precise_sleep(1 / fps - dt_s)
 
         dt_s = time.perf_counter() - start_loop_t
         log_control_info(robot, dt_s, fps=fps)
@@ -434,7 +434,7 @@ def record(
             cv2.waitKey(1)
 
         dt_s = time.perf_counter() - start_loop_t
-        busy_wait(1 / fps - dt_s)
+        precise_sleep(1 / fps - dt_s)
 
         dt_s = time.perf_counter() - start_loop_t
         log_control_info(robot, dt_s, fps=fps)
@@ -523,7 +523,7 @@ def record(
                 frame_index += 1
 
                 dt_s = time.perf_counter() - start_loop_t
-                busy_wait(1 / fps - dt_s)
+                precise_sleep(1 / fps - dt_s)
 
                 dt_s = time.perf_counter() - start_loop_t
                 log_control_info(robot, dt_s, fps=fps)
@@ -712,7 +712,7 @@ def replay(robot: Robot, episode: int, fps: int | None = None, root="data", repo
         robot.send_action(action)
 
         dt_s = time.perf_counter() - start_episode_t
-        busy_wait(1 / fps - dt_s)
+        precise_sleep(1 / fps - dt_s)
 
         dt_s = time.perf_counter() - start_episode_t
         log_control_info(robot, dt_s, fps=fps)


### PR DESCRIPTION
## What this does

Makes `busy_wait` more precise for Linux and non-blocking on other platforms.
Renames `busy_wait` to `precise_sleep`, as it's not actually a "busy" wait.
Adds a benchmarking script to the `if __name__ = "__main__"` (I know this is unconventional, but it feels convenient and useful enough to break the rules for).

## How it was tested

Ran the benchmarking snippet with all cores busy and found that `precise_sleep` was better.

## How to checkout & try? (for the reviewer)

See the benchmarking snippet in the code.
