### PR TITLE
Add Cuda/NVDEC decoding (torchcodec gpu)

### DIFF
--- a/lerobot/common/datasets/lerobot_dataset.py
+++ b/lerobot/common/datasets/lerobot_dataset.py
@@ -736,8 +736,9 @@ class LeRobotDataset(torch.utils.data.Dataset):
         if len(self.meta.video_keys) > 0:
             current_ts = item["timestamp"].item()
             query_timestamps = self._get_query_timestamps(current_ts, query_indices)
-            video_frames = self._query_videos(query_timestamps, ep_idx)
-            item = {**video_frames, **item}
+            if self.video_backend != "torchcodec-gpu":
+                video_frames = self._query_videos(query_timestamps, ep_idx)
+                item = {**video_frames, **item}
 
         if self.image_transforms is not None:
             image_keys = self.meta.camera_keys

--- a/lerobot/scripts/train.py
+++ b/lerobot/scripts/train.py
@@ -207,16 +207,20 @@ def train(cfg: TrainPipelineConfig):
         batch = next(dl_iter)
 
         if dataset.video_backend == "torchcodec-gpu":
+            # make sure we have a cuda device
+            assert torch.cuda.is_available(), (
+                "CUDA device not available. Please run on a machine with a GPU "
+                "to enable CUDA decoding when using `video_backend='torchcodec-gpu'`."
+            )
             # add cuda decoding
             for vid_key, timestamps_list in batch['query_timestamps'].items():
                 frames_list = []
-                # convert list of scalar tensors to a tensor of shape [T]
-                query_ts = torch.stack(timestamps_list).T  # shape: [T]
+                # convert list of scalar tensors to a tensor of shape [T, B]
+                query_ts = torch.stack(timestamps_list).T  # convert to shape: [B, T]
                 for i in range(query_ts.shape[0]):
                     ep_idx = batch['episode_index'][i]
                     timestamps = query_ts[i].tolist()
                     video_path = dataset.root / dataset.meta.get_video_file_path(ep_idx, vid_key)
-                    #TODO: (jadechoghari) make sure user has cuda and num_wokers == 0
                     frames = decode_video_frames_torchcodec(
                         video_path, timestamps, dataset.tolerance_s, device="cuda"
                     )


### PR DESCRIPTION
## What this does
This PR adds CUDA decoding to the training script.
We compared it against torchcodec-cpu using lerobot video benchmark. See results here: 


| Backend        | Timestamps Mode | Load Time (ms) | MSE       | PSNR    | SSIM    |
|----------------|------------------|----------------|-----------|---------|---------|
| torchcodec-cpu | 1_frame          | 12.80          | 0.000056  | 44.50   | 0.9947  |
| torchcodec-cpu | 2_frames         | 7.31           | 0.000057  | 44.50   | 0.9948  |
| torchcodec-cpu | 6_frames         | 5.16           | 0.000061  | 44.39   | 0.9946  |
| torchcodec-gpu | 1_frame          | 271.54         | 0.002487  | 26.04   | 0.4754  |
| torchcodec-gpu | 2_frames         | 121.25         | 0.002492  | 26.04   | 0.4746  |
| torchcodec-gpu | 6_frames         | 40.70          | 0.002495  | 26.03   | 0.4746  |

Note: gpu decoding with torchcodec pays upfront costs: context initialization (constant) and frame transfer (scales with resolution). while GPU decoding (via NVDECs) is faster per frame than single-threaded cpu, it's only a win when `init + transfer < total` cpu decode time. as video resolution increases, gpu wins more often. however, modern cpus with many threads can still outperform gpu decoding due to limited NVDEC units (typically <10). this tradeoff matters when deciding backend defaults or optimizing for throughput.


## What's left
Compare training speed, investigate more when CPU can become a bottleneck and CUDA decoding becomes a win, test trainign speed on DOT Policy (to be added soon): https://github.com/huggingface/lerobot/pull/739