### PR TITLE
Fix bug when n_obs_steps=1 for diffusion policy

### DIFF
--- a/lerobot/common/policies/diffusion/modeling_diffusion.py
+++ b/lerobot/common/policies/diffusion/modeling_diffusion.py
@@ -136,7 +136,7 @@ class DiffusionPolicy(PreTrainedPolicy):
         batch = self.normalize_inputs(batch)
         if self.config.image_features:
             batch = dict(batch)  # shallow copy so that adding a key doesn't modify the original
-            batch[OBS_IMAGES] = torch.stack([batch[key] for key in self.config.image_features], dim=-4)
+            batch[OBS_IMAGES] = torch.stack([batch[key].unsqueeze(1) if batch[key].ndim == 4 else batch[key] for key in self.config.image_features], dim=-4)
         # Note: It's important that this happens after stacking the images into a single key.
         self._queues = populate_queues(self._queues, batch)
 
@@ -152,7 +152,7 @@ class DiffusionPolicy(PreTrainedPolicy):
         batch = self.normalize_inputs(batch)
         if self.config.image_features:
             batch = dict(batch)  # shallow copy so that adding a key doesn't modify the original
-            batch[OBS_IMAGES] = torch.stack([batch[key] for key in self.config.image_features], dim=-4)
+            batch[OBS_IMAGES] = torch.stack([batch[key].unsqueeze(1) if batch[key].ndim == 4 else batch[key] for key in self.config.image_features], dim=-4)
         batch = self.normalize_targets(batch)
         loss = self.diffusion.compute_loss(batch)
         # no output_dict so returning None


### PR DESCRIPTION
## What this does
Currently, it is unable to train diffusion policy when policy.n_obs_steps=1. When policy.n_obs_steps = 1, the shape of batch["observation.images"] is (batch_size, 3, 84, 84) instead of (batch_size, 1, 3, 84, 84) causing size mismatch for training.
So address this, it unsqueeze batch["observation.images"] is ndim is less than 5 in `forward` and `select_action` functions for `DiffusionPolicy` class.

## How to checkout & try? (for the reviewer)
```
python lerobot/scripts/train.py  --dataset.repo_id=lerobot/pusht --policy.type=diffusion --env.type=pusht --policy.n_obs_steps=1 
```