### PR TITLE
fix(utils): canonicalize rotvec dims in ActionInterpolator to avoid identity sweeps

### DIFF
--- a/docs/source/inference.mdx
+++ b/docs/source/inference.mdx
@@ -254,6 +254,7 @@ See the [Real-Time Chunking](./rtc) guide for details on tuning RTC parameters.
 | `--display_data`                  | Stream telemetry to Rerun visualization                           | false   |
 | `--display_ip` / `--display_port` | Remote Rerun server address                                       | --      |
 | `--interpolation_multiplier`      | Action interpolation factor                                       | 1       |
+| `--interpolation_rotation_dims`   | Action indices of rotation-vector (wx, wy, wz) triplets           | []      |
 | `--use_torch_compile`             | Enable `torch.compile` for inference                              | false   |
 | `--resume`                        | Resume a previous recording session                               | false   |
 | `--play_sounds`                   | Vocal synthesis for events                                        | true    |

--- a/src/lerobot/rollout/configs.py
+++ b/src/lerobot/rollout/configs.py
@@ -223,6 +223,11 @@ class RolloutConfig:
     fps: float = 30.0
     duration: float = 0.0  # 0 = infinite (24/7 mode)
     interpolation_multiplier: int = 1
+    # Action indices holding rotation vectors as (wx, wy, wz) triplets, e.g. [3, 4, 5].
+    # When set, these dims are canonicalized to the antipodal-twin rotvec nearest the
+    # previous action before interpolation, so interpolated sub-actions stay on the
+    # short arc instead of sweeping through the identity rotation (see #3691).
+    interpolation_rotation_dims: list[int] = field(default_factory=list)
     device: str | None = None
     task: str = ""
     display_data: bool = False

--- a/src/lerobot/rollout/strategies/core.py
+++ b/src/lerobot/rollout/strategies/core.py
@@ -56,11 +56,14 @@ class RolloutStrategy(abc.ABC):
         """Attach the inference engine and action interpolator, then start the backend.
 
         Creates an :class:`ActionInterpolator` from the config's
-        ``interpolation_multiplier`` and starts the inference engine.
-        Call this from ``setup()`` so strategies share identical
-        initialisation without duplicating code.
+        ``interpolation_multiplier`` and ``interpolation_rotation_dims``, and
+        starts the inference engine. Call this from ``setup()`` so strategies
+        share identical initialisation without duplicating code.
         """
-        self._interpolator = ActionInterpolator(multiplier=ctx.runtime.cfg.interpolation_multiplier)
+        self._interpolator = ActionInterpolator(
+            multiplier=ctx.runtime.cfg.interpolation_multiplier,
+            rotation_dims=ctx.runtime.cfg.interpolation_rotation_dims or None,
+        )
         self._engine = ctx.policy.inference
         logger.info("Starting inference engine...")
         self._engine.reset()

--- a/src/lerobot/utils/action_interpolator.py
+++ b/src/lerobot/utils/action_interpolator.py
@@ -18,7 +18,12 @@ Provides configurable Nx control rate by interpolating between consecutive actio
 Useful with RTC and action-chunking policies to reduce jerkiness.
 """
 
+import math
+
+import torch
 from torch import Tensor
+
+_ROTVEC_EPS = 1e-8
 
 
 class ActionInterpolator:
@@ -31,6 +36,13 @@ class ActionInterpolator:
         prev_action -> [1/3 interpolated, 2/3 interpolated, current_action]
 
     This effectively multiplies the control rate for smoother motion.
+
+    Action dimensions holding rotation vectors (axis-angle) cannot be
+    linearly interpolated directly: two rotvecs can encode (nearly) the same
+    rotation while lying ~2*pi apart in vector space (`r` and its antipodal
+    twin `(|r| - 2*pi) * r/|r|`), and the straight line between them sweeps
+    through the identity rotation. Pass ``rotation_dims`` to canonicalize such
+    dimensions to the twin nearest the previous action before interpolating.
 
     Usage:
         interpolator = ActionInterpolator(multiplier=2)  # 2x control rate
@@ -46,15 +58,27 @@ class ActionInterpolator:
             robot.send_action(action)
     """
 
