### PR TITLE
Fix unnecessary indentations

### DIFF
--- a/src/lerobot/utils/visualization_utils.py
+++ b/src/lerobot/utils/visualization_utils.py
@@ -38,9 +38,9 @@ def log_rerun_data(observation: dict[str | Any], action: dict[str | Any]):
                     rr.log(f"observation.{obs}_{i}", rr.Scalar(float(v)))
             else:
                 rr.log(f"observation.{obs}", rr.Image(val), static=True)
-        for act, val in action.items():
-            if isinstance(val, float):
-                rr.log(f"action.{act}", rr.Scalar(val))
-            elif isinstance(val, np.ndarray):
-                for i, v in enumerate(val):
-                    rr.log(f"action.{act}_{i}", rr.Scalar(float(v)))
+    for act, val in action.items():
+        if isinstance(val, float):
+            rr.log(f"action.{act}", rr.Scalar(val))
+        elif isinstance(val, np.ndarray):
+            for i, v in enumerate(val):
+                rr.log(f"action.{act}_{i}", rr.Scalar(float(v)))


### PR DESCRIPTION
## What this does
https://github.com/huggingface/lerobot/pull/1396 introduced indentations when `log_rerun_data` was refactored. I'm pretty sure that's unintentional.

## How it was tested
Ran the [teleop script](https://huggingface.co/docs/lerobot/en/il_robots#teleoperate) and observe no changes.

## How to checkout & try? (for the reviewer)

Run the [teleop script](https://huggingface.co/docs/lerobot/en/il_robots#teleoperate) script, e.g.:

```sh
python -m lerobot.teleoperate \
    --robot.type=so101_follower \
    --robot.port=/dev/tty.usbmodem58760431541 \
    --robot.id=my_awesome_follower_arm \
    --teleop.type=so101_leader \
    --teleop.port=/dev/tty.usbmodem58760431551 \
    --teleop.id=my_awesome_leader_arm
```

cc @pkooij for review :)
