### PR TITLE
feat(sim): VLABench integration

### DIFF
--- a/src/lerobot/envs/configs.py
+++ b/src/lerobot/envs/configs.py
@@ -319,3 +319,34 @@ class MetaworldEnv(EnvConfig):
             "obs_type": self.obs_type,
             "render_mode": self.render_mode,
         }
+
+@EnvConfig.register_subclass("vlabench")
+@dataclass
+class VLABenchEnv(EnvConfig):
+    task: str = "select_fruit"  # specify the vlabench task name
+    fps: int = 15
+    robot: str = "franka"
+    env_configs: dict | None = None
+    episode_configs: dict | None = None
+    render_resolution: tuple[int, int] = (480, 480)
+    max_episode_length: int = 500
+    features: dict[str, PolicyFeature] = field(
+        default_factory=lambda: {
+            ACTION: PolicyFeature(type=FeatureType.ACTION, shape=(7,)),
+        }
+    )
+    features_map: dict[str, str] = field(
+        default_factory=lambda: {
+            ACTION: ACTION,
+            "rgb": f"{OBS_IMAGE}",
+            "q_state": OBS_STATE,
+            "ee_state": OBS_STATE,
+        }
+    )
+
+    @property
+    def gym_kwargs(self) -> dict:
+        return {
+            "render_resolution": self.render_resolution,
+            "max_episode_length": self.max_episode_length,
+        }

--- a/src/lerobot/envs/factory.py
+++ b/src/lerobot/envs/factory.py
@@ -18,7 +18,7 @@ import importlib
 import gymnasium as gym
 from gymnasium.envs.registration import registry as gym_registry
 
-from lerobot.envs.configs import AlohaEnv, EnvConfig, LiberoEnv, PushtEnv
+from lerobot.envs.configs import AlohaEnv, EnvConfig, LiberoEnv, PushtEnv, VLABenchEnv
 
 
 def make_env_config(env_type: str, **kwargs) -> EnvConfig:
@@ -28,6 +28,8 @@ def make_env_config(env_type: str, **kwargs) -> EnvConfig:
         return PushtEnv(**kwargs)
     elif env_type == "libero":
         return LiberoEnv(**kwargs)
+    elif env_type == "vlabench":
+        return VLABenchEnv(**kwargs)
     else:
         raise ValueError(f"Policy type '{env_type}' is not available.")
 
@@ -84,6 +86,20 @@ def make_env(
             n_envs=n_envs,
             gym_kwargs=cfg.gym_kwargs,
             env_cls=env_cls,
+        )
+    elif "vlabench" in cfg.type:
+        from lerobot.envs.vlabench import create_vlabench_envs
+        
+        if cfg.task is None:
+            raise ValueError("VLABench requires a task to be specified")
+        
+        return create_vlabench_envs(
+            task=cfg.task,
+            n_envs=n_envs,
+            robot=cfg.robot,
+            configs=cfg.env_configs,
+            episode_configs=cfg.episode_configs,
+            gym_kwargs=cfg.gym_kwargs,
         )
 
     if cfg.gym_id not in gym_registry:

