### PR TITLE
Set OpenCV fourcc after size and fps

### DIFF
--- a/src/lerobot/cameras/opencv/camera_opencv.py
+++ b/src/lerobot/cameras/opencv/camera_opencv.py
@@ -224,6 +224,8 @@ class OpenCVCamera(Camera):
             self._validate_fps()
 
         if self.config.fourcc is not None and set_fourcc_after_size_and_fps:
+            # On Windows with DSHOW, changing the resolution can silently override the FOURCC setting.
+            # Set FOURCC last to make sure the requested pixel format is actually enforced.
             self._validate_fourcc()
 
     def _validate_fps(self) -> None:

--- a/src/lerobot/cameras/opencv/camera_opencv.py
+++ b/src/lerobot/cameras/opencv/camera_opencv.py
@@ -185,8 +185,7 @@ class OpenCVCamera(Camera):
 
         This method attempts to set the camera properties via OpenCV. It checks if
         the camera successfully applied the settings and raises an error if not.
-        The camera properties are set in the same order used by direct OpenCV capture tests:
-        width, height, FPS, then FOURCC.
+        FOURCC is set first (if specified) as it can affect the available FPS and resolution options.
 
         Args:
             fourcc: The desired FOURCC code (e.g., "MJPG", "YUYV"). If None, auto-detect.
@@ -202,6 +201,10 @@ class OpenCVCamera(Camera):
 
         if self.videocapture is None:
             raise DeviceNotConnectedError(f"{self} videocapture is not initialized")
+
+        set_fourcc_after_size_and_fps = platform.system() == "Windows"
+        if self.config.fourcc is not None and not set_fourcc_after_size_and_fps:
+            self._validate_fourcc()
 
         default_width = int(round(self.videocapture.get(cv2.CAP_PROP_FRAME_WIDTH)))
         default_height = int(round(self.videocapture.get(cv2.CAP_PROP_FRAME_HEIGHT)))
@@ -220,7 +223,7 @@ class OpenCVCamera(Camera):
         else:
             self._validate_fps()
 
-        if self.config.fourcc is not None:
+        if self.config.fourcc is not None and set_fourcc_after_size_and_fps:
             self._validate_fourcc()
 
     def _validate_fps(self) -> None:

--- a/src/lerobot/cameras/opencv/camera_opencv.py
+++ b/src/lerobot/cameras/opencv/camera_opencv.py
@@ -185,7 +185,8 @@ class OpenCVCamera(Camera):
 
         This method attempts to set the camera properties via OpenCV. It checks if
         the camera successfully applied the settings and raises an error if not.
-        FOURCC is set first (if specified) as it can affect the available FPS and resolution options.
+        The camera properties are set in the same order used by direct OpenCV capture tests:
+        width, height, FPS, then FOURCC.
 
         Args:
             fourcc: The desired FOURCC code (e.g., "MJPG", "YUYV"). If None, auto-detect.
@@ -199,9 +200,6 @@ class OpenCVCamera(Camera):
             DeviceNotConnectedError: If the camera is not connected.
         """
 
-        # Set FOURCC first (if specified) as it can affect available FPS/resolution options
-        if self.config.fourcc is not None:
-            self._validate_fourcc()
         if self.videocapture is None:
             raise DeviceNotConnectedError(f"{self} videocapture is not initialized")
 
@@ -221,6 +219,9 @@ class OpenCVCamera(Camera):
             self.fps = self.videocapture.get(cv2.CAP_PROP_FPS)
         else:
             self._validate_fps()
+
+        if self.config.fourcc is not None:
+            self._validate_fourcc()
 
     def _validate_fps(self) -> None:
         """Validates and sets the camera's frames per second (FPS)."""


### PR DESCRIPTION
## Title

fix(camera): set OpenCV FOURCC after size and FPS

## Summary / Motivation

This PR fixes a Windows-specific OpenCV camera capture issue.

In the affected Windows setup, configuring the OpenCV FOURCC value before setting the requested capture width, height, and FPS could lead to unstable camera configuration. The camera backend / driver may ignore or override part of the requested configuration, which can affect data recording reliability.

## Related issues

- Fixes / Closes: Fixes #3621
- Related: N/A

## What changed

- Added a Windows-specific branch for OpenCV camera property configuration.
- On Windows, width, height, and FPS are configured before setting `FOURCC`.
- On non-Windows platforms, the original property-setting order is preserved.
- This keeps existing behavior unchanged for non-Windows OpenCV backends.
- No breaking changes.

## How was this tested (or how to run locally)

Following the official LeRobot contributing instructions, I used the following local checks:

```powershell
pre-commit run --all-files
git lfs install
git lfs pull
pytest -sv ./tests
```
Local results on native Windows:

pre-commit run --all-files was run.
pytest -sv ./tests was attempted, but the full test suite failed during collection before running the tests:
```
ERROR collecting tests/utils/test_process.py
AttributeError: module 'signal' has no attribute 'SIGHUP'
```
This appears to be a native Windows test collection issue, because signal.SIGHUP is not available on Windows.

Therefore, I did not mark the full local pytest checklist item as completed.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [ ] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [ ] CI is green

## Reviewer notes

This PR targets a Windows-specific OpenCV camera backend behavior. Reviewers may want to check whether setting FOURCC after width, height, and FPS is safe across OpenCV backends and whether CI reproduces any issue with file/image-based OpenCV test sources.