### PR TITLE
feat: dataset viz generic scalars

### DIFF
--- a/src/lerobot/scripts/lerobot_dataset_viz.py
+++ b/src/lerobot/scripts/lerobot_dataset_viz.py
@@ -76,6 +76,60 @@ from lerobot.datasets import LeRobotDataset
 from lerobot.utils.constants import ACTION, DONE, OBS_STATE, REWARD
 from lerobot.utils.utils import init_logging
 
+METADATA_KEYS = {"index", "timestamp", "episode_index", "frame_index", "task_index", "task"}
+KNOWN_SCALAR_KEYS = {DONE, REWARD, "next.success"}
+SCALAR_DTYPES = {
+    "bool",
+    "float",
+    "float16",
+    "float32",
+    "float64",
+    "int8",
+    "int16",
+    "int32",
+    "int64",
+    "uint8",
+    "uint16",
+    "uint32",
+    "uint64",
+}
+
+
+def is_scalar_feature(feature: dict) -> bool:
+    dtype = feature.get("dtype")
+    if dtype not in SCALAR_DTYPES:
+        return False
+
+    shape = feature.get("shape")
+    if shape is None:
+        return True
+    if isinstance(shape, int):
+        return shape == 1
+    if not isinstance(shape, (list, tuple)):
+        return False
+    return len(shape) == 0 or (len(shape) == 1 and shape[0] == 1)
+
+
+def get_extra_scalar_keys(dataset: LeRobotDataset) -> list[str]:
+    known_keys = {ACTION, OBS_STATE, *KNOWN_SCALAR_KEYS, *METADATA_KEYS}
+    known_keys.update(dataset.meta.camera_keys)
+
+    return [
+        key for key, feature in dataset.features.items() if key not in known_keys and is_scalar_feature(feature)
+    ]
+
+
+def is_scalar_like(value) -> bool:
+    if isinstance(value, torch.Tensor):
+        return value.numel() == 1
+    if isinstance(value, np.ndarray):
+        return value.size == 1
+    return np.isscalar(value)
+
+
+def scalar_to_float(value) -> float:
+    return float(value.item() if hasattr(value, "item") else value)
+
 
 def get_feature_names(dataset: LeRobotDataset, key: str) -> list[str]:
     """Return per-dimension names for a feature from the dataset metadata.
@@ -129,6 +183,8 @@ def build_blueprint_from_dataset(dataset: LeRobotDataset):
     for key in (DONE, REWARD, "next.success"):
         if key in dataset.features:
             views.append(rrb.TimeSeriesView(origin=key, name=key))
+    for key in get_extra_scalar_keys(dataset):
+        views.append(rrb.TimeSeriesView(origin=key, name=key))
 
     return rrb.Blueprint(rrb.Grid(*views))
 
@@ -200,6 +256,8 @@ def visualize_dataset(
         hi = stats["q99"] if "q99" in stats else stats["max"]
         depth_ranges[key] = (float(np.asarray(lo).item()), float(np.asarray(hi).item()))
 
+    extra_scalar_keys = get_extra_scalar_keys(dataset)
+
     first_index = None
     for batch in tqdm.tqdm(dataloader, total=len(dataloader)):
         if first_index is None:
@@ -241,6 +299,10 @@ def visualize_dataset(
 
             if "next.success" in batch:
                 rr.log("next.success", rr.Scalars(batch["next.success"][i].item()))
+
+            for key in extra_scalar_keys:
+                if key in batch and is_scalar_like(batch[key][i]):
+                    rr.log(key, rr.Scalars(scalar_to_float(batch[key][i])))
 
     # save .rrd locally
     if mode == "local" and save:

--- a/tests/datasets/test_visualize_dataset.py
+++ b/tests/datasets/test_visualize_dataset.py
@@ -14,10 +14,48 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import pytest
+import torch
 
 pytest.importorskip("datasets", reason="datasets is required (install lerobot[dataset])")
 
-from lerobot.scripts.lerobot_dataset_viz import visualize_dataset
+from lerobot.scripts.lerobot_dataset_viz import get_extra_scalar_keys, is_scalar_like, visualize_dataset
+from lerobot.utils.constants import ACTION, OBS_STATE
+
+
+class DummyMeta:
+    camera_keys = ["observation.images.front"]
+
+
+class DummyDataset:
+    meta = DummyMeta()
+    features = {
+        "index": {"dtype": "int64", "shape": [1]},
+        ACTION: {"dtype": "float32", "shape": [6]},
+        OBS_STATE: {"dtype": "float32", "shape": [6]},
+        "observation.images.front": {"dtype": "video", "shape": [3, 480, 640]},
+        "q_target": {"dtype": "float32", "shape": [1]},
+        "intervention": {"dtype": "bool", "shape": []},
+        "embedding": {"dtype": "float32", "shape": [32]},
+        "comment": {"dtype": "string"},
+    }
+
+
+def test_get_extra_scalar_keys_skips_known_metadata_and_non_scalars():
+    assert get_extra_scalar_keys(DummyDataset()) == ["q_target", "intervention"]
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (torch.tensor(1.0), True),
+        (torch.tensor([1.0]), True),
+        (torch.tensor([1.0, 2.0]), False),
+        (1.0, True),
+        (True, True),
+    ],
+)
+def test_is_scalar_like(value, expected):
+    assert is_scalar_like(value) is expected
 
 
 @pytest.mark.skip("TODO: add dummy videos")


### PR DESCRIPTION
## Title

feat(dataset-viz): render custom scalar columns

## Summary / Motivation

This PR adds generic scalar column rendering to `lerobot-dataset-viz`, so custom scalar dataset fields can appear in Rerun without requiring each key to be hardcoded. Previously, the visualizer only logged known signals such as action, state, reward, done, and success. This change keeps those existing paths unchanged, skips metadata/camera/non-scalar fields, and logs additional scalar features as time-series values. The implementation is intentionally conservative: it only picks numeric/bool scalar-shaped features from the dataset schema to avoid accidentally rendering vectors, embeddings, images, or text fields.

## Related issues

- Fixes / Closes: #3880

## What changed

- Added helper logic to identify extra scalar dataset features while excluding metadata keys, camera keys, and already-rendered signals.
- Added extra scalar features to the Rerun blueprint as `TimeSeriesView`s.
- Logged extra scalar batch values per frame through `rr.Scalars`.
- Added focused tests for scalar feature selection and scalar-like value detection.
- No breaking changes. Existing hardcoded visualization behavior for action, state, reward, done, success, images, and depth images is unchanged.

## How was this tested (or how to run locally)

- Tests added: `tests/datasets/test_visualize_dataset.py`
- Suggested local checks:

```bash
uv run ruff format --check src/lerobot/scripts/lerobot_dataset_viz.py tests/datasets/test_visualize_dataset.py
uv run ruff check src/lerobot/scripts/lerobot_dataset_viz.py tests/datasets/test_visualize_dataset.py
uv run pytest tests/datasets/test_visualize_dataset.py -q
```

- Manual reviewer check with a dataset containing a custom scalar column, for example `q_target` or `intervention`:

```bash
uv run lerobot-dataset-viz \
    --repo-id <repo_id_with_custom_scalar_columns> \
    --episode-index 0
```

- Test Result
```
root@d269ad4036e7:/workspace/lerobot_woo# uv run ruff format --check src/lerobot/scripts/lerobot_dataset_viz.py tests/datasets/test_visualize_dataset.py
uv run ruff check src/lerobot/scripts/lerobot_dataset_viz.py tests/datasets/test_visualize_dataset.py
uv run pytest tests/datasets/test_visualize_dataset.py -q
Would reformat: src/lerobot/scripts/lerobot_dataset_viz.py
1 file would be reformatted, 1 file already formatted
All checks passed!

Testing with DEVICE='cuda'
......s                                                                                                                                            [100%]
6 passed, 1 skipped in 1.45s
```
Then confirm the custom scalar column appears as a Rerun time-series view.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [x] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: # (insert PR number/link)

## Reviewer notes

Please focus on the scalar feature filtering behavior in `lerobot_dataset_viz.py`: the intent is to render custom numeric/bool scalar columns while avoiding metadata, camera streams, existing hardcoded signals, vectors, embeddings, images, and text fields.

Anyone in the community is free to review the PR.