### PR TITLE
(feat) Speedup SARM training by up to 50x speedup (on RTX A6000) with clip precompute + decode skipping

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -310,6 +310,7 @@ lerobot-imgtransform-viz="lerobot.scripts.lerobot_imgtransform_viz:main"
 lerobot-edit-dataset="lerobot.scripts.lerobot_edit_dataset:main"
 lerobot-setup-can="lerobot.scripts.lerobot_setup_can:main"
 lerobot-rollout="lerobot.scripts.lerobot_rollout:main"
+lerobot-sarm-precompute-clip="lerobot.scripts.lerobot_sarm_precompute_clip:main"
 
 # ---------------- Tool Configurations ----------------
 

--- a/src/lerobot/datasets/dataset_reader.py
+++ b/src/lerobot/datasets/dataset_reader.py
@@ -51,6 +51,7 @@ class DatasetReader:
         delta_timestamps: dict[str, list[float]] | None,
         image_transforms: Callable | None,
         return_uint8: bool = False,
+        skip_video_decode: bool = False,
     ):
         """Initialize the reader with metadata, filtering, and transform config.
 
@@ -68,6 +69,7 @@ class DatasetReader:
                 relative timestamp offsets for temporal context windows.
             image_transforms: Optional torchvision v2 transform applied to
                 visual features.
+            skip_video_decode: if True, skip video decoding and return a placeholder tensor
         """
         self._meta = meta
         self.root = root
@@ -76,6 +78,7 @@ class DatasetReader:
         self._video_backend = video_backend
         self._image_transforms = image_transforms
         self._return_uint8 = return_uint8
+        self._skip_video_decode = skip_video_decode
 
         self.hf_dataset: datasets.Dataset | None = None
         self._absolute_to_relative_idx: dict[int, int] | None = None
@@ -235,6 +238,13 @@ class DatasetReader:
         in the main process (e.g. by using a second Dataloader with num_workers=0). It will result in a
         Segmentation Fault.
         """
+        if self._skip_video_decode:
+            # Downstream consumers may want to skip video decoding (.e.g SARM with precomputed
+            # CLIP features). In this case, return a placeholder.
+            return {
+                vid_key: torch.zeros(len(query_ts), 1, 1, 1)
+                for vid_key, query_ts in query_timestamps.items()
+            }
         ep = self._meta.episodes[ep_idx]
 
         def _decode_single(vid_key: str, query_ts: list[float]) -> tuple[str, torch.Tensor]:

--- a/src/lerobot/datasets/factory.py
+++ b/src/lerobot/datasets/factory.py
@@ -86,6 +86,13 @@ def make_dataset(cfg: TrainPipelineConfig) -> LeRobotDataset | MultiLeRobotDatas
             cfg.dataset.repo_id, root=cfg.dataset.root, revision=cfg.dataset.revision
         )
         delta_timestamps = resolve_delta_timestamps(cfg.trainable_config, ds_meta)
+        skip_video_decode = bool(
+            getattr(cfg.trainable_config, "precomputed_image_features_path", None)
+        )
+        if skip_video_decode and cfg.dataset.streaming:
+            raise NotImplementedError(
+                "precomputed_image_features_path with streaming datasets is not yet supported"
+            )
         if not cfg.dataset.streaming:
             dataset = LeRobotDataset(
                 cfg.dataset.repo_id,
@@ -96,6 +103,7 @@ def make_dataset(cfg: TrainPipelineConfig) -> LeRobotDataset | MultiLeRobotDatas
                 revision=cfg.dataset.revision,
                 video_backend=cfg.dataset.video_backend,
                 return_uint8=True,
+                skip_video_decode=skip_video_decode,
                 tolerance_s=cfg.tolerance_s,
             )
         else:

--- a/src/lerobot/datasets/lerobot_dataset.py
+++ b/src/lerobot/datasets/lerobot_dataset.py
@@ -58,6 +58,7 @@ class LeRobotDataset(torch.utils.data.Dataset):
         download_videos: bool = True,
         video_backend: str | None = None,
         return_uint8: bool = False,
+        skip_video_decode: bool = False,
         batch_encoding_size: int = 1,
         camera_encoder: VideoEncoderConfig | None = None,
         encoder_threads: int | None = None,
@@ -208,6 +209,7 @@ class LeRobotDataset(torch.utils.data.Dataset):
         self.revision = revision if revision else CODEBASE_VERSION
         self._video_backend = video_backend if video_backend else get_safe_default_video_backend()
         self._return_uint8 = return_uint8
+        self._skip_video_decode = skip_video_decode
         self._batch_encoding_size = batch_encoding_size
         self._encoder_threads = encoder_threads
 
@@ -248,6 +250,7 @@ class LeRobotDataset(torch.utils.data.Dataset):
             delta_timestamps=delta_timestamps,
             image_transforms=image_transforms,
             return_uint8=self._return_uint8,
+            skip_video_decode=self._skip_video_decode,
         )
 
         # Load actual data
@@ -315,6 +318,7 @@ class LeRobotDataset(torch.utils.data.Dataset):
                 delta_timestamps=self.delta_timestamps,
                 image_transforms=self.image_transforms,
                 return_uint8=self._return_uint8,
+                skip_video_decode=self._skip_video_decode,
             )
         return self.reader
 
@@ -711,6 +715,7 @@ class LeRobotDataset(torch.utils.data.Dataset):
         obj.episodes = None
         obj._video_backend = video_backend if video_backend is not None else get_safe_default_video_backend()
         obj._return_uint8 = False
+        obj._skip_video_decode = False
         obj._batch_encoding_size = batch_encoding_size
         obj._encoder_threads = encoder_threads
 
@@ -805,6 +810,7 @@ class LeRobotDataset(torch.utils.data.Dataset):
         obj.episodes = None
         obj._video_backend = video_backend if video_backend else get_safe_default_video_backend()
         obj._return_uint8 = False
+        obj._skip_video_decode = False
         obj._batch_encoding_size = batch_encoding_size
 
         if obj._requested_root is not None:

--- a/src/lerobot/rewards/sarm/configuration_sarm.py
+++ b/src/lerobot/rewards/sarm/configuration_sarm.py
@@ -19,6 +19,7 @@ Paper: https://arxiv.org/abs/2509.25358
 """
 
 from dataclasses import dataclass, field
