### PR TITLE
[Port HIL-SERL] Add HF vision encoder option in SAC

### DIFF
--- a/lerobot/common/datasets/factory.py
+++ b/lerobot/common/datasets/factory.py
@@ -74,7 +74,23 @@ def make_dataset(cfg, split: str = "train") -> LeRobotDataset | MultiLeRobotData
 
     image_transforms = None
     if cfg.training.image_transforms.enable:
-        cfg_tf = cfg.training.image_transforms
+        default_tf = OmegaConf.create(
+            {
+                "brightness": {"weight": 0.0, "min_max": None},
+                "contrast": {"weight": 0.0, "min_max": None},
+                "saturation": {"weight": 0.0, "min_max": None},
+                "hue": {"weight": 0.0, "min_max": None},
+                "sharpness": {"weight": 0.0, "min_max": None},
+                "max_num_transforms": None,
+                "random_order": False,
+                "image_size": None,
+                "interpolation": None,
+                "normalization_means": None,
+                "normalization_std": None,
+            }
+        )
+        cfg_tf = OmegaConf.merge(OmegaConf.create(default_tf), cfg.training.image_transforms)
+
         image_transforms = get_image_transforms(
             brightness_weight=cfg_tf.brightness.weight,
             brightness_min_max=cfg_tf.brightness.min_max,
@@ -88,6 +104,10 @@ def make_dataset(cfg, split: str = "train") -> LeRobotDataset | MultiLeRobotData
             sharpness_min_max=cfg_tf.sharpness.min_max,
             max_num_transforms=cfg_tf.max_num_transforms,
             random_order=cfg_tf.random_order,
+            image_size=(cfg_tf.image_size.height, cfg_tf.image_size.width) if cfg_tf.image_size else None,
+            interpolation=cfg_tf.interpolation,
+            normalization_means=cfg_tf.normalization_means,
+            normalization_std=cfg_tf.normalization_std,
         )
 
     if isinstance(cfg.dataset_repo_id, str):

--- a/lerobot/common/datasets/factory.py
+++ b/lerobot/common/datasets/factory.py
@@ -85,8 +85,8 @@ def make_dataset(cfg, split: str = "train") -> LeRobotDataset | MultiLeRobotData
                 "random_order": False,
                 "image_size": None,
                 "interpolation": None,
-                "normalization_means": None,
-                "normalization_std": None,
+                "image_mean": None,
+                "image_std": None,
             }
         )
         cfg_tf = OmegaConf.merge(OmegaConf.create(default_tf), cfg.training.image_transforms)
@@ -106,8 +106,8 @@ def make_dataset(cfg, split: str = "train") -> LeRobotDataset | MultiLeRobotData
             random_order=cfg_tf.random_order,
             image_size=(cfg_tf.image_size.height, cfg_tf.image_size.width) if cfg_tf.image_size else None,
             interpolation=cfg_tf.interpolation,
-            normalization_means=cfg_tf.normalization_means,
-            normalization_std=cfg_tf.normalization_std,
+            image_mean=cfg_tf.image_mean,
+            image_std=cfg_tf.image_std,
         )
 
     if isinstance(cfg.dataset_repo_id, str):

--- a/lerobot/common/datasets/transforms.py
+++ b/lerobot/common/datasets/transforms.py
@@ -150,6 +150,10 @@ def get_image_transforms(
     sharpness_min_max: tuple[float, float] | None = None,
     max_num_transforms: int | None = None,
     random_order: bool = False,
+    interpolation: str | None = None,
+    image_size: tuple[int, int] | None = None,
+    normalization_means: list[float] | None = None,
+    normalization_std: list[float] | None = None,
 ):
     def check_value(name, weight, min_max):
         if min_max is not None:
