### PR TITLE
feat(datasets): deterministic, resumable shuffling for EpisodeAwareSampler 

### DIFF
--- a/src/lerobot/common/train_utils.py
+++ b/src/lerobot/common/train_utils.py
@@ -49,12 +49,18 @@ def get_step_checkpoint_dir(output_dir: Path, total_steps: int, step: int) -> Pa
     return output_dir / CHECKPOINTS_DIR / step_identifier
 
 
-def save_training_step(step: int, save_dir: Path, num_processes: int | None = None) -> None:
+def save_training_step(
+    step: int, save_dir: Path, num_processes: int | None = None, batch_size: int | None = None
+) -> None:
     state: dict = {"step": step}
+    # num_processes and batch_size are recorded so a resumed run can detect a changed world size or
+    # batch size: the sampler's resume offset is computed from the (num_processes, batch_size) that
+    # produced `step`, since both scale how many sampler positions a step consumes (see
+    # compute_sampler_state).
     if num_processes is not None:
-        # Recorded so a resumed run can detect a changed world size: the deterministic sampler's
-        # resume offset is computed from the world size that produced `step` (see compute_sampler_state).
         state["num_processes"] = num_processes
+    if batch_size is not None:
+        state["batch_size"] = batch_size
     write_json(state, save_dir / TRAINING_STEP)
 
 
@@ -66,6 +72,11 @@ def load_training_step(save_dir: Path) -> int:
 def load_training_num_processes(checkpoint_dir: Path) -> int | None:
     """World size recorded at checkpoint time, or None for checkpoints written before it was stored."""
     return load_json(checkpoint_dir / TRAINING_STATE_DIR / TRAINING_STEP).get("num_processes")
+
+
+def load_training_batch_size(checkpoint_dir: Path) -> int | None:
+    """Per-process batch size recorded at checkpoint time, or None for older checkpoints."""
+    return load_json(checkpoint_dir / TRAINING_STATE_DIR / TRAINING_STEP).get("batch_size")
 
 
 def update_last_checkpoint(checkpoint_dir: Path) -> Path:
@@ -86,6 +97,7 @@ def save_checkpoint(
     preprocessor: PolicyProcessorPipeline | None = None,
     postprocessor: PolicyProcessorPipeline | None = None,
     num_processes: int | None = None,
+    batch_size: int | None = None,
 ) -> None:
     """This function creates the following directory structure:
 
@@ -113,6 +125,8 @@ def save_checkpoint(
         postprocessor: The postprocessor/pipeline to save. Defaults to None.
         num_processes (int | None, optional): Distributed world size to record for sample-exact
             resume. Defaults to None (not recorded).
+        batch_size (int | None, optional): Per-process batch size to record for sample-exact
+            resume. Defaults to None (not recorded).
     """
     pretrained_dir = checkpoint_dir / PRETRAINED_MODEL_DIR
     policy.save_pretrained(pretrained_dir)
