### PR TITLE
Clamp `torchcodec` frame requests to prevent SmolVLA dataloader crash (🐛 Bug)

### DIFF
--- a/src/lerobot/datasets/video_utils.py
+++ b/src/lerobot/datasets/video_utils.py
@@ -253,8 +253,36 @@ def decode_video_frames_torchcodec(
     # get metadata for frame information
     metadata = decoder.metadata
     average_fps = metadata.average_fps
+
+    num_frames = getattr(metadata, "num_frames", None)
+    max_frame_index = None
+    max_timestamp = None
+    if average_fps is None or average_fps <= 0:
+        raise ValueError("average_fps must be a positive value when decoding videos with torchcodec.")
+    if num_frames is not None and num_frames > 0:
+        max_frame_index = int(num_frames) - 1
+        max_timestamp = max_frame_index / average_fps
+
+    adjusted_timestamps: list[float] = []
+    for ts in timestamps:
+        clamped_ts = max(ts, 0.0)
+        if max_timestamp is not None:
+            clamped_ts = min(clamped_ts, max_timestamp)
+        adjusted_timestamps.append(clamped_ts)
+
+    timestamps = adjusted_timestamps
+
     # convert timestamps to frame indices
-    frame_indices = [round(ts * average_fps) for ts in timestamps]
+    frame_indices = []
+    for ts in timestamps:
+        idx = round(ts * average_fps)
+        if max_frame_index is not None:
+            if idx > max_frame_index:
+                idx = max_frame_index
+            if idx < 0:
+                idx = 0
+        frame_indices.append(idx)
+
     # retrieve frames based on indices
     frames_batch = decoder.get_frames_at(indices=frame_indices)
 


### PR DESCRIPTION
## What this does

Explain what this PR does. Feel free to tag your PR with the appropriate label(s).

When I ran the `lerobot-train` script with SmolVLA on [my dataset](https://huggingface.co/datasets/ryanhoangt/pick-place-round-box/), I got the following error, which didn't happen when I ran training with ACT:

```
Traceback (most recent call last):                                                                                                                                                                                            │
  File "/usr/local/bin/lerobot-train", line 8, in <module>                                                                                                                                                                    │
    sys.exit(main())                                                                                                                                                                                                          │
             ^^^^^^                                                                                                                                                                                                           │
  File "/content/lerobot/src/lerobot/scripts/lerobot_train.py", line 444, in main                                                                                                                                             │
    train()                                                                                                                                                                                                                   │
  File "/content/lerobot/src/lerobot/configs/parser.py", line 233, in wrapper_inner                                                                                                                                           │
    response = fn(cfg, *args, **kwargs)                                                                                                                                                                                       │
               ^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                                       │
  File "/content/lerobot/src/lerobot/scripts/lerobot_train.py", line 328, in train                                                                                                                                            │
    batch = next(dl_iter)                                                                                                                                                                                                     │
            ^^^^^^^^^^^^^                                                                                                                                                                                                     │
  File "/content/lerobot/src/lerobot/datasets/utils.py", line 898, in cycle                                                                                                                                                   │
    yield next(iterator)                                                                                                                                                                                                      │
          ^^^^^^^^^^^^^^                                                                                                                                                                                                      │
  File "/usr/local/lib/python3.11/site-packages/accelerate/data_loader.py", line 567, in __iter__                                                                                                                             │
    current_batch = next(dataloader_iter)                                                                                                                                                                                     │
                    ^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                                     │
  File "/usr/local/lib/python3.11/site-packages/torch/utils/data/dataloader.py", line 733, in __next__                                                                                                                        │
    data = self._next_data()                                                                                                                                                                                                  │
           ^^^^^^^^^^^^^^^^^                                                                                                                                                                                                  │
  File "/usr/local/lib/python3.11/site-packages/torch/utils/data/dataloader.py", line 1515, in _next_data                                                                                                                     │
    return self._process_data(data, worker_id)                                                                                                                                                                                │
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                                │
  File "/usr/local/lib/python3.11/site-packages/torch/utils/data/dataloader.py", line 1550, in _process_data                                                                                                                  │
    data.reraise()                                                                                                                                                                                                            │
  File "/usr/local/lib/python3.11/site-packages/torch/_utils.py", line 750, in reraise                                                                                                                                        │
    raise exception                                                                                                                                                                                                           │
RuntimeError: Caught RuntimeError in DataLoader worker process 0.                                                                                                                                                             │
Original Traceback (most recent call last):                                                                                                                                                                                   │
  File "/usr/local/lib/python3.11/site-packages/torch/utils/data/_utils/worker.py", line 349, in _worker_loop                                                                                                                 │
    data = fetcher.fetch(index)  # type: ignore[possibly-undefined]                                                                                                                                                           │
           ^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                                               │
  File "/usr/local/lib/python3.11/site-packages/torch/utils/data/_utils/fetch.py", line 52, in fetch                                                                                                                          │
    data = [self.dataset[idx] for idx in possibly_batched_index]                                                                                                                                                              │
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                              │
  File "/usr/local/lib/python3.11/site-packages/torch/utils/data/_utils/fetch.py", line 52, in <listcomp>                                                                                                                     │
    data = [self.dataset[idx] for idx in possibly_batched_index]                                                                                                                                                              │
            ~~~~~~~~~~~~^^^^^                                                                                                                                                                                                 │
  File "/content/lerobot/src/lerobot/datasets/lerobot_dataset.py", line 1015, in __getitem__                                                                                                                                  │
    video_frames = self._query_videos(query_timestamps, ep_idx)                                                                                                                                                               │
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                               │
  File "/content/lerobot/src/lerobot/datasets/lerobot_dataset.py", line 980, in _query_videos                                                                                                                                 │
    frames = decode_video_frames(video_path, shifted_query_ts, self.tolerance_s, self.video_backend)                                                                                                                          │
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                          │
  File "/content/lerobot/src/lerobot/datasets/video_utils.py", line 69, in decode_video_frames                                                                                                                                │
    return decode_video_frames_torchcodec(video_path, timestamps, tolerance_s)                                                                                                                                                │
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                │
  File "/content/lerobot/src/lerobot/datasets/video_utils.py", line 259, in decode_video_frames_torchcodec                                                                                                                    │
    frames_batch = decoder.get_frames_at(indices=frame_indices)                                                                                                                                                               │
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                               │
  File "/usr/local/lib/python3.11/site-packages/torchcodec/decoders/_video_decoder.py", line 227, in get_frames_at                                                                                                            │
    data, pts_seconds, duration_seconds = core.get_frames_at_indices(                                                                                                                                                         │
                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                         │
  File "/usr/local/lib/python3.11/site-packages/torch/_ops.py", line 756, in __call__                                                                                                                                         │
    return self._op(*args, **kwargs)                                                                                                                                                                                          │
           ^^^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                                                                                          │
RuntimeError: Invalid frame index=3817 for streamIndex=0; must be less than 3773

```

- Root cause: SmolVLA requests video frames up to its full 50-step prediction horizon. When a sampled window sits near the end of a video file, the derived timestamp (current frame + future steps) can slip slightly past the actual recording length. The decoder converted those timestamps directly to frame indices and called `torchcodec.get_frames_at` without any bounds check, so the first out-of-range request (e.g. index 3817 in a 3773-frame clip raised the runtime error that broke training.

- Fix: Clamp every requested timestamp to the valid range before converting it to a frame index. In `decode_video_frames_torchcodec`, compute the last legal index (`num_frames - 1`) from the decoder metadata, cap timestamps to `[0, max_timestamp]`, convert to indices, and cap the indices as well. This way any “future” request is silently redirected to the final available frame instead of crashing.
- 

## How it was tested

Explain/show how you tested your changes.

Examples:

- Ran the SmolVLA training script with the branch's code and it worked fine:
```bash
!lerobot-train \
    --policy.path=lerobot/smolvla_base \
    --dataset.repo_id=ryanhoangt/pick-place-round-box \
    --batch_size=64 \
    --steps=20000 \
    --output_dir="outputs/train/smolvla_so101_pick_place_round_box" \
    --job_name=smolvla_so101_pick_place_round_box_training \
    --policy.repo_id=ryanhoangt/smolvla_so101_pick_place_round_box \
    --policy.device=cuda \
    --wandb.enable=true \
    --rename_map='{ "observation.images.front": "observation.images.camera1" }'
```

## How to checkout & try? (for the reviewer)

Provide a simple way for the reviewer to try out your changes.

Examples:

```bash
pytest -sx tests/test_stuff.py::test_something
```

```bash
lerobot-train --some.option=true
```

## SECTION TO REMOVE BEFORE SUBMITTING YOUR PR

**Note**: Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR. Try to avoid tagging more than 3 people.

**Note**: Before submitting this PR, please read the [contributor guideline](https://github.com/huggingface/lerobot/blob/main/CONTRIBUTING.md#submitting-a-pull-request-pr).
