### PR TITLE
Added depth frame support for dataset recording/loading

### DIFF
--- a/lerobot/common/datasets/compute_stats.py
+++ b/lerobot/common/datasets/compute_stats.py
@@ -21,7 +21,7 @@ import torch
 import tqdm
 from datasets import Image
 
-from lerobot.common.datasets.video_utils import VideoFrame
+from lerobot.common.datasets.video_utils import VideoFrame, DepthFrame
 
 
 def get_stats_einops_patterns(dataset, num_workers=0):
@@ -56,6 +56,17 @@ def get_stats_einops_patterns(dataset, num_workers=0):
             assert batch[key].dtype == torch.float32, f"expect torch.float32, but instead {batch[key].dtype=}"
             assert batch[key].max() <= 1, f"expect pixels lower than 1, but instead {batch[key].max()=}"
             assert batch[key].min() >= 0, f"expect pixels greater than 1, but instead {batch[key].min()=}"
+
+            stats_patterns[key] = "b c h w -> c 1 1"
+        elif isinstance(feats_type, DepthFrame):
+            # sanity check that images are channel first
+            _, c, h, w = batch[key].shape
+            assert c < h and c < w, f"expect channel first images, but instead {batch[key].shape}"
+
+            # sanity check that images are float32 in range [0,1]
+            assert batch[key].dtype == torch.uint16, f"expect torch.float32, but instead {batch[key].dtype=}"
+            # assert batch[key].max() <= 1, f"expect pixels lower than 1, but instead {batch[key].max()=}"
+            # assert batch[key].min() >= 0, f"expect pixels greater than 1, but instead {batch[key].min()=}"
 
             stats_patterns[key] = "b c h w -> c 1 1"
         elif batch[key].ndim == 2:

--- a/lerobot/common/datasets/push_dataset_to_hub/aloha_hdf5_format.py
+++ b/lerobot/common/datasets/push_dataset_to_hub/aloha_hdf5_format.py
@@ -38,7 +38,7 @@ from lerobot.common.datasets.utils import (
     calculate_episode_data_index,
     hf_transform_to_torch,
 )
-from lerobot.common.datasets.video_utils import VideoFrame, encode_video_frames
+from lerobot.common.datasets.video_utils import VideoFrame, encode_video_frames, DepthFrame
 
 
 def get_cameras(hdf5_data):
@@ -179,6 +179,12 @@ def to_hf_dataset(data_dict, video) -> Dataset:
             features[key] = VideoFrame()
         else:
             features[key] = Image()
+
+
+    depth_keys = [key for key in data_dict if "observation.depth." in key]
+    
+    for key in depth_keys:
+        features[key] = DepthFrame
 
     features["observation.state"] = Sequence(
         length=data_dict["observation.state"].shape[1], feature=Value(dtype="float32", id=None)

--- a/lerobot/common/datasets/utils.py
+++ b/lerobot/common/datasets/utils.py
@@ -88,6 +88,9 @@ def hf_transform_to_torch(items_dict: dict[torch.Tensor | None]):
         elif isinstance(first_item, dict) and "path" in first_item and "timestamp" in first_item:
             # video frame will be processed downstream
             pass
+        elif isinstance(first_item, dict) and "path" in first_item:
+            # depth frame will be processed downstream
+            pass
         elif first_item is None:
             pass
         else:

--- a/lerobot/configs/robot/aloha.yaml
+++ b/lerobot/configs/robot/aloha.yaml
@@ -95,21 +95,25 @@ cameras:
     fps: 30
     width: 640
     height: 480
+    use_depth: false #set "true" if you want to use the depth camera
   cam_low:
     _target_: lerobot.common.robot_devices.cameras.intelrealsense.IntelRealSenseCamera
     camera_index: 130322270656
     fps: 30
     width: 640
     height: 480
+    use_depth: false #set "true" if you want to use the depth camera
   cam_left_wrist:
     _target_: lerobot.common.robot_devices.cameras.intelrealsense.IntelRealSenseCamera
     camera_index: 218622272670
     fps: 30
     width: 640
     height: 480
+    use_depth: false #set "true" if you want to use the depth camera
   cam_right_wrist:
     _target_: lerobot.common.robot_devices.cameras.intelrealsense.IntelRealSenseCamera
     camera_index: 130322272300
     fps: 30
     width: 640
     height: 480
+    use_depth: false #set "true" if you want to use the depth camera


### PR DESCRIPTION
## What this does
Add depth frame support for Intel RealSense cameras in ALOHA 2 setup

This PR introduces the following changes:

1. Recording:
   - Implemented depth frame recording from Intel RealSense cameras
   - Depth frames are saved as .png images, preserving absolute values in uint16 format

2. Loading:
   - Added depth frame loading functionality to LeRobotDataset class
   - Implemented in a similar manner to image frame loading

(Optional) 3. Encoding attempts:
   - Explored options for encoding depth frames into video format like image frames
   - Currently, .png images are used as no suitable codec was found to preserve absolute depth values without normalization
   - .raw format video was successful, but resulted in larger file sizes compared to original .png images



## How it was tested

- With ALOHA 2 setup, recorded and replayed successfully a dataset .

## How to checkout & try? (for the reviewer)

In ALOHA config (lerobot/configs/robot/aloha.yaml) for every camera, you want to record depth from, set the "use_depth" parameter to "true", like in this example:

```
cam_right_wrist:
  _target_: lerobot.common.robot_devices.cameras.intelrealsense.IntelRealSenseCamera
  camera_index: 130322272631
  fps: 30
  width: 640
  height: 480
  **use_depth: false** #set "true" if you want to use the depth camera

```

And then run the recording:

```bash
python lerobot/scripts/control_robot.py record \
   --robot-path lerobot/configs/robot/aloha.yaml \
   --fps 30 \
   --root data \
   --repo-id a/aloha_depth_test \
   --push-to-hub 0 \
   --tags tutorial \
   --warmup-time-s 5 \
   --episode-time-s 30 \
   --reset-time-s 10 \
   --num-episodes 2
```