@@ -170,6 +174,18 @@ def get_image_transforms(
 
     weights = []
     transforms = []
+    if image_size is not None:
+        interpolations = [interpolation.value for interpolation in v2.InterpolationMode]
+        if interpolation is None:
+            # Use BICUBIC as default interpolation
+            interpolation_mode = v2.InterpolationMode.BICUBIC
+        elif interpolation in interpolations:
+            interpolation_mode = v2.InterpolationMode(interpolation)
+        else:
+            raise ValueError("The interpolation passed is not supported")
+        # Weight for resizing is always 1
+        weights.append(1.0)
+        transforms.append(v2.Resize(size=(image_size[0], image_size[1]), interpolation=interpolation_mode))
     if brightness_min_max is not None and brightness_weight > 0.0:
         weights.append(brightness_weight)
         transforms.append(v2.ColorJitter(brightness=brightness_min_max))
@@ -185,6 +201,15 @@ def get_image_transforms(
     if sharpness_min_max is not None and sharpness_weight > 0.0:
         weights.append(sharpness_weight)
         transforms.append(SharpnessJitter(sharpness=sharpness_min_max))
+    if normalization_means is not None and normalization_std is not None:
+        # Weight for normalization is always 1
+        weights.append(1.0)
+        transforms.append(
+            v2.Normalize(
+                mean=normalization_means,
+                std=normalization_std,
+            )
+        )
 
     n_subset = len(transforms)
     if max_num_transforms is not None:

--- a/lerobot/common/datasets/transforms.py
+++ b/lerobot/common/datasets/transforms.py
@@ -152,8 +152,8 @@ def get_image_transforms(
     random_order: bool = False,
     interpolation: str | None = None,
     image_size: tuple[int, int] | None = None,
-    normalization_means: list[float] | None = None,
-    normalization_std: list[float] | None = None,
+    image_mean: list[float] | None = None,
+    image_std: list[float] | None = None,
 ):
     def check_value(name, weight, min_max):
         if min_max is not None:
@@ -201,13 +201,13 @@ def get_image_transforms(
     if sharpness_min_max is not None and sharpness_weight > 0.0:
         weights.append(sharpness_weight)
         transforms.append(SharpnessJitter(sharpness=sharpness_min_max))
-    if normalization_means is not None and normalization_std is not None:
+    if image_mean is not None and image_std is not None:
         # Weight for normalization is always 1
         weights.append(1.0)
         transforms.append(
             v2.Normalize(
-                mean=normalization_means,
-                std=normalization_std,
+                mean=image_mean,
+                std=image_std,
             )
         )
 

--- a/lerobot/common/policies/sac/configuration_sac.py
+++ b/lerobot/common/policies/sac/configuration_sac.py
@@ -27,34 +27,6 @@ class SACConfig:
             "observation.state": [4],
         }
     )
-
-    output_shapes: dict[str, list[int]] = field(
-        default_factory=lambda: {
-            "action": [2],
-        }
-    )
-
-    # Normalization / Unnormalization
-    input_normalization_modes: dict[str, str] = field(
-        default_factory=lambda: {
-            "observation.image": "mean_std",
-            "observation.state": "min_max",
-            "observation.environment_state": "min_max",
-        }
-    )
-    output_normalization_modes: dict[str, str] = field(
-        default_factory=lambda: {"action": "min_max"},
-    )
-from dataclasses import dataclass, field
-
-@dataclass
-class SACConfig:
-    input_shapes: dict[str, list[int]] = field(
-        default_factory=lambda: {
-            "observation.image": [3, 84, 84],
-            "observation.state": [4],
-        }
-    )
     output_shapes: dict[str, list[int]] = field(
         default_factory=lambda: {
             "action": [2],
@@ -67,11 +39,10 @@ class SACConfig:
             "observation.environment_state": "min_max",
         }
     )
-    output_normalization_modes: dict[str, str] = field(
-        default_factory=lambda: {"action": "min_max"}
-    )
+    output_normalization_modes: dict[str, str] = field(default_factory=lambda: {"action": "min_max"})
 
     # Add type annotations for these fields:
+    vision_encoder_name: str = field(default="microsoft/resnet-18")
     image_encoder_hidden_dim: int = 32
     shared_encoder: bool = False
     discount: float = 0.99

--- a/lerobot/common/policies/sac/modeling_sac.py
+++ b/lerobot/common/policies/sac/modeling_sac.py
@@ -425,10 +425,12 @@ class SACObservationEncoder(nn.Module):
         """
         super().__init__()
         self.config = config
+        self.has_pretrained_vision_encoder = False
         if "observation.image" in config.input_shapes:
             self.camera_number = config.camera_number
             self.aggregation_size: int = 0
             if self.config.vision_encoder_name is not None:
+                self.has_pretrained_vision_encoder = True
                 self.image_enc_layers, self.image_enc_out_shape = self._load_pretrained_vision_encoder()
                 self.freeze_encoder()
                 self.image_enc_proj = nn.Sequential(
@@ -529,7 +531,7 @@ class SACObservationEncoder(nn.Module):
         # Concatenate all images along the channel dimension.
         image_keys = [k for k in self.config.input_shapes if k.startswith("observation.image")]
         for image_key in image_keys:
-            if self.config.vision_encoder_name is not None:
+            if self.has_pretrained_vision_encoder:
                 enc_feat = self.image_enc_layers(obs_dict[image_key]).pooler_output
                 enc_feat = self.image_enc_proj(enc_feat.view(enc_feat.shape[0], -1))
             else:

--- a/lerobot/common/policies/sac/modeling_sac.py
+++ b/lerobot/common/policies/sac/modeling_sac.py
@@ -434,6 +434,11 @@ class SACObservationEncoder(nn.Module):
             if self.config.vision_encoder_name is not None:
                 self.image_enc_layers, self.image_enc_out_shape = self._load_pretrained_vision_encoder()
                 self.freeze_encoder()
+                self.image_enc_proj = nn.Sequential(
+                    nn.Linear(np.prod(self.image_enc_out_shape), config.latent_dim),
+                    nn.LayerNorm(config.latent_dim),
+                    nn.Tanh(),
+                )
             else:
                 self.image_enc_layers = nn.Sequential(
                     nn.Conv2d(
@@ -453,12 +458,14 @@ class SACObservationEncoder(nn.Module):
                 dummy_batch = torch.zeros(1, *config.input_shapes["observation.image"])
                 with torch.inference_mode():
                     self.image_enc_out_shape = self.image_enc_layers(dummy_batch).shape[1:]
-                self.image_enc_layers.extend(nn.Sequential(nn.Flatten()))
-            self.image_enc_proj = nn.Sequential(
-                nn.Linear(np.prod(self.image_enc_out_shape), config.latent_dim),
-                nn.LayerNorm(config.latent_dim),
-                nn.Tanh(),
-            )
+                self.image_enc_layers.extend(
+                    nn.Sequential(
+                        nn.Flatten(),
+                        nn.Linear(np.prod(self.image_enc_out_shape), config.latent_dim),
+                        nn.LayerNorm(config.latent_dim),
+                        nn.Tanh(),
+                    )
+                )
         if "observation.state" in config.input_shapes:
             self.state_enc_layers = nn.Sequential(
                 nn.Linear(config.input_shapes["observation.state"][0], config.latent_dim),

--- a/lerobot/common/policies/sac/modeling_sac.py
+++ b/lerobot/common/policies/sac/modeling_sac.py
@@ -454,12 +454,10 @@ class SACObservationEncoder(nn.Module):
                 with torch.inference_mode():
                     self.image_enc_out_shape = self.image_enc_layers(dummy_batch).shape[1:]
                 self.image_enc_layers.extend(nn.Sequential(nn.Flatten()))
-            self.image_enc_layers.extend(
-                nn.Sequential(
-                    nn.Linear(np.prod(self.image_enc_out_shape), config.latent_dim),
-                    nn.LayerNorm(config.latent_dim),
-                    nn.Tanh(),
-                )
+            self.image_enc_proj = nn.Sequential(
+                nn.Linear(np.prod(self.image_enc_out_shape), config.latent_dim),
+                nn.LayerNorm(config.latent_dim),
+                nn.Tanh(),
             )
         if "observation.state" in config.input_shapes:
             self.state_enc_layers = nn.Sequential(

--- a/lerobot/common/policies/sac/modeling_sac.py
+++ b/lerobot/common/policies/sac/modeling_sac.py
@@ -477,10 +477,10 @@ class SACObservationEncoder(nn.Module):
     def _load_pretrained_vision_encoder(self):
         """Set up CNN encoder"""
         self.image_enc_layers = AutoModel.from_pretrained(self.config.vision_encoder_name)
-        if hasattr(self.image_enc_layers, "fc"):
-            self.image_enc_out_shape = self.image_enc_layers.fc.in_features
-        elif hasattr(self.image_enc_layers.config, "hidden_sizes"):
+        if hasattr(self.image_enc_layers.config, "hidden_sizes"):
             self.image_enc_out_shape = self.image_enc_layers.config.hidden_sizes[-1]  # Last channel dimension
+        elif hasattr(self.image_enc_layers, "fc"):
+            self.image_enc_out_shape = self.image_enc_layers.fc.in_features
         else:
             raise ValueError("Unsupported vision encoder architecture, make sure you are using a CNN")
         return self.image_enc_layers, self.image_enc_out_shape

--- a/lerobot/common/policies/sac/modeling_sac.py
+++ b/lerobot/common/policies/sac/modeling_sac.py
@@ -475,15 +475,13 @@ class SACObservationEncoder(nn.Module):
 
     def _setup_cnn_backbone(self):
         """Set up CNN encoder"""
-        # Initializing a timm backbone
         self.image_enc_layers = AutoModel.from_pretrained(self.config.vision_encoder_name)
         if hasattr(self.image_enc_layers, "fc"):
             self.image_enc_out_shape = self.image_enc_layers.fc.in_features
         elif hasattr(self.image_enc_layers.config, "hidden_sizes"):
             self.image_enc_out_shape = self.image_enc_layers.config.hidden_sizes[-1]  # Last channel dimension
         else:
-            raise ValueError("Unsupported architecture, make sure you are using a CNN")
-        # self.image_enc_layers = nn.Sequential(*list(self.image_enc_layers.children()))
+            raise ValueError("Unsupported vision encoder architecture, make sure you are using a CNN")
         self.image_enc_layers = self.image_enc_layers.to(self.config.device)
         self.freeze_encoder()
         return self.image_enc_layers, self.image_enc_out_shape

--- a/lerobot/common/policies/sac/modeling_sac.py
+++ b/lerobot/common/policies/sac/modeling_sac.py
@@ -432,7 +432,8 @@ class SACObservationEncoder(nn.Module):
 
         if "observation.image" in config.input_shapes:
             if self.config.vision_encoder_name is not None:
-                self.image_enc_layers, self.image_enc_out_shape = self._setup_cnn_backbone()
+                self.image_enc_layers, self.image_enc_out_shape = self._load_pretrained_vision_encoder()
+                self.freeze_encoder()
             else:
                 self.image_enc_layers = nn.Sequential(
                     nn.Conv2d(
@@ -473,7 +474,7 @@ class SACObservationEncoder(nn.Module):
                 nn.Tanh(),
             )
 
-    def _setup_cnn_backbone(self):
+    def _load_pretrained_vision_encoder(self):
         """Set up CNN encoder"""
         self.image_enc_layers = AutoModel.from_pretrained(self.config.vision_encoder_name)
         if hasattr(self.image_enc_layers, "fc"):
@@ -482,8 +483,6 @@ class SACObservationEncoder(nn.Module):
             self.image_enc_out_shape = self.image_enc_layers.config.hidden_sizes[-1]  # Last channel dimension
         else:
             raise ValueError("Unsupported vision encoder architecture, make sure you are using a CNN")
-        self.image_enc_layers = self.image_enc_layers.to(self.config.device)
-        self.freeze_encoder()
         return self.image_enc_layers, self.image_enc_out_shape
 
     def freeze_encoder(self):


### PR DESCRIPTION
## What this does
Adds a pretrained vision encoder from HF to the sac modeling + allows for appropriate transforms when training.

## How it was tested
Ran a sac training with moss. 
My sac training script and associated modeling have slight differences, so it would be good to double check with a training loop incorporating real images and the current sac training script.
