### PR TITLE
fix(deps): cap placo below 0.9.16 and harden kinematics import

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,7 +138,9 @@ dataset_viz = ["lerobot[dataset]", "lerobot[viz]"]
 # Common
 av-dep = ["av>=15.0.0,<16.0.0"]
 pygame-dep = ["pygame>=2.5.1,<2.7.0"]
-placo-dep = ["placo>=0.9.6,<0.9.17"]
+# NOTE: 0.9.16 links against liburdfdom_sensor.so.4, which is unavailable on Ubuntu 24.04
+# (noble ships urdfdom 3.x). Cap below 0.9.16 until system urdfdom 4.x is broadly available.
+placo-dep = ["placo>=0.9.6,<0.9.16"]
 transformers-dep = ["transformers>=5.4.0,<5.6.0"]
 grpcio-dep = ["grpcio==1.73.1", "protobuf>=6.31.1,<6.32.0"]
 can-dep = ["python-can>=4.2.0,<5.0.0"]

--- a/src/lerobot/model/kinematics.py
+++ b/src/lerobot/model/kinematics.py
@@ -20,23 +20,11 @@ import numpy as np
 
 from lerobot.utils.import_utils import require_package
 
-# Declared unconditionally so it is visible to mypy under TYPE_CHECKING; the
-# runtime ``else`` branch below assigns it when the actual import fails.
 _placo_runtime_error: ImportError | None = None
 
 if TYPE_CHECKING:
     import placo  # type: ignore[import-not-found]
 else:
-    # We attempt the actual import rather than relying solely on
-    # ``_placo_available`` (which is ``importlib.util.find_spec``-based).
-    # ``find_spec`` only checks that the Python module exists; it does not
-    # execute the import, so it cannot detect failures from native libraries
-    # the wheel dlopens at import time (e.g. placo 0.9.16 needs
-    # ``liburdfdom_sensor.so.4`` which is not available on Ubuntu 24.04).
-    # Catching the ImportError here keeps unrelated subsystems (RL actor,
-    # gym_manipulator, etc.) importable when placo can't load; the user
-    # gets an actionable error only when they actually instantiate
-    # ``RobotKinematics``, via ``_raise_if_placo_unusable``.
     try:
         import placo  # type: ignore[import-not-found]
     except ImportError as _placo_import_err:
@@ -45,12 +33,9 @@ else:
 
 
 def _raise_if_placo_unusable() -> None:
-    """Surface a useful error when placo is installed but fails to dlopen."""
     if placo is None and _placo_runtime_error is not None:
         raise ImportError(
-            "placo is installed but failed to import — a transitive native "
-            "library is missing. Original error: "
-            f"{_placo_runtime_error!s}"
+            f"placo is installed but failed to import: {_placo_runtime_error!s}"
         ) from _placo_runtime_error
 
 

--- a/src/lerobot/model/kinematics.py
+++ b/src/lerobot/model/kinematics.py
@@ -20,6 +20,10 @@ import numpy as np
 
 from lerobot.utils.import_utils import require_package
 
+# Declared unconditionally so it is visible to mypy under TYPE_CHECKING; the
+# runtime ``else`` branch below assigns it when the actual import fails.
+_placo_runtime_error: ImportError | None = None
+
 if TYPE_CHECKING:
     import placo  # type: ignore[import-not-found]
 else:
@@ -37,9 +41,7 @@ else:
         import placo  # type: ignore[import-not-found]
     except ImportError as _placo_import_err:
         placo = None
-        _placo_runtime_error: ImportError | None = _placo_import_err
-    else:
-        _placo_runtime_error = None
+        _placo_runtime_error = _placo_import_err
 
 
 def _raise_if_placo_unusable() -> None:

--- a/src/lerobot/model/kinematics.py
+++ b/src/lerobot/model/kinematics.py
@@ -18,12 +18,38 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
-from lerobot.utils.import_utils import _placo_available, require_package
+from lerobot.utils.import_utils import require_package
 
-if TYPE_CHECKING or _placo_available:
+if TYPE_CHECKING:
     import placo  # type: ignore[import-not-found]
 else:
-    placo = None
+    # We attempt the actual import rather than relying solely on
+    # ``_placo_available`` (which is ``importlib.util.find_spec``-based).
+    # ``find_spec`` only checks that the Python module exists; it does not
+    # execute the import, so it cannot detect failures from native libraries
+    # the wheel dlopens at import time (e.g. placo 0.9.16 needs
+    # ``liburdfdom_sensor.so.4`` which is not available on Ubuntu 24.04).
+    # Catching the ImportError here keeps unrelated subsystems (RL actor,
+    # gym_manipulator, etc.) importable when placo can't load; the user
+    # gets an actionable error only when they actually instantiate
+    # ``RobotKinematics``, via ``_raise_if_placo_unusable``.
+    try:
+        import placo  # type: ignore[import-not-found]
+    except ImportError as _placo_import_err:
+        placo = None
+        _placo_runtime_error: ImportError | None = _placo_import_err
+    else:
+        _placo_runtime_error = None
+
+
+def _raise_if_placo_unusable() -> None:
+    """Surface a useful error when placo is installed but fails to dlopen."""
+    if placo is None and _placo_runtime_error is not None:
+        raise ImportError(
+            "placo is installed but failed to import — a transitive native "
+            "library is missing. Original error: "
+            f"{_placo_runtime_error!s}"
+        ) from _placo_runtime_error
 
 
 class RobotKinematics:
