### PR TITLE
fix(utils): allow any JSON payload in write_json

### DIFF
--- a/src/lerobot/utils/io_utils.py
+++ b/src/lerobot/utils/io_utils.py
@@ -32,21 +32,23 @@ def load_json(fpath: Path) -> Any:
     Returns:
         Any: The data loaded from the JSON file.
     """
-    with open(fpath) as f:
+    with open(fpath, encoding="utf-8") as f:
         return json.load(f)
 
 
-def write_json(data: dict, fpath: Path) -> None:
-    """Write data to a JSON file.
+def write_json(data: Any, fpath: Path) -> None:
+    """Write JSON-serializable data to a file.
 
-    Creates parent directories if they don't exist.
+    Creates parent directories if they don't exist. Accepts any value that
+    ``json.dump`` can encode (dict, list, str, …) so callers are not forced
+    through a spurious ``dict``-only annotation.
 
     Args:
-        data (dict): The dictionary to write.
+        data: JSON-serializable payload.
         fpath (Path): The path to the output JSON file.
     """
     fpath.parent.mkdir(exist_ok=True, parents=True)
-    with open(fpath, "w") as f:
+    with open(fpath, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=4, ensure_ascii=False)
 
 

--- a/tests/utils/test_io_utils.py
+++ b/tests/utils/test_io_utils.py
@@ -88,3 +88,20 @@ def test_list_length_mismatch_raises(tmp_json_file):
     obj = {"nums": [0, 0]}
     with pytest.raises(ValueError):
         deserialize_json_into_object(json_path, obj)
+
+
+def test_write_and_load_json_roundtrip(tmp_path: Path):
+    from lerobot.utils.io_utils import load_json, write_json
+
+    path = tmp_path / "nested" / "data.json"
+    payload = {"a": 1, "b": [1, 2, 3]}
+    write_json(payload, path)
+    assert load_json(path) == payload
+
+
+def test_write_json_list(tmp_path: Path):
+    from lerobot.utils.io_utils import load_json, write_json
+
+    path = tmp_path / "list.json"
+    write_json([1, 2, 3], path)
+    assert load_json(path) == [1, 2, 3]


### PR DESCRIPTION
## Summary
- `write_json` accepts `Any` (lists/scalars allowed), writes with `encoding=\"utf-8\"` matching `load_json`.

## Motivation
Call sites already dump sequencing lists / mixed payloads; the `dict`-only annotation was a type-level footgun. Symmetric encoding avoids platform-default locale issues.

## Verification
- `python -m pytest tests/utils/test_io_utils.py --noconftest` → 9 passed