### PR TITLE
fix(dataset): patches torchvision transforms registration

### DIFF
--- a/src/lerobot/datasets/dataset_reader.py
+++ b/src/lerobot/datasets/dataset_reader.py
@@ -72,7 +72,8 @@ class DatasetReader:
         self.episodes = episodes
         self._tolerance_s = tolerance_s
         self._video_backend = video_backend
-        self._image_transforms = image_transforms
+        self._image_transforms = None
+        self.set_image_transforms(image_transforms)
 
         self.hf_dataset: datasets.Dataset | None = None
         self._absolute_to_relative_idx: dict[int, int] | None = None
@@ -82,6 +83,16 @@ class DatasetReader:
         if delta_timestamps is not None:
             check_delta_timestamps(delta_timestamps, meta.fps, tolerance_s)
             self.delta_indices = get_delta_indices(delta_timestamps, meta.fps)
+
+    def set_image_transforms(self, image_transforms: Callable | None) -> None:
+        """Replace the transform applied to visual observations."""
+        if image_transforms is not None and not callable(image_transforms):
+            raise TypeError("image_transforms must be callable or None.")
+        self._image_transforms = image_transforms
+
+    def clear_image_transforms(self) -> None:
+        """Remove the transform applied to visual observations."""
+        self.set_image_transforms(None)
 
     def try_load(self) -> bool:
         """Attempt to load from local cache. Returns True if data is sufficient."""

--- a/src/lerobot/datasets/lerobot_dataset.py
+++ b/src/lerobot/datasets/lerobot_dataset.py
@@ -194,8 +194,9 @@ class LeRobotDataset(torch.utils.data.Dataset):
         super().__init__()
         self.repo_id = repo_id
         self._requested_root = Path(root) if root else None
-        self.reader = None
-        self.set_image_transforms(image_transforms)
+        if image_transforms is not None and not callable(image_transforms):
+            raise TypeError("image_transforms must be callable or None.")
+        self.image_transforms = image_transforms
         self.delta_timestamps = delta_timestamps
         self.episodes = episodes
         self.tolerance_s = tolerance_s
@@ -484,7 +485,7 @@ class LeRobotDataset(torch.utils.data.Dataset):
             raise TypeError("image_transforms must be callable or None.")
         self.image_transforms = image_transforms
         if self.reader is not None:
-            self.reader._image_transforms = image_transforms
+            self.reader.set_image_transforms(image_transforms)
 
     def clear_image_transforms(self) -> None:
         """Remove the transform applied to visual observations."""

--- a/tests/datasets/test_dataset_reader.py
+++ b/tests/datasets/test_dataset_reader.py
@@ -143,6 +143,32 @@ def test_image_transforms_are_applied(tmp_path, lerobot_dataset_factory):
         assert transform_called["count"] >= 1
 
 
+def test_set_image_transforms_updates_reader_behavior(tmp_path, lerobot_dataset_factory):
+    """Reader setters update and clear visual transforms without replacing the reader."""
+    transform_called = {"count": 0}
+
+    def sentinel_transform(img):
+        transform_called["count"] += 1
+        return img
+
+    dataset = lerobot_dataset_factory(
+        root=tmp_path / "ds",
+        total_episodes=1,
+        total_frames=5,
+        use_videos=False,
+    )
+    reader = dataset.reader
+
+    reader.set_image_transforms(sentinel_transform)
+    reader.get_item(0)
+    assert transform_called["count"] >= 1
+
+    calls_after_set = transform_called["count"]
+    reader.clear_image_transforms()
+    reader.get_item(0)
+    assert transform_called["count"] == calls_after_set
+
+
 # ── File paths ───────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Title

Patches comments from @imstevenpmwork on #3153

## Type / Scope

- **Type**: Chore
- **Scope**: patch

## Summary / Motivation

NA

## Related issues

See #3152 

## What changed

- Taking in @imstevenpmwork comments, mostly related to separation of concerns between `LeRobotDataset` facade and the newly introduced double Writer/Reader backends. 

## How was this tested (or how to run locally)

- Ran normal tests

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated
- [ ] CI is green

## Reviewer notes

- Anything the reviewer should focus on (performance, edge-cases, specific files) or general notes.
- Anyone in the community is free to review the PR.
