### PR TITLE
perf(dataset): use select() for multi-index queries in _query_hf_dataset

### DIFF
--- a/src/lerobot/datasets/lerobot_dataset.py
+++ b/src/lerobot/datasets/lerobot_dataset.py
@@ -1008,9 +1008,9 @@ class LeRobotDataset(torch.utils.data.Dataset):
             if query_indices is not None and key in query_indices:
                 if self._absolute_to_relative_idx is not None:
                     relative_indices = [self._absolute_to_relative_idx[idx] for idx in query_indices[key]]
-                    timestamps = self.hf_dataset[relative_indices]["timestamp"]
                 else:
-                    timestamps = self.hf_dataset[query_indices[key]]["timestamp"]
+                    relative_indices = query_indices[key]
+                timestamps = self.hf_dataset.select(relative_indices)["timestamp"]
                 query_timestamps[key] = torch.stack(timestamps).tolist()
             else:
                 query_timestamps[key] = [current_ts]
@@ -1021,7 +1021,7 @@ class LeRobotDataset(torch.utils.data.Dataset):
         """
         Query dataset for indices across keys, skipping video keys.
 
-        Tries column-first [key][indices] for speed, falls back to row-first.
+        Uses select() for efficient multi-index access.
 
         Args:
             query_indices: Dict mapping keys to index lists to retrieve
@@ -1039,10 +1039,7 @@ class LeRobotDataset(torch.utils.data.Dataset):
                 if self._absolute_to_relative_idx is None
                 else [self._absolute_to_relative_idx[idx] for idx in q_idx]
             )
-            try:
-                result[key] = torch.stack(self.hf_dataset[key][relative_indices])
-            except (KeyError, TypeError, IndexError):
-                result[key] = torch.stack(self.hf_dataset[relative_indices][key])
+            result[key] = torch.stack(self.hf_dataset.select(relative_indices)[key])
         return result
 
     def _query_videos(self, query_timestamps: dict[str, list[float]], ep_idx: int) -> dict[str, torch.Tensor]:


### PR DESCRIPTION
## Summary
- Replace direct indexing (`hf_dataset[key][indices]` / `hf_dataset[indices][key]`) with `hf_dataset.select(indices)[key]` in `_query_hf_dataset` and `_get_query_timestamps`
- `select()` is the datasets library's native multi-index operation and is significantly faster for the action horizon query pattern used by Pi0/diffusion policies with `delta_timestamps`

## Root Cause
The V3 migration (commit a4aa3164) changed from `select()` to direct indexing. The column-first approach `hf_dataset[key][indices]` was slow because it loaded the entire column before indexing (fixed in newer `datasets` versions), but even row-first `hf_dataset[indices][key]` is slower than `select()` for typical action horizon sizes (~50 frames).

The issue reporter benchmarked a ~40x regression vs `select()`:
| Method | Time per sample |
|--------|----------------|
| `hf_dataset.select(indices)[key]` | 6.4ms |
| `hf_dataset[indices][key]` | 262.6ms |

## Changes
- `_query_hf_dataset`: use `select()` instead of try/except column-first/row-first pattern
- `_get_query_timestamps`: use `select()` instead of direct indexing for timestamp lookups

## Test plan
- [ ] Existing dataset tests pass (`pytest tests/datasets/`)
- [ ] Training with `delta_timestamps` works correctly
- [ ] Performance improvement verified with action horizon queries

Fixes #2895