### PR TITLE
fix:  update get_video_size_in_mb to get_file_size_in_mb

### DIFF
--- a/src/lerobot/datasets/v30/convert_dataset_v21_to_v30.py
+++ b/src/lerobot/datasets/v30/convert_dataset_v21_to_v30.py
@@ -71,7 +71,7 @@ from lerobot.datasets.utils import (
     flatten_dict,
     get_parquet_file_size_in_mb,
     get_parquet_num_frames,
-    get_video_size_in_mb,
+    get_file_size_in_mb,
     load_info,
     update_chunk_file_indices,
     write_episodes,
@@ -310,7 +310,7 @@ def convert_videos_of_camera(root: Path, new_root: Path, video_key: str, video_f
     episodes_metadata = []
 
     for ep_path in tqdm.tqdm(ep_paths, desc=f"convert videos of {video_key}"):
-        ep_size_in_mb = get_video_size_in_mb(ep_path)
+        ep_size_in_mb = get_file_size_in_mb(ep_path)
         ep_duration_in_s = get_video_duration_in_s(ep_path)
 
         # Check if adding this episode would exceed the limit


### PR DESCRIPTION
# Pull Request Template

## What this does
Fixes the ImportError when running the dataset conversion script by updating the import from get_video_size_in_mb to get_file_size_in_mb in convert_dataset_v21_to_v30.py. This resolves the issue where the function name in lerobot/datasets/utils.py has changed.
**Labels:** (🐛 Bug)

## How it was tested
Ran the conversion script locally:
`python -m lerobot.datasets.v30.convert_dataset_v21_to_v30 --repo-id=lerobot/svla_so101_pickplace`
The script now executes without the ImportError, successfully importing from `lerobot.datasets.utils` and proceeding with dataset conversion.

## How to checkout & try? (for the reviewer)
Provide a simple way for the reviewer to try out your changes.

1. Checkout the branch: `git checkout bugfix--get_video_size_in_mb-not-found`
2. Run the conversion: `python -m lerobot.datasets.v30.convert_dataset_v21_to_v30 --repo-id=lerobot/svla_so101_pickplace`
   - Verify no ImportError occurs and the script runs to completion.

---

**SECTION TO REMOVE BEFORE SUBMITTING YOUR PR**  
Note: Anyone in the community is free to review the PR once the tests have passed. Feel free to tag members/contributors who may be interested in your PR. Try to avoid tagging more than 3 people.  

Note: Before submitting this PR, please read the contributor guideline.