### PR TITLE
fix(datasets): handle missing tasks.parquet and episodes dir on resume

### DIFF
--- a/src/lerobot/datasets/io_utils.py
+++ b/src/lerobot/datasets/io_utils.py
@@ -181,8 +181,11 @@ def write_tasks(tasks: pandas.DataFrame, local_dir: Path) -> None:
     tasks.to_parquet(path)
 
 
-def load_tasks(local_dir: Path) -> pandas.DataFrame:
-    tasks = pd.read_parquet(local_dir / DEFAULT_TASKS_PATH)
+def load_tasks(local_dir: Path) -> pandas.DataFrame | None:
+    path = local_dir / DEFAULT_TASKS_PATH
+    if not path.exists():
+        return None
+    tasks = pd.read_parquet(path)
     tasks.index.name = "task"
     return tasks
 
@@ -209,8 +212,11 @@ def write_episodes(episodes: Dataset, local_dir: Path) -> None:
     episodes.to_parquet(fpath)
 
 
-def load_episodes(local_dir: Path) -> datasets.Dataset:
-    episodes = load_nested_dataset(local_dir / EPISODES_DIR)
+def load_episodes(local_dir: Path) -> datasets.Dataset | None:
+    episodes_dir = local_dir / EPISODES_DIR
+    if not any(episodes_dir.glob("*/*.parquet")):
+        return None
+    episodes = load_nested_dataset(episodes_dir)
     # Select episode features/columns containing references to episode data and videos
     # (e.g. tasks, dataset_from_index, dataset_to_index, data/chunk_index, data/file_index, etc.)
     # This is to speedup access to these data, instead of having to load episode stats.


### PR DESCRIPTION
## Summary / Motivation

`LeRobotDataset.resume()` fails with a spurious Hub 404 error when called on a freshly-created local dataset that has no recorded episodes yet. The root cause is that `load_tasks()` and `load_episodes()` raise `FileNotFoundError` when their files are absent: `tasks.parquet` and the episodes parquet directory are only written lazily after the first episode is saved. The `FileNotFoundError` is caught by `LeRobotDatasetMetadata.__init__`, which assumes the error means the dataset lives on the Hub and attempts a remote fetch, producing a confusing 404 for datasets that were never pushed. This patch makes `load_tasks` and `load_episodes` return `None` when their files do not exist, consistent with the behaviour of `load_subtasks` and `load_stats` and with the in-memory state set by `LeRobotDataset.create().

## Related issues

- Fixes / Closes: #3857 

## What changed

- `load_tasks()` now returns None instead of raising FileNotFoundError when meta/tasks.parquet is absent.
- `load_episodes()` now returns None instead of raising FileNotFoundError when the episodes directory contains no parquet files.
- No breaking changes: all existing call sites already guard for `None` (matching the `create()` in-memory state) or are only reached when episodes genuinely exist on disk.

## How was this tested (or how to run locally)

Manually verified by calling `LeRobotDataset.create()` followed by `LeRobotDataset.resume()` on a local dataset with no recorded episode; previously raised RepositoryNotFoundError, now succeeds.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [ ] CI is green
