### PR TITLE
fix: Add stabilization delay for OpenCV camera sequential initialization

### DIFF
--- a/src/lerobot/cameras/opencv/camera_opencv.py
+++ b/src/lerobot/cameras/opencv/camera_opencv.py
@@ -171,6 +171,15 @@ class OpenCVCamera(Camera):
 
         self._configure_capture_settings()
 
+        # Give the camera time to initialize after configuration
+        # This helps prevent read failures when multiple cameras are initialized sequentially
+        time.sleep(1.0)
+
+        # Grab a few frames to clear the buffer and ensure camera is ready
+        for i in range(3):
+            self.videocapture.grab()
+            time.sleep(0.1)
+
         if warmup:
             start_time = time.time()
             while time.time() - start_time < self.warmup_s:


### PR DESCRIPTION
## Summary

Fixes an issue where multiple OpenCV cameras fail to initialize when connected sequentially. The second (and subsequent) cameras would fail during the warmup phase with `RuntimeError: OpenCVCamera(X) read failed (status=False)`.

## Problem

When initializing multiple cameras sequentially (e.g., for multi-camera robot setups), the second camera would consistently fail during warmup with a read error. This occurred even though:
- The camera hardware was detected and opened successfully
- The camera worked fine when tested individually
- No other applications were using the camera

## Root Cause

After opening a camera and configuring its settings (resolution, FPS), the camera hardware needs time to stabilize before frame capture begins. When multiple cameras are initialized in quick succession, the second camera doesn't get sufficient time between configuration and the first read attempt.

## Solution

Added two initialization steps after camera configuration:

1. **1-second stabilization delay** - Gives the camera hardware time to fully initialize with the new settings
2. **Initial frame buffer clearing** - Grabs and discards 3 frames to ensure the buffer is primed and ready

These changes ensure the camera is truly ready before warmup reads begin.

## Testing

Tested successfully with:
- 2 cameras: Insta360 Link 2 and Logitech BRIO 
- macOS with MPS device
- SO100 Follower robot setup
- Both cameras now initialize reliably without read failures

## Impact

- Minimal: Adds ~1.3 seconds to camera initialization time
- Only affects the `connect()` method during startup