### PR TITLE
docs(il_robots): update API examples and bash snippets from SO100 to SO101

### DIFF
--- a/docs/source/il_robots.mdx
+++ b/docs/source/il_robots.mdx
@@ -515,18 +515,18 @@ You can use the `record` script from [`lerobot-record`](https://github.com/huggi
 <hfoption id="Command">
 ```bash
 lerobot-record  \
-  --robot.type=so100_follower \
+  --robot.type=so101_follower \
   --robot.port=/dev/ttyACM1 \
   --robot.cameras="{ up: {type: opencv, index_or_path: /dev/video10, width: 640, height: 480, fps: 30}, side: {type: intelrealsense, serial_number_or_name: 233522074606, width: 640, height: 480, fps: 30}}" \
   --robot.id=my_awesome_follower_arm \
   --display_data=false \
-  --dataset.repo_id=${HF_USER}/eval_so100 \
+  --dataset.repo_id=${HF_USER}/eval_so101 \
   --dataset.single_task="Put lego brick into the transparent box" \
   --dataset.streaming_encoding=true \
   --dataset.encoder_threads=2 \
   # --dataset.vcodec=auto \
   # <- Teleop optional if you want to teleoperate in between episodes \
-  # --teleop.type=so100_leader \
+  # --teleop.type=so101_leader \
   # --teleop.port=/dev/ttyACM0 \
   # --teleop.id=my_awesome_leader_arm \
   --policy.path=${HF_USER}/my_policy

--- a/docs/source/il_robots.mdx
+++ b/docs/source/il_robots.mdx
@@ -204,8 +204,8 @@ lerobot-record \
 from lerobot.cameras.opencv import OpenCVCameraConfig
 from lerobot.datasets import LeRobotDataset
 from lerobot.utils.feature_utils import hw_to_dataset_features
-from lerobot.robots.so_follower import SO100Follower, SO100FollowerConfig
-from lerobot.teleoperators.so_leader import SO100Leader, SO100LeaderConfig
+from lerobot.robots.so_follower import SO101Follower, SO101FollowerConfig
+from lerobot.teleoperators.so_leader import SO101Leader, SO101LeaderConfig
 from lerobot.common.control_utils import init_keyboard_listener
 from lerobot.utils.utils import log_say
 from lerobot.utils.visualization_utils import init_rerun
@@ -219,7 +219,7 @@ RESET_TIME_SEC = 10
 TASK_DESCRIPTION = "My task description"
 
 # Create robot configuration
-robot_config = SO100FollowerConfig(
+robot_config = SO101FollowerConfig(
     id="my_awesome_follower_arm",
     cameras={
         "front": OpenCVCameraConfig(index_or_path=0, width=640, height=480, fps=FPS) # Optional: fourcc="MJPG" for troubleshooting OpenCV async error.
@@ -227,14 +227,14 @@ robot_config = SO100FollowerConfig(
     port="/dev/tty.usbmodem58760434471",
 )
 
-teleop_config = SO100LeaderConfig(
+teleop_config = SO101LeaderConfig(
     id="my_awesome_leader_arm",
     port="/dev/tty.usbmodem585A0077581",
 )
 
 # Initialize the robot and teleoperator
-robot = SO100Follower(robot_config)
-teleop = SO100Leader(teleop_config)
+robot = SO101Follower(robot_config)
+teleop = SO101Leader(teleop_config)
 
 # Configure the dataset features
 action_features = hw_to_dataset_features(robot.action_features, "action")
@@ -416,15 +416,15 @@ lerobot-replay \
 import time
 
 from lerobot.datasets import LeRobotDataset
-from lerobot.robots.so_follower import SO100Follower, SO100FollowerConfig
+from lerobot.robots.so_follower import SO101Follower, SO101FollowerConfig
 from lerobot.utils.robot_utils import precise_sleep
 from lerobot.utils.utils import log_say
 
 episode_idx = 0
 
-robot_config = SO100FollowerConfig(port="/dev/tty.usbmodem58760434471", id="my_awesome_follower_arm")
+robot_config = SO101FollowerConfig(port="/dev/tty.usbmodem58760434471", id="my_awesome_follower_arm")
 
-robot = SO100Follower(robot_config)
+robot = SO101Follower(robot_config)
 robot.connect()
 
 dataset = LeRobotDataset("<hf_username>/<dataset_repo_id>", episodes=[episode_idx])
@@ -541,7 +541,7 @@ from lerobot.datasets import LeRobotDataset
 from lerobot.utils.feature_utils import hw_to_dataset_features
 from lerobot.policies.act import ACTPolicy
 from lerobot.policies import make_pre_post_processors
-from lerobot.robots.so_follower import SO100Follower, SO100FollowerConfig
+from lerobot.robots.so_follower import SO101Follower, SO101FollowerConfig
 from lerobot.scripts.lerobot_record import record_loop
 from lerobot.common.control_utils import init_keyboard_listener
 from lerobot.utils.utils import log_say
@@ -557,12 +557,12 @@ HF_DATASET_ID = "<hf_username>/<eval_dataset_repo_id>"
 
 # Create the robot configuration
 camera_config = {"front": OpenCVCameraConfig(index_or_path=0, width=640, height=480, fps=FPS)}
-robot_config = SO100FollowerConfig(
+robot_config = SO101FollowerConfig(
     port="/dev/tty.usbmodem58760434471", id="my_awesome_follower_arm", cameras=camera_config
 )
 
 # Initialize the robot
-robot = SO100Follower(robot_config)
+robot = SO101Follower(robot_config)
 
 # Initialize the policy
 policy = ACTPolicy.from_pretrained(HF_MODEL_ID)


### PR DESCRIPTION
## Summary
Addresses the SO100 / SO101 naming inconsistency half of #3219.

Inside `docs/source/il_robots.mdx`, bash commands and Python API examples previously mixed old SO100 class names with newer SO101 names. This PR makes the tutorial use SO101 consistently across every section where SO100/SO101 appear.

## Scope (explicit)
This PR **only** addresses the naming inconsistency. It does **not** fix the "rerun.io visualization not showing data" part of #3219 — that root cause appears unrelated to class naming and warrants separate investigation. Issue #3219 should stay open for the visualization problem after this lands.

Refs #3219

## Changes
All SO100 → SO101 renames in `docs/source/il_robots.mdx`:

- **Record a dataset** (~line 207-237): Python API example — `SO100Follower`, `SO100FollowerConfig`, `SO100Leader`, `SO100LeaderConfig` → SO101 equivalents.
- **Replay an episode** (~line 419-427): Python API example — same classes.
- **Run inference and evaluate your policy — Command** (~line 518-529): bash args — `so100_follower` / `eval_so100` / `so100_leader` → SO101.
- **Run inference and evaluate your policy — API example** (~line 544-565): Python API example — same classes.

The SO101 classes (`SO101Follower`, `SO101FollowerConfig`, `SO101Leader`, `SO101LeaderConfig`) are already exported from `lerobot.robots.so_follower` and `lerobot.teleoperators.so_leader`.

## Testing
Documentation-only change, no code paths affected. After the change:

\`\`\`
$ grep -i so100 docs/source/il_robots.mdx
(no matches)
\`\`\`

SO101 now appears uniformly where SO100 used to.

## Notes
Keeping the PR as a draft for now — please convert to ready-for-review when you're happy with it.