### PR TITLE
refactor(datasets): rename merge_features to merge_dataset_features for clarity

### DIFF
--- a/examples/phone_to_so100/evaluate.py
+++ b/examples/phone_to_so100/evaluate.py
@@ -17,7 +17,7 @@
 from lerobot.cameras.opencv.configuration_opencv import OpenCVCameraConfig
 from lerobot.datasets.lerobot_dataset import LeRobotDataset
 from lerobot.datasets.pipeline_features import aggregate_pipeline_dataset_features
-from lerobot.datasets.utils import merge_features
+from lerobot.datasets.utils import merge_dataset_features
 from lerobot.model.kinematics import RobotKinematics
 from lerobot.policies.act.modeling_act import ACTPolicy
 from lerobot.policies.factory import make_pre_post_processors
@@ -103,7 +103,7 @@ obs_ee = aggregate_pipeline_dataset_features(
     patterns=["observation.state.ee"],
 )  # Get all ee observation features
 
-dataset_features = merge_features(obs_ee, action_ee_and_gripper)
+dataset_features = merge_dataset_features(obs_ee, action_ee_and_gripper)
 
 print("All dataset features: ", dataset_features)
 

--- a/examples/phone_to_so100/record.py
+++ b/examples/phone_to_so100/record.py
@@ -18,7 +18,7 @@
 from lerobot.cameras.opencv.configuration_opencv import OpenCVCameraConfig
 from lerobot.datasets.lerobot_dataset import LeRobotDataset
 from lerobot.datasets.pipeline_features import aggregate_pipeline_dataset_features
-from lerobot.datasets.utils import merge_features
+from lerobot.datasets.utils import merge_dataset_features
 from lerobot.model.kinematics import RobotKinematics
 from lerobot.processor.converters import (
     robot_observation_to_transition,
@@ -142,7 +142,7 @@ observation_ee = aggregate_pipeline_dataset_features(
     patterns=["observation.state.ee"],
 )
 
-dataset_features = merge_features(action_ee, gripper, observation_ee)
+dataset_features = merge_dataset_features(action_ee, gripper, observation_ee)
 
 print("All dataset features: ", dataset_features)
 

--- a/src/lerobot/datasets/utils.py
+++ b/src/lerobot/datasets/utils.py
@@ -470,7 +470,7 @@ def dataset_to_policy_features(features: dict[str, dict]) -> dict[str, PolicyFea
     return policy_features
 
 
-def merge_features(*dicts: dict) -> dict:
+def merge_dataset_features(*dicts: dict) -> dict:
     """
     Merge LeRobot grouped feature dicts.
 

--- a/tests/datasets/test_dataset_utils.py
+++ b/tests/datasets/test_dataset_utils.py
@@ -20,7 +20,7 @@ from datasets import Dataset
 from huggingface_hub import DatasetCard
 
 from lerobot.datasets.push_dataset_to_hub.utils import calculate_episode_data_index
-from lerobot.datasets.utils import create_lerobot_dataset_card, hf_transform_to_torch, merge_features
+from lerobot.datasets.utils import create_lerobot_dataset_card, hf_transform_to_torch, merge_dataset_features
 
 
 def test_default_parameters():
@@ -72,7 +72,7 @@ def test_merge_simple_vectors():
         }
     }
 
-    out = merge_features(g1, g2)
+    out = merge_dataset_features(g1, g2)
 
     assert "action" in out
     assert out["action"]["dtype"] == "float32"
@@ -87,7 +87,7 @@ def test_merge_multiple_groups_order_and_dedup():
     g2 = {"action": {"dtype": "float32", "shape": (2,), "names": ["b", "c"]}}
     g3 = {"action": {"dtype": "float32", "shape": (3,), "names": ["a", "c", "d"]}}
 
-    out = merge_features(g1, g2, g3)
+    out = merge_dataset_features(g1, g2, g3)
 
     assert out["action"]["names"] == ["a", "b", "c", "d"]
     assert out["action"]["shape"] == (4,)
@@ -110,7 +110,7 @@ def test_non_vector_last_wins_for_images():
         }
     }
 
-    out = merge_features(g1, g2)
+    out = merge_dataset_features(g1, g2)
     assert out["observation.images.front"]["shape"] == (3, 720, 1280)
     assert out["observation.images.front"]["dtype"] == "image"
 
@@ -120,13 +120,13 @@ def test_dtype_mismatch_raises():
     g2 = {"action": {"dtype": "float64", "shape": (1,), "names": ["b"]}}
 
     with pytest.raises(ValueError, match="dtype mismatch for 'action'"):
-        _ = merge_features(g1, g2)
+        _ = merge_dataset_features(g1, g2)
 
 
 def test_non_dict_passthrough_last_wins():
     g1 = {"misc": 123}
     g2 = {"misc": 456}
 
-    out = merge_features(g1, g2)
+    out = merge_dataset_features(g1, g2)
     # For non-dict entries the last one wins
     assert out["misc"] == 456


### PR DESCRIPTION
- Updated references in evaluate.py, record.py, and test_dataset_utils.py to reflect the new function name.
- Improved code readability and maintainability by standardizing the naming convention.