### PR TITLE
feat(robots): add context managers

### DIFF
--- a/src/lerobot/robots/robot.py
+++ b/src/lerobot/robots/robot.py
@@ -58,6 +58,32 @@ class Robot(abc.ABC):
     def __str__(self) -> str:
         return f"{self.id} {self.__class__.__name__}"
 
+    def __enter__(self):
+        """
+        Context manager entry.
+        Automatically connects to the camera.
+        """
+        self.connect()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        """
+        Context manager exit.
+        Automatically disconnects, ensuring resources are released even on error.
+        """
+        self.disconnect()
+
+    def __del__(self) -> None:
+        """
+        Destructor safety net.
+        Attempts to disconnect if the object is garbage collected without cleanup.
+        """
+        try:
+            if self.is_connected:
+                self.disconnect()
+        except Exception:  # nosec B110
+            pass
+
     # TODO(aliberts): create a proper Feature class for this that links with datasets
     @property
     @abc.abstractmethod

--- a/src/lerobot/teleoperators/teleoperator.py
+++ b/src/lerobot/teleoperators/teleoperator.py
@@ -58,6 +58,32 @@ class Teleoperator(abc.ABC):
     def __str__(self) -> str:
         return f"{self.id} {self.__class__.__name__}"
 
+    def __enter__(self):
+        """
+        Context manager entry.
+        Automatically connects to the camera.
+        """
+        self.connect()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        """
+        Context manager exit.
+        Automatically disconnects, ensuring resources are released even on error.
+        """
+        self.disconnect()
+
+    def __del__(self) -> None:
+        """
+        Destructor safety net.
+        Attempts to disconnect if the object is garbage collected without cleanup.
+        """
+        try:
+            if self.is_connected:
+                self.disconnect()
+        except Exception:  # nosec B110
+            pass
+
     @property
     @abc.abstractmethod
     def action_features(self) -> dict:


### PR DESCRIPTION
## Type / Scope

- **Type**: Feature
- **Scope**: Robots

## Summary / Motivation

- Add context managers to the `Robot` and `Teleop` class. This will allow us to use `with SOFollower(..) as ...:` when convenient, specially useful to guarantee the `disconnect()` attempt when shutting down.

## Related issues

- Fixes / Closes: N/A
- Related: N/A

## What changed

- New methods to the base classes

## How was this tested (or how to run locally)

- `pytest -vv tests/`

## Checklist (required before merge)

- [ ] Linting/formatting run (`pre-commit run -a`)
- [ ] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [ ] CI is green

## Reviewer notes

- For now I didn't implement it anywhere because I think we handle already the shut-down cases in the most important parts. I will open a PR in the future for updating the examples, but ideally that would be after the cameras PR