+from pathlib import Path
 
 from lerobot.configs import FeatureType, NormalizationMode, PolicyFeature
 from lerobot.configs.rewards import RewardModelConfig
@@ -86,6 +87,12 @@ class SARMConfig(RewardModelConfig):
     device: str | None = None
     image_key: str = OBS_IMAGES + ".top"  # Key for image used from the dataset
     state_key: str = OBS_STATE
+    # Optional path to a .npy memmap of CLIP image features, shape (N_total_frames, 512),
+    # indexed by absolute global frame index. When set, the per-step CLIP image-encoder
+    # forward in SARMEncodingProcessorStep is replaced by a memmap lookup, and the video
+    # decode step is short-circuited. When None (default), upstream online-CLIP behavior
+    # is preserved unchanged, and CLIP forward is performed online for each frame.
+    precomputed_image_features_path: str | None = None
 
     # Populated by the processor (video_features, state_features, text_features)
     input_features: dict = field(default_factory=lambda: {})
@@ -174,6 +181,12 @@ class SARMConfig(RewardModelConfig):
             and self.num_dense_stages < 2
         ):
             raise ValueError(f"num_dense_stages must be at least 2, got {self.num_dense_stages}")
+
+        if self.precomputed_image_features_path is not None:
+            if not Path(self.precomputed_image_features_path).is_file():
+                raise FileNotFoundError(
+                    f"precomputed_image_features_path={self.precomputed_image_features_path} not found"
+                )
 
     def get_optimizer_preset(self) -> AdamWConfig:
         """Get default optimizer configuration for SARM training."""

--- a/src/lerobot/rewards/sarm/processor_sarm.py
+++ b/src/lerobot/rewards/sarm/processor_sarm.py
@@ -120,6 +120,22 @@ class SARMEncodingProcessorStep(ProcessorStep):
         self.verbs = ["move", "grasp", "rotate", "push", "pull", "slide", "lift", "place"]
         self.fake = Faker()
 
