### PR TITLE
fix assembly instructions typo - SO-ARM101

### DIFF
--- a/docs/source/so101.mdx
+++ b/docs/source/so101.mdx
@@ -338,7 +338,7 @@ It is advisable to install one 3-pin cable in the motor after placing them befor
 <hfoption id="Leader">
 
 - Mount the leader holder onto the wrist and secure it with 4 M3x6mm screws.
-- Attach the handle to motor 5 using 1 M2x6mm screw.
+- Attach the handle to the leader holder using 1 M2x6mm screw.
 - Insert the gripper motor, secure it with 2 M2x6mm screws on each side, attach a motor horn using a M3x6mm horn screw.
 - Attach the follower trigger with 4 M3x6mm screws.
 


### PR DESCRIPTION
## Title

Fixes a small typo in SO-ARM101 assembly instruction reported in issue #4007 
