### PR TITLE
refactor(processors): move to inheritance

### DIFF
--- a/src/lerobot/policies/pi0/processor_pi0.py
+++ b/src/lerobot/policies/pi0/processor_pi0.py
@@ -14,11 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any
 
 import torch
 
-from lerobot.configs.types import PolicyFeature
 from lerobot.constants import POSTPROCESSOR_DEFAULT_NAME, PREPROCESSOR_DEFAULT_NAME
 from lerobot.policies.pi0.configuration_pi0 import PI0Config
 from lerobot.processor import (
@@ -30,61 +28,40 @@ from lerobot.processor import (
     UnnormalizerProcessor,
 )
 from lerobot.processor.pipeline import (
-    EnvTransition,
+    ComplementaryDataProcessor,
     ProcessorStep,
     ProcessorStepRegistry,
-    TransitionKey,
 )
 from lerobot.processor.rename_processor import RenameProcessor
 
 
 @ProcessorStepRegistry.register(name="pi0_new_line_processor")
-class Pi0NewLineProcessor(ProcessorStep):
+class Pi0NewLineProcessor(ComplementaryDataProcessor):
     """Add a new line to the end of the task if it doesn't have one.
     This is required for the PaliGemma tokenizer.
     """
 
-    def __call__(self, transition: EnvTransition) -> EnvTransition:
-        # Check if complementary_data exists
-        complementary_data = transition.get(TransitionKey.COMPLEMENTARY_DATA)
-        if complementary_data is None or "task" not in complementary_data:
-            return transition
+    def complementary_data(self, complementary_data):
+        if "task" not in complementary_data:
+            return complementary_data
 
         task = complementary_data["task"]
         if task is None:
-            return transition
+            return complementary_data
+
+        new_complementary_data = dict(complementary_data)
 
         # Handle both string and list of strings
         if isinstance(task, str):
             # Single string: add newline if not present
             if not task.endswith("\n"):
-                complementary_data["task"] = f"{task}\n"
+                new_complementary_data["task"] = f"{task}\n"
         elif isinstance(task, list) and all(isinstance(t, str) for t in task):
             # List of strings: add newline to each if not present
-            complementary_data["task"] = [t if t.endswith("\n") else f"{t}\n" for t in task]
+            new_complementary_data["task"] = [t if t.endswith("\n") else f"{t}\n" for t in task]
         # If task is neither string nor list of strings, leave unchanged
 
-        return transition
-
-    def transform_features(self, features: dict[str, PolicyFeature]) -> dict[str, PolicyFeature]:
-        """Add tokenized task features to the features."""
-        return features
-
-    def state_dict(self) -> dict[str, torch.Tensor]:
-        """Return state dictionary (empty for this processor)."""
-        return {}
-
-    def load_state_dict(self, state: dict[str, torch.Tensor]) -> None:
-        """Load state dictionary (no-op for this processor)."""
-        pass
-
-    def reset(self) -> None:
-        """Reset processor state (no-op for this processor)."""
-        pass
-
-    def get_config(self) -> dict[str, Any]:
-        """Return configuration for serialization."""
-        return {}
+        return new_complementary_data
 
 
 def make_pi0_processor(

--- a/src/lerobot/policies/smolvla/processor_smolvla.py
+++ b/src/lerobot/policies/smolvla/processor_smolvla.py
@@ -13,11 +13,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any
 
 import torch
 
-from lerobot.configs.types import PolicyFeature
 from lerobot.constants import POSTPROCESSOR_DEFAULT_NAME, PREPROCESSOR_DEFAULT_NAME
 from lerobot.policies.smolvla.configuration_smolvla import SmolVLAConfig
 from lerobot.processor import (
@@ -29,7 +27,10 @@ from lerobot.processor import (
     TokenizerProcessor,
     UnnormalizerProcessor,
 )
-from lerobot.processor.pipeline import EnvTransition, ProcessorStep, ProcessorStepRegistry, TransitionKey
+from lerobot.processor.pipeline import (
+    ComplementaryDataProcessor,
+    ProcessorStepRegistry,
+)
 
 
 def make_smolvla_processor(
@@ -64,47 +65,27 @@ def make_smolvla_processor(
 
 
 @ProcessorStepRegistry.register(name="smolvla_new_line_processor")
-class SmolVLANewLineProcessor(ProcessorStep):
+class SmolVLANewLineProcessor(ComplementaryDataProcessor):
     """Add a new line to the end of the task if it doesn't have one."""
 
-    def __call__(self, transition: EnvTransition) -> EnvTransition:
-        # Check if complementary_data exists
-        complementary_data = transition.get(TransitionKey.COMPLEMENTARY_DATA)
-        if complementary_data is None or "task" not in complementary_data:
-            return transition
+    def complementary_data(self, complementary_data):
+        if "task" not in complementary_data:
+            return complementary_data
 
         task = complementary_data["task"]
         if task is None:
-            return transition
+            return complementary_data
+
+        new_complementary_data = dict(complementary_data)
 
         # Handle both string and list of strings
         if isinstance(task, str):
             # Single string: add newline if not present
             if not task.endswith("\n"):
-                complementary_data["task"] = f"{task}\n"
+                new_complementary_data["task"] = f"{task}\n"
         elif isinstance(task, list) and all(isinstance(t, str) for t in task):
             # List of strings: add newline to each if not present
-            complementary_data["task"] = [t if t.endswith("\n") else f"{t}\n" for t in task]
+            new_complementary_data["task"] = [t if t.endswith("\n") else f"{t}\n" for t in task]
         # If task is neither string nor list of strings, leave unchanged
 
-        return transition
-
-    def transform_features(self, features: dict[str, PolicyFeature]) -> dict[str, PolicyFeature]:
-        """Adds nothing to the features."""
-        return features
-
-    def state_dict(self) -> dict[str, torch.Tensor]:
-        """Return state dictionary (empty for this processor)."""
-        return {}
-
-    def load_state_dict(self, state: dict[str, torch.Tensor]) -> None:
-        """Load state dictionary (no-op for this processor)."""
-        pass
-
-    def reset(self) -> None:
-        """Reset processor state (no-op for this processor)."""
-        pass
-
-    def get_config(self) -> dict[str, Any]:
-        """Return configuration for serialization."""
-        return {}
+        return new_complementary_data

--- a/src/lerobot/processor/batch_processor.py
+++ b/src/lerobot/processor/batch_processor.py
@@ -11,20 +11,88 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from dataclasses import dataclass
-from typing import Any
+from dataclasses import dataclass, field
 
-import torch
 from torch import Tensor
 
-from lerobot.configs.types import PolicyFeature
 from lerobot.constants import OBS_ENV_STATE, OBS_IMAGE, OBS_IMAGES, OBS_STATE
-from lerobot.processor.pipeline import EnvTransition, ProcessorStepRegistry, TransitionKey
+from lerobot.processor.pipeline import (
+    ActionProcessor,
+    ComplementaryDataProcessor,
+    EnvTransition,
+    ObservationProcessor,
+    ProcessorStep,
+    ProcessorStepRegistry,
+)
+
+
+@dataclass
+@ProcessorStepRegistry.register(name="to_batch_processor_action")
+class ToBatchProcessorAction(ActionProcessor):
+    """Process action component in-place, adding batch dimension if needed."""
+
+    def action(self, action):
+        if not isinstance(action, Tensor) or action.dim() != 1:
+            return action
+
+        return action.unsqueeze(0)
+
+
+@dataclass
+@ProcessorStepRegistry.register(name="to_batch_processor_observation")
+class ToBatchProcessorObservation(ObservationProcessor):
+    """Process observation component in-place, adding batch dimensions where needed."""
+
+    def observation(self, observation):
+        # Process state observations - add batch dim if 1D
+        for state_key in [OBS_STATE, OBS_ENV_STATE]:
+            if state_key in observation:
+                state_value = observation[state_key]
+                if isinstance(state_value, Tensor) and state_value.dim() == 1:
+                    observation[state_key] = state_value.unsqueeze(0)
+
+        # Process single image observation - add batch dim if 3D
+        if OBS_IMAGE in observation:
+            image_value = observation[OBS_IMAGE]
+            if isinstance(image_value, Tensor) and image_value.dim() == 3:
+                observation[OBS_IMAGE] = image_value.unsqueeze(0)
+
+        # Process multiple image observations - add batch dim if 3D
+        for key, value in observation.items():
+            if key.startswith(f"{OBS_IMAGES}.") and isinstance(value, Tensor) and value.dim() == 3:
+                observation[key] = value.unsqueeze(0)
+        return observation
+
+
+@dataclass
+@ProcessorStepRegistry.register(name="to_batch_processor_complementary_data")
+class ToBatchProcessorComplementaryData(ComplementaryDataProcessor):
+    """Process complementary data in-place, handling task field batching."""
+
+    def complementary_data(self, complementary_data):
+        # Process task field - wrap string in list to add batch dimension
+        if "task" in complementary_data:
+            task_value = complementary_data["task"]
+            if isinstance(task_value, str):
+                complementary_data["task"] = [task_value]
+
+        # Process index field - add batch dim if 0D
+        if "index" in complementary_data:
+            index_value = complementary_data["index"]
+            if isinstance(index_value, Tensor) and index_value.dim() == 0:
+                complementary_data["index"] = index_value.unsqueeze(0)
+
+        # Process task_index field - add batch dim if 0D
+        if "task_index" in complementary_data:
+            task_index_value = complementary_data["task_index"]
+            if isinstance(task_index_value, Tensor) and task_index_value.dim() == 0:
+                complementary_data["task_index"] = task_index_value.unsqueeze(0)
+        return complementary_data
 
 
 @dataclass
 @ProcessorStepRegistry.register(name="to_batch_processor")
-class ToBatchProcessor:
+class ToBatchProcessor(ProcessorStep):
     """Processor that adds batch dimensions to observations and actions when needed.
 
     This processor ensures that observations and actions have proper batch dimensions for model processing:
@@ -59,81 +127,16 @@ class ToBatchProcessor:
         ```
     """
 
+    to_batch_action_processor: ToBatchProcessorAction = field(default_factory=ToBatchProcessorAction)
+    to_batch_observation_processor: ToBatchProcessorObservation = field(
+        default_factory=ToBatchProcessorObservation
+    )
+    to_batch_complementary_data_processor: ToBatchProcessorComplementaryData = field(
+        default_factory=ToBatchProcessorComplementaryData
+    )
+
     def __call__(self, transition: EnvTransition) -> EnvTransition:
-        self._process_observation(transition)
-        self._process_action(transition)
-        self._process_complementary_data(transition)
+        transition = self.to_batch_action_processor(transition)
+        transition = self.to_batch_observation_processor(transition)
+        transition = self.to_batch_complementary_data_processor(transition)
         return transition
-
-    def _process_observation(self, transition: EnvTransition) -> None:
-        """Process observation component in-place, adding batch dimensions where needed."""
-        observation = transition.get(TransitionKey.OBSERVATION)
-        if observation is None:
-            return
-
-        # Process state observations - add batch dim if 1D
-        for state_key in [OBS_STATE, OBS_ENV_STATE]:
-            if state_key in observation:
-                state_value = observation[state_key]
-                if isinstance(state_value, Tensor) and state_value.dim() == 1:
-                    observation[state_key] = state_value.unsqueeze(0)
-
-        # Process single image observation - add batch dim if 3D
-        if OBS_IMAGE in observation:
-            image_value = observation[OBS_IMAGE]
-            if isinstance(image_value, Tensor) and image_value.dim() == 3:
-                observation[OBS_IMAGE] = image_value.unsqueeze(0)
-
-        # Process multiple image observations - add batch dim if 3D
-        for key, value in observation.items():
-            if key.startswith(f"{OBS_IMAGES}.") and isinstance(value, Tensor) and value.dim() == 3:
-                observation[key] = value.unsqueeze(0)
-
-    def _process_action(self, transition: EnvTransition) -> None:
-        """Process action component in-place, adding batch dimension if needed."""
-        action = transition.get(TransitionKey.ACTION)
-        if action is not None and isinstance(action, Tensor) and action.dim() == 1:
-            transition[TransitionKey.ACTION] = action.unsqueeze(0)
-
-    def _process_complementary_data(self, transition: EnvTransition) -> None:
-        """Process complementary data in-place, handling task field batching."""
-        complementary_data = transition.get(TransitionKey.COMPLEMENTARY_DATA)
-        if complementary_data is None:
-            return
-
-        # Process task field - wrap string in list to add batch dimension
-        if "task" in complementary_data:
-            task_value = complementary_data["task"]
-            if isinstance(task_value, str):
-                complementary_data["task"] = [task_value]
-
-        # Process index field - add batch dim if 0D
-        if "index" in complementary_data:
-            index_value = complementary_data["index"]
-            if isinstance(index_value, Tensor) and index_value.dim() == 0:
-                complementary_data["index"] = index_value.unsqueeze(0)
-
-        # Process task_index field - add batch dim if 0D
-        if "task_index" in complementary_data:
-            task_index_value = complementary_data["task_index"]
-            if isinstance(task_index_value, Tensor) and task_index_value.dim() == 0:
-                complementary_data["task_index"] = task_index_value.unsqueeze(0)
-
-    def get_config(self) -> dict[str, Any]:
-        """Return configuration for serialization."""
-        return {}
-
-    def state_dict(self) -> dict[str, torch.Tensor]:
-        """Return state dictionary (empty for this processor)."""
-        return {}
-
-    def load_state_dict(self, state: dict[str, torch.Tensor]) -> None:
-        """Load state dictionary (no-op for this processor)."""
-        pass
-
-    def reset(self) -> None:
-        """Reset processor state (no-op for this processor)."""
-        pass
-
-    def transform_features(self, features: dict[str, PolicyFeature]) -> dict[str, PolicyFeature]:
-        return features

--- a/src/lerobot/processor/delta_action_processor.py
+++ b/src/lerobot/processor/delta_action_processor.py
@@ -78,10 +78,7 @@ class MapDeltaActionToRobotAction(ActionProcessor):
     position_scale: float = 1.0
     rotation_scale: float = 0.0  # No rotation deltas for gamepad/keyboard
 
-    def action(self, action: dict | None) -> dict:
-        if action is None:
-            return {}
-
+    def action(self, action: dict) -> dict:
         # NOTE (maractingi): Action can be a dict from the teleop_devices or a tensor from the policy
         # TODO (maractingi): changing this target_xyz naming convention from the teleop_devices
         delta_x = action.pop("action.delta_x", 0.0)

--- a/src/lerobot/processor/device_processor.py
+++ b/src/lerobot/processor/device_processor.py
@@ -18,14 +18,13 @@ from typing import Any
 
 import torch
 
-from lerobot.configs.types import PolicyFeature
-from lerobot.processor.pipeline import EnvTransition, ProcessorStepRegistry, TransitionKey
+from lerobot.processor.pipeline import EnvTransition, ProcessorStep, ProcessorStepRegistry, TransitionKey
 from lerobot.utils.utils import get_safe_torch_device
 
 
 @ProcessorStepRegistry.register("device_processor")
 @dataclass
-class DeviceProcessor:
+class DeviceProcessor(ProcessorStep):
     """Processes transitions by moving tensors to the specified device and optionally converting float dtypes.
 
     This processor ensures that all tensors in the transition are moved to the
@@ -145,18 +144,3 @@ class DeviceProcessor:
     def get_config(self) -> dict[str, Any]:
         """Return configuration for serialization."""
         return {"device": self.device, "float_dtype": self.float_dtype}
-
-    def state_dict(self) -> dict[str, torch.Tensor]:
-        """Return state dictionary (empty for this processor)."""
-        return {}
-
-    def load_state_dict(self, state: dict[str, torch.Tensor]) -> None:
-        """Load state dictionary (no-op for this processor)."""
-        pass
-
-    def reset(self) -> None:
-        """Reset processor state (no-op for this processor)."""
-        pass
-
-    def transform_features(self, features: dict[str, PolicyFeature]) -> dict[str, PolicyFeature]:
-        return features

--- a/src/lerobot/processor/gym_action_processor.py
+++ b/src/lerobot/processor/gym_action_processor.py
@@ -26,10 +26,7 @@ class Torch2NumpyActionProcessor(ActionProcessor):
 
     squeeze_batch_dim: bool = True
 
-    def action(self, action: torch.Tensor | None) -> np.ndarray | None:
-        if action is None:
-            return None
-
+    def action(self, action: torch.Tensor) -> np.ndarray:
         if not isinstance(action, torch.Tensor):
             raise TypeError(
                 f"Expected torch.Tensor or None, got {type(action).__name__}. "
@@ -56,9 +53,7 @@ class Torch2NumpyActionProcessor(ActionProcessor):
 class Numpy2TorchActionProcessor(ActionProcessor):
     """Convert NumPy array action to PyTorch tensor."""
 
-    def action(self, action: np.ndarray | None) -> torch.Tensor | None:
-        if action is None:
-            return None
+    def action(self, action: np.ndarray) -> torch.Tensor:
         if not isinstance(action, np.ndarray):
             raise TypeError(
                 f"Expected np.ndarray or None, got {type(action).__name__}. "

--- a/src/lerobot/processor/joint_observations_processor.py
+++ b/src/lerobot/processor/joint_observations_processor.py
@@ -22,10 +22,7 @@ class JointVelocityProcessor(ObservationProcessor):
 
     last_joint_positions: torch.Tensor | None = None
 
-    def observation(self, observation: dict | None) -> dict | None:
-        if observation is None:
-            return None
-
+    def observation(self, observation: dict) -> dict:
         # Get current joint positions (assuming they're in observation.state)
         current_positions = observation.get("observation.state")
         if current_positions is None:
@@ -75,10 +72,7 @@ class MotorCurrentProcessor(ObservationProcessor):
 
     robot: Robot | None = None
 
-    def observation(self, observation: dict | None) -> dict | None:
-        if observation is None:
-            return None
-
+    def observation(self, observation: dict) -> dict:
         # Get current values from robot state
         if self.robot is None:
             return observation

--- a/src/lerobot/processor/normalize_processor.py
+++ b/src/lerobot/processor/normalize_processor.py
@@ -11,7 +11,13 @@ from torch import Tensor
 
 from lerobot.configs.types import FeatureType, NormalizationMode, PolicyFeature
 from lerobot.datasets.lerobot_dataset import LeRobotDataset
-from lerobot.processor.pipeline import EnvTransition, ProcessorStepRegistry, RobotProcessor, TransitionKey
+from lerobot.processor.pipeline import (
+    EnvTransition,
+    ProcessorStep,
+    ProcessorStepRegistry,
+    RobotProcessor,
+    TransitionKey,
+)
 
 
 def _convert_stats_to_tensors(stats: dict[str, dict[str, Any]]) -> dict[str, dict[str, Tensor]]:
@@ -34,7 +40,7 @@ def _convert_stats_to_tensors(stats: dict[str, dict[str, Any]]) -> dict[str, dic
 
 @dataclass
 @ProcessorStepRegistry.register(name="normalizer_processor")
-class NormalizerProcessor:
+class NormalizerProcessor(ProcessorStep):
     """Normalizes observations and actions in a single processor step.
 
     This processor handles normalization of both observation and action tensors
@@ -254,16 +260,10 @@ class NormalizerProcessor:
             key, stat_name = flat_key.rsplit(".", 1)
             self._tensor_stats.setdefault(key, {})[stat_name] = tensor
 
-    def reset(self):
-        pass
-
-    def transform_features(self, features: dict[str, PolicyFeature]) -> dict[str, PolicyFeature]:
-        return features
-
 
 @dataclass
 @ProcessorStepRegistry.register(name="unnormalizer_processor")
-class UnnormalizerProcessor:
+class UnnormalizerProcessor(ProcessorStep):
     """Inverse normalisation for observations and actions.
 
     Exactly mirrors :class:`NormalizerProcessor` but applies the inverse
@@ -431,12 +431,6 @@ class UnnormalizerProcessor:
         for flat_key, tensor in state.items():
             key, stat_name = flat_key.rsplit(".", 1)
             self._tensor_stats.setdefault(key, {})[stat_name] = tensor
-
-    def reset(self):
-        pass
-
-    def transform_features(self, features: dict[str, PolicyFeature]) -> dict[str, PolicyFeature]:
-        return features
 
 
 def hotswap_stats(robot_processor: RobotProcessor, stats: dict[str, dict[str, Any]]) -> RobotProcessor:

--- a/src/lerobot/processor/pipeline.py
+++ b/src/lerobot/processor/pipeline.py
@@ -18,12 +18,13 @@ from __future__ import annotations
 import importlib
 import json
 import os
+from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable, Sequence
 from copy import deepcopy
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import Any, Protocol, TypedDict, runtime_checkable
+from typing import Any, TypedDict
 
 import torch
 from huggingface_hub import ModelHubMixin, hf_hub_download
@@ -132,8 +133,7 @@ class ProcessorStepRegistry:
         cls._registry.clear()
 
 
-@runtime_checkable
-class ProcessorStep(Protocol):
+class ProcessorStep(ABC):
     """Structural typing interface for a single processor step.
 
     A step is any callable accepting a full `EnvTransition` dict and
@@ -166,17 +166,34 @@ class ProcessorStep(Protocol):
     - state_dict(): {"weights": torch.tensor(...), "running_mean": torch.tensor(...)}
     """
 
-    def __call__(self, transition: EnvTransition) -> EnvTransition: ...
+    _current_transition: EnvTransition | None = None
 
-    def get_config(self) -> dict[str, Any]: ...
+    @property
+    def transition(self) -> EnvTransition:
+        """The current transition being processed by this step."""
+        if self._current_transition is None:
+            raise ValueError("Transition is not set. Make sure to call the step with a transition first.")
+        return self._current_transition
 
-    def state_dict(self) -> dict[str, torch.Tensor]: ...
+    @abstractmethod
+    def __call__(self, transition: EnvTransition) -> EnvTransition:
+        return transition
 
-    def load_state_dict(self, state: dict[str, torch.Tensor]) -> None: ...
+    def get_config(self) -> dict[str, Any]:
+        return {}
 
-    def reset(self) -> None: ...
+    def state_dict(self) -> dict[str, torch.Tensor]:
+        return {}
 
-    def transform_features(self, features: dict[str, PolicyFeature]) -> dict[str, PolicyFeature]: ...
+    def load_state_dict(self, state: dict[str, torch.Tensor]) -> None:
+        return None
+
+    def reset(self) -> None:
+        return None
+
+    # TODO(Steven): Consider making this abstract so it is more explicit
+    def transform_features(self, features: dict[str, PolicyFeature]) -> dict[str, PolicyFeature]:
+        return features
 
 
 def _default_batch_to_transition(batch: dict[str, Any]) -> EnvTransition:  # noqa: D401
@@ -837,7 +854,7 @@ class RobotProcessor(ModelHubMixin):
         return features
 
 
-class ObservationProcessor:
+class ObservationProcessor(ProcessorStep, ABC):
     """Base class for processors that modify only the observation component of a transition.
 
     Subclasses should override the `observation` method to implement custom observation processing.
@@ -858,7 +875,8 @@ class ObservationProcessor:
     manipulation, focusing only on the specific observation processing logic.
     """
 
-    def observation(self, observation):
+    @abstractmethod
+    def observation(self, observation) -> dict[str, Any]:
         """Process the observation component.
 
         Args:
@@ -867,36 +885,22 @@ class ObservationProcessor:
         Returns:
             The processed observation
         """
-        return observation
+        ...
 
     def __call__(self, transition: EnvTransition) -> EnvTransition:
-        observation = transition.get(TransitionKey.OBSERVATION)
+        self._current_transition = transition.copy()
+        new_transition = self._current_transition
+
+        observation = new_transition.get(TransitionKey.OBSERVATION)
         if observation is None:
-            return transition
+            return new_transition
 
         processed_observation = self.observation(observation)
-        # Create a new transition dict with the processed observation
-        new_transition = transition.copy()
         new_transition[TransitionKey.OBSERVATION] = processed_observation
         return new_transition
 
-    def get_config(self) -> dict[str, Any]:
-        return {}
 
-    def state_dict(self) -> dict[str, torch.Tensor]:
-        return {}
-
-    def load_state_dict(self, state: dict[str, torch.Tensor]) -> None:
-        pass
-
-    def reset(self) -> None:
-        pass
-
-    def transform_features(self, features: dict[str, PolicyFeature]) -> dict[str, PolicyFeature]:
-        return features
-
-
-class ActionProcessor:
+class ActionProcessor(ProcessorStep, ABC):
     """Base class for processors that modify only the action component of a transition.
 
     Subclasses should override the `action` method to implement custom action processing.
@@ -918,7 +922,8 @@ class ActionProcessor:
     manipulation, focusing only on the specific action processing logic.
     """
 
-    def action(self, action):
+    @abstractmethod
+    def action(self, action) -> Any | torch.Tensor:
         """Process the action component.
 
         Args:
@@ -927,36 +932,22 @@ class ActionProcessor:
         Returns:
             The processed action
         """
-        return action
+        ...
 
     def __call__(self, transition: EnvTransition) -> EnvTransition:
-        action = transition.get(TransitionKey.ACTION)
+        self._current_transition = transition.copy()
+        new_transition = self._current_transition
+
+        action = new_transition.get(TransitionKey.ACTION)
         if action is None:
-            return transition
+            return new_transition
 
         processed_action = self.action(action)
-        # Create a new transition dict with the processed action
-        new_transition = transition.copy()
         new_transition[TransitionKey.ACTION] = processed_action
         return new_transition
 
-    def get_config(self) -> dict[str, Any]:
-        return {}
 
-    def state_dict(self) -> dict[str, torch.Tensor]:
-        return {}
-
-    def load_state_dict(self, state: dict[str, torch.Tensor]) -> None:
-        pass
-
-    def reset(self) -> None:
-        pass
-
-    def transform_features(self, features: dict[str, PolicyFeature]) -> dict[str, PolicyFeature]:
-        return features
-
-
-class RewardProcessor:
+class RewardProcessor(ProcessorStep, ABC):
     """Base class for processors that modify only the reward component of a transition.
 
     Subclasses should override the `reward` method to implement custom reward processing.
@@ -977,7 +968,8 @@ class RewardProcessor:
     manipulation, focusing only on the specific reward processing logic.
     """
 
-    def reward(self, reward):
+    @abstractmethod
+    def reward(self, reward) -> float | torch.Tensor:
         """Process the reward component.
 
         Args:
@@ -986,36 +978,22 @@ class RewardProcessor:
         Returns:
             The processed reward
         """
-        return reward
+        ...
 
     def __call__(self, transition: EnvTransition) -> EnvTransition:
-        reward = transition.get(TransitionKey.REWARD)
+        self._current_transition = transition.copy()
+        new_transition = self._current_transition
+
+        reward = new_transition.get(TransitionKey.REWARD)
         if reward is None:
-            return transition
+            return new_transition
 
         processed_reward = self.reward(reward)
-        # Create a new transition dict with the processed reward
-        new_transition = transition.copy()
         new_transition[TransitionKey.REWARD] = processed_reward
         return new_transition
 
-    def get_config(self) -> dict[str, Any]:
-        return {}
 
-    def state_dict(self) -> dict[str, torch.Tensor]:
-        return {}
-
-    def load_state_dict(self, state: dict[str, torch.Tensor]) -> None:
-        pass
-
-    def reset(self) -> None:
-        pass
-
-    def transform_features(self, features: dict[str, PolicyFeature]) -> dict[str, PolicyFeature]:
-        return features
-
-
-class DoneProcessor:
+class DoneProcessor(ProcessorStep, ABC):
     """Base class for processors that modify only the done flag of a transition.
 
     Subclasses should override the `done` method to implement custom done flag processing.
@@ -1041,7 +1019,8 @@ class DoneProcessor:
     manipulation, focusing only on the specific done flag processing logic.
     """
 
-    def done(self, done):
+    @abstractmethod
+    def done(self, done) -> bool | torch.Tensor:
         """Process the done flag.
 
         Args:
@@ -1050,36 +1029,22 @@ class DoneProcessor:
         Returns:
             The processed done flag
         """
-        return done
+        ...
 
     def __call__(self, transition: EnvTransition) -> EnvTransition:
-        done = transition.get(TransitionKey.DONE)
+        self._current_transition = transition.copy()
+        new_transition = self._current_transition
+
+        done = new_transition.get(TransitionKey.DONE)
         if done is None:
-            return transition
+            return new_transition
 
         processed_done = self.done(done)
-        # Create a new transition dict with the processed done flag
-        new_transition = transition.copy()
         new_transition[TransitionKey.DONE] = processed_done
         return new_transition
 
-    def get_config(self) -> dict[str, Any]:
-        return {}
 
-    def state_dict(self) -> dict[str, torch.Tensor]:
-        return {}
-
-    def load_state_dict(self, state: dict[str, torch.Tensor]) -> None:
-        pass
-
-    def reset(self) -> None:
-        pass
-
-    def transform_features(self, features: dict[str, PolicyFeature]) -> dict[str, PolicyFeature]:
-        return features
-
-
-class TruncatedProcessor:
+class TruncatedProcessor(ProcessorStep, ABC):
     """Base class for processors that modify only the truncated flag of a transition.
 
     Subclasses should override the `truncated` method to implement custom truncated flag processing.
@@ -1101,7 +1066,8 @@ class TruncatedProcessor:
     manipulation, focusing only on the specific truncated flag processing logic.
     """
 
-    def truncated(self, truncated):
+    @abstractmethod
+    def truncated(self, truncated) -> bool | torch.Tensor:
         """Process the truncated flag.
 
         Args:
@@ -1110,36 +1076,22 @@ class TruncatedProcessor:
         Returns:
             The processed truncated flag
         """
-        return truncated
+        ...
 
     def __call__(self, transition: EnvTransition) -> EnvTransition:
-        truncated = transition.get(TransitionKey.TRUNCATED)
+        self._current_transition = transition.copy()
+        new_transition = self._current_transition
+
+        truncated = new_transition.get(TransitionKey.TRUNCATED)
         if truncated is None:
-            return transition
+            return new_transition
 
         processed_truncated = self.truncated(truncated)
-        # Create a new transition dict with the processed truncated flag
-        new_transition = transition.copy()
         new_transition[TransitionKey.TRUNCATED] = processed_truncated
         return new_transition
 
-    def get_config(self) -> dict[str, Any]:
-        return {}
 
-    def state_dict(self) -> dict[str, torch.Tensor]:
-        return {}
-
-    def load_state_dict(self, state: dict[str, torch.Tensor]) -> None:
-        pass
-
-    def reset(self) -> None:
-        pass
-
-    def transform_features(self, features: dict[str, PolicyFeature]) -> dict[str, PolicyFeature]:
-        return features
-
-
-class InfoProcessor:
+class InfoProcessor(ProcessorStep, ABC):
     """Base class for processors that modify only the info dictionary of a transition.
 
     Subclasses should override the `info` method to implement custom info processing.
@@ -1166,7 +1118,8 @@ class InfoProcessor:
     manipulation, focusing only on the specific info dictionary processing logic.
     """
 
-    def info(self, info):
+    @abstractmethod
+    def info(self, info) -> dict[str, Any]:
         """Process the info dictionary.
 
         Args:
@@ -1175,36 +1128,22 @@ class InfoProcessor:
         Returns:
             The processed info dictionary
         """
-        return info
+        ...
 
     def __call__(self, transition: EnvTransition) -> EnvTransition:
-        info = transition.get(TransitionKey.INFO)
+        self._current_transition = transition.copy()
+        new_transition = self._current_transition
+
+        info = new_transition.get(TransitionKey.INFO)
         if info is None:
-            return transition
+            return new_transition
 
         processed_info = self.info(info)
-        # Create a new transition dict with the processed info
-        new_transition = transition.copy()
         new_transition[TransitionKey.INFO] = processed_info
         return new_transition
 
-    def get_config(self) -> dict[str, Any]:
-        return {}
 
-    def state_dict(self) -> dict[str, torch.Tensor]:
-        return {}
-
-    def load_state_dict(self, state: dict[str, torch.Tensor]) -> None:
-        pass
-
-    def reset(self) -> None:
-        pass
-
-    def transform_features(self, features: dict[str, PolicyFeature]) -> dict[str, PolicyFeature]:
-        return features
-
-
-class ComplementaryDataProcessor:
+class ComplementaryDataProcessor(ProcessorStep, ABC):
     """Base class for processors that modify only the complementary data of a transition.
 
     Subclasses should override the `complementary_data` method to implement custom complementary data processing.
@@ -1212,7 +1151,8 @@ class ComplementaryDataProcessor:
     into the transition dict, eliminating the need to implement the `__call__` method in subclasses.
     """
 
-    def complementary_data(self, complementary_data):
+    @abstractmethod
+    def complementary_data(self, complementary_data) -> dict[str, Any]:
         """Process the complementary data.
 
         Args:
@@ -1221,52 +1161,23 @@ class ComplementaryDataProcessor:
         Returns:
             The processed complementary data
         """
-        return complementary_data
+        ...
 
     def __call__(self, transition: EnvTransition) -> EnvTransition:
-        complementary_data = transition.get(TransitionKey.COMPLEMENTARY_DATA)
+        self._current_transition = transition.copy()
+        new_transition = self._current_transition
+
+        complementary_data = new_transition.get(TransitionKey.COMPLEMENTARY_DATA)
         if complementary_data is None:
-            return transition
+            return new_transition
 
         processed_complementary_data = self.complementary_data(complementary_data)
-        # Create a new transition dict with the processed complementary data
-        new_transition = transition.copy()
         new_transition[TransitionKey.COMPLEMENTARY_DATA] = processed_complementary_data
         return new_transition
 
-    def get_config(self) -> dict[str, Any]:
-        return {}
 
-    def state_dict(self) -> dict[str, torch.Tensor]:
-        return {}
-
-    def load_state_dict(self, state: dict[str, torch.Tensor]) -> None:
-        pass
-
-    def reset(self) -> None:
-        pass
-
-    def transform_features(self, features: dict[str, PolicyFeature]) -> dict[str, PolicyFeature]:
-        return features
-
-
-class IdentityProcessor:
+class IdentityProcessor(ProcessorStep):
     """Identity processor that does nothing."""
 
     def __call__(self, transition: EnvTransition) -> EnvTransition:
         return transition
-
-    def get_config(self) -> dict[str, Any]:
-        return {}
-
-    def state_dict(self) -> dict[str, torch.Tensor]:
-        return {}
-
-    def load_state_dict(self, state: dict[str, torch.Tensor]) -> None:
-        pass
-
-    def reset(self) -> None:
-        pass
-
-    def transform_features(self, features: dict[str, PolicyFeature]) -> dict[str, PolicyFeature]:
-        return features

--- a/src/lerobot/processor/tokenizer_processor.py
+++ b/src/lerobot/processor/tokenizer_processor.py
@@ -11,7 +11,12 @@ import torch
 
 from lerobot.configs.types import FeatureType, PolicyFeature
 from lerobot.constants import OBS_LANGUAGE
-from lerobot.processor.pipeline import EnvTransition, ProcessorStepRegistry, TransitionKey
+from lerobot.processor.pipeline import (
+    EnvTransition,
+    ObservationProcessor,
+    ProcessorStepRegistry,
+    TransitionKey,
+)
 from lerobot.utils.import_utils import _transformers_available
 
 if TYPE_CHECKING or _transformers_available:
@@ -22,7 +27,7 @@ else:
 
 @dataclass
 @ProcessorStepRegistry.register(name="tokenizer_processor")
-class TokenizerProcessor:
+class TokenizerProcessor(ObservationProcessor):
     """Tokenizes text tasks in complementary data using a huggingface tokenizer.
 
     This processor handles tokenization of task strings found in the complementary_data
@@ -118,7 +123,7 @@ class TokenizerProcessor:
 
         return None
 
-    def __call__(self, transition: EnvTransition) -> EnvTransition:
+    def observation(self, observation):
         """Process the transition by tokenizing the task text.
 
         Args:
@@ -130,15 +135,15 @@ class TokenizerProcessor:
         Raises:
             ValueError: If tokenizer initialization failed.
         """
-        task = self.get_task(transition)
+        task = self.get_task(self.transition)
         if task is None:
-            return transition
+            return observation
 
         # Tokenize the task (creates CPU tensors)
         tokenized_prompt = self._tokenize_text(task)
 
         # Detect device from existing tensors in the transition
-        target_device = self._detect_device(transition)
+        target_device = self._detect_device(self.transition)
 
         # Move tokenized tensors to match the device of other data
         if target_device is not None:
@@ -148,20 +153,15 @@ class TokenizerProcessor:
             }
 
         # Get or create observation dict
-        observation = transition.get(TransitionKey.OBSERVATION)
-        if observation is None:
-            observation = {}
-        else:
-            observation = dict(observation)  # Make a copy
+        new_observation = dict(observation)
 
         # Add tokenized data to observation
-        observation[f"{OBS_LANGUAGE}.tokens"] = tokenized_prompt["input_ids"]
-        observation[f"{OBS_LANGUAGE}.attention_mask"] = tokenized_prompt["attention_mask"].to(
+        new_observation[f"{OBS_LANGUAGE}.tokens"] = tokenized_prompt["input_ids"]
+        new_observation[f"{OBS_LANGUAGE}.attention_mask"] = tokenized_prompt["attention_mask"].to(
             dtype=torch.bool
         )
 
-        transition[TransitionKey.OBSERVATION.value] = observation  # type: ignore[misc]
-        return transition
+        return new_observation
 
     def _detect_device(self, transition: EnvTransition) -> torch.device | None:
         """Detect device from existing tensors in the transition.
@@ -239,18 +239,6 @@ class TokenizerProcessor:
             config["tokenizer_name"] = self.tokenizer_name
 
         return config
-
-    def state_dict(self) -> dict[str, torch.Tensor]:
-        """Return state dictionary (empty for this processor)."""
-        return {}
-
-    def load_state_dict(self, state: dict[str, torch.Tensor]) -> None:
-        """Load state dictionary (no-op for this processor)."""
-        pass
-
-    def reset(self) -> None:
-        """Reset processor state (no-op for this processor)."""
-        pass
 
     def transform_features(self, features: dict[str, PolicyFeature]) -> dict[str, PolicyFeature]:
         """Add tokenized task features to the feature contract.

--- a/src/lerobot/teleoperators/phone/phone_processor.py
+++ b/src/lerobot/teleoperators/phone/phone_processor.py
@@ -16,7 +16,6 @@
 
 from dataclasses import dataclass, field
 
-from lerobot.configs.types import PolicyFeature
 from lerobot.processor.pipeline import ActionProcessor, ProcessorStepRegistry
 from lerobot.teleoperators.phone.config_phone import PhoneOS
 
@@ -46,7 +45,7 @@ class MapPhoneActionToRobotAction(ActionProcessor):
     platform: PhoneOS
     _enabled_prev: bool = field(default=False, init=False, repr=False)
 
-    def action(self, act: dict | None) -> dict:
+    def action(self, act: dict) -> dict:
         # Pop them from the action
         enabled = act.pop("action.phone.enabled", 0)
         pos = act.pop("action.phone.pos", None)
@@ -82,6 +81,3 @@ class MapPhoneActionToRobotAction(ActionProcessor):
             }
         )
         return act
-
-    def transform_features(self, features: dict[str, PolicyFeature]) -> dict[str, PolicyFeature]:
-        return features


### PR DESCRIPTION
* Move to inheritance over Protocol for the `ProcessorStep`, this reduces boiler plate code and enforces the interfaces
* Specialized Processors can now access the transition from `ProcessorStep`
* Update all processors to inherit either from `ProcessorStep` if they modify more than one item in the `EnvTransition` or from the specialized Processors if they modify only specific item.