### PR TITLE
docs: add virtual environment troubleshooting

### DIFF
--- a/docs/source/installation.mdx
+++ b/docs/source/installation.mdx
@@ -268,6 +268,58 @@ sudo apt-get install cmake build-essential python3-dev pkg-config libavformat-de
 
 For other systems, see: [Compiling PyAV](https://pyav.org/docs/develop/overview/installation.html#bring-your-own-ffmpeg)
 
+### Verify your Python environment
+
+After activating your virtual environment, verify that `python` and `pip` are using the same environment:
+
+```bash
+which python
+python --version
+python -m pip --version
+python -c "import sys; print(sys.executable)"
+```
+
+The output should point to your active virtual environment, for example:
+
+```bash
+/path/to/lerobot/.venv/bin/python
+```
+
+We recommend using:
+
+```bash
+python -m pip install -e .
+```
+
+instead of:
+
+```bash
+pip install -e .
+```
+
+This helps avoid installing packages into a different Python environment.
+
+If you encounter:
+
+```bash
+No module named pip
+```
+
+you can install pip into the active environment with:
+
+```bash
+python -m ensurepip --upgrade
+python -m pip install --upgrade pip
+```
+
+### Verify your LeRobot installation
+
+After installation, verify that LeRobot is correctly installed:
+
+```bash
+python -c "import lerobot; print(lerobot.__file__)"
+```
+
 ## Optional dependencies
 
 LeRobot provides optional extras for specific functionalities. Multiple extras can be combined (e.g., `.[aloha,feetech]`). For all available extras, refer to `pyproject.toml`. If you are using `uv`, replace `pip install` with `uv pip install` in the commands below.


### PR DESCRIPTION
## Title

Short, imperative summary (e.g., "fix(robots): handle None in sensor parser"). See [CONTRIBUTING.md](../CONTRIBUTING.md) for PR conventions.

## Summary / Motivation

Adds a troubleshooting section for Python virtual environments, including:

* verifying that `python` and `pip` use the same environment
* recommending `python -m pip`
* resolving `No module named pip`
* verifying LeRobot installation

This aims to reduce onboarding friction and environment setup confusion for new contributors, especially when using local virtual environments such as `.venv`.


## Related issues

- Fixes / Closes: n/a
- Related: n/a

## What changed
- Added a "Verify your Python environment" section to the installation guide
- Added commands for checking the active Python executable and pip environment
- Added troubleshooting steps for missing pip inside virtual environments
- Added a simple command for verifying that LeRobot is correctly installed

## How was this tested (or how to run locally)

Manual checks performed locally on Apple Silicon macOS using a .venv environment:

which python
python -m pip --version
python -c "import sys; print(sys.executable)"
python -c "import lerobot; print(lerobot.__file__)"

Verified that:

the commands point to the active .venv
python -m ensurepip --upgrade correctly installs missing pip
python -m pip install -e . works correctly after environment setup

## Checklist (required before merge)

- [ ] Linting/formatting run (`pre-commit run -a`)
- [ ] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: # (insert PR number/link)

## Reviewer notes

n/a
