### PR TITLE
fix(busy_wait): fix busy_wait implementation for Windows platforms

### DIFF
--- a/src/lerobot/utils/robot_utils.py
+++ b/src/lerobot/utils/robot_utils.py
@@ -17,10 +17,9 @@ import time
 
 
 def busy_wait(seconds):
-    if platform.system() == "Darwin":
-        # On Mac, `time.sleep` is not accurate and we need to use this while loop trick,
+    if platform.system() == "Darwin" or platform.system() == "Windows":
+        # On Mac and Windows, `time.sleep` is not accurate and we need to use this while loop trick,
         # but it consumes CPU cycles.
-        # TODO(rcadene): find an alternative: from python 11, time.sleep is precise
         end_time = time.perf_counter() + seconds
         while time.perf_counter() < end_time:
             pass


### PR DESCRIPTION
## What this does

This PR extends the `while` loop approach in `busy_wait` to Windows as well as MacOS, as `time.sleep` is not accurate on this platform.
This PR is actually drawn from #1187.

## How it was tested

See #1187.

## How to checkout & try? (for the reviewer)

Without this fix, a 30 fps teleoperation control loop should not be able to exceed ~26 fps, even without any cameras. With this fix, 30 fps control is effectively achieved.