### PR TITLE
Feat/add hans s30 robot

### DIFF
--- a/examples/hans_s30/README.md
+++ b/examples/hans_s30/README.md
@@ -1,0 +1,134 @@
+# Hans Robot S30 – LeRobot Integration
+
+This directory contains example scripts for using the
+[Hans Robot S30](https://www.hansrobot.com/) 6-DOF industrial arm with
+🤗 LeRobot.
+
+## Hardware overview
+
+| Property | Value |
+|---|---|
+| DoF | 6 (J1 – J6) |
+| Communication | TCP socket (port 10003) + XML-RPC (port 20000) |
+| Protocol | Hans CPS (Controller Programming System) |
+| Default controller IP | 192.168.115.11 |
+| Joint units | Degrees |
+| Teaching mode | Zero-force (gravity compensation) |
+
+## Prerequisites
+
+1. **Network connection** – connect your PC to the same subnet as the Hans
+   controller (default: `192.168.115.x`).  Verify connectivity:
+   ```bash
+   ping 192.168.115.11
+   ```
+
+2. **LeRobot installation** – follow the
+   [Installation Guide](https://huggingface.co/docs/lerobot/installation).
+
+3. **Optional cameras** – any OpenCV-compatible USB camera(s).
+
+## Robot adapter
+
+The adapter lives in `src/lerobot/robots/hans_s30/` and exposes the standard
+`Robot` interface:
+
+```python
+from lerobot.robots.hans_s30 import HansS30, HansS30RobotConfig
+
+config = HansS30RobotConfig(ip="192.168.115.11", id="my_hans_s30")
+robot = HansS30(config)
+robot.connect()
+
+obs = robot.get_observation()   # {"joint_1.pos": ..., ..., "joint_6.pos": ...}
+robot.send_action(obs)          # echo current position as action
+robot.disconnect()
+```
+
+### Configuration options
+
+| Parameter | Default | Description |
+|---|---|---|
+| `ip` | `"192.168.115.11"` | Controller IP address |
+| `port` | `10003` | CPS TCP port |
+| `box_id` | `0` | Controller box ID |
+| `robot_id` | `0` | Robot ID |
+| `velocity` | `50.0` | Default joint velocity (deg/s) |
+| `acc` | `50.0` | Default joint acceleration (deg/s²) |
+| `speed_override` | `0.5` | Global speed ratio [0.01, 1.0] |
+| `tcp_name` | `"TCP"` | Tool-frame name on controller |
+| `ucs_name` | `"Base"` | User-frame name on controller |
+| `electrify_wait_s` | `15.0` | Wait after power-on (s) |
+| `controller_init_wait_s` | `20.0` | Wait after EtherCAT init (s) |
+| `max_relative_target` | `None` | Per-joint displacement clamp (deg) |
+| `cameras` | `{}` | Optional `{name: OpenCVCameraConfig}` dict |
+
+## Scripts
+
+### `teleoperate.py` – zero-force teaching
+
+Switches the arm into gravity-compensation mode so the operator can manually
+guide it while joint positions and camera frames are streamed to Rerun.
+
+```bash
+python examples/hans_s30/teleoperate.py
+```
+
+### `record.py` – collect a dataset
+
+Records demonstrations via zero-force teaching and saves them as a
+`LeRobotDataset`.  Edit the constants at the top of the file:
+
+```python
+ROBOT_IP        = "192.168.115.11"
+HF_REPO_ID      = "<hf_username>/<dataset_repo_id>"
+TASK_DESCRIPTION = "Pick up the red block and place it in the bin"
+NUM_EPISODES     = 10
+```
+
+```bash
+python examples/hans_s30/record.py
+```
+
+**Keyboard shortcuts during recording:**
+
+| Key | Action |
+|---|---|
+| `→` / Space | Exit current episode early and save |
+| `←` | Discard and re-record current episode |
+| `Esc` | Stop recording |
+
+### `replay.py` – replay a recorded episode
+
+Plays back joint-position actions from a saved dataset.
+
+```bash
+python examples/hans_s30/replay.py
+```
+
+### `evaluate.py` – run a trained policy
+
+Loads a policy from the Hugging Face Hub and runs it in closed loop.
+
+```bash
+python examples/hans_s30/evaluate.py
+```
+
+## Safety notes
+
+- Set `speed_override` ≤ 0.3 and `max_relative_target` ≤ 10.0 (degrees)
+  during initial testing.
+- Ensure the work envelope is clear before enabling the robot.
+- The controller's hardware emergency-stop button remains active at all times.
+- `electrify_wait_s` and `controller_init_wait_s` must be long enough for your
+  power supply; increase them if `GrpEnable` fails.
+
+## Contributing
+
+Please read the [LeRobot CONTRIBUTING guide](../../CONTRIBUTING.md) before
+opening a pull request.  Run checks locally before submitting:
+
+```bash
+pre-commit run --all-files
+pytest -sv tests/
+```

--- a/examples/hans_s30/evaluate.py
+++ b/examples/hans_s30/evaluate.py
@@ -1,0 +1,119 @@
+# !/usr/bin/env python
+
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Run a trained policy on the Hans Robot S30.
+
+Loads a policy checkpoint from the Hugging Face Hub (or a local path) and
+executes it in a closed-loop on the real robot.
+
+Edit the constants below to match your setup before running::
+
+    python examples/hans_s30/evaluate.py
+
+Key settings to edit:
+- ``ROBOT_IP``    – IPv4 address of the Hans controller.
+- ``MODEL_ID``    – HF Hub model ID or local path to the policy checkpoint.
+- ``TASK``        – Natural-language task description (required for VLA models).
+- ``MAX_EPISODES``– Number of evaluation episodes to run.
+- ``MAX_STEPS``   – Maximum steps per episode before resetting.
+"""
+
+import time
+
+import torch
+
+from lerobot.cameras.opencv import OpenCVCameraConfig
+from lerobot.policies import make_pre_post_processors
+from lerobot.policies.utils import build_inference_frame, make_robot_action
+from lerobot.robots.hans_s30 import HansS30, HansS30RobotConfig
+from lerobot.utils.feature_utils import hw_to_dataset_features
+from lerobot.utils.robot_utils import precise_sleep
+
+# ── User settings ────────────────────────────────────────────────────────────
+ROBOT_IP = "192.168.115.11"
+MODEL_ID = "<hf_username>/<policy_repo_id>"
+TASK = "Pick up the red block and place it in the bin"
+MAX_EPISODES = 5
+MAX_STEPS = 200
+FPS = 30
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def main():
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    # Load policy
+    from lerobot.policies import get_policy_class
+
+    policy_cls = get_policy_class(MODEL_ID)
+    policy = policy_cls.from_pretrained(MODEL_ID)
+    policy.eval()
+    policy.to(device)
+
+    preprocess, postprocess = make_pre_post_processors(policy.config, MODEL_ID)
+
+    # Robot setup
+    camera_config = {
+        "wrist_cam": OpenCVCameraConfig(index_or_path=0, width=640, height=480, fps=FPS),
+        "base_cam": OpenCVCameraConfig(index_or_path=1, width=640, height=480, fps=FPS),
+    }
+
+    robot_config = HansS30RobotConfig(
+        ip=ROBOT_IP,
+        port=10003,
+        id="my_hans_s30",
+        cameras=camera_config,
+    )
+    robot = HansS30(robot_config)
+    robot.connect()
+
+    action_features = hw_to_dataset_features(robot.action_features, "action")
+    obs_features = hw_to_dataset_features(robot.observation_features, "observation")
+    dataset_features = {**action_features, **obs_features}
+
+    try:
+        for ep in range(MAX_EPISODES):
+            print(f"\n── Episode {ep + 1} / {MAX_EPISODES} ──")
+            for _step in range(MAX_STEPS):
+                t0 = time.perf_counter()
+
+                obs = robot.get_observation()
+                obs_frame = build_inference_frame(
+                    observation=obs,
+                    ds_features=dataset_features,
+                    device=device,
+                    task=TASK,
+                    robot_type=robot.name,
+                )
+                obs_preprocessed = preprocess(obs_frame)
+
+                with torch.inference_mode():
+                    action_tensor = policy.select_action(obs_preprocessed)
+
+                action_postprocessed = postprocess(action_tensor)
+                action = make_robot_action(action_postprocessed, dataset_features)
+                robot.send_action(action)
+
+                precise_sleep(max(1.0 / FPS - (time.perf_counter() - t0), 0.0))
+
+            print("Episode finished.")
+
+    finally:
+        robot.disconnect()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/hans_s30/record.py
+++ b/examples/hans_s30/record.py
@@ -1,0 +1,140 @@
+# !/usr/bin/env python
+
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Record a LeRobotDataset with the Hans Robot S30 via zero-force teaching.
+
+The operator manually guides the arm while joint positions and camera frames
+are recorded.  After ``NUM_EPISODES`` episodes the dataset is saved and
+optionally uploaded to the Hugging Face Hub.
+
+Edit the constants below to match your setup before running::
+
+    python examples/hans_s30/record.py
+
+Key settings to edit:
+- ``ROBOT_IP``        – IPv4 address of the Hans controller.
+- ``HF_REPO_ID``      – Hugging Face dataset repository (``<user>/<dataset>``).
+- ``TASK_DESCRIPTION``– Natural-language description of the task.
+- ``NUM_EPISODES``    – Number of demos to collect.
+- ``EPISODE_TIME_SEC``– Duration of each demonstration in seconds.
+- ``RESET_TIME_SEC``  – Duration for the manual environment reset between demos.
+"""
+
+from lerobot.cameras.opencv import OpenCVCameraConfig
+from lerobot.common.control_utils import init_keyboard_listener
+from lerobot.datasets import LeRobotDataset, create_initial_features
+from lerobot.robots.hans_s30 import HansS30, HansS30RobotConfig
+from lerobot.scripts.lerobot_record import record_loop
+from lerobot.utils.utils import log_say
+from lerobot.utils.visualization_utils import init_rerun
+
+# ── User settings ────────────────────────────────────────────────────────────
+ROBOT_IP = "192.168.115.11"
+HF_REPO_ID = "<hf_username>/<dataset_repo_id>"
+TASK_DESCRIPTION = "Pick up the red block and place it in the bin"
+
+NUM_EPISODES = 10
+FPS = 30
+EPISODE_TIME_SEC = 60
+RESET_TIME_SEC = 20
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def main():
+    camera_config = {
+        "wrist_cam": OpenCVCameraConfig(index_or_path=0, width=640, height=480, fps=FPS),
+        "base_cam": OpenCVCameraConfig(index_or_path=1, width=640, height=480, fps=FPS),
+    }
+
+    robot_config = HansS30RobotConfig(
+        ip=ROBOT_IP,
+        port=10003,
+        id="my_hans_s30",
+        cameras=camera_config,
+    )
+
+    robot = HansS30(robot_config)
+
+    dataset = LeRobotDataset.create(
+        repo_id=HF_REPO_ID,
+        fps=FPS,
+        features=create_initial_features(observation=robot.observation_features),
+        robot_type=robot.name,
+        use_videos=True,
+        image_writer_threads=4,
+    )
+
+    robot.connect()
+    listener, events = init_keyboard_listener()
+    init_rerun(session_name="hans_s30_record")
+
+    try:
+        if not robot.is_connected:
+            raise RuntimeError("Robot is not connected!")
+
+        recorded_episodes = 0
+        while recorded_episodes < NUM_EPISODES and not events["stop_recording"]:
+            log_say(f"Recording episode {recorded_episodes + 1} of {NUM_EPISODES}")
+            log_say("Guide the arm using zero-force teaching …")
+
+            robot.enable_free_driver()
+
+            record_loop(
+                robot=robot,
+                events=events,
+                fps=FPS,
+                dataset=dataset,
+                control_time_s=EPISODE_TIME_SEC,
+                single_task=TASK_DESCRIPTION,
+                display_data=True,
+            )
+
+            robot.disable_free_driver()
+
+            if not events["stop_recording"] and (
+                recorded_episodes < NUM_EPISODES - 1 or events["rerecord_episode"]
+            ):
+                log_say("Reset the environment, then press Enter to continue")
+                record_loop(
+                    robot=robot,
+                    events=events,
+                    fps=FPS,
+                    control_time_s=RESET_TIME_SEC,
+                    single_task=TASK_DESCRIPTION,
+                    display_data=True,
+                )
+
+            if events["rerecord_episode"]:
+                log_say("Re-recording episode")
+                events["rerecord_episode"] = False
+                events["exit_early"] = False
+                dataset.clear_episode_buffer()
+                continue
+
+            dataset.save_episode()
+            recorded_episodes += 1
+
+    finally:
+        log_say("Stopping recording")
+        robot.disconnect()
+        listener.stop()
+
+        dataset.finalize()
+        dataset.push_to_hub()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/hans_s30/replay.py
+++ b/examples/hans_s30/replay.py
@@ -1,0 +1,79 @@
+# !/usr/bin/env python
+
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Replay a recorded episode on the Hans Robot S30.
+
+Loads a LeRobotDataset and plays back a single episode by replaying the
+stored joint-position actions.
+
+Edit the constants below to match your setup before running::
+
+    python examples/hans_s30/replay.py
+
+Key settings to edit:
+- ``ROBOT_IP``     – IPv4 address of the Hans controller.
+- ``HF_REPO_ID``   – Dataset repository used during recording.
+- ``EPISODE_INDEX``– Index of the episode to replay (0-based).
+"""
+
+import time
+
+from lerobot.datasets import LeRobotDataset
+from lerobot.robots.hans_s30 import HansS30, HansS30RobotConfig
+from lerobot.utils.robot_utils import precise_sleep
+
+# ── User settings ────────────────────────────────────────────────────────────
+ROBOT_IP = "192.168.115.11"
+HF_REPO_ID = "<hf_username>/<dataset_repo_id>"
+EPISODE_INDEX = 0
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def main():
+    robot_config = HansS30RobotConfig(
+        ip=ROBOT_IP,
+        port=10003,
+        id="my_hans_s30",
+    )
+    robot = HansS30(robot_config)
+    robot.connect()
+
+    dataset = LeRobotDataset(HF_REPO_ID, episodes=[EPISODE_INDEX])
+
+    from_idx = dataset.meta.episodes["dataset_from_index"][EPISODE_INDEX]
+    to_idx = dataset.meta.episodes["dataset_to_index"][EPISODE_INDEX]
+    fps = dataset.fps
+
+    print(f"Replaying episode {EPISODE_INDEX} ({to_idx - from_idx} frames @ {fps} Hz) …")
+
+    try:
+        for idx in range(from_idx, to_idx):
+            t0 = time.perf_counter()
+            frame = dataset[idx]
+
+            action = {key: frame[key].item() for key in robot.action_features}
+            robot.send_action(action)
+
+            precise_sleep(max(1.0 / fps - (time.perf_counter() - t0), 0.0))
+
+        print("Replay finished.")
+
+    finally:
+        robot.disconnect()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/hans_s30/teleoperate.py
+++ b/examples/hans_s30/teleoperate.py
@@ -1,0 +1,76 @@
+# !/usr/bin/env python
+
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Teleoperate the Hans Robot S30 using its built-in zero-force teaching mode.
+
+The S30's gravity-compensation mode lets an operator manually guide the arm
+while joint positions are streamed at ``FPS`` Hz and displayed via Rerun.
+
+Edit the constants below to match your setup before running::
+
+    python examples/hans_s30/teleoperate.py
+
+Press Ctrl-C to stop.  The robot is automatically returned to position-control
+mode on exit.
+"""
+
+import time
+
+from lerobot.cameras.opencv import OpenCVCameraConfig
+from lerobot.robots.hans_s30 import HansS30, HansS30RobotConfig
+from lerobot.utils.robot_utils import precise_sleep
+from lerobot.utils.visualization_utils import init_rerun, log_rerun_data
+
+# ── User settings ────────────────────────────────────────────────────────────
+ROBOT_IP = "192.168.115.11"
+FPS = 30
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def main():
+    camera_config = {
+        "wrist_cam": OpenCVCameraConfig(index_or_path=0, width=640, height=480, fps=FPS),
+    }
+
+    robot_config = HansS30RobotConfig(
+        ip=ROBOT_IP,
+        port=10003,
+        id="my_hans_s30",
+        cameras=camera_config,
+    )
+
+    robot = HansS30(robot_config)
+    robot.connect()
+
+    init_rerun(session_name="hans_s30_teleoperate")
+
+    try:
+        print("Enabling zero-force teaching mode …  Press Ctrl-C to stop.")
+        robot.enable_free_driver()
+
+        while True:
+            t0 = time.perf_counter()
+            obs = robot.get_observation()
+            log_rerun_data(observation=obs)
+            precise_sleep(max(1.0 / FPS - (time.perf_counter() - t0), 0.0))
+
+    finally:
+        robot.disable_free_driver()
+        robot.disconnect()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -317,6 +317,8 @@ ignore = [
 # E402: conditional-import guards (TYPE_CHECKING / is_package_available) must precede the imports they protect
 "src/lerobot/scripts/convert_dataset_v21_to_v30.py" = ["E402"]
 "src/lerobot/policies/wall_x/**" = ["N801", "N812", "SIM102", "SIM108", "SIM210", "SIM211", "B006", "B007", "SIM118"] # Supprese these as they are coming from original Qwen2_5_vl code TODO(pepijn): refactor original
+# N802: HRIF_* method names intentionally follow the Hans CPS vendor API naming convention
+"src/lerobot/robots/hans_s30/cps_client.py" = ["N802"]
 
 [tool.ruff.lint.isort]
 combine-as-imports = true

--- a/src/lerobot/robots/hans_s30/__init__.py
+++ b/src/lerobot/robots/hans_s30/__init__.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .config_hans_s30 import HansS30Config, HansS30RobotConfig
+from .hans_s30 import HansS30
+
+__all__ = [
+    "HansS30",
+    "HansS30Config",
+    "HansS30RobotConfig",
+]

--- a/src/lerobot/robots/hans_s30/config_hans_s30.py
+++ b/src/lerobot/robots/hans_s30/config_hans_s30.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass, field
+
+from lerobot.cameras import CameraConfig
+
+from ..config import RobotConfig
+
+
+@dataclass
+class HansS30Config:
+    """Base configuration for Hans Robot S30 6-DOF arm.
+
+    The S30 communicates via TCP socket (port 10003) and XML-RPC (port 20000).
+    No USB serial port is required.
+
+    Args:
+        ip: IPv4 address of the Hans controller box.
+        port: TCP port for CPS motion commands (default: 10003).
+        box_id: Controller box ID (default: 0).
+        robot_id: Robot ID inside the controller (default: 0).
+        velocity: Default joint-motion velocity in deg/s (default: 50).
+            Must be strictly less than ``acc`` (controller enforces this).
+        acc: Default joint-motion acceleration in deg/s² (default: 100).
+            Must be strictly greater than ``velocity``.
+        speed_override: Global speed override ratio, range [0.01, 1.0] (default: 0.5).
+        tcp_name: Name of the tool-coordinate frame configured on the controller.
+        ucs_name: Name of the user-coordinate frame configured on the controller.
+        electrify_wait_s: Seconds to wait after powering on before connecting the
+            EtherCAT master. Increase if the power supply is slow.
+        controller_init_wait_s: Seconds to wait after starting the EtherCAT master
+            before enabling the servo group.
+        max_relative_target: Maximum allowed joint displacement (degrees) per command.
+            Set to a positive value to add a safety clamp, or None to disable.
+        cameras: Optional dict of camera configs keyed by camera name.
+    """
+
+    ip: str = "192.168.115.11"
+    port: int = 10003
+    box_id: int = 0
+    robot_id: int = 0
+
+    velocity: float = 50.0
+    acc: float = 100.0
+    speed_override: float = 0.5
+
+    tcp_name: str = "TCP"
+    ucs_name: str = "Base"
+
+    electrify_wait_s: float = 15.0
+    controller_init_wait_s: float = 20.0
+
+    max_relative_target: float | None = None
+
+    cameras: dict[str, CameraConfig] = field(default_factory=dict)
+
+
+@RobotConfig.register_subclass("hans_s30")
+@dataclass
+class HansS30RobotConfig(RobotConfig, HansS30Config):
+    """LeRobot-registered configuration for the Hans Robot S30."""

--- a/src/lerobot/robots/hans_s30/cps_client.py
+++ b/src/lerobot/robots/hans_s30/cps_client.py
@@ -1,0 +1,390 @@
+#!/usr/bin/env python
+
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Minimal CPS (Controller Programming System) client for Hans Robot arms.
+
+Communicates with the Hans robot controller via TCP socket + XML-RPC.
+This is a focused subset of the full CPS API covering the methods needed
+for LeRobot integration: connection, power, enable/disable, state reading,
+and joint-space motion.
+"""
+
+import socket
+import time
+import xmlrpc.client
+from enum import IntEnum
+
+
+class RobotFSM(IntEnum):
+    """Hans robot finite state machine states."""
+
+    UNINITIALIZED = 0
+    INITIALIZED = 1
+    BOX_DISCONNECTED = 2
+    BOX_CONNECTING = 3
+    EMERGENCY_STOP_HANDLING = 4
+    EMERGENCY_STOP = 5
+    BLACKOUT_48V = 7
+    CONTROLLER_DISCONNECTED = 14
+    CONTROLLER_CONNECTING = 15
+    ETHERCAT_ERROR = 17
+    ROBOT_ERROR = 22
+    ENABLING = 23
+    DISABLED = 24
+    MOVING = 25
+    STOPPING = 27
+    DISABLING = 28
+    FREE_DRIVER_OPENING = 29
+    FREE_DRIVER_CLOSING = 30
+    FREE_DRIVER = 31
+    STANDBY = 33
+
+
+class _TcpChannel:
+    """Low-level TCP channel used to send/receive commands to the CPS controller."""
+
+    TIMEOUT_S = 5.0
+
+    def __init__(self) -> None:
+        self._sock: socket.socket | None = None
+        self._xmlrpc: xmlrpc.client.ServerProxy | None = None
+
+    def connect(self, host: str, port: int) -> int:
+        self._sock = socket.socket()
+        self._sock.settimeout(self.TIMEOUT_S)
+        xmlrpc_url = f"http://{host}:20000"
+        self._xmlrpc = xmlrpc.client.ServerProxy(xmlrpc_url)
+        ret = self._sock.connect_ex((host, port))
+        if ret != 0:
+            self._sock.close()
+            self._sock = None
+        return ret
+
+    def disconnect(self) -> None:
+        if self._sock is not None:
+            self._sock.close()
+            self._sock = None
+
+    def send_recv(self, cmd: str, result: list) -> int:
+        """Send a text command and parse the comma-separated response."""
+        if self._sock is None:
+            return 39500
+        try:
+            self._sock.send(cmd.encode())
+            raw = self._sock.recv(4096).decode("utf-8", "ignore")
+            parts = raw.split(",")
+            if len(parts) < 3 or parts[0] == "errorcmd":
+                return 39503
+            if parts[1] == "Fail":
+                return int(parts[2])
+            # Strip the leading cmd-name and "OK" tokens, and the trailing ';'
+            data = parts[2:]
+            if data and data[-1].strip() in ("", ";"):
+                data = data[:-1]
+            result.clear()
+            result.extend(data)
+            return 0
+        except (OSError, TimeoutError):
+            return 39503
+
+
+class CPSClient:
+    """
+    Client for the Hans Robot CPS (Controller Programming System) interface.
+
+    Uses TCP socket communication on port 10003 for motion commands and
+    XML-RPC on port 20000 for auxiliary operations.
+
+    Supports up to ``MAX_BOXES`` independent controller boxes.
+    """
+
+    MAX_BOXES = 5
+
+    def __init__(self) -> None:
+        self._channels: list[_TcpChannel] = [_TcpChannel() for _ in range(self.MAX_BOXES)]
+        self._connected: list[bool] = [False] * self.MAX_BOXES
+
+    # ------------------------------------------------------------------
+    # Part 1 – Connection & Initialization
+    # ------------------------------------------------------------------
+
+    def HRIF_Connect(self, box_id: int, host: str, port: int) -> int:
+        """Connect to the robot controller TCP server."""
+        if box_id >= self.MAX_BOXES:
+            return 39501
+        ret = self._channels[box_id].connect(host, port)
+        if ret != 0:
+            return 39504
+        self._connected[box_id] = True
+        return 0
+
+    def HRIF_DisConnect(self, box_id: int) -> int:
+        """Disconnect from the robot controller."""
+        if box_id >= self.MAX_BOXES:
+            return 39501
+        self._channels[box_id].disconnect()
+        self._connected[box_id] = False
+        return 0
+
+    def HRIF_IsConnected(self, box_id: int) -> bool:
+        """Return whether this box is currently connected."""
+        return self._connected[box_id]
+
+    def HRIF_Electrify(self, box_id: int) -> int:
+        """Power on the robot body (48 V)."""
+        result: list = []
+        return self._channels[box_id].send_recv("Electrify,;", result)
+
+    def HRIF_BlackOut(self, box_id: int) -> int:
+        """Power off the robot body."""
+        result: list = []
+        return self._channels[box_id].send_recv("BlackOut,;", result)
+
+    def HRIF_Connect2Controller(self, box_id: int) -> int:
+        """Start the EtherCAT master and initialise all drives."""
+        result: list = []
+        return self._channels[box_id].send_recv("StartMaster,;", result)
+
+    # ------------------------------------------------------------------
+    # Part 2 – Axis / Group Control
+    # ------------------------------------------------------------------
+
+    def HRIF_GrpEnable(self, box_id: int, rbt_id: int) -> int:
+        """Enable (servo-on) the robot group."""
+        result: list = []
+        cmd = f"GrpPowerOn,{rbt_id},;"
+        return self._channels[box_id].send_recv(cmd, result)
+
+    def HRIF_GrpDisable(self, box_id: int, rbt_id: int) -> int:
+        """Disable (servo-off) the robot group."""
+        result: list = []
+        cmd = f"GrpPowerOff,{rbt_id},;"
+        return self._channels[box_id].send_recv(cmd, result)
+
+    def HRIF_GrpReset(self, box_id: int, rbt_id: int) -> int:
+        """Reset robot errors."""
+        result: list = []
+        cmd = f"GrpReset,{rbt_id},;"
+        return self._channels[box_id].send_recv(cmd, result)
+
+    def HRIF_GrpStop(self, box_id: int, rbt_id: int) -> int:
+        """Stop all motion immediately."""
+        result: list = []
+        cmd = f"GrpStop,{rbt_id},;"
+        return self._channels[box_id].send_recv(cmd, result)
+
+    def HRIF_GrpOpenFreeDriver(self, box_id: int, rbt_id: int) -> int:
+        """Enable zero-force (gravity-compensated) teaching mode."""
+        result: list = []
+        cmd = f"GrpOpenFreeDriver,{rbt_id},;"
+        return self._channels[box_id].send_recv(cmd, result)
+
+    def HRIF_GrpCloseFreeDriver(self, box_id: int, rbt_id: int) -> int:
+        """Disable zero-force teaching mode."""
+        result: list = []
+        cmd = f"GrpCloseFreeDriver,{rbt_id},;"
+        return self._channels[box_id].send_recv(cmd, result)
+
+    # ------------------------------------------------------------------
+    # Part 3 – State Reading
+    # ------------------------------------------------------------------
+
+    def HRIF_ReadCurFSM(self, box_id: int, rbt_id: int, result: list) -> int:
+        """Read the current FSM state code and description."""
+        cmd = f"ReadCurFSM,{rbt_id},;"
+        return self._channels[box_id].send_recv(cmd, result)
+
+    def HRIF_ReadRobotState(self, box_id: int, rbt_id: int, result: list) -> int:
+        """Read detailed robot state flags (motion, enable, error, …)."""
+        cmd = f"ReadRobotState,{rbt_id},;"
+        return self._channels[box_id].send_recv(cmd, result)
+
+    def HRIF_ReadActJointPos(self, box_id: int, rbt_id: int, result: list) -> int:
+        """Read actual joint positions (degrees) for J1-J6."""
+        cmd = f"ReadActACS,{rbt_id},;"
+        return self._channels[box_id].send_recv(cmd, result)
+
+    def HRIF_ReadActJointVel(self, box_id: int, rbt_id: int, result: list) -> int:
+        """Read actual joint velocities for J1-J6."""
+        cmd = f"ReadActACSVel,{rbt_id},;"
+        return self._channels[box_id].send_recv(cmd, result)
+
+    def HRIF_ReadActTcpPos(self, box_id: int, rbt_id: int, result: list) -> int:
+        """Read actual TCP Cartesian position [X, Y, Z, RX, RY, RZ]."""
+        cmd = f"ReadActPos,{rbt_id},;"
+        return self._channels[box_id].send_recv(cmd, result)
+
+    def HRIF_IsMotionDone(self, box_id: int, rbt_id: int, result: list) -> int:
+        """Return True in result[0] when the robot has finished its current motion."""
+        state: list = []
+        err = self.HRIF_ReadRobotState(box_id, rbt_id, state)
+        if err != 0:
+            return err
+        # result[11] == "1" → not moving; result[0] == "0" → no motion command pending
+        result.append(len(state) > 11 and state[11] == "1" and state[0] == "0")
+        return 0
+
+    # ------------------------------------------------------------------
+    # Part 4 – Speed
+    # ------------------------------------------------------------------
+
+    def HRIF_SetOverride(self, box_id: int, rbt_id: int, ratio: float) -> int:
+        """Set global speed override ratio (0.01 – 1.0)."""
+        result: list = []
+        cmd = f"SetOverride,{rbt_id},{ratio},;"
+        return self._channels[box_id].send_recv(cmd, result)
+
+    # ------------------------------------------------------------------
+    # Part 5 – Motion Commands
+    # ------------------------------------------------------------------
+
+    def HRIF_WayPoint(
+        self,
+        box_id: int,
+        rbt_id: int,
+        end_pos: list[float],
+        acs_pos: list[float],
+        tcp_name: str,
+        ucs_name: str,
+        velocity: float,
+        acc: float,
+        radius: float,
+        move_type: int,
+        is_joint: int,
+        is_seek: int,
+        io_bit: int,
+        io_state: int,
+        cmd_id: str,
+    ) -> int:
+        """
+        Execute a waypoint motion command (WayPoint protocol).
+
+        Note: ``velocity`` must be strictly less than ``acc``; otherwise the
+        controller rejects the command with error 20073.
+
+        Args:
+            box_id: Controller box ID.
+            rbt_id: Robot ID (usually 0).
+            end_pos: Target Cartesian position [X, Y, Z, RX, RY, RZ] (mm / deg).
+                     When ``is_joint=1`` the controller uses ``acs_pos`` as the
+                     target; ``end_pos`` must still be 6 non-zero floats.
+            acs_pos: Target joint angles [J1-J6] in degrees.
+            tcp_name: Name of the tool-coordinate frame (e.g. "TCP").
+            ucs_name: Name of the user-coordinate frame (e.g. "Base").
+            velocity: Motion velocity in deg/s (joint) or mm/s (linear).
+                      Must satisfy ``velocity < acc``.
+            acc: Motion acceleration. Must satisfy ``acc > velocity``.
+            radius: Blending radius in mm (0 = no blending).
+            move_type: Motion type (0 = joint, 1 = linear, 2 = arc).
+            is_joint: Use joint angles (``acs_pos``) as target when 1.
+            is_seek: Enable DI-based seek stop when 1.
+            io_bit: DI bit index for seek.
+            io_state: DI state for seek stop.
+            cmd_id: Waypoint ID string (e.g. "1").
+        """
+        result: list = []
+        parts = ["WayPoint", str(rbt_id)]
+        parts += [str(v) for v in end_pos[:6]]
+        parts += [str(v) for v in acs_pos[:6]]
+        parts += [tcp_name, ucs_name]
+        parts += [str(velocity), str(acc), str(radius)]
+        parts += [str(move_type), str(is_joint), str(is_seek)]
+        parts += [str(io_bit), str(io_state), cmd_id]
+        cmd = ",".join(parts) + ",;"
+        return self._channels[box_id].send_recv(cmd, result)
+
+    def HRIF_MoveJ(
+        self,
+        box_id: int,
+        rbt_id: int,
+        acs_pos: list[float],
+        tcp_name: str = "TCP",
+        ucs_name: str = "Base",
+        velocity: float = 50.0,
+        acc: float = 100.0,
+        radius: float = 0.0,
+        cmd_id: str = "0",
+    ) -> int:
+        """
+        Convenience wrapper: move to a joint-space target.
+
+        Uses the ``WayPoint`` command with ``is_joint=1``.  The same joint
+        target is passed as both the Cartesian hint (``end_pos``) and the
+        joint target (``acs_pos``); the controller uses ``acs_pos`` for actual
+        positioning when ``is_joint=1``.
+
+        Note: ``velocity`` must be strictly less than ``acc`` (controller
+        enforces this constraint).
+        """
+        pos = list(acs_pos)
+        return self.HRIF_WayPoint(
+            box_id=box_id,
+            rbt_id=rbt_id,
+            end_pos=pos,
+            acs_pos=pos,
+            tcp_name=tcp_name,
+            ucs_name=ucs_name,
+            velocity=velocity,
+            acc=acc,
+            radius=radius,
+            move_type=0,
+            is_joint=1,
+            is_seek=0,
+            io_bit=0,
+            io_state=0,
+            cmd_id=cmd_id,
+        )
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def wait_for_fsm(self, box_id: int, rbt_id: int, target_fsm: int, timeout_s: float = 60.0) -> int:
+        """Block until the FSM reaches ``target_fsm`` or timeout expires.
+
+        Returns the final FSM state code.
+        """
+        deadline = time.monotonic() + timeout_s
+        while time.monotonic() < deadline:
+            result: list = []
+            self.HRIF_ReadCurFSM(box_id, rbt_id, result)
+            if result and int(result[0]) == target_fsm:
+                return target_fsm
+            time.sleep(0.1)
+        result = []
+        self.HRIF_ReadCurFSM(box_id, rbt_id, result)
+        return int(result[0]) if result else -1
+
+    def wait_motion_done(self, box_id: int, rbt_id: int, timeout_s: float = 60.0) -> bool:
+        """Block until motion is finished or timeout. Returns True on success."""
+        deadline = time.monotonic() + timeout_s
+        while time.monotonic() < deadline:
+            result: list = []
+            self.HRIF_IsMotionDone(box_id, rbt_id, result)
+            if result and result[0] is True:
+                return True
+            time.sleep(0.02)
+        return False
+
+    @staticmethod
+    def raise_on_error(ret: int, context: str = "") -> None:
+        """Raise a ``RuntimeError`` if *ret* is non-zero."""
+        if ret != 0:
+            msg = f"Hans CPS error {ret}"
+            if context:
+                msg += f" ({context})"
+            raise RuntimeError(msg)

--- a/src/lerobot/robots/hans_s30/hans_s30.py
+++ b/src/lerobot/robots/hans_s30/hans_s30.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python
+
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""LeRobot Robot adapter for the Hans Robot S30 6-DOF industrial arm.
+
+The S30 exposes a 6-joint state/action interface over a TCP socket using
+the CPS (Controller Programming System) protocol. No USB serial port or
+Dynamixel/Feetech bus is required.
+
+Typical usage::
+
+    from lerobot.robots.hans_s30 import HansS30, HansS30RobotConfig
+
+    config = HansS30RobotConfig(ip="192.168.115.11", id="my_hans_s30")
+    robot = HansS30(config)
+    robot.connect()
+
+    obs = robot.get_observation()
+    robot.send_action({"joint_1.pos": 0.0, ..., "joint_6.pos": 0.0})
+
+    robot.disconnect()
+"""
+
+import logging
+import time
+from functools import cached_property
+
+import numpy as np
+
+from lerobot.cameras import make_cameras_from_configs
+from lerobot.types import RobotAction, RobotObservation
+from lerobot.utils.decorators import check_if_already_connected, check_if_not_connected
+
+from ..robot import Robot
+from .config_hans_s30 import HansS30RobotConfig
+from .cps_client import CPSClient, RobotFSM
+
+logger = logging.getLogger(__name__)
+
+# Joint names match the S30 documentation: J1 (base) → J6 (wrist).
+JOINT_NAMES = ["joint_1", "joint_2", "joint_3", "joint_4", "joint_5", "joint_6"]
+
+# Number of degrees of freedom.
+NUM_JOINTS = 6
+
+
+class HansS30(Robot):
+    """LeRobot interface for the Hans Robot S30 6-DOF arm.
+
+    The S30 is an industrial manipulator that communicates via TCP/IP using
+    the Hans CPS protocol. Joint positions are exchanged in **degrees**.
+
+    Connection sequence (handled inside :pymeth:`connect`):
+
+    1. ``HRIF_Connect``      – open TCP socket
+    2. ``HRIF_Electrify``    – power on body (48 V), wait ~15 s
+    3. ``HRIF_Connect2Controller`` – start EtherCAT master, wait ~20 s
+    4. ``HRIF_GrpEnable``    – servo-on all joints
+
+    Disconnection sequence (handled inside :pymeth:`disconnect`):
+
+    1. ``HRIF_GrpDisable``   – servo-off
+    2. ``HRIF_DisConnect``   – close TCP socket
+
+    Observations contain 6 joint positions (deg) and optionally camera frames.
+    Actions contain 6 joint-position targets (deg).
+    """
+
+    config_class = HansS30RobotConfig
+    name = "hans_s30"
+
+    def __init__(self, config: HansS30RobotConfig) -> None:
+        super().__init__(config)
+        self.config = config
+        self._cps = CPSClient()
+        self._is_connected = False
+        self.cameras = make_cameras_from_configs(config.cameras)
+
+    # ------------------------------------------------------------------
+    # Feature descriptors (no hardware access required)
+    # ------------------------------------------------------------------
+
+    @cached_property
+    def observation_features(self) -> dict[str, type | tuple]:
+        features: dict[str, type | tuple] = {f"{j}.pos": float for j in JOINT_NAMES}
+        for cam_key, cam_cfg in self.config.cameras.items():
+            features[cam_key] = (cam_cfg.height, cam_cfg.width, 3)
+        return features
+
+    @cached_property
+    def action_features(self) -> dict[str, type]:
+        return {f"{j}.pos": float for j in JOINT_NAMES}
+
+    # ------------------------------------------------------------------
+    # Connection state
+    # ------------------------------------------------------------------
+
+    @property
+    def is_connected(self) -> bool:
+        return self._is_connected
+
+    @property
+    def is_calibrated(self) -> bool:
+        """The S30 uses absolute encoders; no external calibration is needed."""
+        return True
+
+    def calibrate(self) -> None:
+        """No-op: the S30 ships factory-calibrated."""
+
+    # ------------------------------------------------------------------
+    # Connect / Disconnect
+    # ------------------------------------------------------------------
+
+    @check_if_already_connected
+    def connect(self, calibrate: bool = True) -> None:  # noqa: ARG002
+        """Establish communication and bring the robot to the *standby* state.
+
+        The method is **idempotent with respect to controller state**: it reads
+        the current FSM after opening the TCP socket and skips any initialisation
+        steps that the controller has already completed.  This avoids the
+        ``error 20018`` that occurs when, for example, ``HRIF_Electrify`` is
+        called on a body that is already powered on.
+
+        Typical FSM progression handled automatically:
+
+        * FSM ≤ 7  (body unpowered)      → Electrify → Connect2Controller → GrpEnable
+        * FSM 14   (controller offline)  → Connect2Controller → GrpEnable
+        * FSM 24   (servo disabled)      → GrpEnable only
+        * FSM 33   (standby / already on)→ nothing, just apply speed override
+
+        The ``calibrate`` parameter is accepted for API compatibility but has
+        no effect because the S30 uses absolute encoders.
+
+        Raises:
+            RuntimeError: if any step of the connection sequence fails.
+        """
+        cfg = self.config
+        logger.info(f"Connecting to Hans S30 at {cfg.ip}:{cfg.port} …")
+        CPSClient.raise_on_error(
+            self._cps.HRIF_Connect(cfg.box_id, cfg.ip, cfg.port), "HRIF_Connect"
+        )
+
+        # Read current FSM to decide which init steps are still needed.
+        fsm_result: list = []
+        self._cps.HRIF_ReadCurFSM(cfg.box_id, cfg.robot_id, fsm_result)
+        fsm = int(fsm_result[0]) if fsm_result else -1
+        logger.info(f"Current FSM after TCP connect: {fsm}")
+
+        # ── Step A: Power on body (only when body is unpowered) ──────────────
+        # FSM ≤ 7 means the 48 V supply is off or just coming up.
+        if fsm <= int(RobotFSM.BLACKOUT_48V):
+            logger.info("Powering on robot body …")
+            CPSClient.raise_on_error(self._cps.HRIF_Electrify(cfg.box_id), "HRIF_Electrify")
+            time.sleep(cfg.electrify_wait_s)
+            # Refresh FSM
+            self._cps.HRIF_ReadCurFSM(cfg.box_id, cfg.robot_id, fsm_result)
+            fsm = int(fsm_result[0]) if fsm_result else fsm
+            logger.info(f"FSM after Electrify: {fsm}")
+        else:
+            logger.info(f"Body already powered (FSM={fsm}), skipping Electrify.")
+
+        # ── Step B: Start EtherCAT master (only when controller is offline) ──
+        # FSM 13–14 means EtherCAT master has not been started yet.
+        if fsm <= int(RobotFSM.CONTROLLER_DISCONNECTED):
+            logger.info("Starting EtherCAT master …")
+            CPSClient.raise_on_error(
+                self._cps.HRIF_Connect2Controller(cfg.box_id), "HRIF_Connect2Controller"
+            )
+            time.sleep(cfg.controller_init_wait_s)
+            self._cps.HRIF_ReadCurFSM(cfg.box_id, cfg.robot_id, fsm_result)
+            fsm = int(fsm_result[0]) if fsm_result else fsm
+            logger.info(f"FSM after Connect2Controller: {fsm}")
+        else:
+            logger.info(f"Controller already initialised (FSM={fsm}), skipping Connect2Controller.")
+
+        # ── Step C: Enable servo group (only when servos are off) ────────────
+        # FSM 24 = DISABLED means servos are off but everything else is ready.
+        if fsm <= int(RobotFSM.DISABLED):
+            logger.info("Enabling servo group …")
+            CPSClient.raise_on_error(
+                self._cps.HRIF_GrpEnable(cfg.box_id, cfg.robot_id), "HRIF_GrpEnable"
+            )
+            fsm = self._cps.wait_for_fsm(
+                cfg.box_id, cfg.robot_id, RobotFSM.STANDBY, timeout_s=30.0
+            )
+            logger.info(f"FSM after GrpEnable: {fsm}")
+        else:
+            logger.info(f"Servos already enabled (FSM={fsm}), skipping GrpEnable.")
+
+        if fsm not in (int(RobotFSM.STANDBY), int(RobotFSM.DISABLED), int(RobotFSM.MOVING)):
+            logger.warning(f"Unexpected FSM state after connect sequence: {fsm}")
+
+        # Apply global speed override.
+        self._cps.HRIF_SetOverride(cfg.box_id, cfg.robot_id, cfg.speed_override)
+
+        for cam in self.cameras.values():
+            cam.connect()
+
+        self._is_connected = True
+        logger.info(f"{self} connected (final FSM={fsm}).")
+
+    @check_if_not_connected
+    def disconnect(self) -> None:
+        """Disable servos, release cameras, and close the TCP socket."""
+        cfg = self.config
+        logger.info(f"Disabling servo group for {self} …")
+        self._cps.HRIF_GrpDisable(cfg.box_id, cfg.robot_id)
+
+        for cam in self.cameras.values():
+            cam.disconnect()
+
+        self._cps.HRIF_DisConnect(cfg.box_id)
+        self._is_connected = False
+        logger.info(f"{self} disconnected.")
+
+    # ------------------------------------------------------------------
+    # Configuration (no-op for industrial arm)
+    # ------------------------------------------------------------------
+
+    def configure(self) -> None:
+        """No additional runtime configuration is required for the S30."""
+
+    # ------------------------------------------------------------------
+    # Observation
+    # ------------------------------------------------------------------
+
+    @check_if_not_connected
+    def get_observation(self) -> RobotObservation:
+        """Read current joint positions and camera frames.
+
+        Returns:
+            dict with keys ``joint_1.pos`` … ``joint_6.pos`` (float, degrees)
+            plus one key per camera returning an ``(H, W, 3)`` uint8 array.
+        """
+        cfg = self.config
+        result: list = []
+        start = time.perf_counter()
+        ret = self._cps.HRIF_ReadActJointPos(cfg.box_id, cfg.robot_id, result)
+        dt_ms = (time.perf_counter() - start) * 1e3
+        logger.debug(f"{self} read joints: {dt_ms:.1f} ms")
+
+        if ret != 0 or len(result) < NUM_JOINTS:
+            raise RuntimeError(f"Failed to read joint positions (error {ret})")
+
+        obs: RobotObservation = {
+            f"{j}.pos": float(result[i]) for i, j in enumerate(JOINT_NAMES)
+        }
+
+        for cam_key, cam in self.cameras.items():
+            start = time.perf_counter()
+            obs[cam_key] = cam.read_latest()
+            dt_ms = (time.perf_counter() - start) * 1e3
+            logger.debug(f"{self} read {cam_key}: {dt_ms:.1f} ms")
+
+        return obs
+
+    # ------------------------------------------------------------------
+    # Action
+    # ------------------------------------------------------------------
+
+    @check_if_not_connected
+    def send_action(self, action: RobotAction) -> RobotAction:
+        """Command the arm to move to a target joint configuration.
+
+        The action dict must contain keys ``joint_1.pos`` … ``joint_6.pos``
+        with values in **degrees**.
+
+        If ``config.max_relative_target`` is set, the displacement from the
+        current position is clamped to that value per joint.
+
+        Args:
+            action: Target joint positions in degrees.
+
+        Returns:
+            The action actually sent (after optional safety clamping).
+        """
+        cfg = self.config
+        goal = [float(action[f"{j}.pos"]) for j in JOINT_NAMES]
+
+        if cfg.max_relative_target is not None:
+            # Read current positions to apply safety clamping.
+            result: list = []
+            ret = self._cps.HRIF_ReadActJointPos(cfg.box_id, cfg.robot_id, result)
+            if ret == 0 and len(result) >= NUM_JOINTS:
+                current = [float(result[i]) for i in range(NUM_JOINTS)]
+                delta = np.array(goal) - np.array(current)
+                clipped = np.clip(delta, -cfg.max_relative_target, cfg.max_relative_target)
+                goal = (np.array(current) + clipped).tolist()
+
+        ret = self._cps.HRIF_MoveJ(
+            box_id=cfg.box_id,
+            rbt_id=cfg.robot_id,
+            acs_pos=goal,
+            tcp_name=cfg.tcp_name,
+            ucs_name=cfg.ucs_name,
+            velocity=cfg.velocity,
+            acc=cfg.acc,
+        )
+        if ret != 0:
+            logger.warning(f"{self} HRIF_MoveJ returned error {ret}")
+
+        return {f"{j}.pos": goal[i] for i, j in enumerate(JOINT_NAMES)}
+
+    # ------------------------------------------------------------------
+    # Zero-force teaching (useful for manual teleoperation / dataset collection)
+    # ------------------------------------------------------------------
+
+    def _read_fsm(self) -> int:
+        """Return the current FSM state code, or -1 on error."""
+        result: list = []
+        ret = self._cps.HRIF_ReadCurFSM(self.config.box_id, self.config.robot_id, result)
+        if ret != 0 or not result:
+            return -1
+        return int(result[0])
+
+    def _wait_for_standby(self, timeout_s: float = 15.0) -> int:
+        """Block until the robot reaches STANDBY (FSM=33) or timeout.
+
+        Returns the final FSM state code.
+        """
+        return self._cps.wait_for_fsm(
+            self.config.box_id, self.config.robot_id, RobotFSM.STANDBY, timeout_s=timeout_s
+        )
+
+    @check_if_not_connected
+    def enable_free_driver(self) -> None:
+        """Switch to zero-force (gravity-compensated) teaching mode.
+
+        ``GrpOpenFreeDriver`` requires the robot to be in **STANDBY** state
+        (FSM=33). This method first waits up to 15 s for that state and raises
+        a ``RuntimeError`` if the robot does not reach it in time.
+
+        In this mode the arm can be manually guided. Use
+        :pymeth:`disable_free_driver` to return to position-control mode.
+
+        Raises:
+            RuntimeError: if the robot is not in STANDBY after waiting, or if
+                the controller rejects the command.
+        """
+        cfg = self.config
+
+        # GrpOpenFreeDriver requires STANDBY (33); wait if not there yet.
+        fsm = self._read_fsm()
+        if fsm != int(RobotFSM.STANDBY):
+            logger.info(f"FSM={fsm}, waiting for STANDBY before enabling free driver …")
+            fsm = self._wait_for_standby(timeout_s=15.0)
+
+        if fsm != int(RobotFSM.STANDBY):
+            raise RuntimeError(
+                f"Cannot enable free-driver mode: robot is in FSM state {fsm} "
+                f"(expected STANDBY=33). Check robot for errors."
+            )
+
+        ret = self._cps.HRIF_GrpOpenFreeDriver(cfg.box_id, cfg.robot_id)
+        if ret == 20606:
+            raise RuntimeError(
+                "Free-driver (zero-force teaching) mode is disabled on this controller "
+                "(error 20606: 'Free drive function is disabled'). "
+                "Please activate the zero-force teaching license on the Hans controller "
+                "or enable it in the teach pendant's system settings."
+            )
+        CPSClient.raise_on_error(ret, "HRIF_GrpOpenFreeDriver")
+        logger.info(f"{self} entered zero-force teaching mode.")
+
+    @check_if_not_connected
+    def disable_free_driver(self) -> None:
+        """Exit zero-force teaching mode and return to position control."""
+        cfg = self.config
+        CPSClient.raise_on_error(
+            self._cps.HRIF_GrpCloseFreeDriver(cfg.box_id, cfg.robot_id),
+            "HRIF_GrpCloseFreeDriver",
+        )
+        # Wait for the robot to settle back to STANDBY after closing free driver.
+        fsm = self._wait_for_standby(timeout_s=10.0)
+        logger.info(f"{self} exited zero-force teaching mode (FSM={fsm}).")

--- a/tests/robots/test_hans_s30.py
+++ b/tests/robots/test_hans_s30.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python
+
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the Hans Robot S30 adapter.
+
+All tests run fully offline using a mock CPSClient – no physical robot
+or network connection is required.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from lerobot.robots.hans_s30 import HansS30, HansS30RobotConfig
+from lerobot.robots.hans_s30.cps_client import CPSClient, RobotFSM
+from lerobot.utils.errors import DeviceAlreadyConnectedError, DeviceNotConnectedError
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+JOINT_NAMES = ["joint_1", "joint_2", "joint_3", "joint_4", "joint_5", "joint_6"]
+FAKE_JOINT_POS = [10.0, -20.0, 30.0, 0.0, 45.5, -10.0]
+
+
+def _make_cps_mock() -> MagicMock:
+    """Build a CPSClient mock that simulates a healthy, connected robot."""
+    cps = MagicMock(spec=CPSClient)
+    cps.HRIF_IsConnected.return_value = True
+
+    # All commands return 0 (success) by default.
+    for method in [
+        "HRIF_Connect",
+        "HRIF_Electrify",
+        "HRIF_Connect2Controller",
+        "HRIF_GrpEnable",
+        "HRIF_GrpDisable",
+        "HRIF_DisConnect",
+        "HRIF_SetOverride",
+        "HRIF_GrpOpenFreeDriver",
+        "HRIF_GrpCloseFreeDriver",
+        "HRIF_MoveJ",
+    ]:
+        getattr(cps, method).return_value = 0
+
+    # wait_for_fsm returns STANDBY immediately.
+    cps.wait_for_fsm.return_value = int(RobotFSM.STANDBY)
+
+    # ReadActJointPos fills result with fake joint values.
+    def _read_joints(_box, _rbt, result):
+        result.clear()
+        result.extend([str(v) for v in FAKE_JOINT_POS])
+        return 0
+
+    cps.HRIF_ReadActJointPos.side_effect = _read_joints
+    return cps
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def robot():
+    """Return a HansS30 instance with a fully mocked CPSClient (no hardware)."""
+    cfg = HansS30RobotConfig(ip="192.168.0.1", id="test_s30")
+
+    with patch("lerobot.robots.hans_s30.hans_s30.CPSClient", return_value=_make_cps_mock()):
+        r = HansS30(cfg)
+        yield r
+        if r.is_connected:
+            r.disconnect()
+
+
+# ---------------------------------------------------------------------------
+# Tests: CPSClient protocol
+# ---------------------------------------------------------------------------
+
+
+class TestCPSClientProtocol:
+    """Verify that CPSClient builds the correct TCP command strings."""
+
+    def setup_method(self):
+        self.cps = CPSClient()
+        self.captured: list[str] = []
+
+        class FakeChannel:
+            def send_recv(self_, cmd, result):  # noqa: N805
+                self.captured.append(cmd)
+                return 0
+
+        self.cps._channels[0] = FakeChannel()
+
+    def test_grp_enable_command(self):
+        self.cps.HRIF_GrpEnable(0, 0)
+        assert self.captured[-1] == "GrpPowerOn,0,;"
+
+    def test_grp_disable_command(self):
+        self.cps.HRIF_GrpDisable(0, 0)
+        assert self.captured[-1] == "GrpPowerOff,0,;"
+
+    def test_set_override_command(self):
+        self.cps.HRIF_SetOverride(0, 0, 0.5)
+        assert self.captured[-1] == "SetOverride,0,0.5,;"
+
+    def test_read_joint_pos_command(self):
+        result: list = []
+        self.cps.HRIF_ReadActJointPos(0, 0, result)
+        assert self.captured[-1] == "ReadActACS,0,;"
+
+    def test_move_j_builds_waypoint(self):
+        self.cps.HRIF_MoveJ(0, 0, [10.0, -20.0, 30.0, 0.0, 45.0, -10.0])
+        cmd = self.captured[-1]
+        assert cmd.startswith("WayPoint,")
+        assert "10.0,-20.0,30.0,0.0,45.0,-10.0" in cmd
+        assert "TCP" in cmd
+        assert "Base" in cmd
+        # is_joint flag must be 1 for pure joint-space motion
+        assert ",1," in cmd
+        assert cmd.endswith(",;")
+
+    def test_open_free_driver_command(self):
+        self.cps.HRIF_GrpOpenFreeDriver(0, 0)
+        assert self.captured[-1] == "GrpOpenFreeDriver,0,;"
+
+    def test_raise_on_error_zero(self):
+        CPSClient.raise_on_error(0)  # should not raise
+
+    def test_raise_on_error_nonzero(self):
+        with pytest.raises(RuntimeError, match="39504"):
+            CPSClient.raise_on_error(39504, "connect")
+
+
+# ---------------------------------------------------------------------------
+# Tests: HansS30 Robot interface
+# ---------------------------------------------------------------------------
+
+
+class TestHansS30Config:
+    def test_default_config_values(self):
+        cfg = HansS30RobotConfig(ip="10.0.0.1", id="arm")
+        assert cfg.port == 10003
+        assert cfg.velocity == 50.0
+        assert cfg.speed_override == 0.5
+        assert cfg.tcp_name == "TCP"
+        assert cfg.type == "hans_s30"
+
+    def test_custom_config(self):
+        cfg = HansS30RobotConfig(ip="192.168.1.1", port=10004, velocity=30.0, id="custom")
+        assert cfg.port == 10004
+        assert cfg.velocity == 30.0
+
+
+class TestHansS30Features:
+    def test_observation_features_keys(self, robot):
+        keys = set(robot.observation_features.keys())
+        assert keys == {f"{j}.pos" for j in JOINT_NAMES}
+
+    def test_action_features_keys(self, robot):
+        keys = set(robot.action_features.keys())
+        assert keys == {f"{j}.pos" for j in JOINT_NAMES}
+
+    def test_observation_features_types(self, robot):
+        for key, typ in robot.observation_features.items():
+            assert typ is float, f"{key} should be float"
+
+    def test_is_calibrated_always_true(self, robot):
+        assert robot.is_calibrated is True
+
+    def test_calibrate_is_noop(self, robot):
+        robot.calibrate()  # must not raise
+
+    def test_name(self, robot):
+        assert robot.name == "hans_s30"
+
+
+class TestHansS30Connection:
+    def test_initial_state_disconnected(self, robot):
+        assert not robot.is_connected
+
+    def test_connect_sets_connected(self, robot):
+        robot.connect()
+        assert robot.is_connected
+
+    def test_disconnect_clears_connected(self, robot):
+        robot.connect()
+        robot.disconnect()
+        assert not robot.is_connected
+
+    def test_connect_calls_correct_sequence(self, robot):
+        robot.connect()
+        cps = robot._cps
+        cps.HRIF_Connect.assert_called_once()
+        cps.HRIF_Electrify.assert_called_once()
+        cps.HRIF_Connect2Controller.assert_called_once()
+        cps.HRIF_GrpEnable.assert_called_once()
+        cps.HRIF_SetOverride.assert_called_once()
+
+    def test_disconnect_calls_disable_and_close(self, robot):
+        robot.connect()
+        robot.disconnect()
+        cps = robot._cps
+        cps.HRIF_GrpDisable.assert_called_once()
+        cps.HRIF_DisConnect.assert_called_once()
+
+    def test_double_connect_raises(self, robot):
+        robot.connect()
+        with pytest.raises(DeviceAlreadyConnectedError):
+            robot.connect()
+
+    def test_get_observation_without_connect_raises(self, robot):
+        with pytest.raises(DeviceNotConnectedError):
+            robot.get_observation()
+
+    def test_send_action_without_connect_raises(self, robot):
+        action = {f"{j}.pos": 0.0 for j in JOINT_NAMES}
+        with pytest.raises(DeviceNotConnectedError):
+            robot.send_action(action)
+
+
+class TestHansS30Observation:
+    def test_get_observation_returns_six_joints(self, robot):
+        robot.connect()
+        obs = robot.get_observation()
+        assert set(obs.keys()) == {f"{j}.pos" for j in JOINT_NAMES}
+
+    def test_get_observation_values_are_floats(self, robot):
+        robot.connect()
+        obs = robot.get_observation()
+        for key, val in obs.items():
+            assert isinstance(val, float), f"{key} should be float, got {type(val)}"
+
+    def test_get_observation_values_match_mock(self, robot):
+        robot.connect()
+        obs = robot.get_observation()
+        for i, j in enumerate(JOINT_NAMES):
+            assert obs[f"{j}.pos"] == pytest.approx(FAKE_JOINT_POS[i])
+
+
+class TestHansS30Action:
+    def test_send_action_returns_dict_with_correct_keys(self, robot):
+        robot.connect()
+        action = {f"{j}.pos": float(i * 10) for i, j in enumerate(JOINT_NAMES, 1)}
+        returned = robot.send_action(action)
+        assert set(returned.keys()) == {f"{j}.pos" for j in JOINT_NAMES}
+
+    def test_send_action_calls_move_j(self, robot):
+        robot.connect()
+        action = {f"{j}.pos": float(i * 5) for i, j in enumerate(JOINT_NAMES, 1)}
+        robot.send_action(action)
+        robot._cps.HRIF_MoveJ.assert_called_once()
+
+    def test_send_action_passes_correct_joint_values(self, robot):
+        robot.connect()
+        target = [5.0, 10.0, 15.0, 20.0, 25.0, 30.0]
+        action = {f"{j}.pos": target[i] for i, j in enumerate(JOINT_NAMES)}
+        robot.send_action(action)
+
+        call_args = robot._cps.HRIF_MoveJ.call_args
+        sent_joints = call_args.kwargs.get("acs_pos") or call_args.args[2]
+        assert sent_joints == pytest.approx(target)
+
+    def test_send_action_with_max_relative_target_clamps(self):
+        """When max_relative_target is set, large jumps must be clamped."""
+        cfg = HansS30RobotConfig(ip="0.0.0.0", id="clamp_test", max_relative_target=5.0)
+
+        with patch("lerobot.robots.hans_s30.hans_s30.CPSClient", return_value=_make_cps_mock()):
+            r = HansS30(cfg)
+            r.connect()
+
+            # Current position from mock: FAKE_JOINT_POS = [10, -20, 30, 0, 45.5, -10]
+            # Request a 50-degree jump on joint_1 → should be clamped to +5
+            action = {f"{j}.pos": FAKE_JOINT_POS[i] + 50.0 for i, j in enumerate(JOINT_NAMES)}
+            returned = robot.send_action(action) if False else r.send_action(action)
+
+            for j in JOINT_NAMES:
+                i = JOINT_NAMES.index(j)
+                assert returned[f"{j}.pos"] == pytest.approx(FAKE_JOINT_POS[i] + 5.0)
+
+            r.disconnect()
+
+
+class TestHansS30FreeDriver:
+    def test_enable_free_driver(self, robot):
+        robot.connect()
+        robot.enable_free_driver()
+        robot._cps.HRIF_GrpOpenFreeDriver.assert_called_once()
+
+    def test_disable_free_driver(self, robot):
+        robot.connect()
+        robot.disable_free_driver()
+        robot._cps.HRIF_GrpCloseFreeDriver.assert_called_once()
+
+    def test_free_driver_without_connect_raises(self, robot):
+        with pytest.raises(DeviceNotConnectedError):
+            robot.enable_free_driver()
+
+
+# ---------------------------------------------------------------------------
+# Tests: RobotFSM enum
+# ---------------------------------------------------------------------------
+
+
+class TestRobotFSM:
+    def test_standby_value(self):
+        assert int(RobotFSM.STANDBY) == 33
+
+    def test_free_driver_value(self):
+        assert int(RobotFSM.FREE_DRIVER) == 31
+
+    def test_disabled_value(self):
+        assert int(RobotFSM.DISABLED) == 24
+
+    def test_moving_value(self):
+        assert int(RobotFSM.MOVING) == 25


### PR DESCRIPTION
## Summary / Motivation

This PR adds a new LeRobot `Robot` implementation for the [Hans Robot S30](https://www.hansrobot.com/) 6-DOF industrial arm. The controller is reached over the network via the vendor **CPS (Controller Programming System)** TCP API (default port 10003) and XML-RPC (port 20000), so no USB serial or Dynamixel/Feetech bus is required. The adapter exposes the standard observation/action joint interface (`joint_1.pos` … `joint_6.pos` in degrees), optional OpenCV cameras, example scripts under `examples/hans_s30/`, and offline unit tests with a mocked CPS client so CI does not need hardware.

**Design notes:** CPS method names follow the vendor SDK (`HRIF_*`); ruff `N802` is suppressed for `cps_client.py` only to keep names aligned with the official API.

## Related issues

- Fixes / Closes: #
- Related: #

## What changed

- **New package** `src/lerobot/robots/hans_s30/`: `HansS30` robot class, `HansS30RobotConfig` registered as `type="hans_s30"`, `CPSClient` wrapper for TCP/XML-RPC CPS calls (power, EtherCAT init, servo on/off, joint reads, `MoveJ`, zero-force teaching helpers).
- **`examples/hans_s30/`**: `README.md`, `teleoperate.py`, `record.py`, `replay.py`, `evaluate.py` for teaching, dataset recording, replay, and policy eval.
- **`tests/robots/test_hans_s30.py`**: offline tests with mocked `CPSClient` (connection lifecycle, observations, actions, error paths).
- **`pyproject.toml`**: per-file ruff ignore for `cps_client.py` (`N802`) only.

**Breaking changes:** None. This is additive; existing robots and configs are unchanged.

## How was this tested (or how to run locally)

**Tests added**

- `tests/robots/test_hans_s30.py` — mock-based, no robot or network required.

pytest -q tests/robots/test_hans_s30.py
