### PR TITLE
feat(train): static node-level data partitioning (LPT) for multi-node training

### DIFF
--- a/src/lerobot/configs/train.py
+++ b/src/lerobot/configs/train.py
@@ -105,6 +105,13 @@ class TrainPipelineConfig(HubMixin):
     # and enables sample-exact resume of interrupted runs. The shuffle is pseudo-random rather
     # than a true uniform permutation. Not compatible with dataset.streaming.
     deterministic_sampler: bool = False
+    # Statically partition the dataset's episodes across nodes ("node") so each node downloads
+    # and stores only its near-uniform share (greedy LPT on frame counts) instead of the full
+    # dataset. Implies deterministic_sampler; ranks within a node shard the node-local data
+    # arithmetically. Sample-exact resume requires resuming with the same topology (number of
+    # nodes and processes). "none" (default) keeps the current behavior: full dataset everywhere,
+    # batch-level sharding across all ranks via accelerate.
+    data_partition: str = "none"
     steps: int = 100_000
     eval_freq: int = 20_000
     log_freq: int = 200
@@ -144,6 +151,18 @@ class TrainPipelineConfig(HubMixin):
                 "deterministic_sampler requires a map-style dataset and is not compatible with "
                 "dataset.streaming=true."
             )
+        if self.data_partition not in ("none", "node"):
+            raise ValueError(f"data_partition must be 'none' or 'node', got '{self.data_partition}'")
+        if self.data_partition == "node":
+            if self.dataset.streaming:
+                raise ValueError("data_partition='node' is not compatible with dataset.streaming=true.")
+            if self.sample_weighting is not None:
+                raise ValueError(
+                    "data_partition='node' is not compatible with sample_weighting: per-node data "
+                    "subsets change the weighting semantics."
+                )
+            if not isinstance(self.dataset.repo_id, str):
+                raise ValueError("data_partition='node' currently supports a single dataset repo_id.")
 
         # HACK: We parse again the cli args here to get the pretrained paths if there was some.
         policy_path = parser.get_path_arg("policy")

--- a/src/lerobot/datasets/__init__.py
+++ b/src/lerobot/datasets/__init__.py
@@ -48,6 +48,7 @@ from .language import (
 )
 from .lerobot_dataset import LeRobotDataset
 from .multi_dataset import MultiLeRobotDataset
+from .partition import partition_episodes
 from .pipeline_features import aggregate_pipeline_dataset_features, create_initial_features
 from .pyav_utils import check_video_encoder_parameters_pyav, detect_available_encoders_pyav
 from .sampler import DeterministicEpisodeAwareSampler, EpisodeAwareSampler, compute_sampler_state
