### PR TITLE
feat(ci): add release workflow

### DIFF
--- a/.github/workflows/full_tests.yml
+++ b/.github/workflows/full_tests.yml
@@ -131,8 +131,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3 # zizmor: ignore[unpinned-uses]
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          username: ${{ secrets.DOCKERHUB_LEROBOT_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_LEROBOT_PASSWORD }}
       - name: Build and push Docker image
         uses: docker/build-push-action@v6 # zizmor: ignore[unpinned-uses]
         with:
@@ -157,8 +157,8 @@ jobs:
       image: ${{ needs.build-and-push-docker.outputs.image_tag }} # zizmor: ignore[unpinned-images]
       options: --gpus all --shm-size "16gb"
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ secrets.DOCKERHUB_LEROBOT_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_LEROBOT_PASSWORD }}
     defaults:
       run:
         shell: bash
@@ -187,7 +187,7 @@ jobs:
 
           TOKEN=$(curl -s -H "Content-Type: application/json" \
                        -X POST \
-                       -d '{"username": "${{ secrets.DOCKERHUB_USERNAME }}", "password": "${{ secrets.DOCKERHUB_PASSWORD }}"}' \
+                       -d '{"username": "${{ secrets.DOCKERHUB_LEROBOT_USERNAME }}", "password": "${{ secrets.DOCKERHUB_LEROBOT_PASSWORD }}"}' \
                        https://hub.docker.com/v2/users/login/ | jq -r .token)
 
           if [ "$TOKEN" == "null" ] || [ -z "$TOKEN" ]; then

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -62,8 +62,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3 # zizmor: ignore[unpinned-uses]
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          username: ${{ secrets.DOCKERHUB_LEROBOT_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_LEROBOT_PASSWORD }}
       - name: Build and push Docker image CPU
         uses: docker/build-push-action@v6 # zizmor: ignore[unpinned-uses]
         with:
@@ -96,8 +96,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@v3 # zizmor: ignore[unpinned-uses]
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          username: ${{ secrets.DOCKERHUB_LEROBOT_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_LEROBOT_PASSWORD }}
       - name: Build and push Docker image GPU
         uses: docker/build-push-action@v6 # zizmor: ignore[unpinned-uses]
         with:
@@ -120,8 +120,8 @@ jobs:
     container:
       image: ${{ needs.build-docker-cpu-nightly.outputs.image_tag }} # zizmor: ignore[unpinned-images]
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ secrets.DOCKERHUB_LEROBOT_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_LEROBOT_PASSWORD }}
     defaults:
       run:
         shell: bash
@@ -147,8 +147,8 @@ jobs:
       image: ${{ needs.build-docker-gpu-nightly.outputs.image_tag }} # zizmor: ignore[unpinned-images]
       options: --gpus all --shm-size "16gb"
       credentials:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_PASSWORD }}
+        username: ${{ secrets.DOCKERHUB_LEROBOT_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_LEROBOT_PASSWORD }}
     defaults:
       run:
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,88 @@
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Create Release and Publish to PyPI
+
+on:
+  push:
+    tags:
+      - 'v*.*.*' # Trigger on tags like v0.1.0, v1.0.0
+
+jobs:
+  # TODO(Steven): Publish draft/pre-release and to test pypi
+  # TODO(Steven): Tag documentation with the same version as the package
+  # TODO(Steven): Define entry points for main CLI scripts
+  build-and-publish:
+    name: Build and publish Python distributions
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Extract Version and Package Name
+        id: extract_info
+        # zizmor: ignore[template-injection]
+        run: |
+          # Extract version from tag (e.g., v0.1.0 -> 0.1.0)
+          VERSION=${{ github.ref_name }}
+          VERSION_NUMBER=${VERSION#v}
+          echo "tag_version=$VERSION_NUMBER" >> $GITHUB_OUTPUT
+
+          # Extract package name from pyproject.toml
+          PACKAGE_NAME=$(grep -oP 'name = "\K[^"]+' pyproject.toml)
+          echo "package_name=$PACKAGE_NAME" >> $GITHUB_OUTPUT
+
+      - name: Check if version exists on PyPI
+      # zizmor: ignore[template-injection]
+        run: |
+          PACKAGE_NAME=${{ steps.extract_info.outputs.package_name }}
+          NEW_VERSION=${{ steps.extract_info.outputs.tag_version }}
+
+          response=$(curl -s "https://pypi.org/pypi/$PACKAGE_NAME/$NEW_VERSION/json")
+          if echo "$response" | grep -q "message"; then
+            echo "Version $NEW_VERSION is available on PyPI. Proceeding with release."
+          else
+            echo "Error: Version $NEW_VERSION already exists on PyPI. Aborting."
+            exit 1
+          fi
+
+      - name: Install build dependencies
+        run: python -m pip install build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        # zizmor: ignore[template-injection]
+        run: gh release create ${{ github.ref_name }} --release-name "Release ${{ github.ref_name }}" --generate-notes ./dist/*
+
+      # TODO(Steven): Uncomment when ready to publish to PyPI
+      # - name: Publish to PyPI
+      #   if: startsWith(github.ref, 'refs/tags/v')
+      #   uses: pypa/gh-action-pypi-publish@v1.12.4
+      #   with:
+      #     password: ${{ secrets.PYPI_API_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -26,11 +26,11 @@ export PATH := $(dir $(PYTHON_PATH)):$(PATH)
 
 DEVICE ?= cpu
 
-build-cpu:
-	docker build -t lerobot:latest -f docker/lerobot-cpu/Dockerfile .
+build-user:
+	docker build -f docker/Dockerfile.user -t lerobot-user .
 
-build-gpu:
-	docker build -t lerobot:latest -f docker/lerobot-gpu/Dockerfile .
+build-internal:
+	docker build -f docker/Dockerfile.internal -t lerobot-internal .
 
 test-end-to-end:
 	${MAKE} DEVICE=$(DEVICE) test-act-ete-train

--- a/docker/Dockerfile.internal
+++ b/docker/Dockerfile.internal
@@ -15,7 +15,7 @@
 # This Dockerfile is designed for HuggingFace internal CI environments
 # that require GPU access. It starts from an NVIDIA CUDA base image.
 
-# docker build -f docker/Dockerfile.internal -t lerobot-ci .
+# docker build -f docker/Dockerfile.internal -t lerobot-internal .
 
 # Configure the base image for CI with GPU access
 # TODO(Steven): Bump these versions


### PR DESCRIPTION
This PR is part of a series of future improvements to build a reliable system and infrastructure that lets us publish new releases with confidence. This takes care of:
* Adding a Github CI workflows for creating a GH Release (and a PyPI release in the future)

### How does it work?
* For now we manually bump the `pyproject.toml` version + manually create & push a tag of the form of `v*.*.*` in `main`
* Once the tag has been pushed, the release workflow will trigger: does a sanity check on the version number, build the wheels, creates a GH release, automates the release notes and uploads the assets.

### Notes
We don't publish to PyPI yet due to the following reasons: 
* We need to properly configure the entry points for the main CLI scripts we provide (like `lerobot.teleoperate`)
* We need to configure the `__init__` root module for exposing properly our public API
* We need the permissions/ownership of [lerobot name in pypi](https://pypi.org/project/lerobot/)