### PR TITLE
fix(xvla): remove gripper zeroing and sigmoid from BimanualSO101 action space

### DIFF
--- a/docs/source/xvla.mdx
+++ b/docs/source/xvla.mdx
@@ -201,8 +201,8 @@ X-VLA uses an **Action Registry** system to handle different action spaces and e
 When you have a pretrained checkpoint like `lerobot/xvla-base` trained with `action_dim=20`, and you want to train on a dataset with a different action dimension (e.g., 14 for bimanual arms), you can't simply trim the action dimension. The action mode orchestrates:
 
 1. **Loss Computation**: Different loss functions for different action components (MSE for joints, BCE for grippers, etc.)
-2. **Preprocessing**: Zeroing out gripper channels, padding dimensions
-3. **Postprocessing**: Applying sigmoid to gripper logits, trimming padding
+2. **Preprocessing**: Padding dimensions and, for action modes with a binary gripper (`ee6d`, `joint`), zeroing out gripper channels
+3. **Postprocessing**: Trimming padding and, for action modes with a binary gripper (`ee6d`, `joint`), applying sigmoid to gripper logits
 
 #### Example: BimanualSO101 Action Space
 
@@ -220,7 +220,7 @@ REAL_DIM = 12
 # Postprocessing: Trim 20D predictions to 12D for deployment
 ```
 
-See the [action_hub.py](/home/jade_choghari/robot/lerobot/src/lerobot/policies/xvla/action_hub.py) implementation for details.
+See the [action_hub.py](https://github.com/huggingface/lerobot/blob/main/src/lerobot/policies/xvla/action_hub.py) implementation for details.
 
 #### Auto Action Mode (Recommended)
 

--- a/src/lerobot/policies/xvla/action_hub.py
+++ b/src/lerobot/policies/xvla/action_hub.py
@@ -528,46 +528,28 @@ class BimanualSO101ActionSpace(BaseActionSpace):
     # ---------- preprocess / postprocess ----------
 
     def preprocess(self, proprio, action, mode="train"):
-        """
-        - If proprio/action are 12-dim, pad them to 20 for the model.
-        - Zero-out gripper channels in proprio/action to focus learning on joints.
-        """
-        proprio_m = self._pad_to_model_dim(proprio.clone())
-        action_m = self._pad_to_model_dim(action.clone()) if action is not None else None
-
-        proprio_m[..., self.gripper_idx] = 0.0
-        if action_m is not None:
-            action_m[..., self.gripper_idx] = 0.0
-
+        """Pad 12-dim proprio/action to the 20-dim model space."""
+        proprio_m = self._pad_to_model_dim(proprio)
+        action_m = self._pad_to_model_dim(action) if action is not None else None
         return proprio_m, action_m
 
     def postprocess(self, action: torch.Tensor) -> torch.Tensor:
+        """Trim the 20-dim model output back to the real 12-dim control vector:
+        ["left_shoulder_pan.pos",
+         "left_shoulder_lift.pos",
+         "left_elbow_flex.pos",
+         "left_wrist_flex.pos",
+         "left_wrist_roll.pos",
+         "left_gripper.pos",
+         "right_shoulder_pan.pos",
+         "right_shoulder_lift.pos",
+         "right_elbow_flex.pos",
+         "right_wrist_flex.pos",
+         "right_wrist_roll.pos",
+         "right_gripper.pos"]
         """
-        - Model outputs [*, 20]
-        - Apply sigmoid to gripper logits
-        - Return only the first 12 dims for the real robot:
-          ["left_shoulder_pan.pos",
-           "left_shoulder_lift.pos",
-           "left_elbow_flex.pos",
-           "left_wrist_flex.pos",
-           "left_wrist_roll.pos",
-           "left_gripper.pos",
-           "right_shoulder_pan.pos",
-           "right_shoulder_lift.pos",
-           "right_elbow_flex.pos",
-           "right_wrist_flex.pos",
-           "right_wrist_roll.pos",
-           "right_gripper.pos"]
-        """
-        # Ensure we at least have the real dims + grippers
         if action.size(-1) < self.REAL_DIM:
             raise ValueError(f"Expected at least {self.REAL_DIM} dims in action, got {action.size(-1)}")
-
-        # Apply sigmoid on gripper channels in model space (indices 5 and 11)
-        if action.size(-1) > max(self.gripper_idx):
-            action[..., self.gripper_idx] = torch.sigmoid(action[..., self.gripper_idx])
-
-        # Return only the real 12-dim control vector for the env
         return self._trim_to_real_dim(action)
 
 

--- a/tests/policies/xvla/test_action_hub.py
+++ b/tests/policies/xvla/test_action_hub.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for XVLA action spaces."""
+
+import pytest
+import torch
+
+from lerobot.policies.xvla.action_hub import BimanualSO101ActionSpace
+
+
+class TestBimanualSO101ActionSpace:
+    # SO-101 grippers are continuous joint positions, not binary open/close.
+    # preprocess must not zero them (the model needs them as conditioning) and
+    # postprocess must not squash them through sigmoid (training uses plain MSE,
+    # so a sigmoid at inference creates a train/inference mismatch that pins the
+    # gripper output near 0.5). See discussion in fix/xvla_so_bimanual.
+
+    @pytest.fixture
+    def space(self):
+        return BimanualSO101ActionSpace()
+
+    def test_preprocess_preserves_gripper_values(self, space):
+        proprio = torch.arange(12, dtype=torch.float32).reshape(1, 1, 12)
+        action = proprio.clone() + 100.0
+
+        proprio_m, action_m = space.preprocess(proprio, action)
+
+        # Padded to model dim
+        assert proprio_m.shape == (1, 1, 20)
+        assert action_m.shape == (1, 1, 20)
+
+        # Gripper channels (idx 5, 11) must carry the original values through
+        for idx in space.gripper_idx:
+            assert proprio_m[..., idx].item() == proprio[..., idx].item()
+            assert action_m[..., idx].item() == action[..., idx].item()
+
+    def test_preprocess_accepts_none_action(self, space):
+        proprio = torch.randn(2, 3, 12)
+        proprio_m, action_m = space.preprocess(proprio, None)
+        assert proprio_m.shape == (2, 3, 20)
+        assert action_m is None
+
+    def test_postprocess_does_not_apply_sigmoid(self, space):
+        # Large logits — if sigmoid were applied, output would saturate near 1.
+        action = torch.full((1, 1, 20), 5.0)
+        out = space.postprocess(action)
+
+        assert out.shape == (1, 1, 12)
+        assert torch.allclose(out, torch.full_like(out, 5.0))
+
+    def test_postprocess_preserves_gripper_sign_and_magnitude(self, space):
+        action = torch.zeros(1, 1, 20)
+        action[..., 5] = -2.5  # left gripper
+        action[..., 11] = 3.5  # right gripper
+
+        out = space.postprocess(action)
+
+        assert out[..., 5].item() == pytest.approx(-2.5)
+        assert out[..., 11].item() == pytest.approx(3.5)
+
+    def test_postprocess_rejects_too_short_input(self, space):
+        with pytest.raises(ValueError):
+            space.postprocess(torch.zeros(1, 1, 8))


### PR DESCRIPTION
## fix(xvla): remove gripper zeroing and sigmoid from BimanualSO101 action space

## Summary / Motivation

`BimanualSO101ActionSpace` zeroed gripper channels in `preprocess` and applied `sigmoid` in `postprocess`, while `compute_loss` uses plain MSE on raw values. That created a train/inference mismatch: MSE drives predictions toward the (normalized) target magnitude, but the sigmoid at inference squashes those outputs into a narrow band around 0.5, pinning the gripper in a half-open position regardless of intent.

SO-101 grippers are continuous joint positions, not binary open/close, so the sigmoid + BCE-style treatment inherited from `ee6d`/`joint` is wrong here. The zeroed proprio/action inputs also stripped gripper conditioning from the transformer.


## Related issues

None.

## What changed

- `BimanualSO101ActionSpace.preprocess` no longer zeros gripper channels; it only pads `12 -> 20`.
- `BimanualSO101ActionSpace.postprocess` no longer applies `sigmoid`; it only trims `20 -> 12`.
- `docs/source/xvla.mdx`: clarified that gripper zeroing/sigmoid applies to `ee6d`/`joint` (binary-gripper modes) only, and fixed a stale absolute link to `action_hub.py`.
- Added regression tests in `tests/policies/xvla/test_action_hub.py` locking in: gripper values pass through `preprocess`, `None` action is accepted, no sigmoid in `postprocess`, sign/magnitude preserved, short inputs rejected.

No breaking changes. Existing checkpoints trained with the old behavior will produce different (correct) gripper outputs at inference. Users seeing stuck half-open grippers should retrain.


## How was this tested (or how to run locally)

- `uv run python -m pytest tests/policies/xvla/test_action_hub.py -v`
- `pre-commit run --files src/lerobot/policies/xvla/action_hub.py tests/policies/xvla/test_action_hub.py docs/source/xvla.mdx`
- Originally surfaced while fine-tuning `lerobot/xvla-base` on an SO-101 bimanual dataset: the gripper stayed in a half-open position. Switching to `action_mode=auto` confirmed the diagnosis; this PR makes `so101_bimanual` behave correctly without giving up its per-arm loss breakdowns.


## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated
- [ ] CI is green
- [x] Community Review: #3326 


## Reviewer notes

Focus areas: (1) confirm the MSE + sigmoid mismatch diagnosis matches your intent for this action space, (2) whether the per-arm `left_arm_loss`/`right_arm_loss`/`gripper_loss` breakdown in `compute_loss` is still worth keeping over just using `auto`. I've kept it since it's useful for diagnosing bimanual training, but happy to simplify if preferred.

