### PR TITLE
Fix the bug in crop_dataset_roi.py

### DIFF
--- a/lerobot/scripts/rl/crop_dataset_roi.py
+++ b/lerobot/scripts/rl/crop_dataset_roi.py
@@ -214,9 +214,14 @@ def convert_lerobot_dataset_to_cropper_lerobot_dataset(
         for key, value in frame.items():
             if key in ("task_index", "timestamp", "episode_index", "frame_index", "index", "task"):
                 continue
-            if key in ("next.done", "next.reward"):
-                # if not isinstance(value, str) and len(value.shape) == 0:
-                value = value.unsqueeze(0)
+                
+            # Ensure scalar values are properly shaped as (1,)
+            if isinstance(value, (int, float)) or (hasattr(value, 'ndim') and value.ndim == 0):
+                value = value.unsqueeze(0) if hasattr(value, 'unsqueeze') else np.array([value])
+            # Handle special cases like next.done, next.reward, and complementary_info.*
+            elif key in ("next.done", "next.reward") or key.startswith("complementary_info"):
+                if hasattr(value, 'ndim') and value.ndim == 0:
+                    value = value.unsqueeze(0) if hasattr(value, 'unsqueeze') else np.array([value])
 
             if key in crop_params_dict:
                 top, left, height, width = crop_params_dict[key]

--- a/lerobot/scripts/rl/crop_dataset_roi.py
+++ b/lerobot/scripts/rl/crop_dataset_roi.py
@@ -214,14 +214,14 @@ def convert_lerobot_dataset_to_cropper_lerobot_dataset(
         for key, value in frame.items():
             if key in ("task_index", "timestamp", "episode_index", "frame_index", "index", "task"):
                 continue
-                
+
             # Ensure scalar values are properly shaped as (1,)
-            if isinstance(value, (int, float)) or (hasattr(value, 'ndim') and value.ndim == 0):
-                value = value.unsqueeze(0) if hasattr(value, 'unsqueeze') else np.array([value])
+            if isinstance(value, (int, float)) or (hasattr(value, "ndim") and value.ndim == 0):
+                value = value.unsqueeze(0) if hasattr(value, "unsqueeze") else np.array([value])
             # Handle special cases like next.done, next.reward, and complementary_info.*
             elif key in ("next.done", "next.reward") or key.startswith("complementary_info"):
-                if hasattr(value, 'ndim') and value.ndim == 0:
-                    value = value.unsqueeze(0) if hasattr(value, 'unsqueeze') else np.array([value])
+                if hasattr(value, "ndim") and value.ndim == 0:
+                    value = value.unsqueeze(0) if hasattr(value, "unsqueeze") else np.array([value])
 
             if key in crop_params_dict:
                 top, left, height, width = crop_params_dict[key]


### PR DESCRIPTION
Fix the bug: `ValueError: The feature 'complementary_info.discrete_penalty' of shape '()' does not have the expected shape '(1,)'` to prevent errors when running `crop_dataset_roi` in hil-serl.