### PR TITLE
Fix unable to set camera width/height to non-default

### DIFF
--- a/lerobot/common/cameras/opencv/camera_opencv.py
+++ b/lerobot/common/cameras/opencv/camera_opencv.py
@@ -225,16 +225,17 @@ class OpenCVCamera(Camera):
     def _validate_width_and_height(self) -> None:
         """Validates and sets the camera's frame capture width and height."""
 
-        success = self.videocapture.set(cv2.CAP_PROP_FRAME_WIDTH, float(self.capture_width))
-        actual_width = int(round(self.videocapture.get(cv2.CAP_PROP_FRAME_WIDTH)))
-        if not success or self.capture_width != actual_width:
-            raise RuntimeError(f"{self} failed to set capture_width={self.capture_width} ({actual_width=}).")
+        width_success = self.videocapture.set(cv2.CAP_PROP_FRAME_WIDTH, int(self.capture_width))
+        height_success = self.videocapture.set(cv2.CAP_PROP_FRAME_HEIGHT, int(self.capture_height))
 
-        success = self.videocapture.set(cv2.CAP_PROP_FRAME_HEIGHT, float(self.capture_height))
+        actual_width = int(round(self.videocapture.get(cv2.CAP_PROP_FRAME_WIDTH)))
+        if not width_success or self.capture_width != actual_width:
+            raise RuntimeError(f"{self} failed to set capture_width={self.capture_width} ({actual_width=}, {width_success=}).")
+
         actual_height = int(round(self.videocapture.get(cv2.CAP_PROP_FRAME_HEIGHT)))
-        if not success or self.capture_height != actual_height:
+        if not height_success or self.capture_height != actual_height:
             raise RuntimeError(
-                f"{self} failed to set capture_height={self.capture_height} ({actual_height})."
+                f"{self} failed to set capture_height={self.capture_height} ({actual_height=}, {height_success=})."
             )
 
     @staticmethod


### PR DESCRIPTION
## What this does

(🐛 Bug)

The cameras that I'm using (OV5693) started experiencing this error when setting to non-default width/height after #777 :
```
Traceback (most recent call last):
  File "/Users/ben/Projects/miniconda3/envs/lerobot/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/Users/ben/Projects/miniconda3/envs/lerobot/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/Users/ben/Projects/lerobot/lerobot/test_cameras_sdk.py", line 28, in <module>
    camera.connect()
  File "/Users/ben/Projects/lerobot/lerobot/common/cameras/opencv/camera_opencv.py", line 168, in connect
    self._configure_capture_settings()
  File "/Users/ben/Projects/lerobot/lerobot/common/cameras/opencv/camera_opencv.py", line 214, in _configure_capture_settings
    self._validate_width_and_height()
  File "/Users/ben/Projects/lerobot/lerobot/common/cameras/opencv/camera_opencv.py", line 231, in _validate_width_and_height
    raise RuntimeError(f"{self} failed to set capture_width={self.capture_width} ({actual_width=}).")
RuntimeError: OpenCVCamera(0) failed to set capture_width=800 (actual_width=1920).
```

This appears to be due to the change in the order of operations from the old (write everything, then read everything):

https://github.com/huggingface/lerobot/blob/f7ba84de07f0b1cf952d8909026c0b08d3436caf/lerobot/common/robot_devices/cameras/opencv.py#L335-L344

to the new (write width, read width, write height, read height):

https://github.com/huggingface/lerobot/blob/1ee2ca5c2627eab05940452472d876d0d4e73d1f/lerobot/common/cameras/opencv/camera_opencv.py#L225-L238

For some reason, inserting read operations between writing width and height breaks applying the writes.

This PR makes it so that the write operations happen before the read operations on width and height.

## How it was tested

Here's a minimal reproducible example:

```py
import cv2

camera_idx = 0

print("--------")
print("write width, read width, write height, read height")
camera = cv2.VideoCapture(camera_idx)
print("set width:", camera.set(cv2.CAP_PROP_FRAME_WIDTH, 800))
print(f"Actual width: {camera.get(cv2.CAP_PROP_FRAME_WIDTH)}")
print("set height:", camera.set(cv2.CAP_PROP_FRAME_HEIGHT, 600))
print(f"Actual height: {camera.get(cv2.CAP_PROP_FRAME_HEIGHT)}")
camera.release()

print("--------")
print("write width, write height, read width, read height")
camera = cv2.VideoCapture(camera_idx)
print("set width:", camera.set(cv2.CAP_PROP_FRAME_WIDTH, 800))
print("set height:", camera.set(cv2.CAP_PROP_FRAME_HEIGHT, 600))
print(f"Actual width: {camera.get(cv2.CAP_PROP_FRAME_WIDTH)}")
print(f"Actual height: {camera.get(cv2.CAP_PROP_FRAME_HEIGHT)}")
camera.release()
```

Sample output from my camera:

```
--------
write width, read width, write height, read height
set width: True
Actual width: 1920.0
set height: True
Actual height: 600.0
--------
write width, write height, read width, read height
set width: True
set height: True
Actual width: 800.0
Actual height: 600.0
```

Observe that the `Actual width` output is different in the two blocks.

## How to checkout & try? (for the reviewer)

Try the example above.