### PR TITLE
Small docstring fix in diffusion configuration

### DIFF
--- a/src/lerobot/policies/diffusion/configuration_diffusion.py
+++ b/src/lerobot/policies/diffusion/configuration_diffusion.py
@@ -73,7 +73,7 @@ class DiffusionConfig(PreTrainedConfig):
         use_group_norm: Whether to replace batch normalization with group normalization in the backbone.
             The group sizes are set to be about 16 (to be precise, feature_dim // 16).
         spatial_softmax_num_keypoints: Number of keypoints for SpatialSoftmax.
-        use_separate_rgb_encoders_per_camera: Whether to use a separate RGB encoder for each camera view.
+        use_separate_rgb_encoder_per_camera: Whether to use a separate RGB encoder for each camera view.
         down_dims: Feature dimension for each stage of temporal downsampling in the diffusion modeling Unet.
             You may provide a variable number of dimensions, therefore also controlling the degree of
             downsampling.


### PR DESCRIPTION
## Title
Fix docstring of use_separate_rgb_encoder_per_camera for diffusion policy implementation (there was an extra s)

## Type / Scope

- **Type**:  Docs
- **Scope**: diffusion

## Summary / Motivation

- Fix docstring of use_separate_rgb_encoder_per_camera for diffusion policy implementation (there was an extra s)

## Related issues

- Fixes / Closes: # (if any)
- Related: # (if any)

## What changed

- Fix docstring of use_separate_rgb_encoder_per_camera for diffusion policy implementation (there was an extra s)

## How was this tested (or how to run locally)

- Tests added: list new tests or test files.
- Manual checks / dataset runs performed.
- Instructions for the reviewer

Example:

- Ran the relevant tests:

  ```bash
  pytest -q tests/ -k <keyword>
  ```

- Reproduce with a quick example or CLI (if applicable):

  ```bash
  lerobot-train --some.option=true
  ```

## Checklist (required before merge)

- [ x ] Linting/formatting run (`pre-commit run -a`)
- [ x ] All tests pass locally (`pytest`)
- [ x ] Documentation updated
- [ x ] CI is green

## Reviewer notes

- Anything the reviewer should focus on (performance, edge-cases, specific files) or general notes.
- Anyone in the community is free to review the PR.
