### PR TITLE
fix(rollout): honor policy revision when loading checkpoints

### DIFF
--- a/src/lerobot/configs/policies.py
+++ b/src/lerobot/configs/policies.py
@@ -79,6 +79,9 @@ class PreTrainedConfig(draccus.ChoiceRegistry, HubMixin, abc.ABC):  # type: igno
     # Either the repo ID of a model hosted on the Hub or a path to a directory containing weights
     # saved using `Policy.save_pretrained`. If not provided, the policy is initialized from scratch.
     pretrained_path: Path | None = None
+    # Hub revision used when loading a policy from `pretrained_path`. This is set by CLIs that accept
+    # `--policy.path` and need to pin both config and weights to a branch, tag, or commit.
+    revision: str | None = None
 
     def __post_init__(self) -> None:
         if not self.device or not is_torch_device_available(self.device):

--- a/src/lerobot/rollout/configs.py
+++ b/src/lerobot/rollout/configs.py
@@ -288,9 +288,18 @@ class RolloutConfig:
 
         policy_path = parser.get_path_arg("policy")
         if policy_path:
-            cli_overrides = parser.get_cli_overrides("policy")
-            self.policy = PreTrainedConfig.from_pretrained(policy_path, cli_overrides=cli_overrides)
+            cli_overrides = [
+                *parser.get_yaml_overrides("policy"),
+                *(parser.get_cli_overrides("policy") or []),
+            ]
+            policy_revision = parser.parse_arg("revision", cli_overrides)
+            self.policy = PreTrainedConfig.from_pretrained(
+                policy_path,
+                revision=policy_revision,
+                cli_overrides=cli_overrides,
+            )
             self.policy.pretrained_path = policy_path
+            self.policy.revision = policy_revision
         if self.policy is None:
             raise ValueError("--policy.path is required for rollout")
 

--- a/src/lerobot/rollout/context.py
+++ b/src/lerobot/rollout/context.py
@@ -176,6 +176,7 @@ def build_rollout_context(
     # --- 1. Policy (heavy I/O, but no hardware yet) -------------------
     logger.info("Loading policy from '%s'...", cfg.policy.pretrained_path)
     policy_config = cfg.policy
+    policy_revision = policy_config.revision
     policy_class = get_policy_class(policy_config.type)
 
     if hasattr(policy_config, "compile_model"):
@@ -191,13 +192,19 @@ def build_rollout_context(
         from peft import PeftConfig, PeftModel
 
         peft_path = policy_config.pretrained_path
-        peft_config = PeftConfig.from_pretrained(peft_path)
+        peft_config = PeftConfig.from_pretrained(peft_path, revision=policy_revision)
         policy = policy_class.from_pretrained(
-            pretrained_name_or_path=peft_config.base_model_name_or_path, config=policy_config
+            pretrained_name_or_path=peft_config.base_model_name_or_path,
+            config=policy_config,
+            revision=policy_revision,
         )
-        policy = PeftModel.from_pretrained(policy, peft_path, config=peft_config)
+        policy = PeftModel.from_pretrained(policy, peft_path, config=peft_config, revision=policy_revision)
     else:
-        policy = policy_class.from_pretrained(policy_config.pretrained_path, config=policy_config)
+        policy = policy_class.from_pretrained(
+            policy_config.pretrained_path,
+            config=policy_config,
+            revision=policy_revision,
+        )
 
     if is_rtc:
         policy.config.rtc_config = cfg.inference.rtc

--- a/tests/test_rollout.py
+++ b/tests/test_rollout.py
@@ -17,6 +17,8 @@
 from __future__ import annotations
 
 import dataclasses
+import sys
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -102,6 +104,34 @@ def test_sentry_config_defaults():
     cfg = SentryStrategyConfig()
     assert cfg.upload_every_n_episodes == 5
     assert cfg.target_video_file_size_mb is None
+
+
+def test_rollout_config_passes_policy_revision(monkeypatch):
+    from lerobot.configs import PreTrainedConfig
+    from lerobot.rollout import RolloutConfig
+    from tests.mocks.mock_robot import MockRobotConfig
+
+    captured = {}
+
+    def fake_from_pretrained(cls, pretrained_name_or_path, **kwargs):
+        captured["pretrained_name_or_path"] = pretrained_name_or_path
+        captured.update(kwargs)
+        return SimpleNamespace(device="cpu", revision=None)
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["lerobot-rollout", "--policy.path=user/policy", "--policy.revision=abc123"],
+    )
+    monkeypatch.setattr(PreTrainedConfig, "from_pretrained", classmethod(fake_from_pretrained))
+
+    cfg = RolloutConfig(robot=MockRobotConfig())
+
+    assert captured["pretrained_name_or_path"] == "user/policy"
+    assert captured["revision"] == "abc123"
+    assert "--revision=abc123" in captured["cli_overrides"]
+    assert cfg.policy.pretrained_path == "user/policy"
+    assert cfg.policy.revision == "abc123"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add a policy revision field so rollout can persist the Hub revision selected from CLI/YAML config
- pass the revision through policy config loading, policy weight loading, and PEFT adapter loading
- cover the  path with a rollout config regression test

Fixes #3549.

## Tests
- 
Testing with DEVICE='mps'
........................                                                 [100%]
24 passed in 0.13s
- All checks passed!