### PR TITLE
docs fix: keyboard config hilserl

### DIFF
--- a/docs/source/il_sim.mdx
+++ b/docs/source/il_sim.mdx
@@ -24,11 +24,11 @@ pip install -e ".[hilserl]"
 
 To use `gym_hil` with LeRobot, you need to use a configuration file. An example config file can be found [here](https://huggingface.co/datasets/aractingi/lerobot-example-config-files/blob/main/env_config_gym_hil_il.json).
 
-To teleoperate and collect a dataset, we need to modify this config file and you should add your `repo_id` here: `"repo_id": "il_gym",` and `"num_episodes": 30,` and make sure you set `mode` to `record`, "mode": "record".
+To teleoperate and collect a dataset, we need to modify this config file and you should add your `repo_id` here: `"repo_id": "il_gym",` and `"num_episodes": 30,` and make sure you set `mode` to `record`, `"mode": "record"`.
 
 If you do not have a Nvidia GPU also change `"device": "cuda"` parameter in the config file (for example to `mps` for MacOS).
 
-By default the config file assumes you use a controller. To use your keyboard please change the envoirment specified at `"task"` in the config file and set it to `"PandaPickCubeKeyboard-v0"`.
+By default, the config file assumes you use a controller. To use your keyboard, update the config file by setting `"task": "PandaPickCubeKeyboard-v0"` and `"control_mode": "keyboard_ee"`.
 
 Then we can run this command to start:
 


### PR DESCRIPTION
Fixing docs for Imitation Learning in Sim with hilserl. If you want to use the keyboard you also need to change the control_mode to `keyboard_ee`.