### PR TITLE
[NIRYO x HF] Making Ned2 Available in LeRobot

### DIFF
--- a/docs/source/_static/ned2_right_angle_pose.svg
+++ b/docs/source/_static/ned2_right_angle_pose.svg
@@ -2,7 +2,6 @@
   <rect width="100%" height="100%" fill="#F5F7FA"/>
   <rect x="20" y="20" width="920" height="500" fill="none" stroke="#CBD5E1" stroke-width="2"/>
   <text x="480" y="70" text-anchor="middle" font-family="Arial, sans-serif" font-size="24" fill="#0F172A">Right-angle Pose — Placeholder</text>
-  <text x="480" y="100" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" fill="#475569">Replace this file with your real illustration</text>
 
   <!-- Base -->
   <rect x="430" y="360" width="100" height="40" fill="#E2E8F0" stroke="#94A3B8"/>

--- a/docs/source/_static/ned2_right_angle_pose.svg
+++ b/docs/source/_static/ned2_right_angle_pose.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="540" viewBox="0 0 960 540">
+  <rect width="100%" height="100%" fill="#F5F7FA"/>
+  <rect x="20" y="20" width="920" height="500" fill="none" stroke="#CBD5E1" stroke-width="2"/>
+  <text x="480" y="70" text-anchor="middle" font-family="Arial, sans-serif" font-size="24" fill="#0F172A">Right-angle Pose — Placeholder</text>
+  <text x="480" y="100" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" fill="#475569">Replace this file with your real illustration</text>
+
+  <!-- Base -->
+  <rect x="430" y="360" width="100" height="40" fill="#E2E8F0" stroke="#94A3B8"/>
+  <!-- Shoulder -->
+  <rect x="475" y="280" width="10" height="80" fill="#BFDBFE" stroke="#60A5FA"/>
+  <!-- Elbow (right angle) -->
+  <rect x="485" y="280" width="80" height="10" fill="#BFDBFE" stroke="#60A5FA"/>
+  <!-- Forearm -->
+  <rect x="565" y="280" width="10" height="70" fill="#BFDBFE" stroke="#60A5FA"/>
+  <!-- Gripper open -->
+  <line x1="560" y1="350" x2="580" y2="370" stroke="#F59E0B" stroke-width="4"/>
+  <line x1="570" y1="350" x2="590" y2="370" stroke="#F59E0B" stroke-width="4"/>
+
+  <text x="480" y="420" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="#475569">Approximate “right-angle” pose, gripper open</text>
+</svg> 

--- a/docs/source/_static/ned2_teleop_setup.svg
+++ b/docs/source/_static/ned2_teleop_setup.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="960" height="540" viewBox="0 0 960 540">
+  <rect width="100%" height="100%" fill="#F5F7FA"/>
+  <rect x="20" y="20" width="920" height="500" fill="none" stroke="#CBD5E1" stroke-width="2"/>
+  <text x="480" y="70" text-anchor="middle" font-family="Arial, sans-serif" font-size="24" fill="#0F172A">Ned2 Teleoperation Wiring — Placeholder</text>
+  <text x="480" y="100" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" fill="#475569">Replace this file with your real diagram</text>
+
+  <!-- Router/Switch -->
+  <rect x="430" y="200" width="100" height="60" rx="8" fill="#E2E8F0" stroke="#94A3B8"/>
+  <text x="480" y="235" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" fill="#0F172A">Router</text>
+
+  <!-- Leader -->
+  <rect x="110" y="190" width="140" height="80" rx="10" fill="#DBEAFE" stroke="#60A5FA"/>
+  <text x="180" y="235" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" fill="#1E3A8A">Ned2 Leader</text>
+
+  <!-- Follower -->
+  <rect x="710" y="190" width="140" height="80" rx="10" fill="#DCFCE7" stroke="#34D399"/>
+  <text x="780" y="235" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" fill="#065F46">Ned2 Follower</text>
+
+  <!-- PC -->
+  <rect x="430" y="370" width="100" height="60" rx="8" fill="#FFE4E6" stroke="#FB7185"/>
+  <text x="480" y="405" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" fill="#9F1239">PC</text>
+
+  <!-- Links -->
+  <line x1="250" y1="230" x2="430" y2="230" stroke="#64748B" stroke-width="2"/>
+  <line x1="530" y1="230" x2="710" y2="230" stroke="#64748B" stroke-width="2"/>
+  <line x1="480" y1="260" x2="480" y2="370" stroke="#64748B" stroke-width="2"/>
+
+  <text x="340" y="220" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="#475569">Ethernet</text>
+  <text x="620" y="220" text-anchor="middle" font-family="Arial, sans-serif" font-size="12" fill="#475569">Ethernet</text>
+  <text x="500" y="320" text-anchor="start" font-family="Arial, sans-serif" font-size="12" fill="#475569" transform="rotate(90,500,320)">Ethernet</text>
+</svg> 

--- a/docs/source/_static/ned2_teleop_setup.svg
+++ b/docs/source/_static/ned2_teleop_setup.svg
@@ -2,7 +2,6 @@
   <rect width="100%" height="100%" fill="#F5F7FA"/>
   <rect x="20" y="20" width="920" height="500" fill="none" stroke="#CBD5E1" stroke-width="2"/>
   <text x="480" y="70" text-anchor="middle" font-family="Arial, sans-serif" font-size="24" fill="#0F172A">Ned2 Teleoperation Wiring — Placeholder</text>
-  <text x="480" y="100" text-anchor="middle" font-family="Arial, sans-serif" font-size="14" fill="#475569">Replace this file with your real diagram</text>
 
   <!-- Router/Switch -->
   <rect x="430" y="200" width="100" height="60" rx="8" fill="#E2E8F0" stroke="#94A3B8"/>

--- a/docs/source/installation.mdx
+++ b/docs/source/installation.mdx
@@ -100,7 +100,7 @@ pip install -e ".[aloha]" # or "[pusht]" for example
 
 ### Motor Control
 
-For Koch v1.1 install the Dynamixel SDK, for SO100/SO101/Moss install the Feetech SDK.
+For Koch v1.1 and Ned2 install the Dynamixel SDK, for SO100/SO101/Moss install the Feetech SDK.
 
 ```bash
 pip install -e ".[feetech]" # or "[dynamixel]" for example

--- a/docs/source/ned2.mdx
+++ b/docs/source/ned2.mdx
@@ -132,7 +132,7 @@ Run the following command to calibrate a Ned2 robot:
 lerobot-calibrate \
     --robot.type=ned2 \
     --robot.ip=169.254.XX.XX \
-    --robot.id=my_awesome_follower_arm
+    --robot.id=my_awesome_follower_arm #<- Give your robot a unique name
 ```
 
 During calibration, you will be prompted to place the robot roughly in the middle of its motion range and press Enter. This corresponds to a "right-angle" pose with the gripper open. This safe reference pose reduces the risk of erroneous or corrupted readings from the stepper motor encoders that can occur when joints are too close to their mechanical end-stops.

--- a/docs/source/ned2.mdx
+++ b/docs/source/ned2.mdx
@@ -37,7 +37,7 @@ conda install socat -c conda-forge
   - Connect the router/switch to your computer
   - Use 3 distinct Ethernet cables (one per link)
 
-![Wiring diagram (example)](/_static/ned2_teleop_setup.svg)
+![Wiring diagram (example)](/docs/source/_static/ned2_teleop_setup.svg)
 
 _TODO: place the diagram image at `docs/source/_static/ned2_teleop_setup.svg`._
 
@@ -142,7 +142,7 @@ lerobot-calibrate \
 
 During calibration, you will be prompted to place the robot roughly in the middle of its motion range and press Enter. This corresponds to a "right-angle" pose with the gripper open. This safe reference pose reduces the risk of erroneous or corrupted readings from the stepper motor encoders that can occur when joints are too close to their mechanical end-stops.
 
-![Right-angle pose (example)](/_static/ned2_right_angle_pose.svg)
+![Right-angle pose (example)](/docs/source/_static/ned2_right_angle_pose.svg)
 
 _TODO: place our image at `docs/source/_static/ned2_right_angle_pose.svg`._
 

