### PR TITLE
fix(cameras): snapshot stop_event in read loops to avoid None deref

### DIFF
--- a/src/lerobot/cameras/opencv/camera_opencv.py
+++ b/src/lerobot/cameras/opencv/camera_opencv.py
@@ -486,7 +486,6 @@ class OpenCVCamera(Camera):
             self.thread.join(timeout=2.0)
 
         self.thread = None
-        self.stop_event = None
 
         with self.frame_lock:
             self.latest_frame = None

--- a/src/lerobot/cameras/opencv/camera_opencv.py
+++ b/src/lerobot/cameras/opencv/camera_opencv.py
@@ -442,11 +442,12 @@ class OpenCVCamera(Camera):
 
         Stops on DeviceNotConnectedError, logs other errors and continues.
         """
-        if self.stop_event is None:
+        stop_event = self.stop_event
+        if stop_event is None:
             raise RuntimeError(f"{self}: stop_event is not initialized before starting read loop.")
 
         failure_count = 0
-        while not self.stop_event.is_set():
+        while not stop_event.is_set():
             try:
                 raw_frame = self._read_from_hardware()
                 processed_frame = self._postprocess_image(raw_frame)
@@ -486,6 +487,7 @@ class OpenCVCamera(Camera):
             self.thread.join(timeout=2.0)
 
         self.thread = None
+        self.stop_event = None
 
         with self.frame_lock:
             self.latest_frame = None

--- a/src/lerobot/cameras/realsense/camera_realsense.py
+++ b/src/lerobot/cameras/realsense/camera_realsense.py
@@ -471,11 +471,12 @@ class RealSenseCamera(Camera):
 
         Stops on DeviceNotConnectedError, logs other errors and continues.
         """
-        if self.stop_event is None:
+        stop_event = self.stop_event
+        if stop_event is None:
             raise RuntimeError(f"{self}: stop_event is not initialized before starting read loop.")
 
         failure_count = 0
-        while not self.stop_event.is_set():
+        while not stop_event.is_set():
             try:
                 frame = self._read_from_hardware()
                 color_frame_raw = frame.get_color_frame()

--- a/src/lerobot/cameras/zmq/camera_zmq.py
+++ b/src/lerobot/cameras/zmq/camera_zmq.py
@@ -246,11 +246,12 @@ class ZMQCamera(Camera):
         """
         Internal loop run by the background thread for asynchronous reading.
         """
-        if self.stop_event is None:
+        stop_event = self.stop_event
+        if stop_event is None:
             raise RuntimeError(f"{self}: stop_event is not initialized.")
 
         failure_count = 0
-        while not self.stop_event.is_set():
+        while not stop_event.is_set():
             try:
                 frame = self._read_from_hardware()
                 capture_time = time.perf_counter()


### PR DESCRIPTION
This PR supersedes #3571 

## Summary / Motivation

- This PR hardens the asynchronous background read loop (`_read_loop`) in all cameras that run a worker thread (`OpenCVCamera`, `RealSenseCamera`, and the ZMQ camera) against a race on `self.stop_event`. The loop previously read the `self.stop_event` attribute on every iteration, but `_stop_read_thread()` reassigns it to `None` after joining the worker. Reading the attribute across a compound condition (`self.stop_event is None or self.stop_event.is_set()`) is a time-of-check/time-of-use race: if the attribute flips to `None` between the two sub-expressions, the worker thread raises `AttributeError`.

- The fix snapshots `self.stop_event` into a local once at the top of the loop and uses that local throughout. The `threading.Event` object is thread-safe and lives for the worker's lifetime, and `_stop_read_thread()` always calls `.set()` before nulling the attribute, so the local reliably observes the stop request and the loop exits cleanly. Trade-off: this relies on the existing "set-before-null" invariant; if a future change nulls the event without setting it, an identity guard (`if self.stop_event is not stop_event: break`) would be needed.

## Related issues

- Fixes / Closes: # (n/a)
- Related: #3571

## What changed

- `_read_loop` in `OpenCVCamera`, `RealSenseCamera`, and the ZMQ camera now snapshot `self.stop_event` into a local variable, guard it for `None`, and loop on `while not stop_event.is_set()` instead of re-reading the attribute.

## How was this tested (or how to run locally)

- Solves the `AttributeError` consistently on a RealSense camera setup. No impact on a functional OpenCV camera setup.

## Checklist (required before merge)

- [ ] Linting/formatting run (`pre-commit run -a`)
- [ ] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: # (insert PR number/link)

## Reviewer notes

- Anything the reviewer should focus on (performance, edge-cases, specific files) or general notes.
- Anyone in the community is free to review the PR.
