### PR TITLE
Refactor kinematics and switch to using plac

### DIFF
--- a/lerobot/common/model/kinematics.py
+++ b/lerobot/common/model/kinematics.py
@@ -1,483 +1,123 @@
-# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
-
 import numpy as np
-from numpy.typing import NDArray
-from scipy.spatial.transform import Rotation
 
 
-def skew_symmetric(w: NDArray[np.float32]) -> NDArray[np.float32]:
-    """Creates the skew-symmetric matrix from a 3D vector."""
-    return np.array([[0, -w[2], w[1]], [w[2], 0, -w[0]], [-w[1], w[0], 0]])
-
-
-def rodrigues_rotation(w: NDArray[np.float32], theta: float) -> NDArray[np.float32]:
-    """Computes the rotation matrix using Rodrigues' formula."""
-    w_hat = skew_symmetric(w)
-    return np.eye(3) + np.sin(theta) * w_hat + (1 - np.cos(theta)) * w_hat @ w_hat
-
-
-def screw_axis_to_transform(s: NDArray[np.float32], theta: float) -> NDArray[np.float32]:
-    """Converts a screw axis to a 4x4 transformation matrix."""
-    screw_axis_rot = s[:3]
-    screw_axis_trans = s[3:]
-
-    # Pure translation
-    if np.allclose(screw_axis_rot, 0) and np.linalg.norm(screw_axis_trans) == 1:
-        transform = np.eye(4)
-        transform[:3, 3] = screw_axis_trans * theta
-
-    # Rotation (and potentially translation)
-    elif np.linalg.norm(screw_axis_rot) == 1:
-        w_hat = skew_symmetric(screw_axis_rot)
-        rot_mat = np.eye(3) + np.sin(theta) * w_hat + (1 - np.cos(theta)) * w_hat @ w_hat
-        t = (
-            np.eye(3) * theta + (1 - np.cos(theta)) * w_hat + (theta - np.sin(theta)) * w_hat @ w_hat
-        ) @ screw_axis_trans
-        transform = np.eye(4)
-        transform[:3, :3] = rot_mat
-        transform[:3, 3] = t
-    else:
-        raise ValueError("Invalid screw axis parameters")
-    return transform
-
-
-def pose_difference_se3(pose1: NDArray[np.float32], pose2: NDArray[np.float32]) -> NDArray[np.float32]:
-    """
-    Calculates the SE(3) difference between two 4x4 homogeneous transformation matrices.
-    SE(3) (Special Euclidean Group) represents rigid body transformations in 3D space,
-    combining rotation (SO(3)) and translation.
-
-    Each 4x4 matrix has the following structure:
-    [R11 R12 R13 tx]
-    [R21 R22 R23 ty]
-    [R31 R32 R33 tz]
-    [ 0   0   0   1]
-
-    where R is the 3x3 rotation matrix and [tx,ty,tz] is the translation vector.
-
-    Args:
-        pose1: A 4x4 numpy array representing the first pose.
-        pose2: A 4x4 numpy array representing the second pose.
-
-    Returns:
-        A 6D numpy array concatenating translation and rotation differences.
-        First 3 elements are the translational difference (position).
-        Last 3 elements are the rotational difference in axis-angle representation.
-    """
-    rot1 = pose1[:3, :3]
-    rot2 = pose2[:3, :3]
-
-    translation_diff = pose1[:3, 3] - pose2[:3, 3]
-
-    # Calculate rotational difference using scipy's Rotation library
-    rot_diff = Rotation.from_matrix(rot1 @ rot2.T)
-    rotation_diff = rot_diff.as_rotvec()  # Axis-angle representation
-
-    return np.concatenate([translation_diff, rotation_diff])
-
-
-def se3_error(target_pose: NDArray[np.float32], current_pose: NDArray[np.float32]) -> NDArray[np.float32]:
-    pos_error = target_pose[:3, 3] - current_pose[:3, 3]
-
-    rot_target = target_pose[:3, :3]
-    rot_current = current_pose[:3, :3]
-    rot_error_mat = rot_target @ rot_current.T
-    rot_error = Rotation.from_matrix(rot_error_mat).as_rotvec()
-
-    return np.concatenate([pos_error, rot_error])
-
-
-class RobotKinematics:
-    """Robot kinematics class supporting multiple robot models."""
-
-    # Robot measurements dictionary
-    ROBOT_MEASUREMENTS = {
-        "koch": {
-            "gripper": [0.239, -0.001, 0.024],
-            "wrist": [0.209, 0, 0.024],
-            "forearm": [0.108, 0, 0.02],
-            "humerus": [0, 0, 0.036],
-            "shoulder": [0, 0, 0],
-            "base": [0, 0, 0.02],
-        },
-        "moss": {
-            "gripper": [0.246, 0.013, 0.111],
-            "wrist": [0.245, 0.002, 0.064],
-            "forearm": [0.122, 0, 0.064],
-            "humerus": [0.001, 0.001, 0.063],
-            "shoulder": [0, 0, 0],
-            "base": [0, 0, 0.02],
-        },
-        "so_old_calibration": {
-            "gripper": [0.320, 0, 0.050],
-            "wrist": [0.278, 0, 0.050],
-            "forearm": [0.143, 0, 0.044],
-            "humerus": [0.031, 0, 0.072],
-            "shoulder": [0, 0, 0],
-            "base": [0, 0, 0.02],
-        },
-        "so_new_calibration": {
-            "gripper": [0.33, 0.0, 0.285],
-            "wrist": [0.30, 0.0, 0.267],
-            "forearm": [0.25, 0.0, 0.266],
-            "humerus": [0.06, 0.0, 0.264],
-            "shoulder": [0.0, 0.0, 0.238],
-            "base": [0.0, 0.0, 0.12],
-        },
-    }
-
-    def __init__(self, robot_type: str = "so100"):
-        """Initialize kinematics for the specified robot type.
-
-        Args:
-            robot_type: String specifying the robot model ("koch", "so100", or "moss")
+class PlacoRobotKinematics:
+    """Robot kinematics using placo library for forward and inverse kinematics."""
+    
+    def __init__(self, urdf_path: str, ee_frame_name: str = "gripper_tip", joint_names: list[str] = None):
         """
