### PR TITLE
fix(datasets): support multi-dimensional per-frame features in add_features

### DIFF
--- a/src/lerobot/datasets/dataset_tools.py
+++ b/src/lerobot/datasets/dataset_tools.py
@@ -1010,10 +1010,12 @@ def _copy_data_with_feature_changes(
                     df[feature_name] = feature_values
                 else:
                     feature_slice = values[frame_idx:end_idx]
-                    if len(feature_slice.shape) > 1 and feature_slice.shape[1] == 1:
+                    if feature_slice.ndim == 1:
+                        df[feature_name] = feature_slice
+                    elif feature_slice.ndim == 2 and feature_slice.shape[1] == 1:
                         df[feature_name] = feature_slice.flatten()
                     else:
-                        df[feature_name] = feature_slice
+                        df[feature_name] = list(feature_slice)
             frame_idx = end_idx
 
         # Write using the same chunk/file structure as source

--- a/tests/datasets/test_dataset_tools.py
+++ b/tests/datasets/test_dataset_tools.py
@@ -369,6 +369,40 @@ def test_add_features_with_callable(sample_dataset, tmp_path):
     assert float(first_frame["reward"]) == 0.0
 
 
+def test_add_features_with_multidimensional_values(sample_dataset, tmp_path):
+    """Test adding a multi-dimensional per-frame feature."""
+    num_frames = sample_dataset.meta.total_frames
+    latent_values = np.random.randn(num_frames, 1, 4).astype(np.float32)
+
+    feature_info = {
+        "dtype": "float32",
+        "shape": (1, 4),
+        "names": None,
+    }
+    features = {
+        "latent_vectors": (latent_values, feature_info),
+    }
+
+    with (
+        patch("lerobot.datasets.dataset_metadata.get_safe_version") as mock_get_safe_version,
+        patch("lerobot.datasets.dataset_metadata.snapshot_download") as mock_snapshot_download,
+    ):
+        mock_get_safe_version.return_value = "v3.0"
+        mock_snapshot_download.return_value = str(tmp_path / "with_latents")
+
+        new_dataset = add_features(
+            dataset=sample_dataset,
+            features=features,
+            output_dir=tmp_path / "with_latents",
+        )
+
+    assert "latent_vectors" in new_dataset.meta.features
+    sample_item = new_dataset[0]
+    assert "latent_vectors" in sample_item
+    assert isinstance(sample_item["latent_vectors"], torch.Tensor)
+    assert tuple(sample_item["latent_vectors"].shape) == (1, 4)
+
+
 def test_add_existing_feature(sample_dataset, tmp_path):
     """Test error when adding an existing feature."""
     feature_info = {"dtype": "float32", "shape": (1,)}

--- a/tests/datasets/test_dataset_tools.py
+++ b/tests/datasets/test_dataset_tools.py
@@ -372,7 +372,7 @@ def test_add_features_with_callable(sample_dataset, tmp_path):
 def test_add_features_with_multidimensional_values(sample_dataset, tmp_path):
     """Test adding a multi-dimensional per-frame feature."""
     num_frames = sample_dataset.meta.total_frames
-    latent_values = np.random.randn(num_frames, 1, 4).astype(np.float32)
+    feature_values = np.random.randn(num_frames, 1, 4).astype(np.float32)
 
     feature_info = {
         "dtype": "float32",
@@ -380,7 +380,7 @@ def test_add_features_with_multidimensional_values(sample_dataset, tmp_path):
         "names": None,
     }
     features = {
-        "latent_vectors": (latent_values, feature_info),
+        "multi_dim_feature": (feature_values, feature_info),
     }
 
     with (
@@ -388,19 +388,19 @@ def test_add_features_with_multidimensional_values(sample_dataset, tmp_path):
         patch("lerobot.datasets.dataset_metadata.snapshot_download") as mock_snapshot_download,
     ):
         mock_get_safe_version.return_value = "v3.0"
-        mock_snapshot_download.return_value = str(tmp_path / "with_latents")
+        mock_snapshot_download.return_value = str(tmp_path / "with_multi_dim_feature")
 
         new_dataset = add_features(
             dataset=sample_dataset,
             features=features,
-            output_dir=tmp_path / "with_latents",
+            output_dir=tmp_path / "with_multi_dim_feature",
         )
 
-    assert "latent_vectors" in new_dataset.meta.features
+    assert "multi_dim_feature" in new_dataset.meta.features
     sample_item = new_dataset[0]
-    assert "latent_vectors" in sample_item
-    assert isinstance(sample_item["latent_vectors"], torch.Tensor)
-    assert tuple(sample_item["latent_vectors"].shape) == (1, 4)
+    assert "multi_dim_feature" in sample_item
+    assert isinstance(sample_item["multi_dim_feature"], torch.Tensor)
+    assert tuple(sample_item["multi_dim_feature"].shape) == (1, 4)
 
 
 def test_add_existing_feature(sample_dataset, tmp_path):


### PR DESCRIPTION
## Title

  fix(datasets): support multi-dimensional per-frame features in add_features

  ## Type / Scope

  - Type: Bug
  - Scope: datasets

  ## Summary / Motivation

  This fixes add_features(...) for multi-dimensional per-frame features such as vectors with shape (1, 4) or
  (1, 32). Previously, the parquet rewrite path assigned multi-dimensional ndarray slices directly into a pandas
  column, which worked for scalar-like features but failed for array-valued per-row features because pandas expects
  one row entry per dataframe row. The fix keeps the existing scalar behavior and assigns higher-dimensional slices
  row-wise.

  ## Related issues

  - Fixes / Closes: N/A
  - Related: N/A

  ## What changed

  - Updated src/lerobot/datasets/dataset_tools.py so add_features(...):
      - keeps direct assignment for 1D feature slices
      - keeps flattening for 2D feature slices with trailing dimension 1
      - assigns higher-dimensional per-row feature slices via list(feature_slice)
  - Added a regression test in tests/datasets/test_dataset_tools.py for a float feature with shape (1, 4)

  ## How was this tested (or how to run locally)

  - Tests added:
      - tests/datasets/test_dataset_tools.py::test_add_features_with_multidimensional_values
  - Ran the relevant tests:

  pytest -sv tests/datasets/test_dataset_tools.py -k add_features

  - Manual validation:
      - verified the fix in a local dataset-editing workflow that adds per-frame latent vector features and reloads
        them successfully

  ## Checklist (required before merge)

  - [x] Linting/formatting run (pre-commit run -a)
  - [ ] All tests pass locally (pytest)
  - [ ] Documentation updated
  - [ ] CI is green