### PR TITLE
Fix: wrap homing_offset to 12-bit signed range (-2048..2047) for grip…

### DIFF
--- a/src/lerobot/motors/feetech/feetech.py
+++ b/src/lerobot/motors/feetech/feetech.py
@@ -273,7 +273,10 @@ class FeetechMotorsBus(MotorsBus):
     def write_calibration(self, calibration_dict: dict[str, MotorCalibration], cache: bool = True) -> None:
         for motor, calibration in calibration_dict.items():
             if self.protocol_version == 0:
-                self.write("Homing_Offset", motor, calibration.homing_offset)
+                offset = int(calibration.homing_offset)
+                # 12-bit signed domain for Homing_Offset: [-2048, +2047]
+                offset = ((offset + 2048) % 4096) - 2048
+                self.write("Homing_Offset", motor, offset)
             self.write("Min_Position_Limit", motor, calibration.range_min)
             self.write("Max_Position_Limit", motor, calibration.range_max)
 


### PR DESCRIPTION
…per motors from partabot

Wrap homing_offset into 12-bit signed range before write

## What this does

On the partabot FeeTech gripper servo it reports values that are outside of the allowed range. This normalizes the values to a 12 bit range and fixes issues with overflowing the vartiable

## How it was tested

I ran this before and after the fix. The before calibration step shows the gripper in values beyond 12 bit as seen in the picture below

<img width="723" height="378" alt="Screenshot 2025-09-07 152753" src="https://github.com/user-attachments/assets/93637ad2-e887-4e4a-9104-a00a1d87fdde" />

## How to checkout & try? (for the reviewer)

Calibrate a leader arm and see the values fall within the range