### PR TITLE
fix(viz): handle 1D action/state in lerobot-dataset-viz

### DIFF
--- a/src/lerobot/scripts/lerobot_dataset_viz.py
+++ b/src/lerobot/scripts/lerobot_dataset_viz.py
@@ -154,13 +154,15 @@ def visualize_dataset(
                 rr.log(key, entity=img_entity)
 
             # display each dimension of action space (e.g. actuators command)
+            # atleast_1d so 1D features (single motor / single-dim action) don't blow up
+            # on `iteration over a 0-d tensor` after indexing the batch.
             if ACTION in batch:
-                for dim_idx, val in enumerate(batch[ACTION][i]):
+                for dim_idx, val in enumerate(torch.atleast_1d(batch[ACTION][i])):
                     rr.log(f"{ACTION}/{dim_idx}", rr.Scalars(val.item()))
 
             # display each dimension of observed state space (e.g. agent position in joint space)
             if OBS_STATE in batch:
-                for dim_idx, val in enumerate(batch[OBS_STATE][i]):
+                for dim_idx, val in enumerate(torch.atleast_1d(batch[OBS_STATE][i])):
                     rr.log(f"state/{dim_idx}", rr.Scalars(val.item()))
 
             if DONE in batch:


### PR DESCRIPTION
## Summary / Motivation

`lerobot-dataset-viz` crashes immediately for datasets with a single-dimensional action or observation state (e.g. one motor, or one scalar reading). Indexing the batch produces a 0-d tensor, and iterating over it raises `TypeError: iteration over a 0-d tensor`. Wrapping the tensor with `torch.atleast_1d` makes the 0-d case iterate as a single element while leaving the multi-dim path unchanged.

## Related issues

- Fixes #3415

## What changed

- `src/lerobot/scripts/lerobot_dataset_viz.py`: wrap `batch[ACTION][i]` and `batch[OBS_STATE][i]` in `torch.atleast_1d(...)` before iterating, so 1D features no longer crash with `iteration over a 0-d tensor`.

No behavioral change for datasets where action/state already have shape `(N, dim)`, since `atleast_1d` is a no-op for tensors with `ndim >= 1`.

## How was this tested (or how to run locally)

Quick repro of the bug and the fix (no dataset needed):

```python
import torch

# 0-d (what 1D action/state degenerates to after batch[...] [i])
t = torch.tensor(1.5)
list(enumerate(t))                       # TypeError: iteration over a 0-d tensor
list(enumerate(torch.atleast_1d(t)))     # [(0, tensor(1.5000))]

# Multi-dim case unchanged
t2 = torch.tensor([1.0, 2.0, 3.0])
list(enumerate(t2)) == list(enumerate(torch.atleast_1d(t2)))   # True
```

End-to-end repro from the original issue (one-motor robot plugin, record an episode, then `lerobot-dataset-viz --repo-id ... --episode-index 0`) now logs the single state/action dim instead of crashing.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [ ] All tests pass locally (`pytest`). `dataset_viz` has no dedicated unit test today; verified manually as above.
- [ ] Documentation updated. Not applicable, behavior fix only.
- [ ] CI is green
- [x] Community Review: I have reviewed another contributor's open PR and linked it here: #3540

## Reviewer notes

- Two-line change, both wrapping the existing iterables.
- Happy to add a regression test if you want one. `dataset_viz` doesn't currently have its own test file, so I left it out rather than scaffold one in this PR. Let me know if you'd prefer it bundled.