### PR TITLE
fix(opencv backend): Removing open cv default backend on Windows

### DIFF
--- a/lerobot/common/cameras/utils.py
+++ b/lerobot/common/cameras/utils.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import platform
 from pathlib import Path
 from typing import TypeAlias
 
@@ -59,7 +58,4 @@ def get_cv2_rotation(rotation: Cv2Rotation) -> int | None:
 def get_cv2_backend() -> int:
     import cv2
 
-    if platform.system() == "Windows":
-        return cv2.CAP_AVFOUNDATION
-    else:
-        return cv2.CAP_ANY
+    return cv2.CAP_ANY


### PR DESCRIPTION
## What this does

This PR removes the forced open cv backend choice for Windows platforms :

```python
if platform.system() == "Windows":
      return cv2.CAP_AVFOUNDATION
```

This choice reportedly caused errors that could have been avoided by letting open cv picking a available and working backend, _i.e._ using `cv2.CAP_ANY` for all operating systems.

## How it was tested

TBD

## How to checkout & try? (for the reviewer)

On Windows, plug a camera and run :

```python
python lerobot/find_cameras.py
```