### PR TITLE
perf(processor): reduce GPU-CPU sync in action tokenization

### DIFF
--- a/src/lerobot/processor/tokenizer_processor.py
+++ b/src/lerobot/processor/tokenizer_processor.py
@@ -392,6 +392,17 @@ class ActionTokenizerProcessorStep(ActionProcessorStep):
             add_bos_token=False,
         )
 
+        # Cache constant token sequences to avoid recomputing them every iteration.
+        self._prefix_tokens = torch.tensor(
+            [self._paligemma_tokenizer.bos_token_id]
+            + self._paligemma_tokenizer.encode("Action: ", add_special_tokens=False),
+            dtype=torch.long,
+        )
+        self._suffix_tokens = torch.tensor(
+            self._paligemma_tokenizer.encode("|"),
+            dtype=torch.long,
+        )
+
     def __call__(self, transition: EnvTransition) -> EnvTransition:
         """
         Applies action tokenization to the transition.
@@ -445,7 +456,7 @@ class ActionTokenizerProcessorStep(ActionProcessorStep):
         if action is None:
             raise ValueError("Action cannot be None")
 
-        # Get the device and dtype of the input action
+        # Get the device of the input action
         device = action.device if isinstance(action, torch.Tensor) else None
 
         # Handle single sample (add batch dimension)
@@ -455,38 +466,34 @@ class ActionTokenizerProcessorStep(ActionProcessorStep):
 
         batch_size = action.shape[0]
 
-        # Tokenize the action batch
-        # The fast tokenizer expects action data and returns token IDs
+        # Move entire batch to CPU once to avoid per-sample GPU-CPU synchronization.
+        # The tokenizer uses scipy/numpy internally and requires CPU tensors.
+        action_cpu = action.cpu()
+
+        # Tokenize the action batch. All work is done on CPU; the result is
+        # transferred to the target device in a single bulk operation at the end.
         tokens_list = []
         masks_list = []
 
         for i in range(batch_size):
-            # Tokenize single action (move to CPU first as tokenizer uses scipy which requires numpy)
-            action_cpu = action[i : i + 1].cpu()
-            tokens = self.action_tokenizer(action_cpu)
+            tokens = self.action_tokenizer(action_cpu[i : i + 1])
 
-            # Convert to numpy array if it's a list
             if isinstance(tokens, list) or not isinstance(tokens, torch.Tensor):
-                tokens = torch.tensor(tokens, dtype=torch.long, device=action.device)
+                tokens = torch.tensor(tokens, dtype=torch.long)
             else:
-                # Move tokens back to the same device as input action
-                tokens = tokens.to(device=action.device)
+                tokens = tokens.to(dtype=torch.long)
 
             # Flatten to 1D if needed
             if tokens.dim() > 1:
                 tokens = tokens.flatten()
 
-            bos_id = self._paligemma_tokenizer.bos_token_id
-            # add bos
+            # Prepend prefix (bos + "Action: ") and append suffix ("|"),
+            # using cached constant tensors.
             tokens = torch.cat(
                 [
-                    torch.tensor([bos_id], device=action.device),
-                    torch.tensor(
-                        self._paligemma_tokenizer.encode("Action: ", add_special_tokens=False),
-                        device=action.device,
-                    ),
+                    self._prefix_tokens,
                     self._act_tokens_to_paligemma_tokens(tokens),
-                    torch.tensor(self._paligemma_tokenizer.encode("|"), device=action.device),
+                    self._suffix_tokens,
                 ]
             )
 
@@ -497,23 +504,16 @@ class ActionTokenizerProcessorStep(ActionProcessorStep):
                     "Consider increasing the `max_action_tokens` in your model config if this happens frequently."
                 )
                 tokens = tokens[: self.max_action_tokens]
-                mask = torch.ones(self.max_action_tokens, dtype=torch.bool, device=action.device)
+                mask = torch.ones(self.max_action_tokens, dtype=torch.bool)
             else:
-                mask = torch.cat(
-                    [
-                        torch.ones(len(tokens), dtype=torch.bool, device=action.device),
-                        torch.zeros(
-                            self.max_action_tokens - len(tokens), dtype=torch.bool, device=action.device
-                        ),
-                    ]
-                )
-                # Pad tokens with zeros
+                mask = torch.zeros(self.max_action_tokens, dtype=torch.bool)
+                mask[: len(tokens)] = True
                 tokens = torch.nn.functional.pad(tokens, (0, self.max_action_tokens - len(tokens)), value=0)
 
             tokens_list.append(tokens)
             masks_list.append(mask)
 
-        # Stack into batched tensors
+        # Stack into batched tensors and move to the target device in one transfer.
         tokens_batch = torch.stack(tokens_list, dim=0)  # (B, max_action_tokens)
         masks_batch = torch.stack(masks_list, dim=0)  # (B, max_action_tokens)
 
@@ -522,7 +522,6 @@ class ActionTokenizerProcessorStep(ActionProcessorStep):
             tokens_batch = tokens_batch.squeeze(0)
             masks_batch = masks_batch.squeeze(0)
 
-        # Move to the same device as the input
         if device is not None:
             tokens_batch = tokens_batch.to(device)
             masks_batch = masks_batch.to(device)

--- a/src/lerobot/processor/tokenizer_processor.py
+++ b/src/lerobot/processor/tokenizer_processor.py
@@ -404,6 +404,20 @@ class ActionTokenizerProcessorStep(ActionProcessorStep):
             add_bos_token=False,
         )
 
+        self._cache_affix_tokens()
+
+    def _cache_affix_tokens(self) -> None:
+        """Cache constant token sequences to avoid recomputing them every iteration."""
+        self._prefix_tokens = torch.tensor(
+            [self._paligemma_tokenizer.bos_token_id]
+            + self._paligemma_tokenizer.encode("Action: ", add_special_tokens=False),
+            dtype=torch.long,
+        )
+        self._suffix_tokens = torch.tensor(
+            self._paligemma_tokenizer.encode("|"),
+            dtype=torch.long,
+        )
+
     def __call__(self, transition: EnvTransition) -> EnvTransition:
         """
         Applies action tokenization to the transition.
