### PR TITLE
fix(dataset-tools): unable to merge local datasets in cache due to a …

### DIFF
--- a/src/lerobot/scripts/lerobot_edit_dataset.py
+++ b/src/lerobot/scripts/lerobot_edit_dataset.py
@@ -206,7 +206,7 @@ def handle_merge(cfg: EditDatasetConfig) -> None:
         raise ValueError("repo_id must be specified as the output repository for merged dataset")
 
     logging.info(f"Loading {len(cfg.operation.repo_ids)} datasets to merge")
-    datasets = [LeRobotDataset(repo_id, root=cfg.root) for repo_id in cfg.operation.repo_ids]
+    datasets = [LeRobotDataset(repo_id, root=Path(cfg.root) / repo_id) for repo_id in cfg.operation.repo_ids]
 
     output_dir = Path(cfg.root) / cfg.repo_id if cfg.root else HF_LEROBOT_HOME / cfg.repo_id
 


### PR DESCRIPTION
## What this does

When using local root, the `lerobot-edit-dataset` with `--operation.type=merge` returned the `FileNotFoundError`. This was due to the fact that when specifying root to load a dataset in the generator `[LeRobotDataset(repo_id, root=Path(cfg.root) for repo_id in cfg.operation.repo_ids]`, the root to the exact dataset was not actually passed. 

This PR fixes that by adding `[...] root=Path(cfg.root) / repo_id) for repo_id in [...]`.

## How it was tested

Just run the merge and it worked, unlike before.

## How to checkout & try? (for the reviewer)

Try merging with local root, such as

```
lerobot-edit-dataset \
    --repo_id ${HF_USER}/merged_dataset \
    --operation.type merge \
    --operation.repo_ids "['user/local_dataset_1', 'user/local_dataset_1']" \
    --root `root/to/local/cache`
```
