### PR TITLE
typo fix: example_1 python script

### DIFF
--- a/examples/1_load_lerobot_dataset.py
+++ b/examples/1_load_lerobot_dataset.py
@@ -105,7 +105,7 @@ print(dataset.features[camera_key]["shape"])
 delta_timestamps = {
     # loads 4 images: 1 second before current frame, 500 ms before, 200 ms before, and current frame
     camera_key: [-1, -0.5, -0.20, 0],
-    # loads 8 state vectors: 1.5 seconds before, 1 second before, ... 200 ms, 100 ms, and current frame
+    # loads 6 state vectors: 1.5 seconds before, 1 second before, ... 200 ms, 100 ms, and current frame
     "observation.state": [-1.5, -1, -0.5, -0.20, -0.10, 0],
     # loads 64 action vectors: current frame, 1 frame in the future, 2 frames, ... 63 frames in the future
     "action": [t / dataset.fps for t in range(64)],
@@ -129,6 +129,6 @@ dataloader = torch.utils.data.DataLoader(
 
 for batch in dataloader:
     print(f"{batch[camera_key].shape=}")  # (32, 4, c, h, w)
-    print(f"{batch['observation.state'].shape=}")  # (32, 5, c)
+    print(f"{batch['observation.state'].shape=}")  # (32, 6, c)
     print(f"{batch['action'].shape=}")  # (32, 64, c)
     break


### PR DESCRIPTION
## What this does
Fixes typos in the code comments of `examples/1_load_lerobot_dataset.py`. There should be 6 state vectors rather than 8 after [this PR](https://github.com/huggingface/lerobot/pull/461/files#diff-724de84dd7a2b7c496a8efa58ce9074d2d820062176ee9d115cdbc0060af4d46R108-R109) was merged previously, and code comments should to be updated accordingly.

## How it was tested
Only changed code comments with no functional impact, so did not run or write additional tests. Ran `python3 1_load_lerobot_dataset.py` to confirm it matches the comments.

## How to checkout & try? (for the reviewer)
1. For the first changed line - relatively straightforward comment change, since there are only 6 elements in the vector that follows.
2. For the second changed line, run :
```
python3 1_load_lerobot_dataset.py
```
and you'll see the printout corresponded to the changed line is actually
```
batch['observation.state'].shape=torch.Size([32, 6, 14])
```