### PR TITLE
Extending MPS eval fix to examples/2_evaluate_pretrained_policy.py

### DIFF
--- a/examples/2_evaluate_pretrained_policy.py
+++ b/examples/2_evaluate_pretrained_policy.py
@@ -37,7 +37,12 @@ output_directory = Path("outputs/eval/example_pusht_diffusion")
 output_directory.mkdir(parents=True, exist_ok=True)
 
 # Select your device
-device = "cuda"
+if torch.cuda.is_available():
+    device = torch.device("cuda")
+elif torch.backends.mps.is_available():
+    device = torch.device("mps")
+else:
+    device = torch.device("cpu")
 
 # Provide the [hugging face repo id](https://huggingface.co/lerobot/diffusion_pusht):
 pretrained_policy_path = "lerobot/diffusion_pusht"
@@ -91,8 +96,8 @@ while not done:
     image = image.permute(2, 0, 1)
 
     # Send data tensors from CPU to GPU
-    state = state.to(device, non_blocking=True)
-    image = image.to(device, non_blocking=True)
+    state = state.to(device, non_blocking=device.type == "cuda")
+    image = image.to(device, non_blocking=device.type == "cuda")
 
     # Add extra (empty) batch dimension, required to forward the policy
     state = state.unsqueeze(0)

--- a/lerobot/scripts/visualize_dataset_html.py
+++ b/lerobot/scripts/visualize_dataset_html.py
@@ -22,7 +22,7 @@ However, there might not be a transition from a final state to another state.
 
 Note: This script aims to visualize the data used to train the neural networks.
 ~What you see is what you get~. When visualizing image modality, it is often expected to observe
-lossly compression artifacts since these images have been decoded from compressed mp4 videos to
+lossy compression artifacts since these images have been decoded from compressed mp4 videos to
 save disk space. The compression factor applied has been tuned to not affect success rate.
 
 Example of usage:


### PR DESCRIPTION
## What this does
I found a bug when running examples/2_evaluate_pretrained_policy.py on my Macbook Pro M1, where unexpected NaN values which resulted in unexpected behaviour during evaluation, and constant task failure, when tested on PushT.
This PR adds in the fix to run examples/2_evaluate_pretrained_policy.py on MPS. This extends the same logic as #702 to the example script.

The issue faced is NaN values appearing when running policy evaluation on MPS #475 . The fix is to check which device the user is running eval on and set non_blocking to True only when running on CUDA.

Extends fixes of #496 #475 .

## How it was tested
I encountered the error when evaluating diffusion policy on PushT environment, on device MPS. The solution was tested with the following command:

```bash
python examples/2_evaluate_pretrained_policy.py
```
Prior to the fix, it resulted in random actions. Post-fix policy works well.


## How to checkout & try? (for the reviewer)
Running the following command before and after the fix should save rollout videos that can be visualized to understand the error, an error message for the same appears when running on MPS without the fix.

```bash
python examples/2_evaluate_pretrained_policy.py
```

The before and after videos are similar to ones seen in #702 

