### PR TITLE
feat(robots): WebRTCProxyRobot — drive a remote robot over WebRTC

### DIFF
--- a/examples/webrtc_remote_so100/README.md
+++ b/examples/webrtc_remote_so100/README.md
@@ -1,0 +1,73 @@
+# WebRTC remote control of an SO-100
+
+Drive a real SO-100 that's plugged into a **robot**, from a **cloud** process, over
+WebRTC. The cloud runs the control logic; the arm + camera stay on the user's
+machine. The cloud `WebRTCProxyRobot` is a drop-in lerobot `Robot` — `get_observation()`
+returns the remote arm's joints + camera and `send_action()` moves the remote motors,
+so any standard `send_action`/`get_observation` control loop drives it. This example
+keeps it self-contained: a tiny inline keyboard jog (no extra teleoperator dependency)
+that proves the link end-to-end.
+
+Implementation: [`src/lerobot/robots/webrtc_proxy`](../../src/lerobot/robots/webrtc_proxy/).
+
+```
+ robot (arm + camera)                    Cloud
+ robot_daemon_so100.py                   signaling relay  +  cloud_teleop_so100.py
+   SO100Follower ──┐                        │                 WebRTCProxyRobot
+   (bus + camera)  ├── WebRTC ──────────────┴──────────────── + keyboard jog loop
+   watchdog (P0) ──┘   media track (camera) + DataChannels (joints/action/control)
+```
+
+Needs the `webrtc` extra: `uv pip install --native-tls 'aiortc>=1.9.0,<2.0.0' 'aiohttp>=3.9.0,<4.0.0'`
+(or `uv sync --extra webrtc`), plus `lerobot[hardware]` for the SO-100.
+
+## 1. Onboarding (once, on the robot) — find the port + camera
+
+```bash
+uv run lerobot-find-port       # unplug/replug the bus -> /dev/tty.usbmodem...  -> PORT
+uv run lerobot-find-cameras    # saves preview images   -> the camera index     -> CAMERA_INDEX
+```
+Put both into `robot_daemon_so100.py`. (These can also be driven from the cloud over the
+control plane — see `python -m lerobot.robots.webrtc_proxy.sim_remote --rpc find_port --real-devices`.)
+
+## 2. Start the three pieces
+
+```bash
+# (cloud) signaling relay — pairs the daemon with the controller
+uv run python -m lerobot.robots.webrtc_proxy.signaling_server --port 8765
+
+# (robot) serve the real arm; safes the arm if the cloud drops
+uv run python examples/webrtc_remote_so100/robot_daemon_so100.py
+
+# (cloud) drive it — web UI with a LIVE camera view (default)
+uv run python examples/webrtc_remote_so100/cloud_teleop_so100.py
+# -> open http://localhost:8088  (live remote camera + per-joint jog buttons)
+
+# ...or a terminal keyboard jog instead:
+uv run python examples/webrtc_remote_so100/cloud_teleop_so100.py --mode console
+# -> type (then Enter):  1..6 select joint   +/- jog selected   q quit
+```
+
+The web panel (`panel.html`, served by the stdlib HTTP server) shows the remote
+camera as a live MJPEG stream — pressing a jog button and watching the remote view
+move is the end-to-end proof the WebRTC link works.
+
+Same machine for a quick test (`ws://127.0.0.1:8765/ws`, `ICE_SERVERS=[]`). Real
+cloud↔robot across the public internet: point `SIGNALING_URL` at the relay's public
+address and add STUN/TURN urls to `ICE_SERVERS` (coturn) for NAT traversal.
+
+## What this demonstrates
+
+- **Drop-in Robot.** `cloud_teleop_so100.py` is a plain `send_action` /
+  `get_observation` loop over `WebRTCProxyRobot` — no WebRTC-specific control code, and
+  no special teleoperator. Swap the inline jog for `lerobot-record` to record a remote
+  dataset, or a policy to run inference in the cloud.
+- **IDs stay robot-local.** The cloud config declares only the logical schema (6 motors
+  + camera `front` at a resolution); the serial port and camera index live on the robot.
+- **P0 safety.** If the action stream stalls (network drop, cloud crash), the robot-side
+  watchdog cuts motor torque so the arm goes limp instead of holding/straining.
+
+## Not covered here (later milestones)
+
+- Public-net NAT traversal (STUN/TURN/coturn) and K8s media deployment — M4.
+- Multi-camera (one media track each) — currently one camera (`front`).

--- a/examples/webrtc_remote_so100/cloud_teleop_so100.py
+++ b/examples/webrtc_remote_so100/cloud_teleop_so100.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Cloud side: a minimal proof that WebRTCProxyRobot drives a REMOTE arm.
+
+WebRTCProxyRobot is a drop-in lerobot ``Robot``: ``get_observation()`` returns the
+remote arm's joints + camera (over WebRTC) and ``send_action()`` moves the remote
+motors. Self-contained (no extra teleoperator dependency), two control front-ends:
+
+- ``--mode web`` (default): serves ``panel.html`` from the stdlib HTTP server —
+  a **live camera view** (MJPEG) + per-joint jog buttons + joint readout.
+- ``--mode console``: keyboard jog in the terminal (1..6 select, +/- jog, q quit).
+
+Either way it's the same plain ``send_action`` / ``get_observation`` loop. Seeing the
+remote camera move when you press a button is the end-to-end proof the link works.
+
+    Run after the relay + robot daemon are up (see README):
+        uv run python examples/webrtc_remote_so100/cloud_teleop_so100.py            # web
+        uv run python examples/webrtc_remote_so100/cloud_teleop_so100.py --mode console
+"""
+
+import argparse
+import io
+import json
+import logging
+import os
+import sys
+import threading
+import time
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+import numpy as np
+from PIL import Image
+
+from lerobot.robots.webrtc_proxy.configuration_webrtc_proxy import WebRTCCameraSpec, WebRTCProxyRobotConfig
+from lerobot.robots.webrtc_proxy.proxy_robot import CameraLayoutMismatchError, WebRTCProxyRobot
+
+SIGNALING_URL = "ws://127.0.0.1:8765/ws"
+SESSION_ID = "so100"
+FPS, WIDTH, HEIGHT = 30, 640, 480
+WEB_PORT = 8088
+JOG_DEG = 3.0
+HOME_RATE_DPS = 30.0  # "reset to home" ramps to 0 at this deg/sec (gentle, not a snap)
+
+_PANEL_HTML = (Path(__file__).parent / "panel.html").read_text(encoding="utf-8")
+
+# Shared state: the control loop (single writer) touches the robot; the web handlers /
+# console reader only read frames/joints and nudge targets.
+_targets: dict[str, float] = {}
+_latest_frame: dict[str, np.ndarray | None] = {"img": None}
+_latest_joints: dict[str, float] = {}
+_motors: list[str] = []
+_cam_names: list[str] = []  # one or more cameras; the panel hconcats them into one view
+_homing = {"on": False}  # when True, the control loop ramps every target toward 0
+_sel = {"i": 0}
+_running = True
+
+
+# ---- web front-end --------------------------------------------------------
+class _Handler(BaseHTTPRequestHandler):
+    def log_message(self, *args):  # noqa: ANN002 - quiet
+        pass
+
+    def do_GET(self):  # noqa: N802
+        path = urlparse(self.path)
+        if path.path == "/":
+            self._bytes("text/html; charset=utf-8", _PANEL_HTML.encode())
+        elif path.path == "/config":
+            self._json({"motors": _motors, "step": JOG_DEG})
+        elif path.path == "/state":
+            self._json({m: round(float(v), 2) for m, v in _latest_joints.items()})
+        elif path.path == "/stream":
+            self._stream()
+        elif path.path == "/jog":
+            q = parse_qs(path.query)
+            key = f"{q.get('motor', [''])[0]}.pos"
+            if key in _targets:
+                _homing["on"] = False  # manual jog cancels an in-progress home
+                _targets[key] += float(q.get("delta", ["0"])[0])
+            self._json({"ok": True})
+        elif path.path == "/home":
+            _homing["on"] = True  # ramp to 0 gradually in the control loop (HOME_RATE_DPS)
+            self._json({"ok": True})
+        else:
+            self.send_error(HTTPStatus.NOT_FOUND)
+
+    def _bytes(self, content_type: str, body: bytes):
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _json(self, obj):
+        self._bytes("application/json", json.dumps(obj).encode())
+
+    def _stream(self):
+        # MJPEG: the remote camera frames, live in the browser <img>.
+        self.send_response(HTTPStatus.OK)
+        self.send_header("Content-Type", "multipart/x-mixed-replace; boundary=frame")
+        self.end_headers()
+        try:
+            while _running:
+                img = _latest_frame["img"]
+                if img is None:
+                    time.sleep(0.05)
+                    continue
+                buf = io.BytesIO()
+                Image.fromarray(img).save(buf, format="JPEG", quality=70)
+                data = buf.getvalue()
+                self.wfile.write(b"--frame\r\nContent-Type: image/jpeg\r\n")
+                self.wfile.write(f"Content-Length: {len(data)}\r\n\r\n".encode())
+                self.wfile.write(data)
+                self.wfile.write(b"\r\n")
+                time.sleep(1 / 15)
+        except (BrokenPipeError, ConnectionResetError):
+            pass
+
+
+# ---- console front-end ----------------------------------------------------
+def _console_reader() -> None:
+    global _running
+    print("\ncommands: " + "  ".join(f"{i + 1}={m}" for i, m in enumerate(_motors)))
+    print("          +/- jog selected joint   q quit\n")
+    for line in sys.stdin:
+        cmd = line.strip().lower()
+        if cmd == "q":
+            _running = False
+            break
+        if cmd.isdigit() and 1 <= int(cmd) <= len(_motors):
+            _sel["i"] = int(cmd) - 1
+        elif cmd in ("+", "="):
+            _targets[f"{_motors[_sel['i']]}.pos"] += JOG_DEG
+        elif cmd == "-":
+            _targets[f"{_motors[_sel['i']]}.pos"] -= JOG_DEG
+        sel = _motors[_sel["i"]]
+        print(f"  -> {sel} target = {_targets[f'{sel}.pos']:.1f} deg")
+
+
+# ---- shared control loop --------------------------------------------------
+def _control_loop(robot: WebRTCProxyRobot) -> None:
+    """Stream the absolute target every tick (arm tracks it AND the robot watchdog never
+    safe-stops), and refresh the latest obs (joints + camera) for the front-end."""
+    try:
+        while _running:
+            if _homing["on"]:  # ease every joint toward 0 by a bounded step per tick
+                step = HOME_RATE_DPS / FPS
+                done = True
+                for k in _targets:
+                    cur = _targets[k]
+                    if abs(cur) <= step:
+                        _targets[k] = 0.0
+                    else:
+                        _targets[k] = cur - step if cur > 0 else cur + step
+                        done = False
+                if done:
+                    _homing["on"] = False
+            robot.send_action(dict(_targets))  # action -> WebRTC -> robot motors
+            o = robot.get_observation()  # joints + camera(s) <- WebRTC <- robot
+            imgs = [o[n] for n in _cam_names if o.get(n) is not None]
+            if imgs:
+                try:
+                    _latest_frame["img"] = imgs[0] if len(imgs) == 1 else np.concatenate(imgs, axis=1)
+                except ValueError:  # mismatched heights — fall back to the first camera
+                    _latest_frame["img"] = imgs[0]
+            _latest_joints.update({m: float(o[f"{m}.pos"]) for m in _motors})
+            time.sleep(1 / FPS)
+    except KeyboardInterrupt:
+        pass
+
+
+def main() -> None:
+    global _running
+    parser = argparse.ArgumentParser(description="Cloud-side teleop for a remote SO-100 over WebRTC")
+    parser.add_argument("--mode", choices=["web", "console"], default="web")
+    parser.add_argument(
+        "--session", default=SESSION_ID, help="session id == LiveKit room; must match the daemon's --session"
+    )
+    parser.add_argument("--web-port", type=int, default=WEB_PORT, help=f"web panel port (default {WEB_PORT})")
+    parser.add_argument(
+        "--transport", choices=["aiortc", "livekit"], default="aiortc", help="transport backend"
+    )
+    parser.add_argument("--signaling-url", default=SIGNALING_URL, help="WS relay URL (aiortc)")
+    parser.add_argument(
+        "--auth-token",
+        default=os.environ.get("SIGNALING_AUTH_TOKEN"),
+        help="shared token for an authed signaling relay (aiortc; default $SIGNALING_AUTH_TOKEN)",
+    )
+    parser.add_argument(
+        "--livekit-url", default=os.environ.get("LIVEKIT_URL"), help="LiveKit URL (default $LIVEKIT_URL)"
+    )
+    parser.add_argument(
+        "--livekit-token", default=None, help="pre-signed JWT; omit to self-sign from api key/secret"
+    )
+    parser.add_argument(
+        "--livekit-api-key", default=os.environ.get("LIVEKIT_API_KEY"), help="default $LIVEKIT_API_KEY"
+    )
+    parser.add_argument(
+        "--livekit-api-secret", default=os.environ.get("LIVEKIT_API_SECRET"), help="$LIVEKIT_API_SECRET"
+    )
+    parser.add_argument("--livekit-identity", default="controller", help="this controller's LiveKit identity")
+    parser.add_argument(
+        "--cameras",
+        default="front",
+        help="camera set, comma-separated; must match the robot daemon's names. "
+        f"Each is 'name' (default {WIDTH}x{HEIGHT}) or 'name:WxH'. e.g. 'front,wrist:640x480'",
+    )
+    args = parser.parse_args()
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+
+    livekit_token = args.livekit_token
+    if args.transport == "livekit":
+        if not args.livekit_url:
+            parser.error("--livekit-url (or $LIVEKIT_URL) is required for --transport livekit")
+        if not livekit_token:
+            if not args.livekit_api_key or not args.livekit_api_secret:
+                parser.error(
+                    "--transport livekit needs --livekit-token, or --livekit-api-key + "
+                    "--livekit-api-secret (or $LIVEKIT_API_KEY/$LIVEKIT_API_SECRET) to self-sign"
+                )
+            from lerobot.robots.webrtc_proxy.transport_livekit import make_livekit_token
+
+            # Room == session id; must match the daemon's --session.
+            livekit_token = make_livekit_token(
+                api_key=args.livekit_api_key,
+                api_secret=args.livekit_api_secret,
+                identity=args.livekit_identity,
+                room=args.session,
+            )
+
+    # camera set must match the robot daemon (same names + per-camera height/width) so the
+    # tiled video de-tiles correctly. 'name' => default res; 'name:WxH' => custom.
+    cams_cfg: dict[str, WebRTCCameraSpec] = {}
+    for item in (s.strip() for s in args.cameras.split(",")):
+        if not item:
+            continue
+        if ":" in item:
+            name, res = item.split(":", 1)
+            w, h = (int(x) for x in res.lower().split("x"))
+        else:
+            name, h, w = item, HEIGHT, WIDTH
+        cams_cfg[name.strip()] = WebRTCCameraSpec(height=h, width=w, fps=FPS)
+    _cam_names[:] = list(cams_cfg)
+
+    robot = WebRTCProxyRobot(
+        WebRTCProxyRobotConfig(
+            cameras=cams_cfg,
+            signaling_url=args.signaling_url,
+            signaling_token=args.auth_token,
+            session_id=args.session,
+            capture_fps=FPS,
+            action_timeout_s=0.5,
+            transport_backend=args.transport,
+            livekit_url=args.livekit_url,
+            livekit_token=livekit_token,
+        )
+    )
+    robot.connect()
+    _motors[:] = robot.motors
+    try:
+        obs = robot.get_observation()  # first obs validates the camera layout vs the robot
+    except CameraLayoutMismatchError as e:
+        # Friendly, actionable exit instead of a deep cv2.resize traceback.
+        print(f"\n  ✗ {e}\n", file=sys.stderr)
+        print(
+            f"  This side:  --cameras {args.cameras}\n"
+            "  Set the daemon's --cameras to the same names + resolutions (or fix this side),\n"
+            "  then re-run. Tip: a single shared camera is the easiest to get working first.\n",
+            file=sys.stderr,
+        )
+        robot.disconnect()
+        sys.exit(2)
+    _targets.update({f"{m}.pos": float(obs[f"{m}.pos"]) for m in _motors})  # hold current pose
+
+    server = None
+    if args.mode == "web":
+        server = ThreadingHTTPServer(("0.0.0.0", args.web_port), _Handler)  # noqa: S104
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        print(
+            f"\n  open http://localhost:{args.web_port}  — live remote camera + jog buttons. Ctrl-C to stop.\n"
+        )
+    else:
+        threading.Thread(target=_console_reader, daemon=True).start()
+
+    try:
+        _control_loop(robot)
+    finally:
+        _running = False
+        if server is not None:
+            server.shutdown()
+        robot.disconnect()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/webrtc_remote_so100/panel.html
+++ b/examples/webrtc_remote_so100/panel.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Remote SO-100 over WebRTC</title>
+  <style>
+    body { font-family: system-ui, sans-serif; margin: 16px; }
+    h3 { margin: 0 0 12px; }
+    img { width: 480px; border: 1px solid #ccc; display: block; background: #111; }
+    .row { margin: 6px 0; }
+    span.j { display: inline-block; width: 130px; }
+    button { width: 36px; height: 32px; font-size: 16px; }
+    b { margin-left: 8px; font-variant-numeric: tabular-nums; }
+  </style>
+</head>
+<body>
+  <h3>Remote SO-100 over WebRTC — live camera + jog</h3>
+  <img src="/stream" alt="remote camera" />
+  <div id="ctrl"></div>
+  <div class="row" style="margin-top:12px">
+    <button id="home" style="width:auto;height:34px;padding:0 14px;font-size:14px">Reset to Home</button>
+  </div>
+  <script>
+    let STEP = 3;
+    function jog(m, sign) { fetch(`/jog?motor=${m}&delta=${sign * STEP}`); }
+    function home() { fetch("/home"); }
+    async function poll() {
+      try {
+        const j = await (await fetch("/state")).json();
+        for (const m in j) {
+          const e = document.getElementById("v_" + m);
+          if (e) e.textContent = j[m].toFixed(1);
+        }
+      } catch (e) { /* transient */ }
+    }
+    async function init() {
+      const cfg = await (await fetch("/config")).json();
+      STEP = cfg.step;
+      const c = document.getElementById("ctrl");
+      for (const m of cfg.motors) {
+        const r = document.createElement("div");
+        r.className = "row";
+        r.innerHTML =
+          `<span class="j">${m}</span>` +
+          `<button onclick="jog('${m}', -1)">−</button> ` +
+          `<button onclick="jog('${m}', 1)">+</button>` +
+          `<b id="v_${m}">–</b>`;
+        c.appendChild(r);
+      }
+      document.getElementById("home").onclick = home;
+      setInterval(poll, 300);
+    }
+    init();
+  </script>
+</body>
+</html>

--- a/examples/webrtc_remote_so100/robot_daemon_so100.py
+++ b/examples/webrtc_remote_so100/robot_daemon_so100.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""robot side: serve a real SO-100 over WebRTC.
+
+Run this on the machine the arm + camera are plugged into. It opens the real
+``SO100Follower`` (serial bus + camera, torque enabled), then hands it to the
+WebRTCProxyRobot daemon: the daemon streams joints + camera to the cloud, applies
+incoming actions to the motors, and — crucially — cuts torque if the action stream
+stalls (network drop / cloud crash), so the arm never holds a dangerous pose.
+
+    Onboarding first (find the ids — see README):
+        uv run lerobot-find-port            # -> PORT below
+        uv run lerobot-find-cameras         # -> CAMERA_INDEX below
+
+    Then:
+        uv run python examples/webrtc_remote_so100/robot_daemon_so100.py
+"""
+
+import asyncio
+
+from lerobot.cameras.opencv import OpenCVCameraConfig
+from lerobot.robots.so_follower import SO100Follower, SO100FollowerConfig
+from lerobot.robots.webrtc_proxy.robot_daemon import run_daemon
+
+# ── fill these in from onboarding ──────────────────────────────────────────
+PORT = "/dev/tty.usbmodem5A460814411"  # lerobot-find-port
+CAMERA_INDEX = 0  # lerobot-find-cameras
+SIGNALING_URL = "ws://127.0.0.1:8765/ws"  # the relay (cloud); 127.0.0.1 for a same-host test
+SESSION_ID = "so100"
+FPS, WIDTH, HEIGHT = 30, 640, 480
+# Public internet? add STUN/TURN urls here (M4); empty is fine same-host / same-LAN.
+ICE_SERVERS: list[str] = []
+
+
+def main() -> None:
+    robot = SO100Follower(
+        SO100FollowerConfig(
+            port=PORT,
+            id="webrtc_so100",
+            cameras={
+                "front": OpenCVCameraConfig(index_or_path=CAMERA_INDEX, width=WIDTH, height=HEIGHT, fps=FPS)
+            },
+        )
+    )
+    robot.connect()  # opens the bus + camera and enables torque
+    try:
+        # run_daemon outlives any single cloud session: serve one, safe the arm on
+        # drop, then wait for the next. The robot is reused across sessions.
+        asyncio.run(
+            run_daemon(
+                SIGNALING_URL,
+                session_id=SESSION_ID,
+                motors=list(robot.bus.motors),
+                cam_name="front",
+                cam_height=HEIGHT,
+                cam_width=WIDTH,
+                capture_fps=FPS,
+                action_timeout_s=0.5,
+                ice_servers=ICE_SERVERS,
+                robot=robot,
+            )
+        )
+    except KeyboardInterrupt:
+        pass
+    finally:
+        robot.disconnect()  # disables torque on disconnect
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,6 +127,21 @@ viz = [
     "rerun-sdk>=0.24.0,<0.34.0",
     "foxglove-sdk>=0.25.1,<0.26.0",
 ]
+# WebRTCProxyRobot transport (cloud-side proxy <-> robot-side capture agent over WebRTC).
+# aiortc pulls in PyAV (decoded frames as ndarray) + DataChannels; see src/lerobot/robots/webrtc_proxy.
+webrtc = [
+    "aiortc>=1.9.0,<2.0.0",
+    "aiohttp>=3.9.0,<4.0.0",  # WebSocket signaling client + relay server
+    "lerobot[av-dep]",
+]
+# Optional alternative transport backend (LiveKit SFU; cross-public-net / scale). EXPERIMENTAL.
+# `livekit` provides livekit.rtc (the transport); `livekit-api` provides livekit.api,
+# used to self-sign room tokens (robot_daemon/cloud_teleop --livekit-api-key/secret).
+webrtc-livekit = [
+    "lerobot[webrtc]",
+    "livekit>=0.18.0,<2.0.0",
+    "livekit-api>=0.8.0,<2.0.0",
+]
 # ── User-facing composite extras (map to CLI scripts) ─────
 # lerobot-record, lerobot-replay, lerobot-calibrate, lerobot-teleoperate, etc.
 core_scripts = ["lerobot[dataset]", "lerobot[hardware]", "lerobot[viz]"]
@@ -335,6 +350,7 @@ all = [
     "lerobot[robometer]",
     "lerobot[topreward]",
     "lerobot[peft]",
+    "lerobot[webrtc-livekit]",
     # "lerobot[unitree_g1]", TODO: Unitree requires specific installation instructions for unitree_sdk2
 ]
 

