### PR TITLE
Fix pi05 expert only speed

### DIFF
--- a/src/lerobot/policies/pi05/modeling_pi05.py
+++ b/src/lerobot/policies/pi05/modeling_pi05.py
@@ -234,13 +234,30 @@ def resize_with_pad_torch(  # see openpi `resize_with_pad_torch` (exact copy)
 
 
 # Define the complete layer computation function for gradient checkpointing
-def compute_layer_complete(inputs_embeds, attention_mask, position_ids, adarms_cond, layers, rotary_emb):
+def compute_layer_complete(
+    inputs_embeds, attention_mask, position_ids, adarms_cond, layers, rotary_emb, freeze_prefix=False
+):
     query_states = []
     key_states = []
     value_states = []
     gates = []
     for i, hidden_states in enumerate(inputs_embeds):
         layer = layers[i]
+        if freeze_prefix and i == 0:
+            hidden_states = hidden_states.detach()
+            with torch.no_grad():
+                hidden_states, gate = layernorm_forward(layer.input_layernorm, hidden_states, adarms_cond[i])
+                input_shape = hidden_states.shape[:-1]
+                hidden_shape = (*input_shape, -1, layer.self_attn.head_dim)
+                query_state = layer.self_attn.q_proj(hidden_states).view(hidden_shape).transpose(1, 2)
+                key_state = layer.self_attn.k_proj(hidden_states).view(hidden_shape).transpose(1, 2)
+                value_state = layer.self_attn.v_proj(hidden_states).view(hidden_shape).transpose(1, 2)
+            gates.append(gate)
+            query_states.append(query_state)
+            key_states.append(key_state)
+            value_states.append(value_state)
+            continue
+
         hidden_states, gate = layernorm_forward(layer.input_layernorm, hidden_states, adarms_cond[i])
         gates.append(gate)
         input_shape = hidden_states.shape[:-1]
@@ -287,19 +304,32 @@ def compute_layer_complete(inputs_embeds, attention_mask, position_ids, adarms_c
     for i, hidden_states in enumerate(inputs_embeds):
         layer = layers[i]
         end_pos = start_pos + hidden_states.shape[1]
-        if att_output.dtype != layer.self_attn.o_proj.weight.dtype:
-            att_output = att_output.to(layer.self_attn.o_proj.weight.dtype)
-        out_emb = layer.self_attn.o_proj(att_output[:, start_pos:end_pos])
-        # first residual
-        out_emb = _gated_residual(hidden_states, out_emb, gates[i])
-        after_first_residual = out_emb.clone()
-        out_emb, gate = layernorm_forward(layer.post_attention_layernorm, out_emb, adarms_cond[i])
-        # Convert to bfloat16 if the next layer (mlp) uses bfloat16
-        if layer.mlp.up_proj.weight.dtype == torch.bfloat16:
-            out_emb = out_emb.to(dtype=torch.bfloat16)
-        out_emb = layer.mlp(out_emb)
-        # second residual
-        out_emb = _gated_residual(after_first_residual, out_emb, gate)
+        layer_att_output = att_output
+        if layer_att_output.dtype != layer.self_attn.o_proj.weight.dtype:
+            layer_att_output = layer_att_output.to(layer.self_attn.o_proj.weight.dtype)
+
+        if freeze_prefix and i == 0:
+            with torch.no_grad():
+                out_emb = layer.self_attn.o_proj(layer_att_output[:, start_pos:end_pos])
+                out_emb = _gated_residual(hidden_states.detach(), out_emb, gates[i])
+                after_first_residual = out_emb.clone()
+                out_emb, gate = layernorm_forward(layer.post_attention_layernorm, out_emb, adarms_cond[i])
+                if layer.mlp.up_proj.weight.dtype == torch.bfloat16:
+                    out_emb = out_emb.to(dtype=torch.bfloat16)
+                out_emb = layer.mlp(out_emb)
+                out_emb = _gated_residual(after_first_residual, out_emb, gate).detach()
+        else:
+            out_emb = layer.self_attn.o_proj(layer_att_output[:, start_pos:end_pos])
+            # first residual
+            out_emb = _gated_residual(hidden_states, out_emb, gates[i])
+            after_first_residual = out_emb.clone()
+            out_emb, gate = layernorm_forward(layer.post_attention_layernorm, out_emb, adarms_cond[i])
+            # Convert to bfloat16 if the next layer (mlp) uses bfloat16
+            if layer.mlp.up_proj.weight.dtype == torch.bfloat16:
+                out_emb = out_emb.to(dtype=torch.bfloat16)
+            out_emb = layer.mlp(out_emb)
+            # second residual
+            out_emb = _gated_residual(after_first_residual, out_emb, gate)
         outputs_embeds.append(out_emb)
         start_pos = end_pos
     return outputs_embeds
@@ -412,15 +442,27 @@ class PaliGemmaWithExpertModel(
         else:
             raise ValueError(f"Invalid precision: {precision}")
 
-        # Keep full vision path in float32 so we never toggle (toggle causes optimizer
-        # "same dtype" error). Saves memory vs full float32; more memory than only 3 params.
-        params_to_keep_float32 = [
-            "vision_tower",
-            "multi_modal_projector",
-            "input_layernorm",
-            "post_attention_layernorm",
-            "model.norm",
-        ]
+        # Full-model fine-tuning needs the full vision path in float32 to avoid
+        # mixed optimizer dtype errors. Expert-only training freezes PaliGemma,
+        # so keep only the numerically sensitive parameters in float32 and let
+        # the frozen vision encoder run mostly in bfloat16.
+        if self.train_expert_only:
+            params_to_keep_float32 = [
+                "vision_tower.vision_model.embeddings.patch_embedding.weight",
+                "vision_tower.vision_model.embeddings.patch_embedding.bias",
+                "vision_tower.vision_model.embeddings.position_embedding.weight",
+                "input_layernorm",
+                "post_attention_layernorm",
+                "model.norm",
+            ]
+        else:
+            params_to_keep_float32 = [
+                "vision_tower",
+                "multi_modal_projector",
+                "input_layernorm",
+                "post_attention_layernorm",
+                "model.norm",
+            ]
 
         for name, param in self.named_parameters():
             if any(selector in name for selector in params_to_keep_float32):
@@ -517,6 +559,7 @@ class PaliGemmaWithExpertModel(
                         preserve_rng_state=False,
                         layers=layers,
                         rotary_emb=rotary_emb,
+                        freeze_prefix=self.train_expert_only,
                     )
                 else:
                     inputs_embeds = compute_layer_complete(
@@ -526,6 +569,7 @@ class PaliGemmaWithExpertModel(
                         adarms_cond,
                         layers=layers,
                         rotary_emb=rotary_emb,
+                        freeze_prefix=self.train_expert_only,
                     )
 
             # final norm
@@ -537,7 +581,14 @@ class PaliGemmaWithExpertModel(
             def compute_final_norms(inputs_embeds, adarms_cond):
                 outputs_embeds = []
                 for i, hidden_states in enumerate(inputs_embeds):
-                    out_emb, _ = layernorm_forward(final_norms[i], hidden_states, adarms_cond[i])
+                    if self.train_expert_only and i == 0:
+                        with torch.no_grad():
+                            out_emb, _ = layernorm_forward(
+                                final_norms[i], hidden_states.detach(), adarms_cond[i]
+                            )
+                            out_emb = out_emb.detach()
+                    else:
+                        out_emb, _ = layernorm_forward(final_norms[i], hidden_states, adarms_cond[i])
                     outputs_embeds.append(out_emb)
                 return outputs_embeds
 
@@ -623,7 +674,8 @@ class PI05Pytorch(nn.Module):  # see openpi `PI0Pytorch`
 
     def _apply_checkpoint(self, func, *args, **kwargs):
         """Helper method to apply gradient checkpointing if enabled."""
-        if self.gradient_checkpointing_enabled and self.training:
+        has_grad_input = any(isinstance(arg, torch.Tensor) and arg.requires_grad for arg in args)
+        if self.gradient_checkpointing_enabled and self.training and has_grad_input:
             return torch.utils.checkpoint.checkpoint(
                 func, *args, use_reentrant=False, preserve_rng_state=False, **kwargs
             )
@@ -664,7 +716,11 @@ class PI05Pytorch(nn.Module):  # see openpi `PI0Pytorch`
             def image_embed_func(img):
                 return self.paligemma_with_expert.embed_image(img)
 
-            img_emb = self._apply_checkpoint(image_embed_func, img)
+            if self.paligemma_with_expert.train_expert_only:
+                with torch.no_grad():
+                    img_emb = image_embed_func(img).detach()
+            else:
+                img_emb = self._apply_checkpoint(image_embed_func, img)
             bsize, num_img_embs = img_emb.shape[:2]
 
             embs.append(img_emb)
@@ -676,7 +732,11 @@ class PI05Pytorch(nn.Module):  # see openpi `PI0Pytorch`
             lang_emb = self.paligemma_with_expert.embed_language_tokens(tokens)
             return lang_emb
 
-        lang_emb = self._apply_checkpoint(lang_embed_func, tokens)
+        if self.paligemma_with_expert.train_expert_only:
+            with torch.no_grad():
+                lang_emb = lang_embed_func(tokens).detach()
+        else:
+            lang_emb = self._apply_checkpoint(lang_embed_func, tokens)
         embs.append(lang_emb)
         pad_masks.append(masks)
 
@@ -774,9 +834,7 @@ class PI05Pytorch(nn.Module):  # see openpi `PI0Pytorch`
             )
             return suffix_out
 
-        suffix_out = self._apply_checkpoint(
-            forward_func, prefix_embs, suffix_embs, att_2d_masks_4d, position_ids, adarms_cond
-        )
+        suffix_out = forward_func(prefix_embs, suffix_embs, att_2d_masks_4d, position_ids, adarms_cond)
 
         suffix_out = suffix_out[:, -self.config.chunk_size :]
         suffix_out = suffix_out.to(dtype=torch.float32)


### PR DESCRIPTION
  ## Title

  fix(pi05): speed up expert-only training

  ## Summary / Motivation

  This PR fixes a PI05 expert-only training slowdown introduced by keeping the frozen PaliGemma prefix path on the expensive training path. When train_expert_only=true, PaliGemma is frozen, but the previous implementation still checkpointed frozen image/language prefix work and kept the full frozen vision tower/projector in fp32. This change detaches the frozen prefix branch, avoids unnecessary checkpointing for tensors without gradients, and lets the frozen heavy vision path run mostly in bf16 while preserving fp32 for sensitive embedding/norm parameters. Full-model training keeps the existing full-vision fp32 behavior.

  ## Related issues

  - Fixes / Closes: N/A
  - Related: N/A

  ## What changed

  - Detach the frozen PaliGemma prefix branch when train_expert_only=true while keeping the action expert branch trainable.
  - Avoid wrapping the already layer-checkpointed PI05 joint forward in an extra outer checkpoint.
  - Skip checkpointing when no tensor input requires gradients.
  - In expert-only mode, keep only sensitive vision embedding/norm parameters in fp32 and run the frozen vision tower/projector mostly in bf16.
  - No breaking changes expected.

  ## How was this tested (or how to run locally)

  - Tests added: none.
  - Local checks:
python -m py_compile src/lerobot/policies/pi05/modeling_pi05.py
git diff --check -- src/lerobot/policies/pi05/modeling_pi05.py

  - Manual CUDA timing probe with PI05, train_expert_only=true, dtype=bfloat16, gradient_checkpointing=true, batch size 16:
      - Before final dtype fix: steady updt_s around 6.6-7.8s.
      - After fix: steady updt_s around 1.67s after warmup.
      - 8-step probe full tqdm average: 3.14s/step including first-step data/startup overhead.

  Example probe shape:

  lerobot-train \
      --dataset.repo_id=your_dataset \
      --policy.type=pi05 \
      --output_dir=./outputs/pi05_training \
      --job_name=pi05_training \
      --policy.repo_id=your_repo_id \
      --policy.pretrained_path=lerobot/pi05_base \
      --policy.compile_model=false \
      --policy.gradient_checkpointing=true \
      --wandb.enable=false \
      --policy.dtype=bfloat16 \
      --policy.freeze_vision_encoder=false \
      --policy.train_expert_only=**true** \
      --batch_size=16

  ## Checklist (required before merge)

  - [x] Linting/formatting run (pre-commit run -a)
  - [ ] All tests pass locally (pytest)
  - [ ] Documentation updated
  - [ ] CI is green
  - [ ] Community Review: I have reviewed another contributor's open PR and linked it here: # (insert PR number/link)

  ## Reviewer notes

  Please focus on whether the expert-only branch correctly prevents gradients through the frozen PaliGemma prefix while preserving gradients through the action expert. The dtype change is intentionally conditional: full-model fine-tuning keeps the existing fp32 vision path, while expert-only fine-tuning uses bf16 for the frozen heavy vision path.