### PR TITLE
fix(video): clamp frame indices in torchcodec decoder to prevent IndexError

### DIFF
--- a/src/lerobot/datasets/video_utils.py
+++ b/src/lerobot/datasets/video_utils.py
@@ -346,8 +346,10 @@ def decode_video_frames_torchcodec(
     # get metadata for frame information
     metadata = decoder.metadata
     average_fps = metadata.average_fps
-    # convert timestamps to frame indices
-    frame_indices = [round(ts * average_fps) for ts in timestamps]
+    num_frames = metadata.num_frames
+    # convert timestamps to frame indices, clamping to valid range to handle
+    # hardware timestamp jitter that can slightly exceed video duration
+    frame_indices = [min(round(ts * average_fps), num_frames - 1) for ts in timestamps]
     # retrieve frames based on indices
     frames_batch = decoder.get_frames_at(indices=frame_indices)
 


### PR DESCRIPTION
## Summary

Fixes #3513

When datasets use real hardware timestamps (wall-clock from robot/camera controller), the last parquet timestamp can slightly exceed the encoded video duration due to capture jitter. This causes `round(ts * average_fps)` to produce an index >= `num_frames`, crashing `get_frames_at` with `IndexError`.

## Fix

Clamp computed frame indices to `[0, num_frames - 1]` using `min(round(ts * average_fps), num_frames - 1)`.

## Test plan

- Verified that the fix handles the case where `ts * fps` rounds to exactly `num_frames`
- Existing video decoding tests still pass (no behavior change for in-bounds timestamps)