### PR TITLE
Add support for delta timesteps streaming

### DIFF
--- a/.cache/calibration/so100/main_follower.json
+++ b/.cache/calibration/so100/main_follower.json
@@ -1,0 +1,1 @@
+{"homing_offset": [-1764, 3077, -1035, -1969, 2024, -2430], "drive_mode": [0, 1, 0, 0, 1, 0], "start_pos": [1973, 3029, 1111, 1920, 2077, 2044], "end_pos": [2788, -2053, 2059, 2993, -1000, 3454], "calib_mode": ["DEGREE", "DEGREE", "DEGREE", "DEGREE", "DEGREE", "LINEAR"], "motor_names": ["shoulder_pan", "shoulder_lift", "elbow_flex", "wrist_flex", "wrist_roll", "gripper"]}

--- a/.cache/calibration/so100/main_leader.json
+++ b/.cache/calibration/so100/main_leader.json
@@ -1,0 +1,1 @@
+{"homing_offset": [-2147, 3044, -1075, -2043, 2078, -2213], "drive_mode": [0, 1, 0, 0, 1, 0], "start_pos": [2032, 2997, 1044, 2055, 1999, 2054], "end_pos": [3171, -2020, 2099, 3067, -1054, 3237], "calib_mode": ["DEGREE", "DEGREE", "DEGREE", "DEGREE", "DEGREE", "LINEAR"], "motor_names": ["shoulder_pan", "shoulder_lift", "elbow_flex", "wrist_flex", "wrist_roll", "gripper"]}

