### PR TITLE
Use importlib.resources.files for card template path access

### DIFF
--- a/lerobot/common/datasets/utils.py
+++ b/lerobot/common/datasets/utils.py
@@ -477,7 +477,7 @@ def create_lerobot_dataset_card(
     Note: If specified, license must be one of https://huggingface.co/docs/hub/repositories-licenses.
     """
     card_tags = ["LeRobot"]
-    card_template_path = importlib.resources.path("lerobot.common.datasets", "card_template.md")
+    card_template_path = importlib.resources.files("lerobot.common.datasets").joinpath("card_template.md")
 
     if tags:
         card_tags += tags


### PR DESCRIPTION
## What this does
Replace importlib.resources.path with importlib.resources.files to properly handle package resource paths without requiring context manager. This fixes the FileNotFoundError caused by incorrect context manager handling.

## How it was tested
I tested it trying to record dataset in sim using this script `control_sim_robot_no_env.py` from https://github.com/s1lent4gnt/lerobot/blob/lilkm/joystick-control-sim-robot-no-env/lerobot/scripts/control_sim_robot_no_env.py. (NOTE: You need to make the change from this PR to check that is working.)
Using this command
```bash
python lerobot/scripts/control_sim_robot_no_env.py record \
    --robot-path lerobot/configs/robot/koch_sim.yaml \
    --fps 30 \
    --root data \
    --repo-id ${HF_USER}/moss_test \
    --warmup-time-s 1 \
    --display-cameras 0 \
    --episode-time-s 40 \
    --reset-time-s 10 \
    --num-episodes 2 \
    --push-to-hub 1 \
    --assign_rewards 1 \
    --single-task test_sim
```
You need a joystick/gamepad (xbox or ps5) to control the robot!