### PR TITLE
Add optional motor telemetry to SO-follower recording

### DIFF
--- a/src/lerobot/robots/so_follower/config_so_follower.py
+++ b/src/lerobot/robots/so_follower/config_so_follower.py
@@ -41,6 +41,13 @@ class SOFollowerConfig:
     # Set to `True` for backward compatibility with previous policies/dataset
     use_degrees: bool = True
 
+    # If True, include Present_Velocity, Present_Load, and Present_Temperature in
+    # observations (read from the Feetech motor registers). Adds 3 extra `sync_read`
+    # calls per `get_observation()` (~15-30ms on a 6-motor bus at 1Mbaud), which
+    # may impact sustained FPS above 30Hz. Default False preserves existing behavior
+    # and keeps observations compatible with policies trained on position-only data.
+    record_telemetry: bool = False
+
 
 @RobotConfig.register_subclass("so101_follower")
 @RobotConfig.register_subclass("so100_follower")

--- a/src/lerobot/robots/so_follower/so_follower.py
+++ b/src/lerobot/robots/so_follower/so_follower.py
@@ -62,9 +62,20 @@ class SOFollower(Robot):
         )
         self.cameras = make_cameras_from_configs(config.cameras)
 
+    _TELEMETRY_REGISTERS: tuple[tuple[str, str], ...] = (
+        ("Present_Velocity", "vel"),
+        ("Present_Load", "load"),
+        ("Present_Temperature", "temp"),
+    )
+
     @property
     def _motors_ft(self) -> dict[str, type]:
-        return {f"{motor}.pos": float for motor in self.bus.motors}
+        features: dict[str, type] = {f"{motor}.pos": float for motor in self.bus.motors}
+        if self.config.record_telemetry:
+            for _, suffix in self._TELEMETRY_REGISTERS:
+                for motor in self.bus.motors:
+                    features[f"{motor}.{suffix}"] = float
+        return features
 
     @property
     def _cameras_ft(self) -> dict[str, tuple]:
@@ -180,6 +191,12 @@ class SOFollower(Robot):
         start = time.perf_counter()
         obs_dict = self.bus.sync_read("Present_Position")
         obs_dict = {f"{motor}.pos": val for motor, val in obs_dict.items()}
+
+        if self.config.record_telemetry:
+            for register, suffix in self._TELEMETRY_REGISTERS:
+                values = self.bus.sync_read(register)
+                obs_dict.update({f"{motor}.{suffix}": val for motor, val in values.items()})
+
         dt_ms = (time.perf_counter() - start) * 1e3
         logger.debug(f"{self} read state: {dt_ms:.1f}ms")
 

--- a/tests/robots/test_so100_follower.py
+++ b/tests/robots/test_so100_follower.py
@@ -109,3 +109,74 @@ def test_send_action(follower):
 
     goal_pos = {m: (i + 1) * 10 for i, m in enumerate(follower.bus.motors)}
     follower.bus.sync_write.assert_called_once_with("Goal_Position", goal_pos)
+
+
+@pytest.fixture
+def follower_with_telemetry():
+    bus_mock = _make_bus_mock()
+
+    # Return distinct values per register so the test can verify plumbing
+    _register_offsets = {
+        "Present_Position": 0,
+        "Present_Velocity": 100,
+        "Present_Load": 200,
+        "Present_Temperature": 300,
+    }
+
+    def _bus_side_effect(*_args, **kwargs):
+        bus_mock.motors = kwargs["motors"]
+        motors_order: list[str] = list(bus_mock.motors)
+
+        def _sync_read(register, _motors=None):
+            offset = _register_offsets.get(register, 0)
+            return {motor: idx + offset for idx, motor in enumerate(motors_order, 1)}
+
+        bus_mock.sync_read.side_effect = _sync_read
+        bus_mock.sync_write.return_value = None
+        bus_mock.write.return_value = None
+        bus_mock.disable_torque.return_value = None
+        bus_mock.enable_torque.return_value = None
+        bus_mock.is_calibrated = True
+        return bus_mock
+
+    with (
+        patch(
+            "lerobot.robots.so_follower.so_follower.FeetechMotorsBus",
+            side_effect=_bus_side_effect,
+        ),
+        patch.object(SO100Follower, "configure", lambda self: None),
+    ):
+        cfg = SO100FollowerConfig(port="/dev/null", record_telemetry=True)
+        robot = SO100Follower(cfg)
+        yield robot
+        if robot.is_connected:
+            robot.disconnect()
+
+
+def test_observation_features_includes_telemetry(follower_with_telemetry):
+    robot = follower_with_telemetry
+    features = robot.observation_features
+    for motor in robot.bus.motors:
+        assert f"{motor}.pos" in features
+        assert f"{motor}.vel" in features
+        assert f"{motor}.load" in features
+        assert f"{motor}.temp" in features
+
+
+def test_get_observation_with_telemetry(follower_with_telemetry):
+    robot = follower_with_telemetry
+    robot.connect()
+    obs = robot.get_observation()
+
+    motors = list(robot.bus.motors)
+    expected_keys = set()
+    for motor in motors:
+        expected_keys.update({f"{motor}.pos", f"{motor}.vel", f"{motor}.load", f"{motor}.temp"})
+    assert set(obs.keys()) == expected_keys
+
+    # Each register read produces distinct values; verify plumbing maps them correctly
+    for idx, motor in enumerate(motors, 1):
+        assert obs[f"{motor}.pos"] == idx
+        assert obs[f"{motor}.vel"] == idx + 100
+        assert obs[f"{motor}.load"] == idx + 200
+        assert obs[f"{motor}.temp"] == idx + 300


