### PR TITLE
feat(rl): add configurable online/offline replay mixing scheduler

### DIFF
--- a/src/lerobot/policies/sac/configuration_sac.py
+++ b/src/lerobot/policies/sac/configuration_sac.py
@@ -47,6 +47,29 @@ class ConcurrencyConfig:
 
 
 @dataclass
+class ReplayMixingConfig:
+    """Controls how online and offline replay are mixed during RL updates."""
+
+    # Keep current behavior by default: 50/50 online-offline when offline data is available.
+    mode: str = "fixed"
+    online_ratio: float = 0.5
+    final_online_ratio: float = 1.0
+    schedule_steps: int = 250_000
+    keep_minimum_offline_samples: bool = True
+
+    def __post_init__(self) -> None:
+        valid_modes = {"fixed", "linear"}
+        if self.mode not in valid_modes:
+            raise ValueError(f"Replay mixing mode must be one of {sorted(valid_modes)}, got {self.mode!r}")
+        if not (0.0 <= self.online_ratio <= 1.0):
+            raise ValueError(f"online_ratio must be in [0, 1], got {self.online_ratio}")
+        if not (0.0 <= self.final_online_ratio <= 1.0):
+            raise ValueError(f"final_online_ratio must be in [0, 1], got {self.final_online_ratio}")
+        if self.schedule_steps <= 0:
+            raise ValueError(f"schedule_steps must be > 0, got {self.schedule_steps}")
+
+
+@dataclass
 class ActorLearnerConfig:
     learner_host: str = "127.0.0.1"
     learner_port: int = 50051
@@ -192,6 +215,8 @@ class SACConfig(PreTrainedConfig):
     actor_learner_config: ActorLearnerConfig = field(default_factory=ActorLearnerConfig)
     # Configuration for concurrency settings (you can use threads or processes for the actor and learner)
     concurrency: ConcurrencyConfig = field(default_factory=ConcurrencyConfig)
+    # Configuration for dynamic online/offline replay sampling.
+    replay_mixing: ReplayMixingConfig = field(default_factory=ReplayMixingConfig)
 
     # Optimizations
     use_torch_compile: bool = True

--- a/src/lerobot/rl/learner.py
+++ b/src/lerobot/rl/learner.py
@@ -102,6 +102,86 @@ from .buffer import ReplayBuffer, concatenate_batch_transitions
 from .learner_service import MAX_WORKERS, SHUTDOWN_TIMEOUT, LearnerService
 
 
+def compute_online_replay_ratio(cfg: TrainRLServerPipelineConfig, optimization_step: int) -> float:
+    """Return the online replay sampling ratio for the current optimization step."""
+    mixing_cfg = cfg.policy.replay_mixing
+    if mixing_cfg.mode == "fixed":
+        return mixing_cfg.online_ratio
+
+    # Linear schedule from online_ratio -> final_online_ratio over schedule_steps.
+    progress = min(max(optimization_step, 0), mixing_cfg.schedule_steps) / float(mixing_cfg.schedule_steps)
+    return mixing_cfg.online_ratio + (mixing_cfg.final_online_ratio - mixing_cfg.online_ratio) * progress
+
+
+def compute_replay_batch_sizes(
+    total_batch_size: int,
+    online_ratio: float,
+    use_offline_buffer: bool,
+    keep_minimum_offline_samples: bool = True,
+) -> tuple[int, int]:
+    """Compute online/offline batch sizes from a ratio and total batch size."""
+    if not use_offline_buffer:
+        return total_batch_size, 0
+
+    online_batch_size = int(round(total_batch_size * online_ratio))
+    online_batch_size = max(0, min(total_batch_size, online_batch_size))
+    offline_batch_size = total_batch_size - online_batch_size
+
+    # Optional safeguard to keep both sources active during mixed training.
+    if keep_minimum_offline_samples and total_batch_size > 1:
+        if online_batch_size == 0:
+            online_batch_size = 1
+            offline_batch_size = total_batch_size - 1
+        if offline_batch_size == 0:
+            offline_batch_size = 1
+            online_batch_size = total_batch_size - 1
+
+    return online_batch_size, offline_batch_size
+
+
+def sample_training_batch(
+    cfg: TrainRLServerPipelineConfig,
+    replay_buffer: ReplayBuffer,
+    offline_replay_buffer: ReplayBuffer | None,
+    total_batch_size: int,
+    optimization_step: int,
+    async_prefetch: bool,
+    online_iterators: dict[int, any],
+    offline_iterators: dict[int, any],
+) -> tuple[dict, float, int, int]:
+    """Sample a batch according to the configured online/offline replay mix."""
+    online_ratio = compute_online_replay_ratio(cfg, optimization_step)
+    online_batch_size, offline_batch_size = compute_replay_batch_sizes(
+        total_batch_size=total_batch_size,
+        online_ratio=online_ratio,
+        use_offline_buffer=offline_replay_buffer is not None,
+        keep_minimum_offline_samples=cfg.policy.replay_mixing.keep_minimum_offline_samples,
+    )
+
+    if online_batch_size > 0 and online_batch_size not in online_iterators:
+        online_iterators[online_batch_size] = replay_buffer.get_iterator(
+            batch_size=online_batch_size, async_prefetch=async_prefetch, queue_size=2
+        )
+
+    if offline_batch_size > 0 and offline_batch_size not in offline_iterators and offline_replay_buffer is not None:
+        offline_iterators[offline_batch_size] = offline_replay_buffer.get_iterator(
+            batch_size=offline_batch_size, async_prefetch=async_prefetch, queue_size=2
+        )
+
+    batch = next(online_iterators[online_batch_size]) if online_batch_size > 0 else None
+    if offline_batch_size > 0 and offline_replay_buffer is not None:
+        batch_offline = next(offline_iterators[offline_batch_size])
+        if batch is None:
+            batch = batch_offline
+        else:
+            batch = concatenate_batch_transitions(
+                left_batch_transitions=batch,
+                right_batch_transition=batch_offline,
+            )
+
+    return batch, online_ratio, online_batch_size, offline_batch_size
+
+
 @parser.wrap()
 def train_cli(cfg: TrainRLServerPipelineConfig):
     if not use_threads(cfg):