--- a/lerobot/common/datasets/profile_streaming_dataset.py
+++ b/lerobot/common/datasets/profile_streaming_dataset.py
@@ -250,8 +250,24 @@ def profile_dataset(
     stats_file_path = "streaming_dataset_profile.txt"
 
     print(f"Creating dataset from {repo_id} with buffer_size={buffer_size}, max_num_shards={max_num_shards}")
+    camera_key = "observation.images.cam_right_wrist"
+    fps = 50
+
+    delta_timestamps = {
+        # loads 4 images: 1 second before current frame, 500 ms before, 200 ms before, and current frame
+        camera_key: [-1, -0.5, -0.20, 0],
+        # loads 6 state vectors: 1.5 seconds before, 1 second before, ... 200 ms, 100 ms, and current frame
+        "observation.state": [-1.5, -1, -0.5, -0.20, -0.10, 0],
+        # loads 64 action vectors: current frame, 1 frame in the future, 2 frames, ... 63 frames in the future
+        "action": [t / fps for t in range(64)],
+    }
+
     dataset = StreamingLeRobotDataset(
-        repo_id=repo_id, buffer_size=buffer_size, max_num_shards=max_num_shards, seed=seed
+        repo_id=repo_id,
+        buffer_size=buffer_size,
+        max_num_shards=max_num_shards,
+        seed=seed,
+        delta_timestamps=delta_timestamps,
     )
 
     _time_iterations(dataset, num_samples, num_runs, warmup_iters, stats_file_path)

--- a/lerobot/common/datasets/profile_streaming_dataset.py
+++ b/lerobot/common/datasets/profile_streaming_dataset.py
@@ -163,7 +163,7 @@ def _profile_iteration(dataset, num_samples, stats_file_path):
     # Add functions to profile
     profiler.add_function(dataset.__iter__)
     profiler.add_function(dataset.make_frame)
-    profiler.add_function(dataset._make_iterable_dataset)
+    profiler.add_function(dataset._make_backtrackable_dataset)
 
     # Profile the iteration
 

--- a/lerobot/common/datasets/profile_streaming_dataset.py
+++ b/lerobot/common/datasets/profile_streaming_dataset.py
@@ -164,6 +164,7 @@ def _profile_iteration(dataset, num_samples, stats_file_path):
     profiler.add_function(dataset.__iter__)
     profiler.add_function(dataset.make_frame)
     profiler.add_function(dataset._make_backtrackable_dataset)
+    profiler.add_function(dataset._get_delta_frames)
 
     # Profile the iteration
 

--- a/lerobot/common/datasets/streaming_dataset.py
+++ b/lerobot/common/datasets/streaming_dataset.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Callable, Dict, Generator, Iterator, Tuple
+from typing import Callable, Dict, Generator, Iterator
 
 import datasets
 import numpy as np
@@ -13,9 +13,7 @@ from lerobot.common.datasets.utils import (
     Backtrackable,
     LookAheadError,
     LookBackError,
-    check_delta_timestamps,
     check_version_compatibility,
-    get_delta_indices,
     item_to_torch,
 )
 from lerobot.common.datasets.video_utils import (

--- a/lerobot/common/datasets/streaming_dataset.py
+++ b/lerobot/common/datasets/streaming_dataset.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Callable, Dict, Generator, Iterator
+from typing import Callable, Dict, Generator, Iterator, Tuple
 
 import datasets
 import numpy as np
@@ -10,7 +10,12 @@ from line_profiler import profile
 from lerobot.common.constants import HF_LEROBOT_HOME
 from lerobot.common.datasets.lerobot_dataset import CODEBASE_VERSION, LeRobotDatasetMetadata
 from lerobot.common.datasets.utils import (
+    Backtrackable,
+    LookAheadError,
+    LookBackError,
+    check_delta_timestamps,
     check_version_compatibility,
+    get_delta_indices,
     item_to_torch,
 )
 from lerobot.common.datasets.video_utils import (
@@ -64,6 +69,7 @@ class StreamingLeRobotDataset(torch.utils.data.IterableDataset):
         root: str | Path | None = None,
         episodes: list[int] | None = None,
         image_transforms: Callable | None = None,
+        delta_timestamps: dict[list[float]] | None = None,
         tolerance_s: float = 1e-4,
         revision: str | None = None,
         force_cache_sync: bool = False,
@@ -125,8 +131,17 @@ class StreamingLeRobotDataset(torch.utils.data.IterableDataset):
         # Check version
         check_version_compatibility(self.repo_id, self.meta._version, CODEBASE_VERSION)
 
-        self.hf_dataset = self.load_hf_dataset()
+        if delta_timestamps is not None:
+            self._validate_delta_timestamp_keys(delta_timestamps)  # raises ValueError if invalid
+            self.delta_timestamps = delta_timestamps
+
+        self.hf_dataset: datasets.IterableDataset = self.load_hf_dataset()
         self.num_shards = min(self.hf_dataset.num_shards, max_num_shards)
+
+        max_backward_steps, max_forward_steps = self._get_window_steps()
+        self.backtrackable_dataset: Backtrackable = Backtrackable(
+            self.hf_dataset, history=max_backward_steps, lookahead=max_forward_steps
+        )
 
     @property
     def fps(self):
@@ -163,11 +178,6 @@ class StreamingLeRobotDataset(torch.utils.data.IterableDataset):
 
         # This buffer is populated while iterating on the dataset's shards
         frames_buffer = []
-        idx_to_iterable_dataset = {
-            idx: self._make_iterable_dataset(self.hf_dataset.shard(self.num_shards, index=idx))
-            for idx in range(self.num_shards)
-        }
-
         try:
             while available_shards := list(idx_to_iterable_dataset.keys()):
                 shard_key = next(self._infinite_generator_over_elements(rng, available_shards))
@@ -185,18 +195,18 @@ class StreamingLeRobotDataset(torch.utils.data.IterableDataset):
             RuntimeError,
             StopIteration,
         ):  # NOTE: StopIteration inside a generator throws a RuntimeError since 3.7
-            # Remove exhausted shard
-            del idx_to_iterable_dataset[shard_key]
+            del idx_to_backtracktable_dataset[shard_key]  # Remove exhausted shard, onto another shard
 
         # Once shards are all exhausted, shuffle the buffer and yield the remaining frames
         rng.shuffle(frames_buffer)
         yield from frames_buffer
 
-    def _make_iterable_dataset(self, dataset: datasets.IterableDataset) -> Iterator:
-        return iter(dataset)
+    def _make_backtrackable_dataset(self, dataset: datasets.IterableDataset) -> Backtrackable:
+        history, lookahead = self._get_window_steps()
+        return Backtrackable(dataset, history=history, lookahead=lookahead)
 
     @profile
-    def make_frame(self, dataset_iterator: datasets.IterableDataset) -> Generator:
+    def make_frame(self, dataset_iterator: Backtrackable) -> Generator:
         """Makes a frame starting from a dataset iterator"""
         item = next(dataset_iterator)
         item = item_to_torch(item)
@@ -204,16 +214,20 @@ class StreamingLeRobotDataset(torch.utils.data.IterableDataset):
         # Get episode index from the item
         ep_idx = item["episode_index"]
 
+        # Apply delta querying logic if necessary
+        if self.delta_indices is not None:
+            query_result, padding = self._get_delta_frames(dataset_iterator, item)
+            item = {**item, **query_result, **padding}
+
         # Load video frames, when needed
         if len(self.meta.video_keys) > 0:
             current_ts = item["timestamp"]
-            query_timestamps = self._get_query_timestamps(current_ts, None)
+            query_indices = self.delta_indices if self.delta_indices is not None else None
+            query_timestamps = self._get_query_timestamps(current_ts, query_indices)
             video_frames = self._query_videos(query_timestamps, ep_idx)
             item = {**video_frames, **item}
 
-        # Add task as a string
-        task_idx = item["task_index"]
-        item["task"] = self.meta.tasks.iloc[task_idx].name
+        item["task"] = self.meta.tasks.iloc[item["task_index"]].name
 
         yield item
 
@@ -225,8 +239,9 @@ class StreamingLeRobotDataset(torch.utils.data.IterableDataset):
         query_timestamps = {}
         for key in self.meta.video_keys:
             if query_indices is not None and key in query_indices:
-                timestamps = self.hf_dataset.select(query_indices[key])["timestamp"]
-                query_timestamps[key] = torch.stack(timestamps).tolist()
+                timestamps = current_ts + torch.tensor(query_indices[key]) / self.fps
+                # never query for negative timestamps!
+                query_timestamps[key] = list(filter(lambda x: x >= 0, timestamps.tolist()))
             else:
                 query_timestamps[key] = [current_ts]
 
@@ -250,14 +265,145 @@ class StreamingLeRobotDataset(torch.utils.data.IterableDataset):
 
         return item
 
+    def _get_future_frame(self, dataset_iterator: Backtrackable, n_steps: int):
+        if dataset_iterator.can_go_ahead(n_steps):
+            return dataset_iterator.peek_ahead(n_steps)
+        else:
+            pass
+
+    def _get_previous_frame(self, dataset_iterator: Backtrackable, n_steps: int):
+        if dataset_iterator.can_go_back(n_steps):
+            return dataset_iterator.peek_back(n_steps)
+        else:
+            pass
+
+    def _get_delta_frames(self, dataset_iterator: Backtrackable, current_item: dict):
+        """Get frames with delta offsets using the backtrackable iterator.
+
+        Args:
+            current_item (dict): Current item from the iterator.
+            ep_idx (int): Episode index.
+
+        Returns:
+            tuple: (query_result, padding) - frames at delta offsets and padding info.
+        """
+        current_episode_idx = current_item["episode_index"]
+
+        # Prepare results
+        query_result = {}
+        padding = {}
+
+        for key, delta_indices in self.delta_indices.items():
+            if key in self.meta.video_keys:
+                continue  # visual frames are decoded separately
+
+            target_frames = []
+            is_pad = []
+
+            # NOTE(fracapuano): Optimize this. What's the point in checking all deltas after first error?
+            for delta in delta_indices:
+                if delta == 0:
+                    # Current frame
+                    target_frames.append(current_item[key])
+                    is_pad.append(False)
+
+                elif delta < 0:
+                    # Past frame. Use backtrackable iterator, looking back delta steps
+                    try:
+                        steps_back = abs(delta)
+                        if dataset_iterator.can_peek_back(steps_back):
+                            past_item = dataset_iterator.peek_back(steps_back)
+                            past_item = item_to_torch(past_item)
+
+                            # Check if it's from the same episode
+                            if past_item["episode_index"] == current_episode_idx:
+                                target_frames.append(past_item[key])
+                                is_pad.append(False)
+
+                            else:
+                                raise LookBackError("Retrieved frame is from different episode!")
+                        else:
+                            raise LookBackError("Cannot go back further than the history buffer!")
+
+                    except LookBackError:
+                        target_frames.append(torch.zeros_like(current_item[key]))
+                        is_pad.append(True)
+
+                elif delta > 0:
+                    # Future frame - read ahead from the iterator
+                    try:
+                        if dataset_iterator.can_peek_ahead(delta):
+                            future_item = dataset_iterator.peek_ahead(delta)
+                            future_item = item_to_torch(future_item)
+
+                            # Check if it's from the same episode
+                            if future_item["episode_index"] == current_episode_idx:
+                                target_frames.append(future_item[key])
+                                is_pad.append(False)
+
+                            else:
+                                raise LookAheadError("Retrieved frame is from different episode!")
+                        else:
+                            raise LookAheadError("Cannot go ahead further than the lookahead buffer!")
+
+                    except LookAheadError:
+                        target_frames.append(torch.zeros_like(current_item[key]))
+                        is_pad.append(True)
+
+            # Stack frames and add to results
+            if target_frames:
+                query_result[key] = torch.stack(target_frames)
+                padding[f"{key}.pad_masking"] = torch.BoolTensor(is_pad)
+
+        return query_result, padding
+
+    def _validate_delta_timestamp_keys(self, delta_timestamps: dict[list[float]]) -> None:
+        """
+        Validate that all keys in delta_timestamps correspond to actual features in the dataset.
+
+        Raises:
+            ValueError: If any delta timestamp key doesn't correspond to a dataset feature.
+        """
+        if delta_timestamps is None:
+            return
+
+        # Get all available feature keys from the dataset metadata
+        available_features = set(self.meta.features.keys())
+
+        # Get all keys from delta_timestamps
+        delta_keys = set(delta_timestamps.keys())
+
+        # Find any keys that don't correspond to features
+        invalid_keys = delta_keys - available_features
+
+        if invalid_keys:
+            raise ValueError(
+                f"The following delta_timestamp keys do not correspond to dataset features: {invalid_keys}. "
+                f"Available features are: {sorted(available_features)}"
+            )
+
 
 # Example usage
 if __name__ == "__main__":
+    from tqdm import tqdm
+
     repo_id = "lerobot/aloha_mobile_cabinet"
-    dataset = StreamingLeRobotDataset(repo_id)
 
-    for i, frame in enumerate(dataset):
+    camera_key = "observation.images.cam_right_wrist"
+    fps = 50
+
+    delta_timestamps = {
+        # loads 4 images: 1 second before current frame, 500 ms before, 200 ms before, and current frame
+        camera_key: [-1, -0.5, -0.20, 0],
+        # loads 6 state vectors: 1.5 seconds before, 1 second before, ... 200 ms, 100 ms, and current frame
+        "observation.state": [-1.5, -1, -0.5, -0.20, -0.10, 0],
+        # loads 64 action vectors: current frame, 1 frame in the future, 2 frames, ... 63 frames in the future
+        "action": [t / fps for t in range(64)],
+    }
+
+    dataset = StreamingLeRobotDataset(repo_id, delta_timestamps=delta_timestamps)
+
+    for i, frame in tqdm(enumerate(dataset)):
         print(frame)
-
-        if i > 10:  # only stream first 10 frames
+        if i > 1000:  # only stream first 10 frames
             break

--- a/lerobot/common/datasets/utils.py
+++ b/lerobot/common/datasets/utils.py
@@ -20,11 +20,12 @@ import logging
 import shutil
 import subprocess
 import tempfile
-from collections.abc import Iterator
+from collections import deque
+from collections.abc import Iterable, Iterator
 from pathlib import Path
 from pprint import pformat
 from types import SimpleNamespace
-from typing import Any, TypeVar
+from typing import Any, Deque, Generic, List, TypeVar
 
 import datasets
 import numpy as np
@@ -929,3 +930,179 @@ def item_to_torch(item: dict) -> dict:
             # Convert numpy arrays and lists to torch tensors
             item[key] = torch.tensor(val)
     return item
+
+
+class LookBackError(Exception):
+    """
+    Exception raised when trying to look back in the history of a Backtrackable object.
+    """
+
+    pass
+
+
+class LookAheadError(Exception):
+    """
+    Exception raised when trying to look ahead in the future of a Backtrackable object.
+    """
+
+    pass
+
+
+class Backtrackable(Generic[T]):
+    """
+    Wrap any iterator/iterable so you can step back up to `history` items
+    and look ahead up to `lookahead` items.
+
+    This is useful for streaming datasets where you need to access previous and future items
+    but can't load the entire dataset into memory.
+
+    Example:
+    -------
+    ```python
+    ds = load_dataset("c4", "en", streaming=True, split="train")
+    rev = Backtrackable(ds, history=3, lookahead=2)
+
+    x0 = next(rev)      # forward
+    x1 = next(rev)
+    x2 = next(rev)
+
+    # Look ahead
+    x3_peek = rev.peek_ahead(1)  # next item without moving cursor
+    x4_peek = rev.peek_ahead(2)  # two items ahead
+
+    # Look back
+    x1_again = rev.peek_back(1)  # previous item without moving cursor
+    x0_again = rev.peek_back(2)  # two items back
+
+    # Move backward
+    x1_back = rev.prev()     # back one step
+    next(rev)                # returns x2, continues forward from where we were
+    ```
+    """
+
+    __slots__ = ("_source", "_back_buf", "_ahead_buf", "_cursor", "_lookahead")
+
+    def __init__(self, iterable: Iterable[T], *, history: int = 1, lookahead: int = 0):
+        if history < 1:
+            raise ValueError("history must be ≥ 1")
+        if lookahead < 0:
+            raise ValueError("lookahead must be ≥ 0")
+
+        self._source: Iterator[T] = iter(iterable)
+        self._back_buf: Deque[T] = deque(maxlen=history)
+        self._ahead_buf: Deque[T] = deque(maxlen=lookahead) if lookahead > 0 else deque()
+        self._cursor: int = 0  # 0 == just after the newest item in back_buf
+        self._lookahead = lookahead
+
+    def __iter__(self) -> "Backtrackable[T]":
+        return self
+
+    def __next__(self) -> T:
+        # If we've stepped back, consume from back buffer first
+        if self._cursor < 0:  # -1 means "last item", etc.
+            self._cursor += 1
+            return self._back_buf[self._cursor]
+
+        # If we have items in the ahead buffer, use them first
+        item = self._ahead_buf.popleft() if self._ahead_buf else next(self._source)
+
+        # Add current item to back buffer and reset cursor
+        self._back_buf.append(item)
+        self._cursor = 0
+        return item
+
+    def prev(self) -> T:
+        """
+        Step one item back in history and return it.
+        Raises IndexError if already at the oldest buffered item.
+        """
+        if len(self._back_buf) + self._cursor <= 1:
+            raise LookBackError("At start of history")
+
+        self._cursor -= 1
+        return self._back_buf[self._cursor]
+
+    def peek_back(self, n: int = 1) -> T:
+        """
+        Look `n` items back (n=1 == previous item) without moving the cursor.
+        """
+        if n < 1 or n > len(self._back_buf) + self._cursor:
+            raise LookBackError("peek_back distance out of range")
+
+        return self._back_buf[self._cursor - n]
+
+    def peek_ahead(self, n: int = 1) -> T:
+        """
+        Look `n` items ahead (n=1 == next item) without moving the cursor.
+        Fills the ahead buffer if necessary.
+        """
+        if n < 1:
+            raise LookAheadError("peek_ahead distance must be 1 or more")
+        elif n > self._lookahead:
+            raise LookAheadError("peek_ahead distance exceeds lookahead limit")
+
+        # Fill ahead buffer if we don't have enough items
+        while len(self._ahead_buf) < n:
+            try:
+                item = next(self._source)
+                self._ahead_buf.append(item)
+
+            except StopIteration as err:
+                raise LookAheadError("peek_ahead: not enough items in source") from err
+
+        return self._ahead_buf[n - 1]
+
+    def history(self) -> List[T]:
+        """
+        Return a copy of the buffered history (most recent last).
+        The list length ≤ `history` argument passed at construction.
+        """
+        if self._cursor == 0:
+            return list(self._back_buf)
+
+        # When cursor<0, slice so the order remains chronological
+        return list(self._back_buf)[: self._cursor or None]
+
+    def lookahead_buffer(self) -> List[T]:
+        """
+        Return a copy of the current lookahead buffer.
+        """
+        return list(self._ahead_buf)
+
+    def can_peek_back(self, steps: int = 1) -> bool:
+        """
+        Check if we can go back `steps` items without raising an IndexError.
+        """
+        return steps <= len(self._back_buf) + self._cursor
+
+    def can_peek_ahead(self, steps: int = 1) -> bool:
+        """
+        Check if we can peek ahead `steps` items.
+        This may involve trying to fill the ahead buffer.
+        """
+        if self._lookahead > 0 and steps > self._lookahead:
+            return False
+
+        # Try to fill ahead buffer to check if we can peek that far
+        try:
+            while len(self._ahead_buf) < steps:
+                if self._lookahead > 0 and len(self._ahead_buf) >= self._lookahead:
+                    return False
+                item = next(self._source)
+                self._ahead_buf.append(item)
+            return True
+        except StopIteration:
+            return False
+
+    def reset_cursor(self) -> None:
+        """
+        Reset cursor to the most recent position (equivalent to calling next()
+        until you're back to the latest item).
+        """
+        self._cursor = 0
+
+    def clear_ahead_buffer(self) -> None:
+        """
+        Clear the ahead buffer, discarding any pre-fetched items.
+        """
+        self._ahead_buf.clear()


### PR DESCRIPTION
Part of PR stack
👉 https://github.com/huggingface/lerobot/pull/1173
👀 https://github.com/huggingface/lerobot/pull/1165
👀 https://github.com/huggingface/lerobot/pull/969

## What this does

This PR extends `StreamingLeRobotDataset` to support delta timestamps, enabling efficient access to past and future frames during streaming without loading the entire dataset into memory.

## Key Features

### Enhanced Backtrackable Iterator
- **Bidirectional buffering**: Maintains separate buffers for history (`_back_buf`) and lookahead (`_ahead_buf`)
- **Configurable windows**: Set `history` and `lookahead` parameters to control buffer sizes. These parameters are inferred automatically from the input `delta_timesteps` according to a worst-case-scenario logic (min and max delta values, respectively).
- **Memory efficient**: Only keeps necessary frames in memory based on delta timestamp requirements
- **Episode-aware**: Prevents accessing frames across episode boundaries, returning padding and padding masks when within-same-episode values are not accessible.

### Delta Timestamps Integration
- **Automatic validation**: Checks delta timestamp keys against dataset features at initialization
- **Temporal queries**: Supports both past (`delta < 0`) and future (`delta > 0`) frame access
- **Padding handling**: Automatically pads with zeros when frames are unavailable or cross episode boundaries. Returns the padding masks as a `torch.Bool` mask within `{key}.pad_masking` for easy post-filtering of the returned elements
- **Video compatibility**: Works seamlessly with video decoding for visual modalities. Relies on `torchcodec` multi-timesteps integration.

## Implementation Details

### Backtrackable Class (`utils.py`)
```python
# Create iterator with 5-frame history and 3-frame lookahead
backtrackable = Backtrackable(dataset, history=5, lookahead=3)

# Access patterns
current = next(backtrackable)           # Move forward
previous = backtrackable.peek_back(1)   # Look back without moving
future = backtrackable.peek_ahead(2)    # Look ahead without moving
```

**Core methods**:
- `peek_back(n)`: Access n frames back without cursor movement
- `peek_ahead(n)`: Access n frames ahead, pre-fetching if needed
- `can_peek_back/ahead()`: Check availability before access
- Episode boundary protection via custom exceptions

### Streaming Dataset Extensions
- **Window calculation**: Automatically determines required buffer sizes from delta timestamps
- **Frame stacking**: Assembles multi-temporal observations into single items
- **Graceful degradation**: Falls back to zero-padding when frames unavailable
- **Performance optimization**: Minimal memory footprint with bounded buffers

## How it was tested
Tested using the `profile_streaming_dataset.py` profiling script (complete report below 👇)

## How to checkout & try? (for the reviewer)
Checkout to the branch, install the correct dependancies (pay particular attention to `torchcodec`, cfr. #1165) and then execute this: 
```python
delta_timestamps = {
    "observation.images.cam_right_wrist": [-0.1, -0.05, 0.0],  # 100ms, 50ms ago, current
    "action": [0.0, 0.02, 0.04],  # current, 20ms, 40ms future
}

dataset = StreamingLeRobotDataset(
    repo_id="lerobot/aloha_mobile_cabinet",
    delta_timestamps=delta_timestamps
)

for item in dataset:
    # item contains stacked frames according to delta_timestamps, with padding information for easier filtering
    print(item["action"].shape)  # (3, action_dim), as we're quering for 3 elements. Same for `observation`
    print(item["action.pad_masking"])  # torch.tensor([False, False, True]), in this example first two elements are *not* padded, third one is
```

cc. @lhoestq for review and @Cadene for viz