-    def __init__(self, multiplier: int = 1):
+    def __init__(self, multiplier: int = 1, rotation_dims: list[int] | None = None):
         """Initialize the interpolator.
 
         Args:
             multiplier: Control rate multiplier (1 = no interpolation, 2 = 2x, 3 = 3x, etc.)
+            rotation_dims: Optional flat list of action indices that hold rotation
+                vectors, grouped in consecutive (wx, wy, wz) triplets, e.g.
+                ``[3, 4, 5]`` for a single end-effector or ``[3, 4, 5, 10, 11, 12]``
+                for a bimanual setup. When None (default), all dimensions are
+                interpolated linearly as before.
         """
         if multiplier < 1:
             raise ValueError(f"multiplier must be >= 1, got {multiplier}")
+        if rotation_dims is not None and len(rotation_dims) % 3 != 0:
+            raise ValueError(
+                f"rotation_dims must contain (wx, wy, wz) triplets, got {len(rotation_dims)} indices"
+            )
         self.multiplier = multiplier
+        self._rotation_triplets = (
+            [rotation_dims[i : i + 3] for i in range(0, len(rotation_dims), 3)] if rotation_dims else []
+        )
         self._prev: Tensor | None = None
         self._buffer: list[Tensor] = []
         self._idx = 0
@@ -74,6 +98,29 @@ class ActionInterpolator:
         """Check if a new action is needed from the queue."""
         return self._idx >= len(self._buffer)
 
+    def _canonicalize_rotvecs(self, action: Tensor) -> Tensor:
+        """Replace each rotation-vector triplet with its antipodal twin when closer to the previous action.
+
+        A rotation vector ``r`` and its twin ``(|r| - 2*pi) * r/|r|`` encode the
+        same rotation. Interpolating toward whichever lies closer to the previous
+        rotvec keeps the interpolated path on the short arc instead of sweeping
+        through the identity rotation.
+        """
+        if not self._rotation_triplets or self._prev is None:
+            return action
+        action = action.clone()
+        for triplet in self._rotation_triplets:
+            r = action[..., triplet]
+            norm = torch.linalg.vector_norm(r, dim=-1, keepdim=True)
+            twin = (norm - 2 * math.pi) * r / norm.clamp_min(_ROTVEC_EPS)
+            prev_r = self._prev[..., triplet]
+            twin_is_closer = torch.linalg.vector_norm(twin - prev_r, dim=-1, keepdim=True) < (
+                torch.linalg.vector_norm(r - prev_r, dim=-1, keepdim=True)
+            )
+            use_twin = (norm > _ROTVEC_EPS) & twin_is_closer
+            action[..., triplet] = torch.where(use_twin, twin, r)
+        return action
+
     def add(self, action: Tensor) -> None:
         """Add a new action and compute interpolated sequence.
 
@@ -81,6 +128,7 @@ class ActionInterpolator:
             action: New action tensor from policy/queue (already on CPU).
         """
         if self.multiplier > 1 and self._prev is not None:
+            action = self._canonicalize_rotvecs(action)
             self._buffer = []
             for i in range(1, self.multiplier + 1):
                 t = i / self.multiplier

--- a/tests/policies/rtc/test_action_interpolator.py
+++ b/tests/policies/rtc/test_action_interpolator.py
@@ -14,6 +14,8 @@
 
 """Tests for ActionInterpolator and its interaction with ActionQueue (RTC)."""
 
+import math
+
 import pytest
 import torch
 
@@ -557,3 +559,148 @@ def test_queue_interpolator_delay_skips_stale_actions():
     first_action = queue.get()
     assert first_action is not None
     torch.testing.assert_close(first_action, torch.tensor([103.0, 103.0]))
