### PR TITLE
feat(teleop): add Isaac Teleop reBot DevArm leader arm (Damiao)

### DIFF
--- a/docs/source/isaac_teleop.mdx
+++ b/docs/source/isaac_teleop.mdx
@@ -306,6 +306,36 @@ The URDF fetch uses `huggingface_hub` (already a LeRobot dependency) against the
 `lerobot/robot-urdfs` bucket, so it needs no login. It is cached under
 `HF_LEROBOT_HOME/robot-urdfs/so101/`; delete that folder to force a re‑download.
 
+### reBot DevArm leader (Damiao)
+
+The third device, `RebotDevArmLeaderArm` (`rebot_devarm_leader` in the Isaac device registry),
+does the same 1:1 joint mirror for the Seeed Studio reBot DevArm (B601-DM: 6-DOF + gripper,
+seven Damiao CAN motors) onto LeRobot's `rebot_b601_follower` — the identical arm hardware, so
+every joint including the gripper is a plain rad→deg mirror with **no** gripper normalization
+(the follower's soft `joint_limits` clip out-of-range targets). Isaac Teleop's native
+`rebot_devarm_leader` plugin owns the Damiao USB-to-CAN serial bus: it torque-disables the
+motors (Damiao motors keep answering feedback requests while disabled, which is what makes the
+leader back-drivable) and streams the decoded joint angles in radians.
+
+Like `so101_leader_plugin`, the `rebot_devarm_leader_plugin` binary is built from the Isaac
+Teleop source tree and lands at `install/plugins/rebot_devarm_leader/rebot_devarm_leader_plugin`.
+Start it separately (or with an empty device path for its synthetic, hardware-free trajectory),
+then create the teleoperator:
+
+```python
+from lerobot.teleoperators.isaac_teleop import RebotDevArmLeaderArm, RebotDevArmLeaderArmConfig
+
+teleop = RebotDevArmLeaderArm(RebotDevArmLeaderArmConfig(device="/dev/ttyACM0"))
+teleop.connect()
+action = teleop.get_action()  # {"shoulder_pan.pos": ..., ..., "gripper.pos": ...} [deg]
+```
+
+`config.joint_name_map` renames the plugin's URDF joint names (`joint1..joint6, gripper`) to the
+follower motor names and can be overridden for a differently-named follower. Before trusting the
+wiring, run the plugin's `probe` subcommand (`rebot_devarm_leader_plugin probe /dev/ttyACM0`) —
+it verifies the bus, motor ids, and decode path with no OpenXR runtime and exits 0 when all
+seven motors reply.
+
 Then, in your headset: squeeze and hold the grip to engage, move the controller to drive the
 arm, twist/tilt it to orient the wrist, and press the trigger to close the gripper
 (proportionally — release to open).

--- a/src/lerobot/teleoperators/isaac_teleop/__init__.py
+++ b/src/lerobot/teleoperators/isaac_teleop/__init__.py
@@ -17,12 +17,22 @@
 """NVIDIA Isaac Teleop teleoperators for LeRobot.
 
 Each input device is an :class:`IsaacTeleopTeleoperator` subclass: :class:`XRController`
-(XR/VR controller) and :class:`SO101LeaderArm` (back-drivable SO-101 leader arm) ship today.
+(XR/VR controller), :class:`SO101LeaderArm` (back-drivable SO-101 leader arm), and
+:class:`RebotDevArmLeaderArm` (back-drivable Seeed reBot DevArm leader) ship today.
 """
 
 from .base import IsaacTeleopTeleoperator
 from .clutch import Clutch
-from .config_isaac_teleop import IsaacTeleopConfig, SO101LeaderArmConfig, XRControllerConfig
+from .config_isaac_teleop import (
+    IsaacTeleopConfig,
+    RebotDevArmLeaderArmConfig,
+    SO101LeaderArmConfig,
+    XRControllerConfig,
+)
+from .teleop_rebot_devarm_leader_arm import (
+    RebotDevArmLeaderArm,
+    rebot_leader_joints_to_robot_action,
+)
 from .teleop_so101_leader_arm import SO101LeaderArm, leader_joints_to_robot_action
 from .teleop_xr_controller import XRController
 from .xr_controller_processor import MapXRControllerActionToRobotAction
@@ -32,9 +42,12 @@ __all__ = [
     "IsaacTeleopConfig",
     "IsaacTeleopTeleoperator",
     "MapXRControllerActionToRobotAction",
+    "RebotDevArmLeaderArm",
+    "RebotDevArmLeaderArmConfig",
     "SO101LeaderArm",
     "SO101LeaderArmConfig",
     "XRController",
     "XRControllerConfig",
     "leader_joints_to_robot_action",
+    "rebot_leader_joints_to_robot_action",
 ]

--- a/src/lerobot/teleoperators/isaac_teleop/config_isaac_teleop.py
+++ b/src/lerobot/teleoperators/isaac_teleop/config_isaac_teleop.py
@@ -125,3 +125,46 @@ class SO101LeaderArmConfig(IsaacTeleopConfig):
     gripper_close_rad: float = _DEFAULT_GRIPPER_CLOSE_RAD
     """Leader gripper angle [rad] at fully CLOSED -> follower jaw 0. Provisional default;
     set from the plugin's ``calibrate`` subcommand. See ``_DEFAULT_GRIPPER_CLOSE_RAD``."""
+
+
+# Stream (URDF) joint names -> rebot_b601_follower motor names, in stream order. The plugin
+# streams the ``reBot-DevArm_fixend`` URDF names; the follower names its seven Damiao motors
+# functionally. Same physical joints, so the mapping is a pure rename.
+_DEFAULT_REBOT_JOINT_NAME_MAP: dict[str, str] = {
+    "joint1": "shoulder_pan",
+    "joint2": "shoulder_lift",
+    "joint3": "elbow_flex",
+    "joint4": "wrist_flex",
+    "joint5": "wrist_yaw",
+    "joint6": "wrist_roll",
+    "gripper": "gripper",
+}
+
+
+@IsaacTeleopConfig.register_subclass("rebot_devarm_leader")
+@dataclass(kw_only=True)
+class RebotDevArmLeaderArmConfig(IsaacTeleopConfig):
+    """Config for an Isaac Teleop reBot DevArm *leader arm* (generic joint-space device).
+
+    Mirrors the leader's joint angles 1:1 onto a follower reBot B601-DM (LeRobot's
+    ``rebot_b601_follower``) — the same 6-DOF + gripper Damiao hardware, so no IK, clutch,
+    retargeter, or gripper normalization is needed. The leader state is streamed in radians
+    by the native ``rebot_devarm_leader`` plugin (which torque-disables the motors so the
+    arm is back-drivable) and read via a ``JointStateSource``; the device converts all
+    joints to degrees and renames them via :attr:`joint_name_map`.
+    """
+
+    device: str = ""
+    """Serial device of the physical LEADER arm's Damiao USB-to-CAN adapter (e.g.
+    ``/dev/ttyACM0``), forwarded to the plugin (which owns the bus) when the example
+    launches it. Empty -> the plugin runs its synthetic trajectory."""
+
+    collection_id: str = "rebot_devarm_leader"
+    """Tensor collection id the leader plugin pushes on; must match the running
+    ``rebot_devarm_leader`` plugin (its second positional arg, default
+    ``"rebot_devarm_leader"``)."""
+
+    joint_name_map: dict[str, str] = field(default_factory=lambda: dict(_DEFAULT_REBOT_JOINT_NAME_MAP))
+    """Stream (URDF) joint name -> follower motor name. Defaults to the
+    ``rebot_b601_follower`` motor names; override to drive a follower with a different
+    naming scheme. Stream joints absent from the map are dropped from the action."""

--- a/src/lerobot/teleoperators/isaac_teleop/teleop_rebot_devarm_leader_arm.py
+++ b/src/lerobot/teleoperators/isaac_teleop/teleop_rebot_devarm_leader_arm.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python
+
+# Copyright 2026 NVIDIA Corporation and The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""reBot DevArm leader-arm device for NVIDIA Isaac Teleop, exposed to LeRobot.
+
+The leader is a back-drivable Seeed Studio reBot DevArm (B601-DM: 6-DOF + gripper, seven
+Damiao CAN motors) whose joint angles are streamed in radians by Isaac Teleop's native
+``rebot_devarm_leader`` plugin; this device reads them via a ``JointStateSource`` and
+converts them into follower-ready ``{joint}.pos``.
+
+The natural follower is LeRobot's ``rebot_b601_follower`` — the SAME arm hardware — so the
+mirror is 1:1 in joint space: every streamed angle (gripper included) is converted
+``rad2deg`` and renamed from the plugin's URDF joint names (``joint1..joint6, gripper``) to
+the follower's motor names via :attr:`RebotDevArmLeaderArmConfig.joint_name_map`. The
+follower's own soft ``joint_limits`` clip out-of-range targets, so no extra normalization
+is applied here.
+
+``isaacteleop`` imports are deferred so this module — and the pure
+:func:`rebot_leader_joints_to_robot_action` converter — import without it.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from lerobot.types import RobotAction
+
+from .base import IsaacTeleopTeleoperator
+from .config_isaac_teleop import RebotDevArmLeaderArmConfig
+from .teleop_so101_leader_arm import _joints_group_to_rad
+
+# Canonical reBot DevArm DOF names and order — matches the ``rebot_devarm_leader`` plugin
+# stream (the ``reBot-DevArm_fixend`` URDF order: six arm joints then the gripper motor).
+# Passed to the ``JointStateSource`` as its output layout; the source maps by name and
+# ``_joints_group_to_rad`` reads back by name, so a layout mismatch can't mislabel a DOF.
+REBOT_DEVARM_LEADER_JOINTS = [
+    "joint1",
+    "joint2",
+    "joint3",
+    "joint4",
+    "joint5",
+    "joint6",
+    "gripper",
+]
+
+
+def rebot_leader_joints_to_robot_action(
+    joints_rad: dict[str, float],
+    *,
+    joint_name_map: dict[str, str],
+) -> RobotAction:
+    """Convert streamed leader joint angles [rad] to follower-ready ``{joint}.pos`` [deg].
+
+    Pure (no ``isaacteleop``, no I/O). Every mapped joint — gripper included — is converted
+    ``rad2deg`` and renamed through ``joint_name_map`` (stream name -> follower motor name);
+    leader and follower are the same B601-DM hardware, so a 1:1 angle mirror is exact and
+    the follower's soft joint limits handle clipping. Iteration follows ``joints_rad``
+    insertion order, so pass it in :data:`REBOT_DEVARM_LEADER_JOINTS` order for a stable
+    layout. Stream joints absent from the map are dropped (not guessed at).
+    """
+    action: RobotAction = {}
+    for name, rad in joints_rad.items():
+        target = joint_name_map.get(name)
+        if target is None:
+            continue
+        action[f"{target}.pos"] = float(np.rad2deg(rad))
+    return action
+
+
+class RebotDevArmLeaderArm(IsaacTeleopTeleoperator):
+    """reBot DevArm leader-arm teleoperator (joint-space), direct joint mirror.
+
+    Reads the seven joint angles off a single ``JointStateSource`` each frame; no
+    retargeter, no clutch (shared kinematics with the ``rebot_b601_follower``). When the
+    leader is not streaming, :meth:`get_action` returns the held-last joints and
+    :attr:`is_tracking` is ``False`` so the owning loop can hold the follower.
+    """
+
+    config_class = RebotDevArmLeaderArmConfig
+    name = "isaac_teleop_rebot_devarm_leader"
+
+    def __init__(self, config: RebotDevArmLeaderArmConfig):
+        super().__init__(config)
+        self.config: RebotDevArmLeaderArmConfig = config
+        # Held-last joint angles [rad], seeded at zero (URDF/vendor zero pose) so the first
+        # frames before the plugin starts pushing read as the zero pose, not garbage.
+        self._last_joints_rad: dict[str, float] = dict.fromkeys(REBOT_DEVARM_LEADER_JOINTS, 0.0)
+        # Whether the most recent get_action() read live leader data (vs held-last).
+        self._is_tracking = False
+
+    # ------------------------------------------------------------------
+    # Pipeline construction
+    # ------------------------------------------------------------------
+
+    def _build_pipeline(self):
+        """Build the joint-mirror pipeline: a single ``JointStateSource`` leaf that converts
+        the raw stream into a name-keyed joint group. No retargeter (shared kinematics)."""
+        from isaacteleop.retargeting_engine.deviceio_source_nodes import JointStateSource
+        from isaacteleop.retargeting_engine.interface import OutputCombiner
+
+        source = JointStateSource(
+            name="rebot_devarm_leader",
+            collection_id=self.config.collection_id,
+            joint_names=REBOT_DEVARM_LEADER_JOINTS,
+        )
+        return OutputCombiner({"joints": source.output(JointStateSource.JOINTS)})
+
+    # ------------------------------------------------------------------
+    # Action features
+    # ------------------------------------------------------------------
+
+    @property
+    def action_features(self) -> dict[str, type]:
+        # Matches the rebot_b601_follower's action features so this is a drop-in
+        # joint-space leader: one float `{joint}.pos` per DOF, in the follower's units.
+        return {f"{target}.pos": float for target in self.config.joint_name_map.values()}
+
+    @property
+    def feedback_features(self) -> dict[str, type]:
+        return {}
+
+    @property
+    def is_tracking(self) -> bool:
+        """Whether the last :meth:`get_action` read live leader data (vs held-last)."""
+        return self._is_tracking
+
+    # ------------------------------------------------------------------
+    # Action extraction
+    # ------------------------------------------------------------------
+
+    def get_action(self) -> RobotAction:
+        """Step the session and return the leader joints as follower-ready ``{joint}.pos``.
+
+        When the leader is streaming, the live angles are cached and converted; otherwise
+        the held-last angles are reused and :attr:`is_tracking` is set ``False``.
+        """
+        result = self._step(execution_events=self._running_events())
+
+        joints = result["joints"]
+        # The JointStateSource output is Optional: absent (is_none) when the device is
+        # inactive. Treat that as "not tracking" and reuse the held-last angles.
+        self._is_tracking = not getattr(joints, "is_none", False)
+        if self._is_tracking:
+            try:
+                self._last_joints_rad = _joints_group_to_rad(joints)
+            except (AttributeError, IndexError, KeyError, TypeError, ValueError):
+                # A partially-populated / malformed group on an odd frame: keep held-last,
+                # but report not-tracking so the loop holds the follower rather than trust it.
+                self._is_tracking = False
+
+        return rebot_leader_joints_to_robot_action(
+            self._last_joints_rad,
+            joint_name_map=self.config.joint_name_map,
+        )

--- a/tests/teleoperators/test_rebot_devarm_leader_arm.py
+++ b/tests/teleoperators/test_rebot_devarm_leader_arm.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python
+
+# Copyright 2026 NVIDIA Corporation and The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pure unit tests for the Isaac Teleop reBot DevArm leader-arm unit conversion.
+
+These tests deliberately do NOT import ``isaacteleop`` --
+:func:`rebot_leader_joints_to_robot_action` is the pure-math bridge from the leader's
+streamed joint angles [rad] to the follower's native ``{joint}.pos`` degrees, and must be
+testable without the XR runtime (mirroring ``test_so101_leader_arm.py``).
+"""
+
+import numpy as np
+import pytest
+
+from lerobot.teleoperators.isaac_teleop.config_isaac_teleop import RebotDevArmLeaderArmConfig
+from lerobot.teleoperators.isaac_teleop.teleop_rebot_devarm_leader_arm import (
+    REBOT_DEVARM_LEADER_JOINTS,
+    rebot_leader_joints_to_robot_action,
+)
+
+# The default stream-name -> follower-motor-name map (rebot_b601_follower naming).
+_NAME_MAP = RebotDevArmLeaderArmConfig().joint_name_map
+
+
+def _convert(joints_rad, name_map=None):
+    return rebot_leader_joints_to_robot_action(
+        joints_rad, joint_name_map=_NAME_MAP if name_map is None else name_map
+    )
+
+
+def _all_zero_joints():
+    return dict.fromkeys(REBOT_DEVARM_LEADER_JOINTS, 0.0)
+
+
+# ----------------------------------------------------------------------------
+# All joints (gripper included): rad -> deg, 1:1 mirror
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("rad", "expected_deg"),
+    [(0.0, 0.0), (np.pi, 180.0), (-np.pi / 2, -90.0), (np.pi / 4, 45.0)],
+)
+def test_joint_rad2deg(rad, expected_deg):
+    out = _convert({**_all_zero_joints(), "joint1": float(rad)})
+    assert out["shoulder_pan.pos"] == pytest.approx(expected_deg)
+
+
+def test_all_joints_converted_to_degrees_including_gripper():
+    # Leader and follower are the same hardware: EVERY DOF (gripper too) is a plain
+    # rad2deg mirror, unlike the SO-101 device which normalizes its gripper.
+    joints = dict.fromkeys(REBOT_DEVARM_LEADER_JOINTS, np.pi)
+    out = _convert(joints)
+    assert len(out) == len(REBOT_DEVARM_LEADER_JOINTS)
+    for value in out.values():
+        assert value == pytest.approx(180.0)
+
+
+def test_emits_follower_motor_names_in_stream_order():
+    out = _convert(_all_zero_joints())
+    assert list(out.keys()) == [f"{_NAME_MAP[name]}.pos" for name in REBOT_DEVARM_LEADER_JOINTS]
+
+
+def test_default_map_targets_rebot_b601_follower_motors():
+    # The default action layout must be follower-ready for rebot_b601_follower.
+    out = _convert(_all_zero_joints())
+    assert set(out.keys()) == {
+        "shoulder_pan.pos",
+        "shoulder_lift.pos",
+        "elbow_flex.pos",
+        "wrist_flex.pos",
+        "wrist_yaw.pos",
+        "wrist_roll.pos",
+        "gripper.pos",
+    }
+
+
+def test_gripper_multi_turn_angle_passes_through_unclipped():
+    # The B601 gripper is multi-turn (several rad of travel); the leader mirrors the raw
+    # angle and leaves clipping to the follower's soft joint_limits.
+    out = _convert({**_all_zero_joints(), "gripper": -6.8})
+    assert out["gripper.pos"] == pytest.approx(float(np.rad2deg(-6.8)))
+
+
+# ----------------------------------------------------------------------------
+# joint_name_map behavior
+# ----------------------------------------------------------------------------
+
+
+def test_unmapped_stream_joints_are_dropped():
+    # A stream joint absent from the map is dropped, not guessed at.
+    partial_map = {"joint1": "shoulder_pan"}
+    out = _convert(_all_zero_joints(), name_map=partial_map)
+    assert list(out.keys()) == ["shoulder_pan.pos"]
+
+
+def test_custom_name_map_renames_targets():
+    custom = {name: f"motor_{i}" for i, name in enumerate(REBOT_DEVARM_LEADER_JOINTS)}
+    out = _convert(_all_zero_joints(), name_map=custom)
+    assert list(out.keys()) == [f"motor_{i}.pos" for i in range(len(REBOT_DEVARM_LEADER_JOINTS))]
+
+
+# ----------------------------------------------------------------------------
+# Config
+# ----------------------------------------------------------------------------
+
+
+def test_config_defaults_register_and_round_trip():
+    cfg = RebotDevArmLeaderArmConfig()
+    assert cfg.type == "rebot_devarm_leader"
+    assert cfg.collection_id == "rebot_devarm_leader"
+    assert cfg.device == ""
+    # The default map covers the full stream, one target per stream joint (no fan-in).
+    assert set(cfg.joint_name_map.keys()) == set(REBOT_DEVARM_LEADER_JOINTS)
+    assert len(set(cfg.joint_name_map.values())) == len(REBOT_DEVARM_LEADER_JOINTS)
+
+
+def test_config_joint_name_map_is_not_shared_between_instances():
+    # default_factory must give each config its own dict (no mutable default aliasing).
+    a = RebotDevArmLeaderArmConfig()
+    b = RebotDevArmLeaderArmConfig()
+    a.joint_name_map["joint1"] = "mutated"
+    assert b.joint_name_map["joint1"] == "shoulder_pan"


### PR DESCRIPTION
Stacked on #3927 (targets its `feat/isaac-teleop` branch).

## Summary / Motivation

#3927 ships two Isaac Teleop input devices: `xr_controller` and the `so101_leader` arm. This PR adds the third one on the same generic joint-space device path: a **reBot DevArm leader arm** (`rebot_devarm_leader`) for the Seeed Studio reBot DevArm / B601-DM (6-DOF + gripper, seven Damiao CAN motors), whose joint angles are streamed by Isaac Teleop's native `rebot_devarm_leader` plugin (NVIDIA/IsaacTeleop#729, Damiao dm-serial backend).

The natural follower is LeRobot's existing `rebot_b601_follower` — the *same* arm hardware — so the mirror is exactly 1:1 in joint space: every streamed angle (multi-turn gripper included) is converted rad→deg and renamed from the plugin's URDF joint names (`joint1..joint6, gripper`) to the follower's motor names. No IK, no clutch, no gripper normalization; the follower's own soft `joint_limits` clip out-of-range targets.

## Related issues / PRs

- Stacked on: #3927
- Plugin side: NVIDIA/IsaacTeleop#729

## What changed

- `src/lerobot/teleoperators/isaac_teleop/teleop_rebot_devarm_leader_arm.py` — `RebotDevArmLeaderArm` (mirrors `SO101LeaderArm`'s structure: single `JointStateSource` pipeline, held-last + `is_tracking` semantics, malformed-frame guard) and the pure converter `rebot_leader_joints_to_robot_action` (importable and testable without `isaacteleop`).
- `config_isaac_teleop.py` — `RebotDevArmLeaderArmConfig`, registered as `rebot_devarm_leader` in the Isaac device registry: `device` (Damiao USB-to-CAN serial path; empty selects the plugin's synthetic backend), `collection_id`, and `joint_name_map` (stream URDF names → `rebot_b601_follower` motor names, overridable for differently-named followers).
- `__init__.py` — exports.
- `tests/teleoperators/test_rebot_devarm_leader_arm.py` — pure-math tests (no `isaacteleop` import, mirroring `test_so101_leader_arm.py`): rad→deg for all DOFs, follower-ready layout/order, multi-turn gripper pass-through, name-map drop/rename semantics, config registration, no mutable-default aliasing.
- `docs/source/isaac_teleop.mdx` — new "reBot DevArm leader (Damiao)" section (plugin build/probe, usage snippet, name-map note).

No new dependencies: reuses the `isaac-teleop` extra from #3927; the Damiao bus lives entirely in the C++ plugin.

## How was this tested (or how to run locally)

- `pytest tests/teleoperators/test_rebot_devarm_leader_arm.py` — 12 passed (plus the existing `test_so101_leader_arm.py` still green).
- Live end-to-end against the real plugin (CloudXR auto-launch through `IsaacTeleopTeleoperator.connect()`):
  - synthetic backend: 8/8 tracked frames, follower-ready action layout, values varying over time, clean disconnect;
  - physical reBot Arm B601-DM on `/dev/ttyACM0` (plugin `probe` exit 0, all seven Damiao motors replying): 6/6 tracked frames matching the arm's measured rest pose (e.g. `wrist_roll.pos=+18.02°` == 0.3145 rad from the plugin probe).
- `pre-commit run` on all touched files — clean.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated
- [ ] CI is green
- [ ] Community Review

## Reviewer notes

- The deliberate difference vs `SO101LeaderArm`: no gripper open/close normalization. The SO-101 leader normalizes its gripper into RANGE_0_100 because leader and follower calibrations differ; here leader and follower are the same B601-DM hardware, so the raw angle mirror is exact and simpler.
- `joint_name_map` (rather than hardcoded follower names) keeps the device usable with a differently-named or partial follower; unmapped stream joints are dropped, not guessed at.
