### PR TITLE
Fix dataset visualization issues for behavior1k and other datasets

### DIFF
--- a/src/lerobot/datasets/utils.py
+++ b/src/lerobot/datasets/utils.py
@@ -131,6 +131,9 @@ def load_nested_dataset(
         table = arrow_dataset.to_table(filter=filter_expr)
 
         if features is not None:
+            # Reorder columns to match schema field order before casting
+            schema_field_names = features.arrow_schema.names
+            table = table.select(schema_field_names)
             table = table.cast(features.arrow_schema)
 
         return Dataset(table)

--- a/src/lerobot/scripts/lerobot_dataset_viz.py
+++ b/src/lerobot/scripts/lerobot_dataset_viz.py
@@ -133,7 +133,7 @@ def visualize_dataset(
     for batch in tqdm.tqdm(dataloader, total=len(dataloader)):
         # iterate over the batch
         for i in range(len(batch["index"])):
-            rr.set_time("frame_index", sequence=batch["frame_index"][i].item())
+            rr.set_time("frame_index", sequence=batch["index"][i].item())
             rr.set_time("timestamp", timestamp=batch["timestamp"][i].item())
 
             # display each camera image


### PR DESCRIPTION
This fixes two issues that prevented visualization of certain datasets like lerobot/behavior1k-task*:

1. Fixed PyArrow schema field ordering mismatch
   - PyArrow's cast() requires field names in exact order
   - Added column reordering before casting in load_nested_dataset()
   - Fixes ValueError: "Target schema's field names are not matching"

2. Fixed KeyError: 'frame_index' in visualization script
   - Changed batch["frame_index"] to batch["index"]
   - The dataset uses "index" field, not "frame_index"
   - Line 135 already correctly uses batch["index"]

Tested with: lerobot/behavior1k-task0000

## Title

Short, imperative summary (e.g., "fix(robots): handle None in sensor parser"). See [CONTRIBUTING.md](../CONTRIBUTING.md) for PR conventions.

## Type / Scope

- **Type**: (Bug | Feature | Docs | Performance | Test | CI | Chore)
- **Scope**: (optional — name of module or package affected)

## Summary / Motivation

- One-paragraph description of what changes and why.
- Why this change is needed and any trade-offs or design notes.

## Related issues

- Fixes / Closes: # (if any)
- Related: # (if any)

## What changed

- Short, concrete bullets of the modifications (files/behaviour).
- Short note if this introduces breaking changes and migration steps.

## How was this tested (or how to run locally)

- Tests added: list new tests or test files.
- Manual checks / dataset runs performed.
- Instructions for the reviewer

Example:

- Ran the relevant tests:

  ```bash
  pytest -q tests/ -k <keyword>
  ```

- Reproduce with a quick example or CLI (if applicable):

  ```bash
  lerobot-train --some.option=true
  ```

## Checklist (required before merge)

- [ ] Linting/formatting run (`pre-commit run -a`)
- [ ] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [ ] CI is green

## Reviewer notes

- Anything the reviewer should focus on (performance, edge-cases, specific files) or general notes.
- Anyone in the community is free to review the PR.
