### PR TITLE
Fixes: Overriding input and output features from a config (🐛 Bug) 

### DIFF
--- a/src/lerobot/policies/factory.py
+++ b/src/lerobot/policies/factory.py
@@ -157,8 +157,10 @@ def make_policy(
             )
         features = env_to_policy_features(env_cfg)
 
-    cfg.output_features = {key: ft for key, ft in features.items() if ft.type is FeatureType.ACTION}
-    cfg.input_features = {key: ft for key, ft in features.items() if key not in cfg.output_features}
+    if not cfg.output_features:
+        cfg.output_features = {key: ft for key, ft in features.items() if ft.type is FeatureType.ACTION}
+    if not cfg.input_features:
+        cfg.input_features = {key: ft for key, ft in features.items() if key not in cfg.output_features}
     kwargs["config"] = cfg
 
     if cfg.pretrained_path:


### PR DESCRIPTION
## What this does

If the config already defines some `input_features` selection, e.g. only a subset of images, this selection is overwritten.
This happens for example when loading a checkpoint or using the `train()` function from `scripts/train.py`

By including this change, it would allow to filter for specific camera views / modalities.
