### PR TITLE
Optimize pi0 for torch.compile 

### DIFF
--- a/lerobot/common/policies/pi0/modeling_pi0.py
+++ b/lerobot/common/policies/pi0/modeling_pi0.py
@@ -330,8 +330,8 @@ class PI0Policy(PreTrainedPolicy):
 
         # For backward pass
         loss = losses.mean()
-        # For logging
-        loss_dict["l2_loss"] = loss.item()
+        # For logging. Use detach so won't create scalar to break graph when using torch.compile
+        loss_dict["l2_loss"] = loss.detach()
 
         return loss, loss_dict
 


### PR DESCRIPTION
## What this does
Original code use loss.item(), which creates a scalar. Thus, if we call torch.compile() on this policy, the computational graph will break, and PyTorch will issue a warning regarding performance degradation


## How it was tested

Initialize the model and then call torch.compile on it. See that there is no longer warnings about graph break.

