### PR TITLE
Allow zero-shot reward configs without optimizer presets

### DIFF
--- a/src/lerobot/configs/rewards.py
+++ b/src/lerobot/configs/rewards.py
@@ -89,9 +89,9 @@ class RewardModelConfig(draccus.ChoiceRegistry, HubMixin, abc.ABC):
     def reward_delta_indices(self) -> list | None:  # type: ignore[type-arg]
         return None
 
-    @abc.abstractmethod
-    def get_optimizer_preset(self) -> OptimizerConfig:
-        raise NotImplementedError
+    def get_optimizer_preset(self) -> OptimizerConfig | None:
+        """Default optimizer for this reward model, or ``None`` for zero-shot models."""
+        return None
 
     def get_scheduler_preset(self) -> LRSchedulerConfig | None:
         return None

--- a/src/lerobot/templates/lerobot_modelcard_template.md
+++ b/src/lerobot/templates/lerobot_modelcard_template.md
@@ -41,8 +41,6 @@ For more details, see the [Physical Intelligence π₀ blog post](https://www.ph
 For more details, see the [Physical Intelligence π₀.₅ blog post](https://www.physicalintelligence.company/blog/pi05).
 {% elif model_name == "gaussian_actor" %}
 This is a Gaussian Actor policy (Gaussian policy with a tanh squash) — the policy-side component used by [Soft Actor-Critic (SAC)](https://huggingface.co/papers/1801.01290) and related maximum-entropy continuous-control algorithms.
-{% elif model_name == "reward_classifier" %}
-A reward classifier is a lightweight neural network that scores observations or trajectories for task success, providing a learned reward signal or offline evaluation when explicit rewards are unavailable.
 {% else %}
 _Model type not recognized — please update this template._
 {% endif %}


### PR DESCRIPTION
## Title

Fix(rewards): Update reward config and model card template 

## Summary / Motivation

- This PR updates the base reward model config so `zero-shot` reward models can omit optimizer presets while trainable reward models continue to provide concrete optimizer configs.
- It also removes the reward classifier description from the generic policy model card template, since reward model cards are handled separately.

## Related issues

- Fixes / Closes: N/A
- Related: rewards, model cards

## What changed

- Made `RewardModelConfig.get_optimizer_preset()` return `OptimizerConfig | None` with a default `None`.
- Removed the `reward_classifier` branch from `lerobot_modelcard_template.md`.

## How was this tested (or how to run locally)

- Tests added: N/A
- Manual checks / dataset runs performed: N/A

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: # (insert PR number/link)