### PR TITLE
fix(eval): cast actions to float32 before numpy conversion

### DIFF
--- a/src/lerobot/scripts/lerobot_eval.py
+++ b/src/lerobot/scripts/lerobot_eval.py
@@ -181,8 +181,8 @@ def rollout(
         action_transition = env_postprocessor(action_transition)
         action = action_transition[ACTION]
 
-        # Convert to CPU / numpy.
-        action_numpy: np.ndarray = action.to("cpu").numpy()
+        # Convert to CPU / numpy. Cast to float32 first since numpy doesn't support bfloat16.
+        action_numpy: np.ndarray = action.to("cpu", dtype=torch.float32).numpy()
         assert action_numpy.ndim == 2, "Action dimensions should be (batch, action_dim)"
 
         # Apply the next action.


### PR DESCRIPTION
## What this does

Fixes a crash in the evaluation pipeline when policies output `bfloat16` tensors (e.g. X-VLA with `dtype: bfloat16`).

The issue is that `action.to("cpu").numpy()` fails because numpy does not support `bfloat16`. The fix explicitly casts to `float32` before the numpy conversion.

## Changes

- `lerobot_eval.py`: `action.to("cpu").numpy()` -> `action.to("cpu", dtype=torch.float32).numpy()`

Fixes #2956