### PR TITLE
Fix `lerobot-find-cameras` hang with Intel IPU6 (MIPI) cameras by forcing V4L2 on Linux

### DIFF
--- a/src/lerobot/cameras/opencv/camera_opencv.py
+++ b/src/lerobot/cameras/opencv/camera_opencv.py
@@ -308,7 +308,7 @@ class OpenCVCamera(Camera):
             targets_to_scan = [int(i) for i in range(MAX_OPENCV_INDEX)]
 
         for target in targets_to_scan:
-            camera = cv2.VideoCapture(target)
+            camera = cv2.VideoCapture(target, get_cv2_backend())
             if camera.isOpened():
                 default_width = int(camera.get(cv2.CAP_PROP_FRAME_WIDTH))
                 default_height = int(camera.get(cv2.CAP_PROP_FRAME_HEIGHT))

--- a/src/lerobot/cameras/utils.py
+++ b/src/lerobot/cameras/utils.py
@@ -72,5 +72,7 @@ def get_cv2_backend() -> int:
         return int(cv2.CAP_MSMF)  # Use MSMF for Windows instead of AVFOUNDATION
     # elif platform.system() == "Darwin":  # macOS
     #     return cv2.CAP_AVFOUNDATION
-    else:  # Linux and others
+    elif platform.system() == "Linux":
+        return int(cv2.CAP_V4L2)
+    else:  # others
         return int(cv2.CAP_ANY)


### PR DESCRIPTION
## What this does

This PR fixes an indefinite hang in `lerobot-find-cameras` on Linux with Intel IPU6 cameras caused by OpenCV selecting the FFmpeg backend for `/dev/video*` paths.
The fix forces the V4L2 backend when probing video devices on Linux while preserving existing behavior elsewhere.

Closes #2594.

## How it was tested

The changes were tested on a Linux laptop equipped with an Intel IPU6 (MIPI) webcam.
- On the `main` branch, `lerobot-find-cameras opencv` hangs indefinitely while probing `/dev/video*`.
- With this patch applied, `lerobot-find-cameras opencv` completes successfully and lists the available camera devices.

## How to checkout & try?

To verify the fix, run:

```bash
lerobot-find-cameras
```

On Linux, Windows, or macOS, and with any supported camera configuration (e.g., MIPI, USB webcam, RealSense), the command should complete without hanging and list all detected cameras.