### PR TITLE
feat(find-cameras): add --live tiled preview for camera placement

### DIFF
--- a/docs/source/cameras.mdx
+++ b/docs/source/cameras.mdx
@@ -40,6 +40,17 @@ Camera #0:
 (more cameras ...)
 ```
 
+To fine-tune a camera's physical placement (for example, rotating a wrist camera), add the `--live` flag to open a real-time tiled preview of every detected camera in a single window. This is handy when the default still-capture window does not give you enough time to adjust the hardware:
+
+```bash
+lerobot-find-cameras opencv --live
+```
+
+While the preview window is focused, press `q` or `ESC` to quit and `s` to save a snapshot of all current frames to the output directory.
+
+> [!WARNING]
+> `--live` requires an OpenCV build with GUI support. LeRobot ships `opencv-python-headless` by default, which has no display backend. If you see an error about GUI support, install the GUI build: `pip uninstall -y opencv-python-headless && pip install opencv-python`.
+
 > [!WARNING]
 > When using Intel RealSense cameras in `macOS`, you could get this [error](https://github.com/IntelRealSense/librealsense/issues/12307): `Error finding RealSense cameras: failed to set power state`, this can be solved by running the same command with `sudo` permissions. Note that using RealSense cameras in `macOS` is unstable.
 

--- a/src/lerobot/scripts/lerobot_find_cameras.py
+++ b/src/lerobot/scripts/lerobot_find_cameras.py
@@ -17,11 +17,15 @@
 """
 Helper to find the camera devices available in your system.
 
-Example:
+Examples:
 
 ```shell
 lerobot-find-cameras
