### PR TITLE
Fix: Resolve PermissionError and UnicodeDecodeError in Python scripts

### DIFF
--- a/src/lerobot/configs/policies.py
+++ b/src/lerobot/configs/policies.py
@@ -196,11 +196,10 @@ class PreTrainedConfig(draccus.ChoiceRegistry, HubMixin, abc.ABC):
             config = json.load(f)
 
         config.pop("type")
-        with tempfile.NamedTemporaryFile("w+") as f:
+        with tempfile.NamedTemporaryFile("w+", delete=False, suffix=".json") as f:
             json.dump(config, f)
             config_file = f.name
-            f.flush()
 
-            cli_overrides = policy_kwargs.pop("cli_overrides", [])
-            with draccus.config_type("json"):
-                return draccus.parse(orig_config.__class__, config_file, args=cli_overrides)
+        cli_overrides = policy_kwargs.pop("cli_overrides", [])
+        with draccus.config_type("json"):
+            return draccus.parse(orig_config.__class__, config_file, args=cli_overrides)

--- a/src/lerobot/policies/pretrained.py
+++ b/src/lerobot/policies/pretrained.py
@@ -246,7 +246,7 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
             base_model=base_model,
         )
 
-        template_card = files("lerobot.templates").joinpath("lerobot_modelcard_template.md").read_text()
+        template_card = files("lerobot.templates").joinpath("lerobot_modelcard_template.md").read_text(encoding="utf-8")
         card = ModelCard.from_template(card_data, template_str=template_card)
         card.validate()
         return card


### PR DESCRIPTION
Problem:
1. PermissionError when running eval.py
2. UnicodeDecodeError: 'gbk' when running migrate_policy_normalization.py
