### PR TITLE
xs: Add error message in homepage of dataset visualizer. (⚡️ UX Improvement)

### DIFF
--- a/lerobot/templates/visualize_dataset_homepage.html
+++ b/lerobot/templates/visualize_dataset_homepage.html
@@ -9,10 +9,21 @@
 </head>
 <body class="h-screen overflow-hidden font-mono text-white" x-data="{
     inputValue: '',
+    errorMessage: '',
     navigateToDataset() {
         const trimmedValue = this.inputValue.trim();
         if (trimmedValue) {
-            window.location.href = `/${trimmedValue}`;
+            fetch(`/${trimmedValue}`, { method: 'HEAD' })
+                .then(response => {
+                    if (response.ok) {
+                        window.location.href = `/${trimmedValue}`;
+                    } else {
+                        this.errorMessage = `Error when trying to visualize the dataset. Please make sure you uploaded the dataset ${trimmedValue}`;
+                    }
+                })
+                .catch(error => {
+                    this.errorMessage = `Error when trying to visualize the dataset. Please make sure you uploaded the dataset ${trimmedValue}`;
+                });
         }
     }
 }">
@@ -54,7 +65,8 @@
                 Go
             </button>
         </div>
-
+        <!-- Display error message if dataset not found -->
+        <div x-show="errorMessage" class="text-red-500 mt-2" x-text="errorMessage"></div>
         <details class="mt-4 max-w-full px-4">
             <summary>More example datasets</summary>
             <ul class="list-disc list-inside max-h-28 overflow-y-auto break-all">


### PR DESCRIPTION
## What this does
We verify the dataset endpoint before redirecting. When a user enters a dataset ID, a HEAD request is sent to check for the dataset’s existence. If the dataset isn’t found or if there is something wrong, an error message is shown:
  
## How it was tested
- test_visualize_dataset is skipped.

## How to checkout & try? (for the reviewer)
1. Start the development server.
2. Navigate to the homepage.
3. Enter a valid or invalid dataset ID in the input field and press Enter

## Before

<img width="1134" alt="Capture d’écran 2025-02-20 à 17 42 36" src="https://github.com/user-attachments/assets/824a77e5-5e19-446f-99d2-844e7335613b" />

## After

<img width="1134" alt="Capture d’écran 2025-02-20 à 17 43 15" src="https://github.com/user-attachments/assets/d7dd38d0-907d-43a4-b761-6259e97af4cf" />


cc: @Pierre-LouisBJT 