### PR TITLE
chore(ci): disable auto-stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,8 +19,8 @@ on:
   workflow_dispatch:
 
   # Runs at 02:00
-  schedule:
-    - cron: "0 2 * * *"
+  # schedule:
+  #   - cron: "0 2 * * *"
 
 env:
   CLOSE_ISSUE_MESSAGE: >


### PR DESCRIPTION
In early stages of the project, we used the auto-stale bot to help clean up old and inactive GitHub issues. However, as the project has stabilized, we recognize that older tickets often remain highly relevant. Out of respect for our contributors' valuable input, and for the overall health of the project, we are disabling the auto-stale feature. Moving forward, we will rely on manual stale checks instead.