### PR TITLE
Fix high RAM usage when loading LeRobotDataset with specific episodes

### DIFF
--- a/src/lerobot/datasets/lerobot_dataset.py
+++ b/src/lerobot/datasets/lerobot_dataset.py
@@ -830,7 +830,12 @@ class LeRobotDataset(torch.utils.data.Dataset):
     def load_hf_dataset(self) -> datasets.Dataset:
         """hf_dataset contains all the observations, states, actions, rewards, etc."""
         features = get_hf_features_from_features(self.features)
-        hf_dataset = load_nested_dataset(self.root / "data", features=features, episodes=self.episodes)
+        hf_dataset = load_nested_dataset(
+            self.root / "data",
+            features=features,
+            episodes=self.episodes,
+            episodes_metadata=self.meta.episodes,
+        )
         hf_dataset.set_transform(hf_transform_to_torch)
         return hf_dataset
 


### PR DESCRIPTION
# Fix high RAM usage when loading LeRobotDataset with specific episodes

Related to  #2456 

## What this does

(⚡️ Performance)

I noticed a significant memory issue when loading LeRobotDataset with a specific list of episodes. It seemed to be loading the filtered data directly into RAM, which was causing huge spikes compared to loading the full dataset (which uses memory mapping).

I dug into src/lerobot/datasets/utils.py and found that load_nested_dataset was indeed materializing the table in memory when filtering.

To fix this, I refactored load_nested_dataset to support an optimized loading path when episodes_metadata is available:
1.  It loads the full dataset using memory mapping (Dataset.from_parquet). -> just like when   episodes is not specified
2.  It calculates the exact row indices for the requested episodes using the metadata.
3.  It uses Dataset.select(indices) to return a filtered view.

This keeps the memory-mapped nature of the dataset, so we only load data from disk when we actually access it. I also kept the legacy path as a fallback for when metadata isn't provided.

## How it was tested

I wrote a script to monitor peak RAM usage while loading subsets of the erecting/droid_1.0.1 dataset.

Before the fix:

*   500 episodes: 3.5 GB Peak RAM
*   5 000 episodes: 8.7 GB Peak RAM
*   10 000 episodes: 14.1 GB Peak RAM

After the fix:

*   500 episodes: 1.3 GB Peak RAM
*   5 000 episodes: 1.4 GB Peak RAM
*   10 000 episodes: 1.5 GB Peak RAM

## How to checkout & try? (for the reviewer)

You can verify this by loading a large subset of episodes and checking your process memory. It should stay very low now compared to previous version.

```python
from lerobot.datasets.lerobot_dataset import LeRobotDataset

# This should now be memory efficient
ds = LeRobotDataset("lerobot/pusht", episodes=list(range(100)))
```
