### PR TITLE
feat(eval): Add steps tracking to evaluation metrics

### DIFF
--- a/src/lerobot/envs/libero.py
+++ b/src/lerobot/envs/libero.py
@@ -114,7 +114,7 @@ class LiberoEnv(gym.Env):
         episode_index: int = 0,
         n_envs: int = 1,
         camera_name_mapping: dict[str, str] | None = None,
-        num_steps_wait: int = 10,
+        num_steps_wait: int = 20,
         control_mode: str = "relative",
     ):
         super().__init__()


### PR DESCRIPTION
# Better evaluation 

This PR:
- Add task finish steps metric for lerobot-eval
- Change LIBERO num_steps_wait to 20
- Fix bugs in return_observations metric for lerobot-eval

## Type / Scope

- **Type**: Bug, Feature
- **Scope**: lerobot-eval

## Summary / Motivation

- Add task finish steps metric for lerobot-eval.
- Change LIBERO num_steps_wait to 20 (Some objects are not ready when `num_steps_wait==10`)
<img width="249" height="249" alt="屏幕截图 2026-02-25 155453" src="https://github.com/user-attachments/assets/b6811359-2738-4e20-a28c-1351b32eb3f7" />
<img width="246" height="245" alt="屏幕截图 2026-02-25 155504" src="https://github.com/user-attachments/assets/159d7d18-c5b9-4d73-9b01-3170ae241349" />
<img width="252" height="249" alt="屏幕截图 2026-02-25 155518" src="https://github.com/user-attachments/assets/91562e3d-c2b3-4f48-9107-0d804adf21c9" />

## What changed

- Short, concrete bullets of the modifications (files/behaviour).
- Short note if this introduces breaking changes and migration steps.

## How was this tested (or how to run locally)

- Manual checks

Example:

- Reproduce with a quick example or CLI (if applicable):

  ```bash
  lerobot-eval \
  --env.type="libero" \
  --env.task="libero_10" \
  --eval.batch_size=1 \
  --eval.n_episodes=50 \
  --policy.path=$POLICY_PATH \
  --policy.n_action_steps=10 \
  --output_dir=./outputs/eval/$JOB_NAME \
  --env.max_parallel_tasks=1
  ```

## Checklist (required before merge)

- [x] CI is green

## Reviewer notes

- Anything the reviewer should focus on (performance, edge-cases, specific files) or general notes.
- Anyone in the community is free to review the PR.
