### PR TITLE
feat(datasets): add lerobot-dataset-quality to flag outlier episodes

### DIFF
--- a/docs/source/using_dataset_tools.mdx
+++ b/docs/source/using_dataset_tools.mdx
@@ -192,6 +192,29 @@ lerobot-edit-dataset \
 
 There is also a tool for adding features to a dataset that is not yet covered in `lerobot-edit-dataset`.
 
+## Command-Line Tool: lerobot-dataset-quality
+
+For datasets with many episodes, reviewing each one in `lerobot-dataset-viz` is impractical. `lerobot-dataset-quality` computes deterministic per-episode metrics from the recorded actions — duration, trajectory smoothness (jerk), peak velocity, fraction of motionless frames, and end-pose consistency — and flags episodes that are statistical outliers (IQR rule) on any of them. The flagged episodes are a short list of candidates to inspect visually and optionally remove with `lerobot-edit-dataset`:
+
+```bash
+# Analyze a dataset from the hub (or local cache)
+lerobot-dataset-quality --repo-id user/my_dataset
+
+# Analyze a local dataset and emit machine-readable JSON
+lerobot-dataset-quality --repo-id user/my_dataset --root /path/to/dataset --output-format json
+
+# Use a stricter outlier rule and list more episodes
+lerobot-dataset-quality --repo-id user/my_dataset --k-iqr 1.0 --top-bad 20
+```
+
+**Parameters:**
+
+- `top_bad`: How many of the worst episodes to list in the table report (default: 10)
+- `k_iqr`: IQR multiplier for outlier detection; lower is stricter (default: 1.5)
+- `output_format`: `table` (human-readable, default) or `json` (machine-readable)
+
+**Reading the output:** flags name the metric and the direction, e.g. `duration_high` (episode much longer than the rest, often a struggled attempt), `spike_jerk_high` (sharp corrections), `static_high` (long hesitations), `final_state_high` (episode ends in a different pose than the others). The tool is read-only; it prints a ready-to-edit `lerobot-edit-dataset --operation.type delete_episodes` command for the worst episodes, to run only after reviewing them in `lerobot-dataset-viz`.
+
 # Dataset Visualization
 
 ## Online Visualization

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -318,6 +318,7 @@ lerobot-imgtransform-viz="lerobot.scripts.lerobot_imgtransform_viz:main"
 lerobot-edit-dataset="lerobot.scripts.lerobot_edit_dataset:main"
 lerobot-setup-can="lerobot.scripts.lerobot_setup_can:main"
 lerobot-rollout="lerobot.scripts.lerobot_rollout:main"
+lerobot-dataset-quality="lerobot.scripts.lerobot_dataset_quality:main"
 
 # ---------------- Tool Configurations ----------------
 

