### PR TITLE
docs: fix env processor code fences and minor doc errors

### DIFF
--- a/docs/source/env_processor.mdx
+++ b/docs/source/env_processor.mdx
@@ -88,20 +88,6 @@ policy_preprocessor = NormalizerProcessorStep(stats=dataset_stats)
 
 The same policy can work with different environment processors, and the same environment processor can work with different policies:
 
-````python
-# Use SmolVLA policy with LIBERO environment
-# Use SmolVLA policy with LIBERO environment
-libero_preprocessor, libero_postprocessor = make_env_pre_post_processors(
-    env_cfg=libero_cfg,
-    policy_cfg=smolvla_cfg,
-)
-smolvla_preprocessor, smolvla_postprocessor = make_pre_post_processors(smolvla_cfg)
-# Or use ACT policy with the same LIBERO environment
-libero_preprocessor, libero_postprocessor = make_env_pre_post_processors(
-    env_cfg=libero_cfg,
-    policy_cfg=act_cfg,
-)
-act_preprocessor, act_postprocessor = make_pre_post_processors(act_cfg)
 ```python
 # Use SmolVLA policy with LIBERO environment
 libero_preprocessor, libero_postprocessor = make_env_pre_post_processors(
@@ -116,6 +102,7 @@ libero_preprocessor, libero_postprocessor = make_env_pre_post_processors(
     policy_cfg=act_cfg,
 )
 act_preprocessor, act_postprocessor = make_pre_post_processors(act_cfg)
+```
 
 ### 3. **Easier Experimentation**
 
@@ -145,7 +132,7 @@ class LiberoVelocityProcessorStep(ObservationProcessorStep):
         state = torch.cat([eef_pos, eef_axisangle, eef_vel,
                           gripper_pos, gripper_vel], dim=-1)  # 14D
         return state
-````
+```
 
 ### 4. **Cleaner Environment Code**
 

--- a/docs/source/hope_jr.mdx
+++ b/docs/source/hope_jr.mdx
@@ -211,7 +211,7 @@ Record, Replay and Train with Hope-JR is still experimental.
 
 ### Record
 
-This step records the dataset, which can be seen as an example [here](https://huggingface.co/datasets/nepyope/hand_record_test_with_video_data/settings).
+This step records the dataset, which can be seen as an example [here](https://huggingface.co/datasets/nepyope/hand_record_test_with_video_data).
 
 ```bash
 lerobot-record \

