### PR TITLE
fix: Add missing dynamixel encoding table entries

### DIFF
--- a/src/lerobot/motors/dynamixel/tables.py
+++ b/src/lerobot/motors/dynamixel/tables.py
@@ -107,6 +107,8 @@ X_SERIES_ENCODINGS_TABLE = {
     "Goal_PWM": X_SERIES_CONTROL_TABLE["Goal_PWM"][1],
     "Goal_Current": X_SERIES_CONTROL_TABLE["Goal_Current"][1],
     "Goal_Velocity": X_SERIES_CONTROL_TABLE["Goal_Velocity"][1],
+    "Goal_Position": X_SERIES_CONTROL_TABLE["Goal_Position"][1],
+    "Present_Position": X_SERIES_CONTROL_TABLE["Present_Position"][1],
     "Present_PWM": X_SERIES_CONTROL_TABLE["Present_PWM"][1],
     "Present_Current": X_SERIES_CONTROL_TABLE["Present_Current"][1],
     "Present_Velocity": X_SERIES_CONTROL_TABLE["Present_Velocity"][1],


### PR DESCRIPTION
### What This Does
Fixes a bug that happens when running calibration on a Dynamixel-based leader arm that is switched to **Extended-Position mode** throws (or silently hides) an overflow when handling joint positions:

```text
ERROR:__main__:Error during calibration: Value -4294965182 out of range for 4-byte two's complement: [-2147483648, 2147483647]
Traceback (most recent call last):
  ...
  File "lerobot/utils/encoding_utils.py", line 49, in encode_twos_complement
    raise ValueError(
ValueError: Value -4294965182 out of range for 4-byte two's complement: [-2147483648, 2147483647]
```

Root cause  
* In EXTENDED_POSITION mode `Present_Position` (and `Goal_Position`) are **signed 32-bit**.  
* These registers were missing from `X_SERIES_ENCODINGS_TABLE`, so the decoder treated the two-complement value as an *unsigned* 32-bit integer.  
* When a negative position was later re-encoded (e.g., while computing half-turn homing offsets) it overflowed and raised the error above.

Hidden impact when the error *didn’t* raise  
If the last recorded position happened to be within the positive range, the overflow check was bypassed.  
Calibration then wrote a wildly incorrect homing offset, causing the robot to **swing violently in one direction on startup**.

### Fix
Added the missing entries so positions are properly (de-)encoded:

```diff
 X_SERIES_ENCODINGS_TABLE = {
      "Homing_Offset":  ...,  
      "Goal_PWM":       ...,  
      "Goal_Current":   ...,  
      "Goal_Velocity":  ...,  
+     "Goal_Position":     X_SERIES_CONTROL_TABLE["Goal_Position"][1],
+     "Present_Position":  X_SERIES_CONTROL_TABLE["Present_Position"][1],
      "Present_PWM":     ...,  
      "Present_Current": ...,  
      "Present_Velocity":...,  
 }
```

### Validation / How To Test
Re-running calibration with the patched library completes without errors and the arm holds position correctly on reboot
`src/lerobot/motors/dynamixel/tables.py`

Command used to reproduce (and verify) the fix:

```bash
python -m lerobot.calibrate \
    --teleop.type=koch_leader \
    --teleop.port=/dev/servo_585A007782 \
    --teleop.id=koch_leader_testing
```
