### PR TITLE
fix(processor): remove duplicate preprocessing steps in XVLA LIBERO pipeline

### DIFF
--- a/src/lerobot/policies/xvla/processor_xvla.py
+++ b/src/lerobot/policies/xvla/processor_xvla.py
@@ -542,9 +542,7 @@ def make_xvla_libero_pre_post_processors() -> tuple[
     """
     pre_processor_steps: list[ProcessorStep] = []
     post_processor_steps: list[ProcessorStep] = []
-    pre_processor_steps.extend(
-        [LiberoProcessorStep(), XVLAImageNetNormalizeProcessorStep(), XVLAAddDomainIdProcessorStep()]
-    )
+    pre_processor_steps.extend([LiberoProcessorStep()])
     post_processor_steps.extend([XVLARotation6DToAxisAngleProcessorStep()])
     return (
         PolicyProcessorPipeline[dict[str, Any], dict[str, Any]](


### PR DESCRIPTION
## Summary

- Removed `XVLAImageNetNormalizeProcessorStep` and `XVLAAddDomainIdProcessorStep` from `make_xvla_libero_pre_post_processors`
- These steps are already applied by the policy-level preprocessor in `make_xvla_pre_post_processors`, so they were being executed twice (env preprocessor then policy preprocessor), causing double ImageNet normalization and producing erroneous negative input values

## Test plan

- Verified the policy preprocessor (`make_xvla_pre_post_processors`) already includes both `XVLAImageNetNormalizeProcessorStep` and `XVLAAddDomainIdProcessorStep`
- The env-level processor should only handle LIBERO-specific observation formatting (`LiberoProcessorStep`), not general XVLA preprocessing

Fixes #2955