### PR TITLE
Fix tests

### DIFF
--- a/tests/artifacts/image_transforms/save_image_transforms_to_safetensors.py
+++ b/tests/artifacts/image_transforms/save_image_transforms_to_safetensors.py
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from importlib.resources import files
 from pathlib import Path
 
 import torch
@@ -27,7 +28,7 @@ from lerobot.common.datasets.transforms import (
 )
 from lerobot.common.utils.random_utils import seeded_context
 
-ARTIFACT_DIR = Path("tests/artifacts/image_transforms")
+ARTIFACT_DIR = files(__package__)
 DATASET_REPO_ID = "lerobot/aloha_mobile_shrimp"
 
 

--- a/tests/cameras/test_cameras.py
+++ b/tests/cameras/test_cameras.py
@@ -38,7 +38,7 @@ import numpy as np
 import pytest
 
 from lerobot.common.robot_devices.utils import RobotDeviceAlreadyConnectedError, RobotDeviceNotConnectedError
-from tests.utils import TEST_CAMERA_TYPES, make_camera, require_camera
+from tests.testutils import TEST_CAMERA_TYPES, make_camera, require_camera
 
 # Maximum absolute difference between two consecutive images recorded by a camera.
 # This value differs with respect to the camera.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,7 @@ from serial import SerialException
 
 from lerobot import available_cameras, available_motors, available_robots
 from lerobot.common.robot_devices.robots.utils import make_robot
