### PR TITLE
Add support for Windows

### DIFF
--- a/lerobot/scripts/find_motors_bus_port.py
+++ b/lerobot/scripts/find_motors_bus_port.py
@@ -1,7 +1,9 @@
-import time
 import os
+import time
 from pathlib import Path
+
 from serial.tools import list_ports  # Part of pyserial library
+
 
 def find_available_ports():
     if os.name == "nt":  # Windows
@@ -11,6 +13,7 @@ def find_available_ports():
         # List /dev/tty* ports for Unix-based systems
         ports = [str(path) for path in Path("/dev").glob("tty*")]
     return ports
+
 
 def find_port():
     print("Finding all available ports for the MotorsBus.")
@@ -32,6 +35,7 @@ def find_port():
         raise OSError(f"Could not detect the port. No difference was found ({ports_diff}).")
     else:
         raise OSError(f"Could not detect the port. More than one port was found ({ports_diff}).")
+
 
 if __name__ == "__main__":
     # Helper to find the USB port associated with your MotorsBus.

--- a/lerobot/scripts/find_motors_bus_port.py
+++ b/lerobot/scripts/find_motors_bus_port.py
@@ -1,36 +1,38 @@
 import time
+import os
 from pathlib import Path
-
+from serial.tools import list_ports  # Part of pyserial library
 
 def find_available_ports():
-    ports = []
-    for path in Path("/dev").glob("tty*"):
-        ports.append(str(path))
+    if os.name == "nt":  # Windows
+        # List COM ports using pyserial
+        ports = [port.device for port in list_ports.comports()]
+    else:  # Linux/macOS
+        # List /dev/tty* ports for Unix-based systems
+        ports = [str(path) for path in Path("/dev").glob("tty*")]
     return ports
-
 
 def find_port():
     print("Finding all available ports for the MotorsBus.")
     ports_before = find_available_ports()
-    print(ports_before)
+    print("Ports before disconnecting:", ports_before)
 
-    print("Remove the usb cable from your MotorsBus and press Enter when done.")
-    input()
+    print("Remove the USB cable from your MotorsBus and press Enter when done.")
+    input()  # Wait for user to disconnect the device
 
-    time.sleep(0.5)
+    time.sleep(0.5)  # Allow some time for port to be released
     ports_after = find_available_ports()
     ports_diff = list(set(ports_before) - set(ports_after))
 
     if len(ports_diff) == 1:
         port = ports_diff[0]
         print(f"The port of this MotorsBus is '{port}'")
-        print("Reconnect the usb cable.")
+        print("Reconnect the USB cable.")
     elif len(ports_diff) == 0:
         raise OSError(f"Could not detect the port. No difference was found ({ports_diff}).")
     else:
         raise OSError(f"Could not detect the port. More than one port was found ({ports_diff}).")
 
-
 if __name__ == "__main__":
-    # Helper to find the usb port associated to all your MotorsBus.
+    # Helper to find the USB port associated with your MotorsBus.
     find_port()


### PR DESCRIPTION
## What this does
Windows uses COM ports not what is expected for Linux/Mac. This commit adds support for Windows OS. It does this by: 
 - checking to see if OS is Windows, or other
 - if Windows, use a new process
 - if other, use existing process 

There is a dependency (`pyserial`) but it is already in the environment so no changes there. Once the port is identified it can be added to the `.yaml` the same as it is today. Although it will be referenced differently (e.g., `COM7` vs. `/dev/ttyACM`) the rest of the functionality still works.

## How it was tested
Successful in Windows environment, and theoretically won't affect others, but does need to be confirmed before merge.

## How to checkout & try? (for the reviewer)
No change to [existing process](https://github.com/huggingface/lerobot/blob/main/examples/10_use_so100.md#configure-the-motors). To use, simply execute the existing script, e.g., `python lerobot/scripts/find_motors_bus_port.py`