### PR TITLE
Add add_feature CLI operation for dataset editing

### DIFF
--- a/src/lerobot/scripts/lerobot_edit_dataset.py
+++ b/src/lerobot/scripts/lerobot_edit_dataset.py
@@ -98,6 +98,16 @@ Remove camera feature:
         --operation.type remove_feature \
         --operation.feature_names "['observation.image']"
 
+Add an externally computed feature from a NumPy file:
+    lerobot-edit-dataset \
+        --repo_id lerobot/pusht \
+        --new_repo_id lerobot/pusht_with_reward \
+        --operation.type add_feature \
+        --operation.feature_name reward \
+        --operation.feature_values_path /path/to/reward.npy \
+        --operation.feature_dtype float32 \
+        --operation.feature_shape "[1]"
+
 Modify tasks - set a single task for all episodes (WARNING: modifies in-place):
     lerobot-edit-dataset \
         --repo_id lerobot/pusht \
@@ -161,9 +171,11 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import draccus
+import numpy as np
 
 from lerobot.configs import parser
 from lerobot.datasets.dataset_tools import (
+    add_features,
     convert_image_to_video_dataset,
     delete_episodes,
     merge_datasets,
@@ -205,6 +217,16 @@ class MergeConfig(OperationConfig):
 @OperationConfig.register_subclass("remove_feature")
 @dataclass
 class RemoveFeatureConfig(OperationConfig):
+    feature_names: list[str] | None = None
+
+
+@OperationConfig.register_subclass("add_feature")
+@dataclass
+class AddFeatureConfig(OperationConfig):
+    feature_name: str | None = None
+    feature_values_path: str | None = None
+    feature_dtype: str | None = None
+    feature_shape: list[int] | None = None
     feature_names: list[str] | None = None
 
 
@@ -421,6 +443,77 @@ def handle_remove_feature(cfg: EditDatasetConfig) -> None:
         LeRobotDataset(output_repo_id, root=output_dir).push_to_hub()
 
 
+def _load_feature_values(feature_values_path: str) -> np.ndarray:
+    path = Path(feature_values_path)
+    if not path.exists():
+        raise FileNotFoundError(f"Feature values file not found: {path}")
+
+    if path.suffix != ".npy":
+        raise ValueError(
+            f"Unsupported feature values format '{path.suffix}'. Only .npy files are currently supported."
+        )
+
+    values = np.load(path, allow_pickle=False)
+    if not isinstance(values, np.ndarray):
+        raise TypeError(f"Expected numpy.ndarray in {path}, got {type(values).__name__}")
+    return values
+
+
+def handle_add_feature(cfg: EditDatasetConfig) -> None:
+    if not isinstance(cfg.operation, AddFeatureConfig):
+        raise ValueError("Operation config must be AddFeatureConfig")
+
+    if not cfg.operation.feature_name:
+        raise ValueError("feature_name must be specified for add_feature operation")
+    if not cfg.operation.feature_values_path:
+        raise ValueError("feature_values_path must be specified for add_feature operation")
+    if not cfg.operation.feature_dtype:
+        raise ValueError("feature_dtype must be specified for add_feature operation")
+    if not cfg.operation.feature_shape:
+        raise ValueError("feature_shape must be specified for add_feature operation")
+
+    dataset = LeRobotDataset(cfg.repo_id, root=cfg.root)
+    output_repo_id, output_dir = get_output_path(
+        cfg.repo_id,
+        new_repo_id=cfg.new_repo_id,
+        root=cfg.root,
+        new_root=cfg.new_root,
+    )
+
+    # In case of in-place modification, make the dataset point to the backup directory
+    if output_dir == dataset.root:
+        dataset.root = dataset.root.with_name(dataset.root.name + "_old")
+
+    feature_values = _load_feature_values(cfg.operation.feature_values_path)
+    feature_info = {
+        "dtype": cfg.operation.feature_dtype,
+        "shape": tuple(cfg.operation.feature_shape),
+        "names": cfg.operation.feature_names,
+    }
+
+    logging.info(
+        f"Adding feature '{cfg.operation.feature_name}' from {cfg.operation.feature_values_path} to {cfg.repo_id}"
+    )
+    new_dataset = add_features(
+        dataset,
+        features={
+            cfg.operation.feature_name: (
+                feature_values,
+                feature_info,
+            )
+        },
+        output_dir=output_dir,
+        repo_id=output_repo_id,
+    )
+
+    logging.info(f"Dataset saved to {output_dir}")
+    logging.info(f"Added feature: {cfg.operation.feature_name}")
+
+    if cfg.push_to_hub:
+        logging.info(f"Pushing to hub as {output_repo_id}")
+        LeRobotDataset(output_repo_id, root=output_dir).push_to_hub()
+
+
 def handle_modify_tasks(cfg: EditDatasetConfig) -> None:
     if not isinstance(cfg.operation, ModifyTasksConfig):
         raise ValueError("Operation config must be ModifyTasksConfig")
@@ -590,6 +683,8 @@ def edit_dataset(cfg: EditDatasetConfig) -> None:
         handle_split(cfg)
     elif operation_type == "merge":
         handle_merge(cfg)
+    elif operation_type == "add_feature":
+        handle_add_feature(cfg)
     elif operation_type == "remove_feature":
         handle_remove_feature(cfg)
     elif operation_type == "modify_tasks":

--- a/tests/scripts/test_edit_dataset_add_feature.py
+++ b/tests/scripts/test_edit_dataset_add_feature.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from lerobot.datasets.lerobot_dataset import LeRobotDataset
+from lerobot.scripts.lerobot_edit_dataset import AddFeatureConfig, EditDatasetConfig, handle_add_feature
+
+
+@pytest.fixture
+def sample_dataset(tmp_path, empty_lerobot_dataset_factory):
+    features = {
+        "action": {"dtype": "float32", "shape": (6,), "names": None},
+        "observation.state": {"dtype": "float32", "shape": (4,), "names": None},
+        "observation.images.top": {"dtype": "image", "shape": (224, 224, 3), "names": None},
+    }
+
+    dataset = empty_lerobot_dataset_factory(
+        root=tmp_path / "test_dataset",
+        features=features,
+    )
+
+    for ep_idx in range(5):
+        for _ in range(10):
+            frame = {
+                "action": np.random.randn(6).astype(np.float32),
+                "observation.state": np.random.randn(4).astype(np.float32),
+                "observation.images.top": np.random.randint(0, 255, size=(224, 224, 3), dtype=np.uint8),
+                "task": f"task_{ep_idx % 2}",
+            }
+            dataset.add_frame(frame)
+        dataset.save_episode()
+
+    dataset.finalize()
+    return dataset
+
+
+def test_handle_add_feature_from_npy(sample_dataset, tmp_path):
+    reward_values = np.random.randn(sample_dataset.meta.total_frames, 1).astype(np.float32)
+    feature_path = tmp_path / "reward.npy"
+    np.save(feature_path, reward_values)
+
+    output_dir = tmp_path / "with_reward"
+    cfg = EditDatasetConfig(
+        repo_id=sample_dataset.repo_id,
+        root=str(sample_dataset.root),
+        new_repo_id=f"{sample_dataset.repo_id}_with_reward",
+        new_root=str(output_dir),
+        operation=AddFeatureConfig(
+            feature_name="reward",
+            feature_values_path=str(feature_path),
+            feature_dtype="float32",
+            feature_shape=[1],
+        ),
+    )
+
+    with (
+        patch("lerobot.datasets.lerobot_dataset.get_safe_version") as mock_get_safe_version,
+        patch("lerobot.datasets.lerobot_dataset.snapshot_download") as mock_snapshot_download,
+    ):
+        mock_get_safe_version.return_value = "v3.0"
+        mock_snapshot_download.return_value = str(output_dir)
+
+        handle_add_feature(cfg)
+
+    new_dataset = LeRobotDataset(cfg.new_repo_id, root=output_dir)
+    assert "reward" in new_dataset.meta.features
+    assert new_dataset.meta.features["reward"] == {
+        "dtype": "float32",
+        "shape": (1,),
+        "names": None,
+    }
+    assert len(new_dataset) == sample_dataset.meta.total_frames
+    assert "reward" in new_dataset[0]
+
+
+def test_handle_add_feature_requires_npy(sample_dataset, tmp_path):
+    feature_path = tmp_path / "reward.txt"
+    feature_path.write_text("not-a-feature-file", encoding="utf-8")
+
+    cfg = EditDatasetConfig(
+        repo_id=sample_dataset.repo_id,
+        root=str(sample_dataset.root),
+        new_repo_id=f"{sample_dataset.repo_id}_with_reward",
+        new_root=str(tmp_path / "with_reward"),
+        operation=AddFeatureConfig(
+            feature_name="reward",
+            feature_values_path=str(feature_path),
+            feature_dtype="float32",
+            feature_shape=[1],
+        ),
+    )
+
+    with pytest.raises(ValueError, match="Only \\.npy files are currently supported"):
+        handle_add_feature(cfg)

--- a/tests/scripts/test_edit_dataset_parsing.py
+++ b/tests/scripts/test_edit_dataset_parsing.py
@@ -18,6 +18,7 @@ import draccus
 import pytest
 
 from lerobot.scripts.lerobot_edit_dataset import (
+    AddFeatureConfig,
     ConvertImageToVideoConfig,
     DeleteEpisodesConfig,
     EditDatasetConfig,
@@ -45,6 +46,7 @@ class TestOperationTypeParsing:
             ("delete_episodes", DeleteEpisodesConfig),
             ("split", SplitConfig),
             ("merge", MergeConfig),
+            ("add_feature", AddFeatureConfig),
             ("remove_feature", RemoveFeatureConfig),
             ("modify_tasks", ModifyTasksConfig),
             ("convert_image_to_video", ConvertImageToVideoConfig),
@@ -75,6 +77,7 @@ class TestOperationTypeParsing:
             ("delete_episodes", DeleteEpisodesConfig),
             ("split", SplitConfig),
             ("merge", MergeConfig),
+            ("add_feature", AddFeatureConfig),
             ("remove_feature", RemoveFeatureConfig),
             ("modify_tasks", ModifyTasksConfig),
             ("convert_image_to_video", ConvertImageToVideoConfig),
@@ -87,3 +90,28 @@ class TestOperationTypeParsing:
         )
         resolved_name = OperationConfig.get_choice_name(type(cfg.operation))
         assert resolved_name == type_name
+
+    def test_add_feature_args_parse(self):
+        cfg = parse_cfg(
+            [
+                "--repo_id",
+                "test/repo",
+                "--new_repo_id",
+                "test/repo_with_reward",
+                "--operation.type",
+                "add_feature",
+                "--operation.feature_name",
+                "reward",
+                "--operation.feature_values_path",
+                "reward.npy",
+                "--operation.feature_dtype",
+                "float32",
+                "--operation.feature_shape",
+                "[1]",
+            ]
+        )
+        assert isinstance(cfg.operation, AddFeatureConfig)
+        assert cfg.operation.feature_name == "reward"
+        assert cfg.operation.feature_values_path == "reward.npy"
+        assert cfg.operation.feature_dtype == "float32"
+        assert cfg.operation.feature_shape == [1]


### PR DESCRIPTION
## Summary
- add a new `add_feature` edit-dataset operation to the CLI
- support loading feature values from `.npy` files and passing feature metadata
- cover the new parsing and handler behavior with tests

## Testing
- `set PYTHONPATH=src&&..\lerobot-main\.venv\Scripts\python -m pytest tests\scripts\test_edit_dataset_parsing.py tests\scripts\test_edit_dataset_add_feature.py -q`

Part of #2326.
