### PR TITLE
Add opt-in rollout action smoothing

### DIFF
--- a/src/lerobot/rollout/configs.py
+++ b/src/lerobot/rollout/configs.py
@@ -223,6 +223,15 @@ class RolloutConfig:
     fps: float = 30.0
     duration: float = 0.0  # 0 = infinite (24/7 mode)
     interpolation_multiplier: int = 1
+    # Post-processor for absolute action commands. Disabled by default because
+    # not every robot action space is safe to smooth as a position target.
+    action_smoothing_enabled: bool = False
+    # EMA weight for the current action: lower values smooth more but add lag.
+    action_smoothing_alpha: float = 0.25
+    # Maximum per-control-tick change in action units.
+    action_smoothing_max_delta: float = 1.25
+    # Action gap above which EMA blending is skipped; velocity clipping still applies.
+    action_smoothing_reset_threshold: float = 10.0
     device: str | None = None
     task: str = ""
     display_data: bool = False
@@ -252,6 +261,14 @@ class RolloutConfig:
 
     def __post_init__(self):
         """Validate config invariants and load the policy config from ``--policy.path``."""
+        if self.action_smoothing_enabled:
+            if not 0.0 <= self.action_smoothing_alpha <= 1.0:
+                raise ValueError("action_smoothing_alpha must be in [0.0, 1.0]")
+            if self.action_smoothing_max_delta <= 0.0:
+                raise ValueError("action_smoothing_max_delta must be > 0.0")
+            if self.action_smoothing_reset_threshold < 0.0:
+                raise ValueError("action_smoothing_reset_threshold must be >= 0.0")
+
         # --- Strategy-specific validation ---
         if isinstance(self.strategy, DAggerStrategyConfig) and self.teleop is None:
             raise ValueError("DAgger strategy requires --teleop.type to be set")

--- a/src/lerobot/rollout/strategies/base.py
+++ b/src/lerobot/rollout/strategies/base.py
@@ -65,7 +65,7 @@ class BaseStrategy(RolloutStrategy):
             if self._handle_warmup(cfg.use_torch_compile, loop_start, control_interval):
                 continue
 
-            action_dict = send_next_action(obs_processed, obs, ctx, interpolator)
+            action_dict = send_next_action(obs_processed, obs, ctx, interpolator, self._action_smoother)
             self._log_telemetry(obs_processed, action_dict, ctx.runtime)
 
             dt = time.perf_counter() - loop_start

--- a/src/lerobot/rollout/strategies/core.py
+++ b/src/lerobot/rollout/strategies/core.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import abc
 import logging
 import time
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from lerobot.datasets.utils import DEFAULT_VIDEO_FILE_SIZE_IN_MB
 from lerobot.utils.action_interpolator import ActionInterpolator
@@ -37,6 +37,41 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+class ActionSmoother:
+    """Stateful EMA + velocity clip for robot action dictionaries."""
+
+    def __init__(self) -> None:
+        self._previous: dict[str, Any] | None = None
+
+    def reset(self) -> None:
+        self._previous = None
+
+    def apply(
+        self,
+        action: dict[str, Any],
+        alpha: float,
+        max_delta: float,
+        reset_threshold: float,
+    ) -> dict[str, Any]:
+        if self._previous is None:
+            self._previous = dict(action)
+            return action
+
+        smoothed = dict(action)
+        for key, value in action.items():
+            previous_value = self._previous.get(key, value)
+            if abs(value - previous_value) <= reset_threshold:
+                value = alpha * value + (1.0 - alpha) * previous_value
+
+            delta = value - previous_value
+            if abs(delta) > max_delta:
+                delta = max(-max_delta, min(max_delta, delta))
+            smoothed[key] = previous_value + delta
+
+        self._previous = dict(smoothed)
+        return smoothed
+
+
 class RolloutStrategy(abc.ABC):
     """Abstract base for rollout execution strategies.
 
@@ -51,6 +86,7 @@ class RolloutStrategy(abc.ABC):
         self._interpolator: ActionInterpolator | None = None
         self._warmup_flushed: bool = False
         self._cached_obs_processed: dict | None = None
+        self._action_smoother = ActionSmoother()
 
     def _init_engine(self, ctx: RolloutContext) -> None:
         """Attach the inference engine and action interpolator, then start the backend.
