### PR TITLE
bug(pi): pi05 inheritence chain duplicates model causing huge memory spike

### DIFF
--- a/src/lerobot/policies/groot/__init__.py
+++ b/src/lerobot/policies/groot/__init__.py
@@ -15,7 +15,12 @@
 # limitations under the License.
 
 from .configuration_groot import GrootConfig
-from .modeling_groot import GrootPolicy
-from .processor_groot import make_groot_pre_post_processors
+
+try:
+    from .modeling_groot import GrootPolicy
+    from .processor_groot import make_groot_pre_post_processors
+except (ImportError, TypeError):
+    GrootPolicy = None
+    make_groot_pre_post_processors = None
 
 __all__ = ["GrootConfig", "GrootPolicy", "make_groot_pre_post_processors"]

--- a/src/lerobot/policies/pi_gemma.py
+++ b/src/lerobot/policies/pi_gemma.py
@@ -14,12 +14,23 @@
 
 from __future__ import annotations
 
+import logging
+import resource
 from typing import TYPE_CHECKING
 
 import torch
 from torch import nn
 
 from lerobot.utils.import_utils import _transformers_available
+
+
+def _log_mem(label: str) -> None:
+    rss_mb = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
+    parts = [f"[PI_GEMMA_MEM {label}] RSS={rss_mb:.0f}MB"]
+    if torch.cuda.is_available():
+        alloc = torch.cuda.memory_allocated() / (1024**2)
+        parts.append(f"CUDA_alloc={alloc:.0f}MB")
+    logging.info(" ".join(parts))
 
 if TYPE_CHECKING or _transformers_available:
     from transformers.cache_utils import DynamicCache
@@ -196,7 +207,9 @@ class PiGemmaModel(GemmaModel):  # type: ignore[misc]
     """
 
     def __init__(self, config: GemmaConfig, **kwargs):
+        _log_mem("PiGemmaModel: before super().__init__ (creates standard GemmaModel layers)")
         super().__init__(config, **kwargs)
+        _log_mem("PiGemmaModel: after super().__init__ (standard layers allocated, about to replace)")
         # if not getattr(config, "use_adarms", False):
         #     return
         cond_dim = getattr(config, "adarms_cond_dim", None)
@@ -205,6 +218,7 @@ class PiGemmaModel(GemmaModel):  # type: ignore[misc]
             [pi_gemma_decoder_layer_base(config, layer_idx) for layer_idx in range(config.num_hidden_layers)]
         )
         self.norm = PiGemmaRMSNorm(config.hidden_size, eps=config.rms_norm_eps, cond_dim=cond_dim)
+        _log_mem("PiGemmaModel: after replacing layers with PiGemma layers")
 
     def forward(
         self,
@@ -327,24 +341,33 @@ class PiGemmaForCausalLM(GemmaForCausalLM):  # type: ignore[misc]
     """
 
     def __init__(self, config: GemmaConfig, **kwargs):
+        _log_mem("PiGemmaForCausalLM: before super().__init__ (creates standard GemmaForCausalLM)")
         super().__init__(config, **kwargs)
+        _log_mem("PiGemmaForCausalLM: after super().__init__ (about to replace with PiGemmaModel)")
         self.model = PiGemmaModel(config)
+        _log_mem("PiGemmaForCausalLM: done")
 
 
 class PaliGemmaModelWithPiGemma(PaliGemmaModel):
     """PaliGemmaModel whose language_model is PiGemmaModel (custom decoder with PiGemmaRMSNorm and gated residuals)."""
 
     def __init__(self, config):
+        _log_mem("PaliGemmaModelWithPiGemma: before super().__init__ (creates full PaliGemmaModel)")
         super().__init__(config)
+        _log_mem("PaliGemmaModelWithPiGemma: after super().__init__ (about to replace language_model)")
         self.language_model = PiGemmaModel(config.text_config)
