### PR TITLE
Add a New Experiment Tracker: `SwanLab`

### DIFF
--- a/lerobot/common/utils/swanlab_utils.py
+++ b/lerobot/common/utils/swanlab_utils.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python
+
+# Copyright 2024 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+import re
+from glob import glob
+from pathlib import Path
+
+from huggingface_hub.constants import SAFETENSORS_SINGLE_FILE
+from termcolor import colored
+
+from lerobot.common.constants import PRETRAINED_MODEL_DIR
+from lerobot.configs.train import TrainPipelineConfig
+
+
+def cfg_to_group(cfg: TrainPipelineConfig, return_list: bool = False) -> list[str] | str:
+    """Return a group name for logging. Optionally returns group name as list."""
+    lst = [
+        f"policy:{cfg.policy.type}",
+        f"seed:{cfg.seed}",
+    ]
+    if cfg.dataset is not None:
+        lst.append(f"dataset:{cfg.dataset.repo_id}")
+    if cfg.env is not None:
+        lst.append(f"env:{cfg.env.type}")
+    return lst if return_list else "-".join(lst)
+
+
+def get_swanlab_run_id_from_filesystem(log_dir: Path) -> str:
+    # Get the SwanLab run ID.
+    paths = glob(str(log_dir / "swanlab/latest-run/run-*"))
+    if len(paths) != 1:
+        raise RuntimeError("Couldn't get the previous SwanLab run ID for run resumption.")
+    match = re.search(r"run-([^\.]+).swanlab", paths[0].split("/")[-1])
+    if match is None:
+        raise RuntimeError("Couldn't get the previous SwanLab run ID for run resumption.")
+    swanlab_run_id = match.groups(0)[0]
+    return swanlab_run_id
+
+
+def get_safe_swanlab_artifact_name(name: str):
+    """SwanLab artifacts don't accept ":" or "/" in their name."""
+    return name.replace(":", "_").replace("/", "_")
+
+
+class SwanLabLogger:
+    """A helper class to log object using swanlab."""
+
+    def __init__(self, cfg: TrainPipelineConfig):
+        self.cfg = cfg.swanlab
+        self.log_dir = cfg.output_dir
+        self.job_name = cfg.job_name
+        self.env_fps = cfg.env.fps if cfg.env else None
+        self._group = cfg_to_group(cfg)
+
+        import swanlab
+
+        swanlab_run_id = (
+            cfg.swanlab.run_id
+            if cfg.swanlab.run_id
+            else get_swanlab_run_id_from_filesystem(self.log_dir)
+            if cfg.resume
+            else None
+        )
+        self._run = swanlab.init(
+            run_id=swanlab_run_id,
+            project=self.cfg.project,
+            experiment_name=self.job_name,
+            description=self.cfg.notes,
+            tags=cfg_to_group(cfg, return_list=True),
+            logdir=str(self.log_dir),
+            config=cfg.to_dict(),
+            save_code=False,
+            resume=cfg.resume,
+            mode=self.cfg.mode if self.cfg.mode in ["online", "offline", "disabled"] else "online",
+        )
+        run_id = self._run.run_id
+        # NOTE: We will override the cfg.swanlab.run_id with the swanlab run id.
+        # This is because we want to be able to resume the run from the swanlab run id.
+        cfg.swanlab.run_id = run_id
+        # Handle custom step key for rl asynchronous training.
+        self._swanlab_custom_step_key: set[str] | None = None
+        print(colored("Logs will be synced with swanlab.", "blue", attrs=["bold"]))
+        logging.info(f"Track this run --> {colored(self._run.url, 'yellow', attrs=['bold'])}")
+        self._swanlab = swanlab
+
+    def log_policy(self, checkpoint_dir: Path):
+        """Checkpoints the policy to swanlab."""
+        if self.cfg.disable_artifact:
+            return
+
+        step_id = checkpoint_dir.name
+        artifact_name = f"{self._group}-{step_id}"
+        artifact_name = get_safe_swanlab_artifact_name(artifact_name)
+        # SwanLab doesn't have direct artifact logging like wandb
+        # We'll log the model file path as a text log for now
+        model_path = str(checkpoint_dir / PRETRAINED_MODEL_DIR / SAFETENSORS_SINGLE_FILE)
+        self._swanlab.log({f"model_checkpoint/{step_id}": model_path})
+
+    def log_dict(
+        self, d: dict, step: int | None = None, mode: str = "train", custom_step_key: str | None = None
+    ):
+        if mode not in {"train", "eval"}:
+            raise ValueError(mode)
+        if step is None and custom_step_key is None:
+            raise ValueError("Either step or custom_step_key must be provided.")
+
+        # NOTE: This is not simple. SwanLab step must always monotonically increase and it
+        # increases with each swanlab.log call, but in the case of asynchronous RL for example,
+        # multiple time steps is possible. For example, the interaction step with the environment,
+        # the training step, the evaluation step, etc. So we need to define a custom step key
+        # to log the correct step for each metric.
+        if custom_step_key is not None:
+            if self._swanlab_custom_step_key is None:
+                self._swanlab_custom_step_key = set()
+            new_custom_key = f"{mode}/{custom_step_key}"
+            if new_custom_key not in self._swanlab_custom_step_key:
+                self._swanlab_custom_step_key.add(new_custom_key)
+
+        for k, v in d.items():
+            if not isinstance(v, (int, float, str)):
+                logging.warning(
+                    f'SwanLab logging of key "{k}" was ignored as its type "{type(v)}" is not handled by this wrapper.'
+                )
+                continue
+
+            # Do not log the custom step key itself.
+            if self._swanlab_custom_step_key is not None and k in self._swanlab_custom_step_key:
+                continue
+
+            if custom_step_key is not None:
+                value_custom_step = d[custom_step_key]
+                data = {f"{mode}/{k}": v, f"{mode}/{custom_step_key}": value_custom_step}
+                self._swanlab.log(data)
+                continue
+
+            self._swanlab.log(data={f"{mode}/{k}": v}, step=step)
+
+    def log_video(self, video_path: str, step: int, mode: str = "train"):
+        if mode not in {"train", "eval"}:
+            raise ValueError(mode)
+
+        # SwanLab media logging - using Media.Video for video logging
+        swanlab_video = self._swanlab.Video(video_path, fps=self.env_fps)
+        self._swanlab.log({f"{mode}/video": swanlab_video}, step=step)

