### PR TITLE
refactor(utils): simplify log_rerun_data function

### DIFF
--- a/examples/phone_to_so100/evaluate.py
+++ b/examples/phone_to_so100/evaluate.py
@@ -23,6 +23,7 @@ from lerobot.policies.act.modeling_act import ACTPolicy
 from lerobot.policies.factory import make_pre_post_processors
 from lerobot.processor import RobotProcessorPipeline
 from lerobot.processor.converters import (
+    identity_transition,
     observation_to_transition,
     transition_to_robot_action,
 )
@@ -74,7 +75,7 @@ robot_ee_to_joints_processor = RobotProcessorPipeline(
             initial_guess_current_joints=True,
         ),
     ],
-    to_transition=lambda tr: tr,
+    to_transition=identity_transition,
     to_output=transition_to_robot_action,
 )
 
@@ -84,7 +85,7 @@ robot_joints_to_ee_pose_processor = RobotProcessorPipeline(
         ForwardKinematicsJointsToEE(kinematics=kinematics_solver, motor_names=list(robot.bus.motors.keys()))
     ],
     to_transition=observation_to_transition,
-    to_output=lambda tr: tr,
+    to_output=identity_transition,
 )
 
 # Build dataset action and gripper features

--- a/examples/phone_to_so100/record.py
+++ b/examples/phone_to_so100/record.py
@@ -23,6 +23,7 @@ from lerobot.model.kinematics import RobotKinematics
 from lerobot.processor import RobotProcessorPipeline
 from lerobot.processor.converters import (
     action_to_transition,
+    identity_transition,
     observation_to_transition,
     transition_to_robot_action,
 )
@@ -89,7 +90,7 @@ phone_to_robot_ee_pose_processor = RobotProcessorPipeline(
         ),
     ],
     to_transition=action_to_transition,
-    to_output=lambda tr: tr,
+    to_output=identity_transition,
 )
 
 # Build pipeline to convert ee pose action to joint action
@@ -105,7 +106,7 @@ robot_ee_to_joints_processor = RobotProcessorPipeline(
             speed_factor=20.0,
         ),
     ],
-    to_transition=lambda tr: tr,
+    to_transition=identity_transition,
     to_output=transition_to_robot_action,
 )
 
@@ -115,7 +116,7 @@ robot_joints_to_ee_pose = RobotProcessorPipeline(
         ForwardKinematicsJointsToEE(kinematics=kinematics_solver, motor_names=list(robot.bus.motors.keys()))
     ],
     to_transition=observation_to_transition,
-    to_output=lambda tr: tr,
+    to_output=identity_transition,
 )
 
 # Build dataset ee action features

--- a/src/lerobot/processor/converters.py
+++ b/src/lerobot/processor/converters.py
@@ -479,3 +479,7 @@ def transition_to_batch(transition: EnvTransition) -> dict[str, Any]:
         batch.update(observation)
 
     return batch
+
+
+def identity_transition(tr: EnvTransition) -> EnvTransition:
+    return tr

