### PR TITLE
fix(policies): add device back to smolvlm expert

### DIFF
--- a/src/lerobot/policies/smolvla/modeling_smolvla.py
+++ b/src/lerobot/policies/smolvla/modeling_smolvla.py
@@ -527,6 +527,7 @@ class VLAFlowMatching(nn.Module):
             num_vlm_layers=self.config.num_vlm_layers,
             self_attn_every_n_layers=self.config.self_attn_every_n_layers,
             expert_width_multiplier=self.config.expert_width_multiplier,
+            device=self.config.device if self.config.device is not None else "auto",
         )
         self.state_proj = nn.Linear(
             self.config.max_state_dim, self.vlm_with_expert.config.text_config.hidden_size


### PR DESCRIPTION
Fix introduced in: https://github.com/huggingface/lerobot/pull/2270
Wrongly removed in: https://github.com/huggingface/lerobot/pull/1698
Reported in: https://github.com/huggingface/lerobot/pull/2270#issuecomment-3661004741