### PR TITLE
fix(vla_jepa): use device-safe autocast instead of hardcoded bfloat16

### DIFF
--- a/src/lerobot/policies/vla_jepa/modeling_vla_jepa.py
+++ b/src/lerobot/policies/vla_jepa/modeling_vla_jepa.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import logging
 from collections import deque
+from contextlib import nullcontext
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -28,6 +29,7 @@ from torch import Tensor, nn
 from lerobot.policies.pretrained import PreTrainedPolicy, T
 from lerobot.policies.utils import populate_queues
 from lerobot.utils.constants import ACTION, OBS_STATE
+from lerobot.utils.device_utils import is_amp_available
 from lerobot.utils.import_utils import _transformers_available, require_package
 
 if TYPE_CHECKING or _transformers_available:
@@ -40,6 +42,21 @@ from .action_head import VLAJEPAActionHead
 from .configuration_vla_jepa import VLAJEPAConfig
 from .qwen_interface import Qwen3VLInterface
 from .world_model import ActionConditionedVideoPredictor
+
+
+def _get_autocast_context(device_type: str, dtype: torch.dtype = torch.bfloat16):
+    """Return an autocast context appropriate for the device.
+
+    MPS does not support ``torch.autocast`` at all.  On CUDA devices
+    without bfloat16 support (compute capability < 8.0) we fall back to
+    float16.
+    """
+    if not is_amp_available(device_type):
+        return nullcontext()
+    if device_type == "cuda" and dtype == torch.bfloat16 and not torch.cuda.is_bf16_supported():
+        dtype = torch.float16
+    return torch.autocast(device_type=device_type, dtype=dtype)
+
 
 # ============================================================================
 # Native VLA-JEPA Model - follows original starVLA VLA_JEPA.py implementation
@@ -227,7 +244,7 @@ class VLAJEPAModel(nn.Module):
 
         device_type = next(self.parameters()).device.type
 
-        with torch.autocast(device_type=device_type, dtype=torch.bfloat16):
+        with _get_autocast_context(device_type, torch.bfloat16):
             last_hidden = self._qwen_last_decoder_hidden(qwen_inputs)  # [B, seq_len, H]
             b, _, h = last_hidden.shape
 
@@ -363,7 +380,7 @@ class VLAJEPAModel(nn.Module):
 
         device_type = next(self.parameters()).device.type
 
-        with torch.autocast(device_type=device_type, dtype=torch.bfloat16):
+        with _get_autocast_context(device_type, torch.bfloat16):
             last_hidden = self._qwen_last_decoder_hidden(qwen_inputs)  # [B, seq_len, H]
             b, _, h = last_hidden.shape
             embodied_action_tokens = last_hidden[embodied_indices[0], embodied_indices[1], :].view(b, -1, h)

--- a/src/lerobot/policies/vla_jepa/modeling_vla_jepa.py
+++ b/src/lerobot/policies/vla_jepa/modeling_vla_jepa.py
@@ -302,7 +302,7 @@ class VLAJEPAModel(nn.Module):
             return {"wm_loss": wm_loss}
 
         # ---- Step 4: Action Head ----
-        with torch.autocast(device_type=device_type, dtype=torch.float32):
+        with _get_autocast_context(device_type, torch.float32):
             actions_tensor = torch.tensor(
                 np.array(actions), device=last_hidden.device, dtype=torch.float32
             )  # [B, T_full, action_dim]


### PR DESCRIPTION
## Summary / Motivation

VLA-JEPA hardcodes `torch.autocast(device_type=..., dtype=torch.bfloat16)` in both the training forward pass and inference path. This crashes on MPS (no AMP support) and silently misbehaves on pre-Ampere CUDA GPUs (no bf16 support). This PR adds a `_get_autocast_context()` helper that reuses the existing `is_amp_available()` utility to pick a safe autocast strategy per device, following the same pattern already used by pi05 and molmoact2 policies.

## Related issues

- Fixes #3744

## What changed

- Added `_get_autocast_context(device_type, dtype)` helper in `modeling_vla_jepa.py`:
  - MPS: returns `nullcontext()` since MPS has no AMP support
  - CUDA without bf16 (compute capability < 8.0): falls back to float16
  - CPU / CUDA with bf16 / XPU: unchanged behavior
- Replaced the two hardcoded `torch.autocast(..., dtype=torch.bfloat16)` calls with `_get_autocast_context(...)`
- No new dependencies. Uses `is_amp_available` from `lerobot.utils.device_utils` already in the codebase

## How was this tested

- Verified `_get_autocast_context` returns `nullcontext` on MPS, bf16 autocast on CPU, bf16 autocast on CUDA
- Verified forward passes execute correctly under each context manager
- `ruff check` and `ruff format` pass

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [ ] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: #

## Reviewer notes

- The helper is module-private (`_get_autocast_context`) since the pattern varies across policies (pi05 inlines it, molmoact2 uses a different guard). Happy to move it to `device_utils.py` as a shared utility if maintainers prefer that.