### PR TITLE
fix(viz): handle single-dimensional state/action in dataset visualization

### DIFF
--- a/src/lerobot/scripts/lerobot_dataset_viz.py
+++ b/src/lerobot/scripts/lerobot_dataset_viz.py
@@ -155,12 +155,12 @@ def visualize_dataset(
 
             # display each dimension of action space (e.g. actuators command)
             if ACTION in batch:
-                for dim_idx, val in enumerate(batch[ACTION][i]):
+                for dim_idx, val in enumerate(batch[ACTION][i].reshape(-1)):
                     rr.log(f"{ACTION}/{dim_idx}", rr.Scalars(val.item()))
 
             # display each dimension of observed state space (e.g. agent position in joint space)
             if OBS_STATE in batch:
-                for dim_idx, val in enumerate(batch[OBS_STATE][i]):
+                for dim_idx, val in enumerate(batch[OBS_STATE][i].reshape(-1)):
                     rr.log(f"state/{dim_idx}", rr.Scalars(val.item()))
 
             if DONE in batch:


### PR DESCRIPTION
## Summary
- Fix `TypeError: iteration over a 0-d tensor` in `lerobot-dataset-viz` when the observation state or action has only one dimension
- Use `reshape(-1)` to ensure per-sample tensors are always 1-d before enumerating dimensions
- Also fixes the same latent bug for single-dimensional action spaces

## Test plan
- [ ] Verify with a dataset that has a single-dimensional observation state (as reported in #3415)
- [ ] Verify no regression with standard multi-dimensional datasets (e.g. `lerobot/pusht`)

Fixes #3415.
