### PR TITLE
fix(video): replace assertions with proper exceptions in video frame decoding

### DIFF
--- a/src/lerobot/datasets/lerobot_dataset.py
+++ b/src/lerobot/datasets/lerobot_dataset.py
@@ -747,7 +747,7 @@ class LeRobotDataset(torch.utils.data.Dataset):
             # Check if cached dataset contains all requested episodes
             if not self._check_cached_episodes_sufficient():
                 raise FileNotFoundError("Cached dataset doesn't contain all requested episodes")
-        except (AssertionError, FileNotFoundError, NotADirectoryError):
+        except (FileNotFoundError, NotADirectoryError):
             if is_valid_version(self.revision):
                 self.revision = get_safe_version(self.repo_id, self.revision)
             self.download(download_videos)


### PR DESCRIPTION
## Summary

- Replaced `assert` statements with `FrameTimestampError` exceptions in `decode_video_frames_torchvision` and `decode_video_frames_torchcodec` for timestamp tolerance and frame count validation
- Removed `AssertionError` from the `except` clause in `LeRobotDataset.__init__`, which was masking video timestamp errors by silently triggering a dataset re-download instead of surfacing the actual problem

### Why this matters

1. Assertions can be silently disabled with `python -O`, making these runtime checks disappear entirely
2. Users hitting timestamp tolerance issues during training/eval get an unhelpful `AssertionError` traceback instead of the descriptive `FrameTimestampError` that already exists in the codebase for this purpose
3. In `LeRobotDataset.__init__`, `AssertionError` was caught alongside `FileNotFoundError`, causing video timestamp problems to trigger unnecessary re-downloads rather than surfacing the real error

## Test plan

- All 60 dataset tests pass
- `FrameTimestampError` is already a `ValueError` subclass, so existing error handling that catches `ValueError` will continue to work