### PR TITLE
Adds peer reviewed citation (ICLR26🎉)

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ If you use LeRobot in your research, please cite:
 ```bibtex
 @inproceedings{cadenelerobot,
   title={LeRobot: An Open-Source Library for End-to-End Robot Learning},
-  author={Cadene, Remi and Alibert, Simon and Capuano, Francesco and Aractingi, Michel and Zouitine, Adil and Kooijmans, Pepijn and Choghari, Jade and Russi, Martino and Pascal, Caroline and Palma, Steven and Shukor, Mustafa and Moss, Jess and Soare, Alexander and Aubakirova, Dana and Lhoest, Quentin and Gallouédec, Quentin and Wolf, Thomas},
+  author={Cadene, Remi and Alibert, Simon and Capuano, Francesco and Aractingi, Michel and Zouitine, Adil and Kooijmans, Pepijn and Choghari, Jade and Russi, Martino and Pascal, Caroline and Palma, Steven and Shukor, Mustafa and Moss, Jess and Soare, Alexander and Aubakirova, Dana and Lhoest, Quentin and Gallou\'edec, Quentin and Wolf, Thomas},
   booktitle={The Fourteenth International Conference on Learning Representations},
   year={2026}
 }


### PR DESCRIPTION
## Title
Adds peer reviewed citation (ICLR26🎉). Uses the peer reviewed citation coming from ICLR 2026 (https://iclr.cc/virtual/2026/poster/10010831) as citation for the project. 

## Type / Scope

- **Type**: Docs

## Summary / Motivation

- Citation are usually academic only, and the best possible kind of citation is that of a peer reviewed publication that underwent double-blind review. ICLR 2026 was just that for us!

## Related issues

- None

## What changed

- README.md citation now points to the actual bibtex entry correspoding to ICLR 2026 proceedings.

## How was this tested (or how to run locally)
- NA
- 
## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated
- [x] CI is green

## Reviewer notes

- Just changing the bibtex entry to the "more correct" one now that we have a peer-reviewed piece of work here.