### PR TITLE
Group scalars into single entity

### DIFF
--- a/src/lerobot/utils/visualization_utils.py
+++ b/src/lerobot/utils/visualization_utils.py
@@ -97,6 +97,73 @@ def _ensure_blueprint(observation_paths: set[str], action_paths: set[str], image
     rr.send_blueprint(blueprint)
 
 
+def _collect_observation(
+    rr, observation: RobotObservation, image_paths: set[str], compress_images: bool
+) -> tuple[list[str], list[float]]:
+    """Log observation images individually and gather every observation scalar into one batch.
+
+    Images (and depth maps) keep their own entity path; all scalar / vector values are flattened into a
+    single ``(names, values)`` pair so they can be logged as one grouped ``rr.Scalars`` batch.
+    """
+    names: list[str] = []
+    values: list[float] = []
+    for k, v in observation.items():
+        if v is None:
+            continue
+        key = str(k)
+        label = key[len(OBS_PREFIX) :] if key.startswith(OBS_PREFIX) else key
+        path = key if key.startswith(OBS_PREFIX) else f"{OBS_PREFIX}{key}"
+
+        if _is_scalar(v):
+            names.append(label)
+            values.append(float(v))
+        elif isinstance(v, np.ndarray):
+            arr = v
+            # Convert CHW -> HWC when needed
+            if arr.ndim == 3 and arr.shape[0] in (1, 3, 4) and arr.shape[-1] not in (1, 3, 4):
+                arr = np.transpose(arr, (1, 2, 0))
+            if arr.ndim <= 1:
+                _extend_scalars(names, values, label, arr)
+            else:
+                if arr.shape[-1] == 1:
+                    img_entity = rr.DepthImage(arr, colormap=rr.components.Colormap.Viridis)
+                else:
+                    img_entity = rr.Image(arr).compress() if compress_images else rr.Image(arr)
+                rr.log(path, entity=img_entity, static=True)
+                image_paths.add(path)
+    return names, values
+
+
+def _collect_action(action: RobotAction) -> tuple[list[str], list[float]]:
+    """Gather every action scalar / vector value into one ``(names, values)`` batch."""
+    names: list[str] = []
+    values: list[float] = []
+    for k, v in action.items():
+        if v is None:
+            continue
+        key = str(k)
+        label = key[len(ACTION_PREFIX) :] if key.startswith(ACTION_PREFIX) else key
+
+        if _is_scalar(v):
+            names.append(label)
+            values.append(float(v))
+        elif isinstance(v, np.ndarray):
+            _extend_scalars(names, values, label, v.reshape(-1))
+    return names, values
+
+
+def _extend_scalars(names: list[str], values: list[float], label: str, arr: np.ndarray) -> None:
+    """Append a 0/1-D array to the grouped scalar batch, naming multi-element entries ``label[i]``."""
+    flat = arr.reshape(-1).astype(float)
+    if flat.size == 1:
+        names.append(label)
+        values.append(float(flat[0]))
+    else:
+        for i, val in enumerate(flat):
+            names.append(f"{label}[{i}]")
+            values.append(float(val))
+
+
 def log_rerun_data(
     observation: RobotObservation | None = None,
     action: RobotAction | None = None,
@@ -107,17 +174,19 @@ def log_rerun_data(
 
     This function iterates through the provided observation and action dictionaries and sends their contents
     to the Rerun viewer. It handles different data types appropriately:
-    - Scalars values (floats, ints) are logged as `rr.Scalars`.
+    - All observation scalars/vectors are gathered and logged as a single `rr.Scalars` batch under the
+      `observation` entity path; likewise every action value is logged as one `rr.Scalars` batch under the
+      `action` entity path. This keeps a robot's joints grouped in one plot instead of split across one
+      entity path (and one log call) per joint.
     - 3D NumPy arrays that resemble images (e.g., with 1, 3, or 4 channels first) are transposed
-      from CHW to HWC format, (optionally) compressed to JPEG and logged as `rr.Image` or `rr.EncodedImage`.
-    - 1D NumPy arrays are logged as a single `rr.Scalars` batch under one entity path, so that every
-      dimension shares the same view instead of being split across one view per element.
-    - Multi-dimensional **action** arrays are flattened and logged as a single `rr.Scalars` batch.
+      from CHW to HWC format, (optionally) compressed to JPEG and logged as `rr.Image` or `rr.EncodedImage`,
+      and (for single-channel depth) as `rr.DepthImage`. Each image keeps its own entity path.
+    - Vector (1D / flattened) values contribute one named series per element (`label[i]`) within the batch.
 
     Keys are automatically namespaced with "observation." or "action." if not already present.
 
-    On the first call, a blueprint is built and sent so observation and action scalars get separate
-    time-series views and each image gets its own spatial view.
+    On the first call, the per-series names and a blueprint are sent so the observation and action scalars
+    each get a single time-series view and each image gets its own spatial view.
 
     Args:
         observation: An optional dictionary containing observation data to log.
@@ -128,46 +197,32 @@ def log_rerun_data(
     require_package("rerun-sdk", extra="viz", import_name="rerun")
     import rerun as rr
 
+    image_paths: set[str] = set()
     observation_paths: set[str] = set()
     action_paths: set[str] = set()
-    image_paths: set[str] = set()
+    observation_names: list[str] = []
+    action_names: list[str] = []
 
     if observation:
-        for k, v in observation.items():
-            if v is None:
-                continue
-            key = k if str(k).startswith(OBS_PREFIX) else f"{OBS_STR}.{k}"
-
-            if _is_scalar(v):
-                rr.log(key, rr.Scalars(float(v)))
-                observation_paths.add(key)
-            elif isinstance(v, np.ndarray):
-                arr = v
-                # Convert CHW -> HWC when needed
-                if arr.ndim == 3 and arr.shape[0] in (1, 3, 4) and arr.shape[-1] not in (1, 3, 4):
-                    arr = np.transpose(arr, (1, 2, 0))
-                if arr.ndim == 1:
-                    rr.log(key, rr.Scalars(arr.astype(float)))
-                    observation_paths.add(key)
-                else:
-                    if arr.shape[-1] == 1:
-                        img_entity = rr.DepthImage(arr, colormap=rr.components.Colormap.Viridis)
-                    else:
-                        img_entity = rr.Image(arr).compress() if compress_images else rr.Image(arr)
-                    rr.log(key, entity=img_entity, static=True)
-                    image_paths.add(key)
+        observation_names, observation_values = _collect_observation(
+            rr, observation, image_paths, compress_images
+        )
+        if observation_values:
+            rr.log(OBS_STR, rr.Scalars(observation_values))
+            observation_paths.add(OBS_STR)
 
     if action:
-        for k, v in action.items():
-            if v is None:
-                continue
-            key = k if str(k).startswith(ACTION_PREFIX) else f"{ACTION}.{k}"
+        action_names, action_values = _collect_action(action)
+        if action_values:
+            rr.log(ACTION, rr.Scalars(action_values))
+            action_paths.add(ACTION)
 
-            if _is_scalar(v):
-                rr.log(key, rr.Scalars(float(v)))
-                action_paths.add(key)
-            elif isinstance(v, np.ndarray):
-                rr.log(key, rr.Scalars(v.reshape(-1).astype(float)))
-                action_paths.add(key)
+    # On the first call, statically log the per-series names so the grouped batches show a readable
+    # label (e.g. "shoulder_pan.pos") for each line, then send the blueprint.
+    if getattr(log_rerun_data, "blueprint", None) is None:
+        if observation_names:
+            rr.log(OBS_STR, rr.SeriesLines(names=observation_names), static=True)
+        if action_names:
+            rr.log(ACTION, rr.SeriesLines(names=action_names), static=True)
 
     _ensure_blueprint(observation_paths, action_paths, image_paths)

--- a/tests/utils/test_visualization_utils.py
+++ b/tests/utils/test_visualization_utils.py
@@ -42,13 +42,17 @@ def mock_rerun(monkeypatch):
             # Scalars may be built from a single float or from a 1D array batch.
             self.value = value
 
+    class DummySeriesLines:
+        def __init__(self, *, names=None, **kwargs):
+            self.names = names
+
     class DummyImage:
         def __init__(self, arr):
             self.arr = arr
 
         def compress(self, *a, **k):
             return self
-    
+
     class DummyDepthImage:
         def __init__(self, arr, colormap=None):
             self.arr = arr
@@ -80,6 +84,7 @@ def mock_rerun(monkeypatch):
         __package__="rerun",
         __spec__=SimpleNamespace(name="rerun", submodule_search_locations=None),
         Scalars=DummyScalar,
+        SeriesLines=DummySeriesLines,
         Image=DummyImage,
         DepthImage=DummyDepthImage,
         components=SimpleNamespace(Colormap=SimpleNamespace(Viridis="viridis")),
@@ -114,6 +119,14 @@ def _obj_for(calls, key):
         if k == key:
             return obj
     raise KeyError(f"Key {key} not found in calls: {calls}")
+
+
+def _obj_of_type(calls, key, type_name):
+    """Find the first object of a given type logged under a key (a key may be logged more than once)."""
+    for k, obj, _kw in calls:
+        if k == key and type(obj).__name__ == type_name:
+            return obj
+    raise KeyError(f"No {type_name} found under key {key} in calls: {calls}")
 
 
 def _kwargs_for(calls, key):
@@ -152,32 +165,28 @@ def test_log_rerun_data_envtransition_scalars_and_image(mock_rerun):
     action_data = transition.get(TransitionKey.ACTION, {})
     vu.log_rerun_data(observation=obs_data, action=action_data)
 
-    # We expect:
-    # - observation.state.temperature -> Scalars
-    # - observation.camera -> Image (HWC) with static=True
-    # - action.throttle -> Scalars
-    # - action.vector -> single Scalars batch (no per-element suffix)
+    # We expect every scalar/vector to be grouped into a single batch per modality:
+    # - observation -> one Scalars batch (the temperature) + a static SeriesLines for the names
+    # - observation.camera -> Image (HWC) with static=True (images keep their own entity path)
+    # - action -> one Scalars batch (throttle + flattened vector) + a static SeriesLines
     expected_keys = {
-        f"{OBS_STATE}.temperature",
+        "observation",
         "observation.camera",
-        "action.throttle",
-        "action.vector",
+        "action",
     }
     assert set(_keys(calls)) == expected_keys
 
-    # Check scalar types and values
-    temp_obj = _obj_for(calls, f"{OBS_STATE}.temperature")
-    assert type(temp_obj).__name__ == "DummyScalar"
-    assert float(temp_obj.value) == pytest.approx(25.0)
+    # Observation scalars grouped into one batch under "observation"
+    obs_batch = _obj_of_type(calls, "observation", "DummyScalar")
+    np.testing.assert_allclose(np.asarray(obs_batch.value), [25.0])
+    obs_names = _obj_of_type(calls, "observation", "DummySeriesLines")
+    assert obs_names.names == ["state.temperature"]
 
-    throttle_obj = _obj_for(calls, "action.throttle")
-    assert type(throttle_obj).__name__ == "DummyScalar"
-    assert float(throttle_obj.value) == pytest.approx(0.7)
-
-    # 1D vector logged as a single batched Scalars under one entity path
-    vec = _obj_for(calls, "action.vector")
-    assert type(vec).__name__ == "DummyScalar"
-    np.testing.assert_allclose(np.asarray(vec.value), [1.0, 2.0])
+    # Action scalar + flattened vector grouped into one batch under "action"
+    act_batch = _obj_of_type(calls, "action", "DummyScalar")
+    np.testing.assert_allclose(np.asarray(act_batch.value), [0.7, 1.0, 2.0])
+    act_names = _obj_of_type(calls, "action", "DummySeriesLines")
+    assert act_names.names == ["throttle", "vector[0]", "vector[1]"]
 
     # Check image handling: CHW -> HWC
     img_obj = _obj_for(calls, "observation.camera")
@@ -194,11 +203,11 @@ def test_log_rerun_data_envtransition_scalars_and_image(mock_rerun):
     spatial_views = _views_by_kind(bp, "Spatial2DView")
     assert {v.origin for v in spatial_views} == {"observation.camera"}
 
-    # One time-series view each for observation and action scalars
+    # A single time-series view each for the grouped observation and action scalars
     ts_views = {v.name: v for v in _views_by_kind(bp, "TimeSeriesView")}
     assert set(ts_views) == {"observation", "action"}
-    assert ts_views["observation"].contents == [f"{OBS_STATE}.temperature"]
-    assert ts_views["action"].contents == ["action.throttle", "action.vector"]
+    assert ts_views["observation"].contents == ["observation"]
+    assert ts_views["action"].contents == ["action"]
 
 
 def test_log_rerun_data_plain_list_ordering_and_prefixes(mock_rerun):
@@ -221,24 +230,19 @@ def test_log_rerun_data_plain_list_ordering_and_prefixes(mock_rerun):
     # First dict was treated as observation, second as action
     vu.log_rerun_data(observation=obs_plain, action=act_plain)
 
-    # Expected keys with auto-prefixes. The 1D vector is a single batched Scalars.
+    # Keys are grouped: one "observation" batch, one image path, one "action" batch. None is skipped.
     expected = {
-        "observation.temp",
+        "observation",
         "observation.img",
-        "action.throttle",
-        "action.vec",
+        "action",
     }
     logged = set(_keys(calls))
     assert logged == expected
 
-    # Scalars
-    t = _obj_for(calls, "observation.temp")
-    assert type(t).__name__ == "DummyScalar"
-    assert float(t.value) == pytest.approx(1.5)
-
-    throttle = _obj_for(calls, "action.throttle")
-    assert type(throttle).__name__ == "DummyScalar"
-    assert float(throttle.value) == pytest.approx(0.3)
+    # Observation scalar grouped into one batch (the None entry is skipped)
+    obs_batch = _obj_of_type(calls, "observation", "DummyScalar")
+    np.testing.assert_allclose(np.asarray(obs_batch.value), [1.5])
+    assert _obj_of_type(calls, "observation", "DummySeriesLines").names == ["temp"]
 
     # Image stays HWC
     img = _obj_for(calls, "observation.img")
@@ -246,10 +250,15 @@ def test_log_rerun_data_plain_list_ordering_and_prefixes(mock_rerun):
     assert img.arr.shape == (5, 6, 3)
     assert _kwargs_for(calls, "observation.img").get("static", False) is True
 
-    # Vector logged as a single batched Scalars under one entity path
-    vec = _obj_for(calls, "action.vec")
-    assert type(vec).__name__ == "DummyScalar"
-    np.testing.assert_allclose(np.asarray(vec.value), [9, 8, 7])
+    # Action scalar + flattened vector grouped into one batch under "action"
+    act_batch = _obj_of_type(calls, "action", "DummyScalar")
+    np.testing.assert_allclose(np.asarray(act_batch.value), [0.3, 9, 8, 7])
+    assert _obj_of_type(calls, "action", "DummySeriesLines").names == [
+        "throttle",
+        "vec[0]",
+        "vec[1]",
+        "vec[2]",
+    ]
 
     # Blueprint sent once with the expected view layout
     assert len(blueprints) == 1
@@ -257,8 +266,8 @@ def test_log_rerun_data_plain_list_ordering_and_prefixes(mock_rerun):
     spatial_views = _views_by_kind(bp, "Spatial2DView")
     assert {v.origin for v in spatial_views} == {"observation.img"}
     ts_views = {v.name: v for v in _views_by_kind(bp, "TimeSeriesView")}
-    assert ts_views["observation"].contents == ["observation.temp"]
-    assert ts_views["action"].contents == ["action.throttle", "action.vec"]
+    assert ts_views["observation"].contents == ["observation"]
+    assert ts_views["action"].contents == ["action"]
 
 
 def test_log_rerun_data_kwargs_only(mock_rerun):
@@ -270,30 +279,30 @@ def test_log_rerun_data_kwargs_only(mock_rerun):
     )
 
     keys = set(_keys(calls))
-    assert "observation.temp" in keys
+    assert "observation" in keys
     assert "observation.gray" in keys
-    assert "action.a" in keys
+    assert "action" in keys
 
-    temp = _obj_for(calls, "observation.temp")
-    assert type(temp).__name__ == "DummyScalar"
-    assert float(temp.value) == pytest.approx(10.0)
+    temp = _obj_of_type(calls, "observation", "DummyScalar")
+    np.testing.assert_allclose(np.asarray(temp.value), [10.0])
+    assert _obj_of_type(calls, "observation", "DummySeriesLines").names == ["temp"]
 
     img = _obj_for(calls, "observation.gray")
     assert type(img).__name__ == "DummyDepthImage"  # single-channel -> DepthImage
     assert img.arr.shape == (8, 8, 1)  # remains HWC
     assert _kwargs_for(calls, "observation.gray").get("static", False) is True
 
-    a = _obj_for(calls, "action.a")
-    assert type(a).__name__ == "DummyScalar"
-    assert float(a.value) == pytest.approx(1.0)
+    a = _obj_of_type(calls, "action", "DummyScalar")
+    np.testing.assert_allclose(np.asarray(a.value), [1.0])
+    assert _obj_of_type(calls, "action", "DummySeriesLines").names == ["a"]
 
     # Blueprint sent once, with a spatial view for the image and time-series views for scalars
     assert len(blueprints) == 1
     bp = blueprints[0]
     assert {v.origin for v in _views_by_kind(bp, "Spatial2DView")} == {"observation.gray"}
     ts_views = {v.name: v for v in _views_by_kind(bp, "TimeSeriesView")}
-    assert ts_views["observation"].contents == ["observation.temp"]
-    assert ts_views["action"].contents == ["action.a"]
+    assert ts_views["observation"].contents == ["observation"]
+    assert ts_views["action"].contents == ["action"]
 
 
 def test_log_rerun_data_blueprint_sent_only_once(mock_rerun):


### PR DESCRIPTION
Grouping all the free scalars into a vector of scalars with Series lines will generally be more performant and ensure things get grouped into a single plot.