### PR TITLE
fix(train): skip EpisodeAwareSampler for streaming datasets

### DIFF
--- a/src/lerobot/scripts/lerobot_train.py
+++ b/src/lerobot/scripts/lerobot_train.py
@@ -383,7 +383,8 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
         logging.info(f"{num_total_params=} ({format_big_number(num_total_params)})")
 
     # create dataloader for offline training
-    if hasattr(active_cfg, "drop_n_last_frames"):
+    is_streaming = isinstance(dataset, torch.utils.data.IterableDataset)
+    if hasattr(active_cfg, "drop_n_last_frames") and not is_streaming:
         shuffle = False
         sampler = EpisodeAwareSampler(
             dataset.meta.episodes["dataset_from_index"],
@@ -393,6 +394,12 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
             shuffle=True,
         )
     else:
+        if hasattr(active_cfg, "drop_n_last_frames") and is_streaming:
+            logging.warning(
+                "EpisodeAwareSampler is not compatible with streaming datasets. "
+                "Training will proceed without drop_n_last_frames filtering. "
+                "End-of-episode samples may be included in the training data."
+            )
         shuffle = True
         sampler = None
 
@@ -400,7 +407,7 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
         dataset,
         num_workers=cfg.num_workers,
         batch_size=cfg.batch_size,
-        shuffle=shuffle and not cfg.dataset.streaming,
+        shuffle=shuffle and not is_streaming,
         sampler=sampler,
         pin_memory=device.type == "cuda",
         drop_last=False,


### PR DESCRIPTION
## Summary

Training with `--dataset.streaming=true` and a policy that uses `drop_n_last_frames` (e.g. SARM) crashes with `ValueError: DataLoader with IterableDataset: expected unspecified sampler option`.

Fix: detect `IterableDataset` and skip the `EpisodeAwareSampler`, with a warning that end-of-episode filtering is not available in streaming mode.

## Test plan

- [ ] `lerobot-train --dataset.streaming=true --policy.type=sarm` no longer crashes
- [ ] Non-streaming training with SARM still uses `EpisodeAwareSampler` as before
- [ ] Other policies unaffected

Fixes #3436.