### PR TITLE
feat(async_inference):  add configurable similarity function for observation filtering

### DIFF
--- a/docs/source/async.mdx
+++ b/docs/source/async.mdx
@@ -52,6 +52,7 @@ python -m lerobot.async_inference.robot_client \
     --actions_per_chunk=50 \ # POLICY: the number of actions to output at once
     --chunk_size_threshold=0.5 \ # CLIENT: the threshold for the chunk size before sending a new observation to the server
     --aggregate_fn_name=weighted_average \ # CLIENT: the function to aggregate actions on overlapping portions
+    --similarity_fn_name=euclidean \ # CLIENT: the function to check observation similarity (euclidean, disabled)
     --debug_visualize_queue_size=True # CLIENT: whether to visualize the queue size at runtime
 ```
 
@@ -66,6 +67,7 @@ Importantly,
 
 - `actions_per_chunk` and `chunk_size_threshold` are key parameters to tune for your setup.
 - `aggregate_fn_name` is the function to aggregate actions on overlapping portions. You can either add a new one to a registry of functions, or add your own in `robot_client.py` (see [here](NOTE:addlinktoLOC))
+- `similarity_fn_name` is the function to check if observations are similar enough to skip inference. Available options: `euclidean` (default, checks distance between observations), `disabled` (never skip observations). You can add custom functions to the `SIMILARITY_FUNCTIONS` registry in `configs.py`.
 - `debug_visualize_queue_size` is a useful tool to tune the `CLIENT` parameters.
 
 ## Done! You should see your robot moving around by now 😉
@@ -161,6 +163,7 @@ python -m lerobot.async_inference.robot_client \
     --actions_per_chunk=50 \ # POLICY: the number of actions to output at once
     --chunk_size_threshold=0.5 \ # CLIENT: the threshold for the chunk size before sending a new observation to the server
     --aggregate_fn_name=weighted_average \ # CLIENT: the function to aggregate actions on overlapping portions
+    --similarity_fn_name=euclidean \ # CLIENT: the function to check observation similarity (euclidean, disabled)
     --debug_visualize_queue_size=True # CLIENT: whether to visualize the queue size at runtime
 ```
 </hfoption>

--- a/src/lerobot/async_inference/configs.py
+++ b/src/lerobot/async_inference/configs.py
@@ -33,13 +33,31 @@ AGGREGATE_FUNCTIONS = {
     "conservative": lambda old, new: 0.7 * old + 0.3 * new,
 }
 
+SIMILARITY_FUNCTIONS = {
+    "euclidean": lambda s1, s2, tol: torch.linalg.norm(s1 - s2) < tol,
+    "disabled": lambda _, __, ___: False,  # Always return False, never skip an observation due to similarity
+    # Add more similarity functions as needed
+}
 
-def get_aggregate_function(name: str) -> Callable[[torch.Tensor, torch.Tensor], torch.Tensor]:
+
+def get_aggregate_function(
+    name: str,
+) -> Callable[[torch.Tensor, torch.Tensor], torch.Tensor]:
     """Get aggregate function by name from registry."""
     if name not in AGGREGATE_FUNCTIONS:
         available = list(AGGREGATE_FUNCTIONS.keys())
         raise ValueError(f"Unknown aggregate function '{name}'. Available: {available}")
     return AGGREGATE_FUNCTIONS[name]
+
+
+def get_similarity_function(
+    name: str,
+) -> Callable[[torch.Tensor, torch.Tensor, float], bool]:
+    """Get similarity function by name from registry."""
+    if name not in SIMILARITY_FUNCTIONS:
+        available = list(SIMILARITY_FUNCTIONS.keys())
+        raise ValueError(f"Unknown similarity function '{name}'. Available: {available}")
+    return SIMILARITY_FUNCTIONS[name]
 
 
 @dataclass
@@ -57,11 +75,21 @@ class PolicyServerConfig:
     # Timing configuration
     fps: int = field(default=DEFAULT_FPS, metadata={"help": "Frames per second"})
     inference_latency: float = field(
-        default=DEFAULT_INFERENCE_LATENCY, metadata={"help": "Target inference latency in seconds"}
+        default=DEFAULT_INFERENCE_LATENCY,
+        metadata={"help": "Target inference latency in seconds"},
     )
 
     obs_queue_timeout: float = field(
-        default=DEFAULT_OBS_QUEUE_TIMEOUT, metadata={"help": "Timeout for observation queue in seconds"}
+        default=DEFAULT_OBS_QUEUE_TIMEOUT,
+        metadata={"help": "Timeout for observation queue in seconds"},
+    )
+
+    # Similarity function configuration (CLI-compatible)
+    similarity_fn_name: str = field(
+        default="euclidean",
+        metadata={
+            "help": f"Name of similarity function to use. Options: {list(SIMILARITY_FUNCTIONS.keys())}"
+        },
     )
 
     def __post_init__(self):
@@ -77,6 +105,12 @@ class PolicyServerConfig:
 
         if self.obs_queue_timeout < 0:
             raise ValueError(f"obs_queue_timeout must be non-negative, got {self.obs_queue_timeout}")
+
+        # Initialize similarity function if name is provided (will be updated by client)
+        if self.similarity_fn_name:
+            self.similarity_fn = get_similarity_function(self.similarity_fn_name)
+        else:
+            self.similarity_fn = None  # Will be set when client config is received
 
     @classmethod
     def from_dict(cls, config_dict: dict) -> "PolicyServerConfig":
