### PR TITLE
fix(cameras): fix mypy type errors in cameras module

### DIFF
--- a/src/lerobot/cameras/opencv/camera_opencv.py
+++ b/src/lerobot/cameras/opencv/camera_opencv.py
@@ -92,6 +92,9 @@ class OpenCVCamera(Camera):
         ```
     """
 
+    width: int | None
+    height: int | None
+
     def __init__(self, config: OpenCVCameraConfig):
         """
         Initializes the OpenCVCamera instance.
@@ -219,7 +222,7 @@ class OpenCVCamera(Camera):
             self._validate_width_and_height()
 
         if self.fps is None:
-            self.fps = self.videocapture.get(cv2.CAP_PROP_FPS)
+            self.fps = int(self.videocapture.get(cv2.CAP_PROP_FPS))
         else:
             self._validate_fps()
 
@@ -246,7 +249,7 @@ class OpenCVCamera(Camera):
     def _validate_fourcc(self) -> None:
         """Validates and sets the camera's FOURCC code."""
 
-        fourcc_code = cv2.VideoWriter_fourcc(*self.config.fourcc)
+        fourcc_code = cv2.VideoWriter_fourcc(*self.config.fourcc)  # type: ignore[attr-defined,misc]  # opencv-python stubs omit VideoWriter_fourcc; runtime attribute is valid
 
         if self.videocapture is None:
             raise DeviceNotConnectedError(f"{self} videocapture is not initialized")

--- a/src/lerobot/cameras/zmq/camera_zmq.py
+++ b/src/lerobot/cameras/zmq/camera_zmq.py
@@ -36,6 +36,10 @@ from numpy.typing import NDArray
 
 from lerobot.utils.import_utils import _zmq_available, require_package
 
+if TYPE_CHECKING:
+    from zmq.sugar.context import Context
+    from zmq.sugar.socket import Socket
+
 if TYPE_CHECKING or _zmq_available:
     import zmq
 else:
@@ -80,6 +84,9 @@ class ZMQCamera(Camera):
         ```
     """
 
+    width: int | None
+    height: int | None
+
     def __init__(self, config: ZMQCameraConfig):
         require_package("pyzmq", extra="pyzmq-dep", import_name="zmq")
         super().__init__(config)
@@ -92,8 +99,8 @@ class ZMQCamera(Camera):
         self.timeout_ms = config.timeout_ms
 
         # ZMQ Context and Socket
-        self.context: zmq.Context | None = None
-        self.socket: zmq.Socket | None = None
+        self.context: Context | None = None
+        self.socket: Socket | None = None
         self._connected = False
 
         # Threading resources
@@ -124,11 +131,11 @@ class ZMQCamera(Camera):
         logger.info(f"Connecting to {self}...")
 
         try:
-            self.context = zmq.Context()
-            self.socket = self.context.socket(zmq.SUB)
-            self.socket.setsockopt_string(zmq.SUBSCRIBE, "")
-            self.socket.setsockopt(zmq.RCVTIMEO, self.timeout_ms)
-            self.socket.setsockopt(zmq.CONFLATE, True)
+            self.context = zmq.Context()  # type: ignore[attr-defined]  # pyzmq stubs lack constants/Context re-export at top level; see https://github.com/zeromq/pyzmq/issues
+            self.socket = self.context.socket(zmq.SUB)  # type: ignore[attr-defined]
+            self.socket.setsockopt_string(zmq.SUBSCRIBE, "")  # type: ignore[attr-defined]
+            self.socket.setsockopt(zmq.RCVTIMEO, self.timeout_ms)  # type: ignore[attr-defined]
+            self.socket.setsockopt(zmq.CONFLATE, True)  # type: ignore[attr-defined]
             self.socket.connect(f"tcp://{self.server_address}:{self.port}")
             self._connected = True
 
@@ -185,7 +192,7 @@ class ZMQCamera(Camera):
 
         try:
             message = self.socket.recv_string()
-        except zmq.Again as e:
+        except zmq.Again as e:  # type: ignore[attr-defined]  # pyzmq stubs lack Again re-export at top level; runtime attribute is valid
             raise TimeoutError(f"{self} timeout after {self.timeout_ms}ms") from e
 
         # Decode JSON message

--- a/src/lerobot/cameras/zmq/camera_zmq.py
+++ b/src/lerobot/cameras/zmq/camera_zmq.py
@@ -131,7 +131,7 @@ class ZMQCamera(Camera):
         logger.info(f"Connecting to {self}...")
 
         try:
-            self.context = zmq.Context()  # type: ignore[attr-defined]  # pyzmq stubs lack constants/Context re-export at top level; see https://github.com/zeromq/pyzmq/issues
+            self.context = zmq.Context()  # type: ignore[attr-defined]  # pyzmq stubs lack constants/Context re-export at top level
             self.socket = self.context.socket(zmq.SUB)  # type: ignore[attr-defined]
             self.socket.setsockopt_string(zmq.SUBSCRIBE, "")  # type: ignore[attr-defined]
             self.socket.setsockopt(zmq.RCVTIMEO, self.timeout_ms)  # type: ignore[attr-defined]

--- a/src/lerobot/cameras/zmq/image_server.py
+++ b/src/lerobot/cameras/zmq/image_server.py
@@ -114,7 +114,7 @@ class ImageServer:
             self.capture_threads[name] = capture_thread
 
         # ZMQ PUB socket
-        self.context = zmq.Context()  # type: ignore[attr-defined]  # pyzmq stubs lack constants/Context re-export at top level; see https://github.com/zeromq/pyzmq/issues
+        self.context = zmq.Context()  # type: ignore[attr-defined]  # pyzmq stubs lack constants/Context re-export at top level
         self.socket = self.context.socket(zmq.PUB)  # type: ignore[attr-defined]
         self.socket.setsockopt(zmq.SNDHWM, 20)  # type: ignore[attr-defined]
         self.socket.setsockopt(zmq.LINGER, 0)  # type: ignore[attr-defined]

--- a/src/lerobot/cameras/zmq/image_server.py
+++ b/src/lerobot/cameras/zmq/image_server.py
@@ -114,10 +114,10 @@ class ImageServer:
             self.capture_threads[name] = capture_thread
 
         # ZMQ PUB socket
-        self.context = zmq.Context()
-        self.socket = self.context.socket(zmq.PUB)
-        self.socket.setsockopt(zmq.SNDHWM, 20)
-        self.socket.setsockopt(zmq.LINGER, 0)
+        self.context = zmq.Context()  # type: ignore[attr-defined]  # pyzmq stubs lack constants/Context re-export at top level; see https://github.com/zeromq/pyzmq/issues
+        self.socket = self.context.socket(zmq.PUB)  # type: ignore[attr-defined]
+        self.socket.setsockopt(zmq.SNDHWM, 20)  # type: ignore[attr-defined]
+        self.socket.setsockopt(zmq.LINGER, 0)  # type: ignore[attr-defined]
         self.socket.bind(f"tcp://*:{port}")
 
         logger.info(f"ImageServer running on port {port}")


### PR DESCRIPTION
Fixes #1724

This issue was auto-closed as stale in February, but the underlying problem
is still present on current `main` — confirmed by running `mypy src/lerobot/cameras/`,
which currently fails with 15 errors. Two prior attempts (#1788, #2928) were
opened against this issue but neither merged.

## What's fixed

**camera_zmq.py**
- `zmq.Context`/`zmq.Socket` type annotations weren't resolving — pyzmq's
  `zmq/__init__.pyi` re-exports `sugar` via a bare `from .sugar import *`,
  which mypy can't statically expand. Fixed by importing the concrete types
  directly from `zmq.sugar.context`/`zmq.sugar.socket` under `TYPE_CHECKING`.
- Runtime attribute access (`zmq.Context()`, `zmq.SUB`, `zmq.SUBSCRIBE`, etc.)
  has no valid typed alternative — pyzmq's stubs only cover `zmq.backend`
  and `zmq.error`, not the constants/Context surface used here. Added
  `# type: ignore[attr-defined]` with an explanatory comment per the
  contributing guide.
- `width`/`height` were inherited from `Camera.__init__` but mypy couldn't
  resolve their type across the subclass boundary — added explicit
  class-level annotations.

**image_server.py**
- Same `type: ignore[attr-defined]` treatment for the same pyzmq stub gaps
  (`zmq.Context`, `zmq.PUB`, `zmq.SNDHWM`, `zmq.LINGER`).

**camera_opencv.py**
- `self.fps` was being assigned a `float` from `cv2.VideoCapture.get()`
  while declared `int | None` — cast to `int()`, a genuine (minor) type
  fix, not just a mypy appeasement.
- `cv2.VideoWriter_fourcc` is missing from `opencv-python`'s stubs despite
  being a real runtime attribute — `type: ignore[attr-defined,misc]`.
- Same `width`/`height` class-level annotation fix as `ZMQCamera`.

## Verification

- `mypy src/lerobot/cameras/` (and via the `pre-commit` mypy hook): clean,
  0 errors (was 15)
- `pytest tests/cameras/`: 39 passed, 3 skipped, 0 failed