### PR TITLE
docs: fix RTC policy links

### DIFF
--- a/docs/source/policy_rtc_README.md
+++ b/docs/source/policy_rtc_README.md
@@ -2,7 +2,7 @@
 
 This module contains the LeRobot implementation of **Real-Time Chunking (RTC)**, an inference-time technique for flow-matching based policies.
 
-**Note**: RTC is not a policy itself, but rather an inference enhancement that works with flow-matching based policies including [π₀](../pi0/), [π₀.₅](../pi05/), and [SmolVLA](../smolvla/).
+**Note**: RTC is not a policy itself, but rather an inference enhancement that works with flow-matching based policies including [π₀](./pi0), [π₀.₅](./pi05), and [SmolVLA](./smolvla).
 
 ---
 


### PR DESCRIPTION
## Summary / Motivation

Fix the RTC policy links so the README points to the existing policy documentation pages instead of non-existent sibling directories.

## Related issues

- Fixes / Closes: none
- Related: none

## What changed

- Updated the RTC note links for pi0, pi0.5, and SmolVLA to use the docs-page relative targets.

## How was this tested (or how to run locally)

- `git diff --check`
- Targeted local Markdown link check for `docs/source/policy_rtc_README.md`

## Checklist (required before merge)

- [ ] Linting/formatting run (`pre-commit run -a`)
- [ ] All tests pass locally (`pytest`)
- [x] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: # (insert PR number/link)

## Reviewer notes

Docs-only link fix; no runtime behavior changed.