@@ -67,7 +103,11 @@ class RolloutStrategy(abc.ABC):
         self._engine.start()
         self._warmup_flushed = False
         self._cached_obs_processed = None
+        self._reset_action_smoothing()
         logger.info("Inference engine started")
+
+    def _reset_action_smoothing(self) -> None:
+        self._action_smoother.reset()
 
     def _process_observation_and_notify(self, processors: ProcessorContext, obs_raw: dict) -> dict:
         """Run the observation processor and notify the engine — throttled to policy ticks.
@@ -112,6 +152,7 @@ class RolloutStrategy(abc.ABC):
             logger.info("Warmup complete — flushing stale state and resuming engine")
             engine.reset()
             interpolator.reset()
+            self._reset_action_smoothing()
             self._warmup_flushed = True
             engine.resume()
         return False
@@ -271,6 +312,7 @@ def send_next_action(
     obs_raw: dict,
     ctx: RolloutContext,
     interpolator: ActionInterpolator,
+    action_smoother: ActionSmoother | None = None,
 ) -> dict | None:
     """Dispatch the next action to the robot.
 
@@ -300,5 +342,15 @@ def send_next_action(
         raise ValueError(f"Interpolated tensor length ({len(interp)}) != action keys ({len(ordered_keys)})")
     action_dict = {k: interp[i].item() for i, k in enumerate(ordered_keys)}
     processed = ctx.processors.robot_action_processor((action_dict, obs_raw))
+    cfg = ctx.runtime.cfg
+    if cfg.action_smoothing_enabled:
+        if action_smoother is None:
+            raise ValueError("action_smoother is required when action smoothing is enabled")
+        processed = action_smoother.apply(
+            processed,
+            alpha=cfg.action_smoothing_alpha,
+            max_delta=cfg.action_smoothing_max_delta,
+            reset_threshold=cfg.action_smoothing_reset_threshold,
+        )
     ctx.hardware.robot_wrapper.send_action(processed)
     return action_dict

--- a/src/lerobot/rollout/strategies/dagger.py
+++ b/src/lerobot/rollout/strategies/dagger.py
@@ -341,6 +341,7 @@ class DAggerStrategy(RolloutStrategy):
 
         engine.reset()
         interpolator.reset()
+        self._reset_action_smoothing()
         events.reset()
         engine.resume()
 
@@ -415,7 +416,9 @@ class DAggerStrategy(RolloutStrategy):
                         if self._handle_warmup(cfg.use_torch_compile, loop_start, control_interval):
                             continue
 
-                        action_dict = send_next_action(obs_processed, obs, ctx, interpolator)
+                        action_dict = send_next_action(
+                            obs_processed, obs, ctx, interpolator, self._action_smoother
+                        )
                         if action_dict is not None:
                             self._log_telemetry(obs_processed, action_dict, ctx.runtime)
                             last_action = ctx.processors.robot_action_processor((action_dict, obs))
@@ -498,6 +501,7 @@ class DAggerStrategy(RolloutStrategy):
 
         engine.reset()
         interpolator.reset()
+        self._reset_action_smoothing()
         events.reset()
         engine.resume()
 
@@ -597,7 +601,9 @@ class DAggerStrategy(RolloutStrategy):
                         if self._handle_warmup(cfg.use_torch_compile, loop_start, control_interval):
                             continue
 
-                        action_dict = send_next_action(obs_processed, obs, ctx, interpolator)
+                        action_dict = send_next_action(
+                            obs_processed, obs, ctx, interpolator, self._action_smoother
+                        )
                         if action_dict is not None:
                             self._log_telemetry(obs_processed, action_dict, ctx.runtime)
                             last_action = ctx.processors.robot_action_processor((action_dict, obs))
@@ -623,8 +629,8 @@ class DAggerStrategy(RolloutStrategy):
     # State-machine transition side-effects
     # ------------------------------------------------------------------
 
-    @staticmethod
     def _apply_transition(
+        self,
         old_phase: DAggerPhase,
         new_phase: DAggerPhase,
         engine,
@@ -687,6 +693,7 @@ class DAggerStrategy(RolloutStrategy):
         elif new_phase == DAggerPhase.AUTONOMOUS:
             logger.info("Resuming autonomous mode - resetting engine and interpolator")
             interpolator.reset()
+            self._reset_action_smoothing()
             engine.reset()
             engine.resume()
 

--- a/src/lerobot/rollout/strategies/episodic.py
+++ b/src/lerobot/rollout/strategies/episodic.py
@@ -230,7 +230,7 @@ class EpisodicStrategy(RolloutStrategy):
             if self._handle_warmup(ctx.runtime.cfg.use_torch_compile, loop_start, control_interval):
                 continue
 
-            action_dict = send_next_action(obs_processed, obs, ctx, interpolator)
+            action_dict = send_next_action(obs_processed, obs, ctx, interpolator, self._action_smoother)
 
             if action_dict is not None:
                 obs_frame = build_dataset_frame(features, obs_processed, prefix=OBS_STR)

--- a/src/lerobot/rollout/strategies/highlight.py
+++ b/src/lerobot/rollout/strategies/highlight.py
@@ -123,7 +123,9 @@ class HighlightStrategy(RolloutStrategy):
                     if self._handle_warmup(cfg.use_torch_compile, loop_start, control_interval):
                         continue
 
-                    action_dict = send_next_action(obs_processed, obs, ctx, interpolator)
+                    action_dict = send_next_action(
+                        obs_processed, obs, ctx, interpolator, self._action_smoother
+                    )
 
                     if action_dict is not None:
                         self._log_telemetry(obs_processed, action_dict, ctx.runtime)

--- a/src/lerobot/rollout/strategies/sentry.py
+++ b/src/lerobot/rollout/strategies/sentry.py
@@ -116,7 +116,9 @@ class SentryStrategy(RolloutStrategy):
                     if self._handle_warmup(cfg.use_torch_compile, loop_start, control_interval):
                         continue
 
-                    action_dict = send_next_action(obs_processed, obs, ctx, interpolator)
+                    action_dict = send_next_action(
+                        obs_processed, obs, ctx, interpolator, self._action_smoother
+                    )
 
                     if action_dict is not None:
                         self._log_telemetry(obs_processed, action_dict, ctx.runtime)

--- a/tests/test_rollout.py
+++ b/tests/test_rollout.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import dataclasses
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -283,6 +284,96 @@ def test_safe_push_to_hub():
     ds.num_episodes = 5
     assert safe_push_to_hub(ds, tags=["test"]) is True
     ds.push_to_hub.assert_called_once_with(tags=["test"], private=False)
+
+
+def test_action_smoothing_config_defaults_off():
+    from lerobot.rollout import RolloutConfig
+
+    defaults = {field.name: field.default for field in dataclasses.fields(RolloutConfig)}
+    assert defaults["action_smoothing_enabled"] is False
+    assert defaults["action_smoothing_alpha"] == 0.25
+    assert defaults["action_smoothing_max_delta"] == 1.25
+    assert defaults["action_smoothing_reset_threshold"] == 10.0
+
+
+def test_action_smoother_ema_clip_and_reset():
+    from lerobot.rollout.strategies.core import ActionSmoother
+
+    smoother = ActionSmoother()
+    assert smoother.apply({"joint.pos": 0.0}, alpha=0.25, max_delta=100.0, reset_threshold=100.0) == {
+        "joint.pos": 0.0
+    }
+    assert smoother.apply({"joint.pos": 8.0}, alpha=0.25, max_delta=100.0, reset_threshold=100.0) == {
+        "joint.pos": 2.0
+    }
+
+    smoother.reset()
+    assert smoother.apply({"joint.pos": 8.0}, alpha=0.25, max_delta=100.0, reset_threshold=100.0) == {
+        "joint.pos": 8.0
+    }
+
+    smoother = ActionSmoother()
+    smoother.apply({"joint.pos": 0.0}, alpha=1.0, max_delta=2.0, reset_threshold=100.0)
+    assert smoother.apply({"joint.pos": 8.0}, alpha=1.0, max_delta=2.0, reset_threshold=100.0) == {
+        "joint.pos": 2.0
+    }
+
+    smoother = ActionSmoother()
+    smoother.apply({"joint.pos": 0.0}, alpha=0.25, max_delta=100.0, reset_threshold=1.0)
+    assert smoother.apply({"joint.pos": 8.0}, alpha=0.25, max_delta=100.0, reset_threshold=1.0) == {
+        "joint.pos": 8.0
+    }
+
+
+def test_send_next_action_applies_action_smoothing_before_send():
+    from lerobot.rollout.context import (
+        DatasetContext,
+        HardwareContext,
+        PolicyContext,
+        ProcessorContext,
+        RolloutContext,
+        RuntimeContext,
+    )
+    from lerobot.rollout.strategies.core import ActionSmoother, send_next_action
+    from lerobot.utils.action_interpolator import ActionInterpolator
+
+    engine = MagicMock()
+    engine.get_action.side_effect = [torch.tensor([0.0]), torch.tensor([8.0])]
+    robot_wrapper = MagicMock()
+    robot_action_processor = MagicMock(side_effect=lambda action_and_obs: dict(action_and_obs[0]))
+    cfg = SimpleNamespace(
+        action_smoothing_enabled=True,
+        action_smoothing_alpha=1.0,
+        action_smoothing_max_delta=2.0,
+        action_smoothing_reset_threshold=100.0,
+    )
+    ctx = RolloutContext(
+        runtime=RuntimeContext(cfg=cfg, shutdown_event=MagicMock()),
+        hardware=HardwareContext(robot_wrapper=robot_wrapper, teleop=None),
+        policy=PolicyContext(
+            policy=MagicMock(),
+            preprocessor=MagicMock(),
+            postprocessor=MagicMock(),
+            inference=engine,
+        ),
+        processors=ProcessorContext(
+            teleop_action_processor=MagicMock(),
+            robot_action_processor=robot_action_processor,
+            robot_observation_processor=MagicMock(),
+        ),
+        data=DatasetContext(
+            dataset=None,
+            dataset_features={"observation.state": {"dtype": "float32", "shape": (0,), "names": []}},
+            ordered_action_keys=["joint.pos"],
+        ),
+    )
+    interpolator = ActionInterpolator()
+    smoother = ActionSmoother()
+
+    assert send_next_action({}, {}, ctx, interpolator, smoother) == {"joint.pos": 0.0}
+    assert send_next_action({}, {}, ctx, interpolator, smoother) == {"joint.pos": 8.0}
+    robot_wrapper.send_action.assert_any_call({"joint.pos": 0.0})
+    robot_wrapper.send_action.assert_called_with({"joint.pos": 2.0})
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add opt-in rollout action smoothing with EMA and per-tick velocity clipping
- apply smoothing after robot action processing and before send_action across rollout strategies
- reset smoothing state at rollout starts, warmup flushes, and DAgger autonomous resume boundaries

Based on the patch and hardware validation shared by @anikita in #3794. Default is intentionally off per the issue discussion because not every robot action space is safe to smooth as absolute position targets.

Fixes #3794

## Tests
- uv run pytest tests/test_rollout.py -svv
- uv run ruff check src/lerobot/rollout tests/test_rollout.py