### PR TITLE
feat(devx): package with Nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,26 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1746812440,
+        "narHash": "sha256-1IKTKqmnPMJ/8v24aLZwv7a3yzH/Af8XkgdiPhRLMBQ=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "c7f63afcd654206fa65cb6ffc77efad1374a2c72",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,21 @@
+{
+  inputs.nixpkgs.url = "github:nixos/nixpkgs";
+
+  outputs =
+    { self, nixpkgs, ... }:
+    {
+      overlays.default = import ./nix/overlay.nix;
+      legacyPackages.x86_64-linux = nixpkgs.legacyPackages.x86_64-linux.extend (self.overlays.default);
+      devShells.x86_64-linux.default =
+        let
+          pkgs = self.legacyPackages.x86_64-linux;
+        in
+        pkgs.mkShell {
+          buildInputs = [
+            (pkgs.python3.withPackages (pp: [
+              pp.lerobot
+            ]))
+          ];
+        };
+    };
+}

--- a/nix/draccus.nix
+++ b/nix/draccus.nix
@@ -1,0 +1,43 @@
+{
+  buildPythonPackage,
+  fetchPypi,
+  pypaInstallHook,
+  setuptoolsBuildHook,
+  setuptools,
+
+  mergedeep,
+  pyyaml,
+  pyyaml-include,
+  toml,
+  typing-inspect,
+}:
+buildPythonPackage rec {
+  pname = "draccus";
+  version = "0.11.5";
+  src = fetchPypi {
+    inherit pname version;
+    hash = "sha256-uC4sICcDCuGg8QVRUSX5FOBQwHZqtRjfOgVgoH0Q3ck=";
+  };
+
+  nativeBuildInputs = [
+    pypaInstallHook
+    setuptoolsBuildHook
+  ];
+
+  pyproject = true;
+  build-system = [ setuptools ];
+
+  dependencies = [
+    mergedeep
+    pyyaml
+    pyyaml-include
+    toml
+    typing-inspect
+  ];
+
+  pythonRelaxDeps = [
+    "pyyaml-include"
+  ];
+
+  pythonImportsCheck = [ "draccus" ];
+}

--- a/nix/lerobot.nix
+++ b/nix/lerobot.nix
@@ -1,0 +1,98 @@
+{
+  buildPythonPackage,
+  fetchFromGitHub,
+  pytestCheckHook,
+  poetry-core,
+
+  av,
+  datasets,
+  deepdiff,
+  diffusers,
+  draccus,
+  einops,
+  flask,
+  gdown,
+  gymnasium,
+  h5py,
+  huggingface-hub,
+  imageio,
+  jsonlines,
+  numba,
+  omegaconf,
+  opencv-python-headless,
+  pymunk,
+  pynput,
+  pyzmq,
+  rerun-sdk,
+  termcolor,
+  torch,
+  torchvision,
+  wandb,
+  zarr,
+
+  pyserial,
+}:
+buildPythonPackage {
+  pname = "lerobot";
+  version = "a445d9c9da6bea99a8972daa4fe1fdd053d711d2";
+  src = fetchFromGitHub {
+    owner = "huggingface";
+    repo = "lerobot";
+    rev = "a445d9c9da6bea99a8972daa4fe1fdd053d711d2";
+    hash = "sha256-Kr1UoF9iNGutOIuhYg2FhxtIlbkjoo10ffZJIQNA38Q=";
+  };
+
+  nativeCheckInputs = [
+    # pytestCheckHook
+  ];
+
+  pyproject = true;
+  build-system = [
+    poetry-core
+  ];
+
+  dependencies = [
+    av
+    datasets
+    deepdiff
+    diffusers
+    draccus
+    einops
+    flask
+    gdown
+    gymnasium
+    h5py
+    huggingface-hub
+    imageio
+    jsonlines
+    numba
+    omegaconf
+    opencv-python-headless
+    pymunk
+    pynput
+    pyzmq
+    rerun-sdk
+    termcolor
+    torch
+    torchvision
+    wandb
+    zarr
+  ];
+
+  pythonRemoveDeps = [
+    "cmake"
+    "torchcodec" # not packaged
+  ];
+
+  pythonRelaxDeps = [
+    "av"
+    "draccus"
+    "gymnasium"
+  ];
+
+  checkInputs = [
+    pyserial
+  ];
+
+  pythonImportsCheck = [ "lerobot" ];
+}

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,0 +1,8 @@
+final: prev: {
+  pythonPackagesExtensions = prev.pythonPackagesExtensions ++ [
+    (pyFinal: pyPrev: {
+      lerobot = pyFinal.callPackage ./lerobot.nix { };
+      draccus = pyFinal.callPackage ./draccus.nix { };
+    })
+  ];
+}


### PR DESCRIPTION
Nix is a package manager that aims for ease of distribution and reproducibility.

This first iteration provides a flake
(https://wiki.nixos.org/wiki/Flakes) that allows installing and using LeRobot in a single line: `nix develop`.

To do so, this commit:
- packages draccus (not on nixpkgs yet)
- packages lerobot
- provides a nixpkgs overlay to have draccus and lerobot in python packages
- provides a minimal Python dev shell with `lerobot` installed.

## How it was tested

I've tested the first example (loads dataset). Even if torchcodec is not installed (currently not available in nixpkgs), it does load the dataset and can load the first sample.

I have also tested the dataset visualization in scripts.

## How to checkout & try? (for the reviewer)

On Linux (x86 64):
1. install Nix
2. run `nix --option 'extra-experimental-features' 'nix-command flakes' develop`