+        # Optional precompute path: load CLIP image features from a memmap indexed by
+        # absolute global frame index, replacing the per-step CLIP image encoder forward pass.
+        # When enabled, also precompute the CLIP encoding of a zero-pixel image for
+        # padding invalid positions (this is same _encode_images_batch
+        # path the online CLIP code uses for those positions in SARMEncodingProcessorStep.__call__, so the vector is
+        # identical to upstream's padded-position output).
+        self.precomputed_image_features = None
+        self.clip_zero_pad_vec = None
+        if self.config.precomputed_image_features_path is not None:
+            self.precomputed_image_features = np.load(
+                self.config.precomputed_image_features_path, mmap_mode="r"
+            )
+            zero_image = np.zeros((1, 1, 3, 224, 224), dtype=np.uint8)
+            self.clip_zero_pad_vec = self._encode_images_batch(zero_image).squeeze().numpy()  # (512,)
+
+
     def _find_episode_for_frame(self, frame_idx: int) -> int:
         """Find the episode index for a given frame index."""
         for ep_idx in range(len(self.dataset_meta.episodes)):
@@ -211,19 +227,26 @@ class SARMEncodingProcessorStep(ProcessorStep):
         frame_indices = np.atleast_1d(np.asarray(from_tensor_to_numpy(frame_index)))
         episode_indices = self._get_episode_indices(frame_indices, episode_index)
 
-        image = observation.get(self.image_key)
-        if isinstance(image, torch.Tensor):
-            image = image.cpu().numpy()
+        image = None
+        if self.precomputed_image_features is None:
+            image = observation.get(self.image_key)
+            if isinstance(image, torch.Tensor):
+                image = image.cpu().numpy()
 
-        # If 4D (T, C, H, W) from delta_timestamps, add batch dim
-        # If 3D (C, H, W) single frame, add batch and time dims
-        if image.ndim == 4:
-            image = image[np.newaxis, ...]  # (T, C, H, W) -> (1, T, C, H, W)
-        elif image.ndim == 3:
-            image = image[np.newaxis, np.newaxis, ...]  # (C, H, W) -> (1, 1, C, H, W)
+            # If 4D (T, C, H, W) from delta_timestamps, add batch dim
+            # If 3D (C, H, W) single frame, add batch and time dims
+            if image.ndim == 4:
+                image = image[np.newaxis, ...]  # (T, C, H, W) -> (1, T, C, H, W)
+            elif image.ndim == 3:
+                image = image[np.newaxis, np.newaxis, ...]  # (C, H, W) -> (1, 1, C, H, W)
 
-        batch_size = image.shape[0]
-        total_frames = image.shape[1]  # Should be 13: 9 obs + 4 rewind placeholders
+            batch_size = image.shape[0]
+            total_frames = image.shape[1]  # Should be 13: 9 obs + 4 rewind placeholders
+        else:
+            # Precompute path: image is never read; derive batch shape from frame indices.
+            batch_size = len(frame_indices)
+            total_frames = self.config.num_frames
+
         n_obs_steps = self.config.n_obs_steps
         max_rewind_steps = self.config.max_rewind_steps
         n_obs_frames = 1 + n_obs_steps  # 9 observation frames (including current)
@@ -247,15 +270,48 @@ class SARMEncodingProcessorStep(ProcessorStep):
         # Compute valid lengths: n_obs_frames + rewind_steps
         lengths = n_obs_frames + rewind_steps  # (B,)
 
-        # Apply rewind masking to images
+        # Apply rewind masking to images (only relevant for the online CLIP path)
         # For frames beyond valid length, we mask with zeros (or copy last valid frame)
-        for b_idx in range(batch_size):
-            valid_len = lengths[b_idx].item()
-            if valid_len < total_frames:
-                image[b_idx, valid_len:] = 0  # Zero out frames beyond valid length
+        if image is not None:
+            for b_idx in range(batch_size):
+                valid_len = lengths[b_idx].item()
+                if valid_len < total_frames:
+                    image[b_idx, valid_len:] = 0  # Zero out frames beyond valid length
 
         # Encode images with CLIP
