### PR TITLE
Config Files for Aloha Solo

### DIFF
--- a/lerobot/configs/env/aloha_solo_real.yaml
+++ b/lerobot/configs/env/aloha_solo_real.yaml
@@ -1,0 +1,10 @@
+# @package _global_
+
+fps: 30
+
+env:
+  name: real_world
+  task: null
+  state_dim: 9
+  action_dim: 9
+  fps: ${fps}

--- a/lerobot/configs/policy/act_aloha_solo_real.yaml
+++ b/lerobot/configs/policy/act_aloha_solo_real.yaml
@@ -1,0 +1,117 @@
+# @package _global_
+
+# Use `act_aloha_solo_real.yaml` to train on real-world datasets collected on Aloha or Aloha-2 robots.
+# It contains 2 cameras (i.e. cam_right_wrist/cam_left_wrist, cam_high).
+# Also, `training.eval_freq` is set to -1. This config is used to evaluate checkpoints at a certain frequency of training steps.
+# When it is set to -1, it deactivates evaluation. This is because real-world evaluation is done through our `control_robot.py` script.
+# Look at the documentation in header of `control_robot.py` for more information on how to collect data , train and evaluate a policy.
+#
+# Example of usage for training and inference with `control_robot.py`:
+# ```bash
+# python lerobot/scripts/train.py \
+#   policy=act_aloha_solo_real \
+#   env=aloha_solo_real
+# ```
+#
+# Example of usage for training and inference with [Dora-rs](https://github.com/dora-rs/dora-lerobot):
+# ```bash
+# python lerobot/scripts/train.py \
+#   policy=act_aloha_solo_real \
+#   env=dora_aloha_solo_real
+# ```
+
+seed: 1000
+dataset_repo_id: lerobot/aloha_solo_lego
+
+override_dataset_stats:
+  observation.images.cam_right_wrist:
+    # stats from imagenet, since we use a pretrained vision model
+    mean: [[[0.485]], [[0.456]], [[0.406]]]  # (c,1,1)
+    std: [[[0.229]], [[0.224]], [[0.225]]]  # (c,1,1)
+  # Uncomment for left wrist and comment the right wrist
+  # observation.images.cam_left_wrist:
+  #   # stats from imagenet, since we use a pretrained vision model
+  #   mean: [[[0.485]], [[0.456]], [[0.406]]]  # (c,1,1)
+  #   std: [[[0.229]], [[0.224]], [[0.225]]]  # (c,1,1)
+  observation.images.cam_high:
+    # stats from imagenet, since we use a pretrained vision model
+    mean: [[[0.485]], [[0.456]], [[0.406]]]  # (c,1,1)
+    std: [[[0.229]], [[0.224]], [[0.225]]]  # (c,1,1)
+
+
+training:
+  offline_steps: 80000
+  online_steps: 0
+  eval_freq: -1
+  save_freq: 10000
+  log_freq: 100
+  save_checkpoint: true
+
+  batch_size: 8
+  lr: 1e-5
+  lr_backbone: 1e-5
+  weight_decay: 1e-4
+  grad_clip_norm: 10
+  online_steps_between_rollouts: 1
+
+  delta_timestamps:
+    action: "[i / ${fps} for i in range(${policy.chunk_size})]"
+
+eval:
+  n_episodes: 50
+  batch_size: 50
+
+# See `configuration_act.py` for more details.
+policy:
+  name: act
+
+  # Input / output structure.
+  n_obs_steps: 1
+  chunk_size: 100
+  n_action_steps: 100
+
+  input_shapes:
+    # TODO(rcadene, alexander-soare): add variables for height and width from the dataset/env?
+    observation.images.cam_right_wrist: [3, 480, 640]
+    # observation.images.cam_left_wrist: [3, 480, 640] # Uncomment if using left wrist and comment the right.
+    observation.images.cam_high: [3, 480, 640]
+    observation.state: ["${env.state_dim}"]
+  output_shapes:
+    action: ["${env.action_dim}"]
+
+  # Normalization / Unnormalization
+  input_normalization_modes:
+    observation.images.cam_right_wrist: mean_std
+    # observation.images.cam_left_wrist: mean_std # Uncomment if using left wrist and comment the right.
+    observation.images.cam_high: mean_std
+    observation.state: mean_std
+  output_normalization_modes:
+    action: mean_std
+
+  # Architecture.
+  # Vision backbone.
+  vision_backbone: resnet18
+  pretrained_backbone_weights: ResNet18_Weights.IMAGENET1K_V1
+  replace_final_stride_with_dilation: false
+  # Transformer layers.
+  pre_norm: false
+  dim_model: 512
+  n_heads: 8
+  dim_feedforward: 3200
+  feedforward_activation: relu
+  n_encoder_layers: 4
+  # Note: Although the original ACT implementation has 7 for `n_decoder_layers`, there is a bug in the code
+  # that means only the first layer is used. Here we match the original implementation by setting this to 1.
+  # See this issue https://github.com/tonyzhaozh/act/issues/25#issue-2258740521.
+  n_decoder_layers: 1
+  # VAE.
+  use_vae: true
+  latent_dim: 32
+  n_vae_encoder_layers: 4
+
+  # Inference.
+  temporal_ensemble_momentum: null
+
+  # Training and loss computation.
+  dropout: 0.1
+  kl_weight: 10.0

