### PR TITLE
Add vllm policy (remote vLLM OpenPI inference)

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -75,6 +75,8 @@
     title: Multitask DiT Policy
   - local: walloss
     title: WALL-OSS
+  - local: vllm
+    title: vLLM (remote OpenPI)
   title: "Policies"
 - sections:
   - local: sarm

--- a/docs/source/vllm.mdx
+++ b/docs/source/vllm.mdx
@@ -1,0 +1,147 @@
+# vLLM Policy (remote OpenPI inference)
+
+The **vLLM policy** (`--policy.type=vllm`) is a thin, weightless policy that delegates
+action inference to a **remote vLLM OpenPI WebSocket server** — for example
+[vllm-omni](https://github.com/vllm-project/vllm-omni)'s GR00T-N1.7 deployment. It holds no
+model weights locally: at each step it encodes the LeRobot observation into an OpenPI
+request, sends it over a WebSocket, and decodes the returned action trajectory into the
+env's action space.
+
+This is useful when the model is too large to run in the eval process, when inference is
+served centrally (one GPU server, many eval clients), or when you want to evaluate a
+deployment exactly as it will be served in production.
+
+## How it works
+
+```
+LeRobot eval                                  Remote server (vLLM OpenPI)
+┌────────────────────────────┐                ┌────────────────────────────┐
+│ observation (state, images,│  msgpack-numpy │ normalize → model → denorm  │
+│ task prompt)               │ ───────────────▶ (e.g. GR00T-N1.7)          │
+│                            │   WebSocket    │                            │
+│ env action  ◀──────────────│ ◀───────────── │ {action_key: ndarray, ...} │
+└────────────────────────────┘                └────────────────────────────┘
+```
+
+- **Protocol** (`/v1/realtime/robot/openpi`): on connect the server sends its
+  `PolicyServerConfig` metadata; the client then sends one observation and receives a
+  per-action-key dict of action trajectories. Serialization is the OpenPI
+  `msgpack-numpy` (`__ndarray__` envelope) format.
+- **Normalization happens on the server**, so the policy-side processor pipeline is
+  identity w.r.t. values (it only renames keys and moves tensors across devices); the
+  config's `normalization_mapping` is `IDENTITY`.
+- **Decoding is embodiment-agnostic by default**: the policy concatenates the keys named
+  in `action_keys` (in order) into the env action vector, with configurable per-channel
+  post-processing (state subtraction, scaling, gripper normalize/binarize/invert). A
+  dedicated `eef_9d` mode is available for DROID-style SE(3)/rot6d actions.
+
+## Installation
+
+```bash
+pip install -e ".[vllm]"
+```
+
+This pulls in the small runtime deps (`websockets`, `msgpack`). The policy is registered
+in-tree like every other built-in policy, so after install `lerobot-eval --help` lists
+`vllm` under `--policy.type`.
+
+You also need a running vLLM OpenPI server serving a compatible checkpoint (e.g.
+`nvidia/GR00T-N1.7-LIBERO/<suite>`). See the
+[vllm-omni](https://github.com/vllm-project/vllm-omni) docs for serving.
+
+## Quick start
+
+### 1. Run an eval against a remote server
+
+The repo ships a ready-to-use `--policy.path` directory at `examples/vllm_policy/`
+(a `config.json` plus processor JSONs). Point an eval at it:
+
+```bash
+lerobot-eval \
+  --policy.path=examples/vllm_policy \
+  --policy.host=127.0.0.1 \
+  --policy.port=8000 \
+  --env.type=libero \
+  --env.task=libero_object \
+  --eval.batch_size=1 \
+  --eval.n_episodes=2 \
+  --policy.n_action_steps=10 \
+  --output_dir=./outputs/libero_eval
+```
+
+> The `libero` env is Linux-only; install it with `pip install -e ".[libero]"`.
+
+### 2. Or run without a policy-path directory
+
+You don't need the example directory — `--policy.type=vllm` builds the config from
+defaults plus CLI overrides:
+
+```bash
+lerobot-eval \
+  --policy.type=vllm \
+  --policy.host=10.0.0.5 \
+  --policy.port=8000 \
+  --env.type=libero \
+  --env.task=libero_object \
+  --eval.n_episodes=2 \
+  --output_dir=./outputs/libero_eval
+```
+
+### 3. Smoke-test without a GPU (local mock server)
+
+A mock OpenPI server returns dummy no-op actions so you can exercise the full
+encode → send → receive → decode loop locally:
+
+```bash
+# terminal 1: start the mock server
+python -m lerobot.policies.vllm.mock_server --host 127.0.0.1 --port 8001
+
+# terminal 2: point an eval at it
+lerobot-eval --policy.type=vllm --policy.port=8001 \
+  --env.type=libero --env.task=libero_object --eval.n_episodes=1 \
+  --output_dir=./outputs/vllm_smoke
+```
+
+## Configuration
+
+Key options (all settable via `--policy.<name>` or in `config.json`):
+
+| Option | Default | Description |
+|---|---|---|
+| `host` / `port` / `ws_path` | `127.0.0.1` / `8000` / `/v1/realtime/robot/openpi` | Remote server endpoint |
+| `embodiment` | `libero_sim` | Embodiment tag sent to the server |
+| `action_space` | `libero_7d` | `libero_7d` (flat-concat decode) or `eef_9d` (SE(3)/rot6d) |
+| `action_keys` | `[x,y,z,roll,pitch,yaw,gripper]` | Server keys concatenated into the action; `action_dim = len(action_keys)` |
+| `gripper_keys` | `[gripper]` | Which `action_keys` get gripper post-processing |
+| `decode_subtract_state` | `true` | Recover per-step delta from the server's absolute output |
+| `gripper_normalize` / `gripper_binarize` / `gripper_invert` | `true` | Gripper post-processing |
+| `external_camera_obs_key` / `wrist_camera_obs_key` | LIBERO image keys | Which obs images to send |
+| `request_seed` | `null` | Optional per-request flow-matching seed |
+
+The `examples/vllm_policy/` JSONs are **generated artifacts** — rebuild them after changing
+the config with:
+
+```bash
+python examples/vllm_policy/scripts/generate_policy_dir.py
+```
+
+## Other embodiments
+
+Because the server owns normalization and conditions on the `embodiment` tag, adding a new
+robot whose action is a **flat concatenation of scalar channels** is **config-only**: set
+`--policy.embodiment`, `--policy.action_keys`, `--policy.gripper_keys`, and the gripper
+flags — no code change. Robots that need different action math (like `eef_9d`) get their
+own explicit decode path in `src/lerobot/policies/vllm/modeling_vllm.py`.
+
+> The generality is in the extension seam, not a guarantee: any new embodiment still needs
+> an end-to-end run to confirm its action/gripper conventions.
+
+## Notes & limitations
+
+- **Inference only.** The policy has no weights and does not support training.
+- **Network round-trip per inference.** Each `predict_action_chunk` opens a WebSocket,
+  handshakes, sends one observation, and reads one response; the client reconnects per
+  call to stay robust under batched eval.
+- **Server compatibility.** The example targets a GR00T-N1.7 deployment on vllm-omni; any
+  server that speaks the OpenPI `/v1/realtime/robot/openpi` protocol and returns a
+  per-action-key dict of ndarrays will work.

--- a/examples/vllm_policy/README.md
+++ b/examples/vllm_policy/README.md
@@ -1,0 +1,139 @@
+# examples/vllm_policy
+
+A ready-to-use `--policy.path` directory for the `vllm` policy (remote vLLM OpenPI
+server), plus helper scripts for regenerating the config and running a single-task
+visualized rollout.
+
+The policy is an in-tree lerobot policy at `src/lerobot/policies/vllm/` (registered as
+`--policy.type=vllm`, like `act`, `groot`, `pi0`, …).
+
+## Quick start
+
+```bash
+# Install lerobot with the vllm extra (pulls in the websockets/msgpack deps):
+uv pip install -e ".[vllm]"
+
+# Verify the registration appears:
+lerobot-eval --help | grep -E "policy.type" | head -1
+# → --policy.type   {... vllm ...}
+```
+
+## 1. Run a full eval (LIBERO, real GR00T server on :8000)
+
+```bash
+PYTORCH_ENABLE_MPS_FALLBACK=1 .venv/bin/lerobot-eval \
+  --policy.path=examples/vllm_policy \
+  --env.type=libero \
+  --env.task=libero_object \
+  --eval.batch_size=1 \
+  --eval.n_episodes=2 \
+  --policy.n_action_steps=10 \
+  --output_dir=./outputs/libero_eval
+```
+
+## 2. Visualize a single task live (Rerun web viewer)
+
+```bash
+PYTORCH_ENABLE_MPS_FALLBACK=1 .venv/bin/python \
+  examples/vllm_policy/scripts/eval_visualize.py \
+  --benchmark libero_object --task-id 0 --open-browser
+```
+
+Variants: `--spawn` (native desktop viewer) · `--save /tmp/run.rrd --no-keep-alive`
+(offline recording, view with `rerun /tmp/run.rrd`).
+
+## 3. Local mock server (no GPU smoke test)
+
+```bash
+.venv/bin/python -m lerobot.policies.vllm.mock_server --host 127.0.0.1 --port 8001
+# then re-point the config to the mock:
+.venv/bin/python examples/vllm_policy/scripts/generate_policy_dir.py --port 8001
+```
+
+## 4. (Re)generate the policy-path JSONs
+
+The three JSONs in this directory (`config.json`, `policy_preprocessor.json`,
+`policy_postprocessor.json`) are **generated artifacts**, not hand-written. They are
+produced from the `VllmConfig` dataclass defaults by `generate_policy_dir.py`:
+
+```bash
+.venv/bin/python examples/vllm_policy/scripts/generate_policy_dir.py
+```
+
+Internally the script does:
+
+```python
+cfg = VllmConfig(host=..., port=..., chunk_size=..., n_action_steps=...)
+cfg.save_pretrained(out_dir)                       # -> config.json
+pre, post = make_vllm_pre_post_processors(cfg)
+pre.save_pretrained(out_dir, ...)                  # -> policy_preprocessor.json
+post.save_pretrained(out_dir, ...)                 # -> policy_postprocessor.json
+```
+
+Re-run it whenever you:
+- change a field / default in `src/lerobot/policies/vllm/configuration_vllm.py`
+  (this keeps the committed JSONs in sync — otherwise they silently go stale), or
+- want a directory pointed at a different server / chunking, e.g.:
+
+```bash
+.venv/bin/python examples/vllm_policy/scripts/generate_policy_dir.py \
+  --out /tmp/my_vllm_policy --host 10.0.0.5 --port 8001 --chunk-size 32 --n-action-steps 16
+```
+
+Options: `--out` (default `examples/vllm_policy`), `--host`, `--port`, `--chunk-size`,
+`--n-action-steps`.
+
+> You can also skip this directory entirely and run with `--policy.type=vllm` plus CLI
+> overrides (e.g. `--policy.host`, `--policy.port`); the `--policy.path` dir is just a
+> ready-to-use, version-controlled example.
+
+## Contents
+
+```
+examples/vllm_policy/
+├── README.md                       (this file)
+├── config.json                     # generated: {"type": "vllm", host, port, ...}
+├── policy_preprocessor.json        # generated: rename + device steps (no normalization)
+├── policy_postprocessor.json       # generated: move action to CPU
+└── scripts/
+    ├── generate_policy_dir.py      # regenerates the three JSONs above
+    └── eval_visualize.py
+```
+
+## Files NOT here
+
+| What | Where |
+|---|---|
+| `vllm` policy source | `src/lerobot/policies/vllm/` |
+| Registration | `src/lerobot/policies/__init__.py` + `factory.py` (`vllm` branches) |
+
+## Action / state convention (LIBERO)
+
+Authoritative source: `Isaac-GR00T/gr00t/eval/sim/LIBERO/libero_env.py` +
+`examples/LIBERO/modality.json`.
+
+- Embodiment: `libero_sim` (= `LIBERO_PANDA`). Requires the post-trained checkpoint
+  `nvidia/GR00T-N1.7-LIBERO/<suite>` on the server (e.g. `.../libero_object`).
+- Action: native LIBERO 7-D `[x,y,z,roll,pitch,yaw,gripper]` — fed as **delta** to
+  `env.step` (relative control); gripper is `normalize [0,1]→[-1,1]` → `sign` → `invert`.
+- Images sent as an ordered list `[agentview, eye_in_hand]` (server feeds HF image
+  processor; dict rejected).
+- Serialization: vendored OpenPI msgpack-numpy format (`__ndarray__` envelope). The
+  standalone `msgpack-numpy` PyPI package is NOT wire-compatible.
+- Legacy DROID `eef_9d` mode (SE(3)/rot6d math path) is available via
+  `--policy.action_space=eef_9d`.
+
+### Other embodiments
+
+The default decode is a generic **flat concat**: the server returns one trajectory per
+key, and the policy concatenates the keys named in `action_keys` (in order) into the env
+action vector, slicing the request state via `modality_config["state"]`. A new embodiment
+whose action is a flat vector of scalar channels is therefore **config-only** — set
+`--policy.embodiment`, `--policy.action_keys`, `--policy.gripper_keys`, and the gripper
+flags; no code change. `action_dim` is derived from `len(action_keys)`. Embodiments needing
+different action math (like `eef_9d`) get their own decode path in `modeling_vllm.py`.
+
+Tunables: `--policy.host/port`, `--policy.embodiment`, `--policy.action_space`,
+`--policy.action_keys`, `--policy.gripper_keys`, `--policy.decode_subtract_state`,
+`--policy.gripper_normalize`, `--policy.gripper_binarize`, `--policy.gripper_invert`,
+`--policy.action_scale`, `--policy.request_seed`.

--- a/examples/vllm_policy/config.json
+++ b/examples/vllm_policy/config.json
@@ -1,0 +1,126 @@
+{
+    "type": "vllm",
+    "n_obs_steps": 1,
+    "input_features": {},
+    "output_features": {},
+    "device": "mps",
+    "use_amp": false,
+    "use_peft": false,
+    "push_to_hub": true,
+    "repo_id": null,
+    "private": null,
+    "tags": null,
+    "license": null,
+    "pretrained_path": null,
+    "chunk_size": 16,
+    "n_action_steps": 16,
+    "host": "127.0.0.1",
+    "port": 8080,
+    "ws_path": "/v1/realtime/robot/openpi",
+    "connect_timeout_s": 30.0,
+    "max_msg_bytes": 67108864,
+    "embodiment": "libero_sim",
+    "prompt_override": null,
+    "image_height": 256,
+    "image_width": 256,
+    "external_camera_obs_key": "observation.images.image",
+    "wrist_camera_obs_key": "observation.images.image2",
+    "send_wrist_camera": true,
+    "action_space": "libero_7d",
+    "images_as_list": true,
+    "flip_images_180": false,
+    "modality_config": {
+        "state": {
+            "x": {
+                "start": 0,
+                "end": 1
+            },
+            "y": {
+                "start": 1,
+                "end": 2
+            },
+            "z": {
+                "start": 2,
+                "end": 3
+            },
+            "roll": {
+                "start": 3,
+                "end": 4
+            },
+            "pitch": {
+                "start": 4,
+                "end": 5
+            },
+            "yaw": {
+                "start": 5,
+                "end": 6
+            },
+            "gripper": {
+                "start": 6,
+                "end": 8
+            }
+        },
+        "action": {
+            "x": {
+                "start": 0,
+                "end": 1
+            },
+            "y": {
+                "start": 1,
+                "end": 2
+            },
+            "z": {
+                "start": 2,
+                "end": 3
+            },
+            "roll": {
+                "start": 3,
+                "end": 4
+            },
+            "pitch": {
+                "start": 4,
+                "end": 5
+            },
+            "yaw": {
+                "start": 5,
+                "end": 6
+            },
+            "gripper": {
+                "start": 6,
+                "end": 7
+            }
+        }
+    },
+    "request_seed": null,
+    "state_obs_key": "observation.state",
+    "gripper_qpos_open": 0.04,
+    "gripper_qpos_closed": 0.0,
+    "send_joint_position": true,
+    "joint_dim": 7,
+    "action_keys": [
+        "x",
+        "y",
+        "z",
+        "roll",
+        "pitch",
+        "yaw",
+        "gripper"
+    ],
+    "gripper_keys": [
+        "gripper"
+    ],
+    "control_mode": "relative",
+    "action_scale": 1.0,
+    "gripper_action_open": -1.0,
+    "gripper_action_close": 1.0,
+    "decode_subtract_state": true,
+    "gripper_normalize": true,
+    "gripper_binarize": true,
+    "gripper_invert": true,
+    "clip_action": true,
+    "normalization_mapping": {
+        "VISUAL": "IDENTITY",
+        "STATE": "IDENTITY",
+        "ACTION": "IDENTITY"
+    }
+}

--- a/examples/vllm_policy/policy_postprocessor.json
+++ b/examples/vllm_policy/policy_postprocessor.json
@@ -1,0 +1,12 @@
+{
+  "name": "policy_postprocessor",
+  "steps": [
+    {
+      "registry_name": "device_processor",
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      }
+    }
+  ]
+}

--- a/examples/vllm_policy/policy_preprocessor.json
+++ b/examples/vllm_policy/policy_preprocessor.json
@@ -1,0 +1,18 @@
+{
+  "name": "policy_preprocessor",
+  "steps": [
+    {
+      "registry_name": "rename_observations_processor",
+      "config": {
+        "rename_map": {}
+      }
+    },
+    {
+      "registry_name": "device_processor",
+      "config": {
+        "device": "mps",
+        "float_dtype": null
+      }
+    }
+  ]
+}

--- a/examples/vllm_policy/scripts/eval_visualize.py
+++ b/examples/vllm_policy/scripts/eval_visualize.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python
+"""Evaluate ONE LIBERO task with the remote vllm policy and visualize it live in Rerun.
+
+Reuses the exact same ``VllmPolicy`` (and ``examples/vllm_policy/`` config) that
+``lerobot-eval`` uses, so the rollout matches a real eval episode — but for a single task,
+with per-step camera/state/action streaming to Rerun using **lerobot's own Rerun helpers**
+(no dependency on ``libero.libero.utils.rerun_utils``).
+
+Prereq: the vLLM OpenPI server is serving the matching suite checkpoint on 127.0.0.1:8000.
+
+Usage (run from the lerobot repo root):
+    # default: serve a Rerun web viewer
+    python examples/vllm_policy/scripts/eval_visualize.py --benchmark libero_object --task-id 0 --open-browser
+    # save a recording instead
+    python examples/vllm_policy/scripts/eval_visualize.py --benchmark libero_object --task-id 0 --save /tmp/run.rrd --no-keep-alive
+    # native desktop viewer
+    python examples/vllm_policy/scripts/eval_visualize.py --benchmark libero_object --task-id 0 --spawn
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import math
+import time
+
+import numpy as np
+import torch
+
+# LIBERO neutralizes EGL on macOS at import; keep this before robosuite use.
+from libero.libero import benchmark as libero_benchmark  # noqa: E402
+from libero.libero.envs import OffScreenRenderEnv  # noqa: E402
+
+import lerobot.policies  # noqa: E402,F401  (register built-in policies)
+from lerobot.configs.policies import PreTrainedConfig  # noqa: E402
+from lerobot.utils.constants import OBS_IMAGES  # noqa: E402
+from lerobot.utils.visualization_utils import log_rerun_data  # noqa: E402
+
+from lerobot.policies.vllm.modeling_vllm import VllmPolicy  # noqa: E402
+
+LIBERO_DUMMY_ACTION = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, -1.0]
+
+log = logging.getLogger("eval-visualize")
+
+
+def quat2axisangle(quat: np.ndarray) -> np.ndarray:
+    """robosuite (x,y,z,w) quaternion -> axis-angle (matches Isaac-GR00T libero_env)."""
+    quat = np.asarray(quat, dtype=np.float64).copy()
+    quat[3] = min(1.0, max(-1.0, quat[3]))
+    den = math.sqrt(1.0 - quat[3] * quat[3])
+    if den < 1e-8:
+        return np.zeros(3)
+    return (quat[:3] * 2.0 * math.acos(quat[3])) / den
+
+
+def build_batch(raw_obs: dict, task_lang: str, device: str) -> dict:
+    """Raw LIBERO obs -> lerobot policy batch (mirrors preprocess + LiberoProcessorStep)."""
+    eef_pos = np.asarray(raw_obs["robot0_eef_pos"], dtype=np.float32).reshape(3)
+    axisangle = quat2axisangle(raw_obs["robot0_eef_quat"]).astype(np.float32)
+    gripper = np.asarray(raw_obs["robot0_gripper_qpos"], dtype=np.float32).reshape(-1)[:2]
+    state = np.concatenate([eef_pos, axisangle, gripper]).astype(np.float32)  # (8,)
+
+    def to_chw(name: str) -> torch.Tensor:
+        im = np.asarray(raw_obs[name])[::-1, ::-1]  # 180° flip (== LiberoProcessorStep)
+        t = torch.from_numpy(np.ascontiguousarray(im)).permute(2, 0, 1).float() / 255.0
+        return t.unsqueeze(0).to(device)
+
+    return {
+        "observation.state": torch.from_numpy(state).unsqueeze(0).to(device),
+        "observation.images.image": to_chw("agentview_image"),
+        "observation.images.image2": to_chw("robot0_eye_in_hand_image"),
+        "task": [task_lang],
+    }
+
+
+def _init_rerun(args) -> str | None:
+    """Initialize Rerun in one of four modes; return the web URL if serving, else None.
+
+    Modes (mutually exclusive in priority order):
+      --save PATH  → write a .rrd recording (no live viewer)
+      --spawn      → native desktop Rerun viewer (`rr.spawn`)
+      default      → serve gRPC sink + embeddable web viewer
+    """
+    import rerun as rr
+
+    rr.init("lerobot_vllm_libero_eval")
+
+    if args.save:
+        rr.save(args.save)
+        return None
+    if args.spawn:
+        rr.spawn()
+        return None
+    server_uri = rr.serve_grpc(grpc_port=args.grpc_port)
+    rr.serve_web_viewer(open_browser=args.open_browser, web_port=args.web_port, connect_to=server_uri)
+    web_url = f"http://localhost:{args.web_port}"
+    log.info("Rerun web viewer: %s", web_url)
+    log.info("gRPC sink:         %s", server_uri)
+    return web_url
+
+
+def _log_step(t: int, raw_obs: dict, action: np.ndarray, reward: float, done: bool, success: bool) -> None:
+    """Log one rollout step using lerobot's Rerun helpers + temporal image logging.
+
+    `log_rerun_data` logs images with `static=True`, which strips the timeline — fine for a
+    one-shot dataset preview but wrong for rollout playback. We log images ourselves with
+    `rr.set_time` set first so they advance with the step counter.
+    """
+    import rerun as rr
+
+    rr.set_time("step", sequence=int(t))
+
+    # Temporal image logs (use lerobot's canonical OBS_IMAGES path).
+    for cam_key, raw_key in (("image", "agentview_image"), ("image2", "robot0_eye_in_hand_image")):
+        img = np.asarray(raw_obs[raw_key])[::-1, ::-1]  # match LiberoProcessorStep flip
+        rr.log(f"{OBS_IMAGES}.{cam_key}", rr.Image(img))
+
+    # Scalars / state / action via lerobot's standard helper (auto-namespaces observation.* / action.*).
+    eef_pos = np.asarray(raw_obs["robot0_eef_pos"], dtype=np.float32).reshape(3)
+    axisangle = quat2axisangle(raw_obs["robot0_eef_quat"]).astype(np.float32)
+    gripper = np.asarray(raw_obs["robot0_gripper_qpos"], dtype=np.float32).reshape(-1)[:2]
+    obs_log = {
+        "state": np.concatenate([eef_pos, axisangle, gripper]).astype(np.float32),
+        "success": float(bool(success)),
+    }
+    # Name action components explicitly so the viewer shows action.dx ... action.gripper
+    # rather than action.action_0 ... action.action_6.
+    a = np.asarray(action, dtype=np.float32).reshape(-1)
+    action_log = {
+        "dx": float(a[0]), "dy": float(a[1]), "dz": float(a[2]),
+        "droll": float(a[3]), "dpitch": float(a[4]), "dyaw": float(a[5]),
+        "gripper": float(a[6]),
+    }
+    log_rerun_data(observation=obs_log, action=action_log)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--benchmark", default="libero_object")
+    p.add_argument("--task-id", type=int, default=0)
+    p.add_argument("--init-id", type=int, default=0)
+    p.add_argument("--policy-path", default="examples/vllm_policy")
+    p.add_argument("--n-action-steps", type=int, default=10)
+    p.add_argument("--max-steps", type=int, default=300)
+    p.add_argument("--num-steps-wait", type=int, default=10, help="settle steps after reset")
+    p.add_argument("--render-size", type=int, default=256)
+    p.add_argument("--device", default="cpu")
+    # Rerun
+    p.add_argument("--grpc-port", type=int, default=9876)
+    p.add_argument("--web-port", type=int, default=9090)
+    p.add_argument("--open-browser", action="store_true")
+    p.add_argument("--spawn", action="store_true", help="native desktop viewer instead of web")
+    p.add_argument("--save", default=None, help="write a .rrd recording to this path instead of serving")
+    p.add_argument("--no-keep-alive", action="store_true")
+    args = p.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+
+    suite = libero_benchmark.get_benchmark_dict()[args.benchmark]()
+    task = suite.get_task(args.task_id)
+    log.info("[%s][%d] %s", args.benchmark, args.task_id, task.language)
+
+    env = OffScreenRenderEnv(
+        bddl_file_name=suite.get_task_bddl_file_path(args.task_id),
+        camera_heights=args.render_size,
+        camera_widths=args.render_size,
+    )
+
+    # Policy (same config dir as lerobot-eval).
+    cfg = PreTrainedConfig.from_pretrained(args.policy_path)
+    cfg.n_action_steps = args.n_action_steps
+    cfg.device = args.device
+    policy = VllmPolicy(cfg)
+    policy.eval()
+
+    web_url = _init_rerun(args)
+
+    # Reset + set the bundled init state, then settle the scene.
+    env.reset()
+    init_states = suite.get_task_init_states(args.task_id)
+    obs = env.set_init_state(init_states[args.init_id % len(init_states)])
+    for _ in range(args.num_steps_wait):
+        obs, _, _, _ = env.step(LIBERO_DUMMY_ACTION)
+
+    policy.reset()
+    _log_step(0, obs, np.zeros(7, dtype=np.float32), reward=0.0, done=False, success=False)
+
+    success = False
+    for t in range(args.max_steps):
+        batch = build_batch(obs, task.language, args.device)
+        with torch.inference_mode():
+            action = policy.select_action(batch)[0].cpu().numpy().astype(np.float32)
+        obs, reward, done, info = env.step(action)
+        success = bool(env.check_success())
+        _log_step(t + 1, obs, action, float(reward), bool(done), success)
+        if success:
+            log.info("SUCCESS at step %d", t + 1)
+            break
+    else:
+        log.info("finished %d steps without success", args.max_steps)
+
+    env.close()
+
+    if args.save:
+        log.info("saved recording to %s (open with: rerun %s)", args.save, args.save)
+        return 0
+    if args.spawn:
+        # Native viewer is its own process; just hand control back.
+        return 0
+    if args.no_keep_alive:
+        return 0
+    # Keep the web viewer up so the user can scrub the timeline.
+    log.info("[rerun] serving %s — press Ctrl-C to stop", web_url)
+    try:
+        while True:
+            time.sleep(60)
+    except KeyboardInterrupt:
+        pass
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/vllm_policy/scripts/generate_policy_dir.py
+++ b/examples/vllm_policy/scripts/generate_policy_dir.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+"""Generate the ``examples/vllm_policy/`` directory consumed by ``--policy.path``.
+
+Writes ``config.json`` plus the (identity) ``policy_preprocessor.json`` /
+``policy_postprocessor.json`` pipelines, using lerobot's own save machinery so the
+schema always matches what ``lerobot-eval`` loads.
+
+Usage:
+    python examples/vllm_policy/scripts/generate_policy_dir.py [--out examples/vllm_policy]
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+
+import lerobot.policies  # noqa: F401  (register built-in policies)
+from lerobot.policies.vllm.configuration_vllm import VllmConfig  # noqa: E402
+from lerobot.policies.vllm.processor_vllm import make_vllm_pre_post_processors  # noqa: E402
+from lerobot.utils.constants import POLICY_POSTPROCESSOR_DEFAULT_NAME, POLICY_PREPROCESSOR_DEFAULT_NAME
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--out", default="examples/vllm_policy", help="output directory")
+    p.add_argument("--host", default="127.0.0.1")
+    p.add_argument("--port", type=int, default=8000)
+    p.add_argument("--chunk-size", type=int, default=16)
+    p.add_argument("--n-action-steps", type=int, default=16)
+    args = p.parse_args()
+
+    out_dir = os.path.abspath(args.out)
+    os.makedirs(out_dir, exist_ok=True)
+
+    cfg = VllmConfig(
+        host=args.host,
+        port=args.port,
+        chunk_size=args.chunk_size,
+        n_action_steps=args.n_action_steps,
+        image_height=256,
+        image_width=256,
+    )
+    cfg.save_pretrained(out_dir)
+
+    pre, post = make_vllm_pre_post_processors(cfg)
+    pre.save_pretrained(out_dir, config_filename=f"{POLICY_PREPROCESSOR_DEFAULT_NAME}.json")
+    post.save_pretrained(out_dir, config_filename=f"{POLICY_POSTPROCESSOR_DEFAULT_NAME}.json")
+
+    print(f"Wrote {sorted(os.listdir(out_dir))} to {out_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -218,6 +218,8 @@ xvla = ["lerobot[transformers-dep]"]
 eo1 = ["lerobot[transformers-dep]", "lerobot[qwen-vl-utils-dep]"]
 hilserl = ["lerobot[transformers-dep]", "lerobot[dataset]", "gym-hil>=0.1.13,<0.2.0", "lerobot[grpcio-dep]", "lerobot[placo-dep]"]
 vla_jepa = ["lerobot[transformers-dep]", "lerobot[diffusers-dep]", "lerobot[qwen-vl-utils-dep]"]
+# Remote-inference policy that proxies to a vLLM OpenPI WebSocket server (no local weights).
+vllm = ["websockets>=12.0,<16.0", "msgpack>=1.0.0,<2.0.0"]
 
 # Features
 async = ["lerobot[grpcio-dep]", "lerobot[matplotlib-dep]"]
@@ -282,6 +284,7 @@ all = [
     "lerobot[smolvla]",
     # "lerobot[groot]", TODO(Steven): Gr00t requires specific installation instructions for flash-attn
     "lerobot[xvla]",
+    "lerobot[vllm]",
     "lerobot[hilserl]",
     "lerobot[vla_jepa]",
     "lerobot[async]",

--- a/src/lerobot/policies/__init__.py
+++ b/src/lerobot/policies/__init__.py
@@ -29,6 +29,7 @@ from .pretrained import PreTrainedPolicy as PreTrainedPolicy
 from .smolvla.configuration_smolvla import SmolVLAConfig as SmolVLAConfig
 from .tdmpc.configuration_tdmpc import TDMPCConfig as TDMPCConfig
 from .utils import make_robot_action, prepare_observation_for_inference
+from .vllm.configuration_vllm import VllmConfig as VllmConfig
 from .vqbet.configuration_vqbet import VQBeTConfig as VQBeTConfig
 from .wall_x.configuration_wall_x import WallXConfig as WallXConfig
 from .xvla.configuration_xvla import XVLAConfig as XVLAConfig
@@ -51,6 +52,7 @@ __all__ = [
     "PI05Config",
     "SmolVLAConfig",
     "TDMPCConfig",
+    "VllmConfig",
     "VQBeTConfig",
     "WallXConfig",
     "XVLAConfig",

--- a/src/lerobot/policies/factory.py
+++ b/src/lerobot/policies/factory.py
@@ -58,6 +58,7 @@ from .smolvla.configuration_smolvla import SmolVLAConfig
 from .tdmpc.configuration_tdmpc import TDMPCConfig
 from .utils import validate_visual_features_consistency
 from .vla_jepa.configuration_vla_jepa import VLAJEPAConfig
+from .vllm.configuration_vllm import VllmConfig
 from .vqbet.configuration_vqbet import VQBeTConfig
 from .wall_x.configuration_wall_x import WallXConfig
 from .xvla.configuration_xvla import XVLAConfig
@@ -162,6 +163,10 @@ def get_policy_class(name: str) -> type[PreTrainedPolicy]:
         from .vla_jepa.modeling_vla_jepa import VLAJEPAPolicy
 
         return VLAJEPAPolicy
+    elif name == "vllm":
+        from .vllm.modeling_vllm import VllmPolicy
+
+        return VllmPolicy
     else:
         try:
             return _get_policy_cls_from_policy_name(name=name)
@@ -218,6 +223,8 @@ def make_policy_config(policy_type: str, **kwargs) -> PreTrainedConfig:
         return MolmoAct2Config(**kwargs)
     elif policy_type == "vla_jepa":
         return VLAJEPAConfig(**kwargs)
+    elif policy_type == "vllm":
+        return VllmConfig(**kwargs)
     else:
         try:
             config_cls = PreTrainedConfig.get_choice_class(policy_type)

--- a/src/lerobot/policies/vllm/__init__.py
+++ b/src/lerobot/policies/vllm/__init__.py
@@ -1,0 +1,14 @@
+"""``vllm`` policy: proxy action inference to a remote vLLM OpenPI policy server
+(e.g. vllm-omni's GR00T-N1.7 deployment).
+
+This subpackage lives alongside the built-in ``act/``, ``groot/``, ``pi0/``, etc., as an
+in-tree lerobot policy. The draccus type ``"vllm"`` is registered when this package is
+imported, which happens via ``lerobot.policies.__init__`` (like every other built-in
+policy) and through the ``vllm`` branches in ``lerobot.policies.factory``.
+"""
+
+from .configuration_vllm import VllmConfig
+from .modeling_vllm import VllmPolicy
+from .processor_vllm import make_vllm_pre_post_processors
+
+__all__ = ["VllmConfig", "VllmPolicy", "make_vllm_pre_post_processors"]

--- a/src/lerobot/policies/vllm/client.py
+++ b/src/lerobot/policies/vllm/client.py
@@ -1,0 +1,112 @@
+"""Minimal OpenPI WebSocket client for a remote vLLM policy server.
+
+Protocol (e.g. vllm-omni/examples/online_serving/gr00t):
+  1. connect to ``ws://host:port/v1/realtime/robot/openpi``
+  2. server sends msgpack-numpy ``PolicyServerConfig`` metadata
+  3. client sends one msgpack-numpy observation dict
+  4. server responds with ``dict[action_key -> ndarray(action_horizon, dim)]``
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+from typing import Any
+
+import msgpack
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+# --- Vendored OpenPI msgpack-numpy serializer ---------------------------------
+# Wire-compatible with the server's `openpi_client.msgpack_numpy` (the
+# `__ndarray__`/`__npgeneric__` envelope). NOTE: this is a DIFFERENT format from the
+# standalone PyPI `msgpack-numpy` package (`nd`/`type`/`kind`/`data`), which the server
+# cannot decode. Vendoring avoids depending on `openpi-client`, which pins numpy<2 and
+# would conflict with lerobot (numpy>=2). Adapted from openpi-client (Apache-2.0).
+
+
+def _pack_array(obj):
+    if isinstance(obj, (np.ndarray, np.generic)) and obj.dtype.kind in ("V", "O", "c"):
+        raise ValueError(f"Unsupported dtype: {obj.dtype}")
+    if isinstance(obj, np.ndarray):
+        return {b"__ndarray__": True, b"data": obj.tobytes(), b"dtype": obj.dtype.str, b"shape": obj.shape}
+    if isinstance(obj, np.generic):
+        return {b"__npgeneric__": True, b"data": obj.item(), b"dtype": obj.dtype.str}
+    return obj
+
+
+def _unpack_array(obj):
+    if b"__ndarray__" in obj:
+        return np.ndarray(buffer=obj[b"data"], dtype=np.dtype(obj[b"dtype"]), shape=obj[b"shape"])
+    if b"__npgeneric__" in obj:
+        return np.dtype(obj[b"dtype"]).type(obj[b"data"])
+    return obj
+
+
+class _MsgpackNumpy:
+    packb = staticmethod(functools.partial(msgpack.packb, default=_pack_array))
+    unpackb = staticmethod(functools.partial(msgpack.unpackb, object_hook=_unpack_array))
+
+
+def _import_msgpack_numpy():
+    """Return the OpenPI-format serializer (prefer the real package if present)."""
+    try:
+        from openpi_client import msgpack_numpy  # type: ignore
+
+        return msgpack_numpy
+    except Exception:
+        return _MsgpackNumpy
+
+
+class OpenPIClient:
+    """One websocket round-trip per inference call (stateless, reconnect each call).
+
+    Reconnecting per call keeps the implementation simple and robust for batched eval
+    where each env may be queried independently; the server tracks state by
+    ``session_id`` carried in the observation.
+    """
+
+    def __init__(self, url: str, connect_timeout_s: float = 30.0, max_msg_bytes: int = 64 * 1024 * 1024):
+        self.url = url
+        self.connect_timeout_s = connect_timeout_s
+        self.max_msg_bytes = max_msg_bytes
+        self._packer = _import_msgpack_numpy()
+        try:
+            import websockets.sync.client  # noqa: F401
+        except ImportError as exc:  # pragma: no cover
+            raise ImportError(
+                "The vllm policy requires `websockets`. Install with `pip install websockets`."
+            ) from exc
+
+    def infer(self, observation: dict[str, Any]) -> tuple[dict[str, np.ndarray], dict[str, Any]]:
+        """Send one raw observation; return ``(actions_dict, server_metadata)``."""
+        import websockets.sync.client
+
+        with websockets.sync.client.connect(
+            self.url,
+            open_timeout=self.connect_timeout_s,
+            max_size=self.max_msg_bytes,
+        ) as conn:
+            metadata = self._packer.unpackb(conn.recv())  # server handshake metadata
+            conn.send(self._packer.packb(observation))
+            actions = self._packer.unpackb(conn.recv())
+
+        if not isinstance(actions, dict):
+            raise RuntimeError(
+                f"vLLM OpenPI server must return a dict of ndarrays; got {type(actions).__name__}"
+            )
+        # The server returns {"type": "error", "message": ...} on failure.
+        if actions.get("type") == "error":
+            raise RuntimeError(f"vLLM server error: {actions.get('message', actions)}")
+        return {k: np.asarray(v, dtype=np.float32) for k, v in actions.items()}, metadata
+
+    def handshake(self) -> dict[str, Any]:
+        """Connect and return just the server metadata (used to size images, etc.)."""
+        import websockets.sync.client
+
+        with websockets.sync.client.connect(
+            self.url, open_timeout=self.connect_timeout_s, max_size=self.max_msg_bytes
+        ) as conn:
+            return self._packer.unpackb(conn.recv())

--- a/src/lerobot/policies/vllm/configuration_vllm.py
+++ b/src/lerobot/policies/vllm/configuration_vllm.py
@@ -1,0 +1,198 @@
+"""Configuration for the remote vLLM (OpenPI) policy."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from lerobot.configs.policies import PreTrainedConfig
+from lerobot.configs.types import FeatureType, NormalizationMode, PolicyFeature
+from lerobot.optim.optimizers import AdamWConfig
+from lerobot.optim.schedulers import LRSchedulerConfig
+from lerobot.utils.constants import ACTION
+
+# LIBERO (libero_sim / LIBERO_PANDA) modality — the authoritative convention from
+# Isaac-GR00T/examples/LIBERO/modality.json. Action is the NATIVE LIBERO 7-D OSC_POSE
+# command [x, y, z, roll, pitch, yaw, gripper]; state adds a 2-D gripper qpos (8-D total).
+LIBERO_MODALITY_CONFIG: dict = {
+    "state": {
+        "x": {"start": 0, "end": 1},
+        "y": {"start": 1, "end": 2},
+        "z": {"start": 2, "end": 3},
+        "roll": {"start": 3, "end": 4},
+        "pitch": {"start": 4, "end": 5},
+        "yaw": {"start": 5, "end": 6},
+        "gripper": {"start": 6, "end": 8},
+    },
+    "action": {
+        "x": {"start": 0, "end": 1},
+        "y": {"start": 1, "end": 2},
+        "z": {"start": 2, "end": 3},
+        "roll": {"start": 3, "end": 4},
+        "pitch": {"start": 4, "end": 5},
+        "yaw": {"start": 5, "end": 6},
+        "gripper": {"start": 6, "end": 7},
+    },
+}
+# Ordered LIBERO action keys -> the 7-D action vector fed to the LIBERO env.
+LIBERO_ACTION_KEYS: list[str] = ["x", "y", "z", "roll", "pitch", "yaw", "gripper"]
+
+# DROID-style modality (legacy / non-LIBERO embodiments).
+DROID_MODALITY_CONFIG: dict = {
+    "state": {
+        "eef_9d": {"start": 0, "end": 9},
+        "gripper_position": {"start": 9, "end": 10},
+        "joint_position": {"start": 10, "end": 17},
+    },
+    "action": {
+        "eef_9d": {"start": 0, "end": 9},
+        "gripper_position": {"start": 9, "end": 10},
+        "joint_position": {"start": 10, "end": 17},
+    },
+}
+# Back-compat alias.
+DEFAULT_MODALITY_CONFIG = LIBERO_MODALITY_CONFIG
+
+
+@PreTrainedConfig.register_subclass("vllm")
+@dataclass
+class VllmConfig(PreTrainedConfig):
+    """Config for a policy that proxies inference to a remote vLLM OpenPI policy server.
+
+    The server (e.g. vllm-omni GR00T-N1.7) accepts a *raw* observation over a WebSocket
+    (msgpack-numpy) and returns a per-action-key dict of *absolute* action trajectories.
+    This policy encodes LeRobot observations into that request and decodes the response
+    into the env action space. The default decode is a generic "flat concat" of the keys
+    named in ``action_keys`` (so a new embodiment whose action is a flat vector is
+    config-only); ``action_space="eef_9d"`` selects an alternative SE(3)/rot6d math path.
+    """
+
+    # --- action chunking ---
+    n_obs_steps: int = 1
+    chunk_size: int = 16
+    n_action_steps: int = 16
+
+    # --- remote server connection ---
+    host: str = "127.0.0.1"
+    port: int = 8000
+    ws_path: str = "/v1/realtime/robot/openpi"
+    connect_timeout_s: float = 30.0
+    max_msg_bytes: int = 64 * 1024 * 1024
+
+    # --- request construction ---
+    # `libero_sim` is the LIBERO-specific GR00T-N1.7 embodiment (projector id 2).
+    embodiment: str = "libero_sim"
+    # If set, overrides the env-provided task string as the language prompt.
+    prompt_override: str | None = None
+    # Fallback image (H, W); overridden by the server handshake metadata when available.
+    image_height: int = 256
+    image_width: int = 256
+    external_camera_obs_key: str = "observation.images.image"  # LIBERO agentview
+    wrist_camera_obs_key: str = "observation.images.image2"  # LIBERO eye-in-hand
+    send_wrist_camera: bool = True
+    # Action/state convention: "libero_7d" (native LIBERO [x,y,z,roll,pitch,yaw,gripper],
+    # for the libero_sim/LIBERO_PANDA embodiment) or "eef_9d" (legacy DROID-style).
+    action_space: str = "libero_7d"
+    # Send images as an ordered list ([external_0, wrist]) rather than a dict. The deployed
+    # vllm-omni server feeds `images` straight into the HF image processor, which requires a
+    # single image or a list (a dict raises "only a single or a list of entries is supported").
+    images_as_list: bool = True
+    # LiberoProcessorStep already rotates LIBERO images 180°, so default off here.
+    flip_images_180: bool = False
+    modality_config: dict = field(default_factory=lambda: DEFAULT_MODALITY_CONFIG)
+    # Optional per-request flow-matching seed for reproducibility (None = disabled).
+    request_seed: int | None = None
+
+    # --- state encoding ---
+    # LeRobot's LiberoProcessorStep flattens state to [eef_pos(3), eef_axisangle(3), gripper_qpos(2)].
+    state_obs_key: str = "observation.state"
+    # gripper_qpos (2 finger joints) -> single normalized gripper position in [0, 1].
+    gripper_qpos_open: float = 0.04  # per-finger qpos at fully open
+    gripper_qpos_closed: float = 0.0  # per-finger qpos at fully closed
+    # joint positions are not surfaced by LiberoProcessorStep; send zeros unless available.
+    send_joint_position: bool = True
+    joint_dim: int = 7
+
+    # --- action decoding ---
+    # Generic "flat concat" decode (used for every action_space except "eef_9d"): the
+    # server returns one trajectory per key; we concatenate the keys named in `action_keys`
+    # (in order) into the env action vector. Adding a new embodiment whose action is a flat
+    # concat of scalar channels is config-only (set `embodiment` + `action_keys` + the
+    # gripper flags below). `eef_9d` keeps its own SE(3)/rot6d math path (see modeling).
+    action_keys: list[str] = field(default_factory=lambda: list(LIBERO_ACTION_KEYS))
+    # Subset of `action_keys` carrying a gripper command; these get the gripper
+    # post-processing below. All other keys are treated as continuous pose channels.
+    gripper_keys: list[str] = field(default_factory=lambda: ["gripper"])
+    # Must match the env control_mode ("relative" delta or "absolute"). (eef_9d only.)
+    control_mode: str = "relative"
+    action_scale: float = 1.0
+    gripper_action_open: float = -1.0
+    gripper_action_close: float = 1.0
+    # The vllm-omni server returns ABSOLUTE actions (current state + predicted delta).
+    # Isaac-GR00T's native eval feeds the raw DELTA to env.step (relative control), so we
+    # subtract the current state (matched by channel index) to recover it. Default True.
+    decode_subtract_state: bool = True
+    # Gripper post-processing applied to `gripper_keys` (matches Isaac-GR00T's LIBERO eval):
+    # normalize [0,1]->[-1,1], then optional sign-binarize, then optional sign-invert.
+    gripper_normalize: bool = True
+    gripper_binarize: bool = True
+    gripper_invert: bool = True
+    # Clip the final action to the env's [-1, 1] box.
+    clip_action: bool = True
+
+    # Server normalizes/denormalizes; keep the policy-side pipeline identity.
+    normalization_mapping: dict[str, NormalizationMode] = field(
+        default_factory=lambda: {
+            "VISUAL": NormalizationMode.IDENTITY,
+            "STATE": NormalizationMode.IDENTITY,
+            "ACTION": NormalizationMode.IDENTITY,
+        }
+    )
+
+    def __post_init__(self):
+        super().__post_init__()
+        if self.n_action_steps > self.chunk_size:
+            raise ValueError(
+                f"n_action_steps ({self.n_action_steps}) cannot exceed chunk_size ({self.chunk_size})"
+            )
+        if self.control_mode not in ("relative", "absolute"):
+            raise ValueError(f"control_mode must be 'relative' or 'absolute', got {self.control_mode}")
+
+    @property
+    def ws_url(self) -> str:
+        return f"ws://{self.host}:{self.port}{self.ws_path}"
+
+    @property
+    def action_dim(self) -> int:
+        """Env action dimension: a flat concat of `action_keys`, except the `eef_9d`
+        path which is fixed 7-D (xyz(3) + axisangle(3) + gripper(1))."""
+        if self.action_space == "eef_9d":
+            return 7
+        return len(self.action_keys)
+
+    # --- PreTrainedConfig abstract interface ---
+    def validate_features(self) -> None:
+        # This policy reads images + a flat state from the env preprocessor and does not
+        # build normalization buffers, so we only ensure an ACTION output exists.
+        if not self.output_features:
+            self.output_features = {
+                ACTION: PolicyFeature(type=FeatureType.ACTION, shape=(self.action_dim,))
+            }
+
+    def get_optimizer_preset(self) -> AdamWConfig:
+        # Inference-only policy; provided for API completeness (unused during eval).
+        return AdamWConfig()
+
+    def get_scheduler_preset(self) -> LRSchedulerConfig | None:
+        return None
+
+    @property
+    def observation_delta_indices(self) -> None:
+        return None
+
+    @property
+    def action_delta_indices(self) -> None:
+        return None
+
+    @property
+    def reward_delta_indices(self) -> None:
+        return None

--- a/src/lerobot/policies/vllm/encoding.py
+++ b/src/lerobot/policies/vllm/encoding.py
@@ -1,0 +1,97 @@
+"""Pure-numpy helpers to encode LIBERO observations into OpenPI requests and
+decode the absolute action response back into LIBERO's 7-D action space.
+
+LIBERO (via LeRobot's ``LiberoProcessorStep``) exposes a flat state vector
+``[eef_pos(3), eef_axisangle(3), gripper_qpos(2)]`` and two RGB image streams.
+The (legacy) DROID-style GR00T modality expects ``eef_9d = [xyz(3), rot6d(6)]``, a scalar
+``gripper_position`` and a ``joint_position(7)`` vector.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def axisangle_to_matrix(axisangle: np.ndarray) -> np.ndarray:
+    """Rodrigues' formula: axis-angle (3,) -> rotation matrix (3, 3)."""
+    axisangle = np.asarray(axisangle, dtype=np.float64).reshape(3)
+    theta = float(np.linalg.norm(axisangle))
+    if theta < 1e-8:
+        return np.eye(3)
+    axis = axisangle / theta
+    x, y, z = axis
+    K = np.array([[0.0, -z, y], [z, 0.0, -x], [-y, x, 0.0]])
+    return np.eye(3) + np.sin(theta) * K + (1.0 - np.cos(theta)) * (K @ K)
+
+
+def matrix_to_axisangle(mat: np.ndarray) -> np.ndarray:
+    """Rotation matrix (3, 3) -> axis-angle (3,)."""
+    mat = np.asarray(mat, dtype=np.float64).reshape(3, 3)
+    cos_theta = np.clip((np.trace(mat) - 1.0) / 2.0, -1.0, 1.0)
+    theta = float(np.arccos(cos_theta))
+    if theta < 1e-8:
+        return np.zeros(3)
+    if abs(np.pi - theta) < 1e-6:
+        # Near 180°: extract axis from the symmetric part.
+        vals = np.clip((np.diag(mat) + 1.0) / 2.0, 0.0, None)
+        axis = np.sqrt(vals)
+        axis = axis / (np.linalg.norm(axis) + 1e-12)
+        return axis * theta
+    axis = np.array(
+        [mat[2, 1] - mat[1, 2], mat[0, 2] - mat[2, 0], mat[1, 0] - mat[0, 1]]
+    ) / (2.0 * np.sin(theta))
+    return axis * theta
+
+
+def matrix_to_rot6d(mat: np.ndarray) -> np.ndarray:
+    """Rotation matrix (3, 3) -> 6D representation = first two columns, flattened."""
+    mat = np.asarray(mat, dtype=np.float64).reshape(3, 3)
+    return np.concatenate([mat[:, 0], mat[:, 1]]).astype(np.float64)
+
+
+def rot6d_to_matrix(rot6d: np.ndarray) -> np.ndarray:
+    """6D representation -> rotation matrix (3, 3) via Gram-Schmidt (matches GR00T)."""
+    rot6d = np.asarray(rot6d, dtype=np.float64).reshape(6)
+    a1, a2 = rot6d[0:3], rot6d[3:6]
+    b1 = a1 / (np.linalg.norm(a1) + 1e-8)
+    a2 = a2 - np.dot(b1, a2) * b1
+    b2 = a2 / (np.linalg.norm(a2) + 1e-8)
+    b3 = np.cross(b1, b2)
+    return np.stack([b1, b2, b3], axis=1)  # columns
+
+
+def eef_9d_from_pos_axisangle(eef_pos: np.ndarray, eef_axisangle: np.ndarray) -> np.ndarray:
+    """[xyz(3), axisangle(3)] -> eef_9d = [xyz(3), rot6d(6)]."""
+    R = axisangle_to_matrix(eef_axisangle)
+    return np.concatenate([np.asarray(eef_pos, dtype=np.float64).reshape(3), matrix_to_rot6d(R)])
+
+
+def gripper_qpos_to_position(gripper_qpos: np.ndarray, q_open: float, q_closed: float) -> float:
+    """LIBERO gripper finger qpos (2,) -> normalized open fraction in [0, 1]."""
+    gripper_qpos = np.asarray(gripper_qpos, dtype=np.float64).reshape(-1)
+    width = float(np.mean(np.abs(gripper_qpos)))
+    denom = (q_open - q_closed) or 1.0
+    return float(np.clip((width - q_closed) / denom, 0.0, 1.0))
+
+
+def gripper_position_to_action(pos: float, action_open: float, action_close: float) -> float:
+    """Normalized gripper open fraction in [0, 1] -> LIBERO gripper command.
+
+    pos≈1 (open) -> action_open ; pos≈0 (closed) -> action_close.
+    """
+    pos = float(np.clip(pos, 0.0, 1.0))
+    return float(action_close + pos * (action_open - action_close))
+
+
+def chw01_to_hwc_uint8(img: np.ndarray, flip_180: bool = False) -> np.ndarray:
+    """(C, H, W) float [0, 1] (LeRobot image) -> (H, W, 3) uint8 (server image)."""
+    arr = np.asarray(img)
+    if arr.ndim == 3 and arr.shape[0] in (1, 3):  # CHW
+        arr = np.transpose(arr, (1, 2, 0))
+    if arr.dtype != np.uint8:
+        arr = np.clip(arr * 255.0, 0, 255).astype(np.uint8) if arr.max() <= 1.0 + 1e-3 else arr.astype(np.uint8)
+    if arr.shape[-1] == 1:
+        arr = np.repeat(arr, 3, axis=-1)
+    if flip_180:
+        arr = arr[::-1, ::-1].copy()
+    return arr

--- a/src/lerobot/policies/vllm/mock_server.py
+++ b/src/lerobot/policies/vllm/mock_server.py
@@ -1,0 +1,109 @@
+"""A minimal mock OpenPI WebSocket server for local (no-GPU) smoke testing.
+
+It mimics the vllm-omni protocol:
+  1. on connect, send msgpack-numpy ``PolicyServerConfig`` metadata,
+  2. for each received observation, return a dict of dummy no-op action trajectories.
+
+This lets you exercise the full lerobot-eval -> vllm -> LIBERO loop without a GPU
+or the real model.
+
+Run:
+    python -m lerobot.policies.vllm.mock_server --host 127.0.0.1 --port 8000
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+
+import numpy as np
+
+from .client import _import_msgpack_numpy
+
+logger = logging.getLogger("vllm-mock-server")
+
+IDENTITY_ROT6D = np.array([1.0, 0.0, 0.0, 0.0, 1.0, 0.0], dtype=np.float32)
+
+
+LIBERO_KEYS = ["x", "y", "z", "roll", "pitch", "yaw", "gripper"]
+
+
+def _make_metadata(action_horizon: int, image_hw: tuple[int, int], action_space: str) -> dict:
+    keys = LIBERO_KEYS if action_space == "libero_7d" else ["eef_9d", "gripper_position", "joint_position"]
+    return {
+        "action_horizon": action_horizon,
+        "action_keys": keys,
+        "image_resolution": [int(image_hw[0]), int(image_hw[1])],
+        "n_external_cameras": 1,
+        "needs_wrist_camera": True,
+        "needs_session_id": True,
+    }
+
+
+def _make_actions(obs: dict, action_horizon: int, joint_dim: int, action_space: str) -> dict[str, np.ndarray]:
+    """Return plausible, finite no-op actions for smoke testing."""
+    state = obs.get("state", {}) if isinstance(obs, dict) else {}
+    if action_space == "libero_7d":
+        # Zero pose deltas (no motion in relative mode); hold the observed gripper.
+        grip = np.asarray(state.get("gripper", [0.0]), dtype=np.float32).reshape(-1)
+        g = float(grip[0]) if grip.size else 0.0
+        out = {k: np.zeros((action_horizon, 1), dtype=np.float32) for k in LIBERO_KEYS}
+        out["gripper"] = np.full((action_horizon, 1), g, dtype=np.float32)
+        return out
+
+    eef_9d = np.asarray(state.get("eef_9d", [0.0] * 9), dtype=np.float32).reshape(-1)
+    if eef_9d.shape[0] < 9:
+        eef_9d = np.concatenate([np.zeros(3, dtype=np.float32), IDENTITY_ROT6D])
+    gripper = np.asarray(state.get("gripper_position", [0.5]), dtype=np.float32).reshape(-1)[:1]
+    joints = np.asarray(state.get("joint_position", [0.0] * joint_dim), dtype=np.float32).reshape(-1)
+    if joints.shape[0] < joint_dim:
+        joints = np.zeros(joint_dim, dtype=np.float32)
+    return {
+        "eef_9d": np.tile(eef_9d[None, :9], (action_horizon, 1)).astype(np.float32),
+        "gripper_position": np.tile(gripper[None, :1], (action_horizon, 1)).astype(np.float32),
+        "joint_position": np.tile(joints[None, :joint_dim], (action_horizon, 1)).astype(np.float32),
+    }
+
+
+def serve(
+    host: str = "127.0.0.1",
+    port: int = 8000,
+    action_horizon: int = 16,
+    joint_dim: int = 7,
+    action_space: str = "libero_7d",
+) -> None:
+    from websockets.sync.server import serve as ws_serve
+
+    packer = _import_msgpack_numpy()
+    metadata = _make_metadata(action_horizon, (256, 256), action_space)
+
+    def handler(conn):
+        peer = getattr(conn, "remote_address", "?")
+        logger.info("client connected: %s", peer)
+        conn.send(packer.packb(metadata))
+        for raw in conn:
+            obs = packer.unpackb(raw)
+            actions = _make_actions(obs, action_horizon, joint_dim, action_space)
+            conn.send(packer.packb(actions))
+        logger.info("client disconnected: %s", peer)
+
+    logger.info("Mock vLLM OpenPI server listening on ws://%s:%d/v1/realtime/robot/openpi", host, port)
+    with ws_serve(handler, host, port, max_size=64 * 1024 * 1024) as server:
+        server.serve_forever()
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("--host", default="127.0.0.1")
+    p.add_argument("--port", type=int, default=8000)
+    p.add_argument("--action-horizon", type=int, default=16)
+    p.add_argument("--joint-dim", type=int, default=7)
+    p.add_argument("--action-space", default="libero_7d", choices=["libero_7d", "eef_9d"])
+    args = p.parse_args()
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    serve(args.host, args.port, args.action_horizon, args.joint_dim, args.action_space)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/lerobot/policies/vllm/modeling_vllm.py
+++ b/src/lerobot/policies/vllm/modeling_vllm.py
@@ -1,0 +1,298 @@
+"""VllmPolicy: a LeRobot policy that delegates action inference to a remote vLLM
+OpenPI WebSocket server (e.g. vllm-omni GR00T-N1.7).
+
+It does not hold model weights. At each step it encodes the (LIBERO) observation into
+an OpenPI request, sends it to the remote server, and decodes the returned *absolute*
+action trajectory into LIBERO's 7-D action space, buffering ``n_action_steps`` actions.
+"""
+
+from __future__ import annotations
+
+import builtins
+import logging
+import uuid
+from collections import deque
+from pathlib import Path
+from typing import Any, TypeVar
+
+import numpy as np
+import torch
+from torch import Tensor
+
+from lerobot.policies.pretrained import PreTrainedPolicy
+
+from .client import OpenPIClient
+from .configuration_vllm import VllmConfig
+from .encoding import (
+    axisangle_to_matrix,
+    chw01_to_hwc_uint8,
+    eef_9d_from_pos_axisangle,
+    gripper_position_to_action,
+    gripper_qpos_to_position,
+    matrix_to_axisangle,
+    rot6d_to_matrix,
+)
+
+logger = logging.getLogger(__name__)
+T = TypeVar("T", bound="VllmPolicy")
+
+
+def _resize_hwc(img: np.ndarray, height: int, width: int) -> np.ndarray:
+    if img.shape[0] == height and img.shape[1] == width:
+        return img
+    try:
+        import cv2
+
+        return cv2.resize(img, (width, height), interpolation=cv2.INTER_AREA)
+    except Exception:  # pragma: no cover - fallback nearest-neighbour
+        ys = (np.linspace(0, img.shape[0] - 1, height)).astype(int)
+        xs = (np.linspace(0, img.shape[1] - 1, width)).astype(int)
+        return img[ys][:, xs]
+
+
+class VllmPolicy(PreTrainedPolicy):
+    """Remote-inference policy proxying to a vLLM OpenPI server."""
+
+    name = "vllm"
+    config_class = VllmConfig
+
+    def __init__(self, config: VllmConfig, **kwargs):
+        super().__init__(config)
+        config.validate_features()
+        self.config = config
+        # Dummy buffer so the module has a device and `.to(...)`/`.parameters()` behave.
+        self.register_buffer("_device_marker", torch.zeros(1), persistent=False)
+        self._client = OpenPIClient(
+            url=config.ws_url,
+            connect_timeout_s=config.connect_timeout_s,
+            max_msg_bytes=config.max_msg_bytes,
+        )
+        self._server_image_hw: tuple[int, int] | None = None
+        self.reset()
+
+    # --- lifecycle ---
+    def reset(self):
+        """Clear the action buffer and start a fresh server session."""
+        self._action_queue: deque[Tensor] = deque([], maxlen=self.config.n_action_steps)
+        self._session_id = str(uuid.uuid4())
+
+    @classmethod
+    def from_pretrained(
+        cls: builtins.type[T],
+        pretrained_name_or_path: str | Path,
+        *,
+        config: VllmConfig | None = None,
+        **kwargs,
+    ) -> T:
+        """Build the policy from config only (no weights to load for a remote policy)."""
+        if config is None:
+            config = VllmConfig.from_pretrained(pretrained_name_or_path, **kwargs)
+        policy = cls(config)
+        policy.eval()
+        return policy
+
+    def get_optim_params(self) -> dict:
+        return self.parameters()
+
+    def forward(self, batch: dict[str, Tensor]) -> tuple[Tensor, dict]:
+        raise NotImplementedError("VllmPolicy is inference-only (remote server); training is unsupported.")
+
+    # --- inference ---
+    @property
+    def _device(self) -> torch.device:
+        return self._device_marker.device
+
+    def _image_hw(self) -> tuple[int, int]:
+        if self._server_image_hw is not None:
+            return self._server_image_hw
+        return (self.config.image_height, self.config.image_width)
+
+    def _maybe_handshake(self) -> None:
+        """Fetch server image resolution once (best-effort)."""
+        if self._server_image_hw is not None:
+            return
+        try:
+            meta = self._client.handshake()
+            res = meta.get("image_resolution")
+            if res and len(res) == 2:
+                self._server_image_hw = (int(res[0]), int(res[1]))
+        except Exception as exc:  # pragma: no cover - non-fatal
+            logger.debug("Server handshake for image resolution failed: %s", exc)
+            self._server_image_hw = (self.config.image_height, self.config.image_width)
+
+    def _build_request(self, batch: dict[str, Tensor], i: int) -> dict[str, Any]:
+        cfg = self.config
+        state = batch[cfg.state_obs_key][i].detach().cpu().numpy().astype(np.float64).reshape(-1)
+
+        if cfg.action_space == "eef_9d":
+            # legacy DROID eef_9d: derive xyz+rot6d and a scalar gripper from the flat state.
+            eef_9d = eef_9d_from_pos_axisangle(state[0:3], state[3:6])
+            gripper_position = gripper_qpos_to_position(
+                state[6:8], cfg.gripper_qpos_open, cfg.gripper_qpos_closed
+            )
+            raw_state = {
+                "eef_9d": [float(x) for x in eef_9d],
+                "gripper_position": [float(gripper_position)],
+            }
+            if cfg.send_joint_position:
+                raw_state["joint_position"] = [0.0] * cfg.joint_dim
+        else:
+            # Generic: slice the flat LeRobot state vector into named keys per
+            # modality_config["state"]. For LIBERO (LiberoProcessorStep state
+            # [eef_pos(3), eef_axisangle(3), gripper_qpos(2)]) this yields
+            # {x,y,z,roll,pitch,yaw at single dims, gripper at 2 dims}.
+            state_modality = (cfg.modality_config or {}).get("state", {})
+            if not state_modality:
+                raise RuntimeError(
+                    f"action_space={cfg.action_space!r} needs modality_config['state'] to encode "
+                    "the request state (a {key: {'start', 'end'}} slicing of observation.state)."
+                )
+            raw_state = {
+                key: [float(v) for v in state[int(spec["start"]) : int(spec["end"])]]
+                for key, spec in state_modality.items()
+            }
+
+        h, w = self._image_hw()
+        ext = chw01_to_hwc_uint8(batch[cfg.external_camera_obs_key][i].detach().cpu().numpy(), cfg.flip_images_180)
+        ordered: list[tuple[str, np.ndarray]] = [("external_0", _resize_hwc(ext, h, w))]
+        if cfg.send_wrist_camera and cfg.wrist_camera_obs_key in batch:
+            wrist = chw01_to_hwc_uint8(
+                batch[cfg.wrist_camera_obs_key][i].detach().cpu().numpy(), cfg.flip_images_180
+            )
+            ordered.append(("wrist", _resize_hwc(wrist, h, w)))
+        # The deployed server requires a list (or single image); a dict raises in the HF
+        # image processor. `images_as_list` keeps a dict path available for other servers.
+        images: Any = [im for _, im in ordered] if cfg.images_as_list else dict(ordered)
+
+        prompt = cfg.prompt_override
+        if prompt is None:
+            task = batch.get("task")
+            prompt = task[i] if isinstance(task, (list, tuple)) and i < len(task) else (task or "")
+
+        obs: dict[str, Any] = {
+            "session_id": self._session_id,
+            "embodiment": cfg.embodiment,
+            "modality_config": cfg.modality_config,
+            "prompt": prompt,
+            "state": raw_state,
+            "images": images,
+        }
+        if cfg.request_seed is not None:
+            obs["seed"] = int(cfg.request_seed)
+        return obs
+
+    def _decode_concat(self, actions: dict[str, np.ndarray], state_i: np.ndarray) -> np.ndarray:
+        """Generic decode: concatenate the server's per-key trajectories named in
+        ``cfg.action_keys`` (in order) into the env action vector ``(n, len(action_keys))``.
+
+        Per channel, in order:
+          - optionally de-bias by the current state (``decode_subtract_state``, matched by
+            channel index) — the vllm-omni server returns ABSOLUTE values (current state +
+            delta), so this recovers the per-step delta for relative-control envs;
+          - continuous pose channels are scaled by ``action_scale``;
+          - gripper channels (those in ``cfg.gripper_keys``) get gripper post-processing:
+            normalize [0,1]->[-1,1] (``gripper_normalize``), optional sign-binarize, invert.
+
+        This reproduces Isaac-GR00T's LIBERO eval for the default LIBERO keys, but is
+        embodiment-agnostic: any flat-concat action space works by setting ``action_keys``.
+        """
+        cfg = self.config
+        keys = cfg.action_keys
+        missing = [k for k in keys if k not in actions]
+        if missing:
+            raise RuntimeError(
+                f"Server response missing action key(s) {missing}; got {sorted(actions.keys())}"
+            )
+        horizon = min(int(np.asarray(actions[k]).shape[0]) for k in keys)
+        n = min(cfg.n_action_steps, horizon)
+        out = np.zeros((n, len(keys)), dtype=np.float32)
+        gripper_keys = set(cfg.gripper_keys)
+
+        for idx, key in enumerate(keys):
+            col = np.asarray(actions[key], dtype=np.float32).reshape(horizon, -1)[:n, 0]
+            if cfg.decode_subtract_state and idx < state_i.shape[0]:
+                col = col - np.float32(state_i[idx])
+            if key in gripper_keys:
+                if cfg.gripper_normalize:
+                    col = 2.0 * col - 1.0  # [0,1] -> [-1,1]
+                if cfg.gripper_binarize:
+                    col = np.sign(col)
+                if cfg.gripper_invert:
+                    col = -col
+            else:
+                col = col * cfg.action_scale
+            out[:, idx] = col
+
+        if cfg.clip_action:
+            np.clip(out, -1.0, 1.0, out=out)
+        return out
+
+    def _decode_actions(self, actions: dict[str, np.ndarray], state_i: np.ndarray) -> np.ndarray:
+        """Server action dict -> env action chunk (n, action_dim).
+
+        ``eef_9d`` uses an SE(3)/rot6d math path; every other ``action_space`` uses the
+        generic flat-concat decode driven by ``cfg.action_keys``.
+        """
+        if self.config.action_space == "eef_9d":
+            return self._decode_eef_9d(actions, state_i)
+        return self._decode_concat(actions, state_i)
+
+    def _decode_eef_9d(self, actions: dict[str, np.ndarray], state_i: np.ndarray) -> np.ndarray:
+        """DROID-style decode: eef_9d (xyz + rot6d) + gripper_position -> 7-D action."""
+        cfg = self.config
+        eef_traj = actions.get("eef_9d")
+        if eef_traj is None:
+            raise RuntimeError(f"Server response missing 'eef_9d'; got keys {sorted(actions.keys())}")
+        eef_traj = np.asarray(eef_traj, dtype=np.float64)
+        grip_traj = actions.get("gripper_position")
+        grip_traj = np.asarray(grip_traj, dtype=np.float64).reshape(-1) if grip_traj is not None else None
+
+        horizon = eef_traj.shape[0]
+        n = min(cfg.n_action_steps, horizon)
+        out = np.zeros((n, 7), dtype=np.float32)
+
+        prev_xyz = np.asarray(state_i[0:3], dtype=np.float64)
+        prev_R = axisangle_to_matrix(state_i[3:6])
+
+        for j in range(n):
+            tgt_xyz = eef_traj[j, 0:3]
+            tgt_R = rot6d_to_matrix(eef_traj[j, 3:9])
+            if cfg.control_mode == "relative":
+                out[j, 0:3] = (tgt_xyz - prev_xyz) * cfg.action_scale
+                out[j, 3:6] = matrix_to_axisangle(tgt_R @ prev_R.T) * cfg.action_scale
+                prev_xyz, prev_R = tgt_xyz, tgt_R
+            else:  # absolute
+                out[j, 0:3] = tgt_xyz
+                out[j, 3:6] = matrix_to_axisangle(tgt_R)
+            g = float(grip_traj[j]) if grip_traj is not None and j < grip_traj.shape[0] else 0.0
+            out[j, 6] = gripper_position_to_action(g, cfg.gripper_action_open, cfg.gripper_action_close)
+
+        if cfg.clip_action:
+            np.clip(out, -1.0, 1.0, out=out)
+        return out
+
+    @torch.no_grad()
+    def predict_action_chunk(self, batch: dict[str, Tensor], **kwargs) -> Tensor:
+        """Query the remote server for each env and return (B, n_action_steps, 7)."""
+        self._maybe_handshake()
+        cfg = self.config
+        batch_size = batch[cfg.state_obs_key].shape[0]
+
+        chunks: list[np.ndarray] = []
+        for i in range(batch_size):
+            obs = self._build_request(batch, i)
+            actions, _meta = self._client.infer(obs)
+            state_i = batch[cfg.state_obs_key][i].detach().cpu().numpy().astype(np.float64).reshape(-1)
+            chunks.append(self._decode_actions(actions, state_i))
+
+        arr = np.stack(chunks, axis=0)  # (B, n, 7)
+        return torch.from_numpy(arr).to(self._device)
+
+    @torch.no_grad()
+    def select_action(self, batch: dict[str, Tensor], **kwargs) -> Tensor:
+        """Return one action (B, 7); refill the buffer from the server when empty."""
+        if len(self._action_queue) == 0:
+            actions = self.predict_action_chunk(batch)  # (B, n, 7)
+            # queue holds n entries, each (B, 7)
+            self._action_queue.extend(actions.transpose(0, 1))
+        return self._action_queue.popleft()

--- a/src/lerobot/policies/vllm/processor_vllm.py
+++ b/src/lerobot/policies/vllm/processor_vllm.py
@@ -1,0 +1,53 @@
+"""Pre/post-processor pipelines for the vllm policy.
+
+The remote server performs normalization/denormalization, so the policy-side pipeline is
+intentionally identity w.r.t. values: it only renames observation keys and handles device
+placement. The pipeline still includes a ``device_processor`` and a
+``rename_observations_processor`` step because ``lerobot-eval`` passes overrides keyed on
+those step names (and validates that every override was applied).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+
+from lerobot.processor import (
+    DeviceProcessorStep,
+    PolicyAction,
+    PolicyProcessorPipeline,
+    RenameObservationsProcessorStep,
+)
+from lerobot.processor.converters import policy_action_to_transition, transition_to_policy_action
+from lerobot.utils.constants import POLICY_POSTPROCESSOR_DEFAULT_NAME, POLICY_PREPROCESSOR_DEFAULT_NAME
+
+from .configuration_vllm import VllmConfig
+
+
+def make_vllm_pre_post_processors(
+    config: VllmConfig,
+    dataset_stats: dict[str, dict[str, torch.Tensor]] | None = None,
+) -> tuple[
+    PolicyProcessorPipeline[dict[str, Any], dict[str, Any]],
+    PolicyProcessorPipeline[PolicyAction, PolicyAction],
+]:
+    input_steps = [
+        RenameObservationsProcessorStep(rename_map={}),
+        DeviceProcessorStep(device=config.device),
+    ]
+    output_steps = [
+        DeviceProcessorStep(device="cpu"),
+    ]
+    return (
+        PolicyProcessorPipeline[dict[str, Any], dict[str, Any]](
+            steps=input_steps,
+            name=POLICY_PREPROCESSOR_DEFAULT_NAME,
+        ),
+        PolicyProcessorPipeline[PolicyAction, PolicyAction](
+            steps=output_steps,
+            name=POLICY_POSTPROCESSOR_DEFAULT_NAME,
+            to_transition=policy_action_to_transition,
+            to_output=transition_to_policy_action,
+        ),
+    )


### PR DESCRIPTION
Add vllm policy — remote OpenPI inference

  Summary

  Adds a new in-tree policy, --policy.type=vllm, that delegates action inference to a remote vLLM OpenPI WebSocket server (e.g. [vllm-omni](https://github.com/vllm-project/vllm-omni)'s GR00T-N1.7). It holds no local weights: each
  step it encodes the LeRobot observation into an OpenPI request, sends it over a WebSocket, and decodes the returned trajectory into the env action space. Useful for serving inference
  centrally (one GPU server, many eval clients) and for evaluating a deployment exactly as it's served.


  What's added

  - src/lerobot/policies/vllm/ — the policy (client, config, modeling, processors, encoding, mock server).
  - Registration the standard way: import in policies/__init__.py, vllm branches in factory.py, and a vllm optional extra (websockets, msgpack) in pyproject.toml.
  - examples/vllm_policy/ — a ready-to-use --policy.path dir (generated config.json + processor JSONs) plus helper scripts (generate_policy_dir.py, eval_visualize.py).
  - docs/source/vllm.mdx — policy doc + quick start (registered in _toctree.yml).

  How it works

  - Protocol /v1/realtime/robot/openpi: server sends PolicyServerConfig on connect; client sends one obs and receives a per-action-key dict of ndarrays (OpenPI msgpack-numpy format).
  - Normalization happens on the server, so the policy-side processors are identity (rename + device only).
  - Decode is embodiment-agnostic: concatenates the keys named in action_keys into the action vector (action_dim = len(action_keys)) with configurable per-channel post-processing;
  action_space="eef_9d" keeps an explicit SE(3)/rot6d path. Adding a new flat-concat embodiment is config-only.

  Quick start

  pip install -e ".[vllm]"

  lerobot-eval \
    --policy.path=examples/vllm_policy \
    --policy.host=127.0.0.1 --policy.port=8000 \
    --env.type=libero --env.task=libero_object \
    --eval.batch_size=1 --eval.n_episodes=2 \
    --policy.n_action_steps=10 \
    --output_dir=./outputs/libero_eval
  No-GPU smoke test: python -m lerobot.policies.vllm.mock_server --port 8001, then run eval with --policy.type=vllm --policy.port=8001.

  Testing

  - End-to-end against nvidia/GR00T-N1.7-LIBERO/libero_object: pc_success = 100% over 10 tasks × 2 episodes.
  - Local mock-server smoke test covers the full encode→send→receive→decode loop without a GPU.

  Notes

  - Inference only (no weights, no training); one WebSocket round-trip per inference.
  - Works with any server speaking the OpenPI /v1/realtime/robot/openpi protocol; the libero env extra is Linux-only.

I also added a eval_visualize.py to visualize eval on vllm:


https://github.com/user-attachments/assets/8295a57f-a816-4102-99f7-7454fb726e7e


