### PR TITLE
docs: document dataset task modification command

### DIFF
--- a/docs/source/using_dataset_tools.mdx
+++ b/docs/source/using_dataset_tools.mdx
@@ -11,16 +11,17 @@ LeRobot provides several utilities for manipulating datasets:
 3. **Merge Datasets** - Combine multiple datasets into one. The datasets must have identical features, and episodes are concatenated in the order specified in `repo_ids`
 4. **Add Features** - Add new features to a dataset
 5. **Remove Features** - Remove features from a dataset
-6. **Convert to Video** - Convert image-based datasets to video format for efficient storage (RGB and depth cameras are encoded with separate encoders)
-7. **Re-encode Videos** - Re-encode an existing video dataset's RGB and/or depth streams with new encoder settings
-8. **Show the Info of Datasets** - Show the summary of datasets information such as number of episode etc.
+6. **Modify Tasks** - Update the task description for all episodes or specific episodes
+7. **Convert to Video** - Convert image-based datasets to video format for efficient storage (RGB and depth cameras are encoded with separate encoders)
+8. **Re-encode Videos** - Re-encode an existing video dataset's RGB and/or depth streams with new encoder settings
+9. **Show the Info of Datasets** - Show the summary of datasets information such as number of episode etc.
 
 The core implementation is in `lerobot.datasets.dataset_tools`.
 An example script detailing how to use the tools API is available in `examples/dataset/use_dataset_tools.py`.
 
 ## Command-Line Tool: lerobot-edit-dataset
 
-`lerobot-edit-dataset` is a command-line script for editing datasets. It can be used to delete episodes, split datasets, merge datasets, add features, remove features, and convert image datasets to video format.
+`lerobot-edit-dataset` is a command-line script for editing datasets. It can be used to delete episodes, split datasets, merge datasets, add features, remove features, modify tasks, and convert image datasets to video format.
 
 Run `lerobot-edit-dataset --help` for more information on the configuration of each operation.
 
@@ -88,6 +89,27 @@ lerobot-edit-dataset \
     --operation.type remove_feature \
     --operation.feature_names "['observation.images.top']"
 ```
+
+#### Modify Tasks
+
+Update the task description stored for existing episodes. This operation modifies the dataset in place.
+
+```bash
+# Set one task description for all episodes
+lerobot-edit-dataset \
+    --repo_id lerobot/pusht \
+    --operation.type modify_tasks \
+    --operation.new_task "Pick up the cube and place it"
+
+# Set task descriptions for specific episodes
+lerobot-edit-dataset \
+    --repo_id lerobot/pusht \
+    --operation.type modify_tasks \
+    --operation.episode_tasks '{"0": "Pick up the cube", "1": "Place the cube"}'
+```
+
+> [!WARNING]
+> `modify_tasks` overwrites the original dataset metadata in place. `--new_repo_id` and `--new_root` are ignored for this operation.
 
 #### Convert to Video
 


### PR DESCRIPTION
﻿Summary:
- Document the existing `modify_tasks` dataset edit operation in the dataset tools guide.
- Add examples for setting one task for all episodes and setting tasks for specific episodes.
- Note that `modify_tasks` updates dataset metadata in place.

Why:
- `lerobot-edit-dataset` already supports modifying tasks, but the user-facing dataset tools guide did not mention it.
- This gives users a documented path for updating task descriptions after recording episodes.

Validation:
- [x] `git diff --check`
- [x] `rg -n 'register_subclass\("modify_tasks"\)|class ModifyTasksConfig|def handle_modify_tasks|def modify_tasks' src\lerobot\scripts\lerobot_edit_dataset.py src\lerobot\datasets\dataset_tools.py`

Notes for reviewers:
- Docs-only change; no runtime code, dependency, or lockfile changes.
- Related to #2096.
