### PR TITLE
fix(motors): reject out-of-range Goal_Position writes with ValueError

### DIFF
--- a/src/lerobot/motors/motors_bus.py
+++ b/src/lerobot/motors/motors_bus.py
@@ -906,6 +906,40 @@ class SerialMotorsBus(MotorsBusBase):
 
         return unnormalized_values
 
+    def _check_goal_position_bounds(self, data_name: str, motor: str, int_value: int) -> None:
+        """Validate a ``Goal_Position`` write against the motor's calibrated range.
+
+        When ``normalize=True`` the value has already been clamped by
+        :py:meth:`_unnormalize`. When ``normalize=False`` the raw integer is
+        written through unchecked, which lets an out-of-range goal reach the
+        motor firmware. On Feetech STS3215 (and similar), the firmware then
+        silently clamps the goal to the nearest edge of
+        ``[Min_Position_Limit, Max_Position_Limit]``, drives toward that edge,
+        and enables torque even if the host had disabled it. See issue #3585.
+
+        Raising here surfaces the out-of-range write as a ``ValueError``
+        before it reaches the bus, so the caller can either pass an in-range
+        value or recalibrate.
+        """
+        if data_name != "Goal_Position":
+            return
+        if not self.calibration:
+            return
+        calib = self.calibration.get(motor)
+        if calib is None:
+            return
+        if int_value < calib.range_min or int_value > calib.range_max:
+            raise ValueError(
+                f"Cannot write Goal_Position={int_value} to motor '{motor}': "
+                f"value is outside the calibrated range "
+                f"[{calib.range_min}, {calib.range_max}]. Writing an "
+                f"out-of-range goal causes the motor firmware to silently "
+                f"clamp, drive toward the edge, and enable torque even if "
+                f"the host had disabled it (see issue #3585). Pass a value "
+                f"within the calibrated range, or update the calibration to "
+                f"cover this position."
+            )
+
     @abc.abstractmethod
     def _encode_sign(self, data_name: str, ids_values: dict[int, int]) -> dict[int, int]:
         pass
@@ -1087,6 +1121,8 @@ class SerialMotorsBus(MotorsBusBase):
         if normalize and data_name in self.normalized_data:
             int_value = self._unnormalize({id_: value})[id_]
 
+        self._check_goal_position_bounds(data_name, motor, int_value)
+
         int_value = self._encode_sign(data_name, {id_: int_value})[id_]
 
         err_msg = f"Failed to write '{data_name}' on {id_=} with '{int_value}' after {num_retry + 1} tries."
@@ -1247,6 +1283,9 @@ class SerialMotorsBus(MotorsBusBase):
         int_ids_values = {id_: int(val) for id_, val in raw_ids_values.items()}
         if normalize and data_name in self.normalized_data:
             int_ids_values = self._unnormalize(raw_ids_values)
+
+        for id_, int_value in int_ids_values.items():
+            self._check_goal_position_bounds(data_name, self._id_to_name(id_), int_value)
 
         int_ids_values = self._encode_sign(data_name, int_ids_values)
 

