### PR TITLE
Fixes following #670

### DIFF
--- a/lerobot/common/policies/pi0/modeling_pi0.py
+++ b/lerobot/common/policies/pi0/modeling_pi0.py
@@ -300,7 +300,7 @@ class PI0Policy(PreTrainedPolicy):
             self._action_queue.extend(actions.transpose(0, 1))
         return self._action_queue.popleft()
 
-    def forward(self, batch: dict[str, Tensor], noise=None, time=None) -> dict[str, Tensor]:
+    def forward(self, batch: dict[str, Tensor], noise=None, time=None) -> tuple[Tensor, dict[str, Tensor]]:
         """Do a full training forward pass to compute the loss"""
         if self.config.adapt_to_pi_aloha:
             batch[OBS_ROBOT] = self._pi_aloha_decode_state(batch[OBS_ROBOT])
@@ -328,12 +328,12 @@ class PI0Policy(PreTrainedPolicy):
         losses = losses[:, :, : self.config.max_action_dim]
         loss_dict["losses_after_rm_padding"] = losses.clone()
 
-        loss = losses.mean()
         # For backward pass
-        loss_dict["loss"] = loss
+        loss = losses.mean()
         # For logging
         loss_dict["l2_loss"] = loss.item()
-        return loss_dict
+
+        return loss, loss_dict
 
     def prepare_images(self, batch):
         """Apply Pi0 preprocessing to the images, like resizing to 224x224 and padding to keep aspect ratio, and

--- a/lerobot/common/utils/wandb_utils.py
+++ b/lerobot/common/utils/wandb_utils.py
@@ -102,7 +102,7 @@ class WandBLogger:
         self._wandb.log_artifact(artifact)
 
     def log_dict(self, d: dict, step: int, mode: str = "train"):
-        if mode in {"train", "eval"}:
+        if mode not in {"train", "eval"}:
             raise ValueError(mode)
 
         for k, v in d.items():
@@ -114,7 +114,7 @@ class WandBLogger:
             self._wandb.log({f"{mode}/{k}": v}, step=step)
 
     def log_video(self, video_path: str, step: int, mode: str = "train"):
-        if mode in {"train", "eval"}:
+        if mode not in {"train", "eval"}:
             raise ValueError(mode)
 
         wandb_video = self._wandb.Video(video_path, fps=self.env_fps, format="mp4")

--- a/lerobot/scripts/train.py
+++ b/lerobot/scripts/train.py
@@ -233,7 +233,7 @@ def train(cfg: TrainPipelineConfig):
             logging.info(train_tracker)
             if wandb_logger:
                 wandb_log_dict = {**train_tracker.to_dict(), **output_dict}
-                wandb_logger.log_dict(wandb_log_dict)
+                wandb_logger.log_dict(wandb_log_dict, step)
             train_tracker.reset_averages()
 
         if cfg.save_checkpoint and is_saving_step:
@@ -271,6 +271,7 @@ def train(cfg: TrainPipelineConfig):
             logging.info(eval_tracker)
             if wandb_logger:
                 wandb_log_dict = {**eval_tracker.to_dict(), **eval_info}
+                wandb_logger.log_dict(wandb_log_dict, step, mode="eval")
                 wandb_logger.log_video(eval_info["video_paths"][0], step, mode="eval")
 
     if eval_env:


### PR DESCRIPTION
## What this does
- Fix the `.forward()` output format for Pi0 ([issue on discord](https://discord.com/channels/1216765309076115607/1237741463832363039/1339130881696202927))
- Various fixes for `WandBLogger` ([issue on discord](https://discord.com/channels/1216765309076115607/1237741463832363039/1339134743081517117))

## How it was tested
Used this short run with wandb enabled to test out wandb fixes:
```python
python lerobot/scripts/train.py \
    --policy.type=act \
    --policy.dim_model=64 \
    --policy.n_action_steps=20 \
    --policy.chunk_size=20 \
    --env.type=aloha \
    --env.episode_length=5 \
    --dataset.repo_id=lerobot/aloha_sim_transfer_cube_human \
    --dataset.image_transforms.enable=true \
    --dataset.episodes="[0]" \
    --batch_size=2 \
    --steps=4 \
    --eval_freq=2 \
    --eval.n_episodes=1 \
    --eval.batch_size=1 \
    --save_freq=2 \
    --save_checkpoint=true \
    --log_freq=1 \
    --wandb.enable=true \
    --device=cpu --job_name=act_wandb_test
```

Couldn't try Pi0 for now but the fix is simple enough

## How to checkout & try? (for the reviewer)
use command above for wandb fixes and this command for Pi0:
```python
python lerobot/scripts/train.py \
    --policy.path=lerobot/pi0 \
    --dataset.repo_id=pranavsaroha/so100_squishy2colors_1 \
    --output_dir=outputs/train/so100_squishy2colors_1_pi0 \
    --job_name=pi0_so100_squishy2colors_1_pi0_cuda \
    --device=cuda \
    --steps=2 \
    --log_freq=1 \
    --save_freq=2 \
    --eval_freq=2 \
    --eval.n_episodes=1 \
    --eval.batch_size=1 \
    --wandb.enable=true
```