### PR TITLE
Fixing some markdown formatting integrate_hardware.mdx

### DIFF
--- a/docs/source/integrate_hardware.mdx
+++ b/docs/source/integrate_hardware.mdx
@@ -204,34 +204,35 @@ def disconnect(self) -> None:
 
 LeRobot supports saving and loading calibration data automatically. This is useful for joint offsets, zero positions, or sensor alignment.
 
-> Note that depending on your hardware, this may not apply. If that's the case, you can simply leave these methods as no-ops:
-
 <!-- prettier-ignore-start -->
-```python
-> @property
-> def is_calibrated(self) -> bool:
->    return True
+> Note that depending on your hardware, this may not apply. If that's the case, you can simply leave these methods as no-ops:
 >
-> def calibrate(self) -> None:
->    pass
-> ```
+>     @property
+>     def is_calibrated(self) -> bool:
+>        return True
+>
+>     def calibrate(self) -> None:
+>        pass
+<!-- prettier-ignore-end -->
 
 ### `is_calibrated`
 
 This should reflect whether your robot has the required calibration loaded.
 
-```
-<!-- prettier-ignore-end -->python
+<!-- prettier-ignore-start -->
+```python
 @property
 def is_calibrated(self) -> bool:
     return self.bus.is_calibrated
 ```
+<!-- prettier-ignore-end -->
 
 ### `calibrate()`
 
 The goal of the calibration is twofold:
-    - Know the physical range of motion of each motors in order to only send commands within this range.
-    - Normalize raw motors positions to sensible continuous values (e.g. percentages, degrees) instead of arbitrary discrete value dependant on the specific motor used that will not replicate elsewhere.
+
+- Know the physical range of motion of each motors in order to only send commands within this range.
+- Normalize raw motors positions to sensible continuous values (e.g. percentages, degrees) instead of arbitrary discrete value dependant on the specific motor used that will not replicate elsewhere.
 
 It should implement the logic for calibration (if relevant) and update the `self.calibration` dictionary. If you are using Feetech or Dynamixel motors, our bus interfaces already include methods to help with this.
 


### PR DESCRIPTION
## What this does

Fixes some markdown syntax in docs/source/integrate_hardware.mdx in Step 4: Support Calibration and Configuration

## How it was tested

Loaded my version of the page in github

## How to checkout & try? (for the reviewer)

Look at the rendered markdown


## SECTION TO REMOVE BEFORE SUBMITTING YOUR PR

**Note**: Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR. Try to avoid tagging more than 3 people.

**Note**: Before submitting this PR, please read the [contributor guideline](https://github.com/huggingface/lerobot/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr).
