### PR TITLE
Add variable-length test datasets

### DIFF
--- a/tests/fixtures/dataset_factories.py
+++ b/tests/fixtures/dataset_factories.py
@@ -488,6 +488,8 @@ def lerobot_dataset_factory(
         tasks: pd.DataFrame | None = None,
         episodes_metadata: datasets.Dataset | None = None,
         hf_dataset: datasets.Dataset | None = None,
+        data_files_size_in_mb: float = DEFAULT_DATA_FILE_SIZE_IN_MB,
+        chunks_size: int = DEFAULT_CHUNK_SIZE,
         **kwargs,
     ) -> LeRobotDataset:
         # Instantiate objects
@@ -497,6 +499,8 @@ def lerobot_dataset_factory(
                 total_frames=total_frames,
                 total_tasks=total_tasks,
                 use_videos=use_videos,
+                data_files_size_in_mb=data_files_size_in_mb,
+                chunks_size=chunks_size,
             )
         if stats is None:
             stats = stats_factory(features=info["features"])
@@ -525,6 +529,8 @@ def lerobot_dataset_factory(
             tasks=tasks,
             episodes=episodes_metadata,
             hf_dataset=hf_dataset,
+            data_files_size_in_mb=data_files_size_in_mb,
+            chunks_size=chunks_size,
         )
         mock_metadata = lerobot_dataset_metadata_factory(
             root=root,

--- a/tests/fixtures/files.py
+++ b/tests/fixtures/files.py
@@ -81,10 +81,15 @@ def create_episodes(episodes_factory):
 
 @pytest.fixture(scope="session")
 def create_hf_dataset(hf_dataset_factory):
-    def _create_hf_dataset(dir: Path, hf_dataset: datasets.Dataset | None = None):
+    def _create_hf_dataset(
+        dir: Path,
+        hf_dataset: datasets.Dataset | None = None,
+        data_file_size_in_mb: float | None = None,
+        chunk_size: int | None = None,
+    ):
         if hf_dataset is None:
             hf_dataset = hf_dataset_factory()
-        write_hf_dataset(hf_dataset, dir)
+        write_hf_dataset(hf_dataset, dir, data_file_size_in_mb, chunk_size)
 
     return _create_hf_dataset
 

--- a/tests/fixtures/hub.py
+++ b/tests/fixtures/hub.py
@@ -19,6 +19,8 @@ import pytest
 from huggingface_hub.utils import filter_repo_objects
 
 from lerobot.datasets.utils import (
+    DEFAULT_CHUNK_SIZE,
+    DEFAULT_DATA_FILE_SIZE_IN_MB,
     DEFAULT_DATA_PATH,
     DEFAULT_EPISODES_PATH,
     DEFAULT_TASKS_PATH,
@@ -54,9 +56,11 @@ def mock_snapshot_download_factory(
         tasks: pd.DataFrame | None = None,
         episodes: datasets.Dataset | None = None,
         hf_dataset: datasets.Dataset | None = None,
+        data_files_size_in_mb: float = DEFAULT_DATA_FILE_SIZE_IN_MB,
+        chunks_size: int = DEFAULT_CHUNK_SIZE,
     ):
         if info is None:
-            info = info_factory()
+            info = info_factory(data_files_size_in_mb=data_files_size_in_mb, chunks_size=chunks_size)
         if stats is None:
             stats = stats_factory(features=info["features"])
         if tasks is None:
@@ -132,7 +136,7 @@ def mock_snapshot_download_factory(
             if request_episodes:
                 create_episodes(local_dir, episodes)
             if request_data:
-                create_hf_dataset(local_dir, hf_dataset)
+                create_hf_dataset(local_dir, hf_dataset, data_files_size_in_mb, chunks_size)
             if request_videos:
                 create_videos(root=local_dir, info=info)
 


### PR DESCRIPTION
# What this does

- Test datasets are too simplicistic: often containing only one files in one chunk. this prevents us from testing thoroughly more advanced features (like streaming, and aggregation) 
- This PR adds support for arbitrary data and chunk size (in the context of datasets, chunk = #files within a folder), increasing test coverage
- Developed while solving streaming, this PR should land on this branch first