### PR TITLE
fix(processor): handle nested action names in relative action masks

### DIFF
--- a/src/lerobot/processor/relative_action_processor.py
+++ b/src/lerobot/processor/relative_action_processor.py
@@ -36,6 +36,8 @@ __all__ = [
     "to_absolute_actions",
 ]
 
+ActionNames = list[Any] | tuple[Any, ...]
+
 
 def to_relative_actions(actions: Tensor, state: Tensor, mask: Sequence[bool]) -> Tensor:
     """Convert absolute actions to relative: relative = action - state (for masked dims).
@@ -81,6 +83,17 @@ def to_absolute_actions(actions: Tensor, state: Tensor, mask: Sequence[bool]) ->
     return actions
 
 
+def _action_names_for_mask(action_names: ActionNames | None) -> ActionNames | None:
+    if not action_names:
+        return action_names
+
+    first = action_names[0]
+    if isinstance(first, (list, tuple)):
+        return first
+
+    return action_names
+
+
 @ProcessorStepRegistry.register("delta_actions_processor")
 @dataclass
 class RelativeActionsProcessorStep(ProcessorStep):
@@ -95,16 +108,18 @@ class RelativeActionsProcessorStep(ProcessorStep):
         enabled: Whether to apply the relative conversion.
         exclude_joints: Joint names to keep absolute (not converted to relative).
         action_names: Action dimension names from dataset metadata, used to build
-            the mask from exclude_joints. If None, all dims are converted.
+            the mask from exclude_joints. If nested, the first inner sequence is
+            used. If None, all dims are converted.
     """
 
     enabled: bool = False
     exclude_joints: list[str] = field(default_factory=list)
-    action_names: list[str] | None = None
+    action_names: ActionNames | None = None
     _last_state: torch.Tensor | None = field(default=None, init=False, repr=False)
 
     def _build_mask(self, action_dim: int) -> list[bool]:
-        if not self.exclude_joints or self.action_names is None:
+        action_names = _action_names_for_mask(self.action_names)
+        if not self.exclude_joints or action_names is None:
             return [True] * action_dim
 
         exclude_tokens = [str(name).lower() for name in self.exclude_joints if name]
@@ -112,7 +127,7 @@ class RelativeActionsProcessorStep(ProcessorStep):
             return [True] * action_dim
 
         mask = []
-        for name in self.action_names[:action_dim]:
+        for name in action_names[:action_dim]:
             action_name = str(name).lower()
             is_excluded = any(token == action_name or token in action_name for token in exclude_tokens)
             mask.append(not is_excluded)

--- a/tests/policies/test_relative_actions.py
+++ b/tests/policies/test_relative_actions.py
@@ -105,6 +105,41 @@ def test_exclude_joints_supports_partial_name_matching():
     assert step._build_mask(len(names)) == [True, False, True, False]
 
 
+def test_exclude_joints_supports_nested_action_names():
+    names = [
+        ["r_joint.pos", "r_gripper.pos"],
+        ["l_joint.pos", "l_gripper.pos"],
+    ]
+    step = RelativeActionsProcessorStep(
+        enabled=True,
+        exclude_joints=["gripper"],
+        action_names=names,
+    )
+    assert step._build_mask(2) == [True, False]
+    assert step.action_names is names
+
+
+def test_relative_processor_uses_nested_action_names_mask():
+    names = [
+        ["r_joint.pos", "r_gripper.pos"],
+        ["l_joint.pos", "l_gripper.pos"],
+    ]
+    step = RelativeActionsProcessorStep(
+        enabled=True,
+        exclude_joints=["gripper"],
+        action_names=names,
+    )
+    batch = {
+        ACTION: torch.tensor([[3.0, 4.0]]),
+        OBS_STATE: torch.tensor([[1.0, 2.0]]),
+    }
+    result = step(batch_to_transition(batch))
+    torch.testing.assert_close(
+        result[TransitionKey.ACTION],
+        torch.tensor([[2.0, 4.0]]),
+    )
+
+
 # Chunk-level relative stats test
 
 


### PR DESCRIPTION
## Title

fix(processor): handle nested action names in relative action masks

## Summary / Motivation

`RelativeActionsProcessorStep._build_mask()` currently assumes `action_names` is a flat list. For nested metadata such as `[["r_joint.pos", "r_gripper.pos"], ["l_joint.pos", "l_gripper.pos"]]`, it stringifies each inner list and matches `relative_exclude_joints` against the whole list representation. That can exclude the wrong dimensions. This PR keeps the existing flat-list behavior, but when `action_names` is nested it uses the first inner sequence for mask construction, matching the issue request without mutating the saved processor configuration.

## Related issues

- Fixes: #3283

## What changed

- Added a small helper to select the action-name sequence used by relative-action mask construction.
- Preserved current flat `action_names` behavior and existing substring matching for `relative_exclude_joints`.
- Kept nested `action_names` stored as-is so `get_config()` and serialized processor config output remain stable.
- Added regression tests for nested action names at both `_build_mask()` and processor-call level.

This is not a breaking change. It only affects `relative_exclude_joints` mask construction when nested action-name metadata is provided.

## How was this tested (or how to run locally)

- Tests added:
  - `tests/policies/test_relative_actions.py::test_exclude_joints_supports_nested_action_names`
  - `tests/policies/test_relative_actions.py::test_relative_processor_uses_nested_action_names_mask`
- Commands run:
  - `uv run python -m pytest tests/policies/test_relative_actions.py::test_exclude_joints_supports_partial_name_matching tests/policies/test_relative_actions.py::test_exclude_joints_supports_nested_action_names tests/policies/test_relative_actions.py::test_relative_processor_uses_nested_action_names_mask -q`
  - `uv run python -m pytest tests/policies/rtc/test_rtc_relative_actions.py -q`
  - `uv run python -m pytest --collect-only -q tests/policies/test_relative_actions.py`
  - `uv run ruff check src/lerobot/processor/relative_action_processor.py tests/policies/test_relative_actions.py`
  - `uv run ruff format --check src/lerobot/processor/relative_action_processor.py tests/policies/test_relative_actions.py`
  - `uv run python -m py_compile src/lerobot/processor/relative_action_processor.py tests/policies/test_relative_actions.py`
  - `git diff --check`
- Manual probes covered flat names, nested list names, nested tuple names, short action-name lists that extend remaining mask dimensions as relative, disabled exclusions, `None` names, and relative-to-absolute roundtrip recovery.

I did not run the full `tests/policies/test_relative_actions.py` execution because it depends on `lerobot-data-collection/dagger_final_1_21`, which was not cached locally.

## Checklist (required before merge)

- [x] Linting/formatting run (`ruff check`, `ruff format --check`)
- [ ] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: # (insert PR number/link)

## Reviewer notes

Please focus on whether the narrow `action_names[0]` behavior is the desired interpretation for nested metadata. I intentionally did not flatten nested names or change unrelated action-name consumers, because issue #3283 asks for the first inner list specifically and this keeps the change small.
