### PR TITLE
refactor(processors): add transform_features method to various processors

### DIFF
--- a/src/lerobot/policies/pi0/processor_pi0.py
+++ b/src/lerobot/policies/pi0/processor_pi0.py
@@ -17,6 +17,7 @@
 
 import torch
 
+from lerobot.configs.types import PolicyFeature
 from lerobot.constants import POSTPROCESSOR_DEFAULT_NAME, PREPROCESSOR_DEFAULT_NAME
 from lerobot.policies.pi0.configuration_pi0 import PI0Config
 from lerobot.processor import (
@@ -63,6 +64,9 @@ class Pi0NewLineProcessor(ComplementaryDataProcessor):
         # If task is neither string nor list of strings, leave unchanged
 
         return new_complementary_data
+
+    def transform_features(self, features: dict[str, PolicyFeature]) -> dict[str, PolicyFeature]:
+        return features
 
 
 def make_pi0_pre_post_processors(

--- a/src/lerobot/policies/smolvla/processor_smolvla.py
+++ b/src/lerobot/policies/smolvla/processor_smolvla.py
@@ -16,6 +16,7 @@
 
 import torch
 
+from lerobot.configs.types import PolicyFeature
 from lerobot.constants import POSTPROCESSOR_DEFAULT_NAME, PREPROCESSOR_DEFAULT_NAME
 from lerobot.policies.smolvla.configuration_smolvla import SmolVLAConfig
 from lerobot.processor import (
@@ -107,3 +108,6 @@ class SmolVLANewLineProcessor(ComplementaryDataProcessor):
         # If task is neither string nor list of strings, leave unchanged
 
         return new_complementary_data
+
+    def transform_features(self, features: dict[str, PolicyFeature]) -> dict[str, PolicyFeature]:
+        return features

--- a/src/lerobot/processor/batch_processor.py
+++ b/src/lerobot/processor/batch_processor.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass, field
 
 from torch import Tensor
 
+from lerobot.configs.types import PolicyFeature
 from lerobot.constants import OBS_ENV_STATE, OBS_IMAGE, OBS_IMAGES, OBS_STATE
 from lerobot.processor.pipeline import (
     ActionProcessor,
@@ -36,6 +37,9 @@ class ToBatchProcessorAction(ActionProcessor):
             return action
 
         return action.unsqueeze(0)
+
+    def transform_features(self, features: dict[str, PolicyFeature]) -> dict[str, PolicyFeature]:
+        return features
 
 
 @dataclass
@@ -63,6 +67,9 @@ class ToBatchProcessorObservation(ObservationProcessor):
                 observation[key] = value.unsqueeze(0)
         return observation
 
+    def transform_features(self, features: dict[str, PolicyFeature]) -> dict[str, PolicyFeature]:
+        return features
+
 
 @dataclass
 @ProcessorStepRegistry.register(name="to_batch_processor_complementary_data")
@@ -88,6 +95,9 @@ class ToBatchProcessorComplementaryData(ComplementaryDataProcessor):
             if isinstance(task_index_value, Tensor) and task_index_value.dim() == 0:
                 complementary_data["task_index"] = task_index_value.unsqueeze(0)
         return complementary_data
+
+    def transform_features(self, features: dict[str, PolicyFeature]) -> dict[str, PolicyFeature]:
+        return features
 
 
 @dataclass
@@ -140,3 +150,6 @@ class ToBatchProcessor(ProcessorStep):
         transition = self.to_batch_observation_processor(transition)
         transition = self.to_batch_complementary_data_processor(transition)
         return transition
+
+    def transform_features(self, features: dict[str, PolicyFeature]) -> dict[str, PolicyFeature]:
+        return features

--- a/src/lerobot/processor/converters.py
+++ b/src/lerobot/processor/converters.py
@@ -295,7 +295,8 @@ def merge_transitions(transitions: Sequence[EnvTransition] | EnvTransition) -> E
     Returns:
         Merged EnvTransition.
     """
-    if isinstance(transitions, EnvTransition):  # Single transition
+
+    if not isinstance(transitions, Sequence):  # Single transition
         return transitions
 
     items = list(transitions)

--- a/src/lerobot/processor/delta_action_processor.py
+++ b/src/lerobot/processor/delta_action_processor.py
@@ -45,6 +45,9 @@ class MapTensorToDeltaActionDict(ActionProcessor):
             delta_action["action.gripper"] = action[3]
         return delta_action
 
+    def transform_features(self, features: dict[str, PolicyFeature]) -> dict[str, PolicyFeature]:
+        return features
+
 
 @ProcessorStepRegistry.register("map_delta_action_to_robot_action")
 @dataclass

--- a/src/lerobot/processor/device_processor.py
+++ b/src/lerobot/processor/device_processor.py
@@ -18,6 +18,7 @@ from typing import Any
 
 import torch
 
+from lerobot.configs.types import PolicyFeature
 from lerobot.processor.core import EnvTransition, TransitionKey
 from lerobot.processor.pipeline import ProcessorStep, ProcessorStepRegistry
 from lerobot.utils.utils import get_safe_torch_device
@@ -127,3 +128,6 @@ class DeviceProcessor(ProcessorStep):
     def get_config(self) -> dict[str, Any]:
         """Return configuration for serialization."""
         return {"device": self.device, "float_dtype": self.float_dtype}
+
+    def transform_features(self, features: dict[str, PolicyFeature]) -> dict[str, PolicyFeature]:
+        return features

--- a/src/lerobot/processor/gym_action_processor.py
+++ b/src/lerobot/processor/gym_action_processor.py
@@ -16,6 +16,7 @@ from dataclasses import dataclass
 import numpy as np
 import torch
 
+from lerobot.configs.types import PolicyFeature
 from lerobot.processor.converters import to_tensor
 from lerobot.processor.pipeline import ActionProcessor, ProcessorStepRegistry
 
@@ -48,6 +49,9 @@ class Torch2NumpyActionProcessor(ActionProcessor):
 
         return numpy_action
 
+    def transform_features(self, features: dict[str, PolicyFeature]) -> dict[str, PolicyFeature]:
+        return features
+
 
 @ProcessorStepRegistry.register("numpy2torch_action_processor")
 @dataclass
@@ -62,3 +66,6 @@ class Numpy2TorchActionProcessor(ActionProcessor):
             )
         torch_action = to_tensor(action, dtype=None)  # Preserve original dtype
         return torch_action
+
+    def transform_features(self, features: dict[str, PolicyFeature]) -> dict[str, PolicyFeature]:
+        return features

--- a/src/lerobot/processor/hil_processor.py
+++ b/src/lerobot/processor/hil_processor.py
@@ -39,6 +39,9 @@ class AddTeleopActionAsComplimentaryData(ComplementaryDataProcessor):
         new_complementary_data[TELEOP_ACTION_KEY] = self.teleop_device.get_action()
         return new_complementary_data
 
+    def transform_features(self, features: dict[str, PolicyFeature]) -> dict[str, PolicyFeature]:
+        return features
+
 
 @ProcessorStepRegistry.register("add_teleop_action_as_info")
 @dataclass
@@ -52,6 +55,9 @@ class AddTeleopEventsAsInfo(InfoProcessor):
         teleop_events = getattr(self.teleop_device, "get_teleop_events", lambda: {})()
         new_info.update(teleop_events)
         return new_info
+
+    def transform_features(self, features: dict[str, PolicyFeature]) -> dict[str, PolicyFeature]:
+        return features
 
 
 @ProcessorStepRegistry.register("image_crop_resize_processor")
@@ -127,6 +133,9 @@ class TimeLimitProcessor(TruncatedProcessor):
     def reset(self) -> None:
         self.current_step = 0
 
+    def transform_features(self, features: dict[str, PolicyFeature]) -> dict[str, PolicyFeature]:
+        return features
+
 
 @dataclass
 @ProcessorStepRegistry.register("gripper_penalty_processor")
@@ -172,6 +181,9 @@ class GripperPenaltyProcessor(ComplementaryDataProcessor):
     def reset(self) -> None:
         """Reset the processor state."""
         self.last_gripper_state = None
+
+    def transform_features(self, features: dict[str, PolicyFeature]) -> dict[str, PolicyFeature]:
+        return features
 
 
 @dataclass
@@ -243,6 +255,9 @@ class InterventionActionProcessor(ProcessorStep):
             "terminate_on_success": self.terminate_on_success,
         }
 
+    def transform_features(self, features: dict[str, PolicyFeature]) -> dict[str, PolicyFeature]:
+        return features
+
 
 @dataclass
 @ProcessorStepRegistry.register("reward_classifier_processor")
@@ -312,3 +327,6 @@ class RewardClassifierProcessor(ProcessorStep):
             "success_reward": self.success_reward,
             "terminate_on_success": self.terminate_on_success,
         }
+
+    def transform_features(self, features: dict[str, PolicyFeature]) -> dict[str, PolicyFeature]:
+        return features

--- a/src/lerobot/processor/normalize_processor.py
+++ b/src/lerobot/processor/normalize_processor.py
@@ -211,6 +211,9 @@ class NormalizerProcessor(_NormalizationMixin, ProcessorStep):
 
         return new_transition
 
+    def transform_features(self, features: dict[str, PolicyFeature]) -> dict[str, PolicyFeature]:
+        return features
+
 
 @dataclass
 @ProcessorStepRegistry.register(name="unnormalizer_processor")
@@ -248,6 +251,9 @@ class UnnormalizerProcessor(_NormalizationMixin, ProcessorStep):
             new_transition[TransitionKey.ACTION] = self._normalize_action(action, inverse=True)
 
         return new_transition
+
+    def transform_features(self, features: dict[str, PolicyFeature]) -> dict[str, PolicyFeature]:
+        return features
 
 
 def hotswap_stats(robot_processor: RobotProcessor, stats: dict[str, dict[str, Any]]) -> RobotProcessor:

--- a/src/lerobot/processor/pipeline.py
+++ b/src/lerobot/processor/pipeline.py
@@ -169,7 +169,7 @@ class ProcessorStep(ABC):
     def reset(self) -> None:
         return None
 
-    # TODO(Steven): Consider making this abstract so it is more explicit
+    @abstractmethod
     def transform_features(self, features: dict[str, PolicyFeature]) -> dict[str, PolicyFeature]:
         return features
 
@@ -1091,3 +1091,6 @@ class IdentityProcessor(ProcessorStep):
 
     def __call__(self, transition: EnvTransition) -> EnvTransition:
         return transition
+
+    def transform_features(self, features: dict[str, PolicyFeature]) -> dict[str, PolicyFeature]:
+        return features

--- a/src/lerobot/robots/so100_follower/robot_kinematic_processor.py
+++ b/src/lerobot/robots/so100_follower/robot_kinematic_processor.py
@@ -220,6 +220,9 @@ class EEBoundsAndSafety(ActionProcessor):
         self._last_pos = None
         self._last_twist = None
 
+    def transform_features(self, features: dict[str, PolicyFeature]) -> dict[str, PolicyFeature]:
+        return features
+
 
 @ProcessorStepRegistry.register("inverse_kinematics_ee_to_joints")
 @dataclass
@@ -444,3 +447,6 @@ class AddRobotObservationAsComplimentaryData(ComplementaryDataProcessor):
             if isinstance(k, str) and k.endswith(".pos")
         }
         return new_comp
+
+    def transform_features(self, features: dict[str, PolicyFeature]) -> dict[str, PolicyFeature]:
+        return features


### PR DESCRIPTION
This makes `transform_features` abstract to enforce the user/developer to think about the feature contract when developing a new processor step