### PR TITLE
Add Console Scripts for Cleaner, More Simple Script Execution

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,7 +24,7 @@ Examples:
 DATA_DIR=tests/data pytest -sx tests/test_stuff.py::test_something
 ```
 ```bash
-python lerobot/scripts/train.py --some.option=true
+lr_train --some.option=true
 ```
 
 ## SECTION TO REMOVE BEFORE SUBMITTING YOUR PR

--- a/README.md
+++ b/README.md
@@ -148,14 +148,14 @@ Check out [example 1](./examples/1_load_lerobot_dataset.py) that illustrates how
 
 You can also locally visualize episodes from a dataset on the hub by executing our script from the command line:
 ```bash
-python lerobot/scripts/visualize_dataset.py \
+lr_visualize_dataset \
     --repo-id lerobot/pusht \
     --episode-index 0
 ```
 
 or from a dataset in a local folder with the root `DATA_DIR` environment variable (in the following case the dataset will be searched for in `./my_local_data_dir/lerobot/pusht`)
 ```bash
-DATA_DIR='./my_local_data_dir' python lerobot/scripts/visualize_dataset.py \
+DATA_DIR='./my_local_data_dir' lr_visualize_dataset \
     --repo-id lerobot/pusht \
     --episode-index 0
 ```
@@ -166,7 +166,7 @@ It will open `rerun.io` and display the camera streams, robot states and actions
 https://github-production-user-asset-6210df.s3.amazonaws.com/4681518/328035972-fd46b787-b532-47e2-bb6f-fd536a55a7ed.mov?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAVCODYLSA53PQK4ZA%2F20240505%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240505T172924Z&X-Amz-Expires=300&X-Amz-Signature=d680b26c532eeaf80740f08af3320d22ad0b8a4e4da1bcc4f33142c15b509eda&X-Amz-SignedHeaders=host&actor_id=24889239&key_id=0&repo_id=748713144
 
 
-Our script can also visualize datasets stored on a distant server. See `python lerobot/scripts/visualize_dataset.py --help` for more instructions.
+Our script can also visualize datasets stored on a distant server. See `lr_visualize_dataset --help` for more instructions.
 
 ### The `LeRobotDataset` format
 
@@ -221,7 +221,7 @@ Check out [example 2](./examples/2_evaluate_pretrained_policy.py) that illustrat
 
 We also provide a more capable script to parallelize the evaluation over multiple environments during the same rollout. Here is an example with a pretrained model hosted on [lerobot/diffusion_pusht](https://huggingface.co/lerobot/diffusion_pusht):
 ```bash
-python lerobot/scripts/eval.py \
+lr_eval \
     -p lerobot/diffusion_pusht \
     eval.n_episodes=10 \
     eval.batch_size=10
@@ -230,10 +230,10 @@ python lerobot/scripts/eval.py \
 Note: After training your own policy, you can re-evaluate the checkpoints with:
 
 ```bash
-python lerobot/scripts/eval.py -p {OUTPUT_DIR}/checkpoints/last/pretrained_model
+lr_eval -p {OUTPUT_DIR}/checkpoints/last/pretrained_model
 ```
 
-See `python lerobot/scripts/eval.py --help` for more instructions.
+See `lr_eval --help` for more instructions.
 
 ### Train your own policy
 
@@ -242,7 +242,7 @@ Check out [example 3](./examples/3_train_policy.py) that illustrates how to trai
 In general, you can use our training script to easily train any policy. Here is an example of training the ACT policy on trajectories collected by humans on the Aloha simulation environment for the insertion task:
 
 ```bash
-python lerobot/scripts/train.py \
+lr_train \
     policy=act \
     env=aloha \
     env.task=AlohaInsertion-v0 \
@@ -284,14 +284,14 @@ A link to the wandb logs for the run will also show up in yellow in your termina
 
 ![](media/wandb.png)
 
-Note: For efficiency, during training every checkpoint is evaluated on a low number of episodes. You may use `eval.n_episodes=500` to evaluate on more episodes than the default. Or, after training, you may want to re-evaluate your best checkpoints on more episodes or change the evaluation settings. See `python lerobot/scripts/eval.py --help` for more instructions.
+Note: For efficiency, during training every checkpoint is evaluated on a low number of episodes. You may use `eval.n_episodes=500` to evaluate on more episodes than the default. Or, after training, you may want to re-evaluate your best checkpoints on more episodes or change the evaluation settings. See `lr_eval --help` for more instructions.
 
 #### Reproduce state-of-the-art (SOTA)
 
 We have organized our configuration files (found under [`lerobot/configs`](./lerobot/configs)) such that they reproduce SOTA results from a given model variant in their respective original works. Simply running:
 
 ```bash
-python lerobot/scripts/train.py policy=diffusion env=pusht
+lr_train policy=diffusion env=pusht
 ```
 
 reproduces SOTA results for Diffusion Policy on the PushT task.
@@ -311,14 +311,14 @@ huggingface-cli login --token ${HUGGINGFACE_TOKEN} --add-to-git-credential
 
 Then point to your raw dataset folder (e.g. `data/aloha_static_pingpong_test_raw`), and push your dataset to the hub with:
 ```bash
-python lerobot/scripts/push_dataset_to_hub.py \
+lr_push_dataset_to_hub \
 --raw-dir data/aloha_static_pingpong_test_raw \
 --out-dir data \
 --repo-id lerobot/aloha_static_pingpong_test \
 --raw-format aloha_hdf5
 ```
 
-See `python lerobot/scripts/push_dataset_to_hub.py --help` for more instructions.
+See `lr_push_dataset_to_hub --help` for more instructions.
 
 If your dataset format is not supported, implement your own in `lerobot/common/datasets/push_dataset_to_hub/${raw_format}_format.py` by copying examples like [pusht_zarr](https://github.com/huggingface/lerobot/blob/main/lerobot/common/datasets/push_dataset_to_hub/pusht_zarr_format.py), [umi_zarr](https://github.com/huggingface/lerobot/blob/main/lerobot/common/datasets/push_dataset_to_hub/umi_zarr_format.py), [aloha_hdf5](https://github.com/huggingface/lerobot/blob/main/lerobot/common/datasets/push_dataset_to_hub/aloha_hdf5_format.py), or [xarm_pkl](https://github.com/huggingface/lerobot/blob/main/lerobot/common/datasets/push_dataset_to_hub/xarm_pkl_format.py).
 

--- a/examples/10_use_so100.md
+++ b/examples/10_use_so100.md
@@ -50,7 +50,7 @@ Follow steps 1 of the [assembly video](https://www.youtube.com/watch?v=FioA2oeFZ
 **Find USB ports associated to your arms**
 To find the correct ports for each arm, run the utility script twice:
 ```bash
