### PR TITLE
Parse draccus subclass overrides when using `--policy.path`

### DIFF
--- a/src/lerobot/configs/policies.py
+++ b/src/lerobot/configs/policies.py
@@ -16,6 +16,8 @@ import logging
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
+import tempfile
+import json
 from typing import Type, TypeVar
 
 import draccus
@@ -183,8 +185,24 @@ class PreTrainedConfig(draccus.ChoiceRegistry, HubMixin, abc.ABC):
                     f"{CONFIG_NAME} not found on the HuggingFace Hub in {model_id}"
                 ) from e
 
-        # HACK: this is very ugly, ideally we'd like to be able to do that natively with draccus
+
+        # HACK: Parse the original config to get the config subclass, so that we can
+        # apply cli overrides.
+        # This is very ugly, ideally we'd like to be able to do that natively with draccus
         # something like --policy.path (in addition to --policy.type)
-        cli_overrides = policy_kwargs.pop("cli_overrides", [])
         with draccus.config_type("json"):
-            return draccus.parse(cls, config_file, args=cli_overrides)
+            orig_config = draccus.parse(cls, config_file, args=[])
+
+        with open(config_file, "r") as f:
+            config = json.load(f)
+ 
+        config.pop("type")
+        with tempfile.NamedTemporaryFile("w+") as f:
+            json.dump(config, f)
+            config_file = f.name
+            f.flush()
+
+            cli_overrides = policy_kwargs.pop("cli_overrides", [])
+            with draccus.config_type("json"):
+                return draccus.parse(orig_config.__class__, config_file, args=cli_overrides)
+

--- a/src/lerobot/configs/policies.py
+++ b/src/lerobot/configs/policies.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import abc
+import json
 import logging
 import os
+import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
-import tempfile
-import json
 from typing import Type, TypeVar
 
 import draccus
@@ -185,7 +185,6 @@ class PreTrainedConfig(draccus.ChoiceRegistry, HubMixin, abc.ABC):
                     f"{CONFIG_NAME} not found on the HuggingFace Hub in {model_id}"
                 ) from e
 
-
         # HACK: Parse the original config to get the config subclass, so that we can
         # apply cli overrides.
         # This is very ugly, ideally we'd like to be able to do that natively with draccus
@@ -193,9 +192,9 @@ class PreTrainedConfig(draccus.ChoiceRegistry, HubMixin, abc.ABC):
         with draccus.config_type("json"):
             orig_config = draccus.parse(cls, config_file, args=[])
 
-        with open(config_file, "r") as f:
+        with open(config_file) as f:
             config = json.load(f)
- 
+
         config.pop("type")
         with tempfile.NamedTemporaryFile("w+") as f:
             json.dump(config, f)
@@ -205,4 +204,3 @@ class PreTrainedConfig(draccus.ChoiceRegistry, HubMixin, abc.ABC):
             cli_overrides = policy_kwargs.pop("cli_overrides", [])
             with draccus.config_type("json"):
                 return draccus.parse(orig_config.__class__, config_file, args=cli_overrides)
-


### PR DESCRIPTION
## What this does

Currently, it's not possible to specify policy overrides for training when using `--policy.path`. The error looks like:

```
> python -m lerobot.scripts.train \
  --dataset.repo_id="${DATASET_REPO_ID}" \
  --policy.path=lerobot/smolvla_base \
  --policy.repo_id="${POLICY_REPO_ID}" \
  --output_dir="${OUTPUT_DIR}" \
  --job_name="${POLICY_REPO_ID}_${CLUSTER_NAME}" \
  --policy.device=cuda \
  --policy.optimizer_lr="1e-3" \
  --wandb.enable=true \
  --wandb.disable_artifact=true \
  --wandb.notes="${WANDB_NOTES}" \
  --num_workers=8 \
  --batch_size="${BATCH_SIZE}" \
  --steps="100_000" \
  --save_freq="5_000"
...
unrecognized arguments: --optimizer_lr=1e-3
```

This PR resolves this by doing another hack on top of the existing hack to:
1. find the subclass of `PreTrainedConfig`.
2. parse the config file into the subclass directly instead of the generic `PreTrainedConfig`.

Related discussion: https://discord.com/channels/1216765309076115607/1383463707748864101/1383538262077079644

## How it was tested

Subclass-specific configuration like `python -m lerobot.scripts.train ... --policy.optimizer_lr="1e-3"` should now work with this change.

## How to checkout & try? (for the reviewer)

Try to run a training job by using `--policy.path`, and override a policy-subclass-specific setting like `--policy.optimizer_lr="1e-3"`.
