### PR TITLE
Optimizes training progress bar

### DIFF
--- a/lerobot/common/utils/logging_utils.py
+++ b/lerobot/common/utils/logging_utils.py
@@ -15,8 +15,9 @@
 # limitations under the License.
 from typing import Any
 
-from lerobot.common.utils.utils import format_big_number
 from termcolor import colored
+
+from lerobot.common.utils.utils import format_big_number
 
 
 class AverageMeter:
@@ -137,24 +138,32 @@ class MetricsTracker:
         # Create a progress bar
         progress = (self.steps / self._num_frames) * 100
         progress_bar = "=" * int(progress / 5) + ">" + " " * (20 - int(progress / 5))
-        
+
         # Format the metrics with colors
         metrics_str = (
-            f"\n{'='*80}\n"
+            f"\n{'=' * 80}\n"
             f"Training Progress: [{progress_bar}] {progress:.1f}%\n"
-            f"{'='*80}\n"
+            f"{'=' * 80}\n"
             f"Step: {colored(f'{format_big_number(self.steps)}', 'cyan')} / {format_big_number(self._num_frames)}\n"
             f"Samples: {colored(f'{format_big_number(self.samples)}', 'green')}\n"
             f"Episodes: {colored(f'{format_big_number(self.episodes)}', 'yellow')}\n"
             f"Epochs: {colored(f'{self.epochs:.2f}', 'magenta')}\n"
         )
-        
+
         # Add colored metrics
         for name, meter in self.metrics.items():
-            color = 'red' if name == 'loss' else 'blue' if name == 'grdn' else 'green' if name == 'lr' else 'yellow'
+            color = (
+                "red"
+                if name == "loss"
+                else "blue"
+                if name == "grdn"
+                else "green"
+                if name == "lr"
+                else "yellow"
+            )
             metrics_str += f"{name}: {colored(f'{meter.val:.3f}', color)}\n"
-            
-        metrics_str += f"{'='*80}"
+
+        metrics_str += f"{'=' * 80}"
         return metrics_str
 
     def to_dict(self, use_avg: bool = True) -> dict[str, int | float]:

--- a/lerobot/common/utils/logging_utils.py
+++ b/lerobot/common/utils/logging_utils.py
@@ -16,6 +16,7 @@
 from typing import Any
 
 from lerobot.common.utils.utils import format_big_number
+from termcolor import colored
 
 
 class AverageMeter:
@@ -133,17 +134,28 @@ class MetricsTracker:
         self.epochs = self.samples / self._num_frames
 
     def __str__(self) -> str:
-        display_list = [
-            f"step:{format_big_number(self.steps)}",
-            # number of samples seen during training
-            f"smpl:{format_big_number(self.samples)}",
-            # number of episodes seen during training
-            f"ep:{format_big_number(self.episodes)}",
-            # number of time all unique samples are seen
-            f"epch:{self.epochs:.2f}",
-            *[str(m) for m in self.metrics.values()],
-        ]
-        return " ".join(display_list)
+        # Create a progress bar
+        progress = (self.steps / self._num_frames) * 100
+        progress_bar = "=" * int(progress / 5) + ">" + " " * (20 - int(progress / 5))
+        
+        # Format the metrics with colors
+        metrics_str = (
+            f"\n{'='*80}\n"
+            f"Training Progress: [{progress_bar}] {progress:.1f}%\n"
+            f"{'='*80}\n"
+            f"Step: {colored(f'{format_big_number(self.steps)}', 'cyan')} / {format_big_number(self._num_frames)}\n"
+            f"Samples: {colored(f'{format_big_number(self.samples)}', 'green')}\n"
+            f"Episodes: {colored(f'{format_big_number(self.episodes)}', 'yellow')}\n"
+            f"Epochs: {colored(f'{self.epochs:.2f}', 'magenta')}\n"
+        )
+        
+        # Add colored metrics
+        for name, meter in self.metrics.items():
+            color = 'red' if name == 'loss' else 'blue' if name == 'grdn' else 'green' if name == 'lr' else 'yellow'
+            metrics_str += f"{name}: {colored(f'{meter.val:.3f}', color)}\n"
+            
+        metrics_str += f"{'='*80}"
+        return metrics_str
 
     def to_dict(self, use_avg: bool = True) -> dict[str, int | float]:
         """


### PR DESCRIPTION
## What this does
Previously progress bar was hard to read. This PR tries to make the PR more visually appealing.

<img width="595" alt="Screenshot 2025-06-18 at 9 19 15 PM" src="https://github.com/user-attachments/assets/6a83ec72-10cc-40b0-ba8e-797aa1dfd895" />

## How it was tested
Manually by running the train.py script

```
python lerobot/scripts/train.py   --policy.path=lerobot/smolvla_base   --dataset.repo_id=harshav17/salt-test   --batch_size=48   --steps=20000   --output_dir=outputs/train/my_smolvla   --job_name=my_smolvla_training   --policy.device=cuda   --wandb.enable=true
```

## How to checkout & try? (for the reviewer)
Simply run the following script to train smolvla_base model.

```bash
python lerobot/scripts/train.py   --policy.path=lerobot/smolvla_base   --dataset.repo_id=harshav17/salt-test   --batch_size=48   --steps=20000   --output_dir=outputs/train/my_smolvla   --job_name=my_smolvla_training   --policy.device=cuda   --wandb.enable=true
```

## SECTION TO REMOVE BEFORE SUBMITTING YOUR PR
**Note**: Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR. Try to avoid tagging more than 3 people.

**Note**: Before submitting this PR, please read the [contributor guideline](https://github.com/huggingface/lerobot/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr).
