### PR TITLE
refactor(converters): implement unified tensor conversion function

### DIFF
--- a/src/lerobot/processor/gym_action_processor.py
+++ b/src/lerobot/processor/gym_action_processor.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 import numpy as np
 import torch
 
+from lerobot.processor.converters import to_tensor
 from lerobot.processor.pipeline import ActionProcessor, ProcessorStepRegistry
 
 
@@ -59,5 +60,5 @@ class Numpy2TorchActionProcessor(ActionProcessor):
                 f"Expected np.ndarray or None, got {type(action).__name__}. "
                 "Use appropriate processor for non-tensor actions."
             )
-        torch_action = torch.from_numpy(action)
+        torch_action = to_tensor(action, dtype=None)  # Preserve original dtype
         return torch_action

--- a/src/lerobot/processor/normalize_processor.py
+++ b/src/lerobot/processor/normalize_processor.py
@@ -4,12 +4,12 @@ from copy import deepcopy
 from dataclasses import dataclass, field
 from typing import Any
 
-import numpy as np
 import torch
 from torch import Tensor
 
 from lerobot.configs.types import FeatureType, NormalizationMode, PolicyFeature
 from lerobot.datasets.lerobot_dataset import LeRobotDataset
+from lerobot.processor.converters import to_tensor
 from lerobot.processor.pipeline import (
     EnvTransition,
     ProcessorStep,
@@ -17,37 +17,6 @@ from lerobot.processor.pipeline import (
     RobotProcessor,
     TransitionKey,
 )
-
-
-def _to_tensor(value: Any, device: torch.device | None = None) -> Tensor:
-    """Convert common python/numpy/torch types to a torch.float32 tensor.
-
-    Always returns float32; preserves device if provided.
-    """
-    if isinstance(value, torch.Tensor):
-        return value.to(dtype=torch.float32, device=device)
-    if isinstance(value, np.ndarray):
-        # ensure contiguous, cast to float32 then convert
-        return torch.from_numpy(np.ascontiguousarray(value.astype(np.float32))).to(device=device)
-    if isinstance(value, (int, float)):
-        return torch.tensor(value, dtype=torch.float32, device=device)
-    if isinstance(value, (list, tuple)):
-        return torch.tensor(value, dtype=torch.float32, device=device)
-    raise TypeError(f"Unsupported type for stats value: {type(value)}")
-
-
-def _convert_stats_to_tensors(
-    stats: dict[str, dict[str, Any]], device: torch.device | None = None
-) -> dict[str, dict[str, Tensor]]:
-    """Convert numeric stats values to torch tensors, preserving keys."""
-    tensor_stats: dict[str, dict[str, Tensor]] = {}
-    for key, sub in (stats or {}).items():
-        if sub is None:
-            continue
-        tensor_stats[key] = {}
-        for stat_name, value in sub.items():
-            tensor_stats[key][stat_name] = _to_tensor(value, device=device)
-    return tensor_stats
 
 
 @dataclass
@@ -91,12 +60,12 @@ class _NormalizationMixin:
 
         # Convert stats to tensors and move to the target device once during initialization.
         self.stats = self.stats or {}
-        self._tensor_stats = _convert_stats_to_tensors(self.stats, device=self.device)
+        self._tensor_stats = to_tensor(self.stats, device=self.device)
 
     def to(self, device: torch.device | str) -> _NormalizationMixin:
         """Moves the processor's normalization stats to the specified device and returns self."""
         self.device = device
-        self._tensor_stats = _convert_stats_to_tensors(self.stats, device=self.device)
+        self._tensor_stats = to_tensor(self.stats, device=self.device)
         return self
 
     def state_dict(self) -> dict[str, Tensor]:
@@ -165,7 +134,7 @@ class _NormalizationMixin:
         # Move stats to input device if needed
         stats_device = next(iter(stats.values())).device
         if stats_device != input_device:
-            stats = _convert_stats_to_tensors({key: self._tensor_stats[key]}, device=input_device)[key]
+            stats = to_tensor({key: self._tensor_stats[key]}, device=input_device)[key]
 
         if norm_mode == NormalizationMode.MEAN_STD and "mean" in stats and "std" in stats:
             mean, std = stats["mean"], stats["std"]
@@ -295,5 +264,5 @@ def hotswap_stats(robot_processor: RobotProcessor, stats: dict[str, dict[str, An
         if isinstance(step, _NormalizationMixin):
             step.stats = stats
             # Re-initialize tensor_stats on the correct device.
-            step._tensor_stats = _convert_stats_to_tensors(stats, device=step.device)
+            step._tensor_stats = to_tensor(stats, device=step.device)
     return rp

--- a/tests/processor/test_normalize_processor.py
+++ b/tests/processor/test_normalize_processor.py
@@ -20,10 +20,10 @@ import pytest
 import torch
 
 from lerobot.configs.types import FeatureType, NormalizationMode, PolicyFeature
+from lerobot.processor.converters import to_tensor
 from lerobot.processor.normalize_processor import (
     NormalizerProcessor,
     UnnormalizerProcessor,
-    _convert_stats_to_tensors,
     hotswap_stats,
 )
 from lerobot.processor.pipeline import IdentityProcessor, RobotProcessor, TransitionKey
@@ -51,7 +51,7 @@ def test_numpy_conversion():
             "std": np.array([0.2, 0.2, 0.2]),
         }
     }
-    tensor_stats = _convert_stats_to_tensors(stats)
+    tensor_stats = to_tensor(stats)
 
     assert isinstance(tensor_stats["observation.image"]["mean"], torch.Tensor)
     assert isinstance(tensor_stats["observation.image"]["std"], torch.Tensor)
@@ -66,7 +66,7 @@ def test_tensor_conversion():
             "std": torch.tensor([1.0, 1.0]),
         }
     }
