### PR TITLE
fix(ci): bump robotwin benchmark image to CUDA 12.6

### DIFF
--- a/docker/Dockerfile.benchmark.robotwin
+++ b/docker/Dockerfile.benchmark.robotwin
@@ -35,7 +35,7 @@ USER root
 ARG ROBOTWIN_SHA=0aeea2d669c0f8516f4d5785f0aa33ba812c14b4
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-         cuda-nvcc-12-4 cuda-cudart-dev-12-4 \
+         cuda-nvcc-12-6 cuda-cudart-dev-12-6 \
          libvulkan1 vulkan-tools \
     && mkdir -p /usr/share/vulkan/icd.d \
     && echo '{"file_format_version":"1.0.0","ICD":{"library_path":"libGLX_nvidia.so.0","api_version":"1.3.0"}}' \


### PR DESCRIPTION
## Summary
- The RoboTwin benchmark Docker build was failing in CI with `Package 'cuda-nvcc-12-4' has no installation candidate` / `Unable to locate package cuda-cudart-dev-12-4`.
- After [#3505](https://github.com/huggingface/lerobot/pull/3505) bumped the base `lerobot-gpu` image to CUDA 12.6.3 on Ubuntu 24.04, the ubuntu2404 CUDA repo no longer ships the `-12-4` packages, but [docker/Dockerfile.benchmark.robotwin](docker/Dockerfile.benchmark.robotwin) still pinned them.
- Bumped both `cuda-nvcc` and `cuda-cudart-dev` to `-12-6` to match the new base image.

## Test
- [ ] CI build of the RoboTwin benchmark image succeeds