### PR TITLE
Add gamepad IK control support and IK safety check

### DIFF
--- a/examples/gamepad_to_so100/teleoperate.py
+++ b/examples/gamepad_to_so100/teleoperate.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python
+
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+
+from lerobot.model.kinematics import RobotKinematics
+from lerobot.processor import RobotAction, RobotObservation, RobotProcessorPipeline
+from lerobot.processor.converters import (
+    robot_action_observation_to_transition,
+    transition_to_robot_action,
+)
+from lerobot.robots.so100_follower.robot_kinematic_processor import (
+    EEBoundsAndSafety,
+    EEReferenceAndDelta,
+    GripperVelocityToJoint,
+    InverseKinematicsEEToJoints,
+)
+from lerobot.robots.so101_follower.so101_follower import SO101Follower
+from lerobot.robots.so101_follower.config_so101_follower import SO101FollowerConfig
+from lerobot.teleoperators.gamepad.configuration_gamepad import GamepadTeleopConfig
+from lerobot.teleoperators.gamepad.gamepad_processor import MapGamepadActionToRobotAction
+from lerobot.teleoperators.gamepad.teleop_gamepad import GamepadTeleop
+from lerobot.utils.robot_utils import busy_wait
+from lerobot.utils.visualization_utils import init_rerun, log_rerun_data
+
+FPS = 30
+
+# Initialize the robot and teleoperator
+robot_config = SO101FollowerConfig(
+    port="/dev/ttyACM0", id="black", use_degrees=True
+)
+teleop_config = GamepadTeleopConfig(use_gripper=False)
+
+# Initialize the robot and teleoperator
+robot = SO101Follower(robot_config)
+teleop_device = GamepadTeleop(teleop_config)
+
+# NOTE: It is highly recommended to use the urdf in the SO-ARM100 repo: https://github.com/TheRobotStudio/SO-ARM100/blob/main/Simulation/SO101/so101_new_calib.urdf
+kinematics_solver = RobotKinematics(
+    urdf_path="./SO101/so101_new_calib.urdf",
+    target_frame_name="gripper_frame_link",
+    joint_names=list(robot.bus.motors.keys()),
+)
+
+# Build pipeline to convert gamepad action to ee pose action to joint action
+gamepad_to_robot_joints_processor = RobotProcessorPipeline[tuple[RobotAction, RobotObservation], RobotAction](
+    steps=[
+        MapGamepadActionToRobotAction(),
+        EEReferenceAndDelta(
+            kinematics=kinematics_solver,
+            end_effector_step_sizes={"x": 0.02, "y": 0.01, "z": 0.05},  # ← SAFE: 1cm/frame max speed
+            motor_names=list(robot.bus.motors.keys()),
+            use_latched_reference=False,  # ← FALSE = velocity control (continuous movement)
+        ),
+        EEBoundsAndSafety(
+            end_effector_bounds={"min": [0.05, -0.25, -0.05], "max": [0.35, 0.25, 0.45]},  # ← More conservative safe bounds
+            max_ee_step_m=0.02,  # ← CRITICAL: Reduced from 0.10 to 0.02 (2cm max step prevents violent shaking!)
+        ),
+        GripperVelocityToJoint(
+            speed_factor=20.0,
+        ),
+        InverseKinematicsEEToJoints(
+            kinematics=kinematics_solver,
+            motor_names=list(robot.bus.motors.keys()),
+            initial_guess_current_joints=True,
+        ),
+    ],
+    to_transition=robot_action_observation_to_transition,
+    to_output=transition_to_robot_action,
+)
+
+# Connect to the robot and teleoperator
+# run torque disable first
+robot.connect()
+teleop_device.connect()
+
+# Init rerun viewer
+init_rerun(session_name="gamepad_so100_teleop")
+
+if not robot.is_connected or not teleop_device.is_connected:
+    raise ValueError("Robot or teleop is not connected!")
+
+print("Starting teleop loop. Use your gamepad to teleoperate the robot...")
+try:
+    while True:
+        t0 = time.perf_counter()
+
+        # Get robot observation
+        robot_obs = robot.get_observation()
+
+        # Get teleop action
+        gamepad_obs = teleop_device.get_action()
+
+        # Gamepad -> EE pose -> Joints transition
+        joint_action = gamepad_to_robot_joints_processor((gamepad_obs, robot_obs))
+
+        # Send action to robot
+        _ = robot.send_action(joint_action)
+
+        # Visualize
+        log_rerun_data(observation=gamepad_obs, action=joint_action)
+
+        busy_wait(max(1.0 / FPS - (time.perf_counter() - t0), 0.0))
+except KeyboardInterrupt:
+    print("Teleop loop interrupted by user")
+finally:
+    robot.disconnect()
+    teleop_device.disconnect()
+

