### PR TITLE
Fix SmolVLA loss not sent to wandb

### DIFF
--- a/lerobot/common/policies/smolvla/modeling_smolvla.py
+++ b/lerobot/common/policies/smolvla/modeling_smolvla.py
@@ -324,16 +324,16 @@ class SmolVLAPolicy(PreTrainedPolicy):
         actions_is_pad = batch.get("actions_id_pad")
         loss_dict = {}
         losses = self.model.forward(images, img_masks, lang_tokens, lang_masks, state, actions, noise, time)
-        loss_dict["losses_after_forward"] = losses.tolist()
+        loss_dict["losses_after_forward"] = losses.clone()
 
         if actions_is_pad is not None:
             in_episode_bound = ~actions_is_pad
             losses = losses * in_episode_bound.unsqueeze(-1)
-            loss_dict["losses_after_in_ep_bound"] = losses.tolist()
+            loss_dict["losses_after_in_ep_bound"] = losses.clone()
 
         # Remove padding
         losses = losses[:, :, : self.config.max_action_dim]
-        loss_dict["losses_after_rm_padding"] = losses.tolist()
+        loss_dict["losses_after_rm_padding"] = losses.clone()
 
         # For backward pass
         loss = losses.mean()

--- a/lerobot/common/policies/smolvla/modeling_smolvla.py
+++ b/lerobot/common/policies/smolvla/modeling_smolvla.py
@@ -324,21 +324,21 @@ class SmolVLAPolicy(PreTrainedPolicy):
         actions_is_pad = batch.get("actions_id_pad")
         loss_dict = {}
         losses = self.model.forward(images, img_masks, lang_tokens, lang_masks, state, actions, noise, time)
-        loss_dict["losses_after_forward"] = losses.clone()
+        loss_dict["losses_after_forward"] = losses.tolist()
 
         if actions_is_pad is not None:
             in_episode_bound = ~actions_is_pad
             losses = losses * in_episode_bound.unsqueeze(-1)
-            loss_dict["losses_after_in_ep_bound"] = losses.clone()
+            loss_dict["losses_after_in_ep_bound"] = losses.tolist()
 
         # Remove padding
         losses = losses[:, :, : self.config.max_action_dim]
-        loss_dict["losses_after_rm_padding"] = losses.clone()
+        loss_dict["losses_after_rm_padding"] = losses.tolist()
 
         # For backward pass
         loss = losses.mean()
         # For backward pass
-        loss_dict["loss"] = loss
+        loss_dict["loss"] = loss.item()
         return loss, loss_dict
 
     def prepare_images(self, batch):

--- a/lerobot/common/utils/wandb_utils.py
+++ b/lerobot/common/utils/wandb_utils.py
@@ -115,7 +115,7 @@ class WandBLogger:
         for k, v in d.items():
             if not isinstance(v, (int, float, str)):
                 logging.warning(
-                    f'WandB logging of key "{k}" was ignored as its type is not handled by this wrapper.'
+                    f'WandB logging of key "{k}" was ignored as its type "{type(v)}" is not handled by this wrapper.'
                 )
                 continue
             self._wandb.log({f"{mode}/{k}": v}, step=step)


### PR DESCRIPTION
## What this does

This PR fixes an issue where loss values from `SmolVLAPolicy` were not being logged to Weights & Biases (wandb) due to incompatible data types. The code previously attempted to log PyTorch tensors directly, which `wandb_utils.py` ignores. Now, `loss` stored in `loss_dict` is converted to Python scalars using `.item()` to ensuring proper logging.

The warning looks like:
```
WARNING 2025-06-04 01:51:55 db_utils.py:117 WandB logging of key "loss" was ignored as its type "<class 'torch.Tensor'>" is not handled by this wrapper.
```

There are similar warnings for `losses_after_forward`, `losses_after_in_ep_bound`, and `losses_after_rm_padding`, but they are lists. So I'll leave them alone for now.

## How it was tested

- Manually ran training and verified that `loss` is now visible in the wandb dashboard.
- Confirmed that the previous warning message from `db_utils.py` about unsupported tensor type for `loss` no longer appear during training.

## How to checkout & try? (for the reviewer)
Do a training run of smolvla with wandb enabled:

```sh
python lerobot/scripts/train.py \
  --policy.path=lerobot/smolvla_base \
  --dataset.repo_id=lerobot/svla_so100_stacking \
  --batch_size=64 \
  --steps=200000 \
  --wandb.enable=true
```

Observe that the warning described above does not show up and wandb correctly logs the loss.
