### PR TITLE
feat(parallel encoding): making parallel encoding the default choice over all platforms

### DIFF
--- a/src/lerobot/datasets/lerobot_dataset.py
+++ b/src/lerobot/datasets/lerobot_dataset.py
@@ -16,7 +16,6 @@
 import concurrent.futures
 import contextlib
 import logging
-import platform
 import shutil
 import tempfile
 from collections.abc import Callable
@@ -1149,7 +1148,7 @@ class LeRobotDataset(torch.utils.data.Dataset):
     def save_episode(
         self,
         episode_data: dict | None = None,
-        parallel_encoding: bool = platform.system() == "Linux",
+        parallel_encoding: bool = True,
     ) -> None:
         """
         This will save to disk the current episode in self.episode_buffer.


### PR DESCRIPTION
## What this does

This PR removes the previous restriction of parallel encoding to Linux platforms, and makes it the default choice for all platforms. This change is motivated by an observed encoding speedup of ~x1.3 on MacOS while using parallel encoding.