-        video_features = self._encode_images_batch(image)
+        if self.precomputed_image_features is None:
+            video_features = self._encode_images_batch(image)
+        # or lookup precomputed features from memmap
+        else:
+            # Build absolute frame indices for every frame in the window using the
+            # same observation_delta_indices the dataset would have used to load `image`.
+            delta_indices = self.config.observation_delta_indices
+            assert len(delta_indices) == total_frames, (
+                f"delta_indices ({len(delta_indices)}) != total_frames ({total_frames})"
+            )
+            abs_indices = np.empty((batch_size, total_frames), dtype=np.int64)
+            for b_idx in range(batch_size):
+                center = int(frame_indices[b_idx])
+                ep_idx = int(episode_indices[b_idx])
+                ep_start = int(self.dataset_meta.episodes[ep_idx]["dataset_from_index"])
+                ep_end = int(self.dataset_meta.episodes[ep_idx]["dataset_to_index"])
+                for t_idx, delta in enumerate(delta_indices):
+                    i = center + int(delta)
+                    # Clamp to episode bounds (matches LeRobot dataset behavior for OOB deltas).
+                    if i < ep_start:
+                        i = ep_start
+                    elif i >= ep_end:
+                        i = ep_end - 1
+                    abs_indices[b_idx, t_idx] = i
+            feats = np.asarray(self.precomputed_image_features[abs_indices]).copy()  # (B, T, 512)
+            # Pad unused positions (reserved to potentially be filled by rewind during training) 
+            # with the CLIP encoding of a black image — the same vector the online CLIP path produces at those positions.
+            for b_idx in range(batch_size):
+                valid_len = lengths[b_idx].item()
+                if valid_len < total_frames:
+                    feats[b_idx, valid_len:] = self.clip_zero_pad_vec
+            video_features = torch.from_numpy(feats).float()
+
         observation["video_features"] = video_features
 
         state_key = self.config.state_key

