### PR TITLE
Fix merged stats for reindexed episode_index and index

### DIFF
--- a/src/lerobot/datasets/aggregate.py
+++ b/src/lerobot/datasets/aggregate.py
@@ -20,6 +20,7 @@ import shutil
 from pathlib import Path
 
 import datasets
+import numpy as np
 import pandas as pd
 import tqdm
 
@@ -229,7 +230,89 @@ def update_meta_data(
     df["dataset_to_index"] = df["dataset_to_index"] + dst_meta.info.total_frames
     df["episode_index"] = df["episode_index"] + dst_meta.info.total_episodes
 
+    _offset_stats_columns(df, "index", dst_meta.info.total_frames)
+    _offset_stats_columns(df, "episode_index", dst_meta.info.total_episodes)
+
     return df
+
+
+def _offset_stats_columns(df: pd.DataFrame, stats_key: str, offset: int) -> None:
+    """Offset per-episode stats columns for reindexed metadata keys."""
+    if offset == 0:
+        return
+
+    prefix = f"stats/{stats_key}/"
+    for column in df.columns:
+        if not column.startswith(prefix):
+            continue
+        # count/std are invariant to affine offsets.
+        if column.endswith("/count") or column.endswith("/std"):
+            continue
+        df[column] = df[column] + offset
+
+
+def _to_numeric_array(value) -> np.ndarray:
+    """Convert parquet-loaded stats values to numeric numpy arrays."""
+    if isinstance(value, np.ndarray):
+        arr = value
+    elif isinstance(value, list | tuple):
+        arr = np.asarray(value)
+    else:
+        arr = np.asarray([value])
+
+    if arr.dtype == object:
+        def _unwrap_nested(obj):
+            if isinstance(obj, np.ndarray):
+                return _unwrap_nested(obj.tolist())
+            if isinstance(obj, list | tuple):
+                return [_unwrap_nested(x) for x in obj]
+            return obj
+
+        arr = np.asarray(_unwrap_nested(arr.tolist()), dtype=np.float64)
+
+    if arr.ndim == 0:
+        arr = arr.reshape(1)
+
+    return arr
+
+
+def _normalize_stats_value_shape(
+    feature_name: str,
+    stat_name: str,
+    value: np.ndarray,
+    features: dict[str, dict],
+) -> np.ndarray:
+    """Normalize stats value shape after parquet round-trip."""
+    feature_dtype = features.get(feature_name, {}).get("dtype")
+    if feature_dtype in {"image", "video"} and stat_name != "count":
+        if value.ndim == 1:
+            value = value.reshape(-1, 1, 1)
+        elif value.ndim == 2 and value.shape[1] == 1:
+            value = value.reshape(value.shape[0], 1, 1)
+    return value
+
+
+def _load_episode_stats_from_parquet(episodes_dir: Path, features: dict[str, dict]) -> list[dict[str, dict]]:
+    """Load per-episode stats dicts directly from merged episode metadata parquet files."""
+    episode_stats: list[dict[str, dict]] = []
+    parquet_files = sorted(episodes_dir.rglob("*.parquet"))
+    for path in parquet_files:
+        df = pd.read_parquet(path)
+        stats_columns = [col for col in df.columns if col.startswith("stats/")]
+        if not stats_columns:
+            continue
+
+        for _, row in df.iterrows():
+            per_episode: dict[str, dict] = {}
+            for col in stats_columns:
+                _, feature_name, stat_name = col.split("/", 2)
+                per_episode.setdefault(feature_name, {})
+                value = _to_numeric_array(row[col])
+                value = _normalize_stats_value_shape(feature_name, stat_name, value, features)
+                per_episode[feature_name][stat_name] = value
+            episode_stats.append(per_episode)
+
+    return episode_stats
 
 
 def aggregate_datasets(
@@ -647,5 +730,6 @@ def finalize_aggregation(aggr_meta, all_metadata):
     write_info(aggr_meta.info, aggr_meta.root)
 
     logging.info("write stats")
-    aggr_meta.stats = aggregate_stats([m.stats for m in all_metadata])
+    episode_stats = _load_episode_stats_from_parquet(aggr_meta.root / "meta" / "episodes", aggr_meta.features)
+    aggr_meta.stats = aggregate_stats(episode_stats) if episode_stats else aggregate_stats([m.stats for m in all_metadata])
     write_stats(aggr_meta.stats, aggr_meta.root)

--- a/tests/datasets/test_dataset_tools.py
+++ b/tests/datasets/test_dataset_tools.py
@@ -18,6 +18,7 @@
 from unittest.mock import patch
 
 import numpy as np
+import pandas as pd
 import pytest
 import torch
 
@@ -289,6 +290,58 @@ def test_merge_two_datasets(sample_dataset, tmp_path, empty_lerobot_dataset_fact
 
     episode_indices = sorted({int(idx.item()) for idx in merged.hf_dataset["episode_index"]})
     assert episode_indices == list(range(8))
+
+
+def test_merge_reindexes_index_stats(sample_dataset, tmp_path, empty_lerobot_dataset_factory):
+    """Test merged dataset stats stay consistent with reindexed episodes/frames."""
+    features = {
+        "action": {"dtype": "float32", "shape": (6,), "names": None},
+        "observation.state": {"dtype": "float32", "shape": (4,), "names": None},
+        "observation.images.top": {"dtype": "image", "shape": (224, 224, 3), "names": None},
+    }
+
+    dataset2 = empty_lerobot_dataset_factory(
+        root=tmp_path / "test_dataset2",
+        features=features,
+    )
+    for ep_idx in range(3):
+        for _ in range(10):
+            frame = {
+                "action": np.random.randn(6).astype(np.float32),
+                "observation.state": np.random.randn(4).astype(np.float32),
+                "observation.images.top": np.random.randint(0, 255, size=(224, 224, 3), dtype=np.uint8),
+                "task": f"task_{ep_idx % 2}",
+            }
+            dataset2.add_frame(frame)
+        dataset2.save_episode()
+    dataset2.finalize()
+
+    with (
+        patch("lerobot.datasets.dataset_metadata.get_safe_version") as mock_get_safe_version,
+        patch("lerobot.datasets.dataset_metadata.snapshot_download") as mock_snapshot_download,
+    ):
+        mock_get_safe_version.return_value = "v3.0"
+        mock_snapshot_download.return_value = str(tmp_path / "merged_dataset")
+        merged = merge_datasets(
+            [sample_dataset, dataset2],
+            output_repo_id="merged_dataset",
+            output_dir=tmp_path / "merged_dataset",
+        )
+
+    assert merged.meta.stats["episode_index"]["max"][0] == merged.meta.total_episodes - 1
+    assert merged.meta.stats["index"]["max"][0] == merged.meta.total_frames - 1
+
+    episode_meta_files = sorted((merged.root / "meta" / "episodes").glob("*/*.parquet"))
+    assert episode_meta_files
+    episode_meta = pd.concat([pd.read_parquet(path) for path in episode_meta_files], ignore_index=True)
+    episode_meta = episode_meta.sort_values("episode_index")
+
+    assert len(episode_meta) == merged.meta.total_episodes
+    assert all(episode_meta["stats/episode_index/max"].apply(lambda v: int(np.asarray(v).reshape(-1)[0])) == episode_meta["episode_index"])
+    assert all(
+        episode_meta["stats/index/max"].apply(lambda v: int(np.asarray(v).reshape(-1)[0]))
+        == episode_meta["dataset_to_index"] - 1
+    )
 
 
 def test_merge_empty_list(tmp_path):


### PR DESCRIPTION
## Summary

This fixes a metadata consistency issue in dataset merge.

During `aggregate_datasets()`, frame-level data is correctly reindexed (`episode_index`, `index`) for later source datasets, but merged metadata stats could still reflect pre-merge local ranges from source datasets.

This PR makes merged metadata consistent with merged data by:
- offsetting per-episode metadata stats for reindexed keys (`stats/episode_index/*`, `stats/index/*`) during metadata aggregation
- building final merged `meta/stats.json` from merged episode-level stats (read from merged `meta/episodes/*.parquet`) instead of directly aggregating source dataset-level stats

## Tests

Added regression test:
- `tests/datasets/test_dataset_tools.py::test_merge_reindexes_index_stats`
