### PR TITLE
fix(datasets): hoist DatasetReader row-batch fetches under transforms

### DIFF
--- a/src/lerobot/datasets/dataset_reader.py
+++ b/src/lerobot/datasets/dataset_reader.py
@@ -213,22 +213,33 @@ class DatasetReader:
 
         return query_timestamps
 
+    def _to_relative_indices(self, query_indices: list[int]) -> list[int]:
+        if self._absolute_to_relative_idx is None:
+            return query_indices
+        return [self._absolute_to_relative_idx[idx] for idx in query_indices]
+
     def _query_hf_dataset(self, query_indices: dict[str, list[int]]) -> dict:
         """Query dataset for indices across keys, skipping video keys."""
-        result: dict = {}
-        for key, q_idx in query_indices.items():
-            if key in self._meta.video_keys:
-                continue
-            relative_indices = (
-                q_idx
-                if self._absolute_to_relative_idx is None
-                else [self._absolute_to_relative_idx[idx] for idx in q_idx]
+        relative_indices_by_key = {
+            key: self._to_relative_indices(q_idx)
+            for key, q_idx in query_indices.items()
+            if key not in self._meta.video_keys
+        }
+        if not relative_indices_by_key:
+            return {}
+
+        unique_relative_indices = list(
+            dict.fromkeys(
+                idx for indices in relative_indices_by_key.values() for idx in indices
             )
-            try:
-                result[key] = torch.stack(self.hf_dataset[key][relative_indices])
-            except (KeyError, TypeError, IndexError):
-                result[key] = torch.stack(self.hf_dataset[relative_indices][key])
-        return result
+        )
+        batch = self.hf_dataset[unique_relative_indices]
+        position_by_index = {idx: pos for pos, idx in enumerate(unique_relative_indices)}
+
+        return {
+            key: torch.stack([batch[key][position_by_index[idx]] for idx in relative_indices])
+            for key, relative_indices in relative_indices_by_key.items()
+        }
 
     def _query_videos(self, query_timestamps: dict[str, list[float]], ep_idx: int) -> dict[str, torch.Tensor]:
         """Note: When using data workers (e.g. DataLoader with num_workers>0), do not call this function

--- a/tests/datasets/test_dataset_reader.py
+++ b/tests/datasets/test_dataset_reader.py
@@ -16,11 +16,19 @@
 """Contract tests for DatasetReader."""
 
 import pytest
+import torch
 
 pytest.importorskip("datasets", reason="datasets is required (install lerobot[dataset])")
 
-from lerobot.datasets.dataset_reader import DatasetReader
-from lerobot.utils.import_utils import get_safe_default_codec
+from lerobot.datasets.dataset_reader import DatasetReader  # noqa: E402
+from lerobot.datasets.io_utils import hf_transform_to_torch  # noqa: E402
+from lerobot.datasets.lerobot_dataset import LeRobotDataset  # noqa: E402
+from lerobot.utils.import_utils import get_safe_default_codec  # noqa: E402
+
+
+def _row_first_stack(reader: DatasetReader, key: str, indices: list[int]) -> torch.Tensor:
+    return torch.stack(reader.hf_dataset[indices][key])
+
 
 # ── Loading ──────────────────────────────────────────────────────────
 
@@ -119,6 +127,117 @@ def test_get_item_values_are_correct(tmp_path, lerobot_dataset_factory):
 
     assert item_0["index"].item() == 0
     assert item_0["episode_index"].item() == 0
+
+
+# ── HF dataset queries ────────────────────────────────────────────────
+
+
+def test_query_hf_dataset_matches_row_fetch_for_multiple_keys(tmp_path, lerobot_dataset_factory):
+    """_query_hf_dataset returns the same values as row-first access for each key."""
+    dataset = lerobot_dataset_factory(
+        root=tmp_path / "ds", total_episodes=2, total_frames=20, use_videos=False
+    )
+    reader = dataset.reader
+    query_indices = {
+        "state": [0, 2, 2, 1],
+        "action": [3, 3, 4],
+        "laptop": [0, 1],
+    }
+
+    result = reader._query_hf_dataset(query_indices)
+
+    assert set(result) == set(query_indices)
+    for key, indices in query_indices.items():
+        torch.testing.assert_close(result[key], _row_first_stack(reader, key, indices))
+
+
+def test_query_hf_dataset_fetches_shared_batch_once(tmp_path, lerobot_dataset_factory):
+    """Multiple non-video keys should share one transformed row-batch fetch."""
+    dataset = lerobot_dataset_factory(
+        root=tmp_path / "ds", total_episodes=2, total_frames=20, use_videos=False
+    )
+    calls = {"count": 0}
+
+    def counting_transform(items):
+        calls["count"] += 1
+        return hf_transform_to_torch(items)
+
+    dataset.reader.hf_dataset.set_transform(counting_transform)
+
+    dataset.reader._query_hf_dataset(
+        {
+            "state": [0, 1, 2],
+            "action": [0, 1, 2],
+            "laptop": [0, 1, 2],
+        }
+    )
+
+    assert calls["count"] == 1
+
+
+def test_query_hf_dataset_preserves_duplicate_indices(tmp_path, lerobot_dataset_factory):
+    """Boundary-clamped delta indices can contain duplicates and must preserve them."""
+    dataset = lerobot_dataset_factory(
+        root=tmp_path / "ds", total_episodes=2, total_frames=20, use_videos=False
+    )
+    query_indices = {"state": [0, 0, 1]}
+
+    result = dataset.reader._query_hf_dataset(query_indices)
+
+    torch.testing.assert_close(result["state"], _row_first_stack(dataset.reader, "state", [0, 0, 1]))
+
+
+def test_query_hf_dataset_remaps_absolute_indices_with_episode_filter(
+    tmp_path, empty_lerobot_dataset_factory
+):
+    """Episode-filtered readers receive absolute frame indices from delta timestamp logic."""
+    features = {
+        "state": {"dtype": "float32", "shape": (1,), "names": ["x"]},
+        "action": {"dtype": "float32", "shape": (1,), "names": ["x"]},
+    }
+    dataset = empty_lerobot_dataset_factory(
+        root=tmp_path / "recorded", features=features, use_videos=False, fps=10
+    )
+    for ep_idx in range(3):
+        for frame_idx in range(3):
+            value = ep_idx * 10 + frame_idx
+            dataset.add_frame(
+                {
+                    "state": torch.tensor([value], dtype=torch.float32),
+                    "action": torch.tensor([value], dtype=torch.float32),
+                    "task": f"task_{ep_idx}",
+                }
+            )
+        dataset.save_episode()
+    dataset.finalize()
+
+    filtered_dataset = LeRobotDataset(dataset.repo_id, root=dataset.root, episodes=[1])
+    reader = filtered_dataset.reader
+    first_rows = reader.hf_dataset[[0, 1]]
+    absolute_indices = [int(idx.item()) for idx in first_rows["index"]]
+    query_indices = {"state": [absolute_indices[0], absolute_indices[1], absolute_indices[1]]}
+
+    result = reader._query_hf_dataset(query_indices)
+
+    expected = torch.stack([first_rows["state"][0], first_rows["state"][1], first_rows["state"][1]])
+    torch.testing.assert_close(result["state"], expected)
+
+
+def test_query_hf_dataset_skips_video_keys(tmp_path, lerobot_dataset_factory):
+    """Video keys are decoded separately and should not be queried from the HF parquet data."""
+    dataset = lerobot_dataset_factory(
+        root=tmp_path / "ds",
+        total_episodes=2,
+        total_frames=20,
+        use_videos=True,
+        download_videos=False,
+    )
+    video_key = dataset.meta.video_keys[0]
+
+    result = dataset.reader._query_hf_dataset({"state": [0, 1], video_key: [0, 1]})
+
+    assert set(result) == {"state"}
+    torch.testing.assert_close(result["state"], _row_first_stack(dataset.reader, "state", [0, 1]))
 
 
 # ── Transforms ───────────────────────────────────────────────────────

--- a/tests/datasets/test_dataset_reader.py
+++ b/tests/datasets/test_dataset_reader.py
@@ -20,10 +20,10 @@ import torch
 
 pytest.importorskip("datasets", reason="datasets is required (install lerobot[dataset])")
 
-from lerobot.datasets.dataset_reader import DatasetReader  # noqa: E402
-from lerobot.datasets.io_utils import hf_transform_to_torch  # noqa: E402
-from lerobot.datasets.lerobot_dataset import LeRobotDataset  # noqa: E402
-from lerobot.utils.import_utils import get_safe_default_codec  # noqa: E402
+from lerobot.datasets.dataset_reader import DatasetReader
+from lerobot.datasets.io_utils import hf_transform_to_torch
+from lerobot.datasets.lerobot_dataset import LeRobotDataset
+from lerobot.utils.import_utils import get_safe_default_codec
 
 
 def _row_first_stack(reader: DatasetReader, key: str, indices: list[int]) -> torch.Tensor:


### PR DESCRIPTION
## Summary / Motivation

`DatasetReader._query_hf_dataset` previously queried each non-video feature separately and only fell back to row-batch access when column-first indexing failed. With newer Hugging Face `datasets`, transformed column access still routes through the parent dataset transform, so the per-key loop can repeat the same transformed row fetch once per key. This PR hoists the transformed row-batch fetch outside the per-key loop, then reconstructs each requested feature tensor from that shared batch.

The goal is to preserve the intent of the earlier column-access optimization while avoiding the transformed-column regression reported in issue #3523.

## Related issues

- Fixes: #3523
- Related: #2408

## What changed

- Added a small helper to convert absolute frame indices to episode-filtered relative indices when needed.
- Build one ordered, de-duplicated union of all requested non-video row indices.
- Fetch that shared row batch once from the Hugging Face dataset.
- Reconstruct each queried key with the original requested order, including duplicate indices from boundary-clamped delta timestamps.
- Keep video keys out of the Hugging Face parquet query path because they are decoded separately.
- Added contract tests for row-first equivalence, single transformed batch fetches, duplicate index preservation, episode-filter remapping, and video-key skipping.

No public API changes or migration steps are required.

## How was this tested (or how to run locally)

- Tests added: `tests/datasets/test_dataset_reader.py`
- `uv run ruff check src/lerobot/datasets/dataset_reader.py tests/datasets/test_dataset_reader.py`
- `git diff --check`
- `uv run python -m pytest tests/datasets/test_dataset_reader.py -svv`
- `uv run python -m pytest tests/datasets/test_datasets.py -k "delta_timestamps" -svv`
- `uv run python -m pytest tests/datasets/test_lerobot_dataset.py::test_getitem_after_finalize_with_delta_timestamps -svv`

The focused pytest runs passed locally (`15 passed`, `4 passed`, and `1 passed`). I did not run the full repository test suite.

## Checklist (required before merge)

- [x] Linting/formatting run (`ruff check` and `git diff --check`)
- [ ] All tests pass locally (`pytest`)
- [x] Documentation updated / not applicable
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: # (insert PR number/link)

## Reviewer notes

The most important edge cases to review are duplicate delta indices and episode-filtered datasets. The implementation intentionally fails naturally for invalid non-video keys or indices instead of catching broad indexing errors and silently changing access strategies.
