### PR TITLE
Make pretrained policies portable with dataset metadata snapshots

### DIFF
--- a/src/lerobot/common/policy_metadata.py
+++ b/src/lerobot/common/policy_metadata.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from huggingface_hub import hf_hub_download
+from huggingface_hub.errors import EntryNotFoundError, HfHubHTTPError
+
+from lerobot.utils.constants import ACTION
+from lerobot.utils.io_utils import load_json, write_json
+from lerobot.utils.utils import flatten_dict, unflatten_dict
+
+POLICY_DATASET_METADATA_NAME = "dataset_metadata.json"
+POLICY_DATASET_METADATA_SCHEMA_VERSION = 1
+
+
+def _jsonify(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {key: _jsonify(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_jsonify(item) for item in value]
+    if isinstance(value, np.generic):
+        return value.item()
+    if hasattr(value, "tolist") and not isinstance(value, (str, bytes)):
+        return value.tolist()
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    raise TypeError(f"Object of type {type(value).__name__} is not JSON serializable")
+
+
+def _cast_stats_to_numpy(stats: dict[str, Any] | None) -> dict[str, dict[str, np.ndarray]]:
+    if not stats:
+        return {}
+    flattened = {key: np.array(value) for key, value in flatten_dict(stats).items()}
+    return unflatten_dict(flattened)
+
+
+def _normalize_feature_shapes(features: dict[str, dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    normalized = {}
+    for key, feature in features.items():
+        normalized_feature = dict(feature)
+        if isinstance(normalized_feature.get("shape"), list):
+            normalized_feature["shape"] = tuple(normalized_feature["shape"])
+        normalized[key] = normalized_feature
+    return normalized
+
+
+@dataclass
+class PolicyDatasetMetadata:
+    """Lightweight training-dataset metadata snapshot stored with a policy artifact.
+
+    This intentionally exposes only the pieces needed for policy portability and
+    provenance. It is not a full LeRobotDatasetMetadata and should not be used
+    as a dataset handle.
+    """
+
+    repo_id: str | None
+    revision: str | None
+    info: dict[str, Any]
+    stats: dict[str, dict[str, np.ndarray]]
+
+    @property
+    def features(self) -> dict[str, dict[str, Any]]:
+        return self.info["features"]
+
+    @property
+    def fps(self) -> int:
+        return self.info["fps"]
+
+    @property
+    def robot_type(self) -> str | None:
+        return self.info.get("robot_type")
+
+    @property
+    def image_keys(self) -> list[str]:
+        return [key for key, ft in self.features.items() if ft["dtype"] == "image"]
+
+    @property
+    def video_keys(self) -> list[str]:
+        return [key for key, ft in self.features.items() if ft["dtype"] == "video"]
+
+    @property
+    def camera_keys(self) -> list[str]:
+        return [key for key, ft in self.features.items() if ft["dtype"] in ["image", "video"]]
+
+    @property
+    def action_names(self) -> list[str] | None:
+        names = self.features.get(ACTION, {}).get("names")
+        return list(names) if names is not None else None
+
+    @classmethod
+    def from_dataset_metadata(cls, ds_meta: Any) -> PolicyDatasetMetadata:
+        info = ds_meta.info.to_dict() if hasattr(ds_meta.info, "to_dict") else dict(ds_meta.info)
+        info["features"] = _normalize_feature_shapes(info["features"])
+        return cls(
+            repo_id=getattr(ds_meta, "repo_id", None),
+            revision=getattr(ds_meta, "revision", None),
+            info=info,
+            stats=_cast_stats_to_numpy(getattr(ds_meta, "stats", None)),
+        )
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any], source: str | Path) -> PolicyDatasetMetadata:
+        if payload.get("schema_version") != POLICY_DATASET_METADATA_SCHEMA_VERSION:
+            raise ValueError(
+                f"Unsupported {POLICY_DATASET_METADATA_NAME} schema in {source}: "
+                f"{payload.get('schema_version')!r}"
+            )
+        try:
+            dataset = payload.get("dataset", {})
+            info = dict(payload["info"])
+            info["features"] = _normalize_feature_shapes(info["features"])
+        except (KeyError, TypeError) as exc:
+            raise ValueError(f"Malformed {POLICY_DATASET_METADATA_NAME} in {source}") from exc
+        if "fps" not in info:
+            raise ValueError(f"Malformed {POLICY_DATASET_METADATA_NAME} in {source}: missing info.fps")
+        return cls(
+            repo_id=dataset.get("repo_id"),
+            revision=dataset.get("revision"),
+            info=info,
+            stats=_cast_stats_to_numpy(payload.get("stats")),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": POLICY_DATASET_METADATA_SCHEMA_VERSION,
+            "dataset": {
+                "repo_id": self.repo_id,
+                "revision": self.revision,
+            },
+            "info": _jsonify(self.info),
+            "stats": _jsonify(self.stats),
+        }
+
+
+def save_policy_dataset_metadata(save_directory: str | Path, ds_meta: Any | None) -> None:
+    if ds_meta is None:
+        return
+    metadata = PolicyDatasetMetadata.from_dataset_metadata(ds_meta)
+    write_json(metadata.to_dict(), Path(save_directory) / POLICY_DATASET_METADATA_NAME)
+
+
+def load_policy_dataset_metadata(
+    pretrained_name_or_path: str | Path,
+    *,
+    force_download: bool = False,
+    resume_download: bool | None = None,
+    proxies: dict | None = None,
+    token: str | bool | None = None,
+    cache_dir: str | Path | None = None,
+    local_files_only: bool = False,
+    revision: str | None = None,
+) -> PolicyDatasetMetadata | None:
+    model_id = str(pretrained_name_or_path)
+    metadata_file: str | os.PathLike[str] | None
+
+    if Path(model_id).is_dir():
+        metadata_file = Path(model_id) / POLICY_DATASET_METADATA_NAME
+        if not metadata_file.exists():
+            return None
+    else:
+        try:
+            metadata_file = hf_hub_download(
+                repo_id=model_id,
+                filename=POLICY_DATASET_METADATA_NAME,
+                revision=revision,
+                cache_dir=cache_dir,
+                force_download=force_download,
+                proxies=proxies,
+                resume_download=resume_download,
+                token=token,
+                local_files_only=local_files_only,
+            )
+        except (EntryNotFoundError, HfHubHTTPError):
+            return None
+
+    try:
+        payload = load_json(Path(metadata_file))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Malformed {POLICY_DATASET_METADATA_NAME} in {metadata_file}") from exc
+    return PolicyDatasetMetadata.from_dict(payload, metadata_file)

--- a/src/lerobot/common/train_utils.py
+++ b/src/lerobot/common/train_utils.py
@@ -14,10 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from torch.optim import Optimizer
 from torch.optim.lr_scheduler import LRScheduler
 
+from lerobot.common.policy_metadata import save_policy_dataset_metadata
 from lerobot.configs.train import TrainPipelineConfig
 from lerobot.optim import (
     load_optimizer_state,
@@ -36,6 +38,9 @@ from lerobot.utils.constants import (
 )
 from lerobot.utils.io_utils import load_json, write_json
 from lerobot.utils.random_utils import load_rng_state, save_rng_state
+
+if TYPE_CHECKING:
+    from lerobot.datasets import LeRobotDatasetMetadata
 
 
 def get_step_identifier(step: int, total_steps: int) -> str:
@@ -75,6 +80,7 @@ def save_checkpoint(
     scheduler: LRScheduler | None = None,
     preprocessor: PolicyProcessorPipeline | None = None,
     postprocessor: PolicyProcessorPipeline | None = None,
+    dataset_meta: "LeRobotDatasetMetadata | None" = None,
 ) -> None:
     """This function creates the following directory structure:
 
@@ -83,6 +89,7 @@ def save_checkpoint(
     │   ├── config.json  # policy config
     │   ├── model.safetensors  # policy weights
     │   ├── train_config.json  # train config
+    │   ├── dataset_metadata.json  # training dataset metadata snapshot (if provided)
     │   ├── processor.json  # processor config (if preprocessor provided)
     │   └── step_*.safetensors  # processor state files (if any)
     └── training_state/
@@ -99,10 +106,12 @@ def save_checkpoint(
         optimizer (Optimizer | None, optional): The optimizer to save the state from. Defaults to None.
         scheduler (LRScheduler | None, optional): The scheduler to save the state from. Defaults to None.
         preprocessor: The preprocessor/pipeline to save. Defaults to None.
+        dataset_meta: Training dataset metadata to snapshot beside the policy. Defaults to None.
     """
     pretrained_dir = checkpoint_dir / PRETRAINED_MODEL_DIR
     policy.save_pretrained(pretrained_dir)
     cfg.save_pretrained(pretrained_dir)
+    save_policy_dataset_metadata(pretrained_dir, dataset_meta)
     if cfg.peft is not None:
         # When using PEFT, policy.save_pretrained will only write the adapter weights + config, not the
         # policy config which we need for loading the model. In this case we'll write it ourselves.

--- a/src/lerobot/policies/factory.py
+++ b/src/lerobot/policies/factory.py
@@ -18,13 +18,18 @@ from __future__ import annotations
 
 import importlib
 import logging
+import os
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypedDict, Unpack
 
 import torch
+from huggingface_hub.constants import CONFIG_NAME
+from huggingface_hub.errors import EntryNotFoundError
 
 if TYPE_CHECKING:
     from lerobot.datasets import LeRobotDatasetMetadata
 
+from lerobot.common.policy_metadata import PolicyDatasetMetadata, load_policy_dataset_metadata
 from lerobot.configs import FeatureType, PreTrainedConfig
 from lerobot.envs import EnvConfig, env_to_policy_features
 from lerobot.processor import (
@@ -233,6 +238,74 @@ class ProcessorConfigKwargs(TypedDict, total=False):
     dataset_stats: dict[str, dict[str, torch.Tensor]] | None
 
 
+def _load_policy_metadata_if_available(pretrained_path: str | Path | None) -> PolicyDatasetMetadata | None:
+    if pretrained_path is None:
+        return None
+    return load_policy_dataset_metadata(pretrained_path)
+
+
+def _has_policy_features(cfg: PreTrainedConfig) -> bool:
+    return bool(cfg.input_features) and bool(cfg.output_features)
+
+
+def _features_from_policy_config(cfg: PreTrainedConfig) -> dict[str, Any]:
+    if not _has_policy_features(cfg):
+        raise ValueError("Policy config does not contain input and output features.")
+    return {**(cfg.input_features or {}), **(cfg.output_features or {})}
+
+
+def _load_pretrained_policy_config_for_factory(cfg: PreTrainedConfig) -> PreTrainedConfig | None:
+    if cfg.pretrained_path is None:
+        return None
+
+    model_id = str(cfg.pretrained_path)
+    if Path(model_id).is_dir() and CONFIG_NAME not in os.listdir(model_id):
+        return None
+
+    try:
+        return PreTrainedConfig.from_pretrained(cfg.pretrained_path)
+    except (EntryNotFoundError, FileNotFoundError):
+        return None
+
+
+def _apply_runtime_overrides(
+    pretrained_cfg: PreTrainedConfig, runtime_cfg: PreTrainedConfig
+) -> PreTrainedConfig:
+    if pretrained_cfg.type != runtime_cfg.type:
+        logging.warning(
+            "Policy type from pretrained config (%s) differs from requested policy type (%s). "
+            "Using the pretrained config type.",
+            pretrained_cfg.type,
+            runtime_cfg.type,
+        )
+
+    pretrained_cfg.device = runtime_cfg.device
+    pretrained_cfg.use_amp = runtime_cfg.use_amp
+    pretrained_cfg.pretrained_path = runtime_cfg.pretrained_path
+    pretrained_cfg.use_peft = pretrained_cfg.use_peft or runtime_cfg.use_peft
+
+    for attr in ("repo_id", "private", "tags", "license"):
+        value = getattr(runtime_cfg, attr)
+        if value is not None:
+            setattr(pretrained_cfg, attr, value)
+    return pretrained_cfg
+
+
+def _set_action_feature_names_from_metadata(
+    cfg: PreTrainedConfig, metadata: LeRobotDatasetMetadata | PolicyDatasetMetadata | None
+) -> None:
+    if metadata is None or not hasattr(cfg, "action_feature_names"):
+        return
+    if getattr(cfg, "action_feature_names", None):
+        return
+    if isinstance(metadata, PolicyDatasetMetadata):
+        action_names = metadata.action_names
+    else:
+        action_names = metadata.features.get(ACTION, {}).get("names")
+    if action_names is not None:
+        cfg.action_feature_names = list(action_names)
+
+
 def make_pre_post_processors(
     policy_cfg: PreTrainedConfig,
     pretrained_path: str | None = None,
@@ -266,6 +339,11 @@ def make_pre_post_processors(
     if pretrained_path:
         # TODO(Steven): Temporary patch, implement correctly the processors for Gr00t
         if isinstance(policy_cfg, GrootConfig):
+            if kwargs.get("dataset_stats") is None:
+                policy_metadata = _load_policy_metadata_if_available(pretrained_path)
+                if policy_metadata is not None and policy_metadata.stats:
+                    kwargs["dataset_stats"] = policy_metadata.stats
+
             # GROOT handles normalization in groot_pack_inputs_v3 step
             # Need to override both stats AND normalize_min_max since saved config might be empty
             preprocessor_overrides = {}
@@ -458,8 +536,10 @@ def make_policy(
         NotImplementedError: If attempting to use an unsupported policy-backend
                              combination (e.g., VQBeT with 'mps').
     """
-    if bool(ds_meta) == bool(env_cfg):
-        raise ValueError("Either one of a dataset metadata or a sim env must be provided.")
+    if ds_meta is not None and env_cfg is not None:
+        raise ValueError("Only one of a dataset metadata or a sim env must be provided.")
+    if ds_meta is None and env_cfg is None and cfg.pretrained_path is None:
+        raise ValueError("Either a dataset metadata, a sim env, or a pretrained path must be provided.")
 
     # NOTE: Currently, if you try to run vqbet with mps backend, you'll get this error.
     # TODO(aliberts, rcadene): Implement a check_backend_compatibility in policies?
@@ -474,37 +554,51 @@ def make_policy(
             "Please use `cpu` or `cuda` backend."
         )
 
-    policy_cls = get_policy_class(cfg.type)
-
-    kwargs = {}
+    runtime_cfg = cfg
+    policy_metadata = None
     if ds_meta is not None:
         features = dataset_to_policy_features(ds_meta.features)
-    else:
+    elif env_cfg is not None:
         if not cfg.pretrained_path:
             logging.warning(
                 "You are instantiating a policy from scratch and its features are parsed from an environment "
                 "rather than a dataset. Normalization modules inside the policy will have infinite values "
                 "by default without stats from a dataset."
             )
-        if env_cfg is None:
-            raise ValueError("env_cfg cannot be None when ds_meta is not provided")
         features = env_to_policy_features(env_cfg)
+    else:
+        policy_metadata = _load_policy_metadata_if_available(cfg.pretrained_path)
+        pretrained_cfg = _load_pretrained_policy_config_for_factory(cfg)
+        if pretrained_cfg is not None:
+            cfg = _apply_runtime_overrides(pretrained_cfg, runtime_cfg)
+
+        if _has_policy_features(cfg):
+            features = _features_from_policy_config(cfg)
+        elif policy_metadata is not None:
+            features = dataset_to_policy_features(policy_metadata.features)
+        else:
+            raise ValueError(
+                f"Policy '{cfg.type}' cannot be instantiated from pretrained path '{cfg.pretrained_path}' "
+                "without feature metadata. Pass `ds_meta=dataset.meta`, pass `env_cfg=...`, or re-save "
+                "this policy with a newer LeRobot version."
+            )
 
     cfg.output_features = {key: ft for key, ft in features.items() if ft.type is FeatureType.ACTION}
     if not cfg.input_features:
         cfg.input_features = {key: ft for key, ft in features.items() if key not in cfg.output_features}
 
-    # Store action feature names for relative_exclude_joints support
-    if ds_meta is not None and hasattr(cfg, "action_feature_names"):
-        action_names = ds_meta.features.get(ACTION, {}).get("names")
-        if action_names is not None:
-            cfg.action_feature_names = list(action_names)
+    # Store action feature names for relative_exclude_joints support.
+    _set_action_feature_names_from_metadata(cfg, ds_meta or policy_metadata)
 
+    policy_cls = get_policy_class(cfg.type)
+    kwargs = {}
     kwargs["config"] = cfg
 
-    # Pass dataset_stats to the policy if available (needed for some policies like SARM)
+    # Pass dataset_stats to the policy if available (needed for some policies like SARM).
     if ds_meta is not None and hasattr(ds_meta, "stats"):
         kwargs["dataset_stats"] = ds_meta.stats
+    elif policy_metadata is not None and policy_metadata.stats:
+        kwargs["dataset_stats"] = policy_metadata.stats
 
     if ds_meta is not None:
         kwargs["dataset_meta"] = ds_meta

--- a/src/lerobot/policies/pretrained.py
+++ b/src/lerobot/policies/pretrained.py
@@ -19,7 +19,7 @@ import os
 from importlib.resources import files
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import TypedDict, TypeVar, Unpack
+from typing import TYPE_CHECKING, TypedDict, TypeVar, Unpack
 
 import packaging
 import safetensors
@@ -29,11 +29,15 @@ from huggingface_hub.errors import HfHubHTTPError
 from safetensors.torch import load_model as load_model_as_safetensor, save_model as save_model_as_safetensor
 from torch import Tensor, nn
 
+from lerobot.common.policy_metadata import save_policy_dataset_metadata
 from lerobot.configs import PreTrainedConfig
 from lerobot.configs.train import TrainPipelineConfig
 from lerobot.utils.hub import HubMixin
 
 from .utils import log_model_loading_keys
+
+if TYPE_CHECKING:
+    from lerobot.datasets import LeRobotDatasetMetadata
 
 T = TypeVar("T", bound="PreTrainedPolicy")
 
@@ -208,6 +212,7 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
         self,
         cfg: TrainPipelineConfig,
         peft_model=None,
+        dataset_meta: "LeRobotDatasetMetadata | None" = None,
     ):
         api = HfApi()
         repo_id = api.create_repo(
@@ -226,6 +231,8 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
                 self.config.save_pretrained(saved_path)
             else:
                 self.save_pretrained(saved_path)  # Calls _save_pretrained and stores model tensors
+
+            save_policy_dataset_metadata(saved_path, dataset_meta)
 
             card = self.generate_model_card(
                 cfg.dataset.repo_id, self.config.type, self.config.license, self.config.tags

--- a/src/lerobot/scripts/lerobot_train.py
+++ b/src/lerobot/scripts/lerobot_train.py
@@ -510,6 +510,7 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
                     scheduler=lr_scheduler,
                     preprocessor=preprocessor,
                     postprocessor=postprocessor,
+                    dataset_meta=dataset.meta,
                 )
                 update_last_checkpoint(checkpoint_dir)
                 if wandb_logger:
@@ -578,10 +579,12 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
         if getattr(active_cfg, "push_to_hub", False):
             unwrapped_model = accelerator.unwrap_model(policy)
             # PEFT only applies when training a policy — reward models use the plain path.
-            if not cfg.is_reward_model_training and cfg.policy.use_peft:
-                unwrapped_model.push_model_to_hub(cfg, peft_model=unwrapped_model)
-            else:
+            if cfg.is_reward_model_training:
                 unwrapped_model.push_model_to_hub(cfg)
+            elif cfg.policy.use_peft:
+                unwrapped_model.push_model_to_hub(cfg, peft_model=unwrapped_model, dataset_meta=dataset.meta)
+            else:
+                unwrapped_model.push_model_to_hub(cfg, dataset_meta=dataset.meta)
             preprocessor.push_to_hub(active_cfg.repo_id)
             postprocessor.push_to_hub(active_cfg.repo_id)
 

--- a/tests/common/test_policy_metadata.py
+++ b/tests/common/test_policy_metadata.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pytest
+from huggingface_hub.errors import EntryNotFoundError
+
+from lerobot.common.policy_metadata import (
+    POLICY_DATASET_METADATA_NAME,
+    load_policy_dataset_metadata,
+    save_policy_dataset_metadata,
+)
+from lerobot.utils.constants import ACTION
+
+
+def _make_dataset_metadata():
+    features = {
+        ACTION: {
+            "dtype": "float32",
+            "shape": (2,),
+            "names": ["shoulder", "gripper"],
+        },
+        "observation.state": {
+            "dtype": "float32",
+            "shape": (2,),
+            "names": ["shoulder", "gripper"],
+        },
+        "observation.images.front": {
+            "dtype": "video",
+            "shape": (64, 64, 3),
+            "names": ["height", "width", "channels"],
+        },
+    }
+    info_dict = {
+        "codebase_version": "v3.0",
+        "fps": 30,
+        "features": features,
+        "robot_type": "test_bot",
+        "total_episodes": 1,
+        "total_frames": 4,
+        "total_tasks": 1,
+        "splits": {"train": "0:1"},
+    }
+
+    class Info:
+        def to_dict(self):
+            return info_dict
+
+    class DatasetMetadata:
+        repo_id = "user/dataset"
+        revision = "v3.0"
+        info = Info()
+        stats = {
+            ACTION: {
+                "mean": np.array([0.1, 0.2], dtype=np.float32),
+                "std": np.array([1.0, 1.5], dtype=np.float32),
+            },
+            "observation.state": {
+                "mean": np.array([0.3, 0.4], dtype=np.float32),
+                "std": np.array([2.0, 2.5], dtype=np.float32),
+            },
+        }
+
+    return DatasetMetadata()
+
+
+def test_policy_dataset_metadata_roundtrip(tmp_path):
+    ds_meta = _make_dataset_metadata()
+
+    save_policy_dataset_metadata(tmp_path / "policy", ds_meta)
+
+    metadata_path = tmp_path / "policy" / POLICY_DATASET_METADATA_NAME
+    assert metadata_path.is_file()
+
+    loaded = load_policy_dataset_metadata(tmp_path / "policy")
+    assert loaded is not None
+    assert loaded.repo_id == ds_meta.repo_id
+    assert loaded.revision == ds_meta.revision
+    assert loaded.fps == ds_meta.info.to_dict()["fps"]
+    assert loaded.robot_type == ds_meta.info.to_dict()["robot_type"]
+    assert loaded.features.keys() == ds_meta.info.to_dict()["features"].keys()
+    assert loaded.features[ACTION]["shape"] == ds_meta.info.to_dict()["features"][ACTION]["shape"]
+    assert loaded.action_names == ds_meta.info.to_dict()["features"][ACTION]["names"]
+
+    for feature_name, feature_stats in ds_meta.stats.items():
+        for stat_name, stat in feature_stats.items():
+            np.testing.assert_allclose(loaded.stats[feature_name][stat_name], stat)
+
+
+def test_load_policy_dataset_metadata_missing_returns_none(tmp_path):
+    assert load_policy_dataset_metadata(tmp_path) is None
+
+
+def test_load_policy_dataset_metadata_missing_hub_file_returns_none(monkeypatch):
+    def raise_missing_file(*args, **kwargs):
+        raise EntryNotFoundError("missing")
+
+    monkeypatch.setattr("lerobot.common.policy_metadata.hf_hub_download", raise_missing_file)
+
+    assert load_policy_dataset_metadata("user/policy") is None
+
+
+def test_load_policy_dataset_metadata_rejects_malformed_json(tmp_path):
+    policy_dir = tmp_path / "policy"
+    policy_dir.mkdir()
+    (policy_dir / POLICY_DATASET_METADATA_NAME).write_text("{not-json")
+
+    with pytest.raises(ValueError, match=POLICY_DATASET_METADATA_NAME):
+        load_policy_dataset_metadata(policy_dir)

--- a/tests/policies/test_policies.py
+++ b/tests/policies/test_policies.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import inspect
+import json
 from copy import deepcopy
 from pathlib import Path
 
@@ -26,6 +27,7 @@ pytest.importorskip("datasets", reason="datasets is required (install lerobot[da
 from packaging import version
 from safetensors.torch import load_file
 
+from lerobot.common.policy_metadata import save_policy_dataset_metadata
 from lerobot.configs.default import DatasetConfig
 from lerobot.configs.train import TrainPipelineConfig
 from lerobot.configs.types import FeatureType, PolicyFeature
@@ -298,6 +300,97 @@ def test_save_and_load_pretrained(dummy_dataset_metadata, tmp_path, policy_name:
     policy.save_pretrained(save_dir)
     loaded_policy = policy_cls.from_pretrained(save_dir, config=policy_cfg)
     torch.testing.assert_close(list(policy.parameters()), list(loaded_policy.parameters()), rtol=0, atol=0)
+
+
+def test_make_policy_from_pretrained_without_dataset_uses_saved_config(dummy_dataset_metadata, tmp_path):
+    policy_cfg = make_policy_config("act", device="cpu")
+    policy = make_policy(policy_cfg, ds_meta=dummy_dataset_metadata)
+    save_dir = tmp_path / "act_policy"
+    policy.save_pretrained(save_dir)
+
+    runtime_cfg = make_policy_config("act", pretrained_path=save_dir, device="cpu")
+    runtime_cfg.input_features = {}
+    runtime_cfg.output_features = {}
+
+    loaded_policy = make_policy(runtime_cfg)
+
+    assert isinstance(loaded_policy, PreTrainedPolicy)
+    assert loaded_policy.config.input_features == policy.config.input_features
+    assert loaded_policy.config.output_features == policy.config.output_features
+    assert loaded_policy.config.pretrained_path == save_dir
+
+
+def test_make_policy_from_pretrained_without_dataset_uses_metadata_fallback(
+    dummy_dataset_metadata, tmp_path, monkeypatch
+):
+    policy_cls = get_policy_class("act")
+    original_init = policy_cls.__init__
+    captured_dataset_stats = []
+
+    def capture_dataset_stats(self, config, **kwargs):
+        captured_dataset_stats.append(kwargs.get("dataset_stats"))
+        original_init(self, config, **kwargs)
+
+    monkeypatch.setattr(policy_cls, "__init__", capture_dataset_stats)
+
+    policy_cfg = make_policy_config("act", device="cpu")
+    policy = make_policy(policy_cfg, ds_meta=dummy_dataset_metadata)
+    save_dir = tmp_path / "act_policy"
+    policy.save_pretrained(save_dir)
+    save_policy_dataset_metadata(save_dir, dummy_dataset_metadata)
+
+    config_path = save_dir / "config.json"
+    with open(config_path) as f:
+        config = json.load(f)
+    config["input_features"] = None
+    config["output_features"] = None
+    with open(config_path, "w") as f:
+        json.dump(config, f)
+
+    runtime_cfg = make_policy_config("act", pretrained_path=save_dir, device="cpu")
+    runtime_cfg.input_features = {}
+    runtime_cfg.output_features = {}
+
+    loaded_policy = make_policy(runtime_cfg)
+
+    assert isinstance(loaded_policy, PreTrainedPolicy)
+    assert loaded_policy.config.input_features == policy.config.input_features
+    assert loaded_policy.config.output_features == policy.config.output_features
+    assert captured_dataset_stats[-1] is not None
+    torch.testing.assert_close(
+        torch.as_tensor(captured_dataset_stats[-1][ACTION]["mean"]),
+        torch.as_tensor(dummy_dataset_metadata.stats[ACTION]["mean"]),
+    )
+
+
+def test_make_policy_from_pretrained_without_dataset_uses_metadata_if_config_missing(
+    dummy_dataset_metadata, tmp_path
+):
+    policy_cfg = make_policy_config("act", device="cpu")
+    policy = make_policy(policy_cfg, ds_meta=dummy_dataset_metadata)
+    save_dir = tmp_path / "act_policy"
+    policy.save_pretrained(save_dir)
+    save_policy_dataset_metadata(save_dir, dummy_dataset_metadata)
+    (save_dir / "config.json").unlink()
+
+    runtime_cfg = make_policy_config("act", pretrained_path=save_dir, device="cpu")
+    runtime_cfg.input_features = {}
+    runtime_cfg.output_features = {}
+
+    loaded_policy = make_policy(runtime_cfg)
+
+    assert isinstance(loaded_policy, PreTrainedPolicy)
+    assert loaded_policy.config.input_features == policy.config.input_features
+    assert loaded_policy.config.output_features == policy.config.output_features
+
+
+def test_make_policy_from_pretrained_without_metadata_fails_clearly(tmp_path):
+    runtime_cfg = make_policy_config("act", pretrained_path=tmp_path, device="cpu")
+    runtime_cfg.input_features = {}
+    runtime_cfg.output_features = {}
+
+    with pytest.raises(ValueError, match="Pass `ds_meta=dataset.meta`"):
+        make_policy(runtime_cfg)
 
 
 @pytest.mark.parametrize("multikey", [True, False])

--- a/tests/utils/test_train_utils.py
+++ b/tests/utils/test_train_utils.py
@@ -17,6 +17,9 @@
 from pathlib import Path
 from unittest.mock import Mock, patch
 
+import numpy as np
+
+from lerobot.common.policy_metadata import POLICY_DATASET_METADATA_NAME
 from lerobot.common.train_utils import (
     get_step_checkpoint_dir,
     get_step_identifier,
@@ -28,6 +31,7 @@ from lerobot.common.train_utils import (
     update_last_checkpoint,
 )
 from lerobot.utils.constants import (
+    ACTION,
     CHECKPOINTS_DIR,
     LAST_CHECKPOINT_LINK,
     OPTIMIZER_PARAM_GROUPS,
@@ -37,6 +41,43 @@ from lerobot.utils.constants import (
     TRAINING_STATE_DIR,
     TRAINING_STEP,
 )
+
+
+def _make_dataset_metadata():
+    features = {
+        ACTION: {
+            "dtype": "float32",
+            "shape": (2,),
+            "names": ["shoulder", "gripper"],
+        },
+        "observation.state": {
+            "dtype": "float32",
+            "shape": (2,),
+            "names": ["shoulder", "gripper"],
+        },
+    }
+    info_dict = {
+        "codebase_version": "v3.0",
+        "fps": 30,
+        "features": features,
+        "robot_type": "test_bot",
+        "total_episodes": 1,
+        "total_frames": 4,
+        "total_tasks": 1,
+        "splits": {"train": "0:1"},
+    }
+
+    class Info:
+        def to_dict(self):
+            return info_dict
+
+    class DatasetMetadata:
+        repo_id = "user/dataset"
+        revision = "v3.0"
+        info = Info()
+        stats = {ACTION: {"mean": np.array([0.1, 0.2]), "std": np.array([1.0, 1.5])}}
+
+    return DatasetMetadata()
 
 
 def test_get_step_identifier():
@@ -76,6 +117,7 @@ def test_update_last_checkpoint(tmp_path):
 def test_save_checkpoint(mock_save_training_state, tmp_path, optimizer):
     policy = Mock()
     cfg = Mock()
+    cfg.peft = None
     save_checkpoint(tmp_path, 10, cfg, policy, optimizer)
     policy.save_pretrained.assert_called_once()
     cfg.save_pretrained.assert_called_once()
@@ -88,11 +130,25 @@ def test_save_checkpoint_peft(mock_save_training_state, tmp_path, optimizer):
     policy.config = Mock()
     policy.config.save_pretrained = Mock()
     cfg = Mock()
-    cfg.use_peft = True
+    cfg.peft = Mock()
     save_checkpoint(tmp_path, 10, cfg, policy, optimizer)
     policy.save_pretrained.assert_called_once()
     cfg.save_pretrained.assert_called_once()
     policy.config.save_pretrained.assert_called_once()
+    mock_save_training_state.assert_called_once()
+
+
+@patch("lerobot.common.train_utils.save_training_state")
+def test_save_checkpoint_writes_policy_dataset_metadata(mock_save_training_state, tmp_path, optimizer):
+    policy = Mock()
+    cfg = Mock()
+    cfg.peft = None
+    ds_meta = _make_dataset_metadata()
+
+    save_checkpoint(tmp_path / "checkpoint", 10, cfg, policy, optimizer, dataset_meta=ds_meta)
+
+    metadata_path = tmp_path / "checkpoint" / "pretrained_model" / POLICY_DATASET_METADATA_NAME
+    assert metadata_path.is_file()
     mock_save_training_state.assert_called_once()
 
 


### PR DESCRIPTION
## Summary

Fixes https://github.com/huggingface/lerobot/issues/3318.

This PR makes trained policy artifacts more self-contained by saving a lightweight snapshot of the training dataset metadata beside the policy, then using that snapshot when `make_policy()` is called with only a pretrained path.

## What Changed

- Add `lerobot.common.policy_metadata` with helpers to save and load `dataset_metadata.json` for policy artifacts.
- Store a compact metadata snapshot containing dataset provenance, feature definitions, and stats. This intentionally does not serialize episodes, tasks, frames, videos, or a full dataset handle.
- Save the metadata snapshot from offline training checkpoints and model Hub uploads.
- Allow `make_policy(cfg)` to instantiate pretrained policies without `ds_meta` or `env_cfg` when feature metadata is available from the saved config or the new metadata snapshot.
- Preserve existing behavior for scratch policies: they still require either dataset metadata or an environment config.
- Forward stats from the packaged metadata through the existing `dataset_stats` hook when the dataset object itself is unavailable.
- Keep missing metadata backward-compatible for older policy artifacts, with a clear error telling users to pass `ds_meta`, pass `env_cfg`, or re-save with a newer LeRobot version.
- Add focused tests for metadata roundtrip/loading, checkpoint packaging, and pretrained policy loading without dataset access.

## Why

Today, users can save a trained policy but still need access to the original dataset metadata later in order to instantiate it through `make_policy()`. That dataset can change, disappear, or simply be unknown at inference time. Packaging the relevant snapshot with the policy makes trained policies portable and less dependent on mutable external dataset state.

## Validation

- `uv run --extra test python -m pytest tests/common/test_policy_metadata.py tests/utils/test_train_utils.py -q`
- `uv run --extra test --extra dataset python -m pytest tests/policies/test_policies.py -q`
- `uv run --extra test --extra dataset python -m pytest tests/policies/test_sac_policy.py::test_sac_policy_save_and_load -q`
- `uv run --extra dev ruff check src/lerobot/common/policy_metadata.py src/lerobot/policies/factory.py src/lerobot/common/train_utils.py src/lerobot/policies/pretrained.py src/lerobot/scripts/lerobot_train.py tests/common/test_policy_metadata.py tests/utils/test_train_utils.py tests/policies/test_policies.py`
- `uv run --extra dev ruff format --check src/lerobot/common/policy_metadata.py src/lerobot/policies/factory.py src/lerobot/common/train_utils.py src/lerobot/policies/pretrained.py src/lerobot/scripts/lerobot_train.py tests/common/test_policy_metadata.py tests/utils/test_train_utils.py tests/policies/test_policies.py`
- `git diff --check`

## Notes

The snapshot format is versioned with `schema_version` so it can evolve without pretending to be a full `LeRobotDatasetMetadata` replacement.
