### PR TITLE
Fixes #1433 (Raises error when trying to use gamepad with SO101 follower)

### DIFF
--- a/src/lerobot/robots/so101_follower/so101_follower.py
+++ b/src/lerobot/robots/so101_follower/so101_follower.py
@@ -200,7 +200,8 @@ class SO101Follower(Robot):
             raise DeviceNotConnectedError(f"{self} is not connected.")
 
         if all(k in action for k in ["delta_x", "delta_y", "delta_z"]):
-            raise RuntimeError("You are trying to send end-effector actions for a joint-space SO101 follower. Choose so101_follower_end_effector as your robot type if you want to use this control method. See this discussion for details: https://github.com/huggingface/lerobot/issues/1433#issuecomment-3153415286")
+            error_message = "You are trying to send end-effector actions for a joint-space SO101 follower. Choose so101_follower_end_effector as your robot type if you want to use this control method. See this discussion for details: https://github.com/huggingface/lerobot/issues/1433#issuecomment-3153415286"
+            raise RuntimeError(error_message)
 
         goal_pos = {key.removesuffix(".pos"): val for key, val in action.items() if key.endswith(".pos")}
 


### PR DESCRIPTION
## What this does

The SO101 Follower robot class currently doesn't support end-effector-space controls so it throws a confusing error when you try to use it with a gamepad. See https://github.com/huggingface/lerobot/issues/1433 for examples of people encountering this error.

## How it was tested

` python3 -m lerobot.teleoperate --robot.type=so101_follower --robot.port=/dev/ttyACM0 --robot.id=erics_first_so101 --teleop.type=gamepad`

## How to checkout & try? (for the reviewer)

1. check out the repository
2. plug in a SO101 robot and run calibration
3. run the above command, but with the robot port and id replaced with yours
4. On `main` this will raise the exception mentioned in #1433, but on this branch it will raise a custom error that includes helpful information on how to do what the user wants to accomplish.
