### PR TITLE
fix(dataset_viz): fix blank Rerun viewer when launched with "--mode distant"

### DIFF
--- a/src/lerobot/scripts/lerobot_dataset_viz.py
+++ b/src/lerobot/scripts/lerobot_dataset_viz.py
@@ -141,7 +141,8 @@ def visualize_dataset(
     gc.collect()
 
     if mode == "distant":
-        rr.serve_web_viewer(open_browser=False, web_port=web_port)
+        server_uri = rr.serve_grpc()
+        rr.serve_web_viewer(web_port=web_port, open_browser=True, connect_to=server_uri)
 
     logging.info("Logging to Rerun")
 


### PR DESCRIPTION
## What this does

This PR fixes an issue where the Rerun viewer would appear blank when launched with the `--mode distant` flag in the `lerobot-dataset-viz` script.

Change the default value for automatically opening the Rerun viewer in the browser from `False` to `True`.

<img width="2291" height="1562" alt="图片" src="https://github.com/user-attachments/assets/29ae8e5c-e38a-4302-97ed-d2e812b52038" />

| Title | Label |
|----------------------|-----------------|
| Fixes #[issue] | (🐛 Bug) |


## How it was tested

I tested it locally on my Ubuntu 22.04 machine using rerun-sdk >= 0.24.0.

```bash
lerobot-dataset-viz --repo-id "lerobot/pusht" --episode-index 0 --mode distant
```
<img width="2257" height="1725" alt="图片" src="https://github.com/user-attachments/assets/b2df53d2-9542-4822-9450-798c1584917e" />


## How to checkout & try? (for the reviewer)

```bash
lerobot-dataset-viz --repo-id "lerobot/pusht" --episode-index 0 --mode distant
```

