### PR TITLE
[skip ci] chore(pre-commit): bump python version from 3.10 to python3.12

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 exclude: ^(tests/data)
 default_language_version:
-    python: python3.10
+    python: python3.12
 repos:
   ##### Style / Misc. #####
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
## What this does
Bump Python version used for the `pre-commit` checks

## How it was tested
By running: `pre-commit run --all-files`
