### PR TITLE
fix(sarm): warn when dense/sparse targets silently collapse to all-zero

### DIFF
--- a/src/lerobot/rewards/sarm/processor_sarm.py
+++ b/src/lerobot/rewards/sarm/processor_sarm.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import logging
 import random
 from typing import TYPE_CHECKING, Any
 
@@ -69,6 +70,8 @@ from .sarm_utils import (
     pad_state_to_max_dim,
 )
 
+logger = logging.getLogger(__name__)
+
 
 class SARMEncodingProcessorStep(ProcessorStep):
     """ProcessorStep that encodes images and text with CLIP and generates stage and progress labels for SARM."""
@@ -119,6 +122,65 @@ class SARMEncodingProcessorStep(ProcessorStep):
 
         self.verbs = ["move", "grasp", "rotate", "push", "pull", "slide", "lift", "place"]
         self.fake = Faker()
+
+        self._validate_annotation_columns()
+
+    def _validate_annotation_columns(self) -> None:
+        """Warn early if a multi-stage head is configured but the episodes metadata has no
+        usable subtask annotations.
+
+        Without this check, ``_load_episode_annotations`` returns ``None`` for such episodes
+        and ``find_stage_and_tau`` then yields stage 0 / tau 0 for every frame, so the target
+        silently becomes 0 everywhere (predict-all-zero). The head never learns and no error
+        is raised. This complements #2880, which restored loading of ``episodes_df``: here the
+        DataFrame is loaded but the ``*_subtask_names`` column is missing or NaN (e.g. the
+        annotations were never materialized into the episodes metadata).
+        """
+        if self.dataset_meta is None:
+            return
+        try:
+            episodes_df = self.dataset_meta.episodes.to_pandas()
+        except Exception:
+            return
+        num_episodes = len(episodes_df)
+        if num_episodes == 0:
+            return
+
+        modes = []
+        if self.dense_subtask_names and len(self.dense_subtask_names) > 1:
+            modes.append(("dense", self.dense_subtask_names))
+        if self.sparse_subtask_names and len(self.sparse_subtask_names) > 1:
+            modes.append(("sparse", self.sparse_subtask_names))
+
+        for annotation_type, names in modes:
+            prefixed = f"{annotation_type}_subtask_names"
+            col = prefixed if prefixed in episodes_df.columns else "subtask_names"
+            num_missing = (
+                num_episodes if col not in episodes_df.columns else int(episodes_df[col].isna().sum())
+            )
+            if num_missing == num_episodes:
+                logger.warning(
+                    "SARM %s head is configured with %d stages, but NONE of the %d episodes have "
+                    "usable '%s' annotations in meta/episodes/*.parquet. Every %s target will be 0 "
+                    "(predict-all-zero) and the %s head will not learn. Make sure annotations are "
+                    "materialized into the episodes metadata (e.g. via subtask_annotation.py).",
+                    annotation_type,
+                    len(names),
+                    num_episodes,
+                    col,
+                    annotation_type,
+                    annotation_type,
+                )
+            elif num_missing:
+                logger.warning(
+                    "SARM %s head: %d/%d episodes have no '%s' annotation; their targets will be 0 "
+                    "and only annotated episodes will train the %s head.",
+                    annotation_type,
+                    num_missing,
+                    num_episodes,
+                    col,
+                    annotation_type,
+                )
 
     def _find_episode_for_frame(self, frame_idx: int) -> int:
         """Find the episode index for a given frame index."""

--- a/tests/rewards/test_sarm_processor.py
+++ b/tests/rewards/test_sarm_processor.py
@@ -692,3 +692,82 @@ class TestSARMEncodingProcessorStepEndToEnd:
             assert abs(actual_dense - expected_dense) < 0.01, (
                 f"Frame {frame}: dense mismatch {actual_dense:.3f} vs expected {expected_dense:.3f}"
             )