--- a/src/lerobot/record.py
+++ b/src/lerobot/record.py
@@ -386,7 +386,12 @@ def record_loop(
             dataset.add_frame(frame, task=single_task)
 
         if display_data:
-            log_rerun_data([obs_transition, teleop_transition or policy_transition])
+            # Extract observation and action data from transitions
+            obs_data = obs_transition.get(TransitionKey.OBSERVATION, {}) if obs_transition else {}
+            action_transition = teleop_transition or policy_transition
+            action_data = action_transition.get(TransitionKey.ACTION, {}) if action_transition else {}
+
+            log_rerun_data(observation=obs_data, action=action_data)
 
         dt_s = time.perf_counter() - start_loop_t
         busy_wait(1 / fps - dt_s)

--- a/src/lerobot/teleoperate.py
+++ b/src/lerobot/teleoperate.py
@@ -61,7 +61,7 @@ import rerun as rr
 from lerobot.cameras.opencv.configuration_opencv import OpenCVCameraConfig  # noqa: F401
 from lerobot.cameras.realsense.configuration_realsense import RealSenseCameraConfig  # noqa: F401
 from lerobot.configs import parser
-from lerobot.processor import IdentityProcessorStep, RobotProcessorPipeline
+from lerobot.processor import IdentityProcessorStep, RobotProcessorPipeline, TransitionKey
 from lerobot.processor.converters import (
     action_to_transition,
     observation_to_transition,
@@ -162,7 +162,12 @@ def teleop_loop(
             obs = robot.get_observation()
             # Process robot observation through pipeline
             obs_transition = robot_observation_processor(obs)
-            log_rerun_data([obs_transition, teleop_transition])
+
+            # Extract observation and action data from transitions
+            obs_data = obs_transition.get(TransitionKey.OBSERVATION, {}) if obs_transition else {}
+            action_data = teleop_transition.get(TransitionKey.ACTION, {}) if teleop_transition else {}
+
+            log_rerun_data(observation=obs_data, action=action_data)
 
             print("\n" + "-" * (display_len + 10))
             print(f"{'NAME':<{display_len}} | {'NORM':>7}")

--- a/src/lerobot/utils/visualization_utils.py
+++ b/src/lerobot/utils/visualization_utils.py
@@ -19,8 +19,6 @@ from typing import Any
 import numpy as np
 import rerun as rr
 
-from lerobot.processor import EnvTransition, TransitionKey
-
 
 def _init_rerun(session_name: str = "lerobot_control_loop") -> None:
     """Initializes the Rerun SDK for visualizing the control loop."""
@@ -40,78 +38,43 @@ def _is_scalar(x):
 
 
 def log_rerun_data(
-    data: list[dict[str | Any] | EnvTransition] | dict[str | Any] | EnvTransition | None = None,
-    *,
     observation: dict[str, Any] | None = None,
     action: dict[str, Any] | None = None,
 ) -> None:
-    items = data if isinstance(data, list) else ([data] if data is not None else [])
+    """Log observation and action data to Rerun for visualization."""
+    if observation:
+        for k, v in observation.items():
+            if v is None:
+                continue
+            key = k if str(k).startswith("observation.") else f"observation.{k}"
 
-    obs = {} if observation is None else dict(observation)
-    act = {} if action is None else dict(action)
+            if _is_scalar(v):
+                rr.log(key, rr.Scalar(float(v)))
+            elif isinstance(v, np.ndarray):
+                arr = v
+                # Convert CHW -> HWC when needed
+                if arr.ndim == 3 and arr.shape[0] in (1, 3, 4) and arr.shape[-1] not in (1, 3, 4):
+                    arr = np.transpose(arr, (1, 2, 0))
+                if arr.ndim == 1:
+                    for i, vi in enumerate(arr):
+                        rr.log(f"{key}_{i}", rr.Scalar(float(vi)))
+                else:
+                    rr.log(key, rr.Image(arr), static=True)
 
-    for idx, item in enumerate(items):
-        if not isinstance(item, dict):
-            continue
+    if action:
+        for k, v in action.items():
+            if v is None:
+                continue
+            key = k if str(k).startswith("action.") else f"action.{k}"
 
-        if any(isinstance(k, TransitionKey) for k in item.keys()):
-            o = item.get(TransitionKey.OBSERVATION) or {}
-            a = item.get(TransitionKey.ACTION) or {}
-            if isinstance(o, dict):
-                obs.update(o)
-            if isinstance(a, dict):
-                act.update(a)
-            continue
-
-        keys = list(item.keys())
-        has_obs = any(str(k).startswith("observation.") for k in keys)
-        has_act = any(str(k).startswith("action.") for k in keys)
-
-        if has_obs or has_act:
-            if has_obs:
-                obs.update(item)
-            if has_act:
-                act.update(item)
-        else:
-            # No prefixes: assume first is observation, second is action, others are observation
-            if idx == 0:
-                obs.update(item)
-            elif idx == 1:
-                act.update(item)
-            else:
-                obs.update(item)
-
-    for k, v in obs.items():
-        if v is None:
-            continue
-        key = k if str(k).startswith("observation.") else f"observation.{k}"
-
-        if _is_scalar(v):
-            rr.log(key, rr.Scalar(float(v)))
-        elif isinstance(v, np.ndarray):
-            arr = v
-            # Convert CHW -> HWC when needed
-            if arr.ndim == 3 and arr.shape[0] in (1, 3, 4) and arr.shape[-1] not in (1, 3, 4):
-                arr = np.transpose(arr, (1, 2, 0))
-            if arr.ndim == 1:
-                for i, vi in enumerate(arr):
-                    rr.log(f"{key}_{i}", rr.Scalar(float(vi)))
-            else:
-                rr.log(key, rr.Image(arr), static=True)
-
-    for k, v in act.items():
-        if v is None:
-            continue
-        key = k if str(k).startswith("action.") else f"action.{k}"
-
-        if _is_scalar(v):
-            rr.log(key, rr.Scalar(float(v)))
-        elif isinstance(v, np.ndarray):
-            if v.ndim == 1:
-                for i, vi in enumerate(v):
-                    rr.log(f"{key}_{i}", rr.Scalar(float(vi)))
-            else:
-                # Fall back to flattening higher-dimensional arrays
-                flat = v.flatten()
-                for i, vi in enumerate(flat):
-                    rr.log(f"{key}_{i}", rr.Scalar(float(vi)))
+            if _is_scalar(v):
+                rr.log(key, rr.Scalar(float(v)))
+            elif isinstance(v, np.ndarray):
+                if v.ndim == 1:
+                    for i, vi in enumerate(v):
+                        rr.log(f"{key}_{i}", rr.Scalar(float(vi)))
+                else:
+                    # Fall back to flattening higher-dimensional arrays
+                    flat = v.flatten()
+                    for i, vi in enumerate(flat):
+                        rr.log(f"{key}_{i}", rr.Scalar(float(vi)))

--- a/src/lerobot/utils/visualization_utils.py
+++ b/src/lerobot/utils/visualization_utils.py
@@ -31,7 +31,8 @@ def _init_rerun(session_name: str = "lerobot_control_loop") -> None:
 
 def _is_scalar(x):
     return (
-        isinstance(x, numbers.Real)
+        isinstance(x, float)
+        or isinstance(x, numbers.Real)
         or isinstance(x, (np.integer, np.floating))
         or (isinstance(x, np.ndarray) and x.ndim == 0)
     )

--- a/tests/utils/test_visualization_utils.py
+++ b/tests/utils/test_visualization_utils.py
@@ -86,7 +86,10 @@ def test_log_rerun_data_envtransition_scalars_and_image(mock_rerun):
         TransitionKey.ACTION: act,
     }
 
-    vu.log_rerun_data(transition)
+    # Extract observation and action data from transition like in the real call sites
+    obs_data = transition.get(TransitionKey.OBSERVATION, {})
+    action_data = transition.get(TransitionKey.ACTION, {})
+    vu.log_rerun_data(observation=obs_data, action=action_data)
 
     # We expect:
     # - observation.state.temperature -> Scalar
@@ -141,7 +144,9 @@ def test_log_rerun_data_plain_list_ordering_and_prefixes(mock_rerun):
         "vec": np.array([9, 8, 7], dtype=np.float32),
     }
 
-    vu.log_rerun_data([obs_plain, act_plain])
+    # Extract observation and action data from list like the old function logic did
+    # First dict was treated as observation, second as action
+    vu.log_rerun_data(observation=obs_plain, action=act_plain)
 
     # Expected keys with auto-prefixes
     expected = {
@@ -181,7 +186,6 @@ def test_log_rerun_data_kwargs_only(mock_rerun):
     vu, calls = mock_rerun
 
     vu.log_rerun_data(
-        None,
         observation={"observation.temp": 10.0, "observation.gray": np.zeros((8, 8, 1), dtype=np.uint8)},
         action={"action.a": 1.0},
     )


### PR DESCRIPTION
Simplified `log_rerun_data` to only accept observation and action dicts, reducing complexity from 76 to 41 lines.

**Changes:**
- Removed complex EnvTransition handling and heuristics
- Updated 2 call sites to extract obs/action data before calling function
