### PR TITLE
docs(i18n): add Korean translation for multi_gpu_training.mdx

### DIFF
--- a/docs/source/ko/multi_gpu_training.mdx
+++ b/docs/source/ko/multi_gpu_training.mdx
@@ -4,7 +4,7 @@
 
 ## 설치
 
-`accelerate`는 `training` extra에 포함되어 있습니다. 다음 명령으로 설치하세요:
+`accelerate`는 `training` extra에 포함되어 있습니다. 다음 명령으로 설치해주세요:
 
 ```bash
 pip install 'lerobot[training]'
@@ -70,24 +70,24 @@ accelerate launch $(which lerobot-train) \
 accelerate로 훈련을 실행하면:
 
 1. **자동 감지**: LeRobot이 accelerate 환경에서 실행 중인지 자동으로 감지합니다.
-2. **데이터 분산**: 배치가 GPU들에 자동으로 분할됩니다.
+2. **데이터 분산**: 배치가 각 GPU로 자동으로 분할됩니다.
 3. **그래디언트 동기화**: 역전파 동안 GPU 간 그래디언트가 동기화됩니다.
 4. **단일 프로세스 로깅**: 메인 프로세스만 wandb 로깅과 체크포인트 저장을 수행합니다.
 
-## Learning Rate와 훈련 스텝 스케일링
+## 학습률과 훈련 스텝 스케일링
 
-**중요:** LeRobot은 GPU 개수에 따라 learning rate나 훈련 스텝을 자동으로 스케일링하지 **않습니다**. 따라서 하이퍼파라미터를 직접 완전히 제어할 수 있습니다.
+**중요:** LeRobot은 GPU 개수에 따라 학습률 혹은 훈련 스텝을 자동으로 스케일링하지 **않습니다**. 따라서 하이퍼파라미터를 직접 완전히 제어할 수 있습니다.
 
 ### 왜 자동 스케일링을 하지 않나요?
 
-많은 분산 훈련 프레임워크는 GPU 수에 비례해 learning rate를 자동으로 스케일링합니다(예: `lr = base_lr × num_gpus`).
-하지만 LeRobot은 사용자가 지정한 learning rate를 그대로 유지합니다.
+많은 분산 훈련 프레임워크는 GPU 수에 비례해 학습률을 자동으로 스케일링합니다(예: `lr = base_lr × num_gpus`).
+하지만 LeRobot은 사용자가 지정한 학습률을 그대로 유지합니다.
 
 ### 언제, 어떻게 스케일링하나요?
 
 여러 GPU를 사용할 때 하이퍼파라미터를 스케일링하고 싶다면 직접 적용해야 합니다:
 
-**Learning Rate 스케일링:**
+**학습률 스케일링:**
 
 ```bash
 # 예시: 2개 GPU에서 선형 LR 스케일링
@@ -118,7 +118,7 @@ accelerate launch --num_processes=2 $(which lerobot-train) \
 - `lerobot-train`의 `--policy.use_amp` 플래그는 accelerate 없이 실행할 때만 사용됩니다. accelerate 사용 시 mixed precision은 accelerate 설정에서 제어됩니다.
 - 충돌을 방지하기 위해 훈련 로그, 체크포인트, 허브 업로드는 메인 프로세스에서만 수행됩니다. 중복 출력을 막기 위해 비-메인 프로세스의 콘솔 로깅은 비활성화됩니다.
 - 유효 배치 크기는 `batch_size × num_gpus`입니다. 예를 들어 4개 GPU에서 `--batch_size=8`이면 유효 배치 크기는 32입니다.
-- learning rate scheduler는 다중 프로세스에서 올바르게 동작합니다. LeRobot은 프로세스 수에 따라 scheduler step이 바뀌지 않도록 `step_scheduler_with_optimizer=False`를 설정합니다.
+- 학습률 scheduler는 다중 프로세스에서 올바르게 동작합니다. LeRobot은 프로세스 수에 따라 scheduler step이 바뀌지 않도록 `step_scheduler_with_optimizer=False`를 설정합니다.
 - 모델 저장 또는 허브 업로드 시, LeRobot은 호환성을 위해 accelerate의 분산 래퍼를 자동으로 해제(unwrap)합니다.
 - WandB 연동은 메인 프로세스에서만 자동 초기화되어 run이 여러 개 생성되는 것을 방지합니다.
 

