### PR TITLE
fix(rollout): reject incompatible RTC policies

### DIFF
--- a/src/lerobot/rollout/context.py
+++ b/src/lerobot/rollout/context.py
@@ -55,6 +55,7 @@ from .inference import (
     SyncInferenceConfig,
     create_inference_engine,
 )
+from .inference.rtc import supports_rtc_inference_kwargs
 from .robot_wrapper import ThreadSafeRobot
 
 logger = logging.getLogger(__name__)
@@ -203,6 +204,11 @@ def build_rollout_context(
         policy.config.rtc_config = cfg.inference.rtc
         if hasattr(policy, "init_rtc_processor"):
             policy.init_rtc_processor()
+        if not supports_rtc_inference_kwargs(policy):
+            raise ValueError(
+                f"RTC inference is not supported by policy type '{policy_config.type}': "
+                "predict_action_chunk must accept inference_delay and prev_chunk_left_over."
+            )
 
     policy = policy.to(cfg.device)
     policy.eval()

--- a/src/lerobot/rollout/inference/rtc.py
+++ b/src/lerobot/rollout/inference/rtc.py
@@ -22,6 +22,7 @@ way via ``notify_observation``.
 
 from __future__ import annotations
 
+import inspect
 import logging
 import math
 import time
@@ -60,6 +61,15 @@ _RTC_JOIN_TIMEOUT_S: float = 3.0
 # ---------------------------------------------------------------------------
 # RTC helpers
 # ---------------------------------------------------------------------------
+
+
+def supports_rtc_inference_kwargs(policy: PreTrainedPolicy) -> bool:
+    """Whether a policy accepts the extra context passed by RTC inference."""
+    parameters = inspect.signature(policy.predict_action_chunk).parameters
+    return any(parameter.kind is inspect.Parameter.VAR_KEYWORD for parameter in parameters.values()) or {
+        "inference_delay",
+        "prev_chunk_left_over",
+    }.issubset(parameters)
 
 
 def _normalize_prev_actions_length(prev_actions: torch.Tensor, target_steps: int) -> torch.Tensor:

--- a/tests/test_rtc_policy_compatibility.py
+++ b/tests/test_rtc_policy_compatibility.py
@@ -1,0 +1,33 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def test_rtc_policy_kwargs_compatibility():
+    from lerobot.rollout.inference.rtc import supports_rtc_inference_kwargs
+
+    class FixedSignaturePolicy:
+        def predict_action_chunk(self, batch):
+            return batch
+
+    class ExplicitRtcPolicy:
+        def predict_action_chunk(self, batch, inference_delay=None, prev_chunk_left_over=None):
+            return batch
+
+    class VariadicPolicy:
+        def predict_action_chunk(self, batch, **kwargs):
+            return batch
+
+    assert not supports_rtc_inference_kwargs(FixedSignaturePolicy())
+    assert supports_rtc_inference_kwargs(ExplicitRtcPolicy())
+    assert supports_rtc_inference_kwargs(VariadicPolicy())


### PR DESCRIPTION
## Summary / Motivation

RTC passes `inference_delay` and `prev_chunk_left_over` to `predict_action_chunk`, but several policies such as ACT expose a fixed signature and fail later inside the background inference thread. Validate the policy method immediately after loading so an incompatible policy produces a clear error before robot hardware is connected.

Closes #3997

## What changed

- Detect explicit RTC parameters or a variadic `**kwargs` policy signature.
- Raise a policy-specific error before hardware setup when RTC is incompatible.
- Cover fixed, explicit, and variadic signatures.

## How was this tested

- `uv run pytest -q tests/test_rtc_policy_compatibility.py tests/test_rollout.py` — 25 passed
- `uv run pre-commit run --files src/lerobot/rollout/context.py src/lerobot/rollout/inference/rtc.py tests/test_rtc_policy_compatibility.py`

## Checklist

- [x] Linting/formatting run on changed files
- [x] Relevant tests pass locally
- [ ] Documentation updated — not needed; error now describes the existing RTC contract
- [ ] CI is green
- [x] Community Review: reviewed #3995

## Reviewer notes

Please confirm whether fail-fast validation is preferable to widening fixed policy signatures that do not implement RTC semantics.