### PR TITLE
feat(policies): Add language conditioning for diffusion policy

### DIFF
--- a/src/lerobot/constants.py
+++ b/src/lerobot/constants.py
@@ -23,6 +23,7 @@ OBS_IMAGE = "observation.image"
 OBS_IMAGES = "observation.images"
 ACTION = "action"
 REWARD = "next.reward"
+LANG_INSTRUCTION = "task"
 
 ROBOTS = "robots"
 ROBOT_TYPE = "robot_type"

--- a/src/lerobot/policies/diffusion/configuration_diffusion.py
+++ b/src/lerobot/policies/diffusion/configuration_diffusion.py
@@ -129,6 +129,10 @@ class DiffusionConfig(PreTrainedConfig):
     use_group_norm: bool = True
     spatial_softmax_num_keypoints: int = 32
     use_separate_rgb_encoder_per_camera: bool = False
+    # Language conditioning.
+    language_conditioned: bool = False
+    tokenizer: str = "distilbert-base-uncased"
+    tokenizer_max_length: int = 48
     # Unet.
     down_dims: tuple[int, ...] = (512, 1024, 2048)
     kernel_size: int = 5


### PR DESCRIPTION
## What this does

Currently, the current repo doesn't support language conditioning for diffusion policy. Language-conditioned diffusion policy is a regularly ablated policy architecture for multi-task policy training (e.g., LIBERO benchmarks), making it an important feature.

This PR adds language conditioning by concatenate the language embedding to image features and proprio to form the global conditioning vector before feeding into the diffusion head. 

## How it was tested

Tested with scripts/train.py (see below).

## How to checkout & try? (for the reviewer)

```
HF_ENDPOINT=https://hf-mirror.com CUDA_VISIBLE_DEVICES="0" python -m src.lerobot.scripts.train \
 --policy.type=diffusion \
 --policy.crop_shape="[224, 224]" \
 --policy.language_conditioned=True \
 --dataset.repo_id=sean1295/libero_spatial_no_noops_lerobot_v21 \
 --batch_size=128 \
 --steps=20000 \
 --wandb.enable=true \
 --save_freq 1000 \
 --log_freq 100 \
 --job_name=libero_spatial_dp_abs_pose_test \
 --policy.push_to_hub=False
```

Some eval videos (a single language-conditioned diffusion policy trained on libero spatial dataset and evaluated on 10 LIBERO spatial tasks)

https://github.com/user-attachments/assets/7fa681e9-7cfb-4716-a6bb-ab67e4603af6

https://github.com/user-attachments/assets/aa973019-894e-4e71-8f91-fbe48454077e

https://github.com/user-attachments/assets/5015ea9e-4892-45ad-9ceb-afd75487145c







