### PR TITLE
patch(ci): remove pi & libero tags from PyPi release temporary due to their reliance on git dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,14 @@ jobs:
             exit 1
           fi
 
+      - name: Remove Tags with Git dependencies
+        # TODO(Steven): Temporary patch to remove libero and pi from PyPi 0.4.0 release due to its reliance on git dependencies.
+        run: |
+          echo "::info:: Checking for Git dependencies to remove from pyproject.toml..."
+          grep -E '@ git\+https|lerobot\[pi\]|lerobot\[libero\]' pyproject.toml | sed 's/^/::warning:: Removing line: /' || true
+          sed -E -i '/@ git\+https|lerobot\[pi\]|lerobot\[libero\]/d' pyproject.toml
+          echo "::info:: Git dependencies removed. Proceeding with build."
+
       - name: Install build dependencies
         run: python -m pip install build
 

--- a/docs/source/installation.mdx
+++ b/docs/source/installation.mdx
@@ -81,6 +81,9 @@ _Replace `[...]` with your desired features._
 For a full list of optional dependencies, see:
 https://pypi.org/project/lerobot/
 
+> [!NOTE]
+> For lerobot 0.4.0, if you want to install libero or pi, you will have to do: `pip install "lerobot[pi,libero]@git+https://github.com/huggingface/lerobot.git"`
+
 ### Troubleshooting
 
 If you encounter build errors, you may need to install additional dependencies: `cmake`, `build-essential`, and `ffmpeg libs`.


### PR DESCRIPTION
Temporary fix for 0.4.0
Will be addressed in a patch release