### PR TITLE
fix(datasets): cache parquet reads when reindexing episode metadata

### DIFF
--- a/src/lerobot/datasets/dataset_tools.py
+++ b/src/lerobot/datasets/dataset_tools.py
@@ -71,12 +71,21 @@ from .video_utils import (
 )
 
 
-def _load_episode_with_stats(src_dataset: LeRobotDataset, episode_idx: int) -> dict:
+def _load_episode_with_stats(
+    src_dataset: LeRobotDataset,
+    episode_idx: int,
+    parquet_cache: dict[str, pd.DataFrame] | None = None,
+) -> dict:
     """Load a single episode's metadata including stats from parquet file.
 
     Args:
         src_dataset: Source dataset
         episode_idx: Episode index to load
+        parquet_cache: Optional dict used to cache parquet DataFrames across
+            calls. Callers iterating over many episodes should pass in a shared
+            dict to avoid reloading the same metadata parquet file for every
+            episode (which can take hours on large datasets where many
+            episodes share a single file).
 
     Returns:
         dict containing episode metadata and stats
@@ -86,7 +95,13 @@ def _load_episode_with_stats(src_dataset: LeRobotDataset, episode_idx: int) -> d
     file_idx = ep_meta["meta/episodes/file_index"]
 
     parquet_path = src_dataset.root / DEFAULT_EPISODES_PATH.format(chunk_index=chunk_idx, file_index=file_idx)
-    df = pd.read_parquet(parquet_path)
+    if parquet_cache is None:
+        df = pd.read_parquet(parquet_path)
+    else:
+        cache_key = str(parquet_path)
+        if cache_key not in parquet_cache:
+            parquet_cache[cache_key] = pd.read_parquet(parquet_path)
+        df = parquet_cache[cache_key]
 
     episode_row = df[df["episode_index"] == episode_idx].iloc[0]
 
@@ -854,10 +869,15 @@ def _copy_and_reindex_episodes_metadata(
     all_stats = []
     total_frames = 0
 
+    # Many episodes share the same metadata parquet file. Reloading the same
+    # file once per episode scales poorly (hours on ~10k-episode datasets), so
+    # we share a parquet cache across the loop. See issue #3596.
+    parquet_cache: dict[str, pd.DataFrame] = {}
+
     for old_idx, new_idx in tqdm(
         sorted(episode_mapping.items(), key=lambda x: x[1]), desc="Processing episodes metadata"
     ):
-        src_episode_full = _load_episode_with_stats(src_dataset, old_idx)
+        src_episode_full = _load_episode_with_stats(src_dataset, old_idx, parquet_cache=parquet_cache)
 
         src_episode = src_dataset.meta.episodes[old_idx]
 

--- a/tests/datasets/test_dataset_tools.py
+++ b/tests/datasets/test_dataset_tools.py
@@ -18,6 +18,7 @@
 from unittest.mock import patch
 
 import numpy as np
+import pandas as pd
 import pytest
 import torch
 
@@ -1368,3 +1369,35 @@ def test_reencode_dataset_multi_key_multiprocessing(
     for vk in dataset.meta.video_keys:
         persisted_encoder = VideoEncoderConfig.from_video_info(persisted_info.features[vk].get("info", {}))
         assert persisted_encoder == target_cfg
+
+
+def test_copy_and_reindex_metadata_caches_parquet_reads(sample_dataset, tmp_path):
+    """Verify that copy/reindex shares a parquet cache across episodes (issue #3596).
+
+    The sample dataset has five episodes whose stats all live in a single metadata
+    parquet file. Without caching, ``_load_episode_with_stats`` reloads that file
+    once per episode, which scales poorly. With caching, each parquet file should
+    be read exactly once even when many episodes are processed.
+    """
+    output_dir = tmp_path / "filtered"
+
+    with (
+        patch("lerobot.datasets.dataset_metadata.get_safe_version") as mock_get_safe_version,
+        patch("lerobot.datasets.dataset_metadata.snapshot_download") as mock_snapshot_download,
+        patch("lerobot.datasets.dataset_tools.pd.read_parquet", wraps=pd.read_parquet) as mock_read_parquet,
+    ):
+        mock_get_safe_version.return_value = "v3.0"
+        mock_snapshot_download.return_value = str(output_dir)
+
+        delete_episodes(
+            sample_dataset,
+            episode_indices=[2],
+            output_dir=output_dir,
+        )
+
+    metadata_calls = [
+        call for call in mock_read_parquet.call_args_list if "meta/episodes/" in str(call.args[0])
+    ]
+    unique_paths = {str(call.args[0]) for call in metadata_calls}
+    # One read per unique metadata parquet file, not one per episode.
+    assert len(metadata_calls) == len(unique_paths)


### PR DESCRIPTION
Closes #3596.

`_copy_and_reindex_episodes_metadata` loops over every episode in `delete_episodes`, `split_dataset`, and `merge_datasets`, calling `_load_episode_with_stats` for each one. That helper opens the underlying `meta/episodes/.../*.parquet` file from disk on every call, even though many episodes share the same file. The reporter observed an 8 hour reindex on a ~10k-episode dataset where stats lived in a single 130 MB parquet, because that file was loaded thousands of times.

This adds an optional `parquet_cache` dict to `_load_episode_with_stats` and threads a fresh one through the reindex loop, so each unique metadata parquet is read at most once per operation. The cache is local to the call rather than a module global, and the new parameter is opt-in so any other callers of the helper keep their current behavior. Behavior is otherwise unchanged: the returned dict is the same `episode_row.to_dict()` it has always been.

Coverage comes from a new test that patches `pd.read_parquet` around `delete_episodes` and asserts the number of metadata reads equals the number of unique parquet paths, not the number of episodes. Removing the cache wiring causes the test to fail with four reads against one unique path on the existing fixture. All 52 tests in `tests/datasets/test_dataset_tools.py` pass locally on Python 3.13.