### PR TITLE
fix(lekiwi): align default use_degrees with SO leader teleop

### DIFF
--- a/tests/robots/test_lekiwi_config.py
+++ b/tests/robots/test_lekiwi_config.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from lerobot.robots.lekiwi import LeKiwiConfig
+from lerobot.teleoperators.so_leader import SOLeaderConfig
+
+
+def test_lekiwi_use_degrees_defaults_true():
+    cfg = LeKiwiConfig()
+    assert cfg.use_degrees
+
+
+def test_lekiwi_and_so_leader_defaults_are_consistent():
+    lekiwi_cfg = LeKiwiConfig()
+    so_leader_cfg = SOLeaderConfig(port="/dev/null")
+
+    assert lekiwi_cfg.use_degrees is so_leader_cfg.use_degrees


### PR DESCRIPTION
## Summary
- set `LeKiwiConfig.use_degrees` default to `True` to match SO leader/follower defaults
- add regression tests to lock the default and default-consistency contract

## Why
Issue #3176 reports that LeKiwi teleoperation can produce wrist-roll scale mismatch after v0.4.4 due to a default-unit mismatch (leader defaults to degrees while LeKiwi follower defaulted to normalized range).

Aligning defaults removes this out-of-the-box mismatch while still allowing explicit override when needed.

## Tests
- added `tests/robots/test_lekiwi_config.py`:
  - `test_lekiwi_use_degrees_defaults_true`
  - `test_lekiwi_and_so_leader_defaults_are_consistent`

Note: I could not run pytest locally in this environment because only Python 3.10 is available here while this repository uses Python 3.12+ syntax in core modules.