### PR TITLE
fix: add lora_alpha field to PeftConfig (fixes #3551)

### DIFF
--- a/src/lerobot/configs/default.py
+++ b/src/lerobot/configs/default.py
@@ -106,3 +106,7 @@ class PeftConfig:
     # the rank used for the adapter. In general a higher rank means more trainable parameters and closer to full
     # fine-tuning.
     r: int = 16
+
+    # LoRA scaling factor. When using higher ranks (r > 8), the default alpha=8 dampens the adapter
+    # contribution because PEFT scales by alpha/r. Set to match r for rank-proportional scaling.
+    lora_alpha: int = 8


### PR DESCRIPTION
## Problem

`PeftConfig` in `src/lerobot/configs/default.py` was missing `lora_alpha`, causing PEFT's `LoraConfig` to default alpha to 8 regardless of rank. At higher ranks (e.g., r=64), this results in scaling alpha/r = 0.125, dampening adapter contribution 8x and causing near-static robot behavior at deployment.

## Fix

Add `lora_alpha: int = 8` to `PeftConfig`, keeping backward compatibility (default 8) while allowing users to set `--peft.lora_alpha=64` (or any value) to match their chosen rank.

Closes #3551