### PR TITLE
Add opt-in image compression for async inference observations

### DIFF
--- a/docs/source/async.mdx
+++ b/docs/source/async.mdx
@@ -51,6 +51,8 @@ python -m lerobot.async_inference.robot_client \
     --policy_device=mps \ # POLICY: the device to run the policy on, on the server (cuda, mps, xpu, cpu)
     --actions_per_chunk=50 \ # POLICY: the number of actions to output at once
     --chunk_size_threshold=0.5 \ # CLIENT: the threshold for the chunk size before sending a new observation to the server
+    --observation_image_compression=jpeg \ # CLIENT: optional image compression for observations sent over the network
+    --observation_image_compression_quality=90 \ # CLIENT: image compression quality in [1, 100]
     --aggregate_fn_name=weighted_average \ # CLIENT: the function to aggregate actions on overlapping portions
     --debug_visualize_queue_size=True # CLIENT: whether to visualize the queue size at runtime
 ```
@@ -160,6 +162,8 @@ python -m lerobot.async_inference.robot_client \
     --policy_device=mps \ # POLICY: the device to run the policy on, on the server
     --actions_per_chunk=50 \ # POLICY: the number of actions to output at once
     --chunk_size_threshold=0.5 \ # CLIENT: the threshold for the chunk size before sending a new observation to the server
+    --observation_image_compression=jpeg \ # CLIENT: optional image compression for observations sent over the network
+    --observation_image_compression_quality=90 \ # CLIENT: image compression quality in [1, 100]
     --aggregate_fn_name=weighted_average \ # CLIENT: the function to aggregate actions on overlapping portions
     --debug_visualize_queue_size=True # CLIENT: whether to visualize the queue size at runtime
 ```
@@ -200,6 +204,8 @@ client_cfg = RobotClientConfig(
     pretrained_name_or_path="<user>/smolvla_async",
     chunk_size_threshold=0.5,
     actions_per_chunk=50,  # make sure this is less than the max actions of the policy
+    observation_image_compression="jpeg",
+    observation_image_compression_quality=90,
 )
 
 # 4. Create and start client
@@ -280,6 +286,7 @@ We found the default values of `actions_per_chunk` and `chunk_size_threshold` to
 3. **Adjust `chunk_size_threshold`**.
    - Values closer to `0.0` result in almost sequential behavior. Values closer to `1.0` → send observation every step (more bandwidth, relies on good world-model).
    - We found values around 0.5-0.6 to work well. If you want to tweak this, spin up a `RobotClient` setting the `--debug_visualize_queue_size` to `True`. This will plot the action queue size evolution at runtime, and you can use it to find the value of `chunk_size_threshold` that works best for your setup.
+4. **Compress camera observations when bandwidth is the bottleneck.** If the robot and policy server communicate over a bandwidth-limited network, enable `--observation_image_compression=jpeg` to send compressed camera images instead of raw image arrays. `--observation_image_compression_quality=90` is a good starting point; lower values reduce bandwidth further but add more visual loss. Use `png` when you need lossless image transport for debugging, but expect larger payloads and more CPU work than JPEG. This is per-observation image compression, not an inter-frame video codec.
 
 <p align="center">
   <img

--- a/examples/tutorial/async-inf/robot_client.py
+++ b/examples/tutorial/async-inf/robot_client.py
@@ -35,6 +35,8 @@ def main():
         pretrained_name_or_path="<user>/robot_learning_tutorial_act",
         chunk_size_threshold=0.5,  # g
         actions_per_chunk=50,  # make sure this is less than the max actions of the policy
+        observation_image_compression="jpeg",
+        observation_image_compression_quality=90,
     )
 
     # 4. Create and start client

