### PR TITLE
docs(omx): adding some examples and scripts

### DIFF
--- a/examples/omx/README.md
+++ b/examples/omx/README.md
@@ -62,7 +62,7 @@ python -m examples.omx.record_grab \
     --robot.id=omx_follower \
     --robot.cameras="$ROBOT_CAMERAS" \
     --dataset.repo_id=$HF_USERNAME/omx_pickandplace \
-    --dataset.root=data/omx_collect \
+    --dataset.root=data/omx_pickandplace \
     --dataset.num_episodes=50 \
     --dataset.single_task="Pick the cube and place it in the blue square" \
     --dataset.streaming_encoding=true \
@@ -91,6 +91,8 @@ lerobot-train \
     --steps=20000 \
     --wandb.enable=true
 ```
+
+A pretrained `ACT` policy is already available here [`maximellerbach/omx_pickandplace_act`](https://huggingface.co/maximellerbach/omx_pickandplace_act).
 
 ## Step 3 — Rollout
 

--- a/examples/omx/README.md
+++ b/examples/omx/README.md
@@ -1,6 +1,6 @@
 # OMX Follower — Cube Pick And Place Example
 
-This is an example of what is possible to do with LeRobot on a phyisical Setup.
+This is an example of what is possible to do with LeRobot on a physical setup.
 It is a WIP and being used internally at LeRobot and specific to our setup, but we hope it can be a useful reference for how to use LeRobot APIs and CLIs.
 
 It includes an end-to-end example for the **OMX Follower** robot arm: pick and place a cube dataset, train a policy, and deploy it autonomously.
@@ -18,7 +18,6 @@ It includes an end-to-end example for the **OMX Follower** robot arm: pick and p
 | ---------------------- | --------------------------------------------------------------- |
 | `reset_environment.py` | Standalone utility: sweep workspace, grab cube, place cube      |
 | `record_grab.py`       | Automated data collection: reset → place → record grab episodes |
-| `rollout.py`           | Deploy a trained policy on the robot                            |
 
 ## Setup
 
@@ -57,14 +56,12 @@ lerobot-record \
 /!\ This is specific to our setup and the task of picking and placing a cube. It is not a general-purpose data collection script. As you may notice, it doesn't require a teleop.
 
 ```bash
-cd examples/omx
-
-python record_grab.py \
+python -m examples.omx.record_grab \
     --robot.type=omx_follower \
     --robot.port=$ROBOT_PORT \
     --robot.id=omx_follower \
     --robot.cameras="$ROBOT_CAMERAS" \
-    --dataset.repo_id=$HF_USERNAME/omx_autocollect \
+    --dataset.repo_id=$HF_USERNAME/omx_pickandplace \
     --dataset.root=data/omx_collect \
     --dataset.num_episodes=50 \
     --dataset.single_task="Pick the cube and place it in the blue square" \
@@ -78,7 +75,7 @@ Each episode:
 2. The arm returns to HOME.
 3. A targeted grab is recorded: HOME → approach raised → lower onto cube → grasp → lift → carry → drop → HOME.
 
