### PR TITLE
feat(dependency): Bump `torch` beyond 2.6.0 & `torchcodec` beyond 0.2.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ dependencies = [
     "pyzmq>=26.2.1",
     "rerun-sdk>=0.21.0",
     "termcolor>=2.4.0",
-    "torch>=2.2.1,<2.7",
+    "torch>=2.2.1",
     "torchcodec>=0.2.1; sys_platform != 'win32' and (sys_platform != 'linux' or (platform_machine != 'aarch64' and platform_machine != 'arm64' and platform_machine != 'armv7l')) and (sys_platform != 'darwin' or platform_machine != 'x86_64')",
     "torchvision>=0.21.0",
     "wandb>=0.16.3",

--- a/tests/optim/test_schedulers.py
+++ b/tests/optim/test_schedulers.py
@@ -37,7 +37,6 @@ def test_diffuser_scheduler(optimizer):
         "base_lrs": [0.001],
         "last_epoch": 1,
         "lr_lambdas": [None],
-        "verbose": False,
     }
     assert scheduler.state_dict() == expected_state_dict
 
@@ -56,7 +55,6 @@ def test_vqbet_scheduler(optimizer):
         "base_lrs": [0.001],
         "last_epoch": 1,
         "lr_lambdas": [None],
-        "verbose": False,
     }
     assert scheduler.state_dict() == expected_state_dict
 
@@ -77,7 +75,6 @@ def test_cosine_decay_with_warmup_scheduler(optimizer):
         "base_lrs": [0.001],
         "last_epoch": 1,
         "lr_lambdas": [None],
-        "verbose": False,
     }
     assert scheduler.state_dict() == expected_state_dict
 


### PR DESCRIPTION
Apply necessary changes to use latest versions of `torch` and `torchcodec`.

The `torch` 2.7.0 [release notes](https://github.com/pytorch/pytorch/releases/tag/v2.7.0) confirm that the `verbose` argument in `LRScheduler` has been deprecated and removed. To maintain compatibility, we update our tests by dropping `verbose` from the assertions.