@@ -143,6 +177,14 @@ class RobotClientConfig:
         metadata={"help": f"Name of aggregate function to use. Options: {list(AGGREGATE_FUNCTIONS.keys())}"},
     )
 
+    # Similarity function configuration (CLI-compatible, passed to server)
+    similarity_fn_name: str = field(
+        default="euclidean",
+        metadata={
+            "help": f"Name of similarity function to use. Options: {list(SIMILARITY_FUNCTIONS.keys())}"
+        },
+    )
+
     # Debug configuration
     debug_visualize_queue_size: bool = field(
         default=False, metadata={"help": "Visualize the action queue size"}
@@ -200,4 +242,5 @@ class RobotClientConfig:
             "task": self.task,
             "debug_visualize_queue_size": self.debug_visualize_queue_size,
             "aggregate_fn_name": self.aggregate_fn_name,
+            "similarity_fn_name": self.similarity_fn_name,
         }

--- a/src/lerobot/async_inference/configs.py
+++ b/src/lerobot/async_inference/configs.py
@@ -222,6 +222,8 @@ class RobotClientConfig:
             raise ValueError(f"actions_per_chunk must be positive, got {self.actions_per_chunk}")
 
         self.aggregate_fn = get_aggregate_function(self.aggregate_fn_name)
+        # Validate similarity_fn_name early (will raise ValueError if invalid)
+        get_similarity_function(self.similarity_fn_name)
 
     @classmethod
     def from_dict(cls, config_dict: dict) -> "RobotClientConfig":

--- a/src/lerobot/async_inference/constants.py
+++ b/src/lerobot/async_inference/constants.py
@@ -23,7 +23,21 @@ DEFAULT_INFERENCE_LATENCY = 1 / DEFAULT_FPS
 DEFAULT_OBS_QUEUE_TIMEOUT = 2
 
 # All action chunking policies
-SUPPORTED_POLICIES = ["act", "smolvla", "diffusion", "tdmpc", "vqbet", "pi0", "pi05", "groot"]
+SUPPORTED_POLICIES = [
+    "act",
+    "smolvla",
+    "diffusion",
+    "tdmpc",
+    "vqbet",
+    "pi0",
+    "pi05",
+    "groot",
+]
 
 # TODO: Add all other robots
-SUPPORTED_ROBOTS = ["so100_follower", "so101_follower", "bi_so_follower", "omx_follower"]
+SUPPORTED_ROBOTS = [
+    "so100_follower",
+    "so101_follower",
+    "bi_so_follower",
+    "omx_follower",
+]