+
+
+# ====================== Rotation-vector canonicalization tests (#3691) ======================
+
+
+def _rotmat(rv: torch.Tensor) -> torch.Tensor:
+    """Rodrigues formula: rotation vector -> rotation matrix."""
+    theta = torch.linalg.vector_norm(rv)
+    if theta < 1e-12:
+        return torch.eye(3, dtype=rv.dtype)
+    k = rv / theta
+    kx = torch.tensor([[0.0, -k[2], k[1]], [k[2], 0.0, -k[0]], [-k[1], k[0], 0.0]], dtype=rv.dtype)
+    return torch.eye(3, dtype=rv.dtype) + torch.sin(theta) * kx + (1 - torch.cos(theta)) * (kx @ kx)
+
+
+def _geodesic_deg(rv_a: torch.Tensor, rv_b: torch.Tensor) -> float:
+    """Rotation angle in degrees between the rotations encoded by two rotvecs."""
+    cos = (torch.trace(_rotmat(rv_a).T @ _rotmat(rv_b)) - 1) / 2
+    return float(torch.rad2deg(torch.arccos(torch.clamp(cos, -1.0, 1.0))))
+
+
+def _antipodal_twin_pair() -> tuple[torch.Tensor, torch.Tensor]:
+    """Two rotvecs encoding the same physical rotation, ~2*pi apart in vector space.
+
+    179 deg about +x and 181 deg about -x are the same rotation (geodesic
+    distance 0) but their rotvec encodings differ by ~2*pi.
+    """
+    prev = torch.tensor([math.radians(179.0), 0.0, 0.0], dtype=torch.float64)
+    cur = torch.tensor([-math.radians(181.0), 0.0, 0.0], dtype=torch.float64)
+    return prev, cur
+
+
+def test_rotation_dims_antipodal_twins_no_identity_sweep():
+    """Interpolating between antipodal-twin rotvecs must not sweep through identity."""
+    prev, cur = _antipodal_twin_pair()
+    assert _geodesic_deg(prev, cur) < 1e-6  # same physical rotation
+
+    # Without rotation_dims the midpoint collapses to ~identity (the bug).
+    interp_bug = ActionInterpolator(multiplier=4)
+    interp_bug.add(prev)
+    interp_bug.get()
+    interp_bug.add(cur)
+    mid = [interp_bug.get() for _ in range(4)][1]  # t = 0.5
+    assert _geodesic_deg(mid, prev) > 170.0
+
+    # With rotation_dims every interpolated rotvec stays at the endpoint pose.
+    interp = ActionInterpolator(multiplier=4, rotation_dims=[0, 1, 2])
+    interp.add(prev)
+    interp.get()
+    interp.add(cur)
+    for _ in range(4):
+        step = interp.get()
+        assert step is not None
+        assert _geodesic_deg(step, prev) < 1e-6
+
+
+def test_rotation_dims_none_matches_previous_behavior():
+    """rotation_dims=None must reproduce plain linear interpolation exactly."""
+    prev, cur = _antipodal_twin_pair()
+    interp_default = ActionInterpolator(multiplier=3)
+    interp_explicit = ActionInterpolator(multiplier=3, rotation_dims=None)
+    for i in (prev, cur):
+        interp_default.add(i)
+        interp_explicit.add(i)
+    for _ in range(3):
+        torch.testing.assert_close(interp_default.get(), interp_explicit.get(), rtol=0, atol=0)
+
+
+def test_rotation_dims_close_rotvecs_identical_to_plain_lerp():
+    """When no twin is closer, canonicalization is a no-op and output equals plain lerp."""
+    prev = torch.tensor([0.1, 0.2, 0.3])
+    cur = torch.tensor([0.15, 0.25, 0.35])
+    plain = ActionInterpolator(multiplier=2)
+    canon = ActionInterpolator(multiplier=2, rotation_dims=[0, 1, 2])
+    for i in (prev, cur):
+        plain.add(i)
+        canon.add(i)
+    for _ in range(2):
+        torch.testing.assert_close(plain.get(), canon.get(), rtol=0, atol=0)
+
+
+def test_rotation_dims_other_dims_unaffected():
+    """Position and gripper dims must interpolate linearly even with rotation_dims set."""
+    prev_rot, cur_rot = _antipodal_twin_pair()
+    prev = torch.cat(
+        [
+            torch.tensor([0.0, 0.0, 0.0], dtype=torch.float64),
+            prev_rot,
+            torch.tensor([0.0], dtype=torch.float64),
+        ]
+    )
+    cur = torch.cat(
+        [
+            torch.tensor([0.3, 0.6, 0.9], dtype=torch.float64),
+            cur_rot,
+            torch.tensor([1.0], dtype=torch.float64),
+        ]
+    )
+    interp = ActionInterpolator(multiplier=3, rotation_dims=[3, 4, 5])
+    interp.add(prev)
+    interp.get()
+    interp.add(cur)
+    for i in range(1, 4):
+        t = i / 3
+        step = interp.get()
+        assert step is not None
+        expected_pos = prev[:3] + t * (cur[:3] - prev[:3])
+        expected_grip = prev[6:] + t * (cur[6:] - prev[6:])
+        torch.testing.assert_close(step[:3], expected_pos, rtol=0, atol=0)
+        torch.testing.assert_close(step[6:], expected_grip, rtol=0, atol=0)
+
+
+def test_rotation_dims_zero_rotation_no_nan():
+    """A zero rotvec (identity rotation) must not produce NaNs."""
+    interp = ActionInterpolator(multiplier=2, rotation_dims=[0, 1, 2])
+    interp.add(torch.tensor([0.5, 0.0, 0.0]))
+    interp.get()
+    interp.add(torch.zeros(3))
+    for _ in range(2):
+        step = interp.get()
+        assert step is not None
+        assert torch.isfinite(step).all()
+
+
+def test_rotation_dims_bimanual_triplets():
+    """Independent triplets: one arm needing a twin flip must not disturb the other."""
+    prev_rot, cur_rot = _antipodal_twin_pair()
+    near_prev = torch.tensor([0.1, 0.0, 0.0], dtype=torch.float64)
+    near_cur = torch.tensor([0.2, 0.0, 0.0], dtype=torch.float64)
+    prev = torch.cat([prev_rot, near_prev])
+    cur = torch.cat([cur_rot, near_cur])
+    interp = ActionInterpolator(multiplier=2, rotation_dims=[0, 1, 2, 3, 4, 5])
+    interp.add(prev)
+    interp.get()
+    interp.add(cur)
+    mid = interp.get()
+    assert mid is not None
+    assert _geodesic_deg(mid[:3], prev_rot) < 1e-6  # arm 1: stays at pose (twins)
+    torch.testing.assert_close(mid[3:], (near_prev + near_cur) / 2, rtol=0, atol=1e-12)  # arm 2: plain lerp
+
+
+def test_rotation_dims_invalid_length_raises():
+    """rotation_dims not grouped in triplets must raise ValueError."""
+    with pytest.raises(ValueError, match="triplets"):
+        ActionInterpolator(multiplier=2, rotation_dims=[3, 4])


### PR DESCRIPTION
## Summary / Motivation

Lerping raw rotvecs breaks when consecutive actions encode the same rotation as
antipodal twins (~2*pi apart in vector space): the interpolated path sweeps through
the identity rotation, up to 180 deg away from the endpoint pose (#3691).

## Related issues

- Fixes: #3691

## What changed

- `ActionInterpolator` takes an optional `rotation_dims` list of (wx, wy, wz) triplet
  indices; each triplet is canonicalized to the antipodal twin nearest the previous
  action before lerping. Default None leaves behavior unchanged.
- Exposed as `--interpolation_rotation_dims` in the rollout config, documented in
  inference.mdx.

## How was this tested (or how to run locally)

- `uv run pytest tests/policies/rtc/ tests/test_rollout.py -q` -> 235 passed, 3 skipped
  (7 new: twin regression asserting 180 deg -> 0 deg, bimanual triplets, zero rotation,
  default-path equality, validation)
- `pre-commit run --files <changed files>` -> all hooks pass

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: #

## Reviewer notes

- `rotation_dims` sits on the interpolator since that is the only place actions are
  lerped; can move it to the strategy layer if you'd rather it live with the action
  layout.
