### PR TITLE
fix(cameras): release device handle when connect() setup fails

### DIFF
--- a/src/lerobot/cameras/opencv/camera_opencv.py
+++ b/src/lerobot/cameras/opencv/camera_opencv.py
@@ -164,17 +164,24 @@ class OpenCVCamera(Camera):
                 f"Failed to open {self}.Run `lerobot-find-cameras opencv` to find available cameras."
             )
 
-        self._configure_capture_settings()
-        self._start_read_thread()
+        try:
+            self._configure_capture_settings()
+            self._start_read_thread()
 
-        if warmup and self.warmup_s > 0:
-            start_time = time.time()
-            while time.time() - start_time < self.warmup_s:
-                self.async_read(timeout_ms=self.warmup_s * 1000)
-                time.sleep(0.1)
-            with self.frame_lock:
-                if self.latest_frame is None:
-                    raise ConnectionError(f"{self} failed to capture frames during warmup.")
+            if warmup and self.warmup_s > 0:
+                start_time = time.time()
+                while time.time() - start_time < self.warmup_s:
+                    self.async_read(timeout_ms=self.warmup_s * 1000)
+                    time.sleep(0.1)
+                with self.frame_lock:
+                    if self.latest_frame is None:
+                        raise ConnectionError(f"{self} failed to capture frames during warmup.")
+        except Exception:
+            self._stop_read_thread()
+            if self.videocapture is not None:
+                self.videocapture.release()
+                self.videocapture = None
+            raise
 
         logger.info(f"{self} connected.")
 
@@ -338,7 +345,8 @@ class OpenCVCamera(Camera):
                 }
 
                 found_cameras_info.append(camera_info)
-                camera.release()
+
+            camera.release()
 
         return found_cameras_info
 

--- a/src/lerobot/cameras/realsense/camera_realsense.py
+++ b/src/lerobot/cameras/realsense/camera_realsense.py
@@ -189,19 +189,27 @@ class RealSenseCamera(Camera):
                 f"Failed to open {self}.Run `lerobot-find-cameras realsense` to find available cameras."
             ) from e
 
-        self._configure_capture_settings()
-        self._start_read_thread()
+        try:
+            self._configure_capture_settings()
+            self._start_read_thread()
 
-        # NOTE(Steven/Caroline): Enforcing at least one second of warmup as RS cameras need a bit of time before the first read. If we don't wait, the first read from the warmup will raise.
-        self.warmup_s = max(self.warmup_s, 1)
+            # NOTE(Steven/Caroline): Enforcing at least one second of warmup as RS cameras need a bit of time before the first read. If we don't wait, the first read from the warmup will raise.
+            self.warmup_s = max(self.warmup_s, 1)
 
-        start_time = time.time()
-        while time.time() - start_time < self.warmup_s:
-            self.async_read(timeout_ms=self.warmup_s * 1000)
-            time.sleep(0.1)
-        with self.frame_lock:
-            if self.latest_color_frame is None or self.use_depth and self.latest_depth_frame is None:
-                raise ConnectionError(f"{self} failed to capture frames during warmup.")
+            start_time = time.time()
+            while time.time() - start_time < self.warmup_s:
+                self.async_read(timeout_ms=self.warmup_s * 1000)
+                time.sleep(0.1)
+            with self.frame_lock:
+                if self.latest_color_frame is None or self.use_depth and self.latest_depth_frame is None:
+                    raise ConnectionError(f"{self} failed to capture frames during warmup.")
+        except Exception:
+            self._stop_read_thread()
+            if self.rs_pipeline is not None:
+                self.rs_pipeline.stop()
+                self.rs_pipeline = None
+                self.rs_profile = None
+            raise
 
         logger.info(f"{self} connected.")
 

--- a/tests/cameras/test_opencv.py
+++ b/tests/cameras/test_opencv.py
@@ -123,6 +123,39 @@ def test_invalid_width_connect():
         camera.connect(warmup=False)
 
 
+def test_connect_releases_handle_on_settings_failure():
+    """A failure while applying capture settings must not leak the device handle."""
+    config = OpenCVCameraConfig(
+        index_or_path=DEFAULT_PNG_FILE_PATH,
+        width=99999,
+        height=480,
+    )
+
+    camera = OpenCVCamera(config)
+    with pytest.raises(RuntimeError):
+        camera.connect(warmup=False)
+
+    assert camera.videocapture is None
+    assert not camera.is_connected
+    assert camera.thread is None
+
+
+def test_connect_releases_handle_on_warmup_failure():
+    """A failure during warmup must release the handle and stop the read thread."""
+    config = OpenCVCameraConfig(index_or_path=DEFAULT_PNG_FILE_PATH, warmup_s=1)
+
+    camera = OpenCVCamera(config)
+    with (
+        patch.object(OpenCVCamera, "async_read", side_effect=TimeoutError("no frame")),
+        pytest.raises((ConnectionError, TimeoutError)),
+    ):
+        camera.connect(warmup=True)
+
+    assert camera.videocapture is None
+    assert not camera.is_connected
+    assert camera.thread is None
+
+
 @pytest.mark.parametrize("index_or_path", TEST_IMAGE_PATHS, ids=TEST_IMAGE_SIZES)
 def test_read(index_or_path):
     config = OpenCVCameraConfig(index_or_path=index_or_path, warmup_s=0)

--- a/tests/cameras/test_realsense.py
+++ b/tests/cameras/test_realsense.py
@@ -91,6 +91,24 @@ def test_invalid_width_connect():
         camera.connect(warmup=False)
 
 
+def test_connect_releases_pipeline_on_warmup_failure():
+    """A failure during warmup must stop the pipeline and the read thread, leaving the
+    camera fully disconnected so a retry connect() does not raise DeviceAlreadyConnectedError."""
+    config = RealSenseCameraConfig(serial_number_or_name="042", width=640, height=480, fps=30)
+    camera = RealSenseCamera(config)
+
+    with (
+        patch.object(RealSenseCamera, "async_read", side_effect=TimeoutError("no frame")),
+        pytest.raises((ConnectionError, TimeoutError)),
+    ):
+        camera.connect(warmup=True)
+
+    assert camera.rs_pipeline is None
+    assert camera.rs_profile is None
+    assert not camera.is_connected
+    assert camera.thread is None
+
+
 def test_read():
     config = RealSenseCameraConfig(serial_number_or_name="042", width=640, height=480, fps=30, warmup_s=0)
     with RealSenseCamera(config) as camera:


### PR DESCRIPTION

## Summary / Motivation

OpenCVCamera.connect() and RealSenseCamera.connect() ran capture-settings configuration and the warmup loop after opening the device without any error handling. A failure there (e.g. an unsupported fps/resolution, or a camera that never delivers a frame during warmup) propagated while leaving the VideoCapture/pipeline open and the read thread running, so is_connected stayed True and a retry raised DeviceAlreadyConnectedError with the device still busy.

## What changed

Wrap the post-open steps in try/except that stops the read thread and releases the handle before re-raising. Also release the probe handle for cameras that fail to open in OpenCVCamera.find_cameras().

## How was this tested (or how to run locally)

- added a regression test

## Checklist (required before merge)

- [ x] Linting/formatting run (`pre-commit run -a`)
- [ x] All tests pass locally (`pytest`)
- [ x] Documentation updated
- [ x] CI is green
- [x ] Community Review: I have reviewed another contributor's open PR and linked it here: https://github.com/huggingface/lerobot/pull/3694

## Reviewer notes

- Anything the reviewer should focus on (performance, edge-cases, specific files) or general notes.
- Anyone in the community is free to review the PR.
