### PR TITLE
Attempt to fix async test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ classifiers = [
 ]
 dependencies = [
     "cmake>=3.29.0.1",
-    "datasets>=2.19.0",
+    "datasets>=2.19.0,<=3.6.0",
     "deepdiff>=7.0.1",
     "diffusers>=0.27.2",
     "draccus==0.10.0",

--- a/tests/async_inference/test_e2e.py
+++ b/tests/async_inference/test_e2e.py
@@ -32,37 +32,56 @@ from __future__ import annotations
 import threading
 from concurrent import futures
 
-import grpc
 import torch
 
-from lerobot.robots.utils import make_robot_from_config
-from lerobot.scripts.server.configs import RobotClientConfig
-from lerobot.scripts.server.policy_server import PolicyServer
-from lerobot.scripts.server.robot_client import RobotClient
-from lerobot.transport import async_inference_pb2_grpc  # type: ignore
-from tests.async_inference.test_policy_server import policy_server  # noqa: F401
+from tests.utils import require_package
 
 # -----------------------------------------------------------------------------
 # End-to-end test
 # -----------------------------------------------------------------------------
 
 
-def test_async_inference_e2e(policy_server, monkeypatch):  # noqa: F811
-    """Tests the full asynchronous inference pipeline."""
-    # ------------------------------------------------------------------
-    # 1. Spawn a PolicyServer returning dummy action chunks
-    # ------------------------------------------------------------------
-    from lerobot.scripts.server.helpers import map_robot_keys_to_lerobot_features
-    from lerobot.transport import async_inference_pb2  # type: ignore
-    from tests.mocks.mock_robot import MockRobotConfig
+@require_package("grpc")
+def test_async_inference_e2e(monkeypatch):
+    """Smoke-test the full asynchronous inference pipeline."""
+    # Import only when the test actually runs (after decorator check from policy_server fixture)
+    import grpc
 
-    test_config = MockRobotConfig()
-    mock_robot = make_robot_from_config(test_config)
+    from lerobot.scripts.server import (
+        async_inference_pb2,  # type: ignore
+        async_inference_pb2_grpc,  # type: ignore
+    )
+    from lerobot.scripts.server.configs import PolicyServerConfig, RobotClientConfig
+    from lerobot.scripts.server.policy_server import PolicyServer
+    from lerobot.scripts.server.robot_client import RobotClient
 
-    lerobot_features = map_robot_keys_to_lerobot_features(mock_robot)
-    policy_server.lerobot_features = lerobot_features
+    # Create a stub policy similar to test_policy_server.py
+    class MockPolicy:
+        """A minimal mock for an actual policy, returning zeros."""
 
-    # Force server to produce deterministic action chunks in test mode
+        class _Config:
+            robot_type = "dummy_robot"
+
+        def __init__(self):
+            self.config = self._Config()
+
+        def to(self, *args, **kwargs):
+            return self
+
+        def model(self, batch):
+            # Return a chunk of 20 dummy actions.
+            batch_size = len(batch["robot_type"])
+            return torch.zeros(batch_size, 20, 6)
+
+    # Create PolicyServer instance
+    test_config = PolicyServerConfig(host="localhost", port=9999)
+    policy_server = PolicyServer(test_config)
+    # Replace the real policy with our fast, deterministic stub.
+    policy_server.policy = MockPolicy()
+    policy_server.actions_per_chunk = 20
+    policy_server.device = "cpu"
+
+    # Force server to act-style policy; patch method to return deterministic tensor
     policy_server.policy_type = "act"
 
     def _fake_get_action_chunk(_self, _obs, _type="test"):

--- a/tests/async_inference/test_robot_client.py
+++ b/tests/async_inference/test_robot_client.py
@@ -25,14 +25,14 @@ from queue import Queue
 import pytest
 import torch
 
-from tests.utils import require_package
+# Skip entire module if grpc is not available
+pytest.importorskip("grpc")
 
 # -----------------------------------------------------------------------------
 # Test fixtures
 # -----------------------------------------------------------------------------
 
 
-@require_package("grpc")
 @pytest.fixture()
 def robot_client():
     """Fresh `RobotClient` instance for each test case (no threads started).
@@ -90,7 +90,6 @@ def _make_actions(start_ts: float, start_t: int, count: int):
 # -----------------------------------------------------------------------------
 
 
-@require_package("grpc")
 def test_update_action_queue_discards_stale(robot_client):
     """`_update_action_queue` must drop actions with `timestep` <= `latest_action`."""
 
@@ -108,7 +107,6 @@ def test_update_action_queue_discards_stale(robot_client):
     assert resulting_timesteps == [5, 6, 7]
 
 
-@require_package("grpc")
 @pytest.mark.parametrize(
     "weight_old, weight_new",
     [
@@ -175,7 +173,6 @@ def test_aggregate_action_queues_combines_actions_in_overlap(
     assert torch.allclose(queue_non_overlap_actions[0].get_action(), incoming[-1].get_action())
 
 
-@require_package("grpc")
 @pytest.mark.parametrize(
     "chunk_size, queue_len, expected",
     [
@@ -200,7 +197,6 @@ def test_ready_to_send_observation(robot_client, chunk_size: int, queue_len: int
     assert robot_client._ready_to_send_observation() is expected
 
 
-@require_package("grpc")
 @pytest.mark.parametrize(
     "g_threshold, expected",
     [


### PR DESCRIPTION
- Make tests skip-able with `pytest.importorskip("grpc")` and `requires_package` decorator for minimal tests
- Move imports, that implicitly import grpc to inside the test functions