### PR TITLE
chore(teleop): print calibration path saved

### DIFF
--- a/lerobot/common/teleoperators/so100_leader/so100_leader.py
+++ b/lerobot/common/teleoperators/so100_leader/so100_leader.py
@@ -112,7 +112,7 @@ class SO100Leader(Teleoperator):
 
         self.bus.write_calibration(self.calibration)
         self._save_calibration()
-        logger.info(f"Calibration saved to {self.calibration_fpath}")
+        print(f"Calibration saved to {self.calibration_fpath}")
 
     def configure(self) -> None:
         self.bus.disable_torque()

--- a/lerobot/common/teleoperators/so101_leader/so101_leader.py
+++ b/lerobot/common/teleoperators/so101_leader/so101_leader.py
@@ -109,7 +109,7 @@ class SO101Leader(Teleoperator):
 
         self.bus.write_calibration(self.calibration)
         self._save_calibration()
-        logger.info(f"Calibration saved to {self.calibration_fpath}")
+        print(f"Calibration saved to {self.calibration_fpath}")
 
     def configure(self) -> None:
         self.bus.disable_torque()


### PR DESCRIPTION
We print the path where the calibration was saved for the SO10* `robots`, we should do it also for the SO10* `teleop`