### PR TITLE
fix(pi0, wandb): drop no-op vision warning and expand list-valued metrics

### DIFF
--- a/src/lerobot/common/wandb_utils.py
+++ b/src/lerobot/common/wandb_utils.py
@@ -180,7 +180,21 @@ class WandBLogger:
                 self._wandb_custom_step_key.add(new_custom_key)
                 self._wandb.define_metric(new_custom_key, hidden=True)
 
+        # Expand list/tuple of scalars (e.g. loss_per_dim) into per-index entries
+        # before the scalar type guard below; mixed-type or nested lists fall through.
+        expanded = {}
         for k, v in d.items():
+            if (
+                isinstance(v, (list, tuple))
+                and len(v) > 0
+                and all(isinstance(elem, (int, float)) and not isinstance(elem, bool) for elem in v)
+            ):
+                for i, elem in enumerate(v):
+                    expanded[f"{k}_{i}"] = elem
+            else:
+                expanded[k] = v
+
+        for k, v in expanded.items():
             if not isinstance(v, (int | float | str)):
                 logging.warning(
                     f'WandB logging of key "{k}" was ignored as its type "{type(v)}" is not handled by this wrapper.'

--- a/src/lerobot/policies/pi0/modeling_pi0.py
+++ b/src/lerobot/policies/pi0/modeling_pi0.py
@@ -1126,11 +1126,6 @@ class PI0Policy(PreTrainedPolicy):
             elif key.startswith("time_mlp_out."):
                 new_key = key.replace("time_mlp_out.", "action_time_mlp_out.")
 
-            # Handle vision tower embedding layer potential differences
-            if "patch_embedding" in key:
-                # Some checkpoints might have this, but current model expects different structure
-                logging.warning(f"Vision embedding key might need handling: {key}")
-
             if (
                 key == "model.paligemma_with_expert.paligemma.lm_head.weight"
                 or key == "paligemma_with_expert.paligemma.lm_head.weight"

--- a/tests/utils/test_wandb_utils.py
+++ b/tests/utils/test_wandb_utils.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from lerobot.common.wandb_utils import WandBLogger
+
+
+@pytest.fixture
+def logger():
+    instance = WandBLogger.__new__(WandBLogger)
+    instance._wandb = MagicMock()
+    instance._wandb_custom_step_key = None
+    return instance
+
+
+def test_log_dict_expands_list_of_floats(logger):
+    logger.log_dict({"loss_per_dim": [0.1, 0.2, 0.3]}, step=0, mode="train")
+
+    calls = logger._wandb.log.call_args_list
+    logged = {next(iter(c.kwargs["data"])): next(iter(c.kwargs["data"].values())) for c in calls}
+    assert logged == {
+        "train/loss_per_dim_0": 0.1,
+        "train/loss_per_dim_1": 0.2,
+        "train/loss_per_dim_2": 0.3,
+    }
+
+
+def test_log_dict_unsupported_value_still_warned(logger, caplog):
+    with caplog.at_level(logging.WARNING):
+        logger.log_dict({"weird": [0.1, "string", 0.3]}, step=0, mode="train")
+    assert logger._wandb.log.call_count == 0
+    assert any("was ignored" in record.message for record in caplog.records)


### PR DESCRIPTION
Fixes #3109, two small bugs in the PI0 path:

(a) `modeling_pi0.py` emitted `Vision embedding key might need handling: <key>` for every key containing `patch_embedding`, then did nothing actionable. The key flows through the normal mapping on the very next line. Removed the warning; behaviour is unchanged.

(b) `WandBLogger.log_dict` gates on `isinstance(v, (int | float | str))` and drops everything else. But PI0 emits `loss_per_dim` as a `list[float]`, so it never reached WandB. Expand list/tuple of real scalars (int/float, bools excluded) into per-index entries (`loss_per_dim_0`, `loss_per_dim_1`, and so on) before the existing type guard. Mixed-type, empty, and nested sequences still hit the existing warning.

Supersedes the stale #3116 by @he-yufeng, which became conflict-stuck after `wandb_utils.py` was moved from `src/lerobot/rl/` to `src/lerobot/common/` in #3142. This lands the fix on the new path and targets the actual warning site (the `patch_embedding` no-op, not the `embed_tokens.weight` mapping). Thanks @he-yufeng for the original report.

Tests in `tests/utils/test_wandb_utils.py`: one asserts the list is expanded, one asserts mixed-type lists still trigger the existing warning.