### PR TITLE
fix exclude_keys to support smolvla

### DIFF
--- a/lerobot/common/policies/utils.py
+++ b/lerobot/common/policies/utils.py
@@ -18,8 +18,14 @@ import torch
 from torch import nn
 
 
-def populate_queues(queues, batch):
+def populate_queues(queues, batch, exclude_keys=None):
+    if exclude_keys is None:
+        exclude_keys = []
+    
     for key in batch:
+        # Skip keys that are in the exclude list
+        if key in exclude_keys:
+            continue
         # Ignore keys not in the queues already (leaving the responsibility to the caller to make sure the
         # queues have the keys they want).
         if key not in queues:


### PR DESCRIPTION
## What this does

This PR adds exclude_keys to `populate_queues` for supporting smolvla action selection: https://github.com/huggingface/lerobot/blob/main/lerobot/common/policies/smolvla/modeling_smolvla.py#L285


## How it was tested
Explain/show how you tested your changes.

Examples:
- Added `test_something` in `tests/test_stuff.py`.
- Added `new_feature` and checked that training converges with policy X on dataset/environment Y.
- Optimized `some_function`, it now runs X times faster than previously.

## How to checkout & try? (for the reviewer)
Provide a simple way for the reviewer to try out your changes.

Examples:
```bash
pytest -sx tests/test_stuff.py::test_something
```
```bash
python lerobot/scripts/train.py --some.option=true
```

## SECTION TO REMOVE BEFORE SUBMITTING YOUR PR
**Note**: Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR. Try to avoid tagging more than 3 people.

**Note**: Before submitting this PR, please read the [contributor guideline](https://github.com/huggingface/lerobot/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr).
