### PR TITLE
Bug in conversion from v2.1 script

### DIFF
--- a/src/lerobot/datasets/v30/convert_dataset_v21_to_v30.py
+++ b/src/lerobot/datasets/v30/convert_dataset_v21_to_v30.py
@@ -209,7 +209,6 @@ def convert_data(root: Path, new_root: Path, data_file_size_in_mb: int):
 
         # Reset for the next file
         size_in_mb = ep_size_in_mb
-        num_frames = ep_num_frames
         paths_to_cat = [ep_path]
 
         chunk_idx, file_idx = update_chunk_file_indices(chunk_idx, file_idx, DEFAULT_CHUNK_SIZE)


### PR DESCRIPTION
"dataset_to_index" was falsely reset after a parquet file is written which causes the metadata related to the indices to oscillate as the file_index changes. 

Example: HuggingFaceVLA/libero

Looping over dataset_from_index or dataset_to_index you will see an oscillating pattern 
`142, 239, 327, 425, 577, 688, 812, 102, 240, 357, 500, 645, 747, 133, 273, .....`

When it should be always increasing. 

NOTE: This will only effect datasets that (1) have been converted through the conversion script from v2.1 (2) that have multiple data parquet files  