### PR TITLE
fix(teleop): add is_connected check to get_action

### DIFF
--- a/src/lerobot/teleoperators/bi_so_leader/bi_so_leader.py
+++ b/src/lerobot/teleoperators/bi_so_leader/bi_so_leader.py
@@ -18,6 +18,7 @@ import logging
 from functools import cached_property
 
 from lerobot.teleoperators.so_leader import SOLeaderTeleopConfig
+from lerobot.utils.errors import DeviceNotConnectedError
 
 from ..so_leader import SOLeader
 from ..teleoperator import Teleoperator
@@ -92,6 +93,9 @@ class BiSOLeader(Teleoperator):
         self.right_arm.setup_motors()
 
     def get_action(self) -> dict[str, float]:
+        if not self.is_connected:
+            raise DeviceNotConnectedError(f"{self} is not connected.")
+
         action_dict = {}
 
         # Add "left_" prefix

--- a/src/lerobot/teleoperators/gamepad/teleop_gamepad.py
+++ b/src/lerobot/teleoperators/gamepad/teleop_gamepad.py
@@ -21,6 +21,7 @@ from typing import Any
 import numpy as np
 
 from lerobot.processor import RobotAction
+from lerobot.utils.errors import DeviceNotConnectedError
 
 from ..teleoperator import Teleoperator
 from ..utils import TeleopEvents
@@ -86,6 +87,9 @@ class GamepadTeleop(Teleoperator):
         self.gamepad.start()
 
     def get_action(self) -> RobotAction:
+        if not self.is_connected:
+            raise DeviceNotConnectedError(f"{self} is not connected.")
+
         # Update the controller to get fresh inputs
         self.gamepad.update()
 
@@ -158,6 +162,7 @@ class GamepadTeleop(Teleoperator):
             self.gamepad.stop()
             self.gamepad = None
 
+    @property
     def is_connected(self) -> bool:
         """Check if gamepad is connected."""
         return self.gamepad is not None

--- a/src/lerobot/teleoperators/homunculus/homunculus_arm.py
+++ b/src/lerobot/teleoperators/homunculus/homunculus_arm.py
@@ -300,6 +300,9 @@ class HomunculusArm(Teleoperator):
                 logger.debug(f"Error reading frame in background thread for {self}: {e}")
 
     def get_action(self) -> dict[str, float]:
+        if not self.is_connected:
+            raise DeviceNotConnectedError(f"{self} is not connected.")
+
         joint_positions = self._read()
         return {f"{joint}.pos": pos for joint, pos in joint_positions.items()}
 

--- a/src/lerobot/teleoperators/homunculus/homunculus_glove.py
+++ b/src/lerobot/teleoperators/homunculus/homunculus_glove.py
@@ -326,6 +326,9 @@ class HomunculusGlove(Teleoperator):
                 logger.debug(f"Error reading frame in background thread for {self}: {e}")
 
     def get_action(self) -> dict[str, float]:
+        if not self.is_connected:
+            raise DeviceNotConnectedError(f"{self} is not connected.")
+
         joint_positions = self._read()
         return homunculus_glove_to_hope_jr_hand(
             {f"{joint}.pos": pos for joint, pos in joint_positions.items()}

--- a/src/lerobot/teleoperators/phone/teleop_phone.py
+++ b/src/lerobot/teleoperators/phone/teleop_phone.py
@@ -165,6 +165,9 @@ class IOSPhone(BasePhone, Teleoperator):
         return True, pos, rot, pose
 
     def get_action(self) -> dict:
+        if not self.is_connected:
+            raise DeviceNotConnectedError(f"{self} is not connected.")
+
         has_pose, raw_position, raw_rotation, fb_pose = self._read_current_pose()
         if not has_pose or not self.is_calibrated:
             return {}
@@ -319,6 +322,9 @@ class AndroidPhone(BasePhone, Teleoperator):
             self._latest_message = message
 
     def get_action(self) -> dict:
+        if not self.is_connected:
+            raise DeviceNotConnectedError(f"{self} is not connected.")
+
         ok, raw_pos, raw_rot, pose = self._read_current_pose()
         if not ok or not self.is_calibrated:
             return {}

--- a/src/lerobot/teleoperators/so_leader/so_leader.py
+++ b/src/lerobot/teleoperators/so_leader/so_leader.py
@@ -140,6 +140,9 @@ class SOLeader(Teleoperator):
             print(f"'{motor}' motor id set to {self.bus.motors[motor].id}")
 
     def get_action(self) -> dict[str, float]:
+        if not self.is_connected:
+            raise DeviceNotConnectedError(f"{self} is not connected.")
+
         start = time.perf_counter()
         action = self.bus.sync_read("Present_Position")
         action = {f"{motor}.pos": val for motor, val in action.items()}


### PR DESCRIPTION
## Type / Scope

- **Type**: Bug
- **Scope**: Teleoperators

## Summary / Motivation

- Adds defensive check for `get_action` method.

## Related issues

- Fixes / Closes: N/A
- Related: N/A

## What changed

- All teleoperators implementations now check first if it's connected before trying to get the actions.

## How was this tested

- `pytest -vv tests/`

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated
- [x] CI is green

## Reviewer notes

- Similar PR might be good for other methods, but for now I only targeted `get_action` for consistency.
