### PR TITLE
add lora to smolva

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,13 @@ phone = ["hebi-py>=2.8.0,<2.12.0", "teleop>=0.1.0,<0.2.0", "fastapi<1.0"]
 
 # Policies
 pi = ["transformers @ git+https://github.com/huggingface/transformers.git@fix/lerobot_openpi"]
-smolvla = ["lerobot[transformers-dep]", "num2words>=0.5.14,<0.6.0", "accelerate>=1.7.0,<2.0.0", "safetensors>=0.4.3,<1.0.0"]
+smolvla = [
+    "lerobot[transformers-dep]",
+    "num2words>=0.5.14,<0.6.0",
+    "accelerate>=1.7.0,<2.0.0",
+    "safetensors>=0.4.3,<1.0.0",
+    "peft>=0.13.0,<1.0.0"
+]
 groot = [
     "lerobot[transformers-dep]",
     "peft>=0.13.0,<1.0.0",

--- a/src/lerobot/policies/smolvla/configuration_smolvla.py
+++ b/src/lerobot/policies/smolvla/configuration_smolvla.py
@@ -105,6 +105,14 @@ class SmolVLAConfig(PreTrainedConfig):
 
     # Real-Time Chunking (RTC) configuration
     rtc_config: RTCConfig | None = None
+    
+    # LoRA 
+    lora_r: int = 8
+    lora_alpha: int = 16
+    lora_dropout: float = 0.05
+    lora_target_modules: tuple[str, ...] = ("q_proj", "k_proj", "v_proj", "o_proj")
+    lora_on_vlm: bool = False
+    lora_on_expert: bool = False
 
     def __post_init__(self):
         super().__post_init__()

--- a/src/lerobot/policies/smolvla/modeling_smolvla.py
+++ b/src/lerobot/policies/smolvla/modeling_smolvla.py
@@ -527,6 +527,12 @@ class VLAFlowMatching(nn.Module):
             num_vlm_layers=self.config.num_vlm_layers,
             self_attn_every_n_layers=self.config.self_attn_every_n_layers,
             expert_width_multiplier=self.config.expert_width_multiplier,
+            lora_r=self.config.lora_r,
+            lora_alpha=self.config.lora_alpha,
+            lora_dropout=self.config.lora_dropout,
+            lora_target_modules=self.config.lora_target_modules,
+            lora_on_vlm=self.config.lora_on_vlm,
+            lora_on_expert=self.config.lora_on_expert,
         )
         self.state_proj = nn.Linear(
             self.config.max_state_dim, self.vlm_with_expert.config.text_config.hidden_size


### PR DESCRIPTION
## What this does

Add LoRA to smolvla. Add options to use LoRA on the lm layers and/or on the exert layers

- Added corresponding configs
- Modified the model init function
- Updated the set_requires_grad function
- Use PeFT for easy implementation of LoRA compared to Pi0's implementation (they are using JAX, so had to reimplement LoRA modules themselves). 

Note: There is already this MR: https://github.com/huggingface/lerobot/pull/1411 , however it provides less control over the specific components of the model we want to apply LoRA on. 
For example here, we can choose to use LoRA for the lm layers, but still train the full expert model if we wish. 

## How it was tested

Fine-tuned a model using this LoRA option 

## How to checkout & try? (for the reviewer)

```bash
lerobot-train --lora_on_expert=true
```
