### PR TITLE
fix(teleop): avoid heavy imports during startup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ dependencies = [
     "einops>=0.8.0,<0.9.0",
 
     # Config & Hub
-    "draccus==0.10.0", # TODO: Relax version constraint
+    "draccus==0.11.5", # TODO: Relax version constraint
     "huggingface-hub>=1.0.0,<2.0.0",
     "requests>=2.32.0,<3.0.0",
 

--- a/src/lerobot/configs/__init__.py
+++ b/src/lerobot/configs/__init__.py
@@ -15,35 +15,39 @@
 """
 Public API for lerobot configuration types and base config classes.
 
-NOTE: TrainPipelineConfig, EvalPipelineConfig, and TrainRLServerPipelineConfig
-are intentionally NOT re-exported here to avoid circular dependencies
-(they import lerobot.envs and lerobot.policies at module level).
-Import them directly: ``from lerobot.configs.train import TrainPipelineConfig``
+The exports are resolved lazily so lightweight scripts can import
+``lerobot.configs.parser`` without also importing training transforms,
+optimizers, diffusers, torch, and torchvision.
 """
 
-from .dataset import DatasetRecordConfig
-from .default import DatasetConfig, EvalConfig, PeftConfig, WandBConfig
-from .policies import PreTrainedConfig
-from .types import (
-    FeatureType,
-    NormalizationMode,
-    PipelineFeatureType,
-    PolicyFeature,
-    RTCAttentionSchedule,
-)
+_SUBMODULE_ATTRS = {
+    ".dataset": ["DatasetRecordConfig"],
+    ".default": ["DatasetConfig", "EvalConfig", "PeftConfig", "WandBConfig"],
+    ".policies": ["PreTrainedConfig"],
+    ".types": [
+        "FeatureType",
+        "NormalizationMode",
+        "PipelineFeatureType",
+        "PolicyFeature",
+        "RTCAttentionSchedule",
+    ],
+}
 
-__all__ = [
-    # Types
-    "FeatureType",
-    "NormalizationMode",
-    "PipelineFeatureType",
-    "PolicyFeature",
-    "RTCAttentionSchedule",
-    # Config classes
-    "DatasetRecordConfig",
-    "DatasetConfig",
-    "EvalConfig",
-    "PeftConfig",
-    "PreTrainedConfig",
-    "WandBConfig",
-]
+_ATTR_TO_MODULE: dict[str, str] = {}
+for _mod, _attrs in _SUBMODULE_ATTRS.items():
+    for _attr in _attrs:
+        _ATTR_TO_MODULE[_attr] = _mod
+
+
+def __getattr__(name: str):
+    if name in _ATTR_TO_MODULE:
+        import importlib
+
+        mod = importlib.import_module(_ATTR_TO_MODULE[name], __name__)
+        val = getattr(mod, name)
+        globals()[name] = val
+        return val
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+__all__ = list(_ATTR_TO_MODULE.keys())

--- a/src/lerobot/motors/motors_bus.py
+++ b/src/lerobot/motors/motors_bus.py
@@ -33,17 +33,12 @@ from typing import TYPE_CHECKING, Protocol
 
 from tqdm import tqdm
 
-from lerobot.utils.import_utils import _deepdiff_available, _serial_available, require_package
+from lerobot.utils.import_utils import _serial_available, require_package
 
 if TYPE_CHECKING or _serial_available:
     import serial
 else:
     serial = None  # type: ignore[assignment]
-
-if TYPE_CHECKING or _deepdiff_available:
-    from deepdiff import DeepDiff
-else:
-    DeepDiff = None  # type: ignore[assignment, misc]
 
 from lerobot.utils.decorators import check_if_already_connected, check_if_not_connected
 from lerobot.utils.utils import enter_pressed, move_cursor_up
@@ -357,7 +352,6 @@ class SerialMotorsBus(MotorsBusBase):
         calibration: dict[str, MotorCalibration] | None = None,
     ):
         require_package("pyserial", extra="pyserial-dep", import_name="serial")
-        require_package("deepdiff", extra="deepdiff-dep")
         super().__init__(port, motors, calibration)
 
         self.port_handler: PortHandler
@@ -390,9 +384,7 @@ class SerialMotorsBus(MotorsBusBase):
             return False
 
         first_table = self.model_ctrl_table[self.models[0]]
-        return any(
-            DeepDiff(first_table, get_ctrl_table(self.model_ctrl_table, model)) for model in self.models[1:]
-        )
+        return any(first_table != get_ctrl_table(self.model_ctrl_table, model) for model in self.models[1:])
 
     @cached_property
     def models(self) -> list[str]:

--- a/src/lerobot/policies/groot/__init__.py
+++ b/src/lerobot/policies/groot/__init__.py
@@ -15,7 +15,20 @@
 # limitations under the License.
 
 from .configuration_groot import GrootConfig
