### PR TITLE
fix(async): postprocess full action chunks

### DIFF
--- a/src/lerobot/async_inference/policy_server.py
+++ b/src/lerobot/async_inference/policy_server.py
@@ -362,18 +362,15 @@ class PolicyServer(services_pb2_grpc.AsyncInferenceServicer):
 
         """4. Apply postprocessor"""
         # Apply postprocessor (handles unnormalization and device movement)
-        # Postprocessor expects (B, action_dim) per action, but we have (B, chunk_size, action_dim)
-        # So we process each action in the chunk individually
         start_postprocess = time.perf_counter()
-        _, chunk_size, _ = action_tensor.shape
 
-        # Process each action in the chunk
+        # Run postprocessor on the entire 3D tensor first (enables chunk-level postprocessing e.g. GR00T)
+        action_tensor_processed = self.postprocessor(action_tensor)
+
+        _, chunk_size, _ = action_tensor_processed.shape
         processed_actions = []
         for i in range(chunk_size):
-            # Extract action at timestep i: (B, action_dim)
-            single_action = action_tensor[:, i, :]
-            processed_action = self.postprocessor(single_action)
-            processed_actions.append(processed_action)
+            processed_actions.append(action_tensor_processed[:, i, :])
 
         # Stack back to (B, chunk_size, action_dim), then remove batch dim
         action_tensor = torch.stack(processed_actions, dim=1).squeeze(0)

--- a/src/lerobot/async_inference/policy_server.py
+++ b/src/lerobot/async_inference/policy_server.py
@@ -362,21 +362,11 @@ class PolicyServer(services_pb2_grpc.AsyncInferenceServicer):
 
         """4. Apply postprocessor"""
         # Apply postprocessor (handles unnormalization and device movement)
-        # Postprocessor expects (B, action_dim) per action, but we have (B, chunk_size, action_dim)
-        # So we process each action in the chunk individually
         start_postprocess = time.perf_counter()
-        _, chunk_size, _ = action_tensor.shape
 
-        # Process each action in the chunk
-        processed_actions = []
-        for i in range(chunk_size):
-            # Extract action at timestep i: (B, action_dim)
-            single_action = action_tensor[:, i, :]
-            processed_action = self.postprocessor(single_action)
-            processed_actions.append(processed_action)
-
-        # Stack back to (B, chunk_size, action_dim), then remove batch dim
-        action_tensor = torch.stack(processed_actions, dim=1).squeeze(0)
+        # Chunk-dependent postprocessors (for example, GR00T relative-action decoding)
+        # require the time dimension and may change the output horizon.
+        action_tensor = self.postprocessor(action_tensor).squeeze(0)
         self.logger.debug(f"Postprocessed action shape: {action_tensor.shape}")
 
         action_tensor = action_tensor.detach().cpu()

--- a/tests/async_inference/test_policy_server.py
+++ b/tests/async_inference/test_policy_server.py
@@ -217,3 +217,44 @@ def test_predict_action_chunk(monkeypatch, policy_server):
     for i, ta in enumerate(timed_actions):
         expected_ts = obs.get_timestamp() + i * policy_server.config.environment_dt
         assert abs(ta.get_timestamp() - expected_ts) < 1e-6
+
+
+def test_predict_action_chunk_with_shape_sensitive_postprocessor(monkeypatch, policy_server):
+    """Verify that the policy server supports shape-sensitive/chunk-dependent postprocessors
+    (e.g., relative action decoding) by passing the full 3D chunk.
+    """
+    from lerobot.async_inference.policy_server import PolicyServer
+
+    policy_server.policy_type = "act"
+    policy_server.preprocessor = lambda obs: obs
+
+    # 1. Setup a shape-sensitive postprocessor that strictly asserts input has 3 dimensions (ndim == 3)
+    # This mimics GrootN17ActionDecodeStep
+    def mock_shape_sensitive_postprocessor(tensor):
+        assert tensor.ndim == 3, f"Expected 3D tensor, got shape {tensor.shape}"
+        # Dummy operation to verify value preservation: multiply by 2
+        return tensor * 2
+
+    policy_server.postprocessor = mock_shape_sensitive_postprocessor
+    action_dim = 6
+    batch_size = 1
+    actions_per_chunk = policy_server.actions_per_chunk
+
+    # Mock the policy inference to return a deterministic 3D tensor of shape (B, T, D)
+    def _fake_get_action_chunk(_self, _obs, _type="act"):
+        return torch.ones(batch_size, actions_per_chunk, action_dim)
+
+    monkeypatch.setattr(PolicyServer, "_get_action_chunk", _fake_get_action_chunk, raising=True)
+
+    # 2. Run prediction
+    obs = _make_obs(torch.zeros(6), timestep=5)
+    timed_actions = policy_server._predict_action_chunk(obs)
+
+    # 3. Verify assertions
+    assert len(timed_actions) == actions_per_chunk
+    # Check that each action value was processed correctly (multiplied by 2)
+    # The fake policy returned ones, so the postprocessed values should be twos.
+    for ta in timed_actions:
+        assert torch.allclose(ta.action, torch.ones(action_dim) * 2), (
+            "TimedAction values were not correctly postprocessed"
+        )

