### PR TITLE
refactor(processor): Remove scipy dependency: Replace spatial.transform.Rotation with custom implementation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,6 @@ dependencies = [
     "pynput>=1.7.7",
     "pyserial>=3.5",
     "wandb>=0.20.0",
-    "scipy>=1.15.2",
 
     "torch>=2.2.1,<2.8.0", # TODO: Bumb dependency
     "torchcodec>=0.2.1,<0.6.0; sys_platform != 'win32' and (sys_platform != 'linux' or (platform_machine != 'aarch64' and platform_machine != 'arm64' and platform_machine != 'armv7l')) and (sys_platform != 'darwin' or platform_machine != 'x86_64')", # TODO: Bumb dependency

--- a/src/lerobot/robots/so100_follower/robot_kinematic_processor.py
+++ b/src/lerobot/robots/so100_follower/robot_kinematic_processor.py
@@ -17,7 +17,6 @@
 from dataclasses import dataclass, field
 
 import numpy as np
-from scipy.spatial.transform import Rotation
 
 from lerobot.configs.types import FeatureType, PolicyFeature
 from lerobot.constants import ACTION, OBS_STATE
@@ -32,6 +31,7 @@ from lerobot.processor import (
     TransitionKey,
 )
 from lerobot.robots.robot import Robot
+from lerobot.utils.rotation import Rotation
 
 
 @ProcessorStepRegistry.register("ee_reference_and_delta")

--- a/src/lerobot/utils/rotation.py
+++ b/src/lerobot/utils/rotation.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python
+
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Custom rotation utilities to replace scipy.spatial.transform.Rotation."""
+
+import numpy as np
+
+
+class Rotation:
+    """
+    Custom rotation class that provides a subset of scipy.spatial.transform.Rotation functionality.
+
+    Supports conversions between rotation vectors, rotation matrices, and quaternions.
+    """
+
+    def __init__(self, quat: np.ndarray) -> None:
+        """Initialize rotation from quaternion [x, y, z, w]."""
+        self._quat = np.asarray(quat, dtype=float)
+        # Normalize quaternion
+        norm = np.linalg.norm(self._quat)
+        if norm > 0:
+            self._quat = self._quat / norm
+
+    @classmethod
+    def from_rotvec(cls, rotvec: np.ndarray) -> "Rotation":
+        """
+        Create rotation from rotation vector using Rodrigues' formula.
+
+        Args:
+            rotvec: Rotation vector [x, y, z] where magnitude is angle in radians
+
+        Returns:
+            Rotation instance
+        """
+        rotvec = np.asarray(rotvec, dtype=float)
+        angle = np.linalg.norm(rotvec)
+
+        if angle < 1e-8:
+            # For very small angles, use identity quaternion
+            quat = np.array([0.0, 0.0, 0.0, 1.0])
+        else:
+            axis = rotvec / angle
+            half_angle = angle / 2.0
+            sin_half = np.sin(half_angle)
+            cos_half = np.cos(half_angle)
+
+            # Quaternion [x, y, z, w]
+            quat = np.array([axis[0] * sin_half, axis[1] * sin_half, axis[2] * sin_half, cos_half])
+
+        return cls(quat)
+
+    @classmethod
+    def from_matrix(cls, matrix: np.ndarray) -> "Rotation":
+        """
+        Create rotation from 3x3 rotation matrix.
+
+        Args:
+            matrix: 3x3 rotation matrix
+
+        Returns:
+            Rotation instance
+        """
+        matrix = np.asarray(matrix, dtype=float)
+
+        # Shepherd's method for converting rotation matrix to quaternion
+        trace = np.trace(matrix)
+
+        if trace > 0:
+            s = np.sqrt(trace + 1.0) * 2  # s = 4 * qw
+            qw = 0.25 * s
+            qx = (matrix[2, 1] - matrix[1, 2]) / s
+            qy = (matrix[0, 2] - matrix[2, 0]) / s
+            qz = (matrix[1, 0] - matrix[0, 1]) / s
+        elif matrix[0, 0] > matrix[1, 1] and matrix[0, 0] > matrix[2, 2]:
+            s = np.sqrt(1.0 + matrix[0, 0] - matrix[1, 1] - matrix[2, 2]) * 2  # s = 4 * qx
+            qw = (matrix[2, 1] - matrix[1, 2]) / s
+            qx = 0.25 * s
+            qy = (matrix[0, 1] + matrix[1, 0]) / s
+            qz = (matrix[0, 2] + matrix[2, 0]) / s
+        elif matrix[1, 1] > matrix[2, 2]:
+            s = np.sqrt(1.0 + matrix[1, 1] - matrix[0, 0] - matrix[2, 2]) * 2  # s = 4 * qy
+            qw = (matrix[0, 2] - matrix[2, 0]) / s
+            qx = (matrix[0, 1] + matrix[1, 0]) / s
+            qy = 0.25 * s
+            qz = (matrix[1, 2] + matrix[2, 1]) / s
+        else:
+            s = np.sqrt(1.0 + matrix[2, 2] - matrix[0, 0] - matrix[1, 1]) * 2  # s = 4 * qz
+            qw = (matrix[1, 0] - matrix[0, 1]) / s
+            qx = (matrix[0, 2] + matrix[2, 0]) / s
+            qy = (matrix[1, 2] + matrix[2, 1]) / s
+            qz = 0.25 * s
+
+        quat = np.array([qx, qy, qz, qw])
+        return cls(quat)
+
+    @classmethod
+    def from_quat(cls, quat: np.ndarray) -> "Rotation":
+        """
+        Create rotation from quaternion.
+
+        Args:
+            quat: Quaternion [x, y, z, w] or [w, x, y, z] (specify convention in docstring)
+                  This implementation expects [x, y, z, w] format
+
+        Returns:
+            Rotation instance
+        """
+        return cls(quat)
+
+    def as_matrix(self) -> np.ndarray:
+        """
+        Convert rotation to 3x3 rotation matrix.
+
+        Returns:
+            3x3 rotation matrix
+        """
+        qx, qy, qz, qw = self._quat
+
+        # Compute rotation matrix from quaternion
+        return np.array(
+            [
+                [1 - 2 * (qy * qy + qz * qz), 2 * (qx * qy - qz * qw), 2 * (qx * qz + qy * qw)],
+                [2 * (qx * qy + qz * qw), 1 - 2 * (qx * qx + qz * qz), 2 * (qy * qz - qx * qw)],
+                [2 * (qx * qz - qy * qw), 2 * (qy * qz + qx * qw), 1 - 2 * (qx * qx + qy * qy)],
+            ],
+            dtype=float,
+        )
+
+    def as_rotvec(self) -> np.ndarray:
+        """
+        Convert rotation to rotation vector.
+
+        Returns:
+            Rotation vector [x, y, z] where magnitude is angle in radians
+        """
+        qx, qy, qz, qw = self._quat
+
+        # Ensure qw is positive for unique representation
+        if qw < 0:
+            qx, qy, qz, qw = -qx, -qy, -qz, -qw
+
+        # Compute angle and axis
+        angle = 2.0 * np.arccos(np.clip(abs(qw), 0.0, 1.0))
+        sin_half_angle = np.sqrt(1.0 - qw * qw)
+
+        if sin_half_angle < 1e-8:
+            # For very small angles, use linearization: rotvec ≈ 2 * [qx, qy, qz]
+            return 2.0 * np.array([qx, qy, qz])
+
+        # Extract axis and scale by angle
+        axis = np.array([qx, qy, qz]) / sin_half_angle
+        return angle * axis
+
+    def as_quat(self) -> np.ndarray:
+        """
+        Get quaternion representation.
+
+        Returns:
+            Quaternion [x, y, z, w]
+        """
+        return self._quat.copy()


### PR DESCRIPTION
This PR removes the scipy dependency from the robot kinematic processor by implementing a custom `Rotation` class that provides identical functionality to `scipy.spatial.transform.Rotation` for the specific use cases in this codebase.

### **📋 Changes Made**

#### **✅ New Files**
- **`src/lerobot/utils/rotation.py`**: Custom `Rotation` class implementation
  - `from_rotvec()` - Initialize from rotation vectors using Rodrigues' formula
  - `from_matrix()` - Initialize from 3x3 rotation matrices using Shepperd's method  
  - `from_quat()` - Initialize from quaternions
  - `as_matrix()` - Convert to 3x3 rotation matrix
  - `as_rotvec()` - Convert to rotation vector
  - `as_quat()` - Get quaternion representation

#### **✅ Modified Files**
- **`src/lerobot/robots/so100_follower/robot_kinematic_processor.py`**: 
  - Updated import: `from scipy.spatial.transform import Rotation` → `from lerobot.utils.rotation import Rotation`


### **🧪 Testing & Validation**

Comprehensive testing was performed to ensure mathematical accuracy and compatibility:

#### **✅ Test Results Summary**
- **Pattern 1** (`from_rotvec().as_matrix()`): Max difference **2.22e-16**
- **Pattern 2** (`from_matrix().as_rotvec()`): Max difference **7.91e-16**
- **Pattern 3** (Full round-trip): Max difference **7.09e-06** 
- **Pattern 4** (EEReferenceAndDelta): Max difference **1.11e-16** 
- **Pattern 5** (ForwardKinematicsJointsToEE): Max difference **3.97e-06** 

#### **✅ Test Coverage**
- ✅ Identity rotations
- ✅ Small angle rotations (1e-8 to 1e-4 radians)
- ✅ Common robotics angles (30°, 45°, 90°, 180°)
- ✅ Random rotation vectors
- ✅ Matrix ↔ rotation conversions
- ✅ Quaternion ↔ rotation conversions  
- ✅ Large rotations (multiple 2π)
- ✅ Round-trip conversions
- ✅ Exact usage patterns from robot kinematic processor

### **🔬 Mathematical Implementation**

#### **Algorithms Used**
- **Rodrigues' Formula**: For rotation vector ↔ quaternion conversion
- **Shepperd's Method**: For robust rotation matrix ↔ quaternion conversion
- **Standard Quaternion Operations**: For matrix generation and normalization

#### **Accuracy Guarantees**
- **Machine precision** for most operations (differences ~1e-16)
- **Sub-milliradian precision** for robotics applications (differences ~1e-6)
- **Numerically stable** for edge cases (very small rotations, large rotations)


test script:

https://gist.github.com/AdilZouitine/be678ff257d042c5f491a657d1383282

Result:


✅ Pattern 1 max difference: 2.22e-16
✅ Pattern 2 max difference: 7.91e-16  
✅ Pattern 3 max difference: 7.09e-06
✅ Pattern 4 max difference: 1.11e-16
✅ Pattern 5 max difference: 3.97e-06

## Test Pattern Descriptions

Pattern 1: from_rotvec([wx, wy, wz]).as_matrix()
Validates conversion of user rotation commands (twist vectors) into rotation matrices used for end-effector pose calculations in the EEReferenceAndDelta processor.

Pattern 2: from_matrix(matrix).as_rotvec()
Validates extraction of rotation vectors from transformation matrices returned by forward kinematics, ensuring accurate end-effector orientation reporting in the ForwardKinematicsJointsToEE processor.

Pattern 3: Full Round-trip Simulation
Validates the complete robot control workflow: user input → reference frame transformation → matrix operations → final rotation extraction, simulating real-time robot operation.

Pattern 4: Exact EEReferenceAndDelta Code
Validates the precise mathematical operation `desired[:3, :3] = ref[:3, :3] @ r_abs` used to apply relative rotations to reference poses in teleoperation control.

Pattern 5: ForwardKinematicsJointsToEE Code
Validates extraction of twist vectors from 4x4 transformation matrices using `tw = Rotation.from_matrix(t[:3, :3]).as_rotvec()` for end-effector state observation.
