### PR TITLE
Fix nested array parquet round trips in dataset tools

### DIFF
--- a/src/lerobot/datasets/aggregate.py
+++ b/src/lerobot/datasets/aggregate.py
@@ -29,8 +29,10 @@ from .feature_utils import get_hf_features_from_features
 from .io_utils import (
     get_file_size_in_mb,
     get_parquet_file_size_in_mb,
+    read_lerobot_data_frame,
     to_parquet_with_hf_images,
     write_info,
+    write_lerobot_data_frame,
     write_stats,
     write_tasks,
 )
@@ -457,10 +459,7 @@ def aggregate_data(src_meta, dst_meta, data_idx, data_files_size_in_mb, chunk_si
     }
 
     unique_chunk_file_ids = sorted(unique_chunk_file_ids)
-    contains_images = len(dst_meta.image_keys) > 0
-
-    # retrieve features schema for proper image typing in parquet
-    hf_features = get_hf_features_from_features(dst_meta.features) if contains_images else None
+    hf_features = get_hf_features_from_features(dst_meta.features)
 
     # Track source to destination file mapping for metadata update
     # This is critical for handling datasets that are already results of a merge
@@ -470,12 +469,7 @@ def aggregate_data(src_meta, dst_meta, data_idx, data_files_size_in_mb, chunk_si
         src_path = src_meta.root / DEFAULT_DATA_PATH.format(
             chunk_index=src_chunk_idx, file_index=src_file_idx
         )
-        if contains_images:
-            # Use HuggingFace datasets to read source data to preserve image format
-            src_ds = datasets.Dataset.from_parquet(str(src_path))
-            df = src_ds.to_pandas()
-        else:
-            df = pd.read_parquet(src_path)
+        df = read_lerobot_data_frame(src_path, hf_features)
         df = update_data_df(df, src_meta, dst_meta)
 
         # Write data and get the actual destination file it was written to
@@ -487,7 +481,6 @@ def aggregate_data(src_meta, dst_meta, data_idx, data_files_size_in_mb, chunk_si
             data_files_size_in_mb,
             chunk_size,
             DEFAULT_DATA_PATH,
-            contains_images=contains_images,
             aggr_root=dst_meta.root,
             hf_features=hf_features,
         )
@@ -592,8 +585,10 @@ def append_or_create_parquet_file(
 
     if not dst_path.exists():
         dst_path.parent.mkdir(parents=True, exist_ok=True)
-        if contains_images:
-            to_parquet_with_hf_images(df, dst_path, features=hf_features)
+        if hf_features is not None:
+            write_lerobot_data_frame(df, dst_path, hf_features)
+        elif contains_images:
+            to_parquet_with_hf_images(df, dst_path)
         else:
             df.to_parquet(dst_path)
         return idx, (dst_chunk, dst_file)
@@ -609,17 +604,19 @@ def append_or_create_parquet_file(
         final_df = df
         target_path = new_path
     else:
-        if contains_images:
-            # Use HuggingFace datasets to read existing data to preserve image format
-            existing_ds = datasets.Dataset.from_parquet(str(dst_path))
-            existing_df = existing_ds.to_pandas()
+        if hf_features is not None:
+            existing_df = read_lerobot_data_frame(dst_path, hf_features)
+        elif contains_images:
+            existing_df = datasets.Dataset.from_parquet(str(dst_path)).to_pandas()
         else:
             existing_df = pd.read_parquet(dst_path)
         final_df = pd.concat([existing_df, df], ignore_index=True)
         target_path = dst_path
 
-    if contains_images:
-        to_parquet_with_hf_images(final_df, target_path, features=hf_features)
+    if hf_features is not None:
+        write_lerobot_data_frame(final_df, target_path, hf_features)
+    elif contains_images:
+        to_parquet_with_hf_images(final_df, target_path)
     else:
         final_df.to_parquet(target_path)
 

--- a/src/lerobot/datasets/dataset_tools.py
+++ b/src/lerobot/datasets/dataset_tools.py
@@ -29,10 +29,8 @@ from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
-import datasets
 import numpy as np
 import pandas as pd
-import pyarrow.parquet as pq
 import torch
 from tqdm import tqdm
 
@@ -46,10 +44,13 @@ from .compute_stats import (
     compute_relative_action_stats,
 )
 from .dataset_metadata import LeRobotDatasetMetadata
+from .feature_utils import get_hf_features_from_features
 from .io_utils import (
     get_parquet_file_size_in_mb,
     load_episodes,
+    read_lerobot_data_frame,
     write_info,
+    write_lerobot_data_frame,
     write_stats,
     write_tasks,
 )
@@ -504,11 +505,12 @@ def _copy_and_reindex_data(
 
     global_index = 0
     episode_data_metadata: dict[int, dict] = {}
+    src_hf_features = get_hf_features_from_features(src_dataset.meta.features)
 
     if dst_meta.tasks is None:
         all_task_indices = set()
         for src_path in file_to_episodes:
-            df = pd.read_parquet(src_dataset.root / src_path)
+            df = read_lerobot_data_frame(src_dataset.root / src_path, src_hf_features)
             mask = df["episode_index"].isin(list(episode_mapping.keys()))
             task_series: pd.Series = df[mask]["task_index"]
             all_task_indices.update(task_series.unique().tolist())
@@ -523,7 +525,7 @@ def _copy_and_reindex_data(
             task_mapping[old_task_idx] = new_task_idx
 
     for src_path in tqdm(sorted(file_to_episodes.keys()), desc="Processing data files"):
-        df = pd.read_parquet(src_dataset.root / src_path)
+        df = read_lerobot_data_frame(src_dataset.root / src_path, src_hf_features)
 
         all_episodes_in_file = set(df["episode_index"].unique())
         episodes_to_keep = file_to_episodes[src_path]
@@ -918,19 +920,8 @@ def _write_parquet(df: pd.DataFrame, path: Path, meta: LeRobotDatasetMetadata) -
 
     This ensures images are properly embedded and the file can be loaded correctly by HF datasets.
     """
-    from .feature_utils import get_hf_features_from_features
-    from .io_utils import embed_images
-
     hf_features = get_hf_features_from_features(meta.features)
-    ep_dataset = datasets.Dataset.from_dict(df.to_dict(orient="list"), features=hf_features, split="train")
-
-    if len(meta.image_keys) > 0:
-        ep_dataset = embed_images(ep_dataset)
-
-    table = ep_dataset.with_format("arrow")[:]
-    writer = pq.ParquetWriter(path, schema=table.schema, compression="snappy", use_dictionary=True)
-    writer.write_table(table)
-    writer.close()
+    write_lerobot_data_frame(df, path, hf_features)
 
 
 def _save_data_chunk(
@@ -981,9 +972,10 @@ def _copy_data_with_feature_changes(
         raise ValueError(f"No parquet files found in {data_dir}")
 
     frame_idx = 0
+    src_hf_features = get_hf_features_from_features(dataset.meta.features)
 
     for src_path in tqdm(parquet_files, desc="Processing data files"):
-        df = pd.read_parquet(src_path).reset_index(drop=True)
+        df = read_lerobot_data_frame(src_path, src_hf_features).reset_index(drop=True)
 
         relative_path = src_path.relative_to(dataset.root)
         chunk_dir = relative_path.parts[1]
@@ -1371,9 +1363,11 @@ def _copy_data_without_images(
         raise ValueError(f"No parquet files found in {data_dir}")
 
     episode_set = set(episode_indices)
+    src_hf_features = get_hf_features_from_features(src_dataset.meta.features)
+    dst_hf_features = get_hf_features_from_features(dst_meta.features)
 
     for src_path in tqdm(parquet_files, desc="Processing data files"):
-        df = pd.read_parquet(src_path).reset_index(drop=True)
+        df = read_lerobot_data_frame(src_path, src_hf_features).reset_index(drop=True)
 
         # Filter to only include selected episodes
         df = df[df["episode_index"].isin(episode_set)].copy()
@@ -1395,8 +1389,7 @@ def _copy_data_without_images(
 
         # Write to destination without pandas index
         dst_path = dst_meta.root / f"data/chunk-{chunk_idx:03d}/file-{file_idx:03d}.parquet"
-        dst_path.parent.mkdir(parents=True, exist_ok=True)
-        df.to_parquet(dst_path, index=False)
+        write_lerobot_data_frame(df, dst_path, dst_hf_features)
 
 
 # Video conversion constants
@@ -1491,9 +1484,10 @@ def modify_tasks(
     # Update data files - modify task_index column
     logging.info("Updating data files...")
     data_dir = root / DATA_DIR
+    hf_features = get_hf_features_from_features(dataset.meta.features)
 
     for parquet_path in tqdm(sorted(data_dir.rglob("*.parquet")), desc="Updating data"):
-        df = pd.read_parquet(parquet_path)
+        df = read_lerobot_data_frame(parquet_path, hf_features)
 
         # Build a mapping from episode_index to new task_index for rows in this file
         episode_indices_in_file = df["episode_index"].unique()
@@ -1503,7 +1497,7 @@ def modify_tasks(
 
         # Update task_index column
         df["task_index"] = df["episode_index"].map(ep_to_new_task_idx)
-        df.to_parquet(parquet_path, index=False)
+        write_lerobot_data_frame(df, parquet_path, hf_features)
 
     # Update episodes metadata - modify tasks column
     logging.info("Updating episodes metadata...")
@@ -1600,9 +1594,10 @@ def recompute_stats(
 
     all_episode_stats = []
     numeric_keys = [k for k, v in features_to_compute.items() if v["dtype"] not in ["image", "video"]]
+    hf_features = get_hf_features_from_features(dataset.meta.features)
 
     for parquet_path in tqdm(parquet_files, desc="Computing stats from data files"):
-        df = pd.read_parquet(parquet_path)
+        df = read_lerobot_data_frame(parquet_path, hf_features)
 
         for ep_idx in sorted(df["episode_index"].unique()):
             ep_df = df[df["episode_index"] == ep_idx]

--- a/src/lerobot/datasets/io_utils.py
+++ b/src/lerobot/datasets/io_utils.py
@@ -276,6 +276,28 @@ def hf_transform_to_torch(items_dict: dict[str, list[Any]]) -> dict[str, list[to
     return items_dict
 
 
+def read_lerobot_data_frame(path: Path, features: datasets.Features) -> pandas.DataFrame:
+    """Read a LeRobot data parquet file using its authoritative HF feature schema."""
+    dataset = datasets.Dataset.from_parquet(str(path), features=features)
+    return pd.DataFrame(dataset.with_format(None)[:])
+
+
+def write_lerobot_data_frame(df: pandas.DataFrame, path: Path, features: datasets.Features) -> None:
+    """Write a LeRobot data dataframe with the provided HF feature schema."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    dataset = datasets.Dataset.from_dict(df.to_dict(orient="list"), features=features, split="train")
+
+    if any(isinstance(feature, datasets.Image) for feature in features.values()):
+        dataset = embed_images(dataset)
+
+    table = dataset.with_format("arrow")[:]
+    writer = pq.ParquetWriter(path, schema=table.schema, compression="snappy", use_dictionary=True)
+    try:
+        writer.write_table(table)
+    finally:
+        writer.close()
+
+
 def to_parquet_with_hf_images(
     df: pandas.DataFrame, path: Path, features: datasets.Features | None = None
 ) -> None:

--- a/tests/datasets/test_dataset_tools.py
+++ b/tests/datasets/test_dataset_tools.py
@@ -23,15 +23,19 @@ import torch
 
 pytest.importorskip("datasets", reason="datasets is required (install lerobot[dataset])")
 
+import datasets  # noqa: E402
+
 from lerobot.datasets.dataset_tools import (
     add_features,
     delete_episodes,
     merge_datasets,
     modify_features,
     modify_tasks,
+    recompute_stats,
     remove_feature,
     split_dataset,
 )
+from lerobot.datasets.feature_utils import get_hf_features_from_features
 from lerobot.scripts.lerobot_edit_dataset import convert_image_to_video_dataset
 
 
@@ -62,6 +66,50 @@ def sample_dataset(tmp_path, empty_lerobot_dataset_factory):
 
     dataset.finalize()
     return dataset
+
+
+def make_nested_array_dataset(
+    root,
+    empty_lerobot_dataset_factory,
+    num_episodes: int = 3,
+    frames_per_episode: int = 4,
+):
+    """Create a no-image dataset with fixed-shape nested array columns."""
+    features = {
+        "ctrl.joint_angles": {"dtype": "float32", "shape": (2, 7), "names": None},
+        "ctrl.gripper_width": {"dtype": "float32", "shape": (2, 1), "names": None},
+    }
+    dataset = empty_lerobot_dataset_factory(root=root, features=features)
+
+    for ep_idx in range(num_episodes):
+        for frame_idx in range(frames_per_episode):
+            dataset.add_frame(
+                {
+                    "ctrl.joint_angles": np.full((2, 7), ep_idx + frame_idx / 10, dtype=np.float32),
+                    "ctrl.gripper_width": np.full((2, 1), frame_idx, dtype=np.float32),
+                    "task": f"task_{ep_idx % 2}",
+                }
+            )
+        dataset.save_episode()
+
+    dataset.finalize()
+    return dataset
+
+
+def assert_nested_arrays_load(dataset):
+    item = dataset[0]
+    assert item["ctrl.joint_angles"].shape == torch.Size([2, 7])
+    assert item["ctrl.joint_angles"].dtype == torch.float32
+    assert item["ctrl.gripper_width"].shape == torch.Size([2, 1])
+    assert item["ctrl.gripper_width"].dtype == torch.float32
+
+
+def assert_nested_array_parquet_schema(dataset):
+    hf_features = get_hf_features_from_features(dataset.meta.features)
+    parquet_path = dataset.root / dataset.meta.get_data_file_path(0)
+    direct = datasets.Dataset.from_parquet(str(parquet_path), features=hf_features)
+    assert direct.features["ctrl.joint_angles"].shape == (2, 7)
+    assert direct.features["ctrl.gripper_width"].shape == (2, 1)
 
 
 def test_delete_single_episode(sample_dataset, tmp_path):
@@ -295,6 +343,155 @@ def test_merge_empty_list(tmp_path):
     """Test error when merging empty list."""
     with pytest.raises(ValueError, match="No datasets to merge"):
         merge_datasets([], output_repo_id="merged", output_dir=tmp_path)
+
+
+def test_merge_datasets_with_nested_array_features_no_images(tmp_path, empty_lerobot_dataset_factory):
+    """Test merging no-image datasets with fixed-shape nested array features."""
+    dataset1 = make_nested_array_dataset(
+        tmp_path / "nested_dataset1", empty_lerobot_dataset_factory, num_episodes=2
+    )
+    dataset2 = make_nested_array_dataset(
+        tmp_path / "nested_dataset2", empty_lerobot_dataset_factory, num_episodes=3
+    )
+
+    with (
+        patch("lerobot.datasets.dataset_metadata.get_safe_version") as mock_get_safe_version,
+        patch("lerobot.datasets.dataset_metadata.snapshot_download") as mock_snapshot_download,
+    ):
+        mock_get_safe_version.return_value = "v3.0"
+        mock_snapshot_download.return_value = str(tmp_path / "merged_nested")
+
+        merged = merge_datasets(
+            [dataset1, dataset2],
+            output_repo_id="merged_nested",
+            output_dir=tmp_path / "merged_nested",
+        )
+
+    assert merged.meta.total_episodes == dataset1.meta.total_episodes + dataset2.meta.total_episodes
+    assert merged.meta.total_frames == dataset1.meta.total_frames + dataset2.meta.total_frames
+    episode_indices = sorted({int(idx.item()) for idx in merged.hf_dataset["episode_index"]})
+    assert episode_indices == list(range(merged.meta.total_episodes))
+    assert_nested_arrays_load(merged)
+    assert_nested_array_parquet_schema(merged)
+
+
+def test_split_dataset_with_nested_array_features_no_images(tmp_path, empty_lerobot_dataset_factory):
+    """Test splitting no-image datasets with fixed-shape nested array features."""
+    dataset = make_nested_array_dataset(tmp_path / "nested_dataset", empty_lerobot_dataset_factory)
+    splits = {"train": [0, 2], "val": [1]}
+
+    with (
+        patch("lerobot.datasets.dataset_metadata.get_safe_version") as mock_get_safe_version,
+        patch("lerobot.datasets.dataset_metadata.snapshot_download") as mock_snapshot_download,
+    ):
+        mock_get_safe_version.return_value = "v3.0"
+
+        def mock_snapshot(repo_id, **kwargs):
+            for split_name in splits:
+                if split_name in repo_id:
+                    return str(tmp_path / f"{dataset.repo_id}_{split_name}")
+            return str(kwargs.get("local_dir", tmp_path))
+
+        mock_snapshot_download.side_effect = mock_snapshot
+        result = split_dataset(dataset, splits=splits, output_dir=tmp_path)
+
+    assert set(result) == {"train", "val"}
+    assert result["train"].meta.total_episodes == 2
+    assert result["train"].meta.total_frames == 8
+    assert result["val"].meta.total_episodes == 1
+    assert result["val"].meta.total_frames == 4
+
+    train_episodes = sorted({int(idx.item()) for idx in result["train"].hf_dataset["episode_index"]})
+    val_episodes = sorted({int(idx.item()) for idx in result["val"].hf_dataset["episode_index"]})
+    assert train_episodes == [0, 1]
+    assert val_episodes == [0]
+    assert_nested_arrays_load(result["train"])
+    assert_nested_arrays_load(result["val"])
+    assert_nested_array_parquet_schema(result["train"])
+
+
+def test_delete_episodes_with_nested_array_features_no_images(tmp_path, empty_lerobot_dataset_factory):
+    """Test deleting episodes from no-image datasets with nested array features."""
+    dataset = make_nested_array_dataset(tmp_path / "nested_dataset", empty_lerobot_dataset_factory)
+
+    with (
+        patch("lerobot.datasets.dataset_metadata.get_safe_version") as mock_get_safe_version,
+        patch("lerobot.datasets.dataset_metadata.snapshot_download") as mock_snapshot_download,
+    ):
+        mock_get_safe_version.return_value = "v3.0"
+        mock_snapshot_download.return_value = str(tmp_path / "filtered_nested")
+
+        filtered = delete_episodes(dataset, episode_indices=[1], output_dir=tmp_path / "filtered_nested")
+
+    assert filtered.meta.total_episodes == 2
+    assert filtered.meta.total_frames == 8
+    episode_indices = sorted({int(idx.item()) for idx in filtered.hf_dataset["episode_index"]})
+    assert episode_indices == [0, 1]
+    assert_nested_arrays_load(filtered)
+    assert_nested_array_parquet_schema(filtered)
+
+
+def test_modify_features_with_nested_array_features_no_images(tmp_path, empty_lerobot_dataset_factory):
+    """Test adding and removing features preserves existing nested array columns."""
+    dataset = make_nested_array_dataset(tmp_path / "nested_dataset", empty_lerobot_dataset_factory)
+    success_values = np.ones((dataset.meta.total_frames, 1), dtype=np.float32)
+    feature_info = {"dtype": "float32", "shape": (1,), "names": None}
+
+    with (
+        patch("lerobot.datasets.dataset_metadata.get_safe_version") as mock_get_safe_version,
+        patch("lerobot.datasets.dataset_metadata.snapshot_download") as mock_snapshot_download,
+    ):
+        mock_get_safe_version.return_value = "v3.0"
+        mock_snapshot_download.side_effect = lambda repo_id, **kwargs: str(kwargs.get("local_dir", tmp_path))
+
+        with_success = add_features(
+            dataset,
+            features={"success": (success_values, feature_info)},
+            output_dir=tmp_path / "with_success",
+        )
+        without_success = remove_feature(
+            with_success,
+            feature_names="success",
+            output_dir=tmp_path / "without_success",
+        )
+
+    assert "success" in with_success.meta.features
+    assert_nested_arrays_load(with_success)
+    assert "success" not in without_success.meta.features
+    assert_nested_arrays_load(without_success)
+    assert_nested_array_parquet_schema(without_success)
+
+
+def test_modify_tasks_with_nested_array_features_no_images(tmp_path, empty_lerobot_dataset_factory):
+    """Test task edits preserve nested array feature columns."""
+    dataset = make_nested_array_dataset(tmp_path / "nested_dataset", empty_lerobot_dataset_factory)
+    episode_tasks = {
+        0: "Alpha task",
+        1: "Beta task",
+        2: "Alpha task",
+    }
+
+    modified = modify_tasks(dataset, episode_tasks=episode_tasks)
+
+    assert_nested_arrays_load(modified)
+    assert_nested_array_parquet_schema(modified)
+    for i in range(len(modified)):
+        item = modified[i]
+        ep_idx = item["episode_index"].item()
+        assert item["task"] == episode_tasks[ep_idx]
+
+
+def test_recompute_stats_with_nested_array_features_no_images(tmp_path, empty_lerobot_dataset_factory):
+    """Test recomputing stats can read fixed-shape nested array data parquet."""
+    dataset = make_nested_array_dataset(tmp_path / "nested_dataset", empty_lerobot_dataset_factory)
+
+    recomputed = recompute_stats(dataset)
+
+    assert {"ctrl.joint_angles", "ctrl.gripper_width"}.issubset(recomputed.meta.stats)
+    assert recomputed.meta.stats["ctrl.joint_angles"]["mean"].shape == (7,)
+    assert recomputed.meta.stats["ctrl.gripper_width"]["mean"].shape == (1,)
+    assert_nested_arrays_load(recomputed)
+    assert_nested_array_parquet_schema(recomputed)
 
 
 def test_add_features_with_values(sample_dataset, tmp_path):


### PR DESCRIPTION
## What this fixes

Fixes #2445.

`merge_datasets()` and related dataset maintenance helpers could fail when a LeRobot data parquet file contained fixed-shape array features such as `datasets.Array2D`. Those features are represented by Hugging Face Datasets as PyArrow extension types, but several code paths were round-tripping data parquet files through pandas directly. That stripped the authoritative HF feature schema and could produce `pyarrow.lib.ArrowTypeError` when writing or appending nested array columns.

## Changes

- Add schema-aware LeRobot data parquet helpers in `lerobot.datasets.io_utils`.
- Read and write data parquet files through Hugging Face `Features` in dataset aggregation and dataset maintenance tools.
- Preserve the existing image embedding behavior while applying the same schema-aware IO path to non-image fixed-shape arrays.
- Keep metadata parquet handling on the existing pandas path, since the schema issue is specific to data files with HF feature extension types.
- Add regressions for nested array features across:
  - `merge_datasets`
  - `split_dataset`
  - `delete_episodes`
  - `modify_features`
  - `modify_tasks`
  - `recompute_stats`

## Validation

- `uv run --extra dev ruff check src/lerobot/datasets/aggregate.py src/lerobot/datasets/dataset_tools.py src/lerobot/datasets/io_utils.py tests/datasets/test_dataset_tools.py`
- `uv run --extra dev ruff format --check src/lerobot/datasets/aggregate.py src/lerobot/datasets/dataset_tools.py src/lerobot/datasets/io_utils.py tests/datasets/test_dataset_tools.py`
- `uv run --extra test --extra dataset pytest tests/datasets/test_dataset_tools.py -k nested_array -svv`
- `uv run --extra test --extra dataset pytest tests/datasets/test_aggregate.py::test_aggregate_image_datasets -svv`
- `uv run --extra test --extra dataset pytest tests/datasets/test_dataset_tools.py --deselect tests/datasets/test_dataset_tools.py::test_convert_image_to_video_dataset -svv`
- `git diff --check`

Note: `test_convert_image_to_video_dataset` was deselected locally because this macOS environment has a TorchCodec/FFmpeg dylib mismatch unrelated to these parquet schema changes.
