### PR TITLE
Add keyboard teleoperation support for SO follower arms

### DIFF
--- a/AGENT_GUIDE.md
+++ b/AGENT_GUIDE.md
@@ -103,6 +103,17 @@ lerobot-teleoperate \
   --display_data=true
 ```
 
+No leader arm available? Use keyboard joint control for a quick follower-only sanity check:
+
+```bash
+lerobot-teleoperate \
+  --robot.type=so101_follower --robot.port=<FOLLOWER_PORT> --robot.id=my_follower \
+  --teleop.type=keyboard
+```
+
+Keyboard controls: `a`/`d` shoulder pan, `w`/`s` shoulder lift, `i`/`k` elbow flex,
+`j`/`l` wrist flex, `u`/`o` wrist roll, `r`/`f` gripper target.
+
 > **Feetech timeout / comms error on SO-100 / SO-101?** Before touching software, check the **red motor LEDs** on the daisy chain.
 >
 > - **All steady red, gripper → base chain** → wiring OK.

--- a/docs/source/il_robots.mdx
+++ b/docs/source/il_robots.mdx
@@ -96,6 +96,33 @@ The teleoperate command will automatically:
 1. Identify any missing calibrations and initiate the calibration procedure.
 2. Connect the robot and teleop device and start teleoperation.
 
+### Teleoperate SO-100/SO-101 with keyboard
+
+If you do not have a leader arm available, you can also move an SO-100 or SO-101 follower directly
+from your keyboard. Keyboard teleoperation uses small incremental joint-position commands; it is a
+sanity-check and simple-control mode, not end-effector control or inverse kinematics.
+
+```bash
+lerobot-teleoperate \
+    --robot.type=so101_follower \
+    --robot.port=/dev/tty.usbmodem58760431541 \
+    --robot.id=my_awesome_follower_arm \
+    --teleop.type=keyboard
+```
+
+| Keys | Joint |
+| --- | --- |
+| `a` / `d` | shoulder pan - / + |
+| `w` / `s` | shoulder lift + / - |
+| `i` / `k` | elbow flex + / - |
+| `j` / `l` | wrist flex - / + |
+| `u` / `o` | wrist roll - / + |
+| `r` / `f` | gripper target + / - |
+
+The arm holds its current position when no mapped keys are pressed. Keyboard input uses `pynput`,
+so your terminal or Python process may need permission to receive keyboard events depending on your
+operating system.
+
 ## Cameras
 
 To add cameras to your setup, follow this [Guide](./cameras#setup-cameras).

--- a/src/lerobot/motors/motors_bus.py
+++ b/src/lerobot/motors/motors_bus.py
@@ -1237,6 +1237,9 @@ class SerialMotorsBus(MotorsBusBase):
         """
 
         raw_ids_values = self._get_ids_values_dict(values)
+        if not raw_ids_values:
+            raise ValueError(f"Cannot sync write '{data_name}' with no motor values.")
+
         models = [self._id_to_model(id_) for id_ in raw_ids_values]
         if self._has_different_ctrl_tables:
             assert_same_address(self.model_ctrl_table, models, data_name)

--- a/src/lerobot/processor/__init__.py
+++ b/src/lerobot/processor/__init__.py
@@ -61,6 +61,7 @@ from .hil_processor import (
     RewardClassifierProcessorStep,
     TimeLimitProcessorStep,
 )
+from .keyboard_action_processor import MapKeyboardToSOJointPositionsStep
 from .newline_task_processor import NewLineTaskProcessorStep
 from .normalize_processor import NormalizerProcessorStep, UnnormalizerProcessorStep, hotswap_stats
 from .observation_processor import VanillaObservationProcessorStep
@@ -129,6 +130,7 @@ __all__ = [
     "AbsoluteActionsProcessorStep",
     "RelativeActionsProcessorStep",
     "MapDeltaActionToRobotActionStep",
+    "MapKeyboardToSOJointPositionsStep",
     "MapTensorToDeltaActionDictStep",
     "NewLineTaskProcessorStep",
     "NormalizerProcessorStep",

--- a/src/lerobot/processor/factory.py
+++ b/src/lerobot/processor/factory.py
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Any
+
 from lerobot.types import RobotAction, RobotObservation
 
 from .converters import (
@@ -23,6 +25,17 @@ from .converters import (
     transition_to_robot_action,
 )
 from .pipeline import IdentityProcessorStep, RobotProcessorPipeline
+
+SO_FOLLOWER_MOTOR_NAMES = (
+    "shoulder_pan",
+    "shoulder_lift",
+    "elbow_flex",
+    "wrist_flex",
+    "wrist_roll",
+    "gripper",
+)
+
+SO_FOLLOWER_ROBOT_TYPES = {"so100_follower", "so101_follower"}
 
 
 def make_default_teleop_action_processor() -> RobotProcessorPipeline[
@@ -56,8 +69,27 @@ def make_default_robot_observation_processor() -> RobotProcessorPipeline[RobotOb
     return robot_observation_processor
 
 
-def make_default_processors():
+def make_default_processors(
+    teleop_config: Any | None = None,
+    robot_config: Any | None = None,
+) -> tuple[
+    RobotProcessorPipeline[tuple[RobotAction, RobotObservation], RobotAction],
+    RobotProcessorPipeline[tuple[RobotAction, RobotObservation], RobotAction],
+    RobotProcessorPipeline[RobotObservation, RobotObservation],
+]:
     teleop_action_processor = make_default_teleop_action_processor()
+    teleop_type = getattr(teleop_config, "type", None)
+    robot_type = getattr(robot_config, "type", None)
+
+    if teleop_type == "keyboard" and robot_type in SO_FOLLOWER_ROBOT_TYPES:
+        from .keyboard_action_processor import MapKeyboardToSOJointPositionsStep
+
+        teleop_action_processor = RobotProcessorPipeline[tuple[RobotAction, RobotObservation], RobotAction](
+            steps=[MapKeyboardToSOJointPositionsStep(motor_names=SO_FOLLOWER_MOTOR_NAMES)],
+            to_transition=robot_action_observation_to_transition,
+            to_output=transition_to_robot_action,
+        )
+
     robot_action_processor = make_default_robot_action_processor()
     robot_observation_processor = make_default_robot_observation_processor()
     return (teleop_action_processor, robot_action_processor, robot_observation_processor)

--- a/src/lerobot/processor/keyboard_action_processor.py
+++ b/src/lerobot/processor/keyboard_action_processor.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+from types import MappingProxyType
+
+from lerobot.configs import FeatureType, PipelineFeatureType, PolicyFeature
+from lerobot.types import RobotAction, TransitionKey
+
+from .pipeline import ProcessorStepRegistry, RobotActionProcessorStep
+
+SO_KEYBOARD_JOINT_DELTAS = MappingProxyType(
+    {
+        "a": {"shoulder_pan": -1.0},
+        "d": {"shoulder_pan": 1.0},
+        "w": {"shoulder_lift": 1.0},
+        "s": {"shoulder_lift": -1.0},
+        "i": {"elbow_flex": 1.0},
+        "k": {"elbow_flex": -1.0},
+        "j": {"wrist_flex": -1.0},
+        "l": {"wrist_flex": 1.0},
+        "u": {"wrist_roll": -1.0},
+        "o": {"wrist_roll": 1.0},
+        "r": {"gripper": 1.0},
+        "f": {"gripper": -1.0},
+    }
+)
+
+
+@ProcessorStepRegistry.register("map_keyboard_to_so_joint_positions")
+@dataclass
+class MapKeyboardToSOJointPositionsStep(RobotActionProcessorStep):
+    """Map raw keyboard keys to SO follower joint position targets.
+
+    ``KeyboardTeleop`` emits active character keys (for example ``{"w": None}``).
+    SO follower robots expect absolute joint targets with ``*.pos`` keys. This
+    step keeps the current observation as the hold position, then applies small
+    per-frame deltas for any active keyboard keys.
+    """
+
+    motor_names: tuple[str, ...]
+    joint_step_size: float = 1.0
+    gripper_step_size: float = 2.0
+
+    def _get_current_positions(self) -> RobotAction:
+        observation = self.transition.get(TransitionKey.OBSERVATION)
+        if not isinstance(observation, dict):
+            raise ValueError(
+                "MapKeyboardToSOJointPositionsStep requires a robot observation dict "
+                f"but got {type(observation)}."
+            )
+
+        missing_keys = [f"{motor}.pos" for motor in self.motor_names if f"{motor}.pos" not in observation]
+        if missing_keys:
+            raise ValueError(
+                "MapKeyboardToSOJointPositionsStep requires current SO follower joint positions "
+                f"in the observation. Missing keys: {missing_keys}."
+            )
+
+        return {f"{motor}.pos": float(observation[f"{motor}.pos"]) for motor in self.motor_names}
+
+    def action(self, action: RobotAction) -> RobotAction:
+        target_positions = self._get_current_positions()
+        active_keys = {str(key).lower() for key in action}
+        motor_deltas = dict.fromkeys(self.motor_names, 0.0)
+
+        for key in active_keys:
+            for motor, direction in SO_KEYBOARD_JOINT_DELTAS.get(key, {}).items():
+                if motor not in motor_deltas:
+                    continue
+                step_size = self.gripper_step_size if motor == "gripper" else self.joint_step_size
+                motor_deltas[motor] += direction * step_size
+
+        for motor, delta in motor_deltas.items():
+            pos_key = f"{motor}.pos"
+            target_positions[pos_key] += delta
+            if motor == "gripper":
+                target_positions[pos_key] = min(100.0, max(0.0, target_positions[pos_key]))
+
+        return target_positions
+
+    def transform_features(
+        self, features: dict[PipelineFeatureType, dict[str, PolicyFeature]]
+    ) -> dict[PipelineFeatureType, dict[str, PolicyFeature]]:
+        transformed = {
+            feature_type: feature_values.copy() for feature_type, feature_values in features.items()
+        }
+        transformed[PipelineFeatureType.ACTION] = {
+            f"{motor}.pos": PolicyFeature(type=FeatureType.ACTION, shape=(1,)) for motor in self.motor_names
+        }
+        transformed.setdefault(PipelineFeatureType.OBSERVATION, {})
+        return transformed

--- a/src/lerobot/robots/so_follower/so_follower.py
+++ b/src/lerobot/robots/so_follower/so_follower.py
@@ -208,6 +208,12 @@ class SOFollower(Robot):
         """
 
         goal_pos = {key.removesuffix(".pos"): val for key, val in action.items() if key.endswith(".pos")}
+        if not goal_pos:
+            expected_keys = [f"{motor}.pos" for motor in self.bus.motors]
+            raise ValueError(
+                f"{self.__class__.__name__} expected at least one '*.pos' action key from "
+                f"{expected_keys}, but received {list(action)}."
+            )
 
         # Cap goal position when too far away from present position.
         # /!\ Slower fps expected due to reading from the follower.

--- a/src/lerobot/scripts/lerobot_record.py
+++ b/src/lerobot/scripts/lerobot_record.py
@@ -347,7 +347,7 @@ def record(
         or robot_action_processor is None
         or robot_observation_processor is None
     ):
-        _t, _r, _o = make_default_processors()
+        _t, _r, _o = make_default_processors(cfg.teleop, cfg.robot)
         teleop_action_processor = teleop_action_processor or _t
         robot_action_processor = robot_action_processor or _r
         robot_observation_processor = robot_observation_processor or _o

--- a/src/lerobot/scripts/lerobot_teleoperate.py
+++ b/src/lerobot/scripts/lerobot_teleoperate.py
@@ -219,7 +219,9 @@ def teleoperate(cfg: TeleoperateConfig):
 
     teleop = make_teleoperator_from_config(cfg.teleop)
     robot = make_robot_from_config(cfg.robot)
-    teleop_action_processor, robot_action_processor, robot_observation_processor = make_default_processors()
+    teleop_action_processor, robot_action_processor, robot_observation_processor = make_default_processors(
+        cfg.teleop, cfg.robot
+    )
 
     teleop.connect()
     robot.connect()

--- a/tests/motors/test_motors_bus.py
+++ b/tests/motors/test_motors_bus.py
@@ -111,6 +111,14 @@ def test__serialize_data_large_number():
         bus._serialize_data(2**32, 4)  # 4-byte max is 0xFFFFFFFF
 
 
+def test_sync_write_rejects_empty_values(dummy_motors):
+    bus = MockMotorsBus("/dev/dummy-port", dummy_motors)
+    bus.connect(handshake=False)
+
+    with pytest.raises(ValueError, match="Cannot sync write 'Goal_Position' with no motor values."):
+        bus.sync_write("Goal_Position", {})
+
+
 @pytest.mark.parametrize(
     "data_name, id_, value",
     [

--- a/tests/processor/test_keyboard_action_processor.py
+++ b/tests/processor/test_keyboard_action_processor.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from lerobot.configs import FeatureType, PipelineFeatureType
+from lerobot.processor import IdentityProcessorStep, MapKeyboardToSOJointPositionsStep
+from lerobot.processor.converters import create_transition
+from lerobot.processor.factory import SO_FOLLOWER_MOTOR_NAMES, make_default_processors
+from lerobot.types import TransitionKey
+
+
+def _make_observation(**overrides):
+    observation = {
+        "shoulder_pan.pos": 0.0,
+        "shoulder_lift.pos": 10.0,
+        "elbow_flex.pos": -20.0,
+        "wrist_flex.pos": 30.0,
+        "wrist_roll.pos": -40.0,
+        "gripper.pos": 50.0,
+    }
+    observation.update(overrides)
+    return observation
+
+
+def _run_step(step, action, observation=None):
+    transition = create_transition(action=action, observation=observation or _make_observation())
+    return step(transition)[TransitionKey.ACTION]
+
+
+class _FakeConfig:
+    def __init__(self, config_type: str):
+        self.type = config_type
+
+
+def test_no_keys_hold_current_joint_positions():
+    step = MapKeyboardToSOJointPositionsStep(motor_names=SO_FOLLOWER_MOTOR_NAMES)
+
+    assert _run_step(step, {}) == _make_observation()
+
+
+@pytest.mark.parametrize(
+    "key, motor, delta",
+    [
+        ("a", "shoulder_pan", -1.0),
+        ("d", "shoulder_pan", 1.0),
+        ("w", "shoulder_lift", 1.0),
+        ("s", "shoulder_lift", -1.0),
+        ("i", "elbow_flex", 1.0),
+        ("k", "elbow_flex", -1.0),
+        ("j", "wrist_flex", -1.0),
+        ("l", "wrist_flex", 1.0),
+        ("u", "wrist_roll", -1.0),
+        ("o", "wrist_roll", 1.0),
+    ],
+)
+def test_joint_keys_move_expected_motor(key, motor, delta):
+    step = MapKeyboardToSOJointPositionsStep(motor_names=SO_FOLLOWER_MOTOR_NAMES, joint_step_size=3.0)
+    observation = _make_observation()
+
+    result = _run_step(step, {key: None}, observation)
+
+    assert result[f"{motor}.pos"] == pytest.approx(observation[f"{motor}.pos"] + delta * 3.0)
+    unchanged = set(observation) - {f"{motor}.pos"}
+    for action_key in unchanged:
+        assert result[action_key] == pytest.approx(observation[action_key])
+
+
+def test_opposing_keys_cancel_each_other():
+    step = MapKeyboardToSOJointPositionsStep(motor_names=SO_FOLLOWER_MOTOR_NAMES, joint_step_size=5.0)
+
+    assert _run_step(step, {"a": None, "d": None}) == _make_observation()
+
+
+def test_multiple_keys_apply_independent_joint_deltas():
+    step = MapKeyboardToSOJointPositionsStep(motor_names=SO_FOLLOWER_MOTOR_NAMES, joint_step_size=2.0)
+    observation = _make_observation()
+
+    result = _run_step(step, {"w": None, "j": None, "o": None}, observation)
+
+    assert result["shoulder_lift.pos"] == pytest.approx(observation["shoulder_lift.pos"] + 2.0)
+    assert result["wrist_flex.pos"] == pytest.approx(observation["wrist_flex.pos"] - 2.0)
+    assert result["wrist_roll.pos"] == pytest.approx(observation["wrist_roll.pos"] + 2.0)
+
+
+def test_unknown_keys_are_ignored_but_output_stays_complete():
+    step = MapKeyboardToSOJointPositionsStep(motor_names=SO_FOLLOWER_MOTOR_NAMES)
+
+    assert _run_step(step, {"x": None}) == _make_observation()
+
+
+def test_gripper_keys_are_clamped():
+    step = MapKeyboardToSOJointPositionsStep(motor_names=SO_FOLLOWER_MOTOR_NAMES, gripper_step_size=10.0)
+
+    assert _run_step(step, {"r": None}, _make_observation(**{"gripper.pos": 97.0}))[
+        "gripper.pos"
+    ] == pytest.approx(100.0)
+    assert _run_step(step, {"f": None}, _make_observation(**{"gripper.pos": 3.0}))[
+        "gripper.pos"
+    ] == pytest.approx(0.0)
+
+
+def test_missing_observation_key_raises_clear_error():
+    step = MapKeyboardToSOJointPositionsStep(motor_names=SO_FOLLOWER_MOTOR_NAMES)
+    observation = _make_observation()
+    observation.pop("wrist_roll.pos")
+
+    with pytest.raises(ValueError, match="Missing keys: \\['wrist_roll.pos'\\]"):
+        _run_step(step, {"u": None}, observation)
+
+
+def test_transform_features_outputs_so_action_features(policy_feature_factory):
+    step = MapKeyboardToSOJointPositionsStep(motor_names=SO_FOLLOWER_MOTOR_NAMES)
+    features = {
+        PipelineFeatureType.ACTION: {"w": policy_feature_factory(FeatureType.ACTION, (1,))},
+        PipelineFeatureType.OBSERVATION: {
+            f"{motor}.pos": policy_feature_factory(FeatureType.STATE, (1,))
+            for motor in SO_FOLLOWER_MOTOR_NAMES
+        },
+    }
+
+    transformed = step.transform_features(features)
+
+    assert set(transformed[PipelineFeatureType.ACTION]) == {
+        f"{motor}.pos" for motor in SO_FOLLOWER_MOTOR_NAMES
+    }
+
+
+@pytest.mark.parametrize("robot_type", ["so100_follower", "so101_follower"])
+def test_default_processors_route_keyboard_so_follower_to_keyboard_joint_processor(robot_type):
+    teleop_processor, robot_processor, observation_processor = make_default_processors(
+        _FakeConfig("keyboard"), _FakeConfig(robot_type)
+    )
+
+    assert isinstance(teleop_processor.steps[0], MapKeyboardToSOJointPositionsStep)
+    assert isinstance(robot_processor.steps[0], IdentityProcessorStep)
+    assert isinstance(observation_processor.steps[0], IdentityProcessorStep)
+
+
+def test_default_processors_keep_identity_for_no_config_or_leader_config():
+    no_config_processors = make_default_processors()
+    leader_processors = make_default_processors(_FakeConfig("so101_leader"), _FakeConfig("so101_follower"))
+
+    assert isinstance(no_config_processors[0].steps[0], IdentityProcessorStep)
+    assert isinstance(leader_processors[0].steps[0], IdentityProcessorStep)

--- a/tests/robots/test_so100_follower.py
+++ b/tests/robots/test_so100_follower.py
@@ -109,3 +109,13 @@ def test_send_action(follower):
 
     goal_pos = {m: (i + 1) * 10 for i, m in enumerate(follower.bus.motors)}
     follower.bus.sync_write.assert_called_once_with("Goal_Position", goal_pos)
+
+
+@pytest.mark.parametrize("action", [{}, {"w": None}])
+def test_send_action_rejects_action_without_joint_positions(follower, action):
+    follower.connect()
+
+    with pytest.raises(ValueError, match="expected at least one '\\*.pos' action key"):
+        follower.send_action(action)
+
+    follower.bus.sync_write.assert_not_called()

--- a/tests/test_control_robot.py
+++ b/tests/test_control_robot.py
@@ -22,13 +22,72 @@ pytest.importorskip("datasets", reason="datasets is required (install lerobot[da
 pytest.importorskip("deepdiff", reason="deepdiff is required (install lerobot[hardware])")
 
 from lerobot.configs.dataset import DatasetRecordConfig
+from lerobot.configs.types import FeatureType
+from lerobot.robots.so_follower import SO101FollowerConfig
 from lerobot.scripts.lerobot_calibrate import CalibrateConfig, calibrate
 from lerobot.scripts.lerobot_record import RecordConfig, record
 from lerobot.scripts.lerobot_replay import DatasetReplayConfig, ReplayConfig, replay
 from lerobot.scripts.lerobot_teleoperate import TeleoperateConfig, teleoperate
+from lerobot.teleoperators.keyboard import KeyboardTeleopConfig
 from tests.fixtures.constants import DUMMY_REPO_ID
 from tests.mocks.mock_robot import MockRobotConfig
 from tests.mocks.mock_teleop import MockTeleopConfig
+
+_SO_OBSERVATION = {
+    "shoulder_pan.pos": 0.0,
+    "shoulder_lift.pos": 10.0,
+    "elbow_flex.pos": -20.0,
+    "wrist_flex.pos": 30.0,
+    "wrist_roll.pos": -40.0,
+    "gripper.pos": 50.0,
+}
+
+
+class _FakeSOFollower:
+    name = "so_follower"
+    action_features = {key: {"type": FeatureType.ACTION, "shape": (1,)} for key in _SO_OBSERVATION}
+
+    def __init__(self):
+        self.sent_actions = []
+        self._is_connected = False
+
+    @property
+    def is_connected(self):
+        return self._is_connected
+
+    def connect(self):
+        self._is_connected = True
+
+    def get_observation(self):
+        return _SO_OBSERVATION.copy()
+
+    def send_action(self, action):
+        self.sent_actions.append(action)
+        return action
+
+    def disconnect(self):
+        self._is_connected = False
+
+
+class _FakeKeyboardTeleop:
+    def __init__(self):
+        self._is_connected = False
+
+    @property
+    def is_connected(self):
+        return self._is_connected
+
+    def connect(self):
+        self._is_connected = True
+
+    def get_action(self):
+        return {}
+
+    def send_feedback(self, feedback):
+        pass
+
+    def disconnect(self):
+        self._is_connected = False
 
 
 def test_calibrate():
@@ -46,6 +105,29 @@ def test_teleoperate():
         teleop_time_s=0.1,
     )
     teleoperate(cfg)
+
+
+def test_teleoperate_keyboard_so_follower_uses_joint_processor():
+    robot = _FakeSOFollower()
+    teleop_device = _FakeKeyboardTeleop()
+    cfg = TeleoperateConfig(
+        robot=SO101FollowerConfig(port="/dev/null"),
+        teleop=KeyboardTeleopConfig(),
+        fps=1000,
+        teleop_time_s=0.001,
+    )
+
+    with (
+        patch("lerobot.scripts.lerobot_teleoperate.make_robot_from_config", return_value=robot),
+        patch(
+            "lerobot.scripts.lerobot_teleoperate.make_teleoperator_from_config", return_value=teleop_device
+        ),
+    ):
+        teleoperate(cfg)
+
+    assert robot.sent_actions
+    assert robot.sent_actions[0] == _SO_OBSERVATION
+    assert set(robot.sent_actions[0]) == set(_SO_OBSERVATION)
 
 
 def test_record_and_resume(tmp_path):


### PR DESCRIPTION
## Summary

Adds follower-only keyboard teleoperation support for SO-100/SO-101 arms.

- maps raw `keyboard` teleop key states into absolute SO follower joint-position targets
- wires default processor selection through `lerobot-teleoperate` and `lerobot-record`
- makes SO follower and motor-bus empty-action failures explicit instead of silently syncing no motors
- documents the keyboard command and key bindings in the user guide and imitation-learning docs
- adds unit and script-level regression coverage for the new keyboard-to-joint-position path

## Motivation

Issue #3234 reports that using `--teleop.type=keyboard` with an SO follower does not produce the `*.pos` action keys required by the follower robot. The raw keyboard teleoperator emits active keys such as `{"w": None}`, while `SOFollower.send_action()` expects absolute joint-position targets such as `shoulder_lift.pos`.

## Implementation

The new `MapKeyboardToSOJointPositionsStep` uses the current robot observation as the hold position and applies small per-frame deltas for mapped keys:

- `a` / `d`: shoulder pan - / +
- `w` / `s`: shoulder lift + / -
- `i` / `k`: elbow flex + / -
- `j` / `l`: wrist flex - / +
- `u` / `o`: wrist roll - / +
- `r` / `f`: gripper target + / -

The factory now installs this processor only for `teleop.type == "keyboard"` with `so100_follower` or `so101_follower`, preserving identity processors for existing leader-arm and other default flows.

## Validation

- `uv run --extra test --extra core_scripts python -m pytest tests/test_control_robot.py -q`
- `uv run --extra test --extra hardware python -m pytest tests/processor/test_keyboard_action_processor.py tests/robots/test_so100_follower.py tests/motors/test_motors_bus.py -q`
- `uv run --extra dev ruff check --extend-ignore UP042 src/lerobot/processor/keyboard_action_processor.py src/lerobot/processor/factory.py src/lerobot/processor/__init__.py src/lerobot/scripts/lerobot_teleoperate.py src/lerobot/scripts/lerobot_record.py src/lerobot/robots/so_follower/so_follower.py src/lerobot/motors/motors_bus.py tests/processor/test_keyboard_action_processor.py tests/robots/test_so100_follower.py tests/motors/test_motors_bus.py tests/test_control_robot.py`
- `uv run --extra dev ruff format --check src/lerobot/processor/keyboard_action_processor.py src/lerobot/processor/factory.py tests/processor/test_keyboard_action_processor.py tests/robots/test_so100_follower.py tests/motors/test_motors_bus.py tests/test_control_robot.py`
- `git diff --check`

Note: `UP042` is ignored for the targeted ruff check because `motors_bus.py` contains a pre-existing enum-style lint finding unrelated to this change.

Fixes #3234
