### PR TITLE
fix(discord link): fixing discord link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ You can contribute in many ways:
 - **Documentation:** Improve examples, guides, and docstrings.
 - **Feedback:** Submit tickets related to bugs or desired new features.
 
-If you are unsure where to start, join our [Discord Channel](https://discord.gg/JkrYNdmw).
+If you are unsure where to start, join our [Discord Channel](https://discord.gg/q8Dzzpym3f).
 
 ## Development Setup
 


### PR DESCRIPTION
## Title

This PR fixes the link to LeRobot Discord channel in CONTRIBUTING.md. It was copy-pasted from README.md.

## Type / Scope

- **Type**: Chore
- **Scope**: N/A