### PR TITLE
chore(ci): deactivates cron job on unbound dep tests

### DIFF
--- a/.github/workflows/unbound_deps_tests.yml
+++ b/.github/workflows/unbound_deps_tests.yml
@@ -20,8 +20,8 @@ on:
   workflow_dispatch:
 
   # Run on the 1st and 15th of every month at 09:00 UTC
-  schedule:
-    - cron: '0 2 1,15 * *'
+  # schedule:
+  #  - cron: '0 2 1,15 * *'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Type / Scope

- **Type**: CI
- **Scope**: Github actions

## Summary / Motivation

- We know that for now this fails as multiple dependencies would break if bumped. Instead of running this every 15days, we run it only manually via the GH trigger.

## Related issues

- Fixes / Closes: N/A
- Related: N/A

## What changed

- No unbound test job will be run automatically

## How was this tested (or how to run locally)

- N/A

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated
- [x] CI is green

## Reviewer notes

- We can check the result of the previous runs here: https://github.com/huggingface/lerobot/actions/workflows/unbound_deps_tests.yml
