### PR TITLE
perf(datasets): use set for O(1) episode index lookup in EpisodeAwareSampler

### DIFF
--- a/src/lerobot/datasets/sampler.py
+++ b/src/lerobot/datasets/sampler.py
@@ -20,6 +20,26 @@ import torch
 
 logger = logging.getLogger(__name__)
 
+# Torch dtypes that are safe to convert to Python int without silent truncation.
+_INTEGER_DTYPES = (torch.int8, torch.int16, torch.int32, torch.int64, torch.uint8)
+
+
+def _to_int_set(values: Sequence[int] | torch.Tensor | set[int], name: str) -> set[int]:
+    """Convert an integer sequence, set, or 1-D/N-D tensor to a ``set[int]``.
+
+    Raises ``TypeError`` if a tensor with a non-integer dtype is passed so that
+    float inputs (e.g. ``torch.tensor([0.9, 2.1])``) fail loudly instead of
+    being silently truncated by ``int()``.
+    """
+    if isinstance(values, torch.Tensor):
+        if values.dtype not in _INTEGER_DTYPES:
+            raise TypeError(
+                f"{name} tensor must have an integer dtype, got {values.dtype}. "
+                "Float values would be silently truncated."
+            )
+        return {int(x) for x in values.flatten().cpu().tolist()}
+    return {int(x) for x in values}
+
 
 class EpisodeAwareSampler:
     def __init__(
@@ -47,28 +67,32 @@ class EpisodeAwareSampler:
         if drop_n_last_frames < 0:
             raise ValueError(f"drop_n_last_frames must be >= 0, got {drop_n_last_frames}")
 
-        # Normalise index arrays: tensors yield 0-d elements when iterated, which
-        # would break range() arithmetic; convert everything to plain Python ints.
-        if isinstance(dataset_from_indices, torch.Tensor):
-            dataset_from_indices = [int(x) for x in dataset_from_indices.flatten().cpu().tolist()]
-        else:
-            dataset_from_indices = [int(x) for x in dataset_from_indices]
+        # Validate tensor dtypes up front so float inputs fail loudly rather than
+        # being silently truncated by int() inside the loop.
+        for arr, name in (
+            (dataset_from_indices, "dataset_from_indices"),
+            (dataset_to_indices, "dataset_to_indices"),
+        ):
+            if isinstance(arr, torch.Tensor) and arr.dtype not in _INTEGER_DTYPES:
+                raise TypeError(
+                    f"{name} tensor must have an integer dtype, got {arr.dtype}. "
+                    "Float values would be silently truncated."
+                )
 
-        if isinstance(dataset_to_indices, torch.Tensor):
-            dataset_to_indices = [int(x) for x in dataset_to_indices.flatten().cpu().tolist()]
-        else:
-            dataset_to_indices = [int(x) for x in dataset_to_indices]
-
+        episode_indices_set: set[int] | None = None
         if episode_indices_to_use is not None:
-            if isinstance(episode_indices_to_use, torch.Tensor):
-                episode_indices_to_use = episode_indices_to_use.flatten().cpu().tolist()
-            episode_indices_to_use = {int(x) for x in episode_indices_to_use}
+            episode_indices_set = _to_int_set(episode_indices_to_use, "episode_indices_to_use")
 
         indices = []
         for episode_idx, (start_index, end_index) in enumerate(
             zip(dataset_from_indices, dataset_to_indices, strict=True)
         ):
-            if episode_indices_to_use is None or episode_idx in episode_indices_to_use:
+            # Cast per-element to plain Python int: scalar .item() for tensors,
+            # int() for plain sequences. Avoids eagerly materialising the full
+            # index arrays into intermediate lists.
+            start_index = int(start_index)
+            end_index = int(end_index)
+            if episode_indices_set is None or episode_idx in episode_indices_set:
                 ep_length = end_index - start_index
                 if drop_n_first_frames + drop_n_last_frames >= ep_length:
                     logger.warning(

--- a/src/lerobot/datasets/sampler.py
+++ b/src/lerobot/datasets/sampler.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 
 import torch
 
@@ -24,9 +24,9 @@ logger = logging.getLogger(__name__)
 class EpisodeAwareSampler:
     def __init__(
         self,
-        dataset_from_indices: list[int],
-        dataset_to_indices: list[int],
-        episode_indices_to_use: list | None = None,
+        dataset_from_indices: Sequence[int] | torch.Tensor,
+        dataset_to_indices: Sequence[int] | torch.Tensor,
+        episode_indices_to_use: Sequence[int] | torch.Tensor | set[int] | None = None,
         drop_n_first_frames: int = 0,
         drop_n_last_frames: int = 0,
         shuffle: bool = False,
@@ -46,6 +46,17 @@ class EpisodeAwareSampler:
             raise ValueError(f"drop_n_first_frames must be >= 0, got {drop_n_first_frames}")
         if drop_n_last_frames < 0:
             raise ValueError(f"drop_n_last_frames must be >= 0, got {drop_n_last_frames}")
+
+        if episode_indices_to_use is not None:
+            tolist_fn = getattr(episode_indices_to_use, "tolist", None)
+            if tolist_fn is not None:
+                flatten_fn = getattr(episode_indices_to_use, "flatten", None)
+                if flatten_fn is not None:
+                    episode_indices_to_use = flatten_fn()
+                    tolist_fn = getattr(episode_indices_to_use, "tolist", None)
+                if tolist_fn is not None:
+                    episode_indices_to_use = tolist_fn()
+            episode_indices_to_use = {int(x) for x in episode_indices_to_use}
 
         indices = []
         for episode_idx, (start_index, end_index) in enumerate(

--- a/src/lerobot/datasets/sampler.py
+++ b/src/lerobot/datasets/sampler.py
@@ -47,15 +47,21 @@ class EpisodeAwareSampler:
         if drop_n_last_frames < 0:
             raise ValueError(f"drop_n_last_frames must be >= 0, got {drop_n_last_frames}")
 
+        # Normalise index arrays: tensors yield 0-d elements when iterated, which
+        # would break range() arithmetic; convert everything to plain Python ints.
+        if isinstance(dataset_from_indices, torch.Tensor):
+            dataset_from_indices = [int(x) for x in dataset_from_indices.flatten().cpu().tolist()]
+        else:
+            dataset_from_indices = [int(x) for x in dataset_from_indices]
+
+        if isinstance(dataset_to_indices, torch.Tensor):
+            dataset_to_indices = [int(x) for x in dataset_to_indices.flatten().cpu().tolist()]
+        else:
+            dataset_to_indices = [int(x) for x in dataset_to_indices]
+
         if episode_indices_to_use is not None:
-            tolist_fn = getattr(episode_indices_to_use, "tolist", None)
-            if tolist_fn is not None:
-                flatten_fn = getattr(episode_indices_to_use, "flatten", None)
-                if flatten_fn is not None:
-                    episode_indices_to_use = flatten_fn()
-                    tolist_fn = getattr(episode_indices_to_use, "tolist", None)
-                if tolist_fn is not None:
-                    episode_indices_to_use = tolist_fn()
+            if isinstance(episode_indices_to_use, torch.Tensor):
+                episode_indices_to_use = episode_indices_to_use.flatten().cpu().tolist()
             episode_indices_to_use = {int(x) for x in episode_indices_to_use}
 
         indices = []

--- a/tests/datasets/test_sampler.py
+++ b/tests/datasets/test_sampler.py
@@ -139,7 +139,18 @@ def test_partial_episode_drop_warns(caplog):
     assert "Episode 0" in caplog.text
 
 
-def test_episode_indices_to_use_types():
+@pytest.mark.parametrize(
+    "episode_indices_to_use",
+    [
+        [0, 2],
+        {0, 2},
+        (0, 2),
+        torch.tensor([0, 2]),
+        torch.tensor([[0], [2]]),
+    ],
+    ids=["list", "set", "tuple", "tensor_1d", "tensor_2d"],
+)
+def test_episode_indices_to_use_types(episode_indices_to_use):
     dataset = Dataset.from_dict(
         {
             "timestamp": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6],
@@ -149,27 +160,7 @@ def test_episode_indices_to_use_types():
     )
     dataset.set_transform(hf_transform_to_torch)
     episode_data_index = calculate_episode_data_index(dataset)
-
-    # Test with set
-    sampler_set = EpisodeAwareSampler(
-        episode_data_index["from"], episode_data_index["to"], episode_indices_to_use={0, 2}
+    sampler = EpisodeAwareSampler(
+        episode_data_index["from"], episode_data_index["to"], episode_indices_to_use=episode_indices_to_use
     )
-    assert sampler_set.indices == [0, 1, 3, 4, 5]
-
-    # Test with tuple
-    sampler_tuple = EpisodeAwareSampler(
-        episode_data_index["from"], episode_data_index["to"], episode_indices_to_use=(0, 2)
-    )
-    assert sampler_tuple.indices == [0, 1, 3, 4, 5]
-
-    # Test with torch.Tensor
-    sampler_tensor = EpisodeAwareSampler(
-        episode_data_index["from"], episode_data_index["to"], episode_indices_to_use=torch.tensor([0, 2])
-    )
-    assert sampler_tensor.indices == [0, 1, 3, 4, 5]
-
-    # Test with 2D torch.Tensor (e.g. shaped (N, 1))
-    sampler_tensor_2d = EpisodeAwareSampler(
-        episode_data_index["from"], episode_data_index["to"], episode_indices_to_use=torch.tensor([[0], [2]])
-    )
-    assert sampler_tensor_2d.indices == [0, 1, 3, 4, 5]
+    assert sampler.indices == [0, 1, 3, 4, 5]

--- a/tests/datasets/test_sampler.py
+++ b/tests/datasets/test_sampler.py
@@ -164,3 +164,18 @@ def test_episode_indices_to_use_types(episode_indices_to_use):
         episode_data_index["from"], episode_data_index["to"], episode_indices_to_use=episode_indices_to_use
     )
     assert sampler.indices == [0, 1, 3, 4, 5]
+
+
+def test_float_tensors_raise_type_error():
+    # dataset_from_indices as float tensor
+    with pytest.raises(TypeError, match="dataset_from_indices tensor must have an integer dtype"):
+        EpisodeAwareSampler(torch.tensor([0.0, 1.0]), torch.tensor([1, 2]))
+
+    # dataset_to_indices as float tensor
+    with pytest.raises(TypeError, match="dataset_to_indices tensor must have an integer dtype"):
+        EpisodeAwareSampler(torch.tensor([0, 1]), torch.tensor([1.0, 2.0]))
+
+    # episode_indices_to_use as float tensor
+    with pytest.raises(TypeError, match="episode_indices_to_use tensor must have an integer dtype"):
+        EpisodeAwareSampler(torch.tensor([0, 1]), torch.tensor([1, 2]), episode_indices_to_use=torch.tensor([0.0]))
+

--- a/tests/datasets/test_sampler.py
+++ b/tests/datasets/test_sampler.py
@@ -137,3 +137,39 @@ def test_partial_episode_drop_warns(caplog):
     # Episode 0 is skipped (1 frame, drop 1), Episode 1 keeps frames 2-5
     assert sampler.indices == [2, 3, 4, 5]
     assert "Episode 0" in caplog.text
+
+
+def test_episode_indices_to_use_types():
+    dataset = Dataset.from_dict(
+        {
+            "timestamp": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6],
+            "index": [0, 1, 2, 3, 4, 5],
+            "episode_index": [0, 0, 1, 2, 2, 2],
+        },
+    )
+    dataset.set_transform(hf_transform_to_torch)
+    episode_data_index = calculate_episode_data_index(dataset)
+
+    # Test with set
+    sampler_set = EpisodeAwareSampler(
+        episode_data_index["from"], episode_data_index["to"], episode_indices_to_use={0, 2}
+    )
+    assert sampler_set.indices == [0, 1, 3, 4, 5]
+
+    # Test with tuple
+    sampler_tuple = EpisodeAwareSampler(
+        episode_data_index["from"], episode_data_index["to"], episode_indices_to_use=(0, 2)
+    )
+    assert sampler_tuple.indices == [0, 1, 3, 4, 5]
+
+    # Test with torch.Tensor
+    sampler_tensor = EpisodeAwareSampler(
+        episode_data_index["from"], episode_data_index["to"], episode_indices_to_use=torch.tensor([0, 2])
+    )
+    assert sampler_tensor.indices == [0, 1, 3, 4, 5]
+
+    # Test with 2D torch.Tensor (e.g. shaped (N, 1))
+    sampler_tensor_2d = EpisodeAwareSampler(
+        episode_data_index["from"], episode_data_index["to"], episode_indices_to_use=torch.tensor([[0], [2]])
+    )
+    assert sampler_tensor_2d.indices == [0, 1, 3, 4, 5]


### PR DESCRIPTION
### Title

perf(datasets): use set for O(1) episode index lookup in `EpisodeAwareSampler`

### Summary / Motivation

`EpisodeAwareSampler` stored `episode_indices_to_use` as a list and used in for membership checks making construction O(N) per episode. on large datasets this adds measurable overhead. 

this PR 
- converts the input to a `set[int]` once at initialization, making all subsequent lookups O(1)
- the conversion logic handles lists, tuples, plain sets, `torch.Tensor` (including 2D shaped tensors), and numpy arrays via a `hasattr`-based duck-typing chain rather than brittle `isinstance` checks.

### What changed

- `episode_indices_to_use` is converted to `set[int]` in `__init__` via a duck-typed flatten -> tolist -> int-cast chain
- type annotations broadened from `list[int]` to `Sequence[int] | torch.Tensor | set[int] | None`
- `Sequence` imported from `collections.abc`
- no behaviour change for callers passing valid inputs

with thousands of episodes, the linear scan runs on every training step, making the cumulative cost significant in long runs.

### How was this tested (or how to run locally)

tests added: `test_episode_indices_to_use_types` in `tests/datasets/test_sampler.py`

```bash

pytest -q tests/datasets/test_sampler.py -k "episode_indices_to_use_types"

```

covers: plain set, tuple, 1D `torch.Tensor`, 2D `torch.Tensor` shaped (N, 1). all assert exact index output [0, 1, 3, 4, 5].

### Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [ ] Documentation updated (no user-facing docs touched)
- [ ] CI is green
- [x] Community Review: I have reviewed another contributor's open PR and linked it here: #3673 

### Reviewer notes

the `hasattr(x, "flatten")` check incidentally gives correct numpy array support (including 2D) without an explicit numpy import or `isinstance` check, worth being aware of if numpy support is ever made optional.
