### PR TITLE
fix(peft): fix LoRA resume from Hub (PosixPath + double wrap)

### DIFF
--- a/src/lerobot/policies/factory.py
+++ b/src/lerobot/policies/factory.py
@@ -514,7 +514,7 @@ def make_policy(
 
         logging.info("Loading policy's PEFT adapter.")
 
-        peft_pretrained_path = cfg.pretrained_path
+        peft_pretrained_path = str(cfg.pretrained_path)
         peft_config = PeftConfig.from_pretrained(peft_pretrained_path)
 
         kwargs["pretrained_name_or_path"] = peft_config.base_model_name_or_path

--- a/src/lerobot/policies/factory.py
+++ b/src/lerobot/policies/factory.py
@@ -527,7 +527,9 @@ def make_policy(
             )
 
         policy = policy_cls.from_pretrained(**kwargs)
-        policy = PeftModel.from_pretrained(policy, peft_pretrained_path, config=peft_config)
+        policy = PeftModel.from_pretrained(
+            policy, peft_pretrained_path, config=peft_config, is_trainable=True
+        )
 
     else:
         # Make a fresh policy.

--- a/src/lerobot/scripts/lerobot_train.py
+++ b/src/lerobot/scripts/lerobot_train.py
@@ -277,9 +277,14 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
     if cfg.peft is not None:
         if cfg.is_reward_model_training:
             raise ValueError("PEFT is only supported for policy training. ")
-        logging.info("Using PEFT! Wrapping model.")
-        peft_cli_overrides = dataclasses.asdict(cfg.peft)
-        policy = policy.wrap_with_peft(peft_cli_overrides=peft_cli_overrides)
+        from peft import PeftModel
+
+        if isinstance(policy, PeftModel):
+            logging.info("PEFT adapter already loaded from checkpoint, skipping wrap_with_peft.")
+        else:
+            logging.info("Using PEFT! Wrapping model.")
+            peft_cli_overrides = dataclasses.asdict(cfg.peft)
+            policy = policy.wrap_with_peft(peft_cli_overrides=peft_cli_overrides)
 
     # Wait for all processes to finish model creation before continuing
     accelerator.wait_for_everyone()


### PR DESCRIPTION
## Summary

Fixes two bugs that prevent resuming PEFT LoRA training from a Hub adapter:

- **`PosixPath` type error (#3458):** `PeftConfig.from_pretrained()` in `factory.py` receives a `pathlib.PosixPath` from `cfg.pretrained_path`, but PEFT's `hf_hub_download` requires a `str` repo ID. Fix: wrap with `str()`.

- **Silent weight loss (#3459):** After `make_policy()` correctly loads the trained adapter via `PeftModel.from_pretrained()`, `train()` unconditionally re-wraps the model with `wrap_with_peft()`, creating a fresh randomly-initialized LoRA adapter that overwrites the loaded weights. Training silently restarts from scratch. Fix: skip `wrap_with_peft()` when the policy is already a `PeftModel`.

## Test plan

- [ ] `lerobot-train --policy.path=<hub_lora_adapter> --peft.type=lora` no longer crashes with `HfValidationError`
- [ ] Resumed training starts from the checkpoint loss, not from scratch
- [ ] Fresh PEFT training (no pretrained adapter) still works unchanged

Fixes #3458, fixes #3459.