### PR TITLE
fix: add support for 180-degree rotation in camera implementations

### DIFF
--- a/src/lerobot/cameras/opencv/camera_opencv.py
+++ b/src/lerobot/cameras/opencv/camera_opencv.py
@@ -364,7 +364,7 @@ class OpenCVCamera(Camera):
         if requested_color_mode == ColorMode.RGB:
             processed_image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
 
-        if self.rotation in [cv2.ROTATE_90_CLOCKWISE, cv2.ROTATE_90_COUNTERCLOCKWISE]:
+        if self.rotation in [cv2.ROTATE_90_CLOCKWISE, cv2.ROTATE_90_COUNTERCLOCKWISE, cv2.ROTATE_180]:
             processed_image = cv2.rotate(processed_image, self.rotation)
 
         return processed_image

--- a/src/lerobot/cameras/realsense/camera_realsense.py
+++ b/src/lerobot/cameras/realsense/camera_realsense.py
@@ -434,7 +434,7 @@ class RealSenseCamera(Camera):
         if self.color_mode == ColorMode.BGR:
             processed_image = cv2.cvtColor(image, cv2.COLOR_RGB2BGR)
 
-        if self.rotation in [cv2.ROTATE_90_CLOCKWISE, cv2.ROTATE_90_COUNTERCLOCKWISE]:
+        if self.rotation in [cv2.ROTATE_90_CLOCKWISE, cv2.ROTATE_90_COUNTERCLOCKWISE, cv2.ROTATE_180]:
             processed_image = cv2.rotate(processed_image, self.rotation)
 
         return processed_image


### PR DESCRIPTION
## What this does
Fixes missing support for 180-degree rotation in camera implementations. When users configured `rotation=cv2.ROTATE_180`, the rotation was not being applied because the rotation check only included 90-degree rotations.

🐛 Bug

## How it was tested
- Added `cv2.ROTATE_180` to rotation checks in both OpenCV and RealSense camera implementations
- Verified rotation works correctly with test cameras  
- Confirmed no breaking changes to existing functionality
- All existing rotation modes (90° clockwise, 90° counterclockwise) continue to work as expected

## How to checkout & try? (for the reviewer)
```python
import cv2

from lerobot.cameras.configs import ColorMode, Cv2Rotation
from lerobot.cameras.opencv.configuration_opencv import OpenCVCameraConfig
from lerobot.robots.so101_follower import SO101Follower, SO101FollowerConfig

camera_config = {
    'wrist_view': OpenCVCameraConfig(
        index_or_path='/dev/video0',
        fps=30,
        width=640,
        height=480,
        color_mode=ColorMode.BGR,
        rotation=Cv2Rotation.ROTATE_180, # Before this fix, ROTATE_180 was ignored thus behaved like NO_ROTATION
    ),
}

robot_config = SO101FollowerConfig(
    port='/dev/ttyACM1',
    id='my_follower_arm',
    cameras=camera_config,
)

robot = SO101Follower(robot_config)
robot.connect()

while True:
    observation = robot.get_observation()
    wrist_view = observation['wrist_view']
    cv2.imshow('Wrist View', wrist_view)
    
    if cv2.waitKey(1) & 0xFF == ord('q'):
        break
        
cv2.destroyAllWindows()