### PR TITLE
Refactor action generation logic in diffusion policy

### DIFF
--- a/src/lerobot/policies/diffusion/modeling_diffusion.py
+++ b/src/lerobot/policies/diffusion/modeling_diffusion.py
@@ -157,7 +157,9 @@ class DiffusionPolicy(PreTrainedPolicy):
 
         if len(self._queues[ACTION]) == 0:
             # Create prepared batch for action generation
-            prepared_batch = {k: torch.stack(list(self._queues[k]), dim=1) for k in batch if k in self._queues}
+            prepared_batch = {
+                k: torch.stack(list(self._queues[k]), dim=1) for k in batch if k in self._queues
+            }
             actions = self._get_action_chunk(prepared_batch)
             self._queues[ACTION].extend(actions.transpose(0, 1))
 


### PR DESCRIPTION
  ## Summary

  Refactor diffusion policy action generation to properly maintain observation queues when
  `predict_action_chunk()` is called outside of `select_action()`.

  ### Problem

  The original implementation of `predict_action_chunk()` assumed it would only be called
  through `select_action()`, which handles input normalization and queue population. When
  `predict_action_chunk()` was called directly (outside the `select_action()` workflow), it
  would:

  - Skip input normalization
  - Not populate observation queues properly
  - Fail to handle image feature stacking
  - Lead to inconsistent behavior depending on call context

  ### Solution

  - **Extract `_get_action_chunk()` method**: Created a stateless method that handles the 
  core action generation logic from prepared observations
  - **Refactor `predict_action_chunk()`**: Now properly normalizes inputs, handles image 
  features, and populates queues before delegating to `_get_action_chunk()`
  - **Update `select_action()`**: Modified to use `_get_action_chunk()` directly when 
  generating new actions, avoiding duplicate queue operations

  ### Changes

  - Added `_get_action_chunk()` method for stateless action generation from prepared 
  observations
  - Enhanced `predict_action_chunk()` to handle input normalization, image feature stacking, 
  and queue population
  - Updated `select_action()` to use the new stateless method when the action queue is empty
  - Ensures consistent behavior regardless of whether actions are generated through 
  `select_action()` or `predict_action_chunk()`