### PR TITLE
perf(dataset): use select() for multi-index queries to fix ~40x regression

### DIFF
--- a/src/lerobot/datasets/lerobot_dataset.py
+++ b/src/lerobot/datasets/lerobot_dataset.py
@@ -1008,9 +1008,9 @@ class LeRobotDataset(torch.utils.data.Dataset):
             if query_indices is not None and key in query_indices:
                 if self._absolute_to_relative_idx is not None:
                     relative_indices = [self._absolute_to_relative_idx[idx] for idx in query_indices[key]]
-                    timestamps = self.hf_dataset[relative_indices]["timestamp"]
                 else:
-                    timestamps = self.hf_dataset[query_indices[key]]["timestamp"]
+                    relative_indices = query_indices[key]
+                timestamps = self.hf_dataset.select(relative_indices)["timestamp"]
                 query_timestamps[key] = torch.stack(timestamps).tolist()
             else:
                 query_timestamps[key] = [current_ts]
@@ -1021,7 +1021,8 @@ class LeRobotDataset(torch.utils.data.Dataset):
         """
         Query dataset for indices across keys, skipping video keys.
 
-        Tries column-first [key][indices] for speed, falls back to row-first.
+        Uses select() for efficient multi-index access on HuggingFace datasets,
+        which avoids loading entire columns into memory.
 
         Args:
             query_indices: Dict mapping keys to index lists to retrieve
@@ -1029,20 +1030,38 @@ class LeRobotDataset(torch.utils.data.Dataset):
         Returns:
             Dict with stacked tensors of queried data (video keys excluded)
         """
-        result: dict = {}
+        # Collect all unique indices across keys to do a single select()
+        all_indices: set[int] = set()
+        keys_to_query: list[str] = []
+        mapped_indices: dict[str, list[int]] = {}
+
         for key, q_idx in query_indices.items():
             if key in self.meta.video_keys:
                 continue
-            # Map absolute indices to relative indices if needed
+            keys_to_query.append(key)
             relative_indices = (
                 q_idx
                 if self._absolute_to_relative_idx is None
                 else [self._absolute_to_relative_idx[idx] for idx in q_idx]
             )
-            try:
-                result[key] = torch.stack(self.hf_dataset[key][relative_indices])
-            except (KeyError, TypeError, IndexError):
-                result[key] = torch.stack(self.hf_dataset[relative_indices][key])
+            mapped_indices[key] = relative_indices
+            all_indices.update(relative_indices)
+
+        if not keys_to_query:
+            return {}
+
+        # Single select() call is much faster than column-first hf_dataset[key][indices]
+        # which loads entire columns into memory on parquet-backed datasets.
+        unique_indices = sorted(all_indices)
+        selected_data = self.hf_dataset.select(unique_indices)
+
+        # Build reverse map from original index to position in selected subset
+        idx_to_pos = {idx: pos for pos, idx in enumerate(unique_indices)}
+
+        result: dict = {}
+        for key in keys_to_query:
+            positions = [idx_to_pos[idx] for idx in mapped_indices[key]]
+            result[key] = torch.stack(selected_data.select(positions)[key])
         return result
 
     def _query_videos(self, query_timestamps: dict[str, list[float]], ep_idx: int) -> dict[str, torch.Tensor]:


### PR DESCRIPTION
## Summary

`_query_hf_dataset` uses column-first access `hf_dataset[key][indices]` which loads the entire column into memory before indexing. With `delta_timestamps` (e.g. 50-frame action horizons for diffusion policies), this causes a ~40x performance regression: per-sample query time goes from ~6ms to ~260ms, turning a 34-minute epoch into ~26.5 hours.

Switches to `dataset.select(indices)` which reads only the needed rows from parquet files. Also batches all unique indices into a single `select()` call across keys to minimize I/O overhead.

Same fix applied to `_get_query_timestamps` for video timestamp lookups.

## Changes

- `_query_hf_dataset`: Single `select()` call with all unique indices, then per-key extraction via position mapping
- `_get_query_timestamps`: Replace direct indexing with `select()` for timestamp lookups

Fixes #2895