--- a/docs/source/ned2.mdx
+++ b/docs/source/ned2.mdx
@@ -107,7 +107,7 @@ sudo systemctl start ser2net
 systemctl status ser2net
 ```
   - Tip: you only need to do this once; it will persist.
-  - Tip 2: if your robot runs a "HF ready stack, you can avoid the netplan and ser2net part. 
+  - Tip 2: if your robot runs a "HF ready stack", you can avoid the netplan and ser2net part. 
 
 
 ### PC side
@@ -123,7 +123,7 @@ ping <follower-ip> # e.g., 169.254.U.V
 
 ## Calibration
 
-Our robots are a bit special: after each reboot you need to calibrate them. This is because they use relative encoders instead of classic absolute encoders.
+Our robots need a calibration after each reboot. This is because they use relative encoders instead of classic absolute encoders.
 
 Run the following command to calibrate a Ned2 robot:
 

--- a/docs/source/ned2.mdx
+++ b/docs/source/ned2.mdx
@@ -39,7 +39,7 @@ conda install socat -c conda-forge
 
 ![Wiring diagram (example)](/_static/ned2_teleop_setup.svg)
 
-_Tip: place your diagram image at `docs/source/_static/ned2_teleop_setup.svg`._
+_TODO: place the diagram image at `docs/source/_static/ned2_teleop_setup.svg`._
 
 ### Robot side (for both robots)
 
@@ -107,8 +107,13 @@ sudo systemctl start ser2net
 systemctl status ser2net
 ```
   - Tip: you only need to do this once; it will persist.
-  - Tip 2: if your robot runs a "HF ready stack", you can avoid the netplan and ser2net part. 
+  - Tip 2: if your robot runs a "HF ready stack", you can avoid the netplan and ser2net part.
 
+  - Kill the ROS-Stack to free the motor bus. Note that this will make the power button and other Niryo services unavailable. If you want to reuse the robot normally, unplug it and let it reboot.
+
+```bash
+rosnode kill -a
+```
 
 ### PC side
 
@@ -139,7 +144,7 @@ During calibration, you will be prompted to place the robot roughly in the middl
 
 ![Right-angle pose (example)](/_static/ned2_right_angle_pose.svg)
 
-_Tip: place your image at `docs/source/_static/ned2_right_angle_pose.svg`._
+_TODO: place our image at `docs/source/_static/ned2_right_angle_pose.svg`._
 
 Repeat the operation for the teleoperator with its own settings (e.g., `--teleop.type=ned2_leader`, `--teleop.ip`, `--teleop.id`).
 

