### PR TITLE
fix(datasets): skip zero-width features in compute_episode_stats

### DIFF
--- a/src/lerobot/datasets/compute_stats.py
+++ b/src/lerobot/datasets/compute_stats.py
@@ -515,6 +515,9 @@ def compute_episode_stats(
         if features[key]["dtype"] in {"string", "language"}:
             continue
 
+        if any(d == 0 for d in features[key].get("shape", ())):
+            continue
+
         if features[key]["dtype"] in ["image", "video"]:
             ep_ft_array = sample_images(data)
             axes_to_reduce = (0, 2, 3)

--- a/src/lerobot/datasets/compute_stats.py
+++ b/src/lerobot/datasets/compute_stats.py
@@ -516,6 +516,9 @@ def compute_episode_stats(
             continue
 
         if any(d == 0 for d in features[key].get("shape", ())):
+            logging.warning(
+                f"Skipping stats for feature '{key}' with a zero-width shape {features[key]['shape']}."
+            )
             continue
 
         if features[key]["dtype"] in ["image", "video"]:

--- a/tests/datasets/test_compute_stats.py
+++ b/tests/datasets/test_compute_stats.py
@@ -643,6 +643,29 @@ def test_compute_episode_stats_string_features_skipped():
     assert "q01" in stats["action"]
 
 
+def test_compute_episode_stats_zero_width_features_skipped():
+    """Test that features with a zero-width dim (e.g. shape=(0,)) are skipped."""
+    episode_data = {
+        "empty": np.zeros((100, 0), dtype=np.float32),  # Zero-width feature
+        "action": np.random.normal(0, 1, (100, 5)),
+    }
+    features = {
+        "empty": {"dtype": "float32", "shape": (0,)},
+        "action": {"dtype": "float32", "shape": (5,)},
+    }
+
+    stats = compute_episode_stats(
+        episode_data,
+        features,
+    )
+
+    # Zero-width features should be skipped
+    assert "empty" not in stats
+    assert "action" in stats
+    assert "q01" in stats["action"]
+    assert stats["action"]["mean"].shape == (5,)
+
+
 def test_aggregate_feature_stats_with_quantiles():
     """Test aggregating feature stats that include quantiles."""
     stats_ft_list = [

--- a/tests/datasets/test_compute_stats.py
+++ b/tests/datasets/test_compute_stats.py
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import logging
 from unittest.mock import patch
 
 import numpy as np
@@ -643,8 +644,8 @@ def test_compute_episode_stats_string_features_skipped():
     assert "q01" in stats["action"]
 
 
-def test_compute_episode_stats_zero_width_features_skipped():
-    """Test that features with a zero-width dim (e.g. shape=(0,)) are skipped."""
+def test_compute_episode_stats_zero_width_features_skipped(caplog):
+    """Test that features with a zero-width dim (e.g. shape=(0,)) are skipped with a warning."""
     episode_data = {
         "empty": np.zeros((100, 0), dtype=np.float32),  # Zero-width feature
         "action": np.random.normal(0, 1, (100, 5)),
@@ -654,13 +655,12 @@ def test_compute_episode_stats_zero_width_features_skipped():
         "action": {"dtype": "float32", "shape": (5,)},
     }
 
-    stats = compute_episode_stats(
-        episode_data,
-        features,
-    )
+    with caplog.at_level(logging.WARNING):
+        stats = compute_episode_stats(episode_data, features)
 
-    # Zero-width features should be skipped
+    # Zero-width features should be skipped with a warning, others computed as usual
     assert "empty" not in stats
+    assert "empty" in caplog.text
     assert "action" in stats
     assert "q01" in stats["action"]
     assert stats["action"]["mean"].shape == (5,)


### PR DESCRIPTION
Related to #3654. `LeRobotDataset.save_episode()` raises `ValueError: cannot reshape array of size 0 into shape (0)` whenever a non-string feature has a zero-width dimension (e.g. `shape=(0,)`).

`compute_episode_stats` only skips features with `dtype` in `{"string", "language"}`. Numeric features with a zero-width shape fall through to `RunningQuantileStats.update`, which does `batch.reshape(-1, batch.shape[-1])` on an empty array and crashes.

Add an analogous skip right after the existing one:

```python
if any(d == 0 for d in features[key].get("shape", ())):
    continue
```

`test_compute_episode_stats_zero_width_features_skipped` covers the regression: a zero-width feature is absent from the returned stats while a normal numeric feature is fully populated.

This PR is a partial fix for #3654. The end-to-end repro from the issue also hits a second crash one layer further down, in HF Datasets / pyarrow serialization (`ArrowInvalid: list_size needs to be a strict positive integer`). Different code path, so it's split into #3665. Both this PR and #3665 need to land before `save_episode()` succeeds on the issue's repro, so I've used "Related to" instead of a closing keyword on this one.