### PR TITLE
Fix incorrect --resume parameter in recording documentation

### DIFF
--- a/docs/source/il_robots.mdx
+++ b/docs/source/il_robots.mdx
@@ -190,7 +190,7 @@ The `record` function provides a suite of tools for capturing and managing data 
 
 ##### 2. Checkpointing and Resuming
 - Checkpoints are automatically created during recording.
-- If an issue occurs, you can resume by re-running the same command with `--control.resume=true`.
+- If an issue occurs, you can resume by re-running the same command with `--resume=true`.
 - To start recording from scratch, **manually delete** the dataset directory.
 
 ##### 3. Recording Parameters


### PR DESCRIPTION
## What this does
Fixes incorrect documentation for resuming dataset recording. The docs incorrectly stated `--control.resume=true` when the actual parameter is `--resume=true` according to the code implementation in `RecordConfig`.

Label: (🐛 Bug)

## How it was tested
- Verified the correct parameter name in the `RecordConfig` class in `lerobot/record.py`
- Confirmed that `resume: bool = False` is a direct field, not under a `control` section

## How to checkout & try? (for the reviewer)
Review the documentation change and optionally test the recording resume functionality:

This should work after the fix:
```bash
python -m lerobot.record --resume=true [other parameters...]
```

This would fail (the old incorrect documentation)
```bash
python -m lerobot.record --control.resume=true [other parameters...]
```