--- a/src/lerobot/async_inference/compression.py
+++ b/src/lerobot/async_inference/compression.py
@@ -1,0 +1,231 @@
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+from typing import Any
+
+import cv2
+import numpy as np
+
+from lerobot.utils.constants import OBS_IMAGES
+
+from .constants import (
+    IMAGE_COMPRESSION_JPEG,
+    IMAGE_COMPRESSION_NONE,
+    IMAGE_COMPRESSION_PNG,
+    SUPPORTED_IMAGE_COMPRESSIONS,
+)
+from .helpers import RawObservation, TimedObservation
+
+
+@dataclass(frozen=True)
+class CompressedImage:
+    codec: str
+    data: bytes
+    shape: tuple[int, ...]
+    dtype: str
+    uncompressed_nbytes: int
+
+
+@dataclass(frozen=True)
+class CompressionStats:
+    image_count: int = 0
+    uncompressed_nbytes: int = 0
+    compressed_nbytes: int = 0
+
+    @property
+    def compression_ratio(self) -> float:
+        if self.uncompressed_nbytes == 0:
+            return 1.0
+        return self.compressed_nbytes / self.uncompressed_nbytes
+
+
+def validate_image_compression(codec: str, quality: int) -> None:
+    if codec not in SUPPORTED_IMAGE_COMPRESSIONS:
+        raise ValueError(
+            f"Unsupported observation image compression '{codec}'. "
+            f"Expected one of {SUPPORTED_IMAGE_COMPRESSIONS}."
+        )
+
+    if quality < 1 or quality > 100:
+        raise ValueError(f"observation_image_compression_quality must be between 1 and 100, got {quality}")
+
+
+def image_keys_from_lerobot_features(lerobot_features: dict[str, dict]) -> set[str]:
+    image_prefix = f"{OBS_IMAGES}."
+    return {key.removeprefix(image_prefix) for key in lerobot_features if key.startswith(image_prefix)}
+
+
+def _opencv_extension(codec: str) -> str:
+    if codec == IMAGE_COMPRESSION_JPEG:
+        return ".jpg"
+    if codec == IMAGE_COMPRESSION_PNG:
+        return ".png"
+    raise ValueError(f"Unsupported image compression codec '{codec}'")
+
+
+def _opencv_encode_params(codec: str, quality: int) -> list[int]:
+    if codec == IMAGE_COMPRESSION_JPEG:
+        return [int(cv2.IMWRITE_JPEG_QUALITY), quality]
+
+    if codec == IMAGE_COMPRESSION_PNG:
+        # Interpret higher quality as less PNG compression work. PNG is still lossless.
+        compression = round((100 - quality) * 9 / 99)
+        return [int(cv2.IMWRITE_PNG_COMPRESSION), compression]
+
+    raise ValueError(f"Unsupported image compression codec '{codec}'")
+
+
+def _as_uint8_image(image: Any) -> np.ndarray:
+    image_array = np.asarray(image)
+    if image_array.dtype != np.uint8:
+        raise ValueError(f"Only uint8 images can be compressed, got dtype {image_array.dtype}")
+
+    if image_array.ndim not in (2, 3):
+        raise ValueError(f"Only 2D or 3D images can be compressed, got shape {image_array.shape}")
+
+    if image_array.ndim == 3 and image_array.shape[2] not in (1, 3, 4):
+        raise ValueError(
+            "Only 1-, 3-, or 4-channel images can be compressed, "
+            f"got shape {image_array.shape}"
+        )
+
+    return np.ascontiguousarray(image_array)
+
+
+def compress_image(image: Any, codec: str, quality: int) -> CompressedImage:
+    validate_image_compression(codec, quality)
+    if codec == IMAGE_COMPRESSION_NONE:
+        raise ValueError("'none' is not a valid codec for compress_image")
+
+    image_array = _as_uint8_image(image)
+    try:
+        success, encoded = cv2.imencode(
+            _opencv_extension(codec),
+            image_array,
+            _opencv_encode_params(codec, quality),
+        )
+    except cv2.error as exc:
+        raise ValueError(f"Failed to encode image with codec '{codec}'") from exc
+
+    if not success:
+        raise ValueError(f"Failed to encode image with codec '{codec}'")
+
+    return CompressedImage(
+        codec=codec,
+        data=encoded.tobytes(),
+        shape=tuple(image_array.shape),
+        dtype=str(image_array.dtype),
+        uncompressed_nbytes=image_array.nbytes,
+    )
+
+
+def decompress_image(payload: CompressedImage) -> np.ndarray:
+    if payload.codec not in SUPPORTED_IMAGE_COMPRESSIONS or payload.codec == IMAGE_COMPRESSION_NONE:
+        raise ValueError(f"Unsupported compressed image codec '{payload.codec}'")
+
+    encoded = np.frombuffer(payload.data, dtype=np.uint8)
+    image = cv2.imdecode(encoded, cv2.IMREAD_UNCHANGED)
+    if image is None:
+        raise ValueError(f"Failed to decode image with codec '{payload.codec}'")
+
+    if tuple(image.shape) != payload.shape:
+        raise ValueError(f"Decoded image shape {image.shape} does not match expected {payload.shape}")
+
+    expected_dtype = np.dtype(payload.dtype)
+    if image.dtype != expected_dtype:
+        raise ValueError(f"Decoded image dtype {image.dtype} does not match expected {expected_dtype}")
+
+    return image
+
+
+def compression_stats(raw_obs: RawObservation) -> CompressionStats:
+    image_count = 0
+    uncompressed_nbytes = 0
+    compressed_nbytes = 0
+
+    for value in raw_obs.values():
+        if not isinstance(value, CompressedImage):
+            continue
+        image_count += 1
+        uncompressed_nbytes += value.uncompressed_nbytes
+        compressed_nbytes += len(value.data)
+
+    return CompressionStats(
+        image_count=image_count,
+        uncompressed_nbytes=uncompressed_nbytes,
+        compressed_nbytes=compressed_nbytes,
+    )
+
+
+def compress_raw_observation(
+    raw_obs: RawObservation,
+    image_keys: set[str],
+    codec: str,
+    quality: int,
+) -> RawObservation:
+    validate_image_compression(codec, quality)
+    if codec == IMAGE_COMPRESSION_NONE:
+        return raw_obs
+
+    compressed_obs = dict(raw_obs)
+    for key in image_keys:
+        if key not in compressed_obs or isinstance(compressed_obs[key], CompressedImage):
+            continue
+        compressed_obs[key] = compress_image(compressed_obs[key], codec, quality)
+
+    return compressed_obs
+
+
+def decompress_raw_observation(raw_obs: RawObservation) -> RawObservation:
+    if not any(isinstance(value, CompressedImage) for value in raw_obs.values()):
+        return raw_obs
+
+    decompressed_obs = dict(raw_obs)
+    for key, value in raw_obs.items():
+        if isinstance(value, CompressedImage):
+            decompressed_obs[key] = decompress_image(value)
+
+    return decompressed_obs
+
+
+def compress_timed_observation(
+    obs: TimedObservation,
+    image_keys: set[str],
+    codec: str,
+    quality: int,
+) -> TimedObservation:
+    compressed_observation = compress_raw_observation(obs.get_observation(), image_keys, codec, quality)
+    if compressed_observation is obs.get_observation():
+        return obs
+
+    return TimedObservation(
+        timestamp=obs.get_timestamp(),
+        timestep=obs.get_timestep(),
+        observation=compressed_observation,
+        must_go=obs.must_go,
+    )
+
+
+def decompress_timed_observation(obs: TimedObservation) -> TimedObservation:
+    decompressed_observation = decompress_raw_observation(obs.get_observation())
+    if decompressed_observation is obs.get_observation():
+        return obs
+
+    return TimedObservation(
+        timestamp=obs.get_timestamp(),
+        timestep=obs.get_timestep(),
+        observation=decompressed_observation,
+        must_go=obs.must_go,
+    )

