### PR TITLE
fix(groot): support Transformers 5.4+ Eagle Flash Attention initialization

### DIFF
--- a/src/lerobot/policies/groot/eagle2_hg_model/modeling_eagle2_5_vl.py
+++ b/src/lerobot/policies/groot/eagle2_hg_model/modeling_eagle2_5_vl.py
@@ -60,6 +60,7 @@ class Eagle25VLPreTrainedModel(PreTrainedModel):
         "SiglipEncoderLayer",
     ]
     _skip_keys_device_placement = "past_key_values"
+    _supports_flash_attn = True
     _supports_flash_attn_2 = True
     _supports_cache_class = True
     _supports_static_cache = True

--- a/src/lerobot/policies/groot/eagle2_hg_model/processing_eagle2_5_vl.py
+++ b/src/lerobot/policies/groot/eagle2_hg_model/processing_eagle2_5_vl.py
@@ -124,7 +124,6 @@ class Eagle25VLProcessor(ProcessorMixin):
         "videos_kwargs",
         "text_kwargs",
     ]
-    image_processor_class = "AutoImageProcessor"
     tokenizer_class = "AutoTokenizer"
 
     def __init__(

--- a/src/lerobot/policies/groot/processor_groot.py
+++ b/src/lerobot/policies/groot/processor_groot.py
@@ -206,7 +206,11 @@ def _build_eagle_processor(tokenizer_assets_repo: str = DEFAULT_TOKENIZER_ASSETS
             "Vendor files are copied during model creation. Create the policy/model first, "
             "or call ensure_eagle_cache_ready() before building processors."
         )
-    proc = AutoProcessor.from_pretrained(str(cache_dir), trust_remote_code=True, use_fast=True)
+    proc = AutoProcessor.from_pretrained(
+        str(cache_dir),
+        trust_remote_code=True,
+        fix_mistral_regex=False,
+    )
     proc.tokenizer.padding_side = "left"
     return proc
 


### PR DESCRIPTION
## Summary / Motivation

This PR updates the vendored Eagle25VL model and processor of GR00T for the Transformers 5.4+ runtime. 

Original GR00T initialization fails on Transformers 5.4.0 because the dynamic Eagle model only declares the legacy Flash Attention 2 support flag. The PR also removes processor-loading warnings introduced by newer Transformers APIs while keeping tokenizer behavior unchanged.

## What changed

### 1. Declare support for the unified Flash Attention capability flag

```diff
 class Eagle25VLPreTrainedModel(PreTrainedModel):
     ...
     _skip_keys_device_placement = "past_key_values"
+    _supports_flash_attn = True
     _supports_flash_attn_2 = True
```

with `transformers==5.4.0`, GR00T init failed during Eagle model initialization:

```text
transformers 5.4.0
flash_attn 2.8.3

E           ValueError: Eagle25VLForConditionalGeneration does not support Flash Attention 2 yet.
../../../.venvs/lerobot-pi0-pi05-openpi-py312-cu118-apptainer/lib/python3.12/site-packages/transformers/modeling_utils.py:1637: ValueError

FAILED tests/policies/groot/test_groot_lerobot.py::test_lerobot_groot_inference
FAILED tests/policies/groot/test_groot_lerobot.py::test_lerobot_groot_forward_pass
============================== 2 failed in 9.25s ===============================
```

Transformers 5.3.x still accepted the legacy custom-model flag:

```python
self._supports_flash_attn or getattr(self, "_supports_flash_attn_2", False)
```

Transformers 5.4.0 moved to the unified Flash Attention dispatcher, where the init-time check reads:

```python
if not self._supports_flash_attn:
    raise ValueError(...)
```

### 2. Remove deprecated `image_processor_class = "AutoImageProcessor"`

```diff
 class Eagle25VLProcessor(ProcessorMixin):
     ...
-    image_processor_class = "AutoImageProcessor"
     tokenizer_class = "AutoTokenizer"
```

The processor emitted this warning during GR00T inference:

```text
`Eagle25VLProcessor` defines `image_processor_class = 'AutoImageProcessor'`, which is deprecated.
Register the correct mapping in `AutoImageProcessor` instead.
```

Transformers 5.4+ no longer wants processors to hard-code an Auto class through `image_processor_class`. The Eagle processor assets already provide an `auto_map` entry that points `AutoImageProcessor` to the vendored `Eagle25VLImageProcessorFast` implementation, so this is redundant and triggers a deprecation warning.


### 3. Remove deprecated `use_fast=True` and set `fix_mistral_regex=False`

```diff
-proc = AutoProcessor.from_pretrained(str(cache_dir), trust_remote_code=True, use_fast=True)
+proc = AutoProcessor.from_pretrained(
+    str(cache_dir),
+    trust_remote_code=True,
+    fix_mistral_regex=False,
+)
```
- Newer Transformers image processors use an explicit backend selection system. The old `use_fast=True` flag is deprecated.
- The Eagle processor uses a Qwen tokenizer, not a Mistral tokenizer. However, the local dynamic processor cache can still trigger the Transformers' Mistral-regex detection path, producing a misleading warning.

## How was this tested (or how to run locally)

- Test command
```bash
python -u -m pytest -sv tests/policies/groot/test_groot_lerobot.py
```

<details>
<summary>logs under transformers 5.4.0</summary>

```text
[groot-test:tf540] inside apptainer Fri May 22 23:00:32 CST 2026
HOST-10-140-66-122
VIRTUAL_ENV=/mnt/hwfile/songhaoming/.venvs/lerobot-pi0-pi05-openpi-py312-cu118-apptainer
python 3.12.13
torch 2.7.0+cu118
cuda_available True
cuda_device_count 8
cuda_device_0 NVIDIA A800-SXM4-80GB
transformers 5.4.0
flash_attn 2.8.3

collecting ... collected 2 items
tests/policies/groot/test_groot_lerobot.py::test_lerobot_groot_inference PASSED
tests/policies/groot/test_groot_lerobot.py::test_lerobot_groot_forward_pass PASSED
======================== 2 passed, 4 warnings in 30.15s ========================
```

</details>


<details>
<summary>logs under transformers 5.5.4</summary>

```text
[groot-test:tf554] inside apptainer Fri May 22 23:06:47 CST 2026
HOST-10-140-66-17
python 3.12.13
torch 2.7.0+cu118
cuda_available True
cuda_device_count 8
cuda_device_0 NVIDIA A800-SXM4-80GB
transformers 5.5.4
flash_attn 2.8.3

collecting ... collected 2 items
tests/policies/groot/test_groot_lerobot.py::test_lerobot_groot_inference PASSED
tests/policies/groot/test_groot_lerobot.py::test_lerobot_groot_forward_pass PASSED
======================== 2 passed, 4 warnings in 59.30s ========================
```

</details>


## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated (No need for update)
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: # (insert PR number/link)