--- a/src/lerobot/robots/webrtc_proxy/DESIGN.md
+++ b/src/lerobot/robots/webrtc_proxy/DESIGN.md
@@ -1,0 +1,391 @@
+# WebRTCProxyRobot — Design Document
+
+Status: living design. Implementation status per section is marked
+`[done]` / `[partial]` / `[planned]`. Code lives in
+`src/lerobot/robots/webrtc_proxy/`; user-facing setup in `README.md`; original
+product handoff in `/webrtc_proxy_robot_context.md`.
+
+---
+
+## 1. Goal & constraints
+
+Let a user run a **real robot (SO-ARM, STS3215 bus) + cameras plugged into their own
+robot**, while the **control/AI logic runs in our cloud**. The two are bridged over
+**WebRTC**. This is a product, not a single-user research rig:
+
+- **No GPU at the edge.** We cannot ask each customer to host a GPU box. Control,
+  policy inference, recording all run cloud-side. (Rules out "move eval/record local".)
+- **The robot is behind NAT.** No public address; it must register outward.
+- **Hardware stays on the robot.** We transport *semantic* observations/actions, not
+  serial bytes or USB packets. (Rules out socat serial-forward, usbip USB-passthrough —
+  macOS can't host usbip anyway.)
+- **Safety is P0.** A network drop must never leave the arm straining or stuck in a
+  dangerous pose.
+
+## 2. Why cut at the `Robot` abstraction (subclass, not monkey-patch)
+
+Every LeRobot policy / record / teleop path talks to hardware only through
+`get_observation()` and `send_action()`. So we implement a **fake cloud-side
+`Robot`** and run the real one on the robot. We **subclass + register**
+(`@RobotConfig.register_subclass("webrtc_proxy")`) rather than monkey-patch, so:
+
+- LeRobot upgrades don't shatter us;
+- `observation_features` / `action_features` are declared correctly (datasets/policies
+  read them for shapes);
+- existing teleop/record/policy code drives the remote arm **with zero WebRTC-specific
+  code** (see `examples/webrtc_remote_so100`).
+
+## 3. Components & topology
+
+```
+ ROBOT HOST (NAT'd)                SIGNALING (FaaS)          CLOUD (K8s)
+ ┌────────────────────┐            ┌──────────────┐          ┌────────────────────────┐
+ │ robot_daemon.py    │  ws (SDP)  │ relay        │  ws(SDP) │ WebRTCProxyRobot        │
+ │  CaptureAgent      │───────────▶│ pair by      │◀─────────│  (used by record /      │
+ │  SO100Follower     │            │ session_id   │          │   policy / teleop pod)  │
+ │  watchdog (P0)     │            └──────────────┘          │ _ProxyEndpoint          │
+ │                    │                                      │ AlignmentBuffer         │
+ │   ╞═══════════ WebRTC P2P (media track + DataChannels) ═══════════╡                 │
+ │   │  camera→ media (RTP/UDP) ;  joints/action/control → DataChannels               │
+ └───┼────────────────┘   (aiortc: direct UDP, host+STUN; relay → LiveKit backend)     │
+     └──────────────────────────────────────────────────────────────┴────────────────┘
+```
+
+Three processes:
+- **`robot_daemon.py`** `[done]` — long-lived on the robot. Connect to the relay, offer,
+  serve one cloud session, **safe the arm on drop**, loop for the next. Holds the real
+  `SO100Follower` (reused across sessions).
+- **`signaling_server.py`** `[done, single-instance]` — pairs a `robot` and a
+  `controller` by `session_id`, forwards SDP, buffers for the late joiner, sends `bye`
+  on drop. *Carries only signaling — never media.* (FaaS deployment: §11.2.)
+- **`WebRTCProxyRobot`** (`proxy_robot.py`) `[done]` — the cloud `Robot`. Pure
+  controller; owns a bg asyncio loop running `_ProxyEndpoint` (the WebRTC answerer) and
+  bridges the synchronous `Robot` API to it.
+
+## 4. Transport: channels & reliability
+
+WebRTC gives us two kinds of pipe; we use both deliberately (`protocol.py`):
+
+| Carrier | Payload | Reliability | Why |
+|---|---|---|---|
+| **media track** (RTP/UDP) | camera frames (VP8/H.264) | lossy, no retransmit | raw 640×480×3@30 ≈ 220 Mbps (why we must encode, never raw on a DataChannel); the *encoded* track is ≈1–5 Mbps, adaptive |
+| DataChannel `state` | joints + capture `t`,`seq` + applied feedback | **configurable** (default unreliable) | see profiles below |
+| DataChannel `action` | goal joints + `seq` + `obs_seq` | **configurable** (default unreliable) | see profiles below |
+| DataChannel `control` | onboarding RPC (find_port, list_cameras, grab, plan) | **reliable, ordered** (always) | one-shot commands must arrive |
+
+Never put images on a DataChannel — bandwidth blows up (handoff challenge A).
+
+**Absolute, not delta, actions.** Goals are absolute `<motor>.pos`. A dropped action
+just means the next absolute goal corrects the arm — no accumulating error. Deltas
+would be unsafe over a lossy channel.
+
+### 4.1 state/action reliability is per use case `[done]`
+
+`control` is always reliable+ordered. `state`/`action` are configurable
+(`reliable_state`/`reliable_action`; `--profile teleop|eval|record` on the daemon),
+because the requirements genuinely differ:
+
+| | teleop | eval (policy) | record (dataset) |
+|---|---|---|---|
+| **state** | unreliable — freshest wins | unreliable — freshest obs → action | **reliable** — never lose an obs |
+| **action** | unreliable — stale cmd useless | unreliable | **reliable** — never lose a transition's action |
+
+Realtime closed loops (teleop/eval) prize **freshness**: a lost packet on a *reliable*
+channel head-of-line-blocks until retransmitted, delivering a stale sample late — worse
+than dropping it and waiting 33 ms for the next. Recording prizes **completeness**: both
+state and action are reliable so the dataset has no missing obs or actions. Either way,
+total disconnect is still caught by the watchdog (§7), and absolute actions self-correct
+after a drop.
+
+Note (current limitation): channels are created by the robot daemon (the offerer), so the
+profile is set **daemon-side** today. Controller-driven selection per session (push the
+profile through signaling before the offer) is a later refinement.
+
+## 5. Observation assembly — pairing camera & joints `[done]`
+
+Camera (media track) and joints (state channel) traverse the net with **independent
+jitter/loss**. Pairing by *arrival* time would let jitter corrupt temporal ordering of
+a dataset. Joints and the camera frame of one cycle come from a single
+`robot.get_observation()` on the robot, so they **share a capture seq**; the cloud
+`AlignmentBuffer` pairs `frame.seq == state.seq` — exact, and robust to loss (a dropped
+frame/state just skips that seq).
+
+`get_observation` returns the freshest seq present on **both** sides. If the newest seq
+is incomplete (its frame or state hasn't arrived / was dropped) it falls back to the
+previous complete seq, or holds the last obs on a stall — never a fresh-joints /
+stale-frame mismatch.
+
+### 5.1 How a frame carries its capture seq
+
+A decoded video frame arrives **naked**: its RTP `pts` is re-stamped, so it carries no
+application-level `seq`. We encode the seq into the frame's `pts`:
+`pts = seq * VIDEO_PTS_PER_SEQ`, and the cloud recovers
+`seq = round(pts · time_base · clock / VIDEO_PTS_PER_SEQ)`. pts survives VP8/H.264; the
+cloud then pairs `frame.seq == state.seq`. A dropped frame just skips a seq — no cascade.
+
+**Caveat:** the receiver re-bases the *first received* frame to `pts=0`, so seq is
+recovered relative to the first received frame. The daemon resets seq to 0 per session,
+so as long as the first frame lands (true at session start) relative == absolute; loss
+of the *initial* frame would shift the offset.
+
+**End state:** carry an absolute seq in an **RTP header extension** (frame
+self-describes, no re-basing) once the media stack supports custom header extensions —
+aiortc's support is limited today. (Pixel-embedding a seq is rejected: it pollutes the
+recorded image.)
+
+## 6. Control loop & RTT — the paradigm decision `[planned, M5]`
+
+`get_observation`/`send_action` look local and instant to callers, but each now costs a
+public-net RTT. RTT does not vanish by changing the abstraction; it moves to the RPC
+boundary (handoff challenge B). 50 ms RTT ⇒ ~20 Hz, jittery.
+
+Two product paradigms (must be chosen — it shapes what the action channel carries):
+- **Real-time per-frame teleop** — every action crosses the net; hand-feel RTT-locked.
+- **Intent + local autonomy** — the tight loop closes on the robot; the net carries
+  high-level intent + monitoring video + occasional takeover. An order of magnitude more
+  RTT-tolerant.
+
+Cross-net real-time *synchronization* is physically impossible; we make the loop
+**traceable** (§9) and pick a paradigm.
+
+## 7. Safety — watchdog `[done, P0]`
+
+The robot-side `CaptureAgent` watchdog: if no action arrives within `action_timeout_s`, it
+**cuts motor torque** (`robot.bus.disable_torque()`) so the arm goes limp instead of
+holding/straining. Torque is re-enabled at session start and when actions resume. All
+serial-bus access runs on a single worker thread, so the public-net loop never blocks on
+serial and the bus is never touched concurrently.
+
+## 8. Control plane — cloud-driven onboarding `[done]`
+
+Physical IDs (serial port, camera index/serial) are **robot-local** and never enter the
+cloud config (the cloud declares only logical names + resolution). They're discovered
+over the reliable `control` DataChannel (`control.py`):
+
+- `list_ports`, `list_cameras` (real via `LocalDeviceInventory`, hushing the noisy
+  OpenCV/RealSense probe).
+- `find_port` is **event-driven two-step** (`begin` → user unplugs the bus on the robot →
+  `result` diffs) because the human is at the robot, not sharing the cloud's stdin.
+- `grab_camera` returns one JPEG frame of a chosen camera for an onboarding preview
+  (over the control channel — distinct from the continuous obs media track).
+- `set_camera_plan` lets the cloud push its desired `{w,h,fps}` so the robot encodes to it
+  (bandwidth); correctness doesn't depend on it — `get_observation` re-fits to the spec.
+
+## 9. Traceability — provenance & applied feedback `[done]`
+
+So each transition is reconstructable across the data/track split:
+- `ActionMsg.obs_seq` — the cloud stamps each action with the `seq` of the obs it was
+  derived from.
+- `StateMsg.applied_seq/applied_t` — the robot piggybacks "last action I applied (seq +
+  time)" on the 30 Hz state stream (no extra channel), so the cloud confirms landing and
+  measures round-trip / counts dropped actions.
+
+## 10. Packet-loss behaviour (summary)
+
+- **media**: frames drop (UDP); needs seq-keyed re-identification (§5.1) + skew drop as a
+  safety net.
+- **state/action**: configurable (§4.1); unreliable by default — absolute positions +
+  seq pairing + watchdog absorb loss; reliable for record so no obs is lost.
+- **control/signaling**: reliable; no loss unless the connection dies.
+
+---
+
+## 11. Deployment
+
+### 11.1 Cloud control plane in **K8s** `[planned, M4]`
+
+What runs in K8s is **whatever consumes `WebRTCProxyRobot`** — a record job, a policy
+inference server, or a teleop-session backend pod. Each session = one controller pod ↔
+one robot daemon.
+
+**Decision (backend split).** A clean line, no TURN relay under aiortc:
+
+- **aiortc = direct UDP.** Host candidates connect on a LAN; **STUN** adds a
+  server-reflexive (public) candidate so peers also connect **directly** across NAT when at
+  least one side is reachable (e.g. a cloud controller with a public IP + a home daemon
+  dialing out — verified to connect with STUN alone, media direct, no relay hop). STUN only
+  *discovers* the address; media stays peer-to-peer. The **signaling relay distributes STUN
+  on connect** (an `{"kind":"ice"}` message; `signaling_server.py` `IceConfig`,
+  `--stun-url`), so peers need no ICE config. aiortc does **not** run a TURN relay.
+- **LiveKit (SFU) = the relay.** When you genuinely need media relayed (both ends behind
+  restrictive/symmetric NAT, or you want zero-ops NAT traversal / multi-user / scale), use
+  the LiveKit backend. Its SFU bundles signaling + TURN + forwarding in one server and both
+  peers dial outward. We do **not** bolt a coturn onto aiortc to duplicate this — a
+  self-hosted single coturn is a dumb extra hop, whereas the SFU is purpose-built.
+
+So: **direct → aiortc (host + STUN); relay → LiveKit.** This keeps aiortc simple (no
+coturn / `hostNetwork` / announced-IP / port-range ops) and gives relay to the backend
+built for it.
+
+The **media path** per backend:
+
+- **aiortc:** UDP P2P (host or STUN-srflx). Connects when at least one side is reachable;
+  if *both* sit behind restrictive/symmetric NAT (no reachable side), it can't connect —
+  that's the LiveKit case, by design.
+- **LiveKit:** both peers dial *outward* to the SFU; no inbound path / announced IP / port
+  range to manage on our side. `aiortc` (default) gives decoded `ndarray` frames straight
+  into the LeRobot pipeline — great for the adapter, but single-connection / weak at scale.
+  The transport is pluggable (`transport.py` `Transport` interface; pick via
+  `transport_backend`): `AiortcTransport` is the default; `transport_livekit.py` is a
+  working (experimental, optional) `LiveKitTransport`, the chosen SFU because it handles
+  signaling + TURN + scale AND has a Python SDK to pull frames into LeRobot. It is
+  **verified end-to-end** against both a local `livekit-server --dev` and LiveKit Cloud
+  (obs + action + control round-trip with fresh aligned observations); see the opt-in
+  `tests/webrtc/test_webrtc_proxy_livekit.py`.
+
+**The two topologies side by side:**
+
+```
+aiortc backend — direct UDP P2P; the signaling relay only brokers SDP + STUN config.
+
+  robot daemon (home / NAT)          signaling_server (public)        Cloud controller
+  ┌─────────────────────┐   ws    ┌──────────────────────┐   ws   ┌─────────────────────┐
+  │ robot_daemon          │   SDP   │ relay: pair by        │   SDP  │ WebRTCProxyRobot     │
+  │  CaptureAgent       │────────▶│ session_id;           │◀───────│  _ProxyEndpoint      │
+  │  SO100Follower      │  +STUN  │ push STUN on connect  │  +STUN │  AlignmentBuffer     │
+  └──────────┬──────────┘   cfg   └──────────────────────┘   cfg  └──────────┬──────────┘
+             │                      (relay NEVER carries media)                │
+             └════════ WebRTC media — UDP DIRECT (host / STUN srflx) ══════════┘
+                camera→RTP/UDP  ·  joints / action / control → DataChannels
+                STUN only discovers each side's public addr; the media path is peer-to-peer.
+                Connects when ≥1 side is reachable (LAN, or one public + STUN). No relay hop.
+```
+
+```
+livekit backend — SFU; both peers dial OUTWARD, media ALWAYS via the server.
+
+  robot daemon (home / NAT)                                    Cloud controller
+  ┌─────────────────────┐                                    ┌─────────────────────┐
+  │ robot_daemon          │                                    │ WebRTCProxyRobot     │
+  │  CaptureAgent       │                                    │  _ProxyEndpoint      │
+  │  (publisher)        │                                    │  (subscriber)        │
+  └──────────┬──────────┘                                    └──────────┬──────────┘
+             │  dial out: wss signaling + WebRTC media                   │  dial out
+             │              ┌────────────────────────────────┐          │
+             └─────────────▶│        LiveKit SFU             │◀──────────┘
+               publish       │  (LiveKit Cloud or self-hosted │   subscribe
+               video + data  │   livekit-server)              │   video + data
+                             │  signaling + TURN + forwarding │
+                             └────────────────────────────────┘
+                no inbound needed (NAT-friendly); the SFU is always in the media path.
+                Use when both ends are behind hard NAT, or for zero-ops / multi-user / scale.
+```
+
+### 11.1.1 NAT / restrictive-egress reachability `[direct → aiortc, relay → LiveKit]`
+
+The two ends' network conditions pick the backend:
+
+- **aiortc = direct UDP (host + STUN).** Connects directly when at least one side is
+  reachable: same LAN (host), or one side public + STUN for the other's srflx (the common
+  cloud-controller + home-daemon case). If **both** ends are behind restrictive/symmetric
+  NAT with no reachable side — or a peer can only egress via an `HTTP(S)_PROXY` (aiortc
+  can't route media through an HTTP forward proxy) — aiortc can't connect. Use LiveKit.
+- **LiveKit (SFU) = the relay.** **Both** peers *dial outward* to the SFU — neither needs
+  an inbound path — covering the **NAT side** cleanly (outbound + SFU-side TURN). For a
+  **proxy-only side**:
+  - *signaling* (wss:443) traverses the HTTP proxy fine (it is just HTTPS/CONNECT);
+  - *media* still needs the WebRTC client to tunnel ICE/TURN (TURN/TLS:443) through that
+    proxy, which libwebrtc supports only partially and the Python SDK does not expose.
+    Typical failure shape: **room connects, no track/data flows** — verify on the real
+    proxied host; if media won't traverse, place the controller where it has direct egress
+    (the usual cloud deployment, which is the normal topology anyway).
+
+Scaling note: one controller pod per active session (stateful, holds a PeerConnection +
+the bg loop). Autoscale on session count; sessions are sticky to their pod for their
+lifetime.
+
+### 11.2 Signaling in **FaaS** `[planned]`
+
+Signaling is low-traffic (a handful of SDP messages per session) and bursty — a good
+serverless fit. **But a WebSocket relay is awkward on vanilla FaaS**, and this needs
+care:
+
+- **The hard part:** the relay must hold *two long-lived WebSocket connections* (robot +
+  controller) and forward between them. Plain FaaS is request/response and
+  short-lived; the two peers may land on **different ephemeral instances** with no shared
+  memory, so in-process forwarding (what `signaling_server.py` does today) doesn't
+  translate directly.
+- **Recommended FaaS shapes:**
+  1. **Cloudflare Durable Objects (cleanest).** One DO instance *per `session_id`* — both
+     peers route to the *same* single-threaded stateful actor, which holds both sockets
+     and relays in-memory + buffers the early offer. This is essentially the current
+     in-process room, but the platform guarantees per-session affinity. Workers stay
+     serverless; the DO is the per-session rendezvous.
+  2. **AWS API Gateway WebSocket + Lambda + a shared store.** API GW holds the sockets;
+     Lambda handles `$connect`/`$message`/`$disconnect`. Map `session_id → {robotConnId,
+     controllerConnId}` and buffer the early offer in **DynamoDB/Redis**; forward by
+     calling the API GW management API to push to the peer's connection id. (Azure: Web
+     PubSub / SignalR Service is the equivalent.)
+  3. **Volcengine veFaaS "Web App" (single-instance, multi-concurrency).** veFaaS can host a
+     long-running web server (configurable listen port, per-instance concurrency, timeout). Run
+     `signaling_server.py` **unchanged** as a Web App with **per-instance concurrency ≥ 2** and the
+     instance count pinned to **1** — both the robot and controller WebSockets land on the
+     *same* warm instance, so the in-process `rooms` dict works as-is. Ideal for the
+     **single-user** case: no external store, the platform gateway terminates TLS (wss for
+     free on a bound domain), and `--port`/`--auth-token` read from `$PORT`/
+     `$SIGNALING_AUTH_TOKEN`. Caveats: keep min-instances ≥ 1 (or accept a cold start on
+     the daemon's first connect) and don't scale out — a second instance would split the
+     two peers. (Same single-instance trick on any FaaS that supports a long-running web
+     server + per-instance concurrency.)
+- **Porting `signaling_server.py`:** for the multi-instance shapes (1, 2) the in-memory
+  `rooms`/`inbox` dicts become external per-session state (DO memory, or DynamoDB/Redis);
+  the single-instance shape (3) needs no change at all. The wire protocol
+  (`?session=&role=`, `{kind:"sdp"|"bye"}`) is unchanged either way, so `WebSocketSignaling`
+  (client) and the daemon/controller need **no changes**.
+- **Auth lives here** (§12): the FaaS `$connect`/handshake is the natural place to
+  validate a session token before pairing.
+- **STUN config:** the signaling relay also hands each peer its STUN servers on connect
+  (for aiortc's direct cross-NAT P2P). A media **relay** (both ends behind hard NAT) is the
+  LiveKit backend's job, not coturn under aiortc — see §11.1.
+
+So the split is clean: **signaling = stateless-ish FaaS** (cheap, bursty, per-session
+affinity via DO/store); **media = direct P2P (aiortc) or the LiveKit SFU** (never in FaaS);
+**control logic = K8s pods**.
+
+### 11.3 Session lifecycle across the system
+
+1. robot daemon boots → opens WS to the FaaS relay (`role=robot`, `session_id`) → creates
+   the WebRTC offer → relay **buffers** it.
+2. A cloud controller pod starts a session → opens WS (`role=controller`, same
+   `session_id`) → relay flushes the buffered offer → controller answers → relay forwards.
+3. ICE (host + STUN) establishes the **direct** P2P media+data path. **Relay drops out of
+   the data path.** (If both ends are unreachable behind hard NAT, that's the LiveKit
+   backend's case instead — see §11.1.)
+4. Stream obs / send actions / run control-plane RPCs.
+5. Session ends or drops → relay `bye` to the survivor → daemon **safes the arm**, resets,
+   loops for the next session (it outlives any one session).
+
+## 12. Security & multi-tenancy
+
+- **Shared token** `[done]` — `signaling_server --auth-token <str>`; every peer presents
+  it (`Authorization: Bearer …`, constant-time compared) or is rejected (401) before
+  pairing. Gates the door against scanners. **Limitation:** one token for everyone — it
+  does NOT isolate sessions/tenants (anyone holding it can join any `session_id`).
+- **Per-session signed token** `[planned]` (FaaS `$connect`): a short-lived JWT binds a
+  user to a `session_id` and role; reject mismatched pairings. This is what stops
+  cross-tenant hijacking; the shared token is only the first gate.
+- **DTLS-SRTP** encrypts media/data end-to-end for free (WebRTC mandatory).
+- **Daemon identity:** the robot daemon authenticates to the relay; a stolen `session_id`
+  must not let an attacker drive someone's arm. Tokens + per-daemon keys.
+
+## 13. Milestones & status
+
+| M | Scope | Status |
+|---|---|---|
+| M1 | Loopback transport (channels, alignment, watchdog) | `[done]` |
+| M2 | Real `so_follower` (joints/action/torque) + SO-100 example | `[done]` |
+| M3 | WS signaling + robot daemon + control plane (discovery, plan, grab) | `[done]` (same-host) |
+| — | Seq-based obs pairing (pts carrier); provenance + applied feedback; configurable channel reliability | `[done]` |
+| M4 | Public-net: STUN distribution `[done]`; K8s media (hostNetwork/announced IP), FaaS signaling, auth | `[planned]` |
+| M5 | Paradigm: real-time vs intent+local-autonomy; SFU for scale | `[planned]` |
+
+## 14. Open questions
+
+1. **Frame-seq carrier** (§5.1): move from pts (re-basing caveat) to an RTP header
+   extension for an absolute seq. Gating: aiortc header-extension support / SFU choice.
+2. **Paradigm** (§6): real-time per-frame vs intent + local autonomy — gates the action
+   channel design.
+3. **Media plane at scale**: aiortc-per-session vs LiveKit/mediasoup SFU.
+4. **FaaS signaling target**: single-user → Volcengine veFaaS "Web App" single-instance
+   (relay runs unchanged, §11.2.3). Multi-tenant → Durable Objects vs API-GW-WS + store
+   (externalize the room state).

--- a/src/lerobot/robots/webrtc_proxy/README.md
+++ b/src/lerobot/robots/webrtc_proxy/README.md
@@ -1,0 +1,244 @@
+# WebRTCProxyRobot
+
+Cloud-side **proxy robot** that presents a robot-tethered real robot (SO-ARM +
+cameras) to LeRobot as if it were local. Control/AI logic runs in the cloud; the
+real hardware stays on the user's MacBook; the two are bridged over **WebRTC**.
+
+Full product context (topology, K8s/coturn, paradigm decision): see
+[`/webrtc_proxy_robot_context.md`](../../../../webrtc_proxy_robot_context.md).
+Feature ledger + status: [`/feature_list.md`](../../../../feature_list.md).
+
+## Why a `Robot` subclass
+
+Every LeRobot policy / record / teleop flow talks to hardware only through
+`send_action` and `get_observation`. We implement a fake `Robot` cloud-side and run
+the real one on the robot, transporting **semantic action/obs** (not serial bytes or
+USB packets). We subclass + register — never monkey-patch — so LeRobot upgrades
+don't break us and the schema metadata (`observation_features` / `action_features`)
+is declared correctly.
+
+## Architecture
+
+The cloud `WebRTCProxyRobot` is a **pure controller** — it reaches a remote robot
+daemon over a WebSocket signaling relay; it never embeds a robot agent. (Tests/demo
+run the relay + daemon + controller as separate loops in one process — see
+`conftest.py` / `demo_loopback.py`.)
+
+```
+ robot daemon (offerer)                       Cloud controller (answerer)
+ CaptureAgent                               WebRTCProxyRobot  (Robot subclass)
+  ├─ capture loop @ capture_fps              ├─ get_observation()  ← AlignmentBuffer
+  │   ├─ joints + seq ─ DataChannel state ─▶ │      (pairs state↔frame by SEQ)
+  │   └─ frame(seq in pts) ─ media track ──▶ │   _ProxyEndpoint (async, bg loop)
+  ├─ action handler ◀ DataChannel action ─── ┤   send_action()  → action DataChannel
+  └─ watchdog (P0 safe-stop)                 └─ _EventLoopThread bridges sync↔async
+```
+
+- **`protocol.py`** — channel labels, reliability flags, JSON message schemas (incl. RPC).
+- **`control.py`** — cloud-driven onboarding (M3): a reliable `control` DataChannel +
+  request/response RPC. `DeviceInventory` is the OS seam; `ControlServer` (robot)
+  answers `list_ports` / `list_cameras` / `grab_camera` / `find_port_*` /
+  `set_camera_plan`; `ControlClient` (cloud) matches responses by id. Port/camera IDs
+  stay robot-local.
+- **`alignment.py`** — `AlignmentBuffer`: thread-safe pairing of state↔frame by capture
+  **seq** (challenge A; joints+frame share a seq, the frame's seq rides its pts). A dropped
+  frame/state just skips that seq — no cascade. See `DESIGN.md` §5.1.
+- **`transport.py`** — pluggable transport: the `Transport` interface (named data
+  channels + a seq-tagged video stream) + `AiortcTransport` (default WebRTC P2P). The
+  proxy logic is transport-agnostic, so a different backend (e.g. a LiveKit SFU for
+  cross-public-net / scale) can implement `Transport` without touching the rest.
+- **`capture_agent.py`** — robot endpoint. Owns the capture clock, pushes state + video
+  (seq in pts) via the transport, applies actions, runs the **watchdog** (challenge C).
+- **`proxy_robot.py`** — `WebRTCProxyRobot` (sync `Robot` API) + `_ProxyEndpoint`
+  (async answerer) + `_EventLoopThread` (sync↔async bridge).
+- **`signaling.py`** — `Signaling` protocol + `WebSocketSignaling` client (real
+  relay) + an in-process loopback pair (used internally by direct endpoint tests).
+- **`signaling_server.py`** — WebSocket signaling **relay**: pairs a daemon
+  (`role=robot`) with a controller (`role=controller`) by session id, buffering SDP
+  for late joiners. Standalone: `python -m ...signaling_server --port 8765`.
+- **`robot_daemon.py`** — the persistent robot-side daemon: connect → offer → serve one
+  session → safe the arm on drop → loop. Standalone entrypoint with reconnect.
+- **`demo_loopback.py`** — runnable single-machine demo (relay + synthetic daemon +
+  controller in one process): discovery, obs streaming, watchdog.
+- **`sim_remote.py`** — simulate the *remote* control plane on one machine: relay +
+  daemon + controller as three loops over localhost, then run one RPC and print the
+  result. `python -m ...sim_remote --rpc list_cameras|list_ports|find_port|observe|all`.
+
+## Install
+
+```bash
+uv pip install --native-tls 'aiortc>=1.9.0,<2.0.0'   # or: uv sync --extra webrtc
+```
+
+## Manual verification
+
+Run the self-contained demo (relay + synthetic daemon + controller in one process,
+driven through the **synchronous** Robot API):
+
+```bash
+uv run python -m lerobot.robots.webrtc_proxy.demo_loopback
+```
+
+Expect: `observation_features`/`action_features` printed; ~30 re-assembled
+observations (`shoulder_pan.pos` + `front=(120,160,3)uint8`, `skew≈0ms`); the P0
+watchdog logging `SAFE STOP` once actions stop and clearing when they resume; a
+clean disconnect.
+
+The demo also exercises the **control plane**: `list_ports()`, `list_cameras()`, and
+the two-step `find_port_begin()` → (user unplugs the bus) → `find_port_result()`.
+
+To simulate one such call over the *remote* path (relay + daemon + controller, three
+loops, localhost sockets) without three terminals:
+
+```bash
+python -m lerobot.robots.webrtc_proxy.sim_remote --rpc list_cameras   # or list_ports / find_port / observe / all
+python -m lerobot.robots.webrtc_proxy.sim_remote --rpc list_cameras --real-devices   # this machine's real devices
+```
+
+### Device onboarding (port + camera IDs)
+
+Physical IDs are robot-local; the cloud config holds only logical names + resolution.
+The cloud discovers them over the control channel instead of storing them:
+
+```python
+robot.list_ports()        # serial ports visible on the robot
+robot.list_cameras()      # [{type, index_or_path|serial, name}, ...]
+before = robot.find_port_begin()   # snapshot; UI tells the user to unplug the bus
+robot.find_port_result()           # the port that disappeared == the motor bus
+```
+
+`find_port` is split in two because the human unplugs the bus on the robot — the
+cloud cannot share that stdin, so the sync point moves to the robot side (vs. the
+blocking `input()` in `lerobot-find-port`).
+
+By default the daemon answers from `SyntheticInventory` (fake devices). Start it
+with `--real-devices` to enumerate the robot's **actual** ports + cameras via
+`LocalDeviceInventory` (wraps lerobot's `find_available_ports` / `find_cameras`),
+so the calls above return the same ids the stock `lerobot-find-port` /
+`lerobot-find-cameras` CLIs would.
+
+### Real two-process link (robot daemon ↔ cloud controller)
+
+The cloud runs `WebRTCProxyRobot`; the robot runs a long-lived **daemon** that outlives
+any single cloud session. They meet on a WebSocket signaling relay. On one machine
+(same-host, no STUN needed — `ice_servers=[]`):
+
+```bash
+# 1) signaling relay (lives cloud-side in prod)
+python -m lerobot.robots.webrtc_proxy.signaling_server --port 8765
+# 2) robot daemon. --real-devices => real find_port/list_cameras; --real-camera 0 =>
+#    open & stream that opencv camera (index or /dev/videoN) instead of synthetic frames.
+python -m lerobot.robots.webrtc_proxy.robot_daemon \
+    --signaling-url ws://127.0.0.1:8765/ws --real-devices --real-camera 0 --width 640 --height 480
+# 3) cloud controller
+python - <<'PY'
+from lerobot.robots.webrtc_proxy.configuration_webrtc_proxy import WebRTCProxyRobotConfig, WebRTCCameraSpec
+from lerobot.robots.webrtc_proxy.proxy_robot import WebRTCProxyRobot
+cfg = WebRTCProxyRobotConfig(cameras={"front": WebRTCCameraSpec(480, 640, 30)},
+                             signaling_url="ws://127.0.0.1:8765/ws")
+r = WebRTCProxyRobot(cfg); r.connect()
+print(r.get_observation().keys()); print(r.list_ports()); r.disconnect()
+PY
+```
+
+Across NAT, start the **signaling relay with `--stun-url`** — it hands each peer its STUN
+servers on connect (an `{"kind":"ice"}` message; peers need no ICE config). STUN gives a
+server-reflexive (public) candidate, so aiortc connects **directly** as long as one side
+is reachable (e.g. a cloud controller with a public IP + a home daemon dialing out — media
+stays peer-to-peer, no relay hop). aiortc is **direct-only**; if *both* ends sit behind
+restrictive/symmetric NAT (or a peer only egresses via an HTTP proxy), use the **LiveKit
+backend** for the relay — we don't run a TURN/coturn under aiortc. See `DESIGN.md` §11.1.
+
+```bash
+# relay with STUN (public, or domestic, or self-hosted):
+python -m lerobot.robots.webrtc_proxy.signaling_server --host 0.0.0.0 --port 8765 \
+    --auth-token <T> --stun-url stun:stun.l.google.com:19302   # CN: stun:stun.qq.com:3478
+```
+
+Tests (suites needing the transport skip automatically without aiortc/aiohttp):
+
+```bash
+# NOTE: -p no:hydra_pytest works around an unrelated broken pytest plugin in this env.
+uv run pytest tests/webrtc/test_webrtc_proxy_*.py -p no:hydra_pytest -q
+```
+
+## LiveKit backend (experimental, optional)
+
+`aiortc` (default) is P2P and self-contained. The pluggable transport also has a
+**LiveKit (SFU)** backend for cross-public-internet / NAT / scale: both ends dial
+*outward* to a LiveKit server (LiveKit Cloud or self-hosted), so neither needs an
+inbound path. Verified end-to-end against a local `livekit-server --dev` and LiveKit
+Cloud. Install the extra: `uv sync --extra webrtc-livekit`.
+
+Both ends must use `--transport livekit` (an aiortc peer and a LiveKit room don't
+interoperate). The daemon needs no `--signaling-url` (LiveKit does its own signaling).
+Each process **self-signs its own token** from a shared API key/secret — set the
+LiveKit env vars once and you never paste a JWT (the room is `--session`; identities
+default to `robot` / `controller`):
+
+```bash
+# local dev server (key/secret default to devkey/secret)
+livekit-server --dev
+export LIVEKIT_URL=ws://127.0.0.1:7880 LIVEKIT_API_KEY=devkey LIVEKIT_API_SECRET=secret
+
+# robot daemon (publisher) — self-signs identity=robot from the env
+uv run python -m lerobot.robots.webrtc_proxy.robot_daemon --session so100 \
+    --transport livekit --real-camera 0   # drop --real-camera for synthetic frames
+
+# cloud controller (subscriber) — self-signs identity=controller
+uv run python examples/webrtc_remote_so100/cloud_teleop_so100.py --transport livekit
+```
+
+For production, don't ship the API secret to the robot — pass a pre-signed, scoped token
+with `--livekit-token` (minted by a cloud token server) instead of the key/secret.
+
+The opt-in e2e test runs the same two-process path:
+
+```bash
+LEROBOT_LIVEKIT_URL=ws://127.0.0.1:7880 \
+    LEROBOT_LIVEKIT_API_KEY=devkey LEROBOT_LIVEKIT_API_SECRET=secret \
+    uv run pytest tests/webrtc/test_webrtc_proxy_livekit.py -p no:hydra_pytest -q
+```
+
+NAT / restrictive-egress reachability (why SFU, not P2P) is covered in `DESIGN.md` §11.1.1.
+
+## Known limitations (M1 — to fix in later milestones)
+
+- **Frame seq rides `pts`, recovered relative to the first received frame.** Robust to
+  mid-stream frame loss (a drop just skips a seq), but the receiver re-bases the first
+  received frame to pts=0, so if the *initial* frame is lost the seq offset shifts.
+  Mitigated by resetting seq per session; production should carry an absolute seq in an
+  RTP header extension. See `DESIGN.md` §5.1.
+- **Multi-camera (tiled).** N cameras stream over the single video track by stacking each
+  frame into one tall frame on the robot and slicing them back on the cloud (`tiling.py`);
+  both ends derive the same layout from the name-sorted camera specs, so the seq pairing is
+  untouched and one camera is the identity. One encoder for the tiled frame is cheapest on
+  aiortc's Python encode path; for many/high-res streams use the LiveKit backend.
+- **Any robot (not just SO-100).** The daemon is robot-agnostic — it only uses the generic
+  `get_observation` / `send_action` / `bus` interface. Pick any registered robot on the CLI
+  via draccus: `robot_daemon --robot.type=so101_follower --robot.port=/dev/tty... [--robot.cameras...]`.
+  Motors + cameras are derived from the robot's own `observation_features` (the cloud
+  `WebRTCProxyRobotConfig` must declare the same schema). Joints + every camera come from one
+  `robot.get_observation()` (shared capture instant); actions call `robot.send_action`; the
+  watchdog cuts torque via `robot.bus.disable_torque()` (robots without a motor `bus` need a
+  custom `on_safe_stop`). All serial-bus access runs on one worker thread. Without `--robot.*`,
+  the synthetic source (or a bare `--real-camera`) still works for transport testing; the
+  `examples/webrtc_remote_so100` script shows the in-code `run_daemon(robot=...)` path.
+- **Camera sizing.** The daemon opens at the requested capture size, falling back to
+  native if the camera rejects it; `_fit_frame` + the cloud's defensive re-fit guarantee
+  the declared obs shape, and the cloud pushes its spec via `set_camera_plan` at connect.
+- **Device inventory: real but read-only.** `--real-devices` enumerates the robot's
+  actual ports + cameras (`LocalDeviceInventory`), so cloud-driven `find_port` /
+  `list_cameras` return real ids. Default stays `SyntheticInventory`. Persisting the
+  chosen port/camera→role mapping into a daemon config (and using it to open the bus)
+  is M2.
+- **aiortc reach = direct UDP.** Host candidates connect same-host / same-LAN; **STUN**
+  (relay `--stun-url`, auto-distributed on connect) adds a public srflx candidate so peers
+  connect directly across NAT when one side is reachable. aiortc runs **no TURN relay**:
+  if *both* ends are behind restrictive/symmetric NAT, or a peer only egresses via an HTTP
+  proxy, use the **LiveKit backend** (the relay path) instead.
+- **Daemon reconnect is per-session, single controller.** One `session_id` ↔ one
+  daemon ↔ one controller at a time. Multi-tenant routing / auth on the relay is later.
+- **send_action returns the optimistic goal** (no real clip/ack from the robot yet). M2.
+- **Paradigm not yet chosen** (real-time per-frame vs intent + local autonomy). M5;
+  affects what the action DataChannel actually carries.

--- a/src/lerobot/robots/webrtc_proxy/__init__.py
+++ b/src/lerobot/robots/webrtc_proxy/__init__.py
@@ -1,0 +1,37 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""WebRTCProxyRobot: cloud-side proxy for a robot-tethered real robot (see README.md).
+
+The config imports with no extra deps so draccus registration always works. The
+robot class (and its ``aiortc`` dependency) loads lazily on first access so the
+``robots`` package still imports without the ``lerobot[webrtc]`` extra.
+"""
+
+from .configuration_webrtc_proxy import WebRTCCameraSpec, WebRTCProxyRobotConfig
+
+__all__ = [
+    "CameraLayoutMismatchError",
+    "WebRTCCameraSpec",
+    "WebRTCProxyRobot",
+    "WebRTCProxyRobotConfig",
+]
+
+
+def __getattr__(name: str):
+    if name in ("WebRTCProxyRobot", "CameraLayoutMismatchError"):
+        from . import proxy_robot
+
+        return getattr(proxy_robot, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/lerobot/robots/webrtc_proxy/alignment.py
+++ b/src/lerobot/robots/webrtc_proxy/alignment.py
@@ -1,0 +1,84 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Capture-seq alignment buffer (handoff challenge A).
+
+The cloud receives proprioceptive state (state DataChannel) and camera frames
+(media track) on *separate* channels with independent jitter/loss. Each carries the
+robot-side capture **seq** of the cycle that produced it (joints + image come from one
+``robot.get_observation()`` on the robot, so they share a seq; the frame's seq rides
+its ``pts``). Pairing by seq is therefore *exact* — a state and a frame with the same
+seq are from the same capture instant — and robust to loss: a dropped frame or state
+just means that seq is incomplete; we use the freshest seq present on both sides.
+
+Deliberately tiny and thread-safe via a single lock: producers (asyncio receive
+callbacks) push from one thread, the consumer (``get_observation``) pulls from
+another.
+"""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class AlignedObs:
+    """A state and a camera frame from the same capture seq."""
+
+    seq: int
+    t: float  # robot capture time.monotonic() of this cycle (from the state)
+    joints: dict[str, float]
+    frame: np.ndarray  # HxWx3 uint8 RGB
+
+
+class AlignmentBuffer:
+    """Bounded, thread-safe pairing of state and frames by capture seq."""
+
+    def __init__(self, maxlen: int = 128) -> None:
+        self._states: dict[int, tuple[float, dict[str, float]]] = {}  # seq -> (t, joints)
+        self._frames: dict[int, np.ndarray] = {}  # seq -> frame
+        self._maxlen = maxlen
+        self._lock = threading.Lock()
+
+    def add_state(self, seq: int, t: float, joints: dict[str, float]) -> None:
+        with self._lock:
+            self._states[seq] = (t, dict(joints))
+            self._evict(self._states)
+
+    def add_frame(self, seq: int, frame: np.ndarray) -> None:
+        with self._lock:
+            self._frames[seq] = frame
+            self._evict(self._frames)
+
+    def _evict(self, d: dict) -> None:
+        # Bounded ring: drop the lowest (oldest) seqs once over capacity.
+        while len(d) > self._maxlen:
+            del d[min(d)]
+
+    def assemble(self) -> AlignedObs | None:
+        """The freshest seq present on BOTH sides, or None if there is no such pair."""
+        with self._lock:
+            common = self._states.keys() & self._frames.keys()
+            if not common:
+                return None
+            seq = max(common)
+            t, joints = self._states[seq]
+            return AlignedObs(seq=seq, t=t, joints=dict(joints), frame=self._frames[seq])
+
+    def has_state(self) -> bool:
+        with self._lock:
+            return bool(self._states)

--- a/src/lerobot/robots/webrtc_proxy/capture_agent.py
+++ b/src/lerobot/robots/webrtc_proxy/capture_agent.py
@@ -1,0 +1,360 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""robot-side capture agent (the *offerer*).
+
+Without a real ``robot`` it produces a *synthetic* source (no serial bus / camera).
+It runs the capture clock, pushes proprioceptive state over the state DataChannel,
+streams the camera over the media track (each frame's capture seq carried in its
+pts), receives actions, answers control-plane RPCs, and runs the P0 safety watchdog.
+
+The agent owns the WebRTC offer: it creates the state/action/control DataChannels and
+adds the video track, then hands its SDP to the signaling channel.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import time
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
+
+import numpy as np
+
+from . import tiling
+from .control import ControlServer, DeviceInventory, SyntheticInventory
+from .protocol import CH_ACTION, CH_CONTROL, CH_STATE, ActionMsg, StateMsg
+from .signaling import Signaling, SignalingClosedError
+from .transport import Transport, make_transport
+
+logger = logging.getLogger(__name__)
+
+
+def _fit_frame(img: np.ndarray, height: int, width: int) -> np.ndarray:
+    """Coerce a camera frame to the contiguous ``(height, width, 3)`` uint8 RGB the
+    media track requires (the cloud declared this shape in ``observation_features``)."""
+    if img.dtype != np.uint8:
+        img = img.astype(np.uint8)
+    if img.ndim == 2:
+        img = np.stack([img] * 3, axis=-1)
+    if img.shape[2] == 4:
+        img = img[:, :, :3]
+    if img.shape[0] != height or img.shape[1] != width:
+        import cv2
+
+        img = cv2.resize(img, (width, height))
+    return np.ascontiguousarray(img)
+
+
+class CaptureAgent:
+    """robot-side endpoint of the proxy link: publishes state + camera, applies actions.
+
+    Transport-agnostic: it talks to a :class:`Transport` (default aiortc). Swap the
+    transport for another backend (e.g. LiveKit) without touching this logic.
+    """
+
+    def __init__(
+        self,
+        signaling: Signaling | None,  # None for livekit (it does its own signaling)
+        motors: list[str],
+        cam_name: str | None = None,  # single-camera (back-compat); else use `cameras`
+        cam_height: int | None = None,
+        cam_width: int | None = None,
+        capture_fps: int = 30,
+        action_timeout_s: float = 0.5,
+        on_safe_stop: Callable[[], None] | None = None,
+        inventory: DeviceInventory | None = None,
+        ice_servers: list[str] | None = None,
+        camera=None,  # an opened lerobot Camera (read_latest); None => synthetic frames
+        cameras: dict[str, tuple[int, int]] | None = None,  # multi-cam: name -> (height, width)
+        cameras_src: dict | None = None,  # multi-cam: name -> opened Camera (read_latest)
+        robot=None,  # a connected lerobot Robot (so_follower) — drives joints+action+torque (M2)
+        reliable_state: bool = False,  # True for record (no lost obs); False for teleop/eval (fresh)
+        reliable_action: bool = False,
+        transport_backend: str = "aiortc",  # "aiortc" (default) | "livekit"
+        livekit_url: str | None = None,
+        livekit_token: str | None = None,
+        transport: Transport | None = None,  # explicit transport overrides the backend
+    ) -> None:
+        self.signaling = signaling
+        self.motors = list(motors)
+        # Single camera keeps cam_name/cam_h/cam_w (dynamic via set_camera_plan); multi
+        # camera uses a fixed `cameras` map. _capture_sample tiles whichever applies, and a
+        # single camera tiles to the identity frame (so single-cam stays byte-identical).
+        self._multi_cameras = dict(cameras) if cameras else None
+        self.cam_name = cam_name
+        self.cam_h = cam_height
+        self.cam_w = cam_width
+        self._cams_src = dict(cameras_src) if cameras_src else ({cam_name: camera} if camera else {})
+        self._last_frames: dict[str, np.ndarray] = {}  # per-camera last good frame
+        self.period = 1.0 / capture_fps
+        self.action_timeout_s = action_timeout_s
+        self._on_safe_stop = on_safe_stop
+
+        # The transport offers + sends video, exposes the data channels. The publisher
+        # (robot) sets channel reliability; control is always reliable.
+        self._transport = transport or make_transport(
+            transport_backend,
+            role="publisher",
+            channels={CH_STATE: reliable_state, CH_ACTION: reliable_action, CH_CONTROL: True},
+            ice_servers=ice_servers,
+            livekit_url=livekit_url,
+            livekit_token=livekit_token,
+        )
+        self.closed = self._transport.closed  # set when the link drops
+        self._transport.channel(CH_ACTION).on_message(self._on_action)
+        self._control = ControlServer(
+            inventory if inventory is not None else SyntheticInventory(),
+            on_camera_plan=self._apply_camera_plan,
+        )
+        self._control.attach(self._transport.channel(CH_CONTROL))
+        self._robot = robot
+        # All serial-bus access (read joints, send action, toggle torque) goes through
+        # ONE worker thread so the public-net event loop never blocks on serial and the
+        # bus is never touched concurrently. None when there is no real robot.
+        self._io: ThreadPoolExecutor | None = (
+            ThreadPoolExecutor(max_workers=1, thread_name_prefix="webrtc-robot-io")
+            if robot is not None
+            else None
+        )
+        self._seq = 0
+        self._action_seq = 0  # last action seq applied (for telemetry)
+        self._last_obs_seq_seen = -1  # provenance of the last action (which obs it came from)
+        self._last_goal: dict[str, float] = {f"{m}.pos": 0.0 for m in self.motors}
+        self._last_action_t = time.monotonic()
+        self._safed = False
+        self._tasks: list[asyncio.Task] = []
+        self._stop = asyncio.Event()
+
+    # ----- lifecycle -------------------------------------------------------
+    async def run(self) -> None:
+        """Establish the transport (offer) and start the capture/watchdog loops.
+
+        Returns once the loops are running; use :pymeth:`wait_closed` to block until
+        the link drops.
+        """
+        await self._transport.open(self.signaling)
+
+        if self._robot is not None and self._io is not None:
+            # New session: re-enable torque (a previous session's safe-stop may have cut it).
+            self._io.submit(self._robot_enable_torque)
+
+        self._tasks = [
+            asyncio.ensure_future(self._capture_loop()),
+            asyncio.ensure_future(self._watchdog_loop()),
+        ]
+        # Recycle fast: keep watching the signaling channel so the relay's "bye" (controller
+        # left) ends the session in sub-second time, instead of waiting ~10-30s for WebRTC's
+        # own ICE/DTLS disconnect detection. Only for aiortc (livekit has its own signaling).
+        if self.signaling is not None:
+            self._tasks.append(asyncio.ensure_future(self._watch_signaling()))
+        logger.info(
+            "CaptureAgent connected; streaming %d motors + camera %r", len(self.motors), self.cam_name
+        )
+
+    async def _watch_signaling(self) -> None:
+        """End the session promptly when the relay reports the controller left ("bye").
+
+        After the offer/answer exchange the signaling socket is otherwise idle; reading it
+        lets us notice the peer's departure immediately and recycle for the next session,
+        rather than waiting for the media link's slow timeout.
+        """
+        try:
+            while not self._stop.is_set():
+                await self.signaling.recv()  # blocks; raises SignalingClosedError on bye / close
+        except SignalingClosedError:
+            logger.info("signaling: controller left (bye) -> ending session for fast recycle")
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("signaling watcher error")
+        finally:
+            self.closed.set()  # unblock wait_closed() -> daemon loops to the next session
+
+    async def wait_closed(self) -> None:
+        """Block until the WebRTC link to the controller drops."""
+        await self.closed.wait()
+
+    def force_safe_stop(self) -> None:
+        """Idempotently engage the safe state (used when a session ends)."""
+        if not self._safed:
+            self._safed = True
+            self._safe_stop()
+
+    async def close(self) -> None:
+        self._stop.set()
+        for t in self._tasks:
+            t.cancel()
+        await self._transport.close()
+        if self.signaling is not None:
+            await self.signaling.close()
+        if self._io is not None:
+            # Let a pending safe-stop (disable_torque) finish, then stop the io thread.
+            self._io.shutdown(wait=True)
+
+    # ----- capture / actuation -------------------------------------------
+    def _specs(self) -> list[tuple[str, int, int]]:
+        """Ordered (name, h, w) per camera. Single camera tracks the (plan-mutable)
+        cam_name/cam_h/cam_w; multi camera is the fixed ``cameras`` map."""
+        if self._multi_cameras is not None:
+            return tiling.ordered_specs(self._multi_cameras)
+        return [(self.cam_name, self.cam_h, self.cam_w)]
+
+    def _capture_sample(self, t: float, seq: int) -> tuple[dict[str, float], np.ndarray]:
+        """One sample: joints + a (possibly multi-camera, tiled) frame.
+
+        With a real ``robot``, joints and every camera come from a single
+        ``robot.get_observation()`` (so they share a capture instant). Else: each camera is
+        a real one if attached (``cameras_src``), otherwise a synthetic per-camera coloured
+        frame; joints hold the last commanded pose. Frames are tiled into one (single
+        camera => identity), preserving the one-frame-per-seq pipeline.
+        """
+        specs = self._specs()
+        obs = self._robot.get_observation() if self._robot is not None else None
+        if obs is not None:
+            joints = {k: float(v) for k, v in obs.items() if k.endswith(".pos")}
+        else:
+            joints = dict(self._last_goal)  # synthetic arm: hold last commanded pose
+
+        frames: dict[str, np.ndarray] = {}
+        for idx, (name, h, w) in enumerate(specs):
+            frames[name] = self._camera_frame(name, h, w, seq, idx, obs)
+        return joints, tiling.tile(frames, specs)
+
+    def _camera_frame(self, name, h, w, seq, idx, obs) -> np.ndarray:  # noqa: ANN001
+        """One camera's frame at ``(h, w)``: from the robot obs, a real camera, or synthetic."""
+        if obs is not None:
+            frame = obs.get(name)
+            if frame is not None:
+                self._last_frames[name] = _fit_frame(frame, h, w)
+        else:
+            src = self._cams_src.get(name)
+            if src is not None:
+                # camera warming up / stale: fall through to last good (or synthetic)
+                with contextlib.suppress(Exception):
+                    self._last_frames[name] = _fit_frame(src.read_latest(max_age_ms=1000), h, w)
+            elif name not in self._last_frames:
+                # Synthetic, distinct per camera (idx) so each tile is identifiable.
+                img = np.empty((h, w, 3), dtype=np.uint8)
+                img[:] = ((seq + idx * 64) % 256, (seq * 5) % 256, (idx * 80) % 256)
+                return img
+        got = self._last_frames.get(name)
+        return got if got is not None else np.zeros((h, w, 3), dtype=np.uint8)
+
+    def _apply_action(self, goal: dict[str, float]) -> dict[str, float]:
+        """Drive the arm (runs on the io thread). Returns the action actually sent."""
+        if self._robot is not None:
+            try:
+                return self._robot.send_action(goal)
+            except Exception:
+                logger.exception("CaptureAgent: robot.send_action failed")
+                return goal
+        self._last_goal = dict(goal)
+        return self._last_goal
+
+    def _robot_enable_torque(self) -> None:
+        try:
+            self._robot.bus.enable_torque()
+        except Exception:
+            logger.exception("CaptureAgent: enable_torque failed")
+
+    def _robot_disable_torque(self) -> None:
+        try:
+            self._robot.bus.disable_torque()
+            logger.warning("CaptureAgent: torque disabled (safe stop)")
+        except Exception:
+            logger.exception("CaptureAgent: disable_torque failed")
+
+    def _apply_camera_plan(self, plan: dict) -> None:
+        """Cloud told us its desired obs size — encode/resize frames to it (bandwidth)."""
+        w, h = plan.get("width"), plan.get("height")
+        if w and h and (w != self.cam_w or h != self.cam_h):
+            logger.info("camera plan: obs size %dx%d -> %dx%d", self.cam_w, self.cam_h, w, h)
+            self.cam_w, self.cam_h = int(w), int(h)
+
+    def _safe_stop(self) -> None:
+        """P0: watchdog fired (actions stopped). Cut torque so the arm goes limp."""
+        logger.warning("WATCHDOG: no action for %.0fms -> SAFE STOP", self.action_timeout_s * 1e3)
+        if self._robot is not None and self._io is not None:
+            self._io.submit(self._robot_disable_torque)  # never touch the bus off the io thread
+        if self._on_safe_stop is not None:
+            self._on_safe_stop()
+
+    # ----- loops -----------------------------------------------------------
+    async def _capture_loop(self) -> None:
+        loop = asyncio.get_event_loop()
+        next_t = time.monotonic()
+        while not self._stop.is_set():
+            t = time.monotonic()
+            seq = self._seq
+            self._seq += 1
+            # Real serial reads run off-loop so public-net timing never blocks on the bus.
+            if self._io is not None:
+                joints, img = await loop.run_in_executor(self._io, self._capture_sample, t, seq)
+            else:
+                joints, img = self._capture_sample(t, seq)
+
+            # Piggyback the last applied action (seq + time) so the cloud can confirm
+            # landing and measure round-trip without an extra channel.
+            self._transport.channel(CH_STATE).send(
+                StateMsg(
+                    t=t,
+                    seq=seq,
+                    joints=joints,
+                    applied_seq=self._action_seq,
+                    applied_t=self._last_action_t,
+                ).to_json()
+            )
+            # The frame carries its seq in its pts (set inside the transport).
+            self._transport.send_frame(seq, img)
+
+            next_t += self.period
+            await asyncio.sleep(max(0.0, next_t - time.monotonic()))
+
+    def _on_action(self, raw: str) -> None:
+        try:
+            msg = ActionMsg.from_json(raw)
+        except Exception:
+            logger.exception("CaptureAgent: bad action message")
+            return
+        self._last_action_t = time.monotonic()  # sync: keeps the watchdog honest
+        self._action_seq = msg.seq
+        self._last_obs_seq_seen = msg.obs_seq
+        resumed = self._safed
+        if self._safed:
+            logger.info("WATCHDOG: action resumed (seq=%d) -> clearing safe state", msg.seq)
+            self._safed = False
+        if self._io is not None:
+            if resumed:
+                self._io.submit(self._robot_enable_torque)  # safe-stop cut torque; bring it back
+            self._io.submit(self._apply_action, msg.goal)  # serial write off the event loop
+        else:
+            self._apply_action(msg.goal)
+
+    async def _watchdog_loop(self) -> None:
+        # Poll at ~4x the timeout so we catch a stall well within one window.
+        tick = max(self.action_timeout_s / 4.0, 0.02)
+        while not self._stop.is_set():
+            await asyncio.sleep(tick)
+            stalled = (time.monotonic() - self._last_action_t) > self.action_timeout_s
+            if stalled and not self._safed:
+                self._safed = True
+                self._safe_stop()
+
+    # ----- introspection (tests) -------------------------------------------
+    @property
+    def is_safed(self) -> bool:
+        return self._safed

--- a/src/lerobot/robots/webrtc_proxy/configuration_webrtc_proxy.py
+++ b/src/lerobot/robots/webrtc_proxy/configuration_webrtc_proxy.py
@@ -1,0 +1,89 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Config for the cloud-side WebRTCProxyRobot.
+
+The proxy declares its observation/action schema from config alone (no hardware
+present cloud-side), mirroring ``so_follower``: action/state are ``"<motor>.pos"``
+floats and each camera is an ``HxWx3`` frame keyed by camera name.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from ..config import RobotConfig
+
+# SO-100/101 follower motors in bus order (matches so_follower).
+SO100_MOTORS: tuple[str, ...] = (
+    "shoulder_pan",
+    "shoulder_lift",
+    "elbow_flex",
+    "wrist_flex",
+    "wrist_roll",
+    "gripper",
+)
+
+
+@dataclass
+class WebRTCCameraSpec:
+    """One camera streamed over the media track. Drives the obs feature shape."""
+
+    height: int
+    width: int
+    fps: int = 30
+
+
+@RobotConfig.register_subclass("webrtc_proxy")
+@dataclass
+class WebRTCProxyRobotConfig(RobotConfig):
+    """Cloud-side proxy: real hardware lives on the user's robot, reached over WebRTC.
+
+    M1 (loopback) ignores ``signaling_url`` and pairs the two peers in-process.
+    Real deployments (M3+) point ``signaling_url`` at the K8s WebSocket signaler.
+    """
+
+    # Schema (must match the robot-side real robot exactly so dataset/policy shapes line up).
+    motors: list[str] = field(default_factory=lambda: list(SO100_MOTORS))
+    # camera_name -> spec. Default: one wrist+front pair is common, but keep it minimal here.
+    cameras: dict[str, WebRTCCameraSpec] = field(
+        default_factory=lambda: {"front": WebRTCCameraSpec(height=480, width=640, fps=30)}
+    )
+
+    # Capture / transport tuning.
+    capture_fps: int = 30
+    # P0 safety: robot watchdog safes the arm if no action arrives within this window.
+    action_timeout_s: float = 0.5
+    # Max capture-time skew tolerated when pairing state<->frame (telemetry/QA threshold).
+    pair_tolerance_s: float = 0.1
+    # How long connect() waits for the WebRTC link + first observation.
+    connect_timeout_s: float = 10.0
+
+    # Signaling. None / "loopback" => in-process loopback (demo + unit tests).
+    # "ws://host:port/ws" => connect to a WebSocket signaling relay as the controller
+    # and reach a real robot daemon (no in-process capture agent). See signaling_server.py.
+    signaling_url: str | None = None
+    # Session id pairing this controller with its robot daemon on the relay.
+    session_id: str = "default"
+    # Shared token presented to the (public) signaling relay. See signaling_server.py.
+    signaling_token: str | None = None
+    # ICE servers for the controller's peer connection. Empty => host candidates only
+    # (loopback / same-host two-process). M4 injects STUN/TURN for real public-net peers.
+    ice_servers: list[str] = field(default_factory=list)
+    # Transport backend: "aiortc" (default, self-contained P2P) | "livekit" (SFU; both
+    # the controller and the robot daemon must use the same backend).
+    transport_backend: str = "aiortc"
+    # Required when transport_backend == "livekit": the LiveKit server URL + a JWT.
+    livekit_url: str | None = None
+    livekit_token: str | None = None

--- a/src/lerobot/robots/webrtc_proxy/control.py
+++ b/src/lerobot/robots/webrtc_proxy/control.py
@@ -1,0 +1,311 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Control plane: cloud-driven device onboarding over a reliable RPC channel.
+
+Port + camera IDs are *robot-local* physical identifiers that are meaningless in the
+cloud, so the cloud never stores them. Instead the cloud drives discovery over the
+``control`` DataChannel and the robot answers from its own OS:
+
+    cloud  ──RpcRequest{list_ports}──▶  robot (ControlServer -> DeviceInventory)
+    cloud  ◀──RpcResponse{result}─────  robot
+
+The crux vs. the local ``lerobot-find-port`` CLI: that tool blocks on ``input()``
+while the human unplugs the bus, but here the human is at the robot and the
+orchestrator is in the cloud. So ``find_port`` becomes an *event-driven* two-step —
+``find_port_begin`` snapshots the ports, the human unplugs (prompted by the cloud
+UI), then ``find_port_result`` diffs to the port that disappeared. No shared stdin.
+
+``DeviceInventory`` is the seam between this transport and the OS: M3 ships a
+``SyntheticInventory`` (loopback-testable); a real ``LocalDeviceInventory`` wrapping
+``lerobot.scripts.lerobot_find_port`` / ``lerobot_find_cameras`` lands with M2/M4
+hardware bring-up.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import os
+import sys
+from typing import Any, Protocol
+
+import numpy as np
+
+from .protocol import RpcRequest, RpcResponse
+
+logger = logging.getLogger(__name__)
+
+
+def _encode_jpeg_b64(rgb: np.ndarray, quality: int = 75) -> str:
+    """RGB uint8 frame -> base64 JPEG string (small enough for the control DataChannel)."""
+    import base64
+    import io
+
+    from PIL import Image
+
+    buf = io.BytesIO()
+    Image.fromarray(rgb).save(buf, format="JPEG", quality=quality)
+    return base64.b64encode(buf.getvalue()).decode("ascii")
+
+
+def _decode_jpeg_b64(b64: str) -> np.ndarray:
+    """Inverse of :func:`_encode_jpeg_b64`: base64 JPEG -> RGB uint8 ndarray."""
+    import base64
+    import io
+
+    from PIL import Image
+
+    return np.asarray(Image.open(io.BytesIO(base64.b64decode(b64))))
+
+
+@contextlib.contextmanager
+def _silence_native_stderr():
+    """Redirect OS-level fd 2 to /dev/null for the duration of the block.
+
+    lerobot's ``OpenCVCamera.find_cameras`` brute-force-opens every camera index, and
+    OpenCV/AVFoundation writes "out device of bound / camera failed to initialize" for
+    each nonexistent one straight to the C stderr — Python logging can't intercept it.
+    RealSense probing on a machine without a device also logs noisily. This swallows
+    both around the (one-shot, onboarding) enumeration call. Process-wide for the brief
+    call window, so it is intentionally narrow.
+    """
+    sys.stderr.flush()
+    saved_fd = os.dup(2)
+    devnull_fd = os.open(os.devnull, os.O_WRONLY)
+    try:
+        os.dup2(devnull_fd, 2)
+        yield
+    finally:
+        sys.stderr.flush()
+        os.dup2(saved_fd, 2)
+        os.close(devnull_fd)
+        os.close(saved_fd)
+
+
+class FindPortError(RuntimeError):
+    """Raised when a find_port diff is ambiguous (0 or >1 ports changed)."""
+
+
+class DeviceInventory(Protocol):
+    """OS-facing device enumeration. Implementations run on the robot."""
+
+    def list_ports(self) -> list[str]: ...
+
+    def list_cameras(self) -> list[dict[str, Any]]: ...
+
+    def grab_frame(self, cam_id: Any, width: int, height: int) -> np.ndarray:
+        """Open camera ``cam_id``, return one RGB uint8 frame (for an onboarding preview)."""
+        ...
+
+
+class SyntheticInventory:
+    """In-memory inventory for loopback tests / the synthetic capture agent.
+
+    Mirrors the real shapes: ``list_ports`` returns serial-port strings; cameras
+    carry a *stable* identifier (``index_or_path`` for opencv, ``serial`` for
+    realsense) plus a human-readable name so a person can map them to logical roles.
+    ``simulate_unplug`` lets a test reproduce the find_port unplug step.
+    """
+
+    def __init__(
+        self,
+        ports: list[str] | None = None,
+        cameras: list[dict[str, Any]] | None = None,
+    ) -> None:
+        self._ports: list[str] = list(
+            ports if ports is not None else ["/dev/tty.usbmodem-FAKE-A", "/dev/tty.usbmodem-FAKE-B"]
+        )
+        self._cameras: list[dict[str, Any]] = list(
+            cameras
+            if cameras is not None
+            else [
+                {"type": "opencv", "index_or_path": 0, "name": "FaceTime HD Camera"},
+                {"type": "opencv", "index_or_path": 1, "name": "USB Camera"},
+            ]
+        )
+
+    def list_ports(self) -> list[str]:
+        return list(self._ports)
+
+    def list_cameras(self) -> list[dict[str, Any]]:
+        return [dict(c) for c in self._cameras]
+
+    def grab_frame(self, cam_id: Any, width: int = 320, height: int = 240) -> np.ndarray:
+        # Distinct flat colour per id so previews are visually distinguishable in tests.
+        seed = int(cam_id) if str(cam_id).lstrip("-").isdigit() else abs(hash(str(cam_id)))
+        img = np.empty((height, width, 3), dtype=np.uint8)
+        img[:] = ((seed * 70) % 256, (seed * 40 + 80) % 256, 120)
+        return img
+
+    def simulate_unplug(self, port: str) -> None:
+        if port in self._ports:
+            self._ports.remove(port)
+
+
+class LocalDeviceInventory:
+    """Real robot-side inventory: enumerates the actual serial ports + cameras.
+
+    Wraps lerobot's own discovery so it sees exactly what the stock
+    ``lerobot-find-port`` / ``lerobot-find-cameras`` CLIs see. Imports are lazy so
+    ``control.py`` still loads without the hardware/camera extras; a missing extra
+    surfaces as a control-RPC error to the cloud rather than an import failure.
+
+    Note: ``list_cameras`` probes camera indices (opens each briefly), so it is a
+    one-shot onboarding call, not something to poll.
+    """
+
+    def list_ports(self) -> list[str]:
+        from lerobot.scripts.lerobot_find_port import find_available_ports
+
+        return find_available_ports()
+
+    def list_cameras(self) -> list[dict[str, Any]]:
+        # Keep the import *inside* the hush: importing it loads cv2 (libavdevice), whose
+        # objc duplicate-class warning vs. av also goes to C-level stderr — along with
+        # OpenCV's index-scan noise. One-shot onboarding call, so the brief redirect is fine.
+        with _silence_native_stderr():
+            from lerobot.scripts.lerobot_find_cameras import (
+                find_all_opencv_cameras,
+                find_all_realsense_cameras,
+            )
+
+            # Each dict carries a stable id ('id' = opencv index_or_path / realsense serial).
+            return [*find_all_opencv_cameras(), *find_all_realsense_cameras()]
+
+    def grab_frame(self, cam_id: Any, width: int = 320, height: int = 240) -> np.ndarray:
+        """Open this opencv camera at its *native* resolution, read one frame, close it,
+        then downscale to a small preview. Onboarding preview only — fails if the camera
+        is already in use (e.g. currently being streamed).
+
+        We deliberately don't request a capture size: OpenCVCamera errors if the camera
+        can't apply it. Resize happens in software afterwards.
+        """
+        import cv2
+
+        from lerobot.cameras.opencv import OpenCVCamera, OpenCVCameraConfig
+
+        index_or_path = int(cam_id) if str(cam_id).isdigit() else cam_id
+        with _silence_native_stderr():
+            cam = OpenCVCamera(OpenCVCameraConfig(index_or_path=index_or_path))
+            cam.connect(warmup=True)
+            try:
+                frame = cam.read()  # RGB uint8, native resolution
+            finally:
+                cam.disconnect()
+            frame = cv2.resize(frame, (width, height))
+        return np.ascontiguousarray(frame)
+
+
+class ControlServer:
+    """robot side: receives RpcRequests on the control channel and answers them.
+
+    Stateful only for the find_port begin/result handshake (it stashes the
+    pre-unplug port snapshot between the two calls).
+    """
+
+    def __init__(self, inventory: DeviceInventory, on_camera_plan=None) -> None:
+        self.inventory = inventory
+        # Called with the cloud's desired camera spec {width,height,fps} at session start.
+        self._on_camera_plan = on_camera_plan
+        self._channel = None
+        self._ports_before: list[str] | None = None
+
+    def attach(self, channel) -> None:  # noqa: ANN001 (transport Channel)
+        self._channel = channel
+        channel.on_message(self._on_message)
+
+    def _on_message(self, raw: str) -> None:
+        try:
+            req = RpcRequest.from_json(raw)
+        except Exception:
+            logger.exception("ControlServer: malformed RpcRequest")
+            return
+        try:
+            result = self._dispatch(req)
+            resp = RpcResponse(id=req.id, ok=True, result=result)
+        except Exception as e:  # report failures back to the cloud, don't crash the loop
+            resp = RpcResponse(id=req.id, ok=False, error=f"{type(e).__name__}: {e}")
+        if self._channel is not None and self._channel.is_open:
+            self._channel.send(resp.to_json())
+
+    def _dispatch(self, req: RpcRequest) -> Any:
+        if req.method == "list_ports":
+            return {"ports": self.inventory.list_ports()}
+        if req.method == "list_cameras":
+            return {"cameras": self.inventory.list_cameras()}
+        if req.method == "grab_camera":
+            width = int(req.params.get("width", 320))
+            height = int(req.params.get("height", 240))
+            frame = self.inventory.grab_frame(req.params["id"], width, height)
+            return {"jpeg_b64": _encode_jpeg_b64(frame), "width": frame.shape[1], "height": frame.shape[0]}
+        if req.method == "set_camera_plan":
+            # Cloud declares the obs size it wants; the robot resizes/encodes to it.
+            if self._on_camera_plan is not None:
+                self._on_camera_plan(req.params)
+            return {"applied": req.params}
+        if req.method == "find_port_begin":
+            self._ports_before = self.inventory.list_ports()
+            return {"ports": list(self._ports_before)}
+        if req.method == "find_port_result":
+            if self._ports_before is None:
+                raise FindPortError("find_port_result called before find_port_begin")
+            after = self.inventory.list_ports()
+            diff = sorted(set(self._ports_before) - set(after))
+            self._ports_before = None
+            if len(diff) == 1:
+                return {"port": diff[0]}
+            raise FindPortError(f"expected exactly one disconnected port, found {diff}")
+        raise ValueError(f"unknown control method {req.method!r}")
+
+
+class ControlClient:
+    """Cloud side: issues RpcRequests and awaits the matching RpcResponse by id."""
+
+    def __init__(self) -> None:
+        self._channel = None
+        self._next_id = 0
+        self._pending: dict[int, asyncio.Future] = {}
+
+    def attach(self, channel) -> None:  # noqa: ANN001 (transport Channel)
+        self._channel = channel
+        channel.on_message(self._on_message)
+
+    def _on_message(self, raw: str) -> None:
+        try:
+            resp = RpcResponse.from_json(raw)
+        except Exception:
+            logger.exception("ControlClient: malformed RpcResponse")
+            return
+        fut = self._pending.pop(resp.id, None)
+        if fut is None or fut.done():
+            return
+        if resp.ok:
+            fut.set_result(resp.result)
+        else:
+            fut.set_exception(RuntimeError(resp.error or "control RPC failed"))
+
+    async def call(self, method: str, params: dict[str, Any] | None = None, timeout: float = 10.0) -> Any:
+        if self._channel is None or not self._channel.is_open:
+            raise RuntimeError("control channel not open")
+        self._next_id += 1
+        req = RpcRequest(id=self._next_id, method=method, params=params or {})
+        fut: asyncio.Future = asyncio.get_running_loop().create_future()
+        self._pending[req.id] = fut
+        self._channel.send(req.to_json())
+        try:
+            return await asyncio.wait_for(fut, timeout)
+        finally:
+            self._pending.pop(req.id, None)

--- a/src/lerobot/robots/webrtc_proxy/demo_loopback.py
+++ b/src/lerobot/robots/webrtc_proxy/demo_loopback.py
@@ -1,0 +1,121 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Single-machine demo of the full WebRTCProxyRobot link.
+
+    uv run python -m lerobot.robots.webrtc_proxy.demo_loopback
+
+Starts the relay + a synthetic robot daemon + the cloud controller as three event
+loops in one process (localhost sockets — the same path as a real cloud pod and a
+real robot daemon). Then drives it through the synchronous Robot API: control-plane
+discovery, re-assembled observation streaming, and the P0 watchdog.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import threading
+import time
+
+from .configuration_webrtc_proxy import WebRTCCameraSpec, WebRTCProxyRobotConfig
+from .control import SyntheticInventory
+from .proxy_robot import WebRTCProxyRobot
+from .robot_daemon import run_daemon
+from .signaling_server import start_relay
+
+
+def _spawn_loop() -> asyncio.AbstractEventLoop:
+    loop = asyncio.new_event_loop()
+    threading.Thread(target=lambda: (asyncio.set_event_loop(loop), loop.run_forever()), daemon=True).start()
+    return loop
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+
+    relay_loop = _spawn_loop()
+    runner, port = asyncio.run_coroutine_threadsafe(start_relay("127.0.0.1", 0), relay_loop).result(timeout=5)
+    url = f"ws://127.0.0.1:{port}/ws"
+
+    inv = SyntheticInventory()
+    agent_box: dict = {}
+    daemon_loop = _spawn_loop()
+    daemon_fut = asyncio.run_coroutine_threadsafe(
+        run_daemon(
+            url,
+            "demo",
+            cam_name="front",
+            cam_height=120,
+            cam_width=160,
+            capture_fps=30,
+            action_timeout_s=0.4,
+            ice_servers=[],
+            inventory=inv,
+            on_agent=lambda a: agent_box.__setitem__("agent", a),
+        ),
+        daemon_loop,
+    )
+    time.sleep(0.5)  # let the daemon connect + buffer its offer
+
+    robot = WebRTCProxyRobot(
+        WebRTCProxyRobotConfig(
+            cameras={"front": WebRTCCameraSpec(height=120, width=160, fps=30)},
+            signaling_url=url,
+            session_id="demo",
+            ice_servers=[],
+            capture_fps=30,
+            action_timeout_s=0.4,
+            connect_timeout_s=20.0,
+        )
+    )
+    print("observation_features:", dict(robot.observation_features))
+    print("action_features:    ", robot.action_features)
+    robot.connect()
+
+    try:
+        print("\n== control plane: cloud-driven device discovery (over the robot daemon) ==")
+        print("  list_ports():  ", robot.list_ports())
+        before = robot.find_port_begin()
+        inv.simulate_unplug(before[-1])  # in production the user unplugs the bus
+        print(f"  find_port: begin={before} -> result={robot.find_port_result()!r} (the bus)")
+
+        print("\n== streaming re-assembled observations (capture-ts aligned) ==")
+        for _ in range(20):
+            obs = robot.get_observation()
+            pan = obs["shoulder_pan.pos"]
+            print(f"  shoulder_pan.pos={pan:+7.2f}  front={obs['front'].shape}{obs['front'].dtype}")
+            robot.send_action({"shoulder_pan.pos": pan + 1.0})
+            time.sleep(1 / 15)
+
+        print("\n== stop sending actions; daemon watchdog should SAFE STOP within action_timeout_s ==")
+        agent = agent_box.get("agent")
+        deadline = time.monotonic() + 1.5
+        while time.monotonic() < deadline and not (agent and agent.is_safed):
+            time.sleep(0.05)
+        print(f"  watchdog safed = {agent.is_safed if agent else 'n/a'}")
+    finally:
+        robot.disconnect()
+        daemon_fut.cancel()
+        time.sleep(0.3)
+        with contextlib.suppress(Exception):
+            asyncio.run_coroutine_threadsafe(runner.cleanup(), relay_loop).result(timeout=3)
+        daemon_loop.call_soon_threadsafe(daemon_loop.stop)
+        relay_loop.call_soon_threadsafe(relay_loop.stop)
+        print("\n== disconnected cleanly ==")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/lerobot/robots/webrtc_proxy/protocol.py
+++ b/src/lerobot/robots/webrtc_proxy/protocol.py
@@ -1,0 +1,164 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Wire protocol shared by the robot-side capture agent and the cloud-side proxy.
+
+Two real-time DataChannels + one control DataChannel + one video media track:
+
+    label        dir          reliability                payload
+    -----------  -----------  -------------------------  ---------------------------
+    state        robot -> cloud configurable (rt default)  StateMsg: joints + capture ts + seq
+    action       cloud -> robot configurable (rt default)  ActionMsg: goal joints + seq + obs_seq
+    control      both         reliable + ordered         onboarding RPC (device discovery, plan)
+    <video>      robot -> cloud media track (H.264/VP8)    one camera; seq carried in pts
+
+state/action reliability is per-use-case (teleop/eval: unreliable & fresh; record:
+reliable state). control is always reliable+ordered.
+
+The frame's capture **seq** rides its ``pts`` (``pts = seq * VIDEO_PTS_PER_SEQ``); the
+cloud recovers ``seq = round(pts / VIDEO_PTS_PER_SEQ)`` and pairs each frame to the
+StateMsg with the same seq (both are produced by one ``robot.get_observation()``, so
+they share a seq). A dropped frame just leaves a gap in seq — no cascade. See
+``DESIGN.md`` §5.1 for the re-basing caveat and the RTP-header-extension end state.
+
+All timestamps are the robot's ``time.monotonic()`` seconds (a single clock — the
+cloud only ever *compares* them, never interprets them as wall time)."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from typing import Any
+
+# DataChannel labels (must match on both ends).
+CH_STATE = "state"
+CH_ACTION = "action"
+# Control plane: cloud-driven onboarding RPC (device discovery, calibrate, ...).
+# Ordered + reliable — these are one-shot commands, not the realtime control loop.
+CH_CONTROL = "control"
+
+# The capture seq is carried in each frame's pts: pts = seq * VIDEO_PTS_PER_SEQ at a
+# 90 kHz clock. The cloud recovers seq = round(pts / VIDEO_PTS_PER_SEQ) and pairs the
+# frame to the state with the same seq. pts survives VP8/H.264; a dropped frame just
+# leaves a gap in seq (no cascade), unlike an ordered 1:1 side channel.
+# Caveat: the receiver re-bases the *first received* frame to pts=0, so seq is recovered
+# relative to the first received frame. The daemon resets seq to 0 per session, so as long
+# as the first frame lands (true at session start) relative == absolute. Production should
+# carry an absolute seq in an RTP header extension to be robust to initial-frame loss.
+VIDEO_CLOCK_RATE = 90_000
+VIDEO_PTS_PER_SEQ = 3_000  # 1/30 s per seq at 90 kHz; round(pts/this) recovers seq
+
+# DataChannel reliability. The `control` channel is ALWAYS reliable+ordered. The
+# realtime `state`/`action` channels are CONFIGURABLE per use case (see DESIGN.md §4):
+#   - teleop / eval (closed loop): UNRELIABLE — freshest sample wins, drops self-correct,
+#     no head-of-line blocking.
+#   - record (dataset): RELIABLE state AND action — no obs or action lost from a transition.
+# A lost packet on a reliable channel head-of-line-blocks until retransmitted (trades
+# freshness for completeness). Total disconnect is covered by the robot watchdog either way.
+RELIABLE_KWARGS: dict[str, Any] = {"ordered": True}  # reliable + ordered (SCTP default)
+UNRELIABLE_KWARGS: dict[str, Any] = {"ordered": False, "maxRetransmits": 0}  # drop, no retransmit
+
+
+def channel_kwargs(reliable: bool) -> dict[str, Any]:
+    return RELIABLE_KWARGS if reliable else UNRELIABLE_KWARGS
+
+
+@dataclass(frozen=True)
+class StateMsg:
+    """Proprioceptive sample captured on the robot. Sent on ``CH_STATE``."""
+
+    t: float  # capture time.monotonic() seconds
+    seq: int  # capture sequence number (shared with the paired frame)
+    joints: dict[str, float]  # {"<motor>.pos": degrees}
+    # Piggybacked closed-loop feedback: the most recent action this robot applied.
+    # Lets the cloud confirm landing + measure round-trip without an extra channel.
+    applied_seq: int = -1  # ActionMsg.seq of the last applied action (-1 = none yet)
+    applied_t: float = 0.0  # robot time.monotonic() when it was applied
+
+    def to_json(self) -> str:
+        return json.dumps(asdict(self), separators=(",", ":"))
+
+    @classmethod
+    def from_json(cls, raw: str) -> StateMsg:
+        d = json.loads(raw)
+        return cls(
+            t=float(d["t"]),
+            seq=int(d["seq"]),
+            joints={k: float(v) for k, v in d["joints"].items()},
+            applied_seq=int(d.get("applied_seq", -1)),
+            applied_t=float(d.get("applied_t", 0.0)),
+        )
+
+
+@dataclass(frozen=True)
+class ActionMsg:
+    """Goal joint command issued by the cloud. Sent on ``CH_ACTION``."""
+
+    t: float  # cloud send time.monotonic() seconds (debug/telemetry only)
+    seq: int  # monotonically increasing action id
+    goal: dict[str, float]  # {"<motor>.pos": degrees}
+    obs_seq: int = -1  # provenance: the StateMsg.seq of the obs this action was derived from
+
+    def to_json(self) -> str:
+        return json.dumps(asdict(self), separators=(",", ":"))
+
+    @classmethod
+    def from_json(cls, raw: str) -> ActionMsg:
+        d = json.loads(raw)
+        return cls(
+            t=float(d["t"]),
+            seq=int(d["seq"]),
+            goal={k: float(v) for k, v in d["goal"].items()},
+            obs_seq=int(d.get("obs_seq", -1)),
+        )
+
+
+@dataclass(frozen=True)
+class RpcRequest:
+    """Control-plane request: cloud -> robot. Sent on ``CH_CONTROL``."""
+
+    id: int  # client-assigned, echoed in the matching RpcResponse
+    method: str  # e.g. "list_ports", "find_port_begin", "list_cameras"
+    params: dict[str, Any]
+
+    def to_json(self) -> str:
+        return json.dumps(
+            {"id": self.id, "method": self.method, "params": self.params}, separators=(",", ":")
+        )
+
+    @classmethod
+    def from_json(cls, raw: str) -> RpcRequest:
+        d = json.loads(raw)
+        return cls(id=int(d["id"]), method=str(d["method"]), params=dict(d.get("params") or {}))
+
+
+@dataclass(frozen=True)
+class RpcResponse:
+    """Control-plane response: robot -> cloud. Sent on ``CH_CONTROL``."""
+
+    id: int
+    ok: bool
+    result: Any | None = None
+    error: str | None = None
+
+    def to_json(self) -> str:
+        return json.dumps(
+            {"id": self.id, "ok": self.ok, "result": self.result, "error": self.error},
+            separators=(",", ":"),
+        )
+
+    @classmethod
+    def from_json(cls, raw: str) -> RpcResponse:
+        d = json.loads(raw)
+        return cls(id=int(d["id"]), ok=bool(d["ok"]), result=d.get("result"), error=d.get("error"))

--- a/src/lerobot/robots/webrtc_proxy/proxy_robot.py
+++ b/src/lerobot/robots/webrtc_proxy/proxy_robot.py
@@ -1,0 +1,412 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Cloud-side ``WebRTCProxyRobot`` — a fake robot that proxies a real one on a robot.
+
+LeRobot's record/teleop/policy code calls ``get_observation`` / ``send_action`` /
+``observation_features`` synchronously and assumes they are local and instant. This
+class honours that synchronous contract while the work happens over WebRTC: it owns
+a background asyncio loop running an :class:`_ProxyEndpoint` (the *answerer*).
+
+- ``get_observation`` reads the thread-safe :class:`AlignmentBuffer` (no loop hop) and
+  assembles the LeRobot obs dict by *capture* timestamp (handoff challenge A).
+- ``send_action`` marshals an :class:`ActionMsg` onto the loop's action DataChannel.
+- the robot-side watchdog (not here) handles disconnect safety (handoff challenge C).
+
+M1: ``signaling_url`` unset => loopback mode, which also spins up a synthetic
+:class:`CaptureAgent` *in the same loop* so the whole link is self-contained and
+testable on one machine. Real mode (M3) replaces loopback signaling with the K8s
+WebSocket signaler and drops the in-process capture agent.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import threading
+import time
+from functools import cached_property
+
+import numpy as np
+
+from lerobot.types import RobotAction, RobotObservation
+
+from ..robot import Robot
+from . import tiling
+from .alignment import AlignmentBuffer
+from .capture_agent import _fit_frame
+from .configuration_webrtc_proxy import WebRTCProxyRobotConfig
+from .control import ControlClient
+from .protocol import CH_ACTION, CH_CONTROL, CH_STATE, ActionMsg, StateMsg
+from .signaling import Signaling, WebSocketSignaling
+from .transport import Transport, make_transport
+
+logger = logging.getLogger(__name__)
+
+
+class CameraLayoutMismatchError(ValueError):
+    """The robot's tiled video frame doesn't fit this end's camera specs.
+
+    Cameras are tiled into one track and sliced back purely by the (name-sorted)
+    specs — there is no per-frame metadata — so the two ends must declare the SAME
+    camera set (same names AND per-camera WxH). When they disagree the slices are
+    wrong, and a too-short frame would otherwise crash deep in ``cv2.resize`` on an
+    empty tile. We raise this instead, with an actionable message.
+    """
+
+
+class _ProxyEndpoint:
+    """Cloud answerer: receives state + video, sends actions, drives the control plane.
+
+    Transport-agnostic — talks to a :class:`Transport` (default aiortc).
+    """
+
+    def __init__(
+        self,
+        buffer: AlignmentBuffer,
+        cam_name: str,
+        ice_servers: list[str] | None = None,
+        transport_backend: str = "aiortc",
+        livekit_url: str | None = None,
+        livekit_token: str | None = None,
+        transport: Transport | None = None,
+    ) -> None:
+        self.buffer = buffer
+        self.cam_name = cam_name
+        self._action_seq = 0
+        # Closed-loop feedback reported by the robot on the state stream (telemetry).
+        self.last_applied_seq = -1
+        self.last_applied_t = 0.0
+        self._control = ControlClient()
+        self._transport = transport or make_transport(
+            transport_backend,
+            role="subscriber",
+            channels={CH_STATE: False, CH_ACTION: False, CH_CONTROL: True},  # reliability set by publisher
+            ice_servers=ice_servers,
+            livekit_url=livekit_url,
+            livekit_token=livekit_token,
+        )
+        self.connected = self._transport.connected
+        self._transport.channel(CH_STATE).on_message(self._on_state)
+        self._control.attach(self._transport.channel(CH_CONTROL))
+        self._transport.set_frame_handler(self._on_frame)
+
+    def _on_state(self, raw: str) -> None:
+        try:
+            msg = StateMsg.from_json(raw)
+        except Exception:
+            logger.exception("proxy: bad state message")
+            return
+        self.buffer.add_state(msg.seq, msg.t, msg.joints)
+        if msg.applied_seq > self.last_applied_seq:
+            self.last_applied_seq = msg.applied_seq
+            self.last_applied_t = msg.applied_t
+
+    def _on_frame(self, seq: int, img: np.ndarray) -> None:
+        # seq was recovered from the frame pts by the transport. A dropped frame just
+        # leaves a gap — no cascade. (Relative to the first received frame; DESIGN §5.1.)
+        self.buffer.add_frame(seq, img)
+
+    async def run(self, signaling: Signaling) -> None:
+        await self._transport.open(signaling)
+
+    async def send_action(self, goal: dict[str, float], obs_seq: int = -1) -> dict[str, float]:
+        self._action_seq += 1
+        self._transport.channel(CH_ACTION).send(
+            ActionMsg(t=time.monotonic(), seq=self._action_seq, goal=goal, obs_seq=obs_seq).to_json()
+        )
+        return goal
+
+    async def control_call(self, method: str, params: dict | None = None, timeout: float = 10.0):
+        return await self._control.call(method, params, timeout)
+
+    async def close(self) -> None:
+        await self._transport.close()
+
+
+class _EventLoopThread:
+    """Owns an asyncio loop in a daemon thread; bridges sync calls to coroutines."""
+
+    def __init__(self) -> None:
+        self.loop = asyncio.new_event_loop()
+        self._thread = threading.Thread(target=self._run, name="webrtc-proxy-loop", daemon=True)
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def _run(self) -> None:
+        asyncio.set_event_loop(self.loop)
+        self.loop.run_forever()
+
+    def run(self, coro, timeout: float | None = None):
+        return asyncio.run_coroutine_threadsafe(coro, self.loop).result(timeout)
+
+    def stop(self) -> None:
+        self.loop.call_soon_threadsafe(self.loop.stop)
+        self._thread.join(timeout=2.0)
+
+
+class WebRTCProxyRobot(Robot):
+    """Cloud-side proxy presenting a real robot-tethered robot as a local LeRobot Robot."""
+
+    config_class = WebRTCProxyRobotConfig
+    name = "webrtc_proxy"
+
+    def __init__(self, config: WebRTCProxyRobotConfig):
+        super().__init__(config)
+        self.config = config
+        if not config.cameras:
+            raise ValueError("WebRTCProxyRobot needs at least one camera")
+        # Cameras are tiled into one video track on the robot and sliced back here; both ends
+        # derive the same layout from the (name-sorted) specs. See tiling.py.
+        self._cam_specs = {name: (spec.height, spec.width) for name, spec in config.cameras.items()}
+        self._specs = tiling.ordered_specs(self._cam_specs)
+        # The first camera (name order) backs the single-camera set_camera_plan hint.
+        self.cam_name, self.cam_spec = sorted(config.cameras.items())[0]
+        self.motors = list(config.motors)
+
+        self._buffer = AlignmentBuffer()
+        self._loop: _EventLoopThread | None = None
+        self._endpoint: _ProxyEndpoint | None = None
+        self._ws_sig: WebSocketSignaling | None = None
+        self._last_obs: RobotObservation | None = None  # last coherent obs (held on camera lag)
+        self._last_obs_seq = -1  # seq of the most recent obs returned (action provenance)
+        self._connected = False
+        self._frame_checked = False  # one-time camera-layout sanity check (see get_observation)
+
+    # ----- schema (callable whether connected or not) ----------------------
+    @cached_property
+    def _motors_ft(self) -> dict[str, type]:
+        return {f"{m}.pos": float for m in self.motors}
+
+    @property
+    def observation_features(self) -> dict:
+        cams = {name: (spec.height, spec.width, 3) for name, spec in self.config.cameras.items()}
+        return {**self._motors_ft, **cams}
+
+    @property
+    def action_features(self) -> dict:
+        return dict(self._motors_ft)
+
+    @property
+    def is_connected(self) -> bool:
+        return self._connected
+
+    # ----- no-op hardware hooks (calibration lives on the robot, M2) ----------
+    @property
+    def is_calibrated(self) -> bool:
+        return True
+
+    def calibrate(self) -> None:
+        pass
+
+    def configure(self) -> None:
+        pass
+
+    # ----- lifecycle -------------------------------------------------------
+    def connect(self, calibrate: bool = True) -> None:
+        if self._connected:
+            raise RuntimeError("WebRTCProxyRobot already connected")
+        # aiortc reaches the daemon over our WS signaling relay; livekit signals itself.
+        if self.config.transport_backend == "aiortc" and (
+            not self.config.signaling_url or not self.config.signaling_url.startswith("ws")
+        ):
+            raise ValueError("WebRTCProxyRobot (aiortc) needs a WebSocket signaling_url (ws://host:port/ws)")
+
+        self._loop = _EventLoopThread()
+        self._loop.start()
+
+        # CRITICAL: every aiortc object (RTCPeerConnection), asyncio.Event and
+        # asyncio.Queue must be constructed *on the loop thread* so it binds to the
+        # right running loop. Building them in the caller thread silently deadlocks.
+        async def _bringup() -> None:
+            self._endpoint = _ProxyEndpoint(
+                self._buffer,
+                self.cam_name,
+                ice_servers=self.config.ice_servers,
+                transport_backend=self.config.transport_backend,
+                livekit_url=self.config.livekit_url,
+                livekit_token=self.config.livekit_token,
+            )
+            # aiortc reaches the daemon over our WS signaling relay; livekit signals itself
+            # (the transport ignores the signaling arg).
+            if self.config.transport_backend == "aiortc":
+                self._ws_sig = WebSocketSignaling(
+                    self.config.signaling_url,
+                    self.config.session_id,
+                    role="controller",
+                    token=self.config.signaling_token,
+                )
+            # Staged so a connect timeout points at the stuck phase (signaling vs media).
+            logger.info(
+                "connecting: signaling %s (session=%s)…",
+                self.config.signaling_url,
+                self.config.session_id,
+            )
+            await self._endpoint.run(self._ws_sig)
+            logger.info("connecting: signaling done; waiting for media (ICE) to connect…")
+            await self._endpoint.connected.wait()
+            logger.info("connecting: media connected")
+            # Push our desired obs size so the robot resizes/encodes to it (bandwidth).
+            # Correctness doesn't depend on this — get_observation re-fits to the spec.
+            with contextlib.suppress(Exception):
+                await self._endpoint.control_call(
+                    "set_camera_plan",
+                    {"width": self.cam_spec.width, "height": self.cam_spec.height, "fps": self.cam_spec.fps},
+                    timeout=5.0,
+                )
+
+        try:
+            self._loop.run(_bringup(), timeout=self.config.connect_timeout_s)
+        except TimeoutError as e:
+            raise TimeoutError(
+                f"WebRTCProxyRobot connect timed out after {self.config.connect_timeout_s}s. Check: "
+                "(1) the signaling relay is reachable at the signaling_url; "
+                "(2) the robot daemon is connected to the SAME relay with --session "
+                f"'{self.config.session_id}' and a matching --auth-token; "
+                "(3) for a cross-NAT/public link, STUN/TURN is configured on the relay — host-only ICE "
+                "(ice_servers=[]) can't traverse the internet. See the 'connecting:' logs above for the "
+                "phase it stalled in (signaling vs media)."
+            ) from e
+        self._wait_first_obs(self.config.connect_timeout_s)
+        self._connected = True
+        logger.info("WebRTCProxyRobot connected (%s)", self.config.signaling_url)
+
+    def _wait_first_obs(self, timeout: float) -> None:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if self._buffer.assemble() is not None:
+                return  # a state+frame pair (same seq) is available
+            time.sleep(0.02)
+        raise TimeoutError("WebRTCProxyRobot: no aligned observation within connect_timeout_s")
+
+    def get_observation(self) -> RobotObservation:
+        if not self._connected:
+            raise RuntimeError("WebRTCProxyRobot not connected")
+        # The freshest seq present on both the state and frame sides — an exact pair from
+        # one capture instant. A dropped frame/state just means that seq is skipped.
+        aligned = self._buffer.assemble()
+        if aligned is not None:
+            if not self._frame_checked:
+                self._frame_checked = True
+                self._check_frame_layout(aligned.frame)
+            self._last_obs_seq = aligned.seq  # actions sent next derive from this obs
+            obs: RobotObservation = dict(aligned.joints)
+            # The robot tiled all cameras into one frame; slice it back per camera (same
+            # name-sorted layout) and enforce each declared obs shape.
+            for name, tile in tiling.untile(aligned.frame, self._specs).items():
+                spec = self.config.cameras[name]
+                obs[name] = _fit_frame(tile, spec.height, spec.width)
+            self._last_obs = obs
+            return dict(obs)
+        # No complete pair yet (camera lag/stall): hold the last good obs rather than
+        # fabricate one. Raise only if we never had one.
+        if self._last_obs is not None:
+            logger.warning("no state+frame pair yet; holding last obs")
+            return dict(self._last_obs)
+        raise RuntimeError("no observation available yet")
+
+    def _check_frame_layout(self, frame: np.ndarray) -> None:
+        """Verify the robot's first tiled frame matches this end's camera specs.
+
+        Both ends slice the single video track by the same name-sorted specs, so a
+        size disagreement means the two ``--cameras`` sets differ. A frame shorter
+        than the stacked specs would leave empty tiles and crash ``cv2.resize``;
+        raise :class:`CameraLayoutMismatchError` with a fix-it message instead. A taller/
+        wider frame still de-tiles (each tile is re-fit), so warn rather than fail.
+        """
+        exp_h, exp_w = tiling.tiled_size(self._specs)
+        fh, fw = frame.shape[:2]
+        if (fh, fw) == (exp_h, exp_w):
+            return
+        names = [n for n, _, _ in self._specs]
+        per_cam = ", ".join(f"{n}:{w}x{h}" for n, h, w in self._specs)
+        if fh < exp_h or fw < exp_w:
+            raise CameraLayoutMismatchError(
+                f"camera set mismatch: this end is configured for {len(names)} camera(s) "
+                f"[{per_cam}] — expecting a {exp_w}x{exp_h} tiled frame — but the robot daemon "
+                f"is streaming a {fw}x{fh} frame (too small to hold them). Both ends must use "
+                f"the SAME --cameras: identical names AND per-camera WxH. Update --cameras on "
+                f"the robot daemon or here so they match."
+            )
+        logger.warning(
+            "camera frame is %dx%d but this end's --cameras [%s] expect %dx%d; "
+            "de-tiling may be misaligned — make both ends use the same --cameras.",
+            fw,
+            fh,
+            per_cam,
+            exp_w,
+            exp_h,
+        )
+
+    def send_action(self, action: RobotAction) -> RobotAction:
+        if not self._connected or self._endpoint is None or self._loop is None:
+            raise RuntimeError("WebRTCProxyRobot not connected")
+        goal = {k: float(v) for k, v in action.items() if k.endswith(".pos")}
+        return self._loop.run(self._endpoint.send_action(goal, self._last_obs_seq), timeout=2.0)
+
+    # ----- control plane: cloud-driven device onboarding (M3) ---------------
+    # These reach the *robot's* OS over the control channel; port/camera IDs never
+    # live in the cloud config. find_port is two-step because the human unplugs
+    # the bus on the robot between the calls (the cloud cannot share that stdin).
+    def _control(self, method: str, params: dict | None = None, timeout: float = 10.0):
+        if not self._connected or self._endpoint is None or self._loop is None:
+            raise RuntimeError("WebRTCProxyRobot not connected")
+        return self._loop.run(self._endpoint.control_call(method, params, timeout), timeout=timeout + 1.0)
+
+    def list_ports(self) -> list[str]:
+        """Serial ports currently visible on the robot."""
+        return self._control("list_ports")["ports"]
+
+    def list_cameras(self) -> list[dict]:
+        """Cameras on the robot, each with a stable id (opencv index_or_path / realsense serial)."""
+        return self._control("list_cameras")["cameras"]
+
+    def find_port_begin(self) -> list[str]:
+        """Step 1/2: snapshot ports, then prompt the user (robot-side) to unplug the bus."""
+        return self._control("find_port_begin")["ports"]
+
+    def find_port_result(self) -> str:
+        """Step 2/2 (after the user unplugged): the port that disappeared = the bus."""
+        return self._control("find_port_result")["port"]
+
+    def grab_camera_preview(self, cam_id, width: int = 320, height: int = 240) -> np.ndarray:
+        """Grab one frame from camera ``cam_id`` on the robot (RGB uint8 ndarray).
+
+        For onboarding previews — pick which physical camera is "front"/"wrist" before
+        pinning the stream. Opens the camera on the robot, so it fails if that camera is
+        already being streamed; preview the others first, then start streaming.
+        """
+        from .control import _decode_jpeg_b64
+
+        res = self._control("grab_camera", {"id": cam_id, "width": width, "height": height}, timeout=15.0)
+        return _decode_jpeg_b64(res["jpeg_b64"])
+
+    def disconnect(self) -> None:
+        if not self._connected:
+            return
+        if self._loop is not None:
+            if self._endpoint is not None:
+                try:
+                    self._loop.run(self._endpoint.close(), timeout=2.0)
+                except Exception:
+                    logger.exception("error closing proxy endpoint")
+            if self._ws_sig is not None:
+                try:
+                    self._loop.run(self._ws_sig.close(), timeout=2.0)
+                except Exception:
+                    logger.exception("error closing signaling")
+            self._loop.stop()
+        self._connected = False

--- a/src/lerobot/robots/webrtc_proxy/robot_daemon.py
+++ b/src/lerobot/robots/webrtc_proxy/robot_daemon.py
@@ -1,0 +1,361 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""robot-side daemon: the long-lived process that keeps the real robot on the user's
+machine and serves cloud sessions over WebRTC.
+
+It outlives any single cloud session: connect to the signaling relay, offer, serve
+one controller until the link drops, **safe the arm**, then loop and wait for the
+next session. This is the persistent counterpart to the cloud ``WebRTCProxyRobot``.
+
+M3 ships the synthetic source (``CaptureAgent`` + ``SyntheticInventory``); M2 swaps
+in a real ``so_follower`` + cameras + ``LocalDeviceInventory`` behind the same loop.
+
+Run:
+    # 1) start the relay (cloud, here localhost for a same-host demo)
+    python -m lerobot.robots.webrtc_proxy.signaling_server --port 8765
+    # 2a) synthetic source (no hardware):
+    python -m lerobot.robots.webrtc_proxy.robot_daemon --signaling-url ws://127.0.0.1:8765/ws
+    # 2b) a real robot (any registered type, draccus --robot.*):
+    python -m lerobot.robots.webrtc_proxy.robot_daemon --signaling-url ws://127.0.0.1:8765/ws \
+        --robot.type=so101_follower --robot.port=/dev/tty... --robot.cameras='{...}'
+    # 3) cloud side: WebRTCProxyRobotConfig(signaling_url="ws://127.0.0.1:8765/ws").connect()
+       (declare the same motors + cameras the daemon logs on connect)
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import contextlib
+import logging
+import os
+from dataclasses import dataclass
+
+from ..config import RobotConfig
+from .capture_agent import CaptureAgent
+from .configuration_webrtc_proxy import SO100_MOTORS
+from .control import DeviceInventory, LocalDeviceInventory, SyntheticInventory, _silence_native_stderr
+from .signaling import SignalingClosedError, WebSocketSignaling
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _RobotWrap:
+    """draccus wrapper so ``--robot.type=… --robot.port=…`` parses into a RobotConfig.
+
+    Module-level (not nested in ``_build_robot``) so draccus's get_type_hints can resolve
+    the ``RobotConfig`` annotation under ``from __future__ import annotations``.
+    """
+
+    robot: RobotConfig
+
+
+def _build_robot(robot_args: list[str]):
+    """Parse ``--robot.type=… --robot.port=…`` (draccus) into a connected lerobot Robot.
+
+    Robot-agnostic: any robot registered with ``RobotConfig`` works (so100/101, koch, omx,
+    lekiwi, …) — the capture agent only uses the generic ``get_observation`` /
+    ``send_action`` / ``bus`` interface. Returns ``(robot, motors, cameras)`` where motors
+    and cameras (name -> (h, w)) are derived from the robot's own ``observation_features``,
+    so the streamed schema always matches the real hardware. The cloud
+    ``WebRTCProxyRobotConfig`` must declare the same motors + cameras.
+    """
+    import draccus
+
+    # Robots register RobotConfig choices but NOT camera ones; import the camera configs so
+    # `--robot.cameras="{...type: opencv...}"` resolves. Same set lerobot-record imports.
+    from lerobot.cameras.opencv import OpenCVCameraConfig  # noqa: F401
+    from lerobot.cameras.reachy2_camera import Reachy2CameraConfig  # noqa: F401
+    from lerobot.cameras.realsense import RealSenseCameraConfig  # noqa: F401
+    from lerobot.cameras.zmq import ZMQCameraConfig  # noqa: F401
+    from lerobot.utils.import_utils import register_third_party_plugins
+
+    from .. import (  # noqa: F401 - importing registers each RobotConfig draccus choice
+        bi_openarm_follower,
+        bi_rebot_b601_follower,
+        bi_so_follower,
+        earthrover_mini_plus,
+        hope_jr,
+        koch_follower,
+        omx_follower,
+        openarm_follower,
+        reachy2,
+        rebot_b601_follower,
+        so_follower,
+        unitree_g1,
+    )
+    from ..utils import make_robot_from_config
+
+    register_third_party_plugins()  # let pip-installed robots register too
+
+    cfg = draccus.parse(_RobotWrap, args=robot_args).robot
+    robot = make_robot_from_config(cfg)
+    robot.connect()
+    feats = robot.observation_features
+    motors = [k[: -len(".pos")] for k in feats if isinstance(k, str) and k.endswith(".pos")]
+    cameras = {name: (shape[0], shape[1]) for name, shape in feats.items() if isinstance(shape, tuple)}
+    logger.info("robot %s connected: motors=%s cameras=%s", cfg.type, motors, dict(cameras))
+    return robot, motors, cameras
+
+
+def _open_streaming_camera(index_or_path, fps: int, width: int, height: int):
+    """Open an opencv camera for streaming, robustly.
+
+    Try the requested capture size first (cheaper than native+resize for bandwidth/CPU),
+    but fall back to the camera's native profile if it can't apply it — OpenCVCamera
+    raises rather than silently using another size. Either way the capture loop's
+    ``_fit_frame`` (and the cloud's get_observation) resize to the declared obs shape.
+    """
+    from lerobot.cameras.opencv import OpenCVCamera, OpenCVCameraConfig
+
+    with _silence_native_stderr():
+        for kwargs in ({"fps": fps, "width": width, "height": height}, {}):
+            cam = OpenCVCamera(OpenCVCameraConfig(index_or_path=index_or_path, **kwargs))
+            try:
+                cam.connect(warmup=True)
+                logger.info("opened camera %r (%s)", index_or_path, kwargs or "native resolution")
+                return cam
+            except Exception as e:
+                logger.warning("camera %r open at %s failed (%s)", index_or_path, kwargs or "native", e)
+                with contextlib.suppress(Exception):
+                    cam.disconnect()
+    raise RuntimeError(f"could not open camera {index_or_path!r}")
+
+
+async def run_daemon(
+    signaling_url: str,
+    session_id: str = "default",
+    motors: list[str] | None = None,
+    cam_name: str = "front",
+    cam_height: int = 480,
+    cam_width: int = 640,
+    capture_fps: int = 30,
+    action_timeout_s: float = 0.5,
+    ice_servers: list[str] | None = None,
+    inventory: DeviceInventory | None = None,
+    camera=None,
+    cameras: dict[str, tuple[int, int]] | None = None,  # multi-cam: name -> (height, width)
+    cameras_src: dict | None = None,  # multi-cam: name -> opened Camera
+    robot=None,
+    reliable_state: bool = False,
+    reliable_action: bool = False,
+    signaling_token: str | None = None,
+    transport_backend: str = "aiortc",
+    livekit_url: str | None = None,
+    livekit_token: str | None = None,
+    stop: asyncio.Event | None = None,
+    on_agent=None,
+) -> None:
+    """Serve cloud sessions forever (until ``stop`` is set), one session at a time.
+
+    The camera (if any) is owned by the caller and reused across sessions — only the
+    per-session WebRTC peer is rebuilt each loop.
+    """
+    motors = list(motors or SO100_MOTORS)
+    stop = stop or asyncio.Event()
+    while not stop.is_set():
+        # livekit does its own signaling (url+token); only aiortc needs the WS relay.
+        sig = (
+            None
+            if transport_backend == "livekit"
+            else WebSocketSignaling(signaling_url, session_id, role="robot", token=signaling_token)
+        )
+        agent = CaptureAgent(
+            signaling=sig,
+            motors=motors,
+            cam_name=cam_name,
+            cam_height=cam_height,
+            cam_width=cam_width,
+            capture_fps=capture_fps,
+            action_timeout_s=action_timeout_s,
+            inventory=inventory if inventory is not None else SyntheticInventory(),
+            ice_servers=ice_servers,
+            camera=camera,
+            cameras=cameras,
+            cameras_src=cameras_src,
+            robot=robot,
+            reliable_state=reliable_state,
+            reliable_action=reliable_action,
+            transport_backend=transport_backend,
+            livekit_url=livekit_url,
+            livekit_token=livekit_token,
+        )
+        if on_agent is not None:
+            on_agent(agent)  # let a harness observe the live agent (watchdog/plan)
+        try:
+            await agent.run()  # blocks here until a controller answers the offer
+            logger.info("daemon: session %s established", session_id)
+            await agent.wait_closed()
+            logger.info("daemon: session %s closed", session_id)
+        except SignalingClosedError:
+            logger.info("daemon: signaling closed before a session formed")
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.exception("daemon: session error")
+        finally:
+            agent.force_safe_stop()  # P0: never leave the arm live across sessions
+            await agent.close()
+        if not stop.is_set():
+            await asyncio.sleep(0.2)  # brief backoff before waiting for the next session
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="WebRTCProxyRobot robot-side daemon")
+    parser.add_argument(
+        "--signaling-url", default=None, help="ws://host:port/ws (required for --transport aiortc)"
+    )
+    parser.add_argument("--session", default="default")
+    parser.add_argument("--camera-name", default="front")
+    parser.add_argument("--width", type=int, default=640)
+    parser.add_argument("--height", type=int, default=480)
+    parser.add_argument("--fps", type=int, default=30)
+    parser.add_argument("--action-timeout", type=float, default=0.5)
+    parser.add_argument(
+        "--ice-server", action="append", default=[], help="STUN/TURN url (repeatable); omit for same-host"
+    )
+    parser.add_argument(
+        "--real-devices",
+        action="store_true",
+        help="enumerate the robot's actual serial ports + cameras (find_port/list_cameras return real ids)",
+    )
+    parser.add_argument(
+        "--real-camera",
+        default=None,
+        help="open this opencv camera (index e.g. 0, or /dev/videoN) and stream it instead of synthetic frames",
+    )
+    parser.add_argument(
+        "--profile",
+        choices=["teleop", "eval", "record"],
+        default="teleop",
+        help="channel reliability: teleop/eval => unreliable (fresh); record => reliable state+action",
+    )
+    parser.add_argument("--reliable-state", action="store_true", help="override: reliable state channel")
+    parser.add_argument("--reliable-action", action="store_true", help="override: reliable action channel")
+    parser.add_argument("--auth-token", default=None, help="shared token for the signaling relay")
+    parser.add_argument(
+        "--transport", choices=["aiortc", "livekit"], default="aiortc", help="transport backend"
+    )
+    parser.add_argument(
+        "--livekit-url",
+        default=os.environ.get("LIVEKIT_URL"),
+        help="LiveKit server URL (when --transport livekit; default $LIVEKIT_URL)",
+    )
+    parser.add_argument(
+        "--livekit-token",
+        default=None,
+        help="pre-signed LiveKit JWT; omit to self-sign from --livekit-api-key/secret",
+    )
+    parser.add_argument(
+        "--livekit-api-key",
+        default=os.environ.get("LIVEKIT_API_KEY"),
+        help="LiveKit API key for self-signing a token (default $LIVEKIT_API_KEY)",
+    )
+    parser.add_argument(
+        "--livekit-api-secret",
+        default=os.environ.get("LIVEKIT_API_SECRET"),
+        help="LiveKit API secret for self-signing a token (default $LIVEKIT_API_SECRET)",
+    )
+    parser.add_argument(
+        "--livekit-identity", default="robot", help="this daemon's LiveKit participant identity"
+    )
+    # Any leftover args (e.g. --robot.type=so101_follower --robot.port=/dev/...) are parsed
+    # by draccus into a real robot. No --robot.* => synthetic source (or --real-camera).
+    args, robot_args = parser.parse_known_args()
+    # force=True: the livekit SDK configures the root logger on import, which would make a
+    # plain basicConfig a no-op (hiding our INFO logs). Reset so daemon INFO lines show.
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s", force=True)
+
+    # Per-backend required args (livekit does its own signaling; aiortc needs the relay).
+    livekit_token = args.livekit_token
+    if args.transport == "aiortc":
+        if not args.signaling_url:
+            parser.error("--signaling-url is required for --transport aiortc")
+    else:  # livekit: need a URL and a token (pre-signed, or self-signed from api key/secret)
+        if not args.livekit_url:
+            parser.error("--livekit-url (or $LIVEKIT_URL) is required for --transport livekit")
+        if not livekit_token:
+            if not args.livekit_api_key or not args.livekit_api_secret:
+                parser.error(
+                    "--transport livekit needs --livekit-token, or --livekit-api-key + "
+                    "--livekit-api-secret (or $LIVEKIT_API_KEY/$LIVEKIT_API_SECRET) to self-sign"
+                )
+            from .transport_livekit import make_livekit_token
+
+            # The LiveKit room is the session id; both ends must use the same one.
+            livekit_token = make_livekit_token(
+                api_key=args.livekit_api_key,
+                api_secret=args.livekit_api_secret,
+                identity=args.livekit_identity,
+                room=args.session,
+            )
+            logger.info(
+                "self-signed LiveKit token (identity=%s, room=%s)", args.livekit_identity, args.session
+            )
+
+    # record needs complete, ordered obs AND actions (no lost transitions); realtime loops
+    # (teleop/eval) want freshness. Explicit flags override the profile.
+    reliable_state = args.reliable_state or args.profile == "record"
+    reliable_action = args.reliable_action or args.profile == "record"
+
+    inventory: DeviceInventory = LocalDeviceInventory() if args.real_devices else SyntheticInventory()
+    logger.info("daemon device inventory: %s", type(inventory).__name__)
+
+    # A real robot (--robot.*) provides joints + its own cameras; otherwise fall back to a
+    # standalone --real-camera, or a synthetic source. Robot and --real-camera are exclusive.
+    robot = motors = cameras = camera = None
+    if robot_args:
+        robot, motors, cameras = _build_robot(robot_args)
+    elif args.real_camera is not None:
+        index_or_path = int(args.real_camera) if args.real_camera.isdigit() else args.real_camera
+        camera = _open_streaming_camera(index_or_path, args.fps, args.width, args.height)
+
+    try:
+        asyncio.run(
+            run_daemon(
+                signaling_url=args.signaling_url,
+                session_id=args.session,
+                motors=motors,
+                cam_name=args.camera_name,
+                cam_height=args.height,
+                cam_width=args.width,
+                cameras=cameras,
+                capture_fps=args.fps,
+                action_timeout_s=args.action_timeout,
+                ice_servers=args.ice_server,
+                inventory=inventory,
+                camera=camera,
+                robot=robot,
+                reliable_state=reliable_state,
+                reliable_action=reliable_action,
+                signaling_token=args.auth_token,
+                transport_backend=args.transport,
+                livekit_url=args.livekit_url,
+                livekit_token=livekit_token,
+            )
+        )
+    except KeyboardInterrupt:
+        pass
+    finally:
+        if camera is not None:
+            camera.disconnect()
+        if robot is not None:
+            with contextlib.suppress(Exception):
+                robot.disconnect()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/lerobot/robots/webrtc_proxy/signaling.py
+++ b/src/lerobot/robots/webrtc_proxy/signaling.py
@@ -1,0 +1,151 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Signaling abstraction: exchanges SDP offer/answer between the two peers.
+
+M1 uses :class:`LoopbackSignaling`, an in-process pair backed by ``asyncio.Queue``
+(no STUN/TURN, no network — both peers share one event loop). M3 will add a
+WebSocket implementation against the K8s signaler with the *same* ``send``/``recv``
+interface, so neither the capture agent nor the proxy changes.
+
+aiortc gathers ICE candidates into the SDP (non-trickle) by the time
+``localDescription`` is read, so exchanging full session descriptions is enough on
+loopback; trickle-ICE is only needed once real NAT traversal (STUN/TURN) is in play.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Protocol
+
+from aiortc import RTCSessionDescription
+
+
+class SignalingClosedError(Exception):
+    """Raised by ``recv`` when the peer left or the transport closed."""
+
+
+class Signaling(Protocol):
+    """Minimal duplex SDP exchange used by both endpoints.
+
+    ``ice_servers`` is populated by ``open()`` with any STUN/TURN config the relay hands
+    out on connect (empty for loopback / a relay with no TURN configured); the transport
+    merges it into the peer connection. See ``signaling_server.py``.
+    """
+
+    ice_servers: list
+
+    async def open(self) -> None: ...
+
+    async def send(self, description: RTCSessionDescription) -> None: ...
+
+    async def recv(self) -> RTCSessionDescription: ...
+
+    async def close(self) -> None: ...
+
+
+class LoopbackSignaling:
+    """One end of an in-process signaling pair. See :func:`loopback_signaling_pair`."""
+
+    ice_servers: list = []  # loopback has no relay to hand out STUN/TURN
+
+    def __init__(self, outbox: asyncio.Queue, inbox: asyncio.Queue) -> None:
+        self._outbox = outbox
+        self._inbox = inbox
+
+    async def open(self) -> None:
+        pass
+
+    async def send(self, description: RTCSessionDescription) -> None:
+        await self._outbox.put(description)
+
+    async def recv(self) -> RTCSessionDescription:
+        return await self._inbox.get()
+
+    async def close(self) -> None:
+        pass
+
+
+def loopback_signaling_pair() -> tuple[LoopbackSignaling, LoopbackSignaling]:
+    """Return ``(offerer_signaling, answerer_signaling)`` wired back-to-back."""
+    a_to_b: asyncio.Queue = asyncio.Queue()
+    b_to_a: asyncio.Queue = asyncio.Queue()
+    offerer = LoopbackSignaling(outbox=a_to_b, inbox=b_to_a)
+    answerer = LoopbackSignaling(outbox=b_to_a, inbox=a_to_b)
+    return offerer, answerer
+
+
+class WebSocketSignaling:
+    """SDP exchange over a WebSocket relay (see ``signaling_server.py``).
+
+    Both the robot daemon (``role="robot"``) and the cloud controller
+    (``role="controller"``) connect to the same relay URL with a shared
+    ``session`` id; the relay forwards each SDP between them (buffering until the
+    peer joins). Non-trickle ICE means just one offer + one answer cross the wire.
+    """
+
+    def __init__(self, base_url: str, session: str, role: str, token: str | None = None) -> None:
+        sep = "&" if "?" in base_url else "?"
+        self._url = f"{base_url}{sep}session={session}&role={role}"
+        self._token = token
+        self._client = None
+        self._ws = None
+        self.ice_servers: list = []
+        self._pending: dict | None = None  # a non-ICE message read early in open()
+
+    async def open(self) -> None:
+        import aiohttp
+
+        self._client = aiohttp.ClientSession()
+        headers = {"Authorization": f"Bearer {self._token}"} if self._token else None
+        self._ws = await self._client.ws_connect(self._url, headers=headers)
+        # The relay pushes an ICE config message on join (before any buffered SDP). Consume
+        # it here; if the first message isn't ICE (e.g. an older relay), stash it for recv().
+        first = await self._next_message()
+        if first is not None and first.get("kind") == "ice":
+            self.ice_servers = first.get("iceServers", [])
+        else:
+            self._pending = first
+
+    async def _next_message(self) -> dict | None:
+        """Return the next parsed TEXT message, or None if the socket closed."""
+        import aiohttp
+
+        async for msg in self._ws:
+            if msg.type == aiohttp.WSMsgType.TEXT:
+                return msg.json()
+            if msg.type in (aiohttp.WSMsgType.CLOSE, aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.ERROR):
+                break
+        return None
+
+    async def send(self, description: RTCSessionDescription) -> None:
+        await self._ws.send_json({"kind": "sdp", "type": description.type, "sdp": description.sdp})
+
+    async def recv(self) -> RTCSessionDescription:
+        while True:
+            data = self._pending if self._pending is not None else await self._next_message()
+            self._pending = None
+            if data is None:
+                raise SignalingClosedError("signaling websocket closed")
+            if data.get("kind") == "sdp":
+                return RTCSessionDescription(sdp=data["sdp"], type=data["type"])
+            if data.get("kind") == "bye":
+                raise SignalingClosedError("peer left the signaling session")
+            # ignore anything else (e.g. a late ICE refresh) and keep waiting for SDP
+
+    async def close(self) -> None:
+        if self._ws is not None:
+            await self._ws.close()
+        if self._client is not None:
+            await self._client.close()

--- a/src/lerobot/robots/webrtc_proxy/signaling_server.py
+++ b/src/lerobot/robots/webrtc_proxy/signaling_server.py
@@ -1,0 +1,212 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""WebSocket signaling relay: pairs a robot daemon with a cloud controller.
+
+A session has two roles — ``robot`` (the robot daemon) and ``controller`` (the cloud
+``WebRTCProxyRobot``). Each connects to ``GET /ws?session=<id>&role=<role>`` and the
+relay forwards every message to the *other* role, buffering until that peer joins
+(so the daemon may offer before a controller exists). When one side drops, the
+relay sends ``{"kind":"bye"}`` to the survivor so the daemon can reset and loop.
+
+This is the control-plane signaler for the **aiortc** (direct-UDP) backend. It carries
+SDP plus, on connect, a small **ICE config** message (STUN urls) so peers can form a
+server-reflexive candidate and connect directly across NAT — it never carries media.
+With no STUN configured it hands out an empty list (host-candidate-only / LAN). aiortc
+is direct-only; for a media relay (both ends behind restrictive NAT) use the LiveKit
+backend instead (DESIGN §11.1). In production this runs as an ordinary (non-hostNetwork)
+Deployment behind a normal Service/Ingress.
+
+Run standalone:
+    python -m lerobot.robots.webrtc_proxy.signaling_server --port 8765 \
+        --stun-url stun:stun.l.google.com:19302   # or a domestic STUN, or self-hosted
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import contextlib
+import logging
+import os
+import secrets
+import socket
+from collections import defaultdict
+
+from aiohttp import WSMsgType, web
+
+logger = logging.getLogger(__name__)
+
+_OTHER = {"robot": "controller", "controller": "robot"}
+
+
+def _split_env(name: str) -> list[str]:
+    """Comma-separated env var -> list (for argparse defaults). Empty/unset -> []."""
+    return [u.strip() for u in os.environ.get(name, "").split(",") if u.strip()]
+
+
+class IceConfig:
+    """Builds the STUN-server list the relay hands to each peer on connect.
+
+    aiortc is the **direct-UDP** backend: host candidates connect on a LAN, and STUN adds
+    a server-reflexive (public) candidate so peers can also connect directly across NAT
+    when at least one side is reachable. STUN only *discovers* the public address — media
+    still flows peer-to-peer, never through the relay. With no STUN configured this yields
+    ``[]`` (host-candidate-only / LAN). For a genuine media **relay** (both ends behind
+    restrictive NAT), use the LiveKit backend — we deliberately don't run a TURN relay
+    under aiortc (see DESIGN §11.1).
+    """
+
+    def __init__(self, stun_urls: list[str] | None = None) -> None:
+        self._stun = list(stun_urls or [])
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self._stun)
+
+    def for_peer(self, name: str) -> list[dict]:
+        return [{"urls": self._stun}] if self._stun else []
+
+
+class SignalingRelay:
+    """Forwards SDP between the two roles of each session, buffering for late joiners.
+
+    A public relay must gate the door: with ``auth_token`` set, every WebSocket must
+    present a matching token (``Authorization: Bearer <token>`` header, or ``?token=``
+    query as a fallback) or it is rejected before pairing. NOTE: a single shared token
+    only stops random scanners — it does NOT isolate sessions/tenants (anyone holding
+    it can join any session_id). Multi-tenant deployments must move to per-session
+    signed tokens validated here (DESIGN.md §12).
+    """
+
+    def __init__(self, auth_token: str | None = None, ice: IceConfig | None = None) -> None:
+        self._auth_token = auth_token
+        self._ice = ice or IceConfig()
+        self._peers: dict[tuple[str, str], web.WebSocketResponse] = {}
+        self._inbox: dict[tuple[str, str], list[dict]] = defaultdict(list)
+
+    def _authorized(self, request: web.Request) -> bool:
+        if not self._auth_token:
+            return True
+        auth = request.headers.get("Authorization", "")
+        token = auth[7:] if auth.startswith("Bearer ") else request.query.get("token", "")
+        return secrets.compare_digest(token, self._auth_token)
+
+    async def handle(self, request: web.Request) -> web.StreamResponse:
+        if not self._authorized(request):
+            return web.Response(status=401, text="unauthorized")
+        session = request.query.get("session", "default")
+        role = request.query.get("role", "")
+        if role not in _OTHER:
+            return web.Response(status=400, text="role must be 'robot' or 'controller'")
+        other = _OTHER[role]
+
+        ws = web.WebSocketResponse(heartbeat=20)
+        await ws.prepare(request)
+        self._peers[(session, role)] = ws
+        logger.info("signaling: %s joined session %s", role, session)
+
+        # Hand out ICE config (STUN servers) FIRST, so the peer can build its
+        # RTCPeerConnection with it before any SDP arrives. Always sent (empty list when no
+        # STUN is configured) so the client protocol is uniform.
+        await ws.send_json({"kind": "ice", "iceServers": self._ice.for_peer(f"{session}:{role}")})
+
+        # Flush anything buffered for me before I joined.
+        for msg in self._inbox.pop((session, role), []):
+            await ws.send_json(msg)
+
+        try:
+            async for msg in ws:
+                if msg.type == WSMsgType.TEXT:
+                    data = msg.json()
+                    target = self._peers.get((session, other))
+                    if target is not None and not target.closed:
+                        await target.send_json(data)
+                    else:
+                        self._inbox[(session, other)].append(data)
+                elif msg.type in (WSMsgType.CLOSE, WSMsgType.ERROR):
+                    break
+        finally:
+            self._peers.pop((session, role), None)
+            peer = self._peers.get((session, other))
+            if peer is not None and not peer.closed:
+                await peer.send_json({"kind": "bye"})
+            logger.info("signaling: %s left session %s", role, session)
+        return ws
+
+
+def make_app(auth_token: str | None = None, ice: IceConfig | None = None) -> web.Application:
+    relay = SignalingRelay(auth_token=auth_token, ice=ice)
+    app = web.Application()
+    app.router.add_get("/ws", relay.handle)
+    return app
+
+
+async def start_relay(
+    host: str = "127.0.0.1", port: int = 0, auth_token: str | None = None, ice: IceConfig | None = None
+) -> tuple[web.AppRunner, int]:
+    """Start the relay on ``host:port`` (port 0 => ephemeral). Returns (runner, port)."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.bind((host, port))
+    actual_port = sock.getsockname()[1]
+    runner = web.AppRunner(make_app(auth_token=auth_token, ice=ice))
+    await runner.setup()
+    await web.SockSite(runner, sock).start()
+    logger.info(
+        "signaling relay listening on ws://%s:%d/ws (auth=%s, ice=%s)",
+        host,
+        actual_port,
+        bool(auth_token),
+        (ice or IceConfig()).enabled,
+    )
+    return runner, actual_port
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="WebRTCProxyRobot WebSocket signaling relay")
+    parser.add_argument("--host", default="0.0.0.0")  # noqa: S104 (server binds all ifaces by design)
+    # FaaS web-app runtimes inject the listen port via $PORT; fall back to 8765 locally.
+    parser.add_argument("--port", type=int, default=int(os.environ.get("PORT", "8765")))
+    parser.add_argument(
+        "--auth-token",
+        default=os.environ.get("SIGNALING_AUTH_TOKEN"),
+        help="shared token every peer must present (Authorization: Bearer ...). Public relays should set it.",
+    )
+    parser.add_argument(
+        "--stun-url",
+        action="append",
+        default=_split_env("STUN_URLS"),
+        help="STUN url handed to peers for direct cross-NAT P2P (repeatable; or $STUN_URLS "
+        "comma-separated). e.g. stun:stun.l.google.com:19302 (domestic: stun:stun.qq.com:3478). "
+        "For a media relay across hard NATs, use the LiveKit backend instead.",
+    )
+    args = parser.parse_args()
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+
+    ice = IceConfig(stun_urls=args.stun_url)
+
+    async def _run() -> None:
+        runner, _ = await start_relay(args.host, args.port, auth_token=args.auth_token, ice=ice)
+        try:
+            await asyncio.Event().wait()  # run forever
+        finally:
+            await runner.cleanup()
+
+    with contextlib.suppress(KeyboardInterrupt):
+        asyncio.run(_run())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/lerobot/robots/webrtc_proxy/sim_remote.py
+++ b/src/lerobot/robots/webrtc_proxy/sim_remote.py
@@ -1,0 +1,171 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Simulate the *remote* control plane on one machine.
+
+Spins up the relay + robot daemon + cloud controller as three independent event
+loops in this single process — they talk only over localhost sockets, exactly as a
+real cloud pod and a real robot daemon would over the public internet (only the IP
+differs). Then it runs one control-plane RPC from the controller and prints what
+came back "from the robot".
+
+    python -m lerobot.robots.webrtc_proxy.sim_remote --rpc list_cameras
+    python -m lerobot.robots.webrtc_proxy.sim_remote --rpc list_ports
+    python -m lerobot.robots.webrtc_proxy.sim_remote --rpc find_port
+    python -m lerobot.robots.webrtc_proxy.sim_remote --rpc observe
+    python -m lerobot.robots.webrtc_proxy.sim_remote --rpc all
+
+Default uses synthetic devices (no hardware needed). ``--real-devices`` makes the
+daemon enumerate this machine's actual ports/cameras via ``LocalDeviceInventory``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import contextlib
+import logging
+import threading
+import time
+
+from .configuration_webrtc_proxy import WebRTCCameraSpec, WebRTCProxyRobotConfig
+from .control import DeviceInventory, LocalDeviceInventory, SyntheticInventory
+from .proxy_robot import WebRTCProxyRobot
+from .robot_daemon import run_daemon
+from .signaling_server import start_relay
+
+logger = logging.getLogger(__name__)
+
+# Example synthetic devices (ids mirror real output: opencv index / realsense serial).
+_SIM_PORTS = ["/dev/tty.usbmodem-bus-A", "/dev/tty.usbmodem-bus-B"]
+_SIM_CAMERAS = [
+    {"type": "opencv", "id": 0, "name": "FaceTime HD Camera", "width": 1280, "height": 720, "fps": 30.0},
+    {"type": "opencv", "id": 1, "name": "Logitech C920", "width": 640, "height": 480, "fps": 30.0},
+]
+
+
+def _spawn_loop() -> asyncio.AbstractEventLoop:
+    loop = asyncio.new_event_loop()
+    threading.Thread(target=lambda: (asyncio.set_event_loop(loop), loop.run_forever()), daemon=True).start()
+    return loop
+
+
+def _run_rpc(
+    robot: WebRTCProxyRobot, rpc: str, inventory: DeviceInventory, camera_id, save: str | None
+) -> None:
+    if rpc == "grab":
+        img = robot.grab_camera_preview(camera_id, width=320, height=240)
+        print(
+            f"REMOTE grab_camera_preview(id={camera_id!r}): {img.shape} {img.dtype} "
+            f"mean RGB {img.reshape(-1, 3).mean(0).round(1)}"
+        )
+        if save:
+            from PIL import Image
+
+            Image.fromarray(img).save(save)
+            print(f"  saved {save}")
+        return
+    if rpc in ("list_ports", "all"):
+        print("REMOTE list_ports():", robot.list_ports())
+    if rpc in ("list_cameras", "all"):
+        print("REMOTE list_cameras():")
+        for cam in robot.list_cameras():
+            print("  ", cam)
+    if rpc in ("observe", "all"):
+        obs = robot.get_observation()
+        frame = obs[robot.cam_name]
+        print(f"REMOTE get_observation(): {sorted(k for k in obs if k.endswith('.pos'))}")
+        print(f"  {robot.cam_name}: {frame.shape} {frame.dtype}")
+    if rpc in ("find_port", "all"):
+        before = robot.find_port_begin()
+        print("REMOTE find_port_begin():", before)
+        if isinstance(inventory, SyntheticInventory):
+            inventory.simulate_unplug(before[-1])  # headless: auto "unplug" the last port
+            print(f"  (simulated unplug of {before[-1]})")
+        else:
+            input("  Unplug the motor-bus USB on this machine, then press Enter... ")
+        print("REMOTE find_port_result():", robot.find_port_result())
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Simulate a remote control-plane RPC on one machine")
+    parser.add_argument(
+        "--rpc",
+        default="list_cameras",
+        choices=["list_ports", "list_cameras", "grab", "find_port", "observe", "all"],
+    )
+    parser.add_argument("--real-devices", action="store_true", help="enumerate this machine's real devices")
+    parser.add_argument("--camera-id", default="0", help="camera id for --rpc grab (int index or path)")
+    parser.add_argument("--save", default=None, help="for --rpc grab: save the frame to this PNG path")
+    args = parser.parse_args()
+    camera_id = int(args.camera_id) if args.camera_id.isdigit() else args.camera_id
+    logging.basicConfig(level=logging.WARNING, format="%(levelname)s %(name)s: %(message)s")
+
+    inventory: DeviceInventory = (
+        LocalDeviceInventory()
+        if args.real_devices
+        else SyntheticInventory(ports=list(_SIM_PORTS), cameras=[dict(c) for c in _SIM_CAMERAS])
+    )
+
+    # cloud: signaling relay
+    relay_loop = _spawn_loop()
+    runner, port = asyncio.run_coroutine_threadsafe(start_relay("127.0.0.1", 0), relay_loop).result(timeout=5)
+    url = f"ws://127.0.0.1:{port}/ws"
+
+    # robot: daemon
+    daemon_loop = _spawn_loop()
+    daemon_fut = asyncio.run_coroutine_threadsafe(
+        run_daemon(
+            url,
+            "sim",
+            cam_name="front",
+            cam_height=48,
+            cam_width=64,
+            capture_fps=30,
+            ice_servers=[],
+            inventory=inventory,
+        ),
+        daemon_loop,
+    )
+    time.sleep(0.5)  # let the daemon connect + buffer its offer
+
+    # cloud: controller
+    robot = WebRTCProxyRobot(
+        WebRTCProxyRobotConfig(
+            cameras={"front": WebRTCCameraSpec(height=48, width=64, fps=30)},
+            signaling_url=url,
+            session_id="sim",
+            ice_servers=[],
+            connect_timeout_s=20.0,
+        )
+    )
+    print(f"controller connecting to {url} ...")
+    robot.connect()
+    try:
+        _run_rpc(robot, args.rpc, inventory, camera_id, args.save)
+    finally:
+        # Ordered, graceful shutdown so aiohttp/aiortc close cleanly (no pending-task spam):
+        robot.disconnect()  # closes the controller pc + its ws session
+        daemon_fut.cancel()  # interrupts the daemon's wait; its finally closes agent + ws
+        time.sleep(0.3)  # let that finally run on the still-spinning daemon loop
+        with contextlib.suppress(Exception):
+            asyncio.run_coroutine_threadsafe(runner.cleanup(), relay_loop).result(timeout=3)
+        daemon_loop.call_soon_threadsafe(daemon_loop.stop)
+        relay_loop.call_soon_threadsafe(relay_loop.stop)
+        time.sleep(0.1)
+    print("done")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/lerobot/robots/webrtc_proxy/tiling.py
+++ b/src/lerobot/robots/webrtc_proxy/tiling.py
@@ -1,0 +1,73 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Single-track multi-camera tiling.
+
+aiortc carries **one** video track; to stream N cameras we vertically stack their frames
+into one tall frame on the robot (``tile``) and slice them back on the cloud (``untile``).
+Both ends derive the **same** layout from the camera specs — sorted by name, so the order
+is deterministic — which means no per-frame metadata is needed and the existing
+seq-in-pts pairing is untouched (still one frame per capture seq).
+
+Layout: cameras stacked top→bottom in name order; each keeps its own ``(h, w)``; narrower
+ones are left-aligned and the row padded to the max width. **One camera is the identity**
+(the combined frame *is* that frame), so single-camera behaviour is byte-for-byte
+unchanged. This trades per-camera bitrate control for a single encoder (cheapest on
+aiortc's Python/GIL encode path) — the right call for a few same-ish robot cameras; for
+many/high-res streams use the LiveKit backend (DESIGN §11.1).
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+# A camera spec in the canonical tiling order: (name, height, width).
+Spec = tuple[str, int, int]
+
+
+def ordered_specs(cameras: dict[str, tuple[int, int]]) -> list[Spec]:
+    """``{name: (h, w)}`` -> ``[(name, h, w), ...]`` sorted by name (the canonical order)."""
+    return [(name, cameras[name][0], cameras[name][1]) for name in sorted(cameras)]
+
+
+def tiled_size(specs: list[Spec]) -> tuple[int, int]:
+    """``(height, width)`` of the combined frame: stacked heights × max width."""
+    return sum(h for _, h, _ in specs), max((w for _, _, w in specs), default=0)
+
+
+def tile(frames: dict[str, np.ndarray], specs: list[Spec]) -> np.ndarray:
+    """Stack per-camera frames into one ``(ΣH, maxW, 3)`` uint8 frame (name order).
+
+    Each ``frames[name]`` must already be exactly ``(h, w, 3)`` uint8 for its spec.
+    """
+    height, width = tiled_size(specs)
+    out = np.zeros((height, width, 3), dtype=np.uint8)
+    y = 0
+    for name, h, w in specs:
+        out[y : y + h, 0:w] = frames[name]
+        y += h
+    return out
+
+
+def untile(combined: np.ndarray, specs: list[Spec]) -> dict[str, np.ndarray]:
+    """Inverse of :func:`tile`: slice the combined frame back into ``{name: (h, w, 3)}``.
+
+    Returns views into ``combined``; copy/contiguous-ify downstream if needed.
+    """
+    out: dict[str, np.ndarray] = {}
+    y = 0
+    for name, h, w in specs:
+        out[name] = combined[y : y + h, 0:w]
+        y += h
+    return out

--- a/src/lerobot/robots/webrtc_proxy/transport.py
+++ b/src/lerobot/robots/webrtc_proxy/transport.py
@@ -1,0 +1,301 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pluggable transport layer.
+
+The proxy's logic (capture loop, alignment, watchdog, control-plane RPC, the Robot
+API) is transport-agnostic; it only needs:
+
+- named **data channels** (configurable reliability) to send/receive small JSON
+  (state, action, control), and
+- a one-way **video stream** carrying frames tagged with a capture ``seq``.
+
+``Transport`` is that contract. ``AiortcTransport`` implements it with aiortc
+(WebRTC P2P + DataChannels, the default, self-contained backend). A different
+backend — e.g. a LiveKit SFU for cross-public-net / scale — can implement the same
+interface without touching ``CaptureAgent`` / ``_ProxyEndpoint`` / ``WebRTCProxyRobot``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from abc import ABC, abstractmethod
+from collections.abc import Callable
+from fractions import Fraction
+
+import numpy as np
+
+from .protocol import VIDEO_CLOCK_RATE, VIDEO_PTS_PER_SEQ, channel_kwargs
+from .signaling import Signaling
+
+logger = logging.getLogger(__name__)
+
+
+def make_transport(
+    backend: str,
+    *,
+    role: str,
+    channels: dict[str, bool],
+    ice_servers: list[str | dict] | None = None,
+    livekit_url: str | None = None,
+    livekit_token: str | None = None,
+) -> Transport:
+    """Build a transport for ``backend`` ("aiortc" | "livekit").
+
+    Both ends of a session MUST use the same backend (an aiortc P2P peer and a LiveKit
+    room don't interoperate). "aiortc" is the default, self-contained backend. "livekit"
+    (EXPERIMENTAL scaffold, see ``transport_livekit.py``) routes via a LiveKit SFU and
+    needs ``livekit_url`` + ``livekit_token``.
+    """
+    if backend == "aiortc":
+        return AiortcTransport(role=role, channels=channels, ice_servers=ice_servers)
+    if backend == "livekit":
+        if not livekit_url or not livekit_token:
+            raise ValueError("transport_backend='livekit' requires livekit_url and livekit_token")
+        from .transport_livekit import LiveKitTransport
+
+        return LiveKitTransport(role=role, channels=channels, url=livekit_url, token=livekit_token)
+    raise ValueError(f"unknown transport backend {backend!r} (expected 'aiortc' or 'livekit')")
+
+
+class Channel(ABC):
+    """A named message pipe. ``send`` is best-effort (drops if not open)."""
+
+    @abstractmethod
+    def send(self, data: str) -> None: ...
+
+    @abstractmethod
+    def on_message(self, callback: Callable[[str], None]) -> None: ...
+
+    @property
+    @abstractmethod
+    def is_open(self) -> bool: ...
+
+
+class Transport(ABC):
+    """Bidirectional transport: named data channels + one video stream.
+
+    Roles: the ``"publisher"`` side offers + sends video; the ``"subscriber"`` side
+    answers + receives video. Data channels are bidirectional regardless of role.
+    """
+
+    def __init__(self) -> None:
+        self.connected = asyncio.Event()
+        self.closed = asyncio.Event()
+
+    @abstractmethod
+    async def open(self, signaling: Signaling) -> None:
+        """Establish the connection (exchange SDP via ``signaling``) and wire channels."""
+
+    @abstractmethod
+    def channel(self, label: str) -> Channel:
+        """Return the channel handle for ``label`` (created/expected at construction)."""
+
+    @abstractmethod
+    def send_frame(self, seq: int, img: np.ndarray) -> None:
+        """Publish one video frame tagged with its capture ``seq`` (publisher only)."""
+
+    @abstractmethod
+    def set_frame_handler(self, callback: Callable[[int, np.ndarray], None]) -> None:
+        """Register ``callback(seq, rgb_ndarray)`` for received frames (subscriber only)."""
+
+    async def wait_closed(self) -> None:
+        await self.closed.wait()
+
+    @abstractmethod
+    async def close(self) -> None: ...
+
+
+# --------------------------------------------------------------------------- #
+# aiortc backend
+# --------------------------------------------------------------------------- #
+class _AiortcChannel(Channel):
+    """Wraps an aiortc RTCDataChannel, tolerating "registered before it exists"."""
+
+    def __init__(self) -> None:
+        self._ch = None
+        self._pending_cb: Callable[[str], None] | None = None
+
+    def bind(self, ch) -> None:  # noqa: ANN001 (RTCDataChannel)
+        self._ch = ch
+        if self._pending_cb is not None:
+            ch.on("message", self._pending_cb)
+
+    def send(self, data: str) -> None:
+        if self._ch is not None and self._ch.readyState == "open":
+            self._ch.send(data)
+
+    def on_message(self, callback: Callable[[str], None]) -> None:
+        if self._ch is not None:
+            self._ch.on("message", callback)
+        else:
+            self._pending_cb = callback
+
+    @property
+    def is_open(self) -> bool:
+        return self._ch is not None and self._ch.readyState == "open"
+
+
+class _PublisherTrack:
+    """An aiortc MediaStreamTrack fed by ``send_frame``; seq rides the frame pts."""
+
+    kind = "video"
+
+    def __init__(self) -> None:
+        from aiortc import MediaStreamTrack
+
+        # Build the actual track lazily to avoid importing aiortc at module import.
+        class _Track(MediaStreamTrack):
+            kind = "video"
+
+            def __init__(self) -> None:
+                super().__init__()
+                self._q: asyncio.Queue[tuple[int, np.ndarray]] = asyncio.Queue(maxsize=2)
+
+            def push(self, seq: int, img: np.ndarray) -> None:
+                if self._q.full():
+                    _ = self._q.get_nowait()  # drop oldest; don't block the capture clock
+                self._q.put_nowait((seq, img))
+
+            async def recv(self):
+                from av import VideoFrame
+
+                seq, img = await self._q.get()
+                frame = VideoFrame.from_ndarray(img, format="rgb24")
+                frame.pts = seq * VIDEO_PTS_PER_SEQ
+                frame.time_base = Fraction(1, VIDEO_CLOCK_RATE)
+                return frame
+
+        self.track = _Track()
+
+    def push(self, seq: int, img: np.ndarray) -> None:
+        self.track.push(seq, img)
+
+
+class AiortcTransport(Transport):
+    """Default backend: WebRTC P2P (media track + DataChannels) over aiortc."""
+
+    def __init__(
+        self,
+        *,
+        role: str,  # "publisher" (offers + sends video) | "subscriber" (answers + recvs video)
+        channels: dict[str, bool],  # label -> reliable (reliability honoured by the publisher/offerer)
+        # Each entry is a STUN url string or a dict {"urls", ...}. aiortc is direct-UDP:
+        # STUN gives a server-reflexive candidate for cross-NAT direct P2P. Static config;
+        # the signaling relay also hands out STUN at open(). (The dict form accepts
+        # username/credential as a generic escape hatch, but the media-relay path is the
+        # LiveKit backend, not a TURN server under aiortc — see DESIGN §11.1.)
+        ice_servers: list[str | dict] | None = None,
+    ) -> None:
+        super().__init__()
+        if role not in ("publisher", "subscriber"):
+            raise ValueError(f"role must be 'publisher' or 'subscriber', got {role!r}")
+        self.role = role
+        self._channel_specs = dict(channels)
+        self._ice_cfg: list[str | dict] = list(ice_servers or [])
+        # The RTCPeerConnection is built in open(), once the signaling relay has had a
+        # chance to hand us STUN servers. aiortc fixes iceServers at construction, so we
+        # can't build it earlier.
+        self.pc = None
+        self._channels: dict[str, _AiortcChannel] = {label: _AiortcChannel() for label in channels}
+        self._pub = _PublisherTrack() if role == "publisher" else None
+        self._frame_cb: Callable[[int, np.ndarray], None] | None = None
+
+    @staticmethod
+    def _to_ice_server(cfg: str | dict):  # noqa: ANN205 (RTCIceServer)
+        """Coerce a config entry (url string or {urls,username,credential}) to RTCIceServer."""
+        from aiortc import RTCIceServer
+
+        if isinstance(cfg, str):
+            return RTCIceServer(urls=cfg)
+        return RTCIceServer(urls=cfg["urls"], username=cfg.get("username"), credential=cfg.get("credential"))
+
+    def _register(self) -> None:
+        @self.pc.on("connectionstatechange")
+        async def _on_state() -> None:
+            state = self.pc.connectionState
+            logger.info("transport connectionState=%s", state)
+            if state == "connected":
+                self.connected.set()
+            elif state in ("failed", "closed", "disconnected"):
+                self.closed.set()
+
+        if self.role == "subscriber":
+
+            @self.pc.on("datachannel")
+            def _on_channel(ch):  # noqa: ANN001
+                if ch.label in self._channels:
+                    self._channels[ch.label].bind(ch)
+
+            @self.pc.on("track")
+            def _on_track(track):  # noqa: ANN001
+                asyncio.ensure_future(self._consume(track))
+
+    async def _consume(self, track) -> None:  # noqa: ANN001
+        while True:
+            try:
+                frame = await track.recv()
+            except Exception:
+                logger.info("transport: video track ended")
+                return
+            seconds = float(frame.pts) * float(frame.time_base)
+            seq = round(seconds * VIDEO_CLOCK_RATE / VIDEO_PTS_PER_SEQ)
+            if self._frame_cb is not None:
+                self._frame_cb(seq, frame.to_ndarray(format="rgb24"))
+
+    async def open(self, signaling: Signaling) -> None:
+        from aiortc import RTCConfiguration, RTCPeerConnection, RTCSessionDescription
+
+        await signaling.open()
+        # Merge static (config) ICE servers with any the relay handed us on connect
+        # (e.g. TURN with freshly-minted ephemeral credentials). Built now because aiortc
+        # fixes iceServers at RTCPeerConnection construction.
+        ice_cfg = self._ice_cfg + list(getattr(signaling, "ice_servers", None) or [])
+        self.pc = RTCPeerConnection(
+            configuration=RTCConfiguration(iceServers=[self._to_ice_server(c) for c in ice_cfg])
+        )
+        self._register()
+        if self.role == "publisher":
+            for label, reliable in self._channel_specs.items():
+                self._channels[label].bind(self.pc.createDataChannel(label, **channel_kwargs(reliable)))
+            if self._pub is not None:
+                self.pc.addTrack(self._pub.track)
+            await self.pc.setLocalDescription(await self.pc.createOffer())
+            await signaling.send(self.pc.localDescription)
+            answer = await signaling.recv()
+            if not isinstance(answer, RTCSessionDescription):
+                raise RuntimeError(f"publisher expected an SDP answer, got {type(answer)!r}")
+            await self.pc.setRemoteDescription(answer)
+        else:
+            offer = await signaling.recv()
+            if not isinstance(offer, RTCSessionDescription):
+                raise RuntimeError(f"subscriber expected an SDP offer, got {type(offer)!r}")
+            await self.pc.setRemoteDescription(offer)
+            await self.pc.setLocalDescription(await self.pc.createAnswer())
+            await signaling.send(self.pc.localDescription)
+
+    def channel(self, label: str) -> Channel:
+        return self._channels[label]
+
+    def send_frame(self, seq: int, img: np.ndarray) -> None:
+        if self._pub is not None:
+            self._pub.push(seq, img)
+
+    def set_frame_handler(self, callback: Callable[[int, np.ndarray], None]) -> None:
+        self._frame_cb = callback
+
+    async def close(self) -> None:
+        self.closed.set()
+        await self.pc.close()

--- a/src/lerobot/robots/webrtc_proxy/transport_livekit.py
+++ b/src/lerobot/robots/webrtc_proxy/transport_livekit.py
@@ -1,0 +1,253 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""LiveKit transport backend — EXPERIMENTAL (optional).
+
+Implements the :class:`Transport` interface on top of the LiveKit Python SDK
+(``livekit`` / ``livekit-rtc``), so the proxy can run over a LiveKit SFU (LiveKit Cloud
+or self-hosted) instead of aiortc P2P — which gives built-in signaling + NAT
+traversal/TURN + scale, at the cost of running/using a LiveKit server (see DESIGN §11).
+
+Verified end-to-end against a local ``livekit-server --dev`` (obs + action + control
+round-trip, fresh aligned observations); aiortc remains the default, CI-tested backend.
+Map of concepts:
+
+    our channel label  ->  LiveKit data **topic** (publish_data/on data_received)
+    reliable bool      ->  publish_data(reliable=...)
+    video stream       ->  a published/subscribed video track
+    session_id         ->  room name (in the JWT)
+    our Signaling      ->  unused (LiveKit does its own signaling; pass url+token)
+
+Carrying the capture seq with each video frame: LiveKit re-stamps frame timestamps and
+``FrameMetadata`` is a fixed proto, so the seq can't ride the frame. The publisher
+announces each frame's seq on a reliable data topic (``_SEQ_TOPIC``) and the subscriber
+stamps each arriving frame with the latest announced seq (see that constant's note).
+
+Install: ``uv pip install livekit`` (or add the ``webrtc-livekit`` extra).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from collections.abc import Callable
+
+import numpy as np
+
+from .transport import Channel, Transport
+
+logger = logging.getLogger(__name__)
+
+
+def make_livekit_token(
+    *, api_key: str, api_secret: str, identity: str, room: str, ttl_hours: float = 24.0
+) -> str:
+    """Sign a LiveKit access token (JWT) granting ``identity`` room-join in ``room``.
+
+    Lets each process **self-sign** its own token from a shared API key/secret (so the
+    daemon and controller each mint their own ``robot`` / ``controller`` identity instead
+    of you pasting two JWTs). Convenient for dev / single-tenant.
+
+    Production note: the API secret can mint a token for *any* room/identity, so don't
+    ship it to the user's robot — prefer a cloud token server that hands out scoped,
+    short-lived tokens. That's why the transport still accepts a pre-signed token too.
+    """
+    try:
+        from livekit import api
+    except ImportError as e:  # pragma: no cover - optional dep
+        raise ImportError(
+            "signing a LiveKit token needs the LiveKit SDK: `uv pip install livekit-api` "
+            "(or the lerobot[webrtc-livekit] extra)."
+        ) from e
+    from datetime import timedelta
+
+    return (
+        api.AccessToken(api_key, api_secret)
+        .with_identity(identity)
+        .with_ttl(timedelta(hours=ttl_hours))
+        .with_grants(api.VideoGrants(room_join=True, room=room))
+        .to_jwt()
+    )
+
+
+# LiveKit re-stamps frame timestamps and FrameMetadata is a fixed proto, so the capture
+# seq can't ride the frame. The publisher announces each frame's seq on this internal
+# reliable data topic. The subscriber tracks the *latest* announced seq and stamps each
+# arriving video frame with it.
+#
+# Why "latest" and not FIFO 1:1: the seq topic (reliable data) delivers every message,
+# but the video track is lossy — the SFU/encoder decimates frames (measured ~46% delivery
+# on a localhost dev server). A FIFO popleft therefore drifts unboundedly: the Nth
+# surviving frame gets the Nth seq, so the newest frame ends up labelled with a seq tens
+# of frames in the past (huge stale skew). Stamping with the latest announced seq keeps
+# frame seqs monotonic and fresh, and they always pair against a state seq that exists
+# (the state stream carries the same seq numbering), with a bounded skew of a frame or two
+# — which is what teleop/eval want (freshest coherent obs).
+_SEQ_TOPIC = "_seq"
+
+
+class _LiveKitChannel(Channel):
+    """A named data pipe backed by a LiveKit data **topic**."""
+
+    def __init__(self, transport: LiveKitTransport, topic: str, reliable: bool) -> None:
+        self._t = transport
+        self._topic = topic
+        self._reliable = reliable
+        self._cb: Callable[[str], None] | None = None
+
+    def send(self, data: str) -> None:
+        room = self._t.room
+        if room is None or not self._t.connected.is_set():
+            return  # best-effort, like the aiortc backend
+        # publish_data is async; fire-and-forget on the room's loop.
+        asyncio.ensure_future(
+            room.local_participant.publish_data(
+                data.encode("utf-8"), reliable=self._reliable, topic=self._topic
+            )
+        )
+
+    def on_message(self, callback: Callable[[str], None]) -> None:
+        self._cb = callback
+
+    def _dispatch(self, raw: bytes) -> None:
+        if self._cb is not None:
+            self._cb(raw.decode("utf-8"))
+
+    @property
+    def is_open(self) -> bool:
+        return self._t.connected.is_set()
+
+
+class LiveKitTransport(Transport):
+    """Transport over a LiveKit room. EXPERIMENTAL — see module docstring."""
+
+    def __init__(
+        self,
+        *,
+        role: str,  # "publisher" (publishes video) | "subscriber" (subscribes)
+        channels: dict[str, bool],  # label -> reliable
+        url: str,
+        token: str,
+    ) -> None:
+        super().__init__()
+        try:
+            from livekit import rtc
+        except ImportError as e:  # pragma: no cover - optional dep
+            raise ImportError(
+                "transport_backend='livekit' needs the LiveKit SDK: `uv pip install livekit` "
+                "(or the lerobot[webrtc-livekit] extra)."
+            ) from e
+        self._rtc = rtc
+        if role not in ("publisher", "subscriber"):
+            raise ValueError(f"role must be 'publisher' or 'subscriber', got {role!r}")
+        self.role = role
+        self._url = url
+        self._token = token
+        self.room = rtc.Room()
+        self._channels = {
+            label: _LiveKitChannel(self, label, reliable) for label, reliable in channels.items()
+        }
+        self._frame_cb: Callable[[int, np.ndarray], None] | None = None
+        self._video_source = None  # created lazily on first send_frame (needs frame dims)
+        self._latest_seq: int | None = None  # subscriber: newest seq announced on _SEQ_TOPIC
+        self._consume_task: asyncio.Task | None = None  # subscriber: the VideoStream reader
+        self._register()
+
+    def _register(self) -> None:
+        rtc = self._rtc
+
+        # NOTE: livekit's Room does NOT emit a "connected" event from connect() — the
+        # connection is established synchronously when `await room.connect()` returns
+        # (see open()). So we set self.connected there, not via an event handler.
+        @self.room.on("disconnected")
+        def _on_disconnected(*_args) -> None:
+            logger.info("livekit: room disconnected")
+            self.closed.set()
+
+        @self.room.on("data_received")
+        def _on_data(packet) -> None:  # rtc.DataPacket(data, kind, participant, topic)
+            if packet.topic == _SEQ_TOPIC:
+                try:
+                    seq = int(packet.data.decode("utf-8"))
+                except Exception:
+                    logger.exception("livekit: bad seq message")
+                    return
+                # Reliable+ordered, but guard monotonicity defensively.
+                if self._latest_seq is None or seq > self._latest_seq:
+                    self._latest_seq = seq
+                return
+            ch = self._channels.get(packet.topic)
+            if ch is not None:
+                ch._dispatch(packet.data)
+
+        if self.role == "subscriber":
+
+            @self.room.on("track_subscribed")
+            def _on_track(track, publication, participant) -> None:  # noqa: ANN001
+                if track.kind == rtc.TrackKind.KIND_VIDEO:
+                    self._consume_task = asyncio.ensure_future(self._consume(track))
+
+    async def _consume(self, track) -> None:  # noqa: ANN001
+        rtc = self._rtc
+        stream = rtc.VideoStream(track)
+        async for event in stream:  # event.frame: rtc.VideoFrame
+            if self._latest_seq is None:
+                continue  # no seq announced yet (startup); drop until we can label frames
+            seq = self._latest_seq  # freshest announced seq (see _SEQ_TOPIC note)
+            frame = event.frame.convert(rtc.VideoBufferType.RGB24)
+            img = np.frombuffer(frame.data, dtype=np.uint8).reshape(frame.height, frame.width, 3)
+            if self._frame_cb is not None:
+                self._frame_cb(seq, np.ascontiguousarray(img))
+
+    async def open(self, signaling=None) -> None:  # noqa: ANN001 - signaling unused for LiveKit
+        await self.room.connect(self._url, self._token)
+        # connect() establishes the link synchronously and does NOT fire a "connected"
+        # event, so mark connected here. auto_subscribe is on by default, so the
+        # subscriber's track_subscribed fires for the publisher's video track.
+        self.connected.set()
+        # publish_data/track work after connect; the video track is published lazily on
+        # the first send_frame so we know the frame dimensions.
+
+    def channel(self, label: str) -> Channel:
+        return self._channels[label]
+
+    def send_frame(self, seq: int, img: np.ndarray) -> None:
+        if self.role != "publisher":
+            return
+        rtc = self._rtc
+        h, w = img.shape[:2]
+        if self._video_source is None:
+            self._video_source = rtc.VideoSource(w, h)
+            track = rtc.LocalVideoTrack.create_video_track("camera", self._video_source)
+            options = rtc.TrackPublishOptions(source=rtc.TrackSource.SOURCE_CAMERA)
+            asyncio.ensure_future(self.room.local_participant.publish_track(track, options))
+        # Announce this frame's seq (reliable, ordered) so the subscriber can stamp the
+        # frame with the freshest seq (see the _SEQ_TOPIC note for why not FIFO 1:1).
+        asyncio.ensure_future(
+            self.room.local_participant.publish_data(str(seq).encode(), reliable=True, topic=_SEQ_TOPIC)
+        )
+        frame = rtc.VideoFrame(w, h, rtc.VideoBufferType.RGB24, np.ascontiguousarray(img).tobytes())
+        self._video_source.capture_frame(frame)
+
+    def set_frame_handler(self, callback: Callable[[int, np.ndarray], None]) -> None:
+        self._frame_cb = callback
+
+    async def close(self) -> None:
+        self.closed.set()
+        if self._consume_task is not None:
+            self._consume_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await self._consume_task
+        await self.room.disconnect()

--- a/tests/webrtc/conftest.py
+++ b/tests/webrtc/conftest.py
@@ -1,0 +1,164 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared fixtures for robot tests.
+
+``webrtc_link``: an in-process relay + robot daemon + cloud controller for testing
+WebRTCProxyRobot (which is a pure cloud controller with no in-process loopback).
+The relay and a synthetic daemon run as their own event loops in this process and
+talk over localhost sockets, exactly as a cloud pod and a robot daemon would.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import threading
+import time
+
+import pytest
+
+
+class _LoopThread:
+    def __init__(self):
+        self.loop = asyncio.new_event_loop()
+        threading.Thread(target=self._run, daemon=True).start()
+
+    def _run(self):
+        asyncio.set_event_loop(self.loop)
+        self.loop.run_forever()
+
+    def submit(self, coro):
+        return asyncio.run_coroutine_threadsafe(coro, self.loop)
+
+    def stop(self):
+        self.loop.call_soon_threadsafe(self.loop.stop)
+
+
+class _Link:
+    def __init__(self, robot, agent_box, teardown):
+        self.robot = robot
+        self._agent_box = agent_box
+        self._teardown = teardown
+
+    @property
+    def agent(self):
+        """The daemon's live CaptureAgent (for watchdog / camera-plan assertions)."""
+        return self._agent_box.get("agent")
+
+    def close(self):
+        self._teardown()
+
+
+@pytest.fixture
+def webrtc_link():
+    """Return a context-manager factory yielding a connected ``_Link``.
+
+    with webrtc_link(inventory=..., camera=...) as link:
+        link.robot.get_observation(); link.agent.is_safed
+    """
+    from lerobot.robots.webrtc_proxy.configuration_webrtc_proxy import (
+        WebRTCCameraSpec,
+        WebRTCProxyRobotConfig,
+    )
+    from lerobot.robots.webrtc_proxy.proxy_robot import WebRTCProxyRobot
+    from lerobot.robots.webrtc_proxy.robot_daemon import run_daemon
+    from lerobot.robots.webrtc_proxy.signaling_server import start_relay
+
+    @contextlib.contextmanager
+    def _factory(
+        *,
+        inventory=None,
+        camera=None,
+        robot=None,
+        reliable_state=False,
+        reliable_action=False,
+        token=None,
+        motors=None,
+        cam_name: str = "front",
+        height: int = 48,
+        width: int = 64,
+        fps: int = 30,
+        cameras: dict | None = None,  # multi-cam: name -> (height, width); overrides cam_name/size
+        action_timeout_s: float = 0.5,
+        connect_timeout_s: float = 20.0,
+    ):
+        relay_lt = _LoopThread()
+        runner, port = relay_lt.submit(start_relay("127.0.0.1", 0, auth_token=token)).result(timeout=5)
+        url = f"ws://127.0.0.1:{port}/ws"
+
+        # Single camera by default; a `cameras` map enables the multi-camera (tiled) path.
+        cam_specs = cameras or {cam_name: (height, width)}
+
+        agent_box: dict = {}
+        daemon_lt = _LoopThread()
+        daemon_fut = daemon_lt.submit(
+            run_daemon(
+                url,
+                session_id="test",
+                motors=motors,
+                cam_name=cam_name,
+                cam_height=height,
+                cam_width=width,
+                cameras=cameras,
+                capture_fps=fps,
+                action_timeout_s=action_timeout_s,
+                ice_servers=[],
+                inventory=inventory,
+                camera=camera,
+                robot=robot,
+                reliable_state=reliable_state,
+                reliable_action=reliable_action,
+                signaling_token=token,
+                on_agent=lambda a: agent_box.__setitem__("agent", a),
+            )
+        )
+        time.sleep(0.4)  # let the daemon connect + buffer its offer
+
+        cfg_kwargs = {
+            "cameras": {n: WebRTCCameraSpec(height=h, width=w, fps=fps) for n, (h, w) in cam_specs.items()},
+            "signaling_url": url,
+            "session_id": "test",
+            "ice_servers": [],
+            "capture_fps": fps,
+            "action_timeout_s": action_timeout_s,
+            "connect_timeout_s": connect_timeout_s,
+            "signaling_token": token,
+        }
+        if motors is not None:
+            cfg_kwargs["motors"] = list(motors)
+        robot = WebRTCProxyRobot(WebRTCProxyRobotConfig(**cfg_kwargs))
+
+        torn = {"done": False}
+
+        def _teardown():
+            if torn["done"]:
+                return
+            torn["done"] = True
+            with contextlib.suppress(Exception):
+                robot.disconnect()
+            daemon_fut.cancel()
+            time.sleep(0.3)
+            with contextlib.suppress(Exception):
+                relay_lt.submit(runner.cleanup()).result(timeout=3)
+            daemon_lt.stop()
+            relay_lt.stop()
+
+        robot.connect()
+        try:
+            yield _Link(robot, agent_box, _teardown)
+        finally:
+            _teardown()
+
+    yield _factory

--- a/tests/webrtc/test_webrtc_proxy_alignment.py
+++ b/tests/webrtc/test_webrtc_proxy_alignment.py
@@ -1,0 +1,77 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for the capture-seq alignment buffer (no aiortc needed)."""
+
+import numpy as np
+
+from lerobot.robots.webrtc_proxy.alignment import AlignmentBuffer
+
+
+def _frame(val: int) -> np.ndarray:
+    return np.full((4, 4, 3), val, dtype=np.uint8)
+
+
+def test_empty_buffer_assembles_to_none():
+    buf = AlignmentBuffer()
+    assert buf.assemble() is None
+    assert not buf.has_state()
+
+
+def test_state_without_frame_is_incomplete():
+    buf = AlignmentBuffer()
+    buf.add_state(seq=0, t=1.0, joints={"shoulder_pan.pos": 10.0})
+    assert buf.has_state()
+    assert buf.assemble() is None  # no frame with that seq yet
+
+
+def test_pairs_state_and_frame_by_seq():
+    buf = AlignmentBuffer()
+    buf.add_frame(seq=7, frame=_frame(2))
+    buf.add_state(seq=7, t=1.12, joints={"a.pos": 0.0})
+    aligned = buf.assemble()
+    assert aligned is not None
+    assert aligned.seq == 7
+    assert aligned.t == 1.12
+    assert int(aligned.frame[0, 0, 0]) == 2
+
+
+def test_assemble_uses_freshest_complete_seq():
+    buf = AlignmentBuffer()
+    buf.add_state(seq=0, t=1.0, joints={"a.pos": 1.0})
+    buf.add_frame(seq=0, frame=_frame(1))
+    buf.add_state(seq=1, t=2.0, joints={"a.pos": 2.0})
+    buf.add_frame(seq=1, frame=_frame(2))
+    aligned = buf.assemble()
+    assert aligned.seq == 1
+    assert aligned.joints == {"a.pos": 2.0}
+
+
+def test_incomplete_newest_seq_falls_back_to_prior_complete():
+    buf = AlignmentBuffer()
+    buf.add_state(seq=0, t=1.0, joints={"a.pos": 1.0})
+    buf.add_frame(seq=0, frame=_frame(1))
+    # seq 1 frame arrives but its state dropped (state channel is unreliable) -> incomplete.
+    buf.add_frame(seq=1, frame=_frame(2))
+    assert buf.assemble().seq == 0  # newest COMPLETE pair, not the frame-only seq 1
+
+
+def test_history_is_bounded():
+    buf = AlignmentBuffer(maxlen=2)
+    for i in range(5):
+        buf.add_frame(seq=i, frame=_frame(i))
+        buf.add_state(seq=i, t=float(i), joints={"a.pos": float(i)})
+    aligned = buf.assemble()
+    assert aligned.seq == 4
+    assert int(aligned.frame[0, 0, 0]) == 4

--- a/tests/webrtc/test_webrtc_proxy_auth.py
+++ b/tests/webrtc/test_webrtc_proxy_auth.py
@@ -1,0 +1,83 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared-token auth on the signaling relay."""
+
+import asyncio
+import threading
+
+import pytest
+
+pytest.importorskip("aiohttp", reason="signaling needs aiohttp (lerobot[webrtc])")
+
+from lerobot.robots.webrtc_proxy.signaling import WebSocketSignaling  # noqa: E402
+from lerobot.robots.webrtc_proxy.signaling_server import start_relay  # noqa: E402
+
+
+class _Loop:
+    def __init__(self):
+        self.loop = asyncio.new_event_loop()
+        threading.Thread(
+            target=lambda: (asyncio.set_event_loop(self.loop), self.loop.run_forever()), daemon=True
+        ).start()
+
+    def run(self, coro, timeout=5):
+        return asyncio.run_coroutine_threadsafe(coro, self.loop).result(timeout)
+
+    def stop(self):
+        self.loop.call_soon_threadsafe(self.loop.stop)
+
+
+async def _open_close(url, token):
+    sig = WebSocketSignaling(url, "s", "robot", token=token)
+    await sig.open()
+    await sig.close()
+
+
+def test_relay_token_gate():
+    lt = _Loop()
+    runner, port = lt.run(start_relay("127.0.0.1", 0, auth_token="right-token"))
+    url = f"ws://127.0.0.1:{port}/ws"
+    try:
+        # Correct token connects.
+        lt.run(_open_close(url, "right-token"))
+        # Wrong token is rejected (401 -> handshake error). The signaling client surfaces this
+        # as one of several transport errors, so we assert only that the connect fails.
+        with pytest.raises(Exception):  # noqa: B017
+            lt.run(_open_close(url, "wrong-token"))
+        # Missing token is rejected.
+        with pytest.raises(Exception):  # noqa: B017
+            lt.run(_open_close(url, None))
+    finally:
+        lt.run(runner.cleanup())
+        lt.stop()
+
+
+def test_no_token_relay_accepts_anyone():
+    """Without auth_token configured, the relay is open (back-compat / same-host)."""
+    lt = _Loop()
+    runner, port = lt.run(start_relay("127.0.0.1", 0))  # no auth_token
+    url = f"ws://127.0.0.1:{port}/ws"
+    try:
+        lt.run(_open_close(url, None))  # connects fine
+    finally:
+        lt.run(runner.cleanup())
+        lt.stop()
+
+
+def test_full_link_with_token(webrtc_link):
+    pytest.importorskip("aiortc", reason="full controller<->daemon link needs aiortc")
+    with webrtc_link(token="s3cret") as link:
+        assert link.robot.is_connected
+        assert link.robot.get_observation()["front"].shape == (48, 64, 3)

--- a/tests/webrtc/test_webrtc_proxy_camera.py
+++ b/tests/webrtc/test_webrtc_proxy_camera.py
@@ -1,0 +1,89 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Camera streaming, preview grab, obs-shape enforcement, and camera plan."""
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+pytest.importorskip("aiortc", reason="WebRTCProxyRobot needs the lerobot[webrtc] extra (aiortc)")
+
+from lerobot.robots.webrtc_proxy.capture_agent import CaptureAgent, _fit_frame  # noqa: E402
+from lerobot.robots.webrtc_proxy.configuration_webrtc_proxy import (  # noqa: E402
+    WebRTCCameraSpec,
+    WebRTCProxyRobotConfig,
+)
+from lerobot.robots.webrtc_proxy.control import SyntheticInventory  # noqa: E402
+from lerobot.robots.webrtc_proxy.proxy_robot import WebRTCProxyRobot  # noqa: E402
+
+
+class _FakeCamera:
+    """Duck-types a lerobot Camera: read_latest() returns a fixed RGB frame."""
+
+    def __init__(self, height: int, width: int, color: tuple[int, int, int]) -> None:
+        self._frame = np.zeros((height, width, 3), dtype=np.uint8)
+        self._frame[:] = color
+
+    def read_latest(self, max_age_ms: int = 500) -> np.ndarray:
+        return self._frame.copy()
+
+
+# ---- pure units -----------------------------------------------------------
+def test_fit_frame_resizes_and_normalizes():
+    src = np.zeros((30, 40, 4), dtype=np.uint8)  # wrong size + RGBA
+    out = _fit_frame(src, 48, 64)
+    assert out.shape == (48, 64, 3)
+    assert out.dtype == np.uint8
+    assert out.flags["C_CONTIGUOUS"]
+
+
+def test_apply_camera_plan_updates_size():
+    ns = SimpleNamespace(cam_w=64, cam_h=48)
+    CaptureAgent._apply_camera_plan(ns, {"width": 32, "height": 24})
+    assert (ns.cam_w, ns.cam_h) == (32, 24)
+
+
+def test_get_observation_enforces_declared_shape():
+    """A wrong-sized frame is re-fit to the declared obs shape (no transport needed)."""
+    robot = WebRTCProxyRobot(
+        WebRTCProxyRobotConfig(cameras={"front": WebRTCCameraSpec(height=48, width=64, fps=30)})
+    )
+    robot._connected = True  # bypass the link; exercise get_observation directly
+    robot._buffer.add_frame(seq=0, frame=np.full((100, 200, 3), 77, np.uint8))
+    robot._buffer.add_state(seq=0, t=1.0, joints={f"{m}.pos": 0.0 for m in robot.motors})
+    obs = robot.get_observation()
+    assert obs["front"].shape == (48, 64, 3)
+    robot._connected = False
+
+
+# ---- end-to-end over the real link ----------------------------------------
+def test_grab_camera_preview_over_link(webrtc_link):
+    with webrtc_link(inventory=SyntheticInventory()) as link:
+        img = link.robot.grab_camera_preview(1, width=64, height=48)
+        assert img.shape == (48, 64, 3)
+        assert img.dtype == np.uint8
+        other = link.robot.grab_camera_preview(0, width=64, height=48)
+        assert not np.array_equal(img, other)  # SyntheticInventory colours each id distinctly
+
+
+def test_real_camera_frames_reach_the_cloud(webrtc_link):
+    color = (200, 100, 50)
+    with webrtc_link(camera=_FakeCamera(48, 64, color)) as link:
+        frame = link.robot.get_observation()["front"]
+        assert frame.shape == (48, 64, 3)
+        # VP8 round-trip is lossy; the mean colour must still track the camera frame.
+        mean = frame.reshape(-1, 3).mean(axis=0)
+        assert np.allclose(mean, color, atol=40), f"got mean {mean}, expected ~{color}"

--- a/tests/webrtc/test_webrtc_proxy_channels.py
+++ b/tests/webrtc/test_webrtc_proxy_channels.py
@@ -1,0 +1,50 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Configurable channel reliability (control always reliable; state/action per use case)."""
+
+import pytest
+
+from lerobot.robots.webrtc_proxy.protocol import RELIABLE_KWARGS, UNRELIABLE_KWARGS, channel_kwargs
+
+pytest.importorskip("aiortc", reason="WebRTCProxyRobot needs the lerobot[webrtc] extra (aiortc)")
+pytest.importorskip("aiohttp", reason="signaling needs aiohttp (lerobot[webrtc])")
+
+
+def test_channel_kwargs_helper():
+    assert channel_kwargs(True) == RELIABLE_KWARGS == {"ordered": True}
+    assert channel_kwargs(False) == UNRELIABLE_KWARGS == {"ordered": False, "maxRetransmits": 0}
+
+
+def _ch(agent, label):
+    # the underlying aiortc RTCDataChannel behind the transport's Channel handle
+    return agent._transport._channels[label]._ch
+
+
+def test_default_realtime_unreliable_state_action(webrtc_link):
+    # teleop/eval default: fresh, drop-on-loss.
+    with webrtc_link() as link:
+        a = link.agent
+        assert _ch(a, "state").ordered is False and _ch(a, "state").maxRetransmits == 0
+        assert _ch(a, "action").ordered is False and _ch(a, "action").maxRetransmits == 0
+        assert _ch(a, "control").ordered is True  # control always reliable+ordered
+
+
+def test_record_profile_reliable_state_and_action(webrtc_link):
+    # record: both state and action reliable so no obs/action is lost from a transition.
+    with webrtc_link(reliable_state=True, reliable_action=True) as link:
+        a = link.agent
+        assert _ch(a, "state").ordered is True
+        assert _ch(a, "action").ordered is True
+        assert _ch(a, "control").ordered is True

--- a/tests/webrtc/test_webrtc_proxy_control.py
+++ b/tests/webrtc/test_webrtc_proxy_control.py
@@ -1,0 +1,85 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Control-plane (device discovery) tests."""
+
+import pytest
+
+from lerobot.robots.webrtc_proxy.control import ControlServer, FindPortError, SyntheticInventory
+from lerobot.robots.webrtc_proxy.protocol import RpcRequest
+
+aiortc = pytest.importorskip("aiortc", reason="WebRTCProxyRobot needs the lerobot[webrtc] extra (aiortc)")
+
+
+# ---- pure server logic (no transport) -------------------------------------
+def test_find_port_diff_logic():
+    inv = SyntheticInventory(ports=["/dev/a", "/dev/b", "/dev/c"])
+    srv = ControlServer(inv)
+    srv._dispatch(RpcRequest(1, "find_port_begin", {}))
+    inv.simulate_unplug("/dev/b")
+    assert srv._dispatch(RpcRequest(2, "find_port_result", {})) == {"port": "/dev/b"}
+
+
+def test_find_port_ambiguous_raises():
+    srv = ControlServer(SyntheticInventory(ports=["/dev/a", "/dev/b"]))
+    srv._dispatch(RpcRequest(1, "find_port_begin", {}))
+    with pytest.raises(FindPortError):
+        srv._dispatch(RpcRequest(2, "find_port_result", {}))
+
+
+def test_set_camera_plan_invokes_callback():
+    seen = {}
+    srv = ControlServer(SyntheticInventory(), on_camera_plan=seen.update)
+    srv._dispatch(RpcRequest(1, "set_camera_plan", {"width": 320, "height": 240, "fps": 30}))
+    assert seen == {"width": 320, "height": 240, "fps": 30}
+
+
+def test_local_inventory_lists_real_ports():
+    pytest.importorskip("serial", reason="find_available_ports needs pyserial (lerobot[hardware])")
+    from lerobot.robots.webrtc_proxy.control import LocalDeviceInventory
+
+    ports = LocalDeviceInventory().list_ports()
+    assert isinstance(ports, list)
+    assert all(isinstance(p, str) for p in ports)
+
+
+# ---- end-to-end over the real control channel -----------------------------
+def test_discovery_rpc_over_link(webrtc_link):
+    inv = SyntheticInventory(
+        ports=["/dev/tty.usbmodem-A", "/dev/tty.usbmodem-B"],
+        cameras=[{"type": "opencv", "id": 0, "name": "front cam"}],
+    )
+    with webrtc_link(inventory=inv) as link:
+        robot = link.robot
+        assert set(robot.list_ports()) == {"/dev/tty.usbmodem-A", "/dev/tty.usbmodem-B"}
+        assert robot.list_cameras() == [{"type": "opencv", "id": 0, "name": "front cam"}]
+
+        before = robot.find_port_begin()
+        assert "/dev/tty.usbmodem-B" in before
+        inv.simulate_unplug("/dev/tty.usbmodem-B")  # the test holds the daemon's inventory
+        assert robot.find_port_result() == "/dev/tty.usbmodem-B"
+
+
+def test_real_inventory_over_link(webrtc_link):
+    pytest.importorskip("serial", reason="find_available_ports needs pyserial (lerobot[hardware])")
+    from lerobot.robots.webrtc_proxy.control import LocalDeviceInventory
+
+    with webrtc_link(inventory=LocalDeviceInventory()) as link:
+        ports = link.robot.list_ports()
+        assert isinstance(ports, list) and all(isinstance(p, str) for p in ports)
+
+
+def test_control_rpc_error_propagates(webrtc_link):
+    with webrtc_link(inventory=SyntheticInventory()) as link, pytest.raises(RuntimeError):
+        link.robot.find_port_result()  # before begin -> server raises -> RuntimeError on cloud

--- a/tests/webrtc/test_webrtc_proxy_daemon.py
+++ b/tests/webrtc/test_webrtc_proxy_daemon.py
@@ -1,0 +1,135 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Two-endpoint daemon link over a real localhost WebSocket signaling relay.
+
+Exercises the production-shaped path (separate event loops, real ws signaling,
+WebRTC over localhost host candidates) rather than the in-process loopback. Each
+of relay / daemon / cloud-controller runs on its own loop and talks only over
+sockets — same as a real robot daemon and a cloud pod.
+"""
+
+import asyncio
+import threading
+import time
+
+import pytest
+
+pytest.importorskip("aiortc", reason="WebRTCProxyRobot needs the lerobot[webrtc] extra (aiortc)")
+pytest.importorskip("aiohttp", reason="signaling needs aiohttp (lerobot[webrtc])")
+
+from lerobot.robots.webrtc_proxy.configuration_webrtc_proxy import (  # noqa: E402
+    WebRTCCameraSpec,
+    WebRTCProxyRobotConfig,
+)
+from lerobot.robots.webrtc_proxy.control import SyntheticInventory  # noqa: E402
+from lerobot.robots.webrtc_proxy.proxy_robot import WebRTCProxyRobot  # noqa: E402
+from lerobot.robots.webrtc_proxy.robot_daemon import run_daemon  # noqa: E402
+from lerobot.robots.webrtc_proxy.signaling_server import start_relay  # noqa: E402
+
+
+class _LoopThread:
+    """An asyncio loop running in a daemon thread, for hosting relay/daemon."""
+
+    def __init__(self):
+        self.loop = asyncio.new_event_loop()
+        threading.Thread(target=self._run, daemon=True).start()
+
+    def _run(self):
+        asyncio.set_event_loop(self.loop)
+        self.loop.run_forever()
+
+    def submit(self, coro):
+        return asyncio.run_coroutine_threadsafe(coro, self.loop)
+
+    def stop(self):
+        self.loop.call_soon_threadsafe(self.loop.stop)
+
+
+@pytest.fixture
+def relay():
+    lt = _LoopThread()
+    _, port = lt.submit(start_relay("127.0.0.1", 0)).result(timeout=5)
+    yield lt, f"ws://127.0.0.1:{port}/ws"
+    lt.stop()
+
+
+@pytest.fixture
+def daemon(relay):
+    lt, url = relay
+    daemon_lt = _LoopThread()
+    inv = SyntheticInventory(ports=["/dev/tty.bus-A", "/dev/tty.bus-B"])
+    fut = daemon_lt.submit(
+        run_daemon(
+            url,
+            session_id="s1",
+            cam_name="front",
+            cam_height=48,
+            cam_width=64,
+            capture_fps=30,
+            action_timeout_s=0.5,
+            ice_servers=[],
+            inventory=inv,
+        )
+    )
+    time.sleep(0.4)  # let the daemon connect + buffer its offer on the relay
+    yield url
+    fut.cancel()
+    time.sleep(0.3)  # let the daemon's finally close its agent + ws session before the loop stops
+    daemon_lt.stop()
+
+
+def _cloud(url: str) -> WebRTCProxyRobot:
+    cfg = WebRTCProxyRobotConfig(
+        cameras={"front": WebRTCCameraSpec(height=48, width=64, fps=30)},
+        signaling_url=url,
+        session_id="s1",
+        ice_servers=[],
+        capture_fps=30,
+        action_timeout_s=0.5,
+        connect_timeout_s=20.0,
+    )
+    return WebRTCProxyRobot(cfg)
+
+
+def test_cloud_controller_reaches_daemon_over_ws(daemon):
+    robot = _cloud(daemon)
+    robot.connect()
+    try:
+        assert robot.is_connected
+        obs = robot.get_observation()
+        assert set(obs) == set(robot.observation_features)
+        assert obs["front"].shape == (48, 64, 3)
+        # control plane reaches the daemon's (synthetic) OS inventory
+        assert set(robot.list_ports()) == {"/dev/tty.bus-A", "/dev/tty.bus-B"}
+        assert robot.send_action({"shoulder_pan.pos": 3.0}) == {"shoulder_pan.pos": 3.0}
+    finally:
+        robot.disconnect()
+
+
+def test_daemon_outlives_session_and_serves_again(daemon):
+    # First session.
+    r1 = _cloud(daemon)
+    r1.connect()
+    assert r1.get_observation()["front"].shape == (48, 64, 3)
+    r1.disconnect()
+
+    # Daemon must have reset and be ready for a brand-new session on the same id.
+    r2 = _cloud(daemon)
+    r2.connect()
+    try:
+        assert r2.is_connected
+        assert r2.get_observation()["front"].shape == (48, 64, 3)
+    finally:
+        r2.disconnect()

--- a/tests/webrtc/test_webrtc_proxy_ice.py
+++ b/tests/webrtc/test_webrtc_proxy_ice.py
@@ -1,0 +1,109 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""ICE config distribution for the aiortc (direct-UDP) backend.
+
+aiortc connects directly: host candidates on a LAN, plus a server-reflexive (public)
+candidate via STUN for cross-NAT P2P. The signaling relay hands each peer its STUN
+servers on connect, and the transport merges them into the peer connection. (A media
+relay across hard NATs is the LiveKit backend's job, not a TURN server under aiortc.)
+"""
+
+import asyncio
+import threading
+
+import pytest
+
+from lerobot.robots.webrtc_proxy.signaling_server import IceConfig
+
+
+def test_ice_config_empty_when_no_stun():
+    ice = IceConfig()
+    assert ice.enabled is False
+    assert ice.for_peer("sess:robot") == []
+
+
+def test_ice_config_distributes_stun():
+    ice = IceConfig(stun_urls=["stun:stun.l.google.com:19302", "stun:stun.qq.com:3478"])
+    assert ice.enabled is True
+    assert ice.for_peer("sess:controller") == [
+        {"urls": ["stun:stun.l.google.com:19302", "stun:stun.qq.com:3478"]}
+    ]
+
+
+def test_to_ice_server_handles_str_and_dict():
+    pytest.importorskip("aiortc", reason="needs the lerobot[webrtc] extra (aiortc)")
+    from lerobot.robots.webrtc_proxy.transport import AiortcTransport
+
+    plain = AiortcTransport._to_ice_server("stun:stun.example.com:3478")
+    assert plain.username is None
+    listed = AiortcTransport._to_ice_server({"urls": ["stun:stun.example.com:3478"]})
+    assert listed.urls == ["stun:stun.example.com:3478"]
+
+
+pytest.importorskip("aiohttp", reason="signaling needs aiohttp (lerobot[webrtc])")
+
+from lerobot.robots.webrtc_proxy.signaling import WebSocketSignaling  # noqa: E402
+from lerobot.robots.webrtc_proxy.signaling_server import start_relay  # noqa: E402
+
+
+class _Loop:
+    def __init__(self):
+        self.loop = asyncio.new_event_loop()
+        threading.Thread(
+            target=lambda: (asyncio.set_event_loop(self.loop), self.loop.run_forever()), daemon=True
+        ).start()
+
+    def run(self, coro, timeout=5):
+        return asyncio.run_coroutine_threadsafe(coro, self.loop).result(timeout)
+
+    def stop(self):
+        self.loop.call_soon_threadsafe(self.loop.stop)
+
+
+def _open_and_read_ice(url: str) -> list:
+    lt = _Loop()
+
+    async def _go():
+        sig = WebSocketSignaling(url, "sess", role="controller")
+        await sig.open()  # consumes the ICE message the relay pushes on join
+        servers = sig.ice_servers
+        await sig.close()
+        return servers
+
+    try:
+        return lt.run(_go())
+    finally:
+        lt.stop()
+
+
+def test_relay_hands_stun_to_a_client():
+    lt = _Loop()
+    ice = IceConfig(stun_urls=["stun:stun.l.google.com:19302"])
+    try:
+        _, port = lt.run(start_relay("127.0.0.1", 0, ice=ice))
+        servers = _open_and_read_ice(f"ws://127.0.0.1:{port}/ws")
+    finally:
+        lt.stop()
+    assert servers == [{"urls": ["stun:stun.l.google.com:19302"]}]
+
+
+def test_relay_hands_empty_list_when_no_stun():
+    lt = _Loop()
+    try:
+        _, port = lt.run(start_relay("127.0.0.1", 0))  # no IceConfig
+        servers = _open_and_read_ice(f"ws://127.0.0.1:{port}/ws")
+    finally:
+        lt.stop()
+    assert servers == []

--- a/tests/webrtc/test_webrtc_proxy_livekit.py
+++ b/tests/webrtc/test_webrtc_proxy_livekit.py
@@ -1,0 +1,147 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""End-to-end test of the (experimental, optional) LiveKit transport backend.
+
+Skipped by default: it needs the ``livekit`` SDK AND a reachable LiveKit server. To
+run it, start a local dev server and point the test at it::
+
+    brew install livekit            # or: see https://docs.livekit.io/home/self-hosting
+    livekit-server --dev            # API key/secret default to devkey/secret
+    LEROBOT_LIVEKIT_URL=ws://127.0.0.1:7880 \
+        LEROBOT_LIVEKIT_API_KEY=devkey LEROBOT_LIVEKIT_API_SECRET=secret \
+        pytest tests/webrtc/test_webrtc_proxy_livekit.py -p no:hydra_pytest -sv
+
+LiveKit's FFI client binds one room per process, so the robot daemon (publisher) runs as
+a separate subprocess and this test process is the cloud controller (subscriber) —
+exactly the real two-process deployment.
+"""
+
+import os
+import subprocess
+import sys
+import time
+
+import pytest
+
+pytest.importorskip("livekit", reason="livekit transport needs the lerobot[webrtc-livekit] extra")
+# Token signing lives in the separate livekit-api package (livekit.api); guard it too so
+# this test SKIPS (not errors) when only `livekit` (rtc) is installed without `livekit-api`.
+pytest.importorskip("livekit.api", reason="self-signing needs livekit-api (lerobot[webrtc-livekit])")
+
+_URL = os.environ.get("LEROBOT_LIVEKIT_URL")
+if not _URL:
+    pytest.skip(
+        "set LEROBOT_LIVEKIT_URL (+ LEROBOT_LIVEKIT_API_KEY/SECRET) to run the LiveKit e2e test",
+        allow_module_level=True,
+    )
+
+_API_KEY = os.environ.get("LEROBOT_LIVEKIT_API_KEY", "devkey")
+_API_SECRET = os.environ.get("LEROBOT_LIVEKIT_API_SECRET", "secret")
+_ROOM = "lerobot-pytest"
+
+from livekit import api  # noqa: E402
+
+from lerobot.robots.webrtc_proxy.configuration_webrtc_proxy import (  # noqa: E402
+    WebRTCCameraSpec,
+    WebRTCProxyRobotConfig,
+)
+from lerobot.robots.webrtc_proxy.proxy_robot import WebRTCProxyRobot  # noqa: E402
+
+
+def _token(identity: str) -> str:
+    return (
+        api.AccessToken(_API_KEY, _API_SECRET)
+        .with_identity(identity)
+        .with_grants(api.VideoGrants(room_join=True, room=_ROOM))
+        .to_jwt()
+    )
+
+
+@pytest.fixture
+def daemon():
+    """Run the robot daemon (publisher) as its own process, streaming a synthetic source."""
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "lerobot.robots.webrtc_proxy.robot_daemon",
+            "--session",
+            _ROOM,
+            "--transport",
+            "livekit",
+            "--livekit-url",
+            _URL,
+            "--livekit-token",
+            _token("robot"),
+            "--camera-name",
+            "front",
+            "--width",
+            "64",
+            "--height",
+            "48",
+            "--fps",
+            "30",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    time.sleep(3)  # let the daemon join the room + start publishing
+    assert proc.poll() is None, "daemon exited early"
+    yield
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+
+
+def _controller() -> WebRTCProxyRobot:
+    cfg = WebRTCProxyRobotConfig(
+        cameras={"front": WebRTCCameraSpec(height=48, width=64, fps=30)},
+        transport_backend="livekit",
+        livekit_url=_URL,
+        livekit_token=_token("controller"),
+        connect_timeout_s=25.0,
+    )
+    return WebRTCProxyRobot(cfg)
+
+
+def test_controller_reaches_daemon_over_livekit(daemon):
+    robot = _controller()
+    robot.connect()
+    try:
+        assert robot.is_connected
+        obs = robot.get_observation()
+        assert set(obs) == set(robot.observation_features)
+        assert obs["front"].shape == (48, 64, 3)
+
+        # The action round-trip lands: the synthetic arm holds the last commanded pose,
+        # so the joints we read back converge on what we sent.
+        target = 12.0
+        for _ in range(20):
+            robot.send_action({f"{m}.pos": target for m in robot.motors})
+            obs = robot.get_observation()
+            time.sleep(0.05)
+        assert abs(obs["shoulder_pan.pos"] - target) < 1e-3
+
+        # Observations are advancing (fresh seqs), not a single stuck frame.
+        seqs = set()
+        for _ in range(10):
+            robot.get_observation()
+            seqs.add(robot._last_obs_seq)
+            time.sleep(0.05)
+        assert len(seqs) > 1
+    finally:
+        robot.disconnect()

--- a/tests/webrtc/test_webrtc_proxy_multicam.py
+++ b/tests/webrtc/test_webrtc_proxy_multicam.py
@@ -1,0 +1,83 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Multi-camera over a single video track via tiling (stack on the robot, slice on cloud)."""
+
+import numpy as np
+import pytest
+
+from lerobot.robots.webrtc_proxy import tiling
+
+
+def _frame(h, w, val):
+    return np.full((h, w, 3), val, dtype=np.uint8)
+
+
+def test_tile_untile_roundtrip_different_sizes():
+    specs = tiling.ordered_specs({"wrist": (24, 32), "front": (48, 64), "top": (16, 64)})
+    # sorted by name: front, top, wrist
+    assert [s[0] for s in specs] == ["front", "top", "wrist"]
+    frames = {"front": _frame(48, 64, 10), "top": _frame(16, 64, 20), "wrist": _frame(24, 32, 30)}
+
+    combined = tiling.tile(frames, specs)
+    assert combined.shape == (48 + 16 + 24, 64, 3)  # stacked heights x max width
+
+    out = tiling.untile(combined, specs)
+    assert set(out) == {"front", "top", "wrist"}
+    for name in frames:
+        assert np.array_equal(out[name], frames[name])  # exact, lossless slice-back
+
+
+def test_single_camera_tiles_to_identity():
+    specs = tiling.ordered_specs({"front": (48, 64)})
+    f = _frame(48, 64, 7)
+    combined = tiling.tile({"front": f}, specs)
+    assert combined.shape == (48, 64, 3)
+    assert np.array_equal(tiling.untile(combined, specs)["front"], f)
+
+
+def test_narrower_camera_is_width_padded_then_recovered():
+    specs = tiling.ordered_specs({"a": (10, 64), "b": (10, 32)})  # b is narrower
+    frames = {"a": _frame(10, 64, 1), "b": _frame(10, 32, 2)}
+    combined = tiling.tile(frames, specs)
+    assert combined.shape == (20, 64, 3)
+    out = tiling.untile(combined, specs)
+    assert np.array_equal(out["b"], frames["b"])  # the narrower one slices back to 32 wide
+
+
+# --- end-to-end over the real loopback link (relay + daemon + cloud) -----------
+pytest.importorskip("aiortc", reason="WebRTCProxyRobot needs the lerobot[webrtc] extra (aiortc)")
+pytest.importorskip("aiohttp", reason="signaling needs aiohttp (lerobot[webrtc])")
+
+
+def test_three_cameras_stream_and_split(webrtc_link):
+    cameras = {"front": (48, 64), "wrist": (32, 48), "top": (24, 64)}
+    with webrtc_link(cameras=cameras) as link:
+        feats = link.robot.observation_features
+        for name, (h, w) in cameras.items():
+            assert feats[name] == (h, w, 3)
+
+        obs = link.robot.get_observation()
+        # all three cameras present, each at its declared shape
+        for name, (h, w) in cameras.items():
+            assert obs[name].shape == (h, w, 3)
+            assert obs[name].dtype == np.uint8
+
+        # synthetic frames are coloured distinctly per camera (B channel = idx*80 in
+        # name-sorted order: front=0, top=1, wrist=2) — proves the slices aren't crossed.
+        # VP8 is lossy, so check near the expected value (not exact).
+        blues = {name: float(np.median(obs[name][..., 2])) for name in sorted(cameras)}
+        assert abs(blues["front"] - 0) <= 8
+        assert abs(blues["top"] - 80) <= 8
+        assert abs(blues["wrist"] - 160) <= 8

--- a/tests/webrtc/test_webrtc_proxy_obs.py
+++ b/tests/webrtc/test_webrtc_proxy_obs.py
@@ -1,0 +1,77 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""obs / action / watchdog over the real controller<->daemon link (see conftest)."""
+
+import time
+
+import numpy as np
+import pytest
+
+pytest.importorskip("aiortc", reason="WebRTCProxyRobot needs the lerobot[webrtc] extra (aiortc)")
+pytest.importorskip("aiohttp", reason="signaling needs aiohttp (lerobot[webrtc])")
+
+from lerobot.robots.webrtc_proxy.configuration_webrtc_proxy import (  # noqa: E402
+    WebRTCCameraSpec,
+    WebRTCProxyRobotConfig,
+)
+from lerobot.robots.webrtc_proxy.proxy_robot import WebRTCProxyRobot  # noqa: E402
+
+
+def test_schema_available_before_connect():
+    robot = WebRTCProxyRobot(WebRTCProxyRobotConfig(cameras={"front": WebRTCCameraSpec(48, 64, 30)}))
+    assert not robot.is_connected
+    assert robot.action_features == {f"{m}.pos": float for m in robot.motors}
+    obs_ft = robot.observation_features
+    assert obs_ft["front"] == (48, 64, 3)
+    assert obs_ft["shoulder_pan.pos"] is float
+
+
+def test_connect_requires_ws_signaling():
+    robot = WebRTCProxyRobot(WebRTCProxyRobotConfig(cameras={"front": WebRTCCameraSpec(48, 64, 30)}))
+    with pytest.raises(ValueError):
+        robot.connect()  # no signaling_url
+
+
+def test_observation_roundtrip(webrtc_link):
+    with webrtc_link() as link:
+        robot = link.robot
+        assert robot.is_connected
+        obs = robot.get_observation()
+        assert set(obs) == set(robot.observation_features)
+        frame = obs["front"]
+        assert isinstance(frame, np.ndarray)
+        assert frame.shape == (48, 64, 3)
+        assert frame.dtype == np.uint8
+        for m in robot.motors:
+            assert isinstance(obs[f"{m}.pos"], float)
+        sent = robot.send_action({"shoulder_pan.pos": 12.5})
+        assert sent == {"shoulder_pan.pos": 12.5}
+
+
+def test_watchdog_safes_on_action_stall_then_clears(webrtc_link):
+    with webrtc_link(action_timeout_s=0.3) as link:
+        robot, agent = link.robot, link.agent
+        # Resume actions -> watchdog clears (it may already have fired during connect).
+        robot.send_action({"shoulder_pan.pos": 0.0})
+        deadline = time.monotonic() + 1.0
+        while time.monotonic() < deadline and agent.is_safed:
+            time.sleep(0.02)
+        assert not agent.is_safed
+
+        # Stop sending -> watchdog must safe within ~action_timeout_s.
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline and not agent.is_safed:
+            time.sleep(0.02)
+        assert agent.is_safed, "watchdog did not engage after action stall"

--- a/tests/webrtc/test_webrtc_proxy_provenance.py
+++ b/tests/webrtc/test_webrtc_proxy_provenance.py
@@ -1,0 +1,61 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Closed-loop traceability: action -> obs provenance, and applied feedback back."""
+
+import time
+
+import pytest
+
+from lerobot.robots.webrtc_proxy.protocol import ActionMsg, StateMsg
+
+pytest.importorskip("aiortc", reason="WebRTCProxyRobot needs the lerobot[webrtc] extra (aiortc)")
+pytest.importorskip("aiohttp", reason="signaling needs aiohttp (lerobot[webrtc])")
+
+
+# ---- protocol back-compat (new fields are optional) -----------------------
+def test_action_msg_obs_seq_roundtrips_and_defaults():
+    assert ActionMsg.from_json('{"t":1.0,"seq":2,"goal":{}}').obs_seq == -1  # old senders
+    m = ActionMsg(t=1.0, seq=2, goal={"a.pos": 3.0}, obs_seq=7)
+    assert ActionMsg.from_json(m.to_json()).obs_seq == 7
+
+
+def test_state_msg_applied_fields_roundtrip_and_default():
+    assert StateMsg.from_json('{"t":1.0,"seq":2,"joints":{}}').applied_seq == -1
+    m = StateMsg(t=1.0, seq=2, joints={"a.pos": 1.0}, applied_seq=5, applied_t=9.0)
+    back = StateMsg.from_json(m.to_json())
+    assert (back.applied_seq, back.applied_t) == (5, 9.0)
+
+
+# ---- end-to-end over the real link ----------------------------------------
+def test_action_provenance_and_applied_feedback(webrtc_link):
+    with webrtc_link() as link:
+        robot, agent = link.robot, link.agent
+
+        robot.get_observation()  # advances the cloud's _last_obs_seq
+        assert robot._last_obs_seq >= 0
+        robot.send_action({"shoulder_pan.pos": 1.0})
+
+        # robot received the action stamped with the obs it was derived from.
+        deadline = time.monotonic() + 1.5
+        while time.monotonic() < deadline and agent._last_obs_seq_seen < 0:
+            time.sleep(0.02)
+        assert agent._last_obs_seq_seen == robot._last_obs_seq
+
+        # Cloud sees the robot report it applied that action (via the state stream).
+        deadline = time.monotonic() + 1.5
+        while time.monotonic() < deadline and robot._endpoint.last_applied_seq < 1:
+            time.sleep(0.02)
+        assert robot._endpoint.last_applied_seq >= 1
+        assert robot._endpoint.last_applied_t > 0.0

--- a/tests/webrtc/test_webrtc_proxy_robot.py
+++ b/tests/webrtc/test_webrtc_proxy_robot.py
@@ -1,0 +1,81 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""M2: a real lerobot Robot drives joints / action / torque through the daemon."""
+
+import time
+
+import numpy as np
+import pytest
+
+pytest.importorskip("aiortc", reason="WebRTCProxyRobot needs the lerobot[webrtc] extra (aiortc)")
+pytest.importorskip("aiohttp", reason="signaling needs aiohttp (lerobot[webrtc])")
+
+from lerobot.robots.webrtc_proxy.configuration_webrtc_proxy import SO100_MOTORS  # noqa: E402
+
+
+class _FakeBus:
+    def __init__(self):
+        self.torque = True
+
+    def enable_torque(self):
+        self.torque = True
+
+    def disable_torque(self):
+        self.torque = False
+
+
+class _FakeRobot:
+    """Duck-types a lerobot so_follower: get_observation / send_action / bus.*torque."""
+
+    def __init__(self, motors, cam_name, height, width, color):
+        self.motors = list(motors)
+        self.cam_name = cam_name
+        self._frame = np.full((height, width, 3), color, np.uint8)
+        self.bus = _FakeBus()
+        self.last_goal = None
+
+    def get_observation(self):
+        obs = {f"{m}.pos": 1.0 for m in self.motors}
+        obs[self.cam_name] = self._frame.copy()
+        return obs
+
+    def send_action(self, goal):
+        self.last_goal = dict(goal)
+        return goal
+
+
+def test_real_robot_drives_obs_action_and_torque(webrtc_link):
+    dev = _FakeRobot(SO100_MOTORS, "front", 48, 64, (10, 150, 90))
+    with webrtc_link(robot=dev, action_timeout_s=0.3) as link:
+        robot = link.robot
+
+        # obs joints + camera come from the robot's own get_observation.
+        obs = robot.get_observation()
+        assert obs["shoulder_pan.pos"] == 1.0
+        assert np.allclose(obs["front"].reshape(-1, 3).mean(0), (10, 150, 90), atol=40)
+
+        # action reaches the robot (applied on the io thread), torque re-enabled.
+        robot.send_action({"shoulder_pan.pos": 5.0})
+        deadline = time.monotonic() + 1.5
+        while time.monotonic() < deadline and dev.last_goal is None:
+            time.sleep(0.02)
+        assert dev.last_goal == {"shoulder_pan.pos": 5.0}
+        assert dev.bus.torque is True
+
+        # stop sending -> watchdog cuts torque (P0 safe stop).
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline and dev.bus.torque:
+            time.sleep(0.02)
+        assert dev.bus.torque is False

--- a/uv.lock
+++ b/uv.lock
@@ -61,6 +61,15 @@ wheels = [
 ]
 
 [[package]]
+name = "aiofiles"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/c3/534eac40372d8ee36ef40df62ec129bee4fdb5ad9706e58a29be53b2c970/aiofiles-25.1.0.tar.gz", hash = "sha256:a8d728f0a29de45dc521f18f07297428d56992a742f0cd2701ba86e44d23d5b2", size = 46354, upload-time = "2025-10-09T20:51:04.358Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/8a/340a1555ae33d7354dbca4faa54948d76d89a27ceef032c8c3bc661d003e/aiofiles-25.1.0-py3-none-any.whl", hash = "sha256:abe311e527c862958650f9438e859c1fa7568a141b22abcd015e120e86a85695", size = 14668, upload-time = "2025-10-09T20:51:03.174Z" },
+]
+
+[[package]]
 name = "aiohappyeyeballs"
 version = "2.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -167,6 +176,37 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7b/3c/bb4a7cba26956cb3da4553cc2056cf67be5b5ff6e6d8fa4fbdff73bfb7ae/aiohttp-3.14.1-cp314-cp314t-win32.whl", hash = "sha256:47ddf841cdecc810749921d25606dee45857d12d2ad5ddb7b5bd7eab12e4b365", size = 494166, upload-time = "2026-06-07T21:09:28.505Z" },
     { url = "https://files.pythonhosted.org/packages/8a/84/ec80c2c1f66a952555a9f86df6b33af65108a6febfa0471b69013a12f807/aiohttp-3.14.1-cp314-cp314t-win_amd64.whl", hash = "sha256:5e78b522b7a6e27e0b25d19b247b75039ac4c94f99823e3c9e53ae1603a9f7e9", size = 530255, upload-time = "2026-06-07T21:09:30.843Z" },
     { url = "https://files.pythonhosted.org/packages/2a/71/6e22be134a4061ada85a92951b842f2657f17d926b727f3f94c56ae963d6/aiohttp-3.14.1-cp314-cp314t-win_arm64.whl", hash = "sha256:90d53f1609c29ccc2193945ef732428382a28f78d0456ae4d3daf0d48b74f0f6", size = 469640, upload-time = "2026-06-07T21:09:33.028Z" },
+]
+
+[[package]]
+name = "aioice"
+version = "0.10.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "ifaddr" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/67/04/df7286233f468e19e9bedff023b6b246182f0b2ccb04ceeb69b2994021c6/aioice-0.10.2.tar.gz", hash = "sha256:bf236c6829ee33c8e540535d31cd5a066b531cb56de2be94c46be76d68b1a806", size = 44307, upload-time = "2025-11-28T15:56:48.836Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/e3/0d23b1f930c17d371ce1ec36ee529f22fd19ebc2a07fe3418e3d1d884ce2/aioice-0.10.2-py3-none-any.whl", hash = "sha256:14911c15ab12d096dd14d372ebb4aecbb7420b52c9b76fdfcf54375dec17fcbf", size = 24875, upload-time = "2025-11-28T15:56:47.847Z" },
+]
+
+[[package]]
+name = "aiortc"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aioice" },
+    { name = "av" },
+    { name = "cryptography" },
+    { name = "google-crc32c" },
+    { name = "pyee" },
+    { name = "pylibsrtp" },
+    { name = "pyopenssl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/9c/4e027bfe0195de0442da301e2389329496745d40ae44d2d7c4571c4290ce/aiortc-1.14.0.tar.gz", hash = "sha256:adc8a67ace10a085721e588e06a00358ed8eaf5f6b62f0a95358ff45628dd762", size = 1180864, upload-time = "2025-10-13T21:40:37.905Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/ab/31646a49209568cde3b97eeade0d28bb78b400e6645c56422c101df68932/aiortc-1.14.0-py3-none-any.whl", hash = "sha256:4b244d7e482f4e1f67e685b3468269628eca1ec91fa5b329ab517738cfca086e", size = 93183, upload-time = "2025-10-13T21:40:36.59Z" },
 ]
 
 [[package]]