--- a/docs/source/integrate_hardware.mdx
+++ b/docs/source/integrate_hardware.mdx
@@ -18,7 +18,7 @@ If you're using Feetech or Dynamixel motors, LeRobot provides built-in bus inter
 - [`DynamixelMotorsBus`](https://github.com/huggingface/lerobot/blob/main/src/lerobot/motors/dynamixel/dynamixel.py) – for controlling Dynamixel servos
 
 Please refer to the [`MotorsBus`](https://github.com/huggingface/lerobot/blob/main/src/lerobot/motors/motors_bus.py) abstract class to learn about its API.
-For a good example of how it can be used, you can have a look at our own [SO101 follower implementation](https://github.com/huggingface/lerobot/blob/main/src/lerobot/robots/so_follower/so101_follower/so101_follower.py)
+For a good example of how it can be used, you can have a look at our own [SO101 follower implementation](https://github.com/huggingface/lerobot/blob/main/src/lerobot/robots/so_follower/so_follower.py)
 
 Use these if compatible. Otherwise, you'll need to find or write a Python interface (not covered in this tutorial):
 

--- a/docs/source/lekiwi.mdx
+++ b/docs/source/lekiwi.mdx
@@ -51,7 +51,7 @@ In addition to these instructions, you need to install the Feetech SDK & ZeroMQ 
 pip install -e ".[lekiwi]"
 ```
 
-Great :hugs:! You are now done installing LeRobot, and we can begin assembling the SO100/SO101 arms and the mobile base :robot:.
+Great 🤗! You are now done installing LeRobot, and we can begin assembling the SO100/SO101 arms and the mobile base 🤖.
 Every time you now want to use LeRobot, you can go to the `~/lerobot` folder where we installed LeRobot and run one of the commands.
 
 # Step-by-Step Assembly Instructions

--- a/docs/source/pi0fast.mdx
+++ b/docs/source/pi0fast.mdx
@@ -174,7 +174,7 @@ The model takes images, text instructions, and robot state as input, and outputs
 
 ## Reproducing π₀Fast results
 
-We reproduce the results of π₀Fast on the LIBERO benchmark using the LeRobot implementation. We take the LeRobot PiFast base model [lerobot/pi0fast-base](https://huggingface.co/lerobot/pi0fast-base) and finetune for an additional 40kk steps in bfloat16, with batch size of 256 on 8 H100 GPUs using the [HuggingFace LIBERO dataset](https://huggingface.co/datasets/HuggingFaceVLA/libero).
+We reproduce the results of π₀Fast on the LIBERO benchmark using the LeRobot implementation. We take the LeRobot PiFast base model [lerobot/pi0fast-base](https://huggingface.co/lerobot/pi0fast-base) and finetune for an additional 40k steps in bfloat16, with batch size of 256 on 8 H100 GPUs using the [HuggingFace LIBERO dataset](https://huggingface.co/datasets/HuggingFaceVLA/libero).
 
 The finetuned model can be found here:
 

--- a/docs/source/smolvla.mdx
+++ b/docs/source/smolvla.mdx
@@ -93,7 +93,7 @@ lerobot-train --help
 
 ## Evaluate the finetuned model and run it in real-time
 
-Similarly for when recording an episode, it is recommended that you are logged in to the HuggingFace Hub. You can follow the corresponding steps: [Record a dataset](./il_robots).
+Similarly for when recording an episode, it is recommended that you are logged in to the HuggingFace Hub. You can follow the corresponding steps: [Record a dataset](./il_robots#record-a-dataset).
 Once you are logged in, you can run inference in your setup by doing:
 
 ```bash


### PR DESCRIPTION
## Related issues

- Fixes / Closes: # (none)
- Related: # (none)

## What changed

- `docs/source/env_processor.mdx`: removed a duplicated example block and fixed the four-backtick (` ```` `) fences to standard three-backtick(` ``` `) fences, plus added the missing closing fence so the "same policy / same environment processor" example renders correctly.
- `docs/source/integrate_hardware.mdx`: corrected the SO101 follower implementation link from the non-existent `so_follower/so101_follower/so101_follower.py` to the actual `so_follower/so_follower.py`.
- `docs/source/pi0fast.mdx`: fixed a typo in the reproduction section, `40kk steps` → `40k steps`.
- `hope_jr.mdx`: Fixed the dataset "`example`" link in the Record section: it pointed at the dataset's `/settings` page (returns HTTP 403 for readers) instead of the public dataset page.
- `lekiwi.mdx`: Replaced the `:hugs:` / `:robot:` emoji shortcodes (which MDX does not expand, so they showed as literal text) with the 🤗 / 🤖 unicode characters, matching the other robot pages.
- `smolvla.mdx`: Anchored the "`Record a dataset`" link to `./il_robots#record-a-dataset` (the `## Record a dataset` heading) instead of the top of the page.
- No breaking changes.

**Rendering of the env processor section, before vs. after:**

| Before (broken fences) | After (fixed) |
| --- | --- |
| <img width="822" height="1035" alt="截圖 2026-07-06 上午9 27 35" src="https://github.com/user-attachments/assets/d6def6cb-f95f-4ced-81f9-e022d2978c4e" /> | <img width="822" height="729" alt="截圖 2026-07-06 上午9 44 24" src="https://github.com/user-attachments/assets/9361caf6-d419-4c29-af05-5755ac6bed1a" /> |

## How was this tested (or how to run locally)

- Tests added: none (documentation-only change).
- Manual checks: reviewed the rendered `.mdx` fences (see before/after above) and verified the corrected SO101 follower path exists at `src/lerobot/robots/so_follower/so_follower.py`.
-  Build & preview the docs locally, then ensure the env processor code blocks in docs/source/env_processor.mdx render correctly.
    ```bash
    pip install -e . -r docs-requirements.txt
    doc-builder build lerobot docs/source/ --build_dir ~/tmp/test-build
    doc-builder preview lerobot docs/source/
    ```

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -all-files`)
- [ ] All tests pass locally (`pytest`) — N/A, docs-only
- [x] Documentation updated
- [x] CI is green
- [x] Community Review: I have reviewed another contributor's open PR and linked it here: #3937
<details>
<summary>pre-commit run -a (all hooks passed)</summary>
<img width="798" height="424" alt="截圖 2026-07-06 上午10 20 25" src="https://github.com/user-attachments/assets/41b0c41e-141d-4b57-a2e7-052ad13dee4c" />
</details>

## Reviewer notes

- Changes are limited to three `.mdx` files under `docs/source/`; no source code or tests are touched.
- Please double-check the corrected SO101 follower link points to the intended file, and that the env processor example reads correctly after the duplicate block was removed.
- Anyone in the community is free to review the PR.