### PR TITLE
ci: skip Docker Hub login step on fork PRs

### DIFF
--- a/.github/workflows/benchmark_tests.yml
+++ b/.github/workflows/benchmark_tests.yml
@@ -83,10 +83,13 @@ jobs:
           cache-binary: false
 
       - name: Login to Docker Hub
+        if: ${{ env.DOCKERHUB_USERNAME != '' }}
         uses: docker/login-action@v3 # zizmor: ignore[unpinned-uses]
         with:
           username: ${{ secrets.DOCKERHUB_LEROBOT_USERNAME }}
           password: ${{ secrets.DOCKERHUB_LEROBOT_PASSWORD }}
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_LEROBOT_USERNAME }}
 
       # Build the benchmark-specific image. The Dockerfile separates dep-install
       # from source-copy, so code-only changes skip the slow uv-sync layer
@@ -238,10 +241,13 @@ jobs:
           cache-binary: false
 
       - name: Login to Docker Hub
+        if: ${{ env.DOCKERHUB_USERNAME != '' }}
         uses: docker/login-action@v3 # zizmor: ignore[unpinned-uses]
         with:
           username: ${{ secrets.DOCKERHUB_LEROBOT_USERNAME }}
           password: ${{ secrets.DOCKERHUB_LEROBOT_PASSWORD }}
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_LEROBOT_USERNAME }}
 
       - name: Build MetaWorld benchmark image
         uses: docker/build-push-action@v6 # zizmor: ignore[unpinned-uses]


### PR DESCRIPTION
## Summary / Motivation

On fork PRs, GitHub Actions does not expose `secrets.*` to workflow expressions — the values resolve to empty strings. That's currently enough to kill the entire benchmark pipeline: `docker/login-action@v3` hard-fails with `Error: Username and password required` before any of the build/eval work can start, so every fork-sourced PR sees its benchmark jobs reported as failed within a couple of seconds.

This PR gates the Docker Hub login on the expanded username so the step is **skipped** (not failed) when secrets are unavailable, while leaving the maintainer-repo run path identical.

## What changed

- `.github/workflows/benchmark_tests.yml`: two `Login to Docker Hub` steps (Libero + MetaWorld jobs) now expand `DOCKERHUB_LEROBOT_USERNAME` into a step-level `env` and guard the step via `if: \${{ env.DOCKERHUB_USERNAME != '' }}`. When the secret is set (maintainer repo, or `pull_request_review`-approved fork runs) the step behaves exactly as before; when it's unset the step is skipped and the pipeline continues to the build/eval steps.

Scope: only `benchmark_tests.yml`. `full_tests.yml` and `latest_deps_tests.yml` trigger on `pull_request_review` / cron / `workflow_dispatch`, where secrets are already guaranteed, so they don't need the guard.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] No tests required (CI config change)
- [x] No documentation update needed
- [x] CI is green
