### PR TITLE
fix(datasets): report corrupt parquet files during dataset load

### DIFF
--- a/src/lerobot/datasets/io_utils.py
+++ b/src/lerobot/datasets/io_utils.py
@@ -24,8 +24,10 @@ import pyarrow.dataset as pa_ds
 import pyarrow.parquet as pq
 import torch
 from datasets import Dataset
+from datasets.exceptions import DatasetGenerationError
 from datasets.table import embed_table_storage
 from PIL import Image as PILImage
+from pyarrow.lib import ArrowInvalid
 from torchvision import transforms
 
 from lerobot.utils.io_utils import load_json, write_json
@@ -42,6 +44,10 @@ from .utils import (
     DatasetInfo,
     serialize_dict,
 )
+
+
+class CorruptParquetError(RuntimeError):
+    """Raised when one or more parquet files in a LeRobot dataset cannot be read."""
 
 
 def get_parquet_file_size_in_mb(parquet_path: str | Path) -> float:
@@ -78,7 +84,31 @@ def load_nested_dataset(
     with SuppressProgressBars():
         # We use .from_parquet() memory-mapped loading for efficiency
         filters = pa_ds.field("episode_index").isin(episodes) if episodes is not None else None
-        return Dataset.from_parquet([str(path) for path in paths], filters=filters, features=features)
+        try:
+            return Dataset.from_parquet([str(path) for path in paths], filters=filters, features=features)
+        except (DatasetGenerationError, ArrowInvalid) as exc:
+            _raise_corrupt_parquet_error(pq_dir, paths, exc)
+
+
+def _raise_corrupt_parquet_error(pq_dir: Path, paths: list[Path], exc: Exception) -> None:
+    corrupt_paths = []
+    for path in paths:
+        try:
+            pq.read_metadata(path)
+        except Exception:
+            corrupt_paths.append(path)
+
+    if not corrupt_paths:
+        raise exc
+
+    rel_paths = "\n".join(f"  - {path.relative_to(pq_dir)}" for path in corrupt_paths)
+    raise CorruptParquetError(
+        "Failed to load a LeRobot parquet dataset because one or more parquet files are unreadable.\n"
+        f"Dataset directory: {pq_dir}\n"
+        f"Unreadable parquet file(s):\n{rel_paths}\n"
+        "This can happen when recording is interrupted while a parquet file is being written. "
+        "Move or delete the listed file(s), then resume recording or rebuild the affected dataset chunk."
+    ) from exc
 
 
 def get_parquet_num_frames(parquet_path: str | Path) -> int:

--- a/tests/datasets/test_dataset_utils.py
+++ b/tests/datasets/test_dataset_utils.py
@@ -22,7 +22,7 @@ pytest.importorskip("datasets", reason="datasets is required (install lerobot[da
 from datasets import Dataset  # noqa: E402
 from huggingface_hub import DatasetCard
 
-from lerobot.datasets.io_utils import hf_transform_to_torch
+from lerobot.datasets.io_utils import CorruptParquetError, hf_transform_to_torch, load_nested_dataset
 from lerobot.datasets.utils import create_lerobot_dataset_card
 from lerobot.utils.constants import ACTION, OBS_IMAGES
 from lerobot.utils.feature_utils import combine_feature_dicts
@@ -151,3 +151,26 @@ def test_non_dict_passthrough_last_wins():
     out = combine_feature_dicts(g1, g2)
     # For non-dict entries the last one wins
     assert out["misc"] == 456
+
+
+def test_load_nested_dataset_reports_corrupt_parquet_file(tmp_path):
+    pq_dir = tmp_path / "data"
+    chunk_dir = pq_dir / "chunk-000"
+    chunk_dir.mkdir(parents=True)
+
+    Dataset.from_dict(
+        {
+            "timestamp": [0.0],
+            "index": [0],
+            "episode_index": [0],
+        }
+    ).to_parquet(chunk_dir / "file-000.parquet")
+    (chunk_dir / "file-001.parquet").write_text("not parquet")
+
+    with pytest.raises(CorruptParquetError) as exc_info:
+        load_nested_dataset(pq_dir)
+
+    message = str(exc_info.value)
+    assert "one or more parquet files are unreadable" in message
+    assert "chunk-000/file-001.parquet" in message
+    assert "interrupted while a parquet file is being written" in message


### PR DESCRIPTION
## Summary
- add a dedicated CorruptParquetError for unreadable parquet files in nested LeRobot datasets
- preserve the fast Dataset.from_parquet path and only scan individual files after parquet loading fails
- include the relative corrupt file path and recovery guidance for interrupted recording sessions

Helps with #3522.

## Tests
- PYTHONPATH=src python -m pytest tests/datasets/test_dataset_utils.py -q
- python -m ruff check src/lerobot/datasets/io_utils.py tests/datasets/test_dataset_utils.py