### PR TITLE
fix(cameras): avoid opening Linux OpenCV cameras during discovery

### DIFF
--- a/docs/source/cameras.mdx
+++ b/docs/source/cameras.mdx
@@ -22,6 +22,18 @@ Every camera requires a unique identifier to be instantiated, allowing you to di
 lerobot-find-cameras opencv # or realsense for Intel Realsense cameras
 ```
 
+On Linux, OpenCV camera discovery lists `/dev/video*` identifiers without opening the camera devices.
+This avoids backend side effects during discovery, but the default stream profile values may be shown as
+unavailable. To explicitly open detected cameras and save sample images, use:
+
+```bash
+lerobot-find-cameras opencv --save-images
+```
+
+> [!WARNING]
+> `--save-images` opens cameras through their backend. On some Linux OpenCV/V4L2 package combinations,
+> opening a camera can alter its active settings, so use list-only discovery when you only need the camera id.
+
 The output will look something like this if you have two cameras connected:
 
 ```bash

--- a/src/lerobot/cameras/opencv/camera_opencv.py
+++ b/src/lerobot/cameras/opencv/camera_opencv.py
@@ -21,7 +21,6 @@ import math
 import os
 import platform
 import time
-from pathlib import Path
 from threading import Event, Lock, Thread
 from typing import Any
 
@@ -38,6 +37,7 @@ from lerobot.utils.errors import DeviceNotConnectedError
 from ..camera import Camera
 from ..utils import get_cv2_rotation
 from .configuration_opencv import ColorMode, OpenCVCameraConfig
+from .linux_v4l2 import find_linux_video_devices
 
 # NOTE(Steven): The maximum opencv device index depends on your operating system. For instance,
 # if you have 3 cameras, they should be associated to index 0, 1, and 2. This is the case
@@ -287,51 +287,56 @@ class OpenCVCamera(Camera):
         """
         Detects available OpenCV cameras connected to the system.
 
-        On Linux, it scans '/dev/video*' paths. On other systems (like macOS, Windows),
-        it checks indices from 0 up to `MAX_OPENCV_INDEX`.
+        On Linux, discovery enumerates video device paths without opening them. Opening devices
+        through OpenCV can mutate active V4L2 settings on some backend/package combinations.
+        On other systems (like macOS, Windows), it checks indices from 0 up to `MAX_OPENCV_INDEX`.
 
         Returns:
             List[Dict[str, Any]]: A list of dictionaries,
             where each dictionary contains 'type', 'id' (port index or path),
-            and the default profile properties (width, height, fps, format).
+            and the default profile properties. Linux discovery may return unknown profile values
+            because it avoids opening the camera.
         """
-        found_cameras_info = []
-
-        targets_to_scan: list[str | int]
         if platform.system() == "Linux":
-            possible_paths = sorted(Path("/dev").glob("video*"), key=lambda p: p.name)
-            targets_to_scan = [str(p) for p in possible_paths]
-        else:
-            targets_to_scan = [int(i) for i in range(MAX_OPENCV_INDEX)]
+            return find_linux_video_devices()
 
+        return OpenCVCamera._find_cameras_with_opencv([int(i) for i in range(MAX_OPENCV_INDEX)])
+
+    @staticmethod
+    def _find_cameras_with_opencv(targets_to_scan: list[str | int]) -> list[dict[str, Any]]:
+        found_cameras_info = []
         for target in targets_to_scan:
             camera = cv2.VideoCapture(target)
-            if camera.isOpened():
+            try:
+                if not camera.isOpened():
+                    continue
+
                 default_width = int(camera.get(cv2.CAP_PROP_FRAME_WIDTH))
                 default_height = int(camera.get(cv2.CAP_PROP_FRAME_HEIGHT))
                 default_fps = camera.get(cv2.CAP_PROP_FPS)
                 default_format = camera.get(cv2.CAP_PROP_FORMAT)
 
-                # Get FOURCC code and convert to string
-                default_fourcc_code = camera.get(cv2.CAP_PROP_FOURCC)
-                default_fourcc_code_int = int(default_fourcc_code)
-                default_fourcc = "".join([chr((default_fourcc_code_int >> 8 * i) & 0xFF) for i in range(4)])
+                default_fourcc_code_int = int(camera.get(cv2.CAP_PROP_FOURCC))
+                default_fourcc = "".join(
+                    [chr((default_fourcc_code_int >> 8 * i) & 0xFF) for i in range(4)]
+                )
 
