### PR TITLE
Match motor names with ids lekiwi

### DIFF
--- a/examples/lekiwi/record.py
+++ b/examples/lekiwi/record.py
@@ -23,7 +23,7 @@ obs_features = hw_to_dataset_features(robot.observation_features, "observation")
 dataset_features = {**action_features, **obs_features}
 
 dataset = LeRobotDataset.create(
-    repo_id="user/lekiwi" + str(int(time.time())),
+    repo_id="pepijn223/lekiwi" + str(int(time.time())),
     fps=10,
     features=dataset_features,
     robot_type=robot.name,
@@ -36,7 +36,7 @@ robot.connect()
 if not robot.is_connected or not leader_arm.is_connected or not keyboard.is_connected:
     exit()
 
-print("Starting LeKiwi teleoperation")
+print("Starting LeKiwi recording")
 i = 0
 while i < NB_CYCLES_CLIENT_CONNECTION:
     arm_action = leader_arm.get_action()

--- a/lerobot/common/robots/lekiwi/config_lekiwi.py
+++ b/lerobot/common/robots/lekiwi/config_lekiwi.py
@@ -20,6 +20,20 @@ from lerobot.common.cameras.opencv.configuration_opencv import OpenCVCameraConfi
 from ..config import RobotConfig
 
 
+@dataclass
+class LeKiwiCameraConfig:
+    cameras: dict[str, CameraConfig] = field(
+        default_factory=lambda: {
+            "front": OpenCVCameraConfig(
+                index_or_path="/dev/video0", fps=30, width=640, height=480, rotation=Cv2Rotation.ROTATE_180
+            ),
+            "wrist": OpenCVCameraConfig(
+                index_or_path="/dev/video2", fps=30, width=480, height=640, rotation=Cv2Rotation.ROTATE_90
+            ),
+        }
+    )
+
+
 @RobotConfig.register_subclass("lekiwi")
 @dataclass
 class LeKiwiConfig(RobotConfig):
@@ -32,16 +46,7 @@ class LeKiwiConfig(RobotConfig):
     # the number of motors in your follower arms.
     max_relative_target: int | None = None
 
-    cameras: dict[str, CameraConfig] = field(
-        default_factory=lambda: {
-            "front": OpenCVCameraConfig(
-                index_or_path="/dev/video0", fps=30, width=640, height=480, rotation=Cv2Rotation.ROTATE_180
-            ),
-            "wrist": OpenCVCameraConfig(
-                index_or_path="/dev/video2", fps=30, width=480, height=640, rotation=Cv2Rotation.ROTATE_90
-            ),
-        }
-    )
+    cameras: LeKiwiCameraConfig = field(default_factory=LeKiwiCameraConfig)
 
     # Set to `True` for backward compatibility with previous policies/dataset
     use_degrees: bool = False
@@ -87,6 +92,8 @@ class LeKiwiClientConfig(RobotConfig):
             "quit": "q",
         }
     )
+
+    camera_config: LeKiwiCameraConfig = field(default_factory=LeKiwiCameraConfig)
 
     polling_timeout_ms: int = 15
     connect_timeout_s: int = 5

--- a/lerobot/common/robots/lekiwi/config_lekiwi.py
+++ b/lerobot/common/robots/lekiwi/config_lekiwi.py
@@ -20,18 +20,15 @@ from lerobot.common.cameras.opencv.configuration_opencv import OpenCVCameraConfi
 from ..config import RobotConfig
 
 
-@dataclass
-class LeKiwiCameraConfig:
-    cameras: dict[str, CameraConfig] = field(
-        default_factory=lambda: {
-            "front": OpenCVCameraConfig(
-                index_or_path="/dev/video0", fps=30, width=640, height=480, rotation=Cv2Rotation.ROTATE_180
-            ),
-            "wrist": OpenCVCameraConfig(
-                index_or_path="/dev/video2", fps=30, width=480, height=640, rotation=Cv2Rotation.ROTATE_90
-            ),
-        }
-    )
+def lekiwi_cameras_config() -> dict[str, CameraConfig]:
+    return {
+        "front": OpenCVCameraConfig(
+            index_or_path="/dev/video0", fps=30, width=640, height=480, rotation=Cv2Rotation.ROTATE_180
+        ),
+        "wrist": OpenCVCameraConfig(
+            index_or_path="/dev/video2", fps=30, width=480, height=640, rotation=Cv2Rotation.ROTATE_90
+        ),
+    }
 
 
 @RobotConfig.register_subclass("lekiwi")
