### PR TITLE
feat(record): Wayland/headless keyboard controls for lerobot-record

### DIFF
--- a/docs/source/il_robots.mdx
+++ b/docs/source/il_robots.mdx
@@ -394,6 +394,9 @@ Control the data recording flow using keyboard shortcuts:
 - Press **Left Arrow (`←`)**: Cancel the current episode and re-record it.
 - Press **Escape (`ESC`)**: Immediately stop the session, encode videos, and upload the dataset.
 
+> [!NOTE]
+> The arrow/Esc shortcuts above use `pynput`, which only works on an X11 display. On a Wayland session (the default on recent GNOME/KDE and on Raspberry Pi OS) or a headless machine, `pynput` cannot capture these keys. In those cases, as long as you launch `lerobot-record` from an interactive terminal, the same controls are read directly from that terminal instead. If your keyboard's arrow keys are awkward there, you can use the letter equivalents: `n` (next, same as `→`), `r` (re-record, same as `←`), and `q` (quit, same as `ESC`). No `$DISPLAY` setup is needed.
+
 #### Tips for gathering data
 
 Once you're comfortable with data recording, you can create a larger dataset for training. A good starting task is grasping an object at different locations and placing it in a bin. We suggest recording at least 50 episodes, with 10 episodes per location. Keep the cameras fixed and maintain consistent grasping behavior throughout the recordings. Also make sure the object you are manipulating is visible on the camera's. A good rule of thumb is you should be able to do the task yourself by only looking at the camera images.
