### PR TITLE
Detector

### DIFF
--- a/src/lerobot/async_inference/configs.py
+++ b/src/lerobot/async_inference/configs.py
@@ -137,6 +137,23 @@ class RobotClientConfig:
     chunk_size_threshold: float = field(default=0.5, metadata={"help": "Threshold for chunk size control"})
     fps: int = field(default=DEFAULT_FPS, metadata={"help": "Frames per second"})
 
+    # Supervisor monitor configuration (optional event-triggered replanning)
+    supervisor_enabled: bool = field(
+        default=False, metadata={"help": "Enable supervisor camera monitor for event-triggered replanning"}
+    )
+    supervisor_camera: str = field(
+        default="overall", metadata={"help": "Camera key used by the supervisor monitor"}
+    )
+    supervisor_poll_fps: int = field(
+        default=20, metadata={"help": "Supervisor monitor polling rate (Hz)"}
+    )
+    supervisor_cooldown_s: float = field(
+        default=1.0, metadata={"help": "Minimum seconds between supervisor triggers"}
+    )
+    supervisor_motion_threshold: float = field(
+        default=0.02, metadata={"help": "Fraction of frame pixels in motion to fire a trigger"}
+    )
+
     # Aggregate function configuration (CLI-compatible)
     aggregate_fn_name: str = field(
         default="weighted_average",
@@ -179,6 +196,16 @@ class RobotClientConfig:
         if self.actions_per_chunk <= 0:
             raise ValueError(f"actions_per_chunk must be positive, got {self.actions_per_chunk}")
 
+        if self.supervisor_enabled:
+            if self.supervisor_poll_fps <= 0:
+                raise ValueError(f"supervisor_poll_fps must be positive, got {self.supervisor_poll_fps}")
+            if self.supervisor_cooldown_s < 0:
+                raise ValueError(f"supervisor_cooldown_s must be non-negative, got {self.supervisor_cooldown_s}")
+            if not 0 < self.supervisor_motion_threshold <= 1:
+                raise ValueError(
+                    f"supervisor_motion_threshold must be in (0, 1], got {self.supervisor_motion_threshold}"
+                )
+
         self.aggregate_fn = get_aggregate_function(self.aggregate_fn_name)
 
     @classmethod
@@ -200,4 +227,9 @@ class RobotClientConfig:
             "task": self.task,
             "debug_visualize_queue_size": self.debug_visualize_queue_size,
             "aggregate_fn_name": self.aggregate_fn_name,
+            "supervisor_enabled": self.supervisor_enabled,
+            "supervisor_camera": self.supervisor_camera,
+            "supervisor_poll_fps": self.supervisor_poll_fps,
+            "supervisor_cooldown_s": self.supervisor_cooldown_s,
+            "supervisor_motion_threshold": self.supervisor_motion_threshold,
         }

--- a/src/lerobot/async_inference/configs.py
+++ b/src/lerobot/async_inference/configs.py
@@ -144,14 +144,44 @@ class RobotClientConfig:
     supervisor_camera: str = field(
         default="overall", metadata={"help": "Camera key used by the supervisor monitor"}
     )
-    supervisor_poll_fps: int = field(
-        default=20, metadata={"help": "Supervisor monitor polling rate (Hz)"}
-    )
+    supervisor_poll_fps: int = field(default=20, metadata={"help": "Supervisor monitor polling rate (Hz)"})
     supervisor_cooldown_s: float = field(
         default=1.0, metadata={"help": "Minimum seconds between supervisor triggers"}
     )
     supervisor_motion_threshold: float = field(
         default=0.02, metadata={"help": "Fraction of frame pixels in motion to fire a trigger"}
+    )
+    supervisor_detector_type: str = field(
+        default="motion", metadata={"help": "Supervisor detector type. Options: motion, red_cube_speed"}
+    )
+    supervisor_slow_speed_px_s: float = field(
+        default=40.0,
+        metadata={"help": "Red cube speed mapped to the minimum adaptive replan threshold"},
+    )
+    supervisor_fast_speed_px_s: float = field(
+        default=200.0,
+        metadata={"help": "Red cube speed mapped to the maximum adaptive replan threshold"},
+    )
+    supervisor_urgent_speed_px_s: float = field(
+        default=250.0, metadata={"help": "Red cube speed that triggers immediate replanning"}
+    )
+    supervisor_min_chunk_size_threshold: float = field(
+        default=0.25, metadata={"help": "Adaptive threshold used when the red cube is slow"}
+    )
+    supervisor_max_chunk_size_threshold: float = field(
+        default=0.75, metadata={"help": "Adaptive threshold used when the red cube is fast"}
+    )
+    supervisor_red_hue_tolerance_deg: float = field(
+        default=20.0, metadata={"help": "HSV hue tolerance around red for the cube mask"}
+    )
+    supervisor_red_saturation_min: float = field(
+        default=0.45, metadata={"help": "Minimum HSV saturation for the red cube mask"}
+    )
+    supervisor_red_value_min: float = field(
+        default=0.25, metadata={"help": "Minimum HSV value for the red cube mask"}
+    )
+    supervisor_red_min_area_ratio: float = field(
+        default=0.001, metadata={"help": "Minimum frame area occupied by the red cube mask"}
     )
 
     # Aggregate function configuration (CLI-compatible)
@@ -200,10 +230,65 @@ class RobotClientConfig:
             if self.supervisor_poll_fps <= 0:
                 raise ValueError(f"supervisor_poll_fps must be positive, got {self.supervisor_poll_fps}")
             if self.supervisor_cooldown_s < 0:
