### PR TITLE
fix(robot): type FK-to-EE action features as ACTION not STATE

### DIFF
--- a/bugs.txt
+++ b/bugs.txt
@@ -1,0 +1,13 @@
+Processor step carrys a dual contract
+
+src/lerobot/processor/ is a pipeline of transformation steps (DataProcessorPipeline/PolicyProcessorPipeline).
+Each ProcessorStep implements two methods that must stay in sync: 
+    1. action (...) - the runtime path. Takes the actual dict/tensor flowing through at inference time and transforms it. 
+    2. transform_features(...) - the schema path. Takes a dict describing the action feature schema (PipelineFeatureType.ACTION) and mutates it to describe what the data will look like after this step runs. 
+
+# Propagated ACTION schema was inconsistent with the actual dict action()?
+
+This bug fixes and restores the 1:1 correspondence bewteen action() (runtime) and transform_features() (schema) - the same clean contract that the sibling
+MapTensorToDeltaActionDictStep already honored. The regression test in af26049e locks it in by asserting the post-transition schema exactly matches the keys action() produces. 
+
+# How can we code more policies for this or integrate more interesting algorithms?

--- a/src/lerobot/robots/so_follower/robot_kinematic_processor.py
+++ b/src/lerobot/robots/so_follower/robot_kinematic_processor.py
@@ -510,10 +510,12 @@ class ForwardKinematicsJointsToEEAction(RobotActionProcessorStep):
         # We only use the ee pose in the dataset, so we don't need the joint positions
         for n in self.motor_names:
             features[PipelineFeatureType.ACTION].pop(f"{n}.pos", None)
-        # We specify the dataset features of this step that we want to be stored in the dataset
+        # We specify the dataset features of this step that we want to be stored in the dataset.
+        # These live in the ACTION bucket, so they must be typed FeatureType.ACTION (the
+        # observation variant of this step uses FeatureType.STATE for its OBSERVATION features).
         for k in ["x", "y", "z", "wx", "wy", "wz", "gripper_pos"]:
             features[PipelineFeatureType.ACTION][f"ee.{k}"] = PolicyFeature(
-                type=FeatureType.STATE, shape=(1,)
+                type=FeatureType.ACTION, shape=(1,)
             )
         return features
 

--- a/tests/robots/test_robot_kinematic_processor.py
+++ b/tests/robots/test_robot_kinematic_processor.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from lerobot.configs import FeatureType, PipelineFeatureType, PolicyFeature
+from lerobot.robots.so_follower.robot_kinematic_processor import (
+    ForwardKinematicsJointsToEEAction,
+    ForwardKinematicsJointsToEEObservation,
+)
+
+MOTOR_NAMES = ["shoulder_pan", "shoulder_lift", "elbow_flex", "wrist_flex", "wrist_roll", "gripper"]
+EE_KEYS = {f"ee.{k}" for k in ["x", "y", "z", "wx", "wy", "wz", "gripper_pos"]}
+
+
+def _joint_bucket(feature_type: FeatureType) -> dict[str, PolicyFeature]:
+    return {f"{n}.pos": PolicyFeature(type=feature_type, shape=(1,)) for n in MOTOR_NAMES}
+
+
+def test_fk_action_step_types_ee_features_as_action():
+    """The action FK step must emit its EE features in the ACTION bucket typed ACTION.
+
+    Regression test: these were mistakenly typed FeatureType.STATE (copied from the
+    observation variant), mis-classifying the converted end-effector actions as state.
+    """
+    step = ForwardKinematicsJointsToEEAction(kinematics=None, motor_names=MOTOR_NAMES)
+    features = {
+        PipelineFeatureType.ACTION: _joint_bucket(FeatureType.ACTION),
+        PipelineFeatureType.OBSERVATION: {},
+    }
+
+    out = step.transform_features(features)[PipelineFeatureType.ACTION]
+
+    # Joint positions consumed, EE pose produced.
+    assert set(out) == EE_KEYS
+    # Every produced action feature is typed ACTION, not STATE.
+    assert all(feat.type == FeatureType.ACTION for feat in out.values())
+
+
+def test_fk_observation_step_types_ee_features_as_state():
+    """The observation FK step keeps its EE features in the OBSERVATION bucket typed STATE."""
+    step = ForwardKinematicsJointsToEEObservation(kinematics=None, motor_names=MOTOR_NAMES)
+    features = {
+        PipelineFeatureType.ACTION: {},
+        PipelineFeatureType.OBSERVATION: _joint_bucket(FeatureType.STATE),
+    }
+
+    out = step.transform_features(features)[PipelineFeatureType.OBSERVATION]
+
+    assert set(out) == EE_KEYS
+    assert all(feat.type == FeatureType.STATE for feat in out.values())


### PR DESCRIPTION
## What

`ForwardKinematicsJointsToEEAction.transform_features` (`src/lerobot/robots/so_follower/robot_kinematic_processor.py`) declared its end-effector **action** features with `FeatureType.STATE` instead of `FeatureType.ACTION`.

## The bug

The step converts joint-space actions (`{motor}.pos`) into end-effector actions (`ee.x/y/z/wx/wy/wz/gripper_pos`) in the `PipelineFeatureType.ACTION` bucket, but typed each produced feature `FeatureType.STATE`:

```python
for k in ["x", "y", "z", "wx", "wy", "wz", "gripper_pos"]:
    features[PipelineFeatureType.ACTION][f"ee.{k}"] = PolicyFeature(
        type=FeatureType.STATE, shape=(1,)   # ← should be FeatureType.ACTION
    )
```

This was copied verbatim from the sibling `ForwardKinematicsJointsToEEObservation`, where `FeatureType.STATE` is correct because those features live in the `OBSERVATION` bucket. Every *other* action-producing step in this file — `EEReferenceAndDelta`, `InverseKinematicsEEToJoints`, `InverseKinematicsRLStep` — types its `ACTION`-bucket features as `FeatureType.ACTION`.

**Impact:** the propagated feature schema mis-classifies the converted EE actions as state. Downstream consumers keyed on `FeatureType` (normalization `norm_map`, policy input/output feature classification) then treat these actions as state — e.g. applying the `STATE` normalization mode to action data.

## The fix

Type the action-variant's EE features as `FeatureType.ACTION`. The observation variant is unchanged (`STATE` is correct there).

Before → after (reproduced directly):
```
ee.x: FeatureType.STATE   →   ee.x: FeatureType.ACTION
...
ee.gripper_pos: FeatureType.STATE   →   ee.gripper_pos: FeatureType.ACTION
```

## Tests

Adds `tests/robots/test_robot_kinematic_processor.py` (no hardware required) asserting:
- the **action** FK step emits EE features in the `ACTION` bucket typed `ACTION`;
- the **observation** FK step emits them in the `OBSERVATION` bucket typed `STATE`.

```
uv run pytest tests/robots/test_robot_kinematic_processor.py -q
2 passed
```
