### PR TITLE
Fix for the issue https://github.com/huggingface/lerobot/issues/638

### DIFF
--- a/lerobot/scripts/control_robot.py
+++ b/lerobot/scripts/control_robot.py
@@ -300,7 +300,7 @@ def record(
         # TODO(rcadene): add an option to enable teleoperation during reset
         # Skip reset for the last episode to be recorded
         if not events["stop_recording"] and (
-            (dataset.num_episodes < num_episodes - 1) or events["rerecord_episode"]
+            (recorded_episodes < num_episodes - 1) or events["rerecord_episode"]
         ):
             log_say("Reset the environment", play_sounds)
             reset_environment(robot, events, reset_time_s)


### PR DESCRIPTION
When resuming a dataset creation, the reset environment code is skipped and this simple code change fixes the issue.

## What this does
Simple fix for the issue reported in https://github.com/huggingface/lerobot/issues/638

## How it was tested
I attempted the second step in the repro that was showing the unexpected behavior with my fix and now it's behaving as expected. The code change is simple, intuitive and likely the expected code.

## How to checkout & try? (for the reviewer)
Try the repro in the issue and then either checkout my branch or locally make the fix to verify.