### PR TITLE
feat(ci): add new & clean Dockerfiles

### DIFF
--- a/.github/workflows/test-docker-build.yml
+++ b/.github/workflows/test-docker-build.yml
@@ -20,7 +20,9 @@ on:
   pull_request:
     paths:
       # Run only when DockerFile files are modified
-      - "docker/**"
+      - "docker/lerobot-cpu/**"
+      - "docker/lerobot-gpu/**"
+      - "docker/lerobot-gpu-dev/**"
 
 permissions: {}
 

--- a/docker/Dockerfile.internal
+++ b/docker/Dockerfile.internal
@@ -1,0 +1,60 @@
+# Dockerfile.internal
+# This Dockerfile is designed for HuggingFace internal CI environments
+# that require GPU access. It starts from an NVIDIA CUDA base image.
+
+# docker build -f docker/Dockerfile.internal -t lerobot-ci .
+
+# Configure the base image for CI with GPU access
+ARG CUDA_VERSION=12.9.1
+ARG OS_VERSION=24.04
+FROM nvidia/cuda:${CUDA_VERSION}-base-ubuntu${OS_VERSION}
+
+# Define Python version argument
+ARG PYTHON_VERSION=3.10
+
+# Configure environment variables
+ENV DEBIAN_FRONTEND=noninteractive \
+    MUJOCO_GL="egl" \
+    PATH="/lerobot/.venv/bin:$PATH"
+
+# Install Python, system dependencies, and uv (as root)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    software-properties-common \
+    build-essential git curl \
+    libglib2.0-0 libgl1-mesa-glx libegl1-mesa ffmpeg \
+    libusb-1.0-0-dev \
+    speech-dispatcher libgeos-dev \
+    && add-apt-repository -y ppa:deadsnakes/ppa \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
+       python${PYTHON_VERSION} \
+       python${PYTHON_VERSION}-venv \
+       python${PYTHON_VERSION}-dev \
+    && curl -LsSf https://astral.sh/uv/install.sh | sh \
+    && mv /root/.local/bin/uv /usr/local/bin/uv \
+    && useradd --create-home --shell /bin/bash user_lerobot \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Create application directory and set permissions
+WORKDIR /lerobot
+RUN chown -R user_lerobot:user_lerobot /lerobot
+
+# Switch to the non-root user
+USER user_lerobot
+
+# Create the virtual environment
+# We use a virtual environment inside the container—even though the container itself \
+# provides isolation—to ensure compatibility with the cluster and to prevent \
+# issues with MuJoCo and OpenGL drivers.
+RUN uv venv --python python${PYTHON_VERSION}
+
+# Install Python dependencies for caching
+COPY --chown=user_lerobot:user_lerobot pyproject.toml README.md ./
+COPY --chown=user_lerobot:user_lerobot src/ src/
+RUN uv pip install --no-cache ".[all]"
+
+# Copy the rest of the application source code
+COPY --chown=user_lerobot:user_lerobot . .
+
+# Set the default command
+CMD ["/bin/bash"]

