### PR TITLE
Use local recorded dataset if exists

### DIFF
--- a/lerobot/common/datasets/factory.py
+++ b/lerobot/common/datasets/factory.py
@@ -18,7 +18,7 @@ import logging
 import torch
 from omegaconf import ListConfig, OmegaConf
 
-from lerobot.common.datasets.lerobot_dataset import LeRobotDataset, MultiLeRobotDataset
+from lerobot.common.datasets.lerobot_dataset import LEROBOT_HOME, LeRobotDataset, MultiLeRobotDataset
 from lerobot.common.datasets.transforms import get_image_transforms
 
 
@@ -97,6 +97,7 @@ def make_dataset(cfg, split: str = "train") -> LeRobotDataset | MultiLeRobotData
             delta_timestamps=cfg.training.get("delta_timestamps"),
             image_transforms=image_transforms,
             video_backend=cfg.video_backend,
+            local_files_only=(LEROBOT_HOME / cfg.dataset_repo_id).exists(),
         )
     else:
         dataset = MultiLeRobotDataset(
@@ -104,6 +105,7 @@ def make_dataset(cfg, split: str = "train") -> LeRobotDataset | MultiLeRobotData
             delta_timestamps=cfg.training.get("delta_timestamps"),
             image_transforms=image_transforms,
             video_backend=cfg.video_backend,
+            local_files_only=(LEROBOT_HOME / cfg.dataset_repo_id).exists(),
         )
 
     if cfg.get("override_dataset_stats"):

--- a/lerobot/templates/visualize_dataset_homepage.html
+++ b/lerobot/templates/visualize_dataset_homepage.html
@@ -7,7 +7,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>
-<body class="h-screen overflow-hidden font-mono text-white" x-data="{ 
+<body class="h-screen overflow-hidden font-mono text-white" x-data="{
     inputValue: '',
     navigateToDataset() {
         const trimmedValue = this.inputValue.trim();
@@ -40,14 +40,14 @@
             </div>
         </div>
         <div class="flex w-full max-w-lg px-4 mb-4">
-            <input 
-                type="text" 
+            <input
+                type="text"
                 x-model="inputValue"
                 @keyup.enter="navigateToDataset"
                 placeholder="enter dataset id (ex: lerobot/droid_100)"
                 class="flex-grow px-4 py-2 rounded-l bg-white bg-opacity-20 text-white placeholder-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-300"
             >
-            <button 
+            <button
                 @click="navigateToDataset"
                 class="px-4 py-2 bg-blue-500 text-white rounded-r hover:bg-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-300"
             >


### PR DESCRIPTION
## What this does
Explain what this PR does. Feel free to tag your PR with the appropriate label(s).

Use local lerobot dataset if it exists.

Case happened when we recorded dataset with `--push-to-hub 0 --local-files-only 1` and then want to train with it, without this change, there could be exception like:

```bash
huggingface_hub.errors.RepositoryNotFoundError: 401 Client Error. (Request ID: Root=1-67726fa1-235cf0064b60bb1e645fb4cf;f9c85308-8970-46a9-bfbb-5a760a981530)
```

which is caused by default `local_files_only=False` in class `LeRobotDataset` .


Examples:
|  Title               | Label           |
|----------------------|-----------------|
| Enhance     | Use existing local recorded dataset if exist   |

## How it was tested
Explain/show how you tested your changes.

- No current tests breaking

## How to checkout & try? (for the reviewer)
Provide a simple way for the reviewer to try out your changes.

Examples with SO100:

1. Record dataset
```bash
python lerobot/scripts/control_robot.py record \
  --robot-path lerobot/configs/robot/so100.yaml \
  --single-task "SO100 pick and place" \
  --fps 30 \
  --repo-id xuaner233/so100_pick_and_place \
  --tags "so100 pick" \
  --warmup-time-s 5 \
  --episode-time-s 30 \
  --reset-time-s 10 \
  --num-episodes 2 \
  --push-to-hub 0 \
  --local-files-only 1
```

2. Then trying to train with just recorded dataset:
```bash
python lerobot/scripts/train.py \
    dataset_repo_id=xuaner233/so100_pick_and_place \
    policy=act_so100_real \
    env=so100_real \
    hydra.run.dir=outputs/train/act_so100_pick_and_place \
    hydra.job.name=act_so100_pick_and_place \
    device=cuda
```
