### PR TITLE
Possible fix in eager attention (for AMP): Use safe negative constant for half-precision masking

### DIFF
--- a/lerobot/common/policies/pi0/paligemma_with_expert.py
+++ b/lerobot/common/policies/pi0/paligemma_with_expert.py
@@ -395,7 +395,12 @@ class PaliGemmaWithExpertModel(PreTrainedModel):
 
         att_weights = torch.matmul(query_states, key_states.transpose(2, 3))
         att_weights *= head_dim**-0.5
-        big_neg = -2.3819763e38  # See gemma/modules.py
+        
+        if att_weights.dtype in (torch.float16, torch.bfloat16):
+            big_neg_val = -10000.0
+        else:
+            big_neg_val = -2.3819763e38
+        big_neg = torch.tensor(big_neg_val, dtype=att_weights.dtype, device=att_weights.device)
 
         masked_att_weights = torch.where(attention_mask[:, None, :, :], att_weights, big_neg)
 


### PR DESCRIPTION
## What this does
When using AMP, computing masked attention scores in eager_attention_forward, using a very large negative constant (-2.3819763e38) caused overflows when the computation was carried out in half-precision (float16 or bfloat16). This commit updates the masking constant to -10000.0 for half-precision to ensure stable and correct operation.

```
File "/home/jannik/trlc/lerobot/lerobot/common/policies/pi0/paligemma_with_expert.py", line 389, in eager_attention_forward
    masked_att_weights = torch.where(attention_mask[:, None, :, :], att_weights, big_neg)
RuntimeError: value cannot be converted to type at::Half without overflow
```

## How it was tested
Use a pretrained Pi0 checkpoint
```
policy_config = PreTrainedConfig.from_pretrained(policy_path)
policy_config.pretrained_path = policy_path
device = "cuda"
fps = 30
                    
dataset = LeRobotDataset.create(repo_id="lerobot/temp", fps=fps, robot=robot)   
policy = make_policy(policy_config, device=device, ds_meta=dataset.meta)

control_loop(robot,events=events, policy=policy, fps=fps, device=device, display_cameras=display_cameras, use_amp=True)
```


