### PR TITLE
fix scripts of v20 to v21

### DIFF
--- a/lerobot/common/datasets/v21/convert_stats.py
+++ b/lerobot/common/datasets/v21/convert_stats.py
@@ -40,6 +40,7 @@ def convert_episode_stats(dataset: LeRobotDataset, ep_idx: int):
         if ft["dtype"] == "video":
             # We sample only for videos
             ep_ft_data = sample_episode_video_frames(dataset, ep_idx, key)
+            ep_ft_data = ep_ft_data[None, ...] if ep_ft_data.ndim == 3 else ep_ft_data
         else:
             ep_ft_data = np.array(ep_data[key])
 


### PR DESCRIPTION
## What this does
|  Title               | Label           |
|----------------------|-----------------|
| Fixes bugs when len of traj is 1       | (🐛 Bug)        |

## How it was tested
[query_video](https://github.com/huggingface/lerobot/blob/main/lerobot/common/datasets/lerobot_dataset.py#L713) squeezes the first dimension to maintain consistent image shapes across the batch.

However, when converting v20 to v21, we need to process the entire trajectory, which might contain only a single step. This could lead to an error during the [dim reduction](https://github.com/huggingface/lerobot/blob/main/lerobot/common/datasets/v21/convert_stats.py#L46).

## How to checkout & try? (for the reviewer)
While it seems uncommon to have a trajectory with only one step😅, (may be we need to filter it out), you can find an example [here](https://huggingface.co/spaces/IPEC-COMMUNITY/openx_lerobot_visualizer?dataset=IPEC-COMMUNITY%2Froboturk_lerobot&episode=416).