### PR TITLE
fix(envs): set LiberoEnvConfig.fps default to 20 to match robosuite

### DIFF
--- a/src/lerobot/envs/configs.py
+++ b/src/lerobot/envs/configs.py
@@ -322,7 +322,7 @@ class HILSerlRobotEnvConfig(EnvConfig):
 class LiberoEnv(EnvConfig):
     task: str = "libero_10"  # can also choose libero_spatial, libero_object, etc.
     task_ids: list[int] | None = None
-    fps: int = 30
+    fps: int = 20  # Must match robosuite's default control_freq (20 Hz)
     episode_length: int | None = None
     obs_type: str = "pixels_agent_pos"
     render_mode: str = "rgb_array"


### PR DESCRIPTION
## Description

`LiberoEnvConfig.fps` in `src/lerobot/envs/configs.py` defaults to `30`, but the underlying robosuite `OffScreenRenderEnv` (created in `src/lerobot/envs/libero.py`) is never passed a `control_freq` argument, so it always runs at robosuite's default of **20 Hz**.

This means setting `fps` in the config has no effect on the actual simulation rate — it silently decouples the dataset/eval loop rate from the real env step rate.

## Fix

Sets the default `fps` to `20` to match the actual robosuite control frequency. This is the simpler of the two options discussed in #3368 (Option 1: hardcode to match reality).

Fixes #3368