### PR TITLE
chore(deps): bump `wandb` & `protobuf`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ dependencies = [
     "packaging>=24.2,<26.0",
     "pynput>=1.7.7,<1.9.0",
     "pyserial>=3.5,<4.0",
-    "wandb>=0.20.0,<0.22.0", # TODO: Bumb dependency (compatible with protobuf)
+    "wandb>=0.24.0,<0.25.0",
 
     "torch>=2.2.1,<2.8.0", # TODO: Bumb dependency
     "torchcodec>=0.2.1,<0.6.0; sys_platform != 'win32' and (sys_platform != 'linux' or (platform_machine != 'aarch64' and platform_machine != 'arm64' and platform_machine != 'armv7l')) and (sys_platform != 'darwin' or platform_machine != 'x86_64')", # TODO: Bumb dependency
@@ -97,7 +97,7 @@ dependencies = [
 pygame-dep = ["pygame>=2.5.1,<2.7.0"]
 placo-dep = ["placo>=0.9.6,<0.10.0"]
 transformers-dep = ["transformers>=4.57.1,<5.0.0"]
-grpcio-dep = ["grpcio==1.73.1", "protobuf==6.31.0"] # TODO: Bumb dependency (compatible with wandb)
+grpcio-dep = ["grpcio==1.73.1", "protobuf==6.31.1"]
 
 # Motors
 feetech = ["feetech-servo-sdk>=1.0.0,<2.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ dependencies = [
 pygame-dep = ["pygame>=2.5.1,<2.7.0"]
 placo-dep = ["placo>=0.9.6,<0.10.0"]
 transformers-dep = ["transformers>=4.57.1,<5.0.0"]
-grpcio-dep = ["grpcio==1.73.1", "protobuf==6.31.1"]
+grpcio-dep = ["grpcio==1.73.1", "protobuf>=6.31.1,<6.32.0"]
 
 # Motors
 feetech = ["feetech-servo-sdk>=1.0.0,<2.0.0"]


### PR DESCRIPTION
## Title

As reported by both #2797, #2762, (someone opened PR for #2769 but closed).

When navigating to use `wandb login`, prompted API key read will result in this error:

```
bug: API key must be 40 characters long, yours was 86
```

I see that `wandb` was pinned to make sure it's compatible to `grpcio-dep` related feature for `protobuf`:

https://github.com/huggingface/lerobot/blob/15724826dd5b18c18656151a02a24ce5fd690c46/pyproject.toml#L77

https://github.com/huggingface/lerobot/blob/15724826dd5b18c18656151a02a24ce5fd690c46/pyproject.toml#L100

I assume previously this error was thrown:

```
google.protobuf.runtime_version.VersionError: Detected incompatible Protobuf Gencode/Runtime versions when loading wandb/proto/wandb_settings.proto: gencode 6.31.1 runtime 6.31.0. Runtime version cannot be older than the linked gencode version. See Protobuf version guarantees at https://protobuf.dev/support/cross-version-runtime-guarantee.
```

I can confirm that having `wandb` bumpped to `0.24.0` and `protobuf` to `6.31.1` solves the problem.

## Type / Scope

- **Type**: Bug
- **Scope**: None

## Summary / Motivation

Quote from @leledeyuan00:

> Since wandb v0.22.3, it has supported longer API keys.

Verified with 

> API keys longer than 40 characters are now supported. (@jennwandb in https://github.com/wandb/wandb/pull/10688)
>
> cite: https://github.com/wandb/wandb/releases/tag/v0.22.3:

## Related issues

- Fixes / Closes: #2762
- Related: #2797

## What changed

- Bumped `wandb` to `0.24.0`
- Bumped `protobuf` to `6.31.1`

## How was this tested

- Manual checks: 
  - `pixi install`
  - `pixi run uv pip install -e .`
  - `pixi run pip install -e .`
  - `uv sync`
  - `uv pip install -e .`

## How to run locally (reviewer)

- Run the relevant tests:

  ```bash
  wandb login
  ```

- Run a quick example or CLI (if applicable):

  ```bash
  wandb login
  ```

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated
- [x] CI is green

## Reviewer notes

- https://github.com/wandb/wandb/releases/tag/v0.22.3