### PR TITLE
Add keyboard teleoperation support for SO100/SO101 robot

### DIFF
--- a/lerobot/common/teleoperators/keyboard/configuration_keyboard.py
+++ b/lerobot/common/teleoperators/keyboard/configuration_keyboard.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from ..config import TeleoperatorConfig
 
@@ -24,6 +24,39 @@ from ..config import TeleoperatorConfig
 class KeyboardTeleopConfig(TeleoperatorConfig):
     # TODO(Steven): Consider setting in here the keys that we want to capture/listen
     mock: bool = False
+    
+    # Motor mappings for SO100 follower
+    motor_mappings: dict[str, dict[str, str]] = field(
+        default_factory=lambda: {
+            "shoulder_pan": {
+                "left": "a",
+                "right": "d",
+            },
+            "shoulder_lift": {
+                "up": "w",
+                "down": "s",
+            },
+            "elbow_flex": {
+                "up": "q",
+                "down": "e",
+            },
+            "wrist_flex": {
+                "up": "r",
+                "down": "f",
+            },
+            "wrist_roll": {
+                "left": "z",
+                "right": "x",
+            },
+            "gripper": {
+                "open": "g",
+                "close": "h",
+            },
+        }
+    )
+    
+    # Step size for each motor movement
+    step_size: float = 5.0
 
 
 @TeleoperatorConfig.register_subclass("keyboard_ee")

--- a/lerobot/common/teleoperators/keyboard/configuration_keyboard.py
+++ b/lerobot/common/teleoperators/keyboard/configuration_keyboard.py
@@ -24,7 +24,7 @@ from ..config import TeleoperatorConfig
 class KeyboardTeleopConfig(TeleoperatorConfig):
     # TODO(Steven): Consider setting in here the keys that we want to capture/listen
     mock: bool = False
-    
+
     # Motor mappings for SO100 follower
     motor_mappings: dict[str, dict[str, str]] = field(
         default_factory=lambda: {
@@ -54,7 +54,7 @@ class KeyboardTeleopConfig(TeleoperatorConfig):
             },
         }
     )
-    
+
     # Step size for each motor movement
     step_size: float = 5.0
 

--- a/lerobot/common/teleoperators/keyboard/teleop_keyboard.py
+++ b/lerobot/common/teleoperators/keyboard/teleop_keyboard.py
@@ -17,7 +17,6 @@
 import logging
 import os
 import sys
-import time
 from queue import Queue
 from typing import Any
 
@@ -59,12 +58,10 @@ class KeyboardTeleop(Teleoperator):
         self.current_pressed = {}
         self.listener = None
         self.logs = {}
-        
+
         # Initialize current positions
-        self.current_positions = {
-            f"{motor}.pos": 0.0 for motor in self.config.motor_mappings.keys()
-        }
-        
+        self.current_positions = {f"{motor}.pos": 0.0 for motor in self.config.motor_mappings.keys()}
+
         # Set limits for each motor
         self.motor_limits = {
             "shoulder_pan": (-100, 100),
@@ -72,7 +69,7 @@ class KeyboardTeleop(Teleoperator):
             "elbow_flex": (-100, 100),
             "wrist_flex": (-100, 100),
             "wrist_roll": (-100, 100),
-            "gripper": (0, 100), 
+            "gripper": (0, 100),
         }
 
     @property
@@ -143,12 +140,12 @@ class KeyboardTeleop(Teleoperator):
                 if key in self.current_pressed and self.current_pressed[key]:
                     min_val, max_val = self.motor_limits[motor]
                     current_val = self.current_positions[f"{motor}.pos"]
-                    
+
                     if direction in ["up", "right", "open"]:
                         new_val = min(current_val + self.config.step_size, max_val)
-                    else:  
+                    else:
                         new_val = max(current_val - self.config.step_size, min_val)
-                    
+
                     self.current_positions[f"{motor}.pos"] = new_val
 
         return self.current_positions

--- a/lerobot/teleoperate.py
+++ b/lerobot/teleoperate.py
@@ -58,7 +58,7 @@ from lerobot.common.utils.robot_utils import busy_wait
 from lerobot.common.utils.utils import init_logging, move_cursor_up
 from lerobot.common.utils.visualization_utils import _init_rerun
 
