### PR TITLE
Allow max_relative_target to be a float

### DIFF
--- a/src/lerobot/robots/bi_so100_follower/config_bi_so100_follower.py
+++ b/src/lerobot/robots/bi_so100_follower/config_bi_so100_follower.py
@@ -29,10 +29,10 @@ class BiSO100FollowerConfig(RobotConfig):
 
     # Optional
     left_arm_disable_torque_on_disconnect: bool = True
-    left_arm_max_relative_target: float | None = None
+    left_arm_max_relative_target: float | dict[str, float] | None = None
     left_arm_use_degrees: bool = False
     right_arm_disable_torque_on_disconnect: bool = True
-    right_arm_max_relative_target: float | None = None
+    right_arm_max_relative_target: float | dict[str, float] | None = None
     right_arm_use_degrees: bool = False
 
     # cameras (shared between both arms)

--- a/src/lerobot/robots/bi_so100_follower/config_bi_so100_follower.py
+++ b/src/lerobot/robots/bi_so100_follower/config_bi_so100_follower.py
@@ -29,10 +29,10 @@ class BiSO100FollowerConfig(RobotConfig):
 
     # Optional
     left_arm_disable_torque_on_disconnect: bool = True
-    left_arm_max_relative_target: int | None = None
+    left_arm_max_relative_target: float | None = None
     left_arm_use_degrees: bool = False
     right_arm_disable_torque_on_disconnect: bool = True
-    right_arm_max_relative_target: int | None = None
+    right_arm_max_relative_target: float | None = None
     right_arm_use_degrees: bool = False
 
     # cameras (shared between both arms)

--- a/src/lerobot/robots/hope_jr/config_hope_jr.py
+++ b/src/lerobot/robots/hope_jr/config_hope_jr.py
@@ -44,8 +44,8 @@ class HopeJrArmConfig(RobotConfig):
     disable_torque_on_disconnect: bool = True
 
     # `max_relative_target` limits the magnitude of the relative positional target vector for safety purposes.
-    # Set this to a positive scalar to have the same value for all motors, or a list that is the same length as
-    # the number of motors in your follower arms.
-    max_relative_target: float | None = None
+    # Set this to a positive scalar to have the same value for all motors, or a dictionary that maps motor
+    # names to the max_relative_target value for that motor.
+    max_relative_target: float | dict[str, float] | None = None
 
     cameras: dict[str, CameraConfig] = field(default_factory=dict)

--- a/src/lerobot/robots/hope_jr/config_hope_jr.py
+++ b/src/lerobot/robots/hope_jr/config_hope_jr.py
@@ -46,6 +46,6 @@ class HopeJrArmConfig(RobotConfig):
     # `max_relative_target` limits the magnitude of the relative positional target vector for safety purposes.
     # Set this to a positive scalar to have the same value for all motors, or a list that is the same length as
     # the number of motors in your follower arms.
-    max_relative_target: int | None = None
+    max_relative_target: float | None = None
 
     cameras: dict[str, CameraConfig] = field(default_factory=dict)

--- a/src/lerobot/robots/koch_follower/config_koch_follower.py
+++ b/src/lerobot/robots/koch_follower/config_koch_follower.py
@@ -30,7 +30,7 @@ class KochFollowerConfig(RobotConfig):
     # `max_relative_target` limits the magnitude of the relative positional target vector for safety purposes.
     # Set this to a positive scalar to have the same value for all motors, or a list that is the same length as
     # the number of motors in your follower arms.
-    max_relative_target: int | None = None
+    max_relative_target: float | None = None
 
     # cameras
     cameras: dict[str, CameraConfig] = field(default_factory=dict)

--- a/src/lerobot/robots/koch_follower/config_koch_follower.py
+++ b/src/lerobot/robots/koch_follower/config_koch_follower.py
@@ -30,7 +30,7 @@ class KochFollowerConfig(RobotConfig):
     # `max_relative_target` limits the magnitude of the relative positional target vector for safety purposes.
     # Set this to a positive scalar to have the same value for all motors, or a dictionary that maps motor
     # names to the max_relative_target value for that motor.
-    ax_relative_target: float | dict[str, float] | None = None
+    max_relative_target: float | dict[str, float] | None = None
 
     # cameras
     cameras: dict[str, CameraConfig] = field(default_factory=dict)

