### PR TITLE
fix(ci): use base tag for testpy to mimic the pyproject.toml version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,11 +146,12 @@ jobs:
         run: |
           VERSION="${{ needs.build-and-publish.outputs.version }}"
           if [[ "$VERSION" == *-* ]]; then
-            echo "Installing pre-release version $VERSION from TestPyPI..."
+            BASE_VERSION="${VERSION%%-*}"
+            echo "Installing pre-release version $BASE_VERSION from TestPyPI..."
             uv run pip install \
               --index-url https://test.pypi.org/simple/ \
               --extra-index-url https://pypi.org/simple \
-               "lerobot[all]==$VERSION"
+               "lerobot[all]==$BASE_VERSION"
           else
             echo "Installing release version $VERSION from PyPI..."
             uv run pip install "lerobot[all]==$VERSION"


### PR DESCRIPTION
* Uses real pyproject.toml version when testing the pypi test release