### PR TITLE
Fix broken `create_lerobot_dataset_card` 

### DIFF
--- a/lerobot/common/datasets/utils.py
+++ b/lerobot/common/datasets/utils.py
@@ -477,7 +477,6 @@ def create_lerobot_dataset_card(
     Note: If specified, license must be one of https://huggingface.co/docs/hub/repositories-licenses.
     """
     card_tags = ["LeRobot"]
-    card_template_path = importlib.resources.path("lerobot.common.datasets", "card_template.md")
 
     if tags:
         card_tags += tags
@@ -497,8 +496,10 @@ def create_lerobot_dataset_card(
         ],
     )
 
+    card_template = (importlib.resources.files("lerobot.common.datasets") / "card_template.md").read_text()
+
     return DatasetCard.from_template(
         card_data=card_data,
-        template_path=str(card_template_path),
+        template_str=card_template,
         **kwargs,
     )

--- a/tests/lerobot/common/datasets/test_utils.py
+++ b/tests/lerobot/common/datasets/test_utils.py
@@ -14,9 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
 from huggingface_hub import DatasetCard
+
 from lerobot.common.datasets.utils import create_lerobot_dataset_card
+
 
 def test_default_parameters():
     card = create_lerobot_dataset_card()
@@ -29,6 +30,7 @@ def test_default_parameters():
             "data_files": "data/*/*.parquet",
         }
     ]
+
 
 def test_with_tags():
     tags = ["tag1", "tag2"]

--- a/tests/lerobot/common/datasets/test_utils.py
+++ b/tests/lerobot/common/datasets/test_utils.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python
+
+# Copyright 2024 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from huggingface_hub import DatasetCard
+from lerobot.common.datasets.utils import create_lerobot_dataset_card
+
+def test_default_parameters():
+    card = create_lerobot_dataset_card()
+    assert isinstance(card, DatasetCard)
+    assert card.data.tags == ["LeRobot"]
+    assert card.data.task_categories == ["robotics"]
+    assert card.data.configs == [
+        {
+            "config_name": "default",
+            "data_files": "data/*/*.parquet",
+        }
+    ]
+
+def test_with_tags():
+    tags = ["tag1", "tag2"]
+    card = create_lerobot_dataset_card(tags=tags)
+    assert card.data.tags == ["LeRobot", "tag1", "tag2"]


### PR DESCRIPTION
## What this does
During the recording of dataset for HIL-SERL integration I have found the following issue:

```
Traceback (most recent call last):.93M/4.54M [00:01<00:00, 4.89MB/s]
  File "/Users/helper2424/Documents/lerobot/lerobot/scripts/control_robot.py", line 577, in <module>      | 3/6 [00:03<00:04,  1.38s/it]
    record(robot, **kwargs)███████████| 6/6 [00:03<00:00,  1.88it/s]
  File "/Users/helper2424/Documents/lerobot/lerobot/common/robot_devices/utils.py", line 28, in wrapper
    raise e
  File "/Users/helper2424/Documents/lerobot/lerobot/common/robot_devices/utils.py", line 24, in wrapper
    return func(robot, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/helper2424/Documents/lerobot/lerobot/scripts/control_robot.py", line 334, in record
    dataset.push_to_hub(tags=tags)
  File "/Users/helper2424/Documents/lerobot/lerobot/common/datasets/lerobot_dataset.py", line 499, in push_to_hub
    card = create_lerobot_dataset_card(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/helper2424/Documents/lerobot/lerobot/common/datasets/utils.py", line 500, in create_lerobot_dataset_card
    return DatasetCard.from_template(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/helper2424/Library/Caches/pypoetry/virtualenvs/lerobot-_GqtL9sV-py3.12/lib/python3.12/site-packages/huggingface_hub/repocard.py", line 480, in from_template
    return super().from_template(card_data, template_path, template_str, **template_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/helper2424/Library/Caches/pypoetry/virtualenvs/lerobot-_GqtL9sV-py3.12/lib/python3.12/site-packages/huggingface_hub/repocard.py", line 329, in from_template
    template_str = Path(template_path).read_text()
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/pathlib.py", line 1027, in read_text
    with self.open(mode='r', encoding=encoding, errors=errors) as f:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/pathlib.py", line 1013, in open
    return io.open(self, mode, buffering, encoding, errors, newline)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '<contextlib._GeneratorContextManager object at 0x3181632f0>'

```

This is issue is relevant in the last main.

Examples:
|  Title               | Label           |
|----------------------|-----------------|
| Fixes #[issue]       | (🐛 Bug)        |

## How it was tested
How to test that issue is fixed:
- Run data collection script, mine is the following: 
```
python lerobot/scripts/control_robot.py record \
    --robot-path lerobot/configs/robot/koch_helper2424.yaml \
    --num-episodes 2 \
    --warmup-time-s 5 \
    --episode-time-s 10 \
    --fps 30 \
    --assign-rewards 1 \
    --policy-overrides "device=mps" \
    --repo-id ${HF_USER}/hil-serl-pusht-reward-classifier-test \
    --single-task "Push small T object to the correct position"
```
- Run `pytest tests/lerobot/common/datasets/test_utils.py `

