### PR TITLE
Fix: Update minimum wandb version to resolve protobuf dependency conflict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ dependencies = [
     "packaging>=24.2",
     "pynput>=1.7.7",
     "pyserial>=3.5",
-    "wandb>=0.16.3",
+    "wandb>=0.20.0",
 
     "draccus==0.10.0", # TODO: Remove ==
     "gymnasium>=0.29.1,<1.0.0", # TODO: Bumb dependency


### PR DESCRIPTION
## Issue 
Installing `lerobot[grpcio-dep]` with earlier versions of wandb between  0.16.3 - 0.19.* causes a dependency conflict due to incompatible protobuf version constraints:

After #1480 current [grpcio-dep] requires: protobuf==6.31.0

Example of current possible wandb versions: 
 - `wandb==0.16.3`: requires `protobuf!=4.21.0, <5, >=3.19.0`
 - `wandb==0.19.0`: requires `protobuf!=4.21.0, !=5.28.0, <6, >=3.19.0`

Solution is to bump the minimum required version of wandb to 0.20.0, which removes the upper <6 constraint on protobuf and is compatible with protobuf==6.31.0.

## Note
when running something like `pip install -e ".[hilserl]"`  pip will find the proper wandb issue that doesn't cause conflicts. However, it can still cause silent bugs if someone tries to install grpc-dep independently with an older wandb version.  
