### PR TITLE
Lower limits by 50% for current and torque for gripper motor

### DIFF
--- a/src/lerobot/robots/so100_follower/so100_follower.py
+++ b/src/lerobot/robots/so100_follower/so100_follower.py
@@ -161,6 +161,12 @@ class SO100Follower(Robot):
                 self.bus.write("I_Coefficient", motor, 0)
                 self.bus.write("D_Coefficient", motor, 32)
 
+                if motor == "gripper":
+                    self.bus.write(
+                        "Max_Torque_Limit", motor, 500
+                    )  # Set to 50% of the max torque limit for gripper
+                    self.bus.write("Protection_Current", motor, 250)  # Set to 50% of max current for gripper
+
     def setup_motors(self) -> None:
         for motor in reversed(self.bus.motors):
             input(f"Connect the controller board to the '{motor}' motor only and press enter.")

--- a/src/lerobot/robots/so101_follower/so101_follower.py
+++ b/src/lerobot/robots/so101_follower/so101_follower.py
@@ -157,6 +157,12 @@ class SO101Follower(Robot):
                 self.bus.write("I_Coefficient", motor, 0)
                 self.bus.write("D_Coefficient", motor, 32)
 
+                if motor == "gripper":
+                    self.bus.write(
+                        "Max_Torque_Limit", motor, 500
+                    )  # 50% of the max torque limit to avoid burnout
+                    self.bus.write("Protection_Current", motor, 250)  # 50% of max current to avoid burnout
+
     def setup_motors(self) -> None:
         for motor in reversed(self.bus.motors):
             input(f"Connect the controller board to the '{motor}' motor only and press enter.")


### PR DESCRIPTION
## What this does

This PR lower the limits for the max current and torque for the Gripper motor on SO100 and SO101. This is done to avoid burnout, which happened more often (probably due to miscalibration and because the gripper doesn't have feedback when the teleoperator closes it fully), reported by seed studio.