--- a/docker/Dockerfile.user
+++ b/docker/Dockerfile.user
@@ -1,0 +1,50 @@
+# Dockerfile.user
+# This Dockerfile is designed for a lerobot user who wants to
+# experiment with the project. It starts from an Python Slim base image.
+
+# docker build -f docker/Dockerfile.user -t lerobot-user .
+# docker run -it --rm lerobot-user
+
+# Configure the base image
+ARG PYTHON_VERSION=3.10
+FROM python:${PYTHON_VERSION}-slim
+
+# Configure environment variables
+ENV DEBIAN_FRONTEND=noninteractive \
+    MUJOCO_GL="egl" \
+    PATH="/lerobot/.venv/bin:$PATH"
+
+# Install system dependencies and uv (as root)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential git curl \
+    libglib2.0-0 libgl1-mesa-glx libegl1-mesa ffmpeg \
+    libusb-1.0-0-dev \
+    speech-dispatcher libgeos-dev \
+    && curl -LsSf https://astral.sh/uv/install.sh | sh \
+    && mv /root/.local/bin/uv /usr/local/bin/uv \
+    && useradd --create-home --shell /bin/bash user_lerobot \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Create application directory and set permissions
+WORKDIR /lerobot
+RUN chown -R user_lerobot:user_lerobot /lerobot
+
+# Switch to the non-root user
+USER user_lerobot
+
+# Create the virtual environment
+# We use a virtual environment inside the container—even though the container itself \
+# provides isolation—to closely resemble local development and allow users to \
+# run other Python projects in the same container without dependency conflicts.
+RUN uv venv
+
+# Install Python dependencies for caching
+COPY --chown=user_lerobot:user_lerobot pyproject.toml README.md ./
+COPY --chown=user_lerobot:user_lerobot src/ src/
+RUN uv pip install --no-cache ".[all]"
+
+# Copy the rest of the application code
+COPY --chown=user_lerobot:user_lerobot . .
+
+# Set the default command
+CMD ["/bin/bash"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,11 +110,11 @@ intelrealsense = [
     "pyrealsense2>=2.55.1.6486 ; sys_platform != 'darwin'",
     "pyrealsense2-macosx>=2.54 ; sys_platform == 'darwin'",
 ]
-stretch = [
-    "hello-robot-stretch-body>=0.7.27 ; sys_platform == 'linux'",
-    "pyrender @ git+https://github.com/mmatl/pyrender.git ; sys_platform == 'linux'",
-    "pyrealsense2>=2.55.1.6486 ; sys_platform != 'darwin'"
-] # TODO: Currently not supported
+# stretch = [
+#     "hello-robot-stretch-body>=0.7.27 ; sys_platform == 'linux'",
+#     "pyrender @ git+https://github.com/mmatl/pyrender.git ; sys_platform == 'linux'",
+#     "pyrealsense2>=2.55.1.6486 ; sys_platform != 'darwin'"
+# ] # TODO: Currently not supported
 
 # Policies
 pi0 = ["lerobot[transformers-dep]"]
@@ -134,6 +134,27 @@ video_benchmark = ["scikit-image>=0.23.2", "pandas>=2.2.2"]
 aloha = ["gym-aloha>=0.1.1"]
 pusht = ["gym-pusht>=0.1.5", "pymunk>=6.6.0,<7.0.0"] # TODO: Fix pymunk version in gym-pusht instead
 xarm = ["gym-xarm>=0.1.1"]
+
+# All
+all = [
+    "lerobot[dynamixel]",
+    "lerobot[gamepad]",
+    "lerobot[hopejr]",
+    "lerobot[lekiwi]",
+    "lerobot[kinematics]",
+    "lerobot[intelrealsense]",
+    "lerobot[pi0]",
+    "lerobot[smolvla]",
+    "lerobot[hilserl]",
+    "lerobot[async]",
+    "lerobot[docs]",
+    "lerobot[dev]",
+    "lerobot[test]",
+    "lerobot[video_benchmark]",
+    "lerobot[aloha]",
+    "lerobot[pusht]",
+    "lerobot[xarm]"
+]
 
 # ---------------- Tool Configurations ----------------
 [tool.setuptools.packages.find]


### PR DESCRIPTION
This PR is part of a series of future improvements to build a reliable system and infrastructure that lets us publish new releases with confidence. This takes care of:
* Updating Dockerfiles images to be used in the future by the CI workflows.
* Updating `pyproject.toml` accordingly.

We'll use these files after refactoring our CI workflows, which will likely involve removing the current Dockerfiles. Why not edit the existing ones now? Because I want to keep the current CI functioning as-is until the workflow refactoring is complete. Reviewing these now will help us focus solely on the CI changes when they're ready.

### How to review?
As these files are not yet used, it is safe to review them individually.