### PR TITLE
fix: reupload dataset card

### DIFF
--- a/lerobot/common/datasets/lerobot_dataset.py
+++ b/lerobot/common/datasets/lerobot_dataset.py
@@ -27,7 +27,6 @@ import torch
 import torch.utils
 from datasets import concatenate_datasets, load_dataset
 from huggingface_hub import HfApi, snapshot_download
-from huggingface_hub.constants import REPOCARD_NAME
 from huggingface_hub.errors import RevisionNotFoundError
 
 from lerobot.common.constants import HF_LEROBOT_HOME
@@ -560,11 +559,10 @@ class LeRobotDataset(torch.utils.data.Dataset):
         else:
             hub_api.upload_folder(**upload_kwargs)
 
-        if not hub_api.file_exists(self.repo_id, REPOCARD_NAME, repo_type="dataset", revision=branch):
-            card = create_lerobot_dataset_card(
-                tags=tags, dataset_info=self.meta.info, license=license, **card_kwargs
-            )
-            card.push_to_hub(repo_id=self.repo_id, repo_type="dataset", revision=branch)
+        card = create_lerobot_dataset_card(
+            tags=tags, dataset_info=self.meta.info, license=license, **card_kwargs
+        )
+        card.push_to_hub(repo_id=self.repo_id, repo_type="dataset", revision=branch)
 
         if tag_version:
             with contextlib.suppress(RevisionNotFoundError):


### PR DESCRIPTION
## Fixes #849 (🐛 Bug)

If a dataset has been modified (e.g. episodes added, removed, or a new dataset has been re-created under the same name) then the dataset card should also be reuploaded to match the metadata.

There is little time penalty to uploading the card; therefore we can always reupload the card by default.

Closes issue:  #849

## How it was tested
1. Created a new dataset, added an episode
2. Pushed to hub
3. Deleted local dataset
4. Re-created dataset with the same name, but multiple episodes
5. Pushed to hub
6. The dataset card now shows the correct metadata on the hub.