### PR TITLE
Fix: busy_wait Windows Timer

### DIFF
--- a/lerobot/common/robot_devices/utils.py
+++ b/lerobot/common/robot_devices/utils.py
@@ -17,7 +17,7 @@ import time
 
 
 def busy_wait(seconds):
-    if platform.system() == "Darwin":
+    if platform.system() == "Darwin" or platform.system() == "Windows":
         # On Mac, `time.sleep` is not accurate and we need to use this while loop trick,
         # but it consumes CPU cycles.
         # TODO(rcadene): find an alternative: from python 11, time.sleep is precise


### PR DESCRIPTION
## What this does
This code fixes the busy_wait function on Windows to use the same strategy as Mac. Windows time.sleep() frequently oversleeps which is causing issues with framerates in recorded data

Examples:
|  Title               | Label           |
|----------------------|-----------------|
| Fixes #[issue]       | (🐛 Bug)        |
| Adds new dataset     | (🗃️ Dataset)    |
| Optimizes something  | (⚡️ Performance) |

## How it was tested
I ran a remote robot teleop on 10 fps, 20fps, and 30fps. 

For Linux all 3 were approximately correct (maybe off by a few hundredths of an fps)
For Windows all 3 were wildly off, anywhere from 10%-30% 

## How to checkout & try? (for the reviewer)
Record a dataset on Mac, Linux, and Windows and you should now see that all 3 have the proper FPS within the INFO logs when recording data

Examples:
```bash
python lerobot/scripts/control_robot.py \
  --robot.type=so100 \
  --control.type=teleoperate \
  --control.fps=20 \
  --control.display_data=true
```
