### PR TITLE
Add gradient accumulation to trainer

### DIFF
--- a/AGENT_GUIDE.md
+++ b/AGENT_GUIDE.md
@@ -273,7 +273,7 @@ Robotics imitation learning usually converges in a **few epochs over the dataset
 
 ```
 total_frames     = sum of frames over all episodes      # e.g. 50 eps × 30 fps × 30 s ≈ 45,000
-steps_per_epoch  = ceil(total_frames / batch_size)
+steps_per_epoch  = ceil(total_frames / (num_gpus × batch_size × gradient_accumulation_steps))
 total_steps      = epochs × steps_per_epoch
 ```
 

--- a/docs/source/groot.mdx
+++ b/docs/source/groot.mdx
@@ -72,6 +72,7 @@ accelerate launch \
   --output_dir=$OUTPUT_DIR \
   --save_checkpoint=true \
   --batch_size=$BATCH_SIZE \
+  --gradient_accumulation_steps=$GRADIENT_ACCUMULATION_STEPS \
   --steps=$NUM_STEPS \
   --save_freq=$SAVE_FREQ \
   --log_freq=$LOG_FREQ \

--- a/docs/source/hardware_guide.mdx
+++ b/docs/source/hardware_guide.mdx
@@ -25,7 +25,7 @@ Robotics imitation learning typically converges in **5–10 epochs over the data
 
 ```text
 total_frames    = sum of frames over all episodes      # 50 ep × 30 fps × 30 s ≈ 45,000
-steps_per_epoch = ceil(total_frames / (num_gpus × batch_size))
+steps_per_epoch = ceil(total_frames / (num_gpus × batch_size × gradient_accumulation_steps))
 total_steps     = epochs × steps_per_epoch
 wall_clock      ≈ total_steps × per_step_time
 ```
@@ -52,7 +52,7 @@ These are order-of-magnitude figures. Real runs deviate by ±50% depending on im
 
 ### Multi-GPU matters a lot
 
