### PR TITLE
fix(train): synchronize EpisodeAwareSampler shuffling across ranks and gate dataset download per node

### DIFF
--- a/src/lerobot/datasets/sampler.py
+++ b/src/lerobot/datasets/sampler.py
@@ -30,6 +30,7 @@ class EpisodeAwareSampler:
         drop_n_first_frames: int = 0,
         drop_n_last_frames: int = 0,
         shuffle: bool = False,
+        generator: torch.Generator | None = None,
     ):
         """Sampler that optionally incorporates episode boundary information.
 
@@ -41,6 +42,10 @@ class EpisodeAwareSampler:
             drop_n_first_frames: Number of frames to drop from the start of each episode.
             drop_n_last_frames: Number of frames to drop from the end of each episode.
             shuffle: Whether to shuffle the indices.
+            generator: Generator used for shuffling. Exposing this attribute (even when None) lets
+                       `accelerate` register it as the synchronized RNG in distributed training, so
+                       every rank draws the same permutation and batch shards stay disjoint. When
+                       None, shuffling falls back to the global torch RNG.
         """
         if drop_n_first_frames < 0:
             raise ValueError(f"drop_n_first_frames must be >= 0, got {drop_n_first_frames}")
@@ -73,10 +78,11 @@ class EpisodeAwareSampler:
 
         self.indices = indices
         self.shuffle = shuffle
+        self.generator = generator
 
     def __iter__(self) -> Iterator[int]:
         if self.shuffle:
-            for i in torch.randperm(len(self.indices)):
+            for i in torch.randperm(len(self.indices), generator=self.generator):
                 yield self.indices[i]
         else:
             for i in self.indices:

--- a/src/lerobot/scripts/lerobot_train.py
+++ b/src/lerobot/scripts/lerobot_train.py
@@ -232,15 +232,18 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
         torch.backends.cudnn.benchmark = True
     torch.backends.cuda.matmul.allow_tf32 = True
 
-    # Dataset loading synchronization: main process downloads first to avoid race conditions
-    if is_main_process:
-        logging.info("Creating dataset")
+    # Dataset loading synchronization: each node's local main process downloads first to avoid
+    # race conditions (the global main process only exists on node 0, so gating on it would let
+    # all ranks of the other nodes download and build the Arrow cache concurrently).
+    if accelerator.is_local_main_process:
+        if is_main_process:
+            logging.info("Creating dataset")
         dataset = make_dataset(cfg)
 
     accelerator.wait_for_everyone()
 
-    # Now all other processes can safely load the dataset
-    if not is_main_process:
+    # Now all other processes can safely load the dataset from the local cache
+    if not accelerator.is_local_main_process:
         dataset = make_dataset(cfg)
 
     # Create environment used for evaluating checkpoints during training on simulation data.
@@ -386,12 +389,19 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
     # create dataloader for offline training
     if hasattr(active_cfg, "drop_n_last_frames"):
         shuffle = False
+        # A dedicated generator (rather than the global torch RNG) lets accelerator.prepare
+        # synchronize the shuffle permutation across ranks, keeping batch shards disjoint even
+        # when ranks consume the global RNG asymmetrically (e.g. eval on the main process only).
+        sampler_generator = torch.Generator()
+        if cfg.seed is not None:
+            sampler_generator.manual_seed(cfg.seed)
         sampler = EpisodeAwareSampler(
             dataset.meta.episodes["dataset_from_index"],
             dataset.meta.episodes["dataset_to_index"],
             episode_indices_to_use=dataset.episodes,
             drop_n_last_frames=active_cfg.drop_n_last_frames,
             shuffle=True,
+            generator=sampler_generator,
         )
     else:
         shuffle = True

--- a/tests/datasets/test_sampler.py
+++ b/tests/datasets/test_sampler.py
@@ -114,6 +114,30 @@ def test_shuffle():
     assert set(sampler) == {0, 1, 2, 3, 4, 5}
 
 
