### PR TITLE
fix(datasets): recompute task_index stats after aggregation

### DIFF
--- a/src/lerobot/datasets/aggregate.py
+++ b/src/lerobot/datasets/aggregate.py
@@ -26,7 +26,7 @@ import tqdm
 
 from lerobot.configs import VIDEO_ENCODER_INFO_KEYS
 
-from .compute_stats import aggregate_stats
+from .compute_stats import RunningQuantileStats, aggregate_stats
 from .dataset_metadata import LeRobotDatasetMetadata
 from .feature_utils import features_equal_for_merge, get_hf_features_from_features
 from .io_utils import (
@@ -689,6 +689,24 @@ def append_or_create_parquet_file(
     return idx, (dst_chunk, dst_file)
 
 
+def _compute_task_index_stats_from_data(aggr_meta):
+    running_stats = RunningQuantileStats()
+    has_task_indices = False
+
+    for path in sorted((aggr_meta.root / "data").rglob("*.parquet")):
+        df = pd.read_parquet(path, columns=["task_index"])
+        task_indices = df["task_index"].to_numpy().reshape(-1, 1)
+        if len(task_indices) == 0:
+            continue
+        running_stats.update(task_indices)
+        has_task_indices = True
+
+    if not has_task_indices:
+        return None
+
+    return running_stats.get_statistics()
+
+
 def finalize_aggregation(aggr_meta, all_metadata):
     """Finalizes the dataset aggregation by writing summary files and statistics.
 
@@ -711,4 +729,9 @@ def finalize_aggregation(aggr_meta, all_metadata):
 
     logging.info("write stats")
     aggr_meta.stats = aggregate_stats([m.stats for m in all_metadata])
+    if "task_index" in aggr_meta.features:
+        # Source task_index stats use local task ids, so recompute after remapping.
+        task_index_stats = _compute_task_index_stats_from_data(aggr_meta)
+        if task_index_stats is not None:
+            aggr_meta.stats["task_index"] = task_index_stats
     write_stats(aggr_meta.stats, aggr_meta.root)

--- a/tests/datasets/test_aggregate.py
+++ b/tests/datasets/test_aggregate.py
@@ -18,6 +18,8 @@ import json
 import logging
 from unittest.mock import patch
 
+import numpy as np
+import pandas as pd
 import pytest
 
 pytest.importorskip("datasets", reason="datasets is required (install lerobot[dataset])")
@@ -27,6 +29,7 @@ import torch
 
 from lerobot.configs import VIDEO_ENCODER_INFO_KEYS
 from lerobot.datasets.aggregate import aggregate_datasets
+from lerobot.datasets.compute_stats import RunningQuantileStats
 from lerobot.datasets.feature_utils import features_equal_for_merge
 from lerobot.datasets.lerobot_dataset import LeRobotDataset
 from tests.fixtures.constants import DUMMY_REPO_ID
@@ -287,6 +290,66 @@ def test_aggregate_datasets(tmp_path, lerobot_dataset_factory):
     assert_video_frames_integrity(aggr_ds, ds_0, ds_1)
     assert_video_timestamps_within_bounds(aggr_ds)
     assert_dataset_iteration_works(aggr_ds)
+
+
+def test_aggregate_recomputes_task_index_stats_after_remap(
+    tmp_path, lerobot_dataset_factory, info_factory, stats_factory
+):
+    """task_index stats must reflect the remapped aggregated parquet data, not local source ids."""
+
+    def make_single_task_dataset(name: str, task: str, total_frames: int):
+        info = info_factory(
+            total_episodes=1,
+            total_frames=total_frames,
+            total_tasks=1,
+            camera_features={},
+            use_videos=False,
+        )
+        tasks = pd.DataFrame({"task_index": [0]}, index=pd.Index([task], name="task"))
+        stats = stats_factory(features=info.features)
+        stats["task_index"] = {
+            "min": [0],
+            "max": [0],
+            "mean": [0.0],
+            "std": [0.0],
+            "count": [total_frames],
+            "q01": [0.0],
+            "q10": [0.0],
+            "q50": [0.0],
+            "q90": [0.0],
+            "q99": [0.0],
+        }
+        return lerobot_dataset_factory(
+            root=tmp_path / name,
+            repo_id=f"{DUMMY_REPO_ID}_{name}",
+            info=info,
+            stats=stats,
+            tasks=tasks,
+        )
+
+    ds_0 = make_single_task_dataset("task_stats_0", "Task A", total_frames=5)
+    ds_1 = make_single_task_dataset("task_stats_1", "Task B", total_frames=7)
+    aggr_root = tmp_path / "task_stats_aggr"
+
+    aggregate_datasets(
+        repo_ids=[ds_0.repo_id, ds_1.repo_id],
+        roots=[ds_0.root, ds_1.root],
+        aggr_repo_id=f"{DUMMY_REPO_ID}_task_stats_aggr",
+        aggr_root=aggr_root,
+    )
+
+    data_task_indices = pd.concat(
+        pd.read_parquet(path, columns=["task_index"]) for path in (aggr_root / "data").rglob("*.parquet")
+    )["task_index"].to_numpy()
+    expected_running_stats = RunningQuantileStats()
+    expected_running_stats.update(data_task_indices.reshape(-1, 1))
+    expected_stats = expected_running_stats.get_statistics()
+    stats = json.loads((aggr_root / "meta" / "stats.json").read_text())["task_index"]
+
+    assert sorted(np.unique(data_task_indices).tolist()) == [0, 1]
+    assert stats.keys() >= {"min", "max", "mean", "std", "count", "q01", "q10", "q50", "q90", "q99"}
+    for key, expected_value in expected_stats.items():
+        assert stats[key] == [pytest.approx(expected_value.item())]
 
 
 def test_aggregate_datasets_without_concatenation(tmp_path, lerobot_dataset_factory):


### PR DESCRIPTION
﻿﻿## Summary / Motivation

`aggregate_datasets(...)` remaps per-frame `task_index` values from each source dataset's local task ids into the merged dataset's global task table, but final stats were still computed by aggregating the original source `meta/stats.json` values. When merging multiple single-task datasets that each use local `task_index=0`, the merged parquet correctly contains multiple task ids while `meta/stats.json["task_index"]` can still report stale values such as `max: [0]`, `mean: [0.0]`, `std: [0.0]`, and stale quantiles.

This PR recomputes `task_index` stats from the final aggregated parquet files because `task_index` is remapped during aggregation. This keeps `stats.json` consistent with the data actually written to disk while leaving all other feature stats on the existing `aggregate_stats(...)` path.

## Related issues

- Fixes / Closes: #3788

## What changed

- Added a post-aggregation `task_index` stats recomputation path that scans only the `task_index` column from merged parquet files after task remapping.
- Reuses the existing `RunningQuantileStats` helper so the generated schema matches the current stats system, including `min`, `max`, `mean`, `std`, `count`, `q01`, `q10`, `q50`, `q90`, and `q99`.
- Triggers recomputation based on the final dataset features containing `task_index`, rather than depending on whether stale source stats already had a `task_index` entry.
- Added a regression test that merges two different single-task datasets whose local task ids are both `0` and verifies the merged stats match `RunningQuantileStats` computed from the final parquet data.

## How was this tested (or how to run locally)

- Added `tests/datasets/test_aggregate.py::test_aggregate_recomputes_task_index_stats_after_remap`.
- Ran:
  ```bash
  python -m ruff check src/lerobot/datasets/aggregate.py tests/datasets/test_aggregate.py
  ```
- Ran:
  ```bash
  python -m pytest --basetemp .tmp-pytest tests/datasets/test_aggregate.py::test_aggregate_recomputes_task_index_stats_after_remap -q
  ```
- Also attempted `tests/datasets/test_aggregate.py::test_aggregate_datasets_without_concatenation`; it failed locally before exercising this change because this Windows environment cannot load `torchcodec`/FFmpeg DLLs for video decoding.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`) — ran `ruff check` on changed files
- [x] All tests pass locally (`pytest`) — targeted regression test passes
- [x] Documentation updated — n/a, metadata correctness fix only
- [ ] CI is green
- [ ] Community Review: not yet

## Reviewer notes

- The recomputation is intentionally done after data aggregation because `task_index` is remapped while writing merged parquet files; source stats describe local task ids and cannot be aggregated directly once ids are remapped.
- The implementation intentionally stays narrow: only `task_index` is recomputed, and all other feature stats continue to use the existing aggregation path.
- Anyone in the community is free to review the PR.

