### PR TITLE
fix(groot): raise actionable error when transformers is too old for @strict

### DIFF
--- a/src/lerobot/policies/groot/groot_n1.py
+++ b/src/lerobot/policies/groot/groot_n1.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from dataclasses import is_dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -22,7 +23,7 @@ import torch.nn as nn
 from huggingface_hub import snapshot_download
 from huggingface_hub.errors import HFValidationError, RepositoryNotFoundError
 
-from lerobot.utils.import_utils import _transformers_available
+from lerobot.utils.import_utils import _transformers_available, is_package_available
 
 # Conditional import for type checking and lazy loading
 if TYPE_CHECKING or _transformers_available:
@@ -175,6 +176,27 @@ ACTION_KEY = "action_pred"
 LOSS_KEY = "loss"
 ERROR_MSG = "Error: unexpected input/output"
 N_COLOR_CHANNELS = 3
+
+
+def _ensure_strict_compatible_config_base(config_base: type) -> None:
+    """Fail with an actionable error when `transformers` is too old for `@strict`.
+
+    `@strict` requires the decorated class to already be a dataclass, which is only true of
+    `transformers.PretrainedConfig` from v5.4.0 on. With an older version installed, defining
+    `GR00TN15Config` would otherwise fail at import time with a cryptic
+    `StrictDataclassDefinitionError` (see #3765 and #3775).
+    """
+    if config_base is object or is_dataclass(config_base):
+        return
+    _, version = is_package_available("transformers", return_version=True)
+    raise ImportError(
+        "The GR00T policy requires transformers>=5.4.0 (`PretrainedConfig` must be a dataclass), "
+        f"but transformers=={version} is installed. "
+        "Upgrade with `pip install 'transformers>=5.4.0,<5.6.0'` or `pip install 'lerobot[groot]'`."
+    )
+
+
+_ensure_strict_compatible_config_base(PretrainedConfig)
 
 
 # config

--- a/tests/policies/groot/test_transformers_compat.py
+++ b/tests/policies/groot/test_transformers_compat.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for #3765/#3775: importing the GR00T module with an incompatible
+`transformers` version must raise an actionable error instead of a cryptic
+`StrictDataclassDefinitionError`."""
+
+from dataclasses import dataclass
+
+import pytest
+
+from lerobot.policies.groot.groot_n1 import _ensure_strict_compatible_config_base
+
+
+def test_object_base_passes():
+    # `PretrainedConfig` falls back to `object` when transformers is not installed.
+    _ensure_strict_compatible_config_base(object)
+
+
+def test_dataclass_base_passes():
+    # transformers>=5.4.0 makes `PretrainedConfig` a dataclass.
+    @dataclass
+    class DataclassConfigBase:
+        pass
+
+    _ensure_strict_compatible_config_base(DataclassConfigBase)
+
+
+def test_non_dataclass_base_raises_actionable_error():
+    # transformers<5.4.0 ships a non-dataclass `PretrainedConfig`.
+    class LegacyConfigBase:
+        pass
+
+    with pytest.raises(ImportError, match=r"transformers>=5\.4\.0"):
+        _ensure_strict_compatible_config_base(LegacyConfigBase)


### PR DESCRIPTION
## Summary / Motivation

`@strict` requires the decorated class to already be a dataclass, but `transformers.PretrainedConfig` only became a dataclass in v5.4.0. With an older transformers installed (e.g. the `transformers==5.3.0` that the lerobot 0.5.1 release pins), defining `GR00TN15Config` crashes at import time with a cryptic `StrictDataclassDefinitionError` that gives the user no hint about the actual cause. This PR detects the incompatibility before the class definition and raises an `ImportError` naming the installed version and the supported range.

## Related issues

- Fixes: #3765
- Related: #3775

## What changed

- `groot_n1.py`: added `_ensure_strict_compatible_config_base()`, called before the `GR00TN15Config` definition. No-op when transformers is absent (`PretrainedConfig is object`) or `PretrainedConfig` is a dataclass (transformers >= 5.4.0); otherwise raises `ImportError: The GR00T policy requires transformers>=5.4.0 ... but transformers==5.3.0 is installed. Upgrade with ...`
- `tests/policies/groot/test_transformers_compat.py`: 3 regression tests for the helper (no GPU, no model downloads, CI-safe).
- No behavior change on supported transformers versions.

## How was this tested (or how to run locally)

- Reproduced the original crash on a clean py3.12 venv with `transformers==5.3.0`: `python -c "import lerobot.policies.groot.groot_n1"` → `StrictDataclassDefinitionError` before, actionable `ImportError` after.
- Verified no regression with `transformers==5.5.4`: module imports and `GR00TN15Config()` constructs as before.
- `pytest -q tests/policies/groot/test_transformers_compat.py` → 3 passed.
- `pre-commit run --files src/lerobot/policies/groot/groot_n1.py tests/policies/groot/test_transformers_compat.py` → all hooks pass (ruff, mypy, bandit, typos, pyupgrade).

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit` on changed files)
- [x] All tests pass locally (new tests + import smoke tests; full suite not run)
- [ ] Documentation updated (n/a — error-message-only change)
- [ ] CI is green
- [ ] Community Review: not yet

## Reviewer notes

Per the [AI policy](https://github.com/huggingface/lerobot/blob/main/AI_POLICY.md): this PR was written primarily with Claude Code; I reproduced the bug, reviewed the fix, and verified the before/after behavior on both transformers versions myself.

If you'd rather fail earlier (e.g. a version gate in `import_utils`) or fall back gracefully instead of raising, happy to adjust — raising with a clear message seemed safest since transformers <5.4 likely breaks GR00T in deeper ways than this class definition.