### PR TITLE
feat(gamepad): add direct joint control for Xbox/HID gamepad with SO100/SO101

### DIFF
--- a/docs/source/processors_robots_teleop.mdx
+++ b/docs/source/processors_robots_teleop.mdx
@@ -128,6 +128,66 @@ How it works:
 - `combine_feature_dicts(...)`: combine multiple feature dicts.
 - Recording with `record_loop(...)` uses `build_dataset_frame(...)` to build frames consistent with `dataset.features` before we call `add_frame(...)` to add the frame to the dataset.
 
+## Gamepad direct joint control (SO-100 / SO-101)
+
+You can teleoperate an SO-100 or SO-101 follower with a gamepad (Xbox, Logitech, or any HID-compatible controller) without a leader arm, URDF, or IK solver. Each gamepad axis directly controls one joint:
+
+| Control                | Joint                  |
+| ---------------------- | ---------------------- |
+| Left stick up/down     | shoulder_lift          |
+| Left stick left/right  | shoulder_pan           |
+| Right stick up/down    | elbow_flex             |
+| Right stick left/right | wrist_flex             |
+| LB / RB                | wrist_roll             |
+| LT / RT                | gripper (close / open) |
+| Y                      | End episode (success)  |
+| X                      | End episode (failure)  |
+| A                      | Rerecord episode       |
+
+### Quick start
+
+```bash
+lerobot-teleoperate \
+    --robot.type=so101_follower \
+    --robot.port=/dev/tty.usbmodem58760431541 \
+    --robot.id=my_follower \
+    --teleop.type=gamepad
+```
+
+If multiple gamepads or HID devices are connected, select one by name:
+
+```bash
+lerobot-teleoperate \
+    --robot.type=so101_follower \
+    --robot.port=/dev/tty.usbmodem58760431541 \
+    --teleop.type=gamepad \
+    --teleop.device_name=xbox
+```
+
+### How it works
+
+When `make_default_processors()` detects a delta teleop (gamepad or keyboard_ee) paired with a joint-space robot (SO-100/SO-101 follower), it automatically inserts a `MapGamepadToJointPositionsStep` into the teleop action processor. This step:
+
+1. Reads the current joint positions from the robot observation.
+2. Adds scaled gamepad deltas (`joint_step_size` degrees per frame per unit of stick deflection).
+3. Outputs absolute `motor.pos` targets the robot can execute directly.
+
+No IK, URDF, or extra dependencies are needed. The robot action and observation processors remain identity pipelines.
+
+### Recording datasets
+
+Recording works the same way — `make_default_processors()` is called with the teleop and robot configs, so the joint control pipeline is set up automatically:
+
+```bash
+lerobot-record \
+    --robot.type=so101_follower \
+    --robot.port=/dev/tty.usbmodem58760431541 \
+    --teleop.type=gamepad \
+    --dataset.repo_id=<your_username>/<dataset_name> \
+    --dataset.num_episodes=10 \
+    --dataset.single_task="Pick up the cube"
+```
+
 ## Guidance when customizing robot pipelines
 
 You can store any of the following features as your action/observation space:

--- a/src/lerobot/processor/delta_action_processor.py
+++ b/src/lerobot/processor/delta_action_processor.py
@@ -17,7 +17,7 @@
 from dataclasses import dataclass
 
 from lerobot.configs.types import FeatureType, PipelineFeatureType, PolicyFeature
-from lerobot.types import PolicyAction, RobotAction
+from lerobot.types import PolicyAction, RobotAction, TransitionKey
 
 from .pipeline import ActionProcessorStep, ProcessorStepRegistry, RobotActionProcessorStep
 
@@ -97,23 +97,18 @@ class MapDeltaActionToRobotActionStep(RobotActionProcessorStep):
         delta_x = action.pop("delta_x")
         delta_y = action.pop("delta_y")
         delta_z = action.pop("delta_z")
+        delta_wz = action.pop("delta_wz", 0.0)
         gripper = action.pop("gripper")
 
         # Determine if the teleoperator is actively providing input
-        # Consider enabled if any significant movement delta is detected
-        position_magnitude = (delta_x**2 + delta_y**2 + delta_z**2) ** 0.5  # Use Euclidean norm for position
-        enabled = position_magnitude > self.noise_threshold  # Small threshold to avoid noise
+        # Consider enabled if any significant movement or rotation delta is detected
+        position_magnitude = (delta_x**2 + delta_y**2 + delta_z**2) ** 0.5
+        enabled = position_magnitude > self.noise_threshold or abs(delta_wz) > self.noise_threshold
 
         # Scale the deltas appropriately
         scaled_delta_x = delta_x * self.position_scale
         scaled_delta_y = delta_y * self.position_scale
         scaled_delta_z = delta_z * self.position_scale
-
-        # For gamepad/keyboard, we don't have rotation input, so set to 0
-        # These could be extended in the future for more sophisticated teleoperators
-        target_wx = 0.0
-        target_wy = 0.0
-        target_wz = 0.0
 
         # Update action with robot target format
         action = {
@@ -121,9 +116,9 @@ class MapDeltaActionToRobotActionStep(RobotActionProcessorStep):
             "target_x": scaled_delta_x,
             "target_y": scaled_delta_y,
             "target_z": scaled_delta_z,
-            "target_wx": target_wx,
-            "target_wy": target_wy,
-            "target_wz": target_wz,
+            "target_wx": 0.0,
+            "target_wy": 0.0,
+            "target_wz": float(delta_wz),
             "gripper_vel": float(gripper),
         }
 
@@ -137,6 +132,83 @@ class MapDeltaActionToRobotActionStep(RobotActionProcessorStep):
 
         for feat in ["enabled", "target_x", "target_y", "target_z", "target_wx", "target_wy", "target_wz"]:
             features[PipelineFeatureType.ACTION][f"{feat}"] = PolicyFeature(
+                type=FeatureType.ACTION, shape=(1,)
+            )
+
+        return features
+
+
+@ProcessorStepRegistry.register("map_gamepad_to_joint_positions")
+@dataclass
+class MapGamepadToJointPositionsStep(RobotActionProcessorStep):
+    """
+    Maps gamepad axis deltas directly to joint position targets.
+
+    Each gamepad axis controls one joint. The step reads current joint positions
+    from the robot observation and adds scaled deltas to compute target positions.
+
+    Axis mapping:
+        delta_x  (left stick Y)  → shoulder_lift
+        delta_y  (left stick X)  → shoulder_pan
+        delta_z  (right stick Y) → elbow_flex
+        delta_wx (right stick X) → wrist_flex
+        delta_wz (LB/RB)        → wrist_roll
+        gripper  (LT/RT)        → gripper
+
+    Attributes:
+        motor_names: Ordered motor names matching the robot.
+        joint_step_size: Degrees added per frame per unit of stick deflection.
+        gripper_step_size: Gripper position delta per frame for open/close.
+    """
+
+    motor_names: list[str]
+    joint_step_size: float = 3.0
+    gripper_step_size: float = 5.0
+
+    def action(self, action: RobotAction) -> RobotAction:
+        observation = self.transition.get(TransitionKey.OBSERVATION).copy()
+
+        # Read gamepad deltas (each in -1..1 range, or -1/0/1 for buttons)
+        delta_shoulder_pan = float(action.pop("delta_y", 0.0))
+        delta_shoulder_lift = float(action.pop("delta_x", 0.0))
+        delta_elbow_flex = float(action.pop("delta_z", 0.0))
+        delta_wrist_flex = float(action.pop("delta_wx", 0.0))
+        delta_wrist_roll = float(action.pop("delta_wz", 0.0))
+        gripper = float(action.pop("gripper", 1.0))  # 0=open, 1=close, 2=stay
+
+        joint_deltas = {
+            "shoulder_pan": delta_shoulder_pan,
+            "shoulder_lift": delta_shoulder_lift,
+            "elbow_flex": delta_elbow_flex,
+            "wrist_flex": delta_wrist_flex,
+            "wrist_roll": delta_wrist_roll,
+        }
+
+        result: RobotAction = {}
+        for name in self.motor_names:
+            current_pos = float(observation.get(f"{name}.pos", 0.0))
+            if name == "gripper":
+                # Discrete gripper: 0=open, 2=close, 1=stay
+                if gripper == 0:
+                    result[f"{name}.pos"] = max(current_pos - self.gripper_step_size, 0.0)
+                elif gripper == 2:
+                    result[f"{name}.pos"] = min(current_pos + self.gripper_step_size, 100.0)
+                else:
+                    result[f"{name}.pos"] = current_pos
+            else:
+                delta = joint_deltas.get(name, 0.0) * self.joint_step_size
+                result[f"{name}.pos"] = current_pos + delta
+
+        return result
+
+    def transform_features(
+        self, features: dict[PipelineFeatureType, dict[str, PolicyFeature]]
+    ) -> dict[PipelineFeatureType, dict[str, PolicyFeature]]:
+        for key in ["delta_x", "delta_y", "delta_z", "delta_wx", "delta_wz", "gripper"]:
+            features[PipelineFeatureType.ACTION].pop(key, None)
+
+        for name in self.motor_names:
+            features[PipelineFeatureType.ACTION][f"{name}.pos"] = PolicyFeature(
                 type=FeatureType.ACTION, shape=(1,)
             )
 

