### PR TITLE
Colab Notebook for ACT - Update training time with A100

### DIFF
--- a/docs/source/notebooks.mdx
+++ b/docs/source/notebooks.mdx
@@ -14,7 +14,7 @@ We provide a ready-to-run Google Colab notebook to help you train ACT policies u
 | :------------------------------------------------------------------------------------------------------ | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [Train ACT with LeRobot](https://github.com/huggingface/notebooks/blob/main/lerobot/training-act.ipynb) | [![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/huggingface/notebooks/blob/main/lerobot/training-act.ipynb) |
 
-Expected training time for 100k steps: ~1.5 hours on an NVIDIA A100 GPU with batch size of `64`.
+Expected training time for 100k steps: ~18 hours on an NVIDIA A100 GPU with batch size of `64`.
 
 ### Training SmolVLA
 


### PR DESCRIPTION
## What this does

It took me about 11 hours on Google Colab to train ACT with A100 80 GB GDDR for 60k steps (80 credits) .
That make 18 hours (and more than 100 credits) for 100k steps.

## How it was tested

see https://api.wandb.ai/links/hentz-robotics/wdsr4k2r 
https://huggingface.co/gautz/act_so101_pick_red_18650_drop_black_box_test2_100ep_64batch_60ksteps 
https://huggingface.co/datasets/gautz/so101_pick_red_18650_drop_black_box_test2_100ep

## How to checkout & try? (for the reviewer)

see https://innovation.iha.unistra.fr/books/robotique-open-source/page/machine-learning-lerobot-avec-so-arm101#bkmrk-google-colab

Basically run notebook https://colab.research.google.com/github/huggingface/notebooks/blob/main/lerobot/training-act.ipynb#scrollTo=NQUk3Y0WwYZ4 
with:

```
!cd lerobot && python src/lerobot/scripts/lerobot_train.py \
  --dataset.repo_id=gautz/so101_pick_red_18650_drop_black_box_test2_100ep \
  --policy.type=act \
  --output_dir=outputs/train/act_so101_pick_red_18650_drop_black_box_test2_100ep_64batch \
  --job_name=act_so101_pick_red_18650_drop_black_box_test2_100ep_64batch \
  --policy.device=cuda \
  --policy.push_to_hub=True \
  --policy.repo_id=gautz/act_so101_pick_red_18650_drop_black_box_test2_100ep_64batch \
  --batch_size=64 \
  --wandb.enable=true
```