### PR TITLE
Fix wandb logging

### DIFF
--- a/lerobot/scripts/train.py
+++ b/lerobot/scripts/train.py
@@ -232,7 +232,9 @@ def train(cfg: TrainPipelineConfig):
         if is_log_step:
             logging.info(train_tracker)
             if wandb_logger:
-                wandb_log_dict = {**train_tracker.to_dict(), **output_dict}
+                wandb_log_dict = train_tracker.to_dict()
+                if output_dict:
+                    wandb_log_dict.update(output_dict)
                 wandb_logger.log_dict(wandb_log_dict, step)
             train_tracker.reset_averages()
 


### PR DESCRIPTION
## What this does
Fix wandb logging when the `output_dict` from the policy is `None` ([issue on discord](https://discord.com/channels/1216765309076115607/1237070292237422632/1339986785542996009))

## How it was tested
Ran
```bash
python lerobot/scripts/train.py \
    --config_path=lerobot/diffusion_pusht \
    --job_name=fix_train_wandb \
    --log_freq=1 \
    --step=4 \
    --eval_freq=2 \
    --save_freq=2 \
    --eval.n_episodes=1 \
    --eval.batch_size=1 \
    --env.episode_length=10
```