--- a/docs/source/ned2.mdx
+++ b/docs/source/ned2.mdx
@@ -1,0 +1,163 @@
+# Ned2
+
+
+## Buy a robot
+
+You can buy the Ned2 directly from our store:
+[Buy the Ned2 on Niryo’s website](https://niryo.com/fr/produit/bras-robotise-6-axes/)
+
+## Install LeRobot 🤗
+
+To install LeRobot, follow our Installation Guide.
+
+In addition to these instructions, you need to install the **Dynamixel SDK**:
+
+```bash
+pip install -e ".[dynamixel]"
+```
+You will also need to install socat in order to remap the motor bus of the robot’s Raspberry Pi to your computer via an open TCP port.
+We recommend installing it with conda:
+
+```bash
+conda install socat -c conda-forge
+```
+
+## Set up the robot for LeRobot
+
+### Hardware setup
+
+- **Required gear**:
+  - 3 Ethernet RJ45 cables
+  - 1 Ethernet router or switch
+  - 2 Ned2 robots (1 “leader” for teleoperation, 1 “follower”)
+  - The follower robot must be equipped with a custom gripper
+- **Wiring**:
+  - Connect the rear Ethernet port of the Ned2 “follower” to the router/switch
+  - Connect the rear Ethernet port of the Ned2 “leader” to the router/switch
+  - Connect the router/switch to your computer
+  - Use 3 distinct Ethernet cables (one per link)
+
+![Wiring diagram (example)](/_static/ned2_teleop_setup.svg)
+
+_Tip: place your diagram image at `docs/source/_static/ned2_teleop_setup.svg`._
+
+### Robot side (for both robots)
+
+- **SSH connection**
+  - Use NiryoStudio (integrated terminal) or your terminal:
+
+```bash
+ssh niryo@ned2-<robot-ssid>.local
+# Default password: robotics
+```
+
+- **Verify “link-local only” mode** (low latency)
+  - Goal: minimize latency between PC and robots for real-time control (processing on PC, execution on hardware)
+  - Check the local IP address:
+
+```bash
+ip a
+```
+  - If the IP of the robot’s Ethernet interface starts with `169.254.*.*`, you’re good. Otherwise, set the network to “link-local only” via netplan:
+
+```bash
+sudo nano /etc/netplan/*.yaml
+```
+  - Adapt the interface (e.g. `eth0`) and make sure you have at least:
+
+```yaml
+network:
+  version: 2
+  ethernets:
+    eth0:
+      dhcp4: no
+      dhcp6: no
+      link-local: [ipv4]
+```
+  - Save (Ctrl+S), exit (Ctrl+X), then apply:
+
+```bash
+sudo netplan apply
+```
+
+- **Expose the motor TTL bus over TCP (ser2net)**
+
+```bash
+sudo apt update && sudo apt install -y ser2net
+```
+  - Edit the configuration (depending on your version, the file may be `/etc/ser2net.conf`):
+
+```bash
+sudo nano /etc/ser2net.conf
+```
+  - Add the following line to remap `/dev/ttyAMA0` (motors bus) to TCP port `7777` at `1000000` baud:
+
+```
+7777:1000000:8n1:none:/dev/ttyAMA0
+```
+  - Restart the service:
+
+```bash
+sudo systemctl stop ser2net
+sudo systemctl start ser2net
+```
+  - Check status:
+
+```bash
+systemctl status ser2net
+```
+  - Tip: you only need to do this once; it will persist.
+  - Tip 2: if your robot runs a "HF ready stack, you can avoid the netplan and ser2net part. 
+
+
+### PC side
+
+- Ensure your PC is connected to the same local Ethernet network (the router/switch) as both robots
+- If that’s the case, you’re good to go
+- (Optional) Test connectivity by pinging both robots. The IPs should start with `169.254.*.*` when in link-local only mode:
+
+```bash
+ping <leader-ip>   # e.g., 169.254.X.Y
+ping <follower-ip> # e.g., 169.254.U.V
+```
+
+## Calibration
+
+Our robots are a bit special: after each reboot you need to calibrate them. This is because they use relative encoders instead of classic absolute encoders.
+
+Run the following command to calibrate a Ned2 robot:
+
+```bash
+# Replace with the actual link-local IP of your robot (169.254.X.Y)
+lerobot-calibrate \
+    --robot.type=ned2 \
+    --robot.ip=169.254.XX.XX \
+    --robot.id=my_awesome_follower_arm
+```
+
+During calibration, you will be prompted to place the robot roughly in the middle of its motion range and press Enter. This corresponds to a "right-angle" pose with the gripper open. This safe reference pose reduces the risk of erroneous or corrupted readings from the stepper motor encoders that can occur when joints are too close to their mechanical end-stops.
+
+![Right-angle pose (example)](/_static/ned2_right_angle_pose.svg)
+
+_Tip: place your image at `docs/source/_static/ned2_right_angle_pose.svg`._
+
+Repeat the operation for the teleoperator with its own settings (e.g., `--teleop.type=ned2_leader`, `--teleop.ip`, `--teleop.id`).
+
+## Test the teleoperation
+
+Run the following command to start teleoperation between a Ned2 leader and a Ned2 follower:
+
+```bash
+lerobot-teleoperate \
+    --robot.type=ned2 \
+    --robot.ip=169.254.XX.XX \
+    --robot.id=my_awesome_follower_arm \
+    --teleop.type=ned2_leader \
+    --teleop.ip=169.254.UU.VV \
+    --teleop.id=my_awesome_leader_arm
+```
+
+Now take control of the leader; the follower should mirror the same movements in real time. If everything runs as expected, you’re ready to use LeRobot with a Ned2!
+
+
+

--- a/src/lerobot/calibrate.py
+++ b/src/lerobot/calibrate.py
@@ -42,6 +42,7 @@ from lerobot.robots import (  # noqa: F401
     make_robot_from_config,
     so100_follower,
     so101_follower,
+    ned2,
 )
 from lerobot.teleoperators import (  # noqa: F401
     Teleoperator,
@@ -51,6 +52,7 @@ from lerobot.teleoperators import (  # noqa: F401
     make_teleoperator_from_config,
     so100_leader,
     so101_leader,
+    ned2_leader,
 )
 from lerobot.utils.utils import init_logging
 

--- a/src/lerobot/motors/dynamixel/tables.py
+++ b/src/lerobot/motors/dynamixel/tables.py
@@ -90,6 +90,62 @@ X_SERIES_CONTROL_TABLE = {
     "Present_Temperature": (146, 1),
 }
 
+STEPPER_CONTROL_TABLE = {
+    "Model_Number": (0, 2),
+    "Model_Information": (2, 4),
+    "Firmware_Version": (6, 1),
+    "ID": (7, 1),
+    "Baud_Rate": (8, 1),
+    "Return_Delay_Time": (9, 1),
+    "Drive_Mode": (10, 1),
+    "Operating_Mode": (11, 1),
+    "Secondary_ID": (12, 1),
+    "Protocol_Type": (13, 1),
+    "Homing_Offset": (20, 4),
+    "Moving_Threshold": (24, 4),
+    "Temperature_Limit": (31, 1),
+    "Max_Voltage_Limit": (32, 2),
+    "Min_Voltage_Limit": (34, 2),
+    "PWM_Limit": (36, 2),
+    "Current_Limit": (38, 2),
+    "Acceleration_Limit": (40, 4),
+    "Velocity_Limit": (44, 4),
+    "Max_Position_Limit": (48, 4),
+    "Min_Position_Limit": (52, 4),
+    "Shutdown": (63, 1),
+    "Torque_Enable": (64, 1),
+    "LED": (65, 1),
+    "Status_Return_Level": (68, 1),
+    "Registered_Instruction": (69, 1),
+    "Hardware_Error_Status": (70, 1),
+    "Velocity_I_Gain": (76, 2),
+    "Velocity_P_Gain": (78, 2),
+    "Position_D_Gain": (80, 2),
+    "Position_I_Gain": (82, 2),
+    "Position_P_Gain": (84, 2),
+    "Feedforward_2nd_Gain": (88, 2),
+    "Feedforward_1st_Gain": (90, 2),
+    "Bus_Watchdog": (98, 1),
+    "Goal_PWM": (100, 2),
+    "Goal_Current": (102, 2),
+    "Goal_Velocity": (104, 4),
+    "Profile_Acceleration": (108, 4),
+    "Profile_Velocity": (112, 4),
+    "Goal_Position": (116, 4),
+    "Realtime_Tick": (120, 2),
+    "Moving": (122, 1),
+    "Moving_Status": (123, 1),
+    "Present_PWM": (124, 2),
+    "Present_Current": (126, 2),
+    "Present_Velocity": (128, 4),
+    "Present_Position": (132, 4),
+    "Velocity_Trajectory": (136, 4),
+    "Position_Trajectory": (140, 4),
+    "Present_Input_Voltage": (144, 2),
+    "Present_Temperature": (146, 1),
+    "Homing_Status": (148, 1),
+}
+
 # https://emanual.robotis.com/docs/en/dxl/x/{MODEL}/#baud-rate8
 X_SERIES_BAUDRATE_TABLE = {
     9_600: 0,
@@ -112,6 +168,17 @@ X_SERIES_ENCODINGS_TABLE = {
     "Present_Velocity": X_SERIES_CONTROL_TABLE["Present_Velocity"][1],
 }
 
+STEPPER_ENCODINGS_TABLE = {
+    "Homing_Offset": STEPPER_CONTROL_TABLE["Homing_Offset"][1],
+    "Goal_PWM": STEPPER_CONTROL_TABLE["Goal_PWM"][1],
+    "Goal_Current": STEPPER_CONTROL_TABLE["Goal_Current"][1],
+    "Goal_Velocity": STEPPER_CONTROL_TABLE["Goal_Velocity"][1],
+    "Present_PWM": STEPPER_CONTROL_TABLE["Present_PWM"][1],
+    "Present_Current": STEPPER_CONTROL_TABLE["Present_Current"][1],
+    "Present_Velocity": STEPPER_CONTROL_TABLE["Present_Velocity"][1],
+    "Homing_Status": STEPPER_CONTROL_TABLE["Homing_Status"][1],
+}
+
 MODEL_ENCODING_TABLE = {
     "x_series": X_SERIES_ENCODINGS_TABLE,
     "xl330-m077": X_SERIES_ENCODINGS_TABLE,
@@ -120,6 +187,8 @@ MODEL_ENCODING_TABLE = {
     "xm430-w350": X_SERIES_ENCODINGS_TABLE,
     "xm540-w270": X_SERIES_ENCODINGS_TABLE,
     "xc430-w150": X_SERIES_ENCODINGS_TABLE,
+    "stepper": STEPPER_ENCODINGS_TABLE,
+
 }
 
 # {model: model_resolution}
@@ -132,6 +201,8 @@ MODEL_RESOLUTION = {
     "xm430-w350": 4096,
     "xm540-w270": 4096,
     "xc430-w150": 4096,
+    "stepper": 4096,
+
 }
 
 # {model: model_number}
@@ -143,6 +214,7 @@ MODEL_NUMBER_TABLE = {
     "xm430-w350": 1020,
     "xm540-w270": 1120,
     "xc430-w150": 1070,
+    "stepper": 2000,
 }
 
 # {model: available_operating_modes}
@@ -154,6 +226,7 @@ MODEL_OPERATING_MODES = {
     "xm430-w350": [0, 1, 3, 4, 5, 16],
     "xm540-w270": [0, 1, 3, 4, 5, 16],
     "xc430-w150": [1, 3, 4, 16],
+    "stepper": [0, 1, 3, 4, 5, 16],
 }
 
 MODEL_CONTROL_TABLE = {
@@ -164,6 +237,8 @@ MODEL_CONTROL_TABLE = {
     "xm430-w350": X_SERIES_CONTROL_TABLE,
     "xm540-w270": X_SERIES_CONTROL_TABLE,
     "xc430-w150": X_SERIES_CONTROL_TABLE,
+    "stepper": STEPPER_CONTROL_TABLE,
+
 }
 
 MODEL_BAUDRATE_TABLE = {
@@ -174,6 +249,7 @@ MODEL_BAUDRATE_TABLE = {
     "xm430-w350": X_SERIES_BAUDRATE_TABLE,
     "xm540-w270": X_SERIES_BAUDRATE_TABLE,
     "xc430-w150": X_SERIES_BAUDRATE_TABLE,
+    "stepper": X_SERIES_BAUDRATE_TABLE,
 }
 
 AVAILABLE_BAUDRATES = [

--- a/src/lerobot/record.py
+++ b/src/lerobot/record.py
@@ -85,6 +85,7 @@ from lerobot.robots import (  # noqa: F401
     make_robot_from_config,
     so100_follower,
     so101_follower,
+    ned2,
 )
 from lerobot.teleoperators import (  # noqa: F401
     Teleoperator,
@@ -95,6 +96,7 @@ from lerobot.teleoperators import (  # noqa: F401
     make_teleoperator_from_config,
     so100_leader,
     so101_leader,
+    ned2_leader,
 )
 from lerobot.teleoperators.keyboard.teleop_keyboard import KeyboardTeleop
 from lerobot.utils.control_utils import (

--- a/src/lerobot/replay.py
+++ b/src/lerobot/replay.py
@@ -57,6 +57,7 @@ from lerobot.robots import (  # noqa: F401
     make_robot_from_config,
     so100_follower,
     so101_follower,
+    ned2_leader,
 )
 from lerobot.utils.robot_utils import busy_wait
 from lerobot.utils.utils import (

--- a/src/lerobot/replay.py
+++ b/src/lerobot/replay.py
@@ -57,7 +57,7 @@ from lerobot.robots import (  # noqa: F401
     make_robot_from_config,
     so100_follower,
     so101_follower,
-    ned2_leader,
+    ned2,
 )
 from lerobot.utils.robot_utils import busy_wait
 from lerobot.utils.utils import (

--- a/src/lerobot/robots/ned2/__init__.py
+++ b/src/lerobot/robots/ned2/__init__.py
@@ -1,0 +1,2 @@
+from .config_ned2 import Ned2Config
+from .ned2 import Ned2 

--- a/src/lerobot/robots/ned2/config_ned2.py
+++ b/src/lerobot/robots/ned2/config_ned2.py
@@ -1,0 +1,29 @@
+# Copyright 2025 The Phantson Technologies Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass, field
+
+from lerobot.common.cameras import CameraConfig
+
+from ..config import RobotConfig
+
+
+@RobotConfig.register_subclass("ned2")
+@dataclass
+class Ned2Config(RobotConfig):
+    port: str
+    disable_torque_on_disconnect: bool = True
+    max_relative_target: int | None = None
+    cameras: dict[str, CameraConfig] = field(default_factory=dict)
+    use_degrees: bool = False 

--- a/src/lerobot/robots/ned2/config_ned2.py
+++ b/src/lerobot/robots/ned2/config_ned2.py
@@ -14,7 +14,7 @@
 
 from dataclasses import dataclass, field
 
-from lerobot.common.cameras import CameraConfig
+from lerobot.cameras import CameraConfig
 
 from ..config import RobotConfig
 

--- a/src/lerobot/robots/ned2/config_ned2.py
+++ b/src/lerobot/robots/ned2/config_ned2.py
@@ -22,7 +22,8 @@ from ..config import RobotConfig
 @RobotConfig.register_subclass("ned2")
 @dataclass
 class Ned2Config(RobotConfig):
-    port: str
+    port: str = "/tmp/ttyVIRTUAL"
+    ip: str | None = None
     disable_torque_on_disconnect: bool = True
     max_relative_target: int | None = None
     cameras: dict[str, CameraConfig] = field(default_factory=dict)

--- a/src/lerobot/robots/ned2/configure_all_steppers.py
+++ b/src/lerobot/robots/ned2/configure_all_steppers.py
@@ -1,0 +1,201 @@
+"""
+Python Calibration process using Dynamixel SDK
+
+This script is used to configure all steppers on the robot.
+It is used to set the velocity profile, the stall threshold, the direction, the delay, the motor ratio, the limit position min, the limit position max, and the default home position.
+
+It is used to configure the steppers for the calibration process.
+
+Script written by:
+- Pierre HANTSON
+"""
+
+
+
+import time
+import math
+import os
+
+if os.name == 'nt':
+    import msvcrt
+    def getch():
+        return msvcrt.getch().decode()
+else : 
+    import sys, tty, termios
+    fd = sys.stdin.fileno()
+    old_settings = termios.tcgetattr(fd)
+    def getch():
+        try:
+            tty.setraw(sys.stdin.fileno())
+            ch = sys.stdin.read(1)
+        finally:
+            termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
+
+from dynamixel_sdk import *
+
+
+STEPPERS = [
+    {
+        'id': 2,
+        'v_start': 0.0,
+        'a_1': 15.0,
+        'v_1': 3.0,
+        'a_max': 15.0,
+        'v_max': 3.0,
+        'd_max': 15.0,
+        'd_1': 15.0,
+        'v_stop': 0.0209,
+        'stall_threshold': 7,
+        'direction': -1,
+        'delay': 200,
+        'motor_ratio': 0.0872,
+        'limit_position_min': -2.90,
+        'limit_position_max': 2.90,
+        'default_home_position': 0.0
+    },
+    {
+        'id': 3,
+        'v_start': 0.0,
+        'a_1': 9.0,
+        'v_1': 2.0,
+        'a_max': 9.0,
+        'v_max': 2.0,
+        'd_max': 9.0,
+        'd_1': 9.0,
+        'v_stop': 0.0209,
+        'stall_threshold': 7,
+        'direction': 1,
+        'delay': 1000,
+        'motor_ratio': 0.0872,
+        'limit_position_min': -2.09,
+        'limit_position_max': 0.61,
+        'default_home_position': 0.0
+    },
+    {
+        'id': 4,
+        'v_start': 0.0,
+        'a_1': 15.0,
+        'v_1': 2.0,
+        'a_max': 15.0,
+        'v_max': 2.0,
+        'd_max': 15.0,
+        'd_1': 15.0,
+        'v_stop': 0.0209,
+        'stall_threshold': 6,
+        'direction': -1,
+        'delay': 1000,
+        'motor_ratio': 0.0872,
+        'limit_position_min': -1.34,
+        'limit_position_max': 1.54,
+        'default_home_position': 0.0
+    }
+]
+
+RADIAN_PER_SECONDS_TO_RPM = 9.549296586
+RADIAN_PER_SECONDS_SQ_TO_RPM_SQ = 91.1887
+STEPPERS_MOTOR_STEPS_PER_REVOLUTION = 200.0
+MICRO_STEPS = 8.0
+ADDR_VSTART = 1024
+ADDR_A1 = 1028
+ADDR_V1 = 1032
+ADDR_AMAX = 1036
+ADDR_VMAX = 1040
+ADDR_DMAX = 1044
+ADDR_D1 = 1048
+ADDR_VSTOP = 1052
+ADDR_HOMING_DIRECTION = 149
+ADDR_HOMING_STALL_THRESHOLD = 150
+ADDR_COMMAND = 147
+ADDR_HOMING_STATUS = 148
+ADDR_PRESENT_POSITION = 132
+ADDR_HOMING_ABS_POSITION = 151
+ADDR_TORQUE_ENABLE = 64
+ADDR_HW_ERROR_STATUS = 70
+
+def write_register(packetHandler, portHandler, motor_id, address, value, byte_length):
+    if byte_length == 1:
+        value = value & 0xFF
+        dxl_comm_result, dxl_error = packetHandler.write1ByteTxRx(portHandler, motor_id, address, value)
+    elif byte_length == 2:
+        dxl_comm_result, dxl_error = packetHandler.write2ByteTxRx(portHandler, motor_id, address, value)
+    elif byte_length == 4:
+        dxl_comm_result, dxl_error = packetHandler.write4ByteTxRx(portHandler, motor_id, address, value)
+    else:
+        raise ValueError("unsupported byte_length")
+    if dxl_comm_result != 0 or dxl_error != 0:
+        raise Exception(f"error writing register {address}: comm={dxl_comm_result}, err={dxl_error}")
+
+def read_register(packetHandler, portHandler, motor_id, address, byte_length):
+    if byte_length == 1:
+        value, dxl_comm_result, dxl_error = packetHandler.read1ByteTxRx(portHandler, motor_id, address)
+    elif byte_length == 2:
+        value, dxl_comm_result, dxl_error = packetHandler.read2ByteTxRx(portHandler, motor_id, address)
+    elif byte_length == 4:
+        value, dxl_comm_result, dxl_error = packetHandler.read4ByteTxRx(portHandler, motor_id, address)
+    else:
+        raise ValueError("unsupported byte_length")
+    if dxl_comm_result != 0 or dxl_error != 0:
+        raise Exception(f"error reading register {address}: comm={dxl_comm_result}, err={dxl_error}")
+    return value
+
+def calibrate_all_steppers(port_name="/tmp/ttyVIRTUAL", baudrate=1000000, timeout=30):
+    portHandler = PortHandler(port_name)
+    packetHandler = PacketHandler(2.0)
+
+    if not portHandler.openPort():
+        raise Exception("master got error failed to open port")
+    if not portHandler.setBaudRate(baudrate):
+        raise Exception("master got error failed to set baudrate")
+    try:
+        for stepper in STEPPERS:
+            motor_id = stepper['id']
+            hw_error_status = read_register(packetHandler, portHandler, motor_id, ADDR_HW_ERROR_STATUS, 1)
+            if hw_error_status != 0:
+                raise Exception(f"master got error hw_error_status={hw_error_status} for motor {motor_id}")
+
+            velocity_profile = {
+                ADDR_VSTART: int(stepper['v_start'] * RADIAN_PER_SECONDS_TO_RPM * 100),
+                ADDR_A1: int(stepper['a_1'] * RADIAN_PER_SECONDS_SQ_TO_RPM_SQ),
+                ADDR_V1: int(stepper['v_1'] * RADIAN_PER_SECONDS_TO_RPM * 100),
+                ADDR_AMAX: int(stepper['a_max'] * RADIAN_PER_SECONDS_SQ_TO_RPM_SQ),
+                ADDR_VMAX: int(stepper['v_max'] * RADIAN_PER_SECONDS_TO_RPM * 100),
+                ADDR_DMAX: int(stepper['d_max'] * RADIAN_PER_SECONDS_SQ_TO_RPM_SQ),
+                ADDR_D1: int(stepper['d_1'] * RADIAN_PER_SECONDS_SQ_TO_RPM_SQ),
+                ADDR_VSTOP: int(stepper['v_stop'] * RADIAN_PER_SECONDS_TO_RPM * 100)
+            }
+            for addr, value in velocity_profile.items():
+                write_register(packetHandler, portHandler, motor_id, addr, value, 4)
+                time.sleep(0.01)
+            
+            direction = stepper['direction']
+            ttl_direction = 0 if direction < 0 else 1
+
+            write_register(packetHandler, portHandler, motor_id, ADDR_HOMING_DIRECTION, ttl_direction, 1)
+            write_register(packetHandler, portHandler, motor_id, ADDR_HOMING_STALL_THRESHOLD, stepper['stall_threshold'], 1)
+            write_register(packetHandler, portHandler, motor_id, ADDR_COMMAND, 0, 1)
+            time.sleep(0.01)
+
+            start_time = time.time()
+            while time.time() - start_time < timeout:
+                homing_status = read_register(packetHandler, portHandler, motor_id, ADDR_HOMING_STATUS, 1)
+                if homing_status == 2 : 
+                    present_position = read_register(packetHandler, portHandler, motor_id, ADDR_PRESENT_POSITION, 4)
+                    write_register(packetHandler, portHandler, motor_id, ADDR_HOMING_ABS_POSITION, present_position, 4)
+                    write_register(packetHandler, portHandler, motor_id, ADDR_TORQUE_ENABLE, 0, 1)
+                    break
+                elif homing_status == 3:
+                    raise Exception(f"master got error homing_status={homing_status} for motor {motor_id}")
+                time.sleep(0.01)
+            else:
+                raise Exception(f"master got error timeout={timeout} for motor {motor_id}")
+        portHandler.closePort()
+        return True, "master got configured"
+    except Exception as e:
+        portHandler.closePort()
+        return False, str(e)
+    
+
+
+if __name__ == "__main__":
+    result, info = calibrate_all_steppers()
+    print(result, info)

--- a/src/lerobot/robots/ned2/ned2.py
+++ b/src/lerobot/robots/ned2/ned2.py
@@ -1,0 +1,224 @@
+# Copyright 2025 The Phantson Technologies Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+import subprocess
+import sys
+import time
+from functools import cached_property
+from typing import Any
+
+from lerobot.common.cameras.utils import make_cameras_from_configs
+from lerobot.common.constants import OBS_STATE
+from lerobot.common.errors import DeviceAlreadyConnectedError, DeviceNotConnectedError
+from lerobot.common.motors import Motor, MotorCalibration, MotorNormMode
+from lerobot.common.motors.dynamixel import (
+    DynamixelMotorsBus,
+    OperatingMode,
+)
+
+from ..robot import Robot
+from ..utils import ensure_safe_goal_position
+from .config_ned2 import Ned2Config
+
+logger = logging.getLogger(__name__)
+
+class Ned2(Robot):
+    """
+    New implementation of the Niryo Ned2 robot by Phantson Technologies Inc. (August 2025 -- Unofficial)
+    """
+    config_class = Ned2Config
+    name = "ned2"
+
+    def __init__(self, config: Ned2Config):
+        super().__init__(config)
+        self.config = config
+        norm_mode = MotorNormMode.DEGREES if config.use_degrees else MotorNormMode.RANGE_M100_100
+        self.bus = DynamixelMotorsBus(
+            port=self.config.port,
+            motors={
+                "base_to_arm": Motor(2, "stepper", norm_mode),
+                "arm_to_elbow": Motor(3, "stepper", norm_mode),
+                "elbow_to_forearm": Motor(4, "stepper", norm_mode),
+                "forearm_to_hand": Motor(5, "xl430-w250", norm_mode),
+                "hand_to_shoulder": Motor(6, "xl430-w250", norm_mode),
+                "shoulder_to_wrist": Motor(7, "xl330-m288", norm_mode),
+                "gripper": Motor(11, "xl330-m288", MotorNormMode.RANGE_0_100),
+            },
+            calibration=self.calibration,
+        )
+        self.cameras = make_cameras_from_configs(config.cameras)
+
+    @property
+    def _motors_ft(self) -> dict[str, type]:
+        return {f"{motor}.pos": float for motor in self.bus.motors}
+
+    @property
+    def _cameras_ft(self) -> dict[str, tuple]:
+        return {
+            cam: (self.config.cameras[cam].height, self.config.cameras[cam].width, 3) for cam in self.cameras
+        }
+
+    @cached_property
+    def observation_features(self) -> dict[str, type | tuple]:
+        return {**self._motors_ft, **self._cameras_ft}
+
+    @cached_property
+    def action_features(self) -> dict[str, type]:
+        return self._motors_ft
+
+    @property
+    def is_connected(self) -> bool:
+        return self.bus.is_connected and all(cam.is_connected for cam in self.cameras.values())
+
+    def connect(self, calibrate: bool = True) -> None:
+        if self.is_connected:
+            raise DeviceAlreadyConnectedError(f"{self} already connected")
+
+        self.bus.connect()
+        if not self.is_calibrated and calibrate:
+            self.calibrate()
+
+        for cam in self.cameras.values():
+            cam.connect()
+
+        self.configure()
+        logger.info(f"{self} connected.")
+
+    @property
+    def is_calibrated(self) -> bool:
+        steppers = [name for name, m in self.bus.motors.items() if m.model == "stepper"]
+        if len(steppers) != 3:
+            return False  
+        # The ned2 is considered "calibrated" if the motor firmwares of the 3 steppers return "calibrated" (i.e. ==2)
+        statuses = self.bus.sync_read("Homing_Status", steppers, normalize=False)
+        return all(statuses[motor] == 2 for motor in steppers)
+
+    def calibrate(self) -> None:
+        logger.info(f"\nRunning calibration of {self}")
+        script_path = os.path.join(os.path.dirname(__file__), 'configure_all_steppers.py')
+        script_path = os.path.abspath(script_path)
+        subprocess.run([sys.executable, script_path], check=True)
+        self.bus.disable_torque()
+
+        input(f"Move {self} to the middle of its range of motion (with gripper open) and press ENTER....")
+
+        actual_positions = self.bus.sync_read("Present_Position", normalize=False)
+
+        homing_offsets = self.bus._get_half_turn_homings(actual_positions)
+
+        range_mins = {
+            "base_to_arm": 0,
+            "arm_to_elbow": 0,
+            "elbow_to_forearm": 0,
+            "forearm_to_hand": 680,
+            "hand_to_shoulder": 536,
+            "shoulder_to_wrist": 0,
+            "gripper": 800
+        }
+
+        range_maxes = {
+            "base_to_arm": 3795,
+            "arm_to_elbow": 1665,
+            "elbow_to_forearm": 1800,
+            "forearm_to_hand": 3406,
+            "hand_to_shoulder": 3668,
+            "shoulder_to_wrist": 4096,
+            "gripper": 1895
+        }
+
+        self.calibration = {}
+        for motor, m in self.bus.motors.items():
+            self.calibration[motor] = MotorCalibration(
+                id=m.id,
+                drive_mode=0,
+                homing_offset=homing_offsets[motor],
+                range_min=range_mins[motor],
+                range_max=range_maxes[motor],
+            )
+
+        self._save_calibration()
+        logger.info(f"Calibration saved to {self.calibration_fpath}")
+
+    def configure(self) -> None:
+        with self.bus.torque_disabled():
+            for motor, m in self.bus.motors.items():
+                if m.model != "stepper":
+                    self.bus.write("Return_Delay_Time", motor, 0)
+
+    def setup_motors(self) -> None:
+        """unimplemented"""
+        pass
+
+    def get_observation(self) -> dict[str, Any]:
+        if not self.is_connected:
+            raise DeviceNotConnectedError(f"{self} is not connected.")
+
+        obs_dict = {}
+
+        # Read arm position
+        start = time.perf_counter()
+        positions = self.bus.sync_read("Present_Position", num_retry=10)
+        for motor, val in positions.items():
+            obs_dict[f"{motor}.pos"] = val
+        dt_ms = (time.perf_counter() - start) * 1e3
+        logger.debug(f"{self} read state: {dt_ms:.1f}ms")
+
+        # Capture images from cameras
+        for cam_key, cam in self.cameras.items():
+            start = time.perf_counter()
+            obs_dict[cam_key] = cam.async_read()
+            dt_ms = (time.perf_counter() - start) * 1e3
+            logger.debug(f"{self} read {cam_key}: {dt_ms:.1f}ms")
+
+        return obs_dict
+
+    def send_action(self, action: dict[str, float]) -> dict[str, float]:
+        """Command arm to move to a target joint configuration.
+
+        The relative action magnitude may be clipped depending on the configuration parameter
+        `max_relative_target`. In this case, the action sent differs from original action.
+        Thus, this function always returns the action actually sent.
+
+        Args:
+            action (dict[str, float]): The goal positions for the motors.
+
+        Returns:
+            dict[str, float]: The action sent to the motors, potentially clipped.
+        """
+        if not self.is_connected:
+            raise DeviceNotConnectedError(f"{self} is not connected.")
+
+        goal_pos = {key.removesuffix(".pos"): val for key, val in action.items() if key.endswith(".pos")}
+
+        # Cap goal position when too far away from present position.
+        if self.config.max_relative_target is not None:
+            present_pos = self.bus.sync_read("Present_Position")
+            goal_present_pos = {key: (g_pos, present_pos[key]) for key, g_pos in goal_pos.items()}
+            goal_pos = ensure_safe_goal_position(goal_present_pos, self.config.max_relative_target)
+
+        # Send goal position to the arm
+        self.bus.sync_write("Goal_Position", goal_pos)
+        return {f"{motor}.pos": val for motor, val in goal_pos.items()}
+
+    def disconnect(self) -> None:
+        if not self.is_connected:
+            raise DeviceNotConnectedError(f"{self} is not connected.")
+
+        self.bus.disconnect(self.config.disable_torque_on_disconnect)
+        for cam in self.cameras.values():
+            cam.disconnect()
+
+        logger.info(f"{self} disconnected.") 

--- a/src/lerobot/robots/ned2/ned2.py
+++ b/src/lerobot/robots/ned2/ned2.py
@@ -122,7 +122,7 @@ class Ned2(Robot):
             except Exception:
                 self._socat_process.kill()
         self._socat_process = None
-        logger.info("Tunnel socat arrêté.")
+        logger.info("Tunnel socat stopped.")
 
     @property
     def _motors_ft(self) -> dict[str, type]:

--- a/src/lerobot/robots/ned2/ned2.py
+++ b/src/lerobot/robots/ned2/ned2.py
@@ -20,11 +20,11 @@ import time
 from functools import cached_property
 from typing import Any
 
-from lerobot.common.cameras.utils import make_cameras_from_configs
-from lerobot.common.constants import OBS_STATE
-from lerobot.common.errors import DeviceAlreadyConnectedError, DeviceNotConnectedError
-from lerobot.common.motors import Motor, MotorCalibration, MotorNormMode
-from lerobot.common.motors.dynamixel import (
+from lerobot.cameras.utils import make_cameras_from_configs
+from lerobot.constants import OBS_STATE
+from lerobot.errors import DeviceAlreadyConnectedError, DeviceNotConnectedError
+from lerobot.motors import Motor, MotorCalibration, MotorNormMode
+from lerobot.motors.dynamixel import (
     DynamixelMotorsBus,
     OperatingMode,
 )

--- a/src/lerobot/robots/utils.py
+++ b/src/lerobot/robots/utils.py
@@ -65,6 +65,10 @@ def make_robot_from_config(config: RobotConfig) -> Robot:
         from tests.mocks.mock_robot import MockRobot
 
         return MockRobot(config)
+    elif config.type == "ned2":
+        from .ned2 import Ned2
+        
+        return Ned2(config)
     else:
         raise ValueError(config.type)
 

--- a/src/lerobot/setup_motors.py
+++ b/src/lerobot/setup_motors.py
@@ -35,6 +35,7 @@ from lerobot.robots import (  # noqa: F401
     make_robot_from_config,
     so100_follower,
     so101_follower,
+    ned2,
 )
 from lerobot.teleoperators import (  # noqa: F401
     TeleoperatorConfig,
@@ -42,6 +43,7 @@ from lerobot.teleoperators import (  # noqa: F401
     make_teleoperator_from_config,
     so100_leader,
     so101_leader,
+    ned2_leader,
 )
 
 COMPATIBLE_DEVICES = [

--- a/src/lerobot/teleoperate.py
+++ b/src/lerobot/teleoperate.py
@@ -70,6 +70,7 @@ from lerobot.robots import (  # noqa: F401
     make_robot_from_config,
     so100_follower,
     so101_follower,
+    ned2,
 )
 from lerobot.teleoperators import (  # noqa: F401
     Teleoperator,
@@ -81,6 +82,7 @@ from lerobot.teleoperators import (  # noqa: F401
     make_teleoperator_from_config,
     so100_leader,
     so101_leader,
+    ned2_leader,
 )
 from lerobot.utils.robot_utils import busy_wait
 from lerobot.utils.utils import init_logging, move_cursor_up

--- a/src/lerobot/teleoperators/ned2_leader/__init__.py
+++ b/src/lerobot/teleoperators/ned2_leader/__init__.py
@@ -1,0 +1,2 @@
+from .config_ned2_leader import Ned2LeaderConfig
+from .ned2_leader import Ned2Leader 

--- a/src/lerobot/teleoperators/ned2_leader/config_ned2_leader.py
+++ b/src/lerobot/teleoperators/ned2_leader/config_ned2_leader.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+
+# Copyright 2025 The Phantson Technologies Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass, field
+
+from ..config import TeleoperatorConfig
+
+@TeleoperatorConfig.register_subclass("ned2_leader")
+@dataclass
+class Ned2LeaderConfig(TeleoperatorConfig):
+    port: str
+    use_degrees: bool = False 
+    

--- a/src/lerobot/teleoperators/ned2_leader/config_ned2_leader.py
+++ b/src/lerobot/teleoperators/ned2_leader/config_ned2_leader.py
@@ -21,6 +21,7 @@ from ..config import TeleoperatorConfig
 @TeleoperatorConfig.register_subclass("ned2_leader")
 @dataclass
 class Ned2LeaderConfig(TeleoperatorConfig):
-    port: str
+    port: str = "/tmp/ttyVIRTUAL1"
+    ip: str | None = None
     use_degrees: bool = False 
     

--- a/src/lerobot/teleoperators/ned2_leader/configure_all_steppers_of_teleop.py
+++ b/src/lerobot/teleoperators/ned2_leader/configure_all_steppers_of_teleop.py
@@ -1,0 +1,201 @@
+"""
+Python Calibration process using Dynamixel SDK
+
+This script is used to configure all steppers on the robot.
+It is used to set the velocity profile, the stall threshold, the direction, the delay, the motor ratio, the limit position min, the limit position max, and the default home position.
+
+It is used to configure the steppers for the calibration process.
+
+Script written by:
+- Pierre HANTSON
+"""
+
+
+
+import time
+import math
+import os
+
+if os.name == 'nt':
+    import msvcrt
+    def getch():
+        return msvcrt.getch().decode()
+else : 
+    import sys, tty, termios
+    fd = sys.stdin.fileno()
+    old_settings = termios.tcgetattr(fd)
+    def getch():
+        try:
+            tty.setraw(sys.stdin.fileno())
+            ch = sys.stdin.read(1)
+        finally:
+            termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
+
+from dynamixel_sdk import *
+
+
+STEPPERS = [
+    {
+        'id': 2,
+        'v_start': 0.0,
+        'a_1': 0.785,
+        'v_1': 0.314,
+        'a_max': 2.094,
+        'v_max': 0.4,
+        'd_max': 2.094,
+        'd_1': 0.785,
+        'v_stop': 0.0209,
+        'stall_threshold': 7,
+        'direction': -1,
+        'delay': 200,
+        'motor_ratio': 0.0872,
+        'limit_position_min': -2.90,
+        'limit_position_max': 2.90,
+        'default_home_position': 0.0
+    },
+    {
+        'id': 3,
+        'v_start': 0.0,
+        'a_1': 0.524,
+        'v_1': 0.314,
+        'a_max': 1.047,
+        'v_max': 0.3,
+        'd_max': 1.047,
+        'd_1': 0.524,
+        'v_stop': 0.0209,
+        'stall_threshold': 7,
+        'direction': 1,
+        'delay': 1000,
+        'motor_ratio': 0.0872,
+        'limit_position_min': -2.09,
+        'limit_position_max': 0.61,
+        'default_home_position': 0.0
+    },
+    {
+        'id': 4,
+        'v_start': 0.0,
+        'a_1': 0.785,
+        'v_1': 0.314,
+        'a_max': 1.309,
+        'v_max': 0.3,
+        'd_max': 1.309,
+        'd_1': 0.785,
+        'v_stop': 0.0209,
+        'stall_threshold': 6,
+        'direction': -1,
+        'delay': 1000,
+        'motor_ratio': 0.0872,
+        'limit_position_min': -1.34,
+        'limit_position_max': 1.54,
+        'default_home_position': 0.0
+    }
+]
+
+RADIAN_PER_SECONDS_TO_RPM = 9.549296586
+RADIAN_PER_SECONDS_SQ_TO_RPM_SQ = 91.1887
+STEPPERS_MOTOR_STEPS_PER_REVOLUTION = 200.0
+MICRO_STEPS = 8.0
+ADDR_VSTART = 1024
+ADDR_A1 = 1028
+ADDR_V1 = 1032
+ADDR_AMAX = 1036
+ADDR_VMAX = 1040
+ADDR_DMAX = 1044
+ADDR_D1 = 1048
+ADDR_VSTOP = 1052
+ADDR_HOMING_DIRECTION = 149
+ADDR_HOMING_STALL_THRESHOLD = 150
+ADDR_COMMAND = 147
+ADDR_HOMING_STATUS = 148
+ADDR_PRESENT_POSITION = 132
+ADDR_HOMING_ABS_POSITION = 151
+ADDR_TORQUE_ENABLE = 64
+ADDR_HW_ERROR_STATUS = 70
+
+def write_register(packetHandler, portHandler, motor_id, address, value, byte_length):
+    if byte_length == 1:
+        value = value & 0xFF
+        dxl_comm_result, dxl_error = packetHandler.write1ByteTxRx(portHandler, motor_id, address, value)
+    elif byte_length == 2:
+        dxl_comm_result, dxl_error = packetHandler.write2ByteTxRx(portHandler, motor_id, address, value)
+    elif byte_length == 4:
+        dxl_comm_result, dxl_error = packetHandler.write4ByteTxRx(portHandler, motor_id, address, value)
+    else:
+        raise ValueError("unsupported byte_length")
+    if dxl_comm_result != 0 or dxl_error != 0:
+        raise Exception(f"error writing register {address}: comm={dxl_comm_result}, err={dxl_error}")
+
+def read_register(packetHandler, portHandler, motor_id, address, byte_length):
+    if byte_length == 1:
+        value, dxl_comm_result, dxl_error = packetHandler.read1ByteTxRx(portHandler, motor_id, address)
+    elif byte_length == 2:
+        value, dxl_comm_result, dxl_error = packetHandler.read2ByteTxRx(portHandler, motor_id, address)
+    elif byte_length == 4:
+        value, dxl_comm_result, dxl_error = packetHandler.read4ByteTxRx(portHandler, motor_id, address)
+    else:
+        raise ValueError("unsupported byte_length")
+    if dxl_comm_result != 0 or dxl_error != 0:
+        raise Exception(f"error reading register {address}: comm={dxl_comm_result}, err={dxl_error}")
+    return value
+
+def calibrate_all_steppers(port_name="/tmp/ttyVIRTUAL1", baudrate=1000000, timeout=30):
+    portHandler = PortHandler(port_name)
+    packetHandler = PacketHandler(2.0)
+
+    if not portHandler.openPort():
+        raise Exception("master got error failed to open port")
+    if not portHandler.setBaudRate(baudrate):
+        raise Exception("master got error failed to set baudrate")
+    try:
+        for stepper in STEPPERS:
+            motor_id = stepper['id']
+            hw_error_status = read_register(packetHandler, portHandler, motor_id, ADDR_HW_ERROR_STATUS, 1)
+            if hw_error_status != 0:
+                raise Exception(f"master got error hw_error_status={hw_error_status} for motor {motor_id}")
+
+            velocity_profile = {
+                ADDR_VSTART: int(stepper['v_start'] * RADIAN_PER_SECONDS_TO_RPM * 100),
+                ADDR_A1: int(stepper['a_1'] * RADIAN_PER_SECONDS_SQ_TO_RPM_SQ),
+                ADDR_V1: int(stepper['v_1'] * RADIAN_PER_SECONDS_TO_RPM * 100),
+                ADDR_AMAX: int(stepper['a_max'] * RADIAN_PER_SECONDS_SQ_TO_RPM_SQ),
+                ADDR_VMAX: int(stepper['v_max'] * RADIAN_PER_SECONDS_TO_RPM * 100),
+                ADDR_DMAX: int(stepper['d_max'] * RADIAN_PER_SECONDS_SQ_TO_RPM_SQ),
+                ADDR_D1: int(stepper['d_1'] * RADIAN_PER_SECONDS_SQ_TO_RPM_SQ),
+                ADDR_VSTOP: int(stepper['v_stop'] * RADIAN_PER_SECONDS_TO_RPM * 100)
+            }
+            for addr, value in velocity_profile.items():
+                write_register(packetHandler, portHandler, motor_id, addr, value, 4)
+                time.sleep(0.01)
+            
+            direction = stepper['direction']
+            ttl_direction = 0 if direction < 0 else 1
+
+            write_register(packetHandler, portHandler, motor_id, ADDR_HOMING_DIRECTION, ttl_direction, 1)
+            write_register(packetHandler, portHandler, motor_id, ADDR_HOMING_STALL_THRESHOLD, stepper['stall_threshold'], 1)
+            write_register(packetHandler, portHandler, motor_id, ADDR_COMMAND, 0, 1)
+            time.sleep(0.01)
+
+            start_time = time.time()
+            while time.time() - start_time < timeout:
+                homing_status = read_register(packetHandler, portHandler, motor_id, ADDR_HOMING_STATUS, 1)
+                if homing_status == 2 : 
+                    present_position = read_register(packetHandler, portHandler, motor_id, ADDR_PRESENT_POSITION, 4)
+                    write_register(packetHandler, portHandler, motor_id, ADDR_HOMING_ABS_POSITION, present_position, 4)
+                    write_register(packetHandler, portHandler, motor_id, ADDR_TORQUE_ENABLE, 0, 1)
+                    break
+                elif homing_status == 3:
+                    raise Exception(f"master got error homing_status={homing_status} for motor {motor_id}")
+                time.sleep(0.01)
+            else:
+                raise Exception(f"master got error timeout={timeout} for motor {motor_id}")
+        portHandler.closePort()
+        return True, "master got configured"
+    except Exception as e:
+        portHandler.closePort()
+        return False, str(e)
+    
+
+
+if __name__ == "__main__":
+    result, info = calibrate_all_steppers()
+    print(result, info)

--- a/src/lerobot/teleoperators/ned2_leader/ned2_leader.py
+++ b/src/lerobot/teleoperators/ned2_leader/ned2_leader.py
@@ -19,6 +19,7 @@ import os
 import subprocess
 import sys
 import time
+import shutil
 
 from lerobot.errors import DeviceAlreadyConnectedError, DeviceNotConnectedError
 from lerobot.motors import Motor, MotorCalibration, MotorNormMode
@@ -42,6 +43,7 @@ class Ned2Leader(Teleoperator):
     def __init__(self, config: Ned2LeaderConfig):
         super().__init__(config)
         self.config = config
+        self._socat_process: subprocess.Popen | None = None
         norm_mode = MotorNormMode.DEGREES if config.use_degrees else MotorNormMode.RANGE_M100_100
         self.bus = DynamixelMotorsBus(
             port=self.config.port,
@@ -70,9 +72,71 @@ class Ned2Leader(Teleoperator):
     def is_connected(self) -> bool:
         return self.bus.is_connected
 
+    def _start_socat_tunnel(self) -> None:
+        if self.config.ip is None:
+            return
+        if self._socat_process is not None and self._socat_process.poll() is None:
+            return
+        if shutil.which("socat") is None:
+            logger.error("Please install socat to use IP connection.")
+            return
+
+        link_path = self.config.port
+        remote = f"TCP:{self.config.ip}:7777"
+        cmd = [
+            "socat",
+            "-d",
+            "-d",
+            f"PTY,link={link_path},raw,echo=0",
+            remote,
+        ]
+        try:
+            self._socat_process = subprocess.Popen(
+                cmd,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        except Exception as exc:
+            logger.error(f"Failed to start socat: {exc}")
+            self._socat_process = None
+            return
+
+        start_time = time.time()
+        timeout_s = 5.0
+        while not os.path.exists(link_path):
+            if self._socat_process.poll() is not None:
+                logger.error("Socat process stopped prematurely.")
+                self._socat_process = None
+                return
+            if time.time() - start_time > timeout_s:
+                logger.error("Timeout waiting for virtual device creation by socat.")
+                self._socat_process.terminate()
+                try:
+                    self._socat_process.wait(timeout=1)
+                except Exception:
+                    self._socat_process.kill()
+                self._socat_process = None
+                return
+            time.sleep(0.1)
+        logger.info(f"Tunnel socat started to {remote} and linked to {link_path}.")
+
+    def _stop_socat_tunnel(self) -> None:
+        if self._socat_process is None:
+            return
+        if self._socat_process.poll() is None:
+            try:
+                self._socat_process.terminate()
+                self._socat_process.wait(timeout=2)
+            except Exception:
+                self._socat_process.kill()
+        self._socat_process = None
+        logger.info("Tunnel socat stopped.")
+
     def connect(self, calibrate: bool = True) -> None:
         if self.is_connected:
             raise DeviceAlreadyConnectedError(f"{self} already connected")
+
+        self._start_socat_tunnel()
 
         self.bus.connect()
         if not self.is_calibrated and calibrate:
@@ -155,4 +219,5 @@ class Ned2Leader(Teleoperator):
         if not self.is_connected:
             raise DeviceNotConnectedError(f"{self} is not connected.")
         self.bus.disconnect()
+        self._stop_socat_tunnel()
         logger.info(f"{self} disconnected.") 

--- a/src/lerobot/teleoperators/ned2_leader/ned2_leader.py
+++ b/src/lerobot/teleoperators/ned2_leader/ned2_leader.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python
+
+# Copyright 2025 The Phantson Technologies Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+import subprocess
+import sys
+import time
+
+from lerobot.common.errors import DeviceAlreadyConnectedError, DeviceNotConnectedError
+from lerobot.common.motors import Motor, MotorCalibration, MotorNormMode
+from lerobot.common.motors.dynamixel import (
+    DynamixelMotorsBus,
+    OperatingMode,
+)
+
+from ..teleoperator import Teleoperator
+from .config_ned2_leader import Ned2LeaderConfig
+
+logger = logging.getLogger(__name__)
+
+class Ned2Leader(Teleoperator):
+    """
+    The ned2 that will lead the robot (Phantson Technologies Inc.) -- Unofficial
+    """
+    config_class = Ned2LeaderConfig
+    name = "ned2_leader"
+
+    def __init__(self, config: Ned2LeaderConfig):
+        super().__init__(config)
+        self.config = config
+        norm_mode = MotorNormMode.DEGREES if config.use_degrees else MotorNormMode.RANGE_M100_100
+        self.bus = DynamixelMotorsBus(
+            port=self.config.port,
+            motors={
+                "base_to_arm": Motor(2, "stepper", norm_mode),
+                "arm_to_elbow": Motor(3, "stepper", norm_mode),
+                "elbow_to_forearm": Motor(4, "stepper", norm_mode),
+                "forearm_to_hand": Motor(5, "xl430-w250", norm_mode),
+                "hand_to_shoulder": Motor(6, "xl430-w250", norm_mode),
+                "shoulder_to_wrist": Motor(7, "xl330-m288", norm_mode),
+                "gripper": Motor(11, "xl330-m288", MotorNormMode.RANGE_0_100),
+            },
+            calibration=self.calibration,
+        )
+
+    @property
+    def action_features(self) -> dict[str, type]:
+        return {f"{motor}.pos": float for motor in self.bus.motors}
+
+    @property
+    def feedback_features(self) -> dict[str, type]:
+        #TODO (@atphantson) : Implement feedback features
+        return {}
+
+    @property
+    def is_connected(self) -> bool:
+        return self.bus.is_connected
+
+    def connect(self, calibrate: bool = True) -> None:
+        if self.is_connected:
+            raise DeviceAlreadyConnectedError(f"{self} already connected")
+
+        self.bus.connect()
+        if not self.is_calibrated and calibrate:
+            self.calibrate()
+
+        self.configure()
+        logger.info(f"{self} connected.")
+
+    @property
+    def is_calibrated(self) -> bool:
+        steppers = [name for name, m in self.bus.motors.items() if m.model == "stepper"]
+        if len(steppers) != 3:
+            return False
+        statuses = self.bus.sync_read("Homing_Status", steppers, normalize=False)
+        return all(statuses[motor] == 2 for motor in steppers)
+
+    def calibrate(self) -> None:
+        logger.info(f"\nRunning calibration of {self}")
+        script_path = os.path.abspath(os.path.join(os.path.dirname(__file__), 'configure_all_steppers_of_teleop.py'))
+        subprocess.run([sys.executable, script_path], check=True)
+        self.bus.disable_torque()
+        input(f"Move {self} to the middle of its range of motion (with gripper open) and press ENTER....")
+        actual_positions = self.bus.sync_read("Present_Position", normalize=False)
+        homing_offsets = self.bus._get_half_turn_homings(actual_positions)
+        range_mins = {
+            "base_to_arm": 0,
+            "arm_to_elbow": 0,
+            "elbow_to_forearm": 0,
+            "forearm_to_hand": 680,
+            "hand_to_shoulder": 536,
+            "shoulder_to_wrist": 0,
+            "gripper": 800
+        }
+        range_maxes = {
+            "base_to_arm": 3795,
+            "arm_to_elbow": 1665,
+            "elbow_to_forearm": 1800,
+            "forearm_to_hand": 3406,
+            "hand_to_shoulder": 3668,
+            "shoulder_to_wrist": 4096,
+            "gripper": 1895
+        }
+        self.calibration = {}
+        for motor, m in self.bus.motors.items():
+            self.calibration[motor] = MotorCalibration(
+                id=m.id,
+                drive_mode=0,
+                homing_offset=homing_offsets[motor],
+                range_min=range_mins[motor],
+                range_max=range_maxes[motor],
+            )
+        self._save_calibration()
+        logger.info(f"Calibration saved to {self.calibration_fpath}")
+
+    def configure(self) -> None:
+        with self.bus.torque_disabled():
+            for motor, m in self.bus.motors.items():
+                if m.model != "stepper":
+                    self.bus.write("Return_Delay_Time", motor, 0)
+        self.bus.disable_torque()
+
+    def setup_motors(self) -> None:
+        pass
+
+    def get_action(self) -> dict[str, float]:
+        if not self.is_connected:
+            raise DeviceNotConnectedError(f"{self} is not connected.")
+
+        start = time.perf_counter()
+        action = self.bus.sync_read("Present_Position", num_retry=10)
+        action = {f"{motor}.pos": val for motor, val in action.items()}
+        dt_ms = (time.perf_counter() - start) * 1e3
+        logger.debug(f"{self} read action: {dt_ms:.1f}ms")
+        return action
+
+    def send_feedback(self, feedback: dict[str, float]) -> None:
+        raise NotImplementedError
+
+    def disconnect(self) -> None:
+        if not self.is_connected:
+            raise DeviceNotConnectedError(f"{self} is not connected.")
+        self.bus.disconnect()
+        logger.info(f"{self} disconnected.") 

--- a/src/lerobot/teleoperators/ned2_leader/ned2_leader.py
+++ b/src/lerobot/teleoperators/ned2_leader/ned2_leader.py
@@ -20,9 +20,9 @@ import subprocess
 import sys
 import time
 
-from lerobot.common.errors import DeviceAlreadyConnectedError, DeviceNotConnectedError
-from lerobot.common.motors import Motor, MotorCalibration, MotorNormMode
-from lerobot.common.motors.dynamixel import (
+from lerobot.errors import DeviceAlreadyConnectedError, DeviceNotConnectedError
+from lerobot.motors import Motor, MotorCalibration, MotorNormMode
+from lerobot.motors.dynamixel import (
     DynamixelMotorsBus,
     OperatingMode,
 )

--- a/src/lerobot/teleoperators/utils.py
+++ b/src/lerobot/teleoperators/utils.py
@@ -65,5 +65,9 @@ def make_teleoperator_from_config(config: TeleoperatorConfig) -> Teleoperator:
         from .bi_so100_leader import BiSO100Leader
 
         return BiSO100Leader(config)
+    elif config.type == "ned2_leader":
+        from .ned2_leader import Ned2Leader
+
+        return Ned2Leader(config)
     else:
         raise ValueError(config.type)


### PR DESCRIPTION
## What this does

Added code and documentation needed for the implementation of the Niryo Ned2 in Lerobot project. 

## How it was tested

A dataset was recorded and a policy was trained and evaluated using 2 Ned2 as follower and teleoperator. 

## How to checkout & try? (for the reviewer)

Follow the provided documentation to calibrate the robot, then teleoperate it and record a dataset with the following command template : 

```bash
lerobot-record --robot.type=ned2 --robot.ip=169.254.XX.YY --teleop.type=ned2_leader --teleop.ip=169.254.UU.VV --dataset.fps=15
```



