### PR TITLE
RoboCasa365 integration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,7 +175,7 @@ aloha = ["gym-aloha>=0.1.2,<0.2.0", "lerobot[scipy-dep]"]
 pusht = ["gym-pusht>=0.1.5,<0.2.0", "pymunk>=6.6.0,<7.0.0"] # TODO: Fix pymunk version in gym-pusht instead
 libero = ["lerobot[transformers-dep]", "hf-libero>=0.1.3,<0.2.0; sys_platform == 'linux'", "lerobot[scipy-dep]"]
 metaworld = ["metaworld==3.0.0", "lerobot[scipy-dep]"]
-robocasa =  ["robocasa @ git+https://github.com/brunomachado37/robocasa", "robosuite @ git+https://github.com/ARISE-Initiative/robosuite"]
+robocasa =  ["robocasa @ git+https://github.com/brunomachado37/robocasa.git@lerobocasa", "robosuite @ git+https://github.com/ARISE-Initiative/robosuite"]
 
 # All
 all = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,6 +175,7 @@ aloha = ["gym-aloha>=0.1.2,<0.2.0", "lerobot[scipy-dep]"]
 pusht = ["gym-pusht>=0.1.5,<0.2.0", "pymunk>=6.6.0,<7.0.0"] # TODO: Fix pymunk version in gym-pusht instead
 libero = ["lerobot[transformers-dep]", "hf-libero>=0.1.3,<0.2.0; sys_platform == 'linux'", "lerobot[scipy-dep]"]
 metaworld = ["metaworld==3.0.0", "lerobot[scipy-dep]"]
