### PR TITLE
For policy evals, do not `display_data` during warmup

### DIFF
--- a/examples/10_use_so100.md
+++ b/examples/10_use_so100.md
@@ -606,6 +606,7 @@ python lerobot/scripts/control_robot.py \
   --control.episode_time_s=30 \
   --control.reset_time_s=30 \
   --control.num_episodes=10 \
+  --control.display_data=true \
   --control.push_to_hub=true \
   --control.policy.path=outputs/train/act_so100_test/checkpoints/last/pretrained_model
 ```

--- a/lerobot/scripts/control_robot.py
+++ b/lerobot/scripts/control_robot.py
@@ -285,7 +285,9 @@ def record(
     # 3. place the cameras windows on screen
     enable_teleoperation = policy is None
     log_say("Warmup record", cfg.play_sounds)
-    warmup_record(robot, events, enable_teleoperation, cfg.warmup_time_s, cfg.display_data, cfg.fps)
+    # For evals, do not display data during warmup, since you don't pass a policy
+    display_data = cfg.display_data and not is_headless() and policy is None
+    warmup_record(robot, events, enable_teleoperation, cfg.warmup_time_s, display_data, cfg.fps)
 
     if has_method(robot, "teleop_safety_stop"):
         robot.teleop_safety_stop()
@@ -296,12 +298,13 @@ def record(
             break
 
         log_say(f"Recording episode {dataset.num_episodes}", cfg.play_sounds)
+        display_data = cfg.display_data and not is_headless()
         record_episode(
             robot=robot,
             dataset=dataset,
             events=events,
             episode_time_s=cfg.episode_time_s,
-            display_data=cfg.display_data,
+            display_data=display_data,
             policy=policy,
             fps=cfg.fps,
             single_task=cfg.single_task,


### PR DESCRIPTION
## What this does
Fixes Bug 🐛
For policy evals, by default `display_data` is set to False. But there is a use-case for displaying proprioception and camera images *during* evals. Simply adding `--control.display_data=true` during record with a policy eval doesn't work. You get an error
```
 File "/path_to/lerobot/lerobot/common/robot_devices/control_utils.py", line 269, in control_loop
    for k, v in action.items():
UnboundLocalError: local variable 'action' referenced before assignment
```

This is a fix to address that.

## How it was tested
Tested the eval script with `--display_data=true` on `upstream/main` and on my branch.

## How to checkout & try? (for the reviewer)
Run the updated eval script in `examples/10_use_so100.md` step K (Evaluate your policy). To reproduce the bug, run the same command as above, without my changes.

```bash
python lerobot/scripts/control_robot.py \
  --robot.type=so100 \
  --control.type=record \
  --control.fps=30 \
  --control.single_task="Grasp a lego block and put it in the bin." \
  --control.repo_id=${HF_USER}/eval_act_so100_test \
  --control.tags='["tutorial"]' \
  --control.warmup_time_s=5 \
  --control.episode_time_s=30 \
  --control.reset_time_s=30 \
  --control.num_episodes=10 \
  --control.display_data=true \
  --control.push_to_hub=true \
  --control.policy.path=outputs/train/act_so100_test/checkpoints/last/pretrained_model
```

@youliangtan