--- a/src/lerobot/scripts/lerobot_sarm_precompute_clip.py
+++ b/src/lerobot/scripts/lerobot_sarm_precompute_clip.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python
+
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Precompute CLIP image features for a LeRobot dataset.
+
+Writes a (N_total_frames, model.config.projection_dim) float32 .npy memmap indexed by absolute global
+frame index, ready to be passed to SARM via SARMConfig.precomputed_image_features_path.
+
+Usage:
+
+```bash
+lerobot-sarm-precompute-clip \\
+    --repo-id={hf_username}/{repo_name} \\
+    --camera-key=observation.images.top \\
+    --output=/path/to/clip_features.npy
+```
+"""
+
+import argparse
+import logging
+import subprocess
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+from lerobot.datasets import LeRobotDatasetMetadata
+from lerobot.utils.import_utils import _transformers_available, require_package
+from lerobot.utils.utils import init_logging
+
+if TYPE_CHECKING or _transformers_available:
+    from transformers import CLIPImageProcessor, CLIPModel
+else:
+    CLIPModel = None  # type: ignore[assignment, misc]
+    CLIPImageProcessor = None  # type: ignore[assignment, misc]
+
+
+@torch.no_grad()
+def _preprocess_on_device(
+    raw_uint8: torch.Tensor, mean: torch.Tensor, std: torch.Tensor, crop_size: int
+) -> torch.Tensor:
+    """GPU-batched equivalent of HF CLIPImageProcessor preprocessing:
+    resize shorter edge to `crop_size` (bicubic, antialiased), center-crop, /255, normalize.
+
+    Args:
+        raw_uint8: (B, H, W, 3) uint8 tensor on the active device.
+        mean, std: (1, 3, 1, 1) normalization constants on the same device.
+        crop_size: target square crop size (pulled from CLIPImageProcessor at runtime).
+
+    Returns:
+        (B, 3, crop_size, crop_size) float32 tensor ready for the CLIP vision tower.
+    """
+    x = raw_uint8.permute(0, 3, 1, 2).contiguous().float().div_(255.0)
+    _, _, H, W = x.shape
+    if H < W:
+        new_h, new_w = crop_size, int(round(W * crop_size / H))
+    else:
+        new_h, new_w = int(round(H * crop_size / W)), crop_size
+    # Resize while preserving the aspect ratio
+    x = F.interpolate(x, size=(new_h, new_w), mode="bicubic", antialias=True, align_corners=False)
+    # crop in the center
+    top = (new_h - crop_size) // 2
+    left = (new_w - crop_size) // 2
+    x = x[:, :, top : top + crop_size, left : left + crop_size]
+    return (x - mean) / std
+
+
+
+def precompute_for_camera(
+    repo_id: str,
+    camera_key: str,
+    output: Path,
+    root: Path | None = None,
+    revision: str | None = None,
+    clip_model_id: str = "openai/clip-vit-base-patch32",
+    device: str = "cuda" if torch.cuda.is_available() else "cpu",
+    chunk_frames: int = 512,
+) -> None:
+    """Precompute CLIP image features for one camera of a LeRobot dataset.
+
+    Output is a (N_total_frames, proj_dim) float32 .npy memmap indexed by absolute
+    global frame index.
+    """
+    require_package("transformers", extra="sarm")
+
+    logging.info(f"Loading dataset metadata for {repo_id}...")
+    meta = LeRobotDatasetMetadata(repo_id, root=root, revision=revision)
+    if camera_key not in meta.video_keys:
+        raise ValueError(
+            f"camera_key={camera_key!r} not found in dataset video keys: {meta.video_keys}"
+        )
+
+    n_frames_total = meta.total_frames
+    logging.info(f"  episodes={meta.total_episodes}  total_frames={n_frames_total}")
+
+    output.parent.mkdir(parents=True, exist_ok=True)
+    if output.exists():
+        output.unlink()
+
+    device = torch.device(device)
+
+    logging.info(f"Loading CLIP model + image processor: {clip_model_id}")
+    # Pull preprocessing constants (crop size, mean, std) from the model's
+    # CLIPImageProcessor rather than hardcoding them. This keeps the precompute
+    # in lockstep with whichever CLIP checkpoint is used and matches the
+    # online sarm processor's behavior.
+    image_processor = CLIPImageProcessor.from_pretrained(clip_model_id)
+    crop_size_val = image_processor.crop_size
+    # Newer transformers versions return a SizeDict like {"height": 224, "width": 224},
+    # older versions return a plain int. SizeDict isn't always a dict subclass so we
+    # duck-type on dict-style access instead of `isinstance`.
+    try:
+        h, w = crop_size_val["height"], crop_size_val["width"]
+        assert h == w, f"non-square crop_size from CLIPImageProcessor: {crop_size_val}"
+        crop_size = int(h)
+    except (TypeError, KeyError, AttributeError):
+        crop_size = int(crop_size_val)
+    mean = torch.tensor(image_processor.image_mean, device=device).view(1, 3, 1, 1)
+    std = torch.tensor(image_processor.image_std, device=device).view(1, 3, 1, 1)
+    logging.info(
+        f"  crop_size={crop_size}  mean={image_processor.image_mean}  std={image_processor.image_std}"
+    )
+
+    model = CLIPModel.from_pretrained(clip_model_id).to(device).eval()
+    vision = model.vision_model
+    proj = model.visual_projection
+
+    proj_dim = int(model.config.projection_dim)
+    # Create the output memmap that will store the clip features for all the frames
+    out = np.lib.format.open_memmap(
+        output, mode="w+", dtype=np.float32, shape=(n_frames_total, proj_dim)
+    )
+    logging.info(f"Output memmap: {output}  shape={out.shape}  dtype={out.dtype}")
+
+    ### Enumerate episodes and group by mp4 file ###
+    # In LeRobot v3+, multiple episodes can share one mp4 file. Sort by position
+    # in the video files, then group by (chunk_index, file_index) so we open
+    # ffmpeg once per mp4 and stream all of its frames in order.
+    episodes_df = (
+        meta.episodes.to_pandas()
+        .sort_values(
+            [
+                f"videos/{camera_key}/chunk_index",
+                f"videos/{camera_key}/file_index",
+                f"videos/{camera_key}/from_timestamp",
+            ]
+        )
+        .reset_index(drop=True)
+    )
+    file_groups = episodes_df.groupby(
+        [f"videos/{camera_key}/chunk_index", f"videos/{camera_key}/file_index"],
+        sort=True,
+    )
+
+    # Probe video dimensions from the first mp4 (assume all camera mp4s share W,H).
+    sample_ep_idx = int(episodes_df.iloc[0]["episode_index"])
+    sample_path = meta.root / meta.get_video_file_path(sample_ep_idx, camera_key)
+    probe = subprocess.run(
+        [
+            "ffprobe", "-v", "error", "-select_streams", "v:0",
+            "-show_entries", "stream=width,height", "-of", "csv=p=0", str(sample_path),
+        ],
+        capture_output=True, text=True, check=True,
+    )
+    W, H = map(int, probe.stdout.strip().split(","))
+    frame_bytes = H * W * 3
+    logging.info(f"  video: {W}x{H} (frame_bytes={frame_bytes})")
+
+    ### Stream each mp4 with ffmpeg, batch through CLIP on GPU ###
+    t0 = time.time()
+    n_done = 0
+    n_files = len(file_groups)
+
+    with torch.no_grad():
+        for file_idx, ((chunk_i, file_i), group) in enumerate(file_groups, start=1):
+            mp4_ep_idx = int(group.iloc[0]["episode_index"])
+            mp4_path = meta.root / meta.get_video_file_path(mp4_ep_idx, camera_key)
+            group = group.sort_values(f"videos/{camera_key}/from_timestamp").reset_index(drop=True)
+
+            # Build mp4_frame_to_global: within-mp4 frame index -> absolute global frame index.
+            n_frames_in_file = int(group["length"].sum())
+            mp4_frame_to_global = np.empty(n_frames_in_file, dtype=np.int64)
+            cursor = 0
+            for _, ep in group.iterrows():
+                L = int(ep["length"])
+                g0 = int(ep["dataset_from_index"])
+                mp4_frame_to_global[cursor : cursor + L] = np.arange(g0, g0 + L)
+                cursor += L
+
+            ffmpeg = subprocess.Popen(
+                [
+                    "ffmpeg", "-i", str(mp4_path),
+                    "-f", "rawvideo", "-pix_fmt", "rgb24",
+                    "-vsync", "0", "-loglevel", "error", "-",
+                ],
+                stdout=subprocess.PIPE,
+                bufsize=128 * 1024 * 1024,
+            )
+            try:
+                file_frame_idx = 0
+                while True:
+                    n_want = min(chunk_frames, n_frames_in_file - file_frame_idx)
+                    if n_want <= 0:
+                        break
+                    buf = ffmpeg.stdout.read(n_want * frame_bytes)
+                    if not buf:
+                        break
+                    n_got = len(buf) // frame_bytes
+                    if n_got == 0:
+                        break
+                    np_raw = np.frombuffer(buf[: n_got * frame_bytes], dtype=np.uint8).reshape(n_got, H, W, 3)
+                    raw = torch.from_numpy(np_raw.copy()).to(device, non_blocking=True)
+                    pixel_values = _preprocess_on_device(raw, mean, std, crop_size)
+                    out_vision = vision(pixel_values=pixel_values)
+                    pooled = out_vision.pooler_output if hasattr(out_vision, "pooler_output") else out_vision[1]
+                    embs = proj(pooled).float().cpu().numpy()
+                    gidx = mp4_frame_to_global[file_frame_idx : file_frame_idx + n_got]
+                    out[gidx] = embs
+                    file_frame_idx += n_got
+                    n_done += n_got
+                if file_frame_idx != n_frames_in_file:
+                    logging.warning(
+                        f"file-{file_i:03d}: expected {n_frames_in_file} frames, got {file_frame_idx}"
+                    )
+            finally:
+                try:
+                    ffmpeg.stdout.close()
+                except Exception:
+                    pass
+                ffmpeg.wait(timeout=5)
+
+            now = time.time()
+            rate = n_done / max(now - t0, 1e-6)
+            eta = (n_frames_total - n_done) / max(rate, 1e-6)
+            logging.info(
+                f"  [file {file_idx}/{n_files}] {n_done}/{n_frames_total} "
+                f"({100 * n_done / n_frames_total:.1f}%)  rate={rate:.0f} fps  eta={eta:.0f}s"
+            )
+
+    out.flush()
+    elapsed = time.time() - t0
+    logging.info(f"Done in {elapsed:.1f}s ({n_frames_total / elapsed:.0f} fps). Output: {output}")
+
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Precompute CLIP image features for a LeRobot dataset.")
+    parser.add_argument("--repo-id", type=str, required=True, help="Dataset repo ID (e.g. lerobot/pusht).")
+    parser.add_argument("--camera-key", type=str, required=True, help="Video feature key (e.g. observation.images.top).")
+    parser.add_argument("--output", type=Path, required=True, help="Output .npy path for the feature memmap.")
+    parser.add_argument("--root", type=Path, default=None, help="Local dataset root (optional).")
+    parser.add_argument("--revision", type=str, default=None, help="Dataset revision (optional).")
+    parser.add_argument("--clip-model", type=str, default="openai/clip-vit-base-patch32", help="CLIP model ID.")
+    parser.add_argument("--device", type=str, default=None, help="Device override (cuda / cpu).")
+    parser.add_argument("--chunk-frames", type=int, default=512, help="Batch size per CLIP forward.")
+    args = parser.parse_args()
+
+    init_logging()
+    device = args.device or ("cuda" if torch.cuda.is_available() else "cpu")
+    precompute_for_camera(
+        repo_id=args.repo_id,
+        camera_key=args.camera_key,
+        output=args.output,
+        root=args.root,
+        revision=args.revision,
+        clip_model_id=args.clip_model,
+        device=device,
+        chunk_frames=args.chunk_frames,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Title

Speed up SARM training by up to 50x (on RTX A6000) by precomputing CLIP features and bypassing online decoding.

## Summary / Motivation

The SARM training is extremely slow, running at ~3.85s/step, ~12s/step, and ~26s/step for batch sizes of 8, 32, and 64 ,respectively, which means a training session spanning two epochs for a dataset with hundreds of episodes could take between 10-25 hours (and even more for larger datasets).

The current implementation runs CLIP encoding at every forward pass (even though the CLIP is frozen during training) and re-decodes video frames from MP4 on every step. As a result, the GPU sits idle most of the time (the majority of step time is spent on the dataloader not the GPU update) waiting for decoding and CLIP encoding to produce the next batch.  And compute is wasted re-decoding frames that could be cached.


## What changed

**1. new offline script + CLI entry point** (`lerobot_sarm_precompute_clip.py`, `pyproject.toml`)
- `lerobot-sarm-precompute-clip` console script that builds the .npy cache from a LeRobot dataset. CLIP preprocessing constants (crop size, mean, std, projection dim) are pulled dynamically from the model so the script tracks any CLIP checkpoint.

**2. new config option** (`configuration_sarm.py`)
- Added `SARMConfig.precomputed_image_features_path: Path | None = None`. When unset, behavior defaults to the current Lerobot implementation (online CLIP path). When set, points to a .npy memmap of shape `(N_total_frames, proj_dim)` indexed by absolute global frame index.

**3. SARM processor: cache lookup path** (`processor_sarm.py`)
- When the new config option is set, the SARM encoding step reads precomputed CLIP features from the .npy memmap (computed in (1)) instead of running CLIP processing on each frame. Falls back to the online path when the cache isn't provided.

**4. dataset: skip video decode when cache is present** (`dataset_reader.py`, `factory.py`, `lerobot_dataset.py`)
- When the precompute cache is provided, the dataset no longer needs to decode video frames for the SARM image key. The decode is skipped at the reader layer and the corresponding image is omitted from the batch dict (downstream consumers index into the cache by global frame index instead).

**5. No backward-incompat changes.** existing training commands run identically; the new flag is opt-in.

## How was this tested (or how to run locally)

The following numbers are from running several experiments on a 32GB RTX A6000. Numbers may vary for other GPUs.

1. Tested CLIP precomputing using both CPU (matches CLIPProcessor from the existing lerobot implementation) and batched GPU processing:

Precomputing CLIP
| Device | avg FPS | avg ms/frame | 
|--------|--------|--------|
| GPU |  ~200 |  ~5.0 |
| CPU | ~55 | ~18.0 |
| speedup | ~3.5-4.0x | ~3.5-4.0x |

2. Ran multiple tests for each batch size. For the baseline, given that it's too slow, I ran 100-200 steps training runs multiple times and then averaged the s/step (the values were very close across runs with negligible variations). I also tried different num_workers values but found no meaningful differences.

Note:  The 10-50× speedup compares per-step training wall time and does not include the one-time cost of generating the precomputed-feature cache. The precompute cost is very small in comparison to the original training time. For reference, generating the cache for a 100k-frame dataset takes ~8 minutes on a single A6000 (~210 fps end-to-end, including ffmpeg decode + GPU CLIP forward), runs once per dataset, and is reused across all subsequent training runs (if you're running multiple runs for experimentation).

SARM training:
| Batch size | Baseline (lerobot) | Optimized (this PR) | speedup |
|--------|--------|--------|--------|
| 8 | ~3.85s/step | ~0.4s/step | ~10x |
| 32 | ~12.6s/step | ~0.48s/step | ~26x |
| 64 | ~27.6s/step | ~0.55s/step | ~50x |


## Checklist (required before merge)

Waiting for initial review and feedback...

- [ ] Linting/formatting run (`pre-commit run -a`)
- [ ] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: # (insert PR number/link)

## Reviewer notes

- The numbers above are from my own experiments. I used a 32GB RTX A6000. 
- I will followup with some details on issues I faced with unmasked loss for batch size 64.