-from .modeling_groot import GrootPolicy
-from .processor_groot import make_groot_pre_post_processors
+
+
+def __getattr__(name):
+    if name == "GrootPolicy":
+        from .modeling_groot import GrootPolicy
+
+        globals()["GrootPolicy"] = GrootPolicy
+        return GrootPolicy
+    if name == "make_groot_pre_post_processors":
+        from .processor_groot import make_groot_pre_post_processors
+
+        globals()["make_groot_pre_post_processors"] = make_groot_pre_post_processors
+        return make_groot_pre_post_processors
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = ["GrootConfig", "GrootPolicy", "make_groot_pre_post_processors"]

--- a/src/lerobot/processor/__init__.py
+++ b/src/lerobot/processor/__init__.py
@@ -14,155 +14,132 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from lerobot.types import (
-    EnvAction,
-    EnvTransition,
-    PolicyAction,
-    RobotAction,
-    RobotObservation,
-    TransitionKey,
-)
+# Lazy module: submodules are imported only when their names are first accessed.
+# This avoids pulling heavy dependencies into lightweight hardware workflows.
 
-from .batch_processor import AddBatchDimensionProcessorStep
-from .converters import (
-    batch_to_transition,
-    create_transition,
-    from_tensor_to_numpy,
-    identity_transition,
-    observation_to_transition,
-    policy_action_to_transition,
-    robot_action_observation_to_transition,
-    robot_action_to_transition,
-    transition_to_batch,
-    transition_to_observation,
-    transition_to_policy_action,
-    transition_to_robot_action,
-)
-from .delta_action_processor import MapDeltaActionToRobotActionStep, MapTensorToDeltaActionDictStep
-from .device_processor import DeviceProcessorStep
-from .env_processor import IsaaclabArenaProcessorStep, LiberoProcessorStep
-from .factory import (
-    make_default_processors,
-    make_default_robot_action_processor,
-    make_default_robot_observation_processor,
-    make_default_teleop_action_processor,
-)
-from .gym_action_processor import (
-    Numpy2TorchActionProcessorStep,
-    Torch2NumpyActionProcessorStep,
-)
-from .hil_processor import (
-    AddTeleopActionAsComplimentaryDataStep,
-    AddTeleopEventsAsInfoStep,
-    GripperPenaltyProcessorStep,
-    GymHILAdapterProcessorStep,
-    ImageCropResizeProcessorStep,
-    InterventionActionProcessorStep,
-    RewardClassifierProcessorStep,
-    TimeLimitProcessorStep,
-)
-from .newline_task_processor import NewLineTaskProcessorStep
-from .normalize_processor import NormalizerProcessorStep, UnnormalizerProcessorStep, hotswap_stats
-from .observation_processor import VanillaObservationProcessorStep
-from .pipeline import (
-    ActionProcessorStep,
-    ComplementaryDataProcessorStep,
-    DataProcessorPipeline,
-    DoneProcessorStep,
-    IdentityProcessorStep,
-    InfoProcessorStep,
-    ObservationProcessorStep,
-    PolicyActionProcessorStep,
-    PolicyProcessorPipeline,
-    ProcessorKwargs,
-    ProcessorStep,
-    ProcessorStepRegistry,
-    RewardProcessorStep,
-    RobotActionProcessorStep,
-    RobotProcessorPipeline,
-    TruncatedProcessorStep,
-)
-from .policy_robot_bridge import (
-    PolicyActionToRobotActionProcessorStep,
-    RobotActionToPolicyActionProcessorStep,
-)
-from .relative_action_processor import (
-    AbsoluteActionsProcessorStep,
-    RelativeActionsProcessorStep,
-    to_absolute_actions,
-    to_relative_actions,
-)
-from .rename_processor import RenameObservationsProcessorStep, rename_stats
-from .tokenizer_processor import ActionTokenizerProcessorStep, TokenizerProcessorStep
+_SUBMODULE_ATTRS = {
+    "lerobot.types": [
+        "EnvAction",
+        "EnvTransition",
+        "PolicyAction",
+        "TransitionKey",
+    ],
+    ".types": [
+        "RobotAction",
+        "RobotObservation",
+    ],
+    ".batch_processor": [
+        "AddBatchDimensionProcessorStep",
+    ],
+    ".converters": [
+        "batch_to_transition",
+        "create_transition",
+        "from_tensor_to_numpy",
+        "identity_transition",
+        "observation_to_transition",
+        "policy_action_to_transition",
+        "robot_action_observation_to_transition",
+        "robot_action_to_transition",
+        "transition_to_batch",
+        "transition_to_observation",
+        "transition_to_policy_action",
+        "transition_to_robot_action",
+    ],
+    ".delta_action_processor": [
+        "MapDeltaActionToRobotActionStep",
+        "MapTensorToDeltaActionDictStep",
+    ],
+    ".device_processor": [
+        "DeviceProcessorStep",
+    ],
+    ".env_processor": [
+        "IsaaclabArenaProcessorStep",
+        "LiberoProcessorStep",
+    ],
+    ".factory": [
+        "make_default_processors",
+        "make_default_robot_action_processor",
+        "make_default_robot_observation_processor",
+        "make_default_teleop_action_processor",
+    ],
+    ".gym_action_processor": [
+        "Numpy2TorchActionProcessorStep",
+        "Torch2NumpyActionProcessorStep",
+    ],
+    ".hil_processor": [
+        "AddTeleopActionAsComplimentaryDataStep",
+        "AddTeleopEventsAsInfoStep",
+        "GripperPenaltyProcessorStep",
+        "GymHILAdapterProcessorStep",
+        "ImageCropResizeProcessorStep",
+        "InterventionActionProcessorStep",
+        "RewardClassifierProcessorStep",
+        "TimeLimitProcessorStep",
+    ],
+    ".newline_task_processor": [
+        "NewLineTaskProcessorStep",
+    ],
+    ".normalize_processor": [
+        "NormalizerProcessorStep",
+        "UnnormalizerProcessorStep",
+        "hotswap_stats",
+    ],
+    ".observation_processor": [
+        "VanillaObservationProcessorStep",
+    ],
+    ".pipeline": [
+        "ActionProcessorStep",
+        "ComplementaryDataProcessorStep",
+        "DataProcessorPipeline",
+        "DoneProcessorStep",
+        "IdentityProcessorStep",
+        "InfoProcessorStep",
+        "ObservationProcessorStep",
+        "PolicyActionProcessorStep",
+        "PolicyProcessorPipeline",
+        "ProcessorKwargs",
+        "ProcessorStep",
+        "ProcessorStepRegistry",
+        "RewardProcessorStep",
+        "RobotActionProcessorStep",
+        "RobotProcessorPipeline",
+        "TruncatedProcessorStep",
+    ],
+    ".policy_robot_bridge": [
+        "PolicyActionToRobotActionProcessorStep",
+        "RobotActionToPolicyActionProcessorStep",
+    ],
+    ".relative_action_processor": [
+        "AbsoluteActionsProcessorStep",
+        "RelativeActionsProcessorStep",
+        "to_absolute_actions",
+        "to_relative_actions",
+    ],
+    ".rename_processor": [
+        "RenameObservationsProcessorStep",
+        "rename_stats",
+    ],
+    ".tokenizer_processor": [
+        "ActionTokenizerProcessorStep",
+        "TokenizerProcessorStep",
+    ],
+}
 