+robocasa =  ["robocasa @ git+https://github.com/brunomachado37/robocasa", "robosuite @ git+https://github.com/ARISE-Initiative/robosuite"]
 
 # All
 all = [

--- a/src/lerobot/envs/configs.py
+++ b/src/lerobot/envs/configs.py
@@ -454,3 +454,62 @@ class IsaaclabArenaEnv(HubEnvConfig):
     @property
     def gym_kwargs(self) -> dict:
         return {}
+
+@EnvConfig.register_subclass("robocasa")
+@dataclass
+class RoboCasaEnv(EnvConfig):
+    task: str | None = None  # Task name (required)
+    fps: int = 20
+    render_mode: str = "rgb_array"
+    obs_type: str = "pixels_agent_pos"
+    camera_name: str = "robot0_agentview_center,robot0_eye_in_hand"
+    observation_height: int = 256
+    observation_width: int = 256
+    features: dict[str, PolicyFeature] = field(
+        default_factory=lambda: {
+            ACTION: PolicyFeature(type=FeatureType.ACTION, shape=(12,)),
+        }
+    )
+    features_map: dict[str, str] = field(
+        default_factory=lambda: {
+            ACTION: ACTION,
+            "agent_pos": OBS_STATE,
+            "video.robot0_agentview_left": "observation.images.robot0_agentview_left",
+            "video.robot0_agentview_right": "observation.images.robot0_agentview_right",
+            "video.robot0_eye_in_hand": "observation.images.robot0_eye_in_hand",
+        }
+    )
+
+    def __post_init__(self):
+        if self.obs_type == "pixels":
+            self.features["video.robot0_agentview_left"] = PolicyFeature(
+                type=FeatureType.VISUAL, shape=(self.observation_height, self.observation_width, 3)
+            )
+            self.features["video.robot0_agentview_right"] = PolicyFeature(
+                type=FeatureType.VISUAL, shape=(self.observation_height, self.observation_width, 3)
+            )
+            self.features["video.robot0_eye_in_hand"] = PolicyFeature(
+                type=FeatureType.VISUAL, shape=(self.observation_height, self.observation_width, 3)
+            )
+        elif self.obs_type == "pixels_agent_pos":
+            self.features["video.robot0_agentview_left"] = PolicyFeature(
+                type=FeatureType.VISUAL, shape=(self.observation_height, self.observation_width, 3)
+            )
+            self.features["video.robot0_agentview_right"] = PolicyFeature(
+                type=FeatureType.VISUAL, shape=(self.observation_height, self.observation_width, 3)
+            )
+            self.features["video.robot0_eye_in_hand"] = PolicyFeature(
+                type=FeatureType.VISUAL, shape=(self.observation_height, self.observation_width, 3)
+            )
+            self.features["agent_pos"] = PolicyFeature(type=FeatureType.STATE, shape=(16,))
+
+
+    @property
+    def gym_kwargs(self) -> dict:
+        return {
+            "obs_type": self.obs_type,   
+            "render_mode": self.render_mode,
+            "observation_width": self.observation_width,
+            "observation_height": self.observation_height,
+            "camera_name": self.camera_name,
+        }

--- a/src/lerobot/envs/configs.py
+++ b/src/lerobot/envs/configs.py
@@ -462,9 +462,10 @@ class RoboCasaEnv(EnvConfig):
     fps: int = 20
     render_mode: str = "rgb_array"
     obs_type: str = "pixels_agent_pos"
-    camera_name: str = "robot0_agentview_left_image,robot0_eye_in_hand,robot0_agentview_right_image"
+    camera_name: str = "robot0_agentview_left,robot0_eye_in_hand,robot0_agentview_right"
     observation_height: int = 256
     observation_width: int = 256
+    split: str | None = None  # Optional Robocasa dataset split {None, "all", "pretrain", "target"}
     features: dict[str, PolicyFeature] = field(
         default_factory=lambda: {
             ACTION: PolicyFeature(type=FeatureType.ACTION, shape=(12,)),
@@ -512,4 +513,5 @@ class RoboCasaEnv(EnvConfig):
             "observation_width": self.observation_width,
             "observation_height": self.observation_height,
             "camera_name": self.camera_name,
+            "split": self.split,
         }

--- a/src/lerobot/envs/configs.py
+++ b/src/lerobot/envs/configs.py
@@ -462,7 +462,7 @@ class RoboCasaEnv(EnvConfig):
     fps: int = 20
     render_mode: str = "rgb_array"
     obs_type: str = "pixels_agent_pos"
-    camera_name: str = "robot0_agentview_center,robot0_eye_in_hand"
+    camera_name: str = "robot0_agentview_left_image,robot0_eye_in_hand,robot0_agentview_right_image"
     observation_height: int = 256
     observation_width: int = 256
     features: dict[str, PolicyFeature] = field(
@@ -474,31 +474,31 @@ class RoboCasaEnv(EnvConfig):
         default_factory=lambda: {
             ACTION: ACTION,
             "agent_pos": OBS_STATE,
-            "video.robot0_agentview_left": "observation.images.robot0_agentview_left",
-            "video.robot0_agentview_right": "observation.images.robot0_agentview_right",
-            "video.robot0_eye_in_hand": "observation.images.robot0_eye_in_hand",
+            "pixels/robot0_agentview_left": "observation.images.robot0_agentview_left",
+            "pixels/robot0_agentview_right": "observation.images.robot0_agentview_right",
+            "pixels/robot0_eye_in_hand": "observation.images.robot0_eye_in_hand",
         }
     )
 
     def __post_init__(self):
         if self.obs_type == "pixels":
-            self.features["video.robot0_agentview_left"] = PolicyFeature(
+            self.features["pixels/robot0_agentview_left"] = PolicyFeature(
                 type=FeatureType.VISUAL, shape=(self.observation_height, self.observation_width, 3)
             )
-            self.features["video.robot0_agentview_right"] = PolicyFeature(
+            self.features["pixels/robot0_agentview_right"] = PolicyFeature(
                 type=FeatureType.VISUAL, shape=(self.observation_height, self.observation_width, 3)
             )
-            self.features["video.robot0_eye_in_hand"] = PolicyFeature(
+            self.features["pixels/robot0_eye_in_hand"] = PolicyFeature(
                 type=FeatureType.VISUAL, shape=(self.observation_height, self.observation_width, 3)
             )
         elif self.obs_type == "pixels_agent_pos":
-            self.features["video.robot0_agentview_left"] = PolicyFeature(
+            self.features["pixels/robot0_agentview_left"] = PolicyFeature(
                 type=FeatureType.VISUAL, shape=(self.observation_height, self.observation_width, 3)
             )
-            self.features["video.robot0_agentview_right"] = PolicyFeature(
+            self.features["pixels/robot0_agentview_right"] = PolicyFeature(
                 type=FeatureType.VISUAL, shape=(self.observation_height, self.observation_width, 3)
             )
-            self.features["video.robot0_eye_in_hand"] = PolicyFeature(
+            self.features["pixels/robot0_eye_in_hand"] = PolicyFeature(
                 type=FeatureType.VISUAL, shape=(self.observation_height, self.observation_width, 3)
             )
             self.features["agent_pos"] = PolicyFeature(type=FeatureType.STATE, shape=(16,))

--- a/src/lerobot/envs/factory.py
+++ b/src/lerobot/envs/factory.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 import importlib
 from typing import Any
+from functools import partial
 
 import gymnasium as gym
 from gymnasium.envs.registration import registry as gym_registry
@@ -165,7 +166,7 @@ def make_env(
     if n_envs < 1:
         raise ValueError("`n_envs` must be at least 1")
 
-    env_cls = gym.vector.AsyncVectorEnv if use_async_envs else gym.vector.SyncVectorEnv
+    env_cls = partial(gym.vector.AsyncVectorEnv, context="spawn") if use_async_envs else gym.vector.SyncVectorEnv
 
     if "libero" in cfg.type:
         from lerobot.envs.libero import create_libero_envs

--- a/src/lerobot/envs/factory.py
+++ b/src/lerobot/envs/factory.py
@@ -20,7 +20,7 @@ import gymnasium as gym
 from gymnasium.envs.registration import registry as gym_registry
 
 from lerobot.configs.policies import PreTrainedConfig
-from lerobot.envs.configs import AlohaEnv, EnvConfig, HubEnvConfig, IsaaclabArenaEnv, LiberoEnv, PushtEnv
+from lerobot.envs.configs import AlohaEnv, EnvConfig, HubEnvConfig, IsaaclabArenaEnv, LiberoEnv, PushtEnv, RoboCasaEnv
 from lerobot.envs.utils import _call_make_env, _download_hub_file, _import_hub_module, _normalize_hub_result
 from lerobot.policies.xvla.configuration_xvla import XVLAConfig
 from lerobot.processor import ProcessorStep
@@ -35,6 +35,8 @@ def make_env_config(env_type: str, **kwargs) -> EnvConfig:
         return PushtEnv(**kwargs)
     elif env_type == "libero":
         return LiberoEnv(**kwargs)
+    elif env_type == "robocasa":
+        return RoboCasaEnv(**kwargs)
     else:
         raise ValueError(f"Policy type '{env_type}' is not available.")
 
@@ -191,6 +193,19 @@ def make_env(
             task=cfg.task,
             n_envs=n_envs,
             gym_kwargs=cfg.gym_kwargs,
+            env_cls=env_cls,
+        )
+    elif "robocasa" in cfg.type:
+        from lerobot.envs.robocasa import create_robocasa_envs
+
+        if cfg.task is None:
+            raise ValueError("RoboCasa requires a task to be specified")
+
+        return create_robocasa_envs(
+            task_name=cfg.task,
+            n_envs=n_envs,
+            gym_kwargs=cfg.gym_kwargs,
+            camera_name=cfg.camera_name,
             env_cls=env_cls,
         )
 

--- a/src/lerobot/envs/factory.py
+++ b/src/lerobot/envs/factory.py
@@ -206,7 +206,6 @@ def make_env(
             task_name=cfg.task,
             n_envs=n_envs,
             gym_kwargs=cfg.gym_kwargs,
-            camera_name=cfg.camera_name,
             env_cls=env_cls,
         )
 

--- a/src/lerobot/envs/robocasa.py
+++ b/src/lerobot/envs/robocasa.py
@@ -23,21 +23,12 @@ import numpy as np
 
 from lerobot.types import RobotObservation
 from robocasa.wrappers.gym_wrapper import RoboCasaGymEnv
-from robocasa.utils.env_utils import create_env
-from robocasa.utils.dataset_registry import ATOMIC_TASK_DATASETS 
+from robocasa.utils.dataset_registry import ATOMIC_TASK_DATASETS, COMPOSITE_TASK_DATASETS, TARGET_TASKS, PRETRAINING_TASKS
 
 OBS_STATE_DIM = 16
 ACTION_DIM = 12
-AGENT_POS_LOW = -1000.0
-AGENT_POS_HIGH = 1000.0
 ACTION_LOW = -1.0
 ACTION_HIGH = 1.0
-
-CAMERA_NAME_MAPPING = {
-        "robot0_agentview_left_image": "robot0_agentview_left",
-        "robot0_agentview_right_image": "robot0_agentview_right",
-        "robot0_eye_in_hand_image": "robot0_eye_in_hand",
-    }
 
 def convert_state(dict_state): 
     """
@@ -68,38 +59,45 @@ def convert_action(action):
     }
     return output_action
 
+def _parse_camera_names(camera_name: str | Sequence[str]) -> list[str]:
+    """Normalize camera_name into a non-empty list of strings."""
+    if isinstance(camera_name, str):
+        cams = [c.strip() for c in camera_name.split(",") if c.strip()]
+    elif isinstance(camera_name, (list | tuple)):
+        cams = [str(c).strip() for c in camera_name if str(c).strip()]
+    else:
+        raise TypeError(f"camera_name must be str or sequence[str], got {type(camera_name).__name__}")
+    if not cams:
+        raise ValueError("camera_name resolved to an empty list.")
+    return cams
+
 
 class RoboCasaEnv(RoboCasaGymEnv):
     metadata = {"render_modes": ["rgb_array"], "render_fps": 20}
 
     def __init__(
         self,
-        task:str,
-        camera_name: str | Sequence[str] = "robot0_agentview_left_image,robot0_eye_in_hand,robot0_agentview_right_image",
-        render_mode="rgb_array",
+        task: str,
+        camera_name: Sequence[str] = ["robot0_agentview_left", "robot0_eye_in_hand", "robot0_agentview_right"],
+        render_mode: str = "rgb_array",
         obs_type: str = "pixels_agent_pos",
-        observation_width=256,
-        observation_height=256,
-        visualization_width=640,
-        visualization_height=480,
-        split=None, # {None, "all", "pretrain", "target"}
-        ep_meta: dict| None = None,
+        observation_width: int = 256,
+        observation_height: int = 256,
+        split: str | None = None, # {None, "all", "pretrain", "target"}
         **kwargs
     ):
-        kwargs["style_ids"] = ep_meta.get("style_ids", [-1]) if ep_meta is not None else [-1]
-        kwargs["layout_ids"] = ep_meta.get("layout_ids", [-1]) if ep_meta is not None else [-1]
         self.obs_type = obs_type
-        self.camera_name = camera_name
-        self.camera_name_mapping = CAMERA_NAME_MAPPING
         self.render_mode = render_mode
-        self.observation_width = observation_width
-        self.observation_height = observation_height
-        self.visualization_width = visualization_width
-        self.visualization_height = visualization_height
         self.kwargs = kwargs
         self.split = split
         self.task = task
-        self._max_episode_steps = ATOMIC_TASK_DATASETS[task]["horizon"]
+
+        meta_info = {**ATOMIC_TASK_DATASETS, **COMPOSITE_TASK_DATASETS}
+        try:
+            self._max_episode_steps = meta_info[task]['horizon']
+        except KeyError:
+            raise ValueError(f"Unknown task '{task}'. Valid tasks are: {list(meta_info.keys())}")
+        
         super().__init__(
             task,
             camera_names=camera_name,
@@ -109,16 +107,14 @@ class RoboCasaEnv(RoboCasaGymEnv):
             split=split,
             **kwargs
         )
-        if ep_meta is not None:
-            self.env.set_ep_meta(ep_meta)
     
     def _create_obs_and_action_space(self):
         images = {}
-        for cam in self.camera_name:
-            images[self.camera_name_mapping.get(cam, cam)] = spaces.Box(
+        for cam in self.camera_names:
+            images[cam] = spaces.Box(
                 low=0,
                 high=255,
-                shape=(self.observation_height, self.observation_width, 3),
+                shape=(self.camera_heights, self.camera_widths, 3),
                 dtype=np.uint8,
             )
         if self.obs_type == "state":
@@ -137,8 +133,8 @@ class RoboCasaEnv(RoboCasaGymEnv):
                 {
                     "pixels": spaces.Dict(images),
                     "agent_pos": spaces.Box(
-                        low=AGENT_POS_LOW,
-                        high=AGENT_POS_HIGH,
+                        low=-1000,
+                        high=1000,
                         shape=(OBS_STATE_DIM,),
                         dtype=np.float64,
                     ),
@@ -153,32 +149,6 @@ class RoboCasaEnv(RoboCasaGymEnv):
             shape=(ACTION_DIM,),
             dtype=np.float32
         )
-
-    def render(self) -> np.ndarray:
-        """
-        Render the current environment frame.
-
-        Returns:
-            np.ndarray: The rendered RGB image from the environment.
-        """
-        return super().render()
-
-    def _make_envs_task(self, task: Any):
-        env = create_env(
-            task,
-            camera_name=self.camera_name,
-            camera_width=self.observation_width,
-            camera_height=self.observation_height,
-            enable_render=True,
-            split=self.split,
-            **self.kwargs
-        )
-        env.reset()
-        return env
-
-
-    def _format_raw_obs(self, raw_obs: np.ndarray) -> RobotObservation:
-        return super().get_observation(raw_obs)
 
     def reset(
         self,
@@ -197,10 +167,10 @@ class RoboCasaEnv(RoboCasaGymEnv):
         """
         self.unwrapped.sim._render_context_offscreen.gl_ctx.free()
         observation, info = super().reset(seed, **kwargs)
-        new_obs = self.get_obs(observation)
+        new_obs = self._format_raw_obs(observation)
         return new_obs, info 
     
-    def get_obs(self, raw_obs:dict):
+    def _format_raw_obs(self, raw_obs:dict):
         new_obs = {}
         if self.obs_type == "pixels_agent_pos":
             new_obs["agent_pos"] = convert_state(raw_obs)
@@ -232,7 +202,7 @@ class RoboCasaEnv(RoboCasaGymEnv):
             )
         action_dict = convert_action(action)
         observation, reward, done, truncated, info = super().step(action_dict)
-        new_obs = self.get_obs(observation)
+        new_obs = self._format_raw_obs(observation)
 
         # Determine whether the task was successful
         is_success = bool(info.get("success", 0))
@@ -260,38 +230,19 @@ def _make_env_fns(
     task_name: str,
     n_envs: int,
     camera_names: list[str],
-    gym_kwargs: Mapping[str, Any],
-    ep_metas: list[dict[str, Any]] | None = None,
+    gym_kwargs: Mapping[str, Any]
 ) -> list[Callable[[], RoboCasaEnv]]:
-    """Build n_envs factory callables for a dataset."""
+    """Build n_envs factory callables for an environment."""
 
     def _make_env(episode_index: int, **kwargs) -> RoboCasaEnv:
-        local_kwargs = dict(kwargs)
-        
-        # Extract ep_meta for this worker from ep_metas list if provided
-        if ep_metas is not None:
-            if len(ep_metas) <= episode_index:
-                raise ValueError(
-                    f"ep_metas list has {len(ep_metas)} elements, but episode_index {episode_index} "
-                    f"requires at least {episode_index + 1} elements."
-                )
-            ep_meta = ep_metas[episode_index].copy()  # Make a copy to avoid mutations
-        else:
-            # No ep_metas provided: use defaults
-            ep_meta = None
-
-        # Extract seed from ep_meta if present, otherwise use episode_index as default
-        seed = local_kwargs.pop("seed", episode_index)
-        
-        # Remove ep_meta from local_kwargs if present (shouldn't be there, but just in case)
-        local_kwargs.pop("ep_meta", None)
+        # Ensure each environment gets a different seed if not explicitly provided
+        seed = kwargs.pop("seed", episode_index)
         
         return RoboCasaEnv(
             task=task_name,
             camera_name=camera_names,
             seed=seed,
-            ep_meta=ep_meta,
-            **local_kwargs,
+            **kwargs,
         )
 
     fns: list[Callable[[], RoboCasaEnv]] = []
@@ -299,24 +250,14 @@ def _make_env_fns(
         fns.append(partial(_make_env, episode_index, **gym_kwargs))
     return fns
 
-def _parse_camera_names(camera_name: str | Sequence[str]) -> list[str]:
-    """Normalize camera_name into a non-empty list of strings."""
-    if isinstance(camera_name, str):
-        cams = [c.strip() for c in camera_name.split(",") if c.strip()]
-    elif isinstance(camera_name, (list | tuple)):
-        cams = [str(c).strip() for c in camera_name if str(c).strip()]
-    else:
-        raise TypeError(f"camera_name must be str or sequence[str], got {type(camera_name).__name__}")
-    if not cams:
-        raise ValueError("camera_name resolved to an empty list.")
-    return cams
 
 # ---- Main API ----------------------------------------------------------------
+
+
 def create_robocasa_envs(
     task_name: str,
     n_envs: int,
-    gym_kwargs: dict[str, Any] | None = None,
-    camera_name: str | Sequence[str] = "",
+    gym_kwargs: dict[str, Any],
     env_cls: Callable[[Sequence[Callable[[], Any]]], Any] | None = None,
 ) -> dict[str, dict[int, Any]]:
     """
@@ -324,16 +265,12 @@ def create_robocasa_envs(
 
     Returns:
         dict[suite_name][task_id] -> vec_env (env_cls([...]) with exactly n_envs factories)
-    Notes:
-        - n_envs is the number of rollouts *per task* (episode_index = 0..n_envs-1).
-        - For RoboCasa, we use a single suite_name "robocasa" and task_id 0.
     Args:
-        task_name: Name of the task
-        n_envs: Number of environments to create
-        gym_kwargs: Additional arguments to pass to RoboCasaEnv. Can include 'ep_metas' (list of dicts)
-            to provide different ep_meta for each worker. Each ep_meta dict can include a 'seed' key
-            to set a specific seed for that worker.
-        camera_name: Camera name(s) to use for observations, overrides gym_kwargs['camera_name'] if provided
+        task_name:  Name of the task (e.g. "CloseFridge"), 
+                    or list of tasks separated by commas (e.g. "CloseFridge,PrepareCoffee"), 
+                    or benchmark name (i.e.: atomic_seen, composite_seen, composite_unseen, pretrain50, pretrain100, pretrain200, pretrain300).
+        n_envs: Number of environments to create per task.
+        gym_kwargs: Additional arguments to pass to RoboCasaEnv.
         env_cls: Callable that wraps a list of environment factory callables (for vectorization)
     """
     if env_cls is None or not callable(env_cls):
@@ -341,38 +278,30 @@ def create_robocasa_envs(
     if not isinstance(n_envs, int) or n_envs <= 0:
         raise ValueError(f"n_envs must be a positive int; got {n_envs}.")
 
-    gym_kwargs = dict(gym_kwargs or {})
-    gym_kwargs_camera_name = gym_kwargs.pop("camera_name", None)
-    camera_name = camera_name if camera_name != "" else gym_kwargs_camera_name
-    parsed_camera_names = _parse_camera_names(camera_name)
-    
-    # Extract ep_metas from gym_kwargs (similar to how camera_name is handled)
-    # This prevents it from being passed to the main env class
-    ep_metas = gym_kwargs.pop("ep_metas", None)
-    if ep_metas is not None:
-        if not isinstance(ep_metas, (list, tuple)):
-            raise TypeError(f"ep_metas must be a list or tuple, got {type(ep_metas).__name__}")
-        if len(ep_metas) < n_envs:
-            raise ValueError(
-                f"ep_metas list has {len(ep_metas)} elements, but n_envs={n_envs} requires at least {n_envs} elements."
-            )
+    parsed_camera_names = _parse_camera_names(gym_kwargs.pop("camera_name"))
 
-    suite_name = "robocasa"
-    task_id = 0
-    
-    print(f"Creating RoboCasa envs | task={task_name} | n_envs(per task)={n_envs}")
-    
+    combined_tasks = {**TARGET_TASKS, **PRETRAINING_TASKS}
+
+    if task_name in combined_tasks:
+        print(f"Creating RoboCasa {task_name} benchmark")
+        task_names = combined_tasks[task_name]
+        gym_kwargs["split"] = "target" if task_name in TARGET_TASKS else "pretrain"
+    else:
+        task_names = [t.strip() for t in task_name.split(",")]
+
     out: dict[str, dict[int, Any]] = defaultdict(dict)
-    
-    fns = _make_env_fns(
-        task_name=task_name,
-        n_envs=n_envs,
-        camera_names=parsed_camera_names,
-        gym_kwargs=gym_kwargs,
-        ep_metas=ep_metas,
-    )
-    out[suite_name][task_id] = env_cls(fns)
-    print(f"Built vec env | suite={suite_name} | task_id={task_id} | n_envs={n_envs}")
+
+    for task in task_names:
+        print(f"Building vec env | task = {task} | n_envs (per task) = {n_envs}")
+
+        fns = _make_env_fns(
+            task_name=task,
+            n_envs=n_envs,
+            camera_names=parsed_camera_names,
+            gym_kwargs=gym_kwargs
+        )
+
+        out[task][0] = env_cls(fns)
 
     # return plain dicts for predictability
     return {suite: dict(task_map) for suite, task_map in out.items()}

--- a/src/lerobot/envs/robocasa.py
+++ b/src/lerobot/envs/robocasa.py
@@ -25,7 +25,7 @@ import numpy as np
 from lerobot.types import RobotObservation
 from robocasa.wrappers.gym_wrapper import RoboCasaGymEnv
 from robocasa.utils.env_utils import create_env, convert_action
-from robosuite.controllers.composite.composite_controller import HybridMobileBase
+from robocasa.utils.dataset_registry import ATOMIC_TASK_DATASETS 
 
 OBS_STATE_DIM = 16
 ACTION_DIM = 12
@@ -33,47 +33,13 @@ AGENT_POS_LOW = -1000.0
 AGENT_POS_HIGH = 1000.0
 ACTION_LOW = -1.0
 ACTION_HIGH = 1.0
-DEFAULT_MAX_EPISODE_STEPS = 1000
-DEFAULT_MAX_EPISODE_STEPS_BY_TASK = {
-    # single_stage tasks
-    "CloseDoubleDoor": 474,
-    "CloseDrawer": 227,
-    "CloseSingleDoor": 322,
-    "CoffeePressButton": 156,
-    "CoffeeServeMug": 433,
-    "CoffeeSetupMug": 376,
-    "NavigateKitchen": 322,
-    "OpenDoubleDoor": 889,
-    "OpenDrawer": 260,
-    "OpenSingleDoor": 414,
-    "PnPCabToCounter": 477,
-    "PnPCounterToCab": 364,
-    "PnPCounterToMicrowave": 509,
-    "PnPCounterToSink": 680,
-    "PnPCounterToStove": 404,
-    "PnPMicrowaveToCounter": 430,
-    "PnPSinkToCounter": 351,
-    "PnPStoveToCounter": 417,
-    "TurnOffMicrowave": 318,
-    "TurnOffSinkFaucet": 336,
-    "TurnOffStove": 338,
-    "TurnOnMicrowave": 279,
-    "TurnOnSinkFaucet": 342,
-    "TurnOnStove": 349,
-    "TurnSinkSpout": 187,
-    # multi_stage tasks
-    "ArrangeVegetables": 1132,
-    "MicrowaveThawing": 906,
-    "PreSoakPan": 1439,
-    "PrepareCoffee": 980,
-    "RestockPantry": 925,
-}
 
 CAMERA_NAME_MAPPING = {
         "robot0_agentview_left_image": "robot0_agentview_left",
         "robot0_agentview_right_image": "robot0_agentview_right",
         "robot0_eye_in_hand_image": "robot0_eye_in_hand",
     }
+
 def convert_state(dict_state): 
     """
     Converts input state (dict) to format expected LeRobot (np.array)
@@ -112,12 +78,6 @@ class RoboCasaEnv(RoboCasaGymEnv):
         self.obs_type = obs_type
         self.camera_name = camera_name
         self.camera_name_mapping = CAMERA_NAME_MAPPING
-        self.max_episode_steps = DEFAULT_MAX_EPISODE_STEPS_BY_TASK.get(
-            task.replace("PickPlace", "PnP"), DEFAULT_MAX_EPISODE_STEPS
-        )
-        self._max_episode_steps = (
-            self.max_episode_steps
-        )  # Required by gymnasium for env.call("_max_episode_steps")
         self.render_mode = render_mode
         self.observation_width = observation_width
         self.observation_height = observation_height
@@ -126,6 +86,8 @@ class RoboCasaEnv(RoboCasaGymEnv):
         self.kwargs = kwargs
         self.split = split
         self.task = task
+        self.max_episode_steps = ATOMIC_TASK_DATASETS[task]["horizon"]
+        self._max_episode_steps = ATOMIC_TASK_DATASETS[task]["horizon"]
         super().__init__(
             task,
             camera_names=camera_name,

--- a/src/lerobot/envs/robocasa.py
+++ b/src/lerobot/envs/robocasa.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python
+
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import json
+from collections import defaultdict
+from collections.abc import Callable, Sequence, Mapping
+from functools import partial
+from typing import Any
+
+import numpy as np
+
+from lerobot.types import RobotObservation
+from robocasa.wrappers.gym_wrapper import RoboCasaGymEnv
+from robocasa.utils.env_utils import create_env, convert_action
+
+OBS_STATE_DIM = 16
+ACTION_DIM = 12
+AGENT_POS_LOW = -1000.0
+AGENT_POS_HIGH = 1000.0
+ACTION_LOW = -1.0
+ACTION_HIGH = 1.0
+DEFAULT_MAX_EPISODE_STEPS = 1000
+
+def convert_state(dict_state): 
+    """
+    Converts input state (dict) to format expected LeRobot (np.array)
+    """
+    dict_state = dict_state.copy()
+    final_state = np.concat([
+        dict_state["state.end_effector_position_relative"],
+        dict_state["state.end_effector_rotation_relative"],
+        dict_state["state.gripper_qpos"],
+        dict_state["state.base_position"],
+        dict_state["state.base_rotation"],
+    ], axis=0)
+    
+    return final_state
+
+
+class RoboCasaEnv(RoboCasaGymEnv):
+    metadata = {"render_modes": ["rgb_array"], "render_fps": 80}
+
+    def __init__(
+        self,
+        task:str,
+        camera_name: str | Sequence[str] = "robot0_agentview_center,robot0_eye_in_hand",
+        render_mode="rgb_array",
+        obs_type: str = "pixels_agent_pos",
+        observation_width=480,
+        observation_height=480,
+        visualization_width=640,
+        visualization_height=480,
+        split="test",
+        ep_meta: dict| None = None,
+        **kwargs
+    ):
+        kwargs["style_ids"] = ep_meta.get("style_ids", [-1]) if ep_meta is not None else [-1]
+        kwargs["layout_ids"] = ep_meta.get("layout_ids", [-1]) if ep_meta is not None else [-1]
+        super().__init__(
+            task,
+            camera_names=camera_name,
+            camera_widths=observation_width,
+            camera_heights=observation_height,
+            enable_render=(render_mode is not None),
+            split=split,
+            **kwargs
+        )
+        self.obs_type = obs_type
+        self.render_mode = render_mode
+        self.observation_width = observation_width
+        self.observation_height = observation_height
+        self.visualization_width = visualization_width
+        self.visualization_height = visualization_height
+        self.camera_name = camera_name
+        self.kwargs = kwargs
+        self.split = split
+        if ep_meta is not None:
+            self.env.set_ep_meta(ep_meta)
+        # TODO: check observation and action space
+
+    def render(self) -> np.ndarray:
+        """
+        Render the current environment frame.
+
+        Returns:
+            np.ndarray: The rendered RGB image from the environment.
+        """
+        return super().render()
+
+    def _make_envs_task(self, task: Any):
+        env = create_env(
+            task,
+            camera_name=self.camera_name,
+            camera_width=self.observation_width,
+            camera_height=self.observation_height,
+            enable_render=True,
+            split=self.split,
+            **self.kwargs
+        )
+        env.reset()
+        return env
+
+
+    def _format_raw_obs(self, raw_obs: np.ndarray) -> RobotObservation:
+        return super().get_observation(raw_obs)
+
+    def reset(
+        self,
+        seed: int | None = None,
+        **kwargs,
+    ) -> tuple[RobotObservation, dict[str, Any]]:
+        """
+        Reset the environment to its initial state.
+
+        Args:
+            seed (Optional[int]): Random seed for environment initialization.
+
+        Returns:
+            observation (RobotObservation): The initial formatted observation.
+            info (Dict[str, Any]): Additional info about the reset state.
+        """
+        observation, info = super().reset(seed, **kwargs)
+        if self.obs_type == "pixels_agent_pos":
+            observation["agent_pos"] = convert_state(observation)
+        return observation, info 
+
+    def step(self, action: np.ndarray) -> tuple[RobotObservation, float, bool, bool, dict[str, Any]]:
+        """
+        Perform one environment step.
+
+        Args:
+            action (np.ndarray): The action to execute, must be 1-D with shape (action_dim,).
+
+        Returns:
+            observation (RobotObservation): The formatted observation after the step.
+            reward (float): The scalar reward for this step.
+            terminated (bool): Whether the episode terminated successfully.
+            truncated (bool): Whether the episode was truncated due to a time limit.
+            info (Dict[str, Any]): Additional environment info.
+        """
+        if action.ndim != 1:
+            raise ValueError(
+                f"Expected action to be 1-D (shape (action_dim,)), "
+                f"but got shape {action.shape} with ndim={action.ndim}"
+            )
+        action_dict = convert_action(action)
+        observation, reward, done, truncated, info = super().step(action_dict)
+        if self.obs_type == "pixels_agent_pos":
+            observation["agent_pos"] = convert_state(observation)
+
+        # Determine whether the task was successful
+        is_success = bool(info.get("success", 0))
+        terminated = done or is_success
+        info.update(
+            {
+                "task": self.task,
+                "done": done,
+                "is_success": is_success,
+            }
+        )
+        if terminated:
+            info["final_info"] = {
+                "task": self.task,
+                "done": bool(done),
+                "is_success": bool(is_success),
+            }
+            self.reset()
+
+        return observation, reward, terminated, truncated, info
+
+
+def _make_env_fns(
+    *,
+    task_name: str,
+    n_envs: int,
+    camera_names: list[str],
+    gym_kwargs: Mapping[str, Any],
+    ep_metas: list[dict[str, Any]] | None = None,
+) -> list[Callable[[], RoboCasaEnv]]:
+    """Build n_envs factory callables for a dataset."""
+
+    def _make_env(episode_index: int, **kwargs) -> RoboCasaEnv:
+        local_kwargs = dict(kwargs)
+        
+        # Extract ep_meta for this worker from ep_metas list if provided
+        if ep_metas is not None:
+            if len(ep_metas) <= episode_index:
+                raise ValueError(
+                    f"ep_metas list has {len(ep_metas)} elements, but episode_index {episode_index} "
+                    f"requires at least {episode_index + 1} elements."
+                )
+            ep_meta = ep_metas[episode_index].copy()  # Make a copy to avoid mutations
+        else:
+            # No ep_metas provided: use defaults
+            ep_meta = None
+
+        # Extract seed from ep_meta if present, otherwise use episode_index as default
+        seed = local_kwargs.pop("seed", episode_index)
+        
+        # Remove ep_meta from local_kwargs if present (shouldn't be there, but just in case)
+        local_kwargs.pop("ep_meta", None)
+        
+        return RoboCasaEnv(
+            task=task_name,
+            camera_name=camera_names,
+            seed=seed,
+            ep_meta=ep_meta,
+            **local_kwargs,
+        )
+
+    fns: list[Callable[[], RoboCasaEnv]] = []
+    for episode_index in range(n_envs):
+        fns.append(partial(_make_env, episode_index, **gym_kwargs))
+    return fns
+
+def _parse_camera_names(camera_name: str | Sequence[str]) -> list[str]:
+    """Normalize camera_name into a non-empty list of strings."""
+    if isinstance(camera_name, str):
+        cams = [c.strip() for c in camera_name.split(",") if c.strip()]
+    elif isinstance(camera_name, (list | tuple)):
+        cams = [str(c).strip() for c in camera_name if str(c).strip()]
+    else:
+        raise TypeError(f"camera_name must be str or sequence[str], got {type(camera_name).__name__}")
+    if not cams:
+        raise ValueError("camera_name resolved to an empty list.")
+    return cams
+
+# ---- Main API ----------------------------------------------------------------
+def create_robocasa_envs(
+    task_name: str,
+    n_envs: int,
+    gym_kwargs: dict[str, Any] | None = None,
+    camera_name: str | Sequence[str] = "",
+    env_cls: Callable[[Sequence[Callable[[], Any]]], Any] | None = None,
+) -> dict[str, dict[int, Any]]:
+    """
+    Create vectorized RoboCasa environments with a consistent return shape.
+
+    Returns:
+        dict[suite_name][task_id] -> vec_env (env_cls([...]) with exactly n_envs factories)
+    Notes:
+        - n_envs is the number of rollouts *per task* (episode_index = 0..n_envs-1).
+        - For RoboCasa, we use a single suite_name "robocasa" and task_id 0.
+    Args:
+        task_name: Name of the task
+        n_envs: Number of environments to create
+        gym_kwargs: Additional arguments to pass to RoboCasaEnv. Can include 'ep_metas' (list of dicts)
+            to provide different ep_meta for each worker. Each ep_meta dict can include a 'seed' key
+            to set a specific seed for that worker.
+        camera_name: Camera name(s) to use for observations, overrides gym_kwargs['camera_name'] if provided
+        env_cls: Callable that wraps a list of environment factory callables (for vectorization)
+    """
+    if env_cls is None or not callable(env_cls):
+        raise ValueError("env_cls must be a callable that wraps a list of environment factory callables.")
+    if not isinstance(n_envs, int) or n_envs <= 0:
+        raise ValueError(f"n_envs must be a positive int; got {n_envs}.")
+
+    gym_kwargs = dict(gym_kwargs or {})
+    gym_kwargs_camera_name = gym_kwargs.pop("camera_name", None)
+    camera_name = camera_name if camera_name != "" else gym_kwargs_camera_name
+    parsed_camera_names = _parse_camera_names(camera_name)
+    
+    # Extract ep_metas from gym_kwargs (similar to how camera_name is handled)
+    # This prevents it from being passed to the main env class
+    ep_metas = gym_kwargs.pop("ep_metas", None)
+    if ep_metas is not None:
+        if not isinstance(ep_metas, (list, tuple)):
+            raise TypeError(f"ep_metas must be a list or tuple, got {type(ep_metas).__name__}")
+        if len(ep_metas) < n_envs:
+            raise ValueError(
+                f"ep_metas list has {len(ep_metas)} elements, but n_envs={n_envs} requires at least {n_envs} elements."
+            )
+
+    suite_name = "robocasa"
+    task_id = 0
+    
+    print(f"Creating RoboCasa envs | task={task_name} | n_envs(per task)={n_envs}")
+    
+    out: dict[str, dict[int, Any]] = defaultdict(dict)
+    
+    fns = _make_env_fns(
+        task_name=task_name,
+        n_envs=n_envs,
+        camera_names=parsed_camera_names,
+        gym_kwargs=gym_kwargs,
+        ep_metas=ep_metas,
+    )
+    out[suite_name][task_id] = env_cls(fns)
+    print(f"Built vec env | suite={suite_name} | task_id={task_id} | n_envs={n_envs}")
+
+    # return plain dicts for predictability
+    return {suite: dict(task_map) for suite, task_map in out.items()}

--- a/src/lerobot/envs/robocasa.py
+++ b/src/lerobot/envs/robocasa.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import json
 from collections import defaultdict
 from collections.abc import Callable, Sequence, Mapping
 from functools import partial
@@ -24,7 +23,7 @@ import numpy as np
 
 from lerobot.types import RobotObservation
 from robocasa.wrappers.gym_wrapper import RoboCasaGymEnv
-from robocasa.utils.env_utils import create_env, convert_action
+from robocasa.utils.env_utils import create_env
 from robocasa.utils.dataset_registry import ATOMIC_TASK_DATASETS 
 
 OBS_STATE_DIM = 16
@@ -46,18 +45,32 @@ def convert_state(dict_state):
     """
     dict_state = dict_state.copy()
     final_state = np.concat([
+        dict_state["state.base_position"],
+        dict_state["state.base_rotation"],
         dict_state["state.end_effector_position_relative"],
         dict_state["state.end_effector_rotation_relative"],
         dict_state["state.gripper_qpos"],
-        dict_state["state.base_position"],
-        dict_state["state.base_rotation"],
     ], axis=0)
     
     return final_state
 
+def convert_action(action):
+    """
+    Converts input action (np.array) to format expected by gym env (dict)
+    """
+    action = action.copy()
+    output_action = {
+        "action.base_motion": action[0:4],
+        "action.control_mode": action[4:5],
+        "action.end_effector_position": action[5:8],
+        "action.end_effector_rotation": action[8:11],
+        "action.gripper_close": action[11:12],
+    }
+    return output_action
+
 
 class RoboCasaEnv(RoboCasaGymEnv):
-    metadata = {"render_modes": ["rgb_array"], "render_fps": 80}
+    metadata = {"render_modes": ["rgb_array"], "render_fps": 20}
 
     def __init__(
         self,
@@ -65,8 +78,8 @@ class RoboCasaEnv(RoboCasaGymEnv):
         camera_name: str | Sequence[str] = "robot0_agentview_left_image,robot0_eye_in_hand,robot0_agentview_right_image",
         render_mode="rgb_array",
         obs_type: str = "pixels_agent_pos",
-        observation_width=480,
-        observation_height=480,
+        observation_width=256,
+        observation_height=256,
         visualization_width=640,
         visualization_height=480,
         split=None, # {None, "all", "pretrain", "target"}
@@ -86,7 +99,6 @@ class RoboCasaEnv(RoboCasaGymEnv):
         self.kwargs = kwargs
         self.split = split
         self.task = task
-        self.max_episode_steps = ATOMIC_TASK_DATASETS[task]["horizon"]
         self._max_episode_steps = ATOMIC_TASK_DATASETS[task]["horizon"]
         super().__init__(
             task,

--- a/src/lerobot/envs/robocasa.py
+++ b/src/lerobot/envs/robocasa.py
@@ -195,6 +195,7 @@ class RoboCasaEnv(RoboCasaGymEnv):
             observation (RobotObservation): The initial formatted observation.
             info (Dict[str, Any]): Additional info about the reset state.
         """
+        self.unwrapped.sim._render_context_offscreen.gl_ctx.free()
         observation, info = super().reset(seed, **kwargs)
         new_obs = self.get_obs(observation)
         return new_obs, info 
@@ -223,6 +224,7 @@ class RoboCasaEnv(RoboCasaGymEnv):
             truncated (bool): Whether the episode was truncated due to a time limit.
             info (Dict[str, Any]): Additional environment info.
         """
+        self.unwrapped.sim._render_context_offscreen.gl_ctx.make_current()
         if action.ndim != 1:
             raise ValueError(
                 f"Expected action to be 1-D (shape (action_dim,)), "

--- a/src/lerobot/envs/robocasa.py
+++ b/src/lerobot/envs/robocasa.py
@@ -18,12 +18,14 @@ from collections import defaultdict
 from collections.abc import Callable, Sequence, Mapping
 from functools import partial
 from typing import Any
+from gymnasium import spaces
 
 import numpy as np
 
 from lerobot.types import RobotObservation
 from robocasa.wrappers.gym_wrapper import RoboCasaGymEnv
 from robocasa.utils.env_utils import create_env, convert_action
+from robosuite.controllers.composite.composite_controller import HybridMobileBase
 
 OBS_STATE_DIM = 16
 ACTION_DIM = 12
@@ -32,7 +34,46 @@ AGENT_POS_HIGH = 1000.0
 ACTION_LOW = -1.0
 ACTION_HIGH = 1.0
 DEFAULT_MAX_EPISODE_STEPS = 1000
+DEFAULT_MAX_EPISODE_STEPS_BY_TASK = {
+    # single_stage tasks
+    "CloseDoubleDoor": 474,
+    "CloseDrawer": 227,
+    "CloseSingleDoor": 322,
+    "CoffeePressButton": 156,
+    "CoffeeServeMug": 433,
+    "CoffeeSetupMug": 376,
+    "NavigateKitchen": 322,
+    "OpenDoubleDoor": 889,
+    "OpenDrawer": 260,
+    "OpenSingleDoor": 414,
+    "PnPCabToCounter": 477,
+    "PnPCounterToCab": 364,
+    "PnPCounterToMicrowave": 509,
+    "PnPCounterToSink": 680,
+    "PnPCounterToStove": 404,
+    "PnPMicrowaveToCounter": 430,
+    "PnPSinkToCounter": 351,
+    "PnPStoveToCounter": 417,
+    "TurnOffMicrowave": 318,
+    "TurnOffSinkFaucet": 336,
+    "TurnOffStove": 338,
+    "TurnOnMicrowave": 279,
+    "TurnOnSinkFaucet": 342,
+    "TurnOnStove": 349,
+    "TurnSinkSpout": 187,
+    # multi_stage tasks
+    "ArrangeVegetables": 1132,
+    "MicrowaveThawing": 906,
+    "PreSoakPan": 1439,
+    "PrepareCoffee": 980,
+    "RestockPantry": 925,
+}
 
+CAMERA_NAME_MAPPING = {
+        "robot0_agentview_left_image": "robot0_agentview_left",
+        "robot0_agentview_right_image": "robot0_agentview_right",
+        "robot0_eye_in_hand_image": "robot0_eye_in_hand",
+    }
 def convert_state(dict_state): 
     """
     Converts input state (dict) to format expected LeRobot (np.array)
@@ -55,19 +96,36 @@ class RoboCasaEnv(RoboCasaGymEnv):
     def __init__(
         self,
         task:str,
-        camera_name: str | Sequence[str] = "robot0_agentview_center,robot0_eye_in_hand",
+        camera_name: str | Sequence[str] = "robot0_agentview_left_image,robot0_eye_in_hand,robot0_agentview_right_image",
         render_mode="rgb_array",
         obs_type: str = "pixels_agent_pos",
         observation_width=480,
         observation_height=480,
         visualization_width=640,
         visualization_height=480,
-        split="test",
+        split=None, # {None, "all", "pretrain", "target"}
         ep_meta: dict| None = None,
         **kwargs
     ):
         kwargs["style_ids"] = ep_meta.get("style_ids", [-1]) if ep_meta is not None else [-1]
         kwargs["layout_ids"] = ep_meta.get("layout_ids", [-1]) if ep_meta is not None else [-1]
+        self.obs_type = obs_type
+        self.camera_name = camera_name
+        self.camera_name_mapping = CAMERA_NAME_MAPPING
+        self.max_episode_steps = DEFAULT_MAX_EPISODE_STEPS_BY_TASK.get(
+            task.replace("PickPlace", "PnP"), DEFAULT_MAX_EPISODE_STEPS
+        )
+        self._max_episode_steps = (
+            self.max_episode_steps
+        )  # Required by gymnasium for env.call("_max_episode_steps")
+        self.render_mode = render_mode
+        self.observation_width = observation_width
+        self.observation_height = observation_height
+        self.visualization_width = visualization_width
+        self.visualization_height = visualization_height
+        self.kwargs = kwargs
+        self.split = split
+        self.task = task
         super().__init__(
             task,
             camera_names=camera_name,
@@ -77,18 +135,50 @@ class RoboCasaEnv(RoboCasaGymEnv):
             split=split,
             **kwargs
         )
-        self.obs_type = obs_type
-        self.render_mode = render_mode
-        self.observation_width = observation_width
-        self.observation_height = observation_height
-        self.visualization_width = visualization_width
-        self.visualization_height = visualization_height
-        self.camera_name = camera_name
-        self.kwargs = kwargs
-        self.split = split
         if ep_meta is not None:
             self.env.set_ep_meta(ep_meta)
-        # TODO: check observation and action space
+    
+    def _create_obs_and_action_space(self):
+        images = {}
+        for cam in self.camera_name:
+            images[self.camera_name_mapping.get(cam, cam)] = spaces.Box(
+                low=0,
+                high=255,
+                shape=(self.observation_height, self.observation_width, 3),
+                dtype=np.uint8,
+            )
+        if self.obs_type == "state":
+            raise NotImplementedError(
+                "The 'state' observation type is not supported in RoboCasaEnv. "
+                "Please switch to an image-based obs_type (e.g. 'pixels', 'pixels_agent_pos')."
+            )
+        elif self.obs_type == "pixels":
+            self.observation_space = spaces.Dict(
+                {
+                    "pixels": spaces.Dict(images),
+                }
+            )
+        elif self.obs_type == "pixels_agent_pos":
+            self.observation_space = spaces.Dict(
+                {
+                    "pixels": spaces.Dict(images),
+                    "agent_pos": spaces.Box(
+                        low=AGENT_POS_LOW,
+                        high=AGENT_POS_HIGH,
+                        shape=(OBS_STATE_DIM,),
+                        dtype=np.float64,
+                    ),
+                }
+            )
+        else:
+            raise ValueError(f"Unknown obs_type: {self.obs_type}")
+
+        self.action_space = spaces.Box(
+            low=ACTION_LOW,
+            high=ACTION_HIGH,
+            shape=(ACTION_DIM,),
+            dtype=np.float32
+        )
 
     def render(self) -> np.ndarray:
         """
@@ -132,9 +222,18 @@ class RoboCasaEnv(RoboCasaGymEnv):
             info (Dict[str, Any]): Additional info about the reset state.
         """
         observation, info = super().reset(seed, **kwargs)
+        new_obs = self.get_obs(observation)
+        return new_obs, info 
+    
+    def get_obs(self, raw_obs:dict):
+        new_obs = {}
         if self.obs_type == "pixels_agent_pos":
-            observation["agent_pos"] = convert_state(observation)
-        return observation, info 
+            new_obs["agent_pos"] = convert_state(raw_obs)
+        new_obs["pixels"] = {}
+        for k, v in raw_obs.items():
+            if "video." in k:
+                new_obs["pixels"][k.replace("video.", "")] = v
+        return new_obs
 
     def step(self, action: np.ndarray) -> tuple[RobotObservation, float, bool, bool, dict[str, Any]]:
         """
@@ -157,8 +256,7 @@ class RoboCasaEnv(RoboCasaGymEnv):
             )
         action_dict = convert_action(action)
         observation, reward, done, truncated, info = super().step(action_dict)
-        if self.obs_type == "pixels_agent_pos":
-            observation["agent_pos"] = convert_state(observation)
+        new_obs = self.get_obs(observation)
 
         # Determine whether the task was successful
         is_success = bool(info.get("success", 0))
@@ -178,7 +276,7 @@ class RoboCasaEnv(RoboCasaGymEnv):
             }
             self.reset()
 
-        return observation, reward, terminated, truncated, info
+        return new_obs, reward, terminated, truncated, info
 
 
 def _make_env_fns(

--- a/src/lerobot/envs/utils.py
+++ b/src/lerobot/envs/utils.py
@@ -130,24 +130,24 @@ def env_to_policy_features(env_cfg: EnvConfig) -> dict[str, PolicyFeature]:
     return policy_features
 
 
-def are_all_envs_same_type(env: gym.vector.VectorEnv) -> bool:
-    first_type = type(env.envs[0])  # Get type of first env
-    return all(type(e) is first_type for e in env.envs)  # Fast type check
+def all_envs_have_same_name(env: gym.vector.VectorEnv) -> bool:
+    env_names = env.get_attr("env_name")
+    return len(set(env_names)) == 1  # Check if all env names are the same
 
 
 def check_env_attributes_and_types(env: gym.vector.VectorEnv) -> None:
     with warnings.catch_warnings():
         warnings.simplefilter("once", UserWarning)  # Apply filter only in this function
 
-        if not (hasattr(env.envs[0], "task_description") and hasattr(env.envs[0], "task")):
+        if not (env.call("has_wrapper_attr", "task_description")[0] and env.call("has_wrapper_attr", "task")[0]):
             warnings.warn(
                 "The environment does not have 'task_description' and 'task'. Some policies require these features.",
                 UserWarning,
                 stacklevel=2,
             )
-        if not are_all_envs_same_type(env):
+        if not all_envs_have_same_name(env):
             warnings.warn(
-                "The environments have different types. Make sure you infer the right task from each environment. Empty task will be passed instead.",
+                "The environments have different names. Make sure you infer the right task from each environment. Empty task will be passed instead.",
                 UserWarning,
                 stacklevel=2,
             )
@@ -155,7 +155,7 @@ def check_env_attributes_and_types(env: gym.vector.VectorEnv) -> None:
 
 def add_envs_task(env: gym.vector.VectorEnv, observation: RobotObservation) -> RobotObservation:
     """Adds task feature to the observation dict with respect to the first environment attribute."""
-    if hasattr(env.envs[0], "task_description"):
+    if env.call("has_wrapper_attr", "task_description")[0]:
         task_result = env.call("task_description")
 
         if isinstance(task_result, tuple):
@@ -167,7 +167,7 @@ def add_envs_task(env: gym.vector.VectorEnv, observation: RobotObservation) -> R
             raise TypeError("All items in task_description result must be strings")
 
         observation["task"] = task_result
-    elif hasattr(env.envs[0], "task"):
+    elif env.call("has_wrapper_attr", "task")[0]:
         task_result = env.call("task")
 
         if isinstance(task_result, tuple):

--- a/src/lerobot/envs/utils.py
+++ b/src/lerobot/envs/utils.py
@@ -130,24 +130,24 @@ def env_to_policy_features(env_cfg: EnvConfig) -> dict[str, PolicyFeature]:
     return policy_features
 
 
-def all_envs_have_same_name(env: gym.vector.VectorEnv) -> bool:
-    env_names = env.get_attr("env_name")
-    return len(set(env_names)) == 1  # Check if all env names are the same
+def are_all_envs_same_type(env: gym.vector.VectorEnv) -> bool:
+    env_types = env.call("get_wrapper_attr", "__class__")
+    return len(set(env_types)) == 1
 
 
 def check_env_attributes_and_types(env: gym.vector.VectorEnv) -> None:
     with warnings.catch_warnings():
         warnings.simplefilter("once", UserWarning)  # Apply filter only in this function
 
-        if not (env.call("has_wrapper_attr", "task_description")[0] and env.call("has_wrapper_attr", "task")[0]):
+        if not (env.call("has_wrapper_attr", "task_description")[0] or env.call("has_wrapper_attr", "task")[0]):
             warnings.warn(
-                "The environment does not have 'task_description' and 'task'. Some policies require these features.",
+                "The environment has neither 'task_description' nor 'task'. Some policies might require one of these features.",
                 UserWarning,
                 stacklevel=2,
             )
-        if not all_envs_have_same_name(env):
+        if not are_all_envs_same_type(env):
             warnings.warn(
-                "The environments have different names. Make sure you infer the right task from each environment. Empty task will be passed instead.",
+                "The environments have different types. Make sure you infer the right task from each environment. Empty task will be passed instead.",
                 UserWarning,
                 stacklevel=2,
             )

--- a/src/lerobot/scripts/lerobot_eval.py
+++ b/src/lerobot/scripts/lerobot_eval.py
@@ -511,8 +511,7 @@ def eval_main(cfg: EvalPipelineConfig):
 
     torch.backends.cudnn.benchmark = True
     torch.backends.cuda.matmul.allow_tf32 = True
-    if cfg.seed is not None:
-        set_seed(cfg.seed)
+    set_seed(cfg.seed)
 
     logging.info(colored("Output dir:", "yellow", attrs=["bold"]) + f" {cfg.output_dir}")
 

--- a/src/lerobot/scripts/lerobot_eval.py
+++ b/src/lerobot/scripts/lerobot_eval.py
@@ -167,7 +167,6 @@ def rollout(
             all_observations.append(deepcopy(observation))
 
         # Infer "task" from attributes of environments.
-        # TODO: works with SyncVectorEnv but not AsyncVectorEnv
         observation = add_envs_task(env, observation)
 
         # Apply environment-specific preprocessing (e.g., LiberoProcessorStep for LIBERO)
@@ -512,7 +511,8 @@ def eval_main(cfg: EvalPipelineConfig):
 
     torch.backends.cudnn.benchmark = True
     torch.backends.cuda.matmul.allow_tf32 = True
-    set_seed(cfg.seed)
+    if cfg.seed is not None:
+        set_seed(cfg.seed)
 
     logging.info(colored("Output dir:", "yellow", attrs=["bold"]) + f" {cfg.output_dir}")
 


### PR DESCRIPTION
## Title

Integrating RoboCasa365 simulation environment.

## Type / Scope

- **Type**: Feature
- **Scope**: Add a new simulation environment (lerobot.envs.robocasa).

## Summary / Motivation

Adds more diversity to the available benchmarks in the library.

## Related issues

- Related: [Add RoboCasa environment and imitation learning dataset integration #2380](https://github.com/huggingface/lerobot/issues/2380)

## Related pull requests

- Related: [feat(envs): Adding RoboCasa to LeRobot #2725](https://github.com/huggingface/lerobot/pull/2725) 

This pull request integrate the latest version of RoboCasa (365), while the pull request mentioned above implements the original release of RoboCasa. Due to the numerous differences between the two versions, I found it easier to directly integrate the new version.

## What changed

- `src/lerobot/envs/robocasa.py` : Implements the gym environment from RoboCasa, making it compatible with LeRobot.
- `src/lerobot/envs/configs.py` : Add configuration for RoboCasa enviroment.
- `src/lerobot/envs/factory.py` : Add RoboCasa to the env factory.
- `src/lerobot/envs/utils.py` : Fix compatibility with `gym.vector.AsyncVectorEnv` (Solves [this](https://github.com/huggingface/lerobot/blob/017ff73fbfe46bf9a673cd9b402988dcb79151f7/src/lerobot/scripts/lerobot_eval.py#L170) TODO).
- `pyproject.toml` : Add dependencies for RoboCasa installation. 

## Installation

```
pip install -e ".[robocasa]"
python -m robocasa.scripts.setup_macros
python -m robocasa.scripts.download_kitchen_assets
```

## Dataset conversion

All the datasets released by RoboCasa are already in the LeRobotDataset format. Nevertheless, they are not on the HuggingFace Hub. Since they are on version 2.1, we perform the following steps to convert them to v3.0 and to upload them to the Hub:

```
python -m robocasa.scripts.download_datasets --tasks CloseBlenderLid --split target --source human # It will download a folder containing the dataset (e.g. DOWNLOAD_PATH/v1.0/target/atomic/CloseBlenderLid/20250822/lerobot, referenced as `downloaded_folder` for short)
rm -r downloaded_folder/extras # Remove unnecessary extras (they add a lot of files to the hub, making downloading the dataset really slow)
cd lerobot
git checkout tags/v0.3.2   # Checkout to old LeRobot version, to load a LeRobotDataset v2.1
python -c "from lerobot.datasets.lerobot_dataset import LeRobotDataset ; d=LeRobotDataset('downloaded_folder') ; d.repo_id='UserName/robocasa_target_CloseBlenderLid' ; d.push_to_hub()"
git checkout main
python -m lerobot.datasets.v30.convert_dataset_v21_to_v30 --repo-id=UserName/robocasa_target_CloseBlenderLid
```

We have only converted and pushed to the hub 3 datasets for now: `BrunoM42/robocasa_target_PickPlaceCounterToCabinet`, `BrunoM42/robocasa_target_CloseFridge`, and `BrunoM42/robocasa_target_CloseBlenderLid` .


## Training example

```
lerobot-train --dataset.repo_id="BrunoM42/robocasa_target_PickPlaceCounterToCabinet" --policy.type=act --policy.device=cuda --steps=50_000 --save_freq=50_000
```

## Evaluation

We have trained ACT in 2 tasks: `CloseFridge` and `PickPlaceCounterToCabinet`. Both checkpoints are on the hub and can be tested. We have evaluated them using the command:

```
lerobot-eval --policy.path="BrunoM42/act_base-robocasa_target_CloseFridge" --env.type=robocasa --env.task=CloseFridge --eval.batch_size=5 --eval.n_episodes=20 --policy.device=cuda --seed=87 --eval.use_async_envs=True
```

The success rate was of 60%.

```
lerobot-eval --policy.path="BrunoM42/act_base-robocasa_target_PickPlaceCounterToCabinet" --env.type=robocasa --env.task=PickPlaceCounterToCabinet --eval.batch_size=5 --eval.n_episodes=20 --policy.device=cuda --seed=87 --eval.use_async_envs=True
```

The success rate was of 40%.


## Known issues

The training on the datasets take a really long time, much more than expected.

## Checklist (required before merge)

- [ ] Linting/formatting run (`pre-commit run -a`)
- [ ] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [ ] CI is green

## Reviewer notes

- Anyone in the community is free to review the PR.
