### PR TITLE
WIP #Hackathon - Force Feedback on Feetech STS3215

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# vim undofile
+.*.un~
+
 # Dev scripts
 .dev
 

--- a/README.md
+++ b/README.md
@@ -20,38 +20,6 @@
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.1%20adopted-ff69b4.svg)](https://github.com/huggingface/lerobot/blob/main/CODE_OF_CONDUCT.md)
 [![Discord](https://dcbadge.vercel.app/api/server/C5P34WJ68S?style=flat)](https://discord.gg/s3KuuzsPFb)
 
-<div align="center">
-
-🛠️ L.A.E.L.E's Force Feedback
-
-Our "force feedback" algorithm is an elegant hack (yes, it’s possible). It works based on current, position, and a traffic light system with three states per motor: green, yellow, and red. The idea is simple: when the current spikes, it means we hit something. And when we hit something, we lock the operator’s arm until the robot recovers.
-
-How it works
-
-Green State – All good! The follower is not struggling, so the operator can move the motor freely.
-
-Yellow State – Danger! The follower is stalled or under high current. We freeze the operator at the current position and monitor.
-
-Red State – Game over! The current stayed too high for too long. The leader is FORCED to imitate the follower’s position until things calm down. The operator loses control until it stabilizes.
-
-Stall Detection:
-If the motor’s current exceeds the threshold AND the position doesn’t change (it's stuck!), we mark the motor as stalled. If the position changes later, we consider it unstuck and back to normal.
-
-State Transitions:
-
-Green ➝ Yellow: if the motor is stalled.
-
-Yellow ➝ Red: current stays too high.
-
-Yellow ➝ Green: if the motor starts moving normally again.
-
-Red ➝ Yellow: once the current drops back to safe levels.
-
-That’s it. Simple, effective, and saves servos and fingers. 
-
-<div align="center">
-
-
 <h2 align="center">
     <p><a href="https://huggingface.co/docs/lerobot/so101">
         Build Your Own SO-101 Robot!</a></p>

--- a/README.md
+++ b/README.md
@@ -20,7 +20,37 @@
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.1%20adopted-ff69b4.svg)](https://github.com/huggingface/lerobot/blob/main/CODE_OF_CONDUCT.md)
 [![Discord](https://dcbadge.vercel.app/api/server/C5P34WJ68S?style=flat)](https://discord.gg/s3KuuzsPFb)
 
-</div>
+<div align="center">
+
+🛠️ L.A.E.L.E's Force Feedback
+
+Our "force feedback" algorithm is an elegant hack (yes, it’s possible). It works based on current, position, and a traffic light system with three states per motor: green, yellow, and red. The idea is simple: when the current spikes, it means we hit something. And when we hit something, we lock the operator’s arm until the robot recovers.
+
+How it works
+
+Green State – All good! The follower is not struggling, so the operator can move the motor freely.
+
+Yellow State – Danger! The follower is stalled or under high current. We freeze the operator at the current position and monitor.
+
+Red State – Game over! The current stayed too high for too long. The leader is FORCED to imitate the follower’s position until things calm down. The operator loses control until it stabilizes.
+
+Stall Detection:
+If the motor’s current exceeds the threshold AND the position doesn’t change (it's stuck!), we mark the motor as stalled. If the position changes later, we consider it unstuck and back to normal.
+
+State Transitions:
+
+Green ➝ Yellow: if the motor is stalled.
+
+Yellow ➝ Red: current stays too high.
+
+Yellow ➝ Green: if the motor starts moving normally again.
+
+Red ➝ Yellow: once the current drops back to safe levels.
+
+That’s it. Simple, effective, and saves servos and fingers. 
+
+<div align="center">
+
 
 <h2 align="center">
     <p><a href="https://huggingface.co/docs/lerobot/so101">

--- a/lerobot/common/motors/feetech/feetech.py
+++ b/lerobot/common/motors/feetech/feetech.py
@@ -296,21 +296,20 @@ class FeetechMotorsBus(MotorsBus):
         for motor in self._get_motors_list(motors):
             self.write("Torque_Enable", motor, TorqueMode.DISABLED.value, num_retry=num_retry)
             self.write("Lock", motor, 0, num_retry=num_retry)
-    
+
     def is_torqued(self, motors):
-        #works for one motor
+        # works for one motor
         if not isinstance(motors, str):
             raise RuntimeError(f"Motor '{motors}' type not supported. Expected str.")
         for motor in self._get_motors_list(motors):
             return self.read("Torque_Enable", motor)
-    
+
     def get_current(self, motors):
-        #works for one motor
+        # works for one motor
         if not isinstance(motors, str):
             raise RuntimeError(f"Motor '{motors}' type not supported. Expected str.")
         for motor in self._get_motors_list(motors):
             return self.read("Present_Current", motor)
-
 
     def _disable_torque(self, motor_id: int, model: str, num_retry: int = 0) -> None:
         addr, length = get_address(self.model_ctrl_table, model, "Torque_Enable")

--- a/lerobot/common/motors/feetech/feetech.py
+++ b/lerobot/common/motors/feetech/feetech.py
@@ -302,11 +302,6 @@ class FeetechMotorsBus(MotorsBus):
         for motor in self._get_motors_list(motors):
             return self.read("Torque_Enable", motor)
     
-    def is_stalled(self, motors):
-        # NAO USAR COM MAIS DE UM MOTOR
-        for motor in self._get_motors_list(motors):
-            return self.read("Present_Current", motor) > 150
-
     def get_current(self, motors):
         # NAO USAR COM MAIS DE UM MOTOR
         for motor in self._get_motors_list(motors):

--- a/lerobot/common/motors/feetech/feetech.py
+++ b/lerobot/common/motors/feetech/feetech.py
@@ -298,12 +298,16 @@ class FeetechMotorsBus(MotorsBus):
             self.write("Lock", motor, 0, num_retry=num_retry)
     
     def is_torqued(self, motors):
-        # NAO USAR COM MAIS DE UM MOTOR
+        #works for one motor
+        if not isinstance(motors, str):
+            raise RuntimeError(f"Motor '{motors}' type not supported. Expected str.")
         for motor in self._get_motors_list(motors):
             return self.read("Torque_Enable", motor)
     
     def get_current(self, motors):
-        # NAO USAR COM MAIS DE UM MOTOR
+        #works for one motor
+        if not isinstance(motors, str):
+            raise RuntimeError(f"Motor '{motors}' type not supported. Expected str.")
         for motor in self._get_motors_list(motors):
             return self.read("Present_Current", motor)
 

--- a/lerobot/common/motors/feetech/feetech.py
+++ b/lerobot/common/motors/feetech/feetech.py
@@ -307,6 +307,11 @@ class FeetechMotorsBus(MotorsBus):
         for motor in self._get_motors_list(motors):
             return self.read("Present_Current", motor) > 150
 
+    def get_current(self, motors):
+        # NAO USAR COM MAIS DE UM MOTOR
+        for motor in self._get_motors_list(motors):
+            return self.read("Present_Current", motor)
+
 
     def _disable_torque(self, motor_id: int, model: str, num_retry: int = 0) -> None:
         addr, length = get_address(self.model_ctrl_table, model, "Torque_Enable")

--- a/lerobot/common/motors/feetech/feetech.py
+++ b/lerobot/common/motors/feetech/feetech.py
@@ -296,6 +296,17 @@ class FeetechMotorsBus(MotorsBus):
         for motor in self._get_motors_list(motors):
             self.write("Torque_Enable", motor, TorqueMode.DISABLED.value, num_retry=num_retry)
             self.write("Lock", motor, 0, num_retry=num_retry)
+    
+    def is_torqued(self, motors):
+        # NAO USAR COM MAIS DE UM MOTOR
+        for motor in self._get_motors_list(motors):
+            return self.read("Torque_Enable", motor)
+    
+    def is_stalled(self, motors):
+        # NAO USAR COM MAIS DE UM MOTOR
+        for motor in self._get_motors_list(motors):
+            return self.read("Present_Current", motor) > 150
+
 
     def _disable_torque(self, motor_id: int, model: str, num_retry: int = 0) -> None:
         addr, length = get_address(self.model_ctrl_table, model, "Torque_Enable")

--- a/lerobot/common/motors/motors_bus.py
+++ b/lerobot/common/motors/motors_bus.py
@@ -347,7 +347,7 @@ class MotorsBus(abc.ABC):
         else:
             raise TypeError(motors)
 
-    def _get_ids_values_dict(self, values: Value | dict[str, Value] | None) -> list[str]:
+    def _get_ids_values_dict(self, values: Value | dict[str, Value] | str | None) -> list[str]:
         if isinstance(values, (int, float)):
             return dict.fromkeys(self.ids, values)
         elif isinstance(values, dict):
@@ -1171,6 +1171,7 @@ class MotorsBus(abc.ABC):
             )
 
         ids_values = self._get_ids_values_dict(values)
+        print("IDS VALUES")
         models = [self._id_to_model(id_) for id_ in ids_values]
         if self._has_different_ctrl_tables:
             assert_same_address(self.model_ctrl_table, models, data_name)

--- a/lerobot/common/motors/motors_bus.py
+++ b/lerobot/common/motors/motors_bus.py
@@ -1171,7 +1171,6 @@ class MotorsBus(abc.ABC):
             )
 
         ids_values = self._get_ids_values_dict(values)
-        print("IDS VALUES")
         models = [self._id_to_model(id_) for id_ in ids_values]
         if self._has_different_ctrl_tables:
             assert_same_address(self.model_ctrl_table, models, data_name)

--- a/lerobot/common/robots/so101_follower/so101_follower.py
+++ b/lerobot/common/robots/so101_follower/so101_follower.py
@@ -183,6 +183,7 @@ class SO101Follower(Robot):
         action = {f"{motor}.pos": val for motor, val in action.items()}
         dt_ms = (time.perf_counter() - start) * 1e3
         logger.debug(f"{self} read action: {dt_ms:.1f}ms")
+        return action
 
     def send_action(self, action: dict[str, Any]) -> dict[str, Any]:
         """Command arm to move to a target joint configuration.
@@ -214,7 +215,7 @@ class SO101Follower(Robot):
         self.bus.sync_write("Goal_Position", goal_pos)
         present_pos = self.bus.sync_read("Present_Position")
 
-        return {f"{motor}.pos": val for motor, val in goal_pos.items()}, diff
+        return {f"{motor}.pos": val for motor, val in goal_pos.items()}
 
     def disconnect(self):
         if not self.is_connected:

--- a/lerobot/common/robots/so101_follower/so101_follower.py
+++ b/lerobot/common/robots/so101_follower/so101_follower.py
@@ -170,6 +170,12 @@ class SO101Follower(Robot):
 
         return obs_dict
 
+    def print_diff(cur, nxt):
+        for k,v in cur:
+            if nxt[k] - v > 0:
+                print("DIFF",k,nxt[k]-v)
+
+
     def send_action(self, action: dict[str, Any]) -> dict[str, Any]:
         """Command arm to move to a target joint configuration.
 
@@ -197,6 +203,7 @@ class SO101Follower(Robot):
 
         # Send goal position to the arm
         self.bus.sync_write("Goal_Position", goal_pos)
+        print_diff(present_pos, goal_pos)
         return {f"{motor}.pos": val for motor, val in goal_pos.items()}
 
     def disconnect(self):

--- a/lerobot/common/robots/so101_follower/so101_follower.py
+++ b/lerobot/common/robots/so101_follower/so101_follower.py
@@ -25,7 +25,6 @@ from lerobot.common.motors import Motor, MotorCalibration, MotorNormMode
 from lerobot.common.motors.feetech import (
     FeetechMotorsBus,
     OperatingMode,
-    TorqueMode,
 )
 
 from ..robot import Robot

--- a/lerobot/common/robots/so101_follower/so101_follower.py
+++ b/lerobot/common/robots/so101_follower/so101_follower.py
@@ -25,6 +25,7 @@ from lerobot.common.motors import Motor, MotorCalibration, MotorNormMode
 from lerobot.common.motors.feetech import (
     FeetechMotorsBus,
     OperatingMode,
+    TorqueMode,
 )
 
 from ..robot import Robot
@@ -210,7 +211,6 @@ class SO101Follower(Robot):
 
         # Send goal position to the arm
 
-        names = ['shoulder_pan', 'shoulder_lift', 'elbow_flex', 'wrist_flex', 'wrist_roll', 'gripper']
         goal_pos = {key.removesuffix(".pos"): val for key, val in action.items() if key.endswith(".pos")}
         self.bus.sync_write("Goal_Position", goal_pos)
         present_pos = self.bus.sync_read("Present_Position")

--- a/lerobot/common/teleoperators/so101_leader/so101_leader.py
+++ b/lerobot/common/teleoperators/so101_leader/so101_leader.py
@@ -149,7 +149,6 @@ class SO101Leader(Teleoperator):
             the action sent to the motors, potentially clipped.
         """
 
-        print("opaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
         if not self.is_connected:
             raise DeviceNotConnectedError(f"{self} is not connected.")
 

--- a/lerobot/common/teleoperators/so101_leader/so101_leader.py
+++ b/lerobot/common/teleoperators/so101_leader/so101_leader.py
@@ -130,6 +130,39 @@ class SO101Leader(Teleoperator):
         dt_ms = (time.perf_counter() - start) * 1e3
         logger.debug(f"{self} read action: {dt_ms:.1f}ms")
 
+
+    def send_action(self, action: dict[str, Any]) -> dict[str, Any]:
+        """Command arm to move to a target joint configuration.
+
+        The relative action magnitude may be clipped depending on the configuration parameter
+        `max_relative_target`. In this case, the action sent differs from original action.
+        Thus, this function always returns the action actually sent.
+
+        Raises:
+            RobotDeviceNotConnectedError: if robot is not connected.
+
+        Returns:
+            the action sent to the motors, potentially clipped.
+        """
+        if not self.is_connected:
+            raise DeviceNotConnectedError(f"{self} is not connected.")
+
+        # Cap goal position when too far away from present position.
+        # /!\ Slower fps expected due to reading from the follower.
+        if self.config.max_relative_target is not None:
+            present_pos = self.bus.sync_read("Present_Position")
+            goal_present_pos = {key: (g_pos, present_pos[key]) for key, g_pos in goal_pos.items()}
+            goal_pos = ensure_safe_goal_position(goal_present_pos, self.config.max_relative_target)
+
+        # Send goal position to the arm
+
+        names = ['shoulder_pan', 'shoulder_lift', 'elbow_flex', 'wrist_flex', 'wrist_roll', 'gripper']
+        goal_pos = {key.removesuffix(".pos"): val for key, val in action.items() if key.endswith(".pos")}
+        self.bus.sync_write("Goal_Position", goal_pos)
+        present_pos = self.bus.sync_read("Present_Position")
+
+        return {f"{motor}.pos": val for motor, val in goal_pos.items()}, diff
+
     def send_feedback(self, feedback: dict[str, float]) -> None:
         # TODO(rcadene, aliberts): Implement force feedback
         raise NotImplementedError

--- a/lerobot/common/teleoperators/so101_leader/so101_leader.py
+++ b/lerobot/common/teleoperators/so101_leader/so101_leader.py
@@ -163,7 +163,6 @@ class SO101Leader(Teleoperator):
 
         goal_pos = {key.removesuffix(".pos"): val for key, val in action.items() if key.endswith(".pos")}
         self.bus.sync_write("Goal_Position", goal_pos)
-        present_pos = self.bus.sync_read("Present_Position")
 
         return {f"{motor}.pos": val for motor, val in goal_pos.items()}
 

--- a/lerobot/common/teleoperators/so101_leader/so101_leader.py
+++ b/lerobot/common/teleoperators/so101_leader/so101_leader.py
@@ -129,7 +129,6 @@ class SO101Leader(Teleoperator):
         action = {f"{motor}.pos": val for motor, val in action.items()}
         dt_ms = (time.perf_counter() - start) * 1e3
         logger.debug(f"{self} read action: {dt_ms:.1f}ms")
-        return action
 
     def send_feedback(self, feedback: dict[str, float]) -> None:
         # TODO(rcadene, aliberts): Implement force feedback

--- a/lerobot/common/teleoperators/so101_leader/so101_leader.py
+++ b/lerobot/common/teleoperators/so101_leader/so101_leader.py
@@ -16,10 +16,10 @@
 
 import logging
 import time
+from typing import Any
 
 from lerobot.common.errors import DeviceAlreadyConnectedError, DeviceNotConnectedError
 from lerobot.common.motors import Motor, MotorCalibration, MotorNormMode
-from typing import Any
 from lerobot.common.motors.feetech import (
     FeetechMotorsBus,
     OperatingMode,
@@ -27,8 +27,6 @@ from lerobot.common.motors.feetech import (
 
 from ..teleoperator import Teleoperator
 from .config_so101_leader import SO101LeaderConfig
-
-from lerobot.common.robots.utils import ensure_safe_goal_position
 
 logger = logging.getLogger(__name__)
 
@@ -133,7 +131,6 @@ class SO101Leader(Teleoperator):
         dt_ms = (time.perf_counter() - start) * 1e3
         logger.debug(f"{self} read action: {dt_ms:.1f}ms")
         return action
-
 
     def send_action(self, action: dict[str, Any]) -> dict[str, float]:
         """Command arm to move to a target joint configuration.

--- a/lerobot/teleoperate.py
+++ b/lerobot/teleoperate.py
@@ -94,7 +94,7 @@ def teleop_loop(
         THRESHOLD_DIFF = 1
         THRESHOLD_TIME= 200
 
-        _, diff = robot.send_action(action, THRESHOLD_DIFF)
+        _, diff = robot.send_action(action)
         print("diff -> ", diff)
         dt_s = time.perf_counter() - loop_start
         busy_wait(1 / fps - dt_s)

--- a/lerobot/teleoperate.py
+++ b/lerobot/teleoperate.py
@@ -91,7 +91,10 @@ def teleop_loop(
                 if isinstance(val, float):
                     rr.log(f"action_{act}", rr.Scalar(val))
 
-        _, diff = robot.send_action(action)
+        THRESHOLD_DIFF = 1
+        THRESHOLD_TIME= 200
+
+        _, diff = robot.send_action(action, THRESHOLD_DIFF)
         print("diff -> ", diff)
         dt_s = time.perf_counter() - loop_start
         busy_wait(1 / fps - dt_s)

--- a/lerobot/teleoperate.py
+++ b/lerobot/teleoperate.py
@@ -94,8 +94,30 @@ def teleop_loop(
         THRESHOLD_DIFF = 1
         THRESHOLD_TIME= 200
 
-        _, diff = robot.send_action(action)
-        print("diff -> ", diff)
+        names = ['shoulder_pan', 'shoulder_lift', 'elbow_flex', 'wrist_flex', 'wrist_roll', 'gripper']
+        last = {}
+        mark  = {}
+
+        # pegar diff com o action e o get action
+        # cur_robot = robot.get_action()
+        robot.send_action(action, THRESHOLD_DIFF)
+
+        for s in names:
+            if diff[s]:
+                if mark[s]:
+                    continue
+                else:
+                    last[s] = time.perf_counter()
+                    mark[s] = True
+            else:
+                last[s] = time.perf_counter()
+                mark[s] = False
+
+        for s in names:
+            if mark[s] and time.perf_counter() - last[s] > THRESHOLD_TIME:
+                # tem que ter isso
+                # teleop.send_action(robot.get_action)
+
         dt_s = time.perf_counter() - loop_start
         busy_wait(1 / fps - dt_s)
 

--- a/lerobot/teleoperate.py
+++ b/lerobot/teleoperate.py
@@ -117,6 +117,7 @@ def teleop_loop(
             if mark[s] and time.perf_counter() - last[s] > THRESHOLD_TIME:
                 # tem que ter isso
                 # teleop.send_action(robot.get_action)
+                pass
 
         dt_s = time.perf_counter() - loop_start
         busy_wait(1 / fps - dt_s)

--- a/lerobot/teleoperate.py
+++ b/lerobot/teleoperate.py
@@ -59,9 +59,9 @@ from lerobot.common.utils.visualization_utils import _init_rerun
 
 from .common.teleoperators import gamepad, koch_leader, so100_leader, so101_leader  # noqa: F401
 
-# 0 -> sinal vermelho
-# 1 -> sinal amarelo
-# 2 -> sinal verde
+# 0 -> red
+# 1 -> yellow
+# 2 -> green
 state = {}
 stall = {}
 pos = {}
@@ -152,7 +152,6 @@ def teleop_loop(
 
         motors = list(robot.bus.motors.keys())
 
-        # pegar diff com o action e o get action
         robot.send_action(action)
 
         if time.perf_counter() - start_time > STARTUP_TIME:
@@ -167,16 +166,16 @@ def teleop_loop(
 
         loop_s = time.perf_counter() - loop_start
 
-        #print("\n" + "-LAELE-" * (display_len//3 + 1))
-        #print(f"{'NAME':<{display_len}} | {'NORM':>7}")
-        #for motor, value in action.items():
-        #    print(f"{motor:<{display_len}} | {value:>7.2f}")
-        #print(f"\ntime: {loop_s * 1e3:.2f}ms ({1 / loop_s:.0f} Hz)")
+        print("\n" + "-" * (display_len + 10))
+        print(f"{'NAME':<{display_len}} | {'NORM':>7}")
+        for motor, value in action.items():
+            print(f"{motor:<{display_len}} | {value:>7.2f}")
+        print(f"\ntime: {loop_s * 1e3:.2f}ms ({1 / loop_s:.0f} Hz)")
 
         if duration is not None and time.perf_counter() - start >= duration:
             return
 
-        #move_cursor_up(len(action) + 5)
+        move_cursor_up(len(action) + 5)
 
 @draccus.wrap()
 def teleoperate(cfg: TeleoperateConfig):

--- a/lerobot/teleoperate.py
+++ b/lerobot/teleoperate.py
@@ -97,7 +97,7 @@ def is_red(motor):
 
 def check_stall(robot,teleop,motors,THRESHOLD_CURRENT):
     for motor in motors:
-        if robot.bus.get_current(motor) > THRESHOLD_CURRENT:
+        if robot.bus.get_current(motor) > THRESHOLD_CURRENT[motor]:
             stall[motor] = True
         elif abs(robot.get_action()[motor+".pos"] - pos[motor]) > 0: 
             stall[motor] = False
@@ -116,14 +116,14 @@ def check_state(robot,teleop,motors,THRESHOLD_CURRENT):
                     teleop.bus.disable_torque(motor,5)
                 green_light(motor)
             else:
-                if robot.bus.get_current(motor) > THRESHOLD_CURRENT:
+                if robot.bus.get_current(motor) > THRESHOLD_CURRENT[motor]:
                     red_light(motor)
                 elif teleop.bus.is_torqued:
                     teleop.bus.disable_torque(motor,5)
         else:
             teleop.bus.sync_write("Goal_Position",{motor:pos[motor]})
             teleop.bus.enable_torque(motor)
-            if not robot.bus.get_current(motor) > THRESHOLD_CURRENT and not teleop.bus.get_current(motor) > 0:
+            if not robot.bus.get_current(motor) > THRESHOLD_CURRENT[motor] and not teleop.bus.get_current(motor) > 0:
                 yellow_light(motor)
 
 def teleop_loop(
@@ -145,8 +145,8 @@ def teleop_loop(
                 if isinstance(val, float):
                     rr.log(f"action_{act}", rr.Scalar(val))
 
-        THRESHOLD_DIFF = {'shoulder_pan': 2, 'shoulder_lift': 2, 'elbow_flex': 2, 'wrist_flex': 2, 'wrist_roll': 2, 'gripper': 1}
-        THRESHOLD_CURRENT = 37.5
+        THRESHOLD_CURRENT = {'shoulder_pan': 50, 'shoulder_lift': 100, 'elbow_flex': 75, 'wrist_flex': 50, 'wrist_roll': 50, 'gripper': 20}
+        # THRESHOLD_CURRENT = 35
 
         motors = list(robot.bus.motors.keys())
 

--- a/lerobot/teleoperate.py
+++ b/lerobot/teleoperate.py
@@ -98,20 +98,20 @@ def is_red(motor):
 
 
 def check_stall(robot,teleop,motors,THRESHOLD_CURRENT):
+    action = robot.get_action()
     for motor in motors:
         if robot.bus.get_current(motor) > THRESHOLD_CURRENT[motor]:
             stall[motor] = True
-        elif abs(robot.get_action()[motor+".pos"] - pos[motor]) > 0: 
+        elif abs(action[motor+".pos"] - pos[motor]) > 0: 
             stall[motor] = False
 
-
-
 def check_state(robot,teleop,motors,THRESHOLD_CURRENT):
+    action = robot.get_action()
     for motor in motors:
         if is_green(motor):
             if stall[motor]:
                 red_light(motor)
-            pos[motor] = robot.get_action()[motor+".pos"]
+            pos[motor] = action[motor+".pos"]
         elif is_yellow(motor):
             if not stall[motor]:
                 if teleop.bus.is_torqued:
@@ -167,16 +167,16 @@ def teleop_loop(
 
         loop_s = time.perf_counter() - loop_start
 
-        print("\n" + "-LAELE-" * (display_len//3 + 1))
-        print(f"{'NAME':<{display_len}} | {'NORM':>7}")
-        for motor, value in action.items():
-            print(f"{motor:<{display_len}} | {value:>7.2f}")
-        print(f"\ntime: {loop_s * 1e3:.2f}ms ({1 / loop_s:.0f} Hz)")
+        #print("\n" + "-LAELE-" * (display_len//3 + 1))
+        #print(f"{'NAME':<{display_len}} | {'NORM':>7}")
+        #for motor, value in action.items():
+        #    print(f"{motor:<{display_len}} | {value:>7.2f}")
+        #print(f"\ntime: {loop_s * 1e3:.2f}ms ({1 / loop_s:.0f} Hz)")
 
         if duration is not None and time.perf_counter() - start >= duration:
             return
 
-        move_cursor_up(len(action) + 5)
+        #move_cursor_up(len(action) + 5)
 
 @draccus.wrap()
 def teleoperate(cfg: TeleoperateConfig):

--- a/lerobot/teleoperate.py
+++ b/lerobot/teleoperate.py
@@ -34,7 +34,6 @@ import logging
 import time
 from dataclasses import asdict, dataclass
 from pprint import pformat
-
 import draccus
 import numpy as np
 import rerun as rr
@@ -111,7 +110,7 @@ def teleop_loop(
                     rr.log(f"action_{act}", rr.Scalar(val))
 
         THRESHOLD_DIFF = 2
-        THRESHOLD_TIME= 2
+        THRESHOLD_TIME= 0.1 
 
         motors = list(robot.bus.motors.keys())
 
@@ -139,12 +138,21 @@ def teleop_loop(
 
         print("last -> ", last)
         print("mark -> ", mark)
+        teleop.send_action(robot.get_action())
         for motor in motors:
             if (mark[motor]):
                 print("diference -> ", time.perf_counter() - last[motor])
             if mark[motor] and time.perf_counter() - last[motor] > THRESHOLD_TIME:
                 # tem que ter isso
-                teleop.send_action(robot.get_action())
+                #teleop.bus.enable_torque(motor, 5)
+                #print("get action",robot.get_action())
+                #print("get action motor",robot.get_action()[motor+".pos"])
+                #print("motor", motor)
+                #teleop.bus.write("Operating_Mode", motor, robot.get_action()[motor+".pos"])
+                pass
+            else:
+                teleop.bus.disable_torque(motor, 5)
+                
 
         dt_s = time.perf_counter() - loop_start
         busy_wait(1 / fps - dt_s)

--- a/lerobot/teleoperate.py
+++ b/lerobot/teleoperate.py
@@ -91,22 +91,25 @@ def teleop_loop(
                 if isinstance(val, float):
                     rr.log(f"action_{act}", rr.Scalar(val))
 
-        robot.send_action(action)
+        _, diff = robot.send_action(action)
+        print("diff -> ", diff)
         dt_s = time.perf_counter() - loop_start
         busy_wait(1 / fps - dt_s)
 
         loop_s = time.perf_counter() - loop_start
 
-        print("\n" + "-" * (display_len + 10))
-        print(f"{'NAME':<{display_len}} | {'NORM':>7}")
-        for motor, value in action.items():
-            print(f"{motor:<{display_len}} | {value:>7.2f}")
-        print(f"\ntime: {loop_s * 1e3:.2f}ms ({1 / loop_s:.0f} Hz)")
+        # print("\n" + "-" * (display_len + 10))
+        # print(f"{'NAME':<{display_len}} | {'NORM':>7}")
+        # for motor, value in action.items():
+        #     print(f"{motor:<{display_len}} | {value:>7.2f}")
+        # print(f"\ntime: {loop_s * 1e3:.2f}ms ({1 / loop_s:.0f} Hz)")
+
+        #print(action)
 
         if duration is not None and time.perf_counter() - start >= duration:
             return
 
-        move_cursor_up(len(action) + 5)
+        # move_cursor_up(len(action) + 5)
 
 
 @draccus.wrap()


### PR DESCRIPTION
## What this does
This is a WIP by team 281 (L.A.E.L.E) for force feedback on STS3215 servo motor leader/follower, made during the LeRobot WorldWide Hackathon 2025.

Contributors: @LuizaMannes, @Askeiroh, @equadras, @leonardonm15, @Grochowicz.

## How it works

The main logic is in teleoperate.py, which will now do two-way position information exchange between leader and follower.

*There are threshold values that may need tweaking.*

The code implements a traffic-light-like state machine and a virtual stall state machine:

Virtual stall:
The virtual stall state machine is used to make the motor current peak (because of a physical stall) set the virtual stall. The virtual stall is unset as soon as the position changes.

Traffic-light:
Green State – The follower is not struggling, so the operator can move the motor freely.
Yellow State – The follower is struggling.
Red State – The follower was blocked and the leader is in an invalid position. The leader is FORCED to imitate the follower’s position until things calm down. The operator loses control until it stabilizes.

Traffic-light State Transitions:
Green ➝ Red: if the motor just stalled.
Red ➝ Yellow: once the current drops back to safe levels (no more external force on the motor).
Yellow ➝ Red: if the motor just stalled.
Yellow ➝ Yellow: if the virtual stall is false.
Yellow ➝ Green: if the virtual stall is false.


TODO
- [ ] Make force feedback optional
- [ ] Make parameters more easily editable
- [ ] Print current state and stall status in teleoperate loop
- [ ] Clean up code
- [ ] Have calibration set current threshold