### PR TITLE
fix(teleoperators): enable mypy strict type checking

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -368,9 +368,9 @@ ignore_errors = false
 # module = "lerobot.robots.*"
 # ignore_errors = false
 
-# [[tool.mypy.overrides]]
-# module = "lerobot.teleoperators.*"
-# ignore_errors = false
+[[tool.mypy.overrides]]
+module = "lerobot.teleoperators.*"
+ignore_errors = false
 
 # [[tool.mypy.overrides]]
 # module = "lerobot.policies.*"

--- a/src/lerobot/teleoperators/keyboard/teleop_keyboard.py
+++ b/src/lerobot/teleoperators/keyboard/teleop_keyboard.py
@@ -61,17 +61,17 @@ class KeyboardTeleop(Teleoperator):
         self.config = config
         self.robot_type = config.type
 
-        self.event_queue = Queue()
-        self.current_pressed = {}
-        self.listener = None
-        self.logs = {}
+        self.event_queue: Queue[tuple[str, bool]] = Queue()
+        self.current_pressed: dict[str, bool] = {}
+        self.listener: Any = None
+        self.logs: dict[str, float] = {}
 
     @property
     def action_features(self) -> dict:
         return {
             "dtype": "float32",
-            "shape": (len(self.arm),),
-            "names": {"motors": list(self.arm.motors)},
+            "shape": (len(self.arm),),  # type: ignore[attr-defined]  # set by subclass/config
+            "names": {"motors": list(self.arm.motors)},  # type: ignore[attr-defined]  # set by subclass/config
         }
 
     @property
@@ -84,11 +84,11 @@ class KeyboardTeleop(Teleoperator):
 
     @property
     def is_calibrated(self) -> bool:
-        pass
+        return True
 
     @check_if_already_connected
-    def connect(self) -> None:
-        if PYNPUT_AVAILABLE:
+    def connect(self, calibrate: bool = True) -> None:
+        if PYNPUT_AVAILABLE and keyboard is not None:
             logging.info("pynput is available - enabling local keyboard listener.")
             self.listener = keyboard.Listener(
                 on_press=self._on_press,
@@ -154,7 +154,7 @@ class KeyboardEndEffectorTeleop(KeyboardTeleop):
     def __init__(self, config: KeyboardEndEffectorTeleopConfig):
         super().__init__(config)
         self.config = config
-        self.misc_keys_queue = Queue()
+        self.misc_keys_queue: Queue[object] = Queue()
 
     @property
     def action_features(self) -> dict:

--- a/src/lerobot/teleoperators/reachy2_teleoperator/reachy2_teleoperator.py
+++ b/src/lerobot/teleoperators/reachy2_teleoperator/reachy2_teleoperator.py
@@ -152,6 +152,7 @@ class Reachy2Teleoperator(Teleoperator):
         joint_action: dict[str, float] = {}
         vel_action: dict[str, float] = {}
 
+        assert self.reachy is not None
         if self.config.use_present_position:
             joint_action = {k: self.reachy.joints[v].present_position for k, v in self.joints_dict.items()}
         else:
@@ -172,5 +173,5 @@ class Reachy2Teleoperator(Teleoperator):
         raise NotImplementedError
 
     def disconnect(self) -> None:
-        if self.is_connected:
+        if self.is_connected and self.reachy is not None:
             self.reachy.disconnect()

--- a/src/lerobot/teleoperators/unitree_g1/exo_calib.py
+++ b/src/lerobot/teleoperators/unitree_g1/exo_calib.py
@@ -242,11 +242,11 @@ def run_exo_calibration(
     bg1 = fig.canvas.copy_from_bbox(ax1.bbox)
 
     # State
-    joints_out = []
+    joints_out: list[dict] = []
     joint_idx = 0
     phase = "ellipse"
     advance_requested = False
-    zero_samples = []
+    zero_samples: list[float] = []
 
     def on_key(event):
         nonlocal advance_requested
@@ -293,7 +293,8 @@ def run_exo_calibration(
                     }
                 )
                 logger.info(f"  -> Ellipse saved for {name}")
-                phase, zero_samples, advance_requested = "zero_pose", [], False
+                phase, advance_requested = "zero_pose", False
+                zero_samples.clear()
                 fig.canvas.manager.set_window_title(f"[{joint_idx + 1}/{len(joint_list)}] {name} - ZERO POSE")
                 ax0.set_title(f"{name} - hold zero pose")
                 fig.canvas.draw()
@@ -444,3 +445,5 @@ def run_exo_calibration(
 
     finally:
         plt.close(fig)
+
+    raise RuntimeError("Calibration window was closed before completing all joints.")

--- a/src/lerobot/teleoperators/unitree_g1/exo_ik.py
+++ b/src/lerobot/teleoperators/unitree_g1/exo_ik.py
@@ -22,6 +22,7 @@ visualizing the result in meshcat after calibration.
 import logging
 import os
 from dataclasses import dataclass
+from typing import Any
 
 import numpy as np
 
@@ -136,11 +137,11 @@ class ExoskeletonIKHelper:
             ),
         ]
 
