### PR TITLE
fix(robots): retry SO follower/leader bus reads on transient Feetech errors

### DIFF
--- a/src/lerobot/robots/so_follower/config_so_follower.py
+++ b/src/lerobot/robots/so_follower/config_so_follower.py
@@ -41,6 +41,12 @@ class SOFollowerConfig:
     # Set to `True` for backward compatibility with previous policies/dataset
     use_degrees: bool = True
 
+    # Number of extra attempts when a `sync_read` of the motors fails. Feetech buses can occasionally
+    # return a corrupted status packet ("Incorrect status packet!"), especially when several joints move
+    # at once, which otherwise aborts the control loop. Retries are immediate (no sleep) and only happen on
+    # failure, so the steady-state read cost is unchanged. Set to `0` to restore the previous behavior.
+    max_read_retry: int = 3
+
 
 @RobotConfig.register_subclass("so101_follower")
 @RobotConfig.register_subclass("so100_follower")

--- a/src/lerobot/robots/so_follower/so_follower.py
+++ b/src/lerobot/robots/so_follower/so_follower.py
@@ -182,7 +182,7 @@ class SOFollower(Robot):
     def get_observation(self) -> RobotObservation:
         # Read arm position
         start = time.perf_counter()
-        obs_dict = self.bus.sync_read("Present_Position")
+        obs_dict = self.bus.sync_read("Present_Position", num_retry=self.config.max_read_retry)
         obs_dict = {f"{motor}.pos": val for motor, val in obs_dict.items()}
         dt_ms = (time.perf_counter() - start) * 1e3
         logger.debug(f"{self} read state: {dt_ms:.1f}ms")
@@ -223,7 +223,7 @@ class SOFollower(Robot):
         # Cap goal position when too far away from present position.
         # /!\ Slower fps expected due to reading from the follower.
         if self.config.max_relative_target is not None:
-            present_pos = self.bus.sync_read("Present_Position")
+            present_pos = self.bus.sync_read("Present_Position", num_retry=self.config.max_read_retry)
             goal_present_pos = {key: (g_pos, present_pos[key]) for key, g_pos in goal_pos.items()}
             goal_pos = ensure_safe_goal_position(goal_present_pos, self.config.max_relative_target)
 

--- a/src/lerobot/teleoperators/so_leader/config_so_leader.py
+++ b/src/lerobot/teleoperators/so_leader/config_so_leader.py
@@ -29,6 +29,13 @@ class SOLeaderConfig:
     # Whether to use degrees for angles
     use_degrees: bool = True
 
+    # Number of extra attempts when a `sync_read` of the motors fails. Feetech buses can occasionally
+    # return a corrupted status packet ("Incorrect status packet!"), especially when several joints move
+    # at once, which otherwise aborts the teleoperation loop. Retries are immediate (no sleep) and only
+    # happen on failure, so the steady-state read cost is unchanged. Set to `0` to restore the previous
+    # behavior.
+    max_read_retry: int = 3
+
 
 @TeleoperatorConfig.register_subclass("so101_leader")
 @TeleoperatorConfig.register_subclass("so100_leader")

--- a/src/lerobot/teleoperators/so_leader/so_leader.py
+++ b/src/lerobot/teleoperators/so_leader/so_leader.py
@@ -145,7 +145,7 @@ class SOLeader(Teleoperator):
     @check_if_not_connected
     def get_action(self) -> dict[str, float]:
         start = time.perf_counter()
-        action = self.bus.sync_read("Present_Position")
+        action = self.bus.sync_read("Present_Position", num_retry=self.config.max_read_retry)
         action = {f"{motor}.pos": val for motor, val in action.items()}
         dt_ms = (time.perf_counter() - start) * 1e3
         logger.debug(f"{self} read action: {dt_ms:.1f}ms")

--- a/tests/robots/test_so100_follower.py
+++ b/tests/robots/test_so100_follower.py
@@ -99,6 +99,17 @@ def test_get_observation(follower):
         assert obs[f"{motor}.pos"] == idx
 
 