-__all__ = [
-    "ActionProcessorStep",
-    "AddTeleopActionAsComplimentaryDataStep",
-    "AddTeleopEventsAsInfoStep",
-    "ComplementaryDataProcessorStep",
-    "batch_to_transition",
-    "create_transition",
-    "from_tensor_to_numpy",
-    "identity_transition",
-    "observation_to_transition",
-    "policy_action_to_transition",
-    "robot_action_observation_to_transition",
-    "robot_action_to_transition",
-    "transition_to_observation",
-    "transition_to_policy_action",
-    "transition_to_robot_action",
-    "DeviceProcessorStep",
-    "DoneProcessorStep",
-    "EnvAction",
-    "EnvTransition",
-    "GymHILAdapterProcessorStep",
-    "GripperPenaltyProcessorStep",
-    "hotswap_stats",
-    "IdentityProcessorStep",
-    "ImageCropResizeProcessorStep",
-    "InfoProcessorStep",
-    "InterventionActionProcessorStep",
-    "make_default_processors",
-    "make_default_teleop_action_processor",
-    "make_default_robot_action_processor",
-    "make_default_robot_observation_processor",
-    "AbsoluteActionsProcessorStep",
-    "RelativeActionsProcessorStep",
-    "MapDeltaActionToRobotActionStep",
-    "MapTensorToDeltaActionDictStep",
-    "NewLineTaskProcessorStep",
-    "NormalizerProcessorStep",
-    "Numpy2TorchActionProcessorStep",
-    "ObservationProcessorStep",
-    "PolicyAction",
-    "PolicyActionProcessorStep",
-    "PolicyProcessorPipeline",
-    "ProcessorKwargs",
-    "ProcessorStep",
-    "ProcessorStepRegistry",
-    "RobotAction",
-    "RobotActionProcessorStep",
-    "RobotObservation",
-    "rename_stats",
-    "RenameObservationsProcessorStep",
-    "RewardClassifierProcessorStep",
-    "RewardProcessorStep",
-    "DataProcessorPipeline",
-    "IsaaclabArenaProcessorStep",
-    "LiberoProcessorStep",
-    "TimeLimitProcessorStep",
-    "AddBatchDimensionProcessorStep",
-    "RobotProcessorPipeline",
-    "TokenizerProcessorStep",
-    "ActionTokenizerProcessorStep",
-    "Torch2NumpyActionProcessorStep",
-    "RobotActionToPolicyActionProcessorStep",
-    "PolicyActionToRobotActionProcessorStep",
-    "transition_to_batch",
-    "TransitionKey",
-    "TruncatedProcessorStep",
-    "to_absolute_actions",
-    "to_relative_actions",
-    "UnnormalizerProcessorStep",
-    "VanillaObservationProcessorStep",
-]
+_ATTR_TO_MODULE: dict[str, str] = {}
+for _mod, _attrs in _SUBMODULE_ATTRS.items():
+    for _attr in _attrs:
+        _ATTR_TO_MODULE[_attr] = _mod
+
+
+def __getattr__(name: str):
+    if name in _ATTR_TO_MODULE:
+        import importlib
+
+        mod = importlib.import_module(_ATTR_TO_MODULE[name], __name__)
+        val = getattr(mod, name)
+        globals()[name] = val
+        return val
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+__all__ = list(_ATTR_TO_MODULE.keys())

