### PR TITLE
fix: catch KeyboardInterrupt in safe_stop_image_writer to prevent corrupted frames

### DIFF
--- a/src/lerobot/datasets/image_writer.py
+++ b/src/lerobot/datasets/image_writer.py
@@ -30,13 +30,13 @@ def safe_stop_image_writer(func):
     def wrapper(*args, **kwargs):
         try:
             return func(*args, **kwargs)
-        except Exception as e:
+        except BaseException:
             dataset = kwargs.get("dataset")
             writer = getattr(dataset, "writer", None) if dataset else None
             if writer is not None and writer.image_writer is not None:
                 logger.warning("Waiting for image writer to terminate...")
                 writer.image_writer.stop()
-            raise e
+            raise
 
     return wrapper
 


### PR DESCRIPTION
## Title

fix(datasets): catch KeyboardInterrupt in safe_stop_image_writer to prevent corrupted frames

## Type / Scope

- **Type**: Bug
- **Scope**: datasets/image_writer

## Summary / Motivation

- `safe_stop_image_writer` uses `except Exception` which does not catch `KeyboardInterrupt` (Ctrl+C) because KeyboardInterrupt inherits from `BaseException`, not `Exception`. When a user presses Ctrl+C during recording with lerobot-record or hil_data_collection, the decorator's cleanup is bypassed, daemon image writer threads are killed mid-write.

Also replaces raise e with bare raise to preserve the original traceback for easier debugging.

## Related issues

- Related: #2651

## What changed

- `src/lerobot/datasets/image_writer.py`: Changed `except Exception as e` to `except BaseException`, and `raise e` to `raise`.

## How was this tested (or how to run locally)

- Existing test passes:

```bash
pytest tests/datasets/test_image_writer.py::test_safe_stop_image_writer_decorator -vv
```

## Checklist (required before merge)

- [ ] Linting/formatting run (`pre-commit run -a`)
- [ ] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [ ] CI is green