### PR TITLE
Fix pi0fast model id in docs

### DIFF
--- a/docs/source/pi0fast.mdx
+++ b/docs/source/pi0fast.mdx
@@ -96,7 +96,7 @@ lerobot-train \
     --policy.type=pi0_fast \
     --output_dir=./outputs/pi0fast_training \
     --job_name=pi0fast_training \
-    --policy.pretrained_path=lerobot/pi0_fast_base \
+    --policy.pretrained_path=lerobot/pi0fast-base \
     --policy.dtype=bfloat16 \
     --policy.gradient_checkpointing=true \
     --policy.chunk_size=10 \
@@ -187,7 +187,7 @@ lerobot-train \
   --dataset.repo_id=lerobot/libero \
   --output_dir=outputs/libero_pi0fast \
   --job_name=libero_pi0fast \
-  --policy.path=lerobot/pi0fast_base \
+  --policy.path=lerobot/pi0fast-base \
   --policy.dtype=bfloat16 \
   --steps=100000 \
   --save_freq=20000 \


### PR DESCRIPTION
Fixes #3847.

Replaces two stale PI0Fast model IDs in docs/source/pi0fast.mdx with the valid Hub repo ID `lerobot/pi0fast-base`.

Validation:
- Confirmed the stale IDs are no longer present in docs/source/pi0fast.mdx.
- Confirmed docs now match the existing default mapping in src/lerobot/policies/pretrained.py and the PI0Fast policy test constant.
- Ran git diff --check.
- Ran pre-commit run --files docs/source/pi0fast.mdx.