@@ -44,6 +70,7 @@ class RobotKinematics:
             joint_names (list[str] | None): List of joint names to use for the kinematics solver
         """
         require_package("placo", extra="placo-dep")
+        _raise_if_placo_unusable()
 
         self.robot = placo.RobotWrapper(urdf_path)
         self.solver = placo.KinematicsSolver(self.robot)

--- a/uv.lock
+++ b/uv.lock
@@ -3203,7 +3203,7 @@ requires-dist = [
     { name = "pandas", marker = "extra == 'video-benchmark'", specifier = ">=2.2.2,<2.4.0" },
     { name = "peft", marker = "extra == 'peft-dep'", specifier = ">=0.18.0,<1.0.0" },
     { name = "pillow", specifier = ">=10.0.0,<13.0.0" },
-    { name = "placo", marker = "extra == 'placo-dep'", specifier = ">=0.9.6,<0.9.17" },
+    { name = "placo", marker = "extra == 'placo-dep'", specifier = ">=0.9.6,<0.9.16" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.7.0,<5.0.0" },
     { name = "protobuf", marker = "extra == 'grpcio-dep'", specifier = ">=6.31.1,<6.32.0" },
     { name = "pyarrow", marker = "extra == 'dataset'", specifier = ">=21.0.0,<30.0.0" },
@@ -4592,7 +4592,7 @@ wheels = [
 
 [[package]]
 name = "placo"
-version = "0.9.16"
+version = "0.9.15"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cmeel" },
@@ -4602,16 +4602,16 @@ dependencies = [
     { name = "pin" },
     { name = "rhoban-cmeel-jsoncpp" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/0a/36c5b729d0d69075e7dfafd1b36c4df6fbb8c1ff1585e88d3c56d4c15010/placo-0.9.16.tar.gz", hash = "sha256:5314faaf6442e7ffe17347680d236af953951813bbfb1c09c4a27f7388d332e4", size = 136871, upload-time = "2025-11-07T14:24:58.811Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/40/c4/a33a0ee2ad798471a1c43a96109d28f358fd95c78a56f8cff57acb66d2bc/placo-0.9.15.tar.gz", hash = "sha256:df47f1154bae305c943bd20ba4f56d50ffc65625efc98679fefb11e8ff3c462c", size = 136856, upload-time = "2025-11-03T10:49:13.151Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/95/8a85b58033303fd354a680e1494f47801abdca9133c222ae1c2473983f25/placo-0.9.16-0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:417a89920b340e3aec19f1f49e1fb06789c679a807450157af8bdf4aef4bc82b", size = 1641806, upload-time = "2025-11-07T14:24:34.736Z" },
-    { url = "https://files.pythonhosted.org/packages/92/bd/2fb3556c71b0689b3168c0e85fce5befb605affcfe4afb3b5e7b5ba6749f/placo-0.9.16-0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a7ef7ac33ba889d2122db0d7ed55eeecdffed020e2282712989bb11e408bab40", size = 1515468, upload-time = "2025-11-07T14:24:36.587Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/fd/7dba380720dfb89df582a51d0b2cb43957a36849f676baa3dfc74704e67f/placo-0.9.16-0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:885773fe8a8e809022451ec16d47479562a042596f663b8c5bbe762cd616f573", size = 2106540, upload-time = "2025-11-07T14:24:38.149Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/40/97c7c799fe4f89111b973d7a5f86626a2ec1d0e6e20ce2988e0a2bda66f5/placo-0.9.16-0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:19f097305c714e539fbf19e761897f6daab2ff73f639319431b144e77dd3852e", size = 2178511, upload-time = "2025-11-07T14:24:40.04Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/4d/f1700aae269584477b5d72561d2fc5ace37b4bca167892a74a369849c67e/placo-0.9.16-0-cp313-cp313-macosx_10_9_x86_64.whl", hash = "sha256:be11fa987702114097ccf3d94e1c4a891796878429e25c8d88b187ecc652e7ae", size = 1641812, upload-time = "2025-11-07T14:24:41.308Z" },
-    { url = "https://files.pythonhosted.org/packages/43/d7/21d1d0dd1311c0cbd9ccd233cdae520bbe2370095e3c831059d6077c90bd/placo-0.9.16-0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c2d65aeb4844eae28006ad3a50c8519b27c701912cc99c46c95e33ed049f3635", size = 1515457, upload-time = "2025-11-07T14:24:42.758Z" },
-    { url = "https://files.pythonhosted.org/packages/0f/e8/939ba23bfa539fb90ab9ab1c2c59ff9a9a46e24699fc90e8ca3ff2948646/placo-0.9.16-0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:a7633aff1c592c1f45e86a174a372d5d7972673935cb9151391277ff49ec2072", size = 2106538, upload-time = "2025-11-07T14:24:44.517Z" },
-    { url = "https://files.pythonhosted.org/packages/08/00/ad24cc0ad85fbe12267df28c2061e1eaef8f852146c467fcd7a681e11028/placo-0.9.16-0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:0d97a7284b65fc45aef27865c80cf7e53f04646d35bb18494ab62dfbbc9a35bd", size = 2178514, upload-time = "2025-11-07T14:24:45.994Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/03/207b1c087996b918fdbaa5a3a685e3b14b068cd303bf87affdf83f722b33/placo-0.9.15-0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:eab7a299e73291fe631c02448b9e9826539f4824e198bcf85f7c91fdd77d054b", size = 1641975, upload-time = "2025-11-03T10:48:48.887Z" },
+    { url = "https://files.pythonhosted.org/packages/92/55/40432b26bb1c5b9e677fbc41e8d85b54fa8897b7daebb2a22d410b0a7f7b/placo-0.9.15-0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:23f9dd19b8d15fa9d86968948b57981ebc6f1decafeffc2d646d8b56f685b50d", size = 1515448, upload-time = "2025-11-03T10:48:50.562Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/8e/e6283201d329409dccf2045b5c1efd73b3dad5268143bbea4668029ca9c6/placo-0.9.15-0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:2680a2166c23a0a2aa6226ad75c63a2b2310c812673a5db296616d9af053e076", size = 2106550, upload-time = "2025-11-03T10:48:52.364Z" },
+    { url = "https://files.pythonhosted.org/packages/51/c3/77efe4c999e1d80ec14879ef73ea2a2144aa12db2b67870a562f87ed5b43/placo-0.9.15-0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:1a2202a78bcd2874ca09a9a6526a95b38874803923cb9b3b4b96cd68ab4b7217", size = 2178531, upload-time = "2025-11-03T10:48:53.932Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/e7/b5cc5ad53414ff7af3357e0c9d97d902a3ce276e7810f8814fe9f0c1fb70/placo-0.9.15-0-cp313-cp313-macosx_10_9_x86_64.whl", hash = "sha256:84a445a99b059a512d1b4c64841a91d6f50149c7be9255c65bedeebbe6663989", size = 1641982, upload-time = "2025-11-03T10:48:55.277Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1c/1c9163d941698a077617f218041efc573d3bf5a1c169a284112bd622fccd/placo-0.9.15-0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b3106e7e6b05cbfa494239d8aa14795f7da8ee5dec851602f0d6297e311d7334", size = 1515447, upload-time = "2025-11-03T10:48:56.975Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/22/3d9b9045b89248c8476dd42243bc9821a123d9199e4e96a944124ad80cf1/placo-0.9.15-0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:66c3d099e87551401aace04f1293a3c3563b1399319976647846845bf92c3ccf", size = 2106558, upload-time = "2025-11-03T10:48:58.667Z" },
+    { url = "https://files.pythonhosted.org/packages/20/0b/45dbdd2c378a7cece578b7344fda493d5a2aa6777089798a315ce4f97c22/placo-0.9.15-0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:0e06b7d3d618ddc2b649ab8b0b46db8001fe72fe2fbcc801524df0ccc8a3da40", size = 2178531, upload-time = "2025-11-03T10:49:00.533Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What this fixes

The nightly **Latest Dependency Tests** run is failing on both CPU and GPU jobs ([run 26268362319](https://github.com/huggingface/lerobot/actions/runs/26268362319), [job 77317299571](https://github.com/huggingface/lerobot/actions/runs/26268362319/job/77317299571)) at the `Run pytest` step.

All 9 failures share the same root cause:

```
ImportError: liburdfdom_sensor.so.4.0: cannot open shared object file: No such file or directory
```

affecting:

- `tests/rl/test_actor.py::test_establish_learner_connection_success`
- `tests/rl/test_actor.py::test_establish_learner_connection_failure`
- `tests/rl/test_actor.py::test_push_transitions_to_transport_queue`
- `tests/rl/test_actor.py::test_transitions_stream`
- `tests/rl/test_actor.py::test_interactions_stream`
- `tests/rl/test_actor_learner.py::test_end_to_end_transitions_flow`
- `tests/rl/test_actor_learner.py::test_end_to_end_interactions_flow`
- `tests/rl/test_actor_learner.py::test_end_to_end_parameters_flow[small]`
- `tests/rl/test_actor_learner.py::test_end_to_end_parameters_flow[large]`

## Why

The traceback chains through:

```
tests/rl/test_actor.py:72
  → src/lerobot/rl/actor.py:108        from .gym_manipulator import (...)
  → src/lerobot/rl/gym_manipulator.py:30  from lerobot.model import RobotKinematics
  → src/lerobot/model/__init__.py:17   from .kinematics import RobotKinematics
  → src/lerobot/model/kinematics.py:24 import placo
  → ImportError: liburdfdom_sensor.so.4.0: cannot open shared object file
```

The nightly lockfile upgrade picked **`placo 0.9.16`** (released 2025-11-07). That wheel's bundled native code dlopens `liburdfdom_sensor.so.4`, but the CI runner image (Ubuntu 24.04 noble) only ships urdfdom 3.x via apt.

The guard in `src/lerobot/model/kinematics.py` was too weak to catch this — it gated on `_placo_available`, which is `importlib.util.find_spec("placo")` and does **not** execute the import, so a transitive `dlopen` failure slipped through and crashed unrelated subsystems (RL actor/learner tests).

## What this PR does

Two changes, both in one commit:

1. **Short-term unblock**: tighten the pin in `pyproject.toml` to `placo>=0.9.6,<0.9.16` and regenerate `uv.lock`. Only `placo` moves (0.9.16 → 0.9.15); no other packages affected.

2. **Structural fix in `src/lerobot/model/kinematics.py`**: wrap `import placo` in `try/except ImportError` so a missing transitive `.so` no longer crashes the module import for unrelated callers. A new `_raise_if_placo_unusable()` is invoked from `RobotKinematics.__init__` so that users actually instantiating the kinematics solver get an informative error citing the underlying dlopen failure, instead of a `NameError` on `placo`. This makes `lerobot.model.kinematics` importable in environments where `placo` is installed but its native deps aren't loadable — exactly the situation tests `tests/rl/test_actor*.py` hit transitively.