### PR TITLE
fix(script help): fixing lerobot-train --help by removing % in the docstrings

### DIFF
--- a/src/lerobot/configs/train.py
+++ b/src/lerobot/configs/train.py
@@ -51,7 +51,7 @@ class TrainPipelineConfig(HubMixin):
     # AND for the evaluation environments.
     seed: int | None = 1000
     # Set to True to use deterministic cuDNN algorithms for reproducibility.
-    # This disables cudnn.benchmark and may reduce training speed by ~10-20%.
+    # This disables cudnn.benchmark and may reduce training speed by ~10-20 percent.
     cudnn_deterministic: bool = False
     # Number of workers for the dataloader.
     num_workers: int = 4


### PR DESCRIPTION
## Type / Scope

- **Type**: Bug
- **Scope**: lerobot-train (script)

## Summary / Motivation

`lerobot-train --help` fails because of the % character in `cudnn_deterministic` docstrings (`draccus` unsupported character).

## Related issues

- Fixes / Closes: # (if any)
- Related: # (if any)

## What changed

- % = percent

## How was this tested (or how to run locally)

`lerobot-train --help` does not fail anymore.

## Checklist (required before merge)

- [ ] Linting/formatting run (`pre-commit run -a`)
- [ ] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [ ] CI is green

## Reviewer notes

- Steps to take for the future : add `lerobot-xxx --help` in the release end-to-end tests