### PR TITLE
feat(rewards): integrate VITA reward model with train/docs/tests

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -61,6 +61,8 @@
 - sections:
   - local: sarm
     title: SARM
+  - local: vita
+    title: VITA
   title: "Reward Models"
 - sections:
   - local: inference

--- a/docs/source/vita.mdx
+++ b/docs/source/vita.mdx
@@ -1,0 +1,207 @@
+# VITA Reward Model
+
+VITA is a reward modeling method based on test-time adaptation over vision-language embeddings. In LeRobot, VITA is integrated as a **reward model** (not a policy) and can be trained with `lerobot-train` through the `reward_model` configuration path.
+
+**Paper**: [VITA: Test-Time Adaptation for Vision-Language Reward Modeling](https://arxiv.org/abs/2506.10085)
+
+## Why Reward Models?
+
+Behavior cloning treats all demonstration frames similarly, but datasets often contain pauses, corrections, and imperfect segments. Reward models estimate task progress from observations and language so you can:
+
+1. score trajectories frame-by-frame,
+2. compare successful vs failed behavior,
+3. build downstream training signals.
+
+VITA does this with online adaptation of a lightweight module while keeping the backbone frozen.
+
+## Overview
+
+The current integration covers the paper-aligned core:
+
+- Frozen multimodal backbone interface (`clip` and `openclip`)
+- Multimodal latent `z_t = [image_t ; text_t]`
+- Learned projections `P_K`, `P_V`, `P_Q`
+- Residual adaptation module `f_adapt` with per-episode fast weights
+- Adaptation loss `MSE(f_adapt(P_K z_t), P_V z_t)`
+- Sequential adaptation updates at inference
+- Reward prediction on adapted queries
+- Meta-learning outer loop in `forward`
+- Dissimilarity-based sub-trajectory sampling
+- Temporal-progress targets `y_t=t/T` by default
+
+## What "Zero-Shot" Means in VITA
+
+In VITA, **zero-shot does not mean "no training at all"**. It means:
+
+1. train a general reward/value model once on source demonstrations (paper-scale pretraining),
+2. then transfer to new tasks without target-task reward annotations,
+3. while using test-time adaptation to specialize to the current trajectory.
+
+For this reason, the quality of transfer depends on domain overlap (visual scene, robot embodiment, instruction style).
+
+## Paper Protocol vs This Integration
+
+The paper evaluates VITA with a broader pretraining/evaluation protocol (for example large expert sets such as BridgeData V2 subsets, plus downstream experiments).  
+This LeRobot integration focuses on the model core and training/inference APIs.
+
+- Included: architecture, adaptation dynamics, dissimilarity sampling, temporal-progress supervision.
+- Not included as a turnkey package: full paper benchmark reproduction pipeline and assets.
+
+If you train VITA directly on one small task dataset, you get a task-specific reward model.  
+To approach paper-style generalization, pretrain on diverse source demonstrations before transfer.
+
+## Inputs and Targets (What the code expects)
+
+At minimum, each training sample should provide:
+
+- `task` (string): natural language task description
+- image tensor at `reward_model.raw_image_key` (for example `observation.images.top`)
+
+By default, VITA uses temporal progress supervision (`t/T`) during training (`force_temporal_progress_targets=True`), so an explicit reward column is not required unless you disable this option.
+
+## Paper-to-code mapping
+
+| Paper component | LeRobot implementation |
+| --- | --- |
+| Frozen backbone encoder | `VitaBackbone`, `ClipVitaBackbone`, `OpenClipVitaBackbone` in `src/lerobot/rewards/vita/modeling_vita.py` |
+| Multimodal latent `z_t` | Concatenation of image/text embeddings in `VitaRewardModel.compute_reward` |
+| `P_K`, `P_V`, `P_Q` | `key_projection`, `value_projection`, `query_projection` |
+| Adaptation module `f_adapt` | `VitaAdaptationModule` in `src/lerobot/rewards/vita/adaptation.py` |
+| Adaptation loss | MSE in `VitaAdaptationModule.adaptation_step` |
+| Fast weights | `VitaAdaptationState.fast_weights` |
+| Reward head | `reward_head` in `VitaRewardModel` |
+| Outer-loop objective | `VitaRewardModel.forward` |
+| Dissimilarity sampling | `VitaRewardModel._sample_dissimilar_windows` |
+
+## Set Up Your Environment
+
+1. Install LeRobot following the [Installation Guide](./installation).
+2. Install VITA/OpenCLIP dependency:
+
+```bash
+pip install open_clip_torch
+```
+
+## Step 1: Inspect Dataset Keys
+
+Before training, confirm camera keys and feature names:
+
+```python
+from lerobot.datasets.lerobot_dataset import LeRobotDataset
+
+ds = LeRobotDataset("<YOUR_DATASET>", download_videos=False)
+print("camera keys:", ds.meta.camera_keys)
+print("feature keys:", list(ds.features.keys()))
+```
+
+## Step 2: Train VITA
+
+Train VITA as a reward model:
+
+```bash
+lerobot-train \
+  --dataset.repo_id=<YOUR_DATASET> \
+  --reward_model.type=vita \
+  --reward_model.backbone_type=openclip \
+  --reward_model.openclip_model_name=ViT-B-32 \
+  --reward_model.openclip_pretrained=openai \
+  --reward_model.raw_image_key=<CAMERA_KEY> \
+  --reward_model.raw_text_key=task \
+  --reward_model.adaptation_dim=64 \
+  --reward_model.adaptation_lr=0.1 \
+  --reward_model.support_len=2 \
+  --reward_model.query_len=1 \
+  --reward_model.inner_steps=1 \
+  --reward_model.inner_lr=0.1 \
+  --reward_model.self_supervised_loss_weight=0.5 \
+  --reward_model.sampling_strategy=dissimilarity \
+  --reward_model.sampling_window_size=8 \
+  --reward_model.sampling_num_windows=8 \
+  --reward_model.sampling_stride=1 \
+  --reward_model.outer_loss_weight=1.0 \
+  --reward_model.device=cuda \
+  --output_dir=outputs/train/vita \
+  --batch_size=8 \
+  --steps=5000
+```
+
+### Multi-GPU training
+
+```bash
+accelerate launch --multi_gpu --num_processes=4 \
+  -m lerobot.scripts.lerobot_train \
+  --dataset.repo_id=<YOUR_DATASET> \
+  --reward_model.type=vita \
+  --reward_model.raw_image_key=<CAMERA_KEY> \
+  --reward_model.raw_text_key=task
+```
+
+### Training arguments (core)
+
+| Argument | Description | Default |
+| --- | --- | --- |
+| `--reward_model.raw_image_key` | Camera/image feature key from dataset | `observation.images.top` |
+| `--reward_model.raw_text_key` | Text key used for task conditioning | `task` |
+| `--reward_model.backbone_type` | `openclip`, `clip`, or `identity` | `openclip` |
+| `--reward_model.adaptation_dim` | Fast adaptation hidden dimension | `64` |
+| `--reward_model.adaptation_lr` | Test-time adaptation step size | `0.1` |
+| `--reward_model.inner_steps` | Number of outer-loop adaptation passes | `1` |
+| `--reward_model.inner_lr` | Outer-loop adaptation step size | `0.1` |
+| `--reward_model.sampling_strategy` | `contiguous` or `dissimilarity` | `dissimilarity` |
+| `--reward_model.force_temporal_progress_targets` | Use `t/T` targets when true | `true` |
+
+## Step 3: Resume or Fine-Tune
+
+Resume an interrupted run from the saved train config:
+
+```bash
+lerobot-train \
+  --config_path=outputs/train/vita/checkpoints/last/pretrained_model/train_config.json \
+  --resume=true
+```
+
+Fine-tune from an existing VITA checkpoint on a (possibly new) dataset:
+
+```bash
+lerobot-train \
+  --reward_model.path=outputs/train/vita/checkpoints/last/pretrained_model \
+  --dataset.repo_id=<YOUR_DATASET> \
+  --output_dir=outputs/train/vita_finetune \
+  --steps=2000
+```
+
+## Step 4: Score Trajectories
+
+Use the reward model directly for inference:
+
+```python
+import torch
+
+from lerobot.rewards.factory import make_reward_model
+from lerobot.rewards.vita.configuration_vita import VitaConfig
+
+cfg = VitaConfig(
+    backbone_type="openclip",
+    openclip_model_name="ViT-B-32",
+    openclip_pretrained="openai",
+    raw_image_key="observation.images.top",
+    raw_text_key="task",
+    adaptation_dim=64,
+)
+model = make_reward_model(cfg)
+
+batch = {
+    "observation.images.top": torch.rand(4, 1, 3, 224, 224),
+    "task": ["pick cube"] * 4,
+    "episode_start": torch.tensor([True, False, False, True]),
+}
+reward = model.compute_reward(batch)
+model.reset()
+```
+
+
+## Citation
+
+If VITA helps your project, please cite the original paper:
+
+- [VITA: Test-Time Adaptation for Vision-Language Reward Modeling](https://arxiv.org/abs/2506.10085)

--- a/src/lerobot/rewards/__init__.py
+++ b/src/lerobot/rewards/__init__.py
@@ -21,11 +21,13 @@ from .factory import (
 )
 from .pretrained import PreTrainedRewardModel as PreTrainedRewardModel
 from .sarm.configuration_sarm import SARMConfig as SARMConfig
+from .vita.configuration_vita import VitaConfig as VitaConfig
 
 __all__ = [
     # Configuration classes
     "RewardClassifierConfig",
     "SARMConfig",
+    "VitaConfig",
     # Base class
     "PreTrainedRewardModel",
     # Factory functions

--- a/src/lerobot/rewards/factory.py
+++ b/src/lerobot/rewards/factory.py
@@ -25,6 +25,7 @@ from lerobot.processor import PolicyAction, PolicyProcessorPipeline
 from lerobot.rewards.classifier.configuration_classifier import RewardClassifierConfig
 from lerobot.rewards.pretrained import PreTrainedRewardModel
 from lerobot.rewards.sarm.configuration_sarm import SARMConfig
+from lerobot.rewards.vita.configuration_vita import VitaConfig
 
 
 def get_reward_model_class(name: str) -> type[PreTrainedRewardModel]:
@@ -36,7 +37,7 @@ def get_reward_model_class(name: str) -> type[PreTrainedRewardModel]:
 
     Args:
         name: The name of the reward model. Supported names are "reward_classifier",
-              "sarm".
+              "sarm", "vita".
 
     Returns:
         The reward model class corresponding to the given name.
@@ -52,6 +53,10 @@ def get_reward_model_class(name: str) -> type[PreTrainedRewardModel]:
         from lerobot.rewards.sarm.modeling_sarm import SARMRewardModel
 
         return SARMRewardModel
+    elif name == "vita":
+        from lerobot.rewards.vita.modeling_vita import VitaRewardModel
+
+        return VitaRewardModel
     else:
         try:
             return _get_reward_model_cls_from_name(name=name)
@@ -68,7 +73,7 @@ def make_reward_model_config(reward_type: str, **kwargs) -> RewardModelConfig:
 
     Args:
         reward_type: The type of the reward model. Supported types include
-                     "reward_classifier", "sarm".
+                     "reward_classifier", "sarm", "vita".
         **kwargs: Keyword arguments to be passed to the configuration class constructor.
 
     Returns:
@@ -81,6 +86,8 @@ def make_reward_model_config(reward_type: str, **kwargs) -> RewardModelConfig:
         return RewardClassifierConfig(**kwargs)
     elif reward_type == "sarm":
         return SARMConfig(**kwargs)
+    elif reward_type == "vita":
+        return VitaConfig(**kwargs)
     else:
         try:
             config_cls = RewardModelConfig.get_choice_class(reward_type)
@@ -159,6 +166,13 @@ def make_reward_pre_post_processors(
             config=reward_cfg,
             dataset_stats=kwargs.get("dataset_stats"),
             dataset_meta=kwargs.get("dataset_meta"),
+        )
+    elif isinstance(reward_cfg, VitaConfig):
+        from lerobot.rewards.vita.processor_vita import make_vita_pre_post_processors
+
+        return make_vita_pre_post_processors(
+            config=reward_cfg,
+            dataset_stats=kwargs.get("dataset_stats"),
         )
 
     else:

--- a/src/lerobot/rewards/vita/__init__.py
+++ b/src/lerobot/rewards/vita/__init__.py
@@ -1,0 +1,11 @@
+from .configuration_vita import VitaConfig as VitaConfig
+from .modeling_vita import ClipVitaBackbone as ClipVitaBackbone
+from .modeling_vita import OpenClipVitaBackbone as OpenClipVitaBackbone
+from .modeling_vita import VitaRewardModel as VitaRewardModel
+
+__all__ = [
+    "ClipVitaBackbone",
+    "OpenClipVitaBackbone",
+    "VitaConfig",
+    "VitaRewardModel",
+]

--- a/src/lerobot/rewards/vita/adaptation.py
+++ b/src/lerobot/rewards/vita/adaptation.py
@@ -1,0 +1,146 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+
+import torch
+import torch.nn.functional as F  # noqa: N812
+from torch import Tensor, nn
+
+
+@dataclass
+class VitaFastWeights:
+    """Per-sample fast weights for the residual adaptation MLP."""
+
+    w1: Tensor
+    b1: Tensor
+    w2: Tensor
+    b2: Tensor
+
+
+@dataclass
+class VitaAdaptationState:
+    """Fast adaptation state tracked across inference steps."""
+
+    fast_weights: VitaFastWeights
+    num_updates: Tensor
+
+    @classmethod
+    def initialize(cls, module: "VitaAdaptationModule", batch_size: int, device: torch.device) -> "VitaAdaptationState":
+        base_weights = module.base_fast_weights()
+        weights = VitaFastWeights(
+            w1=base_weights.w1.detach().to(device).unsqueeze(0).expand(batch_size, -1, -1).clone(),
+            b1=base_weights.b1.detach().to(device).unsqueeze(0).expand(batch_size, -1).clone(),
+            w2=base_weights.w2.detach().to(device).unsqueeze(0).expand(batch_size, -1, -1).clone(),
+            b2=base_weights.b2.detach().to(device).unsqueeze(0).expand(batch_size, -1).clone(),
+        )
+        updates = torch.zeros(batch_size, dtype=torch.long, device=device)
+        return cls(fast_weights=weights, num_updates=updates)
+
+    def reset_indices(self, module: "VitaAdaptationModule", mask: Tensor) -> None:
+        if mask.ndim != 1:
+            raise ValueError(f"Expected mask of shape (B,), got shape {tuple(mask.shape)}")
+        if not torch.any(mask):
+            return
+        base_weights = module.base_fast_weights()
+        self.fast_weights.w1[mask] = base_weights.w1.detach().to(self.fast_weights.w1.device)
+        self.fast_weights.b1[mask] = base_weights.b1.detach().to(self.fast_weights.b1.device)
+        self.fast_weights.w2[mask] = base_weights.w2.detach().to(self.fast_weights.w2.device)
+        self.fast_weights.b2[mask] = base_weights.b2.detach().to(self.fast_weights.b2.device)
+        self.num_updates[mask] = 0
+
+
+class VitaAdaptationModule(nn.Module):
+    """Two-layer residual MLP adaptation module with external fast weights."""
+
+    def __init__(self, adaptation_dim: int):
+        super().__init__()
+        self.fc1 = nn.Linear(adaptation_dim, adaptation_dim)
+        self.fc2 = nn.Linear(adaptation_dim, adaptation_dim)
+
+    @property
+    def base_weight(self) -> Tensor:
+        return self.fc1.weight
+
+    def base_fast_weights(self) -> VitaFastWeights:
+        return VitaFastWeights(
+            w1=self.fc1.weight,
+            b1=self.fc1.bias,
+            w2=self.fc2.weight,
+            b2=self.fc2.bias,
+        )
+
+    def _forward_with_weights(self, inputs: Tensor, weights: VitaFastWeights) -> Tensor:
+        hidden = F.gelu(torch.einsum("bij,bj->bi", weights.w1, inputs) + weights.b1)
+        return inputs + torch.einsum("bij,bj->bi", weights.w2, hidden) + weights.b2
+
+    def forward(self, inputs: Tensor, fast_weights: VitaFastWeights | None = None) -> Tensor:
+        if fast_weights is None:
+            return inputs + self.fc2(F.gelu(self.fc1(inputs)))
+        if inputs.ndim != 2:
+            raise ValueError(f"Expected inputs of shape (B, D), got {tuple(inputs.shape)}")
+        return self._forward_with_weights(inputs, fast_weights)
+
+    def adaptation_step(
+        self,
+        keys: Tensor,
+        values: Tensor,
+        fast_weights: VitaFastWeights,
+        adaptation_lr: float,
+        first_order: bool = True,
+    ) -> tuple[VitaFastWeights, Tensor]:
+        losses: list[Tensor] = []
+        updated_w1: list[Tensor] = []
+        updated_b1: list[Tensor] = []
+        updated_w2: list[Tensor] = []
+        updated_b2: list[Tensor] = []
+
+        for idx in range(keys.shape[0]):
+            key_i = keys[idx : idx + 1]
+            value_i = values[idx : idx + 1]
+
+            w1_i = fast_weights.w1[idx : idx + 1].clone().requires_grad_(True)
+            b1_i = fast_weights.b1[idx : idx + 1].clone().requires_grad_(True)
+            w2_i = fast_weights.w2[idx : idx + 1].clone().requires_grad_(True)
+            b2_i = fast_weights.b2[idx : idx + 1].clone().requires_grad_(True)
+            if first_order:
+                w1_i = w1_i.detach().requires_grad_(True)
+                b1_i = b1_i.detach().requires_grad_(True)
+                w2_i = w2_i.detach().requires_grad_(True)
+                b2_i = b2_i.detach().requires_grad_(True)
+            sample_weights = VitaFastWeights(w1=w1_i, b1=b1_i, w2=w2_i, b2=b2_i)
+
+            prediction_i = self._forward_with_weights(key_i, sample_weights)
+            loss_i = torch.mean((prediction_i - value_i) ** 2)
+            grads = torch.autograd.grad(
+                loss_i,
+                [w1_i, b1_i, w2_i, b2_i],
+                create_graph=not first_order,
+            )
+            if first_order:
+                grads = [grad.detach() for grad in grads]
+
+            updated_w1.append(w1_i - adaptation_lr * grads[0])
+            updated_b1.append(b1_i - adaptation_lr * grads[1])
+            updated_w2.append(w2_i - adaptation_lr * grads[2])
+            updated_b2.append(b2_i - adaptation_lr * grads[3])
+            losses.append(loss_i)
+
+        updated_fast_weights = VitaFastWeights(
+            w1=torch.cat(updated_w1, dim=0),
+            b1=torch.cat(updated_b1, dim=0),
+            w2=torch.cat(updated_w2, dim=0),
+            b2=torch.cat(updated_b2, dim=0),
+        )
+        return updated_fast_weights, torch.stack(losses, dim=0)

--- a/src/lerobot/rewards/vita/configuration_vita.py
+++ b/src/lerobot/rewards/vita/configuration_vita.py
@@ -1,0 +1,144 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+from dataclasses import dataclass, field
+
+from lerobot.configs.rewards import RewardModelConfig
+from lerobot.configs.types import FeatureType, NormalizationMode, PolicyFeature
+from lerobot.optim.optimizers import AdamWConfig, OptimizerConfig
+from lerobot.optim.schedulers import LRSchedulerConfig
+from torch.optim import Optimizer
+from torch.optim.lr_scheduler import LambdaLR
+
+
+@LRSchedulerConfig.register_subclass("vita_paper_cosine")
+@dataclass
+class VitaPaperCosineSchedulerConfig(LRSchedulerConfig):
+    """Cosine scheduler with warmup ratio fixed to paper setting."""
+
+    num_warmup_steps: int | None = None
+    peak_lr: float = 1e-4
+    decay_lr: float = 1e-5
+    warmup_ratio: float = 0.1
+
+    def build(self, optimizer: Optimizer, num_training_steps: int) -> LambdaLR:
+        warmup_steps = max(1, int(self.warmup_ratio * num_training_steps))
+        decay_steps = max(1, num_training_steps)
+
+        def lr_lambda(current_step: int) -> float:
+            if current_step < warmup_steps:
+                return max(1e-8, float(current_step + 1) / float(warmup_steps))
+
+            step = min(current_step, decay_steps)
+            cosine_decay = 0.5 * (1 + math.cos(math.pi * step / decay_steps))
+            alpha = self.decay_lr / self.peak_lr
+            return (1 - alpha) * cosine_decay + alpha
+
+        return LambdaLR(optimizer, lr_lambda, -1)
+
+
+@RewardModelConfig.register_subclass("vita")
+@dataclass
+class VitaConfig(RewardModelConfig):
+    """Configuration for VITA reward modeling."""
+
+    backbone_type: str = "openclip"
+    openclip_model_name: str = "ViT-B-32"
+    openclip_pretrained: str = "openai"
+    clip_model_name: str = "openai/clip-vit-base-patch32"
+    freeze_backbone: bool = True
+    raw_image_key: str = "observation.images.top"
+    raw_text_key: str = "task"
+    image_feature_key: str = "image_features"
+    text_feature_key: str = "text_features"
+    adaptation_lr: float = 0.1
+    adaptation_dim: int = 64
+    image_feature_dim: int = 512
+    text_feature_dim: int = 512
+    reward_hidden_dim: int = 128
+    device: str | None = None
+    meta_enabled: bool = True
+    inner_steps: int = 1
+    inner_lr: float = 0.1
+    outer_loss_weight: float = 1.0
+    self_supervised_loss_weight: float = 0.5
+    first_order: bool = False
+    support_len: int = 1
+    query_len: int = 1
+    target_reward_key: str = "next.reward"
+    sampling_strategy: str = "dissimilarity"
+    sampling_window_size: int = 8
+    sampling_num_windows: int = 8
+    sampling_stride: int = 1
+    force_temporal_progress_targets: bool = True
+    scheduler_decay_lr: float = 1e-5
+
+    input_features: dict[str, PolicyFeature] = field(
+        default_factory=lambda: {
+            "image_features": PolicyFeature(type=FeatureType.VISUAL, shape=(512,)),
+            "text_features": PolicyFeature(type=FeatureType.LANGUAGE, shape=(512,)),
+        }
+    )
+    output_features: dict[str, PolicyFeature] = field(
+        default_factory=lambda: {"reward": PolicyFeature(type=FeatureType.REWARD, shape=(1,))}
+    )
+    normalization_mapping: dict[str, NormalizationMode] = field(
+        default_factory=lambda: {
+            "VISUAL": NormalizationMode.IDENTITY,
+            "LANGUAGE": NormalizationMode.IDENTITY,
+            "REWARD": NormalizationMode.IDENTITY,
+        }
+    )
+
+    @property
+    def latent_dim(self) -> int:
+        return self.image_feature_dim + self.text_feature_dim
+
+    def get_optimizer_preset(self) -> OptimizerConfig:
+        return AdamWConfig(lr=1e-4, weight_decay=1e-4)
+
+    def get_scheduler_preset(self) -> LRSchedulerConfig | None:
+        return VitaPaperCosineSchedulerConfig(
+            peak_lr=1e-4,
+            decay_lr=self.scheduler_decay_lr,
+            warmup_ratio=0.1,
+        )
+
+    def validate_features(self) -> None:
+        if self.support_len < 1 or self.query_len < 1:
+            raise ValueError("support_len and query_len must be >= 1.")
+        if self.inner_steps < 1:
+            raise ValueError("inner_steps must be >= 1.")
+        if self.backbone_type not in {"identity", "clip", "openclip"}:
+            raise ValueError(
+                f"Unsupported backbone_type '{self.backbone_type}'. Expected one of: identity, clip, openclip."
+            )
+        if self.sampling_strategy not in {"contiguous", "dissimilarity"}:
+            raise ValueError(
+                f"Unsupported sampling_strategy '{self.sampling_strategy}'. "
+                "Expected one of: contiguous, dissimilarity."
+            )
+        if self.sampling_window_size < 1 or self.sampling_num_windows < 1 or self.sampling_stride < 1:
+            raise ValueError("sampling_window_size, sampling_num_windows, and sampling_stride must be >= 1.")
+        if self.backbone_type == "identity":
+            if self.image_feature_key not in self.input_features:
+                raise ValueError(f"Missing expected image feature key '{self.image_feature_key}' in input_features.")
+            if self.text_feature_key not in self.input_features:
+                raise ValueError(f"Missing expected text feature key '{self.text_feature_key}' in input_features.")
+        else:
+            if not self.raw_image_key:
+                raise ValueError("raw_image_key must be set for clip/openclip backbone mode.")
+            if not self.raw_text_key:
+                raise ValueError("raw_text_key must be set for clip/openclip backbone mode.")

--- a/src/lerobot/rewards/vita/modeling_vita.py
+++ b/src/lerobot/rewards/vita/modeling_vita.py
@@ -1,0 +1,517 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Protocol
+
+import torch
+import torch.nn.functional as F  # noqa: N812
+import torchvision.transforms.functional as TF
+from torch import Tensor, nn
+
+from lerobot.rewards.pretrained import PreTrainedRewardModel
+from lerobot.rewards.vita.adaptation import VitaAdaptationModule, VitaAdaptationState, VitaFastWeights
+from lerobot.rewards.vita.configuration_vita import VitaConfig
+from lerobot.utils.constants import OBS_STR
+
+
+class VitaBackbone(Protocol):
+    """Backbone interface returning image and text embeddings."""
+
+    def encode(self, batch: dict[str, Tensor], config: VitaConfig) -> tuple[Tensor, Tensor]:
+        """Encode batch inputs into image and text features."""
+        ...
+
+
+class IdentityVitaBackbone(nn.Module):
+    """Lightweight backbone for pre-encoded image/text features."""
+
+    def encode(self, batch: dict[str, Tensor], config: VitaConfig) -> tuple[Tensor, Tensor]:
+        image_features = batch[config.image_feature_key]
+        text_features = batch[config.text_feature_key]
+        return image_features.float(), text_features.float()
+
+
+class DummyVitaBackbone(nn.Module):
+    """Deterministic test backbone with fixed linear encoders."""
+
+    def __init__(self, image_input_dim: int, text_input_dim: int, image_output_dim: int, text_output_dim: int):
+        super().__init__()
+        self.image_encoder = nn.Linear(image_input_dim, image_output_dim, bias=False)
+        self.text_encoder = nn.Linear(text_input_dim, text_output_dim, bias=False)
+        with torch.no_grad():
+            self.image_encoder.weight.copy_(torch.eye(image_output_dim, image_input_dim))
+            self.text_encoder.weight.copy_(torch.eye(text_output_dim, text_input_dim))
+
+    def encode(self, batch: dict[str, Tensor], config: VitaConfig) -> tuple[Tensor, Tensor]:
+        image = batch[config.image_feature_key].float()
+        text = batch[config.text_feature_key].float()
+        return self.image_encoder(image), self.text_encoder(text)
+
+
+class ClipVitaBackbone(nn.Module):
+    """CLIP backbone that encodes raw images and task text."""
+
+    def __init__(self, model_name: str):
+        super().__init__()
+        try:
+            from transformers import CLIPModel, CLIPProcessor
+        except ModuleNotFoundError as exc:
+            raise ModuleNotFoundError(
+                "VITA clip backbone requires `transformers`. Install with: pip install 'lerobot[transformers-dep]'."
+            ) from exc
+
+        self.model = CLIPModel.from_pretrained(model_name)
+        self.processor = CLIPProcessor.from_pretrained(model_name, use_fast=True)
+
+    def _to_image_list(self, images: Tensor) -> list:
+        if images.ndim not in {4, 5}:
+            raise ValueError(f"Expected raw images of shape (B,C,H,W) or (B,T,C,H,W), got {tuple(images.shape)}.")
+        if images.ndim == 4:
+            images = images.unsqueeze(1)
+        image_list: list = []
+        for sample_images in images:  # (T, C, H, W)
+            for image in sample_images:
+                image_list.append(TF.to_pil_image(image.detach().cpu()))
+        return image_list
+
+    def _normalize_texts(self, texts, batch_size: int, seq_len: int) -> list[str]:
+        if isinstance(texts, str):
+            return [texts] * (batch_size * seq_len)
+        if isinstance(texts, list):
+            if len(texts) == batch_size and all(isinstance(t, str) for t in texts):
+                return [t for t in texts for _ in range(seq_len)]
+            if len(texts) == batch_size and all(isinstance(t, list) for t in texts):
+                flat_texts: list[str] = []
+                for per_sample in texts:
+                    if len(per_sample) != seq_len or not all(isinstance(t, str) for t in per_sample):
+                        raise ValueError("Expected nested text list of shape (B, T).")
+                    flat_texts.extend(per_sample)
+                return flat_texts
+            if len(texts) == batch_size * seq_len and all(isinstance(t, str) for t in texts):
+                return texts
+        raise ValueError(
+            "Unsupported text format for clip backbone. Expected str, list[str] (B or B*T), or list[list[str]] (B,T)."
+        )
+
+    def encode(self, batch: dict[str, Tensor], config: VitaConfig) -> tuple[Tensor, Tensor]:
+        images = batch[config.raw_image_key]
+        texts = batch[config.raw_text_key]
+        if not isinstance(images, Tensor):
+            raise ValueError(f"Expected tensor images at key '{config.raw_image_key}', got {type(images)}.")
+
+        if images.ndim == 4:
+            batch_size, seq_len = images.shape[0], 1
+        elif images.ndim == 5:
+            batch_size, seq_len = images.shape[0], images.shape[1]
+        else:
+            raise ValueError(f"Expected raw images rank 4/5, got rank {images.ndim}.")
+
+        flat_images = self._to_image_list(images)
+        flat_texts = self._normalize_texts(texts, batch_size=batch_size, seq_len=seq_len)
+
+        device = next(self.model.parameters()).device
+        inputs = self.processor(
+            text=flat_texts,
+            images=flat_images,
+            return_tensors="pt",
+            padding=True,
+            truncation=True,
+        )
+        inputs = {key: value.to(device) for key, value in inputs.items()}
+
+        with torch.no_grad():
+            image_features = self.model.get_image_features(pixel_values=inputs["pixel_values"])
+            text_features = self.model.get_text_features(
+                input_ids=inputs["input_ids"],
+                attention_mask=inputs["attention_mask"],
+            )
+
+        image_features = image_features.view(batch_size, seq_len, -1)
+        text_features = text_features.view(batch_size, seq_len, -1)
+        return image_features, text_features
+
+
+class OpenClipVitaBackbone(nn.Module):
+    """OpenCLIP backbone aligned with the VITA paper setup."""
+
+    def __init__(self, model_name: str, pretrained: str):
+        super().__init__()
+        try:
+            import open_clip
+        except ModuleNotFoundError as exc:
+            raise ModuleNotFoundError(
+                "VITA openclip backbone requires `open_clip_torch`. Install with: pip install open_clip_torch."
+            ) from exc
+
+        model, _, preprocess = open_clip.create_model_and_transforms(model_name, pretrained=pretrained)
+        tokenizer = open_clip.get_tokenizer(model_name)
+        self.model = model
+        self.preprocess = preprocess
+        self.tokenizer = tokenizer
+
+    def _prepare_images(self, images: Tensor) -> tuple[Tensor, int, int]:
+        if images.ndim == 4:
+            images = images.unsqueeze(1)
+        if images.ndim != 5:
+            raise ValueError(f"Expected raw images of shape (B,C,H,W) or (B,T,C,H,W), got {tuple(images.shape)}.")
+
+        batch_size, seq_len = images.shape[0], images.shape[1]
+        flat_images = []
+        for sample_images in images:
+            for image in sample_images:
+                pil_image = TF.to_pil_image(image.detach().cpu())
+                flat_images.append(self.preprocess(pil_image))
+        return torch.stack(flat_images, dim=0), batch_size, seq_len
+
+    def _prepare_texts(self, texts, batch_size: int, seq_len: int, device: torch.device) -> Tensor:
+        if isinstance(texts, str):
+            text_list = [texts] * (batch_size * seq_len)
+        elif isinstance(texts, list):
+            if len(texts) == batch_size and all(isinstance(t, str) for t in texts):
+                text_list = [t for t in texts for _ in range(seq_len)]
+            elif len(texts) == batch_size and all(isinstance(t, list) for t in texts):
+                text_list = []
+                for per_sample in texts:
+                    if len(per_sample) != seq_len or not all(isinstance(t, str) for t in per_sample):
+                        raise ValueError("Expected nested text list of shape (B, T).")
+                    text_list.extend(per_sample)
+            elif len(texts) == batch_size * seq_len and all(isinstance(t, str) for t in texts):
+                text_list = texts
+            else:
+                raise ValueError("Unsupported list text format for openclip backbone.")
+        else:
+            raise ValueError("Unsupported text format for openclip backbone.")
+        return self.tokenizer(text_list).to(device)
+
+    def encode(self, batch: dict[str, Tensor], config: VitaConfig) -> tuple[Tensor, Tensor]:
+        images = batch[config.raw_image_key]
+        texts = batch[config.raw_text_key]
+        if not isinstance(images, Tensor):
+            raise ValueError(f"Expected tensor images at key '{config.raw_image_key}', got {type(images)}.")
+
+        image_tensor, batch_size, seq_len = self._prepare_images(images)
+        device = next(self.model.parameters()).device
+        image_tensor = image_tensor.to(device)
+        text_tokens = self._prepare_texts(texts, batch_size=batch_size, seq_len=seq_len, device=device)
+
+        with torch.no_grad():
+            image_features = self.model.encode_image(image_tensor)
+            text_features = self.model.encode_text(text_tokens)
+
+        image_features = F.normalize(image_features, dim=-1).view(batch_size, seq_len, -1)
+        text_features = F.normalize(text_features, dim=-1).view(batch_size, seq_len, -1)
+        return image_features, text_features
+
+
+class VitaRewardModel(PreTrainedRewardModel):
+    """VITA reward model with sequential test-time adaptation."""
+
+    name = "vita"
+    config_class = VitaConfig
+
+    def __init__(self, config: VitaConfig, backbone: VitaBackbone | None = None):
+        super().__init__(config)
+        config.validate_features()
+        self.config = config
+        if backbone is not None:
+            self.backbone = backbone
+        elif config.backbone_type == "openclip":
+            self.backbone = OpenClipVitaBackbone(
+                model_name=config.openclip_model_name,
+                pretrained=config.openclip_pretrained,
+            )
+        elif config.backbone_type == "clip":
+            self.backbone = ClipVitaBackbone(model_name=config.clip_model_name)
+        else:
+            self.backbone = IdentityVitaBackbone()
+
+        if isinstance(self.backbone, nn.Module) and config.freeze_backbone:
+            for param in self.backbone.parameters():
+                param.requires_grad = False
+
+        self.key_projection = nn.Linear(config.latent_dim, config.adaptation_dim)
+        self.value_projection = nn.Linear(config.latent_dim, config.adaptation_dim)
+        self.query_projection = nn.Linear(config.latent_dim, config.adaptation_dim)
+        self.adaptation_module = VitaAdaptationModule(config.adaptation_dim)
+        self.reward_head = nn.Sequential(
+            nn.Linear(config.adaptation_dim, config.reward_hidden_dim),
+            nn.Tanh(),
+            nn.Linear(config.reward_hidden_dim, 1),
+        )
+
+        self._adaptation_state: VitaAdaptationState | None = None
+        self.last_adaptation_losses: Tensor | None = None
+
+    @property
+    def adaptation_state(self) -> VitaAdaptationState | None:
+        return self._adaptation_state
+
+    def reset_adaptation_state(self, batch_size: int | None = None, device: torch.device | None = None) -> None:
+        if batch_size is None:
+            self._adaptation_state = None
+            return
+        state_device = device if device is not None else self.adaptation_module.base_weight.device
+        self._adaptation_state = VitaAdaptationState.initialize(self.adaptation_module, batch_size, state_device)
+
+    def reset(self) -> None:
+        self.reset_adaptation_state()
+
+    def _ensure_sequence(self, tensor: Tensor) -> Tensor:
+        if tensor.ndim == 2:
+            return tensor.unsqueeze(1)
+        if tensor.ndim == 3:
+            return tensor
+        raise ValueError(f"Expected tensor rank 2 or 3, got rank {tensor.ndim}")
+
+    def _prepare_episode_starts(self, episode_start: Tensor | None, batch_size: int, seq_len: int, device) -> Tensor:
+        if episode_start is None:
+            return torch.zeros(batch_size, seq_len, dtype=torch.bool, device=device)
+        starts = episode_start.to(device=device, dtype=torch.bool)
+        if starts.ndim == 1:
+            if starts.shape[0] != batch_size:
+                raise ValueError("episode_start must match batch size.")
+            starts = starts.unsqueeze(1).expand(batch_size, seq_len)
+        elif starts.ndim == 2:
+            if starts.shape != (batch_size, seq_len):
+                raise ValueError("episode_start must have shape (B, T).")
+        else:
+            raise ValueError("episode_start must be rank 1 or 2.")
+        return starts
+
+    def _split_support_query(self, tensor: Tensor) -> tuple[Tensor, Tensor]:
+        support_len = self.config.support_len
+        query_len = self.config.query_len
+        total_len = support_len + query_len
+        if tensor.shape[1] < total_len:
+            raise ValueError(
+                f"Expected at least {total_len} timesteps for support/query split, got {tensor.shape[1]}."
+            )
+        support = tensor[:, :support_len]
+        query = tensor[:, support_len : support_len + query_len]
+        return support, query
+
+    def _sample_dissimilar_windows(self, latent: Tensor) -> list[int]:
+        seq_len = latent.shape[0]
+        window = min(self.config.sampling_window_size, seq_len)
+        starts = list(range(0, seq_len - window + 1, self.config.sampling_stride))
+        if not starts:
+            starts = [0]
+        windows = torch.stack([latent[s : s + window].flatten() for s in starts], dim=0)
+        distances = torch.cdist(windows, windows, p=2) ** 2
+        scores = distances.sum(dim=1)
+        k = min(self.config.sampling_num_windows, scores.shape[0])
+        topk_idx = torch.topk(scores, k=k, largest=True).indices.tolist()
+        return [starts[idx] for idx in topk_idx]
+
+    def _select_training_sequence(
+        self,
+        image_features: Tensor,
+        text_features: Tensor,
+        target: Tensor,
+    ) -> tuple[Tensor, Tensor, Tensor]:
+        if self.config.sampling_strategy == "contiguous":
+            return image_features, text_features, target
+
+        seq_len = image_features.shape[1]
+        window = min(self.config.sampling_window_size, seq_len)
+        sampled_image_per_batch: list[Tensor] = []
+        sampled_text_per_batch: list[Tensor] = []
+        sampled_target_per_batch: list[Tensor] = []
+
+        for batch_idx in range(image_features.shape[0]):
+            latent = torch.cat([image_features[batch_idx], text_features[batch_idx]], dim=-1)
+            starts = self._sample_dissimilar_windows(latent)
+            sampled_image = torch.cat([image_features[batch_idx, s : s + window] for s in starts], dim=0)
+            sampled_text = torch.cat([text_features[batch_idx, s : s + window] for s in starts], dim=0)
+            sampled_target = torch.cat([target[batch_idx, s : s + window] for s in starts], dim=0)
+            sampled_image_per_batch.append(sampled_image)
+            sampled_text_per_batch.append(sampled_text)
+            sampled_target_per_batch.append(sampled_target)
+
+        return (
+            torch.stack(sampled_image_per_batch, dim=0),
+            torch.stack(sampled_text_per_batch, dim=0),
+            torch.stack(sampled_target_per_batch, dim=0),
+        )
+
+    def _adapt_fast_weights(
+        self,
+        image_sequence: Tensor,
+        text_sequence: Tensor,
+        fast_weights: VitaFastWeights,
+        adaptation_lr: float,
+    ) -> tuple[VitaFastWeights, Tensor]:
+        adaptation_losses: list[Tensor] = []
+        for timestep in range(image_sequence.shape[1]):
+            latent = torch.cat([image_sequence[:, timestep], text_sequence[:, timestep]], dim=-1)
+            keys = self.key_projection(latent)
+            values = self.value_projection(latent)
+            fast_weights, losses = self.adaptation_module.adaptation_step(
+                keys=keys,
+                values=values,
+                fast_weights=fast_weights,
+                adaptation_lr=adaptation_lr,
+                first_order=self.config.first_order,
+            )
+            adaptation_losses.append(losses)
+
+        return fast_weights, torch.stack(adaptation_losses, dim=1)
+
+    def _predict_reward_sequence(
+        self, image_sequence: Tensor, text_sequence: Tensor, fast_weights: VitaFastWeights
+    ) -> Tensor:
+        rewards: list[Tensor] = []
+        for timestep in range(image_sequence.shape[1]):
+            latent = torch.cat([image_sequence[:, timestep], text_sequence[:, timestep]], dim=-1)
+            queries = self.query_projection(latent)
+            adapted_queries = self.adaptation_module(queries, fast_weights=fast_weights)
+            rewards.append(self.reward_head(adapted_queries).squeeze(-1))
+        return torch.stack(rewards, dim=1)
+
+    def _make_progress_targets(self, batch_size: int, seq_len: int, device: torch.device) -> Tensor:
+        # Paper supervision uses normalized temporal progress y_t = t / T.
+        base = torch.arange(1, seq_len + 1, dtype=torch.float32, device=device) / float(seq_len)
+        return base.unsqueeze(0).expand(batch_size, -1)
+
+    def compute_reward(self, batch: dict[str, Tensor]) -> Tensor:
+        observation = batch.get(OBS_STR, batch)
+        image_features, text_features = self.backbone.encode(observation, self.config)
+        image_features = self._ensure_sequence(image_features)
+        text_features = self._ensure_sequence(text_features)
+        if image_features.shape[:2] != text_features.shape[:2]:
+            raise ValueError("Image and text features must have compatible (B, T) dimensions.")
+
+        batch_size, seq_len, _ = image_features.shape
+        device = image_features.device
+
+        if self._adaptation_state is None or self._adaptation_state.fast_weights.w1.shape[0] != batch_size:
+            self.reset_adaptation_state(batch_size=batch_size, device=device)
+        assert self._adaptation_state is not None
+
+        episode_starts = self._prepare_episode_starts(
+            observation.get("episode_start"), batch_size=batch_size, seq_len=seq_len, device=device
+        )
+
+        rewards: list[Tensor] = []
+        adaptation_losses: list[Tensor] = []
+        for timestep in range(seq_len):
+            step_starts = episode_starts[:, timestep]
+            self._adaptation_state.reset_indices(module=self.adaptation_module, mask=step_starts)
+
+            latent = torch.cat([image_features[:, timestep], text_features[:, timestep]], dim=-1)
+            keys = self.key_projection(latent)
+            values = self.value_projection(latent)
+            queries = self.query_projection(latent)
+
+            updated_fast_weights, losses = self.adaptation_module.adaptation_step(
+                keys=keys,
+                values=values,
+                fast_weights=self._adaptation_state.fast_weights,
+                adaptation_lr=self.config.adaptation_lr,
+                first_order=True,
+            )
+            self._adaptation_state.fast_weights = updated_fast_weights
+            self._adaptation_state.num_updates = self._adaptation_state.num_updates + 1
+            adaptation_losses.append(losses)
+
+            adapted_queries = self.adaptation_module(queries, fast_weights=self._adaptation_state.fast_weights)
+            rewards.append(self.reward_head(adapted_queries).squeeze(-1))
+
+        reward_tensor = torch.stack(rewards, dim=1)
+        self.last_adaptation_losses = torch.stack(adaptation_losses, dim=1)
+        if seq_len == 1:
+            return reward_tensor[:, 0]
+        return reward_tensor
+
+    def forward(self, batch: dict[str, Tensor]) -> tuple[Tensor, dict[str, Tensor]]:
+        if not self.config.meta_enabled:
+            raise NotImplementedError("Meta-learning is disabled in config; use compute_reward() for inference.")
+
+        observation = batch.get(OBS_STR, batch)
+        image_features, text_features = self.backbone.encode(observation, self.config)
+        image_features = self._ensure_sequence(image_features)
+        text_features = self._ensure_sequence(text_features)
+
+        if self.config.force_temporal_progress_targets:
+            target = self._make_progress_targets(
+                batch_size=image_features.shape[0],
+                seq_len=image_features.shape[1],
+                device=image_features.device,
+            )
+        else:
+            target = observation.get(self.config.target_reward_key)
+            if target is None:
+                raise ValueError(f"Missing target reward key '{self.config.target_reward_key}' in batch.")
+            target = target.float()
+            if target.ndim == 1:
+                target = target.unsqueeze(1)
+            if target.ndim == 3 and target.shape[-1] == 1:
+                target = target.squeeze(-1)
+            if target.ndim != 2:
+                raise ValueError(f"Target reward must be (B,T) or (B,T,1), got shape {tuple(target.shape)}.")
+
+        train_image, train_text, train_target = self._select_training_sequence(
+            image_features=image_features,
+            text_features=text_features,
+            target=target,
+        )
+
+        batch_size = image_features.shape[0]
+        device = image_features.device
+        state = VitaAdaptationState.initialize(
+            module=self.adaptation_module,
+            batch_size=batch_size,
+            device=device,
+        )
+        fast_weights = state.fast_weights
+
+        predictions = None
+        adaptation_losses = None
+        for _ in range(self.config.inner_steps):
+            step_predictions: list[Tensor] = []
+            step_losses: list[Tensor] = []
+            for timestep in range(train_image.shape[1]):
+                latent = torch.cat([train_image[:, timestep], train_text[:, timestep]], dim=-1)
+                keys = self.key_projection(latent)
+                values = self.value_projection(latent)
+                queries = self.query_projection(latent)
+                fast_weights, losses = self.adaptation_module.adaptation_step(
+                    keys=keys,
+                    values=values,
+                    fast_weights=fast_weights,
+                    adaptation_lr=self.config.inner_lr,
+                    first_order=self.config.first_order,
+                )
+                adapted_queries = self.adaptation_module(queries, fast_weights=fast_weights)
+                step_predictions.append(self.reward_head(adapted_queries).squeeze(-1))
+                step_losses.append(losses)
+            predictions = torch.stack(step_predictions, dim=1)
+            adaptation_losses = torch.stack(step_losses, dim=1)
+
+        assert predictions is not None
+        assert adaptation_losses is not None
+        outer_loss = F.mse_loss(predictions, train_target)
+        inner_loss = adaptation_losses.mean()
+        loss = (
+            self.config.outer_loss_weight * outer_loss
+            + self.config.self_supervised_loss_weight * inner_loss
+        )
+
+        metrics = {
+            "loss": loss.detach(),
+            "outer_loss": outer_loss.detach(),
+            "inner_loss": inner_loss.detach(),
+            "self_supervised_loss": inner_loss.detach(),
+        }
+        return loss, metrics

--- a/src/lerobot/rewards/vita/processor_vita.py
+++ b/src/lerobot/rewards/vita/processor_vita.py
@@ -1,0 +1,61 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any
+
+import torch
+
+from lerobot.processor import (
+    DeviceProcessorStep,
+    IdentityProcessorStep,
+    NormalizerProcessorStep,
+    PolicyAction,
+    PolicyProcessorPipeline,
+)
+from lerobot.processor.converters import policy_action_to_transition, transition_to_policy_action
+from lerobot.rewards.vita.configuration_vita import VitaConfig
+
+
+def make_vita_pre_post_processors(
+    config: VitaConfig,
+    dataset_stats: dict[str, dict[str, torch.Tensor]] | None = None,
+) -> tuple[
+    PolicyProcessorPipeline[dict[str, Any], dict[str, Any]],
+    PolicyProcessorPipeline[PolicyAction, PolicyAction],
+]:
+    """Create pre/post processing pipelines for VITA."""
+    if config.backbone_type in {"clip", "openclip"}:
+        # Raw image/text inputs are encoded in-model by CLIP/OpenCLIP backbones.
+        pre_steps = [DeviceProcessorStep(device=config.device or "cpu")]
+    else:
+        pre_steps = [
+            NormalizerProcessorStep(
+                features=config.input_features, norm_map=config.normalization_mapping, stats=dataset_stats
+            ),
+            NormalizerProcessorStep(
+                features=config.output_features, norm_map=config.normalization_mapping, stats=dataset_stats
+            ),
+            DeviceProcessorStep(device=config.device or "cpu"),
+        ]
+    post_steps = [DeviceProcessorStep(device="cpu"), IdentityProcessorStep()]
+
+    return (
+        PolicyProcessorPipeline(steps=pre_steps, name="vita_preprocessor"),
+        PolicyProcessorPipeline(
+            steps=post_steps,
+            name="vita_postprocessor",
+            to_transition=policy_action_to_transition,
+            to_output=transition_to_policy_action,
+        ),
+    )

--- a/tests/rewards/test_vita_reward.py
+++ b/tests/rewards/test_vita_reward.py
@@ -1,0 +1,237 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+
+from lerobot.configs.rewards import RewardModelConfig
+from lerobot.optim.schedulers import LRSchedulerConfig
+from lerobot.rewards.factory import (
+    get_reward_model_class,
+    make_reward_model_config,
+    make_reward_pre_post_processors,
+)
+from lerobot.rewards.vita.configuration_vita import VitaConfig
+from lerobot.rewards.vita.modeling_vita import DummyVitaBackbone, VitaRewardModel
+
+
+def _make_model() -> VitaRewardModel:
+    config = VitaConfig(
+        image_feature_dim=4,
+        text_feature_dim=4,
+        adaptation_dim=4,
+        reward_hidden_dim=8,
+        adaptation_lr=0.05,
+    )
+    backbone = DummyVitaBackbone(
+        image_input_dim=4,
+        text_input_dim=4,
+        image_output_dim=4,
+        text_output_dim=4,
+    )
+    return VitaRewardModel(config=config, backbone=backbone)
+
+
+def test_vita_config_registry_and_factory_visibility():
+    known = RewardModelConfig.get_known_choices()
+    assert "vita" in known
+    assert RewardModelConfig.get_choice_class("vita") is VitaConfig
+    assert isinstance(make_reward_model_config("vita"), VitaConfig)
+
+    reward_cls = get_reward_model_class("vita")
+    assert reward_cls is VitaRewardModel
+
+    pre_processor, post_processor = make_reward_pre_post_processors(VitaConfig())
+    assert pre_processor.name == "vita_preprocessor"
+    assert post_processor.name == "vita_postprocessor"
+    default_cfg = VitaConfig()
+    assert default_cfg.backbone_type == "openclip"
+    assert default_cfg.first_order is False
+    assert default_cfg.force_temporal_progress_targets is True
+
+
+def test_vita_clip_mode_validation_and_processor_creation():
+    config = VitaConfig(backbone_type="clip", raw_image_key="observation.images.top", raw_text_key="task")
+    config.validate_features()
+    pre_processor, post_processor = make_reward_pre_post_processors(config)
+    assert pre_processor.name == "vita_preprocessor"
+    assert post_processor.name == "vita_postprocessor"
+
+
+def test_vita_openclip_mode_validation_and_processor_creation():
+    config = VitaConfig(backbone_type="openclip", raw_image_key="observation.images.top", raw_text_key="task")
+    config.validate_features()
+    pre_processor, post_processor = make_reward_pre_post_processors(config)
+    assert pre_processor.name == "vita_preprocessor"
+    assert post_processor.name == "vita_postprocessor"
+
+
+def test_adaptation_state_init_update_reset_without_mutating_base_weights():
+    model = _make_model()
+    base_weights_before = model.adaptation_module.base_fast_weights()
+    base_w1_before = base_weights_before.w1.detach().clone()
+    base_b1_before = base_weights_before.b1.detach().clone()
+    base_w2_before = base_weights_before.w2.detach().clone()
+    base_b2_before = base_weights_before.b2.detach().clone()
+    batch = {
+        "image_features": torch.tensor([[0.1, 0.2, 0.3, 0.4], [0.4, 0.3, 0.2, 0.1]]),
+        "text_features": torch.tensor([[0.5, 0.6, 0.7, 0.8], [0.8, 0.7, 0.6, 0.5]]),
+    }
+
+    _ = model.compute_reward(batch)
+    assert model.adaptation_state is not None
+    state = model.adaptation_state
+    assert torch.equal(state.num_updates, torch.ones(2, dtype=torch.long))
+
+    base_weights = model.adaptation_module.base_fast_weights()
+    base_w1_expanded = base_weights.w1.detach().unsqueeze(0).expand_as(state.fast_weights.w1)
+    assert not torch.allclose(state.fast_weights.w1, base_w1_expanded)
+    assert torch.allclose(model.adaptation_module.base_fast_weights().w1.detach(), base_w1_before)
+    assert torch.allclose(model.adaptation_module.base_fast_weights().b1.detach(), base_b1_before)
+    assert torch.allclose(model.adaptation_module.base_fast_weights().w2.detach(), base_w2_before)
+    assert torch.allclose(model.adaptation_module.base_fast_weights().b2.detach(), base_b2_before)
+
+    model.reset_adaptation_state(batch_size=2, device=torch.device("cpu"))
+    reset_state = model.adaptation_state
+    assert reset_state is not None
+    assert torch.equal(reset_state.num_updates, torch.zeros(2, dtype=torch.long))
+    reset_base = model.adaptation_module.base_fast_weights()
+    reset_w1_expanded = reset_base.w1.detach().unsqueeze(0).expand_as(reset_state.fast_weights.w1)
+    assert torch.allclose(reset_state.fast_weights.w1, reset_w1_expanded)
+
+
+def test_compute_reward_shape_type_and_determinism_with_dummy_backbone():
+    model = _make_model()
+    batch = {
+        "image_features": torch.tensor([[0.2, 0.0, 0.1, 0.3], [0.9, 0.1, 0.2, 0.4]]),
+        "text_features": torch.tensor([[0.5, 0.1, 0.2, 0.0], [0.0, 0.3, 0.2, 0.1]]),
+    }
+
+    model.reset_adaptation_state()
+    reward_first = model.compute_reward(batch)
+    model.reset_adaptation_state()
+    reward_second = model.compute_reward(batch)
+
+    assert reward_first.shape == (2,)
+    assert reward_first.dtype == torch.float32
+    assert torch.allclose(reward_first, reward_second)
+
+
+def test_episode_start_resets_selected_adaptation_states():
+    model = _make_model()
+    batch_step1 = {
+        "image_features": torch.tensor([[0.1, 0.2, 0.1, 0.0], [0.0, 0.1, 0.2, 0.3]]),
+        "text_features": torch.tensor([[0.3, 0.2, 0.1, 0.0], [0.4, 0.3, 0.2, 0.1]]),
+    }
+    batch_step2 = {
+        "image_features": torch.tensor([[0.5, 0.1, 0.0, 0.3], [0.2, 0.2, 0.2, 0.2]]),
+        "text_features": torch.tensor([[0.0, 0.1, 0.2, 0.3], [0.1, 0.2, 0.3, 0.4]]),
+        "episode_start": torch.tensor([True, False]),
+    }
+
+    _ = model.compute_reward(batch_step1)
+    _ = model.compute_reward(batch_step2)
+    assert model.adaptation_state is not None
+    updates = model.adaptation_state.num_updates
+    assert updates.tolist() == [1, 2]
+
+
+def test_forward_meta_learning_outer_loop_outputs_loss_and_metrics():
+    model = _make_model()
+    model.config.meta_enabled = True
+    model.config.support_len = 1
+    model.config.query_len = 1
+    model.config.inner_steps = 2
+    model.config.inner_lr = 0.05
+    model.config.target_reward_key = "reward"
+
+    batch = {
+        "image_features": torch.tensor([[[0.1, 0.2, 0.3, 0.4], [0.2, 0.3, 0.1, 0.0]]]),
+        "text_features": torch.tensor([[[0.5, 0.6, 0.7, 0.8], [0.8, 0.7, 0.6, 0.5]]]),
+        "reward": torch.tensor([[0.0, 1.0]]),
+    }
+
+    loss, metrics = model.forward(batch)
+    assert loss.ndim == 0
+    assert "loss" in metrics
+    assert "outer_loss" in metrics
+    assert "inner_loss" in metrics
+    assert "self_supervised_loss" in metrics
+
+
+def test_forward_dissimilarity_sampling_runs_and_returns_scalar_loss():
+    model = _make_model()
+    model.config.meta_enabled = True
+    model.config.support_len = 2
+    model.config.query_len = 2
+    model.config.sampling_strategy = "dissimilarity"
+    model.config.sampling_window_size = 2
+    model.config.sampling_num_windows = 2
+    model.config.sampling_stride = 1
+    model.config.target_reward_key = "reward"
+
+    batch = {
+        "image_features": torch.tensor(
+            [
+                [
+                    [0.1, 0.0, 0.0, 0.0],
+                    [0.0, 1.0, 0.0, 0.0],
+                    [0.0, 0.0, 1.0, 0.0],
+                    [0.0, 0.0, 0.0, 1.0],
+                    [1.0, 0.0, 0.0, 0.0],
+                ]
+            ]
+        ),
+        "text_features": torch.tensor(
+            [
+                [
+                    [0.0, 0.1, 0.0, 0.0],
+                    [0.0, 0.0, 0.1, 0.0],
+                    [0.0, 0.0, 0.0, 0.1],
+                    [0.1, 0.0, 0.0, 0.0],
+                    [0.0, 0.1, 0.0, 0.0],
+                ]
+            ]
+        ),
+        "reward": torch.tensor([[0.0, 0.2, 0.4, 0.6, 1.0]]),
+    }
+
+    loss, metrics = model.forward(batch)
+    assert loss.ndim == 0
+    assert metrics["outer_loss"].ndim == 0
+    assert metrics["inner_loss"].ndim == 0
+
+
+def test_forward_generates_progress_targets_when_missing_reward_key():
+    model = _make_model()
+    model.config.meta_enabled = True
+    model.config.target_reward_key = "missing_reward"
+    model.config.force_temporal_progress_targets = True
+    batch = {
+        "image_features": torch.tensor([[[0.1, 0.2, 0.3, 0.4], [0.2, 0.3, 0.1, 0.0]]]),
+        "text_features": torch.tensor([[[0.5, 0.6, 0.7, 0.8], [0.8, 0.7, 0.6, 0.5]]]),
+    }
+
+    loss, metrics = model.forward(batch)
+    assert loss.ndim == 0
+    assert "outer_loss" in metrics
+
+
+def test_scheduler_uses_ten_percent_warmup_ratio():
+    cfg = VitaConfig()
+    scheduler_cfg = cfg.get_scheduler_preset()
+    assert scheduler_cfg is not None
+    assert "vita_paper_cosine" in LRSchedulerConfig.get_known_choices()
+    assert LRSchedulerConfig.get_choice_class("vita_paper_cosine") is type(scheduler_cfg)
+    assert hasattr(scheduler_cfg, "warmup_ratio")
+    assert scheduler_cfg.warmup_ratio == 0.1


### PR DESCRIPTION
## Title
feat(rewards): integrate VITA reward model with train/docs/tests
## Summary / Motivation
This PR integrates VITA as a first-class LeRobot reward model (trainable via `lerobot-train` reward-model path), aligned with the core method from the VITA paper https://arxiv.org/abs/2506.10085.  
## Related issues

- Related: #3143 

## What changed
- Added VITA reward model integration in `src/lerobot/rewards/vita/*`.
- Registered VITA in reward exports/factory (`src/lerobot/rewards/__init__.py`, `src/lerobot/rewards/factory.py`).
- Registered `vita_paper_cosine` scheduler for stable config loading/training.
- Updated docs (`docs/source/vita.mdx`) to match current reward-model CLI (`--reward_model.*`), and added VITA to docs toctree.
- Added/updated unit tests in `tests/rewards/test_vita_reward.py`.
No breaking API changes intended for existing policy training paths.:

## Artifacts / qualitative demos
- Paper: [VITA (arXiv:2506.10085)](https://arxiv.org/abs/2506.10085)
- Training data: [praedico/bridgev2-vita-toykitchen-lerobot](https://huggingface.co/datasets/praedico/bridgev2-vita-toykitchen-lerobot), a VITA paper style dataset : BridgeV2 ToyKitchen pick-and-place subset reconstructed from `Gaugou/BridgeV2`, with 2,986 train episodes and 287 held-out test episodes.
- Training setup: trained on `observation.images.primary` + `task`; current checkpoint reached 10k steps with batch size 8 before Colab GPU T4 quota interruption.
- Trained Model / Checkpoint: [praedico/vita-bridgev2-toykitchen-primary](https://huggingface.co/praedico/vita-bridgev2-toykitchen-primary)
- Demo : 

https://github.com/user-attachments/assets/2b985513-abca-409d-b54e-e3f1a02c6e54



## How was this tested (or how to run locally)

- Tests added: list new tests or test files. `pytest -q tests/ -k <keyword>`
- Manual checks / dataset runs performed.
- Instructions for the reviewer for reproducing with a quick example or CLI (if applicable)

## Checklist (required before merge)

- [ ] Linting/formatting run (`pre-commit run -a`)
- [ ] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: # (insert PR number/link)

## Reviewer notes

- Anything the reviewer should focus on (performance, edge-cases, specific files) or general notes.
- Anyone in the community is free to review the PR.
