### PR TITLE
fix(dataset): cache parquet files in _copy_and_reindex_episodes_metadata

### DIFF
--- a/src/lerobot/datasets/dataset_tools.py
+++ b/src/lerobot/datasets/dataset_tools.py
@@ -69,7 +69,9 @@ from .video_utils import (
 )
 
 
-def _load_episode_with_stats(src_dataset: LeRobotDataset, episode_idx: int) -> dict:
+def _load_episode_with_stats(
+    src_dataset: LeRobotDataset, episode_idx: int, parquet_cache: dict[str, pd.DataFrame] | None = None
+) -> dict:
     """Load a single episode's metadata including stats from parquet file.
 
     Args:
@@ -84,7 +86,11 @@ def _load_episode_with_stats(src_dataset: LeRobotDataset, episode_idx: int) -> d
     file_idx = ep_meta["meta/episodes/file_index"]
 
     parquet_path = src_dataset.root / DEFAULT_EPISODES_PATH.format(chunk_index=chunk_idx, file_index=file_idx)
-    df = pd.read_parquet(parquet_path)
+    parquet_path_str = str(parquet_path)
+    if parquet_cache is not None and parquet_path_str in parquet_cache:
+        df = parquet_cache[parquet_path_str]
+    else:
+        df = pd.read_parquet(parquet_path)
 
     episode_row = df[df["episode_index"] == episode_idx].iloc[0]
 
@@ -851,11 +857,23 @@ def _copy_and_reindex_episodes_metadata(
 
     all_stats = []
     total_frames = 0
+    parquet_cache: dict[str, pd.DataFrame] = {}
+
+    for old_idx in episode_mapping:
+        src_episode = src_dataset.meta.episodes[old_idx]
+        chunk_idx = src_episode["meta/episodes/chunk_index"]
+        file_idx = src_episode["meta/episodes/file_index"]
+        parquet_path = src_dataset.root / DEFAULT_EPISODES_PATH.format(
+            chunk_index=chunk_idx, file_index=file_idx
+        )
+        parquet_path_str = str(parquet_path)
+        if parquet_path_str not in parquet_cache:
+            parquet_cache[parquet_path_str] = pd.read_parquet(parquet_path)
 
     for old_idx, new_idx in tqdm(
         sorted(episode_mapping.items(), key=lambda x: x[1]), desc="Processing episodes metadata"
     ):
-        src_episode_full = _load_episode_with_stats(src_dataset, old_idx)
+        src_episode_full = _load_episode_with_stats(src_dataset, old_idx, parquet_cache=parquet_cache)
 
         src_episode = src_dataset.meta.episodes[old_idx]
 

--- a/tests/datasets/test_dataset_tools.py
+++ b/tests/datasets/test_dataset_tools.py
@@ -15,9 +15,11 @@
 # limitations under the License.
 """Tests for dataset tools utilities."""
 
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import numpy as np
+import pandas as pd
 import pytest
 import torch
 
@@ -34,6 +36,7 @@ from lerobot.datasets.dataset_tools import (
     remove_feature,
     split_dataset,
 )
+from lerobot.datasets.utils import DEFAULT_EPISODES_PATH
 
 
 @pytest.fixture
@@ -239,6 +242,68 @@ def test_split_invalid_fractions(sample_dataset, tmp_path):
 
     with pytest.raises(ValueError, match="Split fractions must sum to <= 1.0"):
         split_dataset(sample_dataset, splits=splits, output_dir=tmp_path)
+
+
+def test_copy_and_reindex_episodes_metadata_reads_parquet_once_per_unique_file(tmp_path):
+    from lerobot.datasets import dataset_tools as dataset_tools_module
+
+    shared_chunk_idx = 0
+    shared_file_idx = 0
+    shared_path = tmp_path / DEFAULT_EPISODES_PATH.format(
+        chunk_index=shared_chunk_idx, file_index=shared_file_idx
+    )
+
+    episodes = [
+        {
+            "meta/episodes/chunk_index": shared_chunk_idx,
+            "meta/episodes/file_index": shared_file_idx,
+            "tasks": ["task_a"],
+            "length": 1,
+        }
+        for _ in range(3)
+    ]
+
+    src_dataset = SimpleNamespace(
+        root=tmp_path,
+        meta=SimpleNamespace(episodes=episodes, features={}),
+    )
+
+    class DummyMeta:
+        def __init__(self, root):
+            self.root = root
+            self.features = {}
+            self.tasks = []
+            self.info = SimpleNamespace()
+            self.saved_episodes = []
+
+        def _save_episode_metadata(self, episode_dict):
+            self.saved_episodes.append(episode_dict)
+
+        def finalize(self):
+            return None
+
+    dst_meta = DummyMeta(tmp_path / "dst")
+
+    episode_mapping = {0: 0, 1: 1, 2: 2}
+    data_metadata = {
+        0: {"data/chunk_index": 0, "data/file_index": 0, "dataset_from_index": 0, "dataset_to_index": 1},
+        1: {"data/chunk_index": 0, "data/file_index": 0, "dataset_from_index": 1, "dataset_to_index": 2},
+        2: {"data/chunk_index": 0, "data/file_index": 0, "dataset_from_index": 2, "dataset_to_index": 3},
+    }
+
+    parquet_df = pd.DataFrame({"episode_index": np.array([0, 1, 2])})
+
+    with (
+        patch.object(dataset_tools_module.pd, "read_parquet", return_value=parquet_df) as mock_read_parquet,
+        patch.object(dataset_tools_module, "write_info"),
+        patch.object(dataset_tools_module, "write_stats"),
+    ):
+        dataset_tools_module._copy_and_reindex_episodes_metadata(
+            src_dataset, dst_meta, episode_mapping, data_metadata, video_metadata=None
+        )
+
+    assert mock_read_parquet.call_count == 1
+    assert mock_read_parquet.call_args.args[0] == shared_path
 
 
 def test_split_empty(sample_dataset, tmp_path):


### PR DESCRIPTION
## Title

`fix(datasets): cache episodes parquet reads in metadata reindexing path`

## Summary / Motivation

This PR fixes a major performance bug in episode metadata reindexing for dataset editing flows (e.g. delete/split operations).  
Previously, `_copy_and_reindex_episodes_metadata` called `_load_episode_with_stats` for every episode, and `_load_episode_with_stats` re-ran `pd.read_parquet(...)` on each call. When many episodes are stored in the same episodes parquet file, this caused repeated full-file reads of the same file thousands of times.

On large datasets (e.g. ~10k episodes with ~130MB episodes parquet files), this resulted in pathological runtime (hours instead of seconds/minutes), with no functional benefit.

This change introduces a local parquet cache scoped to the metadata-copy function call, so each unique episodes parquet path is loaded once and reused across episodes mapped to that file.

No public API behavior is changed, and the fix is intentionally minimal.

## Related issues

- Fixes / Closes: N/A (please link issue number if one exists)
- Related: performance regression in `_copy_and_reindex_episodes_metadata` path for large datasets

## What changed

- Added optional cache parameter to `_load_episode_with_stats`:
  - `parquet_cache: dict[str, pd.DataFrame] | None = None`
- Preserved backward compatibility:
  - If `parquet_cache` is `None`, behavior remains unchanged (`pd.read_parquet(parquet_path)` fallback still used).
- Updated `_copy_and_reindex_episodes_metadata` to:
  - Build a local cache before the episode-processing loop.
  - Compute episodes parquet paths using `DEFAULT_EPISODES_PATH.format(chunk_index=..., file_index=...)`.
  - Load each unique parquet path once into `parquet_cache: dict[str, pd.DataFrame]`.
  - Pass cache into `_load_episode_with_stats(..., parquet_cache=parquet_cache)` on each loop iteration.
- Added regression test to verify read deduplication behavior:
  - `test_copy_and_reindex_episodes_metadata_reads_parquet_once_per_unique_file`
  - Mocks `pd.read_parquet` and asserts one call per unique shared file (not per episode).

### Behavioral impact

- Functional outputs are unchanged.
- Performance is significantly improved in workloads where many episodes share the same episodes parquet file.
- Cache is local (no global state), so no cross-call contamination risk.

### Breaking changes

- None.
- No public API changes.

## How was this tested (or how to run locally)

### Added test

- File: `tests/datasets/test_dataset_tools.py`
- Test: `test_copy_and_reindex_episodes_metadata_reads_parquet_once_per_unique_file`

### Command used

```bash
pytest -sv tests/datasets/test_dataset_tools.py::test_copy_and_reindex_episodes_metadata_reads_parquet_once_per_unique_file
```

### Result

- Passes (`1 passed`)

### What the test validates

- Multiple episodes mapped to the same `{chunk_index, file_index}` episodes parquet path.
- `pd.read_parquet` is called exactly once for that unique path.
- Metadata reindexing path still executes successfully with cached DataFrame.

## Reviewer notes

Please focus review on:

1. `src/lerobot/datasets/dataset_tools.py`
- `_load_episode_with_stats` cache branch and unchanged fallback branch.
- `_copy_and_reindex_episodes_metadata` preload loop and cache scoping.
- Path keying logic (`str(parquet_path)`).

2. `tests/datasets/test_dataset_tools.py`
- Mocking path for parquet reads via module-level `pd`.
- Regression assertion for call count.

Design choices were kept intentionally narrow:
- No global cache.
- No refactors outside targeted hot path.
- No changes to semantics, only elimination of redundant I/O.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] Targeted tests pass locally (`pytest -sv tests/datasets/test_dataset_tools.py::test_copy_and_reindex_episodes_metadata_reads_parquet_once_per_unique_file`)
- [ ] Full test suite pass locally (`pytest -sv ./tests`) when feasible
- [x] Documentation updated (not required; internal perf fix with no user-facing API change)
- [ ] CI is green
- [ ] Community Review: reviewed another contributor PR and linked it