--- a/src/lerobot/async_inference/configs.py
+++ b/src/lerobot/async_inference/configs.py
@@ -23,6 +23,8 @@ from .constants import (
     DEFAULT_FPS,
     DEFAULT_INFERENCE_LATENCY,
     DEFAULT_OBS_QUEUE_TIMEOUT,
+    IMAGE_COMPRESSION_NONE,
+    SUPPORTED_IMAGE_COMPRESSIONS,
 )
 
 # Aggregate function registry for CLI usage
@@ -137,6 +139,26 @@ class RobotClientConfig:
     chunk_size_threshold: float = field(default=0.5, metadata={"help": "Threshold for chunk size control"})
     fps: int = field(default=DEFAULT_FPS, metadata={"help": "Frames per second"})
 
+    # Observation compression configuration
+    observation_image_compression: str = field(
+        default=IMAGE_COMPRESSION_NONE,
+        metadata={
+            "help": (
+                "Image compression codec for observations sent to the policy server. "
+                f"Options: {SUPPORTED_IMAGE_COMPRESSIONS}"
+            )
+        },
+    )
+    observation_image_compression_quality: int = field(
+        default=90,
+        metadata={
+            "help": (
+                "Image compression quality in [1, 100]. Higher values improve quality; "
+                "for PNG, higher values use less compression work."
+            )
+        },
+    )
+
     # Aggregate function configuration (CLI-compatible)
     aggregate_fn_name: str = field(
         default="weighted_average",
@@ -179,6 +201,21 @@ class RobotClientConfig:
         if self.actions_per_chunk <= 0:
             raise ValueError(f"actions_per_chunk must be positive, got {self.actions_per_chunk}")
 
+        if self.observation_image_compression not in SUPPORTED_IMAGE_COMPRESSIONS:
+            raise ValueError(
+                f"observation_image_compression must be one of {SUPPORTED_IMAGE_COMPRESSIONS}, "
+                f"got {self.observation_image_compression}"
+            )
+
+        if (
+            self.observation_image_compression_quality < 1
+            or self.observation_image_compression_quality > 100
+        ):
+            raise ValueError(
+                "observation_image_compression_quality must be between 1 and 100, "
+                f"got {self.observation_image_compression_quality}"
+            )
+
         self.aggregate_fn = get_aggregate_function(self.aggregate_fn_name)
 
     @classmethod
@@ -198,6 +235,8 @@ class RobotClientConfig:
             "fps": self.fps,
             "actions_per_chunk": self.actions_per_chunk,
             "task": self.task,
+            "observation_image_compression": self.observation_image_compression,
+            "observation_image_compression_quality": self.observation_image_compression_quality,
             "debug_visualize_queue_size": self.debug_visualize_queue_size,
             "aggregate_fn_name": self.aggregate_fn_name,
         }

