### PR TITLE
fix: Correct parameter name in LeRobotDataset docstring

### DIFF
--- a/lerobot/common/datasets/lerobot_dataset.py
+++ b/lerobot/common/datasets/lerobot_dataset.py
@@ -434,7 +434,7 @@ class LeRobotDataset(torch.utils.data.Dataset):
                 multiples of 1/fps. Defaults to 1e-4.
             revision (str, optional): An optional Git revision id which can be a branch name, a tag, or a
                 commit hash. Defaults to current codebase version tag.
-            sync_cache_first (bool, optional): Flag to sync and refresh local files first. If True and files
+            force_cache_sync (bool, optional): Flag to sync and refresh local files first. If True and files
                 are already present in the local cache, this will be faster. However, files loaded might not
                 be in sync with the version on the hub, especially if you specified 'revision'. Defaults to
                 False.


### PR DESCRIPTION
## What this does
This PR corrects an inconsistency in the docstring of the `LeRobotDataset` class, where the `force_cache_sync` parameter was incorrectly documented as `sync_cache_first`.
```diff
- sync_cache_first (bool, optional): Flag to sync and refresh local files first. If True and files
+ force_cache_sync (bool, optional): Flag to sync and refresh local files first. If True and files
                are already present in the local cache, this will be faster. However, files loaded might not
                be in sync with the version on the hub, especially if you specified 'revision'. Defaults to
                False.
```

- Function signature of `LeRobotDataset.__init__`:
https://github.com/huggingface/lerobot/blob/7c8be7fb9b0f7ae2296b4fd9f12a24c9609f7b93/lerobot/common/datasets/lerobot_dataset.py#L332-L345
- Original docstring:
https://github.com/huggingface/lerobot/blob/7c8be7fb9b0f7ae2296b4fd9f12a24c9609f7b93/lerobot/common/datasets/lerobot_dataset.py#L435-L443

## How it was tested
This is a documentation-only change and does not affect any code logic or behavior.
The correction was verified by inspecting the docstring and the source code of `LeRobotDataset` to ensure accuracy.

## How to checkout & try? (for the reviewer)
Please inspect the docstring for `LeRobotDataset.__init__` in the changed file to confirm that the parameter name has been corrected from `sync_cache_first` to `force_cache_sync`.