### PR TITLE
fix `pi0` with pretrained weights (#1107)

### DIFF
--- a/lerobot/common/policies/pi0/paligemma_with_expert.py
+++ b/lerobot/common/policies/pi0/paligemma_with_expert.py
@@ -20,6 +20,7 @@ from pytest import Cache
 from torch import nn
 from transformers import (
     AutoConfig,
+    AutoModel,
     GemmaForCausalLM,
     PaliGemmaForConditionalGeneration,
     PretrainedConfig,
@@ -174,7 +175,7 @@ class PaliGemmaWithExpertModel(PreTrainedModel):
     def __init__(self, config: PaliGemmaWithExpertConfig):
         super().__init__(config=config)
         self.config = config
-        self.paligemma = PaliGemmaForConditionalGeneration(config=config.paligemma_config)
+        self.paligemma = AutoModel.from_pretrained("google/paligemma-3b-pt-224")
         self.gemma_expert = GemmaForCausalLM(config=config.gemma_expert_config)
         # Remove unused embed_tokens
         self.gemma_expert.model.embed_tokens = None


### PR DESCRIPTION
Fix `pi0` policy to load the pretrianed weights. #1107 