### PR TITLE
Make `say(blocking=True)` work for Linux

### DIFF
--- a/lerobot/scripts/control_robot.py
+++ b/lerobot/scripts/control_robot.py
@@ -146,19 +146,15 @@ from lerobot.scripts.push_dataset_to_hub import (
 def say(text, blocking=False):
     # Check if mac, linux, or windows.
     if platform.system() == "Darwin":
-        cmd = f'say "{text}"'
+        cmd = f'say "{text}"{"" if blocking else " &"}'
     elif platform.system() == "Linux":
-        cmd = f'spd-say "{text}"'
+        cmd = f'spd-say "{text}"{"  --wait" if blocking else ""}'
     elif platform.system() == "Windows":
+        # TODO(rcadene): Make blocking option work for Windows
         cmd = (
             'PowerShell -Command "Add-Type -AssemblyName System.Speech; '
             f"(New-Object System.Speech.Synthesis.SpeechSynthesizer).Speak('{text}')\""
         )
-
-    if not blocking and platform.system() in ["Darwin", "Linux"]:
-        # TODO(rcadene): Make it work for Windows
-        # Use the ampersand to run command in the background
-        cmd += " &"
 
     os.system(cmd)
 


### PR DESCRIPTION
## What this does

`spd-say` is non-blocking by default so this PR adds the `--wait` flag when `blocking=True`

## How it was tested / How to checkout & try
```
>>> from lerobot.scripts.control_robot import say
>>> say("hello world")   # observe immediate return
>>> say("hello word", blocking=True)   # observe blocking till the speaker finishes