### PR TITLE
fix pyrealsense to 2.55.1.6486 to avoid test_realsense fail

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,7 @@ hopejr = ["lerobot[feetech]", "lerobot[pygame-dep]"]
 lekiwi = ["lerobot[feetech]", "pyzmq>=26.2.1"]
 kinematics = ["lerobot[placo-dep]"]
 intelrealsense = [
-    "pyrealsense2>=2.55.1.6486 ; sys_platform != 'darwin'",
+    "pyrealsense2==2.55.1.6486 ; sys_platform != 'darwin'",
     "pyrealsense2-macosx>=2.54 ; sys_platform == 'darwin'",
 ]
 # stretch = [


### PR DESCRIPTION
test_realsense.py is failing with pyrealsense version 2.56.4.9191 that was released today.
I fixed the version to 2.55.1.6486 that works