### PR TITLE
Fix: Prevent Invalid next_state References When optimize_memory=True

### DIFF
--- a/lerobot/scripts/server/buffer.py
+++ b/lerobot/scripts/server/buffer.py
@@ -286,9 +286,10 @@ class ReplayBuffer:
             raise RuntimeError("Cannot sample from an empty buffer. Add transitions first.")
 
         batch_size = min(batch_size, self.size)
+        high = max(0, self.size - 1) if self.optimize_memory and self.size < self.capacity else self.size
 
         # Random indices for sampling - create on the same device as storage
-        idx = torch.randint(low=0, high=self.size, size=(batch_size,), device=self.storage_device)
+        idx = torch.randint(low=0, high=high, size=(batch_size,), device=self.storage_device)
 
         # Identify image keys that need augmentation
         image_keys = [k for k in self.states if k.startswith("observation.image")] if self.use_drq else []


### PR DESCRIPTION
## What this does
When `optimize_memory=True`, the `ReplayBuffer` avoids redundant `next_state` storage by referencing `state[i+1]`. However, if the buffer is not full, sampling indices near `self.size` could reference uninitialized memory, leading to invalid `next_state` values (e.g., black images).

To address this, the sampling logic has been adjusted to:

- Restrict indices to valid transitions when the buffer is not full.

- Allow full sampling when the buffer is full (circular buffer behavior).

## How it was tested
A training experiment was run, confirming no errors related to black images.