### PR TITLE
feat(rewards): add Robometer reward model

### DIFF
--- a/docs/source/robometer.mdx
+++ b/docs/source/robometer.mdx
@@ -1,8 +1,7 @@
-a Trajectory Comparisons
+# Robometer: Scaling General-Purpose Robotic Reward Models via Trajectory Comparisons
 
-Robometer is a pre-trained reward model (4B parameters) trained on large-scale real-robot data to assign progress scores to robot rollout videos. 
-dense progress values
-Qwen3-VL-4B-Instruct fine-tuned on the RBM-1M dataset.
+Robometer is a pre-trained reward model (4B parameters) trained on large-scale real robot videos to predict dense progress values.
+
 This guide covers how to instantiate and use Robometer in LeRobot for reward computation during RL training or evaluation.
 
 **Paper**: [Robometer: Scaling General-Purpose Robotic Reward Models via Trajectory Comparisons](https://arxiv.org/abs/2603.02115)
@@ -11,22 +10,13 @@ This guide covers how to instantiate and use Robometer in LeRobot for reward com
 
 ## Overview
 
-RoboReward fine-tunes Qwen3-VL-4B-Instruct on their RBM-1M dataset, which is built on Open X-Embodiment (OXE) and RoboArena data. Given a robot rollout video and a task description, the model generates a discrete progress score:
-
-| Score | Meaning                                                    |
-| ----- | ---------------------------------------------------------- |
-| 1     | No Success — no goal-relevant change                       |
-| 2     | Minimal Progress — insufficient change toward goal         |
-| 3     | Partial Completion — good progress but misses requirements |
-| 4     | Near Completion — misses a single minor requirement        |
-| 5     | Perfect Completion — all requirements satisfied            |
-
-These scores are mapped to float rewards in [0, 1] via a configurable `score_to_reward` table (default: linear 0.0 → 1.0).
+Robometer fine-tunes Qwen3-VL-4B-Instruct on their RBM-1M dataset. 
+Given a robot rollout video and a task description, the model generates a progress scores between 0 and 1 for each timestep of the vidoe.
 
 ## Requirements
 
 ```bash
-pip install "transformers>=4.51.0" qwen-vl-utils roboreason unsloth>=2025.10
+pip install "transformers>=4.51.0" qwen-vl-utils roboreason
 ```
 
 ## Quickstart
@@ -37,7 +27,6 @@ from lerobot.rewards.robometer.configuration_robometer import RobometerConfig
 from lerobot.rewards.robometer.modeling_robometer import RobometerModel
 
 config = RobometerConfig(
-    model_name="robometer",
     device="cuda",
     image_key="observation.images.side",
     task_key="observation.language_instruction", # if task_key is None, must provide task_instruction string: e.g., task_instruction="pick up the red cube"
@@ -47,13 +36,15 @@ model.eval()
 
 # batch from your dataset or environment (with videos)
 batch = {
-    "observation.images.side": torch.rand(2, 8, 3, 480, 640),   # (B, T, C, H, W) - batch of 2 videos, each with 8 frames
+    "observation.images.side": torch.rand(2, 8, 3, 84, 84),   # (B, T, C, H, W) - batch of 2 videos, each with 8 frames
     "observation.language_instruction": [
         "pick up the red cube",
         "place the block on the tray",
     ],
 }
-rewards = model.compute_reward(batch)  # tensor([[], []])
+rewards = model.compute_reward(batch) 
+# tensor([[0.1404, 0.1278, 0.1569, 0.1777, 0.1788, 0.1907, 0.1687, 0.2079],
+#         [0.0410, 0.0332, 0.0513, 0.0881, 0.0556, 0.0640, 0.0784, 0.0859]])
 ```
 
 ## Configuration
@@ -62,7 +53,6 @@ rewards = model.compute_reward(batch)  # tensor([[], []])
 from lerobot.rewards.robometer.configuration_robometer import RobometerConfig
 
 config = RobometerConfig(
-    model_name="robometer",   
     device="cuda",
     image_key="observation.images.side",
     task_key="observation.language_instruction", # if task_key is None, must provide task_instruction string: e.g., task_instruction="pick up the red cube"
@@ -94,7 +84,7 @@ reward_model = make_reward_model(cfg)
 rewards = reward_model.compute_reward(obs_batch)
 ```
 
-## Notes
+## Notes (similar to RoboReward implementation)
 
 - **Inference only**: The VLM backbone is frozen. `forward()` raises `NotImplementedError`.
   Fine-tuning support is planned as future work.

--- a/docs/source/robometer.mdx
+++ b/docs/source/robometer.mdx
@@ -1,0 +1,104 @@
+a Trajectory Comparisons
+
+Robometer is a pre-trained reward model (4B parameters) trained on large-scale real-robot data to assign progress scores to robot rollout videos. 
+dense progress values
+Qwen3-VL-4B-Instruct fine-tuned on the RBM-1M dataset.
+This guide covers how to instantiate and use Robometer in LeRobot for reward computation during RL training or evaluation.
+
+**Paper**: [Robometer: Scaling General-Purpose Robotic Reward Models via Trajectory Comparisons](https://arxiv.org/abs/2603.02115)
+
+**Models**: [robometer/Robometer-4B](https://huggingface.co/robometer/Robometer-4B)
+
+## Overview
+
+RoboReward fine-tunes Qwen3-VL-4B-Instruct on their RBM-1M dataset, which is built on Open X-Embodiment (OXE) and RoboArena data. Given a robot rollout video and a task description, the model generates a discrete progress score:
+
+| Score | Meaning                                                    |
+| ----- | ---------------------------------------------------------- |
+| 1     | No Success — no goal-relevant change                       |
+| 2     | Minimal Progress — insufficient change toward goal         |
+| 3     | Partial Completion — good progress but misses requirements |
+| 4     | Near Completion — misses a single minor requirement        |
+| 5     | Perfect Completion — all requirements satisfied            |
+
+These scores are mapped to float rewards in [0, 1] via a configurable `score_to_reward` table (default: linear 0.0 → 1.0).
+
+## Requirements
+
+```bash
+pip install "transformers>=4.51.0" qwen-vl-utils roboreason unsloth>=2025.10
+```
+
+## Quickstart
+
+```python
+import torch
+from lerobot.rewards.robometer.configuration_robometer import RobometerConfig
+from lerobot.rewards.robometer.modeling_robometer import RobometerModel
+
+config = RobometerConfig(
+    model_name="robometer",
+    device="cuda",
+    image_key="observation.images.side",
+    task_key="observation.language_instruction", # if task_key is None, must provide task_instruction string: e.g., task_instruction="pick up the red cube"
+)
+model = RobometerModel(config)
+model.eval()
+
+# batch from your dataset or environment (with videos)
+batch = {
+    "observation.images.side": torch.rand(2, 8, 3, 480, 640),   # (B, T, C, H, W) - batch of 2 videos, each with 8 frames
+    "observation.language_instruction": [
+        "pick up the red cube",
+        "place the block on the tray",
+    ],
+}
+rewards = model.compute_reward(batch)  # tensor([[], []])
+```
+
+## Configuration
+
+```python
+from lerobot.rewards.robometer.configuration_robometer import RobometerConfig
+
+config = RobometerConfig(
+    model_name="robometer",   
+    device="cuda",
+    image_key="observation.images.side",
+    task_key="observation.language_instruction", # if task_key is None, must provide task_instruction string: e.g., task_instruction="pick up the red cube"
+    num_reasoning_frames=10,  # the video is evenly downsampled to this number of frames before computing rewards
+)
+```
+
+## Using with the Factory
+
+```python
+from lerobot.rewards.factory import get_reward_model_class, make_reward_model_config
+
+cfg = make_reward_model_config("robometer", device="cuda")
+cls = get_reward_model_class("robometer")
+model = cls(cfg)
+```
+
+## Using with HIL-SERL / RL Training
+
+Pass the reward model config to the RL trainer. The model's `compute_reward()` is called at each environment step to provide dense rewards:
+
+```python
+from lerobot.rewards.factory import make_reward_model
+
+cfg = make_reward_model_config("robometer", device="cuda")
+reward_model = make_reward_model(cfg)
+
+# In your RL loop:
+rewards = reward_model.compute_reward(obs_batch)
+```
+
+## Notes
+
+- **Inference only**: The VLM backbone is frozen. `forward()` raises `NotImplementedError`.
+  Fine-tuning support is planned as future work.
+- **Throughput**: Reward computation runs sequentially per batch item (one `generate()` call each).
+  For high-throughput RL, consider computing rewards asynchronously or at episode end rather than
+  every step.
+

--- a/src/lerobot/rewards/factory.py
+++ b/src/lerobot/rewards/factory.py
@@ -25,6 +25,7 @@ from lerobot.processor import PolicyAction, PolicyProcessorPipeline
 from lerobot.rewards.classifier.configuration_classifier import RewardClassifierConfig
 from lerobot.rewards.pretrained import PreTrainedRewardModel
 from lerobot.rewards.sarm.configuration_sarm import SARMConfig
+from lerobot.rewards.robometer.configuration_robometer import RobometerConfig
 
 
 def get_reward_model_class(name: str) -> type[PreTrainedRewardModel]:
@@ -36,7 +37,7 @@ def get_reward_model_class(name: str) -> type[PreTrainedRewardModel]:
 
     Args:
         name: The name of the reward model. Supported names are "reward_classifier",
-              "sarm".
+              "sarm", "robometer".
 
     Returns:
         The reward model class corresponding to the given name.
@@ -52,6 +53,10 @@ def get_reward_model_class(name: str) -> type[PreTrainedRewardModel]:
         from lerobot.rewards.sarm.modeling_sarm import SARMRewardModel
 
         return SARMRewardModel
+    elif name == "robometer":
+        from lerobot.rewards.robometer.modeling_robometer import RobometerModel
+
+        return RobometerModel
     else:
         try:
             return _get_reward_model_cls_from_name(name=name)
@@ -68,7 +73,7 @@ def make_reward_model_config(reward_type: str, **kwargs) -> RewardModelConfig:
 
     Args:
         reward_type: The type of the reward model. Supported types include
-                     "reward_classifier", "sarm".
+                     "reward_classifier", "sarm", "robometer".
         **kwargs: Keyword arguments to be passed to the configuration class constructor.
 
     Returns:
@@ -81,6 +86,8 @@ def make_reward_model_config(reward_type: str, **kwargs) -> RewardModelConfig:
         return RewardClassifierConfig(**kwargs)
     elif reward_type == "sarm":
         return SARMConfig(**kwargs)
+    elif reward_type == "robometer":
+        return RobometerConfig(**kwargs)
     else:
         try:
             config_cls = RewardModelConfig.get_choice_class(reward_type)
@@ -160,7 +167,6 @@ def make_reward_pre_post_processors(
             dataset_stats=kwargs.get("dataset_stats"),
             dataset_meta=kwargs.get("dataset_meta"),
         )
-
     else:
         try:
             processors = _make_processors_from_reward_model_config(
@@ -236,3 +242,4 @@ def _make_processors_from_reward_model_config(
     module = importlib.import_module(module_path)
     function = getattr(module, function_name)
     return function(config, dataset_stats=dataset_stats)
+

--- a/src/lerobot/rewards/robometer/__init__.py
+++ b/src/lerobot/rewards/robometer/__init__.py
@@ -12,13 +12,3 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from .classifier.configuration_classifier import RewardClassifierConfig as RewardClassifierConfig
-from .sarm.configuration_sarm import SARMConfig as SARMConfig
-from .robometer.configuration_robometer import RobometerConfig as RobometerConfig
-
-__all__ = [
-    "RewardClassifierConfig",
-    "SARMConfig",
-    "RobometerConfig",
-]
-

--- a/src/lerobot/rewards/robometer/configuration_robometer.py
+++ b/src/lerobot/rewards/robometer/configuration_robometer.py
@@ -1,0 +1,60 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Robometer: Scaling General-Purpose Robotic Reward Models via Trajectory Comparisons
+Paper: https://arxiv.org/abs/2603.02115
+Models: robometer/Robometer-4B
+"""
+
+from dataclasses import dataclass, field
+
+from lerobot.configs.rewards import RewardModelConfig
+from lerobot.optim.optimizers import AdamWConfig, OptimizerConfig
+from lerobot.optim.schedulers import LRSchedulerConfig
+
+
+@RewardModelConfig.register_subclass("robometer")
+@dataclass
+class RobometerConfig(RewardModelConfig):
+    """Configuration for the Robometer vision-language reward model.
+
+    Robometer is a pre-trained reward model (based on the Qwen-3-VL-4B-Instruct backbone) 
+    that computes dense progress values from robot rollout videos and task descriptions. 
+    Scores are scaled to float rewards in [0, 1].
+
+    Args:
+        name: model name
+        task_key: Batch key containing the task language instruction string(s).
+        task_instruction: If task_key is None, must provide task_instruction string: e.g., task_instruction="pick up the red cube"
+        image_key: Batch key for the primary camera image(s). Accepts tensors of
+            shape (B, T, C, H, W) for video.
+        num_reasoning_frames: The video is evenly downsampled to this number of frames before computing rewards.
+        view_type: Camera view types used for computing rewards: "external", "wrist", or "external and wrist".
+    """
+
+    name: str = "robometer"
+    device: str = "cpu"
+    task_key: str = "observation.language_instruction"
+    task_instruction: str = ""  
+    image_key: str = "observation.images.side"
+    num_reasoning_frames: int = 10  
+    view_type: str = "external"  
+
+    def get_optimizer_preset(self) -> OptimizerConfig:
+        return AdamWConfig(lr=1e-5, weight_decay=1e-2)
+
+    def get_scheduler_preset(self) -> LRSchedulerConfig | None:
+        return None
+

--- a/src/lerobot/rewards/robometer/modeling_robometer.py
+++ b/src/lerobot/rewards/robometer/modeling_robometer.py
@@ -1,0 +1,235 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Robometer: Scaling General-Purpose Robotic Reward Models via Trajectory Comparisons
+Paper: https://arxiv.org/abs/2603.02115
+
+Inference only: generates dense progress values between 0 and 1 for robot rollout videos with a task instruction prompt.
+
+Requirements:
+    pip install "transformers>=4.51.0" qwen-vl-utils roboreason
+"""
+
+import logging
+import re
+from pathlib import Path
+from typing import Any
+
+import torch
+from torch import Tensor
+
+from lerobot.rewards.pretrained import PreTrainedRewardModel
+from lerobot.rewards.robometer.configuration_robometer import RobometerConfig
+
+logger = logging.getLogger(__name__)
+
+# Optional heavy imports — kept at module level so patch() can target them in tests.
+try:
+    from transformers import AutoProcessor, Qwen3VLForConditionalGeneration
+
+    _TRANSFORMERS_AVAILABLE = True
+except ImportError:
+    AutoProcessor = None  # type: ignore[assignment,misc]
+    Qwen3VLForConditionalGeneration = None  # type: ignore[assignment,misc]
+    _TRANSFORMERS_AVAILABLE = False
+
+try:
+    from qwen_vl_utils import process_vision_info
+
+    _QWEN_VL_UTILS_AVAILABLE = True
+except ImportError:
+    process_vision_info = None  # type: ignore[assignment]
+    _QWEN_VL_UTILS_AVAILABLE = False
+
+try:
+    import roboreason
+    
+    _ROBOREASON_AVAILABLE = True
+except ImportError:
+    roboreason = None 
+    _ROBOREASON_AVAILABLE = False
+
+
+
+class RobometerModel(PreTrainedRewardModel):
+    """Robometer vision-language reward model.
+
+    Wraps a pretrained Robometer-4B model (Qwen3-VL-4B-Instruct backbone) for
+    inference-only reward computation. The VLM backbone is always frozen.
+
+    Usage::
+        config = RobometerConfig(model_name="robometer", device="cuda")
+        model = RobometerModel(config)
+        rewards = model.compute_reward(batch)  # Tensor of shape (B,)
+    """
+    
+    name = "robometer"
+    config_class = RobometerConfig
+
+    def __init__(self, config: RobometerConfig):
+        super().__init__(config)
+        self.config = config
+
+        if not _TRANSFORMERS_AVAILABLE:
+            raise ImportError(
+                "RobometerModel requires transformers>=4.51.0 with Qwen3-VL support.\n"
+                "Install with: pip install 'transformers>=4.51.0'"
+            )
+
+        if not _QWEN_VL_UTILS_AVAILABLE:
+            raise ImportError(
+                "RobometerModel requires the qwen-vl-utils package (for compute_reward).\nInstall with: pip install qwen-vl-utils"
+            )
+
+        if not _ROBOREASON_AVAILABLE:
+            raise ImportError(
+                "RobometerModel requires the roboreason package.\nInstall with: pip install roboreason"
+            )
+        
+        from roboreason.utils.model_utils import get_model_dir
+        
+        # pre-downloads the HF model and stores in local cache
+        get_model_dir('robometer')
+
+    # ------------------------------------------------------------------
+    # Hub save / load
+    # ------------------------------------------------------------------
+
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        pretrained_name_or_path: str | Path,
+        *,
+        config: RobometerConfig | None = None,
+        **kwargs,
+    ) -> "RobometerModel":
+        """Load config from a local directory or Hub repo and instantiate."""
+        from lerobot.configs.rewards import RobometerConfig
+
+        if config is None:
+            config = RobometerConfig.from_pretrained(pretrained_name_or_path, **kwargs)
+        return cls(config)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _tensor_to_frame(self, tensor: Tensor):
+        """
+        Convert a (C, H, W) float tensor in [0, 1]
+        to a NumPy array (H, W, 3) uint8 (RGB),
+        matching load_video_frames output.
+        """
+        import numpy as np
+        frame = (
+            tensor.detach()
+            .cpu()
+            .float()
+            .permute(1, 2, 0)   # (C,H,W) → (H,W,C)
+            .numpy()
+            * 255.0
+        ).clip(0, 255).astype(np.uint8)
+
+        return frame
+
+    # ------------------------------------------------------------------
+    # Inference
+    # ------------------------------------------------------------------
+
+    @torch.no_grad()
+    def compute_reward(self, batch: dict[str, Tensor]) -> Tensor:
+        """Compute scalar rewards for a batch by generating progress scores.
+
+        Args:
+            batch: Must contain ``config.image_key`` (image tensor) and optionally
+                ``config.task_key`` (task description strings). Image tensor shape:
+                ``(B, C, H, W)`` (single frame) or ``(B, T, C, H, W)`` (video).
+
+        Returns:
+            Float tensor of shape ``(B,)`` with rewards in [0, 1].
+        """
+        if not _QWEN_VL_UTILS_AVAILABLE:
+            raise ImportError(
+                "compute_reward requires the qwen-vl-utils package.\nInstall with: pip install qwen-vl-utils"
+            )
+        
+        if not _ROBOREASON_AVAILABLE:
+            raise ImportError(
+                "compute_reward requires the roboreason package.\nInstall with: pip install roboreason"
+            )
+                
+        images = batch.get(self.config.image_key)
+        if images is None:
+            raise ValueError(f"Missing image key '{self.config.image_key}' in batch.")
+
+        # Normalise to (B, T, C, H, W)
+        if images.ndim == 4:
+            images = images.unsqueeze(1)
+
+        batch_size = images.shape[0]
+        if self.config.task_key is not None:
+            tasks = batch.get(self.config.task_key)
+        else:
+            # use self.config.task_instruction str for all samples if task_key is None
+            tasks = [self.config.task_instruction] * batch_size
+        task_list = _decode_tasks(tasks, batch_size)
+
+        vlm_device = torch.device(self.config.device)
+        
+        from roboreason import generate
+        
+        rewards: list[float] = []
+        for i in range(batch_size):
+            frames = [self._tensor_to_frame(images[i, t]) for t in range(images.shape[1])]
+            rewards_i, success_probs_i = generate(
+                model=self.config.name,  
+                task_description=task_list[i], 
+                video_frames=frames, 
+                view_type=self.config.view_type, 
+                num_reasoning_frames=self.config.num_reasoning_frames,
+            )
+            # divide by 100 to convert from percentage to [0, 1] range
+            rewards_i = [r / 100.0 for r in rewards_i]
+            rewards.append(rewards_i)
+
+        return torch.tensor(rewards, dtype=torch.float32, device=images.device)
+
+
+    def forward(self, batch: dict[str, Any]) -> tuple[Tensor, dict[str, Any]]:
+        """Not implemented. Robometer is used inference-only via compute_reward()."""
+        raise NotImplementedError(
+            "RobometerModel does not support training via forward(). "
+            "Use compute_reward() for inference. "
+            "Fine-tuning support is planned as future work."
+        )
+
+
+# ------------------------------------------------------------------
+# Utilities
+# ------------------------------------------------------------------
+
+
+def _decode_tasks(tasks: Any, batch_size: int) -> list[str]:
+    """Decode task descriptions from various batch formats to a list of strings."""
+    if tasks is None:
+        return ["complete the task"] * batch_size
+    if isinstance(tasks, (list, tuple)):
+        return [str(t) for t in tasks]
+    if isinstance(tasks, Tensor):
+        # Byte-string tensor or similar edge case
+        return [str(t.item()) if t.numel() == 1 else str(t.tolist()) for t in tasks]
+    return [str(tasks)] * batch_size
+

--- a/tests/rewards/test_robometer.py
+++ b/tests/rewards/test_robometer.py
@@ -1,0 +1,109 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for Robometer configuration and model."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+from lerobot.configs.rewards import RewardModelConfig
+from lerobot.rewards.robometer.configuration_robometer import RobometerConfig
+
+# ---------------------------------------------------------------------------
+# Configuration tests
+# ---------------------------------------------------------------------------
+
+
+def test_robometer_config_registered():
+    """RobometerConfig must be registered in the reward model registry."""
+    known = RewardModelConfig.get_known_choices()
+    assert "robometer" in known
+
+
+def test_robometer_config_lookup():
+    """Registry lookup must return the correct config class."""
+    cls = RewardModelConfig.get_choice_class("robometer")
+    assert cls is RobometerConfig
+
+
+def test_robometer_config_defaults():
+    """Default config should be instantiable with sensible values."""
+    cfg = RobometerConfig()
+    assert cfg.name == "robometer"
+    assert cfg.task_key == "observation.language_instruction"
+    assert cfg.image_key == "observation.images.side"
+
+def test_robometer_config_type():
+    """config.type must return the registered name."""
+    cfg = RobometerConfig()
+    assert cfg.type == "robometer"
+
+# def test_robometer_config_validate_features_missing_key():
+#     """validate_features must raise if image_key is not in input_features."""
+#     cfg = RobometerConfig(image_key="observation.images.nonexistent")
+#     with pytest.raises(ValueError, match="image_key"):
+#         cfg.validate_features()
+
+
+# ---------------------------------------------------------------------------
+# Factory tests
+# ---------------------------------------------------------------------------
+
+
+def test_factory_get_reward_model_class():
+    """Factory must return RobometerModel for 'robometer'."""
+    from lerobot.rewards.factory import get_reward_model_class
+    from lerobot.rewards.robometer.modeling_robometer import RobometerModel
+    
+    cls = get_reward_model_class("robometer")
+    assert cls is RobometerModel
+
+
+def test_factory_make_reward_model_config():
+    """make_reward_model_config must return a RobometerConfig instance."""
+    from lerobot.rewards.factory import make_reward_model_config
+    
+    cfg = make_reward_model_config("robometer")
+    assert isinstance(cfg, RobometerConfig)
+
+
+# ---------------------------------------------------------------------------
+# Model tests (VLM mocked — no network / GPU required)
+# ---------------------------------------------------------------------------
+
+
+def test_compute_reward_shape():
+    """compute_reward must return (B, T) tensor for (B, T, C, H, W) input."""
+    from lerobot.rewards.robometer.modeling_robometer import RobometerModel
+    cfg = RobometerConfig()
+    model = RobometerModel(cfg)
+    batch = {
+        "observation.images.side": torch.rand(2, 8, 3, 84, 84),
+        "observation.language_instruction": ["pick up the cube", "place the block"],
+    }
+    rewards = model.compute_reward(batch)
+    assert rewards.shape == (2,8)
+    assert rewards.dtype == torch.float32
+
+
+def test_forward_raises_not_implemented():
+    """forward() must raise NotImplementedError (inference-only model)."""
+    from lerobot.rewards.robometer.modeling_robometer import RobometerModel
+    cfg = RobometerConfig()
+    model = RobometerModel(cfg)
+    with pytest.raises(NotImplementedError, match="compute_reward"):
+        model.forward({})
+


### PR DESCRIPTION
## Title

Added Robometer, a popular new reward model ([Robometer website](https://robometer.github.io) and [arXiv paper](https://arxiv.org/abs/2603.02115))

## Type / Scope

- **Type**: Feature
- **Scope**: rewards / robometer

## Summary / Motivation

This PR adds the popular new reward model, Robometer, under the new reward-model foundation in `src/lerobot/rewards/`.

This is in line with the call for contributions from #3143.

Implementation is aligned with the Robometer paper: [arXiv:2603.02115](https://arxiv.org/abs/2603.02115).

This PR follows a similar structure as the PR for adding RoboReward (another new reward model) submitted by int-smart. 


## Related issues

-  #3143


## What changed

- Added new Robometer module files:
  - `src/lerobot/rewards/robometer/configuration_robometer.py`
  - `src/lerobot/rewards/robometer/modeling_robometer.py`
  - `src/lerobot/rewards/robometer/__init__.py`
- Registered Robometer in reward registry/factory:
  - `src/lerobot/robometer/__init__.py`
  - `src/lerobot/robometer/factory.py`
- Added tests:
  - `tests/rewards/test_robometer.py`
- Added docs:
  - `docs/source/robometer.mdx`

## How was this tested (or how to run locally)

- Tests added: tests/rewards/test_robometer.py

Example:

- Ran the relevant tests:

  ```bash
  pytest tests/rewards/test_robometer.py -v
  ```

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated
- [ ] CI is green

## Example videos (successful and failed)
### Task: "Pick up the cube and place it in the target area marked by the X."






https://github.com/user-attachments/assets/334e8d2e-078d-4a6c-b177-5a9e0ca23355




https://github.com/user-attachments/assets/219324b8-6c00-4295-94b0-a2509e48ef42



