### PR TITLE
Add small context to the envHub doc page

### DIFF
--- a/docs/source/envhub.mdx
+++ b/docs/source/envhub.mdx
@@ -19,7 +19,7 @@ This design means you can go from discovering an interesting environment on the 
 
 When you create an EnvHub package, you can build anything you want inside it and use any simulation tool you like: this is your own space to play with. The only requirement is that the package contains an `env.py` file that defines the environment and allows LeRobot to load and use your EnvHub package.
 
-This `env.py` file needs to expose a small API so LeRobot can load and run it. In particular, you must provide a `make_env(n_envs: int, use_async_envs: bool)` function, which is the main entry point for LeRobot. It should return one of:
+This `env.py` file needs to expose a small API so LeRobot can load and run it. In particular, you must provide a `make_env(n_envs: int = 1, use_async_envs: bool = False)` or `make_env(n_envs: int = 1, use_async_envs: bool = False, cfg: EnvConfig)` function, which is the main entry point for LeRobot. It should return one of:
 
 - A `gym.vector.VectorEnv` (most common)
 - A single `gym.Env` (will be automatically wrapped)


### PR DESCRIPTION
## envHub doc page

I Just added some more context into the envHub doc page that I would allow me to understand it faster.

## Type / Scope

- **Type**: Docs
- **Scope**: envHub

## Summary / Motivation

I started using this feature and improved the doc

## Related issues

- Fixes / Closes: # (if any)
- Related: # (if any)

## What changed

- the begin of the doc page

## How was this tested (or how to run locally)

It doesn't break anything on the code side, it's just doc

## Checklist (required before merge)

- [ ] Linting/formatting run (`pre-commit run -a`)
- [ ] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [ ] CI is green