### PR TITLE
feat(datasets): add depth map video support with per-key encoding

### DIFF
--- a/docs/source/lerobot-dataset-v3.mdx
+++ b/docs/source/lerobot-dataset-v3.mdx
@@ -83,6 +83,12 @@ A core v3 principle is **decoupling storage from the user API**: data is stored 
 - **`data/`**: frame‑by‑frame **Parquet** shards; each file typically contains **many episodes**.
 - **`videos/`**: **MP4** shards per camera; each file typically contains **many episodes**.
 
+### Depth map video features
+
+In addition to RGB cameras, v3.0 supports storing depth maps as video streams. Depth maps can use per-video-key encoding parameters (e.g. lossless CRF, custom pixel format) configured in the feature `info` dict, and custom encoding/decoding transforms via `depth_map_encoding_fn` / `depth_map_decoding_fn`.
+
+Depth map video features require `streaming_encoding=True`. See the [streaming video encoding guide](./streaming_video_encoding#5-depth-map-video-features) for details.
+
 ## Load a dataset for training
 
 `LeRobotDataset` returns Python dictionaries of PyTorch tensors and integrates with `torch.utils.data.DataLoader`. Here is a code example showing its use:

--- a/docs/source/streaming_video_encoding.mdx
+++ b/docs/source/streaming_video_encoding.mdx
@@ -78,6 +78,7 @@ Use HW encoding when:
 | --------------------- | --------- | -------------- | ------- | ---------------------------------------------------------------- |
 | `libsvtav1` (default) | High      | Smallest       | Best    | Default. Best compression but most CPU-intensive                 |
 | `h264`                | Medium    | ~30-50% larger | Good    | Software H.264. Lower CPU                                        |
+| `hevc`                | Medium    | Smallest       | Best    | Software HEVC (libx265). Comparable to libsvtav1                 |
 | HW encoders           | Very Low  | Largest        | Good    | Offloads to dedicated hardware. Best for CPU-constrained systems |
 
 ### Available HW Encoders
@@ -91,6 +92,7 @@ Use HW encoding when:
 | `h264_vaapi`        | Linux         | Intel/AMD GPU                                                                                    | `--dataset.vcodec=h264_vaapi`        |
 | `h264_qsv`          | Linux/Windows | Intel Quick Sync                                                                                 | `--dataset.vcodec=h264_qsv`          |
 | `auto`              | Any           | Probes the system for available HW encoders. Falls back to `libsvtav1` if no HW encoder is found | `--dataset.vcodec=auto`              |
+| `av1`               | Any           | Alias for `libsvtav1`                                                                            | `--dataset.vcodec=av1`               |
 
 > [!NOTE]
 > In order to use the HW accelerated encoders you might need to upgrade your GPU drivers.
@@ -98,7 +100,156 @@ Use HW encoding when:
 > [!NOTE]
 > `libsvtav1` is the default because it provides the best training performance; other vcodecs can reduce CPU usage and be faster, but they typically produce larger files and may affect training time.
 
-## 5. Troubleshooting
+## 5. Depth Map Video Features
+
+LeRobot supports storing depth maps as video streams alongside RGB cameras. Depth maps require different encoding parameters (e.g. lossless-friendly CRF, specific pixel formats) and may need a custom transform applied before encoding.
+
+### Per-Video-Key Encoding Parameters
+
+Each video feature can override the dataset-level encoding defaults via its `info` dict in the feature metadata:
+
+| Info key             | Description                               | Example value   |
+| -------------------- | ----------------------------------------- | --------------- |
+| `video.codec`        | Video codec for this feature              | `"libsvtav1"`   |
+| `video.crf`          | Constant rate factor (quality)            | `0`             |
+| `video.pix_fmt`      | Pixel format                              | `"yuv420p"`     |
+| `video.g`            | GOP size (keyframe interval)              | `2`             |
+| `video.preset`       | Encoder preset                            | `12`            |
+| `video.options`      | Arbitrary dict merged into ffmpeg options | `{"foo":"bar"}` |
+| `video.is_depth_map` | Mark this feature as a depth map          | `True`          |
+
+These override the dataset-level defaults so that, for example, a depth camera can use `crf=0` (lossless) while RGB cameras use `crf=30`.
+
+### Depth Map Encoding / Decoding Hooks
+
+Use `depth_map_encoding_fn` and `depth_map_decoding_fn` to apply a custom transform (e.g. log-scaling, quantization) before encoding and after decoding:
+
+```python
+import av
+import numpy as np
+import torch
+
+MIN_DEPTH = 0.01
+MAX_DEPTH = 10.0
+DEPTH_SHIFT = 3.5
+
+def quantize_depth(
+    depth: np.ndarray | th.Tensor,
+    min_depth: float = MIN_DEPTH,
+    max_depth: float = MAX_DEPTH,
+    shift: float = DEPTH_SHIFT,
+) -> np.ndarray:
+    """
+    Quantizes depth values to a 12-bit range (0 to 4096) based on the specified min and max depth.
+
+    Args:
+        depth (np.ndarray or th.tensor): Depth tensor.
+        min_depth (float): Minimum depth value.
+        max_depth (float): Maximum depth value.
+        shift (float): Small value to shift depth to avoid log(0).
+    Returns:
+        np.ndarray: Quantized depth tensor.
+    """
+    # convert to numpy if input is torch tensor
+    if isinstance(depth, th.Tensor):
+        depth = depth.cpu().numpy()
+    qmax = (1 << 12) - 1
+    log_min = math.log(min_depth + shift)
+    log_max = math.log(max_depth + shift)
+
+    log_depth = np.log(depth + shift)
+    log_norm = (log_depth - log_min) / (log_max - log_min)
+    quantized_depth = np.clip((log_norm * qmax).round(), 0, qmax).astype(np.uint16)
+    return quantized_depth
+
+
+def dequantize_depth(
+    quantized_depth: np.ndarray | th.Tensor,
+    min_depth: float = MIN_DEPTH,
+    max_depth: float = MAX_DEPTH,
+    shift: float = DEPTH_SHIFT,
+) -> np.ndarray | th.Tensor:
+    """
+    Dequantizes a 12-bit depth tensor back to the original depth values.
+
+    Args:
+        quantized_depth (np.ndarray or th.tensor): Quantized depth tensor.
+        min_depth (float): Minimum depth value.
+        max_depth (float): Maximum depth value.
+        shift (float): Small value to shift depth to avoid log(0).
+    Returns:
+        np.ndarray or th.tensor: Dequantized depth tensor.
+    """
+    backend = np if isinstance(quantized_depth, np.ndarray) else th
+    qmax = (1 << 12) - 1
+    log_min = math.log(min_depth + shift)
+    log_max = math.log(max_depth + shift)
+
+    log_norm = quantized_depth / qmax
+    log_depth = log_norm * (log_max - log_min) + log_min
+    depth = backend.clip(backend.exp(log_depth) - shift, min_depth, max_depth)
+
+    return depth
+
+
+def encode_depth_frame(depth: np.ndarray | th.Tensor) -> av.VideoFrame:
+    """
+    Encodes a depth frame by quantizing it to a 12-bit range and then packing it into YUV420p12le format.
+
+    Args:
+        depth (np.ndarray or th.tensor): Depth tensor of shape (H, W) with float values.
+    Returns:
+        av.VideoFrame: Encoded depth frame in YUV420p12le format, where the Y plane contains the quantized depth values.
+    """
+    quantized_depth = quantize_depth(depth)
+    H, W = quantized_depth.shape[:2]
+    # Write depth into the Y plane; set U/V to neutral chroma.
+    frame = av.VideoFrame(width=W, height=H, format="yuv420p12le")
+    frame.planes[0].update(quantized_depth.tobytes())
+    # Bit depth of 12 → neutral = 2^11 = 2048.
+    neutral_chroma = np.full((H // 2, W // 2), 2048, dtype=np.uint16)
+    frame.planes[1].update(neutral_chroma.tobytes())
+    frame.planes[2].update(neutral_chroma.tobytes())
+    return frame
+
+
+def decode_depth_frame(frame: list[av.VideoFrame]) -> th.Tensor:
+    """
+    Decodes a depth frame by extracting the quantized depth from the Y plane and then dequantizing it back to float values.
+    Args:
+        frame (list[av.VideoFrame]): Encoded depth frame.
+    Returns:
+        th.Tensor: Decoded depth tensor of shape (N, H, W) with float values.
+    """
+    quantized_depth = th.from_numpy(np.stack([f.reformat(format="gray12le").to_ndarray() for f in frame]))
+    depth = dequantize_depth(quantized_depth)
+    return depth
+
+# Recording
+dataset = LeRobotDataset.create(
+    repo_id="my/depth_dataset",
+    fps=30,
+    features=features,  # includes a video key with video.is_depth_map: True
+    root="data/depth_ds",
+    use_videos=True,
+    streaming_encoding=True,
+    depth_map_encoding_fn=encode_depth,
+)
+
+# Reading (decode is applied automatically with pyav backend)
+dataset = LeRobotDataset(
+    repo_id="my/depth_dataset",
+    ...,
+    depth_map_decoding_fn=decode_depth,
+)
+item = dataset[0]  # depth frames are decoded automatically
+```
+
+> [!IMPORTANT]
+> Depth map video features **require** `streaming_encoding=True`. The non-streaming image pipeline does not currently preserve depth maps correctly because it relies on RGB-oriented image writing and introduces lossy dtype casting/quantization of depth values. Calling `LeRobotDataset.create()` with depth map features and `streaming_encoding=False` raises a `ValueError`.
+> To minimize depth encoding/decoding error, it is recommended to use lossless encoding parameters (e.g. crf-0) during data collection.
+
+## 6. Troubleshooting
 
 | Symptom                                                            | Likely Cause                                 | Fix                                                                                                                                                                                                                                                                                  |
 | ------------------------------------------------------------------ | -------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |

--- a/docs/source/using_dataset_tools.mdx
+++ b/docs/source/using_dataset_tools.mdx
@@ -147,7 +147,7 @@ lerobot-edit-dataset \
 **Parameters:**
 
 - `output_dir`: Custom output directory (optional - by default uses `new_repo_id` or `{repo_id}_video`)
-- `vcodec`: Video codec to use - options: `h264`, `hevc`, `libsvtav1` (default: `libsvtav1`)
+- `vcodec`: Video codec to use - options: `h264`, `hevc`, `libsvtav1` (default: `libsvtav1`). `av1` is an alias for `libsvtav1`.
 - `pix_fmt`: Pixel format - options: `yuv420p`, `yuv444p` (default: `yuv420p`)
 - `g`: Group of pictures (GOP) size - lower values give better quality but larger files (default: 2)
 - `crf`: Constant rate factor - lower values give better quality but larger files, 0 is lossless (default: 30)
@@ -156,6 +156,9 @@ lerobot-edit-dataset \
 - `num_workers`: Number of parallel workers for processing (default: 4)
 
 **Note:** The resulting dataset will be a proper LeRobotDataset with all cameras encoded as videos in the `videos/` directory, with parquet files containing only metadata (no raw image data). All episodes, stats, and tasks are preserved.
+
+> [!TIP]
+> Encoding parameters (codec, CRF, pixel format, etc.) are also stored in each video feature's `info` dict in the metadata (e.g. `video.codec`, `video.crf`, `video.pix_fmt`). These per-video-key settings can be used by `LeRobotDataset` to override dataset-level defaults when re-encoding. See the [streaming video encoding guide](./streaming_video_encoding#5-depth-map-video-features) for details on per-key encoding and depth map support.
 
 ### Show the information of datasets
 

--- a/src/lerobot/datasets/dataset_reader.py
+++ b/src/lerobot/datasets/dataset_reader.py
@@ -49,6 +49,8 @@ class DatasetReader:
         video_backend: str,
         delta_timestamps: dict[str, list[float]] | None,
         image_transforms: Callable | None,
+        depth_map_decoding_fn: Callable | None = None,
+        video_feature_encoding_kwargs: dict[str, dict] | None = None,
     ):
         """Initialize the reader with metadata, filtering, and transform config.
 
@@ -66,6 +68,8 @@ class DatasetReader:
                 relative timestamp offsets for temporal context windows.
             image_transforms: Optional torchvision v2 transform applied to
                 visual features.
+            depth_map_decoding_fn (Callable | None, optional): Optional function to decode depth maps after loading.
+            video_feature_encoding_kwargs: Optional dict mapping video feature keys to their encoding kwargs.
         """
         self._meta = meta
         self.root = root
