### PR TITLE
skip peft cmd test in cli

### DIFF
--- a/tests/test_cli_peft.py
+++ b/tests/test_cli_peft.py
@@ -10,7 +10,7 @@ from .utils import require_package
 # Skip this entire module in CI
 pytestmark = pytest.mark.skipif(
     os.environ.get("CI") == "true" or os.environ.get("GITHUB_ACTIONS") == "true",
-    reason="This test requires peft and pretrained models, not meant for CI",
+    reason="This test requires peft and is very slow, not meant for CI",
 )
 
 


### PR DESCRIPTION
## Title

Skip the PEFT cmd tests in the ci, as they take too much time

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated
- [x] CI is green

## Reviewer notes

- Anything the reviewer should focus on (performance, edge-cases, specific files) or general notes.
- Anyone in the community is free to review the PR.
