### PR TITLE
docs: add tip for Mac users regarding Terminal permissions for keyboard

### DIFF
--- a/examples/11_use_lekiwi.md
+++ b/examples/11_use_lekiwi.md
@@ -393,6 +393,10 @@ python lerobot/scripts/control_robot.py \
 ```
 
 # F. Teleoperate
+
+> [!TIP]
+> If you're using a Mac, you might need to give Terminal permission to access your keyboard. Go to System Preferences > Security & Privacy > Input Monitoring and check the box for Terminal.
+
 To teleoperate SSH into your Raspberry Pi, and run `conda activate lerobot` and this script:
 ```bash
 python lerobot/scripts/control_robot.py \


### PR DESCRIPTION
## What this does
MacOS does require to allow Terminal access keyboard otherwise python can not read keyboard.

## How it was tested
- Run locally on a laptop with MacOs

## How to checkout & try? (for the reviewer)
Run the teleoperation for le kiwi on MacOs
