### PR TITLE
feat(datasets): add dataset diagnostics CLIs (calibration drift + episode quality)

### DIFF
--- a/docs/source/using_dataset_tools.mdx
+++ b/docs/source/using_dataset_tools.mdx
@@ -192,6 +192,32 @@ lerobot-edit-dataset \
 
 There is also a tool for adding features to a dataset that is not yet covered in `lerobot-edit-dataset`.
 
+## Command-Line Tool: lerobot-check-calibration
+
+In leader/follower teleoperation, `action` stores the leader position and `observation.state` stores the follower position. If the two arms are calibrated differently, every recorded frame carries a systematic offset between them. This is invisible during training — the policy simply learns the biased mapping and the loss looks healthy — but it breaks deployment, because at inference time the policy receives follower observations while it was trained to output leader-shifted targets.
+
+`lerobot-check-calibration` detects this drift after recording, using only data the dataset already contains. It restricts the comparison to "stable" frames (frames where the robot is not moving, so the follower controller has converged) and reports the mean `action - observation.state` per motor:
+
+```bash
+# Check a dataset from the hub (or local cache)
+lerobot-check-calibration --repo-id user/my_dataset
+
+# Check a local dataset and emit machine-readable JSON
+lerobot-check-calibration --repo-id user/my_dataset --root /path/to/dataset --output-format json
+
+# Estimate the Cartesian end-effector impact of the worst joint offset (for a 30 cm arm)
+lerobot-check-calibration --repo-id user/my_dataset --arm-length-cm 30
+```
+
+**Parameters:**
+
+- `vel_threshold`: Max per-joint motion (in action units per step) for a frame to count as stable (default: 0.5)
+- `ok_threshold` / `warn_threshold`: Verdict boundaries on the absolute mean delta (defaults: 1.0 / 3.0)
+- `arm_length_cm`: Optional arm length used to estimate the Cartesian impact of the worst offset (assumes degrees)
+- `output_format`: `table` (human-readable, default) or `json` (machine-readable)
+
+**Reading the output:** a mean delta close to zero means the arms are aligned on that motor. A systematic offset above 1-3 degrees indicates a calibration mismatch — consider re-running `lerobot-calibrate` on both arms before recording more episodes. Grippers usually show a high standard deviation (fast open/close motions); focus on the arm joints.
+
 # Dataset Visualization
 
 ## Online Visualization

--- a/docs/source/using_dataset_tools.mdx
+++ b/docs/source/using_dataset_tools.mdx
@@ -218,6 +218,29 @@ lerobot-check-calibration --repo-id user/my_dataset --arm-length-cm 30
 
 **Reading the output:** a mean delta close to zero means the arms are aligned on that motor. A systematic offset above 1-3 degrees indicates a calibration mismatch — consider re-running `lerobot-calibrate` on both arms before recording more episodes. Grippers usually show a high standard deviation (fast open/close motions); focus on the arm joints.
 
+## Command-Line Tool: lerobot-dataset-quality
+
+For datasets with many episodes, reviewing each one in `lerobot-dataset-viz` is impractical. `lerobot-dataset-quality` computes deterministic per-episode metrics from the recorded actions — duration, trajectory smoothness (jerk), peak velocity, fraction of motionless frames, and end-pose consistency — and flags episodes that are statistical outliers (IQR rule) on any of them. The flagged episodes are a short list of candidates to inspect visually and optionally remove with `lerobot-edit-dataset`:
+
+```bash
+# Analyze a dataset from the hub (or local cache)
+lerobot-dataset-quality --repo-id user/my_dataset
+
+# Analyze a local dataset and emit machine-readable JSON
+lerobot-dataset-quality --repo-id user/my_dataset --root /path/to/dataset --output-format json
+
+# Use a stricter outlier rule and list more episodes
+lerobot-dataset-quality --repo-id user/my_dataset --k-iqr 1.0 --top-bad 20
+```
+
+**Parameters:**
+
+- `top_bad`: How many of the worst episodes to list in the table report (default: 10)
+- `k_iqr`: IQR multiplier for outlier detection; lower is stricter (default: 1.5)
+- `output_format`: `table` (human-readable, default) or `json` (machine-readable)
+
+**Reading the output:** flags name the metric and the direction, e.g. `duration_high` (episode much longer than the rest, often a struggled attempt), `spike_jerk_high` (sharp corrections), `static_high` (long hesitations), `final_state_high` (episode ends in a different pose than the others). The tool is read-only; it prints a ready-to-edit `lerobot-edit-dataset --operation.type delete_episodes` command for the worst episodes, to run only after reviewing them in `lerobot-dataset-viz`.
+
 # Dataset Visualization
 
 ## Online Visualization

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -319,6 +319,7 @@ lerobot-edit-dataset="lerobot.scripts.lerobot_edit_dataset:main"
 lerobot-setup-can="lerobot.scripts.lerobot_setup_can:main"
 lerobot-rollout="lerobot.scripts.lerobot_rollout:main"
 lerobot-check-calibration="lerobot.scripts.lerobot_check_calibration:main"
+lerobot-dataset-quality="lerobot.scripts.lerobot_dataset_quality:main"
 
 # ---------------- Tool Configurations ----------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -318,6 +318,7 @@ lerobot-imgtransform-viz="lerobot.scripts.lerobot_imgtransform_viz:main"
 lerobot-edit-dataset="lerobot.scripts.lerobot_edit_dataset:main"
 lerobot-setup-can="lerobot.scripts.lerobot_setup_can:main"
 lerobot-rollout="lerobot.scripts.lerobot_rollout:main"
+lerobot-check-calibration="lerobot.scripts.lerobot_check_calibration:main"
 
 # ---------------- Tool Configurations ----------------
 

