### PR TITLE
Fix issue with wrong using index instead of camera_index in opencv

### DIFF
--- a/lerobot/common/robot_devices/cameras/opencv.py
+++ b/lerobot/common/robot_devices/cameras/opencv.py
@@ -156,7 +156,7 @@ def save_images_from_cameras(
                 executor.submit(
                     save_image,
                     image,
-                    camera.index,
+                    camera.camera_index,
                     frame_index,
                     images_dir,
                 )


### PR DESCRIPTION
## What this does
Explain what this PR does. Feel free to tag your PR with the appropriate label(s).

Examples:
|  Title               | Label           |
|----------------------|-----------------|
| The camera check break with `AttributeError: 'OpenCVCamera' object has no attribute 'index'`      | (🐛 Bug)        |

## How it was tested
Follow the instructions in https://github.com/huggingface/lerobot/blob/main/examples/7_get_started_with_real_robot.md

The main will break at running the following script - 
```
python lerobot/common/robot_devices/cameras/opencv.py \
    --images-dir outputs/images_from_opencv_cameras
  ```
