### PR TITLE
feat(envs): add RoboCasa365 benchmark integration

### DIFF
--- a/.github/workflows/benchmark_tests.yml
+++ b/.github/workflows/benchmark_tests.yml
@@ -310,3 +310,93 @@ jobs:
           name: metaworld-metrics
           path: /tmp/metaworld-artifacts/metrics.json
           if-no-files-found: warn
+
+  # ── ROBOCASA365 ──────────────────────────────────────────────────────────
+  # Isolated image: lerobot[robocasa] only (robocasa, robosuite, mujoco chain)
+  robocasa-integration-test:
+    name: RoboCasa365 — build image + 1-episode eval
+    runs-on:
+      group: aws-g6-4xlarge-plus
+    env:
+      HF_USER_TOKEN: ${{ secrets.LEROBOT_HF_USER }}
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+          lfs: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3 # zizmor: ignore[unpinned-uses]
+        with:
+          cache-binary: false
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3 # zizmor: ignore[unpinned-uses]
+        with:
+          username: ${{ secrets.DOCKERHUB_LEROBOT_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_LEROBOT_PASSWORD }}
+
+      - name: Build RoboCasa365 benchmark image
+        uses: docker/build-push-action@v6 # zizmor: ignore[unpinned-uses]
+        with:
+          context: .
+          file: docker/Dockerfile.benchmark.robocasa
+          push: false
+          load: true
+          tags: lerobot-benchmark-robocasa:ci
+
+      - name: Run RoboCasa365 smoke eval (1 episode)
+        if: env.HF_USER_TOKEN != ''
+        run: |
+          docker run --name robocasa-eval --gpus all \
+            --shm-size=4g \
+            -e HF_HOME=/tmp/hf \
+            -e HF_USER_TOKEN="${HF_USER_TOKEN}" \
+            -e HF_HUB_DOWNLOAD_TIMEOUT=300 \
+            -e MUJOCO_GL=egl \
+            lerobot-benchmark-robocasa:ci \
+            bash -c "
+              hf auth login --token \"\$HF_USER_TOKEN\" --add-to-git-credential 2>/dev/null || true
+              lerobot-eval \
+                --policy.path=pepijn223/smolvla_robocasa \
+                --env.type=robocasa \
+                --env.task=CloseFridge \
+                --eval.batch_size=1 \
+                --eval.n_episodes=1 \
+                --eval.use_async_envs=false \
+                --policy.device=cuda \
+                --output_dir=/tmp/eval-artifacts
+            "
+
+      - name: Copy RoboCasa365 artifacts from container
+        if: always()
+        run: |
+          mkdir -p /tmp/robocasa-artifacts
+          docker cp robocasa-eval:/tmp/eval-artifacts/. /tmp/robocasa-artifacts/ 2>/dev/null || true
+          docker rm -f robocasa-eval || true
+
+      - name: Parse RoboCasa365 eval metrics
+        if: always()
+        run: |
+          python3 scripts/ci/parse_eval_metrics.py \
+            --artifacts-dir /tmp/robocasa-artifacts \
+            --env robocasa \
+            --task CloseFridge \
+            --policy pepijn223/smolvla_robocasa
+
+      - name: Upload RoboCasa365 rollout video
+        if: always()
+        uses: actions/upload-artifact@v4 # zizmor: ignore[unpinned-uses]
+        with:
+          name: robocasa-rollout-video
+          path: /tmp/robocasa-artifacts/videos/
+          if-no-files-found: warn
+
+      - name: Upload RoboCasa365 eval metrics
+        if: always()
+        uses: actions/upload-artifact@v4 # zizmor: ignore[unpinned-uses]
+        with:
+          name: robocasa-metrics
+          path: /tmp/robocasa-artifacts/metrics.json
+          if-no-files-found: warn

--- a/.github/workflows/benchmark_tests.yml
+++ b/.github/workflows/benchmark_tests.yml
@@ -366,7 +366,7 @@ jobs:
                 --eval.n_episodes=1 \
                 --eval.use_async_envs=false \
                 --policy.device=cuda \
-                '--rename_map={\"observation.images.image\": \"observation.images.camera1\", \"observation.images.image2\": \"observation.images.camera2\", \"observation.images.image3\": \"observation.images.camera3\"}' \
+                '--rename_map={\"observation.images.robot0_agentview_left\": \"observation.images.camera1\", \"observation.images.robot0_eye_in_hand\": \"observation.images.camera2\", \"observation.images.robot0_agentview_right\": \"observation.images.camera3\"}' \
                 --output_dir=/tmp/eval-artifacts
             "
 

--- a/.github/workflows/benchmark_tests.yml
+++ b/.github/workflows/benchmark_tests.yml
@@ -83,10 +83,13 @@ jobs:
           cache-binary: false
 
       - name: Login to Docker Hub
+        if: ${{ env.DOCKERHUB_USERNAME != '' }}
         uses: docker/login-action@v3 # zizmor: ignore[unpinned-uses]
         with:
           username: ${{ secrets.DOCKERHUB_LEROBOT_USERNAME }}
           password: ${{ secrets.DOCKERHUB_LEROBOT_PASSWORD }}
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_LEROBOT_USERNAME }}
 
       # Build the benchmark-specific image. The Dockerfile separates dep-install
       # from source-copy, so code-only changes skip the slow uv-sync layer
@@ -238,10 +241,13 @@ jobs:
           cache-binary: false
 
       - name: Login to Docker Hub
+        if: ${{ env.DOCKERHUB_USERNAME != '' }}
         uses: docker/login-action@v3 # zizmor: ignore[unpinned-uses]
         with:
           username: ${{ secrets.DOCKERHUB_LEROBOT_USERNAME }}
           password: ${{ secrets.DOCKERHUB_LEROBOT_PASSWORD }}
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_LEROBOT_USERNAME }}
 
       - name: Build MetaWorld benchmark image
         uses: docker/build-push-action@v6 # zizmor: ignore[unpinned-uses]
@@ -334,10 +340,13 @@ jobs:
           cache-binary: false
 
       - name: Login to Docker Hub
+        if: ${{ env.DOCKERHUB_USERNAME != '' }}
         uses: docker/login-action@v3 # zizmor: ignore[unpinned-uses]
         with:
           username: ${{ secrets.DOCKERHUB_LEROBOT_USERNAME }}
           password: ${{ secrets.DOCKERHUB_LEROBOT_PASSWORD }}
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_LEROBOT_USERNAME }}
 
       - name: Build RoboCasa365 benchmark image
         uses: docker/build-push-action@v6 # zizmor: ignore[unpinned-uses]

--- a/.github/workflows/benchmark_tests.yml
+++ b/.github/workflows/benchmark_tests.yml
@@ -379,6 +379,10 @@ jobs:
                 --policy.device=cuda \
                 '--rename_map={\"observation.images.robot0_agentview_left\": \"observation.images.camera1\", \"observation.images.robot0_eye_in_hand\": \"observation.images.camera2\", \"observation.images.robot0_agentview_right\": \"observation.images.camera3\"}' \
                 --output_dir=/tmp/eval-artifacts
+              python scripts/ci/extract_task_descriptions.py \
+                --env robocasa \
+                --task CloseFridge,OpenCabinet,OpenDrawer,TurnOnMicrowave,TurnOffStove,CloseToasterOvenDoor,SlideDishwasherRack,TurnOnSinkFaucet,NavigateKitchen,TurnOnElectricKettle \
+                --output /tmp/eval-artifacts/task_descriptions.json
             "
 
       - name: Copy RoboCasa365 artifacts from container

--- a/.github/workflows/benchmark_tests.yml
+++ b/.github/workflows/benchmark_tests.yml
@@ -359,7 +359,7 @@ jobs:
             bash -c "
               hf auth login --token \"\$HF_USER_TOKEN\" --add-to-git-credential 2>/dev/null || true
               lerobot-eval \
-                --policy.path=pepijn223/smolvla_robocasa \
+                --policy.path=lerobot/smolvla_robocasa \
                 --env.type=robocasa \
                 --env.task=CloseFridge \
                 --eval.batch_size=1 \
@@ -383,7 +383,7 @@ jobs:
             --artifacts-dir /tmp/robocasa-artifacts \
             --env robocasa \
             --task CloseFridge \
-            --policy pepijn223/smolvla_robocasa
+            --policy lerobot/smolvla_robocasa
 
       - name: Upload RoboCasa365 rollout video
         if: always()

--- a/.github/workflows/benchmark_tests.yml
+++ b/.github/workflows/benchmark_tests.yml
@@ -346,7 +346,7 @@ jobs:
           load: true
           tags: lerobot-benchmark-robocasa:ci
 
-      - name: Run RoboCasa365 smoke eval (1 episode)
+      - name: Run RoboCasa365 smoke eval (10 atomic tasks, 1 episode each)
         if: env.HF_USER_TOKEN != ''
         run: |
           docker run --name robocasa-eval --gpus all \
@@ -361,7 +361,7 @@ jobs:
               lerobot-eval \
                 --policy.path=lerobot/smolvla_robocasa \
                 --env.type=robocasa \
-                --env.task=CloseFridge \
+                --env.task=CloseFridge,OpenCabinet,OpenDrawer,TurnOnMicrowave,TurnOffStove,CloseToasterOvenDoor,SlideDishwasherRack,TurnOnSinkFaucet,NavigateKitchen,TurnOnElectricKettle \
                 --eval.batch_size=1 \
                 --eval.n_episodes=1 \
                 --eval.use_async_envs=false \
@@ -383,7 +383,7 @@ jobs:
           python3 scripts/ci/parse_eval_metrics.py \
             --artifacts-dir /tmp/robocasa-artifacts \
             --env robocasa \
-            --task CloseFridge \
+            --task atomic_smoke_10 \
             --policy lerobot/smolvla_robocasa
 
       - name: Upload RoboCasa365 rollout video

--- a/.github/workflows/benchmark_tests.yml
+++ b/.github/workflows/benchmark_tests.yml
@@ -366,6 +366,7 @@ jobs:
                 --eval.n_episodes=1 \
                 --eval.use_async_envs=false \
                 --policy.device=cuda \
+                '--rename_map={\"observation.images.image\": \"observation.images.camera1\", \"observation.images.image2\": \"observation.images.camera2\", \"observation.images.image3\": \"observation.images.camera3\"}' \
                 --output_dir=/tmp/eval-artifacts
             "
 

--- a/.github/workflows/benchmark_tests.yml
+++ b/.github/workflows/benchmark_tests.yml
@@ -312,7 +312,9 @@ jobs:
           if-no-files-found: warn
 
   # ── ROBOCASA365 ──────────────────────────────────────────────────────────
-  # Isolated image: lerobot[robocasa] only (robocasa, robosuite, mujoco chain)
+  # Isolated image: robocasa + robosuite installed manually as editable
+  # clones (no `lerobot[robocasa]` extra — robocasa's setup.py pins
+  # `lerobot==0.3.3`, which would shadow this repo's lerobot).
   robocasa-integration-test:
     name: RoboCasa365 — build image + 1-episode eval
     runs-on:

--- a/docker/Dockerfile.benchmark.robocasa
+++ b/docker/Dockerfile.benchmark.robocasa
@@ -37,4 +37,8 @@ RUN python -m robocasa.scripts.setup_macros && \
 # Overlay the PR's source code on top of the nightly image.
 COPY --chown=user_lerobot:user_lerobot . .
 
+# Re-install lerobot editably so the new source (with RoboCasaEnv registration)
+# replaces the stale package baked into the nightly image.
+RUN uv pip install --no-cache --no-deps -e .
+
 CMD ["/bin/bash"]

--- a/docker/Dockerfile.benchmark.robocasa
+++ b/docker/Dockerfile.benchmark.robocasa
@@ -21,9 +21,11 @@
 
 FROM huggingface/lerobot-gpu:latest
 
-# Install robocasa and its dependencies
-RUN pip install --no-cache-dir \
-    "robocasa @ git+https://github.com/robocasa/robocasa.git@v1.0.0" \
+# Install robocasa and its dependencies into the existing venv via uv pip.
+# The base image uses uv with a venv at /lerobot/.venv (PATH already set),
+# so `pip` is not available — use `uv pip install` instead.
+RUN uv pip install --no-cache \
+    "robocasa @ git+https://github.com/robocasa/robocasa.git" \
     "robosuite @ git+https://github.com/ARISE-Initiative/robosuite.git"
 
 # Set up robocasa macros and download kitchen assets

--- a/docker/Dockerfile.benchmark.robocasa
+++ b/docker/Dockerfile.benchmark.robocasa
@@ -28,14 +28,22 @@ FROM huggingface/lerobot-gpu:latest
 # `--no-deps` on robocasa is deliberate: its setup.py pins `lerobot==0.3.3`
 # in install_requires, which would shadow the editable lerobot baked into
 # this image. We install robocasa's actual runtime deps explicitly instead.
-RUN git clone --depth 1 https://github.com/robocasa/robocasa.git ~/robocasa && \
-    git clone --depth 1 https://github.com/ARISE-Initiative/robosuite.git ~/robosuite && \
+# Pinned SHAs for reproducible benchmark runs. Bump when you need an
+# upstream fix; don't rely on `main`/`master` drift.
+ARG ROBOCASA_SHA=56e355ccc64389dfc1b8a61a33b9127b975ba681
+ARG ROBOSUITE_SHA=aaa8b9b214ce8e77e82926d677b4d61d55e577ab
+RUN git clone https://github.com/robocasa/robocasa.git ~/robocasa && \
+    git -C ~/robocasa checkout ${ROBOCASA_SHA} && \
+    git clone https://github.com/ARISE-Initiative/robosuite.git ~/robosuite && \
+    git -C ~/robosuite checkout ${ROBOSUITE_SHA} && \
     uv pip install --no-cache -e ~/robocasa --no-deps && \
     uv pip install --no-cache -e ~/robosuite && \
     uv pip install --no-cache \
       "numpy==2.2.5" "numba==0.61.2" "scipy==1.15.3" "mujoco==3.3.1" \
-      pygame Pillow opencv-python pyyaml pynput tqdm termcolor \
-      imageio h5py lxml hidapi "tianshou==0.4.10" gymnasium
+      "pygame==2.6.1" "Pillow==12.2.0" "opencv-python==4.13.0.92" \
+      "pyyaml==6.0.3" "pynput==1.8.1" "tqdm==4.67.3" "termcolor==3.3.0" \
+      "imageio==2.37.3" "h5py==3.16.0" "lxml==6.0.4" "hidapi==0.14.0.post4" \
+      "tianshou==0.4.10" "gymnasium==1.2.3"
 
 # Set up robocasa macros and download kitchen assets. We need:
 #   - tex              : base environment textures

