### PR TITLE
fix(libero): advance init state index across resets during evaluation

### DIFF
--- a/src/lerobot/scripts/lerobot_eval.py
+++ b/src/lerobot/scripts/lerobot_eval.py
@@ -78,6 +78,7 @@ from lerobot.envs.utils import (
     close_envs,
     preprocess_observation,
 )
+from lerobot.envs.libero import LiberoEnv
 from lerobot.policies.factory import make_policy, make_pre_post_processors
 from lerobot.policies.pretrained import PreTrainedPolicy
 from lerobot.processor import PolicyAction, PolicyProcessorPipeline
@@ -139,6 +140,8 @@ def rollout(
     # Reset the policy and environments.
     policy.reset()
     observation, info = env.reset(seed=seeds)
+    if isinstance(env.envs[0], LiberoEnv):
+        env.envs[0]._init_state_id += 1
     if render_callback is not None:
         render_callback(env)
 


### PR DESCRIPTION
## Title
fix(libero): advance init state index across resets during evaluation

## Type / Scope

Type: Bug
Scope: lerobot_eval.py (LIBERO evaluation)

## Summary / Motivation

While evaluating LIBERO with init_states=True, LiberoEnv.reset() selects the initial state via:

raw_obs = self._env.set_init_state(self._init_states[self._init_state_id])

However, I observed that _init_state_id never increments across episodes, so every reset repeatedly uses init_state_id=0. This effectively removes initial-state diversity and can bias evaluation results (all episodes start from the same state).

This PR fixes the issue by incrementing _init_state_id after each reset when the underlying environment is LiberoEnv, ensuring subsequent episodes start from different initial states.

## Related issues

- Fixes / Closes: # (if any)
- Related: # (if any)

## What changed

Added the following logic in lerobot_eval.py after env.reset(seed=seeds):

observation, info = env.reset(seed=seeds)
if isinstance(env.envs[0], LiberoEnv):
    env.envs[0]._init_state_id += 1

Behavior change: when init_states=True for LIBERO eval, the initial state index now advances across episodes instead of staying fixed at 0.

## How was this tested (or how to run locally)
python3 lerobot/src/lerobot/scripts/lerobot_eval.py \
  --env.type=libero \
  --env.task=libero_spatial \
  --eval.n_episodes=20 \
  --eval.batch_size=1 \

Manual verification:
Ran LIBERO evaluation with init_states=True for multiple episodes.
Before: every episode reset started from the same initial state (_init_state_id remained 0).
After: _init_state_id advances across resets, and episodes start from different initial states.


## Checklist (required before merge)

- [ ] Linting/formatting run (`pre-commit run -a`)
- [ ] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [ ] CI is green
