### PR TITLE
Fix policy type check in eval_policy function to use unwrapped model

### DIFF
--- a/src/lerobot/scripts/lerobot_eval.py
+++ b/src/lerobot/scripts/lerobot_eval.py
@@ -279,7 +279,6 @@ def eval_policy(
     """
     if max_episodes_rendered > 0 and not videos_dir:
         raise ValueError("If max_episodes_rendered > 0, videos_dir must be provided.")
-    
     unwrapped_policy = extract_model_from_parallel(policy, keep_torch_compile=False)
 
     if not isinstance(unwrapped_policy, PreTrainedPolicy):


### PR DESCRIPTION
## Title

When using accelerate to run the training the eval function check the policy type which being wrapped raises and exception. This PR fixes it.

## Type / Scope

- **Type**: Bug
- **Scope**: eval

## How was this tested (or how to run locally)

- Running a training with periodic evaluations


## Checklist (required before merge)

- [ ] Linting/formatting run (`pre-commit run -a`)
- [ ] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [ ] CI is green
