### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,10 @@ Install 🤗 LeRobot:
 pip install --no-binary=av -e .
 ```
 
-> **NOTE:** If you encounter build errors, you may need to install additional dependencies (`cmake`, `build-essential`, and `ffmpeg libs`). On Linux, run:
-`sudo apt-get install cmake build-essential python-dev pkg-config libavformat-dev libavcodec-dev libavdevice-dev libavutil-dev libswscale-dev libswresample-dev libavfilter-dev pkg-config`. For other systems, see: [Compiling PyAV](https://pyav.org/docs/develop/overview/installation.html#bring-your-own-ffmpeg)
+> **NOTE:** If you encounter build errors, you may need to install additional dependencies (`cmake`, `build-essential`, and `ffmpeg libs`).:
+> - **Linux:** Run `sudo apt-get install cmake build-essential python-dev pkg-config libavformat-dev libavcodec-dev libavdevice-dev libavutil-dev libswscale-dev libswresample-dev libavfilter-dev pkg-config`
+> - **macOS:** Run `brew install ffmpeg@6 pkg-config` (as higher ffmpeg versions are not compatible with the av version required by lerobot)
+> - **Other systems:** See [Compiling PyAV](https://pyav.org/docs/develop/overview/installation.html#bring-your-own-ffmpeg) for system-specific instructions.
 
 For simulations, 🤗 LeRobot comes with gymnasium environments that can be installed as extras:
 - [aloha](https://github.com/huggingface/gym-aloha)


### PR DESCRIPTION
# Readme update
I have tried installing le robot on 3 different macs following instruction step by step and step:
`pip install --no-binary=av -e .` never worked, I always got :
```
building 'av.plane' extension
      creating build/temp.macosx-11.1-arm64-cpython-312/src/av
      clang -fno-strict-overflow -Wsign-compare -Wunreachable-code -DNDEBUG -O2 -Wall -fPIC -O2 -isystem /opt/miniconda3/include -arch arm64 -fPIC -O2 -isystem /opt/miniconda3/include -arch arm64 -I/opt/homebrew/Cellar/ffmpeg/7.1.1_1/include -I/opt/miniconda3/include/python3.12 -c src/av/plane.c -o build/temp.macosx-11.1-arm64-cpython-312/src/av/plane.o
      src/av/plane.c:5655:13: warning: code will never be executed [-Wunreachable-code]
                  goto bad;
                  ^~~~~~~~
      1 warning generated.
      clang -bundle -undefined dynamic_lookup -Wl,-rpath,/opt/miniconda3/lib -L/opt/miniconda3/lib -Wl,-rpath,/opt/miniconda3/lib -L/opt/miniconda3/lib build/temp.macosx-11.1-arm64-cpython-312/src/av/plane.o -L/opt/homebrew/Cellar/ffmpeg/7.1.1_1/lib -lavdevice -lavfilter -lavformat -lavcodec -lswscale -lswresample -lavutil -o build/lib.macosx-11.1-arm64-cpython-312/av/plane.cpython-312-darwin.so
      ld: warning: duplicate -rpath '/opt/miniconda3/lib' ignored
      building 'av.dictionary' extension
      clang -fno-strict-overflow -Wsign-compare -Wunreachable-code -DNDEBUG -O2 -Wall -fPIC -O2 -isystem /opt/miniconda3/include -arch arm64 -fPIC -O2 -isystem /opt/miniconda3/include -arch arm64 -I/opt/homebrew/Cellar/ffmpeg/7.1.1_1/include -I/opt/miniconda3/include/python3.12 -c src/av/dictionary.c -o build/temp.macosx-11.1-arm64-cpython-312/src/av/dictionary.o
      src/av/dictionary.c:6350:13: warning: code will never be executed [-Wunreachable-code]
                  goto bad;
                  ^~~~~~~~
      1 warning generated.
      clang -bundle -undefined dynamic_lookup -Wl,-rpath,/opt/miniconda3/lib -L/opt/miniconda3/lib -Wl,-rpath,/opt/miniconda3/lib -L/opt/miniconda3/lib build/temp.macosx-11.1-arm64-cpython-312/src/av/dictionary.o -L/opt/homebrew/Cellar/ffmpeg/7.1.1_1/lib -lavdevice -lavfilter -lavformat -lavcodec -lswscale -lswresample -lavutil -o build/lib.macosx-11.1-arm64-cpython-312/av/dictionary.cpython-312-darwin.so
      ld: warning: duplicate -rpath '/opt/miniconda3/lib' ignored
      building 'av.stream' extension
      clang -fno-strict-overflow -Wsign-compare -Wunreachable-code -DNDEBUG -O2 -Wall -fPIC -O2 -isystem /opt/miniconda3/include -arch arm64 -fPIC -O2 -isystem /opt/miniconda3/include -arch arm64 -I/opt/homebrew/Cellar/ffmpeg/7.1.1_1/include -I/opt/miniconda3/include/python3.12 -c src/av/stream.c -o build/temp.macosx-11.1-arm64-cpython-312/src/av/stream.o
      src/av/stream.c:4930:31: warning: 'nb_side_data' is deprecated [-Wdeprecated-declarations]
        __pyx_t_1 = __pyx_v_stream->nb_side_data;
                                    ^
      /opt/homebrew/Cellar/ffmpeg/7.1.1_1/include/libavformat/avformat.h:878:5: note: 'nb_side_data' has been explicitly marked deprecated here
          attribute_deprecated
          ^
      /opt/homebrew/Cellar/ffmpeg/7.1.1_1/include/libavutil/attributes.h:100:49: note: expanded from macro 'attribute_deprecated'
      #    define attribute_deprecated __attribute__((deprecated))
                                                      ^
      src/av/stream.c:4964:35: warning: 'side_data' is deprecated [-Wdeprecated-declarations]
          __pyx_t_5 = ((__pyx_v_stream->side_data[__pyx_v_i]).type == AV_PKT_DATA_DISPLAYMATRIX);
                                        ^
      /opt/homebrew/Cellar/ffmpeg/7.1.1_1/include/libavformat/avformat.h:870:5: note: 'side_data' has been explicitly marked deprecated here
          attribute_deprecated
          ^
      /opt/homebrew/Cellar/ffmpeg/7.1.1_1/include/libavutil/attributes.h:100:49: note: expanded from macro 'attribute_deprecated'
      #    define attribute_deprecated __attribute__((deprecated))
                                                      ^
      src/av/stream.c:4974:97: warning: 'side_data' is deprecated [-Wdeprecated-declarations]
            __pyx_t_2 = PyFloat_FromDouble(av_display_rotation_get(((int32_t const *)(__pyx_v_stream->side_data[__pyx_v_i]).data))); if (unlikely(!__pyx_t_2)) __PYX_ERR(0, 141, __pyx_L1_error)
                                                                                                      ^
      /opt/homebrew/Cellar/ffmpeg/7.1.1_1/include/libavformat/avformat.h:870:5: note: 'side_data' has been explicitly marked deprecated here
          attribute_deprecated
          ^
      /opt/homebrew/Cellar/ffmpeg/7.1.1_1/include/libavutil/attributes.h:100:49: note: expanded from macro 'attribute_deprecated'
      #    define attribute_deprecated __attribute__((deprecated))
                                                      ^
      src/av/stream.c:8617:13: warning: code will never be executed [-Wunreachable-code]
                  goto bad;
                  ^~~~~~~~
      4 warnings generated.
      clang -bundle -undefined dynamic_lookup -Wl,-rpath,/opt/miniconda3/lib -L/opt/miniconda3/lib -Wl,-rpath,/opt/miniconda3/lib -L/opt/miniconda3/lib build/temp.macosx-11.1-arm64-cpython-312/src/av/stream.o -L/opt/homebrew/Cellar/ffmpeg/7.1.1_1/lib -lavdevice -lavfilter -lavformat -lavcodec -lswscale -lswresample -lavutil -o build/lib.macosx-11.1-arm64-cpython-312/av/stream.cpython-312-darwin.so
      ld: warning: duplicate -rpath '/opt/miniconda3/lib' ignored
      building 'av.option' extension
      clang -fno-strict-overflow -Wsign-compare -Wunreachable-code -DNDEBUG -O2 -Wall -fPIC -O2 -isystem /opt/miniconda3/include -arch arm64 -fPIC -O2 -isystem /opt/miniconda3/include -arch arm64 -I/opt/homebrew/Cellar/ffmpeg/7.1.1_1/include -I/opt/miniconda3/include/python3.12 -c src/av/option.c -o build/temp.macosx-11.1-arm64-cpython-312/src/av/option.o
      src/av/option.c:7419:51: error: use of undeclared identifier 'AV_OPT_TYPE_CHANNEL_LAYOUT'; did you mean 'AV_OPT_TYPE_CHLAYOUT'?
        __pyx_t_3 = __Pyx_PyInt_From_enum__AVOptionType(AV_OPT_TYPE_CHANNEL_LAYOUT); if (unlikely(!__pyx_t_3)) __PYX_ERR(0, 36, __pyx_L1_error)
                                                        ^~~~~~~~~~~~~~~~~~~~~~~~~~
                                                        AV_OPT_TYPE_CHLAYOUT
      /opt/homebrew/Cellar/ffmpeg/7.1.1_1/include/libavutil/opt.h:331:5: note: 'AV_OPT_TYPE_CHLAYOUT' declared here
          AV_OPT_TYPE_CHLAYOUT,
          ^
      src/av/option.c:7593:52: error: use of undeclared identifier 'AV_OPT_TYPE_CHANNEL_LAYOUT'; did you mean 'AV_OPT_TYPE_CHLAYOUT'?
        __pyx_t_17 = __Pyx_PyInt_From_enum__AVOptionType(AV_OPT_TYPE_CHANNEL_LAYOUT); if (unlikely(!__pyx_t_17)) __PYX_ERR(0, 47, __pyx_L1_error)
                                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~
                                                         AV_OPT_TYPE_CHLAYOUT
      /opt/homebrew/Cellar/ffmpeg/7.1.1_1/include/libavutil/opt.h:331:5: note: 'AV_OPT_TYPE_CHLAYOUT' declared here
          AV_OPT_TYPE_CHLAYOUT,
          ^
      2 errors generated.
      error: command '/usr/bin/clang' failed with exit code 1
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for av
Successfully built lerobot
Failed to build av
```
This is because ffmpeg has changed `AV_OPT_TYPE_CHANNEL_LAYOUT` to  `AV_OPT_TYPE_CHLAYOUT` in version 7 which is incompatible with older versions of av (I think).
And from what I understand we can't bump the `av` version as we use an older version of openCV, so the only alternative I have found it to force ffmpeg to version 6.x.x.

### Note:
`conda install ffmpeg` has not worked to resolve this error for me, but there might be something to look at here, instead of changing the system ffmpeg.






