### PR TITLE
chore(pyproject): cleaning no longer existing files/folders in pyproject exclude_dirs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -229,9 +229,6 @@ exclude_dirs = [
     "tests",
     "benchmarks",
     "src/lerobot/datasets/push_dataset_to_hub",
-    "src/lerobot/datasets/v2/convert_dataset_v1_to_v2",
-    "src/lerobot/policies/pi0/conversion_scripts",
-    "src/lerobot/scripts/push_dataset_to_hub.py",
 ]
 skips = ["B101", "B311", "B404", "B603", "B615"]
 


### PR DESCRIPTION
## What this does

This PR removes no longer existing files/folders referenced in `exclude_dirs` in `pyproject.toml`.

## How it was tested

N/A

## How to checkout & try? (for the reviewer)

N/A