### PR TITLE
fix(visualise): use correct language description for each episode id

### DIFF
--- a/lerobot/scripts/visualize_dataset_html.py
+++ b/lerobot/scripts/visualize_dataset_html.py
@@ -177,7 +177,7 @@ def run_server(
                 {"url": url_for("static", filename=video_path), "filename": video_path.parent.name}
                 for video_path in video_paths
             ]
-            tasks = dataset.meta.episodes[0]["tasks"]
+            tasks = dataset.meta.episodes[episode_id]["tasks"]
         else:
             video_keys = [key for key, ft in dataset.features.items() if ft["dtype"] == "video"]
             videos_info = [


### PR DESCRIPTION
## What this does

When visualising datasets (v2) that contain a language instruction, the instruction of the first episode is always used. This is confusing when trying to use multi-task datasets, and this PR fixes it.

## How it was tested

using the visualise dataset command.

## How to checkout & try? (for the reviewer)

visualise a dataset that contains different language descriptions, for example the following:

```bash
python lerobot/scripts/visualize_dataset_html.py --repo-id villekuosmanen/pick_up_lid
```