--- a/tests/async_inference/test_policy_server.py
+++ b/tests/async_inference/test_policy_server.py
@@ -217,3 +217,49 @@ def test_predict_action_chunk(monkeypatch, policy_server):
     for i, ta in enumerate(timed_actions):
         expected_ts = obs.get_timestamp() + i * policy_server.config.environment_dt
         assert abs(ta.get_timestamp() - expected_ts) < 1e-6
+
+
+def test_predict_action_chunk_postprocesses_full_chunk_and_uses_output_horizon(monkeypatch, policy_server):
+    """Preserve the time axis for chunk-dependent transforms and horizon changes."""
+    from lerobot.async_inference.policy_server import PolicyServer
+
+    policy_server.policy_type = "act"
+    policy_server.preprocessor = lambda obs: obs
+    action_dim = 6
+    batch_size = 1
+    actions_per_chunk = policy_server.actions_per_chunk
+    output_horizon = actions_per_chunk - 3
+    raw_actions = torch.arange(batch_size * actions_per_chunk * action_dim, dtype=torch.float32).reshape(
+        batch_size, actions_per_chunk, action_dim
+    )
+    received_shapes = []
+
+    def chunk_dependent_postprocessor(tensor):
+        received_shapes.append(tensor.shape)
+        if tensor.ndim != 3:
+            raise NotImplementedError("This postprocessor requires a full action chunk")
+        horizon_offsets = torch.arange(tensor.shape[1], dtype=tensor.dtype, device=tensor.device).reshape(
+            1, -1, 1
+        )
+        return (tensor + horizon_offsets)[:, :output_horizon]
+
+    policy_server.postprocessor = chunk_dependent_postprocessor
+
+    def _fake_get_action_chunk(_self, _obs, _type="act"):
+        return raw_actions
+
+    monkeypatch.setattr(PolicyServer, "_get_action_chunk", _fake_get_action_chunk, raising=True)
+
+    obs = _make_obs(torch.zeros(6), timestep=5)
+    timed_actions = policy_server._predict_action_chunk(obs)
+
+    assert received_shapes == [torch.Size((batch_size, actions_per_chunk, action_dim))]
+    assert len(timed_actions) == output_horizon
+    assert [ta.get_timestep() for ta in timed_actions] == list(range(5, 5 + output_horizon))
+
+    horizon_offsets = torch.arange(actions_per_chunk, dtype=raw_actions.dtype).reshape(1, -1, 1)
+    expected_actions = (raw_actions + horizon_offsets).squeeze(0)[:output_horizon]
+    for i, (timed_action, expected_action) in enumerate(zip(timed_actions, expected_actions, strict=True)):
+        torch.testing.assert_close(timed_action.get_action(), expected_action)
+        expected_timestamp = obs.get_timestamp() + i * policy_server.config.environment_dt
+        assert abs(timed_action.get_timestamp() - expected_timestamp) < 1e-6


### PR DESCRIPTION
## Summary / Motivation

The async policy server currently splits a predicted action chunk `(B, T, D)` into `T` tensors of shape `(B, D)` before output postprocessing. `GrootN17ActionDecodeStep` requires the full temporal chunk for native relative-action decoding, so serving GR00T N1.7 through this path raises `NotImplementedError`.

This PR postprocesses the complete chunk once, then creates `TimedAction`s from the returned time dimension.

## Related issues

- An independent user reproduced the GR00T N1.7 failure on LeRobot 0.6.0: [comment](https://github.com/huggingface/lerobot/pull/3981#issuecomment-5152020759).

## What changed

- Pass `(B, T, D)` to the output postprocessor instead of calling it once per timestep.
- Use the postprocessor's returned horizon when constructing timed actions.
- Add one regression test for the full-chunk contract and returned action values, horizon, timestamps, and timesteps.

No public API or configuration changes.

## How was this tested (or how to run locally)

- The new regression test fails on current `main` because the postprocessor receives `(1, 6)`; it passes on this branch with one `(1, 20, 6)` call.
- `uv run pytest -q tests/async_inference`: 23 passed, 2 skipped.
- `uv run pytest -q tests/policies/test_relative_actions.py`: 13 passed.
- Focused GR00T decoder rank/horizon tests: 3 passed.
- CPU base-dependency test tier: 1376 passed, 414 skipped.
- `uv run pre-commit run --all-files`: passed.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [ ] All tests pass locally (`pytest`) — affected tests and the CPU base tier pass; optional tiers are left to CI
- [x] Documentation updated — N/A, no public API or configuration change
- [ ] CI is green — fork workflow runs are awaiting maintainer approval
- [x] Community Review: reviewed #3970 ([review](https://github.com/huggingface/lerobot/pull/3970#pullrequestreview-4669043597))

## Reviewer notes

The regression uses a generic chunk-dependent postprocessor so the async test suite does not depend on the optional GR00T package. Existing GR00T tests cover its 3D-input requirement and valid-horizon slicing.

AI assistance was used to audit compatibility, refine the regression test, and draft this description. I reviewed the resulting diff and validation evidence and remain responsible for the contribution.