+def test_shuffle_with_generator_is_deterministic():
+    # Two samplers shuffling with same-seed generators must yield identical permutations.
+    # This is what keeps batch shards disjoint across ranks in distributed training, where
+    # accelerate synchronizes the sampler's generator state instead of the global torch RNG.
+    sampler_a = EpisodeAwareSampler([0], [6], shuffle=True, generator=torch.Generator().manual_seed(42))
+    sampler_b = EpisodeAwareSampler([0], [6], shuffle=True, generator=torch.Generator().manual_seed(42))
+    assert list(sampler_a) == list(sampler_b)
+
+    # Desyncing the global RNG must not affect the permutation.
+    sampler_c = EpisodeAwareSampler([0], [6], shuffle=True, generator=torch.Generator().manual_seed(42))
+    order_before = list(sampler_c)
+    sampler_c.generator.manual_seed(42)
+    torch.randperm(1000)  # consume global RNG, as rank-asymmetric code (e.g. eval) would
+    assert list(sampler_c) == order_before
+
+
+def test_generator_attribute_defaults_to_none():
+    # accelerate detects synchronizable samplers via `hasattr(sampler, "generator")`,
+    # so the attribute must exist even when no generator is passed.
+    sampler = EpisodeAwareSampler([0], [6], shuffle=True)
+    assert sampler.generator is None
+    assert set(sampler) == {0, 1, 2, 3, 4, 5}
+
+
 def test_negative_drop_first_frames_raises():
     with pytest.raises(ValueError, match="drop_n_first_frames must be >= 0"):
         EpisodeAwareSampler([0], [10], drop_n_first_frames=-1)


### PR DESCRIPTION
## Summary / Motivation

Two fixes for data-parallel correctness and multi-node scalability of the offline training dataloader. In distributed runs, `accelerator.prepare(dataloader)` shards batches across ranks with `BatchSamplerShard`, which assumes every rank generates the **same** shuffle permutation. `EpisodeAwareSampler` shuffled via the global torch RNG (`torch.randperm` with no `generator`), so accelerate could not synchronize it — disjoint shards relied on every rank's global CPU RNG staying in lockstep forever. Anything rank-asymmetric that consumes CPU RNG (e.g. eval rollouts run on `is_main_process` only) desyncs the permutations, and ranks silently start training on overlapping/duplicated samples with no error. Separately, the dataset download gate used `is_main_process` (global rank 0), which only exists on node 0: on every other node, all local ranks called `make_dataset` concurrently after the barrier and raced on `snapshot_download` + Arrow cache conversion.

## Related issues

- None

## What changed

- `EpisodeAwareSampler` accepts an optional `generator: torch.Generator | None` and uses it in `torch.randperm`. Exposing the attribute is the contract accelerate keys on (`hasattr(sampler, "generator")`, verified against accelerate 1.13.0): it registers the generator as the `synchronized_generator` and broadcasts its state from rank 0 at every epoch start, making shards disjoint by construction. Default `None` preserves the existing global-RNG behavior for single-process use.
- `lerobot_train.py` passes a generator seeded with `cfg.seed` to the sampler, so data order is also reproducible.
- The dataset-creation gate in `lerobot_train.py` now uses `accelerator.is_local_main_process` (one downloader per node, remaining local ranks load from the node-local cache) instead of `is_main_process`.
- No breaking changes. With a set seed, the exact shuffle order changes vs. previous releases (dedicated generator instead of global RNG), but remains deterministic.

## How was this tested (or how to run locally)

- Tests added in `tests/datasets/test_sampler.py`: `test_shuffle_with_generator_is_deterministic` (same-seed generators yield identical permutations; desyncing the global RNG no longer affects the order) and `test_generator_attribute_defaults_to_none` (the attribute accelerate detects exists by default). `uv run pytest -q tests/datasets/test_sampler.py` → 10 passed.
- Manual smoke test: 2-step diffusion training on `lerobot/pusht` (CPU) runs end-to-end through the `EpisodeAwareSampler` + seeded-generator path.
- Verified against installed accelerate 1.13.0 source that `prepare_data_loader` picks up `sampler.generator` as the synchronized RNG in the multi-process map-style path.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`) — all hooks pass on changed files; the repo-wide mypy hook reports 17 pre-existing errors in untouched camera/env files, identical on clean `main`
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated (n/a)
- [x] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: #

## Reviewer notes

- The generator sync matters only for multi-GPU/multi-node runs; single-process behavior is unchanged (modulo the deterministic shuffle order with a set seed).
- The `shuffle=True` branch (policies without `drop_n_last_frames`) was already safe: PyTorch's `RandomSampler` exposes `.generator`, which accelerate handles the same way.
