### PR TITLE
docs: translate notebooks page to Simplified Chinese

### DIFF
--- a/docs/source/zh-hans/notebooks.mdx
+++ b/docs/source/zh-hans/notebooks.mdx
@@ -1,0 +1,29 @@
+# 🤗 LeRobot Notebooks
+
+本仓库包含使用 LeRobot 的示例 Notebook。这些 Notebook 演示了如何使用标准化策略，在真实或仿真数据集上训练策略。
+
+---
+
+### 训练 ACT
+
+[ACT](https://huggingface.co/papers/2304.13705)（Action Chunking Transformer，动作分块 Transformer）是一种基于 Transformer 的模仿学习策略架构，可处理机器人状态和相机输入，以生成平滑的分块动作序列。
+
+我们提供了一个可直接运行的 Google Colab Notebook，帮助你使用 Hugging Face Hub 上的数据集训练 ACT 策略，并可选择记录到 Weights & Biases。
+
+| Notebook                                                                                               | Colab                                                                                                                                                                               |
+| :----------------------------------------------------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [使用 LeRobot 训练 ACT](https://github.com/huggingface/notebooks/blob/main/lerobot/training-act.ipynb) | [![在 Colab 中打开](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/huggingface/notebooks/blob/main/lerobot/training-act.ipynb) |
+
+100k 步的预期训练时间：在批量大小为 `64` 的 NVIDIA A100 GPU 上约 1.5 小时。
+
+### 训练 SmolVLA
+
+[SmolVLA](https://huggingface.co/papers/2506.01844) 是一种小型但高效的视觉-语言-动作模型。它由 Hugging Face 开发，参数量为 4.5 亿，体积紧凑。
+
+我们提供了一个可直接运行的 Google Colab Notebook，帮助你使用 Hugging Face Hub 上的数据集训练 SmolVLA 策略，并可选择记录到 Weights & Biases。
+
+| Notebook                                                                                                       | Colab                                                                                                                                                                                   |
+| :------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [使用 LeRobot 训练 SmolVLA](https://github.com/huggingface/notebooks/blob/main/lerobot/training-smolvla.ipynb) | [![在 Colab 中打开](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/huggingface/notebooks/blob/main/lerobot/training-smolvla.ipynb) |
+
+20k 步的预期训练时间：在批量大小为 `64` 的 NVIDIA A100 GPU 上约 5 小时。

--- a/docs/source/zh-hans/notebooks.mdx
+++ b/docs/source/zh-hans/notebooks.mdx
@@ -18,7 +18,7 @@
 
 ### 训练 SmolVLA
 
-[SmolVLA](https://huggingface.co/papers/2506.01844) 是一种小型但高效的视觉-语言-动作模型。它由 Hugging Face 开发，参数量为 4.5 亿，体积紧凑。
+[SmolVLA](https://huggingface.co/papers/2506.01844) 是一种小型但高效的视觉-语言-动作模型。它由 Hugging Face 开发，参数量为 4.5 亿，模型规模较为紧凑。
 
 我们提供了一个可直接运行的 Google Colab Notebook，帮助你使用 Hugging Face Hub 上的数据集训练 SmolVLA 策略，并可选择记录到 Weights & Biases。
 


### PR DESCRIPTION
## Summary / Motivation

Translate the LeRobot notebooks documentation page (`notebooks.mdx`) into Simplified Chinese (`zh-Hans`) as part of the Chinese documentation effort.

## Related issues

- Related: #3290

## What changed

- Added `docs/source/zh-hans/notebooks.mdx`.
- Preserved the English source page structure, headings, tables, and external links.
- Translated the ACT and SmolVLA notebook descriptions and expected training time notes.
- Did not modify navigation; the broader `zh-hans` `_toctree.yml` work is tracked separately in #3616.

## How was this tested (or how to run locally)

- Ran `npx --yes prettier@3.6.2 --check docs/source/zh-hans/notebooks.mdx`.
- Ran `doc-builder build` against a temporary minimal docs tree containing this translated `notebooks.mdx` and a minimal `_toctree.yml`; the build completed successfully.
- Compared line count with the English source: 29 / 29.
- Compared URL count with the English source: 8 / 8, with no missing or extra URLs.
- Compared table row count with the English source: 6 / 6.
- Compared heading count with the English source: 3 / 3.
- Ran `git diff --check`.
- Note: a full `doc-builder build lerobot docs/source/` is not representative for this standalone i18n file because the broader `zh-hans` navigation is not merged into `main` yet; #3616 tracks that `_toctree.yml` work.

## Checklist (required before merge)

- [ ] Linting/formatting run (`pre-commit run -a`)
- [ ] All tests pass locally (`pytest`)
- [x] Documentation updated
- [x] CI is green (all currently triggered checks are passing)
- [x] Community Review: I have reviewed another contributor's open PR and linked it here: #3929

## Reviewer notes

- AI assistance disclosure: AI assistance was used to draft and refine the translation. I reviewed the final diff for structure, links, terminology, formatting, and consistency with the English source before submitting.