### PR TITLE
refactor(tests): update processor test assertions to reflect new preprocessor and postprocessor names

### DIFF
--- a/tests/processor/test_act_processor.py
+++ b/tests/processor/test_act_processor.py
@@ -81,8 +81,8 @@ def test_make_act_processor_basic():
     preprocessor, postprocessor = make_act_pre_post_processors(config, stats)
 
     # Check processor names
-    assert preprocessor.name == "robot_preprocessor"
-    assert postprocessor.name == "robot_postprocessor"
+    assert preprocessor.name == "policy_preprocessor"
+    assert postprocessor.name == "policy_postprocessor"
 
     # Check steps in preprocessor
     assert len(preprocessor.steps) == 4

--- a/tests/processor/test_diffusion_processor.py
+++ b/tests/processor/test_diffusion_processor.py
@@ -84,8 +84,8 @@ def test_make_diffusion_processor_basic():
     preprocessor, postprocessor = make_diffusion_pre_post_processors(config, stats)
 
     # Check processor names
-    assert preprocessor.name == "robot_preprocessor"
-    assert postprocessor.name == "robot_postprocessor"
+    assert preprocessor.name == "policy_preprocessor"
+    assert postprocessor.name == "policy_postprocessor"
 
     # Check steps in preprocessor
     assert len(preprocessor.steps) == 4

--- a/tests/processor/test_pi0_processor.py
+++ b/tests/processor/test_pi0_processor.py
@@ -110,8 +110,8 @@ def test_make_pi0_processor_basic():
         )
 
     # Check processor names
-    assert preprocessor.name == "robot_preprocessor"
-    assert postprocessor.name == "robot_postprocessor"
+    assert preprocessor.name == "policy_preprocessor"
+    assert postprocessor.name == "policy_postprocessor"
 
     # Check steps in preprocessor
     assert len(preprocessor.steps) == 6

--- a/tests/processor/test_sac_processor.py
+++ b/tests/processor/test_sac_processor.py
@@ -86,8 +86,8 @@ def test_make_sac_processor_basic():
     )
 
     # Check processor names
-    assert preprocessor.name == "robot_preprocessor"
-    assert postprocessor.name == "robot_postprocessor"
+    assert preprocessor.name == "policy_preprocessor"
+    assert postprocessor.name == "policy_postprocessor"
 
     # Check steps in preprocessor
     assert len(preprocessor.steps) == 4

--- a/tests/processor/test_smolvla_processor.py
+++ b/tests/processor/test_smolvla_processor.py
@@ -117,8 +117,8 @@ def test_make_smolvla_processor_basic():
         )
 
     # Check processor names
-    assert preprocessor.name == "robot_preprocessor"
-    assert postprocessor.name == "robot_postprocessor"
+    assert preprocessor.name == "policy_preprocessor"
+    assert postprocessor.name == "policy_postprocessor"
 
     # Check steps in preprocessor
     assert len(preprocessor.steps) == 6

--- a/tests/processor/test_tdmpc_processor.py
+++ b/tests/processor/test_tdmpc_processor.py
@@ -89,8 +89,8 @@ def test_make_tdmpc_processor_basic():
     )
 
     # Check processor names
-    assert preprocessor.name == "robot_preprocessor"
-    assert postprocessor.name == "robot_postprocessor"
+    assert preprocessor.name == "policy_preprocessor"
+    assert postprocessor.name == "policy_postprocessor"
 
     # Check steps in preprocessor
     assert len(preprocessor.steps) == 4

--- a/tests/processor/test_vqbet_processor.py
+++ b/tests/processor/test_vqbet_processor.py
@@ -89,8 +89,8 @@ def test_make_vqbet_processor_basic():
     )
 
     # Check processor names
-    assert preprocessor.name == "robot_preprocessor"
-    assert postprocessor.name == "robot_postprocessor"
+    assert preprocessor.name == "policy_preprocessor"
+    assert postprocessor.name == "policy_postprocessor"
 
     # Check steps in preprocessor
     assert len(preprocessor.steps) == 4


### PR DESCRIPTION
- Changed assertions in multiple processor test files to verify the updated names from "robot_preprocessor" and "robot_postprocessor" to "policy_preprocessor" and "policy_postprocessor" for consistency with recent refactoring.
