### PR TITLE
[2/4][#1998] Add episode subset conversion support for v2.1 to v3.0 datasets

### DIFF
--- a/src/lerobot/scripts/convert_dataset_v21_to_v30.py
+++ b/src/lerobot/scripts/convert_dataset_v21_to_v30.py
@@ -56,6 +56,7 @@ from lerobot.utils.import_utils import require_package
 require_package("jsonlines", extra="dataset")
 
 import jsonlines
+import numpy as np
 import pandas as pd
 import pyarrow as pa
 import tqdm
@@ -176,6 +177,41 @@ def validate_local_dataset_version(local_path: Path) -> None:
         )
 
 
+def resolve_episode_range(
+    total_episodes: int, episode_start: int | None = None, episode_end: int | None = None
+) -> range:
+    start = 0 if episode_start is None else episode_start
+    end = total_episodes if episode_end is None else episode_end
+
+    if start < 0:
+        raise ValueError(f"episode_start must be >= 0, got {episode_start}.")
+    if end < 0:
+        raise ValueError(f"episode_end must be >= 0, got {episode_end}.")
+    if start >= end:
+        raise ValueError(f"episode_start must be smaller than episode_end, got {start} >= {end}.")
+    if end > total_episodes:
+        raise ValueError(f"episode_end={end} is out of range for dataset with {total_episodes} episodes.")
+
+    return range(start, end)
+
+
+def get_episode_index_from_path(path: Path) -> int:
+    return int(path.stem.rsplit("_", 1)[1])
+
+
+def select_episode_paths(paths: list[Path], episode_indices: range) -> list[Path]:
+    selected = [path for path in paths if get_episode_index_from_path(path) in episode_indices]
+    if len(selected) != len(episode_indices):
+        selected_indices = {get_episode_index_from_path(path) for path in selected}
+        missing = sorted(set(episode_indices) - selected_indices)
+        raise FileNotFoundError(f"Missing files for episode indices: {missing}.")
+    return selected
+
+
+def has_episode_subset(episode_start: int | None, episode_end: int | None) -> bool:
+    return episode_start is not None or episode_end is not None
+
+
 def convert_tasks(root, new_root):
     logging.info(f"Converting tasks from {root} to {new_root}")
     tasks, _ = legacy_load_tasks(root)
@@ -185,9 +221,14 @@ def convert_tasks(root, new_root):
     write_tasks(df_tasks, new_root)
 
 
-def concat_data_files(paths_to_cat, new_root, chunk_idx, file_idx, image_keys):
+def concat_data_files(episodes_to_cat, new_root, chunk_idx, file_idx, image_keys):
     # TODO(rcadene): to save RAM use Dataset.from_parquet(file) and concatenate_datasets
-    dataframes = [pd.read_parquet(file) for file in paths_to_cat]
+    dataframes = []
+    for item in episodes_to_cat:
+        dataframe = pd.read_parquet(item["path"])
+        dataframe["episode_index"] = item["episode_index"]
+        dataframe["index"] = np.arange(item["dataset_from_index"], item["dataset_to_index"])
+        dataframes.append(dataframe)
     # Concatenate all DataFrames along rows
     concatenated_df = pd.concat(dataframes, ignore_index=True)
 
@@ -206,9 +247,9 @@ def concat_data_files(paths_to_cat, new_root, chunk_idx, file_idx, image_keys):
     concatenated_df.to_parquet(path, index=False, schema=schema)
 
 
-def convert_data(root: Path, new_root: Path, data_file_size_in_mb: int):
+def convert_data(root: Path, new_root: Path, data_file_size_in_mb: int, episode_indices: range):
     data_dir = root / "data"
-    ep_paths = sorted(data_dir.glob("*/*.parquet"))
+    ep_paths = select_episode_paths(sorted(data_dir.glob("*/*.parquet")), episode_indices)
 
     image_keys = get_image_keys(root)
 
@@ -216,7 +257,7 @@ def convert_data(root: Path, new_root: Path, data_file_size_in_mb: int):
     file_idx = 0
     size_in_mb = 0
     num_frames = 0
