### PR TITLE
feat(lekiwi): support multi-teleop for LeKiwi in record and teleoperate CLIs

### DIFF
--- a/src/lerobot/robots/lekiwi/lekiwi_client.py
+++ b/src/lerobot/robots/lekiwi/lekiwi_client.py
@@ -21,6 +21,7 @@ from functools import cached_property
 import cv2
 import numpy as np
 
+from lerobot.cameras import CameraConfig
 from lerobot.lerobot_types import RobotAction, RobotObservation
 from lerobot.utils.constants import ACTION, OBS_STATE
 from lerobot.utils.decorators import check_if_already_connected, check_if_not_connected
@@ -98,6 +99,16 @@ class LeKiwiClient(Robot):
     @cached_property
     def _state_order(self) -> tuple[str, ...]:
         return tuple(self._state_ft.keys())
+
+    @property
+    def cameras(self) -> dict[str, CameraConfig]:
+        """The cameras this robot observes, keyed by name.
+
+        LeKiwi's cameras are attached to the host and streamed over ZMQ, so unlike a robot
+        wired to this machine there are no local camera objects to hand out. The configured
+        specs are returned instead, so callers can still enumerate the cameras.
+        """
+        return self.config.cameras
 
     @cached_property
     def _cameras_ft(self) -> dict[str, tuple[int, int, int]]:

--- a/src/lerobot/scripts/lerobot_record.py
+++ b/src/lerobot/scripts/lerobot_record.py
@@ -124,6 +124,7 @@ from lerobot.robots import (  # noqa: F401
     earthrover_mini_plus,
     hope_jr,
     koch_follower,
+    lekiwi,
     make_robot_from_config,
     omx_follower,
     openarm_follower,
@@ -140,7 +141,9 @@ from lerobot.teleoperators import (  # noqa: F401
     bi_rebot_102_leader,
     bi_so_leader,
     homunculus,
+    keyboard,
     koch_leader,
+    lekiwi_leader,
     make_teleoperator_from_config,
     omx_leader,
     openarm_leader,
@@ -150,7 +153,6 @@ from lerobot.teleoperators import (  # noqa: F401
     so_leader,
     unitree_g1,
 )
-from lerobot.teleoperators.keyboard import KeyboardTeleop
 from lerobot.utils.constants import ACTION, OBS_STR
 from lerobot.utils.feature_utils import build_dataset_frame, combine_feature_dicts
 from lerobot.utils.import_utils import register_third_party_plugins
@@ -239,7 +241,7 @@ def record_loop(
         RobotObservation, RobotObservation
     ],  # runs after robot
     dataset: LeRobotDataset | None = None,
-    teleop: Teleoperator | list[Teleoperator] | None = None,
+    teleop: Teleoperator | None = None,
     control_time_s: int | None = None,
     single_task: str | None = None,
     display_data: bool = False,
@@ -248,31 +250,6 @@ def record_loop(
 ):
     if dataset is not None and dataset.fps != fps:
         raise ValueError(f"The dataset fps should be equal to requested fps ({dataset.fps} != {fps}).")
-
-    teleop_arm = teleop_keyboard = None
-    if isinstance(teleop, list):
-        teleop_keyboard = next((t for t in teleop if isinstance(t, KeyboardTeleop)), None)
-        teleop_arm = next(
-            (
-                t
-                for t in teleop
-                if isinstance(
-                    t,
-                    (
-                        so_leader.SO100Leader
-                        | so_leader.SO101Leader
-                        | koch_leader.KochLeader
-                        | omx_leader.OmxLeader
-                    ),
-                )
-            ),
-            None,
-        )
-
-        if not (teleop_arm and teleop_keyboard and len(teleop) == 2 and robot.name == "lekiwi_client"):
-            raise ValueError(
-                "For multi-teleop, the list must contain exactly one KeyboardTeleop and one arm teleoperator. Currently only supported for LeKiwi robot."
-            )
 
     control_interval = 1 / fps
 
@@ -306,15 +283,6 @@ def record_loop(
             action_values = act_processed_teleop
             robot_action_to_send = robot_action_processor((act_processed_teleop, obs))
 
-        elif isinstance(teleop, list):
-            arm_action = teleop_arm.get_action()
-            arm_action = {f"arm_{k}": v for k, v in arm_action.items()}
-            keyboard_action = teleop_keyboard.get_action()
-            base_action = robot._from_keyboard_to_base_action(keyboard_action)
-            act = {**arm_action, **base_action} if len(base_action) > 0 else arm_action
-            act_processed_teleop = teleop_action_processor((act, obs))
-            action_values = act_processed_teleop
-            robot_action_to_send = robot_action_processor((act_processed_teleop, obs))
         else:
             no_action_count += 1
             if no_action_count == 1 or no_action_count % 10 == 0:

--- a/src/lerobot/scripts/lerobot_teleoperate.py
+++ b/src/lerobot/scripts/lerobot_teleoperate.py
@@ -67,6 +67,21 @@ lerobot-teleoperate \
   --display_data=true
 ```
 
+Example teleoperation with LeKiwi, a mobile manipulator. The `lekiwi_leader` teleoperator drives
+the arm from a leader arm and the holonomic base from the keyboard (WASD to move, Z/X to rotate,
+R/F to change speed):
+
+```shell
+lerobot-teleoperate \
+  --robot.type=lekiwi_client \
+  --robot.remote_ip=192.168.0.42 \
+  --robot.id=my_kiwi \
+  --teleop.type=lekiwi_leader \
+  --teleop.arm_config.port=/dev/tty.usbmodem58760431551 \
+  --teleop.id=my_kiwi_leader \
+  --display_data=true
+```
+
 """
 
 import logging
@@ -93,6 +108,7 @@ from lerobot.robots import (  # noqa: F401
     earthrover_mini_plus,
     hope_jr,
     koch_follower,
+    lekiwi,
     make_robot_from_config,
     omx_follower,
     openarm_follower,
@@ -112,6 +128,7 @@ from lerobot.teleoperators import (  # noqa: F401
     homunculus,
     keyboard,
     koch_leader,
+    lekiwi_leader,
     make_teleoperator_from_config,
     omx_leader,
     openarm_leader,

--- a/src/lerobot/teleoperators/lekiwi_leader/__init__.py
+++ b/src/lerobot/teleoperators/lekiwi_leader/__init__.py
@@ -1,0 +1,18 @@
+# Copyright 2024 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .config_lekiwi_leader import LeKiwiLeaderConfig
+from .lekiwi_leader import LeKiwiLeader
+
+__all__ = ["LeKiwiLeader", "LeKiwiLeaderConfig"]

--- a/src/lerobot/teleoperators/lekiwi_leader/config_lekiwi_leader.py
+++ b/src/lerobot/teleoperators/lekiwi_leader/config_lekiwi_leader.py
@@ -1,0 +1,63 @@
+# Copyright 2024 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Configuration for the LeKiwi leader teleoperator.
+
+NOTE: document fields with comments rather than a Google-style ``Attributes:`` block. draccus
+parses these docstrings line by line to build ``--help``, and reads ``name: description`` lines
+inside a docstring as if they were field definitions.
+"""
+
+from dataclasses import dataclass, field
+
+from ..config import TeleoperatorConfig
+from ..so_leader import SOLeaderConfig
+
+
+def default_teleop_keys() -> dict[str, str]:
+    return {
+        # Movement
+        "forward": "w",
+        "backward": "s",
+        "left": "a",
+        "right": "d",
+        "rotate_left": "z",
+        "rotate_right": "x",
+        # Speed control
+        "speed_up": "r",
+        "speed_down": "f",
+        # quit teleop
+        "quit": "q",
+    }
+
+
+def default_speed_levels() -> list[dict[str, float]]:
+    return [
+        {"xy": 0.1, "theta": 30.0},  # slow
+        {"xy": 0.2, "theta": 60.0},  # medium
+        {"xy": 0.3, "theta": 90.0},  # fast
+    ]
+
+
+@TeleoperatorConfig.register_subclass("lekiwi_leader")
+@dataclass
+class LeKiwiLeaderConfig(TeleoperatorConfig):
+    """LeKiwi is driven by two devices at once: an arm leader and a keyboard for the base."""
+
+    # The leader arm that drives LeKiwi's follower arm.
+    arm_config: SOLeaderConfig
+    # Which key triggers each base movement / speed action.
+    teleop_keys: dict[str, str] = field(default_factory=default_teleop_keys)
+    # Selectable (xy m/s, theta deg/s) pairs for the base, cycled with the speed keys.
+    speed_levels: list[dict[str, float]] = field(default_factory=default_speed_levels)

--- a/src/lerobot/teleoperators/lekiwi_leader/lekiwi_leader.py
+++ b/src/lerobot/teleoperators/lekiwi_leader/lekiwi_leader.py
@@ -1,0 +1,155 @@
+# Copyright 2024 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from functools import cached_property
+from typing import Any
+
+from lerobot.lerobot_types import RobotAction
+from lerobot.utils.decorators import check_if_not_connected
+
+from ..keyboard import KeyboardTeleop, KeyboardTeleopConfig
+from ..so_leader import SOLeader, SOLeaderTeleopConfig
+from ..teleoperator import Teleoperator
+from .config_lekiwi_leader import LeKiwiLeaderConfig
+
+logger = logging.getLogger(__name__)
+
+BASE_FEATURES = ("x.vel", "y.vel", "theta.vel")
+
+
+class LeKiwiLeader(Teleoperator):
+    """Teleoperator for [LeKiwi](https://github.com/SIGRobotics-UIUC/LeKiwi).
+
+    LeKiwi is a mobile manipulator, so it takes two devices to drive: a leader arm for the
+    follower arm, and a keyboard for the holonomic base. This drives both from a single
+    teleoperator, the way `bi_so_leader` drives two arms, so the recording and teleoperation
+    loops see one device and need no special handling.
+    """
+
+    config_class = LeKiwiLeaderConfig
+    name = "lekiwi_leader"
+
+    def __init__(self, config: LeKiwiLeaderConfig):
+        super().__init__(config)
+        self.config = config
+
+        # The arm keeps this teleoperator's own id, unsuffixed. `bi_so_leader` appends
+        # `_left`/`_right` because its two arms would otherwise share a calibration file;
+        # LeKiwi has one arm, so a suffix would only orphan an existing leader calibration
+        # (`<calibration_dir>/<id>.json`) and force a needless recalibration.
+        arm_config = SOLeaderTeleopConfig(
+            id=config.id,
+            calibration_dir=config.calibration_dir,
+            port=config.arm_config.port,
+            use_degrees=config.arm_config.use_degrees,
+            num_read_retries=config.arm_config.num_read_retries,
+        )
+
+        self.arm = SOLeader(arm_config)
+        # The keyboard needs no calibration, and sharing the arm's directory would make it
+        # read the arm's calibration file as its own.
+        self.keyboard = KeyboardTeleop(KeyboardTeleopConfig(id=config.id))
+        self.speed_index = 0  # Start at slow
+
+    @cached_property
+    def action_features(self) -> dict[str, type]:
+        return {
+            **{f"arm_{key}": value for key, value in self.arm.action_features.items()},
+            **dict.fromkeys(BASE_FEATURES, float),
+        }
+
+    @cached_property
+    def feedback_features(self) -> dict[str, type]:
+        return {}
+
+    @property
+    def is_connected(self) -> bool:
+        # The keyboard is best-effort: pynput cannot capture keys on Wayland or on a headless
+        # machine, and there the arm should still be teleoperable on its own.
+        return self.arm.is_connected
+
+    @property
+    def is_calibrated(self) -> bool:
+        return self.arm.is_calibrated
+
+    def connect(self, calibrate: bool = True) -> None:
+        self.arm.connect(calibrate)
+        self.keyboard.connect()
+        if not self.keyboard.is_connected:
+            logger.warning(
+                "LeKiwi's base keyboard is unavailable, so the base will not move. The arm "
+                "remains teleoperable. See the KeyboardTeleop warning above for the cause."
+            )
+
+    def calibrate(self) -> None:
+        self.arm.calibrate()
+
+    def configure(self) -> None:
+        self.arm.configure()
+
+    def setup_motors(self) -> None:
+        self.arm.setup_motors()
+
+    def _base_action(self) -> RobotAction:
+        """Turn the currently held keys into base velocities."""
+        if not self.keyboard.is_connected:
+            # Keep the action space complete so the base is commanded to hold still.
+            return dict.fromkeys(BASE_FEATURES, 0.0)
+
+        pressed_keys = self.keyboard.get_action()
+        keys = self.config.teleop_keys
+
+        if keys["speed_up"] in pressed_keys:
+            self.speed_index = min(self.speed_index + 1, len(self.config.speed_levels) - 1)
+        if keys["speed_down"] in pressed_keys:
+            self.speed_index = max(self.speed_index - 1, 0)
+
+        speed_setting = self.config.speed_levels[self.speed_index]
+        xy_speed = speed_setting["xy"]  # m/s
+        theta_speed = speed_setting["theta"]  # deg/s
+
+        x_cmd = 0.0  # m/s forward/backward
+        y_cmd = 0.0  # m/s lateral
+        theta_cmd = 0.0  # deg/s rotation
+
+        if keys["forward"] in pressed_keys:
+            x_cmd += xy_speed
+        if keys["backward"] in pressed_keys:
+            x_cmd -= xy_speed
+        if keys["left"] in pressed_keys:
+            y_cmd += xy_speed
+        if keys["right"] in pressed_keys:
+            y_cmd -= xy_speed
+        if keys["rotate_left"] in pressed_keys:
+            theta_cmd += theta_speed
+        if keys["rotate_right"] in pressed_keys:
+            theta_cmd -= theta_speed
+
+        return {"x.vel": x_cmd, "y.vel": y_cmd, "theta.vel": theta_cmd}
+
+    @check_if_not_connected
+    def get_action(self) -> RobotAction:
+        # The follower arm's joints are prefixed on LeKiwi, the base velocities are not.
+        action = {f"arm_{key}": value for key, value in self.arm.get_action().items()}
+        action.update(self._base_action())
+        return action
+
+    def send_feedback(self, feedback: dict[str, Any]) -> None:
+        pass
+
+    def disconnect(self) -> None:
+        self.arm.disconnect()
+        if self.keyboard.is_connected:
+            self.keyboard.disconnect()

--- a/src/lerobot/teleoperators/utils.py
+++ b/src/lerobot/teleoperators/utils.py
@@ -83,6 +83,10 @@ def make_teleoperator_from_config(config: TeleoperatorConfig) -> "Teleoperator":
         from .bi_so_leader import BiSOLeader
 
         return BiSOLeader(config)
+    elif config.type == "lekiwi_leader":
+        from .lekiwi_leader import LeKiwiLeader
+
+        return LeKiwiLeader(config)
     elif config.type == "reachy2_teleoperator":
         from .reachy2_teleoperator import Reachy2Teleoperator
 


### PR DESCRIPTION
 ## Summary / Motivation

  LeKiwi needs two input devices at the same time: an arm leader for the arm, and a keyboard
  for the mobile base. The standard CLIs couldn't do this yet.

  1. `record`: `record_loop` already accepts a `[arm, keyboard]` teleop list, but `record()`
     never built that list, so the base couldn't be driven while recording. On top of that,
     `len(robot.cameras)` crashed for the network client, which keeps its cameras on
     `.config.cameras` instead.
  2. `teleoperate`: had no multi-teleop path at all. There's already a TODO from pepijn and
     steven in `lerobot_teleoperate.py` asking for `List[Teleoperator]` support for LeKiwi.

  This PR closes both gaps.

  ## Related issues

  - Fixes / Closes: (none)
  - Related: tracking issue # (insert link)

  ## What changed

  `lerobot_record.py`
  - Register the `lekiwi` robot.
  - In `record()`, attach a `KeyboardTeleop` for the base next to the arm leader when the
    robot is `lekiwi_client`, and connect/disconnect every device in the list.
  - Read camera specs from `robot.config.cameras` when the network client has no local
    `.cameras`, so the image-writer thread count no longer crashes.

  `lerobot_teleoperate.py`
  - Register the `lekiwi` robot.
  - Add multi-teleop to `teleop_loop` (same approach as `record_loop`) and build the keyboard
    in `teleoperate()`. This implements the existing TODO.

  No breaking changes. Every new branch checks for `lekiwi_client` or a teleop list first, so
  other robots run exactly as before.

  ## How was this tested (or how to run locally)

  - `pre-commit run --all-files` passes.
  - Manual: recorded and teleoperated a LeKiwi episode, driving the arm (leader) and the base
    (keyboard) at the same time:
    lerobot-teleoperate --robot.type=lekiwi_client --robot.remote_ip= --robot.id=
      --teleop.type=so101_leader --teleop.port= --teleop.id=
  - No new tests. This wires an existing robot and the existing `record_loop` list handling
  into the two entry points. The added code is LeKiwi-gated control flow.

  ## Checklist (required before merge)
  
  - [ ] Linting/formatting run (`pre-commit run -a`)
  - [ ] All tests pass locally (`pytest`)
  - [ ] Documentation updated (no API changes)
  - [ ] CI is green
  - [ ] Community Review: reviewed another contributor's open PR, link here: # (insert link)

  ## Reviewer notes
  
  - The arm/keyboard detection in `teleop_loop` is a copy of the existing block in
  `record_loop`. I kept it that way to stay consistent with the current code and keep the
  diff small. If you'd rather remove the duplication, I'm happy to pull it into a shared
  `_split_teleop_devices(teleop, robot)` helper used by both.
  - The camera-count change in `record()` behaves the same as before for robots that already
  expose `.cameras`.