### PR TITLE
Make modify_tasks non-destructive by default

### DIFF
--- a/docs/source/using_dataset_tools.mdx
+++ b/docs/source/using_dataset_tools.mdx
@@ -11,15 +11,16 @@ LeRobot provides several utilities for manipulating datasets:
 3. **Merge Datasets** - Combine multiple datasets into one. The datasets must have identical features, and episodes are concatenated in the order specified in `repo_ids`
 4. **Add Features** - Add new features to a dataset
 5. **Remove Features** - Remove features from a dataset
-6. **Convert to Video** - Convert image-based datasets to video format for efficient storage
-7. **Show the Info of Datasets** - Show the summary of datasets information such as number of episode etc.
+6. **Modify Tasks** - Update task descriptions for all or selected episodes
+7. **Convert to Video** - Convert image-based datasets to video format for efficient storage
+8. **Show the Info of Datasets** - Show the summary of datasets information such as number of episode etc.
 
 The core implementation is in `lerobot.datasets.dataset_tools`.
 An example script detailing how to use the tools API is available in `examples/dataset/use_dataset_tools.py`.
 
 ## Command-Line Tool: lerobot-edit-dataset
 
-`lerobot-edit-dataset` is a command-line script for editing datasets. It can be used to delete episodes, split datasets, merge datasets, add features, remove features, and convert image datasets to video format.
+`lerobot-edit-dataset` is a command-line script for editing datasets. It can be used to delete episodes, split datasets, merge datasets, add features, remove features, modify tasks, and convert image datasets to video format.
 
 Run `lerobot-edit-dataset --help` for more information on the configuration of each operation.
 
@@ -86,6 +87,33 @@ lerobot-edit-dataset \
     --repo_id lerobot/pusht \
     --operation.type remove_feature \
     --operation.feature_names "['observation.images.top']"