@@ -46,7 +43,7 @@ class LeKiwiConfig(RobotConfig):
     # the number of motors in your follower arms.
     max_relative_target: int | None = None
 
-    cameras: LeKiwiCameraConfig = field(default_factory=LeKiwiCameraConfig)
+    cameras: dict[str, CameraConfig] = field(default_factory=lekiwi_cameras_config)
 
     # Set to `True` for backward compatibility with previous policies/dataset
     use_degrees: bool = False
@@ -93,7 +90,7 @@ class LeKiwiClientConfig(RobotConfig):
         }
     )
 
-    camera_config: LeKiwiCameraConfig = field(default_factory=LeKiwiCameraConfig)
+    cameras: dict[str, CameraConfig] = field(default_factory=lekiwi_cameras_config)
 
     polling_timeout_ms: int = 15
     connect_timeout_s: int = 5

--- a/lerobot/common/robots/lekiwi/config_lekiwi.py
+++ b/lerobot/common/robots/lekiwi/config_lekiwi.py
@@ -34,9 +34,11 @@ class LeKiwiConfig(RobotConfig):
 
     cameras: dict[str, CameraConfig] = field(
         default_factory=lambda: {
-            "front": OpenCVCameraConfig(index_or_path="/dev/video0", fps=30, width=640, height=480),
+            "front": OpenCVCameraConfig(
+                index_or_path="/dev/video0", fps=30, width=640, height=480, rotation=Cv2Rotation.ROTATE_180
+            ),
             "wrist": OpenCVCameraConfig(
-                index_or_path="/dev/video2", fps=30, width=640, height=480, rotation=Cv2Rotation.ROTATE_180
+                index_or_path="/dev/video2", fps=30, width=480, height=640, rotation=Cv2Rotation.ROTATE_90
             ),
         }
     )

--- a/lerobot/common/robots/lekiwi/lekiwi.py
+++ b/lerobot/common/robots/lekiwi/lekiwi.py
@@ -65,8 +65,8 @@ class LeKiwi(Robot):
                 "arm_gripper": Motor(6, "sts3215", MotorNormMode.RANGE_0_100),
                 # base
                 "base_left_wheel": Motor(7, "sts3215", MotorNormMode.RANGE_M100_100),
-                "base_right_wheel": Motor(8, "sts3215", MotorNormMode.RANGE_M100_100),
-                "base_back_wheel": Motor(9, "sts3215", MotorNormMode.RANGE_M100_100),
+                "base_back_wheel": Motor(8, "sts3215", MotorNormMode.RANGE_M100_100),
+                "base_right_wheel": Motor(9, "sts3215", MotorNormMode.RANGE_M100_100),
             },
             calibration=self.calibration,
         )
@@ -249,7 +249,7 @@ class LeKiwi(Robot):
         velocity_vector = np.array([x, y, theta_rad])
 
         # Define the wheel mounting angles with a -90° offset.
-        angles = np.radians(np.array([240, 120, 0]) - 90)
+        angles = np.radians(np.array([240, 0, 120]) - 90)
         # Build the kinematic matrix: each row maps body velocities to a wheel’s linear speed.
         # The third column (base_radius) accounts for the effect of rotation.
         m = np.array([[np.cos(a), np.sin(a), base_radius] for a in angles])
@@ -316,7 +316,7 @@ class LeKiwi(Robot):
         wheel_linear_speeds = wheel_radps * wheel_radius
 
         # Define the wheel mounting angles with a -90° offset.
-        angles = np.radians(np.array([240, 120, 0]) - 90)
+        angles = np.radians(np.array([240, 0, 120]) - 90)
         m = np.array([[np.cos(a), np.sin(a), base_radius] for a in angles])
 
         # Solve the inverse kinematics: body_velocity = M⁻¹ · wheel_linear_speeds.

