### PR TITLE
Fix missing log messages when using logging.info

### DIFF
--- a/lerobot/common/utils/utils.py
+++ b/lerobot/common/utils/utils.py
@@ -116,10 +116,13 @@ def init_logging():
         message = f"{record.levelname} {dt} {fnameline[-15:]:>15} {record.msg}"
         return message
 
-    logging.basicConfig(level=logging.INFO)
+    # Clean up previous logging handlers
+    if len(logging.root.handlers) > 0:
+        logging.warning(f"Cleaning up {len(logging.root.handlers)} handler(s) that were initialized before calling init_logging")
+        for handler in logging.root.handlers[:]:
+            logging.root.removeHandler(handler)
 
-    for handler in logging.root.handlers[:]:
-        logging.root.removeHandler(handler)
+    logging.basicConfig(level=logging.INFO)
 
     formatter = logging.Formatter()
     formatter.format = custom_format


### PR DESCRIPTION
## What this does

**Fixes missing log messages when using `logging.info`.**  
(🐛 Bug)

Previously, log messages at the INFO level (and below) were not displayed due to pre-existing logging handlers interfering with `basicConfig()`.  
This PR ensures that any previously initialized handlers are removed before configuring logging, so that the logging configuration in `init_logging()` always takes effect.  
A warning is logged when pre-existing handlers are cleaned up.

## How it was tested

- Manually verified that log messages now appear at the INFO level and above when using e.g. `python -m lerobot.record`

## How to checkout & try? (for the reviewer)

Run the record script and observe that INFO logs now show up.