### PR TITLE
feat: add fine_tune_vision_encoder config to SmolVLA

### DIFF
--- a/src/lerobot/policies/smolvla/configuration_smolvla.py
+++ b/src/lerobot/policies/smolvla/configuration_smolvla.py
@@ -67,6 +67,7 @@ class SmolVLAConfig(PreTrainedConfig):
 
     # Finetuning settings
     freeze_vision_encoder: bool = True
+    fine_tune_vision_encoder: bool = False
     train_expert_only: bool = True
     train_state_proj: bool = True
 

--- a/src/lerobot/policies/smolvla/modeling_smolvla.py
+++ b/src/lerobot/policies/smolvla/modeling_smolvla.py
@@ -246,6 +246,14 @@ class SmolVLAPolicy(PreTrainedPolicy):
         self.config = config
         self.init_rtc_processor()
         self.model = VLAFlowMatching(config, rtc_processor=self.rtc_processor)
+
+        if self.config.fine_tune_vision_encoder:
+            self.model.vlm_with_expert.freeze_vision_encoder = False
+            for params in self.model.vlm_with_expert.get_vlm_model().vision_model.parameters():
+                params.requires_grad = True
+            for params in self.model.vlm_with_expert.get_vlm_model().connector.parameters():
+                params.requires_grad = True
+
         self.reset()
 
     def reset(self):


### PR DESCRIPTION
Fixes #1774

Adds a `fine_tune_vision_encoder` boolean config option to SmolVLA. When enabled, the vision encoder and connector parameters are unfrozen during fine-tuning, allowing the model to learn color/shape discrimination tasks that the frozen vision encoder cannot distinguish.