### PR TITLE
chore(root): fixing `root` semantics in convert_dataset script

### DIFF
--- a/src/lerobot/datasets/v30/convert_dataset_v21_to_v30.py
+++ b/src/lerobot/datasets/v30/convert_dataset_v21_to_v30.py
@@ -36,7 +36,7 @@ Convert a local dataset (works in place):
 ```bash
 python src/lerobot/datasets/v30/convert_dataset_v21_to_v30.py \
     --repo-id=lerobot/pusht \
-    --root=/path/to/local/dataset/directory
+    --root=/path/to/local/dataset/directory \
     --push-to-hub=false
 
 N.B. Path semantics (v2): --root is the exact dataset folder containing


### PR DESCRIPTION
## Type / Scope

- **Type**: Chore
- **Scope**: `convert_dataset_v21_to_v30` script

## Summary / Motivation

Following up on #3035, this PR fixes the interpretation of the `root` argument in the `convert_dataset_v21_to_v30` script.

## Related issues

- Fixes / Closes: # (if any)
- Related: # (if any)

## What changed

- `root` now defines the exact dataset folder containing meta/, data/, videos/.

## How was this tested (or how to run locally)

Successfully converted a local dataset using the `--root` argument.

## Checklist (required before merge)

- [ ] Linting/formatting run (`pre-commit run -a`)
- [ ] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [ ] CI is green

## Reviewer notes

- Anything the reviewer should focus on (performance, edge-cases, specific files) or general notes.
- Anyone in the community is free to review the PR.
