### PR TITLE
feat(examples): add reBot DevArm leader device to the Isaac Teleop example

### DIFF
--- a/docs/source/isaac_teleop.mdx
+++ b/docs/source/isaac_teleop.mdx
@@ -297,6 +297,38 @@ The URDF fetch uses `huggingface_hub` (already a LeRobot dependency) against the
 `lerobot/robot-urdfs` bucket, so it needs no login. It is cached under
 `HF_LEROBOT_HOME/robot-urdfs/so101/`; delete that folder to force a re‑download.
 
+### reBot DevArm leader (Damiao)
+
+The third device, `--teleop.type=rebot_devarm_leader` (`RebotDevArmLeaderArm`), does the same 1:1
+joint mirror for the Seeed Studio reBot DevArm (B601-DM: 6-DOF + gripper, seven Damiao CAN
+motors) onto LeRobot's `rebot_b601_follower` — the identical arm hardware, so every joint
+including the gripper is a plain rad→deg mirror with **no** gripper normalization (the
+follower's soft `joint_limits` clip out-of-range targets). Isaac Teleop's native
+`rebot_devarm_leader` plugin owns the Damiao USB-to-CAN serial bus: it torque-disables the
+motors (Damiao motors keep answering feedback requests while disabled, which is what makes the
+leader back-drivable) and streams the decoded joint angles in radians.
+
+Like `so101_leader_plugin`, the `rebot_devarm_leader_plugin` binary is built from the Isaac
+Teleop source tree and lands at `install/plugins/rebot_devarm_leader/rebot_devarm_leader_plugin`;
+pass it via `--launch_plugin` (or start it yourself; an empty `--teleop.port` runs its synthetic,
+hardware-free trajectory):
+
+```bash
+python -m examples.isaac_teleop_to_so101.teleoperate --robot.type=rebot_b601_follower \
+    --robot.port=/dev/ttyACM0 --robot.id=rebot_b601_follower_arm --teleop.type=rebot_devarm_leader \
+    --teleop.port=/dev/ttyACM1 \
+    --launch_plugin=/code/Teleop/install/plugins/rebot_devarm_leader/rebot_devarm_leader_plugin
+```
+
+`--teleop.joint_name_map` renames the plugin's URDF joint names (`joint1..joint6, gripper`) to
+the follower motor names and can be overridden for a differently-named follower. The plugin has
+its own plain-text calibration format (see its `README.md`), so no LeRobot calibration JSON is
+forwarded. Before trusting the wiring, run the plugin's `probe` subcommand
+(`rebot_devarm_leader_plugin probe /dev/ttyACM0`) — it verifies the bus, motor ids, and decode
+path with no OpenXR runtime and exits 0 when all seven motors reply (exit code 3 means the
+gripper reads outside its physical travel — its multi-turn encoder wrapped after a power cycle;
+re-home it before teleoperating).
+
 Then, in your headset: squeeze and hold the grip to engage, move the controller to drive the
 arm, twist/tilt it to orient the wrist, and press the trigger to close the gripper
 (proportionally — release to open).

--- a/docs/source/isaac_teleop.mdx
+++ b/docs/source/isaac_teleop.mdx
@@ -297,26 +297,41 @@ The URDF fetch uses `huggingface_hub` (already a LeRobot dependency) against the
 `lerobot/robot-urdfs` bucket, so it needs no login. It is cached under
 `HF_LEROBOT_HOME/robot-urdfs/so101/`; delete that folder to force a re‑download.
 
-### reBot DevArm leader (Damiao)
+### reBot DevArm leader (Damiao or RobStride)
 
 The third device, `--teleop.type=rebot_devarm_leader` (`RebotDevArmLeaderArm`), does the same 1:1
-joint mirror for the Seeed Studio reBot DevArm (B601-DM: 6-DOF + gripper, seven Damiao CAN
-motors) onto LeRobot's `rebot_b601_follower` — the identical arm hardware, so every joint
-including the gripper is a plain rad→deg mirror with **no** gripper normalization (the
-follower's soft `joint_limits` clip out-of-range targets). Isaac Teleop's native
-`rebot_devarm_leader` plugin owns the Damiao USB-to-CAN serial bus: it torque-disables the
-motors (Damiao motors keep answering feedback requests while disabled, which is what makes the
-leader back-drivable) and streams the decoded joint angles in radians.
+joint mirror for the Seeed Studio reBot DevArm (6-DOF + gripper, seven CAN motors) onto LeRobot's
+`rebot_b601_follower` — the identical arm hardware, so every joint including the gripper is a
+plain rad→deg mirror with **no** gripper normalization (the follower's soft `joint_limits` clip
+out-of-range targets). Isaac Teleop's native `rebot_devarm_leader` plugin owns the motor bus: it
+torque-disables the motors (they keep answering feedback requests while disabled, which is what
+makes the leader back-drivable) and streams the decoded joint angles in radians.
+
+Both DevArm builds are supported and the plugin picks its backend from the shape of
+`--teleop.port`:
+
+- **B601-DM (Damiao)** — a serial path (e.g. `--teleop.port=/dev/ttyACM1`) selects the Damiao
+  dm-serial backend (USB-to-CAN adapter).
+- **B601-RS (RobStride)** — a bare SocketCAN interface name (e.g. `--teleop.port=can0`) selects
+  the RobStride backend. Bring the interface up first:
+  `sudo ip link set can0 up type can bitrate 1000000`.
+- An empty `--teleop.port` runs the plugin's synthetic, hardware-free trajectory.
 
 Like `so101_leader_plugin`, the `rebot_devarm_leader_plugin` binary is built from the Isaac
 Teleop source tree and lands at `install/plugins/rebot_devarm_leader/rebot_devarm_leader_plugin`;
-pass it via `--launch_plugin` (or start it yourself; an empty `--teleop.port` runs its synthetic,
-hardware-free trajectory):
+pass it via `--launch_plugin` (or start it yourself):
 
 ```bash
+# Damiao build (serial adapter):
 python -m examples.isaac_teleop_to_so101.teleoperate --robot.type=rebot_b601_follower \
     --robot.port=/dev/ttyACM0 --robot.id=rebot_b601_follower_arm --teleop.type=rebot_devarm_leader \
     --teleop.port=/dev/ttyACM1 \
+    --launch_plugin=/code/Teleop/install/plugins/rebot_devarm_leader/rebot_devarm_leader_plugin
+
+# RobStride build (SocketCAN):
+python -m examples.isaac_teleop_to_so101.teleoperate --robot.type=rebot_b601_follower \
+    --robot.port=/dev/ttyACM0 --robot.id=rebot_b601_follower_arm --teleop.type=rebot_devarm_leader \
+    --teleop.port=can0 \
     --launch_plugin=/code/Teleop/install/plugins/rebot_devarm_leader/rebot_devarm_leader_plugin
 ```
 
@@ -324,10 +339,10 @@ python -m examples.isaac_teleop_to_so101.teleoperate --robot.type=rebot_b601_fol
 the follower motor names and can be overridden for a differently-named follower. The plugin has
 its own plain-text calibration format (see its `README.md`), so no LeRobot calibration JSON is
 forwarded. Before trusting the wiring, run the plugin's `probe` subcommand
-(`rebot_devarm_leader_plugin probe /dev/ttyACM0`) — it verifies the bus, motor ids, and decode
-path with no OpenXR runtime and exits 0 when all seven motors reply (exit code 3 means the
-gripper reads outside its physical travel — its multi-turn encoder wrapped after a power cycle;
-re-home it before teleoperating).
+(`rebot_devarm_leader_plugin probe /dev/ttyACM0`, or `probe can0` on the RobStride build) — it
+verifies the bus, motor ids, and decode path with no OpenXR runtime and exits 0 when all seven
+motors reply (exit code 3 means the gripper reads outside its physical travel — its multi-turn
+encoder wrapped after a power cycle; re-home it before teleoperating).
 
 Then, in your headset: squeeze and hold the grip to engage, move the controller to drive the
 arm, twist/tilt it to orient the wrist, and press the trigger to close the gripper

--- a/examples/isaac_teleop_to_so101/README.md
+++ b/examples/isaac_teleop_to_so101/README.md
@@ -9,9 +9,9 @@ Teleoperate an SO-101/SO-100 follower arm — and record LeRobot datasets — wi
 - **SO-101 leader arm** (`--teleop.type=so101_leader`) — a back-drivable leader arm mirrored 1:1
   onto the follower via Isaac Teleop's native `so101_leader` plugin (no clutch, no IK).
 - **reBot DevArm leader arm** (`--teleop.type=rebot_devarm_leader`) — the same 1:1 joint mirror
-  for a back-drivable Seeed Studio reBot DevArm (B601-DM, seven Damiao CAN motors) onto LeRobot's
-  `rebot_b601_follower` (identical hardware, gripper included, no normalization), via the native
-  `rebot_devarm_leader` plugin.
+  for a back-drivable Seeed Studio reBot DevArm (seven CAN motors: Damiao on the B601-DM build,
+  RobStride on the B601-RS build) onto LeRobot's `rebot_b601_follower` (identical hardware,
+  gripper included, no normalization), via the native `rebot_devarm_leader` plugin.
 
 The full narrative guide (how the clutch works, CloudXR setup, headset pairing, tuning, and
 troubleshooting) is in the [LeRobot docs](https://huggingface.co/docs/lerobot/isaac_teleop)
@@ -111,10 +111,13 @@ python -m examples.isaac_teleop_to_so101.teleoperate \
 ```
 
 Same flow as the SO-101 leader (align slew, then 1:1 mirror), driving LeRobot's
-`rebot_b601_follower`. The plugin has its own plain-text calibration format (see its README
-next to the binary); run its `probe` subcommand first to verify wiring — exit code 3 means the
-gripper's multi-turn encoder wrapped after a power cycle and must be re-homed before
-teleoperating.
+`rebot_b601_follower`. The plugin selects its motor backend from the `--teleop.port` shape: a
+serial path (`/dev/ttyACM1`) drives the Damiao build, a bare SocketCAN interface name
+(`--teleop.port=can0`, after `sudo ip link set can0 up type can bitrate 1000000`) drives the
+RobStride build, and an empty port runs the hardware-free synthetic trajectory. The plugin has
+its own plain-text calibration format (see its README next to the binary); run its `probe`
+subcommand first to verify wiring — exit code 3 means the gripper's multi-turn encoder wrapped
+after a power cycle and must be re-homed before teleoperating.
 
 ### Record a dataset
 

--- a/examples/isaac_teleop_to_so101/README.md
+++ b/examples/isaac_teleop_to_so101/README.md
@@ -1,13 +1,17 @@
 # Isaac Teleop → SO-101
 
 Teleoperate an SO-101/SO-100 follower arm — and record LeRobot datasets — with NVIDIA
-[Isaac Teleop](https://github.com/NVIDIA/IsaacTeleop). Two input devices ship today:
+[Isaac Teleop](https://github.com/NVIDIA/IsaacTeleop). Three input devices ship today:
 
 - **XR (VR) controller** (`--teleop.type=xr_controller`) — the controller's grip pose drives the
   end-effector through a squeeze-to-engage clutch and LeRobot's Cartesian IK pipeline; the analog
   trigger drives the gripper.
 - **SO-101 leader arm** (`--teleop.type=so101_leader`) — a back-drivable leader arm mirrored 1:1
   onto the follower via Isaac Teleop's native `so101_leader` plugin (no clutch, no IK).
+- **reBot DevArm leader arm** (`--teleop.type=rebot_devarm_leader`) — the same 1:1 joint mirror
+  for a back-drivable Seeed Studio reBot DevArm (B601-DM, seven Damiao CAN motors) onto LeRobot's
+  `rebot_b601_follower` (identical hardware, gripper included, no normalization), via the native
+  `rebot_devarm_leader` plugin.
 
 The full narrative guide (how the clutch works, CloudXR setup, headset pairing, tuning, and
 troubleshooting) is in the [LeRobot docs](https://huggingface.co/docs/lerobot/isaac_teleop)
@@ -96,6 +100,21 @@ python -m examples.isaac_teleop_to_so101.teleoperate \
 The follower is first slewed to the leader's pose over `--align_duration` seconds
 (`--align=false` to skip), then mirrors it 1:1. The plugin reuses the serial leader's calibration
 (`HF_LEROBOT_CALIBRATION/teleoperators/so_leader/<teleop.id>.json`).
+
+### Teleoperate — reBot DevArm leader arm
+
+```bash
+python -m examples.isaac_teleop_to_so101.teleoperate \
+    --robot.type=rebot_b601_follower --robot.port=/dev/ttyACM0 --robot.id=rebot_b601_follower_arm \
+    --teleop.type=rebot_devarm_leader --teleop.port=/dev/ttyACM1 \
+    --launch_plugin=/path/to/IsaacTeleop/install/plugins/rebot_devarm_leader/rebot_devarm_leader_plugin
+```
+
+Same flow as the SO-101 leader (align slew, then 1:1 mirror), driving LeRobot's
+`rebot_b601_follower`. The plugin has its own plain-text calibration format (see its README
+next to the binary); run its `probe` subcommand first to verify wiring — exit code 3 means the
+gripper's multi-turn encoder wrapped after a power cycle and must be re-homed before
+teleoperating.
 
 ### Record a dataset
 

--- a/examples/isaac_teleop_to_so101/common.py
+++ b/examples/isaac_teleop_to_so101/common.py
@@ -51,6 +51,9 @@ from lerobot.processor import (
     transition_to_robot_action,
 )
 from lerobot.robots import RobotConfig, make_robot_from_config
+from lerobot.robots.rebot_b601_follower import (
+    RebotB601FollowerRobotConfig,  # noqa: F401  (registers rebot_b601_follower)
+)
 from lerobot.robots.so_follower import SOFollowerConfig  # noqa: F401  (registers so101_follower)
 from lerobot.robots.so_follower.robot_kinematic_processor import (
     EEBoundsAndSafety,
@@ -64,6 +67,8 @@ from .isaac_teleop import (
     Clutch,
     IsaacTeleopConfig,
     MapXRControllerActionToRobotAction,
+    RebotDevArmLeaderArm,
+    RebotDevArmLeaderArmConfig,
     SO101LeaderArm,
     SO101LeaderArmConfig,
     XRController,
@@ -432,6 +437,10 @@ def _leader_calibration_path(cfg: LoopConfig) -> Path | None:
     (or ``--teleop.calibration_dir`` if set). Returns None (plugin falls back to defaults) when
     it does not exist, warning if an id was given, or when no ``--teleop.id`` is set.
     """
+    if isinstance(cfg.teleop, RebotDevArmLeaderArmConfig):
+        # The reBot DevArm plugin has its own plain-text calibration format (not the serial
+        # SO-101 leader's JSON); pass none and let the plugin use its factory defaults.
+        return None
     if not cfg.teleop.id:
         return None
     calib_dir = cfg.teleop.calibration_dir or (
@@ -448,13 +457,13 @@ def _leader_calibration_path(cfg: LoopConfig) -> Path | None:
     return None
 
 
-def _wait_for_leader(teleop: SO101LeaderArm, timeout_s: float) -> dict[str, float]:
+def _wait_for_leader(teleop: SO101LeaderArm | RebotDevArmLeaderArm, timeout_s: float) -> dict[str, float]:
     """Poll the leader until it streams a live frame; return that frame's ``{joint}.pos``.
 
     Raises ``SystemExit`` if no live frame arrives within ``timeout_s`` (plugin not pushing,
     wrong ``--teleop.collection_id``, or CloudXR not up).
     """
-    print(f"Waiting up to {timeout_s:.0f}s for the so101_leader plugin to stream…")
+    print(f"Waiting up to {timeout_s:.0f}s for the leader plugin to stream…")
     deadline = time.time() + timeout_s
     while time.time() < deadline:
         action = teleop.get_action()
@@ -463,7 +472,7 @@ def _wait_for_leader(teleop: SO101LeaderArm, timeout_s: float) -> dict[str, floa
             return action
         time.sleep(1.0 / FPS)
     raise SystemExit(
-        f"FAILED: leader did not stream within {timeout_s:.0f}s. Is the so101_leader plugin "
+        f"FAILED: leader did not stream within {timeout_s:.0f}s. Is the leader plugin "
         "running and pushing (check --teleop.collection_id)? Is CloudXR up?"
     )
 
@@ -494,9 +503,12 @@ def _maybe_launch_plugin(cfg: LoopConfig) -> subprocess.Popen | None:
 
 
 def setup_leader(cfg: LoopConfig, robot, motor_names: list[str]) -> Device:
-    """Build the SO-101 leader arm device bundle (1:1 joint mirror)."""
-    teleop_config = cfg.teleop  # SO101LeaderArmConfig (selected via --teleop.type=so101_leader)
-    teleop = SO101LeaderArm(teleop_config)
+    """Build a joint-mirror leader arm device bundle (SO-101 or reBot DevArm, 1:1)."""
+    teleop_config = cfg.teleop  # selected via --teleop.type=so101_leader|rebot_devarm_leader
+    if isinstance(teleop_config, RebotDevArmLeaderArmConfig):
+        teleop = RebotDevArmLeaderArm(teleop_config)
+    else:
+        teleop = SO101LeaderArm(teleop_config)
 
     plugin_proc: subprocess.Popen | None = None
 
@@ -572,11 +584,18 @@ def build_device(cfg: LoopConfig) -> tuple:
     if cfg.teleop.cloudxr_env_file is None:
         cfg.teleop.cloudxr_env_file = CLOUDXR_ENV_FILE
 
-    # SO-101/SO-100 only (both share the SO-101 URDF), reject other followers.
-    supported_robots = {"so101_follower", "so100_follower"}
+    # Follower support depends on the input device: the XR/IK path relies on the SO-101 URDF
+    # (SO-101/SO-100 only); joint-mirror leaders additionally pair the reBot DevArm leader
+    # with its same-hardware rebot_b601_follower.
+    if isinstance(cfg.teleop, RebotDevArmLeaderArmConfig):
+        supported_robots = {"rebot_b601_follower"}
+    elif isinstance(cfg.teleop, SO101LeaderArmConfig):
+        supported_robots = {"so101_follower", "so100_follower"}
+    else:
+        supported_robots = {"so101_follower", "so100_follower"}
     if cfg.robot.type not in supported_robots:
         raise ValueError(
-            f"This example only supports SO-101/SO-100 followers ({sorted(supported_robots)}), "
+            f"--teleop.type={cfg.teleop.type} supports followers {sorted(supported_robots)}, "
             f"but got --robot.type={cfg.robot.type}."
         )
 
@@ -591,7 +610,7 @@ def build_device(cfg: LoopConfig) -> tuple:
         # Joint names in action order, read from {name}.pos action features (robot-agnostic).
         motor_names = [key.removesuffix(".pos") for key in robot.action_features if key.endswith(".pos")]
 
-        if isinstance(cfg.teleop, SO101LeaderArmConfig):
+        if isinstance(cfg.teleop, (SO101LeaderArmConfig, RebotDevArmLeaderArmConfig)):
             device = setup_leader(cfg, robot, motor_names)
         else:
             device = setup_xr(cfg, robot, motor_names)

--- a/examples/isaac_teleop_to_so101/isaac_teleop/__init__.py
+++ b/examples/isaac_teleop_to_so101/isaac_teleop/__init__.py
@@ -17,12 +17,19 @@
 """NVIDIA Isaac Teleop teleoperators for LeRobot.
 
 Each input device is an :class:`IsaacTeleopTeleoperator` subclass: :class:`XRController`
-(XR/VR controller) and :class:`SO101LeaderArm` (back-drivable SO-101 leader arm) ship today.
+(XR/VR controller), :class:`SO101LeaderArm` (back-drivable SO-101 leader arm), and
+:class:`RebotDevArmLeaderArm` (back-drivable Seeed reBot DevArm leader) ship today.
 """
 
 from .base import IsaacTeleopTeleoperator
 from .clutch import Clutch
-from .config_isaac_teleop import IsaacTeleopConfig, SO101LeaderArmConfig, XRControllerConfig
+from .config_isaac_teleop import (
+    IsaacTeleopConfig,
+    RebotDevArmLeaderArmConfig,
+    SO101LeaderArmConfig,
+    XRControllerConfig,
+)
+from .teleop_rebot_devarm_leader_arm import RebotDevArmLeaderArm, rebot_leader_joints_to_robot_action
 from .teleop_so101_leader_arm import SO101LeaderArm, leader_joints_to_robot_action
 from .teleop_xr_controller import XRController
 from .xr_controller_processor import MapXRControllerActionToRobotAction
@@ -32,9 +39,12 @@ __all__ = [
     "IsaacTeleopConfig",
     "IsaacTeleopTeleoperator",
     "MapXRControllerActionToRobotAction",
+    "RebotDevArmLeaderArm",
+    "RebotDevArmLeaderArmConfig",
     "SO101LeaderArm",
     "SO101LeaderArmConfig",
     "XRController",
     "XRControllerConfig",
     "leader_joints_to_robot_action",
+    "rebot_leader_joints_to_robot_action",
 ]

--- a/examples/isaac_teleop_to_so101/isaac_teleop/config_isaac_teleop.py
+++ b/examples/isaac_teleop_to_so101/isaac_teleop/config_isaac_teleop.py
@@ -133,3 +133,46 @@ class SO101LeaderArmConfig(IsaacTeleopConfig):
     gripper_close_rad: float = _DEFAULT_GRIPPER_CLOSE_RAD
     """Leader gripper angle [rad] at fully CLOSED -> follower jaw 0. Provisional default;
     set from the plugin's ``calibrate`` subcommand. See ``_DEFAULT_GRIPPER_CLOSE_RAD``."""
+
+
+# Stream (URDF) joint names -> rebot_b601_follower motor names, in stream order. The plugin
+# streams the ``reBot-DevArm_fixend`` URDF names; the follower names its seven Damiao motors
+# functionally. Same physical joints, so the mapping is a pure rename.
+_DEFAULT_REBOT_JOINT_NAME_MAP: dict[str, str] = {
+    "joint1": "shoulder_pan",
+    "joint2": "shoulder_lift",
+    "joint3": "elbow_flex",
+    "joint4": "wrist_flex",
+    "joint5": "wrist_yaw",
+    "joint6": "wrist_roll",
+    "gripper": "gripper",
+}
+
+
+@IsaacTeleopConfig.register_subclass("rebot_devarm_leader")
+@dataclass(kw_only=True)
+class RebotDevArmLeaderArmConfig(IsaacTeleopConfig):
+    """Config for an Isaac Teleop reBot DevArm *leader arm* (generic joint-space device).
+
+    Mirrors the leader's joint angles 1:1 onto a follower reBot B601-DM (LeRobot's
+    ``rebot_b601_follower``) — the same 6-DOF + gripper Damiao hardware, so no IK, clutch,
+    retargeter, or gripper normalization is needed. The leader state is streamed in radians
+    by the native ``rebot_devarm_leader`` plugin (which torque-disables the motors so the
+    arm is back-drivable) and read via a ``JointStateSource``; the device converts all
+    joints to degrees and renames them via :attr:`joint_name_map`.
+    """
+
+    port: str = ""
+    """Serial device of the physical LEADER arm's Damiao USB-to-CAN adapter (e.g.
+    ``/dev/ttyACM0``), forwarded to the plugin (which owns the bus) when the example
+    launches it. Empty -> the plugin runs its synthetic trajectory."""
+
+    collection_id: str = "rebot_devarm_leader"
+    """Tensor collection id the leader plugin pushes on; must match the running
+    ``rebot_devarm_leader`` plugin (its second positional arg, default
+    ``"rebot_devarm_leader"``)."""
+
+    joint_name_map: dict[str, str] = field(default_factory=lambda: dict(_DEFAULT_REBOT_JOINT_NAME_MAP))
+    """Stream (URDF) joint name -> follower motor name. Defaults to the
+    ``rebot_b601_follower`` motor names; override to drive a follower with a different
+    naming scheme. Stream joints absent from the map are dropped from the action."""

--- a/examples/isaac_teleop_to_so101/isaac_teleop/config_isaac_teleop.py
+++ b/examples/isaac_teleop_to_so101/isaac_teleop/config_isaac_teleop.py
@@ -154,18 +154,22 @@ _DEFAULT_REBOT_JOINT_NAME_MAP: dict[str, str] = {
 class RebotDevArmLeaderArmConfig(IsaacTeleopConfig):
     """Config for an Isaac Teleop reBot DevArm *leader arm* (generic joint-space device).
 
-    Mirrors the leader's joint angles 1:1 onto a follower reBot B601-DM (LeRobot's
-    ``rebot_b601_follower``) — the same 6-DOF + gripper Damiao hardware, so no IK, clutch,
-    retargeter, or gripper normalization is needed. The leader state is streamed in radians
-    by the native ``rebot_devarm_leader`` plugin (which torque-disables the motors so the
-    arm is back-drivable) and read via a ``JointStateSource``; the device converts all
-    joints to degrees and renames them via :attr:`joint_name_map`.
+    Mirrors the leader's joint angles 1:1 onto a follower reBot B601 (LeRobot's
+    ``rebot_b601_follower``) — the same 6-DOF + gripper hardware, so no IK, clutch,
+    retargeter, or gripper normalization is needed. Both DevArm builds work: the plugin
+    drives Damiao motors over a dm-serial adapter (B601-DM) or RobStride motors over
+    SocketCAN (B601-RS), selected by the shape of :attr:`port`. The leader state is streamed
+    in radians by the native ``rebot_devarm_leader`` plugin (which torque-disables the
+    motors so the arm is back-drivable) and read via a ``JointStateSource``; the device
+    converts all joints to degrees and renames them via :attr:`joint_name_map`.
     """
 
     port: str = ""
-    """Serial device of the physical LEADER arm's Damiao USB-to-CAN adapter (e.g.
-    ``/dev/ttyACM0``), forwarded to the plugin (which owns the bus) when the example
-    launches it. Empty -> the plugin runs its synthetic trajectory."""
+    """Device of the physical LEADER arm, forwarded to the plugin (which owns the bus) when
+    the example launches it. The plugin picks its backend from the path shape: a serial path
+    (e.g. ``/dev/ttyACM0``) selects the Damiao dm-serial backend (B601-DM build), a bare
+    SocketCAN interface name (e.g. ``can0``) selects the RobStride backend (B601-RS build),
+    and empty runs the hardware-free synthetic trajectory."""
 
     collection_id: str = "rebot_devarm_leader"
     """Tensor collection id the leader plugin pushes on; must match the running

--- a/examples/isaac_teleop_to_so101/isaac_teleop/teleop_rebot_devarm_leader_arm.py
+++ b/examples/isaac_teleop_to_so101/isaac_teleop/teleop_rebot_devarm_leader_arm.py
@@ -16,10 +16,13 @@
 
 """reBot DevArm leader-arm device for NVIDIA Isaac Teleop, exposed to LeRobot.
 
-The leader is a back-drivable Seeed Studio reBot DevArm (B601-DM: 6-DOF + gripper, seven
-Damiao CAN motors) whose joint angles are streamed in radians by Isaac Teleop's native
-``rebot_devarm_leader`` plugin; this device reads them via a ``JointStateSource`` and
-converts them into follower-ready ``{joint}.pos``.
+The leader is a back-drivable Seeed Studio reBot DevArm (6-DOF + gripper, seven CAN
+motors — Damiao on the B601-DM build, RobStride on the B601-RS build) whose joint angles
+are streamed in radians by Isaac Teleop's native ``rebot_devarm_leader`` plugin; this
+device reads them via a ``JointStateSource`` and converts them into follower-ready
+``{joint}.pos``. The motor backend is the plugin's concern (selected by the device path it
+is launched with: serial path -> Damiao, SocketCAN name -> RobStride); this device is
+backend-agnostic.
 
 The natural follower is LeRobot's ``rebot_b601_follower`` — the SAME arm hardware — so the
 mirror is 1:1 in joint space: every streamed angle (gripper included) is converted

--- a/examples/isaac_teleop_to_so101/isaac_teleop/teleop_rebot_devarm_leader_arm.py
+++ b/examples/isaac_teleop_to_so101/isaac_teleop/teleop_rebot_devarm_leader_arm.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python
+
+# Copyright 2026 NVIDIA Corporation and The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""reBot DevArm leader-arm device for NVIDIA Isaac Teleop, exposed to LeRobot.
+
+The leader is a back-drivable Seeed Studio reBot DevArm (B601-DM: 6-DOF + gripper, seven
+Damiao CAN motors) whose joint angles are streamed in radians by Isaac Teleop's native
+``rebot_devarm_leader`` plugin; this device reads them via a ``JointStateSource`` and
+converts them into follower-ready ``{joint}.pos``.
+
+The natural follower is LeRobot's ``rebot_b601_follower`` — the SAME arm hardware — so the
+mirror is 1:1 in joint space: every streamed angle (gripper included) is converted
+``rad2deg`` and renamed from the plugin's URDF joint names (``joint1..joint6, gripper``) to
+the follower's motor names via :attr:`RebotDevArmLeaderArmConfig.joint_name_map`. The
+follower's own soft ``joint_limits`` clip out-of-range targets, so no extra normalization
+is applied here.
+
+``isaacteleop`` imports are guarded behind the availability flag so this module — and the
+pure :func:`rebot_leader_joints_to_robot_action` converter — import without it
+(construction fails fast via the base class).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from lerobot.types import RobotAction
+
+from .base import IsaacTeleopTeleoperator, _isaacteleop_available
+from .config_isaac_teleop import RebotDevArmLeaderArmConfig
+from .teleop_so101_leader_arm import _joints_group_to_rad
+
+if TYPE_CHECKING or _isaacteleop_available:
+    from isaacteleop.retargeting_engine.deviceio_source_nodes import JointStateSource
+    from isaacteleop.retargeting_engine.interface import OutputCombiner
+else:
+    JointStateSource = None
+    OutputCombiner = None
+
+# Canonical reBot DevArm DOF names and order — matches the ``rebot_devarm_leader`` plugin
+# stream (the ``reBot-DevArm_fixend`` URDF order: six arm joints then the gripper motor).
+# Passed to the ``JointStateSource`` as its output layout; the source maps by name and
+# ``_joints_group_to_rad`` reads back by name, so a layout mismatch can't mislabel a DOF.
+REBOT_DEVARM_LEADER_JOINTS = [
+    "joint1",
+    "joint2",
+    "joint3",
+    "joint4",
+    "joint5",
+    "joint6",
+    "gripper",
+]
+
+
+def rebot_leader_joints_to_robot_action(
+    joints_rad: dict[str, float],
+    *,
+    joint_name_map: dict[str, str],
+) -> RobotAction:
+    """Convert streamed leader joint angles [rad] to follower-ready ``{joint}.pos`` [deg].
+
+    Pure (no ``isaacteleop``, no I/O). Every mapped joint — gripper included — is converted
+    ``rad2deg`` and renamed through ``joint_name_map`` (stream name -> follower motor name);
+    leader and follower are the same B601-DM hardware, so a 1:1 angle mirror is exact and
+    the follower's soft joint limits handle clipping. Iteration follows ``joints_rad``
+    insertion order, so pass it in :data:`REBOT_DEVARM_LEADER_JOINTS` order for a stable
+    layout. Stream joints absent from the map are dropped (not guessed at).
+    """
+    action: RobotAction = {}
+    for name, rad in joints_rad.items():
+        target = joint_name_map.get(name)
+        if target is None:
+            continue
+        action[f"{target}.pos"] = float(np.rad2deg(rad))
+    return action
+
+
+class RebotDevArmLeaderArm(IsaacTeleopTeleoperator):
+    """reBot DevArm leader-arm teleoperator (joint-space), direct joint mirror.
+
+    Reads the seven joint angles off a single ``JointStateSource`` each frame; no
+    retargeter, no clutch (shared kinematics with the ``rebot_b601_follower``). When the
+    leader is not streaming, :meth:`get_action` returns the held-last joints and
+    :attr:`is_tracking` is ``False`` so the owning loop can hold the follower.
+    """
+
+    config_class = RebotDevArmLeaderArmConfig
+    name = "isaac_teleop_rebot_devarm_leader"
+
+    def __init__(self, config: RebotDevArmLeaderArmConfig):
+        super().__init__(config)
+        self.config: RebotDevArmLeaderArmConfig = config
+        # Held-last joint angles [rad], seeded at zero (URDF/vendor zero pose) so the first
+        # frames before the plugin starts pushing read as the zero pose, not garbage.
+        self._last_joints_rad: dict[str, float] = dict.fromkeys(REBOT_DEVARM_LEADER_JOINTS, 0.0)
+        # Whether the most recent get_action() read live leader data (vs held-last).
+        self._is_tracking = False
+
+    # ------------------------------------------------------------------
+    # Pipeline construction
+    # ------------------------------------------------------------------
+
+    def _build_pipeline(self) -> OutputCombiner:
+        """Build the joint-mirror pipeline: a single ``JointStateSource`` leaf that converts
+        the raw stream into a name-keyed joint group. No retargeter (shared kinematics)."""
+        source = JointStateSource(
+            name="rebot_devarm_leader",
+            collection_id=self.config.collection_id,
+            joint_names=REBOT_DEVARM_LEADER_JOINTS,
+        )
+        return OutputCombiner({"joints": source.output(JointStateSource.JOINTS)})
+
+    # ------------------------------------------------------------------
+    # Action features
+    # ------------------------------------------------------------------
+
+    @property
+    def action_features(self) -> dict[str, type]:
+        # Matches the rebot_b601_follower's action features so this is a drop-in
+        # joint-space leader: one float `{joint}.pos` per DOF, in the follower's units.
+        return {f"{target}.pos": float for target in self.config.joint_name_map.values()}
+
+    @property
+    def feedback_features(self) -> dict[str, type]:
+        return {}
+
+    @property
+    def is_tracking(self) -> bool:
+        """Whether the last :meth:`get_action` read live leader data (vs held-last)."""
+        return self._is_tracking
+
+    # ------------------------------------------------------------------
+    # Action extraction
+    # ------------------------------------------------------------------
+
+    def get_action(self) -> RobotAction:
+        """Step the session and return the leader joints as follower-ready ``{joint}.pos``.
+
+        When the leader is streaming, the live angles are cached and converted; otherwise
+        the held-last angles are reused and :attr:`is_tracking` is set ``False``.
+        """
+        result = self._step(execution_events=self._running_events())
+
+        joints = result["joints"]
+        # The JointStateSource output is Optional: absent (is_none) when the device is
+        # inactive. Treat that as "not tracking" and reuse the held-last angles.
+        self._is_tracking = not getattr(joints, "is_none", False)
+        if self._is_tracking:
+            try:
+                self._last_joints_rad = _joints_group_to_rad(joints)
+            except (AttributeError, IndexError, KeyError, TypeError, ValueError):
+                # A partially-populated / malformed group on an odd frame: keep held-last,
+                # but report not-tracking so the loop holds the follower rather than trust it.
+                self._is_tracking = False
+
+        return rebot_leader_joints_to_robot_action(
+            self._last_joints_rad,
+            joint_name_map=self.config.joint_name_map,
+        )

--- a/examples/isaac_teleop_to_so101/record.py
+++ b/examples/isaac_teleop_to_so101/record.py
@@ -68,6 +68,9 @@ from lerobot.datasets import (
 )
 from lerobot.processor import make_default_processors
 from lerobot.robots import RobotConfig
+from lerobot.robots.rebot_b601_follower import (
+    RebotB601FollowerRobotConfig,  # noqa: F401  (registers rebot_b601_follower)
+)
 from lerobot.robots.so_follower import SOFollowerConfig  # noqa: F401  (registers so101_follower)
 from lerobot.utils.constants import ACTION, OBS_STR
 from lerobot.utils.feature_utils import build_dataset_frame, combine_feature_dicts

--- a/examples/isaac_teleop_to_so101/teleoperate.py
+++ b/examples/isaac_teleop_to_so101/teleoperate.py
@@ -40,6 +40,9 @@ from dataclasses import dataclass
 
 from lerobot.configs import parser
 from lerobot.robots import RobotConfig
+from lerobot.robots.rebot_b601_follower import (
+    RebotB601FollowerRobotConfig,  # noqa: F401  (registers rebot_b601_follower)
+)
 from lerobot.robots.so_follower import SOFollowerConfig  # noqa: F401  (registers so101_follower)
 from lerobot.utils.robot_utils import precise_sleep
 

--- a/tests/teleoperators/test_rebot_devarm_leader_arm.py
+++ b/tests/teleoperators/test_rebot_devarm_leader_arm.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python
+
+# Copyright 2026 NVIDIA Corporation and The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pure unit tests for the Isaac Teleop reBot DevArm leader-arm unit conversion.
+
+These tests deliberately do NOT import ``isaacteleop`` --
+:func:`rebot_leader_joints_to_robot_action` is the pure-math bridge from the leader's
+streamed joint angles [rad] to the follower's native ``{joint}.pos`` degrees, and must be
+testable without the XR runtime (mirroring ``test_so101_leader_arm.py``).
+"""
+
+import numpy as np
+import pytest
+
+from examples.isaac_teleop_to_so101.isaac_teleop.config_isaac_teleop import RebotDevArmLeaderArmConfig
+from examples.isaac_teleop_to_so101.isaac_teleop.teleop_rebot_devarm_leader_arm import (
+    REBOT_DEVARM_LEADER_JOINTS,
+    rebot_leader_joints_to_robot_action,
+)
+
+# The default stream-name -> follower-motor-name map (rebot_b601_follower naming).
+_NAME_MAP = RebotDevArmLeaderArmConfig().joint_name_map
+
+
+def _convert(joints_rad, name_map=None):
+    return rebot_leader_joints_to_robot_action(
+        joints_rad, joint_name_map=_NAME_MAP if name_map is None else name_map
+    )
+
+
+def _all_zero_joints():
+    return dict.fromkeys(REBOT_DEVARM_LEADER_JOINTS, 0.0)
+
+
+# ----------------------------------------------------------------------------
+# All joints (gripper included): rad -> deg, 1:1 mirror
+# ----------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("rad", "expected_deg"),
+    [(0.0, 0.0), (np.pi, 180.0), (-np.pi / 2, -90.0), (np.pi / 4, 45.0)],
+)
+def test_joint_rad2deg(rad, expected_deg):
+    out = _convert({**_all_zero_joints(), "joint1": float(rad)})
+    assert out["shoulder_pan.pos"] == pytest.approx(expected_deg)
+
+
+def test_all_joints_converted_to_degrees_including_gripper():
+    # Leader and follower are the same hardware: EVERY DOF (gripper too) is a plain
+    # rad2deg mirror, unlike the SO-101 device which normalizes its gripper.
+    joints = dict.fromkeys(REBOT_DEVARM_LEADER_JOINTS, np.pi)
+    out = _convert(joints)
+    assert len(out) == len(REBOT_DEVARM_LEADER_JOINTS)
+    for value in out.values():
+        assert value == pytest.approx(180.0)
+
+
+def test_emits_follower_motor_names_in_stream_order():
+    out = _convert(_all_zero_joints())
+    assert list(out.keys()) == [f"{_NAME_MAP[name]}.pos" for name in REBOT_DEVARM_LEADER_JOINTS]
+
+
+def test_default_map_targets_rebot_b601_follower_motors():
+    # The default action layout must be follower-ready for rebot_b601_follower.
+    out = _convert(_all_zero_joints())
+    assert set(out.keys()) == {
+        "shoulder_pan.pos",
+        "shoulder_lift.pos",
+        "elbow_flex.pos",
+        "wrist_flex.pos",
+        "wrist_yaw.pos",
+        "wrist_roll.pos",
+        "gripper.pos",
+    }
+
+
+def test_gripper_multi_turn_angle_passes_through_unclipped():
+    # The B601 gripper is multi-turn (several rad of travel); the leader mirrors the raw
+    # angle and leaves clipping to the follower's soft joint_limits.
+    out = _convert({**_all_zero_joints(), "gripper": -6.8})
+    assert out["gripper.pos"] == pytest.approx(float(np.rad2deg(-6.8)))
+
+
+# ----------------------------------------------------------------------------
+# joint_name_map behavior
+# ----------------------------------------------------------------------------
+
+
+def test_unmapped_stream_joints_are_dropped():
+    # A stream joint absent from the map is dropped, not guessed at.
+    partial_map = {"joint1": "shoulder_pan"}
+    out = _convert(_all_zero_joints(), name_map=partial_map)
+    assert list(out.keys()) == ["shoulder_pan.pos"]
+
+
+def test_custom_name_map_renames_targets():
+    custom = {name: f"motor_{i}" for i, name in enumerate(REBOT_DEVARM_LEADER_JOINTS)}
+    out = _convert(_all_zero_joints(), name_map=custom)
+    assert list(out.keys()) == [f"motor_{i}.pos" for i in range(len(REBOT_DEVARM_LEADER_JOINTS))]
+
+
+# ----------------------------------------------------------------------------
+# Config
+# ----------------------------------------------------------------------------
+
+
+def test_config_defaults_register_and_round_trip():
+    cfg = RebotDevArmLeaderArmConfig()
+    assert cfg.type == "rebot_devarm_leader"
+    assert cfg.collection_id == "rebot_devarm_leader"
+    assert cfg.port == ""
+    # The default map covers the full stream, one target per stream joint (no fan-in).
+    assert set(cfg.joint_name_map.keys()) == set(REBOT_DEVARM_LEADER_JOINTS)
+    assert len(set(cfg.joint_name_map.values())) == len(REBOT_DEVARM_LEADER_JOINTS)
+
+
+def test_config_joint_name_map_is_not_shared_between_instances():
+    # default_factory must give each config its own dict (no mutable default aliasing).
+    a = RebotDevArmLeaderArmConfig()
+    b = RebotDevArmLeaderArmConfig()
+    a.joint_name_map["joint1"] = "mutated"
+    assert b.joint_name_map["joint1"] == "shoulder_pan"


### PR DESCRIPTION
## What this does

Adds a third input device to the `examples/isaac_teleop_to_so101` device library (following up on #3927 after its move to `examples/`): **`--teleop.type=rebot_devarm_leader`** (`RebotDevArmLeaderArm`), a joint-space Isaac Teleop leader for the Seeed Studio **reBot DevArm** (B601-DM: 6-DOF + gripper, seven Damiao CAN motors), driving LeRobot's `rebot_b601_follower`.

This supersedes #3943, which targeted the pre-merge `src/lerobot/teleoperators/isaac_teleop/` layout; the device is now implemented in the example device library where the stack lives after the merge.

- **`isaac_teleop/teleop_rebot_devarm_leader_arm.py`** — mirrors the `SO101LeaderArm` structure: a single `JointStateSource` consuming Isaac Teleop's native `rebot_devarm_leader` plugin stream (NVIDIA/IsaacTeleop#729), plus a pure `rebot_leader_joints_to_robot_action` converter (rad → deg, stream URDF names `joint1..joint6, gripper` renamed to follower motor names via `config.joint_name_map`). Leader and follower are the **same hardware**, so the mirror is 1:1 with no gripper normalization — the follower's soft `joint_limits` clip out-of-range targets.
- **`common.py`** — `setup_leader` dispatches on the config type (same align-slew + hold-on-stale flow as the SO-101 leader); `build_device` pairs the DevArm leader with `rebot_b601_follower`; the plugin launch skips the SO-101 JSON calibration forwarding (the DevArm plugin has its own plain-text calibration format).
- **Docs + README** — new device section with usage, `probe` verification, and the multi-turn gripper wrap caveat (probe exit code 3 = the gripper's multi-turn encoder wrapped after a power cycle and must be re-homed before teleoperating).
- **`tests/teleoperators/test_rebot_devarm_leader_arm.py`** — 12 pure unit tests for the converter and config registration, importable without `isaacteleop` (mirroring the SO-101 leader's test pattern).

## Usage

```bash
python -m examples.isaac_teleop_to_so101.teleoperate \
    --robot.type=rebot_b601_follower --robot.port=/dev/ttyACM0 --robot.id=rebot_b601_follower_arm \
    --teleop.type=rebot_devarm_leader --teleop.port=/dev/ttyACM1 \
    --launch_plugin=/path/to/IsaacTeleop/install/plugins/rebot_devarm_leader/rebot_devarm_leader_plugin
```

## Test plan

- 12/12 unit tests pass (`tests/teleoperators/test_rebot_devarm_leader_arm.py`).
- Headless end-to-end verified on aarch64 (isaacteleop 1.3.131 from public PyPI, `retargeters-lite`): the `rebot_devarm_leader` plugin in synthetic mode → `RebotDevArmLeaderArm` → live, changing `{joint}.pos` frames in `rebot_b601_follower` naming (`shoulder_pan/…/wrist_yaw/wrist_roll/gripper`), `is_tracking` behaves, clean teardown.
- `--help` on `teleoperate.py`/`record.py` shows the new `--teleop.type` choice and `rebot_b601_follower` in `--robot.type`.
- Live hardware verification of the plugin side (real B601-DM over `/dev/ttyACM0`): rest pose matches the plugin `probe` output via two independent decode paths.
- `pre-commit` clean on all touched files.

## Companion PRs

- NVIDIA/IsaacTeleop#729 — the native `rebot_devarm_leader` plugin this device consumes.
- Replaces #3943 (pre-`examples/`-move layout).
