### PR TITLE
:bug: Remove `map_location=device` that no longer exists when loading DiffusionPolicy from_pretained after commit 5e94738

### DIFF
--- a/examples/2_evaluate_pretrained_policy.py
+++ b/examples/2_evaluate_pretrained_policy.py
@@ -44,7 +44,7 @@ pretrained_policy_path = "lerobot/diffusion_pusht"
 # OR a path to a local outputs/train folder.
 # pretrained_policy_path = Path("outputs/train/example_pusht_diffusion")
 
-policy = DiffusionPolicy.from_pretrained(pretrained_policy_path, map_location=device)
+policy = DiffusionPolicy.from_pretrained(pretrained_policy_path)
 
 # Initialize evaluation environment to render two observation types:
 # an image of the scene and state/position of the agent. The environment


### PR DESCRIPTION

## What this does
(🐛 Bug) Commit 5e94738 induced a regression in example 2 by omitting to delete  `map_location` argument. This PR simply removes it.

## How it was tested
My changes were tested by running  
```sh
 python examples/2_evaluate_pretrained_policy.py
 ```
after a clean install.
 

## How to checkout & try? (for the reviewer)
Run 
```sh
 python examples/2_evaluate_pretrained_policy.py
 ```

Before the modification, you should get:
```bash
TypeError: DiffusionPolicy.__init__() got an unexpected keyword argument 'map_location'
```