### PR TITLE
fix(pi0&pi05): keep training sampling outside compiled forwards

### DIFF
--- a/src/lerobot/policies/pi0/modeling_pi0.py
+++ b/src/lerobot/policies/pi0/modeling_pi0.py
@@ -748,16 +748,8 @@ class PI0Pytorch(nn.Module):  # see openpi `PI0Pytorch`
 
         return embs, pad_masks, att_masks, adarms_cond
 
-    def forward(
-        self, images, img_masks, lang_tokens, lang_masks, state, actions, noise=None, time=None
-    ) -> Tensor:
+    def forward(self, images, img_masks, lang_tokens, lang_masks, state, actions, noise, time) -> Tensor:
         """Do a full training forward pass and compute the loss."""
-        if noise is None:
-            noise = self.sample_noise(actions.shape, actions.device)
-
-        if time is None:
-            time = self.sample_time(actions.shape[0], actions.device)
-
         time_expanded = time[:, None, None]
         x_t = time_expanded * noise + (1 - time_expanded) * actions
         u_t = noise - actions
@@ -1292,8 +1284,11 @@ class PI0Policy(PreTrainedPolicy):
         state = self.prepare_state(batch)
         actions = self.prepare_action(batch)
 
+        noise = self.model.sample_noise(actions.shape, actions.device)
+        time = self.model.sample_time(actions.shape[0], actions.device)
+
         # Compute loss
-        losses = self.model.forward(images, img_masks, lang_tokens, lang_masks, state, actions)
+        losses = self.model.forward(images, img_masks, lang_tokens, lang_masks, state, actions, noise, time)
 
         # Truncate losses to actual action dimensions
         original_action_dim = self.config.output_features[ACTION].shape[0]

--- a/src/lerobot/policies/pi05/modeling_pi05.py
+++ b/src/lerobot/policies/pi05/modeling_pi05.py
@@ -728,14 +728,8 @@ class PI05Pytorch(nn.Module):  # see openpi `PI0Pytorch`
 
         return embs, pad_masks, att_masks, adarms_cond
 
-    def forward(self, images, img_masks, tokens, masks, actions, noise=None, time=None) -> Tensor:
+    def forward(self, images, img_masks, tokens, masks, actions, noise, time) -> Tensor:
         """Do a full training forward pass and compute the loss."""
-        if noise is None:
-            noise = self.sample_noise(actions.shape, actions.device)
-
-        if time is None:
-            time = self.sample_time(actions.shape[0], actions.device)
-
         time_expanded = time[:, None, None]
         x_t = time_expanded * noise + (1 - time_expanded) * actions
         u_t = noise - actions
@@ -1262,8 +1256,11 @@ class PI05Policy(PreTrainedPolicy):
 
         actions = self.prepare_action(batch)
 
+        noise = self.model.sample_noise(actions.shape, actions.device)
+        time = self.model.sample_time(actions.shape[0], actions.device)
+
         # Compute loss (no separate state needed for PI05)
-        losses = self.model.forward(images, img_masks, tokens, masks, actions)
+        losses = self.model.forward(images, img_masks, tokens, masks, actions, noise, time)
 
         # Truncate losses to actual action dimensions
         original_action_dim = self.config.output_features[ACTION].shape[0]


### PR DESCRIPTION
## Summary / Motivation

