### PR TITLE
Fix metaworld_config.json missing from pip installs and AttributeError crash

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include src/lerobot/templates/lerobot_modelcard_template.md
 include src/lerobot/datasets/card_template.md
+include src/lerobot/envs/metaworld_config.json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,6 +214,9 @@ lerobot-edit-dataset="lerobot.scripts.lerobot_edit_dataset:main"
 lerobot-setup-can="lerobot.scripts.lerobot_setup_can:main"
 
 # ---------------- Tool Configurations ----------------
+[tool.setuptools.package-data]
+lerobot = ["envs/*.json"]
+
 [tool.setuptools.packages.find]
 where = ["src"]
 

--- a/src/lerobot/utils/control_utils.py
+++ b/src/lerobot/utils/control_utils.py
@@ -189,7 +189,7 @@ def sanity_check_dataset_name(repo_id, policy_cfg):
     # Check if dataset_name starts with "eval_" but policy is missing
     if dataset_name.startswith("eval_") and policy_cfg is None:
         raise ValueError(
-            f"Your dataset name begins with 'eval_' ({dataset_name}), but no policy is provided ({policy_cfg.type})."
+            f"Your dataset name begins with 'eval_' ({dataset_name}), but no policy is provided."
         )
 
     # Check if dataset_name does not start with "eval_" but policy is provided


### PR DESCRIPTION
## Summary

- **Packaging**: `metaworld_config.json` is not included when lerobot is installed via pip, causing `FileNotFoundError` at import time for anyone using the metaworld environment. Added the file to both `MANIFEST.in` (sdist) and `pyproject.toml` package-data (wheels).

- **Crash fix**: `sanity_check_dataset_name` in `control_utils.py` accesses `policy_cfg.type` in the error message when `policy_cfg is None`, raising an `AttributeError` instead of the intended `ValueError`.

## Changes

- `MANIFEST.in`: Add `include src/lerobot/envs/metaworld_config.json`
- `pyproject.toml`: Add `[tool.setuptools.package-data]` section with `lerobot = ["envs/*.json"]`
- `src/lerobot/utils/control_utils.py`: Remove `policy_cfg.type` reference from error message where `policy_cfg` is guaranteed to be `None`

## Test plan

- Verified metaworld_config.json loads correctly from source tree
- Verified all 4 branches of `sanity_check_dataset_name` behave correctly (raises ValueError as intended, no longer crashes with AttributeError)

Fixes #2958