### PR TITLE
fix(docs): Add note about hil-serl urdf path setup

### DIFF
--- a/docs/source/hilserl.mdx
+++ b/docs/source/hilserl.mdx
@@ -91,11 +91,15 @@ This helps simplify the problem of learning on the real robot in two ways: 1) by
 This script helps you find the safe operational bounds for your robot's end-effector. Given that you have a follower and leader arm, you can use the script to find the bounds for the follower arm that will be applied during training.
 Bounding the action space will reduce the redundant exploration of the agent and guarantees safety.
 
+> [!NOTE]
+> You need to clone the SO-ARM100 repository from https://github.com/TheRobotStudio/SO-ARM100 first. The `robot.urdf_path` in the command below should point to `<PATH TO SO-ARM100>/Simulation/SO101/so101_new_calib.urdf` in your local clone of the repository.
+
 ```bash
 python -m lerobot.scripts.find_joint_limits \
-    --robot.type=so100_follower \
+    --robot.type=so100_follower_end_effector \
     --robot.port=/dev/tty.usbmodem58760431541 \
     --robot.id=black \
+    --robot.urdf_path="/Users/shared/GitHub/SO-ARM100/Simulation/SO101/so101_new_calib.urdf" \
     --teleop.type=so100_leader \
     --teleop.port=/dev/tty.usbmodem58760431551 \
     --teleop.id=blue


### PR DESCRIPTION
## What this does

This PR fixes the documentation for the robot workspace bounds configuration step by adding essential setup instructions. 

Previously, users would encounter urdf errors in the `find_joint_limits.py` script because the documentation was using the wrong `RobotConfig`. The script requires `so100_follower_end_effector` config type (which supports URDF-based kinematics) but this requirement wasn't clearly documented.

The fix:
- Adds a note about cloning the required SO-ARM100 repository
- Documents the correct path structure for the URDF file
- Ensures proper robot configuration by specifying `so100_follower_end_effector` type, which is needed for end-effector space calculations

Looking at `config_so100_follower.py`, we can see that only `SO100FollowerEndEffectorConfig` supports URDF-based kinematics through its `urdf_path` parameter, while the base `SO100FollowerConfig` does not.

## How it was tested

- Manually verified that using `so100_follower_end_effector` with the proper URDF path allows the script to:
  1. Successfully load the URDF file
  2. Correctly calculate and output min/max end-effector positions
  3. Print joint angle limits as expected:
```
Max ee position [0.1377, 0.0151, -0.0133]
Min ee position [0.1362, 0.0148, -0.0144]
Max joint pos position [-9.1868, -100.2198, 97.6264, 76.0, 6.4615, 4.807]
Min joint pos position [-9.2747, -105.7582, 96.9231, 72.3956, 6.4615, 3.3852]
```