### PR TITLE
feat(policies) Support loading policies from a Hugging Face Hub revision

### DIFF
--- a/docs/source/inference.mdx
+++ b/docs/source/inference.mdx
@@ -244,6 +244,7 @@ See the [Real-Time Chunking](./rtc) guide for details on tuning RTC parameters.
 | Flag                              | Description                                                       | Default |
 | --------------------------------- | ----------------------------------------------------------------- | ------- |
 | `--policy.path`                   | **Required.** HF Hub model ID or local checkpoint path            | --      |
+| `--policy.revision`               | HF Hub model revision/branch/tag/commit.                          | --      |
 | `--robot.type`                    | **Required.** Robot type (e.g. `so100_follower`, `koch_follower`) | --      |
 | `--robot.port`                    | Serial port for the robot                                         | --      |
 | `--robot.cameras`                 | Camera configuration (JSON dict)                                  | --      |

--- a/src/lerobot/configs/eval.py
+++ b/src/lerobot/configs/eval.py
@@ -44,16 +44,8 @@ class EvalPipelineConfig:
 
     def __post_init__(self) -> None:
         # HACK: We parse again the cli args here to get the pretrained path if there was one.
-        policy_path = parser.get_path_arg("policy")
-        if policy_path:
-            yaml_overrides = parser.get_yaml_overrides("policy")
-            cli_overrides = parser.get_cli_overrides("policy") or []
-            self.policy = PreTrainedConfig.from_pretrained(
-                policy_path, cli_overrides=yaml_overrides + cli_overrides
-            )
-            self.policy.pretrained_path = Path(policy_path)
-
-        else:
+        self.policy = parser.load_pretrained_config_from_cli("policy")
+        if self.policy is None:
             logger.warning(
                 "No pretrained path was provided, evaluated policy will be built from scratch (random weights)."
             )

--- a/src/lerobot/configs/parser.py
+++ b/src/lerobot/configs/parser.py
@@ -23,7 +23,10 @@ from functools import wraps
 from pathlib import Path
 from pkgutil import ModuleInfo
 from types import ModuleType
-from typing import Any, TypeVar, cast
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+
+if TYPE_CHECKING:
+    from lerobot.configs.policies import PreTrainedConfig
 
 import draccus
 import yaml  # type: ignore[import-untyped]
@@ -179,6 +182,20 @@ def get_path_arg(field_name: str, args: Sequence[str] | None = None) -> str | No
 
 def get_yaml_overrides(field_name: str) -> list[str]:
     return _config_yaml_overrides.get(field_name, [])
+
+
+def load_pretrained_config_from_cli(field_name: str = "policy") -> "PreTrainedConfig | None":
+    """Load a ``PreTrainedConfig`` from ``--{field_name}.path`` if it was passed on the CLI."""
+    from lerobot.configs.policies import PreTrainedConfig
+
+    path = get_path_arg(field_name)
+    if not path:
+        return None
+
+    overrides = get_yaml_overrides(field_name) + (get_cli_overrides(field_name) or [])
+    config = PreTrainedConfig.from_pretrained(path, cli_overrides=overrides)
+    config.pretrained_path = Path(path)
+    return config
 
 
 def get_type_arg(field_name: str, args: Sequence[str] | None = None) -> str | None:

--- a/src/lerobot/configs/policies.py
+++ b/src/lerobot/configs/policies.py
@@ -31,6 +31,7 @@ from lerobot.utils.constants import ACTION, OBS_STATE
 from lerobot.utils.device_utils import auto_select_torch_device, is_amp_available, is_torch_device_available
 from lerobot.utils.hub import HubMixin
 
+from .parser import parse_arg
 from .types import FeatureType, PolicyFeature
 
 T = TypeVar("T", bound="PreTrainedConfig")
@@ -79,6 +80,9 @@ class PreTrainedConfig(draccus.ChoiceRegistry, HubMixin, abc.ABC):  # type: igno
     # Either the repo ID of a model hosted on the Hub or a path to a directory containing weights
     # saved using `Policy.save_pretrained`. If not provided, the policy is initialized from scratch.
     pretrained_path: Path | None = None
+    # The specific model version to load when `pretrained_path` points to a Hugging Face Hub repo.
+    # Can be a branch name, a tag name, or a commit hash. Ignored for local paths.
+    revision: str | None = None
 
     def __post_init__(self) -> None:
         if not self.device or not is_torch_device_available(self.device):
