### PR TITLE
fix(smolvla): correct loss normalization for padded actions

### DIFF
--- a/src/lerobot/policies/smolvla/modeling_smolvla.py
+++ b/src/lerobot/policies/smolvla/modeling_smolvla.py
@@ -394,13 +394,21 @@ class SmolVLAPolicy(PreTrainedPolicy):
         loss_dict["losses_after_rm_padding"] = losses.clone().mean().item()
 
         if reduction == "none":
-            # Return per-sample losses (B,) by averaging over time and action dims
-            per_sample_loss = losses.mean(dim=(1, 2))
+            # Return per-sample losses (B,) by averaging over valid (time, action) entries
+            if actions_is_pad is None:
+                per_sample_loss = losses.mean(dim=(1, 2))
+            else:
+                num_valid = ((~actions_is_pad).sum(dim=1) * losses.shape[-1]).clamp_min(1)
+                per_sample_loss = losses.sum(dim=(1, 2)) / num_valid
             loss_dict["loss"] = per_sample_loss.mean().item()
             return per_sample_loss, loss_dict
         else:
-            # Default: return scalar mean loss
-            loss = losses.mean()
+            # Default: return scalar mean loss over valid (time, action) entries
+            if actions_is_pad is None:
+                loss = losses.mean()
+            else:
+                num_valid = ((~actions_is_pad).sum() * losses.shape[-1]).clamp_min(1)
+                loss = losses.sum() / num_valid
             loss_dict["loss"] = loss.item()
             return loss, loss_dict
 


### PR DESCRIPTION
## Title

fix(smolvla): correct loss normalization for padded actions

## Summary / Motivation

Same dilution bug as #3353 (originally filed for ACT), applied to SmolVLA. PR #3377 fixed ACT, Diffusion, and MultiTaskDiT but left SmolVLA out of scope — this PR extends the same per-scalar-mean pattern to `modeling_smolvla.py`.

Pre-patch, `losses.mean()` (and `losses.mean(dim=(1, 2))`) divides by the total number of elements — including padded timesteps that `action_is_pad` has already zeroed out. The denominator is larger than the number of valid entries, so the loss is silently rescaled by `1 − padding_fraction`. Fix: divide by `(~actions_is_pad).sum() * losses.shape[-1]` instead.

## Related issues

- Fixes / Closes: #3433
- Related: #3353 (original ACT report), #3377 (fix for ACT / Diffusion / MultiTaskDiT)

## What changed

- `src/lerobot/policies/smolvla/modeling_smolvla.py`: both reduction paths (`reduction == "none"` and scalar default) normalize over valid scalar entries when `actions_is_pad` is set. `clamp_min(1)` preserves the all-padded-batch edge case (0/1 = 0).
- `actions_is_pad is None` -> unchanged behavior (`losses.mean()` fallback).
- No API change. Loss *magnitude* changes when padding is present, so tuned LR / early-stop recipes may need re-tuning -> noting for downstream users, same caveat as #3377.

## How was this tested (or how to run locally)

- `uv run ruff format` and `uv run ruff check` pass clean on the changed file.
- Empirical A/B comparison on current HEAD (variant A = pre-patch, variant B = this fix), 30 training steps, fixed seed, `lerobot/aloha_sim_transfer_cube_human`, `chunk_size=40`, `n_action_steps=40`, `batch_size=2`, single NVIDIA GB200:

  ```
  mean loss_A / loss_B = 0.9672    stdev=0.0884
  ```

  Direction and magnitude consistent with #3377's `loss_A / loss_C ≈ 0.9603` for ACT on the same dataset. Heavier-padding setups (60–70% padded horizon, per #3353) will show a larger gap.

- Repro command:

  ```bash
  lerobot-train \
    --policy.type=smolvla \
    --policy.vlm_model_name=HuggingFaceTB/SmolVLM2-500M-Video-Instruct \
    --policy.chunk_size=40 --policy.n_action_steps=40 --policy.device=cuda \
    --dataset.repo_id=lerobot/aloha_sim_transfer_cube_human \
    --dataset.episodes="[0,1]" --batch_size=2 --steps=30 \
    --log_freq=1 --save_checkpoint=false --eval_freq=0 --wandb.enable=false
  ```

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`) hooks don't apply to this file.
- [x] All tests pass locally (`pytest`) 
- [x] Documentation updated: N/A
- [ ] CI is green: Will confirm after PR opens.
- [ ] Community Review: TBR

## Reviewer notes

- Core change is ~10 lines in one function; logic mirrors what #3377 applied to ACT / Diffusion / MultiTaskDiT, including the `clamp_min(1)` safety and the `None`-branch fallback.
- Worth a sanity check on the `reduction == "none"` path — per-sample loss becomes `losses.sum(dim=(1, 2)) / num_valid` with `num_valid` broadcasting per-batch-row.