+lerobot-find-cameras opencv --live   # live tiled preview; 'q'/ESC quit, 's' snapshot
 ```
+
+Note: --live requires an OpenCV build with GUI support (opencv-python, not
+opencv-python-headless).
 """
 
 # NOTE(Steven): RealSense can also be identified/opened as OpenCV cameras. If you know the camera is a RealSense, use the `lerobot-find-cameras realsense` flag to avoid confusion.
@@ -30,10 +34,12 @@ lerobot-find-cameras
 import argparse
 import concurrent.futures
 import logging
+import math
 import time
 from pathlib import Path
 from typing import Any
 
+import cv2
 import numpy as np
 from PIL import Image
 
@@ -225,6 +231,174 @@ def cleanup_cameras(cameras_to_use: list[dict[str, Any]]):
             logger.error(f"Error disconnecting camera {cam_dict['meta'].get('id')}: {e}")
 
 
+def _check_cv2_gui_available() -> None:
+    """Verify the installed OpenCV build has GUI (highgui) support.
+
+    The declared dependency is ``opencv-python-headless``, which lacks
+    ``imshow``/``namedWindow``/``waitKey``. Calling them raises ``cv2.error``.
+    This probes that capability up front so ``--live`` fails with an actionable
+    message instead of a cryptic traceback mid-loop.
+
+    Raises:
+        RuntimeError: If the OpenCV build has no GUI support.
+    """
+    probe = "__lerobot_gui_probe__"
+    try:
+        cv2.namedWindow(probe, cv2.WINDOW_NORMAL)
+        cv2.destroyWindow(probe)
+        cv2.waitKey(1)
+    except cv2.error as e:
+        raise RuntimeError(
+            "Live preview (--live) requires OpenCV GUI support, but the installed "
+            "build is headless (opencv-python-headless). Install the GUI build:\n"
+            "    pip uninstall -y opencv-python-headless\n"
+            "    pip install opencv-python\n"
+            f"(original error: {e})"
+        ) from e
+
+
+def build_camera_grid(
+    frames: list[np.ndarray | None],
+    labels: list[str],
+    tile_size: tuple[int, int] = (480, 640),
+) -> np.ndarray:
+    """Assemble per-camera BGR frames into a single tiled grid image.
+
+    Computes a near-square grid (``cols = ceil(sqrt(n))``, ``rows = ceil(n/cols)``),
+    resizes every frame to a uniform tile, overlays its label, and pads unused
+    cells with black tiles so the grid is a perfect rectangle.
+
+    Args:
+        frames: One entry per camera. ``None`` (failed read) becomes a black tile.
+        labels: Per-camera label text, same length and order as ``frames``.
+        tile_size: Target ``(height, width)`` of each tile.
+
+    Returns:
+        A single BGR ``uint8`` image of shape ``(rows * tile_h, cols * tile_w, 3)``.
+    """
+    tile_h, tile_w = tile_size
+    n = len(frames)
+    if n == 0:
+        return np.zeros((tile_h, tile_w, 3), dtype=np.uint8)
+
+    cols = math.ceil(math.sqrt(n))
+    rows = math.ceil(n / cols)
+
+    tiles: list[np.ndarray] = []
+    for i in range(rows * cols):
+        if i < n and frames[i] is not None:
+            tile = cv2.resize(frames[i], (tile_w, tile_h))
+            if tile.ndim == 2:  # grayscale safety
+                tile = cv2.cvtColor(tile, cv2.COLOR_GRAY2BGR)
+            tile = np.ascontiguousarray(tile)
+            label = labels[i]
+        else:
+            tile = np.zeros((tile_h, tile_w, 3), dtype=np.uint8)
+            label = f"{labels[i]} (no signal)" if i < n else ""
+
+        if label:
+            cv2.putText(
+                tile,
+                label,
+                (10, 30),
+                cv2.FONT_HERSHEY_SIMPLEX,
+                0.7,
+                (0, 255, 0),
+                2,
+                cv2.LINE_AA,
+            )
+        tiles.append(tile)
+
+    row_imgs = [np.hstack(tiles[r * cols : (r + 1) * cols]) for r in range(rows)]
+    return np.vstack(row_imgs)
+
+
+def _save_snapshot(frames: list[np.ndarray | None], labels: list[str], output_dir: Path) -> None:
+    """Save current live frames (BGR) as PNG files into ``output_dir``.
+
+    Frames are converted BGR->RGB before delegating to :func:`save_image`, which
+    expects RGB. Filenames match the timed-capture path (``<type>_<id>.png``) and
+    overwrite on repeated snapshots.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    for frame, label in zip(frames, labels, strict=False):
+        if frame is None:
+            continue
+        rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+        cam_type, _, cam_id = label.partition(" ")
+        save_image(rgb, cam_id, output_dir, cam_type)
+    logger.info(f"Snapshot saved to {output_dir}")
+
+
+def show_live_preview(
+    output_dir: Path,
+    camera_type: str | None = None,
+    tile_size: tuple[int, int] = (480, 640),
+):
+    """Open all matching cameras and show a live tiled preview in one window.
+
+    Keys: ``q``/``ESC`` quit; ``s`` saves a snapshot of all current frames to
+    ``output_dir``. Used instead of the timed capture when ``--live`` is passed.
+
+    Args:
+        output_dir: Directory snapshots are written to (created on demand).
+        camera_type: Optional filter ("opencv" / "realsense"); None uses all.
+        tile_size: Per-tile ``(height, width)`` for the grid.
+    """
+    _check_cv2_gui_available()
+
+    all_camera_metadata = find_and_print_cameras(camera_type_filter=camera_type)
+    if not all_camera_metadata:
+        logger.warning("No cameras detected matching the criteria. Cannot start live preview.")
+        return
+
+    cameras_to_use = []
+    for cam_meta in all_camera_metadata:
+        camera_instance = create_camera_instance(cam_meta)
+        if camera_instance:
+            cameras_to_use.append(camera_instance)
+
+    if not cameras_to_use:
+        logger.warning("No cameras could be connected. Aborting live preview.")
+        return
+
+    labels = [f"{c['meta'].get('type')} {c['meta'].get('id')}" for c in cameras_to_use]
+    last_good: list[np.ndarray | None] = [None] * len(cameras_to_use)
+
+    window = "lerobot-find-cameras (live)  |  q/ESC: quit   s: snapshot"
+    cv2.namedWindow(window, cv2.WINDOW_NORMAL)
+    logger.info("Live preview started. Press 'q' or ESC to quit, 's' to snapshot.")
+
+    try:
+        while True:
+            frames: list[np.ndarray | None] = []
+            for i, cam_dict in enumerate(cameras_to_use):
+                try:
+                    # Request BGR directly so frames are imshow-ready (no conversion).
+                    frame = cam_dict["instance"].read(color_mode=ColorMode.BGR)
+                    last_good[i] = frame
+                    frames.append(frame)
+                except Exception as e:
+                    logger.debug(f"Read failed for {labels[i]}: {e}")
+                    frames.append(last_good[i])  # last good frame, else None -> black tile
+
+            grid = build_camera_grid(frames, labels, tile_size=tile_size)
+            cv2.imshow(window, grid)
+
+            key = cv2.waitKey(1) & 0xFF
+            if key in (ord("q"), 27):  # q or ESC
+                break
+            if key == ord("s"):
+                _save_snapshot(frames, labels, output_dir)
+    except KeyboardInterrupt:
+        logger.info("Live preview interrupted by user.")
+    finally:
+        cv2.destroyAllWindows()
+        cv2.waitKey(1)  # flush window events on macOS/Qt
+        cleanup_cameras(cameras_to_use)
+        logger.info("Live preview finished.")
+
+
 def save_images_from_all_cameras(
     output_dir: Path,
     record_time_s: float = 2.0,
@@ -309,8 +483,27 @@ def main():
         default=6.0,
         help="Time duration to attempt capturing frames. Default: 6 seconds.",
     )
+    parser.add_argument(
+        "--live",
+        action="store_true",
+        help="Show a live tiled preview of all matching cameras instead of capturing for "
+        "--record-time-s. Press 'q'/ESC to quit, 's' to snapshot. Requires an OpenCV GUI "
+        "build (opencv-python, not opencv-python-headless).",
+    )
     args = parser.parse_args()
-    save_images_from_all_cameras(**vars(args))
+
+    if args.live:
+        try:
+            show_live_preview(output_dir=args.output_dir, camera_type=args.camera_type)
+        except RuntimeError as e:
+            logger.error(str(e))
+            raise SystemExit(1) from e
+    else:
+        save_images_from_all_cameras(
+            output_dir=args.output_dir,
+            record_time_s=args.record_time_s,
+            camera_type=args.camera_type,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/scripts/test_find_cameras_grid.py
+++ b/tests/scripts/test_find_cameras_grid.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+
+import numpy as np
+import pytest
+
+from lerobot.scripts.lerobot_find_cameras import (
+    _check_cv2_gui_available,
+    build_camera_grid,
+)
+
+
+def _frame(h: int, w: int, value: int = 128) -> np.ndarray:
+    return np.full((h, w, 3), value, dtype=np.uint8)
+
+
+def _expected_grid(n: int) -> tuple[int, int]:
+    cols = math.ceil(math.sqrt(n))
+    rows = math.ceil(n / cols)
+    return rows, cols
+
+
+@pytest.mark.parametrize("n", [1, 2, 3, 4, 5, 6, 9])
+def test_grid_shape_matches_layout_formula(n):
+    tile_h, tile_w = 480, 640
+    frames = [_frame(120, 160) for _ in range(n)]
+    labels = [f"OpenCV {i}" for i in range(n)]
+
+    grid = build_camera_grid(frames, labels, tile_size=(tile_h, tile_w))
+
+    rows, cols = _expected_grid(n)
+    assert grid.shape == (rows * tile_h, cols * tile_w, 3)
+    assert grid.dtype == np.uint8
+
+
+def test_non_uniform_input_sizes_are_resized():
+    tile_h, tile_w = 240, 320
+    frames = [_frame(120, 160), _frame(1080, 1920)]
+    labels = ["OpenCV 0", "RealSense 1"]
+
+    grid = build_camera_grid(frames, labels, tile_size=(tile_h, tile_w))
+
+    rows, cols = _expected_grid(2)
+    assert grid.shape == (rows * tile_h, cols * tile_w, 3)
+
+
+def test_none_frame_becomes_black_tile():
+    tile_h, tile_w = 200, 200
+    frames = [None, _frame(100, 100, value=255)]
+    labels = ["OpenCV 0", "OpenCV 1"]
+
+    grid = build_camera_grid(frames, labels, tile_size=(tile_h, tile_w))
+
+    # First tile (top-left) corresponds to the None frame: its corner stays black
+    # (the label is drawn near (10, 30), so sample an untouched corner pixel).
+    assert grid[tile_h - 1, 0].tolist() == [0, 0, 0]
+
+
+def test_padding_cell_is_black_when_not_a_perfect_rectangle():
+    tile_h, tile_w = 100, 100
+    frames = [_frame(50, 50, value=200) for _ in range(3)]
+    labels = [f"OpenCV {i}" for i in range(3)]
+
+    grid = build_camera_grid(frames, labels, tile_size=(tile_h, tile_w))
+
+    rows, cols = _expected_grid(3)  # 2x2
+    assert (rows, cols) == (2, 2)
+    # The 4th cell (bottom-right) is padding -> fully black.
+    bottom_right = grid[tile_h:, tile_w:]
+    assert not bottom_right.any()
+
+
+def test_empty_list_returns_single_black_tile():
+    tile_h, tile_w = 480, 640
+    grid = build_camera_grid([], [], tile_size=(tile_h, tile_w))
+    assert grid.shape == (tile_h, tile_w, 3)
+    assert grid.dtype == np.uint8
+    assert not grid.any()
+
+
+def test_check_cv2_gui_available_raises_on_headless(monkeypatch):
+    import cv2
+
+    def _raise(*args, **kwargs):
+        raise cv2.error("The function is not implemented. Rebuild the library with GUI support.")
+
+    monkeypatch.setattr(cv2, "namedWindow", _raise)
+
+    with pytest.raises(RuntimeError, match="opencv-python"):
+        _check_cv2_gui_available()


### PR DESCRIPTION
## What & why

`lerobot-find-cameras` captures a few still frames and then exits. That window is too short to fine-tune a camera's **physical placement** (e.g. rotating a wrist camera), and it forces you to re-run the command repeatedly to see updated stills.

This adds a `--live` flag that opens a **single real-time window** tiling every detected camera in a near-square grid, so all feeds are visible at once and stay open while you adjust the hardware.

```bash
lerobot-find-cameras opencv --live   # q/ESC quit, s snapshot
```

## Changes

- **`build_camera_grid()`** — pure, unit-tested grid assembler: uniform tiles, per-camera labels, black tiles for failed reads and padding cells (`cols = ceil(sqrt(n))`).
- **`show_live_preview()`** — opens all matching cameras, reads BGR frames imshow-ready, reuses the last good frame on transient read failures; `q`/ESC quits, `s` snapshots all current frames to the output dir.
- **`_check_cv2_gui_available()`** — probes OpenCV highgui up front so a headless build (`opencv-python-headless`, the declared dep) fails with an actionable install hint instead of a cryptic mid-loop traceback.
- Docs (`cameras.mdx`) + tests for grid layout and the headless guard.

## Testing

- `tests/scripts/test_find_cameras_grid.py` — 12 passed (grid shapes, resize, None/black tiles, padding, headless guard).
- `pre-commit` on all changed files — ruff, mypy, typos, prettier, bandit all pass.

The `--live` interactive loop itself needs camera hardware + a GUI OpenCV build, so it is exercised manually; the pure/guard logic is covered by unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)