### PR TITLE
fix(cameras/realsense): encode D405 depth in mm and finish depth-async TODOs

### DIFF
--- a/src/lerobot/cameras/realsense/camera_realsense.py
+++ b/src/lerobot/cameras/realsense/camera_realsense.py
@@ -581,7 +581,52 @@ class RealSenseCamera(Camera):
 
         return frame
 
-    # NOTE(Steven): Missing implementation for depth for now
+    @check_if_not_connected
+    def read_depth_latest(self, max_age_ms: int = 500) -> NDArray[Any]:
+        """
+        Returns the most recent depth frame captured immediately (Peeking).
+
+        This method is non-blocking and returns whatever is currently in the
+        memory buffer. Unlike `async_read`, it does not clear the new-frame
+        event nor wait for a fresh frame — it just peeks at whatever the
+        background capture thread has most recently stored. The frame may be
+        stale (hanging camera scenario e.g.).
+
+        Args:
+            max_age_ms (int): Maximum age in milliseconds a buffered frame may
+                have before it is rejected as stale. Defaults to 500ms.
+
+        Returns:
+            NDArray[Any]: The depth frame (numpy array, uint16, millimeters).
+
+        Raises:
+            TimeoutError: If the latest depth frame is older than `max_age_ms`.
+            DeviceNotConnectedError: If the camera is not connected.
+            RuntimeError: If the depth stream is not enabled, if the background
+                thread is not running, or if no depth frames have been captured yet.
+        """
+
+        if not self.use_depth:
+            raise RuntimeError(
+                f"Failed to capture depth frame '.read_depth_latest()'. Depth stream is not enabled for {self}."
+            )
+        if self.thread is None or not self.thread.is_alive():
+            raise RuntimeError(f"{self} read thread is not running.")
+
+        with self.frame_lock:
+            depth_map = self.latest_depth_frame
+            timestamp = self.latest_timestamp
+
+        if depth_map is None or timestamp is None:
+            raise RuntimeError(f"{self} has not captured any depth frames yet.")
+
+        age_ms = (time.perf_counter() - timestamp) * 1e3
+        if age_ms > max_age_ms:
+            raise TimeoutError(
+                f"{self} latest depth frame is too old: {age_ms:.1f} ms (max allowed: {max_age_ms} ms)."
+            )
+        return depth_map
+
     @check_if_not_connected
     def read_latest(self, max_age_ms: int = 500) -> NDArray[Any]:
         """Return the most recent (color) frame captured immediately (Peeking).

--- a/src/lerobot/cameras/realsense/camera_realsense.py
+++ b/src/lerobot/cameras/realsense/camera_realsense.py
@@ -483,6 +483,14 @@ class RealSenseCamera(Camera):
                 if self.use_depth:
                     depth_frame_raw = frame.get_depth_frame()
                     depth_frame = np.asanyarray(depth_frame_raw.get_data())
+                    # Normalize to mm. D435: 1 mm/count; D405: 0.1 mm/count.
+                    depth_scale_mm = depth_frame_raw.get_units() * 1000.0
+                    if abs(depth_scale_mm - 1.0) > 1e-3:
+                        scaled = depth_frame.astype(np.float32) * depth_scale_mm
+                        # Preserve 0 as invalid sentinel; clip guards against any
+                        # future camera shipping with depth_scale > 1 mm/count.
+                        scaled = np.where(depth_frame == 0, 0, scaled)
+                        depth_frame = np.clip(scaled, 0, np.iinfo(np.uint16).max).astype(np.uint16)
                     processed_depth_frame = self._postprocess_image(depth_frame, depth_frame=True)
 
                 capture_time = time.perf_counter()

--- a/src/lerobot/cameras/realsense/camera_realsense.py
+++ b/src/lerobot/cameras/realsense/camera_realsense.py
@@ -538,7 +538,53 @@ class RealSenseCamera(Camera):
             self.latest_timestamp = None
             self.new_frame_event.clear()
 
-    # NOTE(Steven): Missing implementation for depth for now
+    @check_if_not_connected
+    def async_read_depth(self, timeout_ms: float = 200) -> NDArray[Any]:
+        """
+        Reads the latest available depth frame asynchronously.
+
+        This method retrieves the most recent depth frame captured by the background
+        read thread. It does not block waiting for the camera hardware directly,
+        but may wait up to timeout_ms for the background thread to provide a frame.
+        It is “best effort” under high FPS.
+
+        Args:
+            timeout_ms (float): Maximum time in milliseconds to wait for a frame
+                to become available. Defaults to 200ms (0.2 seconds).
+
+        Returns:
+            np.ndarray:
+            The latest captured depth frame (uint16, millimeters), processed according to configuration.
+
+        Raises:
+            DeviceNotConnectedError: If the camera is not connected.
+            TimeoutError: If no frame data becomes available within the specified timeout.
+            RuntimeError: If the depth stream is not enabled, if the background
+                thread died unexpectedly, or if the event fires without a frame available.
+        """
+
+        if not self.use_depth:
+            raise RuntimeError(
+                f"Failed to capture depth frame '.async_read_depth()'. Depth stream is not enabled for {self}."
+            )
+        if self.thread is None or not self.thread.is_alive():
+            raise RuntimeError(f"{self} read thread is not running.")
+
+        if not self.new_frame_event.wait(timeout=timeout_ms / 1000.0):
+            raise TimeoutError(
+                f"Timed out waiting for depth frame from camera {self} after {timeout_ms} ms. "
+                f"Read thread alive: {self.thread.is_alive()}."
+            )
+
+        with self.frame_lock:
+            frame = self.latest_depth_frame
+            self.new_frame_event.clear()
+
+        if frame is None:
+            raise RuntimeError(f"Internal error: Event set but no depth frame available for {self}.")
+
+        return frame
+
     @check_if_not_connected
     def async_read(self, timeout_ms: float = 200) -> NDArray[Any]:
         """

