### PR TITLE
fix(cameras): fix mypy type errors in cameras module

### DIFF
--- a/src/lerobot/cameras/zmq/image_server.py
+++ b/src/lerobot/cameras/zmq/image_server.py
@@ -39,7 +39,7 @@ logger = logging.getLogger(__name__)
 def encode_image(image: np.ndarray, quality: int = 80) -> str:
     """Encode RGB image to base64 JPEG string."""
     _, buffer = cv2.imencode(".jpg", image, [int(cv2.IMWRITE_JPEG_QUALITY), quality])
-    return base64.b64encode(buffer).decode("utf-8")
+    return base64.b64encode(bytes(buffer)).decode("utf-8")
 
 
 class ImageServer:


### PR DESCRIPTION
## Summary
- Fixes 5 mypy type errors in the cameras module (already had `ignore_errors = false` enabled)
- Converts `CAP_PROP_FPS` float to int, converts `Path` to `str` for `VideoCapture`
- Wraps numpy buffer in `bytes()` for `b64encode` compatibility
- Adds explicit type declarations for `width`, `height`, `capture_width`, `capture_height`

Closes #1724

## Approach
- `int()` conversion for `CAP_PROP_FPS` (returns float but `fps` is `int | None`)
- `str()` conversion for `Path` to satisfy `cv2.VideoCapture` which expects `int | str`
- `bytes()` wrapper for numpy buffer to satisfy `b64encode` type expectation
- `# type: ignore[attr-defined]` for `cv2.VideoWriter_fourcc` (missing from opencv stubs)

## Test plan
- [x] `mypy src/lerobot/cameras/ --config-file pyproject.toml` passes with 0 errors
- [x] All pre-commit hooks pass
- [ ] Existing test suite passes (`pytest`) — covered by CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)