--- a/src/lerobot/envs/vlabench.py
+++ b/src/lerobot/envs/vlabench.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python
+
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Mapping, Sequence
+import gymnasium as gym
+import numpy as np
+from gymnasium import spaces
+from VLABench.envs import load_env
+
+VALID_OBS_KEYS = [
+    "q_state",
+    "q_velocity", 
+    "q_acceleration",
+    "rgb",
+    "depth",
+    "segmentation",
+    "robot_mask",
+    "instrinsic",
+    "extrinsic",
+    "masked_point_cloud",
+    "point_cloud",
+    "ee_state",
+    "grasped_obj_name"
+]
+
+ACTION_DIM = 7
+JOINT_DIM = 7
+ACTION_LOW = -1.0
+ACTION_HIGH = 1.0
+
+
+class VLABenchEnv(gym.Env):
+    """
+    The environment class for VLABench environments.
+    Args: 
+        task: The name of the task to load.
+        robot: The type of robot to use.
+        config: The additional configuration for the environment, such as camera settings, task settings, and engine settings.
+                If None, the default configuration will be used， without any specification.
+        time_limit: The time limit for each episode.
+        reset_wait_step: The steps to wait when init the episode. This is useful to avoid collision at the beginning of the episode.
+        episode_config: A config dict including task-specific parameters, such as object instances, positions, success conditions, etc.
+                If None, the environment will be initialized within a default random range.
+        obs_keys: A list of keys to include in the observation. If empty, all keys will be included.        
+    """
+    def __init__(
+        self,
+        task,
+        robot="franka",
+        config=None,
+        time_limit=500,
+        reset_wait_step=0,
+        episode_config=None,
+        obs_keys=['rgb', 'q_state', 'ee_state'],
+        render_resolution=(480, 480),
+        **kwargs,
+    ):
+        super().__init__()
+        self.task_name = task
+        assert len(obs_keys) >= 3, "obs_keys should at least include 'rgb', 'q_state' and 'ee_state'"
+        assert all([key in VALID_OBS_KEYS for key in obs_keys]), f"obs_keys should be in {VALID_OBS_KEYS}"
+        self.obs_keys = obs_keys
+        self._env = load_env(
+            task,
+            robot,
+            config,
+            time_limit,
+            reset_wait_step,
+            episode_config,
+            render_resolution=render_resolution,
+            **kwargs,
+        )
+        # define observation spaces and action spaces
+        n_cam = self._env.physics.model.ncam
+        self._build_observation_space(n_cam, render_resolution)
+        self.action_space = spaces.Box(
+            low=ACTION_LOW,
+            high=ACTION_HIGH,
+            shape=(ACTION_DIM,),
+            dtype=np.float32,
+        )
+    @property
+    def name(self):
+        return self.task_name
+    
+    @property
+    def task(self):
+        return self._env.task
+    
+    @property
+    def robot(self):
+        return self._env.robot
+    
+    def render(self):
+        return self._env.render()
+    
+    def reset(self):
+        timestep = self._env.reset()
+        obs = timestep.observation
+        obs = self._filter_observation(obs)
+        info = {"is_success": False}
+        return obs, info
+    
+    def _filter_observation(self, observation):
+        if not self.obs_keys:
+            return observation
+        filtered_obs = {key: observation[key] for key in self.obs_keys if key in observation}
+        return filtered_obs
+    
+    def step(self, action: np.ndarray):
+        if action.ndim != 1:
+            raise ValueError(
+                f"Expected action to be 1-D (shape (action_dim,)), "
+                f"but got shape {action.shape} with ndim={action.ndim}"
+            )
+        timestep = self._env.step(action)
+        obs, reward, done, info = timestep.observation, timestep.reward, timestep.last(), {}
+        obs = self._filter_observation(obs)
+        is_success = self._env.task.should_terminate_episode()
+        terminated = done or is_success
+        if done:
+            self.reset()
+            info.update(
+                {
+                    "task": self.task_name,
+                    "episode_config": self._env.save(),
+                    "done": done,
+                    "is_success": is_success,
+                }
+            )
+        truncated = False
+        return obs, reward, terminated, truncated, info
+    
+    def _build_observation_space(self, n_cam, render_resolution):
+        self.observation_space = spaces.Dict(
+            {
+                "rgb": spaces.Box(
+                    low=0, 
+                    high=255, 
+                    shape=(n_cam, 3, render_resolution[0], render_resolution[1]), 
+                    dtype=np.uint8
+                ),
+                "q_state": spaces.Box(
+                    low=-np.inf, 
+                    high=np.inf, 
+                    shape=(7,), 
+                    dtype=np.float32
+                ),
+                "ee_state": spaces.Box(
+                    low=-np.inf, 
+                    high=np.inf, 
+                    shape=(7,), 
+                    dtype=np.float32
+                )
+            }
+        )
+        if "depth" in self.obs_keys:
+            self.observation_space.spaces.update(
+                {
+                    "depth": spaces.Box(
+                        low=0.0, 
+                        high=1.0, 
+                        shape=(n_cam, 1, render_resolution[0], render_resolution[1]), 
+                        dtype=np.float32
+                    )
+                }
+            )
+        if "segmentation" in self.obs_keys:
+            self.observation_space.spaces.update(
+                {
+                    "segmentation": spaces.Box(
+                        low=0, 
+                        high=255, 
+                        shape=(n_cam, 1, render_resolution[0], render_resolution[1]), 
+                        dtype=np.uint8
+                    )
+                }
+            )
+        if "q_velocity" in self.obs_keys:
+            self.observation_space.spaces.update(
+                {
+                    "q_velocity": spaces.Box(
+                        low=-np.inf, 
+                        high=np.inf, 
+                        shape=(self._env.action_spec().shape[0],), 
+                        dtype=np.float32
+                    )
+                }
+            )
+        if "q_acceleration" in self.obs_keys:
+            self.observation_space.spaces.update(
+                {
+                    "q_acceleration": spaces.Box(
+                        low=-np.inf, 
+                        high=np.inf, 
+                        shape=(self._env.action_spec().shape[0],), 
+                        dtype=np.float32
+                    )
+                }
+            )
+    
+    def close(self):
+        self._env.close()
+        
+# ---- Main API ----------------------------------------------------------------
+
+def create_vlabench_envs(
+    task,
+    n_envs: int,
+    robot="franka",
+    configs: Sequence[dict] | None = None,
+    episode_configs: Sequence[dict] | None = None,
+):
+    """
+    Create vectorized VLABench environments.
+    Args:
+        task: The name of the task to load.
+        n_envs: The number of environments to create.
+        robot: The type of robot to use.
+        configs: A sequence of configuration dicts for each environment. 
+            If None, the default configuration will be used for all environments.
+        episode_configs: A sequence of episode configuration dicts for each environment. 
+            If None, the environment will be initialized within a default random range.
+    Notes:
+        - The difference between configs and episode_configs is that configs are used to configure the environment itself such as camera settings, task settings, and engine settings;
+        while episode_configs are used to configure the specific episode within the environment instead of random initialization.
+        - To get the episode configuration, please refer to `VLABench/VLABench/evaluation/evaluator/base.py`
+    Returns:
+        List of VLABenchEnv instances.
+    """
+    if configs is not None :
+        assert len(configs) == n_envs, "Length of configs should match n_envs."
+    if episode_configs is not None :
+        assert len(episode_configs) == n_envs, "Length of episode_configs should match n_envs."
+    # Create the environments
+    envs = {
+        f"{task}":{}
+    }
+    for i in range(n_envs):
+        env = VLABenchEnv(
+            task=task,
+            robot=robot,
+            config=configs[i] if configs is not None else None,
+            time_limit=configs[i]['evaluation'].get("max_episode_length", 500),
+            episode_config=episode_configs[i] if episode_configs is not None else None,
+        )
+        envs[f"{task}"][f"{i}"] = env
+    return envs

