### PR TITLE
Add SO-101 motor utility scripts (scan and set IDs)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,81 @@
+# SO-101 Utility Scripts
+
+Helper scripts for assembling and configuring the SO-101 leader arm.
+
+## Scripts
+
+### `scan_motors.py` — Identify motor IDs on the bus
+
+Scans the motor bus and reports which IDs are present, along with the
+corresponding joint name. Useful when motor labels have been lost or you
+want to verify which motors have already been configured.
+
+```bash
+# Scan for all SO-101 motors (IDs 1–6)
+python examples/so101/scan_motors.py --port /dev/tty.usbmodem5B790332241
+
+# Example output:
+#   Scanning IDs 1–6 on /dev/tty.usbmodem5B790332241 at 1000000 baud...
+#
+#   ✓ Found motor ID 1  →  shoulder_pan
+#   ✓ Found motor ID 2  →  shoulder_lift
+#   ✓ Found motor ID 3  →  elbow_flex
+#   ✓ Found motor ID 4  →  wrist_flex
+#   ✓ Found motor ID 5  →  wrist_roll
+#   ✓ Found motor ID 6  →  gripper
+#
+#   Found 6 motor(s): [1, 2, 3, 4, 5, 6]
+```
+
+Connect one motor at a time to identify a single motor, or daisy-chain
+all motors to get a full report.
+
+---
+
+### `set_motor_ids.py` — Configure motor IDs
+
+Sets motor IDs for individual SO-101 leader arm motors. This is useful
+when `lerobot-setup-motors` fails partway through (e.g. due to a loose
+cable), leaving some motors unconfigured. Since motor IDs are stored in
+non-volatile memory, already-configured motors are unaffected — only the
+remaining ones need to be set.
+
+```bash
+# Configure all motors (same as lerobot-setup-motors, but resumable)
+python examples/so101/set_motor_ids.py --port /dev/tty.usbmodem5B790332241
+
+# Configure only specific motors after a partial failure
+python examples/so101/set_motor_ids.py \
+  --port /dev/tty.usbmodem5B790332241 \
+  --motors shoulder_lift shoulder_pan
+```
+
+Connect each motor **individually** when prompted — do not daisy-chain
+multiple motors during ID assignment, as they all default to ID 1 and
+will conflict on the bus.
+
+---
+
+## Finding your port
+
+Connect the URT-2 board to your computer via USB, then run:
+
+```bash
+# macOS / Linux
+ls /dev/tty.usb*
+
+# or
+python -m serial.tools.list_ports
+```
+
+## Requirements
+
+Install the feetech extra before using these scripts:
+
+```bash
+uv sync --extra feetech
+```
+
+> **Note:** Python 3.12 or 3.13 is required. Python 3.14 is not yet
+> supported due to a `draccus` incompatibility.
+

