### PR TITLE
fix(utils): preserve exc_info/stack_info in init_logging formatter

### DIFF
--- a/src/lerobot/utils/utils.py
+++ b/src/lerobot/utils/utils.py
@@ -65,7 +65,23 @@ def init_logging(
         dt = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         fnameline = f"{record.pathname}:{record.lineno}"
         pid_str = f"[PID: {os.getpid()}] " if display_pid else ""
-        return f"{record.levelname} {pid_str}{dt} {fnameline[-15:]:>15} {record.getMessage()}"
+        msg = f"{record.levelname} {pid_str}{dt} {fnameline[-15:]:>15} {record.getMessage()}"
+        # Preserve traceback / stack info (logging.Formatter.format default behavior).
+        # Replacing Formatter.format wholesale would otherwise drop logging.exception()
+        # and log(..., exc_info=True) traces — critical for HIL-SERL actor/learner.
+        if record.exc_info:
+            if not record.exc_text:
+                record.exc_text = logging.Formatter().formatException(record.exc_info)
+            if record.exc_text:
+                msg = f"{msg}
+{record.exc_text}"
+        if record.stack_info:
+            if msg[-1:] != "
+":
+                msg = msg + "
+"
+            msg = msg + record.stack_info
+        return msg
 
     formatter = logging.Formatter()
     formatter.format = custom_format

--- a/tests/utils/test_init_logging.py
+++ b/tests/utils/test_init_logging.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for `lerobot.utils.utils.init_logging`."""
+
+import io
+import logging
+
+from lerobot.utils.utils import init_logging
+
+
+def test_init_logging_exception_includes_traceback():
+    """logging.exception must print a traceback after init_logging (issue #3978)."""
+    stream = io.StringIO()
+    # Re-init onto a captive stream: wire root logger like init_logging does.
+    init_logging()
+    root = logging.getLogger()
+    # Replace console handlers with our StringIO so the test is hermetic.
+    root.handlers.clear()
+    handler = logging.StreamHandler(stream)
+    # Re-apply the same formatter shape via init_logging on a temp file path then copy ,
+    # simpler: call init_logging again is hard; mirror the product formatter by reusing init
+    # through monkeypatch of StreamHandler.stdout is messy. Rebuild using init_logging + replace stream.
+
+    init_logging()
+    for h in list(root.handlers):
+        if isinstance(h, logging.StreamHandler) and not isinstance(h, logging.FileHandler):
+            h.stream = stream
+
+    try:
+        raise ValueError("boom-for-logging-test")
+    except ValueError:
+        logging.exception("Unhandled exception in act_with_policy")
+
+    out = stream.getvalue()
+    assert "Unhandled exception in act_with_policy" in out
+    assert "ValueError: boom-for-logging-test" in out
+    assert "Traceback (most recent call last)" in out
+
+
+def test_init_logging_plain_info_has_no_traceback():
+    stream = io.StringIO()
+    init_logging()
+    root = logging.getLogger()
+    for h in list(root.handlers):
+        if isinstance(h, logging.StreamHandler) and not isinstance(h, logging.FileHandler):
+            h.stream = stream
+    logging.info("hello-no-exc")
+    out = stream.getvalue()
+    assert "hello-no-exc" in out
+    assert "Traceback" not in out


### PR DESCRIPTION
## Summary
`init_logging()` replaces `logging.Formatter.format` with a custom layout that never appends `record.exc_info` / `record.stack_info`. After `init_logging()`, **`logging.exception()` and `log(..., exc_info=True)` print only the message line** — no traceback.

This makes HIL-SERL actor/learner top-level crash handlers nearly useless:
- `src/lerobot/rl/actor.py` — `logging.exception("[ACTOR] Unhandled exception...")`
- `src/lerobot/rl/learner.py` — `logging.exception("[LEARNER] Unhandled exception...")`

## Motivation
Fixes #3978. Small stdlib-aligned fix; zero AWS/GPU required.

## Changes
- Append formatted exception text (and stack info) in `custom_format`, matching stdlib `Formatter.format` behavior.
- Add `tests/utils/test_init_logging.py` regression tests.

## Verification
- Logic unit-smoked: `logging.exception` after the patched formatter prints `Traceback` + exception type/message.
- Full `pytest` suite not run locally (optional heavy deps / draccus not installed in this agent env); CI `fast_tests` / quality expected to cover.

## Duplicate check
- No open PR for #3978 at ship time.
- Unrelated open: #3865 (HfHubHTTPError import), #3853/#3859 (resume empty dataset).