### PR TITLE
feat(teleop): add startup joint-mismatch guard to teleoperate/record loops

### DIFF
--- a/src/lerobot/robots/rebot_b601_follower/config_rebot_b601_follower.py
+++ b/src/lerobot/robots/rebot_b601_follower/config_rebot_b601_follower.py
@@ -100,6 +100,31 @@ class RebotB601FollowerConfig:
         }
     )
 
+    # --- Gripper multi-turn wrap handling -------------------------------------
+    # The Damiao multi-turn counter is volatile across power cycles: the single-turn
+    # absolute zero survives, but the turn count does not. The B601 gripper travel
+    # (~380 deg) exceeds one turn, so after a repower the gripper can report a
+    # position on a different 2*pi branch (e.g. +356.8 deg while physically closed
+    # in a [-270, 0] frame). Absolute gripper targets are then meaningless and any
+    # command drives the mechanism into its stop through the gear reduction.
+    #
+    # Policy applied at connect() when the gripper reads outside its joint limits
+    # (plus `gripper_wrap_margin_deg`):
+    #   "rehome" - close the gripper until it stalls against the mechanical stop and
+    #              re-zero there (matches the calibration convention closed == 0).
+    #   "abort"  - raise instead of connecting (operator must recalibrate).
+    #   "ignore" - log a warning and continue (NOT recommended).
+    gripper_wrap_policy: str = "rehome"
+    # Tolerance added around the gripper joint limits before a reading is considered
+    # wrapped, in degrees.
+    gripper_wrap_margin_deg: float = 30.0
+    # Re-homing sweep parameters: per-step increment [rad], velocity limit [rad/s],
+    # sustained-torque stall threshold [Nm], and max travel guard [rad].
+    gripper_rehome_step_rad: float = 0.05
+    gripper_rehome_vlim_rad_s: float = 0.5
+    gripper_rehome_stall_torque_nm: float = 0.8
+    gripper_rehome_max_travel_rad: float = 8.0
+
 
 @RobotConfig.register_subclass("rebot_b601_follower")
 @dataclass

--- a/src/lerobot/robots/rebot_b601_follower/rebot_b601_follower.py
+++ b/src/lerobot/robots/rebot_b601_follower/rebot_b601_follower.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import contextlib
 import logging
 import math
 import time
@@ -125,6 +126,8 @@ class RebotB601Follower(Robot):
             )
             self.calibrate()
 
+        self._check_gripper_wrap()
+
         for cam in self.cameras.values():
             cam.connect()
 
@@ -173,7 +176,141 @@ class RebotB601Follower(Robot):
         self._save_calibration()
         print(f"Calibration saved to {self.calibration_fpath}")
 
