### PR TITLE
Fix pyav time_base error

### DIFF
--- a/src/lerobot/datasets/video_utils.py
+++ b/src/lerobot/datasets/video_utils.py
@@ -451,11 +451,6 @@ def concatenate_video_files(
             stream_map[input_stream.index] = output_container.add_stream_from_template(
                 template=input_stream, opaque=True
             )
-            stream_map[
-                input_stream.index
-            ].time_base = (
-                input_stream.time_base
-            )  # set the time base to the input stream time base (missing in the codec context)
 
     # Demux + remux packets (no re-encode)
     for packet in input_container.demux():


### PR DESCRIPTION
Remove extra time_base assignment that was causing issues in av versions < 15.
