### PR TITLE
fix(record): Fix resume recording to respect number of already recorded episodes

### DIFF
--- a/src/lerobot/record.py
+++ b/src/lerobot/record.py
@@ -336,7 +336,7 @@ def record(cfg: RecordConfig) -> LeRobotDataset:
     listener, events = init_keyboard_listener()
 
     with VideoEncodingManager(dataset):
-        recorded_episodes = 0
+        recorded_episodes = dataset.num_episodes if cfg.resume else 0
         while recorded_episodes < cfg.dataset.num_episodes and not events["stop_recording"]:
             log_say(f"Recording episode {dataset.num_episodes}", cfg.play_sounds)
             record_loop(


### PR DESCRIPTION
## What this does

One-line change. Before, when resuming a dataset recording with `--resume=true`, the record script reinitializes the number of recorded episodes to 0, which leads to the user recording more episodes than they specified in `--dataset.num_episodes`. The loop now correctly counts existing episodes instead of always starting from 0.

## How it was tested

To reproduce the bug:
- record a dataset with `--dataset.num_episodes=3`. Early exit after recording 2 episodes
- Resume recording by running the same record command with `--resume` set to True
- Observe that on resume, it will want to record another 3 episodes before finishing the recording session

After the fix
- record a dataset with `--dataset.num_episodes=3`. Early exit after recording 2 episodes
- Resume recording by running the same record command with `--resume` set to True
- Observe that on resume, recording correctly starts from episode 2, and once that episode is recorded, the recording session ends
