### PR TITLE
refactor(converters): rename to_transition_robot_observation to robot_observation_to_transition for clarity

### DIFF
--- a/examples/phone_to_so100/evaluate.py
+++ b/examples/phone_to_so100/evaluate.py
@@ -22,8 +22,8 @@ from lerobot.model.kinematics import RobotKinematics
 from lerobot.policies.act.modeling_act import ACTPolicy
 from lerobot.policies.factory import make_pre_post_processors
 from lerobot.processor.converters import (
+    robot_observation_to_transition,
     to_output_robot_action,
-    to_transition_robot_observation,
 )
 from lerobot.processor.pipeline import DataProcessorPipeline
 from lerobot.record import record_loop
@@ -83,7 +83,7 @@ robot_joints_to_ee_pose = DataProcessorPipeline(
     steps=[
         ForwardKinematicsJointsToEE(kinematics=kinematics_solver, motor_names=list(robot.bus.motors.keys()))
     ],
-    to_transition=to_transition_robot_observation,
+    to_transition=robot_observation_to_transition,
     to_output=lambda tr: tr,
 )
 

--- a/examples/phone_to_so100/record.py
+++ b/examples/phone_to_so100/record.py
@@ -21,8 +21,8 @@ from lerobot.datasets.pipeline_features import aggregate_pipeline_dataset_featur
 from lerobot.datasets.utils import merge_features
 from lerobot.model.kinematics import RobotKinematics
 from lerobot.processor.converters import (
+    robot_observation_to_transition,
     to_output_robot_action,
-    to_transition_robot_observation,
     to_transition_teleop_action,
 )
 from lerobot.processor.pipeline import DataProcessorPipeline
@@ -114,7 +114,7 @@ robot_joints_to_ee_pose = DataProcessorPipeline(
     steps=[
         ForwardKinematicsJointsToEE(kinematics=kinematics_solver, motor_names=list(robot.bus.motors.keys()))
     ],
-    to_transition=to_transition_robot_observation,
+    to_transition=robot_observation_to_transition,
     to_output=lambda tr: tr,
 )
 

--- a/src/lerobot/processor/converters.py
+++ b/src/lerobot/processor/converters.py
@@ -94,7 +94,7 @@ def to_transition_teleop_action(action: dict[str, Any]) -> EnvTransition:
 
 
 # TODO(Adil, Pepijn): Overtime we can maybe add these converters to pipeline.py itself
-def to_transition_robot_observation(observation: dict[str, Any]) -> EnvTransition:
+def robot_observation_to_transition(observation: dict[str, Any]) -> EnvTransition:
     """
     Convert a raw robot observation dict into an EnvTransition under the OBSERVATION TransitionKey.
     """

--- a/src/lerobot/record.py
+++ b/src/lerobot/record.py
@@ -78,9 +78,9 @@ from lerobot.policies.factory import make_policy, make_pre_post_processors
 from lerobot.policies.pretrained import PreTrainedPolicy
 from lerobot.processor import PolicyProcessorPipeline, RobotProcessorPipeline
 from lerobot.processor.converters import (
+    robot_observation_to_transition,
     to_dataset_frame,
     to_output_robot_action,
-    to_transition_robot_observation,
     to_transition_teleop_action,
 )
 from lerobot.processor.pipeline import IdentityProcessorStep, TransitionKey
@@ -253,7 +253,7 @@ def record_loop(
     )
     robot_observation_processor = robot_observation_processor or RobotProcessorPipeline(
         steps=[IdentityProcessorStep()],
-        to_transition=to_transition_robot_observation,
+        to_transition=robot_observation_to_transition,
         to_output=lambda tr: tr,
     )
 

--- a/src/lerobot/teleoperate.py
+++ b/src/lerobot/teleoperate.py
@@ -63,8 +63,8 @@ from lerobot.cameras.realsense.configuration_realsense import RealSenseCameraCon
 from lerobot.configs import parser
 from lerobot.processor import RobotProcessorPipeline
 from lerobot.processor.converters import (
+    robot_observation_to_transition,
     to_output_robot_action,
-    to_transition_robot_observation,
     to_transition_teleop_action,
 )
 from lerobot.processor.pipeline import IdentityProcessorStep
@@ -131,7 +131,7 @@ def teleop_loop(
     )
     robot_observation_processor = robot_observation_processor or RobotProcessorPipeline(
         steps=[IdentityProcessorStep()],
-        to_transition=to_transition_robot_observation,
+        to_transition=robot_observation_to_transition,
         to_output=lambda tr: tr,
     )
 

--- a/tests/processor/test_converters.py
+++ b/tests/processor/test_converters.py
@@ -3,9 +3,9 @@ import pytest
 import torch
 
 from lerobot.processor.converters import (
+    robot_observation_to_transition,
     to_dataset_frame,
     to_output_robot_action,
-    to_transition_robot_observation,
     to_transition_teleop_action,
 )
 from lerobot.processor.pipeline import TransitionKey
@@ -47,7 +47,7 @@ def test_to_transition_teleop_action_prefix_and_tensor_conversion():
     assert tr[TransitionKey.OBSERVATION] == {}
 
 
-def test_to_transition_robot_observation_state_vs_images_split():
+def test_robot_observation_to_transition_state_vs_images_split():
     # Create an observation with mixed content
     img = np.full((10, 20, 3), 255, dtype=np.uint8)  # image (uint8 HWC)
     obs = {
@@ -58,7 +58,7 @@ def test_to_transition_robot_observation_state_vs_images_split():
         "arr": np.array([1.5, 2.5]),  # vector to state to torch tensor
     }
 
-    tr = to_transition_robot_observation(obs)
+    tr = robot_observation_to_transition(obs)
     assert isinstance(tr, dict)
     assert TransitionKey.OBSERVATION in tr
 


### PR DESCRIPTION
- Updated references across evaluate.py, record.py, teleoperate.py, and other files to reflect the new naming convention.
- Improved readability and maintainability of the codebase.