-`accelerate launch --num_processes=N` is the easiest way to cut training time. Each optimizer step processes `N × batch_size` samples in roughly the same wall-clock as a single-GPU step, so 4 GPUs ≈ 4× speedup for compute-bound runs. See the [Multi GPU training](./multi_gpu_training) guide for the full setup.
+`accelerate launch --num_processes=N` is the easiest way to cut training time. Each optimizer step processes `N × batch_size × gradient_accumulation_steps` samples, though accumulation increases wall-clock per optimizer step because it runs multiple microbatches before updating weights. See the [Multi GPU training](./multi_gpu_training) guide for the full setup.
 
 Reference data points on a 4×H100 80 GB cluster (`accelerate launch --num_processes=4`), 5000 steps, batch 32, AdamW, dataset [`imstevenpmwork/super_poulain_draft`](https://huggingface.co/datasets/imstevenpmwork/super_poulain_draft) (~50 episodes, ~640×480 images):
 

--- a/docs/source/multi_gpu_training.mdx
+++ b/docs/source/multi_gpu_training.mdx
@@ -100,7 +100,7 @@ accelerate launch --num_processes=2 $(which lerobot-train) \
 
 **Training Steps Scaling:**
 
-Since the effective batch size `bs` increases with multiple GPUs (batch_size × num_gpus), you may want to reduce the number of training steps proportionally:
+Since the effective batch size `bs` increases with multiple GPUs and gradient accumulation (`batch_size × num_gpus × gradient_accumulation_steps`), you may want to reduce the number of training steps proportionally:
 
 ```bash
 # Example: 2 GPUs with effective batch size 2x larger
@@ -117,7 +117,7 @@ accelerate launch --num_processes=2 $(which lerobot-train) \
 
 - The `--policy.use_amp` flag in `lerobot-train` is only used when **not** running with accelerate. When using accelerate, mixed precision is controlled by accelerate's configuration.
 - Training logs, checkpoints, and hub uploads are only done by the main process to avoid conflicts. Non-main processes have console logging disabled to prevent duplicate output.
-- The effective batch size is `batch_size × num_gpus`. If you use 4 GPUs with `--batch_size=8`, your effective batch size is 32.
+- The effective batch size is `batch_size × num_gpus × gradient_accumulation_steps`. If you use 4 GPUs with `--batch_size=8` and the default `--gradient_accumulation_steps=1`, your effective batch size is 32.
 - Learning rate scheduling is handled correctly across multiple processes—LeRobot sets `step_scheduler_with_optimizer=False` to prevent accelerate from adjusting scheduler steps based on the number of processes.
 - When saving or pushing models, LeRobot automatically unwraps the model from accelerate's distributed wrapper to ensure compatibility.
 - WandB integration automatically initializes only on the main process, preventing multiple runs from being created.

--- a/src/lerobot/configs/train.py
+++ b/src/lerobot/configs/train.py
@@ -97,6 +97,8 @@ class TrainPipelineConfig(HubMixin):
     # Number of workers for the dataloader.
     num_workers: int = 4
     batch_size: int = 8
+    # Number of microbatches to accumulate before each optimizer update.
+    gradient_accumulation_steps: int = 1
     prefetch_factor: int = 4
     persistent_workers: bool = True
     steps: int = 100_000
@@ -175,6 +177,9 @@ class TrainPipelineConfig(HubMixin):
                 "Neither policy nor reward_model is configured. "
                 "Please specify one with `--policy.path` or `--reward_model.path`."
             )
+
+        if self.gradient_accumulation_steps < 1:
+            raise ValueError("gradient_accumulation_steps must be greater than or equal to 1.")
 
         active_cfg = self.trainable_config
         if not self.job_name:

--- a/src/lerobot/scripts/lerobot_train.py
+++ b/src/lerobot/scripts/lerobot_train.py
@@ -75,10 +75,11 @@ def update_policy(
     sample_weighter=None,
 ) -> tuple[MetricsTracker, dict | None]:
     """
-    Performs a single training step to update the policy's weights.
+    Performs a single training microbatch and updates weights when accumulation is complete.
 
-    This function executes the forward and backward passes, clips gradients, and steps the optimizer and
-    learning rate scheduler. Accelerator handles mixed-precision training automatically.
+    This function executes the forward and backward passes, then clips gradients and steps the optimizer
+    and learning rate scheduler only when `accelerator.sync_gradients` is true. Accelerator handles
+    mixed-precision training automatically.
 
     Args:
         train_metrics: A MetricsTracker instance to record training statistics.
@@ -96,7 +97,6 @@ def update_policy(
         - The updated MetricsTracker with new statistics for this step.
         - A dictionary of outputs from the policy's forward pass, for logging purposes.
     """
-    start_time = time.perf_counter()
     policy.train()
 
     # Compute sample weights if a weighter is provided
@@ -132,32 +132,33 @@ def update_policy(
     # Use accelerator's backward method
     accelerator.backward(loss)
 
-    # Clip gradients if specified
-    if grad_clip_norm > 0:
-        grad_norm = accelerator.clip_grad_norm_(policy.parameters(), grad_clip_norm)
-    else:
-        grad_norm = torch.nn.utils.clip_grad_norm_(
-            policy.parameters(), float("inf"), error_if_nonfinite=False
-        )
+    if accelerator.sync_gradients:
+        # Clip gradients once all accumulated microbatches have contributed.
+        if grad_clip_norm > 0:
+            grad_norm = accelerator.clip_grad_norm_(policy.parameters(), grad_clip_norm)
+        else:
+            grad_norm = torch.nn.utils.clip_grad_norm_(
+                policy.parameters(), float("inf"), error_if_nonfinite=False
+            )
 
-    # Optimizer step
-    with lock if lock is not None else nullcontext():
-        optimizer.step()
+        # Optimizer/scheduler updates happen once per accumulated training step.
+        with lock if lock is not None else nullcontext():
+            optimizer.step()
 
-    optimizer.zero_grad()
+        optimizer.zero_grad()
 
-    # Step through pytorch scheduler at every batch instead of epoch
-    if lr_scheduler is not None:
-        lr_scheduler.step()
+        # Step through pytorch scheduler at every optimizer update instead of epoch.
+        if lr_scheduler is not None:
+            lr_scheduler.step()
 
-    # Update internal buffers if policy has update method
-    if has_method(accelerator.unwrap_model(policy, keep_fp32_wrapper=True), "update"):
-        accelerator.unwrap_model(policy, keep_fp32_wrapper=True).update()
+        # Update internal buffers if policy has update method.
+        if has_method(accelerator.unwrap_model(policy, keep_fp32_wrapper=True), "update"):
+            accelerator.unwrap_model(policy, keep_fp32_wrapper=True).update()
+
+        train_metrics.grad_norm = grad_norm.item()
+        train_metrics.lr = optimizer.param_groups[0]["lr"]
 
     train_metrics.loss = loss.item()
-    train_metrics.grad_norm = grad_norm.item()
-    train_metrics.lr = optimizer.param_groups[0]["lr"]
-    train_metrics.update_s = time.perf_counter() - start_time
     return train_metrics, output_dict
 
 
@@ -198,6 +199,7 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
         force_cpu = cfg.trainable_config.device == "cpu"
         accelerator = Accelerator(
             step_scheduler_with_optimizer=False,
+            gradient_accumulation_steps=cfg.gradient_accumulation_steps,
             kwargs_handlers=[ddp_kwargs],
             cpu=force_cpu,
         )
@@ -363,7 +365,7 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
             dataset_repo_id=cfg.dataset.repo_id,
         )
 
-    step = 0  # number of policy updates (forward + backward + optim)
+    step = 0  # number of optimizer updates
 
     if cfg.resume:
         step, optimizer, lr_scheduler = load_training_state(cfg.checkpoint_path, optimizer, lr_scheduler)
@@ -383,8 +385,11 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
         logging.info(f"{dataset.num_frames=} ({format_big_number(dataset.num_frames)})")
         logging.info(f"{dataset.num_episodes=}")
         num_processes = accelerator.num_processes
-        effective_bs = cfg.batch_size * num_processes
-        logging.info(f"Effective batch size: {cfg.batch_size} x {num_processes} = {effective_bs}")
+        effective_bs = cfg.batch_size * num_processes * cfg.gradient_accumulation_steps
+        logging.info(
+            "Effective batch size: "
+            f"{cfg.batch_size} x {num_processes} x {cfg.gradient_accumulation_steps} = {effective_bs}"
+        )
         logging.info(f"{num_learnable_params=} ({format_big_number(num_learnable_params)})")
         logging.info(f"{num_total_params=} ({format_big_number(num_total_params)})")
 
@@ -437,9 +442,10 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
     }
 
     # Keep global batch size for logging; MetricsTracker handles world size internally.
-    effective_batch_size = cfg.batch_size * accelerator.num_processes
+    samples_per_update_per_process = cfg.batch_size * cfg.gradient_accumulation_steps
+    effective_batch_size = samples_per_update_per_process * accelerator.num_processes
     train_tracker = MetricsTracker(
-        cfg.batch_size,
+        samples_per_update_per_process,
         dataset.num_frames,
         dataset.num_episodes,
         train_metrics,
@@ -460,7 +466,9 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
             f"Start offline training on a fixed dataset, with effective batch size: {effective_batch_size}"
         )
 
-    for _ in range(step, cfg.steps):
+    output_dict = None
+    accumulated_update_s = 0.0
+    while step < cfg.steps:
         start_time = time.perf_counter()
         batch = next(dl_iter)
         for cam_key in dataset.meta.camera_keys:
@@ -469,16 +477,26 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
         batch = preprocessor(batch)
         train_tracker.dataloading_s = time.perf_counter() - start_time
 
-        train_tracker, output_dict = update_policy(
-            train_tracker,
-            policy,
-            batch,
-            optimizer,
-            cfg.optimizer.grad_clip_norm,
-            accelerator=accelerator,
-            lr_scheduler=lr_scheduler,
-            sample_weighter=sample_weighter,
-        )
+        update_start_time = time.perf_counter()
+        with accelerator.accumulate(policy):
+            train_tracker, output_dict = update_policy(
+                train_tracker,
+                policy,
+                batch,
+                optimizer,
+                cfg.optimizer.grad_clip_norm,
+                accelerator=accelerator,
+                lr_scheduler=lr_scheduler,
+                sample_weighter=sample_weighter,
+            )
+            did_optimizer_update = accelerator.sync_gradients
+
+        accumulated_update_s += time.perf_counter() - update_start_time
+        if not did_optimizer_update:
+            continue
+
+        train_tracker.update_s = accumulated_update_s
+        accumulated_update_s = 0.0
 
         # Note: eval and checkpoint happens *after* the `step`th training update has completed, so we
         # increment `step` here.
@@ -555,7 +573,7 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
                     "eval_s": AverageMeter("eval_s", ":.3f"),
                 }
                 eval_tracker = MetricsTracker(
-                    cfg.batch_size,
+                    samples_per_update_per_process,
                     dataset.num_frames,
                     dataset.num_episodes,
                     eval_metrics,

--- a/tests/training/test_gradient_accumulation.py
+++ b/tests/training/test_gradient_accumulation.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+import sys
+import types
+
+import pytest
+import torch
+
+from lerobot.utils.logging_utils import AverageMeter, MetricsTracker
+
+
+def import_update_policy():
+    # The trainer module imports the dataset package for the full CLI path, but
+    # this unit test only exercises update_policy. Keep the test runnable with
+    # the base test extra, where Hugging Face datasets is not always installed.
+    if importlib.util.find_spec("datasets") is None:
+        fake_datasets_module = types.ModuleType("lerobot.datasets")
+        fake_datasets_module.__path__ = []
+        fake_datasets_module.EpisodeAwareSampler = object
+        fake_datasets_module.make_dataset = None
+        fake_language_module = types.ModuleType("lerobot.datasets.language")
+        fake_language_module.LANGUAGE_COLUMNS = set()
+        sys.modules.setdefault("lerobot.datasets", fake_datasets_module)
+        sys.modules.setdefault("lerobot.datasets.language", fake_language_module)
+
+    from lerobot.scripts.lerobot_train import update_policy
+
+    return update_policy
+
+
+class StepCounter:
+    def __init__(self):
+        self.steps = 0
+
+    def step(self):
+        self.steps += 1
+
+
+class TinyPolicy(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.tensor([1.0]))
+
+    def forward(self, batch):
+        loss = ((self.weight * batch["x"] - batch["y"]) ** 2).mean()
+        return loss, {"policy_loss": loss.detach()}
+
+
+def make_tracker():
+    return MetricsTracker(
+        batch_size=2,
+        num_frames=100,
+        num_episodes=10,
+        metrics={
+            "loss": AverageMeter("loss", ":.3f"),
+            "grad_norm": AverageMeter("grdn", ":.3f"),
+            "lr": AverageMeter("lr", ":0.1e"),
+            "update_s": AverageMeter("updt_s", ":.3f"),
+        },
+    )
+
+
+def test_update_policy_accumulates_before_optimizer_step():
+    accelerate = pytest.importorskip("accelerate")
+    update_policy = import_update_policy()
+    accelerator = accelerate.Accelerator(cpu=True, gradient_accumulation_steps=2)
+    policy = TinyPolicy()
+    optimizer = torch.optim.SGD(policy.parameters(), lr=0.1)
+    scheduler = StepCounter()
+    policy, optimizer = accelerator.prepare(policy, optimizer)
+    tracker = make_tracker()
+
+    batch = {"x": torch.ones(2), "y": torch.zeros(2)}
+    initial_weight = accelerator.unwrap_model(policy).weight.detach().clone()
+
+    with accelerator.accumulate(policy):
+        update_policy(
+            tracker,
+            policy,
+            batch,
+            optimizer,
+            grad_clip_norm=0.0,
+            accelerator=accelerator,
+            lr_scheduler=scheduler,
+        )
+
+    assert scheduler.steps == 0
+    assert torch.equal(accelerator.unwrap_model(policy).weight.detach(), initial_weight)
+
+    with accelerator.accumulate(policy):
+        update_policy(
+            tracker,
+            policy,
+            batch,
+            optimizer,
+            grad_clip_norm=0.0,
+            accelerator=accelerator,
+            lr_scheduler=scheduler,
+        )
+
+    assert scheduler.steps == 1
+    assert accelerator.unwrap_model(policy).weight.item() < initial_weight.item()


### PR DESCRIPTION
## Title

Add support for gradient accumulation support during training

## Summary / Motivation

- When training Nvidia Gr00t 1.7N, the official docs benchmark docs report a batch size of 640
- This is too large to run an on RTX Pro 6000, requiring a datacenter GPU to run in a single batch
- Instead, we can use gradient accumulation to perform eval on a smaller batchsize, but delay model updates for a few batches to get a larger "effective batch size"
- This is mentioned in the Lerobot hardware guide, but didn't appear to be implemented in lerobot train cli.

## Related issues

None

## What changed

- In train loop, delay optimizer step for passed N steps
- Update docs to indicate new math for effective batch size
- Add CLI flag to control N
- Default behavior still 1, no default behavior changes

## How was this tested (or how to run locally)

- Pytests added to make sure cli flag controls optimizer step correctly
-   python -m pytest -q tests/training/test_gradient_accumulation.py
- Did a test wiht Libero 10 under the following conditions:
    - Train w/ batch size 320 for 20k steps
        - --batch_size=320 --steps=20000 
    - Train w/ batch size 320 Grad Accumulation 2 for 10k steps
       - --batch_size=320 --gradient_accumulation_steps=2 --steps=10000
    - Seen examples the same, but fewer/smoother grad update calls
    - Eval numbers were about the same, but this is a more accurate reproduction of:
        https://github.com/NVIDIA/Isaac-GR00T/blob/main/examples/LIBERO/README.md
        
## Checklist (required before merge)

- [X] Linting/formatting run (`pre-commit run -a`)
- [X] All tests pass locally (`pytest`)
- [X] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: # (insert PR number/link)

## Reviewer notes
- Anyone in the community is free to review the PR.
