### PR TITLE
Fix smolVLA dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ intelrealsense = [
     "pyrealsense2-macosx>=2.54 ; sys_platform == 'darwin'",
 ]
 pi0 = ["transformers>=4.48.0"]
-smolvla = ["transformers>=4.50.3"]
+smolvla = ["transformers>=4.50.3", "num2words>=0.5.14", "accelerate>=1.7.0"]
 pusht = ["gym-pusht>=0.1.5 ; python_version < '4.0'"]
 stretch = [
     "hello-robot-stretch-body>=0.7.27 ; python_version < '4.0' and sys_platform == 'linux'",


### PR DESCRIPTION
## What this does
Reverts some changes from #1208 as num2words and accelerate are actually needed to run smolVLA