-from .common.teleoperators import gamepad, koch_leader, so100_leader, so101_leader  # noqa: F401
+from lerobot.common.teleoperators import gamepad, keyboard, koch_leader, so100_leader, so101_leader  # noqa: F401
 
 
 @dataclass
@@ -75,7 +75,6 @@ class TeleoperateConfig:
 def teleop_loop(
     teleop: Teleoperator, robot: Robot, fps: int, display_data: bool = False, duration: float | None = None
 ):
-    display_len = max(len(key) for key in robot.action_features)
     start = time.perf_counter()
     while True:
         loop_start = time.perf_counter()
@@ -94,14 +93,6 @@ def teleop_loop(
         robot.send_action(action)
         dt_s = time.perf_counter() - loop_start
         busy_wait(1 / fps - dt_s)
-
-        loop_s = time.perf_counter() - loop_start
-
-        print("\n" + "-" * (display_len + 10))
-        print(f"{'NAME':<{display_len}} | {'NORM':>7}")
-        for motor, value in action.items():
-            print(f"{motor:<{display_len}} | {value:>7.2f}")
-        print(f"\ntime: {loop_s * 1e3:.2f}ms ({1 / loop_s:.0f} Hz)")
 
         if duration is not None and time.perf_counter() - start >= duration:
             return

--- a/lerobot/teleoperate.py
+++ b/lerobot/teleoperate.py
@@ -49,16 +49,19 @@ from lerobot.common.robots import (  # noqa: F401
     so100_follower,
     so101_follower,
 )
-from lerobot.common.teleoperators import (
+from lerobot.common.teleoperators import (  # noqa: F401
     Teleoperator,
     TeleoperatorConfig,
+    gamepad,
+    keyboard,
+    koch_leader,
     make_teleoperator_from_config,
+    so100_leader,
+    so101_leader,
 )
 from lerobot.common.utils.robot_utils import busy_wait
 from lerobot.common.utils.utils import init_logging, move_cursor_up
 from lerobot.common.utils.visualization_utils import _init_rerun
-
-from lerobot.common.teleoperators import gamepad, keyboard, koch_leader, so100_leader, so101_leader  # noqa: F401
 
 
 @dataclass
@@ -75,6 +78,7 @@ class TeleoperateConfig:
 def teleop_loop(
     teleop: Teleoperator, robot: Robot, fps: int, display_data: bool = False, duration: float | None = None
 ):
+    display_len = max(len(key) for key in robot.action_features)
     start = time.perf_counter()
     while True:
         loop_start = time.perf_counter()
@@ -93,6 +97,14 @@ def teleop_loop(
         robot.send_action(action)
         dt_s = time.perf_counter() - loop_start
         busy_wait(1 / fps - dt_s)
+
+        loop_s = time.perf_counter() - loop_start
+
+        print("\n" + "-" * (display_len + 10))
+        print(f"{'NAME':<{display_len}} | {'NORM':>7}")
+        for motor, value in action.items():
+            print(f"{motor:<{display_len}} | {value:>7.2f}")
+        print(f"\ntime: {loop_s * 1e3:.2f}ms ({1 / loop_s:.0f} Hz)")
 
         if duration is not None and time.perf_counter() - start >= duration:
             return

--- a/teleoperate.py
+++ b/teleoperate.py
@@ -1,1 +1,0 @@
-from lerobot.common.teleoperators import gamepad, keyboard, koch_leader, so100_leader, so101_leader  # noqa: F401 

--- a/teleoperate.py
+++ b/teleoperate.py
@@ -1,0 +1,1 @@
+from lerobot.common.teleoperators import gamepad, keyboard, koch_leader, so100_leader, so101_leader  # noqa: F401 


### PR DESCRIPTION
## What this does
This PR adds keyboard teleoperation functionality to LeRobot, allowing users to control robots using keyboard inputs. This addresses the need for accessible teleoperation without requiring leader hardware and facilitating control in simulation environments.

|  Title               | Label           |
|----------------------|-----------------|
| Adds new teleoperation support for keyboard     | (Teleoperators)    |

## How it was tested
I ran the teleoperate.py script and moved a so100 arm using my keyboard, I also did the same in a local simulation environment (mujoco). Not part of this pr or the current lerobot repo.

## How to checkout & try? (for the reviewer)
connect a so100 or 101 arm, run teleoperate.py with the curretn instructions, just use  --teleop.type=keyboard instead of     --teleop.type=so101_leader 


