### PR TITLE
fix(robotwin): pin compatible curobo in benchmark image

### DIFF
--- a/docker/Dockerfile.benchmark.robotwin
+++ b/docker/Dockerfile.benchmark.robotwin
@@ -56,11 +56,11 @@ RUN uv pip install --no-cache --no-build-isolation \
         "git+https://github.com/facebookresearch/pytorch3d.git@stable"
 
 # CuRobo — NVlabs motion generator; TORCH_CUDA_ARCH_LIST must be set or the
-# build aborts on an empty arch list. Pinned SHA for reproducibility.
-ARG CUROBO_SHA=ca941586c33b8482ed9c0e74d60f23efd64b516a
+# build aborts on an empty arch list. RoboTwin's own installer pins v0.7.8,
+# which still exposes the v1 API (`curobo.types.math`) that RoboTwin imports.
+ARG CUROBO_REF=v0.7.8
 RUN cd ${ROBOTWIN_ROOT}/envs \
-    && git clone https://github.com/NVlabs/curobo.git \
-    && git -C curobo checkout ${CUROBO_SHA} \
+    && git clone --branch ${CUROBO_REF} --depth 1 https://github.com/NVlabs/curobo.git \
     && cd curobo \
     && TORCH_CUDA_ARCH_LIST="7.0;7.5;8.0;8.6;8.9;9.0" \
        uv pip install -e . --no-build-isolation --no-cache
@@ -112,6 +112,15 @@ WORKDIR ${ROBOTWIN_ROOT}
 RUN python script/update_embodiment_config_path.py
 
 ENV PYTHONPATH="${ROBOTWIN_ROOT}:${PYTHONPATH}"
+
+# Fail the image build early if the CuRobo/RoboTwin import chain regresses.
+RUN python - <<'EOF'
+from curobo.types.math import Pose
+from envs.robot.planner import CuroboPlanner
+
+print("CuRobo import OK:", Pose.__name__)
+print("RoboTwin planner import OK:", CuroboPlanner.__name__)
+EOF
 
 # Return to the lerobot source directory (set by base image) before overlaying.
 WORKDIR /lerobot

--- a/docker/Dockerfile.benchmark.robotwin
+++ b/docker/Dockerfile.benchmark.robotwin
@@ -111,15 +111,22 @@ EOF
 WORKDIR ${ROBOTWIN_ROOT}
 RUN python script/update_embodiment_config_path.py
 
-ENV PYTHONPATH="${ROBOTWIN_ROOT}:${PYTHONPATH}"
+ENV PYTHONPATH="${ROBOTWIN_ROOT}"
 
-# Fail the image build early if the CuRobo/RoboTwin import chain regresses.
+# Fail the image build early if the CuRobo package layout regresses. Importing
+# RoboTwin's planner here is too eager because CuRobo constructs CUDA-backed
+# defaults at import time, while Docker builds don't have access to an NVIDIA
+# driver.
 RUN python - <<'EOF'
+from pathlib import Path
+
 from curobo.types.math import Pose
-from envs.robot.planner import CuroboPlanner
+
+planner_src = (Path("/opt/robotwin/envs/robot/planner.py")).read_text()
+assert "from curobo.types.math import Pose as CuroboPose" in planner_src
 
 print("CuRobo import OK:", Pose.__name__)
-print("RoboTwin planner import OK:", CuroboPlanner.__name__)
+print("RoboTwin planner import references curobo.types.math")
 EOF
 
 # Return to the lerobot source directory (set by base image) before overlaying.


### PR DESCRIPTION
## Summary
- pin the RobotWin benchmark image to the cuRobo version RoboTwin itself installs: NVlabs/curobo v0.7.8
- add a build-time import smoke test for curobo.types.math and envs.robot.planner.CuroboPlanner
- fail the Docker build early instead of letting RobotWin eval crash before videos are written

## Why
The RobotWin CI image was cloning a different cuRobo revision than RoboTwin expects. That broke the curobo.types.math import chain at runtime, so eval died during env reset and no rollout videos were produced.