### PR TITLE
feat(diffusion): add gradient checkpointing for memory optimization

### DIFF
--- a/src/lerobot/policies/diffusion/configuration_diffusion.py
+++ b/src/lerobot/policies/diffusion/configuration_diffusion.py
@@ -132,6 +132,7 @@ class DiffusionConfig(PreTrainedConfig):
     n_groups: int = 8
     diffusion_step_embed_dim: int = 128
     use_film_scale_modulation: bool = True
+    gradient_checkpointing: bool = False
     # Noise scheduler.
     noise_scheduler_type: str = "DDPM"
     num_train_timesteps: int = 100

--- a/src/lerobot/policies/diffusion/modeling_diffusion.py
+++ b/src/lerobot/policies/diffusion/modeling_diffusion.py
@@ -715,22 +715,35 @@ class DiffusionConditionalUnet1d(nn.Module):
         else:
             global_feature = timesteps_embed
 
+        use_gc = self.config.gradient_checkpointing and self.training
+
         # Run encoder, keeping track of skip features to pass to the decoder.
         encoder_skip_features: list[Tensor] = []
         for resnet, resnet2, downsample in self.down_modules:
-            x = resnet(x, global_feature)
-            x = resnet2(x, global_feature)
+            if use_gc:
+                x = torch.utils.checkpoint.checkpoint(resnet, x, global_feature, use_reentrant=False)
+                x = torch.utils.checkpoint.checkpoint(resnet2, x, global_feature, use_reentrant=False)
+            else:
+                x = resnet(x, global_feature)
+                x = resnet2(x, global_feature)
             encoder_skip_features.append(x)
             x = downsample(x)
 
         for mid_module in self.mid_modules:
-            x = mid_module(x, global_feature)
+            if use_gc:
+                x = torch.utils.checkpoint.checkpoint(mid_module, x, global_feature, use_reentrant=False)
+            else:
+                x = mid_module(x, global_feature)
 
         # Run decoder, using the skip features from the encoder.
         for resnet, resnet2, upsample in self.up_modules:
             x = torch.cat((x, encoder_skip_features.pop()), dim=1)
-            x = resnet(x, global_feature)
-            x = resnet2(x, global_feature)
+            if use_gc:
+                x = torch.utils.checkpoint.checkpoint(resnet, x, global_feature, use_reentrant=False)
+                x = torch.utils.checkpoint.checkpoint(resnet2, x, global_feature, use_reentrant=False)
+            else:
+                x = resnet(x, global_feature)
+                x = resnet2(x, global_feature)
             x = upsample(x)
 
         x = self.final_conv(x)


### PR DESCRIPTION
## Summary

Adds gradient checkpointing to DiffusionPolicy's UNet (encoder, mid, and decoder residual blocks). This trades compute for memory, allowing training with larger batch sizes or higher-resolution inputs on memory-constrained GPUs.

Currently only Pi0 and XVLA have gradient checkpointing. This extends it to DiffusionPolicy as called for in the 0.6.0 roadmap (item 3.3).

## Usage

```bash
lerobot-train \
  --policy.type=diffusion \
  --policy.gradient_checkpointing=true \
  --dataset.repo_id=lerobot/pusht
```

## What changed

- Added `gradient_checkpointing: bool = False` to `DiffusionConfig`
- Wrapped UNet encoder/mid/decoder residual blocks with `torch.utils.checkpoint.checkpoint` when enabled and training
- Uses `use_reentrant=False` for compatibility with torch.compile

## Test plan

- [ ] Training without gradient_checkpointing works as before
- [ ] Training with gradient_checkpointing=true runs without error
- [ ] Peak GPU memory is reduced with gradient_checkpointing enabled
- [ ] Training loss converges similarly with and without checkpointing

0.6.0 roadmap item 3.3.