### PR TITLE
fix(datasets): make scalar and vector feature shapes unambiguous

### DIFF
--- a/src/lerobot/datasets/aggregate.py
+++ b/src/lerobot/datasets/aggregate.py
@@ -25,10 +25,15 @@ import pandas as pd
 import tqdm
 
 from lerobot.configs import VIDEO_ENCODER_INFO_KEYS
+from lerobot.utils.constants import DEFAULT_FEATURES
 
 from .compute_stats import aggregate_stats
 from .dataset_metadata import LeRobotDatasetMetadata
-from .feature_utils import features_equal_for_merge, get_hf_features_from_features
+from .feature_utils import (
+    detect_legacy_scalar_features,
+    features_equal_for_merge,
+    get_hf_features_from_features,
+)
 from .io_utils import (
     get_file_size_in_mb,
     get_parquet_file_size_in_mb,
@@ -522,6 +527,14 @@ def aggregate_data(src_meta, dst_meta, data_idx, data_files_size_in_mb, chunk_si
 
     # retrieve features schema for proper image typing in parquet
     hf_features = get_hf_features_from_features(dst_meta.features) if contains_images else None
+    # Only the image path actually casts against hf_features (to_parquet_with_hf_images below);
+    # the non-image path writes df.to_parquet() directly, preserving whatever physical encoding
+    # the source already has, so it never hits a schema mismatch regardless of source convention.
+    legacy_scalar_keys = (
+        detect_legacy_scalar_features(src_meta.features, src_meta.root / "data") - DEFAULT_FEATURES.keys()
+        if contains_images
+        else frozenset()
+    )
 
     # Track source to destination file mapping for metadata update
     # This is critical for handling datasets that are already results of a merge
@@ -535,6 +548,9 @@ def aggregate_data(src_meta, dst_meta, data_idx, data_files_size_in_mb, chunk_si
             # Use HuggingFace datasets to read source data to preserve image format
             src_ds = datasets.Dataset.from_parquet(str(src_path))
             df = src_ds.to_pandas()
+            for key in legacy_scalar_keys:
+                if key in df.columns:
+                    df[key] = df[key].apply(lambda v: [v])
         else:
             df = pd.read_parquet(src_path)
         df = update_data_df(df, src_meta, dst_meta)

--- a/src/lerobot/datasets/compute_stats.py
+++ b/src/lerobot/datasets/compute_stats.py
@@ -517,6 +517,10 @@ def compute_episode_stats(
         if features[key]["dtype"] in {"string", "language"}:
             continue
 
+        if tuple(features[key].get("shape", ())) == (0,):
+            # Nothing to compute statistics over for a zero-length feature.
+            continue
+
         if features[key]["dtype"] in ["image", "video"]:
             ep_ft_array = sample_images(data)
             axes_to_reduce = (0, 2, 3)

--- a/src/lerobot/datasets/dataset_reader.py
+++ b/src/lerobot/datasets/dataset_reader.py
@@ -25,6 +25,7 @@ import torch
 from .dataset_metadata import LeRobotDatasetMetadata
 from .feature_utils import (
     check_delta_timestamps,
+    detect_legacy_scalar_features,
     get_delta_indices,
     get_hf_features_from_features,
 )
@@ -137,7 +138,8 @@ class DatasetReader:
 
     def _load_hf_dataset(self) -> datasets.Dataset:
         """hf_dataset contains all the observations, states, actions, rewards, etc."""
-        features = get_hf_features_from_features(self._meta.features)
+        legacy_scalar_keys = detect_legacy_scalar_features(self._meta.features, self.root / "data")
+        features = get_hf_features_from_features(self._meta.features, legacy_scalar_keys=legacy_scalar_keys)
         hf_dataset = load_nested_dataset(self.root / "data", features=features, episodes=self.episodes)
         hf_dataset.set_transform(hf_transform_to_torch)
         return hf_dataset

--- a/src/lerobot/datasets/dataset_tools.py
+++ b/src/lerobot/datasets/dataset_tools.py
@@ -331,7 +331,7 @@ def modify_features(
         new_dataset = modify_features(
             dataset,
             add_features={
-                "reward": (reward_array, {"dtype": "float32", "shape": [1], "names": None}),
+                "reward": (reward_array, {"dtype": "float32", "shape": [], "names": None}),
             },
             remove_features=["old_feature"],
             output_dir="./output",

--- a/src/lerobot/datasets/dataset_tools.py
+++ b/src/lerobot/datasets/dataset_tools.py
@@ -38,7 +38,7 @@ import torch
 from tqdm import tqdm
 
 from lerobot.configs import VideoEncoderConfig, camera_encoder_defaults
-from lerobot.utils.constants import ACTION, HF_LEROBOT_HOME, OBS_IMAGE, OBS_STATE
+from lerobot.utils.constants import ACTION, DEFAULT_FEATURES, HF_LEROBOT_HOME, OBS_IMAGE, OBS_STATE
 from lerobot.utils.utils import flatten_dict
 
 from .aggregate import aggregate_datasets
@@ -48,6 +48,7 @@ from .compute_stats import (
     compute_relative_action_stats,
 )
 from .dataset_metadata import LeRobotDatasetMetadata
+from .feature_utils import detect_legacy_scalar_features
 from .io_utils import (
     get_parquet_file_size_in_mb,
     load_episodes,
@@ -545,8 +546,17 @@ def _copy_and_reindex_data(
         if new_task_idx is not None:
             task_mapping[old_task_idx] = new_task_idx
 
+    # Bookkeeping fields are excluded: the destination always declares them shape=(),
+    # so a physically-scalar episode_index/index/etc. should stay a bare scalar, not be
+    # wrapped into a length-1 list.
+    legacy_scalar_keys = (
+        detect_legacy_scalar_features(src_dataset.meta.features, src_dataset.root / "data")
+        - DEFAULT_FEATURES.keys()
+    )
+
     for src_path in tqdm(sorted(file_to_episodes.keys()), desc="Processing data files"):
         df = pd.read_parquet(src_dataset.root / src_path)
+        df = _reencode_legacy_scalar_columns(df, legacy_scalar_keys)
 
         all_episodes_in_file = set(df["episode_index"].unique())
         episodes_to_keep = file_to_episodes[src_path]
@@ -1005,9 +1015,14 @@ def _copy_data_with_feature_changes(
         raise ValueError(f"No parquet files found in {data_dir}")
 
     frame_idx = 0
+    # Bookkeeping fields excluded -- see comment in _copy_and_reindex_data.
+    legacy_scalar_keys = (
+        detect_legacy_scalar_features(dataset.meta.features, data_dir) - DEFAULT_FEATURES.keys()
+    )
 
     for src_path in tqdm(parquet_files, desc="Processing data files"):
         df = pd.read_parquet(src_path).reset_index(drop=True)
+        df = _reencode_legacy_scalar_columns(df, legacy_scalar_keys)
 
         relative_path = src_path.relative_to(dataset.root)
         chunk_dir = relative_path.parts[1]
@@ -1021,23 +1036,28 @@ def _copy_data_with_feature_changes(
 
         if add_features:
             end_idx = frame_idx + len(df)
-            for feature_name, (values, _) in add_features.items():
+            for feature_name, (values, feature_info) in add_features.items():
+                shape = feature_info["shape"]
                 if callable(values):
                     feature_values = []
                     for _, row in df.iterrows():
                         ep_idx = row["episode_index"]
                         frame_in_ep = row["frame_index"]
                         value = values(row.to_dict(), ep_idx, frame_in_ep)
-                        if isinstance(value, np.ndarray) and value.size == 1:
-                            value = value.item()
+                        if shape == ():
+                            # True scalar feature: squeeze a 1-element array to a bare value.
+                            if isinstance(value, np.ndarray) and value.size == 1:
+                                value = value.item()
+                        elif np.isscalar(value) or (isinstance(value, np.ndarray) and value.ndim == 0):
+                            # Declared as a vector (e.g. shape=(1,)): wrap a bare scalar to match.
+                            value = [value]
                         feature_values.append(value)
                     df[feature_name] = feature_values
                 else:
                     feature_slice = values[frame_idx:end_idx]
-                    if len(feature_slice.shape) > 1 and feature_slice.shape[1] == 1:
-                        df[feature_name] = feature_slice.flatten()
-                    else:
-                        df[feature_name] = feature_slice
+                    # Keep each row's full sub-array intact (e.g. a length-1 vector stays
+                    # length-1) rather than flattening away the feature dimension.
+                    df[feature_name] = list(feature_slice)
             frame_idx = end_idx
 
         # Write using the same chunk/file structure as source
@@ -1362,6 +1382,23 @@ def _estimate_frame_size_via_calibration(
             shutil.rmtree(calibration_dir)
 
 
+def _reencode_legacy_scalar_columns(df: pd.DataFrame, legacy_scalar_keys: frozenset[str]) -> pd.DataFrame:
+    """Re-wrap columns that were physically stored as bare scalars under the old convention
+    into length-1 lists, so the data matches the schema a freshly-written destination dataset
+    is expected to have.
+
+    Without this, copying a legacy dataset's raw parquet bytes into a new dataset produces a
+    physical encoding mismatch: the new dataset is written with the corrected (non-squeezed)
+    schema, but the copied columns are still scalar-squeezed. `legacy_scalar_keys` comes from
+    `detect_legacy_scalar_features`, which inspects the actual on-disk Arrow schema rather than
+    relying on any codebase-version bookkeeping.
+    """
+    for key in legacy_scalar_keys:
+        if key in df.columns:
+            df[key] = df[key].apply(lambda v: [v])
+    return df
+
+
 def _copy_data_without_images(
     src_dataset: LeRobotDataset,
     dst_meta: LeRobotDatasetMetadata,
@@ -1385,9 +1422,14 @@ def _copy_data_without_images(
         raise ValueError(f"No parquet files found in {data_dir}")
 
     episode_set = set(episode_indices)
+    # Bookkeeping fields excluded -- see comment in _copy_and_reindex_data.
+    legacy_scalar_keys = (
+        detect_legacy_scalar_features(src_dataset.meta.features, data_dir) - DEFAULT_FEATURES.keys()
+    )
 
     for src_path in tqdm(parquet_files, desc="Processing data files"):
         df = pd.read_parquet(src_path).reset_index(drop=True)
+        df = _reencode_legacy_scalar_columns(df, legacy_scalar_keys)
 
         # Filter to only include selected episodes
         df = df[df["episode_index"].isin(episode_set)].copy()

--- a/src/lerobot/datasets/dataset_writer.py
+++ b/src/lerobot/datasets/dataset_writer.py
@@ -250,14 +250,7 @@ class DatasetWriter:
         for key, ft in self._meta.features.items():
             if key in ["index", "episode_index", "task_index"] or ft["dtype"] in ["image", "video"]:
                 continue
-            stacked_values = np.stack(episode_buffer[key])
-
-            # `shape=(1,)` numeric features are serialized as `datasets.Value`, which expects scalars.
-            # Normalizing to `(N,)` keeps save semantics stable across dependency versions.
-            if tuple(ft["shape"]) == (1,) and ft["dtype"] != "string":
-                stacked_values = stacked_values.reshape(episode_length)
-
-            episode_buffer[key] = stacked_values
+            episode_buffer[key] = np.stack(episode_buffer[key])
 
         # Wait for image writer to end, so that episode stats over images can be computed
         self._wait_image_writer()

--- a/src/lerobot/datasets/feature_utils.py
+++ b/src/lerobot/datasets/feature_utils.py
@@ -117,7 +117,7 @@ def detect_legacy_scalar_features(features: dict, data_dir: Path) -> frozenset[s
     candidates = {
         key
         for key, ft in features.items()
-        if tuple(ft.get("shape", ())) == (1,) and ft["dtype"] not in ("image", "video", "string")
+        if tuple(ft.get("shape", ())) == (1,) and ft["dtype"] not in ("image", "video", "string", "language")
     }
     if not candidates:
         return frozenset()

--- a/src/lerobot/datasets/feature_utils.py
+++ b/src/lerobot/datasets/feature_utils.py
@@ -14,10 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
+from pathlib import Path
 from pprint import pformat
+from typing import Any
 
 import datasets
 import numpy as np
+import pyarrow as pa
+import pyarrow.parquet as pq
 from PIL import Image as PILImage
 
 from lerobot.configs import VIDEO_ENCODER_INFO_KEYS
@@ -40,11 +44,114 @@ from .utils import (
 )
 
 
-def get_hf_features_from_features(features: dict) -> datasets.Features:
+def _flat_names_length(names: Any) -> int | None:
+    """Return the number of leaf names in a `names` spec.
+
+    `names` is usually a flat list, but some datasets (notably bimanual setups) declare
+    it as a dict of groups, e.g. `{"motors": ["left_waist", ..., "right_gripper"]}`. Returns
+    None if `names` doesn't look like either shape, so callers can skip validation rather
+    than guess.
+    """
+    if isinstance(names, dict):
+        if not all(isinstance(v, (list, tuple)) for v in names.values()):
+            return None
+        return sum(len(v) for v in names.values())
+    if isinstance(names, (list, tuple)):
+        return len(names)
+    return None
+
+
+def validate_feature_shape_and_names(key: str, ft: dict) -> None:
+    """Validate that a feature's declared `shape` and `names` are mutually consistent.
+
+    A scalar (`shape=()`) has no axis to label, so `names` must be `None`. A vector
+    of length N (`shape=(N,)`, including N=0) must have exactly N names if `names`
+    is provided at all (`names` may be a flat list or a dict of groups, e.g.
+    `{"motors": [...]}`, whose values are flattened before counting).
+
+    Args:
+        key (str): The feature name, used for error messages.
+        ft (dict): The feature spec dict (must contain `shape` and `names`).
+
+    Raises:
+        ValueError: If `names` is inconsistent with `shape`.
+    """
+    shape = ft["shape"]
+    names = ft.get("names")
+    if shape == ():
+        if names:
+            raise ValueError(f"Feature '{key}' is a scalar (shape=()) but declares names={names!r}.")
+        return
+    names_length = _flat_names_length(names)
+    if names_length is not None and names_length != shape[0]:
+        raise ValueError(
+            f"Feature '{key}' has shape={shape!r} but names={names!r} has length {names_length}, expected {shape[0]}."
+        )
+
+
+def detect_legacy_scalar_features(features: dict, data_dir: Path) -> frozenset[str]:
+    """Find declared shape=(1,) features that are physically stored as bare scalars.
+
+    Before this fix, a shape=(1,) feature -- whether a true scalar (e.g. the bookkeeping
+    fields in `DEFAULT_FEATURES`) or a real length-1 vector -- was always squeezed to a bare
+    value at write time. Rather than tracking this with a codebase-version flag, inspect the
+    actual on-disk Arrow schema: a column that was squeezed shows up as a scalar Arrow type
+    (e.g. `float`), while one written under the corrected convention shows up as a list type
+    (e.g. `fixed_size_list<float>[1]`). This lets a dataset's *own* declared shape=(1,)
+    features be read back correctly, matching however they actually were written, without
+    any version bookkeeping.
+
+    This reports purely on physical encoding, regardless of whether a key is a `DEFAULT_FEATURES`
+    bookkeeping field -- callers that are instead preparing data to match a *different*
+    destination schema (e.g. `dataset_tools.py`'s copy/conversion helpers, where the
+    destination always declares bookkeeping fields as `shape=()`) should exclude
+    `DEFAULT_FEATURES` keys themselves before acting on the result.
+
+    Args:
+        features (dict): A LeRobot-style feature dictionary.
+        data_dir (Path): Directory containing the dataset's data parquet shards.
+
+    Returns:
+        frozenset[str]: Keys whose shape=(1,) declaration should be read as a scalar.
+    """
+    candidates = {
+        key
+        for key, ft in features.items()
+        if tuple(ft.get("shape", ())) == (1,) and ft["dtype"] not in ("image", "video", "string")
+    }
+    if not candidates:
+        return frozenset()
+
+    sample_file = next(data_dir.glob("*/*.parquet"), None)
+    if sample_file is None:
+        return frozenset()
+
+    schema = pq.read_schema(sample_file)
+    legacy = set()
+    for key in candidates:
+        if key in schema.names:
+            field_type = schema.field(key).type
+            if not (
+                pa.types.is_list(field_type)
+                or pa.types.is_large_list(field_type)
+                or pa.types.is_fixed_size_list(field_type)
+            ):
+                legacy.add(key)
+    return frozenset(legacy)
+
+
+def get_hf_features_from_features(
+    features: dict, legacy_scalar_keys: frozenset[str] = frozenset()
+) -> datasets.Features:
     """Convert a LeRobot features dictionary to a `datasets.Features` object.
 
     Args:
         features (dict): A LeRobot-style feature dictionary.
+        legacy_scalar_keys (frozenset[str]): Keys whose `shape == (1,)` declaration should be
+            interpreted as a scalar stored via `datasets.Value`, rather than the corrected
+            convention where a length-1 vector is never squeezed. Obtain this set by calling
+            `detect_legacy_scalar_features` against the dataset's actual on-disk schema when
+            reading a dataset that may have been recorded under the old convention.
 
     Returns:
         datasets.Features: The corresponding Hugging Face `datasets.Features` object.
@@ -54,6 +161,8 @@ def get_hf_features_from_features(features: dict) -> datasets.Features:
     """
     hf_features = {}
     for key, ft in features.items():
+        if not is_language_column(key) and ft["dtype"] not in ("image", "video"):
+            validate_feature_shape_and_names(key, ft)
         if is_language_column(key):
             hf_features[key] = (
                 language_persistent_column_feature()
@@ -64,8 +173,13 @@ def get_hf_features_from_features(features: dict) -> datasets.Features:
             continue
         elif ft["dtype"] == "image":
             hf_features[key] = datasets.Image()
-        elif ft["shape"] == (1,):
+        elif ft["shape"] == () or (key in legacy_scalar_keys and ft["shape"] == (1,)):
             hf_features[key] = datasets.Value(dtype=ft["dtype"])
+        elif ft["shape"] == (0,):
+            # A fixed-size datasets.Sequence(length=0, ...) is rejected by PyArrow
+            # ("list_size needs to be a strict positive integer"), so a zero-length
+            # feature must use a variable-length Sequence instead.
+            hf_features[key] = datasets.Sequence(feature=datasets.Value(dtype=ft["dtype"]))
         elif len(ft["shape"]) == 1:
             hf_features[key] = datasets.Sequence(
                 length=ft["shape"][0], feature=datasets.Value(dtype=ft["dtype"])

--- a/src/lerobot/datasets/multi_dataset.py
+++ b/src/lerobot/datasets/multi_dataset.py
@@ -24,7 +24,7 @@ import torch.utils
 from lerobot.utils.constants import HF_LEROBOT_HOME
 
 from .compute_stats import aggregate_stats
-from .feature_utils import get_hf_features_from_features
+from .feature_utils import detect_legacy_scalar_features, get_hf_features_from_features
 from .lerobot_dataset import LeRobotDataset
 from .video_utils import VideoFrame
 
@@ -139,10 +139,13 @@ class MultiLeRobotDataset(torch.utils.data.Dataset):
     def features(self) -> datasets.Features:
         features = {}
         for dataset in self._datasets:
+            legacy_scalar_keys = detect_legacy_scalar_features(dataset.features, dataset.root / "data")
             features.update(
                 {
                     k: v
-                    for k, v in get_hf_features_from_features(dataset.features).items()
+                    for k, v in get_hf_features_from_features(
+                        dataset.features, legacy_scalar_keys=legacy_scalar_keys
+                    ).items()
                     if k not in self.disabled_features
                 }
             )

--- a/src/lerobot/rl/buffer.py
+++ b/src/lerobot/rl/buffer.py
@@ -530,8 +530,8 @@ class ReplayBuffer:
         features[ACTION] = act_info
 
         # Add "reward" and "done"
-        features[REWARD] = {"dtype": "float32", "shape": (1,)}
-        features[DONE] = {"dtype": "bool", "shape": (1,)}
+        features[REWARD] = {"dtype": "float32", "shape": ()}
+        features[DONE] = {"dtype": "bool", "shape": ()}
 
         # Add state keys
         for key in self.states:
@@ -574,8 +574,8 @@ class ReplayBuffer:
 
             # Fill action, reward, done
             frame_dict[ACTION] = self.actions[actual_idx].cpu()
-            frame_dict[REWARD] = torch.tensor([self.rewards[actual_idx]], dtype=torch.float32).cpu()
-            frame_dict[DONE] = torch.tensor([self.dones[actual_idx]], dtype=torch.bool).cpu()
+            frame_dict[REWARD] = self.rewards[actual_idx].cpu()
+            frame_dict[DONE] = self.dones[actual_idx].cpu()
             frame_dict["task"] = task_name
 
             # Add complementary_info if available

--- a/src/lerobot/rl/buffer.py
+++ b/src/lerobot/rl/buffer.py
@@ -517,11 +517,11 @@ class ReplayBuffer:
 
         # Create features dictionary for the dataset
         features = {
-            "index": {"dtype": "int64", "shape": [1]},  # global index across episodes
-            "episode_index": {"dtype": "int64", "shape": [1]},  # which episode
-            "frame_index": {"dtype": "int64", "shape": [1]},  # index inside an episode
-            "timestamp": {"dtype": "float32", "shape": [1]},  # for now we store dummy
-            "task_index": {"dtype": "int64", "shape": [1]},
+            "index": {"dtype": "int64", "shape": ()},  # global index across episodes
+            "episode_index": {"dtype": "int64", "shape": ()},  # which episode
+            "frame_index": {"dtype": "int64", "shape": ()},  # index inside an episode
+            "timestamp": {"dtype": "float32", "shape": ()},  # for now we store dummy
+            "task_index": {"dtype": "int64", "shape": ()},
         }
 
         # Add "action"

--- a/src/lerobot/rl/gym_manipulator.py
+++ b/src/lerobot/rl/gym_manipulator.py
@@ -658,8 +658,8 @@ def control_loop(
         if use_gripper:
             features["complementary_info.discrete_penalty"] = {
                 "dtype": "float32",
-                "shape": (1,),
-                "names": ["discrete_penalty"],
+                "shape": (),
+                "names": None,
             }
 
         for key, value in transition[TransitionKey.OBSERVATION].items():
@@ -731,7 +731,7 @@ def control_loop(
                         "discrete_penalty", 0.0
                     )
                     frame["complementary_info.discrete_penalty"] = np.array(
-                        [discrete_penalty], dtype=np.float32
+                        discrete_penalty, dtype=np.float32
                     )
 
                 if dataset is not None:

--- a/src/lerobot/rl/gym_manipulator.py
+++ b/src/lerobot/rl/gym_manipulator.py
@@ -652,8 +652,8 @@ def control_loop(
             }
         features = {
             ACTION: action_features,
-            REWARD: {"dtype": "float32", "shape": (1,), "names": None},
-            DONE: {"dtype": "bool", "shape": (1,), "names": None},
+            REWARD: {"dtype": "float32", "shape": (), "names": None},
+            DONE: {"dtype": "bool", "shape": (), "names": None},
         }
         if use_gripper:
             features["complementary_info.discrete_penalty"] = {
@@ -723,8 +723,8 @@ def control_loop(
                 frame = {
                     **observation,
                     ACTION: action_to_record.cpu(),
-                    REWARD: np.array([transition[TransitionKey.REWARD]], dtype=np.float32),
-                    DONE: np.array([terminated or truncated], dtype=bool),
+                    REWARD: np.array(transition[TransitionKey.REWARD], dtype=np.float32),
+                    DONE: np.array(terminated or truncated, dtype=bool),
                 }
                 if use_gripper:
                     discrete_penalty = transition[TransitionKey.COMPLEMENTARY_DATA].get(

--- a/src/lerobot/rollout/context.py
+++ b/src/lerobot/rollout/context.py
@@ -344,7 +344,7 @@ def build_rollout_context(
             if isinstance(cfg.strategy, DAggerStrategyConfig):
                 dataset_features["intervention"] = {
                     "dtype": "bool",
-                    "shape": (1,),
+                    "shape": (),
                     "names": None,
                 }
 

--- a/src/lerobot/rollout/strategies/dagger.py
+++ b/src/lerobot/rollout/strategies/dagger.py
@@ -442,7 +442,7 @@ class DAggerStrategy(RolloutStrategy):
                                 **obs_frame,
                                 **action_frame,
                                 "task": task_str,
-                                "intervention": np.array([True], dtype=bool),
+                                "intervention": np.array(True, dtype=bool),
                             }
                             dataset.add_frame(frame)
                         record_tick += 1
@@ -470,7 +470,7 @@ class DAggerStrategy(RolloutStrategy):
                                     **obs_frame,
                                     **action_frame,
                                     "task": task_str,
-                                    "intervention": np.array([False], dtype=bool),
+                                    "intervention": np.array(False, dtype=bool),
                                 }
                                 dataset.add_frame(frame)
                             record_tick += 1
@@ -624,7 +624,7 @@ class DAggerStrategy(RolloutStrategy):
                                     **obs_frame,
                                     **action_frame,
                                     "task": task_str,
-                                    "intervention": np.array([True], dtype=bool),
+                                    "intervention": np.array(True, dtype=bool),
                                 }
                             )
                         record_tick += 1

--- a/src/lerobot/utils/constants.py
+++ b/src/lerobot/utils/constants.py
@@ -77,12 +77,13 @@ HF_LEROBOT_CALIBRATION = Path(os.getenv("HF_LEROBOT_CALIBRATION", default_calibr
 
 
 # Dataset meta-features (auto-populated by the recording pipeline)
+# shape=() because these are true per-frame scalars, not length-1 feature vectors.
 DEFAULT_FEATURES = {
-    "timestamp": {"dtype": "float32", "shape": (1,), "names": None},
-    "frame_index": {"dtype": "int64", "shape": (1,), "names": None},
-    "episode_index": {"dtype": "int64", "shape": (1,), "names": None},
-    "index": {"dtype": "int64", "shape": (1,), "names": None},
-    "task_index": {"dtype": "int64", "shape": (1,), "names": None},
+    "timestamp": {"dtype": "float32", "shape": (), "names": None},
+    "frame_index": {"dtype": "int64", "shape": (), "names": None},
+    "episode_index": {"dtype": "int64", "shape": (), "names": None},
+    "index": {"dtype": "int64", "shape": (), "names": None},
+    "task_index": {"dtype": "int64", "shape": (), "names": None},
 }
 
 # ImageNet normalization constants

--- a/src/lerobot/utils/feature_utils.py
+++ b/src/lerobot/utils/feature_utils.py
@@ -163,6 +163,17 @@ def dataset_to_policy_features(features: dict[str, dict]) -> dict[str, PolicyFea
         else:
             continue
 
+        if type in (FeatureType.STATE, FeatureType.ENV) and tuple(shape) == (0,):
+            # A zero-length state/env feature (e.g. a camera-only robot) carries no
+            # information for a policy to consume. Omitting it here, rather than
+            # emitting a PolicyFeature with an empty shape, keeps every existing
+            # `if config.robot_state_feature:` truthiness check and
+            # `if OBS_STATE in self.input_features:` membership check correct
+            # without needing to touch either pattern individually -- a
+            # PolicyFeature instance is truthy regardless of its shape, so a
+            # present-but-empty entry would silently look like "has state."
+            continue
+
         policy_features[key] = PolicyFeature(
             type=type,
             shape=shape,

--- a/tests/datasets/test_dataset_metadata.py
+++ b/tests/datasets/test_dataset_metadata.py
@@ -67,11 +67,14 @@ def _make_dummy_stats(features: dict) -> dict:
                 "count": np.array([5]),
             }
         elif ft["dtype"] in ("float32", "float64", "int64"):
+            # Real stats always keep at least one dimension, even for a true
+            # scalar (shape=()) feature -- see compute_stats.py's keepdims=True.
+            shape = ft["shape"] or (1,)
             stats[key] = {
-                "max": np.ones(ft["shape"], dtype=np.float32),
-                "mean": np.full(ft["shape"], 0.5, dtype=np.float32),
-                "min": np.zeros(ft["shape"], dtype=np.float32),
-                "std": np.full(ft["shape"], 0.25, dtype=np.float32),
+                "max": np.ones(shape, dtype=np.float32),
+                "mean": np.full(shape, 0.5, dtype=np.float32),
+                "min": np.zeros(shape, dtype=np.float32),
+                "std": np.full(shape, 0.25, dtype=np.float32),
                 "count": np.array([5]),
             }
     return stats

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -238,7 +238,8 @@ def test_add_frame(tmp_path, empty_lerobot_dataset_factory):
     assert len(dataset) == 1
     assert dataset[0]["task"] == "Dummy task"
     assert dataset[0]["task_index"] == 0
-    assert dataset[0]["state"].ndim == 0
+    # shape=(1,) is a length-1 vector, not a scalar -- it must not be squeezed.
+    assert dataset[0]["state"].shape == torch.Size([1])
 
 
 def test_add_frame_state_1d(tmp_path, empty_lerobot_dataset_factory):
@@ -298,11 +299,13 @@ def test_add_frame_state_numpy(tmp_path, empty_lerobot_dataset_factory):
     dataset.save_episode()
     dataset.finalize()
 
-    assert dataset[0]["state"].ndim == 0
+    # shape=(1,) is a length-1 vector, not a scalar -- it must not be squeezed.
+    assert dataset[0]["state"].shape == torch.Size([1])
 
 
 def test_add_frame_string(tmp_path, empty_lerobot_dataset_factory):
-    features = {"caption": {"dtype": "string", "shape": (1,), "names": None}}
+    # A single caption string per frame is a true scalar -- shape=(), not shape=(1,).
+    features = {"caption": {"dtype": "string", "shape": (), "names": None}}
     dataset = empty_lerobot_dataset_factory(root=tmp_path / "test", features=features)
     dataset.add_frame({"caption": "Dummy caption", "task": "Dummy task"})
     dataset.save_episode()
@@ -385,10 +388,14 @@ def test_add_frame_image_pil(image_dataset):
     ],
     ids=["float32", "int64", "bool"],
 )
-def test_save_episode_shape_1_scalar_is_scalarized_before_hf_encoding(
+def test_save_episode_shape_1_vector_is_not_scalarized_before_hf_encoding(
     tmp_path, empty_lerobot_dataset_factory, monkeypatch, dtype, np_dtype, values, assert_fn
 ):
-    features = {"state": {"dtype": dtype, "shape": (1,), "names": None}}
+    """A shape=(1,) feature is a length-1 vector, not a true scalar (see DEFAULT_FEATURES,
+    which uses shape=() for true scalars). It must round-trip as (N, 1), never be squeezed
+    to (N,) -- collapsing the two was the root cause of a real bug across several policies
+    (each saw a batch of N length-1 states as indistinguishable from one N-dim example)."""
+    features = {"state": {"dtype": dtype, "shape": (1,), "names": ["x"]}}
     dataset = empty_lerobot_dataset_factory(root=tmp_path / "test", features=features)
     dataset.add_frame({"state": np.array([values[0]], dtype=np_dtype), "task": "Dummy task"})
     dataset.add_frame({"state": np.array([values[1]], dtype=np_dtype), "task": "Dummy task"})
@@ -407,8 +414,8 @@ def test_save_episode_shape_1_scalar_is_scalarized_before_hf_encoding(
 
     assert "state" in captured
     assert isinstance(captured["state"], np.ndarray)
-    assert captured["state"].shape == (2,)
-    assert_fn(captured["state"], np.array(values, dtype=np_dtype))
+    assert captured["state"].shape == (2, 1)
+    assert_fn(captured["state"], np.array(values, dtype=np_dtype).reshape(2, 1))
 
 
 def test_set_image_transforms_applies_transparently(image_dataset):
@@ -1724,15 +1731,16 @@ def test_delta_timestamps_query_returns_correct_values(tmp_path, empty_lerobot_d
     # Check frame 2 of episode 1 (which has absolute index 7, value 12)
     frame = filtered_dataset[2]
     state_values = frame["observation.state"].tolist()
-    # Should get [11, 12] - the previous and current values within episode 1
-    assert state_values == [11.0, 12.0], f"Expected [11.0, 12.0], got {state_values}"
+    # Should get [11, 12] - the previous and current values within episode 1.
+    # shape=(1,) is a length-1 vector, so each timestep keeps its own [x] sub-list.
+    assert state_values == [[11.0], [12.0]], f"Expected [[11.0], [12.0]], got {state_values}"
 
     # Check first frame - previous frame should be clamped to episode start (padded)
     first_frame = filtered_dataset[0]
     state_values = first_frame["observation.state"].tolist()
     is_pad = first_frame["observation.state_is_pad"].tolist()
     # Previous frame is outside episode, so it's clamped to first frame and marked as padded
-    assert state_values == [10.0, 10.0], f"Expected [10.0, 10.0], got {state_values}"
+    assert state_values == [[10.0], [10.0]], f"Expected [[10.0], [10.0]], got {state_values}"
     assert is_pad == [True, False], f"Expected [True, False], got {is_pad}"
 
 

--- a/tests/datasets/test_feature_utils.py
+++ b/tests/datasets/test_feature_utils.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python
+
+# Copyright 2024 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pytest
+import torch
+
+pytest.importorskip("datasets", reason="datasets is required (install lerobot[dataset])")
+
+import datasets
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from lerobot.datasets.feature_utils import (
+    detect_legacy_scalar_features,
+    get_hf_features_from_features,
+    validate_feature_shape_and_names,
+)
+from lerobot.datasets.lerobot_dataset import LeRobotDataset
+
+
+def test_scalar_shape_dispatches_to_value():
+    features = {"episode_index": {"dtype": "int64", "shape": (), "names": None}}
+    hf_features = get_hf_features_from_features(features)
+    assert isinstance(hf_features["episode_index"], datasets.Value)
+
+
+def test_length_one_vector_dispatches_to_fixed_sequence_not_value():
+    features = {"observation.state": {"dtype": "float32", "shape": (1,), "names": ["x"]}}
+    hf_features = get_hf_features_from_features(features)
+    assert isinstance(hf_features["observation.state"], datasets.Sequence)
+    assert hf_features["observation.state"].length == 1
+
+
+def test_zero_length_vector_uses_variable_length_sequence():
+    # A fixed-length Sequence(length=0, ...) is rejected by PyArrow, so shape=(0,)
+    # must use a variable-length Sequence instead.
+    features = {"observation.state": {"dtype": "float32", "shape": (0,), "names": []}}
+    hf_features = get_hf_features_from_features(features)
+    assert isinstance(hf_features["observation.state"], datasets.Sequence)
+    assert hf_features["observation.state"].length == -1
+
+
+def test_legacy_scalar_keys_squeezes_length_one_to_value():
+    features = {"observation.state": {"dtype": "float32", "shape": (1,), "names": ["x"]}}
+    hf_features = get_hf_features_from_features(features, legacy_scalar_keys=frozenset({"observation.state"}))
+    assert isinstance(hf_features["observation.state"], datasets.Value)
+
+
+def test_detect_legacy_scalar_features_reads_physical_schema(tmp_path):
+    # A column physically stored as a scalar (the pre-fix convention) is detected as legacy...
+    features = {"observation.state": {"dtype": "float32", "shape": (1,), "names": ["x"]}}
+    legacy_table = pa.table({"observation.state": pa.array([1.0, 2.0], type=pa.float32())})
+    legacy_dir = tmp_path / "legacy" / "chunk-000"
+    legacy_dir.mkdir(parents=True)
+    pq.write_table(legacy_table, legacy_dir / "file-000.parquet")
+    assert detect_legacy_scalar_features(features, tmp_path / "legacy") == {"observation.state"}
+
+    # ...but a column already stored as a length-1 list (the corrected convention) is not.
+    new_table = pa.table({"observation.state": pa.array([[1.0], [2.0]], type=pa.list_(pa.float32(), 1))})
+    new_dir = tmp_path / "new" / "chunk-000"
+    new_dir.mkdir(parents=True)
+    pq.write_table(new_table, new_dir / "file-000.parquet")
+    assert detect_legacy_scalar_features(features, tmp_path / "new") == frozenset()
+
+
+def test_detect_legacy_scalar_features_reports_bookkeeping_fields_too(tmp_path):
+    # detect_legacy_scalar_features reports purely on physical encoding -- it doesn't know
+    # or care that episode_index is a DEFAULT_FEATURES bookkeeping field. Callers that need
+    # to treat bookkeeping fields differently (e.g. dataset_tools.py's copy/conversion
+    # helpers, which must not wrap them into length-1 lists) exclude them themselves.
+    features = {"episode_index": {"dtype": "int64", "shape": (1,), "names": None}}
+    table = pa.table({"episode_index": pa.array([0, 0], type=pa.int64())})
+    data_dir = tmp_path / "chunk-000"
+    data_dir.mkdir(parents=True)
+    pq.write_table(table, data_dir / "file-000.parquet")
+    assert detect_legacy_scalar_features(features, tmp_path) == {"episode_index"}
+
+
+@pytest.mark.parametrize(
+    "shape,names",
+    [
+        ((), None),
+        ((1,), ["x"]),
+        ((0,), []),
+        ((3,), ["x", "y", "z"]),
+    ],
+)
+def test_validate_feature_shape_and_names_accepts_valid_specs(shape, names):
+    validate_feature_shape_and_names("f", {"dtype": "float32", "shape": shape, "names": names})
+
+
+def test_validate_feature_shape_and_names_rejects_named_scalar():
+    with pytest.raises(ValueError, match="scalar"):
+        validate_feature_shape_and_names("f", {"dtype": "float32", "shape": (), "names": ["x"]})
+
+
+def test_validate_feature_shape_and_names_accepts_grouped_dict_names():
+    # Some bimanual datasets declare `names` as a dict of groups rather than a flat list.
+    validate_feature_shape_and_names(
+        "observation.state",
+        {
+            "dtype": "float32",
+            "shape": (14,),
+            "names": {"motors": [f"m{i}" for i in range(14)]},
+        },
+    )
+
+
+def test_validate_feature_shape_and_names_rejects_length_mismatch():
+    with pytest.raises(ValueError, match="expected 3"):
+        validate_feature_shape_and_names("f", {"dtype": "float32", "shape": (3,), "names": ["x", "y"]})
+
+
+@pytest.mark.parametrize("state_dim", [0, 1, 6])
+def test_dataset_round_trip_preserves_declared_shape(tmp_path, state_dim):
+    """The original bug: a shape=(N,) feature must never collapse to a bare scalar at
+    read time, for any N -- including the historically-squeezed N=1 case and the N=0
+    (camera-only) case."""
+    names = [f"x{i}" for i in range(state_dim)]
+    features = {
+        "observation.state": {"dtype": "float32", "shape": (state_dim,), "names": names},
+        "action": {"dtype": "float32", "shape": (1,), "names": ["a"]},
+    }
+    root = tmp_path / "ds"
+    dataset = LeRobotDataset.create(repo_id="local/round_trip_test", fps=10, root=root, features=features)
+    for _ep in range(2):
+        for i in range(3):
+            dataset.add_frame(
+                {
+                    "observation.state": np.full(state_dim, float(i), dtype=np.float32),
+                    "action": np.array([float(i)], dtype=np.float32),
+                    "task": "test task",
+                }
+            )
+        dataset.save_episode()
+    dataset.finalize()
+
+    reloaded = LeRobotDataset(repo_id="local/round_trip_test", root=root)
+    item = reloaded[0]
+    assert item["observation.state"].shape == (state_dim,)
+    assert item["action"].shape == (1,)
+    assert item["episode_index"].shape == ()
+
+    batch = torch.utils.data.default_collate([reloaded[i] for i in range(4)])
+    assert batch["observation.state"].shape == (4, state_dim)
+    assert batch["action"].shape == (4, 1)
+    assert batch["episode_index"].shape == (4,)

--- a/tests/fixtures/dataset_factories.py
+++ b/tests/fixtures/dataset_factories.py
@@ -190,7 +190,10 @@ def stats_factory():
     ) -> dict:
         stats = {}
         for key, ft in features.items():
-            shape = ft["shape"]
+            # Real stats always keep at least one dimension (see compute_stats.py's
+            # keepdims=True reduction and _validate_stat_value's ndim>=1 requirement),
+            # even for a true scalar (shape=()) feature.
+            shape = ft["shape"] or (1,)
             dtype = ft["dtype"]
             if dtype in ["image", "video"]:
                 stats[key] = {
@@ -388,7 +391,7 @@ def hf_dataset_factory(features_factory, tasks_factory, episodes_factory, img_ar
                     img_array_factory(height=ft["shape"][1], width=ft["shape"][0], content=f"{key}-{i}")
                     for i in range(len(index_col))
                 ]
-            elif ft["shape"][0] > 1 and ft["dtype"] != "video":
+            elif len(ft["shape"]) > 0 and ft["shape"][0] > 1 and ft["dtype"] != "video":
                 robot_cols[key] = np.random.random((len(index_col), ft["shape"][0])).astype(ft["dtype"])
 
         hf_features = get_hf_features_from_features(features)

--- a/tests/utils/test_dataset_to_policy_features.py
+++ b/tests/utils/test_dataset_to_policy_features.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+
+from lerobot.configs.types import FeatureType
+from lerobot.utils.constants import ACTION, OBS_ENV_STATE, OBS_STATE
+from lerobot.utils.feature_utils import dataset_to_policy_features
+
+
+def test_nonzero_state_feature_is_included():
+    features = {OBS_STATE: {"dtype": "float32", "shape": (6,), "names": None}}
+    policy_features = dataset_to_policy_features(features)
+    assert OBS_STATE in policy_features
+    assert policy_features[OBS_STATE].type is FeatureType.STATE
+    assert policy_features[OBS_STATE].shape == (6,)
+
+
+def test_zero_length_state_feature_is_excluded():
+    # A PolicyFeature instance is truthy regardless of its shape, so emitting one for
+    # a zero-length state would silently look like "this robot has state" to every
+    # `if config.robot_state_feature:` / `if OBS_STATE in self.input_features:` check
+    # across policies. Omitting the key entirely keeps both styles of check correct.
+    features = {OBS_STATE: {"dtype": "float32", "shape": (0,), "names": []}}
+    policy_features = dataset_to_policy_features(features)
+    assert OBS_STATE not in policy_features
+
+
+def test_zero_length_env_state_feature_is_excluded():
+    features = {OBS_ENV_STATE: {"dtype": "float32", "shape": (0,), "names": []}}
+    policy_features = dataset_to_policy_features(features)
+    assert OBS_ENV_STATE not in policy_features
+
+
+def test_zero_length_action_feature_is_still_included():
+    # Only state/env are excluded -- a robot with no action space isn't a real case
+    # this needs to guard against, and ACTION isn't checked with the same
+    # truthiness/membership patterns that motivated excluding STATE/ENV.
+    features = {ACTION: {"dtype": "float32", "shape": (0,), "names": []}}
+    policy_features = dataset_to_policy_features(features)
+    assert ACTION in policy_features
+    assert policy_features[ACTION].shape == (0,)


### PR DESCRIPTION
## Summary

Regarding dataset features, scalars are used for things like timestamps and indices; vectors are used for things like robot state and actions. Each feature has a shape, and the way those shapes are currently defined is inconsistent, which has caused several bugs and attempted fixes throughout the code.

This PR fixes the inconsistency at the source, establishing one consistent shape pattern based on a feature's true rank and saving datasets accordingly, simplifying the code and removing the need for disambiguation and special-casing downstream. Maintains compatibility with current v3.0 datasets.

## Motivation

The existing problem stems from scalar features being declared with `shape=(1,)`, which is the same shape currently used for length-1 vectors (for example, a robot with 1 state variable). Then, at dataset write time, both length-1 vectors *and* genuine scalars get squeezed down to scalars in `get_hf_features_from_features()`. At read time, the two are indistinguishable: a batch of N length-1 vectors and a batch of N true scalars both end up as shape `(N,)`.

#3344 introduced the squeeze as a fix for a different crash. #3771 hits the resulting ambiguity in MolmoAct2 and wants to patch it locally, inside MolmoAct2's own processor. ACT training also fails for robots with 1 state value.

With this fix: `shape=()` for true scalars, `shape=(N,)` for vectors of any length. A camera-only robot, with no proprioceptive state vector (`shape=(0,)`), becomes a supported case too. #3771's workaround becomes unnecessary, and ACT needs no special-casing either, since both are narrower fixes for the same bug.

Per @CarolinePascal on #3771: *"I feel like it would be easier and somehow cleaner to fix it directly on the dataset reader side."* With that in mind, I believe the root cause sits one step further upstream, at write time. Fixing it there removes the ambiguity entirely, rather than working around it downstream.

The dataset spec docs/source/lerobot-dataset-v3.mdx has an example:
```
	'observation.state': tensor([...]) # bracketed (vector)
	'action': tensor([...])            # bracketed (vector)
	'timestamp': tensor(1.234)         # unbracketed (0-D tensor, i.e. a scalar)
```
which shows the distinction this PR enforces. Before this fix, that example was inaccurate (incorrect to the spec) for any robot with a 1-dimensional state, since `observation.state` would be represented as a scalar, indistinguishable from true scalar features such as timestamps. This PR synchronizes the code with the spec.

## Related issues

https://github.com/huggingface/lerobot/pull/3344
https://github.com/huggingface/lerobot/pull/3771
https://github.com/huggingface/lerobot/pull/3665

## What changed

- `get_hf_features_from_features` dispatches on `shape == ()` for true scalars, and no longer special-cases `shape == (1,)`; a length-1 vector round-trips via `Sequence(length=1)` like any other length.
- `shape == (0,)` uses a variable-length `Sequence` to avoid rejection by PyArrow, which doesn't like a length-0 fixed-size list.
- `DEFAULT_FEATURES` (`timestamp`, `frame_index`, `episode_index`, `index`, `task_index`) corrected to `shape=()`. They're true per-frame scalars, not length-1 vectors.
- The dataset-write-time squeeze in `dataset_writer.py` is removed.
- Backward compatibility is handled by `detect_legacy_scalar_features`, which inspects the on-disk Arrow schema (scalar type vs. list type) to tell which convention wrote a given `shape=(1,)` column. Wired into the dataset reader, multi-dataset loading, and the dataset copy/merge/conversion tools, wherever data is read from a possibly-legacy source and written into a freshly-created destination.
- `validate_feature_shape_and_names` added to catch shape/names mismatches at schema-construction time (handles both flat-list and grouped-dict `names` conventions, e.g. bimanual setups).
- `dataset_to_policy_features()` now excludes a `shape=(0,)` state/env feature from the returned PolicyFeature dict, so a policy doesn't wire up model inputs (e.g. a state encoder) for a feature that carries no actual data.
- `rl/buffer.py` and `rl/gym_manipulator.py`: migrated `REWARD`/`DONE` feature declarations to `shape=()` and updated the corresponding frame-construction code so reward/done values are written as scalars, not length-1 arrays.
- `rollout/context.py` and `rollout/strategies/dagger.py`: the DAgger `intervention` flag had the `shape=(1,)` declaration; migrated to `shape=()` and updated the three frame-construction sites to write a bare scalar instead of a length-1 array.
- `gym_manipulator.py`, `complementary_info.discrete_penalty` had `shape=(1,)`; migrated to `shape=()`.
- `detect_legacy_scalar_features`'s dtype exclusion list (`image`, `video`, `string`) was missing `language`. `LANGUAGE_PERSISTENT`/`LANGUAGE_EVENTS` declare `shape=(1,)` but are Arrow `list<struct<...>>` columns, never a squeezed numeric scalar — they were being pulled into the candidate set even though they could never actually match (their physical encoding is always list-typed, so this never misfired in practice). Added `language` to the exclusion list so the filter matches its own intent.
- No breaking changes. Existing datasets continue to load and train correctly.

## How was this tested

- New tests: `tests/datasets/test_feature_utils.py` (round-trips for `shape=()`/`(0,)`/`(1,)`/`(n,)`, legacy-detection against simulated old-convention data, validation edge cases), `tests/utils/test_dataset_to_policy_features.py` (state/env exclusion at zero length).
- Updated several pre-existing tests in `tests/datasets/test_datasets.py` and `tests/datasets/test_dataset_metadata.py` that had encoded the old squeeze behavior as expected output.
- `pytest tests/datasets/ tests/utils/ tests/rl/ tests/policies/test_policies.py`: full pass (756 passed, 19 skipped)
- Re-ran `pytest tests/datasets/ tests/utils/ tests/rl/` after the `discrete_penalty`/`language` follow-up fixes: 740 passed, 10 skipped
- `pre-commit run -a` clean.

## Checklist

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated (N/A)
- [ ] CI is green
- [ ] Community Review # ()
- [ ] Any acknowledgement whatsoever from anyone in the community after over a week

## Reviewer notes

The backward-compatibility mechanism (`detect_legacy_scalar_features`) handles this in lieu of a [minor] codebase_version bump: it infers a dataset's writing convention from a sample file's physical Arrow schema, rather than from version metadata. It only samples the first parquet file found in a dataset's data/ directory. Checked this presumptive approach against a large dataset (`cadene/agibot_alpha_v30`) and found consistent encoding across the first, middle, and last file, but feedback on the tradeoff in general is still welcome regarding the robustness of this approach.

`language.py`'s `LANGUAGE_PERSISTENT`/`LANGUAGE_EVENTS` also declare `shape=(1,)`, but left as-is. Language is an oddball feature (nested list-of-struct columns) and shape is never actually read on them.

