### PR TITLE
Fix pi0 checkpoint state map

### DIFF
--- a/src/lerobot/policies/pi0/modeling_pi0.py
+++ b/src/lerobot/policies/pi0/modeling_pi0.py
@@ -49,7 +49,6 @@ policy = Pi0Policy.from_pretrained("lerobot/pi0")
 
 """
 
-import logging
 import math
 from collections import deque
 
@@ -66,6 +65,7 @@ from lerobot.policies.pi0.paligemma_with_expert import (
     PaliGemmaWithExpertModel,
 )
 from lerobot.policies.pretrained import PreTrainedPolicy
+from lerobot.policies.utils import log_model_loading_keys
 from lerobot.utils.utils import get_safe_dtype, init_logging
 
 
@@ -348,14 +348,7 @@ class PI0Policy(PreTrainedPolicy):
         msg = model.load_state_dict(transformed_state_dict, strict=strict)
 
         # Log message
-        if hasattr(msg, "missing_keys") and len(msg.missing_keys) > 0:
-            logging.warning("Missing key(s):")
-            for k in msg.missing_keys:
-                logging.warning(f"    {k}")
-        if hasattr(msg, "unexpected_keys") and len(msg.unexpected_keys) > 0:
-            logging.warning("Unexpected key(s):")
-            for k in msg.unexpected_keys:
-                logging.warning(f"    {k}")
+        log_model_loading_keys(msg.missing_keys, msg.unexpected_keys)
         return model
 
     def get_optim_params(self) -> dict:

--- a/src/lerobot/policies/utils.py
+++ b/src/lerobot/policies/utils.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 from collections import deque
 
 import torch
@@ -71,3 +72,16 @@ def get_output_shape(module: nn.Module, input_shape: tuple) -> tuple:
     with torch.inference_mode():
         output = module(dummy_input)
     return tuple(output.shape)
+
+
+def log_model_loading_keys(missing_keys: list[str], unexpected_keys: list[str]) -> None:
+    """Log missing and unexpected keys when loading a model.
+
+    Args:
+        missing_keys (list[str]): Keys that were expected but not found.
+        unexpected_keys (list[str]): Keys that were found but not expected.
+    """
+    if missing_keys:
+        logging.warning(f"Missing key(s) when loading model: {missing_keys}")
+    if unexpected_keys:
+        logging.warning(f"Unexpected key(s) when loading model: {unexpected_keys}")


### PR DESCRIPTION
The issue about this bug is #1406, which is probably caused by huggingface/transformers#37033. In the [v4.52.1 release](https://github.com/huggingface/transformers/releases/tag/v4.52.1) of the transformers library, https://github.com/huggingface/transformers/pull/37033 introduced a bug by renaming the class `PaliGemmaForConditionalGeneration(PaliGemmaPreTrainedModel, GenerationMixin)` to class `PaliGemmaModel(PaliGemmaPreTrainedModel)`.


This pull request introduces enhancements to the `PI0Policy` class in `lerobot/common/policies/pi0/modeling_pi0.py` to improve model state handling. The changes include adding a method to transform state dictionary keys and a class method to load model weights as `safetensor` files, ensuring compatibility with expected model structures. Solved #1406.

### Enhancements to model state handling:

* **Key transformation for state dictionaries**: Added `_transform_state_dict_keys` method to modify state dictionary keys for compatibility with expected model structure. This includes specific transformations for `PaliGemma` components to ensure proper mapping of model layers.

* **Support for `safetensor` file loading**: Introduced `_load_as_safetensor` class method to load model weights from `safetensor` files. This method applies the key transformations before loading the state dictionary into the model.
* Apply transformations for PaliGemma components
  * `model.paligemma_with_expert.paligemma.language_model.lm_head` -> `model.paligemma_with_expert.paligemma.lm_head`
  * `model.paligemma_with_expert.paligemma.language_model.model` -> `model.paligemma_with_expert.paligemma.model.language_model`
  * `model.paligemma_with_expert.paligemma.vision_tower` -> `model.paligemma_with_expert.paligemma.model.vision_tower`
  * `model.paligemma_with_expert.paligemma.multi_modal_projector` -> `model.paligemma_with_expert.paligemma.model.multi_modal_projector`

### Environment

- transformers: 4.53.0  
  
  ---

 @Cadene, @mshukor 