--- a/examples/scan_motors.py
+++ b/examples/scan_motors.py
@@ -1,0 +1,107 @@
+# !/usr/bin/env python
+
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Scan the motor bus and report which motor IDs are present.
+
+Useful when motor labels have been lost or you need to verify which
+motors have already been configured.
+
+Connect one motor at a time and run this script to identify its ID,
+or connect all motors on the daisy chain to get a full report.
+
+Example usage:
+
+    # Scan for all motors (IDs 1-6)
+    python scan_motors.py --port /dev/tty.usbmodem5B790332241
+
+    # Scan a custom ID range
+    python scan_motors.py --port /dev/tty.usbmodem5B790332241 --min-id 1 --max-id 253
+"""
+
+import argparse
+
+import scservo_sdk as scs
+
+LEADER_MOTOR_NAMES: dict[int, str] = {
+    1: "shoulder_pan",
+    2: "shoulder_lift",
+    3: "elbow_flex",
+    4: "wrist_flex",
+    5: "wrist_roll",
+    6: "gripper",
+}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Scan the motor bus and report which motor IDs are present."
+    )
+    parser.add_argument(
+        "--port",
+        type=str,
+        required=True,
+        help="Serial port of the URT-2 / bus servo adapter (e.g. /dev/tty.usbmodem5B790332241)",
+    )
+    parser.add_argument(
+        "--baudrate",
+        type=int,
+        default=1000000,
+        help="Baud rate to use for scanning (default: 1000000)",
+    )
+    parser.add_argument(
+        "--min-id",
+        type=int,
+        default=1,
+        help="Lowest motor ID to scan (default: 1)",
+    )
+    parser.add_argument(
+        "--max-id",
+        type=int,
+        default=6,
+        help="Highest motor ID to scan (default: 6)",
+    )
+    args = parser.parse_args()
+
+    port_handler = scs.PortHandler(args.port)
+    packet_handler = scs.PacketHandler(0)  # protocol version 0 for Feetech STS3215
+
+    if not port_handler.openPort():
+        raise RuntimeError(f"Failed to open port {args.port}")
+    if not port_handler.setBaudRate(args.baudrate):
+        raise RuntimeError(f"Failed to set baudrate {args.baudrate}")
+
+    print(f"Scanning IDs {args.min_id}–{args.max_id} on {args.port} at {args.baudrate} baud...\n")
+
+    found = []
+    for motor_id in range(args.min_id, args.max_id + 1):
+        _, result, _ = packet_handler.ping(port_handler, motor_id)
+        if result == scs.COMM_SUCCESS:
+            joint = LEADER_MOTOR_NAMES.get(motor_id, "unknown joint")
+            print(f"  ✓ Found motor ID {motor_id}  →  {joint}")
+            found.append(motor_id)
+
+    port_handler.closePort()
+
+    print(f"\nFound {len(found)} motor(s): {found}" if found else "\nNo motors found. Check cable connection.")
+
+    missing = [i for i in range(1, 7) if i not in found]
+    if missing:
+        print(f"Missing SO-101 IDs:  {missing}")
+        print("Run set_motor_ids.py to configure the missing motors.")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/set_motor_ids.py
+++ b/examples/set_motor_ids.py
@@ -1,0 +1,87 @@
+# !/usr/bin/env python
+
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Set motor IDs for individual SO-101 leader arm motors.
+
+This script is useful when `lerobot-setup-motors` fails partway through
+(e.g. due to a loose cable), leaving some motors unconfigured. Since motor
+IDs are stored in non-volatile memory, already-configured motors are fine —
+only the remaining ones need to be set.
+
+Example usage:
+
+    # Configure all motors (same as lerobot-setup-motors, but resumable)
+    python set_motor_ids.py --port /dev/tty.usbmodem5B790332241
+
+    # Configure only specific motors after a partial failure
+    python set_motor_ids.py --port /dev/tty.usbmodem5B790332241 --motors shoulder_lift shoulder_pan
+"""
+
+import argparse
+
+from lerobot.motors import Motor, MotorNormMode
+from lerobot.motors.feetech import FeetechMotorsBus
+
+LEADER_MOTORS: dict[str, Motor] = {
+    "shoulder_pan": Motor(1, "sts3215", MotorNormMode.RANGE_M100_100),
+    "shoulder_lift": Motor(2, "sts3215", MotorNormMode.RANGE_M100_100),
+    "elbow_flex": Motor(3, "sts3215", MotorNormMode.RANGE_M100_100),
+    "wrist_flex": Motor(4, "sts3215", MotorNormMode.RANGE_M100_100),
+    "wrist_roll": Motor(5, "sts3215", MotorNormMode.RANGE_M100_100),
+    "gripper": Motor(6, "sts3215", MotorNormMode.RANGE_0_100),
+}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Set motor IDs for individual SO-101 leader arm motors. "
+            "Useful for resuming a failed lerobot-setup-motors run."
+        )
+    )
+    parser.add_argument(
+        "--port",
+        type=str,
+        required=True,
+        help="Serial port of the URT-2 / bus servo adapter (e.g. /dev/tty.usbmodem5B790332241)",
+    )
+    parser.add_argument(
+        "--motors",
+        type=str,
+        nargs="+",
+        choices=list(LEADER_MOTORS.keys()),
+        default=list(LEADER_MOTORS.keys()),
+        help=(
+            "One or more motor names to configure. Defaults to all motors in reverse order "
+            "(gripper first, shoulder_pan last), matching the lerobot-setup-motors behaviour. "
+            "Choices: " + ", ".join(LEADER_MOTORS.keys())
+        ),
+    )
+    args = parser.parse_args()
+
+    selected: dict[str, Motor] = {name: LEADER_MOTORS[name] for name in args.motors}
+    bus = FeetechMotorsBus(port=args.port, motors=selected)
+
+    for motor in reversed(list(selected.keys())):
+        input(f"Connect the controller board to the '{motor}' motor only and press Enter...")
+        bus.setup_motor(motor)
+        print(f"'{motor}' motor id set to {selected[motor].id}")
+
+    print("Done! All requested motors configured.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Add SO-101 motor utility scripts (scan and set IDs)

### Problem

Two issues encountered when setting up SO-101 leader arm motors:

1. **Python 3.14 incompatibility**: `lerobot-setup-motors` crashes on Python 3.14 due to a `draccus` incompatibility with the new `str | None` type syntax in `argparse`:
   ```
   TypeError: str | None is not callable
   ```
   Python 3.12 or 3.13 is required. This is not documented anywhere in the SO-101 assembly guide.

2. **No recovery from partial setup**: If `lerobot-setup-motors` crashes mid-way through (e.g. due to a loose cable on one motor), there is no way to resume — restarting always begins from the gripper (ID 6). Motors already configured are fine since IDs are stored on the motor, but the remaining motors have no path forward without a workaround.

### Changes

Adds `examples/so101/` with three files:

- **`scan_motors.py`**: scans the motor bus and reports which IDs are present, along with the corresponding joint name. Useful when motor labels are lost or you want to verify which motors have already been configured.
- **`set_motor_ids.py`**: accepts `--port` and `--motors` arguments, allowing users to configure all or a specific subset of motors. Useful for resuming a failed setup.
- **`README.md`**: explains both scripts with usage examples.

### Usage

```bash
# Identify which motors are connected
python examples/so101/scan_motors.py --port /dev/tty.usbmodem5B790332241

# Configure all motors
python examples/so101/set_motor_ids.py --port /dev/tty.usbmodem5B790332241

# Resume after a crash — configure only the remaining motors
python examples/so101/set_motor_ids.py \
  --port /dev/tty.usbmodem5B790332241 \
  --motors shoulder_lift shoulder_pan
```

### Testing

Tested on macOS (Apple Silicon) with Python 3.12, URT-2 board, and 6x STS3215 motors (C001, C044, C046 variants).