### PR TITLE
feat(dataset-editing) Add feature renaming tool

### DIFF
--- a/src/lerobot/datasets/__init__.py
+++ b/src/lerobot/datasets/__init__.py
@@ -33,6 +33,7 @@ from .dataset_tools import (
     recompute_stats,
     reencode_dataset,
     remove_feature,
+    rename_feature,
     split_dataset,
 )
 from .factory import make_dataset, make_train_eval_datasets, resolve_delta_timestamps
@@ -96,6 +97,7 @@ __all__ = [
     "recompute_stats",
     "reencode_dataset",
     "remove_feature",
+    "rename_feature",
     "resolve_delta_timestamps",
     "resolve_episode_indices",
     "safe_stop_image_writer",

--- a/src/lerobot/datasets/dataset_tools.py
+++ b/src/lerobot/datasets/dataset_tools.py
@@ -1165,6 +1165,15 @@ def _copy_videos(
 
         dst_video_key = rename_keys.get(src_video_key, src_video_key)
 
+        # Update metadata video keys
+        if src_video_key != dst_video_key:
+            video_key_mapping = {}
+            for field in ["chunk_index", "file_index", "from_timestamp", "to_timestamp"]:
+                src_key = f"videos/{src_video_key}/{field}"
+                dst_key = f"videos/{dst_video_key}/{field}"
+                video_key_mapping[src_key] = dst_key
+            dst_meta.episodes = dst_meta.episodes.rename_columns(video_key_mapping)
+
         video_files: set[tuple] = set()
         for ep_idx in range(len(src_dataset.meta.episodes)):
             try:
@@ -1173,22 +1182,6 @@ def _copy_videos(
                     dst_meta.get_video_file_path(ep_idx, dst_video_key),
                 )
                 video_files.add(video_paths)
-
-                # Update metadata video keys
-                if src_video_key != dst_video_key:
-                    src_ep = src_dataset.meta.episodes[ep_idx]
-                    dst_meta.episodes[ep_idx][f"videos/{dst_video_key}/chunk_index"] = src_ep[
-                        f"videos/{src_video_key}/chunk_index"
-                    ]
-                    dst_meta.episodes[ep_idx][f"videos/{dst_video_key}/file_index"] = src_ep[
-                        f"videos/{src_video_key}/file_index"
-                    ]
-                    dst_meta.episodes[ep_idx][f"videos/{dst_video_key}/from_timestamp"] = src_ep[
-                        f"videos/{src_video_key}/from_timestamp"
-                    ]
-                    dst_meta.episodes[ep_idx][f"videos/{dst_video_key}/to_timestamp"] = src_ep[
-                        f"videos/{src_video_key}/to_timestamp"
-                    ]
 
             except KeyError:
                 continue

--- a/src/lerobot/datasets/dataset_tools.py
+++ b/src/lerobot/datasets/dataset_tools.py
@@ -356,6 +356,8 @@ def modify_features(
     if remove_features is not None:
         remove_features_list = [remove_features] if isinstance(remove_features, str) else remove_features
 
+    rename_features_dict: dict[str, str] = rename_features if rename_features is not None else {}
+
     if add_features:
         required_keys = {"dtype", "shape"}
         for feature_name, (_, feature_info) in add_features.items():
@@ -374,8 +376,8 @@ def modify_features(
         if any(name in required_features for name in remove_features_list):
             raise ValueError(f"Cannot remove required features: {required_features}")
 
-    if rename_features:
-        for old_name, new_name in rename_features.items():
+    if rename_features_dict:
+        for old_name, new_name in rename_features_dict.items():
             if old_name not in dataset.meta.features:
                 raise ValueError(f"Feature '{old_name}' not found in dataset")
 
@@ -398,12 +400,15 @@ def modify_features(
         for feature_name, (_, feature_info) in add_features.items():
             new_features[feature_name] = feature_info
 
-    if rename_features:
-        for old_name, new_name in rename_features.items():
+    if rename_features_dict:
+        for old_name, new_name in rename_features_dict.items():
             new_features[new_name] = new_features.pop(old_name)
 
     video_keys_to_remove = [name for name in remove_features_list if name in dataset.meta.video_keys]
     remaining_video_keys = [k for k in dataset.meta.video_keys if k not in video_keys_to_remove]
+    video_keys_to_rename = {
+        name: renamed for name, renamed in rename_features_dict.items() if name in dataset.meta.video_keys
+    }
 
     new_meta = LeRobotDatasetMetadata.create(
         repo_id=repo_id,
@@ -419,11 +424,16 @@ def modify_features(
         new_meta=new_meta,
         add_features=add_features,
         remove_features=remove_features_list if remove_features_list else None,
-        rename_features=rename_features if rename_features else None,
+        rename_features=rename_features_dict if rename_features_dict else None,
     )
 
     if new_meta.video_keys:
-        _copy_videos(dataset, new_meta, exclude_keys=video_keys_to_remove if video_keys_to_remove else None)
+        _copy_videos(
+            dataset,
+            new_meta,
+            exclude_keys=video_keys_to_remove if video_keys_to_remove else None,
+            rename_keys=video_keys_to_rename if video_keys_to_rename else None,
+        )
 
     new_dataset = LeRobotDataset(
         repo_id=repo_id,
@@ -1133,38 +1143,66 @@ def _copy_data_with_feature_changes(
 
         _write_parquet(df, dst_path, new_meta)
 
-    _copy_episodes_metadata_and_stats(dataset, new_meta)
+    _copy_episodes_metadata_and_stats(dataset, new_meta, rename_feature_map=rename_features)
 
 
 def _copy_videos(
     src_dataset: LeRobotDataset,
     dst_meta: LeRobotDatasetMetadata,
     exclude_keys: list[str] | None = None,
+    rename_keys: dict[str, str] | None = None,
 ) -> None:
-    """Copy video files, optionally excluding certain keys."""
+    """Copy video files, optionally excluding or renaming certain keys."""
     if exclude_keys is None:
         exclude_keys = []
 
-    for video_key in src_dataset.meta.video_keys:
-        if video_key in exclude_keys:
+    if rename_keys is None:
+        rename_keys = {}
+
+    for src_video_key in src_dataset.meta.video_keys:
+        if src_video_key in exclude_keys:
             continue
 
-        video_files = set()
+        dst_video_key = rename_keys.get(src_video_key, src_video_key)
+
+        video_files: set[tuple] = set()
         for ep_idx in range(len(src_dataset.meta.episodes)):
             try:
-                video_files.add(src_dataset.meta.get_video_file_path(ep_idx, video_key))
+                video_paths = (
+                    src_dataset.meta.get_video_file_path(ep_idx, src_video_key),
+                    dst_meta.get_video_file_path(ep_idx, dst_video_key),
+                )
+                video_files.add(video_paths)
+
+                # Update metadata video keys
+                if src_video_key != dst_video_key:
+                    src_ep = src_dataset.meta.episodes[ep_idx]
+                    dst_meta.episodes[ep_idx][f"videos/{dst_video_key}/chunk_index"] = src_ep[
+                        f"videos/{src_video_key}/chunk_index"
+                    ]
+                    dst_meta.episodes[ep_idx][f"videos/{dst_video_key}/file_index"] = src_ep[
+                        f"videos/{src_video_key}/file_index"
+                    ]
+                    dst_meta.episodes[ep_idx][f"videos/{dst_video_key}/from_timestamp"] = src_ep[
+                        f"videos/{src_video_key}/from_timestamp"
+                    ]
+                    dst_meta.episodes[ep_idx][f"videos/{dst_video_key}/to_timestamp"] = src_ep[
+                        f"videos/{src_video_key}/to_timestamp"
+                    ]
+
             except KeyError:
                 continue
 
-        for src_path in tqdm(sorted(video_files), desc=f"Copying {video_key} videos"):
-            dst_path = dst_meta.root / src_path
-            dst_path.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copy(src_dataset.root / src_path, dst_path)
+        for src_path, dst_path in tqdm(sorted(video_files), desc=f"Copying {src_video_key} videos"):
+            dst_video_path = dst_meta.root / dst_path
+            dst_video_path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy(src_dataset.root / src_path, dst_video_path)
 
 
 def _copy_episodes_metadata_and_stats(
     src_dataset: LeRobotDataset,
     dst_meta: LeRobotDatasetMetadata,
+    rename_feature_map: dict[str, str] | None = None,
 ) -> None:
     """Copy episodes metadata and recalculate stats."""
     if src_dataset.meta.tasks is not None:
@@ -1192,6 +1230,11 @@ def _copy_episodes_metadata_and_stats(
                 dst_meta.info.features[key]["info"] = deepcopy(
                     src_dataset.meta.info.features[key].get("info", {})
                 )
+
+    if rename_feature_map:
+        for old_name, new_name in rename_feature_map.items():
+            if old_name in dst_meta.info["features"]:
+                dst_meta.info["features"][new_name] = dst_meta.info["features"].pop(old_name)
 
     write_info(dst_meta.info, dst_meta.root)
 

--- a/src/lerobot/datasets/dataset_tools.py
+++ b/src/lerobot/datasets/dataset_tools.py
@@ -318,10 +318,11 @@ def modify_features(
     dataset: LeRobotDataset,
     add_features: dict[str, tuple[np.ndarray | torch.Tensor | Callable, dict]] | None = None,
     remove_features: str | list[str] | None = None,
+    rename_features: dict[str, str] | None = None,
     output_dir: str | Path | None = None,
     repo_id: str | None = None,
 ) -> LeRobotDataset:
-    """Modify a LeRobotDataset by adding and/or removing features in a single pass.
+    """Modify a LeRobotDataset by adding, removing and/or renaming features in a single pass.
 
     This is the most efficient way to modify features, as it only copies the dataset once
     regardless of how many features are being added or removed.
@@ -330,6 +331,7 @@ def modify_features(
         dataset: The source LeRobotDataset.
         add_features: Optional dict mapping feature names to (feature_values, feature_info) tuples.
         remove_features: Optional feature name(s) to remove. Can be a single string or list.
+        rename_features: Optional feature name(s) to rename. Provided as a dict mapping old names to new names.
         output_dir: Root directory where the edited dataset will be stored. If not specified, defaults to $HF_LEROBOT_HOME/repo_id. Equivalent to new_root in EditDatasetConfig.
         repo_id: Edited dataset identifier. Equivalent to new_repo_id in EditDatasetConfig.
 
@@ -343,10 +345,11 @@ def modify_features(
                 "reward": (reward_array, {"dtype": "float32", "shape": [1], "names": None}),
             },
             remove_features=["old_feature"],
+            rename_features={"old_feature_name": "new_feature_name"},
             output_dir="./output",
         )
     """
-    if add_features is None and remove_features is None:
+    if add_features is None and remove_features is None and rename_features is None:
         raise ValueError("Must specify at least one of add_features or remove_features")
 
     remove_features_list: list[str] = []
@@ -371,6 +374,16 @@ def modify_features(
         if any(name in required_features for name in remove_features_list):
             raise ValueError(f"Cannot remove required features: {required_features}")
 
+    if rename_features:
+        for old_name, new_name in rename_features.items():
+            if old_name not in dataset.meta.features:
+                raise ValueError(f"Feature '{old_name}' not found in dataset")
+
+            if new_name in dataset.meta.features:
+                raise ValueError(
+                    f"Feature '{new_name}' already exists in dataset, cannot rename '{old_name}' to it"
+                )
+
     if repo_id is None:
         repo_id = f"{dataset.repo_id}_modified"
     output_dir = Path(output_dir) if output_dir is not None else HF_LEROBOT_HOME / repo_id
@@ -384,6 +397,10 @@ def modify_features(
     if add_features:
         for feature_name, (_, feature_info) in add_features.items():
             new_features[feature_name] = feature_info
+
+    if rename_features:
+        for old_name, new_name in rename_features.items():
+            new_features[new_name] = new_features.pop(old_name)
 
     video_keys_to_remove = [name for name in remove_features_list if name in dataset.meta.video_keys]
     remaining_video_keys = [k for k in dataset.meta.video_keys if k not in video_keys_to_remove]
@@ -402,6 +419,7 @@ def modify_features(
         new_meta=new_meta,
         add_features=add_features,
         remove_features=remove_features_list if remove_features_list else None,
+        rename_features=rename_features if rename_features else None,
     )
 
     if new_meta.video_keys:
@@ -453,6 +471,7 @@ def add_features(
         dataset=dataset,
         add_features=features,
         remove_features=None,
+        rename_features=None,
         output_dir=output_dir,
         repo_id=repo_id,
     )
@@ -479,6 +498,34 @@ def remove_feature(
         dataset=dataset,
         add_features=None,
         remove_features=feature_names,
+        rename_features=None,
+        output_dir=output_dir,
+        repo_id=repo_id,
+    )
+
+
+def rename_feature(
+    dataset: LeRobotDataset,
+    feature_mapping: dict[str, str],
+    output_dir: str | Path | None = None,
+    repo_id: str | None = None,
+) -> LeRobotDataset:
+    """Rename features from a LeRobotDataset.
+
+    Args:
+        dataset: The source LeRobotDataset.
+        feature_mapping: Feature name mapping. Each key should be available features present in the dataset. Corresponding values are the renamed features.
+        output_dir: Directory to save the new dataset. If None, uses default location.
+        repo_id: Repository ID for the new dataset. If None, appends "_modified" to original.
+
+    Returns:
+        New dataset with features renamed.
+    """
+    return modify_features(
+        dataset=dataset,
+        add_features=None,
+        remove_features=None,
+        rename_features=feature_mapping,
         output_dir=output_dir,
         repo_id=repo_id,
     )
@@ -1030,6 +1077,7 @@ def _copy_data_with_feature_changes(
     new_meta: LeRobotDatasetMetadata,
     add_features: dict[str, tuple] | None = None,
     remove_features: list[str] | None = None,
+    rename_features: dict[str, str] | None = None,
 ) -> None:
     """Copy data while adding or removing features."""
     data_dir = dataset.root / DATA_DIR
@@ -1052,6 +1100,9 @@ def _copy_data_with_feature_changes(
 
         if remove_features:
             df = df.drop(columns=remove_features, errors="ignore")
+
+        if rename_features:
+            df = df.rename(columns=rename_features, errors="ignore")
 
         if add_features:
             end_idx = frame_idx + len(df)

--- a/src/lerobot/datasets/dataset_tools.py
+++ b/src/lerobot/datasets/dataset_tools.py
@@ -350,7 +350,7 @@ def modify_features(
         )
     """
     if add_features is None and remove_features is None and rename_features is None:
-        raise ValueError("Must specify at least one of add_features or remove_features")
+        raise ValueError("Must specify at least one of add_features, remove_features or rename_features")
 
     remove_features_list: list[str] = []
     if remove_features is not None:

--- a/src/lerobot/scripts/lerobot_edit_dataset.py
+++ b/src/lerobot/scripts/lerobot_edit_dataset.py
@@ -549,7 +549,6 @@ def handle_merge(cfg: EditDatasetConfig) -> None:
 
 
 def handle_rename_feature(cfg: EditDatasetConfig) -> None:
-    print(cfg)
     if not isinstance(cfg.operation, RenameFeatureConfig):
         raise ValueError("Operation config must be RenameFeatureConfig")
 

--- a/src/lerobot/scripts/lerobot_edit_dataset.py
+++ b/src/lerobot/scripts/lerobot_edit_dataset.py
@@ -133,6 +133,18 @@ Modify tasks - replace existing task strings in-place (WARNING: modifies in-plac
         --operation.type modify_tasks \
         --operation.task_replacements '{"Pick up the red cube": "Lift the red cube"}'
 
+Rename state feature:
+    python -m lerobot.scripts.lerobot_edit_dataset \
+        --repo_id lerobot/pusht_image \
+        --operation.type rename_feature \
+        --operation.feature_mapping '{"observation.state": "observation.state_renamed"}'
+
+Rename camera:
+    python -m lerobot.scripts.lerobot_edit_dataset \
+        --repo_id lerobot/aloha_sim_insertion_human \
+        --operation.type rename_feature \
+        --operation.feature_mapping '{"observation.images.top": "observation.images.top_camera"}'
+
 Convert image dataset to video format and save locally:
     lerobot-edit-dataset \
         --repo_id lerobot/pusht_image \
@@ -264,6 +276,7 @@ from lerobot.datasets import (
     recompute_stats,
     reencode_dataset,
     remove_feature,
+    rename_feature,
     split_dataset,
 )
 from lerobot.utils.constants import HF_LEROBOT_HOME
@@ -297,6 +310,12 @@ class MergeConfig(OperationConfig):
     # When False, keep one file per source file instead of packing into shards.
     concatenate_videos: bool = True
     concatenate_data: bool = True
+
+
+@OperationConfig.register_subclass("rename_feature")
+@dataclass
+class RenameFeatureConfig(OperationConfig):
+    feature_mapping: dict[str, str] | None = None
 
 
 @OperationConfig.register_subclass("remove_feature")
@@ -527,6 +546,38 @@ def handle_merge(cfg: EditDatasetConfig) -> None:
     if cfg.push_to_hub:
         logging.info(f"Pushing to hub as {cfg.new_repo_id}")
         LeRobotDataset(merged_dataset.repo_id, root=output_dir).push_to_hub()
+
+
+def handle_rename_feature(cfg: EditDatasetConfig) -> None:
+    print(cfg)
+    if not isinstance(cfg.operation, RenameFeatureConfig):
+        raise ValueError("Operation config must be RenameFeatureConfig")
+
+    if not cfg.operation.feature_mapping:
+        raise ValueError("feature_mapping must be specified for rename_feature operation")
+
+    dataset = LeRobotDataset(cfg.repo_id, root=cfg.root)
+    output_repo_id, output_dir = get_output_path(
+        cfg.repo_id, cfg.new_repo_id, Path(cfg.root) if cfg.root else None
+    )
+
+    if cfg.new_repo_id is None:
+        dataset.root = Path(str(dataset.root) + "_old")
+
+    logging.info(f"Renaming features {cfg.operation.feature_mapping} from {cfg.repo_id}")
+    new_dataset = rename_feature(
+        dataset,
+        feature_mapping=cfg.operation.feature_mapping,
+        output_dir=output_dir,
+        repo_id=output_repo_id,
+    )
+
+    logging.info(f"Dataset saved to {output_dir}")
+    logging.info(f"Current feature names: {list(new_dataset.meta.features.keys())}")
+
+    if cfg.push_to_hub:
+        logging.info(f"Pushing to hub as {output_repo_id}")
+        LeRobotDataset(output_repo_id, root=output_dir).push_to_hub()
 
 
 def handle_remove_feature(cfg: EditDatasetConfig) -> None:
@@ -853,6 +904,8 @@ def edit_dataset(cfg: EditDatasetConfig) -> None:
         handle_split(cfg)
     elif operation_type == "merge":
         handle_merge(cfg)
+    elif operation_type == "rename_feature":
+        handle_rename_feature(cfg)
     elif operation_type == "remove_feature":
         handle_remove_feature(cfg)
     elif operation_type == "modify_tasks":

--- a/tests/datasets/test_dataset_tools.py
+++ b/tests/datasets/test_dataset_tools.py
@@ -35,6 +35,7 @@ from lerobot.datasets.dataset_tools import (
     modify_tasks,
     reencode_dataset,
     remove_feature,
+    rename_feature,
     split_dataset,
 )
 from lerobot.datasets.io_utils import load_info
@@ -411,7 +412,7 @@ def test_add_feature_invalid_info(sample_dataset, tmp_path):
         )
 
 
-def test_modify_features_add_and_remove(sample_dataset, tmp_path):
+def test_modify_features_add_remove_and_rename(sample_dataset, tmp_path):
     """Test modifying features by adding and removing simultaneously."""
     feature_info = {"dtype": "float32", "shape": (1,), "names": None}
 
@@ -429,18 +430,29 @@ def test_modify_features_add_and_remove(sample_dataset, tmp_path):
             output_dir=tmp_path / "with_reward",
         )
 
+        # Now rename "reward" to "model_reward"
+        renamed_dataset = modify_features(
+            dataset_with_reward,
+            rename_features={"reward": "model_reward"},
+            output_dir=tmp_path / "renamed",
+        )
+
         # Now use modify_features to add "success" and remove "reward" in one pass
         modified_dataset = modify_features(
-            dataset_with_reward,
+            renamed_dataset,
             add_features={
                 "success": (np.random.randn(50, 1).astype(np.float32), feature_info),
             },
-            remove_features="reward",
+            remove_features="model_reward",
             output_dir=tmp_path / "modified",
         )
 
+    assert "reward" not in renamed_dataset.meta.features
+    assert "model_reward" in renamed_dataset.meta.features
+    assert "model_reward" not in modified_dataset.meta.features
     assert "success" in modified_dataset.meta.features
-    assert "reward" not in modified_dataset.meta.features
+
+    assert len(renamed_dataset) == 50
     assert len(modified_dataset) == 50
 
 
@@ -493,9 +505,38 @@ def test_modify_features_only_remove(sample_dataset, tmp_path):
     assert "reward" not in modified_dataset.meta.features
 
 
+def test_modify_features_only_rename(sample_dataset, tmp_path):
+    """Test that modify_features works with only rename_features."""
+    feature_info = {"dtype": "float32", "shape": (1,), "names": None}
+
+    with (
+        patch("lerobot.datasets.lerobot_dataset.get_safe_version") as mock_get_safe_version,
+        patch("lerobot.datasets.lerobot_dataset.snapshot_download") as mock_snapshot_download,
+    ):
+        mock_get_safe_version.return_value = "v3.0"
+        mock_snapshot_download.side_effect = lambda repo_id, **kwargs: str(kwargs.get("local_dir", tmp_path))
+
+        dataset_with_reward = add_features(
+            sample_dataset,
+            features={"reward": (np.random.randn(50, 1).astype(np.float32), feature_info)},
+            output_dir=tmp_path / "with_reward",
+        )
+
+        modified_dataset = modify_features(
+            dataset_with_reward,
+            rename_features={"reward": "reward_modified"},
+            output_dir=tmp_path / "renamed",
+        )
+
+    assert "reward" not in modified_dataset.meta.features
+    assert "reward_modified" in modified_dataset.meta.features
+
+
 def test_modify_features_no_changes(sample_dataset, tmp_path):
     """Test error when modify_features is called with no changes."""
-    with pytest.raises(ValueError, match="Must specify at least one of add_features or remove_features"):
+    with pytest.raises(
+        ValueError, match="Must specify at least one of add_features, remove_features or rename_features"
+    ):
         modify_features(
             sample_dataset,
             output_dir=tmp_path / "modified",
@@ -608,6 +649,37 @@ def test_remove_camera_feature(sample_dataset, tmp_path):
 
     sample_item = dataset_without_camera[0]
     assert camera_to_remove not in sample_item
+
+
+def test_rename_camera_feature(sample_dataset, tmp_path):
+    """Test removing a camera feature."""
+    camera_keys = sample_dataset.meta.camera_keys
+    if not camera_keys:
+        pytest.skip("No camera keys in dataset")
+
+    camera_to_rename = camera_keys[0]
+
+    with (
+        patch("lerobot.datasets.lerobot_dataset.get_safe_version") as mock_get_safe_version,
+        patch("lerobot.datasets.lerobot_dataset.snapshot_download") as mock_snapshot_download,
+    ):
+        mock_get_safe_version.return_value = "v3.0"
+        mock_snapshot_download.return_value = str(tmp_path / "without_camera")
+
+        dataset_with_renamed_camera = rename_feature(
+            sample_dataset,
+            feature_mapping={camera_to_rename: "my_camera"},
+            output_dir=tmp_path / "without_camera",
+        )
+
+    assert camera_to_rename not in dataset_with_renamed_camera.meta.features
+    assert camera_to_rename not in dataset_with_renamed_camera.meta.camera_keys
+    assert "my_camera" in dataset_with_renamed_camera.meta.features
+    assert "my_camera" in dataset_with_renamed_camera.meta.camera_keys
+
+    sample_item = dataset_with_renamed_camera[0]
+    assert camera_to_rename not in sample_item
+    assert "my_camera" in sample_item
 
 
 def test_complex_workflow_integration(sample_dataset, tmp_path):


### PR DESCRIPTION
## What this does

Add a new dataset editing tool to rename features. Part of the #2326 initiative to create lerobot dataset editing tools.

## How it was tested

- Added `handle_rename_feature` function in `src/lerobot/scripts/lerobot_edit_dataset.py`
- Edited `src/lerobot/datasets/dataset_tools.py`:
    - Added `rename_feature`
    - Edited `modify_features` with a new field called `rename_features`
- Added or edited tests in `tests/datasets/test_dataset_tools.py`:
    - `test_modify_features_add_remove_and_rename`
    - `test_modify_features_only_rename`
    - `test_rename_camera_feature`
- Added usage example in docstring

## How to checkout & try? (for the reviewer)

Run the tool:

```bash
lerobot-edit-dataset \
    --repo_id lerobot/pusht_image \
    --operation.type rename_feature  \
    --operation.feature_mapping '{"observation.image": "observation.camera.image", "observation.state": "observation.state_values"}' \
    --new_repo_id ${HF_USER}/pusht_image_renamed
```

Run the tests

```bash
pytest tests/datasets/test_dataset_tools.py
```
