### PR TITLE
fix(video_path): setting video_path to None during conversion for images datasets

### DIFF
--- a/src/lerobot/datasets/v30/convert_dataset_v21_to_v30.py
+++ b/src/lerobot/datasets/v30/convert_dataset_v21_to_v30.py
@@ -413,7 +413,7 @@ def convert_info(root, new_root, data_file_size_in_mb, video_file_size_in_mb):
     info["data_files_size_in_mb"] = data_file_size_in_mb
     info["video_files_size_in_mb"] = video_file_size_in_mb
     info["data_path"] = DEFAULT_DATA_PATH
-    info["video_path"] = DEFAULT_VIDEO_PATH
+    info["video_path"] = DEFAULT_VIDEO_PATH if info["video_path"] is not None else None
     info["fps"] = int(info["fps"])
     logging.info(f"Converting info from {root} to {new_root}")
     for key in info["features"]:


### PR DESCRIPTION
## What this does

This PR fixes a small bug in the v2.1 to v3.0 dataset conversion script. The value of `video_path` is now correctly set to `None` when the dataset only contains images>

## How it was tested

On the images datasets `CarolinePascal/kitchen`, `CarolinePascal/paris_street` and `CarolinePascal/aloha_mobile_shrimp_image`. See latests commits.

## How to checkout & try? (for the reviewer)

N/A