### PR TITLE
Add JointStates output and Foxglove app URL for URDF visualization

### DIFF
--- a/src/lerobot/utils/foxglove_visualization.py
+++ b/src/lerobot/utils/foxglove_visualization.py
@@ -66,7 +66,6 @@ _SCALARS_SCHEMA = {
     },
 }
 
-# Topic for foxglove.JointStates messages that drive a URDF in the Foxglove 3D panel.
 JOINT_STATES_TOPIC = "/joint_states"
 
 

--- a/src/lerobot/utils/foxglove_visualization.py
+++ b/src/lerobot/utils/foxglove_visualization.py
@@ -21,6 +21,7 @@ importing from here directly. Requires the ``viz`` extra (``pip install 'lerobot
 """
 
 import logging
+import math
 import numbers
 import time
 
@@ -65,6 +66,9 @@ _SCALARS_SCHEMA = {
     },
 }
 
+# Topic for foxglove.JointStates messages that drive a URDF in the Foxglove 3D panel.
+JOINT_STATES_TOPIC = "/joint_states"
+
 
 def _is_scalar(x):
     return isinstance(x, (float | numbers.Real | np.integer | np.floating)) or (
@@ -94,6 +98,11 @@ def init_foxglove(host: str = "127.0.0.1", port: int | None = 8765) -> None:
         return
     log_foxglove_data.server = foxglove.start_server(host=host, port=port or 8765)
     log_foxglove_data.channels = {}
+    app_url = log_foxglove_data.server.app_url()
+    if app_url is not None:
+        message = f"Open in Foxglove: {app_url}"
+        logging.info(message)
+        print(message)
 
 
 def shutdown_foxglove() -> None:
@@ -159,6 +168,57 @@ def _log_foxglove_scalars(
     if channel is None:
         channel = channels[topic] = foxglove.Channel(topic, schema=_SCALARS_SCHEMA, message_encoding="json")
     msg = {"scalars": [{"label": label, "value": value} for label, value in values.items()]}
+    if log_time is None:
+        channel.log(msg)
+    else:
+        channel.log(msg, log_time=log_time)
+
+
+def _observation_to_joint_positions(scalars: dict[str, float]) -> dict[str, float]:
+    """Convert observation scalars to URDF joint positions in radians.
+
+    LeRobot reports joint positions as ``<joint>.pos`` scalars. Revolute joints are assumed to be in
+    degrees; gripper joints are assumed to be a 0-100 percent (SO-101 convention) and mapped to radians.
+    """
+
+    positions: dict[str, float] = {}
+    for key, value in scalars.items():
+        if not key.endswith(".pos"):
+            continue
+        joint_name = key[: -len(".pos")]
+        if "gripper" in joint_name:
+            # SO-101 gripper: percent (0-100) -> radians (0-pi).
+            positions[joint_name] = (value / 100.0) * math.pi
+        else:
+            positions[joint_name] = math.radians(value)
+    return positions
+
+
+def _log_foxglove_joint_states(
+    topic: str,
+    positions: dict[str, float],
+    *,
+    channels: dict | None = None,
+    log_time: int | None = None,
+) -> None:
+    """Log joint positions as a ``foxglove.JointStates`` message for URDF visualization."""
+
+    if not positions:
+        return
+
+    from foxglove.channels import JointStatesChannel
+    from foxglove.messages import JointState, JointStates, Timestamp
+
+    if channels is None:
+        channels = log_foxglove_data.channels
+    channel = channels.get(topic)
+    if channel is None:
+        channel = channels[topic] = JointStatesChannel(topic=topic)
+
+    time_ns = time.time_ns() if log_time is None else log_time
+    timestamp = Timestamp(sec=time_ns // 1_000_000_000, nsec=time_ns % 1_000_000_000)
+    joints = [JointState(name=name, position=position) for name, position in positions.items()]
+    msg = JointStates(timestamp=timestamp, joints=joints)
     if log_time is None:
         channel.log(msg)
     else:
@@ -333,6 +393,11 @@ def log_foxglove_data(
                         log_time=now,
                     )
         _log_foxglove_scalars(_foxglove_topic(OBS_STATE), obs_scalars, log_time=now)
+        _log_foxglove_joint_states(
+            JOINT_STATES_TOPIC,
+            _observation_to_joint_positions(obs_scalars),
+            log_time=now,
+        )
 
     if action:
         action_scalars: dict[str, float] = {}
@@ -488,9 +553,16 @@ def serve_foxglove_dataset_playback(
                 depth_range=depth_ranges.get(key),
                 raw_depth_values=True,
             )
+        obs_scalars = _frame_to_scalars(sample, OBS_STATE, scalar_labels[OBS_STATE])
         _log_foxglove_scalars(
             _foxglove_topic(OBS_STATE),
-            _frame_to_scalars(sample, OBS_STATE, scalar_labels[OBS_STATE]),
+            obs_scalars,
+            channels=channels,
+            log_time=log_time,
+        )
+        _log_foxglove_joint_states(
+            JOINT_STATES_TOPIC,
+            _observation_to_joint_positions(obs_scalars),
             channels=channels,
             log_time=log_time,
         )
@@ -638,6 +710,9 @@ def serve_foxglove_dataset_playback(
     thread.start()
 
     print(f"Foxglove server running. Connect the Foxglove app to ws://{host}:{port}")
+    app_url = server.app_url()
+    if app_url is not None:
+        print(f"Open in Foxglove: {app_url}")
     print("Use the playback controls in Foxglove to play/pause and scrub the episode. Ctrl-C to exit.")
     try:
         while not stop_event.is_set():

--- a/tests/utils/test_foxglove_visualization.py
+++ b/tests/utils/test_foxglove_visualization.py
@@ -99,3 +99,21 @@ def test_is_scalar():
     assert fv._is_scalar(np.array(3.0))  # 0-d array
     assert not fv._is_scalar(np.array([1.0, 2.0]))
     assert not fv._is_scalar("x")
+
+
+def test_observation_to_joint_positions():
+    import math
+
+    scalars = {
+        "shoulder_pan.pos": 90.0,
+        "shoulder_lift.pos": 45.0,
+        "gripper.pos": 50.0,
+        "temperature": 36.5,
+    }
+    positions = fv._observation_to_joint_positions(scalars)
+    assert positions == {
+        "shoulder_pan": math.radians(90.0),
+        "shoulder_lift": math.radians(45.0),
+        "gripper": (50.0 / 100.0) * math.pi,
+    }
+    assert fv._observation_to_joint_positions({}) == {}


### PR DESCRIPTION
## Add JointStates output and Foxglove app URL for URDF visualization

Publish foxglove.JointStates on /joint_states from observation joint positions (degrees to radians, gripper percent to radians) so the Foxglove 3D panel can drive a URDF. Print a clickable app.foxglove.dev URL when the WebSocket server starts for live streaming and dataset playback.

## Summary / Motivation

- With Foxglove, it's easy to visualize a robot state using URDF and joint states (in Radians)
- This approach can be useful to visually confirm there are no large joint offsets between the robot and reported joint positions

## Related issues

- Related: #3902 that added Foxglove support

## What changed

- Output a hyperlink on Foxglove connection that allows you to quickly open Foxglove
- Convert joint states to radians, and output joint state message on `/joint_states` topic

## How was this tested (or how to run locally)

- Added a test test_observation_to_joint_positions in test_foxglove_visualization.py
- Tested it locally, following these steps:

1. Run lerobot-dataset-viz:

```
uv run lerobot-dataset-viz \              
  --repo-id lerobot/svla_so101_pickplace \
  --episode-index 0 \
  --display-mode foxglove
```
2. Open Foxglove, and connected to `ws://localhost:8765`
3. Add a 3D panel and add a URDF custom layer with URL source: https://raw.githubusercontent.com/TheRobotStudio/SO-ARM100/refs/heads/main/Simulation/SO101/so101_new_calib.urdf
4. In URDF layer setting set Control mode to `Joint states ` and select `/joint_states` topic

Note: It can happen that when you open a URDF it's all weirdly broken. If it happens, you have to change the Mesh up-axis in The 3D Panel scene settings
<img width="428" height="489" alt="image" src="https://github.com/user-attachments/assets/c661feb4-1683-4d78-b547-2f44f6f18372" />

Here is the layout file in case you don't want to set the layout manually:
[lerobot-joint-states.json](https://github.com/user-attachments/files/29887711/lerobot-joint-states.json)

Here is a video showing how to run it and set up a 3D panel and visualize the 3D state:

https://github.com/user-attachments/assets/cb2a17ee-a404-422e-8f96-cfe9e02daaa2


## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: # (insert PR number/link)

