### PR TITLE
Add dual wheels and bi-arm plugins

### DIFF
--- a/lerobot_robot_bi_so_follower_mobile/lerobot_robot_bi_so_follower_mobile/__init__.py
+++ b/lerobot_robot_bi_so_follower_mobile/lerobot_robot_bi_so_follower_mobile/__init__.py
@@ -1,0 +1,4 @@
+from .bi_so_follower_mobile import BiSOFollowerMobile
+from .config_bi_so_follower_mobile import BiSOFollowerMobileConfig
+
+__all__ = ["BiSOFollowerMobile", "BiSOFollowerMobileConfig"]

--- a/lerobot_robot_bi_so_follower_mobile/lerobot_robot_bi_so_follower_mobile/bi_so_follower_mobile.py
+++ b/lerobot_robot_bi_so_follower_mobile/lerobot_robot_bi_so_follower_mobile/bi_so_follower_mobile.py
@@ -1,0 +1,203 @@
+import logging
+from functools import cached_property
+
+from lerobot.motors import Motor, MotorNormMode
+from lerobot.motors.feetech import FeetechMotorsBus, OperatingMode
+from lerobot.robots import Robot
+from lerobot.robots.so_follower import SOFollower, SOFollowerRobotConfig
+from lerobot.types import RobotAction, RobotObservation
+from lerobot.utils.decorators import check_if_already_connected, check_if_not_connected
+
+from .config_bi_so_follower_mobile import BiSOFollowerMobileConfig
+
+logger = logging.getLogger(__name__)
+
+ARM_MOTOR_NAMES = [
+    "shoulder_pan", "shoulder_lift", "elbow_flex",
+    "wrist_flex", "wrist_roll", "gripper",
+]
+
+WHEEL_MOTORS = {
+    "base_left_wheel": Motor(9, "sts3250", MotorNormMode.RANGE_M100_100),
+    "base_right_wheel": Motor(10, "sts3250", MotorNormMode.RANGE_M100_100),
+}
+
+
+class BiSOFollowerMobile(Robot):
+    """
+    Bimanual SO-101 follower arms (Henrietta=left, Kermy=right) with a
+    dual-wheel mobile base. The wheel motors (STS3250, IDs 9 & 10) share
+    Kermy's motor bus with her 6 arm motors (STS3215, IDs 1-6).
+
+    Wheel velocities are included as action and observation dimensions so
+    they are recorded as part of the dataset during data collection.
+    """
+    config_class = BiSOFollowerMobileConfig
+    name = "bi_so_follower_mobile"
+
+    def __init__(self, config: BiSOFollowerMobileConfig):
+        super().__init__(config)
+        self.config = config
+
+        left_arm_config = SOFollowerRobotConfig(
+            id=f"{config.id}_left" if config.id else None,
+            calibration_dir=config.calibration_dir,
+            port=config.left_arm_config.port,
+            disable_torque_on_disconnect=config.left_arm_config.disable_torque_on_disconnect,
+            max_relative_target=config.left_arm_config.max_relative_target,
+            use_degrees=config.left_arm_config.use_degrees,
+            cameras=config.left_arm_config.cameras,
+        )
+
+        right_arm_config = SOFollowerRobotConfig(
+            id=f"{config.id}_right" if config.id else None,
+            calibration_dir=config.calibration_dir,
+            port=config.right_arm_config.port,
+            disable_torque_on_disconnect=config.right_arm_config.disable_torque_on_disconnect,
+            max_relative_target=config.right_arm_config.max_relative_target,
+            use_degrees=config.right_arm_config.use_degrees,
+            cameras=config.right_arm_config.cameras,
+        )
+
+        self.left_arm = SOFollower(left_arm_config)
+        self.right_arm = SOFollower(right_arm_config)
+        self.cameras = {**self.left_arm.cameras, **self.right_arm.cameras}
+
+    def _inject_wheels(self):
+        """
+        Add wheel motors into the right arm's already-open bus after arm
+        connect/calibration is complete. Injecting after connect ensures
+        the calibration check only sees arm motors 1-6, not the wheels.
+        """
+        for name, motor in WHEEL_MOTORS.items():
+            self.right_arm.bus.motors[name] = motor
+        self.right_arm.bus._id_to_model_dict[9] = "sts3250"
+        self.right_arm.bus._id_to_model_dict[10] = "sts3250"
+        self.right_arm.bus._id_to_name_dict[9] = "base_left_wheel"
+        self.right_arm.bus._id_to_name_dict[10] = "base_right_wheel"
+
+    def _init_wheels(self):
+        """Put wheel motors into velocity mode on the shared bus."""
+        wheel_names = list(WHEEL_MOTORS.keys())
+        self.right_arm.bus.disable_torque(wheel_names)
+        for name in wheel_names:
+            self.right_arm.bus.write("Operating_Mode", name, OperatingMode.VELOCITY.value)
+        self.right_arm.bus.write("Maximum_Velocity_Limit", "base_left_wheel", 255, normalize=False)
+        self.right_arm.bus.write("Maximum_Velocity_Limit", "base_right_wheel", 255, normalize=False)
+        self.right_arm.bus.enable_torque(wheel_names)
+        logger.info("Wheel motors initialized in velocity mode.")
+
+    @property
+    def _motors_ft(self) -> dict[str, type]:
+        return {
+            **{f"left_{m}.pos": float for m in ARM_MOTOR_NAMES},
+            **{f"right_{m}.pos": float for m in ARM_MOTOR_NAMES},
+            "base_left_wheel.vel": float,
+            "base_right_wheel.vel": float,
+        }
+
+    @property
+    def _cameras_ft(self) -> dict[str, tuple]:
+        return {
+            **{f"left_{k}": v for k, v in self.left_arm._cameras_ft.items()},
+            **{f"right_{k}": v for k, v in self.right_arm._cameras_ft.items()},
+        }
+
+    @cached_property
+    def observation_features(self) -> dict[str, type | tuple]:
+        return {**self._motors_ft, **self._cameras_ft}
+
+    @cached_property
+    def action_features(self) -> dict[str, type]:
+        return self._motors_ft
+
+    @property
+    def is_connected(self) -> bool:
+        return self.left_arm.is_connected and self.right_arm.is_connected
+
+    @check_if_already_connected
+    def connect(self, calibrate: bool = True) -> None:
+        # Connect arms first — calibration only sees motors 1-6 per arm
+        self.left_arm.connect(calibrate)
+        self.right_arm.connect(calibrate)
+        # Inject and initialize wheels on the already-open right arm bus
+        self._inject_wheels()
+        self._init_wheels()
+
+    @property
+    def is_calibrated(self) -> bool:
+        return self.left_arm.is_calibrated and self.right_arm.is_calibrated
+
+    def calibrate(self) -> None:
+        self.left_arm.calibrate()
+        self.right_arm.calibrate()
+
+    def configure(self) -> None:
+        self.left_arm.configure()
+        self.right_arm.configure()
+
+    def setup_motors(self) -> None:
+        self.left_arm.setup_motors()
+        self.right_arm.setup_motors()
+
+    @check_if_not_connected
+    def get_observation(self) -> RobotObservation:
+        obs_dict = {}
+
+        # Left arm — clean bus, use SOFollower normally
+        left_obs = self.left_arm.get_observation()
+        obs_dict.update({f"left_{k}": v for k, v in left_obs.items()})
+
+        # Right arm — read only the 6 arm motors by name to avoid wheel reads
+        right_pos = self.right_arm.bus.sync_read("Present_Position", ARM_MOTOR_NAMES)
+        for motor, value in right_pos.items():
+            obs_dict[f"right_{motor}.pos"] = float(value)
+
+        # Right arm cameras
+        for name, cam in self.right_arm.cameras.items():
+            obs_dict[f"right_{name}"] = cam.async_read()
+
+        # Wheel velocities from shared bus
+        wheel_vel = self.right_arm.bus.sync_read("Present_Velocity", list(WHEEL_MOTORS.keys()))
+        obs_dict["base_left_wheel.vel"] = float(wheel_vel["base_left_wheel"])
+        obs_dict["base_right_wheel.vel"] = float(wheel_vel["base_right_wheel"])
+
+        return obs_dict
+
+    @check_if_not_connected
+    def send_action(self, action: RobotAction) -> RobotAction:
+        left_action = {k.removeprefix("left_"): v for k, v in action.items() if k.startswith("left_")}
+        right_action = {k.removeprefix("right_"): v for k, v in action.items() if k.startswith("right_")}
+
+        sent_left = self.left_arm.send_action(left_action)
+        sent_right = self.right_arm.send_action(right_action)
+
+        # Wheel velocity commands — right wheel negated due to mirrored mounting
+        if "base_left_wheel.vel" in action:
+            self.right_arm.bus.write(
+                "Goal_Velocity", "base_left_wheel",
+                int(action["base_left_wheel.vel"]), normalize=False
+            )
+        if "base_right_wheel.vel" in action:
+            self.right_arm.bus.write(
+                "Goal_Velocity", "base_right_wheel",
+                int(action["base_right_wheel.vel"]) * -1, normalize=False
+            )
+
+        return {
+            **{f"left_{k}": v for k, v in sent_left.items()},
+            **{f"right_{k}": v for k, v in sent_right.items()},
+            "base_left_wheel.vel": action.get("base_left_wheel.vel", 0.0),
+            "base_right_wheel.vel": action.get("base_right_wheel.vel", 0.0),
+        }
+
+    @check_if_not_connected
+    def disconnect(self) -> None:
+        # Stop wheels before closing the bus
+        try:
+            self.right_arm.bus.write("Goal_Velocity", "base_left_wheel", 0, normalize=False)
+            self.right_arm.bus.write("Goal_Velocity", "base_right_wheel", 0, normalize=False)
+        except Exception:
+            pass
+        self.left_arm.disconnect()
+        self.right_arm.disconnect()

