### PR TITLE
feat(act) Add resize_imgs option to ACT preprocessing

### DIFF
--- a/src/lerobot/policies/act/configuration_act.py
+++ b/src/lerobot/policies/act/configuration_act.py
@@ -95,6 +95,7 @@ class ACTConfig(PreTrainedConfig):
 
     # Architecture.
     # Vision backbone.
+    resize_imgs: tuple[int, int] = (480, 640)
     vision_backbone: str = "resnet18"
     pretrained_backbone_weights: str | None = "ResNet18_Weights.IMAGENET1K_V1"
     replace_final_stride_with_dilation: int = False

--- a/src/lerobot/policies/act/configuration_act.py
+++ b/src/lerobot/policies/act/configuration_act.py
@@ -95,6 +95,7 @@ class ACTConfig(PreTrainedConfig):
 
     # Architecture.
     # Vision backbone.
+    # ACT uses 480x640 sized images
     resize_imgs: tuple[int, int] = (480, 640)
     vision_backbone: str = "resnet18"
     pretrained_backbone_weights: str | None = "ResNet18_Weights.IMAGENET1K_V1"

--- a/src/lerobot/policies/act/processor_act.py
+++ b/src/lerobot/policies/act/processor_act.py
@@ -28,6 +28,8 @@ from lerobot.processor import (
     policy_action_to_transition,
     transition_to_policy_action,
 )
+from lerobot.processor.hil_processor import ImageCropResizeProcessorStep
+from lerobot.processor.converters import policy_action_to_transition, transition_to_policy_action
 from lerobot.utils.constants import POLICY_POSTPROCESSOR_DEFAULT_NAME, POLICY_PREPROCESSOR_DEFAULT_NAME
 
 from .configuration_act import ACTConfig
@@ -59,6 +61,7 @@ def make_act_pre_post_processors(
         RenameObservationsProcessorStep(rename_map={}),
         AddBatchDimensionProcessorStep(),
         DeviceProcessorStep(device=config.device),
+        ImageCropResizeProcessorStep(resize_size=config.resize_imgs),
         NormalizerProcessorStep(
             features={**config.input_features, **config.output_features},
             norm_map=config.normalization_mapping,

--- a/src/lerobot/policies/act/processor_act.py
+++ b/src/lerobot/policies/act/processor_act.py
@@ -28,7 +28,7 @@ from lerobot.processor import (
     policy_action_to_transition,
     transition_to_policy_action,
 )
-from lerobot.processor.hil_processor import ImageCropResizeProcessorStep
+from lerobot.processor import ImageCropResizeProcessorStep
 from lerobot.processor.converters import policy_action_to_transition, transition_to_policy_action
 from lerobot.utils.constants import POLICY_POSTPROCESSOR_DEFAULT_NAME, POLICY_PREPROCESSOR_DEFAULT_NAME
 

--- a/tests/processor/test_act_processor.py
+++ b/tests/processor/test_act_processor.py
@@ -27,6 +27,7 @@ from lerobot.processor import (
     AddBatchDimensionProcessorStep,
     DataProcessorPipeline,
     DeviceProcessorStep,
+    ImageCropResizeProcessorStep,
     NormalizerProcessorStep,
     RenameObservationsProcessorStep,
     TransitionKey,
@@ -73,11 +74,12 @@ def test_make_act_processor_basic():
     assert postprocessor.name == "policy_postprocessor"
 
     # Check steps in preprocessor
-    assert len(preprocessor.steps) == 4
+    assert len(preprocessor.steps) == 5
     assert isinstance(preprocessor.steps[0], RenameObservationsProcessorStep)
     assert isinstance(preprocessor.steps[1], AddBatchDimensionProcessorStep)
     assert isinstance(preprocessor.steps[2], DeviceProcessorStep)
-    assert isinstance(preprocessor.steps[3], NormalizerProcessorStep)
+    assert isinstance(preprocessor.steps[3], ImageCropResizeProcessorStep)
+    assert isinstance(preprocessor.steps[4], NormalizerProcessorStep)
 
     # Check steps in postprocessor
     assert len(postprocessor.steps) == 2


### PR DESCRIPTION
## Title

feat(act) Add resize_imgs option to ACT preprocessing

## Summary / Motivation

- The ACT paper says that they use 480x640 size images, but there is no resizing done in the current preprocessor
- I was folllowing the lerobot imitation learning guide, which runs `lerobot-record` at 1080x1920, which makes training with `lerobot-train` almost 10x slower

## Related issues

- Fixes / Closes: # (if any)
- Related: # (if any)

## What changed

- adds `resize_imgs` arg
- adds a `ImageCropResizeProcessorStep` to act preprocessor

## How was this tested (or how to run locally)

- `pytest -sv tests/processor/test_act_processor.py`

## Checklist (required before merge)

- [ ] Linting/formatting run (`pre-commit run -a`)
- [ ] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: # (insert PR number/link)

## Reviewer notes

- Anything the reviewer should focus on (performance, edge-cases, specific files) or general notes.
- Anyone in the community is free to review the PR.
