### PR TITLE
fix(ci): rename libegl1-mesa in deb13 trixie

### DIFF
--- a/docker/Dockerfile.user
+++ b/docker/Dockerfile.user
@@ -29,7 +29,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
 
 # Install system dependencies and uv (as root)
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential git curl libglib2.0-0 libegl1-mesa ffmpeg \
+    build-essential git curl libglib2.0-0 libegl1-mesa-dev ffmpeg \
     libusb-1.0-0-dev speech-dispatcher libgeos-dev portaudio19-dev \
     && curl -LsSf https://astral.sh/uv/install.sh | sh \
     && mv /root/.local/bin/uv /usr/local/bin/uv \


### PR DESCRIPTION
`python:${PYTHON_VERSION}-slim` base image tag we use for `Dockerfile.user`, transitioned from Debian 12 "Bookworm" to Debian 13 "Trixie". In Trixie, the `libegl1-mesa` package is not longer available, but we can use `libegl-mesa-dev` instead.

CI Nightly test: https://github.com/huggingface/lerobot/actions/runs/16960539630