### PR TITLE
Support Intel XPU

### DIFF
--- a/docker/lerobot-xpu/Dockerfile
+++ b/docker/lerobot-xpu/Dockerfile
@@ -10,15 +10,28 @@ ENV PATH="/opt/venv/bin:$PATH"
 RUN apt-get update && apt-get install -y --no-install-recommends \
     software-properties-common \
     build-essential cmake git \
-    libglib2.0-0 libgl1-mesa-glx libegl1-mesa ffmpeg \
+    libglib2.0-0 libgl1-mesa-glx libegl1-mesa libglu1-mesa ffmpeg \
     speech-dispatcher libgeos-dev \
     python${PYTHON_VERSION}-dev \
     python${PYTHON_VERSION}-venv \
-    && apt-get clean && rm -rf /var/lib/apt/lists/* \
-    && python -m venv /opt/venv --system-site-packages \
-    && echo "source /opt/venv/bin/activate" >> /root/.bashrc
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN useradd -u 1000 -g 100 -m lerobot
+
+USER 1000:100
+
+WORKDIR /home/lerobot
+RUN python -m venv ./venv --system-site-packages
+COPY --chown=1000:100 --chmod=555 <<EOF ./entrypoint.sh
+#!/bin/bash -eu
+source /home/lerobot/venv/bin/activate
+exec "\$@"
+EOF
+
+RUN ./venv/bin/pip install --no-cache-dir PyOpenGL PyOpenGL_accelerate
 
 WORKDIR /lerobot
-COPY . ./
+COPY --chown=1000:100 . ./
+RUN /home/lerobot/venv/bin/pip install --no-cache-dir ".[aloha, pusht, smolvla, hilserl]"
 
-RUN /opt/venv/bin/pip install --no-cache-dir ".[aloha, pusht, smolvla]"
+ENTRYPOINT ["/home/lerobot/entrypoint.sh"]

--- a/docker/lerobot-xpu/Dockerfile
+++ b/docker/lerobot-xpu/Dockerfile
@@ -21,4 +21,4 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /lerobot
 COPY . ./
 
-RUN /opt/venv/bin/pip install --no-cache-dir ".[pusht]"
+RUN /opt/venv/bin/pip install --no-cache-dir ".[aloha, pusht, smolvla]"

--- a/docker/lerobot-xpu/Dockerfile
+++ b/docker/lerobot-xpu/Dockerfile
@@ -1,0 +1,24 @@
+FROM intel/intel-extension-for-pytorch:2.7.10-xpu
+
+# Configure environment variables
+ARG PYTHON_VERSION=3.10
+ENV DEBIAN_FRONTEND=noninteractive
+ENV MUJOCO_GL="egl"
+ENV PATH="/opt/venv/bin:$PATH"
+
+# Install dependencies and set up Python in a single layer
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    software-properties-common \
+    build-essential cmake git \
+    libglib2.0-0 libgl1-mesa-glx libegl1-mesa ffmpeg \
+    speech-dispatcher libgeos-dev \
+    python${PYTHON_VERSION}-dev \
+    python${PYTHON_VERSION}-venv \
+    && apt-get clean && rm -rf /var/lib/apt/lists/* \
+    && python -m venv /opt/venv --system-site-packages \
+    && echo "source /opt/venv/bin/activate" >> /root/.bashrc
+
+WORKDIR /lerobot
+COPY . ./
+
+RUN /opt/venv/bin/pip install --no-cache-dir ".[pusht]"

--- a/src/lerobot/utils/utils.py
+++ b/src/lerobot/utils/utils.py
@@ -83,7 +83,7 @@ def get_safe_dtype(dtype: torch.dtype, device: str | torch.device):
     """
     if isinstance(device, torch.device):
         device = device.type
-    if device == "mps" and dtype == torch.float64:
+    if (device == "mps" or device == "xpu") and dtype == torch.float64:
         return torch.float32
     if device == "xpu" and dtype == torch.float64:
         if hasattr(torch.xpu, "get_device_capability"):


### PR DESCRIPTION
## What this does

While testinging on Intel (XPU) I found that:

- 2_evaluate_pretrained_policy.py failed with an error claiming tensors were on CPU as well as XPU. Moving the policy to the specified device (xpu) fixes the issue and matches the behaviour in the training script.
- train.py failed to run just because some utility functions failed to recognize XPU as a valid device type, so I added it.

Also this adds a Dockerfile file for XPU based on Intel's PyTorch Dockerfile.

## How it was tested

I ran the policy training and evaluation for pusht on an Intel Arc a770 using the provided Dockerfile.

## How to checkout & try? (for the reviewer)

Run the examples/2_evaluate_pretrained_policy.py script or the training script.

To test on Intel the following Docker commands could be used:

```
docker build -t lerobot:xpu -f docker/lerobot-xpu/Dockerfile .
docker run -it --rm \
      --device /dev/dri \
      -v /dev/dri/by-path:/dev/dri/by-path \
      --ipc=host \
      -v ~/.cache/huggingface:/root/.cache/huggingface \
      -v ~/python/lerobot/outputs:/lerobot/outputs \
      lerobot:xpu python lerobot/scripts/train.py \
      --dataset.repo_id=lerobot/pusht \
      --policy.type=diffusion \
      --policy.device=xpu \
      --env.type=pusht \
      --log_freq=100 \
      --save_freq=1000 \
      --steps=10000
```