--- a/src/lerobot/async_inference/constants.py
+++ b/src/lerobot/async_inference/constants.py
@@ -22,6 +22,15 @@ DEFAULT_INFERENCE_LATENCY = 1 / DEFAULT_FPS
 """Server side: Timeout for observation queue in seconds"""
 DEFAULT_OBS_QUEUE_TIMEOUT = 2
 
+IMAGE_COMPRESSION_NONE = "none"
+IMAGE_COMPRESSION_JPEG = "jpeg"
+IMAGE_COMPRESSION_PNG = "png"
+SUPPORTED_IMAGE_COMPRESSIONS = (
+    IMAGE_COMPRESSION_NONE,
+    IMAGE_COMPRESSION_JPEG,
+    IMAGE_COMPRESSION_PNG,
+)
+
 # All action chunking policies
 SUPPORTED_POLICIES = ["act", "smolvla", "diffusion", "tdmpc", "vqbet", "pi0", "pi05", "groot"]
 

--- a/src/lerobot/async_inference/policy_server.py
+++ b/src/lerobot/async_inference/policy_server.py
@@ -47,6 +47,7 @@ from lerobot.transport import (
 from lerobot.transport.utils import receive_bytes_in_chunks
 from lerobot.types import PolicyAction
 
+from .compression import compression_stats, decompress_timed_observation
 from .configs import PolicyServerConfig
 from .constants import SUPPORTED_POLICIES
 from .helpers import (
@@ -181,9 +182,17 @@ class PolicyServer(services_pb2_grpc.AsyncInferenceServicer):
             request_iterator, None, self.shutdown_event, self.logger
         )  # blocking call while looping over request_iterator
         timed_observation = pickle.loads(received_bytes)  # nosec
+        stats = compression_stats(timed_observation.get_observation())
+        timed_observation = decompress_timed_observation(timed_observation)
         deserialize_time = time.perf_counter() - start_deserialize
 
         self.logger.debug(f"Received observation #{timed_observation.get_timestep()}")
+        if stats.image_count > 0:
+            self.logger.debug(
+                f"Observation decompression: images={stats.image_count} | "
+                f"image bytes={stats.compressed_nbytes}->{stats.uncompressed_nbytes} | "
+                f"compressed ratio={stats.compression_ratio:.3f}"
+            )
 
         obs_timestep = timed_observation.get_timestep()
         obs_timestamp = timed_observation.get_timestamp()

--- a/src/lerobot/async_inference/robot_client.py
+++ b/src/lerobot/async_inference/robot_client.py
@@ -28,6 +28,8 @@ python src/lerobot/async_inference/robot_client.py \
     --client_device=cpu \
     --actions_per_chunk=50 \
     --chunk_size_threshold=0.5 \
+    --observation_image_compression=jpeg \
+    --observation_image_compression_quality=90 \
     --aggregate_fn_name=weighted_average \
     --debug_visualize_queue_size=True
 ```
@@ -65,7 +67,13 @@ from lerobot.transport import (
 from lerobot.transport.utils import grpc_channel_options, send_bytes_in_chunks
 from lerobot.utils.import_utils import register_third_party_plugins
 
+from .compression import (
+    compress_timed_observation,
+    compression_stats,
+    image_keys_from_lerobot_features,
+)
 from .configs import RobotClientConfig
+from .constants import IMAGE_COMPRESSION_NONE
 from .helpers import (
     Action,
     FPSTracker,
@@ -96,6 +104,7 @@ class RobotClient:
         self.robot.connect()
 
         lerobot_features = map_robot_keys_to_lerobot_features(self.robot)
+        self.observation_image_keys = image_keys_from_lerobot_features(lerobot_features)
 
         # Use environment variable if server_address is not provided in config
         self.server_address = config.server_address
@@ -192,10 +201,34 @@ class RobotClient:
         if not isinstance(obs, TimedObservation):
             raise ValueError("Input observation needs to be a TimedObservation!")
 
+        observation_to_send = obs
+        compression_time = 0.0
+        stats = None
+        if self.config.observation_image_compression != IMAGE_COMPRESSION_NONE:
+            compression_start = time.perf_counter()
+            observation_to_send = compress_timed_observation(
+                obs,
+                self.observation_image_keys,
+                self.config.observation_image_compression,
+                self.config.observation_image_compression_quality,
+            )
+            compression_time = time.perf_counter() - compression_start
+            stats = compression_stats(observation_to_send.get_observation())
+
         start_time = time.perf_counter()
-        observation_bytes = pickle.dumps(obs)
+        observation_bytes = pickle.dumps(observation_to_send)
         serialize_time = time.perf_counter() - start_time
         self.logger.debug(f"Observation serialization time: {serialize_time:.6f}s")
+        if stats is not None and stats.image_count > 0:
+            self.logger.debug(
+                f"Observation compression: codec={self.config.observation_image_compression} | "
+                f"quality={self.config.observation_image_compression_quality} | "
+                f"images={stats.image_count} | "
+                f"image bytes={stats.uncompressed_nbytes}->{stats.compressed_nbytes} | "
+                f"ratio={stats.compression_ratio:.3f} | "
+                f"compression time={compression_time:.6f}s | "
+                f"payload bytes={len(observation_bytes)}"
+            )
 
         try:
             observation_iterator = send_bytes_in_chunks(

--- a/tests/async_inference/test_compression.py
+++ b/tests/async_inference/test_compression.py
@@ -1,0 +1,152 @@
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+
+import numpy as np
+import pytest
+
+pytest.importorskip("grpc")
+
+from lerobot.async_inference.compression import (  # noqa: E402
+    CompressedImage,
+    compress_image,
+    compress_raw_observation,
+    compress_timed_observation,
+    compression_stats,
+    decompress_image,
+    decompress_timed_observation,
+    image_keys_from_lerobot_features,
+)
+from lerobot.async_inference.configs import RobotClientConfig  # noqa: E402
+from lerobot.async_inference.helpers import TimedObservation  # noqa: E402
+from lerobot.utils.constants import OBS_IMAGES, OBS_STATE  # noqa: E402
+from tests.mocks.mock_robot import MockRobotConfig  # noqa: E402
+
+
+def _structured_image(height: int = 96, width: int = 128) -> np.ndarray:
+    x = np.linspace(0, 255, width, dtype=np.uint8)
+    y = np.linspace(0, 255, height, dtype=np.uint8)
+    xx, yy = np.meshgrid(x, y)
+    average = ((xx.astype(np.uint16) + yy.astype(np.uint16)) // 2).astype(np.uint8)
+    return np.stack([xx, yy, average], axis=-1)
+
+
+def test_image_keys_from_lerobot_features_extracts_raw_camera_keys():
+    lerobot_features = {
+        OBS_STATE: {"dtype": "float32", "shape": [2], "names": ["joint_1", "joint_2"]},
+        f"{OBS_IMAGES}.front": {"dtype": "image", "shape": [96, 128, 3]},
+        f"{OBS_IMAGES}.wrist": {"dtype": "image", "shape": [64, 64, 3]},
+    }
+
+    assert image_keys_from_lerobot_features(lerobot_features) == {"front", "wrist"}
+
+
+def test_png_round_trip_is_lossless_for_uint8_images():
+    image = _structured_image()
+
+    compressed = compress_image(image, "png", quality=90)
+    decompressed = decompress_image(compressed)
+
+    assert decompressed.dtype == image.dtype
+    assert decompressed.shape == image.shape
+    np.testing.assert_array_equal(decompressed, image)
+
+
+def test_jpeg_round_trip_preserves_shape_dtype_and_reduces_structured_payload():
+    image = _structured_image()
+
+    compressed = compress_image(image, "jpeg", quality=95)
+    decompressed = decompress_image(compressed)
+
+    assert decompressed.dtype == image.dtype
+    assert decompressed.shape == image.shape
+    assert len(compressed.data) < image.nbytes
+    mean_abs_error = np.abs(decompressed.astype(np.int16) - image.astype(np.int16)).mean()
+    assert mean_abs_error < 5
+
+
+def test_compress_raw_observation_preserves_non_image_fields_and_does_not_mutate_input():
+    image = _structured_image()
+    raw_observation = {
+        "joint_1": 1.0,
+        "joint_2": 2.0,
+        "front": image,
+        "task": "pick up the cube",
+    }
+
+    compressed = compress_raw_observation(raw_observation, {"front"}, "jpeg", quality=90)
+
+    assert compressed is not raw_observation
+    assert raw_observation["front"] is image
+    assert compressed["joint_1"] == raw_observation["joint_1"]
+    assert compressed["joint_2"] == raw_observation["joint_2"]
+    assert compressed["task"] == raw_observation["task"]
+    assert isinstance(compressed["front"], CompressedImage)
+
+
+def test_compress_timed_observation_preserves_timing_metadata():
+    timestamp = time.time()
+    observation = TimedObservation(
+        timestamp=timestamp,
+        timestep=12,
+        observation={"front": _structured_image(), "joint_1": 1.0},
+        must_go=True,
+    )
+
+    compressed = compress_timed_observation(observation, {"front"}, "png", quality=90)
+    stats = compression_stats(compressed.get_observation())
+    decompressed = decompress_timed_observation(compressed)
+
+    assert compressed is not observation
+    assert stats.image_count == 1
+    assert decompressed.get_timestamp() == timestamp
+    assert decompressed.get_timestep() == 12
+    assert decompressed.must_go is True
+    np.testing.assert_array_equal(decompressed.get_observation()["front"], observation.get_observation()["front"])
+    assert decompressed.get_observation()["joint_1"] == 1.0
+
+
+@pytest.mark.parametrize(
+    ("image", "match"),
+    [
+        (np.zeros((4, 4), dtype=np.float32), "uint8"),
+        (np.zeros((4,), dtype=np.uint8), "2D or 3D"),
+        (np.zeros((4, 4, 2), dtype=np.uint8), "1-, 3-, or 4-channel"),
+    ],
+)
+def test_compress_image_rejects_unsupported_image_payloads(image, match):
+    with pytest.raises(ValueError, match=match):
+        compress_image(image, "jpeg", quality=90)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"observation_image_compression": "webp"},
+        {"observation_image_compression_quality": 0},
+        {"observation_image_compression_quality": 101},
+    ],
+)
+def test_robot_client_config_validates_observation_compression(kwargs):
+    config_kwargs = {
+        "policy_type": "act",
+        "pretrained_name_or_path": "test/model",
+        "robot": MockRobotConfig(),
+        "actions_per_chunk": 1,
+    }
+    config_kwargs.update(kwargs)
+
+    with pytest.raises(ValueError):
+        RobotClientConfig(**config_kwargs)

--- a/tests/async_inference/test_policy_server.py
+++ b/tests/async_inference/test_policy_server.py
@@ -17,8 +17,10 @@ Monkey-patch the `policy` attribute with a stub so that no real model inference 
 
 from __future__ import annotations
 
+import pickle
 import time
 
+import numpy as np
 import pytest
 import torch
 
@@ -168,6 +170,39 @@ def test_maybe_enqueue_observation_is_skipped(policy_server):
 
     assert policy_server._enqueue_observation(new_obs) is False
     assert policy_server.observation_queue.empty() is True
+
+
+def test_send_observations_decompresses_before_enqueue(policy_server):
+    from lerobot.async_inference.compression import compress_timed_observation
+    from lerobot.async_inference.helpers import TimedObservation
+    from lerobot.transport import services_pb2
+    from lerobot.transport.utils import send_bytes_in_chunks
+
+    class FakeContext:
+        def peer(self):
+            return "test-client"
+
+    image = np.zeros((16, 16, 3), dtype=np.uint8)
+    image[:, :, 1] = 128
+    obs = TimedObservation(
+        timestamp=time.time(),
+        timestep=7,
+        observation={"front": image, "joint1": 0.0},
+        must_go=True,
+    )
+    compressed_obs = compress_timed_observation(obs, {"front"}, "png", quality=90)
+    request_iterator = send_bytes_in_chunks(
+        pickle.dumps(compressed_obs),  # nosec
+        services_pb2.Observation,
+    )
+
+    response = policy_server.SendObservations(request_iterator, FakeContext())
+
+    assert isinstance(response, services_pb2.Empty)
+    queued_obs = policy_server.observation_queue.get_nowait()
+    assert queued_obs.get_timestep() == obs.get_timestep()
+    assert queued_obs.must_go is True
+    np.testing.assert_array_equal(queued_obs.get_observation()["front"], image)
 
 
 def test_obs_sanity_checks(policy_server):

--- a/tests/async_inference/test_robot_client.py
+++ b/tests/async_inference/test_robot_client.py
@@ -19,9 +19,11 @@ no real hardware is accessed. Only the queue-update mechanism is verified.
 
 from __future__ import annotations
 
+import pickle
 import time
 from queue import Queue
 
+import numpy as np
 import pytest
 import torch
 
@@ -233,6 +235,44 @@ def test_ready_to_send_observation_with_varying_threshold(robot_client, g_thresh
         robot_client.action_queue.put(act)
 
     assert robot_client._ready_to_send_observation() is expected
+
+
+def test_send_observation_compresses_configured_image_keys(robot_client):
+    """When image compression is enabled, outgoing observation payloads contain compressed images."""
+    from lerobot.async_inference.compression import CompressedImage
+    from lerobot.async_inference.helpers import TimedObservation
+    from lerobot.transport import services_pb2
+
+    class FakeStub:
+        def __init__(self):
+            self.chunks = None
+
+        def SendObservations(self, request_iterator):  # noqa: N802
+            self.chunks = list(request_iterator)
+            return services_pb2.Empty()
+
+    fake_stub = FakeStub()
+    robot_client.stub = fake_stub
+    robot_client.observation_image_keys = {"front"}
+    robot_client.config.observation_image_compression = "png"
+    robot_client.config.observation_image_compression_quality = 90
+
+    image = np.zeros((16, 16, 3), dtype=np.uint8)
+    obs = TimedObservation(
+        timestamp=time.time(),
+        timestep=3,
+        observation={"front": image, "motor_1.pos": 1.0},
+        must_go=True,
+    )
+
+    assert robot_client.send_observation(obs) is True
+
+    assert fake_stub.chunks is not None
+    payload = b"".join(chunk.data for chunk in fake_stub.chunks)
+    sent_obs = pickle.loads(payload)  # nosec B301
+    assert isinstance(sent_obs.get_observation()["front"], CompressedImage)
+    assert sent_obs.get_observation()["motor_1.pos"] == 1.0
+    assert obs.get_observation()["front"] is image
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add opt-in JPEG/PNG compression for async inference observation images before gRPC chunking.
- Decode compressed observations on the policy server before queueing and preprocessing, preserving the existing raw-observation contract.
- Add config flags, docs/example usage, and focused client/server/compression tests.

## Why

Async inference currently pickles and streams raw camera observations from `RobotClient` to `PolicyServer`. With multiple high-resolution cameras, this can saturate the robot-to-server link, as reported in #2561. This keeps default behavior unchanged while allowing users to enable per-observation image compression when bandwidth is the bottleneck.

Fixes #2561.

## Design notes

- The default remains `observation_image_compression="none"` for backward compatibility.
- Supported codecs are `jpeg` and `png`: JPEG is bandwidth-oriented and lossy, while PNG is lossless and useful for debug/quality-preserving paths.
- The protobuf and transport chunking layers are unchanged; compression happens before `send_bytes_in_chunks()` and decompression after `receive_bytes_in_chunks()`.
- Compression accepts only `uint8` 2D images or 1/3/4-channel 3D image arrays, with clear errors for unsupported payloads.

## Validation

- `PYTHONPATH=src uv run --extra test --extra async python -m pytest tests/async_inference/test_compression.py -svv`
- `PYTHONPATH=src uv run --extra test --extra async --extra pyserial-dep --extra dataset python -m pytest tests/async_inference -svv`
- `PYTHONPATH=src uv run --extra dev --extra test --extra async ruff check src/lerobot/async_inference tests/async_inference examples/tutorial/async-inf/robot_client.py`
- `PYTHONPATH=src uv run --extra test --extra async python -m compileall -q src/lerobot/async_inference tests/async_inference`
- `git diff --check`
