### PR TITLE
Fix the URL to setup hardware Aloha Stationary in the example document

### DIFF
--- a/examples/9_use_aloha.md
+++ b/examples/9_use_aloha.md
@@ -2,7 +2,7 @@ This tutorial explains how to use [Aloha and Aloha 2 stationary](https://www.tro
 
 ## Setup
 
-Follow the [documentation from Trossen Robotics](https://docs.trossenrobotics.com/aloha_docs/getting_started/stationary/hardware_setup.html) for setting up the hardware and plugging the 4 arms and 4 cameras to your computer.
+Follow the [documentation from Trossen Robotics](https://docs.trossenrobotics.com/aloha_docs/2.0/getting_started/stationary/hardware_setup.html) for setting up the hardware and plugging the 4 arms and 4 cameras to your computer.
 
 
 ## Install LeRobot


### PR DESCRIPTION
## What this does

Fix the URL to setup hardware Aloha Stationary in the example document.
- from: https://docs.trossenrobotics.com/aloha_docs/getting_started/stationary/hardware_setup.html
- to: https://docs.trossenrobotics.com/aloha_docs/2.0/getting_started/stationary/hardware_setup.html

## How it was tested

It is just a URL in the document.