### PR TITLE
fix(xvla): cast bfloat16 tensors to float32 before numpy conversion

### DIFF
--- a/src/lerobot/policies/xvla/processor_xvla.py
+++ b/src/lerobot/policies/xvla/processor_xvla.py
@@ -499,7 +499,7 @@ class XVLARotation6DToAxisAngleProcessorStep(ProcessorStep):
         # Convert to numpy for processing
         device = action.device
         dtype = action.dtype
-        action_np = action.cpu().numpy()
+        action_np = action.cpu().float().numpy()
 
         # Extract components
         # action shape: (B, D) where D >= 10


### PR DESCRIPTION
## Problem

Fixes #2956.

When running the evaluation pipeline with a model that uses `bfloat16` (e.g. for flash-attn), the pipeline crashes during action post-processing:

```
TypeError: Got unsupported ScalarType BFloat16
```

The crash occurs in `XVLARotation6DToAxisAngleProcessorStep` at:
```python
action_np = action.cpu().numpy()
```

NumPy doesn't natively support `bfloat16`, so calling `.numpy()` on a bfloat16 CPU tensor fails.

## Fix

Added `.float()` cast before `.numpy()`:
```python
action_np = action.cpu().float().numpy()
```

The original dtype is preserved via the `dtype` variable captured earlier, which is used when converting back to tensor at the end of the processor step.

## Changes

- `src/lerobot/policies/xvla/processor_xvla.py`: Cast to float32 before numpy conversion in `XVLARotation6DToAxisAngleProcessorStep`