### PR TITLE
Add Remote Rerun Viewer

### DIFF
--- a/src/lerobot/scripts/lerobot_record.py
+++ b/src/lerobot/scripts/lerobot_record.py
@@ -182,6 +182,10 @@ class RecordConfig:
     policy: PreTrainedConfig | None = None
     # Display all cameras on screen
     display_data: bool = False
+    # Display data on a remote Rerun server
+    display_url: str = None
+    # Port of the remote Rerun server
+    display_port: int = 9876
     # Use vocal synthesis to read events.
     play_sounds: bool = True
     # Resume recording on an existing dataset.
@@ -374,7 +378,7 @@ def record(cfg: RecordConfig) -> LeRobotDataset:
     init_logging()
     logging.info(pformat(asdict(cfg)))
     if cfg.display_data:
-        init_rerun(session_name="recording")
+        init_rerun(session_name="recording", url=cfg.display_url, port=cfg.display_port)
 
     robot = make_robot_from_config(cfg.robot)
     teleop = make_teleoperator_from_config(cfg.teleop) if cfg.teleop is not None else None

--- a/src/lerobot/scripts/lerobot_teleoperate.py
+++ b/src/lerobot/scripts/lerobot_teleoperate.py
@@ -104,6 +104,10 @@ class TeleoperateConfig:
     teleop_time_s: float | None = None
     # Display all cameras on screen
     display_data: bool = False
+    # Display data on a remote Rerun server
+    display_url: str = None
+    # Port of the remote Rerun server
+    display_port: int = 9876
 
 
 def teleop_loop(
@@ -186,7 +190,7 @@ def teleoperate(cfg: TeleoperateConfig):
     init_logging()
     logging.info(pformat(asdict(cfg)))
     if cfg.display_data:
-        init_rerun(session_name="teleoperation")
+        init_rerun(session_name="teleoperation", url=cfg.display_url, port=cfg.display_port)
 
     teleop = make_teleoperator_from_config(cfg.teleop)
     robot = make_robot_from_config(cfg.robot)


### PR DESCRIPTION
## What this does

When running LeRobot headless (on a NVIDIA Jetson for example), it can be helpful to visualize data on a remote machine. This PR changes two things:

1. Add two options to `TeleoperateConfig` and `RecordConfig`: (1) `display_url` and (2) `display_port`. When `display_url` is set, the Rerun SDK will connects to a remote viewer and stream all the data via gRPC. Read more about Rerun's operating modes [here](https://rerun.io/docs/reference/sdk/operating-modes).
2. Change the way images are logged from uncompressed `rr.Image` to compressed JPEG via `rr.EncodedImage` to save space and bandwidth.

## How it was tested

Tested buy running multiple teleop and recording trials on a Jetson AGX Thor with data streamed over a VPN to different devices like: Raspberry Pi, Jetson Orin Nano, Macbook.

## How to checkout & try?
Start a Rerun Viewer on a remote machine
```bash
rerun
```
Start a teleoperation loop:
```bash
lerobot-teleoperate \
    --robot.type=YOUR_ROBOT \
    --robot.port=YOUR_PORT \
    --robot.cameras="main: {type: opencv, index_or_path: 0, width: 640, height: 480, fps: 30}"
    --teleop.type=YOUR_ROBOT \
    --teleop.port=YOUR_PORT \
    --display_data=true \
    --display_url=YOUR_REMOTE_IP
```
The remote viewer should start displaying the data.