### PR TITLE
feat: add support for Intel XPU backend in device selection

### DIFF
--- a/src/lerobot/utils/utils.py
+++ b/src/lerobot/utils/utils.py
@@ -50,6 +50,9 @@ def auto_select_torch_device() -> torch.device:
     elif torch.backends.mps.is_available():
         logging.info("Metal backend detected, using mps.")
         return torch.device("mps")
+    elif torch.xpu.is_available():
+        logging.info("Intel XPU backend detected, using xpu.")
+        return torch.device("xpu")
     else:
         logging.warning("No accelerated backend detected. Using default cpu, this will be slow.")
         return torch.device("cpu")
@@ -66,6 +69,9 @@ def get_safe_torch_device(try_device: str, log: bool = False) -> torch.device:
         case "mps":
             assert torch.backends.mps.is_available()
             device = torch.device("mps")
+        case "xpu":
+            assert torch.xpu.is_available()
+            device = torch.device("xpu")
         case "cpu":
             device = torch.device("cpu")
             if log:
@@ -86,6 +92,12 @@ def get_safe_dtype(dtype: torch.dtype, device: str | torch.device):
         device = device.type
     if device == "mps" and dtype == torch.float64:
         return torch.float32
+    if device == "xpu" and dtype == torch.float64:
+        if not torch.xpu.get_device_capability().get("has_fp64", False):
+            print(f"Device {device} does not support float64, using float32 instead.")
+            return torch.float32
+        else:
+            return dtype
     else:
         return dtype
 
@@ -96,10 +108,12 @@ def is_torch_device_available(try_device: str) -> bool:
         return torch.cuda.is_available()
     elif try_device == "mps":
         return torch.backends.mps.is_available()
+    elif try_device == "xpu":
+        return torch.xpu.is_available()
     elif try_device == "cpu":
         return True
     else:
-        raise ValueError(f"Unknown device {try_device}. Supported devices are: cuda, mps or cpu.")
+        raise ValueError(f"Unknown device {try_device}. Supported devices are: cuda, mps, xpu or cpu.")
 
 
 def is_amp_available(device: str):


### PR DESCRIPTION

This pull request enhances the `src/lerobot/utils/utils.py` file by adding support for Intel XPU devices. The changes ensure that the utility functions can detect, validate, and handle the XPU backend alongside existing backends like CUDA, MPS, and CPU.

### Added support for Intel XPU:

* [`auto_select_torch_device`](diffhunk://#diff-5c10c485b490c4bf8197aeb1121edc6239265608e39efba362042288677cbdafR53-R55): Added logic to detect and select the XPU backend when available.
* [`get_safe_torch_device`](diffhunk://#diff-5c10c485b490c4bf8197aeb1121edc6239265608e39efba362042288677cbdafR72-R74): Extended the function to handle `"xpu"` as a valid device option, ensuring proper assertions and device creation.
* [`get_safe_dtype`](diffhunk://#diff-5c10c485b490c4bf8197aeb1121edc6239265608e39efba362042288677cbdafR95-R100): Introduced checks for XPU devices to handle cases where `torch.float64` is unsupported, falling back to `torch.float32` if necessary.
* [`is_torch_device_available`](diffhunk://#diff-5c10c485b490c4bf8197aeb1121edc6239265608e39efba362042288677cbdafR111-R116): Updated to include detection of XPU availability and adjusted the error message to list XPU as a supported device.

## How to checkout & try? (for the reviewer)

Provide a simple way for the reviewer to try out your changes.

Examples:

### Install environment
```bash
python3 -m venv .venv
source .venv/bin/activate
git clone https://github.com/huggingface/lerobot.git
cd lerobot
pip install -e ".[smolvla]" --extra-index-url https://download.pytorch.org/whl/xpu
```

### Run training
```bash
python3 src/lerobot/scripts/train.py \
  --policy.path=lerobot/smolvla_base \
  --policy.push_to_hub=false \
  --policy.device=xpu \
  --dataset.repo_id=lerobot/svla_so100_stacking \
  --batch_size=4 \
  --steps=20000 \
  --output_dir=outputs/train/my_smolvla \
  --job_name=my_smolvla_training \
  --wandb.enable=false
```

## SECTION TO REMOVE BEFORE SUBMITTING YOUR PR

**Note**: Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR. Try to avoid tagging more than 3 people.

**Note**: Before submitting this PR, please read the [contributor guideline](https://github.com/huggingface/lerobot/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr).