-        self.exo = {}  # side -> pin.RobotWrapper
-        self.q_exo = {}  # side -> q
-        self.ee_id_exo = {}  # side -> frame id
-        self.qmap = {}  # side -> {joint_name: q_idx}
-        self.ee_id_g1 = {}  # side -> frame id
+        self.exo: dict[str, Any] = {}  # side -> pin.RobotWrapper
+        self.q_exo: dict[str, Any] = {}  # side -> q
+        self.ee_id_exo: dict[str, int] = {}  # side -> frame id
+        self.qmap: dict[str, dict[str, int]] = {}  # side -> {joint_name: q_idx}
+        self.ee_id_g1: dict[str, int | None] = {}  # side -> frame id
 
         self._load_exo_models(assets_dir)
         for a in self.arms:
@@ -149,7 +150,7 @@ class ExoskeletonIKHelper:
         self.viewer = None
         self.markers: Markers | None = None
         self.viz_g1 = None
-        self.viz_exo = {}  # side -> viz
+        self.viz_exo: dict[str, Any] = {}  # side -> viz
 
     def _frozen_joint_indices(self) -> dict[str, int]:
         out = {}

--- a/src/lerobot/teleoperators/unitree_g1/unitree_g1.py
+++ b/src/lerobot/teleoperators/unitree_g1/unitree_g1.py
@@ -117,6 +117,7 @@ class UnitreeG1Teleoperator(Teleoperator):
     def get_action(self) -> dict[str, float]:
         left_angles = self.left_arm.get_angles()
         right_angles = self.right_arm.get_angles()
+        assert self.ik_helper is not None
         return self.ik_helper.compute_g1_joints_from_exo(left_angles, right_angles)
 
     def send_feedback(self, feedback: dict[str, float]) -> None:

--- a/src/lerobot/teleoperators/utils.py
+++ b/src/lerobot/teleoperators/utils.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
     from .teleoperator import Teleoperator
 
 
-class TeleopEvents(Enum):
+class TeleopEvents(str, Enum):
     """Shared constants for teleoperator events across teleoperators."""
 
     SUCCESS = "success"


### PR DESCRIPTION
## Summary
- Enables mypy for `lerobot.teleoperators.*` by uncommenting the override in `pyproject.toml`
- Fixes all 72 type errors across 10 files
- Makes `TeleopEvents` a `str` enum so it works as dict keys typed `dict[str, ...]`
- Adds type annotations, assert guards, and fixes method signatures to match base class

Closes #1726

## Approach
Follows the same patterns established in the `optim` module:
- Python 3.10+ union syntax (`str | None`)
- `assert` guards for type narrowing
- `Any` type for dynamically-imported objects (GamepadController, pinocchio wrappers)
- `# type: ignore` with explanatory comments where stubs are missing

## Test plan
- [x] `mypy src/lerobot/teleoperators/ --config-file pyproject.toml` passes with 0 errors
- [x] All pre-commit hooks pass (ruff, bandit, mypy, etc.)
- [ ] Existing test suite passes (`pytest`) — covered by CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)