### PR TITLE
fix(DiffusionPolicy): Fix bug where training without image features would crash with exception, fix environment state docs

### DIFF
--- a/src/lerobot/policies/diffusion/configuration_diffusion.py
+++ b/src/lerobot/policies/diffusion/configuration_diffusion.py
@@ -217,12 +217,13 @@ class DiffusionConfig(PreTrainedConfig):
                     )
 
         # Check that all input images have the same shape.
-        first_image_key, first_image_ft = next(iter(self.image_features.items()))
-        for key, image_ft in self.image_features.items():
-            if image_ft.shape != first_image_ft.shape:
-                raise ValueError(
-                    f"`{key}` does not match `{first_image_key}`, but we expect all image shapes to match."
-                )
+        if len(self.image_features) > 0:
+            first_image_key, first_image_ft = next(iter(self.image_features.items()))
+            for key, image_ft in self.image_features.items():
+                if image_ft.shape != first_image_ft.shape:
+                    raise ValueError(
+                        f"`{key}` does not match `{first_image_key}`, but we expect all image shapes to match."
+                    )
 
     @property
     def observation_delta_indices(self) -> list:

--- a/src/lerobot/policies/diffusion/modeling_diffusion.py
+++ b/src/lerobot/policies/diffusion/modeling_diffusion.py
@@ -288,7 +288,7 @@ class DiffusionModel(nn.Module):
 
             "observation.images": (B, n_obs_steps, num_cameras, C, H, W)
                 AND/OR
-            "observation.environment_state": (B, environment_dim)
+            "observation.environment_state": (B, n_obs_steps, environment_dim)
         }
         """
         batch_size, n_obs_steps = batch["observation.state"].shape[:2]
@@ -315,7 +315,7 @@ class DiffusionModel(nn.Module):
 
             "observation.images": (B, n_obs_steps, num_cameras, C, H, W)
                 AND/OR
-            "observation.environment_state": (B, environment_dim)
+            "observation.environment_state": (B, n_obs_steps, environment_dim)
 
             "action": (B, horizon, action_dim)
             "action_is_pad": (B, horizon)


### PR DESCRIPTION
## What this does

This PR fixes a simple bug in the DiffusionPolicy implementation that crashes when not specifying image features. Concretely, the code was iterating over the image features without checking if there are any image features in the first place.

Additionally, the docstrings incorrectly specified the shape of the `observation.environment_state`, saying that it should be `(batch_size, env_dim)`. Passing this shape causes a crash, however, as it can't be stacked with the state and image features. Actually, the shape should be `(batch_size, n_obs_steps, env_dim)`. The docs have been updated to reflect this.

Examples:
| Title | Label |
|----------------------|-----------------|
| Fixes #1616 | (🐛 Bug) |

## How it was tested

I created a toy dataset that has only state and env state (no image features). This causes a `StopIteration` exception, as it can't iterate over the (empty) image features. After adding this fix, this bug no longer occurs and training proceeds as normal.

The toy script I used for testing is below, which is slightly modified from [example 3](https://github.com/huggingface/lerobot/blob/c7c3b477d6d39cf7046a7225eecc4e5debe67065/examples/3_train_policy.py).

## How to checkout & try? (for the reviewer)

Run the script below to test:

```
from pathlib import Path
import os

import numpy as np
import torch

from lerobot.configs.types import FeatureType
from lerobot.datasets.lerobot_dataset import LeRobotDataset
from lerobot.datasets.utils import dataset_to_policy_features
from lerobot.policies.diffusion.configuration_diffusion import DiffusionConfig
from lerobot.policies.diffusion.modeling_diffusion import DiffusionPolicy


def get_dataset(data_dir="test_data", **kwargs):
    return LeRobotDataset(repo_id="test", root=data_dir, **kwargs)

def create_dataset(data_dir="test_data"):
    if os.path.isdir(data_dir):
        return

    dataset = LeRobotDataset.create(repo_id="test", fps=20, root=data_dir, features={
        "observation.state": {
            "dtype": "float64",
            "shape": (2,),
        },
        "observation.environment_state": {
            "dtype": "float64",
            "shape": (2,),
        },
        "action": {
            "dtype": "float64",
            "shape": (2,),
        },
    })
    for _ in range(10):
        for _ in range(20):
            state = np.random.randn(2)
            env_state = np.random.randn(2)
            action = state + env_state
            dataset.add_frame(
                task="test",
                frame={
                    "observation.state": state,
                    "observation.environment_state": env_state,
                    "action": action,
                }
            )
        dataset.save_episode()


def main():
    output_directory = Path("test_policy")
    output_directory.mkdir(parents=True, exist_ok=True)

    create_dataset()

    device = torch.device("cpu")
    if torch.cuda.is_available():
        device = torch.device("cuda")
    elif torch.backends.mps.is_available():
        device = torch.device("mps")

    training_steps = 10
    log_freq = 1

    dataset_metadata = get_dataset().meta
    features = dataset_to_policy_features(dataset_metadata.features)
    output_features = {key: ft for key, ft in features.items() if ft.type is FeatureType.ACTION}
    input_features = {key: ft for key, ft in features.items() if key not in output_features}

    cfg = DiffusionConfig(input_features=input_features, output_features=output_features, n_obs_steps=1)

    policy = DiffusionPolicy(cfg, dataset_stats=dataset_metadata.stats)
    policy.train()
    policy.to(device)

    delta_timestamps = {
        "observation.state": [i / dataset_metadata.fps for i in cfg.observation_delta_indices],
        "observation.environment_state": [i / dataset_metadata.fps for i in cfg.observation_delta_indices],
        "action": [i / dataset_metadata.fps for i in cfg.action_delta_indices],
    }

    dataset = get_dataset(delta_timestamps=delta_timestamps)

    optimizer = torch.optim.Adam(policy.parameters(), lr=1e-4)
    dataloader = torch.utils.data.DataLoader(
        dataset,
        num_workers=4,
        batch_size=64,
        shuffle=True,
        pin_memory=device.type == "cuda",
        drop_last=True,
    )

    step = 0
    done = False
    while not done:
        for batch in dataloader:
            batch = {k: (v.to(device) if isinstance(v, torch.Tensor) else v) for k, v in batch.items()}
            breakpoint()
            loss, _ = policy.forward(batch)
            loss.backward()
            optimizer.step()
            optimizer.zero_grad()

            if step % log_freq == 0:
                print(f"step: {step} loss: {loss.item():.3f}")
            step += 1
            if step >= training_steps:
                done = True
                break

    policy.save_pretrained(output_directory)


if __name__ == "__main__":
    main()
```
