### PR TITLE
feat(policies): add LingBot-VLA

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -77,6 +77,10 @@
     title: Multitask DiT Policy
   - local: walloss
     title: WALL-OSS
+  - local: lingbot_vla
+    title: LingBot-VLA
+  - local: lingbot_vla_deployment
+    title: LingBot-VLA Deployment Protocol
   title: "Policies"
 - sections:
   - local: sarm

--- a/docs/source/lingbot_vla.mdx
+++ b/docs/source/lingbot_vla.mdx
@@ -1,0 +1,106 @@
+# LingBot-VLA
+
+LingBot-VLA is an open-source embodied foundation model from the [LingBot / Robbyant](https://github.com/Robbyant/lingbot-vla) team. The LeRobot implementation is adapted from their open-source [lingbot-vla](https://github.com/Robbyant/lingbot-vla) repository.
+
+LingBot-VLA is now integrated into Hugging Face's LeRobot ecosystem. You can now post-train, evaluate, and deploy LingBot-VLA directly through LeRobot, on the same footing as OpenVLA, π0, SmolVLA, and WALL-OSS. The integration mirrors the WALL-OSS / `wall_x` precedent (Qwen2.5-VL + flow matching), so customizing and deploying LingBot-VLA is a one-line affair.
+
+## Model Overview
+
+LingBot-VLA pairs a **Qwen2.5-VL** multimodal backbone with a **Qwen2 action expert** and **Flow-Matching** continuous action generation, supporting cross-embodiment and bimanual manipulation. Core features:
+
+- **External VLM↔expert KV fusion (LingBot core IP)**: per-layer `compute_kqv` → concatenate prefix/suffix Q/K/V → unified attention → split back by length, rather than framework-internal fusion.
+- **75-D unified state/action space** (`max_state_dim=75`, `max_action_dim=75`, `chunk_size=50`): the key to cross-embodiment alignment; per-slot semantics in the [Deployment Protocol](./lingbot_vla_deployment).
+- **AdaRMSNorm time-conditioned action expert** (flow-matching timestep conditioning).
+- **Optional depth-alignment head** (depth loss + MoGe; experimental, off by default on the main path).
+
+## Installation Requirements
+
+1. Install LeRobot by following our [Installation Guide](./installation).
+2. Install LingBot dependencies by running:
+
+   ```bash
+   pip install -e ".[lingbot]"
+   ```
+
+## Usage
+
+To use LingBot-VLA in LeRobot, specify the policy type as:
+
+```python
+policy.type=lingbot_vla
+```
+
+## Training
+
+For training LingBot-VLA, you can use the standard LeRobot training script with the appropriate configuration:
+
+```bash
+lerobot-train \
+    --dataset.repo_id=your_dataset \
+    --policy.type=lingbot_vla \
+    --output_dir=./outputs/lingbot_training \
+    --job_name=lingbot_training \
+    --policy.repo_id=your_repo_id \
+    --policy.pretrained_name_or_path=robbyant/lingbot-vla-4b \
+    --policy.attention_implementation=eager \
+    --policy.num_steps=10 \
+    --steps=3000 \
+    --policy.device=cuda \
+    --batch_size=32
+```
+
+### Training Arguments
+
+Only LingBot-specific arguments are listed; all other arguments are the standard LeRobot ones.
+
+| Argument                       | Description                                                                                          |
+| ------------------------------ | --------------------------------------------------------------------------------------------------- |
+| `--policy.type`                | Specifies using the LingBot-VLA policy architecture (`lingbot_vla`)                                  |
+| `--policy.pretrained_name_or_path` | Path to pretrained LingBot weights: `robbyant/lingbot-vla-4b` (HF format, loaded directly)        |
+| `--policy.attention_implementation` | Dual-stream attention backend — `eager` (default), `fa2` (needs the flash-attn extra), or `flex`   |
+| `--policy.num_steps`           | Flow-matching denoising steps (default `10`)                                                         |
+| `--policy.loss_type`           | Flow-matching loss: `fm` (MSE, default) / `L1_fm` (L1)                                               |
+| `--policy.chunk_size`          | Action chunk length (default `50`)                                                                   |
+
+## Inference / Deployment
+
+Load the policy and predict actions in a single line:
+
+```python
+from lerobot.policies.lingbot_vla.modeling_lingbot_vla import LingbotVLAPolicy
+from lerobot.policies.lingbot_vla.processor_lingbot_vla import make_lingbot_vla_pre_post_processors
+
+# `config` carries your embodiment's input/output features (camera views, real
+# state/action dims). State and action are padded to the 75-D slots internally.
+policy = LingbotVLAPolicy.from_pretrained("robbyant/lingbot-vla-4b", config=config, strict=True)
+preprocessor, postprocessor = make_lingbot_vla_pre_post_processors(config, dataset_stats=stats)
+
+batch = preprocessor(observation)  # observation: dict of images + state + task string
+action = postprocessor(policy.select_action(batch))
+```
+
+**Single-process in-process is preferred** (the 4B model runs on a single GPU); only real-robot cross-machine deployment needs WebSocket. The WebSocket protocol — fields, shapes, `reset` timing, chunk return convention, and control-frame handling — is documented on the [Deployment Protocol](./lingbot_vla_deployment) sub-page (this resolves the historical "only the 1st episode succeeds" frame-offset bug).
+
+### Quick start (one-line)
+
+A one-line smoke test ships with the integration:
+
+```bash
+bash examples/lingbot_vla/run_lingbot_vla.sh
+```
+
+This loads the policy from a pretrained checkpoint, feeds a synthetic observation (one camera view + real-dim state + a `task` string) through the processor pipeline, runs `select_action`, and asserts a final action vector matching the configured action dimension — verifying the full install → load → infer path end to end. Override the checkpoint with `LINGBOT_CKPT` and the device with `LINGBOT_DEVICE`.
+
+### Robot Config (reBotArm / SO-ARM101 → 75-D slot mapping)
+
+| Embodiment            | LeRobot robot class        | Note                                  |
+| --------------------- | -------------------------- | ------------------------------------- |
+| Seeed reBotArm single | `rebot_b601_follower`      | joint motors, already in main repo    |
+| Seeed reBotArm bimanual | `bi_rebot_b601_follower` | bimanual uses both sides of the 75-D  |
+| SO-ARM101 single      | `so_follower`              | servos                                |
+
+The 75-D slot order, gripper channels, and zero-fill semantics are tabulated per-embodiment in the migration guide (mismatches here are silent — see the Deployment Protocol).
+
+## License
+
+This model follows the **Apache 2.0 License**, consistent with the original [lingbot-vla repository](https://github.com/Robbyant/lingbot-vla).

--- a/docs/source/lingbot_vla_deployment.mdx
+++ b/docs/source/lingbot_vla_deployment.mdx
@@ -1,0 +1,106 @@
+# LingBot-VLA Deployment Protocol Reference
+
+This page documents the client↔server WebSocket inference protocol used by LingBot-VLA for cross-machine real-robot deployment: fields, shapes, `reset` timing, chunk return convention, and control-frame handling. It is the contract that eliminates the historical "frame-offset / only the 1st episode succeeds" bug.
+
+> **Single-process in-process is preferred** (the 4B model runs on a single GPU). Only real-robot cross-machine deployment needs WebSocket.
+
+## 1. Transport overview
+
+| Item               | Convention                                                                                  |
+| ------------------ | ------------------------------------------------------------------------------------------- |
+| Transport          | WebSocket (single long-lived connection), binary frames carrying msgpack                     |
+| Codec              | msgpack (`packb` / `unpackb`)                                                                |
+| Interaction model  | Strict lockstep: send 1, receive 1; the i-th response corresponds to the i-th request (§4)   |
+| Connection life    | One connection per eval session; call `reset` once at the start of every episode (§3)        |
+
+Lockstep is simple but fragile: correctness depends 100% on `send_count == recv_count`. If §4 control frames are handled wrong, you get a permanent off-by-one — the historical root cause.
+
+## 2. infer request / response
+
+**Request `infer` (client → server)** — field names follow the server source.
+
+| Field                        | Type / shape       | Description                                                                                      |
+| ---------------------------- | ------------------ | ----------------------------------------------------------------------------------------------- |
+| `observation.images.<name>`  | uint8 `(H, W, 3)`  | Per-camera image (e.g. `cam_high` / `cam_left_wrist` / `cam_right_wrist`). Key must match `robot_config` or `ValueError`. |
+| `observation.state`          | float `(state_dim,)` | Proprioception, padded per the 75-D slot convention (§5)                                       |
+| `task`                       | str                | Language instruction. (Easy to miss: the `__main__` example uses a pi0 prompt that does not match the real server — copying it silently fails.) |
+
+**Response (server → client)**
+
+| Field        | Shape          | Description                                                                                |
+| ------------ | -------------- | ----------------------------------------------------------------------------------------- |
+| `action`     | float `(T, 14)`| One action chunk, `T = chunk_size` (default 50); 14 = real embodiment action dim (bimanual 6+1 gripper ×2), distinct from the internal 75-D (§5) |
+| `use_length` | int            | Number of steps in the chunk to actually execute (≤ T). The client executes only the first `use_length` steps before re-observing. |
+
+**Chunk open-loop convention**: each `infer` returns `T` steps, executed open-loop (default 50) before re-observing. This amplifies any "one beat late" — being one beat off equals being one whole chunk (~half a second) behind.
+
+## 3. reset request
+
+| Field        | Type        | Description                                          |
+| ------------ | ----------- | --------------------------------------------------- |
+| `reset`      | bool / flag | Marks an episode reset (clears inference-side cache / chunk queue) |
+| `robo_name`  | str         | Embodiment id; selects slot mapping / norm_stats     |
+
+**Timing**: call once at the start of every episode, before any `infer`. Missing `reset` → cross-episode state / chunk residue → artificially low success rate.
+
+## 4. Frame-layer protocol (correctness命门)
+
+A WebSocket multiplexes data frames and control frames on the same TCP stream. The client must consume control frames correctly itself (a raw-socket client is hand-written to dodge py3.10/3.12 `websockets` version conflicts, so no library eats the pings for you).
+
+| opcode | Frame type                         | Required client handling                                 |
+| ------ | ---------------------------------- | -------------------------------------------------------- |
+| `0x02` | binary (msgpack business data)     | The only returnable frame → `unpackb` then return         |
+| `0x09` | ping (server auto-sends every 20s) | Reply one pong, keep reading; **never re-send data**      |
+| `0x0A` | pong                               | Ignore, keep reading                                      |
+| `0x08` | close                              | Raise `ConnectionError`                                   |
+| `0x01` | text                               | Treat as server error traceback, raise `RuntimeError`     |
+
+**Two iron rules (violation = permanent off-by-one):**
+
+1. **Send data exactly once per inference** — the send must be outside the read loop; control-frame branches must never re-send the observation.
+2. **Consume control frames transparently** — on ping/pong do not return and do not re-send; just `continue` to the next frame until a `0x02` arrives.
+
+**Historical failure**: the old `_send_recv` did `return self._send_recv(data)` on ping, and that function re-packs+sends at its top → the same observation is sent twice → the server queues an extra response → every subsequent `infer` returns the previous frame's action → because of the 50-step open-loop chunk, this is equivalent to a full-chunk lag → "usually only the 1st episode succeeds."
+
+### Reference implementation (verified fix)
+
+```python
+def _send_recv(self, data):
+    if self._sock is None:
+        raise ConnectionError("Not connected")
+    self._ws_write_frame(self._sock, self._packer.pack(data))  # send ONCE, outside the loop
+    while True:
+        opcode, raw = self._ws_read_frame(self._sock)
+        if opcode == 0x09:  # ping -> pong
+            self._ws_write_frame(self._sock, raw, opcode=0x0A)
+            continue
+        if opcode == 0x0A:  # pong
+            continue
+        if opcode == 0x08:  # close
+            raise ConnectionError("Server closed connection")
+        if opcode == 0x01:  # text -> server error
+            raise RuntimeError(f"Server error:\n{raw.decode()}")
+        if opcode == 0x02:  # binary -> response
+            return _msgpack_unpackb(raw)
+        raise RuntimeError(f"Unexpected opcode 0x{opcode:02X}")
+```
+
+**Additional rule**: `sock.recv(2)` is not guaranteed to return 2 bytes in one call on TCP; under load, reading the header desyncs. Read the header / length / mask key with `recv_exact(n)` (loop until n bytes are read).
+
+## 5. 75-D ↔ real embodiment dim slot convention (#48 / #49)
+
+- 75-D is the unified training-side maximum (`max_state_dim = max_action_dim = 75`), used for cross-embodiment alignment; unused slots are zero-filled.
+- The real embodiment action is 14-D (bimanual 6 joints + 1 gripper ×2); the on-wire `action` shape is `(T, 14)`.
+- **Must be tabulated per slot**: for each embodiment (reBotArm single/bimanual, SO-ARM101) the 75-D slot order, which slot each joint/gripper channel falls in, and the zero-fill ranges. A wrong slot order or gripper channel is **silent** (no error) and directly causes "gripper opening/closing randomly / actions scrambled" (#47/#48/#49).
+
+> This table is the only line of defense against silent mismatch. Maintain it per-embodiment and keep it in the migration guide.
+
+## 6. Validation checklist (self-check for integrators)
+
+- [ ] Send/recv count 1:1 (`send_cnt += 1` where data is sent, `recv_cnt += 1` where a binary is returned; they must stay equal every `infer`; a fixed delta of 1 is the frame-offset signature).
+- [ ] Disable ping (`serve(ping_interval=None)`); if behavior recovers from the 2nd episode onward, the ping handling is the bug.
+- [ ] The obs image keys match `robot_config` exactly (missing key → `ValueError`; extra/wrong key → partial silent failure).
+- [ ] `task` field present and not the pi0 prompt.
+- [ ] `reset` called at the start of every episode.
+- [ ] `use_length` honored (only the first `use_length` steps executed).
+- [ ] 75-D slots / gripper channels verified against the embodiment table.

--- a/examples/lingbot_vla/run_lingbot_vla.sh
+++ b/examples/lingbot_vla/run_lingbot_vla.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# LingBot-VLA one-line smoke test.
+# Loads the policy from a pretrained checkpoint, feeds a synthetic observation
+# (one camera view + real-dim state + a task string) through the processor
+# pipeline, runs select_action, and asserts a final action vector. Verifies the
+# full install -> load -> infer path end to end.
+#
+# Usage:
+#   bash examples/lingbot_vla/run_lingbot_vla.sh
+#
+# Env overrides:
+#   LINGBOT_CKPT   pretrained path or HF repo id (default: robbyant/lingbot-vla-4b)
+#   LINGBOT_DEVICE cuda | cpu (default: cuda)
+set -euo pipefail
+
+CKPT="${LINGBOT_CKPT:-robbyant/lingbot-vla-4b}"
+DEVICE="${LINGBOT_DEVICE:-cuda}"
+
+python examples/lingbot_vla/smoke_test.py \
+    --pretrained_path "${CKPT}" \
+    --device "${DEVICE}"

--- a/examples/lingbot_vla/smoke_test.py
+++ b/examples/lingbot_vla/smoke_test.py
@@ -1,0 +1,97 @@
+# Copyright 2025 HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""End-to-end smoke test for the LingBot-VLA policy.
+
+Loads the pretrained 4B checkpoint, feeds a synthetic observation (one camera
+view + real-dim state + a task string) through the processor pipeline, runs
+``select_action``, and prints the unnormalized action. Verifies the full
+install -> load -> infer path on a single command.
+
+Usage:
+    python examples/lingbot_vla/smoke_test.py \
+        --pretrained_path robbyant/lingbot-vla-4b --device cuda
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import torch
+
+from lerobot.configs.types import FeatureType, PolicyFeature
+from lerobot.policies.lingbot_vla.configuration_lingbot_vla import LingbotVLAConfig
+from lerobot.policies.lingbot_vla.modeling_lingbot_vla import LingbotVLAPolicy
+from lerobot.policies.lingbot_vla.processor_lingbot_vla import (
+    make_lingbot_vla_pre_post_processors,
+)
+from lerobot.utils.constants import ACTION, OBS_STATE
+
+CAM = "observation.images.cam"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="LingBot-VLA smoke test")
+    parser.add_argument("--pretrained_path", default="robbyant/lingbot-vla-4b")
+    parser.add_argument("--device", default="cuda")
+    parser.add_argument("--state_dim", type=int, default=6)
+    parser.add_argument("--action_dim", type=int, default=6)
+    parser.add_argument("--task", default="pick up the red cube")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    device = args.device
+    dtype = torch.bfloat16 if device.startswith("cuda") else torch.float32
+
+    config = LingbotVLAConfig(device=device, attention_implementation="eager")
+    config.input_features = {
+        CAM: PolicyFeature(type=FeatureType.VISUAL, shape=(3, 480, 640)),
+        OBS_STATE: PolicyFeature(type=FeatureType.STATE, shape=(args.state_dim,)),
+    }
+    config.output_features = {ACTION: PolicyFeature(type=FeatureType.ACTION, shape=(args.action_dim,))}
+
+    dataset_stats = {
+        OBS_STATE: {"mean": torch.zeros(args.state_dim), "std": torch.ones(args.state_dim)},
+        ACTION: {"mean": torch.zeros(args.action_dim), "std": torch.ones(args.action_dim)},
+    }
+
+    print(f"Loading {args.pretrained_path} (strict) ...", flush=True)
+    policy = LingbotVLAPolicy.from_pretrained(args.pretrained_path, config=config, strict=True)
+    policy = policy.to(device=device, dtype=dtype)
+    policy.eval()
+
+    preprocessor, postprocessor = make_lingbot_vla_pre_post_processors(
+        config=config, dataset_stats=dataset_stats
+    )
+
+    obs = {
+        CAM: torch.rand(3, 480, 640),
+        OBS_STATE: torch.randn(args.state_dim),
+        "task": args.task,
+    }
+
+    batch = preprocessor(obs)
+    with torch.no_grad():
+        action = policy.select_action(batch)
+        action = postprocessor(action)
+
+    print(f"action shape: {tuple(action.shape)} device: {action.device}", flush=True)
+    assert action.shape[-1] == args.action_dim, action.shape
+    print("LINGBOT_VLA_SMOKE_OK", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -210,6 +210,12 @@ wallx = [
     "torchdiffeq>=0.2.4,<0.3.0",
     "lerobot[qwen-vl-utils-dep]",
 ]
+lingbot = [
+    "lerobot[transformers-dep]",
+    "lerobot[peft-dep]",
+    "lerobot[scipy-dep]",
+    "lerobot[qwen-vl-utils-dep]",
+]
 pi = ["lerobot[transformers-dep]", "lerobot[scipy-dep]"]
 molmoact2 = ["lerobot[transformers-dep]", "lerobot[peft-dep]", "lerobot[scipy-dep]"]
 smolvla = ["lerobot[transformers-dep]", "num2words>=0.5.14,<0.6.0", "lerobot[accelerate-dep]"]
@@ -305,6 +311,7 @@ all = [
     "lerobot[diffusion]",
     "lerobot[multi_task_dit]",
     "lerobot[wallx]",
+    "lerobot[lingbot]",
     "lerobot[pi]",
     "lerobot[molmoact2]",
     "lerobot[smolvla]",
@@ -404,6 +411,7 @@ ignore = [
 # E402: conditional-import guards (TYPE_CHECKING / is_package_available) must precede the imports they protect
 "src/lerobot/scripts/convert_dataset_v21_to_v30.py" = ["E402"]
 "src/lerobot/policies/wall_x/**" = ["N801", "N812", "SIM102", "SIM108", "SIM210", "SIM211", "B006", "B007", "SIM118"] # Supprese these as they are coming from original Qwen2_5_vl code TODO(pepijn): refactor original
+"src/lerobot/policies/lingbot_vla/**" = ["N801", "N806", "N812", "SIM102", "SIM108", "SIM210", "SIM211", "B006", "B007", "SIM118"] # Suppressed: adapted from original Qwen2.5-VL code
 
 [tool.ruff.lint.isort]
 combine-as-imports = true

--- a/src/lerobot/policies/factory.py
+++ b/src/lerobot/policies/factory.py
@@ -49,6 +49,7 @@ from .diffusion.configuration_diffusion import DiffusionConfig
 from .eo1.configuration_eo1 import EO1Config
 from .gaussian_actor.configuration_gaussian_actor import GaussianActorConfig
 from .groot.configuration_groot import GrootConfig
+from .lingbot_vla.configuration_lingbot_vla import LingbotVLAConfig
 from .molmoact2.configuration_molmoact2 import MolmoAct2Config
 from .multi_task_dit.configuration_multi_task_dit import MultiTaskDiTConfig
 from .pi0.configuration_pi0 import PI0Config
@@ -150,6 +151,10 @@ def get_policy_class(name: str) -> type[PreTrainedPolicy]:
         from .wall_x.modeling_wall_x import WallXPolicy
 
         return WallXPolicy
+    elif name == "lingbot_vla":
+        from .lingbot_vla.modeling_lingbot_vla import LingbotVLAPolicy
+
+        return LingbotVLAPolicy
     elif name == "eo1":
         from .eo1.modeling_eo1 import EO1Policy
 
@@ -212,6 +217,8 @@ def make_policy_config(policy_type: str, **kwargs) -> PreTrainedConfig:
         return XVLAConfig(**kwargs)
     elif policy_type == "wall_x":
         return WallXConfig(**kwargs)
+    elif policy_type == "lingbot_vla":
+        return LingbotVLAConfig(**kwargs)
     elif policy_type == "eo1":
         return EO1Config(**kwargs)
     elif policy_type == "molmoact2":

--- a/src/lerobot/policies/lingbot_vla/README.md
+++ b/src/lerobot/policies/lingbot_vla/README.md
@@ -1,0 +1,26 @@
+# LingBot-VLA
+
+LingBot-VLA is an open-source vision-language-action model integrated into LeRobot as
+the `lingbot_vla` policy. It pairs a **Qwen2.5-VL** multimodal backbone with a **Qwen2
+action expert** and **Flow-Matching** continuous action generation over a unified 75-D
+state/action space, supporting cross-embodiment and bimanual manipulation.
+
+Full documentation: [`docs/source/lingbot_vla.mdx`](../../../../docs/source/lingbot_vla.mdx)
+and the [Deployment Protocol](../../../../docs/source/lingbot_vla_deployment.mdx).
+
+## Install
+
+```bash
+pip install -e ".[lingbot]"
+```
+
+## Usage
+
+```bash
+lerobot-train --policy.type=lingbot_vla ...
+```
+
+The vendored Qwen2.5-VL backbone lives in [`qwen_model/`](./qwen_model) and is adapted
+from HuggingFace Transformers. Flash-attention is optional: the policy defaults to the
+`eager` attention implementation and only uses `flash_attention_2` when explicitly
+requested via the config (and when the `flash-attn` package is installed).

--- a/src/lerobot/policies/lingbot_vla/__init__.py
+++ b/src/lerobot/policies/lingbot_vla/__init__.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .configuration_lingbot_vla import LingbotVLAConfig
+
+# NOTE: LingbotVLAPolicy is intentionally NOT imported here. It pulls in heavy
+# optional deps (transformers Qwen2.5-VL, etc.) and is loaded lazily by the policy
+# factory only when policy.type == "lingbot_vla".
+__all__ = ["LingbotVLAConfig"]

--- a/src/lerobot/policies/lingbot_vla/configuration_lingbot_vla.py
+++ b/src/lerobot/policies/lingbot_vla/configuration_lingbot_vla.py
@@ -1,0 +1,182 @@
+# Copyright 2025 HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass, field
+
+from lerobot.configs import FeatureType, NormalizationMode, PolicyFeature, PreTrainedConfig
+from lerobot.optim import AdamWConfig, CosineDecayWithWarmupSchedulerConfig
+from lerobot.utils.constants import ACTION, OBS_STATE
+
+
+@PreTrainedConfig.register_subclass("lingbot_vla")
+@dataclass
+class LingbotVLAConfig(PreTrainedConfig):
+    """
+    Configuration class for the LingBot-VLA policy.
+
+    LingBot-VLA is a Qwen2.5-VL based vision-language-action model that predicts
+    action chunks via flow matching. It supports cross-embodiment control through a
+    unified 75-dim state/action representation and an optional depth-distillation branch.
+    """
+
+    # ==================== Input / Output Structure ====================
+    n_obs_steps: int = 1
+    chunk_size: int = 50  # action_horizon in LingBot-VLA
+    n_action_steps: int = 50
+
+    # Unified cross-embodiment slots (padded to these dims).
+    max_action_dim: int = 75
+    max_state_dim: int = 75
+
+    normalization_mapping: dict[str, NormalizationMode] = field(
+        default_factory=lambda: {
+            "VISUAL": NormalizationMode.IDENTITY,
+            "STATE": NormalizationMode.MEAN_STD,
+            "ACTION": NormalizationMode.MEAN_STD,
+        }
+    )
+
+    # ==================== Pretrained backbone ====================
+    pretrained_name_or_path: str = "robbyant/lingbot-vla-4b"
+    tokenizer_path: str = "Qwen/Qwen2.5-VL-3B-Instruct"
+    tokenizer_max_length: int = 72
+
+    # Image resize target (width, height) applied before Qwen2.5-VL patchification.
+    resize_imgs_with_padding: tuple[int, int] = (224, 224)
+
+    # Number of flow-matching denoising steps at inference.
+    num_steps: int = 10
+
+    # ==================== Optional depth distillation branch ====================
+    # Only used by the LingBot-VLA-4B-Depth variant.
+    use_depth: bool = False
+    num_task_tokens: int = 8
+
+    # ==================== Modeling internals (FlowMatching / dual-stream expert) ====================
+    # Attention used inside the vendored dual-stream model, one of {"eager", "fa2", "flex"}.
+    # "eager" is the safe default and required where flash-attn is unavailable.
+    attention_implementation: str = "eager"
+    use_cache: bool = True
+    freeze_vision_encoder: bool = True
+    train_expert_only: bool = True
+    train_state_proj: bool = True
+    # 0 keeps the Qwen2.5-VL vocab as-is (no resize).
+    vocab_size: int = 0
+    use_lm_head: bool = False
+    loss_type: str = "fm"  # flow-matching MSE loss ("L1_fm" for L1)
+    # Empty dict disables the depth-alignment heads (no-depth checkpoint).
+    align_params: dict = field(default_factory=dict)
+
+    # Adaptive layernorm settings for the action expert. The 4B checkpoint was
+    # trained with adanorm_time=True, which replaces the expert RMSNorms with
+    # AdaNorm modules (gamma/beta nn.Linear from the time embedding). The rest
+    # match the LingBot training defaults (arguments.py).
+    adanorm_time: bool = True
+    split_gate_liner: bool = False
+    nosplit_gate_liner: bool = False
+    separate_time_proj: bool = False
+    final_norm_adanorm: bool = False
+    norm_qkv: bool = False
+
+    # ==================== Optimizer / Scheduler Presets ====================
+    optimizer_lr: float = 5e-5
+    optimizer_betas: tuple[float, float] = (0.9, 0.95)
+    optimizer_eps: float = 1e-8
+    optimizer_weight_decay: float = 0.01
+    optimizer_grad_clip_norm: float = 1.0
+
+    scheduler_warmup_steps: int = 1000
+    scheduler_decay_steps: int = 40000
+    scheduler_decay_lr: float = 5e-5  # constant lr schedule (decay_lr == peak_lr)
+
+    def __post_init__(self):
+        super().__post_init__()
+
+        if self.n_action_steps > self.chunk_size:
+            raise ValueError(
+                f"The chunk size is the upper bound for the number of action steps per model invocation. Got "
+                f"{self.n_action_steps} for `n_action_steps` and {self.chunk_size} for `chunk_size`."
+            )
+
+        if self.attention_implementation not in ["eager", "fa2", "flex"]:
+            raise ValueError(
+                f"attention_implementation must be one of 'eager', 'fa2', 'flex', "
+                f"got {self.attention_implementation}"
+            )
+
+    def validate_features(self) -> None:
+        """Validate and set up input/output features."""
+        image_features = [key for key, feat in self.input_features.items() if feat.type == FeatureType.VISUAL]
+        if not image_features:
+            raise ValueError(
+                "LingBot-VLA policy requires at least one visual input feature. "
+                "No features of type FeatureType.VISUAL found in input_features."
+            )
+
+        if OBS_STATE not in self.input_features:
+            self.input_features[OBS_STATE] = PolicyFeature(
+                type=FeatureType.STATE,
+                shape=(self.max_state_dim,),
+            )
+        else:
+            state_shape = self.input_features[OBS_STATE].shape
+            state_dim = state_shape[0] if state_shape else 0
+            if state_dim > self.max_state_dim:
+                raise ValueError(
+                    f"State dimension {state_dim} exceeds max_state_dim {self.max_state_dim}. "
+                    f"Either reduce state dimension or increase max_state_dim in config."
+                )
+
+        if ACTION not in self.output_features:
+            self.output_features[ACTION] = PolicyFeature(
+                type=FeatureType.ACTION,
+                shape=(self.max_action_dim,),
+            )
+        else:
+            action_shape = self.output_features[ACTION].shape
+            action_dim = action_shape[0] if action_shape else 0
+            if action_dim > self.max_action_dim:
+                raise ValueError(
+                    f"Action dimension {action_dim} exceeds max_action_dim {self.max_action_dim}. "
+                    f"Either reduce action dimension or increase max_action_dim in config."
+                )
+
+    def get_optimizer_preset(self) -> AdamWConfig:
+        return AdamWConfig(
+            lr=self.optimizer_lr,
+            betas=self.optimizer_betas,
+            eps=self.optimizer_eps,
+            weight_decay=self.optimizer_weight_decay,
+            grad_clip_norm=self.optimizer_grad_clip_norm,
+        )
+
+    def get_scheduler_preset(self):
+        return CosineDecayWithWarmupSchedulerConfig(
+            peak_lr=self.optimizer_lr,
+            decay_lr=self.scheduler_decay_lr,
+            num_warmup_steps=self.scheduler_warmup_steps,
+            num_decay_steps=self.scheduler_decay_steps,
+        )
+
+    @property
+    def observation_delta_indices(self) -> list:
+        return None
+
+    @property
+    def action_delta_indices(self) -> list:
+        return list(range(self.chunk_size))
+
+    @property
+    def reward_delta_indices(self) -> None:
+        return None

--- a/src/lerobot/policies/lingbot_vla/flex_attention.py
+++ b/src/lerobot/policies/lingbot_vla/flex_attention.py
@@ -1,0 +1,138 @@
+# Copyright 2024 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+import torch.nn.functional as F  # noqa: N812
+from packaging.version import Version
+
+if Version(torch.__version__) > Version("2.5.0"):
+    # Ffex attention is only available from torch 2.5 onwards
+    from torch.nn.attention.flex_attention import (
+        _mask_mod_signature,
+        _round_up_to_multiple,
+        create_block_mask,
+        create_mask,
+        flex_attention,
+    )
+
+# more aggressive compile setting
+_flex_attention = torch.compile(flex_attention, mode="max-autotune-no-cudagraphs")
+
+
+def flex_attention_forward(
+    query_states: torch.Tensor,
+    key_states: torch.Tensor,
+    value_states: torch.Tensor,
+    attention_mask: torch.Tensor,
+    scaling=None,
+):
+    """
+    This is defined out of classes to make compile happy.
+    """
+    batch_size, seq_len, num_att_heads, head_dim = query_states.shape
+    original_dtype = query_states.dtype
+    # num_key_value_heads = key_states.shape[2]
+    # num_key_value_groups = num_att_heads // num_key_value_heads
+
+    query_states = query_states.transpose(1, 2)
+    key_states = key_states.transpose(1, 2)
+    value_states = value_states.transpose(1, 2)
+
+    query_states = query_states.to(torch.float32)
+    key_states = key_states.to(torch.float32)
+    value_states = value_states.to(torch.float32)
+
+    causal_mask = attention_mask
+    if causal_mask is not None:
+        causal_mask = causal_mask[:, None, :, : key_states.shape[2]]
+
+        if causal_mask.shape[1] == 1 and query_states.shape[1] > 1:
+            causal_mask = causal_mask.expand(-1, query_states.shape[1], -1, -1)
+
+    def precomputed_mask_factory(precomputed_mask: torch.Tensor) -> _mask_mod_signature:
+        def mask_mod(b, h, q_idx, kv_idx):
+            # Danger zone: if b,h,q_idx,kv_idx exceed the shape, device-side assert occurs.
+            return precomputed_mask[b][h][q_idx][kv_idx]
+
+        return mask_mod
+
+    b_mask, h_mask, q_len, kv_len = causal_mask.shape  # The shape of your mask
+
+    block_size = 128  # some gpus do not support 64
+    q_len_rounded = _round_up_to_multiple(q_len, block_size)
+    kv_len_rounded = _round_up_to_multiple(kv_len, block_size)
+
+    # *CRITICAL* we do need to expand here, else we get a CUDA index error
+
+    pad_q = q_len_rounded - q_len
+    pad_k = kv_len_rounded - kv_len
+
+    if pad_q > 0:
+        query_states = F.pad(query_states, (0, 0, 0, pad_q), value=0.0)  # [B, H, q_len_rounded, D]
+    if pad_k > 0:
+        key_states = F.pad(key_states, (0, 0, 0, pad_k), value=0.0)
+        value_states = F.pad(value_states, (0, 0, 0, pad_k), value=0.0)
+    padded_causal_mask = F.pad(causal_mask, (0, pad_k, 0, pad_q), value=0.0)
+    mask_mod_fn_orig = precomputed_mask_factory(padded_causal_mask)
+
+    mask_4d = create_mask(
+        mod_fn=mask_mod_fn_orig,
+        B=b_mask,
+        H=h_mask,
+        Q_LEN=q_len_rounded,
+        KV_LEN=kv_len_rounded,
+        device=causal_mask.device,
+    )
+
+    mask_mod_fn_padded = precomputed_mask_factory(mask_4d)
+    block_mask = create_block_mask(
+        mask_mod=mask_mod_fn_padded,
+        B=b_mask,
+        H=h_mask,
+        Q_LEN=q_len_rounded,
+        KV_LEN=kv_len_rounded,
+        BLOCK_SIZE=block_size,
+        device=causal_mask.device,
+        _compile=False,
+    )
+
+    #  mask is applied inside the kernel, ideally more efficiently than score_mod.
+    attn_output = _flex_attention(
+        query_states,
+        key_states,
+        value_states,
+        block_mask=block_mask,
+        kernel_options={
+            "BLOCK_M": 32,
+            "BLOCK_N": 32,
+            "BLOCK_M1": 32,
+            "BLOCK_N1": 32,
+            "BLOCK_M2": 32,
+            "BLOCK_N2": 32,
+            "num_stages": 2,
+            "num_warps": 4,
+        },
+        enable_gqa=True,  # because we shaped query/key states for GQA
+        scale=head_dim**-0.5
+        if scaling is None
+        else scaling,  # on certain device, the head_dim ** 0.5 break compile !
+    )
+    attn_output = attn_output[:, :, :seq_len, :].to(dtype=original_dtype)
+    attn_output = attn_output.transpose(1, 2).contiguous()  # [B, Q_LEN, H, head_dim]
+    attn_output = attn_output.reshape(
+        batch_size,
+        -1,
+        attn_output.shape[2] * attn_output.shape[3],  # merges [H, head_dim]
+    )
+    return attn_output

--- a/src/lerobot/policies/lingbot_vla/modeling_lingbot_vla.py
+++ b/src/lerobot/policies/lingbot_vla/modeling_lingbot_vla.py
@@ -1,0 +1,2111 @@
+#!/usr/bin/env python
+
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections import deque
+from collections.abc import Callable
+from functools import partial
+from typing import TypedDict
+
+import einops
+import torch
+import torch.nn.functional as F
+from torch import Tensor, nn
+from transformers import (
+    AutoConfig,
+    AutoTokenizer,
+    PretrainedConfig,
+    PreTrainedModel,
+)
+from transformers.activations import ACT2FN
+from transformers.cache_utils import Cache, DynamicCache, SlidingWindowCache, StaticCache
+from transformers.generation import GenerationMixin
+from transformers.modeling_attn_mask_utils import AttentionMaskConverter
+from transformers.modeling_flash_attention_utils import FlashAttentionKwargs
+from transformers.modeling_outputs import (
+    BaseModelOutputWithPast,
+    CausalLMOutputWithPast,
+)
+from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS, dynamic_rope_update
+from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
+from transformers.models.auto import CONFIG_MAPPING
+from transformers.models.qwen2.configuration_qwen2 import Qwen2Config
+from transformers.processing_utils import Unpack
+from transformers.utils import (
+    add_start_docstrings,
+    add_start_docstrings_to_model_forward,
+    can_return_tuple,
+    logging,
+    replace_return_docstrings,
+)
+from transformers.utils.deprecation import deprecate_kwarg
+
+from lerobot.policies.pretrained import PreTrainedPolicy
+from lerobot.policies.utils import populate_queues
+from lerobot.utils.constants import ACTION, OBS_STATE
+
+from .configuration_lingbot_vla import LingbotVLAConfig
+from .flex_attention import flex_attention_forward
+from .qwen_model.qwenvl_in_vla import (
+    Qwen2_5_VLForConditionalGeneration,
+    Qwen2_5_VLModel,
+    Qwen2_5_VLPreTrainedModel,
+)
+from .utils import (
+    apply_rope,
+    create_sinusoidal_pos_embedding,
+    make_att_2d_masks,
+    our_eager_attention_forward,
+    sample_beta,
+)
+
+
+# `LossKwargs` was removed from `transformers.utils` in transformers>=5.0; it is only
+# used here as a TypedDict base for loss-related forward kwargs, so define a local shim.
+class LossKwargs(TypedDict, total=False):
+    num_items_in_batch: int | None
+
+
+logger = logging.get_logger(__name__)
+
+_CHECKPOINT_FOR_DOC = "meta-qwen2/Qwen2-2-7b-hf"
+_CONFIG_FOR_DOC = "Qwen2Config"
+
+
+# Depth-alignment heads are only needed for the LingBot-VLA-*-Depth checkpoints. They are
+# imported lazily (see FlowMatching.init_depth_heads) so the no-depth model has no extra deps.
+
+
+class Qwen2MLP(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.config = config
+        self.hidden_size = config.hidden_size
+        self.intermediate_size = config.intermediate_size
+        self.gate_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
+        self.up_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
+        self.down_proj = nn.Linear(self.intermediate_size, self.hidden_size, bias=False)
+        self.act_fn = ACT2FN[config.hidden_act]
+
+    def forward(self, x):
+        down_proj = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))
+        return down_proj
+
+
+def rotate_half(x):
+    """Rotates half the hidden dims of the input."""
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def apply_rotary_pos_emb(q, k, cos, sin, position_ids=None, unsqueeze_dim=1):
+    """Applies Rotary Position Embedding to the query and key tensors.
+
+    Args:
+        q (`torch.Tensor`): The query tensor.
+        k (`torch.Tensor`): The key tensor.
+        cos (`torch.Tensor`): The cosine part of the rotary embedding.
+        sin (`torch.Tensor`): The sine part of the rotary embedding.
+        position_ids (`torch.Tensor`, *optional*):
+            Deprecated and unused.
+        unsqueeze_dim (`int`, *optional*, defaults to 1):
+            The 'unsqueeze_dim' argument specifies the dimension along which to unsqueeze cos[position_ids] and
+            sin[position_ids] so that they can be properly broadcasted to the dimensions of q and k. For example, note
+            that cos[position_ids] and sin[position_ids] have the shape [batch_size, seq_len, head_dim]. Then, if q and
+            k have the shape [batch_size, heads, seq_len, head_dim], then setting unsqueeze_dim=1 makes
+            cos[position_ids] and sin[position_ids] broadcastable to the shapes of q and k. Similarly, if q and k have
+            the shape [batch_size, seq_len, heads, head_dim], then set unsqueeze_dim=2.
+    Returns:
+        `tuple(torch.Tensor)` comprising of the query and key tensors rotated using the Rotary Position Embedding.
+    """
+    cos = cos.unsqueeze(unsqueeze_dim)
+    sin = sin.unsqueeze(unsqueeze_dim)
+    q_embed = (q * cos) + (rotate_half(q) * sin)
+    k_embed = (k * cos) + (rotate_half(k) * sin)
+    return q_embed, k_embed
+
+
+def repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
+    """
+    This is the equivalent of torch.repeat_interleave(x, dim=1, repeats=n_rep). The hidden states go from (batch,
+    num_key_value_heads, seqlen, head_dim) to (batch, num_attention_heads, seqlen, head_dim)
+    """
+    batch, num_key_value_heads, slen, head_dim = hidden_states.shape
+    if n_rep == 1:
+        return hidden_states
+    hidden_states = hidden_states[:, :, None, :, :].expand(batch, num_key_value_heads, n_rep, slen, head_dim)
+    return hidden_states.reshape(batch, num_key_value_heads * n_rep, slen, head_dim)
+
+
+def eager_attention_forward(
+    module: nn.Module,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attention_mask: torch.Tensor | None,
+    scaling: float,
+    dropout: float = 0.0,
+    **kwargs,
+):
+    key_states = repeat_kv(key, module.num_key_value_groups)
+    value_states = repeat_kv(value, module.num_key_value_groups)
+
+    attn_weights = torch.matmul(query, key_states.transpose(2, 3)) * scaling
+    if attention_mask is not None:
+        causal_mask = attention_mask[:, :, :, : key_states.shape[-2]]
+        attn_weights = attn_weights + causal_mask
+
+    attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query.dtype)
+    attn_weights = nn.functional.dropout(attn_weights, p=dropout, training=module.training)
+    attn_output = torch.matmul(attn_weights, value_states)
+    attn_output = attn_output.transpose(1, 2).contiguous()
+
+    return attn_output, attn_weights
+
+
+class Qwen2Attention(nn.Module):
+    """Multi-headed attention from 'Attention Is All You Need' paper"""
+
+    def __init__(self, config: Qwen2Config, layer_idx: int):
+        super().__init__()
+        self.config = config
+        self.layer_idx = layer_idx
+        self.head_dim = getattr(config, "head_dim", config.hidden_size // config.num_attention_heads)
+        self.num_key_value_groups = config.num_attention_heads // config.num_key_value_heads
+        self.scaling = self.head_dim**-0.5
+        self.attention_dropout = config.attention_dropout
+        self.is_causal = True
+        self.q_proj = nn.Linear(config.hidden_size, config.num_attention_heads * self.head_dim, bias=True)
+        self.k_proj = nn.Linear(config.hidden_size, config.num_key_value_heads * self.head_dim, bias=True)
+        self.v_proj = nn.Linear(config.hidden_size, config.num_key_value_heads * self.head_dim, bias=True)
+        self.o_proj = nn.Linear(config.num_attention_heads * self.head_dim, config.hidden_size, bias=False)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor],
+        attention_mask: torch.Tensor | None,
+        past_key_value: Cache | None = None,
+        cache_position: torch.LongTensor | None = None,
+        **kwargs: Unpack[FlashAttentionKwargs],
+    ) -> tuple[torch.Tensor, torch.Tensor | None, tuple[torch.Tensor] | None]:
+        input_shape = hidden_states.shape[:-1]
+        hidden_shape = (*input_shape, -1, self.head_dim)
+
+        query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1, 2)
+        key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1, 2)
+        value_states = self.v_proj(hidden_states).view(hidden_shape).transpose(1, 2)
+
+        cos, sin = position_embeddings
+        query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin)
+
+        if past_key_value is not None:
+            # sin and cos are specific to RoPE models; cache_position needed for the static cache
+            cache_kwargs = {"sin": sin, "cos": cos, "cache_position": cache_position}
+            key_states, value_states = past_key_value.update(
+                key_states, value_states, self.layer_idx, cache_kwargs
+            )
+
+        sliding_window = None
+        if (
+            self.config.use_sliding_window
+            and getattr(self.config, "sliding_window", None) is not None
+            and self.layer_idx >= self.config.max_window_layers
+        ):
+            sliding_window = self.config.sliding_window
+
+        attention_interface: Callable = eager_attention_forward
+        if self.config._attn_implementation != "eager":
+            if self.config._attn_implementation == "sdpa" and kwargs.get("output_attentions", False):
+                logger.warning_once(
+                    "`torch.nn.functional.scaled_dot_product_attention` does not support `output_attentions=True`. Falling back to "
+                    'eager attention. This warning can be removed using the argument `attn_implementation="eager"` when loading the model.'
+                )
+            else:
+                attention_interface = ALL_ATTENTION_FUNCTIONS[self.config._attn_implementation]
+
+        attn_output, attn_weights = attention_interface(
+            self,
+            query_states,
+            key_states,
+            value_states,
+            attention_mask,
+            dropout=0.0 if not self.training else self.attention_dropout,
+            scaling=self.scaling,
+            sliding_window=sliding_window,  # main diff with Llama
+            **kwargs,
+        )
+
+        attn_output = attn_output.reshape(*input_shape, -1).contiguous()
+        attn_output = self.o_proj(attn_output)
+        return attn_output, attn_weights
+
+
+class Qwen2RMSNorm(nn.Module):
+    def __init__(self, hidden_size, eps=1e-6):
+        """
+        Qwen2RMSNorm is equivalent to T5LayerNorm
+        """
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(hidden_size))
+        self.variance_epsilon = eps
+
+    def forward(self, hidden_states):
+        input_dtype = hidden_states.dtype
+        hidden_states = hidden_states.to(torch.float32)
+        variance = hidden_states.pow(2).mean(-1, keepdim=True)
+        hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
+        return self.weight * hidden_states.to(input_dtype)
+
+    def extra_repr(self):
+        return f"{tuple(self.weight.shape)}, eps={self.variance_epsilon}"
+
+
+class FixQwen2RMSNorm(nn.Module):
+    def __init__(self, hidden_size, eps=1e-6):
+        """
+        FixQwen2RMSNorm is equivalent to T5LayerNorm
+        """
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(hidden_size))
+        self.variance_epsilon = eps
+
+    def forward(self, hidden_states):
+        input_dtype = hidden_states.dtype
+        hidden_states = hidden_states.to(torch.float32)
+        variance = hidden_states.pow(2).mean(-1, keepdim=True)
+        hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
+        return self.weight * hidden_states.to(input_dtype)
+
+    def extra_repr(self):
+        return f"{tuple(self.weight.shape)}, eps={self.variance_epsilon}"
+
+
+class Qwen2DecoderLayer(nn.Module):
+    def __init__(self, config: Qwen2Config, layer_idx: int):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.self_attn = Qwen2Attention(config=config, layer_idx=layer_idx)
+        self.mlp = Qwen2MLP(config)
+        self.input_layernorm = Qwen2RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = Qwen2RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+        if config.norm_qkv:
+            self.q_layernorm = Qwen2RMSNorm(self.self_attn.head_dim, eps=config.rms_norm_eps)
+            self.k_layernorm = Qwen2RMSNorm(self.self_attn.head_dim, eps=config.rms_norm_eps)
+
+        if config.sliding_window and config._attn_implementation != "flash_attention_2":
+            logger.warning_once(
+                f"Sliding Window Attention is enabled but not implemented for `{config._attn_implementation}`; "
+                "unexpected results may be encountered."
+            )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        att_output: torch.Tensor | None = None,
+        start: int | None = 0,
+        end: int | None = 0,
+        compute_kqv: bool = False,
+        norm_qkv: bool = False,
+        output_atten: bool = False,
+        ada_cond: torch.Tensor | None = None,
+        gate: torch.Tensor | None = None,
+        **kwargs: Unpack[FlashAttentionKwargs],
+    ) -> tuple[torch.FloatTensor, tuple[torch.FloatTensor, torch.FloatTensor] | None]:
+        if compute_kqv:
+            if ada_cond is not None:
+                hidden_states = self.input_layernorm(hidden_states, ada_cond)
+                gate = None
+            else:
+                hidden_states = self.input_layernorm(hidden_states)
+                gate = None
+            hidden_shape = (*hidden_states.shape[:-1], -1, self.self_attn.head_dim)
+
+            query_state = self.self_attn.q_proj(hidden_states).view(hidden_shape)
+            key_state = self.self_attn.k_proj(hidden_states).view(hidden_shape)
+            value_state = self.self_attn.v_proj(hidden_states).view(hidden_shape)
+            if norm_qkv:
+                query_state = self.q_layernorm(query_state)
+                key_state = self.k_layernorm(key_state)
+
+            return query_state, key_state, value_state, gate
+
+        elif output_atten:
+            if att_output.dtype != self.self_attn.o_proj.weight.dtype:
+                att_output = att_output.to(self.self_attn.o_proj.weight.dtype)
+            out_emb = self.self_attn.o_proj(att_output[:, start:end])
+
+            # first residual
+            if gate is not None:
+                out_emb = out_emb * gate + hidden_states
+            else:
+                out_emb += hidden_states
+            after_first_residual = out_emb.clone()
+            if ada_cond is not None:
+                out_emb = self.post_attention_layernorm(out_emb, ada_cond)
+                after_gate = None
+            else:
+                out_emb = self.post_attention_layernorm(out_emb)
+                after_gate = None
+            out_emb = self.mlp(out_emb)
+
+            # second residual
+            if after_gate is not None:
+                out_emb = out_emb * after_gate + after_first_residual
+            else:
+                out_emb += after_first_residual
+
+            return out_emb
+
+        else:
+            raise ValueError(
+                f"Invaild Operation compute_kqv={compute_kqv} and output_atten={output_atten} with Qwen2DecoderLayer in LingBot-VLA"
+            )
+
+
+class Qwen2RotaryEmbedding(nn.Module):
+    def __init__(self, config: Qwen2Config, device=None):
+        super().__init__()
+        # BC: "rope_type" was originally "type"
+        if hasattr(config, "rope_scaling") and config.rope_scaling is not None:
+            self.rope_type = config.rope_scaling.get("rope_type", config.rope_scaling.get("type"))
+        else:
+            self.rope_type = "default"
+        self.max_seq_len_cached = config.max_position_embeddings
+        self.original_max_seq_len = config.max_position_embeddings
+
+        self.config = config
+        # transformers>=5.0 dropped the "default" key from ROPE_INIT_FUNCTIONS.
+        # In the dual-stream VLA path rope is applied externally via utils.apply_rope,
+        # so this embedding only needs to instantiate; fall back to the standard
+        # (non-scaled) inv_freq computation for "default"/unknown rope types.
+        if self.rope_type in ROPE_INIT_FUNCTIONS:
+            self.rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]
+            inv_freq, self.attention_scaling = self.rope_init_fn(self.config, device)
+        else:
+            base = getattr(config, "rope_theta", None)
+            if base is None and config.rope_scaling is not None:
+                base = config.rope_scaling.get("rope_theta", 10000.0)
+            base = base if base is not None else 10000.0
+            head_dim = getattr(config, "head_dim", config.hidden_size // config.num_attention_heads)
+            inv_freq = 1.0 / (
+                base ** (torch.arange(0, head_dim, 2, dtype=torch.int64).to(device).float() / head_dim)
+            )
+            self.attention_scaling = 1.0
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self.original_inv_freq = self.inv_freq
+
+    @torch.no_grad()
+    @dynamic_rope_update  # power user: used with advanced RoPE types (e.g. dynamic rope)
+    def forward(self, x, position_ids):
+        inv_freq_expanded = (
+            self.inv_freq[None, :, None].float().expand(position_ids.shape[0], -1, 1).to(x.device)
+        )
+        position_ids_expanded = position_ids[:, None, :].float()
+
+        device_type = x.device.type if isinstance(x.device.type, str) and x.device.type != "mps" else "cpu"
+        with torch.autocast(device_type=device_type, enabled=False):  # Force float32
+            freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(1, 2)
+            emb = torch.cat((freqs, freqs), dim=-1)
+            cos = emb.cos() * self.attention_scaling
+            sin = emb.sin() * self.attention_scaling
+
+        return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)
+
+
+QWEN2_START_DOCSTRING = r"""
+    This model inherits from [`PreTrainedModel`]. Check the superclass documentation for the generic methods the
+    library implements for all its model (such as downloading or saving, resizing the input embeddings, pruning heads
+    etc.)
+
+    This model is also a PyTorch [torch.nn.Module](https://pytorch.org/docs/stable/nn.html#torch.nn.Module) subclass.
+    Use it as a regular PyTorch Module and refer to the PyTorch documentation for all matter related to general usage
+    and behavior.
+
+    Parameters:
+        config ([`Qwen2Config`]):
+            Model configuration class with all the parameters of the model. Initializing with a config file does not
+            load the weights associated with the model, only the configuration. Check out the
+            [`~PreTrainedModel.from_pretrained`] method to load the model weights.
+"""
+
+
+@add_start_docstrings(
+    "The bare Qwen2 Model outputting raw hidden-states without any specific head on top.",
+    QWEN2_START_DOCSTRING,
+)
+class Qwen2PreTrainedModel(PreTrainedModel):
+    config_class = Qwen2Config
+    base_model_prefix = "model"
+    supports_gradient_checkpointing = True
+    _no_split_modules = ["Qwen2DecoderLayer"]
+    _skip_keys_device_placement = ["past_key_values"]
+    _supports_flash_attn_2 = True
+    _supports_sdpa = True
+    _supports_flex_attn = True
+    _supports_cache_class = True
+    _supports_quantized_cache = True
+    _supports_static_cache = True
+    _supports_attention_backend = True
+
+    def _init_weights(self, module):
+        std = self.config.initializer_range
+        if isinstance(module, nn.Linear):
+            module.weight.data.normal_(mean=0.0, std=std)
+            if module.bias is not None:
+                module.bias.data.zero_()
+        elif isinstance(module, nn.Embedding):
+            module.weight.data.normal_(mean=0.0, std=std)
+            if module.padding_idx is not None:
+                module.weight.data[module.padding_idx].zero_()
+
+
+QWEN2_INPUTS_DOCSTRING = r"""
+    Args:
+        input_ids (`torch.LongTensor` of shape `(batch_size, sequence_length)`):
+            Indices of input sequence tokens in the vocabulary. Padding will be ignored by default should you provide
+            it.
+
+            Indices can be obtained using [`AutoTokenizer`]. See [`PreTrainedTokenizer.encode`] and
+            [`PreTrainedTokenizer.__call__`] for details.
+
+            [What are input IDs?](../glossary#input-ids)
+        attention_mask (`torch.Tensor` of shape `(batch_size, sequence_length)`, *optional*):
+            Mask to avoid performing attention on padding token indices. Mask values selected in `[0, 1]`:
+
+            - 1 for tokens that are **not masked**,
+            - 0 for tokens that are **masked**.
+
+            [What are attention masks?](../glossary#attention-mask)
+
+            Indices can be obtained using [`AutoTokenizer`]. See [`PreTrainedTokenizer.encode`] and
+            [`PreTrainedTokenizer.__call__`] for details.
+
+            If `past_key_values` is used, optionally only the last `input_ids` have to be input (see
+            `past_key_values`).
+
+            If you want to change padding behavior, you should read [`modeling_opt._prepare_decoder_attention_mask`]
+            and modify to your needs. See diagram 1 in [the paper](https://arxiv.org/abs/1910.13461) for more
+            information on the default strategy.
+
+            - 1 indicates the head is **not masked**,
+            - 0 indicates the head is **masked**.
+        position_ids (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
+            Indices of positions of each input sequence tokens in the position embeddings. Selected in the range `[0,
+            config.n_positions - 1]`.
+
+            [What are position IDs?](../glossary#position-ids)
+        past_key_values (`Cache`, *optional*):
+            Pre-computed hidden-states (key and values in the self-attention blocks and in the cross-attention
+            blocks) that can be used to speed up sequential decoding. This typically consists in the `past_key_values`
+            returned by the model at a previous stage of decoding, when `use_cache=True` or `config.use_cache=True`.
+
+            It is a [`~cache_utils.Cache`] instance. For more details, see our [kv cache guide](https://huggingface.co/docs/transformers/en/kv_cache).
+
+            If `past_key_values` are used, the user can optionally input only the last `input_ids` (those that don't
+            have their past key value states given to this model) of shape `(batch_size, 1)` instead of all `input_ids`
+            of shape `(batch_size, sequence_length)`.
+        inputs_embeds (`torch.FloatTensor` of shape `(batch_size, sequence_length, hidden_size)`, *optional*):
+            Optionally, instead of passing `input_ids` you can choose to directly pass an embedded representation. This
+            is useful if you want more control over how to convert `input_ids` indices into associated vectors than the
+            model's internal embedding lookup matrix.
+        use_cache (`bool`, *optional*):
+            If set to `True`, `past_key_values` key value states are returned and can be used to speed up decoding (see
+            `past_key_values`).
+        output_attentions (`bool`, *optional*):
+            Whether or not to return the attentions tensors of all attention layers. See `attentions` under returned
+            tensors for more detail.
+        output_hidden_states (`bool`, *optional*):
+            Whether or not to return the hidden states of all layers. See `hidden_states` under returned tensors for
+            more detail.
+        return_dict (`bool`, *optional*):
+            Whether or not to return a [`~utils.ModelOutput`] instead of a plain tuple.
+        cache_position (`torch.LongTensor` of shape `(sequence_length)`, *optional*):
+            Indices depicting the position of the input sequence tokens in the sequence. Contrarily to `position_ids`,
+            this tensor is not affected by padding. It is used to update the cache in the correct position and to infer
+            the complete sequence length.
+"""
+
+
+@add_start_docstrings(
+    "The bare Qwen2 Model outputting raw hidden-states without any specific head on top.",
+    QWEN2_START_DOCSTRING,
+)
+class Qwen2Model(Qwen2PreTrainedModel):
+    """
+    Transformer decoder consisting of *config.num_hidden_layers* layers. Each layer is a [`Qwen2DecoderLayer`]
+
+    Args:
+        config: Qwen2Config
+    """
+
+    def __init__(self, config: Qwen2Config, eval=False):
+        super().__init__(config)
+        self.padding_idx = config.pad_token_id
+        self.vocab_size = config.vocab_size
+
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size, self.padding_idx)
+        self.layers = nn.ModuleList(
+            [Qwen2DecoderLayer(config, layer_idx) for layer_idx in range(config.num_hidden_layers)]
+        )
+        self.norm = FixQwen2RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.rotary_emb = Qwen2RotaryEmbedding(config=config)
+        self.gradient_checkpointing = False
+
+        # Initialize weights and apply final processing
+        if eval:
+            self._init_weights = lambda module: None
+        self.post_init()
+
+    def get_input_embeddings(self):
+        return self.embed_tokens
+
+    def set_input_embeddings(self, value):
+        self.embed_tokens = value
+
+    @can_return_tuple
+    @add_start_docstrings_to_model_forward(QWEN2_INPUTS_DOCSTRING)
+    def forward(
+        self,
+        input_ids: torch.LongTensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        position_ids: torch.LongTensor | None = None,
+        past_key_values: Cache | None = None,
+        inputs_embeds: torch.FloatTensor | None = None,
+        use_cache: bool | None = None,
+        output_attentions: bool | None = None,
+        output_hidden_states: bool | None = None,
+        cache_position: torch.LongTensor | None = None,
+        **flash_attn_kwargs: Unpack[FlashAttentionKwargs],
+    ) -> BaseModelOutputWithPast:
+        output_attentions = (
+            output_attentions if output_attentions is not None else self.config.output_attentions
+        )
+        output_hidden_states = (
+            output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
+        )
+        use_cache = use_cache if use_cache is not None else self.config.use_cache
+
+        if (input_ids is None) ^ (inputs_embeds is not None):
+            raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
+
+        if self.gradient_checkpointing and self.training and use_cache:
+            logger.warning_once(
+                "`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`."
+            )
+            use_cache = False
+
+        # TODO (joao): remove this exception in v4.56 -- it exists for users that try to pass a legacy cache
+        if not isinstance(past_key_values, (type(None), Cache)):
+            raise ValueError("The `past_key_values` should be either a `Cache` object or `None`.")
+
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_tokens(input_ids)
+
+        if use_cache and past_key_values is None:
+            past_key_values = DynamicCache()
+
+        if cache_position is None:
+            past_seen_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0
+            cache_position = torch.arange(
+                past_seen_tokens, past_seen_tokens + inputs_embeds.shape[1], device=inputs_embeds.device
+            )
+
+        if position_ids is None:
+            position_ids = cache_position.unsqueeze(0)
+
+        causal_mask = self._update_causal_mask(
+            attention_mask, inputs_embeds, cache_position, past_key_values, output_attentions
+        )
+
+        hidden_states = inputs_embeds
+
+        # create position embeddings to be shared across the decoder layers
+        position_embeddings = self.rotary_emb(hidden_states, position_ids)
+
+        # decoder layers
+        all_hidden_states = () if output_hidden_states else None
+        all_self_attns = () if output_attentions else None
+
+        for decoder_layer in self.layers[: self.config.num_hidden_layers]:
+            if output_hidden_states:
+                all_hidden_states += (hidden_states,)
+
+            if self.gradient_checkpointing and self.training:
+                layer_outputs = self._gradient_checkpointing_func(
+                    partial(decoder_layer.__call__, **flash_attn_kwargs),
+                    hidden_states,
+                    causal_mask,
+                    position_ids,
+                    past_key_values,
+                    output_attentions,
+                    use_cache,
+                    cache_position,
+                    position_embeddings,
+                )
+            else:
+                layer_outputs = decoder_layer(
+                    hidden_states,
+                    attention_mask=causal_mask,
+                    position_ids=position_ids,
+                    past_key_value=past_key_values,
+                    output_attentions=output_attentions,
+                    use_cache=use_cache,
+                    cache_position=cache_position,
+                    position_embeddings=position_embeddings,
+                    **flash_attn_kwargs,
+                )
+
+            hidden_states = layer_outputs[0]
+
+            if output_attentions:
+                all_self_attns += (layer_outputs[1],)
+
+        hidden_states = self.norm(hidden_states)
+
+        # add hidden states from the last decoder layer
+        if output_hidden_states:
+            all_hidden_states += (hidden_states,)
+
+        return BaseModelOutputWithPast(
+            last_hidden_state=hidden_states,
+            past_key_values=past_key_values if use_cache else None,
+            hidden_states=all_hidden_states,
+            attentions=all_self_attns,
+        )
+
+    def _update_causal_mask(
+        self,
+        attention_mask: torch.Tensor,
+        input_tensor: torch.Tensor,
+        cache_position: torch.Tensor,
+        past_key_values: Cache,
+        output_attentions: bool = False,
+    ):
+        if self.config._attn_implementation == "flash_attention_2":
+            if attention_mask is not None and past_key_values is not None:
+                is_padding_right = attention_mask[:, -1].sum().item() != input_tensor.size()[0]
+                if is_padding_right:
+                    raise ValueError(
+                        "You are attempting to perform batched generation with padding_side='right'"
+                        " this may lead to unexpected behaviour for Flash Attention version of Qwen2. Make sure to "
+                        " call `tokenizer.padding_side  = 'left'` before tokenizing the input. "
+                    )
+            if attention_mask is not None and 0.0 in attention_mask:
+                return attention_mask
+            return None
+
+        # For SDPA, when possible, we will rely on its `is_causal` argument instead of its `attn_mask` argument, in
+        # order to dispatch on Flash Attention 2. This feature is not compatible with static cache, as SDPA will fail
+        # to infer the attention mask.
+        past_seen_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0
+        using_static_cache = isinstance(past_key_values, StaticCache)
+        using_sliding_window_cache = isinstance(past_key_values, SlidingWindowCache)
+
+        # When output attentions is True, sdpa implementation's forward method calls the eager implementation's forward
+        if (
+            self.config._attn_implementation == "sdpa"
+            and not (using_static_cache or using_sliding_window_cache)
+            and not output_attentions
+        ):
+            if AttentionMaskConverter._ignore_causal_mask_sdpa(
+                attention_mask,
+                inputs_embeds=input_tensor,
+                past_key_values_length=past_seen_tokens,
+                sliding_window=self.config.sliding_window,
+                is_training=self.training,
+            ):
+                return None
+
+        dtype, device = input_tensor.dtype, input_tensor.device
+        min_dtype = torch.finfo(dtype).min
+        sequence_length = input_tensor.shape[1]
+        # SlidingWindowCache or StaticCache
+        if using_sliding_window_cache or using_static_cache:
+            target_length = past_key_values.get_max_cache_shape()
+        # DynamicCache or no cache
+        else:
+            target_length = (
+                attention_mask.shape[-1]
+                if isinstance(attention_mask, torch.Tensor)
+                else past_seen_tokens + sequence_length + 1
+            )
+
+        # In case the provided `attention` mask is 2D, we generate a causal mask here (4D).
+        causal_mask = self._prepare_4d_causal_attention_mask_with_cache_position(
+            attention_mask,
+            sequence_length=sequence_length,
+            target_length=target_length,
+            dtype=dtype,
+            device=device,
+            cache_position=cache_position,
+            batch_size=input_tensor.shape[0],
+            config=self.config,
+            past_key_values=past_key_values,
+        )
+
+        if (
+            self.config._attn_implementation == "sdpa"
+            and attention_mask is not None
+            and attention_mask.device.type in ["cuda", "xpu"]
+            and not output_attentions
+        ):
+            # Attend to all tokens in fully masked rows in the causal_mask, for example the relevant first rows when
+            # using left padding. This is required by F.scaled_dot_product_attention memory-efficient attention path.
+            # Details: https://github.com/pytorch/pytorch/issues/110213
+            causal_mask = AttentionMaskConverter._unmask_unattended(causal_mask, min_dtype)
+
+        return causal_mask
+
+    @staticmethod
+    def _prepare_4d_causal_attention_mask_with_cache_position(
+        attention_mask: torch.Tensor,
+        sequence_length: int,
+        target_length: int,
+        dtype: torch.dtype,
+        device: torch.device,
+        cache_position: torch.Tensor,
+        batch_size: int,
+        config: Qwen2Config,
+        past_key_values: Cache,
+    ):
+        """
+        Creates a causal 4D mask of shape `(batch_size, 1, query_length, key_value_length)` from a 2D mask of shape
+        `(batch_size, key_value_length)`, or if the input `attention_mask` is already 4D, do nothing.
+
+        Args:
+            attention_mask (`torch.Tensor`):
+                A 2D attention mask of shape `(batch_size, key_value_length)` or a 4D attention mask of shape `(batch_size, 1, query_length, key_value_length)`.
+            sequence_length (`int`):
+                The sequence length being processed.
+            target_length (`int`):
+                The target length: when generating with static cache, the mask should be as long as the static cache, to account for the 0 padding, the part of the cache that is not filled yet.
+            dtype (`torch.dtype`):
+                The dtype to use for the 4D attention mask.
+            device (`torch.device`):
+                The device to place the 4D attention mask on.
+            cache_position (`torch.Tensor`):
+                Indices depicting the position of the input sequence tokens in the sequence.
+            batch_size (`torch.Tensor`):
+                Batch size.
+            config (`Qwen2Config`):
+                The model's configuration class
+            past_key_values (`Cache`):
+                The cache class that is being used currently to generate
+        """
+        if attention_mask is not None and attention_mask.dim() == 4:
+            # In this case we assume that the mask comes already in inverted form and requires no inversion or slicing.
+            causal_mask = attention_mask
+        else:
+            min_dtype = torch.finfo(dtype).min
+            causal_mask = torch.full(
+                (sequence_length, target_length), fill_value=min_dtype, dtype=dtype, device=device
+            )
+            diagonal_attend_mask = torch.arange(target_length, device=device) > cache_position.reshape(-1, 1)
+            if config.sliding_window is not None:
+                # if we have sliding window, we should not attend to tokens beyond sliding window length, so we mask them out also
+                # the check is needed to verify is current checkpoint was trained with sliding window or not
+                if not isinstance(past_key_values, SlidingWindowCache) or sequence_length > target_length:
+                    sliding_attend_mask = torch.arange(target_length, device=device) <= (
+                        cache_position.reshape(-1, 1) - config.sliding_window
+                    )
+                    diagonal_attend_mask.bitwise_or_(sliding_attend_mask)
+            causal_mask *= diagonal_attend_mask
+            causal_mask = causal_mask[None, None, :, :].expand(batch_size, 1, -1, -1)
+            if attention_mask is not None:
+                causal_mask = causal_mask.clone()  # copy to contiguous memory for in-place edit
+                if attention_mask.shape[-1] > target_length:
+                    attention_mask = attention_mask[:, :target_length]
+                mask_length = attention_mask.shape[-1]
+                padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :].to(
+                    causal_mask.device
+                )
+                padding_mask = padding_mask == 0
+                causal_mask[:, :, :, :mask_length] = causal_mask[:, :, :, :mask_length].masked_fill(
+                    padding_mask, min_dtype
+                )
+        return causal_mask
+
+
+class KwargsForCausalLM(FlashAttentionKwargs, LossKwargs): ...
+
+
+class Qwen2ForCausalLM(Qwen2PreTrainedModel, GenerationMixin):
+    # transformers>=5.0 expects a dict mapping {output: input} for tied weights.
+    _tied_weights_keys = {"lm_head.weight": "model.embed_tokens.weight"}
+    _tp_plan = {"lm_head": "colwise_rep"}
+    _pp_plan = {"lm_head": (["hidden_states"], ["logits"])}
+
+    def __init__(self, config, eval, **kwargs):
+        super().__init__(config)
+        self.model = Qwen2Model(config, eval)
+        self.vocab_size = config.vocab_size
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+
+        # Initialize weights and apply final processing
+        self.post_init()
+
+    def get_input_embeddings(self):
+        return self.model.embed_tokens
+
+    def set_input_embeddings(self, value):
+        self.model.embed_tokens = value
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+    def set_output_embeddings(self, new_embeddings):
+        self.lm_head = new_embeddings
+
+    def set_decoder(self, decoder):
+        self.model = decoder
+
+    def get_decoder(self):
+        return self.model
+
+    @can_return_tuple
+    @deprecate_kwarg("num_logits_to_keep", version="4.50", new_name="logits_to_keep")
+    @add_start_docstrings_to_model_forward(QWEN2_INPUTS_DOCSTRING)
+    @replace_return_docstrings(output_type=CausalLMOutputWithPast, config_class=_CONFIG_FOR_DOC)
+    def forward(
+        self,
+        input_ids: torch.LongTensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        position_ids: torch.LongTensor | None = None,
+        past_key_values: Cache | None = None,
+        inputs_embeds: torch.FloatTensor | None = None,
+        labels: torch.LongTensor | None = None,
+        use_cache: bool | None = None,
+        output_attentions: bool | None = None,
+        output_hidden_states: bool | None = None,
+        cache_position: torch.LongTensor | None = None,
+        logits_to_keep: int | torch.Tensor = 0,
+        **kwargs: Unpack[KwargsForCausalLM],
+    ) -> CausalLMOutputWithPast:
+        r"""
+            labels (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
+                Labels for computing the masked language modeling loss. Indices should either be in `[0, ...,
+                config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored
+                (masked), the loss is only computed for the tokens with labels in `[0, ..., config.vocab_size]`.
+
+            logits_to_keep (`int` or `torch.Tensor`, *optional*):
+                If an `int`, compute logits for the last `logits_to_keep` tokens. If `0`, calculate logits for all
+                `input_ids` (special case). Only last token logits are needed for generation, and calculating them only for that
+                token can save memory, which becomes pretty significant for long sequences or large vocabulary size.
+                If a `torch.Tensor`, must be 1D corresponding to the indices to keep in the sequence length dimension.
+                This is useful when using packed tensor format (single dimension for batch and sequence length).
+
+        Returns:
+
+        Example:
+
+        ```python
+        >>> from transformers import AutoTokenizer, Qwen2ForCausalLM
+
+        >>> model = Qwen2ForCausalLM.from_pretrained("meta-qwen2/Qwen2-2-7b-hf")
+        >>> tokenizer = AutoTokenizer.from_pretrained("meta-qwen2/Qwen2-2-7b-hf")
+
+        >>> prompt = "Hey, are you conscious? Can you talk to me?"
+        >>> inputs = tokenizer(prompt, return_tensors="pt")
+
+        >>> # Generate
+        >>> generate_ids = model.generate(inputs.input_ids, max_length=30)
+        >>> tokenizer.batch_decode(generate_ids, skip_special_tokens=True, clean_up_tokenization_spaces=False)[0]
+        "Hey, are you conscious? Can you talk to me?\nI'm not conscious, but I can talk to you."
+        ```"""
+        output_attentions = (
+            output_attentions if output_attentions is not None else self.config.output_attentions
+        )
+        output_hidden_states = (
+            output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
+        )
+
+        # decoder outputs consists of (dec_features, layer_state, dec_hidden, dec_attn)
+        outputs: BaseModelOutputWithPast = self.model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            inputs_embeds=inputs_embeds,
+            use_cache=use_cache,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            cache_position=cache_position,
+            **kwargs,
+        )
+
+        hidden_states = outputs.last_hidden_state
+        # Only compute necessary logits, and do not upcast them to float if we are not computing the loss
+        slice_indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
+        logits = self.lm_head(hidden_states[:, slice_indices, :])
+
+        loss = None
+        if labels is not None:
+            loss = self.loss_function(
+                logits=logits, labels=labels, vocab_size=self.config.vocab_size, **kwargs
+            )
+
+        return CausalLMOutputWithPast(
+            loss=loss,
+            logits=logits,
+            past_key_values=outputs.past_key_values,
+            hidden_states=outputs.hidden_states,
+            attentions=outputs.attentions,
+        )
+
+
+class QwenvlWithExpertConfig(PretrainedConfig):
+    model_type = "QwenvlWithExpertModel"
+    sub_configs = {"qwenvl_config": AutoConfig, "qwen_expert_config": AutoConfig}
+
+    def __init__(
+        self,
+        qwenvl_config: dict | None = None,
+        qwen_expert_config: dict | None = None,
+        freeze_vision_encoder: bool = True,
+        train_expert_only: bool = True,
+        vocab_size: int = 257152,
+        use_lm_head: bool = False,
+        attention_implementation: str = "eager",
+        tokenizer_path: str | None = None,
+        use_cache: bool = False,
+        **kwargs,
+    ):
+        self.freeze_vision_encoder = freeze_vision_encoder
+        self.train_expert_only = train_expert_only
+        self.attention_implementation = attention_implementation
+        self.tokenizer_path = tokenizer_path
+        self.vocab_size = vocab_size
+        self.use_lm_head = use_lm_head
+        if qwenvl_config is None:
+            self.qwenvl_config = CONFIG_MAPPING["qwen2_5_vl"](
+                attention_dropout=0.0,
+                bos_token_id=151643,
+                eos_token_id=151645,
+                vision_start_token_id=151652,
+                vision_end_token_id=151653,
+                vision_token_id=151654,
+                image_token_id=151655,
+                video_token_id=151656,
+                hidden_act="silu",
+                hidden_size=2048,
+                initializer_range=0.02,
+                intermediate_size=11008,
+                max_position_embeddings=128000,
+                max_window_layers=70,
+                model_type="qwen2_5_vl",
+                num_attention_heads=16,
+                num_hidden_layers=36,
+                num_key_value_heads=2,
+                rms_norm_eps=1e-06,
+                rope_theta=1000000.0,
+                sliding_window=32768,
+                tie_word_embeddings=True,
+                torch_dtype="bfloat16",
+                transformers_version="4.41.2",
+                use_cache=use_cache,
+                use_sliding_window=False,
+                vision_config={
+                    "depth": 32,
+                    "hidden_act": "silu",
+                    "hidden_size": 1280,
+                    "intermediate_size": 3420,
+                    "num_heads": 16,
+                    "in_chans": 3,
+                    "out_hidden_size": 2048,
+                    "patch_size": 14,
+                    "spatial_merge_size": 2,
+                    "spatial_patch_size": 14,
+                    "window_size": 112,
+                    "fullatt_block_indexes": [7, 15, 23, 31],
+                    "tokens_per_second": 2,
+                    "temporal_patch_size": 2,
+                },
+                rope_scaling={"type": "mrope", "mrope_section": [16, 24, 24]},
+                vocab_size=151936,
+            )
+        elif isinstance(self.qwenvl_config, dict):
+            if "model_type" not in qwen_expert_config:
+                qwenvl_config["model_type"] = "qwen2_5_vl"
+
+            cfg_cls = CONFIG_MAPPING[qwenvl_config["model_type"]]
+            self.qwenvl_config = cfg_cls(**qwenvl_config)
+
+        if qwen_expert_config is None:
+            self.qwen_expert_config = CONFIG_MAPPING["qwen2"](
+                attention_dropout=0.0,
+                bos_token_id=151643,
+                eos_token_id=151645,
+                hidden_act="silu",
+                hidden_size=768,
+                head_dim=128,
+                initializer_range=0.02,
+                intermediate_size=2752,
+                max_position_embeddings=32768,
+                max_window_layers=21,
+                model_type="qwen2",
+                num_attention_heads=16,
+                num_hidden_layers=36,
+                num_key_value_heads=2,
+                rms_norm_eps=1e-06,
+                rope_theta=1000000.0,
+                sliding_window=32768,
+                tie_word_embeddings=True,
+                torch_dtype="bfloat16",
+                transformers_version="4.43.1",
+                use_cache=use_cache,
+                use_sliding_window=False,
+                vocab_size=151936,
+            )
+        elif isinstance(self.qwen_expert_config, dict):
+            if "model_type" not in qwen_expert_config:
+                qwen_expert_config["model_type"] = "qwen2"
+
+            cfg_cls = CONFIG_MAPPING[qwenvl_config["model_type"]]
+            self.qwen_expert_config = cfg_cls(**qwen_expert_config)
+
+        super().__init__(**kwargs)
+
+    def __post_init__(self):
+        super().__post_init__()
+        if self.train_expert_only and not self.freeze_vision_encoder:
+            raise ValueError(
+                "You set `freeze_vision_encoder=False` and `train_expert_only=True` which are not compatible."
+            )
+
+        if self.attention_implementation not in ["eager", "fa2", "flex"]:
+            raise ValueError(
+                f"Wrong value provided for `attention_implementation` ({self.attention_implementation}). Expected 'eager', 'fa2' or 'flex'."
+            )
+
+
+class AdaRMSNorm(nn.Module):
+    def __init__(self, hidden_size, cond_dim, eps=1e-6):
+        """
+        AdaRMSNorm: RMSNorm + FiLM
+        """
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(hidden_size))
+        self.variance_epsilon = eps
+        self.gamma = nn.Linear(cond_dim, hidden_size)
+        self.beta = nn.Linear(cond_dim, hidden_size)
+
+        # DiT style init: gamma.weight=0, gamma.bias=1; beta.weight=0, beta.bias=0
+        nn.init.zeros_(self.gamma.weight)
+        nn.init.zeros_(self.gamma.bias)
+        nn.init.zeros_(self.beta.weight)
+        nn.init.zeros_(self.beta.bias)
+
+    def _init_weights(self, module):
+        if isinstance(module, nn.Linear):
+            nn.init.constant_(module.weight, 0.0)
+            if module.bias is not None:
+                nn.init.constant_(module.bias, 0.0)
+
+    def forward(self, hidden_states, cond):
+        input_dtype = hidden_states.dtype
+        hidden_states = hidden_states.to(torch.float32)
+        variance = hidden_states.pow(2).mean(-1, keepdim=True)
+        hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
+
+        hidden_states = self.weight * hidden_states
+        gamma = self.gamma(cond).unsqueeze(1)  # [B, 1, H]
+        beta = self.beta(cond).unsqueeze(1)  # [B, 1, H]
+        hidden_states = (1 + gamma.to(torch.float32)) * hidden_states + beta.to(torch.float32)
+        return hidden_states.to(input_dtype)
+
+
+# HACK: show directly use this norm during initialization
+def replace_lnorm_with_adanorm(
+    module, hidden_size, cond_dim, split_gate_liner, no_split_gate_liner, final_norm_adanorm
+):
+    for name, child in module.named_children():
+        if isinstance(child, Qwen2RMSNorm):
+            if "q_layernorm" not in name and "k_layernorm" not in name:
+                setattr(module, name, AdaRMSNorm(hidden_size, cond_dim))
+        else:
+            replace_lnorm_with_adanorm(
+                child, hidden_size, cond_dim, split_gate_liner, no_split_gate_liner, final_norm_adanorm
+            )
+
+
+class QwenvlWithExpertModel(PreTrainedModel):
+    config_class = QwenvlWithExpertConfig
+
+    def __init__(self, config: QwenvlWithExpertConfig, eval=False):
+        super().__init__(config=config)
+        self.config = config
+        vlm_config = AutoConfig.from_pretrained(self.config.tokenizer_path)
+        # transformers>=5.0 nests the text-model fields (hidden_size, vocab_size,
+        # pad_token_id, rope_scaling, ...) under `text_config`. The vendored Qwen2.5-VL
+        # reads them flat, so promote any missing field onto the top-level config. The
+        # vision tower keeps reading from `vlm_config.vision_config` (left untouched).
+        text_config = getattr(vlm_config, "text_config", None)
+        if text_config is not None:
+            for k, v in vars(text_config).items():
+                if k.startswith("_"):
+                    continue
+                if getattr(vlm_config, k, None) is None:
+                    setattr(vlm_config, k, v)
+        if getattr(vlm_config, "pad_token_id", None) is None:
+            vlm_config.pad_token_id = None
+        vlm_config.vision_config.initializer_range = 0.02
+        vlm_config.norm_qkv = self.config.norm_qkv
+        if (
+            self.config.vocab_size != 0
+            and self.config.vocab_size != 257152
+            and vlm_config.vocab_size != self.config.vocab_size
+        ):
+            vlm_config.vocab_size = self.config.vocab_size
+
+        # Map the dual-stream attention setting to a HF-recognised attn implementation.
+        # Runtime attention is dispatched via get_attention_interface(); this only sets the
+        # sub-models' internal default. flash_attention_2 requires the flash-attn package.
+        _hf_attn_impl = "flash_attention_2" if self.config.attention_implementation == "fa2" else "eager"
+        vlm_config._attn_implementation = _hf_attn_impl
+        self.qwenvl = Qwen2_5_VLForConditionalGeneration._from_config(vlm_config)
+        if self.config.use_lm_head:
+            self.qwenvl.tie_weights()
+        self.config.qwen_expert_config.norm_qkv = self.config.norm_qkv
+        self.config.qwen_expert_config._attn_implementation = _hf_attn_impl
+        self.qwen_expert = Qwen2ForCausalLM._from_config(self.config.qwen_expert_config, eval=eval)
+
+        self.rotary_pos_emb = None
+        self.window_index = None
+        self.cu_window_seqlens = None
+        self.cu_seqlens = None
+
+        if getattr(self.config, "adanorm_time", False):
+            replace_lnorm_with_adanorm(
+                self.qwen_expert,
+                self.config.qwen_expert_config.hidden_size,
+                self.config.qwen_expert_config.hidden_size,
+                config.split_gate_liner,
+                config.no_split_gate_liner,
+                config.final_norm_adanorm,
+            )
+        # Remove unused embed_tokens
+        del self.qwen_expert.model.embed_tokens
+        self.attention_interface = self.get_attention_interface()
+
+        # self.to_bfloat16_like_physical_intelligence()
+        self.set_requires_grad()
+
+    def set_requires_grad(self):
+        """sets the requires_grad attribute of the model parameters based on the configuration.
+        If `freeze_vision_encoder` is True, the vision tower parameters are frozen.
+        If `train_expert_only` is True, the entire Qwenvl model is frozen.
+        """
+        if self.config.freeze_vision_encoder:
+            self.qwenvl.visual.eval()
+            for params in self.qwenvl.visual.parameters():
+                params.requires_grad = False
+
+        if self.config.train_expert_only:
+            self.qwenvl.eval()
+            for params in self.qwenvl.parameters():
+                params.requires_grad = False
+
+    def train(self, mode: bool = True):
+        super().train(mode)
+        if self.config.freeze_vision_encoder:
+            self.qwenvl.visual.eval()
+        if self.config.train_expert_only:
+            self.qwenvl.eval()
+
+    def to_bfloat16_like_physical_intelligence(self):
+        """casts the model to bfloat16.
+
+        Modules not casted to bfloat16:
+        - qwenvl.model.embed_tokens.weight
+        - qwenvl.model.norm.weight
+        - qwen_expert.model.norm.weight
+        - qwen_expert.lm_head.weight
+        """
+        self.qwenvl = self.qwenvl.to(dtype=torch.bfloat16)
+
+        params_to_change_dtype = [
+            "qwenvl.model.layers",
+            "qwen_expert.model.layers",
+            "visual",
+            "multi_modal",
+        ]
+        for name, param in self.named_parameters():
+            if any(selector in name for selector in params_to_change_dtype):
+                param.data = param.data.to(dtype=torch.bfloat16)
+
+    def get_image_features(
+        self, pixel_values: torch.FloatTensor, image_grid_thw: torch.LongTensor | None = None
+    ):
+        """
+        Encodes images into continuous embeddings that can be forwarded to the language model.
+
+        Args:
+            pixel_values (`torch.FloatTensor` of shape `(batch_size, num_channels, image_size, image_size)`):
+                The tensors corresponding to the input images.
+            image_grid_thw (`torch.LongTensor` of shape `(num_images, 3)`, *optional*):
+                The temporal, height and width of feature shape of each image in LLM.
+        """
+        if (
+            self.rotary_pos_emb is None
+            or self.window_index is None
+            or self.cu_window_seqlens is None
+            or self.cu_seqlens is None
+        ):
+            (self.rotary_pos_emb, self.window_index, self.cu_window_seqlens, self.cu_seqlens) = (
+                self.qwenvl.visual.preprcess_grid_thw(grid_thw=image_grid_thw)
+            )
+        image_embeds = self.qwenvl.visual(
+            pixel_values,
+            grid_thw=image_grid_thw,
+            rotary_pos_emb=self.rotary_pos_emb,
+            window_index=self.window_index,
+            cu_window_seqlens=self.cu_window_seqlens,
+            cu_seqlens=self.cu_seqlens,
+        )
+        split_sizes = (image_grid_thw.prod(-1) // self.qwenvl.visual.spatial_merge_size**2).tolist()
+        image_embeds = torch.split(image_embeds, split_sizes)
+        image_embeds = torch.stack(image_embeds, dim=0)
+        return image_embeds
+
+    def embed_image(self, image: torch.Tensor, patch_size=14, temporal_patch_size=2):
+        h = w = int(image.shape[1] ** 0.5)
+        image_grid_thw = torch.tensor([[1, h, w]] * image.shape[0], device=image.device)
+        image_embeds = self.get_image_features(image, image_grid_thw=image_grid_thw)
+        return image_embeds
+        # return torch.randn(72, 64, 2048).to(device=image.device, dtype=torch.bfloat16)
+
+    def embed_language_tokens(self, tokens: torch.Tensor):
+        return self.qwenvl.model.embed_tokens(tokens)
+
+    def handle_kv_cache(
+        self,
+        key_states: torch.Tensor,
+        value_states: torch.Tensor,
+        layer_idx: int,
+        past_key_values: list[torch.FloatTensor] | Cache | None = None,
+        use_cache: bool | None = None,
+        fill_kv_cache: bool | None = None,
+    ):
+        if use_cache:
+            if past_key_values is None:
+                past_key_values = {}
+
+            if fill_kv_cache:
+                past_key_values[layer_idx] = {
+                    "key_states": key_states,
+                    "value_states": value_states,
+                }
+            else:
+                key_states = torch.cat([past_key_values[layer_idx]["key_states"], key_states], dim=1)
+                value_states = torch.cat(
+                    [past_key_values[layer_idx]["value_states"], value_states],
+                    dim=1,
+                )
+        return key_states, value_states, past_key_values
+
+    def forward(
+        self,
+        attention_mask: torch.Tensor | None = None,
+        position_ids: torch.LongTensor | None = None,
+        vlm_position_ids: torch.LongTensor | None = None,
+        past_key_values: list[torch.FloatTensor] | Cache | None = None,
+        inputs_embeds: list[torch.FloatTensor] = None,
+        use_cache: bool | None = None,
+        fill_kv_cache: bool | None = None,
+        ada_cond: list[torch.FloatTensor] = None,
+        norm_qkv: bool = False,
+    ):
+        """
+        Args:
+            attention_mask (Optional[torch.Tensor], optional):
+                Attention mask with shape (b, seq_len, seq_len). Defaults to None.
+            position_ids (Optional[torch.LongTensor], optional):
+                Position indices for applying RoPE. Defaults to None.
+            past_key_values (Optional[Union[List[torch.FloatTensor], Cache]], optional):
+                Optional kv cache. Defaults to None.
+            inputs_embeds (List[torch.FloatTensor], optional):
+                Input embeddings. Defaults to None.
+            use_cache (Optional[bool], optional):
+                Whether to use kv cache. Defaults to None.
+            fill_kv_cache (Optional[bool], optional):
+                Whether to return kv tensors in this forward pass as cache. Defaults to None.
+
+        Returns:
+            outputs_embeds (torch.Tensor): Output embeddings.
+            past_key_values (Optional[Union[List[torch.FloatTensor], Cache]]):
+                Optional kv cache.
+        """
+        models = [self.qwenvl.model, self.qwen_expert.model]
+
+        # RMSNorm
+        num_layers = self.qwenvl.config.num_hidden_layers  # 36
+        for layer_idx in range(num_layers):
+            query_states = []
+            key_states = []
+            value_states = []
+            gates = []
+            for i, hidden_states in enumerate(inputs_embeds):
+                if hidden_states is None:
+                    continue
+                if i == 1:  # For action expert
+                    query_state, key_state, value_state, gate = models[i].layers[layer_idx](
+                        hidden_states, compute_kqv=True, ada_cond=ada_cond, norm_qkv=norm_qkv
+                    )
+                else:  # For VLM
+                    query_state, key_state, value_state = models[i].layers[layer_idx](
+                        hidden_states, compute_kqv=True, norm_qkv=norm_qkv
+                    )
+                    gate = None
+
+                if query_state.dtype != torch.float32:
+                    query_state, key_state, value_state = (
+                        query_state.to(torch.float32),
+                        key_state.to(torch.float32),
+                        value_state.to(torch.float32),
+                    )
+                query_states.append(query_state)
+                key_states.append(key_state)
+                value_states.append(value_state)
+                gates.append(gate)
+
+            # B,L,H,D with L sequence length (img, lang, state, action), H number of heads, D head dim
+            # concatenate on the number of embeddings/tokens
+            query_states = torch.cat(query_states, dim=1)
+            key_states = torch.cat(key_states, dim=1)
+            value_states = torch.cat(value_states, dim=1)
+
+            query_states = apply_rope(query_states, position_ids)
+            key_states = apply_rope(key_states, position_ids)
+
+            key_states, value_states, past_key_values = self.handle_kv_cache(
+                key_states,
+                value_states,
+                layer_idx,
+                past_key_values=past_key_values,
+                use_cache=use_cache,
+                fill_kv_cache=fill_kv_cache,
+            )
+
+            att_output = self.attention_interface(query_states, key_states, value_states, attention_mask)
+
+            # first part of att_output is prefix (up to sequence length, [:, 0:prefix_seq_len])
+            outputs_embeds = []
+            start = 0
+            for i, hidden_states in enumerate(inputs_embeds):
+                if hidden_states is not None:
+                    end = start + hidden_states.shape[1]
+                    if i == 1:
+                        out_emb = models[i].layers[layer_idx](
+                            hidden_states,
+                            att_output,
+                            start,
+                            end,
+                            output_atten=True,
+                            ada_cond=ada_cond,
+                            gate=(gates[0] if len(gates) == 1 else gates[i]),
+                        )
+                    else:
+                        out_emb = models[i].layers[layer_idx](
+                            hidden_states, att_output, start, end, output_atten=True
+                        )
+                    outputs_embeds.append(out_emb)
+                    start = end
+                else:
+                    outputs_embeds.append(None)
+
+            inputs_embeds = outputs_embeds
+
+        # final norm
+        outputs_embeds = []
+        for i, hidden_states in enumerate(inputs_embeds):
+            if hidden_states is not None:
+                if self.config.final_norm_adanorm:
+                    if i == 1:
+                        out_emb, _ = models[i].norm(hidden_states, ada_cond)
+                    else:
+                        out_emb = models[i].norm(hidden_states)
+                else:
+                    out_emb = models[i].norm(hidden_states)
+                outputs_embeds.append(out_emb)
+            else:
+                outputs_embeds.append(None)
+
+        return outputs_embeds, past_key_values
+
+    def get_attention_interface(self):
+        if self.config.attention_implementation == "fa2":
+            raise NotImplementedError("FA2 is not implemented (yet)")
+        elif self.config.attention_implementation == "flex":
+            attention_interface = flex_attention_forward
+        elif self.config.attention_implementation == "eager":
+            attention_interface = our_eager_attention_forward
+        elif self.config.attention_implementation == "xformer":
+            # attention_interface = xformer_attention_forward
+            raise NotImplementedError("Xformer attention is not implemented (yet)")
+        else:
+            raise ValueError(
+                f"Invalid attention implementation: {self.config.attention_implementation}. "
+                "Expected one of ['fa2', 'flex', 'eager', 'xformer']."
+            )
+        return attention_interface
+
+
+class LingbotVLAPolicy(PreTrainedPolicy):
+    """LingBot-VLA policy for cross-embodiment robotic control.
+
+    Couples a Qwen2.5-VL vision-language backbone with a narrow action expert
+    (pi0-style dual-stream) and predicts action chunks via flow matching.
+
+    The model expects already model-ready tensors in the batch (produced by the
+    lingbot_vla processor / feature transform):
+        - ``images``: (B, num_views, num_patches, patch_dim) patchified pixels
+        - ``img_masks``: (B, num_views) per-view validity mask
+        - ``lang_tokens`` / ``lang_masks``: (B, L) tokenized instruction + mask
+        - ``observation.state``: (B, max_state_dim) padded state
+        - ``action``: (B, chunk_size, max_action_dim) padded action (training only)
+    """
+
+    config_class = LingbotVLAConfig
+    name = "lingbot_vla"
+    _no_split_modules = ["Qwen2DecoderLayer", "FixQwen2RMSNorm"]
+
+    def __init__(self, config: LingbotVLAConfig, **kwargs):
+        super().__init__(config)
+        config.validate_features()
+        self.config = config
+        self.language_tokenizer = AutoTokenizer.from_pretrained(config.tokenizer_path)
+        self.model = FlowMatching(config, eval=False)
+
+        if not getattr(self.config, "use_lm_head", False):
+            del self.model.qwenvl_with_expert.qwenvl.lm_head
+        del self.model.qwenvl_with_expert.qwen_expert.lm_head
+
+        self.reset()
+        torch.set_float32_matmul_precision("high")
+
+    def reset(self):
+        """Reset the rolling action queue used by select_action."""
+        self._queues = {ACTION: deque(maxlen=self.config.n_action_steps)}
+
+    def get_optim_params(self) -> dict:
+        return self.parameters()
+
+    def _extract_model_inputs(self, batch: dict[str, Tensor]):
+        dtype = next(self.parameters()).dtype
+        images = batch["images"].to(dtype=dtype)
+        img_masks = batch["img_masks"]
+        lang_tokens = batch["lang_tokens"]
+        lang_masks = batch["lang_masks"]
+        state = batch[OBS_STATE].to(dtype=dtype)
+        state = F.pad(state, (0, self.config.max_state_dim - state.shape[-1]))
+        return images, img_masks, lang_tokens, lang_masks, state
+
+    def forward(self, batch: dict[str, Tensor]) -> tuple[Tensor, dict[str, Tensor]]:
+        """Training forward pass returning the flow-matching loss in lerobot convention."""
+        images, img_masks, lang_tokens, lang_masks, state = self._extract_model_inputs(batch)
+        actions = batch[ACTION].to(dtype=state.dtype)
+        action_dim = actions.shape[-1]
+        actions = F.pad(actions, (0, self.config.max_action_dim - action_dim))
+
+        losses, loss_depth, _ = self.model.forward(
+            images,
+            img_masks,
+            lang_tokens,
+            lang_masks,
+            state,
+            actions,
+            label=None,
+            noise=batch.get("noise"),
+            time=batch.get("time"),
+            vlm_causal=False,
+            loss_type=self.config.loss_type,
+            depth_targets=batch.get("depth_targets"),
+            norm_qkv=False,
+        )
+
+        losses = losses[:, :, :action_dim]
+        loss_vla = losses.mean()
+
+        loss_dict: dict[str, Tensor] = {"l2_loss": loss_vla.item()}
+        total_loss = loss_vla
+        if not isinstance(loss_depth, int):
+            loss_dict["depth_loss"] = loss_depth.item()
+            total_loss = total_loss + loss_depth
+        loss_dict["loss"] = total_loss.item()
+
+        return total_loss, loss_dict
+
+    @torch.no_grad()
+    def predict_action_chunk(self, batch: dict[str, Tensor], noise: Tensor | None = None) -> Tensor:
+        """Run flow-matching denoising and return an action chunk (B, chunk, action_dim)."""
+        self.eval()
+        images, img_masks, lang_tokens, lang_masks, state = self._extract_model_inputs(batch)
+
+        actions = self.model.sample_actions(
+            images,
+            img_masks,
+            lang_tokens,
+            lang_masks,
+            state,
+            noise=noise,
+            num_steps=self.config.num_steps,
+        )
+        action_dim = self.config.output_features[ACTION].shape[0]
+        return actions[:, :, :action_dim]
+
+    @torch.no_grad()
+    def select_action(self, batch: dict[str, Tensor], noise: Tensor | None = None) -> Tensor:
+        """Select a single action for environment execution, buffering chunks in a queue."""
+        self.eval()
+        self._queues = populate_queues(self._queues, batch, exclude_keys=[ACTION])
+
+        if len(self._queues[ACTION]) == 0:
+            actions = self.predict_action_chunk(batch, noise=noise)
+            self._queues[ACTION].extend(actions.transpose(0, 1)[: self.config.n_action_steps])
+
+        return self._queues[ACTION].popleft()
+
+
+class FlowMatching(nn.Module):
+    def __init__(self, config, eval):
+        super().__init__()
+        self.config = config
+        # qwenvl with action expert
+        qwenvl_with_export_config = QwenvlWithExpertConfig(
+            freeze_vision_encoder=self.config.freeze_vision_encoder,
+            train_expert_only=self.config.train_expert_only,
+            vocab_size=getattr(self.config, "vocab_size", 0),
+            use_lm_head=getattr(self.config, "use_lm_head", False),
+            attention_implementation=self.config.attention_implementation,
+            tokenizer_path=self.config.tokenizer_path,
+            use_cache=getattr(self.config, "use_cache", True),
+        )
+        qwenvl_with_export_config.adanorm_time = getattr(config, "adanorm_time", False)
+        qwenvl_with_export_config.split_gate_liner = getattr(config, "split_gate_liner", False)
+        qwenvl_with_export_config.no_split_gate_liner = getattr(config, "nosplit_gate_liner", False)
+        qwenvl_with_export_config.separate_time_proj = getattr(config, "separate_time_proj", False)
+        qwenvl_with_export_config.final_norm_adanorm = getattr(config, "final_norm_adanorm", False)
+        qwenvl_with_export_config.norm_qkv = getattr(config, "norm_qkv", False)
+        self.qwenvl_with_expert = QwenvlWithExpertModel(qwenvl_with_export_config, eval)
+        self.config.proj_width = qwenvl_with_export_config.qwen_expert_config.hidden_size
+        self.config.initializer_range = getattr(
+            qwenvl_with_export_config.qwen_expert_config, "initializer_range", None
+        )
+        # projection layers
+        self.state_proj = nn.Linear(self.config.max_state_dim, self.config.proj_width)
+        self.action_in_proj = nn.Linear(self.config.max_action_dim, self.config.proj_width)
+        self.action_out_proj = nn.Linear(self.config.proj_width, self.config.max_action_dim)
+        if getattr(config, "separate_time_proj", False):
+            self.time_mlp_in = nn.Linear(self.config.proj_width, self.config.proj_width)
+            self.time_mlp_out = nn.Linear(self.config.proj_width, self.config.proj_width)
+        else:
+            self.action_time_mlp_in = nn.Linear(self.config.proj_width * 2, self.config.proj_width)
+            self.action_time_mlp_out = nn.Linear(self.config.proj_width, self.config.proj_width)
+        self.config.align_params = getattr(self.config, "align_params", {})
+        if self.config.align_params != {}:
+            self.steps = 0
+            self.use_depth_align = True
+            self.init_depth_heads(self.config.align_params)
+        else:
+            self.use_depth_align = False
+
+        self.set_requires_grad()
+
+    def init_depth_heads(self, config):
+        # Depth-alignment heads live in the LingBot source tree; import lazily so the
+        # no-depth checkpoint (align_params={}) carries no extra dependency.
+        from lingbotvla.models.vla.vision_models.align_heads.depth_head import (
+            TaskTokenDepthHead,
+        )
+
+        self.llm_image_token_size = config["llm"]["image_token_size"]
+        self.llm_image_input_size = config["llm"]["image_input_size"]
+        self.depth_token_size = config["depth"]["token_size"]
+        self.depth_input_size = config["depth"]["input_size"]
+        self.align_type = config.get("mode", None)
+        self.model_type = config["depth"]["model_type"]
+
+        if self.align_type == "direct":
+            self.depth_align_head = nn.Sequential(
+                nn.Linear(config["llm"]["dim_out"], config["depth"]["dim_out"] * 2),
+                nn.GELU(),
+                nn.Linear(config["depth"]["dim_out"] * 2, config["depth"]["dim_out"]),
+            )
+            for p in self.depth_align_head.parameters():
+                p.requires_grad = True
+        elif self.align_type == "query":
+            self.num_task_tokens = config["num_task_tokens"]
+            assert config["depth"]["num_backbone_tokens"] % self.num_task_tokens == 0
+            self.depth_align_embs = nn.Parameter(
+                torch.randn(config["depth"]["num_backbone_tokens"], config["llm"]["dim_out"])
+            ).to(dtype=torch.bfloat16)
+            self.depth_align_embs.requires_grad_ = True
+
+            self.depth_align_head = TaskTokenDepthHead(
+                config["depth"], llm_hidden_size=config["llm"]["dim_out"]
+            ).to(dtype=torch.bfloat16)
+
+            for p in self.depth_align_head.parameters():
+                p.requires_grad = True
+
+    def _init_weights(self, module):
+        std = self.config.initializer_range
+        if isinstance(module, (nn.Linear, nn.Conv3d)):
+            module.weight.data.normal_(mean=0.0, std=std)
+            if module.bias is not None:
+                module.bias.data.zero_()
+        elif isinstance(module, nn.Embedding):
+            module.weight.data.normal_(mean=0.0, std=std)
+            if module.padding_idx is not None:
+                module.weight.data[module.padding_idx].zero_()
+
+    def set_requires_grad(self):
+        for params in self.state_proj.parameters():
+            params.requires_grad = self.config.train_state_proj
+
+    def sample_time(self, bsize, device):
+        time_beta = sample_beta(1.5, 1.0, bsize, device)
+        time = time_beta * 0.999 + 0.001
+        return time.to(dtype=torch.float32, device=device)
+
+    def embed_prefix(
+        self, images, img_masks, lang_tokens, lang_masks, vlm_causal, label=None
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        bsize = images.shape[0]
+        device = images.device
+
+        # embed image
+        if images.ndim == 5:
+            images = einops.rearrange(images, "b n c h w -> (b n) c h w")
+        elif images.ndim == 4:
+            images = einops.rearrange(images, "b n l d -> (b n) l d")
+        elif images.ndim == 3:  # For inference bs=1
+            bsize = 1
+
+        img_emb = self.qwenvl_with_expert.embed_image(images)
+        num_patch = img_emb.shape[1]
+        img_emb = einops.rearrange(img_emb, "(b n) l d -> b (n l) d", b=bsize)  # bsize = 24
+        num_img_embs = img_emb.shape[1]
+        if img_masks.ndim == 1:  # For inference bs=1
+            img_masks = img_masks.unsqueeze(0)
+        if self.use_depth_align and self.align_type == "query":
+            align_masks = einops.repeat(img_masks, "b n -> b (n l)", l=self.num_task_tokens)
+        img_masks = einops.repeat(img_masks, "b n -> b (n l)", l=num_patch)
+
+        # embed language
+        lang_emb = self.qwenvl_with_expert.embed_language_tokens(lang_tokens)
+        num_lang_embs = lang_emb.shape[1]
+
+        if self.use_depth_align and self.align_type == "query":
+
+            def _get_align_tokens(tokens):
+                tk_weights = tokens.view(
+                    self.num_task_tokens, tokens.shape[0] // self.num_task_tokens, tokens.shape[1]
+                )
+                tk_weights = tk_weights.mean(dim=1)
+                return tk_weights
+
+            align_embs = (
+                _get_align_tokens(self.depth_align_embs)
+                .repeat(img_emb.size(0), 1, 1)
+                .to(img_emb.device, img_emb.dtype)
+            )
+            # align_masks = einops.rearrange(img_masks, "b (n l) -> b n l", n=3)
+            # align_masks = align_masks[:, :, 0]
+            # align_masks = einops.repeat(align_masks, "b n -> b (n l)", l=self.num_task_tokens)
+            embs = torch.cat([img_emb, align_embs, align_embs, align_embs, lang_emb], dim=1)
+            pad_masks = torch.cat([img_masks, align_masks, lang_masks], dim=1)
+        else:
+            # assemble embeddings
+            embs = torch.cat([img_emb, lang_emb], dim=1)
+            pad_masks = torch.cat([img_masks, lang_masks], dim=1)
+
+        # (see `make_att_2d_masks` to understand why zeros means bidirection)
+        if not vlm_causal:
+            if self.use_depth_align and self.align_type == "query":
+                att_masks = torch.zeros(
+                    (img_emb.size(0), num_img_embs + 3 * self.num_task_tokens + num_lang_embs),
+                    device=device,
+                    dtype=torch.bool,
+                )
+            else:
+                att_masks = torch.zeros(
+                    (img_emb.size(0), num_img_embs + num_lang_embs), device=device, dtype=torch.bool
+                )
+        else:
+            if self.use_depth_align and self.align_type == "query":
+                att_masks = torch.ones(
+                    (img_emb.size(0), num_img_embs + 3 * self.num_task_tokens + num_lang_embs),
+                    device=device,
+                    dtype=torch.bool,
+                )
+            else:
+                att_masks = torch.ones(
+                    (img_emb.size(0), num_img_embs + num_lang_embs), device=device, dtype=torch.bool
+                )
+        return embs, pad_masks, att_masks
+
+    def embed_suffix(self, state, noisy_actions, timestep):
+        bsize = state.shape[0]  # state_bs = img_bs
+        device = state.device
+        dtype = state.dtype
+        # embed state
+        state_emb = self.state_proj(state)  # torch.Size([state_bs, 1024])
+
+        # embed timestep using sine-cosine positional encoding with sensitivity in the range [0, 1]
+        time_emb = create_sinusoidal_pos_embedding(  # 1, 1024
+            timestep,  # torch.Size([1]))
+            self.config.proj_width,  # 1024
+            min_period=4e-3,
+            max_period=4.0,
+            device=device,
+        )
+        time_emb = time_emb.type(dtype=dtype)
+
+        time_emb_ori = time_emb
+
+        # Fuse timestep + action information using an MLP
+        action_emb = self.action_in_proj(noisy_actions)  # torch.Size([1, state_bs*50, 1024])
+        if getattr(self.config, "separate_time_proj", False):
+            time_emb = self.time_mlp_in(time_emb)
+            time_emb = F.silu(time_emb)
+            time_emb_ori = F.silu(self.time_mlp_out(time_emb))  # [1, 1024]
+            action_time_emb = action_emb
+        else:
+            time_emb = einops.repeat(
+                time_emb, "b d -> b n d", n=action_emb.shape[1]
+            )  # [1, 1024] -> [1, state_bs*50, 1024]
+            action_time_emb = torch.cat([action_emb, time_emb], dim=-1)  # [1, state_bs*50, 2048]
+
+            action_time_emb = self.action_time_mlp_in(action_time_emb)
+            action_time_emb = F.silu(action_time_emb)  # swish == silu
+            action_time_emb = self.action_time_mlp_out(action_time_emb)  # [1, state_bs*50, 1024]
+        action_time_dim = action_time_emb.shape[1]
+
+        embs = torch.cat([state_emb[:, None], action_time_emb], dim=1)
+        pad_masks = torch.ones((bsize, action_time_dim + 1), device=device, dtype=torch.bool)
+
+        # Set attention masks for suffix tokens so that prefix tokens cannot attend to suffix tokens.
+        # And state token cannot attend action tokens.
+        # Action tokens use a bidirectional attention.
+        att_masks = torch.zeros((bsize, action_time_dim + 1), device=device, dtype=torch.bool)
+        att_masks[:, :2] = True
+
+        return time_emb_ori, embs, pad_masks, att_masks
+
+    def forward(
+        self,
+        images,
+        img_masks,
+        lang_tokens,
+        lang_masks,
+        state,
+        actions,
+        label=None,
+        noise=None,
+        time=None,
+        vlm_causal=False,
+        loss_type="fm",
+        depth_targets=None,
+        norm_qkv=False,
+    ) -> Tensor:
+        dtype = state.dtype
+        device = state.device
+        if noise is None:
+            noise = torch.randn(actions.shape, device=device, dtype=dtype)
+
+        if time is None:
+            time = self.sample_time(actions.size(0), device).to(dtype)
+
+        time_expanded = time[:, None, None]
+        x_t = time_expanded * noise + (1 - time_expanded) * actions
+        u_t = noise - actions
+
+        prefix_embs, prefix_pad_masks, prefix_att_masks = self.embed_prefix(
+            images, img_masks, lang_tokens, lang_masks, vlm_causal, label
+        )  # 1,bs_img*(768+48),2048  1,bs_img*(768+48)  1,bs_img*(768+48)
+        time_embs, suffix_embs, suffix_pad_masks, suffix_att_masks = self.embed_suffix(
+            state, x_t, time
+        )  # [1, state_bs*(50+1), 1024], [1, state_bs*(50+1)], [1, state_bs*(50+1)]   state_bs=bs_img
+
+        pad_masks = torch.cat([prefix_pad_masks, suffix_pad_masks], dim=1)
+        att_masks = torch.cat([prefix_att_masks, suffix_att_masks], dim=1)
+
+        # pad_masks = pad_masks.reshape(state.size(0), -1)
+        # att_masks = att_masks.reshape(state.size(0), -1)
+        att_2d_masks = make_att_2d_masks(pad_masks, att_masks)
+        if self.use_depth_align and self.align_type == "query":
+            att_2d_masks = self.make_att_2d_masks_with_query(
+                att_2d_masks, prefix_pad_masks.shape[-1], img_masks
+            )
+        position_ids = torch.cumsum(pad_masks, dim=1) - 1
+        vlm_position_ids = torch.cumsum(prefix_pad_masks, dim=1) - 1
+
+        # prefix_embs = prefix_embs.reshape(state.size(0), -1, prefix_embs.size(-1))
+        # suffix_embs = suffix_embs.reshape(state.size(0), -1, suffix_embs.size(-1))
+        (outputs_embeds, suffix_out), _ = self.qwenvl_with_expert.forward(
+            attention_mask=att_2d_masks,
+            position_ids=position_ids,
+            vlm_position_ids=vlm_position_ids,
+            past_key_values=None,
+            inputs_embeds=[prefix_embs, suffix_embs],
+            use_cache=self.config.use_cache,
+            fill_kv_cache=True,
+            ada_cond=time_embs if getattr(self.config, "adanorm_time", False) else None,
+            norm_qkv=norm_qkv,
+        )
+        if self.config.align_params != {}:
+            loss_depth, depth_preds = self.depth_emb_forward(outputs_embeds, depth_targets, img_masks)
+            loss_depth = loss_depth * self.config.align_params["depth_loss_weight"]
+            self.steps += 1
+        else:
+            loss_depth = 0
+            depth_preds = None
+        suffix_out = suffix_out[:, -self.config.n_action_steps :]
+        if suffix_out.dtype != self.action_out_proj.weight.dtype:
+            suffix_out = suffix_out.to(self.action_out_proj.weight.dtype)
+        v_t = self.action_out_proj(suffix_out)
+        # u_t = u_t.reshape(images.size(0), -1, u_t.size(-1))
+        if loss_type == "fm":
+            losses = F.mse_loss(u_t, v_t, reduction="none")
+        elif loss_type == "L1_fm":
+            losses = F.l1_loss(u_t, v_t, reduction="none")
+
+        return losses, loss_depth, depth_preds
+
+    def sample_actions(
+        self, images, img_masks, lang_tokens, lang_masks, state, vlm_causal=False, noise=None, num_steps=None
+    ) -> Tensor:
+        """Do a full inference forward and compute the action (batch_size x num_steps x num_motors)"""
+        bsize = state.shape[0]
+        device = state.device
+        dtype = state.dtype
+
+        if noise is None:
+            actions_shape = (
+                bsize,
+                self.config.n_action_steps,
+                self.config.max_action_dim,
+            )
+            noise = torch.randn(actions_shape, device=device, dtype=dtype)
+
+        prefix_embs, prefix_pad_masks, prefix_att_masks = self.embed_prefix(
+            images, img_masks, lang_tokens, lang_masks, vlm_causal
+        )
+        prefix_att_2d_masks = make_att_2d_masks(
+            prefix_pad_masks, prefix_att_masks
+        )  # bs, prefix_len, prefix_len
+        if self.use_depth_align and self.align_type == "query":
+            prefix_att_2d_masks = self.make_att_2d_masks_with_query(
+                prefix_att_2d_masks, prefix_pad_masks.shape[-1], img_masks
+            )
+        prefix_position_ids = torch.cumsum(prefix_pad_masks, dim=1) - 1
+
+        # Compute image and language key value cache
+        _, past_key_values = self.qwenvl_with_expert.forward(
+            attention_mask=prefix_att_2d_masks,
+            position_ids=prefix_position_ids,
+            past_key_values=None,
+            inputs_embeds=[prefix_embs, None],
+            use_cache=self.config.use_cache,
+            fill_kv_cache=True,
+        )
+
+        num_steps = num_steps if num_steps is not None else self.config.num_steps
+        dt = torch.tensor(-1.0 / num_steps, dtype=dtype, device=device)
+        x_t = noise
+        time = torch.tensor(1.0, dtype=dtype, device=device)
+        count = 0
+        while time >= -dt / 2:
+            count += 1
+            expanded_time = time.expand(bsize)
+
+            v_t = self.predict_velocity(state, prefix_pad_masks, past_key_values, x_t, expanded_time)
+
+            # Euler step
+            x_t += dt * v_t
+            time += dt
+        return x_t
+
+    def predict_velocity(self, state, prefix_pad_masks, past_key_values, x_t, timestep):
+        """predict velocity at time t using the suffix model."""
+        time_embs, suffix_embs, suffix_pad_masks, suffix_att_masks = self.embed_suffix(state, x_t, timestep)
+
+        suffix_len = suffix_pad_masks.shape[1]
+        batch_size = prefix_pad_masks.shape[0]
+        prefix_len = prefix_pad_masks.shape[1]
+        prefix_pad_2d_masks = prefix_pad_masks[:, None, :].expand(batch_size, suffix_len, prefix_len)
+
+        suffix_att_2d_masks = make_att_2d_masks(suffix_pad_masks, suffix_att_masks)
+
+        full_att_2d_masks = torch.cat(
+            [prefix_pad_2d_masks, suffix_att_2d_masks], dim=2
+        )  # bs, suffix_len, prefix_len+suffix_len
+
+        prefix_offsets = torch.sum(prefix_pad_masks, dim=-1)[:, None]
+        position_ids = prefix_offsets + torch.cumsum(suffix_pad_masks, dim=1) - 1
+
+        outputs_embeds, _ = self.qwenvl_with_expert.forward(
+            attention_mask=full_att_2d_masks,
+            position_ids=position_ids,
+            past_key_values=past_key_values,
+            inputs_embeds=[None, suffix_embs],
+            use_cache=self.config.use_cache,
+            fill_kv_cache=False,
+            ada_cond=time_embs if getattr(self.config, "adanorm_time", False) else None,
+        )
+        suffix_out = outputs_embeds[1]
+        suffix_out = suffix_out[:, -self.config.n_action_steps :]
+        v_t = self.action_out_proj(suffix_out)
+        return v_t
+
+    def make_att_2d_masks_with_query(self, att_2d_masks, prefix_len, img_masks):
+        if img_masks.ndim == 1:
+            img_masks = img_masks.unsqueeze(0)
+
+        num_image_tokens = self.llm_image_token_size * self.llm_image_token_size
+
+        att_2d_masks[
+            :,
+            num_image_tokens * 0 : num_image_tokens * 3,
+            num_image_tokens * 3 + self.num_task_tokens * 0 : num_image_tokens * 3 + self.num_task_tokens * 3,
+        ] = False
+        att_2d_masks[
+            :,
+            num_image_tokens * 3 + self.num_task_tokens * 3 : prefix_len,
+            num_image_tokens * 3 + self.num_task_tokens * 0 : num_image_tokens * 3 + self.num_task_tokens * 3,
+        ] = False
+
+        att_2d_masks[
+            :,
+            num_image_tokens * 3 + self.num_task_tokens * 0 : num_image_tokens * 3 + self.num_task_tokens * 3,
+            :,
+        ] = False
+
+        att_2d_masks[
+            img_masks[:, 0],
+            num_image_tokens * 3 + self.num_task_tokens * 0 : num_image_tokens * 3 + self.num_task_tokens * 1,
+            num_image_tokens * 0 : num_image_tokens * 1,
+        ] = True
+        att_2d_masks[
+            img_masks[:, 1],
+            num_image_tokens * 3 + self.num_task_tokens * 1 : num_image_tokens * 3 + self.num_task_tokens * 2,
+            num_image_tokens * 1 : num_image_tokens * 2,
+        ] = True
+        att_2d_masks[
+            img_masks[:, 2],
+            num_image_tokens * 3 + self.num_task_tokens * 2 : num_image_tokens * 3 + self.num_task_tokens * 3,
+            num_image_tokens * 2 : num_image_tokens * 3,
+        ] = True
+
+        att_2d_masks[
+            img_masks[:, 0],
+            num_image_tokens * 3 + self.num_task_tokens * 0 : num_image_tokens * 3 + self.num_task_tokens * 1,
+            num_image_tokens * 3 + self.num_task_tokens * 0 : num_image_tokens * 3 + self.num_task_tokens * 1,
+        ] = True
+        att_2d_masks[
+            img_masks[:, 1],
+            num_image_tokens * 3 + self.num_task_tokens * 1 : num_image_tokens * 3 + self.num_task_tokens * 2,
+            num_image_tokens * 3 + self.num_task_tokens * 1 : num_image_tokens * 3 + self.num_task_tokens * 2,
+        ] = True
+        att_2d_masks[
+            img_masks[:, 2],
+            num_image_tokens * 3 + self.num_task_tokens * 2 : num_image_tokens * 3 + self.num_task_tokens * 3,
+            num_image_tokens * 3 + self.num_task_tokens * 2 : num_image_tokens * 3 + self.num_task_tokens * 3,
+        ] = True
+
+        return att_2d_masks
+
+    def depth_emb_forward(self, hidden_states, depth_targets=None, img_masks=None):
+        chunk_size = self.llm_image_token_size * self.llm_image_token_size
+        img_masks = einops.rearrange(img_masks, "b n -> (b n)")
+        if self.align_type == "direct":
+            image_embs = hidden_states[:, chunk_size * 0 : chunk_size * 3, :]
+            image_embs = einops.rearrange(image_embs, "b (n l) c -> (b n) l c", n=3)
+
+            depth_preds = self.depth_align_head(image_embs).contiguous().float()
+        elif self.align_type == "query":
+            align_embs = hidden_states[:, chunk_size * 3 : chunk_size * 3 + self.num_task_tokens * 3, :]
+            align_embs = einops.rearrange(align_embs, "b (n l) c -> (b n) l c", n=3)
+
+            image_embs = hidden_states[:, chunk_size * 0 : chunk_size * 3, :]
+            image_embs = einops.rearrange(image_embs, "b (n l) c -> (b n) l c", n=3)
+
+            align_embs = torch.cat([image_embs, align_embs], dim=1)
+            depth_preds = self.depth_align_embs.repeat(align_embs.shape[0], 1, 1).to(
+                dtype=align_embs.dtype, device=align_embs.device
+            )
+
+            depth_preds = self.depth_align_head(align_embs, depth_preds).contiguous().float()
+
+        loss = self._emb_loss(depth_preds[img_masks], depth_targets[img_masks])
+
+        return loss, depth_preds
+
+    def _emb_loss(self, emb_preds, emb_targets):
+        if self.align_type == "direct":
+            S, L, D = emb_targets.shape
+            emb_preds = emb_preds.contiguous().view(
+                S * self.llm_image_token_size * self.llm_image_token_size, emb_preds.shape[-1]
+            )
+
+            emb_targets = emb_targets.to(emb_preds.dtype).to(emb_preds.device)
+            emb_targets = (
+                emb_targets.view(S, self.depth_token_size, self.depth_token_size, D)
+                .permute(0, 3, 1, 2)
+                .contiguous()
+            )
+            emb_targets = F.adaptive_avg_pool2d(
+                emb_targets, (self.llm_image_token_size, self.llm_image_token_size)
+            ).view(S, D, self.llm_image_token_size, self.llm_image_token_size)
+            emb_targets = (
+                emb_targets.view(S, D, self.llm_image_token_size * self.llm_image_token_size)
+                .permute(0, 2, 1)
+                .contiguous()
+                .view(S * self.llm_image_token_size * self.llm_image_token_size, D)
+            )
+
+            l1_loss = F.l1_loss(emb_preds.float(), emb_targets.float().detach(), reduction="none")
+
+            emb_preds_norm = F.normalize(emb_preds.float(), p=2, dim=-1, eps=1e-6)
+            emb_targets_norm = F.normalize(emb_targets.float(), p=2, dim=-1, eps=1e-6)
+            emb_preds_matrix = torch.matmul(emb_preds_norm, emb_preds_norm.transpose(0, 1))
+            emb_targets_matrix = torch.matmul(emb_targets_norm, emb_targets_norm.transpose(0, 1))
+
+            sim_loss = F.l1_loss(
+                emb_preds_matrix.float(), emb_targets_matrix.float().detach(), reduction="none"
+            )
+
+            emb_loss = sim_loss.mean() + l1_loss.mean()
+        elif self.align_type == "query":
+            l1_loss = F.smooth_l1_loss(emb_preds.float(), emb_targets.float().detach(), reduction="none")
+            emb_loss = l1_loss.mean()
+            if self.model_type == "MoRGBD":
+                emb_loss = emb_loss
+        return emb_loss
+
+
+__all__ = [
+    "LingbotVLAPolicy",
+    "FlowMatching",
+    "QwenvlWithExpertModel",
+    "Qwen2_5_VLForConditionalGeneration",
+    "Qwen2_5_VLModel",
+    "Qwen2ForCausalLM",
+    "Qwen2_5_VLPreTrainedModel",
+]

--- a/src/lerobot/policies/lingbot_vla/processor_lingbot_vla.py
+++ b/src/lerobot/policies/lingbot_vla/processor_lingbot_vla.py
@@ -1,0 +1,270 @@
+# Copyright 2025 HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pre/post-processing pipeline for the LingBot-VLA policy.
+
+The pre-processor turns a raw LeRobot observation into the model-ready tensors
+that ``LingbotVLAPolicy`` consumes:
+
+    - ``images``      (B, num_views, num_patches, patch_dim) Qwen2.5-VL patchified pixels
+    - ``img_masks``   (B, num_views) per-view validity mask
+    - ``lang_tokens`` (B, L) tokenized instruction
+    - ``lang_masks``  (B, L) instruction attention mask
+
+State and action stay at their real (dataset) dimensionality through the
+pipeline; the policy pads them to the unified 75-dim slots internally.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+import torch
+
+from lerobot.configs import FeatureType, PipelineFeatureType, PolicyFeature
+from lerobot.processor import (
+    AddBatchDimensionProcessorStep,
+    ComplementaryDataProcessorStep,
+    DeviceProcessorStep,
+    NormalizerProcessorStep,
+    ObservationProcessorStep,
+    PolicyAction,
+    PolicyProcessorPipeline,
+    ProcessorStep,
+    ProcessorStepRegistry,
+    RenameObservationsProcessorStep,
+    UnnormalizerProcessorStep,
+    policy_action_to_transition,
+    transition_to_policy_action,
+)
+from lerobot.types import TransitionKey
+from lerobot.utils.constants import (
+    POLICY_POSTPROCESSOR_DEFAULT_NAME,
+    POLICY_PREPROCESSOR_DEFAULT_NAME,
+)
+from lerobot.utils.import_utils import _transformers_available
+
+from .configuration_lingbot_vla import LingbotVLAConfig
+from .utils import resize_with_pad
+
+if _transformers_available:
+    from transformers import AutoProcessor, AutoTokenizer
+else:
+    AutoProcessor = None
+    AutoTokenizer = None
+
+
+@ProcessorStepRegistry.register(name="lingbot_vla_task_processor")
+class LingbotVLATaskProcessor(ComplementaryDataProcessorStep):
+    """Ensures a task instruction string is always present."""
+
+    def complementary_data(self, complementary_data):
+        new_complementary_data = dict(complementary_data)
+        task = complementary_data.get("task")
+        if task is None:
+            new_complementary_data["task"] = "Execute the robot action."
+        return new_complementary_data
+
+    def transform_features(
+        self, features: dict[PipelineFeatureType, dict[str, PolicyFeature]]
+    ) -> dict[PipelineFeatureType, dict[str, PolicyFeature]]:
+        return features
+
+
+@dataclass
+@ProcessorStepRegistry.register(name="lingbot_vla_images_processor")
+class LingbotVLAImagesProcessorStep(ObservationProcessorStep):
+    """Resize + Qwen2.5-VL patchify the camera views into ``images`` / ``img_masks``."""
+
+    tokenizer_path: str = "Qwen/Qwen2.5-VL-3B-Instruct"
+    image_keys: list[str] = field(default_factory=list)
+    resize_size: tuple[int, int] = (224, 224)
+
+    image_processor: Any = field(default=None, init=False, repr=False)
+
+    def __post_init__(self):
+        if not _transformers_available:
+            raise ImportError(
+                "transformers is required for LingbotVLAImagesProcessorStep. "
+                "Install it with `pip install 'lerobot[lingbot]'`."
+            )
+        processor = AutoProcessor.from_pretrained(
+            self.tokenizer_path, padding_side="right", trust_remote_code=True
+        )
+        self.image_processor = processor.image_processor
+
+    def _patchify_view(self, img: torch.Tensor) -> torch.Tensor:
+        # img: (B, C, H, W) in [0, 1] -> (B, num_patches, patch_dim)
+        img = img.to(torch.float32) * 255.0
+        img = resize_with_pad(img, self.resize_size[0], self.resize_size[1], pad_value=0)
+        patches = []
+        for b in range(img.shape[0]):
+            pixel_values = self.image_processor(img[b])["pixel_values"]
+            if not isinstance(pixel_values, torch.Tensor):
+                pixel_values = torch.as_tensor(np.asarray(pixel_values))
+            patches.append(pixel_values)
+        return torch.stack(patches, dim=0)
+
+    def observation(self, observation):
+        new_observation = dict(observation)
+        present_keys = [k for k in self.image_keys if k in observation]
+        if not present_keys:
+            raise ValueError(f"None of the configured image keys {self.image_keys} found in the observation.")
+
+        ref = observation[present_keys[0]]
+        batch_size = ref.shape[0]
+
+        view_tensors, masks = [], []
+        for key in self.image_keys:
+            if key in observation:
+                view_tensors.append(self._patchify_view(observation[key]))
+                masks.append(torch.ones(batch_size, dtype=torch.bool))
+            else:
+                view_tensors.append(torch.zeros_like(view_tensors[0]))
+                masks.append(torch.zeros(batch_size, dtype=torch.bool))
+            new_observation.pop(key, None)
+
+        new_observation["images"] = torch.stack(view_tensors, dim=1)  # (B, n_views, L, patch_dim)
+        new_observation["img_masks"] = torch.stack(masks, dim=1)  # (B, n_views)
+        return new_observation
+
+    def get_config(self) -> dict[str, Any]:
+        return {
+            "tokenizer_path": self.tokenizer_path,
+            "image_keys": list(self.image_keys),
+            "resize_size": list(self.resize_size),
+        }
+
+    def transform_features(
+        self, features: dict[PipelineFeatureType, dict[str, PolicyFeature]]
+    ) -> dict[PipelineFeatureType, dict[str, PolicyFeature]]:
+        return features
+
+
+@dataclass
+@ProcessorStepRegistry.register(name="lingbot_vla_language_processor")
+class LingbotVLALanguageProcessorStep(ObservationProcessorStep):
+    """Tokenize the instruction into ``lang_tokens`` / ``lang_masks`` (Qwen2.5-VL tokenizer)."""
+
+    tokenizer_path: str = "Qwen/Qwen2.5-VL-3B-Instruct"
+    max_length: int = 72
+
+    tokenizer: Any = field(default=None, init=False, repr=False)
+
+    def __post_init__(self):
+        if not _transformers_available:
+            raise ImportError(
+                "transformers is required for LingbotVLALanguageProcessorStep. "
+                "Install it with `pip install 'lerobot[lingbot]'`."
+            )
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            self.tokenizer_path, padding_side="right", trust_remote_code=True
+        )
+
+    def observation(self, observation):
+        complementary_data = self.transition.get(TransitionKey.COMPLEMENTARY_DATA) or {}
+        task = complementary_data.get("task")
+        if task is None:
+            raise ValueError("A 'task' instruction is required but was not found in complementary data.")
+        if isinstance(task, str):
+            task = [task]
+
+        # Match the LingBot-VLA training prompt format: "<bos>{task}\n".
+        prompts = [p if p.startswith("<bos>") else f"<bos>{p}" for p in task]
+        prompts = [p if p.endswith("\n") else f"{p}\n" for p in prompts]
+
+        tokenized = self.tokenizer(
+            prompts,
+            max_length=self.max_length,
+            truncation=True,
+            padding="max_length",
+            padding_side="right",
+            return_tensors="pt",
+        )
+
+        new_observation = dict(observation)
+        new_observation["lang_tokens"] = tokenized["input_ids"]
+        new_observation["lang_masks"] = tokenized["attention_mask"].to(dtype=torch.bool)
+        return new_observation
+
+    def get_config(self) -> dict[str, Any]:
+        return {"tokenizer_path": self.tokenizer_path, "max_length": self.max_length}
+
+    def transform_features(
+        self, features: dict[PipelineFeatureType, dict[str, PolicyFeature]]
+    ) -> dict[PipelineFeatureType, dict[str, PolicyFeature]]:
+        if "lang_tokens" not in features[PipelineFeatureType.OBSERVATION]:
+            features[PipelineFeatureType.OBSERVATION]["lang_tokens"] = PolicyFeature(
+                type=FeatureType.LANGUAGE, shape=(self.max_length,)
+            )
+        if "lang_masks" not in features[PipelineFeatureType.OBSERVATION]:
+            features[PipelineFeatureType.OBSERVATION]["lang_masks"] = PolicyFeature(
+                type=FeatureType.LANGUAGE, shape=(self.max_length,)
+            )
+        return features
+
+
+def make_lingbot_vla_pre_post_processors(
+    config: LingbotVLAConfig,
+    dataset_stats: dict[str, dict[str, torch.Tensor]] | None = None,
+) -> tuple[
+    PolicyProcessorPipeline[dict[str, Any], dict[str, Any]],
+    PolicyProcessorPipeline[PolicyAction, PolicyAction],
+]:
+    """Build the LingBot-VLA pre- and post-processing pipelines."""
+
+    image_keys = [key for key, feat in config.input_features.items() if feat.type == FeatureType.VISUAL]
+
+    input_steps: list[ProcessorStep] = [
+        RenameObservationsProcessorStep(rename_map={}),
+        AddBatchDimensionProcessorStep(),
+        LingbotVLATaskProcessor(),
+        NormalizerProcessorStep(
+            features={**config.input_features, **config.output_features},
+            norm_map=config.normalization_mapping,
+            stats=dataset_stats,
+        ),
+        LingbotVLAImagesProcessorStep(
+            tokenizer_path=config.tokenizer_path,
+            image_keys=image_keys,
+            resize_size=tuple(config.resize_imgs_with_padding),
+        ),
+        LingbotVLALanguageProcessorStep(
+            tokenizer_path=config.tokenizer_path,
+            max_length=config.tokenizer_max_length,
+        ),
+        DeviceProcessorStep(device=config.device),
+    ]
+
+    output_steps: list[ProcessorStep] = [
+        UnnormalizerProcessorStep(
+            features=config.output_features, norm_map=config.normalization_mapping, stats=dataset_stats
+        ),
+        DeviceProcessorStep(device="cpu"),
+    ]
+
+    return (
+        PolicyProcessorPipeline[dict[str, Any], dict[str, Any]](
+            steps=input_steps,
+            name=POLICY_PREPROCESSOR_DEFAULT_NAME,
+        ),
+        PolicyProcessorPipeline[PolicyAction, PolicyAction](
+            steps=output_steps,
+            name=POLICY_POSTPROCESSOR_DEFAULT_NAME,
+            to_transition=policy_action_to_transition,
+            to_output=transition_to_policy_action,
+        ),
+    )

--- a/src/lerobot/policies/lingbot_vla/qwen_model/__init__.py
+++ b/src/lerobot/policies/lingbot_vla/qwen_model/__init__.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/src/lerobot/policies/lingbot_vla/qwen_model/qwenvl_in_vla.py
+++ b/src/lerobot/policies/lingbot_vla/qwen_model/qwenvl_in_vla.py
@@ -1,0 +1,1992 @@
+#!/usr/bin/env python
+
+# Copyright 2025 The Qwen team, Alibaba Group and The HuggingFace Inc. team. All rights reserved.
+#
+# This file is adapted from HuggingFace Transformers'
+# `models/qwen2_5_vl/modeling_qwen2_5_vl.py` (Qwen2.5-VL) and modified for the
+# LingBot-VLA dual-stream policy integration.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+from torch.nn import CrossEntropyLoss
+from transformers.activations import ACT2FN
+from transformers.cache_utils import Cache, DynamicCache, SlidingWindowCache, StaticCache
+from transformers.generation import GenerationMixin
+from transformers.modeling_attn_mask_utils import AttentionMaskConverter
+from transformers.modeling_flash_attention_utils import (
+    FlashAttentionKwargs,
+    flash_attn_supports_top_left_mask,
+    is_flash_attn_available,
+)
+from transformers.modeling_outputs import (
+    BaseModelOutputWithPast,
+)
+from transformers.modeling_rope_utils import ROPE_INIT_FUNCTIONS, dynamic_rope_update
+from transformers.modeling_utils import PreTrainedModel
+from transformers.models.qwen2_5_vl.configuration_qwen2_5_vl import Qwen2_5_VLConfig, Qwen2_5_VLVisionConfig
+from transformers.processing_utils import Unpack
+from transformers.utils import (
+    ModelOutput,
+    add_start_docstrings,
+    add_start_docstrings_to_model_forward,
+    logging,
+    replace_return_docstrings,
+)
+
+if is_flash_attn_available():
+    from transformers.modeling_flash_attention_utils import apply_rotary_emb, flash_attn_varlen_func
+if is_flash_attn_available():
+    from transformers.modeling_flash_attention_utils import _flash_attention_forward
+
+
+logger = logging.get_logger(__name__)
+
+_CONFIG_FOR_DOC = "Qwen2_5_VLConfig"
+
+
+def repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
+    """
+    This is the equivalent of torch.repeat_interleave(x, dim=1, repeats=n_rep). The hidden states go from (batch,
+    num_key_value_heads, seqlen, head_dim) to (batch, num_attention_heads, seqlen, head_dim)
+    """
+    batch, num_key_value_heads, slen, head_dim = hidden_states.shape
+    if n_rep == 1:
+        return hidden_states
+    hidden_states = hidden_states[:, :, None, :, :].expand(batch, num_key_value_heads, n_rep, slen, head_dim)
+    return hidden_states.reshape(batch, num_key_value_heads * n_rep, slen, head_dim)
+
+
+class Qwen2_5_VLMLP(nn.Module):
+    def __init__(self, config, bias: bool = False):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.intermediate_size = config.intermediate_size
+        self.gate_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=bias)
+        self.up_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=bias)
+        self.down_proj = nn.Linear(self.intermediate_size, self.hidden_size, bias=bias)
+        self.act_fn = ACT2FN[config.hidden_act]
+
+    def forward(self, hidden_state):
+        return self.down_proj(self.act_fn(self.gate_proj(hidden_state)) * self.up_proj(hidden_state))
+
+
+class Qwen2_5_VisionPatchEmbed(nn.Module):
+    def __init__(
+        self,
+        patch_size: int = 14,
+        temporal_patch_size: int = 2,
+        in_channels: int = 3,
+        embed_dim: int = 1152,
+    ) -> None:
+        super().__init__()
+        self.patch_size = patch_size
+        self.temporal_patch_size = temporal_patch_size
+        self.in_channels = in_channels
+        self.embed_dim = embed_dim
+
+        kernel_size = [temporal_patch_size, patch_size, patch_size]
+        self.proj = nn.Conv3d(in_channels, embed_dim, kernel_size=kernel_size, stride=kernel_size, bias=False)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        target_dtype = self.proj.weight.dtype
+        hidden_states = hidden_states.view(
+            -1, self.in_channels, self.temporal_patch_size, self.patch_size, self.patch_size
+        )
+        hidden_states = self.proj(hidden_states.to(dtype=target_dtype)).view(-1, self.embed_dim)
+        return hidden_states
+
+
+class Qwen2_5_VisionRotaryEmbedding(nn.Module):
+    def __init__(self, dim: int, theta: float = 10000.0) -> None:
+        super().__init__()
+        inv_freq = 1.0 / (theta ** (torch.arange(0, dim, 2, dtype=torch.float) / dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+
+    def forward(self, seqlen: int) -> torch.Tensor:
+        seq = torch.arange(seqlen, device=self.inv_freq.device, dtype=self.inv_freq.dtype)
+        freqs = torch.outer(seq, self.inv_freq)
+        return freqs
+
+
+class Qwen2RMSNorm(nn.Module):
+    def __init__(self, hidden_size, eps=1e-6):
+        """
+        Qwen2RMSNorm is equivalent to T5LayerNorm
+        """
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(hidden_size))
+        self.variance_epsilon = eps
+
+    def forward(self, hidden_states):
+        input_dtype = hidden_states.dtype
+        hidden_states = hidden_states.to(torch.float32)
+        variance = hidden_states.pow(2).mean(-1, keepdim=True)
+        hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
+        return self.weight * hidden_states.to(input_dtype)
+
+    def extra_repr(self):
+        return f"{tuple(self.weight.shape)}, eps={self.variance_epsilon}"
+
+
+class Qwen2_5_VLPatchMerger(nn.Module):
+    def __init__(self, dim: int, context_dim: int, spatial_merge_size: int = 2) -> None:
+        super().__init__()
+        self.hidden_size = context_dim * (spatial_merge_size**2)
+        self.ln_q = Qwen2RMSNorm(context_dim, eps=1e-6)
+        self.mlp = nn.Sequential(
+            nn.Linear(self.hidden_size, self.hidden_size),
+            nn.GELU(),
+            nn.Linear(self.hidden_size, dim),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.mlp(self.ln_q(x).view(-1, self.hidden_size))
+        return x
+
+
+def apply_rotary_pos_emb_flashatt(
+    q: torch.Tensor, k: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    cos = cos.chunk(2, dim=-1)[0].contiguous()
+    sin = sin.chunk(2, dim=-1)[0].contiguous()
+    q_embed = apply_rotary_emb(q.float(), cos.float(), sin.float()).type_as(q)
+    k_embed = apply_rotary_emb(k.float(), cos.float(), sin.float()).type_as(k)
+    return q_embed, k_embed
+
+
+class Qwen2_5_VLVisionAttention(nn.Module):
+    def __init__(self, dim: int, num_heads: int = 16) -> None:
+        super().__init__()
+        self.num_heads = num_heads
+        self.head_dim = dim // num_heads
+        self.qkv = nn.Linear(dim, dim * 3, bias=True)
+        self.proj = nn.Linear(dim, dim)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        rotary_pos_emb: torch.Tensor | None = None,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
+    ) -> torch.Tensor:
+        seq_length = hidden_states.shape[0]
+        q, k, v = (
+            self.qkv(hidden_states).reshape(seq_length, 3, self.num_heads, -1).permute(1, 0, 2, 3).unbind(0)
+        )
+        if position_embeddings is None:
+            logger.warning_once(
+                "The attention layers in this model are transitioning from computing the RoPE embeddings internally "
+                "through `rotary_pos_emb` (2D tensor of RoPE theta values), to using externally computed "
+                "`position_embeddings` (Tuple of tensors, containing cos and sin). In v4.54 `rotary_pos_emb` will be "
+                "removed and `position_embeddings` will be mandatory."
+            )
+            emb = torch.cat((rotary_pos_emb, rotary_pos_emb), dim=-1)
+            cos = emb.cos()
+            sin = emb.sin()
+        else:
+            cos, sin = position_embeddings
+        q, k = apply_rotary_pos_emb_vision(q, k, cos, sin)
+
+        attention_mask = torch.full(
+            [1, seq_length, seq_length], torch.finfo(q.dtype).min, device=q.device, dtype=q.dtype
+        )
+        for i in range(1, len(cu_seqlens)):
+            attention_mask[..., cu_seqlens[i - 1] : cu_seqlens[i], cu_seqlens[i - 1] : cu_seqlens[i]] = 0
+
+        q = q.transpose(0, 1)
+        k = k.transpose(0, 1)
+        v = v.transpose(0, 1)
+        attn_weights = torch.matmul(q, k.transpose(1, 2)) / math.sqrt(self.head_dim)
+        attn_weights = attn_weights + attention_mask
+        attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(q.dtype)
+        attn_output = torch.matmul(attn_weights, v)
+        attn_output = attn_output.transpose(0, 1)
+        attn_output = attn_output.reshape(seq_length, -1)
+        attn_output = self.proj(attn_output)
+        return attn_output
+
+
+class Qwen2_5_VLVisionFlashAttention2(nn.Module):
+    def __init__(self, dim: int, num_heads: int = 16) -> None:
+        super().__init__()
+        self.num_heads = num_heads
+        self.qkv = nn.Linear(dim, dim * 3, bias=True)
+        self.proj = nn.Linear(dim, dim)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        rotary_pos_emb: torch.Tensor | None = None,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
+    ) -> torch.Tensor:
+        seq_length = hidden_states.shape[0]
+        q, k, v = (
+            self.qkv(hidden_states).reshape(seq_length, 3, self.num_heads, -1).permute(1, 0, 2, 3).unbind(0)
+        )
+        if position_embeddings is None:
+            logger.warning_once(
+                "The attention layers in this model are transitioning from computing the RoPE embeddings internally "
+                "through `rotary_pos_emb` (2D tensor of RoPE theta values), to using externally computed "
+                "`position_embeddings` (Tuple of tensors, containing cos and sin). In v4.54 `rotary_pos_emb` will be "
+                "removed and `position_embeddings` will be mandatory."
+            )
+            emb = torch.cat((rotary_pos_emb, rotary_pos_emb), dim=-1)
+            cos = emb.cos()
+            sin = emb.sin()
+        else:
+            cos, sin = position_embeddings
+        q, k = apply_rotary_pos_emb_flashatt(q.unsqueeze(0), k.unsqueeze(0), cos, sin)
+        q = q.squeeze(0)
+        k = k.squeeze(0)
+
+        max_seqlen = (cu_seqlens[1:] - cu_seqlens[:-1]).max().item()
+        out_fp32_atten = False
+        if k.dtype == torch.float32:
+            out_fp32_atten = True
+            q, k, v = q.to(torch.bfloat16), k.to(torch.bfloat16), v.to(torch.bfloat16)
+        attn_output = flash_attn_varlen_func(q, k, v, cu_seqlens, cu_seqlens, max_seqlen, max_seqlen).reshape(
+            seq_length, -1
+        )
+        if out_fp32_atten:
+            attn_output = attn_output.to(torch.float32)
+        attn_output = self.proj(attn_output)
+        return attn_output
+
+
+def rotate_half(x):
+    """Rotates half the hidden dims of the input (standard RoPE helper)."""
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def apply_rotary_pos_emb_vision(
+    q: torch.Tensor, k: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    orig_q_dtype = q.dtype
+    orig_k_dtype = k.dtype
+    q, k = q.float(), k.float()
+    cos, sin = cos.unsqueeze(-2).float(), sin.unsqueeze(-2).float()
+    q_embed = (q * cos) + (rotate_half(q) * sin)
+    k_embed = (k * cos) + (rotate_half(k) * sin)
+    q_embed = q_embed.to(orig_q_dtype)
+    k_embed = k_embed.to(orig_k_dtype)
+    return q_embed, k_embed
+
+
+QWEN2_5_VL_VISION_ATTENTION_CLASSES = {
+    "eager": Qwen2_5_VLVisionAttention,
+    "flash_attention_2": Qwen2_5_VLVisionFlashAttention2,
+}
+
+
+class Qwen2_5_VLVisionBlock(nn.Module):
+    def __init__(self, config, attn_implementation: str = "flash_attention_2") -> None:
+        super().__init__()
+        self.norm1 = Qwen2RMSNorm(config.hidden_size, eps=1e-6)
+        self.norm2 = Qwen2RMSNorm(config.hidden_size, eps=1e-6)
+        self.attn = QWEN2_5_VL_VISION_ATTENTION_CLASSES[attn_implementation](
+            config.hidden_size, num_heads=config.num_heads
+        )
+        self.mlp = Qwen2_5_VLMLP(config, bias=True)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        cu_seqlens: torch.Tensor,
+        rotary_pos_emb: torch.Tensor | None = None,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor] | None = None,
+    ) -> torch.Tensor:
+        hidden_states = hidden_states + self.attn(
+            self.norm1(hidden_states),
+            cu_seqlens=cu_seqlens,
+            rotary_pos_emb=rotary_pos_emb,
+            position_embeddings=position_embeddings,
+        )
+        hidden_states = hidden_states + self.mlp(self.norm2(hidden_states))
+        return hidden_states
+
+
+Qwen2_5_VL_START_DOCSTRING = r"""
+    This model inherits from [`PreTrainedModel`]. Check the superclass documentation for the generic methods the
+    library implements for all its model (such as downloading or saving, resizing the input embeddings, pruning heads
+    etc.)
+
+    This model is also a PyTorch [torch.nn.Module](https://pytorch.org/docs/stable/nn.html#torch.nn.Module) subclass.
+    Use it as a regular PyTorch Module and refer to the PyTorch documentation for all matter related to general usage
+    and behavior.
+
+    Parameters:
+        config ([`Qwen2_5_VLConfig`]):
+            Model configuration class with all the parameters of the model. Initializing with a config file does not
+            load the weights associated with the model, only the configuration. Check out the
+            [`~PreTrainedModel.from_pretrained`] method to load the model weights.
+"""
+
+
+@add_start_docstrings(
+    "The bare Qwen2_5_VL Model outputting raw hidden-states without any specific head on top.",
+    Qwen2_5_VL_START_DOCSTRING,
+)
+class Qwen2_5_VLPreTrainedModel(PreTrainedModel):
+    config_class = Qwen2_5_VLConfig
+    base_model_prefix = "model"
+    supports_gradient_checkpointing = True
+    _no_split_modules = ["Qwen2_5_VLDecoderLayer", "Qwen2_5_VLVisionBlock"]
+    _skip_keys_device_placement = "past_key_values"
+    _supports_flash_attn_2 = True
+    _supports_sdpa = True
+    _supports_cache_class = True
+    _supports_static_cache = (
+        False  # TODO (joao): fix. torch.compile failing probably due to `cache_positions`
+    )
+
+    # def _init_weights(self, module):
+    #     std = self.config.initializer_range
+    #     if isinstance(module, (nn.Linear, nn.Conv3d)):
+    #         module.weight.data.normal_(mean=0.0, std=std)
+    #         if module.bias is not None:
+    #             module.bias.data.zero_()
+    #     elif isinstance(module, nn.Embedding):
+    #         module.weight.data.normal_(mean=0.0, std=std)
+    #         if module.padding_idx is not None:
+    #             module.weight.data[module.padding_idx].zero_()
+
+
+class Qwen2_5_VisionTransformerPretrainedModel(Qwen2_5_VLPreTrainedModel):
+    config_class = Qwen2_5_VLVisionConfig
+    _no_split_modules = ["Qwen2_5_VLVisionBlock"]
+
+    def __init__(self, config, *inputs, **kwargs) -> None:
+        super().__init__(config, *inputs, **kwargs)
+        self.spatial_merge_size = config.spatial_merge_size
+        self.patch_size = config.patch_size
+        self.fullatt_block_indexes = config.fullatt_block_indexes
+        self.window_size = config.window_size
+        self.spatial_merge_unit = self.spatial_merge_size * self.spatial_merge_size
+
+        self.patch_embed = Qwen2_5_VisionPatchEmbed(
+            patch_size=config.patch_size,
+            temporal_patch_size=config.temporal_patch_size,
+            in_channels=config.in_channels,
+            embed_dim=config.hidden_size,
+        )
+
+        head_dim = config.hidden_size // config.num_heads
+        self.rotary_pos_emb = Qwen2_5_VisionRotaryEmbedding(head_dim // 2)
+
+        self.blocks = nn.ModuleList(
+            [Qwen2_5_VLVisionBlock(config, config._attn_implementation) for _ in range(config.depth)]
+        )
+        self.merger = Qwen2_5_VLPatchMerger(
+            dim=config.out_hidden_size,
+            context_dim=config.hidden_size,
+            spatial_merge_size=config.spatial_merge_size,
+        )
+        self.gradient_checkpointing = False
+
+    def rot_pos_emb(self, grid_thw):
+        pos_ids = []
+        for t, h, w in grid_thw:
+            hpos_ids = torch.arange(h).unsqueeze(1).expand(-1, w)
+            hpos_ids = hpos_ids.reshape(
+                h // self.spatial_merge_size,
+                self.spatial_merge_size,
+                w // self.spatial_merge_size,
+                self.spatial_merge_size,
+            )
+            hpos_ids = hpos_ids.permute(0, 2, 1, 3)
+            hpos_ids = hpos_ids.flatten()
+
+            wpos_ids = torch.arange(w).unsqueeze(0).expand(h, -1)
+            wpos_ids = wpos_ids.reshape(
+                h // self.spatial_merge_size,
+                self.spatial_merge_size,
+                w // self.spatial_merge_size,
+                self.spatial_merge_size,
+            )
+            wpos_ids = wpos_ids.permute(0, 2, 1, 3)
+            wpos_ids = wpos_ids.flatten()
+            pos_ids.append(torch.stack([hpos_ids, wpos_ids], dim=-1).repeat(t, 1))
+        pos_ids = torch.cat(pos_ids, dim=0)
+        max_grid_size = grid_thw[:, 1:].max()
+        rotary_pos_emb_full = self.rotary_pos_emb(max_grid_size)
+        rotary_pos_emb = rotary_pos_emb_full[pos_ids].flatten(1)
+        return rotary_pos_emb
+
+    def get_window_index(self, grid_thw):
+        window_index: list = []
+        cu_window_seqlens: list = [0]
+        window_index_id = 0
+        vit_merger_window_size = self.window_size // self.spatial_merge_size // self.patch_size
+
+        for grid_t, grid_h, grid_w in grid_thw:
+            llm_grid_h, llm_grid_w = (
+                grid_h // self.spatial_merge_size,
+                grid_w // self.spatial_merge_size,
+            )
+            index = torch.arange(grid_t * llm_grid_h * llm_grid_w).reshape(grid_t, llm_grid_h, llm_grid_w)
+            pad_h = vit_merger_window_size - llm_grid_h % vit_merger_window_size
+            pad_w = vit_merger_window_size - llm_grid_w % vit_merger_window_size
+            num_windows_h = (llm_grid_h + pad_h) // vit_merger_window_size
+            num_windows_w = (llm_grid_w + pad_w) // vit_merger_window_size
+            index_padded = F.pad(index, (0, pad_w, 0, pad_h), "constant", -100)
+            index_padded = index_padded.reshape(
+                grid_t,
+                num_windows_h,
+                vit_merger_window_size,
+                num_windows_w,
+                vit_merger_window_size,
+            )
+            index_padded = index_padded.permute(0, 1, 3, 2, 4).reshape(
+                grid_t,
+                num_windows_h * num_windows_w,
+                vit_merger_window_size,
+                vit_merger_window_size,
+            )
+            seqlens = (index_padded != -100).sum([2, 3]).reshape(-1)
+            index_padded = index_padded.reshape(-1)
+            index_new = index_padded[index_padded != -100]
+            window_index.append(index_new + window_index_id)
+            cu_seqlens_tmp = seqlens.cumsum(0) * self.spatial_merge_unit + cu_window_seqlens[-1]
+            cu_window_seqlens.extend(cu_seqlens_tmp.tolist())
+            window_index_id += (grid_t * llm_grid_h * llm_grid_w).item()
+        window_index = torch.cat(window_index, dim=0)
+
+        return window_index, cu_window_seqlens
+
+    def preprcess_grid_thw(self, grid_thw: torch.Tensor):
+        rotary_pos_emb = self.rot_pos_emb(grid_thw)
+        window_index, cu_window_seqlens = self.get_window_index(grid_thw)
+        cu_window_seqlens = torch.tensor(
+            cu_window_seqlens,
+            device=grid_thw.device,
+            dtype=grid_thw.dtype if torch.jit.is_tracing() else torch.int32,
+        )
+        cu_window_seqlens = torch.unique_consecutive(cu_window_seqlens)
+        cu_seqlens = torch.repeat_interleave(grid_thw[:, 1] * grid_thw[:, 2], grid_thw[:, 0]).cumsum(
+            dim=0,
+            # Select dtype based on the following factors:
+            #  - FA2 requires that cu_seqlens_q must have dtype int32
+            #  - torch.onnx.export requires that cu_seqlens_q must have same dtype as grid_thw
+            # See https://github.com/huggingface/transformers/pull/34852 for more information
+            dtype=grid_thw.dtype if torch.jit.is_tracing() else torch.int32,
+        )
+        cu_seqlens = F.pad(cu_seqlens, (1, 0), value=0)
+        return rotary_pos_emb, window_index, cu_window_seqlens, cu_seqlens
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        grid_thw: torch.Tensor = None,
+        rotary_pos_emb=None,
+        window_index=None,
+        cu_window_seqlens=None,
+        cu_seqlens=None,
+        **kwargs,
+    ) -> torch.Tensor:
+        """
+        Args:
+            hidden_states (`torch.Tensor` of shape `(seq_len, hidden_size)`):
+                The final hidden states of the model.
+            grid_thw (`torch.Tensor` of shape `(num_images_or_videos, 3)`):
+                The temporal, height and width of feature shape of each image in LLM.
+
+        Returns:
+            `torch.Tensor`: hidden_states.
+        """
+        hidden_states = self.patch_embed(hidden_states)
+
+        if rotary_pos_emb is None or window_index is None or cu_window_seqlens is None or cu_seqlens is None:
+            rotary_pos_emb, window_index, cu_window_seqlens, cu_seqlens = self.preprcess_grid_thw(grid_thw)
+
+        seq_len, _ = hidden_states.size()
+        hidden_states = hidden_states.reshape(seq_len // self.spatial_merge_unit, self.spatial_merge_unit, -1)
+        hidden_states = hidden_states[window_index, :, :]
+        hidden_states = hidden_states.reshape(seq_len, -1)
+        rotary_pos_emb = rotary_pos_emb.reshape(
+            seq_len // self.spatial_merge_unit, self.spatial_merge_unit, -1
+        )
+        rotary_pos_emb = rotary_pos_emb[window_index, :, :]
+        rotary_pos_emb = rotary_pos_emb.reshape(seq_len, -1)
+        emb = torch.cat((rotary_pos_emb, rotary_pos_emb), dim=-1)
+        position_embeddings = (emb.cos(), emb.sin())
+
+        for layer_num, blk in enumerate(self.blocks):
+            if layer_num in self.fullatt_block_indexes:
+                cu_seqlens_now = cu_seqlens
+            else:
+                cu_seqlens_now = cu_window_seqlens
+            if self.gradient_checkpointing and self.training:
+                hidden_states = self._gradient_checkpointing_func(
+                    blk.__call__, hidden_states, cu_seqlens_now, None, position_embeddings
+                )
+            else:
+                hidden_states = blk(
+                    hidden_states, cu_seqlens=cu_seqlens_now, position_embeddings=position_embeddings
+                )
+
+        hidden_states = self.merger(hidden_states)
+        reverse_indices = torch.argsort(window_index)
+        hidden_states = hidden_states[reverse_indices, :]
+
+        return hidden_states
+
+
+class Qwen2_5_VLRotaryEmbedding(nn.Module):
+    def __init__(self, config: Qwen2_5_VLConfig, device=None):
+        super().__init__()
+        # BC: "rope_type" was originally "type"
+        if hasattr(config, "rope_scaling") and config.rope_scaling is not None:
+            self.rope_type = config.rope_scaling.get("rope_type", config.rope_scaling.get("type"))
+        else:
+            self.rope_type = "default"
+        self.max_seq_len_cached = config.max_position_embeddings
+        self.original_max_seq_len = config.max_position_embeddings
+
+        self.config = config
+        # transformers>=5.0 dropped the "default" key from ROPE_INIT_FUNCTIONS.
+        # In the dual-stream VLA path rope is applied externally via utils.apply_rope,
+        # so this embedding only needs to instantiate; fall back to the standard
+        # (non-scaled) inv_freq computation for "default"/unknown rope types.
+        if self.rope_type in ROPE_INIT_FUNCTIONS:
+            self.rope_init_fn = ROPE_INIT_FUNCTIONS[self.rope_type]
+            inv_freq, self.attention_scaling = self.rope_init_fn(self.config, device)
+        else:
+            base = getattr(config, "rope_theta", None)
+            if base is None and config.rope_scaling is not None:
+                base = config.rope_scaling.get("rope_theta", 10000.0)
+            base = base if base is not None else 10000.0
+            head_dim = getattr(config, "head_dim", config.hidden_size // config.num_attention_heads)
+            inv_freq = 1.0 / (
+                base ** (torch.arange(0, head_dim, 2, dtype=torch.int64).to(device).float() / head_dim)
+            )
+            self.attention_scaling = 1.0
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self.original_inv_freq = self.inv_freq
+
+    @torch.no_grad()
+    @dynamic_rope_update  # power user: used with advanced RoPE types (e.g. dynamic rope)
+    def forward(self, x, position_ids):
+        # In contrast to other models, Qwen2_5_VL has different position ids for the grids
+        # So we expand the inv_freq to shape (3, ...)
+        inv_freq_expanded = self.inv_freq[None, None, :, None].float().expand(3, position_ids.shape[1], -1, 1)
+        position_ids_expanded = position_ids[:, :, None, :].float()  # shape (3, bs, 1, positions)
+
+        device_type = x.device.type if isinstance(x.device.type, str) and x.device.type != "mps" else "cpu"
+        with torch.autocast(device_type=device_type, enabled=False):  # Force float32
+            freqs = (inv_freq_expanded.float() @ position_ids_expanded.float()).transpose(2, 3)
+            emb = torch.cat((freqs, freqs), dim=-1)
+            cos = emb.cos() * self.attention_scaling
+            sin = emb.sin() * self.attention_scaling
+
+        return cos.to(dtype=x.dtype), sin.to(dtype=x.dtype)
+
+
+def apply_multimodal_rotary_pos_emb(q, k, cos, sin, mrope_section, unsqueeze_dim=1):
+    """Applies Rotary Position Embedding with Multimodal Sections to the query and key tensors (https://qwenlm.github.io/blog/qwen2-vl/).
+
+    Explanation:
+        Multimodal 3D rotary position embedding is an extension to 1D rotary position embedding. The input embedding
+        sequence contains vision (images / videos) embedding and text embedding or just contains text embedding. For
+        vision embedding part, we apply rotary position embedding on temporal, height and width dimension separately.
+        Here we split the channel dimension to 3 chunks for the temporal, height and width rotary position embedding.
+        For text embedding part, we just apply 1D rotary position embedding. The three rotary position index (temporal,
+        height and width) of text embedding is always the same, so the text embedding rotary position embedding has no
+        difference with modern LLMs.
+
+    Args:
+        q (`torch.Tensor`): The query tensor.
+        k (`torch.Tensor`): The key tensor.
+        cos (`torch.Tensor`): The cosine part of the rotary embedding.
+        sin (`torch.Tensor`): The sine part of the rotary embedding.
+        position_ids (`torch.Tensor`):
+            The position indices of the tokens corresponding to the query and key tensors. For example, this can be
+            used to pass offsetted position ids when working with a KV-cache.
+        mrope_section(`List(int)`):
+            Multimodal rope section is for channel dimension of temporal, height and width in rope calculation.
+        unsqueeze_dim (`int`, *optional*, defaults to 1):
+            The 'unsqueeze_dim' argument specifies the dimension along which to unsqueeze cos[position_ids] and
+            sin[position_ids] so that they can be properly broadcasted to the dimensions of q and k. For example, note
+            that cos[position_ids] and sin[position_ids] have the shape [batch_size, seq_len, head_dim]. Then, if q and
+            k have the shape [batch_size, heads, seq_len, head_dim], then setting unsqueeze_dim=1 makes
+            cos[position_ids] and sin[position_ids] broadcastable to the shapes of q and k. Similarly, if q and k have
+            the shape [batch_size, seq_len, heads, head_dim], then set unsqueeze_dim=2.
+    Returns:
+        `tuple(torch.Tensor)` comprising of the query and key tensors rotated using the Rotary Position Embedding.
+    """
+    mrope_section = mrope_section * 2
+    cos = torch.cat([m[i % 3] for i, m in enumerate(cos.split(mrope_section, dim=-1))], dim=-1).unsqueeze(
+        unsqueeze_dim
+    )
+    sin = torch.cat([m[i % 3] for i, m in enumerate(sin.split(mrope_section, dim=-1))], dim=-1).unsqueeze(
+        unsqueeze_dim
+    )
+
+    q_embed = (q * cos) + (rotate_half(q) * sin)
+    k_embed = (k * cos) + (rotate_half(k) * sin)
+    return q_embed, k_embed
+
+
+class Qwen2_5_VLAttention(nn.Module):
+    """
+    Multi-headed attention from 'Attention Is All You Need' paper. Modified to use sliding window attention: Longformer
+    and "Generating Long Sequences with Sparse Transformers".
+    """
+
+    def __init__(self, config: Qwen2_5_VLConfig, layer_idx: int | None = None):
+        super().__init__()
+        self.config = config
+        self.layer_idx = layer_idx
+        if layer_idx is None:
+            logger.warning_once(
+                f"Instantiating {self.__class__.__name__} without passing `layer_idx` is not recommended and will "
+                "to errors during the forward call, if caching is used. Please make sure to provide a `layer_idx` "
+                "when creating this class."
+            )
+
+        self.hidden_size = config.hidden_size
+        self.num_heads = config.num_attention_heads
+        self.head_dim = self.hidden_size // self.num_heads
+        self.num_key_value_heads = config.num_key_value_heads
+        self.num_key_value_groups = self.num_heads // self.num_key_value_heads
+        self.is_causal = True
+        self.attention_dropout = config.attention_dropout
+        self.rope_scaling = config.rope_scaling
+
+        if (self.head_dim * self.num_heads) != self.hidden_size:
+            raise ValueError(
+                f"hidden_size must be divisible by num_heads (got `hidden_size`: {self.hidden_size}"
+                f" and `num_heads`: {self.num_heads})."
+            )
+        self.q_proj = nn.Linear(self.hidden_size, self.num_heads * self.head_dim, bias=True)
+        self.k_proj = nn.Linear(self.hidden_size, self.num_key_value_heads * self.head_dim, bias=True)
+        self.v_proj = nn.Linear(self.hidden_size, self.num_key_value_heads * self.head_dim, bias=True)
+        self.o_proj = nn.Linear(self.num_heads * self.head_dim, self.hidden_size, bias=False)
+
+        self.rotary_emb = Qwen2_5_VLRotaryEmbedding(config=config)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+        position_ids: torch.LongTensor | None = None,
+        past_key_value: Cache | None = None,
+        output_attentions: bool = False,
+        use_cache: bool = False,
+        cache_position: torch.LongTensor | None = None,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor]
+        | None = None,  # necessary, but kept here for BC
+    ) -> tuple[torch.Tensor, torch.Tensor | None, tuple[torch.Tensor] | None]:
+        bsz, q_len, _ = hidden_states.size()
+
+        query_states = self.q_proj(hidden_states)
+        key_states = self.k_proj(hidden_states)
+        value_states = self.v_proj(hidden_states)
+
+        query_states = query_states.view(bsz, q_len, -1, self.head_dim).transpose(1, 2)
+        key_states = key_states.view(bsz, q_len, -1, self.head_dim).transpose(1, 2)
+        value_states = value_states.view(bsz, q_len, -1, self.head_dim).transpose(1, 2)
+
+        cos, sin = position_embeddings
+        query_states, key_states = apply_multimodal_rotary_pos_emb(
+            query_states, key_states, cos, sin, self.rope_scaling["mrope_section"]
+        )
+
+        if past_key_value is not None:
+            cache_kwargs = {
+                "sin": sin,
+                "cos": cos,
+                "cache_position": cache_position,
+            }  # Specific to RoPE models
+            key_states, value_states = past_key_value.update(
+                key_states, value_states, self.layer_idx, cache_kwargs
+            )
+
+        # repeat k/v heads if n_kv_heads < n_heads
+        key_states = repeat_kv(key_states, self.num_key_value_groups)
+        value_states = repeat_kv(value_states, self.num_key_value_groups)
+
+        attn_weights = torch.matmul(query_states, key_states.transpose(2, 3)) / math.sqrt(self.head_dim)
+
+        if attention_mask is not None:  # no matter the length, we just slice it
+            causal_mask = attention_mask[:, :, :, : key_states.shape[-2]]
+            attn_weights = attn_weights + causal_mask
+
+        # Fix precision issues in Qwen2-VL float16 inference
+        # Replace inf values with zeros in attention weights to prevent NaN propagation
+        if query_states.dtype == torch.float16:
+            attn_weights = torch.where(
+                torch.isinf(attn_weights), torch.zeros_like(attn_weights), attn_weights
+            )
+
+        # upcast attention to fp32
+        attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query_states.dtype)
+        attn_weights = nn.functional.dropout(attn_weights, p=self.attention_dropout, training=self.training)
+        attn_output = torch.matmul(attn_weights, value_states)
+
+        if attn_output.size() != (bsz, self.num_heads, q_len, self.head_dim):
+            raise ValueError(
+                f"`attn_output` should be of size {(bsz, self.num_heads, q_len, self.head_dim)}, but is"
+                f" {attn_output.size()}"
+            )
+
+        attn_output = attn_output.transpose(1, 2).contiguous()
+        attn_output = attn_output.reshape(bsz, q_len, -1)
+
+        attn_output = self.o_proj(attn_output)
+
+        if not output_attentions:
+            attn_weights = None
+
+        return attn_output, attn_weights, past_key_value
+
+
+class Qwen2_5_VLFlashAttention2(Qwen2_5_VLAttention):
+    """
+    Qwen2_5_VL flash attention module, following Qwen2_5_VL attention module. This module inherits from `Qwen2_5_VLAttention`
+    as the weights of the module stays untouched. The only required change would be on the forward pass
+    where it needs to correctly call the public API of flash attention and deal with padding tokens
+    in case the input contains any of them. Additionally, for sliding window attention, we apply SWA only to the bottom
+    config.max_window_layers layers.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # TODO: Should be removed once Flash Attention for RoCm is bumped to 2.1.
+        # flash_attn<2.1 generates top-left aligned causal mask, while what is needed here is bottom-right alignment, that was made default for flash_attn>=2.1. This attribute is used to handle this difference. Reference: https://github.com/Dao-AILab/flash-attention/releases/tag/v2.1.0.
+        # Beware that with flash_attn<2.1, using q_seqlen != k_seqlen (except for the case q_seqlen == 1) produces a wrong mask (top-left).
+        self._flash_attn_uses_top_left_mask = flash_attn_supports_top_left_mask()
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor | None = None,
+        position_ids: torch.LongTensor | None = None,
+        past_key_value: Cache | None = None,
+        output_attentions: bool = False,
+        use_cache: bool = False,
+        cache_position: torch.LongTensor | None = None,
+        position_embeddings: tuple[torch.Tensor, torch.Tensor]
+        | None = None,  # necessary, but kept here for BC
+    ):
+        bsz, q_len, _ = hidden_states.size()
+
+        query_states = self.q_proj(hidden_states)
+        key_states = self.k_proj(hidden_states)
+        value_states = self.v_proj(hidden_states)
+
+        query_states = query_states.view(bsz, q_len, -1, self.head_dim).transpose(1, 2)
+        key_states = key_states.view(bsz, q_len, -1, self.head_dim).transpose(1, 2)
+        value_states = value_states.view(bsz, q_len, -1, self.head_dim).transpose(1, 2)
+
+        # Because the input can be padded, the absolute sequence length depends on the max position id.
+        cos, sin = position_embeddings
+        query_states, key_states = apply_multimodal_rotary_pos_emb(
+            query_states, key_states, cos, sin, self.rope_scaling["mrope_section"]
+        )
+
+        if past_key_value is not None:
+            cache_kwargs = {
+                "sin": sin,
+                "cos": cos,
+                "cache_position": cache_position,
+            }  # Specific to RoPE models
+            key_states, value_states = past_key_value.update(
+                key_states, value_states, self.layer_idx, cache_kwargs
+            )
+
+        # repeat k/v heads if n_kv_heads < n_heads
+        key_states = repeat_kv(key_states, self.num_key_value_groups)
+        value_states = repeat_kv(value_states, self.num_key_value_groups)
+        dropout_rate = 0.0 if not self.training else self.attention_dropout
+
+        # In PEFT, usually we cast the layer norms in float32 for training stability reasons
+        # therefore the input hidden states gets silently casted in float32. Hence, we need
+        # cast them back in float16 just to be sure everything works as expected.
+        input_dtype = query_states.dtype
+        if input_dtype == torch.float32:
+            if torch.is_autocast_enabled():
+                target_dtype = torch.get_autocast_gpu_dtype()
+            # Handle the case where the model is quantized
+            elif hasattr(self.config, "_pre_quantization_dtype"):
+                target_dtype = self.config._pre_quantization_dtype
+            else:
+                target_dtype = self.q_proj.weight.dtype
+
+            logger.warning_once(
+                f"The input hidden states seems to be silently casted in float32, this might be related to"
+                f" the fact you have upcasted embedding or layer norm layers in float32. We will cast back the input in"
+                f" {target_dtype}."
+            )
+
+            query_states = query_states.to(target_dtype)
+            key_states = key_states.to(target_dtype)
+            value_states = value_states.to(target_dtype)
+
+        # Reashape to the expected shape for Flash Attention
+        query_states = query_states.transpose(1, 2)
+        key_states = key_states.transpose(1, 2)
+        value_states = value_states.transpose(1, 2)
+
+        if (
+            self.config.use_sliding_window
+            and getattr(self.config, "sliding_window", None) is not None
+            and self.layer_idx >= self.config.max_window_layers
+        ):
+            sliding_window = self.config.sliding_window
+        else:
+            sliding_window = None
+
+        attn_output = _flash_attention_forward(
+            query_states,
+            key_states,
+            value_states,
+            attention_mask,
+            q_len,
+            dropout=dropout_rate,
+            sliding_window=sliding_window,
+            is_causal=self.is_causal,
+            use_top_left_mask=self._flash_attn_uses_top_left_mask,
+        )
+
+        attn_output = attn_output.reshape(bsz, q_len, self.hidden_size).contiguous()
+        attn_output = self.o_proj(attn_output)
+
+        if not output_attentions:
+            attn_weights = None
+
+        return attn_output, attn_weights, past_key_value
+
+
+class Qwen2MLP(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.config = config
+        self.hidden_size = config.hidden_size
+        self.intermediate_size = config.intermediate_size
+        self.gate_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
+        self.up_proj = nn.Linear(self.hidden_size, self.intermediate_size, bias=False)
+        self.down_proj = nn.Linear(self.intermediate_size, self.hidden_size, bias=False)
+        self.act_fn = ACT2FN[config.hidden_act]
+
+    def forward(self, x):
+        down_proj = self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))
+        return down_proj
+
+
+QWEN2_5_VL_ATTENTION_CLASSES = {
+    "eager": Qwen2_5_VLAttention,
+    "flash_attention_2": Qwen2_5_VLFlashAttention2,
+}
+
+
+class Qwen2_5_VLDecoderLayer(nn.Module):
+    def __init__(self, config: Qwen2_5_VLConfig, layer_idx: int):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+
+        if config.use_sliding_window and config._attn_implementation != "flash_attention_2":
+            logger.warning_once(
+                f"Sliding Window Attention is enabled but not implemented for `{config._attn_implementation}`; "
+                "unexpected results may be encountered."
+            )
+        self.self_attn = QWEN2_5_VL_ATTENTION_CLASSES[config._attn_implementation](config, layer_idx)
+
+        self.mlp = Qwen2MLP(config)
+        self.input_layernorm = Qwen2RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = Qwen2RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+        if config.norm_qkv:
+            self.q_layernorm = Qwen2RMSNorm(self.self_attn.head_dim, eps=config.rms_norm_eps)
+            self.k_layernorm = Qwen2RMSNorm(self.self_attn.head_dim, eps=config.rms_norm_eps)
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        att_output: torch.Tensor | None = None,
+        start: int | None = 0,
+        end: int | None = 0,
+        compute_kqv: bool = False,
+        norm_qkv: bool = False,
+        output_atten: bool = False,
+        **kwargs: Unpack[FlashAttentionKwargs],
+    ) -> tuple[torch.FloatTensor, tuple[torch.FloatTensor, torch.FloatTensor] | None]:
+        """
+        Args:
+            hidden_states (`torch.FloatTensor`): input to the layer of shape `(batch, seq_len, embed_dim)`
+            attention_mask (`torch.FloatTensor`, *optional*): attention mask of size
+                `(batch, sequence_length)` where padding elements are indicated by 0.
+            output_attentions (`bool`, *optional*):
+                Whether or not to return the attentions tensors of all attention layers. See `attentions` under
+                returned tensors for more detail.
+            use_cache (`bool`, *optional*):
+                If set to `True`, `past_key_values` key value states are returned and can be used to speed up decoding
+                (see `past_key_values`).
+            past_key_value (`Tuple(torch.FloatTensor)`, *optional*): cached past key and value projection states
+            cache_position (`torch.LongTensor` of shape `(sequence_length)`, *optional*):
+                Indices depicting the position of the input sequence tokens in the sequence.
+            position_embeddings (`Tuple[torch.FloatTensor, torch.FloatTensor]`, *optional*):
+                Tuple containing the cosine and sine positional embeddings of shape `(batch_size, seq_len, head_dim)`,
+                with `head_dim` being the embedding dimension of each attention head.
+            kwargs (`dict`, *optional*):
+                Arbitrary kwargs to be ignored, used for FSDP and other methods that injects code
+                into the model
+        """
+
+        if compute_kqv:
+            hidden_states = self.input_layernorm(hidden_states)
+            hidden_shape = (*hidden_states.shape[:-1], -1, self.self_attn.head_dim)
+
+            query_state = self.self_attn.q_proj(hidden_states).view(hidden_shape)
+            key_state = self.self_attn.k_proj(hidden_states).view(hidden_shape)
+            value_state = self.self_attn.v_proj(hidden_states).view(hidden_shape)
+
+            if norm_qkv:
+                query_state = self.q_layernorm(query_state)
+                key_state = self.k_layernorm(key_state)
+
+            return query_state, key_state, value_state
+
+        elif output_atten:
+            if att_output.dtype != self.self_attn.o_proj.weight.dtype:
+                att_output = att_output.to(self.self_attn.o_proj.weight.dtype)
+            out_emb = self.self_attn.o_proj(att_output[:, start:end])
+
+            # first residual
+            out_emb += hidden_states
+            after_first_residual = out_emb.clone()
+
+            out_emb = self.post_attention_layernorm(out_emb)
+            out_emb = self.mlp(out_emb)
+
+            # second residual
+            out_emb += after_first_residual
+
+            return out_emb
+
+        else:
+            raise ValueError(
+                f"Invaild Operation compute_kqv={compute_kqv} and output_atten={output_atten} with Qwen2_5_VLDecoderLayer in LingBot-VLA"
+            )
+
+
+@add_start_docstrings(
+    "The bare Qwen2_5_VL Model outputting raw hidden-states without any specific head on top.",
+    Qwen2_5_VL_START_DOCSTRING,
+)
+class Qwen2_5_VLModel(Qwen2_5_VLPreTrainedModel):
+    def __init__(self, config: Qwen2_5_VLConfig):
+        super().__init__(config)
+        self.padding_idx = config.pad_token_id
+        self.vocab_size = config.vocab_size
+
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size, self.padding_idx)
+        self.layers = nn.ModuleList(
+            [Qwen2_5_VLDecoderLayer(config, layer_idx) for layer_idx in range(config.num_hidden_layers)]
+        )
+        self._attn_implementation = config._attn_implementation
+        self.norm = Qwen2RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.rotary_emb = Qwen2_5_VLRotaryEmbedding(config=config)
+
+        self.gradient_checkpointing = False
+        # Initialize weights and apply final processing
+        self._init_weights = lambda module: None
+        self.post_init()
+
+    def get_input_embeddings(self):
+        return self.embed_tokens
+
+    def set_input_embeddings(self, value):
+        self.embed_tokens = value
+
+    def forward(
+        self,
+        input_ids: torch.LongTensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        position_ids: torch.LongTensor | None = None,
+        past_key_values: list[torch.FloatTensor] | None = None,
+        inputs_embeds: torch.FloatTensor | None = None,
+        use_cache: bool | None = None,
+        output_attentions: bool | None = None,
+        output_hidden_states: bool | None = None,
+        return_dict: bool | None = None,
+        cache_position: torch.LongTensor | None = None,
+    ) -> tuple | BaseModelOutputWithPast:
+        output_attentions = (
+            output_attentions if output_attentions is not None else self.config.output_attentions
+        )
+        output_hidden_states = (
+            output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
+        )
+        use_cache = use_cache if use_cache is not None else self.config.use_cache
+
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+
+        if (input_ids is None) ^ (inputs_embeds is not None):
+            raise ValueError("You must specify exactly one of input_ids or inputs_embeds")
+
+        if self.gradient_checkpointing and self.training:
+            if use_cache:
+                logger.warning_once(
+                    "`use_cache=True` is incompatible with gradient checkpointing. Setting `use_cache=False`..."
+                )
+                use_cache = False
+
+        # torch.jit.trace() doesn't support cache objects in the output
+        if use_cache and past_key_values is None and not torch.jit.is_tracing():
+            past_key_values = DynamicCache()
+
+        if inputs_embeds is None:
+            inputs_embeds = self.embed_tokens(input_ids)
+
+        if cache_position is None:
+            past_seen_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0
+            cache_position = torch.arange(
+                past_seen_tokens, past_seen_tokens + inputs_embeds.shape[1], device=inputs_embeds.device
+            )
+
+        # the hard coded `3` is for temporal, height and width.
+        if position_ids is None:
+            position_ids = cache_position.view(1, 1, -1).expand(3, inputs_embeds.shape[0], -1)
+        elif position_ids.dim() == 2:
+            position_ids = position_ids[None, ...].expand(3, position_ids.shape[0], -1)
+
+        causal_mask = self._update_causal_mask(
+            attention_mask, inputs_embeds, cache_position, past_key_values, output_attentions
+        )
+
+        hidden_states = inputs_embeds
+
+        # create position embeddings to be shared across the decoder layers
+        position_embeddings = self.rotary_emb(hidden_states, position_ids)
+
+        # decoder layers
+        all_hidden_states = () if output_hidden_states else None
+        all_self_attns = () if output_attentions else None
+        next_decoder_cache = None
+
+        for decoder_layer in self.layers:
+            if output_hidden_states:
+                all_hidden_states += (hidden_states,)
+
+            if self.gradient_checkpointing and self.training:
+                layer_outputs = self._gradient_checkpointing_func(
+                    decoder_layer.__call__,
+                    hidden_states,
+                    causal_mask,
+                    position_ids,
+                    past_key_values,
+                    output_attentions,
+                    use_cache,
+                    cache_position,
+                    position_embeddings,
+                )
+            else:
+                layer_outputs = decoder_layer(
+                    hidden_states,
+                    attention_mask=causal_mask,
+                    position_ids=position_ids,
+                    past_key_value=past_key_values,
+                    output_attentions=output_attentions,
+                    use_cache=use_cache,
+                    cache_position=cache_position,
+                    position_embeddings=position_embeddings,
+                )
+
+            hidden_states = layer_outputs[0]
+
+            if use_cache:
+                next_decoder_cache = layer_outputs[2 if output_attentions else 1]
+
+            if output_attentions:
+                all_self_attns += (layer_outputs[1],)
+
+        hidden_states = self.norm(hidden_states)
+
+        # add hidden states from the last decoder layer
+        if output_hidden_states:
+            all_hidden_states += (hidden_states,)
+
+        next_cache = next_decoder_cache if use_cache else None
+
+        if not return_dict:
+            return tuple(
+                v for v in [hidden_states, next_cache, all_hidden_states, all_self_attns] if v is not None
+            )
+        return BaseModelOutputWithPast(
+            last_hidden_state=hidden_states,
+            past_key_values=next_cache,
+            hidden_states=all_hidden_states,
+            attentions=all_self_attns,
+        )
+
+    def _update_causal_mask(
+        self,
+        attention_mask: torch.Tensor,
+        input_tensor: torch.Tensor,
+        cache_position: torch.Tensor,
+        past_key_values: Cache,
+        output_attentions: bool = False,
+    ):
+        if self.config._attn_implementation == "flash_attention_2":
+            if attention_mask is not None and past_key_values is not None:
+                is_padding_right = attention_mask[:, -1].sum().item() != input_tensor.size()[0]
+                if is_padding_right:
+                    raise ValueError(
+                        "You are attempting to perform batched generation with padding_side='right'"
+                        " this may lead to unexpected behaviour for Flash Attention version of Qwen2_5_VL. Make sure to "
+                        " call `tokenizer.padding_side  = 'left'` before tokenizing the input. "
+                    )
+            if attention_mask is not None and 0.0 in attention_mask:
+                return attention_mask
+            return None
+
+        # For SDPA, when possible, we will rely on its `is_causal` argument instead of its `attn_mask` argument, in
+        # order to dispatch on Flash Attention 2. This feature is not compatible with static cache, as SDPA will fail
+        # to infer the attention mask.
+        past_seen_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0
+        using_static_cache = isinstance(past_key_values, StaticCache)
+        using_sliding_window_cache = isinstance(past_key_values, SlidingWindowCache)
+
+        # When output attentions is True, sdpa implementation's forward method calls the eager implementation's forward
+        if (
+            self.config._attn_implementation == "sdpa"
+            and not (using_static_cache or using_sliding_window_cache)
+            and not output_attentions
+        ):
+            if AttentionMaskConverter._ignore_causal_mask_sdpa(
+                attention_mask,
+                inputs_embeds=input_tensor,
+                past_key_values_length=past_seen_tokens,
+                sliding_window=self.config.sliding_window,
+                is_training=self.training,
+            ):
+                return None
+
+        dtype, device = input_tensor.dtype, input_tensor.device
+        min_dtype = torch.finfo(dtype).min
+        sequence_length = input_tensor.shape[1]
+        # SlidingWindowCache or StaticCache
+        if using_sliding_window_cache or using_static_cache:
+            target_length = past_key_values.get_max_cache_shape()
+        # DynamicCache or no cache
+        else:
+            target_length = (
+                attention_mask.shape[-1]
+                if isinstance(attention_mask, torch.Tensor)
+                else past_seen_tokens + sequence_length + 1
+            )
+
+        # In case the provided `attention` mask is 2D, we generate a causal mask here (4D).
+        causal_mask = self._prepare_4d_causal_attention_mask_with_cache_position(
+            attention_mask,
+            sequence_length=sequence_length,
+            target_length=target_length,
+            dtype=dtype,
+            device=device,
+            cache_position=cache_position,
+            batch_size=input_tensor.shape[0],
+            config=self.config,
+            past_key_values=past_key_values,
+        )
+
+        if (
+            self.config._attn_implementation == "sdpa"
+            and attention_mask is not None
+            and attention_mask.device.type in ["cuda", "xpu"]
+            and not output_attentions
+        ):
+            # Attend to all tokens in fully masked rows in the causal_mask, for example the relevant first rows when
+            # using left padding. This is required by F.scaled_dot_product_attention memory-efficient attention path.
+            # Details: https://github.com/pytorch/pytorch/issues/110213
+            causal_mask = AttentionMaskConverter._unmask_unattended(causal_mask, min_dtype)
+
+        return causal_mask
+
+    @staticmethod
+    def _prepare_4d_causal_attention_mask_with_cache_position(
+        attention_mask: torch.Tensor,
+        sequence_length: int,
+        target_length: int,
+        dtype: torch.dtype,
+        device: torch.device,
+        cache_position: torch.Tensor,
+        batch_size: int,
+        config: Qwen2_5_VLConfig,
+        past_key_values: Cache,
+    ):
+        """
+        Creates a causal 4D mask of shape `(batch_size, 1, query_length, key_value_length)` from a 2D mask of shape
+        `(batch_size, key_value_length)`, or if the input `attention_mask` is already 4D, do nothing.
+
+        Args:
+            attention_mask (`torch.Tensor`):
+                A 2D attention mask of shape `(batch_size, key_value_length)` or a 4D attention mask of shape `(batch_size, 1, query_length, key_value_length)`.
+            sequence_length (`int`):
+                The sequence length being processed.
+            target_length (`int`):
+                The target length: when generating with static cache, the mask should be as long as the static cache, to account for the 0 padding, the part of the cache that is not filled yet.
+            dtype (`torch.dtype`):
+                The dtype to use for the 4D attention mask.
+            device (`torch.device`):
+                The device to place the 4D attention mask on.
+            cache_position (`torch.Tensor`):
+                Indices depicting the position of the input sequence tokens in the sequence.
+            batch_size (`torch.Tensor`):
+                Batch size.
+            config (`Qwen2_5_VLConfig`):
+                The model's configuration class
+            past_key_values (`Cache`):
+                The cache class that is being used currently to generate
+        """
+        if attention_mask is not None and attention_mask.dim() == 4:
+            # In this case we assume that the mask comes already in inverted form and requires no inversion or slicing.
+            causal_mask = attention_mask
+        else:
+            min_dtype = torch.finfo(dtype).min
+            causal_mask = torch.full(
+                (sequence_length, target_length), fill_value=min_dtype, dtype=dtype, device=device
+            )
+            diagonal_attend_mask = torch.arange(target_length, device=device) > cache_position.reshape(-1, 1)
+            if config.sliding_window is not None:
+                # if we have sliding window, we should not attend to tokens beyond sliding window length, so we mask them out also
+                # the check is needed to verify is current checkpoint was trained with sliding window or not
+                if not isinstance(past_key_values, SlidingWindowCache) or sequence_length > target_length:
+                    sliding_attend_mask = torch.arange(target_length, device=device) <= (
+                        cache_position.reshape(-1, 1) - config.sliding_window
+                    )
+                    diagonal_attend_mask.bitwise_or_(sliding_attend_mask)
+            causal_mask *= diagonal_attend_mask
+            causal_mask = causal_mask[None, None, :, :].expand(batch_size, 1, -1, -1)
+            if attention_mask is not None:
+                causal_mask = causal_mask.clone()  # copy to contiguous memory for in-place edit
+                if attention_mask.shape[-1] > target_length:
+                    attention_mask = attention_mask[:, :target_length]
+                mask_length = attention_mask.shape[-1]
+                padding_mask = causal_mask[:, :, :, :mask_length] + attention_mask[:, None, None, :].to(
+                    causal_mask.device
+                )
+                padding_mask = padding_mask == 0
+                causal_mask[:, :, :, :mask_length] = causal_mask[:, :, :, :mask_length].masked_fill(
+                    padding_mask, min_dtype
+                )
+        return causal_mask
+
+
+@dataclass
+class Qwen2_5_VLCausalLMOutputWithPast(ModelOutput):
+    """
+    Base class for Qwen2_5_VL causal language model (or autoregressive) outputs.
+
+    Args:
+        loss (`torch.FloatTensor` of shape `(1,)`, *optional*, returned when `labels` is provided):
+            Language modeling loss (for next-token prediction).
+        logits (`torch.FloatTensor` of shape `(batch_size, sequence_length, config.vocab_size)`):
+            Prediction scores of the language modeling head (scores for each vocabulary token before SoftMax).
+        past_key_values (`tuple(tuple(torch.FloatTensor))`, *optional*, returned when `use_cache=True` is passed or when `config.use_cache=True`):
+            Tuple of `tuple(torch.FloatTensor)` of length `config.n_layers`, with each tuple having 2 tensors of shape
+            `(batch_size, num_heads, sequence_length, embed_size_per_head)`)
+
+            Contains pre-computed hidden-states (key and values in the self-attention blocks) that can be used (see
+            `past_key_values` input) to speed up sequential decoding.
+        hidden_states (`tuple(torch.FloatTensor)`, *optional*, returned when `output_hidden_states=True` is passed or when `config.output_hidden_states=True`):
+            Tuple of `torch.FloatTensor` (one for the output of the embeddings, if the model has an embedding layer, +
+            one for the output of each layer) of shape `(batch_size, sequence_length, hidden_size)`.
+
+            Hidden-states of the model at the output of each layer plus the optional initial embedding outputs.
+        attentions (`tuple(torch.FloatTensor)`, *optional*, returned when `output_attentions=True` is passed or when `config.output_attentions=True`):
+            Tuple of `torch.FloatTensor` (one for each layer) of shape `(batch_size, num_heads, sequence_length,
+            sequence_length)`.
+
+            Attentions weights after the attention softmax, used to compute the weighted average in the self-attention
+            heads.
+        rope_deltas (`torch.LongTensor` of shape `(batch_size, )`, *optional*):
+            The rope index difference between sequence length and multimodal rope.
+    """
+
+    loss: torch.FloatTensor | None = None
+    logits: torch.FloatTensor | None = None
+    past_key_values: list[torch.FloatTensor] | None = None
+    hidden_states: tuple[torch.FloatTensor] | None = None
+    attentions: tuple[torch.FloatTensor] | None = None
+    rope_deltas: torch.LongTensor | None = None
+
+
+QWEN2_5_VL_INPUTS_DOCSTRING = r"""
+    Args:
+        input_ids (`torch.LongTensor` of shape `(batch_size, sequence_length)`):
+            Indices of input sequence tokens in the vocabulary. Padding will be ignored by default should you provide
+            it.
+
+            Indices can be obtained using [`AutoTokenizer`]. See [`PreTrainedTokenizer.encode`] and
+            [`PreTrainedTokenizer.__call__`] for details.
+
+            [What are input IDs?](../glossary#input-ids)
+        attention_mask (`torch.Tensor` of shape `(batch_size, sequence_length)`, *optional*):
+            Mask to avoid performing attention on padding token indices. Mask values selected in `[0, 1]`:
+
+            - 1 for tokens that are **not masked**,
+            - 0 for tokens that are **masked**.
+
+            [What are attention masks?](../glossary#attention-mask)
+
+            Indices can be obtained using [`AutoTokenizer`]. See [`PreTrainedTokenizer.encode`] and
+            [`PreTrainedTokenizer.__call__`] for details.
+
+            If `past_key_values` is used, optionally only the last `decoder_input_ids` have to be input (see
+            `past_key_values`).
+
+            If you want to change padding behavior, you should read [`modeling_opt._prepare_decoder_attention_mask`]
+            and modify to your needs. See diagram 1 in [the paper](https://arxiv.org/abs/1910.13461) for more
+            information on the default strategy.
+
+            - 1 indicates the head is **not masked**,
+            - 0 indicates the head is **masked**.
+        position_ids (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
+            Indices of positions of each input sequence tokens in the position embeddings. Selected in the range `[0,
+            config.n_positions - 1]`. [What are position IDs?](../glossary#position-ids)
+        past_key_values (`tuple(tuple(torch.FloatTensor))`, *optional*, returned when `use_cache=True` is passed or when `config.use_cache=True`):
+            Tuple of `tuple(torch.FloatTensor)` of length `config.n_layers`, with each tuple having 2 tensors of shape
+            `(batch_size, num_heads, sequence_length, embed_size_per_head)`) and 2 additional tensors of shape
+            `(batch_size, num_heads, encoder_sequence_length, embed_size_per_head)`.
+
+            Contains pre-computed hidden-states (key and values in the self-attention blocks and in the cross-attention
+            blocks) that can be used (see `past_key_values` input) to speed up sequential decoding.
+
+            If `past_key_values` are used, the user can optionally input only the last `decoder_input_ids` (those that
+            don't have their past key value states given to this model) of shape `(batch_size, 1)` instead of all
+            `decoder_input_ids` of shape `(batch_size, sequence_length)`.
+        inputs_embeds (`torch.FloatTensor` of shape `(batch_size, sequence_length, hidden_size)`, *optional*):
+            Optionally, instead of passing `input_ids` you can choose to directly pass an embedded representation. This
+            is useful if you want more control over how to convert `input_ids` indices into associated vectors than the
+            model's internal embedding lookup matrix.
+        use_cache (`bool`, *optional*):
+            If set to `True`, `past_key_values` key value states are returned and can be used to speed up decoding (see
+            `past_key_values`).
+        output_attentions (`bool`, *optional*):
+            Whether or not to return the attentions tensors of all attention layers. See `attentions` under returned
+            tensors for more detail.
+        output_hidden_states (`bool`, *optional*):
+            Whether or not to return the hidden states of all layers. See `hidden_states` under returned tensors for
+            more detail.
+        return_dict (`bool`, *optional*):
+            Whether or not to return a [`~utils.ModelOutput`] instead of a plain tuple.
+        pixel_values (`torch.FloatTensor` of shape `(seq_length, num_channels * image_size * image_size)):
+            The tensors corresponding to the input images. Pixel values can be obtained using
+            [`AutoImageProcessor`]. See [`Qwen2_5_VLImageProcessor.__call__`] for details. [`Qwen2_5_VLProcessor`] uses
+            [`Qwen2_5_VLImageProcessor`] for processing images.
+        pixel_values_videos (`torch.FloatTensor` of shape `(seq_length, num_channels * temporal_size * image_size * image_size)):
+            The tensors corresponding to the input videos. Pixel values can be obtained using
+            [`AutoImageProcessor`]. See [`Qwen2_5_VLImageProcessor.__call__`] for details. [`Qwen2_5_VLProcessor`] uses
+            [`Qwen2_5_VLImageProcessor`] for processing videos.
+        image_grid_thw (`torch.LongTensor` of shape `(num_images, 3)`, *optional*):
+            The temporal, height and width of feature shape of each image in LLM.
+        video_grid_thw (`torch.LongTensor` of shape `(num_videos, 3)`, *optional*):
+            The temporal, height and width of feature shape of each video in LLM.
+        rope_deltas (`torch.LongTensor` of shape `(batch_size, )`, *optional*):
+            The rope index difference between sequence length and multimodal rope.
+"""
+
+
+class Qwen2_5_VLForConditionalGeneration(Qwen2_5_VLPreTrainedModel, GenerationMixin):
+    # transformers>=5.0 expects a dict mapping {output: input} for tied weights.
+    _tied_weights_keys = {"lm_head.weight": "model.embed_tokens.weight"}
+    config_class = Qwen2_5_VLConfig
+    _no_split_modules = ["Qwen2_5_VLDecoderLayer", "Qwen2_5_VLVisionBlock"]
+
+    def __init__(self, config, **kwargs):
+        super().__init__(config)
+        # Make flash-attention optional: honour the attention implementation chosen on
+        # the parent config (default "eager") instead of forcing flash_attention_2, which
+        # would require the flash-attn package to be installed.
+        vision_attn = getattr(config, "_attn_implementation", "eager") or "eager"
+        if vision_attn not in QWEN2_5_VL_VISION_ATTENTION_CLASSES:
+            vision_attn = "eager"
+        config.vision_config._attn_implementation = vision_attn
+        self.visual = Qwen2_5_VisionTransformerPretrainedModel._from_config(config.vision_config)
+        self.model = Qwen2_5_VLModel(config)
+        self.vocab_size = config.vocab_size
+        self.lm_head = nn.Linear(config.hidden_size, config.vocab_size, bias=False)
+        self.rope_deltas = None  # cache rope_deltas here
+
+        # Initialize weights and apply final processing
+        self.post_init()
+
+    def get_input_embeddings(self):
+        return self.model.embed_tokens
+
+    def set_input_embeddings(self, value):
+        self.model.embed_tokens = value
+
+    def get_output_embeddings(self):
+        return self.lm_head
+
+    def set_output_embeddings(self, new_embeddings):
+        self.lm_head = new_embeddings
+
+    def set_decoder(self, decoder):
+        self.model = decoder
+
+    def get_decoder(self):
+        return self.model
+
+    def get_rope_index(
+        self,
+        input_ids: torch.LongTensor | None = None,
+        image_grid_thw: torch.LongTensor | None = None,
+        video_grid_thw: torch.LongTensor | None = None,
+        second_per_grid_ts: torch.Tensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """
+        Calculate the 3D rope index based on image and video's temporal, height and width in LLM.
+
+        Explanation:
+            Each embedding sequence contains vision embedding and text embedding or just contains text embedding.
+
+            For pure text embedding sequence, the rotary position embedding has no difference with modern LLMs.
+            Examples:
+                input_ids: [T T T T T], here T is for text.
+                temporal position_ids: [0, 1, 2, 3, 4]
+                height position_ids: [0, 1, 2, 3, 4]
+                width position_ids: [0, 1, 2, 3, 4]
+
+            For vision and text embedding sequence, we calculate 3D rotary position embedding for vision part
+            and 1D rotary position embedding for text part.
+            Examples:
+                Temporal (Time): 3 patches, representing different segments of the video in time.
+                Height: 2 patches, dividing each frame vertically.
+                Width: 2 patches, dividing each frame horizontally.
+                We also have some important parameters:
+                fps (Frames Per Second): The video's frame rate, set to 1. This means one frame is processed each second.
+                tokens_per_second: This is a crucial parameter. It dictates how many "time-steps" or "temporal tokens" are conceptually packed into a one-second interval of the video. In this case, we have 25 tokens per second. So each second of the video will be represented with 25 separate time points. It essentially defines the temporal granularity.
+                temporal_patch_size: The number of frames that compose one temporal patch. Here, it's 2 frames.
+                interval: The step size for the temporal position IDs, calculated as tokens_per_second * temporal_patch_size / fps. In this case, 25 * 2 / 1 = 50. This means that each temporal patch will be have a difference of 50 in the temporal position IDs.
+                input_ids: [V V V V V V V V V V V V T T T T T], here V is for vision.
+                vision temporal position_ids: [0, 0, 0, 0, 50, 50, 50, 50, 100, 100, 100, 100]
+                vision height position_ids: [0, 0, 1, 1, 0, 0, 1, 1, 0, 0, 1, 1]
+                vision width position_ids: [0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1]
+                text temporal position_ids: [101, 102, 103, 104, 105]
+                text height position_ids: [101, 102, 103, 104, 105]
+                text width position_ids: [101, 102, 103, 104, 105]
+                Here we calculate the text start position_ids as the max vision position_ids plus 1.
+
+        Args:
+            input_ids (`torch.LongTensor` of shape `(batch_size, sequence_length)`):
+                Indices of input sequence tokens in the vocabulary. Padding will be ignored by default should you provide
+                it.
+            image_grid_thw (`torch.LongTensor` of shape `(num_images, 3)`, *optional*):
+                The temporal, height and width of feature shape of each image in LLM.
+            video_grid_thw (`torch.LongTensor` of shape `(num_videos, 3)`, *optional*):
+                The temporal, height and width of feature shape of each video in LLM.
+            second_per_grid_ts (`torch.Tensor` of shape `(num_videos)`, *optional*):
+                The time interval (in seconds) for each grid along the temporal dimension in the 3D position IDs.
+            attention_mask (`torch.Tensor` of shape `(batch_size, sequence_length)`, *optional*):
+                Mask to avoid performing attention on padding token indices. Mask values selected in `[0, 1]`:
+
+                - 1 for tokens that are **not masked**,
+                - 0 for tokens that are **masked**.
+
+        Returns:
+            position_ids (`torch.LongTensor` of shape `(3, batch_size, sequence_length)`)
+            mrope_position_deltas (`torch.Tensor` of shape `(batch_size)`)
+        """
+        spatial_merge_size = self.config.vision_config.spatial_merge_size
+        image_token_id = self.config.image_token_id
+        video_token_id = self.config.video_token_id
+        vision_start_token_id = self.config.vision_start_token_id
+        mrope_position_deltas = []
+        if input_ids is not None and (image_grid_thw is not None or video_grid_thw is not None):
+            total_input_ids = input_ids
+            if attention_mask is None:
+                attention_mask = torch.ones_like(total_input_ids)
+            position_ids = torch.ones(
+                3,
+                input_ids.shape[0],
+                input_ids.shape[1],
+                dtype=input_ids.dtype,
+                device=input_ids.device,
+            )
+            image_index, video_index = 0, 0
+            attention_mask = attention_mask.to(total_input_ids.device)
+            for i, input_ids in enumerate(total_input_ids):
+                input_ids = input_ids[attention_mask[i] == 1]
+                image_nums, video_nums = 0, 0
+                vision_start_indices = torch.argwhere(input_ids == vision_start_token_id).squeeze(1)
+                vision_tokens = input_ids[vision_start_indices + 1]
+                image_nums = (vision_tokens == image_token_id).sum()
+                video_nums = (vision_tokens == video_token_id).sum()
+                input_tokens = input_ids.tolist()
+                llm_pos_ids_list: list = []
+                st = 0
+                remain_images, remain_videos = image_nums, video_nums
+                for _ in range(image_nums + video_nums):
+                    if image_token_id in input_tokens and remain_images > 0:
+                        ed_image = input_tokens.index(image_token_id, st)
+                    else:
+                        ed_image = len(input_tokens) + 1
+                    if video_token_id in input_tokens and remain_videos > 0:
+                        ed_video = input_tokens.index(video_token_id, st)
+                    else:
+                        ed_video = len(input_tokens) + 1
+                    if ed_image < ed_video:
+                        t, h, w = (
+                            image_grid_thw[image_index][0],
+                            image_grid_thw[image_index][1],
+                            image_grid_thw[image_index][2],
+                        )
+                        second_per_grid_t = 0
+                        image_index += 1
+                        remain_images -= 1
+                        ed = ed_image
+
+                    else:
+                        t, h, w = (
+                            video_grid_thw[video_index][0],
+                            video_grid_thw[video_index][1],
+                            video_grid_thw[video_index][2],
+                        )
+                        if second_per_grid_ts is not None:
+                            second_per_grid_t = second_per_grid_ts[video_index]
+                        else:
+                            second_per_grid_t = 1.0
+                        video_index += 1
+                        remain_videos -= 1
+                        ed = ed_video
+                    llm_grid_t, llm_grid_h, llm_grid_w = (
+                        t.item(),
+                        h.item() // spatial_merge_size,
+                        w.item() // spatial_merge_size,
+                    )
+                    text_len = ed - st
+
+                    st_idx = llm_pos_ids_list[-1].max() + 1 if len(llm_pos_ids_list) > 0 else 0
+                    llm_pos_ids_list.append(torch.arange(text_len).view(1, -1).expand(3, -1) + st_idx)
+
+                    range_tensor = torch.arange(llm_grid_t).view(-1, 1)
+                    expanded_range = range_tensor.expand(-1, llm_grid_h * llm_grid_w)
+
+                    time_tensor = (
+                        expanded_range * second_per_grid_t * self.config.vision_config.tokens_per_second
+                    )
+
+                    time_tensor_long = time_tensor.long()
+                    t_index = time_tensor_long.flatten()
+
+                    h_index = (
+                        torch.arange(llm_grid_h).view(1, -1, 1).expand(llm_grid_t, -1, llm_grid_w).flatten()
+                    )
+                    w_index = (
+                        torch.arange(llm_grid_w).view(1, 1, -1).expand(llm_grid_t, llm_grid_h, -1).flatten()
+                    )
+                    llm_pos_ids_list.append(torch.stack([t_index, h_index, w_index]) + text_len + st_idx)
+                    st = ed + llm_grid_t * llm_grid_h * llm_grid_w
+
+                if st < len(input_tokens):
+                    st_idx = llm_pos_ids_list[-1].max() + 1 if len(llm_pos_ids_list) > 0 else 0
+                    text_len = len(input_tokens) - st
+                    llm_pos_ids_list.append(torch.arange(text_len).view(1, -1).expand(3, -1) + st_idx)
+
+                llm_positions = torch.cat(llm_pos_ids_list, dim=1).reshape(3, -1)
+                position_ids[..., i, attention_mask[i] == 1] = llm_positions.to(position_ids.device)
+                mrope_position_deltas.append(llm_positions.max() + 1 - len(total_input_ids[i]))
+            mrope_position_deltas = torch.tensor(mrope_position_deltas, device=input_ids.device).unsqueeze(1)
+            return position_ids, mrope_position_deltas
+        else:
+            if attention_mask is not None:
+                position_ids = attention_mask.long().cumsum(-1) - 1
+                position_ids.masked_fill_(attention_mask == 0, 1)
+                position_ids = position_ids.unsqueeze(0).expand(3, -1, -1).to(attention_mask.device)
+                max_position_ids = position_ids.max(0, keepdim=False)[0].max(-1, keepdim=True)[0]
+                mrope_position_deltas = max_position_ids + 1 - attention_mask.shape[-1]
+            else:
+                position_ids = (
+                    torch.arange(input_ids.shape[1], device=input_ids.device)
+                    .view(1, 1, -1)
+                    .expand(3, input_ids.shape[0], -1)
+                )
+                mrope_position_deltas = torch.zeros(
+                    [input_ids.shape[0], 1],
+                    device=input_ids.device,
+                    dtype=input_ids.dtype,
+                )
+
+            return position_ids, mrope_position_deltas
+
+    @add_start_docstrings_to_model_forward(QWEN2_5_VL_INPUTS_DOCSTRING)
+    @replace_return_docstrings(output_type=Qwen2_5_VLCausalLMOutputWithPast, config_class=_CONFIG_FOR_DOC)
+    def forward(
+        self,
+        input_ids: torch.LongTensor | None = None,
+        attention_mask: torch.Tensor | None = None,
+        position_ids: torch.LongTensor | None = None,
+        past_key_values: list[torch.FloatTensor] | None = None,
+        inputs_embeds: torch.FloatTensor | None = None,
+        labels: torch.LongTensor | None = None,
+        use_cache: bool | None = None,
+        output_attentions: bool | None = None,
+        output_hidden_states: bool | None = None,
+        return_dict: bool | None = None,
+        pixel_values: torch.Tensor | None = None,
+        pixel_values_videos: torch.FloatTensor | None = None,
+        image_grid_thw: torch.LongTensor | None = None,
+        video_grid_thw: torch.LongTensor | None = None,
+        rope_deltas: torch.LongTensor | None = None,
+        cache_position: torch.LongTensor | None = None,
+        second_per_grid_ts: torch.Tensor | None = None,
+    ) -> tuple | Qwen2_5_VLCausalLMOutputWithPast:
+        r"""
+            labels (`torch.LongTensor` of shape `(batch_size, sequence_length)`, *optional*):
+                Labels for computing the masked language modeling loss. Indices should either be in `[0, ...,
+                config.vocab_size]` or -100 (see `input_ids` docstring). Tokens with indices set to `-100` are ignored
+                (masked), the loss is only computed for the tokens with labels in `[0, ..., config.vocab_size]`.
+
+        Returns:
+
+        Example:
+
+        ```python
+        >>> from PIL import Image
+        >>> import requests
+        >>> from transformers import AutoProcessor, Qwen2_5_VLForConditionalGeneration
+
+        >>> model = Qwen2_5_VLForConditionalGeneration.from_pretrained("Qwen/Qwen2.5-VL-7B-Instruct")
+        >>> processor = AutoProcessor.from_pretrained("Qwen/Qwen2.5-VL-7B-Instruct")
+
+        >>> messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image"},
+                    {"type": "text", "text": "What is shown in this image?"},
+                ],
+            },
+        ]
+        >>> url = "https://www.ilankelman.org/stopsigns/australia.jpg"
+        >>> image = Image.open(requests.get(url, stream=True).raw)
+
+        >>> text = processor.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+        >>> inputs = processor(text=[text], images=[image], vision_infos=[vision_infos])
+
+        >>> # Generate
+        >>> generate_ids = model.generate(inputs.input_ids, max_length=30)
+        >>> tokenizer.batch_decode(generate_ids, skip_special_tokens=True, clean_up_tokenization_spaces=False)[0]
+        "The image shows a street scene with a red stop sign in the foreground. In the background, there is a large red gate with Chinese characters ..."
+        ```"""
+
+        output_attentions = (
+            output_attentions if output_attentions is not None else self.config.output_attentions
+        )
+        output_hidden_states = (
+            output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
+        )
+        return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+
+        if inputs_embeds is None:
+            inputs_embeds = self.model.embed_tokens(input_ids)
+            if pixel_values is not None:
+                pixel_values = pixel_values.type(self.visual.dtype)
+                image_embeds = self.visual(pixel_values, grid_thw=image_grid_thw)
+                n_image_tokens = (input_ids == self.config.image_token_id).sum().item()
+                n_image_features = image_embeds.shape[0]
+                if n_image_tokens != n_image_features:
+                    raise ValueError(
+                        f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}"
+                    )
+
+                mask = input_ids == self.config.image_token_id
+                mask_unsqueezed = mask.unsqueeze(-1)
+                mask_expanded = mask_unsqueezed.expand_as(inputs_embeds)
+                image_mask = mask_expanded.to(inputs_embeds.device)
+
+                image_embeds = image_embeds.to(inputs_embeds.device, inputs_embeds.dtype)
+                inputs_embeds = inputs_embeds.masked_scatter(image_mask, image_embeds)
+
+            if pixel_values_videos is not None:
+                pixel_values_videos = pixel_values_videos.type(self.visual.dtype)
+                video_embeds = self.visual(pixel_values_videos, grid_thw=video_grid_thw)
+                n_video_tokens = (input_ids == self.config.video_token_id).sum().item()
+                n_video_features = video_embeds.shape[0]
+                if n_video_tokens != n_video_features:
+                    raise ValueError(
+                        f"Video features and video tokens do not match: tokens: {n_video_tokens}, features {n_video_features}"
+                    )
+
+                mask = input_ids == self.config.video_token_id
+                mask_unsqueezed = mask.unsqueeze(-1)
+                mask_expanded = mask_unsqueezed.expand_as(inputs_embeds)
+                video_mask = mask_expanded.to(inputs_embeds.device)
+
+                video_embeds = video_embeds.to(inputs_embeds.device, inputs_embeds.dtype)
+                inputs_embeds = inputs_embeds.masked_scatter(video_mask, video_embeds)
+
+            if attention_mask is not None:
+                attention_mask = attention_mask.to(inputs_embeds.device)
+
+        # if we get 4D attention mask we cannot calculate rope deltas anymore. TODO @raushan fixme
+        if position_ids is None and (attention_mask is None or attention_mask.ndim == 2):
+            # calculate RoPE index once per generation in the pre-fill stage only
+            if (
+                (cache_position is not None and cache_position[0] == 0)
+                or self.rope_deltas is None
+                or (past_key_values is None or past_key_values.get_seq_length() == 0)
+            ):
+                position_ids, rope_deltas = self.get_rope_index(
+                    input_ids,
+                    image_grid_thw,
+                    video_grid_thw,
+                    second_per_grid_ts,
+                    attention_mask,
+                )
+                self.rope_deltas = rope_deltas
+            # then use the prev pre-calculated rope-deltas to get the correct position ids
+            else:
+                batch_size, seq_length, _ = inputs_embeds.shape
+                delta = (
+                    (cache_position[0] + self.rope_deltas).to(inputs_embeds.device)
+                    if cache_position is not None
+                    else 0
+                )
+                position_ids = torch.arange(seq_length, device=inputs_embeds.device)
+                position_ids = position_ids.view(1, -1).expand(batch_size, -1)
+                if cache_position is not None:  # otherwise `deltas` is an int `0`
+                    delta = delta.repeat_interleave(batch_size // delta.shape[0], dim=0)
+                position_ids = position_ids.add(delta)
+                position_ids = position_ids.unsqueeze(0).expand(3, -1, -1)
+
+        outputs = self.model(
+            input_ids=None,
+            position_ids=position_ids,
+            attention_mask=attention_mask,
+            past_key_values=past_key_values,
+            inputs_embeds=inputs_embeds,
+            use_cache=use_cache,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=return_dict,
+            cache_position=cache_position,
+        )
+
+        hidden_states = outputs[0]
+        logits = self.lm_head(hidden_states)
+
+        loss = None
+        if labels is not None:
+            # Upcast to float if we need to compute the loss to avoid potential precision issues
+            logits = logits.float()
+            # Shift so that tokens < n predict n
+            shift_logits = logits[..., :-1, :].contiguous()
+            shift_labels = labels[..., 1:].contiguous()
+            # Flatten the tokens
+            loss_fct = CrossEntropyLoss()
+            shift_logits = shift_logits.view(-1, self.config.vocab_size)
+            shift_labels = shift_labels.view(-1)
+            # Enable model parallelism
+            shift_labels = shift_labels.to(shift_logits.device)
+            loss = loss_fct(shift_logits, shift_labels)
+
+        if not return_dict:
+            output = (logits,) + outputs[1:]
+            return (loss,) + output if loss is not None else output
+
+        return Qwen2_5_VLCausalLMOutputWithPast(
+            loss=loss,
+            logits=logits,
+            past_key_values=outputs.past_key_values,
+            hidden_states=outputs.hidden_states,
+            attentions=outputs.attentions,
+            rope_deltas=self.rope_deltas,
+        )
+
+    def prepare_inputs_for_generation(
+        self,
+        input_ids,
+        past_key_values=None,
+        attention_mask=None,
+        inputs_embeds=None,
+        cache_position=None,
+        position_ids=None,
+        use_cache=True,
+        pixel_values=None,
+        pixel_values_videos=None,
+        image_grid_thw=None,
+        video_grid_thw=None,
+        second_per_grid_ts=None,
+        **kwargs,
+    ):
+        # Overwritten -- in specific circumstances we don't want to forward image inputs to the model
+
+        model_inputs = super().prepare_inputs_for_generation(
+            input_ids,
+            past_key_values=past_key_values,
+            attention_mask=attention_mask,
+            inputs_embeds=inputs_embeds,
+            cache_position=cache_position,
+            position_ids=position_ids,
+            pixel_values=pixel_values,
+            pixel_values_videos=pixel_values_videos,
+            image_grid_thw=image_grid_thw,
+            video_grid_thw=video_grid_thw,
+            second_per_grid_ts=second_per_grid_ts,
+            use_cache=use_cache,
+            **kwargs,
+        )
+
+        # Qwen2-5-VL position_ids are prepareed with rope_deltas in forward
+        model_inputs["position_ids"] = None
+
+        if cache_position[0] != 0:
+            model_inputs["pixel_values"] = None
+            model_inputs["pixel_values_videos"] = None
+
+        return model_inputs
+
+    def _get_image_nums_and_video_nums(
+        self,
+        input_ids: torch.LongTensor | None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """
+        Get the number of images and videos for each sample to calculate the separation length of the sample tensor.
+        These parameters are not passed through the processor to avoid unpredictable impacts from interface modifications.
+
+        Args:
+            input_ids (`torch.LongTensor` of shape `(batch_size, sequence_length)`):
+                Indices of input sequence tokens in the vocabulary.
+
+        Returns:
+            image_nums (`torch.LongTensor` of shape `(batch_size, num_images_sample)`)
+            video_nums (`torch.LongTensor` of shape `(batch_size, num_videos_sample)`)
+        """
+        image_token_id = self.config.image_token_id
+        video_token_id = self.config.video_token_id
+        vision_start_token_id = self.config.vision_start_token_id
+
+        vision_start_mask = input_ids == vision_start_token_id
+        vision_first_mask = torch.roll(vision_start_mask, shifts=1, dims=1)
+        image_mask = input_ids == image_token_id
+        video_mask = input_ids == video_token_id
+        image_nums = torch.sum(vision_first_mask & image_mask, dim=1)
+        video_nums = torch.sum(vision_first_mask & video_mask, dim=1)
+
+        return image_nums, video_nums
+
+    def _expand_inputs_for_generation(
+        self,
+        expand_size: int = 1,
+        is_encoder_decoder: bool = False,
+        input_ids: torch.LongTensor | None = None,
+        **model_kwargs,
+    ) -> tuple[torch.LongTensor, dict[str, Any]]:
+        # Overwritten -- Support for expanding tensors without a batch size dimension
+        # e.g., pixel_values, image_grid_thw, pixel_values_videos, video_grid_thw, second_per_grid_t
+        # pixel_values.shape[0] is sum(seqlen_images for samples)
+        # image_grid_thw.shape[0] is sum(num_images for samples)
+
+        if expand_size == 1:
+            return input_ids, model_kwargs
+
+        visual_keys = [
+            "pixel_values",
+            "image_grid_thw",
+            "pixel_values_videos",
+            "video_grid_thw",
+            "second_per_grid_ts",
+        ]
+
+        def _expand_dict_for_generation_visual(dict_to_expand):
+            image_grid_thw = model_kwargs.get("image_grid_thw", None)
+            video_grid_thw = model_kwargs.get("video_grid_thw", None)
+            image_nums, video_nums = self._get_image_nums_and_video_nums(input_ids)
+
+            def _repeat_interleave_samples(x, lengths, repeat_times):
+                samples = torch.split(x, lengths)
+                repeat_args = [repeat_times] + [1] * (x.dim() - 1)
+                result = torch.cat([sample.repeat(*repeat_args) for sample in samples], dim=0)
+                return result
+
+            for key in dict_to_expand:
+                if key == "pixel_values":
+                    # split images into samples
+                    samples = torch.split(image_grid_thw, list(image_nums))
+                    # compute the sequence length of images for each sample
+                    lengths = [torch.prod(sample, dim=1).sum() for sample in samples]
+                    dict_to_expand[key] = _repeat_interleave_samples(
+                        dict_to_expand[key], lengths=lengths, repeat_times=expand_size
+                    )
+                elif key == "image_grid_thw":
+                    # get the num of images for each sample
+                    lengths = list(image_nums)
+                    dict_to_expand[key] = _repeat_interleave_samples(
+                        dict_to_expand[key], lengths=lengths, repeat_times=expand_size
+                    )
+                elif key == "pixel_values_videos":
+                    samples = torch.split(video_grid_thw, list(video_nums))
+                    lengths = [torch.prod(sample, dim=1).sum() for sample in samples]
+                    dict_to_expand[key] = _repeat_interleave_samples(
+                        dict_to_expand[key], lengths=lengths, repeat_times=expand_size
+                    )
+                elif key == "video_grid_thw":
+                    lengths = list(video_nums)
+                    dict_to_expand[key] = _repeat_interleave_samples(
+                        dict_to_expand[key], lengths=lengths, repeat_times=expand_size
+                    )
+                elif key == "second_per_grid_ts":
+                    if not isinstance(dict_to_expand[key], list):
+                        raise TypeError(
+                            f"Expected value for key '{key}' to be a list, but got {type(dict_to_expand[key])} instead."
+                        )
+                    tensor = torch.tensor(dict_to_expand[key])
+                    lengths = list(video_nums)
+                    tensor = _repeat_interleave_samples(tensor, lengths=lengths, repeat_times=expand_size)
+                    dict_to_expand[key] = tensor.tolist()
+            return dict_to_expand
+
+        def _expand_dict_for_generation(dict_to_expand):
+            for key in dict_to_expand:
+                if (
+                    key != "cache_position"
+                    and dict_to_expand[key] is not None
+                    and isinstance(dict_to_expand[key], torch.Tensor)
+                    and key not in visual_keys
+                ):
+                    dict_to_expand[key] = dict_to_expand[key].repeat_interleave(expand_size, dim=0)
+            return dict_to_expand
+
+        # input_ids is required for expanding visual inputs
+        # If input_ids is unavailable, visual inputs will not be used; therefore, there is no need to expand visual inputs.
+        if input_ids is not None and input_ids.numel() != 0:
+            model_kwargs = _expand_dict_for_generation_visual(model_kwargs)
+
+        if input_ids is not None:
+            input_ids = input_ids.repeat_interleave(expand_size, dim=0)
+
+        model_kwargs = _expand_dict_for_generation(model_kwargs)
+
+        if is_encoder_decoder:
+            if model_kwargs.get("encoder_outputs") is None:
+                raise ValueError(
+                    "If `is_encoder_decoder` is True, make sure that `encoder_outputs` is defined."
+                )
+            model_kwargs["encoder_outputs"] = _expand_dict_for_generation(model_kwargs["encoder_outputs"])
+
+        return input_ids, model_kwargs

--- a/src/lerobot/policies/lingbot_vla/utils.py
+++ b/src/lerobot/policies/lingbot_vla/utils.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python
+
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+
+import einops
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from torch import Tensor
+
+
+def find_next_divisible_by_8_numpy(n: np.ndarray) -> np.ndarray:
+    """
+    Finds the smallest integers greater than each element in a NumPy array 'n'
+    that are divisible by 8. Assumes non-negative integers.
+
+    Args:
+        n: A NumPy array of integers.
+
+    Returns:
+        A NumPy array containing the smallest integers greater than each input element
+        that are divisible by 8.
+    """
+    remainder = n % 8
+    # Calculate the amount to add: 0 if already divisible, otherwise 8 - remainder
+    # np.where is efficient for conditional operations on arrays
+    amount_to_add = np.where(remainder == 0, 8, 8 - remainder)
+    return n + amount_to_add
+
+
+def create_sinusoidal_pos_embedding(
+    time: torch.tensor,
+    dimension: int,
+    min_period: float,
+    max_period: float,
+    device="cpu",
+) -> Tensor:
+    """Computes sine-cosine positional embedding vectors for scalar positions."""
+    if dimension % 2 != 0:
+        raise ValueError(f"dimension ({dimension}) must be divisible by 2")
+
+    if time.ndim != 1:
+        raise ValueError("The time tensor is expected to be of shape `(batch_size, )`.")
+
+    fraction = torch.linspace(0.0, 1.0, dimension // 2, dtype=torch.float32, device=device)
+    period = min_period * (max_period / min_period) ** fraction
+
+    # Compute the outer product
+    scaling_factor = 1.0 / period * 2 * math.pi
+    sin_input = scaling_factor[None, :] * time[:, None]
+    pos_emb = torch.cat([torch.sin(sin_input), torch.cos(sin_input)], dim=1)
+    return pos_emb
+
+
+def sample_beta(alpha, beta, bsize, device):
+    gamma1 = torch.rand((bsize,), device=device).pow(1 / alpha)
+    gamma2 = torch.rand((bsize,), device=device).pow(1 / beta)
+    return gamma1 / (gamma1 + gamma2)
+
+
+def make_att_2d_masks(pad_masks, att_masks):
+    """Copied from big_vision.
+
+    Tokens can attend to valid inputs tokens which have a cumulative mask_ar
+    smaller or equal to theirs. This way `mask_ar` int[B, N] can be used to
+    setup several types of attention, for example:
+
+      [[1 1 1 1 1 1]]: pure causal attention.
+
+      [[0 0 0 1 1 1]]: prefix-lm attention. The first 3 tokens can attend between
+          themselves and the last 3 tokens have a causal attention. The first
+          entry could also be a 1 without changing behaviour.
+
+      [[1 0 1 0 1 0 0 1 0 0]]: causal attention between 4 blocks. Tokens of a
+          block can attend all previous blocks and all tokens on the same block.
+
+    Args:
+      input_mask: bool[B, N] true if its part of the input, false if padding.
+      mask_ar: int32[B, N] mask that's 1 where previous tokens cannot depend on
+        it and 0 where it shares the same attention mask as the previous token.
+    """
+    if att_masks.ndim != 2:
+        raise ValueError(att_masks.ndim)
+    if pad_masks.ndim != 2:
+        raise ValueError(pad_masks.ndim)
+
+    cumsum = torch.cumsum(att_masks, dim=1)
+    att_2d_masks = cumsum[:, None, :] <= cumsum[:, :, None]
+    pad_2d_masks = pad_masks[:, None, :] * pad_masks[:, :, None]
+    att_2d_masks = att_2d_masks & pad_2d_masks
+    return att_2d_masks
+
+
+def resize_with_pad(img, width, height, pad_value=-1):
+    # assume no-op when width height fits already
+    if img.ndim != 4:
+        raise ValueError(f"(b,c,h,w) expected, but {img.shape}")
+
+    cur_height, cur_width = img.shape[2:]
+
+    ratio = max(cur_width / width, cur_height / height)
+    resized_height = int(cur_height / ratio)
+    resized_width = int(cur_width / ratio)
+    resized_img = F.interpolate(
+        img, size=(resized_height, resized_width), mode="bilinear", align_corners=False
+    )
+
+    pad_height = max(0, int(height - resized_height))
+    pad_width = max(0, int(width - resized_width))
+
+    # pad on left and top of image
+    padded_img = F.pad(resized_img, (pad_width, 0, pad_height, 0), value=pad_value)
+    return padded_img
+
+
+def our_eager_attention_forward(
+    query_states: torch.Tensor,
+    key_states: torch.Tensor,
+    value_states: torch.Tensor,
+    attention_mask: torch.Tensor,
+):
+    """
+    Performs eager attention, optimized with torch.einsum.
+
+    Args:
+        query_states: Query tensor of shape [batch_size, seq_len, num_attention_heads, head_dim].
+        key_states: Key tensor of shape [batch_size, seq_len, num_key_value_heads, head_dim].
+        value_states: Value tensor of shape [batch_size, seq_len, num_key_value_heads, head_dim].
+        attention_mask: Attention mask tensor, typically [batch_size, 1, seq_len, seq_len] or [batch_size, seq_len, seq_len].
+
+    Returns:
+        Output tensor of shape [batch_size, seq_len, num_attention_heads * head_dim].
+    """
+    # ipdb.set_trace()
+    bsize, seq_len, num_att_heads, head_dim = query_states.shape
+    num_key_value_heads = key_states.shape[2]
+    num_key_value_groups = num_att_heads // num_key_value_heads
+
+    key_states = einops.repeat(key_states, "b l h d -> b l (h g) d", g=num_key_value_groups)
+    value_states = einops.repeat(value_states, "b l h d -> b l (h g) d", g=num_key_value_groups)
+
+    query_states_permuted = torch.einsum("blhd->bhld", query_states)
+    key_states_permuted = torch.einsum("blhd->bhld", key_states)
+
+    att_weights = torch.einsum("bhqd,bhkd->bhqk", query_states_permuted, key_states_permuted)
+    att_weights *= head_dim**-0.5
+
+    big_neg = -2.3819763e38
+    masked_att_weights = torch.where(attention_mask[:, None, :, :], att_weights, big_neg)
+
+    probs = nn.functional.softmax(masked_att_weights, dim=-1)
+    probs = probs.to(dtype=value_states.dtype)
+
+    value_states_permuted = torch.einsum("blhd->bhld", value_states)  # [B, H, L_v, D]
+    att_output = torch.einsum("bhqk,bhkv->bhqv", probs, value_states_permuted)  # [B, H, L_q, D]
+    att_output = torch.einsum("bhld->blhd", att_output)  # [B, L, H, D]
+    att_output = att_output.reshape(bsize, seq_len, num_att_heads * head_dim)
+
+    return att_output
+
+
+# @torch.jit.script
+def apply_rope(
+    x: torch.Tensor,
+    positions: torch.Tensor,
+    max_wavelength: float = 10_000.0,
+    dtype: torch.dtype = torch.float32,
+) -> torch.Tensor:
+    """Applies RoPE positions [B, L] to x [B, L, H, D]."""
+    # ipdb.set_trace()
+    original_dtype = x.dtype  # bf16
+    d = x.shape[-1]
+    d_half = d // 2
+    device = x.device
+
+    # Cast input to compute_dtype for all internal operations
+    x_casted = x.to(dtype)
+    positions_casted = positions.to(dtype)
+
+    freq_exponents = (2.0 / d) * torch.arange(d_half, dtype=dtype, device=device)
+    timescale = max_wavelength**freq_exponents
+    radians = torch.einsum("bl,h->blh", positions_casted, 1.0 / timescale)  # fp32 -> bf16
+
+    radians = radians[..., None, :]  # [B, L, 1, D_half]
+
+    sin = torch.sin(radians)  # bf16
+    cos = torch.cos(radians)  # bf16
+
+    x1, x2 = x_casted.split(d_half, dim=-1)  # fp32
+
+    res = torch.cat([x1 * cos - x2 * sin, x2 * cos + x1 * sin], dim=-1)  # fp32
+
+    return res.to(original_dtype)  # bf16

--- a/tests/policies/lingbot_vla/test_lingbot_vla.py
+++ b/tests/policies/lingbot_vla/test_lingbot_vla.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python
+
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test script to verify LingBot-VLA policy integration with LeRobot."""
+
+import pytest
+import torch
+
+# Skip if required dependencies are not available
+pytest.importorskip("transformers")
+
+from lerobot.configs.types import FeatureType, PolicyFeature  # noqa: E402
+from lerobot.policies.factory import make_policy_config  # noqa: E402
+from lerobot.policies.lingbot_vla import LingbotVLAConfig  # noqa: E402
+from lerobot.policies.lingbot_vla.modeling_lingbot_vla import LingbotVLAPolicy  # noqa: E402
+from lerobot.policies.lingbot_vla.processor_lingbot_vla import (  # noqa: E402
+    make_lingbot_vla_pre_post_processors,
+)
+from lerobot.utils.constants import ACTION, OBS_STATE  # noqa: E402
+from lerobot.utils.random_utils import set_seed  # noqa: E402
+from tests.utils import require_cuda  # noqa: E402
+
+STATE_DIM = 6
+ACTION_DIM = 6
+CAM = "observation.images.cam"
+
+
+def _make_config() -> LingbotVLAConfig:
+    config = LingbotVLAConfig(device="cuda", attention_implementation="eager")
+    config.input_features = {
+        CAM: PolicyFeature(type=FeatureType.VISUAL, shape=(3, 480, 640)),
+        OBS_STATE: PolicyFeature(type=FeatureType.STATE, shape=(STATE_DIM,)),
+    }
+    config.output_features = {ACTION: PolicyFeature(type=FeatureType.ACTION, shape=(ACTION_DIM,))}
+    return config
+
+
+def _make_dataset_stats() -> dict:
+    return {
+        OBS_STATE: {"mean": torch.zeros(STATE_DIM), "std": torch.ones(STATE_DIM)},
+        ACTION: {"mean": torch.zeros(ACTION_DIM), "std": torch.ones(ACTION_DIM)},
+    }
+
+
+@require_cuda
+def test_policy_instantiation():
+    """Raw observation -> processor pipeline -> forward + select_action round-trip."""
+    set_seed(42)
+    config = _make_config()
+    dataset_stats = _make_dataset_stats()
+
+    policy = LingbotVLAPolicy(config).to(device="cuda", dtype=torch.bfloat16)
+    policy.eval()
+    preprocessor, postprocessor = make_lingbot_vla_pre_post_processors(
+        config=config, dataset_stats=dataset_stats
+    )
+
+    # Forward (training) pass: a pre-batched sample as it would arrive from the
+    # dataloader (batch dim already present on image/state/action).
+    train_obs = {
+        CAM: torch.rand(1, 3, 480, 640),
+        OBS_STATE: torch.randn(1, STATE_DIM),
+        ACTION: torch.randn(1, config.chunk_size, ACTION_DIM),
+        "task": "pick up the red cube",
+    }
+    batch = preprocessor(train_obs)
+    loss, loss_dict = policy.forward(batch)
+    assert torch.isfinite(loss), loss
+    assert "loss" in loss_dict
+
+    # Inference pass: select a single action and unnormalize it.
+    infer_obs = {
+        CAM: torch.rand(3, 480, 640),
+        OBS_STATE: torch.randn(STATE_DIM),
+        "task": "pick up the red cube",
+    }
+    batch = preprocessor(infer_obs)
+    with torch.no_grad():
+        action = policy.select_action(batch)
+        action = postprocessor(action)
+    assert action.shape[-1] == ACTION_DIM, action.shape
+
+
+@require_cuda
+def test_processor_produces_model_ready_keys():
+    """The preprocessor must emit the patchified images/lang tensors the model consumes."""
+    config = _make_config()
+    preprocessor, _ = make_lingbot_vla_pre_post_processors(config=config, dataset_stats=_make_dataset_stats())
+    obs = {
+        CAM: torch.rand(3, 480, 640),
+        OBS_STATE: torch.randn(STATE_DIM),
+        "task": "pick up the red cube",
+    }
+    batch = preprocessor(obs)
+    for key in ("images", "img_masks", "lang_tokens", "lang_masks", OBS_STATE):
+        assert key in batch, key
+    assert batch["images"].ndim == 4  # (B, n_views, num_patches, patch_dim)
+    assert batch["lang_tokens"].shape[-1] == config.tokenizer_max_length
+
+
+def test_config_creation():
+    """Config can be created through the policy factory by type name."""
+    config = make_policy_config(policy_type="lingbot_vla")
+    assert type(config).__name__ == "LingbotVLAConfig"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
     "(python_full_version >= '3.15' and platform_machine == 'AMD64' and sys_platform == 'linux') or (python_full_version >= '3.15' and platform_machine == 'x86_64' and sys_platform == 'linux')",
@@ -3030,6 +3030,12 @@ libero = [
     { name = "torchcodec", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'AMD64' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'arm64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'win32'" },
     { name = "transformers" },
 ]
+lingbot = [
+    { name = "peft" },
+    { name = "qwen-vl-utils" },
+    { name = "scipy" },
+    { name = "transformers" },
+]
 matplotlib-dep = [
     { name = "contourpy" },
     { name = "matplotlib" },
@@ -3281,6 +3287,7 @@ requires-dist = [
     { name = "lerobot", extras = ["kinematics"], marker = "extra == 'all'" },
     { name = "lerobot", extras = ["lekiwi"], marker = "extra == 'all'" },
     { name = "lerobot", extras = ["libero"], marker = "sys_platform == 'linux' and extra == 'all'" },
+    { name = "lerobot", extras = ["lingbot"], marker = "extra == 'all'" },
     { name = "lerobot", extras = ["matplotlib-dep"], marker = "extra == 'async'" },
     { name = "lerobot", extras = ["matplotlib-dep"], marker = "extra == 'sarm'" },
     { name = "lerobot", extras = ["matplotlib-dep"], marker = "extra == 'unitree-g1'" },
@@ -3293,6 +3300,7 @@ requires-dist = [
     { name = "lerobot", extras = ["openarms"], marker = "extra == 'all'" },
     { name = "lerobot", extras = ["peft"], marker = "extra == 'all'" },
     { name = "lerobot", extras = ["peft-dep"], marker = "extra == 'groot'" },
+    { name = "lerobot", extras = ["peft-dep"], marker = "extra == 'lingbot'" },
     { name = "lerobot", extras = ["peft-dep"], marker = "extra == 'molmoact2'" },
     { name = "lerobot", extras = ["peft-dep"], marker = "extra == 'peft'" },
     { name = "lerobot", extras = ["peft-dep"], marker = "extra == 'robometer'" },
@@ -3313,6 +3321,7 @@ requires-dist = [
     { name = "lerobot", extras = ["pyzmq-dep"], marker = "extra == 'lekiwi'" },
     { name = "lerobot", extras = ["pyzmq-dep"], marker = "extra == 'unitree-g1'" },
     { name = "lerobot", extras = ["qwen-vl-utils-dep"], marker = "extra == 'eo1'" },
+    { name = "lerobot", extras = ["qwen-vl-utils-dep"], marker = "extra == 'lingbot'" },
     { name = "lerobot", extras = ["qwen-vl-utils-dep"], marker = "extra == 'robometer'" },
     { name = "lerobot", extras = ["qwen-vl-utils-dep"], marker = "extra == 'sarm'" },
     { name = "lerobot", extras = ["qwen-vl-utils-dep"], marker = "extra == 'vla-jepa'" },
@@ -3324,6 +3333,7 @@ requires-dist = [
     { name = "lerobot", extras = ["sarm"], marker = "extra == 'all'" },
     { name = "lerobot", extras = ["scipy-dep"], marker = "extra == 'aloha'" },
     { name = "lerobot", extras = ["scipy-dep"], marker = "extra == 'libero'" },
+    { name = "lerobot", extras = ["scipy-dep"], marker = "extra == 'lingbot'" },
     { name = "lerobot", extras = ["scipy-dep"], marker = "extra == 'metaworld'" },
     { name = "lerobot", extras = ["scipy-dep"], marker = "extra == 'molmoact2'" },
     { name = "lerobot", extras = ["scipy-dep"], marker = "extra == 'phone'" },
@@ -3338,6 +3348,7 @@ requires-dist = [
     { name = "lerobot", extras = ["transformers-dep"], marker = "extra == 'groot'" },
     { name = "lerobot", extras = ["transformers-dep"], marker = "extra == 'hilserl'" },
     { name = "lerobot", extras = ["transformers-dep"], marker = "extra == 'libero'" },
+    { name = "lerobot", extras = ["transformers-dep"], marker = "extra == 'lingbot'" },
     { name = "lerobot", extras = ["transformers-dep"], marker = "extra == 'molmoact2'" },
     { name = "lerobot", extras = ["transformers-dep"], marker = "extra == 'multi-task-dit'" },
     { name = "lerobot", extras = ["transformers-dep"], marker = "extra == 'peft'" },
@@ -3417,7 +3428,7 @@ requires-dist = [
     { name = "transformers", marker = "extra == 'transformers-dep'", specifier = ">=5.4.0,<5.6.0" },
     { name = "wandb", marker = "extra == 'training'", specifier = ">=0.24.0,<0.28.0" },
 ]
-provides-extras = ["dataset", "training", "hardware", "viz", "core-scripts", "evaluation", "dataset-viz", "av-dep", "pygame-dep", "placo-dep", "transformers-dep", "grpcio-dep", "accelerate-dep", "can-dep", "peft-dep", "scipy-dep", "diffusers-dep", "qwen-vl-utils-dep", "matplotlib-dep", "pyserial-dep", "deepdiff-dep", "pynput-dep", "pyzmq-dep", "motorbridge-dep", "motorbridge-smart-servo-dep", "feetech", "dynamixel", "damiao", "robstride", "openarms", "gamepad", "hopejr", "lekiwi", "unitree-g1", "reachy2", "rebot", "kinematics", "intelrealsense", "phone", "diffusion", "wallx", "pi", "molmoact2", "smolvla", "multi-task-dit", "groot", "sarm", "robometer", "topreward", "xvla", "eo1", "hilserl", "vla-jepa", "async", "peft", "annotations", "dev", "notebook", "test", "video-benchmark", "aloha", "pusht", "libero", "metaworld", "all"]
+provides-extras = ["dataset", "training", "hardware", "viz", "core-scripts", "evaluation", "dataset-viz", "av-dep", "pygame-dep", "placo-dep", "transformers-dep", "grpcio-dep", "accelerate-dep", "can-dep", "peft-dep", "scipy-dep", "diffusers-dep", "qwen-vl-utils-dep", "matplotlib-dep", "pyserial-dep", "deepdiff-dep", "pynput-dep", "pyzmq-dep", "motorbridge-dep", "motorbridge-smart-servo-dep", "feetech", "dynamixel", "damiao", "robstride", "openarms", "gamepad", "hopejr", "lekiwi", "unitree-g1", "reachy2", "rebot", "kinematics", "intelrealsense", "phone", "diffusion", "wallx", "lingbot", "pi", "molmoact2", "smolvla", "multi-task-dit", "groot", "sarm", "robometer", "topreward", "xvla", "eo1", "hilserl", "vla-jepa", "async", "peft", "annotations", "dev", "notebook", "test", "video-benchmark", "aloha", "pusht", "libero", "metaworld", "all"]
 
 [[package]]
 name = "librt"


### PR DESCRIPTION
---
  Summary / Motivation

  Adds LingBot-VLA to LeRobot — an open-source VLA model (arXiv 2601.18692, original repo Robbyant/lingbot-vla). Qwen2.5-VL
   backbone + Qwen2 action expert + Flow-Matching continuous action generation over a 75-D unified state/action space
  (max_state_dim=75, max_action_dim=75, chunk_size=50) for cross-embodiment alignment. The LeRobot integration follows the
  in-tree wall_x precedent (both are Qwen2.5-VL + flow-matching VLAs). Checkpoint is ~4B params (robbyant/lingbot-vla-4b),
  runs on a single GPU.

  Related issues

  - Related: # (none)

  What changed

  - New src/lerobot/policies/lingbot_vla/ package (config / modeling / processor / utils + vendored qwen_model/ Qwen2.5-VL
  backbone)
  - factory.py: model class lazy-imported; config registered via @PreTrainedConfig.register_subclass("lingbot_vla")
  - pyproject.toml: new [lingbot] extra, wired into all; flash-attention optional (default eager, fa2 opt-in only when
  flash-attn installed)
  - Docs lingbot_vla.mdx + deployment protocol, wired into _toctree.yml
  - Tests + one-line smoke test under examples/lingbot_vla/
  - No breaking changes; existing policies untouched

  How was this tested

  - pytest -q tests/policies/lingbot_vla/ — config-creation test runs without CUDA; weight tests guarded by importorskip +
  @require_cuda
  - One-line smoke test: bash examples/lingbot_vla/run_lingbot_vla.sh (install → load → infer)
  - pre-commit (ruff check / format) passes locally

  Checklist (required before merge)

  - Linting/formatting run (pre-commit run -a)
  - All tests pass locally (pytest) — weight tests need CUDA + the 4B checkpoint
  - Documentation updated
  - CI is green
  - Community Review: reviewed another contributor's open PR: #3834

  Reviewer notes

  - Focus on vendored qwen_model/qwenvl_in_vla.py (adapted from HF Transformers Qwen2.5-VL, upstream attribution +
  Apache-2.0 retained) and the 75-D slot mapping.
  - With flash-attn absent the default eager path is used; please confirm config creation works on non-CUDA environments.

