### PR TITLE
fix(ci): test only multi-gpu tests in multi-gpu runner

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -206,5 +206,4 @@ jobs:
           python -c "import torch; print(f'PyTorch CUDA available: {torch.cuda.is_available()}'); print(f'Number of GPUs: {torch.cuda.device_count()}')"
 
       - name: Run multi-GPU training tests
-      # TODO(Steven): Investigate why motors tests are failing in multi-GPU setup
-        run: pytest tests -vv --maxfail=10 --ignore=tests/motors/
+        run: pytest -vv tests/training/


### PR DESCRIPTION
fix(ci): test only multi-gpu tests in multi-gpu runner

With the introduction of new policy tests following transformers v5, we require a runner that has sufficient VRAM. The current multi-GPU runner has less RAM compared to the Full Test GPU runner, causing the multi-GPU test suite to run out of memory (OOM). Importantly, this issue is not related to how `accelerate` is used in the library workflows. 

As a result, for now, we are limiting the multi-GPU runner to only run tests specifically related to multi-GPU functionality. The remaining tests will continue to be covered by the standard Full Test GPU runner.

Nightly job: https://github.com/huggingface/lerobot/actions/runs/22730570789