### PR TITLE
[Async Inference] Remove random noise injected by policy server

### DIFF
--- a/src/lerobot/scripts/server/policy_server.py
+++ b/src/lerobot/scripts/server/policy_server.py
@@ -323,7 +323,7 @@ class PolicyServer(async_inference_pb2_grpc.AsyncInferenceServicer):
         if chunk.ndim != 3:
             chunk = chunk.unsqueeze(0)  # adding batch dimension, now shape is (B, chunk_size, action_dim)
 
-        return chunk[:, : self.actions_per_chunk, :] + torch.randn_like(chunk[:, : self.actions_per_chunk, :])
+        return chunk[:, : self.actions_per_chunk, :]
 
     def _predict_action_chunk(self, observation_t: TimedObservation) -> list[TimedAction]:
         """Predict an action chunk based on an observation"""


### PR DESCRIPTION
## What this does

In the async inference PR (#1196), there's some randn noise injected to all the actions (https://github.com/huggingface/lerobot/commit/2425f6c215d95e7d39309af1ed316c54c8c70e00#diff-e6c27e873b6aab1af2879dc3bc4787516b513eb8bfffe8996de6b28109cf35beR326). This seems to be leftover from testing. This PR removes it.

## How it was tested

Before this change, there's very jerky movement: https://discord.com/channels/1216765309076115607/1343589494485553222/1393108733487480853

After this change, the jerky movement is gone.


## How to checkout & try? (for the reviewer)
Follow the async inference instructions: https://huggingface.co/docs/lerobot/en/async