@@ -125,7 +139,9 @@ def save_checkpoint(
         preprocessor.save_pretrained(pretrained_dir)
     if postprocessor is not None:
         postprocessor.save_pretrained(pretrained_dir)
-    save_training_state(checkpoint_dir, step, optimizer, scheduler, num_processes=num_processes)
+    save_training_state(
+        checkpoint_dir, step, optimizer, scheduler, num_processes=num_processes, batch_size=batch_size
+    )
 
 
 def save_training_state(
@@ -134,6 +150,7 @@ def save_training_state(
     optimizer: Optimizer | None = None,
     scheduler: LRScheduler | None = None,
     num_processes: int | None = None,
+    batch_size: int | None = None,
 ) -> None:
     """
     Saves the training step, optimizer state, scheduler state, and rng state.
@@ -146,10 +163,11 @@ def save_training_state(
         scheduler (LRScheduler | None, optional): The scheduler from which to save the state_dict.
             Defaults to None.
         num_processes (int | None, optional): Distributed world size to record. Defaults to None.
+        batch_size (int | None, optional): Per-process batch size to record. Defaults to None.
     """
     save_dir = checkpoint_dir / TRAINING_STATE_DIR
     save_dir.mkdir(parents=True, exist_ok=True)
-    save_training_step(train_step, save_dir, num_processes=num_processes)
+    save_training_step(train_step, save_dir, num_processes=num_processes, batch_size=batch_size)
     save_rng_state(save_dir)
     if optimizer is not None:
         save_optimizer_state(optimizer, save_dir)

--- a/src/lerobot/common/train_utils.py
+++ b/src/lerobot/common/train_utils.py
@@ -49,13 +49,23 @@ def get_step_checkpoint_dir(output_dir: Path, total_steps: int, step: int) -> Pa
     return output_dir / CHECKPOINTS_DIR / step_identifier
 
 
-def save_training_step(step: int, save_dir: Path) -> None:
-    write_json({"step": step}, save_dir / TRAINING_STEP)
+def save_training_step(step: int, save_dir: Path, num_processes: int | None = None) -> None:
+    state: dict = {"step": step}
+    if num_processes is not None:
+        # Recorded so a resumed run can detect a changed world size: the deterministic sampler's
+        # resume offset is computed from the world size that produced `step` (see compute_sampler_state).
+        state["num_processes"] = num_processes
+    write_json(state, save_dir / TRAINING_STEP)
 
 
 def load_training_step(save_dir: Path) -> int:
     training_step = load_json(save_dir / TRAINING_STEP)
     return training_step["step"]
+
+
+def load_training_num_processes(checkpoint_dir: Path) -> int | None:
+    """World size recorded at checkpoint time, or None for checkpoints written before it was stored."""
+    return load_json(checkpoint_dir / TRAINING_STATE_DIR / TRAINING_STEP).get("num_processes")
 
 
 def update_last_checkpoint(checkpoint_dir: Path) -> Path:
@@ -75,6 +85,7 @@ def save_checkpoint(
     scheduler: LRScheduler | None = None,
     preprocessor: PolicyProcessorPipeline | None = None,
     postprocessor: PolicyProcessorPipeline | None = None,
+    num_processes: int | None = None,
 ) -> None:
     """This function creates the following directory structure:
 
@@ -100,6 +111,8 @@ def save_checkpoint(
         scheduler (LRScheduler | None, optional): The scheduler to save the state from. Defaults to None.
         preprocessor: The preprocessor/pipeline to save. Defaults to None.
         postprocessor: The postprocessor/pipeline to save. Defaults to None.
+        num_processes (int | None, optional): Distributed world size to record for sample-exact
+            resume. Defaults to None (not recorded).
     """
     pretrained_dir = checkpoint_dir / PRETRAINED_MODEL_DIR
     policy.save_pretrained(pretrained_dir)
@@ -112,7 +125,7 @@ def save_checkpoint(
         preprocessor.save_pretrained(pretrained_dir)
     if postprocessor is not None:
         postprocessor.save_pretrained(pretrained_dir)
-    save_training_state(checkpoint_dir, step, optimizer, scheduler)
+    save_training_state(checkpoint_dir, step, optimizer, scheduler, num_processes=num_processes)
 
 
 def save_training_state(
@@ -120,6 +133,7 @@ def save_training_state(
     train_step: int,
     optimizer: Optimizer | None = None,
     scheduler: LRScheduler | None = None,
+    num_processes: int | None = None,
 ) -> None:
     """
     Saves the training step, optimizer state, scheduler state, and rng state.
@@ -131,10 +145,11 @@ def save_training_state(
             Defaults to None.
         scheduler (LRScheduler | None, optional): The scheduler from which to save the state_dict.
             Defaults to None.
+        num_processes (int | None, optional): Distributed world size to record. Defaults to None.
     """
     save_dir = checkpoint_dir / TRAINING_STATE_DIR
     save_dir.mkdir(parents=True, exist_ok=True)
-    save_training_step(train_step, save_dir)
+    save_training_step(train_step, save_dir, num_processes=num_processes)
     save_rng_state(save_dir)
     if optimizer is not None:
         save_optimizer_state(optimizer, save_dir)

--- a/src/lerobot/configs/train.py
+++ b/src/lerobot/configs/train.py
@@ -99,12 +99,13 @@ class TrainPipelineConfig(HubMixin):
     batch_size: int = 8
     prefetch_factor: int = 4
     persistent_workers: bool = True
-    # Use a deterministic O(1)-memory sampler (seeded Feistel permutation) instead of materialized
+    # Use a deterministic O(1)-memory sampler (seeded Feistel permutation) instead of RNG-based
     # index shuffling. The data order becomes a pure function of (seed, epoch), which makes
     # distributed sharding immune to RNG desync, keeps sampler memory constant in dataset size,
     # and enables sample-exact resume of interrupted runs. The shuffle is pseudo-random rather
-    # than a true uniform permutation. Not compatible with dataset.streaming.
-    deterministic_sampler: bool = False
+    # than a true uniform permutation. Set to false to restore the legacy RNG-based shuffle
+    # order. Ignored when dataset.streaming is enabled.
+    deterministic_sampler: bool = True
     steps: int = 100_000
     eval_freq: int = 20_000
     log_freq: int = 200
@@ -139,12 +140,6 @@ class TrainPipelineConfig(HubMixin):
         return self.policy  # type: ignore[return-value]
 
     def validate(self) -> None:
-        if self.deterministic_sampler and self.dataset.streaming:
-            raise ValueError(
-                "deterministic_sampler requires a map-style dataset and is not compatible with "
-                "dataset.streaming=true."
-            )
-
         # HACK: We parse again the cli args here to get the pretrained paths if there was some.
         policy_path = parser.get_path_arg("policy")
         reward_model_path = parser.get_path_arg("reward_model")

--- a/src/lerobot/configs/train.py
+++ b/src/lerobot/configs/train.py
@@ -99,12 +99,9 @@ class TrainPipelineConfig(HubMixin):
     batch_size: int = 8
     prefetch_factor: int = 4
     persistent_workers: bool = True
-    # Use a deterministic O(1)-memory sampler (seeded Feistel permutation) instead of RNG-based
-    # index shuffling. The data order becomes a pure function of (seed, epoch), which makes
-    # distributed sharding immune to RNG desync, keeps sampler memory constant in dataset size,
-    # and enables sample-exact resume of interrupted runs. The shuffle is pseudo-random rather
-    # than a true uniform permutation. Set to false to restore the legacy RNG-based shuffle
-    # order. Ignored when dataset.streaming is enabled.
+    # Deterministic data order (pure function of seed and epoch): immune to cross-rank RNG
+    # desync and enables sample-exact resume. Set to false for the legacy RNG-based shuffle.
+    # Ignored when dataset.streaming is enabled.
     deterministic_sampler: bool = True
     steps: int = 100_000
     eval_freq: int = 20_000

--- a/src/lerobot/configs/train.py
+++ b/src/lerobot/configs/train.py
@@ -99,6 +99,12 @@ class TrainPipelineConfig(HubMixin):
     batch_size: int = 8
     prefetch_factor: int = 4
     persistent_workers: bool = True
+    # Use a deterministic O(1)-memory sampler (seeded Feistel permutation) instead of materialized
+    # index shuffling. The data order becomes a pure function of (seed, epoch), which makes
+    # distributed sharding immune to RNG desync, keeps sampler memory constant in dataset size,
+    # and enables sample-exact resume of interrupted runs. The shuffle is pseudo-random rather
+    # than a true uniform permutation. Not compatible with dataset.streaming.
+    deterministic_sampler: bool = False
     steps: int = 100_000
     eval_freq: int = 20_000
     log_freq: int = 200
@@ -133,6 +139,12 @@ class TrainPipelineConfig(HubMixin):
         return self.policy  # type: ignore[return-value]
 
     def validate(self) -> None:
+        if self.deterministic_sampler and self.dataset.streaming:
+            raise ValueError(
+                "deterministic_sampler requires a map-style dataset and is not compatible with "
+                "dataset.streaming=true."
+            )
+
         # HACK: We parse again the cli args here to get the pretrained paths if there was some.
         policy_path = parser.get_path_arg("policy")
         reward_model_path = parser.get_path_arg("reward_model")

--- a/src/lerobot/configs/train.py
+++ b/src/lerobot/configs/train.py
@@ -99,10 +99,6 @@ class TrainPipelineConfig(HubMixin):
     batch_size: int = 8
     prefetch_factor: int = 4
     persistent_workers: bool = True
-    # Deterministic data order (pure function of seed and epoch): immune to cross-rank RNG
-    # desync and enables sample-exact resume. Set to false for the legacy RNG-based shuffle.
-    # Ignored when dataset.streaming is enabled.
-    deterministic_sampler: bool = True
     steps: int = 100_000
     eval_freq: int = 20_000
     log_freq: int = 200

--- a/src/lerobot/datasets/__init__.py
+++ b/src/lerobot/datasets/__init__.py
@@ -50,7 +50,7 @@ from .lerobot_dataset import LeRobotDataset
 from .multi_dataset import MultiLeRobotDataset
 from .pipeline_features import aggregate_pipeline_dataset_features, create_initial_features
 from .pyav_utils import check_video_encoder_parameters_pyav, detect_available_encoders_pyav
-from .sampler import DeterministicEpisodeAwareSampler, EpisodeAwareSampler, compute_sampler_state
+from .sampler import EpisodeAwareSampler, compute_sampler_state
 from .streaming_dataset import StreamingLeRobotDataset
 from .utils import DEFAULT_EPISODES_PATH, create_lerobot_dataset_card
 from .video_utils import VideoEncodingManager
@@ -64,7 +64,6 @@ __all__ = [
     "DEFAULT_EPISODES_PATH",
     "DEFAULT_QUANTILES",
     "EVENT_ONLY_STYLES",
-    "DeterministicEpisodeAwareSampler",
     "EpisodeAwareSampler",
     "LANGUAGE_EVENTS",
     "LANGUAGE_PERSISTENT",

--- a/src/lerobot/datasets/__init__.py
+++ b/src/lerobot/datasets/__init__.py
@@ -50,7 +50,7 @@ from .lerobot_dataset import LeRobotDataset
 from .multi_dataset import MultiLeRobotDataset
 from .pipeline_features import aggregate_pipeline_dataset_features, create_initial_features
 from .pyav_utils import check_video_encoder_parameters_pyav, detect_available_encoders_pyav
-from .sampler import EpisodeAwareSampler
+from .sampler import DeterministicEpisodeAwareSampler, EpisodeAwareSampler, compute_sampler_state
 from .streaming_dataset import StreamingLeRobotDataset
 from .utils import DEFAULT_EPISODES_PATH, create_lerobot_dataset_card
 from .video_utils import VideoEncodingManager
@@ -64,6 +64,7 @@ __all__ = [
     "DEFAULT_EPISODES_PATH",
     "DEFAULT_QUANTILES",
     "EVENT_ONLY_STYLES",
+    "DeterministicEpisodeAwareSampler",
     "EpisodeAwareSampler",
     "LANGUAGE_EVENTS",
     "LANGUAGE_PERSISTENT",
@@ -82,6 +83,7 @@ __all__ = [
     "aggregate_stats",
     "convert_image_to_video_dataset",
     "create_initial_features",
+    "compute_sampler_state",
     "create_lerobot_dataset_card",
     "column_for_style",
     "delete_episodes",

--- a/src/lerobot/datasets/sampler.py
+++ b/src/lerobot/datasets/sampler.py
@@ -24,6 +24,9 @@ logger = logging.getLogger(__name__)
 
 _MASK_64 = (1 << 64) - 1
 _FEISTEL_ROUNDS = 4
+# Cycle-walking converges in <4 expected steps on the chosen domain; this bound is a generous
+# safety net that should never be hit in practice.
+_MAX_CYCLE_WALK_STEPS = 100
 
 
 def _mix64(x: int) -> int:
@@ -165,13 +168,17 @@ class EpisodeAwareSampler:
     def _permute(self, index: int, keys: list[int]) -> int:
         # Feistel network with cycle-walking: a bijection on [0, num_frames).
         half_bits, half_mask = self._half_bits, self._half_mask
-        while True:
+        for _ in range(_MAX_CYCLE_WALK_STEPS):
             left, right = index >> half_bits, index & half_mask
             for key in keys:
                 left, right = right, left ^ (_mix64(right ^ key) & half_mask)
             index = (left << half_bits) | right
             if index < self._num_frames:
                 return index
+        raise RuntimeError(
+            f"Feistel cycle-walking did not converge within {_MAX_CYCLE_WALK_STEPS} steps; "
+            "this should never happen for a valid domain."
+        )
 
     def _frame_index(self, position: int) -> int:
         episode = int(np.searchsorted(self._cum_lengths, position, side="right"))

--- a/src/lerobot/datasets/sampler.py
+++ b/src/lerobot/datasets/sampler.py
@@ -30,6 +30,7 @@ class EpisodeAwareSampler:
         drop_n_first_frames: int = 0,
         drop_n_last_frames: int = 0,
         shuffle: bool = False,
+        generator: torch.Generator | None = None,
     ):
         """Sampler that optionally incorporates episode boundary information.
 
@@ -41,6 +42,10 @@ class EpisodeAwareSampler:
             drop_n_first_frames: Number of frames to drop from the start of each episode.
             drop_n_last_frames: Number of frames to drop from the end of each episode.
             shuffle: Whether to shuffle the indices.
+            generator: Generator used for shuffling. Exposing this attribute (even when None) lets
+                       `accelerate` register it as the synchronized RNG in distributed training, so
+                       every rank draws the same permutation and batch shards stay disjoint. When
+                       None, shuffling falls back to the global torch RNG.
         """
         if drop_n_first_frames < 0:
             raise ValueError(f"drop_n_first_frames must be >= 0, got {drop_n_first_frames}")
@@ -73,10 +78,11 @@ class EpisodeAwareSampler:
 
         self.indices = indices
         self.shuffle = shuffle
+        self.generator = generator
 
     def __iter__(self) -> Iterator[int]:
         if self.shuffle:
-            for i in torch.randperm(len(self.indices)):
+            for i in torch.randperm(len(self.indices), generator=self.generator):
                 yield self.indices[i]
         else:
             for i in self.indices:

--- a/src/lerobot/datasets/sampler.py
+++ b/src/lerobot/datasets/sampler.py
@@ -35,6 +35,13 @@ class EpisodeAwareSampler:
     `load_state_dict` resume a run sample-exactly by regenerating the epoch's permutation and
     continuing from the saved offset. Each call to `__iter__` advances the epoch. During a
     resumed epoch, `__len__` still reports the full length.
+
+    Epoch advancement: `__iter__` eagerly advances the epoch, and `set_epoch` / `load_state_dict`
+    set it explicitly. Within a single run callers should rely on exactly one of these mechanisms,
+    not both: advancing the epoch by hand *and* letting `__iter__` auto-advance over the same
+    iterations would skip or repeat epochs. The training loop drives it purely through `__iter__`
+    (via `cycle`); `set_epoch` / `load_state_dict` are used only to (re)position before iteration
+    starts (e.g. on resume or in tests).
     """
 
     def __init__(
@@ -158,7 +165,7 @@ def compute_sampler_state(step: int, num_frames: int, batch_size: int, num_proce
     Assumptions (resume is only sample-exact when they hold):
         - `num_processes` and `batch_size` match the run that wrote the checkpoint. Both scale how
           many positions a step consumes, so the epoch/offset are wrong if either changed. The
-          caller passes the checkpoint's `num_processes` and warns on a mismatch.
+          caller passes the checkpoint's `num_processes` and `batch_size` and warns on a mismatch.
         - accelerate uses `even_batches=True` (its default). The `ceil(... / num_processes)` term
           mirrors that padding; with `even_batches=False` the per-epoch batch count differs and
           the boundary is off.

--- a/src/lerobot/datasets/sampler.py
+++ b/src/lerobot/datasets/sampler.py
@@ -29,15 +29,12 @@ class EpisodeAwareSampler:
     Logical positions map to frame indices on the fly (O(num_episodes) construction memory)
     instead of materializing a Python list of every frame index.
 
-    By default (`deterministic=True`) each epoch is shuffled with a `torch.randperm` seeded from
-    `(seed, epoch)`, so the data order is a pure function of `(seed, epoch)`: it reproduces on
-    every rank without synchronizing the global RNG, and `state_dict` / `load_state_dict` resume
-    a run sample-exactly by regenerating the epoch's permutation and continuing from the saved
-    offset. Each call to `__iter__` advances the epoch. During a resumed epoch, `__len__` still
-    reports the full length.
-
-    With `deterministic=False`, shuffling uses `torch.randperm` driven by `generator` instead
-    (accelerate synchronizes the generator across ranks when preparing the dataloader).
+    Each epoch is shuffled with a `torch.randperm` seeded from `(seed, epoch)`, so the data order
+    is a pure function of `(seed, epoch)`: it reproduces on every rank without synchronizing the
+    global RNG (no `generator` to sync across distributed ranks), and `state_dict` /
+    `load_state_dict` resume a run sample-exactly by regenerating the epoch's permutation and
+    continuing from the saved offset. Each call to `__iter__` advances the epoch. During a
+    resumed epoch, `__len__` still reports the full length.
     """
 
     def __init__(
@@ -48,8 +45,6 @@ class EpisodeAwareSampler:
         drop_n_first_frames: int = 0,
         drop_n_last_frames: int = 0,
         shuffle: bool = False,
-        generator: torch.Generator | None = None,
-        deterministic: bool = True,
         seed: int = 0,
     ):
         """
@@ -60,17 +55,12 @@ class EpisodeAwareSampler:
             drop_n_first_frames: Frames to drop from the start of each episode.
             drop_n_last_frames: Frames to drop from the end of each episode.
             shuffle: Whether to shuffle the indices.
-            generator: Generator for non-deterministic shuffling (global torch RNG when None).
-            deterministic: Seed the shuffle from `(seed, epoch)` for reproducible, resumable
-                order instead of a `generator`-driven `torch.randperm`.
-            seed: Seed the deterministic permutation is derived from (together with the epoch).
+            seed: Seed the permutation is derived from (together with the epoch).
         """
         if drop_n_first_frames < 0:
             raise ValueError(f"drop_n_first_frames must be >= 0, got {drop_n_first_frames}")
         if drop_n_last_frames < 0:
             raise ValueError(f"drop_n_last_frames must be >= 0, got {drop_n_last_frames}")
-        if deterministic and generator is not None:
-            raise ValueError("generator is unused in deterministic mode; pass seed instead.")
 
         from_indices = np.asarray(dataset_from_indices, dtype=np.int64)
         to_indices = np.asarray(dataset_to_indices, dtype=np.int64)
@@ -107,8 +97,6 @@ class EpisodeAwareSampler:
         self._cum_lengths = np.cumsum(lengths[used])
         self._num_frames = int(self._cum_lengths[-1])
         self.shuffle = shuffle
-        self.generator = generator
-        self.deterministic = deterministic
         self.seed = seed
         self._epoch = 0
         self._start_index = 0
@@ -119,21 +107,14 @@ class EpisodeAwareSampler:
         return [self._frame_index(k) for k in range(self._num_frames)]
 
     def set_epoch(self, epoch: int) -> None:
-        self._require_deterministic("set_epoch")
         self._epoch = epoch
 
     def state_dict(self) -> dict:
-        self._require_deterministic("state_dict")
         return {"epoch": self._epoch, "start_index": self._start_index}
 
     def load_state_dict(self, state: dict) -> None:
-        self._require_deterministic("load_state_dict")
         self._epoch = state["epoch"]
         self._start_index = state["start_index"]
-
-    def _require_deterministic(self, method: str) -> None:
-        if not self.deterministic:
-            raise RuntimeError(f"{method} requires deterministic=True: an RNG order cannot be sought.")
 
     def _epoch_generator(self, epoch: int) -> torch.Generator:
         # Derive a per-epoch seed from (seed, epoch) so the permutation is a pure function of both
@@ -147,23 +128,13 @@ class EpisodeAwareSampler:
         return int(self._starts[episode]) + position_in_episode
 
     def __iter__(self) -> Iterator[int]:
-        if not self.deterministic:
-            return self._iter_default()
         # Advance epoch state eagerly, not on first consumption of the generator.
         epoch, start = self._epoch, self._start_index
         self._epoch += 1
         self._start_index = 0
-        return self._iter_deterministic_epoch(epoch, start)
+        return self._iter_epoch(epoch, start)
 
-    def _iter_default(self) -> Iterator[int]:
-        if self.shuffle:
-            for i in torch.randperm(self._num_frames, generator=self.generator):
-                yield self._frame_index(int(i))
-        else:
-            for k in range(self._num_frames):
-                yield self._frame_index(k)
-
-    def _iter_deterministic_epoch(self, epoch: int, start: int) -> Iterator[int]:
+    def _iter_epoch(self, epoch: int, start: int) -> Iterator[int]:
         if self.shuffle:
             order = torch.randperm(self._num_frames, generator=self._epoch_generator(epoch))
             for k in range(start, self._num_frames):

--- a/src/lerobot/datasets/sampler.py
+++ b/src/lerobot/datasets/sampler.py
@@ -38,97 +38,27 @@ def _mix64(x: int) -> int:
 
 
 class EpisodeAwareSampler:
-    def __init__(
-        self,
-        dataset_from_indices: list[int],
-        dataset_to_indices: list[int],
-        episode_indices_to_use: list | None = None,
-        drop_n_first_frames: int = 0,
-        drop_n_last_frames: int = 0,
-        shuffle: bool = False,
-        generator: torch.Generator | None = None,
-    ):
-        """Sampler that optionally incorporates episode boundary information.
+    """Sampler that incorporates episode boundary information.
 
-        Args:
-            dataset_from_indices: List of indices containing the start of each episode in the dataset.
-            dataset_to_indices: List of indices containing the end of each episode in the dataset.
-            episode_indices_to_use: List of episode indices to use. If None, all episodes are used.
-                                    Assumes that episodes are indexed from 0 to N-1.
-            drop_n_first_frames: Number of frames to drop from the start of each episode.
-            drop_n_last_frames: Number of frames to drop from the end of each episode.
-            shuffle: Whether to shuffle the indices.
-            generator: Generator used for shuffling. Exposing this attribute (even when None) lets
-                       `accelerate` register it as the synchronized RNG in distributed training, so
-                       every rank draws the same permutation and batch shards stay disjoint. When
-                       None, shuffling falls back to the global torch RNG.
-        """
-        if drop_n_first_frames < 0:
-            raise ValueError(f"drop_n_first_frames must be >= 0, got {drop_n_first_frames}")
-        if drop_n_last_frames < 0:
-            raise ValueError(f"drop_n_last_frames must be >= 0, got {drop_n_last_frames}")
+    Frame indices are never materialized: only per-episode boundaries are stored (a few numpy
+    int64 per episode) and the mapping from a logical position to a frame index is computed on
+    the fly via `searchsorted`, so memory does not grow with the number of frames.
 
-        indices = []
-        for episode_idx, (start_index, end_index) in enumerate(
-            zip(dataset_from_indices, dataset_to_indices, strict=True)
-        ):
-            if episode_indices_to_use is None or episode_idx in episode_indices_to_use:
-                ep_length = end_index - start_index
-                if drop_n_first_frames + drop_n_last_frames >= ep_length:
-                    logger.warning(
-                        "Episode %d has %d frames but drop_n_first_frames=%d and "
-                        "drop_n_last_frames=%d removes all frames. Skipping.",
-                        episode_idx,
-                        ep_length,
-                        drop_n_first_frames,
-                        drop_n_last_frames,
-                    )
-                    continue
-                indices.extend(range(start_index + drop_n_first_frames, end_index - drop_n_last_frames))
+    Two shuffling modes are supported:
 
-        if not indices:
-            raise ValueError(
-                "No valid frames remain after applying drop_n_first_frames and drop_n_last_frames. "
-                "All episodes were either filtered out or had too few frames."
-            )
-
-        self.indices = indices
-        self.shuffle = shuffle
-        self.generator = generator
-
-    def __iter__(self) -> Iterator[int]:
-        if self.shuffle:
-            for i in torch.randperm(len(self.indices), generator=self.generator):
-                yield self.indices[i]
-        else:
-            for i in self.indices:
-                yield i
-
-    def __len__(self) -> int:
-        return len(self.indices)
-
-
-class DeterministicEpisodeAwareSampler:
-    """Episode-aware sampler with O(num_episodes) memory and a deterministic, seekable shuffle.
-
-    Unlike `EpisodeAwareSampler`, frame indices are never materialized: only per-episode
-    boundaries are stored (a few numpy int64 per episode) and the mapping from a logical
-    position to a frame index is computed on the fly via `searchsorted`. Shuffling applies a
-    seeded Feistel permutation over `[0, num_frames)` (cycle-walking to the exact domain size)
-    instead of `torch.randperm`, so the data order is a pure function of `(seed, epoch)`:
-
-    - every distributed rank derives the identical order with no RNG state to synchronize,
-    - any position can be sought in O(1), enabling sample-exact resume of interrupted runs
-      (see `state_dict` / `load_state_dict`),
-    - memory and epoch-boundary cost do not grow with the number of frames.
-
-    The trade-off is that the shuffle is pseudo-random rather than a true uniform permutation,
-    which is the standard compromise in large-scale training loaders.
-
-    Each completed `__iter__` advances the internal epoch, so consecutive dataloader passes
-    yield different permutations without requiring `set_epoch` calls. During an epoch resumed
-    via `load_state_dict`, `__len__` still reports the full epoch length; the first pass simply
-    yields fewer samples.
+    - Default (`deterministic=False`): `torch.randperm` over positions, optionally driven by a
+      dedicated `generator`. Exposing the `generator` attribute (even when None) lets
+      `accelerate` register it as the synchronized RNG in distributed training, so every rank
+      draws the same permutation and batch shards stay disjoint.
+    - `deterministic=True`: a seeded Feistel permutation over `[0, num_frames)` (cycle-walking
+      to the exact domain size). The data order becomes a pure function of `(seed, epoch)`:
+      nothing to synchronize across ranks, O(1) seek to any position (enabling sample-exact
+      resume via `state_dict` / `load_state_dict`), and zero epoch-boundary cost at any dataset
+      size. The shuffle is pseudo-random rather than a true uniform permutation — the standard
+      trade-off in large-scale training loaders. Each completed `__iter__` advances the internal
+      epoch, so consecutive dataloader passes yield different permutations without `set_epoch`
+      calls. During an epoch resumed via `load_state_dict`, `__len__` still reports the full
+      epoch length; the first pass simply yields fewer samples.
     """
 
     def __init__(
@@ -138,7 +68,9 @@ class DeterministicEpisodeAwareSampler:
         episode_indices_to_use: list | None = None,
         drop_n_first_frames: int = 0,
         drop_n_last_frames: int = 0,
-        shuffle: bool = True,
+        shuffle: bool = False,
+        generator: torch.Generator | None = None,
+        deterministic: bool = False,
         seed: int = 0,
     ):
         """
@@ -149,13 +81,18 @@ class DeterministicEpisodeAwareSampler:
                                     Assumes that episodes are indexed from 0 to N-1.
             drop_n_first_frames: Number of frames to drop from the start of each episode.
             drop_n_last_frames: Number of frames to drop from the end of each episode.
-            shuffle: Whether to shuffle with the seeded Feistel permutation.
-            seed: Seed the permutation is derived from (together with the epoch).
+            shuffle: Whether to shuffle the indices.
+            generator: Generator used for default-mode shuffling. When None, shuffling falls
+                       back to the global torch RNG. Incompatible with `deterministic=True`.
+            deterministic: Use the seeded Feistel permutation instead of `torch.randperm`.
+            seed: Seed the deterministic permutation is derived from (together with the epoch).
         """
         if drop_n_first_frames < 0:
             raise ValueError(f"drop_n_first_frames must be >= 0, got {drop_n_first_frames}")
         if drop_n_last_frames < 0:
             raise ValueError(f"drop_n_last_frames must be >= 0, got {drop_n_last_frames}")
+        if deterministic and generator is not None:
+            raise ValueError("generator is unused in deterministic mode; pass seed instead.")
 
         from_indices = np.asarray(dataset_from_indices, dtype=np.int64)
         to_indices = np.asarray(dataset_to_indices, dtype=np.int64)
@@ -192,6 +129,8 @@ class DeterministicEpisodeAwareSampler:
         self._cum_lengths = np.cumsum(lengths[used])
         self._num_frames = int(self._cum_lengths[-1])
         self.shuffle = shuffle
+        self.generator = generator
+        self.deterministic = deterministic
         self.seed = seed
         self._epoch = 0
         self._start_index = 0
@@ -202,16 +141,34 @@ class DeterministicEpisodeAwareSampler:
         self._half_bits = (bits + 1) // 2
         self._half_mask = (1 << self._half_bits) - 1
 
+    @property
+    def indices(self) -> list[int]:
+        """Materialized frame indices, in unshuffled order (back-compat / introspection only).
+
+        This builds an O(num_frames) list — avoid on very large datasets; iteration never uses it.
+        """
+        return [self._frame_index(k) for k in range(self._num_frames)]
+
     def set_epoch(self, epoch: int) -> None:
         """Set the epoch the next `__iter__` will use (DistributedSampler convention)."""
+        self._require_deterministic("set_epoch")
         self._epoch = epoch
 
     def state_dict(self) -> dict:
+        self._require_deterministic("state_dict")
         return {"epoch": self._epoch, "start_index": self._start_index}
 
     def load_state_dict(self, state: dict) -> None:
+        self._require_deterministic("load_state_dict")
         self._epoch = state["epoch"]
         self._start_index = state["start_index"]
+
+    def _require_deterministic(self, method: str) -> None:
+        if not self.deterministic:
+            raise RuntimeError(
+                f"{method} is only meaningful with deterministic=True: in default mode the "
+                "order is drawn from the (generator) RNG and cannot be sought."
+            )
 
     def _round_keys(self, epoch: int) -> list[int]:
         state = _mix64(_mix64(self.seed) ^ _mix64(epoch))
@@ -238,14 +195,24 @@ class DeterministicEpisodeAwareSampler:
         return int(self._starts[episode]) + position_in_episode
 
     def __iter__(self) -> Iterator[int]:
+        if not self.deterministic:
+            return self._iter_default()
         # Capture and advance state eagerly so epoch bookkeeping is not deferred until the
         # returned generator is first consumed.
         epoch, start = self._epoch, self._start_index
         self._epoch += 1
         self._start_index = 0
-        return self._iter_epoch(epoch, start)
+        return self._iter_deterministic_epoch(epoch, start)
 
-    def _iter_epoch(self, epoch: int, start: int) -> Iterator[int]:
+    def _iter_default(self) -> Iterator[int]:
+        if self.shuffle:
+            for i in torch.randperm(self._num_frames, generator=self.generator):
+                yield self._frame_index(int(i))
+        else:
+            for k in range(self._num_frames):
+                yield self._frame_index(k)
+
+    def _iter_deterministic_epoch(self, epoch: int, start: int) -> Iterator[int]:
         keys = self._round_keys(epoch) if self.shuffle else None
         for k in range(start, self._num_frames):
             yield self._frame_index(self._permute(k, keys) if self.shuffle else k)
@@ -255,7 +222,7 @@ class DeterministicEpisodeAwareSampler:
 
 
 def compute_sampler_state(step: int, num_frames: int, batch_size: int, num_processes: int) -> dict:
-    """Map a global optimization step to a `DeterministicEpisodeAwareSampler` state for resume.
+    """Map a global optimization step to an `EpisodeAwareSampler` state for resume.
 
     Under accelerate's batch-level sharding, every rank iterates the same underlying sampler and
     keeps every `num_processes`-th batch, so one optimization step consumes

--- a/src/lerobot/datasets/sampler.py
+++ b/src/lerobot/datasets/sampler.py
@@ -22,38 +22,21 @@ import torch
 
 logger = logging.getLogger(__name__)
 
-_MASK_64 = (1 << 64) - 1
-_FEISTEL_ROUNDS = 4
-# Cycle-walking converges in <4 expected steps on the chosen domain; this bound is a generous
-# safety net that should never be hit in practice.
-_MAX_CYCLE_WALK_STEPS = 100
-
-
-def _mix64(x: int) -> int:
-    """SplitMix64 finalizer (64-bit integer hash)."""
-    x = (x + 0x9E3779B97F4A7C15) & _MASK_64
-    x ^= x >> 30
-    x = (x * 0xBF58476D1CE4E5B9) & _MASK_64
-    x ^= x >> 27
-    x = (x * 0x94D049BB133111EB) & _MASK_64
-    x ^= x >> 31
-    return x
-
 
 class EpisodeAwareSampler:
-    """Sampler over episode frames with O(num_episodes) memory.
+    """Sampler over episode frames that stores only per-episode boundaries.
 
-    Only episode boundaries are stored; logical positions map to frame indices on the fly, so
-    memory does not grow with the number of frames.
+    Logical positions map to frame indices on the fly (O(num_episodes) construction memory)
+    instead of materializing a Python list of every frame index.
 
-    By default (`deterministic=True`) shuffling uses a seeded Feistel permutation over
-    `[0, num_frames)`: the data order is a pure function of `(seed, epoch)`, needs no RNG
-    synchronization across distributed ranks, and any position can be sought in O(1), enabling
-    sample-exact resume via `state_dict` / `load_state_dict`. Each completed `__iter__`
-    advances the epoch. The shuffle is pseudo-random rather than truly uniform — the standard
-    large-scale trade-off. During a resumed epoch, `__len__` still reports the full length.
+    By default (`deterministic=True`) each epoch is shuffled with a `torch.randperm` seeded from
+    `(seed, epoch)`, so the data order is a pure function of `(seed, epoch)`: it reproduces on
+    every rank without synchronizing the global RNG, and `state_dict` / `load_state_dict` resume
+    a run sample-exactly by regenerating the epoch's permutation and continuing from the saved
+    offset. Each call to `__iter__` advances the epoch. During a resumed epoch, `__len__` still
+    reports the full length.
 
-    With `deterministic=False`, shuffling falls back to `torch.randperm` driven by `generator`
+    With `deterministic=False`, shuffling uses `torch.randperm` driven by `generator` instead
     (accelerate synchronizes the generator across ranks when preparing the dataloader).
     """
 
@@ -78,7 +61,8 @@ class EpisodeAwareSampler:
             drop_n_last_frames: Frames to drop from the end of each episode.
             shuffle: Whether to shuffle the indices.
             generator: Generator for non-deterministic shuffling (global torch RNG when None).
-            deterministic: Use the seeded Feistel permutation instead of `torch.randperm`.
+            deterministic: Seed the shuffle from `(seed, epoch)` for reproducible, resumable
+                order instead of a `generator`-driven `torch.randperm`.
             seed: Seed the deterministic permutation is derived from (together with the epoch).
         """
         if drop_n_first_frames < 0:
@@ -129,12 +113,6 @@ class EpisodeAwareSampler:
         self._epoch = 0
         self._start_index = 0
 
-        # Smallest even-bit-width power-of-two domain >= num_frames: equal Feistel halves,
-        # cycle-walking converges in <4 expected steps.
-        bits = max((self._num_frames - 1).bit_length(), 2)
-        self._half_bits = (bits + 1) // 2
-        self._half_mask = (1 << self._half_bits) - 1
-
     @property
     def indices(self) -> list[int]:
         """Materialized frame indices in unshuffled order; O(num_frames), introspection only."""
@@ -157,28 +135,11 @@ class EpisodeAwareSampler:
         if not self.deterministic:
             raise RuntimeError(f"{method} requires deterministic=True: an RNG order cannot be sought.")
 
-    def _round_keys(self, epoch: int) -> list[int]:
-        state = _mix64(_mix64(self.seed) ^ _mix64(epoch))
-        keys = []
-        for _ in range(_FEISTEL_ROUNDS):
-            state = _mix64(state)
-            keys.append(state)
-        return keys
-
-    def _permute(self, index: int, keys: list[int]) -> int:
-        # Feistel network with cycle-walking: a bijection on [0, num_frames).
-        half_bits, half_mask = self._half_bits, self._half_mask
-        for _ in range(_MAX_CYCLE_WALK_STEPS):
-            left, right = index >> half_bits, index & half_mask
-            for key in keys:
-                left, right = right, left ^ (_mix64(right ^ key) & half_mask)
-            index = (left << half_bits) | right
-            if index < self._num_frames:
-                return index
-        raise RuntimeError(
-            f"Feistel cycle-walking did not converge within {_MAX_CYCLE_WALK_STEPS} steps; "
-            "this should never happen for a valid domain."
-        )
+    def _epoch_generator(self, epoch: int) -> torch.Generator:
+        # Derive a per-epoch seed from (seed, epoch) so the permutation is a pure function of both
+        # and reproduces identically on every rank without touching the global RNG.
+        epoch_seed = int(np.random.SeedSequence([self.seed, epoch]).generate_state(1, dtype=np.uint64)[0])
+        return torch.Generator().manual_seed(epoch_seed)
 
     def _frame_index(self, position: int) -> int:
         episode = int(np.searchsorted(self._cum_lengths, position, side="right"))
@@ -203,9 +164,13 @@ class EpisodeAwareSampler:
                 yield self._frame_index(k)
 
     def _iter_deterministic_epoch(self, epoch: int, start: int) -> Iterator[int]:
-        keys = self._round_keys(epoch) if self.shuffle else None
-        for k in range(start, self._num_frames):
-            yield self._frame_index(self._permute(k, keys) if self.shuffle else k)
+        if self.shuffle:
+            order = torch.randperm(self._num_frames, generator=self._epoch_generator(epoch))
+            for k in range(start, self._num_frames):
+                yield self._frame_index(int(order[k]))
+        else:
+            for k in range(start, self._num_frames):
+                yield self._frame_index(k)
 
     def __len__(self) -> int:
         return self._num_frames

--- a/src/lerobot/datasets/sampler.py
+++ b/src/lerobot/datasets/sampler.py
@@ -27,7 +27,7 @@ _FEISTEL_ROUNDS = 4
 
 
 def _mix64(x: int) -> int:
-    """SplitMix64 finalizer: a high-quality, cheap 64-bit integer hash."""
+    """SplitMix64 finalizer (64-bit integer hash)."""
     x = (x + 0x9E3779B97F4A7C15) & _MASK_64
     x ^= x >> 30
     x = (x * 0xBF58476D1CE4E5B9) & _MASK_64
@@ -38,27 +38,20 @@ def _mix64(x: int) -> int:
 
 
 class EpisodeAwareSampler:
-    """Sampler that incorporates episode boundary information.
+    """Sampler over episode frames with O(num_episodes) memory.
 
-    Frame indices are never materialized: only per-episode boundaries are stored (a few numpy
-    int64 per episode) and the mapping from a logical position to a frame index is computed on
-    the fly via `searchsorted`, so memory does not grow with the number of frames.
+    Only episode boundaries are stored; logical positions map to frame indices on the fly, so
+    memory does not grow with the number of frames.
 
-    Two shuffling modes are supported:
+    By default (`deterministic=True`) shuffling uses a seeded Feistel permutation over
+    `[0, num_frames)`: the data order is a pure function of `(seed, epoch)`, needs no RNG
+    synchronization across distributed ranks, and any position can be sought in O(1), enabling
+    sample-exact resume via `state_dict` / `load_state_dict`. Each completed `__iter__`
+    advances the epoch. The shuffle is pseudo-random rather than truly uniform — the standard
+    large-scale trade-off. During a resumed epoch, `__len__` still reports the full length.
 
-    - Default (`deterministic=False`): `torch.randperm` over positions, optionally driven by a
-      dedicated `generator`. Exposing the `generator` attribute (even when None) lets
-      `accelerate` register it as the synchronized RNG in distributed training, so every rank
-      draws the same permutation and batch shards stay disjoint.
-    - `deterministic=True`: a seeded Feistel permutation over `[0, num_frames)` (cycle-walking
-      to the exact domain size). The data order becomes a pure function of `(seed, epoch)`:
-      nothing to synchronize across ranks, O(1) seek to any position (enabling sample-exact
-      resume via `state_dict` / `load_state_dict`), and zero epoch-boundary cost at any dataset
-      size. The shuffle is pseudo-random rather than a true uniform permutation — the standard
-      trade-off in large-scale training loaders. Each completed `__iter__` advances the internal
-      epoch, so consecutive dataloader passes yield different permutations without `set_epoch`
-      calls. During an epoch resumed via `load_state_dict`, `__len__` still reports the full
-      epoch length; the first pass simply yields fewer samples.
+    With `deterministic=False`, shuffling falls back to `torch.randperm` driven by `generator`
+    (accelerate synchronizes the generator across ranks when preparing the dataloader).
     """
 
     def __init__(
@@ -70,20 +63,18 @@ class EpisodeAwareSampler:
         drop_n_last_frames: int = 0,
         shuffle: bool = False,
         generator: torch.Generator | None = None,
-        deterministic: bool = False,
+        deterministic: bool = True,
         seed: int = 0,
     ):
         """
         Args:
-            dataset_from_indices: List of indices containing the start of each episode in the dataset.
-            dataset_to_indices: List of indices containing the end of each episode in the dataset.
-            episode_indices_to_use: List of episode indices to use. If None, all episodes are used.
-                                    Assumes that episodes are indexed from 0 to N-1.
-            drop_n_first_frames: Number of frames to drop from the start of each episode.
-            drop_n_last_frames: Number of frames to drop from the end of each episode.
+            dataset_from_indices: Start index of each episode in the dataset.
+            dataset_to_indices: End index of each episode in the dataset.
+            episode_indices_to_use: Episode indices to use; None means all.
+            drop_n_first_frames: Frames to drop from the start of each episode.
+            drop_n_last_frames: Frames to drop from the end of each episode.
             shuffle: Whether to shuffle the indices.
-            generator: Generator used for default-mode shuffling. When None, shuffling falls
-                       back to the global torch RNG. Incompatible with `deterministic=True`.
+            generator: Generator for non-deterministic shuffling (global torch RNG when None).
             deterministic: Use the seeded Feistel permutation instead of `torch.randperm`.
             seed: Seed the deterministic permutation is derived from (together with the epoch).
         """
@@ -135,22 +126,18 @@ class EpisodeAwareSampler:
         self._epoch = 0
         self._start_index = 0
 
-        # Feistel cipher domain: the smallest even-bit-width power of two >= num_frames,
-        # so both halves have equal width and cycle-walking converges in <4 expected steps.
+        # Smallest even-bit-width power-of-two domain >= num_frames: equal Feistel halves,
+        # cycle-walking converges in <4 expected steps.
         bits = max((self._num_frames - 1).bit_length(), 2)
         self._half_bits = (bits + 1) // 2
         self._half_mask = (1 << self._half_bits) - 1
 
     @property
     def indices(self) -> list[int]:
-        """Materialized frame indices, in unshuffled order (back-compat / introspection only).
-
-        This builds an O(num_frames) list — avoid on very large datasets; iteration never uses it.
-        """
+        """Materialized frame indices in unshuffled order; O(num_frames), introspection only."""
         return [self._frame_index(k) for k in range(self._num_frames)]
 
     def set_epoch(self, epoch: int) -> None:
-        """Set the epoch the next `__iter__` will use (DistributedSampler convention)."""
         self._require_deterministic("set_epoch")
         self._epoch = epoch
 
@@ -165,10 +152,7 @@ class EpisodeAwareSampler:
 
     def _require_deterministic(self, method: str) -> None:
         if not self.deterministic:
-            raise RuntimeError(
-                f"{method} is only meaningful with deterministic=True: in default mode the "
-                "order is drawn from the (generator) RNG and cannot be sought."
-            )
+            raise RuntimeError(f"{method} requires deterministic=True: an RNG order cannot be sought.")
 
     def _round_keys(self, epoch: int) -> list[int]:
         state = _mix64(_mix64(self.seed) ^ _mix64(epoch))
@@ -197,8 +181,7 @@ class EpisodeAwareSampler:
     def __iter__(self) -> Iterator[int]:
         if not self.deterministic:
             return self._iter_default()
-        # Capture and advance state eagerly so epoch bookkeeping is not deferred until the
-        # returned generator is first consumed.
+        # Advance epoch state eagerly, not on first consumption of the generator.
         epoch, start = self._epoch, self._start_index
         self._epoch += 1
         self._start_index = 0
@@ -222,17 +205,12 @@ class EpisodeAwareSampler:
 
 
 def compute_sampler_state(step: int, num_frames: int, batch_size: int, num_processes: int) -> dict:
-    """Map a global optimization step to an `EpisodeAwareSampler` state for resume.
+    """Map an optimization step to an `EpisodeAwareSampler` state for sample-exact resume.
 
-    Under accelerate's batch-level sharding, every rank iterates the same underlying sampler and
-    keeps every `num_processes`-th batch, so one optimization step consumes
-    `batch_size * num_processes` consecutive sampler positions, and (with `even_batches` padding)
-    each rank sees `ceil(ceil(num_frames / batch_size) / num_processes)` batches per epoch.
-
-    `batches_into_epoch * num_processes <= ceil(num_frames / batch_size) - 1` always holds, so the
-    start index stays strictly below `num_frames`; the `min` is purely defensive. Resume is
-    sample-exact up to the `even_batches` padding accelerate appends at epoch boundaries (at most
-    `num_processes - 1` duplicated batches per epoch, the same duplication non-resumed runs get).
+    Under accelerate's batch sharding, one step consumes `batch_size * num_processes` sampler
+    positions and each rank sees `ceil(ceil(num_frames / batch_size) / num_processes)` batches
+    per epoch (`even_batches` padding included). The start index provably stays below
+    `num_frames`; the `min` is defensive.
     """
     batches_per_epoch = math.ceil(math.ceil(num_frames / batch_size) / num_processes)
     epoch, batches_into_epoch = divmod(step, batches_per_epoch)

--- a/src/lerobot/datasets/sampler.py
+++ b/src/lerobot/datasets/sampler.py
@@ -218,6 +218,14 @@ def compute_sampler_state(step: int, num_frames: int, batch_size: int, num_proce
     positions and each rank sees `ceil(ceil(num_frames / batch_size) / num_processes)` batches
     per epoch (`even_batches` padding included). The start index provably stays below
     `num_frames`; the `min` is defensive.
+
+    Assumptions (resume is only sample-exact when they hold):
+        - `num_processes` and `batch_size` match the run that wrote the checkpoint. Both scale how
+          many positions a step consumes, so the epoch/offset are wrong if either changed. The
+          caller passes the checkpoint's `num_processes` and warns on a mismatch.
+        - accelerate uses `even_batches=True` (its default). The `ceil(... / num_processes)` term
+          mirrors that padding; with `even_batches=False` the per-epoch batch count differs and
+          the boundary is off.
     """
     batches_per_epoch = math.ceil(math.ceil(num_frames / batch_size) / num_processes)
     epoch, batches_into_epoch = divmod(step, batches_per_epoch)

--- a/src/lerobot/datasets/sampler.py
+++ b/src/lerobot/datasets/sampler.py
@@ -14,11 +14,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
+import math
 from collections.abc import Iterator
 
+import numpy as np
 import torch
 
 logger = logging.getLogger(__name__)
+
+_MASK_64 = (1 << 64) - 1
+_FEISTEL_ROUNDS = 4
+
+
+def _mix64(x: int) -> int:
+    """SplitMix64 finalizer: a high-quality, cheap 64-bit integer hash."""
+    x = (x + 0x9E3779B97F4A7C15) & _MASK_64
+    x ^= x >> 30
+    x = (x * 0xBF58476D1CE4E5B9) & _MASK_64
+    x ^= x >> 27
+    x = (x * 0x94D049BB133111EB) & _MASK_64
+    x ^= x >> 31
+    return x
 
 
 class EpisodeAwareSampler:
@@ -90,3 +106,168 @@ class EpisodeAwareSampler:
 
     def __len__(self) -> int:
         return len(self.indices)
+
+
+class DeterministicEpisodeAwareSampler:
+    """Episode-aware sampler with O(num_episodes) memory and a deterministic, seekable shuffle.
+
+    Unlike `EpisodeAwareSampler`, frame indices are never materialized: only per-episode
+    boundaries are stored (a few numpy int64 per episode) and the mapping from a logical
+    position to a frame index is computed on the fly via `searchsorted`. Shuffling applies a
+    seeded Feistel permutation over `[0, num_frames)` (cycle-walking to the exact domain size)
+    instead of `torch.randperm`, so the data order is a pure function of `(seed, epoch)`:
+
+    - every distributed rank derives the identical order with no RNG state to synchronize,
+    - any position can be sought in O(1), enabling sample-exact resume of interrupted runs
+      (see `state_dict` / `load_state_dict`),
+    - memory and epoch-boundary cost do not grow with the number of frames.
+
+    The trade-off is that the shuffle is pseudo-random rather than a true uniform permutation,
+    which is the standard compromise in large-scale training loaders.
+
+    Each completed `__iter__` advances the internal epoch, so consecutive dataloader passes
+    yield different permutations without requiring `set_epoch` calls. During an epoch resumed
+    via `load_state_dict`, `__len__` still reports the full epoch length; the first pass simply
+    yields fewer samples.
+    """
+
+    def __init__(
+        self,
+        dataset_from_indices: list[int],
+        dataset_to_indices: list[int],
+        episode_indices_to_use: list | None = None,
+        drop_n_first_frames: int = 0,
+        drop_n_last_frames: int = 0,
+        shuffle: bool = True,
+        seed: int = 0,
+    ):
+        """
+        Args:
+            dataset_from_indices: List of indices containing the start of each episode in the dataset.
+            dataset_to_indices: List of indices containing the end of each episode in the dataset.
+            episode_indices_to_use: List of episode indices to use. If None, all episodes are used.
+                                    Assumes that episodes are indexed from 0 to N-1.
+            drop_n_first_frames: Number of frames to drop from the start of each episode.
+            drop_n_last_frames: Number of frames to drop from the end of each episode.
+            shuffle: Whether to shuffle with the seeded Feistel permutation.
+            seed: Seed the permutation is derived from (together with the epoch).
+        """
+        if drop_n_first_frames < 0:
+            raise ValueError(f"drop_n_first_frames must be >= 0, got {drop_n_first_frames}")
+        if drop_n_last_frames < 0:
+            raise ValueError(f"drop_n_last_frames must be >= 0, got {drop_n_last_frames}")
+
+        from_indices = np.asarray(dataset_from_indices, dtype=np.int64)
+        to_indices = np.asarray(dataset_to_indices, dtype=np.int64)
+        if from_indices.shape != to_indices.shape:
+            raise ValueError(
+                f"dataset_from_indices and dataset_to_indices must have the same length, "
+                f"got {len(from_indices)} and {len(to_indices)}"
+            )
+
+        used = np.ones(len(from_indices), dtype=bool)
+        if episode_indices_to_use is not None:
+            used = np.zeros(len(from_indices), dtype=bool)
+            used[np.asarray(episode_indices_to_use, dtype=np.int64)] = True
+
+        starts = from_indices + drop_n_first_frames
+        lengths = to_indices - drop_n_last_frames - starts
+        for episode_idx in np.flatnonzero(used & (lengths <= 0)):
+            logger.warning(
+                "Episode %d has %d frames but drop_n_first_frames=%d and "
+                "drop_n_last_frames=%d removes all frames. Skipping.",
+                episode_idx,
+                to_indices[episode_idx] - from_indices[episode_idx],
+                drop_n_first_frames,
+                drop_n_last_frames,
+            )
+        used &= lengths > 0
+        if not used.any():
+            raise ValueError(
+                "No valid frames remain after applying drop_n_first_frames and drop_n_last_frames. "
+                "All episodes were either filtered out or had too few frames."
+            )
+
+        self._starts = starts[used]
+        self._cum_lengths = np.cumsum(lengths[used])
+        self._num_frames = int(self._cum_lengths[-1])
+        self.shuffle = shuffle
+        self.seed = seed
+        self._epoch = 0
+        self._start_index = 0
+
+        # Feistel cipher domain: the smallest even-bit-width power of two >= num_frames,
+        # so both halves have equal width and cycle-walking converges in <4 expected steps.
+        bits = max((self._num_frames - 1).bit_length(), 2)
+        self._half_bits = (bits + 1) // 2
+        self._half_mask = (1 << self._half_bits) - 1
+
+    def set_epoch(self, epoch: int) -> None:
+        """Set the epoch the next `__iter__` will use (DistributedSampler convention)."""
+        self._epoch = epoch
+
+    def state_dict(self) -> dict:
+        return {"epoch": self._epoch, "start_index": self._start_index}
+
+    def load_state_dict(self, state: dict) -> None:
+        self._epoch = state["epoch"]
+        self._start_index = state["start_index"]
+
+    def _round_keys(self, epoch: int) -> list[int]:
+        state = _mix64(_mix64(self.seed) ^ _mix64(epoch))
+        keys = []
+        for _ in range(_FEISTEL_ROUNDS):
+            state = _mix64(state)
+            keys.append(state)
+        return keys
+
+    def _permute(self, index: int, keys: list[int]) -> int:
+        # Feistel network with cycle-walking: a bijection on [0, num_frames).
+        half_bits, half_mask = self._half_bits, self._half_mask
+        while True:
+            left, right = index >> half_bits, index & half_mask
+            for key in keys:
+                left, right = right, left ^ (_mix64(right ^ key) & half_mask)
+            index = (left << half_bits) | right
+            if index < self._num_frames:
+                return index
+
+    def _frame_index(self, position: int) -> int:
+        episode = int(np.searchsorted(self._cum_lengths, position, side="right"))
+        position_in_episode = position - (int(self._cum_lengths[episode - 1]) if episode > 0 else 0)
+        return int(self._starts[episode]) + position_in_episode
+
+    def __iter__(self) -> Iterator[int]:
+        # Capture and advance state eagerly so epoch bookkeeping is not deferred until the
+        # returned generator is first consumed.
+        epoch, start = self._epoch, self._start_index
+        self._epoch += 1
+        self._start_index = 0
+        return self._iter_epoch(epoch, start)
+
+    def _iter_epoch(self, epoch: int, start: int) -> Iterator[int]:
+        keys = self._round_keys(epoch) if self.shuffle else None
+        for k in range(start, self._num_frames):
+            yield self._frame_index(self._permute(k, keys) if self.shuffle else k)
+
+    def __len__(self) -> int:
+        return self._num_frames
+
+
+def compute_sampler_state(step: int, num_frames: int, batch_size: int, num_processes: int) -> dict:
+    """Map a global optimization step to a `DeterministicEpisodeAwareSampler` state for resume.
+
+    Under accelerate's batch-level sharding, every rank iterates the same underlying sampler and
+    keeps every `num_processes`-th batch, so one optimization step consumes
+    `batch_size * num_processes` consecutive sampler positions, and (with `even_batches` padding)
+    each rank sees `ceil(ceil(num_frames / batch_size) / num_processes)` batches per epoch.
+
+    `batches_into_epoch * num_processes <= ceil(num_frames / batch_size) - 1` always holds, so the
+    start index stays strictly below `num_frames`; the `min` is purely defensive. Resume is
+    sample-exact up to the `even_batches` padding accelerate appends at epoch boundaries (at most
+    `num_processes - 1` duplicated batches per epoch, the same duplication non-resumed runs get).
+    """
+    batches_per_epoch = math.ceil(math.ceil(num_frames / batch_size) / num_processes)
+    epoch, batches_into_epoch = divmod(step, batches_per_epoch)
+    start_index = min(batches_into_epoch * batch_size * num_processes, num_frames)
+    return {"epoch": epoch, "start_index": start_index}

--- a/src/lerobot/scripts/lerobot_train.py
+++ b/src/lerobot/scripts/lerobot_train.py
@@ -387,7 +387,7 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
         logging.info(f"{num_total_params=} ({format_big_number(num_total_params)})")
 
     # create dataloader for offline training
-    if cfg.deterministic_sampler:
+    if cfg.deterministic_sampler and not cfg.dataset.streaming:
         # Data order is a pure function of (seed, epoch): nothing to synchronize across ranks,
         # O(1) memory in dataset size, and a resumed run continues at the exact sample where the
         # checkpoint left off (up to accelerate's even_batches padding at epoch boundaries).

--- a/src/lerobot/scripts/lerobot_train.py
+++ b/src/lerobot/scripts/lerobot_train.py
@@ -234,18 +234,17 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
         torch.backends.cudnn.benchmark = True
     torch.backends.cuda.matmul.allow_tf32 = True
 
-    # Dataset loading synchronization: each node's local main process downloads first to avoid
-    # race conditions (the global main process only exists on node 0, so gating on it would let
-    # all ranks of the other nodes download and build the Arrow cache concurrently).
-    if accelerator.is_local_main_process:
-        if is_main_process:
-            logging.info("Creating dataset")
+    # Dataset loading synchronization: the global main process downloads once to the shared
+    # dataset root, then a barrier lets every other rank read the already-populated copy.
+    # LeRobotDataset skips its snapshot_download when try_load() succeeds, so no rank re-downloads.
+    if is_main_process:
+        logging.info("Creating dataset")
         dataset = make_dataset(cfg)
 
     accelerator.wait_for_everyone()
 
-    # Now all other processes can safely load the dataset from the local cache
-    if not accelerator.is_local_main_process:
+    # Other ranks read from the shared copy populated by the main process.
+    if not is_main_process:
         dataset = make_dataset(cfg)
 
     # Create environment used for evaluating checkpoints during training on simulation data.

--- a/src/lerobot/scripts/lerobot_train.py
+++ b/src/lerobot/scripts/lerobot_train.py
@@ -388,8 +388,9 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
         logging.info(f"{num_total_params=} ({format_big_number(num_total_params)})")
 
     # create dataloader for offline training
-    if cfg.deterministic_sampler and not cfg.dataset.streaming:
-        # Deterministic data order: no cross-rank RNG sync needed, sample-exact resume.
+    if not cfg.dataset.streaming:
+        # Deterministic data order (pure function of seed and epoch): no cross-rank RNG sync
+        # needed and sample-exact resume.
         shuffle = False
         sampler = EpisodeAwareSampler(
             dataset.meta.episodes["dataset_from_index"],
@@ -417,21 +418,6 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
                     f"Resuming data order at epoch {sampler_state['epoch']}, "
                     f"sample {sampler_state['start_index']}"
                 )
-    elif hasattr(active_cfg, "drop_n_last_frames"):
-        shuffle = False
-        # Legacy RNG shuffle: a dedicated generator lets accelerate synchronize it across ranks.
-        sampler_generator = torch.Generator()
-        if cfg.seed is not None:
-            sampler_generator.manual_seed(cfg.seed)
-        sampler = EpisodeAwareSampler(
-            dataset.meta.episodes["dataset_from_index"],
-            dataset.meta.episodes["dataset_to_index"],
-            episode_indices_to_use=dataset.episodes,
-            drop_n_last_frames=active_cfg.drop_n_last_frames,
-            shuffle=True,
-            deterministic=False,
-            generator=sampler_generator,
-        )
     else:
         shuffle = True
         sampler = None

--- a/src/lerobot/scripts/lerobot_train.py
+++ b/src/lerobot/scripts/lerobot_train.py
@@ -36,6 +36,7 @@ from tqdm import tqdm
 from lerobot.common.train_utils import (
     get_step_checkpoint_dir,
     get_step_identifier,
+    load_training_num_processes,
     load_training_state,
     save_checkpoint,
     update_last_checkpoint,
@@ -399,8 +400,18 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
             seed=cfg.seed if cfg.seed is not None else 0,
         )
         if cfg.resume and step > 0:
+            # The resume offset depends on the world size that produced `step`, so use the world
+            # size recorded in the checkpoint (falling back to the current one for older ckpts).
+            saved_num_processes = load_training_num_processes(cfg.checkpoint_path)
+            ckpt_num_processes = saved_num_processes or accelerator.num_processes
+            if is_main_process and saved_num_processes not in (None, accelerator.num_processes):
+                logging.warning(
+                    f"Resuming with num_processes={accelerator.num_processes} but the checkpoint was "
+                    f"written with num_processes={saved_num_processes}. The data order resumes at the "
+                    "right epoch/offset, but per-rank sample-exactness requires the same world size."
+                )
             sampler_state = compute_sampler_state(
-                step, len(sampler), cfg.batch_size, accelerator.num_processes
+                step, len(sampler), cfg.batch_size, ckpt_num_processes
             )
             sampler.load_state_dict(sampler_state)
             if is_main_process:
@@ -541,6 +552,7 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
                     scheduler=lr_scheduler,
                     preprocessor=preprocessor,
                     postprocessor=postprocessor,
+                    num_processes=accelerator.num_processes,
                 )
                 update_last_checkpoint(checkpoint_dir)
                 if wandb_logger:

--- a/src/lerobot/scripts/lerobot_train.py
+++ b/src/lerobot/scripts/lerobot_train.py
@@ -389,11 +389,7 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
 
     # create dataloader for offline training
     if not cfg.dataset.streaming:
-        # All non-streaming (map-style) datasets use EpisodeAwareSampler. This is broader than the
-        # historical `hasattr(active_cfg, "drop_n_last_frames")` guard: configs that previously fell
-        # back to DataLoader's default random shuffle now get this sampler instead, so their data
-        # order changes for a given seed (a deliberate, reproducibility-breaking improvement).
-        #
+        # All non-streaming (map-style) datasets use EpisodeAwareSampler.
         # The order is a pure function of (seed, epoch), so every rank independently produces the
         # same permutation. accelerate then shards it disjointly across ranks via BatchSamplerShard
         # without needing a `generator` attribute to synchronize an RNG, and resume is sample-exact.

--- a/src/lerobot/scripts/lerobot_train.py
+++ b/src/lerobot/scripts/lerobot_train.py
@@ -388,9 +388,7 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
 
     # create dataloader for offline training
     if cfg.deterministic_sampler and not cfg.dataset.streaming:
-        # Data order is a pure function of (seed, epoch): nothing to synchronize across ranks,
-        # O(1) memory in dataset size, and a resumed run continues at the exact sample where the
-        # checkpoint left off (up to accelerate's even_batches padding at epoch boundaries).
+        # Deterministic data order: no cross-rank RNG sync needed, sample-exact resume.
         shuffle = False
         sampler = EpisodeAwareSampler(
             dataset.meta.episodes["dataset_from_index"],
@@ -398,7 +396,6 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
             episode_indices_to_use=dataset.episodes,
             drop_n_last_frames=getattr(active_cfg, "drop_n_last_frames", 0),
             shuffle=True,
-            deterministic=True,
             seed=cfg.seed if cfg.seed is not None else 0,
         )
         if cfg.resume and step > 0:
@@ -413,9 +410,7 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
                 )
     elif hasattr(active_cfg, "drop_n_last_frames"):
         shuffle = False
-        # A dedicated generator (rather than the global torch RNG) lets accelerator.prepare
-        # synchronize the shuffle permutation across ranks, keeping batch shards disjoint even
-        # when ranks consume the global RNG asymmetrically (e.g. eval on the main process only).
+        # Legacy RNG shuffle: a dedicated generator lets accelerate synchronize it across ranks.
         sampler_generator = torch.Generator()
         if cfg.seed is not None:
             sampler_generator.manual_seed(cfg.seed)
@@ -425,6 +420,7 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
             episode_indices_to_use=dataset.episodes,
             drop_n_last_frames=active_cfg.drop_n_last_frames,
             shuffle=True,
+            deterministic=False,
             generator=sampler_generator,
         )
     else:

--- a/src/lerobot/scripts/lerobot_train.py
+++ b/src/lerobot/scripts/lerobot_train.py
@@ -232,15 +232,18 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
         torch.backends.cudnn.benchmark = True
     torch.backends.cuda.matmul.allow_tf32 = True
 
-    # Dataset loading synchronization: main process downloads first to avoid race conditions
-    if is_main_process:
-        logging.info("Creating dataset")
+    # Dataset loading synchronization: each node's local main process downloads first to avoid
+    # race conditions (the global main process only exists on node 0, so gating on it would let
+    # all ranks of the other nodes download and build the Arrow cache concurrently).
+    if accelerator.is_local_main_process:
+        if is_main_process:
+            logging.info("Creating dataset")
         dataset = make_dataset(cfg)
 
     accelerator.wait_for_everyone()
 
-    # Now all other processes can safely load the dataset
-    if not is_main_process:
+    # Now all other processes can safely load the dataset from the local cache
+    if not accelerator.is_local_main_process:
         dataset = make_dataset(cfg)
 
     # Create environment used for evaluating checkpoints during training on simulation data.
@@ -386,12 +389,19 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
     # create dataloader for offline training
     if hasattr(active_cfg, "drop_n_last_frames"):
         shuffle = False
+        # A dedicated generator (rather than the global torch RNG) lets accelerator.prepare
+        # synchronize the shuffle permutation across ranks, keeping batch shards disjoint even
+        # when ranks consume the global RNG asymmetrically (e.g. eval on the main process only).
+        sampler_generator = torch.Generator()
+        if cfg.seed is not None:
+            sampler_generator.manual_seed(cfg.seed)
         sampler = EpisodeAwareSampler(
             dataset.meta.episodes["dataset_from_index"],
             dataset.meta.episodes["dataset_to_index"],
             episode_indices_to_use=dataset.episodes,
             drop_n_last_frames=active_cfg.drop_n_last_frames,
             shuffle=True,
+            generator=sampler_generator,
         )
     else:
         shuffle = True

--- a/src/lerobot/scripts/lerobot_train.py
+++ b/src/lerobot/scripts/lerobot_train.py
@@ -43,7 +43,12 @@ from lerobot.common.train_utils import (
 from lerobot.common.wandb_utils import WandBLogger
 from lerobot.configs import parser
 from lerobot.configs.train import TrainPipelineConfig
-from lerobot.datasets import EpisodeAwareSampler, make_dataset
+from lerobot.datasets import (
+    DeterministicEpisodeAwareSampler,
+    EpisodeAwareSampler,
+    compute_sampler_state,
+    make_dataset,
+)
 from lerobot.envs import close_envs, make_env, make_env_pre_post_processors
 from lerobot.optim.factory import make_optimizer_and_scheduler
 from lerobot.policies import PreTrainedPolicy, make_policy, make_pre_post_processors
@@ -387,7 +392,30 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
         logging.info(f"{num_total_params=} ({format_big_number(num_total_params)})")
 
     # create dataloader for offline training
-    if hasattr(active_cfg, "drop_n_last_frames"):
+    if cfg.deterministic_sampler:
+        # Data order is a pure function of (seed, epoch): nothing to synchronize across ranks,
+        # O(1) memory in dataset size, and a resumed run continues at the exact sample where the
+        # checkpoint left off (up to accelerate's even_batches padding at epoch boundaries).
+        shuffle = False
+        sampler = DeterministicEpisodeAwareSampler(
+            dataset.meta.episodes["dataset_from_index"],
+            dataset.meta.episodes["dataset_to_index"],
+            episode_indices_to_use=dataset.episodes,
+            drop_n_last_frames=getattr(active_cfg, "drop_n_last_frames", 0),
+            shuffle=True,
+            seed=cfg.seed if cfg.seed is not None else 0,
+        )
+        if cfg.resume and step > 0:
+            sampler_state = compute_sampler_state(
+                step, len(sampler), cfg.batch_size, accelerator.num_processes
+            )
+            sampler.load_state_dict(sampler_state)
+            if is_main_process:
+                logging.info(
+                    f"Resuming data order at epoch {sampler_state['epoch']}, "
+                    f"sample {sampler_state['start_index']}"
+                )
+    elif hasattr(active_cfg, "drop_n_last_frames"):
         shuffle = False
         # A dedicated generator (rather than the global torch RNG) lets accelerator.prepare
         # synchronize the shuffle permutation across ranks, keeping batch shards disjoint even

--- a/src/lerobot/scripts/lerobot_train.py
+++ b/src/lerobot/scripts/lerobot_train.py
@@ -36,6 +36,7 @@ from tqdm import tqdm
 from lerobot.common.train_utils import (
     get_step_checkpoint_dir,
     get_step_identifier,
+    load_training_batch_size,
     load_training_num_processes,
     load_training_state,
     save_checkpoint,
@@ -389,8 +390,14 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
 
     # create dataloader for offline training
     if not cfg.dataset.streaming:
-        # Deterministic data order (pure function of seed and epoch): no cross-rank RNG sync
-        # needed and sample-exact resume.
+        # All non-streaming (map-style) datasets use EpisodeAwareSampler. This is broader than the
+        # historical `hasattr(active_cfg, "drop_n_last_frames")` guard: configs that previously fell
+        # back to DataLoader's default random shuffle now get this sampler instead, so their data
+        # order changes for a given seed (a deliberate, reproducibility-breaking improvement).
+        #
+        # The order is a pure function of (seed, epoch), so every rank independently produces the
+        # same permutation. accelerate then shards it disjointly across ranks via BatchSamplerShard
+        # without needing a `generator` attribute to synchronize an RNG, and resume is sample-exact.
         shuffle = False
         sampler = EpisodeAwareSampler(
             dataset.meta.episodes["dataset_from_index"],
@@ -401,17 +408,26 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
             seed=cfg.seed if cfg.seed is not None else 0,
         )
         if cfg.resume and step > 0:
-            # The resume offset depends on the world size that produced `step`, so use the world
-            # size recorded in the checkpoint (falling back to the current one for older ckpts).
+            # The resume offset depends on the (num_processes, batch_size) that produced `step`, so
+            # use the values recorded in the checkpoint (falling back to the current ones for older
+            # ckpts that did not store them).
             saved_num_processes = load_training_num_processes(cfg.checkpoint_path)
+            saved_batch_size = load_training_batch_size(cfg.checkpoint_path)
             ckpt_num_processes = saved_num_processes or accelerator.num_processes
+            ckpt_batch_size = saved_batch_size or cfg.batch_size
             if is_main_process and saved_num_processes not in (None, accelerator.num_processes):
                 logging.warning(
                     f"Resuming with num_processes={accelerator.num_processes} but the checkpoint was "
                     f"written with num_processes={saved_num_processes}. The data order resumes at the "
                     "right epoch/offset, but per-rank sample-exactness requires the same world size."
                 )
-            sampler_state = compute_sampler_state(step, len(sampler), cfg.batch_size, ckpt_num_processes)
+            if is_main_process and saved_batch_size not in (None, cfg.batch_size):
+                logging.warning(
+                    f"Resuming with batch_size={cfg.batch_size} but the checkpoint was written with "
+                    f"batch_size={saved_batch_size}. The data order resumes at the right epoch/offset, "
+                    "but per-rank sample-exactness requires the same batch size."
+                )
+            sampler_state = compute_sampler_state(step, len(sampler), ckpt_batch_size, ckpt_num_processes)
             sampler.load_state_dict(sampler_state)
             if is_main_process:
                 logging.info(
@@ -537,6 +553,7 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
                     preprocessor=preprocessor,
                     postprocessor=postprocessor,
                     num_processes=accelerator.num_processes,
+                    batch_size=cfg.batch_size,
                 )
                 update_last_checkpoint(checkpoint_dir)
                 if wandb_logger:

--- a/src/lerobot/scripts/lerobot_train.py
+++ b/src/lerobot/scripts/lerobot_train.py
@@ -410,9 +410,7 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
                     f"written with num_processes={saved_num_processes}. The data order resumes at the "
                     "right epoch/offset, but per-rank sample-exactness requires the same world size."
                 )
-            sampler_state = compute_sampler_state(
-                step, len(sampler), cfg.batch_size, ckpt_num_processes
-            )
+            sampler_state = compute_sampler_state(step, len(sampler), cfg.batch_size, ckpt_num_processes)
             sampler.load_state_dict(sampler_state)
             if is_main_process:
                 logging.info(

--- a/src/lerobot/scripts/lerobot_train.py
+++ b/src/lerobot/scripts/lerobot_train.py
@@ -43,12 +43,7 @@ from lerobot.common.train_utils import (
 from lerobot.common.wandb_utils import WandBLogger
 from lerobot.configs import parser
 from lerobot.configs.train import TrainPipelineConfig
-from lerobot.datasets import (
-    DeterministicEpisodeAwareSampler,
-    EpisodeAwareSampler,
-    compute_sampler_state,
-    make_dataset,
-)
+from lerobot.datasets import EpisodeAwareSampler, compute_sampler_state, make_dataset
 from lerobot.envs import close_envs, make_env, make_env_pre_post_processors
 from lerobot.optim.factory import make_optimizer_and_scheduler
 from lerobot.policies import PreTrainedPolicy, make_policy, make_pre_post_processors
@@ -397,12 +392,13 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
         # O(1) memory in dataset size, and a resumed run continues at the exact sample where the
         # checkpoint left off (up to accelerate's even_batches padding at epoch boundaries).
         shuffle = False
-        sampler = DeterministicEpisodeAwareSampler(
+        sampler = EpisodeAwareSampler(
             dataset.meta.episodes["dataset_from_index"],
             dataset.meta.episodes["dataset_to_index"],
             episode_indices_to_use=dataset.episodes,
             drop_n_last_frames=getattr(active_cfg, "drop_n_last_frames", 0),
             shuffle=True,
+            deterministic=True,
             seed=cfg.seed if cfg.seed is not None else 0,
         )
         if cfg.resume and step > 0:

--- a/tests/datasets/test_sampler.py
+++ b/tests/datasets/test_sampler.py
@@ -169,7 +169,7 @@ def test_partial_episode_drop_warns(caplog):
     assert "Episode 0" in caplog.text
 
 
-# --- deterministic mode (seeded Feistel permutation) ---
+# --- deterministic mode (seeded torch.randperm) ---
 
 from functools import partial  # noqa: E402
 
@@ -239,19 +239,26 @@ def test_deterministic_sampler_resume_mid_epoch():
         assert list(resumed) == epoch_1
 
 
-def test_deterministic_sampler_constant_memory():
-    # A trillion-frame dataset must instantiate instantly and seek anywhere in O(1):
-    # only per-episode boundaries are stored, never per-frame indices.
-    num_frames = 10**12
+def test_deterministic_sampler_construction_stores_only_boundaries():
+    # Construction is O(num_episodes), not O(num_frames): a million-frame single episode
+    # instantiates from just its boundaries without materializing a per-frame index list.
+    num_frames = 1_000_000
     sampler = deterministic_sampler([0], [num_frames], shuffle=True, seed=0)
     assert len(sampler) == num_frames
-    sampler.load_state_dict({"epoch": 3, "start_index": num_frames - 3})
-    # Collect via the iterator: list(sampler) would call PyObject_LengthHint -> sampler.__len__
-    # (the full epoch length, here 10**12) and pre-allocate that many slots before iterating. The
-    # iterator itself exposes no length hint, so this stays O(1) like the resumed epoch it drains.
-    tail = list(iter(sampler))
-    assert len(tail) == 3
-    assert all(0 <= idx < num_frames for idx in tail)
+    assert sampler._starts.shape == (1,) and sampler._cum_lengths.shape == (1,)
+
+
+def test_deterministic_sampler_resume_is_exact_at_scale():
+    # Seeded randperm makes resume sample-exact at non-trivial sizes: regenerating the epoch's
+    # permutation and slicing from the saved offset reproduces the remaining order exactly.
+    num_frames = 100_000
+    reference = deterministic_sampler([0], [num_frames], shuffle=True, seed=0)
+    epoch_0 = list(reference)
+    assert sorted(epoch_0) == list(range(num_frames))
+    start = num_frames - 5
+    resumed = deterministic_sampler([0], [num_frames], shuffle=True, seed=0)
+    resumed.load_state_dict({"epoch": 0, "start_index": start})
+    assert list(resumed) == epoch_0[start:]
 
 
 def test_deterministic_sampler_validation_matches_episode_aware():

--- a/tests/datasets/test_sampler.py
+++ b/tests/datasets/test_sampler.py
@@ -114,34 +114,17 @@ def test_shuffle():
     assert set(sampler) == {0, 1, 2, 3, 4, 5}
 
 
-def test_shuffle_with_generator_is_deterministic():
-    # Two samplers shuffling with same-seed generators must yield identical permutations.
-    # This is what keeps batch shards disjoint across ranks in distributed training, where
-    # accelerate synchronizes the sampler's generator state instead of the global torch RNG.
-    sampler_a = EpisodeAwareSampler(
-        [0], [6], shuffle=True, deterministic=False, generator=torch.Generator().manual_seed(42)
-    )
-    sampler_b = EpisodeAwareSampler(
-        [0], [6], shuffle=True, deterministic=False, generator=torch.Generator().manual_seed(42)
-    )
-    assert list(sampler_a) == list(sampler_b)
-
+def test_shuffle_is_reproducible_across_instances():
+    # The order is a pure function of (seed, epoch), so two fresh samplers (e.g. two ranks)
+    # produce the same permutation without any generator synchronization.
+    sampler_a = EpisodeAwareSampler([0], [6], shuffle=True, seed=42)
+    sampler_b = EpisodeAwareSampler([0], [6], shuffle=True, seed=42)
+    epoch_0 = list(sampler_a)
+    assert list(sampler_b) == epoch_0
     # Desyncing the global RNG must not affect the permutation.
-    sampler_c = EpisodeAwareSampler(
-        [0], [6], shuffle=True, deterministic=False, generator=torch.Generator().manual_seed(42)
-    )
-    order_before = list(sampler_c)
-    sampler_c.generator.manual_seed(42)
+    sampler_c = EpisodeAwareSampler([0], [6], shuffle=True, seed=42)
     torch.randperm(1000)  # consume global RNG, as rank-asymmetric code (e.g. eval) would
-    assert list(sampler_c) == order_before
-
-
-def test_generator_attribute_defaults_to_none():
-    # accelerate detects synchronizable samplers via `hasattr(sampler, "generator")`,
-    # so the attribute must exist even when no generator is passed.
-    sampler = EpisodeAwareSampler([0], [6], shuffle=True, deterministic=False)
-    assert sampler.generator is None
-    assert set(sampler) == {0, 1, 2, 3, 4, 5}
+    assert list(sampler_c) == epoch_0
 
 
 def test_negative_drop_first_frames_raises():
@@ -169,54 +152,23 @@ def test_partial_episode_drop_warns(caplog):
     assert "Episode 0" in caplog.text
 
 
-# --- deterministic mode (seeded torch.randperm) ---
-
-from functools import partial  # noqa: E402
+# --- seeded (seed, epoch) shuffling, resume, and state ---
 
 from lerobot.datasets.sampler import compute_sampler_state  # noqa: E402
 
-deterministic_sampler = partial(EpisodeAwareSampler, deterministic=True)
-
-
 EPISODE_BOUNDS = ([0, 2, 3], [2, 3, 6])  # episodes of 2, 1 and 3 frames
-
-
-def test_deterministic_mode_unshuffled_matches_default_mode():
-    for kwargs in (
-        {},
-        {"drop_n_first_frames": 1},
-        {"drop_n_last_frames": 1},
-        {"episode_indices_to_use": [0, 2]},
-    ):
-        reference = EpisodeAwareSampler(*EPISODE_BOUNDS, shuffle=False, **kwargs)
-        sampler = deterministic_sampler(*EPISODE_BOUNDS, shuffle=False, **kwargs)
-        assert list(sampler) == list(reference), kwargs
-        assert len(sampler) == len(reference), kwargs
-
-
-def test_deterministic_mode_rejects_generator():
-    with pytest.raises(ValueError, match="generator is unused in deterministic mode"):
-        deterministic_sampler(*EPISODE_BOUNDS, shuffle=True, generator=torch.Generator())
-
-
-def test_state_methods_require_deterministic_mode():
-    sampler = EpisodeAwareSampler(*EPISODE_BOUNDS, shuffle=True, deterministic=False)
-    with pytest.raises(RuntimeError, match="deterministic=True"):
-        sampler.set_epoch(1)
-    with pytest.raises(RuntimeError, match="deterministic=True"):
-        sampler.state_dict()
 
 
 @pytest.mark.parametrize("num_frames", [1, 2, 3, 37, 64, 100])
 def test_deterministic_sampler_shuffle_is_permutation(num_frames):
     for seed in (0, 1, 1234):
-        sampler = deterministic_sampler([0], [num_frames], shuffle=True, seed=seed)
+        sampler = EpisodeAwareSampler([0], [num_frames], shuffle=True, seed=seed)
         assert sorted(sampler) == list(range(num_frames))
 
 
 def test_deterministic_sampler_epochs_reproduce_and_differ():
-    sampler_a = deterministic_sampler([0], [100], shuffle=True, seed=42)
-    sampler_b = deterministic_sampler([0], [100], shuffle=True, seed=42)
+    sampler_a = EpisodeAwareSampler([0], [100], shuffle=True, seed=42)
+    sampler_b = EpisodeAwareSampler([0], [100], shuffle=True, seed=42)
     epoch_0 = list(sampler_a)
     assert list(sampler_b) == epoch_0  # same (seed, epoch) -> same order on any process
     epoch_1 = list(sampler_a)  # __iter__ auto-advances the epoch
@@ -224,15 +176,15 @@ def test_deterministic_sampler_epochs_reproduce_and_differ():
     assert sorted(epoch_1) == sorted(epoch_0)
     sampler_a.set_epoch(0)
     assert list(sampler_a) == epoch_0
-    assert list(deterministic_sampler([0], [100], shuffle=True, seed=7)) != epoch_0
+    assert list(EpisodeAwareSampler([0], [100], shuffle=True, seed=7)) != epoch_0
 
 
 def test_deterministic_sampler_resume_mid_epoch():
-    reference = deterministic_sampler(*EPISODE_BOUNDS, shuffle=True, seed=42)
+    reference = EpisodeAwareSampler(*EPISODE_BOUNDS, shuffle=True, seed=42)
     epoch_0 = list(reference)
     epoch_1 = list(reference)
     for start in (0, 1, 4, len(epoch_0)):
-        resumed = deterministic_sampler(*EPISODE_BOUNDS, shuffle=True, seed=42)
+        resumed = EpisodeAwareSampler(*EPISODE_BOUNDS, shuffle=True, seed=42)
         resumed.load_state_dict({"epoch": 0, "start_index": start})
         assert list(resumed) == epoch_0[start:]
         # the resumed sampler continues into the same epoch 1 as the uninterrupted one
@@ -243,7 +195,7 @@ def test_deterministic_sampler_construction_stores_only_boundaries():
     # Construction is O(num_episodes), not O(num_frames): a million-frame single episode
     # instantiates from just its boundaries without materializing a per-frame index list.
     num_frames = 1_000_000
-    sampler = deterministic_sampler([0], [num_frames], shuffle=True, seed=0)
+    sampler = EpisodeAwareSampler([0], [num_frames], shuffle=True, seed=0)
     assert len(sampler) == num_frames
     assert sampler._starts.shape == (1,) and sampler._cum_lengths.shape == (1,)
 
@@ -252,27 +204,27 @@ def test_deterministic_sampler_resume_is_exact_at_scale():
     # Seeded randperm makes resume sample-exact at non-trivial sizes: regenerating the epoch's
     # permutation and slicing from the saved offset reproduces the remaining order exactly.
     num_frames = 100_000
-    reference = deterministic_sampler([0], [num_frames], shuffle=True, seed=0)
+    reference = EpisodeAwareSampler([0], [num_frames], shuffle=True, seed=0)
     epoch_0 = list(reference)
     assert sorted(epoch_0) == list(range(num_frames))
     start = num_frames - 5
-    resumed = deterministic_sampler([0], [num_frames], shuffle=True, seed=0)
+    resumed = EpisodeAwareSampler([0], [num_frames], shuffle=True, seed=0)
     resumed.load_state_dict({"epoch": 0, "start_index": start})
     assert list(resumed) == epoch_0[start:]
 
 
 def test_deterministic_sampler_validation_matches_episode_aware():
     with pytest.raises(ValueError, match="drop_n_first_frames must be >= 0"):
-        deterministic_sampler([0], [10], drop_n_first_frames=-1)
+        EpisodeAwareSampler([0], [10], drop_n_first_frames=-1)
     with pytest.raises(ValueError, match="drop_n_last_frames must be >= 0"):
-        deterministic_sampler([0], [10], drop_n_last_frames=-1)
+        EpisodeAwareSampler([0], [10], drop_n_last_frames=-1)
     with pytest.raises(ValueError, match="No valid frames remain"):
-        deterministic_sampler([0, 1, 2], [1, 2, 3], drop_n_first_frames=1)
+        EpisodeAwareSampler([0, 1, 2], [1, 2, 3], drop_n_first_frames=1)
 
 
 def test_deterministic_sampler_partial_episode_drop_warns(caplog):
     with caplog.at_level(logging.WARNING, logger="lerobot.datasets.sampler"):
-        sampler = deterministic_sampler([0, 1], [1, 6], drop_n_first_frames=1, shuffle=False)
+        sampler = EpisodeAwareSampler([0, 1], [1, 6], drop_n_first_frames=1, shuffle=False)
     assert list(sampler) == [2, 3, 4, 5]
     assert "Episode 0" in caplog.text
 

--- a/tests/datasets/test_sampler.py
+++ b/tests/datasets/test_sampler.py
@@ -161,3 +161,109 @@ def test_partial_episode_drop_warns(caplog):
     # Episode 0 is skipped (1 frame, drop 1), Episode 1 keeps frames 2-5
     assert sampler.indices == [2, 3, 4, 5]
     assert "Episode 0" in caplog.text
+
+
+# --- DeterministicEpisodeAwareSampler ---
+
+from lerobot.datasets.sampler import (  # noqa: E402
+    DeterministicEpisodeAwareSampler,
+    compute_sampler_state,
+)
+
+EPISODE_BOUNDS = ([0, 2, 3], [2, 3, 6])  # episodes of 2, 1 and 3 frames
+
+
+def test_deterministic_sampler_unshuffled_matches_episode_aware():
+    for kwargs in (
+        {},
+        {"drop_n_first_frames": 1},
+        {"drop_n_last_frames": 1},
+        {"episode_indices_to_use": [0, 2]},
+    ):
+        reference = EpisodeAwareSampler(*EPISODE_BOUNDS, shuffle=False, **kwargs)
+        sampler = DeterministicEpisodeAwareSampler(*EPISODE_BOUNDS, shuffle=False, **kwargs)
+        assert list(sampler) == list(reference), kwargs
+        assert len(sampler) == len(reference), kwargs
+
+
+@pytest.mark.parametrize("num_frames", [1, 2, 3, 37, 64, 100])
+def test_deterministic_sampler_shuffle_is_permutation(num_frames):
+    for seed in (0, 1, 1234):
+        sampler = DeterministicEpisodeAwareSampler([0], [num_frames], shuffle=True, seed=seed)
+        assert sorted(sampler) == list(range(num_frames))
+
+
+def test_deterministic_sampler_epochs_reproduce_and_differ():
+    sampler_a = DeterministicEpisodeAwareSampler([0], [100], shuffle=True, seed=42)
+    sampler_b = DeterministicEpisodeAwareSampler([0], [100], shuffle=True, seed=42)
+    epoch_0 = list(sampler_a)
+    assert list(sampler_b) == epoch_0  # same (seed, epoch) -> same order on any process
+    epoch_1 = list(sampler_a)  # __iter__ auto-advances the epoch
+    assert epoch_1 != epoch_0
+    assert sorted(epoch_1) == sorted(epoch_0)
+    sampler_a.set_epoch(0)
+    assert list(sampler_a) == epoch_0
+    assert list(DeterministicEpisodeAwareSampler([0], [100], shuffle=True, seed=7)) != epoch_0
+
+
+def test_deterministic_sampler_resume_mid_epoch():
+    reference = DeterministicEpisodeAwareSampler(*EPISODE_BOUNDS, shuffle=True, seed=42)
+    epoch_0 = list(reference)
+    epoch_1 = list(reference)
+    for start in (0, 1, 4, len(epoch_0)):
+        resumed = DeterministicEpisodeAwareSampler(*EPISODE_BOUNDS, shuffle=True, seed=42)
+        resumed.load_state_dict({"epoch": 0, "start_index": start})
+        assert list(resumed) == epoch_0[start:]
+        # the resumed sampler continues into the same epoch 1 as the uninterrupted one
+        assert list(resumed) == epoch_1
+
+
+def test_deterministic_sampler_constant_memory():
+    # A trillion-frame dataset must instantiate instantly and seek anywhere in O(1):
+    # only per-episode boundaries are stored, never per-frame indices.
+    num_frames = 10**12
+    sampler = DeterministicEpisodeAwareSampler([0], [num_frames], shuffle=True, seed=0)
+    assert len(sampler) == num_frames
+    sampler.load_state_dict({"epoch": 3, "start_index": num_frames - 3})
+    tail = list(sampler)
+    assert len(tail) == 3
+    assert all(0 <= idx < num_frames for idx in tail)
+
+
+def test_deterministic_sampler_validation_matches_episode_aware():
+    with pytest.raises(ValueError, match="drop_n_first_frames must be >= 0"):
+        DeterministicEpisodeAwareSampler([0], [10], drop_n_first_frames=-1)
+    with pytest.raises(ValueError, match="drop_n_last_frames must be >= 0"):
+        DeterministicEpisodeAwareSampler([0], [10], drop_n_last_frames=-1)
+    with pytest.raises(ValueError, match="No valid frames remain"):
+        DeterministicEpisodeAwareSampler([0, 1, 2], [1, 2, 3], drop_n_first_frames=1)
+
+
+def test_deterministic_sampler_partial_episode_drop_warns(caplog):
+    with caplog.at_level(logging.WARNING, logger="lerobot.datasets.sampler"):
+        sampler = DeterministicEpisodeAwareSampler([0, 1], [1, 6], drop_n_first_frames=1, shuffle=False)
+    assert list(sampler) == [2, 3, 4, 5]
+    assert "Episode 0" in caplog.text
+
+
+def test_compute_sampler_state():
+    # 100 frames, batch 10, 2 ranks -> 10 underlying batches, 5 per rank per epoch.
+    assert compute_sampler_state(step=0, num_frames=100, batch_size=10, num_processes=2) == {
+        "epoch": 0,
+        "start_index": 0,
+    }
+    # step 7 -> epoch 1, 2 per-rank batches in = 2 * 10 * 2 = 40 samples in
+    assert compute_sampler_state(step=7, num_frames=100, batch_size=10, num_processes=2) == {
+        "epoch": 1,
+        "start_index": 40,
+    }
+    # uneven epoch: 95 frames -> 10 underlying batches (last short), still 5 per rank
+    assert compute_sampler_state(step=12, num_frames=95, batch_size=10, num_processes=2) == {
+        "epoch": 2,
+        "start_index": 40,
+    }
+    # uneven sharding: 105 frames -> 11 underlying batches, 6 per rank (even_batches pads)
+    assert compute_sampler_state(step=11, num_frames=105, batch_size=10, num_processes=2) == {
+        "epoch": 1,
+        "start_index": 100,
+    }

--- a/tests/datasets/test_sampler.py
+++ b/tests/datasets/test_sampler.py
@@ -163,17 +163,19 @@ def test_partial_episode_drop_warns(caplog):
     assert "Episode 0" in caplog.text
 
 
-# --- DeterministicEpisodeAwareSampler ---
+# --- deterministic mode (seeded Feistel permutation) ---
 
-from lerobot.datasets.sampler import (  # noqa: E402
-    DeterministicEpisodeAwareSampler,
-    compute_sampler_state,
-)
+from functools import partial  # noqa: E402
+
+from lerobot.datasets.sampler import compute_sampler_state  # noqa: E402
+
+deterministic_sampler = partial(EpisodeAwareSampler, deterministic=True)
+
 
 EPISODE_BOUNDS = ([0, 2, 3], [2, 3, 6])  # episodes of 2, 1 and 3 frames
 
 
-def test_deterministic_sampler_unshuffled_matches_episode_aware():
+def test_deterministic_mode_unshuffled_matches_default_mode():
     for kwargs in (
         {},
         {"drop_n_first_frames": 1},
@@ -181,21 +183,34 @@ def test_deterministic_sampler_unshuffled_matches_episode_aware():
         {"episode_indices_to_use": [0, 2]},
     ):
         reference = EpisodeAwareSampler(*EPISODE_BOUNDS, shuffle=False, **kwargs)
-        sampler = DeterministicEpisodeAwareSampler(*EPISODE_BOUNDS, shuffle=False, **kwargs)
+        sampler = deterministic_sampler(*EPISODE_BOUNDS, shuffle=False, **kwargs)
         assert list(sampler) == list(reference), kwargs
         assert len(sampler) == len(reference), kwargs
+
+
+def test_deterministic_mode_rejects_generator():
+    with pytest.raises(ValueError, match="generator is unused in deterministic mode"):
+        deterministic_sampler(*EPISODE_BOUNDS, shuffle=True, generator=torch.Generator())
+
+
+def test_state_methods_require_deterministic_mode():
+    sampler = EpisodeAwareSampler(*EPISODE_BOUNDS, shuffle=True)
+    with pytest.raises(RuntimeError, match="deterministic=True"):
+        sampler.set_epoch(1)
+    with pytest.raises(RuntimeError, match="deterministic=True"):
+        sampler.state_dict()
 
 
 @pytest.mark.parametrize("num_frames", [1, 2, 3, 37, 64, 100])
 def test_deterministic_sampler_shuffle_is_permutation(num_frames):
     for seed in (0, 1, 1234):
-        sampler = DeterministicEpisodeAwareSampler([0], [num_frames], shuffle=True, seed=seed)
+        sampler = deterministic_sampler([0], [num_frames], shuffle=True, seed=seed)
         assert sorted(sampler) == list(range(num_frames))
 
 
 def test_deterministic_sampler_epochs_reproduce_and_differ():
-    sampler_a = DeterministicEpisodeAwareSampler([0], [100], shuffle=True, seed=42)
-    sampler_b = DeterministicEpisodeAwareSampler([0], [100], shuffle=True, seed=42)
+    sampler_a = deterministic_sampler([0], [100], shuffle=True, seed=42)
+    sampler_b = deterministic_sampler([0], [100], shuffle=True, seed=42)
     epoch_0 = list(sampler_a)
     assert list(sampler_b) == epoch_0  # same (seed, epoch) -> same order on any process
     epoch_1 = list(sampler_a)  # __iter__ auto-advances the epoch
@@ -203,15 +218,15 @@ def test_deterministic_sampler_epochs_reproduce_and_differ():
     assert sorted(epoch_1) == sorted(epoch_0)
     sampler_a.set_epoch(0)
     assert list(sampler_a) == epoch_0
-    assert list(DeterministicEpisodeAwareSampler([0], [100], shuffle=True, seed=7)) != epoch_0
+    assert list(deterministic_sampler([0], [100], shuffle=True, seed=7)) != epoch_0
 
 
 def test_deterministic_sampler_resume_mid_epoch():
-    reference = DeterministicEpisodeAwareSampler(*EPISODE_BOUNDS, shuffle=True, seed=42)
+    reference = deterministic_sampler(*EPISODE_BOUNDS, shuffle=True, seed=42)
     epoch_0 = list(reference)
     epoch_1 = list(reference)
     for start in (0, 1, 4, len(epoch_0)):
-        resumed = DeterministicEpisodeAwareSampler(*EPISODE_BOUNDS, shuffle=True, seed=42)
+        resumed = deterministic_sampler(*EPISODE_BOUNDS, shuffle=True, seed=42)
         resumed.load_state_dict({"epoch": 0, "start_index": start})
         assert list(resumed) == epoch_0[start:]
         # the resumed sampler continues into the same epoch 1 as the uninterrupted one
@@ -222,7 +237,7 @@ def test_deterministic_sampler_constant_memory():
     # A trillion-frame dataset must instantiate instantly and seek anywhere in O(1):
     # only per-episode boundaries are stored, never per-frame indices.
     num_frames = 10**12
-    sampler = DeterministicEpisodeAwareSampler([0], [num_frames], shuffle=True, seed=0)
+    sampler = deterministic_sampler([0], [num_frames], shuffle=True, seed=0)
     assert len(sampler) == num_frames
     sampler.load_state_dict({"epoch": 3, "start_index": num_frames - 3})
     tail = list(sampler)
@@ -232,16 +247,16 @@ def test_deterministic_sampler_constant_memory():
 
 def test_deterministic_sampler_validation_matches_episode_aware():
     with pytest.raises(ValueError, match="drop_n_first_frames must be >= 0"):
-        DeterministicEpisodeAwareSampler([0], [10], drop_n_first_frames=-1)
+        deterministic_sampler([0], [10], drop_n_first_frames=-1)
     with pytest.raises(ValueError, match="drop_n_last_frames must be >= 0"):
-        DeterministicEpisodeAwareSampler([0], [10], drop_n_last_frames=-1)
+        deterministic_sampler([0], [10], drop_n_last_frames=-1)
     with pytest.raises(ValueError, match="No valid frames remain"):
-        DeterministicEpisodeAwareSampler([0, 1, 2], [1, 2, 3], drop_n_first_frames=1)
+        deterministic_sampler([0, 1, 2], [1, 2, 3], drop_n_first_frames=1)
 
 
 def test_deterministic_sampler_partial_episode_drop_warns(caplog):
     with caplog.at_level(logging.WARNING, logger="lerobot.datasets.sampler"):
-        sampler = DeterministicEpisodeAwareSampler([0, 1], [1, 6], drop_n_first_frames=1, shuffle=False)
+        sampler = deterministic_sampler([0, 1], [1, 6], drop_n_first_frames=1, shuffle=False)
     assert list(sampler) == [2, 3, 4, 5]
     assert "Episode 0" in caplog.text
 

--- a/tests/datasets/test_sampler.py
+++ b/tests/datasets/test_sampler.py
@@ -213,22 +213,6 @@ def test_deterministic_sampler_resume_is_exact_at_scale():
     assert list(resumed) == epoch_0[start:]
 
 
-def test_deterministic_sampler_validation_matches_episode_aware():
-    with pytest.raises(ValueError, match="drop_n_first_frames must be >= 0"):
-        EpisodeAwareSampler([0], [10], drop_n_first_frames=-1)
-    with pytest.raises(ValueError, match="drop_n_last_frames must be >= 0"):
-        EpisodeAwareSampler([0], [10], drop_n_last_frames=-1)
-    with pytest.raises(ValueError, match="No valid frames remain"):
-        EpisodeAwareSampler([0, 1, 2], [1, 2, 3], drop_n_first_frames=1)
-
-
-def test_deterministic_sampler_partial_episode_drop_warns(caplog):
-    with caplog.at_level(logging.WARNING, logger="lerobot.datasets.sampler"):
-        sampler = EpisodeAwareSampler([0, 1], [1, 6], drop_n_first_frames=1, shuffle=False)
-    assert list(sampler) == [2, 3, 4, 5]
-    assert "Episode 0" in caplog.text
-
-
 def test_compute_sampler_state():
     # 100 frames, batch 10, 2 ranks -> 10 underlying batches, 5 per rank per epoch.
     assert compute_sampler_state(step=0, num_frames=100, batch_size=10, num_processes=2) == {

--- a/tests/datasets/test_sampler.py
+++ b/tests/datasets/test_sampler.py
@@ -246,7 +246,10 @@ def test_deterministic_sampler_constant_memory():
     sampler = deterministic_sampler([0], [num_frames], shuffle=True, seed=0)
     assert len(sampler) == num_frames
     sampler.load_state_dict({"epoch": 3, "start_index": num_frames - 3})
-    tail = list(sampler)
+    # Collect via the iterator: list(sampler) would call PyObject_LengthHint -> sampler.__len__
+    # (the full epoch length, here 10**12) and pre-allocate that many slots before iterating. The
+    # iterator itself exposes no length hint, so this stays O(1) like the resumed epoch it drains.
+    tail = list(iter(sampler))
     assert len(tail) == 3
     assert all(0 <= idx < num_frames for idx in tail)
 

--- a/tests/datasets/test_sampler.py
+++ b/tests/datasets/test_sampler.py
@@ -118,12 +118,18 @@ def test_shuffle_with_generator_is_deterministic():
     # Two samplers shuffling with same-seed generators must yield identical permutations.
     # This is what keeps batch shards disjoint across ranks in distributed training, where
     # accelerate synchronizes the sampler's generator state instead of the global torch RNG.
-    sampler_a = EpisodeAwareSampler([0], [6], shuffle=True, generator=torch.Generator().manual_seed(42))
-    sampler_b = EpisodeAwareSampler([0], [6], shuffle=True, generator=torch.Generator().manual_seed(42))
+    sampler_a = EpisodeAwareSampler(
+        [0], [6], shuffle=True, deterministic=False, generator=torch.Generator().manual_seed(42)
+    )
+    sampler_b = EpisodeAwareSampler(
+        [0], [6], shuffle=True, deterministic=False, generator=torch.Generator().manual_seed(42)
+    )
     assert list(sampler_a) == list(sampler_b)
 
     # Desyncing the global RNG must not affect the permutation.
-    sampler_c = EpisodeAwareSampler([0], [6], shuffle=True, generator=torch.Generator().manual_seed(42))
+    sampler_c = EpisodeAwareSampler(
+        [0], [6], shuffle=True, deterministic=False, generator=torch.Generator().manual_seed(42)
+    )
     order_before = list(sampler_c)
     sampler_c.generator.manual_seed(42)
     torch.randperm(1000)  # consume global RNG, as rank-asymmetric code (e.g. eval) would
@@ -133,7 +139,7 @@ def test_shuffle_with_generator_is_deterministic():
 def test_generator_attribute_defaults_to_none():
     # accelerate detects synchronizable samplers via `hasattr(sampler, "generator")`,
     # so the attribute must exist even when no generator is passed.
-    sampler = EpisodeAwareSampler([0], [6], shuffle=True)
+    sampler = EpisodeAwareSampler([0], [6], shuffle=True, deterministic=False)
     assert sampler.generator is None
     assert set(sampler) == {0, 1, 2, 3, 4, 5}
 
@@ -194,7 +200,7 @@ def test_deterministic_mode_rejects_generator():
 
 
 def test_state_methods_require_deterministic_mode():
-    sampler = EpisodeAwareSampler(*EPISODE_BOUNDS, shuffle=True)
+    sampler = EpisodeAwareSampler(*EPISODE_BOUNDS, shuffle=True, deterministic=False)
     with pytest.raises(RuntimeError, match="deterministic=True"):
         sampler.set_epoch(1)
     with pytest.raises(RuntimeError, match="deterministic=True"):

--- a/tests/datasets/test_sampler.py
+++ b/tests/datasets/test_sampler.py
@@ -114,6 +114,30 @@ def test_shuffle():
     assert set(sampler) == {0, 1, 2, 3, 4, 5}
 
 
+def test_shuffle_with_generator_is_deterministic():
+    # Two samplers shuffling with same-seed generators must yield identical permutations.
+    # This is what keeps batch shards disjoint across ranks in distributed training, where
+    # accelerate synchronizes the sampler's generator state instead of the global torch RNG.
+    sampler_a = EpisodeAwareSampler([0], [6], shuffle=True, generator=torch.Generator().manual_seed(42))
+    sampler_b = EpisodeAwareSampler([0], [6], shuffle=True, generator=torch.Generator().manual_seed(42))
+    assert list(sampler_a) == list(sampler_b)
+
+    # Desyncing the global RNG must not affect the permutation.
+    sampler_c = EpisodeAwareSampler([0], [6], shuffle=True, generator=torch.Generator().manual_seed(42))
+    order_before = list(sampler_c)
+    sampler_c.generator.manual_seed(42)
+    torch.randperm(1000)  # consume global RNG, as rank-asymmetric code (e.g. eval) would
+    assert list(sampler_c) == order_before
+
+
+def test_generator_attribute_defaults_to_none():
+    # accelerate detects synchronizable samplers via `hasattr(sampler, "generator")`,
+    # so the attribute must exist even when no generator is passed.
+    sampler = EpisodeAwareSampler([0], [6], shuffle=True)
+    assert sampler.generator is None
+    assert set(sampler) == {0, 1, 2, 3, 4, 5}
+
+
 def test_negative_drop_first_frames_raises():
     with pytest.raises(ValueError, match="drop_n_first_frames must be >= 0"):
         EpisodeAwareSampler([0], [10], drop_n_first_frames=-1)

--- a/tests/utils/test_train_utils.py
+++ b/tests/utils/test_train_utils.py
@@ -20,6 +20,7 @@ from unittest.mock import Mock, patch
 from lerobot.common.train_utils import (
     get_step_checkpoint_dir,
     get_step_identifier,
+    load_training_batch_size,
     load_training_num_processes,
     load_training_state,
     load_training_step,
@@ -73,6 +74,17 @@ def test_load_training_num_processes_absent_returns_none(tmp_path, optimizer, sc
     # Checkpoints written before the world size was recorded must still load (back-compat).
     save_training_state(tmp_path, 10, optimizer, scheduler)
     assert load_training_num_processes(tmp_path) is None
+
+
+def test_save_training_state_records_batch_size(tmp_path, optimizer, scheduler):
+    save_training_state(tmp_path, 10, optimizer, scheduler, batch_size=32)
+    assert load_training_batch_size(tmp_path) == 32
+
+
+def test_load_training_batch_size_absent_returns_none(tmp_path, optimizer, scheduler):
+    # Checkpoints written before the batch size was recorded must still load (back-compat).
+    save_training_state(tmp_path, 10, optimizer, scheduler)
+    assert load_training_batch_size(tmp_path) is None
 
 
 def test_update_last_checkpoint(tmp_path):

--- a/tests/utils/test_train_utils.py
+++ b/tests/utils/test_train_utils.py
@@ -20,6 +20,7 @@ from unittest.mock import Mock, patch
 from lerobot.common.train_utils import (
     get_step_checkpoint_dir,
     get_step_identifier,
+    load_training_num_processes,
     load_training_state,
     load_training_step,
     save_checkpoint,
@@ -61,6 +62,17 @@ def test_load_training_step(tmp_path):
     save_training_step(step, tmp_path)
     loaded_step = load_training_step(tmp_path)
     assert loaded_step == step
+
+
+def test_save_training_state_records_num_processes(tmp_path, optimizer, scheduler):
+    save_training_state(tmp_path, 10, optimizer, scheduler, num_processes=4)
+    assert load_training_num_processes(tmp_path) == 4
+
+
+def test_load_training_num_processes_absent_returns_none(tmp_path, optimizer, scheduler):
+    # Checkpoints written before the world size was recorded must still load (back-compat).
+    save_training_state(tmp_path, 10, optimizer, scheduler)
+    assert load_training_num_processes(tmp_path) is None
 
 
 def test_update_last_checkpoint(tmp_path):


### PR DESCRIPTION
## Summary

On `main`, `EpisodeAwareSampler` materializes a Python list of every frame index (memory scales with frame count) and reshuffles each epoch, while checkpoints save step/optimizer/RNG but no dataloader position. So large datasets pay a big per-rank memory cost, and resuming a long run reshuffles from scratch (re-seeing/skipping samples within the interrupted epoch).

This PR fixes both **inside the existing sampler** (no new class):

- **Stores only per-episode boundaries** and maps a logical position to a frame index on the fly via `searchsorted`. Construction is **O(num_episodes)** instead of O(num_frames). (`indices` stays as a back-compat/introspection property.)
- **Always-deterministic shuffle**: each epoch is a `torch.randperm` **seeded from `(seed, epoch)`**, so the order is a pure function of `(seed, epoch)` — it reproduces on every rank with no global-RNG sync (no `generator` to keep in lockstep), and `state_dict` / `load_state_dict` resume **sample-exactly** by regenerating the epoch's permutation and continuing from the saved offset.

The per-epoch `randperm` tensor is unchanged; the win is dropping the persistent per-frame list and gaining reproducible, resumable ordering.

## What changed

- `EpisodeAwareSampler`: boundary-based, seeded-`randperm` shuffle. `__iter__` auto-advances the epoch; `set_epoch` / `state_dict` / `load_state_dict` drive it explicitly (incl. mid-epoch resume). Used for all non-streaming map-style datasets; streaming is unaffected.
- New `compute_sampler_state(...)`: maps a checkpointed step to `(epoch, start_index)`, accounting for accelerate's batch sharding. Resume is sample-exact when `batch_size`/`num_processes` match the checkpoint; both are now recorded in `training_step.json` and a mismatch is warned about.
- Dataset download is gated on the **global** main process (download once to the shared root, barrier, others read), instead of once per node.

## Testing

- `pytest -q tests/datasets/test_sampler.py tests/utils/test_train_utils.py` passes. Covers unshuffled order per drop/filter combo, real permutations across sizes/seeds, `(seed, epoch)` reproducibility + global-RNG immunity, mid-epoch resume flowing into the right next epoch, boundary-only construction, sample-exact resume at scale, and the resume math (incl. uneven splits and the recorded-state mismatch warnings).
- E2E: 4-step diffusion on `lerobot/pusht` with `save_freq=2`, resumed from step 2 with `--resume=true` — logged `Resuming data order at epoch 0, sample 4` and finished correctly.
- Large-scale: pi05 on 8xH100 over full RoboCasa (29.1M frames / 32,043 episodes). No epoch-boundary stall; steady-state dataloader wait ~0.014 s/step (searchsorted adds no measurable overhead).
- Sampler memory at that scale (RSS, per rank):

  | phase | old (main) | this PR |
  |---|---|---|
  | construction (persistent) | 1,118.8 MB | 2.2 MB |
  | per-epoch `randperm` (transient) | 213 MB | 213 MB |
  | **peak per process** | **~1,332 MB** | **~215 MB** |

  ~6x smaller footprint (~1.1 GB/rank saved) from dropping the per-frame list.

## Checklist

- [x] `pre-commit run -a` passes (incl. strict mypy for `lerobot.configs`)
- [x] Tests pass locally
- [x] Docstrings updated
- [x] CI is green
- [ ] Community Review: reviewed another contributor's open PR and linked it here: #
