### PR TITLE
fix(typing): fix typing of make_cameras_from_config

### DIFF
--- a/lerobot/common/robot_devices/cameras/utils.py
+++ b/lerobot/common/robot_devices/cameras/utils.py
@@ -31,7 +31,7 @@ class Camera(Protocol):
     def disconnect(self): ...
 
 
-def make_cameras_from_configs(camera_configs: dict[str, CameraConfig]) -> list[Camera]:
+def make_cameras_from_configs(camera_configs: dict[str, CameraConfig]) -> dict[str, Camera]:
     cameras = {}
 
     for key, cfg in camera_configs.items():


### PR DESCRIPTION
## What this does
Explain what this PR does. Feel free to tag your PR with the appropriate label(s).

At the `make_cameras_from_configs` [here](https://github.com/huggingface/lerobot/blob/f39652707caed42a7cd5ab36066da5663b9565eb/lerobot/common/robot_devices/cameras/utils.py#L34), the function actually returns a dictionary not a list, have a wrong signature from what is actually implemented.
