### PR TITLE
refactor(policies): multiple improvements

### DIFF
--- a/examples/lekiwi/evaluate.py
+++ b/examples/lekiwi/evaluate.py
@@ -1,7 +1,7 @@
 from lerobot.datasets.lerobot_dataset import LeRobotDataset
 from lerobot.datasets.utils import hw_to_dataset_features
 from lerobot.policies.act.modeling_act import ACTPolicy
-from lerobot.policies.factory import make_processor
+from lerobot.policies.factory import make_pre_post_processors
 from lerobot.record import record_loop
 from lerobot.robots.lekiwi import LeKiwiClient, LeKiwiClientConfig
 from lerobot.utils.control_utils import init_keyboard_listener
@@ -46,7 +46,7 @@ listener, events = init_keyboard_listener()
 if not robot.is_connected:
     raise ValueError("Robot is not connected!")
 
-preprocessor, postprocessor = make_processor(
+preprocessor, postprocessor = make_pre_post_processors(
     policy_cfg=policy,
     pretrained_path=HF_MODEL_ID,
     dataset_stats=dataset.meta.stats,

--- a/examples/phone_so100_eval.py
+++ b/examples/phone_so100_eval.py
@@ -20,7 +20,7 @@ from lerobot.datasets.pipeline_features import aggregate_pipeline_dataset_featur
 from lerobot.datasets.utils import merge_features
 from lerobot.model.kinematics import RobotKinematics
 from lerobot.policies.act.modeling_act import ACTPolicy
-from lerobot.policies.factory import make_processor
+from lerobot.policies.factory import make_pre_post_processors
 from lerobot.processor.converters import (
     to_output_robot_action,
     to_transition_robot_observation,
@@ -127,7 +127,7 @@ robot.connect()
 episode_idx = 0
 
 policy = ACTPolicy.from_pretrained(HF_MODEL_ID)
-preprocessor, postprocessor = make_processor(
+preprocessor, postprocessor = make_pre_post_processors(
     policy_cfg=policy,
     pretrained_path=HF_MODEL_ID,
     dataset_stats=dataset.meta.stats,

--- a/src/lerobot/policies/act/modeling_act.py
+++ b/src/lerobot/policies/act/modeling_act.py
@@ -287,7 +287,7 @@ class ACT(nn.Module):
                                 └───────────────────────┘
     """
 
-    def __init__(self, config: ACTConfig, dataset_stats=None):
+    def __init__(self, config: ACTConfig):
         # BERT style VAE encoder with input tokens [cls, robot_state, *action_sequence].
         # The cls token forms parameters of the latent's distribution (like this [*means, *log_variances]).
         super().__init__()

--- a/src/lerobot/policies/act/processor_act.py
+++ b/src/lerobot/policies/act/processor_act.py
@@ -27,7 +27,7 @@ from lerobot.processor import (
 )
 
 
-def make_act_processor(
+def make_act_pre_post_processors(
     config: ACTConfig, dataset_stats: dict[str, dict[str, torch.Tensor]] | None = None
 ) -> tuple[RobotProcessor, RobotProcessor]:
     input_steps = [

--- a/src/lerobot/policies/diffusion/processor_diffusion.py
+++ b/src/lerobot/policies/diffusion/processor_diffusion.py
@@ -28,7 +28,7 @@ from lerobot.processor import (
 )
 
 
-def make_diffusion_processor(
+def make_diffusion_pre_post_processors(
     config: DiffusionConfig, dataset_stats: dict[str, dict[str, torch.Tensor]] | None = None
 ) -> tuple[RobotProcessor, RobotProcessor]:
     input_steps = [

--- a/src/lerobot/policies/factory.py
+++ b/src/lerobot/policies/factory.py
@@ -17,7 +17,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, TypedDict, cast
+from typing import Any, TypedDict
 
 import torch
 from torch import nn
@@ -117,7 +117,7 @@ class ProcessorConfigKwargs(TypedDict, total=False):
     dataset_stats: dict[str, dict[str, torch.Tensor]] | None
 
 
-def make_processor(
+def make_pre_post_processors(
     policy_cfg: PreTrainedConfig,
     pretrained_path: str | None = None,
     **kwargs: Unpack[ProcessorConfigKwargs],
@@ -154,68 +154,65 @@ def make_processor(
         )
 
     # Create a new processor based on policy type
-    if policy_cfg.type == "tdmpc":
-        from lerobot.policies.tdmpc.configuration_tdmpc import TDMPCConfig
-        from lerobot.policies.tdmpc.processor_tdmpc import make_tdmpc_processor
+    if isinstance(policy_cfg, TDMPCConfig):
+        from lerobot.policies.tdmpc.processor_tdmpc import make_tdmpc_pre_post_processors
 
-        processors = make_tdmpc_processor(
-            config=cast(TDMPCConfig, policy_cfg), dataset_stats=kwargs.get("dataset_stats")
+        processors = make_tdmpc_pre_post_processors(
+            config=policy_cfg, dataset_stats=kwargs.get("dataset_stats")
         )
 
-    elif policy_cfg.type == "diffusion":
-        from lerobot.policies.diffusion.processor_diffusion import make_diffusion_processor
+    elif isinstance(policy_cfg, DiffusionConfig):
+        from lerobot.policies.diffusion.processor_diffusion import make_diffusion_pre_post_processors
 
-        processors = make_diffusion_processor(
-            cast(DiffusionConfig, policy_cfg), dataset_stats=kwargs.get("dataset_stats")
+        processors = make_diffusion_pre_post_processors(
+            config=policy_cfg, dataset_stats=kwargs.get("dataset_stats")
         )
 
-    elif policy_cfg.type == "act":
-        from lerobot.policies.act.processor_act import make_act_processor
+    elif isinstance(policy_cfg.type, ACTConfig):
+        from lerobot.policies.act.processor_act import make_act_pre_post_processors
 
-        processors = make_act_processor(
-            config=cast(ACTConfig, policy_cfg), dataset_stats=kwargs.get("dataset_stats")
+        processors = make_act_pre_post_processors(
+            config=policy_cfg, dataset_stats=kwargs.get("dataset_stats")
         )
 
-    elif policy_cfg.type == "vqbet":
-        from lerobot.policies.vqbet.processor_vqbet import make_vqbet_processor
+    elif isinstance(policy_cfg, VQBeTConfig):
+        from lerobot.policies.vqbet.processor_vqbet import make_vqbet_pre_post_processors
 
-        processors = make_vqbet_processor(
-            config=cast(VQBeTConfig, policy_cfg), dataset_stats=kwargs.get("dataset_stats")
+        processors = make_vqbet_pre_post_processors(
+            config=policy_cfg, dataset_stats=kwargs.get("dataset_stats")
         )
 
-    elif policy_cfg.type == "pi0":
-        from lerobot.policies.pi0.processor_pi0 import make_pi0_processor
+    elif isinstance(policy_cfg, PI0Config):
+        from lerobot.policies.pi0.processor_pi0 import make_pi0_pre_post_processors
 
-        processors = make_pi0_processor(
-            config=cast(PI0Config, policy_cfg), dataset_stats=kwargs.get("dataset_stats")
+        processors = make_pi0_pre_post_processors(
+            config=policy_cfg, dataset_stats=kwargs.get("dataset_stats")
         )
 
-    elif policy_cfg.type == "pi0fast":
-        from lerobot.policies.pi0fast.processor_pi0fast import make_pi0fast_processor
+    elif isinstance(policy_cfg, PI0Config):
+        from lerobot.policies.pi0fast.processor_pi0fast import make_pi0fast_pre_post_processors
 
-        processors = make_pi0fast_processor(
-            cast(PI0Config, policy_cfg), dataset_stats=kwargs.get("dataset_stats")
+        processors = make_pi0fast_pre_post_processors(
+            config=policy_cfg, dataset_stats=kwargs.get("dataset_stats")
         )
 
-    elif policy_cfg.type == "sac":
-        from lerobot.policies.sac.processor_sac import make_sac_processor
+    elif isinstance(policy_cfg, SACConfig):
+        from lerobot.policies.sac.processor_sac import make_sac_pre_post_processors
 
-        processors = make_sac_processor(
-            cast(SACConfig, policy_cfg), dataset_stats=kwargs.get("dataset_stats")
+        processors = make_sac_pre_post_processors(
+            config=policy_cfg, dataset_stats=kwargs.get("dataset_stats")
         )
 
-    elif policy_cfg.type == "reward_classifier":
+    elif isinstance(policy_cfg, RewardClassifierConfig):
         from lerobot.policies.sac.reward_model.processor_classifier import make_classifier_processor
 
-        processors = make_classifier_processor(
-            cast(RewardClassifierConfig, policy_cfg), dataset_stats=kwargs.get("dataset_stats")
-        )
+        processors = make_classifier_processor(config=policy_cfg, dataset_stats=kwargs.get("dataset_stats"))
 
-    elif policy_cfg.type == "smolvla":
-        from lerobot.policies.smolvla.processor_smolvla import make_smolvla_processor
+    elif isinstance(policy_cfg, SmolVLAConfig):
+        from lerobot.policies.smolvla.processor_smolvla import make_smolvla_pre_post_processors
 
-        processors = make_smolvla_processor(
-            cast(SmolVLAConfig, policy_cfg), dataset_stats=kwargs.get("dataset_stats")
+        processors = make_smolvla_pre_post_processors(
+            config=policy_cfg, dataset_stats=kwargs.get("dataset_stats")
         )
 
     else:

--- a/src/lerobot/policies/pi0/processor_pi0.py
+++ b/src/lerobot/policies/pi0/processor_pi0.py
@@ -64,7 +64,7 @@ class Pi0NewLineProcessor(ComplementaryDataProcessor):
         return new_complementary_data
 
 
-def make_pi0_processor(
+def make_pi0_pre_post_processors(
     config: PI0Config, dataset_stats: dict[str, dict[str, torch.Tensor]] | None = None
 ) -> tuple[RobotProcessor, RobotProcessor]:
     # Add remaining processors

--- a/src/lerobot/policies/pi0fast/processor_pi0fast.py
+++ b/src/lerobot/policies/pi0fast/processor_pi0fast.py
@@ -28,7 +28,7 @@ from lerobot.processor import (
 )
 
 
-def make_pi0fast_processor(
+def make_pi0fast_pre_post_processors(
     config: PI0Config, dataset_stats: dict[str, dict[str, torch.Tensor]] | None = None
 ) -> tuple[RobotProcessor, RobotProcessor]:
     input_steps = [

--- a/src/lerobot/policies/sac/processor_sac.py
+++ b/src/lerobot/policies/sac/processor_sac.py
@@ -29,7 +29,7 @@ from lerobot.processor import (
 )
 
 
-def make_sac_processor(
+def make_sac_pre_post_processors(
     config: SACConfig, dataset_stats: dict[str, dict[str, torch.Tensor]] | None = None
 ) -> tuple[RobotProcessor, RobotProcessor]:
     input_steps = [

--- a/src/lerobot/policies/smolvla/processor_smolvla.py
+++ b/src/lerobot/policies/smolvla/processor_smolvla.py
@@ -33,7 +33,7 @@ from lerobot.processor.pipeline import (
 )
 
 
-def make_smolvla_processor(
+def make_smolvla_pre_post_processors(
     config: SmolVLAConfig, dataset_stats: dict[str, dict[str, torch.Tensor]] | None = None
 ) -> tuple[RobotProcessor, RobotProcessor]:
     input_steps = [

--- a/src/lerobot/policies/tdmpc/processor_tdmpc.py
+++ b/src/lerobot/policies/tdmpc/processor_tdmpc.py
@@ -28,7 +28,7 @@ from lerobot.processor import (
 )
 
 
-def make_tdmpc_processor(
+def make_tdmpc_pre_post_processors(
     config: TDMPCConfig, dataset_stats: dict[str, dict[str, torch.Tensor]] | None = None
 ) -> tuple[RobotProcessor, RobotProcessor]:
     input_steps = [

--- a/src/lerobot/policies/vqbet/processor_vqbet.py
+++ b/src/lerobot/policies/vqbet/processor_vqbet.py
@@ -29,7 +29,7 @@ from lerobot.processor import (
 )
 
 
-def make_vqbet_processor(
+def make_vqbet_pre_post_processors(
     config: VQBeTConfig, dataset_stats: dict[str, dict[str, torch.Tensor]] | None = None
 ) -> tuple[RobotProcessor, RobotProcessor]:
     input_steps = [

--- a/src/lerobot/record.py
+++ b/src/lerobot/record.py
@@ -74,7 +74,7 @@ from lerobot.datasets.image_writer import safe_stop_image_writer
 from lerobot.datasets.lerobot_dataset import LeRobotDataset
 from lerobot.datasets.utils import hw_to_dataset_features
 from lerobot.datasets.video_utils import VideoEncodingManager
-from lerobot.policies.factory import make_policy, make_processor
+from lerobot.policies.factory import make_policy, make_pre_post_processors
 from lerobot.policies.pretrained import PreTrainedPolicy
 from lerobot.processor import RobotProcessor
 from lerobot.processor.converters import (
@@ -434,7 +434,7 @@ def record(cfg: RecordConfig) -> LeRobotDataset:
     preprocessor = None
     postprocessor = None
     if cfg.policy is not None:
-        preprocessor, postprocessor = make_processor(
+        preprocessor, postprocessor = make_pre_post_processors(
             policy_cfg=cfg.policy,
             pretrained_path=cfg.policy.pretrained_path,
             dataset_stats=rename_stats(dataset.meta.stats, cfg.dataset.rename_map),

--- a/src/lerobot/scripts/train.py
+++ b/src/lerobot/scripts/train.py
@@ -32,7 +32,7 @@ from lerobot.datasets.sampler import EpisodeAwareSampler
 from lerobot.datasets.utils import cycle
 from lerobot.envs.factory import make_env
 from lerobot.optim.factory import make_optimizer_and_scheduler
-from lerobot.policies.factory import make_policy, make_processor
+from lerobot.policies.factory import make_policy, make_pre_post_processors
 from lerobot.policies.pretrained import PreTrainedPolicy
 from lerobot.policies.utils import get_device_from_parameters
 from lerobot.scripts.eval import eval_policy
@@ -141,7 +141,7 @@ def train(cfg: TrainPipelineConfig):
         cfg=cfg.policy,
         ds_meta=dataset.meta,
     )
-    preprocessor, postprocessor = make_processor(
+    preprocessor, postprocessor = make_pre_post_processors(
         policy_cfg=cfg.policy, pretrained_path=cfg.policy.pretrained_path, dataset_stats=dataset.meta.stats
     )
 

--- a/tests/artifacts/policies/save_policy_to_safetensors.py
+++ b/tests/artifacts/policies/save_policy_to_safetensors.py
@@ -23,7 +23,7 @@ from lerobot.configs.default import DatasetConfig
 from lerobot.configs.train import TrainPipelineConfig
 from lerobot.datasets.factory import make_dataset
 from lerobot.optim.factory import make_optimizer_and_scheduler
-from lerobot.policies.factory import make_policy, make_policy_config, make_processor
+from lerobot.policies.factory import make_policy, make_policy_config, make_pre_post_processors
 from lerobot.processor import TransitionKey
 from lerobot.utils.random_utils import set_seed
 
@@ -40,7 +40,7 @@ def get_policy_stats(ds_repo_id: str, policy_name: str, policy_kwargs: dict):
     dataset = make_dataset(train_cfg)
     dataset_stats = dataset.meta.stats
     policy = make_policy(train_cfg.policy, ds_meta=dataset.meta)
-    preprocessor, postprocessor = make_processor(train_cfg.policy, dataset_stats=dataset_stats)
+    preprocessor, postprocessor = make_pre_post_processors(train_cfg.policy, dataset_stats=dataset_stats)
     policy.train()
 
     optimizer, _ = make_optimizer_and_scheduler(train_cfg, policy)

--- a/tests/policies/test_policies.py
+++ b/tests/policies/test_policies.py
@@ -39,7 +39,7 @@ from lerobot.policies.factory import (
     get_policy_class,
     make_policy,
     make_policy_config,
-    make_processor,
+    make_pre_post_processors,
 )
 from lerobot.policies.pretrained import PreTrainedPolicy
 from lerobot.utils.random_utils import seeded_context
@@ -151,7 +151,7 @@ def test_policy(ds_repo_id, env_name, env_kwargs, policy_name, policy_kwargs):
 
     # Check that we can make the policy object.
     dataset = make_dataset(train_cfg)
-    preprocessor, _ = make_processor(train_cfg.policy, None)
+    preprocessor, _ = make_pre_post_processors(train_cfg.policy, None)
     policy = make_policy(train_cfg.policy, ds_meta=dataset.meta)
     assert isinstance(policy, PreTrainedPolicy)
 
@@ -225,7 +225,7 @@ def test_act_backbone_lr():
     assert cfg.policy.optimizer_lr_backbone == 0.001
 
     dataset = make_dataset(cfg)
-    preprocessor, _ = make_processor(cfg.policy, None)
+    preprocessor, _ = make_pre_post_processors(cfg.policy, None)
     policy = make_policy(cfg.policy, ds_meta=dataset.meta)
     optimizer, _ = make_optimizer_and_scheduler(cfg, policy)
     assert len(optimizer.param_groups) == 2

--- a/tests/processor/test_act_processor.py
+++ b/tests/processor/test_act_processor.py
@@ -23,7 +23,7 @@ import torch
 from lerobot.configs.types import FeatureType, NormalizationMode, PolicyFeature
 from lerobot.constants import ACTION, OBS_STATE
 from lerobot.policies.act.configuration_act import ACTConfig
-from lerobot.policies.act.processor_act import make_act_processor
+from lerobot.policies.act.processor_act import make_act_pre_post_processors
 from lerobot.processor import (
     DeviceProcessor,
     NormalizerProcessor,
@@ -78,7 +78,7 @@ def test_make_act_processor_basic():
     config = create_default_config()
     stats = create_default_stats()
 
-    preprocessor, postprocessor = make_act_processor(config, stats)
+    preprocessor, postprocessor = make_act_pre_post_processors(config, stats)
 
     # Check processor names
     assert preprocessor.name == "robot_preprocessor"
@@ -102,7 +102,7 @@ def test_act_processor_normalization():
     config = create_default_config()
     stats = create_default_stats()
 
-    preprocessor, postprocessor = make_act_processor(config, stats)
+    preprocessor, postprocessor = make_act_pre_post_processors(config, stats)
 
     # Create test data
     observation = {OBS_STATE: torch.randn(7)}
@@ -131,7 +131,7 @@ def test_act_processor_cuda():
     config.device = "cuda"
     stats = create_default_stats()
 
-    preprocessor, postprocessor = make_act_processor(config, stats)
+    preprocessor, postprocessor = make_act_pre_post_processors(config, stats)
 
     # Create CPU data
     observation = {OBS_STATE: torch.randn(7)}
@@ -160,7 +160,7 @@ def test_act_processor_accelerate_scenario():
     config.device = "cuda:0"
     stats = create_default_stats()
 
-    preprocessor, postprocessor = make_act_processor(config, stats)
+    preprocessor, postprocessor = make_act_pre_post_processors(config, stats)
 
     # Simulate Accelerate: data already on GPU
     device = torch.device("cuda:0")
@@ -183,7 +183,7 @@ def test_act_processor_multi_gpu():
     config.device = "cuda:0"
     stats = create_default_stats()
 
-    preprocessor, postprocessor = make_act_processor(config, stats)
+    preprocessor, postprocessor = make_act_pre_post_processors(config, stats)
 
     # Simulate data on different GPU (like in multi-GPU training)
     device = torch.device("cuda:1")
@@ -203,7 +203,7 @@ def test_act_processor_without_stats():
     """Test ACT processor creation without dataset statistics."""
     config = create_default_config()
 
-    preprocessor, postprocessor = make_act_processor(config, dataset_stats=None)
+    preprocessor, postprocessor = make_act_pre_post_processors(config, dataset_stats=None)
 
     # Should still create processors, but normalization won't have stats
     assert preprocessor is not None
@@ -223,7 +223,7 @@ def test_act_processor_save_and_load():
     config = create_default_config()
     stats = create_default_stats()
 
-    preprocessor, postprocessor = make_act_processor(config, stats)
+    preprocessor, postprocessor = make_act_pre_post_processors(config, stats)
 
     with tempfile.TemporaryDirectory() as tmpdir:
         # Save preprocessor
@@ -249,7 +249,7 @@ def test_act_processor_device_placement_preservation():
 
     # Test with CPU config
     config.device = "cpu"
-    preprocessor, _ = make_act_processor(config, stats)
+    preprocessor, _ = make_act_pre_post_processors(config, stats)
 
     # Process CPU data
     observation = {OBS_STATE: torch.randn(7)}
@@ -269,7 +269,7 @@ def test_act_processor_mixed_precision():
     stats = create_default_stats()
 
     # Modify the device processor to use float16
-    preprocessor, postprocessor = make_act_processor(config, stats)
+    preprocessor, postprocessor = make_act_pre_post_processors(config, stats)
 
     # Replace DeviceProcessor with one that uses float16
     for i, step in enumerate(preprocessor.steps):
@@ -294,7 +294,7 @@ def test_act_processor_batch_consistency():
     config = create_default_config()
     stats = create_default_stats()
 
-    preprocessor, postprocessor = make_act_processor(config, stats)
+    preprocessor, postprocessor = make_act_pre_post_processors(config, stats)
 
     # Test single sample (unbatched)
     observation = {OBS_STATE: torch.randn(7)}

--- a/tests/processor/test_diffusion_processor.py
+++ b/tests/processor/test_diffusion_processor.py
@@ -23,7 +23,7 @@ import torch
 from lerobot.configs.types import FeatureType, NormalizationMode, PolicyFeature
 from lerobot.constants import ACTION, OBS_IMAGE, OBS_STATE
 from lerobot.policies.diffusion.configuration_diffusion import DiffusionConfig
-from lerobot.policies.diffusion.processor_diffusion import make_diffusion_processor
+from lerobot.policies.diffusion.processor_diffusion import make_diffusion_pre_post_processors
 from lerobot.processor import (
     DeviceProcessor,
     NormalizerProcessor,
@@ -81,7 +81,7 @@ def test_make_diffusion_processor_basic():
     config = create_default_config()
     stats = create_default_stats()
 
-    preprocessor, postprocessor = make_diffusion_processor(config, stats)
+    preprocessor, postprocessor = make_diffusion_pre_post_processors(config, stats)
 
     # Check processor names
     assert preprocessor.name == "robot_preprocessor"
@@ -105,7 +105,7 @@ def test_diffusion_processor_with_images():
     config = create_default_config()
     stats = create_default_stats()
 
-    preprocessor, postprocessor = make_diffusion_processor(config, stats)
+    preprocessor, postprocessor = make_diffusion_pre_post_processors(config, stats)
 
     # Create test data with images
     observation = {
@@ -131,7 +131,7 @@ def test_diffusion_processor_cuda():
     config.device = "cuda"
     stats = create_default_stats()
 
-    preprocessor, postprocessor = make_diffusion_processor(config, stats)
+    preprocessor, postprocessor = make_diffusion_pre_post_processors(config, stats)
 
     # Create CPU data
     observation = {
@@ -164,7 +164,7 @@ def test_diffusion_processor_accelerate_scenario():
     config.device = "cuda:0"
     stats = create_default_stats()
 
-    preprocessor, postprocessor = make_diffusion_processor(config, stats)
+    preprocessor, postprocessor = make_diffusion_pre_post_processors(config, stats)
 
     # Simulate Accelerate: data already on GPU
     device = torch.device("cuda:0")
@@ -191,7 +191,7 @@ def test_diffusion_processor_multi_gpu():
     config.device = "cuda:0"
     stats = create_default_stats()
 
-    preprocessor, postprocessor = make_diffusion_processor(config, stats)
+    preprocessor, postprocessor = make_diffusion_pre_post_processors(config, stats)
 
     # Simulate data on different GPU
     device = torch.device("cuda:1")
@@ -215,7 +215,7 @@ def test_diffusion_processor_without_stats():
     """Test Diffusion processor creation without dataset statistics."""
     config = create_default_config()
 
-    preprocessor, postprocessor = make_diffusion_processor(config, dataset_stats=None)
+    preprocessor, postprocessor = make_diffusion_pre_post_processors(config, dataset_stats=None)
 
     # Should still create processors
     assert preprocessor is not None
@@ -238,7 +238,7 @@ def test_diffusion_processor_save_and_load():
     config = create_default_config()
     stats = create_default_stats()
 
-    preprocessor, postprocessor = make_diffusion_processor(config, stats)
+    preprocessor, postprocessor = make_diffusion_pre_post_processors(config, stats)
 
     with tempfile.TemporaryDirectory() as tmpdir:
         # Save preprocessor
@@ -269,7 +269,7 @@ def test_diffusion_processor_mixed_precision():
     stats = create_default_stats()
 
     # Create processor
-    preprocessor, postprocessor = make_diffusion_processor(config, stats)
+    preprocessor, postprocessor = make_diffusion_pre_post_processors(config, stats)
 
     # Replace DeviceProcessor with one that uses float16
     for i, step in enumerate(preprocessor.steps):
@@ -298,7 +298,7 @@ def test_diffusion_processor_identity_normalization():
     config = create_default_config()
     stats = create_default_stats()
 
-    preprocessor, postprocessor = make_diffusion_processor(config, stats)
+    preprocessor, postprocessor = make_diffusion_pre_post_processors(config, stats)
 
     # Create test data
     image_value = torch.rand(3, 224, 224) * 255  # Large values
@@ -322,7 +322,7 @@ def test_diffusion_processor_batch_consistency():
     config = create_default_config()
     stats = create_default_stats()
 
-    preprocessor, postprocessor = make_diffusion_processor(config, stats)
+    preprocessor, postprocessor = make_diffusion_pre_post_processors(config, stats)
 
     # Test with different batch sizes
     for batch_size in [1, 8, 32]:

--- a/tests/processor/test_pi0_processor.py
+++ b/tests/processor/test_pi0_processor.py
@@ -23,7 +23,7 @@ import torch
 from lerobot.configs.types import FeatureType, NormalizationMode, PolicyFeature
 from lerobot.constants import ACTION, OBS_IMAGE, OBS_STATE
 from lerobot.policies.pi0.configuration_pi0 import PI0Config
-from lerobot.policies.pi0.processor_pi0 import Pi0NewLineProcessor, make_pi0_processor
+from lerobot.policies.pi0.processor_pi0 import Pi0NewLineProcessor, make_pi0_pre_post_processors
 from lerobot.processor import (
     DeviceProcessor,
     NormalizerProcessor,
@@ -84,7 +84,7 @@ def test_make_pi0_processor_basic():
     stats = create_default_stats()
 
     with patch("lerobot.policies.pi0.processor_pi0.TokenizerProcessor"):
-        preprocessor, postprocessor = make_pi0_processor(config, stats)
+        preprocessor, postprocessor = make_pi0_pre_post_processors(config, stats)
 
     # Check processor names
     assert preprocessor.name == "robot_preprocessor"
@@ -183,7 +183,7 @@ def test_pi0_processor_cuda():
             return features
 
     with patch("lerobot.policies.pi0.processor_pi0.TokenizerProcessor", MockTokenizerProcessor):
-        preprocessor, postprocessor = make_pi0_processor(config, stats)
+        preprocessor, postprocessor = make_pi0_pre_post_processors(config, stats)
 
     # Create CPU data
     observation = {
@@ -233,7 +233,7 @@ def test_pi0_processor_accelerate_scenario():
             return features
 
     with patch("lerobot.policies.pi0.processor_pi0.TokenizerProcessor", MockTokenizerProcessor):
-        preprocessor, postprocessor = make_pi0_processor(config, stats)
+        preprocessor, postprocessor = make_pi0_pre_post_processors(config, stats)
 
     # Simulate Accelerate: data already on GPU and batched
     device = torch.device("cuda:0")
@@ -284,7 +284,7 @@ def test_pi0_processor_multi_gpu():
             return features
 
     with patch("lerobot.policies.pi0.processor_pi0.TokenizerProcessor", MockTokenizerProcessor):
-        preprocessor, postprocessor = make_pi0_processor(config, stats)
+        preprocessor, postprocessor = make_pi0_pre_post_processors(config, stats)
 
     # Simulate data on different GPU
     device = torch.device("cuda:1")
@@ -310,7 +310,7 @@ def test_pi0_processor_without_stats():
 
     # Mock the tokenizer processor
     with patch("lerobot.policies.pi0.processor_pi0.TokenizerProcessor"):
-        preprocessor, postprocessor = make_pi0_processor(config, dataset_stats=None)
+        preprocessor, postprocessor = make_pi0_pre_post_processors(config, dataset_stats=None)
 
     # Should still create processors
     assert preprocessor is not None

--- a/tests/processor/test_sac_processor.py
+++ b/tests/processor/test_sac_processor.py
@@ -23,7 +23,7 @@ import torch
 from lerobot.configs.types import FeatureType, NormalizationMode, PolicyFeature
 from lerobot.constants import ACTION, OBS_STATE
 from lerobot.policies.sac.configuration_sac import SACConfig
-from lerobot.policies.sac.processor_sac import make_sac_processor
+from lerobot.policies.sac.processor_sac import make_sac_pre_post_processors
 from lerobot.processor import (
     DeviceProcessor,
     NormalizerProcessor,
@@ -78,7 +78,7 @@ def test_make_sac_processor_basic():
     config = create_default_config()
     stats = create_default_stats()
 
-    preprocessor, postprocessor = make_sac_processor(config, stats)
+    preprocessor, postprocessor = make_sac_pre_post_processors(config, stats)
 
     # Check processor names
     assert preprocessor.name == "robot_preprocessor"
@@ -102,7 +102,7 @@ def test_sac_processor_normalization_modes():
     config = create_default_config()
     stats = create_default_stats()
 
-    preprocessor, postprocessor = make_sac_processor(config, stats)
+    preprocessor, postprocessor = make_sac_pre_post_processors(config, stats)
 
     # Create test data
     observation = {OBS_STATE: torch.randn(10) * 2}  # Larger values to test normalization
@@ -133,7 +133,7 @@ def test_sac_processor_cuda():
     config.device = "cuda"
     stats = create_default_stats()
 
-    preprocessor, postprocessor = make_sac_processor(config, stats)
+    preprocessor, postprocessor = make_sac_pre_post_processors(config, stats)
 
     # Create CPU data
     observation = {OBS_STATE: torch.randn(10)}
@@ -162,7 +162,7 @@ def test_sac_processor_accelerate_scenario():
     config.device = "cuda:0"
     stats = create_default_stats()
 
-    preprocessor, postprocessor = make_sac_processor(config, stats)
+    preprocessor, postprocessor = make_sac_pre_post_processors(config, stats)
 
     # Simulate Accelerate: data already on GPU
     device = torch.device("cuda:0")
@@ -185,7 +185,7 @@ def test_sac_processor_multi_gpu():
     config.device = "cuda:0"
     stats = create_default_stats()
 
-    preprocessor, postprocessor = make_sac_processor(config, stats)
+    preprocessor, postprocessor = make_sac_pre_post_processors(config, stats)
 
     # Simulate data on different GPU
     device = torch.device("cuda:1")
@@ -205,7 +205,7 @@ def test_sac_processor_without_stats():
     """Test SAC processor creation without dataset statistics."""
     config = create_default_config()
 
-    preprocessor, postprocessor = make_sac_processor(config, dataset_stats=None)
+    preprocessor, postprocessor = make_sac_pre_post_processors(config, dataset_stats=None)
 
     # Should still create processors
     assert preprocessor is not None
@@ -225,7 +225,7 @@ def test_sac_processor_save_and_load():
     config = create_default_config()
     stats = create_default_stats()
 
-    preprocessor, postprocessor = make_sac_processor(config, stats)
+    preprocessor, postprocessor = make_sac_pre_post_processors(config, stats)
 
     with tempfile.TemporaryDirectory() as tmpdir:
         # Save preprocessor
@@ -252,7 +252,7 @@ def test_sac_processor_mixed_precision():
     stats = create_default_stats()
 
     # Create processor
-    preprocessor, postprocessor = make_sac_processor(config, stats)
+    preprocessor, postprocessor = make_sac_pre_post_processors(config, stats)
 
     # Replace DeviceProcessor with one that uses float16
     for i, step in enumerate(preprocessor.steps):
@@ -277,7 +277,7 @@ def test_sac_processor_batch_data():
     config = create_default_config()
     stats = create_default_stats()
 
-    preprocessor, postprocessor = make_sac_processor(config, stats)
+    preprocessor, postprocessor = make_sac_pre_post_processors(config, stats)
 
     # Test with batched data
     batch_size = 32
@@ -298,7 +298,7 @@ def test_sac_processor_edge_cases():
     config = create_default_config()
     stats = create_default_stats()
 
-    preprocessor, postprocessor = make_sac_processor(config, stats)
+    preprocessor, postprocessor = make_sac_pre_post_processors(config, stats)
 
     # Test with empty observation
     transition = create_transition(observation={}, action=torch.randn(5))

--- a/tests/processor/test_smolvla_processor.py
+++ b/tests/processor/test_smolvla_processor.py
@@ -23,7 +23,10 @@ import torch
 from lerobot.configs.types import FeatureType, NormalizationMode, PolicyFeature
 from lerobot.constants import ACTION, OBS_IMAGE, OBS_STATE
 from lerobot.policies.smolvla.configuration_smolvla import SmolVLAConfig
-from lerobot.policies.smolvla.processor_smolvla import SmolVLANewLineProcessor, make_smolvla_processor
+from lerobot.policies.smolvla.processor_smolvla import (
+    SmolVLANewLineProcessor,
+    make_smolvla_pre_post_processors,
+)
 from lerobot.processor import (
     DeviceProcessor,
     NormalizerProcessor,
@@ -86,7 +89,7 @@ def test_make_smolvla_processor_basic():
     stats = create_default_stats()
 
     with patch("lerobot.policies.smolvla.processor_smolvla.TokenizerProcessor"):
-        preprocessor, postprocessor = make_smolvla_processor(config, stats)
+        preprocessor, postprocessor = make_smolvla_pre_post_processors(config, stats)
 
     # Check processor names
     assert preprocessor.name == "robot_preprocessor"
@@ -185,7 +188,7 @@ def test_smolvla_processor_cuda():
             return features
 
     with patch("lerobot.policies.smolvla.processor_smolvla.TokenizerProcessor", MockTokenizerProcessor):
-        preprocessor, postprocessor = make_smolvla_processor(config, stats)
+        preprocessor, postprocessor = make_smolvla_pre_post_processors(config, stats)
 
     # Create CPU data
     observation = {
@@ -235,7 +238,7 @@ def test_smolvla_processor_accelerate_scenario():
             return features
 
     with patch("lerobot.policies.smolvla.processor_smolvla.TokenizerProcessor", MockTokenizerProcessor):
-        preprocessor, postprocessor = make_smolvla_processor(config, stats)
+        preprocessor, postprocessor = make_smolvla_pre_post_processors(config, stats)
 
     # Simulate Accelerate: data already on GPU and batched
     device = torch.device("cuda:0")
@@ -286,7 +289,7 @@ def test_smolvla_processor_multi_gpu():
             return features
 
     with patch("lerobot.policies.smolvla.processor_smolvla.TokenizerProcessor", MockTokenizerProcessor):
-        preprocessor, postprocessor = make_smolvla_processor(config, stats)
+        preprocessor, postprocessor = make_smolvla_pre_post_processors(config, stats)
 
     # Simulate data on different GPU
     device = torch.device("cuda:1")
@@ -312,7 +315,7 @@ def test_smolvla_processor_without_stats():
 
     # Mock the tokenizer processor
     with patch("lerobot.policies.smolvla.processor_smolvla.TokenizerProcessor"):
-        preprocessor, postprocessor = make_smolvla_processor(config, dataset_stats=None)
+        preprocessor, postprocessor = make_smolvla_pre_post_processors(config, dataset_stats=None)
 
     # Should still create processors
     assert preprocessor is not None

--- a/tests/processor/test_tdmpc_processor.py
+++ b/tests/processor/test_tdmpc_processor.py
@@ -23,7 +23,7 @@ import torch
 from lerobot.configs.types import FeatureType, NormalizationMode, PolicyFeature
 from lerobot.constants import ACTION, OBS_IMAGE, OBS_STATE
 from lerobot.policies.tdmpc.configuration_tdmpc import TDMPCConfig
-from lerobot.policies.tdmpc.processor_tdmpc import make_tdmpc_processor
+from lerobot.policies.tdmpc.processor_tdmpc import make_tdmpc_pre_post_processors
 from lerobot.processor import (
     DeviceProcessor,
     NormalizerProcessor,
@@ -81,7 +81,7 @@ def test_make_tdmpc_processor_basic():
     config = create_default_config()
     stats = create_default_stats()
 
-    preprocessor, postprocessor = make_tdmpc_processor(config, stats)
+    preprocessor, postprocessor = make_tdmpc_pre_post_processors(config, stats)
 
     # Check processor names
     assert preprocessor.name == "robot_preprocessor"
@@ -105,7 +105,7 @@ def test_tdmpc_processor_normalization():
     config = create_default_config()
     stats = create_default_stats()
 
-    preprocessor, postprocessor = make_tdmpc_processor(config, stats)
+    preprocessor, postprocessor = make_tdmpc_pre_post_processors(config, stats)
 
     # Create test data
     observation = {
@@ -138,7 +138,7 @@ def test_tdmpc_processor_cuda():
     config.device = "cuda"
     stats = create_default_stats()
 
-    preprocessor, postprocessor = make_tdmpc_processor(config, stats)
+    preprocessor, postprocessor = make_tdmpc_pre_post_processors(config, stats)
 
     # Create CPU data
     observation = {
@@ -171,7 +171,7 @@ def test_tdmpc_processor_accelerate_scenario():
     config.device = "cuda:0"
     stats = create_default_stats()
 
-    preprocessor, postprocessor = make_tdmpc_processor(config, stats)
+    preprocessor, postprocessor = make_tdmpc_pre_post_processors(config, stats)
 
     # Simulate Accelerate: data already on GPU
     device = torch.device("cuda:0")
@@ -198,7 +198,7 @@ def test_tdmpc_processor_multi_gpu():
     config.device = "cuda:0"
     stats = create_default_stats()
 
-    preprocessor, postprocessor = make_tdmpc_processor(config, stats)
+    preprocessor, postprocessor = make_tdmpc_pre_post_processors(config, stats)
 
     # Simulate data on different GPU
     device = torch.device("cuda:1")
@@ -222,7 +222,7 @@ def test_tdmpc_processor_without_stats():
     """Test TDMPC processor creation without dataset statistics."""
     config = create_default_config()
 
-    preprocessor, postprocessor = make_tdmpc_processor(config, dataset_stats=None)
+    preprocessor, postprocessor = make_tdmpc_pre_post_processors(config, dataset_stats=None)
 
     # Should still create processors
     assert preprocessor is not None
@@ -245,7 +245,7 @@ def test_tdmpc_processor_save_and_load():
     config = create_default_config()
     stats = create_default_stats()
 
-    preprocessor, postprocessor = make_tdmpc_processor(config, stats)
+    preprocessor, postprocessor = make_tdmpc_pre_post_processors(config, stats)
 
     with tempfile.TemporaryDirectory() as tmpdir:
         # Save preprocessor
@@ -276,7 +276,7 @@ def test_tdmpc_processor_mixed_precision():
     stats = create_default_stats()
 
     # Create processor
-    preprocessor, postprocessor = make_tdmpc_processor(config, stats)
+    preprocessor, postprocessor = make_tdmpc_pre_post_processors(config, stats)
 
     # Replace DeviceProcessor with one that uses float16
     for i, step in enumerate(preprocessor.steps):
@@ -305,7 +305,7 @@ def test_tdmpc_processor_batch_data():
     config = create_default_config()
     stats = create_default_stats()
 
-    preprocessor, postprocessor = make_tdmpc_processor(config, stats)
+    preprocessor, postprocessor = make_tdmpc_pre_post_processors(config, stats)
 
     # Test with batched data
     batch_size = 64
@@ -330,7 +330,7 @@ def test_tdmpc_processor_edge_cases():
     config = create_default_config()
     stats = create_default_stats()
 
-    preprocessor, postprocessor = make_tdmpc_processor(config, stats)
+    preprocessor, postprocessor = make_tdmpc_pre_post_processors(config, stats)
 
     # Test with only state observation (no image)
     observation = {OBS_STATE: torch.randn(12)}

--- a/tests/processor/test_vqbet_processor.py
+++ b/tests/processor/test_vqbet_processor.py
@@ -23,7 +23,7 @@ import torch
 from lerobot.configs.types import FeatureType, NormalizationMode, PolicyFeature
 from lerobot.constants import ACTION, OBS_IMAGE, OBS_STATE
 from lerobot.policies.vqbet.configuration_vqbet import VQBeTConfig
-from lerobot.policies.vqbet.processor_vqbet import make_vqbet_processor
+from lerobot.policies.vqbet.processor_vqbet import make_vqbet_pre_post_processors
 from lerobot.processor import (
     DeviceProcessor,
     NormalizerProcessor,
@@ -81,7 +81,7 @@ def test_make_vqbet_processor_basic():
     config = create_default_config()
     stats = create_default_stats()
 
-    preprocessor, postprocessor = make_vqbet_processor(config, stats)
+    preprocessor, postprocessor = make_vqbet_pre_post_processors(config, stats)
 
     # Check processor names
     assert preprocessor.name == "robot_preprocessor"
@@ -105,7 +105,7 @@ def test_vqbet_processor_with_images():
     config = create_default_config()
     stats = create_default_stats()
 
-    preprocessor, postprocessor = make_vqbet_processor(config, stats)
+    preprocessor, postprocessor = make_vqbet_pre_post_processors(config, stats)
 
     # Create test data with images and states
     observation = {
@@ -131,7 +131,7 @@ def test_vqbet_processor_cuda():
     config.device = "cuda"
     stats = create_default_stats()
 
-    preprocessor, postprocessor = make_vqbet_processor(config, stats)
+    preprocessor, postprocessor = make_vqbet_pre_post_processors(config, stats)
 
     # Create CPU data
     observation = {
@@ -164,7 +164,7 @@ def test_vqbet_processor_accelerate_scenario():
     config.device = "cuda:0"
     stats = create_default_stats()
 
-    preprocessor, postprocessor = make_vqbet_processor(config, stats)
+    preprocessor, postprocessor = make_vqbet_pre_post_processors(config, stats)
 
     # Simulate Accelerate: data already on GPU and batched
     device = torch.device("cuda:0")
@@ -191,7 +191,7 @@ def test_vqbet_processor_multi_gpu():
     config.device = "cuda:0"
     stats = create_default_stats()
 
-    preprocessor, postprocessor = make_vqbet_processor(config, stats)
+    preprocessor, postprocessor = make_vqbet_pre_post_processors(config, stats)
 
     # Simulate data on different GPU
     device = torch.device("cuda:1")
@@ -215,7 +215,7 @@ def test_vqbet_processor_without_stats():
     """Test VQBeT processor creation without dataset statistics."""
     config = create_default_config()
 
-    preprocessor, postprocessor = make_vqbet_processor(config, dataset_stats=None)
+    preprocessor, postprocessor = make_vqbet_pre_post_processors(config, dataset_stats=None)
 
     # Should still create processors
     assert preprocessor is not None
@@ -238,7 +238,7 @@ def test_vqbet_processor_save_and_load():
     config = create_default_config()
     stats = create_default_stats()
 
-    preprocessor, postprocessor = make_vqbet_processor(config, stats)
+    preprocessor, postprocessor = make_vqbet_pre_post_processors(config, stats)
 
     with tempfile.TemporaryDirectory() as tmpdir:
         # Save preprocessor
@@ -269,7 +269,7 @@ def test_vqbet_processor_mixed_precision():
     stats = create_default_stats()
 
     # Create processor
-    preprocessor, postprocessor = make_vqbet_processor(config, stats)
+    preprocessor, postprocessor = make_vqbet_pre_post_processors(config, stats)
 
     # Replace DeviceProcessor with one that uses float16
     for i, step in enumerate(preprocessor.steps):
@@ -298,7 +298,7 @@ def test_vqbet_processor_large_batch():
     config = create_default_config()
     stats = create_default_stats()
 
-    preprocessor, postprocessor = make_vqbet_processor(config, stats)
+    preprocessor, postprocessor = make_vqbet_pre_post_processors(config, stats)
 
     # Test with large batch
     batch_size = 128
@@ -323,7 +323,7 @@ def test_vqbet_processor_sequential_processing():
     config = create_default_config()
     stats = create_default_stats()
 
-    preprocessor, postprocessor = make_vqbet_processor(config, stats)
+    preprocessor, postprocessor = make_vqbet_pre_post_processors(config, stats)
 
     # Process multiple samples sequentially
     results = []


### PR DESCRIPTION
* Rename from `make_XYZ_processor()` to `make_XYZ_pre_post_processors()`
* Delete unused `dataset_stats` in modeling ACT
* Delete not needed re-import of `TDMPCConfig`
* Rename from `make_processor()` to `make_pre_post_processor()`
* Instead of checking `config.type` we check `isinstance(config,XYZ)` and remove the casting