--- a/docker/Dockerfile.benchmark.robocasa
+++ b/docker/Dockerfile.benchmark.robocasa
@@ -28,12 +28,21 @@ RUN git clone --depth 1 https://github.com/robocasa/robocasa.git ~/robocasa && \
     git clone --depth 1 https://github.com/ARISE-Initiative/robosuite.git ~/robosuite && \
     uv pip install --no-cache -e ~/robocasa -e ~/robosuite
 
-# Set up robocasa macros and download kitchen assets. Include tex + fixtures_lw
-# + objs_lw (kitchen tasks reference lightwheel object meshes like stools); skip
-# objaverse/aigen object categories (~8GB extra, not used by the smoke tasks).
+# Set up robocasa macros and download kitchen assets. We need:
+#   - tex              : base environment textures
+#   - tex_generative   : AI-generated textures; kitchen fixture XMLs embed
+#                        refs to generative_textures/wall/tex*.png
+#                        unconditionally, so MjModel.from_xml_string fails
+#                        at reset time without them (even if the env is
+#                        constructed with generative_textures=None).
+#   - fixtures_lw      : lightwheel kitchen fixtures (fridge, counters...)
+#   - objs_lw          : lightwheel object meshes (stools, misc props)
+# We skip the objaverse/aigen object packs (~30GB combined) by pairing
+# this with --env.obj_registries=["lightwheel"] on the lerobot side.
 # The download script prompts interactively, so pipe 'y' to auto-accept.
 RUN python -m robocasa.scripts.setup_macros && \
-    yes y | python -m robocasa.scripts.download_kitchen_assets --type tex fixtures_lw objs_lw
+    yes y | python -m robocasa.scripts.download_kitchen_assets \
+      --type tex tex_generative fixtures_lw objs_lw
 
 # Overlay the PR's source code on top of the nightly image.
 COPY --chown=user_lerobot:user_lerobot . .

--- a/docker/Dockerfile.benchmark.robocasa
+++ b/docker/Dockerfile.benchmark.robocasa
@@ -1,0 +1,36 @@
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Benchmark image for RoboCasa365 integration tests.
+# Extends the nightly GPU image (which already has all extras installed)
+# with the PR's source code and RoboCasa-specific asset setup.
+#
+# Build:  docker build -f docker/Dockerfile.benchmark.robocasa -t lerobot-benchmark-robocasa .
+# Run:    docker run --gpus all --rm lerobot-benchmark-robocasa lerobot-eval ...
+
+FROM huggingface/lerobot-gpu:latest
+
+# Install robocasa and its dependencies
+RUN pip install --no-cache-dir \
+    "robocasa @ git+https://github.com/robocasa/robocasa.git@v1.0.0" \
+    "robosuite @ git+https://github.com/ARISE-Initiative/robosuite.git"
+
+# Set up robocasa macros and download kitchen assets
+RUN python -m robocasa.scripts.setup_macros && \
+    python -m robocasa.scripts.download_kitchen_assets
+
+# Overlay the PR's source code on top of the nightly image.
+COPY --chown=user_lerobot:user_lerobot . .
+
+CMD ["/bin/bash"]

--- a/docker/Dockerfile.benchmark.robocasa
+++ b/docker/Dockerfile.benchmark.robocasa
@@ -28,11 +28,12 @@ RUN git clone --depth 1 https://github.com/robocasa/robocasa.git ~/robocasa && \
     git clone --depth 1 https://github.com/ARISE-Initiative/robosuite.git ~/robosuite && \
     uv pip install --no-cache -e ~/robocasa -e ~/robosuite
 
-# Set up robocasa macros and download kitchen assets (textures + fixtures only —
-# skip objaverse/aigen objects to keep the image under size limits).
+# Set up robocasa macros and download kitchen assets. Include tex + fixtures_lw
+# + objs_lw (kitchen tasks reference lightwheel object meshes like stools); skip
+# objaverse/aigen object categories (~8GB extra, not used by the smoke tasks).
 # The download script prompts interactively, so pipe 'y' to auto-accept.
 RUN python -m robocasa.scripts.setup_macros && \
-    yes y | python -m robocasa.scripts.download_kitchen_assets --type tex fixtures_lw
+    yes y | python -m robocasa.scripts.download_kitchen_assets --type tex fixtures_lw objs_lw
 
 # Overlay the PR's source code on top of the nightly image.
 COPY --chown=user_lerobot:user_lerobot . .

--- a/docker/Dockerfile.benchmark.robocasa
+++ b/docker/Dockerfile.benchmark.robocasa
@@ -24,9 +24,18 @@ FROM huggingface/lerobot-gpu:latest
 # Install robocasa + robosuite as editable clones. pip-installing from git
 # omits data files like robocasa/models/assets/box_links/box_links_assets.json
 # (not declared in package_data), which download_kitchen_assets needs at import.
+#
+# `--no-deps` on robocasa is deliberate: its setup.py pins `lerobot==0.3.3`
+# in install_requires, which would shadow the editable lerobot baked into
+# this image. We install robocasa's actual runtime deps explicitly instead.
 RUN git clone --depth 1 https://github.com/robocasa/robocasa.git ~/robocasa && \
     git clone --depth 1 https://github.com/ARISE-Initiative/robosuite.git ~/robosuite && \
-    uv pip install --no-cache -e ~/robocasa -e ~/robosuite
+    uv pip install --no-cache -e ~/robocasa --no-deps && \
+    uv pip install --no-cache -e ~/robosuite && \
+    uv pip install --no-cache \
+      "numpy==2.2.5" "numba==0.61.2" "scipy==1.15.3" "mujoco==3.3.1" \
+      pygame Pillow opencv-python pyyaml pynput tqdm termcolor \
+      imageio h5py lxml hidapi "tianshou==0.4.10" gymnasium
 
 # Set up robocasa macros and download kitchen assets. We need:
 #   - tex              : base environment textures

--- a/docker/Dockerfile.benchmark.robocasa
+++ b/docker/Dockerfile.benchmark.robocasa
@@ -21,16 +21,18 @@
 
 FROM huggingface/lerobot-gpu:latest
 
-# Install robocasa and its dependencies into the existing venv via uv pip.
-# The base image uses uv with a venv at /lerobot/.venv (PATH already set),
-# so `pip` is not available — use `uv pip install` instead.
-RUN uv pip install --no-cache \
-    "robocasa @ git+https://github.com/robocasa/robocasa.git" \
-    "robosuite @ git+https://github.com/ARISE-Initiative/robosuite.git"
+# Install robocasa + robosuite as editable clones. pip-installing from git
+# omits data files like robocasa/models/assets/box_links/box_links_assets.json
+# (not declared in package_data), which download_kitchen_assets needs at import.
+RUN git clone --depth 1 https://github.com/robocasa/robocasa.git ~/robocasa && \
+    git clone --depth 1 https://github.com/ARISE-Initiative/robosuite.git ~/robosuite && \
+    uv pip install --no-cache -e ~/robocasa -e ~/robosuite
 
-# Set up robocasa macros and download kitchen assets
+# Set up robocasa macros and download kitchen assets (textures + fixtures only —
+# skip objaverse/aigen objects to keep the image under size limits).
+# The download script prompts interactively, so pipe 'y' to auto-accept.
 RUN python -m robocasa.scripts.setup_macros && \
-    python -m robocasa.scripts.download_kitchen_assets
+    yes y | python -m robocasa.scripts.download_kitchen_assets --type tex fixtures_lw
 
 # Overlay the PR's source code on top of the nightly image.
 COPY --chown=user_lerobot:user_lerobot . .

--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -79,6 +79,8 @@
     title: LIBERO
   - local: metaworld
     title: Meta-World
+  - local: robocasa
+    title: RoboCasa365
   - local: envhub_isaaclab_arena
     title: NVIDIA IsaacLab Arena Environments
   title: "Benchmarks"

--- a/docs/source/robocasa.mdx
+++ b/docs/source/robocasa.mdx
@@ -27,18 +27,32 @@ RoboCasa365 includes **365 tasks** organized into atomic (single-skill) and comp
 
 ## Installation
 
-After following the LeRobot installation instructions:
+RoboCasa and its dependency `robosuite` are not published on PyPI, and RoboCasa's own `setup.py` hardcodes `lerobot==0.3.3`, which conflicts with this repo's `lerobot`. Install them manually as editable clones (using `--no-deps` on `robocasa` to skip its shadowed `lerobot` pin):
 
 ```bash
-pip install -e ".[robocasa]"
+# After following the standard LeRobot installation instructions.
+
+git clone https://github.com/robocasa/robocasa.git ~/robocasa
+git clone https://github.com/ARISE-Initiative/robosuite.git ~/robosuite
+pip install -e ~/robocasa --no-deps
+pip install -e ~/robosuite
+
+# Robocasa's runtime deps (the ones its setup.py would have pulled,
+# minus the bad lerobot pin).
+pip install numpy numba scipy mujoco pygame Pillow opencv-python \
+            pyyaml pynput tqdm termcolor imageio h5py lxml hidapi \
+            tianshou gymnasium
+
 python -m robocasa.scripts.setup_macros
-# Lightweight assets only (lightwheel registry, ~2GB). Enough for the
-# default env out of the box.
-python -m robocasa.scripts.download_kitchen_assets --type tex fixtures_lw objs_lw
+# Lightweight assets only (lightwheel registry, ~2GB + the generative
+# textures needed by the fixture XMLs). Enough for the default env out
+# of the box.
+python -m robocasa.scripts.download_kitchen_assets \
+  --type tex tex_generative fixtures_lw objs_lw
 # Optional: full objaverse/aigen registries (~30GB) for richer object
 # variety. If you download these, pass them via `--env.obj_registries`
 # at eval/train time (see below).
-# python -m robocasa.scripts.download_kitchen_assets --type objaverse
+# python -m robocasa.scripts.download_kitchen_assets --type objs_objaverse
 ```
 
 <Tip>

--- a/docs/source/robocasa.mdx
+++ b/docs/source/robocasa.mdx
@@ -32,7 +32,13 @@ After following the LeRobot installation instructions:
 ```bash
 pip install -e ".[robocasa]"
 python -m robocasa.scripts.setup_macros
-python -m robocasa.scripts.download_kitchen_assets
+# Lightweight assets only (lightwheel registry, ~2GB). Enough for the
+# default env out of the box.
+python -m robocasa.scripts.download_kitchen_assets --type tex fixtures_lw objs_lw
+# Optional: full objaverse/aigen registries (~30GB) for richer object
+# variety. If you download these, pass them via `--env.obj_registries`
+# at eval/train time (see below).
+# python -m robocasa.scripts.download_kitchen_assets --type objaverse
 ```
 
 <Tip>
@@ -43,6 +49,12 @@ export MUJOCO_GL=egl  # for headless servers (HPC, cloud)
 ```
 
 </Tip>
+
+By default the env samples objects only from the `lightwheel` registry (the one shipped by `--type objs_lw`), which avoids a `Probabilities contain NaN` crash when the objaverse/aigen packs are absent. If you've downloaded the full asset set, enable it with:
+
+```bash
+--env.obj_registries='[objaverse,lightwheel]'
+```
 
 ## Policy inputs and outputs
 

--- a/docs/source/robocasa.mdx
+++ b/docs/source/robocasa.mdx
@@ -19,7 +19,11 @@ RoboCasa365 includes **365 tasks** organized into atomic (single-skill) and comp
 
 **Composite task categories:** baking, boiling, brewing, chopping food, clearing table, defrosting food, loading dishwasher, making tea, microwaving food, washing dishes, and many more.
 
-Pass individual task class names directly as `--env.task` (e.g., `CloseFridge`, `PickPlaceCoffee`). Multiple tasks can be comma-separated for multi-task evaluation.
+`--env.task` accepts three forms:
+
+- a single task name (e.g. `CloseFridge`)
+- a comma-separated list of task names (e.g. `CloseFridge,OpenBlenderLid`)
+- a benchmark-group shortcut — `atomic_seen`, `composite_seen`, `composite_unseen`, `pretrain50`, `pretrain100`, `pretrain200`, `pretrain300` — which auto-expands to the upstream task list and auto-sets the dataset `split` (`target` or `pretrain`).
 
 ## Installation
 
@@ -40,71 +44,82 @@ export MUJOCO_GL=egl  # for headless servers (HPC, cloud)
 
 </Tip>
 
-## Evaluation
+## Policy inputs and outputs
 
-### Single-task evaluation
+**Observations** (raw RoboCasa camera names are preserved verbatim):
 
-Evaluate a policy on a single RoboCasa task:
+- `observation.state` -- 16-dim proprioceptive state (base position, base quaternion, relative end-effector position, relative end-effector quaternion, gripper qpos)
+- `observation.images.robot0_agentview_left` -- left agent view, 256x256 HWC uint8
+- `observation.images.robot0_eye_in_hand` -- wrist camera view, 256x256 HWC uint8
+- `observation.images.robot0_agentview_right` -- right agent view, 256x256 HWC uint8
+
+**Actions:**
+
+- Continuous control in `Box(-1, 1, shape=(12,))` -- base motion (4D) + control mode (1D) + end-effector position (3D) + end-effector rotation (3D) + gripper (1D)
+
+## Training on a single task
+
+A ready-to-use single-task dataset is available on the Hub:
+[`pepijn223/robocasa_CloseFridge`](https://huggingface.co/datasets/pepijn223/robocasa_CloseFridge).
+
+Train a SmolVLA policy on `CloseFridge`:
+
+```bash
+lerobot-train \
+  --policy.type=smolvla \
+  --policy.repo_id=${HF_USER}/smolvla_robocasa_CloseFridge \
+  --policy.load_vlm_weights=true \
+  --policy.push_to_hub=true \
+  --dataset.repo_id=pepijn223/robocasa_CloseFridge \
+  --env.type=robocasa \
+  --env.task=CloseFridge \
+  --output_dir=./outputs/smolvla_robocasa_CloseFridge \
+  --steps=100000 \
+  --batch_size=4 \
+  --eval_freq=5000 \
+  --eval.batch_size=1 \
+  --eval.n_episodes=5 \
+  --save_freq=10000
+```
+
+Evaluate the trained checkpoint on the same task:
 
 ```bash
 lerobot-eval \
