### PR TITLE
Don't use async envs by default

### DIFF
--- a/lerobot/configs/default.yaml
+++ b/lerobot/configs/default.yaml
@@ -120,7 +120,7 @@ eval:
   # `batch_size` specifies the number of environments to use in a gym.vector.VectorEnv.
   batch_size: 1
   # `use_async_envs` specifies whether to use asynchronous environments (multiprocessing).
-  use_async_envs: true
+  use_async_envs: false
 
 wandb:
   enable: false

--- a/lerobot/configs/env/aloha.yaml
+++ b/lerobot/configs/env/aloha.yaml
@@ -2,11 +2,6 @@
 
 fps: 50
 
-eval:
-  # `use_async_envs` specifies whether to use asynchronous environments (multiprocessing).
-  # set it to false to avoid some problems of the aloha env
-  use_async_envs: false
-
 env:
   name: aloha
   task: AlohaInsertion-v0

--- a/lerobot/configs/env/xarm.yaml
+++ b/lerobot/configs/env/xarm.yaml
@@ -2,11 +2,6 @@
 
 fps: 15
 
-eval:
-  # `use_async_envs` specifies whether to use asynchronous environments (multiprocessing).
-  # set it to false to avoid some problems of the aloha env
-  use_async_envs: false
-
 env:
   name: xarm
   task: XarmLift-v0


### PR DESCRIPTION
## What this does

Several people have reported issues with the PushT environment using asynchronous batches of envs. For example

```
gymnasium.error.NamespaceNotFound: Namespace gym_pusht not found. Have you installed the proper package for gym_pusht?
```

This PR switches back to no using async envs by default (which was the case most of the time but changed recently).