--- a/src/lerobot/robots/koch_follower/config_koch_follower.py
+++ b/src/lerobot/robots/koch_follower/config_koch_follower.py
@@ -28,9 +28,9 @@ class KochFollowerConfig(RobotConfig):
     disable_torque_on_disconnect: bool = True
 
     # `max_relative_target` limits the magnitude of the relative positional target vector for safety purposes.
-    # Set this to a positive scalar to have the same value for all motors, or a list that is the same length as
-    # the number of motors in your follower arms.
-    max_relative_target: float | None = None
+    # Set this to a positive scalar to have the same value for all motors, or a dictionary that maps motor
+    # names to the max_relative_target value for that motor.
+    ax_relative_target: float | dict[str, float] | None = None
 
     # cameras
     cameras: dict[str, CameraConfig] = field(default_factory=dict)

--- a/src/lerobot/robots/lekiwi/config_lekiwi.py
+++ b/src/lerobot/robots/lekiwi/config_lekiwi.py
@@ -41,7 +41,7 @@ class LeKiwiConfig(RobotConfig):
     # `max_relative_target` limits the magnitude of the relative positional target vector for safety purposes.
     # Set this to a positive scalar to have the same value for all motors, or a list that is the same length as
     # the number of motors in your follower arms.
-    max_relative_target: int | None = None
+    max_relative_target: float | None = None
 
     cameras: dict[str, CameraConfig] = field(default_factory=lekiwi_cameras_config)
 

--- a/src/lerobot/robots/lekiwi/config_lekiwi.py
+++ b/src/lerobot/robots/lekiwi/config_lekiwi.py
@@ -39,9 +39,9 @@ class LeKiwiConfig(RobotConfig):
     disable_torque_on_disconnect: bool = True
 
     # `max_relative_target` limits the magnitude of the relative positional target vector for safety purposes.
-    # Set this to a positive scalar to have the same value for all motors, or a list that is the same length as
-    # the number of motors in your follower arms.
-    max_relative_target: float | None = None
+    # Set this to a positive scalar to have the same value for all motors, or a dictionary that maps motor
+    # names to the max_relative_target value for that motor.
+    max_relative_target: float | dict[str, float] | None = None
 
     cameras: dict[str, CameraConfig] = field(default_factory=lekiwi_cameras_config)
 

--- a/src/lerobot/robots/so100_follower/config_so100_follower.py
+++ b/src/lerobot/robots/so100_follower/config_so100_follower.py
@@ -32,7 +32,7 @@ class SO100FollowerConfig(RobotConfig):
     # `max_relative_target` limits the magnitude of the relative positional target vector for safety purposes.
     # Set this to a positive scalar to have the same value for all motors, or a list that is the same length as
     # the number of motors in your follower arms.
-    max_relative_target: int | None = None
+    max_relative_target: float | None = None
 
     # cameras
     cameras: dict[str, CameraConfig] = field(default_factory=dict)

--- a/src/lerobot/robots/so100_follower/config_so100_follower.py
+++ b/src/lerobot/robots/so100_follower/config_so100_follower.py
@@ -30,9 +30,9 @@ class SO100FollowerConfig(RobotConfig):
     disable_torque_on_disconnect: bool = True
 
     # `max_relative_target` limits the magnitude of the relative positional target vector for safety purposes.
-    # Set this to a positive scalar to have the same value for all motors, or a list that is the same length as
-    # the number of motors in your follower arms.
-    max_relative_target: float | None = None
+    # Set this to a positive scalar to have the same value for all motors, or a dictionary that maps motor
+    # names to the max_relative_target value for that motor.
+    max_relative_target: float | dict[str, float] | None = None
 
     # cameras
     cameras: dict[str, CameraConfig] = field(default_factory=dict)

--- a/src/lerobot/robots/so101_follower/config_so101_follower.py
+++ b/src/lerobot/robots/so101_follower/config_so101_follower.py
@@ -32,7 +32,7 @@ class SO101FollowerConfig(RobotConfig):
     # `max_relative_target` limits the magnitude of the relative positional target vector for safety purposes.
     # Set this to a positive scalar to have the same value for all motors, or a list that is the same length as
     # the number of motors in your follower arms.