@@ -406,7 +409,7 @@ If you want to dive deeper into this important topic, you can check out the [blo
 
 #### Troubleshooting:
 
-- On Linux, if the left and right arrow keys and escape key don't have any effect during data recording, make sure you've set the `$DISPLAY` environment variable. See [pynput limitations](https://pynput.readthedocs.io/en/latest/limitations.html#linux).
+- On Linux, if the left and right arrow keys and escape key don't have any effect during data recording on an X11 session, make sure you've set the `$DISPLAY` environment variable. See [pynput limitations](https://pynput.readthedocs.io/en/latest/limitations.html#linux). On a Wayland session or a headless machine, `pynput` cannot capture these keys at all; run `lerobot-record` from an interactive terminal and the same controls (plus the `n`/`r`/`q` letter equivalents) are read from the terminal instead — no `$DISPLAY` needed.
 
 ## Visualize a dataset
 

--- a/docs/source/lekiwi.mdx
+++ b/docs/source/lekiwi.mdx
@@ -319,7 +319,7 @@ If you want to dive deeper into this important topic, you can check out the [blo
 
 #### Troubleshooting:
 
-- On Linux, if the left and right arrow keys and escape key don't have any effect during data recording, make sure you've set the `$DISPLAY` environment variable. See [pynput limitations](https://pynput.readthedocs.io/en/latest/limitations.html#linux).
+- On Linux, if the left and right arrow keys and escape key don't have any effect during data recording on an X11 session, make sure you've set the `$DISPLAY` environment variable. See [pynput limitations](https://pynput.readthedocs.io/en/latest/limitations.html#linux). On a Wayland session or a headless machine, `pynput` cannot capture these keys at all; run the recording from an interactive terminal and the same controls (plus the `n`/`r`/`q` letter equivalents) are read from the terminal instead — no `$DISPLAY` needed.
 
 ## Replay an episode
 

--- a/src/lerobot/common/control_utils.py
+++ b/src/lerobot/common/control_utils.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 ########################################################################################
 import logging
 import os
+import sys
+import threading
 import time
 import traceback
 from contextlib import nullcontext
@@ -166,6 +168,108 @@ def handle_key(kind: str, events: dict) -> None:
         print("Escape key pressed. Stopping data recording...")
         events["stop_recording"] = True
         events["exit_early"] = True
+
+
+class TerminalKeyListener:
+    """
+    Display-independent keyboard listener that reads control keys from the terminal (stdin).
+
+    Used as the Wayland/headless equivalent of the ``pynput`` listener. ``pynput`` needs an X11
+    backend and cannot capture global hotkeys under Wayland, but a controlling TTY still delivers
+    key bytes to the foreground process. This backend puts the terminal into cbreak mode and reads
+    bytes on a daemon thread, recognizing:
+
+    - the same Right / Left / Esc controls via their ANSI escape sequences (``ESC [ C`` / ``ESC [ D``
+      / bare ``ESC``), routed through :func:`handle_key` so behavior matches the ``pynput`` path; and
+    - ``n`` / ``r`` / ``q`` letter fallbacks (next / re-record / quit) for keymaps where the arrow
+      keys are inconvenient.
+
+    Only a *bare* ``ESC`` maps to "stop"; other CSI sequences such as the up/down arrows
+    (``ESC [ A`` / ``ESC [ B``) are intentionally ignored so they cannot accidentally trigger a
+    stop. The original terminal attributes are captured on :meth:`start` and restored on
+    :meth:`stop`, so the terminal is never left in cbreak mode.
+
+    The POSIX-only modules (``termios``/``tty``/``select``) are imported lazily inside the methods
+    so this module remains importable on platforms without them (e.g. Windows).
+    """
+
+    def __init__(self, events: dict):
+        self._events = events
+        self._running = False
+        self._thread: threading.Thread | None = None
+        self._fd: int | None = None
+        self._old_attrs = None
+
+    def _read_char(self, timeout: float) -> str | None:
+        """Return one character from stdin within ``timeout`` seconds, or ``None`` on timeout."""
+        import select
+
+        if self._fd is None:
+            return None
+        ready, _, _ = select.select([self._fd], [], [], timeout)
+        if not ready:
+            return None
+        return os.read(self._fd, 1).decode(errors="ignore")
+
+    def _run(self) -> None:
+        while self._running:
+            ch = self._read_char(timeout=0.05)
+            if ch is None:
+                continue
+
+            if ch == "\x1b":
+                # Start of a possible ANSI escape sequence (e.g. arrow keys: ``ESC [ <code>``).
+                # Use short follow-up reads so a *bare* ESC isn't mistaken for a sequence.
+                ch2 = self._read_char(timeout=0.02)
+                if ch2 is None:
+                    handle_key("esc", self._events)
+                    continue
+                ch3 = self._read_char(timeout=0.02)
+                seq = ch2 + (ch3 or "")
+                if seq == "[C":
+                    handle_key("right", self._events)
+                elif seq == "[D":
+                    handle_key("left", self._events)
+                # Any other sequence (incl. up/down "[A"/"[B") is ignored on purpose.
+                continue
+
+            lowered = ch.lower()
+            if lowered == "n":
+                handle_key("right", self._events)
+            elif lowered == "r":
+                handle_key("left", self._events)
+            elif lowered == "q":
+                handle_key("esc", self._events)
+
+    def start(self) -> None:
+        """Switch the terminal to cbreak mode and begin reading keys on a daemon thread.
+
+        No-op when stdin is not a TTY (e.g. piped/redirected input), so non-interactive
+        runs are never affected.
+        """
+        import termios
+        import tty
+
+        if not sys.stdin.isatty():
+            return
+        self._fd = sys.stdin.fileno()
+        self._old_attrs = termios.tcgetattr(self._fd)
+        tty.setcbreak(self._fd)
+        self._running = True
+        self._thread = threading.Thread(target=self._run, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        """Stop the reader thread and restore the original terminal attributes."""
+        self._running = False
+        if self._thread is not None:
+            self._thread.join(timeout=0.5)
+            self._thread = None
+        if self._fd is not None and self._old_attrs is not None:
+            import termios
+
+            termios.tcsetattr(self._fd, termios.TCSADRAIN, self._old_attrs)
+            self._old_attrs = None
 
 
 def init_keyboard_listener():

--- a/src/lerobot/common/control_utils.py
+++ b/src/lerobot/common/control_utils.py
@@ -280,9 +280,18 @@ def init_keyboard_listener():
     the program flow during execution, such as stopping recording or exiting loops. It gracefully
     handles headless environments where keyboard listening is not possible.
 
+    Backend selection:
+        - On an X11 display, the ``pynput`` global listener is used.
+        - On a Wayland session (where ``pynput`` cannot capture global hotkeys) or a headless
+          machine (where ``pynput`` is unavailable), a terminal listener reads the same keys from
+          stdin instead, as long as stdin is an interactive TTY.
+        - When neither backend is usable (e.g. stdin is not a TTY in an automated run), no listener
+          is created and recording relies on the episode/reset timers.
+
     Returns:
         A tuple containing:
-        - The `pynput.keyboard.Listener` instance, or `None` if in a headless environment.
+        - A listener instance exposing ``stop()`` (``pynput.keyboard.Listener`` or
+          :class:`TerminalKeyListener`), or ``None`` when no keyboard backend is available.
         - A dictionary of event flags (e.g., `exit_early`) that are set by key presses.
     """
     # Allow to exit early while recording an episode or resetting the environment,
@@ -293,30 +302,44 @@ def init_keyboard_listener():
     events["rerecord_episode"] = False
     events["stop_recording"] = False
 
-    if is_headless():
-        logging.warning(
-            "Headless environment detected. On-screen cameras display and keyboard inputs will not be available."
-        )
-        listener = None
+    # pynput needs an X11 backend. It is unavailable on headless machines, and on Wayland it still
+    # imports but cannot capture *global* hotkeys, so the arrow/Esc shortcuts are non-functional.
+    if not is_headless() and not is_wayland():
+        from pynput import keyboard
+
+        def on_press(key):
+            try:
+                if key == keyboard.Key.right:
+                    handle_key("right", events)
+                elif key == keyboard.Key.left:
+                    handle_key("left", events)
+                elif key == keyboard.Key.esc:
+                    handle_key("esc", events)
+            except Exception as e:
+                print(f"Error handling key press: {e}")
+
+        listener = keyboard.Listener(on_press=on_press)
+        listener.start()
         return listener, events
 
-    # Only import pynput if not in a headless environment
-    from pynput import keyboard
+    # Display-independent fallback (Wayland / headless): read the same keys from the terminal.
+    # This requires an interactive TTY; otherwise there is nothing to read from.
+    session = "Headless environment" if is_headless() else "Wayland session"
+    if not sys.stdin.isatty():
+        logging.warning(
+            "%s detected and stdin is not a TTY: keyboard controls are unavailable. "
+            "Recording will rely on the episode/reset timers (or Ctrl+C).",
+            session,
+        )
+        return None, events
 
-    def on_press(key):
-        try:
-            if key == keyboard.Key.right:
-                handle_key("right", events)
-            elif key == keyboard.Key.left:
-                handle_key("left", events)
-            elif key == keyboard.Key.esc:
-                handle_key("esc", events)
-        except Exception as e:
-            print(f"Error handling key press: {e}")
-
-    listener = keyboard.Listener(on_press=on_press)
+    logging.info(
+        "%s detected - enabling terminal keyboard listener. "
+        "Controls: Right/Left/Esc (or n=next, r=re-record, q=quit).",
+        session,
+    )
+    listener = TerminalKeyListener(events)
     listener.start()
-
     return listener, events
 
 

--- a/src/lerobot/common/control_utils.py
+++ b/src/lerobot/common/control_utils.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 # Utilities
 ########################################################################################
 import logging
+import os
 import time
 import traceback
 from contextlib import nullcontext
@@ -71,6 +72,25 @@ def is_headless():
         return True
 
 
+@cache
+def is_wayland() -> bool:
+    """
+    Detects whether the current session is a Wayland session.
+
+    ``pynput`` relies on an X11 backend. Under Wayland it only observes XWayland clients and
+    cannot capture *global* hotkeys reliably, so the documented arrow/Esc shortcuts are
+    non-functional while a Wayland-native window has focus. Unlike a missing display, this case
+    is invisible to :func:`is_headless` because ``pynput`` still imports successfully (XWayland is
+    usually present and ``$DISPLAY`` is set), which is why a dedicated check is needed.
+
+    Returns:
+        True if a Wayland session is detected, False otherwise.
+    """
+    return os.environ.get("XDG_SESSION_TYPE", "").lower() == "wayland" or bool(
+        os.environ.get("WAYLAND_DISPLAY")
+    )
+
+
 def predict_action(
     observation: dict[str, np.ndarray],
     policy: PreTrainedPolicy,
@@ -122,6 +142,32 @@ def predict_action(
     return action
 
 
+def handle_key(kind: str, events: dict) -> None:
+    """
+    Applies a recording control key press to the shared ``events`` dict.
+
+    Centralizes the mapping from a logical key (``"right"`` / ``"left"`` / ``"esc"``) to the
+    corresponding event flags so every keyboard backend (pynput on X11, and the terminal reader
+    used on Wayland/headless sessions) produces identical behavior.
+
+    Args:
+        kind: One of ``"right"`` (end episode early), ``"left"`` (re-record episode), or
+            ``"esc"`` (stop recording).
+        events: The shared event-flag dict mutated in place.
+    """
+    if kind == "right":
+        print("Right arrow key pressed. Exiting loop...")
+        events["exit_early"] = True
+    elif kind == "left":
+        print("Left arrow key pressed. Exiting loop and rerecord the last episode...")
+        events["rerecord_episode"] = True
+        events["exit_early"] = True
+    elif kind == "esc":
+        print("Escape key pressed. Stopping data recording...")
+        events["stop_recording"] = True
+        events["exit_early"] = True
+
+
 def init_keyboard_listener():
     """
     Initializes a non-blocking keyboard listener for real-time user interaction.
@@ -156,16 +202,11 @@ def init_keyboard_listener():
     def on_press(key):
         try:
             if key == keyboard.Key.right:
-                print("Right arrow key pressed. Exiting loop...")
-                events["exit_early"] = True
+                handle_key("right", events)
             elif key == keyboard.Key.left:
-                print("Left arrow key pressed. Exiting loop and rerecord the last episode...")
-                events["rerecord_episode"] = True
-                events["exit_early"] = True
+                handle_key("left", events)
             elif key == keyboard.Key.esc:
-                print("Escape key pressed. Stopping data recording...")
-                events["stop_recording"] = True
-                events["exit_early"] = True
+                handle_key("esc", events)
         except Exception as e:
             print(f"Error handling key press: {e}")
 

--- a/src/lerobot/rollout/strategies/dagger.py
+++ b/src/lerobot/rollout/strategies/dagger.py
@@ -328,7 +328,7 @@ class DAggerStrategy(RolloutStrategy):
         logger.info("Stopping DAgger recording")
         log_say("Stopping DAgger recording", play_sounds)
 
-        if self._listener is not None and not is_headless():
+        if self._listener is not None:
             logger.info("Stopping keyboard listener")
             self._listener.stop()
 

--- a/src/lerobot/rollout/strategies/episodic.py
+++ b/src/lerobot/rollout/strategies/episodic.py
@@ -36,7 +36,6 @@ import time
 from lerobot.common.control_utils import (
     follower_smooth_move_to,
     init_keyboard_listener,
-    is_headless,
     teleop_smooth_move_to,
     teleop_supports_feedback,
 )
@@ -307,7 +306,7 @@ class EpisodicStrategy(RolloutStrategy):
 
         log_say("Stop recording", play_sounds, blocking=True)
 
-        if not is_headless() and self._listener is not None:
+        if self._listener is not None:
             self._listener.stop()
 
         if ctx.data.dataset is not None:

--- a/src/lerobot/scripts/lerobot_record.py
+++ b/src/lerobot/scripts/lerobot_record.py
@@ -98,7 +98,6 @@ from lerobot.cameras.realsense import RealSenseCameraConfig  # noqa: F401
 from lerobot.cameras.zmq import ZMQCameraConfig  # noqa: F401
 from lerobot.common.control_utils import (
     init_keyboard_listener,
-    is_headless,
     sanity_check_dataset_robot_compatibility,
 )
 from lerobot.configs import parser
@@ -508,7 +507,7 @@ def record(
         if teleop and teleop.is_connected:
             teleop.disconnect()
 
-        if not is_headless() and listener:
+        if listener is not None:
             listener.stop()
 
         if cfg.dataset.push_to_hub:

--- a/tests/test_terminal_keyboard_listener.py
+++ b/tests/test_terminal_keyboard_listener.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python
+
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the Wayland/headless keyboard backend in ``lerobot.common.control_utils``.
+
+Covers ``is_wayland`` session detection, the shared ``handle_key`` mapping, and the
+``TerminalKeyListener`` key parsing (ANSI escape sequences + letter fallbacks, with up/down
+arrows ignored) and terminal-state restore on teardown.
+"""
+
+import sys
+
+import pytest
+
+from lerobot.common.control_utils import (
+    TerminalKeyListener,
+    handle_key,
+    is_wayland,
+)
+
+
+@pytest.fixture
+def events():
+    return {"exit_early": False, "rerecord_episode": False, "stop_recording": False}
+
+
+def _drive(listener: TerminalKeyListener, keys: list[str | None]) -> None:
+    """Run the listener's read loop synchronously over a scripted list of characters.
+
+    ``None`` entries simulate a read timeout (no character available). The loop stops once the
+    script is exhausted, so no real terminal or thread is involved.
+    """
+    script = list(keys)
+
+    def fake_read(_timeout):
+        if script:
+            return script.pop(0)
+        listener._running = False
+        return None
+
+    listener._read_char = fake_read
+    listener._running = True
+    listener._run()
+
+
+class TestHandleKey:
+    def test_right_sets_exit_early(self, events):
+        handle_key("right", events)
+        assert events == {"exit_early": True, "rerecord_episode": False, "stop_recording": False}
+
+    def test_left_sets_rerecord_and_exit(self, events):
+        handle_key("left", events)
+        assert events == {"exit_early": True, "rerecord_episode": True, "stop_recording": False}
+
+    def test_esc_sets_stop_and_exit(self, events):
+        handle_key("esc", events)
+        assert events == {"exit_early": True, "rerecord_episode": False, "stop_recording": True}
+
+    def test_unknown_kind_is_noop(self, events):
+        handle_key("up", events)
+        assert not any(events.values())
+
+
+class TestTerminalKeyParsing:
+    def test_right_arrow_sequence(self, events):
+        _drive(TerminalKeyListener(events), ["\x1b", "[", "C"])
+        assert events["exit_early"] is True
+        assert events["rerecord_episode"] is False
+        assert events["stop_recording"] is False
+
+    def test_left_arrow_sequence(self, events):
+        _drive(TerminalKeyListener(events), ["\x1b", "[", "D"])
+        assert events["rerecord_episode"] is True
+        assert events["exit_early"] is True
+
+    def test_bare_esc_stops(self, events):
+        # No bytes follow the ESC -> treated as the Escape key, not a CSI sequence.
+        _drive(TerminalKeyListener(events), ["\x1b"])
+        assert events["stop_recording"] is True
+        assert events["exit_early"] is True
+
+    @pytest.mark.parametrize("final", ["A", "B"])
+    def test_up_down_arrows_are_ignored(self, events, final):
+        _drive(TerminalKeyListener(events), ["\x1b", "[", final])
+        assert not any(events.values())
+
+    def test_letter_n_is_next(self, events):
+        _drive(TerminalKeyListener(events), ["n"])
+        assert events["exit_early"] is True
+        assert events["rerecord_episode"] is False
+
+    def test_letter_r_is_rerecord(self, events):
+        _drive(TerminalKeyListener(events), ["r"])
+        assert events["rerecord_episode"] is True
+        assert events["exit_early"] is True
+
+    def test_letter_q_is_quit(self, events):
+        _drive(TerminalKeyListener(events), ["q"])
+        assert events["stop_recording"] is True
+
+    def test_letters_are_case_insensitive(self, events):
+        _drive(TerminalKeyListener(events), ["Q"])
+        assert events["stop_recording"] is True
+
+    def test_unmapped_letter_is_noop(self, events):
+        _drive(TerminalKeyListener(events), ["x"])
+        assert not any(events.values())
+
+
+class TestIsWayland:
+    @pytest.fixture(autouse=True)
+    def _clear_cache(self):
+        # is_wayland is @cache-decorated; clear around each test so env changes take effect.
+        is_wayland.cache_clear()
+        yield
+        is_wayland.cache_clear()
+
+    def test_detects_xdg_session_type(self, monkeypatch):
+        monkeypatch.setenv("XDG_SESSION_TYPE", "wayland")
+        monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+        assert is_wayland() is True
+
+    def test_xdg_session_type_is_case_insensitive(self, monkeypatch):
+        monkeypatch.setenv("XDG_SESSION_TYPE", "Wayland")
+        monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+        assert is_wayland() is True
+
+    def test_detects_wayland_display(self, monkeypatch):
+        monkeypatch.delenv("XDG_SESSION_TYPE", raising=False)
+        monkeypatch.setenv("WAYLAND_DISPLAY", "wayland-0")
+        assert is_wayland() is True
+
+    def test_x11_is_not_wayland(self, monkeypatch):
+        monkeypatch.setenv("XDG_SESSION_TYPE", "x11")
+        monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+        assert is_wayland() is False
+
+    def test_no_env_is_not_wayland(self, monkeypatch):
+        monkeypatch.delenv("XDG_SESSION_TYPE", raising=False)
+        monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+        assert is_wayland() is False
+
+
+class TestStartStopLifecycle:
+    def test_start_is_noop_without_tty(self, events, monkeypatch):
+        pytest.importorskip("termios")
+
+        class _FakeStdin:
+            def isatty(self):
+                return False
+
+        monkeypatch.setattr(sys, "stdin", _FakeStdin())
+        listener = TerminalKeyListener(events)
+        listener.start()
+        assert listener._thread is None
+        # stop() must be safe even though start() did nothing.
+        listener.stop()
+
+    def test_stop_restores_terminal_attributes(self, events, monkeypatch):
+        termios = pytest.importorskip("termios")
+        import tty
+
+        class _FakeStdin:
+            def isatty(self):
+                return True
+
+            def fileno(self):
+                return 0
+
+        restored = {}
+        monkeypatch.setattr(sys, "stdin", _FakeStdin())
+        monkeypatch.setattr(termios, "tcgetattr", lambda fd: "ORIGINAL_ATTRS")
+        monkeypatch.setattr(tty, "setcbreak", lambda fd: None)
+        monkeypatch.setattr(
+            termios,
+            "tcsetattr",
+            lambda fd, when, attrs: restored.update(fd=fd, attrs=attrs),
+        )
+
+        listener = TerminalKeyListener(events)
+        # Avoid the reader thread touching real stdin while it runs.
+        listener._read_char = lambda _timeout: None
+
+        listener.start()
+        assert listener._thread is not None
+        listener.stop()
+
+        assert restored["attrs"] == "ORIGINAL_ATTRS"
+        assert listener._thread is None


### PR DESCRIPTION
> Draft — work in progress. Opening early to surface the approach and run CI while the implementation lands in small commits. Real-hardware (Raspberry Pi 5 / Wayland) validation pending before marking ready.

## Summary / Motivation

`lerobot-record`'s episode controls (Right = end episode early, Left = re-record, Esc = stop) are driven by a `pynput` global keyboard listener. `pynput` requires an X11 backend, so on Wayland sessions it cannot capture global hotkeys — the arrow/Esc keys silently do nothing and leak into the terminal as raw escape codes. This affects modern Linux desktops (GNOME/KDE default to Wayland) and, notably, Raspberry Pi OS (Bookworm+), which now defaults to the labwc Wayland compositor across all Pi models.

The existing headless guard (`is_headless()`) does not catch this case: under Wayland `pynput` still *imports* successfully (XWayland is present, `$DISPLAY` is set), so the code takes the pynput path and the controls remain non-functional. Setting `$DISPLAY` does not help.

This PR adds a display-independent terminal keyboard backend that preserves the exact same Right/Left/Esc UX on Wayland and headless TTY sessions, using only the standard library (no new runtime dependency).

## Related issues

- Related: #3700 (feature discussion: Wayland-friendly interactive reset)
- Related: #3701 (dependency-free stdin prompt + SIGQUIT approach)
- Related: #3730 (terminal/termios fallback approach)

This change converges the above: it keeps the identical arrow/Esc keybindings (rather than a separate prompt/keybinding set) and adds Wayland detection so the fallback actually activates on Wayland — not only when `pynput` fails to import. It does so without adding a runtime dependency.

## What changed

- Add `is_wayland()` detection (`XDG_SESSION_TYPE` / `WAYLAND_DISPLAY`) so the fallback engages on Wayland, where `pynput` imports but cannot capture global hotkeys.
- Extract the Right/Left/Esc handling into a shared `handle_key()` so every backend produces identical event semantics.
- Add a stdlib `termios`-based terminal listener for Wayland/headless TTY sessions (arrow/Esc + `n`/`r`/`q` letter fallbacks; up/down safely ignored; terminal state restored on stop).
- Select the backend automatically: `pynput` on X11, terminal reader on Wayland/headless TTY, no-op when stdin is not a TTY (CI/piped runs are unaffected).
- No new runtime dependency.

Backward compatible: on X11 the `pynput` path is unchanged.

## How was this tested (or how to run locally)

- Unit tests for `is_wayland()` detection, terminal key parsing (escape sequences + letter fallbacks, up/down ignored), non-TTY no-op, and terminal-state restore.
- Manual validation on Raspberry Pi 5, Raspberry Pi OS Bookworm (64-bit), labwc/Wayland session over RealVNC: Right/Left/Esc during `lerobot-record`, dataset saves with correct episode count. (Pending — will update before marking ready.)
- X11 session: confirm `pynput` path unchanged.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: #

## Reviewer notes

- Focus areas: the backend-selection logic in `init_keyboard_listener()` and the terminal-state restore on teardown (terminal must not be left in cbreak mode).
- The terminal reader maps only a bare `ESC` to "stop"; other CSI sequences (up/down arrows) are ignored to avoid an accidental stop on up/down.
