### PR TITLE
fix: pin transformers version range in setup.py (closes #3776)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,4 +69,7 @@ def read_long_description() -> str:
 setup(
     long_description=read_long_description(),
     long_description_content_type="text/markdown",
+    install_requires=[
+        "transformers>=4.49,<6",
+    ],
 )


### PR DESCRIPTION
## What
Currently, `transformers` is not pinned in setup.py, so users get whatever version pip resolves (e.g., 5.11.0). This causes API drift and breakage when transformers introduces breaking changes (e.g., SiglipVisionModel attribute layout).

## Fix
Added an explicit version range `transformers>=4.49,<6` in setup.py to prevent major-version surprises while staying compatible with the range exercised by CI.

Closes #3776