--- a/src/lerobot/scripts/lerobot_dataset_quality.py
+++ b/src/lerobot/scripts/lerobot_dataset_quality.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Compute per-episode quality metrics for a LeRobotDataset and flag outlier episodes.
+
+For datasets with more than a handful of episodes, reviewing each one in `lerobot-dataset-viz` is
+impractical. This tool computes deterministic metrics from the recorded actions of every episode:
+
+- `n_frames` / `duration_s`: episode length
+- `median_jerk` / `p95_jerk`: trajectory smoothness (second derivative of the actions)
+- `max_velocity`: peak action-space velocity
+- `static_fraction`: fraction of near-motionless frames (hesitations, dead time)
+- `final_action`: last action of the episode (end-pose consistency across episodes)
+
+Episodes that are outliers on any metric (IQR rule) are flagged and ranked, producing a short list of
+candidates to inspect in `lerobot-dataset-viz` and optionally remove with `lerobot-edit-dataset`.
+
+Usage examples:
+
+Analyze a dataset from the Hugging Face hub (or local cache):
+```shell
+lerobot-dataset-quality --repo-id=user/my_dataset
+```
+
+Analyze a local dataset and emit machine-readable JSON:
+```shell
+lerobot-dataset-quality --repo-id=user/my_dataset --root=/path/to/dataset --output-format=json
+```
+
+Use a stricter outlier rule and list more episodes:
+```shell
+lerobot-dataset-quality --repo-id=user/my_dataset --k-iqr=1.0 --top-bad=20
+```
+"""
+
+import argparse
+import json
+import logging
+from collections import defaultdict
+from pathlib import Path
+
+import numpy as np
+
+from lerobot.datasets.lerobot_dataset import LeRobotDataset
+from lerobot.utils.constants import ACTION
+from lerobot.utils.utils import init_logging
+
+
+def group_actions_by_episode(hf_dataset) -> dict[int, np.ndarray]:
+    """Group action arrays by episode from a LeRobotDataset's underlying hf_dataset."""
+    columns = hf_dataset.select_columns(["episode_index", "frame_index", ACTION])
+    rows_by_ep: dict[int, list[tuple[int, np.ndarray]]] = {}
+    for row in columns:
+        ep = int(row["episode_index"])
+        rows_by_ep.setdefault(ep, []).append(
+            (int(row["frame_index"]), np.asarray(row[ACTION], dtype=np.float64))
+        )
+    actions_by_ep = {}
+    for ep, rows in rows_by_ep.items():
+        rows.sort(key=lambda r: r[0])
+        actions_by_ep[ep] = np.stack([r[1] for r in rows])
+    return actions_by_ep
+
+
+def compute_episode_metrics(actions: np.ndarray, episode_index: int, fps: float) -> dict:
+    """Compute deterministic quality metrics from one episode's actions array of shape (T, action_dim)."""
+    n_frames = len(actions)
+    metrics = {
+        "episode": episode_index,
+        "n_frames": int(n_frames),
+        "duration_s": round(n_frames / fps, 2),
+        "median_jerk": 0.0,
+        "p95_jerk": 0.0,
+        "max_velocity": 0.0,
+        "static_fraction": 0.0,
+        "final_action": actions[-1].tolist() if n_frames > 0 else [],
+    }
+    if n_frames < 3:
+        return metrics
+
+    velocities = np.diff(actions, axis=0)  # (T-1, action_dim)
+    jerk = np.diff(velocities, axis=0)  # (T-2, action_dim)
+
+    # Median is robust to isolated spikes from quick corrections; p95 captures those spikes instead.
+    jerk_magnitude = np.linalg.norm(jerk, axis=1)
+    metrics["median_jerk"] = round(float(np.median(jerk_magnitude)), 5)
+    metrics["p95_jerk"] = round(float(np.percentile(jerk_magnitude, 95)), 5)
+
+    velocity_magnitude = np.linalg.norm(velocities, axis=1)
+    metrics["max_velocity"] = round(float(np.max(velocity_magnitude)), 4)
+
+    # A frame is "static" when it moves less than 5% of the median active velocity.
+    active_vels = velocity_magnitude[velocity_magnitude > 1e-6]
+    if len(active_vels) > 0:
+        static_threshold = 0.05 * np.median(active_vels)
+        metrics["static_fraction"] = round(float(np.mean(velocity_magnitude < static_threshold)), 3)
+    else:
+        metrics["static_fraction"] = 1.0
+
+    return metrics
+
+
+def detect_outliers(metrics: list[dict], k_iqr: float = 1.5) -> dict[int, set[str]]:
+    """Flag episodes that are outliers on any metric using the IQR rule.
+
+    Returns a dict mapping episode index to the set of flags raised for it (e.g. "duration_high").
+    """
+    outliers: dict[int, set[str]] = defaultdict(set)
+
+    def iqr_outliers(values: list[float], episodes: list[int], name: str, direction: str = "both") -> None:
+        q1, q3 = np.percentile(values, [25, 75])
+        iqr = q3 - q1
+        lo, hi = q1 - k_iqr * iqr, q3 + k_iqr * iqr
+        for v, ep in zip(values, episodes, strict=True):
+            if direction in ("both", "high") and v > hi:
+                outliers[ep].add(f"{name}_high")
+            if direction in ("both", "low") and v < lo:
+                outliers[ep].add(f"{name}_low")
+
+    eps = [m["episode"] for m in metrics]
+    iqr_outliers([m["n_frames"] for m in metrics], eps, "duration")
+    iqr_outliers([m["median_jerk"] for m in metrics], eps, "jerk", "high")
+    iqr_outliers([m["p95_jerk"] for m in metrics], eps, "spike_jerk", "high")
+    iqr_outliers([m["max_velocity"] for m in metrics], eps, "max_vel", "high")
+    iqr_outliers([m["static_fraction"] for m in metrics], eps, "static", "high")
+
+    # End-pose consistency: distance of each episode's final action from the across-episode mean.
+    finals = [m["final_action"] for m in metrics if m["final_action"]]
+    final_eps = [m["episode"] for m in metrics if m["final_action"]]
+    if finals:
+        finals_arr = np.array(finals)
+        distances = np.linalg.norm(finals_arr - np.mean(finals_arr, axis=0), axis=1)
+        iqr_outliers(distances.tolist(), final_eps, "final_state", "high")
+
+    return dict(outliers)
+
+
+def evaluate_dataset_quality(dataset: LeRobotDataset, k_iqr: float = 1.5) -> dict:
+    """Run the full quality analysis: per-episode metrics plus IQR outlier flags."""
+    if ACTION not in dataset.meta.features:
+        raise ValueError(f"Dataset must contain an '{ACTION}' feature. Found: {list(dataset.meta.features)}")
+
+    actions_by_ep = group_actions_by_episode(dataset.hf_dataset)
+    metrics = [compute_episode_metrics(actions_by_ep[ep], ep, dataset.fps) for ep in sorted(actions_by_ep)]
+    outliers = detect_outliers(metrics, k_iqr=k_iqr)
+    return {"metrics": metrics, "outliers": {ep: sorted(flags) for ep, flags in outliers.items()}}
+
+
+def print_table_report(repo_id: str, report: dict, top_bad: int = 10) -> None:
+    """Print a human-readable summary of the quality analysis."""
+    metrics = report["metrics"]
+    outliers = report["outliers"]
+    n = len(metrics)
+
+    print(f"\nEpisode quality report — {repo_id} ({n} episodes)\n")
+
+    durations = [m["duration_s"] for m in metrics]
+    n_frames = [m["n_frames"] for m in metrics]
+    jerks = [m["median_jerk"] for m in metrics]
+    velocities = [m["max_velocity"] for m in metrics]
+    statics = [m["static_fraction"] for m in metrics]
+
+    print("Aggregate stats (mean ± std, min–max):")
+    print(
+        f"  Duration         : {np.mean(durations):.1f} ± {np.std(durations):.1f}s "
+        f"({np.min(durations):.1f}–{np.max(durations):.1f}s)"
+    )
+    print(
+        f"  Frames           : {np.mean(n_frames):.0f} ± {np.std(n_frames):.0f} "
+        f"({np.min(n_frames)}–{np.max(n_frames)})"
+    )
+    print(f"  Median jerk      : {np.mean(jerks):.4f} ± {np.std(jerks):.4f}")
+    print(f"  Max velocity     : {np.mean(velocities):.3f} ± {np.std(velocities):.3f}")
+    print(f"  Static fraction  : {np.mean(statics) * 100:.1f}% ± {np.std(statics) * 100:.1f}%")
+    print()
+
+    flag_counts: dict[str, int] = defaultdict(int)
+    for flags in outliers.values():
+        for flag in flags:
+            flag_counts[flag] += 1
+    print(f"Outlier flags ({len(outliers)} episodes flagged at least once):")
+    for flag, count in sorted(flag_counts.items(), key=lambda x: -x[1]):
+        print(f"  {flag:25s}: {count} episodes")
+    print()
+
+    ranked = sorted(outliers.items(), key=lambda x: -len(x[1]))[:top_bad]
+    if ranked:
+        print(f"Top {len(ranked)} worst episodes (most flags):")
+        print(f"  {'ep':>4} | {'#flags':>6} | flags")
+        print(f"  {'-' * 4} | {'-' * 6} | {'-' * 60}")
+        for ep, flags in ranked:
+            print(f"  {ep:>4} | {len(flags):>6} | {', '.join(flags)}")
+        print()
+
+        bad_eps = sorted(ep for ep, _ in ranked)
+        print("Suggested next step — review these in lerobot-dataset-viz, then optionally delete:")
+        print(f"  lerobot-dataset-viz --repo-id {repo_id} --episode-index {bad_eps[0]}")
+        print("  lerobot-edit-dataset \\")
+        print(f"    --repo_id {repo_id} \\")
+        print(f"    --new_repo_id {repo_id}_clean \\")
+        print("    --operation.type delete_episodes \\")
+        print(f'    --operation.episode_indices "{bad_eps}"')
+    else:
+        print("No outlier episodes flagged — dataset looks consistent.")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Compute per-episode quality metrics for a LeRobotDataset and flag outlier episodes."
+    )
+    parser.add_argument(
+        "--repo-id",
+        type=str,
+        required=True,
+        help="Name of the Hugging Face repository containing a LeRobotDataset (e.g. `user/my_dataset`).",
+    )
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=None,
+        help="Root directory of a dataset stored locally. By default, the dataset is loaded from the "
+        "Hugging Face cache folder, or downloaded from the hub if available.",
+    )
+    parser.add_argument(
+        "--top-bad",
+        type=int,
+        default=10,
+        help="How many of the worst episodes to list in the table report (default: 10).",
+    )
+    parser.add_argument(
+        "--k-iqr",
+        type=float,
+        default=1.5,
+        help="IQR multiplier for outlier detection; lower is stricter (default: 1.5).",
+    )
+    parser.add_argument(
+        "--output-format",
+        type=str,
+        choices=["table", "json"],
+        default="table",
+        help="Print a human-readable table (default) or machine-readable JSON.",
+    )
+    args = parser.parse_args()
+
+    init_logging()
+    logging.info(f"Loading dataset: {args.repo_id}")
+    dataset = LeRobotDataset(args.repo_id, root=args.root)
+
+    report = evaluate_dataset_quality(dataset, k_iqr=args.k_iqr)
+
+    if args.output_format == "json":
+        print(json.dumps({"repo_id": args.repo_id, **report}, indent=2))
+    else:
+        print_table_report(args.repo_id, report, top_bad=args.top_bad)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/scripts/test_dataset_quality.py
+++ b/tests/scripts/test_dataset_quality.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pytest
+
+from lerobot.scripts.lerobot_dataset_quality import (
+    compute_episode_metrics,
+    detect_outliers,
+    evaluate_dataset_quality,
+    group_actions_by_episode,
+)
+from lerobot.utils.constants import ACTION
+
+FPS = 30
+
+
+def smooth_episode(n_frames: int = 90, num_motors: int = 3) -> np.ndarray:
+    """A smooth sinusoidal trajectory: low jerk, no static frames."""
+    t = np.linspace(0, np.pi, n_frames)[:, None]
+    return 10.0 * np.sin(t) * np.ones(num_motors)
+
+
+class TestComputeEpisodeMetrics:
+    def test_smooth_trajectory_has_low_jerk(self):
+        metrics = compute_episode_metrics(smooth_episode(), episode_index=0, fps=FPS)
+
+        assert metrics["episode"] == 0
+        assert metrics["n_frames"] == 90
+        assert metrics["duration_s"] == 3.0
+        assert metrics["median_jerk"] < 0.1
+        assert metrics["static_fraction"] < 0.2
+
+    def test_spike_increases_p95_jerk(self):
+        actions = smooth_episode(n_frames=40)
+        spiked = actions.copy()
+        spiked[20] += 20.0  # single sharp correction
+        smooth = compute_episode_metrics(actions, episode_index=0, fps=FPS)
+        jerky = compute_episode_metrics(spiked, episode_index=1, fps=FPS)
+
+        assert jerky["p95_jerk"] > smooth["p95_jerk"]
+        assert jerky["max_velocity"] > smooth["max_velocity"]
+
+    def test_hold_increases_static_fraction(self):
+        moving = smooth_episode(n_frames=45)
+        hold = np.tile(moving[-1], (45, 1))
+        with_hold = np.concatenate([moving, hold])
+        metrics = compute_episode_metrics(with_hold, episode_index=0, fps=FPS)
+
+        assert metrics["static_fraction"] > 0.4
+
+    def test_short_episode_returns_defaults(self):
+        actions = np.ones((2, 3))
+        metrics = compute_episode_metrics(actions, episode_index=5, fps=FPS)
+
+        assert metrics["episode"] == 5
+        assert metrics["n_frames"] == 2
+        assert metrics["median_jerk"] == 0.0
+        assert metrics["final_action"] == [1.0, 1.0, 1.0]
+
+    def test_final_action_is_last_action(self):
+        actions = smooth_episode()
+        metrics = compute_episode_metrics(actions, episode_index=0, fps=FPS)
+        np.testing.assert_allclose(metrics["final_action"], actions[-1])
+
+
+class TestDetectOutliers:
+    def make_uniform_metrics(self, n: int = 20) -> list[dict]:
+        return [compute_episode_metrics(smooth_episode(), episode_index=ep, fps=FPS) for ep in range(n)]
+
+    def test_uniform_dataset_has_no_outliers(self):
+        outliers = detect_outliers(self.make_uniform_metrics())
+        assert outliers == {}
+
+    def test_long_episode_flagged_as_duration_outlier(self):
+        metrics = self.make_uniform_metrics()
+        metrics.append(compute_episode_metrics(smooth_episode(n_frames=900), episode_index=99, fps=FPS))
+        outliers = detect_outliers(metrics)
+
+        assert 99 in outliers
+        assert "duration_high" in outliers[99]
+
+    def test_divergent_final_pose_flagged(self):
+        metrics = self.make_uniform_metrics()
+        divergent = smooth_episode()
+        divergent[-1] += 50.0
+        metrics.append(compute_episode_metrics(divergent, episode_index=99, fps=FPS))
+        outliers = detect_outliers(metrics)
+
+        assert "final_state_high" in outliers.get(99, set())
+
+
+class FakeMeta:
+    def __init__(self, num_motors):
+        self.features = {ACTION: {"dtype": "float32", "shape": (num_motors,), "names": None}}
+
+
+class FakeDataset:
+    def __init__(self, hf_dataset, num_motors, fps=FPS):
+        self.hf_dataset = hf_dataset
+        self.meta = FakeMeta(num_motors)
+        self.fps = fps
+
+
+def make_fake_dataset(episodes: dict[int, np.ndarray]):
+    datasets = pytest.importorskip("datasets", reason="datasets is required (install lerobot[dataset])")
+
+    episode_index, frame_index, actions = [], [], []
+    for ep, ep_actions in episodes.items():
+        episode_index += [ep] * len(ep_actions)
+        frame_index += list(range(len(ep_actions)))
+        actions += ep_actions.tolist()
+    hf_dataset = datasets.Dataset.from_dict(
+        {"episode_index": episode_index, "frame_index": frame_index, ACTION: actions}
+    )
+    num_motors = next(iter(episodes.values())).shape[1]
+    return FakeDataset(hf_dataset, num_motors)
+
+
+class TestGroupActionsByEpisode:
+    def test_groups_and_sorts_by_frame_index(self):
+        datasets = pytest.importorskip("datasets", reason="datasets is required (install lerobot[dataset])")
+
+        hf_dataset = datasets.Dataset.from_dict(
+            {
+                "episode_index": [1, 0, 0, 1],
+                "frame_index": [1, 1, 0, 0],
+                ACTION: [[10.0], [1.0], [0.0], [9.0]],
+            }
+        )
+        actions_by_ep = group_actions_by_episode(hf_dataset)
+
+        assert set(actions_by_ep) == {0, 1}
+        np.testing.assert_allclose(actions_by_ep[0], [[0.0], [1.0]])
+        np.testing.assert_allclose(actions_by_ep[1], [[9.0], [10.0]])
+
+
+class TestEvaluateDatasetQuality:
+    def test_end_to_end_flags_bad_episode(self):
+        episodes = {ep: smooth_episode() for ep in range(20)}
+        episodes[20] = smooth_episode(n_frames=900)  # 10x longer than the rest
+        dataset = make_fake_dataset(episodes)
+
+        report = evaluate_dataset_quality(dataset)
+
+        assert len(report["metrics"]) == 21
+        assert report["metrics"][0]["episode"] == 0
+        assert "duration_high" in report["outliers"][20]
+
+    def test_missing_action_feature_raises(self):
+        dataset = make_fake_dataset({0: smooth_episode()})
+        del dataset.meta.features[ACTION]
+        with pytest.raises(ValueError, match="must contain"):
+            evaluate_dataset_quality(dataset)


