### PR TITLE
Fix from_pretrained losing converter functions

### DIFF
--- a/src/lerobot/processor/converters.py
+++ b/src/lerobot/processor/converters.py
@@ -16,7 +16,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from functools import singledispatch
 from typing import Any
 
@@ -414,3 +414,34 @@ def identity_transition(transition: EnvTransition) -> EnvTransition:
         The same `EnvTransition`.
     """
     return transition
+
+
+CONVERTER_REGISTRY: dict[str, Callable] = {
+    "batch_to_transition": batch_to_transition,
+    "transition_to_batch": transition_to_batch,
+    "policy_action_to_transition": policy_action_to_transition,
+    "transition_to_policy_action": transition_to_policy_action,
+    "robot_action_to_transition": robot_action_to_transition,
+    "transition_to_robot_action": transition_to_robot_action,
+    "observation_to_transition": observation_to_transition,
+    "transition_to_observation": transition_to_observation,
+    "robot_action_observation_to_transition": robot_action_observation_to_transition,
+    "identity_transition": identity_transition,
+}
+
+
+def get_converter(name: str) -> Callable:
+    """Look up a converter function by name.
+
+    Args:
+        name: The function name to look up.
+
+    Returns:
+        The converter function.
+
+    Raises:
+        ValueError: If the name is not found in the registry.
+    """
+    if name not in CONVERTER_REGISTRY:
+        raise ValueError(f"Unknown converter '{name}'. Available: {list(CONVERTER_REGISTRY.keys())}")
+    return CONVERTER_REGISTRY[name]


### PR DESCRIPTION
## Summary
- Fixes #2702: `from_pretrained` was silently dropping custom converter functions (`to_transition`/`to_output`), always falling back to `batch_to_transition`/`transition_to_batch` defaults, breaking all 13+ policy postprocessors
- Adds a `CONVERTER_REGISTRY` in `converters.py` that maps function names to function objects
- `_save_pretrained` now serializes converter function names into the config JSON
- `from_pretrained` resolves saved names via the registry, with graceful fallback to defaults for backward compatibility

## Test plan
- [x] New test: `test_from_pretrained_restores_registered_converters` — roundtrips a pipeline with `policy_action_to_transition` and verifies the converter is restored
- [x] New test: `test_from_pretrained_backward_compat_no_converter_keys` — old configs without converter keys fall back to defaults
- [x] New test: `test_from_pretrained_explicit_override_takes_priority` — explicitly passed converters override saved values
- [x] All 68 existing + new tests pass
- [x] Pre-commit checks pass (ruff, mypy, bandit, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)