### PR TITLE
User/pepijn/2025 03 17 act different image shapes

### DIFF
--- a/lerobot/common/policies/act/modeling_act.py
+++ b/lerobot/common/policies/act/modeling_act.py
@@ -483,8 +483,8 @@ class ACT(nn.Module):
 
         # Camera observation features and positional embeddings.
         if self.config.image_features:
-            all_tokens = []
-            all_pos_tokens = []
+            all_cam_features = []
+            all_cam_pos_embeds = []
 
             # For a list of images, the H and W may vary but H*W is constant.
             for img in batch["observation.images"]:
@@ -493,14 +493,14 @@ class ACT(nn.Module):
                 cam_features = self.encoder_img_feat_input_proj(cam_features)
 
                 # Rearrange features to (sequence, batch, dim).
-                tokens = einops.rearrange(cam_features, "b c h w -> (h w) b c")
-                pos_tokens = einops.rearrange(cam_pos_embed, "b c h w -> (h w) b c")
+                cam_features = einops.rearrange(cam_features, "b c h w -> (h w) b c")
+                cam_pos_embed = einops.rearrange(cam_pos_embed, "b c h w -> (h w) b c")
 
-                all_tokens.append(tokens)
-                all_pos_tokens.append(pos_tokens)
+                all_cam_features.append(cam_features)
+                all_cam_pos_embeds.append(cam_pos_embed)
 
-            encoder_in_tokens.extend(torch.cat(all_tokens, axis=0))
-            encoder_in_pos_embed.extend(torch.cat(all_pos_tokens, axis=0))
+            encoder_in_tokens.extend(torch.cat(all_cam_features, axis=0))
+            encoder_in_pos_embed.extend(torch.cat(all_cam_pos_embeds, axis=0))
 
         # Stack all tokens along the sequence dimension.
         encoder_in_tokens = torch.stack(encoder_in_tokens, axis=0)

--- a/lerobot/common/policies/act/modeling_act.py
+++ b/lerobot/common/policies/act/modeling_act.py
@@ -119,9 +119,7 @@ class ACTPolicy(PreTrainedPolicy):
         batch = self.normalize_inputs(batch)
         if self.config.image_features:
             batch = dict(batch)  # shallow copy so that adding a key doesn't modify the original
-            images = [batch[key] for key in self.config.image_features]
-
-            batch["observation.images"] = images
+            batch["observation.images"] = [batch[key] for key in self.config.image_features]
 
         # If we are doing temporal ensembling, do online updates where we keep track of the number of actions
         # we are ensembling over.
@@ -149,9 +147,7 @@ class ACTPolicy(PreTrainedPolicy):
         batch = self.normalize_inputs(batch)
         if self.config.image_features:
             batch = dict(batch)  # shallow copy so that adding a key doesn't modify the original
-            images = [batch[key] for key in self.config.image_features]
-
-            batch["observation.images"] = images
+            batch["observation.images"] = [batch[key] for key in self.config.image_features]
 
         batch = self.normalize_targets(batch)
         actions_hat, (mu_hat, log_sigma_x2_hat) = self.model(batch)

--- a/lerobot/common/policies/act/modeling_act.py
+++ b/lerobot/common/policies/act/modeling_act.py
@@ -500,12 +500,28 @@ class ACT(nn.Module):
             all_cam_pos_embeds = []
 
             if isinstance(batch["observation.images"], list):
+                # For a list of images, the H and W may vary but H*W is constant.
                 for img in batch["observation.images"]:
                     cam_features = self.backbone(img)["feature_map"]
                     cam_pos_embed = self.encoder_cam_feat_pos_embed(cam_features).to(dtype=cam_features.dtype)
                     cam_features = self.encoder_img_feat_input_proj(cam_features)
+                    # Flatten dimensions into a single token dimension: (B, C, H*W)
+                    cam_features = einops.rearrange(cam_features, "b c h w -> b c (h w)")
+                    cam_pos_embed = einops.rearrange(cam_pos_embed, "b c h w -> b c (h w)")
                     all_cam_features.append(cam_features)
                     all_cam_pos_embeds.append(cam_pos_embed)
