### PR TITLE
Fix typos in `lerobot/scripts/visualize_dataset.py`

### DIFF
--- a/lerobot/scripts/visualize_dataset.py
+++ b/lerobot/scripts/visualize_dataset.py
@@ -15,14 +15,14 @@
 # limitations under the License.
 """ Visualize data of **all** frames of any episode of a dataset of type LeRobotDataset.
 
-Note: The last frame of the episode doesnt always correspond to a final state.
+Note: The last frame of the episode doesn't always correspond to a final state.
 That's because our datasets are composed of transition from state to state up to
 the antepenultimate state associated to the ultimate action to arrive in the final state.
 However, there might not be a transition from a final state to another state.
 
 Note: This script aims to visualize the data used to train the neural networks.
 ~What you see is what you get~. When visualizing image modality, it is often expected to observe
-lossly compression artifacts since these images have been decoded from compressed mp4 videos to
+lossy compression artifacts since these images have been decoded from compressed mp4 videos to
 save disk space. The compression factor applied has been tuned to not affect success rate.
 
 Examples:
@@ -199,7 +199,7 @@ def main():
         "--repo-id",
         type=str,
         required=True,
-        help="Name of hugging face repositery containing a LeRobotDataset dataset (e.g. `lerobot/pusht`).",
+        help="Name of hugging face repository containing a LeRobotDataset dataset (e.g. `lerobot/pusht`).",
     )
     parser.add_argument(
         "--episode-index",


### PR DESCRIPTION
## What this does
This commit addresses several typos in `lerobot/scripts/visualize_dataset.py`:
- "doesnt" → "doesn't" (line 18)
- "lossly" → "lossy" (line 25)
- "repositery" → "repository" (line 202)

## How it was tested
- Ran `python lerobot/scripts/visualize_dataset.py --repo-id lerobot/pusht --episode-index 0` locally to verify everything still works.
- Ran the test case of `lerobot/scripts/visualize_dataset.py` by running `pytest tests/test_visualize_dataset.py`.  
  - However, the test function `test_visualize_local_dataset` is currently skipped via `@pytest.mark.skip("TODO: add dummy videos")`. The test file still ensures that we can import the relevant modules by `from lerobot.scripts.visualize_dataset import visualize_dataset` without error.

## How to checkout & try? (for the reviewer)
- You can review the updated docstrings and help texts to ensure the spelling corrections are properly applied.
- ```bash
  python lerobot/scripts/visualize_dataset.py --repo-id lerobot/pusht --episode-index 0
  ```
- ```bash
  pytest tests/test_visualize_dataset.py
  ```