### PR TITLE
fix(sarm): warn when dense subtask columns are missing/NaN instead of silent all-zero targets

### DIFF
--- a/src/lerobot/rewards/sarm/processor_sarm.py
+++ b/src/lerobot/rewards/sarm/processor_sarm.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import logging
 import random
 from typing import TYPE_CHECKING, Any
 
@@ -69,6 +70,8 @@ from .sarm_utils import (
     pad_state_to_max_dim,
 )
 
+logger = logging.getLogger(__name__)
+
 
 class SARMEncodingProcessorStep(ProcessorStep):
     """ProcessorStep that encodes images and text with CLIP and generates stage and progress labels for SARM."""
@@ -107,6 +110,11 @@ class SARMEncodingProcessorStep(ProcessorStep):
             if config.uses_dual_heads
             else None
         )
+
+        # Warn at most once per (annotation_type, episode) about missing/NaN
+        # subtask columns so a misconfigured dataset is visible without spamming
+        # on every batch (#3842).
+        self._warned_missing_annotations: set[tuple[str, int]] = set()
 
         self.device = torch.device(
             self.config.device if self.config.device else "cuda" if torch.cuda.is_available() else "cpu"
@@ -155,6 +163,26 @@ class SARMEncodingProcessorStep(ProcessorStep):
             return self.dense_subtask_names, self.dense_temporal_proportions
         return self.sparse_subtask_names, self.sparse_temporal_proportions
 
+    def _warn_missing_annotations(self, annotation_type: str, ep_idx: int, reason: str) -> None:
+        """Warn once per (annotation_type, episode) that subtask annotations are
+        missing, so the corresponding progress targets silently fall back to
+        all-zero (#3842)."""
+        key = (annotation_type, int(ep_idx))
+        if key in self._warned_missing_annotations:
+            return
+        self._warned_missing_annotations.add(key)
+        logger.warning(
+            "SARM episode %d has no usable '%s' subtask annotations (%s); its '%s' "
+            "progress targets fall back to all-zero, so the '%s' head silently "
+            "collapses to predict-0. Check the episode metadata's '%s' subtask columns.",
+            ep_idx,
+            annotation_type,
+            reason,
+            annotation_type,
+            annotation_type,
+            annotation_type,
+        )
+
     def _load_episode_annotations(
         self,
         ep_idx: int,
@@ -173,11 +201,15 @@ class SARMEncodingProcessorStep(ProcessorStep):
             return prefixed if prefixed in episodes_df.columns else suffix
 
         col_names = col("subtask_names")
-        if col_names not in episodes_df.columns or ep_idx >= len(episodes_df):
+        if col_names not in episodes_df.columns:
+            self._warn_missing_annotations(annotation_type, ep_idx, f"column '{col_names}' is absent")
+            return None, None, None
+        if ep_idx >= len(episodes_df):
             return None, None, None
 
         subtask_names = episodes_df.loc[ep_idx, col_names]
         if subtask_names is None or (isinstance(subtask_names, float) and pd.isna(subtask_names)):
+            self._warn_missing_annotations(annotation_type, ep_idx, f"'{col_names}' is NaN")
             return None, None, None
 
         return (

--- a/tests/rewards/test_sarm_processor.py
+++ b/tests/rewards/test_sarm_processor.py
@@ -692,3 +692,41 @@ class TestSARMEncodingProcessorStepEndToEnd:
             assert abs(actual_dense - expected_dense) < 0.01, (
                 f"Frame {frame}: dense mismatch {actual_dense:.3f} vs expected {expected_dense:.3f}"
             )
+
+    def test_missing_dense_subtask_columns_warns(self, processor_with_mocks, caplog):
+        """Dense/dual episodes that lack subtask columns must warn instead of
+        silently producing all-zero targets (#3842)."""
+        import logging
+
+        import pandas as pd
+
+        processor = processor_with_mocks
+        dense_names = processor.dense_subtask_names
+
+        # Episode metadata with no dense subtask columns at all.
+        df_missing = pd.DataFrame([{"episode_index": 0}])
+        with caplog.at_level(logging.WARNING):
+            result = processor._load_episode_annotations(0, df_missing, "dense", dense_names)
+        assert result == (None, None, None)
+        assert "no usable 'dense' subtask annotations" in caplog.text
+        assert "all-zero" in caplog.text
+
+        # Warns once per (annotation_type, episode): a repeat call stays quiet.
+        caplog.clear()
+        with caplog.at_level(logging.WARNING):
+            processor._load_episode_annotations(0, df_missing, "dense", dense_names)
+        assert "no usable" not in caplog.text
+
+    def test_nan_dense_subtask_column_warns(self, processor_with_mocks, caplog):
+        """A NaN subtask-names cell should warn too, not silently zero out (#3842)."""
+        import logging
+
+        import pandas as pd
+
+        processor = processor_with_mocks
+        dense_names = processor.dense_subtask_names
+        df_nan = pd.DataFrame([{"episode_index": 0, "dense_subtask_names": float("nan")}])
+        with caplog.at_level(logging.WARNING):
+            result = processor._load_episode_annotations(0, df_nan, "dense", dense_names)
+        assert result == (None, None, None)
+        assert "is NaN" in caplog.text


### PR DESCRIPTION
## Summary / Motivation

In `dense_only` / `dual` SARM annotation modes, if an episode's metadata has no usable subtask columns (the column is absent, or its value is `NaN`), `SARMEncodingProcessorStep` silently produces **all-zero** progress targets. Training "succeeds" (loss goes down) but the dense head collapses to predict-0, with no warning or error anywhere — the only symptom is a flat-at-0 progress curve, which is very hard to diagnose. This is the complementary case to #2870 / #2880 (which fixed `episodes_df` being `None`): here `episodes_df` *is* loaded, but the dense subtask columns are missing/`NaN`.

## Related issues

- Fixes: #3842

## What changed

- `_load_episode_annotations` now logs a warning when, in multi-stage mode, the subtask-names column is absent or its value is `NaN` — the two paths that fall back to all-zero targets. It warns once per `(annotation_type, episode)` to avoid per-batch spam.
- Single-stage / linear-progress mode is unchanged (no warning). The fallback behavior itself is unchanged; this only makes the misconfiguration visible.

## How was this tested

- Added `test_missing_dense_subtask_columns_warns` and `test_nan_dense_subtask_column_warns` to `tests/rewards/test_sarm_processor.py` (reuse the existing CLIP-mocked fixture; assert the warning fires for the missing-column and NaN cases, and that it is emitted once per episode):
  `pytest -q tests/rewards/test_sarm_processor.py -k "missing_dense or nan_dense"`
- Verified fail-before/pass-after by exercising the actual `_load_episode_annotations` source: pre-change it returns `(None, None, None)` silently; post-change it warns for both cases and stays quiet on the legitimate single-stage path.
- `ruff format` / `ruff check`: clean.

## Checklist

- [x] Linting/formatting run (ruff)
- [ ] All tests pass locally
- [ ] Documentation updated
- [ ] CI is green
- [ ] Community Review

## Reviewer notes

I used a warning rather than a hard error so a partially-annotated dataset still runs; can switch to raising in dense/dual mode if you'd rather fail fast.
