### PR TITLE
fix(opencv): handle non-int index_or_path in OpenCVCamera and docstring

### DIFF
--- a/src/lerobot/cameras/opencv/camera_opencv.py
+++ b/src/lerobot/cameras/opencv/camera_opencv.py
@@ -159,7 +159,10 @@ class OpenCVCamera(Camera):
         # blocking in multi-threaded applications, especially during data collection.
         cv2.setNumThreads(1)
 
-        self.videocapture = cv2.VideoCapture(self.index_or_path, self.backend)
+        if isinstance(self.index_or_path, int):
+            self.videocapture = cv2.VideoCapture(self.index_or_path, self.backend)
+        else:
+            self.videocapture = cv2.VideoCapture(str(self.index_or_path), self.backend)
 
         if not self.videocapture.isOpened():
             self.videocapture.release()

--- a/src/lerobot/cameras/opencv/configuration_opencv.py
+++ b/src/lerobot/cameras/opencv/configuration_opencv.py
@@ -38,8 +38,8 @@ class OpenCVCameraConfig(CameraConfig):
     ```
 
     Attributes:
-        index_or_path: Either an integer representing the camera device index,
-                      or a Path object pointing to a video file.
+        index_or_path: Either an integer (camera index), a string path like
+                '/dev/video2' or 'C:\\video.mp4', or a Path (device or file).
         fps: Requested frames per second for the color stream.
         width: Requested frame width in pixels for the color stream.
         height: Requested frame height in pixels for the color stream.

--- a/src/lerobot/cameras/opencv/configuration_opencv.py
+++ b/src/lerobot/cameras/opencv/configuration_opencv.py
@@ -51,7 +51,7 @@ class OpenCVCameraConfig(CameraConfig):
         - Only 3-channel color output (RGB/BGR) is currently supported.
     """
 
-    index_or_path: int | Path
+    index_or_path: int | str | Path
     color_mode: ColorMode = ColorMode.RGB
     rotation: Cv2Rotation = Cv2Rotation.NO_ROTATION
     warmup_s: int = 1


### PR DESCRIPTION
## What this does

* **Fix**: Handle non-int `index_or_path` in `OpenCVCamera` by passing non-ints as `str` to `cv2.VideoCapture`.

* **Docs**: Clarify `OpenCVCameraConfig.index_or_path` supports `int | str | Path` with examples.

* **Affects**: `src/lerobot/cameras/opencv/camera_opencv.py` and `src/lerobot/cameras/opencv/configuration_opencv.py`.

| Title | Label |
|----------------------|-----------------|
| Fixes #749  | (🐛 Bug) |

## How it was tested

Ran existing camera tests:
```bash
pytest -q tests/cameras/test_opencv.py
```
Result 
```bash
Testing with DEVICE='cuda'
..................................                                                                    [100%]
34 passed in 0.24s
```

Manual checks:
Ran:
```bash
lerobot-teleoperate \
    --robot.type=so101_follower \
    --robot.port=/dev/follower \
    --robot.id=follower \
    --teleop.type=so101_leader \
    --teleop.port=/dev/leader \
    --teleop.id=leader\
    --robot.cameras="{ wrist: {type: opencv, index_or_path: 0, width: 640, height: 480, fps: 30}, front: {type: opencv, index_or_path: /dev/video2, width: 640, height: 360, fps: 30}}"
```
```bash
lerobot-teleoperate \
    --robot.type=so101_follower \
    --robot.port=/dev/follower \
    --robot.id=follower \
    --teleop.type=so101_leader \
    --teleop.port=/dev/leader \
    --teleop.id=leader\
    --robot.cameras="{ wrist: {type: opencv, index_or_path: /dev/video0, width: 640, height: 480, fps: 30}, front: {type: opencv, index_or_path: 2, width: 640, height: 360, fps: 30}}"
```

## How to checkout & try? (for the reviewer)
Over Bash
```bash
lerobot-teleoperate \
    --robot.type=so101_follower \
    --robot.port=/dev/follower \
    --robot.id=follower \
    --teleop.type=so101_leader \
    --teleop.port=/dev/leader \
    --teleop.id=leader\
    --robot.cameras="{front: {type: opencv, index_or_path: 0, width: 640, height: 360, fps: 30}}"
```
```bash
lerobot-teleoperate \
    --robot.type=so101_follower \
    --robot.port=/dev/follower \
    --robot.id=follower \
    --teleop.type=so101_leader \
    --teleop.port=/dev/leader \
    --teleop.id=leader\
    --robot.cameras="{ front: {type: opencv, index_or_path: /dev/video0, width: 640, height: 360, fps: 30}}"
```

Over Python script
```python
from lerobot.cameras.opencv.camera_opencv import OpenCVCamera
from lerobot.cameras.opencv.configuration_opencv import OpenCVCameraConfig, ColorMode

config = OpenCVCameraConfig(index_or_path="/dev/video0", color_mode=ColorMode.RGB)
cam = OpenCVCamera(config)
cam.connect()
frame = cam.read()
print(frame.shape)
cam.disconnect()
```
```python
from lerobot.cameras.opencv.camera_opencv import OpenCVCamera
from lerobot.cameras.opencv.configuration_opencv import OpenCVCameraConfig, ColorMode

config = OpenCVCameraConfig(index_or_path=0, color_mode=ColorMode.RGB)
cam = OpenCVCamera(config)
cam.connect()
frame = cam.read()
print(frame.shape)
cam.disconnect()
```