### PR TITLE
fix: restore policy.train() after eval_policy() (#3668)

### DIFF
--- a/src/lerobot/scripts/lerobot_eval.py
+++ b/src/lerobot/scripts/lerobot_eval.py
@@ -304,172 +304,176 @@ def eval_policy(
             raise exc from None
 
     start = time.time()
+    was_training = policy.training
     policy.eval()
+    try:
+        # Determine how many batched rollouts we need to get n_episodes. Note that if n_episodes is not evenly
+        # divisible by env.num_envs we end up discarding some data in the last batch.
+        n_batches = n_episodes // env.num_envs + int((n_episodes % env.num_envs) != 0)
 
-    # Determine how many batched rollouts we need to get n_episodes. Note that if n_episodes is not evenly
-    # divisible by env.num_envs we end up discarding some data in the last batch.
-    n_batches = n_episodes // env.num_envs + int((n_episodes % env.num_envs) != 0)
+        # Keep track of some metrics.
+        sum_rewards = []
+        max_rewards = []
+        all_successes = []
+        all_seeds = []
+        threads = []  # for video saving threads
+        n_episodes_rendered = 0  # for saving the correct number of videos
 
-    # Keep track of some metrics.
-    sum_rewards = []
-    max_rewards = []
-    all_successes = []
-    all_seeds = []
-    threads = []  # for video saving threads
-    n_episodes_rendered = 0  # for saving the correct number of videos
+        # Callback for visualization.
+        def render_frame(env: gym.vector.VectorEnv):
+            # noqa: B023
+            if n_episodes_rendered >= max_episodes_rendered:
+                return
+            n_to_render_now = min(max_episodes_rendered - n_episodes_rendered, env.num_envs)
+            if isinstance(env, gym.vector.SyncVectorEnv):
+                ep_frames.append(np.stack([env.envs[i].render() for i in range(n_to_render_now)]))  # noqa: B023
+            elif hasattr(env, "call"):
+                # Here we must render all frames and discard any we don't need.
+                # Covers AsyncVectorEnv and _LazyAsyncVectorEnv (which wraps one).
+                ep_frames.append(np.stack(env.call("render")[:n_to_render_now]))
 
-    # Callback for visualization.
-    def render_frame(env: gym.vector.VectorEnv):
-        # noqa: B023
-        if n_episodes_rendered >= max_episodes_rendered:
-            return
-        n_to_render_now = min(max_episodes_rendered - n_episodes_rendered, env.num_envs)
-        if isinstance(env, gym.vector.SyncVectorEnv):
-            ep_frames.append(np.stack([env.envs[i].render() for i in range(n_to_render_now)]))  # noqa: B023
-        elif hasattr(env, "call"):
-            # Here we must render all frames and discard any we don't need.
-            # Covers AsyncVectorEnv and _LazyAsyncVectorEnv (which wraps one).
-            ep_frames.append(np.stack(env.call("render")[:n_to_render_now]))
-
-    if max_episodes_rendered > 0:
-        video_paths: list[str] = []
-
-    if return_episode_data:
-        episode_data: dict | None = None
-
-    # we dont want progress bar when we use slurm, since it clutters the logs
-    progbar = trange(n_batches, desc="Stepping through eval batches", disable=inside_slurm())
-    for batch_ix in progbar:
-        # Cache frames for rendering videos. Each item will be (b, h, w, c), and the list indexes the rollout
-        # step.
         if max_episodes_rendered > 0:
-            ep_frames: list[np.ndarray] = []
+            video_paths: list[str] = []
 
-        if start_seed is None:
-            seeds = None
-        else:
-            seeds = range(
-                start_seed + (batch_ix * env.num_envs), start_seed + ((batch_ix + 1) * env.num_envs)
-            )
-        rollout_data = rollout(
-            env=env,
-            policy=policy,
-            env_preprocessor=env_preprocessor,
-            env_postprocessor=env_postprocessor,
-            preprocessor=preprocessor,
-            postprocessor=postprocessor,
-            seeds=list(seeds) if seeds else None,
-            return_observations=return_episode_data,
-            render_callback=render_frame if max_episodes_rendered > 0 else None,
-        )
-
-        # Figure out where in each rollout sequence the first done condition was encountered (results after
-        # this won't be included).
-        n_steps = rollout_data["done"].shape[1]
-        # Note: this relies on a property of argmax: that it returns the first occurrence as a tiebreaker.
-        done_indices = torch.argmax(rollout_data["done"].to(int), dim=1)
-
-        # Make a mask with shape (batch, n_steps) to mask out rollout data after the first done
-        # (batch-element-wise). Note the `done_indices + 1` to make sure to keep the data from the done step.
-        mask = (torch.arange(n_steps) <= einops.repeat(done_indices + 1, "b -> b s", s=n_steps)).int()
-        # Extend metrics.
-        batch_sum_rewards = einops.reduce((rollout_data["reward"] * mask), "b n -> b", "sum")
-        sum_rewards.extend(batch_sum_rewards.tolist())
-        batch_max_rewards = einops.reduce((rollout_data["reward"] * mask), "b n -> b", "max")
-        max_rewards.extend(batch_max_rewards.tolist())
-        batch_successes = einops.reduce((rollout_data["success"] * mask), "b n -> b", "any")
-        all_successes.extend(batch_successes.tolist())
-        if seeds:
-            all_seeds.extend(seeds)
-        else:
-            all_seeds.append(None)
-
-        # FIXME: episode_data is either None or it doesn't exist
         if return_episode_data:
-            this_episode_data = _compile_episode_data(
-                rollout_data,
-                done_indices,
-                start_episode_index=batch_ix * env.num_envs,
-                start_data_index=(0 if episode_data is None else (episode_data["index"][-1].item() + 1)),
-                fps=env.unwrapped.metadata["render_fps"],
-            )
-            if episode_data is None:
-                episode_data = this_episode_data
+            episode_data: dict | None = None
+
+        # we dont want progress bar when we use slurm, since it clutters the logs
+        progbar = trange(n_batches, desc="Stepping through eval batches", disable=inside_slurm())
+        for batch_ix in progbar:
+            # Cache frames for rendering videos. Each item will be (b, h, w, c), and the list indexes the rollout
+            # step.
+            if max_episodes_rendered > 0:
+                ep_frames: list[np.ndarray] = []
+
+            if start_seed is None:
+                seeds = None
             else:
-                # Some sanity checks to make sure we are correctly compiling the data.
-                assert episode_data["episode_index"][-1] + 1 == this_episode_data["episode_index"][0]
-                assert episode_data["index"][-1] + 1 == this_episode_data["index"][0]
-                # Concatenate the episode data.
-                episode_data = {k: torch.cat([episode_data[k], this_episode_data[k]]) for k in episode_data}
-
-        # Maybe render video for visualization.
-        if max_episodes_rendered > 0 and len(ep_frames) > 0:
-            batch_stacked_frames = np.stack(ep_frames, axis=1)  # (b, t, *)
-            for stacked_frames, done_index in zip(
-                batch_stacked_frames, done_indices.flatten().tolist(), strict=False
-            ):
-                if n_episodes_rendered >= max_episodes_rendered:
-                    break
-
-                videos_dir.mkdir(parents=True, exist_ok=True)
-                video_path = videos_dir / f"eval_episode_{n_episodes_rendered}.mp4"
-                video_paths.append(str(video_path))
-                thread = threading.Thread(
-                    target=write_video,
-                    args=(
-                        str(video_path),
-                        stacked_frames[: done_index + 1],  # + 1 to capture the last observation
-                        env.unwrapped.metadata["render_fps"],
-                    ),
+                seeds = range(
+                    start_seed + (batch_ix * env.num_envs), start_seed + ((batch_ix + 1) * env.num_envs)
                 )
-                thread.start()
-                threads.append(thread)
-                n_episodes_rendered += 1
-
-        progbar.set_postfix(
-            {"running_success_rate": f"{np.mean(all_successes[:n_episodes]).item() * 100:.1f}%"}
-        )
-
-    # Wait till all video rendering threads are done.
-    for thread in threads:
-        thread.join()
-
-    # Compile eval info.
-    info = {
-        "per_episode": [
-            {
-                "episode_ix": i,
-                "sum_reward": sum_reward,
-                "max_reward": max_reward,
-                "success": success,
-                "seed": seed,
-            }
-            for i, (sum_reward, max_reward, success, seed) in enumerate(
-                zip(
-                    sum_rewards[:n_episodes],
-                    max_rewards[:n_episodes],
-                    all_successes[:n_episodes],
-                    all_seeds[:n_episodes],
-                    strict=True,
-                )
+            rollout_data = rollout(
+                env=env,
+                policy=policy,
+                env_preprocessor=env_preprocessor,
+                env_postprocessor=env_postprocessor,
+                preprocessor=preprocessor,
+                postprocessor=postprocessor,
+                seeds=list(seeds) if seeds else None,
+                return_observations=return_episode_data,
+                render_callback=render_frame if max_episodes_rendered > 0 else None,
             )
-        ],
-        "aggregated": {
-            "avg_sum_reward": float(np.nanmean(sum_rewards[:n_episodes])),
-            "avg_max_reward": float(np.nanmean(max_rewards[:n_episodes])),
-            "pc_success": float(np.nanmean(all_successes[:n_episodes]) * 100),
-            "eval_s": time.time() - start,
-            "eval_ep_s": (time.time() - start) / n_episodes,
-        },
-    }
 
-    if return_episode_data:
-        info["episodes"] = episode_data
+            # Figure out where in each rollout sequence the first done condition was encountered (results after
+            # this won't be included).
+            n_steps = rollout_data["done"].shape[1]
+            # Note: this relies on a property of argmax: that it returns the first occurrence as a tiebreaker.
+            done_indices = torch.argmax(rollout_data["done"].to(int), dim=1)
 
-    if max_episodes_rendered > 0:
-        info["video_paths"] = video_paths
+            # Make a mask with shape (batch, n_steps) to mask out rollout data after the first done
+            # (batch-element-wise). Note the `done_indices + 1` to make sure to keep the data from the done step.
+            mask = (torch.arange(n_steps) <= einops.repeat(done_indices + 1, "b -> b s", s=n_steps)).int()
+            # Extend metrics.
+            batch_sum_rewards = einops.reduce((rollout_data["reward"] * mask), "b n -> b", "sum")
+            sum_rewards.extend(batch_sum_rewards.tolist())
+            batch_max_rewards = einops.reduce((rollout_data["reward"] * mask), "b n -> b", "max")
+            max_rewards.extend(batch_max_rewards.tolist())
+            batch_successes = einops.reduce((rollout_data["success"] * mask), "b n -> b", "any")
+            all_successes.extend(batch_successes.tolist())
+            if seeds:
+                all_seeds.extend(seeds)
+            else:
+                all_seeds.append(None)
 
-    return info
+            # FIXME: episode_data is either None or it doesn't exist
+            if return_episode_data:
+                this_episode_data = _compile_episode_data(
+                    rollout_data,
+                    done_indices,
+                    start_episode_index=batch_ix * env.num_envs,
+                    start_data_index=(0 if episode_data is None else (episode_data["index"][-1].item() + 1)),
+                    fps=env.unwrapped.metadata["render_fps"],
+                )
+                if episode_data is None:
+                    episode_data = this_episode_data
+                else:
+                    # Some sanity checks to make sure we are correctly compiling the data.
+                    assert episode_data["episode_index"][-1] + 1 == this_episode_data["episode_index"][0]
+                    assert episode_data["index"][-1] + 1 == this_episode_data["index"][0]
+                    # Concatenate the episode data.
+                    episode_data = {k: torch.cat([episode_data[k], this_episode_data[k]]) for k in episode_data}
+
+            # Maybe render video for visualization.
+            if max_episodes_rendered > 0 and len(ep_frames) > 0:
+                batch_stacked_frames = np.stack(ep_frames, axis=1)  # (b, t, *)
+                for stacked_frames, done_index in zip(
+                    batch_stacked_frames, done_indices.flatten().tolist(), strict=False
+                ):
+                    if n_episodes_rendered >= max_episodes_rendered:
+                        break
+
+                    videos_dir.mkdir(parents=True, exist_ok=True)
+                    video_path = videos_dir / f"eval_episode_{n_episodes_rendered}.mp4"
+                    video_paths.append(str(video_path))
+                    thread = threading.Thread(
+                        target=write_video,
+                        args=(
+                            str(video_path),
+                            stacked_frames[: done_index + 1],  # + 1 to capture the last observation
+                            env.unwrapped.metadata["render_fps"],
+                        ),
+                    )
+                    thread.start()
+                    threads.append(thread)
+                    n_episodes_rendered += 1
+
+            progbar.set_postfix(
+                {"running_success_rate": f"{np.mean(all_successes[:n_episodes]).item() * 100:.1f}%"}
+            )
+
+        # Wait till all video rendering threads are done.
+        for thread in threads:
+            thread.join()
+
+        # Compile eval info.
+        info = {
+            "per_episode": [
+                {
+                    "episode_ix": i,
+                    "sum_reward": sum_reward,
+                    "max_reward": max_reward,
+                    "success": success,
+                    "seed": seed,
+                }
+                for i, (sum_reward, max_reward, success, seed) in enumerate(
+                    zip(
+                        sum_rewards[:n_episodes],
+                        max_rewards[:n_episodes],
+                        all_successes[:n_episodes],
+                        all_seeds[:n_episodes],
+                        strict=True,
+                    )
+                )
+            ],
+            "aggregated": {
+                "avg_sum_reward": float(np.nanmean(sum_rewards[:n_episodes])),
+                "avg_max_reward": float(np.nanmean(max_rewards[:n_episodes])),
+                "pc_success": float(np.nanmean(all_successes[:n_episodes]) * 100),
+                "eval_s": time.time() - start,
+                "eval_ep_s": (time.time() - start) / n_episodes,
+            },
+        }
+
+        if return_episode_data:
+            info["episodes"] = episode_data
+
+        if max_episodes_rendered > 0:
+            info["video_paths"] = video_paths
+
+        return info
+    finally:
+        if was_training:
+            policy.train()
 
 
 def _compile_episode_data(

--- a/tests/scripts/test_eval_policy_train_mode.py
+++ b/tests/scripts/test_eval_policy_train_mode.py
@@ -1,0 +1,118 @@
+"""Regression tests for eval_policy() train-mode restore (issue #3668).
+
+eval_policy() must leave policy.training unchanged after returning, whether
+it succeeds or raises an exception.
+"""
+import torch
+import torch.nn as nn
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from lerobot.scripts.lerobot_eval import eval_policy
+
+
+class _FakePolicy(nn.Module):
+    """Minimal policy with Dropout so policy.training is observable."""
+
+    def __init__(self):
+        super().__init__()
+        self.dropout = nn.Dropout(0.5)
+
+    def reset(self):
+        pass
+
+
+# Shape [1, 1] matches n_episodes=1, env.num_envs=1 used in all tests below.
+_ROLLOUT_RETURN = {
+    "done": torch.tensor([[True]], dtype=torch.bool),
+    "reward": torch.tensor([[1.0]], dtype=torch.float32),
+    "success": torch.tensor([[True]], dtype=torch.bool),
+}
+
+
+def _make_env():
+    env = MagicMock()
+    env.num_envs = 1
+    return env
+
+
+def test_eval_policy_restores_train_mode():
+    """Policy started in train mode must be back in train mode after eval_policy()."""
+    policy = _FakePolicy()
+    policy.train()
+    assert policy.training is True
+
+    # Patch PreTrainedPolicy to nn.Module so _FakePolicy passes the isinstance guard.
+    with patch("lerobot.scripts.lerobot_eval.PreTrainedPolicy", nn.Module):
+        with patch("lerobot.scripts.lerobot_eval.rollout", return_value=_ROLLOUT_RETURN):
+            eval_policy(
+                env=_make_env(),
+                policy=policy,
+                env_preprocessor=None,
+                env_postprocessor=None,
+                preprocessor=None,
+                postprocessor=None,
+                n_episodes=1,
+                max_episodes_rendered=0,
+                videos_dir=None,
+                return_episode_data=False,
+                start_seed=None,
+            )
+
+    assert policy.training is True, (
+        "eval_policy() left the policy in eval mode. "
+        "Dropout is now disabled and BatchNorm stats are frozen for the rest of training."
+    )
+
+
+def test_eval_policy_preserves_eval_mode():
+    """Policy already in eval mode must stay in eval mode after eval_policy()."""
+    policy = _FakePolicy()
+    policy.eval()
+    assert policy.training is False
+
+    with patch("lerobot.scripts.lerobot_eval.PreTrainedPolicy", nn.Module):
+        with patch("lerobot.scripts.lerobot_eval.rollout", return_value=_ROLLOUT_RETURN):
+            eval_policy(
+                env=_make_env(),
+                policy=policy,
+                env_preprocessor=None,
+                env_postprocessor=None,
+                preprocessor=None,
+                postprocessor=None,
+                n_episodes=1,
+                max_episodes_rendered=0,
+                videos_dir=None,
+                return_episode_data=False,
+                start_seed=None,
+            )
+
+    assert policy.training is False
+
+
+def test_eval_policy_restores_train_mode_on_exception():
+    """Train mode must be restored even if eval_policy() raises mid-flight."""
+    policy = _FakePolicy()
+    policy.train()
+
+    with patch("lerobot.scripts.lerobot_eval.PreTrainedPolicy", nn.Module):
+        with patch("lerobot.scripts.lerobot_eval.rollout", side_effect=RuntimeError("simulated crash")):
+            with pytest.raises(RuntimeError, match="simulated crash"):
+                eval_policy(
+                    env=_make_env(),
+                    policy=policy,
+                    env_preprocessor=None,
+                    env_postprocessor=None,
+                    preprocessor=None,
+                    postprocessor=None,
+                    n_episodes=1,
+                    max_episodes_rendered=0,
+                    videos_dir=None,
+                    return_episode_data=False,
+                    start_seed=None,
+                )
+
+    assert policy.training is True, (
+        "eval_policy() left the policy in eval mode after raising an exception."
+    )


### PR DESCRIPTION
Fixes #3668

`eval_policy()` sets `policy.eval()` before rollouts but doesn't restore training mode on return. After the first eval checkpoint, every subsequent training step runs with Dropout disabled and BatchNorm stats frozen. The issue report measured 10–25% worse val loss on a small reproducer; under DDP it's worse because only the main rank runs eval, so it ends up in eval mode while workers stay in train mode.

Snapshot `policy.training` before `policy.eval()`, wrap the body in `try/finally`, restore the original mode on the way out. Works whether the function returns normally or raises.

Three regression tests in `tests/scripts/test_eval_policy_train_mode.py`:
- train mode is restored after a normal run
- if the caller already set eval mode, it stays in eval mode (no side effect)
- train mode is restored even when `rollout()` raises

```
pytest tests/scripts/test_eval_policy_train_mode.py -v
```

First and third fail on `main`; all three pass with this fix.