@@ -338,7 +418,6 @@ def add_actor_information_and_train(
             device=device,
             storage_device=storage_device,
         )
-        batch_size: int = batch_size // 2  # We will sample from both replay buffer
 
     logging.info("Starting learner thread")
     interaction_message = None
@@ -349,9 +428,8 @@ def add_actor_information_and_train(
     if cfg.dataset is not None:
         dataset_repo_id = cfg.dataset.repo_id
 
-    # Initialize iterators
-    online_iterator = None
-    offline_iterator = None
+    online_iterators = {}
+    offline_iterators = {}
 
     # NOTE: THIS IS THE MAIN LOOP OF THE LEARNER
     while True:
@@ -382,26 +460,18 @@ def add_actor_information_and_train(
         if len(replay_buffer) < online_step_before_learning:
             continue
 
-        if online_iterator is None:
-            online_iterator = replay_buffer.get_iterator(
-                batch_size=batch_size, async_prefetch=async_prefetch, queue_size=2
-            )
-
-        if offline_replay_buffer is not None and offline_iterator is None:
-            offline_iterator = offline_replay_buffer.get_iterator(
-                batch_size=batch_size, async_prefetch=async_prefetch, queue_size=2
-            )
-
         time_for_one_optimization_step = time.time()
         for _ in range(utd_ratio - 1):
-            # Sample from the iterators
-            batch = next(online_iterator)
-
-            if dataset_repo_id is not None:
-                batch_offline = next(offline_iterator)
-                batch = concatenate_batch_transitions(
-                    left_batch_transitions=batch, right_batch_transition=batch_offline
-                )
+            batch, _, _, _ = sample_training_batch(
+                cfg=cfg,
+                replay_buffer=replay_buffer,
+                offline_replay_buffer=offline_replay_buffer,
+                total_batch_size=batch_size,
+                optimization_step=optimization_step,
+                async_prefetch=async_prefetch,
+                online_iterators=online_iterators,
+                offline_iterators=offline_iterators,
+            )
 
             actions = batch[ACTION]
             rewards = batch["reward"]
@@ -452,14 +522,16 @@ def add_actor_information_and_train(
             # Update target networks (main and discrete)
             policy.update_target_networks()
 
-        # Sample for the last update in the UTD ratio
-        batch = next(online_iterator)
-
-        if dataset_repo_id is not None:
-            batch_offline = next(offline_iterator)
-            batch = concatenate_batch_transitions(
-                left_batch_transitions=batch, right_batch_transition=batch_offline
-            )
+        batch, online_ratio, online_batch_size, offline_batch_size = sample_training_batch(
+            cfg=cfg,
+            replay_buffer=replay_buffer,
+            offline_replay_buffer=offline_replay_buffer,
+            total_batch_size=batch_size,
+            optimization_step=optimization_step,
+            async_prefetch=async_prefetch,
+            online_iterators=online_iterators,
+            offline_iterators=offline_iterators,
+        )
 
         actions = batch[ACTION]
         rewards = batch["reward"]
@@ -498,6 +570,9 @@ def add_actor_information_and_train(
         training_infos = {
             "loss_critic": loss_critic.item(),
             "critic_grad_norm": critic_grad_norm,
+            "online_replay_ratio": online_ratio,
+            "online_batch_size": online_batch_size,
+            "offline_batch_size": offline_batch_size,
         }
 
         # Discrete critic optimization (if available)

--- a/tests/policies/test_sac_config.py
+++ b/tests/policies/test_sac_config.py
@@ -23,6 +23,7 @@ from lerobot.policies.sac.configuration_sac import (
     ConcurrencyConfig,
     CriticNetworkConfig,
     PolicyConfig,
+    ReplayMixingConfig,
     SACConfig,
 )
 from lerobot.utils.constants import ACTION, OBS_IMAGE, OBS_STATE
@@ -133,12 +134,16 @@ def test_sac_config_default_initialization():
     # Concurrency configuration
     assert config.concurrency.actor == "threads"
     assert config.concurrency.learner == "threads"
+    assert config.replay_mixing.mode == "fixed"
+    assert config.replay_mixing.online_ratio == 0.5
+    assert config.replay_mixing.final_online_ratio == 1.0
 
     assert isinstance(config.actor_network_kwargs, ActorNetworkConfig)
     assert isinstance(config.critic_network_kwargs, CriticNetworkConfig)
     assert isinstance(config.policy_kwargs, PolicyConfig)
     assert isinstance(config.actor_learner_config, ActorLearnerConfig)
     assert isinstance(config.concurrency, ConcurrencyConfig)
+    assert isinstance(config.replay_mixing, ReplayMixingConfig)
 
 
 def test_critic_network_kwargs():
@@ -173,6 +178,20 @@ def test_concurrency_config():
     config = ConcurrencyConfig()
     assert config.actor == "threads"
     assert config.learner == "threads"
+
+
+def test_replay_mixing_config():
+    config = ReplayMixingConfig()
+    assert config.mode == "fixed"
+    assert config.online_ratio == 0.5
+    assert config.final_online_ratio == 1.0
+    assert config.schedule_steps == 250000
+    assert config.keep_minimum_offline_samples is True
+
+
+def test_replay_mixing_config_rejects_invalid_mode():
+    with pytest.raises(ValueError, match="Replay mixing mode"):
+        ReplayMixingConfig(mode="cosine")
 
 
 def test_sac_config_custom_initialization():

--- a/tests/rl/test_replay_mixing.py
+++ b/tests/rl/test_replay_mixing.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+pytest.importorskip("datasets", reason="datasets is required (install lerobot[dataset])")
+
+from lerobot.configs.train import TrainRLServerPipelineConfig
+from lerobot.policies.sac.configuration_sac import SACConfig
+from lerobot.rl.learner import compute_online_replay_ratio, compute_replay_batch_sizes
+
+
+@pytest.fixture
+def rl_cfg():
+    cfg = TrainRLServerPipelineConfig()
+    cfg.policy = SACConfig()
+    return cfg
+
+
+def test_compute_online_replay_ratio_fixed_mode(rl_cfg):
+    rl_cfg.policy.replay_mixing.mode = "fixed"
+    rl_cfg.policy.replay_mixing.online_ratio = 0.35
+
+    assert compute_online_replay_ratio(rl_cfg, optimization_step=0) == pytest.approx(0.35)
+    assert compute_online_replay_ratio(rl_cfg, optimization_step=10_000) == pytest.approx(0.35)
+
+
+def test_compute_online_replay_ratio_linear_mode(rl_cfg):
+    rl_cfg.policy.replay_mixing.mode = "linear"
+    rl_cfg.policy.replay_mixing.online_ratio = 0.2
+    rl_cfg.policy.replay_mixing.final_online_ratio = 0.8
+    rl_cfg.policy.replay_mixing.schedule_steps = 100
+
+    assert compute_online_replay_ratio(rl_cfg, optimization_step=0) == pytest.approx(0.2)
+    assert compute_online_replay_ratio(rl_cfg, optimization_step=50) == pytest.approx(0.5)
+    assert compute_online_replay_ratio(rl_cfg, optimization_step=100) == pytest.approx(0.8)
+    assert compute_online_replay_ratio(rl_cfg, optimization_step=200) == pytest.approx(0.8)
+
+
+def test_compute_replay_batch_sizes_without_offline_buffer():
+    online_bs, offline_bs = compute_replay_batch_sizes(
+        total_batch_size=128,
+        online_ratio=0.25,
+        use_offline_buffer=False,
+    )
+    assert online_bs == 128
+    assert offline_bs == 0
+
+
+def test_compute_replay_batch_sizes_preserves_both_sources_when_enabled():
+    online_bs, offline_bs = compute_replay_batch_sizes(
+        total_batch_size=32,
+        online_ratio=1.0,
+        use_offline_buffer=True,
+        keep_minimum_offline_samples=True,
+    )
+    assert online_bs == 31
+    assert offline_bs == 1
+


### PR DESCRIPTION
## Summary
- add `ReplayMixingConfig` to SAC with fixed and linear scheduling modes for online/offline replay blending
- integrate replay-mix scheduling into the learner sampling loop with dynamic per-step batch allocation
- expose replay mix telemetry (`online_replay_ratio`, `online_batch_size`, `offline_batch_size`) in training logs and add tests for config + scheduler behavior

## Test plan
- [x] `python3 -m py_compile src/lerobot/policies/sac/configuration_sac.py src/lerobot/rl/learner.py tests/policies/test_sac_config.py tests/rl/test_replay_mixing.py`
- [x] `PYTHONPATH=src pytest -q tests/policies/test_sac_config.py tests/rl/test_replay_mixing.py` (requires torch in environment)