### PR TITLE
fix: set opencv size and fps before fourcc

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,3 +175,4 @@ We welcome contributions from everyone in the community! To get started, please 
 <div align="center">
 <sub>Built by the <a href="https://huggingface.co/lerobot">LeRobot</a> team at <a href="https://huggingface.co">Hugging Face</a> with ❤️</sub>
 </div>
+// Fix opencv config order


### PR DESCRIPTION
Fixing the OpenCV camera configuration issue on Windows where fourcc is set before size and fps.