### PR TITLE
fix: address remaining pickle deserialization vector in RL transport layer (CVE-2026-25874 supplement)

### DIFF
--- a/src/lerobot/transport/utils.py
+++ b/src/lerobot/transport/utils.py
@@ -18,7 +18,6 @@
 import io
 import json
 import logging
-import pickle  # nosec B403: Safe usage for internal serialization only
 from multiprocessing.synchronize import Event as MpEvent
 from queue import Queue
 from typing import Any
@@ -126,15 +125,24 @@ def bytes_to_state_dict(buffer: bytes) -> dict[str, torch.Tensor]:
 
 
 def python_object_to_bytes(python_object: Any) -> bytes:
-    return pickle.dumps(python_object)
+    """Serialize a JSON-safe object to bytes.
+
+    Uses JSON instead of pickle to prevent arbitrary code execution when
+    deserializing data received over unauthenticated gRPC channels (CVE-2026-25874).
+    The RL actor sends plain dicts of numeric stats (reward, step count, rates)
+    which are fully JSON-serializable.
+    """
+    return json.dumps(python_object).encode("utf-8")
 
 
 def bytes_to_python_object(buffer: bytes) -> Any:
-    bytes_buffer = io.BytesIO(buffer)
-    bytes_buffer.seek(0)
-    obj = pickle.load(bytes_buffer)  # nosec B301: Safe usage of pickle.load
-    # Add validation checks here
-    return obj
+    """Deserialize bytes produced by ``python_object_to_bytes``.
+
+    Uses JSON instead of pickle so that malicious payloads received over
+    unauthenticated gRPC (LearnerService.SendInteractions) cannot trigger
+    arbitrary code execution (CVE-2026-25874).
+    """
+    return json.loads(buffer.decode("utf-8"))
 
 
 def bytes_to_transitions(buffer: bytes) -> list[Transition]:

--- a/tests/async_inference/test_helpers.py
+++ b/tests/async_inference/test_helpers.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import math
-import pickle
 import time
 
 import pytest
@@ -129,24 +128,32 @@ def test_timed_observation_getters():
 
 
 def test_timed_data_deserialization_data_getters():
-    """TimedAction / TimedObservation survive a round-trip through ``pickle``.
+    """TimedAction / TimedObservation survive a round-trip through safe serialization.
 
-    The async-inference stack uses ``pickle.dumps`` to move these objects across
-    the gRPC boundary (see RobotClient.send_observation and PolicyServer.StreamActions).
-    This test ensures that the payload keeps its content intact after
-    the (de)serialization round-trip.
+    The async-inference stack uses safetensors+JSON (via safe_serialization.py) to
+    move these objects across the gRPC boundary (see RobotClient.send_observation and
+    PolicyServer.StreamActions). Pickle is no longer used over gRPC (CVE-2026-25874).
+    This test ensures that the payload keeps its content intact after the round-trip.
     """
+    pytest.importorskip("safetensors")
+    from lerobot.async_inference.safe_serialization import (
+        deserialize_actions,
+        deserialize_observation,
+        serialize_actions,
+        serialize_observation,
+    )
+
     ts = time.time()
 
     # ------------------------------------------------------------------
-    # TimedAction
+    # TimedAction — uses serialize_actions / deserialize_actions
     # ------------------------------------------------------------------
     original_action = torch.randn(6)
     ta_in = TimedAction(timestamp=ts, action=original_action, timestep=13)
 
-    # Serialize → bytes → deserialize
-    ta_bytes = pickle.dumps(ta_in)  # nosec
-    ta_out: TimedAction = pickle.loads(ta_bytes)  # nosec B301
+    # Serialize → bytes → deserialize using the safe serialization layer
+    ta_bytes = serialize_actions(ta_in)
+    ta_out: TimedAction = deserialize_actions(ta_bytes)
 
     # Identity & content checks
     assert math.isclose(ta_out.get_timestamp(), ts, rel_tol=0, abs_tol=1e-6)
@@ -154,13 +161,13 @@ def test_timed_data_deserialization_data_getters():
     torch.testing.assert_close(ta_out.get_action(), original_action)
 
     # ------------------------------------------------------------------
-    # TimedObservation
+    # TimedObservation — uses serialize_observation / deserialize_observation
     # ------------------------------------------------------------------
     obs_dict = {OBS_STATE: torch.arange(4).float()}
     to_in = TimedObservation(timestamp=ts, observation=obs_dict, timestep=7, must_go=True)
 
-    to_bytes = pickle.dumps(to_in)  # nosec
-    to_out: TimedObservation = pickle.loads(to_bytes)  # nosec B301
+    to_bytes = serialize_observation(to_in)
+    to_out: TimedObservation = deserialize_observation(to_bytes)
 
     assert math.isclose(to_out.get_timestamp(), ts, rel_tol=0, abs_tol=1e-6)
     assert to_out.get_timestep() == 7


### PR DESCRIPTION
## Summary

This PR addresses a **second unauthenticated pickle deserialization vector** not covered by #3048 (CVE-2026-25874).

### What #3048 fixes
PR #3048 replaces `pickle.loads()` in `async_inference/policy_server.py` and `async_inference/robot_client.py` with a safe `safetensors+JSON` serialization layer.

### What this PR fixes

**`src/lerobot/transport/utils.py` — `bytes_to_python_object()` (line 135)**

`LearnerService.SendInteractions()` in `learner_service.py` is an unauthenticated gRPC handler (note the `# TODO: authorize the request` comment) that receives bytes from a remote actor and places them directly into `interaction_message_queue`. Those bytes are consumed by `process_interaction_message()` in `learner.py`, which calls `bytes_to_python_object()` — which previously called `pickle.load()`.

Attack path:
```
attacker → gRPC port → LearnerService.SendInteractions (no auth)
         → interaction_message_queue
         → process_interaction_message()
         → bytes_to_python_object()
         → pickle.load()  ← RCE
```

The fix replaces `pickle` with `json` in both `python_object_to_bytes` and `bytes_to_python_object`. The RL actor only ever serializes plain dicts of numeric stats (episodic reward, step count, intervention rate) which are fully JSON-serializable, so this is a safe, non-breaking change.

### Files changed

| File | Change |
|------|--------|
| `src/lerobot/transport/utils.py` | Replace `pickle.dumps/load` with `json.dumps/loads` in `python_object_to_bytes` / `bytes_to_python_object`; remove `import pickle` |
| `tests/async_inference/test_helpers.py` | Update stale test that used raw `pickle` round-trips to use the `safe_serialization` helpers from #3048 instead |

### CVE reference
CVE-2026-25874 / GHSA-f7vj-73pm-m822 — supplements #3048

### All pickle callsites in the repo

| File:Line | Covered by |
|-----------|-----------|
| `src/lerobot/async_inference/policy_server.py:125,183` | PR #3048 |
| `src/lerobot/async_inference/robot_client.py:286` | PR #3048 |
| `src/lerobot/transport/utils.py:135` | **This PR** |
| `tests/async_inference/test_helpers.py:149,163` | **This PR** (test updated) |