### PR TITLE
fix(scripts): register third-party plugins in lerobot_setup_motors

### DIFF
--- a/src/lerobot/scripts/lerobot_setup_motors.py
+++ b/src/lerobot/scripts/lerobot_setup_motors.py
@@ -46,20 +46,7 @@ from lerobot.teleoperators import (  # noqa: F401
     openarm_mini,
     so_leader,
 )
-
-COMPATIBLE_DEVICES = [
-    "koch_follower",
-    "koch_leader",
-    "omx_follower",
-    "omx_leader",
-    "openarm_mini",
-    "so100_follower",
-    "so100_leader",
-    "so101_follower",
-    "so101_leader",
-    "lekiwi",
-]
-
+from lerobot.utils.import_utils import register_third_party_plugins
 
 @dataclass
 class SetupConfig:
@@ -75,9 +62,6 @@ class SetupConfig:
 
 @draccus.wrap()
 def setup_motors(cfg: SetupConfig):
-    if cfg.device.type not in COMPATIBLE_DEVICES:
-        raise NotImplementedError
-
     if isinstance(cfg.device, RobotConfig):
         device = make_robot_from_config(cfg.device)
     else:
@@ -87,6 +71,7 @@ def setup_motors(cfg: SetupConfig):
 
 
 def main():
+    register_third_party_plugins()
     setup_motors()
 
 


### PR DESCRIPTION
## Type / Scope

- **Type**: Bug
- **Scope**: `scripts`

## Summary / Motivation

`lerobot-setup-motors` did not call `register_third_party_plugins()` before running, meaning third-party robot and teleoperator devices were never registered and the command would fail for them. The compatible devices check has also been removed, as it would reject any third-party device type not in the hardcoded list. This mirrors the pattern already used in `lerobot-teleoperate`, which performs no such check.

## What changed

- Added `register_third_party_plugins()` import from `lerobot.utils.import_utils`
- Added `register_third_party_plugins()` call in `main()` before `setup_motors()`
- Removed `COMPATIBLE_DEVICES` check in `setup_motors()` that blocked third-party device types

## How was this tested (or how to run locally)

- Ran the relevant tests:

  ```bash
  pytest -q tests/ -k setup_motors
  ```

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated
- [x] CI is green

## Reviewer notes

Small, focused fix — only `src/lerobot/scripts/lerobot_setup_motors.py` is touched.
