### PR TITLE
changes

### DIFF
--- a/lerobot/common/robot_devices/cameras/intelrealsense.py
+++ b/lerobot/common/robot_devices/cameras/intelrealsense.py
@@ -359,12 +359,12 @@ class IntelRealSenseCamera:
 
         self.is_connected = True
 
-    def read(self, temporary_color: str | None = None) -> np.ndarray | tuple[np.ndarray, np.ndarray]:
+    def read(self, temporary_color: str | None = None) -> dict[str, np.ndarray]:
         """Read a frame from the camera returned in the format height x width x channels (e.g. 480 x 640 x 3)
         of type `np.uint8`, contrarily to the pytorch format which is float channel first.
 
-        When `use_depth=True`, returns a tuple `(color_image, depth_map)` with a depth map in the format
-        height x width (e.g. 480 x 640) of type np.uint16.
+        When `use_depth=True`, there is a `depth` key containing the depth map in the format
+        height x width (e.g. 480 x 640) of type `np.uint16`.
 
         Note: Reading a frame is done every `camera.fps` times per second, and it is blocking.
         If you are reading data from other sensors, we advise to use `camera.async_read()` which is non blocking version of `camera.read()`.
@@ -431,9 +431,9 @@ class IntelRealSenseCamera:
             if self.rotation is not None:
                 depth_map = cv2.rotate(depth_map, self.rotation)
 
-            return color_image, depth_map
+            return dict(rgb=color_image, depth=depth_map)
         else:
-            return color_image
+            return dict(rgb=color_image)
 
     def read_loop(self):
         while not self.stop_event.is_set():
@@ -442,7 +442,7 @@ class IntelRealSenseCamera:
             else:
                 self.color_image = self.read()
 
-    def async_read(self):
+    def async_read(self) -> dict[str, np.ndarray]:
         """Access the latest color image"""
         if not self.is_connected:
             raise RobotDeviceNotConnectedError(
@@ -466,9 +466,9 @@ class IntelRealSenseCamera:
                 )
 
         if self.use_depth:
-            return self.color_image, self.depth_map
+            return dict(rgb=self.color_image, depth=self.depth_map)
         else:
-            return self.color_image
+            return dict(rgb=self.color_image)
 
     def disconnect(self):
         if not self.is_connected:

--- a/lerobot/common/robot_devices/cameras/opencv.py
+++ b/lerobot/common/robot_devices/cameras/opencv.py
@@ -367,7 +367,7 @@ class OpenCVCamera:
         self.capture_height = round(actual_height)
         self.is_connected = True
 
-    def read(self, temporary_color_mode: str | None = None) -> np.ndarray:
+    def read(self, temporary_color_mode: str | None = None) -> dict[str, np.ndarray]:
         """Read a frame from the camera returned in the format (height, width, channels)
         (e.g. 480 x 640 x 3), contrarily to the pytorch format which is channel first.
 
@@ -421,7 +421,7 @@ class OpenCVCamera:
 
         self.color_image = color_image
 
-        return color_image
+        return dict(rgb=color_image)
 
     def read_loop(self):
         while not self.stop_event.is_set():
@@ -430,7 +430,7 @@ class OpenCVCamera:
             except Exception as e:
                 print(f"Error reading in thread: {e}")
 
-    def async_read(self):
+    def async_read(self) -> dict[str, np.ndarray]:
         if not self.is_connected:
             raise RobotDeviceNotConnectedError(
                 f"OpenCVCamera({self.camera_index}) is not connected. Try running `camera.connect()` first."
@@ -445,7 +445,7 @@ class OpenCVCamera:
         num_tries = 0
         while True:
             if self.color_image is not None:
-                return self.color_image
+                return dict(rgb=self.color_image)
 
             time.sleep(1 / self.fps)
             num_tries += 1


### PR DESCRIPTION
## What this does
This addresses #860 

Currently the cameras in lerobot have inconsistent and backwards incompatible return formats. This PR modifies the `read` and `read_async` functions to return a dictionary which is more flexible and always backwards compatible if you want ot add new outputs (for example other sensors may have other kinds of outputs if you plan to support them).

This also makes it easier for lerobot integration into some other repos that currently have to check what type of camera is being used and whether depth is turned on to determine the output type of `read` and `read_async`.


## How it was tested
Not super sure how to best test this in LeRobot. This change will likely break a number of deployment scripts that currently assume the returned data is always an RGB image.

This PR is more of a proposal first rather than a fully completed PR hence the short nature of the changes.