--- a/docs/source/ko/multi_gpu_training.mdx
+++ b/docs/source/ko/multi_gpu_training.mdx
@@ -116,10 +116,10 @@ accelerate launch --num_processes=2 $(which lerobot-train) \
 ## 참고 사항
 
 - `lerobot-train`의 `--policy.use_amp` 플래그는 accelerate 없이 실행할 때만 사용됩니다. accelerate 사용 시 mixed precision은 accelerate 설정에서 제어됩니다.
-- 충돌을 방지하기 위해 훈련 로그, 체크포인트, 허브 업로드는 메인 프로세스에서만 수행됩니다. 중복 출력을 막기 위해 비-메인 프로세스의 콘솔 로깅은 비활성화됩니다.
+- 충돌을 방지하기 위해 훈련 로그, 체크포인트, 허브 업로드는 메인 프로세스에서만 수행됩니다. 중복 출력을 막기 위해 메인이 아닌 프로세스의 콘솔 로깅은 비활성화됩니다.
 - 유효 배치 크기는 `batch_size × num_gpus`입니다. 예를 들어 4개 GPU에서 `--batch_size=8`이면 유효 배치 크기는 32입니다.
-- 학습률 scheduler는 다중 프로세스에서 올바르게 동작합니다. LeRobot은 프로세스 수에 따라 scheduler step이 바뀌지 않도록 `step_scheduler_with_optimizer=False`를 설정합니다.
-- 모델 저장 또는 허브 업로드 시, LeRobot은 호환성을 위해 accelerate의 분산 래퍼를 자동으로 해제(unwrap)합니다.
+- 학습률 스케줄링은 여러 프로세스 환경에서도 올바르게 처리됩니다. LeRobot은 accelerate가 프로세스 수에 따라 스케줄러 스텝을 조정하지 못하도록 step_scheduler_with_optimizer=False를 설정합니다.
+- 모델 저장 또는 허브 업로드 시, LeRobot은 호환성을 위해 accelerate의 분산 래퍼를 자동으로 추출(unwrap)합니다.
 - WandB 연동은 메인 프로세스에서만 자동 초기화되어 run이 여러 개 생성되는 것을 방지합니다.
 
 고급 구성이나 문제 해결은 [Accelerate 문서](https://huggingface.co/docs/accelerate)를 참고하세요. 많은 GPU에서 훈련하는 방법을 더 깊게 알고 싶다면 [Ultrascale Playbook](https://huggingface.co/spaces/nanotron/ultrascale-playbook)도 추천합니다.

--- a/docs/source/ko/multi_gpu_training.mdx
+++ b/docs/source/ko/multi_gpu_training.mdx
@@ -1,0 +1,125 @@
+# Multi-GPU 훈련
+
+이 가이드는 [Hugging Face Accelerate](https://huggingface.co/docs/accelerate)를 사용해 여러 GPU에서 정책을 훈련하는 방법을 설명합니다.
+
+## 설치
+
+`accelerate`는 `training` extra에 포함되어 있습니다. 다음 명령으로 설치하세요:
+
+```bash
+pip install 'lerobot[training]'
+```
+
+## 여러 GPU로 훈련하기
+
+훈련은 두 가지 방법으로 실행할 수 있습니다:
+
+### 방법 1: config 없이 실행 (파라미터 직접 지정)
+
+`accelerate config`를 실행하지 않고도 명령어에서 모든 파라미터를 직접 지정할 수 있습니다:
+
+```bash
+accelerate launch \
+  --multi_gpu \
+  --num_processes=2 \
+  $(which lerobot-train) \
+  --dataset.repo_id=${HF_USER}/my_dataset \
+  --policy.type=act \
+  --policy.repo_id=${HF_USER}/my_trained_policy \
+  --output_dir=outputs/train/act_multi_gpu \
+  --job_name=act_multi_gpu \
+  --wandb.enable=true
+```
+
+**주요 accelerate 파라미터:**
+
+- `--multi_gpu`: multi-GPU 훈련 활성화
+- `--num_processes=2`: 사용할 GPU 개수
+- `--mixed_precision=fp16`: fp16 mixed precision 사용 (`bf16` 지원 시 대체 가능)
+
+### 방법 2: accelerate config 사용
+
+설정을 저장해서 쓰고 싶다면, 다음 명령으로 하드웨어 환경에 맞게 accelerate를 구성할 수 있습니다:
+
+```bash
+accelerate config
+```
+
+이 대화형 설정 과정에서는 훈련 환경(GPU 수, mixed precision 설정 등)에 대한 질문을 받고, 이후 재사용할 수 있도록 구성을 저장합니다. 단일 머신에서 간단한 multi-GPU 구성을 할 때는 다음 권장값을 사용할 수 있습니다:
+
+- Compute environment: This machine
+- Number of machines: 1
+- Number of processes: (사용할 GPU 개수)
+- GPU ids to use: (전체 사용 시 비워두기)
+- Mixed precision: fp16 또는 bf16 (더 빠른 훈련에 권장)
+
+그다음 아래처럼 훈련을 실행합니다:
+
+```bash
+accelerate launch $(which lerobot-train) \
+  --dataset.repo_id=${HF_USER}/my_dataset \
+  --policy.type=act \
+  --policy.repo_id=${HF_USER}/my_trained_policy \
+  --output_dir=outputs/train/act_multi_gpu \
+  --job_name=act_multi_gpu \
+  --wandb.enable=true
+```
+
+## 동작 방식
+
+accelerate로 훈련을 실행하면:
+
+1. **자동 감지**: LeRobot이 accelerate 환경에서 실행 중인지 자동으로 감지합니다.
+2. **데이터 분산**: 배치가 GPU들에 자동으로 분할됩니다.
+3. **그래디언트 동기화**: 역전파 동안 GPU 간 그래디언트가 동기화됩니다.
+4. **단일 프로세스 로깅**: 메인 프로세스만 wandb 로깅과 체크포인트 저장을 수행합니다.
+
+## Learning Rate와 훈련 스텝 스케일링
+
+**중요:** LeRobot은 GPU 개수에 따라 learning rate나 훈련 스텝을 자동으로 스케일링하지 **않습니다**. 따라서 하이퍼파라미터를 직접 완전히 제어할 수 있습니다.
+
+### 왜 자동 스케일링을 하지 않나요?
+
+많은 분산 훈련 프레임워크는 GPU 수에 비례해 learning rate를 자동으로 스케일링합니다(예: `lr = base_lr × num_gpus`).
+하지만 LeRobot은 사용자가 지정한 learning rate를 그대로 유지합니다.
+
+### 언제, 어떻게 스케일링하나요?
+
+여러 GPU를 사용할 때 하이퍼파라미터를 스케일링하고 싶다면 직접 적용해야 합니다:
+
+**Learning Rate 스케일링:**
+
+```bash
+# 예시: 2개 GPU에서 선형 LR 스케일링
+# 기준 LR: 1e-4, GPU 2개 사용 시 -> 2e-4
+accelerate launch --num_processes=2 $(which lerobot-train) \
+  --optimizer.lr=2e-4 \
+  --dataset.repo_id=lerobot/pusht \
+  --policy=act
+```
+
+**훈련 스텝 스케일링:**
+
+여러 GPU를 사용하면 유효 배치 크기 `bs`가 증가하므로(`batch_size × num_gpus`), 훈련 스텝 수를 비례해서 줄이는 것이 유리할 수 있습니다:
+
+```bash
+# 예시: 2개 GPU 사용으로 유효 배치 크기가 2배
+# 원래 설정: batch_size=8, steps=100000
+# 2개 GPU 사용 시: batch_size=8 (총 16), steps=50000
+accelerate launch --num_processes=2 $(which lerobot-train) \
+  --batch_size=8 \
+  --steps=50000 \
+  --dataset.repo_id=lerobot/pusht \
+  --policy=act
+```
+
+## 참고 사항
+
+- `lerobot-train`의 `--policy.use_amp` 플래그는 accelerate 없이 실행할 때만 사용됩니다. accelerate 사용 시 mixed precision은 accelerate 설정에서 제어됩니다.
+- 충돌을 방지하기 위해 훈련 로그, 체크포인트, 허브 업로드는 메인 프로세스에서만 수행됩니다. 중복 출력을 막기 위해 비-메인 프로세스의 콘솔 로깅은 비활성화됩니다.
+- 유효 배치 크기는 `batch_size × num_gpus`입니다. 예를 들어 4개 GPU에서 `--batch_size=8`이면 유효 배치 크기는 32입니다.
+- learning rate scheduler는 다중 프로세스에서 올바르게 동작합니다. LeRobot은 프로세스 수에 따라 scheduler step이 바뀌지 않도록 `step_scheduler_with_optimizer=False`를 설정합니다.
+- 모델 저장 또는 허브 업로드 시, LeRobot은 호환성을 위해 accelerate의 분산 래퍼를 자동으로 해제(unwrap)합니다.
+- WandB 연동은 메인 프로세스에서만 자동 초기화되어 run이 여러 개 생성되는 것을 방지합니다.
+
+고급 구성이나 문제 해결은 [Accelerate 문서](https://huggingface.co/docs/accelerate)를 참고하세요. 많은 GPU에서 훈련하는 방법을 더 깊게 알고 싶다면 [Ultrascale Playbook](https://huggingface.co/spaces/nanotron/ultrascale-playbook)도 추천합니다.


### PR DESCRIPTION
## Title

docs(i18n): add Korean translation for multi_gpu_training.mdx

## Summary / Motivation

Adds a Korean translation of [docs/source/multi_gpu_training.mdx](docs/source/multi_gpu_training.mdx) under [docs/source/ko/multi_gpu_training.mdx](docs/source/ko/multi_gpu_training.mdx). This is part of the ongoing Korean localization effort tracked in https://github.com/huggingface/lerobot/issues/3058. The translation preserves commands, code blocks, links, and the original document structure while adapting the explanatory text and terminology to match the tone of the existing Korean documentation.

## Related issues

- Related: #3058 (https://github.com/huggingface/lerobot/issues/3058)

## What changed

- Added a Korean translation for [docs/source/ko/multi_gpu_training.mdx](docs/source/ko/multi_gpu_training.mdx)
- Translated the narrative sections covering:
  - multi-GPU training with Hugging Face Accelerate
  - setup via direct `accelerate launch` arguments
  - setup via `accelerate config`
  - distributed training behavior in LeRobot
  - learning rate and training step scaling guidance
  - operational notes for logging, checkpointing, and WandB
- Preserved all shell commands, code blocks, external links, and examples in their original form
- No breaking changes

## How was this tested (or how to run locally)

- Tests added: none (docs-only change)
- Manual checks performed:
  - reviewed the rendered Markdown structure
  - verified commands and code blocks were preserved unchanged
  - verified links remained intact
  - checked terminology consistency with existing Korean docs
- Reviewer quick check:
  - compare [docs/source/multi_gpu_training.mdx](docs/source/multi_gpu_training.mdx) and [docs/source/ko/multi_gpu_training.mdx](docs/source/ko/multi_gpu_training.mdx)
  - confirm that only explanatory prose was translated and technical content remained accurate

## Checklist (required before merge)

- [ ] Linting/formatting run (`pre-commit run -a`)
- [ ] All tests pass locally (`pytest`)
- [x] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: # (insert PR number/link)

## Reviewer notes

- Please focus on translation quality and terminology consistency with other Korean docs in this repository.
- Commands, configuration examples, and links were intentionally preserved verbatim.
- Anyone in the community is free to review the PR.