+        _log_mem("PaliGemmaModelWithPiGemma: done")
 
 
 class PaliGemmaForConditionalGenerationWithPiGemma(PaliGemmaForConditionalGeneration):
     """PaliGemmaForConditionalGeneration using PiGemma decoder for the language model."""
 
     def __init__(self, config):
+        _log_mem("PaliGemmaForCondGenWithPiGemma: before super().__init__ (creates full PaliGemmaForConditionalGeneration)")
         super().__init__(config)
+        _log_mem("PaliGemmaForCondGenWithPiGemma: after super().__init__ (about to replace self.model)")
         self.model = PaliGemmaModelWithPiGemma(config)
+        _log_mem("PaliGemmaForCondGenWithPiGemma: done")
 
     # Make modules available through conditional class for BC
     @property


### PR DESCRIPTION
## Problem: Excessive peak memory allocation during pi0/pi05 policy initialization

The `pi_gemma.py` model hierarchy uses an init then replace pattern that causes massive transient memory allocation during construction. Each subclass calls `super().__init__()` (which builds the **entire** parent model in RAM), then immediately discards major submodules and replaces them with custom variants.

This was causing my machine with 32GB ram to crash. If I had more memory (say 64gb) it would succeed and the  allocated memory would be garbage collected, this is likely why this has gone unnoticed.

I would recommend moving away form the deep inheritance pattern used here.

### Initialization chain and observed RSS

Note: I killed the process once I got to about 30/32GB.

| Step | Class | What happens | RSS (MB) |
|------|-------|-------------|----------|
| 1 | `PaliGemmaForCondGenWithPiGemma` | `super().__init__()` builds full `PaliGemmaForConditionalGeneration` (VLM + full GemmaModel language backbone) | 837 → **14,003** (+13.2 GB) |
| 2 | ↳ replaces `self.model` → `PaliGemmaModelWithPiGemma` | `super().__init__()` builds **another** full `PaliGemmaModel` (vision encoder + another GemmaModel) | 14,003 → **23,146** (+9.1 GB) |
| 3 | ↳ replaces `self.language_model` → `PiGemmaModel` | `super().__init__()` builds **yet another** full `GemmaModel` (all decoder layers) | 23,146 → **~32 GB** (killed / interrupted) |
| 4 | ↳ replaces `self.layers` with PiGemma custom layers | Allocates final set of decoder layers | even higher |

The standard GemmaModel weights are instantiated **3 times** and discarded **2 times**. This means peak RSS is roughly **3× the final model size** — easily OOM on GPUs with ≤24 GB or machines with limited system RAM.

### Logging added

Added a `_log_mem()` helper to `pi_gemma.py` that logs RSS and CUDA allocated memory at each construction boundary:

```python
def _log_mem(label: str) -> None:
    rss_mb = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
    parts = [f"[PI_GEMMA_MEM {label}] RSS={rss_mb:.0f}MB"]
    if torch.cuda.is_available():
        alloc = torch.cuda.memory_allocated() / (1024**2)
        parts.append(f"CUDA_alloc={alloc:.0f}MB")
    logging.info(" ".join(parts))
```

Calls were inserted before/after every `super().__init__()` and after each replacement in:
- `PaliGemmaForConditionalGenerationWithPiGemma.__init__`
- `PaliGemmaModelWithPiGemma.__init__`
- `PiGemmaModel.__init__`
- `PiGemmaForCausalLM.__init__`

### Reproduce

```bash
python -m lerobot.scripts.lerobot_train \
  --dataset.repo_id=jackvial/so101_pickplace_recap_merged_v2 \
  --dataset.root=/home/jack/.cache/huggingface/lerobot \
  --policy.type=pi05 \
  --policy.dtype=bfloat16 \
  --output_dir=outputs/repro_pi0_mem \
  --job_name=repro_pi0_mem \
  --batch_size=1 \
  --steps=1 \
  --num_workers=0 \
  --save_checkpoint=false \
  --eval_freq=-1 \
  --log_freq=1 \
  --policy.push_to_hub=false
```

Watch for `[PI_GEMMA_MEM ...]` lines in the log output.

