### PR TITLE
Proposal for fix for enter_pressed on Windows

### DIFF
--- a/lerobot/common/utils/utils.py
+++ b/lerobot/common/utils/utils.py
@@ -231,10 +231,15 @@ def is_valid_numpy_dtype_string(dtype_str: str) -> bool:
         # If a TypeError is raised, the string is not a valid dtype
         return False
 
-
 def enter_pressed() -> bool:
-    return select.select([sys.stdin], [], [], 0)[0] and sys.stdin.readline().strip() == ""
-
+    if os.name == 'nt':
+        import msvcrt
+        if msvcrt.kbhit():
+            key = msvcrt.getch()
+            return key in (b'\r', b'\n')  # enter key
+        return False
+    else:
+        return select.select([sys.stdin], [], [], 0)[0] and sys.stdin.readline().strip() == ""
 
 def move_cursor_up(lines):
     """Move the cursor up by a specified number of lines."""


### PR DESCRIPTION
Windows crashes on OSError: [WinError 10038] An operation was attempted on something that is not a socket

## What this does
This PR fixes the enter_pressed function

## How it was tested
This was tested on Windows by running the calibrate procedure
python -m lerobot.calibrate --teleop.type=so100_leader --teleop.port=COM25 --teleop.id=my_yellow_leader_arm

## How to checkout & try? (for the reviewer)
Run the above calibration on Windows

Examples:
```
python -m lerobot.calibrate --teleop.type=so100_leader --teleop.port=COM25 --teleop.id=my_yellow_leader_arm
```