-                raise ValueError(f"supervisor_cooldown_s must be non-negative, got {self.supervisor_cooldown_s}")
+                raise ValueError(
+                    f"supervisor_cooldown_s must be non-negative, got {self.supervisor_cooldown_s}"
+                )
             if not 0 < self.supervisor_motion_threshold <= 1:
                 raise ValueError(
                     f"supervisor_motion_threshold must be in (0, 1], got {self.supervisor_motion_threshold}"
+                )
+            if self.supervisor_detector_type not in {"motion", "red_cube_speed"}:
+                raise ValueError(
+                    "supervisor_detector_type must be one of {'motion', 'red_cube_speed'}, "
+                    f"got {self.supervisor_detector_type}"
+                )
+            if self.supervisor_slow_speed_px_s < 0:
+                raise ValueError(
+                    f"supervisor_slow_speed_px_s must be non-negative, got {self.supervisor_slow_speed_px_s}"
+                )
+            if self.supervisor_fast_speed_px_s <= self.supervisor_slow_speed_px_s:
+                raise ValueError(
+                    "supervisor_fast_speed_px_s must be greater than supervisor_slow_speed_px_s, "
+                    f"got {self.supervisor_fast_speed_px_s} <= {self.supervisor_slow_speed_px_s}"
+                )
+            if self.supervisor_urgent_speed_px_s < self.supervisor_slow_speed_px_s:
+                raise ValueError(
+                    "supervisor_urgent_speed_px_s must be at least supervisor_slow_speed_px_s, "
+                    f"got {self.supervisor_urgent_speed_px_s} < {self.supervisor_slow_speed_px_s}"
+                )
+            if not 0 <= self.supervisor_min_chunk_size_threshold <= 1:
+                raise ValueError(
+                    "supervisor_min_chunk_size_threshold must be between 0 and 1, "
+                    f"got {self.supervisor_min_chunk_size_threshold}"
+                )
+            if not 0 <= self.supervisor_max_chunk_size_threshold <= 1:
+                raise ValueError(
+                    "supervisor_max_chunk_size_threshold must be between 0 and 1, "
+                    f"got {self.supervisor_max_chunk_size_threshold}"
+                )
+            if self.supervisor_min_chunk_size_threshold > self.supervisor_max_chunk_size_threshold:
+                raise ValueError(
+                    "supervisor_min_chunk_size_threshold must be <= supervisor_max_chunk_size_threshold, "
+                    f"got {self.supervisor_min_chunk_size_threshold} > "
+                    f"{self.supervisor_max_chunk_size_threshold}"
+                )
+            if not 0 <= self.supervisor_red_hue_tolerance_deg <= 180:
+                raise ValueError(
+                    "supervisor_red_hue_tolerance_deg must be between 0 and 180, "
+                    f"got {self.supervisor_red_hue_tolerance_deg}"
+                )
+            if not 0 <= self.supervisor_red_saturation_min <= 1:
+                raise ValueError(
+                    "supervisor_red_saturation_min must be between 0 and 1, "
+                    f"got {self.supervisor_red_saturation_min}"
+                )
+            if not 0 <= self.supervisor_red_value_min <= 1:
+                raise ValueError(
+                    f"supervisor_red_value_min must be between 0 and 1, got {self.supervisor_red_value_min}"
+                )
+            if not 0 < self.supervisor_red_min_area_ratio <= 1:
+                raise ValueError(
+                    f"supervisor_red_min_area_ratio must be in (0, 1], got {self.supervisor_red_min_area_ratio}"
                 )
 
         self.aggregate_fn = get_aggregate_function(self.aggregate_fn_name)
@@ -232,4 +317,14 @@ class RobotClientConfig:
             "supervisor_poll_fps": self.supervisor_poll_fps,
             "supervisor_cooldown_s": self.supervisor_cooldown_s,
             "supervisor_motion_threshold": self.supervisor_motion_threshold,
+            "supervisor_detector_type": self.supervisor_detector_type,
+            "supervisor_slow_speed_px_s": self.supervisor_slow_speed_px_s,
+            "supervisor_fast_speed_px_s": self.supervisor_fast_speed_px_s,
+            "supervisor_urgent_speed_px_s": self.supervisor_urgent_speed_px_s,
+            "supervisor_min_chunk_size_threshold": self.supervisor_min_chunk_size_threshold,
+            "supervisor_max_chunk_size_threshold": self.supervisor_max_chunk_size_threshold,
+            "supervisor_red_hue_tolerance_deg": self.supervisor_red_hue_tolerance_deg,
+            "supervisor_red_saturation_min": self.supervisor_red_saturation_min,
+            "supervisor_red_value_min": self.supervisor_red_value_min,
+            "supervisor_red_min_area_ratio": self.supervisor_red_min_area_ratio,
         }

--- a/src/lerobot/async_inference/robot_client.py
+++ b/src/lerobot/async_inference/robot_client.py
@@ -78,7 +78,7 @@ from .helpers import (
     map_robot_keys_to_lerobot_features,
     visualize_action_queue_size,
 )
-from .supervisor import MotionDetector, SupervisorMonitor
+from .supervisor import MotionDetector, RedCubeSpeedDetector, SupervisorMonitor
 
 
 class RobotClient:
@@ -140,9 +140,24 @@ class RobotClient:
         # Optional supervisor monitor for event-triggered replanning (Tier 2)
         self.supervisor = None
         if config.supervisor_enabled:
+            if config.supervisor_detector_type == "red_cube_speed":
+                detect_fn = RedCubeSpeedDetector(
+                    slow_speed_px_s=config.supervisor_slow_speed_px_s,
+                    fast_speed_px_s=config.supervisor_fast_speed_px_s,
+                    min_chunk_size_threshold=config.supervisor_min_chunk_size_threshold,
+                    max_chunk_size_threshold=config.supervisor_max_chunk_size_threshold,
+                    urgent_speed_px_s=config.supervisor_urgent_speed_px_s,
+                    hue_tolerance_deg=config.supervisor_red_hue_tolerance_deg,
+                    saturation_min=config.supervisor_red_saturation_min,
+                    value_min=config.supervisor_red_value_min,
+                    min_area_ratio=config.supervisor_red_min_area_ratio,
+                )
+            else:
+                detect_fn = MotionDetector(motion_area_threshold=config.supervisor_motion_threshold)
+
             self.supervisor = SupervisorMonitor(
                 camera=self.robot.cameras[config.supervisor_camera],
-                detect_fn=MotionDetector(motion_area_threshold=config.supervisor_motion_threshold),
+                detect_fn=detect_fn,
                 poll_fps=config.supervisor_poll_fps,
                 cooldown_s=config.supervisor_cooldown_s,
             )
@@ -416,12 +431,35 @@ class RobotClient:
 
     def _ready_to_send_observation(self):
         """Flags when the client is ready to send an observation"""
+        chunk_size_threshold = self._adaptive_chunk_size_threshold()
         with self.action_queue_lock:
-            queue_ready = self.action_queue.qsize() / self.action_chunk_size <= self._chunk_size_threshold
+            queue_ready = self.action_queue.qsize() / self.action_chunk_size <= chunk_size_threshold
         if queue_ready:
             return True
-        # Event-triggered early replan: fire the instant the supervisor detects a change
-        return self.supervisor is not None and self.supervisor.consume_trigger()
+
+        if self.supervisor is None:
+            return False
+
+        # Event-triggered early replan: fire instantly for urgent detector outputs.
+        trigger_output = self.supervisor.consume_trigger()
+        if trigger_output is None:
+            return False
+        self.logger.debug(
+            "Supervisor trigger consumed"
+            f" | reason={trigger_output.reason}"
+            f" | speed_px_s={trigger_output.speed_px_s}"
+        )
+        return True
+
+    def _adaptive_chunk_size_threshold(self) -> float:
+        if self.supervisor is None:
+            return self._chunk_size_threshold
+
+        latest_output = self.supervisor.latest_output()
+        if latest_output is None or latest_output.effective_chunk_size_threshold is None:
+            return self._chunk_size_threshold
+
+        return latest_output.effective_chunk_size_threshold
 
     def control_loop_observation(self, task: str, verbose: bool = False) -> RawObservation:
         try:

--- a/src/lerobot/async_inference/robot_client.py
+++ b/src/lerobot/async_inference/robot_client.py
@@ -78,6 +78,7 @@ from .helpers import (
     map_robot_keys_to_lerobot_features,
     visualize_action_queue_size,
 )
+from .supervisor import MotionDetector, SupervisorMonitor
 
 
 class RobotClient:
@@ -136,6 +137,16 @@ class RobotClient:
         self.must_go = threading.Event()
         self.must_go.set()  # Initially set - observations qualify for direct processing
 
+        # Optional supervisor monitor for event-triggered replanning (Tier 2)
+        self.supervisor = None
+        if config.supervisor_enabled:
+            self.supervisor = SupervisorMonitor(
+                camera=self.robot.cameras[config.supervisor_camera],
+                detect_fn=MotionDetector(motion_area_threshold=config.supervisor_motion_threshold),
+                poll_fps=config.supervisor_poll_fps,
+                cooldown_s=config.supervisor_cooldown_s,
+            )
+
     @property
     def running(self):
         return not self.shutdown_event.is_set()
@@ -173,6 +184,9 @@ class RobotClient:
     def stop(self):
         """Stop the robot client"""
         self.shutdown_event.set()
+
+        if self.supervisor is not None:
+            self.supervisor.stop()
 
         self.robot.disconnect()
         self.logger.debug("Robot disconnected")
@@ -403,7 +417,11 @@ class RobotClient:
     def _ready_to_send_observation(self):
         """Flags when the client is ready to send an observation"""
         with self.action_queue_lock:
-            return self.action_queue.qsize() / self.action_chunk_size <= self._chunk_size_threshold
+            queue_ready = self.action_queue.qsize() / self.action_chunk_size <= self._chunk_size_threshold
+        if queue_ready:
+            return True
+        # Event-triggered early replan: fire the instant the supervisor detects a change
+        return self.supervisor is not None and self.supervisor.consume_trigger()
 
     def control_loop_observation(self, task: str, verbose: bool = False) -> RawObservation:
         try:
@@ -499,6 +517,10 @@ def async_client(cfg: RobotClientConfig):
 
         # Start action receiver thread
         action_receiver_thread.start()
+
+        # Start supervisor monitor thread (event-triggered replanning), if enabled
+        if client.supervisor is not None:
+            client.supervisor.start()
 
         try:
             # The main thread runs the control loop

--- a/src/lerobot/async_inference/supervisor.py
+++ b/src/lerobot/async_inference/supervisor.py
@@ -24,11 +24,23 @@ detected, regardless of action-queue level, without touching the static
 import threading
 import time
 from collections.abc import Callable
+from dataclasses import dataclass
 
 import numpy as np
 from numpy.typing import NDArray
 
 from .helpers import get_logger
+
+
+@dataclass(frozen=True)
+class DetectorOutput:
+    """Structured detector output for event-triggered and speed-adaptive replanning."""
+
+    replan_now: bool = False
+    center_px: tuple[float, float] | None = None
+    speed_px_s: float | None = None
+    effective_chunk_size_threshold: float | None = None
+    reason: str = ""
 
 
 class MotionDetector:
@@ -57,6 +69,123 @@ class MotionDetector:
         return motion_ratio > self.motion_area_threshold
 
 