-    tensor_stats = _convert_stats_to_tensors(stats)
+    tensor_stats = to_tensor(stats)
 
     assert tensor_stats["action"]["mean"].dtype == torch.float32
     assert tensor_stats["action"]["std"].dtype == torch.float32
@@ -79,7 +79,7 @@ def test_scalar_conversion():
             "std": 0.1,
         }
     }
-    tensor_stats = _convert_stats_to_tensors(stats)
+    tensor_stats = to_tensor(stats)
 
     assert torch.allclose(tensor_stats["reward"]["mean"], torch.tensor(0.5))
     assert torch.allclose(tensor_stats["reward"]["std"], torch.tensor(0.1))
@@ -92,7 +92,7 @@ def test_list_conversion():
             "max": [1.0, 1.0, 2.0],
         }
     }
-    tensor_stats = _convert_stats_to_tensors(stats)
+    tensor_stats = to_tensor(stats)
 
     assert torch.allclose(tensor_stats["observation.state"]["min"], torch.tensor([0.0, -1.0, -2.0]))
     assert torch.allclose(tensor_stats["observation.state"]["max"], torch.tensor([1.0, 1.0, 2.0]))
@@ -105,7 +105,7 @@ def test_unsupported_type():
         }
     }
     with pytest.raises(TypeError, match="Unsupported type"):
-        _convert_stats_to_tensors(stats)
+        to_tensor(stats)
 
 
 # Helper functions to create feature maps and norm maps
@@ -1017,7 +1017,7 @@ def test_hotswap_stats_basic_functionality():
     assert new_processor.steps[1].stats == new_stats
 
     # Check that tensor stats are updated correctly
-    expected_tensor_stats = _convert_stats_to_tensors(new_stats)
+    expected_tensor_stats = to_tensor(new_stats)
     for key in expected_tensor_stats:
         for stat_name in expected_tensor_stats[key]:
             torch.testing.assert_close(
@@ -1223,7 +1223,7 @@ def test_hotswap_stats_multiple_normalizer_types():
         assert step.stats == new_stats
 
         # Check tensor stats conversion
-        expected_tensor_stats = _convert_stats_to_tensors(new_stats)
+        expected_tensor_stats = to_tensor(new_stats)
         for key in expected_tensor_stats:
             for stat_name in expected_tensor_stats[key]:
                 torch.testing.assert_close(


### PR DESCRIPTION
- Introduced `to_tensor` function using `singledispatch` to handle various input types, including scalars, arrays, and dictionaries, converting them to PyTorch tensors.
- Replaced previous tensor conversion logic in `gym_action_processor`, `normalize_processor`, and `test_converters` with the new `to_tensor` function for improved readability and maintainability.