### PR TITLE
fix(docs): Record-Upload failed? Don't panic!

### DIFF
--- a/docs/source/il_robots.mdx
+++ b/docs/source/il_robots.mdx
@@ -284,7 +284,7 @@ You can look for other LeRobot datasets on the hub by searching for `LeRobot` [t
 
 You can also push your local dataset to the Hub manually, running:
 ```bash
-huggingface-cli upload ${HF_USER}/record-test ~/.cache/huggingface/lerobot/{repo-id}
+huggingface-cli upload ${HF_USER}/record-test ~/.cache/huggingface/lerobot/{repo-id} --repo-type dataset
 ```
 
 


### PR DESCRIPTION
## What this does
Adds a minimal instruction to manually upload the local version of a recorded dataset. The workflow is:
- Record a dataset 
- Encode the dataset, and prepare for upload 
- **Upload-only** fails (for instance, because users did not run `huggingface-cli login`)

This adds an extra instruction to help users tackle this issue using `huggingface-cli upload ...`