### PR TITLE
fix(teleop): replace unitree_g1-specific guard with teleop.feedback_features

### DIFF
--- a/src/lerobot/scripts/lerobot_record.py
+++ b/src/lerobot/scripts/lerobot_record.py
@@ -289,7 +289,7 @@ def record_loop(
         # Get action from teleop
         if isinstance(teleop, Teleoperator):
             act = teleop.get_action()
-            if robot.name == "unitree_g1":
+            if teleop.feedback_features:
                 teleop.send_feedback(obs)
 
             # Applies a pipeline to the raw teleop action, default is IdentityProcessor

--- a/src/lerobot/scripts/lerobot_teleoperate.py
+++ b/src/lerobot/scripts/lerobot_teleoperate.py
@@ -167,7 +167,7 @@ def teleop_loop(
         # given that it is the identity processor as default
         obs = robot.get_observation()
 
-        if robot.name == "unitree_g1":
+        if teleop.feedback_features:
             teleop.send_feedback(obs)
 
         # Get teleop action

--- a/tests/test_control_robot.py
+++ b/tests/test_control_robot.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from unittest.mock import patch
+from unittest.mock import PropertyMock, patch
 
 import pytest
 
@@ -28,7 +28,7 @@ from lerobot.scripts.lerobot_replay import DatasetReplayConfig, ReplayConfig, re
 from lerobot.scripts.lerobot_teleoperate import TeleoperateConfig, teleoperate
 from tests.fixtures.constants import DUMMY_REPO_ID
 from tests.mocks.mock_robot import MockRobotConfig
-from tests.mocks.mock_teleop import MockTeleopConfig
+from tests.mocks.mock_teleop import MockTeleop, MockTeleopConfig
 
 
 def test_calibrate():
@@ -127,3 +127,24 @@ def test_record_and_replay(tmp_path):
         mock_get_safe_version.return_value = "v3.0"
         mock_snapshot_download.return_value = str(tmp_path / "record_and_replay")
         replay(replay_cfg)
+
+
+def test_teleoperate_calls_send_feedback_when_supported():
+    robot_cfg = MockRobotConfig()
+    teleop_cfg = MockTeleopConfig()
+    cfg = TeleoperateConfig(robot=robot_cfg, teleop=teleop_cfg, teleop_time_s=0.1)
+    with patch.object(MockTeleop, "send_feedback") as mock_send:
+        teleoperate(cfg)
+    mock_send.assert_called()
+
+
+def test_teleoperate_skips_send_feedback_when_not_supported():
+    robot_cfg = MockRobotConfig()
+    teleop_cfg = MockTeleopConfig()
+    cfg = TeleoperateConfig(robot=robot_cfg, teleop=teleop_cfg, teleop_time_s=0.1)
+    with (
+        patch.object(MockTeleop, "feedback_features", new_callable=PropertyMock, return_value={}),
+        patch.object(MockTeleop, "send_feedback") as mock_send,
+    ):
+        teleoperate(cfg)
+    mock_send.assert_not_called()


### PR DESCRIPTION
**Update** This PR is currently blocked by send_feedback() implementation on SOLeader and OpenArmMini, that's used by teleop_smooth_move_to for dataset aggregation.

## Summary / Motivation

`lerobot_teleoperate.py` and `lerobot_record.py` both gated `teleop.send_feedback()` behind a `robot.name == "unitree_g1"` check, in scripts which should be robot-agnostic. Any new robot or teleoperator that supports feedback would require a separate edit to these scripts to be enabled.

The `Teleoperator` base class already defines `feedback_features` as an abstract property that returns a dict of supported feedback signals: non-empty when feedback is supported, `{}` when not. This update uses that teleoperator property as the guard: if `teleop.feedback_features` is truthy, send feedback; if falsy, skip it.

## What Changed

- `lerobot_teleoperate.py:170` — replaced `if robot.name == "unitree_g1":` with `if teleop.feedback_features:`
- `lerobot_record.py:292` — same replacement
- `tests/test_control_robot.py` — two new tests:
  - `test_teleoperate_calls_send_feedback_when_supported` — asserts `send_feedback` is called when `feedback_features` is non-empty
  - `test_teleoperate_skips_send_feedback_when_not_supported` — asserts `send_feedback` is not called when `feedback_features` is `{}`

## How Was This Tested
Note: I used Anthropic's Claude to generate the tests.
```
pytest tests/test_control_robot.py
```

All 6 tests pass (including the 2 new ones). `pre-commit run --all-files` passes.

All existing teleoperator implementations were audited against the guard condition. Every teleoperator that raises `NotImplementedError` in `send_feedback()` returns `{}` from `feedback_features` (falsy); every teleoperator with a working `send_feedback()` implementation returns a non-empty dict (truthy). The guard is consistent with existing behavior across the board.

## Checklist

- [x] `pre-commit run -a` passes
- [x] All tests pass locally
- [ ] CI is green
- [X] Community Review: # https://github.com/huggingface/lerobot/pull/3735

## Notes

The three existing teleoperators with non-empty `feedback_features` [and working `send_feedback()` implementations] are `UnitreeG1Teleoperator`, `SOLeader`, and `OpenArmMini`. In their `send_feedback()` methods, `SOLeader` and `OpenArmMini` do write feedback to their servo bus as goal positions, ~~but this has no physical effect because they never enable servo torque~~.  Unitree users will see no change in behavior.

**Update** setting Goal_Position on SOLeader and OpenArmMini *does* cause them to resist movement, even without enabling torque, which is a problem. Therefore this PR's change would also require that `feedback_features` on SOLeader and OpenArmMini  be reverted to {}; I propose creating a new function on teleoperators to be used in the new automatic movement feature that DAgger introduced.