### PR TITLE
refactor(processor): action field as dict

### DIFF
--- a/src/lerobot/processor/batch_processor.py
+++ b/src/lerobot/processor/batch_processor.py
@@ -47,7 +47,7 @@ class AddBatchDimensionActionStep(ActionProcessorStep):
     This is useful for creating a batch of size 1 from a single action sample.
     """
 
-    def action(self, action: Tensor) -> Tensor:
+    def action(self, action: ActionDict | dict[str, Any]) -> ActionDict | dict[str, Any]:
         """
         Adds a batch dimension to the action if it's a 1D tensor.
 
@@ -57,8 +57,6 @@ class AddBatchDimensionActionStep(ActionProcessorStep):
         Returns:
             The action tensor with an added batch dimension.
         """
-
-    def action(self, action: ActionDict | dict[str, Any]) -> ActionDict | dict[str, Any]:
         # Handle ActionDict format
         action_tensor: Tensor | None = action.get(TransitionKey.ACTION.value)
         if action_tensor is None or not isinstance(action_tensor, Tensor) or action_tensor.dim() != 1:

--- a/src/lerobot/processor/core.py
+++ b/src/lerobot/processor/core.py
@@ -22,6 +22,7 @@ from typing import Any, TypedDict
 import torch
 
 
+# NOTE: When upgrading to Python 3.11, use StrEnum instead of Enum
 class TransitionKey(str, Enum):
     """Keys for accessing EnvTransition dictionary components."""
 
@@ -35,11 +36,15 @@ class TransitionKey(str, Enum):
     COMPLEMENTARY_DATA = "complementary_data"
 
 
+TensorActionDict = TypedDict("TensorActionDict", {TransitionKey.ACTION.value: torch.Tensor | None})
+ActionDict = dict[str, Any] | TensorActionDict
+
+
 EnvTransition = TypedDict(
     "EnvTransition",
     {
         TransitionKey.OBSERVATION.value: dict[str, Any] | None,
-        TransitionKey.ACTION.value: Any | torch.Tensor | None,
+        TransitionKey.ACTION.value: ActionDict | None,
         TransitionKey.REWARD.value: float | torch.Tensor | None,
         TransitionKey.DONE.value: bool | torch.Tensor | None,
         TransitionKey.TRUNCATED.value: bool | torch.Tensor | None,

--- a/src/lerobot/processor/device_processor.py
+++ b/src/lerobot/processor/device_processor.py
@@ -131,7 +131,6 @@ class DeviceProcessorStep(ProcessorStep):
         new_transition = transition.copy()
 
         simple_tensor_keys = [
-            TransitionKey.ACTION,
             TransitionKey.REWARD,
             TransitionKey.DONE,
             TransitionKey.TRUNCATED,
@@ -140,6 +139,7 @@ class DeviceProcessorStep(ProcessorStep):
         dict_tensor_keys = [
             TransitionKey.OBSERVATION,
             TransitionKey.COMPLEMENTARY_DATA,
+            TransitionKey.ACTION,
         ]
 
         # Process simple, top-level tensors

--- a/src/lerobot/processor/hil_processor.py
+++ b/src/lerobot/processor/hil_processor.py
@@ -446,9 +446,18 @@ class InterventionActionProcessorStep(ProcessorStep):
                 action_list = teleop_action.tolist()
             else:
                 action_list = teleop_action
+            action_tensor = action.get(TransitionKey.ACTION.value)
 
-            teleop_action_tensor = torch.tensor(action_list, dtype=action.dtype, device=action.device)
-            new_transition[TransitionKey.ACTION] = teleop_action_tensor
+            if action_tensor is None:
+                raise ValueError("Action tensor is None")
+
+            if not isinstance(action_tensor, torch.Tensor):
+                raise ValueError("Action tensor is not a torch.Tensor")
+
+            teleop_action_tensor = torch.tensor(
+                action_list, dtype=action_tensor.dtype, device=action_tensor.device
+            )
+            new_transition[TransitionKey.ACTION] = {TransitionKey.ACTION.value: teleop_action_tensor}
 
         # Handle episode termination
         new_transition[TransitionKey.DONE] = bool(terminate_episode) or (

--- a/src/lerobot/processor/pipeline.py
+++ b/src/lerobot/processor/pipeline.py
@@ -32,7 +32,7 @@ from safetensors.torch import load_file, save_file
 from lerobot.configs.types import PipelineFeatureType, PolicyFeature
 
 from .converters import batch_to_transition, create_transition, transition_to_batch
-from .core import EnvTransition, TransitionKey
+from .core import ActionDict, EnvTransition, TransitionKey
 
 # Type variable for generic processor output type
 TOutput = TypeVar("TOutput")
@@ -859,7 +859,7 @@ class ActionProcessorStep(ProcessorStep, ABC):
     """
 
     @abstractmethod
