### PR TITLE
Update 4_train_policy_with_script.md with resume training terminal command example update

### DIFF
--- a/examples/4_train_policy_with_script.md
+++ b/examples/4_train_policy_with_script.md
@@ -156,7 +156,7 @@ INFO 2025-01-24 16:10:56 ts/train.py:263 Checkpoint policy after step 100
 Now let's simulate a crash by killing the process (hit `ctrl`+`c`). We can then simply resume this run from the last checkpoint available with:
 ```bash
 python -m lerobot.scripts.train \
-    --config_path=outputs/train/run_resumption/checkpoints/last/pretrained_model/ \
+    --config_path=outputs/train/run_resumption/checkpoints/last/pretrained_model/train_config.json \
     --resume=true
 ```
 You should see from the logging that your training picks up from where it left off.
@@ -165,7 +165,7 @@ Another reason for which you might want to resume a run is simply to extend trai
 You could double the number of steps of the previous run with:
 ```bash
 python -m lerobot.scripts.train \
-    --config_path=outputs/train/run_resumption/checkpoints/last/pretrained_model/ \
+    --config_path=outputs/train/run_resumption/checkpoints/last/pretrained_model/train_config.json \
     --resume=true \
     --steps=200000
 ```


### PR DESCRIPTION
Non functional example of resuming a training run. The issue is documented also in comment of [issue #1033](https://github.com/huggingface/lerobot/issues/1033#issuecomment-2910824450) 

The full path should include the file name "train_config.json" then it is working.
`--config_path=outputs/train/run_resumption/checkpoints/last/pretrained_model/train_config.json
`
## What this does
This PR fixes outdated/non-working terminal command example.
Optimizes documentation.

## How it was tested
Run terminal command
```
python lerobot/scripts/train.py \
   --config_path=outputs/train/act_test/checkpoints/last/pretrained_model/  \
   --resume=true
```
leads to error:

> FileNotFoundError: No such file or directory: "outputs/train/my_model_001/checkpoints/last/model.safetensors"

When running the updated terminal command with including the file name "train_config.json":
```
python lerobot/scripts/train.py \
   --config_path=outputs/train/act_test/checkpoints/last/pretrained_model/train_config.json  \
   --resume=true
```
it works.