-python lerobot/scripts/find_motors_bus_port.py
+lr_find_motors_bus_port
 ```
 
 Example output when identifying the leader arm's port (e.g., `/dev/tty.usbmodem575E0031751` on Mac, or possibly `/dev/ttyACM0` on Linux):
@@ -86,7 +86,7 @@ sudo chmod 666 /dev/ttyACM1
 **Configure your motors**
 Plug your first motor and run this script to set its ID to 1. It will also set its present position to 2048, so expect your motor to rotate:
 ```bash
-python lerobot/scripts/configure_motor.py \
+lr_configure_motor \
   --port /dev/tty.usbmodem58760432961 \
   --brand feetech \
   --model sts3215 \
@@ -98,7 +98,7 @@ Note: These motors are currently limitated. They can take values between 0 and 4
 
 Then unplug your motor and plug the second motor and set its ID to 2.
 ```bash
-python lerobot/scripts/configure_motor.py \
+lr_configure_motor \
   --port /dev/tty.usbmodem58760432961 \
   --brand feetech \
   --model sts3215 \
@@ -134,7 +134,7 @@ You will need to move the follower arm to these positions sequentially:
 
 Make sure both arms are connected and run this script to launch manual calibration:
 ```bash
-python lerobot/scripts/control_robot.py calibrate \
+lr_control_robot calibrate \
     --robot-path lerobot/configs/robot/so100.yaml \
     --robot-overrides '~cameras' --arms main_follower
 ```
@@ -148,7 +148,7 @@ Follow step 6 of the [assembly video](https://www.youtube.com/watch?v=FioA2oeFZ5
 
 Run this script to launch manual calibration:
 ```bash
-python lerobot/scripts/control_robot.py calibrate \
+lr_control_robot calibrate \
     --robot-path lerobot/configs/robot/so100.yaml \
     --robot-overrides '~cameras' --arms main_leader
 ```
@@ -158,7 +158,7 @@ python lerobot/scripts/control_robot.py calibrate \
 **Simple teleop**
 Then you are ready to teleoperate your robot! Run this simple script (it won't connect and display the cameras):
 ```bash
-python lerobot/scripts/control_robot.py teleoperate \
+lr_control_robot teleoperate \
     --robot-path lerobot/configs/robot/so100.yaml \
     --robot-overrides '~cameras' \
     --display-cameras 0
