### PR TITLE
fix(frame_index): making rerun's "frame_index" timeline compatible with behaviour1k datasets

### DIFF
--- a/src/lerobot/scripts/lerobot_dataset_viz.py
+++ b/src/lerobot/scripts/lerobot_dataset_viz.py
@@ -132,8 +132,10 @@ def visualize_dataset(
 
     logging.info("Logging to Rerun")
 
-    first_index = dataset[0]["index"].item()
+    first_index = None
     for batch in tqdm.tqdm(dataloader, total=len(dataloader)):
+        if first_index is None:
+            first_index = batch["index"][0].item()
         # iterate over the batch
         for i in range(len(batch["index"])):
             rr.set_time("frame_index", sequence=batch["index"][i].item() - first_index)


### PR DESCRIPTION
Supersedes #2872 - Thank you @fwd4 for the fix !

## Type / Scope

- **Type**: Bug
- **Scope**: lerobot-dataset-viz

## Summary / Motivation

- Because behavior1k datasets do not have a `frame_index` feature, `lerobot-dataset_viz` crashes.

## Related issues

- Fixes / Closes: # (if any)
- Related: # (if any)

## What changed

- The `frame_index` pipeline is now defined according to `index` which is present in all datasets. The episode-wise normalization (first frame is at index 0) is achieved with the first index of the episode.

## How was this tested (or how to run locally)

No regression :
  ```bash
lerobot-dataset-viz --repo-id "lerobot/pusht"  --episode-index 10              
 ```

Fixed feature :
  ```bash
lerobot-dataset-viz --repo-id "erobot/behavior1k-task0000"  --episode-index 10              
 ```

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated
- [x] CI is green

## Reviewer notes

- Anything the reviewer should focus on (performance, edge-cases, specific files) or general notes.
- Anyone in the community is free to review the PR.
