### PR TITLE
typo fix: batch_convert_dataset_v1_to_v2.py

### DIFF
--- a/lerobot/common/datasets/v2/batch_convert_dataset_v1_to_v2.py
+++ b/lerobot/common/datasets/v2/batch_convert_dataset_v1_to_v2.py
@@ -159,11 +159,11 @@ DATASETS = {
         **ALOHA_STATIC_INFO,
     },
     "aloha_static_vinh_cup": {
-        "single_task": "Pick up the platic cup with the right arm, then pop its lid open with the left arm.",
+        "single_task": "Pick up the plastic cup with the right arm, then pop its lid open with the left arm.",
         **ALOHA_STATIC_INFO,
     },
     "aloha_static_vinh_cup_left": {
-        "single_task": "Pick up the platic cup with the left arm, then pop its lid open with the right arm.",
+        "single_task": "Pick up the plastic cup with the left arm, then pop its lid open with the right arm.",
         **ALOHA_STATIC_INFO,
     },
     "aloha_static_ziploc_slide": {"single_task": "Slide open the ziploc bag.", **ALOHA_STATIC_INFO},


### PR DESCRIPTION
fix: typo "platic" to "plastic" in dataset descriptions  

Fixed typo in "aloha_static_vinh_cup" dataset description: "platic" -> "plastic"  

Fixed typo in "aloha_static_vinh_cup_left" dataset description: "platic" -> "plastic"  

### What this does  
This PR corrects a minor typo in the task descriptions for two datasets:  
- **"aloha_static_vinh_cup"**: Changed "platic" to "plastic"  
- **"aloha_static_vinh_cup_left"**: Changed "platic" to "plastic"  

These updates ensure the descriptions are accurate and professional. Tagging this as a **🐛 Bug** fix.

### How it was tested  
The changes were manually verified by reviewing the updated dataset descriptions to ensure the typo was corrected. No additional code was modified, so functionality remains unaffected.

### How to checkout & try? (for the reviewer)  
1. Pull the branch with this fix.  
2. Open the affected dataset descriptions in `lerobot/configs/robot/aloha.yaml` or related script outputs.  
3. Confirm that the term "platic" has been corrected to "plastic" in both entries.  

---

Note: This is a straightforward typo fix with no functional impact, and no additional tests are required.  