### PR TITLE
Fix several bugs relating to saving offline datasets when not logged in to HuggingFace

### DIFF
--- a/lerobot/common/datasets/lerobot_dataset.py
+++ b/lerobot/common/datasets/lerobot_dataset.py
@@ -79,7 +79,7 @@ class LeRobotDatasetMetadata:
         local_files_only: bool = False,
     ):
         self.repo_id = repo_id
-        self.root = Path(root) if root is not None else LEROBOT_HOME / repo_id
+        self.root = Path(root) / repo_id if root is not None else LEROBOT_HOME / repo_id
         self.local_files_only = local_files_only
 
         # Load metadata
@@ -286,9 +286,9 @@ class LeRobotDatasetMetadata:
         """Creates metadata for a LeRobotDataset."""
         obj = cls.__new__(cls)
         obj.repo_id = repo_id
-        obj.root = Path(root) if root is not None else LEROBOT_HOME / repo_id
+        obj.root = Path(root) / repo_id if root is not None else LEROBOT_HOME / repo_id
 
-        obj.root.mkdir(parents=True, exist_ok=False)
+        obj.root.mkdir(parents=True, exist_ok=True)
 
         if robot is not None:
             features = get_features_from_robot(robot, use_videos)
@@ -427,7 +427,7 @@ class LeRobotDataset(torch.utils.data.Dataset):
         """
         super().__init__()
         self.repo_id = repo_id
-        self.root = Path(root) if root else LEROBOT_HOME / repo_id
+        self.root = Path(root) / repo_id if root else LEROBOT_HOME / repo_id
         self.image_transforms = image_transforms
         self.delta_timestamps = delta_timestamps
         self.episodes = episodes
@@ -443,7 +443,7 @@ class LeRobotDataset(torch.utils.data.Dataset):
         self.root.mkdir(exist_ok=True, parents=True)
 
         # Load metadata
-        self.meta = LeRobotDatasetMetadata(self.repo_id, self.root, self.local_files_only)
+        self.meta = LeRobotDatasetMetadata(self.repo_id, root, self.local_files_only)
 
         # Check version
         check_version_compatibility(self.repo_id, self.meta._version, CODEBASE_VERSION)

--- a/lerobot/scripts/control_robot.py
+++ b/lerobot/scripts/control_robot.py
@@ -464,6 +464,12 @@ if __name__ == "__main__":
         help="Upload dataset to Hugging Face hub.",
     )
     parser_record.add_argument(
+        "--local-files-only",
+        type=int,
+        default=0,
+        help="Use local files only. By default, this script will try to fetch the dataset from the hub if it exists.",
+    )
+    parser_record.add_argument(
         "--tags",
         type=str,
         nargs="*",


### PR DESCRIPTION
## What this does
This PR fixes https://github.com/huggingface/lerobot/issues/534 and fixes several bugs I found that all relate to not being logged in to huggingface.

I found a few places that were broken.

1) When `--root` is set, your dataset was being saved in `root/DATA` instead of `root/hf_username/repo`.
2) If you go to `control_robot record` on an existing dataset, you would get an exception because it was trying to path.mkdir(exist_ok=false), when actually, it should be `exist_ok=True`.
3) There are still some issues in the training pipeline, but I'm going to leave that for another PR.

## How it was tested

1. Record a few episodes
2. Try to continue recording on the existing dataset
3. Train a model (there's still some issues here, I ended up just logging in to huggingface to skip by them. I'll revisit this later)
4. Visualizing the dataset

## How to checkout & try? (for the reviewer)
Here's how I've been running `control_robot record`

```shell
record
--robot-path lerobot/configs/robot/myarm.yaml
--root "data"
--repo-id username/dataset_name
--single-task "Cool task description, wow!"
--fps 20
--push-to-hub 0
--resume 1
--local-files-only 1
```