-  --policy.path="your-policy-id" \
+  --policy.path=${HF_USER}/smolvla_robocasa_CloseFridge \
   --env.type=robocasa \
   --env.task=CloseFridge \
   --eval.batch_size=1 \
   --eval.n_episodes=20
 ```
 
-### Multi-task evaluation
+## Multi-task evaluation
 
-Evaluate across multiple tasks at once by passing a comma-separated list:
+Evaluate across several tasks at once:
 
 ```bash
 lerobot-eval \
-  --policy.path="your-policy-id" \
+  --policy.path=your-policy-id \
   --env.type=robocasa \
   --env.task=CloseFridge,OpenBlenderLid,PickPlaceCoffee \
   --eval.batch_size=1 \
   --eval.n_episodes=20
 ```
 
-- `--env.task` accepts individual task names (comma-separated).
+Or run a full benchmark group:
+
+```bash
+lerobot-eval \
+  --policy.path=your-policy-id \
+  --env.type=robocasa \
+  --env.task=atomic_seen \
+  --eval.batch_size=1 \
+  --eval.n_episodes=20
+```
+
 - `--eval.batch_size` controls how many environments run in parallel.
 - `--eval.n_episodes` sets how many episodes to run per task.
-
-### Policy inputs and outputs
-
-**Observations:**
-
-- `observation.state` -- 16-dim proprioceptive state (base position, base quaternion, relative end-effector position, relative end-effector quaternion, gripper qpos)
-- `observation.images.image` -- left agent view (`robot0_agentview_left`), 256x256 HWC uint8
-- `observation.images.image2` -- wrist camera view (`robot0_eye_in_hand`), 256x256 HWC uint8
-- `observation.images.image3` -- right agent view (`robot0_agentview_right`), 256x256 HWC uint8
-
-**Actions:**
-
-- Continuous control in `Box(-1, 1, shape=(12,))` -- base motion (4D) + control mode (1D) + end-effector position (3D) + end-effector rotation (3D) + gripper (1D)
 
 ### Recommended evaluation episodes
 
 For reproducible benchmarking, use **20 episodes per task**. This matches the protocol used in published results.
-
-## Training
-
-### Example training command
-
-```bash
-lerobot-train \
-  --policy.type=smolvla \
-  --policy.repo_id=${HF_USER}/robocasa-test \
-  --policy.load_vlm_weights=true \
-  --dataset.repo_id=your-robocasa-dataset \
-  --env.type=robocasa \
-  --env.task=CloseFridge \
-  --output_dir=./outputs/ \
-  --steps=100000 \
-  --batch_size=4 \
-  --eval.batch_size=1 \
-  --eval.n_episodes=1 \
-  --eval_freq=1000
-```

--- a/docs/source/robocasa.mdx
+++ b/docs/source/robocasa.mdx
@@ -1,33 +1,35 @@
 # RoboCasa365
 
-RoboCasa365 is a large-scale simulation framework for training and benchmarking **generalist robots** in everyday kitchen tasks. It provides 365 diverse manipulation tasks across 2,500 kitchen environments, with over 3,200 object assets and 600+ hours of human demonstration data. The benchmark tests whether robots can handle the diversity and complexity of real-world household environments.
+[RoboCasa365](https://robocasa.ai) is a large-scale simulation framework for training and benchmarking **generalist robots** in everyday kitchen tasks. It ships 365 diverse manipulation tasks across 2,500 kitchen environments, 3,200+ object assets and 600+ hours of human demonstration data, on a PandaOmron 12-DOF mobile manipulator (Franka arm on a holonomic base).
 
-- Paper: [RoboCasa365: A Large-Scale Simulation Framework for Training and Benchmarking Generalist Robots](https://arxiv.org/abs/2603.04356)
+- Paper: [RoboCasa: Large-Scale Simulation of Everyday Tasks for Generalist Robots](https://arxiv.org/abs/2406.02523)
 - GitHub: [robocasa/robocasa](https://github.com/robocasa/robocasa)
 - Project website: [robocasa.ai](https://robocasa.ai)
+- Pretrained policy: [`lerobot/smolvla_robocasa`](https://huggingface.co/lerobot/smolvla_robocasa)
+- Single-task dataset (CloseFridge): [`pepijn223/robocasa_CloseFridge`](https://huggingface.co/datasets/pepijn223/robocasa_CloseFridge)
 
 ## Available tasks
 
-RoboCasa365 includes **365 tasks** organized into atomic (single-skill) and composite (multi-step) categories:
+RoboCasa365 organizes its 365 tasks into two families and three upstream benchmark groups that LeRobot exposes as first-class `--env.task` shortcuts:
 
-| Category  | Tasks | Description                                                                     |
+| Family    | Tasks | Description                                                                     |
 | --------- | ----- | ------------------------------------------------------------------------------- |
 | Atomic    | ~65   | Single-skill tasks: pick-and-place, door/drawer manipulation, appliance control |
 | Composite | ~300  | Multi-step tasks across 60+ categories: cooking, cleaning, organizing, etc.     |
 
-**Atomic task examples:** `CloseFridge`, `OpenBlenderLid`, `PickPlaceCoffee`, `ManipulateStoveKnob`, `NavigateKitchen`, `TurnOnToaster`
+**Atomic task examples:** `CloseFridge`, `OpenDrawer`, `OpenCabinet`, `TurnOnMicrowave`, `TurnOffStove`, `NavigateKitchen`, `PickPlaceCounterToStove`.
 
-**Composite task categories:** baking, boiling, brewing, chopping food, clearing table, defrosting food, loading dishwasher, making tea, microwaving food, washing dishes, and many more.
+**Composite task categories:** baking, boiling, brewing, chopping, clearing table, defrosting food, loading dishwasher, making tea, microwaving food, washing dishes, and more.
 
 `--env.task` accepts three forms:
 
-- a single task name (e.g. `CloseFridge`)
-- a comma-separated list of task names (e.g. `CloseFridge,OpenBlenderLid`)
+- a single task name (`CloseFridge`)
+- a comma-separated list (`CloseFridge,OpenBlenderLid,PickPlaceCoffee`)
 - a benchmark-group shortcut — `atomic_seen`, `composite_seen`, `composite_unseen`, `pretrain50`, `pretrain100`, `pretrain200`, `pretrain300` — which auto-expands to the upstream task list and auto-sets the dataset `split` (`target` or `pretrain`).
 
 ## Installation
 
-RoboCasa and its dependency `robosuite` are not published on PyPI, and RoboCasa's own `setup.py` hardcodes `lerobot==0.3.3`, which conflicts with this repo's `lerobot`. Install them manually as editable clones (using `--no-deps` on `robocasa` to skip its shadowed `lerobot` pin):
+RoboCasa and its dependency `robosuite` are not published on PyPI, and RoboCasa's own `setup.py` hardcodes `lerobot==0.3.3`, which conflicts with this repo's `lerobot`. LeRobot therefore does **not** expose a `robocasa` extra — install the two packages manually as editable clones (using `--no-deps` on `robocasa` to skip its shadowed `lerobot` pin):
 
 ```bash
 # After following the standard LeRobot installation instructions.
@@ -37,26 +39,24 @@ git clone https://github.com/ARISE-Initiative/robosuite.git ~/robosuite
 pip install -e ~/robocasa --no-deps
 pip install -e ~/robosuite
 
-# Robocasa's runtime deps (the ones its setup.py would have pulled,
-# minus the bad lerobot pin).
+# Robocasa's runtime deps (the ones its setup.py would have pulled, minus
+# the bad lerobot pin).
 pip install numpy numba scipy mujoco pygame Pillow opencv-python \
             pyyaml pynput tqdm termcolor imageio h5py lxml hidapi \
             tianshou gymnasium
 
 python -m robocasa.scripts.setup_macros
-# Lightweight assets only (lightwheel registry, ~2GB + the generative
-# textures needed by the fixture XMLs). Enough for the default env out
-# of the box.
+# Lightweight assets (lightwheel object meshes + textures). Enough for
+# the default env out of the box.
 python -m robocasa.scripts.download_kitchen_assets \
   --type tex tex_generative fixtures_lw objs_lw
 # Optional: full objaverse/aigen registries (~30GB) for richer object
-# variety. If you download these, pass them via `--env.obj_registries`
-# at eval/train time (see below).
+# variety. Enable at eval time via --env.obj_registries (see below).
 # python -m robocasa.scripts.download_kitchen_assets --type objs_objaverse
 ```
 
 <Tip>
-RoboCasa365 requires MuJoCo for simulation. Set the rendering backend before training or evaluation:
+RoboCasa requires MuJoCo. Set the rendering backend before training or evaluation:
 
 ```bash
 export MUJOCO_GL=egl  # for headless servers (HPC, cloud)
@@ -64,31 +64,78 @@ export MUJOCO_GL=egl  # for headless servers (HPC, cloud)
 
 </Tip>
 
-By default the env samples objects only from the `lightwheel` registry (the one shipped by `--type objs_lw`), which avoids a `Probabilities contain NaN` crash when the objaverse/aigen packs are absent. If you've downloaded the full asset set, enable it with:
+### Object registries
+
+By default the env samples objects only from the `lightwheel` registry (what `--type objs_lw` ships), which avoids a `Probabilities contain NaN` crash when the objaverse / aigen packs aren't on disk. If you've downloaded the full asset set, enable the full registry at runtime:
 
 ```bash
 --env.obj_registries='[objaverse,lightwheel]'
 ```
 
+## Evaluation
+
+### Single-task evaluation (recommended for quick iteration)
+
+```bash
+lerobot-eval \
+  --policy.path=lerobot/smolvla_robocasa \
+  --env.type=robocasa \
+  --env.task=CloseFridge \
+  --eval.batch_size=1 \
+  --eval.n_episodes=20
+```
+
+### Multi-task evaluation
+
+Pass a comma-separated list of tasks:
+
+```bash
+lerobot-eval \
+  --policy.path=lerobot/smolvla_robocasa \
+  --env.type=robocasa \
+  --env.task=CloseFridge,OpenCabinet,OpenDrawer,TurnOnMicrowave,TurnOffStove \
+  --eval.batch_size=1 \
+  --eval.n_episodes=20
+```
+
+### Benchmark-group evaluation
+
+Run an entire upstream group (e.g. all 18 `atomic_seen` tasks with `split=target`):
+
+```bash
+lerobot-eval \
+  --policy.path=lerobot/smolvla_robocasa \
+  --env.type=robocasa \
+  --env.task=atomic_seen \
+  --eval.batch_size=1 \
+  --eval.n_episodes=20
+```
+
+### Recommended evaluation episodes
+
+**20 episodes per task** for reproducible benchmarking. Matches the protocol used in published results.
+
 ## Policy inputs and outputs
 
 **Observations** (raw RoboCasa camera names are preserved verbatim):
 
-- `observation.state` -- 16-dim proprioceptive state (base position, base quaternion, relative end-effector position, relative end-effector quaternion, gripper qpos)
-- `observation.images.robot0_agentview_left` -- left agent view, 256x256 HWC uint8
-- `observation.images.robot0_eye_in_hand` -- wrist camera view, 256x256 HWC uint8
-- `observation.images.robot0_agentview_right` -- right agent view, 256x256 HWC uint8
+- `observation.state` — 16-dim proprioceptive state (base position, base quaternion, relative end-effector position, relative end-effector quaternion, gripper qpos)
+- `observation.images.robot0_agentview_left` — left agent view, 256×256 HWC uint8
+- `observation.images.robot0_eye_in_hand` — wrist camera view, 256×256 HWC uint8
+- `observation.images.robot0_agentview_right` — right agent view, 256×256 HWC uint8
 
 **Actions:**
 
-- Continuous control in `Box(-1, 1, shape=(12,))` -- base motion (4D) + control mode (1D) + end-effector position (3D) + end-effector rotation (3D) + gripper (1D)
+- Continuous control in `Box(-1, 1, shape=(12,))` — base motion (4D) + control mode (1D) + end-effector position (3D) + end-effector rotation (3D) + gripper (1D).
 
-## Training on a single task
+## Training
 
