### PR TITLE
feat(envs): Add task ids to libero env cfg

### DIFF
--- a/src/lerobot/envs/configs.py
+++ b/src/lerobot/envs/configs.py
@@ -260,6 +260,7 @@ class HILSerlRobotEnvConfig(EnvConfig):
 @dataclass
 class LiberoEnv(EnvConfig):
     task: str = "libero_10"  # can also choose libero_spatial, libero_object, etc.
+    task_ids: list[int] | None = None
     fps: int = 30
     episode_length: int | None = None
     obs_type: str = "pixels_agent_pos"
@@ -338,10 +339,10 @@ class LiberoEnv(EnvConfig):
 
     @property
     def gym_kwargs(self) -> dict:
-        return {
-            "obs_type": self.obs_type,
-            "render_mode": self.render_mode,
-        }
+        kwargs: dict[str, Any] = {"obs_type": self.obs_type, "render_mode": self.render_mode}
+        if self.task_ids is not None:
+            kwargs["task_ids"] = self.task_ids
+        return kwargs
 
 
 @EnvConfig.register_subclass("metaworld")


### PR DESCRIPTION
## Type / Scope

- **Type**: Feature
- **Scope**: Envs

## Summary / Motivation

- This add support for setting the task ids of libero envs in the env config. This functionality already exists in the underlying env creation but isn't exposed in the config. Having this allows you to just run a subset of tasks instead of being forced to run all them for every libero suite

## Related issues

- Fixes / Closes: 
- Related:

## What changed

- `task_ids` attribute added to `LiberoEnv` config class

## How was this tested (or how to run locally)
  ```bash
  pytest -sv tests/
  ```
  ```bash
 lerobot-eval --policy.path="HuggingFaceVLA/smolvla_libero" --env.type=libero --env.task=libero_object --env.task_ids=[0] --eval.batch_size=1 --eval.n_episodes=1
  ```

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [ ] CI is green

## Reviewer notes
N/A
