### PR TITLE
fix(groot):  compatibility fixes for gr00t in v0.5

### DIFF
--- a/src/lerobot/policies/groot/action_head/flow_matching_action_head.py
+++ b/src/lerobot/policies/groot/action_head/flow_matching_action_head.py
@@ -252,7 +252,7 @@ class FlowmatchingActionHead(nn.Module):
 
     def sample_time(self, batch_size, device, dtype):
         if self._beta_dist is None:
-           self._beta_dist = Beta(self._noise_beta_alpha, self._noise_beta_beta, validate_args=False)
+            self._beta_dist = Beta(self._noise_beta_alpha, self._noise_beta_beta, validate_args=False)
         sample = self._beta_dist.sample([batch_size]).to(device, dtype=dtype)
         return (self.config.noise_s - sample) / self.config.noise_s
 

--- a/src/lerobot/policies/groot/action_head/flow_matching_action_head.py
+++ b/src/lerobot/policies/groot/action_head/flow_matching_action_head.py
@@ -204,7 +204,9 @@ class FlowmatchingActionHead(nn.Module):
             self.position_embedding = nn.Embedding(config.max_seq_len, self.input_embedding_dim)
             nn.init.normal_(self.position_embedding.weight, mean=0.0, std=0.02)
 
-        self.beta_dist = Beta(config.noise_beta_alpha, config.noise_beta_beta)
+        self._noise_beta_alpha = config.noise_beta_alpha
+        self._noise_beta_beta = config.noise_beta_beta
+        self._beta_dist = None
         self.num_timestep_buckets = config.num_timestep_buckets
         self.config = config
         self.set_trainable_parameters(config.tune_projector, config.tune_diffusion_model)
@@ -249,7 +251,9 @@ class FlowmatchingActionHead(nn.Module):
                 self.model.eval()
 
     def sample_time(self, batch_size, device, dtype):
-        sample = self.beta_dist.sample([batch_size]).to(device, dtype=dtype)
+        if self._beta_dist is None:
+           self._beta_dist = Beta(self._noise_beta_alpha, self._noise_beta_beta, validate_args=False)
+        sample = self._beta_dist.sample([batch_size]).to(device, dtype=dtype)
         return (self.config.noise_s - sample) / self.config.noise_s
 
     def prepare_input(self, batch: dict) -> BatchFeature:

--- a/src/lerobot/policies/groot/eagle2_hg_model/processing_eagle2_5_vl.py
+++ b/src/lerobot/policies/groot/eagle2_hg_model/processing_eagle2_5_vl.py
@@ -247,6 +247,7 @@ class Eagle25VLProcessor(ProcessorMixin):
                         video_inputs["pixel_values"] = torch.stack(
                             [t if isinstance(t, torch.Tensor) else torch.as_tensor(t) for t in _pv]
                         )
+                    num_all_tiles = video_inputs["pixel_values"].shape[0]
                     image_sizes = video_inputs["image_sizes"]
                     if timestamps_list is not None and -1 not in timestamps_list:
                         frame_timestamps = timestamps_list[idx_in_list]
@@ -312,7 +313,7 @@ class Eagle25VLProcessor(ProcessorMixin):
                     )
                 return torch.as_tensor(v)
             pixel_values = torch.cat([_to_tensor(frame["pixel_values"]) for frame in unified_frame_list])
-            image_sizes = torch.cat([_to_tensor(frame["image_sizes"]) for frame in unified_frame_list])   
+            image_sizes = torch.cat([_to_tensor(frame["image_sizes"]) for frame in unified_frame_list])
         else:
             pixel_values = None
             image_sizes = None

--- a/src/lerobot/policies/groot/eagle2_hg_model/processing_eagle2_5_vl.py
+++ b/src/lerobot/policies/groot/eagle2_hg_model/processing_eagle2_5_vl.py
@@ -222,6 +222,13 @@ class Eagle25VLProcessor(ProcessorMixin):
                         videos=None,
                         **output_kwargs["images_kwargs"],
                     )
