### PR TITLE
fix(record): no teleop needed when running with policy

### DIFF
--- a/docs/source/getting_started_real_world_robot.mdx
+++ b/docs/source/getting_started_real_world_robot.mdx
@@ -297,9 +297,6 @@ python -m lerobot.record  \
   --robot.port=/dev/ttyACM1 \
   --robot.cameras="{ up: {type: opencv, index_or_path: /dev/video10, width: 640, height: 480, fps: 30}, side: {type: intelrealsense, serial_number_or_name: 233522074606, width: 640, height: 480, fps: 30}}" \
   --robot.id=my_awesome_follower_arm \
-  --teleop.type=so100_leader \
-  --teleop.port=/dev/ttyACM0 \
-  --teleop.id=my_awesome_leader_arm \
   --display_data=false \
   --dataset.repo_id=$HF_USER/eval_so100 \
   --dataset.single_task="Put lego brick into the transparent box" \

--- a/lerobot/record.py
+++ b/lerobot/record.py
@@ -139,7 +139,7 @@ class RecordConfig:
     resume: bool = False
 
     def __post_init__(self):
-        if bool(self.teleop) == bool(self.policy):
+        if self.teleop is not None and self.policy is not None:
             raise ValueError("Choose either a policy or a teleoperator to control the robot")
 
         # HACK: We parse again the cli args here to get the pretrained path if there was one.


### PR DESCRIPTION
This allows to run `record.py` with a policy without the need of passing `teleop` CLI arguments + updates docs