### PR TITLE
fix(ci): cap VLABench smoke eval at 50 steps per task

### DIFF
--- a/.github/workflows/benchmark_tests.yml
+++ b/.github/workflows/benchmark_tests.yml
@@ -901,6 +901,7 @@ jobs:
                 --env.type=vlabench \
                 --env.task=select_fruit,select_toy,select_book,select_painting,select_drink,select_ingredient,select_billiards,select_poker,add_condiment,insert_flower \
                 --env.episode_length=50 \
+                --env.max_parallel_tasks=5 \
                 --eval.batch_size=1 \
                 --eval.n_episodes=1 \
                 --eval.use_async_envs=false \

--- a/.github/workflows/benchmark_tests.yml
+++ b/.github/workflows/benchmark_tests.yml
@@ -900,6 +900,7 @@ jobs:
                 --policy.path=lerobot/smolvla_vlabench \
                 --env.type=vlabench \
                 --env.task=select_fruit,select_toy,select_book,select_painting,select_drink,select_ingredient,select_billiards,select_poker,add_condiment,insert_flower \
+                --env.episode_length=50 \
                 --eval.batch_size=1 \
                 --eval.n_episodes=1 \
                 --eval.use_async_envs=false \


### PR DESCRIPTION
## Summary
- The VLABench benchmark CI job was taking ~1h 40m, dominated by rollouts: 10 tasks × 500 default steps × ~1 it/s ≈ 80 min just stepping the env
- Override `--env.episode_length=50` (VLABench defaults to 500 in [src/lerobot/envs/configs.py:581](src/lerobot/envs/configs.py:581)) to cut rollout time ~10x.

## Test
- [ ] Benchmark Integration Tests workflow completes successfully on this PR
- [ ] VLABench job total wall time drops from ~100 min to ~25-30 min
- [ ] Eval still produces `metrics.json` and rollout videos as artifacts