+                    if isinstance(image_inputs["pixel_values"], list):
+                        _pv = image_inputs["pixel_values"]
+                        if _pv and isinstance(_pv[0], list):
+                            _pv = [t for sub in _pv for t in sub]
+                        image_inputs["pixel_values"] = torch.stack(
+                            [t if isinstance(t, torch.Tensor) else torch.as_tensor(t) for t in _pv]
+                        )
                     num_all_tiles = image_inputs["pixel_values"].shape[0]
                     special_placeholder = f"<image {idx_in_list + 1}>{self.image_start_token}{self.image_token * num_all_tiles * self.tokens_per_tile}{self.image_end_token}"
                     unified_frame_list.append(image_inputs)
@@ -233,7 +240,13 @@ class Eagle25VLProcessor(ProcessorMixin):
                         videos=[video_list[idx_in_list]],
                         **output_kwargs["videos_kwargs"],
                     )
-                    num_all_tiles = video_inputs["pixel_values"].shape[0]
+                    if isinstance(video_inputs["pixel_values"], list):
+                        _pv = video_inputs["pixel_values"]
+                        if _pv and isinstance(_pv[0], list):
+                            _pv = [t for sub in _pv for t in sub]
+                        video_inputs["pixel_values"] = torch.stack(
+                            [t if isinstance(t, torch.Tensor) else torch.as_tensor(t) for t in _pv]
+                        )
                     image_sizes = video_inputs["image_sizes"]
                     if timestamps_list is not None and -1 not in timestamps_list:
                         frame_timestamps = timestamps_list[idx_in_list]
@@ -288,8 +301,18 @@ class Eagle25VLProcessor(ProcessorMixin):
 
         text = replace_in_text(text)
         if len(unified_frame_list) > 0:
-            pixel_values = torch.cat([frame["pixel_values"] for frame in unified_frame_list])
-            image_sizes = torch.cat([frame["image_sizes"] for frame in unified_frame_list])
+            def _to_tensor(v):
+                if isinstance(v, torch.Tensor):
+                    return v
+                if isinstance(v, list):
+                    if v and isinstance(v[0], list):
+                        v = [t for sub in v for t in sub]
+                    return torch.stack(
+                        [t if isinstance(t, torch.Tensor) else torch.as_tensor(t) for t in v]
+                    )
+                return torch.as_tensor(v)
+            pixel_values = torch.cat([_to_tensor(frame["pixel_values"]) for frame in unified_frame_list])
+            image_sizes = torch.cat([_to_tensor(frame["image_sizes"]) for frame in unified_frame_list])   
         else:
             pixel_values = None
             image_sizes = None

--- a/src/lerobot/policies/groot/eagle2_hg_model/processing_eagle2_5_vl.py
+++ b/src/lerobot/policies/groot/eagle2_hg_model/processing_eagle2_5_vl.py
@@ -302,16 +302,16 @@ class Eagle25VLProcessor(ProcessorMixin):
 
         text = replace_in_text(text)
         if len(unified_frame_list) > 0:
+
             def _to_tensor(v):
                 if isinstance(v, torch.Tensor):
                     return v
                 if isinstance(v, list):
                     if v and isinstance(v[0], list):
                         v = [t for sub in v for t in sub]
-                    return torch.stack(
-                        [t if isinstance(t, torch.Tensor) else torch.as_tensor(t) for t in v]
-                    )
+                    return torch.stack([t if isinstance(t, torch.Tensor) else torch.as_tensor(t) for t in v])
                 return torch.as_tensor(v)
+
             pixel_values = torch.cat([_to_tensor(frame["pixel_values"]) for frame in unified_frame_list])
             image_sizes = torch.cat([_to_tensor(frame["image_sizes"]) for frame in unified_frame_list])
         else:

--- a/src/lerobot/policies/groot/groot_n1.py
+++ b/src/lerobot/policies/groot/groot_n1.py
@@ -221,6 +221,7 @@ class GR00TN15(PreTrainedModel):
         self.action_horizon = config.action_horizon
         self.action_dim = config.action_dim
         self.compute_dtype = config.compute_dtype
