### PR TITLE
fix(pi): avoid peak RAM in PiGemma construction by freeing replaced submodules

### DIFF
--- a/src/lerobot/policies/pi0_fast/modeling_pi0_fast.py
+++ b/src/lerobot/policies/pi0_fast/modeling_pi0_fast.py
@@ -227,6 +227,7 @@ class PI0FastPaliGemma(nn.Module):
         # forward(..., adarms_cond=...) is supported (same as pi0/pi05).
         if use_adarms[0]:
             text_config = self.paligemma.config.text_config
+            del self.paligemma.model.language_model
             self.paligemma.model.language_model = PiGemmaModel(text_config)
 
         self.to_bfloat16_for_selected_params(precision)

--- a/src/lerobot/policies/pi_gemma.py
+++ b/src/lerobot/policies/pi_gemma.py
@@ -197,6 +197,9 @@ class PiGemmaModel(GemmaModel):  # type: ignore[misc]
 
     def __init__(self, config: GemmaConfig, **kwargs):
         super().__init__(config, **kwargs)
+        # Free parent-allocated layers/norm before replacing to avoid ~2x peak memory.
+        del self.layers
+        del self.norm
         # if not getattr(config, "use_adarms", False):
         #     return
         cond_dim = getattr(config, "adarms_cond_dim", None)
@@ -328,6 +331,7 @@ class PiGemmaForCausalLM(GemmaForCausalLM):  # type: ignore[misc]
 
     def __init__(self, config: GemmaConfig, **kwargs):
         super().__init__(config, **kwargs)
+        del self.model
         self.model = PiGemmaModel(config)
 
 
@@ -336,6 +340,7 @@ class PaliGemmaModelWithPiGemma(PaliGemmaModel):
 
     def __init__(self, config):
         super().__init__(config)
+        del self.language_model
         self.language_model = PiGemmaModel(config.text_config)
 
 
@@ -344,6 +349,7 @@ class PaliGemmaForConditionalGenerationWithPiGemma(PaliGemmaForConditionalGenera
 
     def __init__(self, config):
         super().__init__(config)
+        del self.model
         self.model = PaliGemmaModelWithPiGemma(config)
 
     # Make modules available through conditional class for BC


### PR DESCRIPTION
## Summary / Motivation

- PR #2964 (transformers v5 bump) introduced `pi_gemma.py` where four classes subclass HuggingFace model classes and replace submodules after `super().__init__()`. Because the old submodules are not freed before the new ones are allocated — and the classes are nested — the standard GemmaModel weights end up instantiated 3 times and discarded 2 times, causing ~3x peak memory relative to the final model size. Users report PI05 fine-tuning went from ~40 GB on v0.4.0 to OOM on A100 80 GB with the same command.
- The fix adds `del self.<submodule>` before each replacement. CPython's reference counting guarantees immediate deallocation of the acyclic `nn.Module` trees, bringing peak memory back down to ~1x final model size. This pattern already exists in the codebase (`xvla/modeling_florence2.py:2455-2456`). No new dependencies are introduced.

## Related issues

- Fixes: #3251
- Related: #3254, #3326, #2216

## What changed

- Added `del self.layers` + `del self.norm` in `PiGemmaModel.__init__`, `del self.model` in `PiGemmaForCausalLM.__init__` and `PaliGemmaForConditionalGenerationWithPiGemma.__init__`, and `del self.language_model` in `PaliGemmaModelWithPiGemma.__init__` — all immediately after `super().__init__()` and before the replacement allocation.
- Added `del self.paligemma.model.language_model` before its replacement in the `use_adarms[0]` branch of `PI0FastPaliGemma.__init__`.

## How was this tested (or how to run locally)

- Verified memory improvement on a GPU machine:
```python
import resource, torch
from transformers.models.auto import CONFIG_MAPPING
from lerobot.policies.pi_gemma import PaliGemmaForConditionalGenerationWithPiGemma
rss = lambda: resource.getrusage(resource.RUSAGE_SELF).ru_maxrss // 1024  # MB
config = CONFIG_MAPPING["paligemma"]()  # use full-size defaults
print(f"Before: {rss()} MB")
model = PaliGemmaForConditionalGenerationWithPiGemma(config=config)
print(f"After:  {rss()} MB")
```
main:
Before: 838 MB
After:  40184 MB

this PR:
Before: 837 MB
After:  13956 MB

- Full Tests CI run: https://github.com/huggingface/lerobot/actions/runs/24897115349

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated
- [x] CI is green
- [x] Community Review: I have reviewed another contributor's open PR and linked it here: #

## Reviewer notes

- This supersedes the approach in PR #3326 (which used `accelerate.init_empty_weights()`) — the `del` approach achieves the same peak-memory reduction without adding `accelerate` as a dependency of the `pi` extra.