--- a/src/lerobot/teleoperators/gamepad/gamepad_processor.py
+++ b/src/lerobot/teleoperators/gamepad/gamepad_processor.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+import numpy as np
+from lerobot.configs.types import FeatureType, PipelineFeatureType, PolicyFeature
+from lerobot.processor import ProcessorStepRegistry, RobotAction, RobotActionProcessorStep
+
+
+@ProcessorStepRegistry.register("map_gamepad_action_to_robot_action")
+@dataclass
+class MapGamepadActionToRobotAction(RobotActionProcessorStep):
+    """
+    Maps gamepad deltas to standardized robot action inputs expected downstream.
+
+    Inputs (from `GamepadTeleop.get_action()`):
+        - "delta_x", "delta_y", "delta_z" (float) in controller space
+
+    Outputs (for downstream steps like `EEReferenceAndDelta`):
+        - "enabled" (bool): True when any delta is non-zero
+        - "target_x", "target_y", "target_z" (float): passed-through deltas
+        - "target_wx", "target_wy", "target_wz" (float): zero (no rotation control initially)
+        - "gripper_vel" (float): zero (gripper handled later; held by velocity=0)
+    """
+
+    def action(self, action: RobotAction) -> RobotAction:
+        dx = float(action.pop("delta_x", 0.0))
+        dy = float(action.pop("delta_y", 0.0))
+        dz = float(action.pop("delta_z", 0.0))
+
+        # Clip dx, dy, dz to be between -0.5 and 0.5 to achieve smoother movement
+        dx = np.clip(dx, -0.5, 0.5)
+        dy = np.clip(dy, -0.5, 0.5)
+        dz = np.clip(dz, -0.5, 0.5)
+
+        print(f"dx: {dx}, dy: {dy}, dz: {dz}")
+
+        enabled = abs(dx) > 1e-8 or abs(dy) > 1e-8 or abs(dz) > 1e-8
+
+        action["enabled"] = enabled
+        action["target_x"] = dx if enabled else 0.0
+        action["target_y"] = dy if enabled else 0.0
+        action["target_z"] = dz if enabled else 0.0
+        action["target_wx"] = 0.0
+        action["target_wy"] = 0.0
+        action["target_wz"] = 0.0
+        action["gripper_vel"] = 0.0
+        return action
+
+    def transform_features(
+        self, features: dict[PipelineFeatureType, dict[str, PolicyFeature]]
+    ) -> dict[PipelineFeatureType, dict[str, PolicyFeature]]:
+        for feat in ["delta_x", "delta_y", "delta_z"]:
+            features[PipelineFeatureType.ACTION].pop(f"{feat}", None)
+
+        for feat in [
+            "enabled",
+            "target_x",
+            "target_y",
+            "target_z",
+            "target_wx",
+            "target_wy",
+            "target_wz",
+            "gripper_vel",
+        ]:
+            features[PipelineFeatureType.ACTION][f"{feat}"] = PolicyFeature(
+                type=FeatureType.ACTION, shape=(1,)
+            )
+
+        return features
+
+


### PR DESCRIPTION
## What this does

This PR solved below issues:

**Gamepad teleoperation is not supported by `lerobot-teleoperate`**: The default command only supports leader-follower joint-to-joint mapping, lacking the IK pipeline required for gamepad delta control.

**IK solver lacks safety validation**: When the target end-effector position is unreachable, the IK solver returns invalid joint configurations, causing the robot to shake violently and potentially break hardware.

## How it was tested


## How to checkout & try? (for the reviewer)

Examples:

```bash
python examples/gamepad_to_so100/teleoperate.py
```