--- a/src/lerobot/cameras/realsense/camera_realsense.py
+++ b/src/lerobot/cameras/realsense/camera_realsense.py
@@ -565,7 +565,7 @@ class RealSenseCamera(Camera):
 
         if not self.use_depth:
             raise RuntimeError(
-                f"Failed to capture depth frame '.async_read_depth()'. Depth stream is not enabled for {self}."
+                f"Failed to capture depth frame via async_read_depth(); depth stream is not enabled for {self}."
             )
         if self.thread is None or not self.thread.is_alive():
             raise RuntimeError(f"{self} read thread is not running.")
@@ -633,7 +633,7 @@ class RealSenseCamera(Camera):
         Returns the most recent depth frame captured immediately (Peeking).
 
         This method is non-blocking and returns whatever is currently in the
-        memory buffer. Unlike `async_read`, it does not clear the new-frame
+        memory buffer. Unlike `async_read_depth`, it does not clear the new-frame
         event nor wait for a fresh frame — it just peeks at whatever the
         background capture thread has most recently stored. The frame may be
         stale (hanging camera scenario e.g.).

--- a/tests/cameras/test_realsense.py
+++ b/tests/cameras/test_realsense.py
@@ -161,6 +161,49 @@ def test_async_read_before_connect():
         _ = camera.async_read()
 
 
+def test_async_read_depth_before_connect():
+    config = RealSenseCameraConfig(serial_number_or_name="042", use_depth=True)
+    camera = RealSenseCamera(config)
+
+    with pytest.raises(DeviceNotConnectedError):
+        _ = camera.async_read_depth()
+
+
+def test_async_read_depth_depth_disabled():
+    config = RealSenseCameraConfig(serial_number_or_name="042", warmup_s=0)
+    with (
+        RealSenseCamera(config) as camera,
+        pytest.raises(RuntimeError, match="Depth stream is not enabled"),
+    ):
+        _ = camera.async_read_depth()
+
+
+# TODO(Steven): Fix this test for the latest version of pyrealsense2.
+@pytest.mark.skip("Skipping test: pyrealsense2 version > 2.55.1.6486")
+def test_async_read_depth():
+    config = RealSenseCameraConfig(serial_number_or_name="042", width=640, height=480, fps=30, use_depth=True)
+    camera = RealSenseCamera(config)
+    camera.connect(warmup=False)
+
+    img = camera.async_read_depth()
+
+    assert camera.thread is not None
+    assert camera.thread.is_alive()
+    assert isinstance(img, np.ndarray)
+
+
+# TODO(Steven): Fix this test for the latest version of pyrealsense2.
+@pytest.mark.skip("Skipping test: pyrealsense2 version > 2.55.1.6486")
+def test_async_read_depth_timeout():
+    config = RealSenseCameraConfig(serial_number_or_name="042", width=640, height=480, fps=30, use_depth=True)
+    camera = RealSenseCamera(config)
+    camera.connect(warmup=False)
+
+    with pytest.raises(TimeoutError):
+        camera.async_read_depth(timeout_ms=0)  # consumes any available frame by then
+        camera.async_read_depth(timeout_ms=0)  # request immediately another one
+
+
 def test_read_latest():
     config = RealSenseCameraConfig(serial_number_or_name="042", width=640, height=480, fps=30, warmup_s=0)
     with RealSenseCamera(config) as camera:

