### PR TITLE
feat(policies): add optional Diffusion language conditioning

### DIFF
--- a/docs/source/libero.mdx
+++ b/docs/source/libero.mdx
@@ -146,6 +146,32 @@ lerobot-train \
   --eval_freq=1000
 ```
 
+### Diffusion Policy with task language
+
+Classic Diffusion Policy does not use language by default, matching the original visuomotor policy.
+To train a language-conditioned Diffusion model on LIBERO task descriptions, enable the opt-in
+language path:
+
+```bash
+lerobot-train \
+  --policy.type=diffusion \
+  --policy.use_language_conditioning=true \
+  --policy.repo_id=${HF_USER}/libero-diffusion-language \
+  --dataset.repo_id=HuggingFaceVLA/libero \
+  --env.type=libero \
+  --env.task=libero_10 \
+  --output_dir=./outputs/ \
+  --steps=100000 \
+  --batch_size=4 \
+  --eval.batch_size=1 \
+  --eval.n_episodes=1 \
+  --eval_freq=1000
+```
+
+Enabling language conditioning changes the Diffusion architecture because the U-Net receives an
+additional projected text feature. Existing non-language Diffusion checkpoints should be evaluated
+with the default disabled setting.
+
 ## Reproducing published results
 
 We reproduce the results of Pi0.5 on the LIBERO benchmark. We take the Physical Intelligence LIBERO base model (`pi05_libero`) and finetune for an additional 6k steps in bfloat16, with batch size of 256 on 8 H100 GPUs using the [HuggingFace LIBERO dataset](https://huggingface.co/datasets/HuggingFaceVLA/libero).

--- a/docs/source/policy_diffusion_README.md
+++ b/docs/source/policy_diffusion_README.md
@@ -2,6 +2,25 @@
 
 https://diffusion-policy.cs.columbia.edu
 
+## Language conditioning
+
+Diffusion Policy keeps the original visuomotor behavior by default. For language-conditioned
+multi-task datasets such as LIBERO, enable task-language conditioning with:
+
+```bash
+--policy.use_language_conditioning=true
+```
+
+When enabled, the policy preprocessor tokenizes the batch `task` field and the model appends a
+projected CLIP text embedding to the Diffusion global conditioning vector. This requires
+`transformers` in addition to the regular Diffusion dependencies. LIBERO users get this through the
+`libero` extra; non-LIBERO users can install `diffusion` plus `transformers-dep`.
+
+This flag changes the model architecture because the U-Net conditioning dimension grows. Existing
+non-language Diffusion checkpoints remain compatible with the default disabled setting, but they
+cannot be transparently evaluated as language-conditioned checkpoints without retraining or
+fine-tuning with language conditioning enabled.
+
 ## Citation
 
 ```bibtex

--- a/src/lerobot/policies/diffusion/configuration_diffusion.py
+++ b/src/lerobot/policies/diffusion/configuration_diffusion.py
@@ -96,6 +96,16 @@ class DiffusionConfig(PreTrainedConfig):
         do_mask_loss_for_padding: Whether to mask the loss when there are copy-padded actions. See
             `LeRobotDataset` and `load_previous_and_future_frames` for more information. Note, this defaults
             to False as the original Diffusion Policy implementation does the same.
