### PR TITLE
Update 12_use_so101.md

### DIFF
--- a/examples/12_use_so101.md
+++ b/examples/12_use_so101.md
@@ -145,7 +145,7 @@ Reconnect the usb cable.
 #### Update config file
 
 Now that you have your ports, update the **port** default values of [`SO101RobotConfig`](https://github.com/huggingface/lerobot/blob/main/lerobot/common/robot_devices/robots/configs.py).
-You will find something a class called `so101` where you can update the `port` values with your actual motor ports:
+You will find a class called `so101` where you can update the `port` values with your actual motor ports:
 ```python
 @RobotConfig.register_subclass("so101")
 @dataclass
@@ -308,7 +308,7 @@ Remove all support material from the 3D-printed parts.
 ##### Wiring
 
 - Attach the motor controller on the back.
-- Then insert all wires, use the wire guides everywhere to make sure the wires don't unplug themself and stay in place.
+- Then insert all wires, use the wire guides everywhere to make sure the wires don't unplug themselves and stay in place.
 
 <video controls width="640" src="https://github.com/user-attachments/assets/4c2cacfd-9276-4ee4-8bf2-ba2492667b78" type="video/mp4"></video>
 
@@ -351,7 +351,7 @@ python lerobot/scripts/control_robot.py \
 ```
 ## Control your robot
 
-Congrats 🎉, your robot is all set to learn a task on its own. Next we will explain you how to train a neural network to autonomously control a real robot.
+Congrats 🎉, your robot is all set to learn a task on its own. Next we will explain to you how to train a neural network to autonomously control a real robot.
 
 **You'll learn to:**
 1. How to record and visualize your dataset.
@@ -515,7 +515,7 @@ If you have an additional camera you can add a wrist camera to the SO101. There 
 
 ## Teleoperate with cameras
 
-We can now teleoperate again while at the same time visualizing the camera's and joint positions with `rerun`.
+We can now teleoperate again while at the same time visualizing the cameras and joint positions with `rerun`.
 
 ```bash
 python lerobot/scripts/control_robot.py \
@@ -526,7 +526,7 @@ python lerobot/scripts/control_robot.py \
 
 ## Record a dataset
 
-Once you're familiar with teleoperation, you can record your first dataset with SO-100.
+Once you're familiar with teleoperation, you can record your first dataset with SO-101.
 
 We use the Hugging Face hub features for uploading your dataset. If you haven't previously used the Hub, make sure you can login via the cli using a write-access token, this token can be generated from the [Hugging Face settings](https://huggingface.co/settings/tokens).
 


### PR DESCRIPTION
- Fix possessive “its” in motor-ID section (`it's ID` ➜ `its ID`)
- Change singular reflexive “themself” to plural “themselves” for wires
- Remove stray word in config explanation (“something a class” ➜ “a class”)
- Use proper plural “cameras” instead of “camera's”
- Correct robot model reference from “SO-100” to “SO-101”
- Add missing preposition (“explain to you”)