### PR TITLE
feat(teleoperator): add leader arm support for HIL-SERL recording

### DIFF
--- a/docs/source/hilserl.mdx
+++ b/docs/source/hilserl.mdx
@@ -492,7 +492,7 @@ To setup the SO101 leader, you need to set the `control_mode` to `"leader"` and 
 }
 ```
 
-In order to annotate the success/failure of the episode, **you will need** to use a keyboard to press `s` for success, `esc` for failure.
+In order to annotate the success/failure of the episode, **you will need** to use a keyboard to press `s` for success, `esc` for failure, and `r` to rerecord the episode.
 During the online training, press `space` to take over the policy and `space` again to give the control back to the policy.
 
 <details>

--- a/src/lerobot/processor/hil_processor.py
+++ b/src/lerobot/processor/hil_processor.py
@@ -87,7 +87,7 @@ def _check_teleop_with_events(teleop: "Teleoperator") -> None:
     if not isinstance(teleop, HasTeleopEvents):
         raise TypeError(
             f"Teleoperator {type(teleop).__name__} must implement get_teleop_events() method. "
-            f"Compatible teleoperators: GamepadTeleop, KeyboardEndEffectorTeleop"
+            f"Ensure your teleoperator inherits from the Teleoperator base class, which provides a default implementation."
         )
 
 
@@ -443,6 +443,7 @@ class InterventionActionProcessorStep(ProcessorStep):
 
     use_gripper: bool = False
     terminate_on_success: bool = True
+    control_mode: str = "gamepad"
 
     def __call__(self, transition: EnvTransition) -> EnvTransition:
         """
@@ -473,14 +474,18 @@ class InterventionActionProcessorStep(ProcessorStep):
         # Override action if intervention is active
         if is_intervention and teleop_action is not None:
             if isinstance(teleop_action, dict):
-                # Convert teleop_action dict to tensor format
-                action_list = [
-                    teleop_action.get("delta_x", 0.0),
-                    teleop_action.get("delta_y", 0.0),
-                    teleop_action.get("delta_z", 0.0),
-                ]
-                if self.use_gripper:
-                    action_list.append(teleop_action.get(GRIPPER_KEY, 1.0))
+                if self.control_mode == "leader":
+                    # Joint position mode (leader arm) — values are direct joint positions
+                    action_list = list(teleop_action.values())
+                else:
+                    # End-effector delta mode (gamepad/keyboard EE)
+                    action_list = [
+                        teleop_action.get("delta_x", 0.0),
+                        teleop_action.get("delta_y", 0.0),
+                        teleop_action.get("delta_z", 0.0),
+                    ]
+                    if self.use_gripper:
+                        action_list.append(teleop_action.get(GRIPPER_KEY, 1.0))
             elif isinstance(teleop_action, np.ndarray):
                 action_list = teleop_action.tolist()
             else:
@@ -519,6 +524,7 @@ class InterventionActionProcessorStep(ProcessorStep):
         return {
             "use_gripper": self.use_gripper,
             "terminate_on_success": self.terminate_on_success,
+            "control_mode": self.control_mode,
         }
 
     def transform_features(

--- a/src/lerobot/rl/gym_manipulator.py
+++ b/src/lerobot/rl/gym_manipulator.py
@@ -28,6 +28,7 @@ from lerobot.configs import parser
 from lerobot.datasets.lerobot_dataset import LeRobotDataset
 from lerobot.envs.configs import HILSerlRobotEnvConfig
 from lerobot.model.kinematics import RobotKinematics
+from lerobot.motors.motors_bus import MotorNormMode
 from lerobot.processor import (
     AddBatchDimensionProcessorStep,
     AddTeleopActionAsComplimentaryDataStep,
@@ -129,6 +130,7 @@ class RobotEnv(gym.Env):
         display_cameras: bool = False,
         reset_pose: list[float] | None = None,
         reset_time_s: float = 5.0,
+        control_mode: str = "gamepad",
     ) -> None:
         """Initialize robot environment with configuration options.
 
@@ -138,11 +140,13 @@ class RobotEnv(gym.Env):
             display_cameras: Whether to show camera feeds during execution.
             reset_pose: Joint positions for environment reset.
             reset_time_s: Time to wait during reset.
+            control_mode: Control mode - "leader" for direct joint control, "gamepad" for delta EE.
         """
         super().__init__()
 
         self.robot = robot
         self.display_cameras = display_cameras
+        self.control_mode = control_mode
 
         # Connect to the robot if not already connected.
         if not self.robot.is_connected:
@@ -202,16 +206,34 @@ class RobotEnv(gym.Env):
 
         self.observation_space = gym.spaces.Dict(observation_spaces)
 
-        # Define the action space for joint positions along with setting an intervention flag.
-        action_dim = 3
-        bounds = {}
-        bounds["min"] = -np.ones(action_dim)
-        bounds["max"] = np.ones(action_dim)
-
-        if self.use_gripper:
-            action_dim += 1
-            bounds["min"] = np.concatenate([bounds["min"], [0]])
-            bounds["max"] = np.concatenate([bounds["max"], [2]])
+        # Define the action space.
+        if self.control_mode == "leader":
+            # Leader arm: direct joint positions, one per motor (including gripper).
+            # Bounds are derived from the follower's motor normalization modes, which
+            # must match the leader's modes for positions to be compatible.
+            low, high = [], []
+            for motor in self.robot.bus.motors.values():
+                if motor.norm_mode == MotorNormMode.DEGREES:
+                    low.append(-180.0)
+                    high.append(180.0)
+                elif motor.norm_mode == MotorNormMode.RANGE_M100_100:
+                    low.append(-100.0)
+                    high.append(100.0)
+                elif motor.norm_mode == MotorNormMode.RANGE_0_100:
+                    low.append(0.0)
+                    high.append(100.0)
+            action_dim = len(low)
+            bounds = {"min": np.array(low, dtype=np.float32), "max": np.array(high, dtype=np.float32)}
+        else:
+            # Gamepad/keyboard EE: delta end-effector control
+            action_dim = 3
+            bounds = {}
+            bounds["min"] = -np.ones(action_dim)
+            bounds["max"] = np.ones(action_dim)
+            if self.use_gripper:
+                action_dim += 1
+                bounds["min"] = np.concatenate([bounds["min"], [0]])
+                bounds["max"] = np.concatenate([bounds["max"], [2]])
 
         self.action_space = gym.spaces.Box(
             low=bounds["min"],
@@ -342,12 +364,26 @@ def make_robot_env(cfg: HILSerlRobotEnvConfig) -> tuple[gym.Env, Any]:
         cfg.processor.observation.display_cameras if cfg.processor.observation is not None else False
     )
     reset_pose = cfg.processor.reset.fixed_reset_joint_positions if cfg.processor.reset is not None else None
+    control_mode = cfg.processor.control_mode if cfg.processor is not None else "gamepad"
+
+    if control_mode == "leader":
+        # The intervention pipeline converts leader actions to a positional list and
+        # RobotEnv.step() reconstructs a dict using the follower's motor order.
+        # These must match or joint positions will be silently swapped.
+        leader_keys = list(teleop_device.bus.motors.keys())
+        follower_keys = list(robot.bus.motors.keys())
+        if leader_keys != follower_keys:
+            raise ValueError(
+                f"Leader and follower motor key order must match for joint-position control. "
+                f"Leader: {leader_keys}, Follower: {follower_keys}"
+            )
 
     env = RobotEnv(
         robot=robot,
         use_gripper=use_gripper,
         display_cameras=display_cameras,
         reset_pose=reset_pose,
+        control_mode=control_mode,
     )
 
     return env, teleop_device
@@ -476,11 +512,17 @@ def make_processors(
         InterventionActionProcessorStep(
             use_gripper=cfg.processor.gripper.use_gripper if cfg.processor.gripper is not None else False,
             terminate_on_success=terminate_on_success,
+            control_mode=cfg.processor.control_mode if cfg.processor is not None else "gamepad",
         ),
     ]
 
-    # Replace InverseKinematicsProcessor with new kinematic processors
-    if cfg.processor.inverse_kinematics is not None and kinematics_solver is not None:
+    # IK pipeline converts EE deltas → joint targets.  Leader arm actions are already
+    # joint positions, so the IK pipeline must be skipped in leader mode.
+    if (
+        cfg.processor.inverse_kinematics is not None
+        and kinematics_solver is not None
+        and cfg.processor.control_mode != "leader"
+    ):
         # Add EE bounds and safety processor
         inverse_kinematics_steps = [
             MapTensorToDeltaActionDictStep(
@@ -612,6 +654,14 @@ def control_loop(
     if cfg.mode == "record":
         if teleop_device:
             action_features = teleop_device.action_features
+            # Leader arm teleoperators return motor-specific format: {"motor.pos": float, ...}
+            # Convert to dataset feature format: {"dtype": "float32", "shape": (n,), "names": [...]}
+            if cfg.env.processor.control_mode == "leader":
+                action_features = {
+                    "dtype": "float32",
+                    "shape": (len(action_features),),
+                    "names": list(action_features.keys()),
+                }
         else:
             action_features = {
                 "dtype": "float32",
@@ -662,10 +712,16 @@ def control_loop(
     while episode_idx < cfg.dataset.num_episodes_to_record:
         step_start_time = time.perf_counter()
 
-        # Create a neutral action (no movement)
-        neutral_action = torch.tensor([0.0, 0.0, 0.0], dtype=torch.float32)
-        if use_gripper:
-            neutral_action = torch.cat([neutral_action, torch.tensor([0.0])])  # Gripper stay
+        # Create a neutral action (no movement).
+        # In leader mode actions are absolute joint positions, so "no movement"
+        # means holding the current position — not zeros which would slam the arm.
+        if env.control_mode == "leader":
+            raw = env.get_raw_joint_positions()
+            neutral_action = torch.tensor(
+                [raw[f"{k}.pos"] for k in env.robot.bus.motors], dtype=torch.float32
+            )
+        else:
+            neutral_action = torch.zeros(env.action_space.shape[0], dtype=torch.float32)
 
         # Use the new step function
         transition = step_env_and_process_transition(

--- a/src/lerobot/teleoperators/teleoperator.py
+++ b/src/lerobot/teleoperators/teleoperator.py
@@ -24,6 +24,7 @@ from lerobot.processor import RobotAction
 from lerobot.utils.constants import HF_LEROBOT_CALIBRATION, TELEOPERATORS
 
 from .config import TeleoperatorConfig
+from .utils import KeyboardTeleopEvents
 
 
 class Teleoperator(abc.ABC):
@@ -55,6 +56,8 @@ class Teleoperator(abc.ABC):
         if self.calibration_fpath.is_file():
             self._load_calibration()
 
+        self._keyboard_events: KeyboardTeleopEvents | None = None
+
     def __str__(self) -> str:
         return f"{self.id} {self.__class__.__name__}"
 
@@ -79,6 +82,8 @@ class Teleoperator(abc.ABC):
         Attempts to disconnect if the object is garbage collected without cleanup.
         """
         try:
+            if self._keyboard_events is not None:
+                self._keyboard_events.stop()
             if self.is_connected:
                 self.disconnect()
         except Exception:  # nosec B110
@@ -201,6 +206,20 @@ class Teleoperator(abc.ABC):
                 safety limits on velocity.
         """
         pass
+
+    def get_teleop_events(self) -> dict[str, Any]:
+        """Get control events for episode management.
+
+        This default implementation uses keyboard keys matching the HIL-SERL
+        docs for leader arm usage (Space, s, Esc, r). Subclasses with
+        hardware-based event support (e.g., gamepad buttons) should override.
+
+        Returns:
+            Dictionary containing episode control events.
+        """
+        if self._keyboard_events is None:
+            self._keyboard_events = KeyboardTeleopEvents()
+        return self._keyboard_events.get_events()
 
     @abc.abstractmethod
     def disconnect(self) -> None:

--- a/src/lerobot/teleoperators/utils.py
+++ b/src/lerobot/teleoperators/utils.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from enum import Enum
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from lerobot.utils.import_utils import make_device_from_device_class
 
@@ -31,6 +31,122 @@ class TeleopEvents(Enum):
     RERECORD_EPISODE = "rerecord_episode"
     IS_INTERVENTION = "is_intervention"
     TERMINATE_EPISODE = "terminate_episode"
+
+
+class KeyboardTeleopEvents:
+    """Keyboard-based episode control for teleoperators without hardware buttons.
+
+    Key bindings match the HIL-SERL docs for leader arm usage:
+    - Space: toggle intervention (take over / release control)
+    - s: mark episode as success
+    - Escape: mark episode as failure
+    - r: rerecord episode
+    """
+
+    def __init__(self):
+        import logging
+        import os
+        import sys
+        from queue import Queue
+
+        self._logger = logging.getLogger(__name__)
+        self._listener = None
+        self._event_queue: Queue[str] = Queue()
+        self._intervention_active = False
+        self._success_active = False
+
+        self._pynput_keyboard = None
+        try:
+            if ("DISPLAY" not in os.environ) and ("linux" in sys.platform):
+                raise ImportError("No DISPLAY set — keyboard listener unavailable.")
+            from pynput import keyboard as pynput_keyboard
+
+            self._pynput_keyboard = pynput_keyboard
+        except ImportError:
+            pass
+
+    def start(self) -> None:
+        """Start the keyboard listener. Called automatically on first get_events()."""
+        if self._listener is not None:
+            return
+
+        if self._pynput_keyboard is None:
+            raise ImportError(
+                "pynput is required for keyboard-based teleop events but is unavailable. "
+                "On headless systems (no DISPLAY), keyboard input is not supported."
+            )
+
+        pynput_kb = self._pynput_keyboard
+
+        def on_press(key):
+            try:
+                if key == pynput_kb.Key.space:
+                    self._intervention_active = not self._intervention_active
+                elif key == pynput_kb.Key.esc:
+                    self._event_queue.put("failure")
+                elif hasattr(key, "char"):
+                    if key.char == "s":
+                        self._success_active = True
+                    elif key.char == "r":
+                        self._event_queue.put("rerecord")
+            except AttributeError:
+                pass
+
+        def on_release(key):
+            try:
+                if hasattr(key, "char") and key.char == "s":
+                    self._success_active = False
+            except AttributeError:
+                pass
+
+        self._listener = pynput_kb.Listener(on_press=on_press, on_release=on_release)
+        self._listener.start()
+        self._logger.info(
+            "Keyboard listener started for teleop events "
+            "(Space=intervention, s=success, Esc=failure, r=rerecord)"
+        )
+
+    def stop(self) -> None:
+        """Stop the keyboard listener if running."""
+        if self._listener is not None:
+            self._listener.stop()
+            self._listener = None
+        self._success_active = False
+
+    def get_events(self) -> dict[str, Any]:
+        """Get pending teleop events, starting the listener on first call.
+
+        Returns:
+            Dictionary containing episode control events.
+        """
+        from queue import Empty
+
+        if self._listener is None:
+            self.start()
+
+        terminate_episode = False
+        success = self._success_active
+        rerecord_episode = False
+
+        while True:
+            try:
+                event = self._event_queue.get_nowait()
+            except Empty:
+                break
+            if event == "failure":
+                terminate_episode = True
+                self._success_active = False
+            elif event == "rerecord":
+                terminate_episode = True
+                rerecord_episode = True
+                self._success_active = False
+
+        return {
+            TeleopEvents.IS_INTERVENTION: self._intervention_active,
+            TeleopEvents.TERMINATE_EPISODE: terminate_episode,
+            TeleopEvents.SUCCESS: success,
+            TeleopEvents.RERECORD_EPISODE: rerecord_episode,
+        }
 
 
 def make_teleoperator_from_config(config: TeleoperatorConfig) -> "Teleoperator":


### PR DESCRIPTION
## Type / Scope

- **Type**: Feature
- **Scope**: teleoperators, rl/gym_manipulator, processor

## Summary / Motivation

The HIL-SERL docs describe using an SO-101 leader arm as a teleop device with control_mode: "leader", but SOLeader doesn't implement get_teleop_events(), causing a TypeError at startup. This PR adds leader arm support throughout the HIL-SERL recording pipeline: a standalone KeyboardTeleopEvents class provides keyboard-based episode control for any teleoperator that lacks hardware buttons, and the gym_manipulator pipeline is wired to handle joint-position actions from the leader arm.

## Related issues

- Fixes: #2952

## What changed

- teleoperators/utils.py: New KeyboardTeleopEvents class encapsulating pynput keyboard listener (Space=intervention, s=success, Esc=failure, r=rerecord)
- teleoperators/teleoperator.py: Default get_teleop_events() on base class that lazily delegates to KeyboardTeleopEvents, so all teleoperators satisfy the HasTeleopEvents protocol
- rl/gym_manipulator.py:
  - Action space bounds derived from follower motor MotorNormMode in leader mode
  - Leader/follower motor key order validated at startup to prevent silent joint swapping
  - IK pipeline skipped in leader mode (actions are already joint positions)
  - Neutral action uses current joint positions instead of zeros to prevent arm slamming
  - Leader arm action_features converted to dataset feature format for recording
- processor/hil_processor.py: InterventionActionProcessorStep dispatches on control_mode to handle joint-position dicts from leader arm vs delta dicts from gamepad/keyboard
- docs/source/hilserl.mdx: Added r rerecord keybinding to leader arm docs

## How was this tested (or how to run locally)

- Tested on real SO-101 leader/follower hardware
- Recorded several episodes with control_mode: "leader": Intervention (Space), Success (s), failure (Esc), rerecord (r) all work correctly
- Arm holds position when not intervening (no slam to zero)
- Inspected recorded dataset: correct 6-DOF action features, proper rewards (1.0 for success, 0.0 for failure), rerecorded episode correctly discarded
- Unit tests for KeyboardTeleopEvents and InterventionActionProcessorStep written but not included in this PR

Run with:  python -m lerobot.rl.gym_manipulator --config_path your_config.json

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated
- [ ] CI is green

## Reviewer notes

- The action_features property has two conventions in the codebase (motor-keyed format vs dataset feature format). This PR converts at the callsite in control_loop rather than changing SOLeader.action_features, because BiSOLeader depends on the motor-keyed format.
- The _check_teleop_with_events guard in hil_processor.py is now effectively always-pass since the base class provides the method. Left in place as a defensive check at the processor boundary.