### PR TITLE
fix(scripts): convert action_values to dict in non-interpolation policy path

### DIFF
--- a/src/lerobot/scripts/lerobot_record.py
+++ b/src/lerobot/scripts/lerobot_record.py
@@ -421,6 +421,7 @@ def record_loop(
                 act_processed_policy: RobotAction = make_robot_action(action_values, dataset.features)
                 # Applies a pipeline to the action, default is IdentityProcessor
                 robot_action_to_send = robot_action_processor((act_processed_policy, obs))
+                action_values = robot_action_to_send
 
         elif policy is None and isinstance(teleop, Teleoperator):
             act = teleop.get_action()


### PR DESCRIPTION
## Title

fix(scripts): convert action_values to dict in non-interpolation policy path

## Type / Scope

- **Type**: Bug
- **Scope**: scripts/lerobot_record

## Summary / Motivation

Running lerobot-record with --policy.path (without interpolation) crashes with IndexError: too many indices for tensor of dimension 2 at build_dataset_frame. The non-interpolation policy path passes the raw policy tensor as action_values, but build_dataset_frame expects a dict of scalars. The interpolation path and teleop paths already convert action_values to a dict, this change makes the non-interpolation path consistent.

## Related issues

- Fixes / Closes: N/A
- Related: N/A

## What changed

- lerobot/src/lerobot/scripts/lerobot_record.py: Added action_values = robot_action_to_send after the robot_action_processor call in the non-interpolation policy path, matching the pattern used in the interpolation path and teleop paths.

## How was this tested (or how to run locally)

- Manual test: ran lerobot-record with --policy.path pointing to a trained ACT checkpoint on an SO-101 robot. Before the fix, it crashed immediately on the first inference step. After the fix, inference runs correctly and actions are recorded to the dataset.

## Checklist (required before merge)

- [ X ] Linting/formatting run (`pre-commit run -a`)
- [ X ] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [ ] CI is green

## Reviewer notes

N/A
