### PR TITLE
fix(feetech): handle wrap boundary in _get_half_turn_homings

### DIFF
--- a/src/lerobot/motors/feetech/feetech.py
+++ b/src/lerobot/motors/feetech/feetech.py
@@ -276,7 +276,13 @@ class FeetechMotorsBus(SerialMotorsBus):
         for motor, pos in positions.items():
             model = self._get_motor_model(motor)
             max_res = self.model_resolution_table[model] - 1
-            half_turn_homings[motor] = pos - int(max_res / 2)
+            full_range = max_res + 1
+            midpoint = max_res // 2
+            offset = (pos - midpoint) % full_range
+            if offset > full_range // 2:
+                offset -= full_range
+            max_magnitude = full_range // 2 - 1
+            half_turn_homings[motor] = max(-max_magnitude, min(max_magnitude, offset))
 
         return half_turn_homings
 

--- a/tests/motors/test_feetech.py
+++ b/tests/motors/test_feetech.py
@@ -429,6 +429,22 @@ def test_set_half_turn_homings(mock_motors, dummy_motors):
     assert all(mock_motors.stubs[stub].wait_called() for stub in write_homing_stubs)
 
 
+def test_set_half_turn_homings_at_wrap_boundary(dummy_motors):
+    """Regression test for huggingface/lerobot#1296.
+
+    A Feetech motor parked at the encoder's wrap boundary (raw 4095) must not
+    crash the calibration pipeline. Without the wrap fix, ``pos - max_res // 2``
+    produces offset 2048 at ``pos = 4095``, which ``encode_sign_magnitude`` then
+    rejects because the 11-bit Homing_Offset register can only hold magnitudes
+    up to 2047.
+    """
+    bus = FeetechMotorsBus(port="/dev/dummy-port", motors=dummy_motors)
+    for motor in dummy_motors:
+        offset = bus._get_half_turn_homings({motor: 4095})[motor]
+        assert abs(offset) <= 2047, f"offset {offset} exceeds 11-bit register capacity"
+        encode_sign_magnitude(offset, 11)  # must not raise
+
+
 def test_record_ranges_of_motion(mock_motors, dummy_motors):
     positions = {
         1: [351, 42, 1337],


### PR DESCRIPTION
The naive `pos - max_res // 2` produces an offset of magnitude 2048 when a motor is parked at `max_res` (the 0/4095 encoder wrap boundary), which exceeds the 11-bit Homing_Offset register and raises `ValueError: Magnitude 2048 exceeds 2047` from `encode_sign_magnitude`.

This is reachable on continuous-rotation joints like the SO-101 wrist_roll whenever the motor happens to be physically sitting on the wrap boundary at calibration time.

Wrap the computed offset into the shortest signed distance around the encoder's circular domain, then clamp to the register capacity. For any `pos` in [0, max_res - 1] this produces the same value as the original formula (preserved by the existing test); only the crashing edge `pos == max_res` is changed.


## Related issues

This should fix https://github.com/huggingface/lerobot/issues/1296 
If related to https://github.com/huggingface/lerobot/pull/3348

## What changed

- created test case to reproduced the issue
- prevent overflow in half_turn_homings

## How was this tested (or how to run locally)

- tests/motors/repro_feetech_homing_boundary.py can run on a raw motor

- on the arm 
    - turn the wrist all the way to the left
    - run calibration
    - turn the wrist all the way to the right
    - run calibration again -> an error will show up