--- a/tests/motors/test_motors_bus.py
+++ b/tests/motors/test_motors_bus.py
@@ -23,6 +23,7 @@ pytest.importorskip("serial", reason="pyserial is required (install lerobot[hard
 
 from lerobot.motors.motors_bus import (
     Motor,
+    MotorCalibration,
     MotorNormMode,
     assert_same_address,
     get_address,
@@ -178,6 +179,107 @@ def test_write(data_name, id_, value, dummy_motors):
     mock__encode_sign.assert_called_once_with(data_name, {id_: value})
     if data_name in bus.normalized_data:
         mock__unnormalize.assert_called_once_with({id_: value})
+
+
+def _calibration_for(motor: str, id_: int, range_min: int, range_max: int) -> dict:
+    """Build a minimal :class:`MotorCalibration` dict keyed by motor name."""
+    return {
+        motor: MotorCalibration(
+            id=id_,
+            drive_mode=0,
+            homing_offset=0,
+            range_min=range_min,
+            range_max=range_max,
+        )
+    }
+
+
+def test_write_goal_position_out_of_calibrated_range_raises(dummy_motors):
+    """Regression for #3585: a Goal_Position write outside the calibrated
+    range must raise ``ValueError`` before the bus is touched.
+
+    The reported failure mode is a Feetech STS3215 motor that silently
+    clamps an out-of-range Goal_Position, drives toward the clamped edge,
+    and re-enables torque even after the host disabled it. Surface the
+    out-of-range value as a typed error instead of forwarding it.
+    """
+    bus = MockMotorsBus("/dev/dummy-port", dummy_motors)
+    bus.connect(handshake=False)
+    bus.calibration = _calibration_for("dummy_1", id_=1, range_min=2045, range_max=3919)
+
+    with (
+        patch.object(MockMotorsBus, "_write", return_value=(0, 0)) as mock__write,
+        patch.object(MockMotorsBus, "_encode_sign", return_value={1: 228}) as mock__encode_sign,
+        pytest.raises(ValueError, match=r"outside the calibrated range \[2045, 3919\]"),
+    ):
+        bus.write("Goal_Position", "dummy_1", 228, normalize=False)
+
+    mock__write.assert_not_called()
+    mock__encode_sign.assert_not_called()
+
+
+def test_write_goal_position_in_calibrated_range_succeeds(dummy_motors):
+    """A Goal_Position write inside the calibrated range must reach the bus."""
+    bus = MockMotorsBus("/dev/dummy-port", dummy_motors)
+    bus.connect(handshake=False)
+    bus.calibration = _calibration_for("dummy_1", id_=1, range_min=2045, range_max=3919)
+
+    with (
+        patch.object(MockMotorsBus, "_write", return_value=(0, 0)) as mock__write,
+        patch.object(MockMotorsBus, "_encode_sign", return_value={1: 3000}),
+    ):
+        bus.write("Goal_Position", "dummy_1", 3000, normalize=False)
+
+    mock__write.assert_called_once()
+
+
+def test_write_non_goal_position_skips_bounds_check(dummy_motors):
+    """Only Goal_Position participates in the bounds check. Other registers
+    (Goal_Velocity, Lock, etc.) must still write through unchanged even when
+    their value lies outside the calibrated position range."""
+    bus = MockMotorsBus("/dev/dummy-port", dummy_motors)
+    bus.connect(handshake=False)
+    bus.calibration = _calibration_for("dummy_1", id_=1, range_min=2045, range_max=3919)
+
+    with (
+        patch.object(MockMotorsBus, "_write", return_value=(0, 0)) as mock__write,
+        patch.object(MockMotorsBus, "_encode_sign", return_value={1: 10000}),
+    ):
+        bus.write("Goal_Velocity", "dummy_1", 10000, normalize=False)
+
+    mock__write.assert_called_once()
+
+
+def test_sync_write_goal_position_out_of_range_raises(dummy_motors):
+    """The same bounds check applies to :py:meth:`sync_write` per motor."""
+    bus = MockMotorsBus("/dev/dummy-port", dummy_motors)
+    bus.connect(handshake=False)
+    bus.calibration = _calibration_for("dummy_1", id_=1, range_min=2045, range_max=3919)
+
+    with (
+        patch.object(MockMotorsBus, "_sync_write", return_value=0) as mock__sync_write,
+        patch.object(MockMotorsBus, "_encode_sign", return_value={1: 228}),
+        pytest.raises(ValueError, match=r"outside the calibrated range \[2045, 3919\]"),
+    ):
+        bus.sync_write("Goal_Position", {"dummy_1": 228}, normalize=False)
+
+    mock__sync_write.assert_not_called()
+
+
+def test_write_goal_position_uncalibrated_motor_skips_check(dummy_motors):
+    """A motor with no calibration entry should not be rejected: callers may
+    intentionally bypass calibration for setup or diagnostics."""
+    bus = MockMotorsBus("/dev/dummy-port", dummy_motors)
+    bus.connect(handshake=False)
+    # bus.calibration is empty by default
+
+    with (
+        patch.object(MockMotorsBus, "_write", return_value=(0, 0)) as mock__write,
+        patch.object(MockMotorsBus, "_encode_sign", return_value={1: 228}),
+    ):
+        bus.write("Goal_Position", "dummy_1", 228, normalize=False)
+
+    mock__write.assert_called_once()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary / Motivation

`MotorsBus.write()` and `sync_write()` skip any bounds check on the value when `normalize=False`. The raw integer is forwarded to the bus, so an out-of-range `Goal_Position` reaches the motor firmware. On Feetech STS3215 (and similar) the firmware then silently clamps the goal to the nearest edge of `[Min_Position_Limit, Max_Position_Limit]`, drives toward that edge, and enables torque even when the host had just disabled it. The `Goal_Position` register on the bus is left at the value the host wrote, so above the bus there is no signal that the firmware substituted a different target.

This shows up as a hardware-fault-looking slam when `Present_Position` happens to sit outside `[Min, Max]` (most naturally arising from the companion calibration-wrap bug), and is very hard to root-cause from the visible register state.

Adding the bounds check at the host layer surfaces the unsafe write as a typed `ValueError` before it reaches the bus, so the caller can either pass an in-range value or recalibrate.

## Related issues

- Fixes: #3585

## What changed

- New private helper `MotorsBus._check_goal_position_bounds(data_name, motor, int_value)`. Validates `Goal_Position` writes against `calibration[motor].range_min` and `range_max`. Raises `ValueError` with the calibration context when the value falls outside that band.
- `MotorsBus.write()` calls the helper after the `_unnormalize` step and before `_encode_sign`.
- `MotorsBus.sync_write()` calls the helper per motor in the loop after `_unnormalize`.
- The helper is a no-op for non-`Goal_Position` registers, for buses without `self.calibration`, and for motors that are absent from the calibration dict, so setup, diagnostics, and any intentionally-uncalibrated paths are unaffected.
- Five regression tests added in `tests/motors/test_motors_bus.py`:
  - `test_write_goal_position_out_of_calibrated_range_raises` (the reported bug shape; `_write` is never reached)
  - `test_write_goal_position_in_calibrated_range_succeeds`
  - `test_write_non_goal_position_skips_bounds_check` (Goal_Velocity etc. unaffected)
  - `test_sync_write_goal_position_out_of_range_raises`
  - `test_write_goal_position_uncalibrated_motor_skips_check`

No breaking change to the public API. Callers that were already writing in-range values see no behavior change; callers that were writing out-of-range values now get a `ValueError` instead of a silent firmware-side clamp + torque-on.

## How was this tested

- New tests: `pytest -q tests/motors/test_motors_bus.py -k "goal_position or sync_write_goal"`
- Standalone Python repro (no lerobot install needed) that mirrors the bounds-check logic. Covers the bug repro, in-range happy path, both calibration boundaries, off-by-one above `range_max`, non-`Goal_Position` register bypass, uncalibrated bus bypass, and unknown-motor bypass. All 9 cases pass with the new helper applied and the bug reproduces under the pre-fix mirror.
- `ruff check` and `ruff format --check` clean on both modified files (one pre-existing `UP042` finding on `MotorNormMode(str, enum.Enum)` at `motors_bus.py:168` is not from this change).

I could not run the full `pytest tests` suite locally without the hardware extras installed; the new tests use the existing `MockMotorsBus` fixture so they should run cleanly under CI's `fast_tests.yml`.

## Checklist

- [x] Linting/formatting run (ruff clean on touched files)
- [ ] All tests pass locally (new tests verified via standalone repro; full suite needs the hardware extras and will run on CI)
- [ ] Documentation updated (no public API surface change, no doc update needed)

## AI Assistance Disclosure

This PR was drafted with AI assistance (Claude Code). I read the issue carefully (including the Test A / Test B repro the author provided), traced both `write()` and `sync_write()` end to end, confirmed via `_unnormalize` line 894 that the `normalize=True` path is already in-bounds by construction, audited every existing call site of `self.calibration` and `_id_to_name`, and verified the bounds-check logic against the issue's repro shape via a standalone Python mirror before adding the helper to the live module.