### PR TITLE
fix(ci): Pin `torchcodec` (==0.2.1) to fix pipeline temporarly

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ dependencies = [
     "rerun-sdk>=0.21.0",
     "termcolor>=2.4.0",
     "torch>=2.2.1,<2.7",
-    "torchcodec>=0.2.1; sys_platform != 'win32' and (sys_platform != 'linux' or (platform_machine != 'aarch64' and platform_machine != 'arm64' and platform_machine != 'armv7l')) and (sys_platform != 'darwin' or platform_machine != 'x86_64')",
+    "torchcodec==0.2.1; sys_platform != 'win32' and (sys_platform != 'linux' or (platform_machine != 'aarch64' and platform_machine != 'arm64' and platform_machine != 'armv7l')) and (sys_platform != 'darwin' or platform_machine != 'x86_64')",
     "torchvision>=0.21.0",
     "wandb>=0.16.3",
     "zarr>=2.17.0",


### PR DESCRIPTION
Context: The dependency manager currently picks up the latest `torchcodec` (released 20 minutes ago), which depends on yesterday’s `torch` release—the same version we restricted in: https://github.com/huggingface/lerobot/pull/1022

To maintain compatibility, we have this PR as a hotfix to pin `torchcodec` to `0.2.1` for now.

Next Steps:
1. Open a PR to relax constraints (both `torchcodec` and `torch`): https://github.com/huggingface/lerobot/pull/1029
2. Fix tests and ensure compatibility in #1029 with the latest versions.
3. Once CI passes, merge #1029 .

This is important because audio work will depend on the latest `torchcodec`

