### PR TITLE
fix(policies): derive input_features from dataset in make_policy

### DIFF
--- a/src/lerobot/policies/factory.py
+++ b/src/lerobot/policies/factory.py
@@ -528,8 +528,17 @@ def make_policy(
         features = env_to_policy_features(env_cfg)
 
     cfg.output_features = {key: ft for key, ft in features.items() if ft.type is FeatureType.ACTION}
-    if not cfg.input_features:
-        cfg.input_features = {key: ft for key, ft in features.items() if key not in cfg.output_features}
+    # Always derive input_features from the current dataset/env rather than preserving defaults that
+    # ship with a pretrained base model's config (e.g. LIBERO-style camera keys on pi0_fast). Keeping
+    # those stale keys breaks fine-tuning on a custom dataset whose observation keys differ, failing
+    # later with "All image features are missing from the batch" (see issue #3845).
+    input_features = {key: ft for key, ft in features.items() if key not in cfg.output_features}
+    if rename_map:
+        # Use the keys produced by RenameObservationsProcessorStep at runtime so the config matches
+        # the post-rename batch. Only observation (input) keys are renamed; action (output) features
+        # keep their original names since that processor step never touches actions.
+        input_features = {rename_map.get(key, key): ft for key, ft in input_features.items()}
+    cfg.input_features = input_features
 
     # Store action feature names for relative_exclude_joints support
     if ds_meta is not None and hasattr(cfg, "action_feature_names"):

--- a/tests/policies/test_policies.py
+++ b/tests/policies/test_policies.py
@@ -283,6 +283,46 @@ def test_policy_defaults(dummy_dataset_metadata, policy_name: str):
     policy_cls(policy_cfg)
 
 
+def test_make_policy_overrides_stale_input_features(dummy_dataset_metadata):
+    """`make_policy` must derive `input_features` from the dataset, not preserve stale defaults.
+
+    Regression test for issue #3845: a pretrained base model config can ship with `input_features`
+    that don't match the dataset being fine-tuned on (e.g. LIBERO-style camera keys on pi0_fast).
+    Those stale keys must be replaced by the actual dataset features, otherwise training fails with
+    "All image features are missing from the batch".
+    """
+    policy_cfg = make_policy_config("act", pretrained_backbone_weights=None, device=DEVICE)
+    # Simulate a base model config that ships with input_features for a different camera setup.
+    stale_key = f"{OBS_IMAGES}.stale_camera"
+    policy_cfg.input_features = {stale_key: PolicyFeature(type=FeatureType.VISUAL, shape=(3, 84, 84))}
+
+    make_policy(policy_cfg, ds_meta=dummy_dataset_metadata)
+
+    assert stale_key not in policy_cfg.input_features
+    assert f"{OBS_IMAGES}.laptop" in policy_cfg.input_features
+    assert OBS_STATE in policy_cfg.input_features
+
+
+def test_make_policy_applies_rename_map_to_input_features(dummy_dataset_metadata):
+    """`make_policy` must rename input feature keys so the config matches the post-rename batch.
+
+    Regression test for issue #3845: when a `rename_map` is supplied, `RenameObservationsProcessorStep`
+    renames observation keys at runtime, so `cfg.input_features` must use the renamed keys. Action
+    (output) features are never renamed by that step and must keep their original names.
+    """
+    policy_cfg = make_policy_config("act", pretrained_backbone_weights=None, device=DEVICE)
+    original_key = f"{OBS_IMAGES}.laptop"
+    renamed_key = f"{OBS_IMAGES}.renamed"
+    rename_map = {original_key: renamed_key}
+
+    make_policy(policy_cfg, ds_meta=dummy_dataset_metadata, rename_map=rename_map)
+
+    assert renamed_key in policy_cfg.input_features
+    assert original_key not in policy_cfg.input_features
+    # Action keys are produced by the policy, not the observation rename step, so they are untouched.
+    assert ACTION in policy_cfg.output_features
+
+
 @pytest.mark.parametrize("policy_name", AVAILABLE_POLICIES)
 def test_save_and_load_pretrained(dummy_dataset_metadata, tmp_path, policy_name: str):
     policy_cls = get_policy_class(policy_name)


### PR DESCRIPTION
## Summary / Motivation

When fine-tuning a policy whose pretrained base config ships with `input_features` (for example the LIBERO-style camera keys baked into `pi0_fast` base configs), `make_policy()` preserved those stale keys because of the `if not cfg.input_features:` guard. On a custom dataset with different camera keys (and/or a `rename_map`), the config then disagreed with the actual batch, and training failed downstream with `All image features are missing from the batch`.

This makes `make_policy()` always derive `input_features` from the dataset/env being used, and apply `rename_map` so the stored feature keys match what `RenameObservationsProcessorStep` produces at runtime.

## Related issues

- Fixes: #3845

## What changed

- `src/lerobot/policies/factory.py`: in `make_policy()`, always populate `cfg.input_features` from the current dataset/env features instead of keeping defaults shipped with a pretrained base model config.
- When a `rename_map` is provided, apply it to the input feature keys so they match the post-rename batch. Action (output) features keep their original names, because `RenameObservationsProcessorStep` only renames observations.
- No change for the common case: when keys already line up (or no base-config defaults exist), the resulting `input_features` are identical to before.

## How was this tested

- Added two regression tests in `tests/policies/test_policies.py`:
  - `test_make_policy_overrides_stale_input_features` — stale base-config `input_features` are replaced by the dataset's.
  - `test_make_policy_applies_rename_map_to_input_features` — input keys are renamed per `rename_map`, output keys are not.
- Both tests fail on `main` and pass with this change.

```
pytest -q tests/policies/test_policies.py -k "stale_input_features or rename_map_to_input"
```

- `pre-commit`/`ruff` clean on the changed files.

## Checklist

- [x] Linting/formatting run (`ruff check` / `ruff format --check` on changed files)
- [x] New tests pass locally
- [ ] Documentation updated (no docs change needed)
- [ ] CI is green (pending)
- [x] Community Review: reviewed #3841

## Reviewer notes

The main thing to sanity-check is the `rename_map` direction: keys come from the dataset and are mapped through `rename_map.get(key, key)`, matching `RenameObservationsProcessorStep.observation()` / `transform_features()`. Output (action) features are intentionally left un-renamed.