+class RedCubeSpeedDetector:
+    """Estimate red cube image-plane speed and suggest a replan threshold.
+
+    This detector uses a simple dependency-free HSV red mask. Red wraps around
+    the hue axis, so pixels near both 0 and 360 degrees are accepted.
+    """
+
+    def __init__(
+        self,
+        slow_speed_px_s: float,
+        fast_speed_px_s: float,
+        min_chunk_size_threshold: float,
+        max_chunk_size_threshold: float,
+        urgent_speed_px_s: float,
+        hue_tolerance_deg: float = 20.0,
+        saturation_min: float = 0.45,
+        value_min: float = 0.25,
+        min_area_ratio: float = 0.001,
+    ):
+        self.slow_speed_px_s = slow_speed_px_s
+        self.fast_speed_px_s = fast_speed_px_s
+        self.min_chunk_size_threshold = min_chunk_size_threshold
+        self.max_chunk_size_threshold = max_chunk_size_threshold
+        self.urgent_speed_px_s = urgent_speed_px_s
+        self.hue_tolerance_deg = hue_tolerance_deg
+        self.saturation_min = saturation_min
+        self.value_min = value_min
+        self.min_area_ratio = min_area_ratio
+
+        self._prev_center: tuple[float, float] | None = None
+        self._prev_time_s: float | None = None
+
+    def __call__(self, frame: NDArray) -> DetectorOutput:
+        return self.detect(frame, now_s=time.perf_counter())
+
+    def detect(self, frame: NDArray, now_s: float) -> DetectorOutput:
+        mask = self._red_mask(frame)
+        area_ratio = float(mask.mean())
+        if area_ratio < self.min_area_ratio:
+            self._prev_center = None
+            self._prev_time_s = None
+            return DetectorOutput(reason="red_cube_not_visible")
+
+        ys, xs = np.nonzero(mask)
+        center = (float(xs.mean()), float(ys.mean()))
+        speed_px_s = self._estimate_speed(center, now_s)
+        self._prev_center = center
+        self._prev_time_s = now_s
+
+        if speed_px_s is None:
+            return DetectorOutput(center_px=center, reason="red_cube_initialized")
+
+        threshold = self._map_speed_to_threshold(speed_px_s)
+        replan_now = speed_px_s >= self.urgent_speed_px_s
+        reason = "red_cube_urgent_speed" if replan_now else "red_cube_speed"
+        return DetectorOutput(
+            replan_now=replan_now,
+            center_px=center,
+            speed_px_s=speed_px_s,
+            effective_chunk_size_threshold=threshold,
+            reason=reason,
+        )
+
+    def _estimate_speed(self, center: tuple[float, float], now_s: float) -> float | None:
+        if self._prev_center is None or self._prev_time_s is None:
+            return None
+
+        dt = now_s - self._prev_time_s
+        if dt <= 0:
+            return 0.0
+
+        dx = center[0] - self._prev_center[0]
+        dy = center[1] - self._prev_center[1]
+        return float(np.hypot(dx, dy) / dt)
+
+    def _map_speed_to_threshold(self, speed_px_s: float) -> float:
+        if self.fast_speed_px_s <= self.slow_speed_px_s:
+            return self.max_chunk_size_threshold
+
+        alpha = (speed_px_s - self.slow_speed_px_s) / (self.fast_speed_px_s - self.slow_speed_px_s)
+        alpha = float(np.clip(alpha, 0.0, 1.0))
+        return self.min_chunk_size_threshold + alpha * (
+            self.max_chunk_size_threshold - self.min_chunk_size_threshold
+        )
+
+    def _red_mask(self, frame: NDArray) -> NDArray[np.bool_]:
+        if frame.ndim != 3 or frame.shape[2] < 3:
+            raise ValueError(f"Expected an RGB image with shape HxWx3, got {frame.shape}")
+
+        rgb = frame[..., :3].astype(np.float32)
+        if rgb.max(initial=0) > 1.0:
+            rgb = rgb / 255.0
+
+        r, g, b = rgb[..., 0], rgb[..., 1], rgb[..., 2]
+        maxc = np.maximum(np.maximum(r, g), b)
+        minc = np.minimum(np.minimum(r, g), b)
+        delta = maxc - minc
+
+        hue = np.zeros_like(maxc)
+        nonzero_delta = delta > 1e-6
+
+        red_is_max = (maxc == r) & nonzero_delta
+        green_is_max = (maxc == g) & nonzero_delta
+        blue_is_max = (maxc == b) & nonzero_delta
+
+        hue[red_is_max] = (60.0 * ((g[red_is_max] - b[red_is_max]) / delta[red_is_max])) % 360.0
+        hue[green_is_max] = 60.0 * ((b[green_is_max] - r[green_is_max]) / delta[green_is_max] + 2.0)
+        hue[blue_is_max] = 60.0 * ((r[blue_is_max] - g[blue_is_max]) / delta[blue_is_max] + 4.0)
+
+        saturation = np.zeros_like(maxc)
+        nonzero_value = maxc > 1e-6
+        saturation[nonzero_value] = delta[nonzero_value] / maxc[nonzero_value]
+
+        red_hue = (hue <= self.hue_tolerance_deg) | (hue >= 360.0 - self.hue_tolerance_deg)
+        return red_hue & (saturation >= self.saturation_min) & (maxc >= self.value_min)
+
+
 class SupervisorMonitor:
     """Watch a camera on an independent thread and trigger early replanning.
 
@@ -70,7 +199,7 @@ class SupervisorMonitor:
     def __init__(
         self,
         camera,
-        detect_fn: Callable[[NDArray], bool],
+        detect_fn: Callable[[NDArray], bool | DetectorOutput],
         poll_fps: int,
         cooldown_s: float,
     ):
@@ -81,6 +210,8 @@ class SupervisorMonitor:
         self.logger = get_logger("supervisor")
 
         self._trigger = threading.Event()
+        self._latest_output: DetectorOutput | None = None
+        self._output_lock = threading.Lock()
         self._stop = threading.Event()
         self._thread: threading.Thread | None = None
         self._last_fire = -1.0
@@ -95,23 +226,38 @@ class SupervisorMonitor:
             loop_start = time.perf_counter()
             try:
                 frame = self.camera.read_latest(max_age_ms=self.MAX_AGE_MS)
-                if self.detect_fn(frame) and (loop_start - self._last_fire) > self.cooldown_s:
+                output = self._normalize_output(self.detect_fn(frame))
+                with self._output_lock:
+                    self._latest_output = output
+
+                if output.replan_now and (loop_start - self._last_fire) > self.cooldown_s:
                     self._last_fire = loop_start
                     self._trigger.set()
-                    self.logger.info("Re-inference triggered by supervisor")
-            except (TimeoutError, RuntimeError) as e:
+                    self.logger.info(f"Re-inference triggered by supervisor: {output.reason}")
+            except (TimeoutError, RuntimeError, ValueError) as e:
                 self.logger.debug(f"Supervisor frame read skipped: {e}")
 
             time.sleep(max(0, self.poll_dt - (time.perf_counter() - loop_start)))
 
-    def consume_trigger(self) -> bool:
-        """Return True (and clear) if a trigger is pending. One detection fires once."""
+    def consume_trigger(self) -> DetectorOutput | None:
+        """Return latest output (and clear) if a trigger is pending. One detection fires once."""
         if self._trigger.is_set():
             self._trigger.clear()
-            return True
-        return False
+            return self.latest_output()
+        return None
+
+    def latest_output(self) -> DetectorOutput | None:
+        """Return the latest detector output, including non-urgent speed estimates."""
+        with self._output_lock:
+            return self._latest_output
 
     def stop(self):
         self._stop.set()
         if self._thread is not None:
             self._thread.join(timeout=1.0)
+
+    @staticmethod
+    def _normalize_output(output: bool | DetectorOutput) -> DetectorOutput:
+        if isinstance(output, DetectorOutput):
+            return output
+        return DetectorOutput(replan_now=output, reason="motion" if output else "")

--- a/src/lerobot/async_inference/supervisor.py
+++ b/src/lerobot/async_inference/supervisor.py
@@ -1,0 +1,117 @@
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Supervisor monitor for event-triggered replanning (Tier 2).
+
+A `SupervisorMonitor` watches a single camera on an independent thread and,
+when its `detect_fn` fires, raises a trigger that `RobotClient` ORs into its
+observation-sending gate. This forces an early replan the instant a change is
+detected, regardless of action-queue level, without touching the static
+`chunk_size_threshold`.
+"""
+
+import threading
+import time
+from collections.abc import Callable
+
+import numpy as np
+from numpy.typing import NDArray
+
+from .helpers import get_logger
+
+
+class MotionDetector:
+    """Frame-difference motion detector usable as a `detect_fn`.
+
+    Compares consecutive frames in grayscale and fires when the fraction of
+    pixels whose intensity changed by more than `PIXEL_DIFF_THRESHOLD` exceeds
+    `motion_area_threshold`. Dependency-free (numpy only).
+    """
+
+    PIXEL_DIFF_THRESHOLD = 25.0
+
+    def __init__(self, motion_area_threshold: float):
+        self.motion_area_threshold = motion_area_threshold
+        self._prev_gray: NDArray | None = None
+
+    def __call__(self, frame: NDArray) -> bool:
+        gray = frame.mean(axis=2) if frame.ndim == 3 else frame.astype(float)
+        if self._prev_gray is None:
+            self._prev_gray = gray
+            return False
+
+        diff = np.abs(gray - self._prev_gray)
+        self._prev_gray = gray
+        motion_ratio = float((diff > self.PIXEL_DIFF_THRESHOLD).mean())
+        return motion_ratio > self.motion_area_threshold
+
+
+class SupervisorMonitor:
+    """Watch a camera on an independent thread and trigger early replanning.
+
+    Runs decoupled from the control loop: it peeks the camera's latest frame
+    via the non-blocking `read_latest()` and never goes through the policy
+    observation path, so it does not steal the control-loop FPS budget.
+    """
+
+    MAX_AGE_MS = 500
+
+    def __init__(
+        self,
+        camera,
+        detect_fn: Callable[[NDArray], bool],
+        poll_fps: int,
+        cooldown_s: float,
+    ):
+        self.camera = camera
+        self.detect_fn = detect_fn
+        self.poll_dt = 1.0 / poll_fps
+        self.cooldown_s = cooldown_s
+        self.logger = get_logger("supervisor")
+
+        self._trigger = threading.Event()
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._last_fire = -1.0
+
+    def start(self):
+        self._thread = threading.Thread(target=self._loop, daemon=True)
+        self._thread.start()
+        self.logger.info("Supervisor monitor started")
+
+    def _loop(self):
+        while not self._stop.is_set():
+            loop_start = time.perf_counter()
+            try:
+                frame = self.camera.read_latest(max_age_ms=self.MAX_AGE_MS)
+                if self.detect_fn(frame) and (loop_start - self._last_fire) > self.cooldown_s:
+                    self._last_fire = loop_start
+                    self._trigger.set()
+                    self.logger.info("Re-inference triggered by supervisor")
+            except (TimeoutError, RuntimeError) as e:
+                self.logger.debug(f"Supervisor frame read skipped: {e}")
+
+            time.sleep(max(0, self.poll_dt - (time.perf_counter() - loop_start)))
+
+    def consume_trigger(self) -> bool:
+        """Return True (and clear) if a trigger is pending. One detection fires once."""
+        if self._trigger.is_set():
+            self._trigger.clear()
+            return True
+        return False
+
+    def stop(self):
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=1.0)

