### PR TITLE
chore(dependencies): Increase opencv-python-headless upper bound

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ dependencies = [
     "torchvision>=0.21.0,<0.26.0",
 
     "einops>=0.8.0,<0.9.0",
-    "opencv-python-headless>=4.9.0,<4.13.0",
+    "opencv-python-headless>=4.9.0,<4.14.0",
     "av>=15.0.0,<16.0.0",
     "jsonlines>=4.0.0,<5.0.0",
     "pynput>=1.7.8,<1.9.0",


### PR DESCRIPTION
## Title

chore(dependencies): Increase opencv-python-headless upper bound

## Type / Scope

- **Type**:  Chore


## Summary / Motivation

- OpenCV 4.13 is available, and in particular in https://github.com/huggingface/lerobot/pull/3114 opencv-python was updated to 4.13, keeping opencv-python-headless to an earlier version is error prone

## What changed

- The upper bound of `opencv-python-headless` in `pyproject.toml` is raised from `<4.13.0` to `<4.14.0`.

## How was this tested (or how to run locally)

- Test locally run

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated
- [x] CI is green

## Reviewer notes

- Anything the reviewer should focus on (performance, edge-cases, specific files) or general notes.
- Anyone in the community is free to review the PR.
