### PR TITLE
fix policy normalization migration keys

### DIFF
--- a/src/lerobot/processor/normalize_processor.py
+++ b/src/lerobot/processor/normalize_processor.py
@@ -303,8 +303,11 @@ class _NormalizationMixin:
             ValueError: If an unsupported normalization mode is encountered.
         """
         norm_mode = self.norm_map.get(feature_type, NormalizationMode.IDENTITY)
-        if norm_mode == NormalizationMode.IDENTITY or key not in self._tensor_stats:
+        if norm_mode == NormalizationMode.IDENTITY:
             return tensor
+
+        if key not in self._tensor_stats:
+            raise KeyError(f"Key {key} not found in normalization statistics.")
 
         if norm_mode not in (
             NormalizationMode.MEAN_STD,

--- a/tests/processor/test_normalize_processor.py
+++ b/tests/processor/test_normalize_processor.py
@@ -363,7 +363,7 @@ def test_quantile_mixed_with_other_modes():
 
 
 def test_quantile_with_missing_stats():
-    """Test that quantile normalization handles completely missing stats gracefully."""
+    """Test that quantile normalization raises KeyError when stats are completely missing."""
     features = {
         "observation.state": PolicyFeature(FeatureType.STATE, (2,)),
     }
@@ -379,11 +379,9 @@ def test_quantile_with_missing_stats():
     }
     transition = create_transition(observation=observation)
 
-    normalized_transition = normalizer(transition)
-    normalized_obs = normalized_transition[TransitionKey.OBSERVATION]
-
-    # Should pass through unchanged when no stats available
-    assert torch.allclose(normalized_obs["observation.state"], observation["observation.state"])
+    # Should raise KeyError when stats are completely missing for a key
+    with pytest.raises(KeyError, match="not found in normalization statistics"):
+        _ = normalizer(transition)
 
 
 def test_selective_normalization(observation_stats):
@@ -761,9 +759,9 @@ def test_empty_stats():
     observation = {OBS_IMAGE: torch.tensor([0.5])}
     transition = create_transition(observation=observation)
 
-    result = normalizer(transition)
-    # Should return observation unchanged since no stats are available
-    assert torch.allclose(result[TransitionKey.OBSERVATION][OBS_IMAGE], observation[OBS_IMAGE])
+    # Should raise KeyError when stats are completely missing for a key
+    with pytest.raises(KeyError, match="not found in normalization statistics"):
+        _ = normalizer(transition)
 
 
 def test_partial_stats():


### PR DESCRIPTION
## What this does

Noticed a critical bug in the policy migration which introduced severe regressions in policy performance.
When the camera name of the robot contains `_`, line 112 `feature_name = ".".join(parts[:-1]).replace("_", ".")` in `migrate_policy_normalization.py` used to convert it every `_` to `.`. Due to which the `normalize_processor` while normalizing the input images won't be able to find the camera key and return the tensor without normalization at line 307 in `normalize_processor.py` during policy execution.

Fix:
1. Added `_` handling when there are multiple parts to the feature name in `migrate_policy_normalization.py`.
2. Updated `normalize_processor.py` to raise error if policy is missing keys and updated its test.

## How it was tested

- Updated `test_quantile_with_missing_stats` in `test_normalize_processor.py`

## How to checkout & try? (for the reviewer)

Provide a simple way for the reviewer to try out your changes.

- pytest test/test_normalize_processor.py
- Test the policy migration for a robot with camera having underscore `_` in it.