### PR TITLE
Incremental parquet writing

### DIFF
--- a/src/lerobot/datasets/lerobot_dataset.py
+++ b/src/lerobot/datasets/lerobot_dataset.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import contextlib
+import os
 import gc
 import logging
 import shutil


### PR DESCRIPTION
## What this does

Write parquet files for episode metadata and data incrementally without keeping DataFrame in memory or creating HF Dataset. FYI `gc.collect()` slows down conversion. Added `.finalise()` to close parquet writers with an additional safety check to call writers to close on `__del__`

Examples:
| Title | Label |
|----------------------|-----------------|
| Correct episode metadata | (🐛 Bug) |
| Reduce RAM usage | (⚡️ Performance) |

## How it was tested

Building L2D dataset v3 format.

## Notes

Resulting parquet files, _might_ be slightly larger than `DEFAULT_DATA_FILE_SIZE_IN_MB` as we estimate the size of parquet without the footer metadata being written. 

## TODOs

- [x] Add a `.finalize()` method for LeRobotDataset and LeRobotDatasetMetadata which calls writer.close(), this is needed to write metadata to parquet file footer. This should also load the dataset building self.episodes and self.hf_dataset from immutable parquet files as HF Dataset as a sanity check. @michel-aractingi / @hsandhawalia 
- [ ] Add support for updating a the dataset, for adding new episodes. Like in v2.1. 
- [ ] ~~similar update for writing self.tasks to parquet files. final DataFame that still grows in memory.~~