### PR TITLE
feat(policies): add Cosmos3 drafts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,11 +59,11 @@ keywords = ["lerobot", "huggingface", "robotics",  "machine learning", "artifici
 
 dependencies = [
     # Core ML
-    "torch>=2.7,<2.12.0",
-    "torchvision>=0.22.0,<0.27.0",
+    "torch>=2.10.0,<2.11.0",
+    "torchvision>=0.25.0,<0.26.0",
     "numpy>=2.0.0,<2.3.0", # NOTE: Explicitly listing numpy helps the resolver converge faster. Upper bound imposed by opencv-python-headless.
     "opencv-python-headless>=4.9.0,<4.14.0",
-    "Pillow>=10.0.0,<13.0.0",
+    "Pillow>=12.2.0,<13.0.0",
     "einops>=0.8.0,<0.9.0",
 
     # Config & Hub
@@ -108,8 +108,8 @@ dataset = [
     # Each platform gets its own line so the resolver picks the minimum version that has a wheel for it.
 
     # Other torch/torchcodec pairings (informational): 0.8.1 = ffmpeg>=8 support, 0.10 = system-wide ffmpeg support, 0.12 needs torch==2.12.
-    "torchcodec>=0.3.0,<0.12.0; (sys_platform == 'linux' and (platform_machine == 'x86_64' or platform_machine == 'AMD64')) or (sys_platform == 'darwin' and platform_machine == 'arm64')",
-    "torchcodec>=0.7.0,<0.12.0; sys_platform == 'win32'",
+    "torchcodec>=0.10.0,<0.11.0; (sys_platform == 'linux' and (platform_machine == 'x86_64' or platform_machine == 'AMD64')) or (sys_platform == 'darwin' and platform_machine == 'arm64')",
+    "torchcodec>=0.10.0,<0.11.0; sys_platform == 'win32'",
     "torchcodec>=0.11.0,<0.12.0; sys_platform == 'linux' and (platform_machine == 'aarch64' or platform_machine == 'arm64')",
     "jsonlines>=4.0.0,<5.0.0",
 ]
@@ -136,7 +136,7 @@ evaluation = ["lerobot[av-dep]"]
 dataset_viz = ["lerobot[dataset]", "lerobot[viz]"]
 
 # Common
-av-dep = ["av>=15.0.0,<16.0.0"]
+av-dep = ["av>=16.1.0,<17.0.0"]
 pygame-dep = ["pygame>=2.5.1,<2.7.0"]
 # NOTE: 0.9.16 links against liburdfdom_sensor.so.4, which is unavailable on Ubuntu 24.04
 # (noble ships urdfdom 3.x). Cap below 0.9.16 until system urdfdom 4.x is broadly available.
@@ -146,7 +146,7 @@ grpcio-dep = ["grpcio==1.73.1", "protobuf>=6.31.1,<6.32.0"]
 can-dep = ["python-can>=4.2.0,<5.0.0"]
 peft-dep = ["peft>=0.18.0,<1.0.0"]
 scipy-dep = ["scipy>=1.14.0,<2.0.0"]
-diffusers-dep = ["diffusers>=0.27.2,<0.36.0"]
+diffusers-dep = ["diffusers>=0.36.0,<0.40.0"]
 qwen-vl-utils-dep = ["qwen-vl-utils>=0.0.11,<0.1.0"]
 matplotlib-dep = ["matplotlib>=3.10.3,<4.0.0", "contourpy>=1.3.0,<2.0.0"] # NOTE: Explicitly listing contourpy helps the resolver converge faster.
 pyserial-dep = ["pyserial>=3.5,<4.0"]
@@ -218,6 +218,27 @@ xvla = ["lerobot[transformers-dep]"]
 eo1 = ["lerobot[transformers-dep]", "lerobot[qwen-vl-utils-dep]"]
 hilserl = ["lerobot[transformers-dep]", "lerobot[dataset]", "gym-hil>=0.1.13,<0.2.0", "lerobot[grpcio-dep]", "lerobot[placo-dep]"]
 vla_jepa = ["lerobot[transformers-dep]", "lerobot[diffusers-dep]", "lerobot[qwen-vl-utils-dep]"]
+cosmos3 = [
+    "lerobot[transformers-dep]",
+    "lerobot[qwen-vl-utils-dep]",
+    "accelerate>=1.13.0,<2.0.0",
+    "av>=16.1.0,<17.0.0",
+    "cattrs>=26.1.0,<27.0.0",
+    "diffusers @ git+https://github.com/huggingface/diffusers.git@f3d42be118f9af7ed9697b686fba09a8bdcd71d1",
+    "hydra-core>=1.3.2,<2.0.0",
+    "imageio>=2.37.2,<3.0.0",
+    "imageio-ffmpeg>=0.6.0,<1.0.0",
+    "loguru>=0.7.3,<1.0.0",
+    "msgpack>=1.1.2,<2.0.0",
+    "nvidia-cudnn-frontend>=1.18.0,<2.0.0",
+    "nvidia-ml-py>=13.590.48,<14.0.0",
+    "obstore>=0.8.2,<1.0.0",
+    "omegaconf>=2.3.0,<3.0.0",
+    "pydantic>=2.12.5,<3.0.0",
+    "scipy>=1.17.1,<2.0.0",
+    "tyro>=1.0.8,<2.0.0",
+    "websockets>=16.0,<17.0.0",
+]
 
 # Features
 async = ["lerobot[grpcio-dep]", "lerobot[matplotlib-dep]"]
@@ -332,6 +353,7 @@ explicit = true
 
 [tool.uv.sources]
 torch = [{ index = "pytorch-cu128", marker = "sys_platform == 'linux'" }]
+torchcodec = [{ index = "pytorch-cu128", marker = "sys_platform == 'linux'" }]
 torchvision = [{ index = "pytorch-cu128", marker = "sys_platform == 'linux'" }]
 
 [tool.setuptools.package-data]

--- a/src/lerobot/policies/cosmos3/__init__.py
+++ b/src/lerobot/policies/cosmos3/__init__.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .configuration_cosmos3 import Cosmos3Config
+from .modeling_cosmos3 import Cosmos3Policy
+from .processor_cosmos3 import make_cosmos3_pre_post_processors
+
+__all__ = ["Cosmos3Config", "Cosmos3Policy", "make_cosmos3_pre_post_processors"]

--- a/src/lerobot/policies/cosmos3/configuration_cosmos3.py
+++ b/src/lerobot/policies/cosmos3/configuration_cosmos3.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from lerobot.configs import FeatureType, NormalizationMode, PolicyFeature, PreTrainedConfig
+from lerobot.optim import AdamWConfig, CosineDecayWithWarmupSchedulerConfig
+from lerobot.utils.constants import ACTION, OBS_IMAGES, OBS_STATE
+
+COSMOS3_LEFT_IMAGE = f"{OBS_IMAGES}.over_shoulder_left_camera"
+COSMOS3_RIGHT_IMAGE = f"{OBS_IMAGES}.over_shoulder_right_camera"
+COSMOS3_WRIST_IMAGE = f"{OBS_IMAGES}.wrist_cam"
+
+COSMOS3_DROID_DOMAIN_ID = 8
+COSMOS3_CONCAT_VIEW_DESCRIPTION = (
+    "The top row is from the wrist-mounted camera. "
+    "The bottom row contains two horizontally concatenated third-person perspective views of the scene from "
+    "opposite sides, with the robot visible."
+)
+
+
+@PreTrainedConfig.register_subclass("cosmos3")
+@dataclass
+class Cosmos3Config(PreTrainedConfig):
+    """Configuration for LeRobot-format Cosmos3 policy checkpoints."""
+
+    # Converted LeRobot checkpoints store component configs here and load all
+    # model weights through PreTrainedPolicy.from_pretrained(model.safetensors).
+    text_processor_name_or_path: str | None = None
+    transformer_config: dict[str, Any] | None = None
+    vae_config: dict[str, Any] | None = None
+    scheduler_config: dict[str, Any] | None = None
+
+    # Public model-level controls.
+    freeze_vae: bool = True
+    dtype: str = "bfloat16"  # Options: "bfloat16", "float32"
+    local_files_only: bool = True
+
+    # RoboLab/DROID policy contract.
+    n_obs_steps: int = 1
+    chunk_size: int = 32
+    n_action_steps: int = 32
+    raw_action_dim: int = 8
+    max_action_dim: int = 64
+    # Upper bound on the proprioceptive state width accepted by the processor.
+    # Wider state raises; narrower state is zero-padded. Defaults to raw_action_dim.
+    max_state_dim: int | None = None
+    joint_position_dim: int = 7
+    gripper_position_dim: int = 1
+    use_state: bool = True
+    history_length: int = 1
+    action_space: str = "joint_pos"
+    invert_gripper: bool = True
+
+    # Cosmos3 action generation settings matching the RoboLab policy server defaults.
+    domain_name: str = "droid_lerobot"
+    domain_id: int = COSMOS3_DROID_DOMAIN_ID
+    eos_token_id: int = 151645
+    start_of_generation_token_id: int = 151652
+    mode: str = "policy"
+    viewpoint: str = "concat_view"
+    additional_view_description: str = COSMOS3_CONCAT_VIEW_DESCRIPTION
+    conditioning_fps: float = 15.0
+    resolution_tier: int = 480
+    guidance_scale: float = 3.0
+    num_inference_steps: int = 4
+    shift: float = 5.0
+    seed: int = 0
+    deterministic_seed: bool = False
+    generate_video: bool = False
+    output_type: str = "latent"
+    train_time_video_distribution: str = "waver"
+    video_loss_weight: float = 10.0
+    action_loss_weight: float = 10.0
+    normalize_loss_by_active: bool = False
+
+    # Multi-view image composition. `image_keys[0]` is rendered as the primary
+    # (top) view and the remaining views tile the bottom row. The contract is
+    # `num_views` views: fewer observed views are zero-padded up to `num_views`.
+    # RoboLab's three DROID cameras are the default, but any ordered list works.
+    image_keys: list[str] = field(
+        default_factory=lambda: [COSMOS3_WRIST_IMAGE, COSMOS3_LEFT_IMAGE, COSMOS3_RIGHT_IMAGE]
+    )
+    num_views: int = 3
+    image_height: int = 360
+    image_width: int = 640
+    composed_image_height: int = 540
+    composed_image_width: int = 640
+    prompt_key: str = "task"
+
+    normalization_mapping: dict[str, NormalizationMode] = field(
+        default_factory=lambda: {
+            "VISUAL": NormalizationMode.IDENTITY,
+            "STATE": NormalizationMode.IDENTITY,
+            "ACTION": NormalizationMode.IDENTITY,
+        }
+    )
+
+    # Conservative training defaults until task-specific recipes are added.
+    optimizer_lr: float = 1e-5
+    optimizer_betas: tuple[float, float] = (0.9, 0.95)
+    optimizer_eps: float = 1e-8
+    optimizer_weight_decay: float = 0.01
+    optimizer_grad_clip_norm: float = 1.0
+    scheduler_warmup_steps: int = 1_000
+    scheduler_decay_steps: int = 30_000
+    scheduler_decay_lr: float = 0.0
+
+    def __post_init__(self):
+        super().__post_init__()
+        if self.n_action_steps > self.chunk_size:
+            raise ValueError(
+                f"n_action_steps ({self.n_action_steps}) cannot be greater than chunk_size ({self.chunk_size})"
+            )
+        if self.dtype not in {"bfloat16", "float32"}:
+            raise ValueError(f"Invalid dtype: {self.dtype!r}")
+        if self.mode != "policy":
+            raise ValueError("Cosmos3Config currently supports only action mode='policy'.")
+        if self.action_space != "joint_pos":
+            raise ValueError("Cosmos3Config currently supports only action_space='joint_pos'.")
+        if self.history_length < int(self.use_state):
+            raise ValueError("history_length must be at least 1 when use_state=True.")
+        if self.raw_action_dim != self.joint_position_dim + self.gripper_position_dim:
+            raise ValueError("raw_action_dim must equal joint_position_dim + gripper_position_dim.")
+        if self.max_state_dim is None:
+            self.max_state_dim = self.raw_action_dim
+        if self.max_state_dim > self.raw_action_dim:
+            raise ValueError(
+                f"max_state_dim ({self.max_state_dim}) cannot exceed raw_action_dim ({self.raw_action_dim})."
+            )
+        if self.num_views < 1:
+            raise ValueError(f"num_views must be >= 1, got {self.num_views}.")
+        if len(self.image_keys) > self.num_views:
+            raise ValueError(
+                f"Got {len(self.image_keys)} image_keys but num_views={self.num_views}; "
+                "raise num_views or shorten image_keys."
+            )
+
+    @property
+    def transformer_backbone_config(self) -> dict[str, Any]:
+        if self.transformer_config is None:
+            raise ValueError(
+                "Cosmos3Config.transformer_config is required. "
+                "Load a converted LeRobot Cosmos3 checkpoint or provide the serialized transformer config."
+            )
+        config = dict(self.transformer_config)
+        config.setdefault("action_dim", self.max_action_dim)
+        config.setdefault("action_gen", True)
+        return config
+
+    def validate_features(self) -> None:
+        if self.input_features is None:
+            self.input_features = {}
+        if self.output_features is None:
+            self.output_features = {}
+
+        default_image_shape = (3, self.image_height, self.image_width)
+        for image_key in self.image_keys:
+            self.input_features.setdefault(
+                image_key,
+                PolicyFeature(type=FeatureType.VISUAL, shape=default_image_shape),
+            )
+
+        self.input_features.setdefault(
+            OBS_STATE,
+            PolicyFeature(type=FeatureType.STATE, shape=(self.raw_action_dim,)),
+        )
+        self.output_features.setdefault(
+            ACTION,
+            PolicyFeature(type=FeatureType.ACTION, shape=(self.raw_action_dim,)),
+        )
+
+    def get_optimizer_preset(self) -> AdamWConfig:
+        return AdamWConfig(
+            lr=self.optimizer_lr,
+            betas=self.optimizer_betas,
+            eps=self.optimizer_eps,
+            weight_decay=self.optimizer_weight_decay,
+            grad_clip_norm=self.optimizer_grad_clip_norm,
+        )
+
+    def get_scheduler_preset(self):
+        return CosineDecayWithWarmupSchedulerConfig(
+            peak_lr=self.optimizer_lr,
+            decay_lr=self.scheduler_decay_lr,
+            num_warmup_steps=self.scheduler_warmup_steps,
+            num_decay_steps=self.scheduler_decay_steps,
+        )
+
+    @property
+    def observation_delta_indices(self) -> list[int]:
+        return list(range(self.chunk_size + 1))
+
+    @property
+    def action_delta_indices(self) -> list[int]:
+        return list(range(self.chunk_size))
+
+    @property
+    def reward_delta_indices(self) -> None:
+        return None

--- a/src/lerobot/policies/cosmos3/modeling_cosmos3.py
+++ b/src/lerobot/policies/cosmos3/modeling_cosmos3.py
@@ -1,0 +1,1329 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import math
+from collections import deque
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+import torch.nn.functional as F  # noqa: N812
+from torch import Tensor, nn
+
+from lerobot.configs import PreTrainedConfig
+from lerobot.utils.constants import ACTION
+from lerobot.utils.import_utils import require_package
+
+from ..pretrained import PreTrainedPolicy
+from .configuration_cosmos3 import Cosmos3Config
+from .processor_cosmos3 import (
+    COSMOS3_ACTION_CONDITION,
+    COSMOS3_ACTION_CONDITION_MASK,
+    COSMOS3_ACTION_DOMAIN_ID,
+    COSMOS3_CLEAN_ACTION,
+    COSMOS3_COND_INPUT_IDS,
+    COSMOS3_CONDITIONING_FPS,
+    COSMOS3_RAW_ACTION_DIM,
+    COSMOS3_TRAINING_SIGMA,
+    COSMOS3_UNCOND_INPUT_IDS,
+    COSMOS3_VIDEO,
+    classify_cosmos3_action_size,
+)
+
+
+def _torch_dtype(dtype_name: str) -> torch.dtype:
+    if dtype_name == "bfloat16":
+        return torch.bfloat16
+    if dtype_name == "float32":
+        return torch.float32
+    raise ValueError(f"Unsupported Cosmos3 dtype={dtype_name!r}")
+
+
+def _module_device(module: nn.Module) -> torch.device:
+    try:
+        return next(module.parameters()).device
+    except StopIteration:
+        return torch.device("cpu")
+
+
+def _module_dtype(module: nn.Module) -> torch.dtype:
+    try:
+        return next(module.parameters()).dtype
+    except StopIteration:
+        return torch.float32
+
+
+def _retrieve_latents(encoder_output: Any, *, sample_mode: str = "argmax") -> torch.Tensor:
+    if hasattr(encoder_output, "latent_dist"):
+        latent_dist = encoder_output.latent_dist
+    elif isinstance(encoder_output, tuple):
+        latent_dist = encoder_output[0]
+    else:
+        raise TypeError(f"Unexpected VAE encoder output type: {type(encoder_output)!r}")
+
+    if sample_mode == "argmax":
+        return latent_dist.mode()
+    if sample_mode == "sample":
+        return latent_dist.sample()
+    raise ValueError(f"Unsupported VAE latent sample_mode={sample_mode!r}.")
+
+
+def get_3d_mrope_ids_text_tokens(
+    num_tokens: int,
+    temporal_offset: int | float,
+    use_float_positions: bool = False,
+) -> tuple[torch.Tensor, int | float]:
+    if use_float_positions:
+        ids = torch.arange(num_tokens, dtype=torch.float32) + temporal_offset
+    else:
+        ids = torch.arange(num_tokens, dtype=torch.long) + int(temporal_offset)
+
+    mrope_ids = ids.unsqueeze(0).expand(3, -1).contiguous()
+    next_temporal_offset = temporal_offset + num_tokens
+    return mrope_ids, next_temporal_offset
+
+
+def get_3d_mrope_ids_vae_tokens(
+    grid_t: int,
+    grid_h: int,
+    grid_w: int,
+    temporal_offset: int | float,
+    reset_spatial_indices: bool = True,
+    fps: float | None = None,
+    base_fps: float = 24.0,
+    temporal_compression_factor: int = 4,
+    base_temporal_compression_factor: int | None = None,
+    start_frame_offset: int = 0,
+) -> tuple[torch.Tensor, int | float]:
+    fps_modulation_enabled = fps is not None and grid_t > 1
+    effective_base_tcf = (
+        base_temporal_compression_factor
+        if base_temporal_compression_factor is not None
+        else temporal_compression_factor
+    )
+
+    if fps_modulation_enabled:
+        tps = fps / temporal_compression_factor
+        base_tps = base_fps / effective_base_tcf
+        frame_indices = torch.arange(grid_t, dtype=torch.float32)
+        scaled_t = (frame_indices + start_frame_offset) / tps * base_tps + temporal_offset
+        t_index = scaled_t.view(-1, 1).expand(-1, grid_h * grid_w).flatten()
+    else:
+        t_index = (
+            torch.arange(grid_t, dtype=torch.long).view(-1, 1).expand(-1, grid_h * grid_w).flatten()
+            + int(temporal_offset)
+            + start_frame_offset
+        )
+
+    h_index = torch.arange(grid_h, dtype=torch.long).view(1, -1, 1).expand(grid_t, -1, grid_w).flatten()
+    w_index = torch.arange(grid_w, dtype=torch.long).view(1, 1, -1).expand(grid_t, grid_h, -1).flatten()
+
+    if not reset_spatial_indices:
+        spatial_offset = int(temporal_offset)
+        h_index = h_index + spatial_offset
+        w_index = w_index + spatial_offset
+
+    if fps_modulation_enabled:
+        mrope_ids = torch.stack([t_index, h_index.to(torch.float32), w_index.to(torch.float32)], dim=0)
+    else:
+        mrope_ids = torch.stack([t_index, h_index, w_index], dim=0)
+
+    next_temporal_offset = math.ceil(mrope_ids.max().item()) + 1
+    return mrope_ids, next_temporal_offset
+
+
+def _seeded_standard_normal(
+    shape: tuple[int, ...],
+    *,
+    dtype: torch.dtype,
+    device: torch.device | str,
+    seed: int,
+) -> torch.Tensor:
+    random_array = np.random.RandomState(seed).standard_normal(shape).astype(np.float32)
+    return torch.from_numpy(random_array).to(dtype=dtype, device=device)
+
+
+def preprocess_action_video_batch(
+    videos: Tensor,
+    *,
+    resolution_tier: int,
+    num_frames: int,
+    device: torch.device | str,
+    dtype: torch.dtype,
+) -> tuple[Tensor, Tensor, int, int]:
+    if videos.dtype != torch.uint8:
+        raise ValueError(f"Cosmos3 action video input must be uint8, got dtype={videos.dtype}.")
+    if videos.ndim != 5:
+        raise ValueError(f"Expected Cosmos3 action video shape [B,C,T,H,W], got shape={tuple(videos.shape)}.")
+
+    frames = videos.detach().to(device=device)
+    batch_size, channels, _time, source_h, source_w = frames.shape
+    target_h, target_w, content_h, content_w = classify_cosmos3_action_size(
+        source_h,
+        source_w,
+        resolution_tier=resolution_tier,
+    )
+
+    if frames.shape[2] < num_frames:
+        frames = torch.cat(
+            [frames, frames[:, :, -1:].expand(-1, -1, num_frames - frames.shape[2], -1, -1)],
+            dim=2,
+        )
+    else:
+        frames = frames[:, :, :num_frames]
+
+    frames_t = frames.permute(0, 2, 1, 3, 4).reshape(batch_size * num_frames, channels, source_h, source_w)
+    frames_t = frames_t.to(dtype=torch.float32)
+    if content_h != source_h or content_w != source_w:
+        frames_t = F.interpolate(
+            frames_t,
+            size=(content_h, content_w),
+            mode="bicubic",
+            align_corners=False,
+            antialias=True,
+        )
+    pad_right = target_w - content_w
+    pad_bottom = target_h - content_h
+    if pad_right or pad_bottom:
+        pad_mode = "replicate" if pad_right >= content_w or pad_bottom >= content_h else "reflect"
+        frames_t = F.pad(frames_t, (0, pad_right, 0, pad_bottom), mode=pad_mode)
+
+    frames = frames_t.reshape(batch_size, num_frames, channels, target_h, target_w)
+    frames = frames.permute(0, 2, 1, 3, 4).to(device=device, dtype=dtype) / 127.5 - 1.0
+    image_size = torch.tensor([target_h, target_w, content_h, content_w], device=device, dtype=torch.float32)
+    return frames, image_size, target_h, target_w
+
+
+class Cosmos3Policy(PreTrainedPolicy):
+    """LeRobot policy wrapper for Cosmos3 DROID action generation."""
+
+    config_class = Cosmos3Config
+    name = "cosmos3"
+
+    @classmethod
+    def from_pretrained(cls, pretrained_name_or_path: str | Path, *args, config=None, **kwargs):
+        if config is None:
+            config = PreTrainedConfig.from_pretrained(pretrained_name_or_path, **kwargs)
+        if not isinstance(config, Cosmos3Config):
+            raise TypeError(f"Expected Cosmos3Config, got {type(config)!r}.")
+        config.pretrained_path = Path(pretrained_name_or_path)
+        policy = super().from_pretrained(pretrained_name_or_path, *args, config=config, **kwargs)
+        policy.model.ensure_runtime_dtypes()
+        return policy
+
+    def __init__(self, config: Cosmos3Config, **kwargs):
+        require_package("diffusers", extra="cosmos3")
+        super().__init__(config)
+        config.validate_features()
+        self.config = config
+
+        self.model = Cosmos3ActionModel(
+            config,
+            transformer=kwargs.pop("transformer", None),
+            vae=kwargs.pop("vae", None),
+            scheduler=kwargs.pop("scheduler", None),
+        )
+        self.model.ensure_runtime_dtypes()
+        self.to(config.device)
+        self.reset()
+
+    def reset(self):
+        self._action_queue = deque(maxlen=self.config.n_action_steps)
+        self.model.reset_generation()
+
+    def forward(self, batch: dict[str, Tensor]) -> tuple[Tensor, dict]:
+        return self.model(batch)
+
+    @torch.no_grad()
+    def sample_actions(self, batch: dict[str, Tensor], **kwargs) -> Tensor:
+        self.eval()
+        return self.model.sample_actions(batch, **kwargs)
+
+    @torch.no_grad()
+    def predict_action_chunk(self, batch: dict[str, Tensor], **kwargs) -> Tensor:
+        actions = self.sample_actions(batch, **kwargs).to(torch.float32)
+        original_action_dim = self.config.output_features[ACTION].shape[0]
+        return actions[:, :, :original_action_dim]
+
+    @torch.no_grad()
+    def select_action(self, batch: dict[str, Tensor], **kwargs) -> Tensor:
+        self.eval()
+        if len(self._action_queue) == 0:
+            actions = self.predict_action_chunk(batch, **kwargs)[:, : self.config.n_action_steps]
+            self._action_queue.extend(actions.transpose(0, 1))
+        return self._action_queue.popleft()
+
+    @torch.no_grad()
+    def predict_future_video(self, batch: dict[str, Tensor], **kwargs) -> Tensor | None:
+        return self.model.predict_future_video(batch, **kwargs)
+
+    def get_optim_params(self) -> dict:
+        return self.parameters()
+
+
+class Cosmos3ActionModel(nn.Module):
+    """Cosmos3 action model built from public Diffusers model-level components."""
+
+    def __init__(
+        self,
+        config: Cosmos3Config,
+        *,
+        transformer: nn.Module | None = None,
+        vae: nn.Module | None = None,
+        scheduler: Any | None = None,
+    ):
+        super().__init__()
+        self.config = config
+        self.transformer = transformer if transformer is not None else self._build_transformer()
+        self.vae = vae if vae is not None else self._build_vae()
+        self.scheduler = scheduler if scheduler is not None else self._build_scheduler()
+        if self.config.freeze_vae:
+            self.vae.eval().requires_grad_(False)
+        self.reset_generation()
+
+    def ensure_runtime_dtypes(self) -> None:
+        for module_name in getattr(self.transformer, "_keep_in_fp32_modules", []) or []:
+            module = getattr(self.transformer, module_name, None)
+            if module is not None:
+                module.float()
+        rotary_emb = getattr(self.transformer, "rotary_emb", None)
+        inv_freq = getattr(rotary_emb, "inv_freq", None)
+        if inv_freq is not None and inv_freq.device.type != "meta" and inv_freq.dtype != torch.float32:
+            rotary_emb.register_buffer("inv_freq", inv_freq.float(), persistent=False)
+
+    def reset_generation(self) -> None:
+        self._rng = np.random.default_rng(self.config.seed)
+
+    def _next_seed(self) -> int:
+        if self.config.deterministic_seed:
+            return int(self.config.seed)
+        return int(self._rng.integers(0, 2**31))
+
+    def _build_transformer(self) -> nn.Module:
+        from diffusers import Cosmos3OmniTransformer
+
+        torch_dtype = _torch_dtype(self.config.dtype)
+        transformer = Cosmos3OmniTransformer(**self.config.transformer_backbone_config)
+        return transformer.to(dtype=torch_dtype)
+
+    def _build_vae(self) -> nn.Module:
+        from diffusers import AutoencoderKLWan
+
+        torch_dtype = _torch_dtype(self.config.dtype)
+        if self.config.vae_config is not None:
+            return AutoencoderKLWan(**self.config.vae_config).to(dtype=torch_dtype)
+        raise ValueError(
+            "Cosmos3Config.vae_config is required. "
+            "Load a converted LeRobot Cosmos3 checkpoint or provide the serialized VAE config."
+        )
+
+    def _build_scheduler(self) -> Any:
+        from diffusers import UniPCMultistepScheduler
+
+        if self.config.scheduler_config is None:
+            raise ValueError(
+                "Cosmos3Config.scheduler_config is required. "
+                "Load a converted LeRobot Cosmos3 checkpoint or provide the serialized scheduler config."
+            )
+        return UniPCMultistepScheduler.from_config(self.config.scheduler_config)
+
+    def forward(self, batch: dict[str, Tensor]) -> tuple[Tensor, dict]:
+        required = [
+            COSMOS3_VIDEO,
+            COSMOS3_ACTION_CONDITION,
+            COSMOS3_ACTION_CONDITION_MASK,
+            COSMOS3_ACTION_DOMAIN_ID,
+            COSMOS3_CONDITIONING_FPS,
+            COSMOS3_RAW_ACTION_DIM,
+            COSMOS3_COND_INPUT_IDS,
+        ]
+        missing = [key for key in required if key not in batch]
+        if missing:
+            raise ValueError(f"Cosmos3 training batch is missing required model inputs: {missing}")
+
+        videos = batch[COSMOS3_VIDEO]
+        if videos.ndim == 4:
+            videos = videos.unsqueeze(0)
+        action_conditions = batch[COSMOS3_ACTION_CONDITION]
+        if action_conditions.ndim == 2:
+            action_conditions = action_conditions.unsqueeze(0)
+        action_condition_masks = batch[COSMOS3_ACTION_CONDITION_MASK]
+        if action_condition_masks.ndim == 2:
+            action_condition_masks = action_condition_masks.unsqueeze(0)
+
+        batch_size = videos.shape[0]
+        clean_actions = self._prepare_clean_action_tokens(batch, action_conditions)
+        sigmas = self._get_training_sigmas(batch, batch_size=batch_size)
+
+        cond_input_ids = [
+            self._get_ids_for_batch(batch[COSMOS3_COND_INPUT_IDS], batch_idx)
+            for batch_idx in range(batch_size)
+        ]
+        losses = self._compute_training_loss(
+            cond_input_ids=cond_input_ids,
+            videos=videos,
+            clean_action=clean_actions,
+            action_condition_mask=action_condition_masks,
+            domain_id=batch[COSMOS3_ACTION_DOMAIN_ID],
+            conditioning_fps=batch[COSMOS3_CONDITIONING_FPS],
+            raw_action_dim=batch[COSMOS3_RAW_ACTION_DIM],
+            sigma=sigmas,
+        )
+
+        loss = losses["loss"]
+        vision_loss = losses["flow_matching_loss_vision"]
+        action_loss = losses["flow_matching_loss_action"]
+        metrics = {
+            "loss": float(loss.detach().cpu()),
+            "flow_matching_loss_vision": float(vision_loss.detach().cpu()),
+            "flow_matching_loss_action": float(action_loss.detach().cpu()),
+        }
+        return loss, metrics
+
+    def _get_ids_for_batch(self, input_ids: Any, batch_idx: int) -> Tensor:
+        if isinstance(input_ids, Tensor):
+            if input_ids.ndim == 1:
+                return input_ids
+            return input_ids[batch_idx]
+        return input_ids[batch_idx]
+
+    def _prepare_clean_action_tokens(self, batch: dict[str, Tensor], action_conditions: Tensor) -> Tensor:
+        if COSMOS3_CLEAN_ACTION in batch:
+            clean_action = batch[COSMOS3_CLEAN_ACTION]
+            if clean_action.ndim == 2:
+                clean_action = clean_action.unsqueeze(0)
+            if clean_action.shape[-1] < self.config.max_action_dim:
+                clean_action = F.pad(clean_action, (0, self.config.max_action_dim - clean_action.shape[-1]))
+            return clean_action[:, :, : self.config.max_action_dim].to(dtype=torch.float32)
+
+        if ACTION not in batch:
+            raise ValueError(
+                f"Cosmos3 training requires {COSMOS3_CLEAN_ACTION!r} or {ACTION!r} action labels."
+            )
+        action = batch[ACTION]
+        if action.ndim == 2:
+            action = action.unsqueeze(0)
+        if action.ndim != 3:
+            raise ValueError(f"Cosmos3 action labels must have shape [B,T,D], got {tuple(action.shape)}.")
+
+        batch_size, action_len, _ = action_conditions.shape
+        clean_action = torch.zeros(
+            batch_size,
+            action_len,
+            self.config.max_action_dim,
+            dtype=torch.float32,
+            device=action_conditions.device,
+        )
+        clean_action[:, :, : self.config.raw_action_dim] = action_conditions[
+            :, :, : self.config.raw_action_dim
+        ].to(dtype=torch.float32)
+        action = (
+            action[:, : self.config.chunk_size, : self.config.raw_action_dim].to(dtype=torch.float32).clone()
+        )
+        if self.config.invert_gripper:
+            action[:, :, -1] = 1.0 - action[:, :, -1]
+        future_start = int(self.config.use_state)
+        clean_action[:, future_start : future_start + action.shape[1], : self.config.raw_action_dim] = action
+        return clean_action
+
+    def _get_training_sigmas(self, batch: dict[str, Tensor], *, batch_size: int) -> Tensor:
+        device = _module_device(self.transformer)
+        if COSMOS3_TRAINING_SIGMA in batch:
+            sigmas = torch.as_tensor(batch[COSMOS3_TRAINING_SIGMA], device=device, dtype=torch.float32)
+            if sigmas.ndim == 0:
+                sigmas = sigmas.expand(batch_size, 1)
+            elif sigmas.ndim == 1:
+                sigmas = sigmas.view(batch_size, 1)
+            elif sigmas.ndim != 2:
+                raise ValueError(
+                    f"{COSMOS3_TRAINING_SIGMA} must be scalar, [B], or [B,1], got {sigmas.shape}."
+                )
+            return sigmas
+
+        if self.config.train_time_video_distribution == "uniform":
+            t_raw = torch.rand((batch_size, 1), device=device, dtype=torch.float32)
+        elif self.config.train_time_video_distribution == "logitnormal":
+            t_raw = torch.sigmoid(torch.randn((batch_size, 1), device=device, dtype=torch.float32))
+        elif self.config.train_time_video_distribution == "waver":
+            u = torch.rand((batch_size, 1), device=device, dtype=torch.float32)
+            t_raw = 1.0 - u - 1.29 * (torch.cos(torch.pi / 2.0 * u) ** 2 - 1 + u)
+        else:
+            raise ValueError(
+                f"Unsupported Cosmos3 train_time_video_distribution={self.config.train_time_video_distribution!r}."
+            )
+
+        tau = 1.0 - t_raw
+        shift = float(self.config.shift)
+        return shift * tau / (1.0 + (shift - 1.0) * tau)
+
+    def _compute_training_loss(
+        self,
+        *,
+        cond_input_ids: list[Tensor],
+        videos: Tensor,
+        clean_action: Tensor,
+        action_condition_mask: Tensor,
+        domain_id: Tensor,
+        conditioning_fps: Tensor,
+        raw_action_dim: Tensor,
+        sigma: Tensor,
+    ) -> dict[str, Tensor]:
+        device = _module_device(self.transformer)
+        dtype = _module_dtype(self.transformer)
+        batch_size = videos.shape[0]
+        raw_action_dims = torch.as_tensor(raw_action_dim, device=device, dtype=torch.long).view(batch_size)
+        conditioning_fps = torch.as_tensor(conditioning_fps, device=device, dtype=torch.float32).view(
+            batch_size
+        )
+        domain_id = torch.as_tensor(domain_id, device=device, dtype=torch.long).view(batch_size)
+        sigma = torch.as_tensor(sigma, device=device, dtype=torch.float32).view(batch_size, 1)
+
+        vision_tensor, action_image_size, _height, _width = preprocess_action_video_batch(
+            videos,
+            resolution_tier=self.config.resolution_tier,
+            num_frames=self.config.chunk_size + 1,
+            device=device,
+            dtype=dtype,
+        )
+        with torch.no_grad():
+            clean_vision = self._encode_video(vision_tensor).contiguous().float()
+            clean_vision = self._remove_action_video_padding_from_latent(clean_vision, action_image_size)
+
+        vision_condition_mask = torch.zeros(
+            (1, 1, clean_vision.shape[2], 1, 1),
+            device=device,
+            dtype=torch.float32,
+        )
+        vision_condition_mask[:, :, 0] = 1.0
+        vision_noisy_mask = 1.0 - vision_condition_mask
+        vision_sigma = sigma.view(batch_size, 1, 1, 1, 1) * vision_noisy_mask
+        epsilon_vision = torch.randn(clean_vision.shape, device=device, dtype=torch.float32)
+        noised_vision = epsilon_vision * vision_sigma + clean_vision * (1.0 - vision_sigma)
+        target_vision = epsilon_vision - clean_vision
+
+        action_dim = int(self.transformer.config.action_dim)
+        clean_action = clean_action.to(device=device, dtype=torch.float32)
+        if clean_action.shape[-1] < action_dim:
+            clean_action = F.pad(clean_action, (0, action_dim - clean_action.shape[-1]))
+        clean_action = clean_action[:, :, :action_dim]
+        action_condition_mask = action_condition_mask.to(device=device, dtype=torch.float32)
+        sigma_action = sigma.view(batch_size, 1, 1) * (1.0 - action_condition_mask)
+        epsilon_action = torch.randn(clean_action.shape, device=device, dtype=torch.float32)
+        noised_action = epsilon_action * sigma_action + clean_action * (1.0 - sigma_action)
+        target_action = epsilon_action - clean_action
+        action_dim_indexes = torch.arange(action_dim, device=device).view(1, 1, action_dim)
+        raw_action_mask = action_dim_indexes < raw_action_dims.view(batch_size, 1, 1)
+        noised_action = noised_action.masked_fill(~raw_action_mask, 0)
+
+        max_timestep = float(getattr(self.scheduler.config, "num_train_timesteps", 1000))
+        timesteps = sigma.flatten() * max_timestep
+        packed_samples = self._pack_batch_static(
+            cond_input_ids=cond_input_ids,
+            vision_tokens=noised_vision.to(dtype=dtype),
+            action_tokens=noised_action.to(dtype=dtype),
+            conditioning_fps=conditioning_fps,
+        )
+        vision_timesteps = [
+            torch.full(
+                (sample["num_noisy_vision_tokens"],),
+                float(timesteps[batch_idx].item()),
+                device=device,
+                dtype=torch.float32,
+            )
+            for batch_idx, sample in enumerate(packed_samples)
+        ]
+        action_timesteps = [
+            torch.full(
+                (sample["num_noisy_action_tokens"],),
+                float(timesteps[batch_idx].item()),
+                device=device,
+                dtype=torch.float32,
+            )
+            for batch_idx, sample in enumerate(packed_samples)
+        ]
+
+        pred_vision, pred_action = self._predict_velocity_batch(
+            packed_samples=packed_samples,
+            vision_tokens=noised_vision.to(dtype=dtype),
+            action_tokens=noised_action.to(dtype=dtype),
+            vision_timesteps=vision_timesteps,
+            action_timesteps=action_timesteps,
+            action_domain_ids=domain_id,
+            vision_condition_mask=vision_condition_mask.to(dtype=dtype),
+            action_condition_mask=action_condition_mask.to(dtype=dtype),
+            raw_action_dims=raw_action_dims,
+        )
+
+        vision_loss = self._masked_flow_matching_mse_by_sample(
+            pred_vision.to(dtype=torch.float32),
+            target_vision.to(device=pred_vision.device, dtype=torch.float32),
+            vision_noisy_mask.to(device=pred_vision.device, dtype=torch.float32),
+        )
+
+        action_noisy_mask = (1.0 - action_condition_mask) * raw_action_mask
+        action_loss = self._masked_flow_matching_mse_by_sample(
+            pred_action.to(dtype=torch.float32),
+            target_action.to(device=pred_action.device, dtype=torch.float32),
+            action_noisy_mask.to(device=pred_action.device, dtype=torch.float32),
+        )
+        total_loss = (
+            self.config.video_loss_weight * vision_loss + self.config.action_loss_weight * action_loss
+        )
+        return {
+            "loss": total_loss,
+            "flow_matching_loss_vision": vision_loss,
+            "flow_matching_loss_action": action_loss,
+        }
+
+    def _masked_flow_matching_mse_by_sample(self, pred: Tensor, target: Tensor, noisy_mask: Tensor) -> Tensor:
+        noisy_mask = noisy_mask.to(device=pred.device, dtype=pred.dtype).expand_as(pred)
+        sqerr = (pred - target) ** 2 * noisy_mask
+        if not self.config.normalize_loss_by_active:
+            return sqerr.flatten(1).mean(dim=1).mean()
+
+        active_count = noisy_mask.flatten(1).sum(dim=1)
+        return (sqerr.flatten(1).sum(dim=1) / active_count.clamp_min(1.0)).mean()
+
+    def _encode_video(self, video: Tensor) -> Tensor:
+        vae_dtype = _module_dtype(self.vae)
+        encoded = _retrieve_latents(self.vae.encode(video.to(vae_dtype)), sample_mode="argmax")
+        mean = torch.tensor(self.vae.config.latents_mean, device=encoded.device, dtype=encoded.dtype)
+        inv_std = 1.0 / torch.tensor(self.vae.config.latents_std, device=encoded.device, dtype=encoded.dtype)
+        return ((encoded - mean.view(1, -1, 1, 1, 1)) * inv_std.view(1, -1, 1, 1, 1)).to(video.dtype)
+
+    def _remove_action_video_padding_from_latent(self, latents: Tensor, image_size: Tensor) -> Tensor:
+        spatial_factor = int(getattr(self.vae.config, "scale_factor_spatial", 16))
+        content_h = int(image_size[2].item())
+        content_w = int(image_size[3].item())
+        content_h_latent = max(content_h // spatial_factor, 1)
+        content_w_latent = max(content_w // spatial_factor, 1)
+        return latents[:, :, :, :content_h_latent, :content_w_latent].contiguous()
+
+    @torch.no_grad()
+    def sample_actions(
+        self,
+        batch: dict[str, Tensor],
+        *,
+        seed: int | list[int] | tuple[int, ...] | Tensor | None = None,
+        num_inference_steps: int | None = None,
+        guidance_scale: float | None = None,
+    ) -> Tensor:
+        required = [
+            COSMOS3_VIDEO,
+            COSMOS3_ACTION_CONDITION,
+            COSMOS3_ACTION_CONDITION_MASK,
+            COSMOS3_ACTION_DOMAIN_ID,
+            COSMOS3_CONDITIONING_FPS,
+            COSMOS3_RAW_ACTION_DIM,
+            COSMOS3_COND_INPUT_IDS,
+            COSMOS3_UNCOND_INPUT_IDS,
+        ]
+        missing = [key for key in required if key not in batch]
+        if missing:
+            raise ValueError(f"Cosmos3 batch is missing required model inputs: {missing}")
+
+        videos = batch[COSMOS3_VIDEO]
+        if videos.ndim == 4:
+            videos = videos.unsqueeze(0)
+        batch_size = videos.shape[0]
+        action_condition = batch[COSMOS3_ACTION_CONDITION]
+        if action_condition.ndim == 2:
+            action_condition = action_condition.unsqueeze(0)
+        action_condition_mask = batch[COSMOS3_ACTION_CONDITION_MASK]
+        if action_condition_mask.ndim == 2:
+            action_condition_mask = action_condition_mask.unsqueeze(0)
+        seeds = self._normalise_sample_seeds(seed, batch_size)
+        return self._sample_batch(
+            cond_input_ids=[
+                self._get_ids_for_batch(batch[COSMOS3_COND_INPUT_IDS], batch_idx)
+                for batch_idx in range(batch_size)
+            ],
+            uncond_input_ids=[
+                self._get_ids_for_batch(batch[COSMOS3_UNCOND_INPUT_IDS], batch_idx)
+                for batch_idx in range(batch_size)
+            ],
+            videos=videos,
+            action_condition=action_condition,
+            action_condition_mask=action_condition_mask,
+            domain_id=batch[COSMOS3_ACTION_DOMAIN_ID],
+            conditioning_fps=batch[COSMOS3_CONDITIONING_FPS],
+            raw_action_dim=batch[COSMOS3_RAW_ACTION_DIM],
+            seeds=seeds,
+            num_inference_steps=num_inference_steps,
+            guidance_scale=guidance_scale,
+        )
+
+    @torch.no_grad()
+    def predict_future_video(self, batch: dict[str, Tensor], **kwargs) -> Tensor | None:
+        if not self.config.generate_video:
+            return None
+        raise NotImplementedError(
+            "Cosmos3 future-video decoding is reserved for a follow-up integration step."
+        )
+
+    def _normalise_sample_seeds(self, seed: Any, batch_size: int) -> list[int]:
+        if seed is None:
+            return [self._next_seed() for _ in range(batch_size)]
+        if isinstance(seed, Tensor):
+            seed = seed.detach().cpu().flatten().tolist()
+        if isinstance(seed, list | tuple):
+            if len(seed) != batch_size:
+                raise ValueError(f"Expected {batch_size} Cosmos3 seeds, got {len(seed)}.")
+            return [int(item) for item in seed]
+        return [int(seed)] * batch_size
+
+    def _sample_batch(
+        self,
+        *,
+        cond_input_ids: list[Tensor],
+        uncond_input_ids: list[Tensor],
+        videos: Tensor,
+        action_condition: Tensor,
+        action_condition_mask: Tensor,
+        domain_id: Tensor,
+        conditioning_fps: Tensor,
+        raw_action_dim: Tensor,
+        seeds: list[int],
+        num_inference_steps: int | None = None,
+        guidance_scale: float | None = None,
+    ) -> Tensor:
+        device = _module_device(self.transformer)
+        dtype = _module_dtype(self.transformer)
+        batch_size = videos.shape[0]
+        num_inference_steps = num_inference_steps or self.config.num_inference_steps
+        guidance_scale = guidance_scale if guidance_scale is not None else self.config.guidance_scale
+        raw_action_dims = torch.as_tensor(raw_action_dim, device=device, dtype=torch.long).view(batch_size)
+        conditioning_fps = torch.as_tensor(conditioning_fps, device=device, dtype=torch.float32).view(
+            batch_size
+        )
+        domain_id = torch.as_tensor(domain_id, device=device, dtype=torch.long).view(batch_size)
+
+        vision_tensor, action_image_size, _height, _width = preprocess_action_video_batch(
+            videos,
+            resolution_tier=self.config.resolution_tier,
+            num_frames=self.config.chunk_size + 1,
+            device=device,
+            dtype=dtype,
+        )
+        x0_tokens_vision = self._encode_video(vision_tensor).contiguous().float()
+        x0_tokens_vision = self._remove_action_video_padding_from_latent(x0_tokens_vision, action_image_size)
+
+        vision_condition_mask = torch.zeros(
+            (1, 1, x0_tokens_vision.shape[2], 1, 1),
+            device=device,
+            dtype=dtype,
+        )
+        vision_condition_mask[:, :, 0] = 1.0
+        pure_noise = torch.cat(
+            [
+                _seeded_standard_normal(
+                    tuple(x0_tokens_vision[batch_idx : batch_idx + 1].shape),
+                    dtype=dtype,
+                    device=device,
+                    seed=seeds[batch_idx],
+                )
+                for batch_idx in range(batch_size)
+            ],
+            dim=0,
+        )
+        latents = (
+            vision_condition_mask * x0_tokens_vision.to(dtype=dtype)
+            + (1.0 - vision_condition_mask) * pure_noise
+        )
+
+        action_dim = int(self.transformer.config.action_dim)
+        action_condition = action_condition.to(device=device, dtype=dtype)
+        if action_condition.shape[-1] < action_dim:
+            action_condition = F.pad(action_condition, (0, action_dim - action_condition.shape[-1]))
+        action_condition = action_condition[:, :, :action_dim]
+        action_condition_mask = action_condition_mask.to(device=device, dtype=dtype)
+        pure_action_noise = torch.stack(
+            [
+                _seeded_standard_normal(
+                    tuple(action_condition[batch_idx].shape),
+                    dtype=dtype,
+                    device=device,
+                    seed=seeds[batch_idx],
+                )
+                for batch_idx in range(batch_size)
+            ],
+            dim=0,
+        )
+        action_latents = (
+            action_condition_mask * action_condition + (1.0 - action_condition_mask) * pure_action_noise
+        )
+        action_dim_indexes = torch.arange(action_dim, device=device).view(1, 1, action_dim)
+        raw_action_mask = action_dim_indexes < raw_action_dims.view(batch_size, 1, 1)
+        action_latents = action_latents.masked_fill(~raw_action_mask, 0)
+
+        cond_packed_static = self._pack_batch_static(
+            cond_input_ids=cond_input_ids,
+            vision_tokens=latents,
+            action_tokens=action_latents,
+            conditioning_fps=conditioning_fps,
+        )
+        uncond_packed_static = self._pack_batch_static(
+            cond_input_ids=uncond_input_ids,
+            vision_tokens=latents,
+            action_tokens=action_latents,
+            conditioning_fps=conditioning_fps,
+        )
+
+        scheduler = self.scheduler
+        scheduler.set_timesteps(num_inference_steps, device=device)
+        timesteps = scheduler.timesteps
+
+        vision_shape = tuple(latents.shape[1:])
+        action_shape = tuple(action_latents.shape[1:])
+        vision_size = latents[0].numel()
+
+        def pack_latents(vision: Tensor, action: Tensor) -> Tensor:
+            return torch.cat([vision.reshape(batch_size, -1), action.reshape(batch_size, -1)], dim=1)
+
+        def unpack_latents(flat_latents: Tensor) -> tuple[Tensor, Tensor]:
+            vision = flat_latents[:, :vision_size].reshape(batch_size, *vision_shape)
+            action = flat_latents[:, vision_size:].reshape(batch_size, *action_shape)
+            return vision, action
+
+        flat_latents = pack_latents(latents, action_latents)
+        for timestep_tensor in timesteps:
+            timestep = float(timestep_tensor.item())
+            latents, action_latents = unpack_latents(flat_latents)
+            vision_tokens = latents.to(device=device, dtype=dtype)
+            action_tokens = action_latents.to(device=device, dtype=dtype)
+            vision_timesteps = [
+                torch.full((sample["num_noisy_vision_tokens"],), timestep, device=device)
+                for sample in cond_packed_static
+            ]
+            action_timesteps = [
+                torch.full((sample["num_noisy_action_tokens"],), timestep, device=device)
+                for sample in cond_packed_static
+            ]
+
+            cond_v_vision, cond_v_action = self._predict_velocity_batch(
+                packed_samples=cond_packed_static,
+                vision_tokens=vision_tokens,
+                action_tokens=action_tokens,
+                vision_timesteps=vision_timesteps,
+                action_timesteps=action_timesteps,
+                action_domain_ids=domain_id,
+                vision_condition_mask=vision_condition_mask,
+                action_condition_mask=action_condition_mask,
+                raw_action_dims=raw_action_dims,
+            )
+            if guidance_scale != 1.0:
+                uncond_v_vision, uncond_v_action = self._predict_velocity_batch(
+                    packed_samples=uncond_packed_static,
+                    vision_tokens=vision_tokens,
+                    action_tokens=action_tokens,
+                    vision_timesteps=vision_timesteps,
+                    action_timesteps=action_timesteps,
+                    action_domain_ids=domain_id,
+                    vision_condition_mask=vision_condition_mask,
+                    action_condition_mask=action_condition_mask,
+                    raw_action_dims=raw_action_dims,
+                )
+                velocity_vision = uncond_v_vision + guidance_scale * (cond_v_vision - uncond_v_vision)
+                velocity_action = uncond_v_action + guidance_scale * (cond_v_action - uncond_v_action)
+            else:
+                velocity_vision = cond_v_vision
+                velocity_action = cond_v_action
+
+            velocity = pack_latents(velocity_vision, velocity_action)
+            flat_latents = scheduler.step(velocity, timestep_tensor, flat_latents, return_dict=False)[0]
+            latents, action_latents = unpack_latents(flat_latents)
+            action_latents = action_latents.masked_fill(~raw_action_mask, 0)
+            flat_latents = pack_latents(latents, action_latents)
+
+        output_action_dim = int(raw_action_dims.max().item())
+        actions = action_latents[:, :, :output_action_dim].detach().cpu().to(torch.float32)
+        if self.config.history_length:
+            actions = actions[:, self.config.history_length :]
+        if self.config.invert_gripper:
+            for batch_idx, raw_dim in enumerate(raw_action_dims.detach().cpu().tolist()):
+                actions[batch_idx, :, raw_dim - 1] = 1.0 - actions[batch_idx, :, raw_dim - 1]
+        return actions[:, : self.config.chunk_size]
+
+    def _prepare_text_segment(self, input_ids: Tensor, device: torch.device | str) -> dict[str, Any]:
+        input_ids = torch.as_tensor(input_ids, dtype=torch.long, device=device)
+        input_ids = torch.cat(
+            [
+                input_ids,
+                input_ids.new_tensor([self.config.eos_token_id, self.config.start_of_generation_token_id]),
+            ],
+            dim=0,
+        )
+        config = self.transformer.config
+        und_len = int(input_ids.numel())
+        text_mrope_ids, next_mrope_offset = get_3d_mrope_ids_text_tokens(
+            num_tokens=und_len,
+            temporal_offset=0,
+            use_float_positions=bool(config.enable_fps_modulation),
+        )
+        return {
+            "input_ids": input_ids,
+            "text_indexes": torch.arange(und_len, dtype=torch.long, device=device),
+            "und_len": und_len,
+            "text_mrope_ids": text_mrope_ids.to(device),
+            "vision_start_temporal_offset": next_mrope_offset
+            + config.unified_3d_mrope_temporal_modality_margin,
+        }
+
+    def _pack_static_segments(
+        self,
+        *,
+        text_segment: dict[str, Any],
+        latents: Tensor,
+        action_latents: Tensor,
+        vision_condition_indexes: list[int],
+        fps_vision: float,
+        action_start_frame_offset: int,
+    ) -> dict[str, Any]:
+        device = latents.device
+        vision_segment = self._prepare_vision_segment(
+            input_vision_tokens=latents,
+            has_image_condition=True,
+            mrope_offset=text_segment["vision_start_temporal_offset"],
+            vision_fps=fps_vision,
+            curr=text_segment["und_len"],
+            device=device,
+            condition_frame_indexes=vision_condition_indexes,
+        )
+        action_segment = self._prepare_action_segment(
+            input_action_tokens=action_latents,
+            condition_frame_indexes=[0] if self.config.use_state else [],
+            mrope_offset=text_segment["vision_start_temporal_offset"],
+            action_fps=fps_vision,
+            curr=text_segment["und_len"] + vision_segment["num_vision_tokens"],
+            device=device,
+            start_frame_offset=action_start_frame_offset,
+        )
+        position_ids = torch.cat(
+            [
+                text_segment["text_mrope_ids"],
+                vision_segment["vision_mrope_ids"],
+                action_segment["action_mrope_ids"],
+            ],
+            dim=1,
+        )
+        return {
+            **text_segment,
+            **vision_segment,
+            **action_segment,
+            "position_ids": position_ids,
+            "sequence_length": text_segment["und_len"]
+            + vision_segment["num_vision_tokens"]
+            + action_segment["action_len"],
+        }
+
+    def _pack_batch_static(
+        self,
+        *,
+        cond_input_ids: list[Tensor],
+        vision_tokens: Tensor,
+        action_tokens: Tensor,
+        conditioning_fps: Tensor,
+    ) -> list[dict[str, Any]]:
+        device = vision_tokens.device
+        packed_samples = []
+        for batch_idx, input_ids in enumerate(cond_input_ids):
+            text_segment = self._prepare_text_segment(input_ids, device=device)
+            packed_samples.append(
+                self._pack_static_segments(
+                    text_segment=text_segment,
+                    latents=vision_tokens[batch_idx : batch_idx + 1],
+                    action_latents=action_tokens[batch_idx],
+                    vision_condition_indexes=[0],
+                    fps_vision=float(conditioning_fps[batch_idx].item()),
+                    action_start_frame_offset=0 if self.config.use_state else 1,
+                )
+            )
+        return packed_samples
+
+    def _prepare_vision_segment(
+        self,
+        *,
+        input_vision_tokens: Tensor,
+        has_image_condition: bool,
+        mrope_offset: int | float,
+        vision_fps: float | None,
+        curr: int,
+        device: torch.device | str,
+        condition_frame_indexes: list[int] | None = None,
+    ) -> dict[str, Any]:
+        config = self.transformer.config
+        latent_patch_size = int(config.latent_patch_size)
+        _, _, latent_t, latent_h, latent_w = input_vision_tokens.shape
+        patch_h = math.ceil(latent_h / latent_patch_size)
+        patch_w = math.ceil(latent_w / latent_patch_size)
+        num_vision_tokens = latent_t * patch_h * patch_w
+
+        if condition_frame_indexes is None:
+            condition_frame_indexes = [0] if has_image_condition else []
+        cond_frames = {idx for idx in condition_frame_indexes if 0 <= idx < latent_t}
+        noisy_frame_indexes = torch.tensor(
+            [idx for idx in range(latent_t) if idx not in cond_frames], device=device, dtype=torch.long
+        )
+
+        frame_token_stride = patch_h * patch_w
+        mse_loss_indexes: list[int] = []
+        for frame_idx in noisy_frame_indexes.tolist():
+            frame_start = curr + frame_idx * frame_token_stride
+            mse_loss_indexes.extend(range(frame_start, frame_start + frame_token_stride))
+
+        effective_fps = vision_fps if config.enable_fps_modulation else None
+        temporal_compression_factor = int(getattr(self.vae.config, "scale_factor_temporal", 4))
+        vision_mrope_ids, _ = get_3d_mrope_ids_vae_tokens(
+            grid_t=latent_t,
+            grid_h=patch_h,
+            grid_w=patch_w,
+            temporal_offset=mrope_offset,
+            reset_spatial_indices=config.unified_3d_mrope_reset_spatial_ids,
+            fps=effective_fps,
+            base_fps=float(config.base_fps),
+            temporal_compression_factor=temporal_compression_factor,
+        )
+
+        return {
+            "vision_token_shapes": [(latent_t, patch_h, patch_w)],
+            "vision_sequence_indexes": torch.arange(
+                curr, curr + num_vision_tokens, dtype=torch.long, device=device
+            ),
+            "vision_mse_loss_indexes": torch.tensor(mse_loss_indexes, dtype=torch.long, device=device),
+            "vision_noisy_frame_indexes": [noisy_frame_indexes],
+            "vision_mrope_ids": vision_mrope_ids.to(device),
+            "num_vision_tokens": num_vision_tokens,
+            "num_noisy_vision_tokens": len(noisy_frame_indexes) * frame_token_stride,
+        }
+
+    def _prepare_action_segment(
+        self,
+        *,
+        input_action_tokens: Tensor,
+        condition_frame_indexes: list[int],
+        mrope_offset: int | float,
+        action_fps: float | None,
+        curr: int,
+        device: torch.device | str,
+        start_frame_offset: int,
+    ) -> dict[str, Any]:
+        config = self.transformer.config
+        action_len = input_action_tokens.shape[0]
+        cond_frames = {idx for idx in condition_frame_indexes if 0 <= idx < action_len}
+        noisy_frame_indexes = torch.tensor(
+            [idx for idx in range(action_len) if idx not in cond_frames], device=device, dtype=torch.long
+        )
+
+        effective_fps = action_fps if config.enable_fps_modulation else None
+        base_tcf = int(getattr(self.vae.config, "scale_factor_temporal", 4))
+        action_mrope_ids, _ = get_3d_mrope_ids_vae_tokens(
+            grid_t=action_len,
+            grid_h=1,
+            grid_w=1,
+            temporal_offset=mrope_offset,
+            reset_spatial_indices=config.unified_3d_mrope_reset_spatial_ids,
+            fps=effective_fps,
+            base_fps=float(config.base_fps),
+            temporal_compression_factor=1,
+            base_temporal_compression_factor=base_tcf,
+            start_frame_offset=start_frame_offset,
+        )
+        sequence_indexes = torch.arange(curr, curr + action_len, dtype=torch.long, device=device)
+        return {
+            "action_token_shapes": [(action_len, 1, 1)],
+            "action_sequence_indexes": sequence_indexes,
+            "action_mse_loss_indexes": sequence_indexes[noisy_frame_indexes],
+            "action_noisy_frame_indexes": [noisy_frame_indexes],
+            "action_mrope_ids": action_mrope_ids.to(device),
+            "action_len": action_len,
+            "num_noisy_action_tokens": len(noisy_frame_indexes),
+        }
+
+    def _predict_velocity_batch(
+        self,
+        *,
+        packed_samples: list[dict[str, Any]],
+        vision_tokens: Tensor,
+        action_tokens: Tensor,
+        vision_timesteps: list[Tensor],
+        action_timesteps: list[Tensor],
+        action_domain_ids: Tensor,
+        vision_condition_mask: Tensor,
+        action_condition_mask: Tensor,
+        raw_action_dims: Tensor,
+    ) -> tuple[Tensor, Tensor]:
+        transformer = self.transformer
+        batch_size = len(packed_samples)
+        device = vision_tokens.device
+        hidden_size = int(transformer.config.hidden_size)
+        max_und_len = max(sample["und_len"] for sample in packed_samples)
+        gen_lengths = [sample["sequence_length"] - sample["und_len"] for sample in packed_samples]
+        max_gen_len = max(gen_lengths)
+
+        all_input_ids = torch.cat([sample["input_ids"] for sample in packed_samples], dim=0)
+        all_text_embeddings = transformer.embed_tokens(all_input_ids)
+        target_dtype = all_text_embeddings.dtype
+        und_seq = all_text_embeddings.new_zeros((batch_size, max_und_len, hidden_size))
+        gen_seq = all_text_embeddings.new_zeros((batch_size, max_gen_len, hidden_size))
+        und_valid_mask = torch.zeros((batch_size, max_und_len), device=device, dtype=torch.bool)
+        gen_valid_mask = torch.zeros((batch_size, max_gen_len), device=device, dtype=torch.bool)
+
+        position_dtype = packed_samples[0]["position_ids"].dtype
+        position_ids_und = torch.zeros((3, batch_size, max_und_len), device=device, dtype=position_dtype)
+        position_ids_gen = torch.zeros((3, batch_size, max_gen_len), device=device, dtype=position_dtype)
+
+        text_offset = 0
+        for batch_idx, sample in enumerate(packed_samples):
+            und_len = sample["und_len"]
+            gen_len = gen_lengths[batch_idx]
+            und_seq[batch_idx, :und_len] = all_text_embeddings[text_offset : text_offset + und_len]
+            text_offset += und_len
+            und_valid_mask[batch_idx, :und_len] = True
+            gen_valid_mask[batch_idx, :gen_len] = True
+            position_ids = sample["position_ids"]
+            position_ids_und[:, batch_idx, :und_len] = position_ids[:, :und_len]
+            position_ids_gen[:, batch_idx, :gen_len] = position_ids[:, und_len : und_len + gen_len]
+
+        vision_token_list = [vision_tokens[batch_idx : batch_idx + 1] for batch_idx in range(batch_size)]
+        vision_token_shapes = [sample["vision_token_shapes"][0] for sample in packed_samples]
+        vision_noisy_frame_indexes = [sample["vision_noisy_frame_indexes"][0] for sample in packed_samples]
+        packed_vision_tokens, original_latent_shapes = transformer._patchify_and_pack_latents(
+            vision_token_list
+        )
+        packed_vision_tokens = transformer.proj_in(packed_vision_tokens)
+        packed_vision_timestep_embeds = transformer.time_embedder(
+            transformer.time_proj(torch.cat(vision_timesteps, dim=0) * transformer.config.timestep_scale)
+        ).to(target_dtype)
+        packed_vision_tokens = transformer._apply_timestep_embeds_to_noisy_tokens(
+            packed_tokens=packed_vision_tokens,
+            packed_timestep_embeds=packed_vision_timestep_embeds,
+            noisy_frame_indexes=vision_noisy_frame_indexes,
+            token_shapes=vision_token_shapes,
+        )
+
+        vision_token_offset = 0
+        for batch_idx, sample in enumerate(packed_samples):
+            token_count = sample["num_vision_tokens"]
+            gen_indexes = sample["vision_sequence_indexes"] - sample["und_len"]
+            gen_seq[batch_idx, gen_indexes] = packed_vision_tokens[
+                vision_token_offset : vision_token_offset + token_count
+            ]
+            vision_token_offset += token_count
+
+        action_token_list = [action_tokens[batch_idx] for batch_idx in range(batch_size)]
+        action_token_shapes = [sample["action_token_shapes"][0] for sample in packed_samples]
+        action_noisy_frame_indexes = [sample["action_noisy_frame_indexes"][0] for sample in packed_samples]
+        action_domain_id_list = [action_domain_ids[batch_idx].view(1) for batch_idx in range(batch_size)]
+        packed_action_tokens, per_token_domain_ids = transformer._pack_action_latents(
+            action_token_list, action_token_shapes, action_domain_id_list
+        )
+        packed_action_tokens = packed_action_tokens.to(target_dtype)
+        per_token_domain_ids = per_token_domain_ids.to(device=device)
+        packed_action_tokens = transformer.action_proj_in(packed_action_tokens, per_token_domain_ids)
+        packed_action_tokens = packed_action_tokens + transformer.action_modality_embed
+        packed_action_timestep_embeds = transformer.time_embedder(
+            transformer.time_proj(torch.cat(action_timesteps, dim=0) * transformer.config.timestep_scale)
+        ).to(target_dtype)
+        packed_action_tokens = transformer._apply_timestep_embeds_to_noisy_tokens(
+            packed_tokens=packed_action_tokens,
+            packed_timestep_embeds=packed_action_timestep_embeds,
+            noisy_frame_indexes=action_noisy_frame_indexes,
+            token_shapes=action_token_shapes,
+        )
+
+        action_token_offset = 0
+        for batch_idx, sample in enumerate(packed_samples):
+            token_count = sample["action_len"]
+            gen_indexes = sample["action_sequence_indexes"] - sample["und_len"]
+            gen_seq[batch_idx, gen_indexes] = packed_action_tokens[
+                action_token_offset : action_token_offset + token_count
+            ]
+            action_token_offset += token_count
+
+        cos_und, sin_und = transformer.rotary_emb(
+            position_ids=position_ids_und,
+            device=device,
+            dtype=target_dtype,
+        )
+        cos_gen, sin_gen = transformer.rotary_emb(
+            position_ids=position_ids_gen,
+            device=device,
+            dtype=target_dtype,
+        )
+        rotary_emb = (cos_und, sin_und, cos_gen, sin_gen)
+        und_seq = und_seq * und_valid_mask.unsqueeze(-1)
+        gen_seq = gen_seq * gen_valid_mask.unsqueeze(-1)
+
+        for decoder_layer in transformer.layers:
+            und_seq, gen_seq = self._batched_decoder_layer(
+                decoder_layer,
+                und_seq,
+                gen_seq,
+                rotary_emb,
+                und_valid_mask,
+                gen_valid_mask,
+            )
+
+        gen_out = transformer.norm_moe_gen(gen_seq) * gen_valid_mask.unsqueeze(-1)
+
+        vision_hidden_states = []
+        for batch_idx, sample in enumerate(packed_samples):
+            gen_indexes = sample["vision_mse_loss_indexes"] - sample["und_len"]
+            vision_hidden_states.append(gen_out[batch_idx, gen_indexes])
+        preds_vision_packed = transformer.proj_out(torch.cat(vision_hidden_states, dim=0))
+        preds_vision = transformer._unpatchify_and_unpack_latents(
+            preds_vision_packed,
+            token_shapes_vision=vision_token_shapes,
+            noisy_frame_indexes_vision=vision_noisy_frame_indexes,
+            original_latent_shapes=original_latent_shapes,
+        )
+        pred_vision = torch.cat(preds_vision, dim=0)
+
+        action_hidden_states = []
+        action_noisy_domain_ids = []
+        for batch_idx, sample in enumerate(packed_samples):
+            gen_indexes = sample["action_mse_loss_indexes"] - sample["und_len"]
+            action_hidden_states.append(gen_out[batch_idx, gen_indexes])
+            action_noisy_domain_ids.append(action_domain_ids[batch_idx].view(1).expand(len(gen_indexes)))
+        preds_action_packed = transformer.action_proj_out(
+            torch.cat(action_hidden_states, dim=0),
+            torch.cat(action_noisy_domain_ids, dim=0).to(device=device),
+        )
+        preds_action = transformer._unpack_action_latents(
+            preds_action_packed,
+            action_token_shapes,
+            action_noisy_frame_indexes,
+        )
+        pred_action = torch.stack(preds_action, dim=0)
+
+        pred_vision = pred_vision * (1.0 - vision_condition_mask).to(device=pred_vision.device)
+        pred_action = pred_action * (1.0 - action_condition_mask).to(device=pred_action.device)
+        action_dim_indexes = torch.arange(pred_action.shape[-1], device=pred_action.device).view(1, 1, -1)
+        raw_action_mask = action_dim_indexes < raw_action_dims.to(device=pred_action.device).view(
+            batch_size, 1, 1
+        )
+        pred_action = pred_action.masked_fill(~raw_action_mask, 0)
+        return pred_vision, pred_action
+
+    def _batched_decoder_layer(
+        self,
+        decoder_layer: nn.Module,
+        und_seq: Tensor,
+        gen_seq: Tensor,
+        rotary_emb: tuple[Tensor, Tensor, Tensor, Tensor],
+        und_valid_mask: Tensor,
+        gen_valid_mask: Tensor,
+    ) -> tuple[Tensor, Tensor]:
+        und_norm = decoder_layer.input_layernorm(und_seq)
+        gen_norm = decoder_layer.input_layernorm_moe_gen(gen_seq)
+
+        und_attn_out, gen_attn_out = self._batched_mot_attention(
+            decoder_layer.self_attn,
+            und_norm,
+            gen_norm,
+            rotary_emb,
+            und_valid_mask,
+            gen_valid_mask,
+        )
+        residual_und = (und_seq + und_attn_out) * und_valid_mask.unsqueeze(-1)
+        residual_gen = (gen_seq + gen_attn_out) * gen_valid_mask.unsqueeze(-1)
+
+        mlp_out_und = decoder_layer.mlp(decoder_layer.post_attention_layernorm(residual_und))
+        mlp_out_gen = decoder_layer.mlp_moe_gen(decoder_layer.post_attention_layernorm_moe_gen(residual_gen))
+        und_out = (residual_und + mlp_out_und) * und_valid_mask.unsqueeze(-1)
+        gen_out = (residual_gen + mlp_out_gen) * gen_valid_mask.unsqueeze(-1)
+        return und_out, gen_out
+
+    def _batched_mot_attention(
+        self,
+        attn: nn.Module,
+        und_seq: Tensor,
+        gen_seq: Tensor,
+        rotary_emb: tuple[Tensor, Tensor, Tensor, Tensor],
+        und_valid_mask: Tensor,
+        gen_valid_mask: Tensor,
+    ) -> tuple[Tensor, Tensor]:
+        batch_size, und_len, _hidden_size = und_seq.shape
+        gen_len = gen_seq.shape[1]
+
+        q_und = attn.to_q(und_seq).view(batch_size, und_len, attn.num_attention_heads, attn.head_dim)
+        k_und = attn.to_k(und_seq).view(batch_size, und_len, attn.num_key_value_heads, attn.head_dim)
+        v_und = attn.to_v(und_seq).view(batch_size, und_len, attn.num_key_value_heads, attn.head_dim)
+        q_gen = attn.add_q_proj(gen_seq).view(batch_size, gen_len, attn.num_attention_heads, attn.head_dim)
+        k_gen = attn.add_k_proj(gen_seq).view(batch_size, gen_len, attn.num_key_value_heads, attn.head_dim)
+        v_gen = attn.add_v_proj(gen_seq).view(batch_size, gen_len, attn.num_key_value_heads, attn.head_dim)
+
+        q_und = attn.norm_q(q_und)
+        k_und = attn.norm_k(k_und)
+        q_gen = attn.norm_added_q(q_gen)
+        k_gen = attn.norm_added_k(k_gen)
+
+        cos_und, sin_und, cos_gen, sin_gen = rotary_emb
+        q_und = q_und * cos_und.unsqueeze(2) + self._rotate_half(q_und) * sin_und.unsqueeze(2)
+        k_und = k_und * cos_und.unsqueeze(2) + self._rotate_half(k_und) * sin_und.unsqueeze(2)
+        q_gen = q_gen * cos_gen.unsqueeze(2) + self._rotate_half(q_gen) * sin_gen.unsqueeze(2)
+        k_gen = k_gen * cos_gen.unsqueeze(2) + self._rotate_half(k_gen) * sin_gen.unsqueeze(2)
+
+        q_und = q_und.transpose(1, 2)
+        k_und = self._repeat_kv_heads(k_und, attn.num_key_value_groups).transpose(1, 2)
+        v_und = self._repeat_kv_heads(v_und, attn.num_key_value_groups).transpose(1, 2)
+        q_gen = q_gen.transpose(1, 2)
+        k_gen = self._repeat_kv_heads(k_gen, attn.num_key_value_groups).transpose(1, 2)
+        v_gen = self._repeat_kv_heads(v_gen, attn.num_key_value_groups).transpose(1, 2)
+
+        causal_mask = torch.ones((und_len, und_len), device=und_seq.device, dtype=torch.bool).tril()
+        und_attn_mask = causal_mask.view(1, 1, und_len, und_len) & und_valid_mask.view(
+            batch_size, 1, 1, und_len
+        )
+        causal_out = F.scaled_dot_product_attention(
+            q_und,
+            k_und,
+            v_und,
+            attn_mask=und_attn_mask,
+            dropout_p=0.0,
+        )
+        causal_out = causal_out.transpose(1, 2).flatten(-2, -1)
+
+        all_k = torch.cat([k_und, k_gen], dim=2)
+        all_v = torch.cat([v_und, v_gen], dim=2)
+        all_valid_mask = torch.cat([und_valid_mask, gen_valid_mask], dim=1)
+        gen_attn_mask = all_valid_mask.view(batch_size, 1, 1, und_len + gen_len).expand(
+            batch_size, 1, gen_len, und_len + gen_len
+        )
+        full_out = F.scaled_dot_product_attention(
+            q_gen,
+            all_k,
+            all_v,
+            attn_mask=gen_attn_mask,
+            dropout_p=0.0,
+        )
+        full_out = full_out.transpose(1, 2).flatten(-2, -1)
+
+        und_out = attn.to_out(causal_out) * und_valid_mask.unsqueeze(-1)
+        gen_out = attn.to_add_out(full_out) * gen_valid_mask.unsqueeze(-1)
+        return und_out, gen_out
+
+    def _repeat_kv_heads(self, hidden_states: Tensor, num_key_value_groups: int) -> Tensor:
+        if num_key_value_groups == 1:
+            return hidden_states
+        return hidden_states.repeat_interleave(num_key_value_groups, dim=2)
+
+    def _rotate_half(self, hidden_states: Tensor) -> Tensor:
+        half = hidden_states.shape[-1] // 2
+        return torch.cat((-hidden_states[..., half:], hidden_states[..., :half]), dim=-1)

--- a/src/lerobot/policies/cosmos3/processor_cosmos3.py
+++ b/src/lerobot/policies/cosmos3/processor_cosmos3.py
@@ -1,0 +1,629 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+import torch
+import torch.nn.functional as F  # noqa: N812
+from PIL import Image
+
+from lerobot.configs import PipelineFeatureType, PolicyFeature
+from lerobot.processor import (
+    AddBatchDimensionProcessorStep,
+    ComplementaryDataProcessorStep,
+    DeviceProcessorStep,
+    NormalizerProcessorStep,
+    PolicyAction,
+    PolicyProcessorPipeline,
+    ProcessorStep,
+    ProcessorStepRegistry,
+    RenameObservationsProcessorStep,
+    UnnormalizerProcessorStep,
+    policy_action_to_transition,
+    transition_to_policy_action,
+)
+from lerobot.types import TransitionKey
+from lerobot.utils.constants import (
+    OBS_STATE,
+    POLICY_POSTPROCESSOR_DEFAULT_NAME,
+    POLICY_PREPROCESSOR_DEFAULT_NAME,
+)
+from lerobot.utils.import_utils import require_package
+
+from .configuration_cosmos3 import Cosmos3Config
+
+COSMOS3_VIDEO = "cosmos3_video"
+COSMOS3_ACTION_CONDITION = "cosmos3_action_condition"
+COSMOS3_ACTION_CONDITION_MASK = "cosmos3_action_condition_mask"
+COSMOS3_ACTION_DOMAIN_ID = "cosmos3_action_domain_id"
+COSMOS3_CONDITIONING_FPS = "cosmos3_conditioning_fps"
+COSMOS3_RAW_ACTION_DIM = "cosmos3_raw_action_dim"
+COSMOS3_CLEAN_ACTION = "cosmos3_clean_action"
+COSMOS3_PROMPT = "cosmos3_prompt"
+COSMOS3_FORMATTED_PROMPT = "cosmos3_formatted_prompt"
+COSMOS3_COND_INPUT_IDS = "cosmos3_cond_input_ids"
+COSMOS3_UNCOND_INPUT_IDS = "cosmos3_uncond_input_ids"
+COSMOS3_TRAINING_SIGMA = "cosmos3_training_sigma"
+
+COSMOS3_VISION_START_TOKEN = "<|vision_start|>"  # nosec B105
+COSMOS3_VISION_END_TOKEN = "<|vision_end|>"  # nosec B105
+
+_VIEWPOINT_TEMPLATES = {
+    "concat_view": "This video contains concatenated views from multiple camera perspectives.",
+    "ego_view": "This video is captured from a first-person perspective looking at the scene.",
+    "third_person_view": "This video is captured from a third-person perspective looking towards the agent from the front.",
+    "wrist_view": "This video is captured from a wrist-mounted camera.",
+}
+
+
+def _as_batched_image_tensor(image: torch.Tensor) -> torch.Tensor:
+    if image.ndim == 3:
+        image = image.unsqueeze(0)
+    elif image.ndim != 4:
+        raise ValueError(f"Expected image tensor with 3 or 4 dims, got shape={tuple(image.shape)}")
+
+    if image.shape[-1] in {1, 3, 4}:
+        image = image.permute(0, 3, 1, 2)
+    elif image.shape[1] not in {1, 3, 4}:
+        raise ValueError(f"Could not infer image channel dimension from shape={tuple(image.shape)}")
+    if image.shape[1] == 4:
+        image = image[:, :3]
+    if image.shape[1] == 1:
+        image = image.expand(-1, 3, -1, -1)
+    return image.contiguous()
+
+
+def _as_batched_image_sequence_tensor(
+    image: torch.Tensor, *, sequence_length: int | None = None
+) -> torch.Tensor:
+    if image.ndim == 5:
+        if image.shape[2] in {1, 3, 4}:
+            image = image
+        elif image.shape[-1] in {1, 3, 4}:
+            image = image.permute(0, 1, 4, 2, 3)
+        else:
+            raise ValueError(f"Could not infer image channel dimension from shape={tuple(image.shape)}")
+        if image.shape[2] == 4:
+            image = image[:, :, :3]
+        if image.shape[2] == 1:
+            image = image.expand(-1, -1, 3, -1, -1)
+        return image.contiguous()
+
+    if image.ndim == 4 and sequence_length is not None and image.shape[0] == sequence_length:
+        if image.shape[1] in {1, 3, 4}:
+            image = image.unsqueeze(0)
+        elif image.shape[-1] in {1, 3, 4}:
+            image = image.permute(0, 3, 1, 2).unsqueeze(0)
+        else:
+            raise ValueError(f"Could not infer image channel dimension from shape={tuple(image.shape)}")
+        if image.shape[2] == 4:
+            image = image[:, :, :3]
+        if image.shape[2] == 1:
+            image = image.expand(-1, -1, 3, -1, -1)
+        return image.contiguous()
+
+    image = _as_batched_image_tensor(image)
+    return image.unsqueeze(1)
+
+
+def _to_uint8_nthwc(image: torch.Tensor, *, sequence_length: int | None = None) -> np.ndarray:
+    image = _as_batched_image_sequence_tensor(image, sequence_length=sequence_length)
+    if image.dtype.is_floating_point:
+        image = image.clamp(0.0, 1.0).mul(255.0)
+    image = image.round().clamp(0, 255).to(torch.uint8)
+    return image.permute(0, 1, 3, 4, 2).cpu().numpy()
+
+
+def resize_with_pad_uint8(images: np.ndarray, height: int, width: int) -> np.ndarray:
+    """Match RoboLab's openpi-client resize_with_pad behavior for NHWC uint8 images."""
+    if images.shape[-3:-1] == (height, width):
+        return images
+
+    original_shape = images.shape
+    images = images.reshape(-1, *original_shape[-3:])
+    resized = np.stack([_resize_with_pad_pil(Image.fromarray(im), height, width) for im in images])
+    return resized.reshape(*original_shape[:-3], *resized.shape[-3:])
+
+
+def _resize_with_pad_pil(image: Image.Image, height: int, width: int) -> np.ndarray:
+    cur_width, cur_height = image.size
+    if cur_width == width and cur_height == height:
+        return np.array(image)
+
+    ratio = max(cur_width / width, cur_height / height)
+    resized_height = int(cur_height / ratio)
+    resized_width = int(cur_width / ratio)
+    resized_image = image.resize((resized_width, resized_height), resample=Image.BILINEAR)
+
+    zero_image = Image.new(resized_image.mode, (width, height), 0)
+    pad_height = max(0, int((height - resized_height) / 2))
+    pad_width = max(0, int((width - resized_width) / 2))
+    zero_image.paste(resized_image, (pad_width, pad_height))
+    return np.array(zero_image)
+
+
+def compose_cosmos3_views(
+    views: list[torch.Tensor],
+    *,
+    primary_height: int,
+    composed_height: int,
+    composed_width: int,
+    sequence_length: int | None = None,
+) -> torch.Tensor:
+    """Tile camera views onto a single uint8 canvas.
+
+    ``views[0]`` is the primary view rendered full-width across the top
+    ``primary_height`` rows; the remaining views are resized and concatenated
+    left-to-right across the bottom ``composed_height - primary_height`` rows.
+    The layout generalizes to any number of views (RoboLab's wrist-on-top,
+    two-shoulder-bottom layout is the three-view default).
+
+    Returns ``[N, composed_height, composed_width, 3]`` for single-frame inputs
+    or ``[N, T, composed_height, composed_width, 3]`` for sequences.
+    """
+    if not views:
+        raise ValueError("compose_cosmos3_views requires at least one view.")
+
+    def _resize(view: torch.Tensor, height: int, width: int) -> np.ndarray:
+        return resize_with_pad_uint8(_to_uint8_nthwc(view, sequence_length=sequence_length), height, width)
+
+    if len(views) == 1:
+        composed = _resize(views[0], composed_height, composed_width)
+    else:
+        primary = _resize(views[0], primary_height, composed_width)
+        bottom_views = views[1:]
+        bottom_height = composed_height - primary_height
+        tile_width = composed_width // len(bottom_views)
+        tiles = [_resize(view, bottom_height, tile_width) for view in bottom_views]
+        bottom = np.concatenate(tiles, axis=-2)
+        if bottom.shape[-2] < composed_width:
+            pad_width = composed_width - bottom.shape[-2]
+            pad_spec = [(0, 0)] * (bottom.ndim - 2) + [(0, pad_width), (0, 0)]
+            bottom = np.pad(bottom, pad_spec)
+        composed = np.concatenate((primary, bottom), axis=-3)
+
+    composed_tensor = torch.from_numpy(composed)
+    if composed_tensor.shape[1] == 1:  # squeeze the singleton time axis for single frames
+        return composed_tensor[:, 0]
+    return composed_tensor
+
+
+def _normalise_prompt_list(prompts: Any, batch_size: int) -> list[str]:
+    if isinstance(prompts, str):
+        return [prompts] * batch_size
+    if isinstance(prompts, tuple):
+        prompts = list(prompts)
+    if isinstance(prompts, list) and len(prompts) == batch_size and all(isinstance(p, str) for p in prompts):
+        return prompts
+    raise ValueError(f"Expected a prompt string or list[str] with batch_size={batch_size}, got {prompts!r}")
+
+
+def _append_sentence(text: str, addition: str) -> str:
+    if not addition:
+        return text
+    if not text:
+        return addition
+    separator = " " if text.rstrip().endswith(".") else ". "
+    return text.rstrip() + separator + addition
+
+
+def classify_cosmos3_action_size(
+    source_height: int,
+    source_width: int,
+    *,
+    resolution_tier: int,
+) -> tuple[int, int, int, int]:
+    # Reuse Cosmos3's trained resolution buckets straight from Diffusers as the
+    # single source of truth. This is a deliberate exception to the "no Diffusers
+    # internals" rule for one model-defined constant; the diffusers commit is
+    # pinned in pyproject. Imported lazily to keep diffusers an optional extra.
+    require_package("diffusers", extra="cosmos3")
+    from diffusers.pipelines.cosmos.pipeline_cosmos3_omni import _ACTION_RESOLUTION_BINS
+
+    resolution_key = str(resolution_tier)
+    if resolution_key not in _ACTION_RESOLUTION_BINS:
+        raise ValueError(
+            f"Unsupported action resolution_tier={resolution_tier!r}; "
+            f"expected one of {sorted(int(k) for k in _ACTION_RESOLUTION_BINS)}."
+        )
+
+    aspect_ratio = source_height / source_width
+    ratios = _ACTION_RESOLUTION_BINS[resolution_key]
+    target_height, target_width = min(
+        ratios.values(),
+        key=lambda size: abs((size[0] / size[1]) - aspect_ratio),
+    )
+    scale = min(target_width / source_width, target_height / source_height, 1.0)
+    content_height = max(1, int(scale * source_height + 0.5))
+    content_width = max(1, int(scale * source_width + 0.5))
+    return target_height, target_width, content_height, content_width
+
+
+def format_cosmos3_action_prompt(
+    prompt: str,
+    *,
+    viewpoint: str,
+    additional_view_description: str,
+    num_frames: int,
+    height: int,
+    width: int,
+    fps: float,
+) -> str:
+    caption = prompt.rstrip()
+    viewpoint_text = _VIEWPOINT_TEMPLATES.get(viewpoint)
+    if viewpoint_text is not None:
+        additional_view_description = additional_view_description.rstrip()
+        if additional_view_description:
+            viewpoint_text = _append_sentence(viewpoint_text, additional_view_description)
+        caption = _append_sentence(caption, viewpoint_text)
+
+    duration = int(num_frames / fps) if fps > 0 else 0
+    caption = _append_sentence(caption, f"The video is {duration:.1f} seconds long and is of {fps:.0f} FPS.")
+    caption = _append_sentence(caption, f"This video is of {height}x{width} resolution.")
+    return caption
+
+
+def add_cosmos3_special_tokens(tokenizer: Any) -> dict[str, int]:
+    existing_special_tokens: list[str] = []
+    for value in tokenizer.special_tokens_map.values():
+        if isinstance(value, str):
+            existing_special_tokens.append(value)
+        elif isinstance(value, list):
+            existing_special_tokens.extend(value)
+
+    tokens_to_add = []
+    if COSMOS3_VISION_START_TOKEN not in existing_special_tokens:
+        tokens_to_add.append(COSMOS3_VISION_START_TOKEN)
+    if COSMOS3_VISION_END_TOKEN not in existing_special_tokens:
+        tokens_to_add.append(COSMOS3_VISION_END_TOKEN)
+    if tokens_to_add:
+        tokenizer.add_tokens(tokens_to_add)
+
+    return {
+        "start_of_generation": tokenizer.convert_tokens_to_ids(COSMOS3_VISION_START_TOKEN),
+        "end_of_generation": tokenizer.convert_tokens_to_ids(COSMOS3_VISION_END_TOKEN),
+        "eos_token_id": tokenizer.eos_token_id,
+    }
+
+
+@dataclass
+@ProcessorStepRegistry.register(name="cosmos3_pack_inputs")
+class Cosmos3PackInputsStep(ComplementaryDataProcessorStep):
+    """Pack raw multi-view observations into Cosmos3 model inputs.
+
+    Generic over the data source: any ordered ``image_keys`` are composed into a
+    single conditioning video, and the proprioceptive state is validated/padded
+    against ``max_state_dim``. RoboLab's DROID cameras are only the default config.
+    """
+
+    image_keys: list[str]
+    num_views: int
+    image_height: int
+    chunk_size: int
+    raw_action_dim: int
+    max_action_dim: int
+    max_state_dim: int
+    use_state: bool
+    history_length: int
+    invert_gripper: bool
+    domain_id: int
+    conditioning_fps: float
+    resolution_tier: int
+    viewpoint: str
+    additional_view_description: str
+    prompt_key: str = "task"
+    composed_image_height: int = 540
+    composed_image_width: int = 640
+
+    def complementary_data(self, complementary_data: dict[str, Any]) -> dict[str, Any]:
+        observation = self.transition.get(TransitionKey.OBSERVATION)
+        if observation is None:
+            raise ValueError("Observation is required for Cosmos3PackInputsStep.")
+
+        views = []
+        for image_key in self.image_keys:
+            view = observation.get(image_key)
+            if view is None:
+                raise ValueError(
+                    f"Cosmos3 expected image observation {image_key!r} (image_keys={self.image_keys})."
+                )
+            views.append(view)
+        if len(views) > self.num_views:
+            raise ValueError(f"Got {len(views)} image views but num_views={self.num_views}.")
+        while len(views) < self.num_views:  # pad missing views with a blank frame
+            views.append(torch.zeros_like(views[0]))
+
+        composed = compose_cosmos3_views(
+            views,
+            primary_height=self.image_height,
+            composed_height=self.composed_image_height,
+            composed_width=self.composed_image_width,
+            sequence_length=self.chunk_size + 1,
+        )
+        if composed.shape[-3:-1] != (self.composed_image_height, self.composed_image_width):
+            raise ValueError(
+                "Unexpected composed Cosmos3 image shape: "
+                f"{tuple(composed.shape[-3:-1])}, expected {(self.composed_image_height, self.composed_image_width)}."
+            )
+
+        batch_size = composed.shape[0]
+        if composed.ndim == 4:
+            video = torch.zeros(
+                batch_size,
+                3,
+                self.chunk_size + 1,
+                self.composed_image_height,
+                self.composed_image_width,
+                dtype=torch.uint8,
+            )
+            video[:, :, 0] = composed.permute(0, 3, 1, 2)
+        elif composed.ndim == 5:
+            if composed.shape[1] < self.chunk_size + 1:
+                pad = composed[:, -1:].expand(-1, self.chunk_size + 1 - composed.shape[1], -1, -1, -1)
+                composed = torch.cat([composed, pad], dim=1)
+            composed = composed[:, : self.chunk_size + 1]
+            video = composed.permute(0, 4, 1, 2, 3).contiguous()
+        else:
+            raise ValueError(f"Unexpected composed Cosmos3 image rank: {composed.ndim}")
+
+        action_len = self.chunk_size + int(self.use_state)
+        action_condition = torch.zeros(batch_size, action_len, self.raw_action_dim, dtype=torch.float32)
+        action_condition_mask = torch.zeros(batch_size, action_len, 1, dtype=torch.float32)
+        if self.use_state:
+            state = observation.get(OBS_STATE)
+            if state is None:
+                raise ValueError(f"{OBS_STATE} is required when Cosmos3 use_state=True.")
+            if state.ndim == 3:
+                state = state[:, 0]
+            if state.ndim == 2 and state.shape[0] != batch_size and state.shape[0] == self.chunk_size + 1:
+                state = state[:1]
+            if state.ndim == 1:
+                state = state.unsqueeze(0)
+            state = state.to(dtype=torch.float32)
+            if state.shape[0] != batch_size:
+                raise ValueError("Batch size mismatch between Cosmos3 images and state.")
+            state_dim = state.shape[-1]
+            if state_dim > self.max_state_dim:
+                raise ValueError(
+                    f"Cosmos3 state width {state_dim} exceeds max_state_dim={self.max_state_dim}."
+                )
+            if state_dim < self.raw_action_dim:
+                state = F.pad(state, (0, self.raw_action_dim - state_dim))
+            else:
+                state = state[:, : self.raw_action_dim].clone()
+            if self.invert_gripper:
+                state[:, -1] = 1.0 - state[:, -1]
+            action_condition[:, 0] = state
+            action_condition_mask[:, 0, 0] = 1.0
+
+        action = self.transition.get(TransitionKey.ACTION)
+        if action is not None:
+            if action.ndim == 2:
+                action = action.unsqueeze(0)
+            if action.ndim != 3:
+                raise ValueError(
+                    f"Cosmos3 training action must have shape [B,T,D], got {tuple(action.shape)}."
+                )
+            if action.shape[0] != batch_size:
+                raise ValueError("Batch size mismatch between Cosmos3 images and actions.")
+            action = action[:, : self.chunk_size, : self.raw_action_dim].to(dtype=torch.float32).clone()
+            if self.invert_gripper:
+                action[:, :, -1] = 1.0 - action[:, :, -1]
+            clean_action = torch.zeros(batch_size, action_len, self.max_action_dim, dtype=torch.float32)
+            clean_action[:, :, : self.raw_action_dim] = action_condition
+            future_start = int(self.use_state)
+            clean_action[:, future_start : future_start + action.shape[1], : self.raw_action_dim] = action
+            complementary_data[COSMOS3_CLEAN_ACTION] = clean_action
+
+        prompts = _normalise_prompt_list(complementary_data.get(self.prompt_key), batch_size)
+        target_height, target_width, _content_height, _content_width = classify_cosmos3_action_size(
+            self.composed_image_height,
+            self.composed_image_width,
+            resolution_tier=self.resolution_tier,
+        )
+        formatted_prompts = [
+            format_cosmos3_action_prompt(
+                prompt,
+                viewpoint=self.viewpoint,
+                additional_view_description=self.additional_view_description,
+                num_frames=self.chunk_size + 1,
+                height=target_height,
+                width=target_width,
+                fps=self.conditioning_fps,
+            )
+            for prompt in prompts
+        ]
+        complementary_data[COSMOS3_PROMPT] = prompts
+        complementary_data[COSMOS3_FORMATTED_PROMPT] = formatted_prompts
+        complementary_data[COSMOS3_VIDEO] = video
+        complementary_data[COSMOS3_ACTION_CONDITION] = action_condition
+        complementary_data[COSMOS3_ACTION_CONDITION_MASK] = action_condition_mask
+        complementary_data[COSMOS3_ACTION_DOMAIN_ID] = torch.full(
+            (batch_size,), self.domain_id, dtype=torch.long
+        )
+        complementary_data[COSMOS3_CONDITIONING_FPS] = torch.full(
+            (batch_size,), self.conditioning_fps, dtype=torch.float32
+        )
+        complementary_data[COSMOS3_RAW_ACTION_DIM] = torch.full(
+            (batch_size,), self.raw_action_dim, dtype=torch.long
+        )
+        return complementary_data
+
+    def transform_features(
+        self, features: dict[PipelineFeatureType, dict[str, PolicyFeature]]
+    ) -> dict[PipelineFeatureType, dict[str, PolicyFeature]]:
+        return features
+
+    def get_config(self) -> dict[str, Any]:
+        return {
+            "image_keys": self.image_keys,
+            "num_views": self.num_views,
+            "image_height": self.image_height,
+            "chunk_size": self.chunk_size,
+            "raw_action_dim": self.raw_action_dim,
+            "max_action_dim": self.max_action_dim,
+            "max_state_dim": self.max_state_dim,
+            "use_state": self.use_state,
+            "history_length": self.history_length,
+            "invert_gripper": self.invert_gripper,
+            "domain_id": self.domain_id,
+            "conditioning_fps": self.conditioning_fps,
+            "resolution_tier": self.resolution_tier,
+            "viewpoint": self.viewpoint,
+            "additional_view_description": self.additional_view_description,
+            "prompt_key": self.prompt_key,
+            "composed_image_height": self.composed_image_height,
+            "composed_image_width": self.composed_image_width,
+        }
+
+
+@dataclass
+@ProcessorStepRegistry.register(name="cosmos3_qwen_prompt_tokenizer")
+class Cosmos3QwenPromptTokenizerStep(ComplementaryDataProcessorStep):
+    processor_name: str
+    local_files_only: bool = True
+
+    _tokenizer: Any | None = field(default=None, init=False, repr=False)
+    _special_tokens: dict[str, int] = field(default_factory=dict, init=False, repr=False)
+
+    def __post_init__(self):
+        require_package("transformers", extra="cosmos3")
+        try:
+            from transformers import Qwen3VLProcessor
+
+            processor = Qwen3VLProcessor.from_pretrained(
+                self.processor_name,
+                local_files_only=self.local_files_only,
+            )
+            tokenizer = processor.tokenizer
+        except (OSError, ValueError, ImportError):
+            from transformers import AutoTokenizer
+
+            tokenizer = AutoTokenizer.from_pretrained(
+                self.processor_name,
+                local_files_only=self.local_files_only,
+            )
+
+        self._tokenizer = tokenizer
+        self._special_tokens = add_cosmos3_special_tokens(tokenizer)
+
+    def _tokenize(self, text: str) -> torch.Tensor:
+        input_ids = self._tokenizer.apply_chat_template(
+            [{"role": "user", "content": text}],
+            tokenize=True,
+            add_generation_prompt=True,
+            add_vision_id=False,
+            return_dict=False,
+        )
+        return torch.tensor(input_ids, dtype=torch.long)
+
+    def complementary_data(self, complementary_data: dict[str, Any]) -> dict[str, Any]:
+        prompts = complementary_data.get(COSMOS3_FORMATTED_PROMPT)
+        if prompts is None:
+            raise ValueError(f"{COSMOS3_FORMATTED_PROMPT} is required for Cosmos3 prompt tokenization.")
+        if isinstance(prompts, str):
+            prompts = [prompts]
+
+        cond_ids = [self._tokenize(prompt) for prompt in prompts]
+        uncond_ids = [self._tokenize("") for _ in prompts]
+        complementary_data[COSMOS3_COND_INPUT_IDS] = cond_ids
+        complementary_data[COSMOS3_UNCOND_INPUT_IDS] = uncond_ids
+        return complementary_data
+
+    def transform_features(
+        self, features: dict[PipelineFeatureType, dict[str, PolicyFeature]]
+    ) -> dict[PipelineFeatureType, dict[str, PolicyFeature]]:
+        return features
+
+    def get_config(self) -> dict[str, Any]:
+        return {
+            "processor_name": self.processor_name,
+            "local_files_only": self.local_files_only,
+        }
+
+
+def make_cosmos3_pre_post_processors(
+    config: Cosmos3Config,
+    dataset_stats: dict[str, dict[str, torch.Tensor]] | None = None,
+) -> tuple[
+    PolicyProcessorPipeline[dict[str, Any], dict[str, Any]],
+    PolicyProcessorPipeline[PolicyAction, PolicyAction],
+]:
+    config.validate_features()
+
+    input_steps: list[ProcessorStep] = [
+        RenameObservationsProcessorStep(rename_map={}),
+        AddBatchDimensionProcessorStep(),
+        NormalizerProcessorStep(
+            features={**config.input_features, **config.output_features},
+            norm_map=config.normalization_mapping,
+            stats=dataset_stats,
+        ),
+        Cosmos3PackInputsStep(
+            image_keys=config.image_keys,
+            num_views=config.num_views,
+            image_height=config.image_height,
+            composed_image_height=config.composed_image_height,
+            composed_image_width=config.composed_image_width,
+            chunk_size=config.chunk_size,
+            raw_action_dim=config.raw_action_dim,
+            max_action_dim=config.max_action_dim,
+            max_state_dim=config.max_state_dim,
+            use_state=config.use_state,
+            history_length=config.history_length,
+            invert_gripper=config.invert_gripper,
+            domain_id=config.domain_id,
+            conditioning_fps=config.conditioning_fps,
+            resolution_tier=config.resolution_tier,
+            viewpoint=config.viewpoint,
+            additional_view_description=config.additional_view_description,
+            prompt_key=config.prompt_key,
+        ),
+    ]
+    if config.text_processor_name_or_path is not None:
+        input_steps.append(
+            Cosmos3QwenPromptTokenizerStep(
+                processor_name=config.text_processor_name_or_path,
+                local_files_only=config.local_files_only,
+            )
+        )
+    input_steps.append(DeviceProcessorStep(device=config.device))
+
+    output_steps: list[ProcessorStep] = [
+        UnnormalizerProcessorStep(
+            features=config.output_features,
+            norm_map=config.normalization_mapping,
+            stats=dataset_stats,
+        ),
+        DeviceProcessorStep(device="cpu"),
+    ]
+
+    return (
+        PolicyProcessorPipeline[dict[str, Any], dict[str, Any]](
+            steps=input_steps,
+            name=POLICY_PREPROCESSOR_DEFAULT_NAME,
+        ),
+        PolicyProcessorPipeline[PolicyAction, PolicyAction](
+            steps=output_steps,
+            name=POLICY_POSTPROCESSOR_DEFAULT_NAME,
+            to_transition=policy_action_to_transition,
+            to_output=transition_to_policy_action,
+        ),
+    )

--- a/src/lerobot/policies/factory.py
+++ b/src/lerobot/policies/factory.py
@@ -45,6 +45,7 @@ from lerobot.utils.constants import (
 from lerobot.utils.feature_utils import dataset_to_policy_features
 
 from .act.configuration_act import ACTConfig
+from .cosmos3.configuration_cosmos3 import Cosmos3Config
 from .diffusion.configuration_diffusion import DiffusionConfig
 from .eo1.configuration_eo1 import EO1Config
 from .gaussian_actor.configuration_gaussian_actor import GaussianActorConfig
@@ -102,6 +103,10 @@ def get_policy_class(name: str) -> type[PreTrainedPolicy]:
         from .tdmpc.modeling_tdmpc import TDMPCPolicy
 
         return TDMPCPolicy
+    elif name == "cosmos3":
+        from .cosmos3.modeling_cosmos3 import Cosmos3Policy
+
+        return Cosmos3Policy
     elif name == "diffusion":
         from .diffusion.modeling_diffusion import DiffusionPolicy
 
@@ -190,6 +195,8 @@ def make_policy_config(policy_type: str, **kwargs) -> PreTrainedConfig:
     """
     if policy_type == "tdmpc":
         return TDMPCConfig(**kwargs)
+    elif policy_type == "cosmos3":
+        return Cosmos3Config(**kwargs)
     elif policy_type == "diffusion":
         return DiffusionConfig(**kwargs)
     elif policy_type == "act":
@@ -327,6 +334,14 @@ def make_pre_post_processors(
         from .tdmpc.processor_tdmpc import make_tdmpc_pre_post_processors
 
         processors = make_tdmpc_pre_post_processors(
+            config=policy_cfg,
+            dataset_stats=kwargs.get("dataset_stats"),
+        )
+
+    elif isinstance(policy_cfg, Cosmos3Config):
+        from .cosmos3.processor_cosmos3 import make_cosmos3_pre_post_processors
+
+        processors = make_cosmos3_pre_post_processors(
             config=policy_cfg,
             dataset_stats=kwargs.get("dataset_stats"),
         )

--- a/tests/policies/cosmos3/test_cosmos3.py
+++ b/tests/policies/cosmos3/test_cosmos3.py
@@ -1,0 +1,445 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+import torch
+
+from lerobot.configs import FeatureType, PolicyFeature
+from lerobot.policies.cosmos3 import modeling_cosmos3 as cosmos3_modeling
+from lerobot.policies.cosmos3.configuration_cosmos3 import (
+    COSMOS3_LEFT_IMAGE,
+    COSMOS3_RIGHT_IMAGE,
+    COSMOS3_WRIST_IMAGE,
+    Cosmos3Config,
+)
+from lerobot.policies.cosmos3.modeling_cosmos3 import (
+    Cosmos3Policy,
+    preprocess_action_video_batch,
+)
+from lerobot.policies.cosmos3.processor_cosmos3 import (
+    COSMOS3_ACTION_CONDITION,
+    COSMOS3_ACTION_CONDITION_MASK,
+    COSMOS3_ACTION_DOMAIN_ID,
+    COSMOS3_CLEAN_ACTION,
+    COSMOS3_COND_INPUT_IDS,
+    COSMOS3_CONDITIONING_FPS,
+    COSMOS3_PROMPT,
+    COSMOS3_RAW_ACTION_DIM,
+    COSMOS3_TRAINING_SIGMA,
+    COSMOS3_VIDEO,
+    format_cosmos3_action_prompt,
+    make_cosmos3_pre_post_processors,
+)
+from lerobot.policies.factory import get_policy_class, make_policy_config, make_pre_post_processors
+from lerobot.utils.constants import ACTION, OBS_STATE
+
+
+def make_config(**overrides) -> Cosmos3Config:
+    config = Cosmos3Config(
+        device="cpu",
+        transformer_config={
+            "hidden_size": 8,
+            "intermediate_size": 16,
+            "num_hidden_layers": 1,
+            "num_attention_heads": 2,
+            "num_key_value_heads": 1,
+            "head_dim": 4,
+            "patch_latent_dim": 4,
+            "latent_channel": 4,
+            "latent_patch_size": 1,
+            "action_dim": 64,
+            "action_gen": True,
+            "vocab_size": 128,
+            "rope_scaling": {"mrope_section": [2, 1, 1]},
+        },
+        vae_config={
+            "base_dim": 4,
+            "decoder_base_dim": 4,
+            "z_dim": 4,
+            "dim_mult": [1],
+            "num_res_blocks": 1,
+            "attn_scales": [],
+            "temperal_downsample": [],  # spellchecker:disable-line
+            "scale_factor_temporal": 1,
+            "scale_factor_spatial": 1,
+        },
+        scheduler_config={
+            "prediction_type": "flow_prediction",
+            "use_flow_sigmas": True,
+            "use_karras_sigmas": False,
+            "flow_shift": 5.0,
+        },
+        input_features={
+            COSMOS3_LEFT_IMAGE: PolicyFeature(type=FeatureType.VISUAL, shape=(3, 360, 640)),
+            COSMOS3_RIGHT_IMAGE: PolicyFeature(type=FeatureType.VISUAL, shape=(3, 360, 640)),
+            COSMOS3_WRIST_IMAGE: PolicyFeature(type=FeatureType.VISUAL, shape=(3, 360, 640)),
+            OBS_STATE: PolicyFeature(type=FeatureType.STATE, shape=(8,)),
+        },
+        output_features={ACTION: PolicyFeature(type=FeatureType.ACTION, shape=(8,))},
+    )
+    return dataclasses.replace(config, **overrides) if overrides else config
+
+
+def constant_image(value: int) -> torch.Tensor:
+    return torch.full((3, 360, 640), value / 255.0, dtype=torch.float32)
+
+
+def constant_image_sequence(value: int, num_frames: int) -> torch.Tensor:
+    return torch.full((1, num_frames, 3, 360, 640), value / 255.0, dtype=torch.float32)
+
+
+def test_cosmos3_factory_registration():
+    cfg = make_policy_config("cosmos3", device="cpu")
+
+    assert isinstance(cfg, Cosmos3Config)
+    assert get_policy_class("cosmos3") is Cosmos3Policy
+
+    preprocessor, postprocessor = make_pre_post_processors(cfg)
+    assert preprocessor.name == "policy_preprocessor"
+    assert postprocessor.name == "policy_postprocessor"
+
+
+def test_cosmos3_processor_packs_multi_view_inputs():
+    cfg = make_config()
+    preprocessor, _ = make_cosmos3_pre_post_processors(cfg)
+    state = torch.tensor([0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.25], dtype=torch.float32)
+
+    batch = {
+        COSMOS3_LEFT_IMAGE: constant_image(10),
+        COSMOS3_RIGHT_IMAGE: constant_image(20),
+        COSMOS3_WRIST_IMAGE: constant_image(30),
+        OBS_STATE: state,
+        "task": "Pick up the banana and place it in the bowl.",
+    }
+
+    processed = preprocessor(batch)
+    video = processed[COSMOS3_VIDEO]
+    action_condition = processed[COSMOS3_ACTION_CONDITION]
+    action_condition_mask = processed[COSMOS3_ACTION_CONDITION_MASK]
+
+    # Default layout: primary view (wrist) on top, the remaining views tile the bottom.
+    assert video.shape == (1, 3, 33, 540, 640)
+    assert torch.all(video[0, :, 0, :360] == 30)
+    assert torch.all(video[0, :, 0, 360:, :320] == 10)
+    assert torch.all(video[0, :, 0, 360:, 320:] == 20)
+    assert torch.count_nonzero(video[:, :, 1:]) == 0
+
+    assert action_condition.shape == (1, 33, 8)
+    expected_state = state.clone()
+    expected_state[-1] = 1.0 - expected_state[-1]
+    torch.testing.assert_close(action_condition[0, 0], expected_state)
+    assert torch.count_nonzero(action_condition[0, 1:]) == 0
+    torch.testing.assert_close(action_condition_mask[0, 0], torch.ones(1))
+    assert torch.count_nonzero(action_condition_mask[0, 1:]) == 0
+    assert processed[COSMOS3_PROMPT] == ["Pick up the banana and place it in the bowl."]
+
+
+def test_cosmos3_processor_pads_missing_views():
+    cfg = make_config(image_keys=[COSMOS3_WRIST_IMAGE], num_views=3)
+    preprocessor, _ = make_cosmos3_pre_post_processors(cfg)
+
+    batch = {
+        COSMOS3_WRIST_IMAGE: constant_image(30),
+        OBS_STATE: torch.zeros(8, dtype=torch.float32),
+        "task": "Do something useful.",
+    }
+
+    video = preprocessor(batch)[COSMOS3_VIDEO]
+    assert video.shape == (1, 3, 33, 540, 640)
+    # Single supplied view stays primary; the two padded views are blank.
+    assert torch.all(video[0, :, 0, :360] == 30)
+    assert torch.all(video[0, :, 0, 360:] == 0)
+
+
+def test_cosmos3_processor_pads_narrow_state_and_caps_wide_state():
+    cfg = make_config(max_state_dim=8)
+    preprocessor, _ = make_cosmos3_pre_post_processors(cfg)
+    images = {
+        COSMOS3_LEFT_IMAGE: constant_image(10),
+        COSMOS3_RIGHT_IMAGE: constant_image(20),
+        COSMOS3_WRIST_IMAGE: constant_image(30),
+        "task": "Do something useful.",
+    }
+
+    narrow = preprocessor({**images, OBS_STATE: torch.tensor([0.1, 0.2, 0.3, 0.4], dtype=torch.float32)})
+    action_condition = narrow[COSMOS3_ACTION_CONDITION]
+    assert action_condition.shape == (1, 33, 8)
+    torch.testing.assert_close(action_condition[0, 0, :4], torch.tensor([0.1, 0.2, 0.3, 0.4]))
+
+    with pytest.raises(ValueError, match="exceeds max_state_dim"):
+        preprocessor({**images, OBS_STATE: torch.zeros(16, dtype=torch.float32)})
+
+
+def test_cosmos3_processor_packs_training_video_and_clean_actions():
+    cfg = make_config()
+    preprocessor, _ = make_cosmos3_pre_post_processors(cfg)
+    state = torch.zeros(1, cfg.chunk_size + 1, 8, dtype=torch.float32)
+    state[:, :, -1] = 0.25
+    actions = torch.zeros(1, cfg.chunk_size, 8, dtype=torch.float32)
+    actions[:, :, -1] = 0.75
+
+    batch = {
+        COSMOS3_LEFT_IMAGE: constant_image_sequence(10, cfg.chunk_size + 1),
+        COSMOS3_RIGHT_IMAGE: constant_image_sequence(20, cfg.chunk_size + 1),
+        COSMOS3_WRIST_IMAGE: constant_image_sequence(30, cfg.chunk_size + 1),
+        OBS_STATE: state,
+        ACTION: actions,
+        "task": ["Pick up the banana and place it in the bowl."],
+    }
+
+    processed = preprocessor(batch)
+
+    assert processed[COSMOS3_VIDEO].shape == (1, 3, cfg.chunk_size + 1, 540, 640)
+
+    clean_action = processed[COSMOS3_CLEAN_ACTION]
+    assert clean_action.shape == (1, cfg.chunk_size + 1, cfg.max_action_dim)
+    torch.testing.assert_close(clean_action[0, 0, :8], torch.tensor([0, 0, 0, 0, 0, 0, 0, 0.75]).float())
+    torch.testing.assert_close(clean_action[0, 1, :8], torch.tensor([0, 0, 0, 0, 0, 0, 0, 0.25]).float())
+    assert torch.count_nonzero(clean_action[..., 8:]) == 0
+
+
+def test_cosmos3_formats_action_prompt():
+    prompt = format_cosmos3_action_prompt(
+        "Pick up the banana and place it in the bowl.",
+        viewpoint="concat_view",
+        additional_view_description=(
+            "The top row is from the wrist-mounted camera. "
+            "The bottom row contains two horizontally concatenated third-person perspective views of the scene from "
+            "opposite sides, with the robot visible."
+        ),
+        num_frames=33,
+        height=544,
+        width=736,
+        fps=15.0,
+    )
+
+    assert prompt == (
+        "Pick up the banana and place it in the bowl. "
+        "This video contains concatenated views from multiple camera perspectives. "
+        "The top row is from the wrist-mounted camera. "
+        "The bottom row contains two horizontally concatenated third-person perspective views of the scene from "
+        "opposite sides, with the robot visible. "
+        "The video is 2.0 seconds long and is of 15 FPS. "
+        "This video is of 544x736 resolution."
+    )
+
+
+def test_cosmos3_preprocess_action_video_batch_resizes_and_normalizes():
+    video = torch.zeros(2, 3, 33, 540, 640, dtype=torch.uint8)
+    video[:, :, 0] = torch.tensor([10, 20, 30], dtype=torch.uint8).view(1, 3, 1, 1)
+
+    frames, image_size, height, width = preprocess_action_video_batch(
+        video,
+        resolution_tier=480,
+        num_frames=33,
+        device="cpu",
+        dtype=torch.float32,
+    )
+
+    assert frames.shape == (2, 3, 33, 544, 736)
+    torch.testing.assert_close(image_size, torch.tensor([544.0, 736.0, 540.0, 640.0]))
+    assert (height, width) == (544, 736)
+    torch.testing.assert_close(frames[0, :, 0, 0, 0], torch.tensor([10, 20, 30]) / 127.5 - 1.0)
+
+
+def test_cosmos3_select_action_uses_chunk_queue(monkeypatch):
+    policy = Cosmos3Policy(make_config())
+    fixed_chunk = torch.arange(32 * 8, dtype=torch.float32).view(1, 32, 8)
+    sample_calls = {"count": 0}
+
+    def fake_sample_actions(batch, **kwargs):
+        sample_calls["count"] += 1
+        return fixed_chunk
+
+    monkeypatch.setattr(policy.model, "sample_actions", fake_sample_actions)
+
+    action_0 = policy.select_action({})
+    action_1 = policy.select_action({})
+
+    torch.testing.assert_close(action_0, fixed_chunk[:, 0])
+    torch.testing.assert_close(action_1, fixed_chunk[:, 1])
+    assert sample_calls["count"] == 1
+
+
+def test_cosmos3_masked_flow_matching_mse_uses_per_sample_batch_denominator():
+    policy = Cosmos3Policy(make_config())
+    pred = torch.tensor([[10.0, 0.0], [2.0, 4.0]])
+    target = torch.zeros_like(pred)
+    noisy_mask = torch.tensor([[1.0, 0.0], [1.0, 1.0]])
+
+    torch.testing.assert_close(
+        policy.model._masked_flow_matching_mse_by_sample(pred, target, noisy_mask),
+        torch.tensor(30.0),
+    )
+
+    policy.config.normalize_loss_by_active = True
+    torch.testing.assert_close(
+        policy.model._masked_flow_matching_mse_by_sample(pred, target, noisy_mask),
+        torch.tensor(55.0),
+    )
+
+
+def test_cosmos3_forward_uses_batched_training_loss(monkeypatch):
+    cfg = make_config()
+    cfg.dtype = "float32"
+    cfg.eos_token_id = 5
+    cfg.start_of_generation_token_id = 6
+    policy = Cosmos3Policy(cfg)
+    batch_size = 2
+    sequence_length = 3
+    clean_vision = torch.zeros(batch_size, 4, 2, 2, 2)
+    calls = {"batch": 0}
+
+    def fake_video_conditioning(videos, **kwargs):
+        return clean_vision, torch.tensor([2.0, 2.0, 2.0, 2.0]), 2, 2
+
+    def fake_predict_velocity_batch(**kwargs):
+        calls["batch"] += 1
+        assert len(kwargs["packed_samples"]) == batch_size
+        assert kwargs["vision_tokens"].shape[0] == batch_size
+        assert kwargs["action_tokens"].shape[0] == batch_size
+        return torch.zeros_like(kwargs["vision_tokens"]), torch.zeros_like(kwargs["action_tokens"])
+
+    monkeypatch.setattr(cosmos3_modeling, "preprocess_action_video_batch", fake_video_conditioning)
+    monkeypatch.setattr(policy.model, "_encode_video", lambda video: video)
+    monkeypatch.setattr(policy.model, "_predict_velocity_batch", fake_predict_velocity_batch)
+
+    batch = {
+        COSMOS3_VIDEO: torch.zeros(batch_size, 3, sequence_length, 4, 4, dtype=torch.uint8),
+        COSMOS3_ACTION_CONDITION: torch.zeros(batch_size, sequence_length, cfg.raw_action_dim),
+        COSMOS3_ACTION_CONDITION_MASK: torch.tensor([[[1.0], [0.0], [0.0]]] * batch_size),
+        COSMOS3_ACTION_DOMAIN_ID: torch.full((batch_size,), cfg.domain_id),
+        COSMOS3_CONDITIONING_FPS: torch.full((batch_size,), 15.0),
+        COSMOS3_RAW_ACTION_DIM: torch.full((batch_size,), cfg.raw_action_dim),
+        COSMOS3_COND_INPUT_IDS: [torch.tensor([1, 2]), torch.tensor([1, 2, 3])],
+        COSMOS3_CLEAN_ACTION: torch.zeros(batch_size, sequence_length, cfg.max_action_dim),
+        COSMOS3_TRAINING_SIGMA: torch.full((batch_size, 1), 0.5),
+    }
+
+    loss, metrics = policy.model(batch)
+
+    assert calls["batch"] == 1
+    assert not hasattr(policy.model, "_predict_velocity")
+    assert loss.ndim == 0
+    assert set(metrics) == {"loss", "flow_matching_loss_vision", "flow_matching_loss_action"}
+
+
+def test_cosmos3_batched_velocity_treats_single_sample_as_batch_case():
+    cfg = make_config()
+    cfg.dtype = "float32"
+    cfg.eos_token_id = 5
+    cfg.start_of_generation_token_id = 6
+    policy = Cosmos3Policy(cfg)
+    policy.eval()
+
+    vision_tokens = torch.randn(2, 4, 2, 2, 2)
+    action_tokens = torch.randn(2, 3, cfg.max_action_dim)
+    cond_input_ids = [torch.tensor([1, 2, 3], dtype=torch.long), torch.tensor([1, 2], dtype=torch.long)]
+
+    single_packed_samples = policy.model._pack_batch_static(
+        cond_input_ids=[cond_input_ids[0]],
+        vision_tokens=vision_tokens[:1],
+        action_tokens=action_tokens[:1],
+        conditioning_fps=torch.tensor([15.0]),
+    )
+    batch_packed_samples = policy.model._pack_batch_static(
+        cond_input_ids=cond_input_ids,
+        vision_tokens=vision_tokens,
+        action_tokens=action_tokens,
+        conditioning_fps=torch.tensor([15.0, 12.0]),
+    )
+    single_vision_timesteps = [
+        torch.full((sample["num_noisy_vision_tokens"],), 3.0) for sample in single_packed_samples
+    ]
+    single_action_timesteps = [
+        torch.full((sample["num_noisy_action_tokens"],), 3.0) for sample in single_packed_samples
+    ]
+    batch_vision_timesteps = [
+        torch.full((sample["num_noisy_vision_tokens"],), 3.0) for sample in batch_packed_samples
+    ]
+    batch_action_timesteps = [
+        torch.full((sample["num_noisy_action_tokens"],), 3.0) for sample in batch_packed_samples
+    ]
+    vision_condition_mask = torch.tensor([[[[[1.0]], [[0.0]]]]])
+    action_condition_mask = torch.tensor([[[1.0], [0.0], [0.0]], [[1.0], [0.0], [0.0]]])
+
+    with torch.no_grad():
+        single_vision, single_action = policy.model._predict_velocity_batch(
+            packed_samples=single_packed_samples,
+            vision_tokens=vision_tokens[:1],
+            action_tokens=action_tokens[:1],
+            vision_timesteps=single_vision_timesteps,
+            action_timesteps=single_action_timesteps,
+            action_domain_ids=torch.tensor([cfg.domain_id]),
+            vision_condition_mask=vision_condition_mask,
+            action_condition_mask=action_condition_mask[:1],
+            raw_action_dims=torch.tensor([cfg.raw_action_dim]),
+        )
+        batch_vision, batch_action = policy.model._predict_velocity_batch(
+            packed_samples=batch_packed_samples,
+            vision_tokens=vision_tokens,
+            action_tokens=action_tokens,
+            vision_timesteps=batch_vision_timesteps,
+            action_timesteps=batch_action_timesteps,
+            action_domain_ids=torch.tensor([cfg.domain_id, cfg.domain_id]),
+            vision_condition_mask=vision_condition_mask,
+            action_condition_mask=action_condition_mask,
+            raw_action_dims=torch.tensor([cfg.raw_action_dim, cfg.raw_action_dim]),
+        )
+
+    torch.testing.assert_close(batch_vision[:1], single_vision)
+    torch.testing.assert_close(batch_action[:1], single_action)
+
+
+def test_cosmos3_batched_velocity_supports_variable_text_lengths():
+    cfg = make_config()
+    cfg.dtype = "float32"
+    cfg.eos_token_id = 5
+    cfg.start_of_generation_token_id = 6
+    policy = Cosmos3Policy(cfg)
+    policy.eval()
+
+    vision_tokens = torch.randn(2, 4, 2, 2, 2)
+    action_tokens = torch.randn(2, 3, cfg.max_action_dim)
+    cond_input_ids = [torch.tensor([1, 2]), torch.tensor([1, 2, 3, 4])]
+    packed_samples = policy.model._pack_batch_static(
+        cond_input_ids=cond_input_ids,
+        vision_tokens=vision_tokens,
+        action_tokens=action_tokens,
+        conditioning_fps=torch.tensor([15.0, 15.0]),
+    )
+    vision_timesteps = [torch.full((sample["num_noisy_vision_tokens"],), 3.0) for sample in packed_samples]
+    action_timesteps = [torch.full((sample["num_noisy_action_tokens"],), 3.0) for sample in packed_samples]
+
+    with torch.no_grad():
+        batch_vision, batch_action = policy.model._predict_velocity_batch(
+            packed_samples=packed_samples,
+            vision_tokens=vision_tokens,
+            action_tokens=action_tokens,
+            vision_timesteps=vision_timesteps,
+            action_timesteps=action_timesteps,
+            action_domain_ids=torch.tensor([cfg.domain_id, cfg.domain_id]),
+            vision_condition_mask=torch.tensor([[[[[1.0]], [[0.0]]]]]),
+            action_condition_mask=torch.tensor([[[1.0], [0.0], [0.0]], [[1.0], [0.0], [0.0]]]),
+            raw_action_dims=torch.tensor([cfg.raw_action_dim, cfg.raw_action_dim]),
+        )
+
+    assert batch_vision.shape == vision_tokens.shape
+    assert batch_action.shape == action_tokens.shape

--- a/uv.lock
+++ b/uv.lock
@@ -68,8 +68,8 @@ dependencies = [
     { name = "psutil" },
     { name = "pyyaml" },
     { name = "safetensors" },
-    { name = "torch", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
-    { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform == 'linux'" },
+    { name = "torch", version = "2.10.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
+    { name = "torch", version = "2.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ca/14/787e5498cd062640f0f3d92ef4ae4063174f76f9afd29d13fc52a319daae/accelerate-1.13.0.tar.gz", hash = "sha256:d631b4e0f5b3de4aff2d7e9e6857d164810dfc3237d54d017f075122d057b236", size = 402835, upload-time = "2026-03-04T19:34:12.359Z" }
 wheels = [
@@ -352,38 +352,45 @@ wheels = [
 
 [[package]]
 name = "av"
-version = "15.1.0"
+version = "16.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e9/c3/83e6e73d1592bc54436eae0bc61704ae0cff0c3cfbde7b58af9ed67ebb49/av-15.1.0.tar.gz", hash = "sha256:39cda2dc810e11c1938f8cb5759c41d6b630550236b3365790e67a313660ec85", size = 3774192, upload-time = "2025-08-30T04:41:56.076Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/cd/3a83ffbc3cc25b39721d174487fb0d51a76582f4a1703f98e46170ce83d4/av-16.1.0.tar.gz", hash = "sha256:a094b4fd87a3721dacf02794d3d2c82b8d712c85b9534437e82a8a978c175ffd", size = 4285203, upload-time = "2026-01-11T07:31:33.772Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/58/de78b276d20db6ffcd4371283df771721a833ba525a3d57e753d00a9fe79/av-15.1.0-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:40c5df37f4c354ab8190c6fd68dab7881d112f527906f64ca73da4c252a58cee", size = 21760991, upload-time = "2025-08-30T04:40:00.801Z" },
-    { url = "https://files.pythonhosted.org/packages/56/cc/45f85775304ae60b66976360d82ba5b152ad3fd91f9267d5020a51e9a828/av-15.1.0-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:af455ce65ada3d361f80c90c810d9bced4db5655ab9aa513024d6c71c5c476d5", size = 26953097, upload-time = "2025-08-30T04:40:03.998Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/f8/2d781e5e71d02fc829487e775ccb1185e72f95340d05f2e84eb57a11e093/av-15.1.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:86226d2474c80c3393fa07a9c366106029ae500716098b72b3ec3f67205524c3", size = 38319710, upload-time = "2025-08-30T04:40:07.701Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/13/37737ef2193e83862ccacff23580c39de251da456a1bf0459e762cca273c/av-15.1.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:11326f197e7001c4ca53a83b2dbc67fd39ddff8cdf62ce6be3b22d9f3f9338bd", size = 39915519, upload-time = "2025-08-30T04:40:11.066Z" },
-    { url = "https://files.pythonhosted.org/packages/26/e9/e8032c7b8f2a4129a03f63f896544f8b7cf068e2db2950326fa2400d5c47/av-15.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a631ea879cc553080ee62874f4284765c42ba08ee0279851a98a85e2ceb3cc8d", size = 40286166, upload-time = "2025-08-30T04:40:14.561Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/23/612c0fd809444d04b8387a2dfd942ccc77829507bd78a387ff65a9d98c24/av-15.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8f383949b010c3e731c245f80351d19dc0c08f345e194fc46becb1cb279be3ff", size = 41150592, upload-time = "2025-08-30T04:40:17.951Z" },
-    { url = "https://files.pythonhosted.org/packages/15/74/6f8e38a3b0aea5f28e72813672ff45b64615f2c69e6a4a558718c95edb9f/av-15.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:d5921aa45f4c1f8c1a8d8185eb347e02aa4c3071278a2e2dd56368d54433d643", size = 31336093, upload-time = "2025-08-30T04:40:21.393Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/bc/78b2ffa8235eeffc29aa4a8cc47b02e660cfec32f601f39a00975fb06d0e/av-15.1.0-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:2f77853c3119c59d1bff4214ccbe46e3133eccff85ed96adee51c68684443f4e", size = 21726244, upload-time = "2025-08-30T04:40:24.14Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/99/66d69453a2dce028e6e8ebea085d90e880aac03d3a3ab7d8ec16755ffd75/av-15.1.0-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:c0bc4471c156a0a1c70a607502434f477bc8dfe085eef905e55b4b0d66bcd3a5", size = 26918663, upload-time = "2025-08-30T04:40:27.557Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/51/1a7dfbeda71f2772bc46d758af0e7fab1cc8388ce4bc7f24aecbc4bfd764/av-15.1.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:37839d4fa1407f047af82560dfc0f94d8d6266071eff49e1cbe16c4483054621", size = 38041408, upload-time = "2025-08-30T04:40:30.811Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/97/2c4e0288ad4359b6064cb06ae79c2ff3a84ac73d27e91f2161b75fcd86fa/av-15.1.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:729179cd8622815e8b6f6854d13a806fe710576e08895c77e5e4ad254609de9a", size = 39642563, upload-time = "2025-08-30T04:40:34.617Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/94/2362502149e276d00957edabcc201a5f4d5109a8a7b4fd30793714a532f3/av-15.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4abdf085bfa4eec318efccff567831b361ea56c045cc38366811552e3127c665", size = 40022119, upload-time = "2025-08-30T04:40:37.703Z" },
-    { url = "https://files.pythonhosted.org/packages/df/58/1a0ce1b3835d9728da0a7a54aeffaa0a2b1a88405eaed9322efd55212a54/av-15.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f985661644879e4520d28a995fcb2afeb951bc15a1d51412eb8e5f36da85b6fe", size = 40885158, upload-time = "2025-08-30T04:40:40.952Z" },
-    { url = "https://files.pythonhosted.org/packages/30/e6/054bb64e424d90b77ed5fc6a7358e4013fb436154c998fc90a89a186313f/av-15.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:7d7804a44c8048bb4b014a99353dd124663a12cd1d4613ba2bd3b457c3b1d539", size = 31312256, upload-time = "2025-08-30T04:40:44.224Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/8b/89eae6dca10d7d2b83c131025a31ccc750be78699ac0304439faa1d1df99/av-15.1.0-cp314-cp314-macosx_13_0_arm64.whl", hash = "sha256:5dd73c6447947edcb82e5fecf96e1f146aeda0f169c7ad4c54df4d9f66f63fde", size = 21730645, upload-time = "2025-08-30T04:40:47.259Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/f0/abffaf69405ed68041524be12a1e294faf396971d6a0e70eb00e93687df7/av-15.1.0-cp314-cp314-macosx_13_0_x86_64.whl", hash = "sha256:a81cd515934a5d51290aa66b059b7ed29c4a212e704f3c5e99e32877ff1c312c", size = 26913753, upload-time = "2025-08-30T04:40:50.445Z" },
-    { url = "https://files.pythonhosted.org/packages/37/9e/7af078bcfc3cd340c981ac5d613c090ab007023d2ac13b05acd52f22f069/av-15.1.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:57cc7a733a7e7d7a153682f35c9cf5d01e8269367b049c954779de36fc3d0b10", size = 38027048, upload-time = "2025-08-30T04:40:54.076Z" },
-    { url = "https://files.pythonhosted.org/packages/02/76/1f9dac11ad713e3619288993ea04e9c9cf4ec0f04e5ee81e83b8129dd8f3/av-15.1.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:a77b75bdb6899a64302ff923a5246e0747b3f0a3ecee7d61118db407a22c3f53", size = 39565396, upload-time = "2025-08-30T04:40:57.84Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/32/2188c46e2747247458ffc26b230c57dd28e61f65ff7b9e6223a411af5e98/av-15.1.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d0a1154ce081f1720082a133cfe12356c59f62dad2b93a7a1844bf1dcd010d85", size = 40015050, upload-time = "2025-08-30T04:41:01.091Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/41/b57fbce9994580619d7574817ece0fe0e7b822cde2af57904549d0150b8d/av-15.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8a7bf5a34dee15c86790414fa86a144e6d0dcc788bc83b565fdcbc080b4fbc90", size = 40821225, upload-time = "2025-08-30T04:41:04.349Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/36/e85cd1f0d3369c6764ad422882895d082f7ececb66d3df8aeae3234ef7a6/av-15.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:e30c9a6fd9734784941384a2e25fad3c22881a7682f378914676aa7e795acdb7", size = 31311750, upload-time = "2025-08-30T04:41:07.744Z" },
-    { url = "https://files.pythonhosted.org/packages/80/d8/08a681758a4e49adfda409a6a35eff533f42654c6a6cfa102bc5cae1a728/av-15.1.0-cp314-cp314t-macosx_13_0_arm64.whl", hash = "sha256:60666833d7e65ebcfc48034a072de74349edbb62c9aaa3e6722fef31ca028eb6", size = 21828343, upload-time = "2025-08-30T04:41:10.81Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/52/29bec3fe68669b21f7d1ab5d94e21f597b8dfd37f50a3e3c9af6a8da925c/av-15.1.0-cp314-cp314t-macosx_13_0_x86_64.whl", hash = "sha256:53fbdae45aa2a49a22e864ff4f4017416ef62c060a172085d3247ba0a101104e", size = 27001666, upload-time = "2025-08-30T04:41:13.822Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/54/2c1d1faced66d708f5df328e800997cb47f90b500a214130c3a0f2ad601e/av-15.1.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:e6c51061667983dc801502aff9140bbc4f0e0d97f879586f17fb2f9a7e49c381", size = 39496753, upload-time = "2025-08-30T04:41:16.759Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/76/06ded5e52c4dcc2d9b5184c6da8de5ea77bd7ecb79a59a2b9700f1984949/av-15.1.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:2f80ec387f04aa34868662b11018b5f09654ae1530a61e24e92a142a24b10b62", size = 40784729, upload-time = "2025-08-30T04:41:20.491Z" },
-    { url = "https://files.pythonhosted.org/packages/52/ef/797b76f3b39c99a96e387f501bbc07dca340b27d3dda12862fe694066b63/av-15.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4975e03177d37d8165c99c8d494175675ba8acb72458fb5d7e43f746a53e0374", size = 41284953, upload-time = "2025-08-30T04:41:23.949Z" },
-    { url = "https://files.pythonhosted.org/packages/31/47/e4656f00e62fd059ea5a40b492dea784f5aecfe1dfac10c0d7a0664ce200/av-15.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8f78f3dad11780b4cdd024cdb92ce43cb170929297c00f2f4555c2b103f51e55", size = 41985340, upload-time = "2025-08-30T04:41:27.561Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/c9/15bb4fd7a1f39d70db35af2b9c20a0ae19e4220eb58a8b8446e903b98d72/av-15.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:9a20c5eba3ec49c2f4b281797021923fc68a86aeb66c5cda4fd0252fa8004951", size = 31487337, upload-time = "2025-08-30T04:41:30.591Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/84/2535f55edcd426cebec02eb37b811b1b0c163f26b8d3f53b059e2ec32665/av-16.1.0-cp312-cp312-macosx_11_0_x86_64.whl", hash = "sha256:640f57b93f927fba8689f6966c956737ee95388a91bd0b8c8b5e0481f73513d6", size = 26945785, upload-time = "2026-01-09T20:18:34.486Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/17/ffb940c9e490bf42e86db4db1ff426ee1559cd355a69609ec1efe4d3a9eb/av-16.1.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:ae3fb658eec00852ebd7412fdc141f17f3ddce8afee2d2e1cf366263ad2a3b35", size = 21481147, upload-time = "2026-01-09T20:18:36.716Z" },
+    { url = "https://files.pythonhosted.org/packages/15/c1/e0d58003d2d83c3921887d5c8c9b8f5f7de9b58dc2194356a2656a45cfdc/av-16.1.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:27ee558d9c02a142eebcbe55578a6d817fedfde42ff5676275504e16d07a7f86", size = 39517197, upload-time = "2026-01-11T09:57:31.937Z" },
+    { url = "https://files.pythonhosted.org/packages/32/77/787797b43475d1b90626af76f80bfb0c12cfec5e11eafcfc4151b8c80218/av-16.1.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:7ae547f6d5fa31763f73900d43901e8c5fa6367bb9a9840978d57b5a7ae14ed2", size = 41174337, upload-time = "2026-01-11T09:57:35.792Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/ac/d90df7f1e3b97fc5554cf45076df5045f1e0a6adf13899e10121229b826c/av-16.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8cf065f9d438e1921dc31fc7aa045790b58aee71736897866420d80b5450f62a", size = 40817720, upload-time = "2026-01-11T09:57:39.039Z" },
+    { url = "https://files.pythonhosted.org/packages/80/6f/13c3a35f9dbcebafd03fe0c4cbd075d71ac8968ec849a3cfce406c35a9d2/av-16.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a345877a9d3cc0f08e2bc4ec163ee83176864b92587afb9d08dff50f37a9a829", size = 42267396, upload-time = "2026-01-11T09:57:42.115Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/b9/275df9607f7fb44317ccb1d4be74827185c0d410f52b6e2cd770fe209118/av-16.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:f49243b1d27c91cd8c66fdba90a674e344eb8eb917264f36117bf2b6879118fd", size = 31752045, upload-time = "2026-01-11T09:57:45.106Z" },
+    { url = "https://files.pythonhosted.org/packages/75/2a/63797a4dde34283dd8054219fcb29294ba1c25d68ba8c8c8a6ae53c62c45/av-16.1.0-cp313-cp313-macosx_11_0_x86_64.whl", hash = "sha256:ce2a1b3d8bf619f6c47a9f28cfa7518ff75ddd516c234a4ee351037b05e6a587", size = 26916715, upload-time = "2026-01-11T09:57:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/c4/0b49cf730d0ae8cda925402f18ae814aef351f5772d14da72dd87ff66448/av-16.1.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:408dbe6a2573ca58a855eb8cd854112b33ea598651902c36709f5f84c991ed8e", size = 21452167, upload-time = "2026-01-11T09:57:50.606Z" },
+    { url = "https://files.pythonhosted.org/packages/51/23/408806503e8d5d840975aad5699b153aaa21eb6de41ade75248a79b7a37f/av-16.1.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:57f657f86652a160a8a01887aaab82282f9e629abf94c780bbdbb01595d6f0f7", size = 39215659, upload-time = "2026-01-11T09:57:53.757Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/19/a8528d5bba592b3903f44c28dab9cc653c95fcf7393f382d2751a1d1523e/av-16.1.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:adbad2b355c2ee4552cac59762809d791bda90586d134a33c6f13727fb86cb3a", size = 40874970, upload-time = "2026-01-11T09:57:56.802Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/24/2dbcdf0e929ad56b7df078e514e7bd4ca0d45cba798aff3c8caac097d2f7/av-16.1.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f42e1a68ec2aebd21f7eb6895be69efa6aa27eec1670536876399725bbda4b99", size = 40530345, upload-time = "2026-01-11T09:58:00.421Z" },
+    { url = "https://files.pythonhosted.org/packages/54/27/ae91b41207f34e99602d1c72ab6ffd9c51d7c67e3fbcd4e3a6c0e54f882c/av-16.1.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:58fe47aeaef0f100c40ec8a5de9abbd37f118d3ca03829a1009cf288e9aef67c", size = 41972163, upload-time = "2026-01-11T09:58:03.756Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/7a/22158fb923b2a9a00dfab0e96ef2e8a1763a94dd89e666a5858412383d46/av-16.1.0-cp313-cp313-win_amd64.whl", hash = "sha256:565093ebc93b2f4b76782589564869dadfa83af5b852edebedd8fee746457d06", size = 31729230, upload-time = "2026-01-11T09:58:07.254Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/f1/878f8687d801d6c4565d57ebec08449c46f75126ebca8e0fed6986599627/av-16.1.0-cp313-cp313t-macosx_11_0_x86_64.whl", hash = "sha256:574081a24edb98343fd9f473e21ae155bf61443d4ec9d7708987fa597d6b04b2", size = 27008769, upload-time = "2026-01-11T09:58:10.266Z" },
+    { url = "https://files.pythonhosted.org/packages/30/f1/bd4ce8c8b5cbf1d43e27048e436cbc9de628d48ede088a1d0a993768eb86/av-16.1.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:9ab00ea29c25ebf2ea1d1e928d7babb3532d562481c5d96c0829212b70756ad0", size = 21590588, upload-time = "2026-01-11T09:58:12.629Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/dd/c81f6f9209201ff0b5d5bed6da6c6e641eef52d8fbc930d738c3f4f6f75d/av-16.1.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:a84a91188c1071f238a9523fd42dbe567fb2e2607b22b779851b2ce0eac1b560", size = 40638029, upload-time = "2026-01-11T09:58:15.399Z" },
+    { url = "https://files.pythonhosted.org/packages/15/4d/07edff82b78d0459a6e807e01cd280d3180ce832efc1543de80d77676722/av-16.1.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:c2cd0de4dd022a7225ff224fde8e7971496d700be41c50adaaa26c07bb50bf97", size = 41970776, upload-time = "2026-01-11T09:58:19.075Z" },
+    { url = "https://files.pythonhosted.org/packages/da/9d/1f48b354b82fa135d388477cd1b11b81bdd4384bd6a42a60808e2ec2d66b/av-16.1.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:0816143530624a5a93bc5494f8c6eeaf77549b9366709c2ac8566c1e9bff6df5", size = 41764751, upload-time = "2026-01-11T09:58:22.788Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/c7/a509801e98db35ec552dd79da7bdbcff7104044bfeb4c7d196c1ce121593/av-16.1.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:e3a28053af29644696d0c007e897d19b1197585834660a54773e12a40b16974c", size = 43034355, upload-time = "2026-01-11T09:58:26.125Z" },
+    { url = "https://files.pythonhosted.org/packages/36/8b/e5f530d9e8f640da5f5c5f681a424c65f9dd171c871cd255d8a861785a6e/av-16.1.0-cp313-cp313t-win_amd64.whl", hash = "sha256:2e3e67144a202b95ed299d165232533989390a9ea3119d37eccec697dc6dbb0c", size = 31947047, upload-time = "2026-01-11T09:58:31.867Z" },
+    { url = "https://files.pythonhosted.org/packages/df/18/8812221108c27d19f7e5f486a82c827923061edf55f906824ee0fcaadf50/av-16.1.0-cp314-cp314-macosx_11_0_x86_64.whl", hash = "sha256:39a634d8e5a87e78ea80772774bfd20c0721f0d633837ff185f36c9d14ffede4", size = 26916179, upload-time = "2026-01-11T09:58:36.506Z" },
+    { url = "https://files.pythonhosted.org/packages/38/ef/49d128a9ddce42a2766fe2b6595bd9c49e067ad8937a560f7838a541464e/av-16.1.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:0ba32fb9e9300948a7fa9f8a3fc686e6f7f77599a665c71eb2118fdfd2c743f9", size = 21460168, upload-time = "2026-01-11T09:58:39.231Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/a9/b310d390844656fa74eeb8c2750e98030877c75b97551a23a77d3f982741/av-16.1.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:ca04d17815182d34ce3edc53cbda78a4f36e956c0fd73e3bab249872a831c4d7", size = 39210194, upload-time = "2026-01-11T09:58:42.138Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/7b/e65aae179929d0f173af6e474ad1489b5b5ad4c968a62c42758d619e54cf/av-16.1.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:ee0e8de2e124a9ef53c955fe2add6ee7c56cc8fd83318265549e44057db77142", size = 40811675, upload-time = "2026-01-11T09:58:45.871Z" },
+    { url = "https://files.pythonhosted.org/packages/54/3f/5d7edefd26b6a5187d6fac0f5065ee286109934f3dea607ef05e53f05b31/av-16.1.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:22bf77a2f658827043a1e184b479c3bf25c4c43ab32353677df2d119f080e28f", size = 40543942, upload-time = "2026-01-11T09:58:49.759Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/24/f8b17897b67be0900a211142f5646a99d896168f54d57c81f3e018853796/av-16.1.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2dd419d262e6a71cab206d80bbf28e0a10d0f227b671cdf5e854c028faa2d043", size = 41924336, upload-time = "2026-01-11T09:58:53.344Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/cf/d32bc6bbbcf60b65f6510c54690ed3ae1c4ca5d9fafbce835b6056858686/av-16.1.0-cp314-cp314-win_amd64.whl", hash = "sha256:53585986fd431cd436f290fba662cfb44d9494fbc2949a183de00acc5b33fa88", size = 31735077, upload-time = "2026-01-11T09:58:56.684Z" },
+    { url = "https://files.pythonhosted.org/packages/53/f4/9b63dc70af8636399bd933e9df4f3025a0294609510239782c1b746fc796/av-16.1.0-cp314-cp314t-macosx_11_0_x86_64.whl", hash = "sha256:76f5ed8495cf41e1209a5775d3699dc63fdc1740b94a095e2485f13586593205", size = 27014423, upload-time = "2026-01-11T09:58:59.703Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/da/787a07a0d6ed35a0888d7e5cfb8c2ffa202f38b7ad2c657299fac08eb046/av-16.1.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:8d55397190f12a1a3ae7538be58c356cceb2bf50df1b33523817587748ce89e5", size = 21595536, upload-time = "2026-01-11T09:59:02.508Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/f4/9a7d8651a611be6e7e3ab7b30bb43779899c8cac5f7293b9fb634c44a3f3/av-16.1.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:9d51d9037437218261b4bbf9df78a95e216f83d7774fbfe8d289230b5b2e28e2", size = 40642490, upload-time = "2026-01-11T09:59:05.842Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/e4/eb79bc538a94b4ff93cd4237d00939cba797579f3272490dd0144c165a21/av-16.1.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:0ce07a89c15644407f49d942111ca046e323bbab0a9078ff43ee57c9b4a50dad", size = 41976905, upload-time = "2026-01-11T09:59:09.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/f5/f6db0dd86b70167a4d55ee0d9d9640983c570d25504f2bde42599f38241e/av-16.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:cac0c074892ea97113b53556ff41c99562db7b9f09f098adac1f08318c2acad5", size = 41770481, upload-time = "2026-01-11T09:59:12.74Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8b/33651d658e45e16ab7671ea5fcf3d20980ea7983234f4d8d0c63c65581a5/av-16.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7dec3dcbc35a187ce450f65a2e0dda820d5a9e6553eea8344a1459af11c98649", size = 43036824, upload-time = "2026-01-11T09:59:16.507Z" },
+    { url = "https://files.pythonhosted.org/packages/83/41/7f13361db54d7e02f11552575c0384dadaf0918138f4eaa82ea03a9f9580/av-16.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6f90dc082ff2068ddbe77618400b44d698d25d9c4edac57459e250c16b33d700", size = 31948164, upload-time = "2026-01-11T09:59:19.501Z" },
 ]
 
 [[package]]
@@ -435,6 +442,19 @@ wheels = [
 [package.optional-dependencies]
 css = [
     { name = "tinycss2" },
+]
+
+[[package]]
+name = "cattrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a0/ec/ba18945e7d6e55a58364d9fb2e46049c1c2998b3d805f19b703f14e81057/cattrs-26.1.0.tar.gz", hash = "sha256:fa239e0f0ec0715ba34852ce813986dfed1e12117e209b816ab87401271cdd40", size = 495672, upload-time = "2026-02-18T22:15:19.406Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/56/60547f7801b97c67e97491dc3d9ade9fbccbd0325058fd3dfcb2f5d98d90/cattrs-26.1.0-py3-none-any.whl", hash = "sha256:d1e0804c42639494d469d08d4f26d6b9de9b8ab26b446db7b5f8c2e97f7c3096", size = 73054, upload-time = "2026-02-18T22:15:17.958Z" },
 ]
 
 [[package]]
@@ -1004,22 +1024,22 @@ wheels = [
 
 [[package]]
 name = "cuda-bindings"
-version = "12.9.6"
+version = "12.9.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cuda-pathfinder", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/50/04/8a4d45dc154a8a32982658cc55be291e9778d1197834b15d33427e2f65c1/cuda_bindings-12.9.6-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea331bc47d9988cc61f0ecc5fa8df9dd188b4493ae1c6688bb1ee8ce8ba1af4", size = 7050347, upload-time = "2026-03-11T14:47:35.221Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/69/4b0375e1b120dfa7427c31c8420cfdee596ecd03955fd291a96116fa375d/cuda_bindings-12.9.6-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b2b54b95a47104eff56b5155818ab5790e3ccdba8dd51e2928ae56782aaf5b02", size = 7590574, upload-time = "2026-03-11T14:47:37.452Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/ad/2d9b80c28deae971ce4bbe991c23b81347a2a8918b2672020d07f070a596/cuda_bindings-12.9.6-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:da30d89db8188b9beb5a6467d72b2f11d1b667ab901d2d373bcde51b97765b21", size = 6950608, upload-time = "2026-03-11T14:47:40.944Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/ca/729781d11445cfbacd1af1bf0edfe147c311212cfdf1d5c292e0565fabef/cuda_bindings-12.9.6-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3d1be8bd80b34f51dcbaf138dafd817e888cf2d12c47833019fd933beb32d7ef", size = 7439531, upload-time = "2026-03-11T14:47:42.757Z" },
-    { url = "https://files.pythonhosted.org/packages/fe/f3/51768221aade33e711dcf7e4a52fdc0d0446c1baf39f6bcc9d69cfbceb0b/cuda_bindings-12.9.6-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:48666e666f083a4c4387ffe20594b05e092b535a4453d1e4817d71237d02aa13", size = 6861186, upload-time = "2026-03-11T14:47:46.335Z" },
-    { url = "https://files.pythonhosted.org/packages/71/34/14afff4aabe3b5bd84c647dea4a4dfb917c94b8a8df0adb6b1622c2b465b/cuda_bindings-12.9.6-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b4f82f8f8061f3a39446bf854c4edd9bcc2d0da3f58d8f6f54541b3e4d5c933d", size = 7356548, upload-time = "2026-03-11T14:47:48.209Z" },
-    { url = "https://files.pythonhosted.org/packages/3d/d3/a29faf4fb371c2f43ffda23a938ec0bebf6dbab676350e137ae0f61e5ec0/cuda_bindings-12.9.6-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f00290f9468d2cfeee92aaad2275be32dfd2f4967a97ac0f12314b7e6281ad78", size = 7046617, upload-time = "2026-03-11T14:47:52.46Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/97/71e66b2ed65d80f7b70a1538af72d73cd798e22bc93d240d7e69f2366322/cuda_bindings-12.9.6-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d3bc6e28cf5d133f72050c515db72876870fb009f1431bcbf45b54a179be2284", size = 7481379, upload-time = "2026-03-11T14:47:54.281Z" },
-    { url = "https://files.pythonhosted.org/packages/49/91/c10b575a001aad39c036efd649869aac8d97ef0ba9f1d8ad17b4946b3366/cuda_bindings-12.9.6-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e88d38fdf07cc777dec1afaba8139c2eedb3819063f6b42f1e2ea8516bdd6806", size = 6879714, upload-time = "2026-03-11T14:47:58.095Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/9a/998471e76bea78e96d3d7fdf0bc5f46c3210858e81e6d13d8186a9dbb636/cuda_bindings-12.9.6-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4df01e34cefd3275170b2ac0426d325271ab435e85f59a69300eacd8ff23d34c", size = 7367020, upload-time = "2026-03-11T14:47:59.781Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/c2/65bfd79292b8ff18be4dd7f7442cea37bcbc1a228c1886f1dea515c45b67/cuda_bindings-12.9.4-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:694ba35023846625ef471257e6b5a4bc8af690f961d197d77d34b1d1db393f56", size = 11760260, upload-time = "2025-10-21T14:51:40.79Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/c1/dabe88f52c3e3760d861401bb994df08f672ec893b8f7592dc91626adcf3/cuda_bindings-12.9.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fda147a344e8eaeca0c6ff113d2851ffca8f7dfc0a6c932374ee5c47caa649c8", size = 12151019, upload-time = "2025-10-21T14:51:43.167Z" },
+    { url = "https://files.pythonhosted.org/packages/05/8b/b4b2d1c7775fa403b64333e720cfcfccef8dcb9cdeb99947061ca5a77628/cuda_bindings-12.9.4-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cf8bfaedc238f3b115d957d1fd6562b7e8435ba57f6d0e2f87d0e7149ccb2da5", size = 11570071, upload-time = "2025-10-21T14:51:47.472Z" },
+    { url = "https://files.pythonhosted.org/packages/63/56/e465c31dc9111be3441a9ba7df1941fe98f4aa6e71e8788a3fb4534ce24d/cuda_bindings-12.9.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:32bdc5a76906be4c61eb98f546a6786c5773a881f3b166486449b5d141e4a39f", size = 11906628, upload-time = "2025-10-21T14:51:49.905Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/07/6aff13bc1e977e35aaa6b22f52b172e2890c608c6db22438cf7ed2bf43a6/cuda_bindings-12.9.4-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3adf4958dcf68ae7801a59b73fb00a8b37f8d0595060d66ceae111b1002de38d", size = 11566797, upload-time = "2025-10-21T14:51:54.581Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/84/1e6be415e37478070aeeee5884c2022713c1ecc735e6d82d744de0252eee/cuda_bindings-12.9.4-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:56e0043c457a99ac473ddc926fe0dc4046694d99caef633e92601ab52cbe17eb", size = 11925991, upload-time = "2025-10-21T14:51:56.535Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/b5/96a6696e20c4ffd2b327f54c7d0fde2259bdb998d045c25d5dedbbe30290/cuda_bindings-12.9.4-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1f53a7f453d4b2643d8663d036bafe29b5ba89eb904c133180f295df6dc151e5", size = 11624530, upload-time = "2025-10-21T14:52:01.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/af/6dfd8f2ed90b1d4719bc053ff8940e494640fe4212dc3dd72f383e4992da/cuda_bindings-12.9.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8b72ee72a9cc1b531db31eebaaee5c69a8ec3500e32c6933f2d3b15297b53686", size = 11922703, upload-time = "2025-10-21T14:52:03.585Z" },
+    { url = "https://files.pythonhosted.org/packages/39/73/d2fc40c043bac699c3880bf88d3cebe9d88410cd043795382826c93a89f0/cuda_bindings-12.9.4-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:20f2699d61d724de3eb3f3369d57e2b245f93085cab44fd37c3bea036cea1a6f", size = 11565056, upload-time = "2025-10-21T14:52:08.338Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/19/90ac264acc00f6df8a49378eedec9fd2db3061bf9263bf9f39fd3d8377c3/cuda_bindings-12.9.4-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d80bffc357df9988dca279734bc9674c3934a654cab10cadeed27ce17d8635ee", size = 11924658, upload-time = "2025-10-21T14:52:10.411Z" },
 ]
 
 [[package]]
@@ -1028,49 +1048,6 @@ version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/11/d0/c177e29701cf1d3008d7d2b16b5fc626592ce13bd535f8795c5f57187e0e/cuda_pathfinder-1.5.4-py3-none-any.whl", hash = "sha256:9563d3175ce1828531acf4b94e1c1c7d67208c347ca002493e2654878b26f4b7", size = 51657, upload-time = "2026-04-27T22:42:07.712Z" },
-]
-
-[[package]]
-name = "cuda-toolkit"
-version = "12.8.1"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/c8/7dce3a0b15b42a3b58e7d96eb22a687d3bf2c44e01d149a6874629cd9938/cuda_toolkit-12.8.1-py2.py3-none-any.whl", hash = "sha256:adc7906af4ecbf9a352f9dca5734eceb21daec281ccfcf5675e1d2f724fc2cba", size = 2283, upload-time = "2025-08-13T02:03:07.842Z" },
-]
-
-[package.optional-dependencies]
-cublas = [
-    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux'" },
-]
-cudart = [
-    { name = "nvidia-cuda-runtime-cu12", marker = "sys_platform == 'linux'" },
-]
-cufft = [
-    { name = "nvidia-cufft-cu12", marker = "sys_platform == 'linux'" },
-]
-cufile = [
-    { name = "nvidia-cufile-cu12", marker = "sys_platform == 'linux'" },
-]
-cupti = [
-    { name = "nvidia-cuda-cupti-cu12", marker = "sys_platform == 'linux'" },
-]
-curand = [
-    { name = "nvidia-curand-cu12", marker = "sys_platform == 'linux'" },
-]
-cusolver = [
-    { name = "nvidia-cusolver-cu12", marker = "sys_platform == 'linux'" },
-]
-cusparse = [
-    { name = "nvidia-cusparse-cu12", marker = "sys_platform == 'linux'" },
-]
-nvjitlink = [
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
-]
-nvrtc = [
-    { name = "nvidia-cuda-nvrtc-cu12", marker = "sys_platform == 'linux'" },
-]
-nvtx = [
-    { name = "nvidia-nvtx-cu12", marker = "sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -1172,10 +1149,11 @@ wheels = [
 
 [[package]]
 name = "diffusers"
-version = "0.35.2"
-source = { registry = "https://pypi.org/simple" }
+version = "0.39.0.dev0"
+source = { git = "https://github.com/huggingface/diffusers.git?rev=f3d42be118f9af7ed9697b686fba09a8bdcd71d1#f3d42be118f9af7ed9697b686fba09a8bdcd71d1" }
 dependencies = [
     { name = "filelock" },
+    { name = "httpx" },
     { name = "huggingface-hub" },
     { name = "importlib-metadata" },
     { name = "numpy" },
@@ -1183,10 +1161,6 @@ dependencies = [
     { name = "regex" },
     { name = "requests" },
     { name = "safetensors" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/03/68/288ca23c7c05c73e87ffe5efffc282400ac9b017f7a9bb03883f4310ea15/diffusers-0.35.2.tar.gz", hash = "sha256:30ecd552303edfcfe1724573c3918a8462ee3ab4d529bdbd4c0045f763affded", size = 3366711, upload-time = "2025-10-15T04:05:17.213Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/2e/38d9824f8c6bb048c5ba21c6d4da54c29c162a46b58b3ef907a360a76d3e/diffusers-0.35.2-py3-none-any.whl", hash = "sha256:d50d5e74fdd6dcf55e5c1d304bc52cc7c2659abd1752740d736d7b54078b4db5", size = 4121649, upload-time = "2025-10-15T04:05:14.391Z" },
 ]
 
 [[package]]
@@ -1277,6 +1251,15 @@ name = "docopt"
 version = "0.6.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/55/8f8cab2afd404cf578136ef2cc5dfb50baa1761b68c9da1fb1e4eed343c9/docopt-0.6.2.tar.gz", hash = "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491", size = 25901, upload-time = "2014-06-16T11:18:57.406Z" }
+
+[[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
 
 [[package]]
 name = "draccus"
@@ -1470,8 +1453,8 @@ version = "2.8.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "einops", marker = "platform_machine != 'arm64' or sys_platform != 'darwin'" },
-    { name = "torch", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'arm64' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
-    { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform == 'linux'" },
+    { name = "torch", version = "2.10.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'arm64' and sys_platform == 'darwin') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
+    { name = "torch", version = "2.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3b/b2/8d76c41ad7974ee264754709c22963447f7f8134613fd9ce80984ed0dab7/flash_attn-2.8.3.tar.gz", hash = "sha256:1e71dd64a9e0280e0447b8a0c2541bad4bf6ac65bdeaa2f90e51a9e57de0370d", size = 8447812, upload-time = "2025-08-15T08:28:12.911Z" }
 
@@ -2049,9 +2032,9 @@ name = "hydra-core"
 version = "1.3.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "antlr4-python3-runtime", marker = "sys_platform == 'linux'" },
-    { name = "omegaconf", marker = "sys_platform == 'linux'" },
-    { name = "packaging", marker = "sys_platform == 'linux'" },
+    { name = "antlr4-python3-runtime" },
+    { name = "omegaconf" },
+    { name = "packaging" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6d/8e/07e42bc434a847154083b315779b0a81d567154504624e181caf2c71cd98/hydra-core-1.3.2.tar.gz", hash = "sha256:8a878ed67216997c3e9d88a8e72e7b4767e81af37afb4ea3334b269a4390a824", size = 3263494, upload-time = "2023-02-23T18:33:43.03Z" }
 wheels = [
@@ -2676,10 +2659,10 @@ dependencies = [
     { name = "safetensors" },
     { name = "setuptools" },
     { name = "termcolor" },
-    { name = "torch", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
-    { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform == 'linux'" },
-    { name = "torchvision", version = "0.26.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
-    { name = "torchvision", version = "0.26.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform == 'linux'" },
+    { name = "torch", version = "2.10.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
+    { name = "torch", version = "2.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform == 'linux'" },
+    { name = "torchvision", version = "0.25.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
+    { name = "torchvision", version = "0.25.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform == 'linux'" },
     { name = "tqdm" },
 ]
 
@@ -2739,7 +2722,9 @@ all = [
     { name = "scikit-image" },
     { name = "scipy" },
     { name = "teleop" },
-    { name = "torchcodec", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'AMD64' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'arm64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'win32'" },
+    { name = "torchcodec", version = "0.10.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or sys_platform == 'win32'" },
+    { name = "torchcodec", version = "0.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(platform_machine == 'AMD64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "torchcodec", version = "0.11.1+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'arm64' and sys_platform == 'linux')" },
     { name = "torchdiffeq" },
     { name = "transformers" },
     { name = "wandb" },
@@ -2752,7 +2737,9 @@ aloha = [
     { name = "pandas" },
     { name = "pyarrow" },
     { name = "scipy" },
-    { name = "torchcodec", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'AMD64' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'arm64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'win32'" },
+    { name = "torchcodec", version = "0.10.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or sys_platform == 'win32'" },
+    { name = "torchcodec", version = "0.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(platform_machine == 'AMD64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "torchcodec", version = "0.11.1+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'arm64' and sys_platform == 'linux')" },
 ]
 async = [
     { name = "contourpy" },
@@ -2776,7 +2763,30 @@ core-scripts = [
     { name = "pynput" },
     { name = "pyserial" },
     { name = "rerun-sdk" },
-    { name = "torchcodec", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'AMD64' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'arm64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'win32'" },
+    { name = "torchcodec", version = "0.10.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or sys_platform == 'win32'" },
+    { name = "torchcodec", version = "0.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(platform_machine == 'AMD64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "torchcodec", version = "0.11.1+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'arm64' and sys_platform == 'linux')" },
+]
+cosmos3 = [
+    { name = "accelerate" },
+    { name = "av" },
+    { name = "cattrs" },
+    { name = "diffusers" },
+    { name = "hydra-core" },
+    { name = "imageio" },
+    { name = "imageio-ffmpeg" },
+    { name = "loguru" },
+    { name = "msgpack" },
+    { name = "nvidia-cudnn-frontend" },
+    { name = "nvidia-ml-py" },
+    { name = "obstore" },
+    { name = "omegaconf" },
+    { name = "pydantic" },
+    { name = "qwen-vl-utils" },
+    { name = "scipy" },
+    { name = "transformers" },
+    { name = "tyro" },
+    { name = "websockets" },
 ]
 damiao = [
     { name = "python-can" },
@@ -2787,7 +2797,9 @@ dataset = [
     { name = "jsonlines" },
     { name = "pandas" },
     { name = "pyarrow" },
-    { name = "torchcodec", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'AMD64' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'arm64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'win32'" },
+    { name = "torchcodec", version = "0.10.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or sys_platform == 'win32'" },
+    { name = "torchcodec", version = "0.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(platform_machine == 'AMD64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "torchcodec", version = "0.11.1+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'arm64' and sys_platform == 'linux')" },
 ]
 dataset-viz = [
     { name = "av" },
@@ -2796,7 +2808,9 @@ dataset-viz = [
     { name = "pandas" },
     { name = "pyarrow" },
     { name = "rerun-sdk" },
-    { name = "torchcodec", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'AMD64' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'arm64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'win32'" },
+    { name = "torchcodec", version = "0.10.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or sys_platform == 'win32'" },
+    { name = "torchcodec", version = "0.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(platform_machine == 'AMD64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "torchcodec", version = "0.11.1+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'arm64' and sys_platform == 'linux')" },
 ]
 deepdiff-dep = [
     { name = "deepdiff" },
@@ -2868,7 +2882,9 @@ hilserl = [
     { name = "placo" },
     { name = "protobuf" },
     { name = "pyarrow" },
-    { name = "torchcodec", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'AMD64' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'arm64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'win32'" },
+    { name = "torchcodec", version = "0.10.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or sys_platform == 'win32'" },
+    { name = "torchcodec", version = "0.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(platform_machine == 'AMD64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "torchcodec", version = "0.11.1+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'arm64' and sys_platform == 'linux')" },
     { name = "transformers" },
 ]
 hopejr = [
@@ -2898,7 +2914,9 @@ libero = [
     { name = "pandas" },
     { name = "pyarrow" },
     { name = "scipy" },
-    { name = "torchcodec", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'AMD64' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'arm64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'win32'" },
+    { name = "torchcodec", version = "0.10.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or sys_platform == 'win32'" },
+    { name = "torchcodec", version = "0.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(platform_machine == 'AMD64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "torchcodec", version = "0.11.1+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'arm64' and sys_platform == 'linux')" },
     { name = "transformers" },
 ]
 matplotlib-dep = [
@@ -2913,7 +2931,9 @@ metaworld = [
     { name = "pandas" },
     { name = "pyarrow" },
     { name = "scipy" },
-    { name = "torchcodec", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'AMD64' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'arm64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'win32'" },
+    { name = "torchcodec", version = "0.10.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or sys_platform == 'win32'" },
+    { name = "torchcodec", version = "0.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(platform_machine == 'AMD64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "torchcodec", version = "0.11.1+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'arm64' and sys_platform == 'linux')" },
 ]
 molmoact2 = [
     { name = "peft" },
@@ -2965,7 +2985,9 @@ pusht = [
     { name = "pandas" },
     { name = "pyarrow" },
     { name = "pymunk" },
-    { name = "torchcodec", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'AMD64' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'arm64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'win32'" },
+    { name = "torchcodec", version = "0.10.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or sys_platform == 'win32'" },
+    { name = "torchcodec", version = "0.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(platform_machine == 'AMD64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "torchcodec", version = "0.11.1+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'arm64' and sys_platform == 'linux')" },
 ]
 pygame-dep = [
     { name = "pygame" },
@@ -3029,7 +3051,9 @@ training = [
     { name = "jsonlines" },
     { name = "pandas" },
     { name = "pyarrow" },
-    { name = "torchcodec", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'AMD64' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'arm64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'win32'" },
+    { name = "torchcodec", version = "0.10.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or sys_platform == 'win32'" },
+    { name = "torchcodec", version = "0.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(platform_machine == 'AMD64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "torchcodec", version = "0.11.1+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'arm64' and sys_platform == 'linux')" },
     { name = "wandb" },
 ]
 transformers-dep = [
@@ -3070,16 +3094,20 @@ xvla = [
 
 [package.metadata]
 requires-dist = [
+    { name = "accelerate", marker = "extra == 'cosmos3'", specifier = ">=1.13.0,<2.0.0" },
     { name = "accelerate", marker = "extra == 'smolvla'", specifier = ">=1.7.0,<2.0.0" },
     { name = "accelerate", marker = "extra == 'training'", specifier = ">=1.10.0,<2.0.0" },
-    { name = "av", marker = "extra == 'av-dep'", specifier = ">=15.0.0,<16.0.0" },
+    { name = "av", marker = "extra == 'av-dep'", specifier = ">=16.1.0,<17.0.0" },
+    { name = "av", marker = "extra == 'cosmos3'", specifier = ">=16.1.0,<17.0.0" },
+    { name = "cattrs", marker = "extra == 'cosmos3'", specifier = ">=26.1.0,<27.0.0" },
     { name = "cmake", specifier = ">=3.29.0.1,<4.2.0" },
     { name = "contourpy", marker = "extra == 'matplotlib-dep'", specifier = ">=1.3.0,<2.0.0" },
     { name = "datasets", marker = "extra == 'dataset'", specifier = ">=4.7.0,<5.0.0" },
     { name = "debugpy", marker = "extra == 'dev'", specifier = ">=1.8.1,<1.9.0" },
     { name = "decord", marker = "(platform_machine == 'AMD64' and extra == 'groot') or (platform_machine == 'x86_64' and extra == 'groot')", specifier = ">=0.6.0,<1.0.0" },
     { name = "deepdiff", marker = "extra == 'deepdiff-dep'", specifier = ">=7.0.1,<9.0.0" },
-    { name = "diffusers", marker = "extra == 'diffusers-dep'", specifier = ">=0.27.2,<0.36.0" },
+    { name = "diffusers", marker = "extra == 'cosmos3'", git = "https://github.com/huggingface/diffusers.git?rev=f3d42be118f9af7ed9697b686fba09a8bdcd71d1" },
+    { name = "diffusers", marker = "extra == 'diffusers-dep'", specifier = ">=0.36.0,<0.40.0" },
     { name = "dm-tree", marker = "extra == 'groot'", specifier = ">=0.1.8,<1.0.0" },
     { name = "draccus", specifier = "==0.10.0" },
     { name = "dynamixel-sdk", marker = "extra == 'dynamixel'", specifier = ">=3.7.31,<3.9.0" },
@@ -3098,6 +3126,9 @@ requires-dist = [
     { name = "hf-libero", marker = "sys_platform == 'linux' and extra == 'libero'", specifier = ">=0.1.3,<0.2.0" },
     { name = "hidapi", marker = "extra == 'gamepad'", specifier = ">=0.14.0,<0.15.0" },
     { name = "huggingface-hub", specifier = ">=1.0.0,<2.0.0" },
+    { name = "hydra-core", marker = "extra == 'cosmos3'", specifier = ">=1.3.2,<2.0.0" },
+    { name = "imageio", marker = "extra == 'cosmos3'", specifier = ">=2.37.2,<3.0.0" },
+    { name = "imageio-ffmpeg", marker = "extra == 'cosmos3'", specifier = ">=0.6.0,<1.0.0" },
     { name = "ipykernel", marker = "extra == 'notebook'", specifier = ">=6.0.0,<7.0.0" },
     { name = "jsonlines", marker = "extra == 'dataset'", specifier = ">=4.0.0,<5.0.0" },
     { name = "jupyter", marker = "extra == 'notebook'", specifier = ">=1.0.0,<2.0.0" },
@@ -3174,6 +3205,7 @@ requires-dist = [
     { name = "lerobot", extras = ["pyserial-dep"], marker = "extra == 'unitree-g1'" },
     { name = "lerobot", extras = ["pyzmq-dep"], marker = "extra == 'lekiwi'" },
     { name = "lerobot", extras = ["pyzmq-dep"], marker = "extra == 'unitree-g1'" },
+    { name = "lerobot", extras = ["qwen-vl-utils-dep"], marker = "extra == 'cosmos3'" },
     { name = "lerobot", extras = ["qwen-vl-utils-dep"], marker = "extra == 'eo1'" },
     { name = "lerobot", extras = ["qwen-vl-utils-dep"], marker = "extra == 'robometer'" },
     { name = "lerobot", extras = ["qwen-vl-utils-dep"], marker = "extra == 'sarm'" },
@@ -3195,6 +3227,7 @@ requires-dist = [
     { name = "lerobot", extras = ["test"], marker = "extra == 'all'" },
     { name = "lerobot", extras = ["topreward"], marker = "extra == 'all'" },
     { name = "lerobot", extras = ["training"], marker = "extra == 'all'" },
+    { name = "lerobot", extras = ["transformers-dep"], marker = "extra == 'cosmos3'" },
     { name = "lerobot", extras = ["transformers-dep"], marker = "extra == 'eo1'" },
     { name = "lerobot", extras = ["transformers-dep"], marker = "extra == 'groot'" },
     { name = "lerobot", extras = ["transformers-dep"], marker = "extra == 'hilserl'" },
@@ -3217,16 +3250,22 @@ requires-dist = [
     { name = "lerobot", extras = ["vla-jepa"], marker = "extra == 'all'" },
     { name = "lerobot", extras = ["wallx"], marker = "extra == 'all'" },
     { name = "lerobot", extras = ["xvla"], marker = "extra == 'all'" },
+    { name = "loguru", marker = "extra == 'cosmos3'", specifier = ">=0.7.3,<1.0.0" },
     { name = "matplotlib", marker = "extra == 'matplotlib-dep'", specifier = ">=3.10.3,<4.0.0" },
     { name = "meshcat", marker = "extra == 'unitree-g1'", specifier = ">=0.3.0,<0.4.0" },
     { name = "metaworld", marker = "extra == 'metaworld'", specifier = "==3.0.0" },
     { name = "mock-serial", marker = "sys_platform != 'win32' and extra == 'test'", specifier = ">=0.0.1,<0.1.0" },
     { name = "motorbridge", marker = "extra == 'motorbridge-dep'", specifier = ">=0.3.2,<0.4.0" },
     { name = "motorbridge-smart-servo", marker = "extra == 'motorbridge-smart-servo-dep'", specifier = ">=0.0.4,<0.1.0" },
+    { name = "msgpack", marker = "extra == 'cosmos3'", specifier = ">=1.1.2,<2.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.19.1" },
     { name = "ninja", marker = "extra == 'groot'", specifier = ">=1.11.1,<2.0.0" },
     { name = "num2words", marker = "extra == 'smolvla'", specifier = ">=0.5.14,<0.6.0" },
     { name = "numpy", specifier = ">=2.0.0,<2.3.0" },
+    { name = "nvidia-cudnn-frontend", marker = "extra == 'cosmos3'", specifier = ">=1.18.0,<2.0.0" },
+    { name = "nvidia-ml-py", marker = "extra == 'cosmos3'", specifier = ">=13.590.48,<14.0.0" },
+    { name = "obstore", marker = "extra == 'cosmos3'", specifier = ">=0.8.2,<1.0.0" },
+    { name = "omegaconf", marker = "extra == 'cosmos3'", specifier = ">=2.3.0,<3.0.0" },
     { name = "onnx", marker = "extra == 'unitree-g1'", specifier = ">=1.16.0,<2.0.0" },
     { name = "onnxruntime", marker = "extra == 'unitree-g1'", specifier = ">=1.16.0,<2.0.0" },
     { name = "opencv-python-headless", specifier = ">=4.9.0,<4.14.0" },
@@ -3234,11 +3273,12 @@ requires-dist = [
     { name = "pandas", marker = "extra == 'dataset'", specifier = ">=2.0.0,<3.0.0" },
     { name = "pandas", marker = "extra == 'video-benchmark'", specifier = ">=2.2.2,<2.4.0" },
     { name = "peft", marker = "extra == 'peft-dep'", specifier = ">=0.18.0,<1.0.0" },
-    { name = "pillow", specifier = ">=10.0.0,<13.0.0" },
+    { name = "pillow", specifier = ">=12.2.0,<13.0.0" },
     { name = "placo", marker = "extra == 'placo-dep'", specifier = ">=0.9.6,<0.9.16" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.7.0,<5.0.0" },
     { name = "protobuf", marker = "extra == 'grpcio-dep'", specifier = ">=6.31.1,<6.32.0" },
     { name = "pyarrow", marker = "extra == 'dataset'", specifier = ">=21.0.0,<30.0.0" },
+    { name = "pydantic", marker = "extra == 'cosmos3'", specifier = ">=2.12.5,<3.0.0" },
     { name = "pydantic", marker = "extra == 'sarm'", specifier = ">=2.0.0,<3.0.0" },
     { name = "pygame", marker = "extra == 'pygame-dep'", specifier = ">=2.5.1,<2.7.0" },
     { name = "pymunk", marker = "extra == 'pusht'", specifier = ">=6.6.0,<7.0.0" },
@@ -3259,24 +3299,28 @@ requires-dist = [
     { name = "safetensors", specifier = ">=0.4.3,<1.0.0" },
     { name = "scikit-image", marker = "extra == 'video-benchmark'", specifier = ">=0.23.2,<0.26.0" },
     { name = "scipy", marker = "extra == 'all'", specifier = ">=1.14.0,<2.0.0" },
+    { name = "scipy", marker = "extra == 'cosmos3'", specifier = ">=1.17.1,<2.0.0" },
     { name = "scipy", marker = "extra == 'scipy-dep'", specifier = ">=1.14.0,<2.0.0" },
     { name = "setuptools", specifier = ">=71.0.0,<81.0.0" },
     { name = "teleop", marker = "extra == 'phone'", specifier = ">=0.1.0,<0.2.0" },
     { name = "termcolor", specifier = ">=2.4.0,<4.0.0" },
     { name = "timm", marker = "extra == 'groot'", specifier = ">=1.0.0,<1.1.0" },
-    { name = "torch", marker = "sys_platform != 'linux'", specifier = ">=2.7,<2.12.0" },
-    { name = "torch", marker = "sys_platform == 'linux'", specifier = ">=2.7,<2.12.0", index = "https://download.pytorch.org/whl/cu128" },
-    { name = "torchcodec", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin' and extra == 'dataset') or (platform_machine == 'AMD64' and sys_platform == 'linux' and extra == 'dataset') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'dataset')", specifier = ">=0.3.0,<0.12.0" },
-    { name = "torchcodec", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'dataset') or (platform_machine == 'arm64' and sys_platform == 'linux' and extra == 'dataset')", specifier = ">=0.11.0,<0.12.0" },
-    { name = "torchcodec", marker = "sys_platform == 'win32' and extra == 'dataset'", specifier = ">=0.7.0,<0.12.0" },
+    { name = "torch", marker = "sys_platform != 'linux'", specifier = ">=2.10.0,<2.11.0" },
+    { name = "torch", marker = "sys_platform == 'linux'", specifier = ">=2.10.0,<2.11.0", index = "https://download.pytorch.org/whl/cu128" },
+    { name = "torchcodec", marker = "platform_machine == 'arm64' and sys_platform == 'darwin' and extra == 'dataset'", specifier = ">=0.10.0,<0.11.0" },
+    { name = "torchcodec", marker = "(platform_machine == 'AMD64' and sys_platform == 'linux' and extra == 'dataset') or (platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'dataset')", specifier = ">=0.10.0,<0.11.0", index = "https://download.pytorch.org/whl/cu128" },
+    { name = "torchcodec", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux' and extra == 'dataset') or (platform_machine == 'arm64' and sys_platform == 'linux' and extra == 'dataset')", specifier = ">=0.11.0,<0.12.0", index = "https://download.pytorch.org/whl/cu128" },
+    { name = "torchcodec", marker = "sys_platform == 'win32' and extra == 'dataset'", specifier = ">=0.10.0,<0.11.0" },
     { name = "torchdiffeq", marker = "extra == 'wallx'", specifier = ">=0.2.4,<0.3.0" },
-    { name = "torchvision", marker = "sys_platform != 'linux'", specifier = ">=0.22.0,<0.27.0" },
-    { name = "torchvision", marker = "sys_platform == 'linux'", specifier = ">=0.22.0,<0.27.0", index = "https://download.pytorch.org/whl/cu128" },
+    { name = "torchvision", marker = "sys_platform != 'linux'", specifier = ">=0.25.0,<0.26.0" },
+    { name = "torchvision", marker = "sys_platform == 'linux'", specifier = ">=0.25.0,<0.26.0", index = "https://download.pytorch.org/whl/cu128" },
     { name = "tqdm", specifier = ">=4.66.0,<5.0.0" },
     { name = "transformers", marker = "extra == 'transformers-dep'", specifier = ">=5.4.0,<5.6.0" },
+    { name = "tyro", marker = "extra == 'cosmos3'", specifier = ">=1.0.8,<2.0.0" },
     { name = "wandb", marker = "extra == 'training'", specifier = ">=0.24.0,<0.25.0" },
+    { name = "websockets", marker = "extra == 'cosmos3'", specifier = ">=16.0,<17.0.0" },
 ]
-provides-extras = ["dataset", "training", "hardware", "viz", "core-scripts", "evaluation", "dataset-viz", "av-dep", "pygame-dep", "placo-dep", "transformers-dep", "grpcio-dep", "can-dep", "peft-dep", "scipy-dep", "diffusers-dep", "qwen-vl-utils-dep", "matplotlib-dep", "pyserial-dep", "deepdiff-dep", "pynput-dep", "pyzmq-dep", "motorbridge-dep", "motorbridge-smart-servo-dep", "feetech", "dynamixel", "damiao", "robstride", "openarms", "gamepad", "hopejr", "lekiwi", "unitree-g1", "reachy2", "rebot", "kinematics", "intelrealsense", "phone", "diffusion", "wallx", "pi", "molmoact2", "smolvla", "multi-task-dit", "groot", "sarm", "robometer", "topreward", "xvla", "eo1", "hilserl", "vla-jepa", "async", "peft", "dev", "notebook", "test", "video-benchmark", "aloha", "pusht", "libero", "metaworld", "all"]
+provides-extras = ["dataset", "training", "hardware", "viz", "core-scripts", "evaluation", "dataset-viz", "av-dep", "pygame-dep", "placo-dep", "transformers-dep", "grpcio-dep", "can-dep", "peft-dep", "scipy-dep", "diffusers-dep", "qwen-vl-utils-dep", "matplotlib-dep", "pyserial-dep", "deepdiff-dep", "pynput-dep", "pyzmq-dep", "motorbridge-dep", "motorbridge-smart-servo-dep", "feetech", "dynamixel", "damiao", "robstride", "openarms", "gamepad", "hopejr", "lekiwi", "unitree-g1", "reachy2", "rebot", "kinematics", "intelrealsense", "phone", "diffusion", "wallx", "pi", "molmoact2", "smolvla", "multi-task-dit", "groot", "sarm", "robometer", "topreward", "xvla", "eo1", "hilserl", "vla-jepa", "cosmos3", "async", "peft", "dev", "notebook", "test", "video-benchmark", "aloha", "pusht", "libero", "metaworld", "all"]
 
 [[package]]
 name = "librt"
@@ -3352,6 +3396,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/84/3b/e679bc3b29127182a7f4aa2d2e9e5bea42adb93fb840484147d59c236299/llvmlite-0.47.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d4a7b778a2e144fc64468fb9bf509ac1226c9813a00b4d7afea5d988c4e22fca", size = 55128631, upload-time = "2026-03-31T18:29:29.536Z" },
     { url = "https://files.pythonhosted.org/packages/11/03/16090dd6f74ba2b8b922276047f15962fbeea0a75d5601607edb301ba945/llvmlite-0.47.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fa1cbd800edd3b20bc141521f7fd45a6185a5b84109aa6855134e81397ffe72b", size = 56275178, upload-time = "2026-03-31T18:29:42.58Z" },
     { url = "https://files.pythonhosted.org/packages/f5/cb/0abf1dd4c5286a95ffe0c1d8c67aec06b515894a0dd2ac97f5e27b82ab0b/llvmlite-0.47.0-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f6725179b89f03b17dabe236ff3422cb8291b4c1bf40af152826dfd34e350ae8", size = 55128632, upload-time = "2026-03-31T18:29:46.939Z" },
+]
+
+[[package]]
+name = "loguru"
+version = "0.7.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "win32-setctime", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3a/05/a1dae3dffd1116099471c643b8924f5aa6524411dc6c63fdae648c4f1aca/loguru-0.7.3.tar.gz", hash = "sha256:19480589e77d47b8d85b2c827ad95d49bf31b0dcde16593892eb51dd18706eb6", size = 63559, upload-time = "2024-12-06T11:20:56.608Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl", hash = "sha256:31a33c10c8e1e10422bfd431aeb5d351c7cf7fa671e3c4df004162264b28220c", size = 61595, upload-time = "2024-12-06T11:20:54.538Z" },
 ]
 
 [[package]]
@@ -3738,6 +3795,50 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
+]
+
+[[package]]
+name = "msgpack"
+version = "1.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/f2/bfb55a6236ed8725a96b0aa3acbd0ec17588e6a2c3b62a93eb513ed8783f/msgpack-1.1.2.tar.gz", hash = "sha256:3b60763c1373dd60f398488069bcdc703cd08a711477b5d480eecc9f9626f47e", size = 173581, upload-time = "2025-10-08T09:15:56.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/bd/8b0d01c756203fbab65d265859749860682ccd2a59594609aeec3a144efa/msgpack-1.1.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:70a0dff9d1f8da25179ffcf880e10cf1aad55fdb63cd59c9a49a1b82290062aa", size = 81939, upload-time = "2025-10-08T09:15:01.472Z" },
+    { url = "https://files.pythonhosted.org/packages/34/68/ba4f155f793a74c1483d4bdef136e1023f7bcba557f0db4ef3db3c665cf1/msgpack-1.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:446abdd8b94b55c800ac34b102dffd2f6aa0ce643c55dfc017ad89347db3dbdb", size = 85064, upload-time = "2025-10-08T09:15:03.764Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/60/a064b0345fc36c4c3d2c743c82d9100c40388d77f0b48b2f04d6041dbec1/msgpack-1.1.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c63eea553c69ab05b6747901b97d620bb2a690633c77f23feb0c6a947a8a7b8f", size = 417131, upload-time = "2025-10-08T09:15:05.136Z" },
+    { url = "https://files.pythonhosted.org/packages/65/92/a5100f7185a800a5d29f8d14041f61475b9de465ffcc0f3b9fba606e4505/msgpack-1.1.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:372839311ccf6bdaf39b00b61288e0557916c3729529b301c52c2d88842add42", size = 427556, upload-time = "2025-10-08T09:15:06.837Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/87/ffe21d1bf7d9991354ad93949286f643b2bb6ddbeab66373922b44c3b8cc/msgpack-1.1.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2929af52106ca73fcb28576218476ffbb531a036c2adbcf54a3664de124303e9", size = 404920, upload-time = "2025-10-08T09:15:08.179Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/41/8543ed2b8604f7c0d89ce066f42007faac1eaa7d79a81555f206a5cdb889/msgpack-1.1.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:be52a8fc79e45b0364210eef5234a7cf8d330836d0a64dfbb878efa903d84620", size = 415013, upload-time = "2025-10-08T09:15:09.83Z" },
+    { url = "https://files.pythonhosted.org/packages/41/0d/2ddfaa8b7e1cee6c490d46cb0a39742b19e2481600a7a0e96537e9c22f43/msgpack-1.1.2-cp312-cp312-win32.whl", hash = "sha256:1fff3d825d7859ac888b0fbda39a42d59193543920eda9d9bea44d958a878029", size = 65096, upload-time = "2025-10-08T09:15:11.11Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/ec/d431eb7941fb55a31dd6ca3404d41fbb52d99172df2e7707754488390910/msgpack-1.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:1de460f0403172cff81169a30b9a92b260cb809c4cb7e2fc79ae8d0510c78b6b", size = 72708, upload-time = "2025-10-08T09:15:12.554Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/31/5b1a1f70eb0e87d1678e9624908f86317787b536060641d6798e3cf70ace/msgpack-1.1.2-cp312-cp312-win_arm64.whl", hash = "sha256:be5980f3ee0e6bd44f3a9e9dea01054f175b50c3e6cdb692bc9424c0bbb8bf69", size = 64119, upload-time = "2025-10-08T09:15:13.589Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/31/b46518ecc604d7edf3a4f94cb3bf021fc62aa301f0cb849936968164ef23/msgpack-1.1.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4efd7b5979ccb539c221a4c4e16aac1a533efc97f3b759bb5a5ac9f6d10383bf", size = 81212, upload-time = "2025-10-08T09:15:14.552Z" },
+    { url = "https://files.pythonhosted.org/packages/92/dc/c385f38f2c2433333345a82926c6bfa5ecfff3ef787201614317b58dd8be/msgpack-1.1.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:42eefe2c3e2af97ed470eec850facbe1b5ad1d6eacdbadc42ec98e7dcf68b4b7", size = 84315, upload-time = "2025-10-08T09:15:15.543Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/68/93180dce57f684a61a88a45ed13047558ded2be46f03acb8dec6d7c513af/msgpack-1.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1fdf7d83102bf09e7ce3357de96c59b627395352a4024f6e2458501f158bf999", size = 412721, upload-time = "2025-10-08T09:15:16.567Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ba/459f18c16f2b3fc1a1ca871f72f07d70c07bf768ad0a507a698b8052ac58/msgpack-1.1.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fac4be746328f90caa3cd4bc67e6fe36ca2bf61d5c6eb6d895b6527e3f05071e", size = 424657, upload-time = "2025-10-08T09:15:17.825Z" },
+    { url = "https://files.pythonhosted.org/packages/38/f8/4398c46863b093252fe67368b44edc6c13b17f4e6b0e4929dbf0bdb13f23/msgpack-1.1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:fffee09044073e69f2bad787071aeec727183e7580443dfeb8556cbf1978d162", size = 402668, upload-time = "2025-10-08T09:15:19.003Z" },
+    { url = "https://files.pythonhosted.org/packages/28/ce/698c1eff75626e4124b4d78e21cca0b4cc90043afb80a507626ea354ab52/msgpack-1.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5928604de9b032bc17f5099496417f113c45bc6bc21b5c6920caf34b3c428794", size = 419040, upload-time = "2025-10-08T09:15:20.183Z" },
+    { url = "https://files.pythonhosted.org/packages/67/32/f3cd1667028424fa7001d82e10ee35386eea1408b93d399b09fb0aa7875f/msgpack-1.1.2-cp313-cp313-win32.whl", hash = "sha256:a7787d353595c7c7e145e2331abf8b7ff1e6673a6b974ded96e6d4ec09f00c8c", size = 65037, upload-time = "2025-10-08T09:15:21.416Z" },
+    { url = "https://files.pythonhosted.org/packages/74/07/1ed8277f8653c40ebc65985180b007879f6a836c525b3885dcc6448ae6cb/msgpack-1.1.2-cp313-cp313-win_amd64.whl", hash = "sha256:a465f0dceb8e13a487e54c07d04ae3ba131c7c5b95e2612596eafde1dccf64a9", size = 72631, upload-time = "2025-10-08T09:15:22.431Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/db/0314e4e2db56ebcf450f277904ffd84a7988b9e5da8d0d61ab2d057df2b6/msgpack-1.1.2-cp313-cp313-win_arm64.whl", hash = "sha256:e69b39f8c0aa5ec24b57737ebee40be647035158f14ed4b40e6f150077e21a84", size = 64118, upload-time = "2025-10-08T09:15:23.402Z" },
+    { url = "https://files.pythonhosted.org/packages/22/71/201105712d0a2ff07b7873ed3c220292fb2ea5120603c00c4b634bcdafb3/msgpack-1.1.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e23ce8d5f7aa6ea6d2a2b326b4ba46c985dbb204523759984430db7114f8aa00", size = 81127, upload-time = "2025-10-08T09:15:24.408Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/9f/38ff9e57a2eade7bf9dfee5eae17f39fc0e998658050279cbb14d97d36d9/msgpack-1.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6c15b7d74c939ebe620dd8e559384be806204d73b4f9356320632d783d1f7939", size = 84981, upload-time = "2025-10-08T09:15:25.812Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a9/3536e385167b88c2cc8f4424c49e28d49a6fc35206d4a8060f136e71f94c/msgpack-1.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:99e2cb7b9031568a2a5c73aa077180f93dd2e95b4f8d3b8e14a73ae94a9e667e", size = 411885, upload-time = "2025-10-08T09:15:27.22Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/40/dc34d1a8d5f1e51fc64640b62b191684da52ca469da9cd74e84936ffa4a6/msgpack-1.1.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:180759d89a057eab503cf62eeec0aa61c4ea1200dee709f3a8e9397dbb3b6931", size = 419658, upload-time = "2025-10-08T09:15:28.4Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/ef/2b92e286366500a09a67e03496ee8b8ba00562797a52f3c117aa2b29514b/msgpack-1.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:04fb995247a6e83830b62f0b07bf36540c213f6eac8e851166d8d86d83cbd014", size = 403290, upload-time = "2025-10-08T09:15:29.764Z" },
+    { url = "https://files.pythonhosted.org/packages/78/90/e0ea7990abea5764e4655b8177aa7c63cdfa89945b6e7641055800f6c16b/msgpack-1.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8e22ab046fa7ede9e36eeb4cfad44d46450f37bb05d5ec482b02868f451c95e2", size = 415234, upload-time = "2025-10-08T09:15:31.022Z" },
+    { url = "https://files.pythonhosted.org/packages/72/4e/9390aed5db983a2310818cd7d3ec0aecad45e1f7007e0cda79c79507bb0d/msgpack-1.1.2-cp314-cp314-win32.whl", hash = "sha256:80a0ff7d4abf5fecb995fcf235d4064b9a9a8a40a3ab80999e6ac1e30b702717", size = 66391, upload-time = "2025-10-08T09:15:32.265Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/f1/abd09c2ae91228c5f3998dbd7f41353def9eac64253de3c8105efa2082f7/msgpack-1.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:9ade919fac6a3e7260b7f64cea89df6bec59104987cbea34d34a2fa15d74310b", size = 73787, upload-time = "2025-10-08T09:15:33.219Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/b0/9d9f667ab48b16ad4115c1935d94023b82b3198064cb84a123e97f7466c1/msgpack-1.1.2-cp314-cp314-win_arm64.whl", hash = "sha256:59415c6076b1e30e563eb732e23b994a61c159cec44deaf584e5cc1dd662f2af", size = 66453, upload-time = "2025-10-08T09:15:34.225Z" },
+    { url = "https://files.pythonhosted.org/packages/16/67/93f80545eb1792b61a217fa7f06d5e5cb9e0055bed867f43e2b8e012e137/msgpack-1.1.2-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:897c478140877e5307760b0ea66e0932738879e7aa68144d9b78ea4c8302a84a", size = 85264, upload-time = "2025-10-08T09:15:35.61Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/33c8a24959cf193966ef11a6f6a2995a65eb066bd681fd085afd519a57ce/msgpack-1.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a668204fa43e6d02f89dbe79a30b0d67238d9ec4c5bd8a940fc3a004a47b721b", size = 89076, upload-time = "2025-10-08T09:15:36.619Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/6b/62e85ff7193663fbea5c0254ef32f0c77134b4059f8da89b958beb7696f3/msgpack-1.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5559d03930d3aa0f3aacb4c42c776af1a2ace2611871c84a75afe436695e6245", size = 435242, upload-time = "2025-10-08T09:15:37.647Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/47/5c74ecb4cc277cf09f64e913947871682ffa82b3b93c8dad68083112f412/msgpack-1.1.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:70c5a7a9fea7f036b716191c29047374c10721c389c21e9ffafad04df8c52c90", size = 432509, upload-time = "2025-10-08T09:15:38.794Z" },
+    { url = "https://files.pythonhosted.org/packages/24/a4/e98ccdb56dc4e98c929a3f150de1799831c0a800583cde9fa022fa90602d/msgpack-1.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f2cb069d8b981abc72b41aea1c580ce92d57c673ec61af4c500153a626cb9e20", size = 415957, upload-time = "2025-10-08T09:15:40.238Z" },
+    { url = "https://files.pythonhosted.org/packages/da/28/6951f7fb67bc0a4e184a6b38ab71a92d9ba58080b27a77d3e2fb0be5998f/msgpack-1.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:d62ce1f483f355f61adb5433ebfd8868c5f078d1a52d042b0a998682b4fa8c27", size = 422910, upload-time = "2025-10-08T09:15:41.505Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/03/42106dcded51f0a0b5284d3ce30a671e7bd3f7318d122b2ead66ad289fed/msgpack-1.1.2-cp314-cp314t-win32.whl", hash = "sha256:1d1418482b1ee984625d88aa9585db570180c286d942da463533b238b98b812b", size = 75197, upload-time = "2025-10-08T09:15:42.954Z" },
+    { url = "https://files.pythonhosted.org/packages/15/86/d0071e94987f8db59d4eeb386ddc64d0bb9b10820a8d82bcd3e53eeb2da6/msgpack-1.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:5a46bf7e831d09470ad92dff02b8b1ac92175ca36b087f904a0519857c6be3ff", size = 85772, upload-time = "2025-10-08T09:15:43.954Z" },
+    { url = "https://files.pythonhosted.org/packages/81/f2/08ace4142eb281c12701fc3b93a10795e4d4dc7f753911d836675050f886/msgpack-1.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:d99ef64f349d5ec3293688e91486c5fdb925ed03807f64d98d205d2713c60b46", size = 70868, upload-time = "2025-10-08T09:15:44.959Z" },
 ]
 
 [[package]]
@@ -4183,14 +4284,33 @@ wheels = [
 
 [[package]]
 name = "nvidia-cudnn-cu12"
-version = "9.19.0.56"
+version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/09/b8/277c51962ee46fa3e5b203ac5f76107c650f781d6891e681e28e6f3e9fe6/nvidia_cudnn_cu12-9.19.0.56-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:08caaf27fe556aca82a3ee3b5aa49a77e7de0cfcb7ff4e5c29da426387a8267e", size = 656910700, upload-time = "2026-02-03T20:40:25.508Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/41/65225d42fba06fb3dd3972485ea258e7dd07a40d6e01c95da6766ad87354/nvidia_cudnn_cu12-9.19.0.56-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:ac6ad90a075bb33a94f2b4cf4622eac13dd4dc65cf6dd9c7572a318516a36625", size = 657906812, upload-time = "2026-02-03T20:44:12.638Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/41/e79269ce215c857c935fd86bcfe91a451a584dfc27f1e068f568b9ad1ab7/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:c9132cc3f8958447b4910a1720036d9eff5928cc3179b0a51fb6d167c6cc87d8", size = 705026878, upload-time = "2025-06-06T21:52:51.348Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
+]
+
+[[package]]
+name = "nvidia-cudnn-frontend"
+version = "1.24.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/62/4efc0733edd16ed3f024f511dfc1f3a0efd7c1cc1af8caf46f3c50f40851/nvidia_cudnn_frontend-1.24.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:23af4f26bce59a0881ff6c170bab2ca02828bdd8fd80925a821dacc45bf23574", size = 3226159, upload-time = "2026-06-05T07:34:16.241Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/89/b238ba02c08e07c331010811b41f880bac6d823f3e461f0a2ac5b751a292/nvidia_cudnn_frontend-1.24.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:844006309b84e800b00fb720fbd74398f09500c71efd39b8d3e50b7c48e521a2", size = 3379850, upload-time = "2026-06-05T07:34:32.746Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/d4/f1f914965ca7d3e9d7f038bd82dc96f9c299c3ce871e91f2aa147b000365/nvidia_cudnn_frontend-1.24.1-cp312-cp312-win_amd64.whl", hash = "sha256:10b0b0aa4059085065cffecefb9e1ab086057475bec84b7e001dc16f5b604bb9", size = 2765022, upload-time = "2026-06-05T07:34:54.99Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/20/50ca0762f971581ac180f93a094485555943f7a2c42759e3db0fb7d79d9e/nvidia_cudnn_frontend-1.24.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:efa217f6ccb96d24b75925b028deb790c225c6bf03ad12a6aba59228aa94cbff", size = 3226238, upload-time = "2026-06-05T07:35:17.038Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/f0/11b8f27e4db392c150d77cdc4e0dc2eb478fcfb30c2e51e06ff4cf5857ba/nvidia_cudnn_frontend-1.24.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b41eeb7098c7ac5dda3add3c9d154b03a691a9c2421a03de4d15d009836d2dd6", size = 3379172, upload-time = "2026-06-05T07:35:42.354Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/3b/e1bf7694ef2ef007492299437eb7a1f7d3c449f628df4970a00a9384bcc4/nvidia_cudnn_frontend-1.24.1-cp313-cp313-win_amd64.whl", hash = "sha256:e0e440fee335d5c5992ddb17d3358e8f32e0b2a9d99c9a786c1c73c499cc1efa", size = 2765239, upload-time = "2026-06-05T07:36:01.206Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/a9/edcb15c77f392ebbcfd18bf3e19cf429dc4fe3829f5eac3bc5c537f99268/nvidia_cudnn_frontend-1.24.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eec247a317721990e918d9f22e438119f9e1f72498690b46eab77f175d99032c", size = 3228352, upload-time = "2026-06-05T07:36:22.125Z" },
+    { url = "https://files.pythonhosted.org/packages/84/f3/bdd234f52ac2c333c2188335afe37c6142ea745eeea84c672971002c047f/nvidia_cudnn_frontend-1.24.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:026ba8e623e3bd02fe5ad52f2d1f4b5af3272635c52824a88034e80ed57f3710", size = 3378681, upload-time = "2026-06-05T07:36:43.71Z" },
+    { url = "https://files.pythonhosted.org/packages/60/b0/f716e0cb7a69d0521a5a89ca87752260a265ee086f111875425da711c723/nvidia_cudnn_frontend-1.24.1-cp314-cp314-win_amd64.whl", hash = "sha256:3602e7de008c4dedd9c1e05c86094de40b60cb26396ffa25dd30b2bef5b883e4", size = 2765847, upload-time = "2026-06-05T07:37:07.965Z" },
+    { url = "https://files.pythonhosted.org/packages/23/e3/c39dd55b8207f0968db3a726b414004fcbf4e06bfb50213e243bfc3f941c/nvidia_cudnn_frontend-1.24.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4ce47cf199ed335861e55432f68fe3602daa87297b292be6e2ef6b7e609c7d3d", size = 3234639, upload-time = "2026-06-05T07:37:29.408Z" },
+    { url = "https://files.pythonhosted.org/packages/67/3d/fce2a9c24ed8d5ccedf7b70c8c8419c540f9061030c4757fb7dbcbfce474/nvidia_cudnn_frontend-1.24.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccf7f523abfb895a4f0bc67810fee4f7cffa0c329d1c0a6611ff0abdc8ee3362", size = 3384126, upload-time = "2026-06-05T07:37:50.218Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/08/f44bd3f518db0edae9466cc2db1776378df61d63a834a9e71586d1a5be03/nvidia_cudnn_frontend-1.24.1-cp314-cp314t-win_amd64.whl", hash = "sha256:ce9dd20ff694bc6d0531521922d89799939f99333b18d20dceb064effc1bea98", size = 2791016, upload-time = "2026-06-05T07:38:14.455Z" },
 ]
 
 [[package]]
@@ -4259,12 +4379,21 @@ wheels = [
 ]
 
 [[package]]
+name = "nvidia-ml-py"
+version = "13.610.43"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/b5/a8fbc356f768fa5c9cfd646668fd7d34bf55bdd1c6e20754642a64d930d4/nvidia_ml_py-13.610.43.tar.gz", hash = "sha256:65437eb73d68d0c62c931ca4d45038472faff03bd0b8729abba4b899f70d60f2", size = 52109, upload-time = "2026-06-01T18:54:08.829Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/45/caa600acfab94560807a20a64b5830d2cd3c3202b7f1328644d70b7d6bd8/nvidia_ml_py-13.610.43-py3-none-any.whl", hash = "sha256:f13c72698edef492f985cc225f14faafe68ae065a2e407f45bdf6f4b9b43fde8", size = 53163, upload-time = "2026-06-01T18:54:07.704Z" },
+]
+
+[[package]]
 name = "nvidia-nccl-cu12"
-version = "2.28.9"
+version = "2.27.5"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/08/c4/120d2dfd92dff2c776d68f361ff8705fdea2ca64e20b612fab0fd3f581ac/nvidia_nccl_cu12-2.28.9-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:50a36e01c4a090b9f9c47d92cec54964de6b9fcb3362d0e19b8ffc6323c21b60", size = 296766525, upload-time = "2025-11-18T05:49:16.094Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/4e/44dbb46b3d1b0ec61afda8e84837870f2f9ace33c564317d59b70bc19d3e/nvidia_nccl_cu12-2.28.9-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:485776daa8447da5da39681af455aa3b2c2586ddcf4af8772495e7c532c7e5ab", size = 296782137, upload-time = "2025-11-18T05:49:34.248Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/1c/857979db0ef194ca5e21478a0612bcdbbe59458d7694361882279947b349/nvidia_nccl_cu12-2.27.5-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:31432ad4d1fb1004eb0c56203dc9bc2178a1ba69d1d9e02d64a6938ab5e40e7a", size = 322400625, upload-time = "2025-06-26T04:11:04.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/89/f7a07dc961b60645dbbf42e80f2bc85ade7feb9a491b11a1e973aa00071f/nvidia_nccl_cu12-2.27.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ad730cf15cb5d25fe849c6e6ca9eb5b76db16a80f13f425ac68d8e2e55624457", size = 322348229, upload-time = "2025-06-26T04:11:28.385Z" },
 ]
 
 [[package]]
@@ -4295,12 +4424,62 @@ wheels = [
 ]
 
 [[package]]
+name = "obstore"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/e3/34852e48d5acedc1dbfa8bfb1ddcee448c7bb1dee7cefca659dce5ee10b4/obstore-0.10.0.tar.gz", hash = "sha256:b581d2f78b521c7c72862721384c109b6764c57222b7bf06dc83626a7c4a6945", size = 126379, upload-time = "2026-06-01T20:56:59.204Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/36/47/46357284f39465aeaec6b49f7741a26aa6c0258be6d0f968a3c5c1a93401/obstore-0.10.0-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:03b4e07d97e5271da136942dae71febd5a42c455aeee42a40892a6977171e9fa", size = 4090761, upload-time = "2026-06-01T20:55:33.434Z" },
+    { url = "https://files.pythonhosted.org/packages/48/40/dc3d2acc664af08c4b1062cd677c36a1f3a7face6fa4e966562ba58d92cc/obstore-0.10.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:e45deb76f3f1a54cf730c43e917af72d3f1a46e4c502190a9111d2dabec3d71e", size = 3871052, upload-time = "2026-06-01T20:55:35.001Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/22/2a4eec925df64b46839b37222fb46fa32faa6790173688b6bbc1a5fd303c/obstore-0.10.0-cp311-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d90894aafb8baf02d4d7d4e6debbbd43b26890bfbe0bcad7c6d75b41b019ed6b", size = 4024833, upload-time = "2026-06-01T20:55:36.527Z" },
+    { url = "https://files.pythonhosted.org/packages/27/a4/638775f75c7df43596c44684f722db4f130d9a47bc95047c81dcffd8461d/obstore-0.10.0-cp311-abi3-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e8a443c729dfb6324591664aa4cca5394d89924014d585ea4ac7e2d448ad3a8e", size = 4122218, upload-time = "2026-06-01T20:55:38.02Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/31/e7ad24144996cb1c84414f5dfca83ce149ccfca621399a4fafcabdf18635/obstore-0.10.0-cp311-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:52ed02949c1ea3dd445c963b246e95801ccd54b5d0d24050ad7ae9570e2c1195", size = 4410778, upload-time = "2026-06-01T20:55:39.468Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/37/d5710ed7aa32082933c89d3864197e9b413dbabd954ebd5504b976b998a6/obstore-0.10.0-cp311-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e360ce37f4b5f7b6e3eaf6517b8bbb481379eb0773a16bb2971c02b4363ca787", size = 4291676, upload-time = "2026-06-01T20:55:41.184Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/5a/11b2947870663c4d804a5467462dcfc66a13505cd360e97b2d6ccbc93686/obstore-0.10.0-cp311-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70accdf1fc624559c810bed68041f599a218f3dc4fb3afdeed50f7151e240ff8", size = 4210395, upload-time = "2026-06-01T20:55:42.923Z" },
+    { url = "https://files.pythonhosted.org/packages/63/2d/363d7d7f89378753e5491e5d1189b0c728d68ea39d2a02baa6644fb8c4ca/obstore-0.10.0-cp311-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:4fc646ad2c2ceaa3dbe07536eb207e1e868e4c701c89f71dd35678e1ee957283", size = 4101733, upload-time = "2026-06-01T20:55:44.561Z" },
+    { url = "https://files.pythonhosted.org/packages/51/fd/7ceffe6b89feb6169f81d2b1b5d06eb53998422346c79365424dd06978b1/obstore-0.10.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:72610b6e7b3da608762b6a8a37989e0559c813ac115b9376a176810eb0173bd8", size = 4285774, upload-time = "2026-06-01T20:55:46.661Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/d9/4c534074516645236157135127e3379184f6f8e2622ab93485946ce2df42/obstore-0.10.0-cp311-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:38a10746b540aab3f898422d87fa7112dab35a824dfa912b64480eb37b55c755", size = 4258354, upload-time = "2026-06-01T20:55:48.435Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/dc/3f40b59c19054d8dc0c2699cdc72348bfd56edec78008c5e6bebe8aed55e/obstore-0.10.0-cp311-abi3-musllinux_1_2_i686.whl", hash = "sha256:e62afd200b2e5bc93cff75e6f930877f4203a6a2f0e13252c6ce7dba78d77c9c", size = 4247831, upload-time = "2026-06-01T20:55:50.005Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/08/28d6917d454ae587ef10b10b5d591c22ceb42bcb42c777463fe04ff3efb7/obstore-0.10.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:25e1cad14a7723e48e358c5635dc199ec1d0ddb0f6724ff58d92057ed93ad81b", size = 4429790, upload-time = "2026-06-01T20:55:51.765Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/de/5c683e75a7504ee73d51e34ac4b98c1eb2ab7679d53d292009028e05338b/obstore-0.10.0-cp311-abi3-win_amd64.whl", hash = "sha256:7e14e1ef6bb63730d6aec78499b0aa48dde160d1ad8fdd1e5553c930e7664107", size = 4166690, upload-time = "2026-06-01T20:55:53.314Z" },
+    { url = "https://files.pythonhosted.org/packages/de/c1/782617a10203916d193ab2bc6efe363f8f42b5bc6fbde0e0cc3bb51a58dc/obstore-0.10.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:f343227c37c6f217aaf56e82f58335fa5f34b70a727f4e5e718becc9c613060a", size = 4073158, upload-time = "2026-06-01T20:55:54.886Z" },
+    { url = "https://files.pythonhosted.org/packages/15/6b/31d0a6801a05fb032060bb38c94acb5348ac4ceb0a3a55d0b100439005b4/obstore-0.10.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:5b071781d2ef95653f78aef588bd054480381d679ae57c4f5d2553b366de1a05", size = 3862303, upload-time = "2026-06-01T20:55:56.509Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/0c/70c1ba253ab9a7dbdb73996381b73ff9a121b032e9d04125709378f44b67/obstore-0.10.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:71657a256f938715f5a4d3fe84c5141b79572dbe2436b90d0020ecb9cfe6548b", size = 4021507, upload-time = "2026-06-01T20:55:58.331Z" },
+    { url = "https://files.pythonhosted.org/packages/81/d5/5495cb6056fac0f9394518c8eb85340ba625245a14de4384385966efeaba/obstore-0.10.0-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1a96beb5628f3303d8fdfd003b1957f4c2a38f0f224a47b6e488ab0b4eb23edb", size = 4113513, upload-time = "2026-06-01T20:55:59.991Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/80/90b292e9989ea387b60f66077cafcb6cc637f3a3ec109ba2c3fd7849b19d/obstore-0.10.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2509b29b89e5a00480f165d5351132da2efeeca6a57d29f018c4e0534a5a5dc0", size = 4400976, upload-time = "2026-06-01T20:56:01.512Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/33/7ae84485bccb672f4abab5a4362e2e1554d3df83f07f76e2d68bee2a0657/obstore-0.10.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6b53a9c3e3afe24ea53e554c1d5626fdd456b2e7960091fce4a77af5b7a0ffb7", size = 4298268, upload-time = "2026-06-01T20:56:03.197Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/f1/9934e3ae0869085449d87c54e41cef137c8ea8527a87d60f9934f822bc08/obstore-0.10.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2d07b04a16c6a586444de1997f2121a332db05aac7953fbcb3e8fb28140306a8", size = 4208768, upload-time = "2026-06-01T20:56:05.314Z" },
+    { url = "https://files.pythonhosted.org/packages/69/76/50cd42e12d8fecef6637a00a857b39c4aade6fa8a100634fe8a000fe56ca/obstore-0.10.0-cp313-cp313t-manylinux_2_24_aarch64.whl", hash = "sha256:012ebb24ba0c47e54840fa02bef780ce4f4d73a3c9685d9addd53222f1b375b2", size = 4100278, upload-time = "2026-06-01T20:56:07.187Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/be/378d4ea417771bfffd49222711f70b426f475475881aa6adddf67e62be18/obstore-0.10.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:defe889c3baf0781eb83e0335e89fb1331723bebd6a015dc4eecb99794c70210", size = 4285696, upload-time = "2026-06-01T20:56:08.898Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/26/40a9a419de6ccc9e828336fab4a89a5d90c1e01523cce781600dfa970b6b/obstore-0.10.0-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:b4b1fcf083474384565c5fd06523894419280fca4aeb23a7f3f88add8db2d824", size = 4255725, upload-time = "2026-06-01T20:56:10.609Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/db/038ae746b5f8ca2677fa95418234edfa22ebdeff77a55fa349abcb6a6823/obstore-0.10.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:c2c4974845b1192ec50959ad8579e01699b6ae8c64adb6433addcfbf35263901", size = 4242564, upload-time = "2026-06-01T20:56:12.127Z" },
+    { url = "https://files.pythonhosted.org/packages/95/a3/dad7562624b89ed8b8c06241eea9340812decb4bbf1e4f744e9fbf652461/obstore-0.10.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:315fe386cc631247175c2cc64dfa77f7ec4746248d0a03a7126d9b6a063a1a1d", size = 4429578, upload-time = "2026-06-01T20:56:13.887Z" },
+    { url = "https://files.pythonhosted.org/packages/96/d2/b2a232c428b7848862da2b31428694237bd4fe71166ace65d48bbfea6eb4/obstore-0.10.0-cp313-cp313t-win_amd64.whl", hash = "sha256:1fc3a232026f9b33affa4c6aa9d4a1765c08aa4e2d0aa8a6034801cf3f8a3cf6", size = 4160793, upload-time = "2026-06-01T20:56:15.629Z" },
+    { url = "https://files.pythonhosted.org/packages/13/54/f3ed3d770279f59d87f476d36715f96ee097a8ab42f08c660c1e29d2a56e/obstore-0.10.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:fedac1464b8835063a5661da8dd33519d0d24988d2b256c92b5841c26b18ce28", size = 4073290, upload-time = "2026-06-01T20:56:17.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/3d/8a20aa21c615b25fc37b1396f4d643a3f0a951b5d73284b1822b443912b0/obstore-0.10.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2cccb3adef4e6e113fcd54a12c342c2a01fb8e470abfa1a5f9ce4ad2830514f1", size = 3862508, upload-time = "2026-06-01T20:56:19.011Z" },
+    { url = "https://files.pythonhosted.org/packages/63/73/e1b00867e462c168de19a518688463f26a3560149373ab9a5b00a62770b7/obstore-0.10.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d0396e857e403848a366ba38ee0289a5ea206cff1e184d2ce7f63eeb2a24da20", size = 4021738, upload-time = "2026-06-01T20:56:20.485Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d9/23438e668d7eeeb7f30de4bece9467bdf9c2df25a849c10aec03edca4fc6/obstore-0.10.0-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3911b95eac66328606cfa0c5545592ef18c04c242f5c5631c18ef4c3ce456009", size = 4113768, upload-time = "2026-06-01T20:56:22.116Z" },
+    { url = "https://files.pythonhosted.org/packages/00/9c/e501563733f212f83ea3f2661f67c25dfd5cfd46bc9a979237662910b424/obstore-0.10.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5f86aa14f02e35db95b5331dda4387761366fefd52ec0856c9eed07bf92c681d", size = 4401455, upload-time = "2026-06-01T20:56:23.742Z" },
+    { url = "https://files.pythonhosted.org/packages/35/12/2d1b356fc58e0868590f402067bcfe58d8de7501109f50924a2d691ae6e3/obstore-0.10.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b29f2477551114f1d3e01d9729fc54f88b6d6cd83fdc6e40d36eb4781ad03cd4", size = 4297930, upload-time = "2026-06-01T20:56:25.365Z" },
+    { url = "https://files.pythonhosted.org/packages/94/5b/4deaf8795054977204925234ad9504b1fb942125bfeea11f6d11c7c04889/obstore-0.10.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8d2290638739df5c4c9e766e716fb536eb0e591350302ba492ff2dac7b03e913", size = 4209433, upload-time = "2026-06-01T20:56:27.151Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/fc/b80e7aa1119b46d7f232499ffda8c6e7db676405b421d566f856bd8034a6/obstore-0.10.0-cp314-cp314t-manylinux_2_24_aarch64.whl", hash = "sha256:0d6b1cf7af217dd6091e097e240347a64709a11eb22a89adcc85dda7462d2b4b", size = 4101258, upload-time = "2026-06-01T20:56:28.616Z" },
+    { url = "https://files.pythonhosted.org/packages/56/7b/1518ad6d7ad39904378395c47fee2726d9d4518053089e7bd23406c827c3/obstore-0.10.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c338a9fcbb18aebf5aab654fbb0731feaa27b80a0c1153aba0aa93188e89a6de", size = 4286477, upload-time = "2026-06-01T20:56:30.247Z" },
+    { url = "https://files.pythonhosted.org/packages/25/27/035ac9f52e84ca7cf17554e11d522d6c213f56e656aff934ac6f1d4e7122/obstore-0.10.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:089d64f61649ded2b4f997ec94a4b659f594e6632f65c1c88622ad21c73f6089", size = 4255950, upload-time = "2026-06-01T20:56:31.883Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2c/5d9a5b2d1674db851bb8c9b886cf6a4f0a1d65adef113bd469bd7bae955d/obstore-0.10.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:d12bc7c84cb923c65055d83705870e4fd7a233aba9db91a26aebcf2327614429", size = 4243073, upload-time = "2026-06-01T20:56:33.428Z" },
+    { url = "https://files.pythonhosted.org/packages/27/38/2899c989997d8576c0a37160721fcc094155b01eca4eff0ef5faf3fdf434/obstore-0.10.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:f4e69ce8e579227f6416c4e547c485a9ff84425ec92fd95107f2ad0cfb02f1cc", size = 4430865, upload-time = "2026-06-01T20:56:35.242Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ed/ddf7aa9f6fbaef49764af51c0aead36770afcb1cb43e05e5658c5bba404a/obstore-0.10.0-cp314-cp314t-win_amd64.whl", hash = "sha256:9a64ededa74677649358bb35a1f07d912c77c51f732b77c531383ef964e29cdd", size = 4161321, upload-time = "2026-06-01T20:56:36.801Z" },
+]
+
+[[package]]
 name = "omegaconf"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "antlr4-python3-runtime", marker = "sys_platform == 'linux'" },
-    { name = "pyyaml", marker = "sys_platform == 'linux'" },
+    { name = "antlr4-python3-runtime" },
+    { name = "pyyaml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/09/48/6388f1bb9da707110532cb70ec4d2822858ddfb44f1cdf1233c20a80ea4b/omegaconf-2.3.0.tar.gz", hash = "sha256:d5d4b6d29955cc50ad50c46dc269bcd92c6e00f5f90d23ab5fee7bfca4ba4cc7", size = 3298120, upload-time = "2022-12-08T20:59:22.753Z" }
 wheels = [
@@ -4509,8 +4688,8 @@ dependencies = [
     { name = "psutil" },
     { name = "pyyaml" },
     { name = "safetensors" },
-    { name = "torch", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
-    { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform == 'linux'" },
+    { name = "torch", version = "2.10.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
+    { name = "torch", version = "2.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform == 'linux'" },
     { name = "tqdm" },
     { name = "transformers" },
 ]
@@ -5737,8 +5916,8 @@ dependencies = [
     { name = "tensorboard", marker = "sys_platform == 'linux'" },
     { name = "tensorboardx", marker = "sys_platform == 'linux'" },
     { name = "termcolor", marker = "sys_platform == 'linux'" },
-    { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform == 'linux'" },
-    { name = "torchvision", version = "0.26.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform == 'linux'" },
+    { name = "torch", version = "2.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform == 'linux'" },
+    { name = "torchvision", version = "0.25.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform == 'linux'" },
     { name = "tqdm", marker = "sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3d/c3/44b1d1ea4bcb4bbed43d19e09505f4142714451ded74020d4f679cdc89fb/robomimic-0.2.0.tar.gz", hash = "sha256:ee3bb5cf9c3e1feead6b57b43c5db738fd0a8e0c015fdf6419808af8fffdc463", size = 192919, upload-time = "2021-12-17T19:00:33.279Z" }
@@ -5868,24 +6047,26 @@ wheels = [
 
 [[package]]
 name = "safetensors"
-version = "0.7.0"
+version = "0.8.0rc1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/29/9c/6e74567782559a63bd040a236edca26fd71bc7ba88de2ef35d75df3bca5e/safetensors-0.7.0.tar.gz", hash = "sha256:07663963b67e8bd9f0b8ad15bb9163606cd27cc5a1b96235a50d8369803b96b0", size = 200878, upload-time = "2025-11-19T15:18:43.199Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/a1/d46f642820c00443e86343b9548647a82c78f8818857652084852757f805/safetensors-0.8.0rc1.tar.gz", hash = "sha256:a4bacbcd2ab9efe4eb5f1ea44afc9ac5f3b40e103ebde146e370e885ba46f2fc", size = 325883, upload-time = "2026-06-01T09:54:53.914Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/47/aef6c06649039accf914afef490268e1067ed82be62bcfa5b7e886ad15e8/safetensors-0.7.0-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c82f4d474cf725255d9e6acf17252991c3c8aac038d6ef363a4bf8be2f6db517", size = 467781, upload-time = "2025-11-19T15:18:35.84Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/00/374c0c068e30cd31f1e1b46b4b5738168ec79e7689ca82ee93ddfea05109/safetensors-0.7.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:94fd4858284736bb67a897a41608b5b0c2496c9bdb3bf2af1fa3409127f20d57", size = 447058, upload-time = "2025-11-19T15:18:34.416Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/06/578ffed52c2296f93d7fd2d844cabfa92be51a587c38c8afbb8ae449ca89/safetensors-0.7.0-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e07d91d0c92a31200f25351f4acb2bc6aff7f48094e13ebb1d0fb995b54b6542", size = 491748, upload-time = "2025-11-19T15:18:09.79Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/33/1debbbb70e4791dde185edb9413d1fe01619255abb64b300157d7f15dddd/safetensors-0.7.0-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8469155f4cb518bafb4acf4865e8bb9d6804110d2d9bdcaa78564b9fd841e104", size = 503881, upload-time = "2025-11-19T15:18:16.145Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/1c/40c2ca924d60792c3be509833df711b553c60effbd91da6f5284a83f7122/safetensors-0.7.0-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:54bef08bf00a2bff599982f6b08e8770e09cc012d7bba00783fc7ea38f1fb37d", size = 623463, upload-time = "2025-11-19T15:18:21.11Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/3a/13784a9364bd43b0d61eef4bea2845039bc2030458b16594a1bd787ae26e/safetensors-0.7.0-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:42cb091236206bb2016d245c377ed383aa7f78691748f3bb6ee1bfa51ae2ce6a", size = 532855, upload-time = "2025-11-19T15:18:25.719Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/60/429e9b1cb3fc651937727befe258ea24122d9663e4d5709a48c9cbfceecb/safetensors-0.7.0-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dac7252938f0696ddea46f5e855dd3138444e82236e3be475f54929f0c510d48", size = 507152, upload-time = "2025-11-19T15:18:33.023Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/a8/4b45e4e059270d17af60359713ffd83f97900d45a6afa73aaa0d737d48b6/safetensors-0.7.0-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1d060c70284127fa805085d8f10fbd0962792aed71879d00864acda69dbab981", size = 541856, upload-time = "2025-11-19T15:18:31.075Z" },
-    { url = "https://files.pythonhosted.org/packages/06/87/d26d8407c44175d8ae164a95b5a62707fcc445f3c0c56108e37d98070a3d/safetensors-0.7.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:cdab83a366799fa730f90a4ebb563e494f28e9e92c4819e556152ad55e43591b", size = 674060, upload-time = "2025-11-19T15:18:37.211Z" },
-    { url = "https://files.pythonhosted.org/packages/11/f5/57644a2ff08dc6325816ba7217e5095f17269dada2554b658442c66aed51/safetensors-0.7.0-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:672132907fcad9f2aedcb705b2d7b3b93354a2aec1b2f706c4db852abe338f85", size = 771715, upload-time = "2025-11-19T15:18:38.689Z" },
-    { url = "https://files.pythonhosted.org/packages/86/31/17883e13a814bd278ae6e266b13282a01049b0c81341da7fd0e3e71a80a3/safetensors-0.7.0-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:5d72abdb8a4d56d4020713724ba81dac065fedb7f3667151c4a637f1d3fb26c0", size = 714377, upload-time = "2025-11-19T15:18:40.162Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/d8/0c8a7dc9b41dcac53c4cbf9df2b9c83e0e0097203de8b37a712b345c0be5/safetensors-0.7.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b0f6d66c1c538d5a94a73aa9ddca8ccc4227e6c9ff555322ea40bdd142391dd4", size = 677368, upload-time = "2025-11-19T15:18:41.627Z" },
-    { url = "https://files.pythonhosted.org/packages/05/e5/cb4b713c8a93469e3c5be7c3f8d77d307e65fe89673e731f5c2bfd0a9237/safetensors-0.7.0-cp38-abi3-win32.whl", hash = "sha256:c74af94bf3ac15ac4d0f2a7c7b4663a15f8c2ab15ed0fc7531ca61d0835eccba", size = 326423, upload-time = "2025-11-19T15:18:45.74Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/e6/ec8471c8072382cb91233ba7267fd931219753bb43814cbc71757bfd4dab/safetensors-0.7.0-cp38-abi3-win_amd64.whl", hash = "sha256:d1239932053f56f3456f32eb9625590cc7582e905021f94636202a864d470755", size = 341380, upload-time = "2025-11-19T15:18:44.427Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/6c/3bf8f6b52f47d15a1d922378893a4b6b7885847ea5ad84b2b4a18ea10f85/safetensors-0.8.0rc1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:7e57730ae523085fda4a80eef74ad40c6d67af60b38498d9995cc9fcb639103b", size = 473516, upload-time = "2026-06-01T09:54:47.735Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5d/2aa9139997bf1681778b96188522480c862af0b4efd978eaae5171296105/safetensors-0.8.0rc1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:ba66ebb7eaa5914ff41cd2b2cd7ccd22c844854be2a5179289e748c70ffa90a4", size = 484485, upload-time = "2026-06-01T09:54:46.523Z" },
+    { url = "https://files.pythonhosted.org/packages/01/07/c78d1bb09f83885467d4472b14598efc933bd37e0de443f18d23758b0ff3/safetensors-0.8.0rc1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3a72817e309ed17a6b805168bca500af711c8bf50cccf7bf790ad247788c676c", size = 503240, upload-time = "2026-06-01T09:54:37.393Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/1a/5ef0b186d4edda2ecdd1b4f4b384c03afa64ce17b4582c33329c32bad9ca/safetensors-0.8.0rc1-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c945f1ec6fc5a04abc174e79bce69c4613ae536c5276a3812a2a89b62ae009d7", size = 511782, upload-time = "2026-06-01T09:54:38.903Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/30/699638f35a524de781ba16cc5c54f31430fd04387960b1d7dc0d5d5fa305/safetensors-0.8.0rc1-cp310-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ba0397739b71400eab5d1f492d68484595cf8b5d13dbfef274e3bcf518348bd8", size = 633524, upload-time = "2026-06-01T09:54:40.169Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/bc/12ecd32fec076e836c25e57ac991e09d26fd448d361228057d3d5b3e4d1b/safetensors-0.8.0rc1-cp310-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f61b7d2c1babc6271d778138788c57c8a95898be6ad3b559971fce20ec1c9c23", size = 545342, upload-time = "2026-06-01T09:54:42.585Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/8f/23e0eca29cbaba9f89917e6ca2840f6a80bbcdf659a0e2cd59d311549b7b/safetensors-0.8.0rc1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:53f59971f435fb5c23bb7bfa3c00e6cdbb26486d41f3aaf04c6d9e2d91bc8e4c", size = 516088, upload-time = "2026-06-01T09:54:45.356Z" },
+    { url = "https://files.pythonhosted.org/packages/18/0b/490c76d05f9dd7041bdf29d72b43084ed1498dadebaca5955491e488f2be/safetensors-0.8.0rc1-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:b070ba9428e6b2b3b820152b1e1583931cfbd692cda595442d5fbc8b5a46e824", size = 513718, upload-time = "2026-06-01T09:54:41.477Z" },
+    { url = "https://files.pythonhosted.org/packages/34/e5/6ccbe61ac09b831b65b3d44239758bebe857a4c4d072a731472f2cd7e131/safetensors-0.8.0rc1-cp310-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:69f73c2ec4f76e89deaefe485fec0c6fc42c04a70e318aaefd235da8edacccb1", size = 560058, upload-time = "2026-06-01T09:54:43.954Z" },
+    { url = "https://files.pythonhosted.org/packages/73/37/1c2cd01fcf86703433bd2df7371f6d864449d31bfc0289d2575d9e4b001c/safetensors-0.8.0rc1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:87aad206a0bb02fa3ddaeb2feb1c6f7f39a87bea1976750ba28a857fbfcd6b31", size = 678511, upload-time = "2026-06-01T09:54:48.861Z" },
+    { url = "https://files.pythonhosted.org/packages/99/55/15c17603d8b575253431a574af4ffff447550a9ad6023f2ea643dad7af47/safetensors-0.8.0rc1-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:6ea00be4f7066ba834064fd7b104ba4b10d2e42cd915c9ece31f0e2b42e6b6d2", size = 786778, upload-time = "2026-06-01T09:54:50.231Z" },
+    { url = "https://files.pythonhosted.org/packages/64/a2/d049bddaf097c260204f3169184d7507e256a0c7e0e800eec96eba23688d/safetensors-0.8.0rc1-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:2445135cda6018a095ed951dec94a2c393f929ee3b7f7a9ca4630db854be6b89", size = 765767, upload-time = "2026-06-01T09:54:51.518Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/03/53ecffb459f5c58b8712e9fde57e8e2a011274eb7ec1f8de3db4641039a2/safetensors-0.8.0rc1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:cf949f6a37287572de1c47294b36131bf49528436724eec2f96015f75a3d0bc8", size = 722435, upload-time = "2026-06-01T09:54:52.767Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/e8/05503308f6b70d0f68b5a70bb24a4022f5630b68ddec4c114e7c0e24dd68/safetensors-0.8.0rc1-cp310-abi3-win32.whl", hash = "sha256:4633355aaa0da80e789cb7c014c462b6dabe0ecc5f5bb56738fca01511b99975", size = 342496, upload-time = "2026-06-01T09:54:57.119Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/23/1c28c20641d222633bddc03bde0b4f719fb8430cf016969683e332fa06e1/safetensors-0.8.0rc1-cp310-abi3-win_amd64.whl", hash = "sha256:d62fad383627979d80b640174c679f3304b3a21614c4d8e71f76910aecac9c8d", size = 355530, upload-time = "2026-06-01T09:54:56.129Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/ad/f8620b79a66144de4e9d018ff135b90abeeb11556947737f9657fb27f335/safetensors-0.8.0rc1-cp310-abi3-win_arm64.whl", hash = "sha256:2b8ce46f7f16376eaf7527ee1dc830a32f74542767c0779f446f76d0be6b5da8", size = 340439, upload-time = "2026-06-01T09:54:54.948Z" },
 ]
 
 [[package]]
@@ -6224,7 +6405,7 @@ name = "thop"
 version = "0.1.1.post2209072238"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform == 'linux'" },
+    { name = "torch", version = "2.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bb/0f/72beeab4ff5221dc47127c80f8834b4bcd0cb36f6ba91c0b1d04a1233403/thop-0.1.1.post2209072238-py3-none-any.whl", hash = "sha256:01473c225231927d2ad718351f78ebf7cffe6af3bed464c4f1ba1ef0f7cdda27", size = 15443, upload-time = "2022-09-07T14:38:37.211Z" },
@@ -6250,10 +6431,10 @@ dependencies = [
     { name = "huggingface-hub" },
     { name = "pyyaml" },
     { name = "safetensors" },
-    { name = "torch", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
-    { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform == 'linux'" },
-    { name = "torchvision", version = "0.26.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
-    { name = "torchvision", version = "0.26.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform == 'linux'" },
+    { name = "torch", version = "2.10.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
+    { name = "torch", version = "2.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform == 'linux'" },
+    { name = "torchvision", version = "0.25.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
+    { name = "torchvision", version = "0.25.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/08/54/ece85b0eef3700c90db8271a43669b05a0ebbe2edb1962329c34374a297e/timm-1.0.27.tar.gz", hash = "sha256:315dfe63186ca9fb7ff941268941231fd5be259f2b4bb4afa28560ae1015cb9a", size = 2439861, upload-time = "2026-05-08T19:38:36.844Z" }
 wheels = [
@@ -6309,7 +6490,7 @@ wheels = [
 
 [[package]]
 name = "torch"
-version = "2.11.0"
+version = "2.10.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15' and platform_machine == 'arm64' and sys_platform == 'darwin'",
@@ -6351,21 +6532,23 @@ dependencies = [
     { name = "typing-extensions", marker = "sys_platform != 'linux'" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/8b/69e3008d78e5cee2b30183340cc425081b78afc5eff3d080daab0adda9aa/torch-2.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4b5866312ee6e52ea625cd211dcb97d6a2cdc1131a5f15cc0d87eec948f6dd34", size = 80606338, upload-time = "2026-03-23T18:11:34.781Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/ff/6756f1c7ee302f6d202120e0f4f05b432b839908f9071157302cedfc5232/torch-2.11.0-cp312-cp312-win_amd64.whl", hash = "sha256:fbf39280699d1b869f55eac536deceaa1b60bd6788ba74f399cc67e60a5fab10", size = 114556047, upload-time = "2026-03-23T18:10:55.931Z" },
-    { url = "https://files.pythonhosted.org/packages/87/89/5ea6722763acee56b045435fb84258db7375c48165ec8be7880ab2b281c5/torch-2.11.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1e6debd97ccd3205bbb37eb806a9d8219e1139d15419982c09e23ef7d4369d18", size = 80606801, upload-time = "2026-03-23T18:10:18.649Z" },
-    { url = "https://files.pythonhosted.org/packages/66/82/3e3fcdd388fbe54e29fd3f991f36846ff4ac90b0d0181e9c8f7236565f82/torch-2.11.0-cp313-cp313-win_amd64.whl", hash = "sha256:4dda3b3f52d121063a731ddb835f010dc137b920d7fec2778e52f60d8e4bf0cd", size = 114555842, upload-time = "2026-03-23T18:09:52.111Z" },
-    { url = "https://files.pythonhosted.org/packages/db/38/8ac78069621b8c2b4979c2f96dc8409ef5e9c4189f6aac629189a78677ca/torch-2.11.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:8b394322f49af4362d4f80e424bcaca7efcd049619af03a4cf4501520bdf0fb4", size = 80959574, upload-time = "2026-03-23T18:10:14.214Z" },
-    { url = "https://files.pythonhosted.org/packages/48/6b/30d1459fa7e4b67e9e3fe1685ca1d8bb4ce7c62ef436c3a615963c6c866c/torch-2.11.0-cp313-cp313t-win_amd64.whl", hash = "sha256:a97b94bbf62992949b4730c6cd2cc9aee7b335921ee8dc207d930f2ed09ae2db", size = 114793702, upload-time = "2026-03-23T18:09:47.304Z" },
-    { url = "https://files.pythonhosted.org/packages/26/0d/8603382f61abd0db35841148ddc1ffd607bf3100b11c6e1dab6d2fc44e72/torch-2.11.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:01018087326984a33b64e04c8cb5c2795f9120e0d775ada1f6638840227b04d7", size = 80573442, upload-time = "2026-03-23T18:09:10.117Z" },
-    { url = "https://files.pythonhosted.org/packages/78/88/d4a4cda8362f8a30d1ed428564878c3cafb0d87971fbd3947d4c84552095/torch-2.11.0-cp314-cp314-win_amd64.whl", hash = "sha256:2b4e811728bd0cc58fb2b0948fe939a1ee2bf1422f6025be2fca4c7bd9d79718", size = 114552300, upload-time = "2026-03-23T18:09:05.617Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/46/4419098ed6d801750f26567b478fc185c3432e11e2cad712bc6b4c2ab0d0/torch-2.11.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8245477871c3700d4370352ffec94b103cfcb737229445cf9946cddb7b2ca7cd", size = 80959460, upload-time = "2026-03-23T18:09:00.818Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/bf/c8d12a2c86dbfd7f40fb2f56fbf5a505ccf2d9ce131eb559dfc7c51e1a04/torch-2.11.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b2a43985ff5ef6ddd923bbcf99943e5f58059805787c5c9a2622bf05ca2965b0", size = 114792991, upload-time = "2026-03-23T18:08:19.216Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/54/a2ba279afcca44bbd320d4e73675b282fcee3d81400ea1b53934efca6462/torch-2.10.0-2-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:13ec4add8c3faaed8d13e0574f5cd4a323c11655546f91fbe6afa77b57423574", size = 79498202, upload-time = "2026-02-10T21:44:52.603Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/23/2c9fe0c9c27f7f6cb865abcea8a4568f29f00acaeadfc6a37f6801f84cb4/torch-2.10.0-2-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:e521c9f030a3774ed770a9c011751fb47c4d12029a3d6522116e48431f2ff89e", size = 79498254, upload-time = "2026-02-10T21:44:44.095Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/01/624c4324ca01f66ae4c7cd1b74eb16fb52596dce66dbe51eff95ef9e7a4c/torch-2.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:2c66c61f44c5f903046cc696d088e21062644cbe541c7f1c4eaae88b2ad23547", size = 113757972, upload-time = "2026-01-21T16:24:39.516Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/5c/dee910b87c4d5c0fcb41b50839ae04df87c1cfc663cf1b5fca7ea565eeaa/torch-2.10.0-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:6d3707a61863d1c4d6ebba7be4ca320f42b869ee657e9b2c21c736bf17000294", size = 79498198, upload-time = "2026-01-21T16:24:34.704Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/16/502fb1b41e6d868e8deb5b0e3ae926bbb36dab8ceb0d1b769b266ad7b0c3/torch-2.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:c2ee399c644dc92ef7bc0d4f7e74b5360c37cdbe7c5ba11318dda49ffac2bc57", size = 113757050, upload-time = "2026-01-21T16:24:19.204Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/0b/39929b148f4824bc3ad6f9f72a29d4ad865bcf7ebfc2fa67584773e083d2/torch-2.10.0-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:3202429f58309b9fa96a614885eace4b7995729f44beb54d3e4a47773649d382", size = 79851305, upload-time = "2026-01-21T16:24:09.209Z" },
+    { url = "https://files.pythonhosted.org/packages/36/53/0197f868c75f1050b199fe58f9bf3bf3aecac9b4e85cc9c964383d745403/torch-2.10.0-cp313-cp313t-win_amd64.whl", hash = "sha256:ff43db38af76fda183156153983c9a096fc4c78d0cd1e07b14a2314c7f01c2c8", size = 113997015, upload-time = "2026-01-21T16:23:00.767Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/13/e76b4d9c160e89fff48bf16b449ea324bda84745d2ab30294c37c2434c0d/torch-2.10.0-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:cdf2a523d699b70d613243211ecaac14fe9c5df8a0b0a9c02add60fb2a413e0f", size = 79498248, upload-time = "2026-01-21T16:23:09.315Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/93/716b5ac0155f1be70ed81bacc21269c3ece8dba0c249b9994094110bfc51/torch-2.10.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:bf0d9ff448b0218e0433aeb198805192346c4fd659c852370d5cc245f602a06a", size = 79464992, upload-time = "2026-01-21T16:23:05.162Z" },
+    { url = "https://files.pythonhosted.org/packages/56/97/078a007208f8056d88ae43198833469e61a0a355abc0b070edd2c085eb9a/torch-2.10.0-cp314-cp314-win_amd64.whl", hash = "sha256:6528f13d2a8593a1a412ea07a99812495bec07e9224c28b2a25c0a30c7da025c", size = 113752373, upload-time = "2026-01-21T16:22:13.471Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/94/71994e7d0d5238393df9732fdab607e37e2b56d26a746cb59fdb415f8966/torch-2.10.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:f5ab4ba32383061be0fb74bda772d470140a12c1c3b58a0cfbf3dae94d164c28", size = 79850324, upload-time = "2026-01-21T16:22:09.494Z" },
+    { url = "https://files.pythonhosted.org/packages/66/4d/35352043ee0eaffdeff154fad67cd4a31dbed7ff8e3be1cc4549717d6d51/torch-2.10.0-cp314-cp314t-win_amd64.whl", hash = "sha256:71283a373f0ee2c89e0f0d5f446039bdabe8dbc3c9ccf35f0f784908b0acd185", size = 113995816, upload-time = "2026-01-21T16:22:05.312Z" },
 ]
 
 [[package]]
 name = "torch"
-version = "2.11.0+cu128"
+version = "2.10.0+cu128"
 source = { registry = "https://download.pytorch.org/whl/cu128" }
 resolution-markers = [
     "(python_full_version >= '3.15' and platform_machine == 'AMD64' and sys_platform == 'linux') or (python_full_version >= '3.15' and platform_machine == 'x86_64' and sys_platform == 'linux')",
@@ -6387,50 +6570,100 @@ resolution-markers = [
 ]
 dependencies = [
     { name = "cuda-bindings", marker = "sys_platform == 'linux'" },
-    { name = "cuda-toolkit", extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
     { name = "filelock", marker = "sys_platform == 'linux'" },
     { name = "fsspec", marker = "sys_platform == 'linux'" },
     { name = "jinja2", marker = "sys_platform == 'linux'" },
     { name = "networkx", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cupti-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime-cu12", marker = "sys_platform == 'linux'" },
     { name = "nvidia-cudnn-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufft-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufile-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-curand-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusolver-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparse-cu12", marker = "sys_platform == 'linux'" },
     { name = "nvidia-cusparselt-cu12", marker = "sys_platform == 'linux'" },
     { name = "nvidia-nccl-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
     { name = "nvidia-nvshmem-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvtx-cu12", marker = "sys_platform == 'linux'" },
     { name = "setuptools", marker = "sys_platform == 'linux'" },
     { name = "sympy", marker = "sys_platform == 'linux'" },
     { name = "triton", marker = "sys_platform == 'linux'" },
     { name = "typing-extensions", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:9c8f38efee365cb9d334de8a83ce52fc7e5fc9e5a7b0853285efa1b69e00b0f2", upload-time = "2026-04-27T17:41:30Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:d252cf975fb18c94a85336323ad425f473df56dab35a44b00399bd70c7a3b997", upload-time = "2026-04-27T17:42:06Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:7db3580106bba044da5b8950f3fb8fe5f31999eaab3f6a3aa2ac5d202c3684d2", upload-time = "2026-04-27T17:45:35Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:db964b33c55035a72ab3e2162287af8f1cc276039c65d015740cc88c26dcedf7", upload-time = "2026-04-27T17:46:18Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:cd1cf1005c5fe419194ee294b7b584ba5ad0f2fb1778b3fe5a7b9c3f4617ddbc", upload-time = "2026-04-27T17:50:01Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:74b628dbc71603977b09f4e140792c6e997081a35ef3421555f3f6e201b81210", upload-time = "2026-04-27T17:50:42Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:baa52f7b8a53cab16587b10f1c27d1000ca033f97236878b685b75d5a1b92408", upload-time = "2026-04-27T17:54:24Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:d389a850677f0d24dafae1573644034428d8d3b9c80b51d55ba62fed7e6c8777", upload-time = "2026-04-27T17:55:03Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:06849e9311dbb0617c97557d9c26c99a9e1c4f2ac9cb8e9b6d9b420d522acb91", upload-time = "2026-04-27T17:58:48Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:169a9987e1f84f0c5eee07544b3a34827a163ac9180e23abf0c3548f1335762c", upload-time = "2026-04-27T17:59:26Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:6f09cdf2415516be028ae82e6b985bcfc3eac37bc52ab401142689f6224516ca", upload-time = "2026-01-21T15:22:03Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:628e89bd5110ced7debee2a57c69959725b7fbc64eab81a39dd70e46c7e28ba5", upload-time = "2026-01-21T15:22:11Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:bdbcc703382f948e951c063448c9406bf38ce66c41dd698d9e2733fcf96c037a", upload-time = "2026-01-21T15:22:29Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:7b4bd23ed63de97456fcc81c26fea9f02ee02ce1112111c4dac0d8cfe574b23e", upload-time = "2026-01-21T15:22:51Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:f1f8b840c64b645a4bc61a393db48effb9c92b2dc26c8373873911f0750d1ea7", upload-time = "2026-01-21T15:23:28Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:23f58258012bcf1c349cb22af387e33aadca7f83ea617b080e774eb41e4fe8ff", upload-time = "2026-01-21T15:23:31Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:c42377bc2607e3e1c60da71b792fb507c3938c87fd6edab8b21c59c91473c36d", upload-time = "2026-01-21T15:23:56Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:37d71feea068776855686a1512058df3f19f6f040a151f055aa746601678744f", upload-time = "2026-01-21T15:24:08Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:777461f50b2daf77e4bdd8e2ad34bdfc5a993bf1bdf2ab9ef39f5edfe4e9c12b", upload-time = "2026-01-21T15:24:20Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.10.0%2Bcu128-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:7bcba6a7c5f0987a13298b1ca843155dcceceac758fa3c7ccd5c7af4059a1080", upload-time = "2026-01-21T15:24:44Z" },
 ]
 
 [[package]]
 name = "torchcodec"
-version = "0.11.1"
+version = "0.10.0"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.15' and platform_machine == 'arm64' and sys_platform == 'darwin'",
+    "python_full_version == '3.14.*' and platform_machine == 'arm64' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and platform_machine == 'arm64' and sys_platform == 'darwin'",
+    "python_full_version < '3.13' and platform_machine == 'arm64' and sys_platform == 'darwin'",
+    "python_full_version >= '3.15' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version < '3.13' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version < '3.13' and platform_machine == 's390x' and sys_platform == 'win32'",
+]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/85/38f4843ff2a6bf7dfb71a153acd99024dadb96749965a67524c2f1cc1894/torchcodec-0.11.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:57056e91d1d883d0fb77ca7759e304be9c0bdb4ea0e37bde5c2e361347063b8c", size = 4368988, upload-time = "2026-04-14T18:24:51.46Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/85/3b41034b0f1289423745f918ace2a1e1e86b9c578c2e2461b6afcbb5354a/torchcodec-0.11.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:f1aee486a84247fcaa67870ac5005aa8d382a9839e91e476fa71b5b3d9fda9b7", size = 2397532, upload-time = "2026-04-14T18:24:53.368Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/a9/a2b6ee3e84c55bdd0c45fd991dde71c95a99115ec9e26938b212b4545dcf/torchcodec-0.11.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:6c26e90e7aa982302644d0af8cb706318682bb390f48a80ecbfeab03499acd04", size = 2329883, upload-time = "2026-04-14T18:24:55.467Z" },
-    { url = "https://files.pythonhosted.org/packages/82/48/683114a4ed6b59f76b6919532a5db0f4068787be26bab92cc18a1dfa6794/torchcodec-0.11.1-cp312-cp312-win_amd64.whl", hash = "sha256:3fd2d10e0e0a5f455c1c87dc1380b3bd43b77dd5eeeaf479470643b1c04a2dd2", size = 1921066, upload-time = "2026-04-14T18:24:57.102Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/61/a8985a7561ef651e409deeac151a0ed5cef763db9577db5cc49c2f5eaab2/torchcodec-0.11.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:915fbe20068ec77486fbbeaf0c627c89c7376445f27d215b7489c0a03c64fd4c", size = 4289805, upload-time = "2026-04-14T18:24:59.124Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/31/c4ec0304dd169a9b2b7fa0dd1d5d659d3cccc975b98ac88c498fe6dd7196/torchcodec-0.11.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:3755de03c96afd37410cba68198225d11cd6431a32f2161a0019791a4a853305", size = 2399057, upload-time = "2026-04-14T18:25:00.782Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/b2/85ad7a81f387e40983c21bc94da0c333974afb41f38c3a85d25875274187/torchcodec-0.11.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:5eee69971cec1147a03b8a6b678b5dfbeff0b2c71ed7929e488391f9fbcd630c", size = 2332721, upload-time = "2026-04-14T18:25:02.518Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/ca/5c66f21d2a12039450e9dd4d9d7c480019dfbe9e8a87696a3c3a827c1e37/torchcodec-0.11.1-cp313-cp313-win_amd64.whl", hash = "sha256:67b34e5733636588ebe0f15082bbb90a8ce1472ccb8bb1a656ec28958a208919", size = 1920990, upload-time = "2026-04-14T18:25:04.269Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/b7/8d6ee76fca0cfefec01402f33c11766455da2b8460cb9191cdc34f8defc0/torchcodec-0.11.1-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:a00ef79e847644f91c9995de021062adc851916b16244d26c0a7a04569710508", size = 4408290, upload-time = "2026-04-14T18:25:05.967Z" },
-    { url = "https://files.pythonhosted.org/packages/1e/1e/e37bd46ffac9eec1a9afc32c5097cd83b0de1e865021f7f953c5142919f4/torchcodec-0.11.1-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:170a3efea64f0cd2c21cee0a233a9e13c67a704b5c5e7ef9aeda31e747ac6885", size = 2402232, upload-time = "2026-04-14T18:25:08.026Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/d0/a9173dbfa011cc2224f7489e50844b9f62110050bbdbd9d29485e7f1e0e2/torchcodec-0.11.1-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:db66ddce36a6fa35f30fbe1d78b57289fcb53f8f43c1c85923edbe339540c665", size = 2334158, upload-time = "2026-04-14T18:25:09.77Z" },
-    { url = "https://files.pythonhosted.org/packages/18/96/6ee0e26547976dc55a69042ce895747a34221eab348931e975141d80d25e/torchcodec-0.11.1-cp314-cp314-win_amd64.whl", hash = "sha256:3fd9ef8302b261d3db5585e42be4a3138c5c240a822031642cdf1f82ea3db5b7", size = 1925002, upload-time = "2026-04-14T18:25:11.718Z" },
+    { url = "https://files.pythonhosted.org/packages/52/ff/2b27797e039673156710e5a0febe87cafc203722acafa3d34db283b40cf9/torchcodec-0.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b35fa4061c5757f8d714187c040a90a11669de6470a644bb04e3cd335ff1c110", size = 4073213, upload-time = "2026-01-22T15:41:45.485Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/6c/9af3bd945a610d6c757d898aa4624e0f5135cc8a6992d0a1d846f1084576/torchcodec-0.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:e4f022fa53d91b414b4177fe87b0afc40a806092da4595d24de4b245d6fb0fba", size = 2225338, upload-time = "2026-01-22T15:41:52.094Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/b6/b1041c8ccb175b08779b3e2d3e60f838bbcbfe2398d49e3673b6a66f0649/torchcodec-0.10.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:be3ce7cc667effecd06da9d0d6c5e9e347c5f376b705934e7b82378a65cf6eef", size = 4043681, upload-time = "2026-01-22T15:41:47.236Z" },
+    { url = "https://files.pythonhosted.org/packages/df/9d/b73a0f47e11b66a1d23c7d867f12f8bb41b1b5e707d7e23d8f54793e3267/torchcodec-0.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:9e077146e894f373b805972da96aee42ff8bb87b1a3f3fb64d26925cd9e64184", size = 2225208, upload-time = "2026-01-22T15:41:53.233Z" },
+    { url = "https://files.pythonhosted.org/packages/90/c9/4b6242e3456bae148f4086337d3e43d98c4e79c04091de3462db9f5eb67a/torchcodec-0.10.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:bb882c12ca07dcf6d82833db67e6b565693a4bccfeab6696697620e43e465556", size = 3821202, upload-time = "2026-01-22T15:41:48.627Z" },
+    { url = "https://files.pythonhosted.org/packages/93/71/0fc10230965e319552e064d66f1c8675b471d1b98c4a94c529e771b3c165/torchcodec-0.10.0-cp314-cp314-win_amd64.whl", hash = "sha256:4734eb82146516049e1070152eb3013d7b9689159ef35db7c0894d130d4e335d", size = 2226749, upload-time = "2026-01-22T15:41:54.393Z" },
+]
+
+[[package]]
+name = "torchcodec"
+version = "0.10.0+cu128"
+source = { registry = "https://download.pytorch.org/whl/cu128" }
+resolution-markers = [
+    "(python_full_version >= '3.15' and platform_machine == 'AMD64' and sys_platform == 'linux') or (python_full_version >= '3.15' and platform_machine == 'x86_64' and sys_platform == 'linux')",
+    "(python_full_version == '3.14.*' and platform_machine == 'AMD64' and sys_platform == 'linux') or (python_full_version == '3.14.*' and platform_machine == 'x86_64' and sys_platform == 'linux')",
+    "(python_full_version == '3.13.*' and platform_machine == 'AMD64' and sys_platform == 'linux') or (python_full_version == '3.13.*' and platform_machine == 'x86_64' and sys_platform == 'linux')",
+    "(python_full_version < '3.13' and platform_machine == 'AMD64' and sys_platform == 'linux') or (python_full_version < '3.13' and platform_machine == 'x86_64' and sys_platform == 'linux')",
+]
+wheels = [
+    { url = "https://download.pytorch.org/whl/cu128/torchcodec-0.10.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:5ecb4aeb61b4f14f30ceed11ce892308f38232d82eee64605ae19583c51a8e72", upload-time = "2026-01-26T17:33:08Z" },
+    { url = "https://download.pytorch.org/whl/cu128/torchcodec-0.10.0%2Bcu128-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:a2c3c16c7be56989360cb2894d8443d6f067cc615ac1830f89cc5f37482861d5", upload-time = "2026-01-26T17:33:09Z" },
+    { url = "https://download.pytorch.org/whl/cu128/torchcodec-0.10.0%2Bcu128-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:c02e3addfb5dccde976596ab4fbbe33bfd41f0d4144a075510383e9d5915a366", upload-time = "2026-01-26T17:33:10Z" },
+]
+
+[[package]]
+name = "torchcodec"
+version = "0.11.1+cu128"
+source = { registry = "https://download.pytorch.org/whl/cu128" }
+resolution-markers = [
+    "(python_full_version >= '3.15' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.15' and platform_machine == 'arm64' and sys_platform == 'linux')",
+    "(python_full_version == '3.14.*' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.14.*' and platform_machine == 'arm64' and sys_platform == 'linux')",
+    "(python_full_version == '3.13.*' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.13.*' and platform_machine == 'arm64' and sys_platform == 'linux')",
+    "(python_full_version < '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.13' and platform_machine == 'arm64' and sys_platform == 'linux')",
+]
+wheels = [
+    { url = "https://download.pytorch.org/whl/cu128/torchcodec-0.11.1%2Bcu128-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:2f1efd182a3728d3a858382f973afabd144f66bfb5c1d5a72c504692cf73a65b", upload-time = "2026-04-14T18:06:03Z" },
+    { url = "https://download.pytorch.org/whl/cu128/torchcodec-0.11.1%2Bcu128-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:15a0d3fb971318be3e2c7d4546e9d3033d7a318a0e166c60ccc0da6eb789a8a2", upload-time = "2026-04-14T18:06:03Z" },
+    { url = "https://download.pytorch.org/whl/cu128/torchcodec-0.11.1%2Bcu128-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:5d5aa85ad3c336664aee5eed5f5a027b12794b9e281dd4155e451232122520ce", upload-time = "2026-04-14T18:06:03Z" },
 ]
 
 [[package]]
@@ -6439,8 +6672,8 @@ version = "0.2.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "scipy" },
-    { name = "torch", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
-    { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform == 'linux'" },
+    { name = "torch", version = "2.10.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
+    { name = "torch", version = "2.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/87/ec/a40aa124660f0ee65e6760cb53df6a82ad91a1a3ef1da5e747f1336644dd/torchdiffeq-0.2.5.tar.gz", hash = "sha256:b50d3760d13fd138dcceac651f4b80396f44fefcebd037a033fecfeaa9cc12e7", size = 31197, upload-time = "2024-11-21T20:20:11.552Z" }
 wheels = [
@@ -6449,7 +6682,7 @@ wheels = [
 
 [[package]]
 name = "torchvision"
-version = "0.26.0"
+version = "0.25.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.15' and platform_machine == 'arm64' and sys_platform == 'darwin'",
@@ -6484,24 +6717,24 @@ resolution-markers = [
 dependencies = [
     { name = "numpy", marker = "sys_platform != 'linux'" },
     { name = "pillow", marker = "sys_platform != 'linux'" },
-    { name = "torch", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
+    { name = "torch", version = "2.10.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/e7/56b47cc3b132aea90ccce22bcb8975dec688b002150012acc842846039d0/torchvision-0.26.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c409e1c3fdebec7a3834465086dbda8bf7680eff79abf7fd2f10c6b59520a7a4", size = 1863502, upload-time = "2026-03-23T18:12:57.326Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/a9/c272623a0f735c35f0f6cd6dc74784d4f970e800cf063bb76687895a2ab9/torchvision-0.26.0-cp312-cp312-win_amd64.whl", hash = "sha256:7993c01648e7c61d191b018e84d38fe0825c8fcb2720cd0f37caf7ba14404aa1", size = 4255155, upload-time = "2026-03-23T18:12:32.652Z" },
-    { url = "https://files.pythonhosted.org/packages/da/80/0762f77f53605d10c9477be39bb47722cc8e383bbbc2531471ce0e396c07/torchvision-0.26.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:5d63dd43162691258b1b3529b9041bac7d54caa37eae0925f997108268cbf7c4", size = 1860809, upload-time = "2026-03-23T18:12:47.629Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/1b/f1bc86a918c5f6feab1eeff11982e2060f4704332e96185463d27855bdf5/torchvision-0.26.0-cp313-cp313-win_amd64.whl", hash = "sha256:4280c35ec8cba1fcc8294fb87e136924708726864c379e4c54494797d86bc474", size = 4319880, upload-time = "2026-03-23T18:12:38.168Z" },
-    { url = "https://files.pythonhosted.org/packages/66/28/b4ad0a723ed95b003454caffcc41894b34bd8379df340848cae2c33871de/torchvision-0.26.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:358fc4726d0c08615b6d83b3149854f11efb2a564ed1acb6fce882e151412d23", size = 1951973, upload-time = "2026-03-23T18:12:48.781Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/a4/f1155e943ae5b32400d7000adc81c79bb0392b16ceb33bcf13e02e48cced/torchvision-0.26.0-cp313-cp313t-win_amd64.whl", hash = "sha256:ebc043cc5a4f0bf22e7680806dbba37ffb19e70f6953bbb44ed1a90aeb5c9bea", size = 4248202, upload-time = "2026-03-23T18:12:41.423Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/c8/9bffa9c7f7bdf95b2a0a2dc535c290b9f1cc580c3fb3033ab1246ffffdeb/torchvision-0.26.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:eb61804eb9dbe88c5a2a6c4da8dec1d80d2d0a6f18c999c524e32266cb1ebcd3", size = 1860813, upload-time = "2026-03-23T18:12:39.636Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/ba/1666f90bc0bdd77aaa11dcc42bb9f621a9c3668819c32430452e3d404730/torchvision-0.26.0-cp314-cp314-win_amd64.whl", hash = "sha256:114bec0c0e98aa4ba446f63e2fe7a2cbca37b39ac933987ee4804f65de121800", size = 4348469, upload-time = "2026-03-23T18:12:24.44Z" },
-    { url = "https://files.pythonhosted.org/packages/45/8f/1f0402ac55c2ae15651ff831957d083fe70b2d12282e72612a30ba601512/torchvision-0.26.0-cp314-cp314t-macosx_12_0_arm64.whl", hash = "sha256:b7d3e295624a28b3b1769228ce1345d94cf4d390dd31136766f76f2d20f718da", size = 1860826, upload-time = "2026-03-23T18:12:34.1Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/6a/09f3844c10643f6c0de5d95abc863420cfaf194c88c7dffd0ac523e2015f/torchvision-0.26.0-cp314-cp314t-win_amd64.whl", hash = "sha256:e9d0e022c19a78552fb055d0414d47fecb4a649309b9968573daea160ba6869c", size = 4454275, upload-time = "2026-03-23T18:12:27.487Z" },
+    { url = "https://files.pythonhosted.org/packages/56/3a/6ea0d73f49a9bef38a1b3a92e8dd455cea58470985d25635beab93841748/torchvision-0.25.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c2abe430c90b1d5e552680037d68da4eb80a5852ebb1c811b2b89d299b10573b", size = 1874920, upload-time = "2026-01-21T16:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/16/8f650c2e288977cf0f8f85184b90ee56ed170a4919347fc74ee99286ed6f/torchvision-0.25.0-cp312-cp312-win_amd64.whl", hash = "sha256:f9c55ae8d673ab493325d1267cbd285bb94d56f99626c00ac4644de32a59ede3", size = 4303059, upload-time = "2026-01-21T16:27:11.08Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/5b/1562a04a6a5a4cf8cf40016a0cdeda91ede75d6962cff7f809a85ae966a5/torchvision-0.25.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:24e11199e4d84ba9c5ee7825ebdf1cd37ce8deec225117f10243cae984ced3ec", size = 1874918, upload-time = "2026-01-21T16:27:39.02Z" },
+    { url = "https://files.pythonhosted.org/packages/32/a5/9a9b1de0720f884ea50dbf9acb22cbe5312e51d7b8c4ac6ba9b51efd9bba/torchvision-0.25.0-cp313-cp313-win_amd64.whl", hash = "sha256:cef0196be31be421f6f462d1e9da1101be7332d91984caa6f8022e6c78a5877f", size = 4321911, upload-time = "2026-01-21T16:27:35.195Z" },
+    { url = "https://files.pythonhosted.org/packages/52/99/dca81ed21ebaeff2b67cc9f815a20fdaa418b69f5f9ea4c6ed71721470db/torchvision-0.25.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a8f8061284395ce31bcd460f2169013382ccf411148ceb2ee38e718e9860f5a7", size = 1896209, upload-time = "2026-01-21T16:27:32.159Z" },
+    { url = "https://files.pythonhosted.org/packages/63/cc/0ea68b5802e5e3c31f44b307e74947bad5a38cc655231d845534ed50ddb8/torchvision-0.25.0-cp313-cp313t-win_amd64.whl", hash = "sha256:5e6b449e9fa7d642142c0e27c41e5a43b508d57ed8e79b7c0a0c28652da8678c", size = 4344260, upload-time = "2026-01-21T16:27:17.018Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/1f/fa839532660e2602b7e704d65010787c5bb296258b44fa8b9c1cd6175e7d/torchvision-0.25.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:620a236288d594dcec7634c754484542dc0a5c1b0e0b83a34bda5e91e9b7c3a1", size = 1896193, upload-time = "2026-01-21T16:27:24.785Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/eb/d0096eed5690d962853213f2ee00d91478dfcb586b62dbbb449fb8abc3a6/torchvision-0.25.0-cp314-cp314-win_amd64.whl", hash = "sha256:d1abd5ed030c708f5dbf4812ad5f6fbe9384b63c40d6bd79f8df41a4a759a917", size = 4325058, upload-time = "2026-01-21T16:27:26.165Z" },
+    { url = "https://files.pythonhosted.org/packages/97/36/96374a4c7ab50dea9787ce987815614ccfe988a42e10ac1a2e3e5b60319a/torchvision-0.25.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ad9a8a5877782944d99186e4502a614770fe906626d76e9cd32446a0ac3075f2", size = 1896207, upload-time = "2026-01-21T16:27:23.383Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/37/e7ca4ec820d434c0f23f824eb29f0676a0c3e7a118f1514f5b949c3356da/torchvision-0.25.0-cp314-cp314t-win_amd64.whl", hash = "sha256:f07f01d27375ad89d72aa2b3f2180f07da95dd9d2e4c758e015c0acb2da72977", size = 4425879, upload-time = "2026-01-21T16:27:12.579Z" },
 ]
 
 [[package]]
 name = "torchvision"
-version = "0.26.0+cu128"
+version = "0.25.0+cu128"
 source = { registry = "https://download.pytorch.org/whl/cu128" }
 resolution-markers = [
     "(python_full_version >= '3.15' and platform_machine == 'AMD64' and sys_platform == 'linux') or (python_full_version >= '3.15' and platform_machine == 'x86_64' and sys_platform == 'linux')",
@@ -6524,19 +6757,19 @@ resolution-markers = [
 dependencies = [
     { name = "numpy", marker = "sys_platform == 'linux'" },
     { name = "pillow", marker = "sys_platform == 'linux'" },
-    { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform == 'linux'" },
+    { name = "torch", version = "2.10.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:63e35234aed13b6edda37056f417b5c281249669db631e706811917af36b21d7", upload-time = "2026-04-09T23:21:35Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:ccf26b4b659cfce6f2208cb8326071d51c70219a34856dfdf468d1e19af52c0d", upload-time = "2026-03-23T15:36:22Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:c4a9cacd521f2a4df0bcd9d8e96704771b928f478f1f3067e4085bb53a1da298", upload-time = "2026-04-09T23:21:37Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:cb1f6184a7ba30fba40580e1a01a6604a86c55e79fdda187f40116ee680441ec", upload-time = "2026-03-23T15:36:22Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:e594732552a8c2fee2ace9c6475c6c6904fc44ccca622ee6765a89a045416a44", upload-time = "2026-04-09T23:21:38Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:6168abc019803ac9e97efce27eafd2fdb33db04dcc54a86039537729e5047b29", upload-time = "2026-03-23T15:36:23Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:b3865fa227661dd75b7b28c96d3d14e739bd08bf0614132758922fe0e7206f91", upload-time = "2026-04-09T23:21:39Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:aac647c9130f1f25f5c8f5bca3d95cfd96bdfac93ab54529690b088e64e4fa64", upload-time = "2026-03-23T15:36:23Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:e2ee9e16ee4518292694537fcbd20d2d27044e381d92b864f637e82795796a84", upload-time = "2026-04-09T23:21:40Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:b5772c55bfda4377df8f1930d43c4e0231ef231b0228eade4b227c8d3ba6e34e", upload-time = "2026-03-23T15:36:23Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.25.0%2Bcu128-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:8623e534ef6a815bd6407d4b52dd70c7154e2eda626ad4b9cb895d36c5a3305b", upload-time = "2026-01-21T22:32:23Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.25.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:1255a0ca2bf987acf9f103b96c5c4cfe3415fc4a1eef17fa08af527a04a4f573", upload-time = "2026-01-21T22:32:24Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.25.0%2Bcu128-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:12c253520a26483fe3c614f63ff16eca6d9b0b4ebe510699b7d15d88e6c0cd35", upload-time = "2026-01-21T22:32:26Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.25.0%2Bcu128-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:a9c0de893dce9c2913c9c7ae88a916910f92d02b99da149678806d18e8079f29", upload-time = "2026-01-21T22:32:27Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.25.0%2Bcu128-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:58b2971b55c761f1d2491bd80fcc4618ea97d363d387a9dd3aff23220cbee264", upload-time = "2026-01-21T22:32:28Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.25.0%2Bcu128-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:1b6878b043513ea3dea1b90bfb5193455d9b248b8c4d5e66ea9f5d1643a43f13", upload-time = "2026-01-21T22:32:29Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.25.0%2Bcu128-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:e2dbf9ea9f4b2416822249e96ff3ad873d9a84e51285d6b9967732be3015c523", upload-time = "2026-01-21T22:32:31Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.25.0%2Bcu128-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:5b7ad3fb6cf03ef2a2fd617cb4b4e41efa9bb0143c67f506c2a3e6765c7b12ad", upload-time = "2026-01-21T22:32:31Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.25.0%2Bcu128-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:687987fbcb074fd7f7a61cf2b407b1eac07588ace8351a3a36978546a00adc52", upload-time = "2026-01-21T22:32:33Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.25.0%2Bcu128-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:84c5e2cb699235339b8a5c295e974a795244a45d1104ecee658d9d19600cdc75", upload-time = "2026-01-21T22:32:33Z" },
 ]
 
 [[package]]
@@ -6627,6 +6860,18 @@ wheels = [
 ]
 
 [[package]]
+name = "typeguard"
+version = "4.5.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/67/1c/dfba5c4633cafc4c701f237d2ba63b416805047fd6d96aab4cfc40969f98/typeguard-4.5.2.tar.gz", hash = "sha256:5a16dcac23502039299c97c8941651bc33d7ea8cc4b2f7d6bbb1b528f6eea423", size = 80240, upload-time = "2026-05-14T12:59:40.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/29/74eeb4d3f3ae61ca096b018ad486b3b3c74b17bec09ab4edab721cbefec3/typeguard-4.5.2-py3-none-any.whl", hash = "sha256:fcf9de18bd945cdb4c7b996e12b4c51ce83f92f191314a6d7cf1739586ec98cf", size = 36748, upload-time = "2026-05-14T12:59:39.473Z" },
+]
+
+[[package]]
 name = "typer"
 version = "0.25.1"
 source = { registry = "https://pypi.org/simple" }
@@ -6673,6 +6918,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tyro"
+version = "1.0.13"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docstring-parser" },
+    { name = "typeguard" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/24/d6/7126f9e7de139632134d59b5d1972e93c610ee2cb13829e8f4f48f6613cb/tyro-1.0.13.tar.gz", hash = "sha256:731a90c9836b77fffe7c3fa0477ef2d3b6fa91252ddc0bb4d32dadd4fcc143d4", size = 489479, upload-time = "2026-04-14T18:21:52.888Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/4f/c43a0a8f0c66fd40a1d6cc47332a5a1d1043e9b331f7070ea701b91a7598/tyro-1.0.13-py3-none-any.whl", hash = "sha256:a0bdb8462c551dd84fc00a76916ce4d37e879c84eefaf34e2165312407cc6c09", size = 185221, upload-time = "2026-04-14T18:21:54.328Z" },
 ]
 
 [[package]]
@@ -6981,6 +7240,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/bd/f4/c67440c7fb409a71b7404b7aefcd7569a9c0d6bd071299bf4198ae7a5d95/widgetsnbextension-4.0.15.tar.gz", hash = "sha256:de8610639996f1567952d763a5a41af8af37f2575a41f9852a38f947eb82a3b9", size = 1097402, upload-time = "2025-11-01T21:15:55.178Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/0e/fa3b193432cfc60c93b42f3be03365f5f909d2b3ea410295cf36df739e31/widgetsnbextension-4.0.15-py3-none-any.whl", hash = "sha256:8156704e4346a571d9ce73b84bee86a29906c9abfd7223b7228a28899ccf3366", size = 2196503, upload-time = "2025-11-01T21:15:53.565Z" },
+]
+
+[[package]]
+name = "win32-setctime"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/8f/705086c9d734d3b663af0e9bb3d4de6578d08f46b1b101c2442fd9aecaa2/win32_setctime-1.2.0.tar.gz", hash = "sha256:ae1fdf948f5640aae05c511ade119313fb6a30d7eabe25fef9764dca5873c4c0", size = 4867, upload-time = "2024-12-07T15:28:28.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/07/c6fe3ad3e685340704d314d765b7912993bcb8dc198f0e7a89382d37974b/win32_setctime-1.2.0-py3-none-any.whl", hash = "sha256:95d644c4e708aba81dc3704a116d8cbc974d70b3bdb8be1d150e36be6e9d1390", size = 4083, upload-time = "2024-12-07T15:28:26.465Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# What is this？

A design plan for landing NVIDIA's Cosmos3 as a first-class LeRobot policy. 

## Table of Contents
- [Capabilities](#1-core-capabilities-we-commit-to): the capabilities we commit to
- [Acceptance criteria](#2-acceptance-criteria): how we will verify them
- [Deliverables (assets)](#3-deliverables-(assets)): what we ship
- [PR plan](#4-pr-plan): how the work is sliced into PRs
- [Cosmos open-source status](#5-cosmos-open-source-status-as-of-2026-06-09): the exact upstream open-source state we are building on as of **2026-06-09**, 
- [Detailed implementation plan](#6-detailed-implementation-plan): the implementation strategy file by file.

---

## 1. Core capabilities we commit to

1. **Inference support.** Run Cosmos3's open-source checkpoints under the LeRobot framework. This means:
    - a checkpoint-format conversion (DCP → LeRobot `model.safetensors` + processor JSON)
    -  a model-code integration that produces actions through LeRobot's standard policy surface.
 2. **Post-training support.** A complete, LeRobot-native post-training path: 
     - load the open-source `Cosmos3-Nano` mid-train checkpoint
     - fine-tune it on robot data through the full LeRobot training stack (dataset → processor → `forward`/loss → optimizer → checkpoint)
     - Obtain a policy whose closed-loop behavior matches the technical report.

---

## 2. Acceptance criteria

Acceptance is defined against the Cosmos3 technical report's published numbers and against the native `cosmos-framework` implementation.

The two tables below are from the report source and are referenced throughout this section.

**Table 1 — RoboLab-120 policy post-training success rate ([technical report](https://arxiv.org/abs/2606.02800) Table-19).** Task success rate (%) on RoboLab-120 across language-specificity levels (Vague / Default / Specific) and difficulty tiers. All policies use off-the-shelf checkpoints fine-tuned on DROID. The two `Cosmos3` rows (highlighted in the report) are the ones this integration must reproduce.

| Model | Overall Vague | Overall Default | Overall Specific | Simple Vague | Simple Default | Simple Specific | Moderate Vague | Moderate Default | Moderate Specific | Complex Vague | Complex Default | Complex Specific |
|---|---|---|---|---|---|---|---|---|---|---|---|---|
| **Cosmos3-Nano-Policy-DROID** | **20.6** | **36.8** | **39.7** | **23.3** | **40.6** | **42.0** | **23.3** | **35.4** | **40.3** | 4.1 | **25.3** | **29.4** |
| **Cosmos3-Nano** (PT-init) | 16.7 | 28.1 | 30.2 | 17.8 | 30.3 | 32.8 | 19.0 | 28.7 | 29.5 | **7.1** | 18.2 | 21.8 |

**Table 2 — LIBERO-10 fast-adaptation success rate ([technical report](https://arxiv.org/abs/2606.02800) Table-20).** Closed-loop success rate of `Cosmos3-Nano` fine-tuned on LIBERO-10 from two initializations (MT-init vs PT-init), 500 rollouts per checkpoint, reported at four training iterations. MT-init adapts faster.

| Model | 500 it. | 1000 it. | 1500 it. | 2000 it. |
|---|---|---|---|---|
| **Cosmos3-Nano** (MT-init) | 24.6% | 91.4% | 95.8% | **97.4%** |
| **Cosmos3-Nano** (PT-init) | 0.0% | 73.8% | 93.4% | 95.2% |

### 2.1 Criterion A — Inference support

We accept inference support of `Cosmos3-Nano-Policy-DROID` under LeRobot through two progressive stages.

**Stage A1 — Offline action parity within the bf16 numerical band.** Replaying a single offline episode (the same observations the native model saw), the action predicted by the LeRobot port must agree with the action predicted by `cosmos-framework` to within the bf16 numerical band.

**Stage A2 — RoboLab closed-loop eval.** Convert the native checkpoint to `Cosmos3-Nano-Policy-DROID-LeRobot` and evaluate it in RoboLab. Success rates must be close to the **Cosmos3-Nano-Policy-DROID** row of **Table 1** (RoboLab-120).

### 2.2 Criterion B — Post-training support

We accept post-training support by demonstrating the full robot-data fine-tuning flow from the `Cosmos3-Nano` mid-train checkpoint.

**Stage B1 — DROID post-training.** Initialize from `Cosmos3-Nano` (`assets/models/nvidia--Cosmos3-Nano`), post-train on `lerobot/droid_1.0.1` through LeRobot, and evaluate in RoboLab. Success rates must be close to **Table 1** (the same RoboLab-120 numbers the native `Cosmos3-Nano-Policy-DROID` achieves).

**Stage B2 — Fast adaptation on LIBERO-10.** Starting from the converted `Cosmos3-Nano` checkpoint, post-train on the `HuggingFaceVLA/libero` dataset entirely through the LeRobot stack and evaluate on LIBERO-10. The success-rate-vs-iteration curve must track the **Cosmos3-Nano (MT-init)** row of **Table 2** (technical report Table 20). 

Stages B1 and B2 together exercise the entire LeRobot-native training stack (cold/fine-tune initialization, the combined world-model + action loss `forward`, the data-packing processor, and checkpoint round-tripping) on two embodiments.

---

## 3. Deliverables (assets)

1. **Cosmos3 policy integration code** in LeRobot (`src/lerobot/policies/cosmos3/`: `configuration_`, `modeling_`, `processor_`).
2. **RoboLab integration code** in LeRobot (the evaluation surface for closed-loop RoboLab rollouts; shipped in PR 2).
3. **LeRobot-format checkpoints:**
   - `Cosmos3-Nano-Policy-DROID-LeRobot` — converted from the native open-source `Cosmos3-Nano-Policy-DROID` (drives Criterion A).
   - `Cosmos3-Nano-LeRobot` — converted from the native open-source `Cosmos3-Nano` mid-train checkpoint (the post-training starting point).
   - `Cosmos3-Nano-DROID-PT` — initialized from `Cosmos3-Nano-LeRobot` and post-trained on `lerobot/droid_1.0.1` through LeRobot (the artifact for Stage B1).
   - `Cosmos3-Nano-LIBERO-PT` — initialized from `Cosmos3-Nano-LeRobot` and post-trained on `HuggingFaceVLA/libero` through LeRobot (the artifact for Stage B2).

---

## 4. PR plan

Two PRs.

- **PR 1 — Cosmos3 integration.** Resolve the dependency conflicts between LeRobot and Cosmos3 and provide the actual policy integration (the three files, the checkpoint converter, and tests).
- **PR 2 — RoboLab simulation integration.** Lands the RoboLab closed-loop evaluation path for the Cosmos3 policy. It is out of scope for this document and will be specified separately.

---

## 5. Cosmos open-source status as of 2026-06-09

This section systematically maps the open-source state of the **checkpoints** and **code** that bear directly on action generation. Multimodal image/text/audio generation is out of focus here except where it constrains what we can reuse.

### 5.1 Checkpoints

| Checkpoint | Open-sourced? | Role w.r.t. this integration |
|---|---|---|
| `Cosmos3-Super`, `Cosmos3-Super-Text2Image`, `Cosmos3-Super-Image2Video` | Yes | Multimodal generation models; weakly related to this integration. |
| `Cosmos3-Nano` (mid-train) | Yes | Mid-train checkpoint; the post-training starting point for robot data; compatible with the `diffusers` inference path. |
| `Cosmos3-Nano-Policy-DROID` (post-train) | Yes | DROID policy; used for RoboLab eval; compatible with the `diffusers` inference path. |
| `Cosmos3-Nano` post-trained on LIBERO | **No** | The **Cosmos3-Nano (MT-init)** row of Table 2 (`action_libero_posttraining_success_rate`) has no released checkpoint. |
| `transformers`-format `Cosmos3-Nano` / `Cosmos3-Nano-Policy-DROID` | **No** | No `transformers`-native checkpoints are published for either model. |

### 5.2 Code

The relevant code is in five repositories: two NVIDIA repos (`cosmos`, `cosmos-framework`), two HF-ecosystem integrations (`diffusers`, `transformers`), and one evaluation repo (`RoboLab`).

#### `nvidia/cosmos` — cookbooks and inference examples

[`NVIDIA/cosmos`](https://github.com/NVIDIA/cosmos) ships cookbook-style tutorials for the Reasoner (text generation) and Generator (multimodal / action generation), with example code for inference under both `vllm` and `cosmos-framework`.
- Provides [`cookbooks/cosmos3/generator/action/run_policy_with_cosmos_framework.md`](https://github.com/NVIDIA/cosmos/blob/4e4f3001fae9238384f9551f1723fcb0f651c42c/cookbooks/cosmos3/generator/action/run_policy_with_cosmos_framework.md), which shows how to load `Cosmos3-Nano-Policy-DROID` with `cosmos-framework` and roll it out in RoboLab.
- **Not** provide a `diffusers` example for action generation — only audiovisual generation, under [`cookbooks/cosmos3/generator/audiovisual`](https://github.com/NVIDIA/cosmos/tree/4e4f3001fae9238384f9551f1723fcb0f651c42c/cookbooks/cosmos3/generator/audiovisual).
- **Not** provide a `transformers` example for action generation.

#### `NVIDIA/cosmos-framework` — native definitions, training, inference

[`NVIDIA/cosmos-framework`](https://github.com/NVIDIA/cosmos-framework) is the source of truth for native model definitions, the training pipeline, and the inference pipeline. For the policy path it provides a **complete inference pipeline** for `Cosmos3-Nano-Policy-DROID`, but **not a complete post-training pipeline**.

- **Missing: action post-train config.** [`cosmos_framework/configs/base/experiment/action/posttrain_config/`](https://github.com/NVIDIA/cosmos-framework/blob/fa63e9934a38eb8127a0c3d6b23969fd4d0e32a7/cosmos_framework/configs/base/experiment/action/posttrain_config/__init__.py) contains only an `__init__.py` with a license header — there is no registered `experiment=<policy_posttrain>` target.

- **Missing: action SFT recipe.** The public [`examples/README.md`](https://github.com/NVIDIA/cosmos-framework/blob/fa63e9934a38eb8127a0c3d6b23969fd4d0e32a7/examples/README.md) exposes only four SFT recipes, none of which are action/policy recipes:

  | Recipe | Launch shell |
  | --- | --- |
  | Vision SFT (Cosmos3-Nano) | `launch_sft_vision_nano.sh` |
  | Vision SFT LoRA (Cosmos3-Super) | `launch_sft_vision_super.sh` |
  | Reasoner Alignment SFT | `launch_sft_llava_ov.sh` |
  | Reasoner Alignment SFT (Cosmos3-Nano) | `launch_sft_videophy2_nano.sh` |
  
- **Retained: the action + world-model loss code.** The repository keeps the per-modality flow-matching losses that the policy post-train must combine. The vision (world-model / future-frame) loss is assembled at [`omni_mot_model.py#L975`](https://github.com/NVIDIA/cosmos-framework/blob/fa63e9934a38eb8127a0c3d6b23969fd4d0e32a7/cosmos_framework/model/vfm/omni_mot_model.py#L975); the action loss is added with its weight at [`omni_mot_model.py#L998`](https://github.com/NVIDIA/cosmos-framework/blob/fa63e9934a38eb8127a0c3d6b23969fd4d0e32a7/cosmos_framework/model/vfm/omni_mot_model.py#L998); both call the shared masked velocity-matching MSE [`compute_flow_matching_loss`](https://github.com/NVIDIA/cosmos-framework/blob/fa63e9934a38eb8127a0c3d6b23969fd4d0e32a7/cosmos_framework/model/vfm/algorithm/loss/flow_matching.py#L17), which masks padded action channels via `raw_action_dim` at [lines 75–76](https://github.com/NVIDIA/cosmos-framework/blob/fa63e9934a38eb8127a0c3d6b23969fd4d0e32a7/cosmos_framework/model/vfm/algorithm/loss/flow_matching.py#L75-L76). Combined with the technical report, this is sufficient to reconstruct the post-train objective as **world-model flow-matching loss + action flow-matching loss** (see §6).
- **Retained: the DROID dataset interface.** [`DROIDLeRobotDataset`](https://github.com/NVIDIA/cosmos-framework/blob/fa63e9934a38eb8127a0c3d6b23969fd4d0e32a7/cosmos_framework/data/vfm/action/datasets/droid_lerobot_dataset.py#L50) reads LeRobot-format DROID data and returns `video`, `action`, `mode`, `domain_id`, and caption fields. Note it is a narrow wrapper (10-D pose-delta actions only), not the 8-D `joint_pos` setup `Cosmos3-Nano-Policy-DROID` actually serves with.

#### `huggingface/diffusers` — Cosmos3 inference integration

[`diffusers`](https://github.com/huggingface/diffusers) integrates the Cosmos3 inference pipeline via NVIDIA's [PR #13818](https://github.com/huggingface/diffusers/pull/13818) and [PR #13823](https://github.com/huggingface/diffusers/pull/13823).

- `Cosmos3OmniTransformer` exposes vision plus optional sound and optional action projection heads, with one forward over a packed joint sequence returning `(preds_vision, preds_sound, preds_action)` velocity predictions.
- The pipeline supports the three action-conditioned modes: `policy`, `forward_dynamics`, and `inverse_dynamics`.
- It has **no training pipeline** (no loss, no target/noise construction, no dataset/collation — the `*_mse_loss_indexes` names are index tensors, not losses), and inference is **single-sample only**: `Cosmos3OmniPipeline` is documented to run one sample per call and is `@torch.no_grad()`.

#### `huggingface/transformers` — not yet integrated

`transformers` has no Cosmos3 integration. The signal is in the cosmos cookbook, which states "Transformers-based **Reasoner** inference is coming soon" — see [`cookbooks/cosmos3/README.md` (Transformers, coming soon)](https://github.com/NVIDIA/cosmos/blob/4e4f3001fae9238384f9551f1723fcb0f651c42c/cookbooks/cosmos3/README.md#transformers-coming-soon) and the [reasoner README](https://github.com/NVIDIA/cosmos/blob/4e4f3001fae9238384f9551f1723fcb0f651c42c/cookbooks/cosmos3/reasoner/README.md#run-with-transformers).

#### `NVlabs/RoboLab` — evaluation

[`NVlabs/RoboLab`](https://github.com/NVlabs/RoboLab) provides the complete script for evaluating Cosmos3 in RoboLab at `policies/cosmos3/run.py` (with `client.py`). 

These gaps are the reason this integration is non-trivial: the inference path can be assembled from public components, but the **training path must be reconstructed** from retained building blocks.

---

## 6. Detailed implementation plan

<details>
<summary>Detailed plan</summary>

### 6.1 LeRobot dependency update (PR 1)

**Raised minimal requirements** (Cosmos3 requires newer than LeRobot's previous floor, and the affected APIs are unchanged across the bump, so only the floor moves):

| Dependency | Before | After | Reason |
|---|---|---|---|
| `torch` | `>=2.7,<2.12.0` | `>=2.10.0,<2.11.0` | Cosmos3's runtime needs `torch>=2.10`; pinned to a single minor to keep the CUDA-12.8 wheel set coherent. |
| `torchvision` | `>=0.22.0,<0.27.0` | `>=0.25.0,<0.26.0` | Paired with `torch 2.10`. |
| `torchcodec` | `>=0.3.0,<0.12.0` | `>=0.10.0,<0.11.0` | Paired with `torch 2.10` (system-ffmpeg-capable line). |
| `Pillow` | `>=10.0.0,<13.0.0` | `>=12.2.0,<13.0.0` | Cosmos3 image preprocessing needs `Pillow>=12.2`. |
| `av-dep` | `av>=15.0.0,<16.0.0` | `av>=16.1.0,<17.0.0` | Video decode path required by Cosmos3. |
| `diffusers-dep` | `>=0.27.2,<0.36.0` | `>=0.36.0,<0.40.0` | Raise the *stable* diffusers floor for the rest of LeRobot. |

**New `cosmos3` optional-dependency group.** Packages Cosmos3 needs that LeRobot does not already carry are isolated in a `cosmos3` extra: `av`, `cattrs`, `hydra-core`, `imageio`, `imageio-ffmpeg`, `loguru`, `msgpack`, `nvidia-cudnn-frontend`, `nvidia-ml-py`, `obstore`, `omegaconf`, `pydantic`, `scipy`, `tyro`, `websockets`.

**`diffusers` is installed from source** Inside the `cosmos3` extra, `diffusers` is installed from source pinned to the exact commit carrying PRs #13818/#13823 (currently `git+https://github.com/huggingface/diffusers.git@f3d42be118f9af7ed9697b686fba09a8bdcd71d1`), **not** through the `diffusers-dep` group.

### 6.2 Cosmos3 code integration (PR 1)

Before committing to a structure, we weigh the two LeRobot-idiomatic options.

**Option 1 — Vendor code, in the style of `src/lerobot/policies/groot`.** Re-implement the full Cosmos3 model definition inside LeRobot on top of `cosmos-framework`.

- *Pro:* a self-contained implementation close to the native model, easy for a user to edit/debug in place.
- *Con:* the native definition is saturated with multimodal-generation, model-parallel, and serving logic we do not need; it would require heavy surgery to strip down.
- *Con:* even after pruning, it imports a multi-thousand-line model-definition file into LeRobot.

**Option 2 — Reuse the `diffusers` Cosmos3 model components, in the style of `src/lerobot/policies/pi0`.** Hold the upstream model classes as plain submodules and write only the policy/training/inference glue.

- *Con:* `diffusers` has no training-loss code and its pipeline only does single-sample inference.
- *Con:* the `diffusers` `Cosmos3OmniPipeline` action path is awkward for our use.
- *Pro:* `Cosmos3OmniTransformer` has already done nearly all of the "strip the native model" work (it is a clean ~720-line `ModelMixin` with the MoT text expert inlined and the action head built in), and it exposes rich, public components we can hold directly. We can reuse the model components and **bypass the pipeline entirely**, which neutralizes the two cons above.

We choose **Option 2**: LeRobot's classic three-file form, assembling the model from `diffusers`' **public, model-level** classes owned as `nn.Module` submodules, with `cosmos-framework` used only as the algorithm reference, never vendored, and reasons  are as follows:

- **Submodule ownership is the right style for `PreTrainedPolicy`.** Holding the transformer, the Wan2.2 VAE, and the scheduler as submodules makes `state_dict` / `from_pretrained` / optimizer wiring fall out naturally.
- **The two real gaps are cheap to fill ourselves.** The missing training loss is a small, well-specified addition (the flow-matching objective in §6.2.2); the single-sample pipeline limit is bypassed by driving the transformer's public submodules in a batched velocity engine (§6.2.2). We pay only for what `diffusers` genuinely lacks, and inherit everything it already simplified.

#### 6.2.1 `configuration_cosmos3.py`

`Cosmos3Config` is organized by the **layered-config** principle: parameters the user is expected to tune live flat on the config; the large, frozen sub-model configs live as serialized dicts and are rehydrated at runtime.

- **Flat policy / action-generation parameters.** Everything action-facing is a first-class config field the user sees and tunes: action geometry (`chunk_size`, `n_action_steps`, ... ), embodiment (`domain_id`, `viewpoint`...), sampling (`guidance_scale`, `num_inference_steps`, ...), training (`video_loss_weight`, `action_loss_weight`, ...).
- **Serialized sub-model configs.** The `Cosmos3OmniTransformer`, Wan2.2 VAE, and scheduler configs are stored as `transformer_config` / `vae_config` / `scheduler_config` dicts and rehydrated through accessor properties at runtime (the qwen3vl processor is bound by a `text_processor_name_or_path` string). This keeps the serialized `config.json` complete — the entire model, from action heads down to the VAE, is recoverable from one file — while keeping the editable surface small.

#### 6.2.2 `modeling_cosmos3.py`

- **`Cosmos3Policy` (outer, policy layer).** Owns only strategy-level concerns: the standardized inference(`sample_actions`, `predict_action_chunk`, `select_action`), the future-frame entry point, optimizer-param exposure. 
- **`Cosmos3ActionModel` (inner, model layer).** Owns the model structure and all forward math: the three reused `diffusers` components, token packing/unpacking, the training loss, the batched velocity engine, and the sampling loop.

Key designs:

- **Reuse, own as submodules.** `Cosmos3OmniTransformer` (trainable backbone), `AutoencoderKLWan` (Wan2.2 VAE, frozen by default when `freeze_vae`), and `UniPCMultistepScheduler` are held as submodules. The inner model is responsible only for *initializing* these three and *calling* their forward interfaces.
- **Uniform "provide-or-build" initialization for all three components.** Each of the transformer / VAE / scheduler is initialized by the same rule: *if an instance is passed in, use it; otherwise construct it from `diffusers` using the serialized config.* This is what makes both initialization paths (below) share one code path for component construction.
- **Two initialization paths.**
  1. *From checkpoint (`from_pretrained`).* 1) Loading a trained policy (e.g. `Cosmos3-Nano-Policy-DROID`) for inference is a direct `from_pretrained` with no extra logic. 2) Loading the vanilla `Cosmos3-Nano` mid-train checkpoint as a fine-tuning start and drops the `sound_gen` weights (Nano has a sound branch, the policy does not) and loads only the shared part.
  2. *Cold init (`__init__`).* Load the `qwen3vl` backbone and Wan2.2 VAE pretrained weights, randomly initialize the remaining denoiser/projection modules, optionally copy the understanding-expert weights into the generation expert (a config switch), and never construct `sound_gen`.
- **Training `forward` = world-model loss + action loss.** The training objective is reconstructed from `cosmos-framework` (the retained loss code in §5.2): a rectified-flow velocity-matching MSE on **vision** latents + a velocity-matching MSE on **action** latents, combined as `video_loss_weight·L_video + action_loss_weight·L_action` (both weights default to 10.0 for the DROID). The mechanics follow the native numerics: noising `x_σ = σ·ε + (1−σ)·x_clean` with target `v = ε − x_clean`; the condition mask zeroes σ on conditioning tokens (clean frame-0 vision context and the clean state row). The VAE encode runs under `no_grad`.
- **Future-frame generation as a reserved, switchable branch.** Future-frame prediction is exposed as a dedicated, clearly named function returning `torch.Tensor`, gated by `config.generate_video`. When off, the video branch is *not computed at all*, lowering inference cost and raising control frequency; the interface is preserved even though the current deliverable focuses on action generation.
- **Inference and batched-velocity interface.** `sample_actions` encodes the conditioning frame, builds the vision+action latents, and runs the scheduler loop with classifier-free guidance, re-masking padded action dims each step. The single-sample pipeline limit is bypassed by a batched velocity engine (`_predict_velocity_batch`) that drives the transformer's *public* submodules directly (embeddings, packing, time embedder, rotary embeddings, the MoT layers, the output heads) over a batch (cond+uncond, multi-sample) — the same forward as `diffusers`, but batched, and shared by both training and sampling.

#### 6.2.3 `processor_cosmos3.py`

The processor turns raw robot observations into model-ready inputs, with each step performing **one atomic operation** so the semantic boundaries stay crisp.

- **Step decomposition.** 1) A data-packing step composes the multi-view images into the conditioning video, validates and pads the proprioceptive state, builds the action condition and its mask, emits the clean action label when present, formats the prompt, and emits the per-sample scalar tensors (domain id, fps, raw action dim). 2) A separate tokenize step loads the `qwen3vl` tokenizer and produces the conditional and unconditional input ids (the latter for CFG).
- **Processor↔model contract constants.** The processor and model communicate through an explicit set of named keys, so neither side hardcodes the other's layout: `COSMOS3_VIDEO`, `COSMOS3_ACTION_CONDITION`, `COSMOS3_ACTION_CONDITION_MASK`, `COSMOS3_ACTION_DOMAIN_ID`, `COSMOS3_CONDITIONING_FPS`, `COSMOS3_RAW_ACTION_DIM`, `COSMOS3_CLEAN_ACTION`, `COSMOS3_PROMPT`/`COSMOS3_FORMATTED_PROMPT`, `COSMOS3_COND_INPUT_IDS`, `COSMOS3_UNCOND_INPUT_IDS`, and `COSMOS3_TRAINING_SIGMA`. Treating these as the contract is what lets the model's `forward`/`sample_actions` consume a flat dict without knowing how the processor built it.
- **Native qwen3vl processor reuse.** The tokenize step holds only a `processor_name` string for serialization: the heavy `Qwen3VLProcessor` is rehydrated from the Hub at runtime, then Cosmos3's vision special tokens are added if absent. Because the Hub object is fixed and the added tokens are constants, every rehydration is deterministic.

</details>