### PR TITLE
Fix formatting of no new line before code block

### DIFF
--- a/docs/source/il_robots.mdx
+++ b/docs/source/il_robots.mdx
@@ -44,6 +44,7 @@ Note that the `id` associated with a robot is used to store the calibration file
 
 <hfoptions id="teleoperate_so101">
 <hfoption id="Command">
+
 ```bash
 lerobot-teleoperate \
     --robot.type=so101_follower \
@@ -100,6 +101,7 @@ With `rerun`, you can teleoperate again while simultaneously visualizing the cam
 
 <hfoptions id="teleoperate_koch_camera">
 <hfoption id="Command">
+
 ```bash
 lerobot-teleoperate \
     --robot.type=koch_follower \
@@ -392,6 +394,7 @@ You can replay the first episode on your robot with either the command below or 
 
 <hfoptions id="replay">
 <hfoption id="Command">
+
 ```bash
 lerobot-replay \
     --robot.type=so101_follower \
@@ -506,6 +509,7 @@ You can use the `record` script from [`lerobot-record`](https://github.com/huggi
 
 <hfoptions id="eval">
 <hfoption id="Command">
+
 ```bash
 lerobot-record  \
   --robot.type=so100_follower \


### PR DESCRIPTION
## Fix formatting of no new line before code block

This fix a GitHub formatting issue thatt code block requires a new line to be displayed properly