### PR TITLE
refactor(logging): standardize logging with getLogger(__name__) in scripts/Refactor/structured logging scripts

### DIFF
--- a/src/lerobot/scripts/convert_dataset_v21_to_v30.py
+++ b/src/lerobot/scripts/convert_dataset_v21_to_v30.py
@@ -93,6 +93,8 @@ from lerobot.datasets.video_utils import concatenate_video_files, get_video_dura
 from lerobot.utils.constants import HF_LEROBOT_HOME
 from lerobot.utils.utils import flatten_dict, init_logging
 
+logger = logging.getLogger(__name__)
+
 V21 = "v2.1"
 V30 = "v3.0"
 
@@ -475,11 +477,11 @@ def convert_dataset(
     # First check if the dataset already has a v3.0 version
     if root is None and not force_conversion:
         try:
-            print("Trying to download v3.0 version of the dataset from the hub...")
+            logger.info("Trying to download v3.0 version of the dataset from the hub...")
             snapshot_download(repo_id, repo_type="dataset", revision=V30, local_dir=HF_LEROBOT_HOME / repo_id)
             return
         except Exception:
-            print("Dataset does not have an uploaded v3.0 version. Continuing with conversion.")
+            logger.info("Dataset does not have an uploaded v3.0 version. Continuing with conversion.")
 
     # Set root based on whether local dataset path is provided
     use_local_dataset = False
@@ -487,7 +489,7 @@ def convert_dataset(
     if root.exists():
         validate_local_dataset_version(root)
         use_local_dataset = True
-        print(f"Using local dataset at {root}")
+        logger.info(f"Using local dataset at {root}")
 
     old_root = root.parent / f"{root.name}_old"
     new_root = root.parent / f"{root.name}_v30"
@@ -522,7 +524,7 @@ def convert_dataset(
         try:
             hub_api.delete_tag(repo_id, tag=CODEBASE_VERSION, repo_type="dataset")
         except HTTPError as e:
-            print(f"tag={CODEBASE_VERSION} probably doesn't exist. Skipping exception ({e})")
+            logger.warning(f"tag={CODEBASE_VERSION} probably doesn't exist. Skipping exception ({e})")
             pass
         hub_api.delete_files(
             delete_patterns=["data/chunk*/episode_*", "meta/*.jsonl", "videos/chunk*"],

--- a/src/lerobot/scripts/lerobot_annotate.py
+++ b/src/lerobot/scripts/lerobot_annotate.py
@@ -130,14 +130,14 @@ def _push_to_hub(root: Path, cfg: AnnotationPipelineConfig) -> None:
     repo_id = cfg.new_repo_id or cfg.repo_id
     commit_message = cfg.push_commit_message or "Add steerable annotations (lerobot-annotate)"
     api = HfApi()
-    print(f"[lerobot-annotate] creating/locating dataset repo {repo_id}...", flush=True)
+    logger.info(f"[lerobot-annotate] creating/locating dataset repo {repo_id}...")
     api.create_repo(
         repo_id=repo_id,
         repo_type="dataset",
         private=cfg.push_private,
         exist_ok=True,
     )
-    print(f"[lerobot-annotate] uploading {root} -> {repo_id}...", flush=True)
+    logger.info(f"[lerobot-annotate] uploading {root} -> {repo_id}...")
     commit_info = api.upload_folder(
         folder_path=str(root),
         repo_id=repo_id,
@@ -145,7 +145,7 @@ def _push_to_hub(root: Path, cfg: AnnotationPipelineConfig) -> None:
         commit_message=commit_message,
         ignore_patterns=[".annotate_staging/**", "**/.DS_Store"],
     )
-    print(f"[lerobot-annotate] uploaded to https://huggingface.co/datasets/{repo_id}", flush=True)
+    logger.info(f"[lerobot-annotate] uploaded to https://huggingface.co/datasets/{repo_id}")
 
     # Tag the upload with the codebase version. ``LeRobotDatasetMetadata``
     # resolves the dataset revision via ``get_safe_version`` which scans
@@ -166,9 +166,8 @@ def _push_to_hub(root: Path, cfg: AnnotationPipelineConfig) -> None:
             if isinstance(ds_version, str) and ds_version.startswith("v"):
                 version_tag = ds_version
         except Exception as exc:  # noqa: BLE001
-            print(
-                f"[lerobot-annotate] could not read codebase_version from info.json ({exc}); falling back to {version_tag}",
-                flush=True,
+            logger.warning(
+                f"[lerobot-annotate] could not read codebase_version from info.json ({exc}); falling back to {version_tag}"
             )
     revision = getattr(commit_info, "oid", None)
     tag_kwargs = {
@@ -187,14 +186,13 @@ def _push_to_hub(root: Path, cfg: AnnotationPipelineConfig) -> None:
         with suppress(RevisionNotFoundError):
             api.delete_tag(repo_id, tag=version_tag, repo_type="dataset")
         api.create_tag(**tag_kwargs)
-        print(f"[lerobot-annotate] tagged {repo_id} as {version_tag}", flush=True)
+        logger.info(f"[lerobot-annotate] tagged {repo_id} as {version_tag}")
     except Exception as exc:  # noqa: BLE001
-        print(
+        logger.warning(
             f"[lerobot-annotate] WARNING: could not create tag {version_tag!r} on {repo_id}: {exc}. "
             "Dataset is uploaded but ``LeRobotDataset`` won't be able to load it until it's tagged. "
             "Run: from huggingface_hub import HfApi; "
-            f"HfApi().create_tag({repo_id!r}, tag={version_tag!r}, repo_type='dataset', exist_ok=True)",
-            flush=True,
+            f"HfApi().create_tag({repo_id!r}, tag={version_tag!r}, repo_type='dataset', exist_ok=True)"
         )
 
 

--- a/src/lerobot/scripts/lerobot_dataset_viz.py
+++ b/src/lerobot/scripts/lerobot_dataset_viz.py
@@ -76,6 +76,8 @@ from lerobot.datasets import LeRobotDataset
 from lerobot.utils.constants import ACTION, DONE, OBS_STATE, REWARD
 from lerobot.utils.utils import init_logging
 
+logger = logging.getLogger(__name__)
+
 
 def to_hwc_uint8_numpy(chw_float32_torch: torch.Tensor) -> np.ndarray:
     assert chw_float32_torch.dtype == torch.float32
@@ -187,7 +189,7 @@ def visualize_dataset(
             while True:
                 time.sleep(1)
         except KeyboardInterrupt:
-            print("Ctrl-C received. Exiting.")
+            logger.info("Ctrl-C received. Exiting.")
 
 
 def main():

--- a/src/lerobot/scripts/lerobot_eval.py
+++ b/src/lerobot/scripts/lerobot_eval.py
@@ -94,6 +94,8 @@ from lerobot.utils.utils import (
     inside_slurm,
 )
 
+logger = logging.getLogger(__name__)
+
 
 def rollout(
     env: gym.vector.VectorEnv,
@@ -577,13 +579,13 @@ def eval_main(cfg: EvalPipelineConfig):
             start_seed=cfg.seed,
             max_parallel_tasks=cfg.env.max_parallel_tasks,
         )
-        print("Overall Aggregated Metrics:")
-        print(info["overall"])
+        logger.info("Overall Aggregated Metrics:")
+        logger.info(info["overall"])
 
         # Print per-suite stats
         for task_group, task_group_info in info.items():
-            print(f"\nAggregated Metrics for {task_group}:")
-            print(task_group_info)
+            logger.info(f"\nAggregated Metrics for {task_group}:")
+            logger.info(task_group_info)
     # Close all vec envs
     close_envs(envs)
 

--- a/src/lerobot/scripts/lerobot_find_cameras.py
+++ b/src/lerobot/scripts/lerobot_find_cameras.py
@@ -113,17 +113,17 @@ def find_and_print_cameras(camera_type_filter: str | None = None) -> list[dict[s
         else:
             logger.warning("No cameras (OpenCV or RealSense) were detected.")
     else:
-        print("\n--- Detected Cameras ---")
+        logger.info("\n--- Detected Cameras ---")
         for i, cam_info in enumerate(all_cameras_info):
-            print(f"Camera #{i}:")
+            logger.info(f"Camera #{i}:")
             for key, value in cam_info.items():
                 if key == "default_stream_profile" and isinstance(value, dict):
-                    print(f"  {key.replace('_', ' ').capitalize()}:")
+                    logger.info(f"  {key.replace('_', ' ').capitalize()}:")
                     for sub_key, sub_value in value.items():
-                        print(f"    {sub_key.capitalize()}: {sub_value}")
+                        logger.info(f"    {sub_key.capitalize()}: {sub_value}")
                 else:
-                    print(f"  {key.replace('_', ' ').capitalize()}: {value}")
-            print("-" * 20)
+                    logger.info(f"  {key.replace('_', ' ').capitalize()}: {value}")
+            logger.info("-" * 20)
     return all_cameras_info
 
 
@@ -278,10 +278,10 @@ def save_images_from_all_cameras(
         except KeyboardInterrupt:
             logger.info("Capture interrupted by user.")
         finally:
-            print("\nFinalizing image saving...")
+            logger.info("Finalizing image saving...")
             executor.shutdown(wait=True)
             cleanup_cameras(cameras_to_use)
-            print(f"Image capture finished. Images saved to {output_dir}")
+            logger.info(f"Image capture finished. Images saved to {output_dir}")
 
 
 def main():

--- a/src/lerobot/scripts/lerobot_find_joint_limits.py
+++ b/src/lerobot/scripts/lerobot_find_joint_limits.py
@@ -35,6 +35,7 @@ lerobot-find-joint-limits \
 ```
 """
 
+import logging
 import time
 from dataclasses import dataclass
 
@@ -71,6 +72,8 @@ from lerobot.teleoperators import (  # noqa: F401
 )
 from lerobot.utils.robot_utils import precise_sleep
 
+logger = logging.getLogger(__name__)
+
 
 @dataclass
 class FindJointLimitsConfig:
@@ -96,17 +99,17 @@ def find_joint_and_ee_bounds(cfg: FindJointLimitsConfig):
     teleop = make_teleoperator_from_config(cfg.teleop)
     robot = make_robot_from_config(cfg.robot)
 
-    print(f"Connecting to robot: {cfg.robot.type}...")
+    logger.info(f"Connecting to robot: {cfg.robot.type}...")
     teleop.connect()
     robot.connect()
-    print("Devices connected.")
+    logger.info("Devices connected.")
 
     # Initialize Kinematics
     try:
         kinematics = RobotKinematics(cfg.urdf_path, cfg.target_frame_name)
     except Exception as e:
-        print(f"Error initializing kinematics: {e}")
-        print("Ensure URDF path and target frame name are correct.")
+        logger.error(f"Error initializing kinematics: {e}")
+        logger.error("Ensure URDF path and target frame name are correct.")
         robot.disconnect()
         teleop.disconnect()
         return
@@ -120,11 +123,11 @@ def find_joint_and_ee_bounds(cfg: FindJointLimitsConfig):
     start_t = time.perf_counter()
     warmup_done = False
 
-    print("\n" + "=" * 40)
-    print(f"  WARMUP PHASE ({cfg.warmup_time_s}s)")
-    print("  Move the robot freely to ensure control works.")
-    print("  Data is NOT being recorded yet.")
-    print("=" * 40 + "\n")
+    logger.info("\n" + "=" * 40)
+    logger.info(f"  WARMUP PHASE ({cfg.warmup_time_s}s)")
+    logger.info("  Move the robot freely to ensure control works.")
+    logger.info("  Data is NOT being recorded yet.")
+    logger.info("=" * 40 + "\n")
 
     try:
         while True:
@@ -153,11 +156,11 @@ def find_joint_and_ee_bounds(cfg: FindJointLimitsConfig):
             else:
                 # Phase Transition: Warmup -> Recording
                 if not warmup_done:
-                    print("\n" + "=" * 40)
-                    print("  RECORDING STARTED")
-                    print("  Move robot to ALL joint limits.")
-                    print("  Press Ctrl+C to stop early and save results.")
-                    print("=" * 40 + "\n")
+                    logger.info("\n" + "=" * 40)
+                    logger.info("  RECORDING STARTED")
+                    logger.info("  Move robot to ALL joint limits.")
+                    logger.info("  Press Ctrl+C to stop early and save results.")
+                    logger.info("=" * 40 + "\n")
 
                     # Initialize limits with current position at start of recording
                     max_pos = joint_positions.copy()
@@ -178,28 +181,28 @@ def find_joint_and_ee_bounds(cfg: FindJointLimitsConfig):
 
                 # Simple throttle for print statements (every ~1 sec)
                 if int(recording_time * 100) % 100 == 0:
-                    print(f"Time remaining: {remaining:.1f}s", end="\r")
+                    logger.info(f"Time remaining: {remaining:.1f}s")
 
                 if recording_time > cfg.teleop_time_s:
-                    print("\nTime limit reached.")
+                    logger.info("Time limit reached.")
                     break
 
             precise_sleep(max(1.0 / cfg.control_loop_fps - (time.perf_counter() - t0), 0.0))
 
     except KeyboardInterrupt:
-        print("\n\nInterrupted by user. Stopping safely...")
+        logger.info("Interrupted by user. Stopping safely...")
 
     finally:
         # Safety: Disconnect devices
-        print("\nDisconnecting devices...")
+        logger.info("Disconnecting devices...")
         robot.disconnect()
         teleop.disconnect()
 
     # Results Output
     if max_pos is not None:
-        print("\n" + "=" * 40)
-        print("FINAL RESULTS")
-        print("=" * 40)
+        logger.info("\n" + "=" * 40)
+        logger.info("FINAL RESULTS")
+        logger.info("=" * 40)
 
         # Rounding for readability
         r_max_ee = np.round(max_ee, 4).tolist()
@@ -207,16 +210,16 @@ def find_joint_and_ee_bounds(cfg: FindJointLimitsConfig):
         r_max_pos = np.round(max_pos, 4).tolist()
         r_min_pos = np.round(min_pos, 4).tolist()
 
-        print("\n# End Effector Bounds (x, y, z):")
-        print(f"max_ee = {r_max_ee}")
-        print(f"min_ee = {r_min_ee}")
+        logger.info("\n# End Effector Bounds (x, y, z):")
+        logger.info(f"max_ee = {r_max_ee}")
+        logger.info(f"min_ee = {r_min_ee}")
 
-        print("\n# Joint Position Limits (radians):")
-        print(f"max_pos = {r_max_pos}")
-        print(f"min_pos = {r_min_pos}")
+        logger.info("\n# Joint Position Limits (radians):")
+        logger.info(f"max_pos = {r_max_pos}")
+        logger.info(f"min_pos = {r_min_pos}")
 
     else:
-        print("No data recorded (exited during warmup).")
+        logger.warning("No data recorded (exited during warmup).")
 
 
 def main():

--- a/src/lerobot/scripts/lerobot_find_port.py
+++ b/src/lerobot/scripts/lerobot_find_port.py
@@ -22,9 +22,12 @@ lerobot-find-port
 ```
 """
 
+import logging
 import platform
 import time
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 
 def find_available_ports():
@@ -43,11 +46,11 @@ def find_available_ports():
 
 
 def find_port():
-    print("Finding all available ports for the MotorsBus.")
+    logger.info("Finding all available ports for the MotorsBus.")
     ports_before = find_available_ports()
-    print("Ports before disconnecting:", ports_before)
+    logger.info("Ports before disconnecting: %s", ports_before)
 
-    print("Remove the USB cable from your MotorsBus and press Enter when done.")
+    logger.info("Remove the USB cable from your MotorsBus and press Enter when done.")
     input()  # Wait for user to disconnect the device
 
     time.sleep(0.5)  # Allow some time for port to be released
@@ -56,8 +59,8 @@ def find_port():
 
     if len(ports_diff) == 1:
         port = ports_diff[0]
-        print(f"The port of this MotorsBus is '{port}'")
-        print("Reconnect the USB cable.")
+        logger.info(f"The port of this MotorsBus is '{port}'")
+        logger.info("Reconnect the USB cable.")
     elif len(ports_diff) == 0:
         raise OSError(f"Could not detect the port. No difference was found ({ports_diff}).")
     else:

--- a/src/lerobot/scripts/lerobot_imgtransform_viz.py
+++ b/src/lerobot/scripts/lerobot_imgtransform_viz.py
@@ -43,6 +43,8 @@ from lerobot.transforms import (
     make_transform_from_config,
 )
 
+logger = logging.getLogger(__name__)
+
 OUTPUT_DIR = Path("outputs/image_transforms")
 to_pil = ToPILImage()
 
@@ -56,8 +58,8 @@ def save_all_transforms(cfg: ImageTransformsConfig, original_frame, output_dir, 
         transformed_frame = tfs(original_frame)
         to_pil(transformed_frame).save(output_dir_all / f"{i}.png", quality=100)
 
-    print("Combined transforms examples saved to:")
-    print(f"    {output_dir_all}")
+    logger.info("Combined transforms examples saved to:")
+    logger.info(f"    {output_dir_all}")
 
 
 def save_each_transform(cfg: ImageTransformsConfig, original_frame, output_dir, n_examples):
@@ -67,7 +69,7 @@ def save_each_transform(cfg: ImageTransformsConfig, original_frame, output_dir, 
         )
         return
 
-    print("Individual transforms examples saved to:")
+    logger.info("Individual transforms examples saved to:")
     for tf_name, tf_cfg in cfg.tfs.items():
         # Apply a few transformation with random value in min_max range
         output_dir_single = output_dir / tf_name
@@ -101,7 +103,7 @@ def save_each_transform(cfg: ImageTransformsConfig, original_frame, output_dir, 
         to_pil(tf_frame_max).save(output_dir_single / "max.png", quality=100)
         to_pil(tf_frame_avg).save(output_dir_single / "mean.png", quality=100)
 
-        print(f"    {output_dir_single}")
+        logger.info(f"    {output_dir_single}")
 
 
 @draccus.wrap()
@@ -119,8 +121,8 @@ def visualize_image_transforms(cfg: DatasetConfig, output_dir: Path = OUTPUT_DIR
     # Get 1st frame from 1st camera of 1st episode
     original_frame = dataset[0][dataset.meta.camera_keys[0]]
     to_pil(original_frame).save(output_dir / "original_frame.png", quality=100)
-    print("\nOriginal frame saved to:")
-    print(f"    {output_dir / 'original_frame.png'}.")
+    logger.info("\nOriginal frame saved to:")
+    logger.info(f"    {output_dir / 'original_frame.png'}.")
 
     save_all_transforms(cfg.image_transforms, original_frame, output_dir, n_examples)
     save_each_transform(cfg.image_transforms, original_frame, output_dir, n_examples)

--- a/src/lerobot/scripts/lerobot_info.py
+++ b/src/lerobot/scripts/lerobot_info.py
@@ -26,10 +26,13 @@ lerobot-info
 """
 
 import importlib
+import logging
 import platform
 import shutil
 import subprocess
 from importlib.metadata import PackageNotFoundError, distribution
+
+logger = logging.getLogger(__name__)
 
 PACKAGE_NAME = "lerobot"
 
@@ -121,7 +124,7 @@ def main():
     Main function to print system info in markdown format.
     """
     system_info = get_sys_info()
-    print(format_dict_for_markdown(system_info))
+    logger.info(format_dict_for_markdown(system_info))
 
 
 if __name__ == "__main__":

--- a/src/lerobot/scripts/lerobot_setup_can.py
+++ b/src/lerobot/scripts/lerobot_setup_can.py
@@ -38,6 +38,7 @@ lerobot-setup-can --mode=speed --interfaces=can0
 ```
 """
 
+import logging
 import subprocess
 import sys
 import time
@@ -46,6 +47,8 @@ from dataclasses import dataclass, field
 import draccus
 
 from lerobot.utils.import_utils import _can_available
+
+logger = logging.getLogger(__name__)
 
 MOTOR_NAMES = {
     0x01: "joint_1",
@@ -104,19 +107,19 @@ def setup_interface(interface: str, bitrate: int, data_bitrate: int, use_fd: boo
 
         result = subprocess.run(cmd, capture_output=True, text=True)  # nosec B607
         if result.returncode != 0:
-            print(f"  ✗ Failed to configure: {result.stderr}")
+            logger.error(f"  ✗ Failed to configure: {result.stderr}")
             return False
 
         result = subprocess.run(  # nosec B607
             ["sudo", "ip", "link", "set", interface, "up"], capture_output=True, text=True
         )
         if result.returncode != 0:
-            print(f"  ✗ Failed to bring up: {result.stderr}")
+            logger.error(f"  ✗ Failed to bring up: {result.stderr}")
             return False
 
         return True
     except Exception as e:
-        print(f"  ✗ Error: {e}")
+        logger.error(f"  ✗ Error: {e}")
         return False
 
 
@@ -154,7 +157,7 @@ def test_motor(bus, motor_id: int, timeout: float, use_fd: bool):
         bus.send(disable_msg)
         bus.recv(timeout=0.1)  # Clear any pending responses
     except Exception:
-        print(f"Error sending message to motor 0x{motor_id:02X}")
+        logger.error(f"Error sending message to motor 0x{motor_id:02X}")
 
     return responses, None
 
@@ -164,10 +167,10 @@ def test_interface(cfg: CANSetupConfig, interface: str):
     import can
 
     is_up, status, _ = check_interface_status(interface)
-    print(f"\n{interface}: {status}")
+    logger.info(f"\n{interface}: {status}")
 
     if not is_up:
-        print(f"  ⚠ Interface is not UP. Run: lerobot-setup-can --mode=setup --interfaces {interface}")
+        logger.warning(f"  ⚠ Interface is not UP. Run: lerobot-setup-can --mode=setup --interfaces {interface}")
         return {}
 
     try:
@@ -176,7 +179,7 @@ def test_interface(cfg: CANSetupConfig, interface: str):
             kwargs.update({"data_bitrate": cfg.data_bitrate, "fd": True})
         bus = can.interface.Bus(**kwargs)
     except Exception as e:
-        print(f"  ✗ Connection failed: {e}")
+        logger.error(f"  ✗ Connection failed: {e}")
         return {}
 
     results = {}
@@ -189,16 +192,16 @@ def test_interface(cfg: CANSetupConfig, interface: str):
             responses, error = test_motor(bus, motor_id, cfg.timeout, cfg.use_fd)
 
             if error:
-                print(f"  Motor 0x{motor_id:02X} ({motor_name}): ✗ {error}")
+                logger.warning(f"  Motor 0x{motor_id:02X} ({motor_name}): ✗ {error}")
                 results[motor_id] = {"found": False, "error": error}
             elif responses:
-                print(f"  Motor 0x{motor_id:02X} ({motor_name}): ✓ FOUND")
+                logger.info(f"  Motor 0x{motor_id:02X} ({motor_name}): ✓ FOUND")
                 for resp_id, data, is_fd in responses:
                     fd_flag = " [FD]" if is_fd else ""
-                    print(f"    → Response 0x{resp_id:02X}{fd_flag}: {data}")
+                    logger.info(f"    → Response 0x{resp_id:02X}{fd_flag}: {data}")
                 results[motor_id] = {"found": True, "responses": responses}
             else:
-                print(f"  Motor 0x{motor_id:02X} ({motor_name}): ✗ No response")
+                logger.warning(f"  Motor 0x{motor_id:02X} ({motor_name}): ✗ No response")
                 results[motor_id] = {"found": False}
 
             time.sleep(0.05)
@@ -206,7 +209,7 @@ def test_interface(cfg: CANSetupConfig, interface: str):
         bus.shutdown()
 
     found = sum(1 for r in results.values() if r.get("found"))
-    print(f"\n  Summary: {found}/{len(cfg.motor_ids)} motors found")
+    logger.info(f"\n  Summary: {found}/{len(cfg.motor_ids)} motors found")
     return results
 
 
@@ -216,10 +219,10 @@ def speed_test(cfg: CANSetupConfig, interface: str):
 
     is_up, status, _ = check_interface_status(interface)
     if not is_up:
-        print(f"{interface}: {status} - skipping")
+        logger.info(f"{interface}: {status} - skipping")
         return
 
-    print(f"\n{interface}: Running speed test ({cfg.speed_iterations} iterations)...")
+    logger.info(f"\n{interface}: Running speed test ({cfg.speed_iterations} iterations)...")
 
     try:
         kwargs = {"channel": interface, "interface": "socketcan", "bitrate": cfg.bitrate}
@@ -227,7 +230,7 @@ def speed_test(cfg: CANSetupConfig, interface: str):
             kwargs.update({"data_bitrate": cfg.data_bitrate, "fd": True})
         bus = can.interface.Bus(**kwargs)
     except Exception as e:
-        print(f"  ✗ Connection failed: {e}")
+        logger.error(f"  ✗ Connection failed: {e}")
         return
 
     responding_motor = None
@@ -238,11 +241,11 @@ def speed_test(cfg: CANSetupConfig, interface: str):
             break
 
     if not responding_motor:
-        print("  ✗ No responding motors found")
+        logger.warning("  ✗ No responding motors found")
         bus.shutdown()
         return
 
-    print(f"  Testing with motor 0x{responding_motor:02X}...")
+    logger.info(f"  Testing with motor 0x{responding_motor:02X}...")
     latencies = []
 
     for _ in range(cfg.speed_iterations):
@@ -263,46 +266,46 @@ def speed_test(cfg: CANSetupConfig, interface: str):
     if latencies:
         avg_latency = sum(latencies) / len(latencies)
         hz = 1000.0 / avg_latency if avg_latency > 0 else 0
-        print(f"  ✓ Success rate: {len(latencies)}/{cfg.speed_iterations}")
-        print(f"  ✓ Avg latency: {avg_latency:.2f} ms")
-        print(f"  ✓ Max frequency: {hz:.1f} Hz")
+        logger.info(f"  ✓ Success rate: {len(latencies)}/{cfg.speed_iterations}")
+        logger.info(f"  ✓ Avg latency: {avg_latency:.2f} ms")
+        logger.info(f"  ✓ Max frequency: {hz:.1f} Hz")
     else:
-        print("  ✗ No successful responses")
+        logger.warning("  ✗ No successful responses")
 
 
 def run_setup(cfg: CANSetupConfig):
     """Setup CAN interfaces."""
-    print("=" * 50)
-    print("CAN Interface Setup")
-    print("=" * 50)
-    print(f"Mode: {'CAN FD' if cfg.use_fd else 'CAN 2.0'}")
-    print(f"Bitrate: {cfg.bitrate / 1_000_000:.1f} Mbps")
+    logger.info("=" * 50)
+    logger.info("CAN Interface Setup")
+    logger.info("=" * 50)
+    logger.info(f"Mode: {'CAN FD' if cfg.use_fd else 'CAN 2.0'}")
+    logger.info(f"Bitrate: {cfg.bitrate / 1_000_000:.1f} Mbps")
     if cfg.use_fd:
-        print(f"Data bitrate: {cfg.data_bitrate / 1_000_000:.1f} Mbps")
-    print()
+        logger.info(f"Data bitrate: {cfg.data_bitrate / 1_000_000:.1f} Mbps")
+    logger.info("")
 
     interfaces = cfg.get_interfaces()
     for interface in interfaces:
-        print(f"Configuring {interface}...")
+        logger.info(f"Configuring {interface}...")
         if setup_interface(interface, cfg.bitrate, cfg.data_bitrate, cfg.use_fd):
             is_up, status, _ = check_interface_status(interface)
-            print(f"  ✓ {interface}: {status}")
+            logger.info(f"  ✓ {interface}: {status}")
         else:
-            print(f"  ✗ {interface}: Failed")
+            logger.warning(f"  ✗ {interface}: Failed")
 
-    print("\nSetup complete!")
-    print("\nNext: Test motors with:")
-    print(f"  lerobot-setup-can --mode=test --interfaces {','.join(interfaces)}")
+    logger.info("\nSetup complete!")
+    logger.info("\nNext: Test motors with:")
+    logger.info(f"  lerobot-setup-can --mode=test --interfaces {','.join(interfaces)}")
 
 
 def run_test(cfg: CANSetupConfig):
     """Test motors on CAN interfaces."""
-    print("=" * 50)
-    print("CAN Motor Test")
-    print("=" * 50)
-    print(f"Testing motors 0x{min(cfg.motor_ids):02X}-0x{max(cfg.motor_ids):02X}")
-    print(f"Mode: {'CAN FD' if cfg.use_fd else 'CAN 2.0'}")
-    print()
+    logger.info("=" * 50)
+    logger.info("CAN Motor Test")
+    logger.info("=" * 50)
+    logger.info(f"Testing motors 0x{min(cfg.motor_ids):02X}-0x{max(cfg.motor_ids):02X}")
+    logger.info(f"Mode: {'CAN FD' if cfg.use_fd else 'CAN 2.0'}")
+    logger.info("")
 
     interfaces = cfg.get_interfaces()
     all_results = {}
@@ -311,25 +314,25 @@ def run_test(cfg: CANSetupConfig):
 
     total_found = sum(sum(1 for r in res.values() if r.get("found")) for res in all_results.values())
 
-    print("\n" + "=" * 50)
-    print("Summary")
-    print("=" * 50)
-    print(f"Total motors found: {total_found}")
+    logger.info("\n" + "=" * 50)
+    logger.info("Summary")
+    logger.info("=" * 50)
+    logger.info(f"Total motors found: {total_found}")
 
     if total_found == 0:
-        print("\n⚠ No motors found! Check:")
-        print("  1. Motors are powered (24V)")
-        print("  2. CAN wiring (CANH, CANL, GND)")
-        print("  3. Motor timeout parameter > 0 (use Damiao tools)")
-        print("  4. 120Ω termination at both cable ends")
-        print(f"  5. Interface configured: lerobot-setup-can --mode=setup --interfaces {interfaces[0]}")
+        logger.warning("\n⚠ No motors found! Check:")
+        logger.warning("  1. Motors are powered (24V)")
+        logger.warning("  2. CAN wiring (CANH, CANL, GND)")
+        logger.warning("  3. Motor timeout parameter > 0 (use Damiao tools)")
+        logger.warning("  4. 120Ω termination at both cable ends")
+        logger.warning(f"  5. Interface configured: lerobot-setup-can --mode=setup --interfaces {interfaces[0]}")
 
 
 def run_speed(cfg: CANSetupConfig):
     """Run speed tests on CAN interfaces."""
-    print("=" * 50)
-    print("CAN Speed Test")
-    print("=" * 50)
+    logger.info("=" * 50)
+    logger.info("CAN Speed Test")
+    logger.info("=" * 50)
 
     for interface in cfg.get_interfaces():
         speed_test(cfg, interface)
@@ -338,7 +341,7 @@ def run_speed(cfg: CANSetupConfig):
 @draccus.wrap()
 def setup_can(cfg: CANSetupConfig):
     if not _can_available:
-        print("Error: python-can not installed. Install with: pip install python-can")
+        logger.error("Error: python-can not installed. Install with: pip install python-can")
         sys.exit(1)
 
     if cfg.mode == "setup":
@@ -348,8 +351,8 @@ def setup_can(cfg: CANSetupConfig):
     elif cfg.mode == "speed":
         run_speed(cfg)
     else:
-        print(f"Unknown mode: {cfg.mode}")
-        print("Available modes: setup, test, speed")
+        logger.error(f"Unknown mode: {cfg.mode}")
+        logger.error("Available modes: setup, test, speed")
         sys.exit(1)
 
 

--- a/src/lerobot/scripts/lerobot_teleoperate.py
+++ b/src/lerobot/scripts/lerobot_teleoperate.py
@@ -110,6 +110,8 @@ from lerobot.utils.robot_utils import precise_sleep
 from lerobot.utils.utils import init_logging, move_cursor_up
 from lerobot.utils.visualization_utils import init_rerun, log_rerun_data, shutdown_rerun
 
+logger = logging.getLogger(__name__)
+
 
 @dataclass
 class TeleoperateConfig:
@@ -193,17 +195,17 @@ def teleop_loop(
                 compress_images=display_compressed_images,
             )
 
-            print("\n" + "-" * (display_len + 10))
-            print(f"{'NAME':<{display_len}} | {'NORM':>7}")
+            logger.info("\n" + "-" * (display_len + 10))
+            logger.info(f"{'NAME':<{display_len}} | {'NORM':>7}")
             # Display the final robot action that was sent
             for motor, value in robot_action_to_send.items():
-                print(f"{motor:<{display_len}} | {value:>7.2f}")
+                logger.info(f"{motor:<{display_len}} | {value:>7.2f}")
             move_cursor_up(len(robot_action_to_send) + 3)
 
         dt_s = time.perf_counter() - loop_start
         precise_sleep(max(1 / fps - dt_s, 0.0))
         loop_s = time.perf_counter() - loop_start
-        print(f"Teleop loop time: {loop_s * 1e3:.2f}ms ({1 / loop_s:.0f} Hz)")
+        logger.info(f"Teleop loop time: {loop_s * 1e3:.2f}ms ({1 / loop_s:.0f} Hz)")
         move_cursor_up(1)
 
         if duration is not None and time.perf_counter() - start >= duration:

--- a/src/lerobot/scripts/lerobot_train_tokenizer.py
+++ b/src/lerobot/scripts/lerobot_train_tokenizer.py
@@ -45,6 +45,7 @@ lerobot-train-tokenizer \
 """
 
 import json
+import logging
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -63,6 +64,8 @@ else:
 from lerobot.configs import NormalizationMode, parser
 from lerobot.datasets import LeRobotDataset
 from lerobot.utils.constants import ACTION, OBS_STATE
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -275,7 +278,7 @@ def process_episode(args):
         return action_chunks
 
     except Exception as e:
-        print(f"Error processing episode {ep_idx}: {e}")
+        logger.error(f"Error processing episode {ep_idx}: {e}")
         import traceback
 
         traceback.print_exc()
@@ -300,10 +303,10 @@ def train_fast_tokenizer(
     Returns:
         Trained FAST tokenizer
     """
-    print(f"Training FAST tokenizer on {len(action_chunks)} action chunks...")
-    print(f"Action chunk shape: {action_chunks.shape}")
-    print(f"Vocab size: {vocab_size}")
-    print(f"DCT scale: {scale}")
+    logger.info(f"Training FAST tokenizer on {len(action_chunks)} action chunks...")
+    logger.info(f"Action chunk shape: {action_chunks.shape}")
+    logger.info(f"Vocab size: {vocab_size}")
+    logger.info(f"DCT scale: {scale}")
 
     # download the tokenizer source code (not pretrained weights)
     # we'll train a new tokenizer on our own data
@@ -314,7 +317,7 @@ def train_fast_tokenizer(
 
     # train the new tokenizer on our action data using .fit()
     # this trains the BPE tokenizer on DCT coefficients
-    print("Training new tokenizer (this may take a few minutes)...")
+    logger.info("Training new tokenizer (this may take a few minutes)...")
     tokenizer = base_tokenizer.fit(
         action_data_list,
         scale=scale,
@@ -322,21 +325,21 @@ def train_fast_tokenizer(
         time_horizon=action_chunks.shape[1],  # action_horizon
         action_dim=action_chunks.shape[2],  # encoded dimensions
     )
-    print("✓ Tokenizer training complete!")
+    logger.info("✓ Tokenizer training complete!")
 
     # validate it works
     sample_chunk = action_chunks[0]
     encoded = tokenizer(sample_chunk[None])[0]
     if isinstance(encoded, list):
         encoded = np.array(encoded)
-    print(f"Sample encoding: {len(encoded)} tokens for chunk shape {sample_chunk.shape}")
+    logger.info(f"Sample encoding: {len(encoded)} tokens for chunk shape {sample_chunk.shape}")
 
     return tokenizer
 
 
 def compute_compression_stats(tokenizer, action_chunks: np.ndarray):
     """Compute compression statistics."""
-    print("\nComputing compression statistics...")
+    logger.info("\nComputing compression statistics...")
 
     # sample for stats (use max 1000 chunks for speed)
     sample_size = min(1000, len(action_chunks))
@@ -366,12 +369,12 @@ def compute_compression_stats(tokenizer, action_chunks: np.ndarray):
         "max_token_length": float(np.max(token_lengths)),
     }
 
-    print("Compression Statistics:")
-    print(f"  Average compression ratio: {stats['compression_ratio']:.2f}x")
-    print(f"  Mean token length: {stats['mean_token_length']:.1f}")
-    print(f"  P99 token length: {stats['p99_token_length']:.0f}")
-    print(f"  Min token length: {stats['min_token_length']:.0f}")
-    print(f"  Max token length: {stats['max_token_length']:.0f}")
+    logger.info("Compression Statistics:")
+    logger.info(f"  Average compression ratio: {stats['compression_ratio']:.2f}x")
+    logger.info(f"  Mean token length: {stats['mean_token_length']:.1f}")
+    logger.info(f"  P99 token length: {stats['p99_token_length']:.0f}")
+    logger.info(f"  Min token length: {stats['min_token_length']:.0f}")
+    logger.info(f"  Max token length: {stats['max_token_length']:.0f}")
 
     return stats
 
@@ -385,9 +388,9 @@ def train_tokenizer(cfg: TokenizerTrainingConfig):
         cfg: TokenizerTrainingConfig dataclass with all configuration parameters
     """
     # load dataset
-    print(f"Loading dataset: {cfg.repo_id}")
+    logger.info(f"Loading dataset: {cfg.repo_id}")
     dataset = LeRobotDataset(repo_id=cfg.repo_id, root=cfg.root)
-    print(f"Dataset loaded: {dataset.num_episodes} episodes, {dataset.num_frames} frames")
+    logger.info(f"Dataset loaded: {dataset.num_episodes} episodes, {dataset.num_frames} frames")
 
     # parse normalization mode
     try:
@@ -397,7 +400,7 @@ def train_tokenizer(cfg: TokenizerTrainingConfig):
             f"Invalid normalization_mode: {cfg.normalization_mode}. "
             f"Must be one of: {', '.join([m.value for m in NormalizationMode])}"
         ) from err
-    print(f"Normalization mode: {norm_mode.value}")
+    logger.info(f"Normalization mode: {norm_mode.value}")
 
     # parse encoded dimensions
     encoded_dim_ranges = []
@@ -406,38 +409,38 @@ def train_tokenizer(cfg: TokenizerTrainingConfig):
         encoded_dim_ranges.append((start, end))
 
     total_encoded_dims = sum(end - start for start, end in encoded_dim_ranges)
-    print(f"Encoding {total_encoded_dims} dimensions: {cfg.encoded_dims}")
+    logger.info(f"Encoding {total_encoded_dims} dimensions: {cfg.encoded_dims}")
 
     # parse relative dimensions
     relative_dim_list = None
     if cfg.relative_dims is not None and cfg.relative_dims.strip():
         relative_dim_list = [int(d.strip()) for d in cfg.relative_dims.split(",")]
-        print(f"Relative dimensions: {relative_dim_list}")
+        logger.info(f"Relative dimensions: {relative_dim_list}")
     else:
-        print("No relative dimensions specified")
+        logger.info("No relative dimensions specified")
 
-    print(f"Use relative transform: {cfg.use_relative_transform}")
+    logger.info(f"Use relative transform: {cfg.use_relative_transform}")
     if cfg.use_relative_transform and (relative_dim_list is None or len(relative_dim_list) == 0):
-        print(
+        logger.warning(
             "Warning: use_relative_transform=True but no relative_dims specified. "
             "No relative transform will be applied."
         )
 
-    print(f"Action horizon: {cfg.action_horizon}")
-    print(f"State key: {cfg.state_key}")
+    logger.info(f"Action horizon: {cfg.action_horizon}")
+    logger.info(f"State key: {cfg.state_key}")
 
     # determine episodes to process
     num_episodes = dataset.num_episodes
     if cfg.max_episodes is not None:
         num_episodes = min(cfg.max_episodes, num_episodes)
 
-    print(f"Processing {num_episodes} episodes...")
+    logger.info(f"Processing {num_episodes} episodes...")
 
     # process episodes sequentially (to avoid pickling issues with dataset)
     all_chunks = []
     for ep_idx in range(num_episodes):
         if ep_idx % 10 == 0:
-            print(f"  Processing episode {ep_idx}/{num_episodes}...")
+            logger.info(f"  Processing episode {ep_idx}/{num_episodes}...")
 
         chunks = process_episode(
             (
@@ -455,19 +458,19 @@ def train_tokenizer(cfg: TokenizerTrainingConfig):
 
     # concatenate all chunks
     all_chunks = np.concatenate(all_chunks, axis=0)
-    print(f"Collected {len(all_chunks)} action chunks")
+    logger.info(f"Collected {len(all_chunks)} action chunks")
 
     # extract only encoded dimensions FIRST (before normalization)
     encoded_chunks = []
     for start, end in encoded_dim_ranges:
         encoded_chunks.append(all_chunks[:, :, start:end])
     encoded_chunks = np.concatenate(encoded_chunks, axis=-1)  # [N, H, D_encoded]
-    print(f"Extracted {encoded_chunks.shape[-1]} encoded dimensions")
+    logger.info(f"Extracted {encoded_chunks.shape[-1]} encoded dimensions")
 
     # apply normalization to encoded dimensions
-    print("\nBefore normalization - overall stats:")
-    print(f"  Min: {np.min(encoded_chunks):.4f}, Max: {np.max(encoded_chunks):.4f}")
-    print(f"  Mean: {np.mean(encoded_chunks):.4f}, Std: {np.std(encoded_chunks):.4f}")
+    logger.info("\nBefore normalization - overall stats:")
+    logger.info(f"  Min: {np.min(encoded_chunks):.4f}, Max: {np.max(encoded_chunks):.4f}")
+    logger.info(f"  Mean: {np.mean(encoded_chunks):.4f}, Std: {np.std(encoded_chunks):.4f}")
 
     # get normalization stats from dataset
     norm_stats = dataset.meta.stats
@@ -489,9 +492,9 @@ def train_tokenizer(cfg: TokenizerTrainingConfig):
                     encoded_stats[stat_name] = stat_array[encoded_dim_indices]
 
         if encoded_stats:
-            print(f"\nNormalization stats for encoded dimensions (mode: {norm_mode.value}):")
+            logger.info(f"\nNormalization stats for encoded dimensions (mode: {norm_mode.value}):")
             for stat_name, stat_values in encoded_stats.items():
-                print(
+                logger.info(
                     f"  {stat_name}: shape={stat_values.shape}, "
                     f"range=[{np.min(stat_values):.4f}, {np.max(stat_values):.4f}]"
                 )
@@ -499,27 +502,27 @@ def train_tokenizer(cfg: TokenizerTrainingConfig):
             # apply normalization based on mode
             try:
                 encoded_chunks = apply_normalization(encoded_chunks, encoded_stats, norm_mode, eps=1e-8)
-                print(f"\nApplied {norm_mode.value} normalization")
+                logger.info(f"\nApplied {norm_mode.value} normalization")
             except ValueError as e:
-                print(f"Warning: {e}. Using raw actions without normalization.")
+                logger.warning(f"Warning: {e}. Using raw actions without normalization.")
 
-            print("\nAfter normalization - overall stats:")
-            print(f"  Min: {np.min(encoded_chunks):.4f}, Max: {np.max(encoded_chunks):.4f}")
-            print(f"  Mean: {np.mean(encoded_chunks):.4f}, Std: {np.std(encoded_chunks):.4f}")
+            logger.info("\nAfter normalization - overall stats:")
+            logger.info(f"  Min: {np.min(encoded_chunks):.4f}, Max: {np.max(encoded_chunks):.4f}")
+            logger.info(f"  Mean: {np.mean(encoded_chunks):.4f}, Std: {np.std(encoded_chunks):.4f}")
 
-            print("\nPer-dimension stats (after normalization):")
+            logger.info("\nPer-dimension stats (after normalization):")
             for d in range(encoded_chunks.shape[-1]):
                 dim_data = encoded_chunks[:, :, d]
-                print(
+                logger.info(
                     f"  Dim {d}: min={np.min(dim_data):7.4f}, max={np.max(dim_data):7.4f}, "
                     f"mean={np.mean(dim_data):7.4f}, std={np.std(dim_data):7.4f}"
                 )
         else:
-            print("Warning: Could not extract stats for encoded dimensions, using raw actions")
+            logger.warning("Warning: Could not extract stats for encoded dimensions, using raw actions")
     else:
-        print("Warning: No normalization stats found in dataset, using raw actions")
+        logger.warning("Warning: No normalization stats found in dataset, using raw actions")
 
-    print(f"Encoded chunks shape: {encoded_chunks.shape}")
+    logger.info(f"Encoded chunks shape: {encoded_chunks.shape}")
 
     # train FAST tokenizer
     tokenizer = train_fast_tokenizer(
@@ -561,8 +564,8 @@ def train_tokenizer(cfg: TokenizerTrainingConfig):
     with open(output_path / "metadata.json", "w") as f:
         json.dump(metadata, f, indent=2)
 
-    print(f"\nSaved FAST tokenizer to {output_path}")
-    print(f"Metadata: {json.dumps(metadata, indent=2)}")
+    logger.info(f"\nSaved FAST tokenizer to {output_path}")
+    logger.info(f"Metadata: {json.dumps(metadata, indent=2)}")
 
     # push to Hugging Face Hub if requested
     if cfg.push_to_hub:
@@ -570,10 +573,10 @@ def train_tokenizer(cfg: TokenizerTrainingConfig):
         hub_repo_id = cfg.hub_repo_id
         if hub_repo_id is None:
             hub_repo_id = output_path.name
-            print(f"\nNo hub_repo_id provided, using: {hub_repo_id}")
+            logger.info(f"\nNo hub_repo_id provided, using: {hub_repo_id}")
 
-        print(f"\nPushing tokenizer to Hugging Face Hub: {hub_repo_id}")
-        print(f"   Private: {cfg.hub_private}")
+        logger.info(f"\nPushing tokenizer to Hugging Face Hub: {hub_repo_id}")
+        logger.info(f"   Private: {cfg.hub_private}")
 
         try:
             # use the tokenizer's push_to_hub method
@@ -593,10 +596,10 @@ def train_tokenizer(cfg: TokenizerTrainingConfig):
                 commit_message="Upload tokenizer metadata",
             )
 
-            print(f"Successfully pushed tokenizer to: https://huggingface.co/{hub_repo_id}")
+            logger.info(f"Successfully pushed tokenizer to: https://huggingface.co/{hub_repo_id}")
         except Exception as e:
-            print(f"Error pushing to hub: {e}")
-            print("   Make sure you're logged in with `huggingface-cli login`")
+            logger.error(f"Error pushing to hub: {e}")
+            logger.error("   Make sure you're logged in with `huggingface-cli login`")
 
 
 def main():


### PR DESCRIPTION
## Summary

Part of the structured logging effort outlined in #3134.

Replaces bare `print()` calls with standard Python `logging.getLogger(__name__)`
across all files in `src/lerobot/scripts/`.

## Changes

- Add `import logging` where missing
- Add `logger = logging.getLogger(__name__)` at module level
- Replace `print(...)` with `logger.info()` / `logger.warning()` / `logger.error()` based on semantics
- No logic changes

## Files changed

- `convert_dataset_v21_to_v30.py`
- `lerobot_annotate.py`
- `lerobot_dataset_viz.py`
- `lerobot_eval.py`
- `lerobot_find_cameras.py`
- `lerobot_find_joint_limits.py`
- `lerobot_find_port.py`
- `lerobot_imgtransform_viz.py`
- `lerobot_setup_can.py`
- `lerobot_teleoperate.py`
- `lerobot_train_tokenizer.py`
- `lerobot_info.py`

## Notes

- `end="\r"` in `lerobot_find_joint_limits.py` was removed; the existing 1-second throttle makes this acceptable
- Empty `print()` separators converted to `logger.info("")`
- Follow-up PRs will cover other modules (teleoperators, robots, policies)

Relates to #3134