### PR TITLE
fix: Solve SmolVLA meta tensor error by removing device_map

### DIFF
--- a/src/lerobot/policies/smolvla/smolvlm_with_expert.py
+++ b/src/lerobot/policies/smolvla/smolvlm_with_expert.py
@@ -77,8 +77,7 @@ class SmolVLMWithExpertModel(nn.Module):
             print(f"Loading  {model_id} weights ...")
             self.vlm = AutoModelForImageTextToText.from_pretrained(
                 model_id,
-                device_map=device,
-                torch_dtype="bfloat16",
+                torch_dtype=torch.bfloat16,
                 low_cpu_mem_usage=True,
             )
             config = self.vlm.config
@@ -132,6 +131,13 @@ class SmolVLMWithExpertModel(nn.Module):
         self.attention_mode = attention_mode
         self.expert_hidden_size = lm_expert_config.hidden_size
         self.set_requires_grad()
+
+        # Move model to device if specified (device_map was removed to avoid meta tensor issues)
+        if device not in ["auto", None]:
+            if load_vlm_weights:
+                self.vlm = self.vlm.to(device)
+            # lm_expert is created from config, needs to be moved to device
+            self.lm_expert = self.lm_expert.to(device)
 
     def get_vlm_model(self):
         return self.vlm.model


### PR DESCRIPTION
Fixes meta tensor copy issue in factory.py:418.

## What this does

This PR fixes a `NotImplementedError: Cannot copy out of meta tensor` that occurs when training the SmolVLA policy with `load_vlm_weights=True`.

The error happened because `device_map=device` in [SmolVLMWithExpertModel](cci:2://file:///home/highsky/lerobot/src/lerobot/policies/smolvla/smolvlm_with_expert.py:60:0-555:25) caused `accelerate` to place some parameters on the meta device. LeRobot's factory later attempts to move the entire policy using `.to()`, which fails for meta tensors.

Changes:
- Remove `device_map` parameter from VLM model loading to prevent automatic meta device placement.
- Change `torch_dtype` from string `"bfloat16"` to `torch.bfloat16` object.
- Add explicit `.to(device)` calls after initialization to ensure the model and `lm_expert` are correctly placed on the target device.

This resolves `NotImplementedError` when training SmolVLA policy.

## How it was tested

Tested locally with the LibERO dataset (`libero_10` task).
- Verified that training starts successfully without the meta tensor error.
- Verified that the model loads to CUDA correctly.
- Verified that loss computation works as expected for 10 steps.

## How to checkout & try? (for the reviewer)

```bash
python3 src/lerobot/scripts/lerobot_train.py \
  --policy.type=smolvla \
  --policy.load_vlm_weights=true \
  --policy.device=cuda \
  --dataset.repo_id=HuggingFaceVLA/libero \
  --env.type=libero \
  --env.task=libero_10 \
  --output_dir=./outputs/train/test \
  --steps=10
