### PR TITLE
fix(dataset): cleanup_interrupted_episode wipes image temp dirs

### DIFF
--- a/src/lerobot/datasets/dataset_writer.py
+++ b/src/lerobot/datasets/dataset_writer.py
@@ -597,7 +597,7 @@ class DatasetWriter:
 
     def cleanup_interrupted_episode(self, episode_index: int) -> None:
         """Remove temporary image directories for an interrupted episode."""
-        for key in self._meta.video_keys:
+        for key in self._meta.camera_keys:
             img_dir = self._get_image_file_path(
                 episode_index=episode_index, image_key=key, frame_index=0
             ).parent

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -454,6 +454,35 @@ def test_tmp_video_deletion(tmp_path, empty_lerobot_dataset_factory):
     )
 
 
+def test_cleanup_interrupted_episode_removes_image_temp_dirs(tmp_path, empty_lerobot_dataset_factory):
+    """Verify interrupted episode cleanup removes temporary image directories for both image and video features."""
+    features = {
+        "image": {"dtype": "image", "shape": DUMMY_CHW, "names": ["channels", "height", "width"]},
+        "video": {"dtype": "video", "shape": DUMMY_HWC, "names": ["height", "width", "channels"]},
+    }
+    ds = empty_lerobot_dataset_factory(
+        root=tmp_path / "interrupted", features=features, streaming_encoding=False
+    )
+    # Add one frame without saving episode simulating an interruption
+    ds.add_frame(
+        {
+            "image": np.random.rand(*DUMMY_CHW),
+            "video": np.random.rand(*DUMMY_HWC),
+            "task": "Dummy task",
+        }
+    )
+    img_dir = ds.writer._get_image_file_dir(0, "image")
+    vid_img_dir = ds.writer._get_image_file_dir(0, "video")
+    # Precondition: both temp dirs exist after add_frame.
+    assert img_dir.exists()
+    assert vid_img_dir.exists()
+
+    ds.writer.cleanup_interrupted_episode(episode_index=0)
+
+    assert not img_dir.exists(), "image temp dir leaked after cleanup_interrupted_episode"
+    assert not vid_img_dir.exists(), "video temp dir leaked after cleanup_interrupted_episode"
+
+
 def test_tmp_mixed_deletion(tmp_path, empty_lerobot_dataset_factory):
     """Verify temporary image directories are removed appropriately when both image and video features are present."""
     image_key = "image"


### PR DESCRIPTION
## Title

`fix(dataset): cleanup_interrupted_episode wipes image temp dirs`

## Summary / Motivation

`DatasetWriter.cleanup_interrupted_episode` iterated only `self._meta.video_keys`. The loop is reached from `VideoEncodingManager.__exit__` when an exception propagates out of the recording block. `clear_episode_buffer(delete_images=True)` handles `image_keys` correctly, but it only runs on the `save_episode` path -> which does not run when recording aborts.

Severity is low: extra files on disk, but I do believe it is some sort of issue that needs to be fixed.

## Related issues

- Fixes / Closes: #3404 
- Related: N/A

## What changed

- `DatasetWriter.cleanup_interrupted_episode` now iterates `self._meta.camera_keys` (= `image_keys + video_keys`) instead of `video_keys`. `shutil.rmtree` is idempotent so keys with nothing on disk cost almost nothing to traverse.
- New regression test `test_cleanup_interrupted_episode_removes_image_temp_dirs` in `tests/datasets/test_datasets.py`: `add_frame` without `save_episode` (simulating abort), call `cleanup_interrupted_episode`, assert both the image and video temp dirs are gone.
- No API change. No behavior change on the successful-recording path.

## How was this tested (or how to run locally)

### Regression test

- **fails** on the pre-fix code (`video_keys`)
- **passes** on the fix (`camera_keys`)

Run locally:

```bash
uv run pytest -v tests/datasets/test_datasets.py::test_cleanup_interrupted_episode_removes_image_temp_dirs
```

Full datasets tests still pass on the fix:

```log
66 passed, 2 skipped, 149 warnings in 390.13s (0:06:30)
```

Run locally:

```bash
uv run pytest -v tests/datasets/test_datasets.py
```

## Checklist (required before merge)

- [x] Linting/formatting run: Have run `ruff`
- [x] All tests pass locally: for the affected subset and `datasets` module
- [x] Documentation updated:  private helper, no user-facing contract change
- [ ] CI is green
- [ ] Community Review: TBC

## Reviewer notes

N/A