### PR TITLE
fix(datasets): Fix metadata when parquet files columns have different orders

### DIFF
--- a/src/lerobot/datasets/dataset_metadata.py
+++ b/src/lerobot/datasets/dataset_metadata.py
@@ -145,6 +145,12 @@ class LeRobotDatasetMetadata:
             self._pq_writer = pq.ParquetWriter(
                 path, schema=table.schema, compression="snappy", use_dictionary=True
             )
+        else:
+            # Column order in `combined_dict` follows the source episode dict's insertion
+            # order, which can differ between batches (e.g. episodes originally stored in
+            # different parquet shards with different column orders). Realign to the
+            # writer's established schema so `write_table` doesn't reject a reordered match.
+            table = table.select(self._pq_writer.schema.names)
 
         self._pq_writer.write_table(table)
 


### PR DESCRIPTION
## Summary / Motivation

Simple fix for reading dataset metadata when parquet files columns do not follow the same ordering. This leads to error when editing datasets in which metadata parquet files happen to have columns with different orders.

## Example of error reproduction

```
lerobot-edit-dataset  --repo_id BrunoM42/shelf_picking  --operation.type delete_episodes  --operation.episode_indices "[0, 34, 190, 203]"
```

Error:
```
Traceback (most recent call last):
  File "lerobot/src/lerobot/scripts/lerobot_edit_dataset.py", line 850, in main
    edit_dataset()
  File "lerobot/src/lerobot/configs/parser.py", line 320, in wrapper_inner
    response = fn(cfg, *args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^
  File "lerobot/src/lerobot/scripts/lerobot_edit_dataset.py", line 826, in edit_dataset
    handle_delete_episodes(cfg)
  File "lerobot/src/lerobot/scripts/lerobot_edit_dataset.py", line 420, in handle_delete_episodes
    new_dataset = delete_episodes(
                  ^^^^^^^^^^^^^^^^
  File "lerobot/src/lerobot/datasets/dataset_tools.py", line 161, in delete_episodes
    _copy_and_reindex_episodes_metadata(dataset, new_meta, episode_mapping, data_metadata, video_metadata)
  File "lerobot/src/lerobot/datasets/dataset_tools.py", line 929, in _copy_and_reindex_episodes_metadata
    dst_meta._save_episode_metadata(episode_dict)
  File "lerobot/src/lerobot/datasets/dataset_metadata.py", line 587, in _save_episode_metadata
    self._flush_metadata_buffer()
  File "lerobot/src/lerobot/datasets/dataset_metadata.py", line 149, in _flush_metadata_buffer
    self._pq_writer.write_table(table)
  File "lerobot/lib/python3.12/site-packages/pyarrow/parquet/core.py", line 1211, in write_table
    raise ValueError(msg)
ValueError: Table schema does not match schema used to create file
```

## How it was fixed

Re-order columns to match the first file read.