### PR TITLE
feat(rlt): add PI0.5 LIBERO workflow

### DIFF
--- a/examples/rlt/README.md
+++ b/examples/rlt/README.md
@@ -1,0 +1,22 @@
+# PI0.5 + RLT LIBERO Examples
+
+This directory contains utilities for training and evaluating RLT on top of a
+frozen PI0.5 policy in LIBERO.
+
+## Workflow
+
+1. Collect or prepare a LeRobotDataset with PI0.5 rollouts.
+2. Precompute PI0.5 prefix embeddings and reference actions.
+3. Train the RLT token encoder and decoder from the precomputed cache.
+4. Run online RLT actor-critic training in LIBERO.
+5. Evaluate PI0.5 alone or PI0.5 with an RLT checkpoint.
+
+## Scripts
+
+- `collect_pi05_sim_dataset.py`: collect LIBERO simulation rollouts from a PI0.5 policy into a LeRobotDataset.
+- `precompute_pi05_rlt_cache.py`: precompute PI0.5 prefix embeddings for RLT training.
+- `train_rlt_token_from_cache.py`: train the RLT token encoder and decoder from cached PI0.5 embeddings.
+- `train_rlt_online_libero.py`: run single-process online RLT actor-critic training in LIBERO.
+- `evaluate_pi05_rlt_libero_success.py`: evaluate success rate for PI0.5 alone or PI0.5 with RLT.
+
+Run each script with `--help` for available arguments.

