### PR TITLE
fix (koch): Disable motor torque before applying calibration logic

### DIFF
--- a/src/lerobot/robots/koch_follower/koch_follower.py
+++ b/src/lerobot/robots/koch_follower/koch_follower.py
@@ -110,6 +110,7 @@ class KochFollower(Robot):
         return self.bus.is_calibrated
 
     def calibrate(self) -> None:
+        self.bus.disable_torque()
         if self.calibration:
             # Calibration file exists, ask user whether to use it or run new calibration
             user_input = input(
@@ -120,7 +121,6 @@ class KochFollower(Robot):
                 self.bus.write_calibration(self.calibration)
                 return
         logger.info(f"\nRunning calibration of {self}")
-        self.bus.disable_torque()
         for motor in self.bus.motors:
             self.bus.write("Operating_Mode", motor, OperatingMode.EXTENDED_POSITION.value)
 

--- a/src/lerobot/teleoperators/koch_leader/koch_leader.py
+++ b/src/lerobot/teleoperators/koch_leader/koch_leader.py
@@ -88,6 +88,7 @@ class KochLeader(Teleoperator):
         return self.bus.is_calibrated
 
     def calibrate(self) -> None:
+        self.bus.disable_torque()
         if self.calibration:
             # Calibration file exists, ask user whether to use it or run new calibration
             user_input = input(
@@ -98,7 +99,6 @@ class KochLeader(Teleoperator):
                 self.bus.write_calibration(self.calibration)
                 return
         logger.info(f"\nRunning calibration of {self}")
-        self.bus.disable_torque()
         for motor in self.bus.motors:
             self.bus.write("Operating_Mode", motor, OperatingMode.EXTENDED_POSITION.value)
 


### PR DESCRIPTION
## What this does

Disable torque before applying calibration logic for koch arms. While the dynamixel motors are in torque mode, it seems that writing to it does not work. This control path is executed when we decide to call `lerobot-calibrate` and not calibrating. 


```
  File "/Users/stevengong/Projects/lerobot/src/lerobot/robots/koch_follower/koch_follower.py", line 120, in calibrate
    self.bus.write_calibration(self.calibration)
  File "/Users/stevengong/Projects/lerobot/src/lerobot/motors/dynamixel/dynamixel.py", line 195, in write_calibration
    self.write("Homing_Offset", motor, calibration.homing_offset)
  File "/Users/stevengong/Projects/lerobot/src/lerobot/motors/motors_bus.py", line 1023, in write
    self._write(addr, length, id_, value, num_retry=num_retry, raise_on_error=True, err_msg=err_msg)
  File "/Users/stevengong/Projects/lerobot/src/lerobot/motors/motors_bus.py", line 1049, in _write
    raise RuntimeError(f"{err_msg} {self.packet_handler.getRxPacketError(error)}")
RuntimeError: Failed to write 'Homing_Offset' on id_=1 with '102' after 1 tries. [RxPacketError] Writing or Reading is not available to target address!
```

## How it was tested
Ran locally on a physical koch arm.

## How to checkout & try? (for the reviewer)

Provide a simple way for the reviewer to try out your changes.

Examples:

```bash
lerobot-calibrate \
    --robot.type=koch_follower \
    --robot.left_arm_port=/dev/tty.usbmodem114201 \
    --robot.id=follower
```

