### PR TITLE
fix(processor): correct feature contract in MapDeltaActionToRobotActionStep

### DIFF
--- a/src/lerobot/processor/delta_action_processor.py
+++ b/src/lerobot/processor/delta_action_processor.py
@@ -132,10 +132,23 @@ class MapDeltaActionToRobotActionStep(RobotActionProcessorStep):
     def transform_features(
         self, features: dict[PipelineFeatureType, dict[str, PolicyFeature]]
     ) -> dict[PipelineFeatureType, dict[str, PolicyFeature]]:
-        for axis in ["x", "y", "z", "gripper"]:
-            features[PipelineFeatureType.ACTION].pop(f"delta_{axis}", None)
+        # Remove the features this step consumes. The upstream
+        # MapTensorToDeltaActionDictStep registers the gripper feature under the key
+        # "gripper" (not "delta_gripper"), so it must be popped by that exact name.
+        for key in ["delta_x", "delta_y", "delta_z", "gripper"]:
+            features[PipelineFeatureType.ACTION].pop(key, None)
 
-        for feat in ["enabled", "target_x", "target_y", "target_z", "target_wx", "target_wy", "target_wz"]:
+        # Declare every feature emitted by action(), including the "gripper_vel" output.
+        for feat in [
+            "enabled",
+            "target_x",
+            "target_y",
+            "target_z",
+            "target_wx",
+            "target_wy",
+            "target_wz",
+            "gripper_vel",
+        ]:
             features[PipelineFeatureType.ACTION][f"{feat}"] = PolicyFeature(
                 type=FeatureType.ACTION, shape=(1,)
             )

--- a/tests/processor/test_delta_action_processor.py
+++ b/tests/processor/test_delta_action_processor.py
@@ -1,0 +1,66 @@
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from lerobot.configs.types import FeatureType, PipelineFeatureType, PolicyFeature
+from lerobot.processor.delta_action_processor import (
+    MapDeltaActionToRobotActionStep,
+    MapTensorToDeltaActionDictStep,
+)
+
+
+def _empty_features() -> dict[PipelineFeatureType, dict[str, PolicyFeature]]:
+    return {PipelineFeatureType.ACTION: {}, PipelineFeatureType.OBSERVATION: {}}
+
+
+def test_map_delta_to_robot_features_match_runtime_output_keys():
+    """The declared action features must be exactly the keys emitted by action().
+
+    Regression test: transform_features previously popped a non-existent
+    "delta_gripper" key (leaving the real "gripper" feature dangling) and never
+    declared the "gripper_vel" output.
+    """
+    # Build the upstream feature schema the way MapTensorToDeltaActionDictStep does.
+    features = _empty_features()
+    features = MapTensorToDeltaActionDictStep(use_gripper=True).transform_features(features)
+    assert set(features[PipelineFeatureType.ACTION]) == {"delta_x", "delta_y", "delta_z", "gripper"}
+
+    step = MapDeltaActionToRobotActionStep()
+    features = step.transform_features(features)
+    declared_keys = set(features[PipelineFeatureType.ACTION])
+
+    # Compute the keys the runtime path actually produces.
+    runtime_out = step.action({"delta_x": 0.1, "delta_y": 0.2, "delta_z": 0.3, "gripper": 1.0})
+
+    # The feature schema must match the runtime output 1:1.
+    assert declared_keys == set(runtime_out)
+    # Consumed inputs are gone; the emitted gripper_vel is present.
+    assert "gripper" not in declared_keys
+    assert "delta_x" not in declared_keys
+    assert "gripper_vel" in declared_keys
+
+
+def test_map_delta_to_robot_features_removes_gripper_when_present():
+    """The "gripper" feature registered upstream must be removed by this step."""
+    features = _empty_features()
+    features[PipelineFeatureType.ACTION] = {
+        "gripper": PolicyFeature(type=FeatureType.ACTION, shape=(1,)),
+        "some_other_feature": PolicyFeature(type=FeatureType.ACTION, shape=(1,)),
+    }
+
+    features = MapDeltaActionToRobotActionStep().transform_features(features)
+    action_features = features[PipelineFeatureType.ACTION]
+
+    assert "gripper" not in action_features
+    # Unrelated features are left untouched.
+    assert "some_other_feature" in action_features


### PR DESCRIPTION
## What

Fixes a feature-contract bug in `MapDeltaActionToRobotActionStep.transform_features` (`src/lerobot/processor/delta_action_processor.py`).

## The bug

Each processor step keeps two paths in sync: `action()` (runtime data) and `transform_features()` (the propagated `PipelineFeatureType.ACTION` schema). In this step they had drifted:

1. **Wrong key removed.** The old loop popped `f"delta_{axis}"` for `axis in [..., "gripper"]`, i.e. it tried to remove `"delta_gripper"`. But the upstream `MapTensorToDeltaActionDictStep` registers that feature under the key `"gripper"`. Since `pop(..., None)` no-ops on a missing key, the consumed `gripper` feature was **never removed** and dangled forward in the schema.
2. **Missing declaration.** `action()` emits `gripper_vel`, but `transform_features()` never declared it, so a key that exists at runtime was **absent** from the schema.

Net effect: the propagated action-feature schema was inconsistent with the dict `action()` actually produces — it advertised a `gripper` feature that no longer exists and omitted the real `gripper_vel`. Because `pop(..., None)` swallows the mismatch, nothing raised; the schema just silently lied, which surfaces downstream (feature counts in dataset metadata / policy config / IK steps).

## The fix

- Pop the real consumed keys: `delta_x`, `delta_y`, `delta_z`, `gripper`.
- Declare every emitted key, including `gripper_vel`.

This restores the 1:1 `action()` ↔ `transform_features()` correspondence that the sibling `MapTensorToDeltaActionDictStep` already follows.

## Tests

Adds a regression test in `tests/processor/test_delta_action_processor.py` asserting the post-transform schema matches exactly the keys `action()` produces.

```
uv run pytest tests/processor/test_delta_action_processor.py -q
2 passed
```