--- a/lerobot_robot_bi_so_follower_mobile/lerobot_robot_bi_so_follower_mobile/config_bi_so_follower_mobile.py
+++ b/lerobot_robot_bi_so_follower_mobile/lerobot_robot_bi_so_follower_mobile/config_bi_so_follower_mobile.py
@@ -1,0 +1,15 @@
+from dataclasses import dataclass
+
+from lerobot.robots import RobotConfig
+from lerobot.robots.so_follower import SOFollowerConfig
+
+
+@RobotConfig.register_subclass("bi_so_follower_mobile")
+@dataclass
+class BiSOFollowerMobileConfig(RobotConfig):
+    """
+    Configuration for bimanual SO-101 follower arms with a dual-wheel mobile base.
+    The wheel motors (STS3250, IDs 9 & 10) share the right arm's motor bus.
+    """
+    left_arm_config: SOFollowerConfig
+    right_arm_config: SOFollowerConfig

--- a/lerobot_robot_bi_so_follower_mobile/pyproject.toml
+++ b/lerobot_robot_bi_so_follower_mobile/pyproject.toml
@@ -1,0 +1,14 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "lerobot_robot_bi_so_follower_mobile"
+version = "0.1.0"
+description = "Bimanual SO-101 follower arms with dual wheel mobile base"
+requires-python = ">=3.10"
+dependencies = ["lerobot"]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["lerobot_robot_bi_so_follower_mobile*"]

