### PR TITLE
fix(datasets): close file handle on VideoDecoder init failure in cache

### DIFF
--- a/src/lerobot/datasets/video_utils.py
+++ b/src/lerobot/datasets/video_utils.py
@@ -282,7 +282,11 @@ class VideoDecoderCache:
         with self._lock:
             if video_path not in self._cache:
                 file_handle = fsspec.open(video_path).__enter__()
-                decoder = VideoDecoder(file_handle, seek_mode="approximate")
+                try:
+                    decoder = VideoDecoder(file_handle, seek_mode="approximate")
+                except Exception:
+                    file_handle.close()
+                    raise
                 self._cache[video_path] = (decoder, file_handle)
 
             return self._cache[video_path][0]


### PR DESCRIPTION
## Summary

In `VideoDecoderCache.get()`, if `VideoDecoder()` raises during initialization (e.g., corrupted video file, unsupported codec), the fsspec file handle opened via `__enter__()` is never closed, causing a resource leak.

Added try/except to close the handle before re-raising.

## Test plan

- [x] Normal path unchanged (decoder succeeds, handle stored in cache)
- [ ] Exception path: handle is closed before propagating the error