+def test_get_observation_uses_read_retry(follower):
+    # Feetech buses can intermittently fail a sync_read; the follower should forward the configured
+    # retry count so transient failures don't abort the control loop (see #3131).
+    follower.connect()
+    follower.get_observation()
+
+    follower.bus.sync_read.assert_called_once_with(
+        "Present_Position", num_retry=follower.config.max_read_retry
+    )
+
+
 def test_send_action(follower):
     follower.connect()
 


### PR DESCRIPTION
## Title

fix(robots): retry SO follower/leader bus reads on transient Feetech errors

## Summary / Motivation

SO-100/SO-101 teleoperation and recording occasionally abort with
`ConnectionError: Failed to sync read 'Present_Position' ... [TxRxResult] Incorrect status packet!`.
This is a known transient failure mode of the Feetech bus that shows up under load (typically when several
joints move at once), reported in #3131 by two users.

The bus read path already supports a `num_retry` argument (`MotorsBus.sync_read(..., num_retry=...)`), and other
control paths already use it (e.g. `lekiwi` passes `num_retry=5` on its base `sync_write`). But the SO follower and
leader read `Present_Position` with the default `num_retry=0`, so a single transient corrupted packet propagates as
a fatal `ConnectionError` and kills the control loop.

## Related issues

- Fixes: #3131

## What changed

- Add `max_read_retry: int = 3` to `SOFollowerConfig` and `SOLeaderConfig`.
- Forward it to every `Present_Position` `sync_read`:
  - `SOFollower.get_observation`
  - `SOFollower.send_action` (the safety read used when `max_relative_target` is set)
  - `SOLeader.get_action`
- Retries reuse the existing `_sync_read` retry loop, which re-sends immediately (no sleep) and only on failure — so
  the steady-state read cost is unchanged. Set `max_read_retry=0` to restore the previous behavior.

Not a breaking change: the new field has a default and the public read APIs are unchanged. `sync_write` of
`Goal_Position` is intentionally left as-is, since it is fire-and-forget (no status packet expected), so it is not
subject to the "Incorrect status packet" failure.

## How was this tested (or how to run locally)

**Unit test added** — `tests/robots/test_so100_follower.py::test_get_observation_uses_read_retry` asserts the
configured retry count is forwarded to the bus read:

```
pytest -q tests/robots/test_so100_follower.py   # 4 passed
```

**On real SO-101 hardware** (leader + follower, macOS) via `lerobot-teleoperate`:

- *No steady-state regression.* Idle loop timing is identical with retries on vs off: `--robot.max_read_retry`/
  `--teleop.max_read_retry` `=0` vs `=3` both held a median **16.67 ms (60 Hz)**, max ~16.7 ms, over 900 loops each.
  Under active teleoperation with the default `=3`, a 90 s run (5383 loops) stayed at median 16.67 ms / max 17.14 ms
  with **0 loops slower than 18 ms** and no errors. This matches expectation: retries only fire on a failed read.
- *The transient failure class is real on this unit.* A `Torque_Enable` write at connect once failed with
  `[TxRxResult] There is no status packet!` (motor id 4) — the same Feetech "no status packet" class that aborts the
  read path in #3131.
- *Honest caveat:* the intermittent read-path crash itself did **not** trigger during my testing — ~105 s of
  `max_read_retry=0` teleop (vigorous multi-joint motion + perturbing a motor cable; 6000+ loops) ran without a
  `sync_read` failure. The failure is stochastic/hardware-dependent (two users hit it independently), so I could not
  force a deterministic before/after on hardware. The change is a strict superset of the previous behavior
  (`max_read_retry=0` reproduces it exactly) and mirrors the existing `num_retry` usage elsewhere in the codebase.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a` — ruff check + format clean on changed files)
- [x] All tests pass locally (`pytest -q tests/robots/test_so100_follower.py`)
- [ ] Documentation updated (n/a — config field documented inline)
- [ ] CI is green
- [x] Community Review: I have reviewed another contributor's open PR and linked it here: #3815

## Reviewer notes

- The default of `3` is a judgement call; happy to change it (or default to `0` to keep behavior byte-identical and
  make it strictly opt-in) if maintainers prefer.
- Focus areas: whether `send_action`'s safety read should share the same knob as `get_observation` (currently yes),
  and whether the leader and follower should expose separate retry counts (currently one field each).