-    def action(self, action) -> Any | torch.Tensor:
+    def action(self, action: ActionDict) -> ActionDict:
         """Process the action component.
 
         Args:
@@ -874,7 +874,7 @@ class ActionProcessorStep(ProcessorStep, ABC):
         self._current_transition = transition.copy()
         new_transition = self._current_transition
 
-        action = new_transition.get(TransitionKey.ACTION)
+        action: ActionDict | None = new_transition.get(TransitionKey.ACTION)
         if action is None:
             return new_transition
 

--- a/src/lerobot/processor/tokenizer_processor.py
+++ b/src/lerobot/processor/tokenizer_processor.py
@@ -195,10 +195,11 @@ class TokenizerProcessorStep(ObservationProcessorStep):
 
         # Fallback to checking the action tensor
         action = transition.get(TransitionKey.ACTION)
-        if isinstance(action, torch.Tensor):
-            return action.device
-
-        return None  # No tensors found, default will be CPU
+        if action is not None:
+            action_tensor = action.get(TransitionKey.ACTION.value)
+            if isinstance(action_tensor, torch.Tensor):
+                return action_tensor.device
+        return None  # No tensors found, keep on CPU
 
     def _tokenize_text(self, text: str | list[str]) -> dict[str, torch.Tensor]:
         """

--- a/tests/processor/test_act_processor.py
+++ b/tests/processor/test_act_processor.py
@@ -187,7 +187,12 @@ def test_act_processor_multi_gpu():
     config.device = "cuda:0"
     stats = create_default_stats()
 
-    preprocessor, postprocessor = make_act_pre_post_processors(config, stats)
+    preprocessor, postprocessor = make_act_pre_post_processors(
+        config,
+        stats,
+        preprocessor_kwargs={"to_transition": lambda x: x, "to_output": lambda x: x},
+        postprocessor_kwargs={"to_transition": lambda x: x, "to_output": lambda x: x},
+    )
 
     # Simulate data on different GPU (like in multi-GPU training)
     device = torch.device("cuda:1")

--- a/tests/processor/test_classifier_processor.py
+++ b/tests/processor/test_classifier_processor.py
@@ -191,7 +191,12 @@ def test_classifier_processor_multi_gpu():
     config.device = "cuda:0"
     stats = create_default_stats()
 
-    preprocessor, postprocessor = make_classifier_processor(config, stats)
+    preprocessor, postprocessor = make_classifier_processor(
+        config,
+        stats,
+        preprocessor_kwargs={"to_transition": lambda x: x, "to_output": lambda x: x},
+        postprocessor_kwargs={"to_transition": lambda x: x, "to_output": lambda x: x},
+    )
 
     # Simulate data on different GPU
     device = torch.device("cuda:1")

--- a/tests/processor/test_converters.py
+++ b/tests/processor/test_converters.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 import torch
 
