### PR TITLE
Extend reward classifier for multiple camera views

### DIFF
--- a/lerobot/common/logger.py
+++ b/lerobot/common/logger.py
@@ -25,13 +25,13 @@ from glob import glob
 from pathlib import Path
 
 import torch
+import wandb
 from huggingface_hub.constants import SAFETENSORS_SINGLE_FILE
 from omegaconf import DictConfig, OmegaConf
 from termcolor import colored
 from torch.optim import Optimizer
 from torch.optim.lr_scheduler import LRScheduler
 
-import wandb
 from lerobot.common.policies.policy_protocol import Policy
 from lerobot.common.utils.utils import get_global_random_state, set_global_random_state
 

--- a/lerobot/common/policies/hilserl/classifier/configuration_classifier.py
+++ b/lerobot/common/policies/hilserl/classifier/configuration_classifier.py
@@ -13,6 +13,7 @@ class ClassifierConfig:
     model_name: str = "microsoft/resnet-50"
     device: str = "cpu"
     model_type: str = "cnn"  # "transformer" or "cnn"
+    num_cameras: int = 2
 
     def save_pretrained(self, save_dir):
         """Save config to json file."""

--- a/lerobot/common/robot_devices/control_utils.py
+++ b/lerobot/common/robot_devices/control_utils.py
@@ -11,6 +11,7 @@ from copy import copy
 from functools import cache
 
 import cv2
+import numpy as np
 import torch
 import tqdm
 from deepdiff import DeepDiff
@@ -330,6 +331,14 @@ def reset_environment(robot, events, reset_time_s):
             if events["exit_early"]:
                 events["exit_early"] = False
                 break
+
+
+def reset_follower_position(robot: Robot, target_position):
+    current_position = robot.follower_arms["main"].read("Present_Position")
+    trajectory = torch.from_numpy(np.linspace(current_position, target_position, 30)) # NOTE: 30 is just an aribtrary number 
+    for pose in trajectory:
+        robot.send_action(pose)
+        busy_wait(0.015)
 
 
 def stop_recording(robot, listener, display_cameras):

--- a/lerobot/configs/policy/hilserl_classifier.yaml
+++ b/lerobot/configs/policy/hilserl_classifier.yaml
@@ -35,6 +35,7 @@ policy:
   name: "hilserl/classifier/pick_place_lego_cube_1"
   model_name: "facebook/convnext-base-224"
   model_type: "cnn"
+  num_cameras: 2 # Has to be len(training.image_keys)
 
 wandb:
   enable: false

--- a/lerobot/configs/policy/hilserl_classifier.yaml
+++ b/lerobot/configs/policy/hilserl_classifier.yaml
@@ -4,7 +4,7 @@ defaults:
   - _self_
 
 seed: 13
-dataset_repo_id: "dataset_repo_id"
+dataset_repo_id: aractingi/pick_place_lego_cube_1
 train_split_proportion: 0.8
 
 # Required by logger
@@ -24,7 +24,7 @@ training:
   eval_freq: 1  # How often to run validation (in epochs)
   save_freq: 1  # How often to save checkpoints (in epochs)
   save_checkpoint: true
-  image_key: "observation.images.phone"
+  image_keys: ["observation.images.top", "observation.images.wrist"]
   label_key: "next.reward"
 
 eval:
@@ -32,7 +32,7 @@ eval:
   num_samples_to_log: 30  # Number of validation samples to log in the table
 
 policy:
-  name: "hilserl/classifier"
+  name: "hilserl/classifier/pick_place_lego_cube_1"
   model_name: "facebook/convnext-base-224"
   model_type: "cnn"
 
@@ -44,4 +44,4 @@ wandb:
 
 device: "mps"
 resume: false
-output_dir: "output"
+output_dir: "outputs/classifier"