@@ -73,7 +77,8 @@ class DatasetReader:
         self._tolerance_s = tolerance_s
         self._video_backend = video_backend
         self._image_transforms = image_transforms
-
+        self._depth_map_decoding_fn = depth_map_decoding_fn
+        self._video_feature_encoding_kwargs = video_feature_encoding_kwargs
         self.hf_dataset: datasets.Dataset | None = None
         self._absolute_to_relative_idx: dict[int, int] | None = None
 
@@ -241,7 +246,19 @@ class DatasetReader:
             shifted_query_ts = [from_timestamp + ts for ts in query_ts]
 
             video_path = self.root / self._meta.get_video_file_path(ep_idx, vid_key)
-            frames = decode_video_frames(video_path, shifted_query_ts, self._tolerance_s, self._video_backend)
+            is_depth_map = (
+                self._video_feature_encoding_kwargs is not None
+                and self._video_feature_encoding_kwargs[vid_key].get("video.is_depth_map", False)
+            )
+            frames = decode_video_frames(
+                video_path,
+                shifted_query_ts,
+                self._tolerance_s,
+                self._video_backend,
+                is_depth_map=is_depth_map,
+                depth_map_decoding_fn=self._depth_map_decoding_fn,
+            )
+
             item[vid_key] = frames.squeeze(0)
 
         return item

--- a/src/lerobot/datasets/dataset_writer.py
+++ b/src/lerobot/datasets/dataset_writer.py
@@ -55,6 +55,7 @@ from lerobot.datasets.video_utils import (
     concatenate_video_files,
     encode_video_frames,
     get_video_duration_in_s,
+    info_to_encoding_kwargs,
 )
 
 logger = logging.getLogger(__name__)
@@ -67,12 +68,19 @@ def _encode_video_worker(
     fps: int,
     vcodec: str = "libsvtav1",
     encoder_threads: int | None = None,
+    **encoding_kwargs,
 ) -> Path:
     temp_path = Path(tempfile.mkdtemp(dir=root)) / f"{video_key}_{episode_index:03d}.mp4"
     fpath = DEFAULT_IMAGE_PATH.format(image_key=video_key, episode_index=episode_index, frame_index=0)
     img_dir = (root / fpath).parent
     encode_video_frames(
-        img_dir, temp_path, fps, vcodec=vcodec, overwrite=True, encoder_threads=encoder_threads
+        imgs_dir=img_dir,
+        video_path=temp_path,
+        fps=fps,
+        vcodec=vcodec,
+        overwrite=True,
+        encoder_threads=encoder_threads,
+        **encoding_kwargs,
     )
     shutil.rmtree(img_dir)
     return temp_path
@@ -94,6 +102,7 @@ class DatasetWriter:
         batch_encoding_size: int,
         streaming_encoder: StreamingVideoEncoder | None = None,
         initial_frames: int = 0,
+        video_feature_encoding_kwargs: dict | None = None,
     ):
         """Initialize the writer with metadata, codec, and encoding config.
 
@@ -108,6 +117,7 @@ class DatasetWriter:
             streaming_encoder: Optional pre-built :class:`StreamingVideoEncoder`
                 for real-time encoding. ``None`` disables streaming mode.
             initial_frames: Starting frame count (non-zero when resuming).
+            video_feature_encoding_kwargs (dict | None, optional): Optional dictionary mapping video feature keys to their specific encoding kwargs.
         """
         self._meta = meta
         self._root = root
@@ -115,6 +125,7 @@ class DatasetWriter:
         self._encoder_threads = encoder_threads
         self._batch_encoding_size = batch_encoding_size
         self._streaming_encoder = streaming_encoder
+        self._video_feature_encoding_kwargs = video_feature_encoding_kwargs
 
         # Writer state
         self.image_writer: AsyncImageWriter | None = None
@@ -197,7 +208,8 @@ class DatasetWriter:
                 )
 
             if self._meta.features[key]["dtype"] == "video" and self._streaming_encoder is not None:
