### PR TITLE
docs(fix): libero example command

### DIFF
--- a/docs/source/libero.mdx
+++ b/docs/source/libero.mdx
@@ -106,6 +106,7 @@ For reference, here is the **original dataset** published by Physical Intelligen
 lerobot-train \
   --policy.type=smolvla \
   --policy.repo_id=${HF_USER}/libero-test \
+  --policy.load_vlm_weights=true \
   --dataset.repo_id=HuggingFaceVLA/libero \
   --env.type=libero \
   --env.task=libero_10 \


### PR DESCRIPTION
## What this does

For best performance, we should always load the VLM weights instead of training the backbone from scratch.
Another option is to update the smolvla config so that this is set to `true` by default
