### PR TITLE
bug fix for #1071 When --display_data=true, Failed running control_robot.

### DIFF
--- a/lerobot/common/robot_devices/control_utils.py
+++ b/lerobot/common/robot_devices/control_utils.py
@@ -250,6 +250,7 @@ def control_loop(
             observation, action = robot.teleop_step(record_data=True)
         else:
             observation = robot.capture_observation()
+            action = None
 
             if policy is not None:
                 pred_action = predict_action(
@@ -266,9 +267,10 @@ def control_loop(
 
         # TODO(Steven): This should be more general (for RemoteRobot instead of checking the name, but anyways it will change soon)
         if (display_data and not is_headless()) or (display_data and robot.robot_type.startswith("lekiwi")):
-            for k, v in action.items():
-                for i, vv in enumerate(v):
-                    rr.log(f"sent_{k}_{i}", rr.Scalar(vv.numpy()))
+            if action is not None:
+                for k, v in action.items():
+                    for i, vv in enumerate(v):
+                        rr.log(f"sent_{k}_{i}", rr.Scalar(vv.numpy()))
 
             image_keys = [key for key in observation if "image" in key]
             for key in image_keys:


### PR DESCRIPTION

As mention in  #1071, When I run control_robot.py record with --display_data=true option and policy, The process is failed caused by Exception. Because In control_utils.py control_loop method when called from warmup_record method, It is failed access action object.

I'm adding codes which create action object and if case to prevent this error in the control_loop method.

I've run test case without real robot on macOS. In polices testcase, some test cased failed due to mixed devices. but I believe this is problem of some settings to test case.

```
FAILED tests/policies/test_policies.py::test_policy[lerobot/pusht-pusht-env_kwargs1-diffusion-policy_kwargs1] - RuntimeError: Expected all tensors to be on the same device, but found at least two devices, mps:0 and cpu!
FAILED tests/policies/test_policies.py::test_policy[lerobot/pusht-pusht-env_kwargs2-vqbet-policy_kwargs2] - NotImplementedError: Current implementation of VQBeT does not support `mps` backend. Please use `cpu` or `cuda` backend.
FAILED tests/policies/test_policies.py::test_policy[lerobot/pusht-pusht-env_kwargs3-act-policy_kwargs3] - RuntimeError: Expected all tensors to be on the same device, but found at least two devices, mps:0 and cpu!
FAILED tests/policies/test_policies.py::test_policy[lerobot/aloha_sim_insertion_human-aloha-env_kwargs4-act-policy_kwargs4] - RuntimeError: Expected all tensors to be on the same device, but found at least two devices, mps:0 and cpu!
FAILED tests/policies/test_policies.py::test_policy[lerobot/aloha_sim_insertion_scripted-aloha-env_kwargs5-act-policy_kwargs5] - RuntimeError: Expected all tensors to be on the same device, but found at least two devices, mps:0 and cpu!
FAILED tests/policies/test_policies.py::test_policy[lerobot/aloha_sim_insertion_human-aloha-env_kwargs6-diffusion-policy_kwargs6] - RuntimeError: Expected all tensors to be on the same device, but found at least two devices, mps:0 and cpu!
FAILED tests/policies/test_policies.py::test_policy[lerobot/aloha_sim_transfer_cube_human-aloha-env_kwargs7-act-policy_kwargs7] - RuntimeError: Expected all tensors to be on the same device, but found at least two devices, mps:0 and cpu!
FAILED tests/policies/test_policies.py::test_policy[lerobot/aloha_sim_transfer_cube_scripted-aloha-env_kwargs8-act-policy_kwargs8] - RuntimeError: Expected all tensors to be on the same device, but found at least two devices, mps:0 and cpu!
======================================= 8 failed, 290 passed, 62 skipped, 10 warnings in 228.63s (0:03:48) ===================================
```