--- a/src/lerobot/processor/converters.py
+++ b/src/lerobot/processor/converters.py
@@ -18,22 +18,71 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from functools import singledispatch
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
-import torch
 
-from lerobot.types import EnvTransition, PolicyAction, RobotAction, RobotObservation, TransitionKey
+from lerobot.types import TransitionKey
 from lerobot.utils.constants import ACTION, DONE, INFO, OBS_PREFIX, REWARD, TRUNCATED
+
+from .types import RobotAction, RobotObservation
+
+if TYPE_CHECKING:
+    import torch
+
+    from lerobot.types import EnvTransition, PolicyAction
+
+_torch_dispatches_registered = False
+
+
+def _ensure_torch_dispatches() -> None:
+    global _torch_dispatches_registered
+    if _torch_dispatches_registered:
+        return
+    _torch_dispatches_registered = True
+
+    import torch
+
+    @to_tensor.register(torch.Tensor)
+    def _tensor(value: torch.Tensor, *, dtype=torch.float32, device=None, **kwargs) -> torch.Tensor:
+        if dtype is not None:
+            value = value.to(dtype=dtype)
+        if device is not None:
+            value = value.to(device=device)
+        return value
+
+    @to_tensor.register(np.ndarray)
+    def _ndarray(value: np.ndarray, *, dtype=torch.float32, device=None, **kwargs) -> torch.Tensor:
+        if value.ndim == 0:
+            scalar_value = value.item()
+            return torch.tensor(scalar_value, dtype=dtype, device=device)
+        tensor = torch.from_numpy(value)
+        if dtype is not None:
+            tensor = tensor.to(dtype=dtype)
+        if device is not None:
+            tensor = tensor.to(device=device)
+        return tensor
+
+    @to_tensor.register(int)
+    @to_tensor.register(float)
+    @to_tensor.register(np.integer)
+    @to_tensor.register(np.floating)
+    def _scalar(value, *, dtype=torch.float32, device=None, **kwargs) -> torch.Tensor:
+        return torch.tensor(value, dtype=dtype, device=device)
+
+    @to_tensor.register(list)
+    @to_tensor.register(tuple)
+    def _seq(value: Sequence, *, dtype=torch.float32, device=None, **kwargs) -> torch.Tensor:
+        return torch.tensor(value, dtype=dtype, device=device)
 
 
 @singledispatch
 def to_tensor(
     value: Any,
     *,
-    dtype: torch.dtype | None = torch.float32,
-    device: torch.device | str | None = None,
-) -> torch.Tensor:
+    dtype=None,
+    device=None,
+):
     """
     Convert various data types to PyTorch tensors with configurable options.
 
@@ -51,65 +100,17 @@ def to_tensor(
     Raises:
         TypeError: If the input type is not supported.
     """
