### PR TITLE
refactor(eval): specify type parameters for preprocessor and postprocessor in eval_policy function

### DIFF
--- a/src/lerobot/scripts/eval.py
+++ b/src/lerobot/scripts/eval.py
@@ -220,8 +220,8 @@ def rollout(
 def eval_policy(
     env: gym.vector.VectorEnv,
     policy: PreTrainedPolicy,
-    preprocessor: PolicyProcessorPipeline,
-    postprocessor: PolicyProcessorPipeline,
+    preprocessor: PolicyProcessorPipeline[dict[str, Any]],
+    postprocessor: PolicyProcessorPipeline[dict[str, Any]],
     n_episodes: int,
     max_episodes_rendered: int = 0,
     videos_dir: Path | None = None,


### PR DESCRIPTION
- Updated the type annotations for the preprocessor and postprocessor parameters in the eval_policy function to use PolicyProcessorPipeline with a dictionary type, enhancing type safety and clarity in the evaluation process.