-A dataset is already available here [`maximellerbach/omx_autocollect`](https://huggingface.co/datasets/maximellerbach/omx_autocollect), so you can skip directly to training if you want.
+A dataset is already available here [`maximellerbach/omx_pickandplace`](https://huggingface.co/datasets/maximellerbach/omx_pickandplace), so you can skip directly to training if you want.
 
 ## Step 2 — Train
 
@@ -106,7 +103,7 @@ lerobot-rollout \
     --robot.port=$ROBOT_PORT \
     --robot.id=omx_follower \
     --robot.cameras="$ROBOT_CAMERAS" \
-    --policy.path=$HF_USERNAME/<model_repo_id>
+    --policy.path=$HF_USERNAME/omx_pickandplace_act \
 ```
 
 For continuous recording with automatic upload (sentry mode):
@@ -119,8 +116,8 @@ lerobot-rollout \
     --robot.port=$ROBOT_PORT \
     --robot.id=omx_follower \
     --robot.cameras="$ROBOT_CAMERAS" \
-    --policy.path=$HF_USERNAME/<model_repo_id> \
-    --dataset.repo_id=$HF_USERNAME/rollout_omx_grab
+    --policy.path=$HF_USERNAME/omx_pickandplace_act \
+    --dataset.repo_id=$HF_USERNAME/rollout_omx_pickandplace_act \
 ```
 
 ## Environment Reset Utility
@@ -130,11 +127,8 @@ Those are specific to this particular physical setup. Those are scripts that exe
 `reset_environment.py` can be run standalone to prepare the workspace:
 
 ```bash
-# Sweep the workspace (cube back to center)
-python reset_environment.py --port $ROBOT_PORT --mode reset
-
-# Grab cube + place it at a random position
-python reset_environment.py --port $ROBOT_PORT --mode grab_and_place
+# Grab cube + place it at a random position on the left side
+python -m examples.omx.reset_environment --port $ROBOT_PORT --mode grab_and_place
 ```
 
 It also exposes `grab_cube(robot)` and `place_cube(robot)` for use in custom scripts.

--- a/examples/omx/README.md
+++ b/examples/omx/README.md
@@ -1,4 +1,4 @@
-# OMX Follower — Cube Grab Example
+# OMX Follower — Cube Pick And Place Example
 
 This is an example of what is possible to do with LeRobot on a phyisical Setup.
 It is a WIP and being used internally at LeRobot and specific to our setup, but we hope it can be a useful reference for how to use LeRobot APIs and CLIs.
@@ -7,11 +7,10 @@ It includes an end-to-end example for the **OMX Follower** robot arm: pick and p
 
 ## Hardware
 
-| Component | Value                                        |
-| --------- | -------------------------------------------- |
-| Robot     | OMX Follower (USB serial)                    |
-| Cameras   | 2× OpenCV cameras (wrist + top-down)         |
-| Port      | `/dev/ttyACM0` (adjust to match your system) |
+| Component | Value                                |
+| --------- | ------------------------------------ |
+| Robot     | OMX Follower                         |
+| Cameras   | 2× OpenCV cameras (wrist + top-down) |
 
 ## Scripts
 
@@ -23,21 +22,49 @@ It includes an end-to-end example for the **OMX Follower** robot arm: pick and p
 
 ## Setup
 
-Make sure you have LeRobot installed in your env
+Make sure you have LeRobot installed in your env. (See [the installation guide](https://huggingface.co/docs/lerobot/installation))
+
+Next, we will declare some environment variables for convenience. Adjust the camera indices and robot port to match your system configuration.
+
+```bash
+export ROBOT_PORT=/dev/ttyACM0
+export TELEOP_PORT=/dev/ttyACM1
+export HF_USERNAME=<your_hf_username>
+export ROBOT_CAMERAS="{ wrist: {type: opencv, index_or_path: 0, width: 640, height: 480, fps: 30, fourcc: MJPG}, top: {type: opencv, index_or_path: 2, width: 640, height: 480, fps: 30, fourcc: MJPG} }"
+```
 
 ## Step 1 — Collect Data
 
-/!\ This is specific to our setup and the task of picking and placing a cube. It is not a general-purpose data collection script.
+```bash
+lerobot-record \
+    --robot.type=omx_follower \
+    --robot.port=$ROBOT_PORT \
+    --robot.id=omx_follower \
+    --robot.cameras="$ROBOT_CAMERAS" \
+    --teleop.type=omx_leader \
+    --teleop.port=$TELEOP_PORT \
+    --teleop.id=omx_leader \
+    --dataset.repo_id=$HF_USERNAME/omx_pickandplace \
+    --dataset.root=data/omx_pickandplace \
+    --dataset.num_episodes=50 \
+    --dataset.single_task="Pick the cube and place it in the blue square" \
+    --dataset.streaming_encoding=true \
+    --dataset.push_to_hub=true
+```
+
+### Bonus Auto-Collect script
+
+/!\ This is specific to our setup and the task of picking and placing a cube. It is not a general-purpose data collection script. As you may notice, it doesn't require a teleop.
 
 ```bash
 cd examples/omx
 
 python record_grab.py \
     --robot.type=omx_follower \
-    --robot.port=/dev/ttyACM0 \
+    --robot.port=$ROBOT_PORT \
     --robot.id=omx_follower \
-    --robot.cameras="{ wrist: {type: opencv, index_or_path: 6, width: 640, height: 480, fps: 30, fourcc: MJPG}, top: {type: opencv, index_or_path: 4, width: 640, height: 480, fps: 30, fourcc: MJPG} }" \
-    --dataset.repo_id=maximellerbach/omx_autocollect \
+    --robot.cameras="$ROBOT_CAMERAS" \
+    --dataset.repo_id=$HF_USERNAME/omx_autocollect \
     --dataset.root=data/omx_collect \
     --dataset.num_episodes=50 \
     --dataset.single_task="Pick the cube and place it in the blue square" \
@@ -55,26 +82,31 @@ A dataset is already available here [`maximellerbach/omx_autocollect`](https://h
 
 ## Step 2 — Train
 
+To train a simple `ACT` policy on the collected dataset, you can use the `lerobot-train` CLI:
+
 ```bash
 lerobot-train \
-    --dataset.repo_id=<hf_username>/omx_pickandplace \
+    --dataset.repo_id=$HF_USERNAME/omx_pickandplace \
     --policy.type=act \
     --output_dir=outputs/train/omx_pickandplace_act \
+    --policy.device=cuda \
+    --policy.repo_id=$HF_USERNAME/omx_pickandplace_act \
+    --steps=20000 \
     --wandb.enable=true
 ```
 
 ## Step 3 — Rollout
 
-use the `lerobot-rollout` CLI:
+Use the `lerobot-rollout` CLI with base strategy:
 
 ```bash
 lerobot-rollout \
     --strategy.type=base \
     --robot.type=omx_follower \
-    --robot.port=/dev/ttyACM0 \
+    --robot.port=$ROBOT_PORT \
     --robot.id=omx_follower \
-    --robot.cameras="{ wrist: {type: opencv, index_or_path: 6, width: 640, height: 480, fps: 30, fourcc: MJPG}, top: {type: opencv, index_or_path: 4, width: 640, height: 480, fps: 30, fourcc: MJPG} }" \
-    --policy.path=<hf_username>/<model_repo_id>
+    --robot.cameras="$ROBOT_CAMERAS" \
+    --policy.path=$HF_USERNAME/<model_repo_id>
 ```
 
 For continuous recording with automatic upload (sentry mode):
@@ -84,25 +116,25 @@ lerobot-rollout \
     --strategy.type=sentry \
     --strategy.upload_every_n_episodes=10 \
     --robot.type=omx_follower \
-    --robot.port=/dev/ttyACM0 \
+    --robot.port=$ROBOT_PORT \
     --robot.id=omx_follower \
-    --robot.cameras="{ wrist: {type: opencv, index_or_path: 6, width: 640, height: 480, fps: 30, fourcc: MJPG}, top: {type: opencv, index_or_path: 4, width: 640, height: 480, fps: 30, fourcc: MJPG} }" \
-    --policy.path=<hf_username>/<model_repo_id> \
-    --dataset.repo_id=<hf_username>/rollout_omx_grab
+    --robot.cameras="$ROBOT_CAMERAS" \
+    --policy.path=$HF_USERNAME/<model_repo_id> \
+    --dataset.repo_id=$HF_USERNAME/rollout_omx_grab
 ```
 
 ## Environment Reset Utility
 
-Those are specific to this particular setup. Those are scripts that execute hardcoded sequences of actions on the robot to reset the environment, which is useful for data collection and evaluation. They are not general-purpose scripts.
+Those are specific to this particular physical setup. Those are scripts that execute hardcoded sequences of actions on the robot to reset the environment, which is useful for data collection and evaluation. They are not general-purpose scripts.
 
 `reset_environment.py` can be run standalone to prepare the workspace:
 
 ```bash
 # Sweep the workspace (cube back to center)
-python reset_environment.py --port /dev/ttyACM0 --mode reset
+python reset_environment.py --port $ROBOT_PORT --mode reset
 
 # Grab cube + place it at a random position
-python reset_environment.py --port /dev/ttyACM0 --mode grab_and_place
+python reset_environment.py --port $ROBOT_PORT --mode grab_and_place
 ```
 
 It also exposes `grab_cube(robot)` and `place_cube(robot)` for use in custom scripts.

--- a/examples/omx/README.md
+++ b/examples/omx/README.md
@@ -1,0 +1,108 @@
+# OMX Follower — Cube Grab Example
+
+This is an example of what is possible to do with LeRobot on a phyisical Setup.
+It is a WIP and being used internally at LeRobot and specific to our setup, but we hope it can be a useful reference for how to use LeRobot APIs and CLIs.
+
+It includes an end-to-end example for the **OMX Follower** robot arm: pick and place a cube dataset, train a policy, and deploy it autonomously.
+
+## Hardware
+
+| Component | Value                                        |
+| --------- | -------------------------------------------- |
+| Robot     | OMX Follower (USB serial)                    |
+| Cameras   | 2× OpenCV cameras (wrist + top-down)         |
+| Port      | `/dev/ttyACM0` (adjust to match your system) |
+
+## Scripts
+
+| Script                 | Purpose                                                         |
+| ---------------------- | --------------------------------------------------------------- |
+| `reset_environment.py` | Standalone utility: sweep workspace, grab cube, place cube      |
+| `record_grab.py`       | Automated data collection: reset → place → record grab episodes |
+| `rollout.py`           | Deploy a trained policy on the robot                            |
+
+## Setup
+
+Make sure you have LeRobot installed in your env
+
+## Step 1 — Collect Data
+
+/!\ This is specific to our setup and the task of picking and placing a cube. It is not a general-purpose data collection script.
+
+```bash
+cd examples/omx
+
+python record_grab.py \
+    --robot.type=omx_follower \
+    --robot.port=/dev/ttyACM0 \
+    --robot.id=omx_follower \
+    --robot.cameras="{ wrist: {type: opencv, index_or_path: 6, width: 640, height: 480, fps: 30, fourcc: MJPG}, top: {type: opencv, index_or_path: 4, width: 640, height: 480, fps: 30, fourcc: MJPG} }" \
+    --dataset.repo_id=maximellerbach/omx_autocollect \
+    --dataset.root=data/omx_collect \
+    --dataset.num_episodes=50 \
+    --dataset.single_task="Pick the cube and place it in the blue square" \
+    --dataset.streaming_encoding=true \
+    --dataset.push_to_hub=true
+```
+
+Each episode:
+
+1. The arm grabs the cube from the center of the workspace and places it at a random position.
+2. The arm returns to HOME.
+3. A targeted grab is recorded: HOME → approach raised → lower onto cube → grasp → lift → carry → drop → HOME.
+
+A dataset is already available here [`maximellerbach/omx_autocollect`](https://huggingface.co/datasets/maximellerbach/omx_autocollect), so you can skip directly to training if you want.
+
+## Step 2 — Train
+
+```bash
+lerobot-train \
+    --dataset.repo_id=<hf_username>/omx_pickandplace \
+    --policy.type=act \
+    --output_dir=outputs/train/omx_pickandplace_act \
+    --wandb.enable=true
+```
+
+## Step 3 — Rollout
+
+use the `lerobot-rollout` CLI:
+
+```bash
+lerobot-rollout \
+    --strategy.type=base \
+    --robot.type=omx_follower \
+    --robot.port=/dev/ttyACM0 \
+    --robot.id=omx_follower \
+    --robot.cameras="{ wrist: {type: opencv, index_or_path: 6, width: 640, height: 480, fps: 30, fourcc: MJPG}, top: {type: opencv, index_or_path: 4, width: 640, height: 480, fps: 30, fourcc: MJPG} }" \
+    --policy.path=<hf_username>/<model_repo_id>
+```
+
+For continuous recording with automatic upload (sentry mode):
+
+```bash
+lerobot-rollout \
+    --strategy.type=sentry \
+    --strategy.upload_every_n_episodes=10 \
+    --robot.type=omx_follower \
+    --robot.port=/dev/ttyACM0 \
+    --robot.id=omx_follower \
+    --robot.cameras="{ wrist: {type: opencv, index_or_path: 6, width: 640, height: 480, fps: 30, fourcc: MJPG}, top: {type: opencv, index_or_path: 4, width: 640, height: 480, fps: 30, fourcc: MJPG} }" \
+    --policy.path=<hf_username>/<model_repo_id> \
+    --dataset.repo_id=<hf_username>/rollout_omx_grab
+```
+
+## Environment Reset Utility
+
+Those are specific to this particular setup. Those are scripts that execute hardcoded sequences of actions on the robot to reset the environment, which is useful for data collection and evaluation. They are not general-purpose scripts.
+
+`reset_environment.py` can be run standalone to prepare the workspace:
+
+```bash
+# Sweep the workspace (cube back to center)
+python reset_environment.py --port /dev/ttyACM0 --mode reset
+
+# Grab cube + place it at a random position
+python reset_environment.py --port /dev/ttyACM0 --mode grab_and_place
+```
+
+It also exposes `grab_cube(robot)` and `place_cube(robot)` for use in custom scripts.

--- a/examples/omx/record_grab.py
+++ b/examples/omx/record_grab.py
@@ -197,11 +197,11 @@ def record_episode_spline(
             commanded = h00 * p0 + h10 * m0 + h01 * p1 + h11 * m1
 
             action = array_to_pose(commanded)
+            robot.send_action(action)
             obs = robot.get_observation()
             obs_frame = build_dataset_frame(dataset.features, obs, prefix=OBS_STR)
             action_frame = build_dataset_frame(dataset.features, action, prefix=ACTION)
             dataset.add_frame({**obs_frame, **action_frame, "task": task})
-            robot.send_action(action)
             precise_sleep(dt)
 
 

--- a/examples/omx/record_grab.py
+++ b/examples/omx/record_grab.py
@@ -8,8 +8,8 @@ Each episode cycle:
   3. record_grab     — execute a targeted grab to the stored position while recording
                        observations + actions to a LeRobotDataset
 
-Usage:
-    python record_grab.py \\
+Usage (run from repo root):
+    python -m examples.omx.record_grab \\
         --robot.type=omx_follower \\
         --robot.port=/dev/ttyACM0 \\
         --robot.id=omx_follower \\
@@ -22,32 +22,10 @@ Usage:
 """
 
 import logging
-import sys
 from dataclasses import dataclass
-from pathlib import Path
 from pprint import pformat
 
 import numpy as np
-
-# Make reset_environment importable from the same directory
-sys.path.insert(0, str(Path(__file__).parent))
-
-from reset_environment import (
-    APPROACH_SPEED,
-    CONTROL_HZ,
-    GRIPPER_CLOSE_POS,
-    HOME_POSE,
-    PUSH_END_ELBOW_FLEX,
-    PUSH_END_SHOULDER_LIFT,
-    PUSH_START_ELBOW_FLEX,
-    PUSH_START_SHOULDER_LIFT,
-    array_to_pose,
-    grab_cube,
-    horizontal_wrist_flex,
-    move_to_pose,
-    place_cube,
-    pose_to_array,
-)
 
 from lerobot.cameras import CameraConfig  # noqa: F401
 from lerobot.cameras.opencv import OpenCVCameraConfig  # noqa: F401
@@ -65,6 +43,23 @@ from lerobot.robots.omx_follower import OmxFollower
 from lerobot.utils.constants import ACTION, OBS_STR
 from lerobot.utils.feature_utils import build_dataset_frame, combine_feature_dicts
 from lerobot.utils.robot_utils import precise_sleep
+
+from .reset_environment import (
+    APPROACH_SPEED,
+    CONTROL_HZ,
+    GRIPPER_CLOSE_POS,
+    HOME_POSE,
+    PUSH_END_ELBOW_FLEX,
+    PUSH_END_SHOULDER_LIFT,
+    PUSH_START_ELBOW_FLEX,
+    PUSH_START_SHOULDER_LIFT,
+    array_to_pose,
+    grab_cube,
+    horizontal_wrist_flex,
+    move_to_pose,
+    place_cube,
+    pose_to_array,
+)
 
 # ── Grab-episode motion parameters ────────────────────────────────────────────
 
@@ -168,18 +163,18 @@ def record_episode_spline(
 
     # Steps and duration per segment
     n_steps_list = []
-    t = []
+    timestamps = []
     for i in range(n - 1):
         max_dist = float(np.max(np.abs(pts[i + 1] - pts[i])))
         ns = max(1, int(max_dist / speeds[i] * CONTROL_HZ)) if max_dist >= 0.5 else 0
         n_steps_list.append(ns)
-        t.append(ns / CONTROL_HZ)
+        timestamps.append(ns / CONTROL_HZ)
 
     # Velocity tangents (deg/sec) — clamped at endpoints, Catmull-Rom for interior
     vels = [np.zeros_like(pts[0])]
     for i in range(1, n - 1):
-        v_prev = (pts[i] - pts[i - 1]) / t[i - 1] if t[i - 1] > 0 else np.zeros_like(pts[0])
-        v_next = (pts[i + 1] - pts[i]) / t[i] if t[i] > 0 else np.zeros_like(pts[0])
+        v_prev = (pts[i] - pts[i - 1]) / timestamps[i - 1] if timestamps[i - 1] > 0 else np.zeros_like(pts[0])
+        v_next = (pts[i + 1] - pts[i]) / timestamps[i] if timestamps[i] > 0 else np.zeros_like(pts[0])
         vels.append(0.5 * (v_prev + v_next))
     vels.append(np.zeros_like(pts[0]))
 
@@ -190,8 +185,8 @@ def record_episode_spline(
             continue
         p0, p1 = pts[seg], pts[seg + 1]
         # Scale velocity (deg/sec) to t-space tangent (deg/t-unit, where t: 0→1 over ns steps)
-        m0 = vels[seg] * t[seg]
-        m1 = vels[seg + 1] * t[seg]
+        m0 = vels[seg] * timestamps[seg]
+        m1 = vels[seg + 1] * timestamps[seg]
 
         for step in range(1, ns + 1):
             t = step / ns
@@ -331,8 +326,7 @@ def record_grab(cfg: OmxRecordGrabConfig) -> LeRobotDataset:
     robot = make_robot_from_config(cfg.robot)
     use_videos = cfg.dataset.video
 
-    _, _, robot_obs_processor = make_default_processors()
-    teleop_action_processor, _, _ = make_default_processors()
+    teleop_action_processor, _, robot_obs_processor = make_default_processors()
 
     dataset_features = combine_feature_dicts(
         aggregate_pipeline_dataset_features(

--- a/examples/omx/record_grab.py
+++ b/examples/omx/record_grab.py
@@ -152,11 +152,14 @@ def record_episode_spline(
     dataset: LeRobotDataset,
     task: str,
 ) -> None:
-    """Execute a Catmull-Rom spline through waypoints, recording each frame.
+    """Execute a Catmull-Rom-style spline through waypoints, recording each frame.
 
-    Uses non-uniform chord-length parameterization for interior tangents and
-    clamped (zero-velocity) endpoints so the arm starts and stops smoothly.
-    Each segment is cubic Hermite, giving C1 continuity at every waypoint.
+    Segment durations are parameterized from the maximum absolute joint delta
+    between consecutive waypoints divided by the requested segment speed,
+    producing non-uniform timing in joint space. Interior tangents are derived
+    from the adjacent per-segment velocities, with clamped (zero-velocity)
+    endpoints so the arm starts and stops smoothly. Each segment is cubic
+    Hermite, giving C1 continuity at every waypoint.
     """
     pts = [pose_to_array(w) for w in waypoints]
     n = len(pts)

--- a/examples/omx/record_grab.py
+++ b/examples/omx/record_grab.py
@@ -46,7 +46,6 @@ from lerobot.utils.robot_utils import precise_sleep
 
 from .reset_environment import (
     APPROACH_SPEED,
-    CONTROL_HZ,
     GRIPPER_CLOSE_POS,
     HOME_POSE,
     PUSH_END_ELBOW_FLEX,
@@ -169,9 +168,9 @@ def record_episode_spline(
     timestamps = []
     for i in range(n - 1):
         max_dist = float(np.max(np.abs(pts[i + 1] - pts[i])))
-        ns = max(1, int(max_dist / speeds[i] * CONTROL_HZ)) if max_dist >= 0.5 else 0
+        ns = max(1, int(max_dist / speeds[i] * dataset.fps)) if max_dist >= 0.5 else 0
         n_steps_list.append(ns)
-        timestamps.append(ns / CONTROL_HZ)
+        timestamps.append(ns / dataset.fps)
 
     # Velocity tangents (deg/sec) — clamped at endpoints, Catmull-Rom for interior
     vels = [np.zeros_like(pts[0])]
@@ -181,7 +180,7 @@ def record_episode_spline(
         vels.append(0.5 * (v_prev + v_next))
     vels.append(np.zeros_like(pts[0]))
 
-    dt = 1.0 / CONTROL_HZ
+    dt = 1.0 / dataset.fps
     for seg in range(n - 1):
         ns = n_steps_list[seg]
         if ns == 0:
@@ -313,8 +312,9 @@ def record_grab_episode(
 
     # Dwell at HOME for ~0.5 s before next episode
     home_action = build_dataset_frame(dataset.features, HOME_POSE, prefix=ACTION)
-    dt = 1.0 / CONTROL_HZ
-    for _ in range(int(CONTROL_HZ * 0.5)):
+    dt = 1.0 / dataset.fps
+    for _ in range(int(dataset.fps * 0.5)):
+        robot.send_action(HOME_POSE)
         obs = robot.get_observation()
         obs_frame = build_dataset_frame(dataset.features, obs, prefix=OBS_STR)
         dataset.add_frame({**obs_frame, **home_action, "task": task})
@@ -395,7 +395,12 @@ def record_grab(cfg: OmxRecordGrabConfig) -> LeRobotDataset:
                 recovery_start = cfg.recovery_prob > 0 and float(rng.random()) < cfg.recovery_prob
                 logger.info(f"Step 2: recording {'recovery ' if recovery_start else ''}grab episode...")
                 record_grab_episode(
-                    robot, dataset, pan, t, cfg.dataset.single_task, recovery_start=recovery_start
+                    robot,
+                    dataset,
+                    pan,
+                    t,
+                    cfg.dataset.single_task,
+                    recovery_start=recovery_start,
                 )
 
                 dataset.save_episode()

--- a/examples/omx/record_grab.py
+++ b/examples/omx/record_grab.py
@@ -1,0 +1,420 @@
+#!/usr/bin/env python3
+"""
+Auto-record grab episodes for the OMX robot arm.
+
+Each episode cycle:
+  1. grab_and_place  — grab cube from workspace center and place at a random (pan, reach) position
+  2. HOME            — return arm to home with gripper open
+  3. record_grab     — execute a targeted grab to the stored position while recording
+                       observations + actions to a LeRobotDataset
+
+Usage:
+    python record_grab.py \\
+        --robot.type=omx_follower \\
+        --robot.port=/dev/ttyACM0 \\
+        --robot.id=omx_follower \\
+        --robot.cameras="{ wrist: {type: opencv, index_or_path: 6, width: 640, height: 480, fps: 30, fourcc: MJPG}, top: {type: opencv, index_or_path: 4, width: 640, height: 480, fps: 30, fourcc: MJPG} }" \\
+        --dataset.repo_id=<hf_username>/<dataset_name> \\
+        --dataset.root=data/omx_grab \\
+        --dataset.num_episodes=50 \\
+        --dataset.single_task="Grab the cube" \\
+        --dataset.streaming_encoding=true
+"""
+
+import logging
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from pprint import pformat
+
+import numpy as np
+
+# Make reset_environment importable from the same directory
+sys.path.insert(0, str(Path(__file__).parent))
+
+from reset_environment import (
+    APPROACH_SPEED,
+    CONTROL_HZ,
+    GRIPPER_CLOSE_POS,
+    HOME_POSE,
+    PUSH_END_ELBOW_FLEX,
+    PUSH_END_SHOULDER_LIFT,
+    PUSH_START_ELBOW_FLEX,
+    PUSH_START_SHOULDER_LIFT,
+    array_to_pose,
+    grab_cube,
+    horizontal_wrist_flex,
+    move_to_pose,
+    place_cube,
+    pose_to_array,
+)
+
+from lerobot.cameras import CameraConfig  # noqa: F401
+from lerobot.cameras.opencv import OpenCVCameraConfig  # noqa: F401
+from lerobot.configs import parser
+from lerobot.configs.dataset import DatasetRecordConfig
+from lerobot.datasets import (
+    LeRobotDataset,
+    VideoEncodingManager,
+    aggregate_pipeline_dataset_features,
+    create_initial_features,
+)
+from lerobot.processor import make_default_processors
+from lerobot.robots import RobotConfig, make_robot_from_config
+from lerobot.robots.omx_follower import OmxFollower
+from lerobot.utils.constants import ACTION, OBS_STR
+from lerobot.utils.feature_utils import build_dataset_frame, combine_feature_dicts
+from lerobot.utils.robot_utils import precise_sleep
+
+# ── Grab-episode motion parameters ────────────────────────────────────────────
+
+# Shoulder-lift offset for the raised approach phase (subtracted from the target sl, arm is higher).
+GRAB_RAISE_SL_OFFSET = 20.0
+GRAB_LOWER_SPEED = 20.0
+RECORD_SPEED = 30.0
+
+# Pose the arm travels to after closing the gripper (cube held).
+GRAB_CARRY_POSE = {
+    "shoulder_pan.pos": -23.0,
+    "shoulder_lift.pos": 5.0,
+    "elbow_flex.pos": 18.0,
+    "wrist_flex.pos": -14.0,
+    "wrist_roll.pos": 0.0,
+    "gripper.pos": GRIPPER_CLOSE_POS,
+}
+
+# Per-joint jitter limits (degrees) applied to transit waypoints for human-like variation.
+# Cube-approach and carry poses are never jittered to preserve precision.
+_JITTER_LIMITS: dict[str, float] = {
+    "shoulder_pan.pos": 5.0,
+    "shoulder_lift.pos": 4.0,
+    "elbow_flex.pos": 4.0,
+    "wrist_flex.pos": 3.0,
+    "wrist_roll.pos": 2.0,
+    "gripper.pos": 0.0,
+}
+
+
+def _jitter_pose(pose: dict, rng: np.random.Generator) -> dict:
+    """Return a copy of pose with independent per-joint random perturbations."""
+    return {
+        k: v + rng.uniform(-_JITTER_LIMITS.get(k, 0.0), _JITTER_LIMITS.get(k, 0.0)) for k, v in pose.items()
+    }
+
+
+def _random_stuck_pose(rng: np.random.Generator) -> dict:
+    """Return a physically plausible stuck pose (failed grasp), gripper closed.
+
+    ef bounds are piecewise-linear in sl so the arm stays in a reachable,
+    table-safe envelope across the full sl range:
+      sl=-50 → ef ∈ [  0,  50]   (arm raised, can be bent forward)
+      sl=  0 → ef ∈ [-25,  25]   (mid reach)
+      sl= 30 → ef ∈ [-20,   0]   (arm extended, little room to flex)
+    wrist_flex is randomly offset from the horizontal value.
+    """
+    pan = float(rng.uniform(-5.0, 35.0))
+    sl = float(rng.uniform(-50.0, 30.0))
+
+    if sl <= 0.0:
+        alpha = (sl + 50.0) / 50.0  # 0 at sl=-50, 1 at sl=0
+        ef_lo = alpha * -25.0  # 0 → -25
+        ef_hi = 50.0 + alpha * -25.0  # 50 → 25
+    else:
+        alpha = sl / 30.0  # 0 at sl=0, 1 at sl=30
+        ef_lo = -25.0 + alpha * 5.0  # -25 → -20
+        ef_hi = 25.0 + alpha * -25.0  # 25 → 0
+
+    ef = float(rng.uniform(ef_lo, ef_hi))
+    wf = horizontal_wrist_flex(sl, ef) + float(rng.uniform(-15.0, 15.0))
+    return {
+        "shoulder_pan.pos": pan,
+        "shoulder_lift.pos": sl,
+        "elbow_flex.pos": ef,
+        "wrist_flex.pos": wf,
+        "wrist_roll.pos": float(rng.uniform(-15.0, 15.0)),
+        "gripper.pos": GRIPPER_CLOSE_POS,
+    }
+
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class OmxRecordGrabConfig:
+    robot: RobotConfig
+    dataset: DatasetRecordConfig
+    # Resume recording on an existing dataset.
+    resume: bool = False
+    # Fraction of episodes that start from a random stuck pose (gripper closed) to
+    # generate recovery data.  0.0 = disabled, 1.0 = all episodes are recovery starts.
+    recovery_prob: float = 0.5
+
+
+def record_episode_spline(
+    robot: OmxFollower,
+    waypoints: list[dict],
+    speeds: list[float],
+    dataset: LeRobotDataset,
+    task: str,
+) -> None:
+    """Execute a Catmull-Rom spline through waypoints, recording each frame.
+
+    Uses non-uniform chord-length parameterization for interior tangents and
+    clamped (zero-velocity) endpoints so the arm starts and stops smoothly.
+    Each segment is cubic Hermite, giving C1 continuity at every waypoint.
+    """
+    pts = [pose_to_array(w) for w in waypoints]
+    n = len(pts)
+
+    # Steps and duration per segment
+    n_steps_list = []
+    t = []
+    for i in range(n - 1):
+        max_dist = float(np.max(np.abs(pts[i + 1] - pts[i])))
+        ns = max(1, int(max_dist / speeds[i] * CONTROL_HZ)) if max_dist >= 0.5 else 0
+        n_steps_list.append(ns)
+        t.append(ns / CONTROL_HZ)
+
+    # Velocity tangents (deg/sec) — clamped at endpoints, Catmull-Rom for interior
+    vels = [np.zeros_like(pts[0])]
+    for i in range(1, n - 1):
+        v_prev = (pts[i] - pts[i - 1]) / t[i - 1] if t[i - 1] > 0 else np.zeros_like(pts[0])
+        v_next = (pts[i + 1] - pts[i]) / t[i] if t[i] > 0 else np.zeros_like(pts[0])
+        vels.append(0.5 * (v_prev + v_next))
+    vels.append(np.zeros_like(pts[0]))
+
+    dt = 1.0 / CONTROL_HZ
+    for seg in range(n - 1):
+        ns = n_steps_list[seg]
+        if ns == 0:
+            continue
+        p0, p1 = pts[seg], pts[seg + 1]
+        # Scale velocity (deg/sec) to t-space tangent (deg/t-unit, where t: 0→1 over ns steps)
+        m0 = vels[seg] * t[seg]
+        m1 = vels[seg + 1] * t[seg]
+
+        for step in range(1, ns + 1):
+            t = step / ns
+            h00 = 2 * t**3 - 3 * t**2 + 1
+            h10 = t**3 - 2 * t**2 + t
+            h01 = -2 * t**3 + 3 * t**2
+            h11 = t**3 - t**2
+            commanded = h00 * p0 + h10 * m0 + h01 * p1 + h11 * m1
+
+            action = array_to_pose(commanded)
+            obs = robot.get_observation()
+            obs_frame = build_dataset_frame(dataset.features, obs, prefix=OBS_STR)
+            action_frame = build_dataset_frame(dataset.features, action, prefix=ACTION)
+            dataset.add_frame({**obs_frame, **action_frame, "task": task})
+            robot.send_action(action)
+            precise_sleep(dt)
+
+
+def record_grab_episode(
+    robot: OmxFollower,
+    dataset: LeRobotDataset,
+    pan: float,
+    t: float,
+    task: str,
+    recovery_start: bool = False,
+) -> None:
+    """Execute a targeted grab to the stored (pan, t) position, recording every frame.
+
+    Normal sequence (initial HOME move is NOT recorded):
+      HOME → raised approach above cube → lower → close gripper
+           → raise [jittered] → retract [jittered] → GRAB_CARRY_POSE → drop → HOME
+
+    Recovery sequence (recovery_start=True): arm is moved to a random stuck pose
+    (gripper closed) without recording, then recording begins from there:
+      stuck_pose → raised approach above cube → [normal grab sequence from there]
+
+    All segments are joined by a Catmull-Rom spline (C1-continuous velocities).
+    """
+    sl = PUSH_START_SHOULDER_LIFT + t * (PUSH_END_SHOULDER_LIFT - PUSH_START_SHOULDER_LIFT)
+    ef = PUSH_START_ELBOW_FLEX + t * (PUSH_END_ELBOW_FLEX - PUSH_START_ELBOW_FLEX)
+    sl_raised = sl - GRAB_RAISE_SL_OFFSET
+    wf_horizontal = horizontal_wrist_flex(sl, ef)
+
+    rng = np.random.default_rng()
+
+    if recovery_start:
+        stuck_pose = _random_stuck_pose(rng)
+        logger.info(f"Recovery start: {stuck_pose}")
+        move_to_pose(robot, stuck_pose, APPROACH_SPEED)
+        first_waypoints = [stuck_pose]
+        first_speeds = []
+    else:
+        jittery_start = _jitter_pose(HOME_POSE, rng)
+        move_to_pose(robot, jittery_start, APPROACH_SPEED)
+        first_waypoints = [jittery_start]
+        first_speeds = []
+
+    waypoints = first_waypoints + [
+        {  # raised approach: arm above cube
+            "shoulder_pan.pos": pan,
+            "shoulder_lift.pos": sl_raised,
+            "elbow_flex.pos": ef,
+            "wrist_flex.pos": horizontal_wrist_flex(sl_raised, ef),
+            "wrist_roll.pos": 0.0,
+            "gripper.pos": 60.0,
+        },
+        {  # lower onto cube — no jitter: precision needed
+            "shoulder_pan.pos": pan,
+            "shoulder_lift.pos": sl,
+            "elbow_flex.pos": ef,
+            "wrist_flex.pos": wf_horizontal,
+            "wrist_roll.pos": 0.0,
+            "gripper.pos": 60.0,
+        },
+        {  # close gripper — no jitter: precision needed
+            "shoulder_pan.pos": pan,
+            "shoulder_lift.pos": sl,
+            "elbow_flex.pos": ef,
+            "wrist_flex.pos": wf_horizontal,
+            "wrist_roll.pos": 0.0,
+            "gripper.pos": GRIPPER_CLOSE_POS,
+        },
+        _jitter_pose(
+            {  # raise with cube
+                "shoulder_pan.pos": pan,
+                "shoulder_lift.pos": sl_raised,
+                "elbow_flex.pos": ef,
+                "wrist_flex.pos": horizontal_wrist_flex(sl_raised, ef),
+                "wrist_roll.pos": 0.0,
+                "gripper.pos": GRIPPER_CLOSE_POS,
+            },
+            rng,
+        ),
+        _jitter_pose(
+            {  # retract: fold arm toward HOME before sweeping to carry zone
+                "shoulder_pan.pos": pan * 0.25,
+                "shoulder_lift.pos": HOME_POSE["shoulder_lift.pos"] + 5.0,
+                "elbow_flex.pos": HOME_POSE["elbow_flex.pos"] - 5.0,
+                "wrist_flex.pos": 0.0,
+                "wrist_roll.pos": 0.0,
+                "gripper.pos": GRIPPER_CLOSE_POS,
+            },
+            rng,
+        ),
+        GRAB_CARRY_POSE,  # no jitter: target drop zone
+        {**GRAB_CARRY_POSE, "gripper.pos": 60.0},  # drop cube
+        HOME_POSE,
+    ]
+    speeds = first_speeds + [
+        RECORD_SPEED,  # (HOME →) raised approach
+        GRAB_LOWER_SPEED,  # raised approach → lower
+        GRAB_LOWER_SPEED,  # lower → close gripper
+        RECORD_SPEED,  # close gripper → raise
+        RECORD_SPEED,  # raise → retract
+        RECORD_SPEED,  # retract → carry pose
+        RECORD_SPEED,  # carry pose → drop
+        RECORD_SPEED,  # drop → HOME
+    ]
+
+    record_episode_spline(robot, waypoints, speeds, dataset, task)
+
+    # Dwell at HOME for ~0.5 s before next episode
+    home_action = build_dataset_frame(dataset.features, HOME_POSE, prefix=ACTION)
+    dt = 1.0 / CONTROL_HZ
+    for _ in range(int(CONTROL_HZ * 0.5)):
+        obs = robot.get_observation()
+        obs_frame = build_dataset_frame(dataset.features, obs, prefix=OBS_STR)
+        dataset.add_frame({**obs_frame, **home_action, "task": task})
+        precise_sleep(dt)
+
+
+@parser.wrap()
+def record_grab(cfg: OmxRecordGrabConfig) -> LeRobotDataset:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+    logger.info(pformat(cfg))
+
+    robot = make_robot_from_config(cfg.robot)
+    use_videos = cfg.dataset.video
+
+    _, _, robot_obs_processor = make_default_processors()
+    teleop_action_processor, _, _ = make_default_processors()
+
+    dataset_features = combine_feature_dicts(
+        aggregate_pipeline_dataset_features(
+            pipeline=teleop_action_processor,
+            initial_features=create_initial_features(action=robot.action_features),
+            use_videos=use_videos,
+        ),
+        aggregate_pipeline_dataset_features(
+            pipeline=robot_obs_processor,
+            initial_features=create_initial_features(observation=robot.observation_features),
+            use_videos=use_videos,
+        ),
+    )
+
+    num_cameras = len(robot.cameras) if hasattr(robot, "cameras") else 0
+    dataset = None
+
+    try:
+        if cfg.resume:
+            dataset = LeRobotDataset.resume(
+                cfg.dataset.repo_id,
+                root=cfg.dataset.root,
+                streaming_encoding=cfg.dataset.streaming_encoding,
+                batch_encoding_size=cfg.dataset.video_encoding_batch_size,
+                vcodec=cfg.dataset.vcodec,
+                encoder_threads=cfg.dataset.encoder_threads,
+                image_writer_processes=cfg.dataset.num_image_writer_processes if num_cameras > 0 else 0,
+                image_writer_threads=cfg.dataset.num_image_writer_threads_per_camera * num_cameras
+                if num_cameras > 0
+                else 0,
+            )
+        else:
+            cfg.dataset.stamp_repo_id()
+            dataset = LeRobotDataset.create(
+                cfg.dataset.repo_id,
+                cfg.dataset.fps,
+                root=cfg.dataset.root,
+                robot_type=robot.name,
+                features=dataset_features,
+                use_videos=use_videos,
+                streaming_encoding=cfg.dataset.streaming_encoding,
+                batch_encoding_size=cfg.dataset.video_encoding_batch_size,
+                vcodec=cfg.dataset.vcodec,
+                encoder_threads=cfg.dataset.encoder_threads,
+                image_writer_processes=cfg.dataset.num_image_writer_processes if num_cameras > 0 else 0,
+                image_writer_threads=cfg.dataset.num_image_writer_threads_per_camera * num_cameras
+                if num_cameras > 0
+                else 0,
+            )
+
+        robot.connect(calibrate=True)
+
+        rng = np.random.default_rng()
+        with VideoEncodingManager(dataset):
+            for episode_idx in range(cfg.dataset.num_episodes):
+                logger.info(f"=== Episode {episode_idx + 1}/{cfg.dataset.num_episodes} ===")
+
+                logger.info("Step 1: grabbing and placing cube...")
+                grab_cube(robot)
+                pan, t = place_cube(robot)
+                logger.info(f"Cube placed at pan={pan:.1f}, reach={t:.2f}")
+
+                recovery_start = cfg.recovery_prob > 0 and float(rng.random()) < cfg.recovery_prob
+                logger.info(f"Step 2: recording {'recovery ' if recovery_start else ''}grab episode...")
+                record_grab_episode(
+                    robot, dataset, pan, t, cfg.dataset.single_task, recovery_start=recovery_start
+                )
+
+                dataset.save_episode()
+                logger.info(f"Episode {episode_idx + 1} saved.")
+
+    finally:
+        if dataset:
+            dataset.finalize()
+        if robot.is_connected:
+            robot.disconnect()
+
+    if cfg.dataset.push_to_hub and dataset and dataset.num_episodes > 0:
+        dataset.push_to_hub(tags=cfg.dataset.tags, private=cfg.dataset.private)
+
+    return dataset
+
+
+if __name__ == "__main__":
+    record_grab()

--- a/examples/omx/reset_environment.py
+++ b/examples/omx/reset_environment.py
@@ -5,12 +5,10 @@ Auto-reset and cube-grab utility for the OMX robot arm.
 Provides:
   - grab_cube(robot): sweep workspace, center cube, close gripper
   - place_cube(robot): carry cube to a random position, release
-  - reset_environment(robot): sweep workspace back to starting config
 
-Standalone usage:
-    python reset_environment.py --port /dev/ttyACM1 --mode reset
-    python reset_environment.py --port /dev/ttyACM1 --mode grab
-    python reset_environment.py --port /dev/ttyACM1 --mode grab_and_place
+Standalone usage (run from repo root):
+    python -m examples.omx.reset_environment --port /dev/ttyACM1 --mode grab
+    python -m examples.omx.reset_environment --port /dev/ttyACM1 --mode grab_and_place
 
 Joint range: -100 to 100 for arm joints; gripper: 50 = closed, 80 = open.
 
@@ -184,9 +182,9 @@ def grab_cube(robot: Robot) -> None:
 
     for pan, end_pan in [
         (SWEEP_LEFT_PAN, GRAB_PAN - SWEEP_END_OFFSET),
-        # (SWEEP_RIGHT_PAN, GRAB_PAN + SWEEP_END_OFFSET),
+        (SWEEP_RIGHT_PAN, GRAB_PAN + SWEEP_END_OFFSET),
     ]:
-        logging.info(f"Sweeping {'left' if pan < 0 else 'right'} → center...")
+        logger.info(f"Sweeping {'left' if pan < 0 else 'right'} → center...")
         move_to_pose(robot, _high_sweep_pose(pan), APPROACH_SPEED)
         move_to_pose(
             robot, _low_sweep_pose(pan, SWEEP_LOW_ELBOW_FLEX_START, wrist_flex=-20.0), APPROACH_SPEED
@@ -194,22 +192,26 @@ def grab_cube(robot: Robot) -> None:
         move_to_pose(robot, _low_sweep_pose(end_pan, SWEEP_LOW_ELBOW_FLEX_END, wrist_flex=0.0), SWEEP_SPEED)
         move_to_pose(robot, HOME_POSE, APPROACH_SPEED)
 
-    logging.info("Extending to push cube into gripper...")
+    logger.info("Extending to push cube into gripper...")
     move_to_pose(
-        robot, _push_pose(PUSH_START_SHOULDER_LIFT - PUSH_RAISE_OFFSET, PUSH_START_ELBOW_FLEX), APPROACH_SPEED
+        robot,
+        _push_pose(PUSH_START_SHOULDER_LIFT - PUSH_RAISE_OFFSET, PUSH_START_ELBOW_FLEX),
+        APPROACH_SPEED,
     )
     move_to_pose(
-        robot, _push_pose(PUSH_END_SHOULDER_LIFT - PUSH_RAISE_OFFSET, PUSH_END_ELBOW_FLEX), SWEEP_SPEED
+        robot,
+        _push_pose(PUSH_END_SHOULDER_LIFT - PUSH_RAISE_OFFSET, PUSH_END_ELBOW_FLEX),
+        SWEEP_SPEED,
     )
 
-    logging.info("Closing gripper...")
+    logger.info("Closing gripper...")
     move_to_pose(
         robot,
         _push_pose(PUSH_END_SHOULDER_LIFT, PUSH_END_ELBOW_FLEX, gripper=GRIPPER_CLOSE_POS),
         APPROACH_SPEED,
     )
 
-    logging.info("Grab complete.")
+    logger.info("Grab complete.")
 
 
 def place_cube(robot: Robot) -> tuple[float, float]:
@@ -222,7 +224,7 @@ def place_cube(robot: Robot) -> tuple[float, float]:
     t = float(np.random.uniform(*PLACE_REACH_RANGE))
     sl = PUSH_START_SHOULDER_LIFT + t * (PUSH_END_SHOULDER_LIFT - PUSH_START_SHOULDER_LIFT)
     ef = PUSH_START_ELBOW_FLEX + t * (PUSH_END_ELBOW_FLEX - PUSH_START_ELBOW_FLEX)
-    logging.info(f"Placing cube at pan={pan:.1f}, reach={t:.2f}...")
+    logger.info(f"Placing cube at pan={pan:.1f}, reach={t:.2f}...")
 
     move_to_pose(robot, {**HOME_POSE, "gripper.pos": GRIPPER_CLOSE_POS}, APPROACH_SPEED)
     move_to_pose(
@@ -230,24 +232,9 @@ def place_cube(robot: Robot) -> tuple[float, float]:
     )
     move_to_pose(robot, _push_pose(sl, ef, pan=pan, gripper=GRIPPER_CLOSE_POS), APPROACH_SPEED)
     move_to_pose(robot, _push_pose(sl, ef, pan=pan, gripper=80.0), APPROACH_SPEED)
-    precise_sleep(0.5)  # let the cube settle before pulling away
     move_to_pose(robot, HOME_POSE, APPROACH_SPEED)
-    logging.info("Place complete.")
+    logger.info("Place complete.")
     return pan, t
-
-
-def reset_environment(robot: Robot) -> None:
-    """Sweep the workspace and return to HOME."""
-    pan = float(np.random.uniform(*SWEEP_END_PAN_RANGE))
-    waypoints = [*SWEEP_WAYPOINTS[:-1], {**SWEEP_WAYPOINTS[-1], "shoulder_pan.pos": pan}]
-
-    move_to_pose(robot, HOME_POSE, APPROACH_SPEED)
-    for i, waypoint in enumerate(waypoints):
-        logging.info(f"Waypoint {i + 1}/{len(waypoints)}...")
-        move_to_pose(robot, waypoint, APPROACH_SPEED if i == 0 else SWEEP_SPEED)
-    move_to_pose(robot, HOME_POSE, APPROACH_SPEED)
-
-    logging.info("Reset complete.")
 
 
 # ── Entry point ───────────────────────────────────────────────────────────────
@@ -257,21 +244,21 @@ def main():
     parser = argparse.ArgumentParser(description="OMX arm reset / grab script")
     parser.add_argument("--port", default="/dev/ttyACM1")
     parser.add_argument("--robot_id", default="omx_follower")
-    parser.add_argument("--mode", choices=["reset", "grab", "grab_and_place"], default="reset")
+    parser.add_argument("--mode", choices=["grab", "grab_and_place"], default="grab_and_place")
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 
     robot = OmxFollower(OmxFollowerConfig(port=args.port, id=args.robot_id))
     robot.connect(calibrate=True)
+
     try:
         if args.mode == "grab":
             grab_cube(robot)
         elif args.mode == "grab_and_place":
             grab_cube(robot)
             place_cube(robot)
-        else:
-            reset_environment(robot)
+
     finally:
         robot.disconnect()
 

--- a/examples/omx/reset_environment.py
+++ b/examples/omx/reset_environment.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""
+Auto-reset and cube-grab utility for the OMX robot arm.
+
+Provides:
+  - grab_cube(robot): sweep workspace, center cube, close gripper
+  - place_cube(robot): carry cube to a random position, release
+  - reset_environment(robot): sweep workspace back to starting config
+
+Standalone usage:
+    python reset_environment.py --port /dev/ttyACM1 --mode reset
+    python reset_environment.py --port /dev/ttyACM1 --mode grab
+    python reset_environment.py --port /dev/ttyACM1 --mode grab_and_place
+
+Joint range: -100 to 100 for arm joints; gripper: 50 = closed, 80 = open.
+
+To read current joint values for calibration, add after robot.connect():
+    obs = robot.get_observation()
+    print({k: round(obs[k], 1) for k in JOINT_NAMES})
+    robot.disconnect(); raise SystemExit
+
+Parallel-to-ground IK: wrist_flex = WRIST_HORIZONTAL_OFFSET - shoulder_lift - elbow_flex.
+Linear interpolation preserves this constraint between any two poses that satisfy it.
+"""
+
+import argparse
+import logging
+
+import numpy as np
+
+from lerobot.robots.omx_follower import OmxFollower, OmxFollowerConfig
+from lerobot.robots.robot import Robot
+from lerobot.utils.robot_utils import precise_sleep
+
+logger = logging.getLogger(__name__)
+
+# ── Poses ─────────────────────────────────────────────────────────────────────
+
+HOME_POSE = {
+    "shoulder_pan.pos": 0.0,
+    "shoulder_lift.pos": -50.0,
+    "elbow_flex.pos": 50.0,
+    "wrist_flex.pos": 0.0,
+    "wrist_roll.pos": 0.0,
+    "gripper.pos": 60.0,
+}
+
+SWEEP_WAYPOINTS = [
+    {
+        "shoulder_pan.pos": -60.0,
+        "shoulder_lift.pos": 50.0,
+        "elbow_flex.pos": -60.0,
+        "wrist_flex.pos": -20.0,
+        "wrist_roll.pos": 0.0,
+        "gripper.pos": 60.0,
+    },
+    {
+        "shoulder_pan.pos": -30.0,
+        "shoulder_lift.pos": 50.0,
+        "elbow_flex.pos": -60.0,
+        "wrist_flex.pos": -5.0,
+        "wrist_roll.pos": 0.0,
+        "gripper.pos": 60.0,
+    },
+    {
+        "shoulder_pan.pos": 20.0,
+        "shoulder_lift.pos": 50.0,
+        "elbow_flex.pos": -55.0,
+        "wrist_flex.pos": -5.0,
+        "wrist_roll.pos": 0.0,
+        "gripper.pos": 60.0,
+    },
+]
+
+# ── Motion parameters ─────────────────────────────────────────────────────────
+
+CONTROL_HZ = 30
+APPROACH_SPEED = 50.0
+SWEEP_SPEED = 40.0
+
+# ── Grab-sequence parameters ──────────────────────────────────────────────────
+
+GRAB_PAN = 0.0
+SWEEP_LEFT_PAN = -60.0
+SWEEP_RIGHT_PAN = 60.0
+SWEEP_END_OFFSET = 5.0  # stop before center so the cube isn't pushed past GRAB_PAN
+SWEEP_END_PAN_RANGE = (15.0, 20.0)
+
+SWEEP_LOW_SHOULDER_LIFT = 50.0
+SWEEP_LOW_ELBOW_FLEX_START = -60.0
+SWEEP_LOW_ELBOW_FLEX_END = -55.0
+
+SWEEP_HIGH_WRIST_FLEX = -20.0  # wrist tilted up during high approach to clear obstacles
+
+PUSH_START_SHOULDER_LIFT = 0.0
+PUSH_START_ELBOW_FLEX = 45.0
+PUSH_END_SHOULDER_LIFT = 50.0
+PUSH_END_ELBOW_FLEX = -50.0
+# Subtracted from shoulder_lift during the push sweep to clear the platform surface.
+# Does not affect the grab-target interpolation in record_grab.py.
+PUSH_RAISE_OFFSET = 5.0
+
+WRIST_HORIZONTAL_OFFSET = 0.0  # tune if gripper tilts during push: + tilts nose up, - down
+GRIPPER_CLOSE_POS = 50.0
+
+PLACE_LEFT_PAN_RANGE = (5.0, 30.0)  # random pan range for cube placement on the left side
+PLACE_REACH_RANGE = (0.1, 0.7)  # 0 = arm retracted (PUSH_START), 1 = fully extended (PUSH_END)
+
+JOINT_NAMES = [
+    "shoulder_pan.pos",
+    "shoulder_lift.pos",
+    "elbow_flex.pos",
+    "wrist_flex.pos",
+    "wrist_roll.pos",
+    "gripper.pos",
+]
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def pose_to_array(pose: dict) -> np.ndarray:
+    return np.array([pose[k] for k in JOINT_NAMES])
+
+
+def array_to_pose(arr: np.ndarray) -> dict:
+    return {k: float(arr[i]) for i, k in enumerate(JOINT_NAMES)}
+
+
+def horizontal_wrist_flex(shoulder_lift: float, elbow_flex: float) -> float:
+    return WRIST_HORIZONTAL_OFFSET - shoulder_lift - elbow_flex
+
+
+def _low_sweep_pose(pan: float, elbow_flex: float, wrist_flex: float | None = None) -> dict:
+    sl = SWEEP_LOW_SHOULDER_LIFT
+    return {
+        "shoulder_pan.pos": pan,
+        "shoulder_lift.pos": sl,
+        "elbow_flex.pos": elbow_flex,
+        "wrist_flex.pos": horizontal_wrist_flex(sl, elbow_flex) if wrist_flex is None else wrist_flex,
+        "wrist_roll.pos": 0.0,
+        "gripper.pos": 60.0,
+    }
+
+
+def _high_sweep_pose(pan: float) -> dict:
+    return {**HOME_POSE, "shoulder_pan.pos": pan, "wrist_flex.pos": SWEEP_HIGH_WRIST_FLEX}
+
+
+def _push_pose(shoulder_lift: float, elbow_flex: float, pan: float = GRAB_PAN, gripper: float = 70.0) -> dict:
+    return {
+        "shoulder_pan.pos": pan,
+        "shoulder_lift.pos": shoulder_lift,
+        "elbow_flex.pos": elbow_flex,
+        "wrist_flex.pos": horizontal_wrist_flex(shoulder_lift, elbow_flex),
+        "wrist_roll.pos": 0.0,
+        "gripper.pos": gripper,
+    }
+
+
+def move_to_pose(robot: Robot, target: dict, speed: float) -> None:
+    """Interpolate from current position to target at the given speed (units/s)."""
+    obs = robot.get_observation()
+    current = np.array([obs[k] for k in JOINT_NAMES])
+    goal = pose_to_array(target)
+
+    max_distance = float(np.max(np.abs(goal - current)))
+    if max_distance < 0.5:
+        return
+
+    n_steps = max(1, int(max_distance / speed * CONTROL_HZ))
+    dt = 1.0 / CONTROL_HZ
+    for step in range(1, n_steps + 1):
+        t = step / n_steps
+        robot.send_action(array_to_pose(current + t * (goal - current)))
+        precise_sleep(dt)
+
+
+# ── Sequences ─────────────────────────────────────────────────────────────────
+
+
+def grab_cube(robot: Robot) -> None:
+    """Left sweep → right sweep → extend arm parallel to ground → close gripper."""
+    move_to_pose(robot, HOME_POSE, APPROACH_SPEED)
+
+    for pan, end_pan in [
+        (SWEEP_LEFT_PAN, GRAB_PAN - SWEEP_END_OFFSET),
+        # (SWEEP_RIGHT_PAN, GRAB_PAN + SWEEP_END_OFFSET),
+    ]:
+        logging.info(f"Sweeping {'left' if pan < 0 else 'right'} → center...")
+        move_to_pose(robot, _high_sweep_pose(pan), APPROACH_SPEED)
+        move_to_pose(
+            robot, _low_sweep_pose(pan, SWEEP_LOW_ELBOW_FLEX_START, wrist_flex=-20.0), APPROACH_SPEED
+        )
+        move_to_pose(robot, _low_sweep_pose(end_pan, SWEEP_LOW_ELBOW_FLEX_END, wrist_flex=0.0), SWEEP_SPEED)
+        move_to_pose(robot, HOME_POSE, APPROACH_SPEED)
+
+    logging.info("Extending to push cube into gripper...")
+    move_to_pose(
+        robot, _push_pose(PUSH_START_SHOULDER_LIFT - PUSH_RAISE_OFFSET, PUSH_START_ELBOW_FLEX), APPROACH_SPEED
+    )
+    move_to_pose(
+        robot, _push_pose(PUSH_END_SHOULDER_LIFT - PUSH_RAISE_OFFSET, PUSH_END_ELBOW_FLEX), SWEEP_SPEED
+    )
+
+    logging.info("Closing gripper...")
+    move_to_pose(
+        robot,
+        _push_pose(PUSH_END_SHOULDER_LIFT, PUSH_END_ELBOW_FLEX, gripper=GRIPPER_CLOSE_POS),
+        APPROACH_SPEED,
+    )
+
+    logging.info("Grab complete.")
+
+
+def place_cube(robot: Robot) -> tuple[float, float]:
+    """Carry the cube (gripper closed) to a random position on the left side, then release.
+
+    Returns:
+        (pan, t): pan angle and reach scalar [0, 1] of the placement position.
+    """
+    pan = float(np.random.uniform(*PLACE_LEFT_PAN_RANGE))
+    t = float(np.random.uniform(*PLACE_REACH_RANGE))
+    sl = PUSH_START_SHOULDER_LIFT + t * (PUSH_END_SHOULDER_LIFT - PUSH_START_SHOULDER_LIFT)
+    ef = PUSH_START_ELBOW_FLEX + t * (PUSH_END_ELBOW_FLEX - PUSH_START_ELBOW_FLEX)
+    logging.info(f"Placing cube at pan={pan:.1f}, reach={t:.2f}...")
+
+    move_to_pose(robot, {**HOME_POSE, "gripper.pos": GRIPPER_CLOSE_POS}, APPROACH_SPEED)
+    move_to_pose(
+        robot, {**HOME_POSE, "shoulder_pan.pos": pan, "gripper.pos": GRIPPER_CLOSE_POS}, APPROACH_SPEED
+    )
+    move_to_pose(robot, _push_pose(sl, ef, pan=pan, gripper=GRIPPER_CLOSE_POS), APPROACH_SPEED)
+    move_to_pose(robot, _push_pose(sl, ef, pan=pan, gripper=80.0), APPROACH_SPEED)
+    precise_sleep(0.5)  # let the cube settle before pulling away
+    move_to_pose(robot, HOME_POSE, APPROACH_SPEED)
+    logging.info("Place complete.")
+    return pan, t
+
+
+def reset_environment(robot: Robot) -> None:
+    """Sweep the workspace and return to HOME."""
+    pan = float(np.random.uniform(*SWEEP_END_PAN_RANGE))
+    waypoints = [*SWEEP_WAYPOINTS[:-1], {**SWEEP_WAYPOINTS[-1], "shoulder_pan.pos": pan}]
+
+    move_to_pose(robot, HOME_POSE, APPROACH_SPEED)
+    for i, waypoint in enumerate(waypoints):
+        logging.info(f"Waypoint {i + 1}/{len(waypoints)}...")
+        move_to_pose(robot, waypoint, APPROACH_SPEED if i == 0 else SWEEP_SPEED)
+    move_to_pose(robot, HOME_POSE, APPROACH_SPEED)
+
+    logging.info("Reset complete.")
+
+
+# ── Entry point ───────────────────────────────────────────────────────────────
+
+
+def main():
+    parser = argparse.ArgumentParser(description="OMX arm reset / grab script")
+    parser.add_argument("--port", default="/dev/ttyACM1")
+    parser.add_argument("--robot_id", default="omx_follower")
+    parser.add_argument("--mode", choices=["reset", "grab", "grab_and_place"], default="reset")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+    robot = OmxFollower(OmxFollowerConfig(port=args.port, id=args.robot_id))
+    robot.connect(calibrate=True)
+    try:
+        if args.mode == "grab":
+            grab_cube(robot)
+        elif args.mode == "grab_and_place":
+            grab_cube(robot)
+            place_cube(robot)
+        else:
+            reset_environment(robot)
+    finally:
+        robot.disconnect()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Adding examples and scripts for the physicial omx setup

We built a physical setup with an `omx` arm to enforce hardware testing and to avoid future regression.

This PR introduces:
- some data recording scripts with auto env reset. (we could use this later on if we deploy a proper physical CI on this setup). 
- some instructions on recording data, training, rollout
- documenting existing collected dataset and working model on this particular physical setup for later validation

## How was this tested (or how to run locally)

Ran both added scripts:
```bash
python -m examples.omx.reset_environment --port $ROBOT_PORT --mode grab_and_place
```

```bash
python -m examples.omx.record_grab \
    --robot.type=omx_follower \
    --robot.port=$ROBOT_PORT \
    --robot.id=omx_follower \
    --robot.cameras="$ROBOT_CAMERAS" \
    --dataset.repo_id=$HF_USERNAME/omx_pickandplace \
    --dataset.root=data/omx_collect \
    --dataset.num_episodes=50 \
    --dataset.single_task="Pick the cube and place it in the blue square" \
    --dataset.streaming_encoding=true \
    --dataset.push_to_hub=true
```

Then successfully ran all the instruction from the newly introduced `examples/omx/README.md`

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated
- [x] CI is green

## Reviewer notes

- /!\ added `__init__.py` to the `examples` folder (to be able to use local imports from within the example folder). Need to think about if this is a good idea or not.