### PR TITLE
fix(scripts): better prints teleop

### DIFF
--- a/src/lerobot/scripts/lerobot_teleoperate.py
+++ b/src/lerobot/scripts/lerobot_teleoperate.py
@@ -170,12 +170,13 @@ def teleop_loop(
             # Display the final robot action that was sent
             for motor, value in robot_action_to_send.items():
                 print(f"{motor:<{display_len}} | {value:>7.2f}")
-            move_cursor_up(len(robot_action_to_send) + 5)
+            move_cursor_up(len(robot_action_to_send) + 3)
 
         dt_s = time.perf_counter() - loop_start
         precise_sleep(1 / fps - dt_s)
         loop_s = time.perf_counter() - loop_start
-        print(f"\ntime: {loop_s * 1e3:.2f}ms ({1 / loop_s:.0f} Hz)")
+        print(f"Teleop loop time: {loop_s * 1e3:.2f}ms ({1 / loop_s:.0f} Hz)")
+        move_cursor_up(1)
 
         if duration is not None and time.perf_counter() - start >= duration:
             return


### PR DESCRIPTION
Before:
```bash
# DISPLAY DATA=TRUE
INFO 2025-11-27 16:18:20 01_leader.py:82 blue SO101Leader connected.
INFO 2025-11-27 16:18:23 a_opencv.py:180 OpenCVCamera(0) connected.
time: 31.59ms (32 Hz):23 follower.py:104 black SO101Follower connected. # <- time in between!

---------------------------
NAME              |    NORM
shoulder_pan.pos  |  -89.66
shoulder_lift.pos |  -99.83
elbow_flex.pos    |   99.91
wrist_flex.pos    |   73.57
wrist_roll.pos    |   69.53
gripper.pos       |    9.46

# DISPLAY DATA=FALSE
INFO 2025-11-27 16:17:55 01_leader.py:82 blue SO101Leader connected.
INFO 2025-11-27 16:17:58 a_opencv.py:180 OpenCVCamera(0) connected.
INFO 2025-11-27 16:17:58 follower.py:104 black SO101Follower connected.

time: 16.67ms (60 Hz)

time: 27.01ms (37 Hz)

time: 32.82ms (30 Hz)  # <- spam!

```

After:
```bash
# DISPLAY DATA=TRUE
INFO 2025-11-27 16:16:53 01_leader.py:82 blue SO101Leader connected.
INFO 2025-11-27 16:16:55 a_opencv.py:180 OpenCVCamera(0) connected.
INFO 2025-11-27 16:16:56 follower.py:104 black SO101Follower connected.
Teleop loop time: 32.64ms (31 Hz) # <- time properly shown
---------------------------
NAME              |    NORM
shoulder_pan.pos  |  -89.66
shoulder_lift.pos |  -99.83
elbow_flex.pos    |   99.91
wrist_flex.pos    |   73.57
wrist_roll.pos    |   69.53
gripper.pos       |    9.46

# DISPLAY DATA=FALSE
INFO 2025-11-27 16:17:29 01_leader.py:82 blue SO101Leader connected.
INFO 2025-11-27 16:17:32 a_opencv.py:180 OpenCVCamera(0) connected.
INFO 2025-11-27 16:17:32 follower.py:104 black SO101Follower connected.
Teleop loop time: 33.02ms (30 Hz) # <- no spam


```