### PR TITLE
Update README.md to fix broken link to example notebook for visuals

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ wandb login
 
 ### Visualize datasets
 
-Check out [example 1](https://github.com/huggingface/lerobot/blob/main/examples/1_load_lerobot_dataset.py) that illustrates how to use our dataset class which automatically downloads data from the Hugging Face hub.
+Check out [example 1](https://github.com/huggingface/lerobot/blob/main/examples/dataset/load_lerobot_dataset.py) that illustrates how to use our dataset class which automatically downloads data from the Hugging Face hub.
 
 You can also locally visualize episodes from a dataset on the hub by executing our script from the command line:
 


### PR DESCRIPTION
Fixed broken link in the *Visualize datasets* section reference to one of the example notebooks.
Folder structure of examples seems to have changed with extra `dataset` folder and the notebook has also changed names.

## What this does

Fixing the readme link to the example doc - the folder structure for exmaples changed  so `/examples/1_load_lerobot_dataset.py` --> `examples/dataset/load_lerobot_dataset.py`

