### PR TITLE
fix(record): pass rename_map to make_policy in lerobot-record

### DIFF
--- a/src/lerobot/scripts/lerobot_record.py
+++ b/src/lerobot/scripts/lerobot_record.py
@@ -559,8 +559,10 @@ def record(cfg: RecordConfig) -> LeRobotDataset:
             )
 
         # Load pretrained policy
-        policy = None if cfg.policy is None else make_policy(
-            cfg.policy, ds_meta=dataset.meta, rename_map=cfg.dataset.rename_map
+        policy = (
+            None
+            if cfg.policy is None
+            else make_policy(cfg.policy, ds_meta=dataset.meta, rename_map=cfg.dataset.rename_map)
         )
         preprocessor = None
         postprocessor = None


### PR DESCRIPTION
## Problem

Fixes #3181.

When using `lerobot-record` with a fine-tuned model whose camera key names differ from the dataset, users get a `feature mismatch` error. The CLI suggests using `--rename_map` to remap keys, but adding the argument has no effect.

### Root cause

In `lerobot_record.py` line 506, `make_policy()` is called without `rename_map`:
```python
policy = None if cfg.policy is None else make_policy(cfg.policy, ds_meta=dataset.meta)
```

While `cfg.dataset.rename_map` is correctly passed to the preprocessor (lines 513, 516), it is never passed to `make_policy()`. The `make_policy()` function already accepts a `rename_map` parameter and uses it to skip visual feature consistency validation when remapping is active — but `lerobot-record` was not passing it through.

## Fix

Pass `cfg.dataset.rename_map` to `make_policy()`:
```python
policy = None if cfg.policy is None else make_policy(
    cfg.policy, ds_meta=dataset.meta, rename_map=cfg.dataset.rename_map
)
```

## Changes

- `src/lerobot/scripts/lerobot_record.py`: Pass `rename_map` to `make_policy()`