### PR TITLE
chore: bump doc-builder SHA for main doc build workflow

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -55,7 +55,7 @@ jobs:
       github.repository == 'huggingface/lerobot'
     permissions:
       contents: read
-    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@90b4ee2c10b81b5c1a6367c4e6fc9e2fb510a7e3  # main
+    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@9ad2de8582b56c017cb530c1165116d40433f1c6  # main
     with:
       commit_sha: ${{ github.sha }}
       package: lerobot


### PR DESCRIPTION
Bump the pinned doc-builder SHA so that main documentation builds also sync to the HF bucket (dual-write).
