### PR TITLE
fix(datasets): preserve feature fps metadata in merge/split/delete

### DIFF
--- a/src/lerobot/datasets/lerobot_dataset.py
+++ b/src/lerobot/datasets/lerobot_dataset.py
@@ -516,7 +516,7 @@ class LeRobotDatasetMetadata:
 
         obj.root.mkdir(parents=True, exist_ok=False)
 
-        features = {**features, **DEFAULT_FEATURES}
+        features = {**DEFAULT_FEATURES, **features}
         _validate_feature_names(features)
 
         obj.tasks = None

--- a/tests/datasets/test_dataset_tools.py
+++ b/tests/datasets/test_dataset_tools.py
@@ -1321,3 +1321,84 @@ def test_convert_image_to_video_dataset_subset_episodes(tmp_path):
 
         if output_dir.exists():
             shutil.rmtree(output_dir)
+
+
+def test_delete_episodes_preserves_feature_fps(sample_dataset, tmp_path):
+    """Test that fps metadata on features is preserved after deleting episodes.
+
+    Regression test for https://github.com/huggingface/lerobot/issues/2679
+    Datasets from the Hub have an 'fps' key on each non-video feature. Operations
+    like delete_episodes, split_dataset, and merge_datasets call
+    LeRobotDatasetMetadata.create(), which must not strip this key.
+    """
+    # Simulate a Hub dataset by adding fps to all features (as Hub datasets have)
+    fps_value = sample_dataset.meta.fps
+    for key in sample_dataset.meta.features:
+        if sample_dataset.meta.features[key]["dtype"] not in ("image", "video"):
+            sample_dataset.meta.features[key]["fps"] = fps_value
+            sample_dataset.meta.info["features"][key]["fps"] = fps_value
+
+    output_dir = tmp_path / "filtered"
+
+    with (
+        patch("lerobot.datasets.lerobot_dataset.get_safe_version") as mock_get_safe_version,
+        patch("lerobot.datasets.lerobot_dataset.snapshot_download") as mock_snapshot_download,
+    ):
+        mock_get_safe_version.return_value = "v3.0"
+        mock_snapshot_download.return_value = str(output_dir)
+
+        new_dataset = delete_episodes(
+            sample_dataset,
+            episode_indices=[0],
+            output_dir=output_dir,
+        )
+
+    # Verify fps is preserved on scalar features
+    default_feature_keys = ["timestamp", "frame_index", "episode_index", "index", "task_index"]
+    for key in default_feature_keys:
+        assert "fps" in new_dataset.meta.features[key], (
+            f"Feature '{key}' lost its 'fps' metadata after delete_episodes"
+        )
+        assert new_dataset.meta.features[key]["fps"] == fps_value
+
+
+def test_split_dataset_preserves_feature_fps(sample_dataset, tmp_path):
+    """Test that fps metadata on features is preserved after splitting.
+
+    Regression test for https://github.com/huggingface/lerobot/issues/2679
+    """
+    fps_value = sample_dataset.meta.fps
+    for key in sample_dataset.meta.features:
+        if sample_dataset.meta.features[key]["dtype"] not in ("image", "video"):
+            sample_dataset.meta.features[key]["fps"] = fps_value
+            sample_dataset.meta.info["features"][key]["fps"] = fps_value
+
+    splits = {"train": [0, 1, 2], "val": [3, 4]}
+
+    with (
+        patch("lerobot.datasets.lerobot_dataset.get_safe_version") as mock_get_safe_version,
+        patch("lerobot.datasets.lerobot_dataset.snapshot_download") as mock_snapshot_download,
+    ):
+        mock_get_safe_version.return_value = "v3.0"
+
+        def mock_snapshot(repo_id, **kwargs):
+            for split_name in splits:
+                if split_name in repo_id:
+                    return str(tmp_path / f"{sample_dataset.repo_id}_{split_name}")
+            return str(kwargs.get("local_dir", tmp_path))
+
+        mock_snapshot_download.side_effect = mock_snapshot
+
+        result = split_dataset(
+            sample_dataset,
+            splits=splits,
+            output_dir=tmp_path,
+        )
+
+    default_feature_keys = ["timestamp", "frame_index", "episode_index", "index", "task_index"]
+    for split_ds in result.values():
+        for key in default_feature_keys:
+            assert "fps" in split_ds.meta.features[key], (
+                f"Feature '{key}' lost its 'fps' metadata after split_dataset"
+            )
+            assert split_ds.meta.features[key]["fps"] == fps_value


### PR DESCRIPTION
## Title

Fix `merge_datasets`, `split_dataset`, and `delete_episodes` silently stripping `fps` from scalar features

## Type / Scope

- **Type**: bug fix
- **Scope**: datasets

## Summary / Motivation

Datasets from the Hub include an `fps` key on each non-video feature (e.g. `{'dtype': 'float32', 'shape': (1,), 'names': None, 'fps': 10}`). When these datasets are processed through `merge_datasets`, `split_dataset`, or `delete_episodes`, the `fps` metadata is silently stripped from scalar features like `timestamp`, `frame_index`, `episode_index`, `index`, and `task_index`.

This causes feature mismatches when trying to add additional datasets to a merged output, since the original datasets have `fps` but the merged one doesn't.

## Related issues

- Fixes #2679

## What changed

- **`src/lerobot/datasets/lerobot_dataset.py`**: In `LeRobotDatasetMetadata.create()`, swapped the dict merge order from `{**features, **DEFAULT_FEATURES}` to `{**DEFAULT_FEATURES, **features}`. This ensures input features (which may contain extra metadata like `fps`) take precedence, while `DEFAULT_FEATURES` still provides defaults for any missing keys.
- **`tests/datasets/test_dataset_tools.py`**: Added two regression tests verifying that `fps` metadata survives `delete_episodes` and `split_dataset` operations.

### Root cause

`DEFAULT_FEATURES` defines the five scalar features without an `fps` key:

```python
DEFAULT_FEATURES = {
    "timestamp": {"dtype": "float32", "shape": (1,), "names": None},
    "frame_index": {"dtype": "int64", "shape": (1,), "names": None},
    ...
}
```

The original merge `{**features, **DEFAULT_FEATURES}` meant `DEFAULT_FEATURES` always overwrote the input — stripping any extra keys like `fps`.

## How was this tested

- Added `test_delete_episodes_preserves_feature_fps` — simulates a Hub dataset with `fps` on features, runs `delete_episodes`, verifies `fps` is preserved
- Added `test_split_dataset_preserves_feature_fps` — same for `split_dataset`
- All 52 existing tests in `test_dataset_tools.py` continue to pass

```
52 passed in 67.60s
```

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [x] CI is green