### PR TITLE
Skip action workflows on forks

### DIFF
--- a/.github/workflows/documentation-upload-pr.yml
+++ b/.github/workflows/documentation-upload-pr.yml
@@ -31,7 +31,8 @@ jobs:
     name: Upload Preview and Comment
     if: >
       github.event.workflow_run.event == 'pull_request' &&
-      github.event.workflow_run.conclusion == 'success'
+      github.event.workflow_run.conclusion == 'success' &&
+      github.repository == 'huggingface/lerobot'
     uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@main
     with:
       package_name: lerobot

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -42,7 +42,9 @@ jobs:
   # This job builds and deploys the official documentation.
   build_main_docs:
     name: Build Main Docs
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    if: |
+      github.repository == 'huggingface/lerobot' &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     permissions:
       contents: read
     uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@main
@@ -58,7 +60,9 @@ jobs:
   # The result of this job triggers the 'Upload PR Documentation' workflow.
   build_pr_docs:
     name: Build PR Docs
-    if: github.event_name == 'pull_request'
+    if: |
+      github.repository == 'huggingface/lerobot' &&
+      github.event_name == 'pull_request'
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/fast_tests.yml
+++ b/.github/workflows/fast_tests.yml
@@ -57,6 +57,7 @@ jobs:
   # It runs everytime we commit to a PR or push to main
   fast-pytest-tests:
     name: Fast Pytest Tests
+    if: github.repository == 'huggingface/lerobot'
     runs-on: ubuntu-latest
     env:
       MUJOCO_GL: egl

--- a/.github/workflows/full_tests.yml
+++ b/.github/workflows/full_tests.yml
@@ -53,9 +53,12 @@ jobs:
     name: Full Tests
     runs-on: ubuntu-latest
     if: |
-      (github.event_name == 'pull_request_review' && github.event.review.state == 'approved') ||
-      github.event_name == 'push' ||
-      github.event_name == 'workflow_dispatch'
+      github.repository == 'huggingface/lerobot' &&
+      (
+        (github.event_name == 'pull_request_review' && github.event.review.state == 'approved') ||
+        github.event_name == 'push' ||
+        github.event_name == 'workflow_dispatch'
+      )
     env:
       MUJOCO_GL: egl
     steps:
@@ -94,9 +97,12 @@ jobs:
     runs-on:
       group: aws-general-8-plus
     if: |
-      (github.event_name == 'pull_request_review' && github.event.review.state == 'approved' && github.event.pull_request.head.repo.fork == false) ||
-      github.event_name == 'push' ||
-      github.event_name == 'workflow_dispatch'
+      github.repository == 'huggingface/lerobot' &&
+      (
+        (github.event_name == 'pull_request_review' && github.event.review.state == 'approved' && github.event.pull_request.head.repo.fork == false) ||
+        github.event_name == 'push' ||
+        github.event_name == 'workflow_dispatch'
+      )
     outputs:
       image_tag: ${{ steps.set_tag.outputs.image_tag }}
     env:
@@ -148,6 +154,7 @@ jobs:
     needs: [build-and-push-docker]
     runs-on:
       group: aws-g6-4xlarge-plus
+    if: github.repository == 'huggingface/lerobot'
     env:
       HF_HOME: /home/user_lerobot/.cache/huggingface
       HF_LEROBOT_HOME: /home/user_lerobot/.cache/huggingface/lerobot
@@ -174,7 +181,7 @@ jobs:
   delete-pr-image:
     name: Delete PR Image
     needs: [gpu-tests, build-and-push-docker]
-    if: always() && ((github.event.review.state == 'approved') || (github.event_name == 'workflow_dispatch')) && needs.build-and-push-docker.result == 'success'
+    if: always() && ((github.event.review.state == 'approved') || (github.event_name == 'workflow_dispatch')) && needs.build-and-push-docker.result == 'success' && github.repository == 'huggingface/lerobot'
     runs-on: ubuntu-latest
     steps:
       - name: Get Docker Hub Token and Delete Image

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -41,6 +41,7 @@ jobs:
   # This job builds a CPU image for testing & distribution
   build-docker-cpu-nightly:
     name: Build CPU Docker for Nightly
+    if: github.repository == 'huggingface/lerobot'
     runs-on:
       group: aws-general-8-plus
     outputs:
