### PR TITLE
repair the bug causing crash when set to record mode in gym_hil sim e…

### DIFF
--- a/src/lerobot/scripts/rl/gym_manipulator.py
+++ b/src/lerobot/scripts/rl/gym_manipulator.py
@@ -2098,8 +2098,12 @@ def record_dataset(env, policy, cfg):
                 break
 
             # For teleop, get action from intervention
-            recorded_action = {
-                "action": info["action_intervention"].cpu().squeeze(0).float() if policy is None else action
+            # recorded_action = {
+            #     "action": info["action_intervention"].cpu().squeeze(0).float() if policy is None else action
+            # }
+
+            recorded_action = { 
+                "action": torch.tensor(info["teleop_action"], dtype=torch.float32) if policy is None else action 
             }
 
             # Process observation for dataset


### PR DESCRIPTION
I modified the code based on v0.3.3. Please merged into v0.3.3. I can't pull request merging into v0.3.3.  #2000 shows that when open the record mode in gym_hil sim environment. It will raise wrong `Initialized gamepad: Xbox Series X Controller Controller Xbox Series X Controller not found in config. Using default configuration. Gamepad controls: 5 button: Intervention Left analog stick: Move in X-Y plane Right analog stick (vertical): Move in Z axis 6 button: Close gripper 7 button: Open gripper 1/Circle button: Exit 3/Triangle button: End episode with SUCCESS 0/Cross button: End episode with FAILURE 2/Square button: Rerecord episode INFO:datasets:PyTorch version 2.7.1 available. INFO:root:Reset delay of 1.0 seconds INFO:root:Recording episode 0 Traceback (most recent call last): File "/home/hw/miniconda3/envs/lerobot1/lib/python3.10/runpy.py", line 196, in _run_module_as_main return _run_code(code, main_globals, None, File "/home/hw/miniconda3/envs/lerobot1/lib/python3.10/runpy.py", line 86, in _run_code exec(code, run_globals) File "/home/hw/下载/lerobot-0.3.3/src/lerobot/scripts/rl/gym_manipulator.py", line 2263, in <module> main() File "/home/hw/下载/lerobot-0.3.3/src/lerobot/configs/parser.py", line 225, in wrapper_inner response = fn(cfg, *args, **kwargs) File "/home/hw/下载/lerobot-0.3.3/src/lerobot/scripts/rl/gym_manipulator.py", line 2216, in main record_dataset( File "/home/hw/下载/lerobot-0.3.3/src/lerobot/scripts/rl/gym_manipulator.py", line 2102, in record_dataset "action": info["action_intervention"].cpu().squeeze(0).float() if policy is None else action KeyError: 'action_intervention' /home/hw/miniconda3/envs/lerobot1/lib/python3.10/site-packages/glfw/__init__.py:917: GLFWError: (65537) b'The GLFW library is not initialized' warnings.warn(message, GLFWError)`
I check the keys of the dict info and find that "action_intervention" is not exist and changed to teleop_action which is a numpy array. So the final modification is
# For teleop, get action from intervention  recorded_action = { "action": torch.tensor(info["teleop_action"], dtype=torch.float32) if policy is None else action }
