### PR TITLE
Store homing after autocorrect calib

### DIFF
--- a/lerobot/common/robot_devices/motors/feetech.py
+++ b/lerobot/common/robot_devices/motors/feetech.py
@@ -586,9 +586,6 @@ class FeetechMotorsBus:
                 # Once autocorrect calibration is done, also store the new homing_offset in yaml
                 if self.calibration_file is not None:
                     calibration = self.calibration
-                    print(
-                        f"Adjusting and storing homing calibration on axis '{calib_idx}' after triggering autocorrect_calibration"
-                    )
                     self.calibration_file.parent.mkdir(parents=True, exist_ok=True)
                     with open(self.calibration_file, "w") as f:
                         json.dump(calibration, f)

--- a/lerobot/common/robot_devices/robots/manipulator.py
+++ b/lerobot/common/robot_devices/robots/manipulator.py
@@ -384,14 +384,14 @@ class ManipulatorRobot:
                 with open(arm_calib_path, "w") as f:
                     json.dump(calibration, f)
 
-            return calibration
+            return calibration, arm_calib_path
 
         for name, arm in self.follower_arms.items():
-            calibration = load_or_run_calibration_(name, arm, "follower")
-            arm.set_calibration(calibration)
+            calibration, arm_calib_path = load_or_run_calibration_(name, arm, "follower")
+            arm.set_calibration(calibration, calibration_file=arm_calib_path)
         for name, arm in self.leader_arms.items():
-            calibration = load_or_run_calibration_(name, arm, "leader")
-            arm.set_calibration(calibration)
+            calibration, arm_calib_path = load_or_run_calibration_(name, arm, "leader")
+            arm.set_calibration(calibration, calibration_file=arm_calib_path)
 
     def set_koch_robot_preset(self):
         def set_operating_mode_(arm):


### PR DESCRIPTION
## What this does
Make sure all homing values are stored after autocorrect_calibration() is called. Once it stored and correct in the yaml there shouldn't be a problem with this anymore. This ensures all motors operate in the same half-turn window when you later do a teleop mapping like pos_leader = pos_follower.

When this happens:
- When the homing of leader and follower per motor is wrong then the teleoperation fails because the motors are both operating in different "-180 <-> +180" or "-2048 <-> 2048"  ranges. Then that leader motor will try to match the follower in the wrong range and either slap forward against a table etc to backward towards it's own base. 
- The autocorrect_calibration will notice a large jump and correct this by adding or subtracting 4096 to the specific homing offset of that motor but this PR also stores this value in the yaml.

Why this happens:
If the motors are not mounted exactly according to instructions  and the calibration is not done precisely at the 90 degree angle, then it can happen that in the calibration difference (homing) both operate in different  "-180 <-> +180" ranges. When in the read() method, apply_calibration() is called. The following will be calculated; Example:

homing_follower_motor[i] = 3170
homing_leader_motor[i] = 1026
direction of both = 1

Current angle (rest position)
values_follower[i] = 1015
values_leader[i] = 2965

(Notice the difference = (3170-1026=2 144) > 2048)

`
if drive_mode:
                    values[i] *= -1
 `
values_follower[i] = 1015 * -1 =-1 015 
values_leader[i] = 2965 * -1=-2 965 

`
  values[i] += homing_offset
` 

values_follower[i]  =-1 015 + 3170 =2 155 
values_leader[i] =-2 965 + 1026 =-1 939 

`
values[i] = values[i] / (resolution // 2) * HALF_TURN_DEGREE
`

values_follower[i]  = (2155/2048)*180=189,404 
values_leader[I] = (-1 939/2048)*180=-170,42 

Now when teleop does, pos_leader = pos_follower, this gives the observed behavior because: 189 is not -170. 

This is fixed now in autocorrect_calibration(), Because if 4096 is added to the homing_leader_motor[i] = 1026.
1026+4096 = 5122, then you get (((5122*-1) + 3170)/2048) * 180 = -171,563  which is about the same as leader position (-170,42)

This PR fixes this beforehand during calibration by making sure that the homing_offset[I] is always between 2048 and -2048. In my example this would mean that 3170 would be adapted to -926, which corresponds to the correct angle (Basically the same is done in autocorrect_calibration() but during teleoperation). The autocorrect_calibration() should also be saved if applied to ensure that if the yaml is changed and the autocorrect still has to correct then that change should be saved to the yaml config. 

