### PR TITLE
fix(diffusion): share observation-queue preprocessing between sync/async entry

### DIFF
--- a/src/lerobot/policies/diffusion/modeling_diffusion.py
+++ b/src/lerobot/policies/diffusion/modeling_diffusion.py
@@ -102,6 +102,21 @@ class DiffusionPolicy(PreTrainedPolicy):
     @torch.no_grad()
     def predict_action_chunk(self, batch: dict[str, Tensor], noise: Tensor | None = None) -> Tensor:
         """Predict a chunk of actions given environment observations."""
+        # Async inference (policy_server) enters here directly, bypassing
+        # select_action. Replicate the preprocessing select_action does before
+        # the queue lookup — otherwise per-camera image keys never get
+        # consolidated into OBS_IMAGES, ACTION leaks into an input queue, and
+        # the observation queues stay empty, producing
+        # "stack expects a non-empty TensorList" on the first request.
+        if ACTION in batch:
+            batch.pop(ACTION)
+        if self.config.image_features:
+            batch = dict(batch)  # shallow copy so we don't mutate the caller's dict
+            batch[OBS_IMAGES] = torch.stack(
+                [batch[key] for key in self.config.image_features], dim=-4
+            )
+        self._queues = populate_queues(self._queues, batch)
+
         # stack n latest observations from the queue
         batch = {k: torch.stack(list(self._queues[k]), dim=1) for k in batch if k in self._queues}
         actions = self.diffusion.generate_actions(batch, noise=noise)
@@ -130,17 +145,10 @@ class DiffusionPolicy(PreTrainedPolicy):
         "horizon" may not the best name to describe what the variable actually means, because this period is
         actually measured from the first observation which (if `n_obs_steps` > 1) happened in the past.
         """
-        # NOTE: for offline evaluation, we have action in the batch, so we need to pop it out
-        if ACTION in batch:
-            batch.pop(ACTION)
-
-        if self.config.image_features:
-            batch = dict(batch)  # shallow copy so that adding a key doesn't modify the original
-            batch[OBS_IMAGES] = torch.stack([batch[key] for key in self.config.image_features], dim=-4)
-        # NOTE: It's important that this happens after stacking the images into a single key.
-        self._queues = populate_queues(self._queues, batch)
-
         if len(self._queues[ACTION]) == 0:
+            # predict_action_chunk now handles the ACTION pop, image-key
+            # consolidation, and populate_queues, so both sync (select_action)
+            # and async (policy_server) entries go through the same path.
             actions = self.predict_action_chunk(batch, noise=noise)
             self._queues[ACTION].extend(actions.transpose(0, 1))
 


### PR DESCRIPTION
Fixes #3445.

## Bug

\`DiffusionPolicy.predict_action_chunk()\` is the entry point the async \`policy_server\` calls directly. The first GetActions request crashes with:

\`\`\`
File "modeling_diffusion.py", line 105, in predict_action_chunk
    batch = {k: torch.stack(list(self._queues[k]), dim=1) for k in batch if k in self._queues}
RuntimeError: stack expects a non-empty TensorList
\`\`\`

## Root cause

Sync inference (\`lerobot-record\` → \`select_action\`) does three preprocessing steps before calling \`predict_action_chunk\`:

1. Pop \`ACTION\` out of the batch (it's an output, not an input).
2. Consolidate per-camera image keys (\`observation.images.front\`, …) into a single \`OBS_IMAGES\` tensor.
3. Call \`populate_queues\` so the observation history deques have content.

None of that happens in the async path — \`policy_server._get_action_chunk\` calls \`predict_action_chunk\` directly. So per-camera keys never collapse into \`OBS_IMAGES\`, \`ACTION\` leaks into a queue that expects observations, and \`populate_queues\` is never run. The downstream \`torch.stack(list(self._queues[k]), dim=1)\` then hits an empty deque.

## Fix

Move the three preprocessing steps out of \`select_action\` and into \`predict_action_chunk\` itself. Both entry points (\`select_action\` → \`predict_action_chunk\`, and the async policy server → \`predict_action_chunk\`) now go through the same code. \`select_action\` is reduced to "fill action queue via \`predict_action_chunk\` when empty, pop and return next action" — no more preprocessing duplication, no risk of \`populate_queues\` running twice on the same frame.

Other policies (ACT, SmolVLA, etc.) that don't use deque-based observation queues are not affected — their \`predict_action_chunk\` methods remain self-contained.

## Test plan

Reporter's async inference repro:

\`\`\`bash
python -m lerobot.async_inference.policy_server ... --policy_type=diffusion
\`\`\`

previously crashed on the first GetActions; after this fix the server returns action chunks normally.

For sync inference, \`select_action\` still ends up with the same processed batch and the same queue state — just routed through \`predict_action_chunk\` instead of inlined. Existing diffusion e2e tests continue to pass on the single-camera + MPS setup I can reproduce locally.