### PR TITLE
Fixes ReadMe Policies Classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,11 +99,11 @@ lerobot-train \
   --dataset.repo_id=lerobot/aloha_mobile_cabinet
 ```
 
-| Category                   | Models                                                                                                                                                                                          |
-| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Imitation Learning**     | [ACT](./docs/source/policy_act_README.md), [Diffusion](./docs/source/policy_diffusion_README.md), [VQ-BeT](./docs/source/policy_vqbet_README.md) |
-| **Reinforcement Learning** | [HIL-SERL](./docs/source/hilserl.mdx), [TDMPC](./docs/source/policy_tdmpc_README.md) & QC-FQL (coming soon) |
-| **VLAs Models**            | [Pi0.5](./docs/source/pi05.mdx), [GR00T N1.5](./docs/source/policy_groot_README.md), [SmolVLA](./docs/source/policy_smolvla_README.md), [XVLA](./docs/source/xvla.mdx)                          |
+| Category                   | Models                                                                                                                                                                 |
+| -------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Imitation Learning**     | [ACT](./docs/source/policy_act_README.md), [Diffusion](./docs/source/policy_diffusion_README.md), [VQ-BeT](./docs/source/policy_vqbet_README.md)                       |
+| **Reinforcement Learning** | [HIL-SERL](./docs/source/hilserl.mdx), [TDMPC](./docs/source/policy_tdmpc_README.md) & QC-FQL (coming soon)                                                            |
+| **VLAs Models**            | [Pi0.5](./docs/source/pi05.mdx), [GR00T N1.5](./docs/source/policy_groot_README.md), [SmolVLA](./docs/source/policy_smolvla_README.md), [XVLA](./docs/source/xvla.mdx) |
 
 Similarly to the hardware, you can easily implement your own policy & leverage LeRobot's data collection, training, and visualization tools, and share your model to the HF Hub
 


### PR DESCRIPTION
## Title

Fixes ReadMe Policies Classification and small typo

## Type / Scope

- **Type**: Docs, Chore

## Summary / Motivation

(The new readme is fire 🔥) This PR fixes a small typo with the classification of policies supported by the library. In short, 
While both IL and RL involve learning from data, TD-MPC is explicitly defined within the RL framework for the following reasons:

- *Trial-and-Error Interaction*: The paper describes the agent as an RL agent that needs to "iteratively interact and consolidate knowledge about the environment". It collects its own data through online interaction rather than relying on a pre-existing dataset of expert demonstrations.

- *Reward Maximization and Temporal Difference (TD) Learning*: The core objective of the algorithm is to maximize a "discounted return" based on a reward signal received from the environment. Behavioral cloning, by contrast, typically optimizes to match the actions of an expert. Also, as the name suggests, the method uses TD-learning---a fundamental RL technique---to jointly learn its model, value function, and policy.

- *Planning and Search*: TD-MPC uses Model Predictive Control (MPC) to optimize a trajectory of actions ahead of time to achieve desired behavior.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- **NA** [ ] All tests pass locally (`pytest`)
- [x] Documentation updated
- [x] CI is green