--- a/src/lerobot/scripts/lerobot_check_calibration.py
+++ b/src/lerobot/scripts/lerobot_check_calibration.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Detect leader/follower calibration drift in a recorded teleoperation dataset.
+
+In leader/follower teleoperation, `action` holds the leader position and `observation.state` holds the
+follower position at the same timestep. On frames where the robot is not moving ("stable" frames), the
+follower controller has had time to converge, so `action - observation.state` should be close to zero.
+A systematic non-zero mean on a joint reveals a calibration offset between the two arms — an error that
+is invisible during training (the policy simply learns the biased mapping) but breaks deployment, since
+inference feeds follower observations to a policy trained on leader-shifted targets.
+
+This tool computes, per motor, the mean and standard deviation of `action - observation.state` restricted
+to stable frames (frames where every joint moves less than `--vel-threshold` units per step).
+
+Note: deltas are expressed in the dataset's native action units (degrees for most Feetech/Dynamixel-based
+arms such as SO-100/SO-101). Adjust `--ok-threshold` / `--warn-threshold` if your dataset uses other units.
+
+Usage examples:
+
+Check a dataset from the Hugging Face hub (or local cache):
+```shell
+lerobot-check-calibration --repo-id=user/my_dataset
+```
+
+Check a local dataset and emit machine-readable JSON:
+```shell
+lerobot-check-calibration --repo-id=user/my_dataset --root=/path/to/dataset --output-format=json
+```
+
+Estimate the Cartesian end-effector impact of the worst joint offset for a 30 cm arm:
+```shell
+lerobot-check-calibration --repo-id=user/my_dataset --arm-length-cm=30
+```
+"""
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+
+import numpy as np
+
+from lerobot.datasets.lerobot_dataset import LeRobotDataset
+from lerobot.utils.constants import ACTION, OBS_STATE
+from lerobot.utils.utils import init_logging
+
+VERDICT_OK = "ok"
+VERDICT_MILD = "mild_offset"
+VERDICT_SIGNIFICANT = "significant_offset"
+
+
+def compute_episode_deltas(
+    actions: np.ndarray, states: np.ndarray, vel_threshold: float
+) -> tuple[np.ndarray, np.ndarray]:
+    """Compute leader-follower deltas for one episode.
+
+    Args:
+        actions: Leader positions, shape (T, num_motors).
+        states: Follower positions, shape (T, num_motors).
+        vel_threshold: A frame is "stable" when every joint of the follower moved less than this amount
+            (in action units) since the previous frame.
+
+    Returns:
+        A tuple `(stable_deltas, all_deltas)` where `all_deltas` has shape (T-1, num_motors) (frame 0 is
+        skipped since it has no velocity estimate) and `stable_deltas` is the subset of rows from stable
+        frames, possibly empty.
+    """
+    if actions.shape != states.shape:
+        raise ValueError(f"actions {actions.shape} and states {states.shape} must have the same shape")
+    if len(actions) < 2:
+        empty = np.empty((0, actions.shape[1]) if actions.ndim == 2 else (0,))
+        return empty, empty
+
+    velocities = np.abs(np.diff(states, axis=0))  # (T-1, num_motors)
+    stable_mask = np.max(velocities, axis=1) < vel_threshold
+    all_deltas = actions[1:] - states[1:]
+    return all_deltas[stable_mask], all_deltas
+
+
+def summarize_calibration(
+    stable_deltas: np.ndarray,
+    all_deltas: np.ndarray,
+    motor_names: list[str],
+    ok_threshold: float = 1.0,
+    warn_threshold: float = 3.0,
+) -> list[dict]:
+    """Build a per-motor summary of calibration deltas.
+
+    Returns one dict per motor with keys `motor`, `mean_stable`, `std_stable`, `mean_all` and `verdict`
+    (one of "ok", "mild_offset", "significant_offset" based on `|mean_stable|`).
+    """
+    summary = []
+    for j, name in enumerate(motor_names):
+        mean_stable = float(np.mean(stable_deltas[:, j]))
+        abs_mean = abs(mean_stable)
+        if abs_mean < ok_threshold:
+            verdict = VERDICT_OK
+        elif abs_mean < warn_threshold:
+            verdict = VERDICT_MILD
+        else:
+            verdict = VERDICT_SIGNIFICANT
+        summary.append(
+            {
+                "motor": name,
+                "mean_stable": mean_stable,
+                "std_stable": float(np.std(stable_deltas[:, j])),
+                "mean_all": float(np.mean(all_deltas[:, j])),
+                "verdict": verdict,
+            }
+        )
+    return summary
+
+
+def group_pairs_by_episode(hf_dataset) -> dict[int, tuple[np.ndarray, np.ndarray]]:
+    """Group (actions, states) arrays by episode from a LeRobotDataset's underlying hf_dataset."""
+    columns = hf_dataset.select_columns(["episode_index", "frame_index", ACTION, OBS_STATE])
+    rows_by_ep: dict[int, list[tuple[int, np.ndarray, np.ndarray]]] = {}
+    for row in columns:
+        ep = int(row["episode_index"])
+        rows_by_ep.setdefault(ep, []).append(
+            (
+                int(row["frame_index"]),
+                np.asarray(row[ACTION], dtype=np.float64),
+                np.asarray(row[OBS_STATE], dtype=np.float64),
+            )
+        )
+    pairs_by_ep = {}
+    for ep, rows in rows_by_ep.items():
+        rows.sort(key=lambda r: r[0])
+        pairs_by_ep[ep] = (np.stack([r[1] for r in rows]), np.stack([r[2] for r in rows]))
+    return pairs_by_ep
+
+
+def check_calibration(
+    dataset: LeRobotDataset,
+    vel_threshold: float = 0.5,
+    ok_threshold: float = 1.0,
+    warn_threshold: float = 3.0,
+) -> dict:
+    """Run the calibration drift analysis on a dataset.
+
+    Returns a dict with aggregate counters and the per-motor summary (see `summarize_calibration`).
+    Raises ValueError if the dataset has no stable frames at the given velocity threshold.
+    """
+    if ACTION not in dataset.meta.features or OBS_STATE not in dataset.meta.features:
+        raise ValueError(
+            f"Dataset must contain both '{ACTION}' and '{OBS_STATE}' features to compare leader and "
+            f"follower positions. Found: {list(dataset.meta.features)}"
+        )
+
+    pairs_by_ep = group_pairs_by_episode(dataset.hf_dataset)
+
+    stable_chunks = []
+    all_chunks = []
+    for actions, states in pairs_by_ep.values():
+        stable, every = compute_episode_deltas(actions, states, vel_threshold)
+        stable_chunks.append(stable)
+        all_chunks.append(every)
+
+    stable_deltas = np.concatenate(stable_chunks) if stable_chunks else np.empty((0, 0))
+    all_deltas = np.concatenate(all_chunks) if all_chunks else np.empty((0, 0))
+
+    if len(stable_deltas) == 0:
+        raise ValueError(
+            f"No stable frames found at vel_threshold={vel_threshold}. The robot may never settle in this "
+            "dataset; try increasing --vel-threshold."
+        )
+
+    motor_names = dataset.meta.features[ACTION].get("names")
+    if not motor_names:
+        motor_names = [f"motor_{j}" for j in range(stable_deltas.shape[1])]
+
+    return {
+        "num_episodes": len(pairs_by_ep),
+        "num_frames": int(len(all_deltas)),
+        "num_stable_frames": int(len(stable_deltas)),
+        "vel_threshold": vel_threshold,
+        "motors": summarize_calibration(stable_deltas, all_deltas, motor_names, ok_threshold, warn_threshold),
+    }
+
+
+def print_table_report(repo_id: str, report: dict, arm_length_cm: float | None = None) -> None:
+    """Print a human-readable report of the calibration analysis."""
+    stable_pct = 100 * report["num_stable_frames"] / report["num_frames"]
+    print("\nLeader (action) vs follower (observation.state) calibration check")
+    print(f"  Dataset        : {repo_id}")
+    print(f"  Episodes       : {report['num_episodes']}")
+    print(f"  Frames         : {report['num_frames']}")
+    print(f"  Stable frames  : {report['num_stable_frames']} ({stable_pct:.1f}%)")
+    print(f"  Vel. threshold : {report['vel_threshold']} units/step\n")
+
+    print(f"{'Motor':20s} | {'mean Δ':>10s} | {'std Δ':>10s} | {'mean Δ all':>10s} | verdict")
+    print(f"{'-' * 20} | {'-' * 10} | {'-' * 10} | {'-' * 10} | {'-' * 20}")
+    for m in report["motors"]:
+        print(
+            f"{m['motor']:20s} | {m['mean_stable']:+10.3f} | {m['std_stable']:10.3f} "
+            f"| {m['mean_all']:+10.3f} | {m['verdict']}"
+        )
+
+    print()
+    print("Interpretation:")
+    print("  - mean Δ = action - observation.state on stable frames (follower converged)")
+    print("  - mean Δ ≈ 0: leader and follower are aligned on this motor")
+    print("  - |mean Δ| systematically above the ok-threshold: calibration offset between the arms")
+    print("  - Grippers typically show a high std (fast open/close); focus on the arm joints")
+
+    if arm_length_cm is not None:
+        worst_offset = max(abs(m["mean_stable"]) for m in report["motors"])
+        cartesian_cm = arm_length_cm * np.tan(np.radians(worst_offset))
+        print()
+        print(
+            f"  Worst-case Cartesian impact at the end effector: ~{cartesian_cm:.1f} cm "
+            f"(offset {worst_offset:.1f} deg on a {arm_length_cm:g} cm arm)"
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Detect leader/follower calibration drift in a recorded teleoperation dataset."
+    )
+    parser.add_argument(
+        "--repo-id",
+        type=str,
+        required=True,
+        help="Name of the Hugging Face repository containing a LeRobotDataset (e.g. `user/my_dataset`).",
+    )
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=None,
+        help="Root directory of a dataset stored locally. By default, the dataset is loaded from the "
+        "Hugging Face cache folder, or downloaded from the hub if available.",
+    )
+    parser.add_argument(
+        "--vel-threshold",
+        type=float,
+        default=0.5,
+        help="Max per-joint motion (in action units per step) for a frame to count as stable (default: 0.5).",
+    )
+    parser.add_argument(
+        "--ok-threshold",
+        type=float,
+        default=1.0,
+        help="|mean delta| below this value is reported as 'ok' (default: 1.0).",
+    )
+    parser.add_argument(
+        "--warn-threshold",
+        type=float,
+        default=3.0,
+        help="|mean delta| above this value is reported as 'significant_offset' (default: 3.0).",
+    )
+    parser.add_argument(
+        "--arm-length-cm",
+        type=float,
+        default=None,
+        help="Optional arm length in cm used to estimate the Cartesian impact of the worst joint offset "
+        "(assumes deltas are in degrees).",
+    )
+    parser.add_argument(
+        "--output-format",
+        type=str,
+        choices=["table", "json"],
+        default="table",
+        help="Print a human-readable table (default) or machine-readable JSON.",
+    )
+    args = parser.parse_args()
+
+    init_logging()
+    logging.info(f"Loading dataset: {args.repo_id}")
+    dataset = LeRobotDataset(args.repo_id, root=args.root)
+
+    try:
+        report = check_calibration(
+            dataset,
+            vel_threshold=args.vel_threshold,
+            ok_threshold=args.ok_threshold,
+            warn_threshold=args.warn_threshold,
+        )
+    except ValueError as e:
+        logging.error(str(e))
+        sys.exit(1)
+
+    if args.output_format == "json":
+        print(json.dumps({"repo_id": args.repo_id, **report}, indent=2))
+    else:
+        print_table_report(args.repo_id, report, arm_length_cm=args.arm_length_cm)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/lerobot/scripts/lerobot_dataset_quality.py
+++ b/src/lerobot/scripts/lerobot_dataset_quality.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Compute per-episode quality metrics for a LeRobotDataset and flag outlier episodes.
+
+For datasets with more than a handful of episodes, reviewing each one in `lerobot-dataset-viz` is
+impractical. This tool computes deterministic metrics from the recorded actions of every episode:
+
+- `n_frames` / `duration_s`: episode length
+- `median_jerk` / `p95_jerk`: trajectory smoothness (second derivative of the actions)
+- `max_velocity`: peak action-space velocity
+- `static_fraction`: fraction of near-motionless frames (hesitations, dead time)
+- `final_action`: last action of the episode (end-pose consistency across episodes)
+
+Episodes that are outliers on any metric (IQR rule) are flagged and ranked, producing a short list of
+candidates to inspect in `lerobot-dataset-viz` and optionally remove with `lerobot-edit-dataset`.
+
+Usage examples:
+
+Analyze a dataset from the Hugging Face hub (or local cache):
+```shell
+lerobot-dataset-quality --repo-id=user/my_dataset
+```
+
+Analyze a local dataset and emit machine-readable JSON:
+```shell
+lerobot-dataset-quality --repo-id=user/my_dataset --root=/path/to/dataset --output-format=json
+```
+
+Use a stricter outlier rule and list more episodes:
+```shell
+lerobot-dataset-quality --repo-id=user/my_dataset --k-iqr=1.0 --top-bad=20
+```
+"""
+
+import argparse
+import json
+import logging
+from collections import defaultdict
+from pathlib import Path
+
+import numpy as np
+
+from lerobot.datasets.lerobot_dataset import LeRobotDataset
+from lerobot.utils.constants import ACTION
+from lerobot.utils.utils import init_logging
+
+
+def group_actions_by_episode(hf_dataset) -> dict[int, np.ndarray]:
+    """Group action arrays by episode from a LeRobotDataset's underlying hf_dataset."""
+    columns = hf_dataset.select_columns(["episode_index", "frame_index", ACTION])
+    rows_by_ep: dict[int, list[tuple[int, np.ndarray]]] = {}
+    for row in columns:
+        ep = int(row["episode_index"])
+        rows_by_ep.setdefault(ep, []).append(
+            (int(row["frame_index"]), np.asarray(row[ACTION], dtype=np.float64))
+        )
+    actions_by_ep = {}
+    for ep, rows in rows_by_ep.items():
+        rows.sort(key=lambda r: r[0])
+        actions_by_ep[ep] = np.stack([r[1] for r in rows])
+    return actions_by_ep
+
+
+def compute_episode_metrics(actions: np.ndarray, episode_index: int, fps: float) -> dict:
+    """Compute deterministic quality metrics from one episode's actions array of shape (T, action_dim)."""
+    n_frames = len(actions)
+    metrics = {
+        "episode": episode_index,
+        "n_frames": int(n_frames),
+        "duration_s": round(n_frames / fps, 2),
+        "median_jerk": 0.0,
+        "p95_jerk": 0.0,
+        "max_velocity": 0.0,
+        "static_fraction": 0.0,
+        "final_action": actions[-1].tolist() if n_frames > 0 else [],
+    }
+    if n_frames < 3:
+        return metrics
+
+    velocities = np.diff(actions, axis=0)  # (T-1, action_dim)
+    jerk = np.diff(velocities, axis=0)  # (T-2, action_dim)
+
+    # Median is robust to isolated spikes from quick corrections; p95 captures those spikes instead.
+    jerk_magnitude = np.linalg.norm(jerk, axis=1)
+    metrics["median_jerk"] = round(float(np.median(jerk_magnitude)), 5)
+    metrics["p95_jerk"] = round(float(np.percentile(jerk_magnitude, 95)), 5)
+
+    velocity_magnitude = np.linalg.norm(velocities, axis=1)
+    metrics["max_velocity"] = round(float(np.max(velocity_magnitude)), 4)
+
+    # A frame is "static" when it moves less than 5% of the median active velocity.
+    active_vels = velocity_magnitude[velocity_magnitude > 1e-6]
+    if len(active_vels) > 0:
+        static_threshold = 0.05 * np.median(active_vels)
+        metrics["static_fraction"] = round(float(np.mean(velocity_magnitude < static_threshold)), 3)
+    else:
+        metrics["static_fraction"] = 1.0
+
+    return metrics
+
+
+def detect_outliers(metrics: list[dict], k_iqr: float = 1.5) -> dict[int, set[str]]:
+    """Flag episodes that are outliers on any metric using the IQR rule.
+
+    Returns a dict mapping episode index to the set of flags raised for it (e.g. "duration_high").
+    """
+    outliers: dict[int, set[str]] = defaultdict(set)
+
+    def iqr_outliers(values: list[float], episodes: list[int], name: str, direction: str = "both") -> None:
+        q1, q3 = np.percentile(values, [25, 75])
+        iqr = q3 - q1
+        lo, hi = q1 - k_iqr * iqr, q3 + k_iqr * iqr
+        for v, ep in zip(values, episodes, strict=True):
+            if direction in ("both", "high") and v > hi:
+                outliers[ep].add(f"{name}_high")
+            if direction in ("both", "low") and v < lo:
+                outliers[ep].add(f"{name}_low")
+
+    eps = [m["episode"] for m in metrics]
+    iqr_outliers([m["n_frames"] for m in metrics], eps, "duration")
+    iqr_outliers([m["median_jerk"] for m in metrics], eps, "jerk", "high")
+    iqr_outliers([m["p95_jerk"] for m in metrics], eps, "spike_jerk", "high")
+    iqr_outliers([m["max_velocity"] for m in metrics], eps, "max_vel", "high")
+    iqr_outliers([m["static_fraction"] for m in metrics], eps, "static", "high")
+
+    # End-pose consistency: distance of each episode's final action from the across-episode mean.
+    finals = [m["final_action"] for m in metrics if m["final_action"]]
+    final_eps = [m["episode"] for m in metrics if m["final_action"]]
+    if finals:
+        finals_arr = np.array(finals)
+        distances = np.linalg.norm(finals_arr - np.mean(finals_arr, axis=0), axis=1)
+        iqr_outliers(distances.tolist(), final_eps, "final_state", "high")
+
+    return dict(outliers)
+
+
+def evaluate_dataset_quality(dataset: LeRobotDataset, k_iqr: float = 1.5) -> dict:
+    """Run the full quality analysis: per-episode metrics plus IQR outlier flags."""
+    if ACTION not in dataset.meta.features:
+        raise ValueError(f"Dataset must contain an '{ACTION}' feature. Found: {list(dataset.meta.features)}")
+
+    actions_by_ep = group_actions_by_episode(dataset.hf_dataset)
+    metrics = [compute_episode_metrics(actions_by_ep[ep], ep, dataset.fps) for ep in sorted(actions_by_ep)]
+    outliers = detect_outliers(metrics, k_iqr=k_iqr)
+    return {"metrics": metrics, "outliers": {ep: sorted(flags) for ep, flags in outliers.items()}}
+
+
+def print_table_report(repo_id: str, report: dict, top_bad: int = 10) -> None:
+    """Print a human-readable summary of the quality analysis."""
+    metrics = report["metrics"]
+    outliers = report["outliers"]
+    n = len(metrics)
+
+    print(f"\nEpisode quality report — {repo_id} ({n} episodes)\n")
+
+    durations = [m["duration_s"] for m in metrics]
+    n_frames = [m["n_frames"] for m in metrics]
+    jerks = [m["median_jerk"] for m in metrics]
+    velocities = [m["max_velocity"] for m in metrics]
+    statics = [m["static_fraction"] for m in metrics]
+
+    print("Aggregate stats (mean ± std, min–max):")
+    print(
+        f"  Duration         : {np.mean(durations):.1f} ± {np.std(durations):.1f}s "
+        f"({np.min(durations):.1f}–{np.max(durations):.1f}s)"
+    )
+    print(
+        f"  Frames           : {np.mean(n_frames):.0f} ± {np.std(n_frames):.0f} "
+        f"({np.min(n_frames)}–{np.max(n_frames)})"
+    )
+    print(f"  Median jerk      : {np.mean(jerks):.4f} ± {np.std(jerks):.4f}")
+    print(f"  Max velocity     : {np.mean(velocities):.3f} ± {np.std(velocities):.3f}")
+    print(f"  Static fraction  : {np.mean(statics) * 100:.1f}% ± {np.std(statics) * 100:.1f}%")
+    print()
+
+    flag_counts: dict[str, int] = defaultdict(int)
+    for flags in outliers.values():
+        for flag in flags:
+            flag_counts[flag] += 1
+    print(f"Outlier flags ({len(outliers)} episodes flagged at least once):")
+    for flag, count in sorted(flag_counts.items(), key=lambda x: -x[1]):
+        print(f"  {flag:25s}: {count} episodes")
+    print()
+
+    ranked = sorted(outliers.items(), key=lambda x: -len(x[1]))[:top_bad]
+    if ranked:
+        print(f"Top {len(ranked)} worst episodes (most flags):")
+        print(f"  {'ep':>4} | {'#flags':>6} | flags")
+        print(f"  {'-' * 4} | {'-' * 6} | {'-' * 60}")
+        for ep, flags in ranked:
+            print(f"  {ep:>4} | {len(flags):>6} | {', '.join(flags)}")
+        print()
+
+        bad_eps = sorted(ep for ep, _ in ranked)
+        print("Suggested next step — review these in lerobot-dataset-viz, then optionally delete:")
+        print(f"  lerobot-dataset-viz --repo-id {repo_id} --episode-index {bad_eps[0]}")
+        print("  lerobot-edit-dataset \\")
+        print(f"    --repo_id {repo_id} \\")
+        print(f"    --new_repo_id {repo_id}_clean \\")
+        print("    --operation.type delete_episodes \\")
+        print(f'    --operation.episode_indices "{bad_eps}"')
+    else:
+        print("No outlier episodes flagged — dataset looks consistent.")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Compute per-episode quality metrics for a LeRobotDataset and flag outlier episodes."
+    )
+    parser.add_argument(
+        "--repo-id",
+        type=str,
+        required=True,
+        help="Name of the Hugging Face repository containing a LeRobotDataset (e.g. `user/my_dataset`).",
+    )
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=None,
+        help="Root directory of a dataset stored locally. By default, the dataset is loaded from the "
+        "Hugging Face cache folder, or downloaded from the hub if available.",
+    )
+    parser.add_argument(
+        "--top-bad",
+        type=int,
+        default=10,
+        help="How many of the worst episodes to list in the table report (default: 10).",
+    )
+    parser.add_argument(
+        "--k-iqr",
+        type=float,
+        default=1.5,
+        help="IQR multiplier for outlier detection; lower is stricter (default: 1.5).",
+    )
+    parser.add_argument(
+        "--output-format",
+        type=str,
+        choices=["table", "json"],
+        default="table",
+        help="Print a human-readable table (default) or machine-readable JSON.",
+    )
+    args = parser.parse_args()
+
+    init_logging()
+    logging.info(f"Loading dataset: {args.repo_id}")
+    dataset = LeRobotDataset(args.repo_id, root=args.root)
+
+    report = evaluate_dataset_quality(dataset, k_iqr=args.k_iqr)
+
+    if args.output_format == "json":
+        print(json.dumps({"repo_id": args.repo_id, **report}, indent=2))
+    else:
+        print_table_report(args.repo_id, report, top_bad=args.top_bad)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/scripts/test_check_calibration.py
+++ b/tests/scripts/test_check_calibration.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pytest
+
+from lerobot.scripts.lerobot_check_calibration import (
+    VERDICT_MILD,
+    VERDICT_OK,
+    VERDICT_SIGNIFICANT,
+    check_calibration,
+    compute_episode_deltas,
+    group_pairs_by_episode,
+    summarize_calibration,
+)
+from lerobot.utils.constants import ACTION, OBS_STATE
+
+
+def make_episode_with_offset(
+    offset: np.ndarray, n_moving: int = 20, n_stable: int = 30
+) -> tuple[np.ndarray, np.ndarray]:
+    """Build a (actions, states) pair: a fast ramp followed by a hold, with actions = states + offset."""
+    num_motors = len(offset)
+    ramp = np.linspace(0.0, 50.0, n_moving)[:, None] * np.ones(num_motors)
+    hold = np.full((n_stable, num_motors), 50.0)
+    states = np.concatenate([ramp, hold])
+    actions = states + offset
+    return actions, states
+
+
+class TestComputeEpisodeDeltas:
+    def test_constant_offset_recovered_on_stable_frames(self):
+        offset = np.array([2.0, -1.5, 0.0])
+        actions, states = make_episode_with_offset(offset)
+        stable, every = compute_episode_deltas(actions, states, vel_threshold=0.5)
+
+        assert len(every) == len(actions) - 1
+        assert len(stable) > 0
+        np.testing.assert_allclose(np.mean(stable, axis=0), offset, atol=1e-9)
+
+    def test_no_stable_frames_when_always_moving(self):
+        offset = np.zeros(3)
+        actions, states = make_episode_with_offset(offset, n_moving=50, n_stable=0)
+        stable, every = compute_episode_deltas(actions, states, vel_threshold=0.5)
+
+        assert len(stable) == 0
+        assert len(every) == 49
+
+    def test_short_episode_returns_empty(self):
+        actions = np.zeros((1, 3))
+        states = np.zeros((1, 3))
+        stable, every = compute_episode_deltas(actions, states, vel_threshold=0.5)
+
+        assert len(stable) == 0
+        assert len(every) == 0
+
+    def test_shape_mismatch_raises(self):
+        with pytest.raises(ValueError, match="same shape"):
+            compute_episode_deltas(np.zeros((10, 3)), np.zeros((10, 4)), vel_threshold=0.5)
+
+
+class TestSummarizeCalibration:
+    def test_verdicts(self):
+        offsets = np.array([0.5, 2.0, 5.0])
+        deltas = np.tile(offsets, (100, 1))
+        summary = summarize_calibration(deltas, deltas, ["a", "b", "c"])
+
+        assert [m["verdict"] for m in summary] == [VERDICT_OK, VERDICT_MILD, VERDICT_SIGNIFICANT]
+        assert [m["motor"] for m in summary] == ["a", "b", "c"]
+        np.testing.assert_allclose([m["mean_stable"] for m in summary], offsets)
+
+    def test_negative_offset_uses_absolute_value(self):
+        deltas = np.full((100, 1), -5.0)
+        summary = summarize_calibration(deltas, deltas, ["a"])
+        assert summary[0]["verdict"] == VERDICT_SIGNIFICANT
+        assert summary[0]["mean_stable"] == pytest.approx(-5.0)
+
+    def test_custom_thresholds(self):
+        deltas = np.full((10, 1), 2.0)
+        summary = summarize_calibration(deltas, deltas, ["a"], ok_threshold=2.5, warn_threshold=5.0)
+        assert summary[0]["verdict"] == VERDICT_OK
+
+
+class TestGroupPairsByEpisode:
+    def test_groups_and_sorts_by_frame_index(self):
+        datasets = pytest.importorskip("datasets", reason="datasets is required (install lerobot[dataset])")
+
+        hf_dataset = datasets.Dataset.from_dict(
+            {
+                "episode_index": [1, 0, 0, 1],
+                "frame_index": [1, 1, 0, 0],
+                ACTION: [[10.0], [1.0], [0.0], [9.0]],
+                OBS_STATE: [[10.5], [1.5], [0.5], [9.5]],
+            }
+        )
+        pairs = group_pairs_by_episode(hf_dataset)
+
+        assert set(pairs) == {0, 1}
+        actions_ep0, states_ep0 = pairs[0]
+        np.testing.assert_allclose(actions_ep0, [[0.0], [1.0]])
+        np.testing.assert_allclose(states_ep0, [[0.5], [1.5]])
+        actions_ep1, _ = pairs[1]
+        np.testing.assert_allclose(actions_ep1, [[9.0], [10.0]])
+
+
+class FakeMeta:
+    def __init__(self, features):
+        self.features = features
+
+
+class FakeDataset:
+    def __init__(self, hf_dataset, motor_names):
+        self.hf_dataset = hf_dataset
+        self.meta = FakeMeta(
+            {
+                ACTION: {"dtype": "float32", "shape": (len(motor_names),), "names": motor_names},
+                OBS_STATE: {"dtype": "float32", "shape": (len(motor_names),), "names": motor_names},
+            }
+        )
+
+
+def make_fake_dataset(offset: np.ndarray, motor_names: list[str], n_moving: int = 20, n_stable: int = 30):
+    datasets = pytest.importorskip("datasets", reason="datasets is required (install lerobot[dataset])")
+
+    actions, states = make_episode_with_offset(offset, n_moving=n_moving, n_stable=n_stable)
+    hf_dataset = datasets.Dataset.from_dict(
+        {
+            "episode_index": [0] * len(actions),
+            "frame_index": list(range(len(actions))),
+            ACTION: actions.tolist(),
+            OBS_STATE: states.tolist(),
+        }
+    )
+    return FakeDataset(hf_dataset, motor_names)
+
+
+class TestCheckCalibration:
+    def test_end_to_end_report(self):
+        offset = np.array([0.2, 4.0])
+        dataset = make_fake_dataset(offset, ["shoulder_pan", "elbow_flex"])
+        report = check_calibration(dataset, vel_threshold=0.5)
+
+        assert report["num_episodes"] == 1
+        assert report["num_stable_frames"] > 0
+        verdicts = {m["motor"]: m["verdict"] for m in report["motors"]}
+        assert verdicts == {"shoulder_pan": VERDICT_OK, "elbow_flex": VERDICT_SIGNIFICANT}
+
+    def test_missing_state_feature_raises(self):
+        dataset = make_fake_dataset(np.zeros(2), ["a", "b"])
+        del dataset.meta.features[OBS_STATE]
+        with pytest.raises(ValueError, match="must contain both"):
+            check_calibration(dataset)
+
+    def test_no_stable_frames_raises(self):
+        dataset = make_fake_dataset(np.zeros(2), ["a", "b"], n_moving=50, n_stable=0)
+        with pytest.raises(ValueError, match="No stable frames"):
+            check_calibration(dataset, vel_threshold=0.5)