--- a/tests/cameras/test_realsense.py
+++ b/tests/cameras/test_realsense.py
@@ -202,6 +202,47 @@ def test_read_latest_too_old():
             _ = camera.read_latest(max_age_ms=0)  # immediately too old
 
 
+def test_read_depth_latest_before_connect():
+    config = RealSenseCameraConfig(serial_number_or_name="042", use_depth=True)
+    camera = RealSenseCamera(config)
+
+    with pytest.raises(DeviceNotConnectedError):
+        _ = camera.read_depth_latest()
+
+
+def test_read_depth_latest_depth_disabled():
+    config = RealSenseCameraConfig(serial_number_or_name="042", warmup_s=0)
+    with (
+        RealSenseCamera(config) as camera,
+        pytest.raises(RuntimeError, match="Depth stream is not enabled"),
+    ):
+        _ = camera.read_depth_latest()
+
+
+# TODO(Steven): Fix this test for the latest version of pyrealsense2.
+@pytest.mark.skip("Skipping test: pyrealsense2 version > 2.55.1.6486")
+def test_read_depth_latest():
+    config = RealSenseCameraConfig(serial_number_or_name="042", width=640, height=480, fps=30, use_depth=True)
+    camera = RealSenseCamera(config)
+    camera.connect(warmup=False)
+
+    _ = camera.read_depth(timeout_ms=2000)  # prime so the buffer is populated
+    img = camera.read_depth_latest()
+    assert isinstance(img, np.ndarray)
+
+
+# TODO(Steven): Fix this test for the latest version of pyrealsense2.
+@pytest.mark.skip("Skipping test: pyrealsense2 version > 2.55.1.6486")
+def test_read_depth_latest_too_old():
+    config = RealSenseCameraConfig(serial_number_or_name="042", width=640, height=480, fps=30, use_depth=True)
+    camera = RealSenseCamera(config)
+    camera.connect(warmup=False)
+
+    _ = camera.read_depth(timeout_ms=2000)
+    with pytest.raises(TimeoutError):
+        _ = camera.read_depth_latest(max_age_ms=0)  # immediately too old
+
+
 @pytest.mark.parametrize(
     "rotation",
     [

--- a/tests/cameras/test_realsense.py
+++ b/tests/cameras/test_realsense.py
@@ -169,7 +169,7 @@ def test_async_read_depth_before_connect():
         _ = camera.async_read_depth()
 
 
-def test_async_read_depth_depth_disabled():
+def test_async_read_depth_disabled():
     config = RealSenseCameraConfig(serial_number_or_name="042", warmup_s=0)
     with (
         RealSenseCamera(config) as camera,


### PR DESCRIPTION
## Title

`fix(cameras/realsense): encode D405 depth in mm and finish depth-async TODOs`

## Summary / Motivation

One bug fix and two TODO completions on the Intel RealSense backend, surfaced while bringing up SO-101 recording with D435 + D405 on the same host. Unblocks the depth recording pipeline in #3253.

- On D405 the recorded depth was 10× the intended magnitude and saturated uint16 at short range, because `_read_loop` passed raw counts through without applying the device's `depth_scale`.
- Both `# NOTE(Steven): Missing implementation for depth for now` markers are removed: `read_depth_latest` (non-blocking peek) and `async_read_depth` (blocking-with-timeout) are now implemented, giving depth callers full parity with the existing color-only `read_latest` / `async_read`.

## Related issues

- Related: #3253 (This is an on-hardware test for future depth support needs for this PR for using D405 and D43)

## What changed

- **fix(`_read_loop`):** multiplies raw depth by `rs.depth_frame.get_units() * 1000` when the native scale differs from 1 mm/count; preserves `0` as the invalid-pixel sentinel and clips to uint16 before postprocess. D435 unchanged (native scale ≈ 1.0 mm/count), D405 now encodes millimeters correctly.
- **feat(`read_depth_latest`):** non-blocking peek at the background thread's latest depth frame. Same `TimeoutError` / `DeviceNotConnectedError` / `RuntimeError` contract as the existing `read_latest`, plus an extra `RuntimeError` if depth wasn't enabled at connect time.
- **feat(`async_read_depth`):** blocking-with-timeout counterpart, mirroring `async_read` exactly (same event-wait / lock / clear pattern).

No breaking changes; new methods only, existing behaviour unchanged.

## How was this tested (or how to run locally)

```bash
uv sync --locked --extra intelrealsense --extra test --extra dev
uv run pytest tests/cameras/test_realsense.py -v
# -> 24 passed, 5 skipped
```

Added 8 new tests (4 per new method):

- 4 runnable error-path tests: `*_before_connect` (decorator-level `DeviceNotConnectedError`) and `*_depth_disabled` (`RuntimeError` when the camera is connected but `use_depth=False`).
- 4 skipped tests for the happy path and timeout/stale-buffer paths. They mirror the existing `test_read_depth` style exactly and carry the same `@pytest.mark.skip("Skipping test: pyrealsense2 version > 2.55.1.6486")` gate.

**Skip reason re-verified bidirectionally before including the gate:**

| pyrealsense2 | Python | Bag color+depth replay |
|---|---|---|
| `2.55.1.6486` (pin floor) | 3.11 | ✅ both frames arrive |
| `2.56.5.9235` (project pin tip) | 3.13 | ❌ timeout |
| `2.57.7.10387` (PyPI latest today) | 3.13 | ❌ timeout |

### Hardware verification

Ran against a real D405 (with a D435 attached on the same host for reference). 
Host on the pinned `pyrealsense2==2.56.5.9235`, Python 3.13.

<details>
<summary>Test script (<code>d405_test.py</code>)</summary>

```python
from __future__ import annotations

import importlib.metadata
import sys
import time

import numpy as np
import pyrealsense2 as rs

from lerobot.cameras.realsense import RealSenseCamera, RealSenseCameraConfig
from lerobot.utils.errors import DeviceNotConnectedError


# Per-model metadata for the scale-fix sanity bounds.
MODEL_SPECS = {
    "D405": {
        "expected_scale_mm_per_count": 0.1,      # 0.0001 m/count
        "working_range_mm": (70, 500),           # ~7-50 cm
        "median_upper_bound_mm": 1500,           # if median > this, fix likely missing
    },
    "D435": {
        "expected_scale_mm_per_count": 1.0,      # 0.001 m/count
        "working_range_mm": (300, 10000),        # ~0.3-10 m
        "median_upper_bound_mm": 15000,          # well under uint16 max, generous bound
    },
}


def _banner(msg: str) -> None:
    print(f"\n=== {msg} ===")


def _enumerate_targets(requested_sns: list[str] | None) -> list[tuple[str, str]]:
    """Return a list of (model_key, serial_number) for what we'll test."""
    ctx = rs.context()
    devices = list(ctx.query_devices())
    if not devices:
        sys.exit("No RealSense devices detected.")

    print("Detected devices:")
    all_devs = []
    for dev in devices:
        name = dev.get_info(rs.camera_info.name)
        sn = dev.get_info(rs.camera_info.serial_number)
        model_key = "D405" if "D405" in name else ("D435" if "D435" in name else None)
        print(f"  {name} (sn={sn})  [{model_key or 'unsupported-by-this-script'}]")
        if model_key is not None:
            all_devs.append((model_key, sn))

    if requested_sns:
        filtered = [(m, s) for (m, s) in all_devs if s in requested_sns]
        if not filtered:
            sys.exit(f"None of the requested serials matched an attached D405/D435: {requested_sns}")
        return filtered

    # Auto mode: first D405 + first D435 (either may be absent).
    seen = set()
    picked = []
    for model_key, sn in all_devs:
        if model_key in seen:
            continue
        seen.add(model_key)
        picked.append((model_key, sn))
    if not picked:
        sys.exit("No D405 or D435 attached; nothing to test.")
    return picked


def _native_depth_scale(serial_number: str) -> float:
    """Read depth_scale directly from the device, bypassing our code."""
    ctx = rs.context()
    for dev in ctx.query_devices():
        if dev.get_info(rs.camera_info.serial_number) != serial_number:
            continue
        for sensor in dev.query_sensors():
            if sensor.is_depth_sensor():
                return sensor.as_depth_sensor().get_depth_scale()
    raise RuntimeError(f"depth sensor not found on {serial_number}")


def test_error_paths(serial_number: str) -> None:
    _banner(f"error paths  (sn={serial_number})")

    cam = RealSenseCamera(RealSenseCameraConfig(serial_number_or_name=serial_number, use_depth=True))
    try:
        cam.read_depth_latest()
    except DeviceNotConnectedError:
        print("  read_depth_latest before connect: DeviceNotConnectedError OK")
    else:
        sys.exit("  FAIL: read_depth_latest did not raise DeviceNotConnectedError")

    try:
        cam.async_read_depth()
    except DeviceNotConnectedError:
        print("  async_read_depth before connect: DeviceNotConnectedError OK")
    else:
        sys.exit("  FAIL: async_read_depth did not raise DeviceNotConnectedError")

    # Connect without depth; both methods must raise "Depth stream is not enabled".
    # warmup_s=5 gives the cameras enough slack when multiple RealSense devices
    # share the same USB bus (the 1 s default can time out during connect warmup).
    cam_no_depth = RealSenseCamera(
        RealSenseCameraConfig(
            serial_number_or_name=serial_number, width=640, height=480, fps=30, warmup_s=5
        )
    )
    cam_no_depth.connect()
    try:
        for method_name, method in (
            ("read_depth_latest", cam_no_depth.read_depth_latest),
            ("async_read_depth", cam_no_depth.async_read_depth),
        ):
            try:
                method()
            except RuntimeError as e:
                if "Depth stream is not enabled" in str(e):
                    print(f"  {method_name} with use_depth=False: RuntimeError OK")
                else:
                    sys.exit(f"  FAIL: unexpected RuntimeError message: {e}")
            else:
                sys.exit(f"  FAIL: {method_name} did not raise with use_depth=False")
    finally:
        cam_no_depth.disconnect()


def test_happy_paths_and_scale(model_key: str, serial_number: str) -> None:
    spec = MODEL_SPECS[model_key]
    _banner(f"happy paths + scale sanity  ({model_key}, sn={serial_number})")

    native_scale = _native_depth_scale(serial_number)
    native_scale_mm = native_scale * 1000.0
    expected_mm = spec["expected_scale_mm_per_count"]
    print(f"  native depth_scale from hardware: {native_scale:.6f} m/count "
          f"({native_scale_mm:.4f} mm/count, expected ~{expected_mm})")
    if abs(native_scale_mm - expected_mm) > expected_mm * 0.5:
        print(f"  WARNING: native scale differs from expected {expected_mm} mm/count for {model_key}. "
              "Continuing anyway.")

    cam = RealSenseCamera(
        RealSenseCameraConfig(
            serial_number_or_name=serial_number,
            width=640, height=480, fps=30,
            use_depth=True,
            warmup_s=5,
        )
    )
    cam.connect()
    try:
        # async_read_depth
        depth = cam.async_read_depth(timeout_ms=2000)
        assert isinstance(depth, np.ndarray)
        assert depth.dtype == np.uint16, f"dtype={depth.dtype}, expected uint16"
        assert depth.shape == (480, 640), f"shape={depth.shape}, expected (480, 640)"
        print(f"  async_read_depth -> shape={depth.shape}, dtype={depth.dtype}")

        # read_depth_latest
        latest = cam.read_depth_latest()
        assert isinstance(latest, np.ndarray)
        assert latest.dtype == np.uint16, f"dtype={latest.dtype}, expected uint16"
        assert latest.shape == (480, 640), f"shape={latest.shape}, expected (480, 640)"
        print(f"  read_depth_latest -> shape={latest.shape}, dtype={latest.dtype}")

        # Scale-fix sanity.
        nonzero = depth[depth > 0]
        if nonzero.size == 0:
            print(f"  WARNING: no nonzero depth pixels — aim the {model_key} at a close object "
                  "and re-run to validate scale behavior.")
        else:
            mn, md, mx, n = (int(np.min(nonzero)), int(np.median(nonzero)),
                             int(np.max(nonzero)), int(nonzero.size))
            print(f"  depth (nonzero) min/median/max/count = ({mn}, {md}, {mx}, {n}) mm")
            if md > spec["median_upper_bound_mm"]:
                sys.exit(
                    f"  FAIL: median nonzero depth {md} mm exceeds {model_key} plausible bound "
                    f"{spec['median_upper_bound_mm']} mm — the depth-scale encoding is likely wrong."
                )
            print(f"  scale sanity: PASS (values consistent with {model_key} mm range)")

        # Timeout path.
        try:
            cam.async_read_depth(timeout_ms=2000)  # prime
            cam.async_read_depth(timeout_ms=0)     # immediate re-ask — likely times out
            print("  async_read_depth(timeout_ms=0): returned (benign race, no event pending)")
        except TimeoutError:
            print("  async_read_depth(timeout_ms=0): TimeoutError OK")

    finally:
        cam.disconnect()


def main() -> None:
    print(f"pyrealsense2 version: {importlib.metadata.version('pyrealsense2')}")

    requested = sys.argv[1:] if len(sys.argv) > 1 else None
    targets = _enumerate_targets(requested)
    print(f"\nWill test {len(targets)} device(s):")
    for m, s in targets:
        print(f"  - {m} (sn={s})")

    # Error-path tests are device-agnostic but exercise the API on each SN.
    for _, sn in targets:
        test_error_paths(sn)

    # Happy-path + scale sanity per device.
    for model_key, sn in targets:
        test_happy_paths_and_scale(model_key, sn)

    _banner("all hardware checks passed")


if __name__ == "__main__":
    main()
```

</details>

**Run log**

```
pyrealsense2 version: 2.56.5.9235
Detected devices:
  Intel RealSense D435 (sn=141722076304)  [D435]
  Intel RealSense D405 (sn=335122271633)  [D405]
  Intel RealSense D405 (sn=323622271837)  [D405]

Will test 2 device(s):
  - D435 (sn=141722076304)
  - D405 (sn=335122271633)

=== error paths  (sn=141722076304) ===
  read_depth_latest before connect: DeviceNotConnectedError OK
  async_read_depth before connect: DeviceNotConnectedError OK
  read_depth_latest with use_depth=False: RuntimeError OK
  async_read_depth with use_depth=False: RuntimeError OK

=== error paths  (sn=335122271633) ===
  read_depth_latest before connect: DeviceNotConnectedError OK
  async_read_depth before connect: DeviceNotConnectedError OK
  read_depth_latest with use_depth=False: RuntimeError OK
  async_read_depth with use_depth=False: RuntimeError OK

=== happy paths + scale sanity  (D435, sn=141722076304) ===
  native depth_scale from hardware: 0.001000 m/count (1.0000 mm/count, expected ~1.0)
  async_read_depth -> shape=(480, 640), dtype=uint16
  read_depth_latest -> shape=(480, 640), dtype=uint16
  depth (nonzero) min/median/max/count = (462, 711, 6761, 270545) mm
  scale sanity: PASS (values consistent with D435 mm range)
  async_read_depth(timeout_ms=0): TimeoutError OK

=== happy paths + scale sanity  (D405, sn=335122271633) ===
  native depth_scale from hardware: 0.000100 m/count (0.1000 mm/count, expected ~0.1)
  async_read_depth -> shape=(480, 640), dtype=uint16
  read_depth_latest -> shape=(480, 640), dtype=uint16
  depth (nonzero) min/median/max/count = (60, 426, 6553, 241568) mm
  scale sanity: PASS (values consistent with D405 mm range)
  async_read_depth(timeout_ms=0): TimeoutError OK

=== all hardware checks passed ===
```

## Checklist (required before merge)

- [x] Linting/formatting run: `ruff check` + `ruff format --check`
- [x] All tests pass locally: `pytest tests/cameras/test_realsense.py`
- [ ] Documentation updated: N/A
- [ ] CI is green
- [ ] Community Review: # (insert PR number/link)

## Reviewer notes

- The two new methods are named as direct depth counterparts of existing color methods (`read_latest` → `read_depth_latest`, `async_read` → `async_read_depth`) and live next to them in the file.
- Not touched here but noticed while writing tests: `_stop_read_thread()` nils `self.stop_event` after `thread.join(timeout=2.0)`; if the join ever times out the background loop can then crash with `AttributeError: 'NoneType' object has no attribute 'is_set'`. Flagged for a separate follow-up — does not regress behavior here.
