### PR TITLE
docs: fix HF_USER to ignore bash ANSI codes

### DIFF
--- a/docs/source/il_robots.mdx
+++ b/docs/source/il_robots.mdx
@@ -165,7 +165,7 @@ hf auth login --token ${HUGGINGFACE_TOKEN} --add-to-git-credential
 Then store your Hugging Face repository name in a variable:
 
 ```bash
-HF_USER=$(hf auth whoami | awk -F': *' 'NR==1 {print $2}')
+HF_USER=$(NO_COLOR=1 hf auth whoami | awk -F': *' 'NR==1 {print $2}')
 echo $HF_USER
 ```
 


### PR DESCRIPTION
## Type / Scope

- **Type**: Docs
- **Scope**: Installation / Setup

## Summary / Motivation

- Current [`$HF_USER` parsing](https://huggingface.co/docs/lerobot/v0.4.4/en/il_robots?record=Command#record-a-dataset) uses `HF_USER=$(hf auth whoami | awk -F': *' 'NR==1 {print $2}')`. This behaves incorrectly when the terminal outputs ANSI styling, which causes errors in later `lerobot-record` command in the docs. For example, `hf auth whoami` may return a bolded **`user: `** for the output `user: j3soon`, which causes `HF_USER` to be ` j3soon` (the leading hidden character is `^[[0m `, which is the ANSI code that returns the style to normal).
- This PR performed a minimal fix by adding `NO_COLOR=1` before `hf auth` to disable ANSI codes, which fixes the parsing.

## Related issues

- Fixes / Closes: # (none)
- Related: https://github.com/huggingface/lerobot/pull/2932

## What changed

- Added `NO_COLOR=1` before `hf auth` to disable ANSI codes.

## How was this tested (or how to run locally)

Performed manual check (bash/zsh on Ubuntu 24.04 that supports ANSI code styling/coloring) with `hf 1.6.0` (latest).

Before the fix:

```
$ hf auth whoami  # Note that the `user: ` part below should be displayed as bold
user:  j3soon
$ hf auth whoami | cat -v
^[[1muser: ^[[0m j3soon


$ HF_USER=$(hf auth whoami | awk -F': *' 'NR==1 {print $2}')
$ echo $HF_USER
 j3soon
$ echo $HF_USER | cat -v
^[[0m j3soon
```

After the `NO_COLOR=1` fix:

```
$ HF_USER=$(NO_COLOR=1 hf auth whoami | awk -F': *' 'NR==1 {print $2}')
$ echo $HF_USER
j3soon
$ echo $HF_USER | cat -v
j3soon
```

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated
- [x] CI is green
