### PR TITLE
fix(num_frames): fixing redundant frames count in conversion script

### DIFF
--- a/src/lerobot/datasets/v30/convert_dataset_v21_to_v30.py
+++ b/src/lerobot/datasets/v30/convert_dataset_v21_to_v30.py
@@ -228,7 +228,6 @@ def convert_data(root: Path, new_root: Path, data_file_size_in_mb: int):
 
             # Reset for the next file
             size_in_mb = 0
-            num_frames += ep_num_frames  # Still need to accumulate total frames
             paths_to_cat = []
 
         # Now create metadata with correct chunk/file indices


### PR DESCRIPTION
## Type / Scope

- **Type**: Bug
- **Scope**: V2.1 -> V3.0 conversion script

## Summary / Motivation

- Fixes a redundant `num_frames` increment introduced by #2941 

## Related issues

- Fixes / Closes: # (if any)
- Related: # (if any)

## What changed

- Removed increment at line 231 (on new file creation) that was already done at line 242 (for every episode).

## How to test it

`python convert_dataset_v21_to_v30.py --repo-id lerobot/berkeley_fanuc_manipulation --data-file-size-in-mb 1 --video-file-size-in-mb 1 --push-to-hub false --force-conversion`

- Without fix : last `dataset_to_index` = 63175 **does not match the total number of frames**
- With fix : last `dataset_to_index` = 62613 **matches the total number of frames**

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated
- [ ] CI is green

## Reviewer notes

- Anything the reviewer should focus on (performance, edge-cases, specific files) or general notes.
- Anyone in the community is free to review the PR.
