### PR TITLE
[Enhance] support depth image when aggregating stats

### DIFF
--- a/lerobot/common/datasets/compute_stats.py
+++ b/lerobot/common/datasets/compute_stats.py
@@ -119,8 +119,11 @@ def _assert_type_and_shape(stats_list: list[dict[str, dict]]):
                     raise ValueError("Number of dimensions must be at least 1, and is 0 instead.")
                 if k == "count" and v.shape != (1,):
                     raise ValueError(f"Shape of 'count' must be (1), but is {v.shape} instead.")
-                if "image" in fkey and k != "count" and v.shape != (3, 1, 1):
-                    raise ValueError(f"Shape of '{k}' must be (3,1,1), but is {v.shape} instead.")
+                if "image" in fkey and k != "count":
+                    if "depth" not in fkey and v.shape != (3, 1, 1):
+                        raise ValueError(f"Shape of '{k}' must be (3,1,1), but is {v.shape} instead.")
+                    if "depth" in fkey and v.shape != (1, 1, 1):
+                        raise ValueError(f"Shape of '{k}' must be (1,1,1), but is {v.shape} instead.")
 
 
 def aggregate_feature_stats(stats_ft_list: list[dict[str, dict]]) -> dict[str, dict[str, np.ndarray]]:


### PR DESCRIPTION
## What this does
This update introduces support for aggregating stats from depth images.

A depth image has shape like `[H, W, 1]`, after dim reduction, we got shape `[1, 1, 1]`.

