### PR TITLE
fix(train): enable relative action overrides for pretrained processors

### DIFF
--- a/src/lerobot/configs/train.py
+++ b/src/lerobot/configs/train.py
@@ -177,6 +177,12 @@ class TrainPipelineConfig(HubMixin):
             )
 
         active_cfg = self.trainable_config
+        if self.rename_map and active_cfg.pretrained_path is None:
+            raise ValueError(
+                "`rename_map` requires a pretrained policy checkpoint. "
+                "Fresh initialization derives feature names from the current dataset, so no rename is applied."
+            )
+
         if not self.job_name:
             if self.env is None:
                 self.job_name = f"{active_cfg.type}"

--- a/src/lerobot/processor/relative_action_processor.py
+++ b/src/lerobot/processor/relative_action_processor.py
@@ -81,7 +81,7 @@ def to_absolute_actions(actions: Tensor, state: Tensor, mask: Sequence[bool]) ->
     return actions
 
 
-@ProcessorStepRegistry.register("delta_actions_processor")
+@ProcessorStepRegistry.register("relative_actions_processor")
 @dataclass
 class RelativeActionsProcessorStep(ProcessorStep):
     """Converts absolute actions to relative actions (action -= state) for masked dimensions.

--- a/src/lerobot/scripts/lerobot_train.py
+++ b/src/lerobot/scripts/lerobot_train.py
@@ -292,19 +292,8 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
 
     active_cfg = cfg.trainable_config
     processor_pretrained_path = active_cfg.pretrained_path
-    if (
-        getattr(active_cfg, "use_relative_actions", False)
-        and processor_pretrained_path is not None
-        and not cfg.resume
-    ):
-        logging.warning(
-            "use_relative_actions=true with pretrained processors can skip relative transforms if "
-            "the checkpoint processors do not define them. Building processors from current policy config."
-        )
-        processor_pretrained_path = None
 
     processor_kwargs = {}
-    postprocessor_kwargs = {}
     if (processor_pretrained_path and not cfg.resume) or not processor_pretrained_path:
         processor_kwargs["dataset_stats"] = dataset.meta.stats
 
@@ -312,24 +301,31 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
         processor_kwargs["dataset_meta"] = dataset.meta
 
     if not cfg.is_reward_model_training and processor_pretrained_path is not None:
-        processor_kwargs["preprocessor_overrides"] = {
+        preprocessor_overrides = {
             "device_processor": {"device": device.type},
             "normalizer_processor": {
                 "stats": dataset.meta.stats,
                 "features": {**policy.config.input_features, **policy.config.output_features},
                 "norm_map": policy.config.normalization_mapping,
             },
+            "rename_observations_processor": {"rename_map": cfg.rename_map},
         }
-        processor_kwargs["preprocessor_overrides"]["rename_observations_processor"] = {
-            "rename_map": cfg.rename_map
-        }
-        postprocessor_kwargs["postprocessor_overrides"] = {
+        postprocessor_overrides = {
             "unnormalizer_processor": {
                 "stats": dataset.meta.stats,
                 "features": policy.config.output_features,
                 "norm_map": policy.config.normalization_mapping,
             },
         }
+        if getattr(active_cfg, "use_relative_actions", False):
+            preprocessor_overrides["relative_actions_processor"] = {
+                "enabled": True,
+                "exclude_joints": getattr(active_cfg, "relative_exclude_joints", []),
+                "action_names": getattr(active_cfg, "action_feature_names", None),
+            }
+            postprocessor_overrides["absolute_actions_processor"] = {"enabled": True}
+        processor_kwargs["preprocessor_overrides"] = preprocessor_overrides
+        processor_kwargs["postprocessor_overrides"] = postprocessor_overrides
 
     if cfg.is_reward_model_training:
         preprocessor, postprocessor = make_reward_pre_post_processors(
@@ -341,7 +337,6 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
             policy_cfg=cfg.policy,
             pretrained_path=processor_pretrained_path,
             **processor_kwargs,
-            **postprocessor_kwargs,
         )
 
     if is_main_process:


### PR DESCRIPTION
## Summary / Motivation

This fixes the `use_relative_actions=true` training path by keeping pretrained policy and pretrained processor initialization aligned.

Processor pipeline is a part of checkpoint contract: when loading a pretrained policy, `lerobot-train` should load the paired pretrained pre/post-processor pipeline; when initializing a policy from scratch, processors will be built from the corresponding policy config. The previous relative-action path mixed these modes by loading a pretrained policy while forcing processors to be rebuilt from the current policy config. Its purpose is to ensure backward compatibility with older pi checkpoints, which did not contain the relative-action processor steps, but it broke the pretrained policy + pretrained processor contract and could bypass checkpoint-specific processor behavior such as `rename_map` (caused in #3425).

This PR replaces the previous "fresh-build fallback" with the same "override-based pattern" used for `device_processor`, `normalizer_processor`, and `unnormalizer_processor`. The official pi checkpoints are updated separately so their processor JSON files include disabled relative/absolute action processor steps. `lerobot-train` can then enable those steps at runtime through overrides.

For stale local checkpoints whose processor JSON has not been migrated, the existing override validation fails fast with a `KeyError` listing the missing override key and available processor step keys. This is intentional: users should update their checkpoint rather than silently rebuilding processors.

## Related issues

- Fixes: https://github.com/huggingface/lerobot/issues/3425
- Related PRs:
  - https://github.com/huggingface/lerobot/pull/3428
  - https://github.com/huggingface/lerobot/pull/3514
  - https://github.com/huggingface/lerobot/pull/2970

## Related checkpoint PRs

This code change is intended to be used together with migrated checkpoint processor JSON files where the checkpoint action space is compatible with `RelativeActionsProcessorStep`.

| Model | Checkpoint change / PR | PR head |
| --- | --- | --- |
| [lerobot/pi0_old](https://huggingface.co/lerobot/pi0_old) | No checkpoint PR opened; legacy archival pi0 checkpoint not targeted by this migration. | N/A |
| [lerobot/pi0_base](https://huggingface.co/lerobot/pi0_base) | Add disabled `relative_actions_processor` / `absolute_actions_processor` steps: [discussion #6](https://huggingface.co/lerobot/pi0_base/discussions/6). | [refs/pr/6](https://huggingface.co/lerobot/pi0_base/tree/refs%2Fpr%2F6) |
| [lerobot/pi0_libero_base](https://huggingface.co/lerobot/pi0_libero_base) | No checkpoint PR opened; LIBERO checkpoint action space is already delta EEF pose. | N/A |
| [lerobot/pi0_libero_finetuned_v044](https://huggingface.co/lerobot/pi0_libero_finetuned_v044) | No checkpoint PR opened; LIBERO checkpoint action space is already delta EEF pose. | N/A |
| [lerobot/pi05_base](https://huggingface.co/lerobot/pi05_base) | Add disabled `relative_actions_processor` / `absolute_actions_processor` steps: [discussion #6](https://huggingface.co/lerobot/pi05_base/discussions/6). | [refs/pr/6](https://huggingface.co/lerobot/pi05_base/tree/refs%2Fpr%2F6) |
| [lerobot/pi05_libero_base](https://huggingface.co/lerobot/pi05_libero_base) | No checkpoint PR opened; LIBERO checkpoint action space is already delta EEF pose. | N/A |
| [lerobot/pi05_libero_finetuned_v044](https://huggingface.co/lerobot/pi05_libero_finetuned_v044) | No checkpoint PR opened; LIBERO checkpoint action space is already delta EEF pose. | N/A |
| [lerobot/pi05_libero_finetuned_quantiles_v044](https://huggingface.co/lerobot/pi05_libero_finetuned_quantiles_v044) | No checkpoint PR opened; LIBERO checkpoint action space is already delta EEF pose. | N/A |
| [lerobot/pi05-libero](https://huggingface.co/lerobot/pi05-libero) | No checkpoint PR opened; LIBERO checkpoint action space is already delta EEF pose. | N/A |
| [lerobot/folding_latest](https://huggingface.co/lerobot/folding_latest) | Rename legacy `delta_actions_processor` to `relative_actions_processor`: [discussion #1](https://huggingface.co/lerobot/folding_latest/discussions/1). | [refs/pr/1](https://huggingface.co/lerobot/folding_latest/tree/refs%2Fpr%2F1) |
| [lerobot/pi0fast-base](https://huggingface.co/lerobot/pi0fast-base) | Add disabled `relative_actions_processor` / `absolute_actions_processor` steps: [discussion #4](https://huggingface.co/lerobot/pi0fast-base/discussions/4). | [refs/pr/4](https://huggingface.co/lerobot/pi0fast-base/tree/refs%2Fpr%2F4) |
| [lerobot/pi0fast-libero-v044](https://huggingface.co/lerobot/pi0fast-libero-v044) | No checkpoint PR opened; LIBERO checkpoint action space is already delta EEF pose. | N/A |
| [lerobot/pi0fast-libero](https://huggingface.co/lerobot/pi0fast-libero) | No checkpoint PR opened; LIBERO checkpoint action space is already delta EEF pose. | N/A |

The LIBERO-related checkpoints are intentionally not migrated to add relative processor steps. LIBERO actions are already delta end-effector pose actions, while the current `RelativeActionsProcessorStep` only supports joint-space relative action conversion by subtracting the current joint state from absolute joint actions.

## What changed

- Renamed the relative action processor registry key from `delta_actions_processor` to `relative_actions_processor`.
- Removed the `lerobot-train` special case that forced fresh-built processors when `use_relative_actions=true`.
- Added pretrained processor overrides for:
  - `relative_actions_processor.enabled`
  - `relative_actions_processor.exclude_joints`
  - `relative_actions_processor.action_names`
  - `absolute_actions_processor.enabled`
- Kept `_reconnect_relative_absolute_steps()` as the runtime mechanism for reconnecting `AbsoluteActionsProcessorStep.relative_step` after deserialization.
- Kept stale-checkpoint behavior fail-fast through the existing processor override validation.

## How was this tested (or how to run locally)

### Quality checks

- `pre-commit run --files src/lerobot/processor/relative_action_processor.py src/lerobot/scripts/lerobot_train.py`
  Result: passed.

- `ruff format --check src/lerobot/processor/relative_action_processor.py src/lerobot/scripts/lerobot_train.py`
  Result: passed, `2 files already formatted`.

- `ruff check src/lerobot/processor/relative_action_processor.py src/lerobot/scripts/lerobot_train.py`
  Result: passed, `All checks passed!`.

### Training smoke tests

| Checkpoint | `use_relative_actions` | Result | Notes |
| --- | --- | --- | --- |
| Updated `lerobot/pi0_base` | `false` | Passed | Normal pretrained path still trains |
| Updated `lerobot/pi0_base` | `true` | Passed | Relative/absolute processors enabled through overrides |
| Original `lerobot/pi0_base` | `false` | Passed | Backward-compatible for non-relative training |
| Original `lerobot/pi0_base` | `true` | Failed as expected | Stale processor topology raises `KeyError` |

Detailed logs:

- `lerobot-train`, `lerobot/pi0_base_update`, `policy.type=pi0`, `use_relative_actions=true`,
  Result: passed.
  Key output: `All keys loaded successfully!`, `step:1 ... loss:1092.798`, `End of training`.

- `lerobot-train`, original `lerobot/pi0_base`, `policy.type=pi0`, `use_relative_actions=true`,
  Result: failed as expected because the original checkpoint processor JSON does not contain `relative_actions_processor`.
  Key error:
  ```text
  KeyError: "Override keys ['relative_actions_processor'] do not match any step in the saved configuration.
  Available step keys: ['rename_observations_processor', 'to_batch_processor', 'pi0_new_line_processor', 'tokenizer_processor', 'device_processor', 'normalizer_processor'].
  ```

This verifies the intended migration behavior: old checkpoint topology fails clearly instead of silently rebuilding processors.



## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated (No need for update)
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: # (insert PR number/link)

## Reviewer notes

Please test `use_relative_actions=true` with the updated checkpoint processor JSON from the linked Hugging Face checkpoint PRs, not with the old checkpoint files currently on `main`.

Using an unmigrated local checkpoint is expected to fail with the existing processor override `KeyError`, because the saved processor topology does not contain `relative_actions_processor` / `absolute_actions_processor`. That failure mode is intentional and points users toward updating the checkpoint processor JSON instead of silently rebuilding processors.

