### PR TITLE
Dataset query indicies load bug fix

### DIFF
--- a/lerobot/common/datasets/lerobot_dataset.py
+++ b/lerobot/common/datasets/lerobot_dataset.py
@@ -643,7 +643,7 @@ class LeRobotDataset(torch.utils.data.Dataset):
     def _get_query_indices(self, idx: int, ep_idx: int) -> tuple[dict[str, list[int | bool]]]:
         if self.episodes is not None:
             ep_idx = self.episodes.index(ep_idx)
-            
+
         ep_start = self.episode_data_index["from"][ep_idx]
         ep_end = self.episode_data_index["to"][ep_idx]
         query_indices = {

--- a/lerobot/common/datasets/lerobot_dataset.py
+++ b/lerobot/common/datasets/lerobot_dataset.py
@@ -641,6 +641,9 @@ class LeRobotDataset(torch.utils.data.Dataset):
             return get_hf_features_from_features(self.features)
 
     def _get_query_indices(self, idx: int, ep_idx: int) -> tuple[dict[str, list[int | bool]]]:
+        if self.episodes is not None:
+            ep_idx = self.episodes.index(ep_idx)
+            
         ep_start = self.episode_data_index["from"][ep_idx]
         ep_end = self.episode_data_index["to"][ep_idx]
         query_indices = {


### PR DESCRIPTION
## What this does
Fixes bug regarding _get_query_indices method in lerobot_dataset.py 
When we load a LeRobotDataset object with episodes set with a custom integer list and delta_timestamps, the _get_query_indices trys to load from the dataset.episode_data_index['from'][ep_idx] using the ep_idx which is the actual ep_idx in the whole dataset, instead of the idx of the subset we have extracted using self.episodes
This means that the key is mismatched and raises an error when, for example, we loaded a dataset with 10 episode indices starting from 30 but there are only 10 values in dataset.episode_data_index['from']

## How it was tested
I changed the logic such that _get_query_indices takes actual current idx of the episode in the dataset.episode_data_index lists
Tested only on IPEC-COMMUNITY/droid_lerobot dataset.

## How to checkout & try? (for the reviewer)

Example:
Fixes bug when trying to load the LeRobot Version of the DROID dataset
For example
```
episodes_indices = [33, 56, 72]
delta_timestamps = {
    "observation.images.exterior_image_1_left": [-10/15, 0.0],
    "observation.images.exterior_image_2_left": [-10/15, 0.0],
    "observation.images.wrist_image_left": [-10/15, 0.0],
    "observation.state": [-i/15 for i in range(10, -1, -1)],
    "action": [-i/15 for i in range(10, -1, -1)],
}
dataset = LeRobotDataset(
    "IPEC-COMMUNITY/droid_lerobot",
    episodes=episode_indices,
    delta_timestamps=delta_timestamps
)
sample = dataset[0]
```