### PR TITLE
Fix for Windows Enter key detection on calibration

### DIFF
--- a/lerobot/common/utils/utils.py
+++ b/lerobot/common/utils/utils.py
@@ -17,7 +17,6 @@ import logging
 import os
 import os.path as osp
 import platform
-import select
 import subprocess
 import sys
 from copy import copy
@@ -235,21 +234,24 @@ def is_valid_numpy_dtype_string(dtype_str: str) -> bool:
 # svaengheld : fix for compatibility with MS PowerShell on Windows, prevents this error:
 # "OSError: [WinError 10038] An operation was attempted on something that is not a socket"
 
-#def enter_pressed() -> bool:
+# def enter_pressed() -> bool:
 #    return select.select([sys.stdin], [], [], 0)[0] and sys.stdin.readline().strip() == ""
 
+
 def enter_pressed() -> bool:
-    import sys
     if sys.platform.startswith("win"):
         import msvcrt
+
         if msvcrt.kbhit():
             ch = msvcrt.getch()
-            return ch in (b'\r', b'\n')          # Enter hit
+            return ch in (b"\r", b"\n")  # Enter hit
         return False
     else:
         import select
-        return select.select([sys.stdin], [], [], 0)[0] \
-               and sys.stdin.readline().strip() == ""
+
+        return select.select([sys.stdin], [], [], 0)[0] and sys.stdin.readline().strip() == ""
+
+
 # svaengheld : end of update
 
 


### PR DESCRIPTION
## What this does
(🐛 Bug) 
Fix for compatibility with MS PowerShell on Windows, prevents this error during calibration:
"OSError: [WinError 10038] An operation was attempted on something that is not a socket"
Update to enter_pressed() in lerobot\common\utils\utils.py
checks the os and adapts the Enter format.

## How it was tested
After I changed the function and ran calibration, it worked, no error, conf file created.
(Not tested in Linux and Mac!! Please test it?)

## How to checkout & try? (for the reviewer)
use this prompt after installing the project on MS Powershell:
(set the right port number)

python -m lerobot.calibrate `
    --robot.type so101_follower `
    --robot.port COM6 `
    --robot.id follower_arm

## Note to the team
It's my first time doing a pull request, I didn't understand all the guidelines in the contributing.md so I did what I could, if you prefer I'll post the fix on Discord instead :-).