### PR TITLE
Add distinction between two unallowed cases in name check "eval_"

### DIFF
--- a/lerobot/common/robot_devices/control_utils.py
+++ b/lerobot/common/robot_devices/control_utils.py
@@ -324,7 +324,15 @@ def sanity_check_dataset_name(repo_id, policy):
     _, dataset_name = repo_id.split("/")
     # either repo_id doesnt start with "eval_" and there is no policy
     # or repo_id starts with "eval_" and there is a policy
-    if dataset_name.startswith("eval_") == (policy is None):
+    
+    # Check if dataset_name starts with "eval_" but policy is missing
+    if dataset_name.startswith("eval_") and policy is None:
         raise ValueError(
-            f"Your dataset name begins by 'eval_' ({dataset_name}) but no policy is provided ({policy})."
+            f"Your dataset name begins with 'eval_' ({dataset_name}), but no policy is provided."
+        )
+    
+    # Check if dataset_name does not start with "eval_" but policy is provided
+    if not dataset_name.startswith("eval_") and policy is not None:
+        raise ValueError(
+            f"Your dataset name does not begin with 'eval_' ({dataset_name}), but a policy is provided ({policy})."
         )

--- a/lerobot/common/robot_devices/control_utils.py
+++ b/lerobot/common/robot_devices/control_utils.py
@@ -324,13 +324,13 @@ def sanity_check_dataset_name(repo_id, policy):
     _, dataset_name = repo_id.split("/")
     # either repo_id doesnt start with "eval_" and there is no policy
     # or repo_id starts with "eval_" and there is a policy
-    
+
     # Check if dataset_name starts with "eval_" but policy is missing
     if dataset_name.startswith("eval_") and policy is None:
         raise ValueError(
             f"Your dataset name begins with 'eval_' ({dataset_name}), but no policy is provided."
         )
-    
+
     # Check if dataset_name does not start with "eval_" but policy is provided
     if not dataset_name.startswith("eval_") and policy is not None:
         raise ValueError(


### PR DESCRIPTION
## What this does
|  Title               | Label           |
|----------------------|-----------------|
| Fixes error in `sanity_check_dataset_name()`       | 🐛 Bug        |

There was a bug within the `sanity_check_dataset_name()` function. When the `control_robot.py` script was executed for evaluation and the repo-id did not start with "eval_" it was raising a wrong ValueError.

This caused some confusion because it was unclear that the prefix "eval_" is needed.

## How it was tested
- Added distinction between two possible error cases and checked that evaluation works with policy act_so100_real on our own dataset.

## How to checkout & try? (for the reviewer)
Examples:
This should raise the right error message:
(Taken from the [SO-100 Guide](https://github.com/huggingface/lerobot/blob/main/examples/10_use_so100.md))

```bash
python lerobot/scripts/control_robot.py record \
  --robot-path lerobot/configs/robot/so100.yaml \
  --fps 30 \
  --root data \
  --repo-id ${HF_USER}/act_so100_test \
  --tags so100 tutorial eval \
  --warmup-time-s 5 \
  --episode-time-s 40 \
  --reset-time-s 10 \
  --num-episodes 10 \
  -p outputs/train/act_so100_test/checkpoints/last/pretrained_model
```