+```
+
+#### Modify Tasks
+
+Update task descriptions after recording a dataset. By default, this creates a new dataset and preserves the original.
+
+```bash
+# Set a single task for all episodes and save to a new dataset
+lerobot-edit-dataset \
+    --repo_id lerobot/pusht \
+    --new_repo_id lerobot/pusht_renamed \
+    --operation.type modify_tasks \
+    --operation.new_task "Pick up the cube and place it"
+
+# Set different tasks for specific episodes and save to a local path
+lerobot-edit-dataset \
+    --repo_id lerobot/pusht \
+    --new_root /path/to/pusht_renamed \
+    --operation.type modify_tasks \
+    --operation.episode_tasks '{"0": "Task A", "1": "Task B", "2": "Task A"}'
+
+# Modify the source dataset in-place
+lerobot-edit-dataset \
+    --repo_id lerobot/pusht \
+    --operation.type modify_tasks \
+    --operation.new_task "Pick up the cube and place it" \
+    --operation.overwrite true
 ```
 
 #### Convert to Video

--- a/src/lerobot/scripts/lerobot_edit_dataset.py
+++ b/src/lerobot/scripts/lerobot_edit_dataset.py
@@ -100,24 +100,26 @@ Remove camera feature:
         --operation.type remove_feature \
         --operation.feature_names "['observation.image']"
 
-Modify tasks - set a single task for all episodes (WARNING: modifies in-place):
+Modify tasks - set a single task for all episodes and save to a new dataset:
     lerobot-edit-dataset \
         --repo_id lerobot/pusht \
+        --new_repo_id lerobot/pusht_renamed \
         --operation.type modify_tasks \
         --operation.new_task "Pick up the cube and place it"
 
-Modify tasks - set different tasks for specific episodes (WARNING: modifies in-place):
+Modify tasks - set different tasks for specific episodes and save to a new path:
     lerobot-edit-dataset \
         --repo_id lerobot/pusht \
+        --new_root /path/to/pusht_renamed \
         --operation.type modify_tasks \
         --operation.episode_tasks '{"0": "Task A", "1": "Task B", "2": "Task A"}'
 
-Modify tasks - set default task with overrides for specific episodes (WARNING: modifies in-place):
+Modify tasks in-place:
     lerobot-edit-dataset \
         --repo_id lerobot/pusht \
         --operation.type modify_tasks \
-        --operation.new_task "Default task" \
-        --operation.episode_tasks '{"5": "Special task for episode 5"}'
+        --operation.new_task "Pick up the cube and place it" \
+        --operation.overwrite true
 
 Convert image dataset to video format and save locally:
     lerobot-edit-dataset \
@@ -270,6 +272,7 @@ class RemoveFeatureConfig(OperationConfig):
 class ModifyTasksConfig(OperationConfig):
     new_task: str | None = None
     episode_tasks: dict[str, str] | None = None
+    overwrite: bool = False
 
 
 @OperationConfig.register_subclass("convert_image_to_video")
@@ -518,13 +521,40 @@ def handle_modify_tasks(cfg: EditDatasetConfig) -> None:
     if new_task is None and episode_tasks_raw is None:
         raise ValueError("Must specify at least one of new_task or episode_tasks for modify_tasks operation")
 
-    if cfg.new_repo_id is not None or cfg.new_root is not None:
-        logging.warning(
-            "modify_tasks modifies datasets in-place. The --new_repo_id and --new_root parameters are ignored."
+    dataset = LeRobotDataset(cfg.repo_id, root=cfg.root)
+
+    if cfg.operation.overwrite:
+        if cfg.new_repo_id is not None or cfg.new_root is not None:
+            logging.warning(
+                "modify_tasks is running in-place because --operation.overwrite is true. "
+                "The --new_repo_id and --new_root parameters are ignored."
+            )
+        output_repo_id = cfg.repo_id
+        output_dir = dataset.root
+        logging.warning(f"Modifying dataset in-place at {dataset.root}. Original data will be overwritten.")
+    else:
+        output_repo_id, input_path, output_dir = _resolve_io_paths(
+            cfg.repo_id,
+            new_repo_id=cfg.new_repo_id,
+            root=cfg.root,
+            new_root=cfg.new_root,
+            default_new_repo_id=f"{cfg.repo_id}_modified_tasks",
         )
 
-    dataset = LeRobotDataset(cfg.repo_id, root=cfg.root)
-    logging.warning(f"Modifying dataset in-place at {dataset.root}. Original data will be overwritten.")
+        if output_dir == input_path:
+            raise ValueError(
+                "modify_tasks would overwrite the source dataset. "
+                "Pass --operation.overwrite true to modify tasks in-place."
+            )
+        if output_dir.exists():
+            raise FileExistsError(
+                f"Output path already exists: {output_dir}. "
+                "Choose a different --new_root or remove the existing directory."
+            )
+
+        logging.warning(f"Copying dataset from {dataset.root} to {output_dir} before modifying tasks.")
+        shutil.copytree(dataset.root, output_dir)
+        dataset = LeRobotDataset(output_repo_id, root=output_dir)
 
     # Convert episode_tasks keys from string to int if needed (CLI passes strings)
     episode_tasks: dict[int, str] | None = None
@@ -543,11 +573,11 @@ def handle_modify_tasks(cfg: EditDatasetConfig) -> None:
         episode_tasks=episode_tasks,
     )
 
-    logging.info(f"Dataset modified at {dataset.root}")
+    logging.info(f"Dataset modified at {output_dir}")
     logging.info(f"Tasks: {list(modified_dataset.meta.tasks.index)}")
 
     if cfg.push_to_hub:
-        logging.info(f"Pushing to hub as {cfg.repo_id}")
+        logging.info(f"Pushing to hub as {output_repo_id}")
         modified_dataset.push_to_hub()
 
 

--- a/tests/scripts/test_edit_dataset_parsing.py
+++ b/tests/scripts/test_edit_dataset_parsing.py
@@ -15,10 +15,12 @@
 # limitations under the License.
 
 import draccus
+import numpy as np
 import pytest
 
 pytest.importorskip("datasets", reason="datasets is required (install lerobot[dataset])")
 
+from lerobot.datasets import LeRobotDataset
 from lerobot.scripts.lerobot_edit_dataset import (
     ConvertImageToVideoConfig,
     DeleteEpisodesConfig,
@@ -30,6 +32,7 @@ from lerobot.scripts.lerobot_edit_dataset import (
     RemoveFeatureConfig,
     SplitConfig,
     _validate_config,
+    handle_modify_tasks,
 )
 
 
@@ -89,3 +92,85 @@ class TestOperationTypeParsing:
         )
         resolved_name = OperationConfig.get_choice_name(type(cfg.operation))
         assert resolved_name == type_name
+
+    def test_modify_tasks_parses_overwrite_flag(self):
+        cfg = parse_cfg(
+            [
+                "--repo_id",
+                "test/repo",
+                "--operation.type",
+                "modify_tasks",
+                "--operation.new_task",
+                "Pick up the cube",
+                "--operation.overwrite",
+                "true",
+            ]
+        )
+
+        assert isinstance(cfg.operation, ModifyTasksConfig)
+        assert cfg.operation.overwrite is True
+
+
+def _create_two_episode_dataset(empty_lerobot_dataset_factory, root, repo_id="test/source"):
+    features = {
+        "action": {"dtype": "float32", "shape": (1,), "names": None},
+        "observation.state": {"dtype": "float32", "shape": (1,), "names": None},
+    }
+    dataset = empty_lerobot_dataset_factory(root=root, repo_id=repo_id, features=features, use_videos=False)
+
+    for task in ["Original task A", "Original task B"]:
+        for _ in range(2):
+            dataset.add_frame(
+                {
+                    "action": np.array([1.0], dtype=np.float32),
+                    "observation.state": np.array([0.0], dtype=np.float32),
+                    "task": task,
+                }
+            )
+        dataset.save_episode()
+
+    dataset.finalize()
+    return dataset
+
+
+def test_handle_modify_tasks_writes_new_dataset_without_changing_source(
+    tmp_path, empty_lerobot_dataset_factory
+):
+    source_root = tmp_path / "source"
+    output_root = tmp_path / "renamed"
+    _create_two_episode_dataset(empty_lerobot_dataset_factory, source_root)
+
+    cfg = EditDatasetConfig(
+        repo_id="test/source",
+        root=str(source_root),
+        new_repo_id="test/renamed",
+        new_root=str(output_root),
+        operation=ModifyTasksConfig(new_task="Renamed task"),
+    )
+
+    handle_modify_tasks(cfg)
+
+    source_dataset = LeRobotDataset("test/source", root=source_root)
+    renamed_dataset = LeRobotDataset("test/renamed", root=output_root)
+
+    assert set(source_dataset.meta.tasks.index) == {"Original task A", "Original task B"}
+    assert set(renamed_dataset.meta.tasks.index) == {"Renamed task"}
+    assert all(renamed_dataset[i]["task"] == "Renamed task" for i in range(len(renamed_dataset)))
+
+
+def test_handle_modify_tasks_overwrite_true_modifies_source_in_place(tmp_path, empty_lerobot_dataset_factory):
+    source_root = tmp_path / "source"
+    _create_two_episode_dataset(empty_lerobot_dataset_factory, source_root)
+
+    cfg = EditDatasetConfig(
+        repo_id="test/source",
+        root=str(source_root),
+        operation=ModifyTasksConfig(new_task="Overwritten task", overwrite=True),
+    )
+
+    handle_modify_tasks(cfg)
+
+    source_dataset = LeRobotDataset("test/source", root=source_root)
+
+    assert set(source_dataset.meta.tasks.index) == {"Overwritten task"}
+    assert all(source_dataset[i]["task"] == "Overwritten task" for i in range(len(source_dataset)))


### PR DESCRIPTION
## Summary
- Make `lerobot-edit-dataset --operation.type modify_tasks` create a modified dataset copy by default.
- Add explicit `--operation.overwrite true` for in-place task edits.
- Document the new modify-tasks workflow and add parser/handler coverage.

## Test plan
- `uv run pytest tests/scripts/test_edit_dataset_parsing.py tests/datasets/test_dataset_tools.py::test_modify_tasks_single_task_for_all tests/datasets/test_dataset_tools.py::test_modify_tasks_keeps_original_when_not_overridden -q`
- `uv run ruff format --check src/lerobot/scripts/lerobot_edit_dataset.py tests/scripts/test_edit_dataset_parsing.py`
- `uv run ruff check src/lerobot/scripts/lerobot_edit_dataset.py tests/scripts/test_edit_dataset_parsing.py`