### PR TITLE
fix(pyserial): adding pyserial dependency to global ones

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,7 @@ dependencies = [
     "av>=14.2.0",
     "pymunk>=6.6.0,<7.0.0",
     "pynput>=1.7.7",
+    "pyserial>=3.5",
     "pyzmq>=26.2.1",
     "rerun-sdk>=0.21.0",
     "termcolor>=2.4.0",
@@ -96,7 +97,7 @@ stretch = [
     "pyrender @ git+https://github.com/mmatl/pyrender.git ; sys_platform == 'linux'",
     "pyrealsense2>=2.55.1.6486 ; sys_platform != 'darwin'"
 ]
-test = ["pytest>=8.1.0", "pytest-cov>=5.0.0", "pyserial>=3.5", "mock-serial>=0.0.1 ; sys_platform != 'win32'"]
+test = ["pytest>=8.1.0", "pytest-cov>=5.0.0", "mock-serial>=0.0.1 ; sys_platform != 'win32'"]
 umi = ["imagecodecs>=2024.1.1"]
 video_benchmark = ["scikit-image>=0.23.2", "pandas>=2.2.2"]
 xarm = ["gym-xarm>=0.1.1 ; python_version < '4.0'"]


### PR DESCRIPTION
# What this does

Moves `pyserial` dependency from test dependencies to global dependencies to avoid installation errors.