@@ -402,10 +442,10 @@ name = "bddl"
 version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jupytext", marker = "sys_platform == 'linux'" },
-    { name = "networkx", marker = "sys_platform == 'linux'" },
-    { name = "numpy", marker = "sys_platform == 'linux'" },
-    { name = "pytest", marker = "sys_platform == 'linux'" },
+    { name = "jupytext" },
+    { name = "networkx" },
+    { name = "numpy" },
+    { name = "pytest" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5c/37/0211f82891a9f14efcfd2b2096f8d9e4351398ad637fdd1ee59cfc580b0e/bddl-1.0.1.tar.gz", hash = "sha256:1fa4e6e5050b93888ff6fd8455c39bfb29d3864ce06b4c37c0f781f513a2ae26", size = 164809, upload-time = "2022-03-08T01:48:23.564Z" }
 
@@ -990,11 +1030,61 @@ wheels = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "49.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/22/adf66990e63584a68dfb50c24f48a125c07b1699899381c8151e63ed458c/cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:966fe0e9c67490071f14c0d2b1cb2dfb3023c5ce39457343931415f08382f2db", size = 4032100, upload-time = "2026-06-12T20:02:32.143Z" },
+    { url = "https://files.pythonhosted.org/packages/09/41/3797cfaf69cae04a13ee78ebd83f0678d9c02b4779d21ce24445326f1a69/cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db", size = 4692978, upload-time = "2026-06-12T20:01:21.305Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/8b/43011f7ebe515a8aa20d61f290a326cd890c2e738e16e59eaff8d9c3a412/cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325", size = 4716422, upload-time = "2026-06-12T20:01:48.566Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/91/01ce7303a4579e6d3a6abef01bd322848e9ea7a219adcabc5048b9033571/cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2", size = 4700503, upload-time = "2026-06-12T20:02:47.091Z" },
+    { url = "https://files.pythonhosted.org/packages/62/99/a2c95cf8293f07491e9e27c20cc4dcd18176d944e674679adeb1d0173fd6/cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b", size = 5309779, upload-time = "2026-06-12T20:02:08.987Z" },
+    { url = "https://files.pythonhosted.org/packages/20/2c/0622f20ff02b2ef32558733443805dc82fd4c275be01b2d19d14676f3a1b/cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6", size = 4749683, upload-time = "2026-06-12T20:02:03.335Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5b/c5246635d5fd3b64e0d45ae10e99fd32fe9676a79915ccfe5a61ba9af1a5/cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c", size = 4337874, upload-time = "2026-06-12T20:02:54.323Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/88/05563c7fe2e914e87d1a536d06fe83e66b4e1d95cb593e05aea375531da8/cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7", size = 4700283, upload-time = "2026-06-12T20:01:34.822Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/b6/d7696e4e890d6ae1469935164c9e5215c557671cb78d6e3f458ccceaa632/cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68", size = 5265844, upload-time = "2026-06-12T20:01:24.09Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/3c/f3ad17eecc1a57b0ba236dc01f90e783c51f4a2f35f64777cc4f47a184b2/cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9", size = 4749290, upload-time = "2026-06-12T20:01:30.848Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/01/339573cf1023163a400b0b5d16f6d507de413b9f60be6fd1b77feeaf6737/cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f", size = 4834612, upload-time = "2026-06-12T20:01:29.246Z" },
+    { url = "https://files.pythonhosted.org/packages/71/fd/577302e213a1be9468f92d1afef66fcf1ef83d516819d9992ca547f592bd/cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459", size = 4980804, upload-time = "2026-06-12T20:01:42.853Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/09/f42b1d190c5ba75f72062a387f8030d1d75f6ab035788f1d9c4b01de6525/cryptography-49.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:e5dfc1e64de5677cec922ffa8da89c546d0415bf6efdf081842e5d44c84e1f0e", size = 3810026, upload-time = "2026-06-12T20:02:39.262Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/9e/db72b3ae7fc9cfad53e630e56c6ae83b9b6ff0bf3718ffb8012d20b3aabf/cryptography-49.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:73a205dce83953d131a4aa1e0fd917a2fd1c5b1eef251e9d7152efefcbf5caf7", size = 4013892, upload-time = "2026-06-12T20:02:10.735Z" },
+    { url = "https://files.pythonhosted.org/packages/86/12/c48a424f38db03027be9f7ed5c7dc5de9933dbee992865f98b13727a009d/cryptography-49.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:196ecd6a36e4e9aa10270393bb98d8df88fccee0bf1e5128b91ae4eb4375896d", size = 4678835, upload-time = "2026-06-12T20:02:48.743Z" },
+    { url = "https://files.pythonhosted.org/packages/68/28/8a3ad4653662c93fc44dc4e5d8fd374c25c42e07b34bbfbadf49cf57a5a8/cryptography-49.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7abcee80084cda3f7691f3eb1ce480d8df49cec637b429aa35986c1de71738aa", size = 4697239, upload-time = "2026-06-12T20:02:56.03Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b2/2193fc74f81aee4f9b62733133b73b5176718932ed8f2e4b03fa040480a6/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:4ae387c9cb68ea569ca17e490d66d8142b81c3cc814bf179974b7d146e490bbb", size = 4685593, upload-time = "2026-06-12T20:02:50.666Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f1/1d3eaa243bfc5de4a187b22aa8c048b3e4980bfbe830ac46e6bac2e66947/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:f37d847238971164fdbc68ade6f6574aecc9c0af714190e2083429ff68f4ce9d", size = 5289961, upload-time = "2026-06-12T20:01:46.468Z" },
+    { url = "https://files.pythonhosted.org/packages/58/39/2d51306721330c486495853eda1c567880ff036de15a14c4b74f399934af/cryptography-49.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c2bc30226390d60ea19d9f82b19db005fe0452154a23c1c410c12ea801e43561", size = 4731145, upload-time = "2026-06-12T20:02:16.832Z" },
+    { url = "https://files.pythonhosted.org/packages/17/50/983e838c7fd0d87fd8c969bcdd328edaf5f756e38df5281637424c155873/cryptography-49.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:07cab27cc7b7e0fd28e5e26bb9eeedde5c135c868b46de4a27845abe94af6122", size = 4321719, upload-time = "2026-06-12T20:02:52.611Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/f5/8f571d7e27c55bce9f76f026143bcb1e040a4233149ecca0bea5fa5dd5f7/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:b20133d204d2bb56ba047642199603876c872026ca53e79c35b83772ab2cc505", size = 4685209, upload-time = "2026-06-12T20:02:07.282Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/84/0e27016a6fc5a0886f797018b26aa42f40c09a82332bff77822a451deaaa/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:b970c6da94d5bb18629db453d14f2a1300f6bf59b61e9b82377931ef95504866", size = 5246285, upload-time = "2026-06-12T20:01:32.439Z" },
+    { url = "https://files.pythonhosted.org/packages/11/2d/5e1fb307cb5931881516b464c98774b3f2c36b5d4bb9a2830253cf553cad/cryptography-49.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d8ecde755e2e91bf773fc94e8c9d730cd7f2007004cb492263a794ec3899a1c8", size = 4730441, upload-time = "2026-06-12T20:02:01.469Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/c0/bff5a02ee731d207d6a1ed51732549d8c53d2bc8da1d10ec6f2844201d68/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e3fb64c420688e5319ae25113a354015abbd8dffbfbc41781a1ea66fc7622ac3", size = 4815869, upload-time = "2026-06-12T20:01:36.574Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/26/814681d14248d95d73d5c3eea0c39a94eb8302df966f670a2c60de90974b/cryptography-49.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32703d93296f5c1f4b53349ad3a250c2cae0fdecd3a3dd5d47e616d8d616af27", size = 4960948, upload-time = "2026-06-12T20:02:18.688Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/93ecac273d3738939d023612ad12cca9a3740a5345d69fda04134c43fd96/cryptography-49.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:33cd0565932807baddb67b96dbee92f2c374b5c89dee09fd74079aeb8c8dba61", size = 3799153, upload-time = "2026-06-12T20:01:39.059Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2a/5bb823f5bedcf80718cea7fbc95ec5515cca3769633c4b01a32be7f30e7c/cryptography-49.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ec5e529fb80935c94fe7b729f9972b50e351a0e6b50aa294fd5cabb109fcc29a", size = 4025947, upload-time = "2026-06-12T20:01:25.745Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/df/40577043ca124e17012f408ddddaeb213b856336ac82ddb3bc915f39e29f/cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4", size = 4692429, upload-time = "2026-06-12T20:01:53.628Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/99/2d13299eb3dd27b02dcfaafcc91d6b5cb3329f7cbd6d8f51921acd566c1a/cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18", size = 4700968, upload-time = "2026-06-12T20:02:45.383Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/4d/9c0cd02f95e2602dd5e563da149ee0830abef3537be8b34dc56281ebe27a/cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69", size = 4697758, upload-time = "2026-06-12T20:01:41.13Z" },
+    { url = "https://files.pythonhosted.org/packages/24/01/186c825898477d77e2324d5360fefe622ff1d8d1963ec0554e2cada8ec77/cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64", size = 5298863, upload-time = "2026-06-12T20:02:24.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/7b/62cbbab75d0659865bf0273790031544a0b16c8072d258f9428dcd8190dc/cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21", size = 4735983, upload-time = "2026-06-12T20:01:50.14Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/72/3e798c064bc39e471008075d0f9bc9daf77a80879c092e4a8e170c585ed4/cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9", size = 4334173, upload-time = "2026-06-12T20:01:44.743Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ee/6fca21d1ac73e06f8bef71940abfd4d2f6472b4bca284d770f32bd4086f6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc", size = 4697298, upload-time = "2026-06-12T20:02:20.918Z" },
+    { url = "https://files.pythonhosted.org/packages/67/d0/a5fcd3515f0bae49a7b6d0413cc1bdccdcc1fc0047037a0d480642cdc5d6/cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8", size = 5254338, upload-time = "2026-06-12T20:02:22.737Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/84/84fe36f19caf857d61cb7fc9c63035a47ffabd84ea12d1d393148efa3615/cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36", size = 4735650, upload-time = "2026-06-12T20:02:41.389Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/a0/db537264e234f7273a73ec020873d6d6b39dfd8a53db78b550ca8320440e/cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e", size = 4834820, upload-time = "2026-06-12T20:01:51.847Z" },
+    { url = "https://files.pythonhosted.org/packages/93/77/8df9eb486495979bccecd1062e2eaf435250e84437040295b57d09048b0b/cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b", size = 4967968, upload-time = "2026-06-12T20:02:12.524Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/e6/f60198ea8d9dfa15fff9ed4ca02ce362f6eadd9ba757dcc50634c4257b63/cryptography-49.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:026ac7423e6fa66872d3bf889be5974507da3944f866f704fa200eadacd00001", size = 3785547, upload-time = "2026-06-12T20:02:26.847Z" },
+]
+
+[[package]]
 name = "cuda-bindings"
 version = "12.9.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "sys_platform == 'linux'" },