--- a/lerobot_teleoperator_rudder_pedal/lerobot_teleoperator_rudder_pedal/__init__.py
+++ b/lerobot_teleoperator_rudder_pedal/lerobot_teleoperator_rudder_pedal/__init__.py
@@ -1,0 +1,4 @@
+from .configuration_rudder_pedal import RudderPedalConfig
+from .rudder_pedal import RudderPedal
+
+__all__ = ["RudderPedal", "RudderPedalConfig"]

--- a/lerobot_teleoperator_rudder_pedal/lerobot_teleoperator_rudder_pedal/configuration_rudder_pedal.py
+++ b/lerobot_teleoperator_rudder_pedal/lerobot_teleoperator_rudder_pedal/configuration_rudder_pedal.py
@@ -1,0 +1,25 @@
+from dataclasses import dataclass
+
+from lerobot.teleoperators.config import TeleoperatorConfig
+
+
+@TeleoperatorConfig.register_subclass("rudder_pedal")
+@dataclass
+class RudderPedalConfig(TeleoperatorConfig):
+    """
+    Configuration for Logitech/Saitek rudder pedals as a differential drive
+    wheel teleoperator.
+
+    Axis mapping (Saitek Pro Flight Rudder Pedals):
+      Axis 0: Right toe brake (-1=released, +1=fully pressed) → forward
+      Axis 1: Left toe brake  (-1=released, +1=fully pressed) → reverse
+      Axis 2: Rudder bar      ( 0=center, -1=full left, +1=full right) → turn
+
+    Control scheme:
+      Right brake → forward throttle
+      Left brake  → reverse throttle
+      Rudder      → differential steering
+    """
+    max_speed: float = 500.0   # raw velocity units sent to STS3250 (0-2000 practical range)
+    deadzone: float = 0.05     # ignore inputs below this to prevent drift
+    joystick_index: int = 0    # pygame joystick index if multiple devices connected