+    # --- Gripper multi-turn wrap handling -------------------------------------
+
+    def _read_gripper_rad(self) -> float | None:
+        """Fresh gripper position read in radians (None if the motor did not reply)."""
+        motor = self.motors.get(GRIPPER_MOTOR)
+        if motor is None:
+            return None
+        motor.request_feedback()
+        time.sleep(0.005)
+        if self.bus is not None:
+            with contextlib.suppress(Exception):
+                self.bus.poll_feedback_once()
+        state = motor.get_state()
+        return float(state.pos) if state is not None else None
+
+    def _check_gripper_wrap(self) -> None:
+        """Detect a 2*pi-wrapped multi-turn gripper reading and apply the configured policy.
+
+        The Damiao multi-turn counter does not survive power cycles: the single-turn
+        absolute zero is preserved but the turn count is lost, so a gripper whose
+        travel exceeds one turn can wake up reporting ``physical + 2*pi*k``. Absolute
+        targets (including the soft-limit clip in :meth:`send_action`) are then wrong
+        by whole turns and drive the mechanism into its stop through the reduction.
+        """
+        if GRIPPER_MOTOR not in self.config.joint_limits:
+            return
+        pos_rad = self._read_gripper_rad()
+        if pos_rad is None:
+            logger.warning("Gripper wrap check skipped: no feedback from the gripper motor.")
+            return
+
+        min_deg, max_deg = self.config.joint_limits[GRIPPER_MOTOR]
+        margin = math.radians(self.config.gripper_wrap_margin_deg)
+        lo = math.radians(min_deg) - margin
+        hi = math.radians(max_deg) + margin
+        if lo <= pos_rad <= hi:
+            return
+
+        message = (
+            f"Gripper reads {pos_rad:+.3f} rad ({math.degrees(pos_rad):+.1f} deg), outside its "
+            f"calibrated travel [{min_deg:.0f}, {max_deg:.0f}] deg (+/- "
+            f"{self.config.gripper_wrap_margin_deg:.0f} deg margin). The multi-turn encoder "
+            f"most likely re-woke on a different 2*pi branch after a power cycle, so absolute "
+            f"gripper targets are invalid."
+        )
+        policy = self.config.gripper_wrap_policy
+        if policy == "abort":
+            raise RuntimeError(message + " Re-run calibration or use gripper_wrap_policy='rehome'.")
+        if policy == "ignore":
+            logger.warning("%s Continuing anyway (gripper_wrap_policy='ignore').", message)
+            return
+
+        logger.warning("%s Re-homing: closing until stall, then re-zeroing there.", message)
+        self._rehome_gripper()
+
+    def _rehome_gripper(self) -> None:
+        """Close the gripper until it stalls against its mechanical stop and re-zero there.
+
+        Restores the calibration convention (fully closed == 0, opening negative)
+        regardless of which 2*pi branch the encoder woke up on. Runs BEFORE
+        :meth:`configure`, so the motor is enabled only for the sweep and left
+        disabled afterwards. Low-speed POS_VEL steps with sustained-torque/lag stall
+        detection (3 consecutive strikes), mirroring the validated calibration sweep.
+        """
+        motor = self.motors[GRIPPER_MOTOR]
+        step = self.config.gripper_rehome_step_rad
+        vlim = self.config.gripper_rehome_vlim_rad_s
+        stall_torque = self.config.gripper_rehome_stall_torque_nm
+        max_travel = self.config.gripper_rehome_max_travel_rad
+        settle_s = 0.15  # per-step dwell: ~step/settle = 0.33 rad/s sweep speed
+
+        motor.clear_error()  # Damiao latches faults (e.g. coil over-temp) across sessions
+        motor.enable()
+        try:
+            for attempt in range(_ENSURE_MODE_RETRIES + 1):
+                try:
+                    motor.ensure_mode(MotorBridgeMode.POS_VEL)
+                    break
+                except Exception:
+                    if attempt == _ENSURE_MODE_RETRIES:
+                        raise
+                    time.sleep(_SETTLE_SEC)
+
+            start = self._read_gripper_rad()
+            if start is None:
+                raise RuntimeError("Gripper re-homing failed: no feedback before the sweep.")
+            target = start
+            strikes = 0
+            stalled = False
+            # Closing direction is positive: calibration convention is closed == 0 with
+            # opening travel negative, so the closed mechanical stop lies on the
+            # positive side of any in-travel (or wrapped) reading.
+            while abs(target - start) < max_travel:
+                target += step
+                motor.send_pos_vel(target, vlim)
+                time.sleep(settle_s)
+                pos = self._read_gripper_rad()
+                state = motor.get_state()
+                if pos is None or state is None:
+                    continue
+                if abs(state.torq) > stall_torque or abs(pos - target) > 0.3:
+                    strikes += 1
+                    if strikes >= 3:
+                        stalled = True
+                        break
+                else:
+                    strikes = 0
+            if not stalled:
+                raise RuntimeError(
+                    f"Gripper re-homing failed: no stall detected within {max_travel:.1f} rad "
+                    f"of travel. Check the mechanism and recalibrate manually."
+                )
+        finally:
+            motor.disable()
+
+        # Torque is off: the gears relax onto the stop; zero the encoder there so the
+        # closed position reads 0 (the calibration convention).
+        time.sleep(0.3)
+        motor.set_zero_position()
+        time.sleep(_ZERO_SETTLE_SEC)
+
+        pos = self._read_gripper_rad()
+        if pos is None or abs(pos) > 0.2:
+            raise RuntimeError(
+                f"Gripper re-homing verification failed: expected ~0 rad at the closed stop, "
+                f"read {pos if pos is None else round(pos, 3)}."
+            )
+        logger.info("Gripper re-homed: closed stop re-zeroed (reads %+.3f rad).", pos)
+
     def configure(self) -> None:
