### PR TITLE
docs: fix ACT policy type examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Training a policy is as simple as running a script configuration:
 
 ```bash
 lerobot-train \
-  --policy=act \
+  --policy.type=act \
   --dataset.repo_id=lerobot/aloha_mobile_cabinet
 ```
 

--- a/docs/source/multi_gpu_training.mdx
+++ b/docs/source/multi_gpu_training.mdx
@@ -95,7 +95,7 @@ If you want to scale your hyperparameters when using multiple GPUs, you should d
 accelerate launch --num_processes=2 $(which lerobot-train) \
   --optimizer.lr=2e-4 \
   --dataset.repo_id=lerobot/pusht \
-  --policy=act
+  --policy.type=act
 ```
 
 **Training Steps Scaling:**
@@ -110,7 +110,7 @@ accelerate launch --num_processes=2 $(which lerobot-train) \
   --batch_size=8 \
   --steps=50000 \
   --dataset.repo_id=lerobot/pusht \
-  --policy=act
+  --policy.type=act
 ```
 
 ## Notes


### PR DESCRIPTION
﻿## What

Some ACT training examples still use the old policy override form `--policy=act`, while the same docs and current examples use the nested config form `--policy.type=act`.

This makes the README and multi-GPU training guide internally inconsistent and can mislead users copying the later examples.

## Fixed references

| File | Before | After |
|------|--------|-------|
| `README.md` | `--policy=act` | `--policy.type=act` |
| `docs/source/multi_gpu_training.mdx` | `--policy=act` | `--policy.type=act` |

## Verification

- Searched the affected docs for remaining `--policy=act` examples.
- Confirmed nearby ACT examples in `docs/source/act.mdx`, `docs/source/il_robots.mdx`, and the earlier multi-GPU examples already use `--policy.type=act`.
- Confirmed `--batch_size` and `--steps` are top-level training config fields in `src/lerobot/configs/train.py`, so this PR only updates the stale policy override syntax.