--- a/tests/envs/test_vlabench_env.py
+++ b/tests/envs/test_vlabench_env.py
@@ -1,0 +1,53 @@
+import importlib
+from dataclasses import dataclass, field
+import os
+import json
+import gymnasium as gym
+import pytest
+import numpy as np
+from gymnasium.envs.registration import register, registry as gym_registry
+from gymnasium.utils.env_checker import check_env
+
+from lerobot.configs.types import PolicyFeature
+from lerobot.envs.configs import EnvConfig
+from lerobot.envs.factory import make_env, make_env_config
+from VLABench.tasks import *
+from VLABench.robots import *
+
+def test_create_vlabench_envs():
+    # Example for create VLABench episode config
+    n_envs = 2
+    test_track = "track_1_in_distribution"
+    test_task = "select_fruit"
+    
+    with open(os.path.join(os.getenv("VLABENCH_ROOT"), "configs/evaluation/tracks", f"{test_track}.json"), "r") as f:
+        episode_configs = json.load(f)
+    assert test_task in episode_configs.keys(), f"{test_task} not found in {test_track} episode configs"
+    target_task_episode_configs = episode_configs[test_task][:n_envs]
+    
+    cfg = make_env_config(
+        "vlabench",
+        task=test_task,
+        robot="franka",
+        env_configs=None,
+        episode_configs=target_task_episode_configs,
+        render_resolution=(480, 480),
+        max_episode_length=500,
+    )
+    envs = make_env(cfg, n_envs=2)
+    task_name = next(iter(envs))
+    task_id = next(iter(envs[task_name]))
+    env = envs[task_name][task_id]
+    obs, info = env.reset()
+    env.last_obs = obs
+    
+    dummy_action = np.array([0.05, 0.0, 0.02, 0, 0, 0, 0]) 
+    # the action could be chosen from ['eef', 'joint', 'delta_eef']
+    obs, reward, done, truncated, info = env.step(dummy_action, mode="delta_eef")
+    for key in obs:
+        print(f"obs key: {key}")
+    
+    env.close()
+
+if __name__ == "__main__":
+    test_create_vlabench_envs()


### PR DESCRIPTION
Creating VLABench environment class in standard gym env styles referring to `libero.py`.

The current version includes the minimum environment class and its functions, and the function to create the vector envs (for one single task).

Paper: https://arxiv.org/pdf/2412.18194

Update[11.3] Add basic testcase for the environment:
Please run `python tests/envs/test_vlabench_env.py` for example.