### PR TITLE
Update 9_use_aloha.md, missing comma

### DIFF
--- a/examples/9_use_aloha.md
+++ b/examples/9_use_aloha.md
@@ -32,7 +32,7 @@ git clone https://github.com/huggingface/lerobot.git ~/lerobot
 
 5. Install LeRobot with dependencies for the Aloha motors (dynamixel) and cameras (intelrealsense):
 ```bash
-cd ~/lerobot && pip install -e ".[dynamixel intelrealsense]"
+cd ~/lerobot && pip install -e ".[dynamixel, intelrealsense]"
 ```
 
 And install extra dependencies for recording datasets on Linux:


### PR DESCRIPTION
The 9_use_aloha.md setup example was missing a comma so the shell cmd that installed dependencies wouldn't run without modification.

Was: 
```bash
cd ~/lerobot && pip install -e ".[dynamixel intelrealsense]"
```

Now:
```bash
cd ~/lerobot && pip install -e ".[dynamixel, intelrealsense]"
```