### PR TITLE
Expose sarm package API and ship reward model card template

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include src/lerobot/templates/lerobot_modelcard_template.md
+include src/lerobot/templates/lerobot_rewardmodel_modelcard_template.md
 include src/lerobot/datasets/card_template.md
 include src/lerobot/envs/metaworld_config.json

--- a/src/lerobot/rewards/sarm/__init__.py
+++ b/src/lerobot/rewards/sarm/__init__.py
@@ -1,0 +1,19 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .configuration_sarm import SARMConfig
+from .modeling_sarm import SARMRewardModel
+from .processor_sarm import make_sarm_pre_post_processors
+
+__all__ = ["SARMConfig", "SARMRewardModel", "make_sarm_pre_post_processors"]


### PR DESCRIPTION
## Title

Chore(rewards): expose sarm package API and ship reward model card template

## Summary / Motivation

This PR completes the public surface of the SARM reward submodule and keeps packaging consistent with the policy model card.

## Related issues

- Fixes / Closes: # (None)
- Related: # (None)

## What changed

- `src/lerobot/rewards/sarm/__init__.py`: add Apache header, re-export `SARMConfig`, `SARMRewardModel`, `make_sarm_pre_post_processors`, and `__all__`.
- `MANIFEST.in`: include `src/lerobot/templates/lerobot_rewardmodel_modelcard_template.md`.

No breaking changes: existing imports from `lerobot.rewards` and deep imports under `lerobot.rewards.sarm.*` continue to work; this only adds a convenient package-level import path.

## How was this tested (or how to run locally)

```bash
uv run python -c "from lerobot.rewards.sarm import SARMConfig, SARMRewardModel, make_sarm_pre_post_processors; print('ok')"
```

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: # (insert PR number/link)
