### PR TITLE
fix: Calibration overflow protection (#3586)

### DIFF
--- a/src/lerobot/motors/motors_bus.py
+++ b/src/lerobot/motors/motors_bus.py
@@ -815,18 +815,36 @@ class SerialMotorsBus(MotorsBusBase):
         Returns:
             tuple[dict[str, Value], dict[str, Value]]: Two dictionaries *mins* and *maxes* with the
                 extreme values observed for each motor.
+
+        Raises:
+            ValueError: A motor's `Present_Position` crossed the 0/max encoder seam during recording,
+                meaning the chosen homing offset places the wrap inside the joint's mechanical travel.
+                The recorded `(min, max)` cannot represent such a range, so the caller is asked to
+                re-run calibration from a pose that moves the wrap outside the joint's travel.
         """
         motor_names = self._get_motors_list(motors)
+        resolutions = {
+            motor: self.model_resolution_table[self._get_motor_model(motor)] for motor in motor_names
+        }
 
         start_positions = self.sync_read("Present_Position", motor_names, normalize=False)
         mins = start_positions.copy()
         maxes = start_positions.copy()
+        prev_positions = start_positions.copy()
+        wrap_detected: dict[str, bool] = dict.fromkeys(motor_names, False)
 
         user_pressed_enter = False
         while not user_pressed_enter:
             positions = self.sync_read("Present_Position", motor_names, normalize=False)
+            for motor in motor_names:
+                # A jump larger than half the encoder resolution between two consecutive samples
+                # means Present_Position wrapped at the 0/max seam. Naive min()/max() on the
+                # modular value can't represent a range that spans the wrap, so flag it.
+                if abs(positions[motor] - prev_positions[motor]) > resolutions[motor] / 2:
+                    wrap_detected[motor] = True
             mins = {motor: min(positions[motor], min_) for motor, min_ in mins.items()}
             maxes = {motor: max(positions[motor], max_) for motor, max_ in maxes.items()}
+            prev_positions = positions
 
             if display_values:
                 print("\n-------------------------------------------")
@@ -840,6 +858,16 @@ class SerialMotorsBus(MotorsBusBase):
             if display_values and not user_pressed_enter:
                 # Move cursor up to overwrite the previous output
                 move_cursor_up(len(motor_names) + 3)
+
+        wrapped = [motor for motor, did_wrap in wrap_detected.items() if did_wrap]
+        if wrapped:
+            raise ValueError(
+                "Present_Position wrapped at the 0/max encoder seam during recording for motor(s):\n"
+                f"{pformat(wrapped)}\n"
+                "The pose chosen for `set_half_turn_homings` places the wrap inside these joints' "
+                "mechanical travel, so the recorded range cannot represent it. Re-run calibration "
+                "from a pose that places the wrap outside each joint's travel."
+            )
 
         same_min_max = [motor for motor in motor_names if mins[motor] == maxes[motor]]
         if same_min_max:

--- a/tests/motors/test_dynamixel.py
+++ b/tests/motors/test_dynamixel.py
@@ -387,10 +387,11 @@ def test_set_half_turn_homings(mock_motors, dummy_motors):
 
 
 def test_record_ranges_of_motion(mock_motors, dummy_motors):
+    # Consecutive deltas stay below max_res / 2 so they're not mistaken for a wrap.
     positions = {
         1: [351, 42, 1337],
-        2: [28, 3600, 2444],
-        3: [4002, 2999, 146],
+        2: [28, 1800, 3600],
+        3: [146, 2000, 4002],
     }
     expected_mins = {
         "dummy_1": 42,
@@ -414,3 +415,24 @@ def test_record_ranges_of_motion(mock_motors, dummy_motors):
     assert mock_motors.stubs[read_pos_stub].calls == 3
     assert mins == expected_mins
     assert maxes == expected_maxes
+
+
+def test_record_ranges_of_motion_raises_on_wrap(mock_motors, dummy_motors):
+    # dummy_2 sweeps across the 0/4095 seam (4080 -> 10), which naive min()/max() on a
+    # modular Present_Position cannot represent. The other motors stay clear of the wrap.
+    positions = {
+        1: [100, 200, 300],
+        2: [4080, 10, 50],
+        3: [1000, 1100, 1200],
+    }
+    mock_motors.build_sequential_sync_read_stub(*X_SERIES_CONTROL_TABLE["Present_Position"], positions)
+    with patch("lerobot.motors.motors_bus.enter_pressed", side_effect=[False, True]):
+        bus = DynamixelMotorsBus(port=mock_motors.port, motors=dummy_motors)
+        bus.connect(handshake=False)
+
+        with pytest.raises(ValueError, match=re.escape("Present_Position wrapped")) as exc_info:
+            bus.record_ranges_of_motion(display_values=False)
+
+    assert "dummy_2" in str(exc_info.value)
+    assert "dummy_1" not in str(exc_info.value)
+    assert "dummy_3" not in str(exc_info.value)

--- a/tests/motors/test_feetech.py
+++ b/tests/motors/test_feetech.py
@@ -491,10 +491,11 @@ def test_configure_motors_skips_phase_for_non_sts3215(mock_motors):
 
 
 def test_record_ranges_of_motion(mock_motors, dummy_motors):
+    # Consecutive deltas stay below max_res / 2 so they're not mistaken for a wrap.
     positions = {
         1: [351, 42, 1337],
-        2: [28, 3600, 2444],
-        3: [4002, 2999, 146],
+        2: [28, 1800, 3600],
+        3: [146, 2000, 4002],
     }
     expected_mins = {
         "dummy_1": 42,
@@ -518,3 +519,24 @@ def test_record_ranges_of_motion(mock_motors, dummy_motors):
     assert mock_motors.stubs[stub].calls == 3
     assert mins == expected_mins
     assert maxes == expected_maxes
+
+
+def test_record_ranges_of_motion_raises_on_wrap(mock_motors, dummy_motors):
+    # dummy_2 sweeps across the 0/4095 seam (4080 -> 10), which naive min()/max() on a
+    # modular Present_Position cannot represent. The other motors stay clear of the wrap.
+    positions = {
+        1: [100, 200, 300],
+        2: [4080, 10, 50],
+        3: [1000, 1100, 1200],
+    }
+    mock_motors.build_sequential_sync_read_stub(*STS_SMS_SERIES_CONTROL_TABLE["Present_Position"], positions)
+    with patch("lerobot.motors.motors_bus.enter_pressed", side_effect=[False, True]):
+        bus = FeetechMotorsBus(port=mock_motors.port, motors=dummy_motors)
+        bus.connect(handshake=False)
+
+        with pytest.raises(ValueError, match=re.escape("Present_Position wrapped")) as exc_info:
+            bus.record_ranges_of_motion(display_values=False)
+
+    assert "dummy_2" in str(exc_info.value)
+    assert "dummy_1" not in str(exc_info.value)
+    assert "dummy_3" not in str(exc_info.value)


### PR DESCRIPTION
# # Title fix(motors): detect encoder wrap in record_ranges_of_motion (#3586) ## Summary / Motivation `MotorsBus.record_ranges_of_motion` accumulated mins/maxes with naive `min()`/`max()` over modular `Present_Position` samples, so a calibration sweep that crossed the 0/max encoder seam silently produced a `(range_min, range_max)` band that couldn't cover the joint's actual mechanical travel. The fix detects wrap events during the sweep and fails fast with actionable guidance instead of returning a broken calibration. ## Related issues
- Fixes: #3586 ## What changed
- `record_ranges_of_motion` in `src/lerobot/motors/motors_bus.py` now tracks the previous sample per motor and flags any consecutive delta exceeding `model_resolution / 2` as a wrap event.
- On detection, it raises a `ValueError` listing the affected motors and pointing the user back to `set_half_turn_homings` so the wrap falls outside each joint's travel. ## How was this tested (or how to run locally)
- Added wrap-detection coverage in `tests/motors/test_dynamixel.py` and `tests/motors/test_feetech.py`.
- `uv run pytest -q tests/motors/test_dynamixel.py tests/motors/test_feetech.py` ## Checklist (required before merge)
- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [x] CI is green
- [ ] Community Review: reviewed another contributor's open PR and linked it here: # (insert PR number/link) ## Reviewer notes
- Focus on the wrap threshold (`model_resolution / 2`) and the error message wording, since the surfaced guidance is what users will act on. Closes https://github.com/huggingface/lerobot/issues/3586