### PR TITLE
fix(deps): bump diffusers cap to <0.39.0 (GHSA-98h9-4798-4q5v)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,7 +144,7 @@ grpcio-dep = ["grpcio==1.73.1", "protobuf>=6.31.1,<6.32.0"]
 can-dep = ["python-can>=4.2.0,<5.0.0"]
 peft-dep = ["peft>=0.18.0,<1.0.0"]
 scipy-dep = ["scipy>=1.14.0,<2.0.0"]
-diffusers-dep = ["diffusers>=0.27.2,<0.36.0"]
+diffusers-dep = ["diffusers>=0.27.2,<0.39.0"]
 qwen-vl-utils-dep = ["qwen-vl-utils>=0.0.11,<0.1.0"]
 matplotlib-dep = ["matplotlib>=3.10.3,<4.0.0", "contourpy>=1.3.0,<2.0.0"] # NOTE: Explicitly listing contourpy helps the resolver converge faster.
 pyserial-dep = ["pyserial>=3.5,<4.0"]


### PR DESCRIPTION
## What

Bump the upper cap of the `diffusers-dep` extra from `<0.36.0` to `<0.39.0`.

```diff
-diffusers-dep = ["diffusers>=0.27.2,<0.36.0"]
+diffusers-dep = ["diffusers>=0.27.2,<0.39.0"]
```

## Why

`diffusers<0.38.0` is affected by **GHSA-98h9-4798-4q5v** (HIGH, CVSS 8.8) — a `trust_remote_code` bypass via `custom_pipeline` and local custom components. The fix landed in `diffusers==0.38.0`.

The current cap (`<0.36.0`) means any project that depends on `lerobot[diffusion]` or `lerobot[groot]` is forced onto a vulnerable diffusers, with no path to the patched version. Downstream Dependabot alerts (e.g. https://github.com/strands-labs/robots/security/dependabot, alert #15) cannot be closed until this cap moves.

## Compatibility analysis

`lerobot` only consumes a small, stable surface of the `diffusers` API. Auditing usages on `main`:

```
src/lerobot/optim/schedulers.py
  from diffusers.optimization import get_scheduler

src/lerobot/policies/diffusion/modeling_diffusion.py
  from diffusers.schedulers.scheduling_ddim import DDIMScheduler
  from diffusers.schedulers.scheduling_ddpm import DDPMScheduler

src/lerobot/policies/groot/action_head/cross_attention_dit.py
  from diffusers import ConfigMixin, ModelMixin
  from diffusers.configuration_utils import register_to_config
  from diffusers.models.attention import Attention, FeedForward
  from diffusers.models.embeddings import (...)
```

I reviewed the release notes for **0.36.0**, **0.37.0**, and **0.38.0** — none of these symbols were removed, renamed, signature-changed, or moved. The breaking-change items in those releases concern Stable Cascade, Qwen Image RoPE caching, Kandinsky 5, Chroma, Flax schedulers, torchao quantization config, etc. — none of them touch the schedulers / mixins / embeddings / optimization helpers that lerobot uses.

## Risk

Low. The cap is widened by 3 minor versions of an internal-mixin / scheduler surface that lerobot uses in a stable way. Major-version safety is preserved (`<0.39.0`).

## Validation

- One-line change in `pyproject.toml`.
- No source-code changes required.
- Diffusers 0.38.0 published 2026-05-01 on PyPI.

## Downstream

Closes the path for downstream consumers like `strands-labs/robots` (https://github.com/strands-labs/robots/pull/153) to fully resolve their Dependabot alerts.
