### PR TITLE
fix(datasets): preserve feature fps metadata in merge/split/delete operations

### DIFF
--- a/src/lerobot/datasets/lerobot_dataset.py
+++ b/src/lerobot/datasets/lerobot_dataset.py
@@ -516,7 +516,7 @@ class LeRobotDatasetMetadata:
 
         obj.root.mkdir(parents=True, exist_ok=False)
 
-        features = {**features, **DEFAULT_FEATURES}
+        features = {**DEFAULT_FEATURES, **features}
         _validate_feature_names(features)
 
         obj.tasks = None


### PR DESCRIPTION
## Title

Fix `merge_datasets`, `split_dataset`, and `delete_episodes` silently stripping `fps` from scalar features

## Type / Scope

- **Type**: bug fix
- **Scope**: datasets

## Summary / Motivation

Datasets from the Hub include an `fps` key on each non-video feature (e.g. `{'dtype': 'float32', 'shape': (1,), 'names': None, 'fps': 10}`). When these datasets are processed through `merge_datasets`, `split_dataset`, or `delete_episodes`, the `fps` metadata is silently stripped from scalar features like `timestamp`, `frame_index`, `episode_index`, `index`, and `task_index`.

This causes feature mismatches when trying to add additional datasets to a merged output, since the original datasets have `fps` but the merged one doesn't.

## Related issues

- Fixes #2679
- Supersedes #2953 (closed — tests were flawed, see below)

## What changed

### Code fix

- **`src/lerobot/datasets/lerobot_dataset.py`**: In `LeRobotDatasetMetadata.create()`, swapped the dict merge order from `{**features, **DEFAULT_FEATURES}` to `{**DEFAULT_FEATURES, **features}`. This ensures input features (which may contain extra metadata like `fps`) take precedence, while `DEFAULT_FEATURES` still provides defaults for any missing keys.

### Root cause

`DEFAULT_FEATURES` defines the five scalar features without an `fps` key:

```python
DEFAULT_FEATURES = {
    "timestamp": {"dtype": "float32", "shape": (1,), "names": None},
    "frame_index": {"dtype": "int64", "shape": (1,), "names": None},
    ...
}
```

The original merge `{**features, **DEFAULT_FEATURES}` meant `DEFAULT_FEATURES` always overwrote the input — stripping any extra keys like `fps`.

### Why the tests in #2953 were wrong

The previous PR's tests passed without the fix due to a subtle shared-reference bug:

1. `LeRobotDatasetMetadata.create()` does `features = {**features, **DEFAULT_FEATURES}` — the resulting dict's values for keys like `"timestamp"` are the **same dict objects** as `DEFAULT_FEATURES["timestamp"]`
2. The test then mutated `sample_dataset.meta.features["timestamp"]["fps"] = 30` **in-place**
3. Since `sample_dataset.meta.features["timestamp"]` IS `DEFAULT_FEATURES["timestamp"]` (same object), this **mutated `DEFAULT_FEATURES` itself**
4. When `delete_episodes()` called `create()` again, `DEFAULT_FEATURES` already had `fps` on it, so the buggy merge preserved it

The fix: use `copy.deepcopy()` before mutation to break the shared reference. With this corrected approach, `DEFAULT_FEATURES` stays clean and the buggy merge order properly strips `fps` — making the tests fail without the fix as expected.

## How was this tested

- `test_delete_episodes_preserves_feature_fps` — simulates a Hub dataset with `fps` on features, runs `delete_episodes`, verifies `fps` is preserved
- `test_split_dataset_preserves_feature_fps` — same for `split_dataset`

**Verified:**
- Without the fix (`{**features, **DEFAULT_FEATURES}`): both tests **FAIL**
- With the fix (`{**DEFAULT_FEATURES, **features}`): both tests **PASS**
- All 52 existing tests in `test_dataset_tools.py` continue to pass (63.75s)

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [x] CI is green