### PR TITLE
Fixes training on multi-state/multi-action datasets

### DIFF
--- a/src/lerobot/configs/policies.py
+++ b/src/lerobot/configs/policies.py
@@ -27,6 +27,7 @@ from huggingface_hub.constants import CONFIG_NAME
 from huggingface_hub.errors import HfHubHTTPError
 
 from lerobot.configs.types import FeatureType, NormalizationMode, PolicyFeature
+from lerobot.constants import ACTION, OBS_STATE
 from lerobot.optim.optimizers import OptimizerConfig
 from lerobot.optim.schedulers import LRSchedulerConfig
 from lerobot.utils.hub import HubMixin
@@ -119,8 +120,8 @@ class PreTrainedConfig(draccus.ChoiceRegistry, HubMixin, abc.ABC):
 
     @property
     def robot_state_feature(self) -> PolicyFeature | None:
-        for _, ft in self.input_features.items():
-            if ft.type is FeatureType.STATE:
+        for ft_name, ft in self.input_features.items():
+            if ft.type is FeatureType.STATE and ft_name == OBS_STATE:
                 return ft
         return None
 
@@ -137,8 +138,8 @@ class PreTrainedConfig(draccus.ChoiceRegistry, HubMixin, abc.ABC):
 
     @property
     def action_feature(self) -> PolicyFeature | None:
-        for _, ft in self.output_features.items():
-            if ft.type is FeatureType.ACTION:
+        for ft_name, ft in self.output_features.items():
+            if ft.type is FeatureType.ACTION and ft_name == ACTION:
                 return ft
         return None
 


### PR DESCRIPTION
## What this does

Fixes a bug in how policy objects access state/action features at policy initialization. Essentially, this PR relaxes the assumption **one and only one** item in the dictionary is going to be either of type `FeatureType.STATE`/`FeatureType.ACTION`. 

Datasets like `aractingi/droid_1.0.1` contain multiple keys stored as `FeatureType.STATE`, while more traditional don't. That's why this bug hadn't surfaced just yet imo 🤗