### PR TITLE
Feat: Support CLI for Launching LeKiwiHost

### DIFF
--- a/src/lerobot/robots/lekiwi/lekiwi_host.py
+++ b/src/lerobot/robots/lekiwi/lekiwi_host.py
@@ -18,12 +18,21 @@ import base64
 import json
 import logging
 import time
+from dataclasses import dataclass, field
 
 import cv2
 import zmq
+import draccus
 
 from .config_lekiwi import LeKiwiConfig, LeKiwiHostConfig
 from .lekiwi import LeKiwi
+
+
+@dataclass
+class LeKiwiServerConfig:
+    """Configuration for the LeKiwi host script."""
+    robot: LeKiwiConfig = field(default_factory=LeKiwiConfig)
+    host: LeKiwiHostConfig = field(default_factory=LeKiwiHostConfig)
 
 
 class LeKiwiHost:
@@ -47,17 +56,16 @@ class LeKiwiHost:
         self.zmq_context.term()
 
 
-def main():
+@draccus.wrap()
+def main(cfg: LeKiwiServerConfig):
     logging.info("Configuring LeKiwi")
-    robot_config = LeKiwiConfig()
-    robot = LeKiwi(robot_config)
+    robot = LeKiwi(cfg.robot)
 
     logging.info("Connecting LeKiwi")
     robot.connect()
 
     logging.info("Starting HostAgent")
-    host_config = LeKiwiHostConfig()
-    host = LeKiwiHost(host_config)
+    host = LeKiwiHost(cfg.host)
 
     last_cmd_time = time.time()
     watchdog_active = False


### PR DESCRIPTION
### Problem

Currently, CLI is not supported by launching LeKiwi Host on Raspberry Pi

In the following tutorial docs
https://huggingface.co/docs/lerobot/lekiwi?example=Linux#teleoperate-lekiwi

it says

```
python -m lerobot.robots.lekiwi.lekiwi_host --robot.id=my_awesome_kiwi
```

But `--robot.id=my_awesome_kiwi` has no effect due to missing CLI parser, therefore teleoperation script may not run seamlessly.

### Key Changes
1. Created configuration dataclass `LeKiwiServerConfig` that contains both robot and host configurations
3. Added CLI parsing with `@draccus.wrap()` decorator on the `main()` function

### How it Works

```
python -m lerobot.robots.lekiwi.lekiwi_host --robot.id=my_awesome_kiwi
```
will now work correctly.

One can also customize any configurations from both `LeKiwiConfig` and `LeKiwiHostConfig`

For example, one could also try to increase the connection time to 1 hour
```
python -m lerobot.robots.lekiwi.lekiwi_host --robot.id=my_awesome_kiwi --host.connection_time_s=3600
```

cc: @pkooij @aliberts @imstevenpmwork 