-from tests.utils import DEVICE, make_camera, make_motors_bus
+from tests.testutils import DEVICE, make_camera, make_motors_bus
 
 # Import fixture modules as plugins
 pytest_plugins = [

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -45,7 +45,7 @@ from lerobot.common.robot_devices.robots.utils import make_robot
 from lerobot.configs.default import DatasetConfig
 from lerobot.configs.train import TrainPipelineConfig
 from tests.fixtures.constants import DUMMY_CHW, DUMMY_HWC, DUMMY_REPO_ID
-from tests.utils import require_x86_64_kernel
+from tests.testutils import require_x86_64_kernel
 
 
 @pytest.fixture

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -17,8 +17,8 @@ import json
 import logging
 import re
 from copy import deepcopy
+from importlib.resources import files
 from itertools import chain
-from pathlib import Path
 
 import numpy as np
 import pytest
@@ -104,7 +104,8 @@ def test_add_frame_missing_task(tmp_path, empty_lerobot_dataset_factory):
     features = {"state": {"dtype": "float32", "shape": (1,), "names": None}}
     dataset = empty_lerobot_dataset_factory(root=tmp_path / "test", features=features)
     with pytest.raises(
-        ValueError, match="Feature mismatch in `frame` dictionary:\nMissing features: {'task'}\n"
+        ValueError,
+        match="Feature mismatch in `frame` dictionary:\nMissing features: {'task'}\n",
     ):
         dataset.add_frame({"state": torch.randn(1)})
 
@@ -113,7 +114,8 @@ def test_add_frame_missing_feature(tmp_path, empty_lerobot_dataset_factory):
     features = {"state": {"dtype": "float32", "shape": (1,), "names": None}}
     dataset = empty_lerobot_dataset_factory(root=tmp_path / "test", features=features)
     with pytest.raises(
-        ValueError, match="Feature mismatch in `frame` dictionary:\nMissing features: {'state'}\n"
+        ValueError,
+        match="Feature mismatch in `frame` dictionary:\nMissing features: {'state'}\n",
     ):
         dataset.add_frame({"task": "Dummy task"})
 
@@ -122,7 +124,8 @@ def test_add_frame_extra_feature(tmp_path, empty_lerobot_dataset_factory):
     features = {"state": {"dtype": "float32", "shape": (1,), "names": None}}
     dataset = empty_lerobot_dataset_factory(root=tmp_path / "test", features=features)
     with pytest.raises(
-        ValueError, match="Feature mismatch in `frame` dictionary:\nExtra features: {'extra'}\n"
+        ValueError,
+        match="Feature mismatch in `frame` dictionary:\nExtra features: {'extra'}\n",
     ):
         dataset.add_frame({"state": torch.randn(1), "task": "Dummy task", "extra": "dummy_extra"})
 
@@ -131,7 +134,8 @@ def test_add_frame_wrong_type(tmp_path, empty_lerobot_dataset_factory):
     features = {"state": {"dtype": "float32", "shape": (1,), "names": None}}
     dataset = empty_lerobot_dataset_factory(root=tmp_path / "test", features=features)
     with pytest.raises(
-        ValueError, match="The feature 'state' of dtype 'float16' is not of the expected dtype 'float32'.\n"
+        ValueError,
+        match="The feature 'state' of dtype 'float16' is not of the expected dtype 'float32'.\n",
     ):
         dataset.add_frame({"state": torch.randn(1, dtype=torch.float16), "task": "Dummy task"})
 
@@ -478,7 +482,7 @@ def test_backward_compatibility(repo_id):
     # TODO(rcadene, aliberts): remove dataset download
     dataset = LeRobotDataset(repo_id, episodes=[0])
 
-    test_dir = Path("tests/artifacts/datasets") / repo_id
+    test_dir = files("tests.artifacts.datasets").joinpath(repo_id)
 
     def load_and_compare(i):
         new_frame = dataset[i]  # noqa: B023

--- a/tests/datasets/test_image_transforms.py
+++ b/tests/datasets/test_image_transforms.py
@@ -34,7 +34,7 @@ from lerobot.scripts.visualize_image_transforms import (
     save_each_transform,
 )
 from tests.artifacts.image_transforms.save_image_transforms_to_safetensors import ARTIFACT_DIR
-from tests.utils import require_x86_64_kernel
+from tests.testutils import require_x86_64_kernel
 
 
 @pytest.fixture

--- a/tests/envs/test_envs.py
+++ b/tests/envs/test_envs.py
@@ -23,7 +23,7 @@ from gymnasium.utils.env_checker import check_env
 import lerobot
 from lerobot.common.envs.factory import make_env, make_env_config
 from lerobot.common.envs.utils import preprocess_observation
-from tests.utils import require_env
+from tests.testutils import require_env
 
 OBS_TYPES = ["state", "pixels", "pixels_agent_pos"]
 

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -22,7 +22,7 @@ from pathlib import Path
 import pytest
 
 from tests.fixtures.constants import DUMMY_REPO_ID
-from tests.utils import require_package
+from tests.testutils import require_package
 
 
 def _find_and_replace(text: str, finds_and_replaces: list[tuple[str, str]]) -> str:

--- a/tests/motors/test_motors.py
+++ b/tests/motors/test_motors.py
@@ -45,7 +45,7 @@ import pytest
 
 from lerobot.common.robot_devices.utils import RobotDeviceAlreadyConnectedError, RobotDeviceNotConnectedError
 from lerobot.scripts.find_motors_bus_port import find_port
-from tests.utils import TEST_MOTOR_TYPES, make_motors_bus, require_motor
+from tests.testutils import TEST_MOTOR_TYPES, make_motors_bus, require_motor
 
 
 @pytest.mark.parametrize("motor_type, mock", TEST_MOTOR_TYPES)

--- a/tests/policies/test_policies.py
+++ b/tests/policies/test_policies.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 import inspect
 from copy import deepcopy
-from pathlib import Path
+from importlib.resources import files
 
 import einops
 import pytest
@@ -59,16 +59,33 @@ def dummy_dataset_metadata(lerobot_dataset_metadata_factory, info_factory, tmp_p
         "action": {
             "dtype": "float32",
             "shape": (6,),
-            "names": ["shoulder_pan", "shoulder_lift", "elbow_flex", "wrist_flex", "wrist_roll", "gripper"],
+            "names": [
+                "shoulder_pan",
+                "shoulder_lift",
+                "elbow_flex",
+                "wrist_flex",
+                "wrist_roll",
+                "gripper",
+            ],
         },
         "observation.state": {
             "dtype": "float32",
             "shape": (6,),
-            "names": ["shoulder_pan", "shoulder_lift", "elbow_flex", "wrist_flex", "wrist_roll", "gripper"],
+            "names": [
+                "shoulder_pan",
+                "shoulder_lift",
+                "elbow_flex",
+                "wrist_flex",
+                "wrist_roll",
+                "gripper",
+            ],
         },
     }
     info = info_factory(
-        total_episodes=1, total_frames=1, camera_features=camera_features, motor_features=motor_features
+        total_episodes=1,
+        total_frames=1,
+        camera_features=camera_features,
+        motor_features=motor_features,
     )
     ds_meta = lerobot_dataset_metadata_factory(root=tmp_path / "init", info=info)
     return ds_meta
@@ -81,7 +98,8 @@ def test_get_policy_and_config_classes(policy_name: str):
     policy_cfg = make_policy_config(policy_name)
     assert policy_cls.name == policy_name
     assert issubclass(
-        policy_cfg.__class__, inspect.signature(policy_cls.__init__).parameters["config"].annotation
+        policy_cfg.__class__,
+        inspect.signature(policy_cls.__init__).parameters["config"].annotation,
     )
 
 
@@ -92,7 +110,13 @@ def test_get_policy_and_config_classes(policy_name: str):
         ("lerobot/pusht", "pusht", {}, "diffusion", {}),
         ("lerobot/pusht", "pusht", {}, "vqbet", {}),
         ("lerobot/pusht", "pusht", {}, "act", {}),
-        ("lerobot/aloha_sim_insertion_human", "aloha", {"task": "AlohaInsertion-v0"}, "act", {}),
+        (
+            "lerobot/aloha_sim_insertion_human",
+            "aloha",
+            {"task": "AlohaInsertion-v0"},
+            "act",
+            {},
+        ),
         (
             "lerobot/aloha_sim_insertion_scripted",
             "aloha",
@@ -174,7 +198,7 @@ def test_policy(ds_repo_id, env_name, env_kwargs, policy_name, policy_kwargs):
     policy.forward(batch)
     assert set(batch) == set(batch_), "Batch keys are not the same after a forward pass."
     assert all(
-        torch.equal(batch[k], batch_[k]) if isinstance(batch[k], torch.Tensor) else batch[k] == batch_[k]
+        (torch.equal(batch[k], batch_[k]) if isinstance(batch[k], torch.Tensor) else batch[k] == batch_[k])
         for k in batch
     ), "Batch values are not the same after a forward pass."
 
@@ -410,7 +434,7 @@ def test_backward_compatibility(ds_repo_id: str, policy_name: str, policy_kwargs
         6. Remember to stage and commit the resulting changes to `tests/artifacts`.
     """
     ds_name = ds_repo_id.split("/")[-1]
-    artifact_dir = Path("tests/artifacts/policies") / f"{ds_name}_{policy_name}_{file_name_extra}"
+    artifact_dir = files("tests.artifacts.policies").joinpath(f"{ds_name}_{policy_name}_{file_name_extra}")
     saved_output_dict = load_file(artifact_dir / "output_dict.safetensors")
     saved_grad_stats = load_file(artifact_dir / "grad_stats.safetensors")
     saved_param_stats = load_file(artifact_dir / "param_stats.safetensors")

--- a/tests/policies/test_policies.py
+++ b/tests/policies/test_policies.py
@@ -41,7 +41,7 @@ from lerobot.configs.default import DatasetConfig
 from lerobot.configs.train import TrainPipelineConfig
 from lerobot.configs.types import FeatureType, NormalizationMode, PolicyFeature
 from tests.artifacts.policies.save_policy_to_safetensors import get_policy_stats
-from tests.utils import DEVICE, require_cpu, require_env, require_x86_64_kernel
+from tests.testutils import DEVICE, require_cpu, require_env, require_x86_64_kernel
 
 
 @pytest.fixture

--- a/tests/robots/test_control_robot.py
+++ b/tests/robots/test_control_robot.py
@@ -52,7 +52,7 @@ from lerobot.common.robot_devices.control_configs import (
 from lerobot.configs.policies import PreTrainedConfig
 from lerobot.scripts.control_robot import calibrate, record, replay, teleoperate
 from tests.robots.test_robots import make_robot
-from tests.utils import TEST_ROBOT_TYPES, mock_calibration_dir, require_robot
+from tests.testutils import TEST_ROBOT_TYPES, mock_calibration_dir, require_robot
 
 
 @pytest.mark.parametrize("robot_type, mock", TEST_ROBOT_TYPES)

--- a/tests/robots/test_robots.py
+++ b/tests/robots/test_robots.py
@@ -41,7 +41,7 @@ import torch
 
 from lerobot.common.robot_devices.robots.utils import make_robot
 from lerobot.common.robot_devices.utils import RobotDeviceAlreadyConnectedError, RobotDeviceNotConnectedError
-from tests.utils import TEST_ROBOT_TYPES, mock_calibration_dir, require_robot
+from tests.testutils import TEST_ROBOT_TYPES, mock_calibration_dir, require_robot
 
 
 @pytest.mark.parametrize("robot_type, mock", TEST_ROBOT_TYPES)

--- a/tests/test_available.py
+++ b/tests/test_available.py
@@ -23,7 +23,7 @@ from lerobot.common.policies.act.modeling_act import ACTPolicy
 from lerobot.common.policies.diffusion.modeling_diffusion import DiffusionPolicy
 from lerobot.common.policies.tdmpc.modeling_tdmpc import TDMPCPolicy
 from lerobot.common.policies.vqbet.modeling_vqbet import VQBeTPolicy
-from tests.utils import require_env
+from tests.testutils import require_env
 
 
 @pytest.mark.parametrize("env_name, task_name", lerobot.env_task_pairs)

--- a/tests/testutils.py
+++ b/tests/testutils.py
@@ -26,7 +26,9 @@ from lerobot import available_cameras, available_motors, available_robots
 from lerobot.common.robot_devices.cameras.utils import Camera
 from lerobot.common.robot_devices.cameras.utils import make_camera as make_camera_device
 from lerobot.common.robot_devices.motors.utils import MotorsBus
-from lerobot.common.robot_devices.motors.utils import make_motors_bus as make_motors_bus_device
+from lerobot.common.robot_devices.motors.utils import (
+    make_motors_bus as make_motors_bus_device,
+)
 from lerobot.common.utils.import_utils import is_package_available
 
 DEVICE = os.environ.get("LEROBOT_TEST_DEVICE", "cuda") if torch.cuda.is_available() else "cpu"
@@ -285,7 +287,14 @@ def mock_calibration_dir(calibration_dir):
         "start_pos": [1442, 843, 2166, 2849, 1988, 1835],
         "end_pos": [2440, 1869, -1106, -1848, -926, 3235],
         "calib_mode": ["DEGREE", "DEGREE", "DEGREE", "DEGREE", "DEGREE", "LINEAR"],
-        "motor_names": ["shoulder_pan", "shoulder_lift", "elbow_flex", "wrist_flex", "wrist_roll", "gripper"],
+        "motor_names": [
+            "shoulder_pan",
+            "shoulder_lift",
+            "elbow_flex",
+            "wrist_flex",
+            "wrist_roll",
+            "gripper",
+        ],
     }
     Path(str(calibration_dir)).mkdir(parents=True, exist_ok=True)
     with open(calibration_dir / "main_follower.json", "w") as f:


### PR DESCRIPTION
## What this does
There are 2 changes in this PR:
1. Switch to use [importlib.resources](https://docs.python.org/3/library/importlib.resources.html) instead of reading file paths
2. renamed tests/utils.py -> tests/testutils.py

neither of the changes have any functional impact but make it easy to integrate lerobot with other codebases.

### Switch to importlib.resources
when lerobot repo is embedded within another project, the `Path(__file__)` logic breaks, using importlib.resources makes it resilient and is supported by the build systems directly.

### Renaming utils.py
In the tests folders, there is a folder called `utils` and a file called `utils.py`, this confuses alternative build systems and is easier to use different names rather than overload them.
