### PR TITLE
fix(ci): speed up multi-task benchmark evals (parallelize + cap VLABench steps)

### DIFF
--- a/.github/workflows/benchmark_tests.yml
+++ b/.github/workflows/benchmark_tests.yml
@@ -905,6 +905,7 @@ jobs:
                 --env.type=vlabench \
                 --env.task=select_fruit,select_toy,select_book,select_painting,select_drink,select_ingredient,select_billiards,select_poker,add_condiment,insert_flower \
                 --env.episode_length=50 \
+                --env.max_parallel_tasks=5 \
                 --eval.batch_size=1 \
                 --eval.n_episodes=1 \
                 --eval.use_async_envs=false \

--- a/.github/workflows/benchmark_tests.yml
+++ b/.github/workflows/benchmark_tests.yml
@@ -382,6 +382,7 @@ jobs:
                 --policy.path=\"\$ROBOTWIN_POLICY\" \
                 --env.type=robotwin \
                 --env.task=\"\$ROBOTWIN_TASKS\" \
+                --env.max_parallel_tasks=5 \
                 --eval.batch_size=1 \
                 --eval.n_episodes=1 \
                 --eval.use_async_envs=false \
@@ -482,6 +483,7 @@ jobs:
                 --policy.path=lerobot/smolvla_robocasa \
                 --env.type=robocasa \
                 --env.task=CloseFridge,OpenCabinet,OpenDrawer,TurnOnMicrowave,TurnOffStove,CloseToasterOvenDoor,SlideDishwasherRack,TurnOnSinkFaucet,NavigateKitchen,TurnOnElectricKettle \
+                --env.max_parallel_tasks=5 \
                 --eval.batch_size=1 \
                 --eval.n_episodes=1 \
                 --eval.use_async_envs=false \
@@ -693,6 +695,7 @@ jobs:
                 --env.task=\"\$ROBOMME_TASKS\" \
                 --env.dataset_split=test \
                 --env.task_ids=[0] \
+                --env.max_parallel_tasks=5 \
                 --eval.batch_size=1 \
                 --eval.n_episodes=1 \
                 --eval.use_async_envs=false \
@@ -800,6 +803,7 @@ jobs:
                 --env.type=libero_plus \
                 --env.task=\"\$LIBERO_PLUS_SUITE\" \
                 --env.task_ids=\"\$LIBERO_PLUS_TASK_IDS\" \
+                --env.max_parallel_tasks=5 \
                 --eval.batch_size=1 \
                 --eval.n_episodes=1 \
                 --eval.use_async_envs=false \

--- a/.github/workflows/benchmark_tests.yml
+++ b/.github/workflows/benchmark_tests.yml
@@ -904,6 +904,7 @@ jobs:
                 --policy.path=lerobot/smolvla_vlabench \
                 --env.type=vlabench \
                 --env.task=select_fruit,select_toy,select_book,select_painting,select_drink,select_ingredient,select_billiards,select_poker,add_condiment,insert_flower \
+                --env.episode_length=50 \
                 --eval.batch_size=1 \
                 --eval.n_episodes=1 \
                 --eval.use_async_envs=false \


### PR DESCRIPTION
## Summary
Speeds up the Benchmark Integration Tests workflow by:

1. **Run multi-task benchmark evals 5-at-a-time in parallel** via `--env.max_parallel_tasks=5`. The eval script already supports this through a ThreadPoolExecutor ([src/lerobot/scripts/lerobot_eval.py:787](src/lerobot/scripts/lerobot_eval.py:787)) but no jobs were using it. Applied to:
   - **VLABench** (10 tasks)
   - **RoboTwin** (10 tasks)
   - **RoboCasa365** (10 tasks)
   - **RoboMME** (10 tasks)
   - **LIBERO-plus** (8 task_ids)
2. **Cap VLABench rollout at 50 steps per task** via `--env.episode_length=50`. The default of 500 made the smoke eval ~80 min of rollouts; since this is a pipeline smoke test (success rate stays at 0% on a short rollout anyway), 50 is plenty.

Single-task jobs (Libero, MetaWorld, RoboCerebra) are untouched. 

## Test
- [ ] Benchmark Integration Tests workflow completes on this PR
- [ ] No GPU/CPU OOMs in the parallelized jobs
- [ ] Per-task `metrics.json` and rollout videos still produced
- [ ] VLABench wall time drops from ~100 min to ~25-30 min; the other multi-task jobs see meaningful speedups too