--- a/examples/rlt/collect_pi05_sim_dataset.py
+++ b/examples/rlt/collect_pi05_sim_dataset.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Collect simulation rollouts from a PI0.5 policy and save a LeRobotDataset.
+
+This script records raw observations/actions/tasks. RLT VLA embeddings should be
+computed later as a sidecar cache from the saved dataset, because they are large
+and tied to the exact frozen VLA checkpoint.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+from tqdm import trange
+
+from lerobot.configs.policies import PreTrainedConfig
+from lerobot.datasets.lerobot_dataset import LeRobotDataset
+from lerobot.envs.factory import make_env, make_env_config, make_env_pre_post_processors
+from lerobot.envs.utils import add_envs_task, close_envs, preprocess_observation
+from lerobot.policies.factory import make_policy, make_pre_post_processors
+from lerobot.utils.constants import ACTION, DONE, REWARD, TRUNCATED
+from lerobot.utils.random_utils import set_seed
+
+
+def _feature_from_tensor(key: str, value: torch.Tensor, *, use_videos: bool) -> dict[str, Any]:
+    value = value.detach().cpu()
+    if value.ndim > 0 and value.shape[0] == 1:
+        value = value.squeeze(0)
+
+    if key.startswith("observation.image"):
+        return {
+            "dtype": "video" if use_videos else "image",
+            "shape": tuple(value.shape),
+            "names": ["channels", "height", "width"],
+        }
+
+    return {
+        "dtype": "float32",
+        "shape": tuple(value.shape),
+        "names": [f"{key}.{i}" for i in range(int(np.prod(value.shape)))],
+    }
+
+
+def _make_dataset_features(
+    observation: dict[str, Any], action: torch.Tensor, *, use_videos: bool
+) -> dict[str, dict[str, Any]]:
+    features = {}
+    for key, value in observation.items():
+        if key == "task" or not isinstance(value, torch.Tensor):
+            continue
+        features[key] = _feature_from_tensor(key, value, use_videos=use_videos)
+
+    features[ACTION] = _feature_from_tensor(ACTION, action, use_videos=use_videos)
+    features[REWARD] = {"dtype": "float32", "shape": (1,), "names": ["reward"]}
+    features[DONE] = {"dtype": "bool", "shape": (1,), "names": ["done"]}
+    features[TRUNCATED] = {"dtype": "bool", "shape": (1,), "names": ["truncated"]}
+    return features
+
+
+def _squeeze_batch(value: torch.Tensor) -> torch.Tensor:
+    value = value.detach().cpu()
+    return value.squeeze(0) if value.ndim > 0 and value.shape[0] == 1 else value
+
+
+def _frame_from_observation(
+    observation: dict[str, Any],
+    action: torch.Tensor,
+    reward: np.ndarray,
+    terminated: np.ndarray,
+    truncated: np.ndarray,
+) -> dict[str, Any]:
+    task = observation.get("task", [""])
+    if isinstance(task, list):
+        task = task[0]
+
+    done = np.asarray(terminated, dtype=np.bool_) | np.asarray(truncated, dtype=np.bool_)
+    frame: dict[str, Any] = {
+        "task": task,
+        ACTION: _squeeze_batch(action),
+        REWARD: np.asarray([float(np.asarray(reward).reshape(-1)[0])], dtype=np.float32),
+        DONE: np.asarray([bool(done.reshape(-1)[0])], dtype=np.bool_),
+        TRUNCATED: np.asarray([bool(np.asarray(truncated).reshape(-1)[0])], dtype=np.bool_),
+    }
+    for key, value in observation.items():
+        if key == "task" or not isinstance(value, torch.Tensor):
+            continue
+        frame[key] = _squeeze_batch(value)
+    return frame
+
+
+def _first_env(envs):
+    suite_name = next(iter(envs))
+    task_id = next(iter(envs[suite_name]))
+    return envs[suite_name][task_id]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--policy-path", required=True, help="PI0.5 policy checkpoint or Hub repo.")
+    parser.add_argument("--repo-id", required=True, help="Repo id recorded in the local LeRobotDataset.")
+    parser.add_argument("--root", required=True, help="Local output directory for the dataset.")
+    parser.add_argument("--env-type", default="libero", choices=["libero", "pusht", "aloha"])
+    parser.add_argument("--env-task", default="libero_10")
+    parser.add_argument("--episodes", type=int, default=10)
+    parser.add_argument("--max-steps", type=int, default=None)
+    parser.add_argument("--seed", type=int, default=1000)
+    parser.add_argument("--device", default="cuda")
+    parser.add_argument("--use-videos", action="store_true")
+    parser.add_argument("--overwrite", action="store_true")
+    args = parser.parse_args()
+
+    set_seed(args.seed)
+
+    root = Path(args.root)
+    if root.exists():
+        if not args.overwrite:
+            raise FileExistsError(f"{root} already exists. Pass --overwrite to replace it.")
+        shutil.rmtree(root)
+
+    env_cfg = make_env_config(args.env_type, task=args.env_task)
+    envs = make_env(env_cfg, n_envs=1, use_async_envs=False)
+    env = _first_env(envs)
+
+    policy_cfg = PreTrainedConfig.from_pretrained(args.policy_path)
+    policy_cfg.pretrained_path = Path(args.policy_path)
+    policy_cfg.device = args.device
+
+    policy = make_policy(policy_cfg, env_cfg=env_cfg)
+    policy.eval()
+
+    env_preprocessor, env_postprocessor = make_env_pre_post_processors(env_cfg, policy_cfg)
+    preprocessor, postprocessor = make_pre_post_processors(
+        policy_cfg=policy_cfg,
+        pretrained_path=policy_cfg.pretrained_path,
+    )
+
+    dataset = None
+    try:
+        for ep_idx in range(args.episodes):
+            policy.reset()
+            raw_observation, _ = env.reset(seed=[args.seed + ep_idx])
+            max_steps = args.max_steps or env.call("_max_episode_steps")[0]
+
+            for _step in trange(max_steps, desc=f"episode {ep_idx}", leave=False):
+                observation = preprocess_observation(raw_observation)
+                observation = add_envs_task(env, observation)
+                observation = env_preprocessor(observation)
+
+                policy_input = preprocessor(observation)
+                with torch.inference_mode():
+                    policy_action = policy.select_action(policy_input)
+                policy_action = postprocessor(policy_action)
+
+                env_action = env_postprocessor({ACTION: policy_action})[ACTION]
+                next_raw_observation, reward, terminated, truncated, _info = env.step(
+                    env_action.detach().cpu().numpy()
+                )
+
+                if dataset is None:
+                    features = _make_dataset_features(
+                        observation, policy_action, use_videos=args.use_videos
+                    )
+                    dataset = LeRobotDataset.create(
+                        repo_id=args.repo_id,
+                        fps=env_cfg.fps,
+                        features=features,
+                        root=root,
+                        robot_type=args.env_type,
+                        use_videos=args.use_videos,
+                    )
+
+                dataset.add_frame(
+                    _frame_from_observation(observation, policy_action, reward, terminated, truncated)
+                )
+
+                raw_observation = next_raw_observation
+                if bool((terminated | truncated)[0]):
+                    break
+
+            if dataset is not None:
+                dataset.save_episode()
+
+        if dataset is not None:
+            dataset.finalize()
+            print(f"Saved {dataset.meta.total_episodes} episodes to {dataset.root}")
+    finally:
+        close_envs(envs)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/rlt/evaluate_pi05_rlt_libero_success.py
+++ b/examples/rlt/evaluate_pi05_rlt_libero_success.py
@@ -1,0 +1,929 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Evaluate LIBERO success rate for PI0.5 alone or PI0.5 + RLT.
+
+The script runs vectorized LIBERO rollouts and records per-episode success.
+Failed episodes are recorded as videos by default.
+
+Modes:
+  - vla: execute PI0.5 reference action chunks directly.
+  - rlt: execute action chunks refined by an RLT policy checkpoint.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+import torch
+from tqdm import tqdm, trange
+
+from lerobot.configs.policies import PreTrainedConfig
+from lerobot.envs.factory import make_env, make_env_config, make_env_pre_post_processors
+from lerobot.envs.utils import add_envs_task, close_envs, preprocess_observation
+from lerobot.policies.factory import make_policy, make_pre_post_processors
+from lerobot.policies.pi05.modeling_pi05 import PI05Policy
+from lerobot.policies.rlt.modeling_rlt import RLTPolicy
+from lerobot.policies.rlt.vla_adapter import (
+    OBS_REFERENCE_ACTION,
+    OBS_RLT_STATE,
+    OBS_VLA_EMBEDDINGS,
+    PI05PrefixRLTAdapter,
+)
+from lerobot.utils.constants import ACTION
+from lerobot.utils.io_utils import write_video
+from lerobot.utils.random_utils import set_seed
+
+
+def _parse_task_ids(value: str | None) -> list[int]:
+    if value is None or not value.strip():
+        return [0]
+    return [int(x.strip()) for x in value.split(",") if x.strip()]
+
+
+def _as_array(value: Any, *, dtype, size: int) -> np.ndarray:
+    array = np.asarray(value, dtype=dtype).reshape(-1)
+    if array.size == 1 and size != 1:
+        array = np.repeat(array, size)
+    if array.size != size:
+        raise ValueError(f"Expected {size} values, got shape {np.asarray(value).shape}.")
+    return array
+
+
+def _info_array(info: Any, keys: tuple[str, ...], size: int) -> np.ndarray | None:
+    if not isinstance(info, dict):
+        return None
+
+    for key in keys:
+        if key in info:
+            return _as_array(info[key], dtype=np.float32, size=size)
+
+    final_info = info.get("final_info")
+    if isinstance(final_info, dict):
+        for key in keys:
+            if key in final_info:
+                return _as_array(final_info[key], dtype=np.float32, size=size)
+
+    if isinstance(final_info, (list, tuple, np.ndarray)):
+        values = np.zeros(size, dtype=np.float32)
+        found = False
+        for idx, item in enumerate(final_info):
+            if idx >= size or not isinstance(item, dict):
+                continue
+            for key in keys:
+                if key in item:
+                    values[idx] = float(item[key])
+                    found = True
+                    break
+        if found:
+            return values
+
+    return None
+
+
+def _maybe_latest_checkpoint(path: Path) -> Path:
+    if path.is_dir() and (path / "config.json").exists():
+        return path
+    checkpoints = sorted(
+        p
+        for p in path.glob("checkpoint-*")
+        if p.is_dir() and not p.name.endswith(".tmp") and (p / "config.json").exists()
+    )
+    if not checkpoints:
+        raise FileNotFoundError(f"No valid checkpoint-* directories with config.json found under {path}")
+    return checkpoints[-1]
+
+
+def _metadata_path(path: Path) -> Path | None:
+    candidates = []
+    if path.is_dir():
+        candidates.extend([path / "online_training.json", path.parent / "online_training.json"])
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _load_online_metadata(path: str | None) -> dict[str, Any]:
+    if path is None:
+        return {}
+    metadata_path = _metadata_path(Path(path))
+    if metadata_path is None:
+        return {}
+    return json.loads(metadata_path.read_text(encoding="utf-8"))
+
+
+def _torch_dtype(name: str | None) -> torch.dtype | None:
+    if name is None:
+        return None
+    if name == "float32":
+        return torch.float32
+    if name == "float16":
+        return torch.float16
+    if name == "bfloat16":
+        return torch.bfloat16
+    raise ValueError(f"Unsupported dtype: {name}")
+
+
+def _env_tasks(env, n_envs: int) -> list[str]:
+    for attr in ("task_description", "task"):
+        try:
+            task_result = env.call(attr)
+        except Exception:
+            continue
+        if isinstance(task_result, tuple):
+            task_result = list(task_result)
+        elif isinstance(task_result, np.ndarray):
+            task_result = task_result.tolist()
+        elif isinstance(task_result, str):
+            task_result = [task_result] * n_envs
+        if not isinstance(task_result, list):
+            continue
+        if len(task_result) == 1 and n_envs != 1:
+            task_result = task_result * n_envs
+        if len(task_result) != n_envs:
+            raise ValueError(f"Expected {n_envs} task strings from env.{attr}, got {len(task_result)}.")
+        return [str(item) for item in task_result]
+    return ["" for _ in range(n_envs)]
+
+
+def _make_pi05_policy(
+    *,
+    policy_path: str,
+    env_cfg,
+    device: str,
+    dtype: str | None,
+    num_inference_steps: int | None,
+    tokenizer_path: str | None,
+    disable_compile: bool,
+) -> tuple[PI05Policy, Any, Any, Any]:
+    policy_cfg = PreTrainedConfig.from_pretrained(policy_path)
+    policy_cfg.pretrained_path = Path(policy_path)
+    policy_cfg.device = device
+    if dtype is not None and hasattr(policy_cfg, "dtype"):
+        policy_cfg.dtype = dtype
+    if num_inference_steps is not None and hasattr(policy_cfg, "num_inference_steps"):
+        policy_cfg.num_inference_steps = num_inference_steps
+    if tokenizer_path is not None and hasattr(policy_cfg, "tokenizer_name"):
+        policy_cfg.tokenizer_name = tokenizer_path
+    if disable_compile and hasattr(policy_cfg, "compile_model"):
+        policy_cfg.compile_model = False
+
+    policy = make_policy(policy_cfg, env_cfg=env_cfg)
+    if not isinstance(policy, PI05Policy):
+        raise TypeError(f"Expected PI05Policy, got {type(policy).__name__}.")
+    policy.eval()
+    for param in policy.parameters():
+        param.requires_grad_(False)
+
+    preprocessor, postprocessor = make_pre_post_processors(
+        policy_cfg=policy_cfg,
+        pretrained_path=policy_cfg.pretrained_path,
+    )
+    return policy, policy_cfg, preprocessor, postprocessor
+
+
+def _load_rlt_policy(path: str, device: str, dtype: str | None) -> tuple[RLTPolicy, Path]:
+    rlt_path = _maybe_latest_checkpoint(Path(path))
+    rlt_cfg = PreTrainedConfig.from_pretrained(rlt_path, local_files_only=True)
+    rlt_cfg.device = device
+    policy = RLTPolicy.from_pretrained(rlt_path, config=rlt_cfg, local_files_only=True, strict=True)
+    torch_dtype = _torch_dtype(dtype)
+    if torch_dtype is None:
+        policy.to(device)
+    else:
+        policy.to(device=device, dtype=torch_dtype)
+    policy.eval()
+    return policy, rlt_path
+
+
+def _prepare_pi05_input(
+    raw_observation,
+    env,
+    env_preprocessor,
+    pi05_preprocessor,
+    task_descriptions: list[str] | None,
+) -> dict[str, torch.Tensor]:
+    observation = preprocess_observation(raw_observation)
+    if task_descriptions is None:
+        observation = add_envs_task(env, observation)
+    else:
+        observation["task"] = task_descriptions
+    observation = env_preprocessor(observation)
+    return pi05_preprocessor(observation)
+
+
+@torch.no_grad()
+def _rlt_features(
+    *,
+    raw_observation,
+    env,
+    env_preprocessor,
+    pi05_preprocessor,
+    adapter: PI05PrefixRLTAdapter,
+    rlt_device: str,
+    include_proprio: bool,
+    task_descriptions: list[str] | None,
+) -> dict[str, torch.Tensor]:
+    pi05_input = _prepare_pi05_input(
+        raw_observation,
+        env,
+        env_preprocessor,
+        pi05_preprocessor,
+        task_descriptions,
+    )
+    batch = adapter(pi05_input)
+    out = {
+        OBS_VLA_EMBEDDINGS: batch[OBS_VLA_EMBEDDINGS].detach().to(rlt_device),
+        OBS_REFERENCE_ACTION: batch[OBS_REFERENCE_ACTION].detach().to(rlt_device),
+    }
+    if include_proprio and "observation.state" in pi05_input:
+        out["observation.state"] = pi05_input["observation.state"].detach().to(rlt_device)
+    return out
+
+
+@torch.no_grad()
+def _vla_action_chunk(
+    *,
+    raw_observation,
+    env,
+    env_preprocessor,
+    pi05_preprocessor,
+    pi05_policy: PI05Policy,
+    task_descriptions: list[str] | None,
+) -> torch.Tensor:
+    pi05_input = _prepare_pi05_input(
+        raw_observation,
+        env,
+        env_preprocessor,
+        pi05_preprocessor,
+        task_descriptions,
+    )
+    return pi05_policy.predict_action_chunk(pi05_input).detach()
+
+
+@torch.no_grad()
+def _attach_rlt_state(features: dict[str, torch.Tensor], rlt_policy: RLTPolicy) -> dict[str, torch.Tensor]:
+    encoder_param = next(rlt_policy.rl_token_encoder.parameters())
+    vla_embeddings = features[OBS_VLA_EMBEDDINGS].to(
+        device=encoder_param.device,
+        dtype=encoder_param.dtype,
+    )
+    features[OBS_RLT_STATE] = rlt_policy.rl_token_encoder(vla_embeddings).detach()
+    return features
+
+
+def _to_policy_tensor(
+    tensor: torch.Tensor,
+    *,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    if tensor.is_floating_point():
+        return tensor.to(device=device, dtype=dtype)
+    return tensor.to(device=device)
+
+
+def _policy_batch_from_features(
+    features: dict[str, torch.Tensor],
+    include_proprio: bool,
+    *,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> dict[str, torch.Tensor]:
+    batch = {
+        OBS_REFERENCE_ACTION: _to_policy_tensor(features[OBS_REFERENCE_ACTION], device=device, dtype=dtype),
+    }
+    if OBS_RLT_STATE in features:
+        batch[OBS_RLT_STATE] = _to_policy_tensor(features[OBS_RLT_STATE], device=device, dtype=dtype)
+    else:
+        batch[OBS_VLA_EMBEDDINGS] = _to_policy_tensor(features[OBS_VLA_EMBEDDINGS], device=device, dtype=dtype)
+    if include_proprio and "observation.state" in features:
+        batch["observation.state"] = _to_policy_tensor(
+            features["observation.state"],
+            device=device,
+            dtype=dtype,
+        )
+    return batch
+
+
+def _postprocess_action_step(
+    action_step_norm: torch.Tensor,
+    *,
+    pi05_postprocessor,
+    env_postprocessor,
+    clip_normalized_action: bool,
+) -> torch.Tensor:
+    if clip_normalized_action:
+        action_step_norm = action_step_norm.clamp(-1.0, 1.0)
+    action_cpu = pi05_postprocessor(action_step_norm.detach().cpu())
+    return env_postprocessor({ACTION: action_cpu})[ACTION]
+
+
+def _reset_finished_envs(env, done_mask: np.ndarray, seed_base: int | None = None):
+    options = {"reset_mask": done_mask.astype(bool)}
+    seeds = None
+    if seed_base is not None:
+        seeds = [seed_base + env_idx for env_idx in range(done_mask.size)]
+    try:
+        return env.reset(seed=seeds, options=options)
+    except TypeError:
+        return env.reset(seed=seeds)
+
+
+def _env_action_dim(env) -> int | None:
+    space = getattr(env, "single_action_space", None)
+    if space is None:
+        space = getattr(env, "action_space", None)
+    shape = getattr(space, "shape", None)
+    if not shape:
+        return None
+    if len(shape) == 1:
+        return int(shape[0])
+    if len(shape) >= 2:
+        return int(shape[-1])
+    return None
+
+
+def _write_jsonl(path: Path, item: dict[str, Any]) -> None:
+    with path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(item) + "\n")
+
+
+def _video_image_batch(raw_observation: Any, video_key: str, n_envs: int) -> np.ndarray:
+    if not isinstance(raw_observation, dict):
+        raise TypeError(
+            f"Expected dict observation for video recording, got {type(raw_observation).__name__}."
+        )
+
+    pixels = raw_observation.get("pixels")
+    if isinstance(pixels, dict):
+        if video_key not in pixels:
+            raise KeyError(f"Video key '{video_key}' not found in observation pixels: {sorted(pixels)}.")
+        images = pixels[video_key]
+    else:
+        flat_keys = (
+            video_key,
+            f"pixels.{video_key}",
+            f"pixels/{video_key}",
+            f"observation.images.{video_key}",
+        )
+        for key in flat_keys:
+            if key in raw_observation:
+                images = raw_observation[key]
+                break
+        else:
+            raise KeyError(f"Video key '{video_key}' not found in observation.")
+
+    if isinstance(images, torch.Tensor):
+        images = images.detach().cpu().numpy()
+    array = np.asarray(images)
+    if array.ndim == 3:
+        array = array[None, ...]
+    if array.ndim != 4:
+        raise ValueError(f"Expected video frames with 3 or 4 dims, got shape {array.shape}.")
+    if array.shape[0] != n_envs:
+        raise ValueError(f"Expected {n_envs} video frames, got shape {array.shape}.")
+
+    if array.shape[-1] not in (1, 3, 4) and array.shape[1] in (1, 3, 4):
+        array = np.moveaxis(array, 1, -1)
+    if array.shape[-1] == 1:
+        array = np.repeat(array, 3, axis=-1)
+    elif array.shape[-1] == 4:
+        array = array[..., :3]
+    elif array.shape[-1] != 3:
+        raise ValueError(f"Expected video frames with 1, 3, or 4 channels, got shape {array.shape}.")
+
+    if array.dtype != np.uint8:
+        is_unit_float = (
+            np.issubdtype(array.dtype, np.floating)
+            and array.size
+            and array.min() >= 0.0
+            and array.max() <= 1.0
+        )
+        if is_unit_float:
+            array = array * 255.0
+        array = np.clip(array, 0, 255).astype(np.uint8)
+
+    # Match LiberoEnv.render(), which flips the raw simulator camera for visualization.
+    array = array[:, ::-1, ::-1, :]
+    return np.ascontiguousarray(array)
+
+
+def _append_video_frames(
+    episode_frames: list[list[np.ndarray]],
+    raw_observation: Any,
+    *,
+    video_key: str,
+    mask: np.ndarray | None = None,
+) -> None:
+    n_envs = len(episode_frames)
+    frames = _video_image_batch(raw_observation, video_key=video_key, n_envs=n_envs)
+    if mask is None:
+        indices = range(n_envs)
+    else:
+        indices = np.flatnonzero(mask.astype(bool))
+    for env_idx in indices:
+        episode_frames[int(env_idx)].append(frames[int(env_idx)].copy())
+
+
+def _write_episode_video(
+    *,
+    frames: list[np.ndarray],
+    video_dir: Path,
+    mode: str,
+    suite_name: str,
+    task_id: int,
+    episode: int,
+    env_idx: int,
+    success: bool,
+    fps: int,
+) -> Path | None:
+    if not frames:
+        return None
+    video_dir.mkdir(parents=True, exist_ok=True)
+    status = "success" if success else "failure"
+    video_path = video_dir / (
+        f"{mode}_{suite_name}_task{task_id:02d}_episode{episode:04d}_env{env_idx}_{status}.mp4"
+    )
+    write_video(str(video_path), np.stack(frames, axis=0), fps=fps)
+    return video_path
+
+
+def _advance_step_progress(
+    step_pbar: tqdm,
+    n_steps: int,
+    *,
+    total_env_steps: int,
+    completed: int,
+    episodes: int,
+    active_step: int,
+    max_steps: int,
+) -> None:
+    if step_pbar.total is None:
+        step_pbar.update(n_steps)
+    else:
+        remaining = int(step_pbar.total - step_pbar.n)
+        if remaining > 0:
+            step_pbar.update(min(n_steps, remaining))
+    step_pbar.set_postfix(
+        {
+            "completed": f"{completed}/{episodes}",
+            "active_step": f"{active_step}/{max_steps}",
+            "env_steps": total_env_steps,
+        }
+    )
+
+
+def _evaluate_one_task(
+    *,
+    args,
+    mode: str,
+    suite_name: str,
+    task_id: int,
+    pi05_cfg,
+    pi05_preprocessor,
+    pi05_postprocessor,
+    pi05_policy: PI05Policy,
+    rlt_policy: RLTPolicy | None,
+    chunk_size: int,
+    execute_steps: int,
+    action_dim: int,
+    metrics_path: Path,
+) -> dict[str, Any]:
+    env_cfg = make_env_config(args.env_type, task=suite_name, task_ids=[task_id])
+    env_preprocessor, env_postprocessor = make_env_pre_post_processors(env_cfg, pi05_cfg)
+    envs = make_env(env_cfg, n_envs=args.n_envs, use_async_envs=args.use_async_envs)
+    env = envs[suite_name][task_id]
+    n_envs = int(getattr(env, "num_envs", args.n_envs))
+    env_action_dim = _env_action_dim(env)
+    if env_action_dim is not None and int(env_action_dim) != int(action_dim):
+        raise ValueError(
+            f"Environment action_dim {env_action_dim} != policy action_dim {action_dim}. "
+            "Use a PI0.5/RLT checkpoint whose action dimension matches this arm-gripper environment."
+        )
+    task_descriptions = _env_tasks(env, n_envs)
+    task_description = task_descriptions[0] if task_descriptions else ""
+
+    include_proprio = bool(rlt_policy is not None and rlt_policy._proprioception_dim > 0)
+    adapter = PI05PrefixRLTAdapter(pi05_policy, rlt_chunk_size=chunk_size) if mode == "rlt" else None
+    max_steps = args.max_steps_per_episode or env.call("_max_episode_steps")[0]
+
+    completed = 0
+    success_count = 0
+    total_env_steps = 0
+    completed_rewards: list[float] = []
+    completed_steps: list[int] = []
+
+    episode_reward = np.zeros(n_envs, dtype=np.float32)
+    episode_steps = np.zeros(n_envs, dtype=np.int64)
+    episode_success = np.zeros(n_envs, dtype=bool)
+    record_episode_videos = args.record_all_videos or not args.no_record_failure_videos
+    record_failure_videos = not args.no_record_failure_videos
+    video_dir = Path(args.video_dir) if args.video_dir else Path(args.output_dir) / "videos"
+    failure_video_dir = (
+        Path(args.failure_video_dir) if args.failure_video_dir else Path(args.output_dir) / "failure_videos"
+    )
+    video_paths: list[str] = []
+    failure_video_paths: list[str] = []
+    episode_frames: list[list[np.ndarray]] = [[] for _ in range(n_envs)]
+
+    seeds = [args.seed + task_id * 100000 + env_idx for env_idx in range(n_envs)]
+    raw_obs, _ = env.reset(seed=seeds)
+    if record_episode_videos:
+        _append_video_frames(episode_frames, raw_obs, video_key=args.failure_video_key)
+
+    pbar = trange(args.episodes, desc=f"{suite_name}:{task_id}", leave=False)
+    step_pbar = tqdm(
+        total=args.episodes * max_steps,
+        desc=f"{suite_name}:{task_id} steps",
+        leave=False,
+        unit="step",
+    )
+    try:
+        while completed < args.episodes:
+            with torch.inference_mode():
+                if mode == "vla":
+                    action_chunk = _vla_action_chunk(
+                        raw_observation=raw_obs,
+                        env=env,
+                        env_preprocessor=env_preprocessor,
+                        pi05_preprocessor=pi05_preprocessor,
+                        pi05_policy=pi05_policy,
+                        task_descriptions=task_descriptions,
+                    )
+                    if action_chunk.shape[1] < chunk_size:
+                        raise ValueError(
+                            f"PI0.5 action chunk has length {action_chunk.shape[1]}, "
+                            f"but evaluation requested {chunk_size}."
+                        )
+                    action_chunk = action_chunk[:, :chunk_size, :action_dim]
+                else:
+                    if rlt_policy is None or adapter is None:
+                        raise RuntimeError("RLT mode requires rlt_policy.")
+                    features = _rlt_features(
+                        raw_observation=raw_obs,
+                        env=env,
+                        env_preprocessor=env_preprocessor,
+                        pi05_preprocessor=pi05_preprocessor,
+                        adapter=adapter,
+                        rlt_device=args.rlt_device,
+                        include_proprio=include_proprio,
+                        task_descriptions=task_descriptions,
+                    )
+                    features = _attach_rlt_state(features, rlt_policy)
+                    actor_param = next(rlt_policy.actor.parameters())
+                    action_chunk = rlt_policy.select_action(
+                        _policy_batch_from_features(
+                            features,
+                            include_proprio=include_proprio,
+                            device=actor_param.device,
+                            dtype=actor_param.dtype,
+                        )
+                    )
+                    action_chunk = action_chunk.reshape(n_envs, chunk_size, action_dim)
+
+            if not args.no_clip_normalized_action:
+                action_chunk = action_chunk.clamp(-1.0, 1.0)
+
+            chunk_reward = np.zeros(n_envs, dtype=np.float32)
+            terminated = np.zeros(n_envs, dtype=bool)
+            truncated = np.zeros(n_envs, dtype=bool)
+
+            for chunk_step in range(execute_steps):
+                action_step = action_chunk[:, chunk_step, :]
+                env_action = _postprocess_action_step(
+                    action_step,
+                    pi05_postprocessor=pi05_postprocessor,
+                    env_postprocessor=env_postprocessor,
+                    clip_normalized_action=not args.no_clip_normalized_action,
+                )
+                raw_obs, reward, term, trunc, info = env.step(env_action.detach().cpu().numpy())
+                if record_episode_videos:
+                    _append_video_frames(episode_frames, raw_obs, video_key=args.failure_video_key)
+
+                reward_array = _as_array(reward, dtype=np.float32, size=n_envs)
+                term_array = _as_array(term, dtype=bool, size=n_envs)
+                trunc_array = _as_array(trunc, dtype=bool, size=n_envs)
+                episode_steps += 1
+                timeout_array = episode_steps >= max_steps
+                trunc_array |= timeout_array
+
+                success_value = _info_array(info, ("success", "is_success", "task_success"), n_envs)
+                if success_value is not None:
+                    episode_success |= success_value.astype(bool)
+
+                chunk_reward += reward_array
+                episode_reward += reward_array
+                total_env_steps += n_envs
+                _advance_step_progress(
+                    step_pbar,
+                    min(n_envs, max(0, args.episodes - completed)),
+                    total_env_steps=total_env_steps,
+                    completed=completed,
+                    episodes=args.episodes,
+                    active_step=int(episode_steps.max()),
+                    max_steps=max_steps,
+                )
+                terminated |= term_array
+                truncated |= trunc_array
+
+                if np.any(term_array | trunc_array) or completed >= args.episodes:
+                    break
+
+            done_mask = terminated | truncated
+            if np.any(done_mask):
+                for env_idx in np.flatnonzero(done_mask):
+                    if completed >= args.episodes:
+                        break
+                    env_idx = int(env_idx)
+                    success = bool(episode_success[env_idx])
+                    success_count += int(success)
+                    completed += 1
+                    completed_rewards.append(float(episode_reward[env_idx]))
+                    completed_steps.append(int(episode_steps[env_idx]))
+                    episode_video_path = None
+                    failure_video_path = None
+                    if record_episode_videos and (args.record_all_videos or (record_failure_videos and not success)):
+                        episode_video_path = _write_episode_video(
+                            frames=episode_frames[env_idx],
+                            video_dir=video_dir if args.record_all_videos else failure_video_dir,
+                            mode=mode,
+                            suite_name=suite_name,
+                            task_id=task_id,
+                            episode=completed,
+                            env_idx=env_idx,
+                            success=success,
+                            fps=args.failure_video_fps,
+                        )
+                        if episode_video_path is not None:
+                            video_paths.append(str(episode_video_path))
+                        if not success and episode_video_path is not None:
+                            failure_video_path = episode_video_path
+                            failure_video_paths.append(str(failure_video_path))
+                    item = {
+                        "type": "episode",
+                        "mode": mode,
+                        "suite": suite_name,
+                        "task_id": task_id,
+                        "task": task_description,
+                        "episode": completed,
+                        "env_index": int(env_idx),
+                        "success": success,
+                        "reward": float(episode_reward[env_idx]),
+                        "steps": int(episode_steps[env_idx]),
+                        "terminated": bool(terminated[env_idx]),
+                        "truncated": bool(truncated[env_idx]),
+                        "env_step": int(total_env_steps),
+                        "running_success_rate": float(success_count / completed),
+                    }
+                    if episode_video_path is not None:
+                        item["video_path"] = str(episode_video_path)
+                    if failure_video_path is not None:
+                        item["failure_video_path"] = str(failure_video_path)
+                    print(json.dumps(item), flush=True)
+                    _write_jsonl(metrics_path, item)
+                    pbar.update(1)
+                    step_pbar.set_postfix(
+                        {
+                            "completed": f"{completed}/{args.episodes}",
+                            "active_step": f"{int(episode_steps.max())}/{max_steps}",
+                            "env_steps": total_env_steps,
+                        }
+                    )
+
+                if completed >= args.episodes:
+                    break
+
+                episode_reward[done_mask] = 0.0
+                episode_steps[done_mask] = 0
+                episode_success[done_mask] = False
+                if record_episode_videos:
+                    for env_idx in np.flatnonzero(done_mask):
+                        episode_frames[int(env_idx)] = []
+                raw_obs, _ = _reset_finished_envs(
+                    env,
+                    done_mask,
+                    seed_base=args.seed + task_id * 100000 + completed * n_envs,
+                )
+                if record_episode_videos:
+                    _append_video_frames(
+                        episode_frames,
+                        raw_obs,
+                        video_key=args.failure_video_key,
+                        mask=done_mask,
+                    )
+
+        summary = {
+            "type": "task_summary",
+            "mode": mode,
+            "suite": suite_name,
+            "task_id": task_id,
+            "task": task_description,
+            "episodes": completed,
+            "success_count": success_count,
+            "success_rate": float(success_count / max(1, completed)),
+            "mean_reward": float(np.mean(completed_rewards)) if completed_rewards else 0.0,
+            "mean_steps": float(np.mean(completed_steps)) if completed_steps else 0.0,
+            "total_env_steps": int(total_env_steps),
+            "record_all_videos": bool(args.record_all_videos),
+            "video_count": len(video_paths),
+            "video_paths": video_paths,
+            "failure_video_count": len(failure_video_paths),
+            "failure_video_paths": failure_video_paths,
+        }
+        print(json.dumps(summary), flush=True)
+        _write_jsonl(metrics_path, summary)
+        return summary
+    finally:
+        step_pbar.close()
+        pbar.close()
+        close_envs(envs)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", choices=["rlt", "vla"], required=True)
+    parser.add_argument("--pi05-policy-path", default="lerobot/pi05_libero_finetuned")
+    parser.add_argument("--rlt-policy-path", default=None, help="Required for --mode rlt.")
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--env-type", default="libero")
+    parser.add_argument("--env-task", default=None, help="Defaults to checkpoint metadata or libero_10.")
+    parser.add_argument(
+        "--env-task-ids",
+        default=None,
+        help="Comma-separated LIBERO task ids. Defaults to checkpoint metadata for RLT, otherwise 0.",
+    )
+    parser.add_argument("--n-envs", type=int, default=1)
+    parser.add_argument("--use-async-envs", action="store_true")
+    parser.add_argument("--episodes", type=int, default=10, help="Episodes to evaluate per task id.")
+    parser.add_argument("--max-steps-per-episode", type=int, default=None)
+    parser.add_argument("--chunk-size", type=int, default=None, help="Defaults to RLT chunk_size or 10 for VLA.")
+    parser.add_argument("--execute-steps-per-chunk", type=int, default=None)
+    parser.add_argument("--pi05-device", default="cuda")
+    parser.add_argument("--rlt-device", default="cuda")
+    parser.add_argument("--pi05-dtype", default="bfloat16", choices=["bfloat16", "float16", "float32"])
+    parser.add_argument(
+        "--rlt-dtype",
+        default=None,
+        choices=["bfloat16", "float16", "float32"],
+        help="Optional dtype for the RLT policy. Defaults to the checkpoint dtype.",
+    )
+    parser.add_argument("--num-inference-steps", type=int, default=10)
+    parser.add_argument("--tokenizer-path", default=None)
+    parser.add_argument(
+        "--disable-pi05-compile",
+        action="store_true",
+        help="Disable torch.compile for PI0.5 inference to avoid Inductor/Triton autotune startup.",
+    )
+    parser.add_argument("--seed", type=int, default=1000)
+    parser.add_argument("--metrics-file", default=None)
+    parser.add_argument(
+        "--failure-video-dir",
+        default=None,
+        help="Directory for failed-episode videos. Defaults to <output-dir>/failure_videos.",
+    )
+    parser.add_argument(
+        "--record-all-videos",
+        action="store_true",
+        help="Record every completed episode, including successes. Videos default to <output-dir>/videos.",
+    )
+    parser.add_argument(
+        "--video-dir",
+        default=None,
+        help="Directory for --record-all-videos. Defaults to <output-dir>/videos.",
+    )
+    parser.add_argument("--failure-video-key", default="image", help="Observation pixels key to record.")
+    parser.add_argument("--failure-video-fps", type=int, default=20)
+    parser.add_argument(
+        "--no-record-failure-videos",
+        action="store_true",
+        help="Disable the default failed-episode video recording.",
+    )
+    parser.add_argument("--no-clip-normalized-action", action="store_true")
+    parser.add_argument("--overwrite", action="store_true")
+    args = parser.parse_args()
+
+    if args.env_type != "libero":
+        raise ValueError("This evaluator currently supports --env-type libero only.")
+    if args.mode == "rlt" and args.rlt_policy_path is None:
+        raise ValueError("--rlt-policy-path is required when --mode rlt.")
+    if args.failure_video_fps <= 0:
+        raise ValueError("--failure-video-fps must be positive.")
+
+    set_seed(args.seed)
+
+    metadata = _load_online_metadata(args.rlt_policy_path) if args.mode == "rlt" else {}
+    env_task = args.env_task or metadata.get("env_task") or "libero_10"
+    task_ids = (
+        _parse_task_ids(args.env_task_ids)
+        if args.env_task_ids is not None
+        else [int(x) for x in metadata.get("env_task_ids", [0])]
+    )
+
+    output_dir = Path(args.output_dir)
+    if output_dir.exists():
+        if not args.overwrite:
+            raise FileExistsError(f"{output_dir} already exists. Pass --overwrite to replace it.")
+        shutil.rmtree(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    metrics_path = Path(args.metrics_file) if args.metrics_file else output_dir / "success_metrics.jsonl"
+
+    policy_env_cfg = make_env_config(args.env_type, task=env_task, task_ids=[task_ids[0]])
+    pi05_policy, pi05_cfg, pi05_preprocessor, pi05_postprocessor = _make_pi05_policy(
+        policy_path=args.pi05_policy_path,
+        env_cfg=policy_env_cfg,
+        device=args.pi05_device,
+        dtype=args.pi05_dtype,
+        num_inference_steps=args.num_inference_steps,
+        tokenizer_path=args.tokenizer_path,
+        disable_compile=args.disable_pi05_compile,
+    )
+
+    rlt_policy = None
+    rlt_path = None
+    if args.mode == "rlt":
+        rlt_policy, rlt_path = _load_rlt_policy(args.rlt_policy_path, args.rlt_device, args.rlt_dtype)
+        chunk_size = args.chunk_size or int(rlt_policy.config.chunk_size)
+        action_dim = int(rlt_policy._action_dim)
+    else:
+        chunk_size = args.chunk_size or 10
+        action_dim = int(pi05_cfg.output_features[ACTION].shape[0])
+
+    execute_steps = args.execute_steps_per_chunk or chunk_size
+    execute_steps = min(execute_steps, chunk_size)
+
+    task_summaries = []
+    for task_id in task_ids:
+        summary = _evaluate_one_task(
+            args=args,
+            mode=args.mode,
+            suite_name=env_task,
+            task_id=task_id,
+            pi05_cfg=pi05_cfg,
+            pi05_preprocessor=pi05_preprocessor,
+            pi05_postprocessor=pi05_postprocessor,
+            pi05_policy=pi05_policy,
+            rlt_policy=rlt_policy,
+            chunk_size=chunk_size,
+            execute_steps=execute_steps,
+            action_dim=action_dim,
+            metrics_path=metrics_path,
+        )
+        task_summaries.append(summary)
+
+    total_episodes = sum(item["episodes"] for item in task_summaries)
+    total_successes = sum(item["success_count"] for item in task_summaries)
+    summary = {
+        "format": "lerobot_pi05_rlt_libero_success_eval_v1",
+        "mode": args.mode,
+        "pi05_policy_path": args.pi05_policy_path,
+        "pi05_dtype": args.pi05_dtype,
+        "rlt_policy_path": None if rlt_path is None else str(rlt_path),
+        "rlt_dtype": args.rlt_dtype,
+        "env_task": env_task,
+        "env_task_ids": task_ids,
+        "n_envs": args.n_envs,
+        "episodes_per_task": args.episodes,
+        "chunk_size": chunk_size,
+        "execute_steps_per_chunk": execute_steps,
+        "record_all_videos": bool(args.record_all_videos),
+        "video_dir": None
+        if not args.record_all_videos
+        else str(Path(args.video_dir) if args.video_dir else output_dir / "videos"),
+        "record_failure_videos": not args.no_record_failure_videos,
+        "failure_video_dir": None
+        if args.no_record_failure_videos
+        else str(Path(args.failure_video_dir) if args.failure_video_dir else output_dir / "failure_videos"),
+        "failure_video_key": args.failure_video_key,
+        "failure_video_fps": args.failure_video_fps,
+        "total_episodes": total_episodes,
+        "total_successes": total_successes,
+        "overall_success_rate": float(total_successes / max(1, total_episodes)),
+        "tasks": task_summaries,
+    }
+    (output_dir / "summary.json").write_text(json.dumps(summary, indent=2), encoding="utf-8")
+    print(json.dumps({"type": "overall_summary", **summary}), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/rlt/precompute_pi05_rlt_cache.py
+++ b/examples/rlt/precompute_pi05_rlt_cache.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Precompute PI0.5-derived RLT cache from an existing LeRobotDataset."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+from pathlib import Path
+from typing import Any
+
+import torch
+from safetensors.torch import save_file
+from tqdm import trange
+
+from lerobot.configs.policies import PreTrainedConfig
+from lerobot.datasets.lerobot_dataset import LeRobotDataset
+from lerobot.policies.factory import make_policy, make_pre_post_processors
+from lerobot.policies.pi05.modeling_pi05 import PI05Policy
+from lerobot.policies.rlt.vla_adapter import OBS_VLA_EMBEDDINGS, PI05PrefixRLTAdapter
+from lerobot.utils.constants import (
+    ACTION,
+    DONE,
+    OBS_LANGUAGE_ATTENTION_MASK,
+    OBS_LANGUAGE_TOKENS,
+    REWARD,
+    TRUNCATED,
+)
+
+
+def _save_dtype(name: str) -> torch.dtype:
+    if name == "float32":
+        return torch.float32
+    if name == "float16":
+        return torch.float16
+    if name == "bfloat16":
+        return torch.bfloat16
+    raise ValueError(f"Unsupported save dtype: {name}")
+
+
+def _collate_samples(samples: list[dict[str, Any]]) -> dict[str, Any]:
+    batch: dict[str, Any] = {}
+    keys = samples[0].keys()
+    for key in keys:
+        values = [sample[key] for sample in samples]
+        first = values[0]
+        if isinstance(first, torch.Tensor):
+            batch[key] = torch.stack(values, dim=0)
+        elif key == "task":
+            batch[key] = values
+        elif isinstance(first, (int, float, bool)):
+            batch[key] = torch.tensor(values)
+    return batch
+
+
+def _policy_input_batch(batch: dict[str, Any]) -> dict[str, Any]:
+    """Keep only fields needed by the PI0.5 preprocessor."""
+    excluded = {
+        ACTION,
+        REWARD,
+        DONE,
+        TRUNCATED,
+        "index",
+        "timestamp",
+        "frame_index",
+        "episode_index",
+        "task_index",
+    }
+    return {key: value for key, value in batch.items() if key not in excluded}
+
+
+def _optional_tensor(batch: dict[str, Any], key: str) -> torch.Tensor | None:
+    value = batch.get(key)
+    return value if isinstance(value, torch.Tensor) else None
+
+
+@torch.no_grad()
+def _add_pi05_embeddings_only(policy: PI05Policy, batch: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
+    batch = dict(batch)
+    images, img_masks = policy._preprocess_images(batch)
+    tokens = batch[OBS_LANGUAGE_TOKENS]
+    masks = batch[OBS_LANGUAGE_ATTENTION_MASK]
+    prefix_embs, _, _ = policy.model.embed_prefix(images, img_masks, tokens, masks)
+    batch[OBS_VLA_EMBEDDINGS] = prefix_embs
+    return batch
+
+
+def _flush_shard(
+    output_dir: Path,
+    shard_id: int,
+    tensors: dict[str, list[torch.Tensor]],
+    *,
+    dtype: torch.dtype,
+) -> dict[str, Any]:
+    shard = {}
+    for key, values in tensors.items():
+        if not values:
+            continue
+        tensor = torch.cat(values, dim=0).contiguous().cpu()
+        if tensor.is_floating_point() and key in {"vla_embeddings", "reference_action"}:
+            tensor = tensor.to(dtype=dtype)
+        shard[key] = tensor
+
+    filename = f"shard-{shard_id:06d}.safetensors"
+    save_file(shard, output_dir / filename)
+
+    num_frames = int(next(iter(shard.values())).shape[0])
+    shapes = {key: list(value.shape) for key, value in shard.items()}
+    return {"file": filename, "num_frames": num_frames, "shapes": shapes}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dataset-repo-id", required=True)
+    parser.add_argument("--dataset-root", default=None)
+    parser.add_argument("--policy-path", required=True, help="PI0.5 checkpoint or Hub repo.")
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--rlt-chunk-size", type=int, default=10)
+    parser.add_argument("--batch-size", type=int, default=4)
+    parser.add_argument("--shard-size", type=int, default=512)
+    parser.add_argument("--start-frame", type=int, default=0, help="Absolute frame index to start from.")
+    parser.add_argument("--max-frames", type=int, default=None, help="Optional limit for smoke tests.")
+    parser.add_argument("--device", default="cuda")
+    parser.add_argument("--policy-dtype", default=None, choices=["bfloat16", "float16", "float32"])
+    parser.add_argument("--num-inference-steps", type=int, default=None)
+    parser.add_argument(
+        "--tokenizer-path",
+        default=None,
+        help="Local tokenizer directory or Hugging Face tokenizer repo. Defaults to the PI0.5 config value.",
+    )
+    parser.add_argument(
+        "--skip-reference-action",
+        action="store_true",
+        help="Only save PI0.5 prefix embeddings. This is enough for RLT Stage 1 and uses less memory/time.",
+    )
+    parser.add_argument("--save-dtype", default="float16", choices=["float32", "float16", "bfloat16"])
+    parser.add_argument("--overwrite", action="store_true")
+    args = parser.parse_args()
+
+    output_dir = Path(args.output_dir)
+    if output_dir.exists():
+        if not args.overwrite:
+            raise FileExistsError(f"{output_dir} already exists. Pass --overwrite to replace it.")
+        shutil.rmtree(output_dir)
+    output_dir.mkdir(parents=True)
+
+    print(f"Loading dataset {args.dataset_repo_id} from {args.dataset_root or 'default cache'}...", flush=True)
+    dataset = LeRobotDataset(args.dataset_repo_id, root=args.dataset_root)
+    if args.start_frame < 0 or args.start_frame >= len(dataset):
+        raise ValueError(f"--start-frame must be in [0, {len(dataset) - 1}], got {args.start_frame}.")
+    end_frame = len(dataset) if args.max_frames is None else min(args.start_frame + args.max_frames, len(dataset))
+    num_frames = end_frame - args.start_frame
+    print(
+        f"Loaded dataset with {len(dataset)} frames; processing frames "
+        f"[{args.start_frame}, {end_frame}) ({num_frames} frames).",
+        flush=True,
+    )
+
+    print(f"Loading PI0.5 config from {args.policy_path}...", flush=True)
+    policy_cfg = PreTrainedConfig.from_pretrained(args.policy_path)
+    policy_cfg.pretrained_path = Path(args.policy_path)
+    policy_cfg.device = args.device
+    if args.policy_dtype is not None and hasattr(policy_cfg, "dtype"):
+        policy_cfg.dtype = args.policy_dtype
+    if args.num_inference_steps is not None and hasattr(policy_cfg, "num_inference_steps"):
+        policy_cfg.num_inference_steps = args.num_inference_steps
+    if args.tokenizer_path is not None and hasattr(policy_cfg, "tokenizer_name"):
+        policy_cfg.tokenizer_name = args.tokenizer_path
+
+    dtype_msg = getattr(policy_cfg, "dtype", "checkpoint-default")
+    steps_msg = getattr(policy_cfg, "num_inference_steps", "checkpoint-default")
+    print(f"Loading PI0.5 policy on {args.device} with dtype={dtype_msg}, num_inference_steps={steps_msg}...", flush=True)
+    policy = make_policy(policy_cfg, ds_meta=dataset.meta)
+    if not isinstance(policy, PI05Policy):
+        raise TypeError(f"Expected a PI05Policy, got {type(policy).__name__}.")
+
+    print("Building PI0.5 preprocessor and RLT adapter...", flush=True)
+    preprocessor, _ = make_pre_post_processors(
+        policy_cfg=policy_cfg,
+        dataset_stats=dataset.meta.stats,
+    )
+    adapter = PI05PrefixRLTAdapter(policy, rlt_chunk_size=args.rlt_chunk_size)
+    dtype = _save_dtype(args.save_dtype)
+
+    pending: dict[str, list[torch.Tensor]] = {}
+    shard_infos = []
+    shard_id = 0
+    frames_in_pending = 0
+
+    for start in trange(args.start_frame, end_frame, args.batch_size, desc="precomputing RLT cache"):
+        end = min(start + args.batch_size, end_frame)
+        samples = [dataset[i] for i in range(start, end)]
+        raw_batch = _collate_samples(samples)
+        pi05_input = preprocessor(_policy_input_batch(raw_batch))
+
+        with torch.inference_mode():
+            if args.skip_reference_action:
+                rlt_batch = _add_pi05_embeddings_only(policy, pi05_input)
+            else:
+                rlt_batch = adapter(pi05_input)
+
+        batch_tensors = {
+            "vla_embeddings": rlt_batch[OBS_VLA_EMBEDDINGS].detach(),
+            "index": raw_batch["index"].to(torch.int64),
+            "episode_index": raw_batch["episode_index"].to(torch.int64),
+            "frame_index": raw_batch["frame_index"].to(torch.int64),
+        }
+        task_index = _optional_tensor(raw_batch, "task_index")
+        if task_index is not None:
+            batch_tensors["task_index"] = task_index.to(torch.int64)
+        if not args.skip_reference_action:
+            batch_tensors["reference_action"] = rlt_batch["observation.reference_action"].detach()
+
+        for key in (ACTION, REWARD, DONE, TRUNCATED):
+            value = _optional_tensor(raw_batch, key)
+            if value is not None:
+                batch_tensors[key] = value.detach()
+
+        for key, value in batch_tensors.items():
+            pending.setdefault(key, []).append(value.cpu())
+
+        frames_in_pending += end - start
+        if frames_in_pending >= args.shard_size:
+            shard_infos.append(_flush_shard(output_dir, shard_id, pending, dtype=dtype))
+            shard_id += 1
+            pending = {}
+            frames_in_pending = 0
+
+    if frames_in_pending > 0:
+        shard_infos.append(_flush_shard(output_dir, shard_id, pending, dtype=dtype))
+
+    metadata = {
+        "format": "lerobot_rlt_pi05_prefix_cache_v1",
+        "embedding_source": "pi05.model.embed_prefix",
+        "policy_path": str(args.policy_path),
+        "dataset_repo_id": args.dataset_repo_id,
+        "dataset_root": str(args.dataset_root) if args.dataset_root is not None else None,
+        "source_num_frames": len(dataset),
+        "start_frame": args.start_frame,
+        "end_frame": end_frame,
+        "num_frames": num_frames,
+        "rlt_chunk_size": args.rlt_chunk_size,
+        "reference_action_saved": not args.skip_reference_action,
+        "save_dtype": args.save_dtype,
+        "fields": {
+            "vla_embeddings": "Tensor[num_frames, prefix_tokens, embed_dim]",
+            "reference_action": "Tensor[num_frames, rlt_chunk_size * action_dim]",
+            "index": "Original LeRobotDataset absolute frame index",
+            "episode_index": "Original episode index",
+            "frame_index": "Frame index inside episode",
+            "task_index": "Optional original task index",
+            ACTION: "Optional original dataset action",
+            REWARD: "Optional original dataset next-step reward",
+            DONE: "Optional original dataset next.done",
+            TRUNCATED: "Optional original dataset next.truncated",
+        },
+        "shards": shard_infos,
+    }
+    (output_dir / "metadata.json").write_text(json.dumps(metadata, indent=2), encoding="utf-8")
+    print(f"Saved RLT cache with {num_frames} frames to {output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/rlt/train_rlt_online_libero.py
+++ b/examples/rlt/train_rlt_online_libero.py
@@ -1,0 +1,733 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Single-process online RLT actor-critic training in LIBERO.
+
+This script is intentionally direct: one process owns PI0.5, the RLT policy,
+the LIBERO environment, replay buffer, and learner update. It is meant to
+validate the online RLT data path before moving to a multi-process actor/learner
+setup.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+from collections import deque
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+import torch
+from tqdm import trange
+
+from lerobot.configs.policies import PreTrainedConfig
+from lerobot.envs.factory import make_env, make_env_config, make_env_pre_post_processors
+from lerobot.envs.utils import add_envs_task, close_envs, preprocess_observation
+from lerobot.policies.factory import make_policy, make_pre_post_processors
+from lerobot.policies.pi05.modeling_pi05 import PI05Policy
+from lerobot.policies.rlt.modeling_rlt import RLTPolicy
+from lerobot.policies.rlt.vla_adapter import (
+    OBS_REFERENCE_ACTION,
+    OBS_RLT_STATE,
+    OBS_VLA_EMBEDDINGS,
+    PI05PrefixRLTAdapter,
+)
+from lerobot.rl.algorithms.rlt.configuration_rlt import RLTAlgorithmConfig
+from lerobot.rl.buffer import ReplayBuffer
+from lerobot.utils.constants import ACTION
+from lerobot.utils.random_utils import set_seed
+
+try:
+    from torch.utils.tensorboard import SummaryWriter
+except ImportError:
+    SummaryWriter = None
+
+
+def _first_env(envs):
+    suite_name = next(iter(envs))
+    task_id = next(iter(envs[suite_name]))
+    return envs[suite_name][task_id]
+
+
+def _env_tasks(env, n_envs: int) -> list[str]:
+    for attr in ("task_description", "task"):
+        try:
+            task_result = env.call(attr)
+        except Exception:
+            continue
+        if isinstance(task_result, tuple):
+            task_result = list(task_result)
+        elif isinstance(task_result, np.ndarray):
+            task_result = task_result.tolist()
+        elif isinstance(task_result, str):
+            task_result = [task_result] * n_envs
+        if not isinstance(task_result, list):
+            continue
+        if len(task_result) == 1 and n_envs != 1:
+            task_result = task_result * n_envs
+        if len(task_result) != n_envs:
+            raise ValueError(f"Expected {n_envs} task strings from env.{attr}, got {len(task_result)}.")
+        return [str(item) for item in task_result]
+    return ["" for _ in range(n_envs)]
+
+
+def _as_array(value: Any, *, dtype, size: int) -> np.ndarray:
+    array = np.asarray(value, dtype=dtype).reshape(-1)
+    if array.size == 1 and size != 1:
+        array = np.repeat(array, size)
+    if array.size != size:
+        raise ValueError(f"Expected {size} values, got shape {np.asarray(value).shape}.")
+    return array
+
+
+def _info_array(info: Any, keys: tuple[str, ...], size: int) -> np.ndarray | None:
+    """Extract vector-env scalar metrics when present."""
+    if not isinstance(info, dict):
+        return None
+    for key in keys:
+        if key in info:
+            return _as_array(info[key], dtype=np.float32, size=size)
+    final_info = info.get("final_info")
+    if isinstance(final_info, dict):
+        for key in keys:
+            if key in final_info:
+                return _as_array(final_info[key], dtype=np.float32, size=size)
+    return None
+
+
+def _maybe_latest_checkpoint(path: Path) -> Path:
+    if path.is_dir() and (path / "config.json").exists():
+        return path
+    checkpoints = sorted(p for p in path.glob("checkpoint-*") if p.is_dir() and not p.name.endswith(".tmp"))
+    if not checkpoints:
+        raise FileNotFoundError(f"No checkpoint-* directories found under {path}")
+    return checkpoints[-1]
+
+
+def _make_pi05_policy(
+    *,
+    policy_path: str,
+    env_cfg,
+    device: str,
+    dtype: str | None,
+    num_inference_steps: int | None,
+    tokenizer_path: str | None,
+    disable_compile: bool,
+) -> tuple[PI05Policy, Any, Any, Any]:
+    policy_cfg = PreTrainedConfig.from_pretrained(policy_path)
+    policy_cfg.pretrained_path = Path(policy_path)
+    policy_cfg.device = device
+    if dtype is not None and hasattr(policy_cfg, "dtype"):
+        policy_cfg.dtype = dtype
+    if num_inference_steps is not None and hasattr(policy_cfg, "num_inference_steps"):
+        policy_cfg.num_inference_steps = num_inference_steps
+    if tokenizer_path is not None and hasattr(policy_cfg, "tokenizer_name"):
+        policy_cfg.tokenizer_name = tokenizer_path
+    if disable_compile and hasattr(policy_cfg, "compile_model"):
+        policy_cfg.compile_model = False
+
+    policy = make_policy(policy_cfg, env_cfg=env_cfg)
+    if not isinstance(policy, PI05Policy):
+        raise TypeError(f"Expected PI05Policy, got {type(policy).__name__}.")
+    policy.eval()
+    for param in policy.parameters():
+        param.requires_grad_(False)
+
+    preprocessor, postprocessor = make_pre_post_processors(
+        policy_cfg=policy_cfg,
+        pretrained_path=policy_cfg.pretrained_path,
+    )
+    return policy, policy_cfg, preprocessor, postprocessor
+
+
+def _load_rlt_policy(path: str, device: str) -> tuple[RLTPolicy, Path]:
+    rlt_path = _maybe_latest_checkpoint(Path(path))
+    rlt_cfg = PreTrainedConfig.from_pretrained(rlt_path, local_files_only=True)
+    rlt_cfg.device = device
+    policy = RLTPolicy.from_pretrained(rlt_path, config=rlt_cfg, local_files_only=True, strict=True)
+    policy.to(device)
+    return policy, rlt_path
+
+
+def _prepare_pi05_input(
+    raw_observation,
+    env,
+    env_preprocessor,
+    pi05_preprocessor,
+    task_descriptions: list[str] | None,
+) -> dict[str, torch.Tensor]:
+    observation = preprocess_observation(raw_observation)
+    if task_descriptions is None:
+        observation = add_envs_task(env, observation)
+    else:
+        observation["task"] = task_descriptions
+    observation = env_preprocessor(observation)
+    return pi05_preprocessor(observation)
+
+
+@torch.no_grad()
+def _rlt_features(
+    *,
+    raw_observation,
+    env,
+    env_preprocessor,
+    pi05_preprocessor,
+    adapter: PI05PrefixRLTAdapter,
+    rlt_device: str,
+    include_proprio: bool,
+    task_descriptions: list[str] | None,
+) -> dict[str, torch.Tensor]:
+    pi05_input = _prepare_pi05_input(
+        raw_observation,
+        env,
+        env_preprocessor,
+        pi05_preprocessor,
+        task_descriptions,
+    )
+    batch = adapter(pi05_input)
+    out = {
+        OBS_VLA_EMBEDDINGS: batch[OBS_VLA_EMBEDDINGS].detach().to(rlt_device),
+        OBS_REFERENCE_ACTION: batch[OBS_REFERENCE_ACTION].detach().to(rlt_device),
+    }
+    if include_proprio and "observation.state" in pi05_input:
+        out["observation.state"] = pi05_input["observation.state"].detach().to(rlt_device)
+    return out
+
+
+@torch.no_grad()
+def _attach_rlt_state(features: dict[str, torch.Tensor], rlt_policy: RLTPolicy) -> dict[str, torch.Tensor]:
+    encoder_param = next(rlt_policy.rl_token_encoder.parameters())
+    vla_embeddings = features[OBS_VLA_EMBEDDINGS].to(
+        device=encoder_param.device,
+        dtype=encoder_param.dtype,
+    )
+    features[OBS_RLT_STATE] = rlt_policy.rl_token_encoder(vla_embeddings).detach()
+    return features
+
+
+def _slice_state(
+    features: dict[str, torch.Tensor],
+    *,
+    index: int,
+    include_proprio: bool,
+) -> dict[str, torch.Tensor]:
+    state_key = OBS_RLT_STATE if OBS_RLT_STATE in features else OBS_VLA_EMBEDDINGS
+    state = {state_key: features[state_key][index : index + 1]}
+    if include_proprio and "observation.state" in features:
+        state["observation.state"] = features["observation.state"][index : index + 1]
+    return state
+
+
+def _policy_batch_from_features(features: dict[str, torch.Tensor], include_proprio: bool) -> dict[str, torch.Tensor]:
+    batch = {
+        OBS_REFERENCE_ACTION: features[OBS_REFERENCE_ACTION],
+    }
+    if OBS_RLT_STATE in features:
+        batch[OBS_RLT_STATE] = features[OBS_RLT_STATE]
+    else:
+        batch[OBS_VLA_EMBEDDINGS] = features[OBS_VLA_EMBEDDINGS]
+    if include_proprio and "observation.state" in features:
+        batch["observation.state"] = features["observation.state"]
+    return batch
+
+
+def _postprocess_action_step(
+    action_step_norm: torch.Tensor,
+    *,
+    pi05_postprocessor,
+    env_postprocessor,
+    clip_normalized_action: bool,
+) -> torch.Tensor:
+    if clip_normalized_action:
+        action_step_norm = action_step_norm.clamp(-1.0, 1.0)
+    action_cpu = pi05_postprocessor(action_step_norm.detach().cpu())
+    env_action = env_postprocessor({ACTION: action_cpu})[ACTION]
+    return env_action
+
+
+def _save_checkpoint(
+    *,
+    output_dir: Path,
+    step: int,
+    rlt_policy: RLTPolicy,
+    algorithm,
+    total_env_steps: int,
+    episode: int,
+) -> None:
+    checkpoint_dir = output_dir / f"checkpoint-{step:06d}"
+    tmp_dir = checkpoint_dir.with_name(f"{checkpoint_dir.name}.tmp")
+    if tmp_dir.exists():
+        shutil.rmtree(tmp_dir)
+    tmp_dir.mkdir(parents=True)
+    rlt_policy.save_pretrained(tmp_dir)
+    torch.save(
+        {
+            "step": step,
+            "total_env_steps": total_env_steps,
+            "episode": episode,
+            "critics": algorithm.critics.state_dict(),
+            "critic_targets": algorithm.critic_targets.state_dict(),
+            "optimizers": {name: opt.state_dict() for name, opt in algorithm.optimizers.items()},
+        },
+        tmp_dir / "online_state.pt",
+    )
+    if checkpoint_dir.exists():
+        shutil.rmtree(checkpoint_dir)
+    tmp_dir.rename(checkpoint_dir)
+
+
+def _try_resume_online_state(checkpoint_dir: Path, algorithm) -> tuple[int, int, int]:
+    state_path = checkpoint_dir / "online_state.pt"
+    if not state_path.exists():
+        return 0, 0, 0
+    state = torch.load(state_path, map_location="cpu", weights_only=False)
+    algorithm.critics.load_state_dict(state["critics"])
+    algorithm.critic_targets.load_state_dict(state["critic_targets"])
+    for name, opt_state in state.get("optimizers", {}).items():
+        if name in algorithm.optimizers:
+            algorithm.optimizers[name].load_state_dict(opt_state)
+    return int(state.get("step", 0)), int(state.get("total_env_steps", 0)), int(state.get("episode", 0))
+
+
+def _write_jsonl(path: Path, item: dict[str, Any]) -> None:
+    with path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(item) + "\n")
+
+
+def _reset_finished_envs(env, done_mask: np.ndarray, seed_base: int | None = None):
+    options = {"reset_mask": done_mask.astype(bool)}
+    seeds = None
+    if seed_base is not None:
+        seeds = [seed_base + env_idx for env_idx in range(done_mask.size)]
+    try:
+        return env.reset(seed=seeds, options=options)
+    except TypeError:
+        return env.reset(seed=seeds)
+
+
+def _env_action_dim(env) -> int | None:
+    space = getattr(env, "single_action_space", None)
+    if space is None:
+        space = getattr(env, "action_space", None)
+    shape = getattr(space, "shape", None)
+    if not shape:
+        return None
+    if len(shape) == 1:
+        return int(shape[0])
+    if len(shape) >= 2:
+        return int(shape[-1])
+    return None
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--pi05-policy-path", default="lerobot/pi05_libero_finetuned")
+    parser.add_argument("--rlt-policy-path", required=True, help="Stage-1 RLT checkpoint or online checkpoint.")
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--env-type", default="libero")
+    parser.add_argument("--env-task", default="libero_10")
+    parser.add_argument("--env-task-ids", default="0", help="Comma-separated LIBERO task ids. First id is used.")
+    parser.add_argument("--n-envs", type=int, default=1, help="Number of parallel LIBERO envs for rollout.")
+    parser.add_argument("--use-async-envs", action="store_true", help="Use AsyncVectorEnv instead of SyncVectorEnv.")
+    parser.add_argument("--episodes", type=int, default=10)
+    parser.add_argument("--max-steps-per-episode", type=int, default=None)
+    parser.add_argument("--chunk-size", type=int, default=None, help="Defaults to the RLT policy chunk_size.")
+    parser.add_argument("--execute-steps-per-chunk", type=int, default=None)
+    parser.add_argument("--buffer-capacity", type=int, default=10000)
+    parser.add_argument("--warmup-transitions", type=int, default=20)
+    parser.add_argument("--updates-per-chunk", type=int, default=1)
+    parser.add_argument("--batch-size", type=int, default=8)
+    parser.add_argument("--pi05-device", default="cuda")
+    parser.add_argument("--rlt-device", default="cuda")
+    parser.add_argument("--storage-device", default="cpu")
+    parser.add_argument("--pi05-dtype", default="bfloat16", choices=["bfloat16", "float16", "float32"])
+    parser.add_argument("--num-inference-steps", type=int, default=10)
+    parser.add_argument("--tokenizer-path", default=None)
+    parser.add_argument(
+        "--disable-pi05-compile",
+        action="store_true",
+        help="Disable torch.compile for PI0.5 inference to avoid Inductor/Triton autotune startup.",
+    )
+    parser.add_argument("--seed", type=int, default=1000)
+    parser.add_argument("--log-freq", type=int, default=1)
+    parser.add_argument("--save-freq", type=int, default=50)
+    parser.add_argument(
+        "--success-window",
+        type=int,
+        default=1000,
+        help="Number of recently completed episodes used for success_rate. Cumulative rate is logged separately.",
+    )
+    parser.add_argument("--metrics-file", default=None)
+    parser.add_argument("--tensorboard-log-dir", default=None)
+    parser.add_argument("--no-tensorboard", action="store_true")
+    parser.add_argument("--no-clip-normalized-action", action="store_true")
+    parser.add_argument(
+        "--exploration-std",
+        type=float,
+        default=0.02,
+        help="Gaussian exploration std added to the RLT action chunk during rollout. Use 0 for deterministic.",
+    )
+    parser.add_argument(
+        "--exploration-steps",
+        type=int,
+        default=0,
+        help="If >0, linearly decay exploration std within each run/window. Default keeps std constant.",
+    )
+    parser.add_argument("--resume", action="store_true", help="Load online_state.pt from --rlt-policy-path if present.")
+    parser.add_argument("--overwrite", action="store_true")
+    args = parser.parse_args()
+
+    set_seed(args.seed)
+    output_dir = Path(args.output_dir)
+    if output_dir.exists() and not args.resume:
+        if not args.overwrite:
+            raise FileExistsError(f"{output_dir} already exists. Pass --overwrite to replace it.")
+        shutil.rmtree(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    metrics_path = Path(args.metrics_file) if args.metrics_file else output_dir / "online_metrics.jsonl"
+    tb_dir = Path(args.tensorboard_log_dir) if args.tensorboard_log_dir else output_dir / "runs"
+    writer = None if args.no_tensorboard or SummaryWriter is None else SummaryWriter(log_dir=str(tb_dir))
+
+    task_ids = [int(x.strip()) for x in args.env_task_ids.split(",") if x.strip()]
+    env_cfg = make_env_config(args.env_type, task=args.env_task, task_ids=task_ids)
+    envs = make_env(env_cfg, n_envs=args.n_envs, use_async_envs=args.use_async_envs)
+    env = _first_env(envs)
+    n_envs = int(getattr(env, "num_envs", args.n_envs))
+    task_descriptions = _env_tasks(env, n_envs)
+
+    rlt_policy, rlt_path = _load_rlt_policy(args.rlt_policy_path, args.rlt_device)
+    include_proprio = rlt_policy._proprioception_dim > 0
+    chunk_size = args.chunk_size or int(rlt_policy.config.chunk_size)
+    execute_steps = args.execute_steps_per_chunk or chunk_size
+    execute_steps = min(execute_steps, chunk_size)
+    action_dim = rlt_policy._action_dim
+    env_action_dim = _env_action_dim(env)
+    if env_action_dim is not None and int(env_action_dim) != int(action_dim):
+        raise ValueError(
+            f"Environment action_dim {env_action_dim} != RLT action_dim {action_dim}. "
+            "Use a checkpoint whose action dimension matches this arm-gripper environment."
+        )
+
+    pi05_policy, pi05_cfg, pi05_preprocessor, pi05_postprocessor = _make_pi05_policy(
+        policy_path=args.pi05_policy_path,
+        env_cfg=env_cfg,
+        device=args.pi05_device,
+        dtype=args.pi05_dtype,
+        num_inference_steps=args.num_inference_steps,
+        tokenizer_path=args.tokenizer_path,
+        disable_compile=args.disable_pi05_compile,
+    )
+    env_preprocessor, env_postprocessor = make_env_pre_post_processors(env_cfg, pi05_cfg)
+    adapter = PI05PrefixRLTAdapter(pi05_policy, rlt_chunk_size=chunk_size)
+
+    algorithm_cfg = RLTAlgorithmConfig.from_policy_config(rlt_policy.config)
+    algorithm = algorithm_cfg.build_algorithm(rlt_policy)
+    algorithm.transition_to_online()
+
+    start_update_step = 0
+    total_env_steps = 0
+    start_episode = 0
+    if args.resume:
+        start_update_step, total_env_steps, start_episode = _try_resume_online_state(rlt_path, algorithm)
+        print(
+            f"Resumed online state from {rlt_path}: update_step={start_update_step}, "
+            f"env_steps={total_env_steps}, episode={start_episode}",
+            flush=True,
+        )
+
+    replay_buffer = ReplayBuffer(
+        capacity=args.buffer_capacity,
+        device=args.rlt_device,
+        storage_device=args.storage_device,
+        use_drq=False,
+    )
+
+    def batch_iterator():
+        while True:
+            yield replay_buffer.sample(args.batch_size)
+
+    update_step = start_update_step
+    max_steps = args.max_steps_per_episode or env.call("_max_episode_steps")[0]
+    seeds = [args.seed + start_episode * n_envs + env_idx for env_idx in range(n_envs)]
+    raw_obs, _ = env.reset(seed=seeds)
+    current = _attach_rlt_state(
+        _rlt_features(
+            raw_observation=raw_obs,
+            env=env,
+            env_preprocessor=env_preprocessor,
+            pi05_preprocessor=pi05_preprocessor,
+            adapter=adapter,
+            rlt_device=args.rlt_device,
+            include_proprio=include_proprio,
+            task_descriptions=task_descriptions,
+        ),
+        rlt_policy,
+    )
+    episode_reward = np.zeros(n_envs, dtype=np.float32)
+    episode_steps = np.zeros(n_envs, dtype=np.int64)
+    episode_success = np.zeros(n_envs, dtype=bool)
+    episode_count = np.zeros(n_envs, dtype=np.int64)
+    success_count = np.zeros(n_envs, dtype=np.int64)
+    completed_episode_reward = np.zeros(n_envs, dtype=np.float32)
+    completed_episode_steps = np.zeros(n_envs, dtype=np.int64)
+    completed_success = np.zeros(n_envs, dtype=bool)
+    recent_successes: deque[bool] = deque(maxlen=max(1, args.success_window))
+
+    try:
+        for ep_idx in range(start_episode, args.episodes):
+            pbar = trange(max_steps, desc=f"rollout window {ep_idx}", leave=False)
+            window_step = 0
+            while window_step < max_steps:
+                with torch.no_grad():
+                    env_batch_size = current[OBS_REFERENCE_ACTION].shape[0]
+                    ref_action_chunk = current[OBS_REFERENCE_ACTION].reshape(
+                        env_batch_size, chunk_size, action_dim
+                    )
+                    action_chunk = rlt_policy.select_action(
+                        _policy_batch_from_features(current, include_proprio=include_proprio)
+                    )
+                    action_chunk = action_chunk.reshape(env_batch_size, chunk_size, action_dim)
+                    if args.exploration_steps > 0:
+                        exploration_scale = max(0.0, 1.0 - window_step / args.exploration_steps)
+                    else:
+                        exploration_scale = 1.0
+                    exploration_std = args.exploration_std * exploration_scale
+                    if exploration_std > 0:
+                        action_chunk = action_chunk + torch.randn_like(action_chunk) * exploration_std
+                    if not args.no_clip_normalized_action:
+                        action_chunk = action_chunk.clamp(-1.0, 1.0)
+                    action_delta = action_chunk - ref_action_chunk
+                    action_delta_l2 = float(action_delta.norm(dim=-1).mean().item())
+                    action_delta_linf = float(action_delta.abs().max().item())
+
+                chunk_reward = np.zeros(env_batch_size, dtype=np.float32)
+                terminated = np.zeros(env_batch_size, dtype=bool)
+                truncated = np.zeros(env_batch_size, dtype=bool)
+                success = np.zeros(env_batch_size, dtype=np.float32)
+                for chunk_step in range(execute_steps):
+                    action_step = action_chunk[:, chunk_step, :]
+                    env_action = _postprocess_action_step(
+                        action_step,
+                        pi05_postprocessor=pi05_postprocessor,
+                        env_postprocessor=env_postprocessor,
+                        clip_normalized_action=not args.no_clip_normalized_action,
+                    )
+                    raw_obs, reward, term, trunc, info = env.step(env_action.detach().cpu().numpy())
+                    reward_array = _as_array(reward, dtype=np.float32, size=env_batch_size)
+                    term_array = _as_array(term, dtype=bool, size=env_batch_size)
+                    trunc_array = _as_array(trunc, dtype=bool, size=env_batch_size)
+                    episode_steps += 1
+                    timeout_array = episode_steps >= max_steps
+                    trunc_array |= timeout_array
+                    chunk_reward += reward_array
+                    episode_reward += reward_array
+                    success_value = _info_array(info, ("success", "is_success", "task_success"), env_batch_size)
+                    if success_value is not None:
+                        success = np.maximum(success, success_value)
+                        episode_success |= success_value.astype(bool)
+                    total_env_steps += env_batch_size
+                    window_step += 1
+                    pbar.update(1)
+                    terminated |= term_array
+                    truncated |= trunc_array
+                    if np.any(term_array | trunc_array) or window_step >= max_steps:
+                        break
+
+                next_features = _attach_rlt_state(
+                    _rlt_features(
+                        raw_observation=raw_obs,
+                        env=env,
+                        env_preprocessor=env_preprocessor,
+                        pi05_preprocessor=pi05_preprocessor,
+                        adapter=adapter,
+                        rlt_device=args.rlt_device,
+                        include_proprio=include_proprio,
+                        task_descriptions=task_descriptions,
+                    ),
+                    rlt_policy,
+                )
+
+                for env_idx in range(env_batch_size):
+                    replay_buffer.add(
+                        state=_slice_state(current, index=env_idx, include_proprio=include_proprio),
+                        action=action_chunk[env_idx : env_idx + 1].reshape(1, -1).detach(),
+                        reward=float(chunk_reward[env_idx]),
+                        next_state=_slice_state(next_features, index=env_idx, include_proprio=include_proprio),
+                        done=bool(terminated[env_idx]),
+                        truncated=bool(truncated[env_idx]),
+                        complementary_info={
+                            "reference_action": current[OBS_REFERENCE_ACTION][env_idx : env_idx + 1].detach(),
+                            "next_reference_action": next_features[OBS_REFERENCE_ACTION][
+                                env_idx : env_idx + 1
+                            ].detach(),
+                        },
+                    )
+
+                done_mask = terminated | truncated
+                if np.any(done_mask):
+                    done_success = done_mask & episode_success
+                    completed_episode_reward[done_mask] = episode_reward[done_mask]
+                    completed_episode_steps[done_mask] = episode_steps[done_mask]
+                    completed_success[done_mask] = episode_success[done_mask]
+                    episode_count += done_mask.astype(np.int64)
+                    success_count += done_success.astype(np.int64)
+                    recent_successes.extend(episode_success[done_mask].tolist())
+                    episode_reward[done_mask] = 0.0
+                    episode_steps[done_mask] = 0
+                    episode_success[done_mask] = False
+                    raw_obs, _ = _reset_finished_envs(
+                        env,
+                        done_mask,
+                        seed_base=args.seed + (ep_idx + 1) * 100000 + int(episode_count.sum()) * n_envs,
+                    )
+                    next_features = _attach_rlt_state(
+                        _rlt_features(
+                            raw_observation=raw_obs,
+                            env=env,
+                            env_preprocessor=env_preprocessor,
+                            pi05_preprocessor=pi05_preprocessor,
+                            adapter=adapter,
+                            rlt_device=args.rlt_device,
+                            include_proprio=include_proprio,
+                            task_descriptions=task_descriptions,
+                        ),
+                        rlt_policy,
+                    )
+                current = next_features
+
+                train_stats = {}
+                if len(replay_buffer) >= args.warmup_transitions:
+                    for _ in range(args.updates_per_chunk):
+                        stats = algorithm.update(batch_iterator())
+                        update_step += 1
+                        train_stats = stats.to_log_dict()
+                        if writer is not None:
+                            for key, value in train_stats.items():
+                                writer.add_scalar(f"train/{key}", value, update_step)
+
+                if update_step == 0 or update_step % args.log_freq == 0:
+                    cumulative_success_rate = float(success_count.sum() / max(1, episode_count.sum()))
+                    recent_success_rate = float(np.mean(recent_successes)) if recent_successes else None
+                    item = {
+                        "episode": ep_idx,
+                        "n_envs": env_batch_size,
+                        "env_step": total_env_steps,
+                        "window_step": window_step,
+                        "episode_count": int(episode_count.sum()),
+                        "episode_env_step_mean": float(episode_steps.mean()),
+                        "update_step": update_step,
+                        "buffer_size": len(replay_buffer),
+                        "chunk_reward_mean": float(chunk_reward.mean()),
+                        "chunk_reward_sum": float(chunk_reward.sum()),
+                        "episode_reward_mean": float(episode_reward.mean()),
+                        "last_completed_episode_reward_mean": float(completed_episode_reward[done_mask].mean())
+                        if np.any(done_mask)
+                        else None,
+                        "last_completed_episode_steps_mean": float(completed_episode_steps[done_mask].mean())
+                        if np.any(done_mask)
+                        else None,
+                        "last_completed_success_rate": float(completed_success[done_mask].mean())
+                        if np.any(done_mask)
+                        else None,
+                        "terminated_count": int(terminated.sum()),
+                        "truncated_count": int(truncated.sum()),
+                        "success_rate": recent_success_rate,
+                        "recent_success_rate": recent_success_rate,
+                        "recent_success_count": int(sum(recent_successes)),
+                        "success_window_size": len(recent_successes),
+                        "success_window_capacity": recent_successes.maxlen,
+                        "cumulative_success_rate": cumulative_success_rate,
+                        "chunk_success_rate": float(success.astype(bool).mean()),
+                        "exploration_std": exploration_std,
+                        "action_delta_l2": action_delta_l2,
+                        "action_delta_linf": action_delta_linf,
+                        **train_stats,
+                    }
+                    print(json.dumps(item), flush=True)
+                    _write_jsonl(metrics_path, item)
+                    if writer is not None:
+                        writer.add_scalar("rollout/chunk_reward_mean", float(chunk_reward.mean()), total_env_steps)
+                        writer.add_scalar("rollout/episode_reward_mean", float(episode_reward.mean()), total_env_steps)
+                        writer.add_scalar("rollout/buffer_size", len(replay_buffer), total_env_steps)
+                        writer.add_scalar(
+                            "rollout/cumulative_success_rate",
+                            cumulative_success_rate,
+                            total_env_steps,
+                        )
+                        if recent_success_rate is not None:
+                            writer.add_scalar("rollout/success_rate", recent_success_rate, total_env_steps)
+                            writer.add_scalar(
+                                "rollout/recent_success_rate", recent_success_rate, total_env_steps
+                            )
+                        writer.add_scalar("rollout/exploration_std", exploration_std, total_env_steps)
+                        writer.add_scalar("action/delta_l2", action_delta_l2, total_env_steps)
+                        writer.add_scalar("action/delta_linf", action_delta_linf, total_env_steps)
+
+                if args.save_freq > 0 and update_step > 0 and update_step % args.save_freq == 0:
+                    _save_checkpoint(
+                        output_dir=output_dir,
+                        step=update_step,
+                        rlt_policy=rlt_policy,
+                        algorithm=algorithm,
+                        total_env_steps=total_env_steps,
+                        episode=ep_idx,
+                    )
+
+            pbar.close()
+
+        _save_checkpoint(
+            output_dir=output_dir,
+            step=max(update_step, 1),
+            rlt_policy=rlt_policy,
+            algorithm=algorithm,
+            total_env_steps=total_env_steps,
+            episode=args.episodes,
+        )
+        rlt_policy.save_pretrained(output_dir)
+        (output_dir / "online_training.json").write_text(
+            json.dumps(
+                {
+                    "format": "lerobot_rlt_online_libero_v1",
+                    "pi05_policy_path": args.pi05_policy_path,
+                    "rlt_initial_path": str(rlt_path),
+                    "env_type": args.env_type,
+                    "env_task": args.env_task,
+                    "env_task_ids": task_ids,
+                    "n_envs": n_envs,
+                    "use_async_envs": args.use_async_envs,
+                    "continuous_rollout": True,
+                    "chunk_size": chunk_size,
+                    "execute_steps_per_chunk": execute_steps,
+                    "success_window": recent_successes.maxlen,
+                    "total_env_steps": total_env_steps,
+                    "update_step": update_step,
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+    finally:
+        if writer is not None:
+            writer.close()
+        close_envs(envs)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/rlt/train_rlt_token_from_cache.py
+++ b/examples/rlt/train_rlt_token_from_cache.py
@@ -1,0 +1,819 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Train the RLT RL-token encoder/decoder from a precomputed PI0.5 cache."""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import json
+import multiprocessing as mp
+import random
+import shutil
+from pathlib import Path
+from typing import Any
+
+import torch
+from safetensors import safe_open
+from safetensors.torch import load_file
+from tqdm import tqdm
+
+from lerobot.configs.types import FeatureType, PolicyFeature
+from lerobot.policies.rlt.configuration_rlt import RLTConfig, RLTokenConfig
+from lerobot.policies.rlt.modeling_rlt import RLTPolicy
+from lerobot.rl.algorithms.rlt.configuration_rlt import RLTAlgorithmConfig
+from lerobot.utils.constants import ACTION
+
+try:
+    from torch.utils.tensorboard import SummaryWriter
+except ImportError:
+    SummaryWriter = None
+
+
+def _read_unique_split_values_worker(args: tuple[str, dict[str, Any], str]) -> list[int]:
+    cache_dir, shard_info, key = args
+    with safe_open(str(Path(cache_dir) / shard_info["file"]), framework="pt", device="cpu") as shard:
+        if key not in shard.keys():
+            raise KeyError(f"Cannot split by {key}; {shard_info['file']} does not contain that field.")
+        values = shard.get_tensor(key).to(torch.int64).unique().tolist()
+    return [int(value) for value in values]
+
+
+def _read_split_ranges_worker(
+    args: tuple[str, dict[str, Any], str, list[int]],
+) -> list[tuple[dict[str, Any], int, int]]:
+    cache_dir, shard_info, key, allowed_values = args
+    allowed = torch.tensor(allowed_values, dtype=torch.int64)
+    with safe_open(str(Path(cache_dir) / shard_info["file"]), framework="pt", device="cpu") as shard:
+        split_values = shard.get_tensor(key).to(torch.int64)
+        mask = torch.isin(split_values, allowed)
+    return [(shard_info, start, end) for start, end in _contiguous_true_ranges(mask)]
+
+
+class RLTCacheBatchIterator:
+    """Infinite iterator yielding batches in the format expected by RLTAlgorithm."""
+
+    def __init__(
+        self,
+        cache_dir: Path,
+        shards: list[dict[str, Any]],
+        *,
+        batch_size: int,
+        device: str,
+        shuffle: bool,
+        skip_zero_embeddings: bool,
+        sampling_mode: str,
+        split_key: str | None = None,
+        allowed_split_values: set[int] | None = None,
+        ranges: list[tuple[dict[str, Any], int, int]] | None = None,
+    ):
+        self.cache_dir = cache_dir
+        self.shards = shards
+        self.batch_size = batch_size
+        self.device = device
+        self.shuffle = shuffle
+        self.skip_zero_embeddings = skip_zero_embeddings
+        self.sampling_mode = sampling_mode
+        self.split_key = split_key
+        self.allowed_split_values = allowed_split_values
+        self.ranges = ranges
+        if self.ranges is None and split_key is not None:
+            self.ranges = _build_split_ranges(cache_dir, shards, key=split_key, allowed_values=allowed_split_values)
+        self._batch_iter = self._iter_batches()
+
+    def __iter__(self) -> RLTCacheBatchIterator:
+        return self
+
+    def __next__(self) -> dict[str, dict[str, torch.Tensor]]:
+        return next(self._batch_iter)
+
+    def _yield_batch(self, shard_info: dict[str, Any], start: int, end: int):
+        shard_path = self.cache_dir / shard_info["file"]
+        with safe_open(str(shard_path), framework="pt", device="cpu") as shard:
+            batch = shard.get_slice("vla_embeddings")[start:end].float().to(self.device, non_blocking=True)
+        if self.skip_zero_embeddings:
+            nonzero = batch.flatten(1).abs().sum(dim=1) > 0
+            batch = batch[nonzero]
+            if batch.numel() == 0:
+                return None
+        return {"state": {"observation.vla_embeddings": batch}}
+
+    def _global_batch_refs(self) -> list[tuple[dict[str, Any], int, int]]:
+        ranges = self.ranges
+        if ranges is None:
+            ranges = []
+            for shard_info in self.shards:
+                shard_path = self.cache_dir / shard_info["file"]
+                with safe_open(str(shard_path), framework="pt", device="cpu") as shard:
+                    num_frames = shard.get_slice("vla_embeddings").get_shape()[0]
+                ranges.append((shard_info, 0, num_frames))
+
+        refs: list[tuple[dict[str, Any], int, int]] = []
+        for shard_info, range_start, range_end in ranges:
+            if range_end <= range_start:
+                continue
+            for start in range(range_start, range_end, self.batch_size):
+                refs.append((shard_info, start, min(start + self.batch_size, range_end)))
+        return refs
+
+    def _iter_batches(self):
+        while True:
+            if self.sampling_mode == "global":
+                batch_refs = self._global_batch_refs()
+                if self.shuffle:
+                    random.shuffle(batch_refs)
+                for shard_info, start, end in batch_refs:
+                    batch = self._yield_batch(shard_info, start, end)
+                    if batch is not None:
+                        yield batch
+                continue
+
+            if self.ranges is not None:
+                range_order = list(range(len(self.ranges)))
+                if self.shuffle:
+                    random.shuffle(range_order)
+
+                for range_idx in range_order:
+                    shard_info, range_start, range_end = self.ranges[range_idx]
+                    if range_end <= range_start:
+                        continue
+                    shard_path = self.cache_dir / shard_info["file"]
+                    batch_starts = list(range(range_start, range_end, self.batch_size))
+                    if self.shuffle:
+                        random.shuffle(batch_starts)
+
+                    with safe_open(str(shard_path), framework="pt", device="cpu") as shard:
+                        embeddings_slice = shard.get_slice("vla_embeddings")
+                        for start in batch_starts:
+                            end = min(start + self.batch_size, range_end)
+                            batch = embeddings_slice[start:end].float().to(self.device, non_blocking=True)
+                            if self.skip_zero_embeddings:
+                                nonzero = batch.flatten(1).abs().sum(dim=1) > 0
+                                batch = batch[nonzero]
+                                if batch.numel() == 0:
+                                    continue
+                            yield {"state": {"observation.vla_embeddings": batch}}
+                continue
+
+            shard_order = list(range(len(self.shards)))
+            if self.shuffle:
+                random.shuffle(shard_order)
+
+            for shard_idx in shard_order:
+                shard_info = self.shards[shard_idx]
+                shard_path = self.cache_dir / shard_info["file"]
+                with safe_open(str(shard_path), framework="pt", device="cpu") as shard:
+                    embeddings = shard.get_tensor("vla_embeddings").float()
+
+                frame_order = torch.randperm(embeddings.shape[0]) if self.shuffle else torch.arange(embeddings.shape[0])
+                for start in range(0, embeddings.shape[0], self.batch_size):
+                    indices = frame_order[start : start + self.batch_size]
+                    batch = embeddings.index_select(0, indices).to(self.device, non_blocking=True)
+                    if self.skip_zero_embeddings:
+                        nonzero = batch.flatten(1).abs().sum(dim=1) > 0
+                        batch = batch[nonzero]
+                        if batch.numel() == 0:
+                            continue
+                    yield {"state": {"observation.vla_embeddings": batch}}
+
+
+def _load_metadata(cache_dir: Path) -> dict[str, Any]:
+    metadata_path = cache_dir / "metadata.json"
+    if not metadata_path.exists():
+        shards = [{"file": path.name} for path in sorted(cache_dir.glob("shard-*.safetensors"))]
+        if not shards:
+            raise FileNotFoundError(f"No metadata.json or shard-*.safetensors found in {cache_dir}.")
+        return {"shards": shards}
+    return json.loads(metadata_path.read_text(encoding="utf-8"))
+
+
+def _split_shards(
+    shards: list[dict[str, Any]],
+    *,
+    val_ratio: float,
+    val_shards: int | None,
+    seed: int,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    if not 0.0 <= val_ratio < 1.0:
+        raise ValueError(f"--val-ratio must be in [0, 1), got {val_ratio}.")
+    if val_shards is not None and val_shards < 0:
+        raise ValueError(f"--val-shards must be non-negative, got {val_shards}.")
+    if len(shards) < 2:
+        return shards, []
+
+    num_val = val_shards if val_shards is not None else int(round(len(shards) * val_ratio))
+    if val_ratio > 0 and num_val == 0:
+        num_val = 1
+    num_val = min(num_val, len(shards) - 1)
+    if num_val == 0:
+        return shards, []
+
+    order = list(range(len(shards)))
+    rng = random.Random(seed)
+    rng.shuffle(order)
+    val_indices = set(order[:num_val])
+    train_shards = [shard for idx, shard in enumerate(shards) if idx not in val_indices]
+    val_split = [shard for idx, shard in enumerate(shards) if idx in val_indices]
+    return train_shards, val_split
+
+
+def _split_values_from_cache(
+    cache_dir: Path,
+    shards: list[dict[str, Any]],
+    *,
+    key: str,
+    val_ratio: float,
+    seed: int,
+) -> tuple[set[int], set[int]]:
+    values: set[int] = set()
+    tasks = [(str(cache_dir), shard_info, key) for shard_info in shards]
+    ctx = mp.get_context("spawn")
+    with ctx.Pool(processes=1, maxtasksperchild=8) as pool:
+        iterator = pool.imap(_read_unique_split_values_worker, tasks, chunksize=1)
+        for shard_values in tqdm(iterator, total=len(shards), desc=f"scanning {key}", unit="shard"):
+            values.update(shard_values)
+            gc.collect()
+
+    if len(values) < 2:
+        return values, set()
+
+    ordered = sorted(values)
+    rng = random.Random(seed)
+    rng.shuffle(ordered)
+    num_val = int(round(len(ordered) * val_ratio))
+    if val_ratio > 0 and num_val == 0:
+        num_val = 1
+    num_val = min(num_val, len(ordered) - 1)
+    val_values = set(ordered[:num_val])
+    train_values = set(ordered[num_val:])
+    return train_values, val_values
+
+
+def _contiguous_true_ranges(mask: torch.Tensor) -> list[tuple[int, int]]:
+    indices = torch.nonzero(mask, as_tuple=False).flatten().tolist()
+    if not indices:
+        return []
+
+    ranges = []
+    start = prev = int(indices[0])
+    for idx in indices[1:]:
+        idx = int(idx)
+        if idx == prev + 1:
+            prev = idx
+            continue
+        ranges.append((start, prev + 1))
+        start = prev = idx
+    ranges.append((start, prev + 1))
+    return ranges
+
+
+def _build_split_ranges(
+    cache_dir: Path,
+    shards: list[dict[str, Any]],
+    *,
+    key: str,
+    allowed_values: set[int] | None,
+) -> list[tuple[dict[str, Any], int, int]]:
+    if allowed_values is None:
+        raise ValueError(f"allowed_values is required when splitting by {key}.")
+
+    ranges: list[tuple[dict[str, Any], int, int]] = []
+    tasks = [(str(cache_dir), shard_info, key, sorted(allowed_values)) for shard_info in shards]
+    ctx = mp.get_context("spawn")
+    with ctx.Pool(processes=1, maxtasksperchild=8) as pool:
+        iterator = pool.imap(_read_split_ranges_worker, tasks, chunksize=1)
+        for shard_ranges in tqdm(iterator, total=len(shards), desc=f"building {key} ranges", unit="shard"):
+            ranges.extend(shard_ranges)
+            gc.collect()
+    return ranges
+
+
+def _split_index_default_path(output_dir: Path, split_by: str, seed: int, val_ratio: float) -> Path:
+    ratio = str(val_ratio).replace(".", "p")
+    return output_dir / f"split_index_{split_by}_seed{seed}_val{ratio}.json"
+
+
+def _serialize_ranges(ranges: list[tuple[dict[str, Any], int, int]]) -> list[dict[str, Any]]:
+    return [{"file": shard_info["file"], "start": int(start), "end": int(end)} for shard_info, start, end in ranges]
+
+
+def _deserialize_ranges(items: list[dict[str, Any]]) -> list[tuple[dict[str, Any], int, int]]:
+    return [({"file": item["file"]}, int(item["start"]), int(item["end"])) for item in items]
+
+
+def _load_or_build_split_index(
+    cache_dir: Path,
+    shards: list[dict[str, Any]],
+    *,
+    split_by: str,
+    split_key: str,
+    val_ratio: float,
+    seed: int,
+    index_file: Path,
+    rebuild: bool,
+) -> tuple[set[int], set[int], list[tuple[dict[str, Any], int, int]], list[tuple[dict[str, Any], int, int]]]:
+    if index_file.exists() and not rebuild:
+        print(f"Loading split index from {index_file}", flush=True)
+        data = json.loads(index_file.read_text(encoding="utf-8"))
+        expected = {
+            "cache_dir": str(cache_dir),
+            "split_by": split_by,
+            "split_key": split_key,
+            "val_ratio": val_ratio,
+            "seed": seed,
+            "num_shards": len(shards),
+        }
+        for key, value in expected.items():
+            if data.get(key) != value:
+                raise ValueError(
+                    f"Split index {index_file} does not match current run for {key}: "
+                    f"{data.get(key)!r} != {value!r}. Pass --rebuild-split-index to rebuild."
+                )
+        return (
+            set(int(v) for v in data["train_values"]),
+            set(int(v) for v in data["val_values"]),
+            _deserialize_ranges(data["train_ranges"]),
+            _deserialize_ranges(data["val_ranges"]),
+        )
+
+    print(f"Building split index at {index_file}", flush=True)
+    train_values, val_values = _split_values_from_cache(
+        cache_dir,
+        shards,
+        key=split_key,
+        val_ratio=val_ratio,
+        seed=seed,
+    )
+    train_ranges = _build_split_ranges(cache_dir, shards, key=split_key, allowed_values=train_values)
+    val_ranges = _build_split_ranges(cache_dir, shards, key=split_key, allowed_values=val_values)
+    data = {
+        "format": "lerobot_rlt_split_index_v1",
+        "cache_dir": str(cache_dir),
+        "split_by": split_by,
+        "split_key": split_key,
+        "val_ratio": val_ratio,
+        "seed": seed,
+        "num_shards": len(shards),
+        "train_values": sorted(int(v) for v in train_values),
+        "val_values": sorted(int(v) for v in val_values),
+        "train_ranges": _serialize_ranges(train_ranges),
+        "val_ranges": _serialize_ranges(val_ranges),
+    }
+    index_file.parent.mkdir(parents=True, exist_ok=True)
+    tmp_file = index_file.with_suffix(index_file.suffix + ".tmp")
+    tmp_file.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    tmp_file.replace(index_file)
+    return train_values, val_values, train_ranges, val_ranges
+
+
+def _read_cache_shapes(cache_dir: Path, first_shard: dict[str, Any]) -> tuple[int, int | None, int | None, int | None]:
+    shard = load_file(str(cache_dir / first_shard["file"]), device="cpu")
+    if "vla_embeddings" not in shard:
+        raise KeyError(f"{first_shard['file']} does not contain vla_embeddings.")
+
+    embeddings = shard["vla_embeddings"]
+    if embeddings.dim() != 3:
+        raise ValueError(f"Expected vla_embeddings to have shape (N, M, D), got {tuple(embeddings.shape)}.")
+
+    reference_action = shard.get("reference_action")
+    reference_action_dim = None if reference_action is None else int(reference_action.shape[-1])
+    action = shard.get(ACTION)
+    action_dim = None if action is None else int(action.shape[-1])
+    return int(embeddings.shape[-1]), int(embeddings.shape[1]), reference_action_dim, action_dim
+
+
+@torch.no_grad()
+def _validation_loss(
+    policy: RLTPolicy,
+    cache_dir: Path,
+    shards: list[dict[str, Any]],
+    *,
+    batch_size: int,
+    device: str,
+    max_batches: int | None,
+    skip_zero_embeddings: bool,
+    split_key: str | None = None,
+    allowed_split_values: set[int] | None = None,
+    ranges: list[tuple[dict[str, Any], int, int]] | None = None,
+) -> float | None:
+    if not shards:
+        return None
+
+    was_training = policy.training
+    policy.eval()
+
+    if ranges is None:
+        ranges = (
+            _build_split_ranges(cache_dir, shards, key=split_key, allowed_values=allowed_split_values)
+            if split_key is not None
+            else [(shard_info, 0, None) for shard_info in shards]
+        )
+
+    losses = []
+    batches_seen = 0
+    for shard_info, range_start, range_end in ranges:
+        with safe_open(str(cache_dir / shard_info["file"]), framework="pt", device="cpu") as shard:
+            embeddings_slice = shard.get_slice("vla_embeddings")
+            if range_end is None:
+                range_end = embeddings_slice.get_shape()[0]
+            for start in range(range_start, range_end, batch_size):
+                end = min(start + batch_size, range_end)
+                batch = embeddings_slice[start:end].float().to(device, non_blocking=True)
+                if skip_zero_embeddings:
+                    nonzero = batch.flatten(1).abs().sum(dim=1) > 0
+                    batch = batch[nonzero]
+                    if batch.numel() == 0:
+                        continue
+                z_rl = policy.rl_token_encoder(batch)
+                z_reconstructed = policy.rl_token_decoder(z_rl, batch)
+                losses.append(torch.nn.functional.mse_loss(z_reconstructed, batch).item())
+                batches_seen += 1
+                if max_batches is not None and batches_seen >= max_batches:
+                    if was_training:
+                        policy.train()
+                    return sum(losses) / len(losses)
+
+    if was_training:
+        policy.train()
+    return sum(losses) / len(losses) if losses else None
+
+
+def _split_key(split_by: str) -> str | None:
+    if split_by == "shard":
+        return None
+    if split_by == "episode":
+        return "episode_index"
+    if split_by == "task":
+        return "task_index"
+    raise ValueError(f"Unsupported split mode: {split_by}")
+
+
+def _build_policy_config(
+    *,
+    input_dim: int,
+    action_dim: int,
+    chunk_size: int,
+    device: str,
+    args: argparse.Namespace,
+) -> RLTConfig:
+    rl_token_dim = args.rl_token_dim or input_dim
+    ff_dim = args.ff_dim or rl_token_dim * 4
+    if rl_token_dim % args.num_heads != 0:
+        raise ValueError(f"rl_token_dim={rl_token_dim} must be divisible by num_heads={args.num_heads}.")
+
+    return RLTConfig(
+        input_features={},
+        output_features={ACTION: PolicyFeature(type=FeatureType.ACTION, shape=(action_dim,))},
+        device=device,
+        chunk_size=chunk_size,
+        rl_token=RLTokenConfig(
+            input_dim=input_dim,
+            rl_token_dim=rl_token_dim,
+            num_encoder_layers=args.num_encoder_layers,
+            num_decoder_layers=args.num_decoder_layers,
+            num_heads=args.num_heads,
+            ff_dim=ff_dim,
+            dropout=args.dropout,
+        ),
+        rl_token_lr=args.lr,
+        clip_grad_norm=args.clip_grad_norm,
+    )
+
+
+def _load_or_create_policy(
+    *,
+    policy_cfg: RLTConfig,
+    device: str,
+    resume_policy_path: str | None,
+) -> RLTPolicy:
+    if resume_policy_path is None:
+        return RLTPolicy(policy_cfg).to(device)
+
+    resume_path = Path(resume_policy_path)
+    if not resume_path.exists():
+        raise FileNotFoundError(
+            f"Resume checkpoint does not exist: {resume_path}. "
+            "Use an existing checkpoint-* directory and do not use checkpoint-*.tmp."
+        )
+    if resume_path.name.endswith(".tmp"):
+        raise ValueError(f"Refusing to resume from temporary checkpoint directory: {resume_path}")
+    print(f"Resuming RLTPolicy from {resume_path}", flush=True)
+    policy = RLTPolicy.from_pretrained(resume_path, local_files_only=True, strict=True)
+    policy.config.device = device
+    return policy.to(device)
+
+
+def _save_policy_checkpoint(policy: RLTPolicy, checkpoint_dir: Path) -> None:
+    tmp_dir = checkpoint_dir.with_name(f"{checkpoint_dir.name}.tmp")
+    if tmp_dir.exists():
+        shutil.rmtree(tmp_dir)
+    policy.save_pretrained(tmp_dir)
+    if checkpoint_dir.exists():
+        shutil.rmtree(checkpoint_dir)
+    tmp_dir.rename(checkpoint_dir)
+
+
+def _save_training_metadata(
+    output_dir: Path,
+    *,
+    cache_dir: Path,
+    source_metadata: dict[str, Any],
+    args: argparse.Namespace,
+    input_dim: int,
+    prefix_tokens: int,
+    action_dim: int,
+    chunk_size: int,
+) -> None:
+    metadata = {
+        "format": "lerobot_rlt_token_stage1_v1",
+        "cache_dir": str(cache_dir),
+        "source_cache_format": source_metadata.get("format"),
+        "source_embedding": source_metadata.get("embedding_source"),
+        "start_step": args.start_step,
+        "steps": args.steps,
+        "batch_size": args.batch_size,
+        "lr": args.lr,
+        "val_ratio": args.val_ratio,
+        "val_shards": args.val_shards,
+        "split_by": args.split_by,
+        "sampling_mode": args.sampling_mode,
+        "skip_zero_embeddings": not args.include_zero_embeddings,
+        "val_freq": args.val_freq,
+        "val_max_batches": args.val_max_batches,
+        "input_dim": input_dim,
+        "prefix_tokens": prefix_tokens,
+        "action_dim": action_dim,
+        "rlt_chunk_size": chunk_size,
+    }
+    (output_dir / "rlt_token_training.json").write_text(json.dumps(metadata, indent=2), encoding="utf-8")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--cache-dir", required=True, help="Directory produced by precompute_pi05_rlt_cache.py.")
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--steps", type=int, default=5000)
+    parser.add_argument(
+        "--start-step",
+        type=int,
+        default=0,
+        help="Global step offset for resumed runs. Training runs from start-step + 1 through steps.",
+    )
+    parser.add_argument("--batch-size", type=int, default=64)
+    parser.add_argument("--device", default="cuda")
+    parser.add_argument("--lr", type=float, default=1e-4)
+    parser.add_argument("--rlt-chunk-size", type=int, default=None)
+    parser.add_argument("--action-dim", type=int, default=None)
+    parser.add_argument("--rl-token-dim", type=int, default=None)
+    parser.add_argument("--num-encoder-layers", type=int, default=2)
+    parser.add_argument("--num-decoder-layers", type=int, default=2)
+    parser.add_argument("--num-heads", type=int, default=8)
+    parser.add_argument("--ff-dim", type=int, default=None)
+    parser.add_argument("--dropout", type=float, default=0.0)
+    parser.add_argument("--clip-grad-norm", type=float, default=10.0)
+    parser.add_argument("--log-freq", type=int, default=10)
+    parser.add_argument("--save-freq", type=int, default=1000)
+    parser.add_argument("--val-ratio", type=float, default=0.05)
+    parser.add_argument("--val-shards", type=int, default=None)
+    parser.add_argument(
+        "--split-by",
+        default="shard",
+        choices=["shard", "episode", "task"],
+        help="Validation split unit. Use task only for caches generated with task_index.",
+    )
+    parser.add_argument("--val-freq", type=int, default=100)
+    parser.add_argument("--val-max-batches", type=int, default=64)
+    parser.add_argument(
+        "--sampling-mode",
+        default="episode_block",
+        choices=["episode_block", "global"],
+        help="episode_block consumes one split range at a time; global shuffles all train batches across ranges.",
+    )
+    parser.add_argument(
+        "--split-index-file",
+        default=None,
+        help="Optional cached split/range index JSON. Defaults to <output-dir>/split_index_<split>_<seed>_<val>.json.",
+    )
+    parser.add_argument(
+        "--rebuild-split-index",
+        action="store_true",
+        help="Rebuild the cached split index even if it already exists.",
+    )
+    parser.add_argument(
+        "--resume-policy-path",
+        default=None,
+        help="Optional RLTPolicy checkpoint directory to initialize from.",
+    )
+    parser.add_argument(
+        "--tensorboard-log-dir",
+        default=None,
+        help="Optional TensorBoard log directory. Defaults to <output-dir>/runs when TensorBoard is installed.",
+    )
+    parser.add_argument("--no-tensorboard", action="store_true", help="Disable TensorBoard event writing.")
+    parser.add_argument(
+        "--metrics-file",
+        default=None,
+        help="Optional JSONL metrics path. Defaults to <output-dir>/train_metrics.jsonl.",
+    )
+    parser.add_argument("--no-shuffle", action="store_true")
+    parser.add_argument(
+        "--include-zero-embeddings",
+        action="store_true",
+        help="Train on all-zero embedding rows. By default they are skipped because they usually indicate bad cache rows.",
+    )
+    parser.add_argument("--seed", type=int, default=1000)
+    parser.add_argument("--overwrite", action="store_true")
+    args = parser.parse_args()
+    if args.start_step < 0:
+        raise ValueError(f"--start-step must be non-negative, got {args.start_step}.")
+    if args.start_step >= args.steps:
+        raise ValueError(f"--start-step must be smaller than --steps, got {args.start_step} >= {args.steps}.")
+
+    random.seed(args.seed)
+    torch.manual_seed(args.seed)
+
+    cache_dir = Path(args.cache_dir)
+    output_dir = Path(args.output_dir)
+    if output_dir.exists():
+        if args.resume_policy_path is not None:
+            pass
+        elif not args.overwrite:
+            raise FileExistsError(f"{output_dir} already exists. Pass --overwrite to replace it.")
+        else:
+            shutil.rmtree(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    metrics_path = Path(args.metrics_file) if args.metrics_file is not None else output_dir / "train_metrics.jsonl"
+    metrics_path.parent.mkdir(parents=True, exist_ok=True)
+    tb_log_dir = Path(args.tensorboard_log_dir) if args.tensorboard_log_dir is not None else output_dir / "runs"
+    writer = None if args.no_tensorboard else SummaryWriter(log_dir=str(tb_log_dir)) if SummaryWriter is not None else None
+    if writer is None:
+        print("TensorBoard is not installed; writing JSONL metrics only.", flush=True)
+    else:
+        print(f"Writing TensorBoard logs to {tb_log_dir}", flush=True)
+
+    source_metadata = _load_metadata(cache_dir)
+    shards = source_metadata["shards"]
+    if not shards:
+        raise ValueError(f"No shards listed in {cache_dir / 'metadata.json'}.")
+    split_key = _split_key(args.split_by)
+    train_values = None
+    val_values = None
+    train_ranges = None
+    val_ranges = None
+    if split_key is None:
+        train_shards, val_shards = _split_shards(
+            shards,
+            val_ratio=args.val_ratio,
+            val_shards=args.val_shards,
+            seed=args.seed,
+        )
+    else:
+        train_shards = shards
+        val_shards = shards
+        split_index_file = (
+            Path(args.split_index_file)
+            if args.split_index_file is not None
+            else _split_index_default_path(output_dir, args.split_by, args.seed, args.val_ratio)
+        )
+        train_values, val_values, train_ranges, val_ranges = _load_or_build_split_index(
+            cache_dir,
+            shards,
+            split_by=args.split_by,
+            split_key=split_key,
+            val_ratio=args.val_ratio,
+            seed=args.seed,
+            index_file=split_index_file,
+            rebuild=args.rebuild_split_index,
+        )
+
+    input_dim, prefix_tokens, reference_action_dim, action_dim_from_cache = _read_cache_shapes(cache_dir, shards[0])
+    chunk_size = args.rlt_chunk_size or source_metadata.get("rlt_chunk_size")
+    if chunk_size is None:
+        raise ValueError("Cannot infer RLT chunk size. Pass --rlt-chunk-size.")
+
+    action_dim = args.action_dim
+    if action_dim is None and reference_action_dim is not None:
+        if reference_action_dim % int(chunk_size) != 0:
+            raise ValueError(
+                f"reference_action dim {reference_action_dim} is not divisible by chunk size {chunk_size}."
+            )
+        action_dim = reference_action_dim // int(chunk_size)
+    if action_dim is None and action_dim_from_cache is not None:
+        action_dim = action_dim_from_cache
+    if action_dim is None:
+        raise ValueError("Cannot infer action dim. Pass --action-dim.")
+
+    print(
+        f"Training RLT token with split_by={args.split_by} from "
+        f"{len(train_shards)} train shard(s), {len(val_shards)} val shard(s): "
+        f"prefix_tokens={prefix_tokens}, input_dim={input_dim}, action_dim={action_dim}, chunk_size={chunk_size}",
+        flush=True,
+    )
+    if split_key is not None:
+        print(
+            f"Train {split_key} values={len(train_values or [])}, val {split_key} values={len(val_values or [])}",
+            flush=True,
+        )
+    print(f"Sampling mode: {args.sampling_mode}", flush=True)
+    if not args.include_zero_embeddings:
+        print("Skipping all-zero vla_embeddings rows during train/validation.", flush=True)
+
+    policy_cfg = _build_policy_config(
+        input_dim=input_dim,
+        action_dim=action_dim,
+        chunk_size=int(chunk_size),
+        device=args.device,
+        args=args,
+    )
+    policy = _load_or_create_policy(
+        policy_cfg=policy_cfg,
+        device=args.device,
+        resume_policy_path=args.resume_policy_path,
+    )
+    policy.train()
+
+    algorithm_cfg = RLTAlgorithmConfig.from_policy_config(policy_cfg)
+    algorithm = algorithm_cfg.build_algorithm(policy)
+    algorithm.make_optimizers()
+
+    batch_iterator = RLTCacheBatchIterator(
+        cache_dir,
+        train_shards,
+        batch_size=args.batch_size,
+        device=args.device,
+        shuffle=not args.no_shuffle,
+        skip_zero_embeddings=not args.include_zero_embeddings,
+        sampling_mode=args.sampling_mode,
+        split_key=split_key,
+        allowed_split_values=train_values,
+        ranges=train_ranges,
+    )
+
+    for step in range(args.start_step + 1, args.steps + 1):
+        stats = algorithm.offline_update(batch_iterator)
+        loss = stats.losses["loss_rl_token"]
+        if writer is not None:
+            writer.add_scalar("train/loss_rl_token", loss, step)
+
+        if step == 1 or step % args.log_freq == 0:
+            print(f"step {step}/{args.steps} loss_rl_token={loss:.6f}", flush=True)
+            with metrics_path.open("a", encoding="utf-8") as f:
+                f.write(json.dumps({"step": step, "loss_rl_token": loss, "split": "train"}) + "\n")
+
+        if val_shards and args.val_freq > 0 and step % args.val_freq == 0:
+            val_loss = _validation_loss(
+                policy,
+                cache_dir,
+                val_shards,
+                batch_size=args.batch_size,
+                device=args.device,
+                max_batches=args.val_max_batches,
+                skip_zero_embeddings=not args.include_zero_embeddings,
+                split_key=split_key,
+                allowed_split_values=val_values,
+                ranges=val_ranges,
+            )
+            if val_loss is not None:
+                if writer is not None:
+                    writer.add_scalar("val/loss_rl_token", val_loss, step)
+                print(f"step {step}/{args.steps} val_loss_rl_token={val_loss:.6f}", flush=True)
+                with metrics_path.open("a", encoding="utf-8") as f:
+                    f.write(json.dumps({"step": step, "loss_rl_token": val_loss, "split": "val"}) + "\n")
+
+        if args.save_freq > 0 and step % args.save_freq == 0:
+            checkpoint_dir = output_dir / f"checkpoint-{step:06d}"
+            _save_policy_checkpoint(policy, checkpoint_dir)
+
+    policy.save_pretrained(output_dir)
+    if writer is not None:
+        writer.close()
+    _save_training_metadata(
+        output_dir,
+        cache_dir=cache_dir,
+        source_metadata=source_metadata,
+        args=args,
+        input_dim=input_dim,
+        prefix_tokens=prefix_tokens,
+        action_dim=action_dim,
+        chunk_size=int(chunk_size),
+    )
+    print(f"Saved trained RLT token policy to {output_dir}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/lerobot/envs/libero.py
+++ b/src/lerobot/envs/libero.py
@@ -57,7 +57,7 @@ def _get_suite(name: str) -> benchmark.Benchmark:
 
 
 def _select_task_ids(total_tasks: int, task_ids: Iterable[int] | None) -> list[int]:
-    """Validate/normalize task ids. If None → all tasks."""
+    """Validate and normalize task ids. If ``None``, select all tasks."""
     if task_ids is None:
         return list(range(total_tasks))
     ids = sorted({int(t) for t in task_ids})
@@ -240,6 +240,9 @@ class LiberoEnv(gym.Env):
         }
         env = OffScreenRenderEnv(**env_args)
         env.reset()
+        language_instruction = getattr(env, "language_instruction", None)
+        if language_instruction:
+            self.task_description = str(language_instruction)
         return env
 
     def _format_raw_obs(self, raw_obs: RobotObservation) -> RobotObservation:
@@ -325,7 +328,27 @@ class LiberoEnv(gym.Env):
                 f"Expected action to be 1-D (shape (action_dim,)), "
                 f"but got shape {action.shape} with ndim={action.ndim}"
             )
-        raw_obs, reward, done, info = self._env.step(action)
+        try:
+            raw_obs, reward, done, info = self._env.step(action)
+        except ValueError as exc:
+            if "terminated episode" not in str(exc):
+                raise
+            observation, reset_info = self.reset()
+            info = {
+                **reset_info,
+                "task": self.task,
+                "task_id": self.task_id,
+                "done": True,
+                "is_success": False,
+                "final_info": {
+                    "task": self.task,
+                    "task_id": self.task_id,
+                    "done": True,
+                    "is_success": False,
+                    "auto_reset_after_terminated_step": True,
+                },
+            }
+            return observation, 0.0, True, False, info
 
         is_success = self._env.check_success()
         terminated = done or is_success

--- a/src/lerobot/policies/pi05/configuration_pi05.py
+++ b/src/lerobot/policies/pi05/configuration_pi05.py
@@ -31,7 +31,7 @@ DEFAULT_IMAGE_SIZE = 224
 class PI05Config(PreTrainedConfig):
     paligemma_variant: str = "gemma_2b"
     action_expert_variant: str = "gemma_300m"
-    dtype: str = "float32"  # Options: "bfloat16", "float32"
+    dtype: str = "float32"  # Options: "bfloat16", "float16", "float32"
 
     n_obs_steps: int = 1
     chunk_size: int = 50  # Number of action steps to predict, in openpi called "action_horizon"
@@ -61,6 +61,7 @@ class PI05Config(PreTrainedConfig):
     # Add empty images. Used to add empty cameras when no image features are present.
     empty_cameras: int = 0
 
+    tokenizer_name: str = "google/paligemma-3b-pt-224"
     tokenizer_max_length: int = 200  # see openpi `__post_init__`
 
     normalization_mapping: dict[str, NormalizationMode] = field(
@@ -112,7 +113,7 @@ class PI05Config(PreTrainedConfig):
         if self.action_expert_variant not in ["gemma_300m", "gemma_2b"]:
             raise ValueError(f"Invalid action_expert_variant: {self.action_expert_variant}")
 
-        if self.dtype not in ["bfloat16", "float32"]:
+        if self.dtype not in ["bfloat16", "float16", "float32"]:
             raise ValueError(f"Invalid dtype: {self.dtype}")
 
     def validate_features(self) -> None:

--- a/src/lerobot/policies/pi05/modeling_pi05.py
+++ b/src/lerobot/policies/pi05/modeling_pi05.py
@@ -278,9 +278,9 @@ def compute_layer_complete(
         out_emb = modeling_gemma._gated_residual(hidden_states, out_emb, gates[i])  # noqa: SLF001
         after_first_residual = out_emb.clone()
         out_emb, gate = layer.post_attention_layernorm(out_emb, cond=adarms_cond[i])
-        # Convert to bfloat16 if the next layer (mlp) uses bfloat16
-        if layer.mlp.up_proj.weight.dtype == torch.bfloat16:
-            out_emb = out_emb.to(dtype=torch.bfloat16)
+        mlp_dtype = layer.mlp.up_proj.weight.dtype
+        if out_emb.dtype != mlp_dtype:
+            out_emb = out_emb.to(dtype=mlp_dtype)
         out_emb = layer.mlp(out_emb)
         # second residual
         out_emb = modeling_gemma._gated_residual(after_first_residual, out_emb, gate)  # noqa: SLF001
@@ -335,7 +335,7 @@ class PaliGemmaWithExpertModel(
         vlm_config,
         action_expert_config,
         use_adarms=None,
-        precision: Literal["bfloat16", "float32"] = "bfloat16",
+        precision: Literal["bfloat16", "float16", "float32"] = "bfloat16",
         image_size: int = DEFAULT_IMAGE_SIZE,
         freeze_vision_encoder: bool = False,
         train_expert_only: bool = False,
@@ -384,12 +384,17 @@ class PaliGemmaWithExpertModel(
         self.gemma_expert = GemmaForCausalLM(config=action_expert_config_hf)
         self.gemma_expert.model.embed_tokens = None
 
-        self.to_bfloat16_for_selected_params(precision)
+        self.to_low_precision_for_selected_params(precision)
         self._set_requires_grad()
 
-    def to_bfloat16_for_selected_params(self, precision: Literal["bfloat16", "float32"] = "bfloat16"):
+    def to_low_precision_for_selected_params(
+        self,
+        precision: Literal["bfloat16", "float16", "float32"] = "bfloat16",
+    ):
         if precision == "bfloat16":
             self.to(dtype=torch.bfloat16)
+        elif precision == "float16":
+            self.to(dtype=torch.float16)
         elif precision == "float32":
             self.to(dtype=torch.float32)
             return
@@ -679,6 +684,9 @@ class PI05Pytorch(nn.Module):  # see openpi `PI0Pytorch`
         embs = []
         pad_masks = []
         att_masks = []
+        action_proj_dtype = self.action_in_proj.weight.dtype
+        time_mlp_dtype = self.time_mlp_in.weight.dtype
+        noisy_actions = noisy_actions.to(dtype=action_proj_dtype)
 
         # Embed timestep using sine-cosine positional encoding
         time_emb = create_sinusoidal_pos_embedding(
@@ -688,7 +696,7 @@ class PI05Pytorch(nn.Module):  # see openpi `PI0Pytorch`
             max_period=self.config.max_period,
             device=timestep.device,
         )
-        time_emb = time_emb.type(dtype=timestep.dtype)
+        time_emb = time_emb.to(dtype=time_mlp_dtype)
 
         # Fuse timestep + action information using an MLP
         def action_proj_func(noisy_actions):
@@ -736,12 +744,12 @@ class PI05Pytorch(nn.Module):  # see openpi `PI0Pytorch`
         prefix_embs, prefix_pad_masks, prefix_att_masks = self.embed_prefix(images, img_masks, tokens, masks)
         suffix_embs, suffix_pad_masks, suffix_att_masks, adarms_cond = self.embed_suffix(x_t, time)
 
-        if (
+        prefix_dtype = (
             self.paligemma_with_expert.paligemma.language_model.layers[0].self_attn.q_proj.weight.dtype
-            == torch.bfloat16
-        ):
-            suffix_embs = suffix_embs.to(dtype=torch.bfloat16)
-            prefix_embs = prefix_embs.to(dtype=torch.bfloat16)
+        )
+        if prefix_dtype != torch.float32:
+            suffix_embs = suffix_embs.to(dtype=prefix_dtype)
+            prefix_embs = prefix_embs.to(dtype=prefix_dtype)
 
         pad_masks = torch.cat([prefix_pad_masks, suffix_pad_masks], dim=1)
         att_masks = torch.cat([prefix_att_masks, suffix_att_masks], dim=1)
@@ -991,7 +999,7 @@ class PI05Policy(PreTrainedPolicy):
                 from safetensors.torch import load_file
 
                 original_state_dict = load_file(resolved_file)
-                print("✓ Loaded state dict from model.safetensors")
+                print("Loaded state dict from model.safetensors")
             except Exception as e:
                 print(f"Could not load state dict from remote files: {e}")
                 print("Returning model without loading pretrained weights")

--- a/src/lerobot/policies/pi05/processor_pi05.py
+++ b/src/lerobot/policies/pi05/processor_pi05.py
@@ -65,7 +65,7 @@ class Pi05PrepareStateTokenizerProcessorStep(ProcessorStep):
         if tasks is None:
             raise ValueError("No task found in complementary data")
 
-        # TODO: check if this necessary
+        # Keep the input transition immutable while padding the state.
         state = deepcopy(state)
 
         # Prepare state (pad to max_state_dim)
@@ -142,7 +142,7 @@ def make_pi05_pre_post_processors(
         ),
         Pi05PrepareStateTokenizerProcessorStep(max_state_dim=config.max_state_dim),
         TokenizerProcessorStep(
-            tokenizer_name="google/paligemma-3b-pt-224",
+            tokenizer_name=config.tokenizer_name,
             max_length=config.tokenizer_max_length,
             padding_side="right",
             padding="max_length",

--- a/src/lerobot/policies/rlt/__init__.py
+++ b/src/lerobot/policies/rlt/__init__.py
@@ -14,5 +14,6 @@
 
 from lerobot.policies.rlt.configuration_rlt import RLTConfig
 from lerobot.policies.rlt.modeling_rlt import RLTPolicy
+from lerobot.policies.rlt.vla_adapter import PI05PrefixRLTAdapter
 
-__all__ = ["RLTConfig", "RLTPolicy"]
+__all__ = ["PI05PrefixRLTAdapter", "RLTConfig", "RLTPolicy"]

--- a/src/lerobot/policies/rlt/configuration_rlt.py
+++ b/src/lerobot/policies/rlt/configuration_rlt.py
@@ -46,6 +46,8 @@ class RLTActorConfig:
 
     hidden_dims: list[int] = field(default_factory=lambda: [256, 256])
     std: float = 0.1
+    residual_scale: float = 0.1
+    clamp_output: bool = False
 
 
 @dataclass
@@ -84,25 +86,25 @@ class RLTConfig(PreTrainedConfig):
         }
     )
 
-    # ── Device ──
+    # Device
     device: str = "cuda"
     storage_device: str = "cpu"
 
-    # ── VLA backbone ──
+    # VLA backbone
     vla_checkpoint: str | None = None
 
-    # ── RL-token ──
+    # RL-token
     rl_token: RLTokenConfig = field(default_factory=RLTokenConfig)
 
-    # ── Actor / Critic heads ──
+    # Actor and critic heads
     actor: RLTActorConfig = field(default_factory=RLTActorConfig)
     critic: RLTCriticConfig = field(default_factory=RLTCriticConfig)
 
-    # ── Action chunks ──
+    # Action chunks
     chunk_size: int = 10
     vla_chunk_size: int = 50
 
-    # ── Training parameters ──
+    # Training parameters
     online_steps: int = 50000
     offline_steps: int = 5000
     online_buffer_capacity: int = 100000
@@ -111,7 +113,7 @@ class RLTConfig(PreTrainedConfig):
     warmup_steps: int = 500
     async_prefetch: bool = False
 
-    # ── Algorithm hyperparameters ──
+    # Algorithm hyperparameters
     utd_ratio: int = 5
     policy_update_freq: int = 2
     discount: float = 0.99
@@ -126,7 +128,7 @@ class RLTConfig(PreTrainedConfig):
     chunk_stride: int = 2
     vla_finetune_weight: float = 0.0
 
-    # ── Distributed ──
+    # Distributed
     actor_learner_config: ActorLearnerConfig = field(default_factory=ActorLearnerConfig)
     concurrency: ConcurrencyConfig = field(default_factory=ConcurrencyConfig)
 

--- a/src/lerobot/policies/rlt/modeling_rlt.py
+++ b/src/lerobot/policies/rlt/modeling_rlt.py
@@ -34,8 +34,13 @@ from torch import Tensor
 
 from lerobot.policies.pretrained import PreTrainedPolicy
 from lerobot.policies.rlt.configuration_rlt import RLTConfig
+from lerobot.policies.rlt.vla_adapter import (
+    OBS_REFERENCE_ACTION,
+    OBS_RLT_STATE,
+    OBS_VLA_EMBEDDINGS,
+)
 
-# ── Building blocks ──────────────────────────────────────────────────
+# Building blocks
 
 
 class MLP(nn.Module):
@@ -56,7 +61,7 @@ class MLP(nn.Module):
         return self.net(x)
 
 
-# ── RL Token Encoder ─────────────────────────────────────────────────
+# RL-token encoder
 
 
 class RLTokenEncoder(nn.Module):
@@ -114,7 +119,7 @@ class RLTokenEncoder(nn.Module):
         return z_rl
 
 
-# ── RL Token Decoder ─────────────────────────────────────────────────
+# RL-token decoder
 
 
 class RLTokenDecoder(nn.Module):
@@ -176,7 +181,7 @@ class RLTokenDecoder(nn.Module):
         return self.output_head(decoded)  # (B, M, D)
 
 
-# ── Actor ────────────────────────────────────────────────────────────
+# Actor
 
 
 class RLTActor(nn.Module):
@@ -188,11 +193,21 @@ class RLTActor(nn.Module):
     chunk, acting as a "VLA-guided action editor".
     """
 
-    def __init__(self, state_dim: int, action_chunk_dim: int, hidden_dims: list[int], std: float = 0.1):
+    def __init__(
+        self,
+        state_dim: int,
+        action_chunk_dim: int,
+        hidden_dims: list[int],
+        std: float = 0.1,
+        residual_scale: float = 0.1,
+        clamp_output: bool = False,
+    ):
         super().__init__()
         input_dim = state_dim + action_chunk_dim
         self.net = MLP(input_dim, hidden_dims, action_chunk_dim)
         self.log_std = math.log(std)
+        self.residual_scale = residual_scale
+        self.clamp_output = clamp_output
 
     def forward(self, state: Tensor, ref_action_chunk: Tensor) -> Tensor:
         """Return the mean action chunk.
@@ -205,7 +220,11 @@ class RLTActor(nn.Module):
             Refined action chunk (mean), shape ``(B, C*d)``.
         """
         x = torch.cat([state, ref_action_chunk], dim=-1)
-        return self.net(x)
+        residual = torch.tanh(self.net(x)) * self.residual_scale
+        action = ref_action_chunk + residual
+        if self.clamp_output:
+            action = action.clamp(-1.0, 1.0)
+        return action
 
     def sample(self, state: Tensor, ref_action_chunk: Tensor) -> tuple[Tensor, Tensor]:
         """Sample an action and return (action, log_prob)."""
@@ -219,11 +238,11 @@ class RLTActor(nn.Module):
         return action, log_prob
 
 
-# ── Policy (inference bundle) ────────────────────────────────────────
+# Policy inference bundle
 
 
 class RLTPolicy(PreTrainedPolicy):
-    """RLT policy — bundles the RL-token encoder and actor for inference.
+    """RLT policy that bundles the RL-token encoder and actor for inference.
 
     The frozen VLA backbone is **not** part of this module; it is loaded
     separately and its embeddings / reference actions are passed in via the
@@ -271,6 +290,8 @@ class RLTPolicy(PreTrainedPolicy):
             action_chunk_dim=action_chunk_dim,
             hidden_dims=config.actor.hidden_dims,
             std=config.actor.std,
+            residual_scale=config.actor.residual_scale,
+            clamp_output=config.actor.clamp_output,
         )
 
         self._action_dim = action_dim
@@ -283,7 +304,7 @@ class RLTPolicy(PreTrainedPolicy):
         """Select a refined action chunk given an observation.
 
         Expects the observation dict to contain:
-          - ``"observation.vla_embeddings"``: VLA internal token embeddings ``(M, D)``
+          - ``"observation.vla_embeddings"`` or ``"observation.rlt_state"``
           - ``"observation.reference_action"``: VLA reference chunk ``(C*d,)``
           - ``"observation.state"`` (optional): proprioceptive state ``(P,)``
 
@@ -292,11 +313,15 @@ class RLTPolicy(PreTrainedPolicy):
         """
         self.eval()
 
-        vla_emb = batch["observation.vla_embeddings"]
-        if vla_emb.dim() == 2:
-            vla_emb = vla_emb.unsqueeze(0)
-
-        z_rl = self.rl_token_encoder(vla_emb)  # (1, D_rl)
+        if OBS_RLT_STATE in batch:
+            z_rl = batch[OBS_RLT_STATE]
+            if z_rl.dim() == 1:
+                z_rl = z_rl.unsqueeze(0)
+        else:
+            vla_emb = batch[OBS_VLA_EMBEDDINGS]
+            if vla_emb.dim() == 2:
+                vla_emb = vla_emb.unsqueeze(0)
+            z_rl = self.rl_token_encoder(vla_emb)  # (1, D_rl)
 
         parts = [z_rl]
         if "observation.state" in batch and self._proprioception_dim > 0:
@@ -307,12 +332,26 @@ class RLTPolicy(PreTrainedPolicy):
 
         state = torch.cat(parts, dim=-1)
 
-        ref = batch["observation.reference_action"]
+        ref = batch[OBS_REFERENCE_ACTION]
         if ref.dim() == 1:
             ref = ref.unsqueeze(0)
 
         action = self.actor(state, ref)
         return action.squeeze(0)
+
+    def predict_action_chunk(self, batch: dict[str, Tensor], **kwargs) -> Tensor:
+        """Return the flattened action chunk produced by the RLT actor."""
+        del kwargs
+        return self.select_action(batch)
+
+    def forward(self, batch: dict[str, Tensor]) -> tuple[Tensor, dict | None]:
+        """RLT is trained through ``RLTAlgorithm`` rather than policy ``forward``."""
+        del batch
+        raise NotImplementedError("Use RLTAlgorithm.offline_update/update to train RLTPolicy.")
+
+    def get_optim_params(self) -> dict:
+        """Return policy parameters for generic optimizer builders."""
+        return {"params": self.parameters()}
 
     def reset(self):
         pass

--- a/src/lerobot/policies/rlt/vla_adapter.py
+++ b/src/lerobot/policies/rlt/vla_adapter.py
@@ -1,0 +1,119 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""VLA adapters for RLT.
+
+The RLT policy expects VLA-derived observations:
+  - ``observation.vla_embeddings``
+  - ``observation.reference_action``
+  - ``observation.rlt_state`` (optional, compact online replay state)
+
+This module provides a minimal PI0.5 adapter that uses
+``PI05Pytorch.embed_prefix`` as the VLA embedding source.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+from torch import Tensor
+
+from lerobot.utils.constants import OBS_LANGUAGE_ATTENTION_MASK, OBS_LANGUAGE_TOKENS
+
+if TYPE_CHECKING:
+    from lerobot.policies.pi05.modeling_pi05 import PI05Policy
+
+OBS_VLA_EMBEDDINGS = "observation.vla_embeddings"
+OBS_REFERENCE_ACTION = "observation.reference_action"
+OBS_RLT_STATE = "observation.rlt_state"
+
+
+class PI05PrefixRLTAdapter:
+    """Populate RLT observation fields from a frozen PI0.5 policy.
+
+    This adapter is intentionally shallow: it extracts the concatenated image
+    and language prefix embeddings before the PaliGemma transformer. That makes
+    it a small integration point for the RLT data path.
+    """
+
+    def __init__(self, pi05_policy: PI05Policy, rlt_chunk_size: int):
+        self.pi05 = pi05_policy.eval()
+        self.rlt_chunk_size = rlt_chunk_size
+
+        for param in self.pi05.parameters():
+            param.requires_grad_(False)
+
+    @torch.no_grad()
+    def __call__(self, batch: dict[str, Tensor]) -> dict[str, Tensor]:
+        """Return a copy of ``batch`` enriched with RLT VLA fields.
+
+        Args:
+            batch: A batch already prepared for PI0.5 inference. It must contain
+                image features plus ``observation.language.tokens`` and
+                ``observation.language.attention_mask``.
+
+        Returns:
+            Batch copy with ``observation.vla_embeddings`` and flattened
+            ``observation.reference_action`` fields added.
+        """
+        batch = dict(batch)
+
+        images, img_masks = self.pi05._preprocess_images(batch)
+        tokens = batch[OBS_LANGUAGE_TOKENS]
+        masks = batch[OBS_LANGUAGE_ATTENTION_MASK]
+
+        prefix_embs, _, _ = self.pi05.model.embed_prefix(images, img_masks, tokens, masks)
+        ref_actions = self.pi05.predict_action_chunk(batch)
+
+        if ref_actions.shape[1] < self.rlt_chunk_size:
+            raise ValueError(
+                f"PI0.5 reference action chunk has length {ref_actions.shape[1]}, "
+                f"but RLT requires {self.rlt_chunk_size}."
+            )
+
+        ref_actions = ref_actions[:, : self.rlt_chunk_size]
+        ref_actions = ref_actions.reshape(ref_actions.shape[0], -1)
+
+        batch[OBS_VLA_EMBEDDINGS] = prefix_embs
+        batch[OBS_REFERENCE_ACTION] = ref_actions
+        return batch
+
+    @staticmethod
+    def add_reference_action_to_complementary_info(batch: dict[str, Tensor]) -> dict[str, Tensor]:
+        """Build complementary info expected by the current RLT algorithm.
+
+        ``RLTPolicy.select_action`` reads ``observation.reference_action`` while
+        ``RLTAlgorithm`` currently reads ``complementary_info["reference_action"]``.
+        This helper bridges that mismatch until the interface is unified.
+        """
+        if OBS_REFERENCE_ACTION not in batch:
+            raise KeyError(f"Missing {OBS_REFERENCE_ACTION}; run PI05PrefixRLTAdapter first.")
+        return {"reference_action": batch[OBS_REFERENCE_ACTION]}
+
+    @staticmethod
+    def unflatten_action_chunk(action_chunk: Tensor, action_dim: int) -> Tensor:
+        """Convert RLT's flattened action chunk to ``(B, C, action_dim)``."""
+        if action_chunk.dim() == 1:
+            action_chunk = action_chunk.unsqueeze(0)
+        return action_chunk.reshape(action_chunk.shape[0], -1, action_dim)
+
+    @staticmethod
+    def flatten_action_chunk(action_chunk: Tensor) -> Tensor:
+        """Convert ``(B, C, action_dim)`` action chunks to RLT's flat format."""
+        if action_chunk.dim() == 1:
+            return action_chunk.unsqueeze(0)
+        if action_chunk.dim() == 2:
+            action_chunk = action_chunk.unsqueeze(0)
+        return action_chunk.reshape(action_chunk.shape[0], -1)

--- a/src/lerobot/rl/algorithms/rlt/configuration_rlt.py
+++ b/src/lerobot/rl/algorithms/rlt/configuration_rlt.py
@@ -31,30 +31,30 @@ if TYPE_CHECKING:
 class RLTAlgorithmConfig(RLAlgorithmConfig):
     """RLT-specific hyper-parameters that control the update loop."""
 
-    # ── Action chunks ──
+    # Action chunks
     chunk_size: int = 10
     chunk_stride: int = 2
 
-    # ── Update cadence ──
+    # Update cadence
     utd_ratio: int = 5
     policy_update_freq: int = 2
     clip_grad_norm: float = 10.0
 
-    # ── Learning rates ──
+    # Learning rates
     actor_lr: float = 3e-4
     critic_lr: float = 3e-4
     rl_token_lr: float = 1e-4
 
-    # ── TD learning ──
+    # TD learning
     discount: float = 0.99
     tau: float = 0.005
     num_critics: int = 2
 
-    # ── Policy constraint (paper Eq. 5) ──
+    # Policy constraint (paper Eq. 5)
     bc_reg_coeff: float = 0.1
     ref_dropout: float = 0.5
 
-    # ── Offline RL-token training ──
+    # Offline RL-token training
     vla_finetune_weight: float = 0.0
 
     @classmethod

--- a/src/lerobot/rl/algorithms/rlt/rlt_algorithm.py
+++ b/src/lerobot/rl/algorithms/rlt/rlt_algorithm.py
@@ -34,6 +34,7 @@ from torch import Tensor
 from torch.optim import Optimizer
 
 from lerobot.policies.rlt.modeling_rlt import MLP, RLTPolicy
+from lerobot.policies.rlt.vla_adapter import OBS_RLT_STATE, OBS_VLA_EMBEDDINGS
 from lerobot.policies.utils import get_device_from_parameters
 from lerobot.rl.algorithms.base import (
     BatchType,
@@ -49,7 +50,7 @@ class RLTCritic(nn.Module):
 
     Paper Eq. 3: Q_psi(x, a_{1:C})
 
-    Training-only component — lives on the algorithm side, not in the policy.
+    Training-only component that lives on the algorithm side, not in the policy.
     """
 
     def __init__(self, state_dim: int, action_chunk_dim: int, hidden_dims: list[int]):
@@ -80,7 +81,7 @@ class RLTAlgorithm(RLAlgorithm):
         self._init_critics()
         self._move_to_device()
 
-    # ── Initialization ───────────────────────────────────────────────
+    # Initialization
 
     def _init_critics(self) -> None:
         state_dim = self.policy._state_dim
@@ -98,7 +99,7 @@ class RLTAlgorithm(RLAlgorithm):
         self.critics.to(self._device)
         self.critic_targets.to(self._device)
 
-    # ── Offline phase (Stage 1): RL-token training ───────────────────
+    # Offline phase (Stage 1): RL-token training
 
     def supports_offline_phase(self) -> bool:
         return True
@@ -110,7 +111,7 @@ class RLTAlgorithm(RLAlgorithm):
         """
         batch = next(batch_iterator)
 
-        vla_embeddings = batch["state"]["observation.vla_embeddings"].to(self._device)
+        vla_embeddings = batch["state"][OBS_VLA_EMBEDDINGS].to(self._device)
         z_vla = vla_embeddings.detach()  # stop-gradient on VLA embeddings
 
         z_rl = self.policy.rl_token_encoder(z_vla)
@@ -133,6 +134,8 @@ class RLTAlgorithm(RLAlgorithm):
         """Freeze RL-token modules; rebuild optimizers for actor-critic only."""
         self.policy.rl_token_encoder.requires_grad_(False)
         self.policy.rl_token_decoder.requires_grad_(False)
+        self.policy.rl_token_encoder.eval()
+        self.policy.rl_token_decoder.eval()
         self._is_online = True
 
         self.optimizers = {
@@ -141,7 +144,7 @@ class RLTAlgorithm(RLAlgorithm):
         }
         self._optimization_step = 0
 
-    # ── Online phase (Stage 2): Actor-Critic ─────────────────────────
+    # Online phase (Stage 2): actor-critic training
 
     def update(self, batch_iterator: Iterator[BatchType]) -> TrainingStats:
         """One full RLT update step with UTD critic warm-up.
@@ -174,19 +177,23 @@ class RLTAlgorithm(RLAlgorithm):
     def _prepare_forward_batch(self, batch: BatchType) -> dict[str, Any]:
         """Convert a replay batch into algorithm-ready tensors.
 
-        Extracts RL-token from VLA embeddings, builds RL state, reads
+        Extracts or reads RL-token state, builds RL state, reads
         reference action from complementary_info.
         """
         obs = batch["state"]
         next_obs = batch["next_state"]
         device = self._device
 
-        vla_emb = obs["observation.vla_embeddings"].to(device)
-        next_vla_emb = next_obs["observation.vla_embeddings"].to(device)
+        if OBS_RLT_STATE in obs and OBS_RLT_STATE in next_obs:
+            z_rl = obs[OBS_RLT_STATE].to(device).detach()
+            z_rl_next = next_obs[OBS_RLT_STATE].to(device).detach()
+        else:
+            vla_emb = obs[OBS_VLA_EMBEDDINGS].to(device)
+            next_vla_emb = next_obs[OBS_VLA_EMBEDDINGS].to(device)
 
-        with torch.no_grad():
-            z_rl = self.policy.rl_token_encoder(vla_emb)
-            z_rl_next = self.policy.rl_token_encoder(next_vla_emb)
+            with torch.no_grad():
+                z_rl = self.policy.rl_token_encoder(vla_emb)
+                z_rl_next = self.policy.rl_token_encoder(next_vla_emb)
 
         parts = [z_rl]
         next_parts = [z_rl_next]
@@ -204,9 +211,12 @@ class RLTAlgorithm(RLAlgorithm):
         done = batch["done"].to(device)
 
         ref_action = None
+        next_ref_action = None
         comp_info = batch.get("complementary_info")
         if comp_info is not None and "reference_action" in comp_info:
             ref_action = comp_info["reference_action"].to(device)
+        if comp_info is not None and "next_reference_action" in comp_info:
+            next_ref_action = comp_info["next_reference_action"].to(device)
 
         return {
             "state": state,
@@ -215,6 +225,7 @@ class RLTAlgorithm(RLAlgorithm):
             "reward": reward,
             "done": done,
             "reference_action": ref_action,
+            "next_reference_action": next_ref_action,
         }
 
     def _critic_step(self, fb: dict[str, Any]) -> float:
@@ -226,7 +237,9 @@ class RLTAlgorithm(RLAlgorithm):
         done = fb["done"]
 
         with torch.no_grad():
-            ref = fb.get("reference_action")
+            ref = fb.get("next_reference_action")
+            if ref is None:
+                ref = fb.get("reference_action")
             if ref is None:
                 ref = torch.zeros_like(action)
             next_action = self.policy.actor(next_state, ref)
@@ -282,7 +295,7 @@ class RLTAlgorithm(RLAlgorithm):
             for p, tp in zip(critic.parameters(), target.parameters(), strict=True):
                 tp.data.copy_(tau * p.data + (1 - tau) * tp.data)
 
-    # ── Optimizer management ─────────────────────────────────────────
+    # Optimizer management
 
     def make_optimizers(self) -> dict[str, Optimizer]:
         """Create optimizers. Initially for RL-token (Stage 1)."""
@@ -300,7 +313,7 @@ class RLTAlgorithm(RLAlgorithm):
     def get_optimizers(self) -> dict[str, Optimizer]:
         return self.optimizers
 
-    # ── Weight sync ──────────────────────────────────────────────────
+    # Weight sync
 
     def get_weights(self) -> dict[str, Any]:
         """Push actor + RL-token encoder to actors (small footprint)."""

--- a/tests/policies/rlt/test_rlt_policy.py
+++ b/tests/policies/rlt/test_rlt_policy.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+
+from lerobot.configs.types import FeatureType, PolicyFeature
+from lerobot.policies.rlt.configuration_rlt import RLTActorConfig, RLTConfig, RLTokenConfig
+from lerobot.policies.rlt.modeling_rlt import RLTPolicy
+from lerobot.policies.rlt.vla_adapter import (
+    OBS_REFERENCE_ACTION,
+    OBS_RLT_STATE,
+    OBS_VLA_EMBEDDINGS,
+    PI05PrefixRLTAdapter,
+)
+from lerobot.utils.constants import ACTION, OBS_STATE
+
+
+def _make_rlt_config() -> RLTConfig:
+    return RLTConfig(
+        input_features={OBS_STATE: PolicyFeature(type=FeatureType.STATE, shape=(3,))},
+        output_features={ACTION: PolicyFeature(type=FeatureType.ACTION, shape=(2,))},
+        device="cpu",
+        chunk_size=3,
+        rl_token=RLTokenConfig(
+            input_dim=4,
+            rl_token_dim=4,
+            num_encoder_layers=1,
+            num_decoder_layers=1,
+            num_heads=2,
+            ff_dim=8,
+            dropout=0.0,
+        ),
+        actor=RLTActorConfig(hidden_dims=[8], residual_scale=0.25, clamp_output=False),
+    )
+
+
+def test_rlt_policy_accepts_compact_rlt_state_and_reference_action():
+    policy = RLTPolicy(_make_rlt_config())
+    for param in policy.actor.net.parameters():
+        param.data.zero_()
+
+    reference_action = torch.linspace(-0.5, 0.5, policy._action_chunk_dim)
+    action = policy.select_action(
+        {
+            OBS_RLT_STATE: torch.ones(policy.config.rl_token.rl_token_dim),
+            OBS_REFERENCE_ACTION: reference_action,
+            OBS_STATE: torch.zeros(3),
+        }
+    )
+
+    assert action.shape == reference_action.shape
+    assert torch.allclose(action, reference_action)
+
+
+def test_rlt_policy_can_encode_vla_embeddings_when_no_compact_state_is_present():
+    policy = RLTPolicy(_make_rlt_config())
+
+    action = policy.select_action(
+        {
+            OBS_VLA_EMBEDDINGS: torch.randn(5, policy.config.rl_token.input_dim),
+            OBS_REFERENCE_ACTION: torch.zeros(policy._action_chunk_dim),
+            OBS_STATE: torch.zeros(3),
+        }
+    )
+
+    assert action.shape == (policy._action_chunk_dim,)
+
+
+def test_flatten_action_chunk_handles_single_flat_chunk():
+    flat_chunk = torch.arange(6)
+    assert PI05PrefixRLTAdapter.flatten_action_chunk(flat_chunk).shape == (1, 6)
+
+    unbatched_chunk = torch.arange(6).reshape(3, 2)
+    assert torch.equal(PI05PrefixRLTAdapter.flatten_action_chunk(unbatched_chunk), flat_chunk.unsqueeze(0))

--- a/tests/rl/test_rlt_algorithm.py
+++ b/tests/rl/test_rlt_algorithm.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import itertools
+
+import torch
+
+from lerobot.configs.types import FeatureType, PolicyFeature
+from lerobot.policies.rlt.configuration_rlt import RLTActorConfig, RLTConfig, RLTokenConfig
+from lerobot.policies.rlt.modeling_rlt import RLTPolicy
+from lerobot.policies.rlt.vla_adapter import OBS_RLT_STATE
+from lerobot.rl.algorithms.rlt.configuration_rlt import RLTAlgorithmConfig
+from lerobot.utils.constants import ACTION, OBS_STATE
+
+
+def _make_rlt_policy() -> RLTPolicy:
+    config = RLTConfig(
+        input_features={OBS_STATE: PolicyFeature(type=FeatureType.STATE, shape=(3,))},
+        output_features={ACTION: PolicyFeature(type=FeatureType.ACTION, shape=(2,))},
+        device="cpu",
+        chunk_size=3,
+        rl_token=RLTokenConfig(
+            input_dim=4,
+            rl_token_dim=4,
+            num_encoder_layers=1,
+            num_decoder_layers=1,
+            num_heads=2,
+            ff_dim=8,
+            dropout=0.0,
+        ),
+        actor=RLTActorConfig(hidden_dims=[8], residual_scale=0.25, clamp_output=False),
+    )
+    return RLTPolicy(config)
+
+
+def _make_replay_batch(policy: RLTPolicy, batch_size: int = 2) -> dict:
+    action_chunk_dim = policy._action_chunk_dim
+    return {
+        "state": {
+            OBS_RLT_STATE: torch.randn(batch_size, policy.config.rl_token.rl_token_dim),
+            OBS_STATE: torch.randn(batch_size, 3),
+        },
+        "next_state": {
+            OBS_RLT_STATE: torch.randn(batch_size, policy.config.rl_token.rl_token_dim),
+            OBS_STATE: torch.randn(batch_size, 3),
+        },
+        ACTION: torch.randn(batch_size, action_chunk_dim),
+        "reward": torch.randn(batch_size),
+        "done": torch.zeros(batch_size),
+        "truncated": torch.zeros(batch_size),
+        "complementary_info": {
+            "reference_action": torch.zeros(batch_size, action_chunk_dim),
+            "next_reference_action": torch.ones(batch_size, action_chunk_dim),
+        },
+    }
+
+
+def test_rlt_algorithm_online_update_accepts_compact_rlt_state():
+    policy = _make_rlt_policy()
+    config = RLTAlgorithmConfig.from_policy_config(policy.config)
+    config.utd_ratio = 1
+    algorithm = config.build_algorithm(policy)
+    algorithm.transition_to_online()
+
+    stats = algorithm.update(iter(itertools.repeat(_make_replay_batch(policy))))
+
+    assert "loss_critic" in stats.losses
+    assert algorithm.optimization_step == 1
+
+
+def test_rlt_algorithm_keeps_next_reference_action_for_target_policy():
+    policy = _make_rlt_policy()
+    algorithm = RLTAlgorithmConfig.from_policy_config(policy.config).build_algorithm(policy)
+    batch = _make_replay_batch(policy)
+
+    prepared = algorithm._prepare_forward_batch(batch)
+
+    assert torch.equal(prepared["next_reference_action"], batch["complementary_info"]["next_reference_action"])


### PR DESCRIPTION
## Summary / Motivation

This PR adds a PI0.5 + RLT workflow for LIBERO. It provides a PI0.5 prefix adapter for RLT, supports compact RLT replay states, and adds example scripts for cache generation, offline RL-token training, online RLT training, and success-rate evaluation.

The main motivation is to make it easier to train and evaluate RLT on top of a frozen PI0.5 policy without storing full VLA prefix embeddings in the online replay buffer.

## Preliminary results

On LIBERO-10 task 0, using the same evaluation setup and precision, I observed an improvement in success rate from `91.17%` with the base PI0.5 policy to `95.01%` with PI0.5 + RLT.

These numbers are intended as a preliminary sanity check for this workflow rather than a full benchmark. I can add more details or run additional seeds/tasks if helpful.

## Related issues

- Fixes / Closes: N/A
- Related: N/A

## What changed

- Added `PI05PrefixRLTAdapter` to populate RLT observations from a frozen PI0.5 policy.
- Added support for compact `observation.rlt_state` in `RLTPolicy` and `RLTAlgorithm`.
- Added `next_reference_action` handling for online actor-critic target actions.
- Changed the RLT actor to refine PI0.5 reference action chunks through a residual update.
- Added configurable PI0.5 `tokenizer_name` and `float16` dtype support.
- Added LIBERO handling for task language instructions and already-terminated step calls.
- Added RLT example scripts and `examples/rlt/README.md`.
- Added small unit tests for the RLT policy and algorithm data paths.

No breaking changes are intended.

## How was this tested (or how to run locally)

Tests added:

- `tests/policies/rlt/test_rlt_policy.py`
- `tests/rl/test_rlt_algorithm.py`

Manual checks run locally:

```bash
python -m py_compile \
  src/lerobot/envs/libero.py \
  src/lerobot/policies/pi05/configuration_pi05.py \
  src/lerobot/policies/pi05/modeling_pi05.py \
  src/lerobot/policies/pi05/processor_pi05.py \
  src/lerobot/policies/rlt/__init__.py \
  src/lerobot/policies/rlt/configuration_rlt.py \
  src/lerobot/policies/rlt/modeling_rlt.py \
  src/lerobot/policies/rlt/vla_adapter.py \
  src/lerobot/rl/algorithms/rlt/configuration_rlt.py \
  src/lerobot/rl/algorithms/rlt/rlt_algorithm.py \
  tests/policies/rlt/test_rlt_policy.py \
  tests/rl/test_rlt_algorithm.py \
  examples/rlt/collect_pi05_sim_dataset.py \
  examples/rlt/evaluate_pi05_rlt_libero_success.py \
  examples/rlt/precompute_pi05_rlt_cache.py \
  examples/rlt/train_rlt_online_libero.py \
  examples/rlt/train_rlt_token_from_cache.py