### PR TITLE
fix(datasets): cast imgs_dir as Path

### DIFF
--- a/lerobot/common/datasets/video_utils.py
+++ b/lerobot/common/datasets/video_utils.py
@@ -257,6 +257,7 @@ def encode_video_frames(
 ) -> None:
     """More info on ffmpeg arguments tuning on `benchmark/video/README.md`"""
     video_path = Path(video_path)
+    imgs_dir = Path(imgs_dir)
     video_path.parent.mkdir(parents=True, exist_ok=True)
 
     ffmpeg_args = OrderedDict(


### PR DESCRIPTION
## What this does
Cast `imgs_dir` as `Path()`

## How it was tested
```python
>>> import os
>>> from pathlib import Path
>>> imgs_dir: Path = os.getcwd()
>>> imgs_dir = Path(imgs_dir)
>>> str(imgs_dir / "frame_%06d.png")
'/Users/steven.palma/Documents/HF/projects/lerobot/frame_%06d.png'
```