### PR TITLE
Improve type hints

### DIFF
--- a/lerobot/common/robots/robot.py
+++ b/lerobot/common/robots/robot.py
@@ -14,7 +14,7 @@
 
 import abc
 from pathlib import Path
-from typing import Any
+from typing import Any, Type
 
 import draccus
 
@@ -39,7 +39,7 @@ class Robot(abc.ABC):
     """
 
     # Set these in ALL subclasses
-    config_class: RobotConfig
+    config_class: Type[RobotConfig]
     name: str
 
     def __init__(self, config: RobotConfig):

--- a/lerobot/common/teleoperators/teleoperator.py
+++ b/lerobot/common/teleoperators/teleoperator.py
@@ -14,7 +14,7 @@
 
 import abc
 from pathlib import Path
-from typing import Any
+from typing import Any, Type
 
 import draccus
 
@@ -37,7 +37,7 @@ class Teleoperator(abc.ABC):
     """
 
     # Set these in ALL subclasses
-    config_class: TeleoperatorConfig
+    config_class: Type[TeleoperatorConfig]
     name: str
 
     def __init__(self, config: TeleoperatorConfig):


### PR DESCRIPTION
The `Robot` base class currently type hints `config_class` as having the exact type `RobotConfig`. The issue with this is that super classes that inherit from `RobotConfig` aren't compatible with the type hint. However we want to accept classes that inherit from `RobotConfig`. With this PR we allow all classes which inherit from `RobotConfig`.

TLDR: Make `config_class` compatible with classes that inherit from `RobotConfig` to satisfy type checkers