-        if robot_type not in self.ROBOT_MEASUREMENTS:
-            raise ValueError(
-                f"Unknown robot type: {robot_type}. Available types: {list(self.ROBOT_MEASUREMENTS.keys())}"
+        Initialize placo-based kinematics solver.
+        
+        Args:
+            urdf_path: Path to the robot URDF file
+            ee_frame_name: Name of the end-effector frame in the URDF
+            joint_names: List of joint names to control (if None, will use default naming)
+        """
+        try:
+            import placo
+        except ImportError:
+            raise ImportError(
+                "placo is required for PlacoRobotKinematics. "
+                "Please install it with: pip install placo"
             )
-
-        self.robot_type = robot_type
-        self.measurements = self.ROBOT_MEASUREMENTS[robot_type]
-
-        # Initialize all transformation matrices and screw axes
-        self._setup_transforms()
-
-    def _create_translation_matrix(
-        self, x: float = 0.0, y: float = 0.0, z: float = 0.0
-    ) -> NDArray[np.float32]:
-        """Create a 4x4 translation matrix."""
-        return np.array([[1, 0, 0, x], [0, 1, 0, y], [0, 0, 1, z], [0, 0, 0, 1]])
-
-    def _setup_transforms(self):
-        """Setup all transformation matrices and screw axes for the robot."""
-        # Set up rotation matrices (constant across robot types)
-
-        # Gripper orientation
-        self.gripper_X0 = np.array(
-            [
-                [1, 0, 0, 0],
-                [0, 0, 1, 0],
-                [0, -1, 0, 0],
-                [0, 0, 0, 1],
-            ],
-            dtype=np.float32,
-        )
-
-        # Wrist orientation
-        self.wrist_X0 = np.array(
-            [
-                [0, -1, 0, 0],
-                [1, 0, 0, 0],
-                [0, 0, 1, 0],
-                [0, 0, 0, 1],
-            ],
-            dtype=np.float32,
-        )
-
-        # Base orientation
-        self.base_X0 = np.array(
-            [
-                [0, 0, 1, 0],
-                [1, 0, 0, 0],
-                [0, 1, 0, 0],
-                [0, 0, 0, 1],
-            ],
-            dtype=np.float32,
-        )
-
-        # Gripper
-        # Screw axis of gripper frame wrt base frame
-        self.S_BG = np.array(
-            [
-                1,
-                0,
-                0,
-                0,
-                self.measurements["gripper"][2],
-                -self.measurements["gripper"][1],
-            ],
-            dtype=np.float32,
-        )
-
-        # Gripper origin to centroid transform
-        self.X_GoGc = self._create_translation_matrix(x=0.07)
-
-        # Gripper origin to tip transform
-        self.X_GoGt = self._create_translation_matrix(x=0.12)
-
-        # 0-position gripper frame pose wrt base
-        self.X_BoGo = self._create_translation_matrix(
-            x=self.measurements["gripper"][0],
-            y=self.measurements["gripper"][1],
-            z=self.measurements["gripper"][2],
-        )
-
-        # Wrist
-        # Screw axis of wrist frame wrt base frame
-        self.S_BR = np.array(
-            [0, 1, 0, -self.measurements["wrist"][2], 0, self.measurements["wrist"][0]], dtype=np.float32
-        )
-
-        # 0-position origin to centroid transform
-        self.X_RoRc = self._create_translation_matrix(x=0.0035, y=-0.002)
-
-        # 0-position wrist frame pose wrt base
-        self.X_BR = self._create_translation_matrix(
-            x=self.measurements["wrist"][0],
-            y=self.measurements["wrist"][1],
-            z=self.measurements["wrist"][2],
-        )
-
-        # Forearm
-        # Screw axis of forearm frame wrt base frame
-        self.S_BF = np.array(
-            [
-                0,
-                1,
-                0,
-                -self.measurements["forearm"][2],
-                0,
-                self.measurements["forearm"][0],
-            ],
-            dtype=np.float32,
-        )
-
-        # Forearm origin + centroid transform
-        self.X_ForearmFc = self._create_translation_matrix(x=0.036)
-
-        # 0-position forearm frame pose wrt base
-        self.X_BF = self._create_translation_matrix(
-            x=self.measurements["forearm"][0],
-            y=self.measurements["forearm"][1],
-            z=self.measurements["forearm"][2],
-        )
-
-        # Humerus
-        # Screw axis of humerus frame wrt base frame
-        self.S_BH = np.array(
-            [
-                0,
-                -1,
-                0,
-                self.measurements["humerus"][2],
-                0,
-                -self.measurements["humerus"][0],
-            ],
-            dtype=np.float32,
-        )
-
-        # Humerus origin to centroid transform
-        self.X_HoHc = self._create_translation_matrix(x=0.0475)
-
-        # 0-position humerus frame pose wrt base
-        self.X_BH = self._create_translation_matrix(
-            x=self.measurements["humerus"][0],
-            y=self.measurements["humerus"][1],
-            z=self.measurements["humerus"][2],
-        )
-
-        # Shoulder
-        # Screw axis of shoulder frame wrt Base frame
-        self.S_BS = np.array([0, 0, -1, 0, 0, 0], dtype=np.float32)
-
-        # Shoulder origin to centroid transform
-        self.X_SoSc = self._create_translation_matrix(x=-0.017, z=0.0235)
-
-        # 0-position shoulder frame pose wrt base
-        self.X_BS = self._create_translation_matrix(
-            x=self.measurements["shoulder"][0],
-            y=self.measurements["shoulder"][1],
-            z=self.measurements["shoulder"][2],
-        )
-
-        # Base
-        # Base origin to centroid transform
-        self.X_BoBc = self._create_translation_matrix(y=0.015)
-
-        # World to base transform
-        self.X_WoBo = self._create_translation_matrix(
-            x=self.measurements["base"][0],
-            y=self.measurements["base"][1],
-            z=self.measurements["base"][2],
-        )
-
-        # Pre-compute gripper post-multiplication matrix
-        self._fk_gripper_post = self.X_GoGc @ self.X_BoGo @ self.gripper_X0
-
-    def forward_kinematics(
-        self,
-        robot_pos_deg: NDArray[np.float32],
-        frame: str = "gripper_tip",
-    ) -> NDArray[np.float32]:
-        """Generic forward kinematics.
-
-        Args:
-            robot_pos_deg: Joint positions in degrees. Can be ``None`` when
-                computing the *base* frame as it does not depend on joint
-                angles.
-            frame: Target frame. One of
-                ``{"base", "shoulder", "humerus", "forearm", "wrist", "gripper", "gripper_tip"}``.
-
-        Returns
-        -------
-        NDArray[np.float32]
-            4×4 homogeneous transformation matrix of the requested frame
-            expressed in the world coordinate system.
+        
+        self.robot = placo.RobotWrapper(urdf_path)
+        self.solver = placo.KinematicsSolver(self.robot)
+        self.solver.mask_fbase(True)  # Fix the base
+        
+        self.ee_frame_name = ee_frame_name
+        
+        # Set joint names
+        if joint_names is None:
+            # Default joint names for SO-ARM100
+            self.joint_names = ["1", "2", "3", "4", "5"]
+        else:
+            self.joint_names = joint_names
+        
+        # Initialize frame task for IK
+        self.tip_starting_pose = np.eye(4)
+        self.tip_frame = self.solver.add_frame_task(self.ee_frame_name, self.tip_starting_pose)
+        self.tip_frame.configure(self.ee_frame_name, "soft", 1.0, 1.0)
+    
+    def forward_kinematics(self, robot_pos_deg, frame=None):
         """
-        frame = frame.lower()
-        if frame not in {
-            "base",
-            "shoulder",
-            "humerus",
-            "forearm",
-            "wrist",
-            "gripper",
-            "gripper_tip",
-        }:
-            raise ValueError(
-                f"Unknown frame '{frame}'. Valid options are base, shoulder, humerus, forearm, wrist, gripper, gripper_tip."
-            )
-
-        # Base frame does not rely on joint angles.
-        if frame == "base":
-            return self.X_WoBo @ self.X_BoBc @ self.base_X0
-
-        robot_pos_rad = robot_pos_deg / 180 * np.pi
-
-        # Extract joint angles (note the sign convention for shoulder lift).
-        theta_shoulder_pan = robot_pos_rad[0]
-        theta_shoulder_lift = -robot_pos_rad[1]
-        theta_elbow_flex = robot_pos_rad[2]
-        theta_wrist_flex = robot_pos_rad[3]
-        theta_wrist_roll = robot_pos_rad[4]
-
-        # Start with the world-to-base transform; incrementally add successive links.
-        transformation_matrix = self.X_WoBo @ screw_axis_to_transform(self.S_BS, theta_shoulder_pan)
-        if frame == "shoulder":
-            return transformation_matrix @ self.X_SoSc @ self.X_BS
-
-        transformation_matrix = transformation_matrix @ screw_axis_to_transform(
-            self.S_BH, theta_shoulder_lift
-        )
-        if frame == "humerus":
-            return transformation_matrix @ self.X_HoHc @ self.X_BH
-
-        transformation_matrix = transformation_matrix @ screw_axis_to_transform(self.S_BF, theta_elbow_flex)
-        if frame == "forearm":
-            return transformation_matrix @ self.X_ForearmFc @ self.X_BF
-
-        transformation_matrix = transformation_matrix @ screw_axis_to_transform(self.S_BR, theta_wrist_flex)
-        if frame == "wrist":
-            return transformation_matrix @ self.X_RoRc @ self.X_BR @ self.wrist_X0
-
-        transformation_matrix = transformation_matrix @ screw_axis_to_transform(self.S_BG, theta_wrist_roll)
-        if frame == "gripper":
-            return transformation_matrix @ self._fk_gripper_post
-        else:  # frame == "gripper_tip"
-            return transformation_matrix @ self.X_GoGt @ self.X_BoGo @ self.gripper_X0
-
-    def compute_jacobian(
-        self, robot_pos_deg: NDArray[np.float32], frame: str = "gripper_tip"
-    ) -> NDArray[np.float32]:
-        """Finite differences to compute the Jacobian.
-        J(i, j) represents how the ith component of the end-effector's velocity changes wrt a small change
-        in the jth joint's velocity.
-
+        Compute forward kinematics for given joint configuration.
+        
         Args:
-            robot_pos_deg: Current joint positions in degrees
-            fk_func: Forward kinematics function to use (defaults to fk_gripper)
+            robot_pos_deg: Joint positions in degrees (numpy array)
+            frame: Target frame name (if None, uses ee_frame_name)
+        
+        Returns:
+            4x4 transformation matrix of the end-effector pose
         """
-
-        eps = 1e-8
-        jac = np.zeros(shape=(6, 5))
-        delta = np.zeros(len(robot_pos_deg[:-1]), dtype=np.float64)
-        for el_ix in range(len(robot_pos_deg[:-1])):
-            delta *= 0
-            delta[el_ix] = eps / 2
-            sdot = (
-                pose_difference_se3(
-                    self.forward_kinematics(robot_pos_deg[:-1] + delta, frame),
-                    self.forward_kinematics(robot_pos_deg[:-1] - delta, frame),
-                )
-                / eps
-            )
-            jac[:, el_ix] = sdot
-        return jac
-
-    def compute_positional_jacobian(
-        self, robot_pos_deg: NDArray[np.float32], frame: str = "gripper_tip"
-    ) -> NDArray[np.float32]:
-        """Finite differences to compute the positional Jacobian.
-        J(i, j) represents how the ith component of the end-effector's position changes wrt a small change
-        in the jth joint's velocity.
-
-        Args:
-            robot_pos_deg: Current joint positions in degrees
-            fk_func: Forward kinematics function to use (defaults to fk_gripper)
+        if frame is None:
+            frame = self.ee_frame_name
+        
+        # Convert degrees to radians
+        robot_pos_rad = np.deg2rad(robot_pos_deg[:len(self.joint_names)])
+        
+        # Update joint positions in placo robot
+        for i, joint_name in enumerate(self.joint_names):
+            self.robot.set_joint(joint_name, robot_pos_rad[i])
+        
+        # Update kinematics
+        self.robot.update_kinematics()
+        
+        # Get the transformation matrix
+        return self.robot.get_T_world_frame(frame)
+    
+    def ik(self, current_joint_pos, desired_ee_pose, position_only=True, frame=None):
         """
-        eps = 1e-8
-        jac = np.zeros(shape=(3, 5))
-        delta = np.zeros(len(robot_pos_deg[:-1]), dtype=np.float64)
-        for el_ix in range(len(robot_pos_deg[:-1])):
-            delta *= 0
-            delta[el_ix] = eps / 2
-            sdot = (
-                self.forward_kinematics(robot_pos_deg[:-1] + delta, frame)[:3, 3]
-                - self.forward_kinematics(robot_pos_deg[:-1] - delta, frame)[:3, 3]
-            ) / eps
-            jac[:, el_ix] = sdot
-        return jac
-
-    def ik(
-        self,
-        current_joint_pos: NDArray[np.float32],
-        desired_ee_pose: NDArray[np.float32],
-        position_only: bool = True,
-        frame: str = "gripper_tip",
-        max_iterations: int = 5,
-        learning_rate: float = 1,
-    ) -> NDArray[np.float32]:
-        """Inverse kinematics using gradient descent.
-
+        Compute inverse kinematics using placo solver.
+        
         Args:
-            current_joint_state: Initial joint positions in degrees
+            current_joint_pos: Current joint positions in degrees (used as initial guess)
             desired_ee_pose: Target end-effector pose as a 4x4 transformation matrix
-            position_only: If True, only match end-effector position, not orientation
-            frame: Target frame. One of
-                ``{"base", "shoulder", "humerus", "forearm", "wrist", "gripper", "gripper_tip"}``.
-            max_iterations: Maximum number of iterations to run
-            learning_rate: Learning rate for gradient descent
-
+            position_only: If True, only match position (not orientation)
+            frame: Target frame name (if None, uses ee_frame_name)
+        
         Returns:
             Joint positions in degrees that achieve the desired end-effector pose
         """
-        # Do gradient descent.
-        current_joint_state = current_joint_pos.copy()
-        for _ in range(max_iterations):
-            current_ee_pose = self.forward_kinematics(current_joint_state, frame)
-            if not position_only:
-                error = se3_error(desired_ee_pose, current_ee_pose)
-                jac = self.compute_jacobian(current_joint_state, frame)
-            else:
-                error = desired_ee_pose[:3, 3] - current_ee_pose[:3, 3]
-                jac = self.compute_positional_jacobian(current_joint_state, frame)
-            delta_angles = np.linalg.pinv(jac) @ error
-            current_joint_state[:-1] += learning_rate * delta_angles
-
-            if np.linalg.norm(error) < 5e-3:
-                return current_joint_state
-        return current_joint_state
+        if frame is None:
+            frame = self.ee_frame_name
+        
+        # Convert current joint positions to radians for initial guess
+        current_joint_rad = np.deg2rad(current_joint_pos[:len(self.joint_names)])
+        
+        # Set current joint positions as initial guess
+        for i, joint_name in enumerate(self.joint_names):
+            self.robot.set_joint(joint_name, current_joint_rad[i])
+        
+        # Update the target pose for the frame task
+        self.tip_frame.T_world_frame = desired_ee_pose
+        
+        # Configure the task based on position_only flag
+        if position_only:
+            # Only constrain position, not orientation
+            self.tip_frame.configure(self.ee_frame_name, "soft", 1.0, 0.0)
+        else:
+            # Constrain both position and orientation
+            self.tip_frame.configure(self.ee_frame_name, "soft", 1.0, 1.0)
+        
+        # Solve IK
+        self.solver.solve(True)
+        self.robot.update_kinematics()
+        
+        # Extract joint positions
+        joint_positions_rad = []
+        for joint_name in self.joint_names:
+            joint = self.robot.get_joint(joint_name)
+            joint_positions_rad.append(joint)
+        
+        # Convert back to degrees
+        joint_positions_deg = np.rad2deg(joint_positions_rad)
+        
+        # Preserve gripper position if present in current_joint_pos
+        if len(current_joint_pos) > len(self.joint_names):
+            result = np.zeros_like(current_joint_pos)
+            result[:len(self.joint_names)] = joint_positions_deg
+            result[len(self.joint_names):] = current_joint_pos[len(self.joint_names):]
+            return result
+        else:
+            return joint_positions_deg

--- a/lerobot/common/model/kinematics.py
+++ b/lerobot/common/model/kinematics.py
@@ -1,97 +1,91 @@
 import numpy as np
 
 
-class PlacoRobotKinematics:
+class RobotKinematics:
     """Robot kinematics using placo library for forward and inverse kinematics."""
-    
+
     def __init__(self, urdf_path: str, ee_frame_name: str = "gripper_tip", joint_names: list[str] = None):
         """
         Initialize placo-based kinematics solver.
-        
+
         Args:
             urdf_path: Path to the robot URDF file
             ee_frame_name: Name of the end-effector frame in the URDF
             joint_names: List of joint names to control (if None, will use default naming)
         """
-        try:
-            import placo
-        except ImportError:
-            raise ImportError(
-                "placo is required for PlacoRobotKinematics. "
-                "Please install it with: pip install placo"
-            )
-        
+        import placo
+
         self.robot = placo.RobotWrapper(urdf_path)
         self.solver = placo.KinematicsSolver(self.robot)
         self.solver.mask_fbase(True)  # Fix the base
-        
+
         self.ee_frame_name = ee_frame_name
-        
+
         # Set joint names
         if joint_names is None:
             # Default joint names for SO-ARM100
             self.joint_names = ["1", "2", "3", "4", "5"]
         else:
             self.joint_names = joint_names
-        
+
         # Initialize frame task for IK
         self.tip_starting_pose = np.eye(4)
         self.tip_frame = self.solver.add_frame_task(self.ee_frame_name, self.tip_starting_pose)
         self.tip_frame.configure(self.ee_frame_name, "soft", 1.0, 1.0)
-    
+
     def forward_kinematics(self, robot_pos_deg, frame=None):
         """
         Compute forward kinematics for given joint configuration.
-        
+
         Args:
             robot_pos_deg: Joint positions in degrees (numpy array)
             frame: Target frame name (if None, uses ee_frame_name)
-        
+
         Returns:
             4x4 transformation matrix of the end-effector pose
         """
         if frame is None:
             frame = self.ee_frame_name
-        
+
         # Convert degrees to radians
-        robot_pos_rad = np.deg2rad(robot_pos_deg[:len(self.joint_names)])
-        
+        robot_pos_rad = np.deg2rad(robot_pos_deg[: len(self.joint_names)])
+
         # Update joint positions in placo robot
         for i, joint_name in enumerate(self.joint_names):
             self.robot.set_joint(joint_name, robot_pos_rad[i])
-        
+
         # Update kinematics
         self.robot.update_kinematics()
-        
+
         # Get the transformation matrix
         return self.robot.get_T_world_frame(frame)
-    
+
     def ik(self, current_joint_pos, desired_ee_pose, position_only=True, frame=None):
         """
         Compute inverse kinematics using placo solver.
-        
+
         Args:
             current_joint_pos: Current joint positions in degrees (used as initial guess)
             desired_ee_pose: Target end-effector pose as a 4x4 transformation matrix
             position_only: If True, only match position (not orientation)
             frame: Target frame name (if None, uses ee_frame_name)
-        
+
         Returns:
             Joint positions in degrees that achieve the desired end-effector pose
         """
         if frame is None:
             frame = self.ee_frame_name
-        
+
         # Convert current joint positions to radians for initial guess
-        current_joint_rad = np.deg2rad(current_joint_pos[:len(self.joint_names)])
-        
+        current_joint_rad = np.deg2rad(current_joint_pos[: len(self.joint_names)])
+
         # Set current joint positions as initial guess
         for i, joint_name in enumerate(self.joint_names):
             self.robot.set_joint(joint_name, current_joint_rad[i])
-        
+
         # Update the target pose for the frame task
         self.tip_frame.T_world_frame = desired_ee_pose
-        
+
         # Configure the task based on position_only flag
         if position_only:
             # Only constrain position, not orientation
@@ -99,25 +93,25 @@ class PlacoRobotKinematics:
         else:
             # Constrain both position and orientation
             self.tip_frame.configure(self.ee_frame_name, "soft", 1.0, 1.0)
-        
+
         # Solve IK
         self.solver.solve(True)
         self.robot.update_kinematics()
-        
+
         # Extract joint positions
         joint_positions_rad = []
         for joint_name in self.joint_names:
             joint = self.robot.get_joint(joint_name)
             joint_positions_rad.append(joint)
-        
+
         # Convert back to degrees
         joint_positions_deg = np.rad2deg(joint_positions_rad)
-        
+
         # Preserve gripper position if present in current_joint_pos
         if len(current_joint_pos) > len(self.joint_names):
             result = np.zeros_like(current_joint_pos)
-            result[:len(self.joint_names)] = joint_positions_deg
-            result[len(self.joint_names):] = current_joint_pos[len(self.joint_names):]
+            result[: len(self.joint_names)] = joint_positions_deg
+            result[len(self.joint_names) :] = current_joint_pos[len(self.joint_names) :]
             return result
         else:
             return joint_positions_deg

--- a/lerobot/common/robots/so100_follower/config_so100_follower.py
+++ b/lerobot/common/robots/so100_follower/config_so100_follower.py
@@ -44,6 +44,15 @@ class SO100FollowerConfig(RobotConfig):
 class SO100FollowerEndEffectorConfig(SO100FollowerConfig):
     """Configuration for the SO100FollowerEndEffector robot."""
 
+    # Path to URDF file for kinematics
+    urdf_path: str | None = None
+    
+    # End-effector frame name in the URDF
+    ee_frame_name: str = "gripperframe"
+    
+    # Joint names for kinematics (if None, uses default naming)
+    joint_names: list[str] | None = None
+
     # Default bounds for the end-effector position (in meters)
     end_effector_bounds: dict[str, list[float]] = field(
         default_factory=lambda: {

--- a/lerobot/common/robots/so100_follower/config_so100_follower.py
+++ b/lerobot/common/robots/so100_follower/config_so100_follower.py
@@ -46,10 +46,10 @@ class SO100FollowerEndEffectorConfig(SO100FollowerConfig):
 
     # Path to URDF file for kinematics
     urdf_path: str | None = None
-    
+
     # End-effector frame name in the URDF
     ee_frame_name: str = "gripperframe"
-    
+
     # Joint names for kinematics (if None, uses default naming)
     joint_names: list[str] | None = None
 

--- a/lerobot/common/robots/so100_follower/so100_follower_end_effector.py
+++ b/lerobot/common/robots/so100_follower/so100_follower_end_effector.py
@@ -22,7 +22,7 @@ import numpy as np
 
 from lerobot.common.cameras import make_cameras_from_configs
 from lerobot.common.errors import DeviceNotConnectedError
-from lerobot.common.model.kinematics import RobotKinematics
+from lerobot.common.model.kinematics_utils import PlacoRobotKinematics
 from lerobot.common.motors import Motor, MotorNormMode
 from lerobot.common.motors.feetech import FeetechMotorsBus
 
@@ -30,7 +30,6 @@ from . import SO100Follower
 from .config_so100_follower import SO100FollowerEndEffectorConfig
 
 logger = logging.getLogger(__name__)
-EE_FRAME = "gripper_tip"
 
 
 class SO100FollowerEndEffector(SO100Follower):
@@ -64,7 +63,17 @@ class SO100FollowerEndEffector(SO100Follower):
         self.config = config
 
         # Initialize the kinematics module for the so100 robot
-        self.kinematics = RobotKinematics(robot_type="so_new_calibration")
+        if self.config.urdf_path is None:
+            raise ValueError(
+                "urdf_path must be provided in the configuration for end-effector control. "
+                "Please set urdf_path in your SO100FollowerEndEffectorConfig."
+            )
+        
+        self.kinematics = PlacoRobotKinematics(
+            urdf_path=self.config.urdf_path,
+            ee_frame_name=self.config.ee_frame_name,
+            joint_names=self.config.joint_names
+        )
 
         # Store the bounds for end-effector position
         self.end_effector_bounds = self.config.end_effector_bounds
@@ -126,7 +135,7 @@ class SO100FollowerEndEffector(SO100Follower):
 
         # Calculate current end-effector position using forward kinematics
         if self.current_ee_pos is None:
-            self.current_ee_pos = self.kinematics.forward_kinematics(self.current_joint_pos, frame=EE_FRAME)
+            self.current_ee_pos = self.kinematics.forward_kinematics(self.current_joint_pos, frame=self.config.ee_frame_name)
 
         # Set desired end-effector position by adding delta
         desired_ee_pos = np.eye(4)
@@ -143,7 +152,7 @@ class SO100FollowerEndEffector(SO100Follower):
 
         # Compute inverse kinematics to get joint positions
         target_joint_values_in_degrees = self.kinematics.ik(
-            self.current_joint_pos, desired_ee_pos, position_only=True, frame=EE_FRAME
+            self.current_joint_pos, desired_ee_pos, position_only=True, frame=self.config.ee_frame_name
         )
 
         target_joint_values_in_degrees = np.clip(target_joint_values_in_degrees, -180.0, 180.0)

--- a/lerobot/common/robots/so100_follower/so100_follower_end_effector.py
+++ b/lerobot/common/robots/so100_follower/so100_follower_end_effector.py
@@ -22,7 +22,7 @@ import numpy as np
 
 from lerobot.common.cameras import make_cameras_from_configs
 from lerobot.common.errors import DeviceNotConnectedError
-from lerobot.common.model.kinematics_utils import PlacoRobotKinematics
+from lerobot.common.model.kinematics import RobotKinematics
 from lerobot.common.motors import Motor, MotorNormMode
 from lerobot.common.motors.feetech import FeetechMotorsBus
 
@@ -68,11 +68,11 @@ class SO100FollowerEndEffector(SO100Follower):
                 "urdf_path must be provided in the configuration for end-effector control. "
                 "Please set urdf_path in your SO100FollowerEndEffectorConfig."
             )
-        
-        self.kinematics = PlacoRobotKinematics(
+
+        self.kinematics = RobotKinematics(
             urdf_path=self.config.urdf_path,
             ee_frame_name=self.config.ee_frame_name,
-            joint_names=self.config.joint_names
+            joint_names=self.config.joint_names,
         )
 
         # Store the bounds for end-effector position
@@ -135,7 +135,7 @@ class SO100FollowerEndEffector(SO100Follower):
 
         # Calculate current end-effector position using forward kinematics
         if self.current_ee_pos is None:
-            self.current_ee_pos = self.kinematics.forward_kinematics(self.current_joint_pos, frame=self.config.ee_frame_name)
+            self.current_ee_pos = self.kinematics.forward_kinematics(self.current_joint_pos)
 
         # Set desired end-effector position by adding delta
         desired_ee_pos = np.eye(4)
@@ -152,7 +152,7 @@ class SO100FollowerEndEffector(SO100Follower):
 
         # Compute inverse kinematics to get joint positions
         target_joint_values_in_degrees = self.kinematics.ik(
-            self.current_joint_pos, desired_ee_pos, position_only=True, frame=self.config.ee_frame_name
+            self.current_joint_pos, desired_ee_pos, position_only=True
         )
 
         target_joint_values_in_degrees = np.clip(target_joint_values_in_degrees, -180.0, 180.0)

--- a/lerobot/scripts/rl/gym_manipulator.py
+++ b/lerobot/scripts/rl/gym_manipulator.py
@@ -1293,6 +1293,7 @@ class BaseLeaderControlWrapper(gym.Wrapper):
                 gripper_action = 1
 
             action = np.append(action, gripper_action)
+            action = torch.from_numpy(action).float()
 
         return action
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,6 @@ dependencies = [
     "pyserial>=3.5",
     "pyzmq>=26.2.1",
     "rerun-sdk>=0.21.0",
-    "scipy>=1.14.0",
     "termcolor>=2.4.0",
     "torch>=2.2.1",
     "torchcodec>=0.2.1; sys_platform != 'win32' and (sys_platform != 'linux' or (platform_machine != 'aarch64' and platform_machine != 'arm64' and platform_machine != 'armv7l')) and (sys_platform != 'darwin' or platform_machine != 'x86_64')",


### PR DESCRIPTION
## What this does

Replace our existing in-house kinematics implementation with one based on [placo](https://github.com/Rhoban/placo). Upgrading our linear IK solver with a QP solver from Placo allows for better handling of singularities and edge cases.

**NOTE:** These additions have been tested on the real robot with `gym_manipulator.py` with the So101 follower and the so101_leader and gamepad as teleop devices. Validated for teleoperation, interventions and recording a dataset.

### Key improvements:
- **Configuration-driven**: URDF path and frame names are now in the robot config  --> Before we relied on a set of measurements related to each link. The measurements were hard to adapt as they were done manually. Now we require the user to use the urdf for automatic adaption of the kinematics based on each robot.  
- **More robust IK solver**: placo's solver handles singularities and joint limits more gracefully
- **Fix bug in gym_manipulator.py**: Fixed a type issue in gym manip when recording a dataset with the so101 leader.

### Changes to config

The `SO100FollowerEndEffectorConfig` now requires additional parameters:

```python
@RobotConfig.register_subclass("so100_follower_end_effector")
@dataclass
class SO100FollowerEndEffectorConfig(SO100FollowerConfig):
    """Configuration for the SO100FollowerEndEffector robot."""

    # Path to URDF file for kinematics
    urdf_path: str | None = None

    # End-effector frame name in the URDF
    ee_frame_name: str = "gripperframe"

    # Joint names for kinematics (if None, uses default naming)
    joint_names: list[str] | None = None```
   
    # Rest of the parameters ....
```

### How to test

You can find example configs for testing [here](https://huggingface.co/datasets/aractingi/lerobot-example-config-files/tree/main)

Add the new arguments to your `robot` config:
```json
"robot": {
        "urdf_path": "/path/to/urdf/so101_new_calib.urdf",
        "ee_frame_name": "gripperframe", 
        "joint_names": [
            "1",
            "2",
            "3",
            "4",
            "5",
            "6"
        ],
        ...
        }
  ```
To test with a gamepad

```bash
# Test with gamepad control
python lerobot/scripts/rl/gym_manipulator.py --config_path path/to/env_config_so100.json
```

To test with an so101_leader

```bash
python lerobot/scripts/rl/gym_manipulator.py --config_path path/to/env_config_so100_leader.json
```
