### PR TITLE
feat(motors): allow per-motor setup and calibration for SO leader/follower

### DIFF
--- a/src/lerobot/motors/feetech/calibration.py
+++ b/src/lerobot/motors/feetech/calibration.py
@@ -56,7 +56,7 @@ def calibrate_partial(
     )
     for motor, m in motors_to_calibrate.items():
         input(f"Move {motor} to the middle of its range of motion and press ENTER....")
-        homing_offset = bus.set_half_turn_homings([motor])[motor]
+        homing_offset = int(bus.set_half_turn_homings([motor])[motor])
         if motor in full_turn_motors:
             range_min_val, range_max_val = 0, 4095
             input(
@@ -67,7 +67,7 @@ def calibrate_partial(
                 f"Move {motor} through its entire range of motion (calibration of other motors won't be affected).\nRecording positions. Press ENTER to stop..."
             )
             range_mins, range_maxs = bus.record_ranges_of_motion([motor])
-            range_min_val, range_max_val = range_mins[motor], range_maxs[motor]
+            range_min_val, range_max_val = int(range_mins[motor]), int(range_maxs[motor])
 
         updated_calibration[motor] = MotorCalibration(
             id=m.id,

--- a/src/lerobot/motors/feetech/calibration.py
+++ b/src/lerobot/motors/feetech/calibration.py
@@ -59,11 +59,11 @@ def calibrate_partial(
         homing_offset = int(bus.set_half_turn_homings([motor])[motor])
         if motor in full_turn_motors:
             range_min_val, range_max_val = 0, 4095
-            input(
+            print(
                 f"'{motor}' is set as the full turn motor with a fixed range of [0, 4095]. Homing offset was recorded but no further calibration is needed. Press ENTER to continue..."
             )
         else:
-            input(
+            print(
                 f"Move {motor} through its entire range of motion (calibration of other motors won't be affected).\nRecording positions. Press ENTER to stop..."
             )
             range_mins, range_maxs = bus.record_ranges_of_motion([motor])

--- a/src/lerobot/motors/feetech/calibration.py
+++ b/src/lerobot/motors/feetech/calibration.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+from lerobot.motors import Motor, MotorCalibration
+
+from .feetech import (
+    FeetechMotorsBus,
+    OperatingMode,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def calibrate_partial(
+    bus: FeetechMotorsBus,
+    existing_calibration: dict[str, MotorCalibration],
+    motors: list[str],
+    device_name: str,
+    full_turn_motors: frozenset[str] = frozenset(),
+) -> dict[str, MotorCalibration]:
+    if not existing_calibration:
+        raise ValueError(
+            "No existing calibration found. Run full calibration first before calibrating specific motors."
+        )
+
+    updated_calibration = existing_calibration.copy()
+    motors_to_calibrate: dict[str, Motor] = {}
+    logger.info(f"\nRunning partial calibration of {device_name} for motors: {set(motors)}")
+    bus.disable_torque()
+    for motor in motors:
+        if motor not in bus.motors:
+            raise ValueError(
+                f"Motor '{motor}' not found in the bus. Available motors: {list(bus.motors.keys())}"
+            )
+        motors_to_calibrate[motor] = bus.motors[motor]
+        bus.write("Operating_Mode", motor, OperatingMode.POSITION.value)
+
+    # calibrate motors one by one
+    logger.info(
+        "Calibration of selected motors will be done sequentially. During calibration, all the motors will have their torque disabled and can be moved freely, but only the specified motor will be calibrated."
+    )
+    for motor, m in motors_to_calibrate.items():
+        input(f"Move {motor} to the middle of its range of motion and press ENTER....")
+        homing_offset = bus.set_half_turn_homings([motor])[motor]
+        if motor in full_turn_motors:
+            range_min_val, range_max_val = 0, 4095
+            input(
+                f"'{motor}' is set as the full turn motor with a fixed range of [0, 4095]. Homing offset was recorded but no further calibration is needed. Press ENTER to continue..."
+            )
+        else:
+            input(
+                f"Move {motor} through its entire range of motion (calibration of other motors won't be affected).\nRecording positions. Press ENTER to stop..."
+            )
+            range_mins, range_maxs = bus.record_ranges_of_motion([motor])
+            range_min_val, range_max_val = range_mins[motor], range_maxs[motor]
+
+        updated_calibration[motor] = MotorCalibration(
+            id=m.id,
+            drive_mode=0,
+            homing_offset=homing_offset,
+            range_min=range_min_val,
+            range_max=range_max_val,
+        )
+
+    return updated_calibration

--- a/src/lerobot/robots/so_follower/so_follower.py
+++ b/src/lerobot/robots/so_follower/so_follower.py
@@ -168,8 +168,19 @@ class SOFollower(Robot):
                     self.bus.write("Protection_Current", motor, 250)  # 50% of max current to avoid burnout
                     self.bus.write("Overload_Torque", motor, 25)  # 25% torque when overloaded
 
-    def setup_motors(self) -> None:
-        for motor in reversed(self.bus.motors):
+    def setup_motors(self, motors: list[str] | None = None) -> None:
+        motors_to_setup: dict[str, Motor] = self.bus.motors
+
+        if motors is not None:
+            motors_to_setup = {}
+            for motor in motors:
+                if motor not in self.bus.motors:
+                    raise ValueError(
+                        f"Motor '{motor}' not found in the bus. Available motors: {list(self.bus.motors.keys())}"
+                    )
+                motors_to_setup[motor] = self.bus.motors[motor]
+
+        for motor in reversed(motors_to_setup):
             input(f"Connect the controller board to the '{motor}' motor only and press enter.")
             self.bus.setup_motor(motor)
             print(f"'{motor}' motor id set to {self.bus.motors[motor].id}")

--- a/src/lerobot/robots/so_follower/so_follower.py
+++ b/src/lerobot/robots/so_follower/so_follower.py
@@ -24,6 +24,7 @@ from lerobot.motors.feetech import (
     FeetechMotorsBus,
     OperatingMode,
 )
+from lerobot.motors.feetech.calibration import calibrate_partial
 from lerobot.types import RobotAction, RobotObservation
 from lerobot.utils.decorators import check_if_already_connected, check_if_not_connected
 
@@ -42,7 +43,6 @@ class SOFollower(Robot):
 
     config_class = SOFollowerRobotConfig
     name = "so_follower"
-    _full_turn_motor = "wrist_roll"
 
     def __init__(self, config: SOFollowerRobotConfig):
         super().__init__(config)
@@ -109,57 +109,30 @@ class SOFollower(Robot):
     def is_calibrated(self) -> bool:
         return self.bus.is_calibrated
 
-    def _calibrate_partial(self, motors: list[str]) -> None:
-        if not self.calibration:
-            raise ValueError(
-                "No existing calibration found. Run full calibration first before calibrating specific motors."
-            )
-
-        motors_to_calibrate: dict[str, Motor] = {}
-        logger.info(f"\nRunning partial calibration of {self} for motors: {set(motors)}")
-        self.bus.disable_torque()
-        for motor in motors:
-            if motor not in self.bus.motors:
-                raise ValueError(
-                    f"Motor '{motor}' not found in the bus. Available motors: {list(self.bus.motors.keys())}"
-                )
-            motors_to_calibrate[motor] = self.bus.motors[motor]
-            self.bus.write("Operating_Mode", motor, OperatingMode.POSITION.value)
-
-        # calibrate motors one by one
-        print(
-            "Calibration of selected motors will be done sequentially. During calibration, all the motors will have their torque disabled and can be moved freely, but only the specified motor will be calibrated.\n"
-        )
-        for motor, m in motors_to_calibrate.items():
-            input(f"Move {motor} to the middle of its range of motion and press ENTER....")
-            homing_offset = self.bus.set_half_turn_homings([motor])[motor]
-            if motor == self._full_turn_motor:
-                range_min_val, range_max_val = 0, 4095
-                input(
-                    f"'{motor}' is set as the full turn motor with a fixed range of [0, 4095]. Homing offset was recorded but no further calibration is needed. Press ENTER to continue..."
-                )
-            else:
-                input(
-                    f"Move {motor} through its entire range of motion.\nRecording positions. Press ENTER to stop..."
-                )
-                range_mins, range_maxs = self.bus.record_ranges_of_motion([motor])
-                range_min_val, range_max_val = range_mins[motor], range_maxs[motor]
-            self.calibration[motor] = MotorCalibration(
-                id=m.id,
-                drive_mode=0,
-                homing_offset=homing_offset,
-                range_min=range_min_val,
-                range_max=range_max_val,
-            )
-
-        self.bus.write_calibration(self.calibration)
-        self._save_calibration()
-        print(f"Calibration saved to {self.calibration_fpath}")
-
     def calibrate(self, motors: list[str] | None = None) -> None:
+        full_turn_motor = "wrist_roll"
         if motors is not None:
-            self._calibrate_partial(motors)
-            return
+            try:
+                new_calibration = calibrate_partial(
+                    bus=self.bus,
+                    existing_calibration=self.calibration,
+                    motors=motors,
+                    device_name=str(self),
+                    full_turn_motors={full_turn_motor},
+                )
+                self.calibration = new_calibration
+                self.bus.write_calibration(self.calibration)
+                self._save_calibration()
+                print(f"Partial calibration of motors {set(motors)} saved to {self.calibration_fpath}")
+                return
+            except Exception:
+                logger.exception(
+                    "Error occurred during partial calibration. Your previous calibration has been restored."
+                )
+                # Restore the original homing offsets of the motors that may have been modified during
+                # calibration before the error occurred.
+                self.bus.write_calibration(self.calibration)
+                raise
 
         if self.calibration:
             # Calibration file exists, ask user whether to use it or run new calibration
@@ -180,14 +153,14 @@ class SOFollower(Robot):
         homing_offsets = self.bus.set_half_turn_homings()
 
         # Attempt to call record_ranges_of_motion with a reduced motor set when appropriate.
-        unknown_range_motors = [motor for motor in self.bus.motors if motor != self._full_turn_motor]
+        unknown_range_motors = [motor for motor in self.bus.motors if motor != full_turn_motor]
         print(
-            f"Move all joints except '{self._full_turn_motor}' sequentially through their "
+            f"Move all joints except '{full_turn_motor}' sequentially through their "
             "entire ranges of motion.\nRecording positions. Press ENTER to stop..."
         )
         range_mins, range_maxes = self.bus.record_ranges_of_motion(unknown_range_motors)
-        range_mins[self._full_turn_motor] = 0
-        range_maxes[self._full_turn_motor] = 4095
+        range_mins[full_turn_motor] = 0
+        range_maxes[full_turn_motor] = 4095
 
         self.calibration = {}
         for motor, m in self.bus.motors.items():

--- a/src/lerobot/robots/so_follower/so_follower.py
+++ b/src/lerobot/robots/so_follower/so_follower.py
@@ -42,6 +42,7 @@ class SOFollower(Robot):
 
     config_class = SOFollowerRobotConfig
     name = "so_follower"
+    _full_turn_motor = "wrist_roll"
 
     def __init__(self, config: SOFollowerRobotConfig):
         super().__init__(config)
@@ -108,7 +109,58 @@ class SOFollower(Robot):
     def is_calibrated(self) -> bool:
         return self.bus.is_calibrated
 
-    def calibrate(self) -> None:
+    def _calibrate_partial(self, motors: list[str]) -> None:
+        if not self.calibration:
+            raise ValueError(
+                "No existing calibration found. Run full calibration first before calibrating specific motors."
+            )
+
+        motors_to_calibrate: dict[str, Motor] = {}
+        logger.info(f"\nRunning partial calibration of {self} for motors: {set(motors)}")
+        self.bus.disable_torque()
+        for motor in motors:
+            if motor not in self.bus.motors:
+                raise ValueError(
+                    f"Motor '{motor}' not found in the bus. Available motors: {list(self.bus.motors.keys())}"
+                )
+            motors_to_calibrate[motor] = self.bus.motors[motor]
+            self.bus.write("Operating_Mode", motor, OperatingMode.POSITION.value)
+
+        # calibrate motors one by one
+        print(
+            "Calibration of selected motors will be done sequentially. During calibration, all the motors will have their torque disabled and can be moved freely, but only the specified motor will be calibrated.\n"
+        )
+        for motor, m in motors_to_calibrate.items():
+            input(f"Move {motor} to the middle of its range of motion and press ENTER....")
+            homing_offset = self.bus.set_half_turn_homings([motor])[motor]
+            if motor == self._full_turn_motor:
+                range_min_val, range_max_val = 0, 4095
+                input(
+                    f"'{motor}' is set as the full turn motor with a fixed range of [0, 4095]. Homing offset was recorded but no further calibration is needed. Press ENTER to continue..."
+                )
+            else:
+                input(
+                    f"Move {motor} through its entire range of motion.\nRecording positions. Press ENTER to stop..."
+                )
+                range_mins, range_maxs = self.bus.record_ranges_of_motion([motor])
+                range_min_val, range_max_val = range_mins[motor], range_maxs[motor]
+            self.calibration[motor] = MotorCalibration(
+                id=m.id,
+                drive_mode=0,
+                homing_offset=homing_offset,
+                range_min=range_min_val,
+                range_max=range_max_val,
+            )
+
+        self.bus.write_calibration(self.calibration)
+        self._save_calibration()
+        print(f"Calibration saved to {self.calibration_fpath}")
+
+    def calibrate(self, motors: list[str] | None = None) -> None:
+        if motors is not None:
+            self._calibrate_partial(motors)
+            return
+
         if self.calibration:
             # Calibration file exists, ask user whether to use it or run new calibration
             user_input = input(
@@ -128,15 +180,14 @@ class SOFollower(Robot):
         homing_offsets = self.bus.set_half_turn_homings()
 
         # Attempt to call record_ranges_of_motion with a reduced motor set when appropriate.
-        full_turn_motor = "wrist_roll"
-        unknown_range_motors = [motor for motor in self.bus.motors if motor != full_turn_motor]
+        unknown_range_motors = [motor for motor in self.bus.motors if motor != self._full_turn_motor]
         print(
-            f"Move all joints except '{full_turn_motor}' sequentially through their "
+            f"Move all joints except '{self._full_turn_motor}' sequentially through their "
             "entire ranges of motion.\nRecording positions. Press ENTER to stop..."
         )
         range_mins, range_maxes = self.bus.record_ranges_of_motion(unknown_range_motors)
-        range_mins[full_turn_motor] = 0
-        range_maxes[full_turn_motor] = 4095
+        range_mins[self._full_turn_motor] = 0
+        range_maxes[self._full_turn_motor] = 4095
 
         self.calibration = {}
         for motor, m in self.bus.motors.items():

--- a/src/lerobot/scripts/lerobot_calibrate.py
+++ b/src/lerobot/scripts/lerobot_calibrate.py
@@ -70,10 +70,15 @@ from lerobot.utils.utils import init_logging
 class CalibrateConfig:
     teleop: TeleoperatorConfig | None = None
     robot: RobotConfig | None = None
+    motors: list[str] | None = None
 
     def __post_init__(self):
         if bool(self.teleop) == bool(self.robot):
             raise ValueError("Choose either a teleop or a robot.")
+        if self.motors is not None and len(self.motors) == 0:
+            raise ValueError(
+                "--motors flag is provided but the list is empty. Remove it or provide at least one motor name."
+            )
 
         self.device = self.robot if self.robot else self.teleop
 
@@ -91,7 +96,7 @@ def calibrate(cfg: CalibrateConfig):
     device.connect(calibrate=False)
 
     try:
-        device.calibrate()
+        device.calibrate(motors=cfg.motors)
     finally:
         device.disconnect()
 

--- a/src/lerobot/scripts/lerobot_calibrate.py
+++ b/src/lerobot/scripts/lerobot_calibrate.py
@@ -19,15 +19,27 @@ Requires: pip install 'lerobot[hardware]'
 
 Example:
 
+Default: calibrate all the motors sequentially
 ```shell
 lerobot-calibrate \
     --teleop.type=so100_leader \
     --teleop.port=/dev/tty.usbmodem58760431551 \
     --teleop.id=blue
 ```
+
+Optional: calibrate specific motors by passing a list of motor names (e.g. "shoulder_pan", "shoulder_lift", "elbow_flex", "wrist_flex", "wrist_roll", "gripper")
+Use the flag `--motors` to specify a comma-separated list of motor names to calibrate. This is useful when you have to recalibrate a specific motor and don't want to redo the calibration for the other motors.
+```shell
+lerobot-calibrate \
+    --teleop.type=so101_leader \
+    --teleop.port=/dev/tty.usbmodem58760431551 \
+    --teleop.id=test \
+    --motors=shoulder_pan,elbow_flex
+```
 """
 
 import logging
+import re
 from dataclasses import asdict, dataclass
 from pprint import pformat
 
@@ -70,15 +82,23 @@ from lerobot.utils.utils import init_logging
 class CalibrateConfig:
     teleop: TeleoperatorConfig | None = None
     robot: RobotConfig | None = None
-    motors: list[str] | None = None
+    motors: str | None = None  # comma-separated list of motors to calibrate, e.g. "shoulder_pan,elbow_flex"
 
     def __post_init__(self):
         if bool(self.teleop) == bool(self.robot):
             raise ValueError("Choose either a teleop or a robot.")
-        if self.motors is not None and len(self.motors) == 0:
-            raise ValueError(
-                "--motors flag is provided but the list is empty. Remove it or provide at least one motor name."
-            )
+        self.motors_list: list[str] | None = None
+        if self.motors is not None:
+            if not re.fullmatch(r"[\w ,]+", self.motors):
+                raise ValueError(
+                    f"Invalid characters in --motors='{self.motors}'. "
+                    "Use comma-separated names (letters, digits, underscores), e.g. shoulder_pan,elbow_flex"
+                )
+            self.motors_list = [m.strip() for m in self.motors.split(",") if m.strip()]
+            if not self.motors_list:
+                raise ValueError(
+                    "--motors flag is provided but the list is empty. Remove it or provide at least one motor name."
+                )
 
         self.device = self.robot if self.robot else self.teleop
 
@@ -96,7 +116,7 @@ def calibrate(cfg: CalibrateConfig):
     device.connect(calibrate=False)
 
     try:
-        device.calibrate(motors=cfg.motors)
+        device.calibrate(motors=cfg.motors_list)
     finally:
         device.disconnect()
 

--- a/src/lerobot/scripts/lerobot_setup_motors.py
+++ b/src/lerobot/scripts/lerobot_setup_motors.py
@@ -30,12 +30,13 @@ This is useful when you have to replace a motor and don't want to redo the setup
 
 ```shell
 lerobot-setup-motors \
-    --teleop.type=so100_leader \
+    --teleop.type=so101_leader \
     --teleop.port=/dev/tty.usbmodem575E0031751 \
-    --motors=[shoulder_pan,elbow_flex]
+    --motors=shoulder_pan,elbow_flex
 ```
 """
 
+import re
 from dataclasses import dataclass
 
 import draccus
@@ -77,15 +78,25 @@ COMPATIBLE_DEVICES = [
 class SetupConfig:
     teleop: TeleoperatorConfig | None = None
     robot: RobotConfig | None = None
-    motors: list[str] | None = None
+    motors: str | None = (
+        None  # comma-separated list of motor names to set up, e.g. "shoulder_pan,elbow_flex". If not provided, all motors will be set up.
+    )
 
     def __post_init__(self):
         if bool(self.teleop) == bool(self.robot):
             raise ValueError("Choose either a teleop or a robot.")
-        if self.motors is not None and len(self.motors) == 0:
-            raise ValueError(
-                "--motors flag is provided but the list is empty. Remove it or provide at least one motor name."
-            )
+        self.motors_list: list[str] | None = None
+        if self.motors is not None:
+            if not re.fullmatch(r"[\w ,]+", self.motors):
+                raise ValueError(
+                    f"Invalid characters in --motors='{self.motors}'. "
+                    "Use comma-separated names (letters, digits, underscores), e.g. shoulder_pan,elbow_flex"
+                )
+            self.motors_list = [m.strip() for m in self.motors.split(",") if m.strip()]
+            if not self.motors_list:
+                raise ValueError(
+                    "--motors flag is provided but the list is empty. Remove it or provide at least one motor name."
+                )
 
         self.device = self.robot if self.robot else self.teleop
 
@@ -100,7 +111,7 @@ def setup_motors(cfg: SetupConfig):
     else:
         device = make_teleoperator_from_config(cfg.device)
 
-    device.setup_motors(motors=cfg.motors)
+    device.setup_motors(motors=cfg.motors_list)
 
 
 def main():

--- a/src/lerobot/scripts/lerobot_setup_motors.py
+++ b/src/lerobot/scripts/lerobot_setup_motors.py
@@ -17,10 +17,22 @@ Helper to set motor ids and baudrate.
 
 Example:
 
+Default: setup all the motors sequentially
+
 ```shell
 lerobot-setup-motors \
     --teleop.type=so100_leader \
     --teleop.port=/dev/tty.usbmodem575E0031751
+```
+
+Optional: setup specific motors by passing a list of motor names (e.g. "shoulder_pan", "shoulder_lift", "elbow_flex", "wrist_flex", "wrist_pan", "gripper")
+This is useful when you have to replace a motor and don't want to redo the setup for the existing motors.
+
+```shell
+lerobot-setup-motors \
+    --teleop.type=so100_leader \
+    --teleop.port=/dev/tty.usbmodem575E0031751 \
+    --motors=[shoulder_pan,elbow_flex]
 ```
 """
 
@@ -65,10 +77,15 @@ COMPATIBLE_DEVICES = [
 class SetupConfig:
     teleop: TeleoperatorConfig | None = None
     robot: RobotConfig | None = None
+    motors: list[str] | None = None
 
     def __post_init__(self):
         if bool(self.teleop) == bool(self.robot):
             raise ValueError("Choose either a teleop or a robot.")
+        if self.motors is not None and len(self.motors) == 0:
+            raise ValueError(
+                "--motors flag is provided but the list is empty. Remove it or provide at least one motor name."
+            )
 
         self.device = self.robot if self.robot else self.teleop
 
@@ -83,7 +100,7 @@ def setup_motors(cfg: SetupConfig):
     else:
         device = make_teleoperator_from_config(cfg.device)
 
-    device.setup_motors()
+    device.setup_motors(motors=cfg.motors)
 
 
 def main():

--- a/src/lerobot/teleoperators/so_leader/so_leader.py
+++ b/src/lerobot/teleoperators/so_leader/so_leader.py
@@ -1,4 +1,4 @@
-# !/usr/bin/env python
+#!/usr/bin/env python
 
 # Copyright 2026 The HuggingFace Inc. team. All rights reserved.
 #
@@ -130,8 +130,19 @@ class SOLeader(Teleoperator):
         for motor in self.bus.motors:
             self.bus.write("Operating_Mode", motor, OperatingMode.POSITION.value)
 
-    def setup_motors(self) -> None:
-        for motor in reversed(self.bus.motors):
+    def setup_motors(self, motors: list[str] | None = None) -> None:
+        motors_to_setup: dict[str, Motor] = self.bus.motors
+
+        if motors is not None:
+            motors_to_setup = {}
+            for motor in motors:
+                if motor not in self.bus.motors:
+                    raise ValueError(
+                        f"Motor '{motor}' not found in the bus. Available motors: {list(self.bus.motors.keys())}"
+                    )
+                motors_to_setup[motor] = self.bus.motors[motor]
+
+        for motor in reversed(motors_to_setup):
             input(f"Connect the controller board to the '{motor}' motor only and press enter.")
             self.bus.setup_motor(motor)
             print(f"'{motor}' motor id set to {self.bus.motors[motor].id}")

--- a/src/lerobot/teleoperators/so_leader/so_leader.py
+++ b/src/lerobot/teleoperators/so_leader/so_leader.py
@@ -100,6 +100,9 @@ class SOLeader(Teleoperator):
             self.bus.write("Operating_Mode", motor, OperatingMode.POSITION.value)
 
         # calibrate motors one by one
+        print(
+            "Calibration of selected motors will be done sequentially. During calibration, all the motors will have their torque disabled and can be moved freely, but only the specified motor will be calibrated.\n"
+        )
         for motor, m in motors_to_calibrate.items():
             input(f"Move {motor} to the middle of its range of motion and press ENTER....")
             homing_offset = self.bus.set_half_turn_homings([motor])[motor]

--- a/src/lerobot/teleoperators/so_leader/so_leader.py
+++ b/src/lerobot/teleoperators/so_leader/so_leader.py
@@ -35,6 +35,7 @@ class SOLeader(Teleoperator):
 
     config_class = SOLeaderTeleopConfig
     name = "so_leader"
+    _full_turn_motor = "wrist_roll"
 
     def __init__(self, config: SOLeaderTeleopConfig):
         super().__init__(config)
@@ -81,7 +82,55 @@ class SOLeader(Teleoperator):
     def is_calibrated(self) -> bool:
         return self.bus.is_calibrated
 
-    def calibrate(self) -> None:
+    def _calibrate_partial(self, motors: list[str]) -> None:
+        if not self.calibration:
+            raise ValueError(
+                "No existing calibration found. Run full calibration first before calibrating specific motors."
+            )
+
+        motors_to_calibrate: dict[str, Motor] = {}
+        logger.info(f"\nRunning partial calibration of {self} for motors: {set(motors)}")
+        self.bus.disable_torque()
+        for motor in motors:
+            if motor not in self.bus.motors:
+                raise ValueError(
+                    f"Motor '{motor}' not found in the bus. Available motors: {list(self.bus.motors.keys())}"
+                )
+            motors_to_calibrate[motor] = self.bus.motors[motor]
+            self.bus.write("Operating_Mode", motor, OperatingMode.POSITION.value)
+
+        # calibrate motors one by one
+        for motor, m in motors_to_calibrate.items():
+            input(f"Move {motor} to the middle of its range of motion and press ENTER....")
+            homing_offset = self.bus.set_half_turn_homings([motor])[motor]
+            if motor == self._full_turn_motor:
+                range_min_val, range_max_val = 0, 4095
+                input(
+                    f"'{motor}' is set as the full turn motor with a fixed range of [0, 4095]. Homing offset was recorded but no further calibration is needed. Press ENTER to continue..."
+                )
+            else:
+                input(
+                    f"Move {motor} through its entire range of motion (calibration of other motors won't be affected).\nRecording positions. Press ENTER to stop..."
+                )
+                range_mins, range_maxs = self.bus.record_ranges_of_motion([motor])
+                range_min_val, range_max_val = range_mins[motor], range_maxs[motor]
+            self.calibration[motor] = MotorCalibration(
+                id=m.id,
+                drive_mode=0,
+                homing_offset=homing_offset,
+                range_min=range_min_val,
+                range_max=range_max_val,
+            )
+
+        self.bus.write_calibration(self.calibration)
+        self._save_calibration()
+        print(f"Calibration saved to {self.calibration_fpath}")
+
+    def calibrate(self, motors: list[str] | None = None) -> None:
+        if motors is not None:
+            self._calibrate_partial(motors=motors)
+            return
+
         if self.calibration:
             # Calibration file exists, ask user whether to use it or run new calibration
             user_input = input(
@@ -100,15 +149,14 @@ class SOLeader(Teleoperator):
         input(f"Move {self} to the middle of its range of motion and press ENTER....")
         homing_offsets = self.bus.set_half_turn_homings()
 
-        full_turn_motor = "wrist_roll"
-        unknown_range_motors = [motor for motor in self.bus.motors if motor != full_turn_motor]
+        unknown_range_motors = [motor for motor in self.bus.motors if motor != self._full_turn_motor]
         print(
-            f"Move all joints except '{full_turn_motor}' sequentially through their "
+            f"Move all joints except '{self._full_turn_motor}' sequentially through their "
             "entire ranges of motion.\nRecording positions. Press ENTER to stop..."
         )
         range_mins, range_maxes = self.bus.record_ranges_of_motion(unknown_range_motors)
-        range_mins[full_turn_motor] = 0
-        range_maxes[full_turn_motor] = 4095
+        range_mins[self._full_turn_motor] = 0
+        range_maxes[self._full_turn_motor] = 4095
 
         self.calibration = {}
         for motor, m in self.bus.motors.items():

--- a/src/lerobot/teleoperators/so_leader/so_leader.py
+++ b/src/lerobot/teleoperators/so_leader/so_leader.py
@@ -22,6 +22,7 @@ from lerobot.motors.feetech import (
     FeetechMotorsBus,
     OperatingMode,
 )
+from lerobot.motors.feetech.calibration import calibrate_partial
 from lerobot.utils.decorators import check_if_already_connected, check_if_not_connected
 
 from ..teleoperator import Teleoperator
@@ -35,7 +36,6 @@ class SOLeader(Teleoperator):
 
     config_class = SOLeaderTeleopConfig
     name = "so_leader"
-    _full_turn_motor = "wrist_roll"
 
     def __init__(self, config: SOLeaderTeleopConfig):
         super().__init__(config)
@@ -82,57 +82,30 @@ class SOLeader(Teleoperator):
     def is_calibrated(self) -> bool:
         return self.bus.is_calibrated
 
-    def _calibrate_partial(self, motors: list[str]) -> None:
-        if not self.calibration:
-            raise ValueError(
-                "No existing calibration found. Run full calibration first before calibrating specific motors."
-            )
-
-        motors_to_calibrate: dict[str, Motor] = {}
-        logger.info(f"\nRunning partial calibration of {self} for motors: {set(motors)}")
-        self.bus.disable_torque()
-        for motor in motors:
-            if motor not in self.bus.motors:
-                raise ValueError(
-                    f"Motor '{motor}' not found in the bus. Available motors: {list(self.bus.motors.keys())}"
-                )
-            motors_to_calibrate[motor] = self.bus.motors[motor]
-            self.bus.write("Operating_Mode", motor, OperatingMode.POSITION.value)
-
-        # calibrate motors one by one
-        print(
-            "Calibration of selected motors will be done sequentially. During calibration, all the motors will have their torque disabled and can be moved freely, but only the specified motor will be calibrated.\n"
-        )
-        for motor, m in motors_to_calibrate.items():
-            input(f"Move {motor} to the middle of its range of motion and press ENTER....")
-            homing_offset = self.bus.set_half_turn_homings([motor])[motor]
-            if motor == self._full_turn_motor:
-                range_min_val, range_max_val = 0, 4095
-                input(
-                    f"'{motor}' is set as the full turn motor with a fixed range of [0, 4095]. Homing offset was recorded but no further calibration is needed. Press ENTER to continue..."
-                )
-            else:
-                input(
-                    f"Move {motor} through its entire range of motion (calibration of other motors won't be affected).\nRecording positions. Press ENTER to stop..."
-                )
-                range_mins, range_maxs = self.bus.record_ranges_of_motion([motor])
-                range_min_val, range_max_val = range_mins[motor], range_maxs[motor]
-            self.calibration[motor] = MotorCalibration(
-                id=m.id,
-                drive_mode=0,
-                homing_offset=homing_offset,
-                range_min=range_min_val,
-                range_max=range_max_val,
-            )
-
-        self.bus.write_calibration(self.calibration)
-        self._save_calibration()
-        print(f"Calibration saved to {self.calibration_fpath}")
-
     def calibrate(self, motors: list[str] | None = None) -> None:
+        full_turn_motor = "wrist_roll"
         if motors is not None:
-            self._calibrate_partial(motors=motors)
-            return
+            try:
+                new_calibration = calibrate_partial(
+                    bus=self.bus,
+                    existing_calibration=self.calibration,
+                    motors=motors,
+                    device_name=str(self),
+                    full_turn_motors={full_turn_motor},
+                )
+                self.calibration = new_calibration
+                self.bus.write_calibration(self.calibration)
+                self._save_calibration()
+                print(f"Partial calibration of motors {set(motors)} saved to {self.calibration_fpath}")
+                return
+            except Exception:
+                logger.exception(
+                    "Error occurred during partial calibration. Your previous calibration has been restored."
+                )
+                # Restore the original homing offsets of the motors that may have been modified during
+                # calibration before the error occurred.
+                self.bus.write_calibration(self.calibration)
+                raise
 
         if self.calibration:
             # Calibration file exists, ask user whether to use it or run new calibration
@@ -152,14 +125,14 @@ class SOLeader(Teleoperator):
         input(f"Move {self} to the middle of its range of motion and press ENTER....")
         homing_offsets = self.bus.set_half_turn_homings()
 
-        unknown_range_motors = [motor for motor in self.bus.motors if motor != self._full_turn_motor]
+        unknown_range_motors = [motor for motor in self.bus.motors if motor != full_turn_motor]
         print(
-            f"Move all joints except '{self._full_turn_motor}' sequentially through their "
+            f"Move all joints except '{full_turn_motor}' sequentially through their "
             "entire ranges of motion.\nRecording positions. Press ENTER to stop..."
         )
         range_mins, range_maxes = self.bus.record_ranges_of_motion(unknown_range_motors)
-        range_mins[self._full_turn_motor] = 0
-        range_maxes[self._full_turn_motor] = 4095
+        range_mins[full_turn_motor] = 0
+        range_maxes[full_turn_motor] = 4095
 
         self.calibration = {}
         for motor, m in self.bus.motors.items():

--- a/tests/motors/test_calibration.py
+++ b/tests/motors/test_calibration.py
@@ -14,59 +14,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from contextlib import contextmanager
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
-from lerobot.motors import MotorCalibration
-from lerobot.robots.so_follower import SO101Follower, SO101FollowerConfig
+from lerobot.motors import Motor, MotorCalibration
+from lerobot.motors.feetech.calibration import calibrate_partial
 
 
 def _make_bus_mock() -> MagicMock:
-    """Return a bus mock with just the attributes used by the robot."""
     bus = MagicMock(name="FeetechBusMock")
-    bus.is_connected = False
-
-    def _connect():
-        bus.is_connected = True
-
-    def _disconnect(_disable=True):
-        bus.is_connected = False
-
-    bus.connect.side_effect = _connect
-    bus.disconnect.side_effect = _disconnect
-
-    @contextmanager
-    def _dummy_cm():
-        yield
-
-    bus.torque_disabled.side_effect = _dummy_cm
-
+    bus.motors = {
+        name: Motor(i, "sts3215", None)
+        for i, name in enumerate(
+            ["shoulder_pan", "shoulder_lift", "elbow_flex", "wrist_flex", "wrist_roll", "gripper"], 1
+        )
+    }
     return bus
-
-
-@pytest.fixture
-def follower():
-    bus_mock = _make_bus_mock()
-
-    def _bus_side_effect(*_args, **kwargs):
-        bus_mock.motors = kwargs["motors"]
-        bus_mock.is_calibrated = True
-        return bus_mock
-
-    with (
-        patch(
-            "lerobot.robots.so_follower.so_follower.FeetechMotorsBus",
-            side_effect=_bus_side_effect,
-        ),
-        patch.object(SO101Follower, "configure", lambda self: None),
-    ):
-        cfg = SO101FollowerConfig(port="/dev/null")
-        robot = SO101Follower(cfg)
-        yield robot
-        if robot.is_connected:
-            robot.disconnect()
 
 
 def _stub_calibration() -> dict[str, MotorCalibration]:
@@ -86,17 +50,24 @@ def verify_calibration_values(
         assert calibration[motor].range_max == expected_range_max, f"{motor} range_max mismatch"
 
 
-def test_partial_calibration_merges_only_targeted(follower, monkeypatch):
+def test_partial_calibration_merges_only_targeted(monkeypatch):
     monkeypatch.setattr("builtins.input", lambda *_: "")
-    follower.calibration = _stub_calibration()
-    follower.bus.set_half_turn_homings.return_value = {"shoulder_pan": 900}
-    follower.bus.record_ranges_of_motion.return_value = ({"shoulder_pan": 50}, {"shoulder_pan": 3500})
+    bus = _make_bus_mock()
+    bus.set_half_turn_homings.return_value = {"shoulder_pan": 900}
+    bus.record_ranges_of_motion.return_value = ({"shoulder_pan": 50}, {"shoulder_pan": 3500})
+    existing_calibration = _stub_calibration()
 
-    follower.calibrate(motors=["shoulder_pan"])
+    result = calibrate_partial(
+        bus=bus,
+        existing_calibration=existing_calibration,
+        motors=["shoulder_pan"],
+        device_name="test_device",
+        full_turn_motors={"wrist_roll"},
+    )
 
     # the shoulder_pan should be updated, while the other motors should remain unchanged
     verify_calibration_values(
-        follower.calibration,
+        result,
         {
             "shoulder_pan": (50, 900, 3500),
             "shoulder_lift": (10, 100, 4000),
@@ -108,20 +79,27 @@ def test_partial_calibration_merges_only_targeted(follower, monkeypatch):
     )
 
 
-def test_partial_calibration_multiple_motors_merges_only_targeted(follower, monkeypatch):
+def test_partial_calibration_multiple_motors_merges_only_targeted(monkeypatch):
     monkeypatch.setattr("builtins.input", lambda *_: "")
-    follower.calibration = _stub_calibration()
-    follower.bus.set_half_turn_homings.return_value = {"shoulder_pan": 900, "elbow_flex": 800}
-    follower.bus.record_ranges_of_motion.return_value = (
+    bus = _make_bus_mock()
+    bus.set_half_turn_homings.return_value = {"shoulder_pan": 900, "elbow_flex": 800}
+    bus.record_ranges_of_motion.return_value = (
         {"shoulder_pan": 50, "elbow_flex": 60},
         {"shoulder_pan": 3500, "elbow_flex": 3600},
     )
+    existing_calibration = _stub_calibration()
 
-    follower.calibrate(motors=["shoulder_pan", "elbow_flex"])
+    result = calibrate_partial(
+        bus=bus,
+        existing_calibration=existing_calibration,
+        motors=["shoulder_pan", "elbow_flex"],
+        device_name="test_device",
+        full_turn_motors={"wrist_roll"},
+    )
 
-    # only hsoulder_pan and elbow_flex should be updated
+    # only shoulder_pan and elbow_flex should be updated
     verify_calibration_values(
-        follower.calibration,
+        result,
         {
             "shoulder_pan": (50, 900, 3500),
             "shoulder_lift": (10, 100, 4000),
@@ -133,18 +111,25 @@ def test_partial_calibration_multiple_motors_merges_only_targeted(follower, monk
     )
 
 
-def test_partial_calibrate_full_turn_motor(follower, monkeypatch):
+def test_partial_calibrate_full_turn_motor(monkeypatch):
     monkeypatch.setattr("builtins.input", lambda *_: "")
-    follower.calibration = _stub_calibration()
-    follower.bus.set_half_turn_homings.return_value = {"wrist_roll": 777}
+    bus = _make_bus_mock()
+    bus.set_half_turn_homings.return_value = {"wrist_roll": 777}
+    existing_calibration = _stub_calibration()
 
-    follower.calibrate(motors=["wrist_roll"])
+    result = calibrate_partial(
+        bus=bus,
+        existing_calibration=existing_calibration,
+        motors=["wrist_roll"],
+        device_name="test_device",
+        full_turn_motors={"wrist_roll"},
+    )
 
-    follower.bus.record_ranges_of_motion.assert_not_called()
+    bus.record_ranges_of_motion.assert_not_called()
 
     # the wrist_roll homing offset should be updated, but the range should remain unchanged [0, 4095]
     verify_calibration_values(
-        follower.calibration,
+        result,
         {
             "shoulder_pan": (10, 100, 4000),
             "shoulder_lift": (10, 100, 4000),
@@ -156,15 +141,29 @@ def test_partial_calibrate_full_turn_motor(follower, monkeypatch):
     )
 
 
-def test_partial_calibration_requires_existing_calibration(follower, monkeypatch):
+def test_partial_calibration_requires_existing_calibration(monkeypatch):
     monkeypatch.setattr("builtins.input", lambda *_: "")
-    follower.calibration = {}
+    bus = _make_bus_mock()
+    existing_calibration = _stub_calibration()
     with pytest.raises(ValueError):
-        follower.calibrate(motors=["shoulder_pan"])
+        calibrate_partial(
+            bus=bus,
+            existing_calibration=existing_calibration,
+            motors=["shoulder_pan"],
+            device_name="test_device",
+            full_turn_motors={"wrist_roll"},
+        )
 
 
-def test_partial_calibration_unknown_motor(follower, monkeypatch):
+def test_partial_calibration_unknown_motor(monkeypatch):
     monkeypatch.setattr("builtins.input", lambda *_: "")
-    follower.calibration = _stub_calibration()
+    bus = _make_bus_mock()
+    existing_calibration = _stub_calibration()
     with pytest.raises(ValueError):
-        follower.calibrate(motors=["joint_x"])
+        calibrate_partial(
+            bus=bus,
+            existing_calibration=existing_calibration,
+            motors=["joint_x"],
+            device_name="test_device",
+            full_turn_motors={"wrist_roll"},
+        )

--- a/tests/robots/test_so101_follower.py
+++ b/tests/robots/test_so101_follower.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python
+
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from contextlib import contextmanager
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from lerobot.motors import MotorCalibration
+from lerobot.robots.so_follower import SO101Follower, SO101FollowerConfig
+
+
+def _make_bus_mock() -> MagicMock:
+    """Return a bus mock with just the attributes used by the robot."""
+    bus = MagicMock(name="FeetechBusMock")
+    bus.is_connected = False
+
+    def _connect():
+        bus.is_connected = True
+
+    def _disconnect(_disable=True):
+        bus.is_connected = False
+
+    bus.connect.side_effect = _connect
+    bus.disconnect.side_effect = _disconnect
+
+    @contextmanager
+    def _dummy_cm():
+        yield
+
+    bus.torque_disabled.side_effect = _dummy_cm
+
+    return bus
+
+
+@pytest.fixture
+def follower():
+    bus_mock = _make_bus_mock()
+
+    def _bus_side_effect(*_args, **kwargs):
+        bus_mock.motors = kwargs["motors"]
+        bus_mock.is_calibrated = True
+        return bus_mock
+
+    with (
+        patch(
+            "lerobot.robots.so_follower.so_follower.FeetechMotorsBus",
+            side_effect=_bus_side_effect,
+        ),
+        patch.object(SO101Follower, "configure", lambda self: None),
+    ):
+        cfg = SO101FollowerConfig(port="/dev/null")
+        robot = SO101Follower(cfg)
+        yield robot
+        if robot.is_connected:
+            robot.disconnect()
+
+
+def _stub_calibration() -> dict[str, MotorCalibration]:
+    names = ["shoulder_pan", "shoulder_lift", "elbow_flex", "wrist_flex", "wrist_roll", "gripper"]
+    return {
+        name: MotorCalibration(id=i, drive_mode=0, homing_offset=100, range_min=10, range_max=4000)
+        for i, name in enumerate(names, 1)
+    }
+
+
+def verify_calibration_values(
+    calibration: dict[str, MotorCalibration], expected_values: dict[str, tuple[int, int, int]]
+):
+    for motor, (expected_range_min, expected_homing_offset, expected_range_max) in expected_values.items():
+        assert calibration[motor].range_min == expected_range_min, f"{motor} range_min mismatch"
+        assert calibration[motor].homing_offset == expected_homing_offset, f"{motor} homing_offset mismatch"
+        assert calibration[motor].range_max == expected_range_max, f"{motor} range_max mismatch"
+
+
+def test_partial_calibration_merges_only_targeted(follower, monkeypatch):
+    monkeypatch.setattr("builtins.input", lambda *_: "")
+    follower.calibration = _stub_calibration()
+    follower.bus.set_half_turn_homings.return_value = {"shoulder_pan": 900}
+    follower.bus.record_ranges_of_motion.return_value = ({"shoulder_pan": 50}, {"shoulder_pan": 3500})
+
+    follower.calibrate(motors=["shoulder_pan"])
+
+    # the shoulder_pan should be updated, while the other motors should remain unchanged
+    verify_calibration_values(
+        follower.calibration,
+        {
+            "shoulder_pan": (50, 900, 3500),
+            "shoulder_lift": (10, 100, 4000),
+            "elbow_flex": (10, 100, 4000),
+            "wrist_flex": (10, 100, 4000),
+            "wrist_roll": (10, 100, 4000),
+            "gripper": (10, 100, 4000),
+        },
+    )
+
+
+def test_partial_calibration_multiple_motors_merges_only_targeted(follower, monkeypatch):
+    monkeypatch.setattr("builtins.input", lambda *_: "")
+    follower.calibration = _stub_calibration()
+    follower.bus.set_half_turn_homings.return_value = {"shoulder_pan": 900, "elbow_flex": 800}
+    follower.bus.record_ranges_of_motion.return_value = (
+        {"shoulder_pan": 50, "elbow_flex": 60},
+        {"shoulder_pan": 3500, "elbow_flex": 3600},
+    )
+
+    follower.calibrate(motors=["shoulder_pan", "elbow_flex"])
+
+    # only hsoulder_pan and elbow_flex should be updated
+    verify_calibration_values(
+        follower.calibration,
+        {
+            "shoulder_pan": (50, 900, 3500),
+            "shoulder_lift": (10, 100, 4000),
+            "elbow_flex": (60, 800, 3600),
+            "wrist_flex": (10, 100, 4000),
+            "wrist_roll": (10, 100, 4000),
+            "gripper": (10, 100, 4000),
+        },
+    )
+
+
+def test_partial_calibrate_full_turn_motor(follower, monkeypatch):
+    monkeypatch.setattr("builtins.input", lambda *_: "")
+    follower.calibration = _stub_calibration()
+    follower.bus.set_half_turn_homings.return_value = {"wrist_roll": 777}
+
+    follower.calibrate(motors=["wrist_roll"])
+
+    follower.bus.record_ranges_of_motion.assert_not_called()
+
+    # the wrist_roll homing offset should be updated, but the range should remain unchanged [0, 4095]
+    verify_calibration_values(
+        follower.calibration,
+        {
+            "shoulder_pan": (10, 100, 4000),
+            "shoulder_lift": (10, 100, 4000),
+            "elbow_flex": (10, 100, 4000),
+            "wrist_flex": (10, 100, 4000),
+            "wrist_roll": (0, 777, 4095),
+            "gripper": (10, 100, 4000),
+        },
+    )
+
+
+def test_partial_calibration_requires_existing_calibration(follower, monkeypatch):
+    monkeypatch.setattr("builtins.input", lambda *_: "")
+    follower.calibration = {}
+    with pytest.raises(ValueError):
+        follower.calibrate(motors=["shoulder_pan"])
+
+
+def test_partial_calibration_unknown_motor(follower, monkeypatch):
+    monkeypatch.setattr("builtins.input", lambda *_: "")
+    follower.calibration = _stub_calibration()
+    with pytest.raises(ValueError):
+        follower.calibrate(motors=["joint_x"])


### PR DESCRIPTION
## Summary / Motivation

Adds a --motors flag that acceps a comma separated list of motor names to lerobot-setup-motors and lerobot-calibrate modules so users can recalibrate or re-register a single motor (or a subset) without redoing the full sequence. Useful when replacing a single servo or correcting drift on one joint without disturbing the rest of the calibration.

Examples:
```
lerobot-calibrate \
    --teleop.type=so101_leader \
    --teleop.port=/dev/tty.usbmodem58760431551 \
    --teleop.id=test \
    --motors=shoulder_pan,elbow_flex      <-- new
```

```
lerobot-setup-motors \
    --teleop.type=so101_leader \
    --teleop.port=/dev/tty.usbmodem58760431551 \
    --motors=shoulder_pan,elbow_flex      <-- new
```

## What changed

1. New calibrate_partial helper in src/lerobot/motors/feetech/calibration.py that takes a list of motor names and merges new homing offsets / ranges into the existing calibration dict. 
2. so_leader.calibrate(motors=...) and so_follower.calibrate(motors=...) dispatch to the helper for partial calibration mode; full path unchanged.
3. so_leader.setup_motors(motors=...) and so_followre.setup_motors(motors=...) accept a subset of motors to setup.
4. CLI: --motors=shoulder_pan,elbow_flex (comma-separated string for shell-friendliness; rejects invalid characters via regex).
5. Full-turn motors (e.g. wrist_roll) still receive a homing offset but skip ROM recording.
6. On failure mid-flight, motor registers are restored to the previous calibration; in-memory and on-disk state untouched.
7. No breaking changes: motors kwarg defaults to None.

## How was this tested (or how to run locally)

* ran `pytest tests/motors/test_calibration.py -v`
* ran `pre-commit run --all-files `
* tested both scripts locally on my own robots:
    * lerobot-setup-motors: replaced one of the servos with another one and was able to register it individually.
    * lerobot-calibrate: ran the script on different subset of servos and recorded their new calibrations; verified that the only the selected motors' calibration values changed; verified that the full_turn_motor ("wrist_roll") was skipped during calibration as expected in the original flow.
* verified that the old flow still works: ran the scripts without passing the new flag

## Checklist (required before merge)

- [X] Linting/formatting run (`pre-commit run -a`)
- [X] All tests pass locally (`pytest`)
- [X] Documentation updated
- [x] Community Review: I have reviewed another contributor's open PR and linked it here: #3456
- [ ] CI is green

## Reviewer notes

* Regarding point (1) in the "what changed" section: at first I followed the existing structure by adding the same partial calibration function to both the follower and leader files separately. But then decided to just create a new file 'calibration.py' under motors/feetech and created the partial calibration as a shared method. The obvious reasons are to reduce redundancy in both the main files and the tests and improve maintainability. However if there are good reasons why we should keep separate methods in both the so_leader.py and so_follower.py, I can change that. But if this approach is accepted, then maybe we should consider moving more of the calibration logic to the new 'calibration.py' file.

* While the partial calibration function is generic and can be used for any feetech-based robot, I only integrated it into the so101 follower and leader files. If this diff is accepted and merged, I will extend it to the other robot files.