### PR TITLE
Update lerobot visualizer to send videos directly to Rerun

### DIFF
--- a/lerobot/common/datasets/lerobot_dataset.py
+++ b/lerobot/common/datasets/lerobot_dataset.py
@@ -144,7 +144,7 @@ class LeRobotDataset(torch.utils.data.Dataset):
                 self.tolerance_s,
             )
 
-        if self.video:
+        if self.video and self.video_backend != "raw":
             item = load_from_videos(
                 item,
                 self.video_frame_keys,

--- a/lerobot/scripts/visualize_dataset.py
+++ b/lerobot/scripts/visualize_dataset.py
@@ -70,6 +70,7 @@ from typing import Iterator
 
 import numpy as np
 import rerun as rr
+import rerun.blueprint as rrb
 import torch
 import torch.utils.data
 import tqdm
@@ -110,6 +111,7 @@ def visualize_dataset(
     save: bool = False,
     root: Path | None = None,
     output_dir: Path | None = None,
+    decode_video: bool = False,
 ) -> Path | None:
     if save:
         assert (
@@ -117,7 +119,7 @@ def visualize_dataset(
         ), "Set an output directory where to write .rrd files with `--output-dir path/to/directory`."
 
     logging.info("Loading dataset")
-    dataset = LeRobotDataset(repo_id, root=root)
+    dataset = LeRobotDataset(repo_id, root=root, video_backend=None if decode_video else "raw")
 
     logging.info("Loading dataloader")
     episode_sampler = EpisodeSampler(dataset, episode_index)
@@ -146,6 +148,17 @@ def visualize_dataset(
 
     logging.info("Logging to Rerun")
 
+    data_dir = dataset.videos_dir.parent
+    sent_videos = {}
+
+    # Video file heuristic doesn't trigger the correct layout, so set up a blueprint
+    # manually.
+    blueprint = rrb.Vertical(
+        rrb.Grid(contents=[rrb.Spatial2DView(origin=key) for key in dataset.camera_keys]),
+        rrb.TimeSeriesView(),
+    )
+    rr.send_blueprint(blueprint, make_active=False)
+
     for batch in tqdm.tqdm(dataloader, total=len(dataloader)):
         # iterate over the batch
         for i in range(len(batch["index"])):
@@ -154,8 +167,18 @@ def visualize_dataset(
 
             # display each camera image
             for key in dataset.camera_keys:
-                # TODO(rcadene): add `.compress()`? is it lossless?
-                rr.log(key, rr.Image(to_hwc_uint8_numpy(batch[key][i])))
+                if decode_video:
+                    rr.log(key, rr.Image(to_hwc_uint8_numpy(batch[key][i])))
+                else:
+                    if sent_videos.get(key) != batch[key]["path"][i]:
+                        sent_videos[key] = batch[key]["path"][i]
+                        rr.log(key, rr.AssetVideo(path=data_dir / batch[key]["path"][i]))
+                    rr.log(
+                        key,
+                        rr.VideoFrameReference(
+                            timestamp=rr.components.VideoTimestamp(seconds=batch[key]["timestamp"][i])
+                        ),
+                    )
 
             # display each dimension of action space (e.g. actuators command)
             if "action" in batch:
@@ -264,6 +287,15 @@ def main():
             "Save a .rrd file in the directory provided by `--output-dir`. "
             "It also deactivates the spawning of a viewer. "
             "Visualize the data by running `rerun path/to/file.rrd` on your local machine."
+        ),
+    )
+    parser.add_argument(
+        "--decode-video",
+        action="store_true",
+        default=False,
+        help=(
+            "Decode the video frames into images."
+            "By default videos are sent to the viewer for direct visualization."
         ),
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ pytest-cov = {version = ">=5.0.0", optional = true}
 datasets = ">=2.19.0"
 imagecodecs = { version = ">=2024.1.1", optional = true }
 pyav = ">=12.0.5"
-rerun-sdk = ">=0.15.1"
+rerun-sdk = ">=0.19.0"
 deepdiff = ">=7.0.1"
 flask = ">=3.0.3"
 pandas = {version = ">=2.2.2", optional = true}


### PR DESCRIPTION
## What this does
Rather than using hugging-face to decode the video and sending individual images, this now sends the video files directly.

To support this I had to introduce a new `video_backend` called `raw` which skips the dataset decoding. 

I introduced a new flag `--decode-video` to maintain the old behavior.

On my desktop this 

## How it was tested

New functionality:
```
python lerobot/scripts/visualize_dataset.py  --repo-id lerobot/aloha_static_coffee_new  --episode-index 0
```

Old functionality:
```
python lerobot/scripts/visualize_dataset.py  --repo-id lerobot/aloha_static_coffee_new  --episode-index 0 --decode-video
```

Also verified old image pathway still works on dataset without video:
```
python lerobot/scripts/visualize_dataset.py     --repo-id lerobot/xarm_lift_medium_image     --episode-index 0
```

## Crude benchmark

This results in a 10x real speedup, a 100x processing-overhead speedup, and a 50x reduction in `.rrd` file size.

Old pathway:
```
➜ time python lerobot/scripts/visualize_dataset.py --repo-id lerobot/aloha_static_coffee_new --episode-index 0 --decode-video --save 1 --output-dir tmp

real	0m40.573s
user	7m33.682s
sys	0m53.324s

➜  ls -lh tmp/lerobot_aloha_static_coffee_new_episode_0.rrd 
-rw-r--r-- 1 jleibs jleibs 2.4G Oct 17 17:29 tmp/lerobot_aloha_static_coffee_new_episode_0.rrd
```

New pathway:
```
➜ time python lerobot/scripts/visualize_dataset.py --repo-id lerobot/aloha_static_coffee_new --episode-index 0 --save 1 --output-dir tmp

real	0m4.380s
user	0m4.481s
sys	0m2.427s

➜  ls -lh tmp/lerobot_aloha_static_coffee_new_episode_0.rrd 
-rw-r--r-- 1 jleibs jleibs 48M Oct 17 17:31 tmp/lerobot_aloha_static_coffee_new_episode_0.rrd
```