### PR TITLE
Add streaming to LeRobotDataset

### DIFF
--- a/lerobot/common/datasets/utils.py
+++ b/lerobot/common/datasets/utils.py
@@ -205,6 +205,18 @@ def hf_transform_to_torch(items_dict: dict[torch.Tensor | None]):
     return items_dict
 
 
+def item_to_torch(item: dict):
+    for key, value in item.items():
+        if isinstance(value, PILImage.Image):
+            to_tensor = transforms.ToTensor()
+            item[key] = to_tensor(value)
+        elif value is None or isinstance(value, str):
+            pass
+        else:
+            item[key] = torch.tensor(value)
+    return item
+
+
 def _get_major_minor(version: str) -> tuple[int]:
     split = version.strip("v").split(".")
     return int(split[0]), int(split[1])


### PR DESCRIPTION
## What this does

A streaming mode could be useful for training at scale. Instead of downloading all the data locally at one place, data subsets are streamed to training nodes on-demand in a fully distributed fashion. It could also unlock federated learning at a massive scale.

Note: LeRobotDataset has already been used with federated learning tools, but not at a massive scale. See [twitter post](https://x.com/flwrlabs/status/1879571258532036739) and [flower quickstart lerobot](https://github.com/adap/flower/tree/main/examples/quickstart-lerobot).

This PR adds a `streaming: bool` argument to LeRobotDataset. Changes are minimal because LeRobotDataset relies on hugging face `datasets` library and `torchvision.io.VideoReader`, both already support streaming.

Note: The current implementation of streaming in HF datasets after `shuffle` is random access.

TODO to unblock merge:
- [ ] Compare against `webdataset`
- [ ] Show a real use case where `streaming=True` is useful
- [ ] Add tests

## How it was tested

Load single frame from distant video:
```python
from lerobot.common.datasets.video_utils import decode_video_frames_torchvision
video_path = "https://huggingface.co/datasets/pepijn223/mobileso100_drive_forward6/resolve/main/videos/chunk-000/observation.images.mobile/episode_000000.mp4"
frames = decode_video_frames_torchvision(video_path, [0.0], tolerance_s=0.2)
```

Load items:
```python
from pathlib import Path
from lerobot.common.datasets.lerobot_dataset import LeRobotDataset
import tqdm

def main():
    dataset = LeRobotDataset("pepijn223/mobileso100_drive_forward6", episodes=[0], streaming=True)

    for i in tqdm.tqdm(range(100000)):
        item = dataset[i]
        print(f'{item["index"]=}')
        print(f'{item["frame_index"]=}')
        print(f'{item["episode_index"]=}')
        print(f'{item["timestamp"]=}')

if __name__ == "__main__":
    main()
```
