### PR TITLE
Update assembly instructions to match outputs from 'python -m lerobot.setup_motors' script

### DIFF
--- a/lerobot/common/robots/so101_follower/so101.mdx
+++ b/lerobot/common/robots/so101_follower/so101.mdx
@@ -22,11 +22,11 @@ The follower arm uses 6x STS3215 motors with 1/345 gearing. The leader, however,
 
 | Leader-Arm Axis | Motor | Gear Ratio |
 |-----------------|:-------:|:----------:|
-| Base / Shoulder Yaw | 1 | 1 / 191 |
-| Shoulder Pitch      | 2 | 1 / 345 |
-| Elbow               | 3 | 1 / 191 |
-| Wrist Roll          | 4 | 1 / 147 |
-| Wrist Pitch         | 5 | 1 / 147 |
+| Base / Shoulder Pan | 1 | 1 / 191 |
+| Shoulder Lift       | 2 | 1 / 345 |
+| Elbow Flex          | 3 | 1 / 191 |
+| Wrist Flex          | 4 | 1 / 147 |
+| Wrist Roll          | 5 | 1 / 147 |
 | Gripper             | 6 | 1 / 147 |
 
 ### Clean Parts


### PR DESCRIPTION
## What this does

Update docs to match what setup motors sript outputs: 

== LEADER
python -m lerobot.setup_motors --teleop.type=so101_leader --teleop.port=/dev/tty.usbmodem5A680087821

Connect the controller board to the 'gripper' motor only and press enter.
'gripper' motor id set to 6
Connect the controller board to the 'wrist_roll' motor only and press enter.
'wrist_roll' motor id set to 5
Connect the controller board to the 'wrist_flex' motor only and press enter.
'wrist_flex' motor id set to 4
Connect the controller board to the 'elbow_flex' motor only and press enter.
'elbow_flex' motor id set to 3
Connect the controller board to the 'shoulder_lift' motor only and press enter.
'shoulder_lift' motor id set to 2
Connect the controller board to the 'shoulder_pan' motor only and press enter.
'shoulder_pan' motor id set to 1


== FOLLOWER
python -m lerobot.setup_motors --robot.type=so101_follower --robot.port=/dev/tty.usbmodem5A680105781

Connect the controller board to the 'gripper' motor only and press enter.
'gripper' motor id set to 6
Connect the controller board to the 'wrist_roll' motor only and press enter.
'wrist_roll' motor id set to 5
Connect the controller board to the 'wrist_flex' motor only and press enter.
'wrist_flex' motor id set to 4
Connect the controller board to the 'elbow_flex' motor only and press enter.
'elbow_flex' motor id set to 3
Connect the controller board to the 'shoulder_lift' motor only and press enter.
'shoulder_lift' motor id set to 2
Connect the controller board to the 'shoulder_pan' motor only and press enter.
'shoulder_pan' motor id set to 1

