### PR TITLE
fix(async): skip redundant policy reload between eval runs

### DIFF
--- a/src/lerobot/async_inference/policy_server.py
+++ b/src/lerobot/async_inference/policy_server.py
@@ -89,6 +89,8 @@ class PolicyServer(services_pb2_grpc.AsyncInferenceServicer):
         self.policy = None
         self.preprocessor: PolicyProcessorPipeline[dict[str, Any], dict[str, Any]] | None = None
         self.postprocessor: PolicyProcessorPipeline[PolicyAction, PolicyAction] | None = None
+        self._loaded_policy_path: str | None = None
+        self._loaded_policy_type: str | None = None
 
     @property
     def running(self):
@@ -143,6 +145,18 @@ class PolicyServer(services_pb2_grpc.AsyncInferenceServicer):
             f"Device: {policy_specs.device}"
         )
 
+        # Skip reload if the same policy is already loaded
+        if (
+            self.policy is not None
+            and self._loaded_policy_path == policy_specs.pretrained_name_or_path
+            and self._loaded_policy_type == policy_specs.policy_type
+        ):
+            self.logger.info("Policy already loaded with same configuration, skipping reload")
+            # Still update mutable config fields that may differ between runs
+            self.lerobot_features = policy_specs.lerobot_features
+            self.actions_per_chunk = policy_specs.actions_per_chunk
+            return services_pb2.Empty()
+
         self.device = policy_specs.device
         self.policy_type = policy_specs.policy_type  # act, pi0, etc.
         self.lerobot_features = policy_specs.lerobot_features
@@ -165,6 +179,9 @@ class PolicyServer(services_pb2_grpc.AsyncInferenceServicer):
             },
             postprocessor_overrides={"device_processor": device_override},
         )
+
+        self._loaded_policy_path = policy_specs.pretrained_name_or_path
+        self._loaded_policy_type = policy_specs.policy_type
 
         end = time.perf_counter()
 


### PR DESCRIPTION
## Summary

When running multiple evaluation episodes, `robot_client.start()` calls `SendPolicyInstructions` every time, triggering a full policy reload from disk and GPU placement even when the same policy is already loaded. This adds unnecessary latency between evaluation runs.

Caches the loaded policy path and type on the server side, and skips the reload when the same policy is requested again. Mutable fields like `lerobot_features` and `actions_per_chunk` are still updated to allow configuration changes between runs.

## Changes

- Added `_loaded_policy_path` and `_loaded_policy_type` tracking fields to `PolicyServer.__init__`
- Added early-return check in `SendPolicyInstructions` when same policy is already loaded
- Cache policy identity after successful load

Fixes #2866