### PR TITLE
Fix Libero Env reset logic for correct scene initialization

### DIFF
--- a/src/lerobot/envs/libero.py
+++ b/src/lerobot/envs/libero.py
@@ -293,9 +293,9 @@ class LiberoEnv(gym.Env):
     def reset(self, seed=None, **kwargs):
         super().reset(seed=seed)
         self._env.seed(seed)
-        if self.init_states and self._init_states is not None:
-            self._env.set_init_state(self._init_states[self._init_state_id])
         raw_obs = self._env.reset()
+        if self.init_states and self._init_states is not None:
+            raw_obs = self._env.set_init_state(self._init_states[self._init_state_id])
 
         # After reset, objects may be unstable (slightly floating, intersecting, etc.).
         # Step the simulator with a no-op action for a few frames so everything settles.


### PR DESCRIPTION
## Title

Short, imperative summary (e.g., "fix(robots): handle None in sensor parser"). See [CONTRIBUTING.md](../CONTRIBUTING.md) for PR conventions.
Summary / Motivation

This PR fixes the environment reset procedure when using fixed initial states (init_states). Previously, the wrapper called set_init_state(...) before env.reset(), which can be overwritten by the reset call and lead to non-deterministic or incorrect starting states. The updated behavior follows the official LIBERO usage pattern by applying the init state after calling reset(), ensuring reproducibility for benchmarking and consistent resets. See https://github.com/Lifelong-Robot-Learning/LIBERO/blob/8f1084e3132a39270c3a13ebe37270a43ece2a01/README.md?plain=1#L126 for the correct logic from the original Libero repo.

What changed

Updated reset() logic so that when init_states is enabled, the environment initial state is applied after self._env.reset().

**Before** (Libero Spatial 25 initial scenes)
<img width="960" height="959" alt="스크린샷 2026-01-19 021659" src="https://github.com/user-attachments/assets/a8fcdbef-67d8-4562-bd46-135ab8bf9df3" />

**After** (Libero Spatial 25 initial scenes)
<img width="961" height="961" alt="스크린샷 2026-01-19 021921" src="https://github.com/user-attachments/assets/e78016b3-b024-4ca6-9ea3-496615602dfc" />


Aligned behavior with LIBERO’s official example (seed → reset → set_init_state → wait a few frames). The latter is aligned with the training dataset. 

No breaking API changes (behavioral fix only).