### PR TITLE
Misc changes to enable training ACT

### DIFF
--- a/src/lerobot/configs/default.py
+++ b/src/lerobot/configs/default.py
@@ -29,6 +29,8 @@ class DatasetConfig:
     repo_id: str
     # Root directory where the dataset will be stored (e.g. 'dataset/path').
     root: str | None = None
+    # Root directory where the raw dataset recordings by are stored
+    raw_dataset_root: str | None = None
     episodes: list[int] | None = None
     image_transforms: ImageTransformsConfig = field(default_factory=ImageTransformsConfig)
     revision: str | None = None

--- a/src/lerobot/policies/act/modeling_act.py
+++ b/src/lerobot/policies/act/modeling_act.py
@@ -145,7 +145,7 @@ class ACTPolicy(PreTrainedPolicy):
         ).mean()
 
         loss_dict = {"l1_loss": l1_loss.item()}
-        if self.config.use_vae:
+        if self.config.use_vae and self.training:
             # Calculate Dₖₗ(latent_pdf || standard_normal). Note: After computing the KL-divergence for
             # each dimension independently, we sum over the latent dimension to get the total
             # KL-divergence per batch element, then take the mean over the batch.


### PR DESCRIPTION
## What this does
1. Adding raw_dataset_root to `DatasetConfig` for loading splits.yaml
2. Updating lerobot_dataset.py to enable loading a subset for train / eval
3. Update modeling_act.py to enable computing eval loss (i.e. without VAE loss)

## How it was tested
```
python -m robopicker.scripts.train \
  --dataset.repo_id=sherryxychen/2025-08-28_pick-and-place-block \
  --dataset.raw_dataset_root=/home/melon/sherry/robopicker/datasets \
  --output_dir=/home/melon/sherry/robopicker/outputs/2025-10-06_test-act-sim \
  --job_name=2025-10-06_test-act-sim \
  --wandb.enable=true \
  --eval_freq=1 \
  --log_freq=1 \
  --save_freq=100 \
  --policy.type=act \
  --policy.device=cuda \
  --policy.repo_id=${HF_USER}/2025-10-06_test-act-sim
```