### PR TITLE
fix(train): drive Accelerate mixed precision from policy.dtype

### DIFF
--- a/src/lerobot/scripts/lerobot_train.py
+++ b/src/lerobot/scripts/lerobot_train.py
@@ -211,8 +211,15 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
         # Accelerate auto-detects the device based on the available hardware and ignores the policy.device setting.
         # Force the device to be CPU when the active config's device is set to CPU (works for both policy and reward model training).
         force_cpu = cfg.trainable_config.device == "cpu"
+        # Drive Accelerate's autocast from the policy dtype so `accelerator.autocast()`
+        # actually casts to bf16/fp16 when `--policy.dtype` requests it, and stays full
+        # precision for float32. Policies that don't expose a string `dtype` (e.g. those
+        # using torch_dtype/compute_dtype) fall back to Accelerate's launcher default.
+        policy_dtype = getattr(cfg.trainable_config, "dtype", None)
+        mixed_precision = {"bfloat16": "bf16", "float16": "fp16", "float32": "no"}.get(policy_dtype)
         accelerator = Accelerator(
             step_scheduler_with_optimizer=False,
+            mixed_precision=mixed_precision,
             kwargs_handlers=[ddp_kwargs],
             cpu=force_cpu,
         )

--- a/src/lerobot/scripts/lerobot_train.py
+++ b/src/lerobot/scripts/lerobot_train.py
@@ -211,10 +211,7 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
         # Accelerate auto-detects the device based on the available hardware and ignores the policy.device setting.
         # Force the device to be CPU when the active config's device is set to CPU (works for both policy and reward model training).
         force_cpu = cfg.trainable_config.device == "cpu"
-        # Drive Accelerate's autocast from the policy dtype so `accelerator.autocast()`
-        # actually casts to bf16/fp16 when `--policy.dtype` requests it, and stays full
-        # precision for float32. Policies that don't expose a string `dtype` (e.g. those
-        # using torch_dtype/compute_dtype) fall back to Accelerate's launcher default.
+        # Drive Accelerate's autocast from policy.dtype (bf16/fp16 activate it; float32/absent -> launcher default).
         policy_dtype = getattr(cfg.trainable_config, "dtype", None)
         mixed_precision = {"bfloat16": "bf16", "float16": "fp16", "float32": "no"}.get(policy_dtype)
         accelerator = Accelerator(


### PR DESCRIPTION
## Summary
- `accelerator.autocast()` in the training loop was always a no-op because `Accelerator` was created without `mixed_precision`. As a result, `--policy.dtype=bfloat16` only cast the model params (done inside the policy), while autocast-eligible ops (e.g. the fp32-kept `vision_tower` / `lm_head` matmuls) still ran in fp32/tf32.
- This wires the active policy's `dtype` into Accelerate's `mixed_precision`: `bfloat16 -> bf16`, `float16 -> fp16`, `float32 -> no`. So `accelerator.autocast()` is now actually active for bf16/fp16 and stays full precision for float32 — "works with both".
- Policies that don't expose a string `dtype` field (those using `torch_dtype` / `compute_dtype` / etc.) resolve to `None`, so `Accelerator` falls back to the launcher default and existing behavior is preserved.

```python
policy_dtype = getattr(cfg.trainable_config, "dtype", None)
mixed_precision = {"bfloat16": "bf16", "float16": "fp16", "float32": "no"}.get(policy_dtype)
accelerator = Accelerator(
    step_scheduler_with_optimizer=False,
    mixed_precision=mixed_precision,
    kwargs_handlers=[ddp_kwargs],
    cpu=force_cpu,
)
```

## Test plan
- [x] Smoke test: `pi052` on 2×H100, `--policy.dtype=bfloat16`, 6 steps — completed (exit 0) with finite loss / grad norms and no dtype-mismatch in the forward/backward under bf16 autocast.
- [ ] `float32` path unchanged (maps to `"no"` == prior default behavior).
- [ ] CI (fast tests + quality).

Made with [Cursor](https://cursor.com)