--- a/tests/scripts/test_dataset_quality.py
+++ b/tests/scripts/test_dataset_quality.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pytest
+
+from lerobot.scripts.lerobot_dataset_quality import (
+    compute_episode_metrics,
+    detect_outliers,
+    evaluate_dataset_quality,
+    group_actions_by_episode,
+)
+from lerobot.utils.constants import ACTION
+
+FPS = 30
+
+
+def smooth_episode(n_frames: int = 90, num_motors: int = 3) -> np.ndarray:
+    """A smooth sinusoidal trajectory: low jerk, no static frames."""
+    t = np.linspace(0, np.pi, n_frames)[:, None]
+    return 10.0 * np.sin(t) * np.ones(num_motors)
+
+
+class TestComputeEpisodeMetrics:
+    def test_smooth_trajectory_has_low_jerk(self):
+        metrics = compute_episode_metrics(smooth_episode(), episode_index=0, fps=FPS)
+
+        assert metrics["episode"] == 0
+        assert metrics["n_frames"] == 90
+        assert metrics["duration_s"] == 3.0
+        assert metrics["median_jerk"] < 0.1
+        assert metrics["static_fraction"] < 0.2
+
+    def test_spike_increases_p95_jerk(self):
+        actions = smooth_episode(n_frames=40)
+        spiked = actions.copy()
+        spiked[20] += 20.0  # single sharp correction
+        smooth = compute_episode_metrics(actions, episode_index=0, fps=FPS)
+        jerky = compute_episode_metrics(spiked, episode_index=1, fps=FPS)
+
+        assert jerky["p95_jerk"] > smooth["p95_jerk"]
+        assert jerky["max_velocity"] > smooth["max_velocity"]
+
+    def test_hold_increases_static_fraction(self):
+        moving = smooth_episode(n_frames=45)
+        hold = np.tile(moving[-1], (45, 1))
+        with_hold = np.concatenate([moving, hold])
+        metrics = compute_episode_metrics(with_hold, episode_index=0, fps=FPS)
+
+        assert metrics["static_fraction"] > 0.4
+
+    def test_short_episode_returns_defaults(self):
+        actions = np.ones((2, 3))
+        metrics = compute_episode_metrics(actions, episode_index=5, fps=FPS)
+
+        assert metrics["episode"] == 5
+        assert metrics["n_frames"] == 2
+        assert metrics["median_jerk"] == 0.0
+        assert metrics["final_action"] == [1.0, 1.0, 1.0]
+
+    def test_final_action_is_last_action(self):
+        actions = smooth_episode()
+        metrics = compute_episode_metrics(actions, episode_index=0, fps=FPS)
+        np.testing.assert_allclose(metrics["final_action"], actions[-1])
+
+
+class TestDetectOutliers:
+    def make_uniform_metrics(self, n: int = 20) -> list[dict]:
+        return [compute_episode_metrics(smooth_episode(), episode_index=ep, fps=FPS) for ep in range(n)]
+
+    def test_uniform_dataset_has_no_outliers(self):
+        outliers = detect_outliers(self.make_uniform_metrics())
+        assert outliers == {}
+
+    def test_long_episode_flagged_as_duration_outlier(self):
+        metrics = self.make_uniform_metrics()
+        metrics.append(compute_episode_metrics(smooth_episode(n_frames=900), episode_index=99, fps=FPS))
+        outliers = detect_outliers(metrics)
+
+        assert 99 in outliers
+        assert "duration_high" in outliers[99]
+
+    def test_divergent_final_pose_flagged(self):
+        metrics = self.make_uniform_metrics()
+        divergent = smooth_episode()
+        divergent[-1] += 50.0
+        metrics.append(compute_episode_metrics(divergent, episode_index=99, fps=FPS))
+        outliers = detect_outliers(metrics)
+
+        assert "final_state_high" in outliers.get(99, set())
+
+
+class FakeMeta:
+    def __init__(self, num_motors):
+        self.features = {ACTION: {"dtype": "float32", "shape": (num_motors,), "names": None}}
+
+
+class FakeDataset:
+    def __init__(self, hf_dataset, num_motors, fps=FPS):
+        self.hf_dataset = hf_dataset
+        self.meta = FakeMeta(num_motors)
+        self.fps = fps
+
+
+def make_fake_dataset(episodes: dict[int, np.ndarray]):
+    datasets = pytest.importorskip("datasets", reason="datasets is required (install lerobot[dataset])")
+
+    episode_index, frame_index, actions = [], [], []
+    for ep, ep_actions in episodes.items():
+        episode_index += [ep] * len(ep_actions)
+        frame_index += list(range(len(ep_actions)))
+        actions += ep_actions.tolist()
+    hf_dataset = datasets.Dataset.from_dict(
+        {"episode_index": episode_index, "frame_index": frame_index, ACTION: actions}
+    )
+    num_motors = next(iter(episodes.values())).shape[1]
+    return FakeDataset(hf_dataset, num_motors)
+
+
+class TestGroupActionsByEpisode:
+    def test_groups_and_sorts_by_frame_index(self):
+        datasets = pytest.importorskip("datasets", reason="datasets is required (install lerobot[dataset])")
+
+        hf_dataset = datasets.Dataset.from_dict(
+            {
+                "episode_index": [1, 0, 0, 1],
+                "frame_index": [1, 1, 0, 0],
+                ACTION: [[10.0], [1.0], [0.0], [9.0]],
+            }
+        )
+        actions_by_ep = group_actions_by_episode(hf_dataset)
+
+        assert set(actions_by_ep) == {0, 1}
+        np.testing.assert_allclose(actions_by_ep[0], [[0.0], [1.0]])
+        np.testing.assert_allclose(actions_by_ep[1], [[9.0], [10.0]])
+
+
+class TestEvaluateDatasetQuality:
+    def test_end_to_end_flags_bad_episode(self):
+        episodes = {ep: smooth_episode() for ep in range(20)}
+        episodes[20] = smooth_episode(n_frames=900)  # 10x longer than the rest
+        dataset = make_fake_dataset(episodes)
+
+        report = evaluate_dataset_quality(dataset)
+
+        assert len(report["metrics"]) == 21
+        assert report["metrics"][0]["episode"] == 0
+        assert "duration_high" in report["outliers"][20]
+
+    def test_missing_action_feature_raises(self):
+        dataset = make_fake_dataset({0: smooth_episode()})
+        del dataset.meta.features[ACTION]
+        with pytest.raises(ValueError, match="must contain"):
+            evaluate_dataset_quality(dataset)


