### PR TITLE
   fix(datasets): use exact seek mode for torchcodec to avoid off-by-one frames in v3 concatenated videos

### DIFF
--- a/src/lerobot/datasets/video_utils.py
+++ b/src/lerobot/datasets/video_utils.py
@@ -275,7 +275,7 @@ class VideoDecoderCache:
 
             file_handle = fsspec.open(video_path).__enter__()
             try:
-                decoder = VideoDecoder(file_handle, seek_mode="approximate")
+                decoder = VideoDecoder(file_handle, seek_mode="exact")
             except Exception:
                 file_handle.close()
                 raise


### PR DESCRIPTION
### Summary

  `VideoDecoderCache` builds its torchcodec `VideoDecoder` with `seek_mode="approximate"`.
  Approximate seek never scans the file — it locates frames by assuming a perfectly uniform
  `frame_index = round(timestamp × average_fps)` grid derived from container metadata.

  This assumption breaks for **v3 datasets**, where many episodes are concatenated into a
  single long video. The per-frame `pts` drift slightly from the ideal `i / fps` grid, and the
  drift accumulates toward the end of the file. Deep into such a video the approximate estimate
  flips to a neighboring frame (off-by-one, ≈ `1/fps` ≈ 0.033 s). That exceeds the default
  `tolerance_s = 1e-4` and raises `FrameTimestampError`, crashing training.

  ### Fix

  Construct the decoder with `seek_mode="exact"`. torchcodec then scans the file once to build a
  real frame index, so frames are selected by their true `pts` instead of an estimated grid —
  eliminating the off-by-one.

  ### Why exact is the right default here

  - **Correctness over masking.** The alternative — loosening `tolerance_s` — would only hide the
    problem and risk silently returning the wrong frame. Exact seek selects by true `pts`, so it
    fixes the cause rather than the symptom.
  - **Cost is amortized.** The only added cost is a one-time index scan at decoder construction.
    `VideoDecoderCache` caches one decoder per file (LRU), so the scan happens once per file and
    frame-retrieval speed is unchanged. For the v3 format — a handful of large concatenated videos,
    read many times — this overhead is negligible.

  ### Changes

  - `src/lerobot/datasets/video_utils.py` — `VideoDecoderCache.get_decoder` now constructs
    `VideoDecoder(..., seek_mode="exact")` instead of `"approximate"`.

  No API or signature changes. No breaking changes.