-    raise TypeError(f"Unsupported type for tensor conversion: {type(value)}")
-
-
-@to_tensor.register(torch.Tensor)
-def _(value: torch.Tensor, *, dtype=torch.float32, device=None, **kwargs) -> torch.Tensor:
-    """Handle conversion for existing PyTorch tensors."""
-    if dtype is not None:
-        value = value.to(dtype=dtype)
-    if device is not None:
-        value = value.to(device=device)
-    return value
-
-
-@to_tensor.register(np.ndarray)
-def _(
-    value: np.ndarray,
-    *,
-    dtype=torch.float32,
-    device=None,
-    **kwargs,
-) -> torch.Tensor:
-    """Handle conversion for numpy arrays."""
-    # Check for numpy scalars (0-dimensional arrays) and treat them as scalars.
-    if value.ndim == 0:
-        # Numpy scalars should be converted to 0-dimensional tensors.
-        scalar_value = value.item()
-        return torch.tensor(scalar_value, dtype=dtype, device=device)
-
-    # Create tensor from numpy array.
-    tensor = torch.from_numpy(value)
-
-    # Apply dtype and device conversion if specified.
-    if dtype is not None:
-        tensor = tensor.to(dtype=dtype)
-    if device is not None:
-        tensor = tensor.to(device=device)
-
-    return tensor
-
-
-@to_tensor.register(int)
-@to_tensor.register(float)
-@to_tensor.register(np.integer)
-@to_tensor.register(np.floating)
-def _(value, *, dtype=torch.float32, device=None, **kwargs) -> torch.Tensor:
-    """Handle conversion for scalar values including numpy scalars."""
-    return torch.tensor(value, dtype=dtype, device=device)
-
-
-@to_tensor.register(list)
-@to_tensor.register(tuple)
-def _(value: Sequence, *, dtype=torch.float32, device=None, **kwargs) -> torch.Tensor:
-    """Handle conversion for sequences (lists, tuples)."""
-    return torch.tensor(value, dtype=dtype, device=device)
+    _ensure_torch_dispatches()
+    handler = to_tensor.dispatch(type(value))
+    if handler is to_tensor:
+        raise TypeError(f"Unsupported type for tensor conversion: {type(value)}")
+    return handler(value, dtype=dtype, device=device)
 
 
 @to_tensor.register(dict)
 def _(value: dict, *, device=None, **kwargs) -> dict:
     """Handle conversion for dictionaries by recursively converting their values to tensors."""
+    _ensure_torch_dispatches()
     if not value:
         return {}
 

