### PR TITLE
Update Rerun Configuration

### DIFF
--- a/src/lerobot/utils/visualization_utils.py
+++ b/src/lerobot/utils/visualization_utils.py
@@ -75,7 +75,7 @@ def log_rerun_data(
                     for i, vi in enumerate(arr):
                         rr.log(f"{key}_{i}", rr.Scalar(float(vi)))
                 else:
-                    rr.log(key, rr.Image(arr), static=True)
+                    rr.log(key, rr.Image(arr))
 
     if action:
         for k, v in action.items():


### PR DESCRIPTION
## What this does

**before this PR**

Rerun would only log a single image. Saving the recording wouldn't provide the rest of the video. This means that if you save the recording, you only get that single starting frame.

**after this PR**

Rerun will show / log all the images. so that if the sure saves the recording, you will have all of those images recorded.

## How it was tested

Manually, but I work at Rerun.

## How to checkout & try? (for the reviewer)

Very simple, run teleop, it will open Rerun.
<img width="853" height="890" alt="image" src="https://github.com/user-attachments/assets/0e824dad-53b9-4040-95e2-8d3614bc48ad" />

Save the recording.

Open that recording with `rerun path-to-recording.rrd`

Rather than a single image, it will show all of the images.