### PR TITLE
fix(edit-dataset): redirect dataset.root via backup_path from get_output_path

### DIFF
--- a/src/lerobot/scripts/lerobot_edit_dataset.py
+++ b/src/lerobot/scripts/lerobot_edit_dataset.py
@@ -347,10 +347,11 @@ def get_output_path(
     new_repo_id: str | None,
     root: Path | str | None,
     new_root: Path | str | None,
-) -> tuple[str, Path]:
+) -> tuple[str, Path, Path | None]:
     output_repo_id, input_path, output_path = _resolve_io_paths(repo_id, new_repo_id, root, new_root)
 
     # In case of in-place modification, create a backup of the original dataset (if it exists)
+    backup_path: Path | None = None
     if output_path == input_path:
         backup_path = input_path.with_name(input_path.name + "_old")
 
@@ -359,7 +360,7 @@ def get_output_path(
                 shutil.rmtree(backup_path)
             shutil.move(input_path, backup_path)
 
-    return output_repo_id, output_path
+    return output_repo_id, output_path, backup_path
 
 
 def handle_delete_episodes(cfg: EditDatasetConfig) -> None:
@@ -370,16 +371,15 @@ def handle_delete_episodes(cfg: EditDatasetConfig) -> None:
         raise ValueError("episode_indices must be specified for delete_episodes operation")
 
     dataset = LeRobotDataset(cfg.repo_id, root=cfg.root)
-    output_repo_id, output_dir = get_output_path(
+    output_repo_id, output_dir, backup_path = get_output_path(
         cfg.repo_id,
         new_repo_id=cfg.new_repo_id,
         root=cfg.root,
         new_root=cfg.new_root,
     )
 
-    # In case of in-place modification, make the dataset point to the backup directory
-    if output_dir == dataset.root:
-        dataset.root = dataset.root.with_name(dataset.root.name + "_old")
+    if backup_path is not None:
+        dataset.root = backup_path
 
     logging.info(f"Deleting episodes {cfg.operation.episode_indices} from {cfg.repo_id}")
     new_dataset = delete_episodes(
@@ -481,16 +481,15 @@ def handle_remove_feature(cfg: EditDatasetConfig) -> None:
         raise ValueError("feature_names must be specified for remove_feature operation")
 
     dataset = LeRobotDataset(cfg.repo_id, root=cfg.root)
-    output_repo_id, output_dir = get_output_path(
+    output_repo_id, output_dir, backup_path = get_output_path(
         cfg.repo_id,
         new_repo_id=cfg.new_repo_id,
         root=cfg.root,
         new_root=cfg.new_root,
     )
 
-    # In case of in-place modification, make the dataset point to the backup directory
-    if output_dir == dataset.root:
-        dataset.root = dataset.root.with_name(dataset.root.name + "_old")
+    if backup_path is not None:
+        dataset.root = backup_path
 
     logging.info(f"Removing features {cfg.operation.feature_names} from {cfg.repo_id}")
     new_dataset = remove_feature(

--- a/tests/scripts/test_edit_dataset_io.py
+++ b/tests/scripts/test_edit_dataset_io.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+
+import pytest
+
+pytest.importorskip("datasets", reason="datasets is required (install lerobot[dataset])")
+
+from lerobot.scripts import lerobot_edit_dataset as edit_dataset_module
+from lerobot.scripts.lerobot_edit_dataset import get_output_path
+
+
+def test_get_output_path_non_in_place(tmp_path, monkeypatch):
+    monkeypatch.setattr(edit_dataset_module, "HF_LEROBOT_HOME", tmp_path)
+    src = tmp_path / "user/dataset"
+    src.mkdir(parents=True)
+
+    _, output_path, backup_path = get_output_path("user/dataset", "user/dataset-edited", None, None)
+
+    assert output_path == (tmp_path / "user/dataset-edited").resolve()
+    assert backup_path is None
+    assert src.exists()
+
+
+def test_get_output_path_in_place_backs_up_original(tmp_path, monkeypatch):
+    monkeypatch.setattr(edit_dataset_module, "HF_LEROBOT_HOME", tmp_path)
+    src = tmp_path / "user/dataset"
+    src.mkdir(parents=True)
+    (src / "marker").write_text("x")
+
+    _, _, backup_path = get_output_path("user/dataset", None, None, None)
+
+    assert backup_path == tmp_path / "user/dataset_old"
+    assert (backup_path / "marker").exists()
+    assert not src.exists()
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="symlink semantics differ on Windows")
+def test_get_output_path_in_place_with_symlinked_cache(tmp_path, monkeypatch):
+    # Regression: with a symlinked HF_LEROBOT_HOME, the previous caller-side
+    # path-equality check missed the in-place case and the backup was skipped.
+    real_home = tmp_path / "real"
+    real_home.mkdir()
+    link_home = tmp_path / "linked"
+    link_home.symlink_to(real_home)
+    monkeypatch.setattr(edit_dataset_module, "HF_LEROBOT_HOME", link_home)
+
+    src = link_home / "user/dataset"
+    src.mkdir(parents=True)
+    (src / "marker").write_text("x")
+
+    _, _, backup_path = get_output_path("user/dataset", None, None, None)
+
+    assert backup_path is not None
+    assert (backup_path / "marker").exists()


### PR DESCRIPTION
## Summary / Motivation

When running `lerobot-edit-dataset` for in-place edits (`delete_episodes` / `remove_feature`), the original dataset is renamed to `<name>_old` so the new dataset can be written under the same name. The handler then redirects the open `LeRobotDataset` to read from the backup. That redirect was guarded by `output_dir == dataset.root`:

- `output_dir` came from `get_output_path` / `_resolve_io_paths`, which runs `.resolve()`.
- `dataset.root` was set in `LeRobotDatasetMetadata.__init__` as `HF_LEROBOT_HOME / repo_id`, **without** `.resolve()`.

If `HF_LEROBOT_HOME` traverses a symlink (common when `~/.cache` is symlinked to scratch / another disk), the two paths describe the same directory but compare unequal as strings, the redirect is skipped, and `_copy_and_reindex_videos` then tries to read from the just-renamed-away original location:

```
FileNotFoundError: [Errno 2] No such file or directory:
'/home/<user>/.cache/huggingface/lerobot/<user>/<dataset>/videos/<key>/chunk-000/file-000.mp4'
```

(reproduced locally on a setup where `/home/<user>/.cache` symlinks to a separate disk).

## What changed

- `get_output_path` now returns `(output_repo_id, output_path, backup_path)`. `backup_path` is the new location of the original dataset for in-place edits, or `None` otherwise.
- `handle_delete_episodes` and `handle_remove_feature` use the returned `backup_path` to redirect `dataset.root`, removing the path-equality check that broke under a symlinked cache.

No behavior change for non-in-place edits, and no change to the on-disk layout of either the output or backup directory.

## Related issues

None linked.

## How was this tested

- Added `tests/scripts/test_edit_dataset_io.py` covering: non-in-place (no backup), in-place backup of original, and the regression case where `HF_LEROBOT_HOME` is a symlink.
- `pytest tests/scripts/test_edit_dataset_io.py tests/scripts/test_edit_dataset_parsing.py tests/datasets/test_dataset_tools.py` → all pass.
- Manually reproduced the original failure on a symlinked-cache machine; same invocation succeeds with this patch.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a` on changed files)
- [x] All tests pass locally (touched modules)
- [ ] Documentation updated (no user-facing API changes)
- [ ] CI is green
- [ ] Community Review

🤖 Generated with [Claude Code](https://claude.com/claude-code)