-    paths_to_cat = []
+    episodes_to_cat = []
     episodes_metadata = []
 
     logging.info(f"Converting data files from {len(ep_paths)} episodes")
@@ -226,16 +267,16 @@ def convert_data(root: Path, new_root: Path, data_file_size_in_mb: int):
         ep_num_frames = get_parquet_num_frames(ep_path)
 
         # Check if we need to start a new file BEFORE creating metadata
-        if size_in_mb + ep_size_in_mb >= data_file_size_in_mb and len(paths_to_cat) > 0:
+        if size_in_mb + ep_size_in_mb >= data_file_size_in_mb and len(episodes_to_cat) > 0:
             # Write the accumulated data files
-            concat_data_files(paths_to_cat, new_root, chunk_idx, file_idx, image_keys)
+            concat_data_files(episodes_to_cat, new_root, chunk_idx, file_idx, image_keys)
 
             # Move to next file
             chunk_idx, file_idx = update_chunk_file_indices(chunk_idx, file_idx, DEFAULT_CHUNK_SIZE)
 
             # Reset for the next file
             size_in_mb = 0
-            paths_to_cat = []
+            episodes_to_cat = []
 
         # Now create metadata with correct chunk/file indices
         ep_metadata = {
@@ -248,11 +289,11 @@ def convert_data(root: Path, new_root: Path, data_file_size_in_mb: int):
         size_in_mb += ep_size_in_mb
         num_frames += ep_num_frames
         episodes_metadata.append(ep_metadata)
-        paths_to_cat.append(ep_path)
+        episodes_to_cat.append({"path": ep_path, **ep_metadata})
 
     # Write remaining data if any
-    if paths_to_cat:
-        concat_data_files(paths_to_cat, new_root, chunk_idx, file_idx, image_keys)
+    if episodes_to_cat:
+        concat_data_files(episodes_to_cat, new_root, chunk_idx, file_idx, image_keys)
 
     return episodes_metadata
 
@@ -271,7 +312,7 @@ def get_image_keys(root):
     return image_keys
 
 
-def convert_videos(root: Path, new_root: Path, video_file_size_in_mb: int):
+def convert_videos(root: Path, new_root: Path, video_file_size_in_mb: int, episode_indices: range):
     logging.info(f"Converting videos from {root} to {new_root}")
 
     video_keys = get_video_keys(root)
@@ -282,7 +323,9 @@ def convert_videos(root: Path, new_root: Path, video_file_size_in_mb: int):
 
     eps_metadata_per_cam = []
     for camera in video_keys:
-        eps_metadata = convert_videos_of_camera(root, new_root, camera, video_file_size_in_mb)
+        eps_metadata = convert_videos_of_camera(
+            root, new_root, camera, video_file_size_in_mb, episode_indices
+        )
         eps_metadata_per_cam.append(eps_metadata)
 
     num_eps_per_cam = [len(eps_cam_map) for eps_cam_map in eps_metadata_per_cam]
@@ -307,10 +350,12 @@ def convert_videos(root: Path, new_root: Path, video_file_size_in_mb: int):
     return episodes_metadata
 
 
-def convert_videos_of_camera(root: Path, new_root: Path, video_key: str, video_file_size_in_mb: int):
+def convert_videos_of_camera(
+    root: Path, new_root: Path, video_key: str, video_file_size_in_mb: int, episode_indices: range
+):
     # Access old paths to mp4
     videos_dir = root / "videos"
-    ep_paths = sorted(videos_dir.glob(f"*/{video_key}/*.mp4"))
+    ep_paths = select_episode_paths(sorted(videos_dir.glob(f"*/{video_key}/*.mp4")), episode_indices)
 
     ep_idx = 0
     chunk_idx = 0
@@ -412,11 +457,25 @@ def generate_episode_metadata_dict(
         yield ep_dict
 
 
-def convert_episodes_metadata(root, new_root, episodes_metadata, episodes_video_metadata=None):
+def convert_episodes_metadata(
+    root, new_root, episodes_metadata, episode_indices, episodes_video_metadata=None
+):
     logging.info(f"Converting episodes metadata from {root} to {new_root}")
 
-    episodes_legacy_metadata = legacy_load_episodes(root)
-    episodes_stats = legacy_load_episodes_stats(root)
+    legacy_episodes = legacy_load_episodes(root)
+    legacy_episodes_stats = legacy_load_episodes_stats(root)
+    episodes_legacy_metadata = {
+        new_ep_idx: {**legacy_episode, "episode_index": new_ep_idx}
+        for new_ep_idx, legacy_episode in enumerate(
+            legacy_episodes[source_ep_idx] for source_ep_idx in episode_indices
+        )
+    }
+    episodes_stats = {
+        new_ep_idx: legacy_stats
+        for new_ep_idx, legacy_stats in enumerate(
+            legacy_episodes_stats[source_ep_idx] for source_ep_idx in episode_indices
+        )
+    }
 
     num_eps_set = {len(episodes_legacy_metadata), len(episodes_metadata)}
     if episodes_video_metadata is not None:
@@ -436,10 +495,20 @@ def convert_episodes_metadata(root, new_root, episodes_metadata, episodes_video_
     write_stats(stats, new_root)
 
 
-def convert_info(root, new_root, data_file_size_in_mb, video_file_size_in_mb):
+def convert_info(
+    root,
+    new_root,
+    data_file_size_in_mb,
+    video_file_size_in_mb,
+    total_episodes: int,
+    total_frames: int,
+):
     # Load as raw dict to remove legacy v2.1 fields before constructing DatasetInfo.
     info = load_json(root / INFO_PATH)
     info["codebase_version"] = V30
+    info["total_episodes"] = total_episodes
+    info["total_frames"] = total_frames
+    info["splits"] = {"train": f"0:{total_episodes}"}
     del info["total_chunks"]
     del info["total_videos"]
     info["data_files_size_in_mb"] = data_file_size_in_mb
@@ -466,6 +535,8 @@ def convert_dataset(
     root: str | Path | None = None,
     push_to_hub: bool = True,
     force_conversion: bool = False,
+    episode_start: int | None = None,
+    episode_end: int | None = None,
 ):
     if data_file_size_in_mb is None:
         data_file_size_in_mb = DEFAULT_DATA_FILE_SIZE_IN_MB
@@ -473,7 +544,7 @@ def convert_dataset(
         video_file_size_in_mb = DEFAULT_VIDEO_FILE_SIZE_IN_MB
 
     # First check if the dataset already has a v3.0 version
-    if root is None and not force_conversion:
+    if root is None and not force_conversion and not has_episode_subset(episode_start, episode_end):
         try:
             print("Trying to download v3.0 version of the dataset from the hub...")
             snapshot_download(repo_id, repo_type="dataset", revision=V30, local_dir=HF_LEROBOT_HOME / repo_id)
@@ -508,11 +579,24 @@ def convert_dataset(
             local_dir=root,
         )
 
-    convert_info(root, new_root, data_file_size_in_mb, video_file_size_in_mb)
+    info = load_info(root)
+    episode_indices = resolve_episode_range(info.total_episodes, episode_start, episode_end)
+    if has_episode_subset(episode_start, episode_end):
+        logging.info(
+            "Converting episode subset [%s, %s) from %s total episodes",
+            episode_indices.start,
+            episode_indices.stop,
+            info.total_episodes,
+        )
+
     convert_tasks(root, new_root)
-    episodes_metadata = convert_data(root, new_root, data_file_size_in_mb)
-    episodes_videos_metadata = convert_videos(root, new_root, video_file_size_in_mb)
-    convert_episodes_metadata(root, new_root, episodes_metadata, episodes_videos_metadata)
+    episodes_metadata = convert_data(root, new_root, data_file_size_in_mb, episode_indices)
+    total_frames = episodes_metadata[-1]["dataset_to_index"] if episodes_metadata else 0
+    episodes_videos_metadata = convert_videos(root, new_root, video_file_size_in_mb, episode_indices)
+    convert_info(
+        root, new_root, data_file_size_in_mb, video_file_size_in_mb, len(episode_indices), total_frames
+    )
+    convert_episodes_metadata(root, new_root, episodes_metadata, episode_indices, episodes_videos_metadata)
 
     shutil.move(str(root), str(old_root))
     shutil.move(str(new_root), str(root))
@@ -579,6 +663,21 @@ if __name__ == "__main__":
         "--force-conversion",
         action="store_true",
         help="Force conversion even if the dataset already has a v3.0 version.",
+    )
+    parser.add_argument(
+        "--episode-start",
+        type=int,
+        default=None,
+        help="First episode index to convert, inclusive. Defaults to the first episode.",
+    )
+    parser.add_argument(
+        "--episode-end",
+        type=int,
+        default=None,
+        help=(
+            "Episode index at which to stop conversion, exclusive. "
+            "Defaults to the total number of episodes."
+        ),
     )
 
     args = parser.parse_args()

--- a/src/lerobot/scripts/convert_dataset_v21_to_v30.py
+++ b/src/lerobot/scripts/convert_dataset_v21_to_v30.py
@@ -674,8 +674,7 @@ if __name__ == "__main__":
         type=int,
         default=None,
         help=(
-            "Episode index at which to stop conversion, exclusive. "
-            "Defaults to the total number of episodes."
+            "Episode index at which to stop conversion, exclusive. Defaults to the total number of episodes."
         ),
     )
 

--- a/src/lerobot/scripts/convert_dataset_v21_to_v30.py
+++ b/src/lerobot/scripts/convert_dataset_v21_to_v30.py
@@ -263,6 +263,7 @@ def convert_data(root: Path, new_root: Path, data_file_size_in_mb: int, episode_
     logging.info(f"Converting data files from {len(ep_paths)} episodes")
 
     for ep_idx, ep_path in enumerate(tqdm.tqdm(ep_paths, desc="convert data files")):
+        source_ep_idx = get_episode_index_from_path(ep_path)
         ep_size_in_mb = get_parquet_file_size_in_mb(ep_path)
         ep_num_frames = get_parquet_num_frames(ep_path)
 
@@ -281,6 +282,7 @@ def convert_data(root: Path, new_root: Path, data_file_size_in_mb: int, episode_
         # Now create metadata with correct chunk/file indices
         ep_metadata = {
             "episode_index": ep_idx,
+            "source_episode_index": source_ep_idx,
             "data/chunk_index": chunk_idx,
             "data/file_index": file_idx,
             "dataset_from_index": num_frames,
@@ -464,18 +466,15 @@ def convert_episodes_metadata(
 
     legacy_episodes = legacy_load_episodes(root)
     legacy_episodes_stats = legacy_load_episodes_stats(root)
-    episodes_legacy_metadata = {
-        new_ep_idx: {**legacy_episode, "episode_index": new_ep_idx}
-        for new_ep_idx, legacy_episode in enumerate(
-            legacy_episodes[source_ep_idx] for source_ep_idx in episode_indices
-        )
-    }
-    episodes_stats = {
-        new_ep_idx: legacy_stats
-        for new_ep_idx, legacy_stats in enumerate(
-            legacy_episodes_stats[source_ep_idx] for source_ep_idx in episode_indices
-        )
-    }
+    episodes_legacy_metadata = {}
+    episodes_stats = {}
+    for new_ep_idx, source_ep_idx in enumerate(episode_indices):
+        episodes_legacy_metadata[new_ep_idx] = {
+            **legacy_episodes[source_ep_idx],
+            "episode_index": new_ep_idx,
+            "source_episode_index": source_ep_idx,
+        }
+        episodes_stats[new_ep_idx] = legacy_episodes_stats[source_ep_idx]
 
     num_eps_set = {len(episodes_legacy_metadata), len(episodes_metadata)}
     if episodes_video_metadata is not None:

--- a/src/lerobot/scripts/convert_dataset_v21_to_v30.py
+++ b/src/lerobot/scripts/convert_dataset_v21_to_v30.py
@@ -459,16 +459,16 @@ def generate_episode_metadata_dict(
         yield ep_dict
 
 
-def convert_episodes_metadata(
-    root, new_root, episodes_metadata, episode_indices, episodes_video_metadata=None
-):
+def convert_episodes_metadata(root, new_root, episodes_metadata, episodes_video_metadata=None):
     logging.info(f"Converting episodes metadata from {root} to {new_root}")
 
     legacy_episodes = legacy_load_episodes(root)
     legacy_episodes_stats = legacy_load_episodes_stats(root)
     episodes_legacy_metadata = {}
     episodes_stats = {}
-    for new_ep_idx, source_ep_idx in enumerate(episode_indices):
+    for ep_metadata in episodes_metadata:
+        new_ep_idx = ep_metadata["episode_index"]
+        source_ep_idx = ep_metadata["source_episode_index"]
         episodes_legacy_metadata[new_ep_idx] = {
             **legacy_episodes[source_ep_idx],
             "episode_index": new_ep_idx,
@@ -595,7 +595,7 @@ def convert_dataset(
     convert_info(
         root, new_root, data_file_size_in_mb, video_file_size_in_mb, len(episode_indices), total_frames
     )
-    convert_episodes_metadata(root, new_root, episodes_metadata, episode_indices, episodes_videos_metadata)
+    convert_episodes_metadata(root, new_root, episodes_metadata, episodes_videos_metadata)
 
     shutil.move(str(root), str(old_root))
     shutil.move(str(new_root), str(root))

--- a/src/lerobot/scripts/convert_dataset_v21_to_v30.py
+++ b/src/lerobot/scripts/convert_dataset_v21_to_v30.py
@@ -48,6 +48,8 @@ meta/, data/, videos/. When omitted, defaults to $HF_LEROBOT_HOME/{repo_id}.
 import argparse
 import logging
 import shutil
+import subprocess
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -210,6 +212,75 @@ def select_episode_paths(paths: list[Path], episode_indices: range) -> list[Path
 
 def has_episode_subset(episode_start: int | None, episode_end: int | None) -> bool:
     return episode_start is not None or episode_end is not None
+
+
+def split_episode_ranges(episode_indices: range, num_workers: int) -> list[range]:
+    if num_workers < 1:
+        raise ValueError(f"num_workers must be >= 1, got {num_workers}.")
+
+    total_episodes = len(episode_indices)
+    num_shards = min(num_workers, total_episodes)
+    base_size, remainder = divmod(total_episodes, num_shards)
+    ranges = []
+    shard_start = episode_indices.start
+    for shard_idx in range(num_shards):
+        shard_size = base_size + (1 if shard_idx < remainder else 0)
+        shard_end = shard_start + shard_size
+        ranges.append(range(shard_start, shard_end))
+        shard_start = shard_end
+    return ranges
+
+
+def run_conversion_workers(
+    repo_id: str,
+    root: Path,
+    output_root: Path,
+    episode_ranges: list[range],
+    data_file_size_in_mb: int,
+    video_file_size_in_mb: int,
+):
+    output_root.mkdir(parents=True, exist_ok=True)
+    processes = []
+    for worker_idx, episode_range in enumerate(episode_ranges):
+        shard_root = output_root / f"shard-{worker_idx:03d}"
+        cmd = [
+            sys.executable,
+            "-m",
+            "lerobot.scripts.convert_dataset_v21_to_v30",
+            "--repo-id",
+            repo_id,
+            "--root",
+            str(root),
+            "--output-root",
+            str(shard_root),
+            "--push-to-hub=false",
+            "--force-conversion",
+            "--episode-start",
+            str(episode_range.start),
+            "--episode-end",
+            str(episode_range.stop),
+            "--data-file-size-in-mb",
+            str(data_file_size_in_mb),
+            "--video-file-size-in-mb",
+            str(video_file_size_in_mb),
+        ]
+        logging.info(
+            "Launching worker %s for episode range [%s, %s) -> %s",
+            worker_idx,
+            episode_range.start,
+            episode_range.stop,
+            shard_root,
+        )
+        processes.append((worker_idx, subprocess.Popen(cmd)))
+
+    failed_workers = []
+    for worker_idx, process in processes:
+        return_code = process.wait()
+        if return_code != 0:
+            failed_workers.append((worker_idx, return_code))
+
+    if failed_workers:
+        raise RuntimeError(f"Conversion workers failed: {failed_workers}")
 
 
 def convert_tasks(root, new_root):
@@ -536,14 +607,30 @@ def convert_dataset(
     force_conversion: bool = False,
     episode_start: int | None = None,
     episode_end: int | None = None,
+    output_root: str | Path | None = None,
+    num_workers: int = 1,
 ):
     if data_file_size_in_mb is None:
         data_file_size_in_mb = DEFAULT_DATA_FILE_SIZE_IN_MB
     if video_file_size_in_mb is None:
         video_file_size_in_mb = DEFAULT_VIDEO_FILE_SIZE_IN_MB
+    if num_workers < 1:
+        raise ValueError(f"num_workers must be >= 1, got {num_workers}.")
+    if num_workers > 1 and push_to_hub:
+        raise ValueError("--num-workers writes local shard directories and cannot be used with --push-to-hub=true.")
+    if output_root is not None and push_to_hub:
+        raise ValueError(
+            "--output-root writes a local shard/output directory and cannot be used with --push-to-hub=true."
+        )
 
     # First check if the dataset already has a v3.0 version
-    if root is None and not force_conversion and not has_episode_subset(episode_start, episode_end):
+    if (
+        root is None
+        and not force_conversion
+        and not has_episode_subset(episode_start, episode_end)
+        and output_root is None
+        and num_workers == 1
+    ):
         try:
             print("Trying to download v3.0 version of the dataset from the hub...")
             snapshot_download(repo_id, repo_type="dataset", revision=V30, local_dir=HF_LEROBOT_HOME / repo_id)
@@ -559,15 +646,21 @@ def convert_dataset(
         use_local_dataset = True
         print(f"Using local dataset at {root}")
 
+    output_root = Path(output_root) if output_root is not None else None
+    if num_workers > 1 and output_root is None:
+        output_root = root.parent / f"{root.name}_shards"
     old_root = root.parent / f"{root.name}_old"
-    new_root = root.parent / f"{root.name}_v30"
+    new_root = output_root if output_root is not None else root.parent / f"{root.name}_v30"
 
-    # Handle old_root cleanup if both old_root and root exist
-    if old_root.is_dir() and root.is_dir():
-        shutil.rmtree(str(root))
-        shutil.move(str(old_root), str(root))
+    if output_root is None:
+        # Handle old_root cleanup if both old_root and root exist
+        if old_root.is_dir() and root.is_dir():
+            shutil.rmtree(str(root))
+            shutil.move(str(old_root), str(root))
 
-    if new_root.is_dir():
+        if new_root.is_dir():
+            shutil.rmtree(new_root)
+    elif new_root.is_dir():
         shutil.rmtree(new_root)
 
     if not use_local_dataset:
@@ -588,6 +681,25 @@ def convert_dataset(
             info.total_episodes,
         )
 
+    if num_workers > 1:
+        if output_root.is_dir():
+            shutil.rmtree(output_root)
+        episode_ranges = split_episode_ranges(episode_indices, num_workers)
+        logging.info(
+            "Running local multiprocessing conversion with %s worker(s) into %s",
+            len(episode_ranges),
+            output_root,
+        )
+        run_conversion_workers(
+            repo_id,
+            root,
+            output_root,
+            episode_ranges,
+            data_file_size_in_mb,
+            video_file_size_in_mb,
+        )
+        return
+
     convert_tasks(root, new_root)
     episodes_metadata = convert_data(root, new_root, data_file_size_in_mb, episode_indices)
     total_frames = episodes_metadata[-1]["dataset_to_index"] if episodes_metadata else 0
@@ -597,8 +709,9 @@ def convert_dataset(
     )
     convert_episodes_metadata(root, new_root, episodes_metadata, episodes_videos_metadata)
 
-    shutil.move(str(root), str(old_root))
-    shutil.move(str(new_root), str(root))
+    if output_root is None:
+        shutil.move(str(root), str(old_root))
+        shutil.move(str(new_root), str(root))
 
     if push_to_hub:
         hub_api = HfApi()
@@ -676,6 +789,20 @@ if __name__ == "__main__":
         help=(
             "Episode index at which to stop conversion, exclusive. Defaults to the total number of episodes."
         ),
+    )
+    parser.add_argument(
+        "--output-root",
+        type=str,
+        default=None,
+        help=(
+            "Local output directory for the converted dataset. When set, the source root is left unchanged."
+        ),
+    )
+    parser.add_argument(
+        "--num-workers",
+        type=int,
+        default=1,
+        help="Number of local subprocess workers to launch. Defaults to 1.",
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
## Title

[2/4][#1998] Add episode subset conversion support for v2.1 to v3.0 datasets

## Summary / Motivation

This PR adds --episode-start and --episode-end to convert_dataset_v21_to_v30.py, allowing the conversion script to convert only a subset of episodes.

The selected source episodes are converted into a compact v3.0 dataset with contiguous episode_index and frame index values starting at 0. To preserve lineage, the episode metadata also includes source_episode_index, which records the original v2.1 episode id.

## Related issues

- Fixes / Closes: # (if any)
- Related: #1998

## What changed

- Added --episode-start and --episode-end CLI arguments to convert only a selected episode range.
- Treats episode-start as inclusive and episode-end as exclusive.
- Filters data parquet files and camera video files to the selected source episodes.
- Re-indexes the converted subset into a compact v3.0 dataset with contiguous episode_index values starting at 0.
- Rewrites frame-level index and episode_index values in converted data parquet files.
- Adds source_episode_index to episode metadata to preserve the original v2.1 episode id.
- Updates converted info.json with subset-specific total_episodes, total_frames, and splits.
- Keeps stats aggregation scoped to the selected episode subset.

## How was this tested (or how to run locally)

- Manual checks / dataset runs performed.
- Instructions for the reviewer for reproducing with a quick example or CLI (if applicable)


run data slice from episode 1 to 3 (exclusive):

```bash
TMP_DIR=$(mktemp -d /private/tmp/lerobot_subset_pr.XXXXXX)
cp -R /Users/huixiy/.cache/huggingface/lerobot/lerobot/svla_so101_pickplace_old \  
  "$TMP_DIR/svla_so101_pickplace"

echo "$TMP_DIR"

uv run python -m lerobot.scripts.convert_dataset_v21_to_v30 \
  --repo-id=lerobot/svla_so101_pickplace \
  --root="$TMP_DIR/svla_so101_pickplace" \
  --push-to-hub=false \
  --force-conversion \
  --episode-start=1 \
  --episode-end=3
```
inspect metadata for verification:

```bash
uv run python -c "import pandas as pd; root='$TMP_DIR/svla_so101_pickplace'; df=pd.read_parquet(f'{root}/meta/episodes/chunk-000/file-000.parquet'); print(df[['episode_index','source_episode_index','dataset_from_index','dataset_to_index','length']].to_string())"
```
<img width="922" height="47" alt="image" src="https://github.com/user-attachments/assets/e3caeb24-354e-47dc-ba21-289eeb09dbef" />

Backward Compatibility
```bash
uv run python -m lerobot.scripts.convert_dataset_v21_to_v30 \
  --repo-id=lerobot/svla_so101_pickplace \
  --root="$TMP_DIR/svla_so101_pickplace" \
  --push-to-hub=false \
  --force-conversion

```
## Checklist (required before merge)

- [✔️] Linting/formatting run (`pre-commit run -a`)
- [✔️] All tests pass locally (`pytest`)
- [✔️] Documentation updated
- [✔️] CI is green
- [✔️] Community Review: I have reviewed another contributor's open PR and linked it here: # (insert PR number/link)

## Reviewer notes

N/A
