### PR TITLE
fix(dataset): Correctly use episode_data parameter in save_episode

### DIFF
--- a/src/lerobot/datasets/lerobot_dataset.py
+++ b/src/lerobot/datasets/lerobot_dataset.py
@@ -825,6 +825,8 @@ class LeRobotDataset(torch.utils.data.Dataset):
         """
         if not episode_data:
             episode_buffer = self.episode_buffer
+        else:
+            episode_buffer = episode_data
 
         validate_episode_buffer(episode_buffer, self.meta.total_episodes, self.features)
 


### PR DESCRIPTION
(🐛 Bug) 

## What this does

This PR fixes a bug in the `LeRobotDataset.save_episode` method where the `episode_data` parameter was ignored when provided.

Previously, the method's logic did not correctly handle the `episode_data` parameter. This would cause an error if `self.episode_buffer` was not the intended data source, for instance, in an asynchronous data recording scenario.

The change ensures that if `episode_data` is passed, it is used as the source for saving the episode. Otherwise, it defaults to `self.episode_buffer` as before.

This fix is crucial for enabling non-blocking, asynchronous data recording. Users can now pass a copy of the episode buffer to this method for saving, while the main buffer is immediately cleared to continue collecting new data without being blocked by I/O operations.

## How it was tested

The changes were validated by running the existing test suite for datasets.

Specifically, the full `tests/datasets/test_datasets.py` suite was executed and all 49 tests passed successfully (2 were skipped). This confirms that the change does not introduce any regressions to the existing functionality of `LeRobotDataset`.

## How to checkout & try? (for the reviewer)

A reviewer can verify the fix by checking out this branch and running the dataset test suite:

```bash
# After setting up the environment as per CONTRIBUTING.md
pytest -sv tests/datasets/test_datasets.py
```