### PR TITLE
feat(robots): add NexArm 6-DOF robot arm support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,181 +1,589 @@
-<p align="center">
-  <img alt="LeRobot, Hugging Face Robotics Library" src="./media/readme/lerobot-logo-thumbnail.png" width="100%">
-</p>
+# NexArm 6-DOF 机械臂 — LeRobot 完整使用指南
 
-<div align="center">
+NexArm 是一款基于 ESP32 + AT32F421 协处理器的高性能 6 自由度桌面机械臂，采用 HX-30HM 高性能串行总线舵机，具备 12 位精度与 1 Mbps 高速通信，响应迅速、扭矩强劲。本文档涵盖从硬件连接、遥操作测试、数据采集、模型训练到策略推理的完整流程。
 
-[![Tests](https://github.com/huggingface/lerobot/actions/workflows/latest_deps_tests.yml/badge.svg?branch=main)](https://github.com/huggingface/lerobot/actions/workflows/latest_deps_tests.yml?query=branch%3Amain)
-[![Tests](https://github.com/huggingface/lerobot/actions/workflows/docker_publish.yml/badge.svg?branch=main)](https://github.com/huggingface/lerobot/actions/workflows/docker_publish.yml?query=branch%3Amain)
-[![Python versions](https://img.shields.io/pypi/pyversions/lerobot)](https://www.python.org/downloads/)
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/huggingface/lerobot/blob/main/LICENSE)
-[![Status](https://img.shields.io/pypi/status/lerobot)](https://pypi.org/project/lerobot/)
-[![Version](https://img.shields.io/pypi/v/lerobot)](https://pypi.org/project/lerobot/)
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.1-ff69b4.svg)](https://github.com/huggingface/lerobot/blob/main/CODE_OF_CONDUCT.md)
-[![Discord](https://img.shields.io/badge/Discord-Join_Us-5865F2?style=flat&logo=discord&logoColor=white)](https://discord.gg/q8Dzzpym3f)
+---
 
-</div>
+## 目录
 
-**LeRobot** aims to provide models, datasets, and tools for real-world robotics in PyTorch. The goal is to lower the barrier to entry so that everyone can contribute to and benefit from shared datasets and pretrained models.
+- [硬件概述](#硬件概述)
+- [环境安装](#环境安装)
+- [第一步：查找串口](#第一步查找串口)
+- [第二步：查找摄像头](#第二步查找摄像头)
+- [第三步：遥操作 / 标定](#第三步遥操作--标定)
+- [第四步：采集数据集](#第四步采集数据集)
+- [第五步：训练策略模型](#第五步训练策略模型)
+- [第六步：策略推理部署](#第六步策略推理部署)
+- [代码架构说明](#代码架构说明)
+- [PR 提交指南](#pr-提交指南)
+- [常见问题排查](#常见问题排查)
 
-🤗 A hardware-agnostic, Python-native interface that standardizes control across diverse platforms, from low-cost arms (SO-100) to humanoids.
+---
 
-🤗 A standardized, scalable LeRobotDataset format (Parquet + MP4 or images) hosted on the Hugging Face Hub, enabling efficient storage, streaming and visualization of massive robotic datasets.
+## 硬件概述
 
-🤗 State-of-the-art policies that have been shown to transfer to the real-world ready for training and deployment.
+### 硬件组成
 
-🤗 Comprehensive support for the open-source ecosystem to democratize physical AI.
+| 组件 | 说明 |
+|------|------|
+| **主臂 (Leader)** | ESP32 开发板，直接驱动 6 个 HX-30HM 舵机。用于遥操作，操作者自由拖动此臂 |
+| **从臂 (Follower)** | ESP32 开发板 + AT32F421 协处理器，驱动 6 个 HX-30HM 舵机。镜像主臂动作或执行策略输出 |
+| **舵机** | HX-30HM 高性能串行总线舵机，12 位精度 (0–4095)，1 Mbps 波特率，高扭矩、快响应 |
+| **摄像头** | 2 个 USB 摄像头 — "front"（工作区俯视）和 "wrist"（末端执行器近景），640×480 @ 30 FPS |
 
-## Quick Start
+### 关节布局 (6 DOF)
 
-LeRobot can be installed directly from PyPI.
+| 关节编号 | 名称 | 说明 |
+|----------|------|------|
+| 1 | `shoulder_pan` | 底座旋转 |
+| 2 | `shoulder_lift` | 大臂俯仰（leader 与 follower 装配方向相反，由校准的 drive_mode/homing_offset 自动对齐） |
+| 3 | `elbow_flex` | 肘关节 |
+| 4 | `wrist_flex` | 腕部俯仰 |
+| 5 | `wrist_roll` | 腕部旋转 |
+| 6 | `gripper` | 夹爪开合（leader 与 follower 物理行程不同，由校准 range_min/range_max 自动对齐） |
 
-```bash
-pip install lerobot
-lerobot-info
+### 通信协议
+
+NexArm 使用自定义 CommProtocol 通过 USB 串口通信：
+
+```
+帧格式: [0xFF][0xFF][ID][LEN][CMD][ARGS...][CHECKSUM]
 ```
 
-> [!IMPORTANT]
-> For detailed installation guide, please see the [Installation Documentation](https://huggingface.co/docs/lerobot/installation).
+| 命令 | 功能 | 方向 |
+|------|------|------|
+| CMD 68 | 进入/退出 LeRobot 桥接模式（仅从臂） | 主机 → 从臂 |
+| CMD 96 | 读取 6 个舵机位置（回复：12 字节） | 主机 → 设备 → 主机 |
+| CMD 97 | 写入 6 个舵机位置（12 字节，无回复） | 主机 → 设备 |
+| CMD 98 | 使能/失能力矩 | 主机 → 设备 |
 
-## Robots & Control
+---
 
-<div align="center">
-  <img src="./media/readme/robots_control_video.webp" width="640px" alt="Reachy 2 Demo">
-</div>
+## 环境安装
 
-LeRobot provides a unified `Robot` class interface that decouples control logic from hardware specifics. It supports a wide range of robots and teleoperation devices.
+### 1. 创建环境并安装
+
+推荐使用 conda 创建独立环境：
+
+```bash
+git clone https://github.com/liangfuyuan581-creator/lerobot-nexarm.git
+cd lerobot-nexarm
+
+conda create -n nexarm python=3.12 -y
+conda activate nexarm
+
+# 安装 lerobot（editable 模式，包含所有必要依赖）
+pip install -e ".[nexarm]"
+```
+
+如果需要遥操作时实时可视化（rerun 界面），额外安装：
+
+```bash
+pip install -e ".[nexarm,viz]"
+```
+
+> **注意：** 不安装 `viz` 也可以正常使用遥操作、采集、训练和推理，只是没有实时画面显示。配置文件中已默认关闭 `display_data`。
+
+也可以使用 venv 代替 conda：
+
+```bash
+git clone https://github.com/liangfuyuan581-creator/lerobot-nexarm.git
+cd lerobot-nexarm
+
+python -m venv .venv
+
+# 激活虚拟环境
+# Windows:
+.venv\Scripts\activate
+# Linux/macOS:
+source .venv/bin/activate
+
+pip install -e ".[nexarm]"
+```
+
+### 2. 验证安装
+
+```bash
+python -c "import lerobot.rollout; print('OK')"
+```
+
+### 3. 连接硬件
+
+- 将 **从臂 (Follower/Slave)** 的 ESP32 通过 USB 连接到电脑
+- 将 **主臂 (Leader/Master)** 的 ESP32 通过 USB 连接到电脑
+- 插入两个 USB 摄像头（front + wrist）
+
+### 平台兼容性
+
+| 平台 | 状态 | 说明 |
+|------|------|------|
+| Windows 10/11 | 已验证 | CH340 驱动需安装，串口格式 COM19 |
+| Ubuntu 20.04+ | 已验证 | 串口格式 /dev/ttyUSB0，需 dialout 权限 |
+| macOS | 应兼容 | 串口格式 /dev/tty.usbserial-xxx |
+
+---
+
+## 第一步：查找串口
+
+确定主臂和从臂各自对应哪个串口。
+
+```bash
+python -m lerobot.scripts.lerobot_find_port
+```
+
+Windows 上的典型输出：
+
+| 端口 | 设备 |
+|------|------|
+| COM18 | 主臂 (Leader/Master) ESP32 |
+| COM19 | 从臂 (Follower/Slave) ESP32 |
+
+Linux 上通常是 `/dev/ttyUSB0` 和 `/dev/ttyUSB1`。
+
+> **提示：** 如果无法确定哪个是主臂哪个是从臂，可以只插一个试试，或查看设备管理器中的 USB 设备描述。
+
+---
+
+## 第二步：查找摄像头
+
+确定哪个摄像头索引对应"前方"和"腕部"。
+
+```bash
+python -m lerobot.scripts.lerobot_find_cameras opencv
+```
+
+或者手动扫描并拍照确认：
 
 ```python
-from lerobot.robots.myrobot import MyRobot
+import cv2
 
-# Connect to a robot
-robot = MyRobot(config=...)
-robot.connect()
-
-# Read observation and send action
-obs = robot.get_observation()
-action = model.select_action(obs)
-robot.send_action(action)
+for i in range(10):
+    cap = cv2.VideoCapture(i)
+    if cap.isOpened():
+        ret, frame = cap.read()
+        if ret:
+            cv2.imwrite(f"cam_{i}.png", frame)
+            print(f"摄像头 {i}: 可用")
+        cap.release()
 ```
 
-**Supported Hardware:** SO100, LeKiwi, Koch, HopeJR, OMX, EarthRover, Reachy2, Gamepads, Keyboards, Phones, OpenARM, Unitree G1, reBot B601.
+查看保存的图片，确定：
+- **front**（前方摄像头）：拍到整个工作区的俯视画面
+- **wrist**（腕部摄像头）：拍到末端执行器/夹爪的近景
 
-While these devices are natively integrated into the LeRobot codebase, the library is designed to be extensible. You can easily implement the Robot interface to utilize LeRobot's data collection, training, and visualization tools for your own custom robot.
+> **注意：** 摄像头索引会随 USB 插拔顺序变化。每次重新插拔后建议重新扫描确认。
 
-For detailed hardware setup guides, see the [Hardware Documentation](https://huggingface.co/docs/lerobot/integrate_hardware).
+---
 
-## LeRobot Dataset
+## 第三步：遥操作 / 标定
 
-To solve the data fragmentation problem in robotics, we utilize the **LeRobotDataset** format.
+验证主臂-从臂的遥操作链路是否正常。主臂力矩关闭，操作者自由拖动主臂，从臂实时镜像跟随。
 
-- **Structure:** Synchronized MP4 videos (or images) for vision and Parquet files for state/action data.
-- **HF Hub Integration:** Explore thousands of robotics datasets on the [Hugging Face Hub](https://huggingface.co/lerobot).
-- **Tools:** Seamlessly delete episodes, split by indices/fractions, add/remove features, and merge multiple datasets.
+> **关于标定：** NexArm 沿用 lerobot 官方标定流程（与 SO-100/SO-101 一致），主臂和从臂各跑一次：先把臂摆到机械中点，再依次拨动每个关节走完整行程。标定会写入 `~/.cache/huggingface/lerobot/calibration/{robots,teleoperators}/{nexarm_follower,nexarm_leader}/{id}.json`。第一次 `lerobot_teleoperate` 启动时会自动进入这个流程；之后会直接读取缓存。
+>
+> 标定记录的是每个关节真实的 raw min/max + homing_offset，主从臂之间的镜像/重映射不再写死在代码里，而是由 calibration 自动吸收（drive_mode + offset + range）。这意味着：换舵机、换臂、装配公差变化，**只需要重跑一次标定**，不用改任何代码。
 
-```python
-from lerobot.datasets.lerobot_dataset import LeRobotDataset
+### 方式一：使用配置文件
 
-# Load a dataset from the Hub
-dataset = LeRobotDataset("lerobot/aloha_mobile_cabinet")
-
-# Access data (automatically handles video decoding)
-episode_index=0
-print(f"{dataset[episode_index]['action'].shape=}\n")
-```
-
-Learn more about it in the [LeRobotDataset Documentation](https://huggingface.co/docs/lerobot/lerobot-dataset-v3)
-
-## SoTA Models
-
-LeRobot implements state-of-the-art policies in pure PyTorch, covering Imitation Learning, Reinforcement Learning, Vision-Language-Action (VLA) models, World Models, and Reward Models, with more coming soon. It also provides you with the tools to instrument and inspect your training process.
-
-<p align="center">
-  <img alt="Gr00t Architecture" src="./media/readme/VLA_architecture.jpg" width="640px">
-</p>
-
-Training a policy is as simple as running a script configuration:
+先根据你的实际情况修改 `examples/nexarm/teleoperate.yaml` 中的串口和摄像头索引，然后运行：
 
 ```bash
-lerobot-train \
-  --policy.type=act \
-  --dataset.repo_id=lerobot/aloha_mobile_cabinet
+python -m lerobot.scripts.lerobot_teleoperate --config_path=examples/nexarm/teleoperate.yaml
 ```
 
-| Category                   | Models                                                                                                                                                                                                                                                                                                                                                                                     |
-| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Imitation Learning**     | [ACT](./docs/source/policy_act_README.md), [Diffusion](./docs/source/policy_diffusion_README.md), [VQ-BeT](./docs/source/policy_vqbet_README.md), [Multitask DiT Policy](./docs/source/policy_multi_task_dit_README.md)                                                                                                                                                                    |
-| **Reinforcement Learning** | [HIL-SERL](./docs/source/hilserl.mdx), [TDMPC](./docs/source/policy_tdmpc_README.md) & QC-FQL (coming soon)                                                                                                                                                                                                                                                                                |
-| **VLAs Models**            | [Pi0](./docs/source/pi0.mdx), [Pi0Fast](./docs/source/pi0fast.mdx), [Pi0.5](./docs/source/pi05.mdx), [GR00T N1.7](./docs/source/policy_groot_README.md), [SmolVLA](./docs/source/policy_smolvla_README.md), [XVLA](./docs/source/xvla.mdx), [EO-1](./docs/source/eo1.mdx), [MolmoAct2](./docs/source/molmoact2.mdx), [WALL-OSS](./docs/source/walloss.mdx), [EVO1](./docs/source/evo1.mdx) |
-| **World Models**           | [VLA-JEPA](./docs/source/vla_jepa.mdx), [LingBot-VA](./docs/source/lingbot_va.mdx), [FastWAM](./docs/source/fastwam.mdx)                                                                                                                                                                                                                                                                   |
-| **Reward Models**          | [SARM](./docs/source/sarm.mdx), [TOPReward](./docs/source/topreward.mdx), [Robometer](./docs/source/robometer.mdx)                                                                                                                                                                                                                                                                         |
-
-Similarly to the hardware, you can easily implement your own policy & leverage LeRobot's data collection, training, and visualization tools, and share your model to the HF Hub
-
-For detailed policy setup guides, see the [Policy Documentation](https://huggingface.co/docs/lerobot/bring_your_own_policies). For GPU/RAM requirements and expected training time per policy, see the [Compute Hardware Guide](https://huggingface.co/docs/lerobot/hardware_guide).
-
-## Inference & Evaluation
-
-Evaluate your policies in simulation or on real hardware using the unified evaluation script. LeRobot supports standard benchmarks like **LIBERO**, **MetaWorld** and more to come.
+### 方式二：使用命令行参数
 
 ```bash
-# Evaluate a policy on the LIBERO benchmark
-lerobot-eval \
-  --policy.path=lerobot/pi0_libero_finetuned \
-  --env.type=libero \
-  --env.task=libero_object \
-  --eval.n_episodes=10
+python -m lerobot.scripts.lerobot_teleoperate --robot.type=nexarm_follower --robot.port=COM19 --teleop.type=nexarm_leader --teleop.port=COM18 --fps=30
 ```
 
-Learn how to implement your own simulation environment or benchmark and distribute it from the HF Hub by following the [EnvHub Documentation](https://huggingface.co/docs/lerobot/envhub)
+### 标定流程要点
 
-## Resources
+每个关节走完整行程时尽量缓慢、覆盖到机械极限附近（但不要硬撞）。
 
-- **[Documentation](https://huggingface.co/docs/lerobot/index):** The complete guide to tutorials & API.
-- **[Chinese Tutorials: LeRobot+SO-ARM101中文教程-同济子豪兄](https://zihao-ai.feishu.cn/wiki/space/7589642043471924447)** Detailed doc for assembling, teleoperate, dataset, train, deploy. Verified by Seed Studio and 5 global hackathon players.
-- **[Discord](https://discord.gg/q8Dzzpym3f):** Join the `LeRobot` server to discuss with the community.
-- **[X](https://x.com/LeRobotHF):** Follow us on X to stay up-to-date with the latest developments.
-- **[Robot Learning Tutorial](https://huggingface.co/spaces/lerobot/robot-learning-tutorial):** A free, hands-on course to learn robot learning using LeRobot.
-- **[T-Shirt Folding Experiment](https://huggingface.co/spaces/lerobot/robot-folding):** An end-to-end demonstration of folding t-shirts with LeRobot.
-- **[LeLab](https://github.com/huggingface/leLab):** A web interface for LeRobot — teleoperate, calibrate, record datasets, replay, and train your SO arm from the browser, no CLI required.
+- 错把 leader 当 follower 标定 → 数值范围还在但方向会反，可以删掉 `~/.cache/.../<arm>/main.json` 重新标
+- 标定中途想中止 → Ctrl+C，已有的缓存不受影响
+- 多套臂共存 → 在 yaml 里加 `robot.id: arm_a` / `arm_b`，校准文件会按 id 分别落盘
 
-## Citation
+### 验证要点
 
-If you use LeRobot in your project, please cite the GitHub repository to acknowledge the ongoing development and contributors:
+- 拖动主臂时从臂应该实时跟随
+- 各个关节方向一致（标定的 drive_mode 自动处理装配反向）
+- 夹爪开合应该自然映射，主臂全行程 → 从臂全行程
 
-```bibtex
-@misc{cadene2024lerobot,
-    author = {Cadene, Remi and Alibert, Simon and Soare, Alexander and Gallouedec, Quentin and Zouitine, Adil and Palma, Steven and Kooijmans, Pepijn and Aractingi, Michel and Shukor, Mustafa and Aubakirova, Dana and Russi, Martino and Capuano, Francesco and Pascal, Caroline and Choghari, Jade and Meftah, Khalil and Ellerbach, Maxime and Moss, Jess and Wolf, Thomas},
-    title = {LeRobot: State-of-the-art Machine Learning for Real-World Robotics in Pytorch},
-    howpublished = "\url{https://github.com/huggingface/lerobot}",
-    year = {2024}
-}
+> **提示：** 如果遥操作感觉卡顿，检查是否有其他程序（如 Arduino IDE 串口监视器）占用了 COM 端口。
+
+---
+
+## 第四步：采集数据集
+
+通过遥操作录制示范数据，用于后续模仿学习训练。操作者拖动主臂执行任务，从臂跟随执行，同时录制摄像头画面和关节位置。
+
+### 运行采集
+
+先修改 `examples/nexarm/record.yaml` 中的配置（串口、摄像头、数据集名称等），然后运行：
+
+```bash
+python -m lerobot.scripts.lerobot_record --config_path=examples/nexarm/record.yaml
 ```
 
-If you are referencing our research or the academic paper, please also cite our ICLR publication:
+### 关键参数说明
 
-<details>
-<summary><b>ICLR 2026 Paper</b></summary>
+| 参数 | 默认值 | 说明 |
+|------|--------|------|
+| `dataset.repo_id` | `local/nexarm_pick` | 数据集名称（本地保存） |
+| `dataset.num_episodes` | 50 | 录制的 episode 数量 |
+| `dataset.episode_time_s` | 10 | 每个 episode 的时长（秒） |
+| `dataset.reset_time_s` | 10 | episode 之间用于重置场景的等待时间 |
+| `dataset.fps` | 30 | 录制帧率 |
+| `dataset.push_to_hub` | false | 是否上传到 HuggingFace Hub |
 
-```bibtex
-@inproceedings{cadenelerobot,
-  title={LeRobot: An Open-Source Library for End-to-End Robot Learning},
-  author={Cadene, Remi and Alibert, Simon and Capuano, Francesco and Aractingi, Michel and Zouitine, Adil and Kooijmans, Pepijn and Choghari, Jade and Russi, Martino and Pascal, Caroline and Palma, Steven and Shukor, Mustafa and Moss, Jess and Soare, Alexander and Aubakirova, Dana and Lhoest, Quentin and Gallou\'edec, Quentin and Wolf, Thomas},
-  booktitle={The Fourteenth International Conference on Learning Representations},
-  year={2026},
-  url={https://arxiv.org/abs/2602.22818}
-}
+### 采集流程
+
+1. 脚本启动后自动连接双臂和摄像头
+2. 每个 episode：
+   - 按 Enter 开始录制
+   - 拖动主臂执行任务（如抓取物体）
+   - 到达 `episode_time_s` 后自动结束录制
+   - 在 `reset_time_s` 内将物体重置到初始位置
+3. 全部 episode 录完后，数据集保存到本地并可选上传到 HuggingFace Hub
+
+### 仅本地保存（不上传）
+
+```bash
+python -m lerobot.scripts.lerobot_record --config_path=examples/nexarm/record.yaml --dataset.repo_id=local/nexarm_pick --dataset.push_to_hub=false
 ```
 
-</details>
+### 数据质量建议
 
-## Contribute
+- **至少录制 50 个 episode** 才能获得可用的训练效果
+- 每次录制保持动作一致性（相同的起始位置、相似的运动轨迹）
+- 确保摄像头画面清晰、光照稳定
+- 录制完成后可用 `lerobot_dataset_viz` 查看数据集质量
 
-We welcome contributions from everyone in the community! To get started, please read our [CONTRIBUTING.md](https://github.com/huggingface/lerobot/blob/main/CONTRIBUTING.md) guide. Whether you're adding a new feature, improving documentation, or fixing a bug, your help and feedback are invaluable. We're incredibly excited about the future of open-source robotics and can't wait to work with you on what's next—thank you for your support!
+---
 
-<p align="center">
-  <img alt="SO101 Video" src="./media/readme/so100_video.webp" width="640px">
-</p>
+## 第五步：训练策略模型
 
-<div align="center">
-<sub>Built by the <a href="https://huggingface.co/lerobot">LeRobot</a> team at <a href="https://huggingface.co">Hugging Face</a> with ❤️</sub>
-</div>
+使用 ACT（Action Chunking with Transformers）策略在采集的数据集上训练。
+
+### 安装训练依赖
+
+训练需要额外的依赖（accelerate、wandb 等），安装方式：
+
+```bash
+pip install -e ".[nexarm,training]"
+```
+
+### 运行训练
+
+```bash
+python -m lerobot.scripts.lerobot_train --dataset.repo_id=local/nexarm_pick --policy.type=act --output_dir=outputs/train/nexarm_act --batch_size=32 --steps=100000 --save_freq=25000
+```
+
+> **注意：** 不建议使用 `--config_path=examples/nexarm/train.yaml` 加 `--dataset.repo_id` 覆盖的方式，可能会报 JSON 格式错误。直接使用命令行参数即可。
+
+### 训练建议
+
+| 项目 | 建议值 | 说明 |
+|------|--------|------|
+| 训练设备 | CUDA GPU | 推荐 RTX 3090 或以上 |
+| 示范 episode 数 | 50+ | 越多越好，至少 50 个 |
+| 训练步数 | 100,000 | 根据 loss 收敛情况调整 |
+| 批量大小 | 32 | 默认值，显存不足可降到 16 |
+| 保存频率 | 25,000 | 每 25k 步保存一个检查点 |
+
+> **关于 episode 时长：** 每个 episode 可以是 10-30 秒。ACT 训练时从 episode 中随机采样起始帧，取接下来 chunk_size=100 帧（3.3秒）作为预测目标。episode 长度不影响 chunk_size 设置。关键是每个 episode 内包含完整的任务动作（如完整的一次抓取-放置）。
+
+### 训练输出
+
+训练完成后，模型检查点保存在：
+
+```
+outputs/train/nexarm_act/checkpoints/last/pretrained_model/
+├── config.json                    # 策略配置
+├── model.safetensors              # 模型权重
+├── policy_preprocessor.json       # 输入预处理流水线
+├── policy_preprocessor_step_3_normalizer_processor.safetensors
+├── policy_postprocessor.json      # 输出后处理流水线
+├── policy_postprocessor_step_0_unnormalizer_processor.safetensors
+└── train_config.json              # 训练配置记录
+```
+
+---
+
+## 第六步：策略推理部署
+
+将训练好的策略部署到真实机器人上。从臂自主执行模型预测的动作，无需主臂。
+
+### 运行推理
+
+```bash
+python -m lerobot.scripts.lerobot_rollout --config_path=examples/nexarm/inference.yaml --policy.path=outputs/train/nexarm_act/checkpoints/last/pretrained_model
+```
+
+### 重要说明
+
+- **不需要传 `--teleop` 参数** — 策略替代人类操作者
+- 数据集名称必须以 `rollout_` 开头（配置文件中已设置为 `rollout_nexarm_pick`）
+- 每次推理会自动在 repo_id 后追加时间戳，生成唯一目录，不会冲突
+- 推理结果会录制成数据集，方便后续分析评估
+- 配置文件中 `device: cuda`，有 GPU 时使用 GPU 推理；无 GPU 时系统自动退回 CPU
+- 推理结束后机械臂会回到初始位置并保持力矩（不掉电）
+
+### 推理性能参考
+
+| 设备 | 大约帧率 | 说明 |
+|------|----------|------|
+| NVIDIA GPU | 30 Hz | 满速实时控制 |
+| CPU (i7/i5) | 20–30 Hz | ACT 策略利用 action chunking，模型每 100 帧推理一次，其余帧从队列弹出，CPU 也能实时 |
+
+> **ACT 策略在 CPU 上可以正常实时运行。** chunk_size=100 意味着模型推理（~700ms）只在队列为空时触发，其余 99 帧只需 ~1ms 弹出动作，整体帧率可达 20-30 Hz。
+
+### 不同策略模式
+
+| 策略 | 命令 | 说明 |
+|------|------|------|
+| `base` | `--strategy.type=base` | 仅推理，不录制 |
+| `sentry` | `--strategy.type=sentry` | 连续录制 + 自动保存（推荐用于评估） |
+| `highlight` | `--strategy.type=highlight` | 环形缓冲区，按键保存精彩片段 |
+| `dagger` | `--strategy.type=dagger` | 人机协作，需要主臂 |
+
+---
+
+## 代码架构说明
+
+### 文件结构
+
+```
+src/lerobot/
+├── motors/nexarm/                          # 串口驱动层
+│   ├── __init__.py                         # 导出 NexArmMotorsBus
+│   └── nexarm.py                           # CommProtocol 帧构建/解析、
+│                                           #   位置读写、力矩控制、桥接模式
+├── robots/nexarm_follower/                 # 从臂机器人
+│   ├── __init__.py                         # 导出 NexArmFollower, NexArmFollowerConfig
+│   ├── config_nexarm_follower.py           # RobotConfig 子类（端口、摄像头、波特率）
+│   └── nexarm_follower.py                  # Robot 子类（连接、观测、动作执行）
+└── teleoperators/nexarm_leader/            # 主臂遥操作
+    ├── __init__.py                         # 导出 NexArmLeader, NexArmLeaderConfig
+    ├── config_nexarm_leader.py             # TeleoperatorConfig 子类（端口、波特率）
+    └── nexarm_leader.py                    # Teleoperator 子类（读取动作、主从映射）
+```
+
+### 修改的已有文件
+
+| 文件 | 修改内容 |
+|------|----------|
+| `src/lerobot/robots/utils.py` | 在 `make_robot_from_config()` 中添加 `nexarm_follower` 分支 |
+| `src/lerobot/teleoperators/utils.py` | 在 `make_teleoperator_from_config()` 中添加 `nexarm_leader` 分支 |
+| `pyproject.toml` | 在 `[project.optional-dependencies]` 中添加 `nexarm = ["lerobot[pyserial-dep]", "lerobot[av-dep]"]` |
+
+### 数据流向
+
+```
+遥操作模式:
+  主臂 → sync_read("Present_Position", normalize=True)
+        ↓ leader calibration: raw → DEGREES / RANGE_0_100
+        ↓ follower calibration: DEGREES / RANGE_0_100 → raw
+  从臂 → sync_write("Goal_Position", normalize=True) → write_positions()
+
+策略推理模式:
+  摄像头 + sync_read("Present_Position") → ACT 模型推理 → 预测动作
+        ↓ follower calibration: DEGREES / RANGE_0_100 → raw (clamped to range_min/range_max)
+  从臂 → sync_write("Goal_Position", normalize=True)
+```
+
+> **不再需要手写镜像/重映射函数。** 每个关节的方向、零点、机械限位都由标定的 `MotorCalibration(drive_mode, homing_offset, range_min, range_max)` 决定，校准后 leader 输出与 follower 输入都在同一个归一化空间。
+
+---
+
+## PR 提交指南
+
+### 步骤 1：Fork 并克隆
+
+```bash
+# Fork huggingface/lerobot 到你自己的 GitHub 账号
+git clone https://github.com/你的用户名/lerobot.git
+cd lerobot
+git remote add upstream https://github.com/huggingface/lerobot.git
+git fetch upstream
+git checkout -b add-nexarm-support upstream/main
+```
+
+### 步骤 2：复制 NexArm 文件
+
+将本仓库中的 NexArm 相关文件复制到你 fork 的仓库中：
+
+```bash
+# 克隆本仓库
+git clone https://github.com/liangfuyuan581-creator/lerobot-nexarm.git
+
+# 从本仓库复制 NexArm 相关文件到你 fork 的 lerobot
+cp -r lerobot-nexarm/src/lerobot/motors/nexarm           lerobot/src/lerobot/motors/
+cp -r lerobot-nexarm/src/lerobot/robots/nexarm_follower  lerobot/src/lerobot/robots/
+cp -r lerobot-nexarm/src/lerobot/teleoperators/nexarm_leader  lerobot/src/lerobot/teleoperators/
+cp -r lerobot-nexarm/examples/nexarm                     lerobot/examples/
+cp -r lerobot-nexarm/tests/motors/test_nexarm.py         lerobot/tests/motors/
+cp -r lerobot-nexarm/tests/robots/test_nexarm_follower.py  lerobot/tests/robots/
+cp -r lerobot-nexarm/tests/teleoperators/test_nexarm_leader.py  lerobot/tests/teleoperators/
+```
+
+### 步骤 3：修改已有文件
+
+参考本仓库中已修改的文件，对你 fork 的仓库做同样的修改：
+
+1. `src/lerobot/robots/utils.py` — 添加 `nexarm_follower` 分支
+2. `src/lerobot/teleoperators/utils.py` — 添加 `nexarm_leader` 分支
+3. `pyproject.toml` — 添加 `nexarm` 依赖项
+
+### 步骤 4：安装并测试
+
+```bash
+pip install -e ".[nexarm,dev]"
+
+# 代码风格检查
+pre-commit install
+pre-commit run --all-files
+
+# 运行测试
+pytest tests/ -v
+```
+
+### 步骤 5：提交 PR
+
+```bash
+git add -A
+git commit -m "Add NexArm 6-DOF robot arm support (follower + leader)"
+git push origin add-nexarm-support
+```
+
+在 GitHub 上创建 Pull Request，标题和描述建议：
+
+- **标题：** `Add NexArm 6-DOF robot arm support`
+- **描述：** 包含硬件简介、测试结果截图（遥操作、训练曲线、推理视频链接）
+
+---
+
+## 常见问题排查
+
+### 串口权限不足 (Linux)
+
+```bash
+sudo usermod -a -G dialout $USER
+# 需要注销并重新登录
+```
+
+### 找不到摄像头
+
+- 运行 `lerobot_find_cameras` 扫描可用索引
+- Windows 上关闭其他占用摄像头的程序（OBS、浏览器等）
+- 重新插拔 USB 后摄像头索引可能会变
+
+### 遥操作时从臂不动
+
+1. 检查从臂的 COM 端口是否正确
+2. 确认从臂 ESP32 固件支持 CMD 68（LeRobot 桥接模式）
+3. 尝试重新给从臂上电
+
+### 采集数据时主臂报 TimeoutError
+
+```
+TimeoutError: No position reply from NexArm
+```
+
+**原因 1：** 旧版主臂固件在 LeRobot 模式下仍会通过 Serial 打印 `[WARN]`、`[POS]` 调试信息，这些文本会污染协议帧；同时 LeRobot 模式下还会跑 ESPNow 读舵机循环，与 CMD 96 抢占 Serial1。
+
+**解决方案：** 本仓库已修复主臂固件 `Nex_Arm_sys/Nex_Arm.ino`，在 LeRobot 模式下直接 `return`，让出 Serial1 和 USB Serial。重新烧录主臂固件即可。
+
+**原因 2：** 旧版从臂固件 `Nex_Arm/system_task_handle.cpp` 使用 `volatile bool servo_uart_busy` 自旋等待 AT32 总线，两个核心同时进入会形成竞态，AT32 返回的帧错乱被 PC 端解析失败。
+
+**解决方案：** 本仓库已把锁换成 FreeRTOS mutex（`servo_uart_lock()` / `servo_uart_unlock()`）。重新烧录从臂固件即可。
+
+修复后单次读 < 25ms，30 Hz 帧率有充足余量。
+
+### 训练 loss 不下降
+
+- 确保有足够的示范 episode（建议 50+ 个）
+- 检查数据集中的摄像头画面是否正常（非黑屏/模糊）
+- 尝试提高学习率（如 `--policy.optimizer_lr=1e-4`）
+
+### 推理时机械臂犹犹豫豫/动作幅度很小
+
+这通常是模型"坍缩到均值"——输出的动作接近训练数据的平均值，没有学到完整的时序轨迹。排查和调整方法：
+
+**1. 检查训练数据质量**
+
+```bash
+# 查看数据集统计，确认 observation.state 和 action 的值范围接近
+python -c "
+from safetensors.torch import load_file
+stats = load_file('outputs/train/nexarm_act/checkpoints/last/pretrained_model/policy_preprocessor_step_3_normalizer_processor.safetensors')
+print('state mean:', stats['observation.state.mean'].tolist())
+print('action mean:', stats['action.mean'].tolist())
+# 两者应该很接近（差距 < 100），否则说明采集时位置反馈有问题
+"
+```
+
+**2. 增大 batch_size**
+
+batch_size 越大，VAE 的 latent space 学得越稳定，模型越不容易坍缩。
+
+```bash
+--batch_size=32    # 默认值，显存不足可用 16
+--batch_size=64    # 如果显存够（24GB+），效果更好
+```
+
+**3. 调整 kl_weight**
+
+kl_weight 控制 VAE 正则化强度。太大会让模型输出过于保守（接近均值），太小会让动作不连贯。
+
+```bash
+--policy.kl_weight=10.0   # 默认值
+--policy.kl_weight=5.0    # 如果动作太保守，尝试降低
+--policy.kl_weight=1.0    # 进一步降低，让模型更大胆
+```
+
+**4. 提高学习率**
+
+默认 1e-5 比较保守，可以适当提高：
+
+```bash
+--policy.optimizer_lr=5e-5     # 适度提高
+--policy.optimizer_lr=1e-4     # 更激进，注意观察 loss 是否震荡
+```
+
+**5. 增加训练步数**
+
+如果 loss 还在下降但还没收敛：
+
+```bash
+--steps=200000    # 从 100k 增加到 200k
+```
+
+**6. 增加训练数据**
+
+50 个 episode 是下限。如果任务复杂（多步骤、多物体），建议：
+
+```bash
+--dataset.num_episodes=100    # 或更多
+```
+
+**7. 确保采集数据动作一致**
+
+- 每个 episode 都应包含完整的任务动作（伸手→抓取→抬起→放置）
+- 起始位置尽量一致
+- 避免 episode 中有大量空闲/等待时间
+- 动作速度保持均匀，不要忽快忽慢
+
+### CPU 推理帧率低于预期
+
+ACT 策略使用 action chunking（chunk_size=100），正常情况下 CPU 也能达到 20-30 Hz。如果帧率异常低：
+
+- 确认 `inference.yaml` 中设置了 `device: cpu`
+- 检查是否有其他程序占用 CPU（如后台编码、杀毒软件）
+- 双摄像头采集本身需要 ~45ms，这是正常开销
+
+### 串口通信校验和错误
+
+主臂固件存在一个已知的校验和 bug（`tx_packet_complete` 使用了 `rx_packet.elements.length` 而非 `tx_packet.elements.length`）。驱动程序同时接受正确和错误的校验和以保持兼容性。

--- a/examples/nexarm/inference.yaml
+++ b/examples/nexarm/inference.yaml
@@ -1,0 +1,41 @@
+# NexArm inference - sentry recording, no display
+robot:
+  type: nexarm_follower
+  port: COM9  # Windows: COM9  |  Linux: /dev/ttyUSB0  |  macOS: /dev/tty.usbserial-120
+  baudrate: 1000000
+  cameras:
+    front:
+      type: opencv
+      index_or_path: 1  # Windows: 1  |  Linux: /dev/video0  |  macOS: 0
+      width: 640
+      height: 480
+      fps: 30
+    wrist:
+      type: opencv
+      index_or_path: 2  # Windows: 2  |  Linux: /dev/video2  |  macOS: 1
+      width: 640
+      height: 480
+      fps: 30
+
+strategy:
+  type: sentry
+  upload_every_n_episodes: 999
+
+dataset:
+  repo_id: local/rollout_nexarm
+  single_task: "pick up the object"
+  push_to_hub: false
+  streaming_encoding: true
+  vcodec: h264_nvenc
+
+inference:
+  type: sync
+
+fps: 30
+duration: 60
+interpolation_multiplier: 2
+device: cuda
+task: "pick up the object"
+display_data: false
+play_sounds: false
+return_to_initial_position: false

--- a/examples/nexarm/inference_base.yaml
+++ b/examples/nexarm/inference_base.yaml
@@ -1,0 +1,34 @@
+# NexArm inference - base strategy, no recording
+robot:
+  type: nexarm_follower
+  port: COM8  # Windows: COM8  |  Linux: /dev/ttyUSB0  |  macOS: /dev/tty.usbserial-120
+  baudrate: 1000000
+  cameras:
+    front:
+      type: opencv
+      index_or_path: 1  # Windows: 1  |  Linux: /dev/video0  |  macOS: 0
+      width: 640
+      height: 480
+      fps: 30
+      fourcc: MJPG  # MJPG starts faster than YUYV on Linux V4L2
+    wrist:
+      type: opencv
+      index_or_path: 2  # Windows: 2  |  Linux: /dev/video2  |  macOS: 1
+      width: 640
+      height: 480
+      fps: 30
+      fourcc: MJPG
+
+strategy:
+  type: base
+
+inference:
+  type: sync
+
+fps: 30
+duration: 60
+device: cpu
+task: "pick up the object"
+display_data: false
+play_sounds: false
+return_to_initial_position: false

--- a/examples/nexarm/jetson_inference.yaml
+++ b/examples/nexarm/jetson_inference.yaml
@@ -1,0 +1,46 @@
+# NexArm inference config (Jetson) - sentry recording, no display
+# Usage: python -m lerobot.scripts.lerobot_rollout --config_path=examples/nexarm/jetson_inference.yaml \
+#        --policy.path=outputs/train/nexarm_act/checkpoints/last/pretrained_model
+
+robot:
+  type: nexarm_follower
+  port: /dev/ttyCH341USB0
+  baudrate: 1000000
+  cameras:
+    wrist:
+      type: opencv
+      index_or_path: /dev/video0
+      width: 640
+      height: 480
+      fps: 30
+      fourcc: YUYV
+    front:
+      type: opencv
+      index_or_path: /dev/video2
+      width: 640
+      height: 480
+      fps: 30
+      fourcc: MJPG
+
+strategy:
+  type: sentry
+  upload_every_n_episodes: 999
+
+dataset:
+  repo_id: local/rollout_nexarm
+  single_task: "pick up the object"
+  push_to_hub: false
+  streaming_encoding: true
+  vcodec: h264_nvenc
+
+inference:
+  type: sync
+
+fps: 30
+duration: 60
+interpolation_multiplier: 2
+device: cuda
+task: "pick up the object"
+display_data: false
+play_sounds: false
+return_to_initial_position: false

--- a/examples/nexarm/jetson_record.yaml
+++ b/examples/nexarm/jetson_record.yaml
@@ -1,0 +1,46 @@
+# NexArm dataset recording config (Jetson)
+# Usage: python -m lerobot.scripts.lerobot_record --config_path=examples/nexarm/jetson_record.yaml
+#
+# Hardware:
+#   /dev/ttyCH341USB0  ← follower (slave) ESP32  (插入顺序：第一个)
+#   /dev/ttyCH341USB1  ← leader  (master) ESP32  (插入顺序：第二个)
+#   /dev/video0        ← wrist (YUYV only)
+#   /dev/video2        ← front (MJPG capable)
+
+robot:
+  type: nexarm_follower
+  port: /dev/ttyCH341USB0
+  baudrate: 1000000
+  cameras:
+    wrist:
+      type: opencv
+      index_or_path: /dev/video0
+      width: 640
+      height: 480
+      fps: 30
+      fourcc: YUYV
+    front:
+      type: opencv
+      index_or_path: /dev/video2
+      width: 640
+      height: 480
+      fps: 30
+      fourcc: MJPG
+
+teleop:
+  type: nexarm_leader
+  port: /dev/ttyCH341USB1
+  baudrate: 1000000
+
+dataset:
+  repo_id: local/nexarm_pick
+  single_task: "pick up the object"
+  num_episodes: 10
+  episode_time_s: 20
+  reset_time_s: 10
+  fps: 30
+  video: true
+  push_to_hub: false
+
+display_data: false
+play_sounds: true

--- a/examples/nexarm/jetson_teleoperate.yaml
+++ b/examples/nexarm/jetson_teleoperate.yaml
@@ -1,0 +1,36 @@
+# NexArm teleoperation config (Jetson + 2 cameras)
+# Usage: python -m lerobot.scripts.lerobot_teleoperate --config_path=examples/nexarm/jetson_teleoperate.yaml
+#
+# Hardware:
+#   /dev/ttyCH341USB0  ← follower (slave) ESP32
+#   /dev/ttyCH341USB1  ← leader  (master) ESP32
+#   /dev/video0        ← first-person camera (YUYV only)
+#   /dev/video2        ← third-person camera (MJPG capable)
+
+robot:
+  type: nexarm_follower
+  port: /dev/ttyCH341USB0
+  baudrate: 1000000
+  cameras:
+    wrist:
+      type: opencv
+      index_or_path: /dev/video0
+      width: 640
+      height: 480
+      fps: 30
+      fourcc: YUYV
+    front:
+      type: opencv
+      index_or_path: /dev/video2
+      width: 640
+      height: 480
+      fps: 30
+      fourcc: MJPG
+
+teleop:
+  type: nexarm_leader
+  port: /dev/ttyCH341USB1
+  baudrate: 1000000
+
+display_data: false
+fps: 30

--- a/examples/nexarm/record.yaml
+++ b/examples/nexarm/record.yaml
@@ -1,0 +1,42 @@
+# NexArm dataset recording config
+# Usage: python -m lerobot.scripts.lerobot_record --config_path=examples/nexarm/record.yaml
+
+robot:
+  type: nexarm_follower
+  port: COM19          # Follower (slave) ESP32 serial port
+                       # Windows: COM19  |  Linux: /dev/ttyUSB1  |  macOS: /dev/tty.usbserial-120
+  baudrate: 1000000
+  cameras:
+    front:
+      type: opencv
+      index_or_path: 1  # Windows: 1  |  Linux: /dev/video0  |  macOS: 0
+      width: 640
+      height: 480
+      fps: 30
+      fourcc: MJPG
+    wrist:
+      type: opencv
+      index_or_path: 2  # Windows: 2  |  Linux: /dev/video2  |  macOS: 1
+      width: 640
+      height: 480
+      fps: 30
+      fourcc: MJPG
+
+teleop:
+  type: nexarm_leader
+  port: COM18          # Leader (master) ESP32 serial port
+                       # Windows: COM18  |  Linux: /dev/ttyUSB0  |  macOS: /dev/tty.usbserial-110
+  baudrate: 1000000
+
+dataset:
+  repo_id: local/nexarm_pick
+  single_task: "pick up the object"
+  num_episodes: 50
+  episode_time_s: 10
+  reset_time_s: 10
+  fps: 30
+  video: true
+  push_to_hub: false
+
+display_data: false
+play_sounds: true

--- a/examples/nexarm/teleoperate.yaml
+++ b/examples/nexarm/teleoperate.yaml
@@ -1,0 +1,32 @@
+# NexArm teleoperation config
+# Usage: python -m lerobot.scripts.lerobot_teleoperate --config_path=examples/nexarm/teleoperate.yaml
+
+robot:
+  type: nexarm_follower
+  port: COM19          # Follower (slave) ESP32 serial port
+                       # Windows: COM19  |  Linux: /dev/ttyUSB1  |  macOS: /dev/tty.usbserial-120
+  baudrate: 1000000
+  cameras:
+    front:
+      type: opencv
+      index_or_path: 1  # Windows: 1  |  Linux: /dev/video0  |  macOS: 0
+      width: 640
+      height: 480
+      fps: 30
+      fourcc: MJPG
+    wrist:
+      type: opencv
+      index_or_path: 2  # Windows: 2  |  Linux: /dev/video2  |  macOS: 1
+      width: 640
+      height: 480
+      fps: 30
+      fourcc: MJPG
+
+teleop:
+  type: nexarm_leader
+  port: COM18          # Leader (master) ESP32 serial port
+                       # Windows: COM18  |  Linux: /dev/ttyUSB0  |  macOS: /dev/tty.usbserial-110
+  baudrate: 1000000
+
+display_data: false
+fps: 30

--- a/examples/nexarm/train.json
+++ b/examples/nexarm/train.json
@@ -1,0 +1,19 @@
+{
+  "dataset": {
+    "repo_id": "local/nexarm_pick"
+  },
+  "policy": {
+    "type": "act"
+  },
+  "output_dir": "outputs/train/nexarm_act",
+  "job_name": "nexarm_act",
+  "seed": 1000,
+  "batch_size": 32,
+  "steps": 100000,
+  "save_freq": 25000,
+  "log_freq": 100,
+  "eval_freq": 25000,
+  "wandb": {
+    "enable": false
+  }
+}

--- a/examples/nexarm/train.yaml
+++ b/examples/nexarm/train.yaml
@@ -1,0 +1,20 @@
+# NexArm training config (ACT policy)
+# Usage: python -m lerobot.scripts.lerobot_train --config_path=examples/nexarm/train.yaml
+
+dataset:
+  repo_id: local/nexarm_pick
+
+policy:
+  type: act
+
+output_dir: outputs/train/nexarm_act
+job_name: nexarm_act
+seed: 1000
+batch_size: 32
+steps: 100000
+save_freq: 25000
+log_freq: 100
+eval_freq: 25000
+
+wandb:
+  enable: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,6 +196,7 @@ reachy2 = [
 # Seeed Studio reBot B601-DM follower (motorbridge / CAN) + StarArm102 / reBot Arm 102
 # leader (motorbridge-smart-servo / FashionStar UART servos).
 rebot = ["lerobot[motorbridge-dep]", "lerobot[motorbridge-smart-servo-dep]"]
+nexarm = ["lerobot[pyserial-dep]", "lerobot[av-dep]"]
 kinematics = ["lerobot[placo-dep]"]
 intelrealsense = [
     "pyrealsense2>=2.55.1.6486,<2.57.0 ; sys_platform != 'darwin'",

--- a/src/lerobot/motors/nexarm/__init__.py
+++ b/src/lerobot/motors/nexarm/__init__.py
@@ -1,0 +1,17 @@
+# Copyright 2024 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .nexarm import NexArmMotorsBus
+
+__all__ = ["NexArmMotorsBus"]

--- a/src/lerobot/motors/nexarm/nexarm.py
+++ b/src/lerobot/motors/nexarm/nexarm.py
@@ -1,0 +1,655 @@
+# Copyright 2024 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""NexArm motor bus driver.
+
+NexArm uses a custom CommProtocol over USB serial at 1 Mbps.
+Frame format: [0xFF][0xFF][ID][LEN][CMD][ARGS...][CHECKSUM]
+
+The leader (master) ESP32 directly drives HX-30HM servos.
+The follower (slave) ESP32 forwards commands through an AT32F421 co-processor
+to the same servos.
+
+The bus only exposes Present_Position / Goal_Position on the standard
+``MotorsBusBase`` interface; it does not use Dynamixel/Feetech SDK port handlers
+because the wire protocol is custom. Calibration (homing_offset / range_min /
+range_max) and normalisation (DEGREES, RANGE_0_100, RANGE_M100_100) are
+implemented directly so that follower/leader code matches the official
+SO-100/SO-101 flow.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import struct
+import threading
+import time
+from collections.abc import Sequence
+from pprint import pformat
+from typing import TYPE_CHECKING
+
+from lerobot.utils.decorators import check_if_already_connected, check_if_not_connected
+from lerobot.utils.import_utils import _serial_available, require_package
+from lerobot.utils.utils import enter_pressed, move_cursor_up
+
+if TYPE_CHECKING or _serial_available:
+    import serial
+else:
+    serial = None  # type: ignore[assignment]
+
+from ..motors_bus import (
+    Motor,
+    MotorCalibration,
+    MotorNormMode,
+    MotorsBusBase,
+    NameOrID,
+    Value,
+)
+
+logger = logging.getLogger(__name__)
+
+SYSTEM_ID = 0xFF
+
+CMD_LEROBOT_MODE = 68
+CMD_READ_POS = 96
+CMD_WRITE_POS = 97
+CMD_TORQUE = 98
+CMD_SET_MOTION_PARAMS = 56
+
+JOINT_COUNT = 6
+JOINT_NAMES = (
+    "shoulder_pan",
+    "shoulder_lift",
+    "elbow_flex",
+    "wrist_flex",
+    "wrist_roll",
+    "gripper",
+)
+
+MODEL = "hx30hm"
+MODEL_RESOLUTION = 4096
+POSITION_MIN = 0
+POSITION_MAX = MODEL_RESOLUTION - 1
+HALF_TURN = MODEL_RESOLUTION // 2
+
+DEFAULT_BAUDRATE = 1_000_000
+DEFAULT_TIMEOUT = 0.05
+REPLY_TIMEOUT = 0.15
+
+
+def build_frame(device_id: int, cmd: int, args: bytes = b"") -> bytes:
+    length = len(args) + 2
+    data_raw = bytes([device_id & 0xFF, length & 0xFF, cmd & 0xFF]) + args
+    checksum = (~sum(data_raw)) & 0xFF
+    return b"\xff\xff" + data_raw + bytes([checksum])
+
+
+def parse_frame(data: bytes) -> tuple[int, int, bytes] | None:
+    """Parse a CommProtocol frame. Returns (id, cmd, args) or None.
+
+    Accepts both the correct full-range checksum and the short checksum from
+    the leader firmware (``tx_packet_complete`` uses ``rx_packet.elements.length``
+    instead of ``tx_packet.elements.length``).
+    """
+    if len(data) < 6 or data[0] != 0xFF or data[1] != 0xFF:
+        return None
+    device_id = data[2]
+    length = data[3]
+    total = 4 + length
+    if len(data) < total:
+        return None
+    cmd = data[4]
+    n = length - 2
+    args = data[5 : 5 + n]
+    checksum_byte = data[total - 1]
+    expected_full = (~sum(data[2 : total - 1])) & 0xFF
+    expected_short = (~sum(data[2:5])) & 0xFF
+    if checksum_byte != expected_full and checksum_byte != expected_short:
+        return None
+    return (device_id, cmd, bytes(args))
+
+
+class NexArmMotorsBus(MotorsBusBase):
+    """Bus driver for NexArm 6-DOF arms (leader or follower).
+
+    Implements the subset of the official ``MotorsBusBase`` API needed for
+    teleoperation and policy inference: ``sync_read("Present_Position")``,
+    ``sync_write("Goal_Position", ...)``, torque enable/disable, calibration
+    with ``set_half_turn_homings`` and ``record_ranges_of_motion``.
+
+    Unlike Dynamixel/Feetech buses, NexArm has no per-register access; the
+    embedded firmware exposes only a small command set. ``read``/``write`` and
+    ``sync_read``/``sync_write`` therefore only accept ``"Present_Position"``
+    and ``"Goal_Position"`` data names.
+    """
+
+    model_resolution_table = {MODEL: MODEL_RESOLUTION}
+    apply_drive_mode = True
+
+    def __init__(
+        self,
+        port: str,
+        motors: dict[str, Motor] | None = None,
+        calibration: dict[str, MotorCalibration] | None = None,
+        baudrate: int = DEFAULT_BAUDRATE,
+        timeout: float = DEFAULT_TIMEOUT,
+    ):
+        require_package("pyserial", extra="nexarm", import_name="serial")
+        if motors is None:
+            motors = self.default_motors()
+        super().__init__(port, motors, calibration)
+        self.baudrate = baudrate
+        self.timeout = timeout
+        self._serial: serial.Serial | None = None
+        self._lock = threading.Lock()
+        self._id_to_name_dict = {m.id: name for name, m in self.motors.items()}
+        self._name_to_id_dict = {name: m.id for name, m in self.motors.items()}
+        self._ordered_names: list[str] = sorted(self.motors, key=lambda n: self.motors[n].id)
+        self._validate_motors()
+
+    @staticmethod
+    def default_motors() -> dict[str, Motor]:
+        norm = MotorNormMode.RANGE_M100_100
+        gripper_norm = MotorNormMode.RANGE_0_100
+        return {
+            "shoulder_pan": Motor(id=1, model=MODEL, norm_mode=norm),
+            "shoulder_lift": Motor(id=2, model=MODEL, norm_mode=norm),
+            "elbow_flex": Motor(id=3, model=MODEL, norm_mode=norm),
+            "wrist_flex": Motor(id=4, model=MODEL, norm_mode=norm),
+            "wrist_roll": Motor(id=5, model=MODEL, norm_mode=norm),
+            "gripper": Motor(id=6, model=MODEL, norm_mode=gripper_norm),
+        }
+
+    def _validate_motors(self) -> None:
+        ids = [m.id for m in self.motors.values()]
+        if len(ids) != len(set(ids)):
+            raise ValueError(f"Some motors have the same id: {ids}")
+        for name in self._ordered_names:
+            if self.motors[name].model != MODEL:
+                raise ValueError(
+                    f"NexArm only supports model '{MODEL}', got '{self.motors[name].model}' for {name!r}"
+                )
+
+    def __repr__(self):
+        return (
+            f"{self.__class__.__name__}(\n"
+            f"    Port: '{self.port}',\n"
+            f"    Motors: \n{pformat(self.motors, indent=8, sort_dicts=False)},\n"
+            ")',\n"
+        )
+
+    @property
+    def is_connected(self) -> bool:
+        return self._serial is not None and self._serial.is_open
+
+    @property
+    def is_calibrated(self) -> bool:
+        if not self.calibration:
+            return False
+        for name in self.motors:
+            c = self.calibration.get(name)
+            if c is None or c.range_min == c.range_max:
+                return False
+        return True
+
+    def connect(self, handshake: bool = True) -> None:
+        if self.is_connected:
+            return
+        try:
+            self._serial = serial.Serial(
+                port=self.port,
+                baudrate=self.baudrate,
+                timeout=self.timeout,
+                write_timeout=self.timeout,
+            )
+        except (FileNotFoundError, OSError, serial.SerialException) as e:
+            raise ConnectionError(
+                f"Could not connect on port '{self.port}'. "
+                "Make sure you are using the correct port (try `lerobot-find-port`)."
+            ) from e
+        time.sleep(0.1)
+        self._serial.reset_input_buffer()
+        logger.info(f"NexArmMotorsBus connected on {self.port}")
+        if handshake:
+            self._handshake()
+
+    def _handshake(self) -> None:
+        try:
+            self._raw_read_positions()
+        except TimeoutError as e:
+            raise ConnectionError(
+                f"NexArm handshake failed on '{self.port}': no position reply. "
+                "Check that the arm is powered and in LeRobot bridge mode."
+            ) from e
+
+    def handshake(self) -> None:
+        self._handshake()
+
+    def disconnect(self, disable_torque: bool = True) -> None:
+        if self._serial is None:
+            return
+        if disable_torque:
+            with contextlib.suppress(Exception):
+                self.disable_torque()
+        with contextlib.suppress(Exception):
+            self._serial.close()
+        self._serial = None
+        logger.info(f"NexArmMotorsBus disconnected from {self.port}")
+
+    # ── Low-level frame I/O ────────────────────────────────────────────
+
+    def _send(
+        self,
+        frame: bytes,
+        expect_reply: bool = True,
+        reply_timeout: float = REPLY_TIMEOUT,
+    ) -> tuple[int, bytes] | None:
+        if self._serial is None:
+            raise ConnectionError("Serial port not open")
+        with self._lock:
+            self._serial.reset_input_buffer()
+            self._serial.write(frame)
+            if not expect_reply:
+                return None
+            return self._read_reply(reply_timeout)
+
+    def _read_reply(self, timeout: float) -> tuple[int, bytes] | None:
+        assert self._serial is not None
+        buf = bytearray()
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            avail = self._serial.in_waiting
+            if avail:
+                buf.extend(self._serial.read(avail))
+                result = self._try_parse(buf)
+                if result is not None:
+                    return result
+            else:
+                time.sleep(0.001)
+        return None
+
+    def _try_parse(self, buf: bytearray) -> tuple[int, bytes] | None:
+        while len(buf) >= 6:
+            idx = bytes(buf).find(b"\xff\xff")
+            if idx < 0:
+                buf.clear()
+                return None
+            if idx > 0:
+                del buf[:idx]
+            if len(buf) < 4:
+                return None
+            length = buf[3]
+            total = 4 + length
+            if len(buf) < total:
+                return None
+            parsed = parse_frame(bytes(buf[:total]))
+            if parsed is not None:
+                del buf[:total]
+                return (parsed[1], parsed[2])
+            else:
+                del buf[:2]
+        return None
+
+    def _raw_read_positions(self, retries: int = 3) -> list[int]:
+        """Read 6 raw servo positions via CMD 96, retrying on garbled replies.
+
+        The leader firmware's short-checksum bug leaves the 12 position bytes
+        unverified, so a bit flip on the 1 Mbps bus can slip past parse_frame.
+        HX30HM is a 12-bit encoder, so any value outside [0, 4095] is
+        physically impossible — reject the frame and retry instead of
+        clamping (which would poison record_ranges_of_motion's min/max).
+        """
+        for attempt in range(retries):
+            frame = build_frame(SYSTEM_ID, CMD_READ_POS)
+            result = self._send(frame, reply_timeout=REPLY_TIMEOUT)
+            if result is not None:
+                _, args = result
+                if len(args) >= JOINT_COUNT * 2:
+                    raw = [struct.unpack_from("<h", args, i * 2)[0] for i in range(JOINT_COUNT)]
+                    if all(POSITION_MIN <= v <= POSITION_MAX for v in raw):
+                        return raw
+            if attempt < retries - 1:
+                time.sleep(0.005)
+        raise TimeoutError("No valid position reply from NexArm")
+
+    def _raw_write_positions(self, positions_by_id: dict[int, int]) -> None:
+        """Write 6 raw servo positions via CMD 97 (sync write, no reply).
+
+        Missing IDs default to the last known target (or mid-range on first call).
+        """
+        if not hasattr(self, "_last_goal_raw"):
+            self._last_goal_raw = [HALF_TURN] * JOINT_COUNT
+        for i in range(JOINT_COUNT):
+            id_ = i + 1
+            if id_ in positions_by_id:
+                self._last_goal_raw[i] = max(
+                    POSITION_MIN, min(POSITION_MAX, int(round(positions_by_id[id_])))
+                )
+        args = b"".join(struct.pack("<h", self._last_goal_raw[i]) for i in range(JOINT_COUNT))
+        frame = build_frame(SYSTEM_ID, CMD_WRITE_POS, args)
+        self._send(frame, expect_reply=False)
+
+    # ── LeRobot-mode control ──────────────────────────────────────────
+
+    def enter_lerobot_mode(self) -> None:
+        frame = build_frame(SYSTEM_ID, CMD_LEROBOT_MODE, bytes([1]))
+        self._send(frame, expect_reply=False)
+        time.sleep(0.1)
+
+    def exit_lerobot_mode(self) -> None:
+        frame = build_frame(SYSTEM_ID, CMD_LEROBOT_MODE, bytes([0]))
+        self._send(frame, expect_reply=False)
+        time.sleep(0.1)
+
+    def write_motion_params(self, acc: int, speed: int = 0) -> None:
+        """Set per-frame servo acceleration and max speed (CMD 56).
+
+        acc:   0-254. 0 = max acceleration, ~100 is a smooth default.
+        speed: 0-3400 raw units/s. 0 = no limit (full speed).
+        """
+        acc = max(0, min(254, int(acc)))
+        speed = max(0, min(3400, int(speed)))
+        args = bytes([acc & 0xFF, speed & 0xFF, (speed >> 8) & 0xFF])
+        frame = build_frame(SYSTEM_ID, CMD_SET_MOTION_PARAMS, args)
+        self._send(frame, expect_reply=False)
+
+    # ── Torque ────────────────────────────────────────────────────────
+
+    # CMD 98 is fanned out by the AT32 co-processor to all 6 servos with no
+    # per-servo retry. On a noisy 1 Mbps half-duplex bus one servo (usually
+    # 5/6 — they sit at the end of the loop) can drop the write packet and
+    # stay enabled. Resend the frame ``_TORQUE_RESEND_TIMES`` times with a
+    # short gap so any single-frame loss is covered.
+    _TORQUE_RESEND_TIMES = 5
+    _TORQUE_RESEND_GAP = 0.02
+
+    def _send_torque(self, enable: bool) -> None:
+        frame = build_frame(SYSTEM_ID, CMD_TORQUE, bytes([1 if enable else 0]))
+        for _ in range(self._TORQUE_RESEND_TIMES):
+            self._send(frame, expect_reply=False)
+            time.sleep(self._TORQUE_RESEND_GAP)
+
+    @check_if_not_connected
+    def enable_torque(
+        self, motors: str | list[str] | None = None, num_retry: int = 0
+    ) -> None:
+        # NexArm only supports torque on/off for the whole bus.
+        _ = motors, num_retry
+        self._send_torque(True)
+
+    @check_if_not_connected
+    def disable_torque(
+        self, motors: str | list[str] | None = None, num_retry: int = 0
+    ) -> None:
+        _ = motors, num_retry
+        self._send_torque(False)
+
+    @contextlib.contextmanager
+    def torque_disabled(self, motors: str | list[str] | None = None):
+        self.disable_torque(motors)
+        try:
+            yield
+        finally:
+            self.enable_torque(motors)
+
+    # ── Standard read/write API ───────────────────────────────────────
+
+    def _get_motors_list(self, motors: NameOrID | Sequence[NameOrID] | None) -> list[str]:
+        if motors is None:
+            return list(self._ordered_names)
+        if isinstance(motors, str):
+            return [motors]
+        if isinstance(motors, int):
+            return [self._id_to_name_dict[motors]]
+        return [m if isinstance(m, str) else self._id_to_name_dict[m] for m in motors]
+
+    def _check_data_name(self, data_name: str) -> None:
+        if data_name not in ("Present_Position", "Goal_Position"):
+            raise NotImplementedError(
+                f"NexArmMotorsBus only supports 'Present_Position' and 'Goal_Position', got {data_name!r}"
+            )
+
+    @check_if_not_connected
+    def read(self, data_name: str, motor: str) -> Value:
+        self._check_data_name(data_name)
+        if data_name != "Present_Position":
+            raise NotImplementedError(f"NexArmMotorsBus.read does not support {data_name!r}")
+        values = self.sync_read("Present_Position", [motor])
+        return values[motor]
+
+    @check_if_not_connected
+    def write(self, data_name: str, motor: str, value: Value) -> None:
+        self._check_data_name(data_name)
+        if data_name != "Goal_Position":
+            raise NotImplementedError(f"NexArmMotorsBus.write does not support {data_name!r}")
+        self.sync_write("Goal_Position", {motor: value})
+
+    @check_if_not_connected
+    def sync_read(
+        self,
+        data_name: str,
+        motors: NameOrID | Sequence[NameOrID] | None = None,
+        *,
+        normalize: bool = True,
+    ) -> dict[str, Value]:
+        self._check_data_name(data_name)
+        if data_name != "Present_Position":
+            raise NotImplementedError(f"NexArmMotorsBus.sync_read does not support {data_name!r}")
+        names = self._get_motors_list(motors)
+        raw_all = self._raw_read_positions()
+        raw_by_name: dict[str, int] = {}
+        for name in names:
+            motor_id = self.motors[name].id
+            raw_by_name[name] = raw_all[motor_id - 1]
+        if not normalize or not self.calibration:
+            return {name: float(raw_by_name[name]) for name in names}
+        ids_values = {self.motors[name].id: raw_by_name[name] for name in names}
+        normalized = self._normalize(ids_values)
+        return {self._id_to_name_dict[id_]: normalized[id_] for id_ in ids_values}
+
+    @check_if_not_connected
+    def sync_write(
+        self,
+        data_name: str,
+        values: dict[str, Value],
+        *,
+        normalize: bool = True,
+    ) -> None:
+        self._check_data_name(data_name)
+        if data_name != "Goal_Position":
+            raise NotImplementedError(f"NexArmMotorsBus.sync_write does not support {data_name!r}")
+        if normalize and self.calibration:
+            ids_values = {self.motors[name].id: float(v) for name, v in values.items()}
+            raw_by_id = self._unnormalize(ids_values)
+        else:
+            raw_by_id = {
+                self.motors[name].id: max(POSITION_MIN, min(POSITION_MAX, int(round(float(v)))))
+                for name, v in values.items()
+            }
+        # Apply range_min/max clamp in raw space for safety.
+        for id_ in list(raw_by_id):
+            name = self._id_to_name_dict[id_]
+            cal = self.calibration.get(name)
+            if cal is not None and cal.range_min != cal.range_max:
+                raw_by_id[id_] = max(cal.range_min, min(cal.range_max, raw_by_id[id_]))
+            else:
+                raw_by_id[id_] = max(POSITION_MIN, min(POSITION_MAX, raw_by_id[id_]))
+        self._raw_write_positions(raw_by_id)
+
+    # ── Normalisation (mirrors SerialMotorsBus) ──────────────────────
+
+    def _normalize(self, ids_values: dict[int, int]) -> dict[int, float]:
+        if not self.calibration:
+            raise RuntimeError(f"{self} has no calibration registered.")
+        normalized: dict[int, float] = {}
+        for id_, val in ids_values.items():
+            name = self._id_to_name_dict[id_]
+            cal = self.calibration[name]
+            drive_mode = self.apply_drive_mode and cal.drive_mode
+            min_, max_ = cal.range_min, cal.range_max
+            if max_ == min_:
+                raise ValueError(f"Invalid calibration for motor '{name}': min == max")
+            bounded = min(max_, max(min_, val))
+            mode = self.motors[name].norm_mode
+            if mode is MotorNormMode.RANGE_M100_100:
+                norm = (((bounded - min_) / (max_ - min_)) * 200) - 100
+                normalized[id_] = -norm if drive_mode else norm
+            elif mode is MotorNormMode.RANGE_0_100:
+                norm = ((bounded - min_) / (max_ - min_)) * 100
+                normalized[id_] = 100 - norm if drive_mode else norm
+            elif mode is MotorNormMode.DEGREES:
+                mid = (min_ + max_) / 2
+                max_res = self.model_resolution_table[self.motors[name].model] - 1
+                deg = (val - mid) * 360 / max_res
+                normalized[id_] = -deg if drive_mode else deg
+            else:
+                raise NotImplementedError(mode)
+        return normalized
+
+    def _unnormalize(self, ids_values: dict[int, float]) -> dict[int, int]:
+        if not self.calibration:
+            raise RuntimeError(f"{self} has no calibration registered.")
+        unnormalized: dict[int, int] = {}
+        for id_, val in ids_values.items():
+            name = self._id_to_name_dict[id_]
+            cal = self.calibration[name]
+            drive_mode = self.apply_drive_mode and cal.drive_mode
+            min_, max_ = cal.range_min, cal.range_max
+            if max_ == min_:
+                raise ValueError(f"Invalid calibration for motor '{name}': min == max")
+            mode = self.motors[name].norm_mode
+            if mode is MotorNormMode.RANGE_M100_100:
+                v = -val if drive_mode else val
+                bounded = min(100.0, max(-100.0, v))
+                unnormalized[id_] = int(((bounded + 100) / 200) * (max_ - min_) + min_)
+            elif mode is MotorNormMode.RANGE_0_100:
+                v = 100 - val if drive_mode else val
+                bounded = min(100.0, max(0.0, v))
+                unnormalized[id_] = int((bounded / 100) * (max_ - min_) + min_)
+            elif mode is MotorNormMode.DEGREES:
+                mid = (min_ + max_) / 2
+                max_res = self.model_resolution_table[self.motors[name].model] - 1
+                v = -val if drive_mode else val
+                unnormalized[id_] = int((v * max_res / 360) + mid)
+            else:
+                raise NotImplementedError(mode)
+        return unnormalized
+
+    # ── Calibration helpers ───────────────────────────────────────────
+
+    def read_calibration(self) -> dict[str, MotorCalibration]:
+        """NexArm servos do not expose calibration registers; return cache."""
+        return dict(self.calibration)
+
+    def write_calibration(
+        self, calibration_dict: dict[str, MotorCalibration], cache: bool = True
+    ) -> None:
+        """NexArm servos do not expose calibration registers; only update cache."""
+        if cache:
+            self.calibration = dict(calibration_dict)
+
+    def reset_calibration(
+        self, motors: NameOrID | Sequence[NameOrID] | None = None
+    ) -> None:
+        names = self._get_motors_list(motors)
+        for name in names:
+            self.calibration[name] = MotorCalibration(
+                id=self.motors[name].id,
+                drive_mode=0,
+                homing_offset=0,
+                range_min=POSITION_MIN,
+                range_max=POSITION_MAX,
+            )
+
+    def set_half_turn_homings(
+        self, motors: NameOrID | Sequence[NameOrID] | None = None
+    ) -> dict[str, int]:
+        """Record the current position of each motor as its half-turn (mid) point.
+
+        The recorded value is stored as ``homing_offset = current_raw - HALF_TURN``.
+        ``range_min``/``range_max`` are left at full resolution until
+        :pymeth:`record_ranges_of_motion` runs.
+        """
+        names = self._get_motors_list(motors)
+        present = self.sync_read("Present_Position", names, normalize=False)
+        offsets: dict[str, int] = {}
+        for name in names:
+            raw = int(present[name])
+            offset = raw - HALF_TURN
+            existing = self.calibration.get(name)
+            drive_mode = existing.drive_mode if existing else 0
+            range_min = existing.range_min if existing else POSITION_MIN
+            range_max = existing.range_max if existing else POSITION_MAX
+            if range_min == range_max:
+                range_min, range_max = POSITION_MIN, POSITION_MAX
+            self.calibration[name] = MotorCalibration(
+                id=self.motors[name].id,
+                drive_mode=drive_mode,
+                homing_offset=offset,
+                range_min=range_min,
+                range_max=range_max,
+            )
+            offsets[name] = offset
+        return offsets
+
+    def record_ranges_of_motion(
+        self,
+        motors: NameOrID | Sequence[NameOrID] | None = None,
+        display_values: bool = True,
+    ) -> tuple[dict[str, int], dict[str, int]]:
+        """Stream live positions while the operator walks each joint through its full range.
+
+        Press ENTER to finish. Returns (min_dict, max_dict).
+        """
+        names = self._get_motors_list(motors)
+        start = self.sync_read("Present_Position", names, normalize=False)
+        mins = {name: int(start[name]) for name in names}
+        maxes = dict(mins)
+
+        done = False
+        while not done:
+            positions = self.sync_read("Present_Position", names, normalize=False)
+            for name in names:
+                p = int(positions[name])
+                mins[name] = min(mins[name], p)
+                maxes[name] = max(maxes[name], p)
+            if display_values:
+                print("\n-------------------------------------------")
+                print(f"{'NAME':<15} | {'MIN':>6} | {'POS':>6} | {'MAX':>6}")
+                for name in names:
+                    print(
+                        f"{name:<15} | {mins[name]:>6} | {int(positions[name]):>6} | {maxes[name]:>6}"
+                    )
+            if enter_pressed():
+                done = True
+            if display_values and not done:
+                move_cursor_up(len(names) + 3)
+
+        same = [n for n in names if mins[n] == maxes[n]]
+        if same:
+            raise ValueError(
+                f"Some motors have identical min and max — did the joint move? {pformat(same)}"
+            )
+
+        for name in names:
+            existing = self.calibration.get(name)
+            self.calibration[name] = MotorCalibration(
+                id=self.motors[name].id,
+                drive_mode=existing.drive_mode if existing else 0,
+                homing_offset=existing.homing_offset if existing else 0,
+                range_min=mins[name],
+                range_max=maxes[name],
+            )
+        return mins, maxes

--- a/src/lerobot/robots/nexarm_follower/__init__.py
+++ b/src/lerobot/robots/nexarm_follower/__init__.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+
+# Copyright 2024 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .config_nexarm_follower import NexArmFollowerConfig
+from .nexarm_follower import NexArmFollower
+
+__all__ = ["NexArmFollower", "NexArmFollowerConfig"]

--- a/src/lerobot/robots/nexarm_follower/config_nexarm_follower.py
+++ b/src/lerobot/robots/nexarm_follower/config_nexarm_follower.py
@@ -1,0 +1,44 @@
+# Copyright 2024 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass, field
+
+from lerobot.cameras import CameraConfig
+
+from ..config import RobotConfig
+
+
+@RobotConfig.register_subclass("nexarm_follower")
+@dataclass
+class NexArmFollowerConfig(RobotConfig):
+    """Configuration for the NexArm follower (slave) robot.
+
+    Attributes:
+        port: Serial port for the slave ESP32 (e.g. "COM19", "/dev/ttyUSB1").
+        baudrate: Serial baud rate. NexArm uses 1 Mbps.
+        disable_torque_on_disconnect: If True, disable servo torque on disconnect.
+        max_relative_target: Per-step ceiling on |goal - present|. Float applies
+            uniformly; dict applies per joint name. ``None`` disables clamping.
+        motion_acc: CMD 56 acceleration for every CMD 97 write. 0 = max accel.
+        motion_speed: CMD 56 speed limit (raw units/s). 0 = no limit.
+        cameras: Camera configs keyed by name (e.g. ``front``, ``wrist``).
+    """
+
+    port: str
+    baudrate: int = 1_000_000
+    disable_torque_on_disconnect: bool = True
+    max_relative_target: float | dict[str, float] | None = None
+    motion_acc: int = 100
+    motion_speed: int = 2000
+    cameras: dict[str, CameraConfig] = field(default_factory=dict)

--- a/src/lerobot/robots/nexarm_follower/nexarm.mdx
+++ b/src/lerobot/robots/nexarm_follower/nexarm.mdx
@@ -1,0 +1,237 @@
+# NexArm
+
+NexArm is a 6-DOF desktop robot arm built on an ESP32 + AT32F421 co-processor
+architecture, using HX-30HM serial bus servos with 12-bit precision (0–4095) and
+1 Mbps communication. It is designed for imitation learning research and supports
+leader-follower teleoperation, dataset recording, and policy inference with LeRobot.
+
+## Hardware Overview
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| **Leader arm** | ESP32 dev board directly driving 6 HX-30HM servos. Used for teleoperation — the operator freely drags this arm. |
+| **Follower arm** | ESP32 dev board + AT32F421 co-processor driving 6 HX-30HM servos. Mirrors the leader or executes policy outputs. |
+| **Servos** | HX-30HM high-performance serial bus servos — 12-bit resolution (0–4095), 1 Mbps baud rate, high torque and fast response. |
+| **Cameras** | 2 USB cameras — `front` (workspace overview) and `wrist` (end-effector close-up), 640×480 @ 30 fps. |
+
+### Joint Layout
+
+| Joint ID | Name | Description |
+|----------|------|-------------|
+| 1 | `shoulder_pan` | Base rotation |
+| 2 | `shoulder_lift` | Mirrored between leader and follower — handled automatically by calibration |
+| 3 | `elbow_flex` | Elbow joint |
+| 4 | `wrist_flex` | Wrist pitch |
+| 5 | `wrist_roll` | Wrist rotation |
+| 6 | `gripper` | Gripper open/close, range remapped via calibration |
+
+### Registered Device Types
+
+| Type | Class | Role |
+|------|-------|------|
+| `nexarm_follower` | `NexArmFollower` | Robot (follower arm) |
+| `nexarm_leader` | `NexArmLeader` | Teleoperator (leader arm) |
+
+### Communication Protocol
+
+NexArm uses a custom CommProtocol over USB serial:
+
+```
+Frame format: [0xFF][0xFF][ID][LEN][CMD][ARGS...][CHECKSUM]
+```
+
+| Command | Function | Direction |
+|---------|----------|-----------|
+| CMD 68 | Enter/exit LeRobot bridge mode (follower only) | Host → Follower |
+| CMD 96 | Read 6 servo positions (reply: 12 bytes) | Host → Device → Host |
+| CMD 97 | Write 6 servo positions (12 bytes, no reply) | Host → Device |
+| CMD 98 | Enable/disable torque | Host → Device |
+
+## Install LeRobot 🤗
+
+Follow the [installation guide](./installation) to set up LeRobot from source, then
+install the NexArm extras:
+
+```bash
+pip install -e ".[nexarm]"
+```
+
+This installs `pyserial`, which is required for USB serial communication with the
+ESP32 boards.
+
+## Find the USB Ports
+
+Connect each arm to your computer via USB, then run:
+
+```bash
+python -m lerobot.scripts.lerobot_find_port
+```
+
+Run it once per arm (plug in only one at a time if you cannot tell them apart).
+Note down the port for each:
+
+| Platform | Leader example | Follower example |
+|----------|----------------|------------------|
+| Windows | `COM18` | `COM19` |
+| Linux | `/dev/ttyUSB0` | `/dev/ttyUSB1` |
+| macOS | `/dev/tty.usbserial-110` | `/dev/tty.usbserial-120` |
+
+## Find Cameras
+
+Identify which camera index corresponds to `front` and `wrist`:
+
+```bash
+python -m lerobot.scripts.lerobot_find_cameras --camera-type opencv
+```
+
+Review the captured images to identify each camera. Camera indices can change when
+USB devices are replugged — re-scan after any hardware changes.
+
+## Calibration
+
+NexArm follows the standard LeRobot calibration flow (same as SO-100/SO-101). On
+first `connect()`, if no calibration file is found, the procedure runs automatically:
+
+1. Move the arm to its mechanical midpoint, then press Enter.
+2. Slowly move each joint through its full range of motion, then press Enter.
+
+Calibration is saved to:
+```
+~/.cache/huggingface/lerobot/calibration/{robots,teleoperators}/nexarm_{follower,leader}/<id>.json
+```
+
+Run the leader and follower calibration separately. After calibration, joint
+mirroring and range remapping between leader and follower are handled automatically
+by `MotorCalibration(drive_mode, homing_offset, range_min, range_max)` — no
+hard-coded remap functions are needed. If hardware changes (new servo, different
+assembly), re-running calibration is all that is required.
+
+## Teleoperation
+
+Edit `examples/nexarm/teleoperate.yaml` with your serial ports and camera indices,
+then run:
+
+```bash
+python -m lerobot.scripts.lerobot_teleoperate \
+    --config_path=examples/nexarm/teleoperate.yaml
+```
+
+Or pass arguments directly:
+
+```bash
+python -m lerobot.scripts.lerobot_teleoperate \
+    --robot.type=nexarm_follower \
+    --robot.port=COM19 \
+    --teleop.type=nexarm_leader \
+    --teleop.port=COM18 \
+    --fps=30
+```
+
+The leader arm runs in torque-off mode so you can freely drag it. The follower
+mirrors all 6 joints in real time. Joint directions, zero points, and mechanical
+limits are all absorbed by calibration.
+
+## Recording Datasets
+
+```bash
+python -m lerobot.scripts.lerobot_record \
+    --config_path=examples/nexarm/record.yaml
+```
+
+Key parameters in `record.yaml`:
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `dataset.repo_id` | `local/nexarm_pick` | Dataset name |
+| `dataset.num_episodes` | 50 | Number of episodes |
+| `dataset.episode_time_s` | 10 | Duration per episode (s) |
+| `dataset.reset_time_s` | 10 | Scene reset time between episodes (s) |
+| `dataset.fps` | 30 | Recording frame rate |
+| `dataset.push_to_hub` | `false` | Upload to HuggingFace Hub when done |
+
+Record at least 50 episodes for reasonable training results. Keep starting positions
+consistent and ensure good lighting and clear camera views.
+
+## Training a Policy
+
+```bash
+python -m lerobot.scripts.lerobot_train \
+    --dataset.repo_id=local/nexarm_pick \
+    --policy.type=act \
+    --output_dir=outputs/train/nexarm_act \
+    --batch_size=32 \
+    --steps=100000
+```
+
+A CUDA GPU is strongly recommended. Training checkpoints are saved to
+`outputs/train/nexarm_act/checkpoints/`.
+
+## Running Inference
+
+```bash
+python -m lerobot.scripts.lerobot_rollout \
+    --config_path=examples/nexarm/inference.yaml \
+    --policy.path=outputs/train/nexarm_act/checkpoints/last/pretrained_model
+```
+
+The follower arm executes policy-predicted actions autonomously — no leader arm is
+needed. Thanks to ACT's action chunking (chunk_size=100), the model only runs
+inference once per 100 frames; remaining frames are served from the action queue,
+so the loop reaches 20–30 Hz even on a CPU.
+
+## Code Architecture
+
+```
+src/lerobot/
+├── motors/nexarm/                    # Serial bus driver
+│   ├── __init__.py
+│   └── nexarm.py                     # CommProtocol frame build/parse,
+│                                     #   position read/write, torque, bridge mode
+├── robots/nexarm_follower/           # Follower robot
+│   ├── __init__.py
+│   ├── config_nexarm_follower.py     # RobotConfig subclass
+│   └── nexarm_follower.py            # Robot subclass
+└── teleoperators/nexarm_leader/      # Leader teleoperator
+    ├── __init__.py
+    ├── config_nexarm_leader.py       # TeleoperatorConfig subclass
+    └── nexarm_leader.py              # Teleoperator subclass
+```
+
+Upstream files modified:
+
+| File | Change |
+|------|--------|
+| `src/lerobot/robots/utils.py` | Added `nexarm_follower` branch in `make_robot_from_config()` |
+| `src/lerobot/teleoperators/utils.py` | Added `nexarm_leader` branch in `make_teleoperator_from_config()` |
+| `pyproject.toml` | Added `nexarm = ["lerobot[pyserial-dep]", "lerobot[av-dep]"]` |
+
+## Troubleshooting
+
+**Serial port permission denied (Linux)**
+```bash
+sudo usermod -a -G dialout $USER
+# Log out and back in for the change to take effect
+```
+
+**Cameras not found** — Close other programs using the cameras (OBS, browsers,
+etc.), then re-run `lerobot_find_cameras`. Camera indices may change after replugging.
+
+**Follower arm not responding** — Verify the serial port is correct, confirm the
+follower ESP32 firmware supports CMD 68 (LeRobot bridge mode), and try
+power-cycling the arm.
+
+**TimeoutError on leader arm** — Older leader firmware prints debug text over Serial
+in LeRobot mode, which corrupts protocol frames. The updated firmware in this
+repository disables that output. Reflash the leader ESP32 to resolve this.
+
+**Serial checksum warnings** — The leader firmware has a known checksum quirk
+(`tx_packet_complete` uses `rx_packet.elements.length` instead of
+`tx_packet.elements.length`). The driver accepts both the correct and the buggy
+short checksum for backward compatibility; this does not affect functionality.
+
+**Arm moves hesitantly or with small amplitude after training** — This is typically
+an ACT "mean collapse". Try increasing `batch_size`, lowering `kl_weight` (e.g.
+from 10 to 5), raising `optimizer_lr` (e.g. to `5e-5`), or recording more
+demonstration episodes with consistent starting positions and complete task motions.

--- a/src/lerobot/robots/nexarm_follower/nexarm_follower.py
+++ b/src/lerobot/robots/nexarm_follower/nexarm_follower.py
@@ -1,0 +1,195 @@
+# Copyright 2024 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""NexArm follower (slave) robot — LeRobot Robot subclass.
+
+Mirrors the SO-100/SO-101 follower pattern: motors live in
+``NexArmMotorsBus``, observations use ``sync_read("Present_Position")``,
+and actions go through ``sync_write("Goal_Position", ...)`` with normalised
+values (DEGREES / RANGE_0_100 by default). Calibration is performed via the
+official ``set_half_turn_homings`` + ``record_ranges_of_motion`` flow.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from functools import cached_property
+
+from lerobot.cameras import make_cameras_from_configs
+from lerobot.motors.nexarm import NexArmMotorsBus
+from lerobot.motors.nexarm.nexarm import JOINT_NAMES
+from lerobot.types import RobotAction, RobotObservation
+from lerobot.utils.decorators import check_if_already_connected, check_if_not_connected
+
+from ..robot import Robot
+from ..utils import ensure_safe_goal_position
+from .config_nexarm_follower import NexArmFollowerConfig
+
+logger = logging.getLogger(__name__)
+
+
+class NexArmFollower(Robot):
+    """NexArm 6-DOF desktop robot arm (follower / slave).
+
+    The follower connects to the slave ESP32 via USB serial at 1 Mbps. The
+    ESP32 forwards CMD 96/97/98 through an AT32F421 co-processor to the HX-30HM
+    serial-bus servos. CMD 68 enables LeRobot bridge mode on connect.
+    """
+
+    config_class = NexArmFollowerConfig
+    name = "nexarm_follower"
+
+    def __init__(self, config: NexArmFollowerConfig):
+        super().__init__(config)
+        self.config = config
+        self.bus = NexArmMotorsBus(
+            port=config.port,
+            calibration=self.calibration,
+            baudrate=config.baudrate,
+        )
+        self.cameras = make_cameras_from_configs(config.cameras)
+
+    @property
+    def _motors_ft(self) -> dict[str, type]:
+        return {f"{m}.pos": float for m in self.bus.motors}
+
+    @property
+    def _cameras_ft(self) -> dict[str, tuple]:
+        return {
+            cam: (self.config.cameras[cam].height, self.config.cameras[cam].width, 3)
+            for cam in self.cameras
+        }
+
+    @cached_property
+    def observation_features(self) -> dict[str, type | tuple]:
+        return {**self._motors_ft, **self._cameras_ft}
+
+    @cached_property
+    def action_features(self) -> dict[str, type]:
+        return self._motors_ft
+
+    @property
+    def is_connected(self) -> bool:
+        return self.bus.is_connected and all(cam.is_connected for cam in self.cameras.values())
+
+    @property
+    def is_calibrated(self) -> bool:
+        return self.bus.is_calibrated
+
+    @check_if_already_connected
+    def connect(self, calibrate: bool = True) -> None:
+        self.bus.connect(handshake=False)
+        self.bus.enter_lerobot_mode()
+        # Now that bridge mode is active, do a real handshake.
+        self.bus.handshake()
+
+        if calibrate and not self.is_calibrated:
+            logger.info("No calibration found, running calibration")
+            self.calibrate()
+
+        for cam in self.cameras.values():
+            cam.connect()
+
+        self.configure()
+        logger.info(f"{self} connected.")
+
+    def calibrate(self) -> None:
+        if self.calibration:
+            user_input = input(
+                f"Press ENTER to keep the existing calibration for {self.id}, or type 'c' "
+                "and press ENTER to run a new one: "
+            )
+            if user_input.strip().lower() != "c":
+                logger.info("Keeping existing calibration")
+                return
+
+        logger.info(f"\nRunning calibration of {self}")
+        self.bus.reset_calibration()
+        self.bus.disable_torque()
+
+        print(
+            "Move all joints sequentially through their entire ranges of motion.\n"
+            "Recording positions. Press ENTER to stop..."
+        )
+        self.bus.record_ranges_of_motion()
+
+        self.calibration = dict(self.bus.calibration)
+        self._save_calibration()
+        print(f"Calibration saved to {self.calibration_fpath}")
+
+    def configure(self) -> None:
+        self.bus.write_motion_params(acc=self.config.motion_acc, speed=self.config.motion_speed)
+        self.bus.enable_torque()
+
+    @check_if_not_connected
+    def get_observation(self) -> RobotObservation:
+        start = time.perf_counter()
+        positions = self.bus.sync_read("Present_Position")
+        dt_ms = (time.perf_counter() - start) * 1e3
+        logger.debug(f"{self} read state: {dt_ms:.1f}ms")
+        obs: RobotObservation = {f"{m}.pos": v for m, v in positions.items()}
+
+        for cam_key, cam in self.cameras.items():
+            start = time.perf_counter()
+            obs[cam_key] = cam.read_latest(max_age_ms=1500)
+            dt_ms = (time.perf_counter() - start) * 1e3
+            logger.debug(f"{self} read {cam_key}: {dt_ms:.1f}ms")
+
+        return obs
+
+    @check_if_not_connected
+    def send_action(self, action: RobotAction) -> RobotAction:
+        goal_pos = {
+            k.removesuffix(".pos"): float(v) for k, v in action.items() if k.endswith(".pos")
+        }
+
+        if self.config.max_relative_target is not None:
+            present = self.bus.sync_read("Present_Position")
+            goal_present = {
+                name: (goal_pos[name], present[name]) for name in goal_pos if name in present
+            }
+            goal_pos = ensure_safe_goal_position(goal_present, self.config.max_relative_target)
+
+        self.bus.sync_write("Goal_Position", goal_pos)
+        return {f"{m}.pos": v for m, v in goal_pos.items()}
+
+    @check_if_not_connected
+    def disconnect(self) -> None:
+        for cam in self.cameras.values():
+            try:
+                cam.disconnect()
+            except Exception:  # nosec B110
+                pass
+
+        if self.config.disable_torque_on_disconnect:
+            try:
+                # Hold current position briefly so servos don't drop on torque off.
+                present = self.bus.sync_read("Present_Position")
+                self.bus.sync_write("Goal_Position", present)
+                time.sleep(0.4)
+                self.bus.disable_torque()
+            except Exception:  # nosec B110
+                pass
+
+        try:
+            self.bus.exit_lerobot_mode()
+        except Exception:  # nosec B110
+            pass
+
+        self.bus.disconnect(disable_torque=False)
+        logger.info(f"{self} disconnected.")
+
+
+__all__ = ["NexArmFollower", "JOINT_NAMES"]

--- a/src/lerobot/robots/utils.py
+++ b/src/lerobot/robots/utils.py
@@ -76,6 +76,10 @@ def make_robot_from_config(config: RobotConfig) -> Robot:
         from .bi_rebot_b601_follower import BiRebotB601Follower
 
         return BiRebotB601Follower(config)
+    elif config.type == "nexarm_follower":
+        from .nexarm_follower import NexArmFollower
+
+        return NexArmFollower(config)
     elif config.type == "mock_robot":
         from tests.mocks.mock_robot import MockRobot
 

--- a/src/lerobot/teleoperators/nexarm_leader/__init__.py
+++ b/src/lerobot/teleoperators/nexarm_leader/__init__.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+
+# Copyright 2024 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .config_nexarm_leader import NexArmLeaderConfig
+from .nexarm_leader import NexArmLeader
+
+__all__ = ["NexArmLeader", "NexArmLeaderConfig"]

--- a/src/lerobot/teleoperators/nexarm_leader/config_nexarm_leader.py
+++ b/src/lerobot/teleoperators/nexarm_leader/config_nexarm_leader.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+# Copyright 2024 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+
+from ..config import TeleoperatorConfig
+
+
+@TeleoperatorConfig.register_subclass("nexarm_leader")
+@dataclass
+class NexArmLeaderConfig(TeleoperatorConfig):
+    """Configuration for the NexArm leader (master) teleoperator.
+
+    The leader connects to the master ESP32 via USB serial. The master
+    directly controls HX-30HM servos. In teleop mode, torque is disabled
+    so the operator can freely drag the arm.
+
+    Attributes:
+        port: Serial port for the master ESP32 (e.g. "COM18", "/dev/ttyUSB0").
+        baudrate: Serial baud rate (default 1 Mbps).
+    """
+
+    port: str
+    baudrate: int = 1_000_000

--- a/src/lerobot/teleoperators/nexarm_leader/nexarm_leader.py
+++ b/src/lerobot/teleoperators/nexarm_leader/nexarm_leader.py
@@ -1,0 +1,153 @@
+# Copyright 2024 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""NexArm leader (master) teleoperator — LeRobot Teleoperator subclass.
+
+The leader connects to the master ESP32 via USB serial. Torque is disabled so
+the operator can freely drag the arm; positions are streamed to the follower
+through the normalised LeRobot pipeline. Calibration uses the same
+``set_half_turn_homings`` + ``record_ranges_of_motion`` flow as the follower,
+which removes the need for any hard-coded mirror or remap of joint values.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+from lerobot.motors import MotorCalibration
+from lerobot.motors.nexarm import NexArmMotorsBus
+from lerobot.utils.decorators import check_if_already_connected, check_if_not_connected
+
+from ..teleoperator import Teleoperator
+from .config_nexarm_leader import NexArmLeaderConfig
+
+logger = logging.getLogger(__name__)
+
+
+class NexArmLeader(Teleoperator):
+    """NexArm 6-DOF leader teleoperator.
+
+    The leader runs the master ESP32 in LeRobot mode. Each tick we read
+    Present_Position (normalised to DEGREES / RANGE_0_100 by the bus) and pass
+    it straight through as the follower's goal. The follower's calibration
+    handles per-joint sign / offset / range differences, so no mirror or
+    bespoke remap is needed.
+    """
+
+    config_class = NexArmLeaderConfig
+    name = "nexarm_leader"
+
+    def __init__(self, config: NexArmLeaderConfig):
+        super().__init__(config)
+        self.config = config
+        self.bus = NexArmMotorsBus(
+            port=config.port,
+            calibration=self.calibration,
+            baudrate=config.baudrate,
+        )
+
+    @property
+    def action_features(self) -> dict[str, type]:
+        return {f"{m}.pos": float for m in self.bus.motors}
+
+    @property
+    def feedback_features(self) -> dict[str, type]:
+        return {}
+
+    @property
+    def is_connected(self) -> bool:
+        return self.bus.is_connected
+
+    @property
+    def is_calibrated(self) -> bool:
+        return self.bus.is_calibrated
+
+    @check_if_already_connected
+    def connect(self, calibrate: bool = True) -> None:
+        self.bus.connect(handshake=False)
+        self.bus.enter_lerobot_mode()
+        self.bus.handshake()
+
+        if calibrate and not self.is_calibrated:
+            logger.info("No calibration found, running calibration")
+            self.calibrate()
+
+        self.configure()
+        logger.info(f"{self} connected.")
+
+    def calibrate(self) -> None:
+        if self.calibration:
+            user_input = input(
+                f"Press ENTER to keep the existing calibration for {self.id}, or type 'c' "
+                "and press ENTER to run a new one: "
+            )
+            if user_input.strip().lower() != "c":
+                logger.info("Keeping existing calibration")
+                return
+
+        logger.info(f"\nRunning calibration of {self}")
+        self.bus.reset_calibration()
+        self.bus.disable_torque()
+
+        print(
+            "Move all joints sequentially through their entire ranges of motion.\n"
+            "Recording positions. Press ENTER to stop..."
+        )
+        self.bus.record_ranges_of_motion()
+
+        # shoulder_lift (servo 2) on the leader is mounted mirrored relative
+        # to the follower — see Nex_Arm/EspNow_Ctrl.cpp mapMasterTeachToFollower
+        # which does target = 4096 - master_pos. The LeRobot bridge forwards
+        # CMD 97 raw with no remap, so we compensate here by flipping the
+        # leader's normalised output on that joint via drive_mode=1.
+        lift = "shoulder_lift"
+        cal = self.bus.calibration[lift]
+        self.bus.calibration[lift] = MotorCalibration(
+            id=cal.id,
+            drive_mode=1,
+            homing_offset=cal.homing_offset,
+            range_min=cal.range_min,
+            range_max=cal.range_max,
+        )
+
+        self.calibration = dict(self.bus.calibration)
+        self._save_calibration()
+        print(f"Calibration saved to {self.calibration_fpath}")
+
+    def configure(self) -> None:
+        # Leader must stay torque-off so the operator can drag it.
+        self.bus.disable_torque()
+
+    @check_if_not_connected
+    def get_action(self) -> dict[str, float]:
+        start = time.perf_counter()
+        positions = self.bus.sync_read("Present_Position")
+        dt_ms = (time.perf_counter() - start) * 1e3
+        logger.debug(f"{self} read action: {dt_ms:.1f}ms")
+        return {f"{m}.pos": v for m, v in positions.items()}
+
+    @check_if_not_connected
+    def send_feedback(self, feedback: dict[str, float]) -> None:
+        # Leader has no force feedback channel.
+        return None
+
+    @check_if_not_connected
+    def disconnect(self) -> None:
+        try:
+            self.bus.exit_lerobot_mode()
+        except Exception:  # nosec B110
+            pass
+        self.bus.disconnect(disable_torque=False)
+        logger.info(f"{self} disconnected.")

--- a/src/lerobot/teleoperators/utils.py
+++ b/src/lerobot/teleoperators/utils.py
@@ -111,6 +111,10 @@ def make_teleoperator_from_config(config: TeleoperatorConfig) -> "Teleoperator":
         from .bi_rebot_102_leader import BiRebot102Leader
 
         return BiRebot102Leader(config)
+    elif config.type == "nexarm_leader":
+        from .nexarm_leader import NexArmLeader
+
+        return NexArmLeader(config)
     else:
         try:
             return cast("Teleoperator", make_device_from_device_class(config))

--- a/tests/motors/test_nexarm.py
+++ b/tests/motors/test_nexarm.py
@@ -1,0 +1,423 @@
+#!/usr/bin/env python
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the NexArm motor bus driver.
+
+Cover frame building/parsing, the standard ``sync_read``/``sync_write`` API,
+torque control, LeRobot bridge-mode entry/exit, and the calibration flow
+(``set_half_turn_homings`` + ``record_ranges_of_motion``). All tests use mock
+serial I/O — no physical hardware is required.
+"""
+
+import struct
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+serial = pytest.importorskip("serial", reason="pyserial is required for NexArm tests")
+
+from lerobot.motors import MotorCalibration, MotorNormMode  # noqa: E402
+from lerobot.motors.nexarm.nexarm import (  # noqa: E402
+    CMD_LEROBOT_MODE,
+    CMD_READ_POS,
+    CMD_TORQUE,
+    CMD_WRITE_POS,
+    DEFAULT_BAUDRATE,
+    HALF_TURN,
+    JOINT_COUNT,
+    JOINT_NAMES,
+    POSITION_MAX,
+    POSITION_MIN,
+    SYSTEM_ID,
+    NexArmMotorsBus,
+    build_frame,
+    parse_frame,
+)
+
+# ── Frame building / parsing ─────────────────────────────────────────
+
+
+class TestBuildFrame:
+    def test_header_bytes(self):
+        frame = build_frame(0xFF, CMD_READ_POS)
+        assert frame[:2] == b"\xff\xff"
+
+    def test_length_no_args(self):
+        frame = build_frame(0xFF, CMD_READ_POS)
+        assert frame[3] == 2
+
+    def test_length_with_args(self):
+        frame = build_frame(0xFF, CMD_READ_POS, bytes([1, 2, 3]))
+        assert frame[3] == 5
+
+    def test_cmd_byte(self):
+        assert build_frame(0xFF, CMD_READ_POS)[4] == CMD_READ_POS
+
+    def test_checksum_correct(self):
+        frame = build_frame(0xFF, CMD_READ_POS)
+        expected = (~sum(frame[2:-1])) & 0xFF
+        assert frame[-1] == expected
+
+    def test_round_trip(self):
+        payload = bytes([0x01, 0x02, 0x03])
+        frame = build_frame(SYSTEM_ID, CMD_TORQUE, payload)
+        result = parse_frame(frame)
+        assert result == (SYSTEM_ID, CMD_TORQUE, payload)
+
+    @pytest.mark.parametrize("cmd", [CMD_READ_POS, CMD_WRITE_POS, CMD_TORQUE, CMD_LEROBOT_MODE])
+    def test_all_commands_round_trip(self, cmd):
+        frame = build_frame(SYSTEM_ID, cmd)
+        result = parse_frame(frame)
+        assert result is not None
+        assert result[1] == cmd
+
+
+class TestParseFrame:
+    def test_too_short(self):
+        assert parse_frame(b"\xff\xff\x01") is None
+
+    def test_bad_header(self):
+        frame = build_frame(SYSTEM_ID, CMD_READ_POS)
+        assert parse_frame(b"\x00\x00" + frame[2:]) is None
+
+    def test_truncated_data(self):
+        frame = build_frame(SYSTEM_ID, CMD_READ_POS, bytes(12))
+        assert parse_frame(frame[:-3]) is None
+
+    def test_bad_checksum(self):
+        frame = bytearray(build_frame(SYSTEM_ID, CMD_READ_POS))
+        frame[-1] ^= 0xFF
+        assert parse_frame(bytes(frame)) is None
+
+    def test_firmware_buggy_checksum_accepted(self):
+        """Leader firmware uses rx_packet.elements.length instead of tx_packet's."""
+        args = bytes(12)
+        length = len(args) + 2
+        data_raw = bytes([SYSTEM_ID, length, CMD_READ_POS]) + args
+        correct = (~sum(data_raw)) & 0xFF
+        buggy = (~sum(data_raw[:3])) & 0xFF
+        assert parse_frame(b"\xff\xff" + data_raw + bytes([correct])) is not None
+        if buggy != correct:
+            assert parse_frame(b"\xff\xff" + data_raw + bytes([buggy])) is not None
+
+    def test_parse_position_reply(self):
+        positions = [2048, 1024, 3072, 512, 4000, 2000]
+        args = b"".join(struct.pack("<h", p) for p in positions)
+        result = parse_frame(build_frame(SYSTEM_ID, CMD_READ_POS, args))
+        assert result is not None
+        _, cmd, parsed_args = result
+        assert cmd == CMD_READ_POS
+        parsed = [struct.unpack_from("<h", parsed_args, i * 2)[0] for i in range(JOINT_COUNT)]
+        assert parsed == positions
+
+
+# ── Mock helpers ─────────────────────────────────────────────────────
+
+
+def _make_mock_serial(reply_bytes: bytes | None = None) -> MagicMock:
+    mock = MagicMock()
+    mock.is_open = True
+    mock.port = "/dev/null"
+    if reply_bytes is None:
+        mock.in_waiting = 0
+        mock.read.return_value = b""
+    else:
+        # The bus polls in_waiting then reads exactly that many bytes.
+        # Each write() re-arms the reply so successive request/response cycles
+        # (handshake → sync_read → sync_read → …) all see the canned bytes.
+        state = {"sent": False}
+
+        def _in_waiting():
+            return 0 if state["sent"] else len(reply_bytes)
+
+        def _read(n):
+            if state["sent"]:
+                return b""
+            state["sent"] = True
+            return reply_bytes
+
+        def _write(data):
+            state["sent"] = False
+            return len(data)
+
+        # ``in_waiting`` is a property on real Serial — emulate as PropertyMock.
+        type(mock).in_waiting = property(lambda self: _in_waiting())
+        mock.read.side_effect = _read
+        mock.write.side_effect = _write
+    return mock
+
+
+def _reply_for_positions(positions: list[int]) -> bytes:
+    args = b"".join(struct.pack("<h", p) for p in positions)
+    return build_frame(SYSTEM_ID, CMD_READ_POS, args)
+
+
+# ── Bus lifecycle ────────────────────────────────────────────────────
+
+
+class TestNexArmMotorsBusLifecycle:
+    def test_default_motors(self):
+        bus = NexArmMotorsBus(port="/dev/null")
+        assert set(bus.motors) == set(JOINT_NAMES)
+        assert bus.motors["gripper"].norm_mode == MotorNormMode.RANGE_0_100
+        assert bus.motors["shoulder_pan"].norm_mode == MotorNormMode.RANGE_M100_100
+
+    def test_init_defaults(self):
+        bus = NexArmMotorsBus(port="/dev/null")
+        assert bus.port == "/dev/null"
+        assert bus.baudrate == DEFAULT_BAUDRATE
+        assert not bus.is_connected
+        assert not bus.is_calibrated
+
+    def test_connect_disconnect(self):
+        positions = [2048] * JOINT_COUNT
+        with patch("lerobot.motors.nexarm.nexarm.serial.Serial") as serial_cls:
+            mock_ser = _make_mock_serial(_reply_for_positions(positions))
+            serial_cls.return_value = mock_ser
+            bus = NexArmMotorsBus(port="/dev/null")
+            bus.connect()
+            assert bus.is_connected
+            bus.disconnect(disable_torque=False)
+            assert not bus.is_connected
+            mock_ser.close.assert_called_once()
+
+    def test_connect_idempotent(self):
+        positions = [2048] * JOINT_COUNT
+        with patch("lerobot.motors.nexarm.nexarm.serial.Serial") as serial_cls:
+            serial_cls.return_value = _make_mock_serial(_reply_for_positions(positions))
+            bus = NexArmMotorsBus(port="/dev/null")
+            bus.connect()
+            bus.connect()
+            assert serial_cls.call_count == 1
+
+    def test_handshake_failure_raises(self):
+        with patch("lerobot.motors.nexarm.nexarm.serial.Serial") as serial_cls:
+            serial_cls.return_value = _make_mock_serial(None)
+            bus = NexArmMotorsBus(port="/dev/null")
+            with pytest.raises(ConnectionError, match="handshake failed"):
+                bus.connect()
+
+
+# ── sync_read / sync_write ──────────────────────────────────────────
+
+
+class TestSyncRead:
+    def test_returns_raw_when_no_calibration(self):
+        positions = [2048, 1024, 3072, 512, 4000, 2000]
+        with patch("lerobot.motors.nexarm.nexarm.serial.Serial") as serial_cls:
+            serial_cls.return_value = _make_mock_serial(_reply_for_positions(positions))
+            bus = NexArmMotorsBus(port="/dev/null")
+            bus.connect()
+            result = bus.sync_read("Present_Position")
+            for i, name in enumerate(JOINT_NAMES):
+                assert result[name] == float(positions[i])
+
+    def test_normalizes_when_calibrated(self):
+        positions = [2048] * JOINT_COUNT
+        calibration = {
+            name: MotorCalibration(
+                id=i + 1, drive_mode=0, homing_offset=0, range_min=0, range_max=4095
+            )
+            for i, name in enumerate(JOINT_NAMES)
+        }
+        with patch("lerobot.motors.nexarm.nexarm.serial.Serial") as serial_cls:
+            serial_cls.return_value = _make_mock_serial(_reply_for_positions(positions))
+            bus = NexArmMotorsBus(port="/dev/null", calibration=calibration)
+            bus.connect()
+            result = bus.sync_read("Present_Position")
+            # 2048 is the midpoint -> ~0 in RANGE_M100_100, ~50 in RANGE_0_100.
+            assert abs(result["shoulder_pan"]) < 0.05
+            assert abs(result["gripper"] - 50.0) < 0.05
+
+    def test_rejects_unknown_data_name(self):
+        bus = NexArmMotorsBus(port="/dev/null")
+        bus._serial = MagicMock()
+        bus._serial.is_open = True
+        with pytest.raises(NotImplementedError):
+            bus.sync_read("Present_Voltage")
+
+
+class TestSyncWrite:
+    def _make_bus(self, mock_ser):
+        with patch("lerobot.motors.nexarm.nexarm.serial.Serial") as serial_cls:
+            serial_cls.return_value = mock_ser
+            bus = NexArmMotorsBus(port="/dev/null")
+            bus.connect()
+            mock_ser.write.reset_mock()
+            return bus
+
+    def test_writes_cmd97_with_six_int16(self):
+        # _reply_for_positions handshake then ignore subsequent reads
+        mock_ser = _make_mock_serial(_reply_for_positions([2048] * 6))
+        bus = self._make_bus(mock_ser)
+
+        calibration = {
+            name: MotorCalibration(
+                id=i + 1, drive_mode=0, homing_offset=0, range_min=0, range_max=4095
+            )
+            for i, name in enumerate(JOINT_NAMES)
+        }
+        bus.calibration = calibration
+
+        values = dict.fromkeys(JOINT_NAMES, 0.0)
+        values["gripper"] = 50.0
+        bus.sync_write("Goal_Position", values)
+
+        written = mock_ser.write.call_args[0][0]
+        result = parse_frame(written)
+        assert result is not None
+        _, cmd, args = result
+        assert cmd == CMD_WRITE_POS
+        assert len(args) == JOINT_COUNT * 2
+        parsed = [struct.unpack_from("<h", args, i * 2)[0] for i in range(JOINT_COUNT)]
+        # 0% in RANGE_M100_100 -> midpoint 2047; 50% in RANGE_0_100 -> midpoint 2047
+        for v in parsed:
+            assert 2046 <= v <= 2049
+
+    def test_clamps_to_range_min_max(self):
+        mock_ser = _make_mock_serial(_reply_for_positions([2048] * 6))
+        bus = self._make_bus(mock_ser)
+
+        # Tighten elbow_flex range to [968, 3200].
+        bus.calibration = {
+            name: MotorCalibration(
+                id=i + 1,
+                drive_mode=0,
+                homing_offset=0,
+                range_min=968 if name == "elbow_flex" else 0,
+                range_max=3200 if name == "elbow_flex" else 4095,
+            )
+            for i, name in enumerate(JOINT_NAMES)
+        }
+
+        # Ask for elbow_flex at +200 (RANGE_M100_100 -> outside max) → clamp to 3200.
+        values = dict.fromkeys(JOINT_NAMES, 0.0)
+        values["elbow_flex"] = 200.0
+        bus.sync_write("Goal_Position", values)
+
+        written = mock_ser.write.call_args[0][0]
+        _, _, args = parse_frame(written)
+        parsed = [struct.unpack_from("<h", args, i * 2)[0] for i in range(JOINT_COUNT)]
+        assert parsed[2] == 3200
+
+    def test_rejects_unknown_data_name(self):
+        bus = NexArmMotorsBus(port="/dev/null")
+        bus._serial = MagicMock()
+        bus._serial.is_open = True
+        with pytest.raises(NotImplementedError):
+            bus.sync_write("Goal_Velocity", {"shoulder_pan": 0.0})
+
+
+# ── Torque / LeRobot bridge mode ────────────────────────────────────
+
+
+class TestTorqueAndBridgeMode:
+    def _bus_with_mock(self, mock_ser):
+        with patch("lerobot.motors.nexarm.nexarm.serial.Serial") as serial_cls:
+            serial_cls.return_value = mock_ser
+            bus = NexArmMotorsBus(port="/dev/null")
+            bus.connect()
+            mock_ser.write.reset_mock()
+            return bus
+
+    def test_enable_torque_sends_cmd98_one(self):
+        mock_ser = _make_mock_serial(_reply_for_positions([2048] * 6))
+        bus = self._bus_with_mock(mock_ser)
+        bus.enable_torque()
+        written = mock_ser.write.call_args[0][0]
+        _, cmd, args = parse_frame(written)
+        assert cmd == CMD_TORQUE
+        assert args == bytes([1])
+
+    def test_disable_torque_sends_cmd98_zero(self):
+        mock_ser = _make_mock_serial(_reply_for_positions([2048] * 6))
+        bus = self._bus_with_mock(mock_ser)
+        bus.disable_torque()
+        written = mock_ser.write.call_args[0][0]
+        _, cmd, args = parse_frame(written)
+        assert cmd == CMD_TORQUE
+        assert args == bytes([0])
+
+    def test_enter_lerobot_mode(self):
+        mock_ser = _make_mock_serial(_reply_for_positions([2048] * 6))
+        bus = self._bus_with_mock(mock_ser)
+        bus.enter_lerobot_mode()
+        written = mock_ser.write.call_args[0][0]
+        _, cmd, args = parse_frame(written)
+        assert cmd == CMD_LEROBOT_MODE
+        assert args == bytes([1])
+
+    def test_exit_lerobot_mode(self):
+        mock_ser = _make_mock_serial(_reply_for_positions([2048] * 6))
+        bus = self._bus_with_mock(mock_ser)
+        bus.exit_lerobot_mode()
+        written = mock_ser.write.call_args[0][0]
+        _, cmd, args = parse_frame(written)
+        assert cmd == CMD_LEROBOT_MODE
+        assert args == bytes([0])
+
+
+# ── Calibration helpers ─────────────────────────────────────────────
+
+
+class TestCalibrationHelpers:
+    def test_set_half_turn_homings_stores_offset(self):
+        positions = [2200, 1900, 2050, 2100, 2000, 1800]
+        with patch("lerobot.motors.nexarm.nexarm.serial.Serial") as serial_cls:
+            serial_cls.return_value = _make_mock_serial(_reply_for_positions(positions))
+            bus = NexArmMotorsBus(port="/dev/null")
+            bus.connect()
+            offsets = bus.set_half_turn_homings()
+        for i, name in enumerate(JOINT_NAMES):
+            assert offsets[name] == positions[i] - HALF_TURN
+            assert bus.calibration[name].homing_offset == positions[i] - HALF_TURN
+            assert bus.calibration[name].range_min == POSITION_MIN
+            assert bus.calibration[name].range_max == POSITION_MAX
+
+    def test_is_calibrated_requires_distinct_range(self):
+        bus = NexArmMotorsBus(port="/dev/null")
+        # range_min == range_max should be rejected.
+        bus.calibration = {
+            name: MotorCalibration(id=i + 1, drive_mode=0, homing_offset=0, range_min=0, range_max=0)
+            for i, name in enumerate(JOINT_NAMES)
+        }
+        assert not bus.is_calibrated
+        bus.calibration["shoulder_pan"] = MotorCalibration(
+            id=1, drive_mode=0, homing_offset=0, range_min=100, range_max=3900
+        )
+        # Still false because other motors have invalid ranges.
+        assert not bus.is_calibrated
+
+
+# ── Constants ───────────────────────────────────────────────────────
+
+
+class TestConstants:
+    def test_joint_count_matches_names(self):
+        assert len(JOINT_NAMES) == JOINT_COUNT
+
+    def test_position_range(self):
+        assert POSITION_MIN == 0
+        assert POSITION_MAX == 4095
+
+    def test_joint_names(self):
+        assert JOINT_NAMES == (
+            "shoulder_pan",
+            "shoulder_lift",
+            "elbow_flex",
+            "wrist_flex",
+            "wrist_roll",
+            "gripper",
+        )

--- a/tests/robots/test_nexarm_follower.py
+++ b/tests/robots/test_nexarm_follower.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the NexArmFollower robot class.
+
+Exercises lifecycle, get_observation / send_action and the new normalised
+``sync_read`` / ``sync_write`` API using a mocked NexArmMotorsBus — no
+physical hardware required.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+serial = pytest.importorskip("serial", reason="pyserial is required for NexArm tests")
+
+from lerobot.motors import MotorCalibration  # noqa: E402
+from lerobot.motors.nexarm.nexarm import JOINT_NAMES  # noqa: E402
+from lerobot.robots.nexarm_follower import (  # noqa: E402
+    NexArmFollower,
+    NexArmFollowerConfig,
+)
+
+
+def _make_bus_mock(positions: dict[str, float] | None = None) -> MagicMock:
+    if positions is None:
+        positions = dict.fromkeys(JOINT_NAMES, 0.0)
+
+    bus = MagicMock(name="NexArmBusMock")
+    bus.is_connected = False
+    bus.is_calibrated = True
+    bus.motors = {name: MagicMock(id=i + 1) for i, name in enumerate(JOINT_NAMES)}
+    bus.calibration = {
+        name: MotorCalibration(
+            id=i + 1, drive_mode=0, homing_offset=0, range_min=100, range_max=3900
+        )
+        for i, name in enumerate(JOINT_NAMES)
+    }
+
+    def _connect(handshake=True):  # noqa: ARG001
+        bus.is_connected = True
+
+    def _disconnect(disable_torque=True):  # noqa: ARG001
+        bus.is_connected = False
+
+    bus.connect.side_effect = _connect
+    bus.disconnect.side_effect = _disconnect
+    bus.sync_read.return_value = dict(positions)
+    bus.sync_write.return_value = None
+    bus.enable_torque.return_value = None
+    bus.disable_torque.return_value = None
+    bus.enter_lerobot_mode.return_value = None
+    bus.exit_lerobot_mode.return_value = None
+    bus.write_motion_params.return_value = None
+    bus.handshake.return_value = None
+    return bus
+
+
+@pytest.fixture
+def follower():
+    bus_mock = _make_bus_mock()
+    with patch(
+        "lerobot.robots.nexarm_follower.nexarm_follower.NexArmMotorsBus",
+        return_value=bus_mock,
+    ):
+        cfg = NexArmFollowerConfig(port="/dev/null", cameras={})
+        robot = NexArmFollower(cfg)
+        robot._bus_mock = bus_mock
+        yield robot
+        if robot.is_connected:
+            robot.disconnect()
+
+
+@pytest.fixture
+def follower_with_positions():
+    positions = {name: float(i + 1) * 10 for i, name in enumerate(JOINT_NAMES)}
+    bus_mock = _make_bus_mock(positions)
+    with patch(
+        "lerobot.robots.nexarm_follower.nexarm_follower.NexArmMotorsBus",
+        return_value=bus_mock,
+    ):
+        cfg = NexArmFollowerConfig(port="/dev/null", cameras={})
+        robot = NexArmFollower(cfg)
+        robot._bus_mock = bus_mock
+        robot._expected_positions = positions
+        yield robot
+        if robot.is_connected:
+            robot.disconnect()
+
+
+class TestConnectDisconnect:
+    def test_not_connected_initially(self, follower):
+        assert not follower.is_connected
+
+    def test_connect(self, follower):
+        follower.connect()
+        assert follower.is_connected
+
+    def test_connect_enters_lerobot_mode(self, follower):
+        follower.connect()
+        follower._bus_mock.enter_lerobot_mode.assert_called_once()
+
+    def test_connect_calls_handshake(self, follower):
+        follower.connect()
+        follower._bus_mock.handshake.assert_called_once()
+
+    def test_connect_does_not_calibrate_when_already_calibrated(self, follower):
+        # is_calibrated defaults to True in the fixture.
+        follower.connect()
+        # No interactive prompt should run; we just call configure.
+        follower._bus_mock.write_motion_params.assert_called_once()
+        follower._bus_mock.enable_torque.assert_called_once()
+
+    def test_disconnect(self, follower):
+        follower.connect()
+        follower.disconnect()
+        assert not follower.is_connected
+
+    def test_connect_idempotent(self, follower):
+        from lerobot.utils.errors import DeviceAlreadyConnectedError
+
+        follower.connect()
+        with pytest.raises(DeviceAlreadyConnectedError):
+            follower.connect()
+
+
+class TestGetObservation:
+    def test_returns_all_joint_keys(self, follower_with_positions):
+        follower_with_positions.connect()
+        obs = follower_with_positions.get_observation()
+        for name in JOINT_NAMES:
+            assert f"{name}.pos" in obs
+
+    def test_returns_correct_values(self, follower_with_positions):
+        follower_with_positions.connect()
+        obs = follower_with_positions.get_observation()
+        for name in JOINT_NAMES:
+            assert obs[f"{name}.pos"] == follower_with_positions._expected_positions[name]
+
+    def test_calls_sync_read(self, follower):
+        follower.connect()
+        follower.get_observation()
+        follower._bus_mock.sync_read.assert_called_with("Present_Position")
+
+
+class TestSendAction:
+    def test_calls_sync_write(self, follower):
+        follower.connect()
+        action = {f"{name}.pos": 0.0 for name in JOINT_NAMES}
+        follower.send_action(action)
+        # The first sync_write call (after potential present-read) targets Goal_Position.
+        assert follower._bus_mock.sync_write.called
+        last_call = follower._bus_mock.sync_write.call_args_list[-1]
+        assert last_call.args[0] == "Goal_Position"
+
+    def test_strips_pos_suffix(self, follower):
+        follower.connect()
+        values = {name: float(i + 1) * 5 for i, name in enumerate(JOINT_NAMES)}
+        action = {f"{name}.pos": v for name, v in values.items()}
+        follower.send_action(action)
+        last_call = follower._bus_mock.sync_write.call_args_list[-1]
+        assert last_call.args[1] == values
+
+    def test_returns_action_with_pos_suffix(self, follower):
+        follower.connect()
+        action = {f"{name}.pos": 0.0 for name in JOINT_NAMES}
+        out = follower.send_action(action)
+        assert set(out.keys()) == {f"{n}.pos" for n in JOINT_NAMES}
+
+    def test_max_relative_target_clamps_step(self, follower):
+        # Pretend the arm is at 0 and we ask for +50; cap is 10.
+        follower._bus_mock.sync_read.return_value = dict.fromkeys(JOINT_NAMES, 0.0)
+        follower.config.max_relative_target = 10.0
+        follower.connect()
+
+        action = {f"{name}.pos": 50.0 for name in JOINT_NAMES}
+        follower.send_action(action)
+
+        last_call = follower._bus_mock.sync_write.call_args_list[-1]
+        for name in JOINT_NAMES:
+            assert last_call.args[1][name] == 10.0
+
+
+class TestConfig:
+    def test_default_baudrate(self):
+        cfg = NexArmFollowerConfig(port="/dev/null")
+        assert cfg.baudrate == 1_000_000
+
+    def test_default_max_relative_target_none(self):
+        cfg = NexArmFollowerConfig(port="/dev/null")
+        assert cfg.max_relative_target is None
+
+    def test_action_features_match_joints(self):
+        with patch(
+            "lerobot.robots.nexarm_follower.nexarm_follower.NexArmMotorsBus",
+            return_value=_make_bus_mock(),
+        ):
+            cfg = NexArmFollowerConfig(port="/dev/null", cameras={})
+            robot = NexArmFollower(cfg)
+            assert set(robot.action_features.keys()) == {f"{n}.pos" for n in JOINT_NAMES}

--- a/tests/robots/test_nexarm_leader.py
+++ b/tests/robots/test_nexarm_leader.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the NexArmLeader teleoperator class.
+
+Exercises lifecycle, get_action, and send_feedback using a mocked
+NexArmMotorsBus — no physical hardware required.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+serial = pytest.importorskip("serial", reason="pyserial is required for NexArm tests")
+
+from lerobot.motors import MotorCalibration  # noqa: E402
+from lerobot.motors.nexarm.nexarm import JOINT_NAMES  # noqa: E402
+from lerobot.teleoperators.nexarm_leader import (  # noqa: E402
+    NexArmLeader,
+    NexArmLeaderConfig,
+)
+
+
+def _make_bus_mock(positions: dict[str, float] | None = None) -> MagicMock:
+    if positions is None:
+        positions = dict.fromkeys(JOINT_NAMES, 0.0)
+
+    bus = MagicMock(name="NexArmBusMock")
+    bus.is_connected = False
+    bus.is_calibrated = True
+    bus.motors = {name: MagicMock(id=i + 1) for i, name in enumerate(JOINT_NAMES)}
+    bus.calibration = {
+        name: MotorCalibration(
+            id=i + 1, drive_mode=0, homing_offset=0, range_min=100, range_max=3900
+        )
+        for i, name in enumerate(JOINT_NAMES)
+    }
+
+    def _connect(handshake=True):  # noqa: ARG001
+        bus.is_connected = True
+
+    def _disconnect(disable_torque=True):  # noqa: ARG001
+        bus.is_connected = False
+
+    bus.connect.side_effect = _connect
+    bus.disconnect.side_effect = _disconnect
+    bus.sync_read.return_value = dict(positions)
+    bus.enable_torque.return_value = None
+    bus.disable_torque.return_value = None
+    bus.enter_lerobot_mode.return_value = None
+    bus.exit_lerobot_mode.return_value = None
+    bus.handshake.return_value = None
+    return bus
+
+
+@pytest.fixture
+def leader():
+    bus_mock = _make_bus_mock()
+    with patch(
+        "lerobot.teleoperators.nexarm_leader.nexarm_leader.NexArmMotorsBus",
+        return_value=bus_mock,
+    ):
+        cfg = NexArmLeaderConfig(port="/dev/null")
+        teleop = NexArmLeader(cfg)
+        teleop._bus_mock = bus_mock
+        yield teleop
+        if teleop.is_connected:
+            teleop.disconnect()
+
+
+@pytest.fixture
+def leader_with_positions():
+    positions = {name: float(i + 1) * 10 for i, name in enumerate(JOINT_NAMES)}
+    bus_mock = _make_bus_mock(positions)
+    with patch(
+        "lerobot.teleoperators.nexarm_leader.nexarm_leader.NexArmMotorsBus",
+        return_value=bus_mock,
+    ):
+        cfg = NexArmLeaderConfig(port="/dev/null")
+        teleop = NexArmLeader(cfg)
+        teleop._bus_mock = bus_mock
+        teleop._expected_positions = positions
+        yield teleop
+        if teleop.is_connected:
+            teleop.disconnect()
+
+
+class TestLeaderConnectDisconnect:
+    def test_not_connected_initially(self, leader):
+        assert not leader.is_connected
+
+    def test_connect(self, leader):
+        leader.connect()
+        assert leader.is_connected
+
+    def test_connect_enters_lerobot_mode(self, leader):
+        leader.connect()
+        leader._bus_mock.enter_lerobot_mode.assert_called_once()
+
+    def test_connect_calls_handshake(self, leader):
+        leader.connect()
+        leader._bus_mock.handshake.assert_called_once()
+
+    def test_connect_disables_torque(self, leader):
+        leader.connect()
+        leader._bus_mock.disable_torque.assert_called()
+
+    def test_connect_does_not_calibrate_when_already_calibrated(self, leader):
+        leader.connect()
+        leader._bus_mock.record_ranges_of_motion.assert_not_called()
+
+    def test_disconnect(self, leader):
+        leader.connect()
+        leader.disconnect()
+        assert not leader.is_connected
+
+    def test_connect_idempotent(self, leader):
+        from lerobot.utils.errors import DeviceAlreadyConnectedError
+
+        leader.connect()
+        with pytest.raises(DeviceAlreadyConnectedError):
+            leader.connect()
+
+
+class TestLeaderGetAction:
+    def test_returns_all_joint_keys(self, leader_with_positions):
+        leader_with_positions.connect()
+        action = leader_with_positions.get_action()
+        for name in JOINT_NAMES:
+            assert f"{name}.pos" in action
+
+    def test_returns_correct_values(self, leader_with_positions):
+        leader_with_positions.connect()
+        action = leader_with_positions.get_action()
+        for name in JOINT_NAMES:
+            assert action[f"{name}.pos"] == leader_with_positions._expected_positions[name]
+
+    def test_calls_sync_read(self, leader):
+        leader.connect()
+        leader.get_action()
+        leader._bus_mock.sync_read.assert_called_with("Present_Position")
+
+
+class TestLeaderSendFeedback:
+    def test_send_feedback_is_noop(self, leader):
+        leader.connect()
+        result = leader.send_feedback({"some_key": 1.0})
+        assert result is None
+
+
+class TestLeaderConfig:
+    def test_default_baudrate(self):
+        cfg = NexArmLeaderConfig(port="/dev/null")
+        assert cfg.baudrate == 1_000_000
+
+    def test_action_features_match_joints(self):
+        with patch(
+            "lerobot.teleoperators.nexarm_leader.nexarm_leader.NexArmMotorsBus",
+            return_value=_make_bus_mock(),
+        ):
+            cfg = NexArmLeaderConfig(port="/dev/null")
+            teleop = NexArmLeader(cfg)
+            assert set(teleop.action_features.keys()) == {f"{n}.pos" for n in JOINT_NAMES}
+
+    def test_feedback_features_empty(self):
+        with patch(
+            "lerobot.teleoperators.nexarm_leader.nexarm_leader.NexArmMotorsBus",
+            return_value=_make_bus_mock(),
+        ):
+            cfg = NexArmLeaderConfig(port="/dev/null")
+            teleop = NexArmLeader(cfg)
+            assert teleop.feedback_features == {}


### PR DESCRIPTION
## Summary

- Add `NexArmFollower` robot and `NexArmLeader` teleoperator for the NexArm 6-DOF desktop arm (Hiwonder)
- Custom `NexArmMotorsBus` driver over USB serial at 1 Mbps using ESP32 + AT32F421 co-processor + HX-30HM serial bus servos
- Calibration follows the standard `record_ranges_of_motion` flow (same as SO-100/SO-101) — no hard-coded joint remaps needed
- 68 unit tests covering frame parsing, bus lifecycle, normalisation, calibration, and robot/teleop interfaces; all pass with mocked serial I/O (no hardware required)

## Related issues

- Depends on #3872 (Hiwonder HX-30HM motor driver — needed for `NexArmMotorsBus`)

## Hardware

| Component | Description |
|-----------|-------------|
| Leader arm | ESP32 directly driving 6 HX-30HM servos, torque-off for drag-to-teach |
| Follower arm | ESP32 + AT32F421 co-processor driving 6 HX-30HM servos |
| Servos | HX-30HM — 12-bit resolution (0–4095), 1 Mbps baud rate |
| Cameras | 2× USB cameras (`front` + `wrist`), 640×480 @ 30 fps |

## Demo

https://github.com/user-attachments/assets/0b70a2d8-9112-4549-9a44-3a291db6fcd6

## Test plan

- [x] `pytest tests/motors/test_nexarm.py` — 37 passed
- [x] `pytest tests/robots/test_nexarm_follower.py` — 17 passed
- [x] `pytest tests/robots/test_nexarm_leader.py` — 14 passed
- [x] Teleoperation demo video (see above)

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest tests/motors/test_nexarm.py tests/robots/test_nexarm_follower.py tests/robots/test_nexarm_leader.py`)
- [x] Documentation updated (`examples/nexarm/`, robot config comments)
- [x] CI is green (label check passed; full test suite pending CI run)
- [x] Community Review: reviewed #3936 — https://github.com/huggingface/lerobot/pull/3936#pullrequestreview-4668174816

## Reviewer notes

- `NexArmMotorsBus` is a fully independent driver (not inheriting Feetech) — it implements a custom CommProtocol over USB serial to the ESP32+AT32 co-processor. Frame format and CMD table are documented in the PR description and in `src/lerobot/motors/nexarm/nexarm.py`.
- All tests use mocked serial I/O — no hardware required to run the test suite.
- This PR can be reviewed independently of #3872 since `NexArmMotorsBus` is separate from `HiwonderMotorsBus`. They share the same servo hardware (HX-30HM) but different firmware and communication protocols.
