### PR TITLE
Fixed Failed Symlink in Dockerfile

### DIFF
--- a/docker/lerobot-cpu/Dockerfile
+++ b/docker/lerobot-cpu/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential cmake git \
     libglib2.0-0 libgl1-mesa-glx libegl1-mesa ffmpeg \
     speech-dispatcher libgeos-dev \
-    && ln -s /usr/bin/python${PYTHON_VERSION} /usr/bin/python \
+    && ln -s /usr/local/bin/python${PYTHON_VERSION} /usr/bin/python \
     && python -m venv /opt/venv \
     && apt-get clean && rm -rf /var/lib/apt/lists/* \
     && echo "source /opt/venv/bin/activate" >> /root/.bashrc


### PR DESCRIPTION
## What this does
Fixed the symlink for python in cpu dockerfile. This failed link caused problems down the line for certain workflows. 

## How it was tested
1. /usr/bin/python is confirmed to exist in the image
2. The updated dockerfile works in my cloud workflow 

## How to checkout & try? (for the reviewer)
1. (Re)Build the docker
2. Check that `/usr/bin/python` opens python3.10

**Note**: Before submitting this PR, please read the [contributor guideline](https://github.com/huggingface/lerobot/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr).