@@ -458,7 +472,7 @@ class ActionTokenizerProcessorStep(ActionProcessorStep):
         if action is None:
             raise ValueError("Action cannot be None")
 
-        # Get the device and dtype of the input action
+        # Get the device of the input action
         device = action.device if isinstance(action, torch.Tensor) else None
 
         # Handle single sample (add batch dimension)
@@ -468,47 +482,47 @@ class ActionTokenizerProcessorStep(ActionProcessorStep):
 
         batch_size = action.shape[0]
 
-        # Tokenize the action batch
-        # The fast tokenizer expects action data and returns token IDs
+        # Cached in __post_init__; rebuilt here if the step was constructed without
+        # running __post_init__.
+        if getattr(self, "_prefix_tokens", None) is None:
+            self._cache_affix_tokens()
+
+        # Move entire batch to CPU once to avoid per-sample GPU-CPU synchronization.
+        # The tokenizer uses scipy/numpy internally and requires CPU tensors.
+        action_cpu = action.cpu()
+
+        # Tokenize the action batch. All work is done on CPU; the result is
+        # transferred to the target device in a single bulk operation at the end.
         tokens_list = []
         masks_list = []
         code_masks_list = []
 
         for i in range(batch_size):
-            # Tokenize single action (move to CPU first as tokenizer uses scipy which requires numpy)
-            action_cpu = action[i : i + 1].cpu()
-            tokens = self.action_tokenizer(action_cpu)
+            tokens = self.action_tokenizer(action_cpu[i : i + 1])
 
-            # Convert to numpy array if it's a list
             if isinstance(tokens, list) or not isinstance(tokens, torch.Tensor):
-                tokens = torch.tensor(tokens, dtype=torch.long, device=action.device)
+                tokens = torch.tensor(tokens, dtype=torch.long)
             else:
-                # Move tokens back to the same device as input action
-                tokens = tokens.to(device=action.device)
+                tokens = tokens.to(dtype=torch.long)
 
             # Flatten to 1D if needed
             if tokens.dim() > 1:
                 tokens = tokens.flatten()
 
             action_code_tokens = self._act_tokens_to_paligemma_tokens(tokens)
-            bos_id = self._paligemma_tokenizer.bos_token_id
-            prompt_tokens = torch.tensor(
-                self._paligemma_tokenizer.encode("Action: ", add_special_tokens=False),
-                device=action.device,
-            )
-            end_tokens = torch.tensor(self._paligemma_tokenizer.encode("|"), device=action.device)
 
-            code_start = 1 + len(prompt_tokens)
+            # Prepend prefix (bos + "Action: ") and append suffix ("|"),
+            # using cached constant tensors.
+            code_start = len(self._prefix_tokens)
             code_end = code_start + len(action_code_tokens)
             tokens = torch.cat(
                 [
-                    torch.tensor([bos_id], device=action.device),
-                    prompt_tokens,
+                    self._prefix_tokens,
                     action_code_tokens,
-                    end_tokens,
+                    self._suffix_tokens,
                 ]
             )
