### PR TITLE
fix(datasets): correct stats aggregation for merged datasets

### DIFF
--- a/src/lerobot/datasets/aggregate.py
+++ b/src/lerobot/datasets/aggregate.py
@@ -15,6 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import logging
 import shutil
 from pathlib import Path
@@ -647,5 +648,28 @@ def finalize_aggregation(aggr_meta, all_metadata):
     write_info(aggr_meta.info, aggr_meta.root)
 
     logging.info("write stats")
-    aggr_meta.stats = aggregate_stats([m.stats for m in all_metadata])
+    # episode_index and index are re-indexed during aggregation: each source
+    # dataset k has its values shifted by the cumulative total_episodes /
+    # total_frames of all preceding datasets.  The per-dataset stats were
+    # computed on the original (pre-shift) values, so we must apply the same
+    # offsets to min/max/mean and all quantiles before aggregating.  std and
+    # count are invariant to translation and need no adjustment.
+    adjusted_stats: list[dict] = []
+    ep_offset = 0
+    frame_offset = 0
+    for m in all_metadata:
+        s = copy.deepcopy(m.stats)
+        for feat_key, offset in (("episode_index", ep_offset), ("index", frame_offset)):
+            if feat_key not in s:
+                continue
+            feat = s[feat_key]
+            for stat_key in list(feat):
+                if stat_key in ("min", "max", "mean") or (
+                    stat_key.startswith("q") and stat_key[1:].isdigit()
+                ):
+                    feat[stat_key] = feat[stat_key] + offset
+        adjusted_stats.append(s)
+        ep_offset += m.total_episodes
+        frame_offset += m.total_frames
+    aggr_meta.stats = aggregate_stats(adjusted_stats)
     write_stats(aggr_meta.stats, aggr_meta.root)

--- a/tests/datasets/test_dataset_tools.py
+++ b/tests/datasets/test_dataset_tools.py
@@ -852,6 +852,22 @@ def test_merge_preserves_stats(sample_dataset, tmp_path, empty_lerobot_dataset_f
         assert "mean" in merged.meta.stats[feature]
         assert "std" in merged.meta.stats[feature]
 
+    # episode_index.max must equal total_episodes - 1 (= 7), not max(4, 2) = 4
+    expected_episode_max = merged.meta.total_episodes - 1
+    actual_episode_max = int(merged.meta.stats["episode_index"]["max"].item())
+    assert actual_episode_max == expected_episode_max, (
+        f"episode_index.max in stats ({actual_episode_max}) != total_episodes - 1 ({expected_episode_max}). "
+        "Stats were aggregated from per-dataset maxima without accounting for the episode index offset."
+    )
+
+    # index.max must equal total_frames - 1 (= 79), not max(49, 29) = 49
+    expected_index_max = merged.meta.total_frames - 1
+    actual_index_max = int(merged.meta.stats["index"]["max"].item())
+    assert actual_index_max == expected_index_max, (
+        f"index.max in stats ({actual_index_max}) != total_frames - 1 ({expected_index_max}). "
+        "Stats were aggregated from per-dataset maxima without accounting for the frame index offset."
+    )
+
 
 def test_add_features_preserves_existing_stats(sample_dataset, tmp_path):
     """Test that adding a feature preserves existing stats."""


### PR DESCRIPTION
## Title

fix(datasets): correct stats aggregation for merged datasets

## Summary / Motivation

- Fix incorrect `max` (and related quantiles/means) for `episode_index` and `index` after merging datasets; these stats were aggregated from per-dataset values without applying the offsets used while reindexing data during aggregation. This makes `stats.json` consistent with the merged data and prevents downstream normalization/monitoring surprises.

## Related issues

- Fixes / Closes: #3508

## What changed

- Files changed: aggregate.py, test_dataset_tools.py
- Behavior: When aggregating stats, per-dataset `episode_index` and `index` statistics are adjusted by cumulative offsets (episodes, frames) before running `aggregate_stats`, so `min`, `max`, `mean`, and quantiles reflect the merged dataset.
- Tests: Added assertions in `test_merge_preserves_stats` to assert `episode_index.max == total_episodes - 1` and `index.max == total_frames - 1`.
- Breaking changes: None — this is a correctness fix for aggregation; existing APIs unchanged.

## How was this tested (or how to run locally)

- Unit tests added/updated: test_dataset_tools.py (extended `test_merge_preserves_stats`)
- Run single test:
  - `source conda.sh && conda activate lerobot`
  - `python -m pytest -q tests/datasets/test_dataset_tools.py::test_merge_preserves_stats -q`
- Run full suite (local):
  - `python -m pytest -q ./tests`
  - Local run used for verification: `1490 passed, 197 skipped` (macOS dev env).
- Manual checks: Verified merged dataset `meta.total_episodes`, `meta.total_frames`, and `meta.stats['episode_index']['max']`/`meta.stats['index']['max']` match expected totals on local aggregated dataset created by the integration test.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [ ] Documentation updated (none required for public API)
- [x] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: #

## Reviewer notes

- Focus areas: `finalize_aggregation` in aggregate.py — ensure the offset logic is correct and performance/serialization semantics are unchanged. The change deep-copies per-dataset stats and applies simple numeric translations to `min/max/mean` and quantiles; `std`/`count` left unchanged because they are translation-invariant.
- Performance: No large I/O penalty — only deep-copying small stats dicts, not re-scanning data files.

## AI assistance disclosure

- Claude Sonnet 4.6 was used to help draft and structure parts of this PR text.