+        if self.config.gripper_wrap_policy not in ("rehome", "abort", "ignore"):
+            raise ValueError(
+                f"Unsupported gripper_wrap_policy '{self.config.gripper_wrap_policy}'. "
+                "Use 'rehome', 'abort' or 'ignore'."
+            )
         if self.config.control_mode not in ("pos_vel", "mit"):
             raise ValueError(
                 f"Unsupported control_mode '{self.config.control_mode}'. Use 'pos_vel' or 'mit'."

--- a/src/lerobot/scripts/lerobot_record.py
+++ b/src/lerobot/scripts/lerobot_record.py
@@ -156,6 +156,7 @@ from lerobot.utils.feature_utils import build_dataset_frame, combine_feature_dic
 from lerobot.utils.import_utils import register_third_party_plugins
 from lerobot.utils.keyboard_input import init_keyboard_listener
 from lerobot.utils.robot_utils import precise_sleep
+from lerobot.utils.startup_guard import StartupJointGuard
 from lerobot.utils.utils import (
     init_logging,
     log_say,
@@ -188,6 +189,14 @@ class RecordConfig:
     play_sounds: bool = True
     # Resume recording on an existing dataset.
     resume: bool = False
+    # Startup joint-mismatch guard: on the first frame of every episode, commanded vs
+    # measured joint positions are compared; a disagreement larger than
+    # `startup_guard_threshold` (action units, e.g. degrees) is ramped over
+    # `startup_guard_ramp_s` seconds ("ramp") or raises ("abort") instead of jumping.
+    startup_guard: bool = True
+    startup_guard_threshold: float = 10.0
+    startup_guard_ramp_s: float = 1.5
+    startup_guard_mode: str = "ramp"
 
     def __post_init__(self):
         if self.teleop is None:
@@ -245,9 +254,16 @@ def record_loop(
     display_data: bool = False,
     display_mode: str = "rerun",
     display_compressed_images: bool = False,
+    startup_guard: StartupJointGuard | None = None,
 ):
     if dataset is not None and dataset.fps != fps:
         raise ValueError(f"The dataset fps should be equal to requested fps ({dataset.fps} != {fps}).")
+
+    # Re-arm the guard at every episode start: reconnections, manual environment
+    # resets, or a power-cycled multi-turn encoder can (re)introduce a mismatch
+    # between episodes, not just at process startup.
+    if startup_guard is not None:
+        startup_guard.reset()
 
     teleop_arm = teleop_keyboard = None
     if isinstance(teleop, list):
@@ -329,6 +345,8 @@ def record_loop(
         # Action can eventually be clipped using `max_relative_target`,
         # so action actually sent is saved in the dataset. action = postprocessor.process(action)
         # TODO(steven, pepijn, adil): we should use a pipeline step to clip the action, so the sent action is the action that we input to the robot.
+        if startup_guard is not None:
+            robot_action_to_send = startup_guard.process(robot_action_to_send, obs)
         _sent_action = robot.send_action(robot_action_to_send)
 
         # Write to dataset
@@ -459,6 +477,16 @@ def record(
 
         listener, events = init_keyboard_listener()
 
+        startup_guard = (
+            StartupJointGuard(
+                threshold=cfg.startup_guard_threshold,
+                ramp_duration_s=cfg.startup_guard_ramp_s,
+                mode=cfg.startup_guard_mode,
+            )
+            if cfg.startup_guard
+            else None
+        )
+
         if not cfg.dataset.streaming_encoding:
             logging.info(
                 "Streaming encoding is disabled. If you have capable hardware, consider enabling it for way faster episode saving. --dataset.streaming_encoding=true --dataset.encoder_threads=2 # --dataset.rgb_encoder.vcodec=auto. More info in the documentation: https://huggingface.co/docs/lerobot/streaming_video_encoding"
@@ -482,6 +510,7 @@ def record(
                     display_data=cfg.display_data,
                     display_mode=cfg.display_mode,
                     display_compressed_images=display_compressed_images,
+                    startup_guard=startup_guard,
                 )
 
                 # Execute a few seconds without recording to give time to manually reset the environment
@@ -503,6 +532,7 @@ def record(
                         single_task=cfg.dataset.single_task,
                         display_data=cfg.display_data,
                         display_mode=cfg.display_mode,
+                        startup_guard=startup_guard,
                     )
 
                 if events["rerecord_episode"]:

--- a/src/lerobot/scripts/lerobot_teleoperate.py
+++ b/src/lerobot/scripts/lerobot_teleoperate.py
@@ -123,6 +123,7 @@ from lerobot.teleoperators import (  # noqa: F401
 )
 from lerobot.utils.import_utils import register_third_party_plugins
 from lerobot.utils.robot_utils import precise_sleep
+from lerobot.utils.startup_guard import StartupJointGuard
 from lerobot.utils.utils import init_logging, move_cursor_up
 from lerobot.utils.visualization_utils import (
     init_visualization,
@@ -150,6 +151,14 @@ class TeleoperateConfig:
     display_port: int | None = None
     # Whether to display compressed (JPEG) images instead of raw frames
     display_compressed_images: bool = False
+    # Startup joint-mismatch guard: on the first frame, commanded vs measured joint
+    # positions are compared; a disagreement larger than `startup_guard_threshold`
+    # (action units, e.g. degrees) is ramped over `startup_guard_ramp_s` seconds
+    # ("ramp") or raises ("abort") instead of jumping at full speed.
+    startup_guard: bool = True
+    startup_guard_threshold: float = 10.0
+    startup_guard_ramp_s: float = 1.5
+    startup_guard_mode: str = "ramp"
 
 
 def teleop_loop(
@@ -163,6 +172,7 @@ def teleop_loop(
     display_mode: str = "rerun",
     duration: float | None = None,
     display_compressed_images: bool = False,
+    startup_guard: StartupJointGuard | None = None,
 ):
     """
     This function continuously reads actions from a teleoperation device, processes them through optional
@@ -205,6 +215,11 @@ def teleop_loop(
 
         # Process action for robot through pipeline
         robot_action_to_send = robot_action_processor((teleop_action, obs))
+
+        # Defuse first-frame convention mismatches (sign flips, stale zeros,
+        # wrapped multi-turn encoders) before anything reaches the motors.
+        if startup_guard is not None:
+            robot_action_to_send = startup_guard.process(robot_action_to_send, obs)
 
         # Send processed action to robot (robot_action_processor.to_output should return RobotAction)
         _ = robot.send_action(robot_action_to_send)
@@ -258,6 +273,16 @@ def teleoperate(cfg: TeleoperateConfig):
     teleop.connect()
     robot.connect()
 
+    guard = (
+        StartupJointGuard(
+            threshold=cfg.startup_guard_threshold,
+            ramp_duration_s=cfg.startup_guard_ramp_s,
+            mode=cfg.startup_guard_mode,
+        )
+        if cfg.startup_guard
+        else None
+    )
+
     try:
         teleop_loop(
             teleop=teleop,
@@ -270,6 +295,7 @@ def teleoperate(cfg: TeleoperateConfig):
             robot_action_processor=robot_action_processor,
             robot_observation_processor=robot_observation_processor,
             display_compressed_images=display_compressed_images,
+            startup_guard=guard,
         )
     except KeyboardInterrupt:
         pass

--- a/src/lerobot/utils/startup_guard.py
+++ b/src/lerobot/utils/startup_guard.py
@@ -1,0 +1,181 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Startup joint-mismatch guard for teleoperation and policy control loops.
+
+The very first action sent to a robot is unconditional: nothing verifies that the
+teleoperator (or policy) and the follower agree on where the joints currently are.
+Any constant offset between the two conventions -- a flipped sign, a stale homing
+offset, a multi-turn encoder that re-woke on a different 2*pi branch after a power
+cycle -- therefore materializes as a full-speed jump on frame zero, usually silently
+clipped against the soft joint limits. This class turns that jump into either a
+smooth ramp or a hard, explainable error.
+
+The guard is robot-agnostic: it only inspects action/observation keys that end in
+``.pos`` and are present in both dictionaries with float values. Everything else
+(velocities, cameras, robots whose teleop does not speak joint space) passes
+through untouched.
+
+Typical wiring, once per control loop before ``robot.send_action``::
+
+    guard = StartupJointGuard(threshold=10.0, ramp_duration_s=1.5)
+    ...
+    action = guard.process(action, obs, now=time.perf_counter())
+    robot.send_action(action)
+"""
+
+import logging
+import time
+
+logger = logging.getLogger(__name__)
+
+_POS_SUFFIX = ".pos"
+
+
+class StartupJointGuard:
+    """Detects and defuses first-frame joint mismatches between commanded and measured positions.
+
+    On the first processed frame, every joint key ``{name}.pos`` present in both the
+    action and the observation is compared. If all deltas are within ``threshold``
+    the guard disarms immediately and becomes a pass-through. Otherwise:
+
+    - ``mode="ramp"`` (default): the commanded positions are blended from the
+      measured positions to the live targets over ``ramp_duration_s`` seconds
+      (``cmd = measured_0 + alpha * (target - measured_0)``), so the robot converges
+      to the leader/policy smoothly instead of jumping.
+    - ``mode="abort"``: raises :class:`StartupMismatchError` listing the offending
+      joints, so a badly calibrated convention is surfaced instead of executed.
+
+    Args:
+        threshold: Maximum tolerated per-joint |action - observation| on the first
+            frame, in the robot's action units (degrees for followers that speak
+            degrees, normalized units for normalized followers).
+        ramp_duration_s: Duration of the blend-in ramp when a mismatch is detected.
+        mode: ``"ramp"`` or ``"abort"``.
+        enabled: If False the guard is a pass-through (single CLI switch-off).
+    """
+
+    def __init__(
+        self,
+        threshold: float = 10.0,
+        ramp_duration_s: float = 1.5,
+        mode: str = "ramp",
+        enabled: bool = True,
+    ):
+        if mode not in ("ramp", "abort"):
+            raise ValueError(f"Unsupported startup guard mode '{mode}'. Use 'ramp' or 'abort'.")
+        if not (threshold > 0.0):
+            raise ValueError(f"threshold must be > 0, got {threshold}")
+        if not (ramp_duration_s > 0.0):
+            raise ValueError(f"ramp_duration_s must be > 0, got {ramp_duration_s}")
+        self.threshold = threshold
+        self.ramp_duration_s = ramp_duration_s
+        self.mode = mode
+        self.enabled = enabled
+
+        self._armed = True  # True until the first frame has been inspected
+        self._ramping = False
+        self._ramp_start_ts: float | None = None
+        self._ramp_base: dict[str, float] = {}  # measured positions captured on frame 0
+
+    @property
+    def is_ramping(self) -> bool:
+        """Whether the guard is currently blending commands toward the live target."""
+        return self._ramping
+
+    @staticmethod
+    def _joint_pairs(action: dict, observation: dict) -> dict[str, tuple[float, float]]:
+        """Return ``{key: (commanded, measured)}`` for float ``.pos`` keys present in both dicts."""
+        pairs = {}
+        for key, cmd in action.items():
+            if not key.endswith(_POS_SUFFIX):
+                continue
+            meas = observation.get(key)
+            if isinstance(cmd, (int, float)) and isinstance(meas, (int, float)):
+                pairs[key] = (float(cmd), float(meas))
+        return pairs
+
+    def process(self, action: dict, observation: dict, now: float | None = None) -> dict:
+        """Inspect (and possibly rewrite) the action about to be sent to the robot.
+
+        Args:
+            action: The action dictionary bound for ``robot.send_action``.
+            observation: The most recent ``robot.get_observation()`` result.
+            now: Injectable monotonic timestamp [s] (defaults to ``time.perf_counter()``).
+
+        Returns:
+            The action to actually send: the input unchanged once disarmed, or a
+            blended copy while ramping.
+
+        Raises:
+            StartupMismatchError: In ``"abort"`` mode when the first frame disagrees.
+        """
+        if not self.enabled:
+            return action
+        if now is None:
+            now = time.perf_counter()
+
+        if self._armed:
+            self._armed = False
+            pairs = self._joint_pairs(action, observation)
+            offending = {
+                key: cmd - meas for key, (cmd, meas) in pairs.items() if abs(cmd - meas) > self.threshold
+            }
+            if not offending:
+                return action
+
+            details = ", ".join(
+                f"{key}: commanded {pairs[key][0]:.2f} vs measured {pairs[key][1]:.2f} (delta {delta:+.2f})"
+                for key, delta in sorted(offending.items())
+            )
+            message = (
+                f"Startup mismatch between commanded and measured joint positions "
+                f"(threshold {self.threshold:.2f}): {details}. This usually means the "
+                f"teleoperator and follower disagree on calibration conventions "
+                f"(sign flip, stale zero, or a multi-turn encoder that wrapped after "
+                f"a power cycle)."
+            )
+            if self.mode == "abort":
+                raise StartupMismatchError(message)
+
+            logger.warning("%s Ramping to the target over %.1f s.", message, self.ramp_duration_s)
+            self._ramping = True
+            self._ramp_start_ts = now
+            self._ramp_base = {key: meas for key, (_cmd, meas) in pairs.items()}
+
+        if self._ramping and self._ramp_start_ts is not None:
+            alpha = (now - self._ramp_start_ts) / self.ramp_duration_s
+            if alpha >= 1.0:
+                self._ramping = False
+                self._ramp_base = {}
+                return action
+            blended = dict(action)
+            for key, base in self._ramp_base.items():
+                cmd = blended.get(key)
+                if isinstance(cmd, (int, float)):
+                    blended[key] = base + alpha * (float(cmd) - base)
+            return blended
+
+        return action
+
+    def reset(self) -> None:
+        """Re-arm the guard (e.g. after a reconnection or a new episode)."""
+        self._armed = True
+        self._ramping = False
+        self._ramp_start_ts = None
+        self._ramp_base = {}
+
+
+class StartupMismatchError(RuntimeError):
+    """Raised in ``"abort"`` mode when the first commanded frame disagrees with the measured state."""

--- a/tests/utils/test_startup_guard.py
+++ b/tests/utils/test_startup_guard.py
@@ -1,0 +1,107 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the startup joint-mismatch guard (pure logic, no hardware)."""
+
+import pytest
+
+from lerobot.utils.startup_guard import StartupJointGuard, StartupMismatchError
+
+
+def test_pass_through_when_agreeing():
+    guard = StartupJointGuard(threshold=10.0)
+    action = {"shoulder_pan.pos": 1.0, "gripper.pos": -5.0}
+    obs = {"shoulder_pan.pos": 0.5, "gripper.pos": -4.0}
+    out = guard.process(action, obs, now=0.0)
+    assert out is action
+    assert not guard.is_ramping
+    # Subsequent frames stay pass-through even with huge deltas (guard is disarmed).
+    wild = {"shoulder_pan.pos": 500.0}
+    assert guard.process(wild, obs, now=0.1) is wild
+
+
+def test_first_frame_mismatch_triggers_ramp():
+    guard = StartupJointGuard(threshold=10.0, ramp_duration_s=1.0)
+    # The verified real-world case: a 2*pi-wrapped multi-turn gripper. Leader streams
+    # +356.8 deg while the follower measures ~0 (physically closed).
+    action = {"gripper.pos": 356.8, "shoulder_pan.pos": 0.2}
+    obs = {"gripper.pos": -0.5, "shoulder_pan.pos": 0.0}
+    out = guard.process(action, obs, now=0.0)
+    assert guard.is_ramping
+    # At t=0 the command must equal the measured position, not the target.
+    assert out["gripper.pos"] == pytest.approx(-0.5)
+    # Joints within threshold ramp too (base captured for all pairs), starting at measured.
+    assert out["shoulder_pan.pos"] == pytest.approx(0.0)
+
+    # Halfway through the ramp: halfway between measured and the live target.
+    out = guard.process(action, obs, now=0.5)
+    assert out["gripper.pos"] == pytest.approx(-0.5 + 0.5 * (356.8 - (-0.5)))
+
+    # After the ramp: exact pass-through again.
+    out = guard.process(action, obs, now=1.5)
+    assert out is action
+    assert not guard.is_ramping
+
+
+def test_ramp_tracks_moving_target():
+    guard = StartupJointGuard(threshold=1.0, ramp_duration_s=1.0)
+    obs = {"j1.pos": 0.0}
+    guard.process({"j1.pos": 100.0}, obs, now=0.0)
+    # Target moved mid-ramp: blend goes toward the NEW target (leader keeps authority).
+    out = guard.process({"j1.pos": 50.0}, obs, now=0.5)
+    assert out["j1.pos"] == pytest.approx(0.0 + 0.5 * 50.0)
+
+
+def test_abort_mode_raises_with_offending_joints():
+    guard = StartupJointGuard(threshold=10.0, mode="abort")
+    action = {"gripper.pos": 356.8, "shoulder_pan.pos": 0.0}
+    obs = {"gripper.pos": -0.5, "shoulder_pan.pos": 0.0}
+    with pytest.raises(StartupMismatchError, match="gripper.pos"):
+        guard.process(action, obs, now=0.0)
+
+
+def test_ignores_non_pos_and_missing_keys():
+    guard = StartupJointGuard(threshold=1.0)
+    action = {"j1.vel": 999.0, "j2.pos": 5.0, "camera": object()}
+    obs = {"j1.vel": 0.0}  # j2.pos missing from obs -> not comparable -> ignored
+    out = guard.process(action, obs, now=0.0)
+    assert out is action
+    assert not guard.is_ramping
+
+
+def test_reset_rearms():
+    guard = StartupJointGuard(threshold=1.0, ramp_duration_s=1.0)
+    obs = {"j1.pos": 0.0}
+    assert guard.process({"j1.pos": 0.5}, obs, now=0.0) is not None
+    assert not guard.is_ramping  # agreed -> disarmed
+    guard.reset()
+    guard.process({"j1.pos": 100.0}, obs, now=10.0)
+    assert guard.is_ramping  # re-armed guard caught the new mismatch
+
+
+def test_disabled_guard_is_pass_through():
+    guard = StartupJointGuard(threshold=0.1, enabled=False)
+    action = {"j1.pos": 1000.0}
+    obs = {"j1.pos": 0.0}
+    assert guard.process(action, obs, now=0.0) is action
+    assert not guard.is_ramping
+
+
+def test_invalid_params_rejected():
+    with pytest.raises(ValueError):
+        StartupJointGuard(mode="explode")
+    with pytest.raises(ValueError):
+        StartupJointGuard(threshold=0.0)
+    with pytest.raises(ValueError):
+        StartupJointGuard(ramp_duration_s=-1.0)


### PR DESCRIPTION
## What this does

The first action of every teleoperation / recording session is sent to the robot unconditionally: nothing verifies that the teleoperator (or policy) and the follower agree on where the joints currently are. Any constant offset between the two conventions materializes as a **full-speed jump on frame zero**, usually silently absorbed by soft-limit clipping — the operator only sees the robot slam.

This PR adds `StartupJointGuard`, a robot-agnostic first-frame safety check wired into `lerobot-teleoperate` and `lerobot-record`:

- On the first frame, every `{joint}.pos` key present in **both** the action and the observation is compared.
- If all deltas are within `--startup_guard_threshold` (default 10, action units), the guard disarms and becomes a pass-through (zero steady-state overhead).
- On a mismatch, the commanded positions are **blended from the measured pose to the live target** over `--startup_guard_ramp_s` seconds (default 1.5 s), so the robot converges smoothly instead of jumping. `--startup_guard_mode=abort` raises instead, listing the offending joints, for users who prefer a hard fail.
- In `lerobot-record` the guard re-arms at every episode (reconnections and manual resets can reintroduce a mismatch mid-session).
- `--startup_guard=false` switches it off entirely.

The guard is pure dict inspection — no robot- or teleop-specific code, works for every joint-space robot in the registry, and ignores keys that are not `.pos` floats present on both sides (Cartesian teleops, cameras, velocities pass through untouched).

## Why (two real incidents, same failure class, different robots)

1. **SO-101:** a gripper drive direction that calibration recorded wrong commanded a full-speed slam on the first teleop frame and stripped a follower motor gear (#3948 fixes the calibration side; this guard would have reduced it to a slow ramp).
2. **reBot B601 (Damiao motors):** the multi-turn gripper encoder loses its turn count across power cycles (single-turn zero survives, turn count does not). A physically closed gripper (travel `[-270, 0]` deg) woke up reading **+356.8 deg = -0.056 rad + 2π** — verified on hardware via two independent decode paths. The soft-limit clip silently turned that into a full-close command at t=0. No static calibration offset can fix this (travel > 2π makes the branch ambiguous), so a generic first-frame guard is the right backstop layer.

Both incidents share the same signature: *teleop and follower disagree on convention → unconditional first `send_action()` → silent clip → mechanical slam*. The guard defuses the entire class, including future robots with conventions nobody has broken yet.

## Test plan

- `tests/utils/test_startup_guard.py` — 8 unit tests, pure logic, no hardware: pass-through on agreement, ramp starts at measured pose / tracks a moving target / hands over exactly at ramp end, abort mode raises with offending joints, non-`.pos` and one-sided keys ignored, `reset()` re-arms, disabled guard is inert, invalid params rejected.
- Mutation check: disabling the mismatch predicate makes the tests fail (the tests actually guard the logic).
- `pre-commit run` clean on all touched files.
- Hardware: the reBot B601 wrapped-gripper state was reproduced on a real arm and the first-frame delta this guard targets was measured live (+6.227 rad read on a physically closed gripper).

## Notes

- Default is `ramp` rather than `abort` to keep existing workflows running (a false positive costs 1.5 s of slew, not a dead session). Threshold of 10 units is deliberately loose — it only needs to catch convention-level disagreements (sign flips, 2π wraps, stale zeros), which show up as tens-to-hundreds of units.
- The ramp rewrites only the commanded positions during the blend window; the action dict is otherwise passed through untouched, and the blended action is what gets recorded in datasets (matching what was actually sent, consistent with the existing `max_relative_target` semantics).