@@ -168,7 +168,7 @@ python lerobot/scripts/control_robot.py teleoperate \
 **Teleop with displaying cameras**
 Follow [this guide to setup your cameras](https://github.com/huggingface/lerobot/blob/main/examples/7_get_started_with_real_robot.md#c-add-your-cameras-with-opencvcamera). Then you will be able to display the cameras on your computer while you are teleoperating by running the following code. This is useful to prepare your setup before recording your first dataset.
 ```bash
-python lerobot/scripts/control_robot.py teleoperate \
+lr_control_robot teleoperate \
     --robot-path lerobot/configs/robot/so100.yaml
 ```
 
@@ -189,7 +189,7 @@ echo $HF_USER
 
 Record 2 episodes and upload your dataset to the hub:
 ```bash
-python lerobot/scripts/control_robot.py record \
+lr_control_robot record \
     --robot-path lerobot/configs/robot/so100.yaml \
     --fps 30 \
     --root data \
@@ -211,7 +211,7 @@ echo ${HF_USER}/so100_test
 
 If you didn't upload with `--push-to-hub 0`, you can also visualize it locally with:
 ```bash
-python lerobot/scripts/visualize_dataset_html.py \
+lr_visualize_dataset_html \
   --root data \
   --repo-id ${HF_USER}/so100_test
 ```
@@ -220,7 +220,7 @@ python lerobot/scripts/visualize_dataset_html.py \
 
 Now try to replay the first episode on your robot:
 ```bash
-DATA_DIR=data python lerobot/scripts/control_robot.py replay \
+DATA_DIR=data lr_control_robot replay \
     --robot-path lerobot/configs/robot/so100.yaml \
     --fps 30 \
     --root data \
@@ -230,9 +230,9 @@ DATA_DIR=data python lerobot/scripts/control_robot.py replay \
 
 ## Train a policy
 
-To train a policy to control your robot, use the [`python lerobot/scripts/train.py`](../lerobot/scripts/train.py) script. A few arguments are required. Here is an example command:
+To train a policy to control your robot, use the [`lr_train`](../lerobot/scripts/train.py) script. A few arguments are required. Here is an example command:
 ```bash
-DATA_DIR=data python lerobot/scripts/train.py \
+DATA_DIR=data lr_train \
   dataset_repo_id=${HF_USER}/so100_test \
   policy=act_so100_real \
   env=so100_real \
@@ -256,7 +256,7 @@ Training should take several hours. You will find checkpoints in `outputs/train/
 
 You can use the `record` function from [`lerobot/scripts/control_robot.py`](../lerobot/scripts/control_robot.py) but with a policy checkpoint as input. For instance, run this command to record 10 evaluation episodes:
 ```bash
-python lerobot/scripts/control_robot.py record \
+lr_control_robot record \
   --robot-path lerobot/configs/robot/so100.yaml \
   --fps 30 \
   --root data \

--- a/examples/11_use_moss.md
+++ b/examples/11_use_moss.md
@@ -50,7 +50,7 @@ Follow steps 1 of the [assembly video](https://www.youtube.com/watch?v=DA91NJOtM
 **Find USB ports associated to your arms**
 To find the correct ports for each arm, run the utility script twice:
 ```bash
-python lerobot/scripts/find_motors_bus_port.py
+lr_find_motors_bus_port
 ```
 
 Example output when identifying the leader arm's port (e.g., `/dev/tty.usbmodem575E0031751` on Mac, or possibly `/dev/ttyACM0` on Linux):
@@ -134,7 +134,7 @@ You will need to move the follower arm to these positions sequentially:
 
 Make sure both arms are connected and run this script to launch manual calibration:
 ```bash
-python lerobot/scripts/control_robot.py calibrate \
+lr_control_robot calibrate \
     --robot-path lerobot/configs/robot/moss.yaml \
     --robot-overrides '~cameras' --arms main_follower
 ```
@@ -148,7 +148,7 @@ Follow step 6 of the [assembly video](https://www.youtube.com/watch?v=DA91NJOtMi
 
 Run this script to launch manual calibration:
 ```bash
-python lerobot/scripts/control_robot.py calibrate \
+lr_control_robot calibrate \
     --robot-path lerobot/configs/robot/moss.yaml \
     --robot-overrides '~cameras' --arms main_leader
 ```
@@ -158,7 +158,7 @@ python lerobot/scripts/control_robot.py calibrate \
 **Simple teleop**
 Then you are ready to teleoperate your robot! Run this simple script (it won't connect and display the cameras):
 ```bash
-python lerobot/scripts/control_robot.py teleoperate \
+lr_control_robot teleoperate \
     --robot-path lerobot/configs/robot/moss.yaml \
     --robot-overrides '~cameras' \
     --display-cameras 0
@@ -168,7 +168,7 @@ python lerobot/scripts/control_robot.py teleoperate \
 **Teleop with displaying cameras**
 Follow [this guide to setup your cameras](https://github.com/huggingface/lerobot/blob/main/examples/7_get_started_with_real_robot.md#c-add-your-cameras-with-opencvcamera). Then you will be able to display the cameras on your computer while you are teleoperating by running the following code. This is useful to prepare your setup before recording your first dataset.
 ```bash
-python lerobot/scripts/control_robot.py teleoperate \
+lr_control_robot teleoperate \
     --robot-path lerobot/configs/robot/moss.yaml
 ```
 
@@ -189,7 +189,7 @@ echo $HF_USER
 
 Record 2 episodes and upload your dataset to the hub:
 ```bash
-python lerobot/scripts/control_robot.py record \
+lr_control_robot record \
     --robot-path lerobot/configs/robot/moss.yaml \
     --fps 30 \
     --root data \
@@ -211,7 +211,7 @@ echo ${HF_USER}/moss_test
 
 If you didn't upload with `--push-to-hub 0`, you can also visualize it locally with:
 ```bash
-python lerobot/scripts/visualize_dataset_html.py \
+lr_visualize_dataset_html \
   --root data \
   --repo-id ${HF_USER}/moss_test
 ```
@@ -220,7 +220,7 @@ python lerobot/scripts/visualize_dataset_html.py \
 
 Now try to replay the first episode on your robot:
 ```bash
-DATA_DIR=data python lerobot/scripts/control_robot.py replay \
+DATA_DIR=data lr_control_robot replay \
     --robot-path lerobot/configs/robot/moss.yaml \
     --fps 30 \
     --root data \
@@ -230,9 +230,9 @@ DATA_DIR=data python lerobot/scripts/control_robot.py replay \
 
 ## Train a policy
 
-To train a policy to control your robot, use the [`python lerobot/scripts/train.py`](../lerobot/scripts/train.py) script. A few arguments are required. Here is an example command:
+To train a policy to control your robot, use the [`lr_train`](../lerobot/scripts/train.py) script. A few arguments are required. Here is an example command:
 ```bash
-DATA_DIR=data python lerobot/scripts/train.py \
+DATA_DIR=data lr_train \
   dataset_repo_id=${HF_USER}/moss_test \
   policy=act_moss_real \
   env=moss_real \
@@ -256,7 +256,7 @@ Training should take several hours. You will find checkpoints in `outputs/train/
 
 You can use the `record` function from [`lerobot/scripts/control_robot.py`](../lerobot/scripts/control_robot.py) but with a policy checkpoint as input. For instance, run this command to record 10 evaluation episodes:
 ```bash
-python lerobot/scripts/control_robot.py record \
+lr_control_robot record \
   --robot-path lerobot/configs/robot/moss.yaml \
   --fps 30 \
   --root data \

--- a/examples/4_train_policy_with_script.md
+++ b/examples/4_train_policy_with_script.md
@@ -34,7 +34,7 @@ First, `lerobot/configs` has a directory structure like this:
 When you run the training script with
 
 ```python
-python lerobot/scripts/train.py
+lr_train
 ```
 
 Hydra is set up to read `default.yaml` (via the `@hydra.main` decorator). If you take a look at the `@hydra.main`'s arguments you will see `config_path="../configs", config_name="default"`. At the top of `default.yaml`, is a `defaults` section which looks likes this:
@@ -53,19 +53,19 @@ Then, `default.yaml` also contains common configuration parameters such as `devi
 Thanks to this `defaults` section in `default.yaml`, if you want to train Diffusion Policy with PushT, you really only need to run:
 
 ```bash
-python lerobot/scripts/train.py
+lr_train
 ```
 
 However, you can be more explicit and launch the exact same Diffusion Policy training on PushT with:
 
 ```bash
-python lerobot/scripts/train.py policy=diffusion env=pusht
+lr_train policy=diffusion env=pusht
 ```
 
 This way of overriding defaults via the CLI is especially useful when you want to change the policy and/or environment. For instance, you can train ACT on the default Aloha environment with:
 
 ```bash
-python lerobot/scripts/train.py policy=act env=aloha
+lr_train policy=act env=aloha
 ```
 
 There are two things to note here:
@@ -113,7 +113,7 @@ Then, we'd also need to switch to using the cube transfer dataset.
 Then, you'd be able to run:
 
 ```bash
-python lerobot/scripts/train.py policy=act env=aloha
+lr_train policy=act env=aloha
 ```
 
 and you'd be training and evaluating on the cube transfer task.
@@ -121,7 +121,7 @@ and you'd be training and evaluating on the cube transfer task.
 An alternative approach to editing the yaml configuration files, would be to override the defaults via the command line:
 
 ```bash
-python lerobot/scripts/train.py \
+lr_train \
     policy=act \
     dataset_repo_id=lerobot/aloha_sim_transfer_cube_human \
     env=aloha \
@@ -133,7 +133,7 @@ There's something new here. Notice the `.` delimiter used to traverse the config
 Putting all that knowledge together, here's the command that was used to train https://huggingface.co/lerobot/act_aloha_sim_transfer_cube_human.
 
 ```bash
-python lerobot/scripts/train.py \
+lr_train \
     hydra.run.dir=outputs/train/act_aloha_sim_transfer_cube_human \
     device=cuda
     env=aloha \
@@ -157,7 +157,7 @@ There's one new thing here: `hydra.run.dir=outputs/train/act_aloha_sim_transfer_
 Above we discusses the our training script is set up such that Hydra looks for `default.yaml` in `lerobot/configs`. But, if you have a configuration file elsewhere in your filesystem you may use:
 
 ```bash
-python lerobot/scripts/train.py --config-dir PARENT/PATH --config-name FILE_NAME_WITHOUT_EXTENSION
+lr_train --config-dir PARENT/PATH --config-name FILE_NAME_WITHOUT_EXTENSION
 ```
 
 Note: here we use regular syntax for providing CLI arguments to a Python script, not Hydra's `param_name=param_value` syntax.
@@ -165,7 +165,7 @@ Note: here we use regular syntax for providing CLI arguments to a Python script,
 As a concrete example, this becomes particularly handy when you have a folder with training outputs, and would like to re-run the training. For example, say you previously ran the training script with one of the earlier commands and have `outputs/train/my_experiment/checkpoints/pretrained_model/config.yaml`. This `config.yaml` file will have the full set of configuration parameters within it. To run the training with the same configuration again, do:
 
 ```bash
-python lerobot/scripts/train.py --config-dir outputs/train/my_experiment/checkpoints/last/pretrained_model --config-name config
+lr_train --config-dir outputs/train/my_experiment/checkpoints/last/pretrained_model --config-name config
 ```
 
 Note that you may still use the regular syntax for config parameter overrides (eg: by adding `training.offline_steps=200000`).
@@ -205,7 +205,7 @@ Some metrics are useful for initial performance profiling. For example, if you f
 So far we've seen how to train Diffusion Policy for PushT and ACT for ALOHA. Now, what if we want to train ACT for PushT? Well, there are aspects of the ACT configuration that are specific to the ALOHA environments, and these happen to be incompatible with PushT. Therefore, trying to run the following will almost certainly raise an exception of sorts (eg: feature dimension mismatch):
 
 ```bash
-python lerobot/scripts/train.py policy=act env=pusht dataset_repo_id=lerobot/pusht
+lr_train policy=act env=pusht dataset_repo_id=lerobot/pusht
 ```
 
 Please, head on over to our [advanced tutorial on adapting policy configuration to various environments](./advanced/train_act_pusht/train_act_pusht.md) to learn more.

--- a/examples/5_resume_training.md
+++ b/examples/5_resume_training.md
@@ -5,7 +5,7 @@ This tutorial explains how to resume a training run that you've started with the
 Let's consider the example of training ACT for one of the ALOHA tasks. Here's a command that can achieve that:
 
 ```bash
-python lerobot/scripts/train.py \
+lr_train \
     hydra.run.dir=outputs/train/run_resumption \
     policy=act \
     dataset_repo_id=lerobot/aloha_sim_transfer_cube_human \
@@ -21,7 +21,7 @@ Here we're using the default dataset and environment for ACT, and we've taken ca
 To resume, all that we have to do is run the training script, providing the run directory, and the resume option:
 
 ```bash
-python lerobot/scripts/train.py \
+lr_train \
     hydra.run.dir=outputs/train/run_resumption \
     resume=true
 ```

--- a/examples/7_get_started_with_real_robot.md
+++ b/examples/7_get_started_with_real_robot.md
@@ -58,7 +58,7 @@ Finally, connect both arms to your computer via USB. Note that the USB doesn't p
 
 In the upcoming sections, you'll learn about our classes and functions by running some python code, in an interactive session, or by copy-pasting it in a python file. If this is your first time using the tutorial., we highly recommend going through these steps to get deeper intuition about how things work. Once you're more familiar, you can streamline the process by directly running the teleoperate script (which is detailed further in the tutorial):
 ```bash
-python lerobot/scripts/control_robot.py teleoperate \
+lr_control_robot teleoperate \
   --robot-path lerobot/configs/robot/koch.yaml \
   --robot-overrides '~cameras'  # do not instantiate the cameras
 ```
@@ -678,7 +678,7 @@ Instead of manually running the python code in a terminal window, you can use [`
 
 Try running this code to teleoperate your robot (if you dont have a camera, keep reading):
 ```bash
-python lerobot/scripts/control_robot.py teleoperate \
+lr_control_robot teleoperate \
   --robot-path lerobot/configs/robot/koch.yaml
 ```
 
@@ -696,7 +696,7 @@ It contains
 
 Note: you can override any entry in the yaml file using `--robot-overrides` and the [hydra.cc](https://hydra.cc/docs/advanced/override_grammar/basic) syntax. If needed, you can override the ports like this:
 ```bash
-python lerobot/scripts/control_robot.py teleoperate \
+lr_control_robot teleoperate \
   --robot-path lerobot/configs/robot/koch.yaml \
   --robot-overrides \
     leader_arms.main.port=/dev/tty.usbmodem575E0031751 \
@@ -705,7 +705,7 @@ python lerobot/scripts/control_robot.py teleoperate \
 
 Importantly: If you don't have any camera, you can remove them dynamically with this [hydra.cc](https://hydra.cc/docs/advanced/override_grammar/basic) syntax `'~cameras'`:
 ```bash
-python lerobot/scripts/control_robot.py teleoperate \
+lr_control_robot teleoperate \
   --robot-path lerobot/configs/robot/koch.yaml \
   --robot-overrides \
     '~cameras'
@@ -775,7 +775,7 @@ If you don't want to push to hub, use `--push-to-hub 0`.
 
 Now run this to record 2 episodes:
 ```bash
-python lerobot/scripts/control_robot.py record \
+lr_control_robot record \
   --robot-path lerobot/configs/robot/koch.yaml \
   --fps 30 \
   --root data \
@@ -839,7 +839,7 @@ In the coming months, we plan to release a foundational model for robotics. We a
 
 You can visualize your dataset by running:
 ```bash
-python lerobot/scripts/visualize_dataset_html.py \
+lr_visualize_dataset_html \
   --root data \
   --repo-id ${HF_USER}/koch_test
 ```
@@ -855,7 +855,7 @@ A useful feature of [`lerobot/scripts/control_robot.py`](../lerobot/scripts/cont
 
 To replay the first episode of the dataset you just recorded, run the following command:
 ```bash
-python lerobot/scripts/control_robot.py replay \
+lr_control_robot replay \
   --robot-path lerobot/configs/robot/koch.yaml \
   --fps 30 \
   --root data \
@@ -869,9 +869,9 @@ Your robot should replicate movements similar to those you recorded. For example
 
 ### a. Use the `train` script
 
-To train a policy to control your robot, use the [`python lerobot/scripts/train.py`](../lerobot/scripts/train.py) script. A few arguments are required. Here is an example command:
+To train a policy to control your robot, use the [`lr_train`](../lerobot/scripts/train.py) script. A few arguments are required. Here is an example command:
 ```bash
-DATA_DIR=data python lerobot/scripts/train.py \
+DATA_DIR=data lr_train \
   dataset_repo_id=${HF_USER}/koch_test \
   policy=act_koch_real \
   env=koch_real \
@@ -988,7 +988,7 @@ Ideally, when controlling your robot with your neural network, you would want to
 
 To this end, you can use the `record` function from [`lerobot/scripts/control_robot.py`](../lerobot/scripts/control_robot.py) but with a policy checkpoint as input. For instance, run this command to record 10 evaluation episodes:
 ```bash
-python lerobot/scripts/control_robot.py record \
+lr_control_robot record \
   --robot-path lerobot/configs/robot/koch.yaml \
   --fps 30 \
   --root data \
@@ -1009,7 +1009,7 @@ As you can see, it's almost the same command as previously used to record your t
 
 You can then visualize your evaluation dataset by running the same command as before but with the new inference dataset as argument:
 ```bash
-python lerobot/scripts/visualize_dataset.py \
+lr_visualize_dataset \
   --root data \
   --repo-id ${HF_USER}/eval_koch_test
 ```

--- a/examples/8_use_stretch.md
+++ b/examples/8_use_stretch.md
@@ -92,7 +92,7 @@ Serial Number = stretch-se3-3054
 **Calibrate (Optional)**
 Before operating Stretch, you need to [home](https://docs.hello-robot.com/0.3/getting_started/stretch_hardware_overview/#homing) it first. Be mindful about giving Stretch some space as this procedure will move the robot's arm and gripper. Now run this command:
 ```bash
-python lerobot/scripts/control_robot.py calibrate \
+lr_control_robot calibrate \
     --robot-path lerobot/configs/robot/stretch.yaml
 ```
 This is equivalent to running `stretch_robot_home.py`
@@ -104,7 +104,7 @@ Before trying teleoperation, you need activate the gamepad controller by pressin
 
 Now try out teleoperation (see above documentation to learn about the gamepad controls):
 ```bash
-python lerobot/scripts/control_robot.py teleoperate \
+lr_control_robot teleoperate \
     --robot-path lerobot/configs/robot/stretch.yaml
 ```
 This is essentially the same as running `stretch_gamepad_teleop.py`
@@ -125,7 +125,7 @@ echo $HF_USER
 
 Record one episode:
 ```bash
-python lerobot/scripts/control_robot.py record \
+lr_control_robot record \
     --robot-path lerobot/configs/robot/stretch.yaml \
     --fps 20 \
     --root data \
@@ -143,7 +143,7 @@ python lerobot/scripts/control_robot.py record \
 **Replay an episode**
 Now try to replay this episode (make sure the robot's initial position is the same):
 ```bash
-python lerobot/scripts/control_robot.py replay \
+lr_control_robot replay \
     --robot-path lerobot/configs/robot/stretch.yaml \
     --fps 20 \
     --root data \

--- a/examples/9_use_aloha.md
+++ b/examples/9_use_aloha.md
@@ -51,14 +51,14 @@ Teleoperation consists in manually operating the leader arms to move the followe
 
 By running the following code, you can start your first **SAFE** teleoperation:
 ```bash
-python lerobot/scripts/control_robot.py teleoperate \
+lr_control_robot teleoperate \
     --robot-path lerobot/configs/robot/aloha.yaml \
     --robot-overrides max_relative_target=5
 ```
 
 By adding `--robot-overrides max_relative_target=5`, we override the default value for `max_relative_target` defined in `lerobot/configs/robot/aloha.yaml`. It is expected to be `5` to limit the magnitude of the movement for more safety, but the teloperation won't be smooth. When you feel confident, you can disable this limit by adding `--robot-overrides max_relative_target=null` to the command line:
 ```bash
-python lerobot/scripts/control_robot.py teleoperate \
+lr_control_robot teleoperate \
     --robot-path lerobot/configs/robot/aloha.yaml \
     --robot-overrides max_relative_target=null
 ```
@@ -80,7 +80,7 @@ echo $HF_USER
 
 Record 2 episodes and upload your dataset to the hub:
 ```bash
-python lerobot/scripts/control_robot.py record \
+lr_control_robot record \
     --robot-path lerobot/configs/robot/aloha.yaml \
     --robot-overrides max_relative_target=null \
     --fps 30 \
@@ -103,7 +103,7 @@ echo ${HF_USER}/aloha_test
 
 If you didn't upload with `--push-to-hub 0`, you can also visualize it locally with:
 ```bash
-python lerobot/scripts/visualize_dataset_html.py \
+lr_visualize_dataset_html \
   --root data \
   --repo-id ${HF_USER}/aloha_test
 ```
@@ -115,7 +115,7 @@ Replay consists in automatically replaying the sequence of actions (i.e. goal po
 
 Now try to replay the first episode on your robot:
 ```bash
-python lerobot/scripts/control_robot.py replay \
+lr_control_robot replay \
     --robot-path lerobot/configs/robot/aloha.yaml \
     --robot-overrides max_relative_target=null \
     --fps 30 \
@@ -126,9 +126,9 @@ python lerobot/scripts/control_robot.py replay \
 
 ## Train a policy
 
-To train a policy to control your robot, use the [`python lerobot/scripts/train.py`](../lerobot/scripts/train.py) script. A few arguments are required. Here is an example command:
+To train a policy to control your robot, use the [`lr_train`](../lerobot/scripts/train.py) script. A few arguments are required. Here is an example command:
 ```bash
-DATA_DIR=data python lerobot/scripts/train.py \
+DATA_DIR=data lr_train \
   dataset_repo_id=${HF_USER}/aloha_test \
   policy=act_aloha_real \
   env=aloha_real \
@@ -152,7 +152,7 @@ Training should take several hours. You will find checkpoints in `outputs/train/
 
 You can use the `record` function from [`lerobot/scripts/control_robot.py`](../lerobot/scripts/control_robot.py) but with a policy checkpoint as input. For instance, run this command to record 10 evaluation episodes:
 ```bash
-python lerobot/scripts/control_robot.py record \
+lr_control_robot record \
   --robot-path lerobot/configs/robot/aloha.yaml \
   --robot-overrides max_relative_target=null \
   --fps 30 \

--- a/examples/advanced/1_train_act_pusht/train_act_pusht.md
+++ b/examples/advanced/1_train_act_pusht/train_act_pusht.md
@@ -7,7 +7,7 @@ Let's get started!
 Suppose we want to train ACT for PushT. Well, there are aspects of the ACT configuration that are specific to the ALOHA environments, and these happen to be incompatible with PushT. Therefore, trying to run the following will almost certainly raise an exception of sorts (eg: feature dimension mismatch):
 
 ```bash
-python lerobot/scripts/train.py policy=act env=pusht dataset_repo_id=lerobot/pusht
+lr_train policy=act env=pusht dataset_repo_id=lerobot/pusht
 ```
 
 We need to adapt the parameters of the ACT policy configuration to the PushT environment. The most important ones are the image keys.
@@ -54,7 +54,7 @@ cp examples/advanced/1_train_act_pusht/act_pusht.yaml lerobot/configs/policy/act
 
 <!-- Note to contributor: are you changing this command? Note that it's tested in `Makefile`, so change it there too! -->
 ```bash
-python lerobot/scripts/train.py policy=act_pusht env=pusht
+lr_train policy=act_pusht env=pusht
 ```
 
 Notice that this is much the same as the command that failed at the start of the tutorial, only:

--- a/lerobot/common/datasets/push_dataset_to_hub/openx_rlds_format.py
+++ b/lerobot/common/datasets/push_dataset_to_hub/openx_rlds_format.py
@@ -17,7 +17,7 @@
 For https://github.com/google-deepmind/open_x_embodiment (OPENX) datasets.
 
 Example:
-    python lerobot/scripts/push_dataset_to_hub.py \
+    lr_push_dataset_to_hub \
         --raw-dir /hdd/tensorflow_datasets/bridge_dataset/1.0.0/ \
         --repo-id youliangtan/sampled_bridge_data_v2 \
         --raw-format openx_rlds.bridge_orig \

--- a/lerobot/common/robot_devices/motors/dynamixel.py
+++ b/lerobot/common/robot_devices/motors/dynamixel.py
@@ -480,7 +480,7 @@ class DynamixelMotorsBus:
                         f"with a maximum range of [{LOWER_BOUND_DEGREE}, {UPPER_BOUND_DEGREE}] degrees to account for joints that can rotate a bit more, "
                         f"but present value is {values[i]} degree. "
                         "This might be due to a cable connection issue creating an artificial 360 degrees jump in motor values. "
-                        "You need to recalibrate by running: `python lerobot/scripts/control_robot.py calibrate`"
+                        "You need to recalibrate by running: `lr_control_robot calibrate`"
                     )
 
             elif CalibrationMode[calib_mode] == CalibrationMode.LINEAR:
@@ -498,7 +498,7 @@ class DynamixelMotorsBus:
                         f"with a maximum range of [{LOWER_BOUND_LINEAR}, {UPPER_BOUND_LINEAR}] % to account for some imprecision during calibration, "
                         f"but present value is {values[i]} %. "
                         "This might be due to a cable connection issue creating an artificial jump in motor values. "
-                        "You need to recalibrate by running: `python lerobot/scripts/control_robot.py calibrate`"
+                        "You need to recalibrate by running: `lr_control_robot calibrate`"
                     )
 
         return values

--- a/lerobot/common/robot_devices/motors/feetech.py
+++ b/lerobot/common/robot_devices/motors/feetech.py
@@ -459,7 +459,7 @@ class FeetechMotorsBus:
                         f"with a maximum range of [{LOWER_BOUND_DEGREE}, {UPPER_BOUND_DEGREE}] degrees to account for joints that can rotate a bit more, "
                         f"but present value is {values[i]} degree. "
                         "This might be due to a cable connection issue creating an artificial 360 degrees jump in motor values. "
-                        "You need to recalibrate by running: `python lerobot/scripts/control_robot.py calibrate`"
+                        "You need to recalibrate by running: `lr_control_robot calibrate`"
                     )
 
             elif CalibrationMode[calib_mode] == CalibrationMode.LINEAR:
@@ -477,7 +477,7 @@ class FeetechMotorsBus:
                         f"with a maximum range of [{LOWER_BOUND_LINEAR}, {UPPER_BOUND_LINEAR}] % to account for some imprecision during calibration, "
                         f"but present value is {values[i]} %. "
                         "This might be due to a cable connection issue creating an artificial jump in motor values. "
-                        "You need to recalibrate by running: `python lerobot/scripts/control_robot.py calibrate`"
+                        "You need to recalibrate by running: `lr_control_robot calibrate`"
                     )
 
         return values

--- a/lerobot/configs/policy/act_aloha_real.yaml
+++ b/lerobot/configs/policy/act_aloha_real.yaml
@@ -8,14 +8,14 @@
 #
 # Example of usage for training and inference with `control_robot.py`:
 # ```bash
-# python lerobot/scripts/train.py \
+# lr_train \
 #   policy=act_aloha_real \
 #   env=aloha_real
 # ```
 #
 # Example of usage for training and inference with [Dora-rs](https://github.com/dora-rs/dora-lerobot):
 # ```bash
-# python lerobot/scripts/train.py \
+# lr_train \
 #   policy=act_aloha_real \
 #   env=dora_aloha_real
 # ```

--- a/lerobot/configs/policy/act_koch_real.yaml
+++ b/lerobot/configs/policy/act_koch_real.yaml
@@ -8,7 +8,7 @@
 #
 # Example of usage for training:
 # ```bash
-# python lerobot/scripts/train.py \
+# lr_train \
 #   policy=act_koch_real \
 #   env=koch_real
 # ```

--- a/lerobot/configs/policy/act_moss_real.yaml
+++ b/lerobot/configs/policy/act_moss_real.yaml
@@ -8,7 +8,7 @@
 #
 # Example of usage for training:
 # ```bash
-# python lerobot/scripts/train.py \
+# lr_train \
 #   policy=act_koch_real \
 #   env=koch_real
 # ```

--- a/lerobot/configs/policy/act_so100_real.yaml
+++ b/lerobot/configs/policy/act_so100_real.yaml
@@ -8,7 +8,7 @@
 #
 # Example of usage for training:
 # ```bash
-# python lerobot/scripts/train.py \
+# lr_train \
 #   policy=act_koch_real \
 #   env=koch_real
 # ```

--- a/lerobot/configs/policy/tdmpc_pusht_keypoints.yaml
+++ b/lerobot/configs/policy/tdmpc_pusht_keypoints.yaml
@@ -2,7 +2,7 @@
 
 # Train with:
 #
-# python lerobot/scripts/train.py \
+# lr_train \
 #   env=pusht \
 #   env.gym.obs_type=environment_state_agent_pos \
 #   policy=tdmpc_pusht_keypoints \

--- a/lerobot/scripts/configure_motor.py
+++ b/lerobot/scripts/configure_motor.py
@@ -144,5 +144,6 @@ def main() -> None:
 
     configure_motor(args.port, args.brand, args.model, args.ID, args.baudrate)
 
+
 if __name__ == "__main__":
     main()

--- a/lerobot/scripts/configure_motor.py
+++ b/lerobot/scripts/configure_motor.py
@@ -3,7 +3,7 @@ This script configure a single motor at a time to a given ID and baudrate.
 
 Example of usage:
 ```bash
-python lerobot/scripts/configure_motor.py \
+lr_configure_motor \
   --port /dev/tty.usbmodem585A0080521 \
   --brand feetech \
   --model sts3215 \

--- a/lerobot/scripts/configure_motor.py
+++ b/lerobot/scripts/configure_motor.py
@@ -131,7 +131,7 @@ def configure_motor(port, brand, model, motor_idx_des, baudrate_des):
         print("Disconnected from motor bus.")
 
 
-if __name__ == "__main__":
+def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--port", type=str, required=True, help="Motors bus port (e.g. dynamixel,feetech)")
     parser.add_argument("--brand", type=str, required=True, help="Motor brand (e.g. dynamixel,feetech)")
@@ -143,3 +143,6 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     configure_motor(args.port, args.brand, args.model, args.ID, args.baudrate)
+
+if __name__ == "__main__":
+    main()

--- a/lerobot/scripts/control_robot.py
+++ b/lerobot/scripts/control_robot.py
@@ -529,5 +529,6 @@ def main() -> None:
         # termination due to camera threads not properly exiting.
         robot.disconnect()
 
+
 if __name__ == "__main__":
     main()

--- a/lerobot/scripts/control_robot.py
+++ b/lerobot/scripts/control_robot.py
@@ -345,7 +345,7 @@ def replay(
         log_control_info(robot, dt_s, fps=fps)
 
 
-if __name__ == "__main__":
+def main() -> None:
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest="mode", required=True)
 
@@ -528,3 +528,6 @@ if __name__ == "__main__":
         # Disconnect manually to avoid a "Core dump" during process
         # termination due to camera threads not properly exiting.
         robot.disconnect()
+
+if __name__ == "__main__":
+    main()

--- a/lerobot/scripts/control_robot.py
+++ b/lerobot/scripts/control_robot.py
@@ -8,26 +8,26 @@ Examples of usage:
 
 - Recalibrate your robot:
 ```bash
-python lerobot/scripts/control_robot.py calibrate
+lr_control_robot calibrate
 ```
 
 - Unlimited teleoperation at highest frequency (~200 Hz is expected), to exit with CTRL+C:
 ```bash
-python lerobot/scripts/control_robot.py teleoperate
+lr_control_robot teleoperate
 
 # Remove the cameras from the robot definition. They are not used in 'teleoperate' anyway.
-python lerobot/scripts/control_robot.py teleoperate --robot-overrides '~cameras'
+lr_control_robot teleoperate --robot-overrides '~cameras'
 ```
 
 - Unlimited teleoperation at a limited frequency of 30 Hz, to simulate data recording frequency:
 ```bash
-python lerobot/scripts/control_robot.py teleoperate \
+lr_control_robot teleoperate \
     --fps 30
 ```
 
 - Record one episode in order to test replay:
 ```bash
-python lerobot/scripts/control_robot.py record \
+lr_control_robot record \
     --fps 30 \
     --root tmp/data \
     --repo-id $USER/koch_test \
@@ -37,7 +37,7 @@ python lerobot/scripts/control_robot.py record \
 
 - Visualize dataset:
 ```bash
-python lerobot/scripts/visualize_dataset.py \
+lr_visualize_dataset \
     --root tmp/data \
     --repo-id $USER/koch_test \
     --episode-index 0
@@ -45,7 +45,7 @@ python lerobot/scripts/visualize_dataset.py \
 
 - Replay this test episode:
 ```bash
-python lerobot/scripts/control_robot.py replay \
+lr_control_robot replay \
     --fps 30 \
     --root tmp/data \
     --repo-id $USER/koch_test \
@@ -55,7 +55,7 @@ python lerobot/scripts/control_robot.py replay \
 - Record a full dataset in order to train a policy, with 2 seconds of warmup,
 30 seconds of recording for each episode, and 10 seconds to reset the environment in between episodes:
 ```bash
-python lerobot/scripts/control_robot.py record \
+lr_control_robot record \
     --fps 30 \
     --root data \
     --repo-id $USER/koch_pick_place_lego \
@@ -77,7 +77,7 @@ To avoid resuming by deleting the dataset, use `--force-override 1`.
 
 - Train on this dataset with the ACT policy:
 ```bash
-DATA_DIR=data python lerobot/scripts/train.py \
+DATA_DIR=data lr_train \
     policy=act_koch_real \
     env=koch_real \
     dataset_repo_id=$USER/koch_pick_place_lego \
@@ -86,7 +86,7 @@ DATA_DIR=data python lerobot/scripts/train.py \
 
 - Run the pretrained policy on the robot:
 ```bash
-python lerobot/scripts/control_robot.py record \
+lr_control_robot record \
     --fps 30 \
     --root data \
     --repo-id $USER/eval_act_koch_real \

--- a/lerobot/scripts/eval.py
+++ b/lerobot/scripts/eval.py
@@ -442,12 +442,14 @@ def _compile_episode_data(
     return data_dict
 
 
-def main(
+def eval_and_export_policy(
     pretrained_policy_path: Path | None = None,
     hydra_cfg_path: str | None = None,
     out_dir: str | None = None,
     config_overrides: list[str] | None = None,
 ):
+    """Runs 'eval_policy' and saves the output to a directory."""
+
     assert (pretrained_policy_path is None) ^ (hydra_cfg_path is None)
     if pretrained_policy_path is not None:
         hydra_cfg = init_hydra_config(str(pretrained_policy_path / "config.yaml"), config_overrides)
@@ -532,7 +534,8 @@ def get_pretrained_policy_path(pretrained_policy_name_or_path, revision=None):
     return pretrained_policy_path
 
 
-if __name__ == "__main__":
+
+def main() -> None:
     init_logging()
 
     parser = argparse.ArgumentParser(
@@ -571,14 +574,17 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     if args.pretrained_policy_name_or_path is None:
-        main(hydra_cfg_path=args.config, out_dir=args.out_dir, config_overrides=args.overrides)
+        eval_and_export_policy(hydra_cfg_path=args.config, out_dir=args.out_dir, config_overrides=args.overrides)
     else:
         pretrained_policy_path = get_pretrained_policy_path(
             args.pretrained_policy_name_or_path, revision=args.revision
         )
 
-        main(
+        eval_and_export_policy(
             pretrained_policy_path=pretrained_policy_path,
             out_dir=args.out_dir,
             config_overrides=args.overrides,
         )
+
+if __name__ == "__main__":
+    main()

--- a/lerobot/scripts/eval.py
+++ b/lerobot/scripts/eval.py
@@ -21,13 +21,13 @@ You want to evaluate a model from the hub (eg: https://huggingface.co/lerobot/di
 for 10 episodes.
 
 ```
-python lerobot/scripts/eval.py -p lerobot/diffusion_pusht eval.n_episodes=10
+lr_eval -p lerobot/diffusion_pusht eval.n_episodes=10
 ```
 
 OR, you want to evaluate a model checkpoint from the LeRobot training script for 10 episodes.
 
 ```
-python lerobot/scripts/eval.py \
+lr_eval \
     -p outputs/train/diffusion_pusht/checkpoints/005000/pretrained_model \
     eval.n_episodes=10
 ```

--- a/lerobot/scripts/eval.py
+++ b/lerobot/scripts/eval.py
@@ -534,7 +534,6 @@ def get_pretrained_policy_path(pretrained_policy_name_or_path, revision=None):
     return pretrained_policy_path
 
 
-
 def main() -> None:
     init_logging()
 
@@ -574,7 +573,9 @@ def main() -> None:
     args = parser.parse_args()
 
     if args.pretrained_policy_name_or_path is None:
-        eval_and_export_policy(hydra_cfg_path=args.config, out_dir=args.out_dir, config_overrides=args.overrides)
+        eval_and_export_policy(
+            hydra_cfg_path=args.config, out_dir=args.out_dir, config_overrides=args.overrides
+        )
     else:
         pretrained_policy_path = get_pretrained_policy_path(
             args.pretrained_policy_name_or_path, revision=args.revision
@@ -585,6 +586,7 @@ def main() -> None:
             out_dir=args.out_dir,
             config_overrides=args.overrides,
         )
+
 
 if __name__ == "__main__":
     main()

--- a/lerobot/scripts/push_dataset_to_hub.py
+++ b/lerobot/scripts/push_dataset_to_hub.py
@@ -20,22 +20,22 @@ installation of neural net specific packages like pytorch, tensorflow, jax.
 
 Example of how to download raw datasets, convert them into LeRobotDataset format, and push them to the hub:
 ```
-python lerobot/scripts/push_dataset_to_hub.py \
+lr_push_dataset_to_hub \
 --raw-dir data/pusht_raw \
 --raw-format pusht_zarr \
 --repo-id lerobot/pusht
 
-python lerobot/scripts/push_dataset_to_hub.py \
+lr_push_dataset_to_hub \
 --raw-dir data/xarm_lift_medium_raw \
 --raw-format xarm_pkl \
 --repo-id lerobot/xarm_lift_medium
 
-python lerobot/scripts/push_dataset_to_hub.py \
+lr_push_dataset_to_hub \
 --raw-dir data/aloha_sim_insertion_scripted_raw \
 --raw-format aloha_hdf5 \
 --repo-id lerobot/aloha_sim_insertion_scripted
 
-python lerobot/scripts/push_dataset_to_hub.py \
+lr_push_dataset_to_hub \
 --raw-dir data/umi_cup_in_the_wild_raw \
 --raw-format umi_zarr \
 --repo-id lerobot/umi_cup_in_the_wild

--- a/lerobot/scripts/visualize_dataset.py
+++ b/lerobot/scripts/visualize_dataset.py
@@ -29,14 +29,14 @@ Examples:
 
 - Visualize data stored on a local machine:
 ```
-local$ python lerobot/scripts/visualize_dataset.py \
+local$ lr_visualize_dataset \
     --repo-id lerobot/pusht \
     --episode-index 0
 ```
 
 - Visualize data stored on a distant machine with a local viewer:
 ```
-distant$ python lerobot/scripts/visualize_dataset.py \
+distant$ lr_visualize_dataset \
     --repo-id lerobot/pusht \
     --episode-index 0 \
     --save 1 \
@@ -50,7 +50,7 @@ local$ rerun lerobot_pusht_episode_0.rrd
 (You need to forward the websocket port to the distant machine, with
 `ssh -L 9087:localhost:9087 username@remote-host`)
 ```
-distant$ python lerobot/scripts/visualize_dataset.py \
+distant$ lr_visualize_dataset \
     --repo-id lerobot/pusht \
     --episode-index 0 \
     --mode distant \

--- a/lerobot/scripts/visualize_dataset_html.py
+++ b/lerobot/scripts/visualize_dataset_html.py
@@ -29,7 +29,7 @@ Example of usage:
 
 - Visualize data stored on a local machine:
 ```bash
-local$ python lerobot/scripts/visualize_dataset_html.py \
+local$ lr_visualize_dataset_html \
     --repo-id lerobot/pusht
 
 local$ open http://localhost:9090
@@ -37,7 +37,7 @@ local$ open http://localhost:9090
 
 - Visualize data stored on a distant machine with a local viewer:
 ```bash
-distant$ python lerobot/scripts/visualize_dataset_html.py \
+distant$ lr_visualize_dataset_html \
     --repo-id lerobot/pusht
 
 local$ ssh -L 9090:localhost:9090 distant  # create a ssh tunnel
@@ -46,7 +46,7 @@ local$ open http://localhost:9090
 
 - Select episodes to visualize:
 ```bash
-python lerobot/scripts/visualize_dataset_html.py \
+lr_visualize_dataset_html \
     --repo-id lerobot/pusht \
     --episodes 7 3 5 1 4
 ```

--- a/lerobot/scripts/visualize_image_transforms.py
+++ b/lerobot/scripts/visualize_image_transforms.py
@@ -23,14 +23,14 @@ Additionally, each individual transform can be visualized separately as well as 
 
 Increase hue jitter
 ```
-python lerobot/scripts/visualize_image_transforms.py \
+lr_visualize_image_transforms \
     dataset_repo_id=lerobot/aloha_mobile_shrimp \
     training.image_transforms.hue.min_max="[-0.25,0.25]"
 ```
 
 Increase brightness & brightness weight
 ```
-python lerobot/scripts/visualize_image_transforms.py \
+lr_visualize_image_transforms \
     dataset_repo_id=lerobot/aloha_mobile_shrimp \
     training.image_transforms.brightness.weight=10.0 \
     training.image_transforms.brightness.min_max="[1.0,2.0]"
@@ -38,7 +38,7 @@ python lerobot/scripts/visualize_image_transforms.py \
 
 Blur images and disable saturation & hue
 ```
-python lerobot/scripts/visualize_image_transforms.py \
+lr_visualize_image_transforms \
     dataset_repo_id=lerobot/aloha_mobile_shrimp \
     training.image_transforms.sharpness.weight=10.0 \
     training.image_transforms.sharpness.min_max="[0.0,1.0]" \
@@ -48,7 +48,7 @@ python lerobot/scripts/visualize_image_transforms.py \
 
 Use all transforms with random order
 ```
-python lerobot/scripts/visualize_image_transforms.py \
+lr_visualize_image_transforms \
     dataset_repo_id=lerobot/aloha_mobile_shrimp \
     training.image_transforms.max_num_transforms=5 \
     training.image_transforms.random_order=true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,19 @@ feetech = ["feetech-servo-sdk", "pynput"]
 intelrealsense = ["pyrealsense2"]
 stretch = ["hello-robot-stretch-body", "pyrender", "pyrealsense2", "pynput"]
 
+[tool.poetry.scripts]
+# Create executables for each lerobot script and put them in your (virtualenv) PATH
+lr_configure_motor = "lerobot.scripts.configure_motor:main"
+lr_control_robot = "lerobot.scripts.control_robot:main"
+lr_display_sys_info = "lerobot.scripts.display_sys_info:display_sys_info"
+lr_eval = "lerobot.scripts.eval:main"
+lr_find_motors_bus_port = "lerobot.scripts.find_motors_bus_port:find_port"
+lr_push_dataset_to_hub = "lerobot.scripts.push_dataset_to_hub:main"
+lr_train = "lerobot.scripts.train:train_cli"
+lr_visualize_dataset = "lerobot.scripts.visualize_dataset:main"
+lr_visualize_dataset_html = "lerobot.scripts.visualize_dataset_html:main"
+lr_visualize_image_transforms = "lerobot.scripts.visualize_image_transforms:visualize_transforms_cli"
+
 [tool.ruff]
 line-length = 110
 target-version = "py310"


### PR DESCRIPTION
## What this does
This PR adds console script entry points in `pyproject.toml` using Poetry's `[tool.poetry.scripts]` section. This enables running scripts with simple commands like ``lr_train`` instead of ``python lerobot/scripts/train.py``. All documentation has been updated accordingly, and the original method of running scripts remains functional.

**Benefits**

- Users can run scripts with short, legible commands without needing to specify the python command or the script's file path.

- Removing hardcoded file paths from documentation and docstrings decouples the documentation from the project's directory structure, facilitating future refactors.

- Scripts can now be executed from any directory, not just the repository's root.

- Low risk of breakage

## How it was tested

- I ran each new script command to ensure they execute correctly.
- Verified that the original script execution method still works.


## How to checkout & try? (for the reviewer)
```bash
# Ensure you have the changes to your poetry environment
poetry install

# Activate the virtual environment
poetry shell

# Run a script using the new command
lr_train --some-option

# Alternatively, use `poetry run`
poetry run lr_visualize_dataset --help

# Confirm the original method still works
python lerobot/scripts/train.py --some-option
```
