### PR TITLE
fix(loading errors): improving dataset loading errors handling and logging

### DIFF
--- a/src/lerobot/datasets/dataset_reader.py
+++ b/src/lerobot/datasets/dataset_reader.py
@@ -87,7 +87,7 @@ class DatasetReader:
         """Attempt to load from local cache. Returns True if data is sufficient."""
         try:
             self.hf_dataset = self._load_hf_dataset()
-        except (FileNotFoundError, NotADirectoryError):
+        except (FileNotFoundError, NotADirectoryError, ValueError):
             self.hf_dataset = None
             return False
         if not self._check_cached_episodes_sufficient():

--- a/src/lerobot/datasets/io_utils.py
+++ b/src/lerobot/datasets/io_utils.py
@@ -78,7 +78,10 @@ def load_nested_dataset(
     with SuppressProgressBars():
         # We use .from_parquet() memory-mapped loading for efficiency
         filters = pa_ds.field("episode_index").isin(episodes) if episodes is not None else None
-        return Dataset.from_parquet([str(path) for path in paths], filters=filters, features=features)
+        try:
+            return Dataset.from_parquet([str(path) for path in paths], filters=filters, features=features)
+        except ValueError:
+            raise ValueError(f"Failed to load parquet files in {pq_dir}, make sure the dataset is valid and is not missing any files.")
 
 
 def get_parquet_num_frames(parquet_path: str | Path) -> int:


### PR DESCRIPTION
## Type / Scope

- **Type**: Bug
- **Scope**: LeRobotDataset

## Summary / Motivation

This PR improves the handling of dataset loading errors when files are missing (e.g. not yet downloaded or inexistent). 

## Related issues

- Fixes / Closes: # (if any)
- Related: # (if any)

## What changed

- `DatasetReader.try_load` now catches the `ValueError` triggered when files are missing locally but may exist remotely. 
- `load_nested_dataset` wraps the unclear `ValueError` raised by `Dataset.from_parquet` when parquet files are missing.

## How was this tested (or how to run locally)

This was tested while trying to fix `lerobot/droid_1.0.1` dataset, which was missing a bunch of files remotely.

## Checklist (required before merge)

- [ ] Linting/formatting run (`pre-commit run -a`)
- [ ] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [ ] CI is green

## Reviewer notes

- Anything the reviewer should focus on (performance, edge-cases, specific files) or general notes.
- Anyone in the community is free to review the PR.
