### PR TITLE
fix(rollout): fixing the episode length to use hwc

### DIFF
--- a/src/lerobot/rollout/strategies/core.py
+++ b/src/lerobot/rollout/strategies/core.py
@@ -219,7 +219,7 @@ def estimate_max_episode_seconds(
     The estimate ignores codec-specific settings (CRF, preset) on purpose:
     we only need a rough lower bound on bitrate, not a precise prediction.
 
-    Falls back to 600 s (10 min) when no video features are present.
+    Falls back to 300 s (5 min) when no video features are present.
     """
     # 0.1 bits-per-pixel is a *low* estimate for CRF-30 streaming video of
     # robot footage (real-world is typically 0.1 – 0.3 bpp).  Under-
@@ -233,16 +233,16 @@ def estimate_max_episode_seconds(
         if feat.get("dtype") == "video":
             shape = feat.get("shape", ())
 
-            # Assuming shape could be (C, H, W) or (T, C, H, W)
+            # (H, W, C)
             # We want to extract the spatial dimensions.
-            if len(shape) >= 3:
-                h, w = shape[-2], shape[-1]
-                pixels = h * w
-                if pixels > 0:
-                    camera_pixels.append(pixels)
+            if len(shape) == 3:
+                pixels = shape[0] * shape[1] * shape[2]
+                camera_pixels.append(pixels)
+            else:
+                raise ValueError(f"Unexpected video feature shape: {shape}")
 
     if not camera_pixels:
-        return 600.0
+        return 300.0
 
     # Use the smallest camera: it produces the lowest bitrate and therefore
     # takes the longest to reach the target — the conservative choice.
@@ -252,7 +252,7 @@ def estimate_max_episode_seconds(
 
     # Guard against division by zero just in case
     if bytes_per_second <= 0:
-        return 600.0
+        return 300.0
 
     return (target_size_mb * 1024 * 1024) / bytes_per_second
 


### PR DESCRIPTION
## fixing the episode length

- Previous implem did `w*c`, fixes it to be `h*w*c`
- lowered the fallback value to be 5 minutes (roughly 100MB for a single 480x640x3 camera and `strategy.upload_every_n_episodes=5`)

## How was this tested (or how to run locally)

```bash
lerobot-rollout \
    --strategy.type=sentry \
    --strategy.upload_every_n_episodes=5 \
    --policy.path=maximellerbach/omx_multicubes_act \
    --robot.type=omx_follower \
    --robot.port=/dev/ttyACM0 \
    --robot.id=omx_follower \
    --robot.cameras="{ wrist: {type: opencv, index_or_path: 6, width: 640, height: 480, fps: 30, fourcc: MJPG}, top: {type: opencv, index_or_path: 4, width: 640, height: 480, fps: 30, fourcc: MJPG} }" \
    --task="pick all the blocks and place them one by one in the blue square" \
    --dataset.repo_id=maximellerbach/rollout_omx_sentry_act \
    --policy.n_action_steps=15 \
    --strategy.target_video_file_size_mb=10
```

=> target size of 10 mb yields 30 sec per episode

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)