-                self._streaming_encoder.feed_frame(key, frame[key])
+                frame_data = frame[key]
+                self._streaming_encoder.feed_frame(key, frame_data)
                 self.episode_buffer[key].append(None)
             elif self._meta.features[key]["dtype"] in ["image", "video"]:
                 img_path = self._get_image_file_path(
@@ -277,18 +289,29 @@ class DatasetWriter:
             num_cameras = len(self._meta.video_keys)
             if parallel_encoding and num_cameras > 1:
                 with concurrent.futures.ProcessPoolExecutor(max_workers=num_cameras) as executor:
-                    future_to_key = {
-                        executor.submit(
-                            _encode_video_worker,
-                            video_key,
-                            episode_index,
-                            self._root,
-                            self._meta.fps,
-                            self._vcodec,
-                            self._encoder_threads,
-                        ): video_key
-                        for video_key in self._meta.video_keys
-                    }
+                    future_to_key = {}
+                    for video_key in self._meta.video_keys:
+                        encoding_kwargs = info_to_encoding_kwargs(
+                            self._video_feature_encoding_kwargs[video_key]
+                        )
+                        encoding_vcodec = encoding_kwargs.pop("vcodec", self._vcodec)
+                        encoding_fps = encoding_kwargs.pop("fps", self._meta.fps)
+                        if encoding_fps != self._meta.fps:
+                            raise ValueError(
+                                f"Encoding fps {encoding_fps} must match dataset fps {self._meta.fps}"
+                            )
+                        future_to_key[
+                            executor.submit(
+                                _encode_video_worker,
+                                video_key=video_key,
+                                episode_index=episode_index,
+                                root=self._root,
+                                fps=encoding_fps,
+                                vcodec=encoding_vcodec,
+                                encoder_threads=self._encoder_threads,
+                                **encoding_kwargs,
+                            )
+                        ] = video_key
 
                     results = {}
                     for future in concurrent.futures.as_completed(future_to_key):
@@ -563,8 +586,24 @@ class DatasetWriter:
 
     def _encode_temporary_episode_video(self, video_key: str, episode_index: int) -> Path:
         """Use ffmpeg to convert frames stored as png into mp4 videos."""
+        video_feature_encoding_kwargs = (
+            self._video_feature_encoding_kwargs.get(video_key, {})
+            if self._video_feature_encoding_kwargs is not None
+            else {}
+        )
+        encoding_kwargs = info_to_encoding_kwargs(video_feature_encoding_kwargs)
+        encoding_vcodec = encoding_kwargs.pop("vcodec", self._vcodec)
+        encoding_fps = encoding_kwargs.pop("fps", self._meta.fps)
+        if encoding_fps != self._meta.fps:
+            raise ValueError(f"Encoding fps {encoding_fps} must match dataset fps {self._meta.fps}")
         return _encode_video_worker(
-            video_key, episode_index, self._root, self._meta.fps, self._vcodec, self._encoder_threads
+            video_key,
+            episode_index,
+            self._root,
+            encoding_fps,
+            encoding_vcodec,
+            self._encoder_threads,
+            **encoding_kwargs,
         )
 
     def close_writer(self) -> None:

--- a/src/lerobot/datasets/feature_utils.py
+++ b/src/lerobot/datasets/feature_utils.py
@@ -554,3 +554,20 @@ def validate_episode_buffer(episode_buffer: dict, total_episodes: int, features:
             f"In episode_buffer not in features: {buffer_keys - set(features)}"
             f"In features not in episode_buffer: {set(features) - buffer_keys}"
         )
+
+
+def get_video_feature_encoding_kwargs(info: dict) -> dict:
+    """
+    Given a features info dict from metadata, locate and extract video information (e.g. vcodec, fps).
+    Maintains backward compatibility with older datasets that stored video information in places other than features/info.
+    This method assumes one video.codec field exists in the info dict, and all other video information is stored in the same location.
+    If no video.codec field is found, returns an empty dict.
+    """
+    if "video.codec" in info:
+        return info
+    for v in info.values():
+        if isinstance(v, dict):
+            result = get_video_feature_encoding_kwargs(v)
+            if "video.codec" in result:
+                return result
+    return {}

--- a/src/lerobot/datasets/lerobot_dataset.py
+++ b/src/lerobot/datasets/lerobot_dataset.py
@@ -18,7 +18,9 @@ import logging
 from collections.abc import Callable
 from pathlib import Path
 
+import av
 import datasets
+import numpy as np
 import torch
 import torch.utils
 from huggingface_hub import HfApi, snapshot_download
@@ -27,6 +29,7 @@ from huggingface_hub.errors import RevisionNotFoundError
 from lerobot.datasets.dataset_metadata import CODEBASE_VERSION, LeRobotDatasetMetadata
 from lerobot.datasets.dataset_reader import DatasetReader
 from lerobot.datasets.dataset_writer import DatasetWriter
+from lerobot.datasets.feature_utils import get_video_feature_encoding_kwargs
 from lerobot.datasets.utils import (
     create_lerobot_dataset_card,
     get_safe_version,
@@ -60,6 +63,8 @@ class LeRobotDataset(torch.utils.data.Dataset):
         streaming_encoding: bool = False,
         encoder_queue_maxsize: int = 30,
         encoder_threads: int | None = None,
+        depth_map_encoding_fn: Callable[[np.ndarray], av.VideoFrame] | None = None,
+        depth_map_decoding_fn: Callable[[list[av.VideoFrame]], torch.Tensor] | None = None,
     ):
         """
         2 modes are available for instantiating this class, depending on 2 different use cases:
@@ -185,8 +190,12 @@ class LeRobotDataset(torch.utils.data.Dataset):
             encoder_threads (int | None, optional): Number of threads per encoder instance. None lets the
                 codec auto-detect (default). Lower values reduce CPU usage per encoder. Maps to 'lp' (via svtav1-params) for
                 libsvtav1 and 'threads' for h264/hevc.
-
-        Note:
+            depth_map_encoding_fn (Callable | None, optional): Optional function to encode depth maps before saving.
+                This can be used to apply transformations like log scaling or quantization.
+                The function should take a numpy array as input and return an av.VideoFrame, which will be fed directly to the video encoder.
+            depth_map_decoding_fn (Callable | None, optional): Optional function to decode depth maps after loading.
+                This should be the inverse of the encoding function provided in depth_map_encoding_fn, if any.
+                The function should take a list of av.VideoFrame as input and return a numpy array representing the decoded depth map.
             Write-mode parameters (``streaming_encoding``, ``batch_encoding_size``) passed to
             ``__init__`` are deprecated. Use :meth:`create` for new datasets or :meth:`resume`
             to append to existing ones.
@@ -204,6 +213,8 @@ class LeRobotDataset(torch.utils.data.Dataset):
         self._batch_encoding_size = batch_encoding_size
         self._vcodec = resolve_vcodec(vcodec)
         self._encoder_threads = encoder_threads
+        self._depth_map_encoding_fn = depth_map_encoding_fn
+        self._depth_map_decoding_fn = depth_map_decoding_fn
 
         if self._requested_root is not None:
             self._requested_root.mkdir(exist_ok=True, parents=True)
@@ -215,6 +226,8 @@ class LeRobotDataset(torch.utils.data.Dataset):
         self.root = self.meta.root
         self.revision = self.meta.revision
 
+        self._video_feature_encoding_kwargs = self.get_all_video_feature_encoding_kwargs()
+
         # Create reader (hf_dataset loaded below)
         self.reader = DatasetReader(
             meta=self.meta,
@@ -224,6 +237,8 @@ class LeRobotDataset(torch.utils.data.Dataset):
             video_backend=self._video_backend,
             delta_timestamps=delta_timestamps,
             image_transforms=image_transforms,
+            depth_map_decoding_fn=depth_map_decoding_fn,
+            video_feature_encoding_kwargs=self._video_feature_encoding_kwargs,
         )
 
         # Load actual data
@@ -244,10 +259,16 @@ class LeRobotDataset(torch.utils.data.Dataset):
                 DeprecationWarning,
                 stacklevel=2,
             )
+            self.ensure_depth_streaming_encoding(streaming_encoding)
             streaming_enc = None
             if streaming_encoding and len(self.meta.video_keys) > 0:
                 streaming_enc = self._build_streaming_encoder(
-                    self.meta.fps, self._vcodec, encoder_queue_maxsize, encoder_threads
+                    self.meta.fps,
+                    self._vcodec,
+                    encoder_queue_maxsize,
+                    encoder_threads,
+                    self._video_feature_encoding_kwargs,
+                    depth_map_encoding_fn,
                 )
             self.writer = DatasetWriter(
                 meta=self.meta,
@@ -257,6 +278,7 @@ class LeRobotDataset(torch.utils.data.Dataset):
                 batch_encoding_size=batch_encoding_size,
                 streaming_encoder=streaming_enc,
                 initial_frames=self.meta.total_frames,
+                video_feature_encoding_kwargs=self._video_feature_encoding_kwargs,
             )
         else:
             self.writer = None
@@ -286,6 +308,8 @@ class LeRobotDataset(torch.utils.data.Dataset):
                 video_backend=self._video_backend,
                 delta_timestamps=self.delta_timestamps,
                 image_transforms=self.image_transforms,
+                depth_map_decoding_fn=self._depth_map_decoding_fn,
+                video_feature_encoding_kwargs=self._video_feature_encoding_kwargs,
             )
         return self.reader
 
@@ -295,6 +319,8 @@ class LeRobotDataset(torch.utils.data.Dataset):
         vcodec: str,
         encoder_queue_maxsize: int,
         encoder_threads: int | None,
+        video_feature_encoding_kwargs: dict[str, dict] | None = None,
+        depth_map_encoding_fn: Callable[[np.ndarray], av.VideoFrame] | None = None,
     ) -> StreamingVideoEncoder:
         return StreamingVideoEncoder(
             fps=fps,
@@ -305,6 +331,8 @@ class LeRobotDataset(torch.utils.data.Dataset):
             preset=None,
             queue_maxsize=encoder_queue_maxsize,
             encoder_threads=encoder_threads,
+            video_feature_encoding_kwargs=video_feature_encoding_kwargs,
+            depth_map_encoding_fn=depth_map_encoding_fn,
         )
 
     # ── Metadata properties ───────────────────────────────────────────
@@ -490,6 +518,35 @@ class LeRobotDataset(torch.utils.data.Dataset):
         """Remove the transform applied to visual observations."""
         self.set_image_transforms(None)
 
+    def ensure_depth_streaming_encoding(self, streaming_encoding: bool) -> None:
+        """
+        Ensure that if any depth map video keys are present, streaming encoding is enabled.
+        This is necessary because the non-streaming encoding pipeline is RGB-oriented and does not
+            reliably preserve depth maps: it can impose image channel/dtype constraints and introduce
+            dtype casting or quantization of depth values.
+        """
+        depth_video_keys = [
+            k
+            for k in self.meta.video_keys
+            if self._video_feature_encoding_kwargs[k].get("video.is_depth_map", False)
+        ]
+        if depth_video_keys and not streaming_encoding:
+            raise ValueError(
+                f"Depth map video keys {depth_video_keys} require streaming_encoding=True. "
+                "The non-streaming image pipeline does not currently preserve depth maps correctly because it relies on RGB-oriented image writing and introduces lossy dtype casting/quantization of depth values."
+            )
+
+    def get_all_video_feature_encoding_kwargs(self) -> dict[str, dict]:
+        """
+        Retrieve per-video-key encoding kwargs from the dataset metadata.
+        This allows for custom encoding settings (e.g. crf, preset) to be specified on a per-video basis directly in the dataset info,
+            which can be useful for modalities like depth maps that may require different encoding parameters than RGB videos.
+        """
+        video_feature_encoding_kwargs = {}
+        for key in self.meta.video_keys:
+            video_feature_encoding_kwargs[key] = get_video_feature_encoding_kwargs(self.features.get(key, {}))
+        return video_feature_encoding_kwargs
+
     # ── Hub methods (stay on facade) ──────────────────────────────────
 
     def push_to_hub(
@@ -624,6 +681,8 @@ class LeRobotDataset(torch.utils.data.Dataset):
         streaming_encoding: bool = False,
         encoder_queue_maxsize: int = 30,
         encoder_threads: int | None = None,
+        depth_map_encoding_fn: Callable | None = None,
+        depth_map_decoding_fn: Callable | None = None,
     ) -> "LeRobotDataset":
         """Create a new LeRobotDataset from scratch for recording data.
 
@@ -657,6 +716,10 @@ class LeRobotDataset(torch.utils.data.Dataset):
             encoder_queue_maxsize: Max buffered frames per camera when using
                 streaming encoding.
             encoder_threads: Threads per encoder instance. ``None`` for auto.
+            depth_map_encoding_fn (Callable | None, optional): Optional function to encode depth maps before saving.
+                This can be used to apply transformations like log scaling or quantization.
+            depth_map_decoding_fn (Callable | None, optional): Optional function to decode depth maps after loading.
+                This should be the inverse of the encoding function provided in depth_map_encoding_fn, if any.
 
         Returns:
             A new :class:`LeRobotDataset` in write mode.
@@ -684,14 +747,25 @@ class LeRobotDataset(torch.utils.data.Dataset):
         obj._batch_encoding_size = batch_encoding_size
         obj._vcodec = vcodec
         obj._encoder_threads = encoder_threads
+        obj._depth_map_encoding_fn = depth_map_encoding_fn
+        obj._depth_map_decoding_fn = depth_map_decoding_fn
+        obj._video_feature_encoding_kwargs = obj.get_all_video_feature_encoding_kwargs()
 
         # Reader is lazily created on first access (write-only mode)
         obj.reader = None
 
         # Create writer
+        obj.ensure_depth_streaming_encoding(streaming_encoding)
         streaming_enc = None
         if streaming_encoding and len(obj.meta.video_keys) > 0:
-            streaming_enc = cls._build_streaming_encoder(fps, vcodec, encoder_queue_maxsize, encoder_threads)
+            streaming_enc = cls._build_streaming_encoder(
+                fps,
+                vcodec,
+                encoder_queue_maxsize,
+                encoder_threads,
+                obj._video_feature_encoding_kwargs,
+                depth_map_encoding_fn,
+            )
         obj.writer = DatasetWriter(
             meta=obj.meta,
             root=obj.root,
@@ -699,6 +773,7 @@ class LeRobotDataset(torch.utils.data.Dataset):
             encoder_threads=encoder_threads,
             batch_encoding_size=batch_encoding_size,
             streaming_encoder=streaming_enc,
+            video_feature_encoding_kwargs=obj._video_feature_encoding_kwargs,
         )
 
         if image_writer_processes or image_writer_threads:
@@ -724,6 +799,8 @@ class LeRobotDataset(torch.utils.data.Dataset):
         streaming_encoding: bool = False,
         encoder_queue_maxsize: int = 30,
         encoder_threads: int | None = None,
+        depth_map_encoding_fn: Callable | None = None,
+        depth_map_decoding_fn: Callable | None = None,
     ) -> "LeRobotDataset":
         """Resume recording on an existing dataset.
 
@@ -753,6 +830,10 @@ class LeRobotDataset(torch.utils.data.Dataset):
                 capture.
             encoder_queue_maxsize: Max buffered frames per camera for streaming.
             encoder_threads: Threads per encoder instance. ``None`` for auto.
+            depth_map_encoding_fn (Callable | None, optional): Optional function to encode depth maps before saving.
+                This can be used to apply transformations like log scaling or quantization.
+            depth_map_decoding_fn (Callable | None, optional): Optional function to decode depth maps after loading.
+                This should be the inverse of the encoding function provided in depth_map_encoding_fn, if any.
 
         Returns:
             A :class:`LeRobotDataset` in write mode, ready to append episodes.
@@ -776,6 +857,8 @@ class LeRobotDataset(torch.utils.data.Dataset):
         obj._batch_encoding_size = batch_encoding_size
         obj._vcodec = vcodec
         obj._encoder_threads = encoder_threads
+        obj._depth_map_encoding_fn = depth_map_encoding_fn
+        obj._depth_map_decoding_fn = depth_map_decoding_fn
 
         if obj._requested_root is not None:
             obj._requested_root.mkdir(exist_ok=True, parents=True)
@@ -785,15 +868,22 @@ class LeRobotDataset(torch.utils.data.Dataset):
             obj.repo_id, obj._requested_root, obj.revision, force_cache_sync=force_cache_sync
         )
         obj.root = obj.meta.root
+        obj._video_feature_encoding_kwargs = obj.get_all_video_feature_encoding_kwargs()
 
         # Reader is lazily created on first access (write-only mode)
         obj.reader = None
 
         # Create writer for appending
+        obj.ensure_depth_streaming_encoding(streaming_encoding)
         streaming_enc = None
         if streaming_encoding and len(obj.meta.video_keys) > 0:
             streaming_enc = cls._build_streaming_encoder(
-                obj.meta.fps, vcodec, encoder_queue_maxsize, encoder_threads
+                obj.meta.fps,
+                vcodec,
+                encoder_queue_maxsize,
+                encoder_threads,
+                obj._video_feature_encoding_kwargs,
+                depth_map_encoding_fn,
             )
         obj.writer = DatasetWriter(
             meta=obj.meta,
@@ -803,6 +893,7 @@ class LeRobotDataset(torch.utils.data.Dataset):
             batch_encoding_size=batch_encoding_size,
             streaming_encoder=streaming_enc,
             initial_frames=obj.meta.total_frames,
+            video_feature_encoding_kwargs=obj._video_feature_encoding_kwargs,
         )
 
         if image_writer_processes or image_writer_threads:

--- a/src/lerobot/datasets/multi_dataset.py
+++ b/src/lerobot/datasets/multi_dataset.py
@@ -47,6 +47,8 @@ class MultiLeRobotDataset(torch.utils.data.Dataset):
         tolerances_s: dict | None = None,
         download_videos: bool = True,
         video_backend: str | None = None,
+        depth_map_encoding_fn: Callable | None = None,
+        depth_map_decoding_fn: Callable | None = None,
     ):
         super().__init__()
         self.repo_ids = repo_ids
@@ -64,6 +66,8 @@ class MultiLeRobotDataset(torch.utils.data.Dataset):
                 tolerance_s=self.tolerances_s[repo_id],
                 download_videos=download_videos,
                 video_backend=video_backend,
+                depth_map_encoding_fn=depth_map_encoding_fn,
+                depth_map_decoding_fn=depth_map_decoding_fn,
             )
             for repo_id in repo_ids
         ]

--- a/src/lerobot/datasets/video_utils.py
+++ b/src/lerobot/datasets/video_utils.py
@@ -22,6 +22,7 @@ import shutil
 import tempfile
 import threading
 import warnings
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from fractions import Fraction
 from pathlib import Path
@@ -102,6 +103,9 @@ def detect_available_hw_encoders() -> list[str]:
 
 def resolve_vcodec(vcodec: str) -> str:
     """Validate vcodec and resolve 'auto' to best available HW encoder, fallback to libsvtav1."""
+    if vcodec == "av1":
+        # Alias "av1" to "libsvtav1"
+        vcodec = "libsvtav1"
     if vcodec not in VALID_VIDEO_CODECS:
         raise ValueError(f"Invalid vcodec '{vcodec}'. Must be one of: {sorted(VALID_VIDEO_CODECS)}")
     if vcodec != "auto":
@@ -126,11 +130,32 @@ def get_safe_default_codec():
         return "pyav"
 
 
+def info_to_encoding_kwargs(info: dict) -> dict:
+    encoding_kwargs = {}
+    if "video.fps" in info:
+        encoding_kwargs["fps"] = int(info["video.fps"])
+    if "video.codec" in info:
+        encoding_kwargs["vcodec"] = resolve_vcodec(info["video.codec"])
+    if "video.pix_fmt" in info:
+        encoding_kwargs["pix_fmt"] = info["video.pix_fmt"]
+    if "video.g" in info:
+        encoding_kwargs["g"] = info["video.g"]
+    if "video.crf" in info:
+        encoding_kwargs["crf"] = info["video.crf"]
+    if "video.preset" in info:
+        encoding_kwargs["preset"] = info["video.preset"]
+    if "video.options" in info:
+        encoding_kwargs["options"] = info["video.options"]
+    return encoding_kwargs
+
+
 def decode_video_frames(
     video_path: Path | str,
     timestamps: list[float],
     tolerance_s: float,
     backend: str | None = None,
+    is_depth_map: bool = False,
+    depth_map_decoding_fn: Callable[[list[av.VideoFrame]], torch.Tensor] | None = None,
 ) -> torch.Tensor:
     """
     Decodes video frames using the specified backend.
