### PR TITLE
Add AgileX Piper plugin docs

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -159,6 +159,8 @@
     title: OpenArm
   - local: rebot_b601
     title: reBot B601-DM
+  - local: piper
+    title: AgileX Piper
   title: "Robots"
 - sections:
   - local: phone_teleop

--- a/docs/source/piper.mdx
+++ b/docs/source/piper.mdx
@@ -1,0 +1,41 @@
+# AgileX Piper
+
+The AgileX Piper can be used with LeRobot through the external [`lerobot_robot_piper`](https://github.com/charlie8612/lerobot_robot_piper) plugin. The plugin registers a `piper_follower` robot type, so it can be used by the standard LeRobot command line tools without patching LeRobot itself.
+
+This is a community-maintained integration. It controls the Piper arm over CAN using `piper-sdk` and exposes the six arm joints plus gripper through the LeRobot `Robot` interface.
+
+## Install
+
+Install LeRobot first, then install the plugin in the same Python environment:
+
+```bash
+pip install git+https://github.com/charlie8612/lerobot_robot_piper.git
+```
+
+You also need to bring up the CAN interface used by your Piper arm before connecting, for example `can0` or a named interface such as `piper_left`.
+
+## Teleoperate
+
+Once installed, the plugin self-registers as `piper_follower`:
+
+```bash
+lerobot-teleoperate \
+  --robot.type=piper_follower \
+  --robot.can_port=can0 \
+  --robot.speed_rate=50 \
+  --teleop.type=keyboard
+```
+
+Replace the teleoperator configuration with the leader device you want to use.
+
+## Key Options
+
+- `can_port`: CAN interface name, for example `can0` or `piper_left`.
+- `speed_rate`: Piper MOVE-J speed percentage.
+- `unit`: API unit, `deg` by default or `rad` for policies/datasets that use radians.
+- `max_relative_target`: optional per-step target clamp in degrees.
+- `go_home_on_connect`: optionally interpolate to a configured home pose after connection.
+- `rest_position_deg`: configurable rest pose used before disabling the arm.
+- `use_mit_mode`: enables Piper MIT impedance control mode.
+
+For the full list of options and safety behavior, see the [`lerobot_robot_piper` README](https://github.com/charlie8612/lerobot_robot_piper).


### PR DESCRIPTION
## What this adds

Adds a short documentation page for the community-maintained AgileX Piper LeRobot plugin:

- links to `charlie8612/lerobot_robot_piper`
- documents installation from GitHub
- shows the `piper_follower` robot type with a minimal `lerobot-teleoperate` example
- summarizes the main configuration options

The plugin remains external and pip-installable; this PR does not add Piper driver code to LeRobot core.

## Why

Piper users can integrate the arm with LeRobot through the plugin system without patching this repository. Adding it to the hardware docs makes the integration discoverable while keeping maintenance outside core.

## Validation

- Verified the plugin installs from the public GitHub repository in a clean Python 3.12 environment with LeRobot 0.5.1.
- Verified `piper_follower` registers in `RobotConfig.get_known_choices()`.
- Docs-only change; no code tests run in this checkout.

## AI assistance

This documentation PR was prepared with AI assistance and reviewed before submission.