+        self.post_init()
 
     def validate_inputs(self, inputs):
         # NOTE -- this should be handled internally by the model


### PR DESCRIPTION
# fix(groot): compatibility fixes for transformers v5 / PyTorch ≥2.7 (superfast init + list image outputs)

## Type / Scope

- **Type**: Bug
- **Scope**: `lerobot/policies/groot`

## Summary / Motivation

Training the `groot` policy crashes when using **lerobot v0.5.0 + transformers ≥5.3.0 + PyTorch ≥2.7**. The crashes originate from two root causes:

1. **Transformers v5 "superfast init"** runs `PreTrainedModel.__init__` inside a meta-device context where all tensors are shape-only placeholders with no storage. Any code that creates non-parameter tensors (e.g. `torch.distributions.Beta`) or relies on `post_init()` being called (required by v5 for `all_tied_weights_keys`) is broken.
2. **Transformers v5 image processor** changed the return type when called without `return_tensors`: `pixel_values` and `image_sizes` are now **Python lists** instead of stacked numpy arrays/tensors.

The fixes are minimal and non-breaking: defer `Beta` construction to first use, add the required `post_init()` call, and normalise list outputs to tensors at the two call-sites.

## Related issues

- Fixes / Closes: #3122 
- Related:

## What changed

- **`groot/action_head/flow_matching_action_head.py`**
  - Removed eager `Beta(alpha, beta)` construction from `__init__` (ran inside meta-device context → `.item()` crash on validation, and later `_sample_dirichlet` crash on sampling).
  - Stored alpha/beta as plain Python floats; added `_beta_dist = None` sentinel.
  - `sample_time()`: lazy-initialises `Beta(..., validate_args=False)` on first call, after the meta-device context has exited.

- **`groot/groot_n1.py`**
  - Added `self.post_init()` at the end of `GR00TN15.__init__`.
  - Required by transformers v5 `_finalize_model_loading` → `mark_tied_weights_as_initialized` which expects the `all_tied_weights_keys` attribute set by `post_init()`.

- **`groot/eagle2_hg_model/processing_eagle2_5_vl.py`**
  - In `replace_media_placeholder()`, after each `self.image_processor()` call, normalise the returned `pixel_values` list to a stacked tensor when needed (image path and video path).
  - Added local `_to_tensor()` helper in the final aggregation block to unify `pixel_values` and `image_sizes` from list/array/tensor to `torch.Tensor` before `torch.cat(...)`.

No breaking changes. No public API or config schema modified.

## How was this tested (or how to run locally)

Conda environment:

```
name: lerobot_groot
channels:
  - conda-forge
dependencies:
  - python=3.12
  - lerobot
  - num2words
  - transformers
  - peft
  - flash-attn
  - dm-tree
```

- Manual end-to-end training run with the patched branch:

  ```bash
  lerobot-train \
    --dataset.repo_id=lerobot/pusht \
    --policy.type=groot \
    --output_dir=outputs/train/groot_test \
    --job_name=groot_test \
    --policy.device=cuda \
    --policy.repo_id=none
  ```

- Confirmed training proceeds past model init, weight loading, preprocessing, and the first forward pass without any of the four errors.

- Run existing groot-related tests:

  ```bash
  pytest -q tests/ -k groot
  ```

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated
- [x] CI is green

## Reviewer notes

- The key subtlety in the `flow_matching_action_head.py` fix: passing `validate_args=False` alone is **not sufficient**. It  still creates `Beta`'s internal `Dirichlet` concentration tensors as meta tensors, triggering an error at sampling time. Full lazy construction (creating `Beta` only after the meta-device context exits) is required to fix both.
- `processing_eagle2_5_vl.py` is copied by lerobot into the HuggingFace modules cache at runtime (`~/.cache/huggingface/modules/transformers_modules/...`). Patching the source file in the package is sufficient for fresh runs; reviewers with an existing cache may need to delete it to pick up the fix.
- Anyone in the community is free to review the PR.
