### PR TITLE
fix(opencv): prevent background thread crash during camera disconnect

### DIFF
--- a/src/lerobot/cameras/opencv/camera_opencv.py
+++ b/src/lerobot/cameras/opencv/camera_opencv.py
@@ -480,7 +480,6 @@ class OpenCVCamera(Camera):
             self.thread.join(timeout=2.0)
 
         self.thread = None
-        self.stop_event = None
 
         with self.frame_lock:
             self.latest_frame = None


### PR DESCRIPTION
## Summary / Motivation

Removes `self.stop_event = None` from `_stop_read_thread()` to resolve a race condition that crashes the background read loop with `AttributeError: 'NoneType' object has no attribute 'is_set'`.

The crash occurs because the thread can still evaluate `self.stop_event.is_set() `after cleanup begins, particularly during `thread.join(timeout=2.0)` delays, rapid connect/disconnect cycles, or warmup failures. By keeping the `Event `object persistent throughout the camera's lifecycle, the thread cleanly exits on its next loop iteration once `.set()` is called. This aligns with standard Python threading patterns and eliminates the need for defensive None checks in the read loop.

## Related issues

- Fixes / Closes: #3569
- Related: #3012

## What changed

Removed `self.stop_event = None` from `_stop_read_thread()` to eliminate the race condition that terminated the background read thread unexpectedly during cleanup.

**Breaking changes**: None. The public API and runtime behavior remain identical; this is a pure internal bug fix. No migration steps required.

## How was this tested (or how to run locally)

This can be tested by simply connecting a webcam and running:

```shell
lerobot-find-cameras opencv
```

## Checklist (required before merge)

- [X] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: # (insert PR number/link)
