### PR TITLE
Upgrade rerun-sdk to 0.24.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ dependencies = [
 
     "draccus==0.10.0", # TODO: Remove ==
     "gymnasium>=0.29.1,<1.0.0", # TODO: Bumb dependency
-    "rerun-sdk>=0.21.0,<0.23.0", # TODO: Bumb dependency
+    "rerun-sdk>=0.24.0",
 
     # Support dependencies
     "deepdiff>=7.0.1,<9.0.0",

--- a/src/lerobot/utils/visualization_utils.py
+++ b/src/lerobot/utils/visualization_utils.py
@@ -31,16 +31,16 @@ def _init_rerun(session_name: str = "lerobot_control_loop") -> None:
 def log_rerun_data(observation: dict[str | Any], action: dict[str | Any]):
     for obs, val in observation.items():
         if isinstance(val, float):
-            rr.log(f"observation.{obs}", rr.Scalar(val))
+            rr.log(f"observation.{obs}", rr.Scalars(val))
         elif isinstance(val, np.ndarray):
             if val.ndim == 1:
                 for i, v in enumerate(val):
-                    rr.log(f"observation.{obs}_{i}", rr.Scalar(float(v)))
+                    rr.log(f"observation.{obs}_{i}", rr.Scalars(float(v)))
             else:
                 rr.log(f"observation.{obs}", rr.Image(val), static=True)
     for act, val in action.items():
         if isinstance(val, float):
-            rr.log(f"action.{act}", rr.Scalar(val))
+            rr.log(f"action.{act}", rr.Scalars(val))
         elif isinstance(val, np.ndarray):
             for i, v in enumerate(val):
-                rr.log(f"action.{act}_{i}", rr.Scalar(float(v)))
+                rr.log(f"action.{act}_{i}", rr.Scalars(float(v)))


### PR DESCRIPTION
## What this does

We pinned([1](https://github.com/huggingface/lerobot/pull/1520), [2](https://github.com/huggingface/lerobot/pull/1435)) rerun-sdk to below 0.23 due to a [memory leak](https://github.com/rerun-io/rerun/issues/10496) issue. This issue was resolved in 0.24. This PR bumps rerun version and removes the ceil.

In the long run, we should still pin package versions (discussed in https://github.com/huggingface/lerobot/pull/1435)so that new users don't have to deal with breaking changes.

## How it was tested

Run [teleop](https://github.com/huggingface/lerobot/blob/89f59b070368f789a8b3aa558d9f0c88796cc324/docs/source/il_robots.mdx#teleoperate-with-cameras) with `--display_data=true`. Open the memory panel and observe that the `counted` memory doesn't rapidly increase.
<img width="1072" height="1167" alt="image" src="https://github.com/user-attachments/assets/c9832c5b-2014-4542-920d-35663e6e587e" />


## How to checkout & try? (for the reviewer)

1. `pip install -e .` to upgrade rerun.

2. Follow the [teleop](https://github.com/huggingface/lerobot/blob/89f59b070368f789a8b3aa558d9f0c88796cc324/docs/source/il_robots.mdx#teleoperate-with-cameras) instructions.