### PR DESCRIPTION
## Summary / Motivation

SO-follower currently records joint positions only, even though the Feetech STS motors used by SO-100 and SO-101 expose velocity (reg 58), load (reg 60), and temperature (reg 63) for free. This PR adds a `record_telemetry` flag to `SOFollowerConfig` that, when enabled, includes these three signals per motor in the observation dict — enabling downstream policy debugging, teleop data quality analysis, and post-hoc mechanical diagnostics without changing any default behavior.

Gated behind an opt-in flag because the 3 extra `sync_read` calls cost ~15-30ms on a 6-motor bus at 1Mbaud, which matters at 60Hz. A follow-up PR could add a batched multi-register read API to `motors_bus.py` to reduce this to a single transaction (addresses 56-63 are contiguous on STS3215).

Opening as **draft** to gather feedback on the API surface (flag name, register selection, whether this should be generalized to `koch_follower` / other Dynamixel/Feetech followers in the same PR) before polishing.

## Related issues

- Related: none open — happy to link if maintainers are aware of prior discussion.

## What changed

- Added `record_telemetry: bool = False` field to `SOFollowerConfig` (keeps default behavior identical).
- Extended `SOFollower._motors_ft` to emit `{motor}.vel`, `{motor}.load`, `{motor}.temp` keys per motor when telemetry is enabled.
- Extended `SOFollower.get_observation()` to conditionally read `Present_Velocity`, `Present_Load`, `Present_Temperature` and populate the observation dict.
- **Not** a breaking change: policies trained on position-only datasets are unaffected; new datasets recorded with the flag enabled simply contain additional observation columns.

## How was this tested (or how to run locally)

- Added `tests/robots/test_so100_follower.py::test_observation_features_includes_telemetry` — asserts `.vel`, `.load`, `.temp` features are declared when flag is set.
- Added `tests/robots/test_so100_follower.py::test_get_observation_with_telemetry` — asserts `get_observation()` populates telemetry keys with values from their respective registers (via a mocked bus that returns distinct values per register).
- Existing `test_connect_disconnect`, `test_get_observation`, `test_send_action` still pass unchanged — regression-proves backward compatibility.
- Full test file:
  ```
  pytest -q tests/robots/test_so100_follower.py
  # 5 passed
  ```
- Hardware validation (SO-101): not performed by the PR author; requesting a reviewer with hardware to verify real reads populate sensible values. Happy to iterate on perf if measurements differ from the ~15-30ms estimate.

## Checklist (required before merge)

- [x] Linting/formatting run (`ruff check` and `ruff format --check` clean on modified files)
- [x] All tests pass locally (`pytest tests/robots/test_so100_follower.py`)
- [ ] Documentation updated (`docs/source/robots/so100.mdx` — will add a short config note in a follow-up commit if the API is approved)
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here — will address before marking ready for review

## Reviewer notes

- **API naming**: `record_telemetry` was chosen as a neutral, opt-in name. Open to alternatives (`include_motor_state`, `extra_motor_features`, …).
- **Register selection**: opted for Velocity + Load + Temperature as the set most useful for post-hoc analysis. Present_Voltage (reg 62) and Present_Current (reg 69, STS only) are also available and could be added — wanted to ship a minimal set first.
- **Perf**: three extra `sync_read` calls is the bottleneck. A batched read API on `FeetechMotorsBus` (registers 56-63 are contiguous → single transaction) would eliminate this; flagged as a natural follow-up. Keeping it out of this PR to minimize review surface.
- **Scope**: intentionally limited to SO-follower. `koch_follower` and similar arms expose equivalent Dynamixel registers — happy to generalize in a follow-up once this API lands.