### PR TITLE
fix(policies): fix GR00TN15Config dataclass

### DIFF
--- a/src/lerobot/policies/groot/groot_n1.py
+++ b/src/lerobot/policies/groot/groot_n1.py
@@ -174,7 +174,7 @@ N_COLOR_CHANNELS = 3
 
 
 # config
-@dataclass
+@dataclass(init=False)
 class GR00TN15Config(PretrainedConfig):
     model_type = "gr00t_n1_5"
     backbone_cfg: dict = field(init=False, metadata={"help": "Backbone configuration."})


### PR DESCRIPTION
## Title

fix(policies): fix `GR00TN15Config` dataclass

## Summary / Motivation

Add `init=False` to `GR00TN15Config` dataclass to prevent init errors like `TypeError: non-default argument 'backbone_cfg' follows default argument 'problem_type'`

## Related issues

- Fixes / Closes: N/A
- Related: #3440 (fixes error B) 
- Related: https://github.com/python/cpython/issues/148941 (not sure)

## What changed

Fixes the bug mentioned, and should not change other behaviors.

## How was this tested (or how to run locally)

**With `transformers` installed**, run `from lerobot.policies.groot.groot_n1 import GR00TN15Config`

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [ ] All tests pass locally (`pytest`)
- [x] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: # (insert PR number/link)

## Reviewer notes

- Anyone in the community is free to review the PR.
