### PR TITLE
feat(async): expose configurable `obs_similarity_atol` in PolicyServerConfig

### DIFF
--- a/src/lerobot/async_inference/configs.py
+++ b/src/lerobot/async_inference/configs.py
@@ -64,6 +64,20 @@ class PolicyServerConfig:
         default=DEFAULT_OBS_QUEUE_TIMEOUT, metadata={"help": "Timeout for observation queue in seconds"}
     )
 
+    # Observation similarity configuration
+    obs_similarity_atol: float = field(
+        default=1.0,
+        metadata={
+            "help": (
+                "Absolute tolerance for the joint-space observation similarity check. "
+                "Observations whose L2 distance is below this threshold are considered "
+                "'similar' and skipped to avoid redundant inference. "
+                "Lower values trigger inference more often (useful for precise robots); "
+                "set to 0.0 to disable the similarity check entirely."
+            )
+        },
+    )
+
     def __post_init__(self):
         """Validate configuration after initialization."""
         if self.port < 1 or self.port > 65535:
@@ -77,6 +91,9 @@ class PolicyServerConfig:
 
         if self.obs_queue_timeout < 0:
             raise ValueError(f"obs_queue_timeout must be non-negative, got {self.obs_queue_timeout}")
+
+        if self.obs_similarity_atol < 0:
+            raise ValueError(f"obs_similarity_atol must be non-negative, got {self.obs_similarity_atol}")
 
     @classmethod
     def from_dict(cls, config_dict: dict) -> "PolicyServerConfig":

--- a/src/lerobot/async_inference/policy_server.py
+++ b/src/lerobot/async_inference/policy_server.py
@@ -274,7 +274,9 @@ class PolicyServer(services_pb2_grpc.AsyncInferenceServicer):
             self.logger.debug(f"Skipping observation #{obs.get_timestep()} - Timestep predicted already!")
             return False
 
-        elif observations_similar(obs, previous_obs, lerobot_features=self.lerobot_features):
+        elif observations_similar(
+            obs, previous_obs, lerobot_features=self.lerobot_features, atol=self.config.obs_similarity_atol
+        ):
             self.logger.debug(
                 f"Skipping observation #{obs.get_timestep()} - Observation too similar to last obs predicted!"
             )

--- a/src/lerobot/async_inference/policy_server.py
+++ b/src/lerobot/async_inference/policy_server.py
@@ -274,7 +274,7 @@ class PolicyServer(services_pb2_grpc.AsyncInferenceServicer):
             self.logger.debug(f"Skipping observation #{obs.get_timestep()} - Timestep predicted already!")
             return False
 
-        elif observations_similar(
+        elif self.config.obs_similarity_atol > 0.0 and observations_similar(
             obs, previous_obs, lerobot_features=self.lerobot_features, atol=self.config.obs_similarity_atol
         ):
             self.logger.debug(

--- a/tests/async_inference/test_policy_server.py
+++ b/tests/async_inference/test_policy_server.py
@@ -189,6 +189,31 @@ def test_obs_sanity_checks(policy_server):
     assert policy_server._obs_sanity_checks(obs_ok, prev) is True
 
 
+def test_obs_similarity_atol_zero_disables_check(policy_server):
+    """When obs_similarity_atol is 0.0, the similarity check is bypassed entirely
+    and even identical observations are enqueued."""
+    policy_server.config.obs_similarity_atol = 0.0
+    prev = _make_obs(torch.zeros(6), timestep=0)
+    policy_server.last_processed_obs = prev
+
+    # Identical observation — would normally be skipped
+    obs_identical = _make_obs(torch.zeros(6), timestep=1)
+    assert policy_server._obs_sanity_checks(obs_identical, prev) is True
+
+
+def test_obs_similarity_atol_custom_threshold(policy_server):
+    """A tighter atol causes previously-similar observations to pass the check."""
+    prev = _make_obs(torch.zeros(6), timestep=0)
+
+    # With default atol=1.0, a small perturbation is considered similar
+    obs_small_diff = _make_obs(torch.ones(6) * 0.1, timestep=1)
+    assert policy_server._obs_sanity_checks(obs_small_diff, prev) is False
+
+    # With a much tighter atol, the same perturbation is now considered dissimilar
+    policy_server.config.obs_similarity_atol = 0.01
+    assert policy_server._obs_sanity_checks(obs_small_diff, prev) is True
+
+
 def test_predict_action_chunk(monkeypatch, policy_server):
     """End-to-end test of `_predict_action_chunk` with a stubbed _get_action_chunk."""
     # Import only when needed


### PR DESCRIPTION
## What this PR does

Exposes the observation similarity threshold (`atol`) as a configurable parameter in `PolicyServerConfig`, addressing the issue raised in #3204.

### Problem

The async inference server uses a **hardcoded `atol=1.0`** for the joint-space observation similarity check in `_obs_sanity_checks()`. For some robot embodiments (e.g., PAL Robotics TIAGo Pro), the L2 distance between consecutive observations never exceeds this threshold, so inference is **never triggered** unless the action queue is empty (`must_go` flag). This effectively breaks the async pipeline's core optimization of skipping redundant inference for similar observations.

### Fix

Added `obs_similarity_atol: float` to `PolicyServerConfig`:

```python
# In PolicyServerConfig
obs_similarity_atol: float = field(
    default=1.0,   # preserves existing behavior
    metadata={...}
)
```

The parameter is forwarded from `PolicyServer._obs_sanity_checks()` → `observations_similar()`, which already accepts `atol` as a keyword argument (default was hardcoded at the call site).

### Usage

```python
# For robots that need more sensitive observation change detection:
config = PolicyServerConfig(obs_similarity_atol=0.1)

# To disable the similarity check entirely:
config = PolicyServerConfig(obs_similarity_atol=0.0)
```

### Changes

| File | Change |
|------|--------|
| `configs.py` | Add `obs_similarity_atol` field with default=1.0, validation, and help text |
| `policy_server.py` | Pass `self.config.obs_similarity_atol` to `observations_similar()` |

### Checklist

- [x] `ruff check` passes
- [x] `ruff format` passes
- [x] Backward compatible (default=1.0 matches previous hardcoded value)
- [x] Minimal change — 2 files, 20 lines added

Closes #3204