### PR TITLE
Fix timestamp shape validation and buffer mismatch in add_frame()

### DIFF
--- a/lerobot/common/datasets/lerobot_dataset.py
+++ b/lerobot/common/datasets/lerobot_dataset.py
@@ -803,7 +803,7 @@ class LeRobotDataset(torch.utils.data.Dataset):
 
         # Automatically add frame_index and timestamp to episode buffer
         frame_index = self.episode_buffer["size"]
-        timestamp = frame.pop("timestamp") if "timestamp" in frame else frame_index / self.fps
+        timestamp = frame.pop("timestamp").item() if "timestamp" in frame else frame_index / self.fps
         self.episode_buffer["frame_index"].append(frame_index)
         self.episode_buffer["timestamp"].append(timestamp)
 


### PR DESCRIPTION
**What this does**  
Fixes a bug where `timestamp` validation requires a `(1,)` array, but storing this directly causes shape mismatch during stacking. The fix:
1. Maintains validation requirement of `(1,)` array input
2. Converts to scalar *after* validation using `.item()`
3. Prevents `(n,1)` vs `(n)` shape errors in buffers

**Why this works**  
Validation ensures:
- Input must be `(1,)` shaped array (not scalar or other shapes)
- `.item()` safely extracts the scalar value from validated array

**Implementation change**  
```python
# Before: stored (1,) array causing shape errors
timestamp = frame.pop("timestamp")  

# After: extract scalar from validated (1,) array
timestamp = frame.pop("timestamp").item()
```  
