### PR TITLE
Removed nonexistent argument in visualization_dataset script readme example usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,13 +192,12 @@ python -m lerobot.scripts.visualize_dataset \
     --episode-index 0
 ```
 
-or from a dataset in a local folder with the `root` option and the `--local-files-only` (in the following case the dataset will be searched for in `./my_local_data_dir/lerobot/pusht`)
+or from a dataset in a local folder with the `root` option (in the following case the dataset will be searched for in `./my_local_data_dir/lerobot/pusht`)
 
 ```bash
 python -m lerobot.scripts.visualize_dataset \
     --repo-id lerobot/pusht \
     --root ./my_local_data_dir \
-    --local-files-only 1 \
     --episode-index 0
 ```
 


### PR DESCRIPTION
## What this does
The readme contained an example usage of a script using a nonexistent parameter `--local-files-only`.

Fixes #1541 

## How it was tested
N/A

## How to checkout & try? (for the reviewer)
Ensure that:

```bash
python -m lerobot.scripts.visualize_dataset --repo-id lerobot/pusht --root ./my_local_data_dir   --episode-index 0```

works correctly.