### PR TITLE
fix(groot): resolve dataclass TypeError in GR00TN15Config

### DIFF
--- a/src/lerobot/policies/groot/groot_n1.py
+++ b/src/lerobot/policies/groot/groot_n1.py
@@ -176,7 +176,7 @@ N_COLOR_CHANNELS = 3
 @dataclass
 class GR00TN15Config(PretrainedConfig):
     model_type = "gr00t_n1_5"
-    backbone_cfg: dict = field(init=False, metadata={"help": "Backbone configuration."})
+    backbone_cfg: dict = field(default_factory=dict, init=False, metadata={"help": "Backbone configuration."})
 
     action_head_cfg: dict = field(init=False, metadata={"help": "Action head configuration."})
 


### PR DESCRIPTION
Add a default value to 'backbone_cfg' to prevent "non-default argument follows default argument" error. This ensures compatibility with Python 3.10+ where dataclass inheritance rules are strictly enforced.

## Title

Short, imperative summary (e.g., "fix(robots): handle None in sensor parser"). See [CONTRIBUTING.md](../CONTRIBUTING.md) for PR conventions.

## Type / Scope

- **Type**: Bug
- **Scope**: lerobot.policies.groot

## Summary / Motivation

This PR fixes a TypeError: non-default argument 'backbone_cfg' follows default argument that occurs when using Python 3.10+. The error stems from the structure of the GR00TN15Config dataclass: it inherits from PretrainedConfig (which contains arguments with default values) but previously defined backbone_cfg without a default value. In Python, all fields following a default argument must also have a default value.

## Related issues

- Fixes / Closes: # (if any)
- Related: # (if any)

## What changed

- Added a default value to the backbone_cfg field in src/lerobot/policies/groot/groot_n1.py.
- Ensured the dataclass signature complies with Python 3.10+ inheritance rules for dataclasses.

## How was this tested (or how to run locally)

- The lerobot-eval command, which previously failed during configuration instantiation, now runs correctly.

Example:

- Ran the relevant tests:

  ``` lerobot-eval --policy.path=lerobot/pi0_libero_finetuned \
     --env.type=libero \
     --env.task=libero_object \
     --eval.n_episodes=1
  ```

- Reproduce with a quick example or CLI (if applicable):

  ```bash
  lerobot-train --some.option=true
  ```

## Checklist (required before merge)

- [ x] Linting/formatting run (`pre-commit run -a`)
- [ ] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [ ] CI is green

## Reviewer notes

- Anyone in the community is free to review the PR.