--- a/lerobot_teleoperator_rudder_pedal/lerobot_teleoperator_rudder_pedal/rudder_pedal.py
+++ b/lerobot_teleoperator_rudder_pedal/lerobot_teleoperator_rudder_pedal/rudder_pedal.py
@@ -1,0 +1,96 @@
+import logging
+
+import numpy as np
+import pygame
+
+from lerobot.teleoperators.teleoperator import Teleoperator
+
+from .configuration_rudder_pedal import RudderPedalConfig
+
+logger = logging.getLogger(__name__)
+
+
+class RudderPedal(Teleoperator):
+    """
+    Teleoperator for Logitech/Saitek rudder pedals controlling a differential
+    drive wheel base. Produces base_left_wheel.vel and base_right_wheel.vel
+    actions to be merged with arm teleop actions before sending to the robot.
+    """
+    config_class = RudderPedalConfig
+    name = "rudder_pedal"
+
+    def __init__(self, config: RudderPedalConfig):
+        super().__init__(config)
+        self.config = config
+        self.joystick = None
+
+    @property
+    def action_features(self) -> dict[str, type]:
+        return {
+            "base_left_wheel.vel": float,
+            "base_right_wheel.vel": float,
+        }
+
+    @property
+    def feedback_features(self) -> dict[str, type]:
+        return {}
+
+    @property
+    def is_connected(self) -> bool:
+        return self.joystick is not None
+
+    def connect(self, calibrate: bool = False) -> None:
+        pygame.init()
+        pygame.joystick.init()
+        if pygame.joystick.get_count() == 0:
+            raise RuntimeError(
+                "No joystick detected. Make sure the rudder pedals are plugged in."
+            )
+        self.joystick = pygame.joystick.Joystick(self.config.joystick_index)
+        self.joystick.init()
+        logger.info(f"Rudder pedal connected: {self.joystick.get_name()}")
+
+    @property
+    def is_calibrated(self) -> bool:
+        return True  # No calibration needed for pedals
+
+    def calibrate(self) -> None:
+        pass
+
+    def configure(self) -> None:
+        pass
+
+    def _apply_deadzone(self, value: float) -> float:
+        return 0.0 if abs(value) < self.config.deadzone else value
+
+    def get_action(self) -> dict[str, float]:
+        pygame.event.pump()
+
+        right_brake = self.joystick.get_axis(0)  # -1=released, +1=pressed → forward
+        left_brake  = self.joystick.get_axis(1)  # -1=released, +1=pressed → reverse
+        rudder      = self.joystick.get_axis(2)  # 0=center, ±1=full turn
+
+        # Normalize brakes from [-1, +1] to [0, 1]
+        reverse  = (left_brake  + 1) / 2
+        forward  = (right_brake + 1) / 2
+        throttle = self._apply_deadzone(forward - reverse)  # [-1, 1]
+        turn     = self._apply_deadzone(rudder)              # [-1, 1]
+
+        left_vel  = float(np.clip(throttle + turn, -1.0, 1.0) * self.config.max_speed)
+        right_vel = float(np.clip(throttle - turn, -1.0, 1.0) * self.config.max_speed)
+
+        return {
+            "base_left_wheel.vel":  left_vel,
+            "base_right_wheel.vel": right_vel,
+        }
+
+    def send_feedback(self, feedback: dict) -> None:
+        pass
+
+    def disconnect(self) -> None:
+        if self.joystick is not None:
+            self.joystick.quit()
+            self.joystick = None
+        pygame.joystick.quit()
+        pygame.quit()
+        logger.info("Rudder pedal disconnected.")

--- a/lerobot_teleoperator_rudder_pedal/pyproject.toml
+++ b/lerobot_teleoperator_rudder_pedal/pyproject.toml
@@ -1,0 +1,14 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "lerobot_teleoperator_rudder_pedal"
+version = "0.1.0"
+description = "Logitech/Saitek rudder pedal teleoperator for differential drive wheel control"
+requires-python = ">=3.10"
+dependencies = ["lerobot", "pygame"]
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["lerobot_teleoperator_rudder_pedal*"]

