### PR TITLE
Decrease PI-05 load time by 72s

### DIFF
--- a/src/lerobot/policies/pi05/modeling_pi05.py
+++ b/src/lerobot/policies/pi05/modeling_pi05.py
@@ -967,7 +967,13 @@ class PI05Policy(PreTrainedPolicy):
 
         # Initialize model without loading weights
         # Check if dataset_stats were provided in kwargs
-        model = cls(config, **kwargs)
+        if _transformers_available:
+            from transformers.modeling_utils import no_init_weights
+            with no_init_weights():
+                model = cls(config, **kwargs)
+            model.model.paligemma_with_expert.paligemma.tie_weights()
+        else:
+            model = cls(config, **kwargs)
 
         # Now manually load and remap the state dict
         try:


### PR DESCRIPTION
Loading of the Pi-05 Model for inference takes ~90 seconds, mostly due to random weight initialization still being turned on. After turning this off and applying a fix such that the language embedding weights are loaded properly, initialization takes ~16s.  
