### PR TITLE
fix(ci): exclude motor tests in multi-gpu setup

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -189,5 +189,6 @@ jobs:
           python -c "import torch; print(f'PyTorch CUDA available: {torch.cuda.is_available()}'); print(f'Number of GPUs: {torch.cuda.device_count()}')"
 
       - name: Run multi-GPU training tests
-        run: pytest tests -vv --maxfail=10 --ignore=tests/motors/test_dynamixel.py
+      # TODO(Steven): Investigate why motors tests are failing in multi-GPU setup
+        run: pytest tests -vv --maxfail=10 --ignore=tests/motors/
         timeout-minutes: 10


### PR DESCRIPTION
Motor tests fail consistently in the multi-gpu CI setup, but not in any other pipelines: https://github.com/huggingface/lerobot/actions/runs/18670997335/job/53231989029

Skip these ones as they are unrelated to the pipeline objective