### PR TITLE
feat(pi05): add native FSDP support via JointDecoderLayerPair

### DIFF
--- a/src/lerobot/common/train_utils.py
+++ b/src/lerobot/common/train_utils.py
@@ -72,6 +72,8 @@ def save_checkpoint(
     cfg: TrainPipelineConfig,
     policy: PreTrainedPolicy,
     optimizer: Optimizer,
+    model_state_dict: dict | None = None,
+    optim_state_dict: dict | None = None,
     scheduler: LRScheduler | None = None,
     preprocessor: PolicyProcessorPipeline | None = None,
     postprocessor: PolicyProcessorPipeline | None = None,
@@ -97,12 +99,24 @@ def save_checkpoint(
         step (int): The training step at that checkpoint.
         policy (PreTrainedPolicy): The policy to save.
         optimizer (Optimizer | None, optional): The optimizer to save the state from. Defaults to None.
+        model_state_dict: Pre-gathered model state dict (for FSDP where state_dict
+            requires a collective op across all ranks). If None, calls policy.save_pretrained().
+        optim_state_dict: Pre-gathered optimizer state dict (for FSDP). If None,
+            calls optimizer.state_dict() during save.
         scheduler (LRScheduler | None, optional): The scheduler to save the state from. Defaults to None.
         preprocessor: The preprocessor/pipeline to save. Defaults to None.
         postprocessor: The postprocessor/pipeline to save. Defaults to None.
     """
     pretrained_dir = checkpoint_dir / PRETRAINED_MODEL_DIR
-    policy.save_pretrained(pretrained_dir)
+    if model_state_dict is not None:
+        from huggingface_hub.constants import SAFETENSORS_SINGLE_FILE
+        from safetensors.torch import save_file
+
+        pretrained_dir.mkdir(parents=True, exist_ok=True)
+        policy.config._save_pretrained(pretrained_dir)
+        save_file(model_state_dict, str(pretrained_dir / SAFETENSORS_SINGLE_FILE))
+    else:
+        policy.save_pretrained(pretrained_dir)
     cfg.save_pretrained(pretrained_dir)
     if cfg.peft is not None:
         # When using PEFT, policy.save_pretrained will only write the adapter weights + config, not the
@@ -112,7 +126,7 @@ def save_checkpoint(
         preprocessor.save_pretrained(pretrained_dir)
     if postprocessor is not None:
         postprocessor.save_pretrained(pretrained_dir)
-    save_training_state(checkpoint_dir, step, optimizer, scheduler)
+    save_training_state(checkpoint_dir, step, optimizer, scheduler, optim_state_dict=optim_state_dict)
 
 
 def save_training_state(
@@ -120,6 +134,8 @@ def save_training_state(
     train_step: int,
     optimizer: Optimizer | None = None,
     scheduler: LRScheduler | None = None,
+    *,
+    optim_state_dict: dict | None = None,
 ) -> None:
     """
     Saves the training step, optimizer state, scheduler state, and rng state.
@@ -131,13 +147,15 @@ def save_training_state(
             Defaults to None.
         scheduler (LRScheduler | None, optional): The scheduler from which to save the state_dict.
             Defaults to None.
+        optim_state_dict: Pre-gathered optimizer state dict (for FSDP). If provided,
+            saves this directly instead of calling optimizer.state_dict().
     """
     save_dir = checkpoint_dir / TRAINING_STATE_DIR
     save_dir.mkdir(parents=True, exist_ok=True)
     save_training_step(train_step, save_dir)
     save_rng_state(save_dir)
     if optimizer is not None:
-        save_optimizer_state(optimizer, save_dir)
+        save_optimizer_state(optimizer, save_dir, optim_state_dict=optim_state_dict)
     if scheduler is not None:
         save_scheduler_state(scheduler, save_dir)
 

--- a/src/lerobot/optim/optimizers.py
+++ b/src/lerobot/optim/optimizers.py
@@ -281,13 +281,17 @@ class MultiAdamConfig(OptimizerConfig):
 
 
 def save_optimizer_state(
-    optimizer: torch.optim.Optimizer | dict[str, torch.optim.Optimizer], save_dir: Path
+    optimizer: torch.optim.Optimizer | dict[str, torch.optim.Optimizer],
+    save_dir: Path,
+    optim_state_dict: dict | None = None,
 ) -> None:
     """Save optimizer state to disk.
 
     Args:
         optimizer: Either a single optimizer or a dictionary of optimizers.
         save_dir: Directory to save the optimizer state.
+        optim_state_dict: Pre-gathered optimizer state dict (for FSDP). If provided,
+            saves this directly instead of calling optimizer.state_dict().
     """
     if isinstance(optimizer, dict):
         # Handle dictionary of optimizers
@@ -297,12 +301,14 @@ def save_optimizer_state(
             _save_single_optimizer_state(opt, optimizer_dir)
     else:
         # Handle single optimizer
-        _save_single_optimizer_state(optimizer, save_dir)
+        _save_single_optimizer_state(optimizer, save_dir, optim_state_dict=optim_state_dict)
 
 
-def _save_single_optimizer_state(optimizer: torch.optim.Optimizer, save_dir: Path) -> None:
+def _save_single_optimizer_state(
+    optimizer: torch.optim.Optimizer, save_dir: Path, optim_state_dict: dict | None = None
+) -> None:
     """Save a single optimizer's state to disk."""
-    state = optimizer.state_dict()
+    state = optim_state_dict.copy() if optim_state_dict is not None else optimizer.state_dict()
     param_groups = state.pop("param_groups")
     flat_state = flatten_dict(state)
     save_file(flat_state, save_dir / OPTIMIZER_STATE)

--- a/src/lerobot/policies/pi05/__init__.py
+++ b/src/lerobot/policies/pi05/__init__.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 from .configuration_pi05 import PI05Config
-from .modeling_pi05 import PI05Policy
+from .modeling_pi05 import JointDecoderLayerPair, PI05Policy
 from .processor_pi05 import make_pi05_pre_post_processors
 
-__all__ = ["PI05Config", "PI05Policy", "make_pi05_pre_post_processors"]
+__all__ = ["JointDecoderLayerPair", "PI05Config", "PI05Policy", "make_pi05_pre_post_processors"]

--- a/src/lerobot/policies/pi05/modeling_pi05.py
+++ b/src/lerobot/policies/pi05/modeling_pi05.py
@@ -233,6 +233,87 @@ def resize_with_pad_torch(  # see openpi `resize_with_pad_torch` (exact copy)
     return padded_images
 
 
+class JointDecoderLayerPair(nn.Module):
+    """Wraps a paired (PaliGemma, Expert) decoder layer for FSDP compatibility.
+
+    Pi0.5's compute_layer_complete() directly accesses weight matrices from both
+    models simultaneously without calling module.forward(). FSDP's all-gather hooks
+    require forward() to fire on the wrapping module. This class provides that
+    forward() boundary so FSDP can wrap each pair as a single sharding unit.
+    """
+
+    def __init__(self, paligemma_layer, expert_layer):
+        super().__init__()
+        self.paligemma_layer = paligemma_layer
+        self.expert_layer = expert_layer
+
+    def forward(self, inputs_embeds, attention_mask, position_ids, adarms_cond, rotary_emb):
+        return compute_layer_complete(
+            inputs_embeds,
+            attention_mask,
+            position_ids,
+            adarms_cond,
+            layers=(self.paligemma_layer, self.expert_layer),
+            rotary_emb=rotary_emb,
+        )
+
+
+class _JointLayerView(nn.Module):
+    """A non-owning view into JointDecoderLayerPair that exposes one side's layers.
+
+    Replaces the original nn.ModuleList on paligemma/expert so that:
+    - The HuggingFace inference forward (which iterates self.layers) still works
+    - Parameters are NOT double-registered (this module registers no children)
+    """
+
+    def __init__(self, joint_layers: nn.ModuleList, attr: str):
+        super().__init__()
+        # Store as plain Python attributes to avoid nn.Module registration
+        object.__setattr__(self, "_joint_layers", joint_layers)
+        object.__setattr__(self, "_attr", attr)
+
+    def __len__(self):
+        return len(self._joint_layers)
+
+    def __iter__(self):
+        for pair in self._joint_layers:
+            yield getattr(pair, self._attr)
+
+    def __getitem__(self, idx):
+        if isinstance(idx, slice):
+            return [getattr(self._joint_layers[i], self._attr) for i in range(*idx.indices(len(self)))]
+        return getattr(self._joint_layers[idx], self._attr)
+
+    def parameters(self, recurse=True, **kwargs):
+        # Return empty iterator; params are owned by joint_layers
+        return iter([])
+
+    def named_parameters(self, prefix="", recurse=True, **kwargs):
+        return iter([])
+
+    def named_modules(self, memo=None, prefix="", remove_duplicate=True):
+        # Only yield self, not the proxied layers (avoids double-counting)
+        if memo is None:
+            memo = set()
+        if self not in memo:
+            memo.add(self)
+            yield prefix, self
+
+    def __getstate__(self):
+        state = self.__dict__.copy()
+        state["_joint_layers"] = self._joint_layers
+        state["_attr"] = self._attr
+        return state
+
+    def __setstate__(self, state):
+        joint_layers = state.pop("_joint_layers")
+        attr = state.pop("_attr")
+        super().__init__()
+        object.__setattr__(self, "_joint_layers", joint_layers)
+        object.__setattr__(self, "_attr", attr)
+        self.__dict__.update(state)
+
+
 # Define the complete layer computation function for gradient checkpointing
 def compute_layer_complete(inputs_embeds, attention_mask, position_ids, adarms_cond, layers, rotary_emb):
     query_states = []
@@ -400,6 +481,8 @@ class PaliGemmaWithExpertModel(
         self.gemma_expert = PiGemmaForCausalLM(config=action_expert_config_hf)
         self.gemma_expert.model.embed_tokens = None
 
+        self._build_joint_layers()
+
         self.to_bfloat16_for_selected_params(precision)
         self._set_requires_grad()
 
@@ -457,6 +540,38 @@ class PaliGemmaWithExpertModel(
     def embed_language_tokens(self, tokens: torch.Tensor):
         return self.paligemma.model.language_model.get_input_embeddings()(tokens)
 
+    def _build_joint_layers(self):
+        """Build JointDecoderLayerPair list from PaliGemma and Expert layers.
+
+        Moves decoder layers into JointDecoderLayerPair wrappers. This gives FSDP
+        a proper module boundary (forward() hook point) for each paired layer
+        without changing the computation.
+
+        The original layer lists on paligemma and gemma_expert are replaced with
+        _JointLayerView instances that proxy into joint_layers, so the standard
+        HuggingFace inference path (prefix-only/suffix-only with KV cache) still
+        works through the existing PiGemmaModel.forward() code.
+        """
+        paligemma_layers = list(self.paligemma.model.language_model.layers)
+        expert_layers = list(self.gemma_expert.model.layers)
+
+        assert len(paligemma_layers) == len(expert_layers), (
+            f"Layer count mismatch: {len(paligemma_layers)} vs {len(expert_layers)}"
+        )
+
+        self.joint_layers = nn.ModuleList(
+            [JointDecoderLayerPair(p, e) for p, e in zip(paligemma_layers, expert_layers, strict=True)]
+        )
+        # Store as non-registered attribute to avoid duplicate module in the tree
+        # (the rotary_emb instance is already registered under paligemma)
+        object.__setattr__(self, "_rotary_emb", self.paligemma.model.language_model.rotary_emb)
+
+        # Replace original layer lists with views that proxy into joint_layers.
+        # This avoids double-registering params in the module tree while keeping
+        # the HuggingFace inference forward (which iterates self.layers) working.
+        self.paligemma.model.language_model.layers = _JointLayerView(self.joint_layers, "paligemma_layer")
+        self.gemma_expert.model.layers = _JointLayerView(self.joint_layers, "expert_layer")
+
     def forward(
         self,
         attention_mask: torch.Tensor | None = None,
@@ -493,10 +608,6 @@ class PaliGemmaWithExpertModel(
             prefix_output = None
             prefix_past_key_values = None
         else:
-            paligemma_layers = self.paligemma.model.language_model.layers
-            gemma_expert_layers = self.gemma_expert.model.layers
-            rotary_emb = self.paligemma.model.language_model.rotary_emb
-
             # Check if gradient checkpointing is enabled for any of the models
             use_gradient_checkpointing = (
                 hasattr(self.gemma_expert.model, "gradient_checkpointing")
@@ -504,28 +615,25 @@ class PaliGemmaWithExpertModel(
                 and self.training
             ) or (hasattr(self, "gradient_checkpointing") and self.gradient_checkpointing and self.training)
 
-            # Process all layers with gradient checkpointing if enabled
-            for layers in zip(paligemma_layers, gemma_expert_layers, strict=True):
+            for joint_layer in self.joint_layers:
                 if use_gradient_checkpointing:
                     inputs_embeds = torch.utils.checkpoint.checkpoint(
-                        compute_layer_complete,
+                        joint_layer,
                         inputs_embeds,
                         attention_mask,
                         position_ids,
                         adarms_cond,
+                        self._rotary_emb,
                         use_reentrant=False,
                         preserve_rng_state=False,
-                        layers=layers,
-                        rotary_emb=rotary_emb,
                     )
                 else:
-                    inputs_embeds = compute_layer_complete(
+                    inputs_embeds = joint_layer(
                         inputs_embeds,
                         attention_mask,
                         position_ids,
                         adarms_cond,
-                        layers=layers,
-                        rotary_emb=rotary_emb,
+                        self._rotary_emb,
                     )
 
             # final norm
@@ -749,7 +857,7 @@ class PI05Pytorch(nn.Module):  # see openpi `PI0Pytorch`
         suffix_embs, suffix_pad_masks, suffix_att_masks, adarms_cond = self.embed_suffix(x_t, time)
 
         if (
-            self.paligemma_with_expert.paligemma.model.language_model.layers[0].self_attn.q_proj.weight.dtype
+            self.paligemma_with_expert.joint_layers[0].paligemma_layer.self_attn.q_proj.weight.dtype
             == torch.bfloat16
         ):
             suffix_embs = suffix_embs.to(dtype=torch.bfloat16)
@@ -1068,6 +1176,24 @@ class PI05Policy(PreTrainedPolicy):
 
         for key, value in state_dict.items():
             new_key = key
+
+            # Remap layer keys to joint_layers structure
+            paligemma_layer_match = re.match(
+                r"paligemma_with_expert\.paligemma\.model\.language_model\.layers\.(\d+)\.(.*)",
+                key,
+            )
+            expert_layer_match = re.match(
+                r"paligemma_with_expert\.gemma_expert\.model\.layers\.(\d+)\.(.*)",
+                key,
+            )
+            if paligemma_layer_match:
+                idx = paligemma_layer_match.group(1)
+                rest = paligemma_layer_match.group(2)
+                new_key = f"paligemma_with_expert.joint_layers.{idx}.paligemma_layer.{rest}"
+            elif expert_layer_match:
+                idx = expert_layer_match.group(1)
+                rest = expert_layer_match.group(2)
+                new_key = f"paligemma_with_expert.joint_layers.{idx}.expert_layer.{rest}"
 
             # Handle layer norm structure changes: .weight -> .dense.weight + .dense.bias
             # For gemma expert layers

--- a/src/lerobot/scripts/lerobot_train.py
+++ b/src/lerobot/scripts/lerobot_train.py
@@ -501,6 +501,30 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
         if cfg.save_checkpoint and is_saving_step:
             if is_main_process:
                 logging.info(f"Checkpoint policy after step {step}")
+            # FSDP state_dict is a collective: all ranks must participate in
+            # the all-gather. We use FSDP.state_dict_type with FULL_STATE_DICT,
+            # rank0_only=True, offload_to_cpu=True so all ranks run the
+            # collective but only rank 0 materializes the full dicts.
+            from accelerate.utils import DistributedType
+
+            if accelerator.distributed_type == DistributedType.FSDP:
+                from torch.distributed.fsdp import (
+                    FullOptimStateDictConfig,
+                    FullStateDictConfig,
+                    FullyShardedDataParallel as FSDP,
+                    StateDictType,
+                )
+
+                fsdp_cfg = FullStateDictConfig(offload_to_cpu=True, rank0_only=True)
+                optim_cfg = FullOptimStateDictConfig(offload_to_cpu=True, rank0_only=True)
+                with FSDP.state_dict_type(policy, StateDictType.FULL_STATE_DICT, fsdp_cfg, optim_cfg):
+                    model_state_dict = policy.state_dict()
+                    optim_state_dict = FSDP.optim_state_dict(policy, optimizer)
+            else:
+                model_state_dict = None
+                optim_state_dict = None
+
+            if is_main_process:
                 checkpoint_dir = get_step_checkpoint_dir(cfg.output_dir, cfg.steps, step)
                 save_checkpoint(
                     checkpoint_dir=checkpoint_dir,
@@ -508,6 +532,8 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
                     cfg=cfg,
                     policy=accelerator.unwrap_model(policy),
                     optimizer=optimizer,
+                    model_state_dict=model_state_dict,
+                    optim_state_dict=optim_state_dict,
                     scheduler=lr_scheduler,
                     preprocessor=preprocessor,
                     postprocessor=postprocessor,

--- a/tests/policies/pi0_pi05/test_pi05_fsdp.py
+++ b/tests/policies/pi0_pi05/test_pi05_fsdp.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python
+
+# Copyright 2025 Physical Intelligence and The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for Pi0.5 FSDP compatibility (JointDecoderLayerPair wrapping)."""
+
+import re
+from functools import partial
+
+import pytest
+import torch
+from torch.distributed.fsdp.wrap import transformer_auto_wrap_policy
+
+pytest.importorskip("transformers")
+
+from lerobot.policies.pi05.configuration_pi05 import PI05Config  # noqa: E402
+from lerobot.policies.pi05.modeling_pi05 import (  # noqa: E402
+    JointDecoderLayerPair,
+    PI05Policy,
+    PI05Pytorch,
+    _JointLayerView,
+)
+
+
+@pytest.fixture
+def model():
+    config = PI05Config(dtype="float32")
+    return PI05Pytorch(config)
+
+
+class TestJointLayerStructure:
+    def test_joint_layers_created(self, model):
+        pwe = model.paligemma_with_expert
+        assert hasattr(pwe, "joint_layers")
+        assert len(pwe.joint_layers) == 18
+
+    def test_joint_layers_type(self, model):
+        pwe = model.paligemma_with_expert
+        for pair in pwe.joint_layers:
+            assert isinstance(pair, JointDecoderLayerPair)
+            assert hasattr(pair, "paligemma_layer")
+            assert hasattr(pair, "expert_layer")
+
+    def test_layer_views_proxy_correctly(self, model):
+        pwe = model.paligemma_with_expert
+        pali_layers = pwe.paligemma.model.language_model.layers
+        expert_layers = pwe.gemma_expert.model.layers
+
+        assert isinstance(pali_layers, _JointLayerView)
+        assert isinstance(expert_layers, _JointLayerView)
+        assert len(pali_layers) == 18
+        assert len(expert_layers) == 18
+
+        # Views should return the correct sub-layers
+        assert pali_layers[0] is pwe.joint_layers[0].paligemma_layer
+        assert expert_layers[0] is pwe.joint_layers[0].expert_layer
+
+    def test_no_duplicate_params(self, model):
+        param_ids = set()
+        duplicate_count = 0
+        for p in model.parameters():
+            if id(p) in param_ids:
+                duplicate_count += 1
+            param_ids.add(id(p))
+        assert duplicate_count == 0
+
+    def test_state_dict_keys_under_joint_layers(self, model):
+        sd = model.state_dict()
+        layer_keys = [k for k in sd if "joint_layers" in k]
+        old_keys = [k for k in sd if "language_model.layers." in k or "gemma_expert.model.layers." in k]
+        assert len(layer_keys) == 360  # 18 pairs x 20 params each
+        assert len(old_keys) == 0
+
+
+class TestFSDPWrapPolicy:
+    def test_auto_wrap_identifies_pairs(self, model):
+        # Verify the policy can be constructed (used by accelerate FSDP config)
+        _ = partial(
+            transformer_auto_wrap_policy,
+            transformer_layer_cls={JointDecoderLayerPair},
+        )
+        wrapped = [name for name, m in model.named_modules() if isinstance(m, JointDecoderLayerPair)]
+        assert len(wrapped) == 18
+        assert wrapped[0] == "paligemma_with_expert.joint_layers.0"
+        assert wrapped[-1] == "paligemma_with_expert.joint_layers.17"
+
+    def test_params_per_pair(self, model):
+        pair = model.paligemma_with_expert.joint_layers[0]
+        params = sum(p.numel() for p in pair.parameters())
+        # Each pair should have ~134M params (2B/18 + 300M/18)
+        assert params > 100_000_000
+        assert params < 300_000_000
+
+
+class TestForwardPass:
+    def test_training_forward(self, model):
+        model.eval()
+        batch_size = 1
+        loss = model(
+            images=[torch.randn(batch_size, 3, 224, 224)],
+            img_masks=[torch.ones(batch_size, dtype=torch.bool)],
+            tokens=torch.randint(0, 1000, (batch_size, 10)),
+            masks=torch.ones(batch_size, 10, dtype=torch.bool),
+            actions=torch.randn(batch_size, 50, 32),
+            noise=torch.randn(batch_size, 50, 32),
+            time=torch.rand(batch_size),
+        )
+        assert loss.shape == (1, 50, 32)
+
+    def test_inference_forward(self, model):
+        model.eval()
+        batch_size = 1
+        with torch.no_grad():
+            actions = model.sample_actions(
+                images=[torch.randn(batch_size, 3, 224, 224)],
+                img_masks=[torch.ones(batch_size, dtype=torch.bool)],
+                tokens=torch.randint(0, 1000, (batch_size, 10)),
+                masks=torch.ones(batch_size, 10, dtype=torch.bool),
+                num_steps=2,
+            )
+        assert actions.shape == (1, 50, 32)
+
+
+class TestCheckpointCompatibility:
+    def test_old_format_keys_remap(self, model):
+        """Verify that old-format checkpoint keys (pre-joint_layers) load correctly."""
+        config = PI05Config(dtype="float32")
+        sd = model.state_dict()
+
+        # Convert to old format
+        old_sd = {}
+        for key, value in sd.items():
+            new_key = key
+            m = re.match(r"paligemma_with_expert\.joint_layers\.(\d+)\.paligemma_layer\.(.*)", key)
+            if m:
+                new_key = (
+                    f"paligemma_with_expert.paligemma.model.language_model.layers.{m.group(1)}.{m.group(2)}"
+                )
+            m = re.match(r"paligemma_with_expert\.joint_layers\.(\d+)\.expert_layer\.(.*)", key)
+            if m:
+                new_key = f"paligemma_with_expert.gemma_expert.model.layers.{m.group(1)}.{m.group(2)}"
+            old_sd[new_key] = value
+
+        # Remap through the policy's key fixing logic
+        policy = PI05Policy(config)
+        fixed = policy._fix_pytorch_state_dict_keys(old_sd, config)
+
+        # Add model. prefix
+        remapped = {}
+        for key, value in fixed.items():
+            if not key.startswith("model."):
+                remapped[f"model.{key}"] = value
+            else:
+                remapped[key] = value
+
+        missing, unexpected = policy.load_state_dict(remapped, strict=True)
+        assert len(missing) == 0, f"Missing keys: {missing[:5]}"
+        assert len(unexpected) == 0, f"Unexpected keys: {unexpected[:5]}"


### PR DESCRIPTION
## Summary / Motivation

Pi0.5's forward pass calls `compute_layer_complete()` as a free function that directly accesses weight matrices from paired PaliGemma/Expert layers without calling `module.forward()`. FSDP relies on `forward()` hooks to trigger all-gather of sharded parameters, so weights remain sharded when accessed, producing dimension mismatches. There is currently no working PyTorch FSDP implementation for Pi0.5 in LeRobot, OpenPI, or the community (see #3562).

This PR adds `JointDecoderLayerPair(nn.Module)` which wraps each paired decoder layer and provides the `forward()` boundary FSDP needs. The 18 pairs (~134M params each) become natural FSDP sharding units via `transformer_auto_wrap_policy`. With FSDP FULL_SHARD, per-GPU memory drops from ~49 GB to much lesser (depending on extent of sharding), enabling full fine-tuning on more commonly available 40GB GPU clusters.

## Related issues

- Closes #3562
- Related: #2216 (GPU memory for pi05), #2154 (Multi-GPU DDP)

## What changed

- **`JointDecoderLayerPair(nn.Module)`**: Wraps each paired (PaliGemma layer_i, Expert layer_i) and delegates `forward()` to `compute_layer_complete()`. FSDP wraps each pair as one sharding unit.
- **`_JointLayerView(nn.Module)`**: Non-owning proxy that replaces the emptied original layer lists. The HuggingFace inference path (prefix-only/suffix-only with KV cache) still iterates `self.layers` unchanged.
- **`_build_joint_layers()`** on `PaliGemmaWithExpertModel`: Called in `__init__`, moves layers into `joint_layers` ModuleList, replaces originals with views.
- **Forward rewrite**: The training path (`else` branch in `PaliGemmaWithExpertModel.forward`) now iterates `self.joint_layers` calling `joint_layer(...)` instead of zipping separate lists and calling the free function directly.
- **State dict key remapping** in `_fix_pytorch_state_dict_keys`: Old checkpoint keys (`paligemma.model.language_model.layers.N...` / `gemma_expert.model.layers.N...`) remap to `joint_layers.N.paligemma_layer...` / `joint_layers.N.expert_layer...` for full backward compatibility.
- **No config changes required**: FSDP users just set `fsdp_transformer_layer_cls_to_wrap: "JointDecoderLayerPair"` in their accelerate config.

This is NOT a breaking change for DDP or single-GPU users. The model produces identical outputs; only the module tree structure changes.

## How was this tested (or how to run locally)

Tests added: `tests/policies/pi0_pi05/test_pi05_fsdp.py`

```bash
pytest -q tests/policies/pi0_pi05/test_pi05_fsdp.py
```

Covers:
- `TestJointLayerStructure`: 18 pairs created, view proxying, no param duplication, state_dict keys correct
- `TestFSDPWrapPolicy`: auto-wrap identifies 18 units, params per pair in expected range
- `TestForwardPass`: training forward (loss shape), inference forward (sample_actions with KV cache)
- `TestCheckpointCompatibility`: old-format keys remap and strict-load with 0 missing/unexpected

Manual validation (CPU, no FSDP runtime):
- Model instantiation: 4.14B params, no duplication
- Training forward pass: correct loss shape
- Inference with KV cache (sample_actions, num_steps=2): correct action shape
- FSDP wrap policy: 18 `JointDecoderLayerPair` modules found at expected paths
- Checkpoint round-trip: old-format state_dict -> key remap -> strict load succeeds
- `ruff check` passes clean

Additionally validated on a 10-node x 8 A100-40GB cluster (80 GPUs) using FSDP FULL_SHARD via accelerate, training for 14+ hours / 2500 steps with loss converging from 0.377 to 0.037.

## Checklist (required before merge)

- [x] Linting/formatting run (`ruff check` passes)
- [ ] All tests pass locally (`pytest`) - pi05 tests require CUDA + HF token; structural tests pass on CPU
- [ ] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: #

## Reviewer notes

- The `_JointLayerView` class is the most subtle piece: it must behave like an `nn.ModuleList` for iteration/indexing (HuggingFace's `PiGemmaModel.forward` iterates `self.layers[: self.config.num_hidden_layers]`) while NOT registering child modules (to avoid double-counting params). Worth careful review.
- The `rotary_emb` reference is stored via `object.__setattr__` to avoid duplicate module registration in the tree (the instance is already registered under `paligemma.model.language_model.rotary_emb`).
- Accelerate FSDP config example for users:
  ```yaml
  fsdp_config:
    fsdp_auto_wrap_policy: TRANSFORMER_BASED_WRAP
    fsdp_transformer_layer_cls_to_wrap: "JointDecoderLayerPair"
    fsdp_sharding_strategy: FULL_SHARD
    fsdp_state_dict_type: SHARDED_STATE_DICT
    fsdp_sync_module_states: true
    fsdp_use_orig_params: true
  ```