### PR TITLE
docs(dataset): document preparing datasets before lerobot-train

### DIFF
--- a/docs/source/lerobot-dataset-v3.mdx
+++ b/docs/source/lerobot-dataset-v3.mdx
@@ -163,6 +163,10 @@ Image transforms are data augmentations applied to camera frames during training
 
 Currently, transforms are applied during **training time only**, not during recording. When you create or record a dataset, the raw images are stored without transforms. This allows you to experiment with different augmentations later without re-recording data.
 
+### Training with `lerobot-train` (CLI)
+
+From the command line, pass `--dataset.image_transforms.*` flags to enable transforms (including `Resize` via `torchvision.transforms.v2`). For a full comparison of permanent dataset edits versus training-time options (episode filtering, resize, FPS), see [Preparing a dataset for training](./using_dataset_tools#preparing-a-dataset-for-training).
+
 ### Adding transforms to existing datasets (API)
 
 Use the `image_transforms` parameter when loading a dataset for training:

--- a/docs/source/using_dataset_tools.mdx
+++ b/docs/source/using_dataset_tools.mdx
@@ -194,13 +194,13 @@ There is also a tool for adding features to a dataset that is not yet covered in
 
 ## Preparing a dataset for training
 
-When you run `lerobot-train` with only `--dataset.repo_id`, you are loading the dataset as stored on disk. Some changes can be applied **at training time** (in memory, not written back to the Hub or local copy). Others require **permanent** edits with `lerobot-edit-dataset`, re-recording, or external preprocessing.
+When you run `lerobot-train` with only `--dataset.repo_id` (and optionally `--dataset.root` for a local dataset tree), you are loading the dataset as stored on disk. Some changes can be applied **at training time** (in memory, not written back to the Hub or local copy). Others require **permanent** edits with `lerobot-edit-dataset`, re-recording, or external preprocessing.
 
-| Goal                 | Permanent (on disk)                                                                                                                | Training-time only (`lerobot-train`)                                                                                   |
-| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| Drop episodes        | `lerobot-edit-dataset` with `--operation.type delete_episodes` and `--new_repo_id`                                                 | `--dataset.episodes="[0, 2, 5]"`                                                                                       |
-| Resize camera images | No dedicated `lerobot-edit-dataset` operation; re-record or preprocess frames, then publish a new dataset                          | `--dataset.image_transforms` with a `Resize` transform (see [Image transforms](./lerobot-dataset-v3#image-transforms)) |
-| Change dataset FPS   | Not supported by `lerobot-edit-dataset`; re-record or downsample externally, then create a new v3 dataset with matching `meta.fps` | N/A — training uses the dataset's stored `fps`                                                                         |
+| Goal                 | Permanent (on disk)                                                                                                                                  | Training-time only (`lerobot-train`)                                                                                   |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| Drop episodes        | `lerobot-edit-dataset` with `--operation.type delete_episodes` (optionally `--new_repo_id` to keep the original; use `--push_to_hub true` to upload) | `--dataset.episodes=[0, 2, 5]`                                                                                         |
+| Resize camera images | No dedicated `lerobot-edit-dataset` operation; re-record or preprocess frames, then publish a new dataset                                            | `--dataset.image_transforms` with a `Resize` transform (see [Image transforms](./lerobot-dataset-v3#image-transforms)) |
+| Change dataset FPS   | Not supported by `lerobot-edit-dataset`; re-record or downsample externally, then create a new v3 dataset with matching `meta.fps`                   | No frame subsampling flag — all frames are read at the dataset's stored `fps`                                          |
 
 ### Drop episodes without rewriting the dataset
 
@@ -209,11 +209,11 @@ To **filter episodes only for one training run** (original dataset unchanged):
 ```bash
 lerobot-train \
     --dataset.repo_id lerobot/pusht \
-    --dataset.episodes="[0, 2, 5]" \
+    --dataset.episodes=[0, 2, 5] \
     ...
 ```
 
-To **remove episodes permanently** and optionally upload a new revision, use [Delete Episodes](#delete-episodes) with `--new_repo_id`.
+To **remove episodes permanently**, use [Delete Episodes](#delete-episodes): omit `--new_repo_id` to modify the dataset in place, or set `--new_repo_id` to write a copy. Add `--push_to_hub true` when you want the result on the Hugging Face Hub.
 
 ### Resize images at training time
 
@@ -224,15 +224,16 @@ lerobot-train \
     --dataset.repo_id lerobot/pusht \
     --dataset.image_transforms.enable=true \
     --dataset.image_transforms.max_num_transforms=1 \
+    --dataset.image_transforms.random_order=false \
     --dataset.image_transforms.tfs='{"resize":{"type":"Resize","kwargs":{"size":[224,224]},"weight":1.0}}' \
     ...
 ```
 
-Many policies (for example PI0 and SmolVLA) also resize images inside their **policy preprocessor** to a fixed resolution. If you enable both dataset transforms and a policy that resizes, images may be resized twice—prefer configuring one place unless you intend both steps.
+Many policies (for example PI0 and SmolVLA) also resize images inside their **policy preprocessor** to a fixed resolution. If you enable both dataset transforms and a policy that resizes, images may be resized twice—prefer configuring one place unless you intend both steps. For Python API usage, see `examples/dataset/use_dataset_image_transforms.py`.
 
 ### FPS downsampling
 
-LeRobot datasets store a single `fps` value in dataset metadata; frame timestamps and episode lengths assume that rate. There is no FPS downsampling operation in `lerobot-edit-dataset`. To train on fewer frames per second, downsample your recordings with an external tool, then record or convert the result into a new LeRobot v3 dataset whose `meta.fps` matches the new rate.
+LeRobot datasets store a single `fps` value in dataset metadata; frame timestamps and episode lengths assume that rate. There is no FPS downsampling operation in `lerobot-edit-dataset`, and `lerobot-train` has no flag to skip frames at a lower rate. To train on fewer frames per second, downsample your recordings with an external tool, then record or convert the result into a new LeRobot v3 dataset whose `meta.fps` matches the new rate.
 
 # Dataset Visualization
 

--- a/docs/source/using_dataset_tools.mdx
+++ b/docs/source/using_dataset_tools.mdx
@@ -196,20 +196,22 @@ There is also a tool for adding features to a dataset that is not yet covered in
 
 When you run `lerobot-train` with only `--dataset.repo_id` (and optionally `--dataset.root` for a local dataset tree), you are loading the dataset as stored on disk. Some changes can be applied **at training time** (in memory, not written back to the Hub or local copy). Others require **permanent** edits with `lerobot-edit-dataset`, re-recording, or external preprocessing.
 
-| Goal                 | Permanent (on disk)                                                                                                                                  | Training-time only (`lerobot-train`)                                                                                   |
-| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| Drop episodes        | `lerobot-edit-dataset` with `--operation.type delete_episodes` (optionally `--new_repo_id` to keep the original; use `--push_to_hub true` to upload) | `--dataset.episodes=[0, 2, 5]`                                                                                         |
-| Resize camera images | No dedicated `lerobot-edit-dataset` operation; re-record or preprocess frames, then publish a new dataset                                            | `--dataset.image_transforms` with a `Resize` transform (see [Image transforms](./lerobot-dataset-v3#image-transforms)) |
-| Change dataset FPS   | Not supported by `lerobot-edit-dataset`; re-record or downsample externally, then create a new v3 dataset with matching `meta.fps`                   | No frame subsampling flag — all frames are read at the dataset's stored `fps`                                          |
+| Goal                         | Permanent (on disk)                                                                                                                                  | Training-time only (`lerobot-train`)                                                                                   |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| Select a subset of episodes  | `lerobot-edit-dataset` with `--operation.type delete_episodes` (optionally `--new_repo_id` to keep the original; use `--push_to_hub true` to upload) | `--dataset.episodes='[0,2,5]'` — inclusion list: train only on listed episode indices                                |
+| Resize camera images         | No dedicated `lerobot-edit-dataset` operation; re-record or preprocess frames, then publish a new dataset                                            | `--dataset.image_transforms` with a `Resize` transform (see [Image transforms](./lerobot-dataset-v3#image-transforms)) |
+| Change dataset FPS           | Not supported by `lerobot-edit-dataset`; re-record or downsample externally, then create a new v3 dataset with matching `meta.fps`                   | No lower-FPS sampling flag; indices and timestamps remain based on stored `meta.fps`                                   |
 
-### Drop episodes without rewriting the dataset
+### Select a subset of episodes (training-time only)
 
-To **filter episodes only for one training run** (original dataset unchanged):
+To **train only on selected episodes for one run** (original dataset unchanged):
+
+`--dataset.episodes` is an **inclusion list**: to exclude bad episodes, pass the list of episode indices you want to keep.
 
 ```bash
 lerobot-train \
     --dataset.repo_id lerobot/pusht \
-    --dataset.episodes=[0, 2, 5] \
+    --dataset.episodes='[0,2,5]' \
     ...
 ```
 
@@ -229,11 +231,11 @@ lerobot-train \
     ...
 ```
 
-Many policies (for example PI0 and SmolVLA) also resize images inside their **policy preprocessor** to a fixed resolution. If you enable both dataset transforms and a policy that resizes, images may be resized twice—prefer configuring one place unless you intend both steps. For Python API usage, see `examples/dataset/use_dataset_image_transforms.py`.
+Some policy configurations may also resize or crop images in their preprocessing pipeline. If you enable both dataset transforms and policy-side preprocessing, images may be resized twice—prefer configuring one place unless you intend both steps. For Python API usage, see `examples/dataset/use_dataset_image_transforms.py`.
 
 ### FPS downsampling
 
-LeRobot datasets store a single `fps` value in dataset metadata; frame timestamps and episode lengths assume that rate. There is no FPS downsampling operation in `lerobot-edit-dataset`, and `lerobot-train` has no flag to skip frames at a lower rate. To train on fewer frames per second, downsample your recordings with an external tool, then record or convert the result into a new LeRobot v3 dataset whose `meta.fps` matches the new rate.
+LeRobot datasets store a single `fps` value in dataset metadata; frame timestamps and episode lengths assume that rate. There is no FPS downsampling operation in `lerobot-edit-dataset`, and `lerobot-train` has no lower-FPS sampling flag—dataset indices and timestamps remain based on the stored `meta.fps`. To train at a genuinely lower frame rate, downsample your recordings with an external tool, then record or convert the result into a new LeRobot v3 dataset whose `meta.fps` matches the new rate.
 
 # Dataset Visualization
 

--- a/docs/source/using_dataset_tools.mdx
+++ b/docs/source/using_dataset_tools.mdx
@@ -192,6 +192,48 @@ lerobot-edit-dataset \
 
 There is also a tool for adding features to a dataset that is not yet covered in `lerobot-edit-dataset`.
 
+## Preparing a dataset for training
+
+When you run `lerobot-train` with only `--dataset.repo_id`, you are loading the dataset as stored on disk. Some changes can be applied **at training time** (in memory, not written back to the Hub or local copy). Others require **permanent** edits with `lerobot-edit-dataset`, re-recording, or external preprocessing.
+
+| Goal                 | Permanent (on disk)                                                                                                                | Training-time only (`lerobot-train`)                                                                                   |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| Drop episodes        | `lerobot-edit-dataset` with `--operation.type delete_episodes` and `--new_repo_id`                                                 | `--dataset.episodes="[0, 2, 5]"`                                                                                       |
+| Resize camera images | No dedicated `lerobot-edit-dataset` operation; re-record or preprocess frames, then publish a new dataset                          | `--dataset.image_transforms` with a `Resize` transform (see [Image transforms](./lerobot-dataset-v3#image-transforms)) |
+| Change dataset FPS   | Not supported by `lerobot-edit-dataset`; re-record or downsample externally, then create a new v3 dataset with matching `meta.fps` | N/A — training uses the dataset's stored `fps`                                                                         |
+
+### Drop episodes without rewriting the dataset
+
+To **filter episodes only for one training run** (original dataset unchanged):
+
+```bash
+lerobot-train \
+    --dataset.repo_id lerobot/pusht \
+    --dataset.episodes="[0, 2, 5]" \
+    ...
+```
+
+To **remove episodes permanently** and optionally upload a new revision, use [Delete Episodes](#delete-episodes) with `--new_repo_id`.
+
+### Resize images at training time
+
+`lerobot-edit-dataset` does not include a resize operation. To resize camera frames when loading data for training, enable dataset image transforms and add a `torchvision.transforms.v2.Resize` entry:
+
+```bash
+lerobot-train \
+    --dataset.repo_id lerobot/pusht \
+    --dataset.image_transforms.enable=true \
+    --dataset.image_transforms.max_num_transforms=1 \
+    --dataset.image_transforms.tfs='{"resize":{"type":"Resize","kwargs":{"size":[224,224]},"weight":1.0}}' \
+    ...
+```
+
+Many policies (for example PI0 and SmolVLA) also resize images inside their **policy preprocessor** to a fixed resolution. If you enable both dataset transforms and a policy that resizes, images may be resized twice—prefer configuring one place unless you intend both steps.
+
+### FPS downsampling
+
+LeRobot datasets store a single `fps` value in dataset metadata; frame timestamps and episode lengths assume that rate. There is no FPS downsampling operation in `lerobot-edit-dataset`. To train on fewer frames per second, downsample your recordings with an external tool, then record or convert the result into a new LeRobot v3 dataset whose `meta.fps` matches the new rate.
+
 # Dataset Visualization
 
 ## Online Visualization


### PR DESCRIPTION
Fixes #2124

## Summary

- Add **Preparing a dataset for training** to `using_dataset_tools.mdx`: permanent on-disk edits vs training-time-only options (`--dataset.episodes`, `--dataset.image_transforms` Resize, FPS limits).
- Add CLI cross-link under **Image transforms** in `lerobot-dataset-v3.mdx`.
- Clarify `--dataset.episodes` is an **inclusion list**, with safer Bash/JSON examples and conservative FPS / policy preprocessing wording.

## Test plan

- Checked `DatasetConfig.episodes` and `LeRobotDataset` usage to confirm `--dataset.episodes` is an inclusion list.
- Checked `ImageTransformsConfig` / `torchvision.transforms.v2` for the `Resize` example.
- Verified `lerobot-edit-dataset` has no FPS downsampling operation and `lerobot-train` has no lower-FPS sampling flag.
- Checked Markdown fences, relative links/anchors, and removed misleading wording.
- Docs-only change; no runtime behavior changed.

## Community review

I completed a community review on #3661:
https://github.com/huggingface/lerobot/pull/3661#issuecomment-4551456402

## AI disclosure

I used AI tools (Cursor/ChatGPT) to help draft and refine this documentation. I reviewed the technical claims against the LeRobot codebase and applied follow-up edits from review feedback.