-    max_relative_target: int | None = None
+    max_relative_target: float | None = None
 
     # cameras
     cameras: dict[str, CameraConfig] = field(default_factory=dict)

--- a/src/lerobot/robots/so101_follower/config_so101_follower.py
+++ b/src/lerobot/robots/so101_follower/config_so101_follower.py
@@ -30,9 +30,9 @@ class SO101FollowerConfig(RobotConfig):
     disable_torque_on_disconnect: bool = True
 
     # `max_relative_target` limits the magnitude of the relative positional target vector for safety purposes.
-    # Set this to a positive scalar to have the same value for all motors, or a list that is the same length as
-    # the number of motors in your follower arms.
-    max_relative_target: float | None = None
+    # Set this to a positive scalar to have the same value for all motors, or a dictionary that maps motor
+    # names to the max_relative_target value for that motor.
+    max_relative_target: float | dict[str, float] | None = None
 
     # cameras
     cameras: dict[str, CameraConfig] = field(default_factory=dict)

--- a/src/lerobot/robots/stretch3/configuration_stretch3.py
+++ b/src/lerobot/robots/stretch3/configuration_stretch3.py
@@ -24,11 +24,6 @@ from ..config import RobotConfig
 @RobotConfig.register_subclass("stretch3")
 @dataclass
 class Stretch3RobotConfig(RobotConfig):
