### PR TITLE
fix(async): use aspect-ratio-preserving resize in async inference

### DIFF
--- a/src/lerobot/async_inference/helpers.py
+++ b/src/lerobot/async_inference/helpers.py
@@ -72,16 +72,38 @@ def is_image_key(k: str) -> bool:
 
 
 def resize_robot_observation_image(image: torch.tensor, resize_dims: tuple[int, int, int]) -> torch.tensor:
-    assert image.ndim == 3, f"Image must be (C, H, W)! Received {image.shape}"
-    # (H, W, C) -> (C, H, W) for resizing from robot obsevation resolution to policy image resolution
+    assert image.ndim == 3, f"Image must be (H, W, C)! Received {image.shape}"
+    # (H, W, C) -> (C, H, W) for resizing from robot observation resolution to policy image resolution
     image = image.permute(2, 0, 1)
-    dims = (resize_dims[1], resize_dims[2])
-    # Add batch dimension for interpolate: (C, H, W) -> (1, C, H, W)
-    image_batched = image.unsqueeze(0)
-    # Interpolate and remove batch dimension: (1, C, H, W) -> (C, H, W)
-    resized = torch.nn.functional.interpolate(image_batched, size=dims, mode="bilinear", align_corners=False)
+    target_height, target_width = resize_dims[1], resize_dims[2]
 
-    return resized.squeeze(0)
+    # Use aspect-ratio-preserving resize with padding (same as sync inference)
+    # to avoid distorting the image content which causes policy failures.
+    _, cur_height, cur_width = image.shape
+    ratio = max(cur_width / target_width, cur_height / target_height)
+    resized_height = int(cur_height / ratio)
+    resized_width = int(cur_width / ratio)
+
+    # Add batch dimension for interpolate: (C, H, W) -> (1, C, H, W)
+    image_batched = image.unsqueeze(0).float()
+    resized = torch.nn.functional.interpolate(
+        image_batched, size=(resized_height, resized_width), mode="bilinear", align_corners=False
+    )
+
+    # Clamp based on dtype
+    if image.dtype == torch.uint8:
+        resized = torch.round(resized).clamp(0, 255).to(torch.uint8)
+    else:
+        resized = resized.clamp(0.0, 1.0)
+
+    # Pad to target dimensions with black
+    pad_h0, remainder_h = divmod(target_height - resized_height, 2)
+    pad_h1 = pad_h0 + remainder_h
+    pad_w0, remainder_w = divmod(target_width - resized_width, 2)
+    pad_w1 = pad_w0 + remainder_w
+    padded = torch.nn.functional.pad(resized, (pad_w0, pad_w1, pad_h0, pad_h1), mode="constant", value=0)
+
+    return padded.squeeze(0)
 
 
 # TODO(Steven): Consider implementing a pipeline step for this


### PR DESCRIPTION
## Summary

The async inference path uses naive `torch.nn.functional.interpolate` to resize camera images to the policy's expected input dimensions. This distorts the aspect ratio (e.g. squashing a 1280x720 image to 224x224), causing newly trained policies to have ~0% success rate under async inference vs 80-90% under sync inference.

The sync inference path (used by pi0, smolvla, xvla) correctly uses `resize_with_pad` which scales proportionally and pads with black to preserve aspect ratio.

This PR aligns the async resize behavior with the sync path.

## Changes

- Modified `resize_robot_observation_image` in `async_inference/helpers.py` to:
  - Calculate the resize ratio to preserve aspect ratio
  - Scale the image proportionally
  - Pad with black to reach the target dimensions
  - Handle both `uint8` and `float32` dtypes

Fixes #2980