### PR TITLE
Pass pi0_fast action tokenizer override to preprocessor

### DIFF
--- a/src/lerobot/scripts/lerobot_train.py
+++ b/src/lerobot/scripts/lerobot_train.py
@@ -320,6 +320,11 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
             },
             "rename_observations_processor": {"rename_map": cfg.rename_map},
         }
+        action_tokenizer_name = getattr(active_cfg, "action_tokenizer_name", None)
+        if action_tokenizer_name is not None:
+            preprocessor_overrides["action_tokenizer_processor"] = {
+                "action_tokenizer_name": action_tokenizer_name,
+            }
         postprocessor_overrides = {
             "unnormalizer_processor": {
                 "stats": dataset.meta.stats,

--- a/tests/scripts/test_lerobot_train.py
+++ b/tests/scripts/test_lerobot_train.py
@@ -1,0 +1,71 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+pytest.importorskip("datasets", reason="lerobot_train imports the dataset module")
+pytest.importorskip("accelerate", reason="train() requires the training extra")
+
+from lerobot.scripts import lerobot_train
+
+
+class StopAfterProcessorCreationError(Exception):
+    pass
+
+
+class DummyAccelerator:
+    is_main_process = True
+    device = torch.device("cpu")
+
+    def wait_for_everyone(self):
+        pass
+
+
+def test_train_passes_action_tokenizer_name_to_preprocessor(monkeypatch):
+    active_cfg = SimpleNamespace(
+        pretrained_path="pi0fast-base",
+        pretrained_revision=None,
+        device="cpu",
+        action_tokenizer_name="lerobot/fast-action-tokenizer",
+    )
+    cfg = SimpleNamespace(
+        policy=active_cfg,
+        trainable_config=active_cfg,
+        reward_model=None,
+        is_reward_model_training=False,
+        resume=False,
+        peft=None,
+        rename_map={},
+        wandb=SimpleNamespace(enable=False, project=None),
+        seed=None,
+        cudnn_deterministic=False,
+        eval_freq=0,
+        env=None,
+        validate=lambda: None,
+        to_dict=lambda: {},
+    )
+    dataset = SimpleNamespace(meta=SimpleNamespace(stats={"observation.state": {"mean": 0.0}}))
+    policy = SimpleNamespace(
+        config=SimpleNamespace(
+            input_features={"observation.state": None},
+            output_features={"action": None},
+            normalization_mapping={},
+        )
+    )
+
+    monkeypatch.setattr(lerobot_train, "init_logging", lambda accelerator: None)
+    monkeypatch.setattr(lerobot_train, "make_dataset", lambda cfg: dataset)
+    monkeypatch.setattr(lerobot_train, "make_policy", lambda **kwargs: policy)
+
+    def assert_preprocessor_overrides(**kwargs):
+        assert kwargs["policy_cfg"] is active_cfg
+        assert kwargs["pretrained_path"] == "pi0fast-base"
+        assert kwargs["preprocessor_overrides"]["action_tokenizer_processor"] == {
+            "action_tokenizer_name": "lerobot/fast-action-tokenizer",
+        }
+        raise StopAfterProcessorCreationError
+
+    monkeypatch.setattr(lerobot_train, "make_pre_post_processors", assert_preprocessor_overrides)
+
+    with pytest.raises(StopAfterProcessorCreationError):
+        lerobot_train.train.__wrapped__(cfg, accelerator=DummyAccelerator())


### PR DESCRIPTION
Fixes #3846.

## Summary
- Pass policy.action_tokenizer_name through training preprocessor overrides for pretrained policies.
- Target the action_tokenizer_processor step so pi0_fast can override the tokenizer stored in policy_preprocessor.json.
- Add a focused train() test that verifies the override reaches make_pre_post_processors.

## Tests
- uv run pytest tests/scripts/test_lerobot_train.py -q
- env UV_CACHE_DIR=/tmp/lerobot-uv-cache uv run ruff check src/lerobot/scripts/lerobot_train.py tests/scripts/test_lerobot_train.py
- uv run pytest tests/policies/test_policies.py -q
