### PR TITLE
Improve generate embeddings function by using dataset tools

### DIFF
--- a/src/lerobot/datasets/dataset_tools.py
+++ b/src/lerobot/datasets/dataset_tools.py
@@ -1003,10 +1003,18 @@ def _copy_data_with_feature_changes(
                     df[feature_name] = feature_values
                 else:
                     feature_slice = values[frame_idx:end_idx]
-                    if len(feature_slice.shape) > 1 and feature_slice.shape[1] == 1:
-                        df[feature_name] = feature_slice.flatten()
-                    else:
+                    if len(feature_slice.shape) == 1:
+                        # 1D array - can assign directly
                         df[feature_name] = feature_slice
+                    elif len(feature_slice.shape) == 2 and feature_slice.shape[1] == 1:
+                        # 2D array with single column - flatten it
+                        df[feature_name] = feature_slice.flatten()
+                    elif len(feature_slice.shape) == 2:
+                        # 2D array with multiple columns (e.g., embeddings) - convert to list of lists
+                        df[feature_name] = feature_slice.tolist()
+                    else:
+                        # Higher dimensional - convert to list
+                        df[feature_name] = [row.tolist() for row in feature_slice]
             frame_idx = end_idx
 
         # Write using the preserved chunk_idx and file_idx from source


### PR DESCRIPTION
## What this does

Refactors `generate_embeddings.py` to use dataset tools. Specifically, `modify_features` to add the image and language embeddings and remove videos in one call. Dataset tools also writes parquet files in a more optimized way.

## How it was tested

Tested by running generate embeddings script on this dataset [aractingi/utokyo_embeddings](https://huggingface.co/datasets/aractingi/utokyo_embeddings)

I ran 
```py
python src/lerobot/datasets/generating_embeddings/generate_embeddings.py \
        --repo-id lerobot/utokyo_xarm_bimanual \
        --output-repo-id aractingi/utokyo_embeddings \
        --image-encoder dinov2_vitb14 \
        --language-encoder minilm-l12 \
        --remove-videos \
        --push-to-hub
```
Then :
```py
python src/lerobot/datasets/generating_embeddings/validate_embeddings.py \
        --original-repo-id lerobot/utokyo_xarm_bimanual \
        --embeddings-repo-id aractingi/utokyo_xarm_bimanual_embeddings \
        --image-encoder dinov2_vitb14 \
        --language-encoder minilm-l12 \
        --num-samples 10
```
Both passed