### PR TITLE
feat(eval): add process-isolated evaluation for low-VRAM GPUs

### DIFF
--- a/src/lerobot/configs/default.py
+++ b/src/lerobot/configs/default.py
@@ -112,6 +112,9 @@ class EvalConfig:
     # `use_async_envs` specifies whether to use asynchronous environments (multiprocessing).
     # Defaults to True; automatically downgraded to SyncVectorEnv when batch_size=1.
     use_async_envs: bool = True
+    # Run environments in a subprocess without GPU access, using OSMesa software rendering.
+    # This keeps the main process's VRAM available for policy inference on low-memory GPUs.
+    process_isolated: bool = False
     # Whether to record eval rollouts as a LeRobot dataset on disk.
     recording: bool = False
     # If set, push recorded eval datasets to the Hub under this repo id (one repo per task,

--- a/src/lerobot/envs/process_isolated.py
+++ b/src/lerobot/envs/process_isolated.py
@@ -1,0 +1,543 @@
+#!/usr/bin/env python
+
+# Copyright 2024 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Process-isolated environment wrapper for low-VRAM GPUs.
+
+Runs simulation environments in a subprocess with GPU access disabled,
+so that the main process can use all available VRAM for policy inference.
+The subprocess uses OSMesa (software rendering) instead of EGL (GPU rendering).
+
+This solves the OOM issue on GPUs with <=8 GB VRAM where the PyTorch CUDA
+context and the EGL rendering context compete for limited GPU memory.
+
+Trade-offs: OSMesa software rendering has been measured at roughly 5-7.5x
+slower than EGL and can use about 1.2 GB of additional host memory. All proxy
+calls share one locked pipe, so work across tasks is effectively serialized.
+
+Security note: IPC uses ``multiprocessing.Pipe`` (pickle-based). Only the
+self-spawned subprocess communicates over the pipe; do not expose the pipe
+file descriptor to untrusted processes.
+
+Usage:
+    lerobot-eval \\
+        --policy.path=lerobot/smolvla_base \\
+        --env.type=libero \\
+        --eval.batch_size=1 \\
+        --eval.process_isolated=true \\
+        --policy.device=cuda
+"""
+
+from __future__ import annotations
+
+import atexit
+import contextlib
+import logging
+import multiprocessing as mp
+import multiprocessing.process
+import os
+import threading
+import traceback
+from collections.abc import Iterator
+from multiprocessing.connection import Connection
+from typing import Any
+
+import gymnasium as gym
+import numpy as np
+
+from lerobot.envs.configs import EnvConfig
+
+logger = logging.getLogger(__name__)
+
+_SUBPROCESS_STARTUP_TIMEOUT_S = 120
+_SUBPROCESS_SHUTDOWN_TIMEOUT_S = 10
+_SUBPROCESS_TERMINATION_TIMEOUT_S = 5
+_DEFAULT_RENDER_FPS = 30
+
+
+def _terminate_and_join_process(process: mp.process.BaseProcess) -> None:
+    """Terminate a process and reap it, escalating to kill if necessary."""
+    if process.is_alive():
+        process.terminate()
+    process.join(timeout=_SUBPROCESS_TERMINATION_TIMEOUT_S)
+    if process.is_alive():
+        process.kill()
+        process.join(timeout=_SUBPROCESS_TERMINATION_TIMEOUT_S)
+
+
+def _cleanup_failed_startup(conn: Connection, process: mp.process.BaseProcess) -> None:
+    conn.close()
+    _terminate_and_join_process(process)
+
+
+def make_env_in_subprocess(
+    env_cfg: EnvConfig | str,
+    n_envs: int = 1,
+    use_async_envs: bool = False,
+    trust_remote_code: bool = False,
+) -> dict[str, dict[int, EnvProxy]]:
+    """Create environments in a subprocess with GPU access disabled.
+
+    This follows ``make_env``'s return shape and provides the subset of the
+    ``gym.vector.VectorEnv`` interface used by the evaluation pipeline.
+
+    The subprocess sets ``CUDA_VISIBLE_DEVICES=""`` and ``MUJOCO_GL=osmesa``
+    so that no GPU memory is allocated by the environment or its rendering
+    backend.
+
+    Args:
+        env_cfg: Environment configuration (same as ``make_env``).
+        n_envs: Number of parallel environments per VectorEnv.
+        use_async_envs: Whether to use AsyncVectorEnv inside the subprocess.
+        trust_remote_code: Whether to trust remote code from the Hub.
+
+    Returns:
+        Nested dict mapping suite names to task IDs to EnvProxy objects.
+    """
+    ctx = mp.get_context("spawn")
+    parent_conn, child_conn = ctx.Pipe()
+    lock = threading.Lock()
+
+    process = ctx.Process(
+        target=_env_server_main,
+        args=(child_conn, env_cfg, n_envs, use_async_envs, trust_remote_code),
+    )
+    try:
+        process.start()
+    except Exception:
+        parent_conn.close()
+        child_conn.close()
+        raise
+    child_conn.close()
+
+    # Wait for the server to report ready with environment metadata.
+    try:
+        server_responded = parent_conn.poll(timeout=_SUBPROCESS_STARTUP_TIMEOUT_S)
+    except BaseException:
+        _cleanup_failed_startup(parent_conn, process)
+        raise
+    if not server_responded:
+        exit_code = process.exitcode
+        _cleanup_failed_startup(parent_conn, process)
+        raise RuntimeError(
+            f"Environment subprocess did not respond within {_SUBPROCESS_STARTUP_TIMEOUT_S}s "
+            f"(exit code: {exit_code}). Check that OSMesa is installed and MUJOCO_GL=osmesa works."
+        )
+
+    try:
+        msg = parent_conn.recv()
+    except (EOFError, OSError) as exc:
+        _cleanup_failed_startup(parent_conn, process)
+        raise RuntimeError("Environment subprocess exited before reporting startup status.") from exc
+    except BaseException:
+        _cleanup_failed_startup(parent_conn, process)
+        raise
+
+    if not isinstance(msg, tuple) or len(msg) != 2:
+        _cleanup_failed_startup(parent_conn, process)
+        raise RuntimeError(f"Unexpected message from subprocess: {msg}")
+
+    if msg[0] == "error":
+        _cleanup_failed_startup(parent_conn, process)
+        raise RuntimeError(f"Environment subprocess failed to start: {msg[1]}")
+
+    if msg[0] != "ready":
+        _cleanup_failed_startup(parent_conn, process)
+        raise RuntimeError(f"Unexpected message from subprocess: {msg}")
+
+    try:
+        env_metadata: dict[str, dict[str, dict[str, Any]]] = msg[1]
+
+        # Build proxy objects. All proxies share the same connection and lock.
+        envs_dict: dict[str, dict[int, EnvProxy]] = {}
+        for suite_name, tasks in env_metadata.items():
+            envs_dict[suite_name] = {}
+            for task_id_str, meta in tasks.items():
+                task_id = int(task_id_str)
+                envs_dict[suite_name][task_id] = EnvProxy(
+                    conn=parent_conn,
+                    lock=lock,
+                    suite_name=suite_name,
+                    task_id=task_id,
+                    metadata=meta,
+                    process=process,
+                )
+        if not any(envs_dict.values()):
+            raise RuntimeError("Environment subprocess returned no environments.")
+    except BaseException:
+        _cleanup_failed_startup(parent_conn, process)
+        raise
+
+    # Ensure the subprocess is cleaned up if the main process exits unexpectedly.
+    try:
+        atexit.register(close_process_isolated_envs, envs_dict)
+    except BaseException:
+        _cleanup_failed_startup(parent_conn, process)
+        raise
+
+    return envs_dict
+
+
+# ── Subprocess entry point ──────────────────────────────────────────────────
+
+
+def _env_server_main(
+    conn: Connection,
+    env_cfg: EnvConfig | str,
+    n_envs: int,
+    use_async_envs: bool,
+    trust_remote_code: bool,
+) -> None:
+    """Entry point for the environment subprocess."""
+    # Disable GPU access so all rendering uses software (OSMesa).
+    os.environ["CUDA_VISIBLE_DEVICES"] = ""
+    os.environ["MUJOCO_GL"] = "osmesa"
+
+    try:
+        from lerobot.envs.factory import make_env
+
+        envs = make_env(
+            env_cfg,
+            n_envs=n_envs,
+            use_async_envs=use_async_envs,
+            trust_remote_code=trust_remote_code,
+        )
+
+        # Collect metadata for each VectorEnv so the parent can build proxies.
+        metadata: dict[str, dict[str, dict]] = {}
+        for suite_name, tasks in envs.items():
+            metadata[suite_name] = {}
+            for task_id, vec_env in tasks.items():
+                metadata[suite_name][str(task_id)] = _collect_env_metadata(vec_env)
+
+        conn.send(("ready", metadata))
+
+    except Exception:
+        logger.error("Environment subprocess failed during setup:\n%s", traceback.format_exc())
+        conn.send(("error", traceback.format_exc()))
+        conn.close()
+        return
+
+    # Serve requests until the parent closes the connection.
+    try:
+        _serve_requests(conn, envs)
+    except (EOFError, BrokenPipeError):
+        pass
+    finally:
+        for suite_tasks in envs.values():
+            for vec_env in suite_tasks.values():
+                with contextlib.suppress(Exception):
+                    vec_env.close()
+        conn.close()
+
+
+def _collect_env_metadata(vec_env: gym.vector.VectorEnv) -> dict[str, Any]:
+    """Extract serializable metadata without materializing lazy worker pools."""
+    render_fps = _DEFAULT_RENDER_FPS
+    if hasattr(vec_env, "unwrapped") and hasattr(vec_env.unwrapped, "metadata"):
+        render_fps = vec_env.unwrapped.metadata.get("render_fps", _DEFAULT_RENDER_FPS)
+
+    return {
+        "num_envs": vec_env.num_envs,
+        "render_fps": render_fps,
+    }
+
+
+def _serve_requests(conn: Connection, envs: dict[str, dict[int, gym.vector.VectorEnv]]) -> None:
+    """Handle RPC-style requests from the parent process."""
+    while True:
+        cmd, payload = conn.recv()
+
+        if cmd == "close_all":
+            conn.send(("ok", None))
+            return
+
+        try:
+            suite, task_id = payload["suite"], payload["task_id"]
+            vec_env = envs[suite][task_id]
+
+            if cmd == "reset":
+                reset_kwargs: dict[str, Any] = {"seed": payload.get("seed")}
+                if payload.get("options") is not None:
+                    reset_kwargs["options"] = payload["options"]
+                obs, info = vec_env.reset(**reset_kwargs)
+                conn.send(("ok", (obs, info)))
+
+            elif cmd == "step":
+                result = vec_env.step(payload["action"])
+                conn.send(("ok", result))
+
+            elif cmd == "call":
+                result = vec_env.call(
+                    payload["method"],
+                    *payload.get("args", ()),
+                    **payload.get("kwargs", {}),
+                )
+                # Convert tuples to lists for consistency.
+                if isinstance(result, tuple):
+                    result = list(result)
+                conn.send(("ok", result))
+
+            elif cmd == "get_attr":
+                result = vec_env.get_attr(payload["name"])
+                if isinstance(result, tuple):
+                    result = list(result)
+                conn.send(("ok", result))
+
+            elif cmd == "render_single":
+                idx = payload["index"]
+                if isinstance(vec_env, gym.vector.SyncVectorEnv):
+                    frame = vec_env.envs[idx].render()
+                else:
+                    frame = vec_env.call("render")[idx]
+                conn.send(("ok", frame))
+
+            elif cmd == "close_env":
+                vec_env.close()
+                conn.send(("ok", None))
+
+            else:
+                conn.send(("error", f"Unknown command: {cmd}"))
+
+        except AttributeError as exc:
+            conn.send(("attribute_error", str(exc)))
+        except NotImplementedError as exc:
+            conn.send(("not_implemented_error", str(exc)))
+        except Exception:
+            tb = traceback.format_exc()
+            logger.error("Subprocess error handling '%s': %s", cmd, tb)
+            conn.send(("error", tb))
+
+
+# ── Proxy objects ────────────────────────────────────────────────────────────
+
+
+class _UnwrappedProxy:
+    """Minimal proxy for vec_env.unwrapped.metadata access."""
+
+    def __init__(self, render_fps: int):
+        self.metadata = {"render_fps": render_fps}
+
+
+class _EnvItemProxy:
+    """Proxy for a single environment item (env.envs[i])."""
+
+    def __init__(self, proxy: EnvProxy, index: int):
+        self._proxy = proxy
+        self._index = index
+
+    @property
+    def task_description(self) -> str:
+        return self._proxy.call("task_description")[self._index]
+
+    @property
+    def task(self) -> str:
+        return self._proxy.call("task")[self._index]
+
+    def render(self) -> np.ndarray:
+        """Render this single environment via IPC."""
+        return self._proxy._render_single(self._index)
+
+
+class _EnvsListProxy:
+    """Proxy for the env.envs list, providing indexed access."""
+
+    def __init__(self, proxy: EnvProxy):
+        self._proxy = proxy
+        self._items = [_EnvItemProxy(proxy, i) for i in range(proxy.num_envs)]
+
+    def __getitem__(self, index: int) -> _EnvItemProxy:
+        return self._items[index]
+
+    def __len__(self) -> int:
+        return len(self._items)
+
+    def __iter__(self) -> Iterator[_EnvItemProxy]:
+        return iter(self._items)
+
+
+class EnvProxy:
+    """Proxy for a gym.vector.VectorEnv running in a subprocess.
+
+    Implements the subset of the VectorEnv interface used by the LeRobot
+    evaluation pipeline (rollout, eval_policy, and render_frame).
+
+    All IPC calls are guarded by a threading lock, so multiple proxies
+    sharing the same pipe can be used safely from different threads (though
+    calls will be serialized).
+    """
+
+    def __init__(
+        self,
+        conn: Connection,
+        lock: threading.Lock,
+        suite_name: str,
+        task_id: int,
+        metadata: dict,
+        process: mp.process.BaseProcess,
+    ):
+        self._conn = conn
+        self._lock = lock
+        self._suite = suite_name
+        self._task_id = task_id
+        self._process = process
+
+        self.num_envs: int = metadata["num_envs"]
+        self._has_task_description: bool | None = metadata.get("has_task_description")
+        self._has_task: bool | None = metadata.get("has_task")
+        self._max_episode_steps: int | None = metadata.get("max_episode_steps")
+        self._render_fps: int = metadata["render_fps"]
+
+        self._unwrapped = _UnwrappedProxy(self._render_fps)
+        self._envs = _EnvsListProxy(self)
+
+    def _send_recv(self, msg: tuple) -> Any:
+        """Thread-safe send-then-recv on the shared pipe."""
+        with self._lock:
+            self._conn.send(msg)
+            status, result = self._conn.recv()
+        if status == "attribute_error":
+            raise AttributeError(result)
+        if status == "not_implemented_error":
+            raise NotImplementedError(result)
+        if status == "error":
+            raise RuntimeError(f"Env subprocess error: {result}")
+        return result
+
+    # ── VectorEnv interface ──────────────────────────────────────────────
+
+    def reset(
+        self,
+        *,
+        seed: int | list[int] | range | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> tuple[dict, dict]:
+        kwargs: dict[str, Any] = {"suite": self._suite, "task_id": self._task_id}
+        if seed is not None:
+            kwargs["seed"] = list(seed) if isinstance(seed, range) else seed
+        if options is not None:
+            kwargs["options"] = options
+        return self._send_recv(("reset", kwargs))
+
+    def step(self, action: np.ndarray) -> tuple[dict, np.ndarray, np.ndarray, np.ndarray, dict]:
+        return self._send_recv(("step", {"suite": self._suite, "task_id": self._task_id, "action": action}))
+
+    def _resolve_method_name(self, method_name: str) -> str:
+        if method_name == "task_description" and self._has_task_description is False:
+            raise AttributeError(method_name)
+        if method_name == "task" and self._has_task is False:
+            if self._has_task_description:
+                return "task_description"
+            raise AttributeError(method_name)
+        return method_name
+
+    def call(self, method_name: str, *args: Any, **kwargs: Any) -> Any:
+        if method_name == "_max_episode_steps" and self._max_episode_steps is not None:
+            return [self._max_episode_steps] * self.num_envs
+        remote_method_name = self._resolve_method_name(method_name)
+        return self._send_recv(
+            (
+                "call",
+                {
+                    "suite": self._suite,
+                    "task_id": self._task_id,
+                    "method": remote_method_name,
+                    "args": args,
+                    "kwargs": kwargs,
+                },
+            )
+        )
+
+    def get_attr(self, name: str) -> Any:
+        if name == "_max_episode_steps" and self._max_episode_steps is not None:
+            return [self._max_episode_steps] * self.num_envs
+        remote_name = self._resolve_method_name(name)
+        return self._send_recv(
+            ("get_attr", {"suite": self._suite, "task_id": self._task_id, "name": remote_name})
+        )
+
+    def close(self) -> None:
+        with contextlib.suppress(EOFError, BrokenPipeError, OSError, RuntimeError):
+            self._send_recv(("close_env", {"suite": self._suite, "task_id": self._task_id}))
+
+    # ── Properties used by eval pipeline ─────────────────────────────────
+
+    @property
+    def envs(self) -> _EnvsListProxy:
+        """Proxy for direct per-environment rendering and task access."""
+        return self._envs
+
+    @property
+    def unwrapped(self) -> _UnwrappedProxy:
+        return self._unwrapped
+
+    @property
+    def connection(self) -> Connection:
+        """The shared pipe connection (used by close_process_isolated_envs)."""
+        return self._conn
+
+    @property
+    def subprocess(self) -> mp.process.BaseProcess:
+        """The subprocess managing this environment."""
+        return self._process
+
+    def _close_server_connection(self) -> None:
+        """Request server shutdown while holding the shared IPC lock."""
+        if not self._lock.acquire(timeout=_SUBPROCESS_SHUTDOWN_TIMEOUT_S):
+            with contextlib.suppress(OSError):
+                self._conn.close()
+            return
+        try:
+            self._conn.send(("close_all", {}))
+            if self._conn.poll(timeout=_SUBPROCESS_SHUTDOWN_TIMEOUT_S):
+                self._conn.recv()
+        except (EOFError, BrokenPipeError, OSError):
+            pass
+        finally:
+            with contextlib.suppress(OSError):
+                self._conn.close()
+            self._lock.release()
+
+    # ── Rendering ────────────────────────────────────────────────────────
+
+    def _render_single(self, index: int) -> np.ndarray:
+        """Render a single environment by index (called by _EnvItemProxy.render)."""
+        return self._send_recv(
+            ("render_single", {"suite": self._suite, "task_id": self._task_id, "index": index})
+        )
+
+
+def close_process_isolated_envs(envs: dict[str, dict[int, EnvProxy]]) -> None:
+    """Close all process-isolated environments and terminate the subprocess.
+
+    Must be called when evaluation is complete.  Also registered via
+    ``atexit`` as a safety net.
+    """
+    owner_proxy = None
+    process = None
+    for suite_tasks in envs.values():
+        for proxy in suite_tasks.values():
+            owner_proxy = proxy
+            process = proxy.subprocess
+            break
+        if owner_proxy is not None:
+            break
+
+    if owner_proxy is not None:
+        owner_proxy._close_server_connection()
+
+    if process is not None:
+        process.join(timeout=_SUBPROCESS_SHUTDOWN_TIMEOUT_S)
+        if process.is_alive():
+            _terminate_and_join_process(process)

--- a/src/lerobot/scripts/lerobot_eval.py
+++ b/src/lerobot/scripts/lerobot_eval.py
@@ -491,6 +491,9 @@ def eval_policy(
             # Here we must render all frames and discard any we don't need.
             # Covers AsyncVectorEnv and _LazyAsyncVectorEnv (which wraps one).
             ep_frames.append(np.stack(env.call("render")[:n_to_render_now]))
+        elif hasattr(env, "envs"):
+            # Process-isolated or other proxy environments that expose env.envs[i].render().
+            ep_frames.append(np.stack([env.envs[i].render() for i in range(n_to_render_now)]))  # noqa: B023
 
     if max_episodes_rendered > 0:
         video_paths: list[str] = []
@@ -750,76 +753,102 @@ def eval_main(cfg: EvalPipelineConfig):
     logging.info(colored("Output dir:", "yellow", attrs=["bold"]) + f" {cfg.output_dir}")
 
     logging.info(f"Making environment (batch_size={cfg.eval.batch_size}, async={cfg.eval.use_async_envs}).")
-    envs = make_env(
-        cfg.env,
-        n_envs=cfg.eval.batch_size,
-        use_async_envs=cfg.eval.use_async_envs,
-        trust_remote_code=cfg.trust_remote_code,
-    )
+    if cfg.eval.process_isolated:
+        from lerobot.envs.process_isolated import make_env_in_subprocess
 
-    logging.info("Making policy.")
-
-    policy = make_policy(
-        cfg=cfg.policy,
-        env_cfg=cfg.env,
-        rename_map=cfg.rename_map,
-    )
-
-    policy.eval()
-
-    # The inference device is automatically set to match the detected hardware, overriding any previous device settings from training to ensure compatibility.
-    preprocessor_overrides = {
-        "device_processor": {"device": str(policy.config.device)},
-        "rename_observations_processor": {"rename_map": cfg.rename_map},
-    }
-
-    preprocessor, postprocessor = make_pre_post_processors(
-        policy_cfg=cfg.policy,
-        pretrained_path=cfg.policy.pretrained_path,
-        preprocessor_overrides=preprocessor_overrides,
-    )
-
-    # Create environment-specific preprocessor and postprocessor (e.g., for LIBERO environments)
-    env_preprocessor, env_postprocessor = make_env_pre_post_processors(env_cfg=cfg.env, policy_cfg=cfg.policy)
-
-    recording_dir = Path(cfg.output_dir) / "recordings" if cfg.eval.recording else None
-    max_episodes_rendered = 0 if cfg.eval.recording else 10
-    videos_dir = None if cfg.eval.recording else Path(cfg.output_dir) / "videos"
-
-    with torch.no_grad(), torch.autocast(device_type=device.type) if cfg.policy.use_amp else nullcontext():
-        info = eval_policy_all(
-            envs=envs,
-            policy=policy,
-            env_preprocessor=env_preprocessor,
-            env_postprocessor=env_postprocessor,
-            preprocessor=preprocessor,
-            postprocessor=postprocessor,
-            n_episodes=cfg.eval.n_episodes,
-            max_episodes_rendered=max_episodes_rendered,
-            videos_dir=videos_dir,
-            return_episode_data=False,
-            start_seed=cfg.seed,
-            max_parallel_tasks=cfg.env.max_parallel_tasks,
-            recording_dir=recording_dir,
-            env_features=cfg.env.features if cfg.eval.recording else None,
-            recording_repo_id=cfg.eval.recording_repo_id,
-            recording_private=cfg.eval.recording_private,
+        logging.info(
+            "Process-isolated mode: environments will run in a subprocess with GPU disabled "
+            "(CUDA_VISIBLE_DEVICES='', MUJOCO_GL=osmesa)."
         )
-        logger.info("Overall Aggregated Metrics:")
-        logger.info(info["overall"])
+        envs = make_env_in_subprocess(
+            cfg.env,
+            n_envs=cfg.eval.batch_size,
+            use_async_envs=cfg.eval.use_async_envs,
+            trust_remote_code=cfg.trust_remote_code,
+        )
+    else:
+        envs = make_env(
+            cfg.env,
+            n_envs=cfg.eval.batch_size,
+            use_async_envs=cfg.eval.use_async_envs,
+            trust_remote_code=cfg.trust_remote_code,
+        )
 
-        # Print per-suite stats
-        for task_group, task_group_info in info.items():
-            logger.info(f"\nAggregated Metrics for {task_group}:")
-            logger.info(task_group_info)
-    # Close all vec envs
-    close_envs(envs)
+    try:
+        logging.info("Making policy.")
 
-    # Save info
-    with open(Path(cfg.output_dir) / "eval_info.json", "w") as f:
-        json.dump(info, f, indent=2)
+        policy = make_policy(
+            cfg=cfg.policy,
+            env_cfg=cfg.env,
+            rename_map=cfg.rename_map,
+        )
 
-    logging.info("End of eval")
+        policy.eval()
+
+        # The inference device is automatically set to match the detected hardware, overriding any previous device settings from training to ensure compatibility.
+        preprocessor_overrides = {
+            "device_processor": {"device": str(policy.config.device)},
+            "rename_observations_processor": {"rename_map": cfg.rename_map},
+        }
+
+        preprocessor, postprocessor = make_pre_post_processors(
+            policy_cfg=cfg.policy,
+            pretrained_path=cfg.policy.pretrained_path,
+            preprocessor_overrides=preprocessor_overrides,
+        )
+
+        # Create environment-specific preprocessor and postprocessor (e.g., for LIBERO environments)
+        env_preprocessor, env_postprocessor = make_env_pre_post_processors(
+            env_cfg=cfg.env, policy_cfg=cfg.policy
+        )
+
+        recording_dir = Path(cfg.output_dir) / "recordings" if cfg.eval.recording else None
+        max_episodes_rendered = 0 if cfg.eval.recording else 10
+        videos_dir = None if cfg.eval.recording else Path(cfg.output_dir) / "videos"
+
+        with (
+            torch.no_grad(),
+            torch.autocast(device_type=device.type) if cfg.policy.use_amp else nullcontext(),
+        ):
+            info = eval_policy_all(
+                envs=envs,
+                policy=policy,
+                env_preprocessor=env_preprocessor,
+                env_postprocessor=env_postprocessor,
+                preprocessor=preprocessor,
+                postprocessor=postprocessor,
+                n_episodes=cfg.eval.n_episodes,
+                max_episodes_rendered=max_episodes_rendered,
+                videos_dir=videos_dir,
+                return_episode_data=False,
+                start_seed=cfg.seed,
+                max_parallel_tasks=cfg.env.max_parallel_tasks,
+                recording_dir=recording_dir,
+                env_features=cfg.env.features if cfg.eval.recording else None,
+                recording_repo_id=cfg.eval.recording_repo_id,
+                recording_private=cfg.eval.recording_private,
+            )
+            logger.info("Overall Aggregated Metrics:")
+            logger.info(info["overall"])
+
+            # Print per-suite stats
+            for task_group, task_group_info in info.items():
+                logger.info(f"\nAggregated Metrics for {task_group}:")
+                logger.info(task_group_info)
+
+        # Save info
+        with open(Path(cfg.output_dir) / "eval_info.json", "w") as f:
+            json.dump(info, f, indent=2)
+
+        logging.info("End of eval")
+    finally:
+        # Close the subprocess even when policy construction or rollout fails.
+        if cfg.eval.process_isolated:
+            from lerobot.envs.process_isolated import close_process_isolated_envs
+
+            close_process_isolated_envs(envs)
+        else:
+            close_envs(envs)
 
 
 # ---- typed payload returned by one task eval ----

--- a/tests/envs/test_process_isolated.py
+++ b/tests/envs/test_process_isolated.py
@@ -1,0 +1,719 @@
+"""Tests for the process-isolated environment wrapper.
+
+These tests verify that the ProcessIsolatedVectorEnv proxy correctly forwards
+environment operations to a subprocess and that the subprocess runs without
+GPU access.
+"""
+
+from __future__ import annotations
+
+import multiprocessing as mp
+import os
+import threading
+import warnings
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import gymnasium as gym
+import numpy as np
+import pytest
+
+from lerobot.envs import process_isolated
+from lerobot.envs.process_isolated import (
+    EnvProxy,
+    _collect_env_metadata,
+    _env_server_main,
+    _serve_requests,
+    close_process_isolated_envs,
+    make_env_in_subprocess,
+)
+from lerobot.envs.utils import NEW_ROLLOUT_OPTION, check_env_attributes_and_types
+
+# ── Fixtures ─────────────────────────────────────────────────────────────────
+
+
+class _DummyEnv(gym.Env):
+    """Minimal gym env for testing without simulation dependencies."""
+
+    metadata = {"render_fps": 10}
+
+    def __init__(self, task_desc: str = "test task"):
+        super().__init__()
+        self.observation_space = gym.spaces.Dict(
+            {
+                "pixels": gym.spaces.Dict(
+                    {
+                        "image": gym.spaces.Box(0, 255, shape=(64, 64, 3), dtype=np.uint8),
+                    }
+                ),
+            }
+        )
+        self.action_space = gym.spaces.Box(-1, 1, shape=(7,), dtype=np.float32)
+        self.task_description = task_desc
+        self._max_episode_steps = 10
+        self._step_count = 0
+
+    def reset(self, seed=None, options=None):
+        self._step_count = 0
+        obs = {"pixels": {"image": np.zeros((64, 64, 3), dtype=np.uint8)}}
+        return obs, {}
+
+    def step(self, action):
+        self._step_count += 1
+        obs = {"pixels": {"image": np.ones((64, 64, 3), dtype=np.uint8)}}
+        reward = 0.0
+        terminated = self._step_count >= self._max_episode_steps
+        truncated = False
+        info = {}
+        if terminated:
+            info["is_success"] = True
+        return obs, reward, terminated, truncated, info
+
+    def render(self):
+        return np.zeros((64, 64, 3), dtype=np.uint8)
+
+
+def _make_dummy_vec_env(n_envs: int = 1) -> gym.vector.SyncVectorEnv:
+    return gym.vector.SyncVectorEnv(
+        [lambda: _DummyEnv() for _ in range(n_envs)],
+        autoreset_mode=gym.vector.AutoresetMode.SAME_STEP,
+    )
+
+
+# ── Unit tests for metadata collection ───────────────────────────────────────
+
+
+def test_environment_server_process_is_not_daemonic(monkeypatch):
+    context = MagicMock()
+    parent_conn = MagicMock()
+    child_conn = MagicMock()
+    process = MagicMock()
+    context.Pipe.return_value = (parent_conn, child_conn)
+    context.Process.return_value = process
+    parent_conn.poll.return_value = True
+    parent_conn.recv.return_value = (
+        "ready",
+        {"test_suite": {"0": {"num_envs": 1, "render_fps": 30}}},
+    )
+    monkeypatch.setattr(mp, "get_context", MagicMock(return_value=context))
+
+    envs = make_env_in_subprocess(MagicMock(), use_async_envs=True)
+
+    assert list(envs["test_suite"]) == [0]
+    assert context.Process.call_args.kwargs.get("daemon", False) is False
+
+
+def test_empty_metadata_terminates_environment_server(monkeypatch):
+    context = MagicMock()
+    parent_conn = MagicMock()
+    child_conn = MagicMock()
+    process = MagicMock()
+    context.Pipe.return_value = (parent_conn, child_conn)
+    context.Process.return_value = process
+    parent_conn.poll.return_value = True
+    parent_conn.recv.return_value = ("ready", {})
+    process.is_alive.return_value = True
+    process.terminate.side_effect = lambda: process.is_alive.configure_mock(return_value=False)
+    monkeypatch.setattr(mp, "get_context", MagicMock(return_value=context))
+
+    with pytest.raises(RuntimeError, match="returned no environments"):
+        make_env_in_subprocess(MagicMock())
+
+    parent_conn.close.assert_called_once_with()
+    process.terminate.assert_called_once_with()
+    process.join.assert_called_once_with(timeout=5)
+
+
+def test_startup_timeout_terminates_environment_server(monkeypatch):
+    context = MagicMock()
+    parent_conn = MagicMock()
+    child_conn = MagicMock()
+    process = MagicMock()
+    context.Pipe.return_value = (parent_conn, child_conn)
+    context.Process.return_value = process
+    parent_conn.poll.return_value = False
+    process.exitcode = None
+    process.is_alive.return_value = True
+    process.terminate.side_effect = lambda: process.is_alive.configure_mock(return_value=False)
+    monkeypatch.setattr(mp, "get_context", MagicMock(return_value=context))
+
+    with pytest.raises(RuntimeError, match="did not respond"):
+        make_env_in_subprocess(MagicMock(), use_async_envs=True)
+
+    parent_conn.close.assert_called_once_with()
+    process.terminate.assert_called_once_with()
+    process.join.assert_called_once_with(timeout=5)
+
+
+def test_startup_interrupt_terminates_environment_server(monkeypatch):
+    context = MagicMock()
+    parent_conn = MagicMock()
+    child_conn = MagicMock()
+    process = MagicMock()
+    context.Pipe.return_value = (parent_conn, child_conn)
+    context.Process.return_value = process
+    parent_conn.poll.side_effect = KeyboardInterrupt
+    process.is_alive.return_value = True
+    process.terminate.side_effect = lambda: process.is_alive.configure_mock(return_value=False)
+    monkeypatch.setattr(mp, "get_context", MagicMock(return_value=context))
+
+    with pytest.raises(KeyboardInterrupt):
+        make_env_in_subprocess(MagicMock())
+
+    parent_conn.close.assert_called_once_with()
+    process.terminate.assert_called_once_with()
+    process.join.assert_called_once_with(timeout=5)
+
+
+def test_startup_recv_interrupt_terminates_environment_server(monkeypatch):
+    context = MagicMock()
+    parent_conn = MagicMock()
+    child_conn = MagicMock()
+    process = MagicMock()
+    context.Pipe.return_value = (parent_conn, child_conn)
+    context.Process.return_value = process
+    parent_conn.poll.return_value = True
+    parent_conn.recv.side_effect = KeyboardInterrupt
+    process.is_alive.return_value = True
+    process.terminate.side_effect = lambda: process.is_alive.configure_mock(return_value=False)
+    monkeypatch.setattr(mp, "get_context", MagicMock(return_value=context))
+
+    with pytest.raises(KeyboardInterrupt):
+        make_env_in_subprocess(MagicMock())
+
+    parent_conn.close.assert_called_once_with()
+    process.terminate.assert_called_once_with()
+    process.join.assert_called_once_with(timeout=5)
+
+
+def test_atexit_registration_interrupt_terminates_environment_server(monkeypatch):
+    context = MagicMock()
+    parent_conn = MagicMock()
+    child_conn = MagicMock()
+    process = MagicMock()
+    context.Pipe.return_value = (parent_conn, child_conn)
+    context.Process.return_value = process
+    parent_conn.poll.return_value = True
+    parent_conn.recv.return_value = (
+        "ready",
+        {"test_suite": {"0": {"num_envs": 1, "render_fps": 30}}},
+    )
+    process.is_alive.return_value = True
+    process.terminate.side_effect = lambda: process.is_alive.configure_mock(return_value=False)
+    monkeypatch.setattr(mp, "get_context", MagicMock(return_value=context))
+    monkeypatch.setattr(process_isolated.atexit, "register", MagicMock(side_effect=KeyboardInterrupt))
+
+    with pytest.raises(KeyboardInterrupt):
+        make_env_in_subprocess(MagicMock())
+
+    parent_conn.close.assert_called_once_with()
+    process.terminate.assert_called_once_with()
+    process.join.assert_called_once_with(timeout=5)
+
+
+def test_process_start_failure_closes_both_pipe_ends(monkeypatch):
+    context = MagicMock()
+    parent_conn = MagicMock()
+    child_conn = MagicMock()
+    process = MagicMock()
+    context.Pipe.return_value = (parent_conn, child_conn)
+    context.Process.return_value = process
+    process.start.side_effect = RuntimeError("spawn failed")
+    monkeypatch.setattr(mp, "get_context", MagicMock(return_value=context))
+
+    with pytest.raises(RuntimeError, match="spawn failed"):
+        make_env_in_subprocess(MagicMock())
+
+    parent_conn.close.assert_called_once_with()
+    child_conn.close.assert_called_once_with()
+
+
+class TestCollectEnvMetadata:
+    def test_collects_num_envs(self):
+        vec_env = _make_dummy_vec_env(n_envs=2)
+        meta = _collect_env_metadata(vec_env)
+        assert meta["num_envs"] == 2
+        vec_env.close()
+
+    def test_does_not_start_vector_env_workers(self):
+        vec_env = MagicMock()
+        vec_env.num_envs = 2
+        vec_env.unwrapped = SimpleNamespace(metadata={"render_fps": 20})
+
+        metadata = _collect_env_metadata(vec_env)
+
+        assert metadata == {"num_envs": 2, "render_fps": 20}
+        vec_env.call.assert_not_called()
+
+    def test_collects_render_fps(self):
+        vec_env = _make_dummy_vec_env(n_envs=1)
+        meta = _collect_env_metadata(vec_env)
+        assert meta["render_fps"] == 10
+        vec_env.close()
+
+
+def test_env_server_main_reports_ready_serves_requests_and_closes(monkeypatch):
+    vec_env = _make_dummy_vec_env()
+    make_env = MagicMock(return_value={"test_suite": {0: vec_env}})
+    monkeypatch.setattr("lerobot.envs.factory.make_env", make_env)
+    parent_conn, child_conn = mp.Pipe()
+    server = threading.Thread(
+        target=_env_server_main,
+        args=(child_conn, MagicMock(), 1, False, False),
+    )
+    server.start()
+
+    try:
+        status, metadata = parent_conn.recv()
+        assert status == "ready"
+        assert metadata == {"test_suite": {"0": {"num_envs": 1, "render_fps": 10}}}
+
+        parent_conn.send(("reset", {"suite": "test_suite", "task_id": 0}))
+        assert parent_conn.recv()[0] == "ok"
+        parent_conn.send(("close_all", {}))
+        assert parent_conn.recv() == ("ok", None)
+    finally:
+        parent_conn.close()
+        server.join(timeout=2)
+
+    assert not server.is_alive()
+    make_env.assert_called_once()
+
+
+def test_env_server_main_reports_setup_error(monkeypatch):
+    monkeypatch.setattr(
+        "lerobot.envs.factory.make_env",
+        MagicMock(side_effect=RuntimeError("setup failed")),
+    )
+    parent_conn, child_conn = mp.Pipe()
+
+    _env_server_main(child_conn, MagicMock(), 1, False, False)
+
+    status, error = parent_conn.recv()
+    parent_conn.close()
+    assert status == "error"
+    assert "setup failed" in error
+
+
+# ── Unit tests for EnvProxy ──────────────────────────────────────────────────
+
+
+class TestEnvProxy:
+    """Tests for proxy interface without spawning a real subprocess."""
+
+    def _make_proxy(
+        self,
+        num_envs: int = 1,
+        **metadata_overrides,
+    ) -> tuple[EnvProxy, mp.connection.Connection]:
+        """Create a proxy with a mock connection."""
+        parent_conn, child_conn = mp.Pipe()
+        metadata = {
+            "num_envs": num_envs,
+            "has_task_description": True,
+            "has_task": False,
+            "task_descriptions": [f"task_{i}" for i in range(num_envs)],
+            "max_episode_steps": 10,
+            "render_fps": 30,
+        } | metadata_overrides
+        proxy = EnvProxy(
+            conn=parent_conn,
+            lock=threading.Lock(),
+            suite_name="test_suite",
+            task_id=0,
+            metadata=metadata,
+            process=MagicMock(),
+        )
+        return proxy, child_conn
+
+    def test_num_envs(self):
+        proxy, child = self._make_proxy(num_envs=3)
+        assert proxy.num_envs == 3
+        child.close()
+
+    def test_envs_proxy_len(self):
+        proxy, child = self._make_proxy(num_envs=2)
+        assert len(proxy.envs) == 2
+        child.close()
+
+    def test_envs_proxy_reads_live_task_description(self):
+        conn = MagicMock()
+        conn.recv.side_effect = [("ok", ["first"]), ("ok", ["second"])]
+        proxy = EnvProxy(
+            conn=conn,
+            lock=threading.Lock(),
+            suite_name="test_suite",
+            task_id=0,
+            metadata={"num_envs": 1, "render_fps": 30},
+            process=MagicMock(),
+        )
+
+        assert proxy.envs[0].task_description == "first"
+        assert proxy.envs[0].task_description == "second"
+        assert conn.send.call_count == 2
+
+    def test_unwrapped_metadata(self):
+        proxy, child = self._make_proxy()
+        assert proxy.unwrapped.metadata["render_fps"] == 30
+        child.close()
+
+    @pytest.mark.parametrize("method", ["call", "get_attr"])
+    def test_proxy_preserves_remote_attribute_error(self, method):
+        conn = MagicMock()
+        conn.recv.return_value = ("attribute_error", "task_description")
+        proxy = EnvProxy(
+            conn=conn,
+            lock=threading.Lock(),
+            suite_name="test_suite",
+            task_id=0,
+            metadata={"num_envs": 1, "render_fps": 30},
+            process=MagicMock(),
+        )
+
+        with pytest.raises(AttributeError, match="task_description"):
+            getattr(proxy, method)("task_description")
+
+    def test_proxy_passes_current_main_attribute_check(self):
+        conn = MagicMock()
+        conn.recv.side_effect = [("ok", ["description"]), ("ok", ["task"])]
+        proxy = EnvProxy(
+            conn=conn,
+            lock=threading.Lock(),
+            suite_name="test_suite",
+            task_id=0,
+            metadata={"num_envs": 1, "render_fps": 30},
+            process=MagicMock(),
+        )
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always", UserWarning)
+            check_env_attributes_and_types(proxy)
+
+        assert not caught
+
+    def test_reset_sends_options_through_ipc(self):
+        conn = MagicMock()
+        conn.recv.return_value = ("ok", ({"observation": np.array([1])}, {}))
+        proxy = EnvProxy(
+            conn=conn,
+            lock=threading.Lock(),
+            suite_name="test_suite",
+            task_id=3,
+            metadata={
+                "num_envs": 1,
+                "has_task_description": False,
+                "has_task": False,
+                "task_descriptions": [],
+                "max_episode_steps": 10,
+                "render_fps": 30,
+            },
+            process=MagicMock(),
+        )
+        options = {NEW_ROLLOUT_OPTION: True}
+
+        proxy.reset(seed=range(4, 5), options=options)
+
+        conn.send.assert_called_once_with(
+            (
+                "reset",
+                {
+                    "suite": "test_suite",
+                    "task_id": 3,
+                    "seed": [4],
+                    "options": options,
+                },
+            )
+        )
+
+
+def test_server_forwards_reset_options_to_vector_env():
+    parent_conn, child_conn = mp.Pipe()
+    vec_env = MagicMock()
+    vec_env.reset.return_value = ({"observation": np.array([1])}, {})
+    server = threading.Thread(
+        target=_serve_requests,
+        args=(child_conn, {"test_suite": {3: vec_env}}),
+        daemon=True,
+    )
+    server.start()
+    options = {NEW_ROLLOUT_OPTION: True}
+
+    parent_conn.send(
+        (
+            "reset",
+            {
+                "suite": "test_suite",
+                "task_id": 3,
+                "seed": [4],
+                "options": options,
+            },
+        )
+    )
+    assert parent_conn.recv()[0] == "ok"
+    parent_conn.send(("close_all", {}))
+    assert parent_conn.recv() == ("ok", None)
+    server.join(timeout=2)
+
+    vec_env.reset.assert_called_once_with(seed=[4], options=options)
+    parent_conn.close()
+    child_conn.close()
+
+
+def test_server_forwards_call_and_get_attr():
+    parent_conn, child_conn = mp.Pipe()
+    vec_env = MagicMock()
+    vec_env.call.return_value = ("called",)
+    vec_env.get_attr.return_value = ("attribute",)
+    server = threading.Thread(
+        target=_serve_requests,
+        args=(child_conn, {"test_suite": {3: vec_env}}),
+        daemon=True,
+    )
+    server.start()
+
+    parent_conn.send(
+        (
+            "call",
+            {
+                "suite": "test_suite",
+                "task_id": 3,
+                "method": "method_name",
+                "args": (1,),
+                "kwargs": {"enabled": True},
+            },
+        )
+    )
+    assert parent_conn.recv() == ("ok", ["called"])
+    parent_conn.send(("get_attr", {"suite": "test_suite", "task_id": 3, "name": "attribute_name"}))
+    assert parent_conn.recv() == ("ok", ["attribute"])
+    parent_conn.send(("close_all", {}))
+    assert parent_conn.recv() == ("ok", None)
+    server.join(timeout=2)
+
+    vec_env.call.assert_called_once_with("method_name", 1, enabled=True)
+    vec_env.get_attr.assert_called_once_with("attribute_name")
+    assert not server.is_alive()
+    parent_conn.close()
+    child_conn.close()
+
+
+# ── Integration test with real subprocess ────────────────────────────────────
+
+
+class TestSubprocessIntegration:
+    """Tests that exercise the full subprocess lifecycle."""
+
+    @pytest.fixture()
+    def _server(self):
+        """Start a subprocess server with a dummy env and yield the connection."""
+        ctx = mp.get_context("spawn")
+        parent_conn, child_conn = ctx.Pipe()
+
+        # We can't use _DummyEnv directly because spawn context requires picklable targets.
+        # Instead, test with a registered gym env.
+        process = ctx.Process(
+            target=_subprocess_with_cartpole,
+            args=(child_conn,),
+            daemon=True,
+        )
+        process.start()
+        child_conn.close()
+
+        msg = parent_conn.recv()
+        assert msg[0] == "ready", f"Server failed: {msg}"
+
+        yield parent_conn, process, msg[1]
+
+        try:
+            parent_conn.send(("close_all", {}))
+            parent_conn.recv()
+        except (EOFError, BrokenPipeError):
+            pass
+        process.join(timeout=5)
+        if process.is_alive():
+            process.terminate()
+
+    def test_server_reports_metadata(self, _server):
+        conn, process, metadata = _server
+        assert "CartPole-v1" in metadata
+        cart_meta = metadata["CartPole-v1"]["0"]
+        assert cart_meta["num_envs"] == 1
+        assert cart_meta["render_fps"] > 0
+
+    def test_reset_returns_observation(self, _server):
+        conn, process, metadata = _server
+        conn.send(("reset", {"suite": "CartPole-v1", "task_id": 0}))
+        status, (obs, info) = conn.recv()
+        assert status == "ok"
+        assert isinstance(obs, np.ndarray)
+
+    def test_step_returns_tuple(self, _server):
+        conn, process, metadata = _server
+        # Reset first.
+        conn.send(("reset", {"suite": "CartPole-v1", "task_id": 0}))
+        conn.recv()
+        # CartPole has Discrete(2) action space; VectorEnv expects shape (n_envs,).
+        action = np.array([0])
+        conn.send(("step", {"suite": "CartPole-v1", "task_id": 0, "action": action}))
+        status, result = conn.recv()
+        assert status == "ok", f"Subprocess error: {result}"
+        assert isinstance(result, tuple)
+        # VectorEnv.step returns (obs, reward, terminated, truncated, info).
+        assert len(result) == 5
+
+    def test_non_daemonic_server_can_run_async_vector_env(self):
+        ctx = mp.get_context("spawn")
+        parent_conn, child_conn = ctx.Pipe()
+        process = ctx.Process(target=_subprocess_with_async_cartpole, args=(child_conn,))
+        process.start()
+        child_conn.close()
+
+        try:
+            assert parent_conn.poll(timeout=30)
+            status, result = parent_conn.recv()
+            process.join(timeout=10)
+
+            assert status == "ok", result
+            assert result == 2
+            assert process.exitcode == 0
+        finally:
+            parent_conn.close()
+            if process.is_alive():
+                process.terminate()
+            process.join(timeout=5)
+
+
+def _subprocess_with_cartpole(conn):
+    """Subprocess target that creates a CartPole env for testing."""
+    os.environ["CUDA_VISIBLE_DEVICES"] = ""
+
+    vec_env = gym.vector.SyncVectorEnv(
+        [lambda: gym.make("CartPole-v1")],
+        autoreset_mode=gym.vector.AutoresetMode.SAME_STEP,
+    )
+
+    # Import inside subprocess since this runs in a spawn context.
+    from lerobot.envs.process_isolated import (
+        _collect_env_metadata as collect_meta,
+        _serve_requests as serve,
+    )
+
+    metadata = {"CartPole-v1": {"0": collect_meta(vec_env)}}
+    conn.send(("ready", metadata))
+
+    try:
+        serve(conn, {"CartPole-v1": {0: vec_env}})
+    except (EOFError, BrokenPipeError):
+        pass
+    finally:
+        vec_env.close()
+        conn.close()
+
+
+def _make_cartpole():
+    return gym.make("CartPole-v1")
+
+
+def _subprocess_with_async_cartpole(conn):
+    vec_env = None
+    try:
+        vec_env = gym.vector.AsyncVectorEnv([_make_cartpole, _make_cartpole], context="spawn")
+        observation, _ = vec_env.reset(seed=[1, 2])
+        conn.send(("ok", len(observation)))
+    except Exception:
+        import traceback
+
+        conn.send(("error", traceback.format_exc()))
+    finally:
+        if vec_env is not None:
+            vec_env.close()
+        conn.close()
+
+
+# ── Test for close_process_isolated_envs ─────────────────────────────────────
+
+
+class TestCloseProcessIsolatedEnvs:
+    def test_closes_gracefully(self):
+        parent_conn, child_conn = mp.Pipe()
+        mock_process = MagicMock()
+        # Process is still alive, so close should call join.
+        mock_process.is_alive.return_value = True
+        mock_process.terminate.side_effect = lambda: mock_process.is_alive.configure_mock(return_value=False)
+
+        proxy = EnvProxy(
+            conn=parent_conn,
+            lock=threading.Lock(),
+            suite_name="test",
+            task_id=0,
+            metadata={
+                "num_envs": 1,
+                "has_task_description": False,
+                "has_task": False,
+                "task_descriptions": [],
+                "max_episode_steps": 10,
+                "render_fps": 30,
+            },
+            process=mock_process,
+        )
+
+        # Simulate the server responding to close_all.
+        def _respond():
+            cmd, _ = child_conn.recv()
+            assert cmd == "close_all"
+            child_conn.send(("ok", None))
+
+        t = threading.Thread(target=_respond)
+        t.start()
+
+        close_process_isolated_envs({"test": {0: proxy}})
+        t.join(timeout=2)
+        assert not t.is_alive()
+        mock_process.terminate.assert_called_once_with()
+        assert mock_process.join.call_count == 2
+
+    def test_close_timeout_terminates_and_reaps_server(self):
+        conn = MagicMock()
+        conn.poll.return_value = False
+        process = MagicMock()
+        process.is_alive.return_value = True
+        process.terminate.side_effect = lambda: process.is_alive.configure_mock(return_value=False)
+        proxy = EnvProxy(
+            conn=conn,
+            lock=threading.Lock(),
+            suite_name="test",
+            task_id=0,
+            metadata={"num_envs": 1, "render_fps": 30},
+            process=process,
+        )
+
+        close_process_isolated_envs({"test": {0: proxy}})
+
+        conn.poll.assert_called_once_with(timeout=10)
+        conn.recv.assert_not_called()
+        conn.close.assert_called_once_with()
+        process.terminate.assert_called_once_with()
+        assert process.join.call_count == 2
+
+    def test_close_returns_when_shared_ipc_lock_is_busy(self, monkeypatch):
+        conn = MagicMock()
+        lock = threading.Lock()
+        lock.acquire()
+        process = MagicMock()
+        proxy = EnvProxy(
+            conn=conn,
+            lock=lock,
+            suite_name="test",
+            task_id=0,
+            metadata={"num_envs": 1, "render_fps": 30},
+            process=process,
+        )
+        monkeypatch.setattr(process_isolated, "_SUBPROCESS_SHUTDOWN_TIMEOUT_S", 0.01)
+
+        try:
+            proxy._close_server_connection()
+        finally:
+            lock.release()
+
+        conn.send.assert_not_called()
+        conn.close.assert_called_once_with()

--- a/tests/scripts/test_lerobot_eval_cleanup.py
+++ b/tests/scripts/test_lerobot_eval_cleanup.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from lerobot.envs import process_isolated
+from lerobot.scripts import lerobot_eval
+
+
+@dataclass
+class _EvalSettings:
+    batch_size: int = 1
+    use_async_envs: bool = False
+    process_isolated: bool = False
+
+
+@dataclass
+class _PolicySettings:
+    device: str = "cpu"
+
+
+@dataclass
+class _EnvSettings:
+    max_parallel_tasks: int = 1
+
+
+@dataclass
+class _EvalPipelineSettings:
+    env: _EnvSettings = field(default_factory=_EnvSettings)
+    eval: _EvalSettings = field(default_factory=_EvalSettings)
+    policy: _PolicySettings = field(default_factory=_PolicySettings)
+    output_dir: Path = Path("unused")
+    seed: int = 0
+    rename_map: dict[str, str] = field(default_factory=dict)
+    trust_remote_code: bool = False
+
+
+def test_eval_main_closes_envs_when_policy_creation_fails(monkeypatch):
+    envs = {"suite": {0: MagicMock()}}
+    close_envs = MagicMock()
+    monkeypatch.setattr(lerobot_eval, "get_safe_torch_device", MagicMock(return_value=MagicMock(type="cpu")))
+    monkeypatch.setattr(lerobot_eval, "set_seed", MagicMock())
+    monkeypatch.setattr(lerobot_eval, "make_env", MagicMock(return_value=envs))
+    monkeypatch.setattr(lerobot_eval, "make_policy", MagicMock(side_effect=RuntimeError("policy failed")))
+    monkeypatch.setattr(lerobot_eval, "close_envs", close_envs)
+
+    with pytest.raises(RuntimeError, match="policy failed"):
+        lerobot_eval.eval_main.__wrapped__(_EvalPipelineSettings())
+
+    close_envs.assert_called_once_with(envs)
+
+
+def test_eval_main_closes_process_isolated_envs_when_policy_creation_fails(monkeypatch):
+    envs = {"suite": {0: MagicMock()}}
+    close_envs = MagicMock()
+    cfg = _EvalPipelineSettings(eval=_EvalSettings(process_isolated=True))
+    monkeypatch.setattr(lerobot_eval, "get_safe_torch_device", MagicMock(return_value=MagicMock(type="cpu")))
+    monkeypatch.setattr(lerobot_eval, "set_seed", MagicMock())
+    monkeypatch.setattr(process_isolated, "make_env_in_subprocess", MagicMock(return_value=envs))
+    monkeypatch.setattr(process_isolated, "close_process_isolated_envs", close_envs)
+    monkeypatch.setattr(lerobot_eval, "make_policy", MagicMock(side_effect=RuntimeError("policy failed")))
+
+    with pytest.raises(RuntimeError, match="policy failed"):
+        lerobot_eval.eval_main.__wrapped__(cfg)
+
+    close_envs.assert_called_once_with(envs)


### PR DESCRIPTION
## Type / Scope

- **Type**: Feature
- **Scope**: eval, envs

## Summary / Motivation

On GPUs with limited VRAM, policy inference and GPU-backed simulation/rendering can compete for the same memory. This PR adds an opt-in `--eval.process_isolated=true` mode that runs all simulation environments in a spawned subprocess with `CUDA_VISIBLE_DEVICES=""` and `MUJOCO_GL=osmesa`, leaving the main process dedicated to policy inference.

The default remains `false`, so the existing evaluation path is unchanged unless isolation is explicitly requested.

## Related issues

- Closes #3098

## What changed

- Added `EvalConfig.process_isolated` with a default of `false`.
- Added `src/lerobot/envs/process_isolated.py`:
  - a non-daemon environment server that can host nested `AsyncVectorEnv` workers;
  - a locked `multiprocessing.Pipe` protocol and `EnvProxy` implementing the `VectorEnv` subset used by eval;
  - forwarding for `reset(seed=..., options=...)`, `step`, `render`, `call`, and `get_attr`;
  - live task/task-description access and preservation of remote `AttributeError`/`NotImplementedError` semantics;
  - bounded startup and shutdown cleanup, including EOF, timeout, malformed metadata, `KeyboardInterrupt`, terminate, and kill paths.
- Updated `lerobot_eval.py` to select the isolated environment factory and to close both normal and isolated environments through `try/finally`, including policy-construction failures.
- Added regression and integration coverage for proxy behavior, real subprocess requests, nested async workers, interruption cleanup, lock/close timeouts, and eval cleanup.
- Rebased onto current `main`; the obsolete `envs/utils.py` hunk has been removed entirely.

### Trade-offs and security

- OSMesa software rendering has been measured by the reviewer at roughly **5–7.5× slower** than EGL and about **1.2 GB additional host RAM** on their setup.
- All proxies share one locked pipe, so cross-task calls are effectively serialized; this mode is intended for memory-constrained GPUs, not as a throughput optimization.
- The pipe is pickle-based, but it is private to the self-spawned parent/child process pair and is not exposed to untrusted peers.
- OSMesa must be installed and functional on the host.

## Reviewer feedback addressed

- Forward `reset(options={NEW_ROLLOUT_OPTION: True})` through IPC.
- Avoid materializing lazy async workers during metadata collection; read task attributes live through `call()`.
- Raise `AttributeError` when task metadata is absent so eval's fallback chain remains correct.
- Add `get_attr()` support for current `check_env_attributes_and_types` behavior.
- Drop the obsolete `envs/utils.py` changes.
- Document the OSMesa/host-RAM/serialized-pipe costs.

## End-to-end verification

Environment:

- NVIDIA GeForce RTX 3050 Ti Laptop GPU, 4096 MiB
- Python 3.12.12
- `lerobot/smolvla_libero`
- LIBERO spatial task 0
- Model and VLM weights loaded from local ModelScope snapshots with Hugging Face/Transformers offline mode enabled
- 4 episodes, batch size 4, `use_async_envs=true`, 2 steps per episode
- Whole-GPU memory sampled with `nvidia-smi` every 100 ms

The short 2-step run is intended to verify the complete env → observation → SmolVLA → action → env-step pipeline and the nested async process topology, not task success quality.

| mode | result | `eval_s` | whole-GPU peak |
|---|---:|---:|---:|
| baseline (`process_isolated=false`) | 4/4 episodes completed | 57.374 s | 1724 MiB |
| isolated (`process_isolated=true`) | 4/4 episodes completed | 36.235 s | 1756 MiB |

This particular LIBERO/EGL/driver combination did not reproduce the original high EGL VRAM overhead, so these local peak numbers do **not** demonstrate a memory reduction and are not presented as such. The independent reviewer reproduced the intended isolation on an RTX 3090: baseline 1732–1809 MiB versus isolated 1276 MiB, with the environment subprocess holding zero VRAM. The original reporter also verified that the isolated path gets past the low-VRAM failure on an RTX 3070 Laptop GPU (8 GB). See the detailed [review measurements](https://github.com/huggingface/lerobot/pull/3235#issuecomment-5181882007).

### Before: current `main`, in-process EGL environments

<details>
<summary>Complete baseline command output</summary>

```text
idle_gpu_memory_mib=508
WARNING 2026-08-05 22:25:57 figs/eval.py:69 No job name provided, using 'libero_smolvla' as job name.
INFO 2026-08-05 22:25:57 bot_eval.py:741 {'env': {'camera_name': 'agentview_image,robot0_eye_in_hand_image',
         'camera_name_mapping': None,
         'control_mode': 'relative',
         'disable_env_checker': True,
         'episode_length': 2,
         'features': {'action': {'shape': (7,),
                                 'type': <FeatureType.ACTION: 'ACTION'>},
                      'pixels/agentview_image': {'shape': (360, 360, 3),
                                                 'type': <FeatureType.VISUAL: 'VISUAL'>},
                      'pixels/robot0_eye_in_hand_image': {'shape': (360,
                                                                    360,
                                                                    3),
                                                          'type': <FeatureType.VISUAL: 'VISUAL'>},
                      'robot_state/eef/mat': {'shape': (3, 3),
                                              'type': <FeatureType.STATE: 'STATE'>},
                      'robot_state/eef/pos': {'shape': (3,),
                                              'type': <FeatureType.STATE: 'STATE'>},
                      'robot_state/eef/quat': {'shape': (4,),
                                               'type': <FeatureType.STATE: 'STATE'>},
                      'robot_state/gripper/qpos': {'shape': (2,),
                                                   'type': <FeatureType.STATE: 'STATE'>},
                      'robot_state/gripper/qvel': {'shape': (2,),
                                                   'type': <FeatureType.STATE: 'STATE'>},
                      'robot_state/joints/pos': {'shape': (7,),
                                                 'type': <FeatureType.STATE: 'STATE'>},
                      'robot_state/joints/vel': {'shape': (7,),
                                                 'type': <FeatureType.STATE: 'STATE'>}},
         'features_map': {'action': 'action',
                          'pixels/agentview_image': 'observation.images.image',
                          'pixels/robot0_eye_in_hand_image': 'observation.images.image2',
                          'robot_state/eef/mat': 'observation.state.eef_mat',
                          'robot_state/eef/pos': 'observation.state.eef_pos',
                          'robot_state/eef/quat': 'observation.state.eef_quat',
                          'robot_state/gripper/qpos': 'observation.state.gripper_qpos',
                          'robot_state/gripper/qvel': 'observation.state.gripper_qvel',
                          'robot_state/joints/pos': 'observation.state.joint_pos',
                          'robot_state/joints/vel': 'observation.state.joint_vel'},
         'fps': 20,
         'hard_reset': True,
         'init_states': True,
         'is_libero_plus': False,
         'max_parallel_tasks': 1,
         'obs_type': 'pixels_agent_pos',
         'observation_height': 360,
         'observation_width': 360,
         'render_mode': 'rgb_array',
         'task': 'libero_spatial',
         'task_ids': [0]},
 'eval': {'batch_size': 4,
          'n_episodes': 4,
          'recording': False,
          'recording_private': False,
          'recording_repo_id': None,
          'use_async_envs': True},
 'job_name': 'libero_smolvla',
 'output_dir': PosixPath('<BEFORE_OUTPUT>'),
 'policy': {'adapt_to_pi_aloha': False,
            'add_image_special_tokens': False,
            'attention_mode': 'cross_attn',
            'chunk_size': 50,
            'compile_mode': 'max-autotune',
            'compile_model': False,
            'device': 'cuda',
            'empty_cameras': 1,
            'expert_width_multiplier': 0.75,
            'freeze_vision_encoder': False,
            'input_features': {'observation.images.camera1': {'shape': (3,
                                                                        256,
                                                                        256),
                                                              'type': <FeatureType.VISUAL: 'VISUAL'>},
                               'observation.images.camera2': {'shape': (3,
                                                                        256,
                                                                        256),
                                                              'type': <FeatureType.VISUAL: 'VISUAL'>},
                               'observation.images.camera3': {'shape': (3,
                                                                        256,
                                                                        256),
                                                              'type': <FeatureType.VISUAL: 'VISUAL'>},
                               'observation.state': {'shape': (6,),
                                                     'type': <FeatureType.STATE: 'STATE'>}},
            'license': None,
            'load_vlm_weights': True,
            'max_action_dim': 32,
            'max_period': 4.0,
            'max_state_dim': 32,
            'min_period': 0.004,
            'n_action_steps': 50,
            'n_obs_steps': 1,
            'normalization_mapping': {'ACTION': <NormalizationMode.MEAN_STD: 'MEAN_STD'>,
                                      'STATE': <NormalizationMode.MEAN_STD: 'MEAN_STD'>,
                                      'VISUAL': <NormalizationMode.IDENTITY: 'IDENTITY'>},
            'num_expert_layers': 0,
            'num_steps': 10,
            'num_vlm_layers': 16,
            'optimizer_betas': (0.9, 0.95),
            'optimizer_eps': 1e-08,
            'optimizer_grad_clip_norm': 10.0,
            'optimizer_lr': 0.0001,
            'optimizer_weight_decay': 1e-10,
            'output_features': {'action': {'shape': (7,),
                                           'type': <FeatureType.ACTION: 'ACTION'>}},
            'pad_language_to': 'max_length',
            'prefix_length': 0,
            'pretrained_path': PosixPath('<HOME>/.cache/modelscope/hub/models/lerobot/smolvla_libero'),
            'pretrained_revision': None,
            'private': None,
            'push_to_hub': True,
            'repo_id': 'pepijn223/smolvla_libero',
            'resize_imgs_with_padding': (512, 512),
            'rtc_config': None,
            'scheduler_decay_lr': 2.5e-06,
            'scheduler_decay_steps': 25000,
            'scheduler_warmup_steps': 1000,
            'self_attn_every_n_layers': 2,
            'tags': None,
            'tokenizer_max_length': 48,
            'train_expert_only': False,
            'train_state_proj': True,
            'use_amp': False,
            'use_cache': True,
            'use_delta_joint_actions_aloha': False,
            'use_peft': False,
            'vlm_model_name': '<HOME>/.cache/modelscope/hub/models/HuggingFaceTB/SmolVLM2-500M-Video-Instruct'},
 'rename_map': {'observation.images.image': 'observation.images.camera1',
                'observation.images.image2': 'observation.images.camera2'},
 'seed': 1000,
 'trust_remote_code': False}
INFO 2026-08-05 22:25:57 bot_eval.py:750 Output dir: <BEFORE_OUTPUT>
INFO 2026-08-05 22:25:57 bot_eval.py:752 Making environment (batch_size=4, async=True).
[robosuite WARNING] No private macro file found! (__init__.py:7)
WARNING 2026-08-05 22:25:57 e/__init__.py:7 No private macro file found!
[robosuite WARNING] It is recommended to use a private macro file (__init__.py:8)
WARNING 2026-08-05 22:25:57 e/__init__.py:8 It is recommended to use a private macro file
[robosuite WARNING] To setup, run: python <HOME>/myenv/lib/python3.12/site-packages/robosuite/scripts/setup_macros.py (__init__.py:9)
WARNING 2026-08-05 22:25:57 e/__init__.py:9 To setup, run: python <HOME>/myenv/lib/python3.12/site-packages/robosuite/scripts/setup_macros.py
INFO 2026-08-05 22:25:57 tesupport.py:24 No OpenGL_accelerate module loaded: No module named 'OpenGL_accelerate'
INFO 2026-08-05 22:25:57 bot_eval.py:760 Making policy.
`torch_dtype` is deprecated! Use `dtype` instead!
Creating LIBERO envs | suites=['libero_spatial'] | n_envs(per task)=4 | init_states=True
Restricting to task_ids=[0]
[info] using task orders [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
Built vec env | suite=libero_spatial | task_id=0 | n_envs=4
Loading  <HOME>/.cache/modelscope/hub/models/HuggingFaceTB/SmolVLM2-500M-Video-Instruct weights ...

Loading weights:   0%|          | 0/489 [00:00<?, ?it/s]
Loading weights:  27%|██▋       | 133/489 [00:00<00:00, 1327.72it/s]
Loading weights:  58%|█████▊    | 285/489 [00:00<00:00, 1439.34it/s]
Loading weights:  88%|████████▊ | 429/489 [00:00<00:00, 1346.06it/s]
Loading weights: 100%|██████████| 489/489 [00:00<00:00, 1397.77it/s]
Reducing the number of VLM layers to 16 ...
Loading weights from local directory

Stepping through eval batches:   0%|          | 0/1 [00:00<?, ?it/s][robosuite WARNING] No private macro file found! (__init__.py:7)
WARNING:robosuite_logs:No private macro file found!
[robosuite WARNING] It is recommended to use a private macro file (__init__.py:8)
WARNING:robosuite_logs:It is recommended to use a private macro file
[robosuite WARNING] To setup, run: python <HOME>/myenv/lib/python3.12/site-packages/robosuite/scripts/setup_macros.py (__init__.py:9)
WARNING:robosuite_logs:To setup, run: python <HOME>/myenv/lib/python3.12/site-packages/robosuite/scripts/setup_macros.py
[robosuite WARNING] No private macro file found! (__init__.py:7)
WARNING:robosuite_logs:No private macro file found!
[robosuite WARNING] It is recommended to use a private macro file (__init__.py:8)
WARNING:robosuite_logs:It is recommended to use a private macro file
[robosuite WARNING] To setup, run: python <HOME>/myenv/lib/python3.12/site-packages/robosuite/scripts/setup_macros.py (__init__.py:9)
WARNING:robosuite_logs:To setup, run: python <HOME>/myenv/lib/python3.12/site-packages/robosuite/scripts/setup_macros.py
[robosuite WARNING] No private macro file found! (__init__.py:7)
WARNING:robosuite_logs:No private macro file found!
[robosuite WARNING] It is recommended to use a private macro file (__init__.py:8)
WARNING:robosuite_logs:It is recommended to use a private macro file
[robosuite WARNING] To setup, run: python <HOME>/myenv/lib/python3.12/site-packages/robosuite/scripts/setup_macros.py (__init__.py:9)
WARNING:robosuite_logs:To setup, run: python <HOME>/myenv/lib/python3.12/site-packages/robosuite/scripts/setup_macros.py
[robosuite WARNING] No private macro file found! (__init__.py:7)
WARNING:robosuite_logs:No private macro file found!
[robosuite WARNING] It is recommended to use a private macro file (__init__.py:8)
WARNING:robosuite_logs:It is recommended to use a private macro file
[robosuite WARNING] To setup, run: python <HOME>/myenv/lib/python3.12/site-packages/robosuite/scripts/setup_macros.py (__init__.py:9)
WARNING:robosuite_logs:To setup, run: python <HOME>/myenv/lib/python3.12/site-packages/robosuite/scripts/setup_macros.py


Running rollout with at most 2 steps:   0%|          | 0/2 [00:00<?, ?it/s]

Running rollout with at most 2 steps:   0%|          | 0/2 [00:05<?, ?it/s, running_success_rate=0.0%]

Running rollout with at most 2 steps:  50%|█████     | 1/2 [00:05<00:05,  5.01s/it, running_success_rate=0.0%]

Running rollout with at most 2 steps:  50%|█████     | 1/2 [00:05<00:05,  5.01s/it, running_success_rate=0.0%]

Running rollout with at most 2 steps: 100%|██████████| 2/2 [00:05<00:00,  2.17s/it, running_success_rate=0.0%]

                                                                                                              
Stepping through eval batches:   0%|          | 0/1 [00:55<?, ?it/s, running_success_rate=0.0%]
Stepping through eval batches: 100%|██████████| 1/1 [00:55<00:00, 55.74s/it, running_success_rate=0.0%]
Stepping through eval batches: 100%|██████████| 1/1 [00:55<00:00, 55.74s/it, running_success_rate=0.0%]
Local assets not found. Downloading from HuggingFace Hub...
Assets already downloaded at <HOME>/.cache/libero/assets
Local assets not found. Downloading from HuggingFace Hub...
Assets already downloaded at <HOME>/.cache/libero/assets
Local assets not found. Downloading from HuggingFace Hub...
Assets already downloaded at <HOME>/.cache/libero/assets
Local assets not found. Downloading from HuggingFace Hub...
Assets already downloaded at <HOME>/.cache/libero/assets
INFO 2026-08-05 22:27:01 bot_eval.py:808 Overall Aggregated Metrics:
INFO 2026-08-05 22:27:01 bot_eval.py:809 {'avg_sum_reward': 0.0, 'avg_max_reward': 0.0, 'pc_success': 0.0, 'n_episodes': 4, 'eval_s': 57.374181270599365, 'eval_ep_s': 14.343545854091644, 'video_paths': ['<BEFORE_OUTPUT>/videos/libero_spatial_0/eval_episode_0.mp4', '<BEFORE_OUTPUT>/videos/libero_spatial_0/eval_episode_1.mp4', '<BEFORE_OUTPUT>/videos/libero_spatial_0/eval_episode_2.mp4', '<BEFORE_OUTPUT>/videos/libero_spatial_0/eval_episode_3.mp4'], 'predicted_video_paths': []}
INFO 2026-08-05 22:27:01 bot_eval.py:813 
Aggregated Metrics for per_task:
INFO 2026-08-05 22:27:01 bot_eval.py:814 [{'task_group': 'libero_spatial', 'task_id': 0, 'metrics': {'sum_rewards': [0.0, 0.0, 0.0, 0.0], 'max_rewards': [0.0, 0.0, 0.0, 0.0], 'successes': [False, False, False, False], 'video_paths': ['<BEFORE_OUTPUT>/videos/libero_spatial_0/eval_episode_0.mp4', '<BEFORE_OUTPUT>/videos/libero_spatial_0/eval_episode_1.mp4', '<BEFORE_OUTPUT>/videos/libero_spatial_0/eval_episode_2.mp4', '<BEFORE_OUTPUT>/videos/libero_spatial_0/eval_episode_3.mp4'], 'predicted_video_paths': []}}]
INFO 2026-08-05 22:27:01 bot_eval.py:813 
Aggregated Metrics for per_group:
INFO 2026-08-05 22:27:01 bot_eval.py:814 {'libero_spatial': {'avg_sum_reward': 0.0, 'avg_max_reward': 0.0, 'pc_success': 0.0, 'n_episodes': 4, 'video_paths': ['<BEFORE_OUTPUT>/videos/libero_spatial_0/eval_episode_0.mp4', '<BEFORE_OUTPUT>/videos/libero_spatial_0/eval_episode_1.mp4', '<BEFORE_OUTPUT>/videos/libero_spatial_0/eval_episode_2.mp4', '<BEFORE_OUTPUT>/videos/libero_spatial_0/eval_episode_3.mp4'], 'predicted_video_paths': []}}
INFO 2026-08-05 22:27:01 bot_eval.py:813 
Aggregated Metrics for overall:
INFO 2026-08-05 22:27:01 bot_eval.py:814 {'avg_sum_reward': 0.0, 'avg_max_reward': 0.0, 'pc_success': 0.0, 'n_episodes': 4, 'eval_s': 57.374181270599365, 'eval_ep_s': 14.343545854091644, 'video_paths': ['<BEFORE_OUTPUT>/videos/libero_spatial_0/eval_episode_0.mp4', '<BEFORE_OUTPUT>/videos/libero_spatial_0/eval_episode_1.mp4', '<BEFORE_OUTPUT>/videos/libero_spatial_0/eval_episode_2.mp4', '<BEFORE_OUTPUT>/videos/libero_spatial_0/eval_episode_3.mp4'], 'predicted_video_paths': []}
INFO 2026-08-05 22:27:01 bot_eval.py:822 End of eval
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
peak_gpu_memory_mib=1724
```

</details>

### After: this PR, process-isolated OSMesa environments

<details>
<summary>Complete isolated command output</summary>

```text
idle_gpu_memory_mib=508
WARNING 2026-08-05 22:27:43 figs/eval.py:69 No job name provided, using 'libero_smolvla' as job name.
INFO 2026-08-05 22:27:43 bot_eval.py:744 {'env': {'camera_name': 'agentview_image,robot0_eye_in_hand_image',
         'camera_name_mapping': None,
         'control_mode': 'relative',
         'disable_env_checker': True,
         'episode_length': 2,
         'features': {'action': {'shape': (7,),
                                 'type': <FeatureType.ACTION: 'ACTION'>},
                      'pixels/agentview_image': {'shape': (360, 360, 3),
                                                 'type': <FeatureType.VISUAL: 'VISUAL'>},
                      'pixels/robot0_eye_in_hand_image': {'shape': (360,
                                                                    360,
                                                                    3),
                                                          'type': <FeatureType.VISUAL: 'VISUAL'>},
                      'robot_state/eef/mat': {'shape': (3, 3),
                                              'type': <FeatureType.STATE: 'STATE'>},
                      'robot_state/eef/pos': {'shape': (3,),
                                              'type': <FeatureType.STATE: 'STATE'>},
                      'robot_state/eef/quat': {'shape': (4,),
                                               'type': <FeatureType.STATE: 'STATE'>},
                      'robot_state/gripper/qpos': {'shape': (2,),
                                                   'type': <FeatureType.STATE: 'STATE'>},
                      'robot_state/gripper/qvel': {'shape': (2,),
                                                   'type': <FeatureType.STATE: 'STATE'>},
                      'robot_state/joints/pos': {'shape': (7,),
                                                 'type': <FeatureType.STATE: 'STATE'>},
                      'robot_state/joints/vel': {'shape': (7,),
                                                 'type': <FeatureType.STATE: 'STATE'>}},
         'features_map': {'action': 'action',
                          'pixels/agentview_image': 'observation.images.image',
                          'pixels/robot0_eye_in_hand_image': 'observation.images.image2',
                          'robot_state/eef/mat': 'observation.state.eef_mat',
                          'robot_state/eef/pos': 'observation.state.eef_pos',
                          'robot_state/eef/quat': 'observation.state.eef_quat',
                          'robot_state/gripper/qpos': 'observation.state.gripper_qpos',
                          'robot_state/gripper/qvel': 'observation.state.gripper_qvel',
                          'robot_state/joints/pos': 'observation.state.joint_pos',
                          'robot_state/joints/vel': 'observation.state.joint_vel'},
         'fps': 20,
         'hard_reset': True,
         'init_states': True,
         'is_libero_plus': False,
         'max_parallel_tasks': 1,
         'obs_type': 'pixels_agent_pos',
         'observation_height': 360,
         'observation_width': 360,
         'render_mode': 'rgb_array',
         'task': 'libero_spatial',
         'task_ids': [0]},
 'eval': {'batch_size': 4,
          'n_episodes': 4,
          'process_isolated': True,
          'recording': False,
          'recording_private': False,
          'recording_repo_id': None,
          'use_async_envs': True},
 'job_name': 'libero_smolvla',
 'output_dir': PosixPath('<AFTER_OUTPUT>'),
 'policy': {'adapt_to_pi_aloha': False,
            'add_image_special_tokens': False,
            'attention_mode': 'cross_attn',
            'chunk_size': 50,
            'compile_mode': 'max-autotune',
            'compile_model': False,
            'device': 'cuda',
            'empty_cameras': 1,
            'expert_width_multiplier': 0.75,
            'freeze_vision_encoder': False,
            'input_features': {'observation.images.camera1': {'shape': (3,
                                                                        256,
                                                                        256),
                                                              'type': <FeatureType.VISUAL: 'VISUAL'>},
                               'observation.images.camera2': {'shape': (3,
                                                                        256,
                                                                        256),
                                                              'type': <FeatureType.VISUAL: 'VISUAL'>},
                               'observation.images.camera3': {'shape': (3,
                                                                        256,
                                                                        256),
                                                              'type': <FeatureType.VISUAL: 'VISUAL'>},
                               'observation.state': {'shape': (6,),
                                                     'type': <FeatureType.STATE: 'STATE'>}},
            'license': None,
            'load_vlm_weights': True,
            'max_action_dim': 32,
            'max_period': 4.0,
            'max_state_dim': 32,
            'min_period': 0.004,
            'n_action_steps': 50,
            'n_obs_steps': 1,
            'normalization_mapping': {'ACTION': <NormalizationMode.MEAN_STD: 'MEAN_STD'>,
                                      'STATE': <NormalizationMode.MEAN_STD: 'MEAN_STD'>,
                                      'VISUAL': <NormalizationMode.IDENTITY: 'IDENTITY'>},
            'num_expert_layers': 0,
            'num_steps': 10,
            'num_vlm_layers': 16,
            'optimizer_betas': (0.9, 0.95),
            'optimizer_eps': 1e-08,
            'optimizer_grad_clip_norm': 10.0,
            'optimizer_lr': 0.0001,
            'optimizer_weight_decay': 1e-10,
            'output_features': {'action': {'shape': (7,),
                                           'type': <FeatureType.ACTION: 'ACTION'>}},
            'pad_language_to': 'max_length',
            'prefix_length': 0,
            'pretrained_path': PosixPath('<HOME>/.cache/modelscope/hub/models/lerobot/smolvla_libero'),
            'pretrained_revision': None,
            'private': None,
            'push_to_hub': True,
            'repo_id': 'pepijn223/smolvla_libero',
            'resize_imgs_with_padding': (512, 512),
            'rtc_config': None,
            'scheduler_decay_lr': 2.5e-06,
            'scheduler_decay_steps': 25000,
            'scheduler_warmup_steps': 1000,
            'self_attn_every_n_layers': 2,
            'tags': None,
            'tokenizer_max_length': 48,
            'train_expert_only': False,
            'train_state_proj': True,
            'use_amp': False,
            'use_cache': True,
            'use_delta_joint_actions_aloha': False,
            'use_peft': False,
            'vlm_model_name': '<HOME>/.cache/modelscope/hub/models/HuggingFaceTB/SmolVLM2-500M-Video-Instruct'},
 'rename_map': {'observation.images.image': 'observation.images.camera1',
                'observation.images.image2': 'observation.images.camera2'},
 'seed': 1000,
 'trust_remote_code': False}
INFO 2026-08-05 22:27:43 bot_eval.py:753 Output dir: <AFTER_OUTPUT>
INFO 2026-08-05 22:27:43 bot_eval.py:755 Making environment (batch_size=4, async=True).
INFO 2026-08-05 22:27:43 bot_eval.py:759 Process-isolated mode: environments will run in a subprocess with GPU disabled (CUDA_VISIBLE_DEVICES='', MUJOCO_GL=osmesa).
[robosuite WARNING] No private macro file found! (__init__.py:7)
WARNING:robosuite_logs:No private macro file found!
[robosuite WARNING] It is recommended to use a private macro file (__init__.py:8)
WARNING:robosuite_logs:It is recommended to use a private macro file
[robosuite WARNING] To setup, run: python <HOME>/myenv/lib/python3.12/site-packages/robosuite/scripts/setup_macros.py (__init__.py:9)
WARNING:robosuite_logs:To setup, run: python <HOME>/myenv/lib/python3.12/site-packages/robosuite/scripts/setup_macros.py
INFO 2026-08-05 22:27:51 bot_eval.py:778 Making policy.
`torch_dtype` is deprecated! Use `dtype` instead!
Loading  <HOME>/.cache/modelscope/hub/models/HuggingFaceTB/SmolVLM2-500M-Video-Instruct weights ...

Loading weights:   0%|          | 0/489 [00:00<?, ?it/s]
Loading weights:  14%|█▍        | 68/489 [00:00<00:00, 638.83it/s]
Loading weights:  27%|██▋       | 132/489 [00:00<00:00, 629.61it/s]
Loading weights:  40%|███▉      | 195/489 [00:00<00:00, 587.59it/s]
Loading weights:  54%|█████▍    | 263/489 [00:00<00:00, 619.45it/s]
Loading weights:  69%|██████▉   | 339/489 [00:00<00:00, 666.60it/s]
Loading weights:  87%|████████▋ | 425/489 [00:00<00:00, 730.54it/s]
Loading weights: 100%|██████████| 489/489 [00:00<00:00, 702.98it/s]
Reducing the number of VLM layers to 16 ...
Loading weights from local directory

Stepping through eval batches:   0%|          | 0/1 [00:00<?, ?it/s]Creating LIBERO envs | suites=['libero_spatial'] | n_envs(per task)=4 | init_states=True
Restricting to task_ids=[0]
[info] using task orders [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
Built vec env | suite=libero_spatial | task_id=0 | n_envs=4
[robosuite WARNING] No private macro file found! (__init__.py:7)
WARNING:robosuite_logs:No private macro file found!
[robosuite WARNING] It is recommended to use a private macro file (__init__.py:8)
WARNING:robosuite_logs:It is recommended to use a private macro file
[robosuite WARNING] To setup, run: python <HOME>/myenv/lib/python3.12/site-packages/robosuite/scripts/setup_macros.py (__init__.py:9)
WARNING:robosuite_logs:To setup, run: python <HOME>/myenv/lib/python3.12/site-packages/robosuite/scripts/setup_macros.py
[robosuite WARNING] No private macro file found! (__init__.py:7)
WARNING:robosuite_logs:No private macro file found!
[robosuite WARNING] It is recommended to use a private macro file (__init__.py:8)
WARNING:robosuite_logs:It is recommended to use a private macro file
[robosuite WARNING] To setup, run: python <HOME>/myenv/lib/python3.12/site-packages/robosuite/scripts/setup_macros.py (__init__.py:9)
WARNING:robosuite_logs:To setup, run: python <HOME>/myenv/lib/python3.12/site-packages/robosuite/scripts/setup_macros.py
[robosuite WARNING] No private macro file found! (__init__.py:7)
WARNING:robosuite_logs:No private macro file found!
[robosuite WARNING] It is recommended to use a private macro file (__init__.py:8)
WARNING:robosuite_logs:It is recommended to use a private macro file
[robosuite WARNING] To setup, run: python <HOME>/myenv/lib/python3.12/site-packages/robosuite/scripts/setup_macros.py (__init__.py:9)
WARNING:robosuite_logs:To setup, run: python <HOME>/myenv/lib/python3.12/site-packages/robosuite/scripts/setup_macros.py
[robosuite WARNING] No private macro file found! (__init__.py:7)
WARNING:robosuite_logs:No private macro file found!
[robosuite WARNING] It is recommended to use a private macro file (__init__.py:8)
WARNING:robosuite_logs:It is recommended to use a private macro file
[robosuite WARNING] To setup, run: python <HOME>/myenv/lib/python3.12/site-packages/robosuite/scripts/setup_macros.py (__init__.py:9)
WARNING:robosuite_logs:To setup, run: python <HOME>/myenv/lib/python3.12/site-packages/robosuite/scripts/setup_macros.py


Running rollout with at most 2 steps:   0%|          | 0/2 [00:00<?, ?it/s]

Running rollout with at most 2 steps:   0%|          | 0/2 [00:05<?, ?it/s, running_success_rate=0.0%]

Running rollout with at most 2 steps:  50%|█████     | 1/2 [00:05<00:05,  5.80s/it, running_success_rate=0.0%]

Running rollout with at most 2 steps:  50%|█████     | 1/2 [00:06<00:05,  5.80s/it, running_success_rate=0.0%]

Running rollout with at most 2 steps: 100%|██████████| 2/2 [00:06<00:00,  2.58s/it, running_success_rate=0.0%]

                                                                                                              
Stepping through eval batches:   0%|          | 0/1 [00:35<?, ?it/s, running_success_rate=0.0%]
Stepping through eval batches: 100%|██████████| 1/1 [00:35<00:00, 35.43s/it, running_success_rate=0.0%]
Stepping through eval batches: 100%|██████████| 1/1 [00:35<00:00, 35.43s/it, running_success_rate=0.0%]
Local assets not found. Downloading from HuggingFace Hub...
Assets already downloaded at <HOME>/.cache/libero/assets
Local assets not found. Downloading from HuggingFace Hub...
Assets already downloaded at <HOME>/.cache/libero/assets
Local assets not found. Downloading from HuggingFace Hub...
Assets already downloaded at <HOME>/.cache/libero/assets
Local assets not found. Downloading from HuggingFace Hub...
Assets already downloaded at <HOME>/.cache/libero/assets
INFO 2026-08-05 22:28:35 bot_eval.py:831 Overall Aggregated Metrics:
INFO 2026-08-05 22:28:35 bot_eval.py:832 {'avg_sum_reward': 0.0, 'avg_max_reward': 0.0, 'pc_success': 0.0, 'n_episodes': 4, 'eval_s': 36.234596967697144, 'eval_ep_s': 9.058649361133575, 'video_paths': ['<AFTER_OUTPUT>/videos/libero_spatial_0/eval_episode_0.mp4', '<AFTER_OUTPUT>/videos/libero_spatial_0/eval_episode_1.mp4', '<AFTER_OUTPUT>/videos/libero_spatial_0/eval_episode_2.mp4', '<AFTER_OUTPUT>/videos/libero_spatial_0/eval_episode_3.mp4'], 'predicted_video_paths': []}
INFO 2026-08-05 22:28:35 bot_eval.py:836 
Aggregated Metrics for per_task:
INFO 2026-08-05 22:28:35 bot_eval.py:837 [{'task_group': 'libero_spatial', 'task_id': 0, 'metrics': {'sum_rewards': [0.0, 0.0, 0.0, 0.0], 'max_rewards': [0.0, 0.0, 0.0, 0.0], 'successes': [False, False, False, False], 'video_paths': ['<AFTER_OUTPUT>/videos/libero_spatial_0/eval_episode_0.mp4', '<AFTER_OUTPUT>/videos/libero_spatial_0/eval_episode_1.mp4', '<AFTER_OUTPUT>/videos/libero_spatial_0/eval_episode_2.mp4', '<AFTER_OUTPUT>/videos/libero_spatial_0/eval_episode_3.mp4'], 'predicted_video_paths': []}}]
INFO 2026-08-05 22:28:35 bot_eval.py:836 
Aggregated Metrics for per_group:
INFO 2026-08-05 22:28:35 bot_eval.py:837 {'libero_spatial': {'avg_sum_reward': 0.0, 'avg_max_reward': 0.0, 'pc_success': 0.0, 'n_episodes': 4, 'video_paths': ['<AFTER_OUTPUT>/videos/libero_spatial_0/eval_episode_0.mp4', '<AFTER_OUTPUT>/videos/libero_spatial_0/eval_episode_1.mp4', '<AFTER_OUTPUT>/videos/libero_spatial_0/eval_episode_2.mp4', '<AFTER_OUTPUT>/videos/libero_spatial_0/eval_episode_3.mp4'], 'predicted_video_paths': []}}
INFO 2026-08-05 22:28:35 bot_eval.py:836 
Aggregated Metrics for overall:
INFO 2026-08-05 22:28:35 bot_eval.py:837 {'avg_sum_reward': 0.0, 'avg_max_reward': 0.0, 'pc_success': 0.0, 'n_episodes': 4, 'eval_s': 36.234596967697144, 'eval_ep_s': 9.058649361133575, 'video_paths': ['<AFTER_OUTPUT>/videos/libero_spatial_0/eval_episode_0.mp4', '<AFTER_OUTPUT>/videos/libero_spatial_0/eval_episode_1.mp4', '<AFTER_OUTPUT>/videos/libero_spatial_0/eval_episode_2.mp4', '<AFTER_OUTPUT>/videos/libero_spatial_0/eval_episode_3.mp4'], 'predicted_video_paths': []}
INFO 2026-08-05 22:28:35 bot_eval.py:843 End of eval
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
peak_gpu_memory_mib=1756
```

</details>

## Test plan

- [x] `pytest -q tests/envs/test_process_isolated.py tests/envs/test_freeze_after_episode_end.py tests/configs/test_default.py tests/scripts/test_lerobot_eval_cleanup.py --timeout=60` — **48 passed**
- [x] Changed-line coverage — **81.7%** (minimum 80%)
- [x] `pre-commit run --all-files` — all 19 hooks passed, including Ruff, mypy, Bandit, and secret detection
- [x] `uv build` — sdist and wheel built successfully
- [x] Real batch-1 isolated LIBERO/SmolVLA evaluation
- [x] Real batch-4 nested `AsyncVectorEnv` isolated LIBERO/SmolVLA evaluation
- [ ] Remote CI is green

## AI Disclosure

This PR was developed with assistance from AI coding tools. All changes were reviewed, tested, and validated by the author. The design was informed by the original issue author's prototype in #3098 and the detailed reviewer measurements linked above.
