### PR TITLE
fix(docs): correct spelling of 'ffmpeg' in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ conda create -y -n lerobot python=3.10
 conda activate lerobot
 ```
 
-When using `miniconda`, if you don't have `fffmpeg` in your environment:
+When using `miniconda`, if you don't have `ffmpeg` in your environment:
 ```bash
 conda install ffmpeg
 ```


### PR DESCRIPTION
## What this does

This PR fixes a spelling mistake in the installation instructions by correcting the spelling of ‘ffmpeg’.

## How it was tested

This is a documentation update, so no testing was required.

