### PR TITLE
fix(config): add lora_alpha to PeftConfig

### DIFF
--- a/docs/source/peft_training.mdx
+++ b/docs/source/peft_training.mdx
@@ -28,7 +28,8 @@ lerobot-train \
  --steps=100000 \
  --batch_size=32 \
  --peft.method_type=LORA \
- --peft.r=64
+ --peft.r=64 \
+ --peft.lora_alpha=64
 ```
 
 Note the `--peft.method_type` parameter that let's you select which PEFT method to use. Here we use

--- a/docs/source/peft_training.mdx
+++ b/docs/source/peft_training.mdx
@@ -35,7 +35,8 @@ lerobot-train \
 Note the `--peft.method_type` parameter that let's you select which PEFT method to use. Here we use
 [LoRA](https://huggingface.co/docs/peft/main/en/package_reference/lora) (Low-Rank Adapter) which is probably the most
 popular fine-tuning method to date. Low-rank adaption means that we only fine-tune a matrix with comparably low rank
-instead of the full weight matrix. This rank can be specified using the `--peft.r` parameter. The higher the rank
+instead of the full weight matrix. This rank can be specified using the `--peft.r` parameter, and the LoRA scaling factor with
+`--peft.lora_alpha` (where `scaling = lora_alpha / r`). The higher the rank
 the closer you get to full fine-tuning
 
 There are more complex methods that have more parameters. These are not yet supported, feel free to raise an issue

--- a/src/lerobot/configs/default.py
+++ b/src/lerobot/configs/default.py
@@ -117,3 +117,8 @@ class PeftConfig:
     # the rank used for the adapter. In general a higher rank means more trainable parameters and closer to full
     # fine-tuning.
     r: int = 16
+
+    # Alpha parameter for LoRA scaling. In general, a higher alpha means stronger adaptation signal.
+    # If None, the PEFT library defaults to alpha=8, which may dampen high-rank adapters.
+    # Common values are r (alpha == rank) or 2*r.
+    lora_alpha: int | None = None

--- a/src/lerobot/configs/default.py
+++ b/src/lerobot/configs/default.py
@@ -118,7 +118,8 @@ class PeftConfig:
     # fine-tuning.
     r: int = 16
 
-    # Alpha parameter for LoRA scaling. In general, a higher alpha means stronger adaptation signal.
+    # Alpha parameter for LoRA scaling (scaling = lora_alpha / r).
+    # In general, a higher alpha means stronger adaptation signal.
     # If None, the PEFT library defaults to alpha=8, which may dampen high-rank adapters.
     # Common values are r (alpha == rank) or 2*r.
     lora_alpha: int | None = None


### PR DESCRIPTION
PeftConfig was missing the `lora_alpha` field, causing the PEFT library to default to `alpha=8` regardless of the LoRA rank (`r`), which dampens the adaptation signal for high-rank adapters (e.g., `r=128`).

This adds `lora_alpha: int | None = None` to `PeftConfig`, allowing users to specify `--peft.lora_alpha <value>` on the CLI. The value flows through `dataclasses.asdict(cfg.peft)` → `LoraConfig(lora_alpha=...)`.

Closes #3551