### PR TITLE
fix(config): load policy from requested revision

### DIFF
--- a/src/lerobot/configs/train.py
+++ b/src/lerobot/configs/train.py
@@ -38,6 +38,15 @@ from .rewards import RewardModelConfig
 TRAIN_CONFIG_NAME = "train_config.json"
 
 
+def _get_override_value(overrides: list[str], name: str) -> str | None:
+    """Return the value for a flattened CLI-style override, if present."""
+    prefix = f"--{name}="
+    for override in reversed(overrides):
+        if override.startswith(prefix):
+            return override[len(prefix) :]
+    return None
+
+
 def _migrate_legacy_rabc_fields(config: dict[str, Any]) -> dict[str, Any] | None:
     """Return migrated payload for legacy RA-BC fields, or None when no migration is needed."""
     legacy_fields = (
@@ -166,7 +175,10 @@ class TrainPipelineConfig(HubMixin):
             self.reward_model.pretrained_path = str(Path(reward_model_path))
         elif policy_path:
             overrides = parser.get_yaml_overrides("policy") + (parser.get_cli_overrides("policy") or [])
-            self.policy = PreTrainedConfig.from_pretrained(policy_path, cli_overrides=overrides)
+            pretrained_revision = _get_override_value(overrides, "pretrained_revision")
+            self.policy = PreTrainedConfig.from_pretrained(
+                policy_path, revision=pretrained_revision, cli_overrides=overrides
+            )
             self.policy.pretrained_path = Path(policy_path)
         elif self.resume:
             self._resolve_resume_checkpoint()

--- a/tests/test_yaml_policy_path.py
+++ b/tests/test_yaml_policy_path.py
@@ -4,11 +4,14 @@ import json
 import sys
 import tempfile
 from dataclasses import dataclass, field
+from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import yaml
 
 from lerobot.configs import parser
+from lerobot.configs.default import DatasetConfig
 from lerobot.configs.parser import (
     _config_path_args,
     _config_yaml_overrides,
@@ -17,6 +20,7 @@ from lerobot.configs.parser import (
     get_path_arg,
     get_yaml_overrides,
 )
+from lerobot.configs.train import TrainPipelineConfig
 
 
 def test_extract_path_fields_from_yaml():
@@ -315,6 +319,62 @@ def test_wrap_uses_cleaned_config_for_draccus_parse():
     # class (a real PreTrainedConfig would now load the checkpoint and apply
     # the captured yaml_overrides via from_pretrained()).
     assert captured["cfg"].nested.foo == 0
+
+    _config_path_args.clear()
+    _config_yaml_overrides.clear()
+
+
+def test_policy_pretrained_revision_passed_to_hub_download_from_cli():
+    """--policy.pretrained_revision must select the Hub revision used for loading."""
+    cfg = TrainPipelineConfig(dataset=DatasetConfig(repo_id="lerobot/pusht"))
+    loaded_policy = SimpleNamespace(pretrained_path=None)
+
+    with (
+        patch.object(
+            sys,
+            "argv",
+            [
+                "prog",
+                "--policy.path=lerobot/smolvla_base",
+                "--policy.pretrained_revision=checkpoint-000100",
+            ],
+        ),
+        patch(
+            "lerobot.configs.train.PreTrainedConfig.from_pretrained", return_value=loaded_policy
+        ) as from_pretrained,
+    ):
+        cfg._resolve_pretrained_from_cli()
+
+    from_pretrained.assert_called_once_with(
+        "lerobot/smolvla_base",
+        revision="checkpoint-000100",
+        cli_overrides=["--pretrained_revision=checkpoint-000100"],
+    )
+    assert cfg.policy is loaded_policy
+    assert loaded_policy.pretrained_path == Path("lerobot/smolvla_base")
+
+
+def test_policy_pretrained_revision_passed_to_hub_download_from_yaml():
+    cfg = TrainPipelineConfig(dataset=DatasetConfig(repo_id="lerobot/pusht"))
+    loaded_policy = SimpleNamespace(pretrained_path=None)
+    _config_path_args.clear()
+    _config_yaml_overrides.clear()
+    _config_path_args["policy"] = "lerobot/smolvla_base"
+    _config_yaml_overrides["policy"] = ["--pretrained_revision=checkpoint-000200"]
+
+    with (
+        patch.object(sys, "argv", ["prog"]),
+        patch(
+            "lerobot.configs.train.PreTrainedConfig.from_pretrained", return_value=loaded_policy
+        ) as from_pretrained,
+    ):
+        cfg._resolve_pretrained_from_cli()
+
+    from_pretrained.assert_called_once_with(
+        "lerobot/smolvla_base",
+        revision="checkpoint-000200",
+        cli_overrides=["--pretrained_revision=checkpoint-000200"],
+    )
 
     _config_path_args.clear()
     _config_yaml_overrides.clear()


### PR DESCRIPTION
Fixes #3867

## Summary
- Pass `--policy.pretrained_revision` through to `PreTrainedConfig.from_pretrained(..., revision=...)` when resolving `--policy.path`.
- Keep the override in `cli_overrides` so the loaded policy config still records the pinned revision.
- Add CLI and YAML regression coverage for policy path loading with `pretrained_revision`.

## Tests
- `PYTHONPATH=src uv run pytest tests/test_yaml_policy_path.py -q`
- `uv run ruff check src/lerobot/configs/train.py tests/test_yaml_policy_path.py`
- `git diff --check`
