### PR TITLE
wait_image_writer

### DIFF
--- a/src/lerobot/datasets/lerobot_dataset.py
+++ b/src/lerobot/datasets/lerobot_dataset.py
@@ -917,6 +917,7 @@ class LeRobotDataset(torch.utils.data.Dataset):
 
         # Clean up image files for the current episode buffer
         if self.image_writer is not None:
+            self._wait_image_writer()
             for cam_key in self.meta.camera_keys:
                 img_dir = self._get_image_file_path(
                     episode_index=episode_index, image_key=cam_key, frame_index=0


### PR DESCRIPTION
## What this does
During the record, if you use different fps cameras, the async image writer somtimes try to write the image after remove the directory and leads to error.
To fix this, it is better to add wait_image_writer before remove the image buffer directory.







