### PR TITLE
fix(calibration): detect inverted gripper drive_mode on SO follower/leader calibration

### DIFF
--- a/src/lerobot/robots/so_follower/so_follower.py
+++ b/src/lerobot/robots/so_follower/so_follower.py
@@ -142,11 +142,22 @@ class SOFollower(Robot):
         range_mins[full_turn_motor] = 0
         range_maxes[full_turn_motor] = 4095
 
+        drive_modes = dict.fromkeys(self.bus.motors, 0)
+        input(f"Fully close the gripper of {self} and press ENTER....")
+        gripper_closed_pos = self.bus.read("Present_Position", "gripper", normalize=False)
+        if abs(gripper_closed_pos - range_maxes["gripper"]) < abs(gripper_closed_pos - range_mins["gripper"]):
+            # The closed position is at the top of the recorded range, meaning the raw position increases
+            # when the gripper closes. This is inverted with respect to the expected convention
+            # (0 = closed, 100 = open), which happens when the gripper motor is mounted mirrored.
+            # Invert it in software via drive_mode so both arms share the same convention.
+            logger.info("Gripper motor is inverted, setting drive_mode=1 to compensate.")
+            drive_modes["gripper"] = 1
+
         self.calibration = {}
         for motor, m in self.bus.motors.items():
             self.calibration[motor] = MotorCalibration(
                 id=m.id,
-                drive_mode=0,
+                drive_mode=drive_modes[motor],
                 homing_offset=homing_offsets[motor],
                 range_min=range_mins[motor],
                 range_max=range_maxes[motor],

--- a/src/lerobot/teleoperators/so_leader/so_leader.py
+++ b/src/lerobot/teleoperators/so_leader/so_leader.py
@@ -110,11 +110,22 @@ class SOLeader(Teleoperator):
         range_mins[full_turn_motor] = 0
         range_maxes[full_turn_motor] = 4095
 
+        drive_modes = dict.fromkeys(self.bus.motors, 0)
+        input(f"Fully close the gripper of {self} and press ENTER....")
+        gripper_closed_pos = self.bus.read("Present_Position", "gripper", normalize=False)
+        if abs(gripper_closed_pos - range_maxes["gripper"]) < abs(gripper_closed_pos - range_mins["gripper"]):
+            # The closed position is at the top of the recorded range, meaning the raw position increases
+            # when the gripper closes. This is inverted with respect to the expected convention
+            # (0 = closed, 100 = open), which happens when the gripper motor is mounted mirrored.
+            # Invert it in software via drive_mode so both arms share the same convention.
+            logger.info("Gripper motor is inverted, setting drive_mode=1 to compensate.")
+            drive_modes["gripper"] = 1
+
         self.calibration = {}
         for motor, m in self.bus.motors.items():
             self.calibration[motor] = MotorCalibration(
                 id=m.id,
-                drive_mode=0,
+                drive_mode=drive_modes[motor],
                 homing_offset=homing_offsets[motor],
                 range_min=range_mins[motor],
                 range_max=range_maxes[motor],

--- a/tests/robots/test_so100_follower.py
+++ b/tests/robots/test_so100_follower.py
@@ -109,3 +109,38 @@ def test_send_action(follower):
 
     goal_pos = {m: (i + 1) * 10 for i, m in enumerate(follower.bus.motors)}
     follower.bus.sync_write.assert_called_once_with("Goal_Position", goal_pos)
+
+
+@pytest.mark.parametrize(
+    "gripper_closed_pos, expected_drive_mode",
+    [
+        (2035, 0),  # closed position at range_min -> raw increases when opening -> not inverted
+        (3528, 1),  # closed position at range_max -> raw increases when closing -> inverted
+    ],
+)
+def test_calibrate_detects_gripper_drive_mode(follower, gripper_closed_pos, expected_drive_mode):
+    """Regression test for #3942: the follower gripper can be mounted mirrored with respect to the
+    leader's, in which case its raw position increases when closing. Calibration must detect this
+    and set drive_mode=1 so that normalized values follow the 0=closed/100=open convention."""
+    follower.connect()
+
+    motors = list(follower.bus.motors)
+    follower.bus.set_half_turn_homings.return_value = dict.fromkeys(motors, 0)
+    follower.bus.record_ranges_of_motion.return_value = (
+        dict.fromkeys(motors, 2035),
+        dict.fromkeys(motors, 3528),
+    )
+    follower.bus.read.return_value = gripper_closed_pos
+
+    with (
+        patch("builtins.input", return_value=""),
+        patch.object(type(follower), "_save_calibration", lambda self: None),
+    ):
+        follower.calibration = {}
+        follower.calibrate()
+
+    follower.bus.read.assert_called_with("Present_Position", "gripper", normalize=False)
+    assert follower.calibration["gripper"].drive_mode == expected_drive_mode
+    for motor in motors:
+        if motor != "gripper":
+            assert follower.calibration[motor].drive_mode == 0


### PR DESCRIPTION
## What this does

Fixes #3942 — SO101 follower gripper slams fully open at teleop start and locks up (Feetech overload / torque off).

**Root cause:** `calibrate()` in `so_follower.py` / `so_leader.py` hardcodes `drive_mode=0` for every motor. If the gripper motor ends up mounted mirrored relative to the other arm's (raw position **increases** when closing instead of decreasing — exactly what the calibration JSONs in the issue show: leader closed ≈ `range_min`, follower closed ≈ `range_max`), the 0=closed/100=open normalization convention flips. A "closed" (0%) command from the leader unnormalizes to the follower's fully-**open** hard stop → gripper presses against it → Feetech overload protection kicks in → torque off until power cycle.

`FeetechMotorsBus` already supports per-motor inversion via `drive_mode` (`apply_drive_mode = True`, see `motors_bus.py::_normalize/_unnormalize`) — calibration just never set it, and users can't hand-edit the calibration file to work around it.

**Change:** after range recording, calibration adds one step: ask the user to fully close the gripper, read the raw `Present_Position`, and set `drive_mode=1` for the gripper when the closed position sits at `range_max`. Applied symmetrically to `SOFollower` and `SOLeader`. No calibration file format change (`MotorCalibration` already carries `drive_mode`).

## How it was tested

Repro with the **real** `FeetechMotorsBus._normalize/_unnormalize` code and the exact gripper calibration values from the issue (`range 2035..3528`, mirrored mount):

```
drive_mode=0: leader 'closed' (0%) -> raw goal 2035 (OPEN ✗, slams open — issue #3942); follower closed reads 100%, open reads 0%
drive_mode=1: leader 'closed' (0%) -> raw goal 3528 (CLOSED ✓); follower closed reads 0%, open reads 100%
```

- New parametrized regression tests in `tests/robots/test_so100_follower.py` covering both mount orientations: **5 passed**
- `tests/motors/test_feetech.py`: **46 passed, 1 skipped**
- `pre-commit` (ruff format/lint, mypy, typos, bandit): **all passed**