### PR TITLE
feat(scripts): show joint names when using lerobot-dataset-viz

### DIFF
--- a/src/lerobot/scripts/lerobot_dataset_viz.py
+++ b/src/lerobot/scripts/lerobot_dataset_viz.py
@@ -151,20 +151,33 @@ def visualize_dataset(
 
             # display each dimension of action space (e.g. actuators command)
             if ACTION in batch:
-                action_features = [*range(batch[ACTION].shape[1])]
-                if ACTION in features:
-                    action_features = features[ACTION]["names"]
+                action_data = batch[ACTION]
 
-                for feature_name, val in zip(action_features, batch[ACTION][i], strict=True):
+                action_names = [*range(action_data.shape[1])]
+
+                names = features.get(ACTION, {}).get("names")
+                if isinstance(names, list):
+                    action_names = names
+                elif isinstance(names, dict):
+                    action_names = next(iter(names.values()))
+
+                for feature_name, val in zip(action_names, batch[ACTION][i], strict=True):
                     rr.log(f"{ACTION}/{feature_name}", rr.Scalars(val.item()))
 
             # display each dimension of observed state space (e.g. agent position in joint space)
             if OBS_STATE in batch:
-                obs_features = [*range(batch[OBS_STATE].shape[1])]
-                if OBS_STATE in features:
-                    obs_features = features[OBS_STATE]["names"]
+                obs_data = batch[OBS_STATE]
 
-                for feature_name, val in zip(obs_features, batch[OBS_STATE][i], strict=True):
+                # Defaults to series index
+                obs_names = [*range(obs_data.shape[1])]
+
+                names = features.get(OBS_STATE, {}).get("names")
+                if isinstance(names, list):
+                    obs_names = names
+                elif isinstance(names, dict):
+                    obs_names = next(iter(names.values()))
+
+                for feature_name, val in zip(obs_names, batch[OBS_STATE][i], strict=True):
                     rr.log(f"state/{feature_name}", rr.Scalars(val.item()))
 
             if DONE in batch:

--- a/src/lerobot/scripts/lerobot_dataset_viz.py
+++ b/src/lerobot/scripts/lerobot_dataset_viz.py
@@ -132,6 +132,8 @@ def visualize_dataset(
 
     logging.info("Logging to Rerun")
 
+    features = dataset.meta.features
+
     first_index = None
     for batch in tqdm.tqdm(dataloader, total=len(dataloader)):
         if first_index is None:
@@ -149,13 +151,21 @@ def visualize_dataset(
 
             # display each dimension of action space (e.g. actuators command)
             if ACTION in batch:
-                for dim_idx, val in enumerate(batch[ACTION][i]):
-                    rr.log(f"{ACTION}/{dim_idx}", rr.Scalars(val.item()))
+                action_features = [*range(batch[ACTION].shape[1])]
+                if ACTION in features:
+                    action_features = features[ACTION]["names"]
+
+                for feature_name, val in zip(action_features, batch[ACTION][i], strict=True):
+                    rr.log(f"{ACTION}/{feature_name}", rr.Scalars(val.item()))
 
             # display each dimension of observed state space (e.g. agent position in joint space)
             if OBS_STATE in batch:
-                for dim_idx, val in enumerate(batch[OBS_STATE][i]):
-                    rr.log(f"state/{dim_idx}", rr.Scalars(val.item()))
+                obs_features = [*range(batch[OBS_STATE].shape[1])]
+                if OBS_STATE in features:
+                    obs_features = features[OBS_STATE]["names"]
+
+                for feature_name, val in zip(obs_features, batch[OBS_STATE][i], strict=True):
+                    rr.log(f"state/{feature_name}", rr.Scalars(val.item()))
 
             if DONE in batch:
                 rr.log(DONE, rr.Scalars(batch[DONE][i].item()))


### PR DESCRIPTION
## Title

feat(scripts): show joint names when using lerobot-dataset-viz

## Type / Scope

- **Type**: Feature
- **Scope**: `lerobot-dataset-viz`

## Summary / Motivation

Log `ACTION` and `OBS_STATE` series with their corresponding feature names. This allows to efficiently determine which time series correspond to which joint or state variable in Rerun.

| Before | <img width="2490" height="1573" alt="image" src="https://github.com/user-attachments/assets/9d91da65-79bd-418e-b362-ecfe641b7cd4" />|
| - | - |
| After | <img width="2490" height="1573" alt="image" src="https://github.com/user-attachments/assets/d05576fb-764e-4318-bc34-ce6e9d26fedf" />  |

## Related issues

- No related issues as I know of.

## What changed

In `src/lerobot/scripts/lerobot_dataset_viz.py`:
- Retrieve the dataset features
- Retrieve the action/state names and iterate on both the names and the batch values to log in Rerun

## How was this tested (or how to run locally)

Ran `lerobot-dataset-viz` on a few datasets:

```sh
uv run lerobot-dataset-viz --repo-id lerobot/aloha_sim_insertion_human --episode-index 0
uv run lerobot-dataset-viz --repo-id lerobot/pusht --episode-index 0
uv run lerobot-dataset-viz --repo-id lerobot/aloha_mobile_cabinet --episode-index 0
uv run lerobot-dataset-viz --repo-id lerobot/koch_pick_place_5_lego_random_pose --episode-index 0
```

## Checklist (required before merge)

- [X] Linting/formatting run (`pre-commit run -a`)
- [X] All tests pass locally (`pytest`)
- [X] Documentation updated
- [ ] CI is green

## Reviewer notes

- Anyone in the community is free to review the PR.
