### PR TITLE
Fixing metadata indexing when writing new Parquet file

### DIFF
--- a/src/lerobot/datasets/v30/convert_dataset_v21_to_v30.py
+++ b/src/lerobot/datasets/v30/convert_dataset_v21_to_v30.py
@@ -201,7 +201,6 @@ def convert_data(root: Path, new_root: Path, data_file_size_in_mb: int):
 
     image_keys = get_image_keys(root)
 
-    ep_idx = 0
     chunk_idx = 0
     file_idx = 0
     size_in_mb = 0
@@ -211,7 +210,7 @@ def convert_data(root: Path, new_root: Path, data_file_size_in_mb: int):
 
     logging.info(f"Converting data files from {len(ep_paths)} episodes")
 
-    for ep_path in tqdm.tqdm(ep_paths, desc="convert data files"):
+    for ep_idx, ep_path in enumerate(tqdm.tqdm(ep_paths, desc="convert data files")):
         ep_size_in_mb = get_parquet_file_size_in_mb(ep_path)
         ep_num_frames = get_parquet_num_frames(ep_path)
 
@@ -240,7 +239,6 @@ def convert_data(root: Path, new_root: Path, data_file_size_in_mb: int):
         num_frames += ep_num_frames
         episodes_metadata.append(ep_metadata)
         paths_to_cat.append(ep_path)
-        ep_idx += 1
 
     # Write remaining data if any
     if paths_to_cat:


### PR DESCRIPTION
## Fixing metadata indexing when writing new Parquet file during V2.1 to v3.0 Conversion

## Type / Scope

- **Type**: Bug
- **Scope**:  convert_dataset_v21_to_v30

## Summary / Motivation

  - addressing this issue: https://github.com/huggingface/lerobot/issues/2401
  - vibe-coded bugfix by Claude Sonnet 4.5
  - this bug breaks downstream tooling

## Related issues

- Fixes / Closes: # 2401
- Related: 

## What changed

- Code now tests if a new Parquet file should be created ahead of writing the indexing metadata
- Fixed bug in writing the `chunk index` and `file index` to ../meta/episodes parquet, such that it now correctly addresses the ../data/chunk-NNN/file-MMM.parquet file (and also fixed video file addressing)
- Removed post-hoc code that tries to fix things up for video

## How was this tested (or how to run locally)

TBD ...

- Tests added: list new tests or test files.
- Manual checks / dataset runs performed.
- Instructions for the reviewer

Example:

- Ran the relevant tests:

  ```bash
  pytest -q tests/ -k <keyword>
  ```

- Reproduce with a quick example or CLI (if applicable):

  ```bash
  lerobot-train --some.option=true
  ```

## Checklist (required before merge)

- [ ] Linting/formatting run (`pre-commit run -a`)
- [ ] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [ ] CI is green

## Reviewer notes

- Anything the reviewer should focus on (performance, edge-cases, specific files) or general notes.
- Anyone in the community is free to review the PR.