-    # `max_relative_target` limits the magnitude of the relative positional target vector for safety purposes.
-    # Set this to a positive scalar to have the same value for all motors, or a list that is the same length as
-    # the number of motors in your follower arms.
-    max_relative_target: int | None = None
-
     # cameras
     cameras: dict[str, CameraConfig] = field(
         default_factory=lambda: {

--- a/src/lerobot/robots/utils.py
+++ b/src/lerobot/robots/utils.py
@@ -74,7 +74,7 @@ def ensure_safe_goal_position(
 ) -> dict[str, float]:
     """Caps relative action target magnitude for safety."""
 
-    if isinstance(max_relative_target, (float, int)):
+    if isinstance(max_relative_target, float):
         diff_cap = dict.fromkeys(goal_present_pos, max_relative_target)
     elif isinstance(max_relative_target, dict):
         if not set(goal_present_pos) == set(max_relative_target):

--- a/src/lerobot/robots/utils.py
+++ b/src/lerobot/robots/utils.py
@@ -70,11 +70,11 @@ def make_robot_from_config(config: RobotConfig) -> Robot:
 
 
 def ensure_safe_goal_position(
-    goal_present_pos: dict[str, tuple[float, float]], max_relative_target: float | dict[float]
+    goal_present_pos: dict[str, tuple[float, float]], max_relative_target: float | dict[str, float]
 ) -> dict[str, float]:
     """Caps relative action target magnitude for safety."""
 
-    if isinstance(max_relative_target, float):
+    if isinstance(max_relative_target, (float, int)):
         diff_cap = dict.fromkeys(goal_present_pos, max_relative_target)
     elif isinstance(max_relative_target, dict):
         if not set(goal_present_pos) == set(max_relative_target):

--- a/src/lerobot/robots/viperx/config_viperx.py
+++ b/src/lerobot/robots/viperx/config_viperx.py
@@ -36,7 +36,7 @@ class ViperXConfig(RobotConfig):
     # Also, everything is expected to work safely out-of-the-box, but we highly advise to
     # first try to teleoperate the grippers only (by commenting out the rest of the motors in this yaml),
     # then to gradually add more motors (by uncommenting), until you can teleoperate both arms fully
-    max_relative_target: int | None = 5
+    max_relative_target: float | None = 5.0
 
     # cameras
     cameras: dict[str, CameraConfig] = field(default_factory=dict)

--- a/src/lerobot/robots/viperx/config_viperx.py
+++ b/src/lerobot/robots/viperx/config_viperx.py
@@ -28,15 +28,15 @@ class ViperXConfig(RobotConfig):
 
     # /!\ FOR SAFETY, READ THIS /!\
     # `max_relative_target` limits the magnitude of the relative positional target vector for safety purposes.
-    # Set this to a positive scalar to have the same value for all motors, or a list that is the same length as
-    # the number of motors in your follower arms.
+    # Set this to a positive scalar to have the same value for all motors, or a dictionary that maps motor
+    # names to the max_relative_target value for that motor.
     # For Aloha, for every goal position request, motor rotations are capped at 5 degrees by default.
     # When you feel more confident with teleoperation or running the policy, you can extend
     # this safety limit and even removing it by setting it to `null`.
     # Also, everything is expected to work safely out-of-the-box, but we highly advise to
     # first try to teleoperate the grippers only (by commenting out the rest of the motors in this yaml),
     # then to gradually add more motors (by uncommenting), until you can teleoperate both arms fully
-    max_relative_target: float | None = 5.0
+    max_relative_target: float | dict[str, float] = 5.0
 
     # cameras
     cameras: dict[str, CameraConfig] = field(default_factory=dict)


### PR DESCRIPTION
## What this does

This PR updates the robot configurations so that `max_relative_target` can be a float instead of just an integer.

This PR also makes a couple of small related changes:
- Updates the documentation for `max_relative_target`. Currently, it states that it can be a list of numbers, but the implementation of `ensure_safe_goal_position` only allows `max_relative_target` to be a scalar or a dictionary.
- Removes `max_relative_target` from `Stretch3RobotConfig`. `Stretch3Robot` does not use `max_relative_target`.
- Fixed an incorrect type annotation in `ensure_safe_goal_position`: `dict[float]` -> `dict[str, float]`.

Fixes #1716 and fixes #1527.

## How it was tested

I have an SO-101 and tested this change by running lerobot-teleoperate under 4 conditions:
- `--robot.max_relative_target 10`
  - Manually verified that teleop worked with goal clamping applied to all joints when moved quickly
- `--robot.max_relative_target 10.5`
  - Manually verified that teleop worked with goal clamping applied to all joints when moved quickly
- `--robot.max_relative_target '{"shoulder_pan":20.0,"shoulder_lift":20.0,"elbow_flex":20.0,"wrist_flex":20.0,"wrist_roll":20.0,"gripper":5.0}'`
  - Manually verified that teleop worked, and goal clamping only applied to the gripper
- And without `--robot.max_relative_target`
  - Manually verified that teleop worked with no goal clamping

I ran all the existing tests. All tests passed except for policy-related tests which I believe are unrelated environment setup issues:
<details>
FAILED tests/envs/test_envs.py::test_factory[aloha] - mujoco.FatalError: Default framebuffer is not complete, error 0x0
FAILED tests/policies/test_policies.py::test_policy[lerobot/aloha_sim_insertion_human-aloha-env_kwargs4-act-policy_kwargs4] - mujoco.FatalError: Default framebuffer is not complete, error 0x0
FAILED tests/policies/test_policies.py::test_policy[lerobot/aloha_sim_insertion_scripted-aloha-env_kwargs5-act-policy_kwargs5] - mujoco.FatalError: Default framebuffer is not complete, error 0x0
FAILED tests/policies/test_policies.py::test_policy[lerobot/aloha_sim_insertion_human-aloha-env_kwargs6-diffusion-policy_kwargs6] - mujoco.FatalError: Default framebuffer is not complete, error 0x0
FAILED tests/policies/test_policies.py::test_policy[lerobot/aloha_sim_transfer_cube_human-aloha-env_kwargs7-act-policy_kwargs7] - mujoco.FatalError: Default framebuffer is not complete, error 0x0
FAILED tests/policies/test_policies.py::test_policy[lerobot/aloha_sim_transfer_cube_scripted-aloha-env_kwargs8-act-policy_kwargs8] - mujoco.FatalError: Default framebuffer is not complete, error 0x0
6 failed, 816 passed, 12 skipped, 66 warnings in 193.68s (0:03:13)
</details>

## How to checkout & try? (for the reviewer)

I tested this using a basic teleop command:
```
lerobot-teleoperate \
    --robot.type=so101_follower \
    --robot.port=$FOLLOWER \
    --robot.id=follower \
    --robot.cameras="$CAMERA_CONFIG" \
    --robot.max_relative_target 10 \
    --teleop.type=so101_leader \
    --teleop.port=$LEADER \
    --teleop.id=leader \
    --display_data=true
```

Where `--robot.max_relative_target` was set to one of the above.