--- a/src/lerobot/processor/factory.py
+++ b/src/lerobot/processor/factory.py
@@ -14,6 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
+import logging
+
 from lerobot.types import RobotAction, RobotObservation
 
 from .converters import (
@@ -23,6 +27,17 @@ from .converters import (
     transition_to_robot_action,
 )
 from .pipeline import IdentityProcessorStep, RobotProcessorPipeline
+
+logger = logging.getLogger(__name__)
+
+# Teleoperator types that output delta EE actions (delta_x, delta_y, delta_z, gripper)
+DELTA_TELEOP_TYPES = {"gamepad", "keyboard_ee"}
+
+# Robot types that accept joint-space actions and have IK support
+JOINT_SPACE_ROBOT_TYPES = {"so100_follower", "so101_follower"}
+
+# Motor names for SO100/SO101 arms (order matters for joint control)
+SO_MOTOR_NAMES = ["shoulder_pan", "shoulder_lift", "elbow_flex", "wrist_flex", "wrist_roll", "gripper"]
 
 
 def make_default_teleop_action_processor() -> RobotProcessorPipeline[
@@ -56,8 +71,48 @@ def make_default_robot_observation_processor() -> RobotProcessorPipeline[RobotOb
     return robot_observation_processor
 
 
-def make_default_processors():
+def make_default_processors(
+    teleop_config: object | None = None,
+    robot_config: object | None = None,
+) -> tuple[
+    RobotProcessorPipeline[tuple[RobotAction, RobotObservation], RobotAction],
+    RobotProcessorPipeline[tuple[RobotAction, RobotObservation], RobotAction],
+    RobotProcessorPipeline[RobotObservation, RobotObservation],
+]:
+    """Build the processor pipelines for the given teleop + robot combination.
+
+    When a delta teleop (gamepad, keyboard_ee) is paired with a joint-space robot
+    (so100/so101_follower), the teleop action processor is set up to map gamepad
+    axes directly to joint positions. Otherwise identity processors are returned.
+
+    Args:
+        teleop_config: The teleoperator configuration (must have a ``.type`` property).
+            When *None*, identity processors are returned.
+        robot_config: The robot configuration (must have a ``.type`` property).
+            When *None*, identity processors are returned.
+
+    Returns:
+        A 3-tuple of (teleop_action_processor, robot_action_processor,
+        robot_observation_processor).
+    """
     teleop_action_processor = make_default_teleop_action_processor()
+
+    if teleop_config is not None and robot_config is not None:
+        teleop_type = teleop_config.type
+        robot_type = robot_config.type
+
+        if teleop_type in DELTA_TELEOP_TYPES and robot_type in JOINT_SPACE_ROBOT_TYPES:
+            from lerobot.processor.delta_action_processor import MapGamepadToJointPositionsStep
+
+            logger.info("Building direct joint control pipeline (gamepad axes -> joint positions)")
+            teleop_action_processor = RobotProcessorPipeline[
+                tuple[RobotAction, RobotObservation], RobotAction
+            ](
+                steps=[MapGamepadToJointPositionsStep(motor_names=SO_MOTOR_NAMES)],
+                to_transition=robot_action_observation_to_transition,
+                to_output=transition_to_robot_action,
+            )
+
     robot_action_processor = make_default_robot_action_processor()
     robot_observation_processor = make_default_robot_observation_processor()
     return (teleop_action_processor, robot_action_processor, robot_observation_processor)

--- a/src/lerobot/scripts/lerobot_record.py
+++ b/src/lerobot/scripts/lerobot_record.py
@@ -446,7 +446,9 @@ def record(cfg: RecordConfig) -> LeRobotDataset:
     robot = make_robot_from_config(cfg.robot)
     teleop = make_teleoperator_from_config(cfg.teleop) if cfg.teleop is not None else None
 
-    teleop_action_processor, robot_action_processor, robot_observation_processor = make_default_processors()
+    teleop_action_processor, robot_action_processor, robot_observation_processor = make_default_processors(
+        cfg.teleop, cfg.robot
+    )
 
     dataset_features = combine_feature_dicts(
         aggregate_pipeline_dataset_features(

--- a/src/lerobot/scripts/lerobot_teleoperate.py
+++ b/src/lerobot/scripts/lerobot_teleoperate.py
@@ -219,7 +219,10 @@ def teleoperate(cfg: TeleoperateConfig):
 
     teleop = make_teleoperator_from_config(cfg.teleop)
     robot = make_robot_from_config(cfg.robot)
-    teleop_action_processor, robot_action_processor, robot_observation_processor = make_default_processors()
+
+    teleop_action_processor, robot_action_processor, robot_observation_processor = make_default_processors(
+        cfg.teleop, cfg.robot
+    )
 
     teleop.connect()
     robot.connect()

--- a/src/lerobot/teleoperators/gamepad/configuration_gamepad.py
+++ b/src/lerobot/teleoperators/gamepad/configuration_gamepad.py
@@ -23,3 +23,7 @@ from ..config import TeleoperatorConfig
 @dataclass
 class GamepadTeleopConfig(TeleoperatorConfig):
     use_gripper: bool = True
+    # Substring to match against device product name (e.g. "Xbox", "PS5", "Logitech Gamepad").
+    # When None, the first recognized gamepad is used. Use --teleop.device_name=Xbox to
+    # select a specific controller when multiple HID devices are connected.
+    device_name: str | None = None

--- a/src/lerobot/teleoperators/gamepad/gamepad_utils.py
+++ b/src/lerobot/teleoperators/gamepad/gamepad_utils.py
@@ -39,6 +39,8 @@ class InputController:
         self.intervention_flag = False
         self.open_gripper_command = False
         self.close_gripper_command = False
+        self.wrist_roll_command = 0.0  # -1.0 = roll left, 0 = stop, +1.0 = roll right
+        self.right_x = 0.0  # right stick horizontal, normalized -1..1
 
     def start(self):
         """Start the controller and initialize resources."""
@@ -198,11 +200,14 @@ class KeyboardController(InputController):
 class GamepadController(InputController):
     """Generate motion deltas from gamepad input."""
 
-    def __init__(self, x_step_size=1.0, y_step_size=1.0, z_step_size=1.0, deadzone=0.1):
+    def __init__(
+        self, x_step_size=1.0, y_step_size=1.0, z_step_size=1.0, deadzone=0.1, device_name: str | None = None
+    ):
         super().__init__(x_step_size, y_step_size, z_step_size)
         self.deadzone = deadzone
         self.joystick = None
         self.intervention_flag = False
+        self.device_name = device_name
 
     def start(self):
         """Initialize pygame and the gamepad."""
@@ -211,12 +216,31 @@ class GamepadController(InputController):
         pygame.init()
         pygame.joystick.init()
 
-        if pygame.joystick.get_count() == 0:
+        count = pygame.joystick.get_count()
+        if count == 0:
             logging.error("No gamepad detected. Please connect a gamepad and try again.")
             self.running = False
             return
 
-        self.joystick = pygame.joystick.Joystick(0)
+        if self.device_name is not None:
+            # Find joystick matching device_name
+            for i in range(count):
+                js = pygame.joystick.Joystick(i)
+                if self.device_name.lower() in js.get_name().lower():
+                    self.joystick = js
+                    break
+            if self.joystick is None:
+                available = [pygame.joystick.Joystick(i).get_name() for i in range(count)]
+                logging.error(
+                    f"No gamepad matching '{self.device_name}' found. "
+                    f"Available: {available}. "
+                    f"Use --teleop.device_name=<name> to select one."
+                )
+                self.running = False
+                return
+        else:
+            self.joystick = pygame.joystick.Joystick(0)
+
         self.joystick.init()
         logging.info(f"Initialized gamepad: {self.joystick.get_name()}")
 
@@ -311,25 +335,34 @@ class GamepadController(InputController):
 class GamepadControllerHID(InputController):
     """Generate motion deltas from gamepad input using HIDAPI."""
 
+    # HID usage_page=0x01 (Generic Desktop), usage=0x05 (Game Pad) per USB HID spec
+    GAMEPAD_USAGE_PAGE = 0x01
+    GAMEPAD_USAGE = 0x05
+
     def __init__(
         self,
         x_step_size=1.0,
         y_step_size=1.0,
         z_step_size=1.0,
         deadzone=0.1,
+        device_name: str | None = None,
     ):
         """
         Initialize the HID gamepad controller.
 
         Args:
-            step_size: Base movement step size in meters
-            z_scale: Scaling factor for Z-axis movement
+            x_step_size: Base movement step size in meters
+            y_step_size: Base movement step size in meters
+            z_step_size: Base movement step size in meters
             deadzone: Joystick deadzone to prevent drift
+            device_name: Substring to match against HID product name. If None,
+                uses DEFAULT_GAMEPAD_NAMES to find the first recognized gamepad.
         """
         super().__init__(x_step_size, y_step_size, z_step_size)
         self.deadzone = deadzone
         self.device = None
         self.device_info = None
+        self.device_name = device_name
 
         # Movement values (normalized from -1.0 to 1.0)
         self.left_x = 0.0
@@ -341,17 +374,57 @@ class GamepadControllerHID(InputController):
         self.buttons = {}
 
     def find_device(self):
-        """Look for the gamepad device by vendor and product ID."""
+        """Find a gamepad HID device.
+
+        Uses the USB HID usage page (Generic Desktop / Game Pad) to reliably
+        identify gamepads regardless of brand. When ``device_name`` is set,
+        further filters by substring match against the product or manufacturer string.
+        """
         import hid
 
         devices = hid.enumerate()
-        for device in devices:
-            device_name = device["product_string"]
-            if any(controller in device_name for controller in ["Logitech", "Xbox", "PS4", "PS5"]):
-                return device
 
+        # First, collect all actual gamepads by HID usage
+        gamepads = [
+            d
+            for d in devices
+            if d.get("usage_page") == self.GAMEPAD_USAGE_PAGE and d.get("usage") == self.GAMEPAD_USAGE
+        ]
+
+        if self.device_name is not None:
+            # Filter gamepads by user-specified name (matches product or manufacturer)
+            needle = self.device_name.lower()
+            for gp in gamepads:
+                product = gp.get("product_string", "")
+                manufacturer = gp.get("manufacturer_string", "")
+                if needle in product.lower() or needle in manufacturer.lower():
+                    return gp
+
+            available = [
+                f"{d.get('manufacturer_string', '')} {d.get('product_string', '')}".strip() for d in gamepads
+            ]
+            logging.error(
+                f"No gamepad matching '{self.device_name}' found. "
+                f"Detected gamepads: {available if available else '(none)'}"
+            )
+            return None
+
+        # No device_name — return the first gamepad found
+        if gamepads:
+            return gamepads[0]
+
+        available = sorted(
+            {
+                f"{d.get('manufacturer_string', '')} {d.get('product_string', '')}".strip()
+                for d in devices
+                if d.get("product_string")
+            }
+        )
         logging.error(
-            "No gamepad found, check the connection and the product string in HID to add your gamepad"
+            f"No gamepad found (looked for HID usage_page={self.GAMEPAD_USAGE_PAGE:#x}, "
+            f"usage={self.GAMEPAD_USAGE:#x}). "
+            f"All HID devices: {available}. "
+            f"Use --teleop.device_name=<name> to match by product/manufacturer name."
         )
         return None
 
@@ -406,55 +479,116 @@ class GamepadControllerHID(InputController):
             return
 
         try:
-            # Read data from the gamepad
             data = self.device.read(64)
-            # Interpret gamepad data - this will vary by controller model
-            # These offsets are for the Logitech RumblePad 2
-            if data and len(data) >= 8:
-                # Normalize joystick values from 0-255 to -1.0-1.0
-                self.left_y = (data[1] - 128) / 128.0
-                self.left_x = (data[2] - 128) / 128.0
-                self.right_x = (data[3] - 128) / 128.0
-                self.right_y = (data[4] - 128) / 128.0
+            if not data:
+                return
 
-                # Apply deadzone
-                self.left_y = 0 if abs(self.left_y) < self.deadzone else self.left_y
-                self.left_x = 0 if abs(self.left_x) < self.deadzone else self.left_x
-                self.right_x = 0 if abs(self.right_x) < self.deadzone else self.right_x
-                self.right_y = 0 if abs(self.right_y) < self.deadzone else self.right_y
-
-                # Parse button states (byte 5 in the Logitech RumblePad 2)
-                buttons = data[5]
-
-                # Check if RB is pressed then the intervention flag should be set
-                self.intervention_flag = data[6] in [2, 6, 10, 14]
-
-                # Check if RT is pressed
-                self.open_gripper_command = data[6] in [8, 10, 12]
-
-                # Check if LT is pressed
-                self.close_gripper_command = data[6] in [4, 6, 12]
-
-                # Check if Y/Triangle button (bit 7) is pressed for saving
-                # Check if X/Square button (bit 5) is pressed for failure
-                # Check if A/Cross button (bit 4) is pressed for rerecording
-                if buttons & 1 << 7:
-                    self.episode_end_status = TeleopEvents.SUCCESS
-                elif buttons & 1 << 5:
-                    self.episode_end_status = TeleopEvents.FAILURE
-                elif buttons & 1 << 4:
-                    self.episode_end_status = TeleopEvents.RERECORD_EPISODE
-                else:
-                    self.episode_end_status = None
+            # Xbox One / Xbox Series controller: 18-byte GIP report (packet type 0x20)
+            # Layout:
+            #   byte[0]    = 0x20 (packet type)
+            #   byte[1]    = 0x00
+            #   byte[2:4]  = u16 LE packet counter
+            #   byte[4]    = buttons: sync(0), _(1), start(2), back(3), A(4), B(5), X(6), Y(7)
+            #   byte[5]    = buttons: dpad_up(0), dpad_down(1), dpad_left(2), dpad_right(3), LB(4), RB(5), L3(6), R3(7)
+            #   byte[6:8]  = u16 LE left trigger  (0-1023)
+            #   byte[8:10] = u16 LE right trigger  (0-1023)
+            #   byte[10:12]= s16 LE left stick X  (-32768 to 32767)
+            #   byte[12:14]= s16 LE left stick Y  (-32768 to 32767)
+            #   byte[14:16]= s16 LE right stick X (-32768 to 32767)
+            #   byte[16:18]= s16 LE right stick Y (-32768 to 32767)
+            if len(data) == 18 and data[0] == 0x20:
+                self._update_xbox(data)
+            elif len(data) >= 8:
+                self._update_logitech(data)
 
         except OSError as e:
             logging.error(f"Error reading from gamepad: {e}")
 
+    def _update_xbox(self, data: list[int]) -> None:
+        """Parse an Xbox One / Xbox Series controller GIP report."""
+        import struct
+
+        # Sticks: signed 16-bit LE, normalize to -1.0..1.0
+        lx = struct.unpack_from("<h", bytes(data), 10)[0] / 32768.0
+        ly = struct.unpack_from("<h", bytes(data), 12)[0] / 32768.0
+        rx = struct.unpack_from("<h", bytes(data), 14)[0] / 32768.0
+        ry = struct.unpack_from("<h", bytes(data), 16)[0] / 32768.0
+
+        # Negate Y axes to match SDL/Logitech convention (stick up = negative)
+        self.left_x = 0.0 if abs(lx) < self.deadzone else lx
+        self.left_y = 0.0 if abs(ly) < self.deadzone else -ly
+        self.right_x = 0.0 if abs(rx) < self.deadzone else rx
+        self.right_y = 0.0 if abs(ry) < self.deadzone else -ry
+
+        # Triggers: unsigned 16-bit LE (0-1023)
+        lt = struct.unpack_from("<H", bytes(data), 6)[0]
+        rt = struct.unpack_from("<H", bytes(data), 8)[0]
+
+        # Use triggers for gripper: RT = open, LT = close (threshold ~10% of 1023)
+        self.open_gripper_command = rt > 100
+        self.close_gripper_command = lt > 100
+
+        # Buttons byte 4: A(bit4), B(bit5), X(bit6), Y(bit7)
+        btn0 = data[4]
+        # Buttons byte 5: LB(bit4), RB(bit5)
+        btn1 = data[5]
+
+        # LB/RB for wrist roll: LB = roll left (-1), RB = roll right (+1)
+        lb = bool(btn1 & (1 << 4))
+        rb = bool(btn1 & (1 << 5))
+        if lb and not rb:
+            self.wrist_roll_command = -1.0
+        elif rb and not lb:
+            self.wrist_roll_command = 1.0
+        else:
+            self.wrist_roll_command = 0.0
+
+        # Y = success, X = failure, A = rerecord
+        if btn0 & (1 << 7):  # Y
+            self.episode_end_status = TeleopEvents.SUCCESS
+        elif btn0 & (1 << 6):  # X
+            self.episode_end_status = TeleopEvents.FAILURE
+        elif btn0 & (1 << 4):  # A
+            self.episode_end_status = TeleopEvents.RERECORD_EPISODE
+        else:
+            self.episode_end_status = None
+
+    def _update_logitech(self, data: list[int]) -> None:
+        """Parse a Logitech RumblePad 2 HID report."""
+        # Normalize joystick values from 0-255 to -1.0..1.0
+        self.left_y = (data[1] - 128) / 128.0
+        self.left_x = (data[2] - 128) / 128.0
+        self.right_x = (data[3] - 128) / 128.0
+        self.right_y = (data[4] - 128) / 128.0
+
+        self.left_y = 0 if abs(self.left_y) < self.deadzone else self.left_y
+        self.left_x = 0 if abs(self.left_x) < self.deadzone else self.left_x
+        self.right_x = 0 if abs(self.right_x) < self.deadzone else self.right_x
+        self.right_y = 0 if abs(self.right_y) < self.deadzone else self.right_y
+
+        buttons = data[5]
+
+        self.intervention_flag = data[6] in [2, 6, 10, 14]
+        self.open_gripper_command = data[6] in [8, 10, 12]
+        self.close_gripper_command = data[6] in [4, 6, 12]
+
+        if buttons & 1 << 7:
+            self.episode_end_status = TeleopEvents.SUCCESS
+        elif buttons & 1 << 5:
+            self.episode_end_status = TeleopEvents.FAILURE
+        elif buttons & 1 << 4:
+            self.episode_end_status = TeleopEvents.RERECORD_EPISODE
+        else:
+            self.episode_end_status = None
+
     def get_deltas(self):
         """Get the current movement deltas from gamepad state."""
-        # Calculate deltas - invert as needed based on controller orientation
-        delta_x = -self.left_x * self.x_step_size  # Forward/backward
-        delta_y = -self.left_y * self.y_step_size  # Left/right
-        delta_z = -self.right_y * self.z_step_size  # Up/down
+        # Left stick vertical (left_y) → forward/backward (delta_x)
+        # Left stick horizontal (left_x) → left/right (delta_y)
+        # Right stick vertical (right_y) → up/down (delta_z)
+        # Convention: stick up/left = negative value (SDL/Logitech), negate to get positive forward/left/up
+        delta_x = -self.left_y * self.x_step_size
+        delta_y = -self.left_x * self.y_step_size
+        delta_z = -self.right_y * self.z_step_size
 
         return delta_x, delta_y, delta_z

--- a/src/lerobot/teleoperators/gamepad/teleop_gamepad.py
+++ b/src/lerobot/teleoperators/gamepad/teleop_gamepad.py
@@ -18,8 +18,6 @@ import sys
 from enum import IntEnum
 from typing import Any
 
-import numpy as np
-
 from lerobot.types import RobotAction
 from lerobot.utils.decorators import check_if_not_connected
 
@@ -78,12 +76,12 @@ class GamepadTeleop(Teleoperator):
     def connect(self) -> None:
         # use HidApi for macos
         if sys.platform == "darwin":
-            # NOTE: On macOS, pygame doesn’t reliably detect input from some controllers so we fall back to hidapi
+            # NOTE: On macOS, pygame doesn't reliably detect input from some controllers so we fall back to hidapi
             from .gamepad_utils import GamepadControllerHID as Gamepad
         else:
             from .gamepad_utils import GamepadController as Gamepad
 
-        self.gamepad = Gamepad()
+        self.gamepad = Gamepad(device_name=self.config.device_name)
         self.gamepad.start()
 
     @check_if_not_connected
@@ -95,12 +93,12 @@ class GamepadTeleop(Teleoperator):
         delta_x, delta_y, delta_z = self.gamepad.get_deltas()
 
         # Create action from gamepad input
-        gamepad_action = np.array([delta_x, delta_y, delta_z], dtype=np.float32)
-
         action_dict = {
-            "delta_x": gamepad_action[0],
-            "delta_y": gamepad_action[1],
-            "delta_z": gamepad_action[2],
+            "delta_x": float(delta_x),
+            "delta_y": float(delta_y),
+            "delta_z": float(delta_z),
+            "delta_wx": float(self.gamepad.right_x),
+            "delta_wz": float(self.gamepad.wrist_roll_command),
         }
 
         # Default gripper action is to stay

--- a/tests/processor/test_gamepad_joint_processor.py
+++ b/tests/processor/test_gamepad_joint_processor.py
@@ -1,0 +1,321 @@
+"""Tests for MapGamepadToJointPositionsStep and make_default_processors factory."""
+
+import pytest
+
+from lerobot.configs.types import FeatureType, PipelineFeatureType
+from lerobot.processor.converters import robot_action_observation_to_transition
+from lerobot.processor.delta_action_processor import MapGamepadToJointPositionsStep
+from lerobot.processor.factory import (
+    SO_MOTOR_NAMES,
+    make_default_processors,
+)
+
+MOTOR_NAMES = ["shoulder_pan", "shoulder_lift", "elbow_flex", "wrist_flex", "wrist_roll", "gripper"]
+
+
+def _make_observation(**overrides: float) -> dict[str, float]:
+    """Create a fake observation dict with motor positions."""
+    obs = {
+        "shoulder_pan.pos": 0.0,
+        "shoulder_lift.pos": 45.0,
+        "elbow_flex.pos": -30.0,
+        "wrist_flex.pos": 10.0,
+        "wrist_roll.pos": 0.0,
+        "gripper.pos": 50.0,
+    }
+    for k, v in overrides.items():
+        obs[k] = v
+    return obs
+
+
+def _make_gamepad_action(
+    delta_x: float = 0.0,
+    delta_y: float = 0.0,
+    delta_z: float = 0.0,
+    delta_wx: float = 0.0,
+    delta_wz: float = 0.0,
+    gripper: float = 1.0,
+) -> dict[str, float]:
+    """Create a gamepad action dict."""
+    return {
+        "delta_x": delta_x,
+        "delta_y": delta_y,
+        "delta_z": delta_z,
+        "delta_wx": delta_wx,
+        "delta_wz": delta_wz,
+        "gripper": gripper,
+    }
+
+
+def _run_step(
+    step: MapGamepadToJointPositionsStep,
+    action: dict[str, float],
+    observation: dict[str, float],
+) -> dict[str, float]:
+    """Run a processor step through the transition machinery."""
+    transition = robot_action_observation_to_transition((action, observation))
+    result_transition = step(transition)
+    return result_transition["action"]
+
+
+# ---------------------------------------------------------------------------
+# MapGamepadToJointPositionsStep tests
+# ---------------------------------------------------------------------------
+
+
+class TestMapGamepadToJointPositionsStep:
+    def test_no_input_preserves_positions(self):
+        """When all deltas are zero and gripper=stay, positions should be unchanged."""
+        step = MapGamepadToJointPositionsStep(motor_names=MOTOR_NAMES)
+        obs = _make_observation()
+        action = _make_gamepad_action()  # all zeros, gripper=stay(1)
+
+        result = _run_step(step, action, obs)
+
+        for name in MOTOR_NAMES:
+            assert result[f"{name}.pos"] == pytest.approx(obs[f"{name}.pos"])
+
+    def test_left_stick_y_moves_shoulder_lift(self):
+        """delta_x (left stick Y) should move shoulder_lift."""
+        step = MapGamepadToJointPositionsStep(motor_names=MOTOR_NAMES, joint_step_size=3.0)
+        obs = _make_observation()
+        action = _make_gamepad_action(delta_x=1.0)
+
+        result = _run_step(step, action, obs)
+
+        assert result["shoulder_lift.pos"] == pytest.approx(45.0 + 3.0)
+        # Other joints should be unchanged
+        assert result["shoulder_pan.pos"] == pytest.approx(0.0)
+        assert result["elbow_flex.pos"] == pytest.approx(-30.0)
+
+    def test_left_stick_x_moves_shoulder_pan(self):
+        """delta_y (left stick X) should move shoulder_pan."""
+        step = MapGamepadToJointPositionsStep(motor_names=MOTOR_NAMES, joint_step_size=3.0)
+        obs = _make_observation()
+        action = _make_gamepad_action(delta_y=-0.5)
+
+        result = _run_step(step, action, obs)
+
+        assert result["shoulder_pan.pos"] == pytest.approx(0.0 + (-0.5 * 3.0))
+
+    def test_right_stick_y_moves_elbow_flex(self):
+        """delta_z (right stick Y) should move elbow_flex."""
+        step = MapGamepadToJointPositionsStep(motor_names=MOTOR_NAMES, joint_step_size=2.0)
+        obs = _make_observation()
+        action = _make_gamepad_action(delta_z=0.8)
+
+        result = _run_step(step, action, obs)
+
+        assert result["elbow_flex.pos"] == pytest.approx(-30.0 + 0.8 * 2.0)
+
+    def test_right_stick_x_moves_wrist_flex(self):
+        """delta_wx (right stick X) should move wrist_flex."""
+        step = MapGamepadToJointPositionsStep(motor_names=MOTOR_NAMES, joint_step_size=3.0)
+        obs = _make_observation()
+        action = _make_gamepad_action(delta_wx=-1.0)
+
+        result = _run_step(step, action, obs)
+
+        assert result["wrist_flex.pos"] == pytest.approx(10.0 + (-1.0 * 3.0))
+
+    def test_bumpers_move_wrist_roll(self):
+        """delta_wz (LB/RB) should move wrist_roll."""
+        step = MapGamepadToJointPositionsStep(motor_names=MOTOR_NAMES, joint_step_size=3.0)
+        obs = _make_observation()
+
+        # RB pressed (+1)
+        result = _run_step(step, _make_gamepad_action(delta_wz=1.0), obs)
+        assert result["wrist_roll.pos"] == pytest.approx(0.0 + 3.0)
+
+        # LB pressed (-1)
+        result = _run_step(step, _make_gamepad_action(delta_wz=-1.0), obs)
+        assert result["wrist_roll.pos"] == pytest.approx(0.0 - 3.0)
+
+    def test_gripper_open(self):
+        """Gripper action 0 (CLOSE) should decrease position."""
+        step = MapGamepadToJointPositionsStep(motor_names=MOTOR_NAMES, gripper_step_size=5.0)
+        obs = _make_observation()
+        action = _make_gamepad_action(gripper=0.0)
+
+        result = _run_step(step, action, obs)
+
+        assert result["gripper.pos"] == pytest.approx(50.0 - 5.0)
+
+    def test_gripper_close(self):
+        """Gripper action 2 (OPEN) should increase position."""
+        step = MapGamepadToJointPositionsStep(motor_names=MOTOR_NAMES, gripper_step_size=5.0)
+        obs = _make_observation()
+        action = _make_gamepad_action(gripper=2.0)
+
+        result = _run_step(step, action, obs)
+
+        assert result["gripper.pos"] == pytest.approx(50.0 + 5.0)
+
+    def test_gripper_stay(self):
+        """Gripper action 1 (STAY) should not change position."""
+        step = MapGamepadToJointPositionsStep(motor_names=MOTOR_NAMES)
+        obs = _make_observation()
+        action = _make_gamepad_action(gripper=1.0)
+
+        result = _run_step(step, action, obs)
+
+        assert result["gripper.pos"] == pytest.approx(50.0)
+
+    def test_gripper_clamps_at_zero(self):
+        """Gripper should not go below 0."""
+        step = MapGamepadToJointPositionsStep(motor_names=MOTOR_NAMES, gripper_step_size=10.0)
+        obs = _make_observation(**{"gripper.pos": 3.0})
+        action = _make_gamepad_action(gripper=0.0)
+
+        result = _run_step(step, action, obs)
+
+        assert result["gripper.pos"] == pytest.approx(0.0)
+
+    def test_gripper_clamps_at_hundred(self):
+        """Gripper should not go above 100."""
+        step = MapGamepadToJointPositionsStep(motor_names=MOTOR_NAMES, gripper_step_size=10.0)
+        obs = _make_observation(**{"gripper.pos": 97.0})
+        action = _make_gamepad_action(gripper=2.0)
+
+        result = _run_step(step, action, obs)
+
+        assert result["gripper.pos"] == pytest.approx(100.0)
+
+    def test_multiple_axes_simultaneously(self):
+        """Multiple axes should be applied independently."""
+        step = MapGamepadToJointPositionsStep(motor_names=MOTOR_NAMES, joint_step_size=2.0)
+        obs = _make_observation()
+        action = _make_gamepad_action(delta_x=1.0, delta_y=-0.5, delta_z=0.3)
+
+        result = _run_step(step, action, obs)
+
+        assert result["shoulder_lift.pos"] == pytest.approx(45.0 + 1.0 * 2.0)
+        assert result["shoulder_pan.pos"] == pytest.approx(0.0 + (-0.5) * 2.0)
+        assert result["elbow_flex.pos"] == pytest.approx(-30.0 + 0.3 * 2.0)
+
+    def test_outputs_all_motor_names(self):
+        """Result should have a .pos key for every motor name."""
+        step = MapGamepadToJointPositionsStep(motor_names=MOTOR_NAMES)
+        obs = _make_observation()
+        action = _make_gamepad_action()
+
+        result = _run_step(step, action, obs)
+
+        for name in MOTOR_NAMES:
+            assert f"{name}.pos" in result
+
+    def test_transform_features_removes_deltas_adds_motor_pos(self, policy_feature_factory):
+        """transform_features should remove delta keys and add motor.pos keys."""
+        step = MapGamepadToJointPositionsStep(motor_names=MOTOR_NAMES)
+        features = {
+            PipelineFeatureType.ACTION: {
+                "delta_x": policy_feature_factory(FeatureType.ACTION, (1,)),
+                "delta_y": policy_feature_factory(FeatureType.ACTION, (1,)),
+                "delta_z": policy_feature_factory(FeatureType.ACTION, (1,)),
+                "delta_wx": policy_feature_factory(FeatureType.ACTION, (1,)),
+                "delta_wz": policy_feature_factory(FeatureType.ACTION, (1,)),
+                "gripper": policy_feature_factory(FeatureType.ACTION, (1,)),
+            },
+            PipelineFeatureType.OBSERVATION: {},
+        }
+
+        out = step.transform_features(features)
+
+        # Deltas should be removed
+        for key in ["delta_x", "delta_y", "delta_z", "delta_wx", "delta_wz", "gripper"]:
+            assert key not in out[PipelineFeatureType.ACTION]
+
+        # Motor positions should be added
+        for name in MOTOR_NAMES:
+            assert f"{name}.pos" in out[PipelineFeatureType.ACTION]
+
+
+# ---------------------------------------------------------------------------
+# make_processors factory tests
+# ---------------------------------------------------------------------------
+
+
+class _FakeConfig:
+    """Minimal config stub with a .type property."""
+
+    def __init__(self, config_type: str):
+        self._type = config_type
+
+    @property
+    def type(self) -> str:
+        return self._type
+
+
+class TestMakeProcessors:
+    def test_gamepad_so_follower_returns_joint_pipeline(self):
+        """Gamepad + SO follower should return the direct joint control pipeline."""
+        teleop_cfg = _FakeConfig("gamepad")
+        robot_cfg = _FakeConfig("so101_follower")
+
+        teleop_proc, robot_proc, obs_proc = make_default_processors(teleop_cfg, robot_cfg)
+
+        # The teleop processor should contain a MapGamepadToJointPositionsStep
+        assert len(teleop_proc.steps) == 1
+        assert isinstance(teleop_proc.steps[0], MapGamepadToJointPositionsStep)
+
+    def test_keyboard_ee_so_follower_returns_joint_pipeline(self):
+        """keyboard_ee + SO follower should also trigger the joint control pipeline."""
+        teleop_cfg = _FakeConfig("keyboard_ee")
+        robot_cfg = _FakeConfig("so100_follower")
+
+        teleop_proc, _, _ = make_default_processors(teleop_cfg, robot_cfg)
+
+        assert isinstance(teleop_proc.steps[0], MapGamepadToJointPositionsStep)
+
+    def test_leader_follower_returns_default_pipeline(self):
+        """Leader-follower teleop should return default (identity) processors."""
+        teleop_cfg = _FakeConfig("so101_leader")
+        robot_cfg = _FakeConfig("so101_follower")
+
+        result = make_default_processors(teleop_cfg, robot_cfg)
+        default = make_default_processors()
+
+        # Both should have a single IdentityProcessorStep in each pipeline
+        assert len(result[0].steps) == len(default[0].steps)
+        assert type(result[0].steps[0]) is type(default[0].steps[0])
+
+    def test_gamepad_non_so_robot_returns_default_pipeline(self):
+        """Gamepad + non-SO robot should return default processors."""
+        teleop_cfg = _FakeConfig("gamepad")
+        robot_cfg = _FakeConfig("koch_follower")
+
+        result = make_default_processors(teleop_cfg, robot_cfg)
+        default = make_default_processors()
+
+        assert type(result[0].steps[0]) is type(default[0].steps[0])
+
+    def test_so_motor_names_constant(self):
+        """SO_MOTOR_NAMES should contain the expected 6 motors in order."""
+        assert SO_MOTOR_NAMES == [
+            "shoulder_pan",
+            "shoulder_lift",
+            "elbow_flex",
+            "wrist_flex",
+            "wrist_roll",
+            "gripper",
+        ]
+
+    def test_joint_pipeline_end_to_end(self):
+        """Full end-to-end test: gamepad action + observation -> motor positions."""
+        teleop_cfg = _FakeConfig("gamepad")
+        robot_cfg = _FakeConfig("so101_follower")
+
+        teleop_proc, robot_proc, _ = make_default_processors(teleop_cfg, robot_cfg)
+
+        obs = _make_observation()
+        action = _make_gamepad_action(delta_x=1.0, gripper=2.0)
+
+        # Run through the teleop processor (which is the only non-identity one)
+        teleop_result = teleop_proc((action, obs))
+
+        # Should have motor.pos keys
+        assert "shoulder_lift.pos" in teleop_result
+
+        # Robot processor is identity, should pass through
+        robot_result = robot_proc((teleop_result, obs))
+        assert robot_result == teleop_result

--- a/tests/teleoperators/test_gamepad_controller.py
+++ b/tests/teleoperators/test_gamepad_controller.py
@@ -1,0 +1,315 @@
+"""Tests for gamepad controller HID parsing and input handling.
+
+These tests validate the Xbox controller GIP report parsing and the
+gamepad axis-to-delta mapping without requiring actual hardware.
+"""
+
+import struct
+
+import pytest
+
+from lerobot.teleoperators.gamepad.gamepad_utils import (
+    GamepadControllerHID,
+    InputController,
+)
+
+# ---------------------------------------------------------------------------
+# InputController base class
+# ---------------------------------------------------------------------------
+
+
+class TestInputController:
+    def test_default_attributes(self):
+        ctrl = InputController()
+        assert ctrl.wrist_roll_command == 0.0
+        assert ctrl.right_x == 0.0
+        assert ctrl.open_gripper_command is False
+        assert ctrl.close_gripper_command is False
+
+    def test_gripper_command_stay(self):
+        ctrl = InputController()
+        assert ctrl.gripper_command() == "stay"
+
+    def test_gripper_command_open(self):
+        ctrl = InputController()
+        ctrl.open_gripper_command = True
+        assert ctrl.gripper_command() == "open"
+
+    def test_gripper_command_close(self):
+        ctrl = InputController()
+        ctrl.close_gripper_command = True
+        assert ctrl.gripper_command() == "close"
+
+
+# ---------------------------------------------------------------------------
+# Xbox GIP report helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_xbox_report(
+    *,
+    lx: int = 0,
+    ly: int = 0,
+    rx: int = 0,
+    ry: int = 0,
+    lt: int = 0,
+    rt: int = 0,
+    buttons0: int = 0,
+    buttons1: int = 0,
+) -> list[int]:
+    """Build a minimal 18-byte Xbox One GIP HID report.
+
+    Args:
+        lx, ly, rx, ry: Signed 16-bit stick values (-32768..32767).
+        lt, rt: Unsigned 16-bit trigger values (0..1023).
+        buttons0: Byte 4 bitmask (A=bit4, B=bit5, X=bit6, Y=bit7).
+        buttons1: Byte 5 bitmask (LB=bit4, RB=bit5).
+    """
+    buf = bytearray(18)
+    buf[0] = 0x20  # GIP packet type
+    buf[1] = 0x00
+    struct.pack_into("<H", buf, 2, 0)  # counter
+    buf[4] = buttons0
+    buf[5] = buttons1
+    struct.pack_into("<H", buf, 6, lt)
+    struct.pack_into("<H", buf, 8, rt)
+    struct.pack_into("<h", buf, 10, lx)
+    struct.pack_into("<h", buf, 12, ly)
+    struct.pack_into("<h", buf, 14, rx)
+    struct.pack_into("<h", buf, 16, ry)
+    return list(buf)
+
+
+# ---------------------------------------------------------------------------
+# Xbox HID parsing tests
+# ---------------------------------------------------------------------------
+
+
+class TestXboxHIDParsing:
+    """Test _update_xbox() by feeding raw byte data to the controller."""
+
+    def _make_controller(self, deadzone: float = 0.1) -> GamepadControllerHID:
+        ctrl = GamepadControllerHID(deadzone=deadzone)
+        # Don't call start() — we'll feed data directly via _update_xbox()
+        return ctrl
+
+    def test_sticks_at_rest(self):
+        ctrl = self._make_controller()
+        report = _build_xbox_report()
+        ctrl._update_xbox(report)
+
+        assert ctrl.left_x == 0.0
+        assert ctrl.left_y == 0.0
+        assert ctrl.right_x == 0.0
+        assert ctrl.right_y == 0.0
+
+    def test_left_stick_full_right(self):
+        ctrl = self._make_controller()
+        report = _build_xbox_report(lx=32767)
+        ctrl._update_xbox(report)
+
+        assert ctrl.left_x == pytest.approx(32767 / 32768.0, abs=0.01)
+        assert ctrl.left_y == 0.0
+
+    def test_left_stick_full_up(self):
+        """Xbox HID: stick up = positive ly. After negation, left_y should be negative."""
+        ctrl = self._make_controller()
+        report = _build_xbox_report(ly=32767)
+        ctrl._update_xbox(report)
+
+        # Y is negated to match SDL convention (up = negative)
+        assert ctrl.left_y == pytest.approx(-32767 / 32768.0, abs=0.01)
+
+    def test_right_stick_full_up(self):
+        """right_y should also be negated (up = negative)."""
+        ctrl = self._make_controller()
+        report = _build_xbox_report(ry=32767)
+        ctrl._update_xbox(report)
+
+        assert ctrl.right_y == pytest.approx(-32767 / 32768.0, abs=0.01)
+
+    def test_right_stick_x_not_negated(self):
+        """right_x should NOT be negated."""
+        ctrl = self._make_controller()
+        report = _build_xbox_report(rx=32767)
+        ctrl._update_xbox(report)
+
+        assert ctrl.right_x == pytest.approx(32767 / 32768.0, abs=0.01)
+
+    def test_deadzone_filters_small_values(self):
+        ctrl = self._make_controller(deadzone=0.1)
+        # ~5% deflection → should be zeroed by deadzone
+        small_val = int(0.05 * 32768)
+        report = _build_xbox_report(lx=small_val, ly=small_val)
+        ctrl._update_xbox(report)
+
+        assert ctrl.left_x == 0.0
+        assert ctrl.left_y == 0.0
+
+    def test_deadzone_passes_large_values(self):
+        ctrl = self._make_controller(deadzone=0.1)
+        # ~50% deflection → should pass through
+        large_val = int(0.5 * 32768)
+        report = _build_xbox_report(lx=large_val)
+        ctrl._update_xbox(report)
+
+        assert ctrl.left_x != 0.0
+
+    def test_triggers_gripper(self):
+        ctrl = self._make_controller()
+
+        # LT pressed → close gripper
+        report = _build_xbox_report(lt=500)
+        ctrl._update_xbox(report)
+        assert ctrl.close_gripper_command is True
+        assert ctrl.open_gripper_command is False
+
+        # RT pressed → open gripper
+        report = _build_xbox_report(rt=500)
+        ctrl._update_xbox(report)
+        assert ctrl.open_gripper_command is True
+
+    def test_triggers_below_threshold_no_gripper(self):
+        ctrl = self._make_controller()
+        report = _build_xbox_report(lt=50, rt=50)
+        ctrl._update_xbox(report)
+
+        assert ctrl.close_gripper_command is False
+        assert ctrl.open_gripper_command is False
+
+    def test_lb_wrist_roll_left(self):
+        ctrl = self._make_controller()
+        report = _build_xbox_report(buttons1=(1 << 4))  # LB
+        ctrl._update_xbox(report)
+
+        assert ctrl.wrist_roll_command == -1.0
+
+    def test_rb_wrist_roll_right(self):
+        ctrl = self._make_controller()
+        report = _build_xbox_report(buttons1=(1 << 5))  # RB
+        ctrl._update_xbox(report)
+
+        assert ctrl.wrist_roll_command == 1.0
+
+    def test_both_bumpers_no_roll(self):
+        ctrl = self._make_controller()
+        report = _build_xbox_report(buttons1=(1 << 4) | (1 << 5))  # LB+RB
+        ctrl._update_xbox(report)
+
+        assert ctrl.wrist_roll_command == 0.0
+
+    def test_no_bumpers_no_roll(self):
+        ctrl = self._make_controller()
+        report = _build_xbox_report()
+        ctrl._update_xbox(report)
+
+        assert ctrl.wrist_roll_command == 0.0
+
+    def test_y_button_success(self):
+        from lerobot.teleoperators.utils import TeleopEvents
+
+        ctrl = self._make_controller()
+        report = _build_xbox_report(buttons0=(1 << 7))  # Y
+        ctrl._update_xbox(report)
+
+        assert ctrl.episode_end_status == TeleopEvents.SUCCESS
+
+    def test_x_button_failure(self):
+        from lerobot.teleoperators.utils import TeleopEvents
+
+        ctrl = self._make_controller()
+        report = _build_xbox_report(buttons0=(1 << 6))  # X
+        ctrl._update_xbox(report)
+
+        assert ctrl.episode_end_status == TeleopEvents.FAILURE
+
+    def test_a_button_rerecord(self):
+        from lerobot.teleoperators.utils import TeleopEvents
+
+        ctrl = self._make_controller()
+        report = _build_xbox_report(buttons0=(1 << 4))  # A
+        ctrl._update_xbox(report)
+
+        assert ctrl.episode_end_status == TeleopEvents.RERECORD_EPISODE
+
+    def test_no_buttons_clears_status(self):
+        ctrl = self._make_controller()
+        report = _build_xbox_report()
+        ctrl._update_xbox(report)
+
+        assert ctrl.episode_end_status is None
+
+
+# ---------------------------------------------------------------------------
+# get_deltas() axis mapping tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetDeltas:
+    """Test the axis-to-delta mapping in get_deltas()."""
+
+    def _make_controller(self) -> GamepadControllerHID:
+        ctrl = GamepadControllerHID(x_step_size=1.0, y_step_size=1.0, z_step_size=1.0, deadzone=0.0)
+        return ctrl
+
+    def test_left_stick_up_gives_positive_delta_x(self):
+        """Left stick up (negative left_y in SDL convention) → positive delta_x (forward)."""
+        ctrl = self._make_controller()
+        ctrl.left_y = -1.0  # SDL: up = negative
+        dx, dy, dz = ctrl.get_deltas()
+        assert dx == pytest.approx(1.0)
+
+    def test_left_stick_right_gives_negative_delta_y(self):
+        """Left stick right (positive left_x) → negative delta_y."""
+        ctrl = self._make_controller()
+        ctrl.left_x = 1.0
+        dx, dy, dz = ctrl.get_deltas()
+        assert dy == pytest.approx(-1.0)
+
+    def test_right_stick_up_gives_positive_delta_z(self):
+        """Right stick up (negative right_y in SDL convention) → positive delta_z (up)."""
+        ctrl = self._make_controller()
+        ctrl.right_y = -1.0
+        dx, dy, dz = ctrl.get_deltas()
+        assert dz == pytest.approx(1.0)
+
+    def test_idle_gives_zero_deltas(self):
+        ctrl = self._make_controller()
+        dx, dy, dz = ctrl.get_deltas()
+        assert dx == 0.0
+        assert dy == 0.0
+        assert dz == 0.0
+
+    def test_step_size_scaling(self):
+        ctrl = GamepadControllerHID(x_step_size=2.0, y_step_size=3.0, z_step_size=4.0, deadzone=0.0)
+        ctrl.left_y = -1.0
+        ctrl.left_x = 1.0
+        ctrl.right_y = -1.0
+
+        dx, dy, dz = ctrl.get_deltas()
+
+        assert dx == pytest.approx(2.0)
+        assert dy == pytest.approx(-3.0)
+        assert dz == pytest.approx(4.0)
+
+    def test_xbox_stick_up_through_full_pipeline(self):
+        """Simulate Xbox stick up → _update_xbox → get_deltas → positive delta_x."""
+        ctrl = GamepadControllerHID(x_step_size=1.0, y_step_size=1.0, z_step_size=1.0, deadzone=0.05)
+        report = _build_xbox_report(ly=32767)  # Xbox HID: stick up = positive ly
+        ctrl._update_xbox(report)
+
+        dx, dy, dz = ctrl.get_deltas()
+
+        # Should be positive (forward)
+        assert dx > 0.9
+
+    def test_xbox_right_stick_up_through_full_pipeline(self):
+        """Simulate Xbox right stick up → _update_xbox → get_deltas → positive delta_z."""
+        ctrl = GamepadControllerHID(x_step_size=1.0, y_step_size=1.0, z_step_size=1.0, deadzone=0.05)
+        report = _build_xbox_report(ry=32767)  # Xbox HID: stick up = positive ry
+        ctrl._update_xbox(report)
+
+        dx, dy, dz = ctrl.get_deltas()
+
+        # Should be positive (up)
+        assert dz > 0.9


### PR DESCRIPTION
## Title

feat(gamepad): add direct joint control for Xbox/HID gamepad with SO100/SO101

## Type / Scope

- **Type**: Feature
- **Scope**: teleoperators/gamepad, processor

## Summary / Motivation

Adds support for teleoperating SO100/SO101 follower robots directly from an Xbox controller (or any HID gamepad) by mapping each gamepad axis to an individual joint servo.

Previously, gamepad teleoperation required an inverse kinematics pipeline with a URDF and the placo C++ dependency.

This approach is simpler, has zero extra dependencies, and gives the operator direct, predictable control over each joint.

The control mapping is:
 - left stick Y → shoulder_lift,
 - left stick X → shoulder_pan,
 - right stick Y → elbow_flex,
 - right stick X → wrist_flex,
 - LB/RB → wrist_roll,
 - LT/RT → gripper.

This was intuitive enough for my 5 year old to master when playing with it locally.

## Related issues

- Fixes / Closes: #3057 
- Related: #1433  

## What changed
 - `gamepad_utils.py`: Added Xbox One GIP HID report parser (`_update_xbox`, see [docs](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-gipusb/e7c90904-5e21-426e-b9ad-d82adeee0dbc)) with 16-bit LE stick/trigger parsing and Y-axis sign normalization to match SDL convention. Replaced string-based gamepad detection with HID usage_page/usage matching. Added `wrist_roll_command` (LB/RB) and `right_x` to base `InputController`. Fixed `get_deltas()` axis mapping so left stick Y → `delta_x` and left stick X → `delta_y`.
 - `configuration_gamepad.py`: Added `device_name: str | None` config for selecting a specific gamepad by product/manufacturer substring.
 - `teleop_gamepad.py`: Action dict now includes delta_wx (right stick X) and delta_wz (wrist roll).
 - `delta_action_processor.py`: Added `MapGamepadToJointPositionsStep` processor that reads current joint positions from observation and applies scaled gamepad deltas. Also added `delta_wz` passthrough to existing `MapDeltaActionToRobotActionStep`.
 - `factory.py`: Extended `make_default_processors()` to accept optional `teleop_config`/`robot_config` params. When a delta teleop + SO follower combination is detected, it swaps in the joint control processor automatically.
 - `lerobot_teleoperate.py`: Calls `make_default_processors(cfg.teleop, cfg.robot)`.
 - No breaking changes. Existing `make_default_processors()` with no args behaves identically to before.

## How was this tested (or how to run locally)

Manual tested by teleoperating an SO101 follower with an Xbox One controller over USB on macOS using:

```bash
lerobot-teleoperate \
   --robot.type=so101_follower \
   --robot.port=/dev/tty.usbmodem58760431541 \
   --teleop.type=gamepad
```

Run tests with
```bash
pytest -v tests/teleoperators/test_gamepad_controller.py tests/processor/test_gamepad_joint_processor.py
```

- Tests added:
  - `tests/teleoperators/test_gamepad_controller.py`
  - `tests/processor/test_gamepad_joint_processor.py`

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated
- [ ] CI is green

## Reviewer notes

 - The `_update_xbox()` parser handles the Xbox One GIP protocol (18-byte reports with 0x20 header). Other Xbox-compatible controllers using this same protocol over USB should work. The existing `_update_logitech()` parser is preserved for Logitech RumblePad 2 and similar 8-byte HID reports.
 - `joint_step_size` defaults to 3.0°/frame. At 60fps this gives ~180°/s at full stick deflection. This is tunable via the `MapGamepadToJointPositionsStep` dataclass field.
 - On macOS, the HID path is used instead of pygame because pygame doesn't reliably detect Xbox controller input. The GamepadController (pygame) path on Linux is unchanged but now also has `right_x` and `wrist_roll_command` attributes from the base class.
 - The `device_name` config option is useful when multiple HID devices are connected (e.g., webcams that register as HID devices - my Logitech Streamcam was detected when using `--teleop.type=gamepad` for some reason, hence adding this).
