### PR TITLE
Add option to disable tags on WandB

### DIFF
--- a/lerobot/common/utils/wandb_utils.py
+++ b/lerobot/common/utils/wandb_utils.py
@@ -83,7 +83,7 @@ class WandBLogger:
             entity=self.cfg.entity,
             name=self.job_name,
             notes=self.cfg.notes,
-            tags=cfg_to_group(cfg, return_list=True),
+            tags=cfg_to_group(cfg, return_list=True) if self.cfg.add_tags else None,
             dir=self.log_dir,
             config=cfg.to_dict(),
             # TODO(rcadene): try set to True

--- a/lerobot/configs/default.py
+++ b/lerobot/configs/default.py
@@ -49,6 +49,7 @@ class WandBConfig:
     notes: str | None = None
     run_id: str | None = None
     mode: str | None = None  # Allowed values: 'online', 'offline' 'disabled'. Defaults to 'online'
+    add_tags: bool = True  # If True, save configuration as tags in the WandB run.
 
 
 @dataclass


### PR DESCRIPTION
## What this does

This PR adds an attribute to the WandBConfig class, allowing the users to disable the usage of tags in WandB.


## Why is it relevant ?

WandB tags are limited to 64 characters strings. If any of the items saved as a tag is larger than this limit, the training run will fail. Usually this limit is more than enough, but in the specific case of using locally cached datasets, the path to the dataset, which is saved as a tag, can surpass this limit. Specifically, this can happen when using the library in machines with no access to internet (i.e. computation servers), forcing the user to give the full path to the dataset instead of the HuggingFace dataset ID.


## How to test it

1. Launch a training run with tags, dataset will be cached
`python lerobot/scripts/train.py  --policy.type=act  --dataset.repo_id="lerobot/aloha_sim_transfer_cube_human_image"  --batch_size=2  --steps=100  --wandb.enable=true --output_dir=outputs/test_tags/  `

Training will run as expected

2. Launch a run given the full path to the dataset (simulating you don't have access to the internet)
`python lerobot/scripts/train.py  --policy.type=act  --dataset.repo_id="PATH_TO_YOUR_HOME/.cache/huggingface/lerobot/lerobot/aloha_sim_transfer_cube_human_image/"  --batch_size=2  --steps=100  --wandb.enable=true --output_dir=outputs/test_tags_2/ ` 

Training run will fail with the following error:
`wandb.errors.errors.CommError: Error uploading run: returned error 400: {"data":{"upsertBucket":null},"errors":[{"message":"invalid tag 'dataset:PATH_TO_YOUR_HOME/.cache/huggingface/lerobot/lerobot/aloha_sim_transfer_cube_human_image/'. must be between 1 and 64 characters","path":["upsertBucket"]}]}`

3. Launch a training run disabling the tags:
`python lerobot/scripts/train.py  --policy.type=act  --dataset.repo_id="lerobot/aloha_sim_transfer_cube_human_image"  --batch_size=2  --steps=100  --wandb.enable=true --output_dir=outputs/test_tags_3/  --wandb.add_tags=False`

Training run will run without errors, the wandb run will not have any tags added to it.