--- a/src/lerobot/processor/factory.py
+++ b/src/lerobot/processor/factory.py
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from lerobot.types import RobotAction, RobotObservation
-
 from .converters import (
     observation_to_transition,
     robot_action_observation_to_transition,
@@ -23,6 +21,7 @@ from .converters import (
     transition_to_robot_action,
 )
 from .pipeline import IdentityProcessorStep, RobotProcessorPipeline
+from .types import RobotAction, RobotObservation
 
 
 def make_default_teleop_action_processor() -> RobotProcessorPipeline[

--- a/src/lerobot/processor/pipeline.py
+++ b/src/lerobot/processor/pipeline.py
@@ -39,18 +39,22 @@ from collections.abc import Callable, Iterable, Sequence
 from copy import deepcopy
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, TypedDict, TypeVar, cast
+from typing import TYPE_CHECKING, Any, TypedDict, TypeVar, cast
 
-import torch
 from huggingface_hub import hf_hub_download
-from safetensors.torch import load_file, save_file
 
-from lerobot.configs import PipelineFeatureType, PolicyFeature
-from lerobot.types import EnvAction, EnvTransition, PolicyAction, RobotAction, RobotObservation, TransitionKey
+from lerobot.types import TransitionKey
 from lerobot.utils.constants import HF_LEROBOT_HOME
 from lerobot.utils.hub import HubMixin
 
 from .converters import batch_to_transition, create_transition, transition_to_batch
+from .types import RobotAction, RobotObservation
+
+if TYPE_CHECKING:
+    import torch
+
+    from lerobot.configs import PipelineFeatureType, PolicyFeature
+    from lerobot.types import EnvAction, EnvTransition, PolicyAction
 
 # Generic type variables for pipeline input and output.
 TInput = TypeVar("TInput")
@@ -385,6 +389,8 @@ class DataProcessorPipeline[TInput, TOutput](HubMixin):
                         state_filename = f"{sanitized_name}_step_{step_index}_{registry_name}.safetensors"
                     else:
                         state_filename = f"{sanitized_name}_step_{step_index}.safetensors"
+
+                    from safetensors.torch import save_file
 
                     save_file(cloned_state, os.path.join(str(save_directory), state_filename))
                     step_entry["state_file"] = state_filename
@@ -978,6 +984,8 @@ class DataProcessorPipeline[TInput, TOutput](HubMixin):
                 repo_type="model",
                 **hub_download_kwargs,
             )
+
+        from safetensors.torch import load_file
 
         step_instance.load_state_dict(load_file(state_path))
 

--- a/src/lerobot/processor/types.py
+++ b/src/lerobot/processor/types.py
@@ -1,0 +1,13 @@
+"""Lightweight type aliases that do not require torch.
+
+These are the most commonly imported names from the processor package.
+Keeping them in a separate module allows robot/teleoperator code to
+import them without pulling in torch or any other heavy dependency.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+RobotAction = dict[str, Any]
+RobotObservation = dict[str, Any]

--- a/src/lerobot/scripts/lerobot_teleoperate.py
+++ b/src/lerobot/scripts/lerobot_teleoperate.py
@@ -57,17 +57,13 @@ import logging
 import time
 from dataclasses import asdict, dataclass
 from pprint import pformat
+from typing import TYPE_CHECKING
 
-from lerobot.cameras.opencv import OpenCVCameraConfig  # noqa: F401
-from lerobot.cameras.realsense import RealSenseCameraConfig  # noqa: F401
-from lerobot.cameras.zmq import ZMQCameraConfig  # noqa: F401
+from lerobot.cameras.opencv.configuration_opencv import OpenCVCameraConfig  # noqa: F401
+from lerobot.cameras.realsense.configuration_realsense import RealSenseCameraConfig  # noqa: F401
+from lerobot.cameras.zmq.configuration_zmq import ZMQCameraConfig  # noqa: F401
 from lerobot.configs import parser
-from lerobot.processor import (
-    RobotAction,
-    RobotObservation,
-    RobotProcessorPipeline,
-    make_default_processors,
-)
+from lerobot.processor import RobotAction, RobotObservation
 from lerobot.robots import (  # noqa: F401
     Robot,
     RobotConfig,
@@ -103,8 +99,9 @@ from lerobot.teleoperators import (  # noqa: F401
 from lerobot.utils.import_utils import register_third_party_plugins
 from lerobot.utils.robot_utils import precise_sleep
 from lerobot.utils.utils import init_logging, move_cursor_up
-from lerobot.utils.visualization_utils import init_rerun, log_rerun_data, shutdown_rerun
 
+if TYPE_CHECKING:
+    from lerobot.processor import RobotProcessorPipeline
 
 @dataclass
 class TeleoperateConfig:
@@ -128,9 +125,9 @@ def teleop_loop(
     teleop: Teleoperator,
     robot: Robot,
     fps: int,
-    teleop_action_processor: RobotProcessorPipeline[tuple[RobotAction, RobotObservation], RobotAction],
-    robot_action_processor: RobotProcessorPipeline[tuple[RobotAction, RobotObservation], RobotAction],
-    robot_observation_processor: RobotProcessorPipeline[RobotObservation, RobotObservation],
+    teleop_action_processor: "RobotProcessorPipeline[tuple[RobotAction, RobotObservation], RobotAction]",
+    robot_action_processor: "RobotProcessorPipeline[tuple[RobotAction, RobotObservation], RobotAction]",
+    robot_observation_processor: "RobotProcessorPipeline[RobotObservation, RobotObservation]",
     display_data: bool = False,
     duration: float | None = None,
     display_compressed_images: bool = False,
@@ -179,6 +176,8 @@ def teleop_loop(
         _ = robot.send_action(robot_action_to_send)
 
         if display_data:
+            from lerobot.utils.visualization_utils import log_rerun_data
+
             # Process robot observation through pipeline
             obs_transition = robot_observation_processor(obs)
 
@@ -210,6 +209,8 @@ def teleoperate(cfg: TeleoperateConfig):
     init_logging()
     logging.info(pformat(asdict(cfg)))
     if cfg.display_data:
+        from lerobot.utils.visualization_utils import init_rerun
+
         init_rerun(session_name="teleoperation", ip=cfg.display_ip, port=cfg.display_port)
     display_compressed_images = (
         True
@@ -219,6 +220,8 @@ def teleoperate(cfg: TeleoperateConfig):
 
     teleop = make_teleoperator_from_config(cfg.teleop)
     robot = make_robot_from_config(cfg.robot)
+    from lerobot.processor import make_default_processors
+
     teleop_action_processor, robot_action_processor, robot_observation_processor = make_default_processors()
 
     teleop.connect()
@@ -240,6 +243,8 @@ def teleoperate(cfg: TeleoperateConfig):
         pass
     finally:
         if cfg.display_data:
+            from lerobot.utils.visualization_utils import shutdown_rerun
+
             shutdown_rerun()
         teleop.disconnect()
         robot.disconnect()

--- a/src/lerobot/types.py
+++ b/src/lerobot/types.py
@@ -20,7 +20,8 @@ from enum import Enum
 from typing import Any, TypedDict
 
 import numpy as np
-import torch
+
+from lerobot.processor.types import RobotAction, RobotObservation  # noqa: F401
 
 
 class TransitionKey(str, Enum):
@@ -36,21 +37,31 @@ class TransitionKey(str, Enum):
     COMPLEMENTARY_DATA = "complementary_data"
 
 
-PolicyAction = torch.Tensor
-RobotAction = dict[str, Any]
 EnvAction = np.ndarray
-RobotObservation = dict[str, Any]
 
 
-EnvTransition = TypedDict(
-    "EnvTransition",
-    {
-        TransitionKey.OBSERVATION.value: RobotObservation | None,
-        TransitionKey.ACTION.value: PolicyAction | RobotAction | EnvAction | None,
-        TransitionKey.REWARD.value: float | torch.Tensor | None,
-        TransitionKey.DONE.value: bool | torch.Tensor | None,
-        TransitionKey.TRUNCATED.value: bool | torch.Tensor | None,
-        TransitionKey.INFO.value: dict[str, Any] | None,
-        TransitionKey.COMPLEMENTARY_DATA.value: dict[str, Any] | None,
-    },
-)
+def __getattr__(name: str):
+    if name == "PolicyAction":
+        import torch
+
+        policy_action = torch.Tensor
+        globals()["PolicyAction"] = policy_action
+        return policy_action
+    if name == "EnvTransition":
+        import torch
+
+        EnvTransition = TypedDict(
+            "EnvTransition",
+            {
+                TransitionKey.OBSERVATION.value: RobotObservation | None,
+                TransitionKey.ACTION.value: torch.Tensor | RobotAction | EnvAction | None,
+                TransitionKey.REWARD.value: float | torch.Tensor | None,
+                TransitionKey.DONE.value: bool | torch.Tensor | None,
+                TransitionKey.TRUNCATED.value: bool | torch.Tensor | None,
+                TransitionKey.INFO.value: dict[str, Any] | None,
+                TransitionKey.COMPLEMENTARY_DATA.value: dict[str, Any] | None,
+            },
+        )
+        globals()["EnvTransition"] = EnvTransition
+        return EnvTransition
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/lerobot/utils/__init__.py
+++ b/src/lerobot/utils/__init__.py
@@ -13,53 +13,46 @@
 # limitations under the License.
 
 """
-Public API for lightweight, base-dependency-only utilities.
+Public API for lightweight utilities.
 
-Heavy cross-cutting modules (train_utils, control_utils) have been moved
-to ``lerobot.common``. ``visualization_utils`` remains here but is
-intentionally NOT re-exported to avoid pulling in optional dependencies.
+Exports are resolved lazily so importing a utility submodule does not
+eagerly import torch through ``device_utils``.
 """
 
-from .constants import (
-    ACTION,
-    DEFAULT_FEATURES,
-    DONE,
-    IMAGENET_STATS,
-    OBS_ENV_STATE,
-    OBS_IMAGE,
-    OBS_IMAGES,
-    OBS_STATE,
-    OBS_STR,
-    REWARD,
-)
-from .decorators import check_if_already_connected, check_if_not_connected
-from .device_utils import auto_select_torch_device, get_safe_torch_device, is_torch_device_available
-from .errors import DeviceAlreadyConnectedError, DeviceNotConnectedError
-from .import_utils import is_package_available, require_package
+_SUBMODULE_ATTRS = {
+    ".constants": [
+        "ACTION",
+        "DEFAULT_FEATURES",
+        "DONE",
+        "IMAGENET_STATS",
+        "OBS_ENV_STATE",
+        "OBS_IMAGE",
+        "OBS_IMAGES",
+        "OBS_STATE",
+        "OBS_STR",
+        "REWARD",
+    ],
+    ".decorators": ["check_if_already_connected", "check_if_not_connected"],
+    ".device_utils": ["auto_select_torch_device", "get_safe_torch_device", "is_torch_device_available"],
+    ".errors": ["DeviceAlreadyConnectedError", "DeviceNotConnectedError"],
+    ".import_utils": ["is_package_available", "require_package"],
+}
 
-__all__ = [
-    # Constants
-    "ACTION",
-    "DEFAULT_FEATURES",
-    "DONE",
-    "IMAGENET_STATS",
-    "OBS_ENV_STATE",
-    "OBS_IMAGE",
-    "OBS_IMAGES",
-    "OBS_STATE",
-    "OBS_STR",
-    "REWARD",
-    # Device utilities
-    "auto_select_torch_device",
-    "get_safe_torch_device",
-    "is_torch_device_available",
-    # Import guards
-    "is_package_available",
-    "require_package",
-    # Decorators
-    "check_if_already_connected",
-    "check_if_not_connected",
-    # Errors
-    "DeviceAlreadyConnectedError",
-    "DeviceNotConnectedError",
-]
+_ATTR_TO_MODULE: dict[str, str] = {}
+for _mod, _attrs in _SUBMODULE_ATTRS.items():
+    for _attr in _attrs:
+        _ATTR_TO_MODULE[_attr] = _mod
+
+
+def __getattr__(name: str):
+    if name in _ATTR_TO_MODULE:
+        import importlib
+
+        mod = importlib.import_module(_ATTR_TO_MODULE[name], __name__)
+        val = getattr(mod, name)
+        globals()[name] = val
+        return val
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+__all__ = list(_ATTR_TO_MODULE.keys())

--- a/uv.lock
+++ b/uv.lock
@@ -1185,7 +1185,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/a2/55/8f8cab2afd404cf57
 
 [[package]]
 name = "draccus"
-version = "0.10.0"
+version = "0.11.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mergedeep" },
@@ -1194,9 +1194,9 @@ dependencies = [
     { name = "toml" },
     { name = "typing-inspect" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4e/e2/f5012fda17ee5d1eaf3481b6ca3e11dffa5348e5e08ab745538fdc8041bb/draccus-0.10.0.tar.gz", hash = "sha256:8dd08304219becdcd66cd16058ba98e9c3e6b7bfe48ccb9579dae39f8d37ae19", size = 62243, upload-time = "2025-02-05T07:27:48.182Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/68/9a054c0d242a948c41b7ae9416a4148bf562df7d244c7a39a4b67e7ff742/draccus-0.11.5.tar.gz", hash = "sha256:b82e2c2027030ae1a0f105515125f914e050c0766ab518df3a0560a07d10ddc9", size = 67384, upload-time = "2025-04-22T20:41:48.972Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c4/9a/a83083b230d352ee5d205757b74006dbe084448ca45e3bc5ca99215b1e55/draccus-0.10.0-py3-none-any.whl", hash = "sha256:90243418ae0e9271c390a59cafb6acfd37001193696ed36fcc8525f791a83282", size = 71783, upload-time = "2025-02-05T07:27:46.1Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/52/3144a4a8341f125d357a8f6e07aeb23b0bde7133dabbd0c78b984c079a1f/draccus-0.11.5-py3-none-any.whl", hash = "sha256:67da70bfbdea8fe67667322c64068d6d8cd832694a418b6c71d9d3b9f5c3c005", size = 78447, upload-time = "2025-04-22T20:41:47.414Z" },
 ]
 
 [[package]]
@@ -2943,7 +2943,7 @@ requires-dist = [
     { name = "deepdiff", marker = "extra == 'deepdiff-dep'", specifier = ">=7.0.1,<9.0.0" },
     { name = "diffusers", marker = "extra == 'diffusers-dep'", specifier = ">=0.27.2,<0.36.0" },
     { name = "dm-tree", marker = "extra == 'groot'", specifier = ">=0.1.8,<1.0.0" },
-    { name = "draccus", specifier = "==0.10.0" },
+    { name = "draccus", specifier = "==0.11.5" },
     { name = "dynamixel-sdk", marker = "extra == 'dynamixel'", specifier = ">=3.7.31,<3.9.0" },
     { name = "einops", specifier = ">=0.8.0,<0.9.0" },
     { name = "faker", marker = "extra == 'sarm'", specifier = ">=33.0.0,<35.0.0" },


### PR DESCRIPTION
## Summary

`lerobot-teleoperate` was spending most of its startup time importing training and policy modules that it does not need for hardware control. This PR trims that import path.

## Benchmark

Measured on Windows / Python 3.12 with the GEM teleoperation command.

| Scenario | `lerobot_teleoperate` import only | `--teleop_time_s=0` |
| --- | ---: | ---: |
| Baseline before this change | 20.8s | 20.8s |
| Import-path fixes before `draccus==0.11.5` | 0.8s | 8.0s |
| Import-path fixes + `draccus==0.11.5` | 0.7s | 2.4s |

## What changed

- Lazily resolve exports from `lerobot.processor`, `lerobot.configs`, and `lerobot.utils`.
- Move torch-free processor type aliases into `lerobot.processor.types`.
- Defer torch, safetensors, rerun, and deepdiff imports until they are actually needed.
- Avoid importing `deepdiff` in `motors_bus.py` at module import time.
- Defer `rerun` visualization imports in `lerobot_teleoperate.py` until display is enabled.
- Update `draccus` to `0.11.5`.

## draccus

`draccus==0.11.5` is part of the fix here, but I had to use my fork while validating because there is a calibration-related bug in that line. The fix is in [marin-community/draccus#62](https://github.com/marin-community/draccus/pull/62), and that should be merged upstream before the version bump is relied on broadly.

## Checks

- `ruff check` on changed files
- import smoke test: `python -c "import lerobot.scripts.lerobot_teleoperate; import lerobot.processor as p; assert hasattr(p, 'RobotAction'); assert hasattr(p, 'make_default_processors')"`
- import-time smoke test: `python -X importtime -c "import lerobot.scripts.lerobot_teleoperate"`