### PR TITLE
fix(dataset): Fix reindexing bug for videos on splits

### DIFF
--- a/src/lerobot/datasets/dataset_tools.py
+++ b/src/lerobot/datasets/dataset_tools.py
@@ -759,9 +759,9 @@ def _copy_and_reindex_videos(
                     src_ep = src_dataset.meta.episodes[old_idx]
                     from_frame = round(src_ep[f"videos/{video_key}/from_timestamp"] * src_dataset.meta.fps)
                     to_frame = round(src_ep[f"videos/{video_key}/to_timestamp"] * src_dataset.meta.fps)
-                    assert (
-                        src_ep["length"] == to_frame - from_frame
-                    ), f"Episode length mismatch: {src_ep['length']} vs {to_frame - from_frame}"
+                    assert src_ep["length"] == to_frame - from_frame, (
+                        f"Episode length mismatch: {src_ep['length']} vs {to_frame - from_frame}"
+                    )
                     episodes_to_keep_ranges.append((from_frame, to_frame))
 
                 # Use PyAV filters to efficiently re-encode only the desired segments.


### PR DESCRIPTION
Sometimes during split operations the frame timestamp floating precision leads to frame ending up in the wrong split.

This changes fixes the issues by directly working with frame indices instead.

Closes #2547.

## How it was tested

I ran the dataset test creation test script before and after the change and verified that the commit indeed fixed the issue.

## How to checkout & try? (for the reviewer)

1. Grab the test script from #2547.
2. Run it before the change -> the script should complain.
3. Run it after the change -> the script sould be happy.