### PR TITLE
fix(policies): support async/single-frame inference for Diffusion

### DIFF
--- a/src/lerobot/policies/diffusion/modeling_diffusion.py
+++ b/src/lerobot/policies/diffusion/modeling_diffusion.py
@@ -104,18 +104,29 @@ class DiffusionPolicy(PreTrainedPolicy):
         """Predict a chunk of actions given environment observations.
 
         Supports two modes:
-        - Online (queues populated via select_action): stacks observations from internal queues.
-        - Offline (empty queues, e.g. dataloader batch): uses the batch directly.
+        - Online (queues populated via select_action): stacks the `n_obs_steps` history from the
+          internal queues.
+        - Queue-less (empty queues): used by offline dataloader batches and by the async inference
+          server, which calls this method directly with a single observation and never warms up the
+          queues. A single frame (state with `ndim == 2`, images with `ndim == 4`) is expanded along a
+          new temporal dimension of length `n_obs_steps`, mirroring the warm-up that `select_action`
+          performs through `populate_queues`. Batches that already carry the temporal dimension are
+          left untouched.
         """
         queues_populated = any(len(q) > 0 for q in self._queues.values())
         if queues_populated:
             batch = {k: torch.stack(list(self._queues[k]), dim=1) for k in batch if k in self._queues}
         else:
             batch = dict(batch)
+            n_obs_steps = self.config.n_obs_steps
+            if batch[OBS_STATE].ndim == 2:
+                batch[OBS_STATE] = batch[OBS_STATE].unsqueeze(1).expand(-1, n_obs_steps, -1)
+            if self.config.env_state_feature and batch[OBS_ENV_STATE].ndim == 2:
+                batch[OBS_ENV_STATE] = batch[OBS_ENV_STATE].unsqueeze(1).expand(-1, n_obs_steps, -1)
             if self.config.image_features:
                 for key in self.config.image_features:
                     if batch[key].ndim == 4:
-                        batch[key] = batch[key].unsqueeze(1)
+                        batch[key] = batch[key].unsqueeze(1).expand(-1, n_obs_steps, -1, -1, -1)
                 batch[OBS_IMAGES] = torch.stack([batch[key] for key in self.config.image_features], dim=-4)
         actions = self.diffusion.generate_actions(batch, noise=noise)
         return actions

--- a/tests/policies/test_policies.py
+++ b/tests/policies/test_policies.py
@@ -284,6 +284,47 @@ def test_policy_defaults(dummy_dataset_metadata, policy_name: str):
     policy_cls(policy_cfg)
 
 
+@pytest.mark.skipif(
+    "diffusion" not in AVAILABLE_POLICIES, reason="diffusers is required (install lerobot[diffusion])"
+)
+def test_diffusion_predict_action_chunk_warms_up_empty_queues(dummy_dataset_metadata):
+    """Regression test for the async-inference path (https://github.com/huggingface/lerobot/issues/3861).
+
+    The async ``PolicyServer`` calls ``predict_action_chunk()`` directly with a single, un-warmed
+    observation and never populates the observation-history queues that ``select_action()`` relies on.
+    With ``n_obs_steps > 1`` the model needs a temporal observation dimension, so ``predict_action_chunk``
+    must build it from the single frame itself (mirroring ``populate_queues``) instead of crashing in
+    ``generate_actions`` (previously ``stack expects a non-empty TensorList`` / a ``n_obs_steps`` assertion).
+    """
+    policy_cls = get_policy_class("diffusion")
+    policy_cfg = make_policy_config("diffusion")
+    features = dataset_to_policy_features(dummy_dataset_metadata.features)
+    policy_cfg.output_features = {key: ft for key, ft in features.items() if ft.type is FeatureType.ACTION}
+    policy_cfg.input_features = {
+        key: ft for key, ft in features.items() if key not in policy_cfg.output_features
+    }
+    policy = policy_cls(policy_cfg)
+    policy.to(DEVICE)
+    policy.reset()
+
+    assert policy.config.n_obs_steps > 1, "Test should exercise a multi-step observation history"
+    assert all(len(q) == 0 for q in policy._queues.values()), "Queues must be empty for this path"
+
+    batch_size = 2
+    # A single observation frame, exactly as the async server provides it: state is (B, state_dim)
+    # and each image is (B, C, H, W), with no temporal (n_obs_steps) dimension.
+    batch = {OBS_STATE: torch.randn(batch_size, policy_cfg.robot_state_feature.shape[0], device=DEVICE)}
+    for key, ft in policy_cfg.image_features.items():
+        c, h, w = ft.shape
+        batch[key] = torch.rand(batch_size, c, h, w, device=DEVICE)
+
+    actions = policy.predict_action_chunk(batch)
+
+    assert actions.ndim == 3
+    assert actions.shape[0] == batch_size
+    assert actions.shape[-1] == policy_cfg.action_feature.shape[0]
+
+
 @pytest.mark.parametrize("policy_name", AVAILABLE_POLICIES)
 def test_save_and_load_pretrained(dummy_dataset_metadata, tmp_path, policy_name: str):
     policy_cls = get_policy_class(policy_name)


