### PR TITLE
fix(datasets): forward HF auth token for private/gated dataset access

### DIFF
--- a/src/lerobot/datasets/dataset_metadata.py
+++ b/src/lerobot/datasets/dataset_metadata.py
@@ -68,6 +68,7 @@ class LeRobotDatasetMetadata:
         revision: str | None = None,
         force_cache_sync: bool = False,
         metadata_buffer_size: int = 10,
+        token: str | bool | None = None,
     ):
         """Load or download metadata for an existing LeRobot dataset.
 
@@ -89,6 +90,9 @@ class LeRobotDatasetMetadata:
                 even when local files exist.
             metadata_buffer_size: Number of episode metadata records to buffer
                 in memory before flushing to parquet.
+            token: Hugging Face authentication token. Pass ``True`` to use the
+                stored token, a string for an explicit token, or ``None`` to let
+                the hub library resolve it automatically.
         """
         self.repo_id = repo_id
         self.revision = revision if revision else CODEBASE_VERSION
@@ -99,6 +103,7 @@ class LeRobotDatasetMetadata:
         self._metadata_buffer: list[dict] = []
         self._metadata_buffer_size = metadata_buffer_size
         self._finalized = False
+        self._token = token
 
         try:
             if force_cache_sync or (
@@ -108,7 +113,7 @@ class LeRobotDatasetMetadata:
             self._load_metadata()
         except (FileNotFoundError, NotADirectoryError):
             if is_valid_version(self.revision):
-                self.revision = get_safe_version(self.repo_id, self.revision)
+                self.revision = get_safe_version(self.repo_id, self.revision, token=self._token)
 
             self._pull_from_repo(allow_patterns="meta/")
             self._load_metadata()
@@ -203,6 +208,7 @@ class LeRobotDatasetMetadata:
                     cache_dir=HF_LEROBOT_HUB_CACHE,
                     allow_patterns=allow_patterns,
                     ignore_patterns=ignore_patterns,
+                    token=self._token,
                 )
             )
             return
@@ -215,6 +221,7 @@ class LeRobotDatasetMetadata:
             local_dir=self._requested_root,
             allow_patterns=allow_patterns,
             ignore_patterns=ignore_patterns,
+            token=self._token,
         )
         self.root = self._requested_root
 

--- a/src/lerobot/datasets/lerobot_dataset.py
+++ b/src/lerobot/datasets/lerobot_dataset.py
@@ -62,6 +62,7 @@ class LeRobotDataset(torch.utils.data.Dataset):
         streaming_encoding: bool = False,
         encoder_queue_maxsize: int = 30,
         encoder_threads: int | None = None,
+        token: str | bool | None = None,
     ):
         """
         2 modes are available for instantiating this class, depending on 2 different use cases:
@@ -207,13 +208,18 @@ class LeRobotDataset(torch.utils.data.Dataset):
         self._batch_encoding_size = batch_encoding_size
         self._vcodec = resolve_vcodec(vcodec)
         self._encoder_threads = encoder_threads
+        self._token = token
 
         if self._requested_root is not None:
             self._requested_root.mkdir(exist_ok=True, parents=True)
 
         # Load metadata (sets self.root once from the resolved metadata root)
         self.meta = LeRobotDatasetMetadata(
-            self.repo_id, self._requested_root, self.revision, force_cache_sync=force_cache_sync
+            self.repo_id,
+            self._requested_root,
+            self.revision,
+            force_cache_sync=force_cache_sync,
+            token=self._token,
         )
         self.root = self.meta.root
         self.revision = self.meta.revision
@@ -233,7 +239,7 @@ class LeRobotDataset(torch.utils.data.Dataset):
         # Load actual data
         if force_cache_sync or not self.reader.try_load():
             if is_valid_version(self.revision):
-                self.revision = get_safe_version(self.repo_id, self.revision)
+                self.revision = get_safe_version(self.repo_id, self.revision, token=self._token)
             self._download(download_videos)
             self.reader.load_and_activate()
 
@@ -591,6 +597,7 @@ class LeRobotDataset(torch.utils.data.Dataset):
                     cache_dir=HF_LEROBOT_HUB_CACHE,
                     allow_patterns=files,
                     ignore_patterns=ignore_patterns,
+                    token=self._token,
                 )
             )
         else:
@@ -602,6 +609,7 @@ class LeRobotDataset(torch.utils.data.Dataset):
                 local_dir=self._requested_root,
                 allow_patterns=files,
                 ignore_patterns=ignore_patterns,
+                token=self._token,
             )
             self.meta.root = self._requested_root
 

--- a/src/lerobot/datasets/utils.py
+++ b/src/lerobot/datasets/utils.py
@@ -316,16 +316,19 @@ def check_version_compatibility(
         logging.warning(FUTURE_MESSAGE.format(repo_id=repo_id, version=v_check))
 
 
-def get_repo_versions(repo_id: str) -> list[packaging.version.Version]:
+def get_repo_versions(repo_id: str, token: str | bool | None = None) -> list[packaging.version.Version]:
     """Return available valid versions (branches and tags) on a given Hub repo.
 
     Args:
         repo_id (str): The repository ID on the Hugging Face Hub.