### PR DESCRIPTION
## Summary / Motivation

This PR adds two complementary, read-only dataset diagnostic CLIs that audit recorded teleoperation datasets *before* GPU hours are spent training on them:

1. **`lerobot-check-calibration`** — detects leader/follower calibration drift. In teleoperation, `action` is the leader position and `observation.state` is the follower position; a calibration mismatch between the arms bakes a systematic offset into every frame. This is invisible during training (the policy learns the biased mapping, loss looks healthy) but breaks deployment, since inference feeds follower observations to a policy trained on leader-shifted targets. The tool compares the two signals on "stable" frames (robot not moving, so the follower controller has converged) and reports per-motor mean/std with a verdict. Real-world motivation: on an SO-101 setup, a ~17° offset on one joint (≈6 cm Cartesian error at the gripper) went completely unnoticed through recording and training — this finds it in seconds.

2. **`lerobot-dataset-quality`** — flags outlier episodes. Once a dataset grows past a few dozen episodes, reviewing each one in `lerobot-dataset-viz` is impractical. The tool computes deterministic per-episode metrics from the actions (duration, median/p95 jerk, peak velocity, static fraction, end-pose consistency), flags statistical outliers via the IQR rule, and prints a ranked worst-episodes list with a ready-to-edit `lerobot-edit-dataset --operation.type delete_episodes` command — turning "watch 200 episodes" into "watch these 8".

