### PR TITLE
Check for "/" in feature names

### DIFF
--- a/lerobot/common/datasets/lerobot_dataset.py
+++ b/lerobot/common/datasets/lerobot_dataset.py
@@ -304,8 +304,18 @@ class LeRobotDatasetMetadata:
             )
         else:
             # TODO(aliberts, rcadene): implement sanity check for features
+            
+            # check if none of the features contains a "/" in their names,
+            # as this would break the dict flattening in the stats computation, which uses '/' as separator
+            for key in features:
+                    if "/" in key:
+                        raise ValueError(
+                            f"Feature names should not contain '/'. Found '/' in feature '{key}'."
+                        )
+                
             features = {**features, **DEFAULT_FEATURES}
 
+            
         obj.tasks, obj.stats, obj.episodes = {}, {}, []
         obj.info = create_empty_dataset_info(CODEBASE_VERSION, fps, robot_type, features, use_videos)
         if len(obj.video_keys) > 0 and not use_videos:

--- a/lerobot/common/datasets/lerobot_dataset.py
+++ b/lerobot/common/datasets/lerobot_dataset.py
@@ -304,18 +304,15 @@ class LeRobotDatasetMetadata:
             )
         else:
             # TODO(aliberts, rcadene): implement sanity check for features
-            
+
             # check if none of the features contains a "/" in their names,
             # as this would break the dict flattening in the stats computation, which uses '/' as separator
             for key in features:
-                    if "/" in key:
-                        raise ValueError(
-                            f"Feature names should not contain '/'. Found '/' in feature '{key}'."
-                        )
-                
+                if "/" in key:
+                    raise ValueError(f"Feature names should not contain '/'. Found '/' in feature '{key}'.")
+
             features = {**features, **DEFAULT_FEATURES}
 
-            
         obj.tasks, obj.stats, obj.episodes = {}, {}, []
         obj.info = create_empty_dataset_info(CODEBASE_VERSION, fps, robot_type, features, use_videos)
         if len(obj.video_keys) > 0 and not use_videos:

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -414,3 +414,16 @@ def test_create_branch():
 
     # Clean
     api.delete_repo(repo_id, repo_type=repo_type)
+
+
+
+def test_dataset_feature_with_forward_slash_raises_error():
+    # make sure dir does not exist
+    from lerobot.common.datasets.lerobot_dataset import LEROBOT_HOME
+    dataset_dir = LEROBOT_HOME / "lerobot/test/with/slash"
+    # make sure does not exist
+    if dataset_dir.exists():
+        dataset_dir.rmdir()
+    
+    with pytest.raises(ValueError):
+        LeRobotDataset.create(repo_id="lerobot/test/with/slash", fps=30, features= {"a/b": {"dtype": "float32", "shape": 2, "names": None}})

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -416,14 +416,18 @@ def test_create_branch():
     api.delete_repo(repo_id, repo_type=repo_type)
 
 
-
 def test_dataset_feature_with_forward_slash_raises_error():
     # make sure dir does not exist
     from lerobot.common.datasets.lerobot_dataset import LEROBOT_HOME
+
     dataset_dir = LEROBOT_HOME / "lerobot/test/with/slash"
     # make sure does not exist
     if dataset_dir.exists():
         dataset_dir.rmdir()
-    
+
     with pytest.raises(ValueError):
-        LeRobotDataset.create(repo_id="lerobot/test/with/slash", fps=30, features= {"a/b": {"dtype": "float32", "shape": 2, "names": None}})
+        LeRobotDataset.create(
+            repo_id="lerobot/test/with/slash",
+            fps=30,
+            features={"a/b": {"dtype": "float32", "shape": 2, "names": None}},
+        )


### PR DESCRIPTION
## What this does
If you create a dataset with feature keys that contain a '/', this will work fine and you can store the dataset. However, the serialized dataset stats will be corrupt because [they are flattened](https://github.com/huggingface/lerobot/blob/4323bdce227fbe91e7fb28eaffd298034b7ffffa/lerobot/common/datasets/lerobot_dataset.py#L900) using a '/' as separator. Upon training, you will get 'keyErrors' as the original feature names are now no longer available in the dataset stats file.

This is rather annoying to debug when you start training, and at that point you have to recreate your datasets. 

This PR adds a simple check to guard against creating a dataset with features that contain a '/' in their key, to make sure this issues is caught upon creation of the dataset.


## How it was tested
Explain/show how you tested your changes.

added a test in `tests/test_dataset` to ensure that dataset creation fails when the feature keys contain '/'


tagging @aliberts  and @Cadene  since their names are linked to a related #TODO in the codebase.