### PR TITLE
improve exo serial reading

### DIFF
--- a/src/lerobot/teleoperators/unitree_g1/exo_serial.py
+++ b/src/lerobot/teleoperators/unitree_g1/exo_serial.py
@@ -38,19 +38,23 @@ def parse_raw16(line: bytes) -> list[int] | None:
 
 def read_raw_from_serial(ser) -> list[int] | None:
     """Read latest sample from serial; if buffer is backed up, keep only the newest."""
-    last = None
-    while ser.in_waiting > 0:
-        b = ser.readline()
-        if not b:
-            break
-        raw16 = parse_raw16(b)
-        if raw16 is not None:
-            last = raw16
-    if last is None:
-        b = ser.readline()
-        if b:
-            last = parse_raw16(b)
-    return last
+    try:
+        last = None
+        while ser.in_waiting > 0:
+            b = ser.readline()
+            if not b:
+                break
+            raw16 = parse_raw16(b)
+            if raw16 is not None:
+                last = raw16
+        if last is None:
+            b = ser.readline()
+            if b:
+                last = parse_raw16(b)
+        return last
+    except (OSError, serial.SerialException) as e:
+        logger.warning(f"Serial read error: {e}")
+        return None
 
 
 @dataclass
@@ -104,14 +108,20 @@ class ExoskeletonArm:
             logger.warning(f"failed to load calibration: {e}")
 
     def read_raw(self) -> list[int] | None:
-        if not self._ser:
+        if not self._ser or not self._ser.is_open:
             return None
         return read_raw_from_serial(self._ser)
 
-    def get_angles(self) -> dict[str, float]:
+    def get_angles(self, raw: list[int] | None = None) -> dict[str, float]:
+        """Convert raw ADC values to joint angles.
+
+        Args:
+            raw: Optional raw ADC values. If None, reads from serial.
+        """
         if not self.calibration:
             raise RuntimeError("exoskeleton not calibrated")
-        raw = self.read_raw()
+        if raw is None:
+            raw = self.read_raw()
         return {} if raw is None else exo_raw_to_angles(raw, self.calibration)
 
     def calibrate(self) -> None:


### PR DESCRIPTION
### Changes in `exo_serial.py`

- Added serial-read exception handling in `read_raw_from_serial()`:
  - wraps reads with `except (OSError, serial.SerialException)`
  - logs warning and returns `None` on serial IO failures instead of crashing

- Strengthened `read_raw()` connection guard:
  - from `if not self._ser`
  - to `if not self._ser or not self._ser.is_open`
  - prevents reads from a closed serial handle

- Updated `get_angles()` signature to support pre-read raw samples:
  - from `get_angles(self)`
  - to `get_angles(self, raw: list[int] | None = None)`
  - uses provided `raw` when available, otherwise reads once internally
  - enables reuse of a single serial sample and avoids redundant serial reads