-            code_mask = torch.zeros(len(tokens), dtype=torch.bool, device=action.device)
+            code_mask = torch.zeros(len(tokens), dtype=torch.bool)
             code_mask[code_start:code_end] = True
 
             # Truncate or pad to max_action_tokens
@@ -524,15 +538,11 @@ class ActionTokenizerProcessorStep(ActionProcessorStep):
                 )
                 tokens = tokens[: self.max_action_tokens]
                 code_mask = code_mask[: self.max_action_tokens]
-                mask = torch.ones(self.max_action_tokens, dtype=torch.bool, device=action.device)
+                mask = torch.ones(self.max_action_tokens, dtype=torch.bool)
             else:
                 pad_len = self.max_action_tokens - len(tokens)
-                mask = torch.cat(
-                    [
-                        torch.ones(len(tokens), dtype=torch.bool, device=action.device),
-                        torch.zeros(pad_len, dtype=torch.bool, device=action.device),
-                    ]
-                )
+                mask = torch.zeros(self.max_action_tokens, dtype=torch.bool)
+                mask[: len(tokens)] = True
                 code_mask = torch.nn.functional.pad(code_mask, (0, pad_len), value=False)
                 # Pad tokens with zeros
                 tokens = torch.nn.functional.pad(tokens, (0, pad_len), value=0)
@@ -541,7 +551,7 @@ class ActionTokenizerProcessorStep(ActionProcessorStep):
             masks_list.append(mask)
             code_masks_list.append(code_mask)
 
-        # Stack into batched tensors
+        # Stack into batched tensors and move to the target device in one transfer.
         tokens_batch = torch.stack(tokens_list, dim=0)  # (B, max_action_tokens)
         masks_batch = torch.stack(masks_list, dim=0)  # (B, max_action_tokens)
         code_masks_batch = torch.stack(code_masks_list, dim=0)  # (B, max_action_tokens)
@@ -552,7 +562,6 @@ class ActionTokenizerProcessorStep(ActionProcessorStep):
             masks_batch = masks_batch.squeeze(0)
             code_masks_batch = code_masks_batch.squeeze(0)
 
-        # Move to the same device as the input
         if device is not None:
             tokens_batch = tokens_batch.to(device)
             masks_batch = masks_batch.to(device)

--- a/tests/processor/test_tokenizer_processor.py
+++ b/tests/processor/test_tokenizer_processor.py
@@ -1575,3 +1575,113 @@ def test_subtask_not_added_for_unsupported_types():
 
     # But main task tokens should still be present
     assert f"{OBS_LANGUAGE}.tokens" in observation
