### PR TITLE
fix(molmoact2): fix to enable training on datasets with state vector len of 1

### DIFF
--- a/src/lerobot/policies/molmoact2/processor_molmoact2.py
+++ b/src/lerobot/policies/molmoact2/processor_molmoact2.py
@@ -793,7 +793,13 @@ class MolmoAct2PackInputsProcessorStep(ProcessorStep):
             raise ValueError("MolmoAct2 requires observation.state for discrete state prompting.")
         state = torch.as_tensor(observation[OBS_STATE], dtype=torch.float32)
         if state.ndim == 1:
-            state = state.unsqueeze(0)
+            # Shape-(1,) state features are stored as scalars, so a batch of them
+            # collates to (batch_size,) rather than (batch_size, 1).
+            state = state.unsqueeze(-1) if int(state.shape[0]) == batch_size else state.unsqueeze(0)
+        elif state.ndim == 2 and state.shape[0] == 1 and int(state.shape[1]) == batch_size and batch_size > 1:
+            # AddBatchDimensionObservationStep misreads a (batch_size,) scalar-state
+            # batch as one sample and unsqueezes it to (1, batch_size).
+            state = state.transpose(0, 1)
         if int(state.shape[0]) != batch_size:
             raise ValueError(f"State batch size {state.shape[0]} does not match batch size {batch_size}.")
         return state

--- a/tests/policies/molmoact2/test_molmoact2.py
+++ b/tests/policies/molmoact2/test_molmoact2.py
@@ -368,6 +368,38 @@ def test_molmoact2_explicit_image_keys_stay_strict():
         step._resolve_image_keys(observation)
 
 
+def test_molmoact2_extract_state_unsqueezes_single_sample():
+    step = object.__new__(MolmoAct2PackInputsProcessorStep)
+    state = torch.tensor([1.0, 2.0, 3.0])
+
+    extracted = step._extract_state({OBS_STATE: state}, batch_size=1)
+
+    assert extracted.shape == (1, 3)
+    assert torch.equal(extracted[0], state)
+
+
+def test_molmoact2_extract_state_handles_batch_of_scalar_states():
+    # Shape-(1,) state features are stored as scalars, so a batch collates to (B,).
+    step = object.__new__(MolmoAct2PackInputsProcessorStep)
+    state = torch.tensor([1.0, 2.0, 3.0, 4.0])
+
+    extracted = step._extract_state({OBS_STATE: state}, batch_size=4)
+
+    assert extracted.shape == (4, 1)
+    assert torch.equal(extracted.squeeze(-1), state)
+
+
+def test_molmoact2_extract_state_handles_scalar_batch_misread_as_single_sample():
+    # AddBatchDimensionObservationStep turns a (B,) batch of scalar states into (1, B).
+    step = object.__new__(MolmoAct2PackInputsProcessorStep)
+    state = torch.tensor([[1.0, 2.0, 3.0, 4.0]])
+
+    extracted = step._extract_state({OBS_STATE: state}, batch_size=4)
+
+    assert extracted.shape == (4, 1)
+    assert torch.equal(extracted.squeeze(-1), state.squeeze(0))
+
+
 def test_enable_lora_vlm_builds_policy_local_peft_config():
     pytest.importorskip("peft")
     policy_cfg = MolmoAct2Config(


### PR DESCRIPTION
## Summary / Motivation

I meantioned I can't train molmoact on my dataset with single value in state vector (example: https://huggingface.co/datasets/Grigorij/Tello_multifruit_sum). That fix allown me to do it.

## What changed

Datasets store shape-(1,) state features as scalars, so a training batch collates to shape (batch_size,) and AddBatchDimensionObservationStep then unsqueezes it to (1, batch_size), making _extract_state fail with 'State batch size 1 does not match batch size N'. Disambiguate 1-D states against the known batch size and transpose the (1, batch_size) misread.


## How was this tested (or how to run locally)

I run training now and it goes. Plus linting/pytest passes.

## Checklist (required before merge)

- [*] Linting/formatting run (`pre-commit run -a`)
- [*] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: # (insert PR number/link)