--- a/lerobot/common/utils/swanlab_utils.py
+++ b/lerobot/common/utils/swanlab_utils.py
@@ -75,9 +75,8 @@ class SwanLabLogger:
             else None
         )
         self._run = swanlab.init(
-            run_id=swanlab_run_id,
             project=self.cfg.project,
-            experiment_name=self.job_name,
+            experiment_name=swanlab_run_id,
             description=self.cfg.notes,
             tags=cfg_to_group(cfg, return_list=True),
             logdir=str(self.log_dir),
@@ -86,14 +85,14 @@ class SwanLabLogger:
             resume=cfg.resume,
             mode=self.cfg.mode if self.cfg.mode in ["online", "offline", "disabled"] else "online",
         )
-        run_id = self._run.run_id
+        run_id = self._run.public.run_id
         # NOTE: We will override the cfg.swanlab.run_id with the swanlab run id.
         # This is because we want to be able to resume the run from the swanlab run id.
         cfg.swanlab.run_id = run_id
         # Handle custom step key for rl asynchronous training.
         self._swanlab_custom_step_key: set[str] | None = None
         print(colored("Logs will be synced with swanlab.", "blue", attrs=["bold"]))
-        logging.info(f"Track this run --> {colored(self._run.url, 'yellow', attrs=['bold'])}")
+        logging.info(f"Track this run --> {colored(self._run.public.cloud.experiment_url, 'yellow', attrs=['bold'])}")
         self._swanlab = swanlab
 
     def log_policy(self, checkpoint_dir: Path):

--- a/lerobot/configs/default.py
+++ b/lerobot/configs/default.py
@@ -41,7 +41,19 @@ class DatasetConfig:
 
 @dataclass
 class WandBConfig:
