### PR TITLE
Add Waveshare RoArm-M3 follower + leader

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -165,6 +165,8 @@
     title: OpenArm
   - local: rebot_b601
     title: reBot B601-DM
+  - local: roarm_m3
+    title: RoArm-M3
   title: "Robots"
 - sections:
   - local: phone_teleop

--- a/docs/source/roarm_m3.mdx
+++ b/docs/source/roarm_m3.mdx
@@ -1,0 +1,86 @@
+# RoArm-M3
+
+[RoArm-M3](https://www.waveshare.com/wiki/RoArm-M3) is a low-cost 5-DOF + gripper desktop robot arm from Waveshare, driven by serial-bus servos through an on-board ESP32. LeRobot controls it over the ESP32's JSON serial protocol (via the `roarm_sdk` package), not a Feetech/Dynamixel binary bus. It comes as a **follower** arm (`roarm_m3_follower`) and can be teleoperated by a second RoArm-M3 used as a passive **leader** (`roarm_m3_leader`).
+
+## Install LeRobot 🤗
+
+Follow our [Installation Guide](./installation), then install the RoArm support:
+
+```bash
+pip install -e ".[roarm]"
+```
+
+This pulls in `roarm_sdk` (the JSON-over-serial control library for the ESP32).
+
+## Registered device types
+
+| Type                | Kind                                           |
+| ------------------- | ---------------------------------------------- |
+| `roarm_m3_follower` | single-arm RoArm-M3 follower robot             |
+| `roarm_m3_leader`   | passive RoArm-M3 used as a leader teleoperator |
+
+## Firmware: baud-rate patch (required)
+
+Out of the box the ESP32 USB serial link is capped at 115200 baud while the servo bus already runs at 1 Mbps internally, which bottlenecks state reads and teleoperation. Reflash the ESP32 so the USB link also runs at 1 Mbps — a one-line change in the Waveshare firmware sketch:
+
+```cpp
+// RoArm-M3_example.ino
+Serial.begin(1000000);   // USB: was 115200 -> 1 Mbps (matches the internal servo bus)
+```
+
+Build with `arduino-cli` (ESP32 Arduino core) and flash the binaries with `esptool`:
+
+```bash
+arduino-cli compile --fqbn esp32:esp32:esp32 RoArm-M3_example/
+python3 -m esptool --port /dev/ttyUSB0 --baud 921600 --chip esp32 write-flash \
+  0x1000  bootloader.bin \
+  0x8000  partitions.bin \
+  0x10000 firmware.bin
+```
+
+After patching, the leader/follower state-read rate rises from ~23 Hz to ~42 Hz and teleop is smooth at 30 fps. Then use `--robot.baudrate=1000000` (the default).
+
+<Tip warning={true}>
+  Confirm the exact board model and the real serial port (`arduino-cli board
+  list`) before flashing, and never pass `--no-verify` — a wrong firmware image
+  can brick the controller board.
+</Tip>
+
+## Gripper
+
+- **Stock gripper / Waveshare Gripper A**: nothing extra — position control works out of the box once the baud patch is applied. This is the default (`force_control_gripper=false`).
+- **Waveshare Gripper B (CF-3512 force control)**: optional. Its constant-current clamping force needs firmware that writes the gripper's torque register, and on the driver side set `--robot.force_control_gripper=true`. The bundled "move all joints" command zeroes that register for every servo, so with the flag on the driver issues a second, gripper-only write each step to re-apply the force (otherwise the jaw won't hold).
+
+## Find the USB ports
+
+```bash
+lerobot-find-port
+```
+
+Prefer the stable `/dev/serial/by-id/...` path for each arm; the `ttyUSB*` numbers can swap on reboot. The leader and follower must be on different ports.
+
+## Calibration
+
+The RoArm-M3 reports joint angles in degrees directly and keeps no per-robot offset calibration file here, so `lerobot-calibrate` is a no-op for these devices and can be skipped.
+
+## Teleoperation
+
+Drive the follower with a second RoArm-M3 held torque-off and moved by hand:
+
+```bash
+lerobot-teleoperate \
+    --robot.type=roarm_m3_follower \
+    --robot.port=/dev/ttyUSB0 \
+    --robot.id=follower \
+    --teleop.type=roarm_m3_leader \
+    --teleop.port=/dev/ttyUSB1 \
+    --teleop.id=leader
+```
+
+The leader reads its joint angles, smooths them with an EMA (`--teleop.ema_alpha`, default `0.5`) to damp gearbox jitter, and sends them to the follower in the same joint space. When both arms use the same gripper it passes through directly; if they differ (for example a Gripper B follower), enable `--teleop.gripper_remap=true` to map the leader's gripper range onto the follower's.
+
+## Recording datasets
+
+Swap `lerobot-teleoperate` for `lerobot-record` (same `--robot.*` / `--teleop.*` arguments, plus `--dataset.*`) to record demonstrations for training. See [Imitation Learning for Robots](./il_robots) for the full workflow.
+
+For firmware and hardware assembly details, see the [Waveshare RoArm-M3 wiki](https://www.waveshare.com/wiki/RoArm-M3).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,6 +196,8 @@ reachy2 = [
 # Seeed Studio reBot B601-DM follower (motorbridge / CAN) + StarArm102 / reBot Arm 102
 # leader (motorbridge-smart-servo / FashionStar UART servos).
 rebot = ["lerobot[motorbridge-dep]", "lerobot[motorbridge-smart-servo-dep]"]
+# Waveshare RoArm-M3 follower + leader (JSON-over-serial via the on-board ESP32).
+roarm = ["roarm_sdk>=0.1.0,<0.2.0"]
 kinematics = ["lerobot[placo-dep]"]
 intelrealsense = [
     "pyrealsense2>=2.55.1.6486,<2.57.0 ; sys_platform != 'darwin'",
@@ -307,6 +309,7 @@ all = [
     "lerobot[openarms]",
     "lerobot[reachy2]",
     "lerobot[rebot]",
+    "lerobot[roarm]",
     "lerobot[kinematics]",
     "lerobot[intelrealsense]",
     "lerobot[diffusion]",

--- a/src/lerobot/robots/roarm_m3_follower/__init__.py
+++ b/src/lerobot/robots/roarm_m3_follower/__init__.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .config_roarm_m3_follower import RoarmM3FollowerConfig
+from .roarm_m3_common import ANGLES_MAX, ANGLES_MIN, JOINT_NAMES
+from .roarm_m3_follower import RoarmM3Follower
+
+__all__ = [
+    "ANGLES_MAX",
+    "ANGLES_MIN",
+    "JOINT_NAMES",
+    "RoarmM3Follower",
+    "RoarmM3FollowerConfig",
+]

--- a/src/lerobot/robots/roarm_m3_follower/async_worker.py
+++ b/src/lerobot/robots/roarm_m3_follower/async_worker.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Background serial-I/O thread for the RoArm-M3 follower.
+
+The ``roarm_sdk`` serial calls block ~35-50 ms each. The synchronous record/eval loop
+would be capped well below 20 fps by a blocking get/set inside the loop, so this worker
+moves ALL serial I/O for the follower onto one background thread: it owns reads AND writes
+in a single thread, so a read and a write never race on the same serial port (no locking
+needed between the main thread and the worker). No reference arm needs this because their
+CAN/gRPC transports are fast; the JSON-over-serial transport here makes it worth it.
+
+Gripper-B force (opt-in via ``force_control_gripper``): the bundled "move all joints"
+command (``joints_angle_ctrl``, firmware T:122 / SyncWritePosEx) zeroes the
+GOAL_TIME/GOAL_TORQUE registers for every servo. On a Waveshare Gripper B (CF-3512, CFSCL)
+that zeroes the constant-current force, so the jaw won't hold. When force control is
+enabled, the worker issues a second, gripper-only write (``joint_angle_ctrl(joint=6)``,
+firmware T:121) right after the bundle, which re-applies the gripper torque. With force
+control off, only the single bundled write is sent (the common case).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import queue as _queue
+import threading
+import time
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+class AsyncArmWorker:
+    """Single background thread that owns ALL serial I/O for one follower arm.
+
+    Main-thread API (non-blocking, ~0 ms):
+        worker.write(goal_pos, speed, acc)  - queue a command, returns instantly
+        worker.get_pos()                    - return the latest cached joint state
+    """
+
+    def __init__(
+        self,
+        arm,
+        name: str,
+        read_interval_s: float = 0.15,
+        force_control_gripper: bool = False,
+    ):
+        self._arm = arm
+        self._name = name
+        self._read_interval = read_interval_s
+        self._force_control_gripper = force_control_gripper
+        self._write_q: _queue.Queue = _queue.Queue(maxsize=1)
+        self._pos: np.ndarray | None = None
+        self._pos_lock = threading.Lock()
+        self._stop_event = threading.Event()
+        self._thread = threading.Thread(target=self._run, daemon=True, name=f"AsyncArmWorker-{name}")
+
+    def start(self):
+        self._thread.start()
+
+    def stop(self):
+        self._stop_event.set()
+        self._thread.join(timeout=2.0)
+
+    def write(self, goal_pos: list, speed: int, acc: int) -> None:
+        """Non-blocking write. Drops the previous command if the queue is full."""
+        cmd = (goal_pos, speed, acc)
+        if self._write_q.full():
+            with contextlib.suppress(_queue.Empty):
+                self._write_q.get_nowait()
+        with contextlib.suppress(_queue.Full):
+            self._write_q.put_nowait(cmd)
+
+    def get_pos(self) -> np.ndarray | None:
+        with self._pos_lock:
+            return None if self._pos is None else self._pos.copy()
+
+    def _execute_write(self, goal_pos: list, speed: int, acc: int) -> None:
+        """Perform one write: the bundled joint command, plus -- when
+        force_control_gripper is set -- a gripper-only command (firmware T:121) that
+        restores the CF-3512 clamping force the bundled write zeroes. Pulled out of the
+        run loop so it can be unit-tested without the background thread."""
+        self._arm.joints_angle_ctrl(angles=goal_pos, speed=speed, acc=acc)
+        if self._force_control_gripper and len(goal_pos) >= 6:
+            self._arm.joint_angle_ctrl(joint=6, angle=float(goal_pos[5]), speed=speed, acc=acc)
+
+    def _run(self):
+        last_read = 0.0
+        while not self._stop_event.is_set():
+            # Priority 1: execute a pending write.
+            try:
+                goal_pos, speed, acc = self._write_q.get(timeout=0.005)
+                self._execute_write(goal_pos, speed, acc)
+            except _queue.Empty:
+                pass
+
+            # Priority 2: periodic joint read.
+            now = time.perf_counter()
+            if now - last_read >= self._read_interval:
+                try:
+                    pos = self._arm.joints_angle_get()
+                    if pos is not None:
+                        with self._pos_lock:
+                            self._pos = np.array(pos, dtype=np.float32)
+                    last_read = now
+                except Exception as exc:  # pragma: no cover - serial flakiness
+                    logger.debug(f"AsyncArmWorker [{self._name}] read error: {exc}")

--- a/src/lerobot/robots/roarm_m3_follower/config_roarm_m3_follower.py
+++ b/src/lerobot/robots/roarm_m3_follower/config_roarm_m3_follower.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+from lerobot.cameras import CameraConfig
+
+from ..config import RobotConfig
+
+
+@RobotConfig.register_subclass("roarm_m3_follower")
+@dataclass
+class RoarmM3FollowerConfig(RobotConfig):
+    """Configuration for a single Waveshare RoArm-M3 follower arm and its cameras.
+
+    The RoArm-M3 is driven over a JSON-over-serial link through its on-board ESP32
+    (via ``roarm_sdk``), not over a Feetech/Dynamixel binary bus, so this config carries a
+    serial ``port`` and ``baudrate`` rather than a motors map.
+    """
+
+    # Serial device of the follower arm, e.g. "/dev/ttyUSB0". Prefer a stable
+    # /dev/serial/by-id/... path; ttyUSBx numbers can swap on reboot.
+    port: str = "/dev/ttyUSB0"
+
+    # Serial baudrate. Use 1_000_000 (1 Mbps) on firmware with the baud patch applied
+    # (USB Serial.begin(1000000), matching the internal servo bus); this lifts the
+    # state-read rate from ~23 Hz to ~42 Hz and enables smooth 30 fps teleop. Stock
+    # firmware is 115200.
+    baudrate: int = 1_000_000
+
+    # `max_relative_target` limits the magnitude of the relative positional target vector
+    # for safety (degrees). float => same value for all joints; dict => per joint (keys
+    # must be joint names); None => disabled.
+    max_relative_target: float | dict[str, float] | None = None
+
+    # Quantization applied to the action before sending it to the firmware (which takes
+    # integer degrees). "floor" truncates toward zero (firmware default), "round" rounds to
+    # the nearest integer (avoids the downward bias of truncation), "float" forwards the raw
+    # float for firmware builds that accept non-integer joint targets.
+    action_quantization: Literal["floor", "round", "float"] = "floor"
+
+    # Opt-in Waveshare Gripper B (CF-3512, force-control) support. Default False =
+    # position-only, a single bundled write per step (right for the stock gripper / Gripper
+    # A). When True, the driver adds a second, gripper-only write each step so the CF-3512
+    # receives its constant-current torque; see the robot docstring and roarm_m3.mdx.
+    force_control_gripper: bool = False
+
+    # Send {"T":605,"cmd":0} on connect to stop the firmware feedback stream (fresh reads).
+    disable_info_flow: bool = True
+
+    # Release follower torque on disconnect so the arm can be moved by hand.
+    disable_torque_on_disconnect: bool = True
+
+    # Motion speed / acceleration passed to the firmware joint commands.
+    motion_speed: int = 500
+    motion_acc: int = 50
+
+    # Cameras keyed by short logical name ("wrist", "front", ...). Empty by default; the
+    # caller injects camera configs (USB indices vary per boot).
+    cameras: dict[str, CameraConfig] = field(default_factory=dict)

--- a/src/lerobot/robots/roarm_m3_follower/roarm_m3_common.py
+++ b/src/lerobot/robots/roarm_m3_follower/roarm_m3_common.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared constants and helpers for the RoArm-M3 follower and leader.
+
+The dataset schema (``JOINT_NAMES``), the per-joint limits, the floor quantization and
+the stale-state handling must be identical on the follower (Robot) and the leader
+(Teleoperator), or recorded action labels would not match what the robot executes.
+This module is the single source for the follower side; the leader keeps its own copy of
+the small constant set (no teleoperator imports a robots subpackage) and the test suite
+asserts they agree.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+# Fixed joint order = the dataset schema. Do not reorder.
+JOINT_NAMES = ["base", "shoulder", "elbow", "wrist_tilt", "wrist_roll", "gripper"]
+
+# Per-joint angle limits in degrees, in JOINT_NAMES order. Wrist-roll (index 4) is
+# restricted to +-90 deg to protect the gripper cables.
+WRIST_R_LIMIT = 90
+ANGLES_MIN = [-190, -110, -70, -110, -WRIST_R_LIMIT, -10]
+ANGLES_MAX = [190, 110, 190, 110, WRIST_R_LIMIT, 300]
+
+
+def quantize_action(goal_pos, mode: str = "floor") -> np.ndarray:
+    """Quantize a joint goal vector before sending it to the firmware.
+
+    The firmware takes integer degrees, which makes a 1-degree staircase on slow
+    trajectories. ``mode`` is set from the config (no hidden global state):
+
+      "floor" (default): astype(int32) truncates toward zero -> 1-degree step with a
+              systematic downward bias (73.8 -> 73). This is the proven path.
+      "round": np.rint then int32 -> removes the downward bias, keeps the 1-degree step.
+      "float": send float degrees -> removes the staircase IF the firmware accepts floats
+               (validate with a roundtrip on the robot before relying on it).
+
+    Applied identically on the follower (send_action) and the leader (get_action) so the
+    recorded action label matches what the robot executes (ACT-space alignment).
+    """
+    arr = goal_pos.numpy() if hasattr(goal_pos, "numpy") else np.asarray(goal_pos)
+    if mode == "float":
+        return arr.astype(np.float64)
+    if mode == "round":
+        return np.rint(arr).astype(np.int32)
+    return arr.astype(np.int32)  # "floor" = proven default
+
+
+def clamp_limits(goal_pos: list) -> list:
+    """Clamp each joint to [ANGLES_MIN, ANGLES_MAX]."""
+    return [max(ANGLES_MIN[i], min(ANGLES_MAX[i], v)) for i, v in enumerate(goal_pos)]
+
+
+def disable_info_flow(arm) -> bool:
+    """Stop the firmware's continuous feedback stream so reads stay fresh.
+
+    Sends ``{"T":605,"cmd":0}`` once on the arm's serial handle. Firmware shipped with the
+    feedback stream on streams frames non-stop, the OS RX buffer fills, and every
+    ``joints_angle_get()`` then returns a stale (FIFO) reading -- adding seconds of
+    control-loop lag. Returns True on success; logs a warning and returns False if the
+    serial handle is missing or the write fails (callers should treat False as
+    "stale-read mitigation not applied").
+    """
+    ser = getattr(arm, "_serial_port", None)
+    if ser is None or not (hasattr(ser, "write") and hasattr(ser, "reset_input_buffer")):
+        logger.warning(
+            "RoArm serial handle (_serial_port) not found; cannot disable the firmware "
+            "info stream. State reads may be stale."
+        )
+        return False
+    try:
+        ser.write(b'{"T":605,"cmd":0}\n')
+        time.sleep(0.1)
+        ser.reset_input_buffer()
+        return True
+    except Exception as exc:
+        logger.warning(f"Failed to disable the RoArm firmware info stream: {exc}")
+        return False

--- a/src/lerobot/robots/roarm_m3_follower/roarm_m3_follower.py
+++ b/src/lerobot/robots/roarm_m3_follower/roarm_m3_follower.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Waveshare RoArm-M3 follower arm (6-DOF incl. gripper, JSON-over-serial via ESP32).
+
+Motor communication goes through the ``roarm_sdk`` package over a USB serial link to the
+arm's on-board ESP32 (JSON commands), not a Feetech/Dynamixel binary bus. This is a thin
+``Robot`` subclass that wraps the SDK directly (no MotorsBus). Because each SDK call blocks
+~35-50 ms, all serial I/O runs on a background ``AsyncArmWorker`` so the synchronous
+record/eval loop stays fast: ``get_observation`` reads a cache and ``send_action`` enqueues
+the write, both ~0 ms.
+
+Joint order is fixed and defines the dataset schema (see ``roarm_m3_common.JOINT_NAMES``):
+``[base, shoulder, elbow, wrist_tilt, wrist_roll, gripper]``.
+
+Gripper B (optional, ``force_control_gripper``): the Waveshare Gripper B uses a CF-3512
+constant-current servo. The bundled "move all joints" command zeroes its torque registers,
+so when force control is enabled the worker issues a second, gripper-only write to restore
+the clamping force. With it off (the default, for the stock gripper / Gripper A) a single
+position-only write is sent.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from functools import cached_property
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from lerobot.cameras import make_cameras_from_configs
+from lerobot.types import RobotAction, RobotObservation
+from lerobot.utils.decorators import check_if_already_connected, check_if_not_connected
+from lerobot.utils.import_utils import _roarm_sdk_available, require_package
+
+from ..robot import Robot
+from ..utils import ensure_safe_goal_position
+from .async_worker import AsyncArmWorker
+from .config_roarm_m3_follower import RoarmM3FollowerConfig
+from .roarm_m3_common import JOINT_NAMES, clamp_limits, disable_info_flow, quantize_action
+
+if TYPE_CHECKING or _roarm_sdk_available:
+    from roarm_sdk.roarm import roarm
+else:
+    roarm = None
+
+logger = logging.getLogger(__name__)
+
+
+class RoarmM3Follower(Robot):
+    """Single Waveshare RoArm-M3 follower arm + its USB cameras, as a LeRobot Robot."""
+
+    config_class = RoarmM3FollowerConfig
+    name = "roarm_m3_follower"
+
+    def __init__(self, config: RoarmM3FollowerConfig):
+        require_package("roarm_sdk", extra="roarm")
+        super().__init__(config)
+        self.config = config
+        self._arm = None  # roarm SDK handle, created in connect()
+        self._worker: AsyncArmWorker | None = None
+        self.cameras = make_cameras_from_configs(config.cameras)
+
+    @property
+    def _motors_ft(self) -> dict[str, type]:
+        return {f"{motor}.pos": float for motor in JOINT_NAMES}
+
+    @property
+    def _cameras_ft(self) -> dict[str, tuple]:
+        return {cam: (self.cameras[cam].height, self.cameras[cam].width, 3) for cam in self.cameras}
+
+    @cached_property
+    def observation_features(self) -> dict[str, type | tuple]:
+        return {**self._motors_ft, **self._cameras_ft}
+
+    @cached_property
+    def action_features(self) -> dict[str, type]:
+        return self._motors_ft
+
+    @property
+    def is_connected(self) -> bool:
+        return self._arm is not None and all(cam.is_connected for cam in self.cameras.values())
+
+    @check_if_already_connected
+    def connect(self, calibrate: bool = True) -> None:
+        logger.info(f"Connecting {self} on {self.config.port}...")
+        self._arm = roarm(roarm_type="roarm_m3", port=self.config.port, baudrate=self.config.baudrate)
+        # Probe the serial link (raises if the port is wrong / contended).
+        self._arm.joints_angle_get()
+
+        # Kill the firmware's continuous feedback stream so reads stay fresh.
+        if self.config.disable_info_flow:
+            disable_info_flow(self._arm)
+
+        if not self.is_calibrated and calibrate:
+            self.calibrate()
+
+        for cam in self.cameras.values():
+            cam.connect()
+
+        self.configure()  # enable follower torque
+
+        # One background thread owns ALL serial I/O so a read and a write never race. The
+        # gripper-B force double-write is opt-in via force_control_gripper.
+        self._worker = AsyncArmWorker(
+            self._arm,
+            f"follower_{self.id}",
+            read_interval_s=0.15,
+            force_control_gripper=self.config.force_control_gripper,
+        )
+        self._worker.start()
+        time.sleep(0.20)  # one read cycle to populate the position cache
+        logger.info(f"{self} connected.")
+
+    @property
+    def is_calibrated(self) -> bool:
+        # The RoArm-M3 has no per-robot motor-offset calibration file here.
+        return True
+
+    def calibrate(self) -> None:
+        # No-op: no per-robot motor-offset calibration.
+        pass
+
+    def configure(self) -> None:
+        """Enable follower torque (active, holds position)."""
+        if self._arm is not None:
+            self._arm.torque_set(cmd=1)
+
+    @check_if_not_connected
+    def disable_torque(self) -> None:
+        """Release follower torque so the arm can be moved by hand (drag-teach /
+        debugging). Call configure() to re-enable it. The background reader keeps the
+        position cache updating, so get_observation tracks the manual motion."""
+        self._arm.torque_set(cmd=0)
+        logger.info(f"{self} torque disabled.")
+
+    def _read_joint_positions(self) -> np.ndarray:
+        """6 joint angles (deg) from the worker cache (~0 ms), with a blocking fallback."""
+        cached = self._worker.get_pos() if self._worker is not None else None
+        if cached is None:
+            cached = np.array(self._arm.joints_angle_get(), dtype=np.float32)
+        return np.asarray(cached, dtype=np.float32)
+
+    @check_if_not_connected
+    def get_observation(self) -> RobotObservation:
+        start = time.perf_counter()
+        pos = self._read_joint_positions()
+        obs_dict: RobotObservation = {f"{n}.pos": float(pos[i]) for i, n in enumerate(JOINT_NAMES)}
+        logger.debug(f"{self} read state: {(time.perf_counter() - start) * 1e3:.1f}ms")
+
+        for cam_key, cam in self.cameras.items():
+            start = time.perf_counter()
+            obs_dict[cam_key] = cam.read_latest()
+            logger.debug(f"{self} read {cam_key}: {(time.perf_counter() - start) * 1e3:.1f}ms")
+
+        return obs_dict
+
+    @check_if_not_connected
+    def send_action(self, action: RobotAction) -> RobotAction:
+        """Enqueue a joint goal (degrees); return the action actually sent.
+
+        Reads goals in the fixed joint order (missing keys hold the present position),
+        optionally caps the relative step via ``max_relative_target``, quantizes per
+        ``action_quantization`` and clamps to the joint limits, then enqueues on the worker
+        (the worker performs the bundled write plus, if ``force_control_gripper`` is set,
+        the gripper-only force write).
+        """
+        present = self._read_joint_positions()
+        goal_pos = {n: float(action.get(f"{n}.pos", present[i])) for i, n in enumerate(JOINT_NAMES)}
+
+        # Cap relative target when too far from the present position.
+        if self.config.max_relative_target is not None:
+            present_pos = {n: float(present[i]) for i, n in enumerate(JOINT_NAMES)}
+            goal_present_pos = {n: (g, present_pos[n]) for n, g in goal_pos.items()}
+            goal_pos = ensure_safe_goal_position(goal_present_pos, self.config.max_relative_target)
+
+        goal = [goal_pos[n] for n in JOINT_NAMES]
+        goal = quantize_action(goal, self.config.action_quantization).tolist()
+        goal = clamp_limits(goal)
+
+        self._worker.write(goal, self.config.motion_speed, self.config.motion_acc)
+        return {f"{n}.pos": float(goal[i]) for i, n in enumerate(JOINT_NAMES)}
+
+    @check_if_not_connected
+    def disconnect(self) -> None:
+        if self._worker is not None:
+            self._worker.stop()
+            self._worker = None
+
+        if self.config.disable_torque_on_disconnect:
+            try:
+                self._arm.torque_set(cmd=0)
+            except Exception as exc:  # pragma: no cover
+                logger.debug(f"torque_set(0) on disconnect failed: {exc}")
+        try:
+            self._arm.disconnect()
+        except Exception as exc:  # pragma: no cover
+            logger.debug(f"arm.disconnect() failed: {exc}")
+        self._arm = None
+
+        for cam in self.cameras.values():
+            cam.disconnect()
+
+        logger.info(f"{self} disconnected.")

--- a/src/lerobot/robots/utils.py
+++ b/src/lerobot/robots/utils.py
@@ -76,6 +76,10 @@ def make_robot_from_config(config: RobotConfig) -> Robot:
         from .bi_rebot_b601_follower import BiRebotB601Follower
 
         return BiRebotB601Follower(config)
+    elif config.type == "roarm_m3_follower":
+        from .roarm_m3_follower import RoarmM3Follower
+
+        return RoarmM3Follower(config)
     elif config.type == "mock_robot":
         from tests.mocks.mock_robot import MockRobot
 

--- a/src/lerobot/scripts/lerobot_calibrate.py
+++ b/src/lerobot/scripts/lerobot_calibrate.py
@@ -48,6 +48,7 @@ from lerobot.robots import (  # noqa: F401
     omx_follower,
     openarm_follower,
     rebot_b601_follower,
+    roarm_m3_follower,
     so_follower,
 )
 from lerobot.teleoperators import (  # noqa: F401
@@ -64,6 +65,7 @@ from lerobot.teleoperators import (  # noqa: F401
     openarm_leader,
     openarm_mini,
     rebot_102_leader,
+    roarm_m3_leader,
     so_leader,
     unitree_g1,
 )

--- a/src/lerobot/scripts/lerobot_find_joint_limits.py
+++ b/src/lerobot/scripts/lerobot_find_joint_limits.py
@@ -52,6 +52,7 @@ from lerobot.robots import (  # noqa: F401
     omx_follower,
     openarm_follower,
     rebot_b601_follower,
+    roarm_m3_follower,
     so_follower,
 )
 from lerobot.teleoperators import (  # noqa: F401
@@ -67,6 +68,7 @@ from lerobot.teleoperators import (  # noqa: F401
     openarm_leader,
     openarm_mini,
     rebot_102_leader,
+    roarm_m3_leader,
     so_leader,
 )
 from lerobot.utils.robot_utils import precise_sleep

--- a/src/lerobot/scripts/lerobot_record.py
+++ b/src/lerobot/scripts/lerobot_record.py
@@ -129,6 +129,7 @@ from lerobot.robots import (  # noqa: F401
     openarm_follower,
     reachy2,
     rebot_b601_follower,
+    roarm_m3_follower,
     so_follower,
     unitree_g1 as unitree_g1_robot,
 )
@@ -147,6 +148,7 @@ from lerobot.teleoperators import (  # noqa: F401
     openarm_mini,
     reachy2_teleoperator,
     rebot_102_leader,
+    roarm_m3_leader,
     so_leader,
     unitree_g1,
 )

--- a/src/lerobot/scripts/lerobot_replay.py
+++ b/src/lerobot/scripts/lerobot_replay.py
@@ -66,6 +66,7 @@ from lerobot.robots import (  # noqa: F401
     openarm_follower,
     reachy2,
     rebot_b601_follower,
+    roarm_m3_follower,
     so_follower,
     unitree_g1,
 )

--- a/src/lerobot/scripts/lerobot_rollout.py
+++ b/src/lerobot/scripts/lerobot_rollout.py
@@ -169,6 +169,7 @@ from lerobot.robots import (  # noqa: F401
     openarm_follower,
     reachy2,
     rebot_b601_follower,
+    roarm_m3_follower,
     so_follower,
     unitree_g1 as unitree_g1_robot,
 )
@@ -187,6 +188,7 @@ from lerobot.teleoperators import (  # noqa: F401
     openarm_mini,
     reachy2_teleoperator,
     rebot_102_leader,
+    roarm_m3_leader,
     so_leader,
     unitree_g1,
 )

--- a/src/lerobot/scripts/lerobot_setup_motors.py
+++ b/src/lerobot/scripts/lerobot_setup_motors.py
@@ -37,6 +37,7 @@ from lerobot.robots import (  # noqa: F401
     make_robot_from_config,
     omx_follower,
     rebot_b601_follower,
+    roarm_m3_follower,
     so_follower,
 )
 from lerobot.teleoperators import (  # noqa: F401
@@ -49,6 +50,7 @@ from lerobot.teleoperators import (  # noqa: F401
     omx_leader,
     openarm_mini,
     rebot_102_leader,
+    roarm_m3_leader,
     so_leader,
 )
 

--- a/src/lerobot/scripts/lerobot_teleoperate.py
+++ b/src/lerobot/scripts/lerobot_teleoperate.py
@@ -98,6 +98,7 @@ from lerobot.robots import (  # noqa: F401
     openarm_follower,
     reachy2,
     rebot_b601_follower,
+    roarm_m3_follower,
     so_follower,
     unitree_g1 as unitree_g1_robot,
 )
@@ -118,6 +119,7 @@ from lerobot.teleoperators import (  # noqa: F401
     openarm_mini,
     reachy2_teleoperator,
     rebot_102_leader,
+    roarm_m3_leader,
     so_leader,
     unitree_g1,
 )

--- a/src/lerobot/teleoperators/roarm_m3_leader/__init__.py
+++ b/src/lerobot/teleoperators/roarm_m3_leader/__init__.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .config_roarm_m3_leader import RoarmM3LeaderConfig
+from .roarm_m3_leader import RoarmM3Leader
+
+__all__ = ["RoarmM3Leader", "RoarmM3LeaderConfig"]

--- a/src/lerobot/teleoperators/roarm_m3_leader/async_reader.py
+++ b/src/lerobot/teleoperators/roarm_m3_leader/async_reader.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Background read-only poller for the RoArm-M3 leader.
+
+The leader arm is held torque-off and moved by hand. ``roarm_sdk``'s ``joints_angle_get``
+blocks ~35-50 ms, so this thread polls continuously and caches the latest reading; the
+synchronous teleop loop reads the cache (~0 ms) via ``get_pos()`` instead of blocking.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+class AsyncArmReader:
+    """Background thread that continuously polls ``joints_angle_get()`` and caches it."""
+
+    def __init__(self, arm, name: str, sleep_between_reads_s: float = 0.005):
+        self._arm = arm
+        self._name = name
+        self._sleep = sleep_between_reads_s
+        self._pos: np.ndarray | None = None
+        self._lock = threading.Lock()
+        self._stop_event = threading.Event()
+        self._thread = threading.Thread(target=self._run, daemon=True, name=f"AsyncArmReader-{name}")
+
+    def start(self):
+        self._thread.start()
+
+    def stop(self):
+        self._stop_event.set()
+        self._thread.join(timeout=2.0)
+
+    def get_pos(self) -> np.ndarray | None:
+        with self._lock:
+            return None if self._pos is None else self._pos.copy()
+
+    def _run(self):
+        while not self._stop_event.is_set():
+            try:
+                pos = self._arm.joints_angle_get()
+                if pos is not None:
+                    arr = np.array(pos, dtype=np.float32)
+                    with self._lock:
+                        self._pos = arr
+            except Exception as exc:  # pragma: no cover - serial flakiness
+                logger.debug(f"AsyncArmReader [{self._name}] error: {exc}")
+            time.sleep(self._sleep)

--- a/src/lerobot/teleoperators/roarm_m3_leader/config_roarm_m3_leader.py
+++ b/src/lerobot/teleoperators/roarm_m3_leader/config_roarm_m3_leader.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from ..config import TeleoperatorConfig
+
+
+@TeleoperatorConfig.register_subclass("roarm_m3_leader")
+@dataclass
+class RoarmM3LeaderConfig(TeleoperatorConfig):
+    """Configuration for a Waveshare RoArm-M3 used as a passive leader arm.
+
+    The leader is a second RoArm-M3 held torque-off and moved by hand; its joint angles
+    drive a ``roarm_m3_follower``. Like the follower it talks JSON-over-serial through its
+    ESP32 (``roarm_sdk``). The produced action is in the follower's joint space (same fixed
+    joint order, in degrees).
+    """
+
+    # Serial device of the leader arm. Prefer a stable /dev/serial/by-id/... path (ttyUSBx
+    # numbers can swap on reboot), and a port distinct from the follower; do not open the
+    # same serial port from another process at the same time.
+    port: str = "/dev/ttyUSB1"
+    baudrate: int = 1_000_000
+
+    # Exponential-moving-average factor on the raw leader read, to smooth gearbox jitter.
+    # 0 => max smoothing, 1 => raw.
+    ema_alpha: float = 0.5
+
+    # Quantization of the produced action; must match the follower's so the recorded label
+    # equals what the robot executes (see RoarmM3FollowerConfig.action_quantization).
+    action_quantization: Literal["floor", "round", "float"] = "floor"
+
+    # Send {"T":605,"cmd":0} on connect to stop the firmware feedback stream (fresh reads).
+    disable_info_flow: bool = True
+
+    # Remap the gripper from the leader's range to the follower's range with a quadratic
+    # curve. Default False => the gripper passes through like any other joint (the right
+    # choice when leader and follower share the same gripper - stock / identical arms). Set
+    # True only when the two grippers differ (e.g. a Gripper B / CF-3512 follower); then the
+    # four gripper_* angles below are used, otherwise they are ignored.
+    gripper_remap: bool = False
+
+    # Leader gripper raw range (degrees). Only used when gripper_remap is True.
+    gripper_leader_open: float = 100.0
+    gripper_leader_close: float = 0.0
+
+    # Follower gripper calibrated range (degrees). Only used when gripper_remap is True.
+    # Rig-specific (these are Gripper B / CF-3512 values).
+    gripper_follower_open: float = 115.0
+    gripper_follower_close: float = 73.0

--- a/src/lerobot/teleoperators/roarm_m3_leader/roarm_m3_leader.py
+++ b/src/lerobot/teleoperators/roarm_m3_leader/roarm_m3_leader.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Waveshare RoArm-M3 used as a passive leader (Teleoperator).
+
+A second RoArm-M3 is held torque-off and moved by hand; its joint angles drive a
+``roarm_m3_follower``. Like the follower it talks JSON-over-serial through its ESP32
+(``roarm_sdk``), not a Feetech/Dynamixel binary bus, so reads go through a background
+poller (``AsyncArmReader``) to keep the synchronous teleop loop fast.
+
+``get_action`` returns positions in the follower's joint space (same fixed joint order, in
+degrees): joints 0-4 pass through (the two RoArm-M3 arms share the same kinematics), the
+raw read is EMA-smoothed to damp gearbox jitter, the gripper is optionally remapped to the
+follower's range (``gripper_remap``, for heterogeneous grippers such as a Gripper B), and
+the result is floor-quantized + clamped so the recorded action label equals what the
+follower executes (ACT-space alignment).
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from lerobot.types import RobotAction
+from lerobot.utils.decorators import check_if_already_connected, check_if_not_connected
+from lerobot.utils.import_utils import _roarm_sdk_available, require_package
+
+from ..teleoperator import Teleoperator
+from .async_reader import AsyncArmReader
+from .config_roarm_m3_leader import RoarmM3LeaderConfig
+
+if TYPE_CHECKING or _roarm_sdk_available:
+    from roarm_sdk.roarm import roarm
+else:
+    roarm = None
+
+logger = logging.getLogger(__name__)
+
+# --- Constants/helpers DUPLICATED from
+# lerobot.robots.roarm_m3_follower.roarm_m3_common. No teleoperator imports a robots
+# subpackage (same choice as reachy2). They MUST stay in sync with the follower; the test
+# suite asserts they agree. ---
+
+# Fixed joint order = the dataset schema.
+JOINT_NAMES = ["base", "shoulder", "elbow", "wrist_tilt", "wrist_roll", "gripper"]
+WRIST_R_LIMIT = 90
+ANGLES_MIN = [-190, -110, -70, -110, -WRIST_R_LIMIT, -10]
+ANGLES_MAX = [190, 110, 190, 110, WRIST_R_LIMIT, 300]
+
+
+def quantize_action(goal_pos, mode: str = "floor") -> np.ndarray:
+    """Floor/round/float quantization. See roarm_m3_follower.roarm_m3_common."""
+    arr = goal_pos.numpy() if hasattr(goal_pos, "numpy") else np.asarray(goal_pos)
+    if mode == "float":
+        return arr.astype(np.float64)
+    if mode == "round":
+        return np.rint(arr).astype(np.int32)
+    return arr.astype(np.int32)
+
+
+def clamp_limits(goal_pos: list) -> list:
+    """Clamp each joint to [ANGLES_MIN, ANGLES_MAX]."""
+    return [max(ANGLES_MIN[i], min(ANGLES_MAX[i], v)) for i, v in enumerate(goal_pos)]
+
+
+def disable_info_flow(arm) -> bool:
+    """Stop the firmware's continuous feedback stream so reads stay fresh."""
+    ser = getattr(arm, "_serial_port", None)
+    if ser is None or not (hasattr(ser, "write") and hasattr(ser, "reset_input_buffer")):
+        logger.warning(
+            "RoArm serial handle (_serial_port) not found; cannot disable the firmware "
+            "info stream. State reads may be stale."
+        )
+        return False
+    try:
+        ser.write(b'{"T":605,"cmd":0}\n')
+        time.sleep(0.1)
+        ser.reset_input_buffer()
+        return True
+    except Exception as exc:
+        logger.warning(f"Failed to disable the RoArm firmware info stream: {exc}")
+        return False
+
+
+class RoarmM3Leader(Teleoperator):
+    """A passive Waveshare RoArm-M3 leader arm, as a LeRobot Teleoperator."""
+
+    config_class = RoarmM3LeaderConfig
+    name = "roarm_m3_leader"
+
+    def __init__(self, config: RoarmM3LeaderConfig):
+        require_package("roarm_sdk", extra="roarm")
+        super().__init__(config)
+        self.config = config
+        self._arm = None  # roarm SDK handle, created in connect()
+        self._reader: AsyncArmReader | None = None
+        self._ema: np.ndarray | None = None  # EMA state over the 6 raw leader angles
+
+    @property
+    def action_features(self) -> dict[str, type]:
+        # Same schema as RoarmM3Follower.action_features.
+        return {f"{motor}.pos": float for motor in JOINT_NAMES}
+
+    @property
+    def feedback_features(self) -> dict[str, type]:
+        return {}
+
+    @property
+    def is_connected(self) -> bool:
+        return self._arm is not None
+
+    @check_if_already_connected
+    def connect(self, calibrate: bool = True) -> None:
+        logger.info(f"Connecting {self} on {self.config.port}...")
+        self._arm = roarm(roarm_type="roarm_m3", port=self.config.port, baudrate=self.config.baudrate)
+        # Probe the serial link (raises if the port is wrong / contended).
+        self._arm.joints_angle_get()
+
+        if self.config.disable_info_flow:
+            disable_info_flow(self._arm)
+
+        # Passive: torque off so the operator moves the arm by hand.
+        self.configure()
+
+        if not self.is_calibrated and calibrate:
+            self.calibrate()
+
+        self._reader = AsyncArmReader(self._arm, f"leader_{self.id}")
+        self._reader.start()
+        time.sleep(0.20)  # one read cycle to populate the cache
+        logger.info(f"{self} connected.")
+
+    @property
+    def is_calibrated(self) -> bool:
+        # No per-leader motor-offset calibration file here.
+        return True
+
+    def calibrate(self) -> None:
+        # No-op: no per-leader motor-offset calibration.
+        pass
+
+    def configure(self) -> None:
+        """Put the leader in passive (torque-off) mode so it can be moved by hand."""
+        if self._arm is not None:
+            self._arm.torque_set(cmd=0)
+
+    def _read_raw(self) -> np.ndarray:
+        """6 leader joint angles (deg) from the reader cache, with a blocking fallback."""
+        cached = self._reader.get_pos() if self._reader is not None else None
+        if cached is None:
+            cached = np.array(self._arm.joints_angle_get(), dtype=np.float32)
+        return np.asarray(cached, dtype=np.float32)
+
+    @check_if_not_connected
+    def get_action(self) -> RobotAction:
+        start = time.perf_counter()
+        raw = np.asarray(self._read_raw()[:6], dtype=np.float32)
+
+        # 1. EMA smoothing over the raw 6-vector to damp gearbox jitter.
+        alpha = self.config.ema_alpha
+        smoothed = raw if self._ema is None else alpha * raw + (1.0 - alpha) * self._ema
+        self._ema = smoothed
+        goal = smoothed.tolist()
+
+        # 2. Gripper: pass through by default (stock/identical grippers - the common case).
+        #    Only when gripper_remap is set do we remap the leader range to the follower
+        #    range with a quadratic curve (heterogeneous grippers, e.g. a Gripper B).
+        c = self.config
+        if c.gripper_remap:
+            span = c.gripper_leader_close - c.gripper_leader_open
+            ratio = (goal[5] - c.gripper_leader_open) / span if abs(span) >= 1 else 0.0
+            ratio = max(0.0, min(1.0, ratio))
+            goal[5] = c.gripper_follower_open + ratio * ratio * (
+                c.gripper_follower_close - c.gripper_follower_open
+            )
+
+        # 3. Floor quantize (ACT space), then 4. clamp limits - same as the follower.
+        goal = quantize_action(goal, c.action_quantization).tolist()
+        goal = clamp_limits(goal)
+
+        action = {f"{name}.pos": float(goal[i]) for i, name in enumerate(JOINT_NAMES)}
+        logger.debug(f"{self} read action: {(time.perf_counter() - start) * 1e3:.1f}ms")
+        return action
+
+    def send_feedback(self, feedback: dict[str, float]) -> None:
+        raise NotImplementedError("Feedback is not implemented for the RoArm-M3 leader.")
+
+    @check_if_not_connected
+    def disconnect(self) -> None:
+        if self._reader is not None:
+            self._reader.stop()
+            self._reader = None
+        try:
+            self._arm.disconnect()
+        except Exception as exc:  # pragma: no cover
+            logger.debug(f"arm.disconnect() failed: {exc}")
+        self._arm = None
+        logger.info(f"{self} disconnected.")

--- a/src/lerobot/teleoperators/utils.py
+++ b/src/lerobot/teleoperators/utils.py
@@ -111,6 +111,10 @@ def make_teleoperator_from_config(config: TeleoperatorConfig) -> "Teleoperator":
         from .bi_rebot_102_leader import BiRebot102Leader
 
         return BiRebot102Leader(config)
+    elif config.type == "roarm_m3_leader":
+        from .roarm_m3_leader import RoarmM3Leader
+
+        return RoarmM3Leader(config)
     else:
         try:
             return cast("Teleoperator", make_device_from_device_class(config))

--- a/src/lerobot/utils/import_utils.py
+++ b/src/lerobot/utils/import_utils.py
@@ -118,6 +118,7 @@ _motorbridge_available = is_package_available("motorbridge")
 _motorbridge_smart_servo_available = is_package_available(
     "motorbridge-smart-servo", import_name="motorbridge_smart_servo"
 )
+_roarm_sdk_available = is_package_available("roarm_sdk")
 _unitree_sdk_available = is_package_available("unitree-sdk2py", "unitree_sdk2py")
 _pyrealsense2_available = is_package_available("pyrealsense2") or is_package_available(
     "pyrealsense2-macosx", import_name="pyrealsense2"

--- a/tests/robots/test_roarm_m3_follower.py
+++ b/tests/robots/test_roarm_m3_follower.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from lerobot.robots.roarm_m3_follower import (
+    JOINT_NAMES,
+    RoarmM3Follower,
+    RoarmM3FollowerConfig,
+)
+from lerobot.robots.roarm_m3_follower.async_worker import AsyncArmWorker
+
+_MODULE = "lerobot.robots.roarm_m3_follower.roarm_m3_follower"
+
+
+def _make_arm_mock(positions) -> MagicMock:
+    arm = MagicMock(name="RoarmMock")
+    arm.joints_angle_get.return_value = list(positions)
+    return arm
+
+
+@pytest.fixture
+def follower():
+    arm = _make_arm_mock([3.0, -98.0, 182.0, -2.0, 4.0, 100.0])
+    with (
+        patch(f"{_MODULE}.require_package", lambda *a, **kw: None),
+        patch(f"{_MODULE}.roarm", return_value=arm),
+    ):
+        robot = RoarmM3Follower(RoarmM3FollowerConfig(id="test", port="/dev/null"))
+        robot.connect(calibrate=False)
+        yield robot, arm
+        if robot.is_connected:
+            robot.disconnect()
+
+
+def test_features_match_joints():
+    with patch(f"{_MODULE}.require_package", lambda *a, **kw: None):
+        robot = RoarmM3Follower(RoarmM3FollowerConfig(id="test", port="/dev/null"))
+    expected = {f"{n}.pos" for n in JOINT_NAMES}
+    assert set(robot.action_features) == expected
+    assert set(robot.observation_features) == expected  # no cameras configured
+    assert "gripper.pos" in expected
+
+
+def test_connect_disconnect(follower):
+    robot, _ = follower
+    assert robot.is_connected
+    robot.disconnect()
+    assert not robot.is_connected
+
+
+def test_get_observation_returns_degrees(follower):
+    robot, _ = follower
+    obs = robot.get_observation()
+    assert set(obs) == {f"{n}.pos" for n in JOINT_NAMES}
+    assert obs["shoulder.pos"] == pytest.approx(-98.0)
+    assert obs["gripper.pos"] == pytest.approx(100.0)
+
+
+def test_send_action_floor_roundtrip(follower):
+    """Known degrees in -> known degrees out: floor quantization (73.6 -> 73)."""
+    robot, _ = follower
+    target = dict(zip([f"{n}.pos" for n in JOINT_NAMES], [73.6, -98.2, 182.7, -2.1, 4.9, 100.4], strict=True))
+    sent = robot.send_action(target)
+    assert sent["base.pos"] == 73.0
+    assert sent["shoulder.pos"] == -98.0
+    assert sent["elbow.pos"] == 182.0
+    assert sent["gripper.pos"] == 100.0
+
+
+def test_send_action_clamps_limits(follower):
+    robot, _ = follower
+    sent = robot.send_action({"base.pos": 999.0, "wrist_roll.pos": 130.0})
+    assert sent["base.pos"] == 190.0  # ANGLES_MAX base
+    assert sent["wrist_roll.pos"] == 90.0  # +-90 cable-protection limit
+
+
+def test_force_control_gripper_double_write():
+    """force_control_gripper=True adds the gripper-only T:121 write; off sends one write."""
+    arm_on = _make_arm_mock([0, 0, 0, 0, 0, 100.0])
+    worker_on = AsyncArmWorker(arm_on, "test", force_control_gripper=True)
+    worker_on._execute_write([3, -98, 182, -2, 4, 73], 500, 50)
+    arm_on.joints_angle_ctrl.assert_called_once()
+    arm_on.joint_angle_ctrl.assert_called_once()  # the second, gripper-only write
+
+    arm_off = _make_arm_mock([0, 0, 0, 0, 0, 100.0])
+    worker_off = AsyncArmWorker(arm_off, "test", force_control_gripper=False)
+    worker_off._execute_write([3, -98, 182, -2, 4, 73], 500, 50)
+    arm_off.joints_angle_ctrl.assert_called_once()
+    arm_off.joint_angle_ctrl.assert_not_called()
+
+
+def test_disable_torque(follower):
+    robot, arm = follower
+    robot.disable_torque()
+    arm.torque_set.assert_any_call(cmd=0)

--- a/tests/teleoperators/test_roarm_m3_leader.py
+++ b/tests/teleoperators/test_roarm_m3_leader.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from lerobot.robots.roarm_m3_follower.roarm_m3_common import (
+    ANGLES_MAX as F_ANGLES_MAX,
+    ANGLES_MIN as F_ANGLES_MIN,
+    JOINT_NAMES as F_JOINT_NAMES,
+)
+from lerobot.teleoperators.roarm_m3_leader import RoarmM3Leader, RoarmM3LeaderConfig
+from lerobot.teleoperators.roarm_m3_leader.roarm_m3_leader import (
+    ANGLES_MAX as L_ANGLES_MAX,
+    ANGLES_MIN as L_ANGLES_MIN,
+    JOINT_NAMES as L_JOINT_NAMES,
+)
+
+_MODULE = "lerobot.teleoperators.roarm_m3_leader.roarm_m3_leader"
+
+
+def _make_arm_mock(positions) -> MagicMock:
+    arm = MagicMock(name="RoarmMock")
+    arm.joints_angle_get.return_value = list(positions)
+    return arm
+
+
+def _make_leader(arm, **cfg_kwargs):
+    with (
+        patch(f"{_MODULE}.require_package", lambda *a, **kw: None),
+        patch(f"{_MODULE}.roarm", return_value=arm),
+    ):
+        leader = RoarmM3Leader(RoarmM3LeaderConfig(id="test", port="/dev/null", **cfg_kwargs))
+        leader.connect(calibrate=False)
+    return leader
+
+
+def test_constants_in_sync_with_follower():
+    """The leader keeps its own copy of the shared schema; it must match the follower."""
+    assert L_JOINT_NAMES == F_JOINT_NAMES
+    assert L_ANGLES_MIN == F_ANGLES_MIN
+    assert L_ANGLES_MAX == F_ANGLES_MAX
+
+
+def test_features_and_feedback():
+    with patch(f"{_MODULE}.require_package", lambda *a, **kw: None):
+        leader = RoarmM3Leader(RoarmM3LeaderConfig(id="test", port="/dev/null"))
+    assert set(leader.action_features) == {f"{n}.pos" for n in L_JOINT_NAMES}
+    assert leader.feedback_features == {}
+    with pytest.raises(NotImplementedError):
+        leader.send_feedback({})
+
+
+def test_get_action_gripper_passthrough_by_default():
+    """Default: gripper passes through (stock/identical grippers). 50 -> 50, floored."""
+    arm = _make_arm_mock([3.4, -98.2, 182.7, -2.1, 4.9, 50.0])
+    leader = _make_leader(arm)  # gripper_remap defaults to False
+    try:
+        action = leader.get_action()
+        assert action["base.pos"] == 3.0  # floor quantized, EMA first step == raw
+        assert action["shoulder.pos"] == -98.0
+        assert action["gripper.pos"] == 50.0  # pass-through
+    finally:
+        leader.disconnect()
+
+
+def test_get_action_gripper_remap_opt_in():
+    """gripper_remap=True maps the leader range to the follower's Gripper B range."""
+    arm = _make_arm_mock([0.0, 0.0, 0.0, 0.0, 0.0, 50.0])
+    leader = _make_leader(arm, gripper_remap=True)
+    try:
+        action = leader.get_action()
+        # ratio = (50-100)/(0-100) = 0.5 ; 0.5^2 = 0.25 ; 115 + 0.25*(73-115) = 104.5 -> 104
+        assert action["gripper.pos"] == 104.0
+    finally:
+        leader.disconnect()
+
+    arm_open = _make_arm_mock([0.0, 0.0, 0.0, 0.0, 0.0, 100.0])
+    leader_open = _make_leader(arm_open, gripper_remap=True)
+    try:
+        assert leader_open.get_action()["gripper.pos"] == 115.0  # leader open -> follower open
+    finally:
+        leader_open.disconnect()


### PR DESCRIPTION
Adds native support for the **Waveshare RoArm-M3**, a low-cost 5-DOF + gripper desktop arm
controlled over a JSON serial protocol through its on-board ESP32 (via the `roarm_sdk`
package), not a Feetech/Dynamixel binary bus.

## What's included

- **Robot** `roarm_m3_follower` (`src/lerobot/robots/roarm_m3_follower/`): a thin `Robot`
  that wraps `roarm_sdk` directly (no `MotorsBus`), modeled on `reachy2`. All blocking
  serial I/O runs on one background thread so the synchronous record/eval loop stays fast.
- **Teleoperator** `roarm_m3_leader` (`src/lerobot/teleoperators/roarm_m3_leader/`): a
  second RoArm-M3 held passive (torque off) and moved by hand, read on a background thread,
  EMA-smoothed, producing actions in the follower's joint space.
- Registration in `robots/utils.py` + `teleoperators/utils.py` and the `lerobot-*` CLI
  scripts; a `roarm` extra in `pyproject.toml`; a `_roarm_sdk_available` flag +
  `require_package` guard in `utils/import_utils.py`.
- Mock-based tests for both devices and a docs page (`docs/source/roarm_m3.mdx`).

## Design notes

- JSON-over-serial through the ESP32 → an SDK wrapper with no `MotorsBus` (same precedent
  as `reachy2`).
- A background serial thread is justified by the ~35–50 ms blocking SDK calls (CAN/gRPC
  arms don't need this); a single thread owns all I/O so reads and writes can't race.
- A firmware **baud-rate patch** (USB 115200 → 1 Mbps, matching the internal servo bus) is
  required and documented in `roarm_m3.mdx`; it lifts the state-read rate from ~23 Hz to
  ~42 Hz and enables smooth 30 fps teleop.
- **Optional Gripper B** (CF-3512 constant-current force) is opt-in via
  `force_control_gripper` (default off = position-only, for the stock gripper). The
  leader's gripper-range remap is opt-in via `gripper_remap` (default off = pass-through,
  for identical grippers). The defaults keep the plugin generic.

## Test plan

```bash
pytest -sv tests/robots/test_roarm_m3_follower.py tests/teleoperators/test_roarm_m3_leader.py
```

Mocked SDK; covers a 73° degrees-in/degrees-out roundtrip, the `max_relative_target`
clamp, the gripper double-write (on/off), the default gripper pass-through vs the opt-in
remap, and a check that the leader's copy of the shared joint schema matches the follower.

Validated on a physical RoArm-M3: connection, leader-follower teleoperation, and recording
to a `LeRobotDataset` (joint states + wrist/front video, replayed back).
