### PR TITLE
Fix feature_slice assignment logic in dataset_tools.py

### DIFF
--- a/src/lerobot/datasets/dataset_tools.py
+++ b/src/lerobot/datasets/dataset_tools.py
@@ -1020,7 +1020,7 @@ def _copy_data_with_feature_changes(
                         # Multi-dimensional features (e.g. images shape (N, H, W, C)):
                         # Store each frame as a separate object in the column so pandas
                         # doesn't try to broadcast the inner dimensions as column axes.
-                        df[feature_name] = [feature_slice[i] for i in range(len(feature_slice))]
+                        df[feature_name] = list(feature_slice)
             frame_idx = end_idx
 
         # Write using the same chunk/file structure as source

--- a/src/lerobot/datasets/dataset_tools.py
+++ b/src/lerobot/datasets/dataset_tools.py
@@ -1009,12 +1009,12 @@ def _copy_data_with_feature_changes(
                         feature_values.append(value)
                     df[feature_name] = feature_values
                 # BEFORE (buggy)
-                #else:
-                 #   feature_slice = values[frame_idx:end_idx]
-                  #  if len(feature_slice.shape) > 1 and feature_slice.shape[1] == 1:
-                   #     df[feature_name] = feature_slice.flatten()
-                    #else:
-                     #   df[feature_name] = feature_slice
+                # else:
+                #   feature_slice = values[frame_idx:end_idx]
+                #  if len(feature_slice.shape) > 1 and feature_slice.shape[1] == 1:
+                #     df[feature_name] = feature_slice.flatten()
+                # else:
+                #   df[feature_name] = feature_slice
                 # AFTER (fixed)
                 else:
                     feature_slice = values[frame_idx:end_idx]

--- a/src/lerobot/datasets/dataset_tools.py
+++ b/src/lerobot/datasets/dataset_tools.py
@@ -1008,12 +1008,27 @@ def _copy_data_with_feature_changes(
                             value = value.item()
                         feature_values.append(value)
                     df[feature_name] = feature_values
+                # BEFORE (buggy)
+                #else:
+                 #   feature_slice = values[frame_idx:end_idx]
+                  #  if len(feature_slice.shape) > 1 and feature_slice.shape[1] == 1:
+                   #     df[feature_name] = feature_slice.flatten()
+                    #else:
+                     #   df[feature_name] = feature_slice
+                # AFTER (fixed)
                 else:
                     feature_slice = values[frame_idx:end_idx]
-                    if len(feature_slice.shape) > 1 and feature_slice.shape[1] == 1:
+                    if len(feature_slice.shape) == 1:
+                        # 1D scalar features (e.g. rewards, flags): assign directly
+                        df[feature_name] = feature_slice
+                    elif len(feature_slice.shape) == 2 and feature_slice.shape[1] == 1:
+                        # Shape (N, 1): flatten to 1D scalar column
                         df[feature_name] = feature_slice.flatten()
                     else:
-                        df[feature_name] = feature_slice
+                        # Multi-dimensional features (e.g. images shape (N, H, W, C)):
+                        # Store each frame as a separate object in the column so pandas
+                        # doesn't try to broadcast the inner dimensions as column axes.
+                        df[feature_name] = [feature_slice[i] for i in range(len(feature_slice))]
             frame_idx = end_idx
 
         # Write using the same chunk/file structure as source

--- a/src/lerobot/datasets/dataset_tools.py
+++ b/src/lerobot/datasets/dataset_tools.py
@@ -1008,14 +1008,6 @@ def _copy_data_with_feature_changes(
                             value = value.item()
                         feature_values.append(value)
                     df[feature_name] = feature_values
-                # BEFORE (buggy)
-                #else:
-                 #   feature_slice = values[frame_idx:end_idx]
-                  #  if len(feature_slice.shape) > 1 and feature_slice.shape[1] == 1:
-                   #     df[feature_name] = feature_slice.flatten()
-                    #else:
-                     #   df[feature_name] = feature_slice
-                # AFTER (fixed)
                 else:
                     feature_slice = values[frame_idx:end_idx]
                     if len(feature_slice.shape) == 1:

--- a/tests/datasets/test_dataset_tools.py
+++ b/tests/datasets/test_dataset_tools.py
@@ -1281,6 +1281,54 @@ def test_convert_image_to_video_dataset(tmp_path):
         if output_dir.exists():
             shutil.rmtree(output_dir)
 
+def test_add_image_features_with_multi_dimensional_shapes(sample_dataset, tmp_path):
+    """Test adding image features with multi-dimensional shapes (N, H, W, C).
+    
+    Regression test for arrow length mismatches when adding image tensor features
+    via add_features. Verifies that the multi-dimensional assignment branch correctly
+    handles image features and that the dataset can be reloaded without errors.
+    """
+    num_frames = sample_dataset.meta.total_frames
+    H, W, C = 64, 64, 3  # Image dimensions
+    
+    # Create synthetic image array with shape (num_frames, H, W, C)
+    image_array = np.random.randint(0, 255, size=(num_frames, H, W, C), dtype=np.uint8)
+    
+    feature_info = {
+        "dtype": "image",
+        "shape": (H, W, C),
+        "names": ["height", "width", "channels"],
+    }
+    features = {
+        "observation.images.new_camera": (image_array, feature_info),
+    }
+    
+    with (
+        patch("lerobot.datasets.dataset_metadata.get_safe_version") as mock_get_safe_version,
+        patch("lerobot.datasets.dataset_metadata.snapshot_download") as mock_snapshot_download,
+    ):
+        mock_get_safe_version.return_value = "v3.0"
+        mock_snapshot_download.return_value = str(tmp_path / "with_images")
+        
+        # Add image features to dataset
+        new_dataset = add_features(
+            dataset=sample_dataset,
+            features=features,
+            output_dir=tmp_path / "with_images",
+        )
+    
+    # Verify feature was added correctly
+    assert "observation.images.new_camera" in new_dataset.meta.features
+    assert new_dataset.meta.features["observation.images.new_camera"] == feature_info
+    assert len(new_dataset) == num_frames
+    
+    # Test that we can load several frames without Arrow errors
+    for frame_idx in [0, 1, len(new_dataset) // 2, len(new_dataset) - 1]:
+        frame_item = new_dataset[frame_idx]
+        assert "observation.images.new_camera" in frame_item
+        assert isinstance(frame_item["observation.images.new_camera"], torch.Tensor)
+        assert frame_item["observation.images.new_camera"].shape == (H, W, C)
+
 
 def test_convert_image_to_video_dataset_subset_episodes(tmp_path):
     """Test converting only specific episodes from lerobot/pusht_image to video format."""


### PR DESCRIPTION
Refactor feature_slice handling for better shape checks and assignment.

## Refactoring feature_slice handling in _copy_data_with_feature_changes for adding image features with add_features

fix(dataset_tools): image tensor features not handled correctly when adding features via add_features, because of incompatibility with _copy_data_with_feature_changes usage of pandas df and assigning images as df column fields.

## Type / Scope

- **Type**: (Feature, Fix)
- **Scope**: (dataset_tools)


## Summary / Motivation

- One-paragraph description of what changes and why. -->I was trying to create a custom dataset with new images for policy conditioning, but add_features unexplainably returned "ArrowInvalid: Column 7 named observation.images.[name] expected length [dataset length] but got length 480"; which was obtained after correctly passing features with shape ([dataset_length], 480, 640, 3) to add_features. This is because of how new features are added (through a pandas dataframe) which fails if given image features. The change adapts new feature shape to dataframe column creation.
- Why this change is needed and any trade-offs or design notes--> this change is needed as this is the straightforward way to add image features using the already existing add-features function, old behavior is retained with the addition of the new capability of handling more complex feature shapes.

## Related issues

- Fixes / Closes: # (if any)
- Related: #3194 

## What changed

- Added conditional statements when adding a new feature via pandas df in add_feature to handle more complex shapes, such as images.
- add_features now correctly handle new image features, without breaking once _copy_data_with_feature_changes

## How was this tested (or how to run locally)

- Manual checks / dataset runs performed. Trying to run the below code will throw an error, although it is the intended and correct way:

new_dummy_feat_arr = np.zeros((T, H, W, C))

new_features = {
    "observation.images.new": (
        new_dummy_feat_arr, 
        {
            "dtype": "image",
            "shape": [H, W, C],
            "names": ["height", "width", "channels"],
        }
    )
}

add_features(dataset=dataset, features=new_features)

---->"ArrowInvalid: Column 7 named observation.images.[name] expected length [dataset length] but got length H"
 While repeating this with modifications proposed won't throw an error, the dataset will be correctly modified and it will be possible to finalize and push to the hub. This can easily be tested on the lerobot/svla_so101_pickplace dataset.


## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated
No need to update documentation (same usage as before).
- [x] CI is green

## Reviewer notes
None