-    enable: bool = False
+    enable: bool = False  # wandb.enable is deprecated, use tracker="wandb" or tracker="both" in train.py, it will be removed in the future
+    # Set to true to disable saving an artifact despite training.save_checkpoint=True
+    disable_artifact: bool = False
+    project: str = "lerobot"
+    entity: str | None = None
+    notes: str | None = None
+    run_id: str | None = None
+    mode: str | None = None  # Allowed values: 'online', 'offline' 'disabled'. Defaults to 'online'
+
+
+@dataclass
+class SwanLabConfig:
+    enable: bool = False  # swanlab.enable is deprecated, use tracker="swanlab" or tracker="both" in train.py, it will be removed in the future
     # Set to true to disable saving an artifact despite training.save_checkpoint=True
     disable_artifact: bool = False
     project: str = "lerobot"

--- a/lerobot/configs/train.py
+++ b/lerobot/configs/train.py
@@ -26,7 +26,7 @@ from lerobot.common.optim import OptimizerConfig
 from lerobot.common.optim.schedulers import LRSchedulerConfig
 from lerobot.common.utils.hub import HubMixin
 from lerobot.configs import parser
-from lerobot.configs.default import DatasetConfig, EvalConfig, WandBConfig
+from lerobot.configs.default import DatasetConfig, EvalConfig, SwanLabConfig, WandBConfig
 from lerobot.configs.policies import PreTrainedConfig
 
 TRAIN_CONFIG_NAME = "train_config.json"
@@ -62,12 +62,27 @@ class TrainPipelineConfig(HubMixin):
     optimizer: OptimizerConfig | None = None
     scheduler: LRSchedulerConfig | None = None
     eval: EvalConfig = field(default_factory=EvalConfig)
+    # Select experiment tracker: "wandb", "swanlab", "both", or "none"
+    tracker: str = "none"
     wandb: WandBConfig = field(default_factory=WandBConfig)
+    swanlab: SwanLabConfig = field(default_factory=SwanLabConfig)
 
     def __post_init__(self):
         self.checkpoint_path = None
 
     def validate(self):
+        # Validate tracker selection
+        if self.tracker not in ["wandb", "swanlab", "both", "none"]:
+            raise ValueError(
+                f"tracker must be one of 'wandb', 'swanlab', 'both', or 'none', got '{self.tracker}'"
+            )
+
+        # Enable the selected trackers
+        if self.tracker in ["wandb", "both"]:
+            self.wandb.enable = True
+        if self.tracker in ["swanlab", "both"]:
+            self.swanlab.enable = True
+
         # HACK: We parse again the cli args here to get the pretrained paths if there was some.
         policy_path = parser.get_path_arg("policy")
         if policy_path:

--- a/lerobot/scripts/train.py
+++ b/lerobot/scripts/train.py
@@ -34,6 +34,7 @@ from lerobot.common.policies.pretrained import PreTrainedPolicy
 from lerobot.common.policies.utils import get_device_from_parameters
 from lerobot.common.utils.logging_utils import AverageMeter, MetricsTracker
 from lerobot.common.utils.random_utils import set_seed
