### PR TITLE
performance(processor): reorder output steps to improve performance

### DIFF
--- a/src/lerobot/policies/act/processor_act.py
+++ b/src/lerobot/policies/act/processor_act.py
@@ -65,10 +65,10 @@ def make_act_pre_post_processors(
         ),
     ]
     output_steps = [
-        DeviceProcessorStep(device="cpu"),
         UnnormalizerProcessorStep(
             features=config.output_features, norm_map=config.normalization_mapping, stats=dataset_stats
         ),
+        DeviceProcessorStep(device="cpu"),
     ]
 
     return (

--- a/src/lerobot/policies/diffusion/processor_diffusion.py
+++ b/src/lerobot/policies/diffusion/processor_diffusion.py
@@ -73,10 +73,10 @@ def make_diffusion_pre_post_processors(
         ),
     ]
     output_steps = [
-        DeviceProcessorStep(device="cpu"),
         UnnormalizerProcessorStep(
             features=config.output_features, norm_map=config.normalization_mapping, stats=dataset_stats
         ),
+        DeviceProcessorStep(device="cpu"),
     ]
     return (
         PolicyProcessorPipeline[dict[str, Any], dict[str, Any]](

--- a/src/lerobot/policies/pi0/processor_pi0.py
+++ b/src/lerobot/policies/pi0/processor_pi0.py
@@ -146,10 +146,10 @@ def make_pi0_pre_post_processors(
     ]
 
     output_steps: list[ProcessorStep] = [
-        DeviceProcessorStep(device="cpu"),
         UnnormalizerProcessorStep(
             features=config.output_features, norm_map=config.normalization_mapping, stats=dataset_stats
         ),
+        DeviceProcessorStep(device="cpu"),
     ]
 
     return (

--- a/src/lerobot/policies/pi0fast/processor_pi0fast.py
+++ b/src/lerobot/policies/pi0fast/processor_pi0fast.py
@@ -73,10 +73,10 @@ def make_pi0fast_pre_post_processors(
         ),
     ]
     output_steps = [
-        DeviceProcessorStep(device="cpu"),
         UnnormalizerProcessorStep(
             features=config.output_features, norm_map=config.normalization_mapping, stats=dataset_stats
         ),
+        DeviceProcessorStep(device="cpu"),
     ]
     return (
         PolicyProcessorPipeline[dict[str, Any], dict[str, Any]](

--- a/src/lerobot/policies/sac/processor_sac.py
+++ b/src/lerobot/policies/sac/processor_sac.py
@@ -73,10 +73,10 @@ def make_sac_pre_post_processors(
         ),
     ]
     output_steps = [
-        DeviceProcessorStep(device="cpu"),
         UnnormalizerProcessorStep(
             features=config.output_features, norm_map=config.normalization_mapping, stats=dataset_stats
         ),
+        DeviceProcessorStep(device="cpu"),
     ]
     return (
         PolicyProcessorPipeline[dict[str, Any], dict[str, Any]](

--- a/src/lerobot/policies/smolvla/processor_smolvla.py
+++ b/src/lerobot/policies/smolvla/processor_smolvla.py
@@ -84,10 +84,10 @@ def make_smolvla_pre_post_processors(
         ),
     ]
     output_steps = [
-        DeviceProcessorStep(device="cpu"),
         UnnormalizerProcessorStep(
             features=config.output_features, norm_map=config.normalization_mapping, stats=dataset_stats
         ),
+        DeviceProcessorStep(device="cpu"),
     ]
     return (
         PolicyProcessorPipeline[dict[str, Any], dict[str, Any]](

--- a/src/lerobot/policies/tdmpc/processor_tdmpc.py
+++ b/src/lerobot/policies/tdmpc/processor_tdmpc.py
@@ -71,10 +71,10 @@ def make_tdmpc_pre_post_processors(
         ),
     ]
     output_steps = [
-        DeviceProcessorStep(device="cpu"),
         UnnormalizerProcessorStep(
             features=config.output_features, norm_map=config.normalization_mapping, stats=dataset_stats
         ),
+        DeviceProcessorStep(device="cpu"),
     ]
     return (
         PolicyProcessorPipeline[dict[str, Any], dict[str, Any]](

--- a/src/lerobot/policies/vqbet/processor_vqbet.py
+++ b/src/lerobot/policies/vqbet/processor_vqbet.py
@@ -72,10 +72,10 @@ def make_vqbet_pre_post_processors(
         ),
     ]
     output_steps = [
-        DeviceProcessorStep(device="cpu"),
         UnnormalizerProcessorStep(
             features=config.output_features, norm_map=config.normalization_mapping, stats=dataset_stats
         ),
+        DeviceProcessorStep(device="cpu"),
     ]
     return (
         PolicyProcessorPipeline[dict[str, Any], dict[str, Any]](

--- a/tests/processor/test_act_processor.py
+++ b/tests/processor/test_act_processor.py
@@ -81,8 +81,8 @@ def test_make_act_processor_basic():
 
     # Check steps in postprocessor
     assert len(postprocessor.steps) == 2
-    assert isinstance(postprocessor.steps[0], DeviceProcessorStep)
-    assert isinstance(postprocessor.steps[1], UnnormalizerProcessorStep)
+    assert isinstance(postprocessor.steps[0], UnnormalizerProcessorStep)
+    assert isinstance(postprocessor.steps[1], DeviceProcessorStep)
 
 
 def test_act_processor_normalization():

--- a/tests/processor/test_diffusion_processor.py
+++ b/tests/processor/test_diffusion_processor.py
@@ -84,8 +84,8 @@ def test_make_diffusion_processor_basic():
 
     # Check steps in postprocessor
     assert len(postprocessor.steps) == 2
-    assert isinstance(postprocessor.steps[0], DeviceProcessorStep)
-    assert isinstance(postprocessor.steps[1], UnnormalizerProcessorStep)
+    assert isinstance(postprocessor.steps[0], UnnormalizerProcessorStep)
+    assert isinstance(postprocessor.steps[1], DeviceProcessorStep)
 
 
 def test_diffusion_processor_with_images():

--- a/tests/processor/test_pi0_processor.py
+++ b/tests/processor/test_pi0_processor.py
@@ -108,8 +108,8 @@ def test_make_pi0_processor_basic():
 
     # Check steps in postprocessor
     assert len(postprocessor.steps) == 2
-    assert isinstance(postprocessor.steps[0], DeviceProcessorStep)
-    assert isinstance(postprocessor.steps[1], UnnormalizerProcessorStep)
+    assert isinstance(postprocessor.steps[0], UnnormalizerProcessorStep)
+    assert isinstance(postprocessor.steps[1], DeviceProcessorStep)
 
 
 def test_pi0_newline_processor_single_task():

--- a/tests/processor/test_sac_processor.py
+++ b/tests/processor/test_sac_processor.py
@@ -84,8 +84,8 @@ def test_make_sac_processor_basic():
 
     # Check steps in postprocessor
     assert len(postprocessor.steps) == 2
-    assert isinstance(postprocessor.steps[0], DeviceProcessorStep)
-    assert isinstance(postprocessor.steps[1], UnnormalizerProcessorStep)
+    assert isinstance(postprocessor.steps[0], UnnormalizerProcessorStep)
+    assert isinstance(postprocessor.steps[1], DeviceProcessorStep)
 
 
 def test_sac_processor_normalization_modes():

--- a/tests/processor/test_smolvla_processor.py
+++ b/tests/processor/test_smolvla_processor.py
@@ -115,8 +115,8 @@ def test_make_smolvla_processor_basic():
 
     # Check steps in postprocessor
     assert len(postprocessor.steps) == 2
-    assert isinstance(postprocessor.steps[0], DeviceProcessorStep)
-    assert isinstance(postprocessor.steps[1], UnnormalizerProcessorStep)
+    assert isinstance(postprocessor.steps[0], UnnormalizerProcessorStep)
+    assert isinstance(postprocessor.steps[1], DeviceProcessorStep)
 
 
 def test_smolvla_newline_processor_single_task():

--- a/tests/processor/test_tdmpc_processor.py
+++ b/tests/processor/test_tdmpc_processor.py
@@ -87,8 +87,8 @@ def test_make_tdmpc_processor_basic():
 
     # Check steps in postprocessor
     assert len(postprocessor.steps) == 2
-    assert isinstance(postprocessor.steps[0], DeviceProcessorStep)
-    assert isinstance(postprocessor.steps[1], UnnormalizerProcessorStep)
+    assert isinstance(postprocessor.steps[0], UnnormalizerProcessorStep)
+    assert isinstance(postprocessor.steps[1], DeviceProcessorStep)
 
 
 def test_tdmpc_processor_normalization():

--- a/tests/processor/test_vqbet_processor.py
+++ b/tests/processor/test_vqbet_processor.py
@@ -87,8 +87,8 @@ def test_make_vqbet_processor_basic():
 
     # Check steps in postprocessor
     assert len(postprocessor.steps) == 2
-    assert isinstance(postprocessor.steps[0], DeviceProcessorStep)
-    assert isinstance(postprocessor.steps[1], UnnormalizerProcessorStep)
+    assert isinstance(postprocessor.steps[0], UnnormalizerProcessorStep)
+    assert isinstance(postprocessor.steps[1], DeviceProcessorStep)
 
 
 def test_vqbet_processor_with_images():


### PR DESCRIPTION
- Moved DeviceProcessorStep to the end of the output steps in multiple processor files to maintain the intended processing order.
- Updated corresponding tests to reflect the change in step order.
