### PR TITLE
feat(envs): add lazy initialization for multi-task environments

### DIFF
--- a/src/lerobot/envs/libero.py
+++ b/src/lerobot/envs/libero.py
@@ -395,6 +395,7 @@ def create_libero_envs(
     env_cls: Callable[[Sequence[Callable[[], Any]]], Any] | None = None,
     control_mode: str = "relative",
     episode_length: int | None = None,
+    lazy: bool = False,
 ) -> dict[str, dict[int, Any]]:
     """
     Create vectorized LIBERO environments with a consistent return shape.
@@ -445,7 +446,7 @@ def create_libero_envs(
                 gym_kwargs=gym_kwargs,
                 control_mode=control_mode,
             )
-            out[suite_name][tid] = env_cls(fns)
+            out[suite_name][tid] = partial(env_cls, fns) if lazy else env_cls(fns)
             print(f"Built vec env | suite={suite_name} | task_id={tid} | n_envs={n_envs}")
 
     # return plain dicts for predictability

--- a/src/lerobot/envs/metaworld.py
+++ b/src/lerobot/envs/metaworld.py
@@ -16,6 +16,7 @@
 import json
 from collections import defaultdict
 from collections.abc import Callable, Sequence
+from functools import partial
 from pathlib import Path
 from typing import Any
 
@@ -274,6 +275,7 @@ def create_metaworld_envs(
     n_envs: int,
     gym_kwargs: dict[str, Any] | None = None,
     env_cls: Callable[[Sequence[Callable[[], Any]]], Any] | None = None,
+    lazy: bool = False,
 ) -> dict[str, dict[int, Any]]:
     """
     Create vectorized Meta-World environments with a consistent return shape.
@@ -309,7 +311,7 @@ def create_metaworld_envs(
             # build n_envs factories
             fns = [(lambda tn=task_name: MetaworldEnv(task=tn, **gym_kwargs)) for _ in range(n_envs)]
 
-            out[group][tid] = env_cls(fns)
+            out[group][tid] = partial(env_cls, fns) if lazy else env_cls(fns)
 
     # return a plain dict for consistency
     return {group: dict(task_map) for group, task_map in out.items()}

--- a/src/lerobot/scripts/lerobot_eval.py
+++ b/src/lerobot/scripts/lerobot_eval.py
@@ -166,7 +166,6 @@ def rollout(
             all_observations.append(deepcopy(observation))
 
         # Infer "task" from attributes of environments.
-        # TODO: works with SyncVectorEnv but not AsyncVectorEnv
         observation = add_envs_task(env, observation)
 
         # Apply environment-specific preprocessing (e.g., LiberoProcessorStep for LIBERO)
@@ -520,6 +519,7 @@ def eval_main(cfg: EvalPipelineConfig):
         cfg.env,
         n_envs=cfg.eval.batch_size,
         use_async_envs=cfg.eval.use_async_envs,
+        lazy=True,
         trust_remote_code=cfg.trust_remote_code,
     )
 
@@ -657,9 +657,10 @@ def run_one(
         task_videos_dir = videos_dir / f"{task_group}_{task_id}"
         task_videos_dir.mkdir(parents=True, exist_ok=True)
 
+    vec_env = env() if callable(env) else env
     # Call the existing eval_one (assumed to return TaskMetrics-like dict)
     metrics = eval_one(
-        env,
+        vec_env,
         policy=policy,
         env_preprocessor=env_preprocessor,
         env_postprocessor=env_postprocessor,


### PR DESCRIPTION
## feat(envs): add lazy initialization for multi-task environments

feat(envs): add lazy initialization for multi-task environments(../CONTRIBUTING.md) for PR conventions.

## Type / Scope

- **Type**: Feature/Performance/Bug
- **Scope**: lerobot-evaluate (libero/metaword)

## Summary / Motivation

This PR adds an opt-in “lazy” mode for multi-task environment creation so evaluation can defer instantiating (potentially many) vectorized envs until they’re actually evaluated. It also changes the process creation to use "spawn" since "fork" caused issues with Mujoco

Before this modifications running `lerobot-eval` with  `eval.use_async_envs=true` would cause the evaluation to fail.
Moreover, adding `eval.batch_size=10` with a full suite of tasks `libero_object,libero_goal,libero_10,libero_spatial` would pre-allocate all of the ennvironments on the GPU (10*40) quickly running out of memory. 

## Related issues

- Fixes / Closes: # (if any)
- Related: # (if any)

## What changed

**Environment Creation and Lazy Instantiation:**

- Added a `lazy` parameter to `make_env`, `create_libero_envs`, and `create_metaworld_envs` to optionally defer environment instantiation. When `lazy=True`, these functions return callables that create vectorized environments on demand, which helps manage resource usage during evaluation.

- Updated the environment class selection logic in `make_env` to use `functools.partial` for `AsyncVectorEnv` with the "spawn" context, ensuring safe process creation.

**Environment Utility Improvements:**

- Updated utility functions to use `env.call("has_wrapper_attr", ...)` for attribute checks, improving compatibility with both synchronous and asynchronous vectorized environments.

**Bug Fixes:**

**Other Minor Improvements:**

## How was this tested (or how to run locally)

running `lerobot-eval.py --config_path=eval_pi05_libero.yaml`

with 
```yaml
# eval_pi05_libero.yaml
output_dir: data/eval_logs/
seed: 0
env:
  type: libero
  task: libero_object,libero_goal,libero_10,libero_spatial
  max_parallel_tasks: 1
eval:
  batch_size: 10
  n_episodes: 10
  use_async_envs: true
policy:
  type: pi05
  pretrained_path: lerobot/pi05_libero_finetuned
  n_action_steps: 10
  device: "cuda:0"
```

the evaluation takes around 35 min on one L40s and the final success rates are comparable to the one reported here: https://huggingface.co/docs/lerobot/libero. Comparing the first frame of different videos I verified that given a task the initial state of each rollout changes.

## Checklist (required before merge)

- [ ] Linting/formatting run (`pre-commit run -a`)
- [ ] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [ ] CI is green

## Reviewer notes

- Anything the reviewer should focus on (performance, edge-cases, specific files) or general notes.
- Anyone in the community is free to review the PR.
