### PR TITLE
feat(record): add `--dataset.no_stamp` to opt out of repo_id timestamping

### DIFF
--- a/src/lerobot/configs/dataset.py
+++ b/src/lerobot/configs/dataset.py
@@ -69,13 +69,19 @@ class DatasetRecordConfig:
     # Number of threads per encoder instance. None = auto (codec default).
     # Lower values reduce CPU usage, maps to 'lp' (via svtav1-params) for libsvtav1 and 'threads' for h264/hevc..
     encoder_threads: int | None = None
+    # Skip appending the date-time tag to repo_id, keeping the user-provided name as-is
+    # (e.g. self-managed versioned names intended for a later `lerobot-edit-dataset merge`).
+    no_stamp: bool = False
 
     def stamp_repo_id(self) -> None:
         """Append a date-time tag to ``repo_id`` so each recording session gets a unique name.
 
         Must be called explicitly at dataset *creation* time — not on resume,
         where the existing ``repo_id`` (already stamped) must be preserved.
+        No-op when ``no_stamp`` is set, preserving a user-managed ``repo_id``.
         """
+        if self.no_stamp:
+            return
         if self.repo_id:
             timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
             self.repo_id = f"{self.repo_id}_{timestamp}"

--- a/tests/configs/test_dataset.py
+++ b/tests/configs/test_dataset.py
@@ -1,0 +1,48 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import re
+
+import draccus
+import pytest
+
+from lerobot.configs.dataset import DatasetRecordConfig
+
+TIMESTAMP_SUFFIX = re.compile(r"_\d{8}_\d{6}$")
+
+
+def test_stamp_repo_id_appends_timestamp():
+    cfg = DatasetRecordConfig(repo_id="user/rollout_my_task_r1")
+    cfg.stamp_repo_id()
+    assert cfg.repo_id.startswith("user/rollout_my_task_r1_")
+    assert TIMESTAMP_SUFFIX.search(cfg.repo_id)
+
+
+def test_stamp_repo_id_no_stamp_keeps_repo_id():
+    cfg = DatasetRecordConfig(repo_id="user/rollout_my_task_r1", no_stamp=True)
+    cfg.stamp_repo_id()
+    assert cfg.repo_id == "user/rollout_my_task_r1"
+
+
+@pytest.mark.parametrize("no_stamp", [False, True])
+def test_stamp_repo_id_empty_repo_id_unchanged(no_stamp):
+    cfg = DatasetRecordConfig(no_stamp=no_stamp)
+    cfg.stamp_repo_id()
+    assert cfg.repo_id == ""
+
+
+def test_no_stamp_parses_from_cli():
+    cfg = draccus.parse(DatasetRecordConfig, args=["--repo_id=user/rollout_my_task_r1", "--no_stamp=true"])
+    assert cfg.no_stamp is True
+    cfg.stamp_repo_id()
+    assert cfg.repo_id == "user/rollout_my_task_r1"


### PR DESCRIPTION
## Summary / Motivation

Fixes #3722.

One correction to the issue: the stamping lives in `DatasetRecordConfig` (`src/lerobot/configs/dataset.py`), not `LeRobotDatasetConfig`. Since that config is shared by `lerobot-record` and `lerobot-rollout`, the opt-out covers both CLIs.

This implements the fix as proposed: a `no_stamp: bool = False` field and an early return in `stamp_repo_id()`. The two call sites need no changes — they call the method unconditionally and it now gates itself — and resume paths are unaffected since they never stamp. Usage: `--dataset.no_stamp=true`.

## Related issues

- Fixes / Closes: #3722

## What changed

- Added `no_stamp: bool = False` field on `DatasetRecordConfig` and an early return in `stamp_repo_id()`, so users who manage their own versioned repo names can opt out of the `_YYYYMMDD_HHMMSS` suffix.
- No call-site changes: both callers invoke the method unconditionally and the method now gates itself. Resume paths never call `stamp_repo_id()`, so they are unaffected. The flag covers both `lerobot-record` and `lerobot-rollout` since they share this config.
- No breaking changes: default behavior (stamping on) is preserved.

## How was this tested (or how to run locally)

- Tests added: `tests/configs/test_dataset.py` covering the default timestamp suffix, the opt-out, empty `repo_id` in both modes, and draccus parsing of the new flag.
- `tests/configs/`, `tests/test_control_robot.py`, and `tests/test_rollout.py` all pass locally.
- The flag shows up with its help text in `lerobot-record --help`. CLI usage: `--dataset.no_stamp=true`.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: # (insert PR number/link)

## Reviewer notes

- The flag name follows the issue reporter's proposal (`no_stamp`); `stamp: bool = True` was considered but reads ambiguously next to the `stamp_repo_id` method.
- Disclosure: this PR was prepared with the help of Claude Code.