### PR DESCRIPTION
## Summary / Motivation

Async inference crashes immediately when serving a **Diffusion** policy: the policy server loads the model, receives observation #0, then errors on the very first inference and never produces an action (the robot never moves). An ACT policy works on the identical setup, isolating the bug to the diffusion inference path.

Root cause: the async `PolicyServer` calls `DiffusionPolicy.predict_action_chunk()` directly with a single, un-warmed observation and never populates the observation-history queues that the synchronous `select_action()` path relies on. Diffusion conditions on `n_obs_steps` past frames (default 2), so the model requires a temporal observation dimension. With empty queues, the existing queue-less branch only gave images a length-1 temporal dimension and left `observation.state` 2D, so `generate_actions()` failed its `n_obs_steps == config.n_obs_steps` assertion (and previously raised `stack expects a non-empty TensorList`). ACT is unaffected because it has no temporal observation queue.

## Related issues

- Fixes: #3861

## What changed

- In `DiffusionPolicy.predict_action_chunk()`, the queue-less branch now expands a single frame (state `ndim==2`, images `ndim==4`, env_state `ndim==2`) along a new temporal dimension of length `n_obs_steps`, mirroring the warm-up that `select_action()` performs via `populate_queues`.
- Batches that already carry the temporal dimension (offline dataloader batches, the case added in #3822) are detected by `ndim` and left untouched, so that path is unchanged.
- No client/server changes are required; the fix is entirely inside the policy.

## How was this tested

- Unit test: added `test_diffusion_predict_action_chunk_warms_up_empty_queues` in `tests/policies/test_policies.py`, which calls `predict_action_chunk()` with a single-frame batch and empty queues (the async path) and asserts a valid action chunk is returned. Run with `pytest -q tests/policies -k diffusion`.
- On-hardware end-to-end validation (see Validation section below).

## Validation (real hardware, end-to-end)

Validated the full async pipeline on real hardware.

Setup:
- Server: RunPod, NVIDIA RTX A4000, CUDA, Python 3.12, PyTorch 2.8, `policy_device=cuda`
- Client: Raspberry Pi 5, SO-101 follower, scene + wrist cameras (640x480), async over direct TCP
- Policy: diffusion (`--policy_type=diffusion`)

Before the fix: the server crashed at observation #0 with `Error in StreamActions: stack expects a non-empty TensorList`, then looped `Starting receiver` forever; no action chunks were ever generated.

After the fix: the server runs diffusion inference continuously and streams action chunks. Representative server log:

```
Running inference for observation #103
Preprocessing and inference took 0.9853s, action shape: torch.Size([1, 8, 6])
Observation 103 | Total time: 1019.97ms
Action chunk #103 generated | Total time: 1020.71ms
Running inference for observation #107
Preprocessing and inference took 0.9925s, action shape: torch.Size([1, 8, 6])
Action chunk #107 generated | Total time: 1025.91ms
```

## Checklist

- [x] Linting/formatting (ruff via CI `quality.yml`)
- [x] Tests pass (new regression test + CI; on-hardware validation above)

## Reviewer notes

- The same empty-queue stacking pattern also affects `vqbet` and `tdmpc` under async inference (they were not touched by #3822). This PR is intentionally scoped to Diffusion only; the others can be addressed as separate follow-ups.
