### PR TITLE
fix(groot): adjust action slicing to use n_action_steps for improved …

### DIFF
--- a/src/lerobot/policies/groot/modeling_groot.py
+++ b/src/lerobot/policies/groot/modeling_groot.py
@@ -278,7 +278,7 @@ class GrootPolicy(PreTrainedPolicy):
         actions = outputs.get("action_pred")
 
         original_action_dim = self.config.output_features[ACTION].shape[0]
-        actions = actions[:, :, :original_action_dim]
+        actions = actions[:, : self.config.n_action_steps, :original_action_dim]
 
         return actions
 


### PR DESCRIPTION


## Fixed Gr00t Chunking

Fixing groot chunking.
Without this PR predict_action_chunk was returning a full chunk that was then added to a dequeue of lenght .n_action_steps.
If action_steps was lower than the chunk length the queue discarded the first elements/
. 
## Type / Scope

- **Type**: Bug
- **Scope**: gr00t


## How was this tested (or how to run locally)

- Started training and got much higher success rate on libero



## Checklist (required before merge)

- [ ] Linting/formatting run (`pre-commit run -a`)
- [ ] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [ ] CI is green

