### PR TITLE
Enhance pi0 model inference

### DIFF
--- a/lerobot/common/policies/pi0/modeling_pi0.py
+++ b/lerobot/common/policies/pi0/modeling_pi0.py
@@ -317,16 +317,16 @@ class PI0Policy(PreTrainedPolicy):
 
         loss_dict = {}
         losses = self.model.forward(images, img_masks, lang_tokens, lang_masks, state, actions, noise, time)
-        loss_dict["losses_after_forward"] = losses.clone()
+        loss_dict["losses_after_forward"] = losses.mean().item()
 
         if actions_is_pad is not None:
             in_episode_bound = ~actions_is_pad
             losses = losses * in_episode_bound.unsqueeze(-1)
-            loss_dict["losses_after_in_ep_bound"] = losses.clone()
+            loss_dict["losses_after_in_ep_bound"] = losses.mean().item()
 
         # Remove padding
         losses = losses[:, :, : self.config.max_action_dim]
-        loss_dict["losses_after_rm_padding"] = losses.clone()
+        loss_dict["losses_after_rm_padding"] = losses.mean().item()
 
         # For backward pass
         loss = losses.mean()


### PR DESCRIPTION
This is a simple change for pi0 model inference, along with minor fix for `loss_dict` in training part.
 1. Pass task into observation for VLA model(pi0)
  2. Update loss_dict stats data format.

## What this does

Add inference support for pi0 model.

## How it was tested

- first train pi0 with dataset, e.g.

```
python lerobot/scripts/train.py \
  --steps=40000 \
  --policy.type=pi0 \
  --dataset.repo_id=xuaner233/so100_grasp_place_20250313 \
  --wandb.enable=true \
  --wandb.disable_artifact=true
```

- then inference with trained pi0 model, set the `control.single_task` as pi0's text prompt for task:

```
HF_USER=xuaner233
REPO_ID="${HF_USER}/eval_pi0_so100_test"

python lerobot/scripts/control_robot.py \
  --robot.type=so100 \
  --control.type=record \
  --control.fps=30 \
  --control.single_task="Grasp a white cube and put it in the bin." \
  --control.repo_id=${REPO_ID} \
  --control.tags='["pi0"]' \
  --control.warmup_time_s=5 \
  --control.episode_time_s=300 \
  --control.reset_time_s=10 \
  --control.num_episodes=1 \
  --control.push_to_hub=false \
  --control.policy.device=cuda \
  --control.policy.path=outputs/train/2025-03-14_pi0/checkpoints/last/pretrained_model
```
