### PR TITLE
feat(rollout): add smooth_handover flag to DAgger strategy config

### DIFF
--- a/docs/source/inference.mdx
+++ b/docs/source/inference.mdx
@@ -155,6 +155,7 @@ Foot pedal input is also supported via `--strategy.input_device=pedal`. Configur
 | `--strategy.record_autonomous`       | Record autonomous frames too (default: false)           |
 | `--strategy.upload_every_n_episodes` | Push to Hub every N episodes (default: 5)               |
 | `--strategy.input_device`            | Input device: `keyboard` or `pedal` (default: keyboard) |
+| `--strategy.smooth_handover`         | Smoothly hand control over at pause / correction start (default: true). Disable for clutch-style teleops that re-reference at the current robot pose on engage |
 | `--teleop.type`                      | **Required.** Teleoperator type                         |
 
 ### Episodic (`--strategy.type=episodic`)

--- a/src/lerobot/rollout/configs.py
+++ b/src/lerobot/rollout/configs.py
@@ -180,6 +180,14 @@ class DAggerStrategyConfig(RolloutStrategyConfig):
     # Target video file size in MB for episode rotation (record_autonomous
     # mode only).  Defaults to DEFAULT_VIDEO_FILE_SIZE_IN_MB when None.
     target_video_file_size_mb: int | None = None
+    # Whether to turn on or off the smooth handover behavior at phase transitions:
+    # the leader is driven to the follower position on pause (teleops with
+    # `send_feedback` capability), and the follower is slid to the teleop pose when
+    # a correction starts (non-actuated teleops). Disable for clutch-style
+    # teleoperators (e.g. VR controllers) that re-reference at the current robot
+    # pose on engage: the handover is already continuous there, and the blocking
+    # interpolation only delays the start of the correction.
+    smooth_handover: bool = True
     input_device: str = "keyboard"
     keyboard: DAggerKeyboardConfig = field(default_factory=DAggerKeyboardConfig)
     pedal: DAggerPedalConfig = field(default_factory=DAggerPedalConfig)

--- a/src/lerobot/rollout/strategies/dagger.py
+++ b/src/lerobot/rollout/strategies/dagger.py
@@ -623,8 +623,8 @@ class DAggerStrategy(RolloutStrategy):
     # State-machine transition side-effects
     # ------------------------------------------------------------------
 
-    @staticmethod
     def _apply_transition(
+        self,
         old_phase: DAggerPhase,
         new_phase: DAggerPhase,
         engine,
@@ -633,6 +633,10 @@ class DAggerStrategy(RolloutStrategy):
         prev_action: dict | None,
     ) -> None:
         """Execute side-effects for a validated phase transition, including smooth handovers.
+
+        The smooth handovers below can be disabled with
+        ``--strategy.smooth_handover=false`` (useful for clutch-style teleops
+        that re-reference at the current robot pose on engage).
 
         AUTONOMOUS -> PAUSED (actuated teleop):
             Pause the engine, then drive the leader arm to the follower's last
@@ -657,7 +661,7 @@ class DAggerStrategy(RolloutStrategy):
             logger.info("Pausing engine - robot holds position")
             engine.pause()
 
-            if teleop_supports_feedback(teleop) and prev_action is not None:
+            if self.config.smooth_handover and teleop_supports_feedback(teleop) and prev_action is not None:
                 # TODO(Maxime): prev_action is in robot action key space (output of robot_action_processor).
                 # send_feedback expects teleop feedback key space. For homogeneous setups (e.g. SO-101
                 # leader + SO-101 follower) the keys are identical so this works. If the processor pipeline
@@ -668,7 +672,11 @@ class DAggerStrategy(RolloutStrategy):
 
         elif old_phase == DAggerPhase.PAUSED and new_phase == DAggerPhase.CORRECTING:
             logger.info("Entering correction mode - human teleop control")
-            if not teleop_supports_feedback(teleop) and prev_action is not None:
+            if (
+                self.config.smooth_handover
+                and not teleop_supports_feedback(teleop)
+                and prev_action is not None
+            ):
                 logger.info("Smooth handover: sliding follower to teleop position")
                 obs = robot.get_observation()
                 teleop_action = teleop.get_action()


### PR DESCRIPTION
## Summary / Motivation

The DAgger strategy's phase transitions run blocking smooth handovers inside the record loop: on AUTONOMOUS → PAUSED the leader is driven to the follower's position (~2 s, actuated teleops), and on PAUSED → CORRECTING the follower is slid to the teleop's pose (~1 s, non-actuated teleops).

For clutch-style teleoperators — e.g. VR controllers that re-reference their command frame at the current robot pose on engage — the handover is already continuous by construction. The interpolation adds no safety, but it blocks the first ~1 s of every correction: short corrections lose most of their frames (we measured a ~1 s correction yielding a 1-frame episode), and the operator's initial motion isn't recorded.

This adds `--strategy.smooth_handover` (default `true`, existing behavior unchanged) so such setups can skip it. It mirrors the episodic strategy's existing `smooth_leader_to_follower_handover` flag.

## Related issues

- None

## What changed

- `DAggerStrategyConfig` gains `smooth_handover: bool = True`.
- `DAggerStrategy._apply_transition` becomes an instance method and gates both handover branches (`teleop_smooth_move_to` on pause, `follower_smooth_move_to` on correction start) on the flag. Torque enable/disable and engine pause/reset are untouched.
- Documented the flag in `docs/source/inference.mdx` (DAgger flags table).
- No breaking changes; the default preserves current behavior.

## How was this tested (or how to run locally)

- `ruff check` / `ruff format` pass on the changed files.
- Manual hardware runs on our rig (YAM arm + Quest 3 VR teleop with an engagement clutch, `--strategy.type=dagger`, corrections-only mode): with the handover skipped, correction recording starts on the first loop tick after engage (previously a "Record loop is running slower (1.0 Hz)" warning fired on every engage and the first second of each correction was lost).
- Default-on path unchanged (flag not set → identical behavior).

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [ ] All tests pass locally (`pytest`)
- [x] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: #

## Reviewer notes

- The only behavioral question is whether gating should be two flags (one per direction). We kept one flag since both handovers serve the same purpose (meeting the operator's hand) and a rig either needs them or doesn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
