### PR TITLE
docs: fix broken dataset script paths (datasets/v30 -> scripts)

### DIFF
--- a/docs/source/lerobot-dataset-v3.mdx
+++ b/docs/source/lerobot-dataset-v3.mdx
@@ -275,7 +275,7 @@ A converter aggregates per‑episode files into larger shards and writes episode
 pip install "https://github.com/huggingface/lerobot/archive/33cad37054c2b594ceba57463e8f11ee374fa93c.zip"
 
 # Convert an existing v2.1 dataset hosted on the Hub:
-python -m lerobot.datasets.v30.convert_dataset_v21_to_v30 --repo-id=<HF_USER/DATASET_ID>
+python -m lerobot.scripts.convert_dataset_v21_to_v30 --repo-id=<HF_USER/DATASET_ID>
 ```
 
 **What it does**

--- a/docs/source/molmoact2.mdx
+++ b/docs/source/molmoact2.mdx
@@ -238,7 +238,7 @@ your dataset has not been converted with quantile statistics, you can add them
 with:
 
 ```bash
-python src/lerobot/datasets/v30/augment_dataset_quantile_stats.py \
+python src/lerobot/scripts/augment_dataset_quantile_stats.py \
   --repo-id=your_dataset
 ```
 

--- a/docs/source/pi05.mdx
+++ b/docs/source/pi05.mdx
@@ -91,7 +91,7 @@ lerobot-train \
 If your dataset is not converted with `quantiles`, you can convert it with the following command:
 
 ```bash
-python src/lerobot/datasets/v30/augment_dataset_quantile_stats.py \
+python src/lerobot/scripts/augment_dataset_quantile_stats.py \
     --repo-id=your_dataset \
 ```
 

--- a/docs/source/porting_datasets_v3.mdx
+++ b/docs/source/porting_datasets_v3.mdx
@@ -300,7 +300,7 @@ This replaces the old episode-per-file structure with efficient, optimally-sized
 If you have existing datasets in v2.1 format, use the migration tool:
 
 ```bash
-python src/lerobot/datasets/v30/convert_dataset_v21_to_v30.py \
+python src/lerobot/scripts/convert_dataset_v21_to_v30.py \
     --repo-id your_id/existing_dataset
 ```
 


### PR DESCRIPTION
## What

Several docs referenced `src/lerobot/datasets/v30/`, a directory that does not exist in the repo. The two scripts actually live in `src/lerobot/scripts/`:

- `convert_dataset_v21_to_v30.py`
- `augment_dataset_quantile_stats.py`

Following any of these commands as written fails with `No such file or directory` (or `No module named` for the `-m` form).

## Fixed references

| File | Before | After |
|------|--------|-------|
| `docs/source/lerobot-dataset-v3.mdx` | `python -m lerobot.datasets.v30.convert_dataset_v21_to_v30` | `python -m lerobot.scripts.convert_dataset_v21_to_v30` |
| `docs/source/porting_datasets_v3.mdx` | `python src/lerobot/datasets/v30/convert_dataset_v21_to_v30.py` | `python src/lerobot/scripts/convert_dataset_v21_to_v30.py` |
| `docs/source/pi05.mdx` | `python src/lerobot/datasets/v30/augment_dataset_quantile_stats.py` | `python src/lerobot/scripts/augment_dataset_quantile_stats.py` |
| `docs/source/molmoact2.mdx` | `python src/lerobot/datasets/v30/augment_dataset_quantile_stats.py` | `python src/lerobot/scripts/augment_dataset_quantile_stats.py` |

## Verification

- `ls src/lerobot/datasets/` has no `v30` directory.
- `find src/lerobot -name convert_dataset_v21_to_v30.py` and `-name augment_dataset_quantile_stats.py` both resolve under `src/lerobot/scripts/`.
- The corrected paths match each script's own usage docstring.