### PR TITLE
Allow arbitrary camera frame dimensions

### DIFF
--- a/lerobot/common/robot_devices/cameras/opencv.py
+++ b/lerobot/common/robot_devices/cameras/opencv.py
@@ -279,7 +279,7 @@ class OpenCVCamera:
             )
         resolution_info_fstring = (
             "The provided {name} ({value}) could not be set natively on your camera. The settings "
-            f"are now (width={int(actual_width)}, height={int(actual_height)}. This class will resize the "
+            f"are now (width={int(actual_width)}, height={int(actual_height)}). This class will resize the "
             "frames to your desired resolution before returning them."
         )
         if self.width is not None and self.width != actual_width:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,7 +46,7 @@ def is_robot_available(robot_type):
 
 
 @pytest.fixture
-def is_camera_available(request: pytest.FixtureRequest):
+def is_camera_available(request: pytest.FixtureRequest) -> bool:
     camera_index = request.param
     if platform.system() == "Linux":
         tmp_camera = cv2.VideoCapture(f"/dev/video{camera_index}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,8 +13,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import platform
 import traceback
 
+import cv2
 import pytest
 
 from lerobot.common.utils.utils import init_hydra_config
@@ -41,3 +43,14 @@ def is_robot_available(robot_type):
         traceback.print_exc()
         print(f"\nA {robot_type} robot is not available.")
         return False
+
+
+@pytest.fixture
+def is_camera_available(request: pytest.FixtureRequest):
+    camera_index = request.param
+    if platform.system() == "Linux":
+        tmp_camera = cv2.VideoCapture(f"/dev/video{camera_index}")
+    else:
+        tmp_camera = cv2.VideoCapture(camera_index)
+
+    return tmp_camera.isOpened()

--- a/tests/test_cameras.py
+++ b/tests/test_cameras.py
@@ -7,6 +7,9 @@ pytest -sx tests/test_cameras.py::test_camera
 ```
 """
 
+from contextlib import nullcontext
+from unittest.mock import patch
+
 import numpy as np
 import pytest
 
@@ -135,14 +138,30 @@ def test_camera(request, robot_type):
     del camera
 
 
-@pytest.mark.parametrize("robot_type", available_robots)
-@require_robot
-def test_camera_resize(*_):
-    """Check that resizing to a resolution not supported by the camera still works."""
+# Note: indirect=True passes the CAMERA_INDEX to the `is_camera_available` fixture, then this returns the
+# `is_camera_available` parameter for the test.
+@pytest.mark.parametrize("is_camera_available", [CAMERA_INDEX], indirect=True)
+def test_camera_resize(is_camera_available: bool):
+    """
+    Check that, even if the requested resolution is not supported natively, the `OpenCVCamera.read` method
+    returns an image with the requested resolution.
+
+    When `is_camera_available=True` this test also checks that the `OpenCVCamera.connect` works with natively
+    unsupported resolutions, otherwise if `is_camera_available=False` we have to use a mock patch which
+    unfortunately can't test this.
+    """
     height = 10
     width = 10
-    camera = OpenCVCamera(CAMERA_INDEX, OpenCVCameraConfig(height=height, width=width))
-    camera.connect()
+    camera = OpenCVCamera(0, OpenCVCameraConfig(height=height, width=width))
+    with nullcontext() if is_camera_available else patch("cv2.VideoCapture") as mock_video_capture:
+        if not is_camera_available:
+            # Set an output resolution that is different from the requested one.
+            mock_video_capture.return_value.read.return_value = (
+                True,
+                np.zeros((2 * height, 2 * width), dtype=np.uint8),
+            )
+            mock_video_capture.return_value.isOpened.return_value = True
+        camera.connect()
     assert camera.height == height
     assert camera.width == width
     img = camera.read()

--- a/tests/test_cameras.py
+++ b/tests/test_cameras.py
@@ -11,7 +11,11 @@ import numpy as np
 import pytest
 
 from lerobot import available_robots
-from lerobot.common.robot_devices.cameras.opencv import OpenCVCamera, save_images_from_cameras
+from lerobot.common.robot_devices.cameras.opencv import (
+    OpenCVCamera,
+    OpenCVCameraConfig,
+    save_images_from_cameras,
+)
 from lerobot.common.robot_devices.utils import RobotDeviceAlreadyConnectedError, RobotDeviceNotConnectedError
 from tests.utils import require_robot
 
@@ -129,6 +133,20 @@ def test_camera(request, robot_type):
     with pytest.raises(OSError):
         camera.connect()
     del camera
+
+
+@pytest.mark.parametrize("robot_type", available_robots)
+@require_robot
+def test_camera_resize(*_):
+    """Check that resizing to a resolution not supported by the camera still works."""
+    height = 10
+    width = 10
+    camera = OpenCVCamera(CAMERA_INDEX, OpenCVCameraConfig(height=height, width=width))
+    camera.connect()
+    assert camera.height == height
+    assert camera.width == width
+    img = camera.read()
+    assert img.shape[:2] == (height, width)
 
 
 @pytest.mark.parametrize("robot_type", available_robots)

--- a/tests/test_cameras.py
+++ b/tests/test_cameras.py
@@ -138,12 +138,12 @@ def test_camera(request, robot_type):
     del camera
 
 
-# Note: indirect=True passes the CAMERA_INDEX to the `is_camera_available` fixture, then this returns the
-# `is_camera_available` parameter for the test.
 @pytest.mark.parametrize("request_resolution", [(10, 10)])
 # This parameter is only used when the camera is not available. Checks for various configurations of
 # (mis)match between the requested resolution and the target resolution.
 @pytest.mark.parametrize("read_resolution", [(10, 10), (10, 20), (20, 10), (20, 20)])
+# Note: indirect=True passes the CAMERA_INDEX to the `is_camera_available` fixture, then this returns the
+# `is_camera_available` parameter for the test.
 @pytest.mark.parametrize("is_camera_available", [CAMERA_INDEX], indirect=True)
 def test_camera_resize(
     request_resolution: tuple[int, int], read_resolution: tuple[int, int], is_camera_available: bool


### PR DESCRIPTION
## What this does

Allows arbitrary camera dimensions for `OpenCVCamera`. Previously, if the camera dimensions were not supported by the camera, an exception would be raised. With this PR, the frame is resized as a postprocessing step.

## How it was tested

Added test which has full coverage if you have a camera connected, but only partial coverage otherwise (see the test docstring).

I also tested it locally with a camera.

## How to checkout & try? (for the reviewer)

Run this script.

```python
import cv2

from lerobot.common.robot_devices.cameras.opencv import OpenCVCamera, OpenCVCameraConfig
from lerobot.common.utils.utils import init_logging

init_logging()

height = 40
width = 40
camera = OpenCVCamera(0, OpenCVCameraConfig(height=height, width=width))
camera.connect()
assert camera.height == height
assert camera.width == width
img = camera.read()
cv2.imshow("window", img)
cv2.waitKey(0)
```

You should probably get logs like:

```
INFO 2024-10-03 14:48:44 s/opencv.py:286 The provided width (40) could not be set natively on your camera. The settings are now (width=160, height=90. This class will resize the frames to your desired resolution before returning them.
INFO 2024-10-03 14:48:44 s/opencv.py:288 The provided height (40) could not be set natively on your camera. The settings are now (width=160, height=90. This class will resize the frames to your desired resolution before returning them.
```

You should see a window with 40x40 image appear. 