### PR TITLE
Show friendly error when tries to record already existed dataset

### DIFF
--- a/lerobot/common/datasets/lerobot_dataset.py
+++ b/lerobot/common/datasets/lerobot_dataset.py
@@ -65,6 +65,7 @@ from lerobot.common.datasets.video_utils import (
     get_video_info,
 )
 from lerobot.common.robot_devices.robots.utils import Robot
+from lerobot.common.exceptions import DatasetExistException
 
 # For maintainers, see lerobot/common/datasets/push_dataset_to_hub/CODEBASE_VERSION.md
 CODEBASE_VERSION = "v2.0"
@@ -288,7 +289,10 @@ class LeRobotDatasetMetadata:
         obj.repo_id = repo_id
         obj.root = Path(root) if root is not None else LEROBOT_HOME / repo_id
 
-        obj.root.mkdir(parents=True, exist_ok=False)
+        try:
+            obj.root.mkdir(parents=True, exist_ok=False)
+        except FileExistsError as e:
+            raise DatasetExistException(e)
 
         if robot is not None:
             features = get_features_from_robot(robot, use_videos)

--- a/lerobot/common/exceptions.py
+++ b/lerobot/common/exceptions.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+
+# Copyright 2024 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The exception is raised when user tries to create a dataset that already exists
+class DatasetExistException(FileExistsError):
+    pass

--- a/lerobot/scripts/control_robot.py
+++ b/lerobot/scripts/control_robot.py
@@ -101,6 +101,7 @@ from typing import List
 
 # from safetensors.torch import load_file, save_file
 from lerobot.common.datasets.lerobot_dataset import LeRobotDataset
+from lerobot.common.exceptions import DatasetExistException
 from lerobot.common.robot_devices.control_utils import (
     control_loop,
     has_method,
@@ -564,7 +565,11 @@ if __name__ == "__main__":
         teleoperate(robot, **kwargs)
 
     elif control_mode == "record":
-        record(robot, **kwargs)
+        try:
+            record(robot, **kwargs)
+        except DatasetExistException as e:
+            logging.error(f"Dataset already exists: {e}")
+            logging.error("To resume from the existing dataset, please pass the `--resume` flag.")
 
     elif control_mode == "replay":
         replay(robot, **kwargs)

--- a/lerobot/scripts/control_sim_robot.py
+++ b/lerobot/scripts/control_sim_robot.py
@@ -80,6 +80,7 @@ import numpy as np
 import torch
 
 from lerobot.common.datasets.lerobot_dataset import LeRobotDataset
+from lerobot.common.exceptions import DatasetExistException
 from lerobot.common.robot_devices.control_utils import (
     init_keyboard_listener,
     init_policy,
@@ -530,7 +531,11 @@ if __name__ == "__main__":
         teleoperate(env_constructor, robot, process_leader_actions_fn)
 
     elif control_mode == "record":
-        record(env_constructor, robot, process_leader_actions_fn, **kwargs)
+        try:
+            record(env_constructor, robot, process_leader_actions_fn, **kwargs)
+        except DatasetExistException as e:
+            logging.error(f"Dataset already exists: {e}")
+            logging.error("To resume from the existing dataset, please pass the `--resume` flag.")
 
     elif control_mode == "replay":
         replay(env_constructor, **kwargs)

--- a/tests/lerobot/common/datasets/lerobot_dataset.py
+++ b/tests/lerobot/common/datasets/lerobot_dataset.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+
+# Copyright 2024 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.


### PR DESCRIPTION
## What this does
This PR makes the process of dataset recording is more friendly. If you try to run scripts for recording dataset two times sequentially (it could happend because of some env error, or robot error or whatever) the script will show you the following error:

```
    obj.meta = LeRobotDatasetMetadata.create(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/helper2424/Documents/lerobot/lerobot/common/datasets/lerobot_dataset.py", line 291, in create
    obj.root.mkdir(parents=True, exist_ok=False)
  File "/opt/homebrew/Cellar/python@3.12/3.12.7_1/Frameworks/Python.framework/Versions/3.12/lib/python3.12/pathlib.py", line 1311, in mkdir
    os.mkdir(self, mode)
FileExistsError: [Errno 17] File exists: '/Users/helper2424/.cache/huggingface/lerobot/helper2424/hil-serl-pusht-reward-classifier-test'
```

It's difficult to realize what it means. The answer is easy - we try to create dataset two times. If it exists the code will crashs.

To avoid the confusion I have added error handling and user friendly error text which asks user to launch the script one more time with `--resume` flag.

Examples:
|  Before               | After           |
|----------------------|-----------------|
|  <img width="1202" alt="Screenshot 2024-12-22 at 3 52 05 PM" src="https://github.com/user-attachments/assets/7c3e2ca2-aea2-4068-b7e2-072275ccc6e3" />  | <img width="1312" alt="Screenshot 2024-12-22 at 3 52 30 PM" src="https://github.com/user-attachments/assets/b4a8120e-022e-4863-a389-f14fc8ac2109" /> |


## How it was tested
I have launched two times the following command

```
python lerobot/scripts/control_robot.py record \    --robot-path lerobot/configs/robot/koch_helper2424.yaml \
    --num-episodes 2 \
    --warmup-time-s 5 \
    --episode-time-s 10 \
    --fps 30 \
    --policy-overrides "device=mps" \
    --repo-id ${HF_USER}/hil12-serl-pusht-reward-classifier-test \
    --single-task "Push small T object to the correct position"
  ```
