### PR TITLE
Reset policy and env together

### DIFF
--- a/lerobot/scripts/control_robot.py
+++ b/lerobot/scripts/control_robot.py
@@ -316,6 +316,8 @@ def record(
         ):
             log_say("Reset the environment", cfg.play_sounds)
             reset_environment(robot, events, cfg.reset_time_s, cfg.fps)
+            if policy is not None:
+                policy.reset()
 
         if events["rerecord_episode"]:
             log_say("Re-record episode", cfg.play_sounds)


### PR DESCRIPTION
## What this does

When evaluating the trained policy, the environment is reset at the beginning of each episode. However, since the policy is not being reset, the action queue is not cleared, and an action from the previous episode is used as the first action of the next episode.

To prevent this, I reset the policy together with the environment.

## How it was tested

I tested the pi0 model on the Aloha robot using this code.

## How to checkout & try? (for the reviewer)
Provide a simple way for the reviewer to try out your changes.

Examples:
```bash
pytest -sx tests/test_stuff.py::test_something
```
```bash
python lerobot/scripts/train.py --some.option=true
```

## SECTION TO REMOVE BEFORE SUBMITTING YOUR PR
**Note**: Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR. Try to avoid tagging more than 3 people.

**Note**: Before submitting this PR, please read the [contributor guideline](https://github.com/huggingface/lerobot/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr).
