### PR TITLE
Prevent resuming from hub

### DIFF
--- a/lerobot/configs/train.py
+++ b/lerobot/configs/train.py
@@ -88,7 +88,7 @@ class TrainPipelineConfig(HubMixin):
             if not Path(config_path).resolve().exists():
                 raise NotADirectoryError(
                     f"{config_path=} is expected to be a local path. "
-                    "Resuming from the hub is not supported for now"
+                    "Resuming from the hub is not supported for now."
                 )
             policy_path = Path(config_path).parent
             self.policy.pretrained_path = policy_path

--- a/lerobot/configs/train.py
+++ b/lerobot/configs/train.py
@@ -85,6 +85,11 @@ class TrainPipelineConfig(HubMixin):
             config_path = parser.parse_arg("config_path")
             if not config_path:
                 raise ValueError("A config_path is expected when resuming a run.")
+            if not Path(config_path).resolve().exists():
+                raise NotADirectoryError(
+                    f"{config_path=} is expected to be a local path. "
+                    "Resuming from the hub is not supported for now"
+                )
             policy_path = Path(config_path).parent
             self.policy.pretrained_path = policy_path
             self.checkpoint_path = policy_path.parent


### PR DESCRIPTION
## What this does
Adds an exception raised if trying to resume a training run from the hub as this is not implemented for now.

## How it was tested
The following correctly raises an error
```bash
python lerobot/scripts/train.py  \
    --config_path=lerobot/diffusion_pusht \
    --resume=true \
    --steps=200000 \
    --wandb.enable=false
```