+    { name = "cuda-pathfinder" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/45/557d4ed1fa54f0c7db8aee083229f624990d69f7d00f55477eed5c7e169a/cuda_bindings-12.9.7-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0666d3c082ef8f4b2d670950589373550e9f3bf564d635dd883f24a0b40402ff", size = 7071026, upload-time = "2026-05-27T18:44:13.356Z" },
@@ -1027,37 +1117,37 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cublas-cu12" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime-cu12" },
 ]
 cufft = [
-    { name = "nvidia-cufft-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufft-cu12" },
 ]
 cufile = [
-    { name = "nvidia-cufile-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufile-cu12" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cupti-cu12" },
 ]
 curand = [
-    { name = "nvidia-curand-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-curand-cu12" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusolver-cu12" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparse-cu12" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc-cu12" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvtx-cu12" },
 ]
 
 [[package]]
@@ -1129,7 +1219,7 @@ name = "decord"
 version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", marker = "(platform_machine != 'arm64' and sys_platform == 'darwin') or (platform_machine == 'AMD64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
+    { name = "numpy" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/11/79/936af42edf90a7bd4e41a6cac89c913d4b47fa48a26b042d5129a9242ee3/decord-0.6.0-py3-none-manylinux2010_x86_64.whl", hash = "sha256:51997f20be8958e23b7c4061ba45d0efcd86bffd5fe81c695d0befee0d442976", size = 13602299, upload-time = "2021-06-14T21:30:55.486Z" },
@@ -1266,10 +1356,10 @@ resolution-markers = [
     "python_full_version == '3.14.*' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "absl-py", marker = "python_full_version >= '3.14'" },
-    { name = "attrs", marker = "python_full_version >= '3.14'" },
-    { name = "numpy", marker = "python_full_version >= '3.14'" },
-    { name = "wrapt", marker = "python_full_version >= '3.14'" },
+    { name = "absl-py" },
+    { name = "attrs" },
+    { name = "numpy" },
+    { name = "wrapt" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a6/83/ce29720ccf934c6cfa9b9c95ebbe96558386e66886626066632b5e44afed/dm_tree-0.1.9.tar.gz", hash = "sha256:a4c7db3d3935a5a2d5e4b383fc26c6b0cd6f78c6d4605d3e7b518800ecd5342b", size = 35623, upload-time = "2025-01-30T20:45:37.13Z" }
 wheels = [
@@ -1307,10 +1397,10 @@ resolution-markers = [
     "python_full_version < '3.13' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "absl-py", marker = "python_full_version < '3.14'" },
-    { name = "attrs", marker = "python_full_version < '3.14'" },
-    { name = "numpy", marker = "python_full_version < '3.14'" },
-    { name = "wrapt", marker = "python_full_version < '3.14'" },
+    { name = "absl-py" },
+    { name = "attrs" },
+    { name = "numpy" },
+    { name = "wrapt" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5a/66/a3ec619d22b6baffa5ab853e8dc6ec9d0c837127948af59bb15b988d7312/dm_tree-0.1.10.tar.gz", hash = "sha256:22f37b599e01cc3402a17f79c257a802aebd8d326de05b54657650845956208a", size = 35748, upload-time = "2026-03-31T17:35:39.03Z" }
 wheels = [
@@ -1332,6 +1422,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/2c/2aaa63a510db520cd9e0c51e053a608486169bb9710f51f4ecf5699cebb4/dm_tree-0.1.10-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:23682221f63ad011dbd762ce5314740d7900b0426a2681614ea2472369b0c49c", size = 324205, upload-time = "2026-03-31T17:35:34.679Z" },
     { url = "https://files.pythonhosted.org/packages/b0/89/a5a302bcf9c345e6bd0498627ee2aa12f0a1c3538d08a2f5884d3c6783ba/dm_tree-0.1.10-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8baeb3db1e92587d686022fb67a52f6c584a7d32bd98444ed3aafb399ad9ce67", size = 185113, upload-time = "2026-03-31T17:35:36.179Z" },
     { url = "https://files.pythonhosted.org/packages/cc/e8/2d4fbc54bb68905588945cfb47c05445c66cab2d822b05827f1c62e23a70/dm_tree-0.1.10-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2236c9a4cf64ed0b04004a94902f39341be652b70dce322b33f08ada9b146baa", size = 187009, upload-time = "2026-03-31T17:35:37.584Z" },
+]
+
+[[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
 ]
 
 [[package]]
@@ -1773,6 +1872,29 @@ wheels = [
 ]
 
 [[package]]
+name = "google-crc32c"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/41/4b9c02f99e4c5fb477122cd5437403b552873f014616ac1d19ac8221a58d/google_crc32c-1.8.0.tar.gz", hash = "sha256:a428e25fb7691024de47fecfbff7ff957214da51eddded0da0ae0e0f03a2cf79", size = 14192, upload-time = "2025-12-16T00:35:25.142Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/5f/7307325b1198b59324c0fa9807cafb551afb65e831699f2ce211ad5c8240/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:4b8286b659c1335172e39563ab0a768b8015e88e08329fa5321f774275fc3113", size = 31300, upload-time = "2025-12-16T00:21:56.723Z" },
+    { url = "https://files.pythonhosted.org/packages/21/8e/58c0d5d86e2220e6a37befe7e6a94dd2f6006044b1a33edf1ff6d9f7e319/google_crc32c-1.8.0-cp312-cp312-macosx_12_0_x86_64.whl", hash = "sha256:2a3dc3318507de089c5384cc74d54318401410f82aa65b2d9cdde9d297aca7cb", size = 30867, upload-time = "2025-12-16T00:38:31.302Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/a9/a780cc66f86335a6019f557a8aaca8fbb970728f0efd2430d15ff1beae0e/google_crc32c-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:14f87e04d613dfa218d6135e81b78272c3b904e2a7053b841481b38a7d901411", size = 33364, upload-time = "2025-12-16T00:40:22.96Z" },
+    { url = "https://files.pythonhosted.org/packages/21/3f/3457ea803db0198c9aaca2dd373750972ce28a26f00544b6b85088811939/google_crc32c-1.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb5c869c2923d56cb0c8e6bcdd73c009c36ae39b652dbe46a05eb4ef0ad01454", size = 33740, upload-time = "2025-12-16T00:40:23.96Z" },
+    { url = "https://files.pythonhosted.org/packages/df/c0/87c2073e0c72515bb8733d4eef7b21548e8d189f094b5dad20b0ecaf64f6/google_crc32c-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:3cc0c8912038065eafa603b238abf252e204accab2a704c63b9e14837a854962", size = 34437, upload-time = "2025-12-16T00:35:21.395Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/db/000f15b41724589b0e7bc24bc7a8967898d8d3bc8caf64c513d91ef1f6c0/google_crc32c-1.8.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:3ebb04528e83b2634857f43f9bb8ef5b2bbe7f10f140daeb01b58f972d04736b", size = 31297, upload-time = "2025-12-16T00:23:20.709Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/0d/8ebed0c39c53a7e838e2a486da8abb0e52de135f1b376ae2f0b160eb4c1a/google_crc32c-1.8.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:450dc98429d3e33ed2926fc99ee81001928d63460f8538f21a5d6060912a8e27", size = 30867, upload-time = "2025-12-16T00:43:14.628Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/42/b468aec74a0354b34c8cbf748db20d6e350a68a2b0912e128cabee49806c/google_crc32c-1.8.0-cp313-cp313-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:3b9776774b24ba76831609ffbabce8cdf6fa2bd5e9df37b594221c7e333a81fa", size = 33344, upload-time = "2025-12-16T00:40:24.742Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/e8/b33784d6fc77fb5062a8a7854e43e1e618b87d5ddf610a88025e4de6226e/google_crc32c-1.8.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:89c17d53d75562edfff86679244830599ee0a48efc216200691de8b02ab6b2b8", size = 33694, upload-time = "2025-12-16T00:40:25.505Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b1/d3cbd4d988afb3d8e4db94ca953df429ed6db7282ed0e700d25e6c7bfc8d/google_crc32c-1.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:57a50a9035b75643996fbf224d6661e386c7162d1dfdab9bc4ca790947d1007f", size = 34435, upload-time = "2025-12-16T00:35:22.107Z" },
+    { url = "https://files.pythonhosted.org/packages/21/88/8ecf3c2b864a490b9e7010c84fd203ec8cf3b280651106a3a74dd1b0ca72/google_crc32c-1.8.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:e6584b12cb06796d285d09e33f63309a09368b9d806a551d8036a4207ea43697", size = 31301, upload-time = "2025-12-16T00:24:48.527Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c6/f7ff6c11f5ca215d9f43d3629163727a272eabc356e5c9b2853df2bfe965/google_crc32c-1.8.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:f4b51844ef67d6cf2e9425983274da75f18b1597bb2c998e1c0a0e8d46f8f651", size = 30868, upload-time = "2025-12-16T00:48:12.163Z" },
+    { url = "https://files.pythonhosted.org/packages/56/15/c25671c7aad70f8179d858c55a6ae8404902abe0cdcf32a29d581792b491/google_crc32c-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b0d1a7afc6e8e4635564ba8aa5c0548e3173e41b6384d7711a9123165f582de2", size = 33381, upload-time = "2025-12-16T00:40:26.268Z" },
+    { url = "https://files.pythonhosted.org/packages/42/fa/f50f51260d7b0ef5d4898af122d8a7ec5a84e2984f676f746445f783705f/google_crc32c-1.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8b3f68782f3cbd1bce027e48768293072813469af6a61a86f6bb4977a4380f21", size = 33734, upload-time = "2025-12-16T00:40:27.028Z" },
+    { url = "https://files.pythonhosted.org/packages/08/a5/7b059810934a09fb3ccb657e0843813c1fee1183d3bc2c8041800374aa2c/google_crc32c-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:d511b3153e7011a27ab6ee6bb3a5404a55b994dc1a7322c0b87b29606d9790e2", size = 34878, upload-time = "2025-12-16T00:35:23.142Z" },
+]
+
+[[package]]
 name = "grpcio"
 version = "1.73.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1911,7 +2033,7 @@ name = "h5py"
 version = "3.16.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", marker = "sys_platform == 'linux'" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/db/33/acd0ce6863b6c0d7735007df01815403f5589a21ff8c2e1ee2587a38f548/h5py-3.16.0.tar.gz", hash = "sha256:a0dbaad796840ccaa67a4c144a0d0c8080073c34c76d5a6941d6818678ef2738", size = 446526, upload-time = "2026-03-06T13:49:08.07Z" }
 wheels = [
@@ -1955,23 +2077,23 @@ name = "hf-libero"
 version = "0.1.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "bddl", marker = "sys_platform == 'linux'" },
-    { name = "cloudpickle", marker = "sys_platform == 'linux'" },
-    { name = "easydict", marker = "sys_platform == 'linux'" },
-    { name = "einops", marker = "sys_platform == 'linux'" },
-    { name = "future", marker = "sys_platform == 'linux'" },
-    { name = "gymnasium", marker = "sys_platform == 'linux'" },
-    { name = "hf-egl-probe", marker = "sys_platform == 'linux'" },
-    { name = "hydra-core", marker = "sys_platform == 'linux'" },
-    { name = "matplotlib", marker = "sys_platform == 'linux'" },
-    { name = "mujoco", marker = "sys_platform == 'linux'" },
-    { name = "numpy", marker = "sys_platform == 'linux'" },
-    { name = "opencv-python", marker = "sys_platform == 'linux'" },
-    { name = "robomimic", marker = "sys_platform == 'linux'" },
-    { name = "robosuite", marker = "sys_platform == 'linux'" },
-    { name = "thop", marker = "sys_platform == 'linux'" },
-    { name = "transformers", marker = "sys_platform == 'linux'" },
-    { name = "wandb", marker = "sys_platform == 'linux'" },
+    { name = "bddl" },
+    { name = "cloudpickle" },
+    { name = "easydict" },
+    { name = "einops" },
+    { name = "future" },
+    { name = "gymnasium" },
+    { name = "hf-egl-probe" },
+    { name = "hydra-core" },
+    { name = "matplotlib" },
+    { name = "mujoco" },
+    { name = "numpy" },
+    { name = "opencv-python" },
+    { name = "robomimic" },
+    { name = "robosuite" },
+    { name = "thop" },
+    { name = "transformers" },
+    { name = "wandb" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/af/aa/4e9eb8715e0bff9cb6553db563a35d253393097d446f82bd53575e8b253d/hf_libero-0.1.4.tar.gz", hash = "sha256:c058d67ad5a2b589529c14d614282ef4cca3a7763dafa134f58a6c9039657e34", size = 2961319, upload-time = "2026-06-10T09:56:13.994Z" }
 wheels = [
@@ -2130,9 +2252,9 @@ name = "hydra-core"
 version = "1.3.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "antlr4-python3-runtime", marker = "sys_platform == 'linux'" },
-    { name = "omegaconf", marker = "sys_platform == 'linux'" },
-    { name = "packaging", marker = "sys_platform == 'linux'" },
+    { name = "antlr4-python3-runtime" },
+    { name = "omegaconf" },
+    { name = "packaging" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/10/dd/220f0e91743136725352497e98540772a01fc7c3ab96ff16c3c74424e984/hydra_core-1.3.4.tar.gz", hash = "sha256:ad0f7b05a0242255a8984d5a4ed2f6847f7b783ed727368a2c0155ec52d6c34c", size = 3263348, upload-time = "2026-07-04T16:25:38.891Z" }
 wheels = [
@@ -2155,6 +2277,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+]
+
+[[package]]
+name = "ifaddr"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/ac/fb4c578f4a3256561548cd825646680edcadb9440f3f68add95ade1eb791/ifaddr-0.2.0.tar.gz", hash = "sha256:cc0cbfcaabf765d44595825fb96a99bb12c79716b73b44330ea38ee2b0c4aed4", size = 10485, upload-time = "2022-06-15T21:40:27.561Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/1f/19ebc343cc71a7ffa78f17018535adc5cbdd87afb31d7c34874680148b32/ifaddr-0.2.0-py3-none-any.whl", hash = "sha256:085e0305cfe6f16ab12d72e2024030f5d52674afad6911bb1eee207177b8a748", size = 12314, upload-time = "2022-06-15T21:40:25.756Z" },
 ]
 
 [[package]]
@@ -2685,11 +2816,11 @@ name = "jupytext"
 version = "1.19.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "markdown-it-py", marker = "sys_platform == 'linux'" },
-    { name = "mdit-py-plugins", marker = "sys_platform == 'linux'" },
-    { name = "nbformat", marker = "sys_platform == 'linux'" },
-    { name = "packaging", marker = "sys_platform == 'linux'" },
-    { name = "pyyaml", marker = "sys_platform == 'linux'" },
+    { name = "markdown-it-py" },
+    { name = "mdit-py-plugins" },
+    { name = "nbformat" },
+    { name = "packaging" },
+    { name = "pyyaml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3b/52/e014296ac8f40ca783aeb73dae52e65edbb0eaae0dcdc1ea41bfaa8aebf7/jupytext-1.19.4.tar.gz", hash = "sha256:739bcd4bc12aa4fe298a38017cdb5ae27b08a6ba3a5470728d2fe9e04b155db1", size = 4581977, upload-time = "2026-06-21T21:48:58.32Z" }
 wheels = [
@@ -2852,6 +2983,8 @@ accelerate-dep = [
 ]
 all = [
     { name = "accelerate" },
+    { name = "aiohttp" },
+    { name = "aiortc" },
     { name = "av" },
     { name = "cmeel-tinyxml2" },
     { name = "cmeel-urdfdom" },
@@ -2879,6 +3012,8 @@ all = [
     { name = "ipykernel" },
     { name = "jsonlines" },
     { name = "jupyter" },
+    { name = "livekit" },
+    { name = "livekit-api" },
     { name = "matplotlib" },
     { name = "metaworld" },
     { name = "mock-serial", marker = "sys_platform != 'win32'" },
@@ -3278,6 +3413,18 @@ wallx = [
     { name = "torchdiffeq" },
     { name = "transformers" },
 ]
+webrtc = [
+    { name = "aiohttp" },
+    { name = "aiortc" },
+    { name = "av" },
+]
+webrtc-livekit = [
+    { name = "aiohttp" },
+    { name = "aiortc" },
+    { name = "av" },
+    { name = "livekit" },
+    { name = "livekit-api" },
+]
 xvla = [
     { name = "transformers" },
 ]
@@ -3285,6 +3432,8 @@ xvla = [
 [package.metadata]
 requires-dist = [
     { name = "accelerate", marker = "extra == 'accelerate-dep'", specifier = ">=1.14.0,<2.0.0" },
+    { name = "aiohttp", marker = "extra == 'webrtc'", specifier = ">=3.9.0,<4.0.0" },
+    { name = "aiortc", marker = "extra == 'webrtc'", specifier = ">=1.9.0,<2.0.0" },
     { name = "av", marker = "extra == 'av-dep'", specifier = ">=15.0.0,<16.0.0" },
     { name = "cmake", specifier = ">=3.29.0.1,<4.2.0" },
     { name = "cmeel-tinyxml2", marker = "extra == 'placo-dep'", specifier = "<11" },
@@ -3324,6 +3473,7 @@ requires-dist = [
     { name = "lerobot", extras = ["async"], marker = "extra == 'all'" },
     { name = "lerobot", extras = ["av-dep"], marker = "extra == 'dataset'" },
     { name = "lerobot", extras = ["av-dep"], marker = "extra == 'evaluation'" },
+    { name = "lerobot", extras = ["av-dep"], marker = "extra == 'webrtc'" },
     { name = "lerobot", extras = ["can-dep"], marker = "extra == 'damiao'" },
     { name = "lerobot", extras = ["can-dep"], marker = "extra == 'robstride'" },
     { name = "lerobot", extras = ["damiao"], marker = "extra == 'all'" },
@@ -3448,7 +3598,11 @@ requires-dist = [
     { name = "lerobot", extras = ["viz"], marker = "extra == 'dataset-viz'" },
     { name = "lerobot", extras = ["vla-jepa"], marker = "extra == 'all'" },
     { name = "lerobot", extras = ["wallx"], marker = "extra == 'all'" },
+    { name = "lerobot", extras = ["webrtc"], marker = "extra == 'webrtc-livekit'" },
+    { name = "lerobot", extras = ["webrtc-livekit"], marker = "extra == 'all'" },
     { name = "lerobot", extras = ["xvla"], marker = "extra == 'all'" },
+    { name = "livekit", marker = "extra == 'webrtc-livekit'", specifier = ">=0.18.0,<2.0.0" },
+    { name = "livekit-api", marker = "extra == 'webrtc-livekit'", specifier = ">=0.8.0,<2.0.0" },
     { name = "matplotlib", marker = "extra == 'matplotlib-dep'", specifier = ">=3.10.3,<4.0.0" },
     { name = "meshcat", marker = "extra == 'unitree-g1'", specifier = ">=0.3.0,<0.4.0" },
     { name = "metaworld", marker = "extra == 'metaworld'", specifier = "==3.0.0" },
@@ -3509,7 +3663,7 @@ requires-dist = [
     { name = "transformers", marker = "extra == 'transformers-dep'", specifier = ">=5.4.0,<5.6.0" },
     { name = "wandb", marker = "extra == 'training'", specifier = ">=0.24.0,<0.28.0" },
 ]
-provides-extras = ["dataset", "training", "hardware", "viz", "core-scripts", "evaluation", "dataset-viz", "av-dep", "pygame-dep", "placo-dep", "transformers-dep", "grpcio-dep", "accelerate-dep", "can-dep", "peft-dep", "scipy-dep", "diffusers-dep", "qwen-vl-utils-dep", "matplotlib-dep", "pyserial-dep", "deepdiff-dep", "pynput-dep", "pyzmq-dep", "motorbridge-dep", "motorbridge-smart-servo-dep", "timm-dep", "feetech", "dynamixel", "damiao", "robstride", "openarms", "gamepad", "hopejr", "lekiwi", "unitree-g1", "reachy2", "rebot", "kinematics", "intelrealsense", "phone", "diffusion", "wallx", "pi", "molmoact2", "smolvla", "multi-task-dit", "groot", "sarm", "robometer", "topreward", "xvla", "eo1", "fastwam", "evo1", "hilserl", "vla-jepa", "lingbot-va", "async", "peft", "annotations", "dev", "notebook", "test", "video-benchmark", "aloha", "pusht", "libero", "metaworld", "all"]
+provides-extras = ["dataset", "training", "hardware", "viz", "webrtc", "webrtc-livekit", "core-scripts", "evaluation", "dataset-viz", "av-dep", "pygame-dep", "placo-dep", "transformers-dep", "grpcio-dep", "accelerate-dep", "can-dep", "peft-dep", "scipy-dep", "diffusers-dep", "qwen-vl-utils-dep", "matplotlib-dep", "pyserial-dep", "deepdiff-dep", "pynput-dep", "pyzmq-dep", "motorbridge-dep", "motorbridge-smart-servo-dep", "timm-dep", "feetech", "dynamixel", "damiao", "robstride", "openarms", "gamepad", "hopejr", "lekiwi", "unitree-g1", "reachy2", "rebot", "kinematics", "intelrealsense", "phone", "diffusion", "wallx", "pi", "molmoact2", "smolvla", "multi-task-dit", "groot", "sarm", "robometer", "topreward", "xvla", "eo1", "fastwam", "evo1", "hilserl", "vla-jepa", "lingbot-va", "async", "peft", "annotations", "dev", "notebook", "test", "video-benchmark", "aloha", "pusht", "libero", "metaworld", "all"]
 
 [[package]]
 name = "librt"
@@ -3571,6 +3725,54 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/78/f0bb41a6f2bbd3c77bdcc66980dc0d69ca1192a0ecec25377afcc5e6db73/librt-0.12.0-cp314-cp314t-win32.whl", hash = "sha256:8d73191883553ee0739741544bf3b00aba2a1224e45d9580b30cbc29e21dc03b", size = 97752, upload-time = "2026-06-30T16:14:06.555Z" },
     { url = "https://files.pythonhosted.org/packages/92/24/e279c27972ab051a070237cfa45728fa51670c3f22f1a4d391711e9f4c31/librt-0.12.0-cp314-cp314t-win_amd64.whl", hash = "sha256:e1cbb037324e759f0afa270229731ff0047772667f3cb38ef5df2cabf0175ede", size = 119562, upload-time = "2026-06-30T16:14:07.908Z" },
     { url = "https://files.pythonhosted.org/packages/06/e6/42a475bfca683b0cd5366f6dd06580062b7e567bb8534d225c877c2f14f3/librt-0.12.0-cp314-cp314t-win_arm64.whl", hash = "sha256:bca1472acbd473eff61059b4409f802c5a1bcb4cd0344d06f939df9c4c125d40", size = 104282, upload-time = "2026-06-30T16:14:09.29Z" },
+]
+
+[[package]]
+name = "livekit"
+version = "1.1.13"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiofiles" },
+    { name = "numpy" },
+    { name = "protobuf" },
+    { name = "types-protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8d/92/dcd4f295913533ddd0d48153cc28f1358d550bea651460bd895256981c4d/livekit-1.1.13.tar.gz", hash = "sha256:aa2bd89cf0c2ebcaa71a240275964c23900a0422a2a3d43d274e88a211a0ecfc", size = 370211, upload-time = "2026-06-30T11:54:00.321Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/bd/15100217109595aedbb9bcfdfc1c77513c0f44940d72644d16b611476941/livekit-1.1.13-py3-none-macosx_10_15_x86_64.whl", hash = "sha256:2a19b023de9a573fe5da629e3ee514f2962c87e1afec95a6b19bbbdb6ea8f703", size = 10147642, upload-time = "2026-06-30T11:53:48.781Z" },
+    { url = "https://files.pythonhosted.org/packages/97/dd/4f001a9c5ccde361a53437a09bc04dc9cad8003c6711c2bcc0734e18e626/livekit-1.1.13-py3-none-macosx_11_0_arm64.whl", hash = "sha256:90b6796e0c4515bc1e8a1e109a40b88d82c36b12452b7ae01fe35be7ee8357ba", size = 8968740, upload-time = "2026-06-30T11:53:51.223Z" },
+    { url = "https://files.pythonhosted.org/packages/26/1a/7e97a45a4b6e10ce3a4e9938e3d3fa0a6512a6557f5990685eab4f6e88d1/livekit-1.1.13-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:43779c0f3bb27589cd517d60c442c674c2f967a97db158829a533974a29a3997", size = 9980507, upload-time = "2026-06-30T11:53:53.349Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/9d/389bbdf39ccd2c464a4749ba7be1584dea608518c32a5ddbc511db6b0cf7/livekit-1.1.13-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:f4e83f0e272f4b2e9cc39dbefd7bb23b75bd8c105478d867c2869254ca4e149a", size = 11367692, upload-time = "2026-06-30T11:53:55.409Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ce/a3d3e0566dbd2586c325240d44afec6d44421eb794bcf8dbaca15463a7b7/livekit-1.1.13-py3-none-win_amd64.whl", hash = "sha256:22dff7a39cb3d590a4757e20d3ce5d326ab882350386f5070f45cbd6d9ccf839", size = 10717013, upload-time = "2026-06-30T11:53:57.701Z" },
+]
+
+[[package]]
+name = "livekit-api"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "livekit-protocol" },
+    { name = "protobuf" },
+    { name = "pyjwt" },
+    { name = "types-protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/03/00e0ec173f247e1f7ea63cb5591d5680a64c7a74ea4d5d558e5aed6cc399/livekit_api-1.1.1.tar.gz", hash = "sha256:70c7b80eecbc297b40756ebd76e4f52d00b0348fb7d212a21c1f69cc57fd9c83", size = 15196, upload-time = "2026-06-24T01:36:19.686Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/c0/d5f3ff74ab5db2d06f173801ec934885d11a754b9fb9ad768c8ede0a6c89/livekit_api-1.1.1-py3-none-any.whl", hash = "sha256:ce8c327676c366e66cf68782934368dd0ba92b9d48f578275227e255c890fe88", size = 19471, upload-time = "2026-06-24T01:36:18.42Z" },
+]
+
+[[package]]
+name = "livekit-protocol"
+version = "1.1.18"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+    { name = "types-protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e7/88/64f2be01a630e249f1dbd0d51876f109b53b7899ae41246d2ca5b647086d/livekit_protocol-1.1.18.tar.gz", hash = "sha256:187af32ebf75333a62117b0db9e551c99060bd4e1f57cfc0fce73bcd7a671da8", size = 115802, upload-time = "2026-06-27T15:31:04.102Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/80/9cc33e4d0280132538850aaf9559d6b8aa9e670c5917f75dab996400ab84/livekit_protocol-1.1.18-py3-none-any.whl", hash = "sha256:30c539410fd3cfc2e551ca3a193aaaaacaaec6dd57dabe2c9be7c7c7d15f0e01", size = 143134, upload-time = "2026-06-27T15:31:02.686Z" },
 ]
 
 [[package]]
@@ -3824,7 +4026,7 @@ name = "mdit-py-plugins"
 version = "0.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "markdown-it-py", marker = "sys_platform == 'linux'" },
+    { name = "markdown-it-py" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/59/fc/f8d0863f8862f25602c0404d75568e89fb6b4109804645e5cdfb1be5cf56/mdit_py_plugins-0.6.1.tar.gz", hash = "sha256:a2bca0f039f39dbd35fb74ae1b5f998608c437463371f0ff7f49a19a17a114d0", size = 56114, upload-time = "2026-05-13T09:03:38.91Z" }
 wheels = [
@@ -4302,8 +4504,8 @@ name = "numba"
 version = "0.66.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "llvmlite", marker = "sys_platform == 'linux'" },
-    { name = "numpy", marker = "sys_platform == 'linux'" },
+    { name = "llvmlite" },
+    { name = "numpy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ae/a0/570e3dc53e5602b49108f62a13e529f1eec8bfc7ef37d49c825924dcf546/numba-0.66.0.tar.gz", hash = "sha256:b900e63a0e26c05ea9a6d5a3a5a0a177cb64c5011887bf43edb8c3ed2c38d363", size = 2806181, upload-time = "2026-07-01T23:12:46.36Z" }
 wheels = [
@@ -4396,7 +4598,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.19.0.56"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cublas-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/09/b8/277c51962ee46fa3e5b203ac5f76107c650f781d6891e681e28e6f3e9fe6/nvidia_cudnn_cu12-9.19.0.56-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:08caaf27fe556aca82a3ee3b5aa49a77e7de0cfcb7ff4e5c29da426387a8267e", size = 656910700, upload-time = "2026-02-03T20:40:25.508Z" },
@@ -4408,7 +4610,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/60/bc/7771846d3a0272026c416fbb7e5f4c1f146d6d80704534d0b187dd6f4800/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:848ef7224d6305cdb2a4df928759dca7b1201874787083b6e7550dd6765ce69a", size = 193109211, upload-time = "2025-03-07T01:44:56.873Z" },
@@ -4438,9 +4640,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cusparse-cu12", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cusparse-cu12" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/32/f7cd6ce8a7690544d084ea21c26e910a97e077c9b7f07bf5de623ee19981/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:db9ed69dbef9715071232caa9b69c52ac7de3a95773c2db65bdba85916e4e5c0", size = 267229841, upload-time = "2025-03-07T01:46:54.356Z" },
@@ -4452,7 +4654,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bc/f7/cd777c4109681367721b00a106f491e0d0d15cfa1fd59672ce580ce42a97/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9b6c161cb130be1a07a27ea6923df8141f3c295852f4b260c65f18f3e0a091dc", size = 288117129, upload-time = "2025-03-07T01:47:40.407Z" },
@@ -4509,8 +4711,8 @@ name = "omegaconf"
 version = "2.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "antlr4-python3-runtime", marker = "sys_platform == 'linux'" },
-    { name = "pyyaml", marker = "sys_platform == 'linux'" },
+    { name = "antlr4-python3-runtime" },
+    { name = "pyyaml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ce/3d/e4b57b8d9008c6ebe0d5eff901f91d5700cf7bdb8c8863df817463a7fd5e/omegaconf-2.3.1.tar.gz", hash = "sha256:e5e7de64aeebeddaf8e6d3f7a783b32ac2a01c0fbd9c878012caecb891a1f42a", size = 3298472, upload-time = "2026-06-11T05:05:12.885Z" }
 wheels = [
@@ -4749,7 +4951,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "ptyprocess" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -5225,6 +5427,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pyee"
+version = "13.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/04/e7c1fe4dc78a6fdbfd6c337b1c3732ff543b8a397683ab38378447baa331/pyee-13.0.1.tar.gz", hash = "sha256:0b931f7c14535667ed4c7e0d531716368715e860b988770fc7eb8578d1f67fc8", size = 31655, upload-time = "2026-02-14T21:12:28.044Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c4/b4d4827c93ef43c01f599ef31453ccc1c132b353284fc6c87d535c233129/pyee-13.0.1-py3-none-any.whl", hash = "sha256:af2f8fede4171ef667dfded53f96e2ed0d6e6bd7ee3bb46437f77e3b57689228", size = 15659, upload-time = "2026-02-14T21:12:26.263Z" },
+]
+
+[[package]]
 name = "pygame"
 version = "2.6.1"
 source = { registry = "https://pypi.org/simple" }
@@ -5253,6 +5467,37 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[[package]]
+name = "pylibsrtp"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0d/a6/6e532bec974aaecbf9fe4e12538489fb1c28456e65088a50f305aeab9f89/pylibsrtp-1.0.0.tar.gz", hash = "sha256:b39dff075b263a8ded5377f2490c60d2af452c9f06c4d061c7a2b640612b34d4", size = 10858, upload-time = "2025-10-13T16:12:31.552Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/aa/af/89e61a62fa3567f1b7883feb4d19e19564066c2fcd41c37e08d317b51881/pylibsrtp-1.0.0-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:822c30ea9e759b333dc1f56ceac778707c51546e97eb874de98d7d378c000122", size = 1865017, upload-time = "2025-10-13T16:12:15.62Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/0e/8d215484a9877adcf2459a8b28165fc89668b034565277fd55d666edd247/pylibsrtp-1.0.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:aaad74e5c8cbc1c32056c3767fea494c1e62b3aea2c908eda2a1051389fdad76", size = 2182739, upload-time = "2025-10-13T16:12:17.121Z" },
+    { url = "https://files.pythonhosted.org/packages/57/3f/76a841978877ae13eac0d4af412c13bbd5d83b3df2c1f5f2175f2e0f68e5/pylibsrtp-1.0.0-cp310-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9209b86e662ebbd17c8a9e8549ba57eca92a3e87fb5ba8c0e27b8c43cd08a767", size = 2732922, upload-time = "2025-10-13T16:12:18.348Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/14/cf5d2a98a66fdfe258f6b036cda570f704a644fa861d7883a34bc359501e/pylibsrtp-1.0.0-cp310-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:293c9f2ac21a2bd689c477603a1aa235d85cf252160e6715f0101e42a43cbedc", size = 2434534, upload-time = "2025-10-13T16:12:20.074Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/08/a3f6e86c04562f7dce6717cd2206a0f84ca85c5e38121d998e0e330194c3/pylibsrtp-1.0.0-cp310-abi3-manylinux_2_28_i686.whl", hash = "sha256:81fb8879c2e522021a7cbd3f4bda1b37c192e1af939dfda3ff95b4723b329663", size = 2345818, upload-time = "2025-10-13T16:12:21.439Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/d5/130c2b5b4b51df5631684069c6f0a6761c59d096a33d21503ac207cf0e47/pylibsrtp-1.0.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4ddb562e443cf2e557ea2dfaeef0d7e6b90e96dd38eb079b4ab2c8e34a79f50b", size = 2774490, upload-time = "2025-10-13T16:12:22.659Z" },
+    { url = "https://files.pythonhosted.org/packages/91/e3/715a453bfee3bea92a243888ad359094a7727cc6d393f21281320fe7798c/pylibsrtp-1.0.0-cp310-abi3-musllinux_1_2_i686.whl", hash = "sha256:f02e616c9dfab2b03b32d8cc7b748f9d91814c0211086f987629a60f05f6e2cc", size = 2372603, upload-time = "2025-10-13T16:12:24.036Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/56/52fa74294254e1f53a4ff170ee2006e57886cf4bb3db46a02b4f09e1d99f/pylibsrtp-1.0.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:c134fa09e7b80a5b7fed626230c5bc257fd771bd6978e754343e7a61d96bc7e6", size = 2451269, upload-time = "2025-10-13T16:12:25.475Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/51/2e9b34f484cbdd3bac999bf1f48b696d7389433e900639089e8fc4e0da0d/pylibsrtp-1.0.0-cp310-abi3-win32.whl", hash = "sha256:bae377c3b402b17b9bbfbfe2534c2edba17aa13bea4c64ce440caacbe0858b55", size = 1247503, upload-time = "2025-10-13T16:12:27.39Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/70/43db21af194580aba2d9a6d4c7bd8c1a6e887fa52cd810b88f89096ecad2/pylibsrtp-1.0.0-cp310-abi3-win_amd64.whl", hash = "sha256:8d6527c4a78a39a8d397f8862a8b7cdad4701ee866faf9de4ab8c70be61fd34d", size = 1601659, upload-time = "2025-10-13T16:12:29.037Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/ec/6e02b2561d056ea5b33046e3cad21238e6a9097b97d6ccc0fbe52b50c858/pylibsrtp-1.0.0-cp310-abi3-win_arm64.whl", hash = "sha256:2696bdb2180d53ac55d0eb7b58048a2aa30cd4836dd2ca683669889137a94d2a", size = 1159246, upload-time = "2025-10-13T16:12:30.285Z" },
 ]
 
 [[package]]
@@ -5330,10 +5575,10 @@ name = "pyobjc-framework-applicationservices"
 version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core", marker = "sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "pyobjc-framework-cocoa", marker = "sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "pyobjc-framework-coretext", marker = "sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "pyobjc-framework-quartz", marker = "sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coretext" },
+    { name = "pyobjc-framework-quartz" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5e/4d/0ebdd8144aba94b8fe9828ccee5616a4bf53d1f8bc51cff55f3cce86d695/pyobjc_framework_applicationservices-12.2.1.tar.gz", hash = "sha256:048ea663c9ac75c44a15dc7d5b8d78cbb4c97bf1c76e83835e8d5498e184001f", size = 109342, upload-time = "2026-06-19T16:19:46.149Z" }
 wheels = [
@@ -5351,7 +5596,7 @@ name = "pyobjc-framework-cocoa"
 version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core", marker = "sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "pyobjc-core" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/51/34/fbe38a204643aa4e1b91391cdce07a34da565a69171ebcad08de7438a556/pyobjc_framework_cocoa-12.2.1.tar.gz", hash = "sha256:b94b37fe5730e5ae1fb0052912cd174e6ec329b0bfba4a012ae5db1014b5864b", size = 3125751, upload-time = "2026-06-19T16:20:05.159Z" }
 wheels = [
@@ -5369,9 +5614,9 @@ name = "pyobjc-framework-coretext"
 version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core", marker = "sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "pyobjc-framework-cocoa", marker = "sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "pyobjc-framework-quartz", marker = "sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-quartz" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5a/9c/4c7f452059dc1d3845b8e627b9113c247a997b9b07518e848c2ab7ff3149/pyobjc_framework_coretext-12.2.1.tar.gz", hash = "sha256:af740e784d7c592c34025ec7165f4f6c1a69b5a2d9075f06e41e4f77c212aed2", size = 97349, upload-time = "2026-06-19T16:20:22.508Z" }
 wheels = [
@@ -5389,8 +5634,8 @@ name = "pyobjc-framework-quartz"
 version = "12.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core", marker = "sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "pyobjc-framework-cocoa", marker = "sys_platform != 'emscripten' and sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3b/f6/2a8b84dbf1fe7c04dd96ea73d991678d4e09a909f51971ecc51629bb2ab4/pyobjc_framework_quartz-12.2.1.tar.gz", hash = "sha256:b3b8b6f71e66147f8ff9e6213864cc8527e3a0b1ee90835b93ce221f4802d9b0", size = 3215521, upload-time = "2026-06-19T16:21:30.199Z" }
 wheels = [
@@ -5410,6 +5655,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/16/912b7225d56284859cd9a672827f18be43f8012f8b7b932bc4bd959a298e/pyopengl-3.1.10.tar.gz", hash = "sha256:c4a02d6866b54eb119c8e9b3fb04fa835a95ab802dd96607ab4cdb0012df8335", size = 1915580, upload-time = "2025-08-18T02:33:01.76Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/de/e4/1ba6f44e491c4eece978685230dde56b14d51a0365bc1b774ddaa94d14cd/pyopengl-3.1.10-py3-none-any.whl", hash = "sha256:794a943daced39300879e4e47bd94525280685f42dbb5a998d336cfff151d74f", size = 3194996, upload-time = "2025-08-18T02:32:59.902Z" },
+]
+
+[[package]]
+name = "pyopenssl"
+version = "26.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/b7/da07bae88f5a9506b4def6f2f4903cf4c3b8831e560dba8fa18ca08f758f/pyopenssl-26.3.0.tar.gz", hash = "sha256:589de7fae1c9ea670d18422ed00fc04da787bbde8e1454aea872aa57b49ad341", size = 182024, upload-time = "2026-06-12T20:28:07.458Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/18/1dd71c9b43192ab83f1d531ad6002dc81108ac36c475f79fb7a295abe2f4/pyopenssl-26.3.0-py3-none-any.whl", hash = "sha256:46367f8f66b92271e6d218da9c87607e1ef5a0bc5c8dea5bb3db82f395c385a3", size = 56008, upload-time = "2026-06-12T20:28:05.999Z" },
 ]
 
 [[package]]
@@ -5965,18 +6223,18 @@ name = "robomimic"
 version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "egl-probe", marker = "sys_platform == 'linux'" },
-    { name = "h5py", marker = "sys_platform == 'linux'" },
-    { name = "imageio", marker = "sys_platform == 'linux'" },
-    { name = "imageio-ffmpeg", marker = "sys_platform == 'linux'" },
-    { name = "numpy", marker = "sys_platform == 'linux'" },
-    { name = "psutil", marker = "sys_platform == 'linux'" },
-    { name = "tensorboard", marker = "sys_platform == 'linux'" },
-    { name = "tensorboardx", marker = "sys_platform == 'linux'" },
-    { name = "termcolor", marker = "sys_platform == 'linux'" },
-    { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform == 'linux'" },
-    { name = "torchvision", version = "0.26.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform == 'linux'" },
-    { name = "tqdm", marker = "sys_platform == 'linux'" },
+    { name = "egl-probe" },
+    { name = "h5py" },
+    { name = "imageio" },
+    { name = "imageio-ffmpeg" },
+    { name = "numpy" },
+    { name = "psutil" },
+    { name = "tensorboard" },
+    { name = "tensorboardx" },
+    { name = "termcolor" },
+    { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" } },
+    { name = "torchvision", version = "0.26.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" } },
+    { name = "tqdm" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3d/c3/44b1d1ea4bcb4bbed43d19e09505f4142714451ded74020d4f679cdc89fb/robomimic-0.2.0.tar.gz", hash = "sha256:ee3bb5cf9c3e1feead6b57b43c5db738fd0a8e0c015fdf6419808af8fffdc463", size = 192919, upload-time = "2021-12-17T19:00:33.279Z" }
 
@@ -5985,12 +6243,12 @@ name = "robosuite"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mujoco", marker = "sys_platform == 'linux'" },
-    { name = "numba", marker = "sys_platform == 'linux'" },
-    { name = "numpy", marker = "sys_platform == 'linux'" },
-    { name = "opencv-python", marker = "sys_platform == 'linux'" },
-    { name = "pillow", marker = "sys_platform == 'linux'" },
-    { name = "scipy", marker = "sys_platform == 'linux'" },
+    { name = "mujoco" },
+    { name = "numba" },
+    { name = "numpy" },
+    { name = "opencv-python" },
+    { name = "pillow" },
+    { name = "scipy" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/25/a1/9dd07a9a5e09c6aa032faf531da985808b34437cbf6c8f358fe8f7c47118/robosuite-1.4.0.tar.gz", hash = "sha256:a8a6233d7458dbd91bf00a86cab15aa1c178bd9d1b28d515db2cf3d152cb48e6", size = 192182147, upload-time = "2022-12-01T07:31:55.791Z" }
 wheels = [
@@ -6411,16 +6669,16 @@ name = "tensorboard"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "absl-py", marker = "sys_platform == 'linux'" },
-    { name = "grpcio", marker = "sys_platform == 'linux'" },
-    { name = "markdown", marker = "sys_platform == 'linux'" },
-    { name = "numpy", marker = "sys_platform == 'linux'" },
-    { name = "packaging", marker = "sys_platform == 'linux'" },
-    { name = "pillow", marker = "sys_platform == 'linux'" },
-    { name = "protobuf", marker = "sys_platform == 'linux'" },
-    { name = "setuptools", marker = "sys_platform == 'linux'" },
-    { name = "tensorboard-data-server", marker = "sys_platform == 'linux'" },
-    { name = "werkzeug", marker = "sys_platform == 'linux'" },
+    { name = "absl-py" },
+    { name = "grpcio" },
+    { name = "markdown" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "protobuf" },
+    { name = "setuptools" },
+    { name = "tensorboard-data-server" },
+    { name = "werkzeug" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9c/d9/a5db55f88f258ac669a92858b70a714bbbd5acd993820b41ec4a96a4d77f/tensorboard-2.20.0-py3-none-any.whl", hash = "sha256:9dc9f978cb84c0723acf9a345d96c184f0293d18f166bb8d59ee098e6cfaaba6", size = 5525680, upload-time = "2025-07-17T19:20:49.638Z" },
@@ -6440,9 +6698,9 @@ name = "tensorboardx"
 version = "2.6.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", marker = "sys_platform == 'linux'" },
-    { name = "packaging", marker = "sys_platform == 'linux'" },
-    { name = "protobuf", marker = "sys_platform == 'linux'" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "protobuf" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/48/a9/fc520ea91ab1f3ba51cbf3fe24f2b6364ed3b49046969e0868d46d6da372/tensorboardx-2.6.5.tar.gz", hash = "sha256:ca176db3997ee8c07d2eb77381225956a3fd1c10c91beafab1f17069adc47017", size = 4770195, upload-time = "2026-04-03T15:40:23.803Z" }
 wheels = [
@@ -6477,7 +6735,7 @@ name = "thop"
 version = "0.1.1.post2209072238"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform == 'linux'" },
+    { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" } },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bb/0f/72beeab4ff5221dc47127c80f8834b4bcd0cb36f6ba91c0b1d04a1233403/thop-0.1.1.post2209072238-py3-none-any.whl", hash = "sha256:01473c225231927d2ad718351f78ebf7cffe6af3bed464c4f1ba1ef0f7cdda27", size = 15443, upload-time = "2022-09-07T14:38:37.211Z" },
@@ -6583,13 +6841,13 @@ resolution-markers = [
     "python_full_version < '3.13' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "filelock", marker = "sys_platform != 'linux'" },
-    { name = "fsspec", marker = "sys_platform != 'linux'" },
-    { name = "jinja2", marker = "sys_platform != 'linux'" },
-    { name = "networkx", marker = "sys_platform != 'linux'" },
-    { name = "setuptools", marker = "sys_platform != 'linux'" },
-    { name = "sympy", marker = "sys_platform != 'linux'" },
-    { name = "typing-extensions", marker = "sys_platform != 'linux'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6f/8b/69e3008d78e5cee2b30183340cc425081b78afc5eff3d080daab0adda9aa/torch-2.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4b5866312ee6e52ea625cd211dcb97d6a2cdc1131a5f15cc0d87eec948f6dd34", size = 80606338, upload-time = "2026-03-23T18:11:34.781Z" },
@@ -6623,32 +6881,32 @@ resolution-markers = [
     "python_full_version < '3.13' and platform_machine != 'AMD64' and platform_machine != 'aarch64' and platform_machine != 'arm64' and platform_machine != 'x86_64' and sys_platform == 'linux'",
 ]
 dependencies = [
-    { name = "cuda-bindings", marker = "sys_platform == 'linux'" },
-    { name = "cuda-toolkit", extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
-    { name = "filelock", marker = "sys_platform == 'linux'" },
-    { name = "fsspec", marker = "sys_platform == 'linux'" },
-    { name = "jinja2", marker = "sys_platform == 'linux'" },
-    { name = "networkx", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cudnn-cu12", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cusparselt-cu12", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nccl-cu12", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nvshmem-cu12", marker = "sys_platform == 'linux'" },
-    { name = "setuptools", marker = "sys_platform == 'linux'" },
-    { name = "sympy", marker = "sys_platform == 'linux'" },
-    { name = "triton", marker = "sys_platform == 'linux'" },
-    { name = "typing-extensions", marker = "sys_platform == 'linux'" },
+    { name = "cuda-bindings" },
+    { name = "cuda-toolkit", extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"] },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "nvidia-cudnn-cu12" },
+    { name = "nvidia-cusparselt-cu12" },
+    { name = "nvidia-nccl-cu12" },
+    { name = "nvidia-nvshmem-cu12" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "triton" },
+    { name = "typing-extensions" },
 ]
 wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:9c8f38efee365cb9d334de8a83ce52fc7e5fc9e5a7b0853285efa1b69e00b0f2", upload-time = "2026-04-27T17:41:30Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:d252cf975fb18c94a85336323ad425f473df56dab35a44b00399bd70c7a3b997", upload-time = "2026-04-27T17:42:06Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:7db3580106bba044da5b8950f3fb8fe5f31999eaab3f6a3aa2ac5d202c3684d2", upload-time = "2026-04-27T17:45:35Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:db964b33c55035a72ab3e2162287af8f1cc276039c65d015740cc88c26dcedf7", upload-time = "2026-04-27T17:46:18Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:cd1cf1005c5fe419194ee294b7b584ba5ad0f2fb1778b3fe5a7b9c3f4617ddbc", upload-time = "2026-04-27T17:50:01Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:74b628dbc71603977b09f4e140792c6e997081a35ef3421555f3f6e201b81210", upload-time = "2026-04-27T17:50:42Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:baa52f7b8a53cab16587b10f1c27d1000ca033f97236878b685b75d5a1b92408", upload-time = "2026-04-27T17:54:24Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:d389a850677f0d24dafae1573644034428d8d3b9c80b51d55ba62fed7e6c8777", upload-time = "2026-04-27T17:55:03Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:06849e9311dbb0617c97557d9c26c99a9e1c4f2ac9cb8e9b6d9b420d522acb91", upload-time = "2026-04-27T17:58:48Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:169a9987e1f84f0c5eee07544b3a34827a163ac9180e23abf0c3548f1335762c", upload-time = "2026-04-27T17:59:26Z" },
+    { url = "https://download.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:9c8f38efee365cb9d334de8a83ce52fc7e5fc9e5a7b0853285efa1b69e00b0f2", upload-time = "2026-04-27T17:41:30Z" },
+    { url = "https://download.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:d252cf975fb18c94a85336323ad425f473df56dab35a44b00399bd70c7a3b997", upload-time = "2026-04-27T17:42:06Z" },
+    { url = "https://download.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:7db3580106bba044da5b8950f3fb8fe5f31999eaab3f6a3aa2ac5d202c3684d2", upload-time = "2026-04-27T17:45:35Z" },
+    { url = "https://download.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:db964b33c55035a72ab3e2162287af8f1cc276039c65d015740cc88c26dcedf7", upload-time = "2026-04-27T17:46:18Z" },
+    { url = "https://download.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:cd1cf1005c5fe419194ee294b7b584ba5ad0f2fb1778b3fe5a7b9c3f4617ddbc", upload-time = "2026-04-27T17:50:01Z" },
+    { url = "https://download.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:74b628dbc71603977b09f4e140792c6e997081a35ef3421555f3f6e201b81210", upload-time = "2026-04-27T17:50:42Z" },
+    { url = "https://download.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:baa52f7b8a53cab16587b10f1c27d1000ca033f97236878b685b75d5a1b92408", upload-time = "2026-04-27T17:54:24Z" },
+    { url = "https://download.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:d389a850677f0d24dafae1573644034428d8d3b9c80b51d55ba62fed7e6c8777", upload-time = "2026-04-27T17:55:03Z" },
+    { url = "https://download.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:06849e9311dbb0617c97557d9c26c99a9e1c4f2ac9cb8e9b6d9b420d522acb91", upload-time = "2026-04-27T17:58:48Z" },
+    { url = "https://download.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:169a9987e1f84f0c5eee07544b3a34827a163ac9180e23abf0c3548f1335762c", upload-time = "2026-04-27T17:59:26Z" },
 ]
 
 [[package]]
@@ -6707,9 +6965,9 @@ resolution-markers = [
     "python_full_version < '3.13' and sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "numpy", marker = "sys_platform != 'linux'" },
-    { name = "pillow", marker = "sys_platform != 'linux'" },
-    { name = "torch", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux'" },
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "torch", version = "2.11.0", source = { registry = "https://pypi.org/simple" } },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ae/e7/56b47cc3b132aea90ccce22bcb8975dec688b002150012acc842846039d0/torchvision-0.26.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c409e1c3fdebec7a3834465086dbda8bf7680eff79abf7fd2f10c6b59520a7a4", size = 1863502, upload-time = "2026-03-23T18:12:57.326Z" },
@@ -6743,21 +7001,21 @@ resolution-markers = [
     "python_full_version < '3.13' and platform_machine != 'AMD64' and platform_machine != 'aarch64' and platform_machine != 'arm64' and platform_machine != 'x86_64' and sys_platform == 'linux'",
 ]
 dependencies = [
-    { name = "numpy", marker = "sys_platform == 'linux'" },
-    { name = "pillow", marker = "sys_platform == 'linux'" },
-    { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform == 'linux'" },
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" } },
 ]
 wheels = [
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:63e35234aed13b6edda37056f417b5c281249669db631e706811917af36b21d7", upload-time = "2026-04-09T23:21:35Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:ccf26b4b659cfce6f2208cb8326071d51c70219a34856dfdf468d1e19af52c0d", upload-time = "2026-03-23T15:36:22Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:c4a9cacd521f2a4df0bcd9d8e96704771b928f478f1f3067e4085bb53a1da298", upload-time = "2026-04-09T23:21:37Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:cb1f6184a7ba30fba40580e1a01a6604a86c55e79fdda187f40116ee680441ec", upload-time = "2026-03-23T15:36:22Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:e594732552a8c2fee2ace9c6475c6c6904fc44ccca622ee6765a89a045416a44", upload-time = "2026-04-09T23:21:38Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:6168abc019803ac9e97efce27eafd2fdb33db04dcc54a86039537729e5047b29", upload-time = "2026-03-23T15:36:23Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:b3865fa227661dd75b7b28c96d3d14e739bd08bf0614132758922fe0e7206f91", upload-time = "2026-04-09T23:21:39Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:aac647c9130f1f25f5c8f5bca3d95cfd96bdfac93ab54529690b088e64e4fa64", upload-time = "2026-03-23T15:36:23Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:e2ee9e16ee4518292694537fcbd20d2d27044e381d92b864f637e82795796a84", upload-time = "2026-04-09T23:21:40Z" },
-    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:b5772c55bfda4377df8f1930d43c4e0231ef231b0228eade4b227c8d3ba6e34e", upload-time = "2026-03-23T15:36:23Z" },
+    { url = "https://download.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:63e35234aed13b6edda37056f417b5c281249669db631e706811917af36b21d7", upload-time = "2026-04-09T23:21:35Z" },
+    { url = "https://download.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:ccf26b4b659cfce6f2208cb8326071d51c70219a34856dfdf468d1e19af52c0d", upload-time = "2026-03-23T15:36:22Z" },
+    { url = "https://download.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:c4a9cacd521f2a4df0bcd9d8e96704771b928f478f1f3067e4085bb53a1da298", upload-time = "2026-04-09T23:21:37Z" },
+    { url = "https://download.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:cb1f6184a7ba30fba40580e1a01a6604a86c55e79fdda187f40116ee680441ec", upload-time = "2026-03-23T15:36:22Z" },
+    { url = "https://download.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:e594732552a8c2fee2ace9c6475c6c6904fc44ccca622ee6765a89a045416a44", upload-time = "2026-04-09T23:21:38Z" },
+    { url = "https://download.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:6168abc019803ac9e97efce27eafd2fdb33db04dcc54a86039537729e5047b29", upload-time = "2026-03-23T15:36:23Z" },
+    { url = "https://download.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:b3865fa227661dd75b7b28c96d3d14e739bd08bf0614132758922fe0e7206f91", upload-time = "2026-04-09T23:21:39Z" },
+    { url = "https://download.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:aac647c9130f1f25f5c8f5bca3d95cfd96bdfac93ab54529690b088e64e4fa64", upload-time = "2026-03-23T15:36:23Z" },
+    { url = "https://download.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:e2ee9e16ee4518292694537fcbd20d2d27044e381d92b864f637e82795796a84", upload-time = "2026-04-09T23:21:40Z" },
+    { url = "https://download.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:b5772c55bfda4377df8f1930d43c4e0231ef231b0228eade4b227c8d3ba6e34e", upload-time = "2026-03-23T15:36:23Z" },
 ]
 
 [[package]]
@@ -6860,6 +7118,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7c/f7/68adc395201b20b872d68e975386832e8005ffeacedd43a1d837a32815be/typer-0.26.8.tar.gz", hash = "sha256:c244a6bd558886fe3f8780efb6bdd28bb9aff005a94eedebaa5cb32926fe2f7e", size = 202097, upload-time = "2026-06-26T09:22:45.705Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/80/87/b9fd69c92c6102a066e1b86a35243f53e70bd4c709f2a26d9f4fee4f4dc0/typer-0.26.8-py3-none-any.whl", hash = "sha256:3512ca79ac5c11113414b36e80281b872884477722440691c89d1112e321a49c", size = 122564, upload-time = "2026-06-26T09:22:44.72Z" },
+]
+
+[[package]]
+name = "types-protobuf"
+version = "7.34.1.20260518"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/59/e2b13b499d15e6720150c4b1a8d91e31fcacf716b432397475b3151ff7e4/types_protobuf-7.34.1.20260518.tar.gz", hash = "sha256:28cfaded25889cb83ebfb63cfb0a43628f0b6f3785767bec17287dc6468795f2", size = 68936, upload-time = "2026-05-18T06:01:47.332Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/1f/ec5caf72c2e3b688ca3927e0979a04ddad19e1afc4bf1c199bd743e0f419/types_protobuf-7.34.1.20260518-py3-none-any.whl", hash = "sha256:a0a5337413347166439c0e07cbc26c6164d091401c6f01b1dfd8cdb966c4dd8f", size = 85992, upload-time = "2026-05-18T06:01:45.696Z" },
 ]
 
 [[package]]
@@ -7204,7 +7471,7 @@ name = "werkzeug"
 version = "3.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "markupsafe", marker = "sys_platform == 'linux'" },
+    { name = "markupsafe" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/dd/b2/381be8cfdee792dd117872481b6e378f85c957dd7c5bca38897b08f765fd/werkzeug-3.1.8.tar.gz", hash = "sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44", size = 875852, upload-time = "2026-04-02T18:49:14.268Z" }
 wheels = [


### PR DESCRIPTION
# WebRTCProxyRobot — drive a remote robot over WebRTC

A lerobot `Robot` whose body is on another machine. The cloud side is a normal `Robot`
(record / teleoperate / eval); the robot side runs a small capture daemon.

## Why

The GPU that runs the policy and the robot that has the motors are often **not on the
same network**, and a direct connection between them may not be possible:

- **Intranet:** a GPU/training server in the cluster may not be able to directly reach a
  robot on the lab / office LAN — separate subnets, firewalls, or NAT can sit in between.
- **Public cloud GPU:** a cloud-vendor GPU on the public internet may not be able to reach
  a robot behind a home/office router (NAT).

WebRTC bridges the two with proper NAT traversal, so the policy stays on the GPU and the
arm stays wherever it is. Two transports — **pick by where the two sides live:**

- **Intranet → `aiortc`** (peer-to-peer, lowest latency, no extra service).
- **Across the public internet → `livekit`** (an SFU handles NAT traversal / TURN relaying
  at scale).

```
   ROBOT HOST                                      CLOUD / CONTROLLER
 ┌──────────────────────┐                        ┌──────────────────────────┐
 │ robot_daemon         │   observation  ──▶     │ WebRTCProxyRobot         │
 │  • motor bus         │   (joints + camera)    │  a normal lerobot Robot  │
 │  • camera            │                        │   get_observation()      │
 │  • safety watchdog   │      ◀──  action       │   send_action()          │
 └──────────────────────┘        (goal joints)   └──────────────────────────┘

     obs + action ride WebRTC DataChannels · camera rides a media track
```

Two interchangeable transports behind one interface:

### aiortc (default) — peer-to-peer · `lerobot[webrtc]` · recommended on an intranet

```
   robot_daemon  ◀════════ WebRTC P2P (UDP, host + STUN) ════════▶  WebRTCProxyRobot
        │                                                                │
        └──────────── SDP ──▶   signaling relay   ◀── SDP ──────────────┘
                               (bundled WebSocket;
                                only brokers SDP)
```

### livekit (experimental) — SFU · `lerobot[webrtc-livekit]` · recommended across the public net

```
   robot_daemon  ◀════▶   LiveKit SFU   ◀════▶  WebRTCProxyRobot
                        (media + data relayed
                         through the server)
```

| | aiortc | livekit |
|---|---|---|
| topology | peer-to-peer | via SFU |
| recommended for | **intranet** (GPU cluster ↔ lab robot) | **public internet** (cloud GPU ↔ remote robot) |
| needs | nothing (bundled relay) | a LiveKit server |

### Try it — SO-100 (`examples/webrtc_remote_so100/`)

```bash
python examples/webrtc_remote_so100/robot_daemon_so100.py    # robot host
python examples/webrtc_remote_so100/cloud_teleop_so100.py    # controller: web panel (camera + jog)
```

Additive: new `webrtc_proxy` package + SO-100 example + `webrtc`/`webrtc-livekit` extras +
13 tests (they `importorskip("aiortc")`, so skip without the extra). Base `uv sync` unchanged.