Both tools load any dataset via the standard `LeRobotDataset` API, read only the action/state columns (no image/video decoding, runs in seconds), require no new dependencies, and never modify the dataset.

Submitted as one PR since they share the same shape (read-only diagnostics following the `lerobot-dataset-viz` CLI conventions) and documentation page; supersedes #3759 and #3761.

## Related issues

- Closes: #3758
- Closes: #3760

## What changed

- `src/lerobot/scripts/lerobot_check_calibration.py`: calibration drift analysis. Core logic in pure, importable functions (`compute_episode_deltas`, `summarize_calibration`, `check_calibration`) with a thin argparse `main()`. Flags: `--vel-threshold` (stability cutoff), `--ok-threshold`/`--warn-threshold` (verdict boundaries — configurable since action units are dataset-dependent), `--arm-length-cm` (optional Cartesian impact estimate), `--output-format table|json`.
- `src/lerobot/scripts/lerobot_dataset_quality.py`: per-episode quality metrics + IQR outlier flagging (`compute_episode_metrics`, `detect_outliers`, `evaluate_dataset_quality`). Flags: `--k-iqr` (outlier strictness), `--top-bad`, `--output-format table|json`.
- `pyproject.toml`: two new entry points, `lerobot-check-calibration` and `lerobot-dataset-quality`.
- `tests/scripts/test_check_calibration.py` + `tests/scripts/test_dataset_quality.py`: 22 unit tests on synthetic trajectories with known properties (known offsets, spikes, holds, divergent end poses), covering verdicts, outlier detection, episode grouping/sorting, and end-to-end reports including error paths.
- `docs/source/using_dataset_tools.mdx`: user-facing documentation sections for both tools.

