### PR TITLE
Add resize_images dataset edit operation

### DIFF
--- a/src/lerobot/datasets/__init__.py
+++ b/src/lerobot/datasets/__init__.py
@@ -33,6 +33,7 @@ from .dataset_tools import (
     recompute_stats,
     reencode_dataset,
     remove_feature,
+    resize_images,
     split_dataset,
 )
 from .factory import make_dataset, resolve_delta_timestamps
@@ -95,6 +96,7 @@ __all__ = [
     "recompute_stats",
     "reencode_dataset",
     "remove_feature",
+    "resize_images",
     "resolve_delta_timestamps",
     "safe_stop_image_writer",
     "split_dataset",

--- a/src/lerobot/datasets/dataset_tools.py
+++ b/src/lerobot/datasets/dataset_tools.py
@@ -474,6 +474,83 @@ def remove_feature(
     )
 
 
+def resize_images(
+    dataset: LeRobotDataset,
+    size: tuple[int, int],
+    image_keys: list[str] | None = None,
+    output_dir: str | Path | None = None,
+    repo_id: str | None = None,
+) -> LeRobotDataset:
+    """Resize image features in a LeRobotDataset and create a new dataset.
+
+    Args:
+        dataset: The source LeRobotDataset.
+        size: Target image size as ``(height, width)``.
+        image_keys: Image feature names to resize. If None, all image features are resized.
+        output_dir: Root directory where the resized dataset will be stored. If not specified, defaults to $HF_LEROBOT_HOME/repo_id.
+        repo_id: Resized dataset identifier. If not specified, defaults to ``{dataset.repo_id}_resized``.
+
+    Returns:
+        New dataset with selected image features resized.
+    """
+    if len(size) != 2:
+        raise ValueError("size must be a tuple of (height, width)")
+
+    height, width = size
+    if height <= 0 or width <= 0:
+        raise ValueError("size height and width must be positive")
+
+    available_image_keys = dataset.meta.image_keys
+    if not available_image_keys:
+        raise ValueError(f"No image features found in dataset {dataset.repo_id}")
+
+    selected_image_keys = image_keys or available_image_keys
+    invalid_keys = set(selected_image_keys) - set(available_image_keys)
+    if invalid_keys:
+        raise ValueError(f"Invalid image keys: {invalid_keys}")
+
+    if repo_id is None:
+        repo_id = f"{dataset.repo_id}_resized"
+    output_dir = Path(output_dir) if output_dir is not None else HF_LEROBOT_HOME / repo_id
+
+    new_features = deepcopy(dataset.meta.features)
+    for key in selected_image_keys:
+        feature = deepcopy(new_features[key])
+        old_shape = tuple(feature["shape"])
+        if len(old_shape) != 3:
+            raise ValueError(f"Image feature '{key}' must have shape (height, width, channels)")
+        channels = old_shape[2]
+        feature["shape"] = (height, width, channels)
+        new_features[key] = feature
+
+    new_meta = LeRobotDatasetMetadata.create(
+        repo_id=repo_id,
+        fps=dataset.meta.fps,
+        features=new_features,
+        robot_type=dataset.meta.robot_type,
+        root=output_dir,
+        use_videos=len(dataset.meta.video_keys) > 0,
+    )
+
+    _copy_data_with_resized_images(
+        dataset=dataset,
+        new_meta=new_meta,
+        image_keys=selected_image_keys,
+        size=(height, width),
+    )
+
+    if new_meta.video_keys:
+        _copy_videos(dataset, new_meta)
+
+    return LeRobotDataset(
+        repo_id=repo_id,
+        root=output_dir,
+        image_transforms=dataset.image_transforms,
+        delta_timestamps=dataset.delta_timestamps,
+        tolerance_s=dataset.tolerance_s,
+    )
+
+
 def _fractions_to_episode_indices(
     total_episodes: int,
     splits: dict[str, float],
@@ -1041,6 +1118,50 @@ def _copy_data_with_feature_changes(
             frame_idx = end_idx
 
         # Write using the same chunk/file structure as source
+        dst_path = new_meta.root / DEFAULT_DATA_PATH.format(chunk_index=chunk_idx, file_index=file_idx)
+        dst_path.parent.mkdir(parents=True, exist_ok=True)
+
+        _write_parquet(df, dst_path, new_meta)
+
+    _copy_episodes_metadata_and_stats(dataset, new_meta)
+
+
+def _copy_data_with_resized_images(
+    dataset: LeRobotDataset,
+    new_meta: LeRobotDatasetMetadata,
+    image_keys: list[str],
+    size: tuple[int, int],
+) -> None:
+    """Copy data files while resizing selected image columns."""
+    data_dir = dataset.root / DATA_DIR
+    parquet_files = sorted(data_dir.glob("*/*.parquet"))
+
+    if not parquet_files:
+        raise ValueError(f"No parquet files found in {data_dir}")
+
+    height, width = size
+    hf_dataset = dataset.hf_dataset.with_format(None)
+
+    for src_path in tqdm(parquet_files, desc="Resizing image data files"):
+        df = pd.read_parquet(src_path).reset_index(drop=True)
+        frame_indices = [int(idx) for idx in df["index"].tolist()]
+        image_rows = hf_dataset.select(frame_indices).select_columns(image_keys)
+        resized_columns = {key: [] for key in image_keys}
+
+        for item in image_rows:
+            for key in image_keys:
+                resized_columns[key].append(item[key].resize((width, height)))
+
+        for key, values in resized_columns.items():
+            df[key] = values
+
+        relative_path = src_path.relative_to(dataset.root)
+        chunk_dir = relative_path.parts[1]
+        file_name = relative_path.parts[2]
+
+        chunk_idx = int(chunk_dir.split("-")[1])
+        file_idx = int(file_name.split("-")[1].split(".")[0])
+
         dst_path = new_meta.root / DEFAULT_DATA_PATH.format(chunk_index=chunk_idx, file_index=file_idx)
         dst_path.parent.mkdir(parents=True, exist_ok=True)
 

--- a/src/lerobot/scripts/lerobot_edit_dataset.py
+++ b/src/lerobot/scripts/lerobot_edit_dataset.py
@@ -108,6 +108,23 @@ Remove camera feature:
         --operation.type remove_feature \
         --operation.feature_names "['observation.image']"
 
+Resize all image features and save to a new dataset:
+    lerobot-edit-dataset \
+        --repo_id lerobot/pusht_image \
+        --new_repo_id lerobot/pusht_image_128 \
+        --operation.type resize_images \
+        --operation.height 128 \
+        --operation.width 128
+
+Resize selected image features:
+    lerobot-edit-dataset \
+        --repo_id lerobot/pusht_image \
+        --new_root /path/to/pusht_image_resized \
+        --operation.type resize_images \
+        --operation.image_keys "['observation.image']" \
+        --operation.height 128 \
+        --operation.width 160
+
 Modify tasks - set a single task for all episodes (WARNING: modifies in-place):
     lerobot-edit-dataset \
         --repo_id lerobot/pusht \
@@ -235,6 +252,7 @@ from lerobot.datasets import (
     recompute_stats,
     reencode_dataset,
     remove_feature,
+    resize_images,
     split_dataset,
 )
 from lerobot.utils.constants import HF_LEROBOT_HOME
@@ -274,6 +292,14 @@ class MergeConfig(OperationConfig):
 @dataclass
 class RemoveFeatureConfig(OperationConfig):
     feature_names: list[str] | None = None
+
+
+@OperationConfig.register_subclass("resize_images")
+@dataclass
+class ResizeImagesConfig(OperationConfig):
+    height: int | None = None
+    width: int | None = None
+    image_keys: list[str] | None = None
 
 
 @OperationConfig.register_subclass("modify_tasks")
@@ -515,6 +541,44 @@ def handle_remove_feature(cfg: EditDatasetConfig) -> None:
 
     logging.info(f"Dataset saved to {output_dir}")
     logging.info(f"Remaining features: {list(new_dataset.meta.features.keys())}")
+
+    if cfg.push_to_hub:
+        logging.info(f"Pushing to hub as {output_repo_id}")
+        LeRobotDataset(output_repo_id, root=output_dir).push_to_hub()
+
+
+def handle_resize_images(cfg: EditDatasetConfig) -> None:
+    if not isinstance(cfg.operation, ResizeImagesConfig):
+        raise ValueError("Operation config must be ResizeImagesConfig")
+
+    if cfg.operation.height is None or cfg.operation.width is None:
+        raise ValueError("height and width must be specified for resize_images operation")
+
+    dataset = LeRobotDataset(cfg.repo_id, root=cfg.root)
+    output_repo_id, output_dir = get_output_path(
+        cfg.repo_id,
+        new_repo_id=cfg.new_repo_id,
+        root=cfg.root,
+        new_root=cfg.new_root,
+    )
+
+    if output_dir == dataset.root:
+        dataset.root = dataset.root.with_name(dataset.root.name + "_old")
+
+    logging.info(
+        f"Resizing image features {cfg.operation.image_keys or dataset.meta.image_keys} "
+        f"to {(cfg.operation.height, cfg.operation.width)}"
+    )
+    new_dataset = resize_images(
+        dataset,
+        size=(cfg.operation.height, cfg.operation.width),
+        image_keys=cfg.operation.image_keys,
+        output_dir=output_dir,
+        repo_id=output_repo_id,
+    )
+
+    logging.info(f"Dataset saved to {output_dir}")
+    logging.info(f"Image features: {new_dataset.meta.image_keys}")
 
     if cfg.push_to_hub:
         logging.info(f"Pushing to hub as {output_repo_id}")
@@ -801,6 +865,8 @@ def edit_dataset(cfg: EditDatasetConfig) -> None:
         handle_merge(cfg)
     elif operation_type == "remove_feature":
         handle_remove_feature(cfg)
+    elif operation_type == "resize_images":
+        handle_resize_images(cfg)
     elif operation_type == "modify_tasks":
         handle_modify_tasks(cfg)
     elif operation_type == "convert_image_to_video":

--- a/tests/datasets/test_dataset_tools.py
+++ b/tests/datasets/test_dataset_tools.py
@@ -34,6 +34,7 @@ from lerobot.datasets.dataset_tools import (
     modify_tasks,
     reencode_dataset,
     remove_feature,
+    resize_images,
     split_dataset,
 )
 from lerobot.datasets.io_utils import load_info
@@ -600,6 +601,46 @@ def test_remove_camera_feature(sample_dataset, tmp_path):
 
     sample_item = dataset_without_camera[0]
     assert camera_to_remove not in sample_item
+
+
+def test_resize_images_updates_metadata_and_data(sample_dataset, tmp_path):
+    """Test resizing image features in a dataset."""
+    output_dir = tmp_path / "resized"
+
+    with (
+        patch("lerobot.datasets.dataset_metadata.get_safe_version") as mock_get_safe_version,
+        patch("lerobot.datasets.dataset_metadata.snapshot_download") as mock_snapshot_download,
+    ):
+        mock_get_safe_version.return_value = "v3.0"
+        mock_snapshot_download.return_value = str(output_dir)
+
+        resized_dataset = resize_images(
+            sample_dataset,
+            size=(112, 160),
+            output_dir=output_dir,
+            repo_id="test/resized",
+        )
+
+    image_key = "observation.images.top"
+    assert resized_dataset.meta.features[image_key]["shape"] == (112, 160, 3)
+    assert resized_dataset.meta.total_episodes == sample_dataset.meta.total_episodes
+    assert resized_dataset.meta.total_frames == sample_dataset.meta.total_frames
+
+    item = resized_dataset.hf_dataset.with_format(None)[0]
+    assert item[image_key].size == (160, 112)
+    assert "action" in item
+    assert "observation.state" in item
+
+
+def test_resize_images_rejects_invalid_image_key(sample_dataset, tmp_path):
+    """Test error when resizing a non-image feature."""
+    with pytest.raises(ValueError, match="Invalid image keys"):
+        resize_images(
+            sample_dataset,
+            size=(112, 160),
+            image_keys=["observation.state"],
+            output_dir=tmp_path / "resized",
+        )
 
 
 def test_complex_workflow_integration(sample_dataset, tmp_path):

--- a/tests/scripts/test_edit_dataset_parsing.py
+++ b/tests/scripts/test_edit_dataset_parsing.py
@@ -28,6 +28,7 @@ from lerobot.scripts.lerobot_edit_dataset import (
     ModifyTasksConfig,
     OperationConfig,
     RemoveFeatureConfig,
+    ResizeImagesConfig,
     SplitConfig,
     _validate_config,
 )
@@ -48,6 +49,7 @@ class TestOperationTypeParsing:
             ("split", SplitConfig),
             ("merge", MergeConfig),
             ("remove_feature", RemoveFeatureConfig),
+            ("resize_images", ResizeImagesConfig),
             ("modify_tasks", ModifyTasksConfig),
             ("convert_image_to_video", ConvertImageToVideoConfig),
             ("info", InfoConfig),
@@ -92,6 +94,7 @@ class TestOperationTypeParsing:
             ("split", SplitConfig),
             ("merge", MergeConfig),
             ("remove_feature", RemoveFeatureConfig),
+            ("resize_images", ResizeImagesConfig),
             ("modify_tasks", ModifyTasksConfig),
             ("convert_image_to_video", ConvertImageToVideoConfig),
             ("info", InfoConfig),
@@ -103,3 +106,24 @@ class TestOperationTypeParsing:
         )
         resolved_name = OperationConfig.get_choice_name(type(cfg.operation))
         assert resolved_name == type_name
+
+    def test_resize_images_parses_size_and_keys(self):
+        cfg = parse_cfg(
+            [
+                "--repo_id",
+                "test/repo",
+                "--operation.type",
+                "resize_images",
+                "--operation.height",
+                "128",
+                "--operation.width",
+                "160",
+                "--operation.image_keys",
+                "['observation.images.top']",
+            ]
+        )
+
+        assert isinstance(cfg.operation, ResizeImagesConfig)
+        assert cfg.operation.height == 128
+        assert cfg.operation.width == 160
+        assert cfg.operation.image_keys == ["observation.images.top"]


### PR DESCRIPTION
## Summary

Adds a `resize_images` operation to `lerobot-edit-dataset` for image-backed LeRobot datasets.

This covers a focused part of #2124: resizing image datasets before training without requiring users to write a custom script.

## Changes

- Adds `resize_images()` to dataset tools.
- Updates image feature metadata shapes when resizing.
- Wires the operation into `lerobot-edit-dataset` with `--operation.height`, `--operation.width`, and optional `--operation.image_keys`.
- Adds parsing and dataset behavior tests.

## Validation

- `uv run --extra dataset --extra test pytest tests/scripts/test_edit_dataset_parsing.py::TestOperationTypeParsing::test_resize_images_parses_size_and_keys tests/datasets/test_dataset_tools.py::test_resize_images_updates_metadata_and_data tests/datasets/test_dataset_tools.py::test_resize_images_rejects_invalid_image_key -q`
- `uv run --extra dataset --extra test pytest tests/scripts/test_edit_dataset_parsing.py -q`
- `uv run --extra dev ruff check src/lerobot/datasets/dataset_tools.py src/lerobot/datasets/__init__.py src/lerobot/scripts/lerobot_edit_dataset.py tests/scripts/test_edit_dataset_parsing.py tests/datasets/test_dataset_tools.py`

Would appreciate review on whether the operation should stay image-dataset-only for now, or if maintainers prefer extending the scope later to video-backed datasets via re-encoding.