+        use_language_conditioning: Whether to encode the batch `task` language and append it to the global
+            conditioning vector. Defaults to False to preserve the original Diffusion Policy behavior.
+        language_encoder_name: Hugging Face CLIP text model used for task-language embeddings when
+            `use_language_conditioning` is enabled.
+        language_condition_dim: Size of the projected task-language feature appended per observation step.
+        language_encoder_freeze: Whether to freeze the CLIP text encoder and only train the projection.
+        tokenizer_max_length: Maximum token length used by the task tokenizer.
+        tokenizer_padding: Padding strategy passed to `TokenizerProcessorStep`.
+        tokenizer_padding_side: Padding side passed to `TokenizerProcessorStep`.
+        tokenizer_truncation: Whether task strings should be truncated to `tokenizer_max_length`.
     """
 
     # Inputs / output structure.
@@ -152,6 +162,16 @@ class DiffusionConfig(PreTrainedConfig):
     # Loss computation
     do_mask_loss_for_padding: bool = False
 
+    # Language conditioning.
+    use_language_conditioning: bool = False
+    language_encoder_name: str = "openai/clip-vit-base-patch16"
+    language_condition_dim: int = 128
+    language_encoder_freeze: bool = True
+    tokenizer_max_length: int = 77
+    tokenizer_padding: str = "max_length"
+    tokenizer_padding_side: str = "right"
+    tokenizer_truncation: bool = True
+
     # Training presets
     optimizer_lr: float = 1e-4
     optimizer_betas: tuple = (0.95, 0.999)
@@ -199,6 +219,30 @@ class DiffusionConfig(PreTrainedConfig):
                 self.crop_shape = None
         if self.crop_shape is not None and (self.crop_shape[0] <= 0 or self.crop_shape[1] <= 0):
             raise ValueError(f"`crop_shape` must have positive dimensions. Got {self.crop_shape}.")
+
+        if self.use_language_conditioning:
+            if not self.language_encoder_name:
+                raise ValueError("`language_encoder_name` must be set when language conditioning is enabled.")
+            if self.language_condition_dim <= 0:
+                raise ValueError(
+                    f"`language_condition_dim` must be a positive integer. Got {self.language_condition_dim}."
+                )
+            if self.tokenizer_max_length <= 0:
+                raise ValueError(
+                    f"`tokenizer_max_length` must be a positive integer. Got {self.tokenizer_max_length}."
+                )
+            supported_padding = {"max_length", "longest", "do_not_pad"}
+            if self.tokenizer_padding not in supported_padding:
+                raise ValueError(
+                    f"`tokenizer_padding` must be one of {sorted(supported_padding)}. "
+                    f"Got {self.tokenizer_padding}."
+                )
+            supported_padding_sides = {"left", "right"}
+            if self.tokenizer_padding_side not in supported_padding_sides:
+                raise ValueError(
+                    f"`tokenizer_padding_side` must be one of {sorted(supported_padding_sides)}. "
+                    f"Got {self.tokenizer_padding_side}."
+                )
 
         # Check that the horizon size and U-Net downsampling is compatible.
         # U-Net downsamples by 2 with each stage.

--- a/src/lerobot/policies/diffusion/modeling_diffusion.py
+++ b/src/lerobot/policies/diffusion/modeling_diffusion.py
@@ -32,8 +32,15 @@ import torch.nn.functional as F  # noqa: N812
 import torchvision
 from torch import Tensor, nn
 
-from lerobot.utils.constants import ACTION, OBS_ENV_STATE, OBS_IMAGES, OBS_STATE
-from lerobot.utils.import_utils import _diffusers_available, require_package
+from lerobot.utils.constants import (
+    ACTION,
+    OBS_ENV_STATE,
+    OBS_IMAGES,
+    OBS_LANGUAGE_ATTENTION_MASK,
+    OBS_LANGUAGE_TOKENS,
+    OBS_STATE,
+)
+from lerobot.utils.import_utils import _diffusers_available, _transformers_available, require_package
 
 if TYPE_CHECKING or _diffusers_available:
     from diffusers.schedulers.scheduling_ddim import DDIMScheduler
@@ -41,6 +48,11 @@ if TYPE_CHECKING or _diffusers_available:
 else:
     DDIMScheduler = None
     DDPMScheduler = None
+
+if TYPE_CHECKING or _transformers_available:
+    from transformers import CLIPTextModel
+else:
+    CLIPTextModel = None
 
 from ..pretrained import PreTrainedPolicy
 from ..utils import (
@@ -50,6 +62,18 @@ from ..utils import (
     populate_queues,
 )
 from .configuration_diffusion import DiffusionConfig
+
+LANGUAGE_CONDITIONING_KEYS = (OBS_LANGUAGE_TOKENS, OBS_LANGUAGE_ATTENTION_MASK)
+
+
+def _validate_language_conditioning_inputs(batch: dict[str, Tensor]) -> None:
+    missing = [key for key in LANGUAGE_CONDITIONING_KEYS if key not in batch]
+    if missing:
+        raise ValueError(
+            "Diffusion language conditioning is enabled, but the preprocessed batch is missing "
+            f"{missing}. Make sure each sample includes a `task` field and the diffusion preprocessor "
+            "runs `TokenizerProcessorStep`."
+        )
 
 
 class DiffusionPolicy(PreTrainedPolicy):
@@ -103,8 +127,11 @@ class DiffusionPolicy(PreTrainedPolicy):
     def predict_action_chunk(self, batch: dict[str, Tensor], noise: Tensor | None = None) -> Tensor:
         """Predict a chunk of actions given environment observations."""
         # stack n latest observations from the queue
-        batch = {k: torch.stack(list(self._queues[k]), dim=1) for k in batch if k in self._queues}
-        actions = self.diffusion.generate_actions(batch, noise=noise)
+        queued_batch = {k: torch.stack(list(self._queues[k]), dim=1) for k in batch if k in self._queues}
+        if self.config.use_language_conditioning:
+            _validate_language_conditioning_inputs(batch)
+            queued_batch.update({key: batch[key] for key in LANGUAGE_CONDITIONING_KEYS})
+        actions = self.diffusion.generate_actions(queued_batch, noise=noise)
 
         return actions
 
@@ -175,6 +202,40 @@ def _make_noise_scheduler(name: str, **kwargs: dict):
         raise ValueError(f"Unsupported noise scheduler type {name}")
 
 
+class DiffusionTextEncoder(nn.Module):
+    """Encode task language with a CLIP text model and project it for Diffusion conditioning."""
+
+    def __init__(self, config: DiffusionConfig):
+        super().__init__()
+        require_package("transformers", extra="transformers-dep")
+        if CLIPTextModel is None:
+            raise ImportError(
+                "`CLIPTextModel` is required for Diffusion language conditioning. "
+                "Install it with `pip install 'lerobot[transformers-dep]'`."
+            )
+
+        self.language_encoder_freeze = config.language_encoder_freeze
+        self.text_encoder = CLIPTextModel.from_pretrained(config.language_encoder_name)
+        if self.language_encoder_freeze:
+            for param in self.text_encoder.parameters():
+                param.requires_grad = False
+
+        self.projection = nn.Linear(self.text_encoder.config.hidden_size, config.language_condition_dim)
+
+    def forward(self, input_ids: Tensor, attention_mask: Tensor) -> Tensor:
+        device = self.projection.weight.device
+        input_ids = input_ids.to(device=device, dtype=torch.long)
+        attention_mask = attention_mask.to(device=device)
+
+        if self.language_encoder_freeze:
+            with torch.no_grad():
+                outputs = self.text_encoder(input_ids=input_ids, attention_mask=attention_mask)
+        else:
+            outputs = self.text_encoder(input_ids=input_ids, attention_mask=attention_mask)
+
+        return self.projection(outputs.pooler_output)
+
+
 class DiffusionModel(nn.Module):
     def __init__(self, config: DiffusionConfig):
         super().__init__()
@@ -193,6 +254,11 @@ class DiffusionModel(nn.Module):
                 global_cond_dim += self.rgb_encoder.feature_dim * num_images
         if self.config.env_state_feature:
             global_cond_dim += self.config.env_state_feature.shape[0]
+        if self.config.use_language_conditioning:
+            self.language_encoder = DiffusionTextEncoder(config)
+            global_cond_dim += self.config.language_condition_dim
+        else:
+            self.language_encoder = None
 
         self.unet = DiffusionConditionalUnet1d(config, global_cond_dim=global_cond_dim * config.n_obs_steps)
 
@@ -255,7 +321,7 @@ class DiffusionModel(nn.Module):
         return sample
 
     def _prepare_global_conditioning(self, batch: dict[str, Tensor]) -> Tensor:
-        """Encode image features and concatenate them all together along with the state vector."""
+        """Encode available observation modalities and concatenate them into a global condition."""
         batch_size, n_obs_steps = batch[OBS_STATE].shape[:2]
         global_cond_feats = [batch[OBS_STATE]]
         # Extract image features.
@@ -288,6 +354,20 @@ class DiffusionModel(nn.Module):
 
         if self.config.env_state_feature:
             global_cond_feats.append(batch[OBS_ENV_STATE])
+
+        if self.config.use_language_conditioning:
+            _validate_language_conditioning_inputs(batch)
+            assert self.language_encoder is not None
+            language_features = self.language_encoder(
+                batch[OBS_LANGUAGE_TOKENS],
+                batch[OBS_LANGUAGE_ATTENTION_MASK],
+            )
+            if language_features.shape[0] != batch_size:
+                raise ValueError(
+                    "Language conditioning batch size does not match observations. "
+                    f"Got {language_features.shape[0]} and {batch_size}."
+                )
+            global_cond_feats.append(language_features.unsqueeze(1).expand(-1, n_obs_steps, -1))
 
         # Concatenate features then flatten to (B, global_cond_dim).
         return torch.cat(global_cond_feats, dim=-1).flatten(start_dim=1)

--- a/src/lerobot/policies/diffusion/processor_diffusion.py
+++ b/src/lerobot/policies/diffusion/processor_diffusion.py
@@ -25,6 +25,7 @@ from lerobot.processor import (
     PolicyAction,
     PolicyProcessorPipeline,
     RenameObservationsProcessorStep,
+    TokenizerProcessorStep,
     UnnormalizerProcessorStep,
     policy_action_to_transition,
     transition_to_policy_action,
@@ -46,9 +47,10 @@ def make_diffusion_pre_post_processors(
 
     The pre-processing pipeline prepares the input data for the model by:
     1. Renaming features.
-    2. Normalizing the input and output features based on dataset statistics.
-    3. Adding a batch dimension.
+    2. Adding a batch dimension.
+    3. Tokenizing the task description when language conditioning is enabled.
     4. Moving the data to the specified device.
+    5. Normalizing the input and output features based on dataset statistics.
 
     The post-processing pipeline handles the model's output by:
     1. Moving the data to the CPU.
@@ -67,13 +69,27 @@ def make_diffusion_pre_post_processors(
     input_steps = [
         RenameObservationsProcessorStep(rename_map={}),
         AddBatchDimensionProcessorStep(),
-        DeviceProcessorStep(device=config.device),
-        NormalizerProcessorStep(
-            features={**config.input_features, **config.output_features},
-            norm_map=config.normalization_mapping,
-            stats=dataset_stats,
-        ),
     ]
+    if config.use_language_conditioning:
+        input_steps.append(
+            TokenizerProcessorStep(
+                tokenizer_name=config.language_encoder_name,
+                max_length=config.tokenizer_max_length,
+                padding=config.tokenizer_padding,
+                padding_side=config.tokenizer_padding_side,
+                truncation=config.tokenizer_truncation,
+            )
+        )
+    input_steps.extend(
+        [
+            DeviceProcessorStep(device=config.device),
+            NormalizerProcessorStep(
+                features={**config.input_features, **config.output_features},
+                norm_map=config.normalization_mapping,
+                stats=dataset_stats,
+            ),
+        ]
+    )
     output_steps = [
         UnnormalizerProcessorStep(
             features=config.output_features, norm_map=config.normalization_mapping, stats=dataset_stats

--- a/tests/policies/test_diffusion_language_conditioning.py
+++ b/tests/policies/test_diffusion_language_conditioning.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for optional language conditioning in Diffusion Policy."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch import nn
+
+from lerobot.configs.types import FeatureType, PolicyFeature
+from lerobot.policies.diffusion import modeling_diffusion
+from lerobot.policies.diffusion.configuration_diffusion import DiffusionConfig
+from lerobot.policies.diffusion.modeling_diffusion import DiffusionModel, DiffusionPolicy
+from lerobot.utils.constants import (
+    ACTION,
+    OBS_ENV_STATE,
+    OBS_LANGUAGE_ATTENTION_MASK,
+    OBS_LANGUAGE_TOKENS,
+    OBS_STATE,
+)
+
+
+class FakeScheduler:
+    config = SimpleNamespace(num_train_timesteps=2)
+
+    def add_noise(
+        self,
+        original_samples: torch.Tensor,
+        noise: torch.Tensor,
+        timesteps: torch.Tensor,
+    ) -> torch.Tensor:
+        del timesteps
+        return original_samples + noise
+
+
+class FakeCLIPTextModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.config = SimpleNamespace(hidden_size=4)
+
+    @classmethod
+    def from_pretrained(cls, model_name: str):
+        return cls()
+
+    def forward(self, input_ids: torch.Tensor, attention_mask: torch.Tensor):
+        pooled = (input_ids.float() * attention_mask.float()).sum(dim=1, keepdim=True)
+        return SimpleNamespace(pooler_output=pooled.repeat(1, self.config.hidden_size))
+
+
+@pytest.fixture(autouse=True)
+def patch_optional_diffusion_deps(monkeypatch):
+    def require_package_stub(pkg_name: str, extra: str, import_name: str | None = None) -> None:
+        return None
+
+    monkeypatch.setattr(modeling_diffusion, "require_package", require_package_stub)
+    monkeypatch.setattr(modeling_diffusion, "_make_noise_scheduler", lambda *args, **kwargs: FakeScheduler())
+    monkeypatch.setattr(modeling_diffusion, "CLIPTextModel", FakeCLIPTextModel)
+
+
+def make_config(use_language_conditioning: bool = True) -> DiffusionConfig:
+    return DiffusionConfig(
+        input_features={
+            OBS_STATE: PolicyFeature(type=FeatureType.STATE, shape=(3,)),
+            OBS_ENV_STATE: PolicyFeature(type=FeatureType.ENV, shape=(2,)),
+        },
+        output_features={ACTION: PolicyFeature(type=FeatureType.ACTION, shape=(2,))},
+        n_obs_steps=2,
+        horizon=4,
+        n_action_steps=2,
+        down_dims=(16,),
+        device="cpu",
+        use_language_conditioning=use_language_conditioning,
+        language_condition_dim=5,
+        tokenizer_max_length=7,
+    )
+
+
+def make_batch(config: DiffusionConfig, batch_size: int = 2) -> dict[str, torch.Tensor]:
+    return {
+        OBS_STATE: torch.randn(batch_size, config.n_obs_steps, 3),
+        OBS_ENV_STATE: torch.randn(batch_size, config.n_obs_steps, 2),
+        OBS_LANGUAGE_TOKENS: torch.tensor([[1, 2, 3, 4, 0, 0, 0], [5, 6, 7, 8, 0, 0, 0]], dtype=torch.long)[
+            :batch_size
+        ],
+        OBS_LANGUAGE_ATTENTION_MASK: torch.tensor(
+            [[1, 1, 1, 1, 0, 0, 0], [1, 1, 1, 1, 0, 0, 0]], dtype=torch.bool
+        )[:batch_size],
+    }
+
+
+def test_language_conditioning_extends_global_conditioning():
+    config = make_config(use_language_conditioning=True)
+    model = DiffusionModel(config)
+    with torch.no_grad():
+        model.language_encoder.projection.weight.fill_(1.0)
+        model.language_encoder.projection.bias.zero_()
+
+    batch = make_batch(config)
+    global_cond = model._prepare_global_conditioning(batch)
+
+    expected_dim = config.n_obs_steps * (3 + 2 + config.language_condition_dim)
+    assert global_cond.shape == (2, expected_dim)
+
+    changed_batch = dict(batch)
+    changed_batch[OBS_LANGUAGE_TOKENS] = batch[OBS_LANGUAGE_TOKENS] + 10
+    changed_global_cond = model._prepare_global_conditioning(changed_batch)
+
+    assert not torch.allclose(global_cond, changed_global_cond)
+
+
+def test_language_conditioning_requires_tokenized_language_keys():
+    config = make_config(use_language_conditioning=True)
+    model = DiffusionModel(config)
+    batch = make_batch(config)
+    batch.pop(OBS_LANGUAGE_TOKENS)
+
+    with pytest.raises(ValueError, match="missing"):
+        model._prepare_global_conditioning(batch)
+
+
+def test_language_conditioning_forward_computes_training_loss():
+    config = make_config(use_language_conditioning=True)
+    policy = DiffusionPolicy(config)
+    batch = make_batch(config)
+    batch[ACTION] = torch.randn(2, config.horizon, config.action_feature.shape[0])
+    batch["action_is_pad"] = torch.zeros(2, config.horizon, dtype=torch.bool)
+
+    loss, output_dict = policy.forward(batch)
+
+    assert output_dict is None
+    assert loss.ndim == 0
+    assert torch.isfinite(loss)
+
+
+def test_default_diffusion_does_not_build_language_encoder():
+    config = make_config(use_language_conditioning=False)
+    model = DiffusionModel(config)
+    batch = make_batch(config)
+    batch.pop(OBS_LANGUAGE_TOKENS)
+    batch.pop(OBS_LANGUAGE_ATTENTION_MASK)
+
+    global_cond = model._prepare_global_conditioning(batch)
+
+    assert model.language_encoder is None
+    assert global_cond.shape == (2, config.n_obs_steps * (3 + 2))
+
+
+def test_language_conditioning_preserves_language_through_action_queue():
+    config = make_config(use_language_conditioning=True)
+    policy = DiffusionPolicy(config)
+    captured_batch = {}
+
+    def fake_generate_actions(batch: dict[str, torch.Tensor], noise=None):
+        captured_batch.update(batch)
+        return torch.zeros(2, config.n_action_steps, config.action_feature.shape[0])
+
+    policy.diffusion.generate_actions = fake_generate_actions
+    batch = {
+        OBS_STATE: torch.randn(2, 3),
+        OBS_ENV_STATE: torch.randn(2, 2),
+        OBS_LANGUAGE_TOKENS: torch.ones(2, config.tokenizer_max_length, dtype=torch.long),
+        OBS_LANGUAGE_ATTENTION_MASK: torch.ones(2, config.tokenizer_max_length, dtype=torch.bool),
+    }
+
+    action = policy.select_action(batch)
+
+    assert action.shape == (2, config.action_feature.shape[0])
+    assert captured_batch[OBS_STATE].shape == (2, config.n_obs_steps, 3)
+    assert captured_batch[OBS_ENV_STATE].shape == (2, config.n_obs_steps, 2)
+    assert captured_batch[OBS_LANGUAGE_TOKENS].shape == (2, config.tokenizer_max_length)
+    assert captured_batch[OBS_LANGUAGE_ATTENTION_MASK].shape == (2, config.tokenizer_max_length)
+
+
+def test_language_conditioning_config_validation():
+    with pytest.raises(ValueError, match="language_condition_dim"):
+        DiffusionConfig(use_language_conditioning=True, language_condition_dim=0)
+
+    with pytest.raises(ValueError, match="tokenizer_padding_side"):
+        DiffusionConfig(use_language_conditioning=True, tokenizer_padding_side="middle")

--- a/tests/processor/test_diffusion_processor.py
+++ b/tests/processor/test_diffusion_processor.py
@@ -21,6 +21,7 @@ import pytest
 import torch
 
 from lerobot.configs.types import FeatureType, NormalizationMode, PolicyFeature
+from lerobot.policies.diffusion import processor_diffusion
 from lerobot.policies.diffusion.configuration_diffusion import DiffusionConfig
 from lerobot.policies.diffusion.processor_diffusion import make_diffusion_pre_post_processors
 from lerobot.processor import (
@@ -28,12 +29,52 @@ from lerobot.processor import (
     DataProcessorPipeline,
     DeviceProcessorStep,
     NormalizerProcessorStep,
+    ProcessorStep,
     RenameObservationsProcessorStep,
     TransitionKey,
     UnnormalizerProcessorStep,
 )
 from lerobot.processor.converters import create_transition, transition_to_batch
-from lerobot.utils.constants import ACTION, OBS_IMAGE, OBS_STATE
+from lerobot.utils.constants import (
+    ACTION,
+    OBS_IMAGE,
+    OBS_LANGUAGE_ATTENTION_MASK,
+    OBS_LANGUAGE_TOKENS,
+    OBS_STATE,
+)
+
+
+class FakeTokenizerProcessorStep(ProcessorStep):
+    """Tiny tokenizer stand-in so language processor tests avoid downloads."""
+
+    def __init__(
+        self,
+        tokenizer_name: str,
+        max_length: int,
+        padding: str,
+        padding_side: str,
+        truncation: bool,
+    ):
+        self.tokenizer_name = tokenizer_name
+        self.max_length = max_length
+        self.padding = padding
+        self.padding_side = padding_side
+        self.truncation = truncation
+
+    def __call__(self, transition):
+        self._current_transition = transition.copy()
+        new_transition = self._current_transition
+        observation = dict(new_transition[TransitionKey.OBSERVATION])
+        complementary_data = new_transition[TransitionKey.COMPLEMENTARY_DATA]
+        task = complementary_data["task"]
+        batch_size = len(task) if isinstance(task, list) else 1
+        observation[OBS_LANGUAGE_TOKENS] = torch.ones(batch_size, self.max_length, dtype=torch.long)
+        observation[OBS_LANGUAGE_ATTENTION_MASK] = torch.ones(batch_size, self.max_length, dtype=torch.bool)
+        new_transition[TransitionKey.OBSERVATION] = observation
+        return new_transition
+
+    def transform_features(self, features):
+        return features
 
 
 def create_default_config():
@@ -86,6 +127,39 @@ def test_make_diffusion_processor_basic():
     assert len(postprocessor.steps) == 2
     assert isinstance(postprocessor.steps[0], UnnormalizerProcessorStep)
     assert isinstance(postprocessor.steps[1], DeviceProcessorStep)
+
+
+def test_make_diffusion_processor_with_language_conditioning(monkeypatch):
+    """Test language-conditioned Diffusion processor tokenizes the task field."""
+    monkeypatch.setattr(processor_diffusion, "TokenizerProcessorStep", FakeTokenizerProcessorStep)
+    config = create_default_config()
+    config.use_language_conditioning = True
+    config.tokenizer_max_length = 8
+    stats = create_default_stats()
+
+    preprocessor, postprocessor = make_diffusion_pre_post_processors(config, stats)
+
+    assert len(preprocessor.steps) == 5
+    assert isinstance(preprocessor.steps[0], RenameObservationsProcessorStep)
+    assert isinstance(preprocessor.steps[1], AddBatchDimensionProcessorStep)
+    assert isinstance(preprocessor.steps[2], FakeTokenizerProcessorStep)
+    assert isinstance(preprocessor.steps[3], DeviceProcessorStep)
+    assert isinstance(preprocessor.steps[4], NormalizerProcessorStep)
+    assert len(postprocessor.steps) == 2
+
+    observation = {
+        OBS_STATE: torch.randn(7),
+        OBS_IMAGE: torch.randn(3, 224, 224),
+    }
+    action = torch.randn(6)
+    transition = create_transition(observation, action, complementary_data={"task": "pick up the cube"})
+    batch = transition_to_batch(transition)
+
+    processed = preprocessor(batch)
+
+    assert processed[OBS_LANGUAGE_TOKENS].shape == (1, config.tokenizer_max_length)
+    assert processed[OBS_LANGUAGE_ATTENTION_MASK].shape == (1, config.tokenizer_max_length)
+    assert processed[OBS_LANGUAGE_ATTENTION_MASK].dtype == torch.bool
 
 
 def test_diffusion_processor_with_images():


### PR DESCRIPTION
## Summary / Motivation

Adds an opt-in language-conditioned variant of Diffusion Policy for language-conditioned multi-task datasets such as LIBERO. The default Diffusion Policy behavior remains unchanged so existing visuomotor checkpoints and classic Diffusion experiments keep the original architecture.

LIBERO already provides natural-language task descriptions through dataset task metadata, but Diffusion Policy previously ignored the `task` field. With `--policy.use_language_conditioning=true`, the Diffusion preprocessor now tokenizes task strings and the model appends a projected CLIP text embedding to the global conditioning vector used by the U-Net.

## Related issues

- Fixes: #2894

## What changed

- Added Diffusion config flags for optional task-language conditioning, CLIP text encoder selection, tokenizer settings, projection size, and text-encoder freezing.
- Reused `TokenizerProcessorStep` in the Diffusion preprocessor when language conditioning is enabled.
- Added a small `DiffusionTextEncoder` wrapper that freezes CLIP by default and projects pooled text features into the Diffusion global conditioning vector.
- Preserved tokenized language tensors through `select_action` / action-queue inference so rollout evaluation can use task descriptions.
- Added explicit validation for missing tokenized language keys when the language-conditioned path is enabled.
- Documented LIBERO usage and checkpoint compatibility notes.

## How was this tested (or how to run locally)

- Tests added:
  - `tests/policies/test_diffusion_language_conditioning.py`
  - new language-conditioned coverage in `tests/processor/test_diffusion_processor.py`
- Commands run:
  - `uvx ruff format --check src/lerobot/policies/diffusion/configuration_diffusion.py src/lerobot/policies/diffusion/modeling_diffusion.py src/lerobot/policies/diffusion/processor_diffusion.py tests/processor/test_diffusion_processor.py tests/policies/test_diffusion_language_conditioning.py`
  - `uvx ruff check src/lerobot/policies/diffusion/configuration_diffusion.py src/lerobot/policies/diffusion/modeling_diffusion.py src/lerobot/policies/diffusion/processor_diffusion.py tests/processor/test_diffusion_processor.py tests/policies/test_diffusion_language_conditioning.py`
  - `git diff --check`
  - `uv run --extra test pytest tests/processor/test_diffusion_processor.py tests/policies/test_diffusion_language_conditioning.py -q`
  - `uv run --extra test --extra transformers-dep pytest tests/processor/test_tokenizer_processor.py -q`
  - `uv run --extra test --extra transformers-dep pytest tests/processor/test_diffusion_processor.py tests/policies/test_diffusion_language_conditioning.py -q`

## Checklist (required before merge)

- [ ] Linting/formatting run (`pre-commit run -a`)
- [ ] All tests pass locally (`pytest`)
- [x] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: # (insert PR number/link)

## Reviewer notes

- The language-conditioned path is deliberately opt-in to keep the original Diffusion Policy implementation close to the paper by default.
- Enabling `use_language_conditioning` changes the U-Net conditioning dimension, so non-language Diffusion checkpoints should continue to use the default disabled setting.
- The tests mock the text model and scheduler to avoid network/model downloads while still covering conditioning shape, missing-key validation, training loss, default compatibility, and inference queue behavior.
