### PR TITLE
fix(datasets): handle converted visual metadata without image stats

### DIFF
--- a/src/lerobot/datasets/factory.py
+++ b/src/lerobot/datasets/factory.py
@@ -126,6 +126,7 @@ def make_dataset(cfg: TrainPipelineConfig) -> LeRobotDataset | MultiLeRobotDatas
 
     if cfg.dataset.use_imagenet_stats:
         for key in dataset.meta.camera_keys:
+            dataset.meta.stats.setdefault(key, {})
             for stats_type, stats in IMAGENET_STATS.items():
                 dataset.meta.stats[key][stats_type] = torch.tensor(stats, dtype=torch.float32)
 

--- a/src/lerobot/utils/feature_utils.py
+++ b/src/lerobot/utils/feature_utils.py
@@ -152,7 +152,9 @@ def dataset_to_policy_features(features: dict[str, dict]) -> dict[str, PolicyFea
 
             names = ft["names"]
             # Backward compatibility for "channel" which is an error introduced in LeRobotDataset v2.0 for ported datasets.
-            if names[2] in ["channel", "channels"]:  # (h, w, c) -> (c, h, w)
+            is_channel_last = names is None and shape[-1] in (1, 3, 4)
+            has_channel_last_names = names is not None and len(names) > 2 and names[2] in ["channel", "channels"]
+            if is_channel_last or has_channel_last_names:  # (h, w, c) -> (c, h, w)
                 shape = (shape[2], shape[0], shape[1])
         elif key == OBS_ENV_STATE:
             type = FeatureType.ENV

--- a/tests/datasets/test_factory.py
+++ b/tests/datasets/test_factory.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import torch
+
+from lerobot.datasets import factory
+from lerobot.utils.constants import IMAGENET_STATS
+
+
+class _FakeTrainableConfig:
+    reward_delta_indices = None
+    action_delta_indices = None
+    observation_delta_indices = None
+
+
+class _FakeMeta:
+    fps = 30
+    features = {"observation.images.front": {"dtype": "video"}}
+    camera_keys = ["observation.images.front"]
+
+    def __init__(self):
+        self.stats = {}
+
+
+class _FakeDataset:
+    def __init__(self):
+        self.meta = _FakeMeta()
+
+
+def test_make_dataset_adds_missing_imagenet_stats_entries(monkeypatch):
+    fake_dataset = _FakeDataset()
+
+    monkeypatch.setattr(factory, "LeRobotDatasetMetadata", lambda *args, **kwargs: _FakeMeta())
+    monkeypatch.setattr(factory, "LeRobotDataset", lambda *args, **kwargs: fake_dataset)
+
+    cfg = SimpleNamespace(
+        dataset=SimpleNamespace(
+            repo_id="local/dataset",
+            root="/tmp/local-dataset",
+            revision=None,
+            episodes=None,
+            image_transforms=SimpleNamespace(enable=False),
+            streaming=False,
+            video_backend="pyav",
+            use_imagenet_stats=True,
+        ),
+        trainable_config=_FakeTrainableConfig(),
+        tolerance_s=1e-4,
+        num_workers=0,
+    )
+
+    dataset = factory.make_dataset(cfg)
+
+    assert dataset is fake_dataset
+    assert "observation.images.front" in dataset.meta.stats
+    for stats_type, stats in IMAGENET_STATS.items():
+        torch.testing.assert_close(
+            dataset.meta.stats["observation.images.front"][stats_type],
+            torch.tensor(stats, dtype=torch.float32),
+        )

--- a/tests/utils/test_feature_utils.py
+++ b/tests/utils/test_feature_utils.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from lerobot.configs.types import FeatureType
+from lerobot.utils.feature_utils import dataset_to_policy_features
+
+
+def test_dataset_to_policy_features_handles_visual_names_none_hwc():
+    features = {
+        "observation.images.front": {
+            "dtype": "video",
+            "shape": (480, 640, 3),
+            "names": None,
+        },
+    }
+
+    policy_features = dataset_to_policy_features(features)
+
+    assert policy_features["observation.images.front"].type is FeatureType.VISUAL
+    assert policy_features["observation.images.front"].shape == (3, 480, 640)


### PR DESCRIPTION
﻿﻿## Summary / Motivation

Official v2.1 -> v3 conversion can preserve visual features with `names: null` and produce `meta/stats.json` without image entries when the legacy stats do not include image features. Current dataset/policy loading then assumes those entries exist: ImageNet stats injection indexes `dataset.meta.stats[camera_key]`, and `dataset_to_policy_features` indexes `names[2]`. This PR makes those downstream paths tolerant of officially converted datasets while keeping the existing behavior for fully specified visual metadata.

## Related issues

- Fixes / Closes: #3786
- Related: #2975
- Related: #2105

## What changed

- `make_dataset(... use_imagenet_stats=True)` now creates missing camera-key stats entries before writing ImageNet mean/std values.
- `dataset_to_policy_features` now treats 3D visual features with `names=None` and a channel-like last dimension as HWC, converting them to CHW for policy features.
- Added regression tests for missing image stats entries and `names=None` visual feature metadata.
- No breaking changes. Existing visual features with explicit `"channel"` / `"channels"` names keep the same compatibility path.

## How was this tested (or how to run locally)

- Added `tests/datasets/test_factory.py::test_make_dataset_adds_missing_imagenet_stats_entries`.
- Added `tests/utils/test_feature_utils.py::test_dataset_to_policy_features_handles_visual_names_none_hwc`.
- Ran:
  ```bash
  python -m ruff check src/lerobot/datasets/factory.py src/lerobot/utils/feature_utils.py tests/datasets/test_factory.py tests/utils/test_feature_utils.py
  ```
- Ran:
  ```bash
  python -m pytest --basetemp .tmp-pytest tests/utils/test_feature_utils.py tests/datasets/test_factory.py tests/policies/test_policies.py::test_policy_defaults -q
  ```

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`) — ran `ruff check` on changed files
- [x] All tests pass locally (`pytest`) — ran the targeted regression tests and `test_policy_defaults`
- [x] Documentation updated — n/a, compatibility fix only
- [ ] CI is green
- [ ] Community Review: not yet

## Reviewer notes

- The `names=None` fallback is intentionally guarded to 3D visual shapes whose last dimension looks like a channel count (`1`, `3`, or `4`).
- This PR fixes downstream loading compatibility. A converter-side normalization pass could still be added separately if maintainers prefer newly converted v3 datasets to write explicit visual axis names.
- Anyone in the community is free to review the PR.



