### PR TITLE
fix issues: checkpoints keys mismatch and 'task' tokenisation in smolvla

### DIFF
--- a/lerobot/common/policies/pretrained.py
+++ b/lerobot/common/policies/pretrained.py
@@ -87,7 +87,7 @@ def standardise_state_dict(
     return out, unmatched
 
 
-def rename_checkpoint_keys(ckpt, rename_str):
+def rename_checkpoint_keys(checkpoint: dict, rename_str: str):
     """
     Renames keys in a checkpoint dictionary based on the given rename string.
 

--- a/lerobot/common/policies/pretrained.py
+++ b/lerobot/common/policies/pretrained.py
@@ -16,7 +16,7 @@ import logging
 import os
 import re
 from pathlib import Path
-from typing import Dict, Tuple, Type, TypeVar
+from typing import Type, TypeVar
 
 import packaging
 import safetensors
@@ -57,8 +57,8 @@ def canonicalise(k: str) -> str:
 
 
 def standardise_state_dict(
-    checkpoint: Dict[str, torch.Tensor], ref_keys: set[str], *, verbose: bool = True
-) -> Tuple[Dict[str, torch.Tensor], list[str]]:
+    checkpoint: dict[str, torch.Tensor], ref_keys: set[str], *, verbose: bool = True
+) -> tuple[dict[str, torch.Tensor], list[str]]:
     """
     • Re-keys `checkpoint ` so that every entry matches the *reference* key set.
     • If several variant keys collapse to the same canonical name we keep the
@@ -115,7 +115,7 @@ def load_model(
     filename: str | os.PathLike,
     *,
     strict: bool = True,
-    device: str | int = "cpu",
+    device: str = "cpu",
     checkpoint_keys_mapping: str = "",
 ) -> tuple[list[str], list[str]]:
     state_dict = safetensors.torch.load_file(filename, device=device)

--- a/lerobot/common/policies/pretrained.py
+++ b/lerobot/common/policies/pretrained.py
@@ -92,7 +92,7 @@ def rename_checkpoint_keys(checkpoint: dict, rename_str: str):
     Renames keys in a checkpoint dictionary based on the given rename string.
 
     Args:
-        ckpt (dict): The checkpoint dictionary.
+        checkpoint (dict): The checkpoint dictionary.
         rename_str (str): A string specifying key mappings in the format "old1//new1,old2//new2".
 
     Returns:

--- a/lerobot/common/policies/pretrained.py
+++ b/lerobot/common/policies/pretrained.py
@@ -148,7 +148,6 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
                 model.to(map_location)
         else:
             safetensors.torch.load_model(model, model_file, strict=strict, device=map_location)
-
         return model
 
     # def generate_model_card(self, *args, **kwargs) -> ModelCard:

--- a/lerobot/common/policies/pretrained.py
+++ b/lerobot/common/policies/pretrained.py
@@ -57,7 +57,7 @@ def canonicalise(k: str) -> str:
 
 
 def standardise_state_dict(
-    ckpt: Dict[str, torch.Tensor], ref_keys: set[str], *, verbose: bool = True
+    checkpoint: Dict[str, torch.Tensor], ref_keys: set[str], *, verbose: bool = True
 ) -> Tuple[Dict[str, torch.Tensor], list[str]]:
     """
     • Re-keys `ckpt` so that every entry matches the *reference* key set.

--- a/lerobot/common/policies/pretrained.py
+++ b/lerobot/common/policies/pretrained.py
@@ -83,7 +83,7 @@ def standardise_state_dict(
         if unmatched:
             print(f"[standardise_state_dict] kept {len(unmatched)} unmatched keys")
 
-    out.update({k: ckpt[k] for k in unmatched})
+    out.update({k: checkpoint[k] for k in unmatched})
     return out, unmatched
 
 

--- a/lerobot/common/policies/pretrained.py
+++ b/lerobot/common/policies/pretrained.py
@@ -101,13 +101,13 @@ def rename_checkpoint_keys(checkpoint: dict, rename_str: str):
 
     rename_dict = dict(pair.split("//") for pair in rename_str.split(","))
 
-    new_ckpt = {}
-    for k, v in ckpt.items():
+    new_checkpoint = {}
+    for k, v in checkpoint.items():
         for old_key, new_key in rename_dict.items():
             if old_key in k:
                 k = k.replace(old_key, new_key)
-        new_ckpt[k] = v
-    return new_ckpt
+        new_checkpoint[k] = v
+    return new_checkpoint
 
 
 def load_model(

--- a/lerobot/common/policies/pretrained.py
+++ b/lerobot/common/policies/pretrained.py
@@ -67,7 +67,7 @@ def standardise_state_dict(
     """
     out, collisions, unmatched = {}, {}, []
 
-    for k, v in ckpt.items():
+    for k, v in checkpoint.items():
         canon = canonicalise(k)
         if canon in ref_keys:
             if canon in out:  # duplicate after collapsing

--- a/lerobot/common/policies/pretrained.py
+++ b/lerobot/common/policies/pretrained.py
@@ -60,7 +60,7 @@ def standardise_state_dict(
     checkpoint: Dict[str, torch.Tensor], ref_keys: set[str], *, verbose: bool = True
 ) -> Tuple[Dict[str, torch.Tensor], list[str]]:
     """
-    • Re-keys `ckpt` so that every entry matches the *reference* key set.
+    • Re-keys `checkpoint ` so that every entry matches the *reference* key set.
     • If several variant keys collapse to the same canonical name we keep the
       first one and log the collision.
     • Returns the new dict + a list of entries that could not be matched.

--- a/lerobot/common/policies/smolvla/modeling_smolvla.py
+++ b/lerobot/common/policies/smolvla/modeling_smolvla.py
@@ -392,7 +392,7 @@ class SmolVLAPolicy(PreTrainedPolicy):
 
         if len(tasks) == 1:
             tasks = [tasks[0] for _ in range(batch[OBS_STATE].shape[0])]
-        
+
         tasks = [task if task.endswith("\n") else f"{task}\n" for task in tasks]
 
         tokenized_prompt = self.language_tokenizer.__call__(
@@ -803,4 +803,3 @@ class VLAFlowMatching(nn.Module):
         suffix_out = suffix_out.to(dtype=torch.float32)
         v_t = self.action_out_proj(suffix_out)
         return v_t
-

--- a/lerobot/common/policies/smolvla/modeling_smolvla.py
+++ b/lerobot/common/policies/smolvla/modeling_smolvla.py
@@ -157,7 +157,7 @@ def load_smolvla(
 
     state_dict, _ = standardise_state_dict(state_dict, set(model.state_dict().keys()))
 
-    missing, unexpected = model.load_state_dict(state_dict, strict=False)
+    missing, unexpected = model.load_state_dict(state_dict)
 
     if missing or unexpected:
         raise RuntimeError(
@@ -372,7 +372,6 @@ class SmolVLAPolicy(PreTrainedPolicy):
         return load_smolvla(
             model,
             model_file,
-            strict=strict,
             device=map_location,
             checkpoint_keys_mapping="model._orig_mod.//model.",
         )

--- a/lerobot/common/policies/smolvla/modeling_smolvla.py
+++ b/lerobot/common/policies/smolvla/modeling_smolvla.py
@@ -387,10 +387,14 @@ class SmolVLAPolicy(PreTrainedPolicy):
         """Tokenize the text input"""
         device = batch[OBS_STATE].device
         tasks = batch["task"]
+        if isinstance(tasks, str):
+            tasks = [tasks]
+
         if len(tasks) == 1:
             tasks = [tasks[0] for _ in range(batch[OBS_STATE].shape[0])]
-
+        
         tasks = [task if task.endswith("\n") else f"{task}\n" for task in tasks]
+
         tokenized_prompt = self.language_tokenizer.__call__(
             tasks,
             padding=self.config.pad_language_to,
@@ -799,3 +803,4 @@ class VLAFlowMatching(nn.Module):
         suffix_out = suffix_out.to(dtype=torch.float32)
         v_t = self.action_out_proj(suffix_out)
         return v_t
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ intelrealsense = [
     "pyrealsense2-macosx>=2.54 ; sys_platform == 'darwin'",
 ]
 pi0 = ["transformers>=4.48.0"]
-smolvla = ["transformers>=4.50.3", "num2words>=0.5.14", "accelerate>=1.7.0"]
+smolvla = ["transformers>=4.50.3", "num2words>=0.5.14", "accelerate>=1.7.0", "safetensors>=0.4.3"]
 pusht = ["gym-pusht>=0.1.5 ; python_version < '4.0'"]
 stretch = [
     "hello-robot-stretch-body>=0.7.27 ; python_version < '4.0' and sys_platform == 'linux'",


### PR DESCRIPTION
This PR proposes a fix 
1. to tokenisation of 'task' in `modeling_smolvla.py` after refactoring. 
2. checkpoint keys mapping/mismatch associated with using smolvla on other robots (e.g. SO101) zero-shot without fine-tuning. 