@@ -75,6 +76,7 @@ jobs:
   # This job builds a GPU image for testing & distribution
   build-docker-gpu-nightly:
     name: Build GPU Docker for Nightly
+    if: github.repository == 'huggingface/lerobot'
     runs-on:
       group: aws-general-8-plus
     outputs:
@@ -109,6 +111,7 @@ jobs:
   # This job runs the E2E tests + pytest with all extras in the CPU image
   nightly-cpu-tests:
     name: Nightly CPU Tests
+    if: github.repository == 'huggingface/lerobot'
     needs: [build-docker-cpu-nightly]
     runs-on:
       group: aws-g6-4xlarge-plus
@@ -136,6 +139,7 @@ jobs:
   # This job runs the E2E tests + pytest with all extras in the GPU image
   nightly-gpu-tests:
     name: Nightly GPU Tests
+    if: github.repository == 'huggingface/lerobot'
     needs: [build-docker-gpu-nightly]
     runs-on:
       group: aws-g6-4xlarge-plus
@@ -163,6 +167,7 @@ jobs:
   # This job runs multi-GPU training tests with 4 GPUs
   nightly-multi-gpu-tests:
     name: Nightly Multi-GPU Tests
+    if: github.repository == 'huggingface/lerobot'
     needs: [build-docker-gpu-nightly]
     runs-on:
       group: aws-g4dn-12xlarge  # Instance with 4 GPUs

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -40,6 +40,7 @@ jobs:
   # This job runs pre-commit hooks to check code style and formatting.
   pre-commit-checks:
     name: Run Pre-commit Hooks (Lint, Format & Static Analysis)
+    if: github.repository == 'huggingface/lerobot'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
   # This job builds the Python package and publishes it to PyPI
   build-and-publish:
     name: Build and publish Python distributions
+    if: github.repository == 'huggingface/lerobot'
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.extract_info.outputs.tag_version }}
@@ -128,6 +129,7 @@ jobs:
   test-release:
     name: Test Release
     needs: [build-and-publish]
+    if: github.repository == 'huggingface/lerobot'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -40,6 +40,7 @@ jobs:
   # This job runs TruffleHog to scan the full history of the repository for secrets.
   trufflehog:
     name: Secret Leaks Scan
+    if: github.repository == 'huggingface/lerobot'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -44,6 +44,7 @@ jobs:
   # This job runs the actions/stale action to close stale issues and PRs.
   stale:
     name: Close Stale Issues and PRs
+    if: github.repository == 'huggingface/lerobot'
     runs-on: ubuntu-latest
     permissions:
       actions: write

--- a/.github/workflows/unbound_deps_tests.yml
+++ b/.github/workflows/unbound_deps_tests.yml
@@ -42,6 +42,7 @@ jobs:
   # This job runs the E2E tests + pytest with all unbound extras
   full-tests:
     name: Full Unbound Tests
+    if: github.repository == 'huggingface/lerobot'
     runs-on: ubuntu-latest
     env:
       MUJOCO_GL: egl
@@ -87,6 +88,7 @@ jobs:
       image_tag: ${{ env.DOCKER_IMAGE_NAME }}
     env:
       GITHUB_REF: ${{ github.ref }}
+    if: github.repository == 'huggingface/lerobot'
     steps:
       - name: Install Git LFS
         run: |
@@ -123,6 +125,7 @@ jobs:
     needs: [build-and-push-docker]
     runs-on:
       group: aws-g6-4xlarge-plus
+    if: github.repository == 'huggingface/lerobot'
     env:
       HF_HOME: /home/user_lerobot/.cache/huggingface
       HF_LEROBOT_HOME: /home/user_lerobot/.cache/huggingface/lerobot
@@ -149,7 +152,7 @@ jobs:
   delete-unbound-image:
     name: Delete Unbound Image
     needs: [gpu-tests, build-and-push-docker]
-    if: always() && needs.build-and-push-docker.result == 'success'
+    if: always() && needs.build-and-push-docker.result == 'success' && github.repository == 'huggingface/lerobot'
     runs-on: ubuntu-latest
     steps:
       - name: Get Docker Hub Token and Delete Image


### PR DESCRIPTION
## What this does

This adds conditionals to all github actions to skip them on forked repos. My fork kept trying to run actions nightly and when I'd sync changes to main. This adds a check to only do so within this repo.

## How it was tested

Requires testing on the Huggingface repo