@@ -84,6 +85,7 @@ __all__ = [
     "convert_image_to_video_dataset",
     "create_initial_features",
     "compute_sampler_state",
+    "partition_episodes",
     "create_lerobot_dataset_card",
     "column_for_style",
     "delete_episodes",

--- a/src/lerobot/datasets/__init__.py
+++ b/src/lerobot/datasets/__init__.py
@@ -48,7 +48,7 @@ from .language import (
 )
 from .lerobot_dataset import LeRobotDataset
 from .multi_dataset import MultiLeRobotDataset
-from .partition import partition_episodes
+from .partition import group_episodes_by_files, partition_episodes
 from .pipeline_features import aggregate_pipeline_dataset_features, create_initial_features
 from .pyav_utils import check_video_encoder_parameters_pyav, detect_available_encoders_pyav
 from .sampler import DeterministicEpisodeAwareSampler, EpisodeAwareSampler, compute_sampler_state
@@ -85,6 +85,7 @@ __all__ = [
     "convert_image_to_video_dataset",
     "create_initial_features",
     "compute_sampler_state",
+    "group_episodes_by_files",
     "partition_episodes",
     "create_lerobot_dataset_card",
     "column_for_style",

--- a/src/lerobot/datasets/partition.py
+++ b/src/lerobot/datasets/partition.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+
+# Copyright 2024 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import heapq
+
+
+def partition_episodes(episode_lengths: list[int], num_partitions: int) -> list[list[int]]:
+    """Statically partition episodes into near-uniform bins by total frame count.
+
+    Uses the greedy Longest-Processing-Time rule: episodes are processed in descending
+    length and each is assigned to the currently least-loaded bin. The result is a pure
+    function of the inputs (ties broken by episode index and bin index), so every process
+    in a distributed run derives the identical assignment from metadata alone, with no
+    coordination.
+
+    Args:
+        episode_lengths: Number of frames of each episode. Position i is returned as
+            episode index i in the bins.
+        num_partitions: Number of bins to partition into.
+
+    Returns:
+        One sorted list of episode indices per bin. Every episode appears in exactly
+        one bin and every bin receives at least one episode.
+
+    Raises:
+        ValueError: If `num_partitions < 1`, fewer episodes than partitions, or any
+            episode has a non-positive length.
+    """
+    if num_partitions < 1:
+        raise ValueError(f"num_partitions must be >= 1, got {num_partitions}")
+    if len(episode_lengths) < num_partitions:
+        raise ValueError(
+            f"Cannot partition {len(episode_lengths)} episodes into {num_partitions} bins: "
+            "every bin needs at least one episode."
+        )
+    if any(length <= 0 for length in episode_lengths):
+        raise ValueError("All episode lengths must be > 0.")
+
+    # (load, bin_index) heap: ties on load resolve to the lowest bin index.
+    heap = [(0, bin_idx) for bin_idx in range(num_partitions)]
+    bins: list[list[int]] = [[] for _ in range(num_partitions)]
+    by_length_desc = sorted(range(len(episode_lengths)), key=lambda i: (-episode_lengths[i], i))
+    for episode_idx in by_length_desc:
+        load, bin_idx = heapq.heappop(heap)
+        bins[bin_idx].append(episode_idx)
+        heapq.heappush(heap, (load + episode_lengths[episode_idx], bin_idx))
+
+    return [sorted(bin_episodes) for bin_episodes in bins]

--- a/src/lerobot/datasets/partition.py
+++ b/src/lerobot/datasets/partition.py
@@ -14,6 +14,46 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import heapq
+from collections import defaultdict
+from collections.abc import Hashable, Sequence
+
+
+def group_episodes_by_files(episode_file_ids: list[Sequence[Hashable]]) -> list[list[int]]:
+    """Group episodes into connected components of shared storage files.
+
+    LeRobot v3 packs many episodes into shared parquet and video files, so a partition
+    only reduces per-node downloads if episodes that live in the same file are assigned
+    to the same bin. This computes the connected components induced by "shares a file
+    with" (union-find), which the partitioner can then treat as indivisible units.
+
+    Args:
+        episode_file_ids: For each episode, the hashable identifiers of every storage
+            file it touches (e.g. data parquet + one video file per camera).
+
+    Returns:
+        Groups of episode indices, each sorted, ordered by their smallest episode.
+        Two episodes are in the same group iff they are connected through shared files.
+    """
+    parent = list(range(len(episode_file_ids)))
+
+    def find(episode: int) -> int:
+        while parent[episode] != episode:
+            parent[episode] = parent[parent[episode]]
+            episode = parent[episode]
+        return episode
+
+    file_owner: dict[Hashable, int] = {}
+    for episode, file_ids in enumerate(episode_file_ids):
+        for file_id in file_ids:
+            if file_id in file_owner:
+                parent[find(episode)] = find(file_owner[file_id])
+            else:
+                file_owner[file_id] = episode
+
+    groups: dict[int, list[int]] = defaultdict(list)
+    for episode in range(len(episode_file_ids)):
+        groups[find(episode)].append(episode)
+    return sorted((sorted(group) for group in groups.values()), key=lambda group: group[0])
 
 
 def partition_episodes(episode_lengths: list[int], num_partitions: int) -> list[list[int]]:

--- a/src/lerobot/datasets/sampler.py
+++ b/src/lerobot/datasets/sampler.py
@@ -129,6 +129,12 @@ class DeterministicEpisodeAwareSampler:
     yield different permutations without requiring `set_epoch` calls. During an epoch resumed
     via `load_state_dict`, `__len__` still reports the full epoch length; the first pass simply
     yields fewer samples.
+
+    With `shard_rank`/`shard_world_size`, the sampler itself shards the (shared) permutation:
+    shard r yields positions r, r + world, r + 2 * world, ... — disjoint across shards by
+    construction, with no accelerate-level batch sharding (and therefore no `even_batches`
+    padding) needed. `__len__`, `start_index` and `compute_sampler_state` (with
+    `num_processes=1`) then all live in shard-local positions.
     """
 
     def __init__(
@@ -140,6 +146,8 @@ class DeterministicEpisodeAwareSampler:
         drop_n_last_frames: int = 0,
         shuffle: bool = True,
         seed: int = 0,
+        shard_rank: int = 0,
+        shard_world_size: int = 1,
     ):
         """
         Args:
@@ -150,8 +158,15 @@ class DeterministicEpisodeAwareSampler:
             drop_n_first_frames: Number of frames to drop from the start of each episode.
             drop_n_last_frames: Number of frames to drop from the end of each episode.
             shuffle: Whether to shuffle with the seeded Feistel permutation.
-            seed: Seed the permutation is derived from (together with the epoch).
+            seed: Seed the permutation is derived from (together with the epoch). Must be
+                  identical on all shards of the same data for shards to stay disjoint.
+            shard_rank: This sampler's shard of the permutation (e.g. the local process index).
+            shard_world_size: Total number of shards (e.g. processes sharing this dataset).
         """
+        if not 0 <= shard_rank < shard_world_size:
+            raise ValueError(
+                f"shard_rank must be in [0, shard_world_size), got {shard_rank=} {shard_world_size=}"
+            )
         if drop_n_first_frames < 0:
             raise ValueError(f"drop_n_first_frames must be >= 0, got {drop_n_first_frames}")
         if drop_n_last_frames < 0:
@@ -191,6 +206,15 @@ class DeterministicEpisodeAwareSampler:
         self._starts = starts[used]
         self._cum_lengths = np.cumsum(lengths[used])
         self._num_frames = int(self._cum_lengths[-1])
+        if self._num_frames < shard_world_size:
+            raise ValueError(
+                f"Cannot shard {self._num_frames} frames across {shard_world_size} processes: "
+                "every shard needs at least one frame."
+            )
+        self._shard_rank = shard_rank
+        self._shard_world_size = shard_world_size
+        # Positions shard_rank, shard_rank + world, ... that are < num_frames.
+        self._shard_len = (self._num_frames - shard_rank + shard_world_size - 1) // shard_world_size
         self.shuffle = shuffle
         self.seed = seed
         self._epoch = 0
@@ -247,11 +271,12 @@ class DeterministicEpisodeAwareSampler:
 
     def _iter_epoch(self, epoch: int, start: int) -> Iterator[int]:
         keys = self._round_keys(epoch) if self.shuffle else None
-        for k in range(start, self._num_frames):
+        for local_k in range(start, self._shard_len):
+            k = self._shard_rank + local_k * self._shard_world_size
             yield self._frame_index(self._permute(k, keys) if self.shuffle else k)
 
     def __len__(self) -> int:
-        return self._num_frames
+        return self._shard_len
 
 
 def compute_sampler_state(step: int, num_frames: int, batch_size: int, num_processes: int) -> dict:

--- a/src/lerobot/scripts/lerobot_train.py
+++ b/src/lerobot/scripts/lerobot_train.py
@@ -20,6 +20,7 @@ Requires: pip install 'lerobot[training]'  (includes dataset + accelerate + wand
 
 import dataclasses
 import logging
+import os
 import time
 from contextlib import nullcontext
 from pprint import pformat
@@ -46,8 +47,10 @@ from lerobot.configs.train import TrainPipelineConfig
 from lerobot.datasets import (
     DeterministicEpisodeAwareSampler,
     EpisodeAwareSampler,
+    LeRobotDatasetMetadata,
     compute_sampler_state,
     make_dataset,
+    partition_episodes,
 )
 from lerobot.envs import close_envs, make_env, make_env_pre_post_processors
 from lerobot.optim.factory import make_optimizer_and_scheduler
@@ -166,6 +169,54 @@ def update_policy(
     return train_metrics, output_dict
 
 
+def node_topology(accelerator: "Accelerator") -> tuple[int, int, int]:
+    """Return (num_nodes, node_index, local_world_size) of the current distributed run.
+
+    Relies on LOCAL_WORLD_SIZE, which torchrun (and therefore `accelerate launch`) sets on every
+    process; when absent, all processes are assumed to live on a single node.
+    """
+    local_world_size = int(os.environ.get("LOCAL_WORLD_SIZE", accelerator.num_processes))
+    if accelerator.num_processes % local_world_size != 0:
+        raise RuntimeError(
+            f"Total processes ({accelerator.num_processes}) is not a multiple of "
+            f"LOCAL_WORLD_SIZE ({local_world_size}); cannot derive the node topology."
+        )
+    return (
+        accelerator.num_processes // local_world_size,
+        accelerator.process_index // local_world_size,
+        local_world_size,
+    )
+
+
+def make_node_dataset(cfg: TrainPipelineConfig, accelerator: "Accelerator"):
+    """`make_dataset` restricted to this node's statically-assigned share of episodes.
+
+    All processes derive the identical partition from metadata alone (greedy LPT on frame
+    counts), so each node downloads and stores only its near-uniform share of the data.
+    """
+    import copy
+
+    num_nodes, node_index, _ = node_topology(accelerator)
+    meta = LeRobotDatasetMetadata(cfg.dataset.repo_id, root=cfg.dataset.root, revision=cfg.dataset.revision)
+    episodes = list(cfg.dataset.episodes) if cfg.dataset.episodes is not None else None
+    if episodes is None:
+        episodes = list(range(meta.total_episodes))
+    from_indices = meta.episodes["dataset_from_index"]
+    to_indices = meta.episodes["dataset_to_index"]
+    lengths = [to_indices[ep] - from_indices[ep] for ep in episodes]
+    bins = partition_episodes(lengths, num_nodes)
+    node_episodes = [episodes[i] for i in bins[node_index]]
+    logging.info(
+        f"Data partition: node {node_index}/{num_nodes} gets {len(node_episodes)}/{len(episodes)} "
+        f"episodes ({sum(lengths[i] for i in bins[node_index])}/{sum(lengths)} frames)"
+    )
+    # Shallow-copy the pipeline config so the node-local episode subset is never persisted to
+    # checkpoints: a resumed run must recompute its own node's share.
+    node_cfg = copy.copy(cfg)
+    node_cfg.dataset = dataclasses.replace(cfg.dataset, episodes=node_episodes)
+    return make_dataset(node_cfg)
+
+
 @parser.wrap()
 def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
     """
@@ -240,16 +291,17 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
     # Dataset loading synchronization: each node's local main process downloads first to avoid
     # race conditions (the global main process only exists on node 0, so gating on it would let
     # all ranks of the other nodes download and build the Arrow cache concurrently).
+    create_dataset = make_node_dataset if cfg.data_partition == "node" else lambda c, _: make_dataset(c)
     if accelerator.is_local_main_process:
         if is_main_process:
             logging.info("Creating dataset")
-        dataset = make_dataset(cfg)
+        dataset = create_dataset(cfg, accelerator)
 
     accelerator.wait_for_everyone()
 
     # Now all other processes can safely load the dataset from the local cache
     if not accelerator.is_local_main_process:
-        dataset = make_dataset(cfg)
+        dataset = create_dataset(cfg, accelerator)
 
     # Create environment used for evaluating checkpoints during training on simulation data.
     # On real-world data, no need to create an environment as evaluations are done outside train.py,
@@ -392,7 +444,36 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
         logging.info(f"{num_total_params=} ({format_big_number(num_total_params)})")
 
     # create dataloader for offline training
-    if cfg.deterministic_sampler:
+    if cfg.data_partition == "node":
+        # Each node trains on its own statically-assigned episode share; the local ranks shard
+        # the node-local permutation arithmetically inside the sampler, so the dataloader is NOT
+        # prepared with accelerate (no batch-level sharding needed). Every rank's stream is an
+        # independent pure function of (seed, epoch, shard), giving sample-exact resume per rank.
+        shuffle = False
+        num_nodes, node_index, local_world_size = node_topology(accelerator)
+        sampler = DeterministicEpisodeAwareSampler(
+            dataset.meta.episodes["dataset_from_index"],
+            dataset.meta.episodes["dataset_to_index"],
+            episode_indices_to_use=dataset.episodes,
+            drop_n_last_frames=getattr(active_cfg, "drop_n_last_frames", 0),
+            shuffle=True,
+            seed=(cfg.seed if cfg.seed is not None else 0) + node_index,
+            shard_rank=accelerator.local_process_index,
+            shard_world_size=local_world_size,
+        )
+        if cfg.resume and step > 0:
+            # Each rank's shard is an independent stream: one step consumes batch_size
+            # shard-local positions, hence num_processes=1 in the state arithmetic.
+            sampler_state = compute_sampler_state(step, len(sampler), cfg.batch_size, num_processes=1)
+            sampler.load_state_dict(sampler_state)
+            logging.info(
+                f"Resuming data order at epoch {sampler_state['epoch']}, "
+                f"shard-local sample {sampler_state['start_index']} "
+                f"(node {node_index}, local rank {accelerator.local_process_index}). "
+                "Sample-exact resume requires the same topology as the interrupted run "
+                f"({num_nodes} nodes x {local_world_size} processes)."
+            )
+    elif cfg.deterministic_sampler:
         # Data order is a pure function of (seed, epoch): nothing to synchronize across ranks,
         # O(1) memory in dataset size, and a resumed run continues at the exact sample where the
         # checkpoint left off (up to accelerate's even_batches padding at epoch boundaries).
@@ -454,9 +535,14 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
 
     # Prepare everything with accelerator
     accelerator.wait_for_everyone()
-    policy, optimizer, dataloader, lr_scheduler = accelerator.prepare(
-        policy, optimizer, dataloader, lr_scheduler
-    )
+    if cfg.data_partition == "node":
+        # The dataloader stays unprepared: sharding lives in the sampler and the policy
+        # preprocessor pipeline (DeviceProcessorStep) moves batches to the right device.
+        policy, optimizer, lr_scheduler = accelerator.prepare(policy, optimizer, lr_scheduler)
+    else:
+        policy, optimizer, dataloader, lr_scheduler = accelerator.prepare(
+            policy, optimizer, dataloader, lr_scheduler
+        )
     dl_iter = cycle(dataloader)
 
     policy.train()
@@ -470,11 +556,16 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
     }
 
     # Keep global batch size for logging; MetricsTracker handles world size internally.
+    # Under node partitioning, dataset.num_frames is node-local, so report global totals.
     effective_batch_size = cfg.batch_size * accelerator.num_processes
+    tracker_num_frames = dataset.meta.total_frames if cfg.data_partition == "node" else dataset.num_frames
+    tracker_num_episodes = (
+        dataset.meta.total_episodes if cfg.data_partition == "node" else dataset.num_episodes
+    )
     train_tracker = MetricsTracker(
         cfg.batch_size,
-        dataset.num_frames,
-        dataset.num_episodes,
+        tracker_num_frames,
+        tracker_num_episodes,
         train_metrics,
         initial_step=step,
         accelerator=accelerator,

--- a/src/lerobot/scripts/lerobot_train.py
+++ b/src/lerobot/scripts/lerobot_train.py
@@ -49,6 +49,7 @@ from lerobot.datasets import (
     EpisodeAwareSampler,
     LeRobotDatasetMetadata,
     compute_sampler_state,
+    group_episodes_by_files,
     make_dataset,
     partition_episodes,
 )
@@ -191,8 +192,12 @@ def node_topology(accelerator: "Accelerator") -> tuple[int, int, int]:
 def make_node_dataset(cfg: TrainPipelineConfig, accelerator: "Accelerator"):
     """`make_dataset` restricted to this node's statically-assigned share of episodes.
 
-    All processes derive the identical partition from metadata alone (greedy LPT on frame
-    counts), so each node downloads and stores only its near-uniform share of the data.
+    All processes derive the identical partition from metadata alone, so each node downloads
+    and stores only its near-uniform share of the data. Because LeRobot v3 packs many episodes
+    into shared parquet/video files, the partition unit is a *file group* (connected component
+    of episodes sharing a storage file), not a raw episode: partitioning episodes individually
+    would scatter them across files and every node would download nearly all files anyway.
+    Greedy LPT on frame counts balances the groups across nodes.
     """
     import copy
 
@@ -204,11 +209,36 @@ def make_node_dataset(cfg: TrainPipelineConfig, accelerator: "Accelerator"):
     from_indices = meta.episodes["dataset_from_index"]
     to_indices = meta.episodes["dataset_to_index"]
     lengths = [to_indices[ep] - from_indices[ep] for ep in episodes]
-    bins = partition_episodes(lengths, num_nodes)
-    node_episodes = [episodes[i] for i in bins[node_index]]
+
+    data_chunk_indices = meta.episodes["data/chunk_index"]
+    data_file_indices = meta.episodes["data/file_index"]
+    video_file_columns = {
+        key: (meta.episodes[f"videos/{key}/chunk_index"], meta.episodes[f"videos/{key}/file_index"])
+        for key in meta.video_keys
+    }
+    episode_file_ids = [
+        [("data", data_chunk_indices[ep], data_file_indices[ep])]
+        + [
+            (key, chunk_indices[ep], file_indices[ep])
+            for key, (chunk_indices, file_indices) in video_file_columns.items()
+        ]
+        for ep in episodes
+    ]
+    groups = group_episodes_by_files(episode_file_ids)
+    if len(groups) < num_nodes:
+        logging.warning(
+            f"Only {len(groups)} file groups for {num_nodes} nodes: falling back to "
+            "episode-granularity partitioning. Training stays correct, but nodes will download "
+            "overlapping files, so the per-node disk savings are limited."
+        )
+        groups = [[i] for i in range(len(episodes))]
+    group_lengths = [sum(lengths[i] for i in group) for group in groups]
+    bins = partition_episodes(group_lengths, num_nodes)
+    node_episodes = sorted(episodes[i] for group_idx in bins[node_index] for i in groups[group_idx])
     logging.info(
         f"Data partition: node {node_index}/{num_nodes} gets {len(node_episodes)}/{len(episodes)} "
-        f"episodes ({sum(lengths[i] for i in bins[node_index])}/{sum(lengths)} frames)"
+        f"episodes in {len(bins[node_index])}/{len(groups)} file groups "
+        f"({sum(group_lengths[i] for i in bins[node_index])}/{sum(lengths)} frames)"
     )
     # Shallow-copy the pipeline config so the node-local episode subset is never persisted to
     # checkpoints: a resumed run must recompute its own node's share.

--- a/tests/datasets/test_partition.py
+++ b/tests/datasets/test_partition.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+
+# Copyright 2024 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import pytest
+
+from lerobot.datasets.partition import partition_episodes
+
+
+def test_partition_covers_every_episode_exactly_once():
+    lengths = [50, 30, 20, 40, 10, 60, 25, 35]
+    bins = partition_episodes(lengths, num_partitions=3)
+    assert len(bins) == 3
+    assigned = sorted(idx for bin_episodes in bins for idx in bin_episodes)
+    assert assigned == list(range(len(lengths)))
+    assert all(len(bin_episodes) > 0 for bin_episodes in bins)
+
+
+def test_partition_is_load_balanced():
+    lengths = [50, 30, 20, 40, 10, 60, 25, 35]
+    bins = partition_episodes(lengths, num_partitions=3)
+    loads = [sum(lengths[i] for i in bin_episodes) for bin_episodes in bins]
+    # LPT guarantees max load <= (4/3 - 1/(3m)) * optimum; for this input the bound means
+    # the spread can never exceed the largest episode.
+    assert max(loads) - min(loads) <= max(lengths)
+
+
+def test_partition_is_deterministic():
+    lengths = [7, 7, 7, 3, 3, 9, 1, 5]
+    assert partition_episodes(lengths, 3) == partition_episodes(lengths, 3)
+
+
+def test_partition_single_bin_returns_all():
+    assert partition_episodes([5, 1, 3], 1) == [[0, 1, 2]]
+
+
+def test_partition_validation():
+    with pytest.raises(ValueError, match="num_partitions must be >= 1"):
+        partition_episodes([1, 2, 3], 0)
+    with pytest.raises(ValueError, match="every bin needs at least one episode"):
+        partition_episodes([1, 2], 3)
+    with pytest.raises(ValueError, match="must be > 0"):
+        partition_episodes([1, 0, 2], 2)
+
+
+def test_partition_skewed_lengths():
+    # One giant episode should sit alone in its bin while the small ones share the other.
+    lengths = [1000, 1, 1, 1, 1]
+    bins = partition_episodes(lengths, 2)
+    assert [0] in bins
+    other = bins[0] if bins[1] == [0] else bins[1]
+    assert sorted(other) == [1, 2, 3, 4]

--- a/tests/datasets/test_partition.py
+++ b/tests/datasets/test_partition.py
@@ -61,3 +61,59 @@ def test_partition_skewed_lengths():
     assert [0] in bins
     other = bins[0] if bins[1] == [0] else bins[1]
     assert sorted(other) == [1, 2, 3, 4]
+
+
+# --- file-group partitioning ---
+
+from lerobot.datasets.partition import group_episodes_by_files  # noqa: E402
+
+
+def test_group_episodes_by_files_shared_data_file():
+    # episodes 0-1 share a parquet, 2-3 share another; videos align
+    file_ids = [
+        [("data", 0, 0), ("cam", 0, 0)],
+        [("data", 0, 0), ("cam", 0, 0)],
+        [("data", 0, 1), ("cam", 0, 1)],
+        [("data", 0, 1), ("cam", 0, 1)],
+    ]
+    assert group_episodes_by_files(file_ids) == [[0, 1], [2, 3]]
+
+
+def test_group_episodes_by_files_chained_by_video():
+    # data files split episodes 0-1 / 2-3, but one video file spans episodes 1-2,
+    # chaining everything into a single component.
+    file_ids = [
+        [("data", 0, 0), ("cam", 0, 0)],
+        [("data", 0, 0), ("cam", 0, 1)],
+        [("data", 0, 1), ("cam", 0, 1)],
+        [("data", 0, 1), ("cam", 0, 2)],
+    ]
+    assert group_episodes_by_files(file_ids) == [[0, 1, 2, 3]]
+
+
+def test_group_episodes_by_files_independent_episodes():
+    file_ids = [[("data", 0, i)] for i in range(4)]
+    assert group_episodes_by_files(file_ids) == [[0], [1], [2], [3]]
+
+
+def test_partition_over_file_groups_is_file_disjoint():
+    # 6 episodes; data and video file boundaries both fall between episodes 2 and 3:
+    # components are {0,1,2} and {3,4,5}; partitioning the groups into 2 bins must
+    # never split a file across bins.
+    file_ids = [
+        [("data", 0, 0), ("cam", 0, 0)],
+        [("data", 0, 0), ("cam", 0, 0)],
+        [("data", 0, 1), ("cam", 0, 0)],
+        [("data", 0, 2), ("cam", 0, 1)],
+        [("data", 0, 2), ("cam", 0, 1)],
+        [("data", 0, 3), ("cam", 0, 1)],
+    ]
+    lengths = [10, 12, 8, 11, 9, 10]
+    groups = group_episodes_by_files(file_ids)
+    assert groups == [[0, 1, 2], [3, 4, 5]]
+    bins = partition_episodes([sum(lengths[i] for i in g) for g in groups], 2)
+    files_per_bin = [
+        {fid for group_idx in bin_groups for ep in groups[group_idx] for fid in file_ids[ep]}
+        for bin_groups in bins
+    ]
+    assert files_per_bin[0].isdisjoint(files_per_bin[1])

--- a/tests/datasets/test_sampler.py
+++ b/tests/datasets/test_sampler.py
@@ -267,3 +267,76 @@ def test_compute_sampler_state():
         "epoch": 1,
         "start_index": 100,
     }
+
+
+# --- internal sharding (data_partition="node" path) ---
+
+
+def test_sharded_samplers_are_disjoint_and_cover_epoch():
+    num_frames, world = 13, 4
+    unsharded = DeterministicEpisodeAwareSampler([0], [num_frames], shuffle=True, seed=42)
+    full_epoch = list(unsharded)
+    shards = [
+        list(
+            DeterministicEpisodeAwareSampler(
+                [0], [num_frames], shuffle=True, seed=42, shard_rank=r, shard_world_size=world
+            )
+        )
+        for r in range(world)
+    ]
+    # every shard is the strided slice of the shared permutation
+    for r, shard in enumerate(shards):
+        assert shard == full_epoch[r::world]
+    # disjoint and complete
+    combined = [idx for shard in shards for idx in shard]
+    assert sorted(combined) == sorted(full_epoch)
+    assert sum(len(s) for s in shards) == num_frames
+    # __len__ reports the shard-local length
+    sampler = DeterministicEpisodeAwareSampler(
+        [0], [num_frames], shuffle=True, seed=42, shard_rank=1, shard_world_size=world
+    )
+    assert len(sampler) == len(full_epoch[1::world])
+
+
+def test_sharded_sampler_resume_is_shard_local():
+    kwargs = {"shuffle": True, "seed": 7, "shard_rank": 1, "shard_world_size": 3}
+    reference = DeterministicEpisodeAwareSampler(*EPISODE_BOUNDS, **kwargs)
+    epoch_0 = list(reference)
+    epoch_1 = list(reference)
+    resumed = DeterministicEpisodeAwareSampler(*EPISODE_BOUNDS, **kwargs)
+    resumed.load_state_dict({"epoch": 0, "start_index": 1})
+    assert list(resumed) == epoch_0[1:]
+    assert list(resumed) == epoch_1
+
+
+def test_sharded_sampler_validation():
+    with pytest.raises(ValueError, match="shard_rank must be in"):
+        DeterministicEpisodeAwareSampler([0], [10], shard_rank=2, shard_world_size=2)
+    with pytest.raises(ValueError, match="shard_rank must be in"):
+        DeterministicEpisodeAwareSampler([0], [10], shard_rank=-1, shard_world_size=2)
+    with pytest.raises(ValueError, match="every shard needs at least one frame"):
+        DeterministicEpisodeAwareSampler([0], [3], shard_rank=0, shard_world_size=4)
+
+
+def test_node_partition_end_to_end_coverage():
+    # Simulate 2 nodes x 2 local ranks over 5 episodes: union of all four rank streams
+    # must cover every frame exactly once per (node-)epoch.
+    from lerobot.datasets.partition import partition_episodes
+
+    from_indices, to_indices = [0, 5, 8, 10, 14], [5, 8, 10, 14, 15]
+    lengths = [t - f for f, t in zip(from_indices, to_indices, strict=True)]
+    bins = partition_episodes(lengths, num_partitions=2)
+    seen = []
+    for node_index, node_episodes in enumerate(bins):
+        for local_rank in range(2):
+            sampler = DeterministicEpisodeAwareSampler(
+                from_indices,
+                to_indices,
+                episode_indices_to_use=node_episodes,
+                shuffle=True,
+                seed=1000 + node_index,
+                shard_rank=local_rank,
+                shard_world_size=2,
+            )
+            seen.extend(sampler)
+    assert sorted(seen) == list(range(15))


### PR DESCRIPTION
## Summary / Motivation

Today every node in a multi-node run downloads and stores the **full** dataset: a 50 TB dataset costs ~50 TB of disk *per node* (~400 TB across 8 nodes) plus a full warmup on every node.

This PR adds static data partitioning, the strategy used by large-scale robot-learning systems (e.g. InternVLA-A1's LPT: Load-balanced Parallel Training): each node is statically assigned a near-uniform share of the data and only ever fetches that share. It is opt-in via `--data_partition=node` (default `"none"`, existing behavior untouched).

> **Stacked on #3769** (`feat/deterministic-sampler`). That PR makes `EpisodeAwareSampler` always deterministic: each epoch is a `torch.randperm` seeded from `(seed, epoch)`, so the data order is a pure function of `(seed, epoch)` with no cross-rank RNG sync and sample-exact resume. This PR builds the node-level sharding directly on that single, always-deterministic path — there is no separate `deterministic` flag or `deterministic_sampler` config field anymore. The branch has been merged up to the latest base, so this PR's diff is just the partitioning feature on top.

## This branch vs `main`

Example: a **50 TB** dataset on **8 nodes** (1 GPU/process per node for simplicity).

| | `main` (`data_partition="none"`) | this branch (`data_partition="node"`) |
|---|---|---|
| Bytes downloaded **per node** | ~50 TB (full dataset) | ~50 TB / 8 ≈ **6.25 TB** (its share of the video files) |
| Aggregate bytes pulled from the Hub | ~400 TB (8 × full) | ~50 TB (each file fetched once) + a negligible parquet overlap |
| Warmup / Arrow cache build per node | full dataset | only the node's share |
| Sharding across ranks | accelerate batch-level sharding over **all** ranks | each node owns disjoint data; local ranks shard the node-local stream arithmetically inside the sampler |
| Cross-node data mixing | every rank sees every sample | mixing happens only through gradient averaging (a frame lives on one node for the whole run) |

## What changed

- New `lerobot/datasets/partition.py`:
  - `group_episodes_by_files(...)`: union-find over episode→file membership, grouping episodes into connected components of shared storage files. **Only video files define the groups** — video is ~98–99% of dataset bytes, while a single parquet packs ~100× more episodes than a video file, so including parquet membership would chain almost everything into one giant component on well-consolidated datasets. Parquet files that span two nodes' episodes are simply downloaded by both (a ~1%-of-bytes overlap). Datasets without video keys fall back to grouping by parquet files.
  - `partition_episodes(group_lengths, num_partitions)`: greedy Longest-Processing-Time bin-packing on frame counts.
- `--data_partition=node` in `TrainPipelineConfig`. When enabled:
  - Each node's local main process resolves the partition from `LeRobotDatasetMetadata` and `make_dataset` runs with only that node's episodes (partial Hub download via the existing `episodes=` path). The partition unit is the **video-file group**, so per-node *video* downloads are disjoint by construction. Node topology is derived from `LOCAL_WORLD_SIZE` (set by torchrun / `accelerate launch`), falling back to single-node.
  - When there are fewer file groups than nodes (e.g. a tiny dataset in one file), it falls back to episode-granularity partitioning with an explicit warning that disk savings will be limited.
  - `EpisodeAwareSampler` gains `shard_rank`/`shard_world_size`: local ranks take strided, provably disjoint slices of the shared node-local permutation (shard r yields positions r, r+world, r+2·world, …). Because the permutation is a pure function of `(seed, epoch)`, every shard regenerates the identical order and the strided slices tile it exactly — no accelerate batch sharding involved, so the dataloader is left unprepared and the policy preprocessor (`DeviceProcessorStep`) handles device placement.
  - Resume restores each rank's exact stream position (`compute_sampler_state` with `num_processes=1`, since each rank's shard is an independent stream). The resume log states the topology requirement explicitly: sample-exactness requires resuming with the same number of nodes and processes. (The non-partitioned accelerate path inherits #3769's behavior of recording `num_processes` *and* `batch_size` in the checkpoint and warning on a mismatch.)
  - The node-local episode subset is never written to checkpoints — `train_config.json` keeps the user's original episode selection and a resumed run recomputes its node's share (verified in the E2E test below).
  - MetricsTracker reports global frame/episode totals rather than node-local ones.
- Guard rails: clear `ValueError`s for `dataset.streaming`, `sample_weighting`, and multi-dataset `repo_id` lists; sharding more processes than frames also errors.
- DDP liveness: LeRobot trains by steps over `cycle(dataloader)`, so uneven per-node data sizes can never starve the gradient all-reduce — every rank always produces a batch. The LPT balance matters for sampling statistics, not liveness.

## How was this tested (or how to run locally)

- `pytest -q tests/datasets/test_partition.py tests/datasets/test_sampler.py` → **37 passed** after merging the latest base. Coverage: partition coverage / disjointness / determinism / balance bound / validation; file-group connected components (incl. video chaining and the realistic "one parquet spans everything, video-only stays in 3 clean groups" layout) and a file-disjointness assertion over the resulting bins; shard streams equal the strided slices of the shared permutation, are disjoint, and their union covers the epoch; shard-local resume; and a 2-nodes × 2-ranks simulation where the four rank streams cover every frame exactly once.
- E2E (single process, `lerobot/pusht`): `--data_partition=node` trains, checkpoints, and resumes with `Resuming data order at epoch 0, shard-local sample 4 (node 0, local rank 0)`; the checkpoint config retains the user's `episodes=[0,1]`, not the node subset.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`) — all hooks pass on changed files (incl. strict mypy for `lerobot.configs`)
- [x] All tests pass locally (`pytest`)
- [ ] Documentation updated (config comment + docstrings; happy to add a docs page on multi-node training if wanted)
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: #
