### PR TITLE
Fix loss normalization for padded actions in ACT, Diffusion, and MultiTaskDiT

### DIFF
--- a/src/lerobot/policies/act/modeling_act.py
+++ b/src/lerobot/policies/act/modeling_act.py
@@ -142,10 +142,10 @@ class ACTPolicy(PreTrainedPolicy):
 
         actions_hat, (mu_hat, log_sigma_x2_hat) = self.model(batch)
 
+        abs_err = F.l1_loss(batch[ACTION], actions_hat, reduction="none")
         valid_mask = ~batch["action_is_pad"].unsqueeze(-1)
-        l1_loss = (
-            F.l1_loss(batch[ACTION], actions_hat, reduction="none") * valid_mask
-        ).sum() / valid_mask.sum().clamp_min(1)
+        num_valid = valid_mask.sum() * abs_err.shape[-1]
+        l1_loss = (abs_err * valid_mask).sum() / num_valid.clamp_min(1)
 
         loss_dict = {"l1_loss": l1_loss.item()}
         if self.config.use_vae:

--- a/src/lerobot/policies/act/modeling_act.py
+++ b/src/lerobot/policies/act/modeling_act.py
@@ -143,7 +143,9 @@ class ACTPolicy(PreTrainedPolicy):
         actions_hat, (mu_hat, log_sigma_x2_hat) = self.model(batch)
 
         valid_mask = ~batch["action_is_pad"].unsqueeze(-1)
-        l1_loss = (F.l1_loss(batch[ACTION], actions_hat, reduction="none") * valid_mask).sum() / valid_mask.sum().clamp_min(1)
+        l1_loss = (
+            F.l1_loss(batch[ACTION], actions_hat, reduction="none") * valid_mask
+        ).sum() / valid_mask.sum().clamp_min(1)
 
         loss_dict = {"l1_loss": l1_loss.item()}
         if self.config.use_vae:

--- a/src/lerobot/policies/act/modeling_act.py
+++ b/src/lerobot/policies/act/modeling_act.py
@@ -142,9 +142,8 @@ class ACTPolicy(PreTrainedPolicy):
 
         actions_hat, (mu_hat, log_sigma_x2_hat) = self.model(batch)
 
-        l1_loss = (
-            F.l1_loss(batch[ACTION], actions_hat, reduction="none") * ~batch["action_is_pad"].unsqueeze(-1)
-        ).mean()
+        valid_mask = ~batch["action_is_pad"].unsqueeze(-1)
+        l1_loss = (F.l1_loss(batch[ACTION], actions_hat, reduction="none") * valid_mask).sum() / valid_mask.sum().clamp_min(1)
 
         loss_dict = {"l1_loss": l1_loss.item()}
         if self.config.use_vae:

--- a/src/lerobot/policies/diffusion/modeling_diffusion.py
+++ b/src/lerobot/policies/diffusion/modeling_diffusion.py
@@ -375,7 +375,8 @@ class DiffusionModel(nn.Module):
                 )
             in_episode_bound = ~batch["action_is_pad"]
             mask = in_episode_bound.unsqueeze(-1)
-            return (loss * mask).sum() / mask.sum().clamp_min(1)
+            num_valid = mask.sum() * loss.shape[-1]
+            return (loss * mask).sum() / num_valid.clamp_min(1)
 
         return loss.mean()
 

--- a/src/lerobot/policies/diffusion/modeling_diffusion.py
+++ b/src/lerobot/policies/diffusion/modeling_diffusion.py
@@ -374,7 +374,8 @@ class DiffusionModel(nn.Module):
                     f"{self.config.do_mask_loss_for_padding=}."
                 )
             in_episode_bound = ~batch["action_is_pad"]
-            loss = loss * in_episode_bound.unsqueeze(-1)
+            mask = in_episode_bound.unsqueeze(-1)
+            return (loss * mask).sum() / mask.sum().clamp_min(1)
 
         return loss.mean()
 

