### PR TITLE
`gym_manipulator.py` Remove None value action_intervention of BaseLeaderTeleoperator

### DIFF
--- a/lerobot/scripts/rl/gym_manipulator.py
+++ b/lerobot/scripts/rl/gym_manipulator.py
@@ -1343,7 +1343,7 @@ class BaseLeaderControlWrapper(gym.Wrapper):
 
         # Add intervention info
         info["is_intervention"] = is_intervention
-        info["action_intervention"] = action if is_intervention else None
+        info["action_intervention"] = action
 
         self.prev_leader_gripper = np.clip(
             self.robot_leader.bus.sync_read("Present_Position")["gripper"],


### PR DESCRIPTION
## What this does

Single line fix in `gym_manipulator.py`
Remove the condition to have a None value for your leader intervention actions that can cause a bug when trying to record a dataset for the RL with the leader in `record_dataset` function. 

Nowhere do we expect that action_intervention to be None as that is governed by the `is_intervention` bool. Therefore, this won't have any backward effect on the code. 