### PR TITLE
Fix: apply rename_map on fresh-built processor pipelines (complete)

### DIFF
--- a/src/lerobot/policies/factory.py
+++ b/src/lerobot/policies/factory.py
@@ -356,6 +356,7 @@ def make_pre_post_processors(
         processors = make_pi0_pre_post_processors(
             config=policy_cfg,
             dataset_stats=kwargs.get("dataset_stats"),
+            rename_map=kwargs.get("rename_map"),
         )
 
     elif isinstance(policy_cfg, PI05Config):
@@ -364,6 +365,7 @@ def make_pre_post_processors(
         processors = make_pi05_pre_post_processors(
             config=policy_cfg,
             dataset_stats=kwargs.get("dataset_stats"),
+            rename_map=kwargs.get("rename_map"),
         )
 
     elif isinstance(policy_cfg, SACConfig):
@@ -380,6 +382,7 @@ def make_pre_post_processors(
         processors = make_smolvla_pre_post_processors(
             config=policy_cfg,
             dataset_stats=kwargs.get("dataset_stats"),
+            rename_map=kwargs.get("rename_map"),
         )
 
     elif isinstance(policy_cfg, GrootConfig):
@@ -398,6 +401,7 @@ def make_pre_post_processors(
         processors = make_xvla_pre_post_processors(
             config=policy_cfg,
             dataset_stats=kwargs.get("dataset_stats"),
+            rename_map=kwargs.get("rename_map"),
         )
 
     elif isinstance(policy_cfg, WallXConfig):
@@ -420,6 +424,7 @@ def make_pre_post_processors(
             processors = _make_processors_from_policy_config(
                 config=policy_cfg,
                 dataset_stats=kwargs.get("dataset_stats"),
+                rename_map=kwargs.get("rename_map"),
             )
         except Exception as e:
             raise ValueError(f"Processor for policy type '{policy_cfg.type}' is not implemented.") from e
@@ -599,6 +604,7 @@ def _get_policy_cls_from_policy_name(name: str) -> type[PreTrainedConfig]:
 def _make_processors_from_policy_config(
     config: PreTrainedConfig,
     dataset_stats: dict[str, dict[str, torch.Tensor]] | None = None,
+    rename_map: dict[str, str] | None = None,
 ) -> tuple[Any, Any]:
     """Create pre- and post-processors from a policy configuration using dynamic imports.
 
@@ -607,6 +613,7 @@ def _make_processors_from_policy_config(
     Args:
         config: The policy configuration object.
         dataset_stats: Dataset statistics for normalization.
+        rename_map: Optional mapping of dataset or environment feature keys to match expected policy feature names.
     Returns:
         A tuple containing the input (pre-processor) and output (post-processor) pipelines.
     """
@@ -621,4 +628,4 @@ def _make_processors_from_policy_config(
     )
     module = importlib.import_module(module_path)
     function = getattr(module, function_name)
-    return function(config, dataset_stats=dataset_stats)
+    return function(config, dataset_stats=dataset_stats, rename_map=rename_map)

--- a/src/lerobot/policies/factory.py
+++ b/src/lerobot/policies/factory.py
@@ -231,6 +231,7 @@ class ProcessorConfigKwargs(TypedDict, total=False):
     preprocessor_overrides: dict[str, Any] | None
     postprocessor_overrides: dict[str, Any] | None
     dataset_stats: dict[str, dict[str, torch.Tensor]] | None
+    rename_map: dict[str, str] | None
 
 
 def make_pre_post_processors(

--- a/src/lerobot/policies/factory.py
+++ b/src/lerobot/policies/factory.py
@@ -638,7 +638,17 @@ def _make_processors_from_policy_config(
     # that only accept (config, dataset_stats=...) and don't have the rename_map parameter.
     if rename_map is not None:
         sig = inspect.signature(function)
-        if "rename_map" in sig.parameters:
+        accepts_rename_map = "rename_map" in sig.parameters
+        accepts_var_keyword = any(
+            p.kind == inspect.Parameter.VAR_KEYWORD for p in sig.parameters.values()
+        )
+        if accepts_rename_map or accepts_var_keyword:
             return function(config, dataset_stats=dataset_stats, rename_map=rename_map)
+        logging.warning(
+            "Policy factory '%s' does not accept `rename_map`; "
+            "observation rename will not be applied. "
+            "Consider updating the factory to accept a `rename_map` parameter.",
+            function_name,
+        )
 
     return function(config, dataset_stats=dataset_stats)

--- a/src/lerobot/policies/factory.py
+++ b/src/lerobot/policies/factory.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import importlib
+import inspect
 import logging
 from typing import TYPE_CHECKING, Any, TypedDict, Unpack
 
@@ -224,6 +225,9 @@ class ProcessorConfigKwargs(TypedDict, total=False):
         preprocessor_overrides: A dictionary of overrides for the preprocessor configuration.
         postprocessor_overrides: A dictionary of overrides for the postprocessor configuration.
         dataset_stats: Dataset statistics for normalization.
+        rename_map: Optional mapping of dataset or environment feature keys to match expected
+            policy feature names. When provided, stats are renamed accordingly so that
+            NormalizerProcessorStep can locate them after observation keys are remapped.
     """
 
     preprocessor_config_filename: str | None
@@ -613,7 +617,8 @@ def _make_processors_from_policy_config(
     Args:
         config: The policy configuration object.
         dataset_stats: Dataset statistics for normalization.
-        rename_map: Optional mapping of dataset or environment feature keys to match expected policy feature names.
+        rename_map: Optional mapping of dataset or environment feature keys to match expected
+            policy feature names.
     Returns:
         A tuple containing the input (pre-processor) and output (post-processor) pipelines.
     """
@@ -628,4 +633,12 @@ def _make_processors_from_policy_config(
     )
     module = importlib.import_module(module_path)
     function = getattr(module, function_name)
-    return function(config, dataset_stats=dataset_stats, rename_map=rename_map)
+
+    # Try calling with rename_map first; fall back without it for third-party factories
+    # that only accept (config, dataset_stats=...) and don't have the rename_map parameter.
+    if rename_map is not None:
+        sig = inspect.signature(function)
+        if "rename_map" in sig.parameters:
+            return function(config, dataset_stats=dataset_stats, rename_map=rename_map)
+
+    return function(config, dataset_stats=dataset_stats)

--- a/src/lerobot/policies/pi0/processor_pi0.py
+++ b/src/lerobot/policies/pi0/processor_pi0.py
@@ -101,6 +101,7 @@ class Pi0NewLineProcessor(ComplementaryDataProcessorStep):
 def make_pi0_pre_post_processors(
     config: PI0Config,
     dataset_stats: dict[str, dict[str, torch.Tensor]] | None = None,
+    rename_map: dict[str, str] | None = None,
 ) -> tuple[
     PolicyProcessorPipeline[dict[str, Any], dict[str, Any]],
     PolicyProcessorPipeline[PolicyAction, PolicyAction],
@@ -136,9 +137,9 @@ def make_pi0_pre_post_processors(
         action_names=getattr(config, "action_feature_names", None),
     )
 
-    # OpenPI order: raw → relative → normalize → model → unnormalize → absolute
+    # OpenPI order: raw → rename → relative → normalize → model → unnormalize → absolute
     input_steps: list[ProcessorStep] = [
-        RenameObservationsProcessorStep(rename_map={}),  # To mimic the same processor as pretrained one
+        RenameObservationsProcessorStep(rename_map=rename_map or {}),
         AddBatchDimensionProcessorStep(),
         Pi0NewLineProcessor(),  # Add newlines before tokenization for PaliGemma
         TokenizerProcessorStep(

--- a/src/lerobot/policies/pi05/processor_pi05.py
+++ b/src/lerobot/policies/pi05/processor_pi05.py
@@ -100,6 +100,7 @@ class Pi05PrepareStateTokenizerProcessorStep(ProcessorStep):
 def make_pi05_pre_post_processors(
     config: PI05Config,
     dataset_stats: dict[str, dict[str, torch.Tensor]] | None = None,
+    rename_map: dict[str, str] | None = None,
 ) -> tuple[
     PolicyProcessorPipeline[dict[str, Any], dict[str, Any]],
     PolicyProcessorPipeline[PolicyAction, PolicyAction],
@@ -135,9 +136,9 @@ def make_pi05_pre_post_processors(
         action_names=getattr(config, "action_feature_names", None),
     )
 
-    # OpenPI order: raw → relative → normalize → model → unnormalize → absolute
+    # OpenPI order: raw → rename → relative → normalize → model → unnormalize → absolute
     input_steps: list[ProcessorStep] = [
-        RenameObservationsProcessorStep(rename_map={}),  # To mimic the same processor as pretrained one
+        RenameObservationsProcessorStep(rename_map=rename_map or {}),
         AddBatchDimensionProcessorStep(),
         relative_step,
         # NOTE: NormalizerProcessorStep MUST come before Pi05PrepareStateTokenizerProcessorStep

--- a/src/lerobot/policies/pi0_fast/processor_pi0_fast.py
+++ b/src/lerobot/policies/pi0_fast/processor_pi0_fast.py
@@ -137,6 +137,9 @@ def make_pi0_fast_pre_post_processors(
     )
 
     # Pi0Fast order: rename → relative → normalize → tokenize → model → unnormalize → absolute
+    # Note: relative_step runs before NormalizerProcessorStep, which is safe because
+    # state features pass through unchanged (only actions are relativized), so the
+    # state tokenizer still sees normalized state in [-1, 1].
     input_steps: list[ProcessorStep] = [
         RenameObservationsProcessorStep(rename_map=rename_map or {}),
         AddBatchDimensionProcessorStep(),

--- a/src/lerobot/policies/pi0_fast/processor_pi0_fast.py
+++ b/src/lerobot/policies/pi0_fast/processor_pi0_fast.py
@@ -101,6 +101,7 @@ class Pi0FastPrepareStateAndLanguageTokenizerProcessorStep(ProcessorStep):
 def make_pi0_fast_pre_post_processors(
     config: PI0FastConfig,
     dataset_stats: dict[str, dict[str, torch.Tensor]] | None = None,
+    rename_map: dict[str, str] | None = None,
 ) -> tuple[
     PolicyProcessorPipeline[dict[str, Any], dict[str, Any]],
     PolicyProcessorPipeline[PolicyAction, PolicyAction],
@@ -135,16 +136,9 @@ def make_pi0_fast_pre_post_processors(
         action_names=getattr(config, "action_feature_names", None),
     )
 
-    # Pi0Fast order: relative → normalize → tokenize → model → unnormalize → absolute
-    # This matches pi0/pi0.5: RelativeActionsProcessorStep runs first on raw absolute actions,
-    # caching the raw state. NormalizerProcessorStep then normalizes the raw relative actions,
-    # so the normalizer (and action tokenizer) sees delta values — relative stats are required.
-    # NOTE: RelativeActionsProcessorStep only modifies the action in the transition; it reads
-    # state from the observation but does not change it. NormalizerProcessorStep still runs
-    # before Pi0FastPrepareStateAndLanguageTokenizerProcessorStep, so the state tokenizer
-    # continues to receive normalized state in [-1, 1] as expected.
+    # Pi0Fast order: rename → relative → normalize → tokenize → model → unnormalize → absolute
     input_steps: list[ProcessorStep] = [
-        RenameObservationsProcessorStep(rename_map={}),  # To mimic the same processor as pretrained one
+        RenameObservationsProcessorStep(rename_map=rename_map or {}),
         AddBatchDimensionProcessorStep(),
         relative_step,
         NormalizerProcessorStep(

--- a/src/lerobot/policies/smolvla/processor_smolvla.py
+++ b/src/lerobot/policies/smolvla/processor_smolvla.py
@@ -39,6 +39,7 @@ from .configuration_smolvla import SmolVLAConfig
 def make_smolvla_pre_post_processors(
     config: SmolVLAConfig,
     dataset_stats: dict[str, dict[str, torch.Tensor]] | None = None,
+    rename_map: dict[str, str] | None = None,
 ) -> tuple[
     PolicyProcessorPipeline[dict[str, Any], dict[str, Any]],
     PolicyProcessorPipeline[PolicyAction, PolicyAction],
@@ -67,7 +68,7 @@ def make_smolvla_pre_post_processors(
     """
 
     input_steps = [
-        RenameObservationsProcessorStep(rename_map={}),  # To mimic the same processor as pretrained one
+        RenameObservationsProcessorStep(rename_map=rename_map or {}),
         AddBatchDimensionProcessorStep(),
         NewLineTaskProcessorStep(),
         TokenizerProcessorStep(

--- a/src/lerobot/policies/xvla/processor_xvla.py
+++ b/src/lerobot/policies/xvla/processor_xvla.py
@@ -53,6 +53,7 @@ from .utils import rotate6d_to_axis_angle
 def make_xvla_pre_post_processors(
     config: XVLAConfig,
     dataset_stats: dict[str, dict[str, torch.Tensor]] | None = None,
+    rename_map: dict[str, str] | None = None,
 ) -> tuple[
     PolicyProcessorPipeline[dict[str, Any], dict[str, Any]],
     PolicyProcessorPipeline[PolicyAction, PolicyAction],
@@ -63,7 +64,7 @@ def make_xvla_pre_post_processors(
 
     features = {**config.input_features, **config.output_features}
     input_steps = [
-        RenameObservationsProcessorStep(rename_map={}),
+        RenameObservationsProcessorStep(rename_map=rename_map or {}),
         AddBatchDimensionProcessorStep(),
         TokenizerProcessorStep(
             tokenizer_name=config.tokenizer_name,

--- a/src/lerobot/scripts/lerobot_train.py
+++ b/src/lerobot/scripts/lerobot_train.py
@@ -310,6 +310,11 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
     if cfg.is_reward_model_training:
         processor_kwargs["dataset_meta"] = dataset.meta
 
+    if not cfg.is_reward_model_training:
+        # Always pass rename_map so it gets applied in the processor even when building
+        # processors from scratch (e.g., when use_relative_actions=True bypasses pretrained_path)
+        processor_kwargs["rename_map"] = cfg.rename_map
+
     if not cfg.is_reward_model_training and processor_pretrained_path is not None:
         processor_kwargs["preprocessor_overrides"] = {
             "device_processor": {"device": device.type},

--- a/src/lerobot/scripts/lerobot_train.py
+++ b/src/lerobot/scripts/lerobot_train.py
@@ -47,6 +47,7 @@ from lerobot.datasets import EpisodeAwareSampler, make_dataset
 from lerobot.envs import close_envs, make_env, make_env_pre_post_processors
 from lerobot.optim.factory import make_optimizer_and_scheduler
 from lerobot.policies import PreTrainedPolicy, make_policy, make_pre_post_processors
+from lerobot.processor.rename_processor import rename_stats
 from lerobot.rewards import make_reward_pre_post_processors
 from lerobot.utils.import_utils import register_third_party_plugins
 from lerobot.utils.logging_utils import AverageMeter, MetricsTracker
@@ -314,6 +315,10 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
         # Always pass rename_map so it gets applied in the processor even when building
         # processors from scratch (e.g., when use_relative_actions=True bypasses pretrained_path)
         processor_kwargs["rename_map"] = cfg.rename_map
+        # When rename_map is provided and stats are used (fresh-build path), rename stats keys
+        # so NormalizerProcessorStep can find them after observations are renamed.
+        if cfg.rename_map and ((processor_pretrained_path and not cfg.resume) or not processor_pretrained_path):
+            processor_kwargs["dataset_stats"] = rename_stats(dataset.meta.stats, cfg.rename_map)
 
     if not cfg.is_reward_model_training and processor_pretrained_path is not None:
         processor_kwargs["preprocessor_overrides"] = {

--- a/src/lerobot/scripts/lerobot_train.py
+++ b/src/lerobot/scripts/lerobot_train.py
@@ -315,9 +315,9 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
         # Always pass rename_map so it gets applied in the processor even when building
         # processors from scratch (e.g., when use_relative_actions=True bypasses pretrained_path)
         processor_kwargs["rename_map"] = cfg.rename_map
-        # When rename_map is provided and stats are used (fresh-build path), rename stats keys
-        # so NormalizerProcessorStep can find them after observations are renamed.
-        if cfg.rename_map and ((processor_pretrained_path and not cfg.resume) or not processor_pretrained_path):
+        # Rename stats whenever we'll build processors fresh —
+        # i.e., unless we're resuming from a pretrained checkpoint that already has renamed stats.
+        if cfg.rename_map and not (processor_pretrained_path and cfg.resume):
             processor_kwargs["dataset_stats"] = rename_stats(dataset.meta.stats, cfg.rename_map)
 
     if not cfg.is_reward_model_training and processor_pretrained_path is not None:


### PR DESCRIPTION
## Fix: apply rename_map on fresh-built processor pipelines (complete fix)

This supersedes #3512 and addresses all Copilot review comments:

### Changes

**1. `lerobot_train.py`** — Rename stats alongside observation keys
When `rename_map` is provided in the fresh-build path, call `rename_stats()` on `dataset.meta.stats` before passing to `make_pre_post_processors`. This ensures `NormalizerProcessorStep` can locate stats for renamed keys.

**2. `factory.py` — Backward-compat for third-party plugin factories**
`_make_processors_from_policy_config()` now inspects the signature of the dynamically-imported factory function. If `rename_map` is not in its parameters, it falls back to calling with only `(config, dataset_stats)` — no breaking change for plugins.

**3. `factory.py` — Document `ProcessorConfigKwargs.rename_map`**
Updated the TypedDict docstring to mention `rename_map` and explain its interaction with `dataset_stats`.

### Previous fixes (included from #3511 and #3512)
- `rename_map` forwarded to `make_pi0/pi05/smolvla/xvla_pre_post_processors()`
- `rename_map` forwarded to `_make_processors_from_policy_config()`
- All 5 processor factories use `rename_map` in `RenameObservationsProcessorStep`

### Related
- Fixes #3425
- Builds on #3511
- Supersedes #3512