### PR TITLE
fix: GR00TN15Config dataclass TypeError on Python 3.12

### DIFF
--- a/src/lerobot/policies/groot/groot_n1.py
+++ b/src/lerobot/policies/groot/groot_n1.py
@@ -15,7 +15,7 @@
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 import numpy as np
 import torch
@@ -177,13 +177,13 @@ N_COLOR_CHANNELS = 3
 @dataclass
 class GR00TN15Config(PretrainedConfig):
     model_type = "gr00t_n1_5"
-    backbone_cfg: dict = field(init=False, metadata={"help": "Backbone configuration."})
+    backbone_cfg: Optional[dict] = field(init=False, default=None, metadata={"help": "Backbone configuration."})
 
-    action_head_cfg: dict = field(init=False, metadata={"help": "Action head configuration."})
+    action_head_cfg: Optional[dict] = field(init=False, default=None, metadata={"help": "Action head configuration."})
 
-    action_horizon: int = field(init=False, metadata={"help": "Action horizon."})
+    action_horizon: Optional[int] = field(init=False, default=None, metadata={"help": "Action horizon."})
 
-    action_dim: int = field(init=False, metadata={"help": "Action dimension."})
+    action_dim: Optional[int] = field(init=False, default=None, metadata={"help": "Action dimension."})
     compute_dtype: str = field(default="float32", metadata={"help": "Compute dtype."})
 
     def __init__(self, **kwargs):


### PR DESCRIPTION
## Summary

Importing anything from `lerobot.policies` crashes on Python 3.12 with:

```
TypeError: non-default argument 'backbone_cfg' follows default argument
```

`lerobot/policies/__init__.py` eagerly imports groot, and `GR00TN15Config` in `groot_n1.py` defines 4 `field(init=False)` fields without a `default`. Python's dataclass `_init_fn` does not exclude `init=False` fields from the ordering check, so it raises `TypeError` at class definition time when those fields follow default fields inherited from `PretrainedConfig`.

**Reproduction** (Python 3.12, lerobot 0.5.1):
```python
# Any lerobot.policies.* import triggers lerobot/policies/__init__.py → groot → crash
from lerobot.policies.act.configuration_act import ACTConfig
# TypeError: non-default argument 'backbone_cfg' follows default argument
```

Note: bare `import lerobot` is unaffected — only `lerobot.policies.*` imports crash.

## Fix

Add `default=None` to the 4 `init=False` fields in `GR00TN15Config`. The existing `__init__` already overwrites all fields via `setattr(self, key, value)`, so semantics are unchanged.

## Test plan

```bash
python -m venv .venv && source .venv/bin/activate
pip install -e ".[dev]"
pytest tests/test_available.py -v --noconftest
```

`test_available_policies` and `test_print` both import from `lerobot.policies.*` and pass on Python 3.12 after this fix (they crashed before).