### PR TITLE
fix(processor): support explicit relative state mapping

### DIFF
--- a/docs/source/action_representations.mdx
+++ b/docs/source/action_representations.mdx
@@ -168,6 +168,22 @@ lerobot-train \
 
 The `relative_exclude_joints` parameter specifies joints that should remain in absolute space. For example, gripper commands are typically binary (open/close) and don't benefit from relative encoding.
 
+If your `observation.state` layout is not prefix-aligned with `action`, pass the same explicit state mapping when recomputing stats and when training. For example, if action dimensions use state columns `[0, 2, 4, 6, 8, 10, 12]`:
+
+```bash
+lerobot-edit-dataset \
+    --repo_id your_dataset \
+    --operation.type recompute_stats \
+    --operation.relative_action true \
+    --operation.relative_state_index_map "[0, 2, 4, 6, 8, 10, 12]"
+
+lerobot-train \
+    --dataset.repo_id=your_dataset \
+    --policy.type=pi0 \
+    --policy.use_relative_actions=true \
+    --policy.relative_state_index_map='[0, 2, 4, 6, 8, 10, 12]'
+```
+
 ### Combining relative actions with RTC
 
 [RTC](https://arxiv.org/abs/2506.07339) runs policy inference at high frequency and sends actions to the robot as they are predicted rather than waiting for a full chunk. Relative actions and RTC are fully compatible: because every chunk in relative mode references the **same** current state (captured at the start of inference), each predicted action in the chunk remains a valid offset even if the robot has already moved. No special handling is needed — `RelativeActionsProcessorStep` caches the state once per inference call and `AbsoluteActionsProcessorStep` applies it to every action in the streamed output.

--- a/src/lerobot/datasets/compute_stats.py
+++ b/src/lerobot/datasets/compute_stats.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Sequence
 
 import numpy as np
 
@@ -654,12 +655,32 @@ def _get_valid_chunk_starts(episode_indices: np.ndarray, chunk_size: int) -> np.
     return starts[valid]
 
 
+def _validate_state_action_index_map(
+    state_action_index_map: Sequence[int],
+    action_dim: int,
+    state_dim: int,
+) -> None:
+    if len(state_action_index_map) != action_dim:
+        raise ValueError(
+            "state_action_index_map length must match the relative action mask length "
+            f"({len(state_action_index_map)} != {action_dim})."
+        )
+
+    invalid_indices = [index for index in state_action_index_map if index < 0 or index >= state_dim]
+    if invalid_indices:
+        raise ValueError(
+            "state_action_index_map entries must be valid observation.state indices "
+            f"(state_dim={state_dim}, invalid={invalid_indices})."
+        )
+
+
 def _compute_relative_chunk_batch(
     start_indices: np.ndarray,
     all_actions: np.ndarray,
     all_states: np.ndarray,
     chunk_size: int,
     relative_mask: np.ndarray,
+    state_action_index_map: Sequence[int] | None = None,
 ) -> np.ndarray:
     """Vectorised relative-action computation for a batch of start indices.
 
@@ -672,7 +693,12 @@ def _compute_relative_chunk_batch(
     chunks = all_actions[frame_idx].copy()
     states = all_states[start_indices]
     mask_dim = len(relative_mask)
-    chunks[:, :, :mask_dim] -= states[:, None, :mask_dim] * relative_mask[None, None, :]
+    if state_action_index_map is None:
+        state_offsets = states[:, :mask_dim]
+    else:
+        _validate_state_action_index_map(state_action_index_map, mask_dim, all_states.shape[1])
+        state_offsets = states[:, state_action_index_map]
+    chunks[:, :, :mask_dim] -= state_offsets[:, None, :] * relative_mask[None, None, :]
     return chunks.reshape(-1, all_actions.shape[1])
 
 
@@ -681,6 +707,7 @@ def compute_relative_action_stats(
     features: dict,
     chunk_size: int,
     exclude_joints: list[str] | None = None,
+    state_action_index_map: Sequence[int] | None = None,
     num_workers: int = 0,
 ) -> dict[str, np.ndarray]:
     """Compute normalization statistics for relative actions over the full dataset.
@@ -697,6 +724,8 @@ def compute_relative_action_stats(
         chunk_size: Number of consecutive frames per action chunk.
         exclude_joints: Joint names whose dimensions should remain absolute
             (not converted to relative actions).
+        state_action_index_map: Optional observation.state index for each action
+            dimension. Defaults to the legacy state prefix behavior.
         num_workers: Number of parallel threads for computation. Values ≤1
             mean single-threaded. Numpy releases the GIL so threads give
             real parallelism here.
@@ -724,6 +753,9 @@ def compute_relative_action_stats(
     all_actions = np.array(hf_dataset[ACTION], dtype=np.float32)
     all_states = np.array(hf_dataset[OBS_STATE], dtype=np.float32)
     episode_indices = np.array(hf_dataset["episode_index"])
+    if state_action_index_map is not None:
+        state_action_index_map = list(state_action_index_map)
+        _validate_state_action_index_map(state_action_index_map, len(relative_mask), all_states.shape[1])
 
     valid_starts = _get_valid_chunk_starts(episode_indices, chunk_size)
     if len(valid_starts) == 0:
@@ -754,6 +786,7 @@ def compute_relative_action_stats(
                     all_states,
                     chunk_size,
                     relative_mask,
+                    state_action_index_map,
                 )
                 for batch in batches
             ]
@@ -762,7 +795,14 @@ def compute_relative_action_stats(
     else:
         for batch in batches:
             running_stats.update(
-                _compute_relative_chunk_batch(batch, all_actions, all_states, chunk_size, relative_mask)
+                _compute_relative_chunk_batch(
+                    batch,
+                    all_actions,
+                    all_states,
+                    chunk_size,
+                    relative_mask,
+                    state_action_index_map,
+                )
             )
 
     stats = running_stats.get_statistics()

--- a/src/lerobot/datasets/dataset_tools.py
+++ b/src/lerobot/datasets/dataset_tools.py
@@ -1588,6 +1588,7 @@ def recompute_stats(
     skip_image_video: bool = True,
     relative_action: bool = False,
     relative_exclude_joints: list[str] | None = None,
+    relative_state_index_map: list[int] | None = None,
     chunk_size: int = 50,
     num_workers: int = 0,
 ) -> LeRobotDataset:
@@ -1603,6 +1604,8 @@ def recompute_stats(
             training with ``use_relative_actions=True``.
         relative_exclude_joints: Joint names to exclude from relative conversion when
             relative_action=True. These dims keep absolute stats.
+        relative_state_index_map: Optional observation.state index for each action
+            dimension. Defaults to the legacy state prefix behavior.
         chunk_size: Action chunk size used for relative stats computation. Should match
             ``policy.chunk_size``. Only used when ``relative_action=True``.
         num_workers: Number of parallel threads for relative action stats computation.
@@ -1638,6 +1641,7 @@ def recompute_stats(
             features=features,
             chunk_size=chunk_size,
             exclude_joints=relative_exclude_joints,
+            state_action_index_map=relative_state_index_map,
             num_workers=num_workers,
         )
         features_to_compute.pop(ACTION, None)

--- a/src/lerobot/policies/pi0/configuration_pi0.py
+++ b/src/lerobot/policies/pi0/configuration_pi0.py
@@ -53,6 +53,8 @@ class PI0Config(PreTrainedConfig):
     use_relative_actions: bool = False
     # Joint names to exclude from relative (kept absolute). Empty list = all dims relative.
     relative_exclude_joints: list[str] = field(default_factory=lambda: ["gripper"])
+    # observation.state index used as the reference for each action dimension.
+    relative_state_index_map: list[int] | None = None
     # Populated at runtime from dataset metadata by make_policy.
     action_feature_names: list[str] | None = None
 

--- a/src/lerobot/policies/pi0/processor_pi0.py
+++ b/src/lerobot/policies/pi0/processor_pi0.py
@@ -128,6 +128,7 @@ def make_pi0_pre_post_processors(
         enabled=config.use_relative_actions,
         exclude_joints=getattr(config, "relative_exclude_joints", []),
         action_names=getattr(config, "action_feature_names", None),
+        state_action_index_map=getattr(config, "relative_state_index_map", None),
     )
 
     steps = make_default_policy_processor_steps(config, dataset_stats)

--- a/src/lerobot/policies/pi05/configuration_pi05.py
+++ b/src/lerobot/policies/pi05/configuration_pi05.py
@@ -53,6 +53,8 @@ class PI05Config(PreTrainedConfig):
     use_relative_actions: bool = False
     # Joint names to exclude from relative (kept absolute). Empty list = all dims relative.
     relative_exclude_joints: list[str] = field(default_factory=lambda: ["gripper"])
+    # observation.state index used as the reference for each action dimension.
+    relative_state_index_map: list[int] | None = None
     # Populated at runtime from dataset metadata by make_policy.
     action_feature_names: list[str] | None = None
 

--- a/src/lerobot/policies/pi05/processor_pi05.py
+++ b/src/lerobot/policies/pi05/processor_pi05.py
@@ -124,6 +124,7 @@ def make_pi05_pre_post_processors(
         enabled=config.use_relative_actions,
         exclude_joints=getattr(config, "relative_exclude_joints", []),
         action_names=getattr(config, "action_feature_names", None),
+        state_action_index_map=getattr(config, "relative_state_index_map", None),
     )
 
     steps = make_default_policy_processor_steps(config, dataset_stats)

--- a/src/lerobot/policies/pi0_fast/configuration_pi0_fast.py
+++ b/src/lerobot/policies/pi0_fast/configuration_pi0_fast.py
@@ -44,6 +44,8 @@ class PI0FastConfig(PreTrainedConfig):
     use_relative_actions: bool = False
     # Joint names to exclude from relative (kept absolute). Empty list = all dims relative.
     relative_exclude_joints: list[str] = field(default_factory=lambda: ["gripper"])
+    # observation.state index used as the reference for each action dimension.
+    relative_state_index_map: list[int] | None = None
     # Populated at runtime from dataset metadata by make_policy.
     action_feature_names: list[str] | None = None
 

--- a/src/lerobot/policies/pi0_fast/processor_pi0_fast.py
+++ b/src/lerobot/policies/pi0_fast/processor_pi0_fast.py
@@ -124,6 +124,7 @@ def make_pi0_fast_pre_post_processors(
         enabled=config.use_relative_actions,
         exclude_joints=getattr(config, "relative_exclude_joints", []),
         action_names=getattr(config, "action_feature_names", None),
+        state_action_index_map=getattr(config, "relative_state_index_map", None),
     )
 
     steps = make_default_policy_processor_steps(config, dataset_stats)

--- a/src/lerobot/policies/rtc/relative.py
+++ b/src/lerobot/policies/rtc/relative.py
@@ -49,7 +49,7 @@ def reanchor_relative_rtc_prefix(
 
     action_cpu = prev_actions_absolute.detach().cpu()
     mask = relative_step._build_mask(action_cpu.shape[-1])
-    relative_actions = to_relative_actions(action_cpu, state, mask)
+    relative_actions = to_relative_actions(action_cpu, state, mask, relative_step.state_action_index_map)
 
     transition = create_transition(action=relative_actions)
     if normalizer_step is not None:

--- a/src/lerobot/processor/relative_action_processor.py
+++ b/src/lerobot/processor/relative_action_processor.py
@@ -37,13 +37,44 @@ __all__ = [
 ]
 
 
-def to_relative_actions(actions: Tensor, state: Tensor, mask: Sequence[bool]) -> Tensor:
+def _select_state_action_offsets(
+    state: Tensor, action_dim: int, state_action_index_map: Sequence[int] | None
+) -> Tensor:
+    if state_action_index_map is None:
+        return state[..., :action_dim]
+
+    if len(state_action_index_map) != action_dim:
+        raise ValueError(
+            "state_action_index_map length must match the relative action mask length "
+            f"({len(state_action_index_map)} != {action_dim})."
+        )
+
+    state_dim = state.shape[-1]
+    invalid_indices = [index for index in state_action_index_map if index < 0 or index >= state_dim]
+    if invalid_indices:
+        raise ValueError(
+            "state_action_index_map entries must be valid observation.state indices "
+            f"(state_dim={state_dim}, invalid={invalid_indices})."
+        )
+
+    index = torch.tensor(state_action_index_map, dtype=torch.long, device=state.device)
+    return state.index_select(-1, index)
+
+
+def to_relative_actions(
+    actions: Tensor,
+    state: Tensor,
+    mask: Sequence[bool],
+    state_action_index_map: Sequence[int] | None = None,
+) -> Tensor:
     """Convert absolute actions to relative: relative = action - state (for masked dims).
 
     Args:
         actions: (B, T, action_dim) or (B, action_dim).
         state: (B, state_dim). Broadcast across time dimension.
         mask: Which dims to convert. Can be shorter than action_dim.
+        state_action_index_map: Optional observation.state index for each masked
+            action dimension. Defaults to the legacy state prefix behavior.
     """
     mask_t = torch.tensor(mask, dtype=actions.dtype, device=actions.device)
     dims = mask_t.shape[0]
@@ -51,7 +82,7 @@ def to_relative_actions(actions: Tensor, state: Tensor, mask: Sequence[bool]) ->
     # DeviceProcessorStep moves the transition, so it can be on CPU while actions are on CUDA.
     if state.device != actions.device or state.dtype != actions.dtype:
         state = state.to(device=actions.device, dtype=actions.dtype)
-    state_offset = state[..., :dims] * mask_t
+    state_offset = _select_state_action_offsets(state, dims, state_action_index_map) * mask_t
     if actions.ndim == 3:
         state_offset = state_offset.unsqueeze(-2)
     actions = actions.clone()
@@ -59,13 +90,20 @@ def to_relative_actions(actions: Tensor, state: Tensor, mask: Sequence[bool]) ->
     return actions
 
 
-def to_absolute_actions(actions: Tensor, state: Tensor, mask: Sequence[bool]) -> Tensor:
+def to_absolute_actions(
+    actions: Tensor,
+    state: Tensor,
+    mask: Sequence[bool],
+    state_action_index_map: Sequence[int] | None = None,
+) -> Tensor:
     """Convert relative actions back to absolute: absolute = relative + state (for masked dims).
 
     Args:
         actions: (B, T, action_dim) or (B, action_dim).
         state: (B, state_dim). Broadcast across time dimension.
         mask: Which dims to convert. Can be shorter than action_dim.
+        state_action_index_map: Optional observation.state index for each masked
+            action dimension. Defaults to the legacy state prefix behavior.
     """
     mask_t = torch.tensor(mask, dtype=actions.dtype, device=actions.device)
     dims = mask_t.shape[0]
@@ -73,7 +111,7 @@ def to_absolute_actions(actions: Tensor, state: Tensor, mask: Sequence[bool]) ->
     # DeviceProcessorStep moves the transition, so it can be on CPU while actions are on CUDA.
     if state.device != actions.device or state.dtype != actions.dtype:
         state = state.to(device=actions.device, dtype=actions.dtype)
-    state_offset = state[..., :dims] * mask_t
+    state_offset = _select_state_action_offsets(state, dims, state_action_index_map) * mask_t
     if actions.ndim == 3:
         state_offset = state_offset.unsqueeze(-2)
     actions = actions.clone()
@@ -96,11 +134,14 @@ class RelativeActionsProcessorStep(ProcessorStep):
         exclude_joints: Joint names to keep absolute (not converted to relative).
         action_names: Action dimension names from dataset metadata, used to build
             the mask from exclude_joints. If None, all dims are converted.
+        state_action_index_map: Optional observation.state index for each action
+            dimension. If unset, actions use the legacy state prefix mapping.
     """
 
     enabled: bool = False
     exclude_joints: list[str] = field(default_factory=list)
     action_names: list[str] | None = None
+    state_action_index_map: list[int] | None = None
     _last_state: torch.Tensor | None = field(default=None, init=False, repr=False)
 
     def _build_mask(self, action_dim: int) -> list[bool]:
@@ -139,7 +180,9 @@ class RelativeActionsProcessorStep(ProcessorStep):
             return new_transition
 
         mask = self._build_mask(action.shape[-1])
-        new_transition[TransitionKey.ACTION] = to_relative_actions(action, state, mask)
+        new_transition[TransitionKey.ACTION] = to_relative_actions(
+            action, state, mask, self.state_action_index_map
+        )
         return new_transition
 
     def get_cached_state(self) -> torch.Tensor | None:
@@ -151,6 +194,7 @@ class RelativeActionsProcessorStep(ProcessorStep):
             "enabled": self.enabled,
             "exclude_joints": self.exclude_joints,
             "action_names": self.action_names,
+            "state_action_index_map": self.state_action_index_map,
         }
 
     def transform_features(
@@ -199,7 +243,9 @@ class AbsoluteActionsProcessorStep(ProcessorStep):
             return new_transition
 
         mask = self.relative_step._build_mask(action.shape[-1])
-        new_transition[TransitionKey.ACTION] = to_absolute_actions(action, cached_state, mask)
+        new_transition[TransitionKey.ACTION] = to_absolute_actions(
+            action, cached_state, mask, self.relative_step.state_action_index_map
+        )
         return new_transition
 
     def get_config(self) -> dict[str, Any]:

--- a/src/lerobot/scripts/lerobot_edit_dataset.py
+++ b/src/lerobot/scripts/lerobot_edit_dataset.py
@@ -331,6 +331,7 @@ class RecomputeStatsConfig(OperationConfig):
     skip_image_video: bool = True
     relative_action: bool = False
     relative_exclude_joints: list[str] | None = None
+    relative_state_index_map: list[int] | None = None
     chunk_size: int = 50
     num_workers: int = 0
     overwrite: bool = False
@@ -713,7 +714,8 @@ def handle_recompute_stats(cfg: EditDatasetConfig) -> None:
     if cfg.operation.relative_action:
         logging.info(
             f"Relative action stats enabled (chunk_size={cfg.operation.chunk_size}, "
-            f"exclude_joints={cfg.operation.relative_exclude_joints})"
+            f"exclude_joints={cfg.operation.relative_exclude_joints}, "
+            f"state_index_map={cfg.operation.relative_state_index_map})"
         )
 
     recompute_stats(
@@ -721,6 +723,7 @@ def handle_recompute_stats(cfg: EditDatasetConfig) -> None:
         skip_image_video=cfg.operation.skip_image_video,
         relative_action=cfg.operation.relative_action,
         relative_exclude_joints=cfg.operation.relative_exclude_joints,
+        relative_state_index_map=cfg.operation.relative_state_index_map,
         chunk_size=cfg.operation.chunk_size,
         num_workers=cfg.operation.num_workers,
     )

--- a/src/lerobot/scripts/lerobot_train.py
+++ b/src/lerobot/scripts/lerobot_train.py
@@ -499,6 +499,7 @@ def train(cfg: TrainPipelineConfig):
                 "enabled": True,
                 "exclude_joints": getattr(active_cfg, "relative_exclude_joints", []),
                 "action_names": getattr(active_cfg, "action_feature_names", None),
+                "state_action_index_map": getattr(active_cfg, "relative_state_index_map", None),
             }
             postprocessor_overrides["absolute_actions_processor"] = {"enabled": True}
         processor_kwargs["preprocessor_overrides"] = preprocessor_overrides

--- a/tests/processor/test_relative_action_processor.py
+++ b/tests/processor/test_relative_action_processor.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pytest
+import torch
+
+from lerobot.processor import (
+    AbsoluteActionsProcessorStep,
+    RelativeActionsProcessorStep,
+    TransitionKey,
+    create_transition,
+    to_absolute_actions,
+    to_relative_actions,
+)
+from lerobot.utils.constants import ACTION, OBS_STATE
+
+
+def test_relative_actions_use_explicit_state_action_index_map_for_2d_actions():
+    state = torch.tensor([[10.0, 0.1, 20.0, 0.2, 30.0]])
+    actions = torch.tensor([[11.0, 22.0, 33.0]])
+    mask = [True, True, True]
+    state_action_index_map = [0, 2, 4]
+
+    relative = to_relative_actions(actions, state, mask, state_action_index_map)
+
+    torch.testing.assert_close(relative, torch.tensor([[1.0, 2.0, 3.0]]))
+    torch.testing.assert_close(
+        to_absolute_actions(relative, state, mask, state_action_index_map),
+        actions,
+    )
+
+
+def test_relative_actions_round_trip_chunked_actions_with_explicit_state_action_index_map():
+    state = torch.tensor([[10.0, 0.1, 20.0, 0.2, 30.0, 0.3, 40.0, 0.4, 50.0, 0.5, 60.0, 0.6, 99.0]])
+    actions = torch.tensor(
+        [
+            [
+                [11.0, 22.0, 33.0, 44.0, 55.0, 66.0, 7.0],
+                [12.0, 24.0, 36.0, 48.0, 60.0, 72.0, 8.0],
+            ]
+        ]
+    )
+    mask = [True, True, True, True, True, True, False]
+    state_action_index_map = [0, 2, 4, 6, 8, 10, 12]
+
+    relative = to_relative_actions(actions, state, mask, state_action_index_map)
+
+    expected_relative = torch.tensor(
+        [
+            [
+                [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0],
+                [2.0, 4.0, 6.0, 8.0, 10.0, 12.0, 8.0],
+            ]
+        ]
+    )
+    torch.testing.assert_close(relative, expected_relative)
+    torch.testing.assert_close(
+        to_absolute_actions(relative, state, mask, state_action_index_map),
+        actions,
+    )
+
+
+def test_relative_and_absolute_processor_steps_share_explicit_state_action_index_map():
+    state = torch.tensor([[10.0, 0.1, 20.0, 0.2, 30.0]])
+    action = torch.tensor([[11.0, 22.0, 33.0]])
+    relative_step = RelativeActionsProcessorStep(
+        enabled=True,
+        state_action_index_map=[0, 2, 4],
+    )
+    absolute_step = AbsoluteActionsProcessorStep(enabled=True, relative_step=relative_step)
+
+    relative_transition = relative_step(create_transition(observation={OBS_STATE: state}, action=action))
+    torch.testing.assert_close(relative_transition[TransitionKey.ACTION], torch.tensor([[1.0, 2.0, 3.0]]))
+
+    absolute_transition = absolute_step(create_transition(action=relative_transition[TransitionKey.ACTION]))
+    torch.testing.assert_close(absolute_transition[TransitionKey.ACTION], action)
+
+
+@pytest.mark.parametrize("state_action_index_map", ([0], [0, -1], [0, 5]))
+def test_relative_actions_reject_invalid_state_action_index_map(state_action_index_map):
+    state = torch.tensor([[10.0, 20.0]])
+    actions = torch.tensor([[11.0, 22.0]])
+    mask = [True, True]
+
+    with pytest.raises(ValueError, match="state_action_index_map"):
+        to_relative_actions(actions, state, mask, state_action_index_map)
+
+
+def test_compute_relative_action_stats_uses_explicit_state_action_index_map():
+    compute_stats = pytest.importorskip("lerobot.datasets.compute_stats", exc_type=ImportError)
+    hf_dataset = {
+        ACTION: np.array(
+            [
+                [11.0, 22.0, 7.0],
+                [12.0, 24.0, 8.0],
+                [13.0, 26.0, 9.0],
+            ],
+            dtype=np.float32,
+        ),
+        OBS_STATE: np.array(
+            [
+                [10.0, 0.1, 20.0, 0.2, 99.0],
+                [11.0, 0.1, 22.0, 0.2, 99.0],
+                [12.0, 0.1, 24.0, 0.2, 99.0],
+            ],
+            dtype=np.float32,
+        ),
+        "episode_index": np.array([0, 0, 0]),
+    }
+    features = {
+        ACTION: {
+            "shape": (3,),
+            "names": ["joint_0.pos", "joint_1.pos", "gripper"],
+        }
+    }
+
+    stats = compute_stats.compute_relative_action_stats(
+        hf_dataset=hf_dataset,
+        features=features,
+        chunk_size=2,
+        exclude_joints=["gripper"],
+        state_action_index_map=[0, 2, 4],
+        num_workers=0,
+    )
+
+    np.testing.assert_allclose(stats["mean"], np.array([1.5, 3.0, 8.0]), rtol=1e-6)


### PR DESCRIPTION
﻿## Summary
- Add an optional explicit state-to-action index map for relative action conversion while preserving the existing state-prefix default.
- Thread the same mapping through pi0/pi0.5/pi0_fast processors, pretrained processor overrides, relative-action stats recomputation, and RTC reanchoring.
- Add regression tests for non-prefix state layouts, invalid maps, processor round-trips, and relative stats.

## Why
- Fixes #3863.
- Relative actions previously assumed `observation.state[..., :action_dim]` matched `action`, which breaks datasets where state interleaves positions with other values.

## Validation
- [x] `uv run --extra test --extra dataset pytest tests/processor/test_relative_action_processor.py -q`
- [x] `uv run --extra test pytest tests/policies/rtc/test_rtc_relative_actions.py -k reanchor -q`
- [x] `uv run --extra dev ruff check src/lerobot/processor/relative_action_processor.py src/lerobot/datasets/compute_stats.py src/lerobot/datasets/dataset_tools.py src/lerobot/scripts/lerobot_edit_dataset.py src/lerobot/scripts/lerobot_train.py src/lerobot/policies/pi0/configuration_pi0.py src/lerobot/policies/pi0/processor_pi0.py src/lerobot/policies/pi05/configuration_pi05.py src/lerobot/policies/pi05/processor_pi05.py src/lerobot/policies/pi0_fast/configuration_pi0_fast.py src/lerobot/policies/pi0_fast/processor_pi0_fast.py src/lerobot/policies/rtc/relative.py tests/processor/test_relative_action_processor.py`
- [x] `uv run --extra dev ruff format --check src/lerobot/processor/relative_action_processor.py src/lerobot/datasets/compute_stats.py src/lerobot/datasets/dataset_tools.py src/lerobot/scripts/lerobot_edit_dataset.py src/lerobot/scripts/lerobot_train.py src/lerobot/policies/pi0/configuration_pi0.py src/lerobot/policies/pi0/processor_pi0.py src/lerobot/policies/pi05/configuration_pi05.py src/lerobot/policies/pi05/processor_pi05.py src/lerobot/policies/pi0_fast/configuration_pi0_fast.py src/lerobot/policies/pi0_fast/processor_pi0_fast.py src/lerobot/policies/rtc/relative.py tests/processor/test_relative_action_processor.py`
- [x] `git diff --cached --check`

## Checklist (required before merge)

- [x] Linting/formatting run — CI's `Run Pre-commit Hooks (Lint, Format & Static Analysis)` passes on the rebased branch; the per-file `ruff check` / `ruff format --check` runs are listed above.
- [x] All tests pass locally — `pytest tests/processor` gives 501 passed, 14 skipped. Two failures in that directory (`test_pi0_processor_inputs_match_openpi_reference`, `test_pi05_processor_inputs_match_openpi_reference`) are pre-existing and unrelated: both fail identically on a clean `main` checkout with a 401 on the gated `google/paligemma-3b-pt-224` repo.
- [x] Documentation updated — `docs/source/action_representations.mdx` documents the new opt-in mapping.
- [x] CI is green — rebased onto current `main`; Fast Pytest Tests, Pre-commit Hooks, Secret Leaks Scan and Build PR Docs all pass.
- [x] Community Review: I have reviewed another contributor's open PR and linked it here: #4315

## Notes for reviewers
- The new mapping is opt-in. With `relative_state_index_map=None`, the previous `state[..., :action_dim]` behavior is unchanged.
- This does not add name-based inference or change policy forward passes.

