### PR TITLE
Add websocket serving and open loop evaluation

### DIFF
--- a/lerobot/common/datasets/utils.py
+++ b/lerobot/common/datasets/utils.py
@@ -419,6 +419,9 @@ def dataset_to_policy_features(features: dict[str, dict]) -> dict[str, PolicyFea
             type = FeatureType.ACTION
         else:
             continue
+        
+        if 'depth' in key:
+            continue
 
         policy_features[key] = PolicyFeature(
             type=type,

--- a/lerobot/common/datasets/v21/convert_dataset_v20_to_v21.py
+++ b/lerobot/common/datasets/v21/convert_dataset_v20_to_v21.py
@@ -59,7 +59,8 @@ def convert_dataset(
     num_workers: int = 4,
 ):
     with SuppressWarnings():
-        dataset = LeRobotDataset(repo_id, revision=V20, force_cache_sync=True)
+        # dataset = LeRobotDataset(repo_id, revision=V20, force_cache_sync=True)
+        dataset = LeRobotDataset("move_reel_test_0322")
 
     if (dataset.root / EPISODES_STATS_PATH).is_file():
         (dataset.root / EPISODES_STATS_PATH).unlink()

--- a/lerobot/common/policies/act/modeling_act.py
+++ b/lerobot/common/policies/act/modeling_act.py
@@ -107,6 +107,20 @@ class ACTPolicy(PreTrainedPolicy):
             self._action_queue = deque([], maxlen=self.config.n_action_steps)
 
     @torch.no_grad
+    def select_action_chunk(self, batch: dict[str, Tensor]) -> Tensor:
+        """Select the entire action chunk given environment observations.
+
+        This method wraps `select_action_chunk` in order to return all actions the policy infers at a time.
+        Resuse the `select_action` method in order to reuse the open source lerobot, but its performance may
+        decrease a bit.
+        """
+        first_action = self.select_action(batch)        
+        result_tensor = torch.cat([first_action] + list(self._action_queue), dim=0)
+        self._action_queue = deque([], maxlen=self.config.n_action_steps)
+        return result_tensor
+
+
+    @torch.no_grad
     def select_action(self, batch: dict[str, Tensor]) -> Tensor:
         """Select a single action given environment observations.
 

--- a/lerobot/common/policies/diffusion/modeling_diffusion.py
+++ b/lerobot/common/policies/diffusion/modeling_diffusion.py
@@ -143,6 +143,19 @@ class DiffusionPolicy(PreTrainedPolicy):
         action = self._queues["action"].popleft()
         return action
 
+    @torch.no_grad
+    def select_action_chunk(self, batch: dict[str, Tensor]) -> Tensor:
+        """Select the entire action chunk given environment observations.
+
+        This method wraps `select_action_chunk` in order to return all actions the policy infers at a time.
+        Resuse the `select_action` method in order to reuse the open source lerobot, but its performance may
+        decrease a bit.
+        """
+        first_action = self.select_action(batch)        
+        result_tensor = torch.cat([first_action] + list(self._action_queue), dim=0)
+        self._action_queue = deque([], maxlen=self.config.n_action_steps)
+        return result_tensor
+
     def forward(self, batch: dict[str, Tensor]) -> tuple[Tensor, None]:
         """Run the batch through the model and compute the loss for training or validation."""
         batch = self.normalize_inputs(batch)

--- a/lerobot/common/policies/normalize.py
+++ b/lerobot/common/policies/normalize.py
@@ -168,6 +168,7 @@ class Normalize(nn.Module):
                 std = buffer["std"]
                 assert not torch.isinf(mean).any(), _no_stats_error_str("mean")
                 assert not torch.isinf(std).any(), _no_stats_error_str("std")
+                print("process key:", key)
                 batch[key] = (batch[key] - mean) / (std + 1e-8)
             elif norm_mode is NormalizationMode.MIN_MAX:
                 min = buffer["min"]

--- a/lerobot/common/policies/pretrained.py
+++ b/lerobot/common/policies/pretrained.py
@@ -197,3 +197,12 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
         with caching.
         """
         raise NotImplementedError
+    
+    @abc.abstractmethod
+    def select_action_chunk(self, batch: dict[str, Tensor]) -> Tensor:
+        """Return one action to run in the environment (potentially in batch mode).
+
+        When the model uses a history of observations, or outputs a sequence of actions, this method deals
+        with caching.
+        """
+        raise NotImplementedError

--- a/lerobot/common/serving/websocket_policy_server.py
+++ b/lerobot/common/serving/websocket_policy_server.py
@@ -94,9 +94,10 @@ class WebsocketPolicyServer:
                     if isinstance(obs[key], torch.Tensor):
                         obs[key] = obs[key].to("cuda", non_blocking=True)
                         
-                with torch.inference_mode():     
-                    action = self._policy.select_action(obs)
-                    print("inference once with action:", action)
+                with torch.inference_mode():
+                    action = self._policy.select_action_chunk(obs)
+                    action = action.squeeze(0)
+                    print("inference once with action:", action.shape, action)
                     res = {"actions": action.cpu().numpy()}
                 await websocket.send(packer.pack(res))
             except websockets.ConnectionClosed:

--- a/lerobot/common/serving/websocket_policy_server.py
+++ b/lerobot/common/serving/websocket_policy_server.py
@@ -1,0 +1,111 @@
+import asyncio
+import logging
+import traceback
+import einops
+
+import numpy as np
+import torch
+import websockets.asyncio.server
+import websockets.frames
+
+import lerobot.common.utils.msgpack_utils as msgpack_utils
+from lerobot.common.policies.pretrained import PreTrainedPolicy
+
+class WebsocketPolicyServer:
+    """Serves a policy using the websocket protocol. See websocket_client_policy.py for a client implementation.
+
+    Currently only implements the `load` and `infer` methods.
+    """
+
+    def __init__(
+        self,
+        policy: PreTrainedPolicy,
+        host: str = "0.0.0.0",
+        port: int = 8000,
+        metadata: dict | None = None,
+    ) -> None:
+        self._policy = policy
+        self._host = host
+        self._port = port
+        self._metadata = metadata or {}        
+
+    def serve_forever(self) -> None:
+        asyncio.run(self.run())
+
+    async def run(self):
+        async with websockets.asyncio.server.serve(
+            self._handler,
+            self._host,
+            self._port,
+            compression=None,
+            max_size=None,
+        ) as server:
+            await server.serve_forever()
+            
+    async def preprocess_observation(self, observations: dict) -> dict[str, torch.Tensor]:
+        images = observations['images']
+        return_observations = {}
+        
+        for imgkey, img in images.items():
+            img = torch.from_numpy(img)
+            img = einops.rearrange(img, "h w c -> c h w").contiguous()
+            c, h, w = img.shape
+            if h == 360:
+                img = torch.nn.functional.pad(img,pad=(0, 0, 60, 60), mode='constant', value=0)
+            c, h, w = img.shape
+
+            assert c < h and c < w, f"expect channel last images, but instead got {img.shape=}"
+            assert img.dtype == torch.uint8, f"expect torch.uint8, but instead {img.dtype=}"
+            img = img.unsqueeze(0)
+            img = img.type(torch.float32)
+            img /= 255
+            
+            imgkey = f"observation.images.{imgkey}"
+            print('add a key: ', imgkey, img.shape)
+            return_observations[imgkey] = img
+            
+        return_observations["observation.state"] = torch.from_numpy(observations["state"]).float()
+        return_observations["observation.state"] = return_observations["observation.state"].unsqueeze(0)
+        
+        return return_observations
+            
+
+    async def _handler(self, websocket: websockets.asyncio.server.ServerConnection):
+        logging.info(f"Connection from {websocket.remote_address} opened")
+        packer = msgpack_utils.Packer()
+
+        await websocket.send(packer.pack(self._metadata))
+
+        while True:
+            try:
+                # example
+                # obs = {
+                #     "images": {
+                #         "cam_high": numpy.NDArray,
+                #         "cam_right_wrist": numpy.NDArray,
+                #     },
+                #     "state": numpy.NDarray,
+                #     "prompt": "xxx text"
+                # }
+                obs = msgpack_utils.unpackb(await websocket.recv())
+                
+                obs = await self.preprocess_observation(obs)
+                for key in obs:
+                    if isinstance(obs[key], torch.Tensor):
+                        obs[key] = obs[key].to("cuda", non_blocking=True)
+                        
+                with torch.inference_mode():     
+                    action = self._policy.select_action(obs)
+                    print("inference once with action:", action)
+                    res = {"actions": action.cpu().numpy()}
+                await websocket.send(packer.pack(res))
+            except websockets.ConnectionClosed:
+                logging.info(f"Connection from {websocket.remote_address} closed")
+                break
+            except Exception:
+                await websocket.send(traceback.format_exc())
+                await websocket.close(
+                    code=websockets.frames.CloseCode.INTERNAL_ERROR,
+                    reason="Internal server error. Traceback included in previous frame.",
+                )
+                raise

--- a/lerobot/common/utils/msgpack_utils.py
+++ b/lerobot/common/utils/msgpack_utils.py
@@ -1,0 +1,43 @@
+import functools
+
+import msgpack
+import numpy as np
+
+
+def pack_array(obj):
+    if (isinstance(obj, (np.ndarray, np.generic))) and obj.dtype.kind in ("V", "O", "c"):
+        raise ValueError(f"Unsupported dtype: {obj.dtype}")
+
+    if isinstance(obj, np.ndarray):
+        return {
+            b"__ndarray__": True,
+            b"data": obj.tobytes(),
+            b"dtype": obj.dtype.str,
+            b"shape": obj.shape,
+        }
+
+    if isinstance(obj, np.generic):
+        return {
+            b"__npgeneric__": True,
+            b"data": obj.item(),
+            b"dtype": obj.dtype.str,
+        }
+
+    return obj
+
+
+def unpack_array(obj):
+    if b"__ndarray__" in obj:
+        return np.ndarray(buffer=obj[b"data"], dtype=np.dtype(obj[b"dtype"]), shape=obj[b"shape"])
+
+    if b"__npgeneric__" in obj:
+        return np.dtype(obj[b"dtype"]).type(obj[b"data"])
+
+    return obj
+
+
+Packer = functools.partial(msgpack.Packer, default=pack_array)
+packb = functools.partial(msgpack.packb, default=pack_array)
+
+Unpacker = functools.partial(msgpack.Unpacker, object_hook=unpack_array)
+unpackb = functools.partial(msgpack.unpackb, object_hook=unpack_array)

--- a/lerobot/common/utils/utils.py
+++ b/lerobot/common/utils/utils.py
@@ -24,6 +24,9 @@ from pathlib import Path
 
 import numpy as np
 import torch
+if hasattr(torch, 'npu'):
+    import torch_npu
+    logging.info("exists npu, import torch_npu")
 
 
 def none_or_int(value):
@@ -46,6 +49,9 @@ def auto_select_torch_device() -> torch.device:
     elif torch.backends.mps.is_available():
         logging.info("Metal backend detected, using cuda.")
         return torch.device("mps")
+    elif torch_npu.npu.is_available():
+        logging.info("Npu backend detected, using npu.")
+        return torch.device("npu")
     else:
         logging.warning("No accelerated backend detected. Using default cpu, this will be slow.")
         return torch.device("cpu")
@@ -94,8 +100,10 @@ def is_torch_device_available(try_device: str) -> bool:
         return torch.backends.mps.is_available()
     elif try_device == "cpu":
         return True
+    elif try_device == "npu":
+        return torch_npu.npu.is_available()
     else:
-        raise ValueError(f"Unknown device {try_device}. Supported devices are: cuda, mps or cpu.")
+        raise ValueError(f"Unknown device {try_device}. Supported devices are: cuda, mps, cpu or npu.")
 
 
 def is_amp_available(device: str):

--- a/lerobot/scripts/eval.py
+++ b/lerobot/scripts/eval.py
@@ -69,6 +69,7 @@ from lerobot.common.envs.factory import make_env
 from lerobot.common.envs.utils import add_envs_task, check_env_attributes_and_types, preprocess_observation
 from lerobot.common.policies.factory import make_policy
 from lerobot.common.policies.pretrained import PreTrainedPolicy
+from lerobot.common.policies.pi0.modeling_pi0 import PI0Policy
 from lerobot.common.policies.utils import get_device_from_parameters
 from lerobot.common.utils.io_utils import write_video
 from lerobot.common.utils.random_utils import set_seed
@@ -152,7 +153,7 @@ def rollout(
             all_observations.append(deepcopy(observation))
 
         observation = {
-            key: observation[key].to(device, non_blocking=device.type == "cuda") for key in observation
+            key: observation[key].to(device, non_blocking=device.type != "cuda") for key in observation
         }
 
         # Infer "task" from attributes of environments.

--- a/lerobot/scripts/openloop_eval.py
+++ b/lerobot/scripts/openloop_eval.py
@@ -1,0 +1,180 @@
+from contextlib import nullcontext
+from pprint import pformat
+from termcolor import colored
+import dataclasses
+import logging
+from typing import Iterator
+
+import wandb
+import numpy as np
+import torch
+
+import lerobot.common.datasets.lerobot_dataset as lerobot_dataset
+from lerobot.common.datasets.factory import make_dataset
+from lerobot.common.datasets.utils import cycle
+from lerobot.common.policies.factory import make_policy
+from lerobot.common.utils.utils import (
+    init_logging,
+    get_safe_torch_device,
+)
+from lerobot.common.utils.random_utils import set_seed
+from lerobot.configs import parser
+from lerobot.configs.train import TrainPipelineConfig
+
+class EpisodeSampler(torch.utils.data.Sampler):
+    def __init__(self, dataset: lerobot_dataset.LeRobotDataset, episode_index: int):
+        from_idx = dataset.episode_data_index["from"][episode_index].item()
+        to_idx = dataset.episode_data_index["to"][episode_index].item()
+        self.frame_ids = range(from_idx, to_idx)
+
+    def __iter__(self) -> Iterator:
+        return iter(self.frame_ids)
+
+    def __len__(self) -> int:
+        return len(self.frame_ids)
+
+@parser.wrap()
+def main(cfg: TrainPipelineConfig):
+    init_logging()
+    logging.info(pformat(dataclasses.asdict(cfg)))
+
+    device = get_safe_torch_device(cfg.policy.device, log=True)
+    torch.backends.cudnn.benchmark = True
+    torch.backends.cuda.matmul.allow_tf32 = True
+    set_seed(cfg.seed)
+
+    wandb.init(
+        name=cfg.job_name,
+        config=dataclasses.asdict(cfg),
+        project="lerobot",
+    )
+    
+    logging.info(colored("Output dir:", "yellow", attrs=["bold"]) + f" {cfg.output_dir}")
+
+    logging.info("Making dataset.")
+    dataset = make_dataset(cfg)
+    dataset.meta.info['features']['observation.state']['shape'] = (13,)
+    dataset.meta.info['features']['observation.state']['names'] = ['left_arm_1', 'left_arm_2', 'left_arm_3', 'left_arm_4', 'left_arm_5', 'left_arm_6', 
+                                                               'right_arm_1', 'right_arm_2', 'right_arm_3', 'right_arm_4', 'right_arm_5', 'right_arm_6', 'vacuum']
+    dataset.meta.info['features']['action']['shape'] = (13,)
+    dataset.meta.info['features']['action']['names'] = ['left_arm_exp_1', 'left_arm_exp_2', 'left_arm_exp_3', 'left_arm_exp_4', 'left_arm_exp_5', 'left_arm_exp_6', 
+                                                    'right_arm_exp_1', 'right_arm_exp_2', 'right_arm_exp_3', 'right_arm_exp_4', 'right_arm_exp_5', 'right_arm_exp_6', 'vacuum_exp']
+    
+    for key, episode_stats in dataset.meta.episodes_stats.items():
+                for feature in ['observation.state', 'action']:
+                    for sub_feature in ['min', 'max', 'mean', 'std']:
+                        episode_stats[feature][sub_feature] = np.delete(episode_stats[feature][sub_feature], [6,13], axis=0)
+                        dataset.meta.episodes_stats[key] = episode_stats
+    for feature in ['min', 'max', 'mean', 'std']:
+        dataset.meta.stats['observation.state'][feature] = np.delete(dataset.meta.stats['observation.state'][feature], [6,13], axis=0)
+        dataset.meta.stats['action'][feature] = np.delete(dataset.meta.stats['action'][feature], [6,13], axis=0)
+    
+
+    logging.info("Making policy.")
+    policy = make_policy(
+        cfg=cfg.policy,
+        ds_meta=dataset.meta,
+    )
+    
+    # TODO: 支持多条，从配置读取
+    episode_index = 0
+    
+    sampler = EpisodeSampler(
+        dataset,  episode_index
+    )
+    data_len = len(sampler)
+    print("entire data len:", data_len)
+    dataloader = torch.utils.data.DataLoader(
+        dataset,
+        num_workers=cfg.num_workers,
+        batch_size=cfg.batch_size,
+        sampler=sampler,
+    )
+    
+    policy.eval()
+    
+    # aloha
+    # dim_names = [
+    #     "arm_left_0", "arm_left_1", "arm_left_2", "arm_left_3", "arm_left_4", "arm_left_5",
+    #     "arm_left_gripper_0", "arm_left_gripper_1",
+    #     "arm_right_0", "arm_right_1", "arm_right_2", "arm_right_3", "arm_right_4", "arm_right_5",
+    #     "arm_right_gripper_0", "arm_right_gripper_1",
+    # ]
+    
+    # galaxea vacumn - 13 dim
+    dim_names = [
+        "arm_left_0", "arm_left_1", "arm_left_2", "arm_left_3", "arm_left_4", "arm_left_5",
+        "arm_right_0", "arm_right_1", "arm_right_2", "arm_right_3", "arm_right_4", "arm_right_5",
+        "arm_right_vacumn",
+    ]
+    # galaxea vacumn - 15 dim
+    # dim_names = [
+    #     "arm_left_0", "arm_left_1", "arm_left_2", "arm_left_3", "arm_left_4", "arm_left_5", "arm_left_gripper",
+    #     "arm_right_0", "arm_right_1", "arm_right_2", "arm_right_3", "arm_right_4", "arm_right_5","arm_right_gripper",
+    #     "arm_right_vacumn",
+    # ]
+    
+    with torch.no_grad(), torch.autocast(device_type=device.type) if cfg.policy.use_amp else nullcontext():
+        # infer_action = policy.forward(input_raw_data)
+        dl_iter = cycle(dataloader)
+        
+        # skip the first few frames
+        for i in range(50):
+            a = next(dl_iter)
+        
+        
+        for step in range(200):
+            # 准备数据
+            input_raw_data = next(dl_iter)
+            
+            # shape记录 galaxea
+            # observation.images.front: torch.Size([batch, 3, 360, 640])
+            # observation.images.wrist_right: torch.Size([batch, 3, 480, 640])
+            # observation.state torch.Size([batch, 15])
+            if 'observation.images.depth' in input_raw_data:
+                del input_raw_data['observation.images.depth']
+                
+            if input_raw_data["observation.state"].shape[-1] == 15:
+                keep_cols = [i for i in range(15) if i not in {6, 13}]
+                # 切片操作删除指定列
+                input_raw_data["observation.state"] = input_raw_data["observation.state"][..., keep_cols]
+                print("state shape", input_raw_data["observation.state"].shape)
+                
+            if input_raw_data["action"].shape[-1] == 15:
+                keep_cols = [i for i in range(15) if i not in {6, 13}]
+                input_raw_data["action"] = input_raw_data["action"][..., keep_cols]
+                print("action shape", input_raw_data["action"].shape)
+            
+            for key in input_raw_data:
+                if isinstance(input_raw_data[key], torch.Tensor):
+                    input_raw_data[key] = input_raw_data[key].to(device, non_blocking=True)
+                    
+            # the front camera resolution is 640x360, pad it to 640x480 which is the resolution of the wrist camera
+            input_raw_data['observation.images.front'] = torch.nn.functional.pad(
+                input_raw_data['observation.images.front'], 
+                pad=(0, 0, 60, 60),  # 左右不填充，上下各填充60
+                mode='constant', 
+                value=0  # black
+            )
+            logging.warning("pad the front images to ", input_raw_data['observation.images.front'].shape)
+            
+            # 推理
+            infer_action = policy.select_action(input_raw_data)
+            infer_action = infer_action[0].cpu().numpy()
+            
+            
+            origin_action = input_raw_data["action"].cpu().numpy()[0][0]
+            
+            # 记录每个action dim的差异
+            diff = infer_action - origin_action
+            log_dict = {}
+            for dim in range(cfg.policy.output_features["action"].shape[0]):
+                key = f"{dim_names[dim]}_diff"
+                log_dict[key] = diff[dim]
+            
+            wandb.log(log_dict)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/lerobot/scripts/serving_policy.py
+++ b/lerobot/scripts/serving_policy.py
@@ -1,0 +1,81 @@
+import dataclasses
+import enum
+import logging
+import socket
+import tyro
+
+import torch
+
+from lerobot.common.utils.utils import (
+    init_logging,
+    get_safe_torch_device,
+)
+from lerobot.common.utils.random_utils import set_seed
+from lerobot.configs import parser
+from lerobot.configs.eval import EvalPipelineConfig
+from lerobot.common.serving.websocket_policy_server import WebsocketPolicyServer
+from lerobot.common.policies.act.modeling_act import ACTPolicy
+from lerobot.common.policies.diffusion.modeling_diffusion import DiffusionPolicy
+
+
+class PolicyType(enum.Enum):
+    """Supported environments."""
+
+    ACT = "act"
+    DIFFUSION = "diffusion"
+    PI0 = "pi0"
+
+@dataclasses.dataclass
+class Checkpoint:
+    """Load a policy from a trained checkpoint."""
+
+    # Checkpoint directory (e.g., "outputs/train/act_move_reel_0322_nodepth/checkpoints/040000/pretrained_mode").
+    path: str
+    
+    # policy type
+    type: str
+
+@dataclasses.dataclass
+class Args:
+    """Arguments for the serve_policy script."""
+    # If provided, will be used in case the "prompt" key is not present in the data, or if the model doesn't have a default
+    # prompt.
+    default_prompt: str | None = None
+
+    # Port to serve the policy on.
+    port: int = 8000
+    # Record the policy's behavior for debugging.
+    record: bool = False
+
+    # Specifies how to load the policy. If not provided, the default policy for the environment will be used.
+    policy: Checkpoint = dataclasses.field(default_factory=Checkpoint)
+
+def main(args: Args) -> None:
+    torch.backends.cudnn.benchmark = True
+    torch.backends.cuda.matmul.allow_tf32 = True
+    set_seed(1000)
+    
+    print(args)
+    
+    # policy has been in device and evaluated
+    if args.policy.type == PolicyType.ACT.value:
+        policy = ACTPolicy.from_pretrained(args.policy.path)
+    elif args.policy.type == PolicyType.DIFFUSION.value:
+        policy = DiffusionPolicy.from_pretrained(args.policy.path)
+    
+    # Record the policy's behavior.
+    # if args.record:
+    #     policy = _policy.PolicyRecorder(policy, "policy_records")
+
+    server = WebsocketPolicyServer(
+        policy=policy,
+        host="0.0.0.0",
+        port=args.port,
+        metadata={},
+    )
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    init_logging()
+    main(tyro.cli(Args))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ dynamixel = ["dynamixel-sdk>=3.7.31", "pynput>=1.7.7"]
 feetech = ["feetech-servo-sdk>=1.0.0", "pynput>=1.7.7"]
 intelrealsense = ["pyrealsense2>=2.55.1.6486 ; sys_platform != 'darwin'"]
 pi0 = ["transformers>=4.48.0"]
+serving = ["websockets==14.1", "msgpack==1.1.0", "tyro"]
 pusht = ["gym-pusht>=0.1.5 ; python_version < '4.0'"]
 stretch = [
     "hello-robot-stretch-body>=0.7.27 ; python_version < '4.0' and sys_platform == 'linux'",

--- a/tests/serving/test_websocket_serving.py
+++ b/tests/serving/test_websocket_serving.py
@@ -1,0 +1,43 @@
+import logging
+import time
+
+import numpy as np
+import websockets.sync.client
+
+import lerobot.common.utils.msgpack_utils as msgpack_utils
+
+input = {
+    "state": np.ones((13,)),
+    "images": {
+        # input images from client has spec h w c (client)
+        "front": np.random.randint(256, size=(480, 640, 3), dtype=np.uint8),
+        "wrist_right": np.random.randint(256, size=(480, 640, 3), dtype=np.uint8),
+    },
+    "prompt": "do something",
+}
+
+url = "ws://127.0.0.1:8000"
+packer = msgpack_utils.Packer()
+
+logging.info(f"Waiting for server at {url}...")
+while True:
+    try:
+        conn = websockets.sync.client.connect(url, compression=None, max_size=None)
+        metadata = msgpack_utils.unpackb(conn.recv())
+        break
+    except ConnectionRefusedError:
+        logging.info("Still waiting for server...")
+        time.sleep(5)
+        
+data = packer.pack(input)
+conn.send(data)
+response = conn.recv()
+if isinstance(response, str):
+    # we're expecting bytes; if the server sends a string, it's an error.
+    print(f"Error in inference server:\n{response}")
+    exit()
+
+infer_result = msgpack_utils.unpackb(response)
+print(infer_result)
+assert len(infer_result['actions'][0]) == len(input['state'])
+

--- a/tests/serving/test_websocket_serving.py
+++ b/tests/serving/test_websocket_serving.py
@@ -38,6 +38,6 @@ if isinstance(response, str):
     exit()
 
 infer_result = msgpack_utils.unpackb(response)
-print(infer_result)
+print(infer_result['actions'].shape, infer_result)
 assert len(infer_result['actions'][0]) == len(input['state'])
 


### PR DESCRIPTION
## Add websocket serving and open loop evaluation

1. Add websocket serving which is compatible with the openpi client
2. Add open-loop evaluation

## Usage
1. websocket serving
```bash
python lerobot/scripts/serving_policy.py --policy.type=act --policy.path=./outputs/train/act_move_reel_0322_nodepth_nogripper/checkpoints/100000/pretrained_model
```

2. open-loop evaluation
the current open-loop eval implementation reuse `TrainPipelineConfig` in `train.py`, so an additional  
```bash
python lerobot/scripts/openloop_eval.py  --dataset.root=data/move_reel_test_0322 --dataset.repo_id=move_reel_test_0322 --resume=true --config_path=outputs/train/act_move_reel_0322_nodepth/checkpoints/040000/pretrained_model --batch_size=1 --policy.n_action_steps=1
```