@@ -140,12 +165,19 @@ def decode_video_frames(
         timestamps (list[float]): List of timestamps to extract frames.
         tolerance_s (float): Allowed deviation in seconds for frame retrieval.
         backend (str, optional): Backend to use for decoding. Defaults to "torchcodec" when available in the platform; otherwise, defaults to "pyav"..
+        is_depth_map (bool, optional): Whether the video is a depth map. Defaults to False.
+        depth_map_decoding_fn (Callable, optional): Function to decode depth map frames. Required when is_depth_map is True.
 
     Returns:
         torch.Tensor: Decoded frames.
 
-    Currently supports torchcodec on cpu and pyav.
+    Currently supports torchcodec on cpu, pyav, video_reader, and native pyav (for depth maps).
     """
+    if is_depth_map:
+        assert depth_map_decoding_fn is not None, (
+            "depth_map_decoding_fn must be provided when is_depth_map is True"
+        )
+        return decode_video_frames_depth(video_path, timestamps, tolerance_s, depth_map_decoding_fn)
     if backend is None:
         backend = get_safe_default_codec()
     if backend == "torchcodec":
@@ -389,6 +421,96 @@ def decode_video_frames_torchcodec(
     return closest_frames
 
 
+def decode_video_frames_depth(
+    video_path: Path | str,
+    timestamps: list[float],
+    tolerance_s: float,
+    depth_map_decoding_fn: Callable[[list[av.VideoFrame]], torch.Tensor],
+    log_loaded_timestamps: bool = False,
+) -> torch.Tensor:
+    """Decodes raw video frames using pyav without any normalization.
+
+    This function uses pyav to decode video frames while preserving the original
+    pixel format (e.g., yuv420p12le for 12-bit depth videos). The provided
+    depth_map_decoding_fn is called to convert the raw av.VideoFrame objects
+    to normalized torch tensors.
+
+    Args:
+        video_path: Path to the video file.
+        timestamps: List of timestamps to extract frames.
+        tolerance_s: Allowed deviation in seconds for frame retrieval.
+        depth_map_decoding_fn: Function to convert list of av.VideoFrame to torch.Tensor.
+        log_loaded_timestamps: Whether to log loaded timestamps.
+
+    Returns:
+        torch.Tensor: Decoded frames as normalized tensors.
+    """
+    video_path = str(video_path)
+
+    container = av.open(video_path)
+    video_stream = container.streams.video[0]
+
+    first_ts = min(timestamps)
+    last_ts = max(timestamps)
+
+    # Seek to first timestamp before decoding
+    # Note: we seek to a keyframe before first_ts, so we may load a few extra frames
+    offset = int(first_ts / video_stream.time_base)
+    container.seek(offset, backward=True, stream=video_stream)
+
+    # Decode frames from seek point
+    reader = container.decode(video_stream)
+    loaded_frames: list[av.VideoFrame] = []
+    loaded_ts: list[float] = []
+
+    for frame in reader:
+        pts = float(frame.pts * frame.time_base)
+        if pts > last_ts + tolerance_s:
+            break
+
+        loaded_frames.append(frame)
+        loaded_ts.append(pts)
+        if log_loaded_timestamps:
+            logger.info(f"frame loaded at timestamp={pts:.4f}")
+
+    container.close()
+
+    query_ts = torch.tensor(timestamps)
+    loaded_ts_tensor = torch.tensor(loaded_ts)
+
+    dist = torch.cdist(query_ts[:, None], loaded_ts_tensor[:, None], p=1)
+    min_, argmin_ = dist.min(1)
+
+    is_within_tol = min_ < tolerance_s
+    if not is_within_tol.all():
+        raise FrameTimestampError(
+            f"One or several query timestamps unexpectedly violate the tolerance ({min_[~is_within_tol]} > {tolerance_s=})."
+            " It means that the closest frame that can be loaded from the video is too far away in time."
+            " This might be due to synchronization issues with timestamps during data collection."
+            " To be safe, we advise to ignore this item during training."
+            f"\nqueried timestamps: {query_ts}"
+            f"\nloaded timestamps: {loaded_ts_tensor}"
+            f"\nvideo: {video_path}"
+            f"\nbackend: pyav"
+        )
+
+    closest_frames = [loaded_frames[idx] for idx in argmin_]
+    closest_ts = loaded_ts_tensor[argmin_]
+
+    if log_loaded_timestamps:
+        logger.info(f"{closest_ts=}")
+
+    result = depth_map_decoding_fn(closest_frames)
+
+    if len(timestamps) != len(result):
+        raise FrameTimestampError(
+            f"Number of retrieved frames ({len(result)}) does not match "
+            f"number of queried timestamps ({len(timestamps)})"
+        )
+
+    return result
+
+
 def encode_video_frames(
     imgs_dir: Path | str,
     video_path: Path | str,
@@ -402,6 +524,7 @@ def encode_video_frames(
     overwrite: bool = False,
     preset: int | None = None,
     encoder_threads: int | None = None,
+    options: dict | None = None,
 ) -> None:
     """More info on ffmpeg arguments tuning on `benchmark/video/README.md`"""
     vcodec = resolve_vcodec(vcodec)
@@ -451,6 +574,9 @@ def encode_video_frames(
                 video_options["svtav1-params"] = lp_param
         else:
             video_options["threads"] = str(encoder_threads)
+
+    if options is not None:
+        video_options.update({str(key): str(value) for key, value in options.items()})
 
     # Set logging level
     if log_level is not None:
@@ -591,6 +717,9 @@ class _CameraEncoderThread(threading.Thread):
         result_queue: queue.Queue,
         stop_event: threading.Event,
         encoder_threads: int | None = None,
+        options: dict | None = None,
+        is_depth_map: bool = False,
+        depth_map_encoding_fn: Callable[[np.ndarray], av.VideoFrame] | None = None,
     ):
         super().__init__(daemon=True)
         self.video_path = video_path
@@ -600,10 +729,13 @@ class _CameraEncoderThread(threading.Thread):
         self.g = g
         self.crf = crf
         self.preset = preset
+        self.options = options
         self.frame_queue = frame_queue
         self.result_queue = result_queue
         self.stop_event = stop_event
         self.encoder_threads = encoder_threads
+        self.is_depth_map = is_depth_map
+        self.depth_map_encoding_fn = depth_map_encoding_fn
 
     def run(self) -> None:
         from lerobot.datasets.compute_stats import RunningQuantileStats, auto_downsample_height_width
@@ -629,7 +761,7 @@ class _CameraEncoderThread(threading.Thread):
                     break
 
                 # Ensure HWC uint8 numpy array
-                if isinstance(frame_data, np.ndarray):
+                if isinstance(frame_data, np.ndarray) and not self.is_depth_map:
                     if frame_data.ndim == 3 and frame_data.shape[0] == 3:
                         # CHW -> HWC
                         frame_data = frame_data.transpose(1, 2, 0)
@@ -649,6 +781,8 @@ class _CameraEncoderThread(threading.Thread):
                                 video_options["svtav1-params"] = lp_param
                         else:
                             video_options["threads"] = str(self.encoder_threads)
+                    if self.options is not None:
+                        video_options.update({str(key): str(value) for key, value in self.options.items()})
                     Path(self.video_path).parent.mkdir(parents=True, exist_ok=True)
                     container = av.open(str(self.video_path), "w")
                     output_stream = container.add_stream(self.vcodec, self.fps, options=video_options)
@@ -658,8 +792,11 @@ class _CameraEncoderThread(threading.Thread):
                     output_stream.time_base = Fraction(1, self.fps)
 
                 # Encode frame with explicit timestamps
-                pil_img = Image.fromarray(frame_data)
-                video_frame = av.VideoFrame.from_image(pil_img)
+                if self.is_depth_map:
+                    video_frame = self.depth_map_encoding_fn(frame_data)
+                else:
+                    pil_img = Image.fromarray(frame_data)
+                    video_frame = av.VideoFrame.from_image(pil_img)
                 video_frame.pts = frame_count
                 video_frame.time_base = Fraction(1, self.fps)
                 packet = output_stream.encode(video_frame)
@@ -722,15 +859,40 @@ class StreamingVideoEncoder:
         g: int | None = 2,
         crf: int | None = 30,
         preset: int | None = None,
+        options: dict | None = None,
         queue_maxsize: int = 30,
         encoder_threads: int | None = None,
+        video_feature_encoding_kwargs: dict[str, dict] | None = None,
+        depth_map_encoding_fn: Callable[[np.ndarray], av.VideoFrame] | None = None,
     ):
-        self.fps = fps
-        self.vcodec = resolve_vcodec(vcodec)
-        self.pix_fmt = pix_fmt
-        self.g = g
-        self.crf = crf
-        self.preset = preset
+        # The following are default encoding settings that can be overridden
+        # on a per-video-key basis via `video_feature_encoding_kwargs`
+        self.default_encoding_kwargs = {
+            "fps": fps,
+            "vcodec": resolve_vcodec(vcodec),
+            "pix_fmt": pix_fmt,
+            "g": g,
+            "crf": crf,
+            "preset": preset,
+            "options": options,
+        }
+        self.video_feature_encoding_kwargs = {}
+        if video_feature_encoding_kwargs is not None:
+            for key, enc in video_feature_encoding_kwargs.items():
+                self.video_feature_encoding_kwargs[key] = info_to_encoding_kwargs(enc)
+        self.is_depth_map = {}
+        if video_feature_encoding_kwargs is not None:
+            self.is_depth_map = {
+                video_key: (
+                    video_feature_encoding_kwargs is not None
+                    and video_feature_encoding_kwargs[video_key].get("video.is_depth_map", False)
+                )
+                for video_key in video_feature_encoding_kwargs
+            }
+        # if any of the videos is a depth map, depth_map_encoding_fn must be provided
+        if any(self.is_depth_map.values()) and depth_map_encoding_fn is None:
+            raise ValueError("depth_map_encoding_fn must be provided if any video is a depth map")
+
         self.queue_maxsize = queue_maxsize
         self.encoder_threads = encoder_threads
 
@@ -742,6 +904,7 @@ class StreamingVideoEncoder:
         self._dropped_frames: dict[str, int] = {}
         self._episode_active = False
         self._closed = False
+        self._depth_map_encoding_fn = depth_map_encoding_fn
 
     def start_episode(self, video_keys: list[str], temp_dir: Path) -> None:
         """Start encoder threads for a new episode.
@@ -763,18 +926,25 @@ class StreamingVideoEncoder:
             temp_video_dir = Path(tempfile.mkdtemp(dir=temp_dir))
             video_path = temp_video_dir / f"{video_key.replace('/', '_')}_streaming.mp4"
 
+            key_enc = self.video_feature_encoding_kwargs.get(video_key, {})
+            # If specified, fps must be the same with self.fps from meta info
+            if "fps" in key_enc and key_enc["fps"] != self.default_encoding_kwargs["fps"]:
+                raise ValueError(
+                    f"FPS mismatch for {video_key}: {key_enc['fps']} in video_feature_encoding_kwargs vs {self.default_encoding_kwargs['fps']} in default_encoding_kwargs"
+                )
+            key_enc = {
+                **self.default_encoding_kwargs,
+                **key_enc,
+            }  # video_feature_encoding_kwargs overrides defaults
             encoder_thread = _CameraEncoderThread(
                 video_path=video_path,
-                fps=self.fps,
-                vcodec=self.vcodec,
-                pix_fmt=self.pix_fmt,
-                g=self.g,
-                crf=self.crf,
-                preset=self.preset,
                 frame_queue=frame_queue,
                 result_queue=result_queue,
                 stop_event=stop_event,
                 encoder_threads=self.encoder_threads,
+                is_depth_map=self.is_depth_map.get(video_key, False),
+                depth_map_encoding_fn=self._depth_map_encoding_fn,
+                **key_enc,
             )
             encoder_thread.start()
 

--- a/tests/datasets/test_dataset_utils.py
+++ b/tests/datasets/test_dataset_utils.py
@@ -148,3 +148,40 @@ def test_non_dict_passthrough_last_wins():
     out = combine_feature_dicts(g1, g2)
     # For non-dict entries the last one wins
     assert out["misc"] == 456
+
+
+# ── get_video_feature_encoding_kwargs ────────────────────────────────
+
+
+def test_get_video_feature_encoding_kwargs_direct_key():
+    """When 'video.codec' is a top-level key, the entire dict is returned."""
+    from lerobot.datasets.feature_utils import get_video_feature_encoding_kwargs
+
+    info = {"video.codec": "libsvtav1", "video.fps": 30, "video.pix_fmt": "yuv420p"}
+    result = get_video_feature_encoding_kwargs(info)
+    assert result == info
+
+
+def test_get_video_feature_encoding_kwargs_nested():
+    """When 'video.codec' is in a nested dict, it is found and that inner dict returned."""
+    from lerobot.datasets.feature_utils import get_video_feature_encoding_kwargs
+
+    inner = {"video.codec": "h264", "video.fps": 25}
+    outer = {"dtype": "video", "shape": (64, 96, 3), "info": inner}
+    result = get_video_feature_encoding_kwargs(outer)
+    assert result == inner
+
+
+def test_get_video_feature_encoding_kwargs_empty():
+    """An empty dict returns {}."""
+    from lerobot.datasets.feature_utils import get_video_feature_encoding_kwargs
+
+    assert get_video_feature_encoding_kwargs({}) == {}
+
+
+def test_get_video_feature_encoding_kwargs_no_codec():
+    """A dict without 'video.codec' anywhere returns {}."""
+    from lerobot.datasets.feature_utils import get_video_feature_encoding_kwargs
+
+    info = {"dtype": "video", "shape": (64, 96, 3), "names": ["h", "w", "c"]}
+    assert get_video_feature_encoding_kwargs(info) == {}

--- a/tests/datasets/test_dataset_writer.py
+++ b/tests/datasets/test_dataset_writer.py
@@ -15,9 +15,11 @@
 # limitations under the License.
 """Contract tests for DatasetWriter."""
 
+import time
 from pathlib import Path
 from unittest.mock import patch
 
+import av
 import numpy as np
 import pytest
 import torch
@@ -90,6 +92,28 @@ def test_encode_video_worker_default_vcodec(tmp_path):
         _encode_video_worker(video_key, 0, tmp_path, fps=30)
 
     assert captured_kwargs["vcodec"] == "libsvtav1"
+
+
+def test_encode_video_worker_forwards_extra_kwargs(tmp_path):
+    """_encode_video_worker forwards extra encoding kwargs like pix_fmt and crf."""
+    video_key = "observation.images.laptop"
+    fpath = DEFAULT_IMAGE_PATH.format(image_key=video_key, episode_index=0, frame_index=0)
+    img_dir = tmp_path / Path(fpath).parent
+    img_dir.mkdir(parents=True, exist_ok=True)
+    Image.new("RGB", (64, 64), color="red").save(img_dir / "frame-000000.png")
+
+    captured_kwargs = {}
+
+    def mock_encode(imgs_dir, video_path, fps, **kwargs):
+        captured_kwargs.update(kwargs)
+        Path(video_path).parent.mkdir(parents=True, exist_ok=True)
+        Path(video_path).touch()
+
+    with patch("lerobot.datasets.dataset_writer.encode_video_frames", side_effect=mock_encode):
+        _encode_video_worker(video_key, 0, tmp_path, fps=30, pix_fmt="yuv420p", crf=20)
+
+    assert captured_kwargs["pix_fmt"] == "yuv420p"
+    assert captured_kwargs["crf"] == 20
 
 
 # ── add_frame contracts ──────────────────────────────────────────────
@@ -203,6 +227,110 @@ def test_finalize_is_idempotent(tmp_path):
 
     dataset.finalize()
     dataset.finalize()  # second call should not raise
+
+
+def test_depth_map_encoding_in_streaming_mode(tmp_path):
+    """Depth map frames are transformed by depth_map_encoding_fn before streaming encoding."""
+    depth_key = "observation.images.depth"
+    features = {
+        depth_key: {
+            "dtype": "video",
+            "shape": (64, 96, 1),
+            "names": ["height", "width", "channels"],
+            "info": {
+                "video.fps": DEFAULT_FPS,
+                "video.codec": "hevc",
+                "video.pix_fmt": "yuv420p12le",
+                "video.is_depth_map": True,
+            },
+        },
+        "state": {"dtype": "float32", "shape": (2,), "names": None},
+    }
+
+    encoding_called = {"count": 0}
+
+    def fake_depth_encoding_fn(depth: np.ndarray) -> av.VideoFrame:
+        encoding_called["count"] += 1
+        height, width = depth.shape[:2]
+        frame = av.VideoFrame(width=width, height=height, format="yuv420p12le")
+        frame.planes[0].update(depth[..., 0].astype(np.uint16).tobytes())
+        return frame
+
+    dataset = LeRobotDataset.create(
+        repo_id=DUMMY_REPO_ID,
+        fps=DEFAULT_FPS,
+        features=features,
+        root=tmp_path / "ds",
+        use_videos=True,
+        streaming_encoding=True,
+        depth_map_encoding_fn=fake_depth_encoding_fn,
+    )
+
+    for _ in range(5):
+        dataset.add_frame(
+            {
+                depth_key: np.random.random((64, 96, 1)).astype(np.float32),
+                "state": torch.randn(2),
+                "task": "test",
+            }
+        )
+    # sleep to allow streaming encoder threads to process frames
+    timeout = time.monotonic() + 5
+    while encoding_called["count"] != 5 and time.monotonic() < timeout:
+        time.sleep(0.01)
+    assert encoding_called["count"] == 5
+    dataset.save_episode()
+    dataset.finalize()
+
+
+def test_non_depth_frames_not_encoded(tmp_path):
+    """Non-depth video frames are NOT transformed by depth_map_encoding_fn."""
+    cam_key = "observation.images.cam"
+    features = {
+        cam_key: {
+            "dtype": "video",
+            "shape": (64, 96, 3),
+            "names": ["height", "width", "channels"],
+            "info": {
+                "video.fps": DEFAULT_FPS,
+                "video.codec": "libsvtav1",
+                "video.pix_fmt": "yuv420p",
+                "video.is_depth_map": False,
+            },
+        },
+        "state": {"dtype": "float32", "shape": (2,), "names": None},
+    }
+
+    encoding_called = {"count": 0}
+
+    def fake_depth_encoding_fn(depth: np.ndarray) -> av.VideoFrame:
+        encoding_called["count"] += 1
+        frame = av.VideoFrame(width=64, height=96, format="yuv420p12le")
+        frame.planes[0].update(depth.tobytes())
+        return frame
+
+    dataset = LeRobotDataset.create(
+        repo_id=DUMMY_REPO_ID,
+        fps=DEFAULT_FPS,
+        features=features,
+        root=tmp_path / "ds",
+        use_videos=True,
+        streaming_encoding=True,
+        depth_map_encoding_fn=fake_depth_encoding_fn,
+    )
+
+    for _ in range(3):
+        dataset.add_frame(
+            {
+                cam_key: np.random.randint(0, 255, (64, 96, 3), dtype=np.uint8),
+                "state": torch.randn(2),
+                "task": "test",
+            }
+        )
+
+    assert encoding_called["count"] == 0
+    dataset.save_episode()
+    dataset.finalize()
 
 
 def test_finalize_then_read_roundtrip(tmp_path):

--- a/tests/datasets/test_lerobot_dataset.py
+++ b/tests/datasets/test_lerobot_dataset.py
@@ -630,3 +630,65 @@ def test_create_record_finalize_read_roundtrip(tmp_path):
         item = reopened[3 + i]
         assert torch.allclose(item["state"], ep1_states[i], atol=1e-5)
         assert item["episode_index"].item() == 1
+
+
+# ── Depth map support ────────────────────────────────────────────────
+
+
+DEPTH_VIDEO_FEATURES = {
+    "observation.images.depth": {
+        "dtype": "video",
+        "shape": (64, 96, 3),
+        "names": ["height", "width", "channels"],
+        "info": {
+            "video.fps": DEFAULT_FPS,
+            "video.codec": "libsvtav1",
+            "video.pix_fmt": "yuv420p",
+            "video.is_depth_map": True,
+        },
+    },
+    "state": {"dtype": "float32", "shape": (2,), "names": None},
+}
+
+
+def test_ensure_depth_streaming_encoding_raises(tmp_path):
+    """ensure_depth_streaming_encoding raises ValueError when depth keys exist and streaming is False."""
+    dataset = LeRobotDataset.create(
+        repo_id=DUMMY_REPO_ID,
+        fps=DEFAULT_FPS,
+        features=DEPTH_VIDEO_FEATURES,
+        root=tmp_path / "ds",
+        use_videos=True,
+        streaming_encoding=True,
+        depth_map_encoding_fn=lambda x: x,  # dummy fn to satisfy video_utils check
+    )
+    with pytest.raises(ValueError, match="require streaming_encoding=True"):
+        dataset.ensure_depth_streaming_encoding(streaming_encoding=False)
+
+
+def test_ensure_depth_streaming_encoding_ok_with_streaming(tmp_path):
+    """ensure_depth_streaming_encoding does not raise when streaming is True."""
+    dataset = LeRobotDataset.create(
+        repo_id=DUMMY_REPO_ID,
+        fps=DEFAULT_FPS,
+        features=DEPTH_VIDEO_FEATURES,
+        root=tmp_path / "ds",
+        use_videos=True,
+        streaming_encoding=True,
+        depth_map_encoding_fn=lambda x: x,  # dummy fn to satisfy video_utils check
+    )
+    dataset.ensure_depth_streaming_encoding(streaming_encoding=True)  # should not raise
+
+
+def test_create_with_depth_map_features_requires_streaming(tmp_path):
+    """LeRobotDataset.create raises ValueError when depth map features + streaming_encoding=False."""
+    with pytest.raises(ValueError, match="require streaming_encoding=True"):
+        LeRobotDataset.create(
+            repo_id=DUMMY_REPO_ID,
+            fps=DEFAULT_FPS,
+            features=DEPTH_VIDEO_FEATURES,
+            root=tmp_path / "ds",
+            use_videos=True,
+            streaming_encoding=False,
+            depth_map_encoding_fn=lambda x: x,  # dummy fn to satisfy video_utils check
+        )

--- a/tests/datasets/test_streaming_video_encoder.py
+++ b/tests/datasets/test_streaming_video_encoder.py
@@ -131,6 +131,10 @@ class TestHWEncoderDetection:
         with pytest.raises(ValueError, match="Invalid vcodec"):
             resolve_vcodec("not_a_real_codec")
 
+    def test_resolve_vcodec_av1_alias(self):
+        """Test that resolve_vcodec('av1') returns 'libsvtav1'."""
+        assert resolve_vcodec("av1") == "libsvtav1"
+
 
 # ─── _CameraEncoderThread tests ───
 
@@ -478,6 +482,70 @@ class TestStreamingVideoEncoder:
         encoder = StreamingVideoEncoder(fps=30, vcodec="libsvtav1", pix_fmt="yuv420p")
         assert encoder.encoder_threads is None
         encoder.close()
+
+    def test_per_key_encoding_kwargs_none_backward_compat(self, tmp_path):
+        """video_feature_encoding_kwargs=None still works (backward compatible)."""
+        encoder = StreamingVideoEncoder(fps=30, vcodec="libsvtav1", video_feature_encoding_kwargs=None)
+        video_keys = [f"{OBS_IMAGES}.cam"]
+        encoder.start_episode(video_keys, tmp_path)
+
+        for _ in range(10):
+            frame = np.random.randint(0, 255, (64, 96, 3), dtype=np.uint8)
+            encoder.feed_frame(f"{OBS_IMAGES}.cam", frame)
+
+        results = encoder.finish_episode()
+        assert results[f"{OBS_IMAGES}.cam"][0].exists()
+        encoder.close()
+
+    def test_per_key_encoding_kwargs_override(self, tmp_path):
+        """Per-video-key encoding kwargs (e.g. crf) override defaults."""
+
+        video_feature_encoding_kwargs = {
+            f"{OBS_IMAGES}.depth": {"video.codec": "libsvtav1", "video.crf": 20, "video.pix_fmt": "yuv420p"},
+        }
+        encoder = StreamingVideoEncoder(
+            fps=30,
+            vcodec="libsvtav1",
+            crf=30,
+            video_feature_encoding_kwargs=video_feature_encoding_kwargs,
+        )
+        video_keys = [f"{OBS_IMAGES}.depth"]
+        encoder.start_episode(video_keys, tmp_path)
+
+        for _ in range(10):
+            frame = np.random.randint(0, 255, (64, 96, 3), dtype=np.uint8)
+            encoder.feed_frame(f"{OBS_IMAGES}.depth", frame)
+
+        results = encoder.finish_episode()
+        mp4_path, stats = results[f"{OBS_IMAGES}.depth"]
+        assert mp4_path.exists()
+        assert stats is not None
+        encoder.close()
+
+    def test_encoder_thread_options(self, tmp_path):
+        """_CameraEncoderThread accepts and stores options dict."""
+        fps = 30
+        video_path = tmp_path / "opts_test" / "test.mp4"
+        custom_options = {"foo": "bar"}
+
+        frame_queue: queue.Queue = queue.Queue(maxsize=60)
+        result_queue: queue.Queue = queue.Queue(maxsize=1)
+        stop_event = threading.Event()
+
+        encoder_thread = _CameraEncoderThread(
+            video_path=video_path,
+            fps=fps,
+            vcodec="libsvtav1",
+            pix_fmt="yuv420p",
+            g=2,
+            crf=30,
+            preset=13,
+            options=custom_options,
+            frame_queue=frame_queue,
+            result_queue=result_queue,
+            stop_event=stop_event,
+        )
+        assert encoder_thread.options == custom_options
 
     def test_graceful_frame_dropping(self, tmp_path):
         """Test that full queue drops frames instead of crashing."""


### PR DESCRIPTION
## Depth & Custom Encoding Parameter Support

feat(datasets): add depth map video support with per-key encoding

## Type / Scope

- **Type**: Feature
- **Scope**: `datasets/` (dataset_reader, dataset_writer, lerobot_dataset, multi_dataset, video_utils, feature_utils)

## Summary / Motivation

Depth maps are lossy when encoded through standard video codecs tuned for RGB. They also require different encoding parameters (e.g. lossless-friendly CRF, specific pixel formats). Previously there was no way to: (1) apply a custom transform (log-scaling, quantization) before encoding depth frames as video, (2) specify different ffmpeg encoding settings per camera/modality, or (3) decode depth maps back to their original representation on read. This PR adds first-class support for depth map modalities stored as video by introducing pluggable encoding/decoding hooks and per-video-key encoding parameters configurable via feature metadata. Streaming encoding is enforced for depth maps to avoid lossy PNG-based intermediate compression.

## Related issues

- Fixes / Closes: N/A
- Related: N/A

## What changed

- Added `depth_map_encoding_fn` / `depth_map_decoding_fn` callables threaded through `DatasetWriter`, `DatasetReader`, `LeRobotDataset` (`__init__`/`create`/`resume`), and `MultiLeRobotDataset`.
- Added `info_to_encoding_kwargs()` in `video_utils.py` — reads per-video keys (`video.codec`, `video.crf`, `video.pix_fmt`, etc.) from feature metadata `info` dicts and converts them to ffmpeg kwargs.
- Added `get_video_feature_encoding_kwargs()` in `feature_utils.py` — recursively extracts encoding info from nested feature dicts.
- `StreamingVideoEncoder` now accepts `video_feature_encoding_kwargs` for per-key codec overrides (merged on top of defaults).
- `_encode_video_worker` and `encode_video_frames` accept an `options` dict for arbitrary ffmpeg options.
- `ensure_depth_streaming_encoding()` raises `ValueError` if any video key has `video.is_depth_map: True` and `streaming_encoding=False`.
- `resolve_vcodec` now maps `"av1"` to `"libsvtav1"` (alias assigned before validation for backward compatibility).
- **No breaking changes** — all new parameters default to `None` and existing behavior is preserved.

## How was this tested (or how to run locally)

- **14 new tests** added across 4 test files:

  | Test file | Tests added |
  | --- | --- |
  | `test_dataset_utils.py` | `get_video_feature_encoding_kwargs`: direct key, nested, empty, no codec |
  | `test_streaming_video_encoder.py` | `resolve_vcodec("av1")` alias, per-key kwargs backward compat & override, `_CameraEncoderThread` options |
  | `test_dataset_writer.py` | `_encode_video_worker` extra kwargs forwarding, depth map encoding in streaming mode, non-depth frame passthrough |
  | `test_lerobot_dataset.py` | `ensure_depth_streaming_encoding` raise/pass, `create` with depth features integration |

- All existing tests pass (default behavior unchanged when no depth maps are present) except policies test (which OOM on local PC, but should be fine since no policy code has been changed).
- `video.is_depth_map` defaults to `False` in existing fixtures (`tests/fixtures/constants.py`).


## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated
- [x] CI is green

## Reviewer notes

- Focus areas: `dataset_writer.py` parallel encoding path (lines ~300–320) where per-key kwargs are extracted and forwarded to `_encode_video_worker`, and `StreamingVideoEncoder.start_episode()` where per-key overrides are merged with defaults.
- Depth map round-trip correctness (encode then decode) is not covered by unit tests due to needing actual video files; manual testing recommended with a dataset containing `video.is_depth_map: True` features.