-A ready-to-use single-task dataset is available on the Hub:
+### Single-task example
+
+A ready-to-use single-task dataset is on the Hub:
 [`pepijn223/robocasa_CloseFridge`](https://huggingface.co/datasets/pepijn223/robocasa_CloseFridge).
 
-Train a SmolVLA policy on `CloseFridge`:
+Fine-tune a SmolVLA base on `CloseFridge`:
 
 ```bash
 lerobot-train \
@@ -108,7 +155,7 @@ lerobot-train \
   --save_freq=10000
 ```
 
-Evaluate the trained checkpoint on the same task:
+Evaluate the resulting checkpoint:
 
 ```bash
 lerobot-eval \
@@ -119,33 +166,6 @@ lerobot-eval \
   --eval.n_episodes=20
 ```
 
-## Multi-task evaluation
+## Reproducing published results
 
-Evaluate across several tasks at once:
-
-```bash
-lerobot-eval \
-  --policy.path=your-policy-id \
-  --env.type=robocasa \
-  --env.task=CloseFridge,OpenBlenderLid,PickPlaceCoffee \
-  --eval.batch_size=1 \
-  --eval.n_episodes=20
-```
-
-Or run a full benchmark group:
-
-```bash
-lerobot-eval \
-  --policy.path=your-policy-id \
-  --env.type=robocasa \
-  --env.task=atomic_seen \
-  --eval.batch_size=1 \
-  --eval.n_episodes=20
-```
-
-- `--eval.batch_size` controls how many environments run in parallel.
-- `--eval.n_episodes` sets how many episodes to run per task.
-
-### Recommended evaluation episodes
-
-For reproducible benchmarking, use **20 episodes per task**. This matches the protocol used in published results.
+The released checkpoint [`lerobot/smolvla_robocasa`](https://huggingface.co/lerobot/smolvla_robocasa) is evaluated with the commands in the [Evaluation](#evaluation) section. CI runs a 10-atomic-task smoke eval (one episode each) on every PR touching the benchmark, picking fixture-centric tasks that don't require the objaverse asset pack.

--- a/docs/source/robocasa.mdx
+++ b/docs/source/robocasa.mdx
@@ -1,0 +1,110 @@
+# RoboCasa365
+
+RoboCasa365 is a large-scale simulation framework for training and benchmarking **generalist robots** in everyday kitchen tasks. It provides 365 diverse manipulation tasks across 2,500 kitchen environments, with over 3,200 object assets and 600+ hours of human demonstration data. The benchmark tests whether robots can handle the diversity and complexity of real-world household environments.
+
+- Paper: [RoboCasa365: A Large-Scale Simulation Framework for Training and Benchmarking Generalist Robots](https://arxiv.org/abs/2603.04356)
+- GitHub: [robocasa/robocasa](https://github.com/robocasa/robocasa)
+- Project website: [robocasa.ai](https://robocasa.ai)
+
+## Available tasks
+
+RoboCasa365 includes **365 tasks** organized into atomic (single-skill) and composite (multi-step) categories:
+
+| Category  | Tasks | Description                                                                     |
+| --------- | ----- | ------------------------------------------------------------------------------- |
+| Atomic    | ~65   | Single-skill tasks: pick-and-place, door/drawer manipulation, appliance control |
+| Composite | ~300  | Multi-step tasks across 60+ categories: cooking, cleaning, organizing, etc.     |
+
+**Atomic task examples:** `CloseFridge`, `OpenBlenderLid`, `PickPlaceCoffee`, `ManipulateStoveKnob`, `NavigateKitchen`, `TurnOnToaster`
+
+**Composite task categories:** baking, boiling, brewing, chopping food, clearing table, defrosting food, loading dishwasher, making tea, microwaving food, washing dishes, and many more.
+
+Pass individual task class names directly as `--env.task` (e.g., `CloseFridge`, `PickPlaceCoffee`). Multiple tasks can be comma-separated for multi-task evaluation.
+
+## Installation
+
+After following the LeRobot installation instructions:
+
+```bash
+pip install -e ".[robocasa]"
+python -m robocasa.scripts.setup_macros
+python -m robocasa.scripts.download_kitchen_assets
+```
+
+<Tip>
+RoboCasa365 requires MuJoCo for simulation. Set the rendering backend before training or evaluation:
+
+```bash
+export MUJOCO_GL=egl  # for headless servers (HPC, cloud)
+```
+
+</Tip>
+
+## Evaluation
+
+### Single-task evaluation
+
+Evaluate a policy on a single RoboCasa task:
+
+```bash
+lerobot-eval \
+  --policy.path="your-policy-id" \
+  --env.type=robocasa \
+  --env.task=CloseFridge \
+  --eval.batch_size=1 \
+  --eval.n_episodes=20
+```
+
+### Multi-task evaluation
+
+Evaluate across multiple tasks at once by passing a comma-separated list:
+
+```bash
+lerobot-eval \
+  --policy.path="your-policy-id" \
+  --env.type=robocasa \
+  --env.task=CloseFridge,OpenBlenderLid,PickPlaceCoffee \
+  --eval.batch_size=1 \
+  --eval.n_episodes=20
+```
+
+- `--env.task` accepts individual task names (comma-separated).
+- `--eval.batch_size` controls how many environments run in parallel.
+- `--eval.n_episodes` sets how many episodes to run per task.
+
+### Policy inputs and outputs
+
+**Observations:**
+
+- `observation.state` -- 16-dim proprioceptive state (base position, base quaternion, relative end-effector position, relative end-effector quaternion, gripper qpos)
+- `observation.images.image` -- left agent view (`robot0_agentview_left`), 256x256 HWC uint8
+- `observation.images.image2` -- wrist camera view (`robot0_eye_in_hand`), 256x256 HWC uint8
+- `observation.images.image3` -- right agent view (`robot0_agentview_right`), 256x256 HWC uint8
+
+**Actions:**
+
+- Continuous control in `Box(-1, 1, shape=(12,))` -- base motion (4D) + control mode (1D) + end-effector position (3D) + end-effector rotation (3D) + gripper (1D)
+
+### Recommended evaluation episodes
+
+For reproducible benchmarking, use **20 episodes per task**. This matches the protocol used in published results.
+
+## Training
+
+### Example training command
+
+```bash
+lerobot-train \
+  --policy.type=smolvla \
+  --policy.repo_id=${HF_USER}/robocasa-test \
+  --policy.load_vlm_weights=true \
+  --dataset.repo_id=your-robocasa-dataset \
+  --env.type=robocasa \
+  --env.task=CloseFridge \
+  --output_dir=./outputs/ \
+  --steps=100000 \
+  --batch_size=4 \
+  --eval.batch_size=1 \
+  --eval.n_episodes=1 \
+  --eval_freq=1000
+```

--- a/docs/source/robocasa.mdx
+++ b/docs/source/robocasa.mdx
@@ -8,6 +8,12 @@
 - Pretrained policy: [`lerobot/smolvla_robocasa`](https://huggingface.co/lerobot/smolvla_robocasa)
 - Single-task dataset (CloseFridge): [`pepijn223/robocasa_CloseFridge`](https://huggingface.co/datasets/pepijn223/robocasa_CloseFridge)
 
+<img
+  src="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/lerobot/robocasa-banner.webp"
+  alt="RoboCasa365 benchmark overview"
+  width="85%"
+/>
+
 ## Available tasks
 
 RoboCasa365 organizes its 365 tasks into two families and three upstream benchmark groups that LeRobot exposes as first-class `--env.task` shortcuts:

--- a/docs/source/robocasa.mdx
+++ b/docs/source/robocasa.mdx
@@ -74,6 +74,8 @@ By default the env samples objects only from the `lightwheel` registry (what `--
 
 ## Evaluation
 
+All eval snippets below mirror the CI command (see `.github/workflows/benchmark_tests.yml`). The `--rename_map` argument maps RoboCasa's native camera keys (`robot0_agentview_left` / `robot0_eye_in_hand` / `robot0_agentview_right`) onto the three-camera (`camera1` / `camera2` / `camera3`) input layout the released `smolvla_robocasa` policy was trained on.
+
 ### Single-task evaluation (recommended for quick iteration)
 
 ```bash
@@ -82,7 +84,10 @@ lerobot-eval \
   --env.type=robocasa \
   --env.task=CloseFridge \
   --eval.batch_size=1 \
-  --eval.n_episodes=20
+  --eval.n_episodes=20 \
+  --eval.use_async_envs=false \
+  --policy.device=cuda \
+  '--rename_map={"observation.images.robot0_agentview_left": "observation.images.camera1", "observation.images.robot0_eye_in_hand": "observation.images.camera2", "observation.images.robot0_agentview_right": "observation.images.camera3"}'
 ```
 
 ### Multi-task evaluation
@@ -95,7 +100,10 @@ lerobot-eval \
   --env.type=robocasa \
   --env.task=CloseFridge,OpenCabinet,OpenDrawer,TurnOnMicrowave,TurnOffStove \
   --eval.batch_size=1 \
-  --eval.n_episodes=20
+  --eval.n_episodes=20 \
+  --eval.use_async_envs=false \
+  --policy.device=cuda \
+  '--rename_map={"observation.images.robot0_agentview_left": "observation.images.camera1", "observation.images.robot0_eye_in_hand": "observation.images.camera2", "observation.images.robot0_agentview_right": "observation.images.camera3"}'
 ```
 
 ### Benchmark-group evaluation
@@ -108,7 +116,10 @@ lerobot-eval \
   --env.type=robocasa \
   --env.task=atomic_seen \
   --eval.batch_size=1 \
-  --eval.n_episodes=20
+  --eval.n_episodes=20 \
+  --eval.use_async_envs=false \
+  --policy.device=cuda \
+  '--rename_map={"observation.images.robot0_agentview_left": "observation.images.camera1", "observation.images.robot0_eye_in_hand": "observation.images.camera2", "observation.images.robot0_agentview_right": "observation.images.camera3"}'
 ```
 
 ### Recommended evaluation episodes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -206,6 +206,7 @@ aloha = ["lerobot[dataset]", "gym-aloha>=0.1.2,<0.2.0", "lerobot[scipy-dep]"]
 pusht = ["lerobot[dataset]", "gym-pusht>=0.1.5,<0.2.0", "pymunk>=6.6.0,<7.0.0"] # TODO: Fix pymunk version in gym-pusht instead
 libero = ["lerobot[dataset]", "lerobot[transformers-dep]", "hf-libero>=0.1.3,<0.2.0; sys_platform == 'linux'", "lerobot[scipy-dep]"]
 metaworld = ["lerobot[dataset]", "metaworld==3.0.0", "lerobot[scipy-dep]"]
+robocasa = ["lerobot[dataset]", "robocasa @ git+https://github.com/robocasa/robocasa.git@v1.0.0", "robosuite @ git+https://github.com/ARISE-Initiative/robosuite.git", "lerobot[scipy-dep]"]
 
 # All
 all = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -206,7 +206,7 @@ aloha = ["lerobot[dataset]", "gym-aloha>=0.1.2,<0.2.0", "lerobot[scipy-dep]"]
 pusht = ["lerobot[dataset]", "gym-pusht>=0.1.5,<0.2.0", "pymunk>=6.6.0,<7.0.0"] # TODO: Fix pymunk version in gym-pusht instead
 libero = ["lerobot[dataset]", "lerobot[transformers-dep]", "hf-libero>=0.1.3,<0.2.0; sys_platform == 'linux'", "lerobot[scipy-dep]"]
 metaworld = ["lerobot[dataset]", "metaworld==3.0.0", "lerobot[scipy-dep]"]
-robocasa = ["lerobot[dataset]", "robocasa @ git+https://github.com/robocasa/robocasa.git@v1.0.0", "robosuite @ git+https://github.com/ARISE-Initiative/robosuite.git", "lerobot[scipy-dep]"]
+robocasa = ["lerobot[dataset]", "robocasa @ git+https://github.com/robocasa/robocasa.git", "robosuite @ git+https://github.com/ARISE-Initiative/robosuite.git", "lerobot[scipy-dep]"]
 
 # All
 all = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,7 +212,11 @@ aloha = ["lerobot[dataset]", "gym-aloha>=0.1.2,<0.2.0", "lerobot[scipy-dep]"]
 pusht = ["lerobot[dataset]", "gym-pusht>=0.1.5,<0.2.0", "pymunk>=6.6.0,<7.0.0"] # TODO: Fix pymunk version in gym-pusht instead
 libero = ["lerobot[dataset]", "lerobot[transformers-dep]", "hf-libero>=0.1.3,<0.2.0; sys_platform == 'linux'", "lerobot[scipy-dep]"]
 metaworld = ["lerobot[dataset]", "metaworld==3.0.0", "lerobot[scipy-dep]"]
-robocasa = ["lerobot[dataset]", "robocasa @ git+https://github.com/robocasa/robocasa.git", "robosuite @ git+https://github.com/ARISE-Initiative/robosuite.git", "lerobot[scipy-dep]"]
+# NOTE: robocasa is NOT exposed as a `lerobot` extra. Its setup.py pins
+# `lerobot==0.3.3` in install_requires, which cyclically shadows our own
+# workspace `lerobot` and makes the graph unsolvable under any resolver
+# (uv, pip). Install it manually alongside robosuite — see
+# docs/source/robocasa.mdx for the recipe.
 
 # All
 all = [

--- a/scripts/ci/extract_task_descriptions.py
+++ b/scripts/ci/extract_task_descriptions.py
@@ -57,6 +57,23 @@ def _metaworld_descriptions(task_name: str) -> dict[str, str]:
     return {f"{task_name}_0": label}
 
 
+def _robocasa_descriptions(task_spec: str) -> dict[str, str]:
+    """For each task in the comma-separated list, emit a cleaned-name label.
+
+    RoboCasa episodes carry their language instruction in the env's
+    `ep_meta['lang']`, populated per reset. Pulling it requires spinning
+    up the full kitchen env per task (~seconds each); we use the task
+    name as the key here and let the eval's episode info carry the
+    actual instruction.
+    """
+    out: dict[str, str] = {}
+    for task in (t.strip() for t in task_spec.split(",") if t.strip()):
+        # Split CamelCase into words: "CloseFridge" → "close fridge".
+        label = "".join(f" {c.lower()}" if c.isupper() else c for c in task).strip()
+        out[f"{task}_0"] = label or task
+    return out
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--env", required=True, help="Environment family (libero, metaworld, ...)")
@@ -70,6 +87,8 @@ def main() -> int:
             descriptions = _libero_descriptions(args.task)
         elif args.env == "metaworld":
             descriptions = _metaworld_descriptions(args.task)
+        elif args.env == "robocasa":
+            descriptions = _robocasa_descriptions(args.task)
         else:
             print(
                 f"[extract_task_descriptions] No description extractor for env '{args.env}'.",

--- a/src/lerobot/envs/configs.py
+++ b/src/lerobot/envs/configs.py
@@ -508,6 +508,12 @@ class RoboCasaEnv(EnvConfig):
     observation_height: int = 256
     observation_width: int = 256
     split: str | None = None
+    # Object-mesh registries to sample from. Upstream default is
+    # ("objaverse", "lightwheel"), but objaverse is ~30GB and the CI image
+    # only ships the lightwheel pack. Override to include objaverse once
+    # you've run `python -m robocasa.scripts.download_kitchen_assets
+    # --type objaverse` locally.
+    obj_registries: list[str] = field(default_factory=lambda: ["lightwheel"])
     features: dict[str, PolicyFeature] = field(
         default_factory=lambda: {ACTION: PolicyFeature(type=FeatureType.ACTION, shape=(12,))}
     )
@@ -557,6 +563,7 @@ class RoboCasaEnv(EnvConfig):
             gym_kwargs=self.gym_kwargs,
             env_cls=env_cls,
             episode_length=self.episode_length,
+            obj_registries=tuple(self.obj_registries),
         )
 
 

--- a/src/lerobot/envs/configs.py
+++ b/src/lerobot/envs/configs.py
@@ -496,6 +496,88 @@ class MetaworldEnv(EnvConfig):
         )
 
 
+@EnvConfig.register_subclass("robocasa")
+@dataclass
+class RoboCasaEnv(EnvConfig):
+    task: str = "CloseFridge"
+    fps: int = 20
+    episode_length: int = 1000
+    obs_type: str = "pixels_agent_pos"
+    render_mode: str = "rgb_array"
+    camera_name: str = "robot0_agentview_left,robot0_eye_in_hand,robot0_agentview_right"
+    camera_name_mapping: dict[str, str] | None = None
+    observation_height: int = 256
+    observation_width: int = 256
+    split: str | None = None
+    features: dict[str, PolicyFeature] = field(
+        default_factory=lambda: {
+            ACTION: PolicyFeature(type=FeatureType.ACTION, shape=(12,)),
+        }
+    )
+    features_map: dict[str, str] = field(
+        default_factory=lambda: {
+            ACTION: ACTION,
+            "agent_pos": OBS_STATE,
+            "pixels/image": f"{OBS_IMAGES}.image",
+            "pixels/image2": f"{OBS_IMAGES}.image2",
+            "pixels/image3": f"{OBS_IMAGES}.image3",
+        }
+    )
+
+    def __post_init__(self):
+        if self.obs_type == "pixels":
+            for cam_key in ["pixels/image", "pixels/image2", "pixels/image3"]:
+                self.features[cam_key] = PolicyFeature(
+                    type=FeatureType.VISUAL,
+                    shape=(self.observation_height, self.observation_width, 3),
+                )
+        elif self.obs_type == "pixels_agent_pos":
+            for cam_key in ["pixels/image", "pixels/image2", "pixels/image3"]:
+                self.features[cam_key] = PolicyFeature(
+                    type=FeatureType.VISUAL,
+                    shape=(self.observation_height, self.observation_width, 3),
+                )
+            self.features["agent_pos"] = PolicyFeature(type=FeatureType.STATE, shape=(16,))
+        else:
+            raise ValueError(f"Unsupported obs_type: {self.obs_type}")
+
+        if self.camera_name_mapping is not None:
+            # Update features_map to reflect custom camera name mapping
+            mapping = self.camera_name_mapping
+            cams = [c.strip() for c in self.camera_name.split(",") if c.strip()]
+            for cam in cams:
+                mapped = mapping.get(cam, cam)
+                self.features_map[f"pixels/{mapped}"] = f"{OBS_IMAGES}.{mapped}"
+
+    @property
+    def gym_kwargs(self) -> dict:
+        kwargs: dict[str, Any] = {
+            "obs_type": self.obs_type,
+            "render_mode": self.render_mode,
+            "observation_height": self.observation_height,
+            "observation_width": self.observation_width,
+        }
+        if self.split is not None:
+            kwargs["split"] = self.split
+        return kwargs
+
+    def create_envs(self, n_envs: int, use_async_envs: bool = False):
+        from .robocasa import create_robocasa_envs
+
+        if self.task is None:
+            raise ValueError("RoboCasaEnv requires a task to be specified")
+        env_cls = _make_vec_env_cls(use_async_envs, n_envs)
+        return create_robocasa_envs(
+            task=self.task,
+            n_envs=n_envs,
+            camera_name=self.camera_name,
+            camera_name_mapping=self.camera_name_mapping,
+            gym_kwargs=self.gym_kwargs,
+            env_cls=env_cls,
+            episode_length=self.episode_length,
+        )
+
+
 @EnvConfig.register_subclass("isaaclab_arena")
 @dataclass
 class IsaaclabArenaEnv(HubEnvConfig):

--- a/src/lerobot/envs/configs.py
+++ b/src/lerobot/envs/configs.py
@@ -507,6 +507,8 @@ class RoboCasaEnv(EnvConfig):
     camera_name: str = "robot0_agentview_left,robot0_eye_in_hand,robot0_agentview_right"
     observation_height: int = 256
     observation_width: int = 256
+    visualization_height: int = 512
+    visualization_width: int = 512
     split: str | None = None
     # Object-mesh registries to sample from. Upstream default is
     # ("objaverse", "lightwheel"), but objaverse is ~30GB and the CI image
@@ -545,6 +547,8 @@ class RoboCasaEnv(EnvConfig):
             "render_mode": self.render_mode,
             "observation_height": self.observation_height,
             "observation_width": self.observation_width,
+            "visualization_height": self.visualization_height,
+            "visualization_width": self.visualization_width,
         }
         if self.split is not None:
             kwargs["split"] = self.split

--- a/src/lerobot/envs/configs.py
+++ b/src/lerobot/envs/configs.py
@@ -505,49 +505,32 @@ class RoboCasaEnv(EnvConfig):
     obs_type: str = "pixels_agent_pos"
     render_mode: str = "rgb_array"
     camera_name: str = "robot0_agentview_left,robot0_eye_in_hand,robot0_agentview_right"
-    camera_name_mapping: dict[str, str] | None = None
     observation_height: int = 256
     observation_width: int = 256
     split: str | None = None
     features: dict[str, PolicyFeature] = field(
-        default_factory=lambda: {
-            ACTION: PolicyFeature(type=FeatureType.ACTION, shape=(12,)),
-        }
+        default_factory=lambda: {ACTION: PolicyFeature(type=FeatureType.ACTION, shape=(12,))}
     )
-    features_map: dict[str, str] = field(
-        default_factory=lambda: {
-            ACTION: ACTION,
-            "agent_pos": OBS_STATE,
-            "pixels/image": f"{OBS_IMAGES}.image",
-            "pixels/image2": f"{OBS_IMAGES}.image2",
-            "pixels/image3": f"{OBS_IMAGES}.image3",
-        }
-    )
+    features_map: dict[str, str] = field(default_factory=lambda: {ACTION: ACTION, "agent_pos": OBS_STATE})
 
     def __post_init__(self):
-        if self.obs_type == "pixels":
-            for cam_key in ["pixels/image", "pixels/image2", "pixels/image3"]:
-                self.features[cam_key] = PolicyFeature(
-                    type=FeatureType.VISUAL,
-                    shape=(self.observation_height, self.observation_width, 3),
-                )
-        elif self.obs_type == "pixels_agent_pos":
-            for cam_key in ["pixels/image", "pixels/image2", "pixels/image3"]:
-                self.features[cam_key] = PolicyFeature(
-                    type=FeatureType.VISUAL,
-                    shape=(self.observation_height, self.observation_width, 3),
-                )
-            self.features["agent_pos"] = PolicyFeature(type=FeatureType.STATE, shape=(16,))
-        else:
+        if self.obs_type not in ("pixels", "pixels_agent_pos"):
             raise ValueError(f"Unsupported obs_type: {self.obs_type}")
 
-        if self.camera_name_mapping is not None:
-            # Update features_map to reflect custom camera name mapping
-            mapping = self.camera_name_mapping
-            cams = [c.strip() for c in self.camera_name.split(",") if c.strip()]
-            for cam in cams:
-                mapped = mapping.get(cam, cam)
-                self.features_map[f"pixels/{mapped}"] = f"{OBS_IMAGES}.{mapped}"
+        # Preserve raw RoboCasa camera names end-to-end (e.g.
+        # `observation.images.robot0_agentview_left`). This matches the
+        # naming convention used by the RoboCasa datasets on the Hub, so
+        # trained policies don't need a `--rename_map` at eval time.
+        cams = [c.strip() for c in self.camera_name.split(",") if c.strip()]
+        for cam in cams:
+            self.features[f"pixels/{cam}"] = PolicyFeature(
+                type=FeatureType.VISUAL,
+                shape=(self.observation_height, self.observation_width, 3),
+            )
+            self.features_map[f"pixels/{cam}"] = f"{OBS_IMAGES}.{cam}"
+
+        if self.obs_type == "pixels_agent_pos":
+            self.features["agent_pos"] = PolicyFeature(type=FeatureType.STATE, shape=(16,))
 
     @property
     def gym_kwargs(self) -> dict:
@@ -571,7 +554,6 @@ class RoboCasaEnv(EnvConfig):
             task=self.task,
             n_envs=n_envs,
             camera_name=self.camera_name,
-            camera_name_mapping=self.camera_name_mapping,
             gym_kwargs=self.gym_kwargs,
             env_cls=env_cls,
             episode_length=self.episode_length,

--- a/src/lerobot/envs/libero.py
+++ b/src/lerobot/envs/libero.py
@@ -31,20 +31,7 @@ from libero.libero.envs import OffScreenRenderEnv
 
 from lerobot.types import RobotObservation
 
-from .utils import _LazyAsyncVectorEnv
-
-
-def _parse_camera_names(camera_name: str | Sequence[str]) -> list[str]:
-    """Normalize camera_name into a non-empty list of strings."""
-    if isinstance(camera_name, str):
-        cams = [c.strip() for c in camera_name.split(",") if c.strip()]
-    elif isinstance(camera_name, (list | tuple)):
-        cams = [str(c).strip() for c in camera_name if str(c).strip()]
-    else:
-        raise TypeError(f"camera_name must be str or sequence[str], got {type(camera_name).__name__}")
-    if not cams:
-        raise ValueError("camera_name resolved to an empty list.")
-    return cams
+from .utils import _LazyAsyncVectorEnv, parse_camera_names
 
 
 def _get_suite(name: str) -> benchmark.Benchmark:
@@ -128,7 +115,7 @@ class LiberoEnv(gym.Env):
         self.visualization_width = visualization_width
         self.visualization_height = visualization_height
         self.init_states = init_states
-        self.camera_name = _parse_camera_names(
+        self.camera_name = parse_camera_names(
             camera_name
         )  # agentview_image (main) or robot0_eye_in_hand_image (wrist)
 
@@ -437,7 +424,7 @@ def create_libero_envs(
     gym_kwargs = dict(gym_kwargs or {})
     task_ids_filter = gym_kwargs.pop("task_ids", None)  # optional: limit to specific tasks
 
-    camera_names = _parse_camera_names(camera_name)
+    camera_names = parse_camera_names(camera_name)
     suite_names = [s.strip() for s in str(task).split(",") if s.strip()]
     if not suite_names:
         raise ValueError("`task` must contain at least one LIBERO suite name.")

--- a/src/lerobot/envs/libero.py
+++ b/src/lerobot/envs/libero.py
@@ -449,6 +449,7 @@ def create_libero_envs(
         # Probe once and reuse to avoid creating a temp env per task.
         cached_obs_space: spaces.Space | None = None
         cached_act_space: spaces.Space | None = None
+        cached_metadata: dict[str, Any] | None = None
 
         for tid in selected:
             fns = _make_env_fns(
@@ -464,10 +465,11 @@ def create_libero_envs(
                 camera_name_mapping=camera_name_mapping,
             )
             if is_async:
-                lazy = _LazyAsyncVectorEnv(fns, cached_obs_space, cached_act_space)
+                lazy = _LazyAsyncVectorEnv(fns, cached_obs_space, cached_act_space, cached_metadata)
                 if cached_obs_space is None:
                     cached_obs_space = lazy.observation_space
                     cached_act_space = lazy.action_space
+                    cached_metadata = lazy.metadata
                 out[suite_name][tid] = lazy
             else:
                 out[suite_name][tid] = env_cls(fns)

--- a/src/lerobot/envs/metaworld.py
+++ b/src/lerobot/envs/metaworld.py
@@ -311,6 +311,7 @@ def create_metaworld_envs(
     is_async = env_cls is gym.vector.AsyncVectorEnv
     cached_obs_space = None
     cached_act_space = None
+    cached_metadata = None
     out: dict[str, dict[int, Any]] = defaultdict(dict)
 
     for group in task_groups:
@@ -324,10 +325,11 @@ def create_metaworld_envs(
             fns = [(lambda tn=task_name: MetaworldEnv(task=tn, **gym_kwargs)) for _ in range(n_envs)]
 
             if is_async:
-                lazy = _LazyAsyncVectorEnv(fns, cached_obs_space, cached_act_space)
+                lazy = _LazyAsyncVectorEnv(fns, cached_obs_space, cached_act_space, cached_metadata)
                 if cached_obs_space is None:
                     cached_obs_space = lazy.observation_space
                     cached_act_space = lazy.action_space
+                    cached_metadata = lazy.metadata
                 out[group][tid] = lazy
             else:
                 out[group][tid] = env_cls(fns)

--- a/src/lerobot/envs/robocasa.py
+++ b/src/lerobot/envs/robocasa.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 from __future__ import annotations
 
+import logging
 from collections import defaultdict
 from collections.abc import Callable, Sequence
 from functools import partial
@@ -27,6 +28,8 @@ from gymnasium import spaces
 from lerobot.types import RobotObservation
 
 from .utils import _LazyAsyncVectorEnv, parse_camera_names
+
+logger = logging.getLogger(__name__)
 
 # Dimensions for the flat action/state vectors used by the LeRobot wrapper.
 # These correspond to the PandaOmron robot in RoboCasa365.
@@ -249,11 +252,12 @@ class RoboCasaEnv(gym.Env):
         self._ensure_env()
         assert self._env is not None
         super().reset(seed=seed)
-        # Spread the user seed across workers. With n_envs factories each
-        # carrying a distinct `episode_index`, the same outer seed produces
-        # a different layout/trajectory per worker instead of all workers
-        # rolling the same scene.
-        worker_seed = seed + self.episode_index if seed is not None else None
+        # Spread the seed across workers so n_envs factories don't all
+        # roll the same scene. With an explicit user seed we shift it by
+        # episode_index; with no seed we fall back to episode_index so
+        # each worker is still distinct rather than inheriting the same
+        # global RNG state.
+        worker_seed = seed + self.episode_index if seed is not None else self.episode_index
         raw_obs, info = self._env.reset(seed=worker_seed)
 
         ep_meta = self._env.env.get_ep_meta()
@@ -377,7 +381,12 @@ def create_robocasa_envs(
     if group_split is not None and split is None:
         split = group_split
 
-    print(f"Creating RoboCasa envs | tasks={task_names} | split={split} | n_envs(per task)={n_envs}")
+    logger.info(
+        "Creating RoboCasa envs | tasks=%s | split=%s | n_envs(per task)=%d",
+        task_names,
+        split,
+        n_envs,
+    )
 
     is_async = env_cls is gym.vector.AsyncVectorEnv
 
@@ -411,6 +420,6 @@ def create_robocasa_envs(
             out[task_name][0] = lazy
         else:
             out[task_name][0] = env_cls(fns)
-        print(f"Built vec env | task={task_name} | n_envs={n_envs}")
+        logger.info("Built vec env | task=%s | n_envs=%d", task_name, n_envs)
 
     return {name: dict(task_map) for name, task_map in out.items()}

--- a/src/lerobot/envs/robocasa.py
+++ b/src/lerobot/envs/robocasa.py
@@ -182,13 +182,15 @@ class RoboCasaEnv(gym.Env):
             return
         from robocasa.wrappers.gym_wrapper import RoboCasaGymEnv
 
+        # RoboCasaGymEnv has a broken default split="test" (invalid for create_env
+        # which only accepts None/"all"/"pretrain"/"target"). Always pass a valid
+        # value so we don't hit that default.
         kwargs: dict[str, Any] = {
             "env_name": self.task,
             "camera_widths": self.observation_width,
             "camera_heights": self.observation_height,
+            "split": self.split if self.split is not None else "all",
         }
-        if self.split is not None:
-            kwargs["split"] = self.split
 
         self._env = RoboCasaGymEnv(**kwargs)
 

--- a/src/lerobot/envs/robocasa.py
+++ b/src/lerobot/envs/robocasa.py
@@ -1,0 +1,384 @@
+#!/usr/bin/env python
+
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Callable, Sequence
+from functools import partial
+from typing import Any
+
+import gymnasium as gym
+import numpy as np
+from gymnasium import spaces
+
+from lerobot.types import RobotObservation
+
+from .utils import _LazyAsyncVectorEnv
+
+# Dimensions for the flat action/state vectors used by the LeRobot wrapper.
+# These correspond to the PandaOmron robot in RoboCasa365.
+OBS_STATE_DIM = 16  # base_pos(3) + base_quat(4) + ee_pos_rel(3) + ee_quat_rel(4) + gripper_qpos(2)
+ACTION_DIM = 12  # base_motion(4) + control_mode(1) + ee_pos(3) + ee_rot(3) + gripper(1)
+ACTION_LOW = -1.0
+ACTION_HIGH = 1.0
+
+# Default cameras for the PandaOmron robot.
+DEFAULT_CAMERAS = [
+    "robot0_agentview_left",
+    "robot0_eye_in_hand",
+    "robot0_agentview_right",
+]
+
+# Map raw RoboCasa camera names to LeRobot convention names.
+DEFAULT_CAMERA_NAME_MAPPING = {
+    "robot0_agentview_left": "image",
+    "robot0_eye_in_hand": "image2",
+    "robot0_agentview_right": "image3",
+}
+
+
+def _parse_camera_names(camera_name: str | Sequence[str]) -> list[str]:
+    """Normalize camera_name into a non-empty list of strings."""
+    if isinstance(camera_name, str):
+        cams = [c.strip() for c in camera_name.split(",") if c.strip()]
+    elif isinstance(camera_name, (list | tuple)):
+        cams = [str(c).strip() for c in camera_name if str(c).strip()]
+    else:
+        raise TypeError(f"camera_name must be str or sequence[str], got {type(camera_name).__name__}")
+    if not cams:
+        raise ValueError("camera_name resolved to an empty list.")
+    return cams
+
+
+def convert_state(raw_obs: dict[str, np.ndarray]) -> np.ndarray:
+    """Concatenate RoboCasa robot state dict into a flat (16,) vector.
+
+    Layout: base_pos(3) + base_quat(4) + ee_pos_rel(3) + ee_quat_rel(4) + gripper_qpos(2)
+    """
+    return np.concatenate(
+        [
+            raw_obs["robot0_base_pos"],  # (3,)
+            raw_obs["robot0_base_quat"],  # (4,)
+            raw_obs["robot0_base_to_eef_pos"],  # (3,)
+            raw_obs["robot0_base_to_eef_quat"],  # (4,)
+            raw_obs["robot0_gripper_qpos"],  # (2,)
+        ],
+        axis=-1,
+    ).astype(np.float32)
+
+
+def convert_action(flat_action: np.ndarray) -> dict[str, Any]:
+    """Split a flat (12,) action vector into a RoboCasa action dict.
+
+    Layout: base_motion(4) + control_mode(1) + ee_pos(3) + ee_rot(3) + gripper(1)
+    """
+    return {
+        "action.base_motion": flat_action[0:4],
+        "action.control_mode": flat_action[4:5],
+        "action.end_effector_position": flat_action[5:8],
+        "action.end_effector_rotation": flat_action[8:11],
+        "action.gripper_close": flat_action[11:12],
+    }
+
+
+class RoboCasaEnv(gym.Env):
+    """LeRobot gym.Env wrapper for RoboCasa365 kitchen environments.
+
+    Wraps the RoboCasaGymEnv from the robocasa package and converts its
+    dict-based observations and actions into flat arrays compatible with
+    the LeRobot evaluation pipeline.
+    """
+
+    metadata = {"render_modes": ["rgb_array"], "render_fps": 20}
+
+    def __init__(
+        self,
+        task: str,
+        camera_name: str | Sequence[str] = ",".join(DEFAULT_CAMERAS),
+        camera_name_mapping: dict[str, str] | None = None,
+        obs_type: str = "pixels_agent_pos",
+        render_mode: str = "rgb_array",
+        observation_width: int = 256,
+        observation_height: int = 256,
+        split: str | None = None,
+        episode_length: int | None = None,
+    ):
+        super().__init__()
+        self.task = task
+        self.obs_type = obs_type
+        self.render_mode = render_mode
+        self.observation_width = observation_width
+        self.observation_height = observation_height
+        self.split = split
+
+        self.camera_name = _parse_camera_names(camera_name)
+        if camera_name_mapping is None:
+            camera_name_mapping = dict(DEFAULT_CAMERA_NAME_MAPPING)
+        self.camera_name_mapping = camera_name_mapping
+
+        self._max_episode_steps = episode_length if episode_length is not None else 1000
+
+        # Deferred — created on first reset() inside the worker subprocess
+        # to avoid inheriting stale GPU/EGL contexts across fork().
+        self._env = None
+        self.task_description = ""
+
+        # Build observation space
+        images = {}
+        for cam in self.camera_name:
+            mapped = self.camera_name_mapping.get(cam, cam)
+            images[mapped] = spaces.Box(
+                low=0,
+                high=255,
+                shape=(self.observation_height, self.observation_width, 3),
+                dtype=np.uint8,
+            )
+
+        if self.obs_type == "pixels":
+            self.observation_space = spaces.Dict({"pixels": spaces.Dict(images)})
+        elif self.obs_type == "pixels_agent_pos":
+            self.observation_space = spaces.Dict(
+                {
+                    "pixels": spaces.Dict(images),
+                    "agent_pos": spaces.Box(
+                        low=-np.inf,
+                        high=np.inf,
+                        shape=(OBS_STATE_DIM,),
+                        dtype=np.float32,
+                    ),
+                }
+            )
+        else:
+            raise ValueError(f"Unsupported obs_type '{self.obs_type}'. Use 'pixels' or 'pixels_agent_pos'.")
+
+        self.action_space = spaces.Box(
+            low=ACTION_LOW,
+            high=ACTION_HIGH,
+            shape=(ACTION_DIM,),
+            dtype=np.float32,
+        )
+
+    def _ensure_env(self) -> None:
+        """Create the underlying RoboCasaGymEnv on first use.
+
+        Called inside the worker subprocess after fork(), so each worker gets
+        its own clean rendering context rather than inheriting a stale one from
+        the parent process (which causes crashes with AsyncVectorEnv).
+        """
+        if self._env is not None:
+            return
+        from robocasa.wrappers.gym_wrapper import RoboCasaGymEnv
+
+        kwargs: dict[str, Any] = {
+            "env_name": self.task,
+            "camera_widths": self.observation_width,
+            "camera_heights": self.observation_height,
+        }
+        if self.split is not None:
+            kwargs["split"] = self.split
+
+        self._env = RoboCasaGymEnv(**kwargs)
+
+        # Extract task description from environment metadata
+        assert self._env is not None
+        ep_meta = self._env.env.get_ep_meta()
+        self.task_description = ep_meta.get("lang", self.task)
+
+    def _format_raw_obs(self, raw_obs: dict) -> RobotObservation:
+        """Convert RoboCasaGymEnv observation dict to LeRobot format."""
+        # Extract camera images (RoboCasaGymEnv provides "video.<cam>" keys)
+        images = {}
+        for cam in self.camera_name:
+            video_key = f"video.{cam}"
+            if video_key in raw_obs:
+                mapped = self.camera_name_mapping.get(cam, cam)
+                images[mapped] = raw_obs[video_key]
+
+        if self.obs_type == "pixels":
+            return {"pixels": images}
+
+        # Extract state from raw_obs (state.* keys from PandaOmronKeyConverter)
+        agent_pos = np.concatenate(
+            [
+                raw_obs.get("state.base_position", np.zeros(3)),
+                raw_obs.get("state.base_rotation", np.zeros(4)),
+                raw_obs.get("state.end_effector_position_relative", np.zeros(3)),
+                raw_obs.get("state.end_effector_rotation_relative", np.zeros(4)),
+                raw_obs.get("state.gripper_qpos", np.zeros(2)),
+            ],
+            axis=-1,
+        ).astype(np.float32)
+
+        return {
+            "pixels": images,
+            "agent_pos": agent_pos,
+        }
+
+    def render(self) -> np.ndarray:
+        self._ensure_env()
+        assert self._env is not None
+        return self._env.render()
+
+    def reset(self, seed=None, **kwargs):
+        self._ensure_env()
+        assert self._env is not None
+        super().reset(seed=seed)
+        raw_obs, info = self._env.reset(seed=seed)
+
+        # Update task description on each reset (may change per episode)
+        ep_meta = self._env.env.get_ep_meta()
+        self.task_description = ep_meta.get("lang", self.task)
+
+        observation = self._format_raw_obs(raw_obs)
+        info = {"is_success": False}
+        return observation, info
+
+    def step(self, action: np.ndarray) -> tuple[RobotObservation, float, bool, bool, dict[str, Any]]:
+        self._ensure_env()
+        assert self._env is not None
+        if action.ndim != 1:
+            raise ValueError(
+                f"Expected action to be 1-D (shape (action_dim,)), "
+                f"but got shape {action.shape} with ndim={action.ndim}"
+            )
+
+        # Convert flat action to RoboCasa dict format
+        action_dict = convert_action(action)
+        raw_obs, reward, done, truncated, info = self._env.step(action_dict)
+
+        is_success = bool(info.get("success", False))
+        terminated = done or is_success
+        info.update(
+            {
+                "task": self.task,
+                "done": done,
+                "is_success": is_success,
+            }
+        )
+
+        observation = self._format_raw_obs(raw_obs)
+        if terminated:
+            self.reset()
+
+        return observation, reward, terminated, truncated, info
+
+    def close(self):
+        if self._env is not None:
+            self._env.close()
+
+
+# ---- Main API ----------------------------------------------------------------
+
+
+def _make_env_fns(
+    *,
+    task: str,
+    n_envs: int,
+    camera_names: list[str],
+    camera_name_mapping: dict[str, str] | None,
+    obs_type: str,
+    render_mode: str,
+    observation_width: int,
+    observation_height: int,
+    split: str | None,
+    episode_length: int | None,
+) -> list[Callable[[], RoboCasaEnv]]:
+    """Build n_envs factory callables for a single task."""
+
+    def _make_env(**kwargs) -> RoboCasaEnv:
+        return RoboCasaEnv(
+            task=task,
+            camera_name=camera_names,
+            camera_name_mapping=camera_name_mapping,
+            obs_type=obs_type,
+            render_mode=render_mode,
+            observation_width=observation_width,
+            observation_height=observation_height,
+            split=split,
+            episode_length=episode_length,
+            **kwargs,
+        )
+
+    return [partial(_make_env) for _ in range(n_envs)]
+
+
+def create_robocasa_envs(
+    task: str,
+    n_envs: int,
+    gym_kwargs: dict[str, Any] | None = None,
+    camera_name: str | Sequence[str] = ",".join(DEFAULT_CAMERAS),
+    camera_name_mapping: dict[str, str] | None = None,
+    env_cls: Callable[[Sequence[Callable[[], Any]]], Any] | None = None,
+    episode_length: int | None = None,
+) -> dict[str, dict[int, Any]]:
+    """Create vectorized RoboCasa365 environments with a consistent return shape.
+
+    Returns:
+        dict[task_name][task_id] -> vec_env (env_cls([...]) with exactly n_envs factories)
+    Notes:
+        - n_envs is the number of rollouts *per task* (parallel environments).
+        - `task` can be a single task or a comma-separated list of tasks.
+    """
+    if env_cls is None or not callable(env_cls):
+        raise ValueError("env_cls must be a callable that wraps a list of environment factory callables.")
+    if not isinstance(n_envs, int) or n_envs <= 0:
+        raise ValueError(f"n_envs must be a positive int; got {n_envs}.")
+
+    gym_kwargs = dict(gym_kwargs or {})
+    obs_type = gym_kwargs.pop("obs_type", "pixels_agent_pos")
+    render_mode = gym_kwargs.pop("render_mode", "rgb_array")
+    observation_width = gym_kwargs.pop("observation_width", 256)
+    observation_height = gym_kwargs.pop("observation_height", 256)
+    split = gym_kwargs.pop("split", None)
+
+    camera_names = _parse_camera_names(camera_name)
+    task_names = [t.strip() for t in str(task).split(",") if t.strip()]
+    if not task_names:
+        raise ValueError("`task` must contain at least one RoboCasa task name.")
+
+    print(f"Creating RoboCasa envs | tasks={task_names} | n_envs(per task)={n_envs}")
+
+    is_async = env_cls is gym.vector.AsyncVectorEnv
+
+    cached_obs_space: spaces.Space | None = None
+    cached_act_space: spaces.Space | None = None
+    out: dict[str, dict[int, Any]] = defaultdict(dict)
+
+    for _tid, task_name in enumerate(task_names):
+        fns = _make_env_fns(
+            task=task_name,
+            n_envs=n_envs,
+            camera_names=camera_names,
+            camera_name_mapping=camera_name_mapping,
+            obs_type=obs_type,
+            render_mode=render_mode,
+            observation_width=observation_width,
+            observation_height=observation_height,
+            split=split,
+            episode_length=episode_length,
+        )
+
+        if is_async:
+            lazy = _LazyAsyncVectorEnv(fns, cached_obs_space, cached_act_space)
+            if cached_obs_space is None:
+                cached_obs_space = lazy.observation_space
+                cached_act_space = lazy.action_space
+            out[task_name][0] = lazy
+        else:
+            out[task_name][0] = env_cls(fns)
+        print(f"Built vec env | task={task_name} | n_envs={n_envs}")
+
+    return {name: dict(task_map) for name, task_map in out.items()}

--- a/src/lerobot/envs/robocasa.py
+++ b/src/lerobot/envs/robocasa.py
@@ -383,6 +383,7 @@ def create_robocasa_envs(
 
     cached_obs_space: spaces.Space | None = None
     cached_act_space: spaces.Space | None = None
+    cached_metadata: dict[str, Any] | None = None
     out: dict[str, dict[int, Any]] = defaultdict(dict)
 
     for task_name in task_names:
@@ -402,10 +403,11 @@ def create_robocasa_envs(
         )
 
         if is_async:
-            lazy = _LazyAsyncVectorEnv(fns, cached_obs_space, cached_act_space)
+            lazy = _LazyAsyncVectorEnv(fns, cached_obs_space, cached_act_space, cached_metadata)
             if cached_obs_space is None:
                 cached_obs_space = lazy.observation_space
                 cached_act_space = lazy.action_space
+                cached_metadata = lazy.metadata
             out[task_name][0] = lazy
         else:
             out[task_name][0] = env_cls(fns)

--- a/src/lerobot/envs/robocasa.py
+++ b/src/lerobot/envs/robocasa.py
@@ -26,7 +26,7 @@ from gymnasium import spaces
 
 from lerobot.types import RobotObservation
 
-from .utils import _LazyAsyncVectorEnv
+from .utils import _LazyAsyncVectorEnv, parse_camera_names
 
 # Dimensions for the flat action/state vectors used by the LeRobot wrapper.
 # These correspond to the PandaOmron robot in RoboCasa365.
@@ -67,19 +67,6 @@ _TASK_GROUP_SPLITS = {
     "pretrain200": "pretrain",
     "pretrain300": "pretrain",
 }
-
-
-def _parse_camera_names(camera_name: str | Sequence[str]) -> list[str]:
-    """Normalize camera_name into a non-empty list of strings."""
-    if isinstance(camera_name, str):
-        cams = [c.strip() for c in camera_name.split(",") if c.strip()]
-    elif isinstance(camera_name, (list | tuple)):
-        cams = [str(c).strip() for c in camera_name if str(c).strip()]
-    else:
-        raise TypeError(f"camera_name must be str or sequence[str], got {type(camera_name).__name__}")
-    if not cams:
-        raise ValueError("camera_name resolved to an empty list.")
-    return cams
 
 
 def _resolve_tasks(task: str) -> tuple[list[str], str | None]:
@@ -140,9 +127,12 @@ class RoboCasaEnv(gym.Env):
         render_mode: str = "rgb_array",
         observation_width: int = 256,
         observation_height: int = 256,
+        visualization_width: int = 512,
+        visualization_height: int = 512,
         split: str | None = None,
         episode_length: int | None = None,
         obj_registries: Sequence[str] = DEFAULT_OBJ_REGISTRIES,
+        episode_index: int = 0,
     ):
         super().__init__()
         self.task = task
@@ -150,10 +140,16 @@ class RoboCasaEnv(gym.Env):
         self.render_mode = render_mode
         self.observation_width = observation_width
         self.observation_height = observation_height
+        self.visualization_width = visualization_width
+        self.visualization_height = visualization_height
         self.split = split
         self.obj_registries = tuple(obj_registries)
+        # Per-worker index (0..n_envs-1) used to spread the user-provided
+        # seed across factories so each sub-env explores a distinct layout
+        # even when the same seed is passed to `reset()`.
+        self.episode_index = int(episode_index)
 
-        self.camera_name = _parse_camera_names(camera_name)
+        self.camera_name = parse_camera_names(camera_name)
 
         self._max_episode_steps = episode_length if episode_length is not None else 1000
 
@@ -253,7 +249,12 @@ class RoboCasaEnv(gym.Env):
         self._ensure_env()
         assert self._env is not None
         super().reset(seed=seed)
-        raw_obs, info = self._env.reset(seed=seed)
+        # Spread the user seed across workers. With n_envs factories each
+        # carrying a distinct `episode_index`, the same outer seed produces
+        # a different layout/trajectory per worker instead of all workers
+        # rolling the same scene.
+        worker_seed = seed + self.episode_index if seed is not None else None
+        raw_obs, info = self._env.reset(seed=worker_seed)
 
         ep_meta = self._env.env.get_ep_meta()
         self.task_description = ep_meta.get("lang", self.task)
@@ -280,6 +281,11 @@ class RoboCasaEnv(gym.Env):
 
         observation = self._format_raw_obs(raw_obs)
         if terminated:
+            info["final_info"] = {
+                "task": self.task,
+                "done": bool(done),
+                "is_success": bool(is_success),
+            }
             self.reset()
 
         return observation, reward, terminated, truncated, info
@@ -298,13 +304,20 @@ def _make_env_fns(
     render_mode: str,
     observation_width: int,
     observation_height: int,
+    visualization_width: int,
+    visualization_height: int,
     split: str | None,
     episode_length: int | None,
     obj_registries: Sequence[str],
 ) -> list[Callable[[], RoboCasaEnv]]:
-    """Build n_envs factory callables for a single task."""
+    """Build n_envs factory callables for a single task.
 
-    def _make_env(**kwargs) -> RoboCasaEnv:
+    Each factory carries a distinct ``episode_index`` (``0..n_envs-1``) so
+    ``RoboCasaEnv.reset()`` can derive a per-worker seed series from the
+    user-provided seed.
+    """
+
+    def _make_env(episode_index: int) -> RoboCasaEnv:
         return RoboCasaEnv(
             task=task,
             camera_name=camera_names,
@@ -312,13 +325,15 @@ def _make_env_fns(
             render_mode=render_mode,
             observation_width=observation_width,
             observation_height=observation_height,
+            visualization_width=visualization_width,
+            visualization_height=visualization_height,
             split=split,
             episode_length=episode_length,
             obj_registries=obj_registries,
-            **kwargs,
+            episode_index=episode_index,
         )
 
-    return [partial(_make_env) for _ in range(n_envs)]
+    return [partial(_make_env, i) for i in range(n_envs)]
 
 
 def create_robocasa_envs(
@@ -353,9 +368,11 @@ def create_robocasa_envs(
     render_mode = gym_kwargs.pop("render_mode", "rgb_array")
     observation_width = gym_kwargs.pop("observation_width", 256)
     observation_height = gym_kwargs.pop("observation_height", 256)
+    visualization_width = gym_kwargs.pop("visualization_width", 512)
+    visualization_height = gym_kwargs.pop("visualization_height", 512)
     split = gym_kwargs.pop("split", None)
 
-    camera_names = _parse_camera_names(camera_name)
+    camera_names = parse_camera_names(camera_name)
     task_names, group_split = _resolve_tasks(str(task))
     if group_split is not None and split is None:
         split = group_split
@@ -377,6 +394,8 @@ def create_robocasa_envs(
             render_mode=render_mode,
             observation_width=observation_width,
             observation_height=observation_height,
+            visualization_width=visualization_width,
+            visualization_height=visualization_height,
             split=split,
             episode_length=episode_length,
             obj_registries=obj_registries,

--- a/src/lerobot/envs/robocasa.py
+++ b/src/lerobot/envs/robocasa.py
@@ -35,18 +35,27 @@ ACTION_DIM = 12  # base_motion(4) + control_mode(1) + ee_pos(3) + ee_rot(3) + gr
 ACTION_LOW = -1.0
 ACTION_HIGH = 1.0
 
-# Default cameras for the PandaOmron robot.
+# Default PandaOmron cameras. We surface these raw names directly as
+# `observation.images.<name>` so the LeRobot dataset/policy keys match
+# RoboCasa's native convention (no implicit renaming).
 DEFAULT_CAMERAS = [
     "robot0_agentview_left",
     "robot0_eye_in_hand",
     "robot0_agentview_right",
 ]
 
-# Map raw RoboCasa camera names to LeRobot convention names.
-DEFAULT_CAMERA_NAME_MAPPING = {
-    "robot0_agentview_left": "image",
-    "robot0_eye_in_hand": "image2",
-    "robot0_agentview_right": "image3",
+# Task-group shortcuts accepted as `--env.task`. When the user passes one of
+# these names, we expand it to the upstream RoboCasa task list and auto-set
+# the dataset split. Individual task names (optionally comma-separated) still
+# take precedence; this only triggers on an exact group-name match.
+_TASK_GROUP_SPLITS = {
+    "atomic_seen": "target",
+    "composite_seen": "target",
+    "composite_unseen": "target",
+    "pretrain50": "pretrain",
+    "pretrain100": "pretrain",
+    "pretrain200": "pretrain",
+    "pretrain300": "pretrain",
 }
 
 
@@ -63,21 +72,30 @@ def _parse_camera_names(camera_name: str | Sequence[str]) -> list[str]:
     return cams
 
 
-def convert_state(raw_obs: dict[str, np.ndarray]) -> np.ndarray:
-    """Concatenate RoboCasa robot state dict into a flat (16,) vector.
+def _resolve_tasks(task: str) -> tuple[list[str], str | None]:
+    """Resolve a `--env.task` value to (task_names, split_override).
 
-    Layout: base_pos(3) + base_quat(4) + ee_pos_rel(3) + ee_quat_rel(4) + gripper_qpos(2)
+    If `task` is a known task-group name (e.g. `atomic_seen`, `pretrain100`),
+    expand it via `robocasa.utils.dataset_registry.{TARGET,PRETRAINING}_TASKS`
+    and return the matching split. Otherwise treat `task` as a single task or
+    comma-separated list and leave the split untouched (None).
     """
-    return np.concatenate(
-        [
-            raw_obs["robot0_base_pos"],  # (3,)
-            raw_obs["robot0_base_quat"],  # (4,)
-            raw_obs["robot0_base_to_eef_pos"],  # (3,)
-            raw_obs["robot0_base_to_eef_quat"],  # (4,)
-            raw_obs["robot0_gripper_qpos"],  # (2,)
-        ],
-        axis=-1,
-    ).astype(np.float32)
+    key = task.strip()
+    if key in _TASK_GROUP_SPLITS:
+        from robocasa.utils.dataset_registry import PRETRAINING_TASKS, TARGET_TASKS
+
+        combined = {**TARGET_TASKS, **PRETRAINING_TASKS}
+        if key not in combined:
+            raise ValueError(
+                f"Task group '{key}' is not available in this version of robocasa. "
+                f"Known groups: {sorted(combined.keys())}."
+            )
+        return list(combined[key]), _TASK_GROUP_SPLITS[key]
+
+    names = [t.strip() for t in task.split(",") if t.strip()]
+    if not names:
+        raise ValueError("`task` must contain at least one RoboCasa task name.")
+    return names, None
 
 
 def convert_action(flat_action: np.ndarray) -> dict[str, Any]:
@@ -97,9 +115,9 @@ def convert_action(flat_action: np.ndarray) -> dict[str, Any]:
 class RoboCasaEnv(gym.Env):
     """LeRobot gym.Env wrapper for RoboCasa365 kitchen environments.
 
-    Wraps the RoboCasaGymEnv from the robocasa package and converts its
-    dict-based observations and actions into flat arrays compatible with
-    the LeRobot evaluation pipeline.
+    Wraps RoboCasaGymEnv from the robocasa package and converts its
+    dict-based observations and actions into the flat arrays LeRobot expects.
+    Raw RoboCasa camera names are preserved verbatim under `pixels/<cam>`.
     """
 
     metadata = {"render_modes": ["rgb_array"], "render_fps": 20}
@@ -108,7 +126,6 @@ class RoboCasaEnv(gym.Env):
         self,
         task: str,
         camera_name: str | Sequence[str] = ",".join(DEFAULT_CAMERAS),
-        camera_name_mapping: dict[str, str] | None = None,
         obs_type: str = "pixels_agent_pos",
         render_mode: str = "rgb_array",
         observation_width: int = 256,
@@ -125,27 +142,23 @@ class RoboCasaEnv(gym.Env):
         self.split = split
 
         self.camera_name = _parse_camera_names(camera_name)
-        if camera_name_mapping is None:
-            camera_name_mapping = dict(DEFAULT_CAMERA_NAME_MAPPING)
-        self.camera_name_mapping = camera_name_mapping
 
         self._max_episode_steps = episode_length if episode_length is not None else 1000
 
         # Deferred — created on first reset() inside the worker subprocess
         # to avoid inheriting stale GPU/EGL contexts across fork().
-        self._env = None
+        self._env: Any = None
         self.task_description = ""
 
-        # Build observation space
-        images = {}
-        for cam in self.camera_name:
-            mapped = self.camera_name_mapping.get(cam, cam)
-            images[mapped] = spaces.Box(
+        images = {
+            cam: spaces.Box(
                 low=0,
                 high=255,
                 shape=(self.observation_height, self.observation_width, 3),
                 dtype=np.uint8,
             )
+            for cam in self.camera_name
+        }
 
         if self.obs_type == "pixels":
             self.observation_space = spaces.Dict({"pixels": spaces.Dict(images)})
@@ -182,37 +195,28 @@ class RoboCasaEnv(gym.Env):
             return
         from robocasa.wrappers.gym_wrapper import RoboCasaGymEnv
 
-        # RoboCasaGymEnv has a broken default split="test" (invalid for create_env
-        # which only accepts None/"all"/"pretrain"/"target"). Always pass a valid
-        # value so we don't hit that default.
-        kwargs: dict[str, Any] = {
-            "env_name": self.task,
-            "camera_widths": self.observation_width,
-            "camera_heights": self.observation_height,
-            "split": self.split if self.split is not None else "all",
-        }
+        # RoboCasaGymEnv defaults split="test", which create_env rejects
+        # (only None/"all"/"pretrain"/"target" are valid). Always pass a
+        # valid value so we don't hit that default.
+        self._env = RoboCasaGymEnv(
+            env_name=self.task,
+            camera_widths=self.observation_width,
+            camera_heights=self.observation_height,
+            split=self.split if self.split is not None else "all",
+        )
 
-        self._env = RoboCasaGymEnv(**kwargs)
-
-        # Extract task description from environment metadata
-        assert self._env is not None
         ep_meta = self._env.env.get_ep_meta()
         self.task_description = ep_meta.get("lang", self.task)
 
     def _format_raw_obs(self, raw_obs: dict) -> RobotObservation:
         """Convert RoboCasaGymEnv observation dict to LeRobot format."""
-        # Extract camera images (RoboCasaGymEnv provides "video.<cam>" keys)
-        images = {}
-        for cam in self.camera_name:
-            video_key = f"video.{cam}"
-            if video_key in raw_obs:
-                mapped = self.camera_name_mapping.get(cam, cam)
-                images[mapped] = raw_obs[video_key]
+        # RoboCasaGymEnv emits camera frames under "video.<cam>".
+        images = {cam: raw_obs[f"video.{cam}"] for cam in self.camera_name if f"video.{cam}" in raw_obs}
 
         if self.obs_type == "pixels":
             return {"pixels": images}
 
-        # Extract state from raw_obs (state.* keys from PandaOmronKeyConverter)
+        # `state.*` keys come from PandaOmronKeyConverter inside the wrapper.
         agent_pos = np.concatenate(
             [
                 raw_obs.get("state.base_position", np.zeros(3)),
@@ -224,10 +228,7 @@ class RoboCasaEnv(gym.Env):
             axis=-1,
         ).astype(np.float32)
 
-        return {
-            "pixels": images,
-            "agent_pos": agent_pos,
-        }
+        return {"pixels": images, "agent_pos": agent_pos}
 
     def render(self) -> np.ndarray:
         self._ensure_env()
@@ -240,7 +241,6 @@ class RoboCasaEnv(gym.Env):
         super().reset(seed=seed)
         raw_obs, info = self._env.reset(seed=seed)
 
-        # Update task description on each reset (may change per episode)
         ep_meta = self._env.env.get_ep_meta()
         self.task_description = ep_meta.get("lang", self.task)
 
@@ -257,19 +257,12 @@ class RoboCasaEnv(gym.Env):
                 f"but got shape {action.shape} with ndim={action.ndim}"
             )
 
-        # Convert flat action to RoboCasa dict format
         action_dict = convert_action(action)
         raw_obs, reward, done, truncated, info = self._env.step(action_dict)
 
         is_success = bool(info.get("success", False))
         terminated = done or is_success
-        info.update(
-            {
-                "task": self.task,
-                "done": done,
-                "is_success": is_success,
-            }
-        )
+        info.update({"task": self.task, "done": done, "is_success": is_success})
 
         observation = self._format_raw_obs(raw_obs)
         if terminated:
@@ -282,15 +275,11 @@ class RoboCasaEnv(gym.Env):
             self._env.close()
 
 
-# ---- Main API ----------------------------------------------------------------
-
-
 def _make_env_fns(
     *,
     task: str,
     n_envs: int,
     camera_names: list[str],
-    camera_name_mapping: dict[str, str] | None,
     obs_type: str,
     render_mode: str,
     observation_width: int,
@@ -304,7 +293,6 @@ def _make_env_fns(
         return RoboCasaEnv(
             task=task,
             camera_name=camera_names,
-            camera_name_mapping=camera_name_mapping,
             obs_type=obs_type,
             render_mode=render_mode,
             observation_width=observation_width,
@@ -322,7 +310,6 @@ def create_robocasa_envs(
     n_envs: int,
     gym_kwargs: dict[str, Any] | None = None,
     camera_name: str | Sequence[str] = ",".join(DEFAULT_CAMERAS),
-    camera_name_mapping: dict[str, str] | None = None,
     env_cls: Callable[[Sequence[Callable[[], Any]]], Any] | None = None,
     episode_length: int | None = None,
 ) -> dict[str, dict[int, Any]]:
@@ -330,9 +317,14 @@ def create_robocasa_envs(
 
     Returns:
         dict[task_name][task_id] -> vec_env (env_cls([...]) with exactly n_envs factories)
-    Notes:
-        - n_envs is the number of rollouts *per task* (parallel environments).
-        - `task` can be a single task or a comma-separated list of tasks.
+
+    `task` can be:
+      - a single task name (e.g. `CloseFridge`)
+      - a comma-separated list of task names (e.g. `CloseFridge,PickPlaceCoffee`)
+      - a benchmark-group shortcut (`atomic_seen`, `composite_seen`,
+        `composite_unseen`, `pretrain50`, `pretrain100`, `pretrain200`,
+        `pretrain300`), which auto-expands to the upstream task list and
+        auto-sets the dataset `split` ("target" or "pretrain").
     """
     if env_cls is None or not callable(env_cls):
         raise ValueError("env_cls must be a callable that wraps a list of environment factory callables.")
@@ -347,11 +339,11 @@ def create_robocasa_envs(
     split = gym_kwargs.pop("split", None)
 
     camera_names = _parse_camera_names(camera_name)
-    task_names = [t.strip() for t in str(task).split(",") if t.strip()]
-    if not task_names:
-        raise ValueError("`task` must contain at least one RoboCasa task name.")
+    task_names, group_split = _resolve_tasks(str(task))
+    if group_split is not None and split is None:
+        split = group_split
 
-    print(f"Creating RoboCasa envs | tasks={task_names} | n_envs(per task)={n_envs}")
+    print(f"Creating RoboCasa envs | tasks={task_names} | split={split} | n_envs(per task)={n_envs}")
 
     is_async = env_cls is gym.vector.AsyncVectorEnv
 
@@ -359,12 +351,11 @@ def create_robocasa_envs(
     cached_act_space: spaces.Space | None = None
     out: dict[str, dict[int, Any]] = defaultdict(dict)
 
-    for _tid, task_name in enumerate(task_names):
+    for task_name in task_names:
         fns = _make_env_fns(
             task=task_name,
             n_envs=n_envs,
             camera_names=camera_names,
-            camera_name_mapping=camera_name_mapping,
             obs_type=obs_type,
             render_mode=render_mode,
             observation_width=observation_width,

--- a/src/lerobot/envs/robocasa.py
+++ b/src/lerobot/envs/robocasa.py
@@ -44,6 +44,16 @@ DEFAULT_CAMERAS = [
     "robot0_agentview_right",
 ]
 
+# Object-mesh registries to sample from. RoboCasa's upstream default is
+# ("objaverse", "lightwheel"), but the objaverse pack is huge (~30GB) and
+# most users — including our CI image — only download the lightwheel pack
+# (`--type objs_lw` in `download_kitchen_assets`). When a sampled object
+# category has zero candidates in every registry, robocasa crashes with
+# `ValueError: Probabilities contain NaN` (0/0 divide in the probability
+# normalization). Restricting to registries that are actually on disk
+# avoids the NaN and matches what the asset download provides.
+DEFAULT_OBJ_REGISTRIES: tuple[str, ...] = ("lightwheel",)
+
 # Task-group shortcuts accepted as `--env.task`. When the user passes one of
 # these names, we expand it to the upstream RoboCasa task list and auto-set
 # the dataset split. Individual task names (optionally comma-separated) still
@@ -132,6 +142,7 @@ class RoboCasaEnv(gym.Env):
         observation_height: int = 256,
         split: str | None = None,
         episode_length: int | None = None,
+        obj_registries: Sequence[str] = DEFAULT_OBJ_REGISTRIES,
     ):
         super().__init__()
         self.task = task
@@ -140,6 +151,7 @@ class RoboCasaEnv(gym.Env):
         self.observation_width = observation_width
         self.observation_height = observation_height
         self.split = split
+        self.obj_registries = tuple(obj_registries)
 
         self.camera_name = _parse_camera_names(camera_name)
 
@@ -197,12 +209,14 @@ class RoboCasaEnv(gym.Env):
 
         # RoboCasaGymEnv defaults split="test", which create_env rejects
         # (only None/"all"/"pretrain"/"target" are valid). Always pass a
-        # valid value so we don't hit that default.
+        # valid value so we don't hit that default. Extra kwargs are
+        # forwarded to the underlying kitchen env via create_env/robosuite.make.
         self._env = RoboCasaGymEnv(
             env_name=self.task,
             camera_widths=self.observation_width,
             camera_heights=self.observation_height,
             split=self.split if self.split is not None else "all",
+            obj_registries=self.obj_registries,
         )
 
         ep_meta = self._env.env.get_ep_meta()
@@ -286,6 +300,7 @@ def _make_env_fns(
     observation_height: int,
     split: str | None,
     episode_length: int | None,
+    obj_registries: Sequence[str],
 ) -> list[Callable[[], RoboCasaEnv]]:
     """Build n_envs factory callables for a single task."""
 
@@ -299,6 +314,7 @@ def _make_env_fns(
             observation_height=observation_height,
             split=split,
             episode_length=episode_length,
+            obj_registries=obj_registries,
             **kwargs,
         )
 
@@ -312,6 +328,7 @@ def create_robocasa_envs(
     camera_name: str | Sequence[str] = ",".join(DEFAULT_CAMERAS),
     env_cls: Callable[[Sequence[Callable[[], Any]]], Any] | None = None,
     episode_length: int | None = None,
+    obj_registries: Sequence[str] = DEFAULT_OBJ_REGISTRIES,
 ) -> dict[str, dict[int, Any]]:
     """Create vectorized RoboCasa365 environments with a consistent return shape.
 
@@ -362,6 +379,7 @@ def create_robocasa_envs(
             observation_height=observation_height,
             split=split,
             episode_length=episode_length,
+            obj_registries=obj_registries,
         )
 
         if is_async:

--- a/src/lerobot/envs/utils.py
+++ b/src/lerobot/envs/utils.py
@@ -34,6 +34,25 @@ from lerobot.utils.utils import get_channel_first_image_shape
 from .configs import EnvConfig
 
 
+def parse_camera_names(camera_name: str | Sequence[str]) -> list[str]:
+    """Normalize ``camera_name`` into a non-empty list of strings.
+
+    Accepts a comma-separated string (``"cam_a,cam_b"``) or a sequence of
+    strings (tuples/lists). Whitespace is stripped; empty entries are
+    dropped. Raises ``TypeError`` for unsupported input types and
+    ``ValueError`` when the normalized list is empty.
+    """
+    if isinstance(camera_name, str):
+        cams = [c.strip() for c in camera_name.split(",") if c.strip()]
+    elif isinstance(camera_name, (list | tuple)):
+        cams = [str(c).strip() for c in camera_name if str(c).strip()]
+    else:
+        raise TypeError(f"camera_name must be str or sequence[str], got {type(camera_name).__name__}")
+    if not cams:
+        raise ValueError("camera_name resolved to an empty list.")
+    return cams
+
+
 def _convert_nested_dict(d):
     result = {}
     for k, v in d.items():

--- a/src/lerobot/envs/utils.py
+++ b/src/lerobot/envs/utils.py
@@ -172,17 +172,20 @@ class _LazyAsyncVectorEnv:
         env_fns: list[Callable],
         observation_space=None,
         action_space=None,
+        metadata=None,
     ):
         self._env_fns = env_fns
         self._env: gym.vector.AsyncVectorEnv | None = None
         self.num_envs = len(env_fns)
-        if observation_space is not None and action_space is not None:
+        if observation_space is not None and action_space is not None and metadata is not None:
             self.observation_space = observation_space
             self.action_space = action_space
+            self.metadata = metadata
         else:
             tmp = env_fns[0]()
             self.observation_space = tmp.observation_space
             self.action_space = tmp.action_space
+            self.metadata = tmp.metadata
             tmp.close()
         self.single_observation_space = self.observation_space
         self.single_action_space = self.action_space
@@ -190,6 +193,10 @@ class _LazyAsyncVectorEnv:
     def _ensure(self) -> None:
         if self._env is None:
             self._env = gym.vector.AsyncVectorEnv(self._env_fns, context="forkserver", shared_memory=True)
+
+    @property
+    def unwrapped(self):
+        return self
 
     def reset(self, **kwargs):
         self._ensure()


### PR DESCRIPTION
## Summary

Adds [**RoboCasa365**](https://robocasa.ai) as a new simulation benchmark: 365 kitchen manipulation tasks on a PandaOmron mobile manipulator (Franka arm on holonomic base). Follows the [Adding a New Benchmark](https://huggingface.co/docs/lerobot/adding_benchmarks) guide — gym.Env wrapper, `EnvConfig`, docs page, Docker image, CI job.

- Paper: [RoboCasa: Large-Scale Simulation of Everyday Tasks](https://arxiv.org/abs/2406.02523) · [GitHub](https://github.com/robocasa/robocasa) · [robocasa.ai](https://robocasa.ai)
- Pretrained policy: [`lerobot/smolvla_robocasa`](https://huggingface.co/lerobot/smolvla_robocasa)
- Single-task dataset (CloseFridge): [`pepijn223/robocasa_CloseFridge`](https://huggingface.co/datasets/pepijn223/robocasa_CloseFridge)

### What's in this PR

- **Env wrapper** `src/lerobot/envs/robocasa.py` — `RoboCasaEnv(gym.Env)` composing `RoboCasaGymEnv` with deferred inner-env creation (safe for `AsyncVectorEnv` under fork). Raw upstream camera names preserved (`robot0_agentview_left/right`, `robot0_eye_in_hand`) so the on-Hub datasets work with no `--rename_map`. 16-D state / 12-D action.
- **Config** `RoboCasaEnv` in `src/lerobot/envs/configs.py` — `--env.task` accepts a single task, comma-separated list, or a benchmark-group shortcut (`atomic_seen`, `composite_seen`, `composite_unseen`, `pretrain50/100/200/300`). New `--env.obj_registries` override (default `["lightwheel"]`) so the env doesn't NaN when the huge `objaverse` pack isn't on disk.
- **CI job** `robocasa-integration-test`: builds the Docker image (clones `robocasa/robocasa` and `ARISE-Initiative/robosuite`, installs robocasa with `--no-deps` to avoid its stale `lerobot==0.3.3` pin, downloads `tex tex_generative fixtures_lw objs_lw` assets) and runs a **10-atomic-task smoke eval** with `lerobot/smolvla_robocasa` (one episode each, fixture-centric tasks chosen so they don't require the objaverse pack).
- **Docs** `docs/source/robocasa.mdx` + `_toctree.yml` entry — follows the `adding_benchmarks.mdx` template, documents the manual install flow (no `lerobot[robocasa]` extra because robocasa's `setup.py` hardcodes `lerobot==0.3.3` and can't be resolved with our workspace).

### Usage

```bash
# Install — no pyproject extra; robocasa's setup.py conflicts with our lerobot
git clone https://github.com/robocasa/robocasa.git ~/robocasa
git clone https://github.com/ARISE-Initiative/robosuite.git ~/robosuite
pip install -e ~/robocasa --no-deps
pip install -e ~/robosuite
pip install numpy numba scipy mujoco pygame Pillow opencv-python \
            pyyaml pynput tqdm termcolor imageio h5py lxml hidapi \
            tianshou gymnasium
python -m robocasa.scripts.setup_macros
python -m robocasa.scripts.download_kitchen_assets \
  --type tex tex_generative fixtures_lw objs_lw

lerobot-eval \
  --policy.path=lerobot/smolvla_robocasa \
  --env.type=robocasa \
  --env.task=CloseFridge \
  --eval.n_episodes=20
```

## Test plan

- [x] `lerobot-eval --env.type=robocasa --env.task=CloseFridge --eval.n_episodes=1` completes end-to-end on CI.
- [x] Docker image builds and the 10-task smoke eval passes on CI.
- [x] Docs page renders and appears in the sidebar.
- [x] `uv sync --locked --extra test` resolves cleanly (no unresolvable robocasa extra in pyproject.toml).