### PR TITLE
Add convert stats in parallel using multiple thread and decord video backend

### DIFF
--- a/lerobot/common/datasets/v21/convert_dataset_v20_to_v21.py
+++ b/lerobot/common/datasets/v21/convert_dataset_v20_to_v21.py
@@ -38,7 +38,7 @@ from huggingface_hub import HfApi
 
 from lerobot.common.datasets.lerobot_dataset import CODEBASE_VERSION, LeRobotDataset
 from lerobot.common.datasets.utils import EPISODES_STATS_PATH, STATS_PATH, load_stats, write_info
-from lerobot.common.datasets.v21.convert_stats import check_aggregate_stats, convert_stats
+from lerobot.common.datasets.v21.convert_stats import check_aggregate_stats, convert_stats, convert_stats_parallel
 
 V20 = "v2.0"
 V21 = "v2.1"
@@ -57,14 +57,15 @@ def convert_dataset(
     repo_id: str,
     branch: str | None = None,
     num_workers: int = 4,
+    video_backend: str = "pyav",
 ):
     with SuppressWarnings():
-        dataset = LeRobotDataset(repo_id, revision=V20, force_cache_sync=True)
+        dataset = LeRobotDataset(repo_id, revision=V20, force_cache_sync=True, video_backend=video_backend)
 
     if (dataset.root / EPISODES_STATS_PATH).is_file():
         (dataset.root / EPISODES_STATS_PATH).unlink()
 
-    convert_stats(dataset, num_workers=num_workers)
+    convert_stats_parallel(dataset, num_workers=num_workers)
     ref_stats = load_stats(dataset.root)
     check_aggregate_stats(dataset, ref_stats)
 

--- a/lerobot/common/datasets/v21/convert_dataset_v20_to_v21.py
+++ b/lerobot/common/datasets/v21/convert_dataset_v20_to_v21.py
@@ -38,7 +38,10 @@ from huggingface_hub import HfApi
 
 from lerobot.common.datasets.lerobot_dataset import CODEBASE_VERSION, LeRobotDataset
 from lerobot.common.datasets.utils import EPISODES_STATS_PATH, STATS_PATH, load_stats, write_info
-from lerobot.common.datasets.v21.convert_stats import check_aggregate_stats, convert_stats, convert_stats_parallel
+from lerobot.common.datasets.v21.convert_stats import (
+    check_aggregate_stats,
+    convert_stats_parallel,
+)
 
 V20 = "v2.0"
 V21 = "v2.1"

--- a/lerobot/common/datasets/video_utils.py
+++ b/lerobot/common/datasets/video_utils.py
@@ -257,11 +257,11 @@ def decode_video_frames_decord(
     frame_ts: np.ndarray = vr.get_frame_timestamp(range(num_frames))
     indices = np.abs(frame_ts[:, :1] - timestamps).argmin(axis=0)
     frames = vr.get_batch(indices)
-    
+
     frames_tensor = torch.tensor(frames.asnumpy()).type(torch.float32).permute(0, 3, 1, 2) / 255
     return frames_tensor
 
-    
+
 def encode_video_frames(
     imgs_dir: Path | str,
     video_path: Path | str,

--- a/lerobot/common/datasets/video_utils.py
+++ b/lerobot/common/datasets/video_utils.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import Any, ClassVar
 
 import decord
+import numpy as np
 import pyarrow as pa
 import torch
 import torchvision
@@ -249,7 +250,7 @@ def decode_video_frames_torchcodec(
 def decode_video_frames_decord(
     video_path: Path | str,
     timestamps: list[float],
-) -> torch.Tensor::
+) -> torch.Tensor:
     video_path = str(video_path)
     vr = decord.VideoReader(video_path)
     num_frames = len(vr)


### PR DESCRIPTION

## What this does
1.Use process pools to speed up episode stats conversion
2.Add decord(https://github.com/dmlc/decord) as video backend to speed up video parsing

I have tested it on multiple OXE datasets, such as the droid dataset. Using the original multithread, num_workers=8, it takes about 300 hours, and using the process pool, num_workers=128, it takes about 20 hours