### PR TITLE
fix(processor): default missing gripper to "stay" in delta action step

### DIFF
--- a/src/lerobot/processor/delta_action_processor.py
+++ b/src/lerobot/processor/delta_action_processor.py
@@ -51,9 +51,8 @@ class MapTensorToDeltaActionDictStep(ActionProcessorStep):
             "delta_x": action[0].item(),
             "delta_y": action[1].item(),
             "delta_z": action[2].item(),
+            "gripper": action[3].item() if self.use_gripper else 1.0,
         }
-        if self.use_gripper:
-            delta_action["gripper"] = action[3].item()
         return delta_action
 
     def transform_features(
@@ -64,10 +63,7 @@ class MapTensorToDeltaActionDictStep(ActionProcessorStep):
                 type=FeatureType.ACTION, shape=(1,)
             )
 
-        if self.use_gripper:
-            features[PipelineFeatureType.ACTION]["gripper"] = PolicyFeature(
-                type=FeatureType.ACTION, shape=(1,)
-            )
+        features[PipelineFeatureType.ACTION]["gripper"] = PolicyFeature(type=FeatureType.ACTION, shape=(1,))
         return features
 
 


### PR DESCRIPTION
MapDeltaActionToRobotActionStep unconditionally popped "gripper" from the action dict, but the upstream MapTensorToDeltaActionDictStep omits that key when use_gripper=False, raising KeyError on the first action. Default to the discrete "stay" command (1) so the gripper holds its position when gripper control is disabled.

Community Review: reviewed #3694.