### PR TITLE
fix(utils): handle ndarray/tensor edges in unwrap_scalar

### DIFF
--- a/src/lerobot/utils/utils.py
+++ b/src/lerobot/utils/utils.py
@@ -174,11 +174,16 @@ def unwrap_scalar(value: Any) -> Any:
             or a zero-dimensional container that does not expose a scalar.
     """
     if isinstance(value, np.ndarray):
-        if value.size != 1:
+        # ndarray.item() already unwraps every size-1 shape (incl. 0-d) and
+        # raises ValueError for multi-element arrays, so defer to it directly.
+        try:
+            return value.item()
+        except ValueError as e:
             raise ValueError(
                 f"Expected a scalar array, got shape {value.shape} (size={value.size}): {value!r}"
-            )
-        return unwrap_scalar(value.reshape(()).item() if value.shape == () else value.reshape(-1)[0])
+            ) from e
+    # Guard excludes bytes/str (no .item) and, deliberately, np.str_ so string
+    # scalars are returned unchanged rather than unwrapped to a Python str.
     if hasattr(value, "item") and not isinstance(value, (bytes, str)):
         # Avoid calling .item() on multi-element torch tensors — it raises a
         # generic RuntimeError. Normalize the message for callers/tests.

--- a/src/lerobot/utils/utils.py
+++ b/src/lerobot/utils/utils.py
@@ -163,15 +163,29 @@ def has_method(cls: object, method_name: str) -> bool:
 def unwrap_scalar(value: Any) -> Any:
     """Unwrap a tensor / numpy scalar / single-element list into a Python scalar.
 
-    Tensors and numpy scalars expose ``.item()``; single-element lists are
-    unwrapped recursively. Anything else is returned unchanged. Centralized
-    here so the language renderer and processor steps share one definition.
+    Tensors and numpy scalars expose ``.item()``; single-element lists and
+    length-1 numpy arrays are unwrapped recursively. Multi-element arrays
+    raise, matching list behaviour. Anything else is returned unchanged.
+    Centralized here so the language renderer and processor steps share one
+    definition.
 
     Raises:
-        ValueError: If ``value`` is a list with zero or multiple elements.
+        ValueError: If ``value`` is a list/array with zero or multiple elements,
+            or a zero-dimensional container that does not expose a scalar.
     """
-    if hasattr(value, "item"):
-        return value.item()
+    if isinstance(value, np.ndarray):
+        if value.size != 1:
+            raise ValueError(
+                f"Expected a scalar array, got shape {value.shape} (size={value.size}): {value!r}"
+            )
+        return unwrap_scalar(value.reshape(()).item() if value.shape == () else value.reshape(-1)[0])
+    if hasattr(value, "item") and not isinstance(value, (bytes, str)):
+        # Avoid calling .item() on multi-element torch tensors — it raises a
+        # generic RuntimeError. Normalize the message for callers/tests.
+        try:
+            return value.item()
+        except Exception as e:  # noqa: BLE001 - library variance (torch RuntimeError)
+            raise ValueError(f"Expected a scalar, got {type(value).__name__}: {value!r}") from e
     if isinstance(value, list):
         if len(value) != 1:
             raise ValueError(f"Expected a scalar, got list of length {len(value)}: {value!r}")

--- a/tests/utils/test_unwrap_scalar.py
+++ b/tests/utils/test_unwrap_scalar.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pytest
+import torch
+
+from lerobot.utils.utils import unwrap_scalar
+
+
+def test_python_scalar_passthrough():
+    assert unwrap_scalar(3) == 3
+    assert unwrap_scalar(1.5) == 1.5
+
+
+def test_single_element_list():
+    assert unwrap_scalar([7]) == 7
+    assert unwrap_scalar([[2.0]]) == 2.0
+
+
+def test_empty_or_multi_list_raises():
+    with pytest.raises(ValueError, match="list of length"):
+        unwrap_scalar([])
+    with pytest.raises(ValueError, match="list of length"):
+        unwrap_scalar([1, 2])
+
+
+def test_numpy_scalar_and_size1():
+    assert unwrap_scalar(np.array(4.0)) == 4.0
+    assert unwrap_scalar(np.array([5])) == 5
+
+
+def test_numpy_multielement_raises():
+    with pytest.raises(ValueError, match="scalar array"):
+        unwrap_scalar(np.array([1, 2, 3]))
+
+
+def test_torch_scalar():
+    assert unwrap_scalar(torch.tensor(9)) == 9
+
+
+def test_torch_multielement_raises():
+    with pytest.raises(ValueError, match="scalar"):
+        unwrap_scalar(torch.tensor([1, 2]))


### PR DESCRIPTION
## Summary
- Normalize length-1 numpy arrays like lists; reject multi-element arrays/tensors with a clear `ValueError`.

## Motivation
Multi-element `.item()` calls raise opaque library errors; size-1 arrays inconsistently fell through. Shared by language renderer / processor paths.

## Verification
- `python -m pytest tests/utils/test_unwrap_scalar.py --noconftest` → 7 passed