### PR TITLE
Allow h264_nvmpi/hevc_nvmpi hardware codecs (NVIDIA Jetson)

### DIFF
--- a/src/lerobot/configs/video.py
+++ b/src/lerobot/configs/video.py
@@ -35,6 +35,8 @@ HW_VIDEO_CODECS = [
     "hevc_videotoolbox",  # macOS
     "h264_nvenc",  # NVIDIA GPU
     "hevc_nvenc",  # NVIDIA GPU
+    "h264_nvmpi",  # NVIDIA Jetson (jetson-ffmpeg, Multimedia API)
+    "hevc_nvmpi",  # NVIDIA Jetson (jetson-ffmpeg, Multimedia API)
     "h264_vaapi",  # Linux Intel/AMD
     "h264_qsv",  # Intel Quick Sync
 ]


### PR DESCRIPTION


## Allow h264_nvmpi/hevc_nvmpi hardware codecs (NVIDIA Jetson)

## Summary / Motivation

- Allow to hardware encode videos on nvidia jetson

## Related issues

- Fixes / Closes: # (if any)
- Related: # (if any)

## What changed

- Short, concrete bullets explaining the functional changes (how the behavior or output differs now).
- Short note if this introduces breaking changes and migration steps.

## How was this tested (or how to run locally)

- I created a dataset on an nvidia jetson passing h264_nvmpi as codec

## Checklist (required before merge)

- [ ] Linting/formatting run (`pre-commit run -a`)
- [ ] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: # (insert PR number/link)

## Reviewer notes

- Anything the reviewer should focus on (performance, edge-cases, specific files) or general notes.
- Anyone in the community is free to review the PR.