--- a/src/lerobot/scripts/teleop_bimanual_mobile.py
+++ b/src/lerobot/scripts/teleop_bimanual_mobile.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+"""
+Teleoperation script for bi_so_follower_mobile with rudder pedal wheel control.
+
+Requires these plugins to be installed:
+  pip install -e /path/to/lerobot_robot_bi_so_follower_mobile
+  pip install -e /path/to/lerobot_teleoperator_rudder_pedal
+
+Usage:
+  python -m lerobot.scripts.teleop_bimanual_mobile \
+    --robot.type=bi_so_follower_mobile \
+    --robot.left_arm_config.port=/dev/tty.usbmodem5B3D0422841 \
+    --robot.right_arm_config.port=/dev/tty.usbmodem5AE60849171 \
+    --robot.id=bi_so101_follower \
+    --arm_teleop.type=bi_so_leader \
+    --arm_teleop.left_arm_config.port=/dev/tty.usbmodem5B3D0466431 \
+    --arm_teleop.right_arm_config.port=/dev/tty.usbmodem5AE60531711 \
+    --arm_teleop.id=bi_so101_leader \
+    --wheel_teleop.max_speed=500.0
+"""
+
+import logging
+import time
+from dataclasses import dataclass, field
+
+import draccus
+
+from lerobot.robots.config import RobotConfig
+from lerobot.robots.utils import make_robot_from_config
+from lerobot.teleoperators.config import TeleoperatorConfig
+from lerobot.teleoperators.utils import make_teleoperator_from_config
+
+# These imports trigger register_subclass decorators
+import lerobot_robot_bi_so_follower_mobile  # noqa: F401
+import lerobot_teleoperator_rudder_pedal    # noqa: F401
+# bi_so_leader lives inside lerobot itself (not a plugin package) so it does not
+# get auto-discovered by the plugin prefix system. We import it explicitly here
+# to trigger its @TeleoperatorConfig.register_subclass decorator so draccus can
+# parse --arm_teleop.type=bi_so_leader from the command line.
+from lerobot.teleoperators import bi_so_leader  # noqa: F401
+from lerobot_teleoperator_rudder_pedal import RudderPedal, RudderPedalConfig
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TeleopBimanualMobileConfig:
+    robot: RobotConfig
+    arm_teleop: TeleoperatorConfig
+    wheel_teleop: RudderPedalConfig = field(default_factory=RudderPedalConfig)
+    fps: int = 60
+    display_data: bool = False
+
+
+@draccus.wrap()
+def main(cfg: TeleopBimanualMobileConfig):
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    robot        = make_robot_from_config(cfg.robot)
+    arm_teleop   = make_teleoperator_from_config(cfg.arm_teleop)
+    wheel_teleop = RudderPedal(cfg.wheel_teleop)
+
+    try:
+        robot.connect()
+        arm_teleop.connect()
+        wheel_teleop.connect()
+
+        print("Teleoperation started.")
+        print("  Right brake = forward | Left brake = reverse | Rudder = turn")
+        print("  Ctrl+C to stop.")
+
+        dt = 1.0 / cfg.fps
+
+        while True:
+            start = time.perf_counter()
+
+            arm_action   = arm_teleop.get_action()
+            wheel_action = wheel_teleop.get_action()
+            action       = {**arm_action, **wheel_action}
+
+            robot.send_action(action)
+
+            if cfg.display_data:
+                print(
+                    f"L_wheel: {wheel_action['base_left_wheel.vel']:+6.1f}  "
+                    f"R_wheel: {wheel_action['base_right_wheel.vel']:+6.1f}",
+                    end="\r"
+                )
+
+            elapsed = time.perf_counter() - start
+            time.sleep(max(0, dt - elapsed))
+
+    except KeyboardInterrupt:
+        print("\nStopping teleoperation.")
+    finally:
+        robot.disconnect()
+        arm_teleop.disconnect()
+        wheel_teleop.disconnect()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Title

Add dual wheels and bi-arm plugins

## Summary / Motivation

- I built the xlerobot with the dual wheel system and needed a way to steer the wheels while both of my arms are teleoperating the 2 follow arms.  My solution was to get Logitech G Pro Flight Rudder Pedals to steer the dual wheel base since my arms are full.

## Related issues

## What changed

- Created a plugin for the dual wheel system to be teleoperated by Logitech G Pro Flight Rudder Pedals
- Attached this to the bi arm plugin since the dual wheels are on the same motorbus as the right arm

## How was this tested (or how to run locally)

- Tested by teleoperating the robot with the rudder wheels and leader arms

python -m lerobot.scripts.teleop_bimanual_mobile \
    --robot.type=bi_so_follower_mobile \
    --robot.left_arm_config.port=/dev/tty.usbmodem5B3D0422841 \
    --robot.right_arm_config.port=/dev/tty.usbmodem5AE60849171 \
    --robot.id=bi_so101_follower \
    --arm_teleop.type=bi_so_leader \
    --arm_teleop.left_arm_config.port=/dev/tty.usbmodem5B3D0466431 \
    --arm_teleop.right_arm_config.port=/dev/tty.usbmodem5AE60531711 \
    --arm_teleop.id=bi_so101_leader \
    --wheel_teleop.max_speed=500.0 \
    --display_data=true

## Checklist (required before merge)

- [ ] Linting/formatting run (`pre-commit run -a`)
- [ ] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: # (insert PR number/link)

## Reviewer notes

- Anything the reviewer should focus on (performance, edge-cases, specific files) or general notes.
- Anyone in the community is free to review the PR.
