### PR TITLE
Fix: emptying action queue between resets

### DIFF
--- a/lerobot/common/robot_devices/control_utils.py
+++ b/lerobot/common/robot_devices/control_utils.py
@@ -243,6 +243,11 @@ def control_loop(
 
     timestamp = 0
     start_episode_t = time.perf_counter()
+
+    # Controls starts, if policy is given it needs cleaning up
+    if policy is not None:
+        policy.reset()
+
     while timestamp < control_time_s:
         start_loop_t = time.perf_counter()
 
@@ -287,10 +292,6 @@ def control_loop(
         if events["exit_early"]:
             events["exit_early"] = False
             break
-
-    # Controlling is over, if policy is given it needs cleaning up
-    if policy is not None:
-        policy.reset()
 
 
 def reset_environment(robot, events, reset_time_s, fps):


### PR DESCRIPTION
## What this does
- Fixes https://github.com/huggingface/lerobot/issues/1116
- Adds policy to the arguments of the `reset_environment` function so that action queues are guaranteed to be emptied between different episodes (regardless of whether the episode is over)
- For more details, check [the issue](https://github.com/huggingface/lerobot/issues/1116)

## How it was tested
- On the real robot running a policy
- With `pytest tests/robots/test_control_robot.py` (output 👇)
```bash
pytest tests/robots/test_control_robot.py 
======================================================================================================= test session starts ========================================================================================================
platform darwin -- Python 3.10.16, pytest-8.3.5, pluggy-1.6.0
rootdir: /Users/fracapuano/Documents/HF/lerobot
configfile: pyproject.toml
collected 53 items                                                                                                                                                                                                                 

Testing with DEVICE='cpu'

tests/robots/test_control_robot.py .s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.s.....                                                                                                                    [100%]

================================================================================================ warnings summary =================================================================================================
tests/robots/test_control_robot.py::test_calibrate[aloha-True]
  /Users/fracapuano/Documents/HF/lerobot/lerobot/common/robot_devices/motors/dynamixel.py:498: RuntimeWarning: invalid value encountered in scalar divide
    values[i] = (values[i] - start_pos) / (end_pos - start_pos) * 100

tests/robots/test_control_robot.py::test_calibrate[so100-True]
tests/robots/test_control_robot.py::test_calibrate[so101-True]
tests/robots/test_control_robot.py::test_calibrate[moss-True]
  /Users/fracapuano/Documents/HF/lerobot/lerobot/common/robot_devices/motors/feetech.py:478: RuntimeWarning: invalid value encountered in scalar divide
    values[i] = (values[i] - start_pos) / (end_pos - start_pos) * 100

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================= 29 passed, 24 skipped, 4 warnings in 171.54s (0:02:51) ==============================================================================
```

Note: all tests pass! Warnings derive from not being connected to a robot and testing on mock robots

Via test:

## How to checkout & try? (for the reviewer)
```bash
git checkout user/fracapuano/2025-05-15-fixing-action-queues
```
```bash
pytest tests/robots/test_control_robot.py
```

This PR also slightly latches on this other PR #1020---I think we should discuss the intended design for policy objects, perhaps exposing the entire action chunk rather than just one action at a time making the policy "stateful". Had this been the case, this bug would have been caught earlier :)

cc. @danaaubakirova as we discussed this issue @imstevenpmwork for a review and @Cadene for viz 😊 