### PR TITLE
Fixes #1050: removes instructions for visualize_dataset.py

### DIFF
--- a/lerobot/scripts/control_robot.py
+++ b/lerobot/scripts/control_robot.py
@@ -59,13 +59,6 @@ python lerobot/scripts/control_robot.py \
     --control.push_to_hub=True
 ```
 
-- Visualize dataset:
-```bash
-python lerobot/scripts/visualize_dataset.py \
-    --repo-id $USER/koch_test \
-    --episode-index 0
-```
-
 - Replay this test episode:
 ```bash
 python lerobot/scripts/control_robot.py replay \


### PR DESCRIPTION
## What this does
This PR fixes #1050 which is a minor issue in documentation

## How it was tested
Nothing to test, only changes comment for help section.

## How to checkout & try? (for the reviewer)
Only need to review instructions in help section. [Easy to see diff](https://github.com/brainwavecollective/lerobot/commit/b5092efe25ded624cab58f2878e0146ea82f6207).

##  CREDIT:  
This issue was identified by @LaurentBerger I am only submitting to close the issue.
