### PR TITLE
fix(scripts): Update action values when running robot without interpolation

### DIFF
--- a/src/lerobot/scripts/lerobot_record.py
+++ b/src/lerobot/scripts/lerobot_record.py
@@ -421,6 +421,7 @@ def record_loop(
                 act_processed_policy: RobotAction = make_robot_action(action_values, dataset.features)
                 # Applies a pipeline to the action, default is IdentityProcessor
                 robot_action_to_send = robot_action_processor((act_processed_policy, obs))
+                action_values = robot_action_to_send
 
         elif policy is None and isinstance(teleop, Teleoperator):
             act = teleop.get_action()


### PR DESCRIPTION
## Type / Scope

- **Type**: Bug
- **Scope**: lerobot_record.py

## Summary / Motivation

When `lerobot_record` is invoked from command line without interpolation, the following error is encountered:

> IndexError: too many indices for tensor of dimension 2 

This is because `build_dataset_frame()` expects a dictionary for action values, but a raw tensor is passed in instead for the non-interpolated case. 

## Related issues

- Related PR: https://github.com/huggingface/lerobot/pull/2833

## What changed

This PR updates `action_values` to the dictionary after processing, similar to the interpolation path. 

## How was this tested

* Run `lerobot_record` with a path to a trained ACT policy, with and without interpolation
* Verify that command runs successfully with no error

```
lerobot_record --policy.path=PATH_TO_ACT_POLICY --interpolation_multiplier={1,2}
```

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`) - there are unrelated failing tests in `test_multi_task_dit.py`
- [x] Documentation updated
- [ ] CI is green