### PR TITLE
Fixing `PI0` Policy

### DIFF
--- a/lerobot/common/policies/pi0/paligemma_with_expert.py
+++ b/lerobot/common/policies/pi0/paligemma_with_expert.py
@@ -223,7 +223,7 @@ class PaliGemmaWithExpertModel(PreTrainedModel):
             return self.paligemma.model.get_image_features(image)
 
     def embed_language_tokens(self, tokens: torch.Tensor):
-        return self.paligemma.language_model.model.embed_tokens(tokens)
+        return self.paligemma.language_model.embed_tokens(tokens)
 
     # TODO: break down this huge forward into modules or functions
     def forward(
@@ -235,7 +235,7 @@ class PaliGemmaWithExpertModel(PreTrainedModel):
         use_cache: Optional[bool] = None,
         fill_kv_cache: Optional[bool] = None,
     ):
-        models = [self.paligemma.language_model.model, self.gemma_expert.model]
+        models = [self.paligemma.language_model, self.gemma_expert.model]
 
         for hidden_states in inputs_embeds:
             # TODO this is very inefficient


### PR DESCRIPTION
## What this does
This PR fixes bugs raising errors at forward using PI0.

This has been tested running inference. To reproduce this test (without needing to fine-tune your own PI0 model), use the following lines:

```python
from lerobot.common.policies.pi0.modeling_pi0 import PI0Policy
policy = PI0Policy.from_pretrained("fracapuano/pi0")  # use this, I have updated the expected keys in the observation
```

Then load a dataset and run inference. You can use this snippet to run an inference pipeline on a given dataset. **Important: use `lerobot/svla_so100_stacking`**

```python
from dataclasses import asdict

from lerobot.common.datasets.lerobot_dataset import LeRobotDataset
import torch
from lerobot.common.policies.pi0.configuration_pi0 import PI0Config
from lerobot.common.policies.pi0.modeling_pi0 import PI0Policy
from lerobot.common.policies.act.modeling_act import ACTPolicy
from constants import DEFAULT_PI0_MODEL

import line_profiler
from memory_profiler import profile


class PI0InferencePipeline:
    """A pipeline for running inference with a PI0 policy on a dataset."""

    def __init__(self, policy_repo_id: str, dataset_repo_id: str, device: str | None = None, actions_per_chunk: int = 50):
        """
        Initializes the inference pipeline.

        Args:
            policy_repo_id: The Hugging Face Hub repository ID of the pretrained policy.
            dataset_repo_id: The Hugging Face Hub repository ID of the dataset.
            device: The device to run inference on. If None, it will be auto-detected.
            n_episodes: The number of random episodes to subsample from the dataset. If None, all episodes are used.
        """
        self.policy_name = policy_repo_id
        self.dataset_name = dataset_repo_id
        self.actions_per_chunk = actions_per_chunk

        self.device = device or ("mps" if torch.backends.mps.is_available() and torch.backends.mps.is_built() else "cpu")
        print(f"Using device: {self.device}")

        # Load dataset to get stats and metadata
        self.dataset = LeRobotDataset(dataset_repo_id)
        print("Loaded dataset: ", self.dataset)
        
        self.policy = PI0Policy.from_pretrained(policy_repo_id)
        self.policy.to(self.device)
        self._inject_normalization_stats()
        
        self.policy.eval()
        print("Inference pipeline is ready.")
    
    @property
    def name(self):
        # removing HF's user name
        model_name = self.policy_name.split("/")[-1]
        dataset_name = self.dataset_name.split("/")[-1]

        return f"{model_name}-{dataset_name}"

    def _prepare_observation(self, batch: dict) -> dict:
        """
        Prepares a batch of samples from the dataset for inference.
        This involves moving tensors to the correct device,
        and remapping image keys to match the policy's expectations.
        """
        observation = {
            "observation.state": batch["observation.state"].to(self.device),
            "observation.image": batch["observation.images.top"].to(self.device),
            "observation.image2": batch["observation.images.wrist"].to(self.device),
            "task": batch["task"],
        }
        return observation
    
    def _inject_normalization_stats(self):
        """Manually loads normalization stats from the dataset into the policy's state dictionary."""
        stats = self.dataset.meta.stats
        pol_state_dict = self.policy.state_dict()

        keys_to_update = {
            "normalize_inputs.buffer_observation_state.mean": ("observation.state", "mean"),
            "normalize_inputs.buffer_observation_state.std": ("observation.state", "std"),
            "normalize_targets.buffer_action.mean": ("action", "mean"),
            "normalize_targets.buffer_action.std": ("action", "std"),
            "unnormalize_outputs.buffer_action.mean": ("action", "mean"),
            "unnormalize_outputs.buffer_action.std": ("action", "std"),
        }

        for pol_key, (stat_key, stat_type) in keys_to_update.items():
            pol_state_dict[pol_key] = torch.from_numpy(stats[stat_key][stat_type])

        self.policy.load_state_dict(pol_state_dict)
        print("Normalization stats injected into the policy.")
    
    # Uncomment the following two decorators to profile both time and memory.
    #@line_profiler.profile
    #@profile
    def get_action_chunk(self, batch: dict, noise: torch.Tensor | None = None) -> torch.Tensor:
        """Maps a batch of observations to a batch of action chunks, one for each observation in the batch."""
        with torch.no_grad():
            batch = self._prepare_observation(batch)
            batch = self.policy.normalize_inputs(batch)

            images, img_masks = self.policy.prepare_images(batch)
            state = self.policy.prepare_state(batch)
            lang_tokens, lang_masks = self.policy.prepare_language(batch)

            actions = self.policy.model.sample_actions(
                images, img_masks, lang_tokens, lang_masks, state, noise=noise
            )

            # Unpad actions
            original_action_dim = self.policy.config.action_feature.shape[0]
            actions = actions[:, :self.actions_per_chunk, :original_action_dim]

        return actions


if __name__ == "__main__":
    from torch.utils.data import DataLoader
    # Initialize the pipeline
    inference_pipeline = PI0InferencePipeline(
        policy_repo_id="fracapuano/pi0",
        dataset_repo_id="lerobot/svla_so100_stacking",
    )

    loader = DataLoader(inference_pipeline.dataset, batch_size=16)
    sample = next(iter(loader))

    print("\n--- Running inference on a single sample ---")
    
    first_action = inference_pipeline.get_action_chunk(sample)
    print("Computed action for the sample:")
```