+from lerobot.common.utils.swanlab_utils import SwanLabLogger
 from lerobot.common.utils.train_utils import (
     get_step_checkpoint_dir,
     get_step_identifier,
@@ -110,10 +111,17 @@ def train(cfg: TrainPipelineConfig):
     cfg.validate()
     logging.info(pformat(cfg.to_dict()))
 
-    if cfg.wandb.enable and cfg.wandb.project:
+    # Initialize loggers based on tracker selection
+    wandb_logger = None
+    swanlab_logger = None
+
+    if cfg.tracker in ["wandb", "both"] and cfg.wandb.project:
         wandb_logger = WandBLogger(cfg)
-    else:
-        wandb_logger = None
+
+    if cfg.tracker in ["swanlab", "both"] and cfg.swanlab.project:
+        swanlab_logger = SwanLabLogger(cfg)
+
+    if cfg.tracker == "none" or (not wandb_logger and not swanlab_logger):
         logging.info(colored("Logs will be saved locally.", "yellow", attrs=["bold"]))
 
     if cfg.seed is not None:
@@ -235,6 +243,11 @@ def train(cfg: TrainPipelineConfig):
                 if output_dict:
                     wandb_log_dict.update(output_dict)
                 wandb_logger.log_dict(wandb_log_dict, step)
+            if swanlab_logger:
+                swanlab_log_dict = train_tracker.to_dict()
+                if output_dict:
+                    swanlab_log_dict.update(output_dict)
+                swanlab_logger.log_dict(swanlab_log_dict, step)
             train_tracker.reset_averages()
 
         if cfg.save_checkpoint and is_saving_step:
@@ -244,6 +257,8 @@ def train(cfg: TrainPipelineConfig):
             update_last_checkpoint(checkpoint_dir)
             if wandb_logger:
                 wandb_logger.log_policy(checkpoint_dir)
+            if swanlab_logger:
+                swanlab_logger.log_policy(checkpoint_dir)
 
         if cfg.env and is_eval_step:
             step_id = get_step_identifier(step, cfg.steps)
@@ -277,6 +292,10 @@ def train(cfg: TrainPipelineConfig):
                 wandb_log_dict = {**eval_tracker.to_dict(), **eval_info}
                 wandb_logger.log_dict(wandb_log_dict, step, mode="eval")
                 wandb_logger.log_video(eval_info["video_paths"][0], step, mode="eval")
+            if swanlab_logger:
+                swanlab_log_dict = {**eval_tracker.to_dict(), **eval_info}
+                swanlab_logger.log_dict(swanlab_log_dict, step, mode="eval")
+                swanlab_logger.log_video(eval_info["video_paths"][0], step, mode="eval")
 
     if eval_env:
         eval_env.close()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ dependencies = [
     "torchvision>=0.21.0",
     "wandb>=0.16.3",
     "zarr>=2.17.0",
+    "swanlab>=0.6.4",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This pull request introduces support for [SwanLab](https://swanlab.cn/) as an experiment tracker alongside WandB in the training pipeline. Key changes include the addition of a `SwanLabLogger` utility, updates to configuration classes, and modifications to the training script to integrate SwanLab logging. 

### SwanLab Integration:

* [`lerobot/common/utils/swanlab_utils.py`](diffhunk://#diff-b16f90ef2f795551af6c6d4817d6ecde85f77c5989b49f130fa694f570871a25R1-R156): Added a new utility module containing the `SwanLabLogger` class for logging metrics, policies, and videos to SwanLab. This includes helper functions for generating group names, retrieving run IDs, and sanitizing artifact names.
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R78): Added `swanlab>=0.6.4` as a dependency to enable SwanLab integration.

### Configuration Updates:

* [`lerobot/configs/default.py`](diffhunk://#diff-bb67f2b9b6839cd7be2bfbcb541397a7169c763511ddfaa31274ec431d4e364dL44-R56): Introduced a new `SwanLabConfig` class for SwanLab-specific configurations, such as enabling/disabling artifacts, specifying project details, and setting the tracking mode. Updated `WandBConfig` with a deprecation notice for `enable` and additional fields for better compatibility with the new tracking system.
* [`lerobot/configs/train.py`](diffhunk://#diff-36141b51406d27903db0a7a9762c842d5e3ed9ed468691bdeb6ba5bf39d71dc1R65-R85): Updated `TrainPipelineConfig` to include a `tracker` field for selecting between "wandb," "swanlab," "both," or "none." Added validation logic to ensure valid tracker selection and enable the appropriate configuration dynamically. [[1]](diffhunk://#diff-36141b51406d27903db0a7a9762c842d5e3ed9ed468691bdeb6ba5bf39d71dc1R65-R85) [[2]](diffhunk://#diff-36141b51406d27903db0a7a9762c842d5e3ed9ed468691bdeb6ba5bf39d71dc1L29-R29)

### Training Script Enhancements:

* [`lerobot/scripts/train.py`](diffhunk://#diff-761a7396d3124db635877cc8a1d6a1bb22086ab54fa3c6ee099dc6ed23246828L113-R124): Modified the training script to initialize and use `SwanLabLogger` based on the selected tracker. Added support for logging metrics, policies, and videos to SwanLab during training and evaluation phases. [[1]](diffhunk://#diff-761a7396d3124db635877cc8a1d6a1bb22086ab54fa3c6ee099dc6ed23246828L113-R124) [[2]](diffhunk://#diff-761a7396d3124db635877cc8a1d6a1bb22086ab54fa3c6ee099dc6ed23246828R246-R250) [[3]](diffhunk://#diff-761a7396d3124db635877cc8a1d6a1bb22086ab54fa3c6ee099dc6ed23246828R260-R261) [[4]](diffhunk://#diff-761a7396d3124db635877cc8a1d6a1bb22086ab54fa3c6ee099dc6ed23246828R295-R298)
