### PR TITLE
fix(mps): gradient exploding and nan loss issues with ACT

### DIFF
--- a/src/lerobot/policies/act/modeling_act.py
+++ b/src/lerobot/policies/act/modeling_act.py
@@ -485,12 +485,10 @@ class ACT(nn.Module):
                 self.encoder_env_state_input_proj(batch["observation.environment_state"])
             )
 
-        # Camera observation features and positional embeddings.
         if self.config.image_features:
-            all_cam_features = []
-            all_cam_pos_embeds = []
-
             # For a list of images, the H and W may vary but H*W is constant.
+            # NOTE: Please if you want to change this, test on MPS, and observe if you don't get
+            # gradient explosion issues or NaNs.
             for img in batch["observation.images"]:
                 cam_features = self.backbone(img)["feature_map"]
                 cam_pos_embed = self.encoder_cam_feat_pos_embed(cam_features).to(dtype=cam_features.dtype)
@@ -500,11 +498,10 @@ class ACT(nn.Module):
                 cam_features = einops.rearrange(cam_features, "b c h w -> (h w) b c")
                 cam_pos_embed = einops.rearrange(cam_pos_embed, "b c h w -> (h w) b c")
 
-                all_cam_features.append(cam_features)
-                all_cam_pos_embeds.append(cam_pos_embed)
-
-            encoder_in_tokens.extend(torch.cat(all_cam_features, axis=0))
-            encoder_in_pos_embed.extend(torch.cat(all_cam_pos_embeds, axis=0))
+                # Extend immediately instead of accumulating and concatenating
+                # Convert to list to extend properly
+                encoder_in_tokens.extend(list(cam_features))
+                encoder_in_pos_embed.extend(list(cam_pos_embed))
 
         # Stack all tokens along the sequence dimension.
         encoder_in_tokens = torch.stack(encoder_in_tokens, axis=0)

--- a/src/lerobot/scripts/train.py
+++ b/src/lerobot/scripts/train.py
@@ -180,7 +180,7 @@ def train(cfg: TrainPipelineConfig):
         batch_size=cfg.batch_size,
         shuffle=shuffle,
         sampler=sampler,
-        pin_memory=device.type != "cpu",
+        pin_memory=device.type == "cpu",
         drop_last=False,
     )
     dl_iter = cycle(dataloader)
@@ -207,7 +207,7 @@ def train(cfg: TrainPipelineConfig):
 
         for key in batch:
             if isinstance(batch[key], torch.Tensor):
-                batch[key] = batch[key].to(device, non_blocking=True)
+                batch[key] = batch[key].to(device, non_blocking=device.type == "cuda")
 
         train_tracker, output_dict = update_policy(
             train_tracker,


### PR DESCRIPTION
## What this does

This PR changes how we concatenate image representations in ACT and modifies the `non_blocking` parameter in `train.py`.

During the port of the pipeline (#1431, #1452), I noticed weird behavior (such as NaN loss and exploding gradients) when training ACT on MPS devices with macOS version 15.X. I tested on the `main` branch and confirmed the issue wasn't specific to my pipeline branch.

I tested on several coworkers' computers:
- @pkooij (M4 chip + macOS 15.X) ✗
- @michel-aractingi (M3 + macOS 14.X) ✓
- @CarolinePascal (M4 chip + macOS 15.X) ✗
- @fracapuano (M1 and M4 on macOS 15.X) ✗

Only @michel-aractingi didn't have the issue, so we hypothesized that macOS 15.X has weird behavior with MPS.

With @pkooij and @michel-aractingi, we found a commit that we know works: `12f52632ed4a74eacdfb766f217f60cb07337ce2`, which is 4 months old and 122 commits behind `main`.

Using `git bisect`, we found the commit that introduced the issue: `e8159997c7399550ef7ea03f7603174cada0cd62`. This commit added support for images with different sizes in ACT. While this addition shouldn't impact learning, it appears to cause instability on macOS 15.X with MPS.

I tried implementing this feature in different ways and tested training on MPS. One of these variations made the training stable. @pkooij and I tried to find a reasonable explanation for why this fix works and why the previous implementation didn't work, but we didn't find any good explanation.

### Example

```bash
python -m lerobot.scripts.train \
  --dataset.repo_id=imstevenpmwork/thanos_picking_power_gem_1749731584242992 \
  --policy.type=act \
  --output_dir=outputs/train/act_so101_test_2 \
  --job_name=act_so101_main \
  --policy.device=mps \
  --wandb.enable=true \
  --policy.push_to_hub=false \
  --steps=400 \
  --log_freq=1
```

**In this branch:**
```
INFO 2025-01-11 18:26:00 ts/train.py:232 step:1 smpl:8 ep:0 epch:0.00 loss:83.043 grdn:1199.969 lr:1.0e-05 updt_s:1.569 data_s:6.242
INFO 2025-01-11 18:26:01 ts/train.py:232 step:2 smpl:16 ep:0 epch:0.00 loss:67.020 grdn:1027.348 lr:1.0e-05 updt_s:0.958 data_s:0.000
INFO 2025-01-11 18:26:02 ts/train.py:232 step:3 smpl:24 ep:0 epch:0.00 loss:53.843 grdn:861.832 lr:1.0e-05 updt_s:0.875 data_s:0.001
...
```

**On the main branch:**
```
INFO 2025-01-11 19:05:09 ts/train.py:232 step:1 smpl:8 ep:0 epch:0.00 loss:83.043 grdn:2916322304.000 lr:1.0e-05 updt_s:2.368 data_s:5.916
INFO 2025-01-11 19:05:10 ts/train.py:232 step:2 smpl:16 ep:0 epch:0.00 loss:81.730 grdn:4778118144.000 lr:1.0e-05 updt_s:0.956 data_s:0.001
INFO 2025-01-11 19:05:11 ts/train.py:232 step:3 smpl:24 ep:0 epch:0.00 loss:77.601 grdn:1296025216.000 lr:1.0e-05 updt_s:0.881 data_s:0.001
...
INFO 2025-01-11 19:05:20 ts/train.py:232 step:13 smpl:104 ep:0 epch:0.01 loss:46.645 grdn:nan lr:1.0e-05 updt_s:0.881 data_s:0.001
INFO 2025-01-11 19:05:21 ts/train.py:232 step:14 smpl:112 ep:0 epch:0.01 loss:nan grdn:nan lr:1.0e-05 updt_s:0.903 data_s:0.001
...
```

As shown, the gradients on the main branch are orders of magnitude larger and eventually become NaN, while this branch maintains stable gradients throughout training.