### PR TITLE
refactor(motors,robots,teleoperators,cameras,rollout,utils): replace `pass` with `raise NotImplementedError` in abstract method bodies

### DIFF
--- a/src/lerobot/cameras/camera.py
+++ b/src/lerobot/cameras/camera.py
@@ -84,7 +84,7 @@ class Camera(abc.ABC):
             bool: True if the camera is connected and ready to capture frames,
                   False otherwise.
         """
-        pass
+        raise NotImplementedError
 
     @staticmethod
     @abc.abstractmethod
@@ -94,7 +94,7 @@ class Camera(abc.ABC):
             List[Dict[str, Any]]: A list of dictionaries,
             where each dictionary contains information about a detected camera.
         """
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def connect(self, warmup: bool = True) -> None:
@@ -105,7 +105,7 @@ class Camera(abc.ABC):
                    for cameras that require time to adjust capture settings.
                    If False, skips the warmup frame.
         """
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def read(self) -> NDArray[Any]:
@@ -116,7 +116,7 @@ class Camera(abc.ABC):
         Returns:
             np.ndarray: Captured frame as a numpy array.
         """
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def async_read(self, timeout_ms: float = ...) -> NDArray[Any]:
@@ -148,7 +148,7 @@ class Camera(abc.ABC):
         Raises:
             TimeoutError: If no new frame arrives within `timeout_ms`.
         """
-        pass
+        raise NotImplementedError
 
     def read_latest(self, max_age_ms: int = 500) -> NDArray[Any]:
         """Return the most recent frame captured immediately (Peeking).
@@ -181,4 +181,4 @@ class Camera(abc.ABC):
     @abc.abstractmethod
     def disconnect(self) -> None:
         """Disconnect from the camera and release resources."""
-        pass
+        raise NotImplementedError

--- a/src/lerobot/motors/motors_bus.py
+++ b/src/lerobot/motors/motors_bus.py
@@ -75,58 +75,58 @@ class MotorsBusBase(abc.ABC):
     @abc.abstractmethod
     def connect(self, handshake: bool = True) -> None:
         """Establish connection to the motors."""
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def disconnect(self, disable_torque: bool = True) -> None:
         """Disconnect from the motors."""
-        pass
+        raise NotImplementedError
 
     @property
     @abc.abstractmethod
     def is_connected(self) -> bool:
         """Check if connected to the motors."""
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def read(self, data_name: str, motor: str) -> Value:
         """Read a value from a single motor."""
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def write(self, data_name: str, motor: str, value: Value) -> None:
         """Write a value to a single motor."""
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def sync_read(self, data_name: str, motors: str | list[str] | None = None) -> dict[str, Value]:
         """Read a value from multiple motors."""
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def sync_write(self, data_name: str, values: dict[str, Value]) -> None:
         """Write values to multiple motors."""
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def enable_torque(self, motors: str | list[str] | None = None, num_retry: int = 0) -> None:
         """Enable torque on selected motors."""
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def disable_torque(self, motors: str | list[str] | None = None, num_retry: int = 0) -> None:
         """Disable torque on selected motors."""
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def read_calibration(self) -> dict[str, MotorCalibration]:
         """Read calibration parameters from the motors."""
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def write_calibration(self, calibration_dict: dict[str, MotorCalibration], cache: bool = True) -> None:
         """Write calibration parameters to the motors."""
-        pass
+        raise NotImplementedError
 
 
 def get_ctrl_table(model_ctrl_table: dict[str, dict], model: str) -> dict[str, tuple[int, int]]:
@@ -502,7 +502,7 @@ class SerialMotorsBus(MotorsBusBase):
 
     @abc.abstractmethod
     def _assert_protocol_is_compatible(self, instruction_name: str) -> None:
-        pass
+        raise NotImplementedError
 
     @property
     def is_connected(self) -> bool:
@@ -540,7 +540,7 @@ class SerialMotorsBus(MotorsBusBase):
 
     @abc.abstractmethod
     def _handshake(self) -> None:
-        pass
+        raise NotImplementedError
 
     @check_if_not_connected
     def disconnect(self, disable_torque: bool = True) -> None:
@@ -631,7 +631,7 @@ class SerialMotorsBus(MotorsBusBase):
 
     @abc.abstractmethod
     def _find_single_motor(self, motor: str, initial_baudrate: int | None = None) -> tuple[int, int]:
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def configure_motors(self) -> None:
@@ -640,7 +640,7 @@ class SerialMotorsBus(MotorsBusBase):
         Typical changes include shortening the return delay, increasing
         acceleration limits or disabling safety locks.
         """
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def disable_torque(self, motors: str | list[str] | None = None, num_retry: int = 0) -> None:
@@ -654,11 +654,11 @@ class SerialMotorsBus(MotorsBusBase):
             num_retry (int, optional): Number of additional retry attempts on communication failure.
                 Defaults to 0.
         """
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def _disable_torque(self, motor: int, model: str, num_retry: int = 0) -> None:
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def enable_torque(self, motors: int | str | list[str] | None = None, num_retry: int = 0) -> None:
@@ -670,7 +670,7 @@ class SerialMotorsBus(MotorsBusBase):
             num_retry (int, optional): Number of additional retry attempts on communication failure.
                 Defaults to 0.
         """
-        pass
+        raise NotImplementedError
 
     @contextmanager
     def torque_disabled(self, motors: str | list[str] | None = None):
@@ -728,7 +728,7 @@ class SerialMotorsBus(MotorsBusBase):
     @abc.abstractmethod
     def is_calibrated(self) -> bool:
         """bool: ``True`` if the cached calibration matches the motors."""
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def read_calibration(self) -> dict[str, MotorCalibration]:
@@ -737,7 +737,7 @@ class SerialMotorsBus(MotorsBusBase):
         Returns:
             dict[str, MotorCalibration]: Mapping *motor name → calibration*.
         """
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def write_calibration(self, calibration_dict: dict[str, MotorCalibration], cache: bool = True) -> None:
@@ -748,7 +748,7 @@ class SerialMotorsBus(MotorsBusBase):
                 :pymeth:`read_calibration` or crafted by the user.
             cache (bool, optional): Save the calibration to :pyattr:`calibration`. Defaults to True.
         """
-        pass
+        raise NotImplementedError
 
     def reset_calibration(self, motors: NameOrID | Sequence[NameOrID] | None = None) -> None:
         """Restore factory calibration for the selected motors.
@@ -797,7 +797,7 @@ class SerialMotorsBus(MotorsBusBase):
 
     @abc.abstractmethod
     def _get_half_turn_homings(self, positions: dict[NameOrID, Value]) -> dict[NameOrID, Value]:
-        pass
+        raise NotImplementedError
 
     def record_ranges_of_motion(
         self, motors: NameOrID | Sequence[NameOrID] | None = None, display_values: bool = True
@@ -908,11 +908,11 @@ class SerialMotorsBus(MotorsBusBase):
 
     @abc.abstractmethod
     def _encode_sign(self, data_name: str, ids_values: dict[int, int]) -> dict[int, int]:
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def _decode_sign(self, data_name: str, ids_values: dict[int, int]) -> dict[int, int]:
-        pass
+        raise NotImplementedError
 
     def _serialize_data(self, value: int, length: int) -> list[int]:
         """
@@ -939,7 +939,7 @@ class SerialMotorsBus(MotorsBusBase):
     @abc.abstractmethod
     def _split_into_byte_chunks(self, value: int, length: int) -> list[int]:
         """Convert an integer into a list of byte-sized integers."""
-        pass
+        raise NotImplementedError
 
     def ping(self, motor: NameOrID, num_retry: int = 0, raise_on_error: bool = False) -> int | None:
         """Ping a single motor and return its model number.
@@ -985,7 +985,7 @@ class SerialMotorsBus(MotorsBusBase):
         Returns:
             dict[int, int] | None: Mapping *id → model number* or `None` if the call failed.
         """
-        pass
+        raise NotImplementedError
 
     @check_if_not_connected
     def read(

--- a/src/lerobot/robots/robot.py
+++ b/src/lerobot/robots/robot.py
@@ -97,7 +97,7 @@ class Robot(abc.ABC):
 
         Note: this property should be able to be called regardless of whether the robot is connected or not.
         """
-        pass
+        raise NotImplementedError
 
     @property
     @abc.abstractmethod
@@ -110,7 +110,7 @@ class Robot(abc.ABC):
 
         Note: this property should be able to be called regardless of whether the robot is connected or not.
         """
-        pass
+        raise NotImplementedError
 
     @property
     @abc.abstractmethod
@@ -119,7 +119,7 @@ class Robot(abc.ABC):
         Whether the robot is currently connected or not. If `False`, calling :pymeth:`get_observation` or
         :pymeth:`send_action` should raise an error.
         """
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def connect(self, calibrate: bool = True) -> None:
@@ -130,13 +130,13 @@ class Robot(abc.ABC):
             calibrate (bool): If True, automatically calibrate the robot after connecting if it's not
                 calibrated or needs calibration (this is hardware-dependant).
         """
-        pass
+        raise NotImplementedError
 
     @property
     @abc.abstractmethod
     def is_calibrated(self) -> bool:
         """Whether the robot is currently calibrated or not. Should be always `True` if not applicable"""
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def calibrate(self) -> None:
@@ -146,7 +146,7 @@ class Robot(abc.ABC):
         This method should collect any necessary data (e.g., motor offsets) and update the
         :pyattr:`calibration` dictionary accordingly.
         """
-        pass
+        raise NotImplementedError
 
     def _load_calibration(self, fpath: Path | None = None) -> None:
         """
@@ -176,7 +176,7 @@ class Robot(abc.ABC):
         Apply any one-time or runtime configuration to the robot.
         This may include setting motor parameters, control modes, or initial state.
         """
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def get_observation(self) -> RobotObservation:
@@ -188,7 +188,7 @@ class Robot(abc.ABC):
                 should match :pymeth:`observation_features`.
         """
 
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def send_action(self, action: RobotAction) -> RobotAction:
@@ -203,9 +203,9 @@ class Robot(abc.ABC):
             RobotAction: The action actually sent to the motors potentially clipped or modified, e.g. by
                 safety limits on velocity.
         """
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def disconnect(self) -> None:
         """Disconnect from the robot and perform any necessary cleanup."""
-        pass
+        raise NotImplementedError

--- a/src/lerobot/rollout/inference/base.py
+++ b/src/lerobot/rollout/inference/base.py
@@ -56,18 +56,22 @@ class InferenceEngine(abc.ABC):
     @abc.abstractmethod
     def start(self) -> None:
         """Initialise the backend."""
+        raise NotImplementedError
 
     @abc.abstractmethod
     def stop(self) -> None:
         """Tear the backend down."""
+        raise NotImplementedError
 
     @abc.abstractmethod
     def reset(self) -> None:
         """Clear episode-scoped state."""
+        raise NotImplementedError
 
     @abc.abstractmethod
     def get_action(self, obs_frame: dict | None) -> torch.Tensor | None:
         """Return the next action tensor, or ``None`` if unavailable."""
+        raise NotImplementedError
 
     def notify_observation(self, obs: dict) -> None:  # noqa: B027
         """Publish the latest processed observation.  Default: no-op."""

--- a/src/lerobot/rollout/strategies/core.py
+++ b/src/lerobot/rollout/strategies/core.py
@@ -176,14 +176,17 @@ class RolloutStrategy(abc.ABC):
     @abc.abstractmethod
     def setup(self, ctx: RolloutContext) -> None:
         """Strategy-specific initialisation (keyboard listeners, buffers, etc.)."""
+        raise NotImplementedError
 
     @abc.abstractmethod
     def run(self, ctx: RolloutContext) -> None:
         """Main rollout loop.  Returns when shutdown is requested or duration expires."""
+        raise NotImplementedError
 
     @abc.abstractmethod
     def teardown(self, ctx: RolloutContext) -> None:
         """Cleanup: save dataset, stop threads, disconnect hardware."""
+        raise NotImplementedError
 
 
 # ---------------------------------------------------------------------------

--- a/src/lerobot/teleoperators/teleoperator.py
+++ b/src/lerobot/teleoperators/teleoperator.py
@@ -95,7 +95,7 @@ class Teleoperator(abc.ABC):
 
         Note: this property should be able to be called regardless of whether the robot is connected or not.
         """
-        pass
+        raise NotImplementedError
 
     @property
     @abc.abstractmethod
@@ -108,7 +108,7 @@ class Teleoperator(abc.ABC):
 
         Note: this property should be able to be called regardless of whether the robot is connected or not.
         """
-        pass
+        raise NotImplementedError
 
     @property
     @abc.abstractmethod
@@ -117,7 +117,7 @@ class Teleoperator(abc.ABC):
         Whether the teleoperator is currently connected or not. If `False`, calling :pymeth:`get_action`
         or :pymeth:`send_feedback` should raise an error.
         """
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def connect(self, calibrate: bool = True) -> None:
@@ -128,13 +128,13 @@ class Teleoperator(abc.ABC):
             calibrate (bool): If True, automatically calibrate the teleoperator after connecting if it's not
                 calibrated or needs calibration (this is hardware-dependant).
         """
-        pass
+        raise NotImplementedError
 
     @property
     @abc.abstractmethod
     def is_calibrated(self) -> bool:
         """Whether the teleoperator is currently calibrated or not. Should be always `True` if not applicable"""
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def calibrate(self) -> None:
@@ -144,7 +144,7 @@ class Teleoperator(abc.ABC):
         This method should collect any necessary data (e.g., motor offsets) and update the
         :pyattr:`calibration` dictionary accordingly.
         """
-        pass
+        raise NotImplementedError
 
     def _load_calibration(self, fpath: Path | None = None) -> None:
         """
@@ -174,7 +174,7 @@ class Teleoperator(abc.ABC):
         Apply any one-time or runtime configuration to the teleoperator.
         This may include setting motor parameters, control modes, or initial state.
         """
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def get_action(self) -> RobotAction:
@@ -185,7 +185,7 @@ class Teleoperator(abc.ABC):
             RobotAction: A flat dictionary representing the teleoperator's current actions. Its
                 structure should match :pymeth:`observation_features`.
         """
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def send_feedback(self, feedback: dict[str, Any]) -> None:
@@ -200,9 +200,9 @@ class Teleoperator(abc.ABC):
             dict[str, Any]: The action actually sent to the motors potentially clipped or modified, e.g. by
                 safety limits on velocity.
         """
-        pass
+        raise NotImplementedError
 
     @abc.abstractmethod
     def disconnect(self) -> None:
         """Disconnect from the teleoperator and perform any necessary cleanup."""
-        pass
+        raise NotImplementedError

--- a/src/lerobot/utils/sample_weighting.py
+++ b/src/lerobot/utils/sample_weighting.py
@@ -65,12 +65,14 @@ class SampleWeighter(ABC):
             batch: Training batch dictionary containing at minimum an "index" key
                    with global frame indices.
         """
+        raise NotImplementedError
 
     @abstractmethod
     def get_stats(self) -> dict:
         """
         Get global statistics about the weighting strategy.
         """
+        raise NotImplementedError
 
 
 @dataclass


### PR DESCRIPTION
## Summary

All 7 base-class modules used `pass` as the body of `@abstractmethod` methods and properties. This is inconsistent with the rest of the codebase where abstract methods raise `NotImplementedError`.

## What changed

- `MotorsBus` (26 methods) — all abstract method bodies changed from `pass` to `raise NotImplementedError`
- `Robot` (10 methods) — same
- `Teleoperator` (10 methods) — same
- `Camera` (6 methods) — same
- `RolloutStrategy` (3 methods) — same (plus added missing bodies)
- `InferenceEngine` (4 methods) — same (plus added missing bodies)
- `SampleWeighter` (2 methods) — same (plus added missing bodies)

## How was this tested

- `ruff check` and `ruff format --check` pass on all 7 modified files
- Python syntax verified via `ast.parse` on all 7 files
- `pytest tests/test_available.py tests/robots tests/teleoperators tests/motors`: 19 passed, 8 skipped, 0 failed (camera test failures are pre-existing — require physical hardware)
- Changes are purely mechanical (`pass` → `raise NotImplementedError`); no logic changes

## Checklist

- [x] Linting/formatting run (`ruff check` + `ruff format --check`)
- [x] All tests pass locally (19 passed, 8 skipped, 0 failed — unrelated camera failures excluded)
- [ ] Documentation updated (N/A — no API change)
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: # (insert PR number/link)