### PR TITLE
feat(cameras): add OpenMV H7 camera support via serial (UART)

### DIFF
--- a/src/lerobot/cameras/__init__.py
+++ b/src/lerobot/cameras/__init__.py
@@ -15,3 +15,4 @@
 from .camera import Camera
 from .configs import CameraConfig, ColorMode, Cv2Backends, Cv2Rotation
 from .utils import make_cameras_from_configs
+from .openmv.configuration_openmv import OpenMVCameraConfig

--- a/src/lerobot/cameras/openmv/__init__.py
+++ b/src/lerobot/cameras/openmv/__init__.py
@@ -1,0 +1,4 @@
+from .camera_openmv import OpenMVCamera
+from .configuration_openmv import OpenMVCameraConfig
+
+__all__ = ["OpenMVCamera", "OpenMVCameraConfig"]

--- a/src/lerobot/cameras/openmv/camera_openmv.py
+++ b/src/lerobot/cameras/openmv/camera_openmv.py
@@ -1,0 +1,119 @@
+import cv2
+import numpy as np
+import serial
+import threading
+import time
+from typing import Any
+from numpy.typing import NDArray
+
+from ..camera import Camera
+from .configuration_openmv import OpenMVCameraConfig
+
+JPEG_START = b'\xff\xd8'
+JPEG_END = b'\xff\xd9'
+
+class OpenMVCamera(Camera):
+    def __init__(self, config: OpenMVCameraConfig):
+        super().__init__(config)
+        self.config = config
+        self.port = config.port
+        self._width = config.width or 640
+        self._height = config.height or 480
+        self._fps = config.fps or 30
+        self.ser = None
+        self._frame = None
+        self._lock = threading.Lock()
+        self._event = threading.Event()
+        self._running = False
+        self._thread = None
+        self._is_connected = False
+        self._frame_count = 0
+
+    @property
+    def is_connected(self) -> bool:
+        return self._is_connected
+
+    @staticmethod
+    def find_cameras() -> list[dict[str, Any]]:
+        return []
+
+    def connect(self, warmup: bool = True) -> None:
+        self.ser = serial.Serial(self.port, baudrate=115200, timeout=0.1)
+        time.sleep(3)
+        self.ser.reset_input_buffer()
+        self._running = True
+        self._thread = threading.Thread(target=self._read_loop, daemon=True)
+        self._thread.start()
+        for _ in range(100):
+            if self._frame is not None:
+                break
+            time.sleep(0.1)
+        self._is_connected = True
+        print(f"OpenMVCamera bağlandı: {self.port}")
+
+    def _read_loop(self):
+        buf = b""
+        last_frame_time = time.time()
+        while self._running:
+            try:
+                chunk = self.ser.read(4096)
+                if chunk:
+                    buf += chunk
+
+                # Buffer cok buyuduyse temizle
+                if len(buf) > 100_000:
+                    last_start = buf.rfind(JPEG_START)
+                    buf = buf[last_start:] if last_start > 0 else b""
+
+                while True:
+                    start = buf.find(JPEG_START)
+                    if start == -1:
+                        buf = buf[-2:]
+                        break
+                    end = buf.find(JPEG_END, start + 2)
+                    if end == -1:
+                        buf = buf[start:]
+                        break
+                    jpeg_data = buf[start:end + 2]
+                    buf = buf[end + 2:]
+                    frame = cv2.imdecode(np.frombuffer(jpeg_data, dtype=np.uint8), cv2.IMREAD_COLOR)
+                    if frame is None:
+                        continue
+                    frame = cv2.resize(frame, (self._width, self._height))
+                    if self.config.color_mode.value == "rgb":
+                        frame = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+                    with self._lock:
+                        self._frame = frame
+                        self._frame_count += 1
+                        if self._frame_count % 30 == 0:
+                            fps = 30 / (time.time() - last_frame_time)
+                            last_frame_time = time.time()
+                            print(f"OpenMV frame: {self._frame_count} ({fps:.1f} fps)", flush=True)
+                    self._event.set()
+
+            except Exception as e:
+                print(f"OpenMV hata: {e}", flush=True)
+                if self._running:
+                    buf = b""
+                    time.sleep(0.1)
+
+    def read(self) -> NDArray[Any]:
+        with self._lock:
+            if self._frame is None:
+                return np.zeros((self._height, self._width, 3), dtype=np.uint8)
+            return self._frame.copy()
+
+    def async_read(self, timeout_ms: float = 200) -> NDArray[Any]:
+        self._event.wait(timeout=timeout_ms / 1000)
+        self._event.clear()
+        return self.read()
+
+    def read_latest(self, max_age_ms: int = 500) -> NDArray[Any]:
+        return self.read()
+
+    def disconnect(self) -> None:
+        self._running = False
+        self._is_connected = False
+        if self.ser:
+            self.ser.close()
+        print("OpenMVCamera bağlantısı kesildi.")

--- a/src/lerobot/cameras/openmv/camera_openmv.py
+++ b/src/lerobot/cameras/openmv/camera_openmv.py
@@ -49,7 +49,7 @@ class OpenMVCamera(Camera):
                 break
             time.sleep(0.1)
         self._is_connected = True
