### PR TITLE
Fix image deletion for non-batched video

### DIFF
--- a/src/lerobot/datasets/lerobot_dataset.py
+++ b/src/lerobot/datasets/lerobot_dataset.py
@@ -860,12 +860,6 @@ class LeRobotDataset(torch.utils.data.Dataset):
         has_video_keys = len(self.meta.video_keys) > 0
         use_batched_encoding = self.batch_encoding_size > 1
 
-        if has_video_keys and not use_batched_encoding:
-            self.encode_episode_videos(episode_index)
-
-        # `meta.save_episode` should be executed after encoding the videos
-        self.meta.save_episode(episode_index, episode_length, episode_tasks, ep_stats)
-
         # Check if we should trigger batch encoding
         if has_video_keys:
             if use_batched_encoding:
@@ -878,11 +872,16 @@ class LeRobotDataset(torch.utils.data.Dataset):
                     )
                     self.batch_encode_videos(start_ep, end_ep)
                     self.episodes_since_last_encoding = 0
+            else:
+                self.encode_episode_videos(episode_index)
         else:
             # delete images
             img_dir = self.root / "images"
             if img_dir.is_dir():
                 shutil.rmtree(self.root / "images")
+
+        # `meta.save_episode` should be executed after encoding the videos
+        self.meta.save_episode(episode_index, episode_length, episode_tasks, ep_stats)
 
         # Episode data index and timestamp checking
         ep_data_index = get_episode_data_index(self.meta.episodes, [episode_index])


### PR DESCRIPTION
## What this does

The batched video PR introduced a bug where temporary PNG images were not deleted if you were not using batched video. This PR is a small change to restore this behavior

## How it was tested

I recorded a dataset using a custom script on main, verifying that images were not deleted.

After implementing this change, temporary images are not stored and the parquet images are verified to be present using the visualize_dataset script

## How to checkout & try? (for the reviewer)
Run record.py with use_videos disabled.