### PR TITLE
refactor(processor): enhance type annotations for processors in record, replay, teleoperate, and control utils

### DIFF
--- a/src/lerobot/record.py
+++ b/src/lerobot/record.py
@@ -243,8 +243,8 @@ def record_loop(
     dataset: LeRobotDataset | None = None,
     teleop: Teleoperator | list[Teleoperator] | None = None,
     policy: PreTrainedPolicy | None = None,
-    preprocessor: PolicyProcessorPipeline | None = None,
-    postprocessor: PolicyProcessorPipeline | None = None,
+    preprocessor: PolicyProcessorPipeline[dict[str, Any]] | None = None,
+    postprocessor: PolicyProcessorPipeline[dict[str, Any]] | None = None,
     control_time_s: int | None = None,
     teleop_action_processor: RobotProcessorPipeline[EnvTransition] | None = None,  # runs after teleop
     robot_action_processor: RobotProcessorPipeline[dict[str, Any]] | None = None,  # runs before robot

--- a/src/lerobot/replay.py
+++ b/src/lerobot/replay.py
@@ -44,6 +44,7 @@ import time
 from dataclasses import asdict, dataclass
 from pathlib import Path
 from pprint import pformat
+from typing import Any
 
 from lerobot.configs import parser
 from lerobot.datasets.lerobot_dataset import LeRobotDataset
@@ -86,7 +87,7 @@ class ReplayConfig:
     # Use vocal synthesis to read events.
     play_sounds: bool = True
     # Optional processor for actions before sending to robot
-    robot_action_processor: RobotProcessorPipeline | None = None
+    robot_action_processor: RobotProcessorPipeline[dict[str, Any]] | None = None
 
 
 @parser.wrap()

--- a/src/lerobot/teleoperate.py
+++ b/src/lerobot/teleoperate.py
@@ -106,9 +106,9 @@ class TeleoperateConfig:
     # Display all cameras on screen
     display_data: bool = False
     # Optional processors for data transformation
-    teleop_action_processor: RobotProcessorPipeline | None = None  # runs after teleop
-    robot_action_processor: RobotProcessorPipeline | None = None  # runs before robot
-    robot_observation_processor: RobotProcessorPipeline | None = None  # runs after robot
+    teleop_action_processor: RobotProcessorPipeline[EnvTransition] | None = None  # runs after teleop
+    robot_action_processor: RobotProcessorPipeline[dict[str, Any]] | None = None  # runs before robot
+    robot_observation_processor: RobotProcessorPipeline[EnvTransition] | None = None  # runs after robot
 
 
 def teleop_loop(

--- a/src/lerobot/utils/control_utils.py
+++ b/src/lerobot/utils/control_utils.py
@@ -22,6 +22,7 @@ import traceback
 from contextlib import nullcontext
 from copy import copy
 from functools import cache
+from typing import Any
 
 import numpy as np
 import torch
@@ -125,8 +126,8 @@ def predict_action(
     observation: dict[str, np.ndarray],
     policy: PreTrainedPolicy,
     device: torch.device,
-    preprocessor: PolicyProcessorPipeline,
-    postprocessor: PolicyProcessorPipeline,
+    preprocessor: PolicyProcessorPipeline[dict[str, Any]],
+    postprocessor: PolicyProcessorPipeline[dict[str, Any]],
     use_amp: bool,
     task: str | None = None,
     robot_type: str | None = None,


### PR DESCRIPTION
### Summary
This PR enhances type safety by adding proper generic type parameters to `PolicyProcessorPipeline` and `RobotProcessorPipeline` instances across multiple modules.

### Changes Made
- **record.py**: Added `[dict[str, Any]]` type parameters to `preprocessor` and `postprocessor` in `record_loop()`
- **replay.py**: Added `[dict[str, Any]]` type parameter to `robot_action_processor` in `ReplayConfig`
- **teleoperate.py**: Added specific type parameters to processor fields:
  - `teleop_action_processor: RobotProcessorPipeline[EnvTransition]`
  - `robot_action_processor: RobotProcessorPipeline[dict[str, Any]]`
  - `robot_observation_processor: RobotProcessorPipeline[EnvTransition]`
- **control_utils.py**: Added `[dict[str, Any]]` type parameters to `preprocessor` and `postprocessor` in `predict_action()`
- Added necessary `from typing import Any` imports where needed

### Impact
- Improves type safety and IDE support for processor pipeline usage
- Makes the expected data types more explicit in function signatures
- Continues the ongoing processor refactoring effort to clarify action types
- No functional changes - purely type annotation improvements