--- a/lerobot/common/robots/lekiwi/lekiwi.py
+++ b/lerobot/common/robots/lekiwi/lekiwi.py
@@ -23,7 +23,6 @@ from typing import Any
 import numpy as np
 
 from lerobot.common.cameras.utils import make_cameras_from_configs
-from lerobot.common.constants import OBS_IMAGES, OBS_STATE
 from lerobot.common.errors import DeviceAlreadyConnectedError, DeviceNotConnectedError
 from lerobot.common.motors import Motor, MotorCalibration, MotorNormMode
 from lerobot.common.motors.feetech import (
@@ -295,10 +294,7 @@ class LeKiwi(Robot):
           base_radius : Distance from the robot center to each wheel (meters).
 
         Returns:
-          A dict (x_cmd, y_cmd, theta_cmd) where:
-             OBS_STATE.x_cmd      : Linear velocity in x (m/s).
-             OBS_STATE.y_cmd      : Linear velocity in y (m/s).
-             OBS_STATE.theta_cmd  : Rotational velocity in deg/s.
+          A dict (x.vel, y.vel, theta.vel) all in m/s
         """
 
         # Convert each raw command back to an angular speed in deg/s.
@@ -347,16 +343,15 @@ class LeKiwi(Robot):
 
         arm_state = {f"{k}.pos": v for k, v in arm_pos.items()}
 
-        flat_states = {**arm_state, **base_vel}
+        obs_dict = {**arm_state, **base_vel}
 
-        obs_dict = {f"{OBS_STATE}": flat_states}
         dt_ms = (time.perf_counter() - start) * 1e3
         logger.debug(f"{self} read state: {dt_ms:.1f}ms")
 
         # Capture images from cameras
         for cam_key, cam in self.cameras.items():
             start = time.perf_counter()
-            obs_dict[f"{OBS_IMAGES}.{cam_key}"] = cam.async_read()
+            obs_dict[cam_key] = cam.async_read()
             dt_ms = (time.perf_counter() - start) * 1e3
             logger.debug(f"{self} read {cam_key}: {dt_ms:.1f}ms")
 

--- a/lerobot/common/robots/lekiwi/lekiwi_client.py
+++ b/lerobot/common/robots/lekiwi/lekiwi_client.py
@@ -92,7 +92,7 @@ class LeKiwiClient(Robot):
 
     @cached_property
     def _cameras_ft(self) -> dict[str, tuple[int, int, int]]:
-        return {f"{name}": (cfg.height, cfg.width, 3) for name, cfg in self.config.cameras.items()}
+        return {name: (cfg.height, cfg.width, 3) for name, cfg in self.config.cameras.items()}
 
     @cached_property
     def observation_features(self) -> dict[str, type | tuple]:

--- a/lerobot/common/robots/lekiwi/lekiwi_client.py
+++ b/lerobot/common/robots/lekiwi/lekiwi_client.py
@@ -25,7 +25,6 @@ import numpy as np
 import torch
 import zmq
 
-from lerobot.common.constants import OBS_IMAGES, OBS_STATE
 from lerobot.common.errors import DeviceAlreadyConnectedError, DeviceNotConnectedError
 
 from ..robot import Robot
@@ -199,7 +198,7 @@ class LeKiwiClient(Robot):
         self, observation: Dict[str, Any]
     ) -> Tuple[Dict[str, np.ndarray], Dict[str, Any]]:
         """Extracts frames, and state from the parsed observation."""
-        flat_state = observation[OBS_STATE]
+        flat_state = {key: value for key, value in observation.items() if key in self._state_ft}
 
         state_vec = np.array(
             [flat_state.get(k, 0.0) for k in self._state_order],
@@ -207,7 +206,7 @@ class LeKiwiClient(Robot):
         )
 
         # Decode images
-        image_observation = {k: v for k, v in observation.items() if k.startswith(OBS_IMAGES)}
+        image_observation = {key: value for key, value in observation.items() if key in self._cameras_ft}
         current_frames: Dict[str, np.ndarray] = {}
         for cam_name, image_b64 in image_observation.items():
             frame = self._decode_image_from_b64(image_b64)

--- a/lerobot/common/robots/lekiwi/lekiwi_client.py
+++ b/lerobot/common/robots/lekiwi/lekiwi_client.py
@@ -91,10 +91,10 @@ class LeKiwiClient(Robot):
         return tuple(self._state_ft.keys())
 
     @cached_property
-    def _cameras_ft(self) -> dict[str, tuple]:
+    def _cameras_ft(self) -> dict[str, tuple[int, int, int]]:
         return {
-            "front": (480, 640, 3),
-            "wrist": (640, 480, 3),
+            f"observation.images.{name}": (cfg.height, cfg.width, 3)
+            for name, cfg in self.config.cameras.items()
         }
 
     @cached_property

--- a/lerobot/common/robots/lekiwi/lekiwi_client.py
+++ b/lerobot/common/robots/lekiwi/lekiwi_client.py
@@ -28,16 +28,18 @@ import zmq
 from lerobot.common.errors import DeviceAlreadyConnectedError, DeviceNotConnectedError
 
 from ..robot import Robot
-from .config_lekiwi import LeKiwiClientConfig
+from .config_lekiwi import LeKiwiClientConfig, LeKiwiConfig
 
 
 class LeKiwiClient(Robot):
     config_class = LeKiwiClientConfig
+    lekiwi_config_class = LeKiwiConfig
     name = "lekiwi_client"
 
-    def __init__(self, config: LeKiwiClientConfig):
+    def __init__(self, config: LeKiwiClientConfig, lekiwi_config):
         super().__init__(config)
         self.config = config
+        self.lekiwi_config = lekiwi_config
         self.id = config.id
         self.robot_type = config.type
 
@@ -94,7 +96,7 @@ class LeKiwiClient(Robot):
     def _cameras_ft(self) -> dict[str, tuple[int, int, int]]:
         return {
             f"observation.images.{name}": (cfg.height, cfg.width, 3)
-            for name, cfg in self.config.cameras.items()
+            for name, cfg in self.lekiwi_config_class.items()
         }
 
     @cached_property

--- a/lerobot/common/robots/lekiwi/lekiwi_client.py
+++ b/lerobot/common/robots/lekiwi/lekiwi_client.py
@@ -28,18 +28,16 @@ import zmq
 from lerobot.common.errors import DeviceAlreadyConnectedError, DeviceNotConnectedError
 
 from ..robot import Robot
-from .config_lekiwi import LeKiwiClientConfig, LeKiwiConfig
+from .config_lekiwi import LeKiwiClientConfig
 
 
 class LeKiwiClient(Robot):
     config_class = LeKiwiClientConfig
-    lekiwi_config_class = LeKiwiConfig
     name = "lekiwi_client"
 
-    def __init__(self, config: LeKiwiClientConfig, lekiwi_config):
+    def __init__(self, config: LeKiwiClientConfig):
         super().__init__(config)
         self.config = config
-        self.lekiwi_config = lekiwi_config
         self.id = config.id
         self.robot_type = config.type
 
@@ -96,7 +94,7 @@ class LeKiwiClient(Robot):
     def _cameras_ft(self) -> dict[str, tuple[int, int, int]]:
         return {
             f"observation.images.{name}": (cfg.height, cfg.width, 3)
-            for name, cfg in self.lekiwi_config_class.items()
+            for name, cfg in self.config.camera_config.cameras.items()
         }
 
     @cached_property

--- a/lerobot/common/robots/lekiwi/lekiwi_client.py
+++ b/lerobot/common/robots/lekiwi/lekiwi_client.py
@@ -94,7 +94,7 @@ class LeKiwiClient(Robot):
     def _cameras_ft(self) -> dict[str, tuple[int, int, int]]:
         return {
             f"observation.images.{name}": (cfg.height, cfg.width, 3)
-            for name, cfg in self.config.camera_config.cameras.items()
+            for name, cfg in self.config.cameras.items()
         }
 
     @cached_property

--- a/lerobot/common/robots/lekiwi/lekiwi_client.py
+++ b/lerobot/common/robots/lekiwi/lekiwi_client.py
@@ -92,10 +92,7 @@ class LeKiwiClient(Robot):
 
     @cached_property
     def _cameras_ft(self) -> dict[str, tuple[int, int, int]]:
-        return {
-            f"observation.images.{name}": (cfg.height, cfg.width, 3)
-            for name, cfg in self.config.cameras.items()
-        }
+        return {f"{name}": (cfg.height, cfg.width, 3) for name, cfg in self.config.cameras.items()}
 
     @cached_property
     def observation_features(self) -> dict[str, type | tuple]:
@@ -206,7 +203,11 @@ class LeKiwiClient(Robot):
         )
 
         # Decode images
-        image_observation = {key: value for key, value in observation.items() if key in self._cameras_ft}
+        image_observation = {
+            f"observation.images.{key}": value
+            for key, value in observation.items()
+            if key in self._cameras_ft
+        }
         current_frames: Dict[str, np.ndarray] = {}
         for cam_name, image_b64 in image_observation.items():
             frame = self._decode_image_from_b64(image_b64)

--- a/lerobot/common/robots/lekiwi/lekiwi_host.py
+++ b/lerobot/common/robots/lekiwi/lekiwi_host.py
@@ -93,12 +93,12 @@ def main():
             # Encode ndarrays to base64 strings
             for cam_key, _ in robot.cameras.items():
                 ret, buffer = cv2.imencode(
-                    ".jpg", last_observation[f"{cam_key}"], [int(cv2.IMWRITE_JPEG_QUALITY), 90]
+                    ".jpg", last_observation[cam_key], [int(cv2.IMWRITE_JPEG_QUALITY), 90]
                 )
                 if ret:
-                    last_observation[f"{cam_key}"] = base64.b64encode(buffer).decode("utf-8")
+                    last_observation[cam_key] = base64.b64encode(buffer).decode("utf-8")
                 else:
-                    last_observation[f"{cam_key}"] = ""
+                    last_observation[cam_key] = ""
 
             # Send the observation to the remote agent
             try:

--- a/lerobot/common/robots/lekiwi/lekiwi_host.py
+++ b/lerobot/common/robots/lekiwi/lekiwi_host.py
@@ -22,8 +22,6 @@ import time
 import cv2
 import zmq
 
-from lerobot.common.constants import OBS_IMAGES
-
 from .config_lekiwi import LeKiwiConfig, LeKiwiHostConfig
 from .lekiwi import LeKiwi
 
@@ -95,12 +93,12 @@ def main():
             # Encode ndarrays to base64 strings
             for cam_key, _ in robot.cameras.items():
                 ret, buffer = cv2.imencode(
-                    ".jpg", last_observation[f"{OBS_IMAGES}.{cam_key}"], [int(cv2.IMWRITE_JPEG_QUALITY), 90]
+                    ".jpg", last_observation[f"{cam_key}"], [int(cv2.IMWRITE_JPEG_QUALITY), 90]
                 )
                 if ret:
-                    last_observation[f"{OBS_IMAGES}.{cam_key}"] = base64.b64encode(buffer).decode("utf-8")
+                    last_observation[f"{cam_key}"] = base64.b64encode(buffer).decode("utf-8")
                 else:
-                    last_observation[f"{OBS_IMAGES}.{cam_key}"] = ""
+                    last_observation[f"{cam_key}"] = ""
 
             # Send the observation to the remote agent
             try:


### PR DESCRIPTION
### What?

This PR changes the LeKiwi kinematics and motor naming to match the documentation and the rest of the code (mentioned on [Discord](https://discord.com/channels/1216765309076115607/1318390825528332371/1381835903965728898)). Issue arose from robots refactor. Additionally the camera rotations are fixed for LeKiwi as can be seen in the dataset visualizer, which shows a dataset recorded with the fixes.

Additionally I removed: `OBS_STATE` and `OBS_IMAGES` constants from lekiwi code to make it similar to other robots in the code base.
 
### To test:

Tested 
- Teleoperation
- Dataset recording

Check: [dataset_visualizer](https://huggingface.co/spaces/lerobot/visualize_dataset?path=%2Fpepijn223%2Flekiwi1749634728%2Fepisode_0)

