### PR TITLE
docs(i18n): add Korean translation for porting_datasets_v3.mdx

### DIFF
--- a/docs/source/ko/porting_datasets_v3.mdx
+++ b/docs/source/ko/porting_datasets_v3.mdx
@@ -1,0 +1,321 @@
+# 대규모 데이터셋을 LeRobot Dataset v3.0으로 포팅하기
+
+이 튜토리얼은 대규모 로봇 데이터셋을 LeRobot Dataset v3.0 형식으로 포팅(Porting)하는 방법을 설명합니다. 주요 예제로 **DROID 1.0.1** 데이터셋을 사용하며, SLURM 클러스터(SLURM Cluster) 환경에서 수천 개의 샤드(Shard)로 구성된 멀티 테라바이트 규모 데이터셋을 처리하는 방법을 보여줍니다.
+
+## 파일 구성: v2.1 vs v3.0
+
+Dataset v3.0은 데이터를 구성하고 저장하는 방식을 근본적으로 변경합니다.
+
+**v2.1 구조 (에피소드 기반)**:
+
+```
+dataset/
+├── data/chunk-000/episode_000000.parquet
+├── data/chunk-000/episode_000001.parquet
+├── videos/chunk-000/camera/episode_000000.mp4
+└── meta/episodes.jsonl
+```
+
+**v3.0 구조 (파일 기반)**:
+
+```
+dataset/
+├── data/chunk-000/file-000.parquet        # 파일당 여러 에피소드
+├── videos/camera/chunk-000/file-000.mp4   # 통합된 비디오 청크
+└── meta/episodes/chunk-000/file-000.parquet  # 구조화된 메타데이터
+```
+
+개별 에피소드 파일에서 파일 기반 청크(File-based Chunk)로의 전환은 성능을 크게 향상시키고 스토리지 오버헤드를 감소시킵니다.
+
+## Dataset v3.0의 새로운 기능
+
+Dataset v3.0은 대규모 데이터셋 처리를 위한 중요한 개선 사항을 도입했습니다.
+
+### 🏗️ **향상된 파일 구성**
+
+- **파일 기반 구조**: 개별 에피소드 파일 대신 청크 파일로 에피소드를 그룹화
+- **구성 가능한 파일 크기**: 데이터 및 비디오 파일에 대해 설정 가능
+- **향상된 스토리지 효율성**: 더 나은 압축률과 감소된 오버헤드 제공
+
+### 📊 **현대적인 메타데이터 관리**
+
+- **Parquet 기반 메타데이터**: JSON Lines를 효율적인 parquet 형식으로 대체
+- **구조화된 에피소드 접근**: `dataset.meta.episodes`를 통해 pandas DataFrame에 직접 접근 가능
+- **에피소드별 통계**: 에피소드 수준에서 향상된 통계 추적 기능 제공
+
+### 🚀 **성능 향상**
+
+- **메모리 매핑(Memory-mapped) 접근**: PyArrow 메모리 매핑을 통한 RAM 사용량 개선
+- **빠른 로딩**: 데이터셋 초기화 시간을 크게 단축
+- **확장성 개선**: 수백만 개의 에피소드를 처리할 수 있도록 설계
+
+## 사전 준비 사항
+
+대규모 데이터셋을 포팅하기 전에 다음 사항을 확인하시기 바랍니다.
+
+- **LeRobot 설치**: v3.0이 지원되는 버전으로 설치합니다. [설치 가이드](./installation)를 따라 진행하시기 바랍니다.
+- **충분한 스토리지**: 원본 데이터셋이 매우 클 수 있습니다 (예: DROID는 2TB 필요).
+- **클러스터 접근 권한** (대규모 데이터셋 권장): SLURM 또는 유사한 작업 스케줄러(Job Scheduler)
+- **데이터셋별 의존성**: DROID의 경우 TensorFlow Dataset 유틸리티가 필요합니다.
+
+## DROID 데이터셋 이해하기
+
+[DROID 1.0.1](https://droid-dataset.github.io/droid/the-droid-dataset)은 대규모 로봇 데이터셋의 훌륭한 예시입니다.
+
+- **크기**: 1.7TB (RLDS 형식), 8.7TB (원본 데이터)
+- **구조**: 2048개의 사전 정의된 TensorFlow 데이터셋 샤드
+- **콘텐츠**: Franka Emika Panda 로봇으로부터 수집된 76,000개 이상의 로봇 매니퓰레이션(Manipulation) 궤적(trajectories)
+- **범위**: 다양한 환경과 객체에 걸친 실세계 매니퓰레이션 작업
+- **형식**: 원래 TensorFlow Records/RLDS 형식이며, LeRobot 형식으로의 변환이 필요
+- **호스팅**: Google Cloud Storage에서 `gsutil`을 통해 공개적으로 접근 가능
+
+이 데이터셋에는 다음과 같은 다양한 매니퓰레이션 시연이 포함되어 있습니다.
+
+- 다중 카메라 뷰 (손목 카메라, 외부 카메라)
+- 자연어(Natural Language) 작업 설명
+- 로봇 고유 감각(Proprioceptive) 상태 및 액션
+- 성공/실패 어노테이션(Annotation)
+
+### DROID Features 스키마
+
+```python
+DROID_FEATURES = {
+    # 에피소드 마커
+    "is_first": {"dtype": "bool", "shape": (1,)},
+    "is_last": {"dtype": "bool", "shape": (1,)},
+    "is_terminal": {"dtype": "bool", "shape": (1,)},
+
+    # 언어 명령어
+    "language_instruction": {"dtype": "string", "shape": (1,)},
+    "language_instruction_2": {"dtype": "string", "shape": (1,)},
+    "language_instruction_3": {"dtype": "string", "shape": (1,)},
+
+    # 로봇 상태
+    "observation.state.gripper_position": {"dtype": "float32", "shape": (1,)},
+    "observation.state.cartesian_position": {"dtype": "float32", "shape": (6,)},
+    "observation.state.joint_position": {"dtype": "float32", "shape": (7,)},
+
+    # 카메라 관측값
+    "observation.images.wrist_left": {"dtype": "image"},
+    "observation.images.exterior_1_left": {"dtype": "image"},
+    "observation.images.exterior_2_left": {"dtype": "image"},
+
+    # 액션
+    "action.gripper_position": {"dtype": "float32", "shape": (1,)},
+    "action.cartesian_position": {"dtype": "float32", "shape": (6,)},
+    "action.joint_position": {"dtype": "float32", "shape": (7,)},
+
+    # 표준 LeRobot 형식
+    "observation.state": {"dtype": "float32", "shape": (8,)},  # 관절 + 그리퍼
+    "action": {"dtype": "float32", "shape": (8,)},  # 관절 + 그리퍼
+}
+```
+
+## 접근법 1: 단일 컴퓨터 포팅
+
+### 1단계: 의존성 설치
+
+DROID의 경우 다음 패키지를 설치하시기 바랍니다.
+
+```bash
+pip install tensorflow
+pip install tensorflow_datasets
+```
+
+다른 데이터셋의 경우 해당 소스 형식에 적합한 리더(Reader)를 설치하시기 바랍니다.
+
+### 2단계: 원본 데이터 다운로드
+
+`gsutil`을 사용하여 Google Cloud Storage에서 DROID를 다운로드합니다.
+
+```bash
+# Google Cloud SDK가 설치되어 있지 않다면 먼저 설치하시기 바랍니다.
+# https://cloud.google.com/sdk/docs/install
+
+# 전체 RLDS 데이터셋 다운로드 (1.7TB)
+gsutil -m cp -r gs://gresearch/robotics/droid/1.0.1 /your/data/
+
+# 또는 테스트용으로 100개 에피소드 샘플(2GB)만 다운로드
+gsutil -m cp -r gs://gresearch/robotics/droid_100 /your/data/
+```
+
+> [!WARNING]
+> 대규모 데이터셋은 상당한 시간과 스토리지를 필요로 합니다.
+>
+> - **전체 DROID (1.7TB)**: 대역폭에 따라 다운로드에 수일이 소요됩니다.
+> - **처리 시간**: 전체 데이터셋의 로컬 포팅에 7일 이상 소요됩니다.
+> - **업로드 시간**: Hugging Face Hub에 푸시(Push)하는 데 3일 이상 소요됩니다.
+> - **로컬 스토리지**: 처리된 LeRobot 형식에 약 400GB가 필요합니다.
+
+### 3단계: 데이터셋 포팅
+
+```bash
+python examples/port_datasets/port_droid.py \
+    --raw-dir /your/data/droid/1.0.1 \
+    --repo-id your_id/droid_1.0.1 \
+    --push-to-hub
+```
+
+### 개발 및 테스트
+
+개발 단계에서는 단일 샤드만 포팅할 수 있습니다.
+
+```bash
+python examples/port_datasets/port_droid.py \
+    --raw-dir /your/data/droid/1.0.1 \
+    --repo-id your_id/droid_1.0.1_test \
+    --num-shards 2048 \
+    --shard-index 0
+```
+
+이 접근법은 소규모 데이터셋 또는 테스트에는 적합하지만, 대규모 데이터셋에는 클러스터 컴퓨팅(Cluster Computing)이 필요합니다.
+
+## 접근법 2: SLURM 클러스터 포팅 (권장)
+
+DROID와 같은 대규모 데이터셋의 경우, 여러 노드에 걸친 병렬 처리(Parallel Processing)를 통해 처리 시간을 크게 단축할 수 있습니다.
+
+### 1단계: 클러스터 의존성 설치
+
+```bash
+pip install datatrove  # Hugging Face의 분산 처리 라이브러리
+```
+
+### 2단계: SLURM 환경 구성
+
+파티션(Partition) 정보를 확인합니다.
+
+```bash
+sinfo --format="%R"  # 사용 가능한 파티션 목록 조회
+sinfo -N -p your_partition -h -o "%N cpus=%c mem=%m"  # 리소스 확인
+```
+
+데이터셋 포팅에는 GPU가 필요하지 않으므로 **CPU 파티션**을 선택하시기 바랍니다.
+
+### 3단계: 병렬 포팅 작업 실행
+
+```bash
+python examples/port_datasets/slurm_port_shards.py \
+    --raw-dir /your/data/droid/1.0.1 \
+    --repo-id your_id/droid_1.0.1 \
+    --logs-dir /your/logs \
+    --job-name port_droid \
+    --partition your_partition \
+    --workers 2048 \
+    --cpus-per-task 8 \
+    --mem-per-cpu 1950M
+```
+
+#### 파라미터 가이드라인
+
+- **`--workers`**: 병렬 작업 수 (DROID의 샤드 수에 따라 최대 2048)
+- **`--cpus-per-task`**: 프레임 인코딩(Frame Encoding) 병렬화를 위해 CPU 8개 권장
+- **`--mem-per-cpu`**: 원본 프레임 로딩을 위한 RAM 약 16GB (8×1950M)
+
+> [!TIP]
+> 수천 개의 작업을 실행하기 전에, 클러스터 구성을 테스트하기 위해 워커 수를 적게(예: 100개) 설정하여 시작하시기 바랍니다.
+
+### 4단계: 진행 상황 모니터링
+
+실행 중인 작업을 확인합니다.
+
+```bash
+squeue -u $USER
+```
+
+전체 진행 상황을 모니터링합니다.
+
+```bash
+jobs_status /your/logs
+```
+
+개별 작업 로그를 점검합니다.
+
+```bash
+less /your/logs/port_droid/slurm_jobs/JOB_ID_WORKER_ID.out
+```
+
+실패한 작업을 디버깅합니다.
+
+```bash
+failed_logs /your/logs/port_droid
+```
+
+### 5단계: 샤드 집계
+
+모든 포팅 작업이 완료되면 다음을 실행합니다.
+
+```bash
+python examples/port_datasets/slurm_aggregate_shards.py \
+    --repo-id your_id/droid_1.0.1 \
+    --logs-dir /your/logs \
+    --job-name aggr_droid \
+    --partition your_partition \
+    --workers 2048 \
+    --cpus-per-task 8 \
+    --mem-per-cpu 1950M
+```
+
+### 6단계: Hub에 업로드
+
+```bash
+python examples/port_datasets/slurm_upload.py \
+    --repo-id your_id/droid_1.0.1 \
+    --logs-dir /your/logs \
+    --job-name upload_droid \
+    --partition your_partition \
+    --workers 50 \
+    --cpus-per-task 4 \
+    --mem-per-cpu 1950M
+```
+
+> [!NOTE]
+> 업로드는 컴퓨팅 바운드(Compute-bound)가 아니라 네트워크 바운드(Network-bound)이므로 더 적은 수의 워커(50개)를 사용합니다.
+
+## Dataset v3.0 파일 구조
+
+완성된 데이터셋은 다음과 같은 모던 구조를 가집니다.
+
+```
+dataset/
+├── meta/
+│   ├── episodes/
+│   │   └── chunk-000/
+│   │       └── file-000.parquet    # 에피소드 메타데이터
+│   ├── tasks.parquet               # 작업 정의
+│   ├── stats.json                  # 집계된 통계
+│   └── info.json                   # 데이터셋 정보
+├── data/
+│   └── chunk-000/
+│       └── file-000.parquet        # 통합된 에피소드 데이터
+└── videos/
+    └── camera_key/
+        └── chunk-000/
+            └── file-000.mp4        # 통합된 비디오 파일
+```
+
+이는 기존의 에피소드별 파일 구조를 효율적이고 최적의 크기로 구성된 청크 구조로 대체합니다.
+
+## Dataset v2.1로부터의 마이그레이션
+
+v2.1 형식의 기존 데이터셋이 있는 경우, 마이그레이션 도구를 사용하시기 바랍니다.
+
+```bash
+python src/lerobot/datasets/v30/convert_dataset_v21_to_v30.py \
+    --repo-id your_id/existing_dataset
+```
+
+이 도구는 다음 작업을 자동으로 수행합니다.
+
+- 파일 구조를 v3.0 형식으로 변환합니다.
+- 메타데이터를 JSON Lines에서 parquet으로 마이그레이션합니다.
+- 통계를 집계하고 에피소드별 통계를 생성합니다.
+- 버전 정보를 업데이트합니다.
+
+## 성능 이점
+
+Dataset v3.0은 대규모 데이터셋에 대해 다음과 같은 상당한 개선을 제공합니다.
+
+- **빠른 로딩**: 초기화 시간 3-5배 단축
+- **메모리 효율성**: 메모리 매핑을 통한 RAM 사용량 개선
+- **확장 가능한 처리**: 수백만 개의 에피소드를 효율적으로 처리
+- **스토리지 최적화**: 파일 수 감소 및 압축률 향상


### PR DESCRIPTION
## Title

docs(i18n): add Korean translation for `porthing_datasets_v3.mdx`

## Summary / Motivation

- Add Korean(`ko`) translation for `porthing_datasets_v3.mdx` under `docs/source/ko/`.
- Part of #3058.
- Korean translation preserves the original MDX structure, headings, code blocks, commands, URLs, and variable names.
- Technical terms are translated consistently with the existing Korean documentation.

## Related issues

- Related: #3058.

## What changed

- `docs/source/ko/porthing_datasets_v3.mdx` — full Korean translation of the datasets documentation page.
- Original MDX structure, headings, code blocks, image tags, and English-only elements are preserved as-is.

## How was this tested (or how to run locally)

- `pre-commit` checks all passed.

## Checklist (required before merge)

- [ ] Linting/formatting run (`pre-commit run -a`)
- [ ] All tests pass locally (`pytest`)
- [x] Documentation updated
- [ ] CI is green
- [x] Community Review: I have reviewed another contributor's open PR and linked it here: #3618.

## Reviewer notes

- Anyone in the community is free to review the PR.
