### PR TITLE
[Optimization] Reduce Rerun memory footprint via automatic image downsampling

### DIFF
--- a/src/lerobot/utils/visualization_utils.py
+++ b/src/lerobot/utils/visualization_utils.py
@@ -58,6 +58,10 @@ def log_rerun_data(
         observation: An optional dictionary containing observation data to log.
         action: An optional dictionary containing action data to log.
     """
+    max_width = os.getenv("LEROBOT_RERUN_MAX_IMAGE_WIDTH")
+    if max_width:
+        max_width = int(max_width)
+
     if observation:
         for k, v in observation.items():
             if v is None:
@@ -75,6 +79,13 @@ def log_rerun_data(
                     for i, vi in enumerate(arr):
                         rr.log(f"{key}_{i}", rr.Scalars(float(vi)))
                 else:
+                    if arr.ndim == 3:
+                        h, w = arr.shape[:2]
+                        if max_width and w > max_width:
+                            import cv2
+                            scale = max_width / w
+                            new_h, new_w = int(h * scale), max_width
+                            arr = cv2.resize(arr, (new_w, new_h), interpolation=cv2.INTER_AREA)
                     rr.log(key, rr.Image(arr), static=True)
 
     if action:


### PR DESCRIPTION
#### **Description:**

This PR optimizes the visualization pipeline by introducing an optional image downsampling mechanism for Rerun.

**The Problem:**
When recording or replaying high-resolution datasets (e.g., 1080p * n), Rerun's default behavior of caching full-resolution frames leads to excessive RAM consumption and system lag, especially during long recording sessions on edge devices.

**The Solution:**
Added a dynamic resizing logic in `log_rerun_data`. If the environment variable `LEROBOT_RERUN_MAX_IMAGE_WIDTH` is set, images sent to Rerun will be downsampled to that width while maintaining the aspect ratio.

**Key Features:**

* **Non-intrusive**: Uses an environment variable to avoid breaking existing API signatures.
* **Efficiency**: Uses `cv2.INTER_AREA` for high-quality downsampling.
* **Preservation**: This optimization **only** affects the Rerun preview; the original high-quality data saved to disk or used for training remains untouched.

#### **Environment Variable:**

* `LEROBOT_RERUN_MAX_IMAGE_WIDTH`: Set the maximum width (e.g., 480 or 640) for images displayed in Rerun.

#### **Testing:**

* Recorded a dataset at 1920x1080.
* With `export LEROBOT_RERUN_MAX_IMAGE_WIDTH=480`: Memory usage remained stable throughout the entire session.