--- a/src/lerobot/policies/multi_task_dit/modeling_multi_task_dit.py
+++ b/src/lerobot/policies/multi_task_dit/modeling_multi_task_dit.py
@@ -685,8 +685,8 @@ class DiffusionObjective(nn.Module):
         loss = F.mse_loss(predicted, target, reduction="none")
 
         if self.do_mask_loss_for_padding and "action_is_pad" in batch:
-            valid_actions = ~batch["action_is_pad"]
-            loss = loss * valid_actions.unsqueeze(-1)
+            mask = ~batch["action_is_pad"].unsqueeze(-1)
+            return (loss * mask).sum() / mask.sum().clamp_min(1)
 
         return loss.mean()
 
@@ -749,8 +749,8 @@ class FlowMatchingObjective(nn.Module):
         loss = F.mse_loss(predicted_velocity, target_velocity, reduction="none")
 
         if self.do_mask_loss_for_padding and "action_is_pad" in batch:
-            valid_mask = ~batch["action_is_pad"]
-            loss = loss * valid_mask.unsqueeze(-1)
+            mask = ~batch["action_is_pad"].unsqueeze(-1)
+            return (loss * mask).sum() / mask.sum().clamp_min(1)
 
         return loss.mean()
 

--- a/src/lerobot/policies/multi_task_dit/modeling_multi_task_dit.py
+++ b/src/lerobot/policies/multi_task_dit/modeling_multi_task_dit.py
@@ -686,7 +686,8 @@ class DiffusionObjective(nn.Module):
 
         if self.do_mask_loss_for_padding and "action_is_pad" in batch:
             mask = ~batch["action_is_pad"].unsqueeze(-1)
-            return (loss * mask).sum() / mask.sum().clamp_min(1)
+            num_valid = mask.sum() * loss.shape[-1]
+            return (loss * mask).sum() / num_valid.clamp_min(1)
 
         return loss.mean()
 

--- a/src/lerobot/policies/multi_task_dit/modeling_multi_task_dit.py
+++ b/src/lerobot/policies/multi_task_dit/modeling_multi_task_dit.py
@@ -750,7 +750,8 @@ class FlowMatchingObjective(nn.Module):
 
         if self.do_mask_loss_for_padding and "action_is_pad" in batch:
             mask = ~batch["action_is_pad"].unsqueeze(-1)
-            return (loss * mask).sum() / mask.sum().clamp_min(1)
+            num_valid = mask.sum() * loss.shape[-1]
+            return (loss * mask).sum() / num_valid.clamp_min(1)
 
         return loss.mean()
 


### PR DESCRIPTION
## What this fixes

When `action_is_pad` masks out padded timesteps, the subsequent `.mean()` still divides by the total element count (including zeroed-out padding). With 60-70% padding this underestimates the loss by 2-3x, reducing gradient signal and hurting training convergence.

**Before (ACT example):**
```python
l1_loss = (
    F.l1_loss(batch[ACTION], actions_hat, reduction="none")
    * ~batch["action_is_pad"].unsqueeze(-1)
).mean()  # divides by ALL elements including padding
```

**After:**
```python
valid_mask = ~batch["action_is_pad"].unsqueeze(-1)
l1_loss = (
    F.l1_loss(batch[ACTION], actions_hat, reduction="none") * valid_mask
).sum() / valid_mask.sum().clamp_min(1)  # divides by valid elements only
```

## Affected policies

| Policy | File | Fixed |
|--------|------|-------|
| ACT | `modeling_act.py:145` | Yes |
| Diffusion | `modeling_diffusion.py:376` | Yes |
| MultiTaskDiT (DDPM) | `modeling_multi_task_dit.py:689` | Yes |
| MultiTaskDiT (Flow) | `modeling_multi_task_dit.py:753` | Yes |
| TDMPC | `modeling_tdmpc.py` | Not affected (sums over time before batch mean) |

## Test plan

- [ ] `uv run pytest tests/policies -v` passes
- [ ] Verify with a batch where ~50% actions are padded: loss should be higher than before (no dilution)

Fixes #3353