### PR TITLE
fix(links): update GitHub issues link in async docs

### DIFF
--- a/docs/source/async.mdx
+++ b/docs/source/async.mdx
@@ -310,4 +310,4 @@ Asynchronous inference represents a significant advancement in real-time robotic
 - **Universal Compatibility**: Works with all LeRobot-supported policies, from lightweight ACT models to vision-language models like SmolVLA
 
 Start experimenting with the default parameters, monitor your action queue sizes, and iteratively refine your setup to achieve optimal performance for your specific use case.
-If you want to discuss this further, hop into our [Discord community](https://discord.gg/s3KuuzsPFb), or open an issue on our [GitHub repository](https://github.com/lerobot/lerobot/issues).
+If you want to discuss this further, hop into our [Discord community](https://discord.gg/s3KuuzsPFb), or open an issue on our [GitHub repository](https://github.com/huggingface/lerobot/issues).


### PR DESCRIPTION
## Title

fix(links): update GitHub issues link in async docs

## Type / Scope

- **Type**: Docs
- **Scope**: Async docs

## Summary / Motivation

This PR fixes an invalid GitHub issues link in the async documentation by replacing `https://github.com/lerobot/lerobot/issues` 
with the correct repository URL: `https://github.com/huggingface/lerobot/issues`.

## Related issues
- Fixes / Closes: N/A
- Related: N/A

## What changed

- Invalid GitHub issues link -> Correct GitHub issues link in `docs/source/async.mdx`.

## How was this tested (or how to run locally)

- N/A (docs-only, single-link fix)

## Checklist (required before merge)
- [ ] Linting/formatting run (`pre-commit run -a`)
- [ ] All tests pass locally (`pytest`)
- [x] Documentation updated
- [ ] CI is green

## Reviewer notes

Tiny docs-only fix (single line, single file), no code or behavior impact
