### PR TITLE
fix(datasets): default private to None in push_to_hub

### DIFF
--- a/src/lerobot/configs/dataset.py
+++ b/src/lerobot/configs/dataset.py
@@ -41,8 +41,8 @@ class DatasetRecordConfig:
     video: bool = True
     # Upload dataset to Hugging Face hub.
     push_to_hub: bool = True
-    # Upload on private repository on the Hugging Face hub.
-    private: bool = False
+    # If True, upload as private; if None, defer to the org default on the Hub (only affects orgs).
+    private: bool | None = None
     # Add tags to your dataset on the hub.
     tags: list[str] | None = None
     # Number of subprocesses handling the saving of frames as PNG. Set to 0 to use threads only;

--- a/src/lerobot/datasets/lerobot_dataset.py
+++ b/src/lerobot/datasets/lerobot_dataset.py
@@ -524,7 +524,7 @@ class LeRobotDataset(torch.utils.data.Dataset):
         license: str | None = "apache-2.0",
         tag_version: bool = True,
         push_videos: bool = True,
-        private: bool = False,
+        private: bool | None = None,
         allow_patterns: list[str] | str | None = None,
         upload_large_folder: bool = False,
         **card_kwargs,
@@ -543,7 +543,8 @@ class LeRobotDataset(torch.utils.data.Dataset):
             tag_version: If ``True``, create a Git tag for the current codebase
                 version.
             push_videos: If ``False``, skip uploading the ``videos/`` directory.
-            private: If ``True``, create a private repository.
+            private: If ``True``, create a private repository. If ``None``
+                (default), defer to the org default on the Hub (only affects orgs).
             allow_patterns: Glob pattern(s) restricting which files to upload.
             upload_large_folder: If ``True``, use ``upload_large_folder`` instead
                 of ``upload_folder`` for very large datasets.


### PR DESCRIPTION
## Title

fix(datasets): default private to None in push_to_hub

## Type / Scope

- **Type**: Bug
- **Scope**: datasets, configs

## Summary / Motivation

- `LeRobotDataset.push_to_hub()` and `DatasetConfig` default `private` to `False`, which sends an explicit visibility to the Hub API rather than deferring to org defaults. Changing the default to `None` lets the server decide, consistent with how the policy path (`configs/policies.py`) already handles it.

## Related issues

- Fixes / Closes: N/A
- Related: N/A

## What changed

- `src/lerobot/configs/dataset.py`: `private: bool = False` → `private: bool | None = None`
- `src/lerobot/datasets/lerobot_dataset.py`: same change in `push_to_hub()` + docstring update
- No breaking changes. Explicit `--dataset.private=true/false` still works.

## How was this tested (or how to run locally)

- 

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [ ] CI is green