-        print(f"OpenMVCamera bağlandı: {self.port}")
+        print(f"OpenMVCamera connected to: {self.port}")
 
     def _read_loop(self):
         buf = b""
@@ -92,7 +92,7 @@ class OpenMVCamera(Camera):
                     self._event.set()
 
             except Exception as e:
-                print(f"OpenMV hata: {e}", flush=True)
+                print(f"OpenMV error: {e}", flush=True)
                 if self._running:
                     buf = b""
                     time.sleep(0.1)
@@ -116,4 +116,4 @@ class OpenMVCamera(Camera):
         self._is_connected = False
         if self.ser:
             self.ser.close()
-        print("OpenMVCamera bağlantısı kesildi.")
+        print("OpenMVCamera disconnected.")

--- a/src/lerobot/cameras/openmv/configuration_openmv.py
+++ b/src/lerobot/cameras/openmv/configuration_openmv.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+from ..configs import CameraConfig, ColorMode
+
+__all__ = ["OpenMVCameraConfig"]
+
+@CameraConfig.register_subclass("openmv")
+@dataclass
+class OpenMVCameraConfig(CameraConfig):
+    port: str = "/dev/cu.usbmodem3071377B34302"
+    color_mode: ColorMode = ColorMode.RGB
+
+    def __post_init__(self):
+        self.color_mode = ColorMode(self.color_mode)

--- a/src/lerobot/cameras/utils.py
+++ b/src/lerobot/cameras/utils.py
@@ -42,6 +42,11 @@ def make_cameras_from_configs(camera_configs: dict[str, CameraConfig]) -> dict[s
 
             cameras[key] = Reachy2Camera(cfg)
 
+        elif cfg.type == "openmv":
+            from .openmv.camera_openmv import OpenMVCamera
+
+            cameras[key] = OpenMVCamera(cfg)
+
         elif cfg.type == "zmq":
             from .zmq.camera_zmq import ZMQCamera
 

--- a/src/lerobot/utils/visualization_utils.py
+++ b/src/lerobot/utils/visualization_utils.py
@@ -91,7 +91,7 @@ def log_rerun_data(
                         rr.log(f"{key}_{i}", rr.Scalars(float(vi)))
                 else:
                     img_entity = rr.Image(arr).compress() if compress_images else rr.Image(arr)
-                    rr.log(key, entity=img_entity, static=True)
+                    rr.log(key, entity=img_entity)
 
     if action:
         for k, v in action.items():


### PR DESCRIPTION
## Summary

Adds support for OpenMV H7 camera to LeRobot, enabling its use as a vision 
input for robots such as SO-101.

The OpenMV H7 streams JPEG frames over USB serial (VCP) at 115200 baud. 
This implementation reads the serial stream, parses JPEG boundaries, 
decodes frames with OpenCV, and exposes them through the standard `Camera` 
interface.

## Changes

- `cameras/openmv/camera_openmv.py`: New serial-based camera driver with 
  background thread for continuous JPEG frame reading
- `cameras/openmv/configuration_openmv.py`: New config class registered 
  under `"openmv"` camera type
- `cameras/__init__.py`: Registered OpenMV camera to the camera registry
- `cameras/utils.py`, `visualization_utils.py`: Minor updates to support 
  the new camera type

## Hardware

- **Camera:** OpenMV H7
- **Robot:** SO-101
- **Connection:** USB serial / VCP (Virtual COM Port)

## Setup

### 1. OpenMV H7 Firmware (MicroPython)

Upload the following script to the OpenMV H7 via **OpenMV IDE**:

```python
import sensor, image
from pyb import USB_VCP

sensor.reset()
sensor.set_pixformat(sensor.RGB565)
sensor.set_framesize(sensor.QVGA)
sensor.skip_frames(time=2000)

usb = USB_VCP()
usb.setinterrupt(-1)

while True:
    img = sensor.snapshot()
    jpeg = img.compress(quality=30)
    n = len(jpeg)
    mv = memoryview(jpeg)
    pos = 0
    while pos < n:
        sent = usb.send(mv[pos:pos+512], timeout=0)
        if sent:
            pos += sent
```

### 2. Python Usage

```python
from lerobot.cameras.openmv import OpenMVCamera, OpenMVCameraConfig

config = OpenMVCameraConfig(
    port="/dev/cu.usbmodem3071377B34302",
    width=640,
    height=480,
    fps=30
)
camera = OpenMVCamera(config)
camera.connect()
frame = camera.read()
print(frame.shape)
camera.disconnect()
```

### 3. Teleoperation with SO-101

```bash
lerobot-teleoperate \
  --robot.type=so101_follower \
  --robot.port=/dev/tty.usbmodem5AE60857631 \
  --robot.id=my_awesome_follower_arm \
  --teleop.type=so101_leader \
  --teleop.port=/dev/tty.usbmodem5AE60560201 \
  --teleop.id=my_awesome_leader_arm \
  --display_data=true \
  --robot.cameras='{ front: {type: openmv, port: /dev/cu.usbmodem3071377B34302, width: 640, height: 480, fps: 30}}'
```

> **Note:** Replace port values with your own device paths.
> - Robot/teleop ports: `ls /dev/tty.usbmodem*`
> - OpenMV port: `ls /dev/cu.usbmodem*`