### PR DESCRIPTION
## Summary / Motivation

Once a teleoperation dataset grows past a few dozen episodes, reviewing each one in `lerobot-dataset-viz` is impractical, so bad demonstrations (struggled long attempts, sharp corrections, hesitations, wrong end poses) silently stay in the training set. This PR adds `lerobot-dataset-quality`, a read-only CLI that computes deterministic per-episode metrics from the recorded actions and flags statistical outliers, turning "watch 200 episodes" into "watch these 8". The flagged list feeds directly into the existing `lerobot-dataset-viz` → `lerobot-edit-dataset --operation.type delete_episodes` workflow.

## Related issues

- Closes: #3760
- Related: #3758 (companion diagnostic for leader/follower calibration drift)

## What changed

- `src/lerobot/scripts/lerobot_dataset_quality.py`: new analysis tool. Core logic is in pure, importable functions (`compute_episode_metrics`, `detect_outliers`, `evaluate_dataset_quality`) with a thin argparse `main()` following the `lerobot-dataset-viz` CLI conventions (`--repo-id`, `--root`). Only the `action` column is read — no image/video decoding, so it runs in seconds.
- Metrics per episode: `n_frames`/`duration_s`, `median_jerk` and `p95_jerk` (smoothness vs. isolated spikes), `max_velocity`, `static_fraction` (hesitations), and final-pose distance from the across-episode mean. Outliers flagged with the IQR rule (`--k-iqr`, default 1.5).
- `pyproject.toml`: new `lerobot-dataset-quality` entry point.
- `tests/scripts/test_dataset_quality.py`: 11 unit tests on synthetic trajectories with known properties (smooth vs. spiked vs. holding), outlier detection (uniform set → no flags; long episode → `duration_high`; divergent end pose → `final_state_high`), episode grouping/sorting, and the end-to-end report including error paths.
- `docs/source/using_dataset_tools.mdx`: user-facing documentation section.

No breaking changes; purely additive and read-only.

## How was this tested (or how to run locally)

- Tests added: `tests/scripts/test_dataset_quality.py` — `uv run pytest tests/scripts/test_dataset_quality.py -v` (11 passed)
- `pre-commit run` passes on all touched files (ruff, mypy, bandit, typos, prettier).
- Manually verified on real SO-101 teleop datasets: flagged episodes matched the ones already identified as bad by manual review in `lerobot-dataset-viz` (over-long struggled attempts and episodes ending in the wrong pose).
- Quick reviewer repro: `lerobot-dataset-quality --repo-id lerobot/pusht` (any dataset with an `action` feature works) or add `--output-format json` for raw numbers.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: # (pending)

## Reviewer notes

- The IQR rule was chosen over z-scores because episode metrics are typically skewed (e.g. a few very long episodes); it is also what flags nothing on a perfectly uniform dataset.
- `median_jerk` vs `p95_jerk` is deliberate: the median is robust to isolated corrective spikes, the p95 is there to catch exactly those spikes.
- The tool prints a suggested `lerobot-edit-dataset` delete command but never modifies anything itself; the docs stress reviewing flagged episodes visually before deleting.
- Happy to rename the command, tune default thresholds, or fold this elsewhere if maintainers prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
