### PR TITLE
Enable mypy for processor module (#1725)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -348,9 +348,9 @@ ignore_errors = false
 module = "lerobot.model.*"
 ignore_errors = false
 
-# [[tool.mypy.overrides]]
-# module = "lerobot.processor.*"
-# ignore_errors = false
+[[tool.mypy.overrides]]
+module = "lerobot.processor.*"
+ignore_errors = false
 
 # [[tool.mypy.overrides]]
 # module = "lerobot.datasets.*"

--- a/src/lerobot/processor/converters.py
+++ b/src/lerobot/processor/converters.py
@@ -77,7 +77,7 @@ def _(
     # Check for numpy scalars (0-dimensional arrays) and treat them as scalars.
     if value.ndim == 0:
         # Numpy scalars should be converted to 0-dimensional tensors.
-        scalar_value = value.item()
+        scalar_value: int | float = value.item()
         return torch.tensor(scalar_value, dtype=dtype, device=device)
 
     # Create tensor from numpy array.
@@ -287,7 +287,9 @@ def transition_to_robot_action(transition: EnvTransition) -> RobotAction:
     action = transition.get(TransitionKey.ACTION)
     if not isinstance(action, dict):
         raise ValueError(f"Action should be a RobotAction type (dict) got {type(action)}")
-    return transition.get(TransitionKey.ACTION)
+    result = transition.get(TransitionKey.ACTION)
+    assert isinstance(result, dict)
+    return result
 
 
 def transition_to_policy_action(transition: EnvTransition) -> PolicyAction:
@@ -298,7 +300,7 @@ def transition_to_policy_action(transition: EnvTransition) -> PolicyAction:
         raise ValueError(f"Transition should be a EnvTransition type (dict) got {type(transition)}")
 
     action = transition.get(TransitionKey.ACTION)
-    if not isinstance(action, PolicyAction):
+    if not isinstance(action, torch.Tensor):
         raise ValueError(f"Action should be a PolicyAction type got {type(action)}")
     return action
 
@@ -320,7 +322,7 @@ def policy_action_to_transition(action: PolicyAction) -> EnvTransition:
     """
     Convert a `PolicyAction` to an `EnvTransition`.
     """
-    if not isinstance(action, PolicyAction):
+    if not isinstance(action, torch.Tensor):
         raise ValueError(f"Action should be a PolicyAction type got {type(action)}")
     return create_transition(action=action)
 
@@ -347,7 +349,7 @@ def batch_to_transition(batch: dict[str, Any]) -> EnvTransition:
         raise ValueError(f"EnvTransition must be a dictionary. Got {type(batch).__name__}")
 
     action = batch.get(ACTION)
-    if action is not None and not isinstance(action, PolicyAction):
+    if action is not None and not isinstance(action, torch.Tensor):
         raise ValueError(f"Action should be a PolicyAction type got {type(action)}")
 
     # Extract observation and complementary data keys.

--- a/src/lerobot/processor/core.py
+++ b/src/lerobot/processor/core.py
@@ -17,7 +17,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any, TypeAlias, TypedDict
+from typing import Any, TypeAlias
 
 import numpy as np
 import torch
@@ -41,16 +41,7 @@ RobotAction: TypeAlias = dict[str, Any]
 EnvAction: TypeAlias = np.ndarray
 RobotObservation: TypeAlias = dict[str, Any]
 
-
-EnvTransition = TypedDict(
-    "EnvTransition",
-    {
-        TransitionKey.OBSERVATION.value: RobotObservation | None,
-        TransitionKey.ACTION.value: PolicyAction | RobotAction | EnvAction | None,
-        TransitionKey.REWARD.value: float | torch.Tensor | None,
-        TransitionKey.DONE.value: bool | torch.Tensor | None,
-        TransitionKey.TRUNCATED.value: bool | torch.Tensor | None,
-        TransitionKey.INFO.value: dict[str, Any] | None,
-        TransitionKey.COMPLEMENTARY_DATA.value: dict[str, Any] | None,
-    },
-)
+# EnvTransition represents a single environment step with observation, action, reward, etc.
+# Using a plain dict alias instead of TypedDict because TransitionKey enum values
+# are used as dynamic keys throughout, which TypedDict cannot express.
+EnvTransition: TypeAlias = dict[str, Any]

--- a/src/lerobot/processor/delta_action_processor.py
+++ b/src/lerobot/processor/delta_action_processor.py
@@ -16,6 +16,8 @@
 
 from dataclasses import dataclass
 
+import torch
+
 from lerobot.configs.types import FeatureType, PipelineFeatureType, PolicyFeature
 
 from .core import PolicyAction, RobotAction
@@ -40,7 +42,7 @@ class MapTensorToDeltaActionDictStep(ActionProcessorStep):
     use_gripper: bool = True
 
     def action(self, action: PolicyAction) -> RobotAction:
-        if not isinstance(action, PolicyAction):
+        if not isinstance(action, torch.Tensor):
             raise ValueError("Only PolicyAction is supported for this processor")
 
         if action.dim() > 1:

--- a/src/lerobot/processor/device_processor.py
+++ b/src/lerobot/processor/device_processor.py
@@ -27,7 +27,7 @@ import torch
 from lerobot.configs.types import PipelineFeatureType, PolicyFeature
 from lerobot.utils.utils import get_safe_torch_device
 
-from .core import EnvTransition, PolicyAction, TransitionKey
+from .core import EnvTransition, TransitionKey
 from .pipeline import ProcessorStep, ProcessorStepRegistry
 
 
@@ -135,7 +135,7 @@ class DeviceProcessorStep(ProcessorStep):
         new_transition = transition.copy()
         action = new_transition.get(TransitionKey.ACTION)
 
-        if action is not None and not isinstance(action, PolicyAction):
+        if action is not None and not isinstance(action, torch.Tensor):
             raise ValueError(f"If action is not None should be a PolicyAction type got {type(action)}")
 
         simple_tensor_keys = [

--- a/src/lerobot/processor/gym_action_processor.py
+++ b/src/lerobot/processor/gym_action_processor.py
@@ -16,6 +16,9 @@
 
 from dataclasses import dataclass
 
+import numpy as np
+import torch
+
 from lerobot.configs.types import PipelineFeatureType, PolicyFeature
 
 from .converters import to_tensor
@@ -41,7 +44,7 @@ class Torch2NumpyActionProcessorStep(ActionProcessorStep):
     squeeze_batch_dim: bool = True
 
     def action(self, action: PolicyAction) -> EnvAction:
-        if not isinstance(action, PolicyAction):
+        if not isinstance(action, torch.Tensor):
             raise TypeError(
                 f"Expected PolicyAction or None, got {type(action).__name__}. "
                 "Use appropriate processor for non-tensor actions."
@@ -81,7 +84,7 @@ class Numpy2TorchActionProcessorStep(ProcessorStep):
 
         action = new_transition.get(TransitionKey.ACTION)
         if action is not None:
-            if not isinstance(action, EnvAction):
+            if not isinstance(action, np.ndarray):
                 raise TypeError(
                     f"Expected np.ndarray or None, got {type(action).__name__}. "
                     "Use appropriate processor for non-tensor actions."

--- a/src/lerobot/processor/migrate_policy_normalization.py
+++ b/src/lerobot/processor/migrate_policy_normalization.py
@@ -78,7 +78,7 @@ def extract_normalization_stats(state_dict: dict[str, torch.Tensor]) -> dict[str
         'observation.state') and inner keys are statistic types ('mean', 'std'),
         mapping to their corresponding tensor values.
     """
-    stats = {}
+    stats: dict[str, dict[str, torch.Tensor]] = {}
 
     # Define patterns to match and their prefixes to remove
     normalization_patterns = [

--- a/src/lerobot/processor/normalize_processor.py
+++ b/src/lerobot/processor/normalize_processor.py
@@ -29,7 +29,7 @@ from lerobot.datasets.lerobot_dataset import LeRobotDataset
 from lerobot.utils.constants import ACTION
 
 from .converters import from_tensor_to_numpy, to_tensor
-from .core import EnvTransition, PolicyAction, TransitionKey
+from .core import EnvTransition, TransitionKey
 from .pipeline import PolicyProcessorPipeline, ProcessorStep, ProcessorStepRegistry, RobotObservation
 
 
@@ -458,7 +458,7 @@ class NormalizerProcessorStep(_NormalizationMixin, ProcessorStep):
         if action is None:
             return new_transition
 
-        if not isinstance(action, PolicyAction):
+        if not isinstance(action, torch.Tensor):
             raise ValueError(f"Action should be a PolicyAction type got {type(action)}")
 
         new_transition[TransitionKey.ACTION] = self._normalize_action(action, inverse=False)
@@ -519,7 +519,7 @@ class UnnormalizerProcessorStep(_NormalizationMixin, ProcessorStep):
 
         if action is None:
             return new_transition
-        if not isinstance(action, PolicyAction):
+        if not isinstance(action, torch.Tensor):
             raise ValueError(f"Action should be a PolicyAction type got {type(action)}")
 
         new_transition[TransitionKey.ACTION] = self._normalize_action(action, inverse=True)

--- a/src/lerobot/processor/pipeline.py
+++ b/src/lerobot/processor/pipeline.py
@@ -93,7 +93,7 @@ class ProcessorStepRegistry:
 
             cls._registry[registration_name] = step_class
             # Store the registration name on the class for easy lookup during serialization.
-            step_class._registry_name = registration_name
+            step_class._registry_name = registration_name  # type: ignore[attr-defined]  # dynamic registry attribute
             return step_class
 
         return decorator
@@ -1546,7 +1546,7 @@ class PolicyActionProcessorStep(ProcessorStep, ABC):
         new_transition = self._current_transition
 
         action = new_transition.get(TransitionKey.ACTION)
-        if not isinstance(action, PolicyAction):
+        if not isinstance(action, torch.Tensor):
             raise ValueError(f"Action should be a PolicyAction type (tensor), but got {type(action)}")
 
         processed_action = self.action(action)

--- a/src/lerobot/processor/policy_robot_bridge.py
+++ b/src/lerobot/processor/policy_robot_bridge.py
@@ -20,7 +20,7 @@ from typing import Any
 import torch
 
 from lerobot.configs.types import FeatureType, PipelineFeatureType, PolicyFeature
-from lerobot.processor import ActionProcessorStep, PolicyAction, ProcessorStepRegistry, RobotAction
+from lerobot.processor import ActionProcessorStep, EnvAction, PolicyAction, ProcessorStepRegistry, RobotAction
 from lerobot.utils.constants import ACTION
 
 
@@ -31,7 +31,7 @@ class RobotActionToPolicyActionProcessorStep(ActionProcessorStep):
 
     motor_names: list[str]
 
-    def action(self, action: RobotAction) -> PolicyAction:
+    def action(self, action: PolicyAction | RobotAction | EnvAction) -> PolicyAction:
         if len(self.motor_names) != len(action):
             raise ValueError(f"Action must have {len(self.motor_names)} elements, got {len(action)}")
         return torch.tensor([action[f"{name}.pos"] for name in self.motor_names])

--- a/src/lerobot/processor/tokenizer_processor.py
+++ b/src/lerobot/processor/tokenizer_processor.py
@@ -547,7 +547,7 @@ class ActionTokenizerProcessorStep(ActionProcessorStep):
         Returns:
             A dictionary with the processor's configuration parameters.
         """
-        config = {
+        config: dict[str, Any] = {
             "trust_remote_code": self.trust_remote_code,
             "max_action_tokens": self.max_action_tokens,
         }


### PR DESCRIPTION
## Summary
- Enables the `lerobot.processor.*` mypy override in `pyproject.toml` and fixes all type checking errors across 12 files
- Changes `EnvTransition` from `TypedDict` to a plain `dict[str, Any]` TypeAlias since `TransitionKey` enum values cannot be used as TypedDict string literal keys
- Replaces `isinstance()` checks against TypeAlias types (`PolicyAction`, `EnvAction`) with their concrete runtime types (`torch.Tensor`, `np.ndarray`)
- Fixes `env_processor.py` to use the correct `PipelineFeatureType.OBSERVATION` (instead of nonexistent `.STATE`) and valid `PolicyFeature` constructor args
- Adds missing type annotations, uses `HasTeleopEvents` protocol instead of unbound TypeVar, and widens `policy_robot_bridge` action param to satisfy Liskov substitution

Closes #1725

## Test plan
- [x] `mypy src/lerobot/processor/ --config-file pyproject.toml` passes with 0 errors
- [x] `pre-commit run --all-files` passes all hooks (ruff, mypy, bandit, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)