--- a/lerobot/configs/robot/aloha_solo.yaml
+++ b/lerobot/configs/robot/aloha_solo.yaml
@@ -1,0 +1,78 @@
+# [Aloha: A Low-Cost Hardware for Bimanual Teleoperation](https://www.trossenrobotics.com/aloha-stationary)
+# https://aloha-2.github.io
+
+# Requires installing extras packages
+# With pip: `pip install -e ".[dynamixel intelrealsense]"`
+# With poetry: `poetry install --sync --extras "dynamixel intelrealsense"`
+
+# See [tutorial](https://github.com/huggingface/lerobot/blob/main/examples/9_use_aloha.md)
+
+
+_target_: lerobot.common.robot_devices.robots.manipulator.ManipulatorRobot
+robot_type: aloha
+# Specific to Aloha, LeRobot comes with default calibration files. Assuming the motors have been
+# properly assembled, no manual calibration step is expected. If you need to run manual calibration,
+# simply update this path to ".cache/calibration/aloha"
+calibration_dir: .cache/calibration/aloha_default
+
+# /!\ FOR SAFETY, READ THIS /!\
+# `max_relative_target` limits the magnitude of the relative positional target vector for safety purposes.
+# Set this to a positive scalar to have the same value for all motors, or a list that is the same length as
+# the number of motors in your follower arms.
+# For Aloha, for every goal position request, motor rotations are capped at 5 degrees by default.
+# When you feel more confident with teleoperation or running the policy, you can extend
+# this safety limit and even removing it by setting it to `null`.
+# Also, everything is expected to work safely out-of-the-box, but we highly advise to
+# first try to teleoperate the grippers only (by commenting out the rest of the motors in this yaml),
+# then to gradually add more motors (by uncommenting), until you can teleoperate both arms fully
+max_relative_target: null
+
+leader_arms:
+  right:
+    _target_: lerobot.common.robot_devices.motors.dynamixel.DynamixelMotorsBus
+    port: /dev/ttyDXL_leader_right
+    motors:  # window_x
+      # name: (index, model)
+      waist: [1, xm430-w350]
+      shoulder: [2, xm430-w350]
+      shoulder_shadow: [3, xm430-w350]
+      elbow: [4, xm430-w350]
+      elbow_shadow: [5, xm430-w350]
+      forearm_roll: [6, xm430-w350]
+      wrist_angle: [7, xm430-w350]
+      wrist_rotate: [8, xl430-w250]
+      gripper: [9, xc430-w150]
+
+follower_arms:
+  right:
+    _target_: lerobot.common.robot_devices.motors.dynamixel.DynamixelMotorsBus
+    port: /dev/ttyDXL_follower_right
+    motors:
+      # name: [index, model]
+      waist: [1, xm540-w270]
+      shoulder: [2, xm540-w270]
+      shoulder_shadow: [3, xm540-w270]
+      elbow: [4, xm540-w270]
+      elbow_shadow: [5, xm540-w270]
+      forearm_roll: [6, xm540-w270]
+      wrist_angle: [7, xm540-w270]
+      wrist_rotate: [8, xm430-w350]
+      gripper: [9, xm430-w350]
+
+# Troubleshooting: If one of your IntelRealSense cameras freeze during
+# data recording due to bandwidth limit, you might need to plug the camera
+# on another USB hub or PCIe card.
+cameras:
+  cam_high:
+    _target_: lerobot.common.robot_devices.cameras.intelrealsense.IntelRealSenseCamera
+    serial_number: 1234567890
+    fps: 30
+    width: 640
+    height: 480
+
+  cam_right_wrist:
+    _target_: lerobot.common.robot_devices.cameras.intelrealsense.IntelRealSenseCamera
+    serial_number: 1234567890
+    fps: 30
+    width: 640
+    height: 480


### PR DESCRIPTION
## What this does
This PR adds the necessary configuration files for Aloha Solo. It includes:

- Robot Configuration: `aloha_solo.yaml` (to be placed in `lerobot/configs/robot/`)
- Policy Configuration: `act_aloha_solo_real.yaml` (to be placed in `lerobot/configs/policy/`)
- Environment Configuration: `aloha_solo_real.yaml` (to be placed in `lerobot/configs/env/`)

## How it was tested

- Verified training convergence using policy `act_aloha_solo` on environment `aloha_solo`.
- Ran teleoperation, data recording, and evaluation commands to confirm functionality.

## How to checkout & try? (for the reviewer)

#### Teleoperation

```bash
python lerobot/scripts/control_robot.py teleoperate \
   --robot-path lerobot/configs/robot/aloha_solo.yaml
```

#### Recording Data

```bash
python lerobot/scripts/control_robot.py record \
   --robot-path lerobot/configs/robot/aloha_solo.yaml \
   --fps 30 \
   --root data \
   --repo-id ${HF_USER}/aloha_solo_dataset \
   --warmup-time-s 5 \
   --episode-time-s 30 \
   --reset-time-s 30 \
   --num-episodes 10
```

#### Training

```bash
DATA_DIR=data python lerobot/scripts/train.py \
   dataset_repo_id=${HF_USER}/aloha_solo_dataset \
   policy=act_aloha_solo_real \
   env=aloha_solo_real \
   hydra.run.dir=outputs/train/act_aloha_solo \
   hydra.job.name=act_aloha_solo \
   device=cuda \
   wandb.enable=false
```

#### Evaluation

```bash
python lerobot/scripts/control_robot.py record \
   --robot-path lerobot/configs/robot/aloha.yaml \
   --fps 30 \
   --root data \
   --repo-id ${HF_USER}/eval_aloha_test \
   --tags tutorial eval \
   --warmup-time-s 5 \
   --episode-time-s 30 \
   --reset-time-s 30 \
   --num-episodes 10 \
   -p outputs/train/act_aloha_solo/checkpoints/last/pretrained_model
```