-                camera_info = {
-                    "name": f"OpenCV Camera @ {target}",
-                    "type": "OpenCV",
-                    "id": target,
-                    "backend_api": camera.getBackendName(),
-                    "default_stream_profile": {
-                        "format": default_format,
-                        "fourcc": default_fourcc,
-                        "width": default_width,
-                        "height": default_height,
-                        "fps": default_fps,
-                    },
-                }
-
-                found_cameras_info.append(camera_info)
+                found_cameras_info.append(
+                    {
+                        "name": f"OpenCV Camera @ {target}",
+                        "type": "OpenCV",
+                        "id": target,
+                        "backend_api": camera.getBackendName(),
+                        "default_stream_profile": {
+                            "format": default_format,
+                            "fourcc": default_fourcc,
+                            "width": default_width,
+                            "height": default_height,
+                            "fps": default_fps,
+                        },
+                    }
+                )
+            finally:
                 camera.release()
 
         return found_cameras_info

--- a/src/lerobot/cameras/opencv/linux_v4l2.py
+++ b/src/lerobot/cameras/opencv/linux_v4l2.py
@@ -1,0 +1,74 @@
+# Copyright 2024 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Safe Linux V4L2 device discovery for OpenCV cameras.
+
+This module intentionally avoids opening /dev/video* devices. Some OpenCV/V4L2
+backend combinations can change the active camera format when VideoCapture opens
+a device, so default discovery only enumerates device identifiers.
+"""
+
+from pathlib import Path
+from typing import Any
+
+
+def _unknown_stream_profile() -> dict[str, None]:
+    return {
+        "format": None,
+        "fourcc": None,
+        "width": None,
+        "height": None,
+        "fps": None,
+    }
+
+
+def _read_device_name(sysfs_video_device: Path) -> str | None:
+    name_path = sysfs_video_device / "name"
+    try:
+        name = name_path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    return name or None
+
+
+def _camera_info(dev_path: Path, name: str | None) -> dict[str, Any]:
+    display_name = f"{name} @ {dev_path}" if name else f"OpenCV Camera @ {dev_path}"
+    return {
+        "name": display_name,
+        "type": "OpenCV",
+        "id": str(dev_path),
+        "backend_api": "V4L2",
+        "default_stream_profile": _unknown_stream_profile(),
+    }
+
+
+def find_linux_video_devices(
+    sysfs_video4linux_path: Path = Path("/sys/class/video4linux"),
+    dev_path: Path = Path("/dev"),
+) -> list[dict[str, Any]]:
+    """
+    Enumerate Linux video devices without opening camera device files.
+
+    Stream profile values are intentionally unknown because querying them through
+    OpenCV opens the device and can mutate active settings on some backends.
+    """
+    sysfs_devices = sorted(sysfs_video4linux_path.glob("video*"), key=lambda path: path.name)
+    if sysfs_devices:
+        return [
+            _camera_info(dev_path / sysfs_device.name, _read_device_name(sysfs_device))
+            for sysfs_device in sysfs_devices
+        ]
+
+    return [_camera_info(path, None) for path in sorted(dev_path.glob("video*"), key=lambda path: path.name)]

--- a/src/lerobot/scripts/lerobot_find_cameras.py
+++ b/src/lerobot/scripts/lerobot_find_cameras.py
@@ -30,6 +30,7 @@ lerobot-find-cameras
 import argparse
 import concurrent.futures
 import logging
+import platform
 import time
 from pathlib import Path
 from typing import Any
@@ -284,11 +285,10 @@ def save_images_from_all_cameras(
             print(f"Image capture finished. Images saved to {output_dir}")
 
 
-def main():
+def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Unified camera utility script for listing cameras and capturing images."
     )
-
     parser.add_argument(
         "camera_type",
         type=str,
@@ -298,19 +298,56 @@ def main():
         help="Specify camera type to capture from (e.g., 'realsense', 'opencv'). Captures from all if omitted.",
     )
     parser.add_argument(
+        "--save-images",
+        action="store_true",
+        help="Open detected cameras and save sample images. By default this command only lists cameras.",
+    )
+    parser.add_argument(
         "--output-dir",
         type=Path,
-        default="outputs/captured_images",
+        default=None,
         help="Directory to save images. Default: outputs/captured_images",
     )
     parser.add_argument(
         "--record-time-s",
         type=float,
-        default=6.0,
+        default=None,
         help="Time duration to attempt capturing frames. Default: 6 seconds.",
     )
-    args = parser.parse_args()
-    save_images_from_all_cameras(**vars(args))
+    return parser
+
+
+def _should_warn_about_opencv_capture(camera_type: str | None) -> bool:
+    return platform.system() == "Linux" and (camera_type is None or camera_type.lower() == "opencv")
+
+
+def run(args: argparse.Namespace) -> list[dict[str, Any]] | None:
+    if not args.save_images:
+        if args.output_dir is not None:
+            logger.warning("Ignoring --output-dir because --save-images was not set.")
+        if args.record_time_s is not None:
+            logger.warning("Ignoring --record-time-s because --save-images was not set.")
+        return find_and_print_cameras(camera_type_filter=args.camera_type)
+
+    if _should_warn_about_opencv_capture(args.camera_type):
+        logger.warning(
+            "Opening OpenCV cameras on Linux may alter active camera settings on some OpenCV/V4L2 "
+            "backend combinations. The default listing mode avoids opening cameras."
+        )
+    output_dir = args.output_dir if args.output_dir is not None else Path("outputs/captured_images")
+    record_time_s = args.record_time_s if args.record_time_s is not None else 6.0
+    save_images_from_all_cameras(
+        output_dir=output_dir,
+        record_time_s=record_time_s,
+        camera_type=args.camera_type,
+    )
+    return None
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    run(args)
 
 
 if __name__ == "__main__":

--- a/tests/cameras/test_opencv_discovery.py
+++ b/tests/cameras/test_opencv_discovery.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python
+
+# Copyright 2024 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from lerobot.cameras.opencv import camera_opencv
+from lerobot.cameras.opencv.camera_opencv import OpenCVCamera
+from lerobot.cameras.opencv.linux_v4l2 import find_linux_video_devices
+
+
+def test_find_cameras_linux_does_not_open_with_opencv(monkeypatch):
+    fake_cameras = [
+        {
+            "name": "OpenCV Camera @ /dev/video0",
+            "type": "OpenCV",
+            "id": "/dev/video0",
+            "backend_api": "V4L2",
+            "default_stream_profile": {
+                "format": None,
+                "fourcc": None,
+                "width": None,
+                "height": None,
+                "fps": None,
+            },
+        }
+    ]
+
+    def fail_if_opened(*args, **kwargs):
+        raise AssertionError("Linux discovery must not open cameras through OpenCV")
+
+    monkeypatch.setattr(camera_opencv.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(camera_opencv, "find_linux_video_devices", lambda: fake_cameras)
+    monkeypatch.setattr(camera_opencv.cv2, "VideoCapture", fail_if_opened)
+
+    assert OpenCVCamera.find_cameras() == fake_cameras
+
+
+def test_safe_linux_enumerator_returns_devices_without_profiles(tmp_path):
+    sysfs_root = tmp_path / "sys" / "class" / "video4linux"
+    dev_root = tmp_path / "dev"
+    video0 = sysfs_root / "video0"
+    video2 = sysfs_root / "video2"
+    video0.mkdir(parents=True)
+    video2.mkdir()
+    dev_root.mkdir()
+    (video0 / "name").write_text("Front Camera\n", encoding="utf-8")
+    (dev_root / "video0").touch()
+    (dev_root / "video2").touch()
+
+    cameras = find_linux_video_devices(sysfs_video4linux_path=sysfs_root, dev_path=dev_root)
+
+    assert cameras == [
+        {
+            "name": f"Front Camera @ {dev_root / 'video0'}",
+            "type": "OpenCV",
+            "id": str(dev_root / "video0"),
+            "backend_api": "V4L2",
+            "default_stream_profile": {
+                "format": None,
+                "fourcc": None,
+                "width": None,
+                "height": None,
+                "fps": None,
+            },
+        },
+        {
+            "name": f"OpenCV Camera @ {dev_root / 'video2'}",
+            "type": "OpenCV",
+            "id": str(dev_root / "video2"),
+            "backend_api": "V4L2",
+            "default_stream_profile": {
+                "format": None,
+                "fourcc": None,
+                "width": None,
+                "height": None,
+                "fps": None,
+            },
+        },
+    ]
+
+
+def test_safe_linux_enumerator_falls_back_to_dev_paths(tmp_path):
+    sysfs_root = tmp_path / "missing-sysfs"
+    dev_root = tmp_path / "dev"
+    dev_root.mkdir()
+    (dev_root / "video1").touch()
+    (dev_root / "video0").touch()
+
+    cameras = find_linux_video_devices(sysfs_video4linux_path=sysfs_root, dev_path=dev_root)
+
+    assert [camera["id"] for camera in cameras] == [str(dev_root / "video0"), str(dev_root / "video1")]
+    assert all(camera["default_stream_profile"]["width"] is None for camera in cameras)
+
+
+def test_non_linux_discovery_uses_opencv_probe(monkeypatch):
+    captures = []
+
+    class FakeVideoCapture:
+        def __init__(self, target):
+            self.target = target
+            self.released = False
+            captures.append(self)
+
+        def isOpened(self):  # noqa: N802
+            return self.target == 0
+
+        def get(self, prop):
+            values = {
+                camera_opencv.cv2.CAP_PROP_FRAME_WIDTH: 1280,
+                camera_opencv.cv2.CAP_PROP_FRAME_HEIGHT: 720,
+                camera_opencv.cv2.CAP_PROP_FPS: 30,
+                camera_opencv.cv2.CAP_PROP_FORMAT: 16,
+                camera_opencv.cv2.CAP_PROP_FOURCC: 1196444237,
+            }
+            return values[prop]
+
+        def getBackendName(self):  # noqa: N802
+            return "MOCK"
+
+        def release(self):
+            self.released = True
+
+    monkeypatch.setattr(camera_opencv.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(camera_opencv, "MAX_OPENCV_INDEX", 2)
+    monkeypatch.setattr(camera_opencv.cv2, "VideoCapture", FakeVideoCapture)
+
+    assert OpenCVCamera.find_cameras() == [
+        {
+            "name": "OpenCV Camera @ 0",
+            "type": "OpenCV",
+            "id": 0,
+            "backend_api": "MOCK",
+            "default_stream_profile": {
+                "format": 16,
+                "fourcc": "MJPG",
+                "width": 1280,
+                "height": 720,
+                "fps": 30,
+            },
+        }
+    ]
+    assert [capture.released for capture in captures] == [True, True]

--- a/tests/scripts/test_lerobot_find_cameras.py
+++ b/tests/scripts/test_lerobot_find_cameras.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python
+
+# Copyright 2024 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+from lerobot.scripts import lerobot_find_cameras
+
+
+def test_default_cli_lists_without_connecting(monkeypatch):
+    fake_cameras = [{"type": "OpenCV", "id": "/dev/video0"}]
+    calls = []
+
+    monkeypatch.setattr(
+        lerobot_find_cameras,
+        "find_and_print_cameras",
+        lambda camera_type_filter=None: fake_cameras,
+    )
+    monkeypatch.setattr(
+        lerobot_find_cameras,
+        "save_images_from_all_cameras",
+        lambda **kwargs: calls.append(kwargs),
+    )
+
+    args = lerobot_find_cameras.build_parser().parse_args(["opencv"])
+
+    assert lerobot_find_cameras.run(args) == fake_cameras
+    assert calls == []
+
+
+def test_save_images_cli_uses_capture_path(monkeypatch, tmp_path):
+    calls = []
+
+    monkeypatch.setattr(lerobot_find_cameras.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(
+        lerobot_find_cameras,
+        "save_images_from_all_cameras",
+        lambda **kwargs: calls.append(kwargs),
+    )
+
+    args = lerobot_find_cameras.build_parser().parse_args(
+        ["opencv", "--save-images", "--output-dir", str(tmp_path), "--record-time-s", "2"]
+    )
+
+    assert lerobot_find_cameras.run(args) is None
+    assert calls == [{"output_dir": tmp_path, "record_time_s": 2.0, "camera_type": "opencv"}]
+
+
+def test_output_dir_without_save_images_warns_and_does_not_capture(monkeypatch, tmp_path, caplog):
+    calls = []
+    fake_cameras = [{"type": "OpenCV", "id": "/dev/video0"}]
+
+    monkeypatch.setattr(
+        lerobot_find_cameras,
+        "find_and_print_cameras",
+        lambda camera_type_filter=None: fake_cameras,
+    )
+    monkeypatch.setattr(
+        lerobot_find_cameras,
+        "save_images_from_all_cameras",
+        lambda **kwargs: calls.append(kwargs),
+    )
+
+    args = lerobot_find_cameras.build_parser().parse_args(["opencv", "--output-dir", str(tmp_path)])
+
+    with caplog.at_level(logging.WARNING):
+        assert lerobot_find_cameras.run(args) == fake_cameras
+
+    assert "Ignoring --output-dir" in caplog.text
+    assert calls == []
+
+
+def test_record_time_without_save_images_warns_and_does_not_capture(monkeypatch, caplog):
+    calls = []
+    fake_cameras = [{"type": "OpenCV", "id": "/dev/video0"}]
+
+    monkeypatch.setattr(
+        lerobot_find_cameras,
+        "find_and_print_cameras",
+        lambda camera_type_filter=None: fake_cameras,
+    )
+    monkeypatch.setattr(
+        lerobot_find_cameras,
+        "save_images_from_all_cameras",
+        lambda **kwargs: calls.append(kwargs),
+    )
+
+    args = lerobot_find_cameras.build_parser().parse_args(["opencv", "--record-time-s", "2"])
+
+    with caplog.at_level(logging.WARNING):
+        assert lerobot_find_cameras.run(args) == fake_cameras
+
+    assert "Ignoring --record-time-s" in caplog.text
+    assert calls == []
+
+
+def test_linux_save_images_warns_about_opencv_capture(monkeypatch, caplog, tmp_path):
+    monkeypatch.setattr(lerobot_find_cameras.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(lerobot_find_cameras, "save_images_from_all_cameras", lambda **kwargs: None)
+
+    args = lerobot_find_cameras.build_parser().parse_args(
+        ["opencv", "--save-images", "--output-dir", str(tmp_path)]
+    )
+
+    with caplog.at_level(logging.WARNING):
+        assert lerobot_find_cameras.run(args) is None
+
+    assert "Opening OpenCV cameras on Linux may alter active camera settings" in caplog.text


### PR DESCRIPTION
## Summary / Motivation

Fixes #3347.

`lerobot-find-cameras opencv` currently opens Linux `/dev/video*` devices through `cv2.VideoCapture` during discovery. Some OpenCV/V4L2 backend combinations, including the `opencv-python-headless==4.13.0.92` setup reported in the issue, can mutate active camera settings just from that open operation. This PR makes the default Linux discovery path side-effect-free by enumerating device identifiers without opening camera devices.

The trade-off is that Linux list-only discovery now reports unknown stream profile values instead of probing exact width, height, fps, and format through OpenCV. Users who want sample images can still opt into opening cameras explicitly.

## Related issues

- Fixes / Closes: #3347

## What changed

- Added safe Linux V4L2 device enumeration for OpenCV cameras that reads `/sys/class/video4linux` or falls back to `/dev/video*` without opening camera devices.
- Updated `OpenCVCamera.find_cameras()` to use safe Linux enumeration while preserving existing OpenCV probing on non-Linux platforms.
- Changed `lerobot-find-cameras` to list cameras by default and added `--save-images` for the previous sample-capture behavior.
- Added a Linux warning when `--save-images` will open OpenCV cameras.
- Documented the safe Linux default and explicit image-capture mode.
- Added regression tests for Linux discovery, `/dev/video*` fallback enumeration, non-Linux OpenCV probing, CLI list-only behavior, explicit capture, and warning behavior.

This does change the default CLI behavior: `lerobot-find-cameras opencv` now lists cameras only. Users who relied on sample images should run `lerobot-find-cameras opencv --save-images`.

## How was this tested (or how to run locally)

- `uv run python -m pytest tests/cameras/test_opencv.py tests/cameras/test_opencv_discovery.py tests/scripts/test_lerobot_find_cameras.py -q`
- `uvx ruff check src/lerobot/cameras/opencv src/lerobot/scripts/lerobot_find_cameras.py tests/cameras/test_opencv_discovery.py tests/scripts/test_lerobot_find_cameras.py`
- `uv run python -m py_compile src/lerobot/cameras/opencv/linux_v4l2.py src/lerobot/cameras/opencv/camera_opencv.py src/lerobot/scripts/lerobot_find_cameras.py tests/cameras/test_opencv_discovery.py tests/scripts/test_lerobot_find_cameras.py`
- `git diff --check`

Manual Linux `v4l2-ctl` before/after validation was not run locally because this development host is not the reported Linux USB-camera setup.

## Checklist (required before merge)

- [ ] Linting/formatting run (`pre-commit run -a`)
- [ ] All tests pass locally (`pytest`)
- [x] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: # (insert PR number/link)

## Reviewer notes

The main review point is the intentional metadata trade-off on Linux: the safe path keeps camera identifiers reliable but leaves stream profile fields unknown, because exact OpenCV probing is the operation implicated in #3347. Non-Linux discovery keeps the previous OpenCV probing behavior.
