### PR TITLE
fix: auto-migrate old Hub models missing processor configs

### DIFF
--- a/tests/processor/test_pipeline_from_pretrained_helpers.py
+++ b/tests/processor/test_pipeline_from_pretrained_helpers.py
@@ -98,6 +98,25 @@ def test_load_config_nonexistent_path_tries_hub():
         DataProcessorPipeline._load_config("nonexistent/path", "processor.json", {})
 
 
+def test_is_old_hub_model_detects_old_model():
+    """Test that _is_old_hub_model returns True for repos with config.json but no processor configs."""
+    # lerobot/diffusion_pusht has config.json but no policy_preprocessor.json
+    assert DataProcessorPipeline._is_old_hub_model("lerobot/diffusion_pusht", {}) is True
+
+
+def test_is_old_hub_model_returns_false_for_nonexistent():
+    """Test that _is_old_hub_model returns False for non-existent repos."""
+    assert DataProcessorPipeline._is_old_hub_model("nonexistent/nonexistent_repo_12345", {}) is False
+
+
+def test_load_config_hub_old_model_raises_migration_error():
+    """Test that loading processor config from an old Hub model raises ProcessorMigrationError."""
+    with pytest.raises(ProcessorMigrationError, match="requires migration"):
+        DataProcessorPipeline._load_config(
+            "lerobot/diffusion_pusht", "policy_preprocessor.json", {}
+        )
+
+
 # Config Validation Tests
 
 


### PR DESCRIPTION
## Summary

- **Old pre-trained Hub models** (e.g., `lerobot/diffusion_pusht`) lack the `policy_preprocessor.json` and `policy_postprocessor.json` files required by the new processor pipeline system (0.4.4+), causing `FileNotFoundError` on `lerobot-eval`
- **Layer 1 — Detection**: Adds `_is_old_hub_model()` to `DataProcessorPipeline` that detects repos with `config.json` but no processor configs, raising `ProcessorMigrationError` with an actionable migration command instead of a cryptic error
- **Layer 2 — Auto-migration**: `make_pre_post_processors()` in `factory.py` catches `ProcessorMigrationError`, downloads `model.safetensors`, extracts normalization stats from the old built-in normalization layers, and auto-creates processor pipelines — with a warning suggesting the permanent migration script

## Files Changed

| File | Description |
|------|-------------|
| `src/lerobot/processor/pipeline.py` | `_is_old_hub_model()` classmethod + migration detection in `_load_config()` Hub path |
| `src/lerobot/policies/factory.py` | `ProcessorMigrationError` catch + `_auto_create_processors_from_pretrained()` helper |
| `tests/processor/test_pipeline_from_pretrained_helpers.py` | 3 test cases for old Hub model detection |

## Test plan

- [x] `lerobot-eval --policy.path=lerobot/diffusion_pusht` works end-to-end (33.3% success, avg_sum_reward 94.5)
- [x] Auto-migration warning is logged with actionable migration command
- [x] 19/19 tests pass in `test_pipeline_from_pretrained_helpers.py`
- [ ] CI should pass (no new dependencies introduced — uses existing `extract_normalization_stats` from migration module)

🤖 Generated with [Claude Code](https://claude.com/claude-code)