### PR TITLE
Support fsspec roots in StreamingLeRobotDataset

### DIFF
--- a/docs/source/lerobot-dataset-v3.mdx
+++ b/docs/source/lerobot-dataset-v3.mdx
@@ -142,6 +142,16 @@ repo_id = "yaak-ai/L2D-v3"
 dataset = StreamingLeRobotDataset(repo_id)  # streams directly from the Hub
 ```
 
+You can also stream a LeRobot v3 dataset from any fsspec-compatible storage root, such as S3 or GCS:
+
+```python
+dataset = StreamingLeRobotDataset(
+    repo_id="my-org/my-dataset",
+    root="s3://my-bucket/path/to/my-dataset",
+    storage_options={"anon": False},  # optional; depends on the filesystem backend
+)
+```
+
 <div style="display:flex; justify-content:center; gap:12px; flex-wrap:wrap;">
   <figure style="margin:0; text-align:center;">
     <img

--- a/src/lerobot/datasets/dataset_metadata.py
+++ b/src/lerobot/datasets/dataset_metadata.py
@@ -14,9 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import contextlib
+import json
 from collections.abc import Callable
 from pathlib import Path
 
+import datasets
+import fsspec
 import numpy as np
 import packaging.version
 import pandas as pd
@@ -32,6 +35,7 @@ from lerobot.utils.utils import flatten_dict
 from .compute_stats import aggregate_stats
 from .feature_utils import create_empty_dataset_info
 from .io_utils import (
+    cast_stats_to_numpy,
     get_file_size_in_mb,
     load_episodes,
     load_info,
@@ -44,6 +48,11 @@ from .io_utils import (
 from .language import DEFAULT_TOOLS, LANGUAGE_COLUMNS
 from .utils import (
     DEFAULT_EPISODES_PATH,
+    DEFAULT_TASKS_PATH,
+    EPISODES_DIR,
+    INFO_PATH,
+    STATS_PATH,
+    DatasetInfo,
     check_version_compatibility,
     get_safe_version,
     has_legacy_hub_download_metadata,
@@ -53,6 +62,14 @@ from .utils import (
 from .video_utils import get_video_info
 
 CODEBASE_VERSION = "v3.0"
+
+
+def is_fsspec_uri(path: str | Path | None) -> bool:
+    return isinstance(path, str) and "://" in path and not path.startswith("file://")
+
+
+def _remote_join(root: str, *parts: str) -> str:
+    return "/".join([root.rstrip("/"), *(part.strip("/") for part in parts)])
 
 
 class LeRobotDatasetMetadata:
@@ -70,6 +87,7 @@ class LeRobotDatasetMetadata:
         revision: str | None = None,
         force_cache_sync: bool = False,
         metadata_buffer_size: int = 10,
+        storage_options: dict | None = None,
     ):
         """Load or download metadata for an existing LeRobot dataset.
 
@@ -94,7 +112,9 @@ class LeRobotDatasetMetadata:
         """
         self.repo_id = repo_id
         self.revision = revision if revision else CODEBASE_VERSION
-        self._requested_root = Path(root) if root is not None else None
+        self._remote_root = is_fsspec_uri(root)
+        self._storage_options = dict(storage_options or {})
+        self._requested_root = root if self._remote_root else Path(root) if root is not None else None
         self.root = self._requested_root if self._requested_root is not None else HF_LEROBOT_HOME / repo_id
         self._pq_writer = None
         self.latest_episode = None
@@ -109,6 +129,8 @@ class LeRobotDatasetMetadata:
                 raise FileNotFoundError
             self._load_metadata()
         except (FileNotFoundError, NotADirectoryError):
+            if self._remote_root:
+                raise
             if is_valid_version(self.revision):
                 self.revision = get_safe_version(self.repo_id, self.revision)
 
@@ -174,11 +196,48 @@ class LeRobotDatasetMetadata:
             self.finalize()
 
     def _load_metadata(self):
+        if self._remote_root:
+            self._load_remote_metadata()
+            return
+
         self.info = load_info(self.root)
         check_version_compatibility(self.repo_id, self._version, CODEBASE_VERSION)
         self.tasks = load_tasks(self.root)
         self.episodes = load_episodes(self.root)
         self.stats = load_stats(self.root)
+
+    def _load_remote_metadata(self):
+        info_path = _remote_join(self.root, INFO_PATH)
+        with fsspec.open(info_path, mode="r", **self._storage_options) as f:
+            self.info = DatasetInfo.from_dict(json.load(f))
+        check_version_compatibility(self.repo_id, self._version, CODEBASE_VERSION)
+
+        tasks_path = _remote_join(self.root, DEFAULT_TASKS_PATH)
+        with fsspec.open(tasks_path, **self._storage_options) as f:
+            self.tasks = pd.read_parquet(f)
+        self.tasks.index.name = "task"
+
+        fs, episodes_pattern = fsspec.core.url_to_fs(
+            _remote_join(self.root, EPISODES_DIR, "*", "*.parquet"),
+            **self._storage_options,
+        )
+        episodes_paths = sorted(fs.unstrip_protocol(path) for path in fs.glob(episodes_pattern))
+        if len(episodes_paths) == 0:
+            raise FileNotFoundError(f"Remote dataset does not contain episode metadata: {self.root}")
+        self.episodes = datasets.Dataset.from_parquet(
+            episodes_paths, storage_options=dict(self._storage_options)
+        )
+        self.episodes = self.episodes.select_columns(
+            [key for key in self.episodes.features if not key.startswith("stats/")]
+        )
+
+        stats_path = _remote_join(self.root, STATS_PATH)
+        fs, stripped_stats_path = fsspec.core.url_to_fs(stats_path, **self._storage_options)
+        if fs.exists(stripped_stats_path):
+            with fsspec.open(stats_path, mode="r", **self._storage_options) as f:
+                self.stats = cast_stats_to_numpy(json.load(f))
+        else:
+            self.stats = None
 
     def ensure_readable(self) -> None:
         """Guarantee metadata is fully loaded for read operations.

--- a/src/lerobot/datasets/streaming_dataset.py
+++ b/src/lerobot/datasets/streaming_dataset.py
@@ -24,7 +24,7 @@ from datasets import load_dataset
 
 from lerobot.utils.constants import HF_LEROBOT_HOME, LOOKAHEAD_BACKTRACKTABLE, LOOKBACK_BACKTRACKTABLE
 
-from .dataset_metadata import CODEBASE_VERSION, LeRobotDatasetMetadata
+from .dataset_metadata import CODEBASE_VERSION, LeRobotDatasetMetadata, is_fsspec_uri
 from .feature_utils import get_delta_indices
 from .io_utils import item_to_torch
 from .utils import (
@@ -252,13 +252,15 @@ class StreamingLeRobotDataset(torch.utils.data.IterableDataset):
         rng: np.random.Generator | None = None,
         shuffle: bool = True,
         return_uint8: bool = False,
+        storage_options: dict | None = None,
     ):
         """Initialize a StreamingLeRobotDataset.
 
         Args:
             repo_id (str): This is the repo id that will be used to fetch the dataset.
-            root (Path | None, optional): Local directory to use for local datasets. When omitted, Hub
-                metadata is resolved through a revision-safe snapshot cache under
+            root (str | Path | None, optional): Local directory to use for local datasets or an
+                fsspec-compatible URI such as ``s3://bucket/dataset`` or ``gs://bucket/dataset``.
+                When omitted, Hub metadata is resolved through a revision-safe snapshot cache under
                 ``$HF_LEROBOT_HOME/hub``.
             episodes (list[int] | None, optional): If specified, this will only load episodes specified by
                 their episode_index in this list.
@@ -272,12 +274,16 @@ class StreamingLeRobotDataset(torch.utils.data.IterableDataset):
             seed (int, optional): Reproducibility random seed.
             rng (np.random.Generator | None, optional): Random number generator.
             shuffle (bool, optional): Whether to shuffle the dataset across exhaustions. Defaults to True.
+            storage_options (dict | None, optional): Extra options passed to fsspec/Hugging Face Datasets
+                when ``root`` is a remote URI.
         """
         super().__init__()
         self.repo_id = repo_id
-        self._requested_root = Path(root) if root else None
+        self.storage_options = dict(storage_options or {})
+        self.streaming_from_remote = is_fsspec_uri(root)
+        self._requested_root = root if self.streaming_from_remote else Path(root) if root else None
         self.root = self._requested_root if self._requested_root is not None else HF_LEROBOT_HOME / repo_id
-        self.streaming_from_local = root is not None
+        self.streaming_from_local = root is not None and not self.streaming_from_remote
 
         self.image_transforms = image_transforms
         self.episodes = episodes
@@ -294,12 +300,16 @@ class StreamingLeRobotDataset(torch.utils.data.IterableDataset):
         # We cache the video decoders to avoid re-initializing them at each frame (avoiding a ~10x slowdown)
         self.video_decoder_cache = None
 
-        if self._requested_root is not None:
+        if self._requested_root is not None and not self.streaming_from_remote:
             self.root.mkdir(exist_ok=True, parents=True)
 
         # Load metadata
         self.meta = LeRobotDatasetMetadata(
-            self.repo_id, self._requested_root, self.revision, force_cache_sync=force_cache_sync
+            self.repo_id,
+            self._requested_root,
+            self.revision,
+            force_cache_sync=force_cache_sync,
+            storage_options=self.storage_options,
         )
         self.root = self.meta.root
         self.revision = self.meta.revision
@@ -314,13 +324,22 @@ class StreamingLeRobotDataset(torch.utils.data.IterableDataset):
             self.delta_timestamps = delta_timestamps
             self.delta_indices = get_delta_indices(self.delta_timestamps, self.fps)
 
-        self.hf_dataset: datasets.IterableDataset = load_dataset(
-            self.repo_id if not self.streaming_from_local else str(self.root),
-            split="train",
-            streaming=self.streaming,
-            data_files="data/*/*.parquet",
-            revision=self.revision,
-        )
+        if self.streaming_from_remote:
+            self.hf_dataset: datasets.IterableDataset = load_dataset(
+                "parquet",
+                split="train",
+                streaming=self.streaming,
+                data_files=f"{str(self.root).rstrip('/')}/data/*/*.parquet",
+                storage_options=dict(self.storage_options),
+            )
+        else:
+            self.hf_dataset: datasets.IterableDataset = load_dataset(
+                self.repo_id if not self.streaming_from_local else str(self.root),
+                split="train",
+                streaming=self.streaming,
+                data_files="data/*/*.parquet",
+                revision=self.revision,
+            )
 
         self.num_shards = min(self.hf_dataset.num_shards, max_num_shards)
 
@@ -552,7 +571,10 @@ class StreamingLeRobotDataset(torch.utils.data.IterableDataset):
 
         item = {}
         for video_key, query_ts in query_timestamps.items():
-            root = self.meta.url_root if self.streaming and not self.streaming_from_local else self.root
+            if self.streaming_from_remote:
+                root = self.root
+            else:
+                root = self.meta.url_root if self.streaming and not self.streaming_from_local else self.root
             video_path = f"{root}/{self.meta.get_video_file_path(ep_idx, video_key)}"
             frames = decode_video_frames_torchcodec(
                 video_path,
@@ -560,6 +582,7 @@ class StreamingLeRobotDataset(torch.utils.data.IterableDataset):
                 self.tolerance_s,
                 decoder_cache=self.video_decoder_cache,
                 return_uint8=self._return_uint8,
+                storage_options=self.storage_options if self.streaming_from_remote else None,
             )
 
             item[video_key] = frames.squeeze(0) if len(query_ts) == 1 else frames

--- a/src/lerobot/datasets/video_utils.py
+++ b/src/lerobot/datasets/video_utils.py
@@ -255,7 +255,7 @@ class VideoDecoderCache:
         with self._lock:
             return str(video_path) in self._cache
 
-    def get_decoder(self, video_path: str):
+    def get_decoder(self, video_path: str, storage_options: dict | None = None):
         """Get a cached decoder or create a new one, evicting LRU if at capacity."""
         if importlib.util.find_spec("torchcodec"):
             from torchcodec.decoders import VideoDecoder
@@ -273,7 +273,7 @@ class VideoDecoderCache:
                 self._cache.move_to_end(video_path)
                 return entry[0]
 
-            file_handle = fsspec.open(video_path).__enter__()
+            file_handle = fsspec.open(video_path, **(storage_options or {})).__enter__()
             try:
                 decoder = VideoDecoder(file_handle, seek_mode="approximate")
             except Exception:
@@ -322,6 +322,7 @@ def decode_video_frames_torchcodec(
     log_loaded_timestamps: bool = False,
     decoder_cache: VideoDecoderCache | None = None,
     return_uint8: bool = False,
+    storage_options: dict | None = None,
 ) -> torch.Tensor:
     """Loads frames associated with the requested timestamps of a video using torchcodec.
 
@@ -331,6 +332,7 @@ def decode_video_frames_torchcodec(
         tolerance_s: Allowed deviation in seconds for frame retrieval.
         log_loaded_timestamps: Whether to log loaded timestamps.
         decoder_cache: Optional decoder cache instance. Uses default if None.
+        storage_options: Extra options passed to fsspec when opening remote video files.
 
     Note: Setting device="cuda" outside the main process, e.g. in data loader workers, will lead to CUDA initialization errors.
 
@@ -344,7 +346,7 @@ def decode_video_frames_torchcodec(
         decoder_cache = _default_decoder_cache
 
     # Use cached decoder instead of creating new one each time
-    decoder = decoder_cache.get_decoder(str(video_path))
+    decoder = decoder_cache.get_decoder(str(video_path), storage_options=storage_options)
 
     loaded_ts = []
     loaded_frames = []

--- a/tests/datasets/test_streaming.py
+++ b/tests/datasets/test_streaming.py
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import fsspec
 import numpy as np
 import pytest
 import torch
@@ -23,6 +24,17 @@ from lerobot.datasets.streaming_dataset import StreamingLeRobotDataset
 from lerobot.datasets.utils import safe_shard
 from lerobot.utils.constants import ACTION
 from tests.fixtures.constants import DUMMY_REPO_ID
+
+
+def copy_tree_to_fsspec(local_root, remote_root: str, storage_options: dict | None = None) -> None:
+    fs, remote_path = fsspec.core.url_to_fs(remote_root, **(storage_options or {}))
+    for local_file in local_root.rglob("*"):
+        if not local_file.is_file():
+            continue
+        remote_file = f"{remote_path.rstrip('/')}/{local_file.relative_to(local_root).as_posix()}"
+        fs.makedirs(remote_file.rsplit("/", 1)[0], exist_ok=True)
+        with local_file.open("rb") as src, fs.open(remote_file, "wb") as dst:
+            dst.write(src.read())
 
 
 def get_frames_expected_order(streaming_ds: StreamingLeRobotDataset) -> list[int]:
@@ -113,6 +125,96 @@ def test_single_frame_consistency(tmp_path, lerobot_dataset_factory):
         assert all(t[1] for t in key_checks), (
             f"Checking {list(filter(lambda t: not t[1], key_checks))[0][0]} left and right were found different (frame_idx: {frame_idx})"
         )
+
+
+def test_streaming_dataset_reads_from_fsspec_root(tmp_path, lerobot_dataset_factory):
+    local_path = tmp_path / "test"
+    repo_id = f"{DUMMY_REPO_ID}-fsspec"
+    remote_root = f"memory://{repo_id}"
+
+    local_ds = lerobot_dataset_factory(
+        root=local_path,
+        repo_id=repo_id,
+        total_episodes=2,
+        total_frames=8,
+        use_videos=False,
+    )
+    copy_tree_to_fsspec(local_path, remote_root)
+
+    streaming_ds = iter(
+        StreamingLeRobotDataset(
+            repo_id=repo_id,
+            root=remote_root,
+            buffer_size=4,
+            shuffle=False,
+        )
+    )
+
+    streaming_frame = next(streaming_ds)
+    target_frame = local_ds[streaming_frame["index"]]
+
+    for key, left in streaming_frame.items():
+        right = target_frame[key]
+        if isinstance(left, str):
+            assert left == right
+        elif isinstance(left, torch.Tensor):
+            assert torch.allclose(left, right)
+            assert left.shape == right.shape
+        elif isinstance(left, float):
+            assert left == right.item()
+
+
+def test_streaming_dataset_passes_storage_options_to_remote_video_decoder(
+    tmp_path, lerobot_dataset_factory, monkeypatch
+):
+    local_path = tmp_path / "test"
+    repo_id = f"{DUMMY_REPO_ID}-fsspec-video"
+    remote_root = f"memory://{repo_id}"
+    storage_options = {"auto_mkdir": True}
+    decoder_calls = []
+
+    lerobot_dataset_factory(
+        root=local_path,
+        repo_id=repo_id,
+        total_episodes=1,
+        total_frames=2,
+        use_videos=True,
+    )
+    copy_tree_to_fsspec(local_path, remote_root, storage_options=storage_options)
+
+    def fake_decode_video_frames_torchcodec(
+        video_path,
+        timestamps,
+        tolerance_s,
+        *,
+        decoder_cache=None,
+        return_uint8=False,
+        storage_options=None,
+    ):
+        decoder_calls.append((video_path, storage_options))
+        return torch.zeros((len(timestamps), 3, 4, 4), dtype=torch.uint8 if return_uint8 else torch.float32)
+
+    monkeypatch.setattr(
+        "lerobot.datasets.streaming_dataset.decode_video_frames_torchcodec",
+        fake_decode_video_frames_torchcodec,
+    )
+
+    streaming_ds = iter(
+        StreamingLeRobotDataset(
+            repo_id=repo_id,
+            root=remote_root,
+            buffer_size=1,
+            shuffle=False,
+            storage_options=storage_options,
+        )
+    )
+
+    next(streaming_ds)
+
+    assert decoder_calls
+    for video_path, passed_storage_options in decoder_calls:
+        assert video_path.startswith(remote_root)
+        assert passed_storage_options == storage_options
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- Add fsspec-compatible remote root handling to `StreamingLeRobotDataset` for roots such as `s3://`, `gs://`, and `memory://`.
- Load remote dataset metadata and parquet shards without treating remote URIs as local `Path`s or falling back to Hub downloads.
- Pass `storage_options` through remote metadata/parquet reads and remote video decoding, with regression coverage and docs.

Closes #3599.

## Test plan
- `uv run pytest tests/datasets/test_streaming.py -q`
- `uv run pytest tests/datasets/test_streaming.py tests/datasets/test_dataset_metadata.py -q`
- `uv run ruff check src/lerobot/datasets/streaming_dataset.py src/lerobot/datasets/dataset_metadata.py src/lerobot/datasets/video_utils.py tests/datasets/test_streaming.py`
- `uv run ruff format --check src/lerobot/datasets/streaming_dataset.py src/lerobot/datasets/dataset_metadata.py src/lerobot/datasets/video_utils.py tests/datasets/test_streaming.py`
- `git diff --check`

Note: `tests/datasets/test_video_decoder_cache.py` could not run locally because `tests/artifacts/encoded_videos/clip_4frames.mp4` is a Git LFS pointer in this checkout and `git lfs` is not installed.