### PR TITLE
fix(pi0): sample Beta distribution on-device to fix torch.compile cudagraphs

### DIFF
--- a/src/lerobot/policies/pi0/modeling_pi0.py
+++ b/src/lerobot/policies/pi0/modeling_pi0.py
@@ -101,9 +101,11 @@ def create_sinusoidal_pos_embedding(  # see openpi `create_sinusoidal_pos_embedd
 
 
 def sample_beta(alpha, beta, bsize, device):  # see openpi `sample_beta` (exact copy)
-    # Beta sampling uses _sample_dirichlet which isn't implemented for MPS, so sample on CPU
-    alpha_t = torch.tensor(alpha, dtype=torch.float32)
-    beta_t = torch.tensor(beta, dtype=torch.float32)
+    # _sample_dirichlet is not implemented for MPS, so fall back to CPU sampling there.
+    # For CUDA (and CPU), sample directly on-device to avoid breaking torch.compile cudagraphs.
+    sample_device = "cpu" if (isinstance(device, torch.device) and device.type == "mps") or device == "mps" else device
+    alpha_t = torch.tensor(alpha, dtype=torch.float32, device=sample_device)
+    beta_t = torch.tensor(beta, dtype=torch.float32, device=sample_device)
     dist = torch.distributions.Beta(alpha_t, beta_t)
     return dist.sample((bsize,)).to(device)
 

--- a/src/lerobot/policies/pi05/modeling_pi05.py
+++ b/src/lerobot/policies/pi05/modeling_pi05.py
@@ -98,9 +98,11 @@ def create_sinusoidal_pos_embedding(  # see openpi `create_sinusoidal_pos_embedd
 
 
 def sample_beta(alpha, beta, bsize, device):  # see openpi `sample_beta` (exact copy)
-    # Beta sampling uses _sample_dirichlet which isn't implemented for MPS, so sample on CPU
-    alpha_t = torch.tensor(alpha, dtype=torch.float32)
-    beta_t = torch.tensor(beta, dtype=torch.float32)
+    # _sample_dirichlet is not implemented for MPS, so fall back to CPU sampling there.
+    # For CUDA (and CPU), sample directly on-device to avoid breaking torch.compile cudagraphs.
+    sample_device = "cpu" if (isinstance(device, torch.device) and device.type == "mps") or device == "mps" else device
+    alpha_t = torch.tensor(alpha, dtype=torch.float32, device=sample_device)
+    beta_t = torch.tensor(beta, dtype=torch.float32, device=sample_device)
     dist = torch.distributions.Beta(alpha_t, beta_t)
     return dist.sample((bsize,)).to(device)
 


### PR DESCRIPTION
## Summary
- Fix `sample_beta()` in Pi0 and Pi0.5 to create tensors directly on the target device instead of always on CPU
- This eliminates the `skipping cudagraphs due to cpu device` warning when training with `torch.compile` in cudagraphs mode
- Retains CPU fallback only for MPS, where `_sample_dirichlet` is not implemented

## Root Cause
`sample_beta()` creates `alpha_t` and `beta_t` tensors without specifying a device (defaulting to CPU), then moves the sampled result to the target device. When `torch.compile` traces this with cudagraphs, it sees a CPU tensor in the CUDA graph and falls back to non-cudagraph execution.

## Test plan
- [ ] Verify Pi0 training with `torch.compile` no longer shows the cudagraphs warning on CUDA
- [ ] Verify Pi0.5 training works the same
- [ ] Verify MPS training still works (falls back to CPU sampling)

Fixes #3108