### PR TITLE
fix(hf hub dependency): adding ceiling version on huggingface_hub

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ dependencies = [
     # Hugging Face dependencies
     "datasets>=2.19.0,<=3.6.0", # TODO: Bumb dependency
     "diffusers>=0.27.2",
-    "huggingface-hub[hf-transfer,cli]>=0.27.1",
+    "huggingface-hub[hf-transfer,cli]>=0.27.1,<0.34.0",
 
     # Core dependencies
     "cmake>=3.29.0.1",


### PR DESCRIPTION
## What this does

This PR limits the version of `huggingface_hub` to `<0.34.0` to avoid caching changes brought by the latest 0.34.0 release.

## How it was tested

N/A

## How to checkout & try? (for the reviewer)

N/A