### PR TITLE
fix(datasets): compute true global quantiles via histogram merge

### DIFF
--- a/src/lerobot/datasets/__init__.py
+++ b/src/lerobot/datasets/__init__.py
@@ -21,7 +21,15 @@ require_package("datasets", extra="dataset")
 require_package("av", extra="dataset")
 
 from .aggregate import aggregate_datasets
-from .compute_stats import DEFAULT_QUANTILES, aggregate_stats, get_feature_stats
+from .compute_stats import (
+    DEFAULT_QUANTILES,
+    RunningQuantileStats,
+    aggregate_quantile_stats,
+    aggregate_stats,
+    compute_feature_running_stats,
+    feature_stats_from_running,
+    get_feature_stats,
+)
 from .dataset_metadata import CODEBASE_VERSION, LeRobotDatasetMetadata
 from .dataset_tools import (
     add_features,
@@ -71,6 +79,7 @@ __all__ = [
     "LeRobotDatasetMetadata",
     "MultiLeRobotDataset",
     "PERSISTENT_STYLES",
+    "RunningQuantileStats",
     "STYLE_REGISTRY",
     "StreamingLeRobotDataset",
     "VideoEncodingManager",
@@ -79,10 +88,13 @@ __all__ = [
     "add_features",
     "aggregate_datasets",
     "aggregate_pipeline_dataset_features",
+    "aggregate_quantile_stats",
     "aggregate_stats",
+    "compute_feature_running_stats",
     "convert_image_to_video_dataset",
     "create_initial_features",
     "compute_sampler_state",
+    "feature_stats_from_running",
     "create_lerobot_dataset_card",
     "column_for_style",
     "delete_episodes",

--- a/src/lerobot/datasets/compute_stats.py
+++ b/src/lerobot/datasets/compute_stats.py
@@ -183,6 +183,13 @@ class RunningQuantileStats:
         if other._count == 0:
             return self
         if self._count == 0:
+            # Merging into an empty accumulator yields a faithful clone of ``other``:
+            # adopt its full configuration too, otherwise ``self``'s histogram length
+            # (now ``other._num_quantile_bins``) would disagree with a stale
+            # ``self._num_quantile_bins`` and silently rebin on the next update/merge.
+            self._num_quantile_bins = other._num_quantile_bins
+            self._quantile_list = list(other._quantile_list)
+            self._quantile_keys = list(other._quantile_keys)
             self._count = other._count
             self._mean = other._mean.copy()
             self._mean_of_squares = other._mean_of_squares.copy()

--- a/src/lerobot/datasets/compute_stats.py
+++ b/src/lerobot/datasets/compute_stats.py
@@ -26,6 +26,9 @@ from .io_utils import load_image_as_numpy
 
 DEFAULT_QUANTILES = [0.01, 0.10, 0.50, 0.90, 0.99]
 
+# Emitted at most once per process: see `_warn_quantile_aggregation_is_approximate`.
+_QUANTILE_AGGREGATION_WARNED = False
+
 
 class RunningQuantileStats:
     """
@@ -130,32 +133,98 @@ class RunningQuantileStats:
 
         return stats
 
+    @staticmethod
+    def _make_bin_edges(low: float, high: float, num_bins: int) -> np.ndarray:
+        """Build ``num_bins + 1`` edges spanning ``[low, high]`` with tiny padding.
+
+        The padding guarantees strictly increasing edges even for a constant
+        feature (``low == high``), so downstream histogram/quantile math is safe.
+        """
+        span = high - low
+        padding = span * 1e-10 if span > 0 else 1e-10
+        return np.linspace(low - padding, high + padding, num_bins + 1)
+
+    @staticmethod
+    def _rebin_histogram(hist: np.ndarray, old_edges: np.ndarray, new_edges: np.ndarray) -> np.ndarray:
+        """Redistribute ``hist`` counts from ``old_edges`` onto ``new_edges``.
+
+        Each old bin's count is assigned to the new bin that contains the old
+        bin's center. This is the mapping used both when a single histogram's
+        range expands and when two histograms are merged.
+        """
+        num_bins = len(new_edges) - 1
+        old_centers = (old_edges[:-1] + old_edges[1:]) / 2
+        bin_idx = np.searchsorted(new_edges, old_centers) - 1
+        np.clip(bin_idx, 0, num_bins - 1, out=bin_idx)
+        new_hist = np.zeros(num_bins)
+        np.add.at(new_hist, bin_idx, hist)
+        return new_hist
+
     def _adjust_histograms(self):
         """Adjust histograms when min or max changes."""
         for i in range(len(self._histograms)):
-            old_edges = self._bin_edges[i]
-            old_hist = self._histograms[i]
+            new_edges = self._make_bin_edges(self._min[i], self._max[i], self._num_quantile_bins)
+            self._histograms[i] = self._rebin_histogram(self._histograms[i], self._bin_edges[i], new_edges)
+            self._bin_edges[i] = new_edges
 
-            # Create new edges with small padding to ensure range coverage
-            padding = (self._max[i] - self._min[i]) * 1e-10
-            new_edges = np.linspace(
-                self._min[i] - padding, self._max[i] + padding, self._num_quantile_bins + 1
+    def merge(self, other: RunningQuantileStats) -> RunningQuantileStats:
+        """Merge another ``RunningQuantileStats`` into this one, in place.
+
+        Combines counts, means, and per-dimension histograms so that the merged
+        object yields the same statistics as if every batch seen by ``other``
+        had instead been passed to ``self.update``. Crucially, the resulting
+        quantiles are *global* over the union of all data (accurate to histogram
+        resolution) -- not a count-weighted average of the two objects'
+        quantiles, which biases distribution tails inward.
+
+        ``mean``/``std``/``min``/``max`` remain exact; only quantiles carry the
+        usual histogram discretization error. Returns ``self`` for chaining.
+        """
+        if other._count == 0:
+            return self
+        if self._count == 0:
+            self._count = other._count
+            self._mean = other._mean.copy()
+            self._mean_of_squares = other._mean_of_squares.copy()
+            self._min = other._min.copy()
+            self._max = other._max.copy()
+            self._histograms = [h.copy() for h in other._histograms]
+            self._bin_edges = [e.copy() for e in other._bin_edges]
+            return self
+
+        if self._num_quantile_bins != other._num_quantile_bins:
+            raise ValueError(
+                "Cannot merge RunningQuantileStats with different num_quantile_bins "
+                f"({self._num_quantile_bins} != {other._num_quantile_bins})."
+            )
+        if self._mean.size != other._mean.size:
+            raise ValueError(
+                "Cannot merge RunningQuantileStats with different vector lengths "
+                f"({self._mean.size} != {other._mean.size})."
             )
 
-            # Redistribute existing histogram counts to new bins
-            # We need to map each old bin center to the new bins
-            old_centers = (old_edges[:-1] + old_edges[1:]) / 2
-            new_hist = np.zeros(self._num_quantile_bins)
+        total_count = self._count + other._count
+        # Mean and mean-of-squares are exact count-weighted averages of the two parts.
+        self._mean = (self._mean * self._count + other._mean * other._count) / total_count
+        self._mean_of_squares = (
+            self._mean_of_squares * self._count + other._mean_of_squares * other._count
+        ) / total_count
 
-            for old_center, count in zip(old_centers, old_hist, strict=False):
-                if count > 0:
-                    # Find which new bin this old center belongs to
-                    bin_idx = np.searchsorted(new_edges, old_center) - 1
-                    bin_idx = max(0, min(bin_idx, self._num_quantile_bins - 1))
-                    new_hist[bin_idx] += count
+        new_min = np.minimum(self._min, other._min)
+        new_max = np.maximum(self._max, other._max)
 
-            self._histograms[i] = new_hist
+        # Re-bin both histograms onto the union range, then sum the counts.
+        for i in range(len(self._histograms)):
+            new_edges = self._make_bin_edges(new_min[i], new_max[i], self._num_quantile_bins)
+            self._histograms[i] = self._rebin_histogram(
+                self._histograms[i], self._bin_edges[i], new_edges
+            ) + self._rebin_histogram(other._histograms[i], other._bin_edges[i], new_edges)
             self._bin_edges[i] = new_edges
+
+        self._min = new_min
+        self._max = new_max
+        self._count = total_count
+        return self
 
     def _update_histograms(self, batch: np.ndarray) -> None:
         """Update histograms with new vectors."""
@@ -469,18 +538,88 @@ def get_feature_stats(
         quantile_list = DEFAULT_QUANTILES
 
     original_shape = array.shape
-    reshaped, sample_count = _prepare_array_for_stats(array, axis)
+    running_stats, sample_count = compute_feature_running_stats(array, axis, quantile_list=quantile_list)
 
-    if reshaped.shape[0] < 2:
+    if running_stats is None:
+        reshaped, _ = _prepare_array_for_stats(array, axis)
         stats = _compute_basic_stats(reshaped, sample_count, quantile_list)
-    else:
-        running_stats = RunningQuantileStats()
-        running_stats.update(reshaped)
-        stats = running_stats.get_statistics()
-        stats["count"] = np.array([sample_count])
+        return _reshape_stats_by_axis(stats, axis, keepdims, original_shape)
 
-    stats = _reshape_stats_by_axis(stats, axis, keepdims, original_shape)
-    return stats
+    return feature_stats_from_running(running_stats, sample_count, axis, keepdims, original_shape)
+
+
+def compute_feature_running_stats(
+    array: np.ndarray,
+    axis: int | tuple[int, ...] | None,
+    quantile_list: list[float] | None = None,
+) -> tuple[RunningQuantileStats | None, int]:
+    """Build a :class:`RunningQuantileStats` accumulator for one feature array.
+
+    The array is reshaped according to ``axis`` (same conventions as
+    :func:`get_feature_stats`) and fed to a single accumulator. The returned
+    accumulator can be merged with others from different shards/episodes via
+    :meth:`RunningQuantileStats.merge` to obtain *global* statistics in a
+    single streaming pass, without holding all data in memory at once.
+
+    Args:
+        array: Input data array.
+        axis: Axis or axes along which to reduce (see :func:`get_feature_stats`).
+        quantile_list: Quantiles to track. Defaults to :data:`DEFAULT_QUANTILES`.
+
+    Returns:
+        ``(running_stats, sample_count)``. ``running_stats`` is ``None`` when
+        fewer than 2 vectors are available (too few for histogram quantiles);
+        callers should fall back to :func:`_compute_basic_stats` in that case.
+    """
+    if quantile_list is None:
+        quantile_list = DEFAULT_QUANTILES
+
+    reshaped, sample_count = _prepare_array_for_stats(array, axis)
+    if reshaped.shape[0] < 2:
+        return None, sample_count
+
+    running_stats = RunningQuantileStats(quantile_list=quantile_list)
+    running_stats.update(reshaped)
+    return running_stats, sample_count
+
+
+def feature_stats_from_running(
+    running_stats: RunningQuantileStats,
+    sample_count: int,
+    axis: int | tuple[int, ...] | None,
+    keepdims: bool,
+    original_shape: tuple[int, ...],
+) -> dict[str, np.ndarray]:
+    """Finalize a (possibly merged) accumulator into a reshaped stats dict.
+
+    Produces the same output layout as :func:`get_feature_stats`. ``count`` is
+    overridden with ``sample_count`` (number of samples, e.g. frames) rather
+    than the accumulator's internal element count, matching the existing
+    convention used throughout the stats pipeline.
+    """
+    stats = running_stats.get_statistics()
+    stats["count"] = np.array([sample_count])
+    return _reshape_stats_by_axis(stats, axis, keepdims, original_shape)
+
+
+def aggregate_quantile_stats(running_stats_list: list[RunningQuantileStats]) -> RunningQuantileStats:
+    """Merge per-shard accumulators into one with correct global quantiles.
+
+    This is the statistically correct counterpart to the quantile handling in
+    :func:`aggregate_feature_stats`: instead of averaging already-computed
+    per-shard quantiles (which biases tails), it merges the underlying
+    histograms so the result reflects the true global distribution.
+    """
+    if not running_stats_list:
+        raise ValueError("Cannot aggregate an empty list of RunningQuantileStats.")
+
+    merged = RunningQuantileStats(
+        quantile_list=running_stats_list[0]._quantile_list,
+        num_quantile_bins=running_stats_list[0]._num_quantile_bins,
+    )
+    for running_stats in running_stats_list:
+        merged.merge(running_stats)
+    return merged
 
 
 def compute_episode_stats(
@@ -602,13 +741,39 @@ def aggregate_feature_stats(stats_ft_list: list[dict[str, dict]]) -> dict[str, d
     if stats_ft_list:
         quantile_keys = [k for k in stats_ft_list[0] if k.startswith("q") and k[1:].isdigit()]
 
+        if quantile_keys and len(stats_ft_list) > 1:
+            _warn_quantile_aggregation_is_approximate()
+
         for q_key in quantile_keys:
             if all(q_key in s for s in stats_ft_list):
+                # WARNING: this count-weighted average of per-shard quantiles is only an
+                # APPROXIMATION. The mean of per-episode q01 values is not the global q01;
+                # averaging pulls the distribution tails inward (q01 too high, q99 too low).
+                # Exact global quantiles cannot be recovered from already-summarized stats
+                # dicts -- they require the underlying data/histograms. For quantile-normalized
+                # policies (e.g. pi0 / pi0.5) recompute true global quantiles by merging
+                # histograms instead (see `aggregate_quantile_stats` /
+                # `scripts/augment_dataset_quantile_stats.py`).
                 quantile_values = np.stack([s[q_key] for s in stats_ft_list])
                 weighted_quantiles = quantile_values * counts
                 aggregated[q_key] = weighted_quantiles.sum(axis=0) / total_count
 
     return aggregated
+
+
+def _warn_quantile_aggregation_is_approximate() -> None:
+    """Warn once per process that aggregated quantiles are an approximation."""
+    global _QUANTILE_AGGREGATION_WARNED
+    if _QUANTILE_AGGREGATION_WARNED:
+        return
+    _QUANTILE_AGGREGATION_WARNED = True
+    logging.warning(
+        "aggregate_stats() approximates aggregated quantiles by count-weighted averaging of "
+        "per-shard quantiles, which biases distribution tails inward (q01 too high, q99 too low). "
+        "Quantile-normalized policies (e.g. pi0 / pi0.5) require TRUE global quantiles -- recompute "
+        "them from data with `python -m lerobot.scripts.augment_dataset_quantile_stats "
+        "--repo-id <repo_id> --overwrite`."
+    )
 
 
 def aggregate_stats(stats_list: list[dict[str, dict]]) -> dict[str, dict[str, np.ndarray]]:

--- a/src/lerobot/scripts/augment_dataset_quantile_stats.py
+++ b/src/lerobot/scripts/augment_dataset_quantile_stats.py
@@ -25,6 +25,14 @@ quantile statistics (q01, q10, q50, q90, q99) in their metadata. This script:
 3. If missing, computes quantile statistics for all features
 4. Updates the dataset metadata with the new quantile statistics
 
+The quantiles computed here are TRUE GLOBAL quantiles over the whole dataset:
+each episode's data is streamed into a per-feature running histogram and those
+histograms are merged across episodes (``RunningQuantileStats.merge``). This is
+the statistically correct way to combine quantiles and matches what
+quantile-normalized policies (e.g. pi0 / pi0.5) expect. It deliberately avoids
+``aggregate_stats``, whose count-weighted averaging of per-episode quantiles
+biases the distribution tails inward.
+
 Usage:
 
 ```bash
@@ -48,8 +56,9 @@ from lerobot.datasets import (
     CODEBASE_VERSION,
     DEFAULT_QUANTILES,
     LeRobotDataset,
-    aggregate_stats,
-    get_feature_stats,
+    RunningQuantileStats,
+    compute_feature_running_stats,
+    feature_stats_from_running,
     write_stats,
 )
 from lerobot.utils.utils import init_logging
@@ -77,15 +86,22 @@ def has_quantile_stats(stats: dict[str, dict] | None, quantile_list_keys: list[s
     return False
 
 
-def process_single_episode(dataset: LeRobotDataset, episode_idx: int) -> dict:
-    """Process a single episode and return its statistics.
+def process_single_episode(dataset: LeRobotDataset, episode_idx: int) -> dict[str, dict]:
+    """Build per-feature running histogram accumulators for a single episode.
+
+    Returns a mapping ``feature_key -> info`` where ``info`` carries the
+    episode's :class:`RunningQuantileStats` accumulator (``None`` if the episode
+    has fewer than 2 usable samples) plus the metadata needed to finalize it
+    after all episodes are merged. Returning accumulators rather than finished
+    stats lets the caller merge histograms across episodes for *global*
+    quantiles, instead of averaging per-episode quantiles.
 
     Args:
         dataset: The LeRobot dataset
         episode_idx: Index of the episode to process
 
     Returns:
-        Dictionary containing episode statistics
+        Dictionary mapping each numerical feature to its accumulator + metadata.
     """
     logging.info(f"Computing stats for episode {episode_idx}")
 
@@ -103,13 +119,14 @@ def process_single_episode(dataset: LeRobotDataset, episode_idx: int) -> dict:
                 collected_data[key] = []
             collected_data[key].append(value)
 
-    ep_stats = {}
+    ep_running: dict[str, dict] = {}
     for key, data_list in collected_data.items():
-        if dataset.features[key]["dtype"] == "string":
+        if dataset.features[key]["dtype"] in {"string", "language"}:
             continue
 
         data = torch.stack(data_list).cpu().numpy()
-        if dataset.features[key]["dtype"] in ["image", "video"]:
+        is_image = dataset.features[key]["dtype"] in ["image", "video"]
+        if is_image:
             if data.dtype == np.uint8:
                 data = data.astype(np.float32) / 255.0
 
@@ -119,42 +136,85 @@ def process_single_episode(dataset: LeRobotDataset, episode_idx: int) -> dict:
             axes_to_reduce = 0
             keepdims = data.ndim == 1
 
-        ep_stats[key] = get_feature_stats(
-            data, axis=axes_to_reduce, keepdims=keepdims, quantile_list=DEFAULT_QUANTILES
+        running_stats, sample_count = compute_feature_running_stats(
+            data, axis=axes_to_reduce, quantile_list=DEFAULT_QUANTILES
         )
 
-        if dataset.features[key]["dtype"] in ["image", "video"]:
-            ep_stats[key] = {
-                k: v if k == "count" else np.squeeze(v, axis=0) for k, v in ep_stats[key].items()
-            }
+        ep_running[key] = {
+            "running_stats": running_stats,
+            "sample_count": sample_count,
+            "axis": axes_to_reduce,
+            "keepdims": keepdims,
+            "original_shape": data.shape,
+            "is_image": is_image,
+        }
 
-    return ep_stats
+    return ep_running
+
+
+def _merge_episode_running_stats(
+    ep_running: dict[str, dict],
+    merged_running: dict[str, RunningQuantileStats],
+    feature_meta: dict[str, dict],
+) -> None:
+    """Merge one episode's accumulators into the dataset-level accumulators.
+
+    Mutates ``merged_running`` and ``feature_meta`` in place. Must be called
+    from a single thread (the merge itself is not thread-safe).
+    """
+    for key, info in ep_running.items():
+        running_stats = info["running_stats"]
+        if running_stats is None:
+            # Episode too short for histogram quantiles; its handful of frames are
+            # negligible for global quantiles, so skip rather than bias the result.
+            continue
+
+        if key not in merged_running:
+            merged_running[key] = running_stats
+            feature_meta[key] = {
+                "axis": info["axis"],
+                "keepdims": info["keepdims"],
+                "original_shape": info["original_shape"],
+                "is_image": info["is_image"],
+                "total_count": int(info["sample_count"]),
+            }
+        else:
+            merged_running[key].merge(running_stats)
+            feature_meta[key]["total_count"] += int(info["sample_count"])
 
 
 def compute_quantile_stats_for_dataset(dataset: LeRobotDataset) -> dict[str, dict]:
-    """Compute quantile statistics for all episodes in the dataset.
+    """Compute TRUE global statistics (incl. quantiles) for the whole dataset.
+
+    Each episode is streamed into per-feature running histograms which are then
+    merged across episodes (:meth:`RunningQuantileStats.merge`). The merged
+    histograms yield global quantiles accurate to histogram resolution -- unlike
+    averaging per-episode quantiles. ``mean``/``std``/``min``/``max`` are exact.
+    Only one merged accumulator per feature is retained at a time, so memory
+    stays bounded regardless of dataset size.
 
     Args:
         dataset: The LeRobot dataset to compute statistics for
 
     Returns:
-        Dictionary containing aggregated statistics with quantiles
+        Dictionary mapping feature keys to their global statistics dictionaries.
 
     Note:
-        Video decoding operations are not thread-safe, so we process episodes sequentially
-        when video keys are present. For datasets without videos, we use parallel processing
-        with ThreadPoolExecutor for better performance.
+        Video decoding operations are not thread-safe, so we process episodes
+        sequentially when video keys are present. For datasets without videos,
+        episodes are processed in parallel and merged as results arrive.
     """
     logging.info(f"Computing quantile statistics for dataset with {dataset.num_episodes} episodes")
 
-    episode_stats_list = []
+    merged_running: dict[str, RunningQuantileStats] = {}
+    feature_meta: dict[str, dict] = {}
     has_videos = len(dataset.meta.video_keys) > 0
 
     if has_videos:
         logging.info("Dataset contains video keys - using sequential processing for thread safety")
         for episode_idx in tqdm(range(dataset.num_episodes), desc="Processing episodes"):
-            ep_stats = process_single_episode(dataset, episode_idx)
-            episode_stats_list.append(ep_stats)
+            ep_running = process_single_episode(dataset, episode_idx)
+            _merge_episode_running_stats(ep_running, merged_running, feature_meta)
     else:
         logging.info("Dataset has no video keys - using parallel processing for better performance")
         max_workers = min(dataset.num_episodes, 16)
@@ -165,23 +225,34 @@ def compute_quantile_stats_for_dataset(dataset: LeRobotDataset) -> dict[str, dic
                 for episode_idx in range(dataset.num_episodes)
             }
 
-            episode_results = {}
             with tqdm(total=dataset.num_episodes, desc="Processing episodes") as pbar:
+                # Episodes are computed in worker threads; merging happens here in the
+                # main thread as each result arrives, keeping memory bounded.
                 for future in concurrent.futures.as_completed(future_to_episode):
-                    episode_idx = future_to_episode[future]
-                    ep_stats = future.result()
-                    episode_results[episode_idx] = ep_stats
+                    _merge_episode_running_stats(future.result(), merged_running, feature_meta)
                     pbar.update(1)
 
-        for episode_idx in range(dataset.num_episodes):
-            if episode_idx in episode_results:
-                episode_stats_list.append(episode_results[episode_idx])
-
-    if not episode_stats_list:
+    if not merged_running:
         raise ValueError("No episode data found for computing statistics")
 
-    logging.info(f"Aggregating statistics from {len(episode_stats_list)} episodes")
-    return aggregate_stats(episode_stats_list)
+    logging.info(f"Finalizing global statistics for {len(merged_running)} features")
+    new_stats: dict[str, dict] = {}
+    for key, running_stats in merged_running.items():
+        meta = feature_meta[key]
+        feature_stats = feature_stats_from_running(
+            running_stats,
+            sample_count=meta["total_count"],
+            axis=meta["axis"],
+            keepdims=meta["keepdims"],
+            original_shape=meta["original_shape"],
+        )
+        if meta["is_image"]:
+            feature_stats = {
+                k: v if k == "count" else np.squeeze(v, axis=0) for k, v in feature_stats.items()
+            }
+        new_stats[key] = feature_stats
+
+    return new_stats
 
 
 def augment_dataset_with_quantile_stats(

--- a/tests/datasets/test_compute_stats.py
+++ b/tests/datasets/test_compute_stats.py
@@ -960,6 +960,38 @@ def test_merge_empty_is_identity():
     np.testing.assert_array_equal(empty.get_statistics()["max"], ref["max"])
 
 
+def test_merge_into_empty_adopts_other_config():
+    """Merging into an empty accumulator clones other's bin config (regression).
+
+    Guards against the empty-copy path leaving a stale ``_num_quantile_bins`` that
+    disagrees with the copied histograms, which would silently rebin on a later
+    update or spuriously fail a later merge compatibility check.
+    """
+    rng = np.random.default_rng(7)
+
+    other = RunningQuantileStats(num_quantile_bins=2000)
+    other.update(rng.normal(size=(500, 2)))
+
+    # Empty receiver constructed with a DIFFERENT bin count.
+    merged = RunningQuantileStats(num_quantile_bins=500)
+    merged.merge(other)
+
+    # Config is adopted from other and consistent with the copied histograms.
+    assert merged._num_quantile_bins == 2000
+    assert all(len(h) == 2000 for h in merged._histograms)
+    assert all(len(e) == 2001 for e in merged._bin_edges)
+
+    # A later update that expands the range keeps the adopted resolution.
+    merged.update(rng.normal(10.0, 1.0, size=(50, 2)))  # shifts max -> triggers _adjust_histograms
+    assert all(len(h) == 2000 for h in merged._histograms)
+
+    # A later merge with a third accumulator at the adopted resolution must not raise.
+    third = RunningQuantileStats(num_quantile_bins=2000)
+    third.update(rng.normal(size=(100, 2)))
+    merged.merge(third)
+    assert merged.get_statistics()["count"][0] == 500 + 50 + 100
+
+
 def test_merge_validates_compatibility():
     """Merging mismatched bin counts or vector lengths raises a clear error."""
     rng = np.random.default_rng(3)

--- a/tests/datasets/test_compute_stats.py
+++ b/tests/datasets/test_compute_stats.py
@@ -21,12 +21,16 @@ import pytest
 pytest.importorskip("datasets", reason="datasets is required (install lerobot[dataset])")
 
 from lerobot.datasets.compute_stats import (
+    DEFAULT_QUANTILES,
     RunningQuantileStats,
     _assert_type_and_shape,
     aggregate_feature_stats,
+    aggregate_quantile_stats,
     aggregate_stats,
     compute_episode_stats,
+    compute_feature_running_stats,
     estimate_num_samples,
+    feature_stats_from_running,
     get_feature_stats,
     sample_images,
     sample_indices,
@@ -857,3 +861,175 @@ def test_fixed_quantiles_always_computed():
         for q_key in expected_quantiles:
             assert q_key in episode_stats[key]
             assert episode_stats[key][q_key].shape == (features[key]["shape"][0],)
+
+
+# ---------------------------------------------------------------------------
+# RunningQuantileStats.merge and global-quantile helpers
+# ---------------------------------------------------------------------------
+
+QUANTILE_KEYS = ["q01", "q10", "q50", "q90", "q99"]
+
+
+def test_merge_matches_single_pass():
+    """Merging per-chunk accumulators matches a single pass over all data."""
+    rng = np.random.default_rng(0)
+    data = rng.normal(0.0, 1.0, size=(20000, 3))
+
+    single = RunningQuantileStats()
+    single.update(data)
+    single_stats = single.get_statistics()
+
+    merged = RunningQuantileStats()
+    for chunk in np.array_split(data, 5):
+        part = RunningQuantileStats()
+        part.update(chunk)
+        merged.merge(part)
+    merged_stats = merged.get_statistics()
+
+    # mean / std / min / max / count are exact (no histogram discretization).
+    np.testing.assert_allclose(merged_stats["mean"], single_stats["mean"], rtol=1e-6, atol=1e-8)
+    np.testing.assert_allclose(merged_stats["std"], single_stats["std"], rtol=1e-6, atol=1e-8)
+    np.testing.assert_allclose(merged_stats["min"], single_stats["min"])
+    np.testing.assert_allclose(merged_stats["max"], single_stats["max"])
+    np.testing.assert_allclose(merged_stats["count"], single_stats["count"])
+
+    # Quantiles match the single pass and the numpy ground truth to bin resolution.
+    for q_key, q in zip(QUANTILE_KEYS, DEFAULT_QUANTILES, strict=True):
+        np.testing.assert_allclose(merged_stats[q_key], single_stats[q_key], atol=0.02)
+        np.testing.assert_allclose(merged_stats[q_key], np.quantile(data, q, axis=0), atol=0.05)
+
+
+def test_merge_yields_global_quantiles_unlike_averaging():
+    """The core fix: merging gives global quantiles; averaging per-shard quantiles does not.
+
+    Two episodes with well-separated distributions make averaging clearly wrong:
+    the global q01 lives inside the lower cluster, but the mean of the two
+    per-episode q01 values lands between the clusters.
+    """
+    rng = np.random.default_rng(1)
+    ep1 = rng.normal(-5.0, 0.5, size=(5000, 1))
+    ep2 = rng.normal(5.0, 0.5, size=(5000, 1))
+    all_data = np.concatenate([ep1, ep2])
+
+    rs1 = RunningQuantileStats()
+    rs1.update(ep1)
+    rs2 = RunningQuantileStats()
+    rs2.update(ep2)
+    s1, s2 = rs1.get_statistics(), rs2.get_statistics()
+
+    merged = aggregate_quantile_stats([rs1, rs2]).get_statistics()
+
+    true_q01 = np.quantile(all_data, 0.01, axis=0)
+    true_q99 = np.quantile(all_data, 0.99, axis=0)
+
+    # Equal counts -> averaging is the simple mean of per-episode quantiles.
+    avg_q01 = (s1["q01"] + s2["q01"]) / 2
+    avg_q99 = (s1["q99"] + s2["q99"]) / 2
+
+    # Merged histogram recovers the true global quantiles.
+    np.testing.assert_allclose(merged["q01"], true_q01, atol=0.15)
+    np.testing.assert_allclose(merged["q99"], true_q99, atol=0.15)
+
+    # Averaging is badly biased toward the center (off by several units), and far
+    # worse than the merged result.
+    merged_err = abs(merged["q01"].item() - true_q01.item())
+    avg_err = abs(avg_q01.item() - true_q01.item())
+    assert avg_err > 1.0
+    assert avg_err > 10 * merged_err
+    assert abs(avg_q99.item() - true_q99.item()) > 1.0
+
+
+def test_merge_empty_is_identity():
+    """Merging with an empty accumulator leaves data unchanged (either direction)."""
+    rng = np.random.default_rng(2)
+    data = rng.normal(size=(200, 2))
+
+    rs = RunningQuantileStats()
+    rs.update(data)
+    ref = rs.get_statistics()
+
+    # Empty other: no-op.
+    rs.merge(RunningQuantileStats())
+    np.testing.assert_allclose(rs.get_statistics()["q50"], ref["q50"])
+    np.testing.assert_allclose(rs.get_statistics()["mean"], ref["mean"])
+
+    # Empty self: copies other's state exactly.
+    empty = RunningQuantileStats()
+    empty.merge(rs)
+    np.testing.assert_array_equal(empty.get_statistics()["q50"], ref["q50"])
+    np.testing.assert_array_equal(empty.get_statistics()["max"], ref["max"])
+
+
+def test_merge_validates_compatibility():
+    """Merging mismatched bin counts or vector lengths raises a clear error."""
+    rng = np.random.default_rng(3)
+
+    a = RunningQuantileStats(num_quantile_bins=100)
+    a.update(rng.normal(size=(10, 2)))
+    b = RunningQuantileStats(num_quantile_bins=200)
+    b.update(rng.normal(size=(10, 2)))
+    with pytest.raises(ValueError, match="num_quantile_bins"):
+        a.merge(b)
+
+    c = RunningQuantileStats()
+    c.update(rng.normal(size=(10, 3)))
+    d = RunningQuantileStats()
+    d.update(rng.normal(size=(10, 2)))
+    with pytest.raises(ValueError, match="vector lengths"):
+        c.merge(d)
+
+
+def test_aggregate_quantile_stats_matches_sequential_merge():
+    """aggregate_quantile_stats equals an explicit sequential merge and ignores input order side effects."""
+    rng = np.random.default_rng(4)
+    chunks = [rng.normal(size=(2000, 2)) for _ in range(4)]
+
+    rs_list = []
+    for chunk in chunks:
+        part = RunningQuantileStats()
+        part.update(chunk)
+        rs_list.append(part)
+
+    agg = aggregate_quantile_stats(rs_list).get_statistics()
+
+    seq = RunningQuantileStats()
+    for chunk in chunks:
+        part = RunningQuantileStats()
+        part.update(chunk)
+        seq.merge(part)
+    seq_stats = seq.get_statistics()
+
+    for key in ("mean", "std", "min", "max", *QUANTILE_KEYS):
+        np.testing.assert_allclose(agg[key], seq_stats[key], rtol=1e-9, atol=1e-9)
+
+    # Inputs are not mutated by aggregation.
+    np.testing.assert_allclose(rs_list[0].get_statistics()["count"], np.array([2000]))
+
+    with pytest.raises(ValueError, match="empty list"):
+        aggregate_quantile_stats([])
+
+
+def test_compute_feature_running_stats_roundtrip():
+    """compute_feature_running_stats + feature_stats_from_running == get_feature_stats."""
+    rng = np.random.default_rng(5)
+    array = rng.normal(size=(50, 4)).astype(np.float32)
+
+    running_stats, sample_count = compute_feature_running_stats(
+        array, axis=0, quantile_list=DEFAULT_QUANTILES
+    )
+    assert sample_count == 50
+    finalized = feature_stats_from_running(
+        running_stats, sample_count, axis=0, keepdims=False, original_shape=array.shape
+    )
+    direct = get_feature_stats(array, axis=0, keepdims=False)
+
+    assert set(finalized.keys()) == set(direct.keys())
+    for key in direct:
+        np.testing.assert_allclose(finalized[key], direct[key], rtol=1e-6, atol=1e-6)
+
+
+def test_compute_feature_running_stats_insufficient_samples():
+    """Fewer than 2 vectors yields no accumulator (caller falls back to basic stats)."""
+    running_stats, sample_count = compute_feature_running_stats(np.array([[1.0, 2.0]]), axis=0)
+    assert running_stats is None
+    assert sample_count == 1


### PR DESCRIPTION
## Summary / Motivation

Dataset-level quantile statistics (`q01, q10, q50, q90, q99`) are currently produced by **count-weighted averaging of per-episode quantiles** in `aggregate_feature_stats`. This is statistically incorrect: the mean of per-episode `q01` values is not the global `q01`. Averaging pulls the distribution tails inward (`q01` too high, `q99` too low).

This matters for quantile-normalized policies (pi0 / pi0.5), which map `[q01, q99] -> [-1, 1]` **without clipping**. With inward-biased quantiles, a large fraction of real actions/states normalize to values well outside `[-1, 1]`.

Exact global quantiles cannot be reconstructed from already-summarized stats dicts (they need the underlying data/histograms), so this PR adds a streaming **histogram-merge** path that yields true global quantiles in a single pass with bounded memory — the same "single global running histogram" approach used by openpi and by the repo's existing `compute_relative_action_stats`.

## Related issues

- Related: N/A

## What changed

- **`RunningQuantileStats.merge(other)`** (new): re-bins both accumulators' histograms onto their union range and sums the counts; `mean`/`std`/`min`/`max`/`count` combine exactly. The resulting quantiles are global, accurate to histogram resolution — not a count-weighted average.
- **New helpers**: `aggregate_quantile_stats(list)`, `compute_feature_running_stats(...)`, `feature_stats_from_running(...)`. `get_feature_stats` is refactored to reuse them (no behavior change). All exported from `lerobot.datasets`.
- **`scripts/augment_dataset_quantile_stats.py`**: now streams each episode into per-feature running histograms and merges them instead of calling `aggregate_stats`, producing true global quantiles with bounded memory (one merged accumulator per feature). Run with `--overwrite` to upgrade datasets that already carry biased quantiles.
- **`aggregate_feature_stats`**: its quantile aggregation remains a documented approximation for summary-only callers (recording / multi-dataset combine), since exact global quantiles can't be recovered there. It now carries an explanatory comment and emits a one-time warning pointing to the recompute path. `mean`/`std`/`min`/`max` aggregation is unchanged.

No breaking changes. Existing stats files remain valid; the augment script (with `--overwrite`) upgrades biased quantiles to correct global ones.

## How was this tested (or how to run locally)

- New unit tests in `tests/datasets/test_compute_stats.py`:
  - `test_merge_matches_single_pass` — merged per-chunk accumulators equal a single pass; mean/std/min/max exact, quantiles match `np.quantile`.
  - `test_merge_yields_global_quantiles_unlike_averaging` — on a bimodal two-episode distribution, merge recovers the true global `q01/q99` (matches `np.quantile`) while averaging per-episode quantiles is >10x worse.
  - empty/identity merges, compatibility validation, and the new-helper round-trips.
- Commands:
  - `pre-commit run --files src/lerobot/datasets/compute_stats.py src/lerobot/datasets/__init__.py src/lerobot/scripts/augment_dataset_quantile_stats.py tests/datasets/test_compute_stats.py` → all hooks pass (ruff, typos, bandit, mypy, …).
  - `pytest -q tests/datasets/test_compute_stats.py tests/datasets/test_quantiles_dataset_integration.py tests/processor/test_normalize_processor.py` → **118 passed, 1 skipped**.
- Manual end-to-end check on a synthetic 4-episode dataset (per-episode means -9/-3/+3/+9): the augment script's merged `q01` matches `np.quantile` to <0.05, whereas the per-episode-averaged `q01` was off by ~8.6.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`) — run on the changed files; all hooks pass
- [x] All tests pass locally (`pytest`) — stats / quantile-integration / normalize suites (118 passed, 1 skipped); commands above
- [ ] Documentation updated — n/a for user-facing docs; inline docstrings + augment-script module docstring updated
- [ ] CI is green — pending CI on this PR
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: # (TODO: add link)

## Reviewer notes

- Focus areas: `RunningQuantileStats.merge` (histogram re-binning math) and the rewritten `compute_quantile_stats_for_dataset` in the augment script.
- Design note: `aggregate_feature_stats` still averages quantiles for summary-only callers because exact global quantiles can't be reconstructed from per-episode summaries. The new one-time `logging.warning` flags this; happy to soften it to a docstring-only note if preferred.
- This PR intentionally does **not** change the live recording path (`save_episode` → `aggregate_stats`); freshly recorded datasets still get approximate quantiles at record time and should be upgraded with the augment script before training quantile-normalized policies. A follow-up could thread running-histogram accumulators through recording for end-to-end correctness if desired.