+        token: Hugging Face authentication token. Pass ``True`` to use the
+            stored token, a string for an explicit token, or ``None`` to let
+            the hub library resolve it automatically.
 
     Returns:
         list[packaging.version.Version]: A list of valid versions found.
     """
-    api = HfApi()
+    api = HfApi(token=token)
     repo_refs = api.list_repo_refs(repo_id, repo_type="dataset")
     repo_refs = [b.name for b in repo_refs.branches + repo_refs.tags]
     repo_versions = []
@@ -336,7 +339,9 @@ def get_repo_versions(repo_id: str) -> list[packaging.version.Version]:
     return repo_versions
 
 
-def get_safe_version(repo_id: str, version: str | packaging.version.Version) -> str:
+def get_safe_version(
+    repo_id: str, version: str | packaging.version.Version, token: str | bool | None = None
+) -> str:
     """Return the specified version if available on repo, or the latest compatible one.
 
     If the exact version is not found, it looks for the latest version with the
@@ -357,7 +362,7 @@ def get_safe_version(repo_id: str, version: str | packaging.version.Version) -> 
     target_version = (
         packaging.version.parse(version) if not isinstance(version, packaging.version.Version) else version
     )
-    hub_versions = get_repo_versions(repo_id)
+    hub_versions = get_repo_versions(repo_id, token=token)
 
     if not hub_versions:
         raise RevisionNotFoundError(

--- a/src/lerobot/scripts/lerobot_dataset_viz.py
+++ b/src/lerobot/scripts/lerobot_dataset_viz.py
@@ -285,11 +285,22 @@ def main():
         help="If set, display compressed images in Rerun instead of uncompressed ones.",
     )
 
+    parser.add_argument(
+        "--token",
+        type=str,
+        default=None,
+        help=(
+            "Hugging Face authentication token for accessing private or gated datasets. "
+            "Uses the stored token from `huggingface-cli login` when not provided."
+        ),
+    )
+
     args = parser.parse_args()
     kwargs = vars(args)
     repo_id = kwargs.pop("repo_id")
     root = kwargs.pop("root")
     tolerance_s = kwargs.pop("tolerance_s")
+    token = kwargs.pop("token")
 
     if kwargs["ws_port"] is not None:
         logging.warning(
@@ -300,7 +311,9 @@ def main():
 
     init_logging()
     logging.info("Loading dataset")
-    dataset = LeRobotDataset(repo_id, episodes=[args.episode_index], root=root, tolerance_s=tolerance_s)
+    dataset = LeRobotDataset(
+        repo_id, episodes=[args.episode_index], root=root, tolerance_s=tolerance_s, token=token
+    )
 
     visualize_dataset(dataset, **vars(args))
 


### PR DESCRIPTION
## Summary
- Threads a `token` parameter through `LeRobotDataset`, `LeRobotDatasetMetadata`, `get_safe_version`, and `get_repo_versions` so that authentication is properly forwarded to all `huggingface_hub` API calls (`snapshot_download`, `HfApi.list_repo_refs`).
- Adds `--token` CLI argument to `lerobot-dataset-viz` for explicit token passing.
- The parameter defaults to `None` which preserves existing behavior (hub library resolves the token automatically from cache/env). When set, it enables access to private or gated datasets that require explicit auth.

Fixes #3392

## Test plan
- [x] `ruff check` and `ruff format` pass on all modified files
- [ ] Manually verified with a private org dataset that passing `--token` resolves the 401 error
- [ ] Existing public dataset workflows remain unaffected (default `token=None` preserves prior behavior)