### PR TITLE
`configure_motor.py --keep-id`: allow reconfiguring a motor without changing its id

### DIFF
--- a/lerobot/scripts/configure_motor.py
+++ b/lerobot/scripts/configure_motor.py
@@ -16,7 +16,14 @@ import argparse
 import time
 
 
-def configure_motor(port, brand, model, motor_idx_des, baudrate_des):
+def configure_motor(
+    port: str,
+    brand: str,
+    model: str,
+    motor_idx_des: int,
+    baudrate_des: int,
+    keep_id: bool,
+):
     if brand == "feetech":
         from lerobot.common.robot_devices.motors.feetech import MODEL_BAUDRATE_TABLE
         from lerobot.common.robot_devices.motors.feetech import (
@@ -65,6 +72,10 @@ def configure_motor(port, brand, model, motor_idx_des, baudrate_des):
         for baudrate in all_baudrates:
             motor_bus.set_bus_baudrate(baudrate)
             present_ids = motor_bus.find_motor_indices(list(range(1, 10)))
+            if keep_id and motor_idx_des in present_ids:
+                motor_index = motor_idx_des
+                break
+
             if len(present_ids) > 1:
                 raise ValueError(
                     "Error: More than one motor ID detected. This script is designed to only handle one motor at a time. Please disconnect all but one motor."
@@ -140,6 +151,18 @@ if __name__ == "__main__":
     parser.add_argument(
         "--baudrate", type=int, default=1000000, help="Desired baudrate for the motor (default: 1000000)"
     )
+    parser.add_argument(
+        "--keep-id",
+        action="store_true",
+        help="Flag to indicate if the robot is already assembled (preserves the id and is more careful about spinning servos)",
+    )
     args = parser.parse_args()
 
-    configure_motor(args.port, args.brand, args.model, args.ID, args.baudrate)
+    configure_motor(
+        args.port,
+        args.brand,
+        args.model,
+        args.ID,
+        args.baudrate,
+        args.keep_id,
+    )


### PR DESCRIPTION
This allowed me to configure an already-configured robot.

## What this does
Explain what this PR does. Feel free to tag your PR with the appropriate label(s).

> one of my servos was attached in a strange orientation and without its offset configured correctly (I put the thing together before configure_motor.py existed, by hand-rolling some python against the sdk code from their wiki), so I had to hack configure_motor.py to allow me to re-calibrate the motor without changing its id 

-- https://discord.com/channels/1216765309076115607/1237741463832363039/1307375596975951923

With this patch applied, you can do:

```bash
python lerobot/scripts/configure_motor.py   --port /dev/tty.usbmodem58A60701511   --brand feetech   --model sts3215   --baudrate 1000000 --keep-id  --ID 2
```

|  Title               | Label           |
|----------------------|-----------------|
| Makes it easier to quickly reconfigure motors on an already assembled robot  | (📎  Paper Cut) |

## How it was tested
Explain/show how you tested your changes.

Manually tested using:

```bash
python lerobot/scripts/configure_motor.py   --port /dev/tty.usbmodem58A60701511   --brand feetech   --model sts3215   --baudrate 1000000 --keep-id  --ID 2
```

This did not require me to unplug any servos. It rotated the servo to somewhere that it thought was central, but wasn't. I then unscrewed the servo horn screws and ran it again, then re-connected the arm in the correct position.


## How to checkout & try? (for the reviewer)
Provide a simple way for the reviewer to try out your changes.

On an already calibrated and connected robot, run:

```bash
python lerobot/scripts/configure_motor.py   --port /dev/tty.usbmodem58A60701511   --brand feetech   --model sts3215   --baudrate 1000000 --keep-id  --ID 6
```

It should twich open the gripper.
