### PR TITLE
fix: update pi0 dependency version constraint

### DIFF
--- a/lerobot/common/policies/pi0/paligemma_with_expert.py
+++ b/lerobot/common/policies/pi0/paligemma_with_expert.py
@@ -216,7 +216,11 @@ class PaliGemmaWithExpertModel(PreTrainedModel):
                 param.data = param.data.to(dtype=torch.bfloat16)
 
     def embed_image(self, image: torch.Tensor):
-        return self.paligemma.get_image_features(image)
+        # Handle different transformers versions
+        if hasattr(self.paligemma, 'get_image_features'):
+            return self.paligemma.get_image_features(image)
+        else:
+            return self.paligemma.model.get_image_features(image)
 
     def embed_language_tokens(self, tokens: torch.Tensor):
         return self.paligemma.language_model.model.embed_tokens(tokens)

--- a/lerobot/common/policies/pi0/paligemma_with_expert.py
+++ b/lerobot/common/policies/pi0/paligemma_with_expert.py
@@ -217,7 +217,7 @@ class PaliGemmaWithExpertModel(PreTrainedModel):
 
     def embed_image(self, image: torch.Tensor):
         # Handle different transformers versions
-        if hasattr(self.paligemma, 'get_image_features'):
+        if hasattr(self.paligemma, "get_image_features"):
             return self.paligemma.get_image_features(image)
         else:
             return self.paligemma.model.get_image_features(image)

--- a/lerobot/common/policies/pi0fast/modeling_pi0fast.py
+++ b/lerobot/common/policies/pi0fast/modeling_pi0fast.py
@@ -878,7 +878,11 @@ class PI0FAST(nn.Module):
         return actions
 
     def embed_image(self, image: torch.Tensor):
-        return self.pi0_paligemma.get_image_features(image)
+        # Handle different transformers versions
+        if hasattr(self.pi0_paligemma, 'get_image_features'):
+            return self.pi0_paligemma.get_image_features(image)
+        else:
+            return self.pi0_paligemma.model.get_image_features(image)
 
     def embed_inputs(
         self,

--- a/lerobot/common/policies/pi0fast/modeling_pi0fast.py
+++ b/lerobot/common/policies/pi0fast/modeling_pi0fast.py
@@ -879,7 +879,7 @@ class PI0FAST(nn.Module):
 
     def embed_image(self, image: torch.Tensor):
         # Handle different transformers versions
-        if hasattr(self.pi0_paligemma, 'get_image_features'):
+        if hasattr(self.pi0_paligemma, "get_image_features"):
             return self.pi0_paligemma.get_image_features(image)
         else:
             return self.pi0_paligemma.model.get_image_features(image)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ intelrealsense = [
     "pyrealsense2>=2.55.1.6486 ; sys_platform != 'darwin'",
     "pyrealsense2-macosx>=2.54 ; sys_platform == 'darwin'",
 ]
-pi0 = ["transformers>=4.48.0"]
+pi0 = ["transformers>=4.48.0, <4.52.1"]
 smolvla = ["transformers>=4.50.3", "num2words>=0.5.14", "accelerate>=1.7.0"]
 pusht = ["gym-pusht>=0.1.5 ; python_version < '4.0'"]
 stretch = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ intelrealsense = [
     "pyrealsense2>=2.55.1.6486 ; sys_platform != 'darwin'",
     "pyrealsense2-macosx>=2.54 ; sys_platform == 'darwin'",
 ]
-pi0 = ["transformers>=4.48.0, <4.52.1"]
+pi0 = ["transformers>=4.48.0"]
 smolvla = ["transformers>=4.50.3", "num2words>=0.5.14", "accelerate>=1.7.0"]
 pusht = ["gym-pusht>=0.1.5 ; python_version < '4.0'"]
 stretch = [


### PR DESCRIPTION
This pull request includes changes to ensure compatibility with different versions of the `transformers` library and updates the dependency constraints for `pi0`. The most important changes include adding conditional logic to handle varying `transformers` versions in image embedding methods and restricting the `transformers` version range in the `pyproject.toml`.

### Compatibility with different `transformers` versions:
* [`lerobot/common/policies/pi0/paligemma_with_expert.py`](diffhunk://#diff-84a97b430342f7245243c2a9b28bdd365a8b4e9debfb55a32af5a6601a282d0cR219-R223): Updated the `embed_image` method to check if `paligemma` has a `get_image_features` method and fallback to `paligemma.model.get_image_features` if not. This ensures compatibility with different versions of the `transformers` library.
* [`lerobot/common/policies/pi0fast/modeling_pi0fast.py`](diffhunk://#diff-1137b099f32838d1c396fdccebb9131805b76eb65a57499ee4034951bd028fe4R881-R885): Added similar conditional logic to the `embed_image` method, checking for `pi0_paligemma.get_image_features` and falling back to `pi0_paligemma.model.get_image_features`.

In the [v4.52.1 release](https://github.com/huggingface/transformers/releases/tag/v4.52.1) of the transformers library, [PR 37033](https://github.com/huggingface/transformers/pull/37033) introduced a bug by renaming the class `PaliGemmaForConditionalGeneration(PaliGemmaPreTrainedModel, GenerationMixin)` to class `PaliGemmaModel(PaliGemmaPreTrainedModel)`, which causes the original `get_image_features` function in line 218, [`lerobot/common/policies/pi0/paligemma_with_expert.py`](https://github.com/huggingface/lerobot/blob/main/lerobot/common/policies/pi0/paligemma_with_expert.py) to be unusable.



```python
class PaliGemmaWithExpertModel(PreTrainedModel):
    config_class = PaliGemmaWithExpertConfig

    def __init__(self, config: PaliGemmaWithExpertConfig):
        super().__init__(config=config)
        self.config = config
        self.paligemma = PaliGemmaForConditionalGeneration(config=config.paligemma_config)
        self.gemma_expert = GemmaForCausalLM(config=config.gemma_expert_config)
        # Remove unused embed_tokens
        self.gemma_expert.model.embed_tokens = None

        self.to_bfloat16_like_physical_intelligence()
        self.set_requires_grad()

    # existing code...

    def embed_image(self, image: torch.Tensor):
        return self.paligemma.get_image_features(image)
 ```       
 
@molbap, @aliberts, @Cadene   