### PR TITLE
fix(cameras): change the key from id to serial_number

### DIFF
--- a/src/lerobot/cameras/camera.py
+++ b/src/lerobot/cameras/camera.py
@@ -39,15 +39,19 @@ class Camera(abc.ABC):
         height (int | None): Frame height in pixels
     """
 
+    fps: int | None
+    width: int | None
+    height: int | None
+
     def __init__(self, config: CameraConfig):
         """Initialize the camera with the given configuration.
 
         Args:
             config: Camera configuration containing FPS and resolution.
         """
-        self.fps: int | None = config.fps
-        self.width: int | None = config.width
-        self.height: int | None = config.height
+        self.fps = config.fps
+        self.width = config.width
+        self.height = config.height
 
     def __enter__(self):
         """

--- a/src/lerobot/cameras/realsense/camera_realsense.py
+++ b/src/lerobot/cameras/realsense/camera_realsense.py
@@ -208,7 +208,7 @@ class RealSenseCamera(Camera):
 
         Returns:
             List[Dict[str, Any]]: A list of dictionaries,
-            where each dictionary contains 'type', 'id' (serial number), 'name',
+            where each dictionary contains 'type', 'serial number', 'name',
             firmware version, USB type, and other available specs, and the default profile properties (width, height, fps, format).
 
         Raises:
@@ -223,7 +223,7 @@ class RealSenseCamera(Camera):
             camera_info = {
                 "name": device.get_info(rs.camera_info.name),
                 "type": "RealSense",
-                "id": device.get_info(rs.camera_info.serial_number),
+                "serial_number": device.get_info(rs.camera_info.serial_number),
                 "firmware_version": device.get_info(rs.camera_info.firmware_version),
                 "usb_type_descriptor": device.get_info(rs.camera_info.usb_type_descriptor),
                 "physical_port": device.get_info(rs.camera_info.physical_port),

--- a/src/lerobot/cameras/realsense/camera_realsense.py
+++ b/src/lerobot/cameras/realsense/camera_realsense.py
@@ -223,7 +223,7 @@ class RealSenseCamera(Camera):
             camera_info = {
                 "name": device.get_info(rs.camera_info.name),
                 "type": "RealSense",
-                "serial_number": device.get_info(rs.camera_info.serial_number),
+                "id": device.get_info(rs.camera_info.serial_number),
                 "firmware_version": device.get_info(rs.camera_info.firmware_version),
                 "usb_type_descriptor": device.get_info(rs.camera_info.usb_type_descriptor),
                 "physical_port": device.get_info(rs.camera_info.physical_port),
@@ -264,13 +264,13 @@ class RealSenseCamera(Camera):
             )
 
         if len(found_devices) > 1:
-            serial_numbers = [dev["serial_number"] for dev in found_devices]
+            serial_numbers = [dev["id"] for dev in found_devices]
             raise ValueError(
                 f"Multiple RealSense cameras found with name '{name}'. "
                 f"Please use a unique serial number instead. Found SNs: {serial_numbers}"
             )
 
-        serial_number = str(found_devices[0]["serial_number"])
+        serial_number = str(found_devices[0]["id"])
         return serial_number
 
     def _configure_rs_pipeline_config(self, rs_config: Any) -> None:

--- a/src/lerobot/cameras/realsense/camera_realsense.py
+++ b/src/lerobot/cameras/realsense/camera_realsense.py
@@ -208,7 +208,7 @@ class RealSenseCamera(Camera):
 
         Returns:
             List[Dict[str, Any]]: A list of dictionaries,
-            where each dictionary contains 'type', 'serial number', 'name',
+            where each dictionary contains 'type', 'id' (serial number), 'name',
             firmware version, USB type, and other available specs, and the default profile properties (width, height, fps, format).
 
         Raises:


### PR DESCRIPTION
## What this does

This PR changes the the key from id to serial_number. The key "serial_number" is used in [`_find_serial_number_from_name`](https://github.com/sotanakamura/lerobot/blob/0f551df8f4bad4c504e395ea3df74fc5f714016f/src/lerobot/cameras/realsense/camera_realsense.py#L259)

This also includes the fix for mypy type checks of instance variables.

fix #2493 

## How it was tested

Tested with a real hardware.

## How to checkout & try? (for the reviewer)

Connect one RealSense and run the following script:

```py
from lerobot.cameras.realsense import RealSenseCamera, RealSenseCameraConfig

realsense = RealSenseCamera(RealSenseCameraConfig("Intel RealSense D415"))
realsense.connect()
realsense.disconnect()
```