### PR TITLE
Make SO follower position P gain configurable

### DIFF
--- a/src/lerobot/robots/bi_so_follower/bi_so_follower.py
+++ b/src/lerobot/robots/bi_so_follower/bi_so_follower.py
@@ -58,6 +58,7 @@ class BiSOFollower(BimanualMixin, Robot):
             port=config.left_arm_config.port,
             disable_torque_on_disconnect=config.left_arm_config.disable_torque_on_disconnect,
             max_relative_target=config.left_arm_config.max_relative_target,
+            position_p_coefficient=config.left_arm_config.position_p_coefficient,
             use_degrees=config.left_arm_config.use_degrees,
             cameras=left_arm_cameras,
         )
@@ -68,6 +69,7 @@ class BiSOFollower(BimanualMixin, Robot):
             port=config.right_arm_config.port,
             disable_torque_on_disconnect=config.right_arm_config.disable_torque_on_disconnect,
             max_relative_target=config.right_arm_config.max_relative_target,
+            position_p_coefficient=config.right_arm_config.position_p_coefficient,
             use_degrees=config.right_arm_config.use_degrees,
             cameras=config.right_arm_config.cameras,
         )

--- a/src/lerobot/robots/so_follower/config_so_follower.py
+++ b/src/lerobot/robots/so_follower/config_so_follower.py
@@ -21,6 +21,11 @@ from lerobot.cameras import CameraConfig
 from ..config import RobotConfig
 
 
+def _validate_position_p_coefficient(value: object) -> None:
+    if isinstance(value, bool) or not isinstance(value, int) or not 0 <= value <= 255:
+        raise ValueError(f"position_p_coefficient must be an integer in [0, 255], got {value!r}")
+
+
 @dataclass
 class SOFollowerConfig:
     """Base configuration class for SO Follower robots."""
@@ -41,12 +46,20 @@ class SOFollowerConfig:
     # Set to `True` for backward compatibility with previous policies/dataset
     use_degrees: bool = True
 
+    # Position-mode proportional gain written to Feetech STS3215 motors at connect time.
+    position_p_coefficient: int = 16
+
+    def __post_init__(self) -> None:
+        _validate_position_p_coefficient(self.position_p_coefficient)
+
 
 @RobotConfig.register_subclass("so101_follower")
 @RobotConfig.register_subclass("so100_follower")
 @dataclass
 class SOFollowerRobotConfig(RobotConfig, SOFollowerConfig):
-    pass
+    def __post_init__(self) -> None:
+        RobotConfig.__post_init__(self)
+        _validate_position_p_coefficient(self.position_p_coefficient)
 
 
 SO100FollowerConfig = SOFollowerRobotConfig

--- a/src/lerobot/robots/so_follower/so_follower.py
+++ b/src/lerobot/robots/so_follower/so_follower.py
@@ -161,9 +161,8 @@ class SOFollower(Robot):
             self.bus.configure_motors()
             for motor in self.bus.motors:
                 self.bus.write("Operating_Mode", motor, OperatingMode.POSITION.value)
-                # Set P_Coefficient to lower value to avoid shakiness (Default is 32)
-                self.bus.write("P_Coefficient", motor, 16)
-                # Set I_Coefficient and D_Coefficient to default value 0 and 32
+                # Keep I/D fixed while allowing P to be tuned for hardware-specific settling behavior.
+                self.bus.write("P_Coefficient", motor, self.config.position_p_coefficient)
                 self.bus.write("I_Coefficient", motor, 0)
                 self.bus.write("D_Coefficient", motor, 32)
 

--- a/tests/robots/test_so100_follower.py
+++ b/tests/robots/test_so100_follower.py
@@ -19,9 +19,11 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from lerobot.robots.bi_so_follower import BiSOFollower, BiSOFollowerConfig
 from lerobot.robots.so_follower import (
     SO100Follower,
     SO100FollowerConfig,
+    SOFollowerConfig,
 )
 
 
@@ -48,27 +50,42 @@ def _make_bus_mock() -> MagicMock:
     return bus
 
 
+def _configure_bus_mock(bus_mock: MagicMock, *_args, **kwargs) -> MagicMock:
+    bus_mock.motors = kwargs["motors"]
+    motors_order: list[str] = list(bus_mock.motors)
+
+    bus_mock.sync_read.return_value = {motor: idx for idx, motor in enumerate(motors_order, 1)}
+    bus_mock.sync_write.return_value = None
+    bus_mock.write.return_value = None
+    bus_mock.disable_torque.return_value = None
+    bus_mock.enable_torque.return_value = None
+    bus_mock.is_calibrated = True
+    return bus_mock
+
+
+@contextmanager
+def _patch_bus(bus_mock: MagicMock):
+    with patch(
+        "lerobot.robots.so_follower.so_follower.FeetechMotorsBus",
+        side_effect=lambda *args, **kwargs: _configure_bus_mock(bus_mock, *args, **kwargs),
+    ):
+        yield
+
+
+def _write_values(bus_mock: MagicMock, register: str) -> dict[str, int]:
+    return {
+        motor: value
+        for reg, motor, value in (call.args for call in bus_mock.write.call_args_list)
+        if reg == register
+    }
+
+
 @pytest.fixture
 def follower():
     bus_mock = _make_bus_mock()
 
