### PR TITLE
fix(scripts): reconstructs action dict from policy output

### DIFF
--- a/lerobot/record.py
+++ b/lerobot/record.py
@@ -189,7 +189,7 @@ def record_loop(
             action_values = predict_action(
                 observation_frame, policy, get_safe_torch_device(policy.config.device), policy.config.use_amp
             )
-            action = {key: action_values[i] for i, key in enumerate(robot.action_features.keys())}
+            action = {key: action_values[i] for i, key in enumerate(robot.action_features)}
         else:
             action = teleop.get_action()
 


### PR DESCRIPTION
This reconstructs the action dictionary from the policy output values (which corresponds to the action features of the robot). This is needed because `robot.send_action(action)` now expects a dictionary as input.