### PR TITLE
[Port HIL-SERL] Balanced sampler function speed up and refactor to align with train.py

### DIFF
--- a/lerobot/configs/policy/hilserl_classifier.yaml
+++ b/lerobot/configs/policy/hilserl_classifier.yaml
@@ -28,7 +28,7 @@ training:
   num_epochs: 6
   batch_size: 16
   learning_rate: 1e-4
-  num_workers: 0
+  num_workers: 4
   grad_clip_norm: 10
   use_amp: true
   log_freq: 1
@@ -56,6 +56,6 @@ wandb:
   job_name: "classifier_training_0"
   disable_artifact: false
 
-device: "cuda"
+device: "mps"
 resume: false
 output_dir: "outputs/classifier/old_trainer_resnet10_frozen"

--- a/lerobot/configs/policy/hilserl_classifier.yaml
+++ b/lerobot/configs/policy/hilserl_classifier.yaml
@@ -3,6 +3,14 @@
 defaults:
   - _self_
 
+hydra:
+  run:
+    # Set `dir` to where you would like to save all of the run outputs. If you run another training session
+    # with the same value for `dir` its contents will be overwritten unless you set `resume` to true.
+    dir: outputs/train_hilserl_classifier/${now:%Y-%m-%d}/${now:%H-%M-%S}_${env.name}_${hydra.job.name}
+  job:
+    name: default
+
 seed: 13
 dataset_repo_id: aractingi/push_cube_square_light_reward_cropped_resized
 # aractingi/push_cube_square_reward_1_cropped_resized
@@ -20,7 +28,7 @@ training:
   num_epochs: 6
   batch_size: 16
   learning_rate: 1e-4
-  num_workers: 4
+  num_workers: 0
   grad_clip_norm: 10
   use_amp: true
   log_freq: 1
@@ -48,6 +56,6 @@ wandb:
   job_name: "classifier_training_0"
   disable_artifact: false
 
-device: "mps"
+device: "cuda"
 resume: false
 output_dir: "outputs/classifier/old_trainer_resnet10_frozen"

--- a/lerobot/scripts/train_hilserl_classifier.py
+++ b/lerobot/scripts/train_hilserl_classifier.py
@@ -42,6 +42,7 @@ from lerobot.common.utils.utils import (
     format_big_number,
     get_safe_torch_device,
     init_hydra_config,
+    init_logging,
     set_global_seed,
 )
 from lerobot.scripts.server.buffer import random_shift
@@ -298,21 +299,21 @@ def benchmark_inference_time(model, dataset, logger, cfg, device, step):
     return avg, median, std
 
 
-@hydra.main(
-    version_base="1.2",
-    config_path="../configs/policy",
-    config_name="hilserl_classifier",
-)
-def train(cfg: DictConfig) -> None:
+def train(cfg: DictConfig, out_dir: str | None = None, job_name: str | None = None) -> None:
+    if out_dir is None:
+        raise NotImplementedError()
+    if job_name is None:
+        raise NotImplementedError()
+
     # Main training pipeline with support for resuming training
+    init_logging()
     logging.info(OmegaConf.to_yaml(cfg))
+
+    logger = Logger(cfg, out_dir, wandb_job_name=job_name)
 
     # Initialize training environment
     device = get_safe_torch_device(cfg.device, log=True)
     set_global_seed(cfg.seed)
-
-    out_dir = hydra.core.hydra_config.HydraConfig.get().run.dir + "frozen_resnet10_2"
-    logger = Logger(cfg, out_dir, cfg.wandb.job_name if cfg.wandb.enable else None)
 
     # Setup dataset and dataloaders
     dataset = LeRobotDataset(
@@ -462,5 +463,23 @@ def train(cfg: DictConfig) -> None:
     logging.info("Training completed")
 
 
+@hydra.main(version_base="1.2", config_name="hilserl_classifier", config_path="../configs/policy")
+def train_cli(cfg: dict):
+    train(
+        cfg,
+        out_dir=hydra.core.hydra_config.HydraConfig.get().run.dir,
+        job_name=hydra.core.hydra_config.HydraConfig.get().job.name,
+    )
+
+
+def train_notebook(out_dir=None, job_name=None, config_name="hilserl_classifier", config_path="../configs/policy"):
+    from hydra import compose, initialize
+
+    hydra.core.global_hydra.GlobalHydra.instance().clear()
+    initialize(config_path=config_path)
+    cfg = compose(config_name=config_name)
+    train(cfg, out_dir=out_dir, job_name=job_name)
+
+
 if __name__ == "__main__":
-    train()
+    train_cli()

--- a/lerobot/scripts/train_hilserl_classifier.py
+++ b/lerobot/scripts/train_hilserl_classifier.py
@@ -62,8 +62,10 @@ def get_model(cfg, logger):  # noqa I001
 
 def create_balanced_sampler(dataset, cfg):
     # Get underlying dataset if using Subset
-    original_dataset = dataset.dataset if isinstance(dataset, torch.utils.data.Subset) else dataset
-    
+    original_dataset = (
+        dataset.dataset if isinstance(dataset, torch.utils.data.Subset) else dataset
+    )
+
     # Get indices if using Subset (for slicing)
     indices = dataset.indices if isinstance(dataset, torch.utils.data.Subset) else None
 
@@ -312,7 +314,9 @@ def benchmark_inference_time(model, dataset, logger, cfg, device, step):
     return avg, median, std
 
 
-def train(cfg: DictConfig, out_dir: str | None = None, job_name: str | None = None) -> None:
+def train(
+    cfg: DictConfig, out_dir: str | None = None, job_name: str | None = None
+) -> None:
     if out_dir is None:
         raise NotImplementedError()
     if job_name is None:
@@ -476,7 +480,11 @@ def train(cfg: DictConfig, out_dir: str | None = None, job_name: str | None = No
     logging.info("Training completed")
 
 
-@hydra.main(version_base="1.2", config_name="hilserl_classifier", config_path="../configs/policy")
+@hydra.main(
+    version_base="1.2",
+    config_name="hilserl_classifier",
+    config_path="../configs/policy",
+)
 def train_cli(cfg: dict):
     train(
         cfg,
@@ -485,7 +493,12 @@ def train_cli(cfg: dict):
     )
 
 
-def train_notebook(out_dir=None, job_name=None, config_name="hilserl_classifier", config_path="../configs/policy"):
+def train_notebook(
+    out_dir=None,
+    job_name=None,
+    config_name="hilserl_classifier",
+    config_path="../configs/policy",
+):
     from hydra import compose, initialize
 
     hydra.core.global_hydra.GlobalHydra.instance().clear()


### PR DESCRIPTION
## What this does

1. Optimize the `create_balanced_sampler()` function for better efficiency. Instead of iterating through the entire dataset, I utilized Huggingface's `select()` method to obtain a subset of the dataset and retrieve the labels using the `label_key`.

-  I achieved a **1794x performance boost** (from 28.08 seconds to 0.015649 seconds) on a dataset containing 8121 samples.

2. Refactor the code to align with the structure of `train.py` and better organized output directories.