### PR TITLE
Fixing wrong argparse examples in the comments (using 'True' not 'true')

### DIFF
--- a/lerobot/common/utils/hub.py
+++ b/lerobot/common/utils/hub.py
@@ -50,14 +50,14 @@ class HubMixin:
             push_to_hub (`bool`, *optional*, defaults to `False`):
                 Whether or not to push your object to the Huggingface Hub after saving it.
             repo_id (`str`, *optional*):
-                ID of your repository on the Hub. Used only if `push_to_hub=True`. Will default to the folder name if
+                ID of your repository on the Hub. Used only if `push_to_hub=true`. Will default to the folder name if
                 not provided.
             card_kwargs (`Dict[str, Any]`, *optional*):
                 Additional arguments passed to the card template to customize the card.
             push_to_hub_kwargs:
                 Additional key word arguments passed along to the [`~HubMixin.push_to_hub`] method.
         Returns:
-            `str` or `None`: url of the commit on the Hub if `push_to_hub=True`, `None` otherwise.
+            `str` or `None`: url of the commit on the Hub if `push_to_hub=true`, `None` otherwise.
         """
         save_directory = Path(save_directory)
         save_directory.mkdir(parents=True, exist_ok=True)

--- a/lerobot/scripts/control_robot.py
+++ b/lerobot/scripts/control_robot.py
@@ -56,7 +56,7 @@ python lerobot/scripts/control_robot.py \
     --control.single_task="Grasp a lego block and put it in the bin." \
     --control.repo_id=$USER/koch_test \
     --control.num_episodes=1 \
-    --control.push_to_hub=True
+    --control.push_to_hub=true
 ```
 
 - Visualize dataset:


### PR DESCRIPTION
## What this does
Explain what this PR does. Feel free to tag your PR with the appropriate label(s).

Examples:
|  Title               | Label           |
|----------------------|-----------------|
| Fixes #1039       | (🐛 Bug)        |

## How it was tested
 Some of the examples written in comments of the code has wrong 'boolean' value parse. Passing `True` or `False` is deprecated. It should be `true` and `false` string. This pull request fixes that.

