### PR TITLE
fix(record): no teleop arg in reset environment

### DIFF
--- a/docs/source/il_robots.mdx
+++ b/docs/source/il_robots.mdx
@@ -303,7 +303,11 @@ python -m lerobot.record  \
   --display_data=false \
   --dataset.repo_id=$HF_USER/eval_so100 \
   --dataset.single_task="Put lego brick into the transparent box" \
-  --policy.path=${HF_USER}/my_policy
+  --policy.path=${HF_USER}/my_policy \
+  # <- Teleop optional if you want to teleoperate in between episodes \
+  # --teleop.type=so100_leader \
+  # --teleop.port=/dev/ttyACM0 \
+  # --teleop.id=my_awesome_leader_arm \
 ```
 
 As you can see, it's almost the same command as previously used to record your training dataset. Two things changed:

--- a/docs/source/smolvla.mdx
+++ b/docs/source/smolvla.mdx
@@ -87,7 +87,11 @@ python -m lerobot.record \
   --dataset.repo_id=${HF_USER}/eval_DATASET_NAME_test \  # <- This will be the dataset name on HF Hub
   --dataset.episode_time_s=50 \
   --dataset.num_episodes=10 \
-  --policy.path=HF_USER/FINETUNE_MODEL_NAME # <- Use your fine-tuned model
+  --policy.path=HF_USER/FINETUNE_MODEL_NAME # <- Use your fine-tuned model \
+  # <- Teleop optional if you want to teleoperate in between episodes \
+  # --teleop.type=so100_leader \
+  # --teleop.port=/dev/ttyACM0 \
+  # --teleop.id=my_red_leader_arm \
 ```
 
 Depending on your evaluation setup, you can configure the duration and the number of episodes to record for your evaluation suite.


### PR DESCRIPTION
Issue Discovery:
I just realized why we initially designed the `record.py` script to require a teleop device even when running with a policy: it's for resetting the environment between episodes.

Key Observations:
1. This [call](https://github.com/huggingface/lerobot/blob/6007a221f0d5e425e3c212e079688fa80f96a268/lerobot/record.py#L297) is meant to trigger [this reset logic](https://github.com/huggingface/lerobot/blob/6007a221f0d5e425e3c212e079688fa80f96a268/lerobot/record.py#L198).
2. This means [PR #1284](https://github.com/huggingface/lerobot/pull/1284) introduced a bug: if you run `record.py` with a policy but without passing a teleop device, the script crashes during the environment reset step.

Possible Solutions:
1. Don’t move the robot between episodes (torques remain enabled):
   - Drawback: The arm won’t return to its rest position at the start of the next episode.
   - Advantage: No teleop device is needed.

2. Revert to the old behavior (require a teleop device, even for inference):
   - Drawback: Forces users to provide a teleop device.
   - Advantage: Allows moving the arm (e.g., to reset position) between episodes.

3. Alternative approach:
   - Save the initial rest position and replay it between episodes.

For now this implements 1 and make the drawback explicit while preventing the crash.