+
+                # Concatenate tokens from all cameras along the token dimension.
+                # Each tensor in the list is (B, C, T) so the concatenated result is (B, C, total_tokens)
+                all_cam_features = torch.cat(all_cam_features, axis=-1)
+                all_cam_pos_embeds = torch.cat(all_cam_pos_embeds, axis=-1)
+                encoder_in_tokens.append(einops.rearrange(all_cam_features, "b c t -> t b c"))
+                encoder_in_pos_embed.append(einops.rearrange(all_cam_pos_embeds, "b c t -> t b c"))
+
+                # Concatenate all tokens along the sequence dimension.
+                encoder_in_tokens = torch.cat(encoder_in_tokens, axis=0)
+                encoder_in_pos_embed = torch.cat(encoder_in_pos_embed, axis=0)
+
             else:
                 for cam_index in range(batch["observation.images"].shape[-4]):
                     cam_features = self.backbone(batch["observation.images"][:, cam_index])["feature_map"]
@@ -516,16 +532,16 @@ class ACT(nn.Module):
                     all_cam_features.append(cam_features)
                     all_cam_pos_embeds.append(cam_pos_embed)
 
-            # Concatenate camera observation feature maps and positional embeddings along the width dimension,
-            # and move to (sequence, batch, dim).
-            all_cam_features = torch.cat(all_cam_features, axis=-1)
-            encoder_in_tokens.extend(einops.rearrange(all_cam_features, "b c h w -> (h w) b c"))
-            all_cam_pos_embeds = torch.cat(all_cam_pos_embeds, axis=-1)
-            encoder_in_pos_embed.extend(einops.rearrange(all_cam_pos_embeds, "b c h w -> (h w) b c"))
+                # Concatenate camera observation feature maps and positional embeddings along the width dimension,
+                # and move to (sequence, batch, dim).
+                all_cam_features = torch.cat(all_cam_features, axis=-1)
+                all_cam_pos_embeds = torch.cat(all_cam_pos_embeds, axis=-1)
+                encoder_in_tokens.extend(einops.rearrange(all_cam_features, "b c h w -> (h w) b c"))
+                encoder_in_pos_embed.extend(einops.rearrange(all_cam_pos_embeds, "b c h w -> (h w) b c"))
 
-        # Stack all tokens along the sequence dimension.
-        encoder_in_tokens = torch.stack(encoder_in_tokens, axis=0)
-        encoder_in_pos_embed = torch.stack(encoder_in_pos_embed, axis=0)
+                # Stack all tokens along the sequence dimension.
+                encoder_in_tokens = torch.stack(encoder_in_tokens, axis=0)
+                encoder_in_pos_embed = torch.stack(encoder_in_pos_embed, axis=0)
 
         # Forward pass through the transformer modules.
         encoder_out = self.encoder(encoder_in_tokens, pos_embed=encoder_in_pos_embed)


### PR DESCRIPTION
## What this does
It adapt the forward method in ACT so it works with rotated images or images in datasets that have different shapes but still have the same total pixels (640,480) and (480,640). 

## How it was tested
Runned train.py with dataset that has different image shapes (640, 480) and (480,640)

Command for dataset with rotation:
```bash
python lerobot/scripts/train.py \        
  --dataset.repo_id=pepijn223/act_lekiwi_cam_test2 \ 
  --policy.type=act \
  --output_dir=outputs/train/act_lekiwi_test \                    
  --job_name=act_lekiwi_test \
  --policy.device=mps \                  
  --wandb.enable=true
```

Command for dataset without rotation:
```bash
python lerobot/scripts/train.py \        
  --dataset.repo_id=pepijn223/lekiwi_block_cleanup2 \ 
  --policy.type=act \
  --output_dir=outputs/train/act_lekiwi_test \                    
  --job_name=act_lekiwi_test \
  --policy.device=mps \                  
  --wandb.enable=true
```