### PR TITLE
fix(rewards): improve factory errors for unknown reward models

### DIFF
--- a/src/lerobot/rewards/factory.py
+++ b/src/lerobot/rewards/factory.py
@@ -27,6 +27,11 @@ from lerobot.rewards.pretrained import PreTrainedRewardModel
 from lerobot.rewards.sarm.configuration_sarm import SARMConfig
 
 
+def _known_reward_model_choices() -> list[str]:
+    """Return known reward model names in deterministic order."""
+    return sorted(RewardModelConfig.get_known_choices())
+
+
 def get_reward_model_class(name: str) -> type[PreTrainedRewardModel]:
     """
     Retrieves a reward model class by its registered name.
@@ -56,7 +61,10 @@ def get_reward_model_class(name: str) -> type[PreTrainedRewardModel]:
         try:
             return _get_reward_model_cls_from_name(name=name)
         except Exception as e:
-            raise ValueError(f"Reward model type '{name}' is not available.") from e
+            raise ValueError(
+                f"Unknown reward model type '{name}'. "
+                f"Available reward models: {_known_reward_model_choices()}"
+            ) from e
 
 
 def make_reward_model_config(reward_type: str, **kwargs) -> RewardModelConfig:
@@ -86,7 +94,10 @@ def make_reward_model_config(reward_type: str, **kwargs) -> RewardModelConfig:
             config_cls = RewardModelConfig.get_choice_class(reward_type)
             return config_cls(**kwargs)
         except Exception as e:
-            raise ValueError(f"Reward model type '{reward_type}' is not available.") from e
+            raise ValueError(
+                f"Unknown reward model type '{reward_type}'. "
+                f"Available reward models: {_known_reward_model_choices()}"
+            ) from e
 
 
 def make_reward_model(cfg: RewardModelConfig, **kwargs) -> PreTrainedRewardModel:
@@ -169,7 +180,8 @@ def make_reward_pre_post_processors(
             )
         except Exception as e:
             raise ValueError(
-                f"Processor for reward model type '{reward_cfg.type}' is not implemented."
+                f"Processor for reward model type '{reward_cfg.type}' is not implemented. "
+                f"Available reward models: {_known_reward_model_choices()}"
             ) from e
         return processors
 

--- a/tests/rewards/test_reward_factory.py
+++ b/tests/rewards/test_reward_factory.py
@@ -1,0 +1,62 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for reward factory error messages and unknown types."""
+
+import pytest
+
+from lerobot.rewards.factory import (
+    get_reward_model_class,
+    make_reward_model_config,
+    make_reward_pre_post_processors,
+)
+
+
+def test_get_reward_model_class_unknown_lists_available_choices():
+    unknown_type = "nonexistent_reward_model"
+
+    with pytest.raises(ValueError, match=f"Unknown reward model type '{unknown_type}'") as exc_info:
+        get_reward_model_class(unknown_type)
+
+    message = str(exc_info.value)
+    assert "Available reward models:" in message
+    assert "reward_classifier" in message
+    assert "sarm" in message
+
+
+def test_make_reward_model_config_unknown_lists_available_choices():
+    unknown_type = "nonexistent_reward_model"
+
+    with pytest.raises(ValueError, match=f"Unknown reward model type '{unknown_type}'") as exc_info:
+        make_reward_model_config(unknown_type)
+
+    message = str(exc_info.value)
+    assert "Available reward models:" in message
+    assert "reward_classifier" in message
+    assert "sarm" in message
+
+
+def test_make_reward_pre_post_processors_unknown_lists_available_choices():
+    class DummyUnsupportedRewardConfig:
+        type = "unknown_reward_type_for_processor"
+
+    with pytest.raises(
+        ValueError, match="Processor for reward model type 'unknown_reward_type_for_processor' is not implemented."
+    ) as exc_info:
+        make_reward_pre_post_processors(DummyUnsupportedRewardConfig())
+
+    message = str(exc_info.value)
+    assert "Available reward models:" in message
+    assert "reward_classifier" in message
+    assert "sarm" in message

--- a/tests/rewards/test_reward_model_base.py
+++ b/tests/rewards/test_reward_model_base.py
@@ -50,8 +50,14 @@ def test_factory_unknown_raises():
     """Unknown name should raise ValueError."""
     from lerobot.rewards.factory import get_reward_model_class
 
-    with pytest.raises(ValueError, match="not available"):
-        get_reward_model_class("nonexistent_reward_model")
+    unknown_type = "nonexistent_reward_model"
+    with pytest.raises(ValueError, match=f"Unknown reward model type '{unknown_type}'") as exc_info:
+        get_reward_model_class(unknown_type)
+
+    message = str(exc_info.value)
+    assert "Available reward models:" in message
+    assert "reward_classifier" in message
+    assert "sarm" in message
 
 
 def test_pretrained_reward_model_requires_config_class():


### PR DESCRIPTION
## Title

fix(rewards): improve factory errors for unknown reward models

## Type / Scope

- **Type**: Test
- **Scope**: rewards factory

## Summary / Motivation

As part of Phase 1 of #3143, this PR improves developer experience in the reward model factory by making unknown-type errors actionable.  
Instead of generic messages, errors now include the list of available reward model choices.

## Related issues

- Fixes / Closes: N/A
- Related: reward models refactor call for contributions

## What changed

- Updated error messages in `src/lerobot/rewards/factory.py` for:
  - `get_reward_model_class`
  - `make_reward_model_config`
  - `make_reward_pre_post_processors`
- Added new tests in `tests/rewards/test_reward_factory.py`:
  - `test_get_reward_model_class_unknown_lists_available_choices`
  - `test_make_reward_model_config_unknown_lists_available_choices`
  - `test_make_reward_pre_post_processors_unknown_lists_available_choices`
- Updated existing test expectation in `tests/rewards/test_reward_model_base.py` to match the new message format.

## How was this tested (or how to run locally)

- Ran:

  ```bash
  pytest -q tests/rewards/test_reward_factory.py tests/rewards/test_reward_model_base.py