-    def _bus_side_effect(*_args, **kwargs):
-        bus_mock.motors = kwargs["motors"]
-        motors_order: list[str] = list(bus_mock.motors)
-
-        bus_mock.sync_read.return_value = {motor: idx for idx, motor in enumerate(motors_order, 1)}
-        bus_mock.sync_write.return_value = None
-        bus_mock.write.return_value = None
-        bus_mock.disable_torque.return_value = None
-        bus_mock.enable_torque.return_value = None
-        bus_mock.is_calibrated = True
-        return bus_mock
-
     with (
-        patch(
-            "lerobot.robots.so_follower.so_follower.FeetechMotorsBus",
-            side_effect=_bus_side_effect,
-        ),
+        _patch_bus(bus_mock),
         patch.object(SO100Follower, "configure", lambda self: None),
     ):
         cfg = SO100FollowerConfig(port="/dev/null")
@@ -109,3 +126,74 @@ def test_send_action(follower):
 
     goal_pos = {m: (i + 1) * 10 for i, m in enumerate(follower.bus.motors)}
     follower.bus.sync_write.assert_called_once_with("Goal_Position", goal_pos)
+
+
+def test_configure_writes_default_position_p_coefficient():
+    bus_mock = _make_bus_mock()
+
+    with _patch_bus(bus_mock):
+        robot = SO100Follower(SO100FollowerConfig(port="/dev/null"))
+        robot.configure()
+
+    motors = set(robot.bus.motors)
+    assert _write_values(bus_mock, "P_Coefficient") == dict.fromkeys(motors, 16)
+    assert _write_values(bus_mock, "I_Coefficient") == dict.fromkeys(motors, 0)
+    assert _write_values(bus_mock, "D_Coefficient") == dict.fromkeys(motors, 32)
+    assert _write_values(bus_mock, "Max_Torque_Limit") == {"gripper": 500}
+    assert _write_values(bus_mock, "Protection_Current") == {"gripper": 250}
+    assert _write_values(bus_mock, "Overload_Torque") == {"gripper": 25}
+
+
+def test_configure_writes_overridden_position_p_coefficient():
+    bus_mock = _make_bus_mock()
+
+    with _patch_bus(bus_mock):
+        robot = SO100Follower(SO100FollowerConfig(port="/dev/null", position_p_coefficient=32))
+        robot.configure()
+
+    assert _write_values(bus_mock, "P_Coefficient") == dict.fromkeys(robot.bus.motors, 32)
+
+
+@pytest.mark.parametrize("value", [-1, 256, 1.5, "32", True])
+def test_position_p_coefficient_rejects_invalid_values(value):
+    with pytest.raises(ValueError, match="position_p_coefficient must be an integer in \\[0, 255\\]"):
+        SO100FollowerConfig(port="/dev/null", position_p_coefficient=value)
+
+
+@pytest.mark.parametrize("value", [0, 16, 32, 255])
+def test_position_p_coefficient_accepts_valid_values(value):
+    config = SO100FollowerConfig(port="/dev/null", position_p_coefficient=value)
+
+    assert config.position_p_coefficient == value
+
+
+def test_position_p_coefficient_preserves_existing_positional_arguments():
+    config = SO100FollowerConfig("/dev/null", True, None, {}, False)
+
+    assert config.cameras == {}
+    assert config.use_degrees is False
+    assert config.position_p_coefficient == 16
+
+
+def test_bi_so_follower_preserves_position_p_coefficients():
+    def make_arm(config):
+        arm = MagicMock()
+        arm.config = config
+        arm.cameras = {}
+        return arm
+
+    config = BiSOFollowerConfig(
+        left_arm_config=SOFollowerConfig(port="/dev/left", position_p_coefficient=16),
+        right_arm_config=SOFollowerConfig(port="/dev/right", position_p_coefficient=32),
+    )
+
+    with patch(
+        "lerobot.robots.bi_so_follower.bi_so_follower.SOFollower", side_effect=make_arm
+    ) as follower_cls:
+        BiSOFollower(config)
+
+    left_config = follower_cls.call_args_list[0].args[0]
+    right_config = follower_cls.call_args_list[1].args[0]
+
+    assert left_config.position_p_coefficient == 16
+    assert right_config.position_p_coefficient == 32


### PR DESCRIPTION
## Summary

- Add `position_p_coefficient` to SO follower configs, defaulting to `16` to preserve existing behavior.
- Use the configured P coefficient when `SOFollower.configure()` writes Feetech `P_Coefficient`.
- Preserve the existing `I_Coefficient=0`, `D_Coefficient=32`, and gripper safety writes.
- Propagate the new field through `BiSOFollower` left/right arm config reconstruction.
- Validate the configured value and preserve the existing positional constructor argument order.
- Extend SO follower tests for default P, override P, validation, positional compatibility, bimanual propagation, and gripper safety register writes.

## Motivation

Addresses #3400.

`SOFollower.configure()` writes the Feetech STS3215 position P coefficient as `16` on every connect. The issue reports that this gain can leave `shoulder_pan` unable to overcome small-error static friction on some hardware, causing direction-dependent settling even when the commanded goal position is the same.

This change preserves the established default of `16` to avoid changing stiffness across all motors without broader hardware validation, while allowing affected users to opt into `position_p_coefficient=32` or another suitable value.

## Validation

- `uv run --extra test pytest tests/robots -q` — 23 passed, 2 skipped
- `uv run ruff check src/lerobot/robots/so_follower/config_so_follower.py src/lerobot/robots/so_follower/so_follower.py src/lerobot/robots/bi_so_follower/bi_so_follower.py tests/robots/test_so100_follower.py`
- `uv run ruff format --check src/lerobot/robots/so_follower/config_so_follower.py src/lerobot/robots/so_follower/so_follower.py src/lerobot/robots/bi_so_follower/bi_so_follower.py tests/robots/test_so100_follower.py`
- `git diff --check`

## Notes

The configurable register writes are covered without hardware. A physical settling test is still needed to determine the best gain for a particular SO-ARM100/SO101 setup.
