### PR TITLE
perf(tests): cache draccus docstring extraction to fix Fast Tests regression

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,13 +14,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import functools
 import traceback
 
+import draccus.wrappers.docstring as _draccus_docstring
 import pytest
 
 from lerobot.configs.types import FeatureType, PipelineFeatureType, PolicyFeature
 from lerobot.utils.import_utils import is_package_available
 from tests.utils import DEVICE
+
+# On every `draccus.parse()`, draccus rebuilds each dataclass field's help text by
+# re-reading and re-parsing the class source (draccus.wrappers.docstring). For a config
+# as large as TrainPipelineConfig this costs ~2.5s per parse — negligible for the single
+# parse a CLI does, but tests parse configs hundreds of times. The source can't change
+# within a run, so memoize it for the whole test session.
+_draccus_docstring.get_attribute_docstring = functools.cache(_draccus_docstring.get_attribute_docstring)
 
 # Import fixture modules as plugins.
 # Fixtures that depend on optional packages are only registered when those packages are available,


### PR DESCRIPTION
## What

Fast Tests CI duration jumped ~62% (≈9 min → ≈14 min) after the PRs merged around Jun 29. This restores it by fixing a per-parse cost in draccus that the test suite pays repeatedly.

## Root cause

On every `draccus.parse()`, draccus rebuilds each dataclass field's help text by re-reading and re-`ast.parse`-ing the config class's **source file** (`draccus.wrappers.docstring.get_attribute_docstring`). For a config as large as `TrainPipelineConfig` this costs **~2.5s per parse**.

A CLI parses a config once, so this never mattered in production. But the test suite parses configs hundreds of times. The regression surfaced because #3856 added ~20 new tests that each parse a `TrainPipelineConfig`:
- Tier 2 (dataset): the `datasets`-gated `tests/jobs/*` tests
- Tier 1 (base): `tests/jobs/test_job_config.py`, `tests/configs/test_resume_from_hub.py`

(The other PRs in that window — MolmoAct2 #3879 and vla-jepa #3750 — are `transformers`-gated and skipped in every Fast Tests tier, so they don't contribute.)

## Fix

The extracted docstring is a pure function of `(class, field_name)` and can't change within a run, so memoize it for the whole test session in `tests/conftest.py`:

```python
_draccus_docstring.get_attribute_docstring = functools.cache(_draccus_docstring.get_attribute_docstring)
```

Test-only; production `draccus.parse()` behavior is unchanged.

## Impact (measured locally)

| Scope | Before | After |
|---|---|---|
| Single `draccus.parse(TrainPipelineConfig)` | 2.55s | 0.05s (**56×**) |
| `tests/{policies,configs,scripts,jobs,processor,optim}` (925 tests) | 116.99s | 28.57s (**4.1×, −75.6%**) |

Because the cache also speeds up config-parsing tests that predate these PRs, Fast Tests should land at/below its pre-regression baseline.