--- a/src/lerobot/policies/groot/eagle2_hg_model/modeling_eagle2_5_vl.py
+++ b/src/lerobot/policies/groot/eagle2_hg_model/modeling_eagle2_5_vl.py
@@ -105,7 +105,8 @@ class Eagle25VLForConditionalGeneration(Eagle25VLPreTrainedModel, GenerationMixi
             self.vision_model = vision_model
         else:
             if config.vision_config.model_type == "siglip_vision_model":
-                config.vision_config._attn_implementation = "flash_attention_2"
+                # flash-attn が無い環境では top-level config の attn 実装 (sdpa) に追従する。
+                config.vision_config._attn_implementation = config._attn_implementation
                 self.vision_model = SiglipVisionModel(config.vision_config)
             else:
                 raise NotImplementedError(f"{config.vision_config.model_type} is not implemented.")
@@ -119,9 +120,7 @@ class Eagle25VLForConditionalGeneration(Eagle25VLPreTrainedModel, GenerationMixi
                 raise NotImplementedError("Phi3 is not implemented.")
                 # self.language_model = Phi3ForCausalLM(config.text_config)
             elif config.text_config.architectures[0] == "Qwen2ForCausalLM":
-                assert config.text_config._attn_implementation == "flash_attention_2", (
-                    f"Qwen2 must use flash_attention_2 but got {config.text_config._attn_implementation}"
-                )
+                # flash-attn が無い環境では sdpa を許容する (Qwen2 は sdpa をサポート)。
                 self.language_model = Qwen2ForCausalLM(config.text_config)
             elif config.text_config.architectures[0] == "Qwen3ForCausalLM":
                 self.language_model = Qwen3ForCausalLM(config.text_config)

--- a/src/lerobot/policies/groot/groot_n1.py
+++ b/src/lerobot/policies/groot/groot_n1.py
@@ -87,6 +87,19 @@ class EagleBackbone(nn.Module):
             print(f"[GROOT] Warning: failed to prepare Eagle cache for backbone: {exc}")
 
         config = AutoConfig.from_pretrained(str(cache_dir), trust_remote_code=True)
+        # flash-attn が無い環境 (例: aarch64) では FA2 を sdpa にフォールバックさせる。
+        # Eagle のモデルクラスは _supports_sdpa=True を宣言しており sdpa を完全サポートする。
+        try:
+            import flash_attn  # noqa: F401
+
+            has_flash_attn = True
+        except Exception:
+            has_flash_attn = False
+        if not has_flash_attn:
+            for sub in (config, getattr(config, "vision_config", None), getattr(config, "text_config", None)):
+                if sub is not None:
+                    sub._attn_implementation = "sdpa"
+                    sub._attn_implementation_autoset = True
         self.eagle_model = AutoModel.from_config(config, trust_remote_code=True)
 
         if project_to_dim is not None:

--- a/src/lerobot/robots/sim_so101/__init__.py
+++ b/src/lerobot/robots/sim_so101/__init__.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .config_sim_so101 import SimCameraConfig, SimSO101Config
+from .sim_so101 import SimSO101
+
+__all__ = ["SimCameraConfig", "SimSO101", "SimSO101Config"]

--- a/src/lerobot/robots/sim_so101/config_sim_so101.py
+++ b/src/lerobot/robots/sim_so101/config_sim_so101.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass, field
+
+from ..config import RobotConfig
+
+
+@dataclass
+class SimCameraConfig:
+    """A camera rendered offscreen from the MuJoCo scene.
+
+    ``mujoco_name`` must match a ``<camera name=...>`` element in the scene XML.
+    The dict key under which this config is stored becomes the observation key
+    (e.g. ``camera1``) and must match the image keys the policy was trained with.
+    """
+
+    mujoco_name: str
+    width: int = 640
+    height: int = 480
+    # Present only so RobotConfig.__post_init__ (which validates width/height/fps
+    # on every camera) passes; the sim renders synchronously, so this is nominal.
+    fps: int = 30
+
+
+@RobotConfig.register_subclass("sim_so101")
+@dataclass
+class SimSO101Config(RobotConfig):
+    """A MuJoCo-backed stand-in for the SO-101 follower.
+
+    Implements the same ``Robot`` contract as ``so101_follower`` but drives a
+    MuJoCo simulation instead of Feetech motors, so the async RTC rollout
+    pipeline (``lerobot-rollout --inference.type=rtc``) can run without hardware.
+    """
+
+    # Path to the MuJoCo scene XML. Use the Menagerie SO-ARM100 ``scene.xml``,
+    # extended with one ``<camera>`` element per entry in ``cameras``.
+    mjcf_path: str
+
+    # Offscreen-rendered observation cameras. Key -> spec.
+    cameras: dict[str, SimCameraConfig] = field(default_factory=dict)
+
+    # Control rate of the rollout loop. ``send_action`` advances the sim by
+    # ~1/control_fps of simulated time. Keep equal to ``lerobot-rollout --fps``.
+    control_fps: float = 30.0
+
+    # so101 motor name -> MuJoCo actuator/joint name.
+    # Defaults match the Menagerie SO-ARM100 model.
+    joint_map: dict[str, str] = field(
+        default_factory=lambda: {
+            "shoulder_pan": "Rotation",
+            "shoulder_lift": "Pitch",
+            "elbow_flex": "Elbow",
+            "wrist_flex": "Wrist_Pitch",
+            "wrist_roll": "Wrist_Roll",
+            "gripper": "Jaw",
+        }
+    )
+
+    # Body joints are reported/commanded in degrees, matching so101 use_degrees=True.
+    use_degrees: bool = True

--- a/src/lerobot/robots/sim_so101/sim_so101.py
+++ b/src/lerobot/robots/sim_so101/sim_so101.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""MuJoCo-backed SO-101 stand-in.
+
+Implements the ``Robot`` contract against a MuJoCo simulation so the async RTC
+rollout pipeline can run without physical hardware. Observation/action keys are
+kept identical to ``so101_follower`` so the same policy and processors apply.
+"""
+
+import logging
+from functools import cached_property
+
+import numpy as np
+
+from lerobot.types import RobotAction, RobotObservation
+from lerobot.utils.decorators import check_if_already_connected, check_if_not_connected
+
+from ..robot import Robot
+from .config_sim_so101 import SimSO101Config
+
+logger = logging.getLogger(__name__)
+
+# Motor order is the source of truth shared with so_follower.py.
+MOTORS = ["shoulder_pan", "shoulder_lift", "elbow_flex", "wrist_flex", "wrist_roll", "gripper"]
+BODY_MOTORS = MOTORS[:-1]
+GRIPPER = "gripper"
+
+
+class SimSO101(Robot):
+    config_class = SimSO101Config
+    name = "sim_so101"
+
+    def __init__(self, config: SimSO101Config):
+        super().__init__(config)
+        self.config = config
+        self._model = None
+        self._data = None
+        self._renderers: dict[str, object] = {}
+        self._actuator_ids: dict[str, int] = {}
+        self._qpos_addr: dict[str, int] = {}
+        self._gripper_range: tuple[float, float] | None = None
+        self._n_substeps = 1
+
+    @property
+    def _motors_ft(self) -> dict[str, type]:
+        return {f"{motor}.pos": float for motor in MOTORS}
+
+    @property
+    def _cameras_ft(self) -> dict[str, tuple]:
+        return {key: (cam.height, cam.width, 3) for key, cam in self.config.cameras.items()}
+
+    @cached_property
+    def observation_features(self) -> dict[str, type | tuple]:
+        return {**self._motors_ft, **self._cameras_ft}
+
+    @cached_property
+    def action_features(self) -> dict[str, type]:
+        return self._motors_ft
+
+    @property
+    def cameras(self) -> dict[str, object]:
+        return self.config.cameras
+
+    @property
+    def is_connected(self) -> bool:
+        return self._data is not None
+
+    @check_if_already_connected
+    def connect(self, calibrate: bool = True) -> None:
+        import mujoco
+
+        self._model = mujoco.MjModel.from_xml_path(self.config.mjcf_path)
+        self._data = mujoco.MjData(self._model)
+
+        # Resolve so101 motor -> MuJoCo actuator id + joint qpos address. Fail fast
+        # if the scene's naming doesn't match joint_map.
+        for motor, sim_name in self.config.joint_map.items():
+            act_id = mujoco.mj_name2id(self._model, mujoco.mjtObj.mjOBJ_ACTUATOR, sim_name)
+            joint_id = mujoco.mj_name2id(self._model, mujoco.mjtObj.mjOBJ_JOINT, sim_name)
+            if act_id < 0 or joint_id < 0:
+                raise ValueError(
+                    f"MJCF '{self.config.mjcf_path}' has no actuator/joint named '{sim_name}' "
+                    f"(mapped from motor '{motor}'). Check SimSO101Config.joint_map."
+                )
+            self._actuator_ids[motor] = act_id
+            self._qpos_addr[motor] = int(self._model.jnt_qposadr[joint_id])
+
+        gripper_joint = mujoco.mj_name2id(self._model, mujoco.mjtObj.mjOBJ_JOINT, self.config.joint_map[GRIPPER])
+        self._gripper_range = tuple(float(x) for x in self._model.jnt_range[gripper_joint])
+
+        self._n_substeps = max(1, round((1.0 / self.config.control_fps) / self._model.opt.timestep))
+
+        for key, cam in self.config.cameras.items():
+            self._renderers[key] = mujoco.Renderer(self._model, height=cam.height, width=cam.width)
+
+        mujoco.mj_forward(self._model, self._data)
+        logger.info(f"{self} connected (sim, {self._n_substeps} substeps per control step).")
+
+    @property
+    def is_calibrated(self) -> bool:
+        return True
+
+    def calibrate(self) -> None:
+        pass
+
+    def configure(self) -> None:
+        pass
+
+    @check_if_not_connected
+    def get_observation(self) -> RobotObservation:
+        obs: dict = {}
+        for motor in BODY_MOTORS:
+            rad = float(self._data.qpos[self._qpos_addr[motor]])
+            obs[f"{motor}.pos"] = float(np.rad2deg(rad)) if self.config.use_degrees else rad
+        obs[f"{GRIPPER}.pos"] = self._gripper_sim_to_robot(float(self._data.qpos[self._qpos_addr[GRIPPER]]))
+
+        for key, renderer in self._renderers.items():
+            renderer.update_scene(self._data, camera=self.config.cameras[key].mujoco_name)
+            obs[key] = renderer.render()  # (H, W, 3) uint8
+
+        return obs
+
+    @check_if_not_connected
+    def send_action(self, action: RobotAction) -> RobotAction:
+        import mujoco
+
+        for motor in BODY_MOTORS:
+            val = action[f"{motor}.pos"]
+            self._data.ctrl[self._actuator_ids[motor]] = float(np.deg2rad(val)) if self.config.use_degrees else val
+        self._data.ctrl[self._actuator_ids[GRIPPER]] = self._gripper_robot_to_sim(action[f"{GRIPPER}.pos"])
+
+        for _ in range(self._n_substeps):
+            mujoco.mj_step(self._model, self._data)
+
+        return {key: val for key, val in action.items() if key.endswith(".pos")}
+
+    def _gripper_sim_to_robot(self, rad: float) -> float:
+        lo, hi = self._gripper_range
+        return 100.0 * (rad - lo) / (hi - lo)
+
+    def _gripper_robot_to_sim(self, val: float) -> float:
+        lo, hi = self._gripper_range
+        return lo + (val / 100.0) * (hi - lo)
+
+    @check_if_not_connected
+    def disconnect(self) -> None:
+        for renderer in self._renderers.values():
+            renderer.close()
+        self._renderers = {}
+        self._model = None
+        self._data = None
+        logger.info(f"{self} disconnected.")

--- a/src/lerobot/robots/utils.py
+++ b/src/lerobot/robots/utils.py
@@ -40,6 +40,10 @@ def make_robot_from_config(config: RobotConfig) -> Robot:
         from .so_follower import SO101Follower
 
         return SO101Follower(config)
+    elif config.type == "sim_so101":
+        from .sim_so101 import SimSO101
+
+        return SimSO101(config)
     elif config.type == "lekiwi":
         from .lekiwi import LeKiwi
 

--- a/src/lerobot/scripts/lerobot_rollout.py
+++ b/src/lerobot/scripts/lerobot_rollout.py
@@ -166,6 +166,7 @@ from lerobot.robots import (  # noqa: F401
     openarm_follower,
     reachy2,
     rebot_b601_follower,
+    sim_so101,
     so_follower,
     unitree_g1 as unitree_g1_robot,
 )

--- a/tests/async_inference/test_supervisor.py
+++ b/tests/async_inference/test_supervisor.py
@@ -1,0 +1,79 @@
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pytest
+
+from lerobot.async_inference.supervisor import DetectorOutput, RedCubeSpeedDetector, SupervisorMonitor
+
+
+def _frame_with_red_square(x0: int, y0: int = 20, size: int = 10) -> np.ndarray:
+    frame = np.zeros((64, 64, 3), dtype=np.uint8)
+    frame[y0 : y0 + size, x0 : x0 + size, 0] = 255
+    return frame
+
+
+def test_red_cube_speed_detector_estimates_speed_and_threshold():
+    detector = RedCubeSpeedDetector(
+        slow_speed_px_s=40.0,
+        fast_speed_px_s=200.0,
+        min_chunk_size_threshold=0.25,
+        max_chunk_size_threshold=0.75,
+        urgent_speed_px_s=250.0,
+    )
+
+    first = detector.detect(_frame_with_red_square(10), now_s=1.0)
+    second = detector.detect(_frame_with_red_square(30), now_s=1.1)
+
+    assert first.center_px == (14.5, 24.5)
+    assert first.speed_px_s is None
+    assert second.center_px == (34.5, 24.5)
+    assert second.speed_px_s == pytest.approx(200.0)
+    assert second.effective_chunk_size_threshold == pytest.approx(0.75)
+    assert second.replan_now is False
+
+
+def test_red_cube_speed_detector_triggers_urgent_replan_for_fast_cube():
+    detector = RedCubeSpeedDetector(
+        slow_speed_px_s=40.0,
+        fast_speed_px_s=200.0,
+        min_chunk_size_threshold=0.25,
+        max_chunk_size_threshold=0.75,
+        urgent_speed_px_s=150.0,
+    )
+
+    detector.detect(_frame_with_red_square(10), now_s=1.0)
+    output = detector.detect(_frame_with_red_square(30), now_s=1.1)
+
+    assert output.replan_now is True
+    assert output.reason == "red_cube_urgent_speed"
+
+
+def test_red_cube_speed_detector_ignores_frames_without_red_cube():
+    detector = RedCubeSpeedDetector(
+        slow_speed_px_s=40.0,
+        fast_speed_px_s=200.0,
+        min_chunk_size_threshold=0.25,
+        max_chunk_size_threshold=0.75,
+        urgent_speed_px_s=150.0,
+    )
+
+    output = detector.detect(np.zeros((64, 64, 3), dtype=np.uint8), now_s=1.0)
+
+    assert output == DetectorOutput(reason="red_cube_not_visible")
+
+
+def test_supervisor_monitor_normalizes_bool_detector_output():
+    assert SupervisorMonitor._normalize_output(True) == DetectorOutput(replan_now=True, reason="motion")
+    assert SupervisorMonitor._normalize_output(False) == DetectorOutput()


### PR DESCRIPTION
## Summary

This PR adds the first Tier 3 speed-adaptive replan path for the async inference client.

It keeps the existing Tier 2 frame-difference supervisor behavior, and adds a new `red_cube_speed` detector for conveyor-belt experiments with a red cube.

## Changes

- Add structured `DetectorOutput` for supervisor detector results
- Add `RedCubeSpeedDetector`
  - HSV red mask for the target cube
  - centroid tracking in image coordinates
  - `speed_px_s` estimation from centroid motion
  - speed-to-`effective_chunk_size_threshold` mapping
  - urgent replan when speed exceeds `supervisor_urgent_speed_px_s`
- Extend `SupervisorMonitor` to store latest detector output
- Let `RobotClient` use adaptive threshold from detector output
- Add config options for red cube speed detection and threshold mapping
- Add focused tests for red cube detection and supervisor output normalization

## Scope

This PR implements speed-adaptive replan timing only.

It does not implement:
- true dynamic action horizon
- action queue flush / partial replacement
- grasp-zone arrival prediction
- YOLO/object detector integration
- 3D/world-frame speed estimation

## Validation

- `pixi run python -m ruff check ...`
- `pixi run python -m ruff format --check ...`
- `pixi run python -m py_compile ...`
- Manual red cube detector assertion