### PR TITLE
fix(policy): resolve state-dict naming clash on save (closes #3384)

### DIFF
--- a/src/lerobot/policies/pretrained.py
+++ b/src/lerobot/policies/pretrained.py
@@ -21,12 +21,12 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import TypedDict, TypeVar, Unpack
 
-import packaging
-import safetensors
+import torch
 from huggingface_hub import HfApi, ModelCard, ModelCardData, hf_hub_download
 from huggingface_hub.constants import SAFETENSORS_SINGLE_FILE
 from huggingface_hub.errors import HfHubHTTPError
-from safetensors.torch import load_model as load_model_as_safetensor, save_model as save_model_as_safetensor
+from safetensors import safe_open
+from safetensors.torch import save_file as save_safetensors_file
 from torch import Tensor, nn
 
 from lerobot.configs import PreTrainedConfig
@@ -36,6 +36,83 @@ from lerobot.utils.hub import HubMixin
 from .utils import log_model_loading_keys
 
 T = TypeVar("T", bound="PreTrainedPolicy")
+
+
+def _materialized_state_dict(model: nn.Module) -> dict[str, Tensor]:
+    """Return ``model.state_dict()`` with each tensor materialized to its own contiguous storage.
+
+    ``safetensors.torch.save_model`` refuses to save when any tensor in the state dict is a
+    non-complete view of a larger storage (it fails with "None is covering the entire storage").
+    This can happen with sub-modules that come from ``transformers.from_pretrained`` (for example
+    ``CLIPVisionModel`` inside ``observation_encoder.vision_encoder``) where individual parameters
+    can end up as slices of a shared underlying storage in some library/version combinations
+    (see https://github.com/huggingface/lerobot/issues/3384,
+    https://github.com/huggingface/lerobot/issues/1142).
+
+    Calling ``.detach().clone()`` on each tensor is a defensive copy that guarantees every entry
+    owns its own contiguous storage, which both unblocks the duplicate-name check in safetensors
+    and produces a self-contained on-disk file. Tied weights become independent copies on disk;
+    on load they are rebuilt by the model's own ``__init__`` / ``_tie_weights`` logic, so this
+    is safe for the existing tied-weight pathways used in lerobot.
+    """
+    return {name: tensor.detach().clone() for name, tensor in model.state_dict().items()}
+
+
+def _safe_load_state_into_model(
+    model: nn.Module, model_file: str, device: str, strict: bool
+) -> tuple[list[str], list[str]]:
+    """Load a safetensors file into ``model`` without ``safetensors.torch.load_model``'s side checks.
+
+    The high-level ``safetensors.torch.load_model`` runs ``_remove_duplicate_names`` on the
+    *destination* model's state dict. When any destination parameter is a non-complete storage
+    view (see :func:`_materialized_state_dict`), that helper raises a confusing
+    ``RuntimeError: ... None is covering the entire storage`` even though the on-disk file is
+    perfectly fine (issue #3384). We bypass it here by streaming the tensors through
+    :func:`safetensors.safe_open` and applying them with ``model.load_state_dict``.
+
+    Returns ``(missing_keys, unexpected_keys)`` mirroring the original function so callers
+    (and ``log_model_loading_keys``) need no change. Keys that are missing solely because they
+    are tied to a key that *was* loaded (i.e. share storage with a loaded parameter) are dropped
+    from ``missing_keys`` so tied-weight models don't trip ``strict=True`` callers.
+    """
+    state_dict: dict[str, Tensor] = {}
+    with safe_open(model_file, framework="pt", device=device) as reader:
+        for key in reader.keys():
+            state_dict[key] = reader.get_tensor(key)
+
+    missing_keys, unexpected_keys = model.load_state_dict(state_dict, strict=False)
+    missing_keys = list(missing_keys)
+    unexpected_keys = list(unexpected_keys)
+
+    if missing_keys:
+        # Drop keys that are missing only because they share storage with a key we did load
+        # (tied weights, e.g. lm_head.weight tied to model.embed_tokens.weight). We compare by
+        # ``storage.data_ptr()`` because ``untyped_storage()`` may return a fresh Python wrapper
+        # on each call, so ``id(...)`` is not stable.
+        post_load_state = model.state_dict()
+        loaded_storage_ptrs = {
+            post_load_state[k].untyped_storage().data_ptr()
+            for k in state_dict
+            if k in post_load_state
+        }
+        missing_keys = [
+            k
+            for k in missing_keys
+            if k not in post_load_state
+            or post_load_state[k].untyped_storage().data_ptr() not in loaded_storage_ptrs
+        ]
+
+    if strict and (missing_keys or unexpected_keys):
+        missing_str = ", ".join(f'"{k}"' for k in sorted(missing_keys))
+        unexpected_str = ", ".join(f'"{k}"' for k in sorted(unexpected_keys))
+        error = f"Error(s) in loading state_dict for {model.__class__.__name__}:"
+        if missing_keys:
+            error += f"\n    Missing key(s) in state_dict: {missing_str}"
+        if unexpected_keys:
+            error += f"\n    Unexpected key(s) in state_dict: {unexpected_str}"
+        raise RuntimeError(error)
+
+    return missing_keys, unexpected_keys
 
 
 class ActionSelectKwargs(TypedDict, total=False):
@@ -70,7 +147,12 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
     def _save_pretrained(self, save_directory: Path) -> None:
         self.config._save_pretrained(save_directory)
         model_to_save = self.module if hasattr(self, "module") else self
-        save_model_as_safetensor(model_to_save, str(save_directory / SAFETENSORS_SINGLE_FILE))
+        # Detach + clone every tensor so each entry owns a complete contiguous storage. This
+        # avoids ``RuntimeError: ... None is covering the entire storage`` from safetensors when
+        # a sub-module exposes parameters that are non-complete views of a shared storage
+        # (see issue #3384, _materialized_state_dict for details).
+        state_dict = _materialized_state_dict(model_to_save)
+        save_safetensors_file(state_dict, str(save_directory / SAFETENSORS_SINGLE_FILE))
 
     @classmethod
     def from_pretrained(
@@ -135,26 +217,40 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
 
     @classmethod
     def _load_as_safetensor(cls, model: T, model_file: str, map_location: str, strict: bool) -> T:
-        # Create base kwargs
-        kwargs = {"strict": strict}
+        # We deliberately avoid ``safetensors.torch.load_model`` here. That helper inspects the
+        # *destination* model's state dict via ``_remove_duplicate_names`` and raises a
+        # ``RuntimeError`` if any parameter is a non-complete storage view (issue #3384). For
+        # policies that wrap third-party encoders (for example transformers' ``CLIPVisionModel``)
+        # this check can fire spuriously even though the on-disk file is valid.
+        target_device = str(map_location) if map_location is not None else "cpu"
+        loaded_device = target_device
+        try:
+            missing_keys, unexpected_keys = _safe_load_state_into_model(
+                model, model_file, target_device, strict
+            )
+        except (TypeError, ValueError) as e:
+            # Some older safetensors backends only support a subset of device strings. Fall
+            # back to CPU and let ``model.to`` below copy the tensors to the requested device.
+            # ``RuntimeError`` is intentionally NOT caught here so genuine load errors (e.g.
+            # strict-mode missing keys) still propagate.
+            if target_device == "cpu":
+                raise
+            logging.warning(
+                "Loading model weights directly on device %r is not supported by your "
+                "safetensors backend (%s); falling back to CPU and copying afterwards. "
+                "Update safetensors to >=0.4.3 for native device loading.",
+                target_device,
+                e,
+            )
+            missing_keys, unexpected_keys = _safe_load_state_into_model(
+                model, model_file, "cpu", strict
+            )
+            loaded_device = "cpu"
 
-        # Add device parameter for newer versions that support it
-        if packaging.version.parse(safetensors.__version__) >= packaging.version.parse("0.4.3"):
-            kwargs["device"] = map_location
-
-        # Load the model with appropriate kwargs
-        missing_keys, unexpected_keys = load_model_as_safetensor(model, model_file, **kwargs)
         log_model_loading_keys(missing_keys, unexpected_keys)
 
-        # For older versions, manually move to device if needed
-        if "device" not in kwargs and map_location != "cpu":
-            logging.warning(
-                "Loading model weights on other devices than 'cpu' is not supported natively in your version of safetensors."
-                " This means that the model is loaded on 'cpu' first and then copied to the device."
-                " This leads to a slower loading time."
-                " Please update safetensors to version 0.4.3 or above for improved performance."
-            )
-            model.to(map_location)
+        if loaded_device == "cpu" and target_device != "cpu":
+            model.to(target_device)
         return model
 
     @abc.abstractmethod

--- a/tests/policies/test_pretrained.py
+++ b/tests/policies/test_pretrained.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python
+
+# Copyright 2024 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Regression tests for save/load helpers in :mod:`lerobot.policies.pretrained`.
+
+Covers issue #3384 — ``RuntimeError: ... None is covering the entire storage`` that fired from
+``safetensors.torch._remove_duplicate_names`` when a sub-module exposed a parameter that was a
+non-complete view of a larger underlying storage.
+"""
+
+from __future__ import annotations
+
+import torch
+from huggingface_hub.constants import SAFETENSORS_SINGLE_FILE
+from torch import nn
+
+from lerobot.policies.pretrained import (
+    _materialized_state_dict,
+    _safe_load_state_into_model,
+)
+
+
+class _ModuleWithViewParam(nn.Module):
+    """Module whose ``state_dict`` exposes a parameter that is a non-complete view.
+
+    This mirrors what some ``transformers`` sub-modules can produce in the wild (issue #3384):
+    ``q_proj.weight`` ends up being a slice of a larger storage allocated by the parent module,
+    so it is registered as a parameter but does not own the entire underlying storage.
+    """
+
+    def __init__(self, in_features: int = 4, out_features: int = 8) -> None:
+        super().__init__()
+        # Allocate a single buffer big enough to hold three projections (Q, K, V).
+        backing = torch.randn(3 * out_features, in_features)
+        # Standard Linear modules — we then re-point each weight at a slice of the shared
+        # backing storage so each parameter becomes a non-complete view. This reproduces the
+        # state-dict shape that triggered ``RuntimeError: ... None is covering the entire
+        # storage`` from ``safetensors._remove_duplicate_names`` before this fix.
+        self.q_proj = nn.Linear(in_features, out_features, bias=False)
+        self.k_proj = nn.Linear(in_features, out_features, bias=False)
+        self.v_proj = nn.Linear(in_features, out_features, bias=False)
+        with torch.no_grad():
+            self.q_proj.weight.data = backing[:out_features]
+            self.k_proj.weight.data = backing[out_features : 2 * out_features]
+            self.v_proj.weight.data = backing[2 * out_features :]
+        # Keep the backing storage alive on the module so the slices remain valid.
+        self._backing = backing
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.q_proj(x) + self.k_proj(x) + self.v_proj(x)
+
+
+def _is_view_param(t: torch.Tensor) -> bool:
+    return t.data_ptr() != t.untyped_storage().data_ptr() or (
+        t.nelement() * t.element_size() != t.untyped_storage().nbytes()
+    )
+
+
+def test_module_with_view_param_actually_has_a_view():
+    """Sanity check — without the fixture having an actual non-complete view there is no bug
+    to regress. If pytorch ever changes ``nn.Linear`` so that ``.data = slice`` no longer
+    creates a view, this test will tell us so we can update the fixture."""
+    module = _ModuleWithViewParam()
+    assert _is_view_param(module.q_proj.weight), (
+        "Expected q_proj.weight to be a non-complete storage view; the regression test "
+        "fixture is no longer reproducing issue #3384."
+    )
+
+
+def test_materialized_state_dict_breaks_views(tmp_path):
+    """``_materialized_state_dict`` must produce tensors that own their own complete storage,
+    so that ``safetensors.torch.save_file`` can persist them without raising the
+    ``_remove_duplicate_names`` error."""
+    module = _ModuleWithViewParam()
+    materialized = _materialized_state_dict(module)
+
+    for name, tensor in materialized.items():
+        assert not _is_view_param(tensor), (
+            f"{name} is still a non-complete view after materialization; saving would still fail."
+        )
+
+    # And we can actually save it. Before the fix this raised ``RuntimeError: ... None is
+    # covering the entire storage``.
+    from safetensors.torch import save_file
+
+    save_path = tmp_path / SAFETENSORS_SINGLE_FILE
+    save_file(materialized, str(save_path))
+    assert save_path.exists()
+
+
+def test_safe_load_round_trip_with_view_param(tmp_path):
+    """End-to-end regression for issue #3384: save a module that has a view parameter, then
+    load the resulting safetensors file back into a freshly-constructed module that *also*
+    has a view parameter. The high-level ``safetensors.torch.load_model`` raised here; the
+    new ``_safe_load_state_into_model`` helper must succeed and restore the values."""
+    torch.manual_seed(0)
+    src = _ModuleWithViewParam()
+
+    # Save through the same path the policy uses.
+    from safetensors.torch import save_file
+
+    save_path = tmp_path / SAFETENSORS_SINGLE_FILE
+    save_file(_materialized_state_dict(src), str(save_path))
+
+    torch.manual_seed(1)  # different init to make sure load actually restores
+    dst = _ModuleWithViewParam()
+    assert not torch.allclose(src.q_proj.weight, dst.q_proj.weight), (
+        "Source and destination modules accidentally share initial values; the round-trip "
+        "test would not detect a no-op load."
+    )
+
+    missing, unexpected = _safe_load_state_into_model(
+        dst, str(save_path), device="cpu", strict=True
+    )
+    assert missing == [], f"Unexpected missing keys after round-trip: {missing}"
+    assert unexpected == [], f"Unexpected extra keys after round-trip: {unexpected}"
+
+    for name in ("q_proj.weight", "k_proj.weight", "v_proj.weight"):
+        assert torch.allclose(src.state_dict()[name], dst.state_dict()[name]), (
+            f"{name} was not restored correctly after the safetensors round-trip."
+        )
+
+
+def test_safe_load_handles_tied_weights(tmp_path):
+    """When the destination model has tied weights (a parameter that points at another
+    parameter's storage), keys that are absent from the file *because they are tied* should
+    not show up in ``missing_keys`` — otherwise ``strict=True`` callers would always fail."""
+
+    class TiedModule(nn.Module):
+        def __init__(self) -> None:
+            super().__init__()
+            self.embed = nn.Embedding(8, 4)
+            self.head = nn.Linear(4, 8, bias=False)
+            # Tie the head weight to the embedding (classic LM tie).
+            self.head.weight = self.embed.weight
+
+    from safetensors.torch import save_file
+
+    src = TiedModule()
+    # The on-disk file should contain only one of the tied keys (whichever pytorch picks
+    # first in state_dict iteration). We materialize and drop the tied alias to emulate a
+    # "saved by transformers" file shape.
+    sd = _materialized_state_dict(src)
+    # Keep "embed.weight" only, drop the tied "head.weight" alias.
+    sd.pop("head.weight", None)
+    save_path = tmp_path / SAFETENSORS_SINGLE_FILE
+    save_file(sd, str(save_path))
+
+    dst = TiedModule()
+    missing, unexpected = _safe_load_state_into_model(
+        dst, str(save_path), device="cpu", strict=True
+    )
+    assert missing == [], (
+        f"head.weight was reported as missing even though it is tied to embed.weight: {missing}"
+    )
+    assert unexpected == []


### PR DESCRIPTION
## Why

`policy.from_pretrained(...)` (and, symmetrically, `save_pretrained(...)`) sometimes blows up with:

```
RuntimeError: Error while trying to find names to remove to save state dict, but found no
suitable name to keep for saving amongst:
{'observation_encoder.vision_encoder.model.vision_model.encoder.layers.0.self_attn.q_proj.weight'}.
None is covering the entire storage. Refusing to save/load the model since you could be storing
much more memory than needed.
```

Reported in #3384 (and, with a different key, in #1142 — closed stale).

The root cause is `safetensors.torch.{save,load}_model`. Both helpers run `_remove_duplicate_names` on the module's `state_dict()`. If even one tensor in that dict is a non-complete view of a larger storage (`tensor.data_ptr() != storage_ptr` or `nelement * size != storage_size`), the helper bails out — even though the on-disk file itself is fine.

This shows up in the wild for policies like `multi_task_dit` that wrap `transformers.CLIPVisionModel` inside `observation_encoder.vision_encoder.model`. Some library/version combinations leave individual `q_proj.weight` (and friends) as slices of a shared backing storage, which is exactly what the user in #3384 hit.

## What

- `src/lerobot/policies/pretrained.py`
  - New helper `_materialized_state_dict(model)`: returns the model's `state_dict()` with every tensor `detach().clone()`'d so each entry owns its own complete storage. Used in `_save_pretrained` to feed `safetensors.torch.save_file` directly instead of `save_model`.
  - New helper `_safe_load_state_into_model(model, file, device, strict)`: streams tensors via `safe_open` and applies them with `model.load_state_dict(strict=False)`. Manually computes `(missing, unexpected)` and drops keys that are missing only because they share storage with a key we did load (tied weights), so `strict=True` callers keep working. Used in `_load_as_safetensor` instead of `safetensors.torch.load_model`.
  - Removed the now-unneeded `safetensors`/`packaging` imports and the version-gated device kwarg branch — `safe_open` accepts `device` directly. A small CPU-fallback is kept for older safetensors backends that reject the requested device string.

- `tests/policies/test_pretrained.py` (new)
  - `test_module_with_view_param_actually_has_a_view` — sanity-checks that the test fixture still exercises a non-complete view (so the regression test stays valid as PyTorch evolves).
  - `test_materialized_state_dict_breaks_views` — asserts the materialized dict no longer contains views and that `safetensors.torch.save_file` accepts it.
  - `test_safe_load_round_trip_with_view_param` — full save/load round-trip into a destination module that itself has view params. Before the fix this raised `RuntimeError: ... None is covering the entire storage`.
  - `test_safe_load_handles_tied_weights` — verifies a tied-weight model loads cleanly under `strict=True` even when the on-disk file omits the tied alias.

## Tested

- [ ] `uv run pytest tests/policies/test_pretrained.py -svv` (please run; the sandbox this PR was prepared in could not execute Python)
- [ ] Existing `tests/policies/multi_task_dit/test_multi_task_dit.py::test_multi_task_dit_policy_save_and_load` still passes

## Checkpoint compatibility

No breaking changes:

- Old checkpoints (saved via the previous `save_model` path, which dropped tied-weight aliases) load cleanly: missing tied keys are now stripped from `missing_keys` via the post-load storage-pointer check.
- New checkpoints (saved via `save_file` after materialization) carry one entry per tensor — including tied-weight aliases — with identical bytes. Loading these with the *previous* code path also works because `safetensors.torch.load_model` happily accepts extra "unexpected" keys when `strict=False` (the lerobot default).