### PR TITLE
Fix StreamingLeRobotDataset using global index for video frame lookup

### DIFF
--- a/src/lerobot/datasets/streaming_dataset.py
+++ b/src/lerobot/datasets/streaming_dataset.py
@@ -308,8 +308,8 @@ class StreamingLeRobotDataset(torch.utils.data.IterableDataset):
         # Get episode index from the item
         ep_idx = item["episode_index"]
 
-        # "timestamp" restarts from 0 for each episode, whereas we need a global timestep within the single .mp4 file (given by index/fps)
-        current_ts = item["index"] / self.fps
+        # Use per-episode timestamp (not global index) for video frame lookup
+        current_ts = item["timestamp"].item() if "timestamp" in item else item["frame_index"].item() / self.fps
 
         episode_boundaries_ts = {
             key: (


### PR DESCRIPTION
## What this PR does

Fixes `StreamingLeRobotDataset` crashing with `IndexError: Invalid frame index` on datasets with multiple episodes.

## Root cause

`streaming_dataset.py:312` computed the current timestamp from `item["index"]` (the global dataset index):

```python
current_ts = item["index"] / self.fps  # e.g. 134029 / 30 = 4467.6s
```

But each `.mp4` file is per-episode, so `torchcodec` received a frame index far beyond the video length (e.g. frame 134029 in a 25215-frame video), causing `IndexError`.

## Fix

Use `item["timestamp"]` (per-episode timestamp) instead, matching what `LeRobotDataset.__getitem__` does at line 1099.

Fixes #3080