No breaking changes; purely additive and read-only.

## How was this tested (or how to run locally)

- Tests added: `uv run pytest tests/scripts/test_check_calibration.py tests/scripts/test_dataset_quality.py -v` (22 passed)
- `pre-commit run` passes on all touched files (ruff, mypy, bandit, typos, prettier).
- Manually verified on real SO-101 teleop datasets:
  - calibration check correctly flags a known miscalibrated dataset (17° offset on `shoulder_lift`) and reports `ok` on a freshly recalibrated one;
  - quality flags matched episodes already identified as bad by manual review (over-long struggled attempts, wrong end poses).
- Quick reviewer repro: `lerobot-dataset-quality --repo-id lerobot/pusht` (any dataset with an `action` feature), `lerobot-check-calibration --repo-id <any teleop dataset with action + observation.state>`.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: # (pending)

## Reviewer notes

- The stability filter is the heart of the calibration method: on moving frames `action - state` is dominated by controller lag, so only converged frames are informative (`compute_episode_deltas`).
- The IQR rule was chosen over z-scores because episode metrics are typically skewed (a few very long episodes); it also flags nothing on a perfectly uniform dataset. `median_jerk` vs `p95_jerk` is deliberate: the median is robust to isolated corrective spikes, the p95 catches exactly those spikes.
- The two commits are kept separate (one per tool) for easier review; happy to squash, rename the commands, or split back into two PRs if maintainers prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