This PR fixes PI0/PI0.5 training with `torch.compile` on MPS while preserving the CUDA fix for [#3108](https://github.com/huggingface/lerobot/issues/3108). The compiled `PI0Pytorch.forward` / `PI05Pytorch.forward` now receive `noise` and `time` as explicit tensor inputs, while the policy wrappers perform stochastic training sampling before calling the compiled `PI0Pytorch.forward` / `PI05Pytorch.forward`. This keeps `torch.distributions.Beta.sample()` out of the compiled forward graph, avoiding the MPS `aten::_sample_dirichlet` Inductor failure without introducing an explicit Dynamo graph break.

## Related issues

- Fixes: https://github.com/huggingface/lerobot/issues/3108
- Related: https://github.com/huggingface/lerobot/pull/3209

## What changed

- `PI0Pytorch.forward` now requires `noise` and `time` tensor arguments.
- `PI0Policy.forward` samples `noise` and `time` before calling the compiled `PI0Pytorch.forward()`.
- `PI05Pytorch.forward` and `PI05Policy.forward` are updated the same way for the PI0.5 training path.
- `sample_beta()` remains unchanged. It still samples on CPU and transfers the result to the training device (cuda / mps), but it is no longer inside the compiled `forward()`.

This only changes the internal `PI0Pytorch` / `PI05Pytorch` training forward API. The public policy-level `PI0Policy.forward(batch, ...)` / `PI05Policy.forward(batch, ...)` API used by training remains unchanged.

## Possible Solutions

There are three possible fixes:

- **PR3209 / In-Graph Sampling**: the approach in #3209, which addresses #3108 on CUDA while keeping the training `sample_time()` path inside the compiled PI0 forward.
- **Disable `sample_beta`**: wrap `sample_beta()` with `@torch.compiler.disable`, sample Beta on CPU in eager mode, and transfer the sampled tensor to the target device.
- **External Sampling (this PR)**: sample `noise` and `time` in the policy wrapper, then pass both tensors into the compiled PI0/PI0.5 core forward.

### Solution 1: PR3209 / In-Graph Sampling

This fixes the CUDA-side issue from #3108, but it still fails on MPS when PI0 training with `torch.compile`:

```bash
Traceback (most recent call last):
  File "/Workspace/lerobot_review/lerobot-pr3209/.venv/bin/lerobot-train", line 12, in <module>
    sys.exit(main())
  File "/Workspace/lerobot_review/lerobot-pr3209/src/lerobot/scripts/lerobot_train.py", line 551, in main
    train()
  File "/Workspace/lerobot_review/lerobot-pr3209/src/lerobot/scripts/lerobot_train.py", line 417, in train
    train_tracker, output_dict = update_policy(...)
  File "/Workspace/lerobot_review/lerobot-pr3209/src/lerobot/scripts/lerobot_train.py", line 117, in update_policy
    loss, output_dict = policy.forward(batch)
  File "/Workspace/lerobot_review/lerobot-pr3209/src/lerobot/policies/pi0/modeling_pi0.py", line 1296, in forward
    losses = self.model.forward(images, img_masks, lang_tokens, lang_masks, state, actions)
  File "/Workspace/lerobot_review/lerobot-pr3209/.venv/lib/python3.13/site-packages/torch/_dynamo/eval_frame.py", line 967, in compile_wrapper
    raise e.remove_dynamo_frames() from None
  File "/Workspace/lerobot_review/lerobot-pr3209/.venv/lib/python3.13/site-packages/torch/_inductor/compile_fx.py", line 1019, in _compile_fx_inner
    raise InductorError(e, currentframe()).with_traceback(e.__traceback__) from None
  File "/Workspace/lerobot_review/lerobot-pr3209/.venv/lib/python3.13/site-packages/torch/_subclasses/fake_tensor.py", line 3170, in run_fallback_kernel
    r = func(*args, **kwargs)
torch._inductor.exc.InductorError: NotImplementedError: The operator 'aten::_sample_dirichlet' is not currently implemented for the MPS device.
```

Training Command:

```bash
uv run lerobot-train \
  --dataset.repo_id=libero_hf \
  --policy.type=pi0 \
  --policy.pretrained_path=lerobot/pi0_base \
  --policy.compile_model=true \
  --policy.compile_mode=default \
  --policy.device=mps \
  --steps=6 \
  --batch_size=1
```
> [!NOTE]
> This is not caused by #3209 itself. The same MPS failure is reproducible from `main` branch at `cb0a9449` when PI0 training with `torch.compile` enabled. The root cause is the compile boundary: even though `sample_beta()` creates `alpha_t` and `beta_t` on CPU and moves the sampled result to MPS afterwards, Dynamo/Inductor traces the `Beta.sample()` call as part of the compiled forward. During Inductor compilation, that distribution sample appears as `aten::_sample_dirichlet` in the graph, and the MPS backend does not implement that operator.

### Solution 2: Disable `sample_beta`

Using `@torch.compiler.disable` keep the sampling call inside `PI0Pytorch.forward`, but force `sample_beta()` to run outside Dynamo:

```python
@torch.compiler.disable
def sample_beta(alpha, beta, bsize, device):
    alpha_t = torch.tensor(alpha, dtype=torch.float32, device="cpu")
    beta_t = torch.tensor(beta, dtype=torch.float32, device="cpu")
    dist = torch.distributions.Beta(alpha_t, beta_t)
    return dist.sample((bsize,)).to(device)
```

This also fixes #3108 on CUDA and lets MPS PI0 training run with the same command shown above. A local MPS run completed 6 training steps:

```bash
INFO 2026-04-29 22:27:35 ot_train.py:448 Start offline training on a fixed dataset, with effective batch size: 1
INFO 2026-04-29 22:27:48 ot_train.py:483 step:1 smpl:1 ep:0 epch:0.00 loss:0.734 grdn:14.745 lr:2.3e-05 updt_s:12.071 data_s:0.413
INFO 2026-04-29 22:27:51 ot_train.py:483 step:2 smpl:2 ep:0 epch:0.01 loss:0.531 grdn:11.260 lr:1.9e-05 updt_s:2.507 data_s:0.140
INFO 2026-04-29 22:27:53 ot_train.py:483 step:3 smpl:3 ep:0 epch:0.01 loss:0.366 grdn:6.071 lr:1.4e-05 updt_s:2.500 data_s:0.120
INFO 2026-04-29 22:27:56 ot_train.py:483 step:4 smpl:4 ep:0 epch:0.02 loss:0.308 grdn:4.084 lr:8.1e-06 updt_s:2.547 data_s:0.119
INFO 2026-04-29 22:27:58 ot_train.py:483 step:5 smpl:5 ep:0 epch:0.02 loss:1.017 grdn:16.995 lr:4.0e-06 updt_s:2.526 data_s:0.116
INFO 2026-04-29 22:28:01 ot_train.py:483 step:6 smpl:6 ep:0 epch:0.03 loss:0.536 grdn:11.033 lr:2.5e-06 updt_s:2.535 data_s:0.113
INFO 2026-04-29 22:28:01 ot_train.py:571 End of training
```

The drawback is that `@torch.compiler.disable` intentionally creates a Dynamo graph break. It is a valid compatibility fix, but it keeps Python/eager execution inside the training hot path and makes the compiled forward less pure.

### Solution 3: External Sampling (this PR)

This PR moves `sample_time()` and `sample_noise()` outside the compiled `forward()`. Instead, they are called from the outside `PI0Policy.forward` / `PI05Policy.forward`. The core `forward` now can operate on tensor inputs only.

Design reasons:

- Removing `if noise is None` and `if time is None` branches and makes the compiled function closer to a pure tensor function, which is a better `torch.compile` boundary.
- Avoiding the manual graph break by keeping `Beta.sample()` out of the compiled graph.
- Faster compilation. On `NVIDIA A800-SXM4-80GB` run with `steps=8`, `batch_size=4`, and dataset `HuggingFaceVLA/libero`, this was also better for cold-start compilation time:

| Scheme | step1 `fwd_s` | step2 `fwd_s` | Stable `fwd_s` | Stable `updt_s` |
| --- | ---: | ---: | ---: | ---: |
| Disable `sample_beta` | 256.483s | 37.471s | 0.123s | 0.489s |
| External Sampling | 198.420s | 21.783s | 0.118s | 0.479s |

Training command:

```bash
lerobot-train \
    --dataset.repo_id=HuggingFaceVLA/libero \
    --policy.type=pi0 \
    --policy.pretrained_path=lerobot/pi0_base \
    --policy.compile_model=true \
    --policy.compile_mode=reduce-overhead \
    --policy.dtype=bfloat16 \
    --policy.device=cuda \
    --steps=8 \
    --batch_size=4 
```

The PR externalizes both `time` and `noise` for the same compile-boundary reason. `noise` was not the failing MPS op, but passing both stochastic training tensors explicitly keeps the `forward()` API consistent.

## How was this tested (or how to run locally)

Test command:

```bash
python -m pytest -sv -rs \
  tests/policies/pi0_pi05/test_pi0.py \
  tests/policies/pi0_pi05/test_pi05.py
```



<details>
<summary>4 passed in 519.39s (0:08:39)</summary>

```bash
============================= test session starts ==============================
platform linux -- Python 3.12.13, pytest-8.4.2, pluggy-1.6.0 -- /mnt/hwfile/songhaoming/.venvs/lerobot-0.5.2-py312-cu118-apptainer/bin/python
cachedir: .pytest_cache
rootdir: /mnt/petrelfs/songhaoming/workspace/lerobot_review/lerobot
configfile: pyproject.toml
plugins: mock-serial-0.0.1, anyio-4.13.0, timeout-2.4.0, cov-7.1.0, hydra-core-1.3.2, hf-doc-builder-0.6.0.dev0
collecting ... collected 4 items

Testing with DEVICE='cuda'

tests/policies/pi0_pi05/test_pi0.py::test_policy_instantiation WARNING:lerobot.configs.policies:Device 'None' is not available. Switching to 'cuda'.
Forward pass successful. Loss: 1.9557
Action: tensor([[-0.8457, -0.2300, -0.0066,  1.0120, -1.2838,  1.0768,  0.8128]])
Action prediction successful. Action shape: torch.Size([1, 7])
PASSED
tests/policies/pi0_pi05/test_pi0.py::test_config_creation WARNING:lerobot.configs.policies:Device 'None' is not available. Switching to 'cuda'.
Config created successfully through factory
  Config type: PI0Config
  PaliGemma variant: gemma_2b
  Action expert variant: gemma_300m
PASSED
tests/policies/pi0_pi05/test_pi05.py::test_policy_instantiation WARNING:lerobot.configs.policies:Device 'None' is not available. Switching to 'cuda'.
Forward pass successful. Loss: 5.1566
Action: tensor([[-0.3250,  0.1791,  0.7158,  1.0962, -0.0522,  1.6099,  0.4838]])
Action prediction successful. Action shape: torch.Size([1, 7])
PASSED
tests/policies/pi0_pi05/test_pi05.py::test_config_creation WARNING:lerobot.configs.policies:Device 'None' is not available. Switching to 'cuda'.
Config created successfully through factory
  Config type: PI0Config
  PaliGemma variant: gemma_2b
  Action expert variant: gemma_300m
PASSED

======================== 4 passed in 519.39s (0:08:39) =========================
```

</details>

## Checklist (required before merge)

- [x] Linting/formatting run on changed files (`pre-commit run --files ...`)
- [x] Targeted PI0/PI0.5 pytest command run locally (`14 skipped` on MPS because the tests require CUDA)
- [x] Full test suite passes locally (`pytest`)
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: # (insert PR number/link)

## Reviewer notes

The main design point to review is the compile boundary. This PR intentionally keeps stochastic training sampling outside `PI0Pytorch.forward` / `PI05Pytorch.forward`, so the compiled core forwards receive only tensor inputs and no longer trace `torch.distributions.Beta.sample()`.

### MPS environment

- Code: LeRobot `0.5.2`; main-derived commit `cb0a9449`; this PR commit `ee1ecba4`
- OS / hardware: macOS 15.2, Darwin 24.2.0, Apple M4, 24 GiB unified memory
- Accelerator: Apple M4 GPU, 10 GPU cores, Metal 3; `torch.backends.mps.is_available() == True`
- Python / PyTorch: Python 3.13.6, torch 2.10.0
- Key packages: accelerate 1.13.0, transformers 5.3.0, datasets 4.8.4, numpy 2.2.6


### CUDA environment:
- Code: LeRobot `0.5.2`; main-derived test branch commit `cb0a9449`; PR-3209 checkout commit `056de2ae`
- Experiment: `steps=8`, `batch_size=4`, dataset `HuggingFaceVLA/libero`, single GPU
- Container: Apptainer 1.3.2, Debian 12 (bookworm), Python 3.12.13
- GPU: NVIDIA A800-SXM4-80GB node, one 80GB-class GPU used, PyTorch reported approximately 79.32 GiB total memory
- Driver / CUDA: NVIDIA driver 550.90.07, `nvidia-smi` CUDA 12.4, torch CUDA runtime 11.8
- Python / PyTorch: torch 2.7.0+cu118, triton 3.3.0
- Key packages: accelerate 1.13.0, transformers 5.3.0, datasets 4.8.4, numpy 2.2.6


