### PR TITLE
multi_task_dit: add DINOv3 and SigLIP 2 vision/text encoder options

### DIFF
--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -1,0 +1,78 @@
+## Summary / Motivation
+
+`multi_task_dit` currently hardcodes CLIP for both the vision and text encoder. This PR lets the
+existing `vision_encoder_name` / `text_encoder_name` fields each accept three encoder families:
+**CLIP** (default, unchanged), **DINOv3** (vision), and **SigLIP 2** (vision + text), chosen
+automatically from each checkpoint's `model_type`. No schema change, just broader accepted values.
+
+DINOv3 and SigLIP 2 are strong alternative encoders that can generalize better than CLIP on some
+setups, while staying within this policy's lightweight, single-`AutoModel` design. The change is
+**additive**: the CLIP path is behaviorally identical (same classes, same pooling, same attention
+mask; the only addition is one `AutoConfig` model-type read at construction), and per-family handling
+is a couple of `if` branches, with no base-class/subclass tree, consistent with the original PR
+keeping the CLIP/LBM baseline intact.
+
+**Validated in practice:** I used the DINOv3 path to train a real SO-101 towel-folding policy for the
+ETH Zürich *Robot Learning* course cloth-folding project (including generalization to cloths unseen
+during training). Full pipeline + training/eval recipe:
+[LarsvanDorp/laundry_folding_robot](https://github.com/LarsvanDorp/laundry_folding_robot); deployed
+model: [`larsvandorp/folding_dit`](https://huggingface.co/larsvandorp/folding_dit) (`multi_task_dit`
++ DINOv3 ViT-B/16). Swapping CLIP for DINOv3 / SigLIP 2 is an increasingly common move; both are
+widely regarded as stronger general-purpose encoders than CLIP, and in our course most teams replaced
+the CLIP encoder with DINOv3 or SigLIP 2.
+
+## What changed
+
+- `VisionEncoder` / `TextEncoder` dispatch on the checkpoint's `model_type` via `AutoModel` + small
+  per-family handling:
+  - **CLIP / DINOv3** use the CLS token (`last_hidden_state[:, 0]`); DINOv3's register tokens are skipped.
+  - **SigLIP 2** uses the attention-pooled `pooler_output` (no CLS token). Fixed-resolution checkpoints
+    (e.g. `siglip2-base-patch16-224`) only; NaFlex variants are rejected with a clear error.
+- Text supports CLIP or SigLIP 2; vision-only encoders (DINO) are rejected. The tokenizer auto-selects
+  from `text_encoder_name`.
+- `hidden_size` is read dynamically for the projection. Config validation gives clear errors for:
+  vision-only-as-text, unknown family, SigLIP text `>64` tokens, and NaFlex.
+- Image normalization is unchanged (handled by the policy's preprocessing pipeline, same for every
+  encoder, so the CLIP path stays byte-identical).
+- Docs (`multi_task_dit.mdx` + policy README) and tests updated.
+- **No breaking changes**: CLIP defaults preserved.
+
+## How was this tested (or how to run locally)
+
+Tests in `tests/policies/multi_task_dit/test_multi_task_dit.py` (local-only, matching the existing
+module; CI skips it since it downloads gated/large weights) now exercise each family in both valid
+slots plus the config guards. Verified locally with real weights (`clip-vit-base-patch16`,
+`dinov3-vitb16`, `siglip2-base-patch16-224`):
+
+```bash
+pytest -q tests/policies/multi_task_dit/test_multi_task_dit.py   # 22 passed
+pre-commit run -a                                                # ruff / typos / ... clean
+```
+
+Selecting an encoder:
+
+```bash
+# Vision
+--policy.vision_encoder_name=openai/clip-vit-base-patch16              # default
+--policy.vision_encoder_name=facebook/dinov3-vitb16-pretrain-lvd1689m
+--policy.vision_encoder_name=google/siglip2-base-patch16-224
+
+# Text (DINO is vision-only)
+--policy.text_encoder_name=openai/clip-vit-base-patch16               # default
+--policy.text_encoder_name=google/siglip2-base-patch16-224
+--policy.tokenizer_max_length=64       # set with SigLIP 2 text (64-token context)
+```
+
+## Checklist (required before merge)
+
+- [x] Linting/formatting run (`pre-commit run -a`)
+- [x] All tests pass locally (the affected `multi_task_dit` tests; `pytest`)
+- [x] Documentation updated
+- [ ] CI is green
+- [x] Community Review: I have reviewed another contributor's open PR and linked it here: #3695
+
+## Reviewer notes
+
+- CLIP is the default and unchanged, so the diff is additive. Validation is **family-level**, so other
+  CLIP/DINO/SigLIP checkpoints (any size) work through the same paths; CLIP/DINOv3/SigLIP 2 are the
+  tested-and-recommended set.

--- a/docs/source/multi_task_dit.mdx
+++ b/docs/source/multi_task_dit.mdx
@@ -6,8 +6,8 @@ Multitask Diffusion Transformer (DiT) Policy is an evolution of the original Dif
 
 The model uses:
 
-- **CLIP Vision Encoder**: Processes RGB images from multiple camera views
-- **CLIP Text Encoder**: Encodes language task instructions (frozen weights with learnable projection)
+- **Vision Encoder**: Processes RGB images from multiple camera views. CLIP (default), DINOv3, or SigLIP 2, selectable via `vision_encoder_name`
+- **Text Encoder**: Encodes language task instructions (frozen weights with learnable projection). CLIP (default) or SigLIP 2, selectable via `text_encoder_name`
 - **Diffusion Transformer**: Predicts action sequences conditioned on observations and language
 - **Two Objectives**: Supports both diffusion (DDPM/DDIM) and flow matching for action generation
 
@@ -22,7 +22,7 @@ Multitask DiT Policy has additional dependencies. Install it with:
 pip install lerobot[multi_task_dit]
 ```
 
-This will install all necessary dependencies including the HuggingFace Transformers library for CLIP models.
+This will install all necessary dependencies including the HuggingFace Transformers library for the vision/text encoders (CLIP, DINOv3, SigLIP 2).
 
 ## Usage
 
@@ -149,10 +149,24 @@ The model supports two positional encoding methods for action sequences:
 
 #### Vision Encoder Configuration
 
+The vision encoder accepts three encoder families (any HuggingFace model id; the right loader is
+chosen from the checkpoint's `model_type`). CLIP is the default and its behaviour is unchanged;
+DINOv3 and SigLIP 2 are alternatives that diverge from the CLIP baseline in the original blog/paper,
+but can generalize better on some setups. We test and recommend the three below, but other
+CLIP/DINO/SigLIP checkpoints (any size) work through the same paths. Broadly, any vision encoder
+exposing a CLS token, or a SigLIP-style attention-pooled output.
+
 ```bash
-# Use different CLIP model for more expressivity at the cost of inference time
-# experiment with larger or smaller models depending on the complexity of your tasks and size of dataset
+# CLIP (default): experiment with larger/smaller models for expressivity vs. inference cost
 --policy.vision_encoder_name=openai/clip-vit-large-patch14
+
+# DINOv3: strong self-supervised features; uses the CLS token (register tokens are skipped)
+--policy.vision_encoder_name=facebook/dinov3-vitb16-pretrain-lvd1689m
+
+# SigLIP 2: fixed-resolution checkpoint; uses the attention-pooled feature (no CLS token).
+# Match image_crop_shape to the checkpoint's native resolution (e.g. 224). NaFlex variants are
+# not supported; use a fixed-resolution checkpoint like below.
+--policy.vision_encoder_name=google/siglip2-base-patch16-224
 
 # Use separate vision encoder per camera
 # This may be useful when cameras have significantly different characteristics, but
@@ -167,11 +181,17 @@ The model supports two positional encoding methods for action sequences:
 
 #### Text Encoder Configuration
 
+The text encoder accepts CLIP (default) or SigLIP 2. The matching tokenizer is selected
+automatically from `text_encoder_name`. DINOv3 is vision-only and is rejected here.
+
 ```bash
-# Use different CLIP text encoder model
-# same as vision: experiment with larger or smaller models depending on the
-# complexity of your tasks and size of dataset
+# CLIP (default): experiment with larger/smaller models for task-language complexity
 --policy.text_encoder_name=openai/clip-vit-large-patch14
+
+# SigLIP 2 text: uses its own (Gemma) tokenizer, selected automatically. SigLIP text has a
+# fixed 64-token context, so also set tokenizer_max_length=64.
+--policy.text_encoder_name=google/siglip2-base-patch16-224
+--policy.tokenizer_max_length=64
 ```
 
 #### Learning Rate Configuration

--- a/docs/source/policy_multi_task_dit_README.md
+++ b/docs/source/policy_multi_task_dit_README.md
@@ -1,5 +1,24 @@
 # Multitask DiT Policy
 
+## Encoders
+
+`vision_encoder_name` and `text_encoder_name` each accept multiple encoder families (any HuggingFace
+model id; the loader is chosen from the checkpoint's `model_type`). CLIP is the default and unchanged.
+
+| Family         | Vision | Text              | Global feature                      |
+| -------------- | ------ | ----------------- | ----------------------------------- |
+| CLIP (default) | ✅     | ✅                | CLS token                           |
+| DINOv3         | ✅     | n/a (vision-only) | CLS token (register tokens skipped) |
+| SigLIP 2       | ✅     | ✅                | attention-pooled `pooler_output`    |
+
+Use a **fixed-resolution** SigLIP 2 checkpoint (e.g. `google/siglip2-base-patch16-224`); NaFlex variants
+are not supported. SigLIP 2 text uses a 64-token context, so set `tokenizer_max_length=64`. The tokenizer
+is selected automatically from `text_encoder_name`. DINOv3/SigLIP 2 diverge from the CLIP baseline of the
+original blog/paper; CLIP remains the default. The three above are what we test and recommend, but other
+CLIP/DINO/SigLIP checkpoints (any size) work through the same paths. Broadly, any vision encoder with a
+CLS token (or SigLIP-style pooled output) and any text encoder with a pooled output. See
+[`multi_task_dit.mdx`](./multi_task_dit.mdx) for configuration examples.
+
 ## Citation
 
 If you use this work, please cite the following works:

--- a/src/lerobot/policies/multi_task_dit/configuration_multi_task_dit.py
+++ b/src/lerobot/policies/multi_task_dit/configuration_multi_task_dit.py
@@ -20,6 +20,17 @@ from dataclasses import dataclass, field
 from lerobot.configs import NormalizationMode, PreTrainedConfig
 from lerobot.optim import AdamConfig, DiffuserSchedulerConfig
 
+# Encoder families accepted by `vision_encoder_name` / `text_encoder_name`, matched as
+# case-insensitive substrings of the Hugging Face model id. See the per-family handling in
+# modeling_multi_task_dit.VisionEncoder / TextEncoder.
+# Matched at the *family* level: any CLIP / DINO / SigLIP checkpoint works through the same code
+# paths (we test & recommend CLIP, DINOv3, and SigLIP 2). Anything exposing a CLS token (vision) or a
+# pooled output (text) is likely compatible; these substrings just gate the common, verified families.
+_SUPPORTED_VISION_ENCODERS = ("clip", "dino", "siglip")
+_SUPPORTED_TEXT_ENCODERS = ("clip", "siglip")
+_VISION_ONLY_ENCODERS = ("dino",)
+_SIGLIP_MAX_TOKENS = 64  # SigLIP 2 text uses a fixed 64-token context (pools the last position)
+
 
 @PreTrainedConfig.register_subclass("multi_task_dit")
 @dataclass
@@ -68,17 +79,17 @@ class MultiTaskDiTConfig(PreTrainedConfig):
     use_rope: bool = True  # Use Rotary Position Embedding
     rope_base: float = 10000.0  # RoPE base frequency
 
-    # Vision Encoder (CLIP)
-    vision_encoder_name: str = "openai/clip-vit-base-patch16"  # HuggingFace CLIP model
+    # Vision Encoder: CLIP (default), DINOv3, or SigLIP 2 (HuggingFace model id)
+    vision_encoder_name: str = "openai/clip-vit-base-patch16"
     use_separate_rgb_encoder_per_camera: bool = False  # Separate encoder per camera view
     vision_encoder_lr_multiplier: float = 0.1  # LR multiplier for vision encoder
     image_resize_shape: tuple[int, int] | None = None  # Resize images before crop
     image_crop_shape: tuple[int, int] | None = (224, 224)  # Crop shape (CLIP default)
     image_crop_is_random: bool = True  # Random crop during training, center at inference
 
-    # Text Encoder (CLIP)
-    text_encoder_name: str = "openai/clip-vit-base-patch16"  # HuggingFace CLIP model
-    tokenizer_max_length: int = 77  # Max length for tokenized text (CLIP default is 77)
+    # Text Encoder: CLIP (default) or SigLIP 2 (HuggingFace model id); tokenizer is auto-selected
+    text_encoder_name: str = "openai/clip-vit-base-patch16"
+    tokenizer_max_length: int = 77  # CLIP uses 77; set 64 for SigLIP 2
     tokenizer_padding: str = "max_length"  # Padding strategy: "max_length" or "longest"
     tokenizer_padding_side: str = "right"  # Padding side: "left" or "right"
     tokenizer_truncation: bool = True  # Whether to truncate sequences longer than max_length
@@ -130,10 +141,16 @@ class MultiTaskDiTConfig(PreTrainedConfig):
         if not (0.0 <= self.dropout <= 1.0):
             raise ValueError("dropout must be between 0.0 and 1.0")
 
-        # Vision encoder validation
-        if "clip" not in self.vision_encoder_name.lower():
+        # Vision encoder validation: CLIP (default), DINOv3, or SigLIP 2.
+        if "naflex" in self.vision_encoder_name.lower() or "naflex" in self.text_encoder_name.lower():
             raise ValueError(
-                f"vision_encoder_name must be a CLIP model (contain 'clip'), got '{self.vision_encoder_name}'"
+                "Variable-resolution SigLIP 2 (NaFlex) is not supported; use a fixed-resolution "
+                "SigLIP 2 checkpoint such as 'google/siglip2-base-patch16-224'."
+            )
+        if not any(family in self.vision_encoder_name.lower() for family in _SUPPORTED_VISION_ENCODERS):
+            raise ValueError(
+                "vision_encoder_name must be a CLIP, DINOv3, or SigLIP 2 model "
+                f"(id containing one of {_SUPPORTED_VISION_ENCODERS}), got '{self.vision_encoder_name}'"
             )
         if (
             self.image_resize_shape
@@ -150,10 +167,23 @@ class MultiTaskDiTConfig(PreTrainedConfig):
             )
             self.image_crop_shape = None
 
-        # Text encoder validation
-        if "clip" not in self.text_encoder_name.lower():
+        # Text encoder validation: CLIP (default) or SigLIP 2. Vision-only encoders are rejected.
+        text_name = self.text_encoder_name.lower()
+        if not any(family in text_name for family in _SUPPORTED_TEXT_ENCODERS):
+            if any(vision_only in text_name for vision_only in _VISION_ONLY_ENCODERS):
+                raise ValueError(
+                    f"text_encoder_name='{self.text_encoder_name}' is a vision-only encoder "
+                    "(DINOv2/DINOv3 have no text tower). Use a CLIP or SigLIP 2 model for text."
+                )
             raise ValueError(
-                f"text_encoder_name must be a CLIP model (contain 'clip'), got '{self.text_encoder_name}'"
+                "text_encoder_name must be a CLIP or SigLIP 2 model "
+                f"(id containing one of {_SUPPORTED_TEXT_ENCODERS}), got '{self.text_encoder_name}'"
+            )
+        # SigLIP 2 text uses a fixed 64-token context (pools the last position); CLIP uses 77.
+        if "siglip" in text_name and self.tokenizer_max_length > _SIGLIP_MAX_TOKENS:
+            raise ValueError(
+                f"SigLIP 2 text supports at most {_SIGLIP_MAX_TOKENS} tokens; "
+                f"set tokenizer_max_length={_SIGLIP_MAX_TOKENS} (got {self.tokenizer_max_length})."
             )
 
         # Objective-specific validation

--- a/src/lerobot/policies/multi_task_dit/modeling_multi_task_dit.py
+++ b/src/lerobot/policies/multi_task_dit/modeling_multi_task_dit.py
@@ -42,10 +42,21 @@ from .configuration_multi_task_dit import MultiTaskDiTConfig
 
 # Conditional import for type checking and lazy loading
 if TYPE_CHECKING or _transformers_available:
-    from transformers import CLIPTextModel, CLIPVisionModel
+    from transformers import (
+        AutoConfig,
+        AutoModel,
+        CLIPTextModel,
+        CLIPVisionModel,
+        SiglipTextModel,
+        SiglipVisionModel,
+    )
 else:
+    AutoConfig = None
+    AutoModel = None
     CLIPTextModel = None
     CLIPVisionModel = None
+    SiglipTextModel = None
+    SiglipVisionModel = None
 
 if TYPE_CHECKING or _diffusers_available:
     from diffusers.schedulers.scheduling_ddim import DDIMScheduler
@@ -201,39 +212,95 @@ class MultiTaskDiTPolicy(PreTrainedPolicy):
 # -- Observation Encoders --
 
 
-class CLIPVisionEncoder(nn.Module):
-    """CLIP vision encoder using the CLS token for global image representation."""
+def _encoder_model_type(model_name: str) -> str:
+    """Return the HuggingFace ``model_type`` for a checkpoint (e.g. ``"clip"``, ``"dinov3"``, ``"siglip"``)."""
+    return AutoConfig.from_pretrained(model_name).model_type
+
+
+class VisionEncoder(nn.Module):
+    """Global-image encoder over a HuggingFace ViT backbone.
+
+    Three encoder families are supported through one AutoModel-based path with small
+    per-family handling (no subclass tree), dispatched on the checkpoint's ``model_type``:
+
+    * **CLIP** (``"clip"``) and **DINOv3** (``"dinov3"``): the global representation is the CLS
+      token, ``last_hidden_state[:, 0]``. DINOv3's register tokens sit at indices
+      ``1 .. 1 + num_register_tokens`` and are skipped automatically since only index 0 is read.
+      (The CLS-token branch is generic and would also accept other DINO ViTs.)
+    * **SigLIP 2** (``"siglip"``): has no CLS token and pools with an attention head, so the global
+      feature is ``pooler_output``. Use a fixed-resolution SigLIP 2 checkpoint (e.g.
+      ``google/siglip2-base-patch16-224``), which uses the standard SigLIP architecture; the
+      variable-resolution NaFlex variants are not supported.
+
+    The CLIP path is unchanged from the original policy.
+    """
 
     def __init__(self, model_name: str):
         super().__init__()
         self.model_name = model_name
-        self.model = CLIPVisionModel.from_pretrained(self.model_name)
+        self.family = _encoder_model_type(model_name)
+
+        if self.family == "siglip":
+            if SiglipVisionModel is None:
+                raise ImportError("SigLIP support requires a `transformers` version with SiglipVisionModel.")
+            self.model = SiglipVisionModel.from_pretrained(self.model_name)
+            self._use_attention_pool = True
+        elif self.family == "clip":
+            self.model = CLIPVisionModel.from_pretrained(self.model_name)
+            self._use_attention_pool = False
+        elif self.family == "siglip2":
+            raise ValueError(
+                "Variable-resolution SigLIP 2 (NaFlex) is not supported; use a fixed-resolution "
+                "SigLIP 2 checkpoint such as 'google/siglip2-base-patch16-224'."
+            )
+        else:  # dinov2 / dinov3 and other CLS-token ViTs loadable via AutoModel
+            self.model = AutoModel.from_pretrained(self.model_name)
+            self._use_attention_pool = False
+
         self.num_non_spatial_tokens = 1
         self.embed_dim = self.model.config.hidden_size
 
     def forward(self, x: Tensor) -> Tensor:
-        """Encode RGB image to CLS token."""
+        """Encode an RGB image batch to one global feature per image, shaped ``(B, embed_dim, 1, 1)``."""
         outputs = self.model(pixel_values=x, output_hidden_states=False)
-        cls_token = outputs.last_hidden_state[:, 0]
-        b, embed_dim = cls_token.shape
-        return cls_token.reshape(b, embed_dim, 1, 1)
+        # SigLIP pools with an attention head (pooler_output); CLIP / DINOv2 / DINOv3 use the CLS token.
+        features = outputs.pooler_output if self._use_attention_pool else outputs.last_hidden_state[:, 0]
+        b, embed_dim = features.shape
+        return features.reshape(b, embed_dim, 1, 1)
 
     def get_output_shape(self) -> tuple:
         return (self.embed_dim, 1, 1)
 
 
-class CLIPTextEncoder(nn.Module):
-    """CLIP text encoder with frozen weights and a learnable projection layer.
+class TextEncoder(nn.Module):
+    """Frozen text encoder (CLIP or SigLIP 2) with a learnable projection layer.
 
-    Accepts pre-tokenized inputs (input_ids and attention_mask) from the processor pipeline. See the processor
-    pipeline to see how the tokenization is handled.
+    Accepts pre-tokenized inputs (``input_ids`` / ``attention_mask``) from the processor
+    pipeline, whose ``TokenizerProcessorStep`` selects the matching tokenizer via
+    ``AutoTokenizer(text_encoder_name)``, so the right tokenizer is chosen automatically.
+    Both families expose a ``pooler_output`` global feature.
+
+    DINOv3 is vision-only and has no text tower; passing one here raises
+    (the config also validates this earlier, at construction time).
     """
 
     def __init__(self, model_name: str = "openai/clip-vit-base-patch16", projection_dim: int = 512):
         super().__init__()
         self.model_name = model_name
         self.projection_dim = projection_dim
-        self.text_encoder = CLIPTextModel.from_pretrained(model_name)
+        self.family = _encoder_model_type(model_name)
+
+        if self.family == "siglip":
+            if SiglipTextModel is None:
+                raise ImportError("SigLIP support requires a `transformers` version with SiglipTextModel.")
+            self.text_encoder = SiglipTextModel.from_pretrained(model_name)
+        elif self.family == "clip":
+            self.text_encoder = CLIPTextModel.from_pretrained(model_name)
+        else:
+            raise ValueError(
+                f"text_encoder_name='{model_name}' (model_type '{self.family}') has no text tower. "
+                "Use a CLIP or SigLIP 2 model for text conditioning."
+            )
 
         for param in self.text_encoder.parameters():
             param.requires_grad = False
@@ -248,11 +315,15 @@ class CLIPTextEncoder(nn.Module):
         input_ids = input_ids.to(device)
         attention_mask = attention_mask.to(device)
 
-        with torch.no_grad():
-            outputs = self.text_encoder(input_ids=input_ids, attention_mask=attention_mask)
-            clip_features = outputs.pooler_output
+        # SigLIP text is trained with full attention over a fixed-length padded sequence and
+        # pools the last position, so it ignores the padding mask; CLIP uses the mask as before.
+        mask = None if self.family == "siglip" else attention_mask
 
-        return self.projection(clip_features)
+        with torch.no_grad():
+            outputs = self.text_encoder(input_ids=input_ids, attention_mask=mask)
+            text_features = outputs.pooler_output
+
+        return self.projection(text_features)
 
 
 class ObservationEncoder(nn.Module):
@@ -269,11 +340,11 @@ class ObservationEncoder(nn.Module):
 
             if config.use_separate_rgb_encoder_per_camera:
                 self.vision_encoders = nn.ModuleList(
-                    [CLIPVisionEncoder(model_name=config.vision_encoder_name) for _ in self.camera_names]
+                    [VisionEncoder(model_name=config.vision_encoder_name) for _ in self.camera_names]
                 )
                 self.vision_encoder = None
             else:
-                self.vision_encoder = CLIPVisionEncoder(model_name=config.vision_encoder_name)
+                self.vision_encoder = VisionEncoder(model_name=config.vision_encoder_name)
                 self.vision_encoders = None
         else:
             self.vision_encoder = None
@@ -287,7 +358,7 @@ class ObservationEncoder(nn.Module):
             self.robot_state_dim = 0
 
         self.text_dim = config.hidden_dim
-        self.text_encoder = CLIPTextEncoder(model_name=config.text_encoder_name, projection_dim=self.text_dim)
+        self.text_encoder = TextEncoder(model_name=config.text_encoder_name, projection_dim=self.text_dim)
 
         self._setup_vector_output()
 

--- a/tests/policies/multi_task_dit/test_multi_task_dit.py
+++ b/tests/policies/multi_task_dit/test_multi_task_dit.py
@@ -37,7 +37,11 @@ pytestmark = pytest.mark.skipif(
 
 from lerobot.configs.types import FeatureType, NormalizationMode, PolicyFeature
 from lerobot.policies.multi_task_dit.configuration_multi_task_dit import MultiTaskDiTConfig
-from lerobot.policies.multi_task_dit.modeling_multi_task_dit import MultiTaskDiTPolicy
+from lerobot.policies.multi_task_dit.modeling_multi_task_dit import (
+    MultiTaskDiTPolicy,
+    TextEncoder,
+    VisionEncoder,
+)
 from lerobot.policies.multi_task_dit.processor_multi_task_dit import (
     make_multi_task_dit_pre_post_processors,
 )
@@ -619,3 +623,87 @@ def test_multi_task_dit_policy_get_optim_params():
     assert "lr" in param_groups[1]
     expected_lr = config.optimizer_lr * config.vision_encoder_lr_multiplier
     assert param_groups[1]["lr"] == expected_lr
+
+
+# --- Encoder family support: CLIP (default) + DINOv2/DINOv3 (vision) + SigLIP/SigLIP 2 (vision & text) ---
+
+VISION_ENCODERS = [
+    "openai/clip-vit-base-patch16",
+    "facebook/dinov3-vitb16-pretrain-lvd1689m",
+    "google/siglip2-base-patch16-224",
+]
+TEXT_ENCODERS = [
+    "openai/clip-vit-base-patch16",
+    "google/siglip2-base-patch16-224",
+]
+
+
+@pytest.mark.parametrize("model_name", VISION_ENCODERS)
+def test_vision_encoder_families(model_name: str):
+    """Each supported vision family loads and returns a (B, embed_dim, 1, 1) global feature."""
+    encoder = VisionEncoder(model_name).eval()
+    with torch.no_grad():
+        out = encoder(torch.rand(2, 3, 224, 224))
+    assert out.shape == (2, encoder.embed_dim, 1, 1)
+
+
+@pytest.mark.parametrize("model_name", TEXT_ENCODERS)
+def test_text_encoder_families(model_name: str):
+    """Each supported text family loads frozen and projects pooled features to projection_dim."""
+    projection_dim = 512
+    encoder = TextEncoder(model_name, projection_dim=projection_dim).eval()
+    assert all(not p.requires_grad for p in encoder.text_encoder.parameters())
+    input_ids = torch.randint(0, 100, (2, 64))
+    attention_mask = torch.ones(2, 64, dtype=torch.long)
+    with torch.no_grad():
+        out = encoder(input_ids, attention_mask)
+    assert out.shape == (2, projection_dim)
+
+
+def test_text_encoder_rejects_vision_only():
+    """A vision-only encoder (DINOv3) has no text tower and must raise."""
+    with pytest.raises(ValueError, match="text tower"):
+        TextEncoder("facebook/dinov3-vitb16-pretrain-lvd1689m")
+
+
+# --- Config-level encoder validation (no network) ---
+
+
+def test_config_accepts_supported_encoders():
+    """CLIP / DINOv3 / SigLIP 2 are all accepted in their valid slots."""
+    for vision in VISION_ENCODERS:
+        MultiTaskDiTConfig(vision_encoder_name=vision)
+    MultiTaskDiTConfig(text_encoder_name="google/siglip2-base-patch16-224", tokenizer_max_length=64)
+
+
+def test_config_rejects_vision_only_text_encoder():
+    """DINOv2/DINOv3 as a text encoder fails with a clear, vision-only message."""
+    with pytest.raises(ValueError, match="vision-only"):
+        MultiTaskDiTConfig(text_encoder_name="facebook/dinov3-vitb16-pretrain-lvd1689m")
+
+
+def test_config_rejects_unsupported_encoders():
+    """Unknown encoder families are rejected for both slots."""
+    with pytest.raises(ValueError, match="vision_encoder_name must be"):
+        MultiTaskDiTConfig(vision_encoder_name="microsoft/resnet-50")
+    with pytest.raises(ValueError, match="text_encoder_name must be"):
+        MultiTaskDiTConfig(text_encoder_name="bert-base-uncased")
+
+
+def test_config_siglip_text_length_guard():
+    """SigLIP text caps at 64 tokens; a larger tokenizer_max_length is rejected."""
+    with pytest.raises(ValueError, match="at most 64"):
+        MultiTaskDiTConfig(text_encoder_name="google/siglip2-base-patch16-224", tokenizer_max_length=77)
+
+
+def test_config_rejects_naflex():
+    """Variable-resolution SigLIP 2 (NaFlex) is explicitly unsupported."""
+    with pytest.raises(ValueError, match="NaFlex"):
+        MultiTaskDiTConfig(vision_encoder_name="google/siglip2-base-patch16-naflex")
+
+
+def test_config_accepts_same_family_checkpoints():
+    """Validation is family-level: other CLIP/DINO/SigLIP checkpoints are accepted (only the
+    current generations are advertised in the docs)."""
+    MultiTaskDiTConfig(vision_encoder_name="facebook/dinov2-base")
+    MultiTaskDiTConfig(vision_encoder_name="google/siglip-base-patch16-224")


### PR DESCRIPTION
## Summary / Motivation

`multi_task_dit` currently hardcodes CLIP for both the vision and text encoder. This PR lets the
existing `vision_encoder_name` / `text_encoder_name` fields each accept three encoder families:
**CLIP** (default, unchanged), **DINOv3** (vision), and **SigLIP 2** (vision + text), chosen
automatically from each checkpoint's `model_type`. No schema change, just broader accepted values.

DINOv3 and SigLIP 2 are strong alternative encoders that can generalize better than CLIP on some
setups, while staying within this policy's lightweight, single-`AutoModel` design. The change is
**additive**: the CLIP path is behaviorally identical (same classes, same pooling, same attention
mask; the only addition is one `AutoConfig` model-type read at construction), and per-family handling
is a couple of `if` branches, with no base-class/subclass tree, consistent with the original PR
keeping the CLIP/LBM baseline intact.

**Validated in practice:** I used the DINOv3 path to train a real SO-101 towel-folding policy for the
ETH Zürich *Robot Learning* course cloth-folding project (including generalization to cloths unseen
during training). Full pipeline + training/eval recipe:
[LarsvanDorp/laundry_folding_robot](https://github.com/LarsvanDorp/laundry_folding_robot); deployed
model: [`larsvandorp/folding_dit`](https://huggingface.co/larsvandorp/folding_dit) (`multi_task_dit`
+ DINOv3 ViT-B/16). Swapping CLIP for DINOv3 / SigLIP 2 is an increasingly common move; both are
widely regarded as stronger general-purpose encoders than CLIP, and in our course most teams replaced
the CLIP encoder with DINOv3 or SigLIP 2.

## What changed

- `VisionEncoder` / `TextEncoder` dispatch on the checkpoint's `model_type` via `AutoModel` + small
  per-family handling:
  - **CLIP / DINOv3** use the CLS token (`last_hidden_state[:, 0]`); DINOv3's register tokens are skipped.
  - **SigLIP 2** uses the attention-pooled `pooler_output` (no CLS token). Fixed-resolution checkpoints
    (e.g. `siglip2-base-patch16-224`) only; NaFlex variants are rejected with a clear error.
- Text supports CLIP or SigLIP 2; vision-only encoders (DINO) are rejected. The tokenizer auto-selects
  from `text_encoder_name`.
- `hidden_size` is read dynamically for the projection. Config validation gives clear errors for:
  vision-only-as-text, unknown family, SigLIP text `>64` tokens, and NaFlex.
- Image normalization is unchanged (handled by the policy's preprocessing pipeline, same for every
  encoder, so the CLIP path stays byte-identical).
- Docs (`multi_task_dit.mdx` + policy README) and tests updated.
- **No breaking changes**: CLIP defaults preserved.

## How was this tested (or how to run locally)

Tests in `tests/policies/multi_task_dit/test_multi_task_dit.py` (local-only, matching the existing
module; CI skips it since it downloads gated/large weights) now exercise each family in both valid
slots plus the config guards. Verified locally with real weights (`clip-vit-base-patch16`,
`dinov3-vitb16`, `siglip2-base-patch16-224`):

```bash
pytest -q tests/policies/multi_task_dit/test_multi_task_dit.py   # 22 passed
pre-commit run -a                                                # ruff / typos / ... clean
```

Selecting an encoder:

```bash
# Vision
--policy.vision_encoder_name=openai/clip-vit-base-patch16              # default
--policy.vision_encoder_name=facebook/dinov3-vitb16-pretrain-lvd1689m
--policy.vision_encoder_name=google/siglip2-base-patch16-224

# Text (DINO is vision-only)
--policy.text_encoder_name=openai/clip-vit-base-patch16               # default
--policy.text_encoder_name=google/siglip2-base-patch16-224
--policy.tokenizer_max_length=64       # set with SigLIP 2 text (64-token context)
```

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (the affected `multi_task_dit` tests; `pytest`)
- [x] Documentation updated
- [ ] CI is green
- [x] Community Review: I have reviewed another contributor's open PR and linked it here: #3695

## Reviewer notes

- CLIP is the default and unchanged, so the diff is additive. Validation is **family-level**, so other
  CLIP/DINO/SigLIP checkpoints (any size) work through the same paths; CLIP/DINOv3/SigLIP 2 are the
  tested-and-recommended set.
