### PR TITLE
Refact warmup waiting

### DIFF
--- a/lerobot/common/robot_devices/control_utils.py
+++ b/lerobot/common/robot_devices/control_utils.py
@@ -181,24 +181,6 @@ def init_policy(pretrained_policy_name_or_path, policy_overrides):
     return policy, policy_fps, device, use_amp
 
 
-def warmup_record(
-    robot,
-    events,
-    enable_teleoperation,
-    warmup_time_s,
-    display_cameras,
-    fps,
-):
-    control_loop(
-        robot=robot,
-        control_time_s=warmup_time_s,
-        display_cameras=display_cameras,
-        events=events,
-        fps=fps,
-        teleoperate=enable_teleoperation,
-    )
-
-
 def record_episode(
     robot,
     dataset,

--- a/lerobot/scripts/control_robot.py
+++ b/lerobot/scripts/control_robot.py
@@ -273,7 +273,7 @@ def record(
     if has_method(robot, "teleop_safety_stop"):
         robot.teleop_safety_stop()
 
-    recorded_episodes = dataset.num_episodes
+    recorded_episodes = 0
     while True:
         if recorded_episodes >= num_episodes:
             break
@@ -300,9 +300,7 @@ def record(
         # Current code logic doesn't allow to teleoperate during this time.
         # TODO(rcadene): add an option to enable teleoperation during reset
         # Skip reset for the last episode to be recorded
-        if not events["stop_recording"] and (
-            (dataset.num_episodes < num_episodes - 1) or events["rerecord_episode"]
-        ):
+        if not events["stop_recording"] and events["rerecord_episode"]:
             log_say("Reset the environment", play_sounds)
             reset_environment(robot, events, reset_time_s, use_policy = policy is not None)
 

--- a/lerobot/scripts/control_robot.py
+++ b/lerobot/scripts/control_robot.py
@@ -112,7 +112,6 @@ from lerobot.common.robot_devices.control_utils import (
     sanity_check_dataset_name,
     sanity_check_dataset_robot_compatibility,
     stop_recording,
-    warmup_record,
 )
 from lerobot.common.robot_devices.robots.factory import make_robot
 from lerobot.common.robot_devices.robots.utils import Robot
@@ -267,7 +266,9 @@ def record(
     # 3. place the cameras windows on screen
     enable_teleoperation = policy is None
     log_say("Warmup record", play_sounds)
-    warmup_record(robot, events, enable_teleoperation, warmup_time_s, display_cameras, fps)
+    
+    # warmup 
+    reset_environment(robot, events, warmup_time_s, use_policy = policy is not None)
 
     if has_method(robot, "teleop_safety_stop"):
         robot.teleop_safety_stop()
@@ -303,7 +304,7 @@ def record(
             (dataset.num_episodes < num_episodes - 1) or events["rerecord_episode"]
         ):
             log_say("Reset the environment", play_sounds)
-            reset_environment(robot, events, reset_time_s)
+            reset_environment(robot, events, reset_time_s, use_policy = policy is not None)
 
         if events["rerecord_episode"]:
             log_say("Re-record episode", play_sounds)

--- a/lerobot/scripts/control_robot.py
+++ b/lerobot/scripts/control_robot.py
@@ -296,10 +296,7 @@ def record(
             fps=fps,
         )
 
-        # Execute a few seconds without recording to give time to manually reset the environment
-        # Current code logic doesn't allow to teleoperate during this time.
-        # TODO(rcadene): add an option to enable teleoperation during reset
-        # Skip reset for the last episode to be recorded
+        # Execute a few seconds without recording to give time to manually reset the environment.
         if not events["stop_recording"] and events["rerecord_episode"]:
             log_say("Reset the environment", play_sounds)
             reset_environment(robot, events, reset_time_s, use_policy = policy is not None)

--- a/lerobot/scripts/control_robot.py
+++ b/lerobot/scripts/control_robot.py
@@ -266,14 +266,14 @@ def record(
     # 3. place the cameras windows on screen
     enable_teleoperation = policy is None
     log_say("Warmup record", play_sounds)
-    
+
     # warmup 
     reset_environment(robot, events, warmup_time_s, use_policy = policy is not None)
 
     if has_method(robot, "teleop_safety_stop"):
         robot.teleop_safety_stop()
 
-    recorded_episodes = 0
+    recorded_episodes = dataset.num_episodes
     while True:
         if recorded_episodes >= num_episodes:
             break


### PR DESCRIPTION
## What this does
Teleoperate is allowed when record reset_environment is used, but teleoperate is not allowed when using policy.
Replace warmup with reset_environment
Removed the condition that would cause reset_environment not to be entered during resume


## How it was tested
``` python
python lerobot/scripts/control_robot.py record   \
    --robot-path lerobot/configs/robot/three_camera_koch.yaml   \
    --fps 30   \
    --repo-id bingcm/tape_grab_three_30hz  \
    --tags experiment  \
    --warmup-time-s 5   \
    --episode-time-s 20   \
    --reset-time-s 4   \
    --num-episodes 200  \
    --push-to-hub 0  \
    --single-task test \
    --local-files-only 1 \

    --resume 1 # if test resume
```

## pytest result
174 passed, 137 skipped, 8 warnings in 193.28s (0:03:13)