-from lerobot.processor import TransitionKey
+from lerobot.processor import TransitionKey, create_transition
 from lerobot.processor.converters import (
     batch_to_transition,
     to_tensor,
@@ -281,21 +281,6 @@ def test_to_tensor_unsupported_type():
 
     with pytest.raises(TypeError, match="Unsupported type for tensor conversion"):
         to_tensor(object())
-
-
-def create_transition(
-    observation=None, action=None, reward=0.0, done=False, truncated=False, info=None, complementary_data=None
-):
-    """Helper to create an EnvTransition dictionary."""
-    return {
-        TransitionKey.OBSERVATION: observation,
-        TransitionKey.ACTION: action,
-        TransitionKey.REWARD: reward,
-        TransitionKey.DONE: done,
-        TransitionKey.TRUNCATED: truncated,
-        TransitionKey.INFO: info if info is not None else {},
-        TransitionKey.COMPLEMENTARY_DATA: complementary_data if complementary_data is not None else {},
-    }
 
 
 def test_batch_to_transition_with_index_fields():

--- a/tests/processor/test_device_processor.py
+++ b/tests/processor/test_device_processor.py
@@ -20,28 +20,7 @@ import torch
 
 from lerobot.configs.types import FeatureType, PipelineFeatureType, PolicyFeature
 from lerobot.processor import DataProcessorPipeline, DeviceProcessorStep, TransitionKey
-
-
-def create_transition(
-    observation=None, action=None, reward=None, done=None, truncated=None, info=None, complementary_data=None
-):
-    """Helper function to create a transition dictionary."""
-    transition = {}
-    if observation is not None:
-        transition[TransitionKey.OBSERVATION] = observation
-    if action is not None:
-        transition[TransitionKey.ACTION] = action
-    if reward is not None:
-        transition[TransitionKey.REWARD] = reward
-    if done is not None:
-        transition[TransitionKey.DONE] = done
-    if truncated is not None:
-        transition[TransitionKey.TRUNCATED] = truncated
-    if info is not None:
-        transition[TransitionKey.INFO] = info
-    if complementary_data is not None:
-        transition[TransitionKey.COMPLEMENTARY_DATA] = complementary_data
-    return transition
+from lerobot.processor.converters import create_transition
 
 
 def test_basic_functionality():

--- a/tests/processor/test_diffusion_processor.py
+++ b/tests/processor/test_diffusion_processor.py
@@ -194,7 +194,12 @@ def test_diffusion_processor_multi_gpu():
     config.device = "cuda:0"
     stats = create_default_stats()
 
-    preprocessor, postprocessor = make_diffusion_pre_post_processors(config, stats)
+    preprocessor, postprocessor = make_diffusion_pre_post_processors(
+        config,
+        stats,
+        preprocessor_kwargs={"to_transition": lambda x: x, "to_output": lambda x: x},
+        postprocessor_kwargs={"to_transition": lambda x: x, "to_output": lambda x: x},
+    )
 
     # Simulate data on different GPU
     device = torch.device("cuda:1")

--- a/tests/processor/test_observation_processor.py
+++ b/tests/processor/test_observation_processor.py
@@ -20,23 +20,8 @@ import torch
 
 from lerobot.configs.types import FeatureType, PipelineFeatureType
 from lerobot.constants import OBS_ENV_STATE, OBS_IMAGE, OBS_IMAGES, OBS_STATE
-from lerobot.processor import TransitionKey, VanillaObservationProcessorStep
+from lerobot.processor import TransitionKey, VanillaObservationProcessorStep, create_transition
 from tests.conftest import assert_contract_is_typed
-
-
-def create_transition(
-    observation=None, action=None, reward=None, done=None, truncated=None, info=None, complementary_data=None
-):
-    """Helper to create an EnvTransition dictionary."""
-    return {
-        TransitionKey.OBSERVATION: observation,
-        TransitionKey.ACTION: action,
-        TransitionKey.REWARD: reward,
-        TransitionKey.DONE: done,
-        TransitionKey.TRUNCATED: truncated,
-        TransitionKey.INFO: info,
-        TransitionKey.COMPLEMENTARY_DATA: complementary_data,
-    }
 
 
 def test_process_single_image():

--- a/tests/processor/test_pi0_processor.py
+++ b/tests/processor/test_pi0_processor.py
@@ -33,6 +33,7 @@ from lerobot.processor import (
     RenameObservationsProcessorStep,
     TransitionKey,
     UnnormalizerProcessorStep,
+    create_transition,
 )
 
 
@@ -50,21 +51,6 @@ class MockTokenizerProcessorStep(ProcessorStep):
     def transform_features(self, features):
         # Pass through features unchanged
         return features
-
-
-def create_transition(observation=None, action=None, **kwargs):
-    """Helper function to create a transition dictionary."""
-    transition = {}
-    if observation is not None:
-        transition[TransitionKey.OBSERVATION] = observation
-    if action is not None:
-        transition[TransitionKey.ACTION] = action
-    for key, value in kwargs.items():
-        if hasattr(TransitionKey, key.upper()):
-            transition[getattr(TransitionKey, key.upper())] = value
-        elif key == "complementary_data":
-            transition[TransitionKey.COMPLEMENTARY_DATA] = value
-    return transition
 
 
 def create_default_config():
@@ -227,7 +213,7 @@ def test_pi0_processor_cuda():
     # Check that data is on CUDA
     assert processed[TransitionKey.OBSERVATION][OBS_STATE].device.type == "cuda"
     assert processed[TransitionKey.OBSERVATION][OBS_IMAGE].device.type == "cuda"
-    assert processed[TransitionKey.ACTION].device.type == "cuda"
+    assert processed[TransitionKey.ACTION][TransitionKey.ACTION.value].device.type == "cuda"
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
@@ -283,7 +269,7 @@ def test_pi0_processor_accelerate_scenario():
     # Check that data stays on same GPU
     assert processed[TransitionKey.OBSERVATION][OBS_STATE].device == device
     assert processed[TransitionKey.OBSERVATION][OBS_IMAGE].device == device
-    assert processed[TransitionKey.ACTION].device == device
+    assert processed[TransitionKey.ACTION][TransitionKey.ACTION.value].device == device
 
 
 @pytest.mark.skipif(torch.cuda.device_count() < 2, reason="Requires at least 2 GPUs")
@@ -339,7 +325,7 @@ def test_pi0_processor_multi_gpu():
     # Check that data stays on cuda:1
     assert processed[TransitionKey.OBSERVATION][OBS_STATE].device == device
     assert processed[TransitionKey.OBSERVATION][OBS_IMAGE].device == device
-    assert processed[TransitionKey.ACTION].device == device
+    assert processed[TransitionKey.ACTION][TransitionKey.ACTION.value].device == device
 
 
 def test_pi0_processor_without_stats():
@@ -437,7 +423,7 @@ def test_pi0_processor_bfloat16_device_float32_normalizer():
     assert (
         processed[TransitionKey.OBSERVATION][OBS_IMAGE].dtype == torch.bfloat16
     )  # IDENTITY normalization still gets dtype conversion
-    assert processed[TransitionKey.ACTION].dtype == torch.bfloat16
+    assert processed[TransitionKey.ACTION][TransitionKey.ACTION.value].dtype == torch.bfloat16
 
     # Verify normalizer automatically adapted its internal state
     assert normalizer_step.dtype == torch.bfloat16

--- a/tests/processor/test_pipeline.py
+++ b/tests/processor/test_pipeline.py
@@ -33,23 +33,9 @@ from lerobot.processor import (
     ProcessorStep,
     ProcessorStepRegistry,
     TransitionKey,
+    create_transition,
 )
 from tests.conftest import assert_contract_is_typed
-
-
-def create_transition(
-    observation=None, action=None, reward=0.0, done=False, truncated=False, info=None, complementary_data=None
-):
-    """Helper to create an EnvTransition dictionary."""
-    return {
-        TransitionKey.OBSERVATION: observation,
-        TransitionKey.ACTION: action,
-        TransitionKey.REWARD: reward,
-        TransitionKey.DONE: done,
-        TransitionKey.TRUNCATED: truncated,
-        TransitionKey.INFO: info if info is not None else {},
-        TransitionKey.COMPLEMENTARY_DATA: complementary_data if complementary_data is not None else {},
-    }
 
 
 @dataclass

--- a/tests/processor/test_rename_processor.py
+++ b/tests/processor/test_rename_processor.py
@@ -25,24 +25,10 @@ from lerobot.processor import (
     ProcessorStepRegistry,
     RenameObservationsProcessorStep,
     TransitionKey,
+    create_transition,
 )
 from lerobot.processor.rename_processor import rename_stats
 from tests.conftest import assert_contract_is_typed
-
-
-def create_transition(
-    observation=None, action=None, reward=None, done=None, truncated=None, info=None, complementary_data=None
-):
-    """Helper to create an EnvTransition dictionary."""
-    return {
-        TransitionKey.OBSERVATION: observation,
-        TransitionKey.ACTION: action,
-        TransitionKey.REWARD: reward,
-        TransitionKey.DONE: done,
-        TransitionKey.TRUNCATED: truncated,
-        TransitionKey.INFO: info,
-        TransitionKey.COMPLEMENTARY_DATA: complementary_data,
-    }
 
 
 def test_basic_renaming():

--- a/tests/processor/test_tokenizer_processor.py
+++ b/tests/processor/test_tokenizer_processor.py
@@ -10,23 +10,8 @@ import torch
 
 from lerobot.configs.types import FeatureType, PipelineFeatureType, PolicyFeature
 from lerobot.constants import OBS_LANGUAGE
-from lerobot.processor import DataProcessorPipeline, TokenizerProcessorStep, TransitionKey
+from lerobot.processor import DataProcessorPipeline, TokenizerProcessorStep, TransitionKey, create_transition
 from tests.utils import require_package
-
-
-def create_transition(
-    observation=None, action=None, reward=None, done=None, truncated=None, info=None, complementary_data=None
-):
-    """Helper function to create test transitions."""
-    return {
-        TransitionKey.OBSERVATION: observation,
-        TransitionKey.ACTION: action,
-        TransitionKey.REWARD: reward,
-        TransitionKey.DONE: done,
-        TransitionKey.TRUNCATED: truncated,
-        TransitionKey.INFO: info,
-        TransitionKey.COMPLEMENTARY_DATA: complementary_data,
-    }
 
 
 class MockTokenizer:
@@ -414,7 +399,10 @@ def test_integration_with_robot_processor(mock_auto_tokenizer):
     assert torch.equal(
         result[TransitionKey.OBSERVATION]["state"], transition[TransitionKey.OBSERVATION]["state"]
     )
-    assert torch.equal(result[TransitionKey.ACTION], transition[TransitionKey.ACTION])
+    assert torch.equal(
+        result[TransitionKey.ACTION][TransitionKey.ACTION.value],
+        transition[TransitionKey.ACTION][TransitionKey.ACTION.value],
+    )
 
 
 @require_package("transformers")
@@ -993,7 +981,7 @@ def test_integration_with_device_processor(mock_auto_tokenizer):
 
     # All tensors should end up on CUDA (moved by DeviceProcessorStep)
     assert result[TransitionKey.OBSERVATION]["observation.state"].device.type == "cuda"
-    assert result[TransitionKey.ACTION].device.type == "cuda"
+    assert result[TransitionKey.ACTION][TransitionKey.ACTION.value].device.type == "cuda"
 
     # Tokenized tensors should also be on CUDA
     tokens = result[TransitionKey.OBSERVATION][f"{OBS_LANGUAGE}.tokens"]


### PR DESCRIPTION
## 🎯 **Motivation**

Previously, actions in the LeRobot processor system had inconsistent representations:
- **Robot actions**: Often came as structured dictionaries (e.g., `{"delta_x": 0.1, "delta_y": 0.2, "gripper": 1.0}`)
- **Policy actions**: Typically raw `torch.Tensor` objects
- **Mixed handling**: Different parts of the codebase expected different formats, leading to complexity and potential bugs

This inconsistency made it difficult to:
- Maintain clear contracts between components

## 🔄 **Solution**

We've unified all action representations under a single `ActionDict` type that can handle both structured robot actions and tensor-based policy actions seamlessly.

### New Type System
```python
# New unified action types
TensorActionDict = TypedDict("TensorActionDict", {TransitionKey.ACTION.value: torch.Tensor | None})
ActionDict = dict[str, Any] | TensorActionDict

# Updated EnvTransition
EnvTransition = TypedDict("EnvTransition", {
    TransitionKey.ACTION.value: ActionDict | None,  # ← Changed from Any | torch.Tensor | None
    # ... other fields unchanged
})
```

### Automatic Conversion
The system now automatically wraps tensor actions in the proper dictionary format:
```python
# Before: Raw tensor
action = torch.tensor([0.1, 0.2, 0.3])

# After: Wrapped in ActionDict
action = {TransitionKey.ACTION.value: torch.tensor([0.1, 0.2, 0.3])}
```

## 🛠 **Changes Made**

### Core Type Updates
- **`core.py`**: Added `ActionDict` and `TensorActionDict` type definitions
- **`EnvTransition`**: Updated action field type from `Any | torch.Tensor | None` to `ActionDict | None`

### Processor Updates
- **All `ActionProcessorStep` subclasses**: Now expect and return `ActionDict` instead of raw tensors/objects
- **Automatic tensor wrapping**: Raw tensors are automatically wrapped in `{TransitionKey.ACTION.value: tensor}` format
- **Backward compatibility**: Existing structured action dictionaries continue to work unchanged

### Conversion Functions
- **`create_transition()`**: Automatically wraps `torch.Tensor` actions in proper dict format
- **`batch_to_transition()`**: Handles conversion from batch format to `ActionDict`
- **`transition_to_batch()`**: Extracts tensor from `ActionDict` for batch format

### Device and Data Processing
- **`DeviceProcessorStep`**: Now treats actions as dictionary data (moved from `simple_tensor_keys` to `dict_tensor_keys`)
- **All action processors**: Updated to extract/wrap tensors properly (`action.get(TransitionKey.ACTION.value)`)