--- a/src/lerobot/async_inference/helpers.py
+++ b/src/lerobot/async_inference/helpers.py
@@ -301,8 +301,10 @@ def observations_similar(
     """
     # Default to euclidean distance for backward compatibility
     if similarity_fn is None:
-        similarity_fn = lambda s1, s2, tol: torch.linalg.norm(s1 - s2) < tol
-    
+
+        def similarity_fn(s1, s2, tol):
+            return torch.linalg.norm(s1 - s2) < tol
+
     obs1_state = extract_state_from_raw_observation(
         make_lerobot_observation(obs1.get_observation(), lerobot_features)
     )

--- a/src/lerobot/async_inference/helpers.py
+++ b/src/lerobot/async_inference/helpers.py
@@ -271,15 +271,25 @@ class RemotePolicyConfig:
     actions_per_chunk: int
     device: str = "cpu"
     rename_map: dict[str, str] = field(default_factory=dict)
+    similarity_fn_name: str = "euclidean"
 
 
-def _compare_observation_states(obs1_state: torch.Tensor, obs2_state: torch.Tensor, atol: float) -> bool:
+def _compare_observation_states(
+    obs1_state: torch.Tensor,
+    obs2_state: torch.Tensor,
+    atol: float,
+    similarity_fn: callable,
+) -> bool:
     """Check if two observation states are similar, under a tolerance threshold"""
-    return bool(torch.linalg.norm(obs1_state - obs2_state) < atol)
+    return bool(similarity_fn(obs1_state, obs2_state, atol))
 
 
 def observations_similar(
-    obs1: TimedObservation, obs2: TimedObservation, lerobot_features: dict[str, dict], atol: float = 1
+    obs1: TimedObservation,
+    obs2: TimedObservation,
+    lerobot_features: dict[str, dict],
+    similarity_fn,
+    atol: float = 1,
 ) -> bool:
     """Check if two observations are similar, under a tolerance threshold. Measures distance between
     observations as the difference in joint-space between the two observations.
@@ -294,5 +304,4 @@ def observations_similar(
     obs2_state = extract_state_from_raw_observation(
         make_lerobot_observation(obs2.get_observation(), lerobot_features)
     )
-
-    return _compare_observation_states(obs1_state, obs2_state, atol=atol)
+    return _compare_observation_states(obs1_state, obs2_state, atol=atol, similarity_fn=similarity_fn)

--- a/src/lerobot/async_inference/helpers.py
+++ b/src/lerobot/async_inference/helpers.py
@@ -16,6 +16,7 @@ import logging
 import logging.handlers
 import os
 import time
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -278,7 +279,7 @@ def _compare_observation_states(
     obs1_state: torch.Tensor,
     obs2_state: torch.Tensor,
     atol: float,
-    similarity_fn: callable,
+    similarity_fn: Callable[[torch.Tensor, torch.Tensor, float], bool],
 ) -> bool:
     """Check if two observation states are similar, under a tolerance threshold"""
     return bool(similarity_fn(obs1_state, obs2_state, atol))
@@ -288,7 +289,7 @@ def observations_similar(
     obs1: TimedObservation,
     obs2: TimedObservation,
     lerobot_features: dict[str, dict],
-    similarity_fn,
+    similarity_fn=None,
     atol: float = 1,
 ) -> bool:
     """Check if two observations are similar, under a tolerance threshold. Measures distance between
@@ -298,6 +299,10 @@ def observations_similar(
     An immediate next step is to use (fast) perceptual difference metrics comparing some camera views,
     to surpass this joint-space similarity check.
     """
+    # Default to euclidean distance for backward compatibility
+    if similarity_fn is None:
+        similarity_fn = lambda s1, s2, tol: torch.linalg.norm(s1 - s2) < tol
+    
     obs1_state = extract_state_from_raw_observation(
         make_lerobot_observation(obs1.get_observation(), lerobot_features)
     )

--- a/src/lerobot/async_inference/policy_server.py
+++ b/src/lerobot/async_inference/policy_server.py
@@ -31,7 +31,6 @@ import time
 from concurrent import futures
 from dataclasses import asdict
 from pprint import pformat
-from queue import Empty, Queue
 from typing import Any
 
 import draccus
@@ -47,7 +46,7 @@ from lerobot.transport import (
 from lerobot.transport.utils import receive_bytes_in_chunks
 from lerobot.types import PolicyAction
 
-from .configs import PolicyServerConfig
+from .configs import PolicyServerConfig, get_similarity_function
 from .constants import SUPPORTED_POLICIES
 from .helpers import (
     FPSTracker,
@@ -72,10 +71,15 @@ class PolicyServer(services_pb2_grpc.AsyncInferenceServicer):
         # FPS measurement
         self.fps_tracker = FPSTracker(target_fps=config.fps)
 
-        self.observation_queue = Queue(maxsize=1)
-
         self._predicted_timesteps_lock = threading.Lock()
         self._predicted_timesteps = set()
+
+        # Single lock guards both _pending_obs and _inference_in_progress so that
+        # "check flag + store obs" and "grab obs + set flag" are each atomic.
+        self._state_lock = threading.Lock()
+        self._pending_obs: TimedObservation | None = None
+        self._inference_in_progress = False
+        self._obs_available = threading.Event()
 
         self.last_processed_obs = None
 
@@ -98,12 +102,15 @@ class PolicyServer(services_pb2_grpc.AsyncInferenceServicer):
 
     def _reset_server(self) -> None:
         """Flushes server state when new client connects."""
-        # only running inference on the latest observation received by the server
         self.shutdown_event.set()
-        self.observation_queue = Queue(maxsize=1)
 
         with self._predicted_timesteps_lock:
             self._predicted_timesteps = set()
+
+        with self._state_lock:
+            self._pending_obs = None
+            self._inference_in_progress = False
+            self._obs_available.clear()
 
     def Ready(self, request, context):  # noqa: N802
         client_id = context.peer()
@@ -145,6 +152,9 @@ class PolicyServer(services_pb2_grpc.AsyncInferenceServicer):
         self.policy_type = policy_specs.policy_type  # act, pi0, etc.
         self.lerobot_features = policy_specs.lerobot_features
         self.actions_per_chunk = policy_specs.actions_per_chunk
+        # Update server config with similarity function from client
+        self.config.similarity_fn_name = policy_specs.similarity_fn_name
+        self.config.similarity_fn = get_similarity_function(policy_specs.similarity_fn_name)
 
         policy_class = get_policy_class(self.policy_type)
 
@@ -217,13 +227,30 @@ class PolicyServer(services_pb2_grpc.AsyncInferenceServicer):
         client_id = context.peer()
         self.logger.debug(f"Client {client_id} connected for action streaming")
 
-        # Generate action based on the most recent observation and its timestep
+        # Clear the inference flag at the START of each call. This means the client
+        # has called GetActions again — implying it received the previous actions.
+        # The flag stays True between inference completion and this next call,
+        # preventing observations from being enqueued while actions are in transit.
+        with self._state_lock:
+            self._inference_in_progress = False
+
+        # Wait for an observation to become available
+        if not self._obs_available.wait(timeout=self.config.obs_queue_timeout):
+            return services_pb2.Empty()
+
+        # Atomically grab the pending observation and mark inference in progress
+        with self._state_lock:
+            obs = self._pending_obs
+            if obs is None:
+                return services_pb2.Empty()
+            self._pending_obs = None
+            self._obs_available.clear()
+            self._inference_in_progress = True
+
+        self.logger.info(f"Running inference for observation #{obs.get_timestep()} (must_go: {obs.must_go})")
+
         try:
             getactions_starts = time.perf_counter()
-            obs = self.observation_queue.get(timeout=self.config.obs_queue_timeout)
-            self.logger.info(
-                f"Running inference for observation #{obs.get_timestep()} (must_go: {obs.must_go})"
-            )
 
             with self._predicted_timesteps_lock:
                 self._predicted_timesteps.add(obs.get_timestep())
@@ -236,7 +263,6 @@ class PolicyServer(services_pb2_grpc.AsyncInferenceServicer):
             actions_bytes = pickle.dumps(action_chunk)  # nosec
             serialize_time = time.perf_counter() - start_time
 
-            # Create and return the action chunk
             actions = services_pb2.Actions(data=actions_bytes)
 
             self.logger.info(
@@ -252,17 +278,21 @@ class PolicyServer(services_pb2_grpc.AsyncInferenceServicer):
             )
 
             time.sleep(
-                max(0, self.config.inference_latency - max(0, time.perf_counter() - getactions_starts))
+                max(
+                    0,
+                    self.config.inference_latency - max(0, time.perf_counter() - getactions_starts),
+                )
             )  # sleep controls inference latency
 
+            # NOTE: _inference_in_progress intentionally stays True here.
+            # It will be cleared when the client calls GetActions again,
+            # confirming it received these actions.
             return actions
 
-        except Empty:  # no observation added to queue in obs_queue_timeout
-            return services_pb2.Empty()
-
         except Exception as e:
-            self.logger.error(f"Error in StreamActions: {e}")
-
+            self.logger.error(f"Error in GetActions: {e}")
+            with self._state_lock:
+                self._inference_in_progress = False
             return services_pb2.Empty()
 
     def _obs_sanity_checks(self, obs: TimedObservation, previous_obs: TimedObservation) -> bool:
@@ -274,40 +304,51 @@ class PolicyServer(services_pb2_grpc.AsyncInferenceServicer):
             self.logger.debug(f"Skipping observation #{obs.get_timestep()} - Timestep predicted already!")
             return False
 
-        elif observations_similar(obs, previous_obs, lerobot_features=self.lerobot_features):
+        if observations_similar(
+            obs,
+            previous_obs,
+            lerobot_features=self.lerobot_features,
+            similarity_fn=self.config.similarity_fn,
+        ):
             self.logger.debug(
                 f"Skipping observation #{obs.get_timestep()} - Observation too similar to last obs predicted!"
             )
             return False
 
-        else:
-            return True
+        return True
 
     def _enqueue_observation(self, obs: TimedObservation) -> bool:
-        """Enqueue an observation if it must go through processing, otherwise skip it.
-        Observations not in queue are never run through the policy network"""
+        """Enqueue an observation if it should go through processing, otherwise skip it.
+        Observations not stored are never run through the policy network.
 
-        if (
+        The _state_lock ensures that checking _inference_in_progress and storing
+        _pending_obs is atomic — closing the race with GetActions."""
+
+        should_enqueue = (
             obs.must_go
             or self.last_processed_obs is None
             or self._obs_sanity_checks(obs, self.last_processed_obs)
-        ):
+        )
+
+        if not should_enqueue:
+            return False
+
+        with self._state_lock:
+            if self._inference_in_progress:
+                self.logger.debug(
+                    f"Skipping observation #{obs.get_timestep()} (must_go={obs.must_go}) - "
+                    "Inference already in progress!"
+                )
+                return False
+
             last_obs = self.last_processed_obs.get_timestep() if self.last_processed_obs else "None"
             self.logger.debug(
                 f"Enqueuing observation. Must go: {obs.must_go} | Last processed obs: {last_obs}"
             )
 
-            # If queue is full, get the old observation to make room
-            if self.observation_queue.full():
-                # pops from queue
-                _ = self.observation_queue.get_nowait()
-                self.logger.debug("Observation queue was full, removed oldest observation")
-
-            # Now put the new observation (never blocks as queue is non-full here)
-            self.observation_queue.put(obs)
+            self._pending_obs = obs
+            self._obs_available.set()
             return True
-
-        return False
 
     def _time_action_chunk(self, t_0: float, action_chunk: list[torch.Tensor], i_0: int) -> list[TimedAction]:
         """Turn a chunk of actions into a list of TimedAction instances,
@@ -315,7 +356,11 @@ class PolicyServer(services_pb2_grpc.AsyncInferenceServicer):
         t_0 + i*environment_dt for i in range(len(action_chunk))
         """
         return [
-            TimedAction(timestamp=t_0 + i * self.config.environment_dt, timestep=i_0 + i, action=action)
+            TimedAction(
+                timestamp=t_0 + i * self.config.environment_dt,
+                timestep=i_0 + i,
+                action=action,
+            )
             for i, action in enumerate(action_chunk)
         ]
 
@@ -383,7 +428,9 @@ class PolicyServer(services_pb2_grpc.AsyncInferenceServicer):
 
         """5. Convert to TimedAction list"""
         action_chunk = self._time_action_chunk(
-            observation_t.get_timestamp(), list(action_tensor), observation_t.get_timestep()
+            observation_t.get_timestamp(),
+            list(action_tensor),
+            observation_t.get_timestep(),
         )
         postprocess_stops = time.perf_counter()
         postprocessing_time = postprocess_stops - start_postprocess
@@ -417,7 +464,9 @@ def serve(cfg: PolicyServerConfig):
     Args:
         config: PolicyServerConfig instance. If None, uses default configuration.
     """
-    logging.info(pformat(asdict(cfg)))
+    config_dict = asdict(cfg)
+    config_dict.pop("similarity_fn_name", None)
+    logging.info(pformat(config_dict))
 
     # Create the server instance first
     policy_server = PolicyServer(cfg)

--- a/src/lerobot/async_inference/policy_server.py
+++ b/src/lerobot/async_inference/policy_server.py
@@ -85,6 +85,7 @@ class PolicyServer(services_pb2_grpc.AsyncInferenceServicer):
 
         # Attributes will be set by SendPolicyInstructions
         self._pretrained_name_or_path = None
+        self._rename_map = {}
         self.device = None
         self.policy_type = None
         self.lerobot_features = None
@@ -119,6 +120,7 @@ class PolicyServer(services_pb2_grpc.AsyncInferenceServicer):
             self._obs_available.clear()
 
         self.last_processed_obs = None
+        self.fps_tracker.reset()
 
         # Reset policy internal state (action queues, ensemblers) if loaded
         if self.policy is not None:
@@ -140,7 +142,8 @@ class PolicyServer(services_pb2_grpc.AsyncInferenceServicer):
             self.policy = None
             self.preprocessor = None
             self.postprocessor = None
-            torch.cuda.empty_cache()
+            if torch.cuda.is_available() and str(self.device).startswith("cuda"):
+                torch.cuda.empty_cache()
 
     def _same_policy_requested(self, policy_specs: RemotePolicyConfig) -> bool:
         """Check if the incoming policy specs match the currently loaded policy."""
@@ -150,6 +153,7 @@ class PolicyServer(services_pb2_grpc.AsyncInferenceServicer):
             self.policy_type == policy_specs.policy_type
             and self._pretrained_name_or_path == policy_specs.pretrained_name_or_path
             and self.device == policy_specs.device
+            and self._rename_map == policy_specs.rename_map
         )
 
     def Ready(self, request, context):  # noqa: N802
@@ -209,6 +213,7 @@ class PolicyServer(services_pb2_grpc.AsyncInferenceServicer):
         self.device = policy_specs.device
         self.policy_type = policy_specs.policy_type  # act, pi0, etc.
         self._pretrained_name_or_path = policy_specs.pretrained_name_or_path
+        self._rename_map = policy_specs.rename_map
         self.lerobot_features = policy_specs.lerobot_features
         self.actions_per_chunk = policy_specs.actions_per_chunk
 

--- a/src/lerobot/async_inference/policy_server.py
+++ b/src/lerobot/async_inference/policy_server.py
@@ -334,7 +334,7 @@ class PolicyServer(services_pb2_grpc.AsyncInferenceServicer):
             return False
 
         with self._state_lock:
-            if self._inference_in_progress:
+            if self._inference_in_progress and not obs.must_go:
                 self.logger.debug(
                     f"Skipping observation #{obs.get_timestep()} (must_go={obs.must_go}) - "
                     "Inference already in progress!"

--- a/src/lerobot/async_inference/policy_server.py
+++ b/src/lerobot/async_inference/policy_server.py
@@ -84,6 +84,7 @@ class PolicyServer(services_pb2_grpc.AsyncInferenceServicer):
         self.last_processed_obs = None
 
         # Attributes will be set by SendPolicyInstructions
+        self._pretrained_name_or_path = None
         self.device = None
         self.policy_type = None
         self.lerobot_features = None
@@ -101,7 +102,12 @@ class PolicyServer(services_pb2_grpc.AsyncInferenceServicer):
         return self.policy.config.image_features
 
     def _reset_server(self) -> None:
-        """Flushes server state when new client connects."""
+        """Flushes server state when new client connects.
+
+        Resets inference state (pending observations, predicted timesteps) but
+        keeps the model in memory. The model is only offloaded if a different
+        policy is requested via SendPolicyInstructions.
+        """
         self.shutdown_event.set()
 
         with self._predicted_timesteps_lock:
@@ -111,6 +117,40 @@ class PolicyServer(services_pb2_grpc.AsyncInferenceServicer):
             self._pending_obs = None
             self._inference_in_progress = False
             self._obs_available.clear()
+
+        self.last_processed_obs = None
+
+        # Reset policy internal state (action queues, ensemblers) if loaded
+        if self.policy is not None:
+            self.policy.reset()
+            self.logger.info(
+                f"Model kept in memory ({self._pretrained_name_or_path}). "
+                "Policy state reset; ready for reuse."
+            )
+        else:
+            self.logger.info("No model loaded. Waiting for SendPolicyInstructions.")
+
+    def _offload_policy(self) -> None:
+        """Free the current policy and processors from memory."""
+        if self.policy is not None:
+            self.logger.info(
+                f"Offloading model ({self._pretrained_name_or_path}) from {self.device}. Freeing memory."
+            )
+            del self.policy
+            self.policy = None
+            self.preprocessor = None
+            self.postprocessor = None
+            torch.cuda.empty_cache()
+
+    def _same_policy_requested(self, policy_specs: RemotePolicyConfig) -> bool:
+        """Check if the incoming policy specs match the currently loaded policy."""
+        if self.policy is None:
+            return False
+        return (
+            self.policy_type == policy_specs.policy_type
+            and self._pretrained_name_or_path == policy_specs.pretrained_name_or_path
+            and self.device == policy_specs.device
+        )
 
     def Ready(self, request, context):  # noqa: N802
         client_id = context.peer()
@@ -148,15 +188,29 @@ class PolicyServer(services_pb2_grpc.AsyncInferenceServicer):
             f"Device: {policy_specs.device}"
         )
 
-        self.device = policy_specs.device
-        self.policy_type = policy_specs.policy_type  # act, pi0, etc.
-        self.lerobot_features = policy_specs.lerobot_features
-        self.actions_per_chunk = policy_specs.actions_per_chunk
         # Update server config with similarity function from client
         # Use getattr with default for backward compatibility with older clients
         similarity_fn_name = getattr(policy_specs, "similarity_fn_name", "euclidean")
         self.config.similarity_fn_name = similarity_fn_name
         self.config.similarity_fn = get_similarity_function(similarity_fn_name)
+
+        # If the same policy is requested, reuse the loaded model
+        if self._same_policy_requested(policy_specs):
+            self.logger.info(
+                f"Same policy requested ({policy_specs.pretrained_name_or_path}), reusing loaded model."
+            )
+            self.lerobot_features = policy_specs.lerobot_features
+            self.actions_per_chunk = policy_specs.actions_per_chunk
+            return services_pb2.Empty()
+
+        # Different policy requested — offload old model and load new one
+        self._offload_policy()
+
+        self.device = policy_specs.device
+        self.policy_type = policy_specs.policy_type  # act, pi0, etc.
+        self._pretrained_name_or_path = policy_specs.pretrained_name_or_path
+        self.lerobot_features = policy_specs.lerobot_features
+        self.actions_per_chunk = policy_specs.actions_per_chunk
 
         policy_class = get_policy_class(self.policy_type)
 

--- a/src/lerobot/async_inference/policy_server.py
+++ b/src/lerobot/async_inference/policy_server.py
@@ -153,8 +153,10 @@ class PolicyServer(services_pb2_grpc.AsyncInferenceServicer):
         self.lerobot_features = policy_specs.lerobot_features
         self.actions_per_chunk = policy_specs.actions_per_chunk
         # Update server config with similarity function from client
-        self.config.similarity_fn_name = policy_specs.similarity_fn_name
-        self.config.similarity_fn = get_similarity_function(policy_specs.similarity_fn_name)
+        # Use getattr with default for backward compatibility with older clients
+        similarity_fn_name = getattr(policy_specs, "similarity_fn_name", "euclidean")
+        self.config.similarity_fn_name = similarity_fn_name
+        self.config.similarity_fn = get_similarity_function(similarity_fn_name)
 
         policy_class = get_policy_class(self.policy_type)
 

--- a/src/lerobot/async_inference/robot_client.py
+++ b/src/lerobot/async_inference/robot_client.py
@@ -106,6 +106,7 @@ class RobotClient:
             lerobot_features,
             config.actions_per_chunk,
             config.policy_device,
+            similarity_fn_name=config.similarity_fn_name,
         )
         self.channel = grpc.insecure_channel(
             self.server_address, grpc_channel_options(initial_backoff=f"{config.environment_dt:.4f}s")

--- a/src/lerobot/async_inference/robot_client.py
+++ b/src/lerobot/async_inference/robot_client.py
@@ -137,6 +137,13 @@ class RobotClient:
         self.must_go = threading.Event()
         self.must_go.set()  # Initially set - observations qualify for direct processing
 
+        # In-flight observation gate: set when an obs has been sent to the server
+        # and not yet acknowledged by a returning GetActions call (chunk or Empty).
+        # Prevents the control loop from emitting a second obs while the server is
+        # still processing the previous one — closes the double-refill race that
+        # used to be masked by the similarity check when similarity is "disabled".
+        self._obs_in_flight = threading.Event()
+
     @property
     def running(self):
         return not self.shutdown_event.is_set()
@@ -278,6 +285,10 @@ class RobotClient:
                 # Use StreamActions to get a stream of actions from the server
                 actions_chunk = self.stub.GetActions(services_pb2.Empty())
                 if len(actions_chunk.data) == 0:
+                    # Server returned Empty (timeout / sanity-check rejection).
+                    # No queue update will happen, so release the in-flight
+                    # gate immediately to avoid deadlocking the control loop.
+                    self._obs_in_flight.clear()
                     continue  # received `Empty` from server, wait for next call
 
                 receive_time = time.time()
@@ -337,6 +348,13 @@ class RobotClient:
 
                 self.must_go.set()  # after receiving actions, next empty queue triggers must-go processing!
 
+                # Release the in-flight gate ONLY now — after the queue has
+                # been refilled. Releasing earlier (e.g. right after GetActions
+                # returned) leaves a window where the control loop sees a
+                # cleared gate but the still-draining old qsize, and fires a
+                # spurious second obs → the tight-V double refill pattern.
+                self._obs_in_flight.clear()
+
                 if verbose:
                     # Get queue state after changes
                     new_size, new_timesteps = self._inspect_action_queue()
@@ -358,6 +376,8 @@ class RobotClient:
 
             except grpc.RpcError as e:
                 self.logger.error(f"Error receiving actions: {e}")
+                # Don't leave the in-flight gate stuck if the RPC itself errored.
+                self._obs_in_flight.clear()
 
     def actions_available(self):
         """Check if there are actions available in the queue"""
@@ -402,7 +422,18 @@ class RobotClient:
         return _performed_action
 
     def _ready_to_send_observation(self):
-        """Flags when the client is ready to send an observation"""
+        """Flags when the client is ready to send an observation.
+
+        Gated on two conditions:
+        1. The action queue is at or below the configured chunk-size threshold.
+        2. No observation is currently in flight to the server. This prevents
+           the control loop from queueing a second inference on top of an
+           in-progress one — the race that produces the "double refill"
+           pattern (especially visible with similarity_fn="disabled", since
+           the server's similarity gate no longer absorbs it).
+        """
+        if self._obs_in_flight.is_set():
+            return False
         with self.action_queue_lock:
             return self.action_queue.qsize() / self.action_chunk_size <= self._chunk_size_threshold
 
@@ -430,7 +461,14 @@ class RobotClient:
                 observation.must_go = self.must_go.is_set() and self.action_queue.empty()
                 current_queue_size = self.action_queue.qsize()
 
-            _ = self.send_observation(observation)
+            # Mark obs as in-flight BEFORE sending so the control loop on the
+            # next tick cannot race ahead and queue a second obs.
+            # The flag is cleared in `receive_actions` once the corresponding
+            # GetActions call returns (chunk or Empty), or here on send failure.
+            self._obs_in_flight.set()
+            send_ok = self.send_observation(observation)
+            if not send_ok:
+                self._obs_in_flight.clear()
 
             self.logger.debug(f"QUEUE SIZE: {current_queue_size} (Must go: {observation.must_go})")
             if observation.must_go:

--- a/tests/async_inference/test_helpers.py
+++ b/tests/async_inference/test_helpers.py
@@ -23,6 +23,7 @@ pytest.importorskip("grpc")
 import numpy as np  # noqa: E402
 import torch  # noqa: E402
 
+from lerobot.async_inference.configs import get_similarity_function  # noqa: E402
 from lerobot.async_inference.helpers import (  # noqa: E402
     FPSTracker,
     TimedAction,
@@ -188,8 +189,8 @@ def _make_obs(state: torch.Tensor) -> TimedObservation:
     )
 
 
-def test_observations_similar_true():
-    """Distance below atol → observations considered similar."""
+def test_observations_similar_euclidean():
+    """Distance below atol → observations considered similar with euclidean distance."""
     # Create mock lerobot features for the similarity check
     lerobot_features = {
         OBS_STATE: {
@@ -199,12 +200,58 @@ def test_observations_similar_true():
         }
     }
 
+    euclidean_fn = get_similarity_function("euclidean")
+
     obs1 = _make_obs(torch.zeros(4))
     obs2 = _make_obs(0.5 * torch.ones(4))
-    assert observations_similar(obs1, obs2, lerobot_features, atol=2.0)
+    assert observations_similar(obs1, obs2, lerobot_features, similarity_fn=euclidean_fn, atol=2.0)
 
     obs3 = _make_obs(2.0 * torch.ones(4))
-    assert not observations_similar(obs1, obs3, lerobot_features, atol=2.0)
+    assert not observations_similar(obs1, obs3, lerobot_features, similarity_fn=euclidean_fn, atol=2.0)
+
+
+def test_observations_similar_deactivate():
+    """With disabled, observations should never be similar."""
+    lerobot_features = {
+        OBS_STATE: {
+            "dtype": "float32",
+            "shape": [4],
+            "names": ["shoulder", "elbow", "wrist", "gripper"],
+        }
+    }
+
+    deactivate_fn = get_similarity_function("disabled")
+
+    # Even identical observations should not be considered similar
+    obs1 = _make_obs(torch.zeros(4))
+    obs2 = _make_obs(torch.zeros(4))
+    assert not observations_similar(obs1, obs2, lerobot_features, similarity_fn=deactivate_fn, atol=0.0)
+
+    # Very close observations also not similar
+    obs3 = _make_obs(0.001 * torch.ones(4))
+    assert not observations_similar(obs1, obs3, lerobot_features, similarity_fn=deactivate_fn, atol=2.0)
+
+
+def test_get_similarity_function():
+    """Test that get_similarity_function returns correct functions."""
+    euclidean_fn = get_similarity_function("euclidean")
+    deactivate_fn = get_similarity_function("disabled")
+
+    # Test euclidean function
+    s1 = torch.tensor([0.0, 0.0, 0.0])
+    s2 = torch.tensor([1.0, 0.0, 0.0])
+    assert euclidean_fn(s1, s2, 2.0)  # Distance = 1.0 < 2.0
+    assert not euclidean_fn(s1, s2, 0.5)  # Distance = 1.0 > 0.5
+
+    # Test deactivate function - should always return False
+    assert not deactivate_fn(s1, s2, 10.0)
+    assert not deactivate_fn(s1, s1, 0.0)  # Even identical states
+
+
+def test_get_similarity_function_invalid():
+    """Test that get_similarity_function raises error for invalid names."""
+    with pytest.raises(ValueError, match="Unknown similarity function"):
+        get_similarity_function("nonexistent_function")
 
 
 # ---------------------------------------------------------------------

--- a/tests/async_inference/test_policy_server.py
+++ b/tests/async_inference/test_policy_server.py
@@ -249,3 +249,24 @@ def test_inference_in_progress_prevents_duplicate_enqueue(policy_server):
     obs3 = _make_obs(torch.ones(6) * 7, timestep=3)
     assert policy_server._enqueue_observation(obs3) is True
     assert policy_server._pending_obs is obs3
+
+
+def test_must_go_bypasses_inference_in_progress(policy_server):
+    """must_go=True observations must bypass _inference_in_progress to prevent action-queue starvation.
+
+    Regression test: when inference is in progress and the client action queue
+    empties, the client sends must_go=True. That observation must NOT be dropped
+    even if _inference_in_progress is still True (it gets cleared at the start
+    of the next GetActions call, which may race with SendObservations).
+    """
+    policy_server.last_processed_obs = _make_obs(torch.zeros(6), timestep=0)
+
+    # Simulate inference in progress (e.g. actions are in transit to the client)
+    with policy_server._state_lock:
+        policy_server._inference_in_progress = True
+
+    # A must_go observation MUST be stored regardless of inference state
+    must_go_obs = _make_obs(torch.ones(6) * 5, timestep=1, must_go=True)
+    assert policy_server._enqueue_observation(must_go_obs) is True
+    assert policy_server._pending_obs is must_go_obs
+    assert policy_server._obs_available.is_set()

--- a/tests/async_inference/test_policy_server.py
+++ b/tests/async_inference/test_policy_server.py
@@ -144,8 +144,8 @@ def test_maybe_enqueue_observation_must_go(policy_server):
     """An observation with `must_go=True` is always enqueued."""
     obs = _make_obs(torch.zeros(6), must_go=True)
     assert policy_server._enqueue_observation(obs) is True
-    assert policy_server.observation_queue.qsize() == 1
-    assert policy_server.observation_queue.get_nowait() is obs
+    assert policy_server._pending_obs is obs
+    assert policy_server._obs_available.is_set()
 
 
 def test_maybe_enqueue_observation_dissimilar(policy_server):
@@ -156,7 +156,7 @@ def test_maybe_enqueue_observation_dissimilar(policy_server):
     new_obs = _make_obs(torch.ones(6) * 5)  # High norm difference
 
     assert policy_server._enqueue_observation(new_obs) is True
-    assert policy_server.observation_queue.qsize() == 1
+    assert policy_server._pending_obs is new_obs
 
 
 def test_maybe_enqueue_observation_is_skipped(policy_server):
@@ -167,7 +167,7 @@ def test_maybe_enqueue_observation_is_skipped(policy_server):
     new_obs = _make_obs(torch.zeros(6) + 1e-4)
 
     assert policy_server._enqueue_observation(new_obs) is False
-    assert policy_server.observation_queue.empty() is True
+    assert policy_server._pending_obs is None
 
 
 def test_obs_sanity_checks(policy_server):
@@ -217,3 +217,35 @@ def test_predict_action_chunk(monkeypatch, policy_server):
     for i, ta in enumerate(timed_actions):
         expected_ts = obs.get_timestamp() + i * policy_server.config.environment_dt
         assert abs(ta.get_timestamp() - expected_ts) < 1e-6
+
+
+def test_inference_in_progress_prevents_duplicate_enqueue(policy_server):
+    """Test that inference_in_progress flag prevents multiple observations from being enqueued."""
+    # Set a last processed observation.
+    policy_server.last_processed_obs = _make_obs(torch.zeros(6), timestep=0)
+
+    # First observation - very different from last, should be enqueued
+    obs1 = _make_obs(torch.ones(6) * 5, timestep=1)
+    assert policy_server._enqueue_observation(obs1) is True
+    assert policy_server._pending_obs is obs1
+
+    # Simulate inference in progress
+    with policy_server._state_lock:
+        policy_server._inference_in_progress = True
+
+    # Second observation arrives while inference is in progress - should be filtered
+    obs2 = _make_obs(torch.ones(6) * 6, timestep=2)
+    assert policy_server._enqueue_observation(obs2) is False
+    # Pending obs should still be the first one
+    assert policy_server._pending_obs is obs1
+
+    # Clear inference flag and pending obs to simulate GetActions consuming the observation
+    with policy_server._state_lock:
+        policy_server._inference_in_progress = False
+        policy_server._pending_obs = None
+        policy_server._obs_available.clear()
+
+    # Now third observation should be enqueued
+    obs3 = _make_obs(torch.ones(6) * 7, timestep=3)
+    assert policy_server._enqueue_observation(obs3) is True
+    assert policy_server._pending_obs is obs3


### PR DESCRIPTION
## Title

feat(async_inference): add configurable similarity function for observation filtering

## Summary / Motivation

On high-DOF real-robot deployments (30+ joints), the async inference server's hardcoded Euclidean distance filter was too aggressive: because joint-space distances across many dimensions sum to a large norm even for small per-joint deltas, incoming observations were almost always flagged as "similar" to the previous one and skipped. In practice this meant inference was only re-triggered once the action queue was fully depleted, causing jerky, reactive behaviour instead of smooth, continuously-updated control.

This PR introduces a `SIMILARITY_FUNCTIONS` registry in `configs.py` and a `--similarity_fn_name` CLI parameter (passed from the robot client to the policy server via `SendPolicyInstructions`). Built-in options are `euclidean` (default, same behaviour as before) and `disabled` (always run inference). Users can add custom functions directly to the registry. As a side-effect, the `Queue(maxsize=1)` observation buffer in `policy_server.py` is replaced with a lock + threading.Event approach that closes a race condition where a new observation could be accepted while the previous inference result was still in transit to the client.

## Related issues
None.

## What changed

- `configs.py`: new `SIMILARITY_FUNCTIONS` dict and `get_similarity_function()` factory; `similarity_fn_name` field added to `PolicyServerConfig` and `RobotClientConfig`; field propagated in `to_server_config_dict()`.
- `helpers.py`: `_compare_observation_states()` and `observations_similar()` now accept a `similarity_fn` callable instead of hardcoding L2 norm; `RemotePolicyConfig` gets `similarity_fn_name` field.
- `policy_server.py`: `Queue(maxsize=1)` replaced with `_state_lock` + `_pending_obs` + `_inference_in_progress` flag + `_obs_available` Event for race-free obs handoff; similarity function is initialised from the `SendPolicyInstructions` payload; `GetActions` atomically grabs the pending obs and sets the in-progress flag; the error path resets the flag.
- `docs/source/async.mdx`: `--similarity_fn_name` documented in both CLI examples and the parameter description list.

## How was this tested (or how to run locally)

- Tests added/updated: `tests/async_inference/test_helpers.py`, `tests/async_inference/test_policy_server.py`
- `pytest -q tests/async_inference/`
- Tests on the real robot.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: #

## Reviewer notes

- The race-condition fix in `policy_server.py` is the most impactful change; please focus there. The `_inference_in_progress` flag is intentionally kept `True` between inference completion and the client's next `GetActions` call, so that stale observations are not buffered while actions are in flight.
- The similarity function selection is entirely backward-compatible: `euclidean` is the default and reproduces the previous behaviour exactly.
