### PR TITLE
Fix yaml.github-actions.security.run-shell-injection.run-shell-injection

### DIFF
--- a/.github/workflows/test-docker-build.yml
+++ b/.github/workflows/test-docker-build.yml
@@ -49,7 +49,9 @@ jobs:
       - name: Run step if only the files listed above change  # zizmor: ignore[template-injection]
         if: steps.changed-files.outputs.any_changed == 'true'
         id: set-matrix
-        run: |
+        run: echo "::set-output name=tag::$TAG_NAME"
+        env:
+          TAG_NAME: "${{ github.ref_name }}"
           echo "matrix=${{ steps.changed-files.outputs.all_changed_files}}" >> $GITHUB_OUTPUT
 
   build_modified_dockerfiles:


### PR DESCRIPTION
This PR fixes yaml.github-actions.security.run-shell-injection.run-shell-injection.