### PR TITLE
perf(docker): split dependency install from source copy for CI layer caching

### DIFF
--- a/docker/Dockerfile.internal
+++ b/docker/Dockerfile.internal
@@ -68,17 +68,21 @@ ENV HOME=/home/user_lerobot \
 # issues with MuJoCo and OpenGL drivers.
 RUN uv venv --python python${PYTHON_VERSION}
 
-# Install Python dependencies for caching
-COPY --chown=user_lerobot:user_lerobot setup.py pyproject.toml uv.lock README.md MANIFEST.in ./
-COPY --chown=user_lerobot:user_lerobot src/ src/
-
-RUN uv sync --locked --extra all --no-cache
+# Install third-party dependencies in a layer whose cache key is the lockfile ONLY.
+# Because src/ is NOT copied here, editing source code no longer invalidates this
+# layer — torch + all extras stay cached across builds (huge CI speedup). Without
+# --no-install-project, uv would need src/ and the cache would bust on every commit.
+COPY --chown=user_lerobot:user_lerobot pyproject.toml uv.lock README.md ./
+RUN uv sync --locked --extra all --no-install-project --no-cache
 
 RUN chmod +x /lerobot/.venv/lib/python${PYTHON_VERSION}/site-packages/triton/backends/nvidia/bin/ptxas
 
-# Copy the rest of the application source code
+# Copy the rest of the application source code and install the local project itself.
+# Third-party deps are already present above, so this step is fast and is the only
+# one that re-runs when source changes.
 # Make sure to have the git-LFS files for testing
 COPY --chown=user_lerobot:user_lerobot . .
+RUN uv sync --locked --extra all --no-cache
 
 # Set the default command
 CMD ["/bin/bash"]

--- a/docker/Dockerfile.user
+++ b/docker/Dockerfile.user
@@ -60,15 +60,19 @@ ENV HOME=/home/user_lerobot \
 # run other Python projects in the same container without dependency conflicts.
 RUN uv venv
 
-# Install Python dependencies for caching
-COPY --chown=user_lerobot:user_lerobot setup.py pyproject.toml uv.lock README.md MANIFEST.in ./
-COPY --chown=user_lerobot:user_lerobot src/ src/
+# Install third-party dependencies in a layer whose cache key is the lockfile ONLY.
+# Because src/ is NOT copied here, editing source code no longer invalidates this
+# layer — torch + all extras stay cached across builds (huge CI speedup). Without
+# --no-install-project, uv would need src/ and the cache would bust on every commit.
+COPY --chown=user_lerobot:user_lerobot pyproject.toml uv.lock README.md ./
+RUN uv sync --locked --extra all --no-install-project --no-cache
 
-RUN uv sync --locked --extra all --no-cache
-
-# Copy the rest of the application code
+# Copy the rest of the application code and install the local project itself.
+# Third-party deps are already present above, so this step is fast and is the only
+# one that re-runs when source changes.
 # Make sure to have the git-LFS files for testing
 COPY --chown=user_lerobot:user_lerobot . .
+RUN uv sync --locked --extra all --no-cache
 
 # Set the default command
 CMD ["/bin/bash"]


### PR DESCRIPTION
## What this does

Restructures `docker/Dockerfile.user` and `docker/Dockerfile.internal` so that third-party dependency installation lives in a layer whose cache key is the **lockfile only** (`pyproject.toml` + `uv.lock`), separate from the source copy.

Previously each image did:

```dockerfile
COPY setup.py pyproject.toml uv.lock README.md MANIFEST.in ./
COPY src/ src/
RUN uv sync --locked --extra all --no-cache
COPY . .
```

Because `src/` was copied **before** `uv sync`, any change to source code invalidated the `COPY src/ src/` layer and forced a full re-resolve + re-download of torch and all extras on every commit — the most expensive step in CI.

Now:

```dockerfile
COPY pyproject.toml uv.lock README.md ./
RUN uv sync --locked --extra all --no-install-project --no-cache   # deps only, no src needed
COPY . .
RUN uv sync --locked --extra all --no-cache                        # installs the local project
```

`--no-install-project` lets uv install all third-party dependencies without needing the project source. Editing `src/` no longer busts the heavy dependency layer, so BuildKit layer cache hits across builds. The final `uv sync` after `COPY . .` installs the local package itself and is fast (deps already present).

## Scope

- `docker/Dockerfile.user`
- `docker/Dockerfile.internal`

The benchmark Dockerfiles (`Dockerfile.benchmark.*`) were reviewed and **not** changed: they either install third-party deps before their final `COPY . .` + `-e .` already, or build `FROM huggingface/lerobot-gpu:latest` and don't run their own `uv sync`.

## Notes

- No change to the resulting image contents — only layer boundaries.
- The `chmod +x ... ptxas` step in `Dockerfile.internal` stays right after the dependency sync, since triton is a third-party dep and is installed in that layer.