+
+    def test_warns_when_dense_annotation_column_missing(self, mock_clip_model, caplog):
+        """A multi-stage dense head with no dense_subtask_* columns must warn about predict-all-zero.
+
+        Regression guard for the silent collapse: without annotations every target is 0 and the
+        head never learns, but nothing used to tell the user.
+        """
+        import logging
+
+        from lerobot.rewards.sarm.processor_sarm import SARMEncodingProcessorStep
+
+        config = MockConfig(
+            annotation_mode="dense_only",
+            dense_subtask_names=["d1", "d2", "d3", "d4"],
+            dense_temporal_proportions=[0.25, 0.25, 0.25, 0.25],
+        )
+        # episodes metadata WITHOUT any dense_subtask_* columns
+        episodes = [
+            {"dataset_from_index": 0, "dataset_to_index": 100, "task": "t"},
+            {"dataset_from_index": 100, "dataset_to_index": 200, "task": "t"},
+        ]
+        dataset_meta = MockDatasetMeta(episodes)
+
+        with caplog.at_level(logging.WARNING, logger="lerobot.rewards.sarm.processor_sarm"):
+            SARMEncodingProcessorStep(config=config, dataset_meta=dataset_meta)
+
+        assert any("predict-all-zero" in m for m in caplog.messages), (
+            f"expected a predict-all-zero warning, got: {caplog.messages}"
+        )
+
+    def test_warns_when_dense_annotations_all_null(self, mock_clip_model, caplog):
+        """A present-but-all-NaN dense column must also warn (e.g. only some episodes annotated)."""
+        import logging
+
+        from lerobot.rewards.sarm.processor_sarm import SARMEncodingProcessorStep
+
+        config = MockConfig(
+            annotation_mode="dense_only",
+            dense_subtask_names=["d1", "d2", "d3", "d4"],
+            dense_temporal_proportions=[0.25, 0.25, 0.25, 0.25],
+        )
+        episodes = [
+            {"dataset_from_index": 0, "dataset_to_index": 100, "task": "t", "dense_subtask_names": None},
+            {"dataset_from_index": 100, "dataset_to_index": 200, "task": "t", "dense_subtask_names": None},
+        ]
+        dataset_meta = MockDatasetMeta(episodes)
+
+        with caplog.at_level(logging.WARNING, logger="lerobot.rewards.sarm.processor_sarm"):
+            SARMEncodingProcessorStep(config=config, dataset_meta=dataset_meta)
+
+        assert any("predict-all-zero" in m for m in caplog.messages)
+
+    def test_no_warning_when_dense_annotations_present(self, mock_clip_model, caplog):
+        """A fully-annotated dataset must not emit the predict-all-zero warning."""
+        import logging
+
+        from lerobot.rewards.sarm.processor_sarm import SARMEncodingProcessorStep
+
+        config = MockConfig(
+            annotation_mode="dense_only",
+            dense_subtask_names=["d1", "d2", "d3", "d4"],
+            dense_temporal_proportions=[0.25, 0.25, 0.25, 0.25],
+        )
+        episodes = [
+            {
+                "dataset_from_index": 0,
+                "dataset_to_index": 100,
+                "task": "t",
+                "dense_subtask_names": ["d1", "d2", "d3", "d4"],
+                "dense_subtask_start_frames": [0, 25, 50, 75],
+                "dense_subtask_end_frames": [25, 50, 75, 100],
+            }
+        ]
+        dataset_meta = MockDatasetMeta(episodes)
+
+        with caplog.at_level(logging.WARNING, logger="lerobot.rewards.sarm.processor_sarm"):
+            SARMEncodingProcessorStep(config=config, dataset_meta=dataset_meta)
+
+        assert not any("predict-all-zero" in m for m in caplog.messages)


### PR DESCRIPTION
## What this does

Fixes a silent failure mode in SARM training. In `dense_only` / `dual` modes, when `meta/episodes/*.parquet` has no usable subtask columns (the column is absent, or it is `NaN`), `_load_episode_annotations` returns `None` and `find_stage_and_tau(subtask_names=None, ...)` returns stage 0 / tau 0 for **every** frame. The dense head then trains against all-zero targets and silently learns to predict 0 everywhere — with **no warning or error** anywhere. The model config and `temporal_proportions_dense.json` look completely normal, so it is very hard to diagnose.

This **complements #2880**, which fixed the case where `episodes_df` was not loaded at all. Here `episodes_df` *is* loaded (post-#2880), but the `*_subtask_names` column is missing/NaN — e.g. annotations were never materialized into the episodes metadata, or only a subset of episodes were annotated.

## Type / Scope

- **Type**: bug / robustness
- **Scope**: sarm

## What changed

- `src/lerobot/rewards/sarm/processor_sarm.py`: add `SARMEncodingProcessorStep._validate_annotation_columns()`, called once at construction. For each multi-stage head (dense/sparse), if the corresponding `*_subtask_names` column is absent or NaN for **all** episodes it logs a clear *predict-all-zero* warning; if **some** episodes are missing it logs a partial warning. Purely additive logging — **no change to training math**.
- `tests/rewards/test_sarm_processor.py`: 3 tests (missing column → warns, all-NaN → warns, fully annotated → silent), reusing the existing mocked-CLIP fixtures.

## Reproduction (no GPU / dataset needed)

```python
from lerobot.rewards.sarm.sarm_utils import find_stage_and_tau
g = ["s0", "s1", "s2", "s3"]; props = {k: 0.25 for k in g}; L = 100
with_ann = [round(find_stage_and_tau(f, L, ["s0","s1","s2","s3"], [0,25,50,75], [24,49,74,99], g, props, return_combined=True), 3) for f in range(0, L, 10)]
no_ann   = [round(find_stage_and_tau(f, L, None, None, None, g, props, return_combined=True), 3) for f in range(0, L, 10)]
print("WITH annotations :", with_ann)
print("WITHOUT (None)   :", no_ann)
# WITH annotations : [0.0, 0.417, 0.833, 1.208, 1.625, 2.0, 2.417, 2.833, 3.208, 3.625]
# WITHOUT (None)   : [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
```

## How was this tested

- `ruff check` and `ruff format --check` clean on the changed files.
- Added unit tests using the existing mocked CLIP + mock dataset metadata (no weight download).
- Full `pytest` runs in CI.

## Checklist

- [x] Linting/formatting run on changed files (`ruff check` / `ruff format --check`)
- [x] Added tests for the new behaviour
- [ ] Full CI is green

Closes #3842
