### PR TITLE
fix: video chunk no corresponding data chunk

### DIFF
--- a/src/lerobot/datasets/aggregate.py
+++ b/src/lerobot/datasets/aggregate.py
@@ -525,14 +525,10 @@ def append_or_create_parquet_file(
         new_path.parent.mkdir(parents=True, exist_ok=True)
         final_df = df
         target_path = new_path
-        target_chunk = idx["chunk"]
-        target_file = idx["file"]
     else:
         existing_df = pd.read_parquet(dst_path)
         final_df = pd.concat([existing_df, df], ignore_index=True)
         target_path = dst_path
-        target_chunk = idx["chunk"]
-        target_file = idx["file"]
 
     if contains_images:
         to_parquet_with_hf_images(final_df, target_path)


### PR DESCRIPTION
## What this does

This PR fix an error of meta file mapping.

The old aggregate.py will produce a merged dataset that has (as an example, the number of video files does not match the number of data files, and the meta has an incorrect mapping):

```
data/chunk-000/file-000.parquet
videos/observation.images.left/chunk-000/file-000.mp4
videos/observation.images.left/chunk-000/file-001.mp4
```

This will bug out when using data conversion tools and reports:

```
"/.../convert_dataset_v30_to_v21.py", line 175, in convert_data
raise FileNotFoundError(f"Expected source parquet file not found: {source_path}")
FileNotFoundError: Expected source parquet file not found: .../data/chunk-000/file-001.parquet
```

The above happens when you merge dataset A and B, where A has 

```
data/chunk-000/file-000.parquet
data/chunk-000/file-001.parquet
videos/observation.images.left/chunk-000/file-000.mp4
videos/observation.images.left/chunk-000/file-001.mp4
```

and B has 

```
data/chunk-000/file-000.parquet
videos/observation.images.left/chunk-000/file-000.mp4
```