### PR TITLE
fix(windows): preserve forward slashes in HF Hub repo IDs for policy.path

### DIFF
--- a/src/lerobot/configs/eval.py
+++ b/src/lerobot/configs/eval.py
@@ -47,7 +47,7 @@ class EvalPipelineConfig:
         if policy_path:
             cli_overrides = parser.get_cli_overrides("policy")
             self.policy = PreTrainedConfig.from_pretrained(policy_path, cli_overrides=cli_overrides)
-            self.policy.pretrained_path = Path(policy_path)
+            self.policy.pretrained_path = policy_path
 
         else:
             logger.warning(

--- a/src/lerobot/configs/policies.py
+++ b/src/lerobot/configs/policies.py
@@ -78,7 +78,7 @@ class PreTrainedConfig(draccus.ChoiceRegistry, HubMixin, abc.ABC):  # type: igno
     license: str | None = None
     # Either the repo ID of a model hosted on the Hub or a path to a directory containing weights
     # saved using `Policy.save_pretrained`. If not provided, the policy is initialized from scratch.
-    pretrained_path: Path | None = None
+    pretrained_path: str | Path | None = None
 
     def __post_init__(self) -> None:
         if not self.device or not is_torch_device_available(self.device):

--- a/src/lerobot/configs/train.py
+++ b/src/lerobot/configs/train.py
@@ -85,7 +85,7 @@ class TrainPipelineConfig(HubMixin):
             # Only load the policy config
             cli_overrides = parser.get_cli_overrides("policy")
             self.policy = PreTrainedConfig.from_pretrained(policy_path, cli_overrides=cli_overrides)
-            self.policy.pretrained_path = Path(policy_path)
+            self.policy.pretrained_path = policy_path
         elif self.resume:
             # The entire train config is already loaded, we just need to get the checkpoint dir
             config_path = parser.parse_arg("config_path")


### PR DESCRIPTION
## What this PR does / why we need it

**Type:** Bug fix
**Scope:** Configs (train, eval, policies)

### Summary
Fixes `--policy.path` failing on Windows when using HuggingFace Hub repo IDs (e.g., `lerobot/smolvla_base`).

### Related Issues
Fixes #2552

### What changed

On Windows, `Path("lerobot/smolvla_base")` converts the forward slash to a backslash, producing `lerobot\smolvla_base`. When this is passed to `huggingface_hub` functions, it fails validation:

```
huggingface_hub.errors.HFValidationError: Repo id must use alphanumeric chars or '-', '_', '.',
'--' and '..' are forbidden, '-' and '.' cannot start or end the name, max length is 96:
'lerobot\smolvla_base'.
```

The root cause is in `TrainPipelineConfig.validate()` and `EvalPipelineConfig.__post_init__()`, which wrap the CLI-provided policy path in `Path()`. Since this value can be either a Hub repo ID or a local filesystem path, wrapping it in `Path()` corrupts Hub repo IDs on Windows.

**Changes:**
- `configs/policies.py`: Widen `pretrained_path` type from `Path | None` to `str | Path | None`
- `configs/train.py`: Remove `Path()` wrapping when assigning `pretrained_path` from CLI
- `configs/eval.py`: Same fix

This is consistent with how `lerobot_record.py` (line 222) already handles the same value — it assigns the raw string without `Path()` wrapping.

Local path usage (e.g., `--resume`) is unaffected, as those code paths assign `Path` objects directly from resolved directories.

### How it was tested

Validated on Windows 11 that:
- `str(Path("lerobot/smolvla_base"))` → `"lerobot\smolvla_base"` (rejected by HF Hub)
- `"lerobot/smolvla_base"` preserves forward slashes (accepted by HF Hub)
- All pre-commit checks pass (ruff, mypy, bandit, typos)

### Checklist
- [x] My PR is minimal and addresses only the stated issue
- [x] I have run `pre-commit run --all-files` (passes)
- [x] Related issue linked (#2552)
- [x] Self-reviewed