### PR TITLE
fix(rl): add exception handling and cleanup guarantee to actor_cli

### DIFF
--- a/src/lerobot/rl/actor.py
+++ b/src/lerobot/rl/actor.py
@@ -175,31 +175,38 @@ def actor_cli(cfg: TrainRLServerPipelineConfig):
     interactions_process.start()
     receive_policy_process.start()
 
-    act_with_policy(
-        cfg=cfg,
-        shutdown_event=shutdown_event,
-        parameters_queue=parameters_queue,
-        transitions_queue=transitions_queue,
-        interactions_queue=interactions_queue,
-    )
-    logging.info("[ACTOR] Policy process joined")
+    try:
+        act_with_policy(
+            cfg=cfg,
+            shutdown_event=shutdown_event,
+            parameters_queue=parameters_queue,
+            transitions_queue=transitions_queue,
+            interactions_queue=interactions_queue,
+        )
+        logging.info("[ACTOR] act_with_policy completed normally")
+    except Exception:
+        logging.exception("[ACTOR] act_with_policy crashed with an unhandled exception")
+        shutdown_event.set()
+        raise
+    finally:
+        logging.info("[ACTOR] Closing queues")
+        transitions_queue.close()
+        interactions_queue.close()
+        parameters_queue.close()
 
-    logging.info("[ACTOR] Closing queues")
-    transitions_queue.close()
-    interactions_queue.close()
-    parameters_queue.close()
+        transitions_process.join()
+        logging.info("[ACTOR] Transitions process joined")
+        interactions_process.join()
+        logging.info("[ACTOR] Interactions process joined")
+        receive_policy_process.join()
+        logging.info("[ACTOR] Receive policy process joined")
 
-    transitions_process.join()
-    logging.info("[ACTOR] Transitions process joined")
-    interactions_process.join()
-    logging.info("[ACTOR] Interactions process joined")
-    receive_policy_process.join()
-    logging.info("[ACTOR] Receive policy process joined")
+        logging.info("[ACTOR] Cancelling queue join threads")
+        transitions_queue.cancel_join_thread()
+        interactions_queue.cancel_join_thread()
+        parameters_queue.cancel_join_thread()
 
-    logging.info("[ACTOR] join queues")
-    transitions_queue.cancel_join_thread()
-    interactions_queue.cancel_join_thread()
-    parameters_queue.cancel_join_thread()
+        logging.info("[ACTOR] Actor process exited")
 
     logging.info("[ACTOR] queues closed")
 


### PR DESCRIPTION
## Problem

Fixes #3059.

The `actor_cli` function is the core entry point for the Actor process. When `act_with_policy()` throws an uncaught exception, all subsequent cleanup logic is skipped:

1. **Resource leak**: `transitions_queue.close()`, `interactions_queue.close()`, `parameters_queue.close()` never execute, leaving GPU/CPU resources consumed
2. **No diagnostics**: The crash reason is not logged, making production debugging extremely difficult
3. **Missing exit log**: No way to confirm whether the Actor process exited normally or crashed

## Fix

Wrapped the `act_with_policy()` call and cleanup logic in `try/except/finally`:

- **`try`**: Runs `act_with_policy()` and logs normal completion
- **`except`**: Logs the exception with full traceback via `logging.exception()`, sets `shutdown_event` to signal child processes, then re-raises
- **`finally`**: Always executes queue close + process join + queue cancel_join_thread, guaranteeing cleanup regardless of how `act_with_policy()` exits

## Changes

- `src/lerobot/rl/actor.py`: Restructured `actor_cli` cleanup into `try/except/finally` block