### PR TITLE
feat: add lekiwi support to async_inference

### DIFF
--- a/src/lerobot/async_inference/robot_client.py
+++ b/src/lerobot/async_inference/robot_client.py
@@ -57,6 +57,7 @@ from lerobot.robots import (  # noqa: F401
     make_robot_from_config,
     omx_follower,
     so_follower,
+    lekiwi,
 )
 from lerobot.transport import (
     services_pb2,  # type: ignore

--- a/src/lerobot/async_inference/robot_client.py
+++ b/src/lerobot/async_inference/robot_client.py
@@ -54,10 +54,10 @@ from lerobot.robots import (  # noqa: F401
     RobotConfig,
     bi_so_follower,
     koch_follower,
+    lekiwi,
     make_robot_from_config,
     omx_follower,
     so_follower,
-    lekiwi,
 )
 from lerobot.transport import (
     services_pb2,  # type: ignore


### PR DESCRIPTION
## Title

add lekiwi support to robot_client

## Summary / Motivation

- This PR adds support for lekiwi to async_inference by including it in the import list within robot_client.py. 
- This change is necessary to enable asynchronous inference functionality for the Lekiwi robot, which was previously missing.

## Related issues

- Related: [# 3740](https://github.com/huggingface/lerobot/issues/3740)

## What changed

- Added lekiwi to the import list in src/lerobot/async_inference/robot_client.py.
- No breaking changes are introduced.

## How was this tested (or how to run locally)

- Verified by manually modifying the local file and confirming that async_inference works correctly with the Lekiwi robot.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [ ] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: # (insert PR number/link)

## Reviewer notes

- This is a minor, straightforward fix to enable compatibility for the Lekiwi robot in async_inference.