--- a/lerobot/scripts/control_robot.py
+++ b/lerobot/scripts/control_robot.py
@@ -109,6 +109,7 @@ from lerobot.common.robot_devices.control_utils import (
     log_control_info,
     record_episode,
     reset_environment,
+    reset_follower_position,
     sanity_check_dataset_name,
     sanity_check_dataset_robot_compatibility,
     stop_recording,
@@ -205,6 +206,7 @@ def record(
     num_image_writer_threads_per_camera: int = 4,
     display_cameras: bool = True,
     play_sounds: bool = True,
+    reset_follower: bool = False, 
     resume: bool = False,
     # TODO(rcadene, aliberts): remove local_files_only when refactor with dataset as argument
     local_files_only: bool = False,
@@ -265,6 +267,9 @@ def record(
         robot.connect()
     listener, events = init_keyboard_listener(assign_rewards=assign_rewards)
 
+    if reset_follower:
+        initial_position = robot.follower_arms["main"].read("Present_Position")
+        
     # Execute a few seconds without recording to:
     # 1. teleoperate the robot to move it in starting position if no policy provided,
     # 2. give times to the robot devices to connect and start synchronizing,
@@ -307,6 +312,8 @@ def record(
             (dataset.num_episodes < num_episodes - 1) or events["rerecord_episode"]
         ):
             log_say("Reset the environment", play_sounds)
+            if reset_follower:
+                reset_follower_position(robot, initial_position)
             reset_environment(robot, events, reset_time_s)
 
         if events["rerecord_episode"]:
@@ -526,6 +533,12 @@ if __name__ == "__main__":
         type=int,
         default=0,
         help="Enables the assignation of rewards to frames (by default no assignation). When enabled, assign a 0 reward to frames until the space bar is pressed which assign a 1 reward. Press the space bar a second time to assign a 0 reward. The reward assigned is reset to 0 when the episode ends.",
+    )
+    parser_record.add_argument(
+        "--reset-follower",
+        type=int,
+        default=0,
+        help="Resets the follower to the initial position during while reseting the evironment, this is to avoid having the follower start at an awkward position in the next episode",
     )
 
     parser_replay = subparsers.add_parser("replay", parents=[base_parser])

--- a/lerobot/scripts/eval_on_robot.py
+++ b/lerobot/scripts/eval_on_robot.py
@@ -39,7 +39,6 @@ for running training on the real robot.
 import argparse
 import logging
 import time
-from copy import deepcopy
 
 import cv2
 import numpy as np
@@ -106,6 +105,7 @@ def rollout(
     Returns:
         The dictionary described above.
     """
+    # TODO (michel-aractingi): Infer the device from policy parameters when policy is added
     # assert isinstance(policy, nn.Module), "Policy must be a PyTorch nn module."
     # device = get_device_from_parameters(policy)
 
@@ -155,7 +155,6 @@ def rollout(
                 cv2.waitKey(1)
             images.append(observation[key].to("mps"))
 
-        
         reward = reward_classifier.predict_reward(images) if reward_classifier is not None else 0.0
         all_rewards.append(reward)
 
@@ -372,10 +371,9 @@ if __name__ == "__main__":
     parser.add_argument(
         "--reward-classifier-config-file",
         type=str,
-        default=None, 
+        default=None,
         help="Path to a yaml config file that is necessary to build the reward classifier model.",
     )
-
 
     args = parser.parse_args()
 

--- a/lerobot/scripts/train_hilserl_classifier.py
+++ b/lerobot/scripts/train_hilserl_classifier.py
@@ -47,7 +47,6 @@ from lerobot.common.utils.utils import (
 
 def get_model(cfg, logger):  # noqa I001
     classifier_config = _policy_cfg_from_hydra_cfg(ClassifierConfig, cfg)
-    classifier_config.num_cameras = len(cfg.training.image_keys)
     model = Classifier(classifier_config)
     if cfg.resume:
         model.load_state_dict(Classifier.from_pretrained(str(logger.last_pretrained_model_dir)).state_dict())


### PR DESCRIPTION
# What this does
(A) This PR adds the possibility to train the reward classifier with multiple camera images. The architecture includes:
1- one pretrained resnet encoder for all images (with frozen parameters)
2- each image is passed through the encoder to get a compressed representation.
3- The representations are concatenated and passed through an MLP that will be trained to predict the reward. 

(B) This PR also extends the `eval_on_robot.py` script to load the reward classifier and the label each timestep with the predicted reward in real-time. 

(C) in `lerobot/common/robot_devices/control_utils.py` a new function to reset the follower arm to the initial position it was in at the start of the control. This is important for collecting a dataset with rewards so we don't get redundant frames in the trajectory (related to manually reseting the robot) after the task has terminated.

# How to test
- Collect a dataset with your robot #528 .
- Train a reward classifier with `lerobot/scripts/train_hilserl_classifier.py`
- Test the reward classifier with `eval_on_robot.py`, example:
```
python lerobot/scripts/eval_on_robot.py \
    --robot-path lerobot/configs/robot/so100.yaml \
    --reward-classifier-pretrained-path outputs/classifier/checkpoints/best/pretrained_model \
    --reward-classifier-config-file lerobot/configs/policy/hilserl_classifier.yaml \
    --display-cameras 1
```

**NOTE** you can use a dataset I collected with so100 `aractingi/pick_place_lego_cube_1`
