### PR TITLE
`learner.py` import so101_leader instead of so100

### DIFF
--- a/lerobot/scripts/rl/learner.py
+++ b/lerobot/scripts/rl/learner.py
@@ -71,7 +71,7 @@ from lerobot.common.datasets.lerobot_dataset import LeRobotDataset
 from lerobot.common.policies.factory import make_policy
 from lerobot.common.policies.sac.modeling_sac import SACPolicy
 from lerobot.common.robots import so100_follower  # noqa: F401
-from lerobot.common.teleoperators import gamepad, so100_leader  # noqa: F401
+from lerobot.common.teleoperators import gamepad, so101_leader  # noqa: F401
 from lerobot.common.transport import services_pb2_grpc
 from lerobot.common.transport.utils import (
     bytes_to_python_object,


### PR DESCRIPTION
Single line fix in `learner.py` to use `so101_leader` instead of `so100_leader`