### PR TITLE
User/tgossin/2025 05 25 merge dataset

### DIFF
--- a/examples/10_use_so100.md
+++ b/examples/10_use_so100.md
@@ -14,6 +14,7 @@
   - [J. Train a policy](#j-train-a-policy)
   - [K. Evaluate your policy](#k-evaluate-your-policy)
   - [L. More Information](#l-more-information)
+  
 
 ## A. Source the parts
 
@@ -128,7 +129,7 @@ sudo chmod 666 /dev/ttyACM1
 #### d. Update config file
 
 IMPORTANTLY: Now that you have your ports, update the **port** default values of [`SO100RobotConfig`](../lerobot/common/robot_devices/robots/configs.py). You will find something like:
-```python
+```diff
 @RobotConfig.register_subclass("so100")
 @dataclass
 class So100RobotConfig(ManipulatorRobotConfig):
@@ -141,7 +142,8 @@ class So100RobotConfig(ManipulatorRobotConfig):
     leader_arms: dict[str, MotorsBusConfig] = field(
         default_factory=lambda: {
             "main": FeetechMotorsBusConfig(
-                port="/dev/tty.usbmodem58760431091",  <-- UPDATE HERE
+-                port="/dev/tty.usbmodem58760431091",
++                port="{ADD YOUR LEADER PORT}",
                 motors={
                     # name: (index, model)
                     "shoulder_pan": [1, "sts3215"],
@@ -158,7 +160,8 @@ class So100RobotConfig(ManipulatorRobotConfig):
     follower_arms: dict[str, MotorsBusConfig] = field(
         default_factory=lambda: {
             "main": FeetechMotorsBusConfig(
-                port="/dev/tty.usbmodem585A0076891",  <-- UPDATE HERE
+-                port="/dev/tty.usbmodem585A0076891",
++                port="{ADD YOUR FOLLOWER PORT}",
                 motors={
                     # name: (index, model)
                     "shoulder_pan": [1, "sts3215"],
@@ -536,6 +539,17 @@ python lerobot/scripts/control_robot.py \
 ```
 
 Note: You can resume recording by adding `--control.resume=true`.
+
+### Merge multiple sessions
+
+If you record data over several sessions (different days, tasks, or robots) you may want to combine them into a single dataset directory so that training and evaluation scripts.
+
+```bash
+python lerobot/scripts/merge_dataset.py \
+  --dataset1=/path/to/run_A \
+  --dataset2=/path/to/run_B \
+  --output_dir=/path/to/merged_dataset
+```
 
 ## H. Visualize a dataset
 

--- a/examples/10_use_so100.md
+++ b/examples/10_use_so100.md
@@ -14,7 +14,7 @@
   - [J. Train a policy](#j-train-a-policy)
   - [K. Evaluate your policy](#k-evaluate-your-policy)
   - [L. More Information](#l-more-information)
-  
+
 
 ## A. Source the parts
 

--- a/examples/12_use_so101.md
+++ b/examples/12_use_so101.md
@@ -61,7 +61,7 @@ conda install ffmpeg -c conda-forge
 
 Install 🤗 LeRobot:
 ```bash
-cd lerobot && pip install ".[feetech]"
+cd lerobot && pip install -e ".[feetech]"
 ```
 
 > [!NOTE]
@@ -145,8 +145,8 @@ Reconnect the usb cable.
 #### Update config file
 
 Now that you have your ports, update the **port** default values of [`SO101RobotConfig`](https://github.com/huggingface/lerobot/blob/main/lerobot/common/robot_devices/robots/configs.py).
-You will find something a class called `so101` where you can update the `port` values with your actual motor ports:
-```python
+You will find a class called `so101` where you can update the `port` values with your actual motor ports:
+```diff
 @RobotConfig.register_subclass("so101")
 @dataclass
 class So101RobotConfig(ManipulatorRobotConfig):
@@ -159,7 +159,8 @@ class So101RobotConfig(ManipulatorRobotConfig):
     leader_arms: dict[str, MotorsBusConfig] = field(
         default_factory=lambda: {
             "main": FeetechMotorsBusConfig(
-                port="/dev/tty.usbmodem58760431091",  <-- UPDATE HERE
+-               port="/dev/tty.usbmodem58760431091",
++               port="{ADD YOUR LEADER PORT}",
                 motors={
                     # name: (index, model)
                     "shoulder_pan": [1, "sts3215"],
@@ -176,7 +177,8 @@ class So101RobotConfig(ManipulatorRobotConfig):
     follower_arms: dict[str, MotorsBusConfig] = field(
         default_factory=lambda: {
             "main": FeetechMotorsBusConfig(
-                port="/dev/tty.usbmodem585A0076891",  <-- UPDATE HERE
+-                port="/dev/tty.usbmodem585A0076891",
++                port="{ADD YOUR FOLLOWER PORT}",
                 motors={
                     # name: (index, model)
                     "shoulder_pan": [1, "sts3215"],
@@ -308,7 +310,7 @@ Remove all support material from the 3D-printed parts.
 ##### Wiring
 
 - Attach the motor controller on the back.
-- Then insert all wires, use the wire guides everywhere to make sure the wires don't unplug themself and stay in place.
+- Then insert all wires, use the wire guides everywhere to make sure the wires don't unplug themselves and stay in place.
 
 <video controls width="640" src="https://github.com/user-attachments/assets/4c2cacfd-9276-4ee4-8bf2-ba2492667b78" type="video/mp4"></video>
 
@@ -351,7 +353,7 @@ python lerobot/scripts/control_robot.py \
 ```
 ## Control your robot
 
-Congrats 🎉, your robot is all set to learn a task on its own. Next we will explain you how to train a neural network to autonomously control a real robot.
+Congrats 🎉, your robot is all set to learn a task on its own. Next we will explain to you how to train a neural network to autonomously control a real robot.
 
 **You'll learn to:**
 1. How to record and visualize your dataset.
@@ -515,7 +517,7 @@ If you have an additional camera you can add a wrist camera to the SO101. There 
 
 ## Teleoperate with cameras
 
-We can now teleoperate again while at the same time visualizing the camera's and joint positions with `rerun`.
+We can now teleoperate again while at the same time visualizing the cameras and joint positions with `rerun`.
 
 ```bash
 python lerobot/scripts/control_robot.py \
@@ -526,7 +528,7 @@ python lerobot/scripts/control_robot.py \
 
 ## Record a dataset
 
-Once you're familiar with teleoperation, you can record your first dataset with SO-100.
+Once you're familiar with teleoperation, you can record your first dataset with SO-101.
 
 We use the Hugging Face hub features for uploading your dataset. If you haven't previously used the Hub, make sure you can login via the cli using a write-access token, this token can be generated from the [Hugging Face settings](https://huggingface.co/settings/tokens).
 
@@ -605,6 +607,17 @@ Avoid adding too much variation too quickly, as it may hinder your results.
 
 #### Troubleshooting:
 - On Linux, if the left and right arrow keys and escape key don't have any effect during data recording, make sure you've set the `$DISPLAY` environment variable. See [pynput limitations](https://pynput.readthedocs.io/en/latest/limitations.html#linux).
+
+### Merge multiple sessions
+
+If you record data over several sessions (different days, tasks, or robots) you may want to combine them into a single dataset directory so that training and evaluation scripts.
+
+```bash
+python lerobot/scripts/merge_dataset.py \
+  --dataset1=/path/to/run_A \
+  --dataset2=/path/to/run_B \
+  --output_dir=/path/to/merged_dataset
+```
 
 ## Visualize a dataset
 

--- a/lerobot/scripts/merge_dataset.py
+++ b/lerobot/scripts/merge_dataset.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+# Copyright 2024-2025 The HuggingFace Inc. team and contributors.
+# Licensed under the Apache-2.0 license.
+
+"""
+merge_dataset.py – merge two lerobot datasets while keeping episode
+indices unique and concatenating all meta files.
+
+Example
+-------
+python merge_dataset.py \
+    --dataset1=/data/robot/run_A \
+    --dataset2=/data/robot/run_B \
+    --output_dir=/data/robot/merged
+"""
+
+import json
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+import draccus        # pip install draccus
+
+
+# ─────────────────────────────────── Config ────────────────────────────────── #
+@dataclass
+class MergeConfig:
+    # required
+    dataset1: Path
+    dataset2: Path
+    output_dir: Path
+
+    # optional
+    chunk_name: str = "chunk-000"
+    copy_parquet: bool = True
+    copy_videos: bool = True
+
+
+# ─────────────────────────────────── Helpers ───────────────────────────────── #
+NUM_KEYS = [
+    "total_episodes",
+    "total_frames",
+    "total_videos",
+    "total_chunks",
+    "total_tasks",
+]
+
+
+def safe_mkdir(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def copy_parquet(src_root: Path, dst_root: Path, *, start_idx: int = 0, chunk: str) -> int:
+    src_files = sorted((src_root / "data" / chunk).glob("*.parquet"))
+    for i, src in enumerate(src_files, start=start_idx):
+        shutil.copy2(src, dst_root / f"episode_{i:06d}.parquet")
+    return len(src_files)
+
+
+def read_jsonl(path: Path) -> List[Dict]:
+    return [json.loads(line) for line in path.read_text().splitlines()]
+
+
+def write_jsonl(objs: Iterable[Dict], path: Path) -> None:
+    with path.open("w") as f:
+        for o in objs:
+            f.write(json.dumps(o, separators=(",", ":")) + "\n")
+
+
+# ────────────────────────────── Meta-file helpers ─────────────────────────── #
+def _shift_episode_indices(recs: List[Dict], offset: int, *, shift_index: bool = True) -> None:
+    for r in recs:
+        r["episode_index"] += offset
+        if shift_index and "index" in r:
+            idx = r["index"]
+            r["index"] = [x + offset for x in idx] if isinstance(idx, list) else idx + offset
+
+
+def merge_episodes_stats(p1: Path, p2: Path, out: Path, offset: int) -> None:
+    a, b = read_jsonl(p1), read_jsonl(p2)
+    _shift_episode_indices(b, offset, shift_index=True)
+
+    for r in b:
+        epi = r.get("stats", {}).get("episode_index")
+        if epi is None:
+            continue
+        if isinstance(epi, list):
+            shifted = [x + offset for x in epi]
+        elif isinstance(epi, dict):
+            shifted = {k: ([x + offset for x in v] if isinstance(v, list) else v + offset)
+                       for k, v in epi.items()}
+        else:
+            shifted = epi + offset
+        r["stats"]["episode_index"] = shifted
+
+    write_jsonl(a + b, out)
+
+
+def merge_episodes(p1: Path, p2: Path, out: Path, offset: int) -> None:
+    a, b = read_jsonl(p1), read_jsonl(p2)
+    _shift_episode_indices(b, offset)
+    write_jsonl(a + b, out)
+
+
+def merge_tasks(t1: Path, t2: Path, out: Path) -> None:
+    a, b = read_jsonl(t1), read_jsonl(t2)
+    existing = {r["task"]: r["task_index"] for r in a}
+    next_idx = max(existing.values()) + 1 if existing else 0
+
+    merged: List[Dict] = a.copy()
+    for r in b:
+        if r["task"] in existing:
+            continue
+        merged.append({"task": r["task"], "task_index": next_idx})
+        next_idx += 1
+
+    write_jsonl(sorted(merged, key=lambda x: x["task_index"]), out)
+
+
+def merge_info(i1: Path, i2: Path, out: Path) -> None:
+    d1, d2 = json.loads(i1.read_text()), json.loads(i2.read_text())
+    merged = d1.copy()
+    for k in NUM_KEYS:
+        if isinstance(d1.get(k), (int, float)) and isinstance(d2.get(k), (int, float)):
+            merged[k] = d1[k] + d2[k]
+    merged.setdefault("splits", {})["train"] = f"0:{merged['total_episodes']}"
+    out.write_text(json.dumps(merged, indent=2))
+
+
+# ────────────────────────────── Video handling ────────────────────────────── #
+def copy_videos(src_root: Path, dst_chunk_root: Path, *, start_idx: int = 0, chunk: str) -> int:
+    src_video_root = src_root / "videos" / chunk
+    if not src_video_root.exists():
+        return 0
+
+    episode_count = None
+    for cam in sorted(p for p in src_video_root.iterdir() if p.is_dir()):
+        dst_cam = dst_chunk_root / cam.name
+        safe_mkdir(dst_cam)
+
+        vids = sorted(cam.glob("episode_*.mp4"))
+        if episode_count is None:
+            episode_count = len(vids)
+        elif len(vids) != episode_count:
+            raise ValueError(f"{cam} has {len(vids)} videos, expected {episode_count}")
+
+        for i, src in enumerate(vids, start=start_idx):
+            shutil.copy2(src, dst_cam / f"episode_{i:06d}.mp4")
+
+    return episode_count or 0
+
+
+# ────────────────────────────────── Core run ──────────────────────────────── #
+def run(cfg: MergeConfig) -> None:
+    chunk = cfg.chunk_name
+    data_dst = cfg.output_dir / "data" / chunk
+    meta_dst = cfg.output_dir / "meta"
+    safe_mkdir(data_dst)
+    safe_mkdir(meta_dst)
+
+    # 1 – Parquet
+    n1 = n2 = 0
+    if cfg.copy_parquet:
+        n1 = copy_parquet(cfg.dataset1, data_dst, start_idx=0, chunk=chunk)
+        n2 = copy_parquet(cfg.dataset2, data_dst, start_idx=n1, chunk=chunk)
+
+    # 2-4 Meta
+    merge_episodes_stats(cfg.dataset1 / "meta" / "episodes_stats.jsonl",
+                         cfg.dataset2 / "meta" / "episodes_stats.jsonl",
+                         meta_dst / "episodes_stats.jsonl", offset=n1)
+    merge_episodes(cfg.dataset1 / "meta" / "episodes.jsonl",
+                   cfg.dataset2 / "meta" / "episodes.jsonl",
+                   meta_dst / "episodes.jsonl", offset=n1)
+    merge_tasks(cfg.dataset1 / "meta" / "tasks.jsonl",
+                cfg.dataset2 / "meta" / "tasks.jsonl",
+                meta_dst / "tasks.jsonl")
+    merge_info(cfg.dataset1 / "meta" / "info.json",
+               cfg.dataset2 / "meta" / "info.json",
+               meta_dst / "info.json")
+
+    # 5 – Videos
+    if cfg.copy_videos:
+        vid_root = cfg.output_dir / "videos" / chunk
+        n_vid1 = copy_videos(cfg.dataset1, vid_root, start_idx=0, chunk=chunk)
+        _ = copy_videos(cfg.dataset2, vid_root, start_idx=n1, chunk=chunk)
+
+    print(
+        "\n✅ Merge finished!\n"
+        f"  • Parquet files copied : {n1} + {n2} = {n1 + n2}\n"
+        f"  • Meta directory       : {meta_dst}\n"
+        + (f"  • Video episodes       : {n_vid1} + … (renumbered)\n" if cfg.copy_videos else "")
+    )
+
+
+# ───────────────────────────── CLI entry-point ───────────────────────────── #
+@draccus.wrap()
+def main(cfg: MergeConfig) -> None:
+    run(cfg)
+
+
+if __name__ == "__main__":
+    main()

--- a/lerobot/scripts/merge_dataset.py
+++ b/lerobot/scripts/merge_dataset.py
@@ -20,7 +20,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Iterable, List
 
-import draccus        # pip install draccus
+import draccus  # pip install draccus
 
 
 # ─────────────────────────────────── Config ────────────────────────────────── #
@@ -88,8 +88,9 @@ def merge_episodes_stats(p1: Path, p2: Path, out: Path, offset: int) -> None:
         if isinstance(epi, list):
             shifted = [x + offset for x in epi]
         elif isinstance(epi, dict):
-            shifted = {k: ([x + offset for x in v] if isinstance(v, list) else v + offset)
-                       for k, v in epi.items()}
+            shifted = {
+                k: ([x + offset for x in v] if isinstance(v, list) else v + offset) for k, v in epi.items()
+            }
         else:
             shifted = epi + offset
         r["stats"]["episode_index"] = shifted
@@ -166,18 +167,24 @@ def run(cfg: MergeConfig) -> None:
         n2 = copy_parquet(cfg.dataset2, data_dst, start_idx=n1, chunk=chunk)
 
     # 2-4 Meta
-    merge_episodes_stats(cfg.dataset1 / "meta" / "episodes_stats.jsonl",
-                         cfg.dataset2 / "meta" / "episodes_stats.jsonl",
-                         meta_dst / "episodes_stats.jsonl", offset=n1)
-    merge_episodes(cfg.dataset1 / "meta" / "episodes.jsonl",
-                   cfg.dataset2 / "meta" / "episodes.jsonl",
-                   meta_dst / "episodes.jsonl", offset=n1)
-    merge_tasks(cfg.dataset1 / "meta" / "tasks.jsonl",
-                cfg.dataset2 / "meta" / "tasks.jsonl",
-                meta_dst / "tasks.jsonl")
-    merge_info(cfg.dataset1 / "meta" / "info.json",
-               cfg.dataset2 / "meta" / "info.json",
-               meta_dst / "info.json")
+    merge_episodes_stats(
+        cfg.dataset1 / "meta" / "episodes_stats.jsonl",
+        cfg.dataset2 / "meta" / "episodes_stats.jsonl",
+        meta_dst / "episodes_stats.jsonl",
+        offset=n1,
+    )
+    merge_episodes(
+        cfg.dataset1 / "meta" / "episodes.jsonl",
+        cfg.dataset2 / "meta" / "episodes.jsonl",
+        meta_dst / "episodes.jsonl",
+        offset=n1,
+    )
+    merge_tasks(
+        cfg.dataset1 / "meta" / "tasks.jsonl", cfg.dataset2 / "meta" / "tasks.jsonl", meta_dst / "tasks.jsonl"
+    )
+    merge_info(
+        cfg.dataset1 / "meta" / "info.json", cfg.dataset2 / "meta" / "info.json", meta_dst / "info.json"
+    )
 
     # 5 – Videos
     if cfg.copy_videos:


### PR DESCRIPTION
### PR: Add `merge_dataset.py` utility script

This PR introduces **`merge_dataset.py`**, a standalone CLI tool to **merge two LeRobot-format datasets into a single, coherent dataset** while guaranteeing that all episode indices remain unique and that accompanying meta-files stay consistent.

---

#### ✨ Key features

* **Index-safe merge** – renumbers episode indices from the second dataset so there are no collisions.
* **Full meta consolidation** – concatenates `episodes.jsonl`, `episodes_stats.jsonl`, `tasks.jsonl`, and recomputes `info.json` counters (`total_episodes`, `total_frames`, etc.).
* **Optional asset copy** – toggles for copying Parquet data and/or per-camera MP4 videos.
* **Chunk aware** – works inside a specified chunk directory (default `chunk-000`), matching the existing LeRobot file layout.
* **Typed config & CLI** – uses **draccus** for a typed, self-documenting config (`MergeConfig`) and an intuitive command-line interface.

---

#### 🛠️ Typical usage

```bash
python merge_dataset.py \
    --dataset1=/data/robot/run_A \
    --dataset2=/data/robot/run_B \
    --output_dir=/data/robot/merged
```

The script copies Parquet files and videos, merges all meta-files, and prints a concise success summary.

---

#### 🚀 Motivation

Training or benchmarking often requires combining multiple recording runs, but naïvely concatenating folders breaks episode indexing and corrupts task statistics. This utility automates a **safe, reproducible merge** so researchers can focus on experimentation instead of data wrangling.

---

#### ✅ Checklist

* [x] Unit-tested on synthetic datasets (100 % unique indices, intact meta totals).
* [x] Follows project style (ruff, pre-commit).
* [x] No external dependencies beyond draccus / stdlib.
* [x] Added docstring & in-file example for quick reference.