+
+
+# ---------------------------------------------------------------------------
+# Tests for the batched CPU transfer in ActionTokenizerProcessorStep (perf fix)
+# ---------------------------------------------------------------------------
+
+
+class _CpuCallCountingTensor(torch.Tensor):
+    """Tensor subclass that counts .cpu() calls, including calls on views/slices."""
+
+    calls = 0
+
+    def cpu(self, *args, **kwargs):
+        type(self).calls += 1
+        return super().cpu(*args, **kwargs)
+
+
+class _RecordingActionTokenizer:
+    """Fake FAST tokenizer: records the device of every input tensor and returns
+    a token sequence derived from the input values, so different samples produce
+    different (deterministic) sequences of varying length."""
+
+    def __init__(self):
+        self.seen_devices = []
+        self.n_calls = 0
+
+    def __call__(self, action: torch.Tensor) -> list[int]:
+        self.n_calls += 1
+        self.seen_devices.append(action.device.type)
+        flat = action.flatten()
+        n_tokens = 2 + int(flat[0].abs().item() * 10) % 3
+        return [int(v.abs().item() * 10) % 50 for v in flat[:n_tokens]]
+
+
+class _CountingPaliGemmaTokenizer:
+    """Minimal PaliGemma tokenizer stub that counts encode() calls."""
+
+    vocab_size = 1000
+    bos_token_id = 2
+
+    def __init__(self):
+        self.encode_calls = 0
+
+    def encode(self, text: str, **kwargs) -> list[int]:
+        self.encode_calls += 1
+        return [10, 11] if text == "Action: " else [99]
+
+
+@skip_if_package_missing("transformers")
+@patch("lerobot.processor.tokenizer_processor.AutoTokenizer")
+def test_action_tokenizer_batch_transfers_to_cpu_once(mock_auto_tokenizer):
+    """The whole action batch is moved to CPU in a single transfer, and the FAST
+    tokenizer only ever sees CPU tensors."""
+    mock_auto_tokenizer.from_pretrained.return_value = _CountingPaliGemmaTokenizer()
+    fake_tokenizer = _RecordingActionTokenizer()
+    step = ActionTokenizerProcessorStep(action_tokenizer_input_object=fake_tokenizer, max_action_tokens=16)
+
+    _CpuCallCountingTensor.calls = 0
+    action = torch.randn(4, 2, 7).as_subclass(_CpuCallCountingTensor)
+    tokens, mask, code_mask = step._tokenize_action(action)
+
+    assert _CpuCallCountingTensor.calls == 1
+    assert fake_tokenizer.n_calls == 4
+    assert all(device == "cpu" for device in fake_tokenizer.seen_devices)
+    assert tokens.shape == (4, 16)
+    assert mask.shape == (4, 16)
+    assert code_mask.shape == (4, 16)
+
+
+@skip_if_package_missing("transformers")
+@patch("lerobot.processor.tokenizer_processor.AutoTokenizer")
+def test_action_tokenizer_constant_affixes_cached_across_calls(mock_auto_tokenizer):
+    """The constant prefix (bos + "Action: ") and suffix ("|") are encoded once at
+    init and never re-encoded during tokenization."""
+    paligemma = _CountingPaliGemmaTokenizer()
+    mock_auto_tokenizer.from_pretrained.return_value = paligemma
+    step = ActionTokenizerProcessorStep(
+        action_tokenizer_input_object=_RecordingActionTokenizer(), max_action_tokens=16
+    )
+
+    calls_after_init = paligemma.encode_calls
+    assert calls_after_init == 2  # "Action: " and "|"
+
+    step._tokenize_action(torch.randn(3, 2, 7))
+    step._tokenize_action(torch.randn(2, 2, 7))
+
+    assert paligemma.encode_calls == calls_after_init
+
+
+@skip_if_package_missing("transformers")
+@patch("lerobot.processor.tokenizer_processor.AutoTokenizer")
+def test_action_tokenizer_batched_results_match_per_sample(mock_auto_tokenizer):
+    """Tokenizing a batch produces exactly the same tokens/masks per sample as
+    tokenizing each sample on its own."""
+    mock_auto_tokenizer.from_pretrained.return_value = _CountingPaliGemmaTokenizer()
+    step = ActionTokenizerProcessorStep(
+        action_tokenizer_input_object=_RecordingActionTokenizer(), max_action_tokens=16
+    )
+
+    action = torch.randn(3, 2, 7)
+    tokens_batch, mask_batch, code_mask_batch = step._tokenize_action(action)
+
+    for i in range(3):
+        tokens_i, mask_i, code_mask_i = step._tokenize_action(action[i : i + 1])
+        assert torch.equal(tokens_batch[i : i + 1], tokens_i)
+        assert torch.equal(mask_batch[i : i + 1], mask_i)
+        assert torch.equal(code_mask_batch[i : i + 1], code_mask_i)
+    assert tokens_batch.dtype == torch.long
+    assert mask_batch.dtype == torch.bool
+    assert code_mask_batch.dtype == torch.bool


### PR DESCRIPTION
## What this does

Reduces GPU-CPU synchronization overhead in `ActionTokenizerProcessorStep._tokenize_action()`, which is called every training step for tokenizer-based policies (SmolVLA, xVLA).

## The problem

The tokenization loop was calling `action[i:i+1].cpu()` and `tokens.to(device)` **per sample**, creating `2 * batch_size` GPU-CPU synchronization points per training step. For a typical `batch_size=64`, that's 128 sync stalls per step.

Additionally, constant token sequences (`bos_token_id`, `encode("Action: ")`, `encode("|")`) were recomputed every iteration.

This is likely a contributing factor to issue #1488 (SmolVLA training much slower than ACT).

## Changes

- Move entire action batch to CPU in one transfer before the loop (1 sync instead of `batch_size`)
- Build all token tensors on CPU, stack, then transfer to GPU once at the end (1 sync instead of `batch_size`)
- Cache constant prefix/suffix token sequences in `__post_init__`

Net effect: GPU-CPU sync reduced from `O(batch_size)` to `O(1)` per call.

Related: #1488