@@ -179,6 +183,8 @@ class PreTrainedConfig(draccus.ChoiceRegistry, HubMixin, abc.ABC):  # type: igno
         **policy_kwargs: Any,
     ) -> T:
         model_id = str(pretrained_name_or_path)
+        if revision is None:
+            revision = parse_arg("revision", policy_kwargs.get("cli_overrides") or [])
         config_file: str | None = None
         if Path(model_id).is_dir():
             if CONFIG_NAME in os.listdir(model_id):
@@ -223,4 +229,9 @@ class PreTrainedConfig(draccus.ChoiceRegistry, HubMixin, abc.ABC):  # type: igno
 
         cli_overrides = policy_kwargs.pop("cli_overrides", [])
         with draccus.config_type("json"):
-            return draccus.parse(orig_config.__class__, config_file, args=cli_overrides)
+            parsed = draccus.parse(orig_config.__class__, config_file, args=cli_overrides)
+
+        # This covers the case where `revision` was passed as an explicit kwarg rather than a CLI override.
+        if parsed.revision is None and revision is not None:
+            parsed.revision = revision
+        return parsed

--- a/src/lerobot/configs/rewards.py
+++ b/src/lerobot/configs/rewards.py
@@ -32,6 +32,7 @@ from lerobot.optim.schedulers import LRSchedulerConfig
 from lerobot.utils.device_utils import auto_select_torch_device, is_torch_device_available
 from lerobot.utils.hub import HubMixin
 
+from .parser import parse_arg
 from .types import PolicyFeature
 
 T = TypeVar("T", bound="RewardModelConfig")
@@ -56,6 +57,9 @@ class RewardModelConfig(draccus.ChoiceRegistry, HubMixin, abc.ABC):
     device: str | None = None
 
     pretrained_path: str | None = None
+    # The specific model version to load when `pretrained_path` points to a Hugging Face Hub repo.
+    # Can be a branch name, a tag name, or a commit hash. Ignored for local paths.
+    revision: str | None = None
 
     push_to_hub: bool = False
     repo_id: str | None = None
@@ -119,6 +123,8 @@ class RewardModelConfig(draccus.ChoiceRegistry, HubMixin, abc.ABC):
         **reward_kwargs: Any,
     ) -> T:
         model_id = str(pretrained_name_or_path)
+        if revision is None:
+            revision = parse_arg("revision", reward_kwargs.get("cli_overrides") or [])
         config_file: str | None = None
         if Path(model_id).is_dir():
             if CONFIG_NAME in os.listdir(model_id):
@@ -161,4 +167,9 @@ class RewardModelConfig(draccus.ChoiceRegistry, HubMixin, abc.ABC):
 
         cli_overrides = reward_kwargs.pop("cli_overrides", [])
         with draccus.config_type("json"):
-            return draccus.parse(orig_config.__class__, config_file, args=cli_overrides)
+            parsed = draccus.parse(orig_config.__class__, config_file, args=cli_overrides)
+
+        # This covers the case where `revision` was passed as an explicit kwarg rather than a CLI override.
+        if parsed.revision is None and revision is not None:
+            parsed.revision = revision
+        return parsed

--- a/src/lerobot/configs/train.py
+++ b/src/lerobot/configs/train.py
@@ -144,12 +144,7 @@ class TrainPipelineConfig(HubMixin):
             )
             self.reward_model.pretrained_path = str(Path(reward_model_path))
         elif policy_path:
-            yaml_overrides = parser.get_yaml_overrides("policy")
-            cli_overrides = parser.get_cli_overrides("policy") or []
-            self.policy = PreTrainedConfig.from_pretrained(
-                policy_path, cli_overrides=yaml_overrides + cli_overrides
-            )
-            self.policy.pretrained_path = Path(policy_path)
+            self.policy = parser.load_pretrained_config_from_cli("policy")
         elif self.resume:
             config_path = parser.parse_arg("config_path")
             if not config_path:

--- a/src/lerobot/policies/factory.py
+++ b/src/lerobot/policies/factory.py
@@ -268,7 +268,8 @@ def make_pre_post_processors(
     Args:
         policy_cfg: The configuration of the policy for which to create processors.
         pretrained_path: An optional path to load pretrained processor pipelines from.
-            If provided, pipelines are loaded from this path.
+            If provided, pipelines are loaded from this path. When it is a Hub repo id, the
+            pipelines are loaded from `policy_cfg.revision` (branch, tag, or commit hash).
         **kwargs: Keyword arguments for processor configuration, as defined in
             `ProcessorConfigKwargs`.
 
@@ -306,6 +307,7 @@ def make_pre_post_processors(
             config_filename=kwargs.get(
                 "preprocessor_config_filename", f"{POLICY_PREPROCESSOR_DEFAULT_NAME}.json"
             ),
+            revision=policy_cfg.revision,
             overrides=kwargs.get("preprocessor_overrides", {}),
             to_transition=batch_to_transition,
             to_output=transition_to_batch,
@@ -315,6 +317,7 @@ def make_pre_post_processors(
             config_filename=kwargs.get(
                 "postprocessor_config_filename", f"{POLICY_POSTPROCESSOR_DEFAULT_NAME}.json"
             ),
+            revision=policy_cfg.revision,
             overrides=kwargs.get("postprocessor_overrides", {}),
             to_transition=policy_action_to_transition,
             to_output=transition_to_policy_action,
@@ -557,6 +560,7 @@ def make_policy(
         # Load a pretrained policy and override the config if needed (for example, if there are inference-time
         # hyperparameters that we want to vary).
         kwargs["pretrained_name_or_path"] = cfg.pretrained_path
+        kwargs["revision"] = cfg.revision
         policy = policy_cls.from_pretrained(**kwargs)
     elif cfg.pretrained_path and cfg.use_peft:
         # Load a pretrained PEFT model on top of the policy. The pretrained path points to the folder/repo
@@ -567,7 +571,9 @@ def make_policy(
         logging.info("Loading policy's PEFT adapter.")
 
         peft_pretrained_path = str(cfg.pretrained_path)
-        peft_config = PeftConfig.from_pretrained(peft_pretrained_path)
+        # `cfg.revision` refers to the adapter repo (`pretrained_path`), not the base model, which
+        # lives in a separate repo with its own versioning. Only the adapter loads get the revision.
+        peft_config = PeftConfig.from_pretrained(peft_pretrained_path, revision=cfg.revision)
 
         kwargs["pretrained_name_or_path"] = peft_config.base_model_name_or_path
         if not kwargs["pretrained_name_or_path"]:
@@ -580,7 +586,7 @@ def make_policy(
 
         policy = policy_cls.from_pretrained(**kwargs)
         policy = PeftModel.from_pretrained(
-            policy, peft_pretrained_path, config=peft_config, is_trainable=True
+            policy, peft_pretrained_path, config=peft_config, is_trainable=True, revision=cfg.revision
         )
 
     else:

--- a/src/lerobot/rollout/configs.py
+++ b/src/lerobot/rollout/configs.py
@@ -321,11 +321,7 @@ class RolloutConfig:
         if self.robot is None:
             raise ValueError("--robot.type is required for rollout")
 
-        policy_path = parser.get_path_arg("policy")
-        if policy_path:
-            cli_overrides = parser.get_cli_overrides("policy")
-            self.policy = PreTrainedConfig.from_pretrained(policy_path, cli_overrides=cli_overrides)
-            self.policy.pretrained_path = policy_path
+        self.policy = parser.load_pretrained_config_from_cli("policy")
         if self.policy is None:
             raise ValueError("--policy.path is required for rollout")
 

--- a/src/lerobot/rollout/context.py
+++ b/src/lerobot/rollout/context.py
@@ -191,13 +191,19 @@ def build_rollout_context(
         from peft import PeftConfig, PeftModel
 
         peft_path = policy_config.pretrained_path
-        peft_config = PeftConfig.from_pretrained(peft_path)
+        # `revision` refers to the adapter repo (`pretrained_path`), not the base model, which lives
+        # in a separate repo with its own versioning. Only the adapter loads get the revision.
+        peft_config = PeftConfig.from_pretrained(peft_path, revision=policy_config.revision)
         policy = policy_class.from_pretrained(
             pretrained_name_or_path=peft_config.base_model_name_or_path, config=policy_config
         )
-        policy = PeftModel.from_pretrained(policy, peft_path, config=peft_config)
+        policy = PeftModel.from_pretrained(
+            policy, peft_path, config=peft_config, revision=policy_config.revision
+        )
     else:
-        policy = policy_class.from_pretrained(policy_config.pretrained_path, config=policy_config)
+        policy = policy_class.from_pretrained(
+            policy_config.pretrained_path, config=policy_config, revision=policy_config.revision
+        )
 
     if is_rtc:
         policy.config.rtc_config = cfg.inference.rtc

--- a/tests/test_policy_revision.py
+++ b/tests/test_policy_revision.py
@@ -1,0 +1,171 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for loading policies from a specific Hugging Face Hub revision.
+
+These stay offline: Hub downloads (`hf_hub_download`) and heavy `from_pretrained` calls are mocked,
+so we only check that `revision` is resolved and threaded through the loading paths.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+
+import lerobot.policies.factory as factory
+from lerobot.configs import parser
+from lerobot.configs.policies import PreTrainedConfig
+from lerobot.configs.rewards import RewardModelConfig
+from lerobot.configs.types import FeatureType, PolicyFeature
+from lerobot.optim.optimizers import AdamWConfig
+from lerobot.policies.act.configuration_act import ACTConfig
+from lerobot.policies.factory import make_policy, make_pre_post_processors
+from lerobot.utils.constants import ACTION, OBS_STATE
+
+
+@pytest.fixture
+def act_config_file(tmp_path):
+    """Write a valid ACT ``config.json`` to a temp dir and return its path."""
+    ACTConfig()._save_pretrained(tmp_path)
+    return tmp_path / "config.json"
+
+
+def test_from_pretrained_resolves_revision_from_cli_overrides(act_config_file):
+    # `--policy.revision` arrives as a CLI override; it must be resolved *before* downloading
+    # config.json (not just for the weights) and recorded on the parsed config.
+    with patch("lerobot.configs.policies.hf_hub_download", return_value=str(act_config_file)) as mock_dl:
+        cfg = PreTrainedConfig.from_pretrained("org/model", cli_overrides=["--revision=abc123"])
+
+    assert mock_dl.call_args.kwargs["revision"] == "abc123"
+    assert cfg.revision == "abc123"
+
+
+def test_from_pretrained_revision_kwarg_is_persisted(act_config_file):
+    # When passed programmatically (no CLI override), the revision is still recorded on the config.
+    with patch("lerobot.configs.policies.hf_hub_download", return_value=str(act_config_file)) as mock_dl:
+        cfg = PreTrainedConfig.from_pretrained("org/model", revision="v1.0")
+
+    assert mock_dl.call_args.kwargs["revision"] == "v1.0"
+    assert cfg.revision == "v1.0"
+
+
+@RewardModelConfig.register_subclass(name="_rev_test_reward")
+@dataclass
+class _RevRewardConfig(RewardModelConfig):
+    def get_optimizer_preset(self):
+        return AdamWConfig(lr=1e-4)
+
+
+def test_reward_config_threads_revision(tmp_path):
+    # RewardModelConfig mirrors the policy loading path; verify the copy stays in sync.
+    _RevRewardConfig()._save_pretrained(tmp_path)
+    with patch(
+        "lerobot.configs.rewards.hf_hub_download", return_value=str(tmp_path / "config.json")
+    ) as mock_dl:
+        loaded = RewardModelConfig.from_pretrained("org/reward", revision="rv2")
+
+    assert mock_dl.call_args.kwargs["revision"] == "rv2"
+    assert loaded.revision == "rv2"
+
+
+def test_load_pretrained_config_from_cli_returns_none_without_path(monkeypatch):
+    monkeypatch.setattr(parser, "get_path_arg", lambda field_name: None)
+    assert parser.load_pretrained_config_from_cli("policy") is None
+
+
+def test_load_pretrained_config_from_cli_threads_overrides_and_path(monkeypatch):
+    monkeypatch.setattr(parser, "get_path_arg", lambda field_name: "org/model")
+    monkeypatch.setattr(parser, "get_yaml_overrides", lambda field_name: ["--n_obs_steps=2"])
+    monkeypatch.setattr(parser, "get_cli_overrides", lambda field_name: ["--revision=v2"])
+
+    sentinel = SimpleNamespace(pretrained_path=None)
+    with patch("lerobot.configs.policies.PreTrainedConfig.from_pretrained", return_value=sentinel) as mock_fp:
+        result = parser.load_pretrained_config_from_cli("policy")
+
+    assert result is sentinel
+    assert result.pretrained_path == Path("org/model")
+    # YAML overrides come before CLI overrides, and `--revision` rides along for from_pretrained.
+    assert mock_fp.call_args.kwargs["cli_overrides"] == ["--n_obs_steps=2", "--revision=v2"]
+
+
+def test_make_pre_post_processors_passes_revision(monkeypatch):
+    cfg = ACTConfig()
+    cfg.revision = "v3"
+
+    mock_pipeline = MagicMock()
+    monkeypatch.setattr(factory, "PolicyProcessorPipeline", mock_pipeline)
+    monkeypatch.setattr(factory, "_reconnect_relative_absolute_steps", lambda *a, **k: None)
+
+    make_pre_post_processors(policy_cfg=cfg, pretrained_path="org/model")
+
+    assert mock_pipeline.from_pretrained.call_count == 2
+    for call in mock_pipeline.from_pretrained.call_args_list:
+        assert call.kwargs["revision"] == "v3"
+
+
+@pytest.fixture
+def fake_policy_cls(monkeypatch):
+    """Patch make_policy's class lookup + feature inference so it can run offline."""
+    features = {
+        ACTION: PolicyFeature(type=FeatureType.ACTION, shape=(6,)),
+        OBS_STATE: PolicyFeature(type=FeatureType.STATE, shape=(6,)),
+    }
+    fake_cls = MagicMock()
+    monkeypatch.setattr(factory, "get_policy_class", lambda _type: fake_cls)
+    monkeypatch.setattr(factory, "env_to_policy_features", lambda _env: features)
+    monkeypatch.setattr(factory, "validate_visual_features_consistency", lambda *a, **k: None)
+    return fake_cls
+
+
+def test_make_policy_threads_revision_to_weights(fake_policy_cls):
+    cfg = ACTConfig()
+    cfg.pretrained_path = "org/model"
+    cfg.revision = "v9"
+    fake_policy_cls.from_pretrained.return_value = MagicMock(spec=torch.nn.Module)
+
+    make_policy(cfg, env_cfg=MagicMock())
+
+    kwargs = fake_policy_cls.from_pretrained.call_args.kwargs
+    assert kwargs["pretrained_name_or_path"] == "org/model"
+    assert kwargs["revision"] == "v9"
+
+
+def test_make_policy_peft_revision_applies_to_adapter_not_base_model(fake_policy_cls):
+    peft = pytest.importorskip("peft")
+
+    cfg = ACTConfig()
+    cfg.pretrained_path = "org/adapter"
+    cfg.revision = "v9"
+    cfg.use_peft = True
+
+    peft_config = SimpleNamespace(base_model_name_or_path="org/base")
+    with (
+        patch.object(peft, "PeftConfig") as mock_peft_config,
+        patch.object(peft, "PeftModel") as mock_peft_model,
+    ):
+        mock_peft_config.from_pretrained.return_value = peft_config
+        mock_peft_model.from_pretrained.return_value = MagicMock(spec=torch.nn.Module)
+        make_policy(cfg, env_cfg=MagicMock())
+
+    # The adapter repo (PeftConfig + PeftModel) is loaded at the requested revision.
+    assert mock_peft_config.from_pretrained.call_args.kwargs["revision"] == "v9"
+    assert mock_peft_model.from_pretrained.call_args.kwargs["revision"] == "v9"
+
+    # The base model lives in a separate repo and must NOT inherit the adapter's revision.
+    base_call = fake_policy_cls.from_pretrained.call_args
+    assert base_call.kwargs["pretrained_name_or_path"] == "org/base"
+    assert "revision" not in base_call.kwargs


### PR DESCRIPTION
## Title

feat(policies) Support loading policies from a Hugging Face Hub revision

## Summary / Motivation

Currently there is `--policy.path` to load a policy from Hub. This PR adds support for `--policy.revision` and `--reward.revision` to specify a branch/tag/commit. 

## Related issues

- [3549](https://github.com/huggingface/lerobot/issues/3549)
- Addresses comments in PR [3630](https://github.com/huggingface/lerobot/pull/3630)

## What changed

- Added a revision field to `PreTrainedConfig` and `RewardModelConfig`.
- For PEFT, the revision is applied to the adapter only.
- `parser.load_pretrained_config_from_cli` to share/centralize functionality.

## How was this tested (or how to run locally)

- Tests added: `test_policy_revision.py`
- Manual checks

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated
- [ ] CI is green
- [x] Community Review: I have reviewed another contributor's open PR and linked it here: #[3630](https://github.com/huggingface/lerobot/pull/3630)

## Reviewer notes

