### PR TITLE
debug: change the data type of expected_shape to tuple

### DIFF
--- a/lerobot/common/datasets/utils.py
+++ b/lerobot/common/datasets/utils.py
@@ -757,7 +757,7 @@ def validate_feature_numpy_array(
         if actual_dtype != np.dtype(expected_dtype):
             error_message += f"The feature '{name}' of dtype '{actual_dtype}' is not of the expected dtype '{expected_dtype}'.\n"
 
-        if actual_shape != expected_shape:
+        if actual_shape != tuple(expected_shape):
             error_message += f"The feature '{name}' of shape '{actual_shape}' does not have the expected shape '{expected_shape}'.\n"
     else:
         error_message += f"The feature '{name}' is not a 'np.ndarray'. Expected type is '{expected_dtype}', but type '{type(value)}' provided instead.\n"


### PR DESCRIPTION
## What this does
When creating a LeRobot dataset and calling add_frame, the validate_frame function was raising an error due to a type mismatch between expected_shape and actual_shape. This fix ensures both shapes are of type tuple, preventing validation errors during dataset creation.

## How it was tested
Verified that the dataset creation process completes without shape validation errors
