### PR TITLE
fix(datasets): support depth (1-ch) and RGBA (4-ch) images in image_writer

### DIFF
--- a/src/lerobot/datasets/image_writer.py
+++ b/src/lerobot/datasets/image_writer.py
@@ -42,17 +42,23 @@ def safe_stop_image_writer(func):
 
 
 def image_array_to_pil_image(image_array: np.ndarray, range_check: bool = True) -> PIL.Image.Image:
-    # TODO(aliberts): handle 1 channel and 4 for depth images
     if image_array.ndim != 3:
         raise ValueError(f"The array has {image_array.ndim} dimensions, but 3 is expected for an image.")
 
-    if image_array.shape[0] == 3:
+    channels = image_array.shape[0] if image_array.shape[0] in (1, 3, 4) else image_array.shape[-1]
+
+    if image_array.shape[0] in (1, 3, 4):
         # Transpose from pytorch convention (C, H, W) to (H, W, C)
         image_array = image_array.transpose(1, 2, 0)
+        channels = image_array.shape[-1]
 
-    elif image_array.shape[-1] != 3:
+    if channels == 1:
+        image_array = image_array.squeeze(-1)
+    elif channels == 4:
+        image_array = image_array[:, :, :3]
+    elif channels != 3:
         raise NotImplementedError(
-            f"The image has {image_array.shape[-1]} channels, but 3 is required for now."
+            f"The image has {channels} channels. Supported: 1 (depth), 3 (RGB), 4 (RGBA)."
         )
 
     if image_array.dtype != np.uint8:


### PR DESCRIPTION
## Summary

`image_array_to_pil_image()` rejected any image that wasn't exactly 3 channels, blocking RGB-D dataset collection with depth cameras and RGBA sources.

Now handles:
- **1-channel**: squeeze to 2D grayscale for PIL (depth images)
- **3-channel**: RGB (unchanged)
- **4-channel**: drop alpha channel, keep RGB

Resolves the TODO on line 45: `# TODO(aliberts): handle 1 channel and 4 for depth images`

## Test plan

- [x] 3-channel images work as before
- [ ] 1-channel numpy array (H, W, 1) saves as grayscale PNG
- [ ] 4-channel numpy array (H, W, 4) saves as RGB PNG (alpha dropped)
- [ ] PyTorch convention (1, H, W) and (4, H, W) transpose correctly