### PR TITLE
Fix: Add support for str imgs_dir in encode_video_frames

### DIFF
--- a/lerobot/common/datasets/video_utils.py
+++ b/lerobot/common/datasets/video_utils.py
@@ -140,6 +140,7 @@ def encode_video_frames(
     overwrite: bool = False,
 ) -> None:
     """More info on ffmpeg arguments tuning on `benchmark/video/README.md`"""
+    imgs_dir = Path(imgs_dir)
     video_path = Path(video_path)
     video_path.parent.mkdir(parents=True, exist_ok=True)
 


### PR DESCRIPTION
## What this does

Hey! 

The parameter `imgs_dir`  was typed as a str or Path, but the function doesn't work if `imgs_dir` is not a Path due to line below:

```
("-i", str(imgs_dir / "frame_%06d.png")),
```

This PR fixes this by casting `imgs_dir` to a Path.

## How it was tested

mypy