### PR TITLE
fix(rewards): accept trainer state_dict/dataset_meta kwargs in push_model_to_hub

### DIFF
--- a/src/lerobot/rewards/pretrained.py
+++ b/src/lerobot/rewards/pretrained.py
@@ -23,7 +23,7 @@ from typing import TYPE_CHECKING, Any, TypeVar
 
 import packaging
 import safetensors
-from huggingface_hub import HfApi, ModelCard, ModelCardData, hf_hub_download
+from huggingface_hub import HfApi, ModelCard, ModelCardData, hf_hub_download, save_torch_state_dict
 from huggingface_hub.constants import SAFETENSORS_SINGLE_FILE
 from huggingface_hub.errors import HfHubHTTPError
 from safetensors.torch import load_model as load_model_as_safetensor, save_model as save_model_as_safetensor
@@ -34,6 +34,7 @@ from lerobot.utils.hub import HubMixin
 
 if TYPE_CHECKING:
     from lerobot.configs.train import TrainPipelineConfig
+    from lerobot.datasets.lerobot_dataset import LeRobotDatasetMetadata
 
 T = TypeVar("T", bound="PreTrainedRewardModel")
 
@@ -61,10 +62,43 @@ class PreTrainedRewardModel(nn.Module, HubMixin, abc.ABC):
         if not getattr(cls, "name", None):
             raise TypeError(f"Class {cls.__name__} must define 'name'")
 
-    def _save_pretrained(self, save_directory: Path) -> None:
+    def save_pretrained(
+        self,
+        save_directory: str | Path,
+        *,
+        state_dict: dict[str, Tensor] | None = None,
+        repo_id: str | None = None,
+        push_to_hub: bool = False,
+        card_kwargs: dict | None = None,
+        **push_to_hub_kwargs,
+    ) -> str | None:
+        """Save the reward model to a directory (and optionally push to the Hub).
+
+        Overrides `HubMixin.save_pretrained` to add a `state_dict` argument (mirroring
+        `PreTrainedPolicy.save_pretrained`). Under FSDP, `self.state_dict()` would return
+        sharded tensors, so the caller gathers the full state dict via a cross-rank
+        collective and passes it here for `_save_pretrained` to write directly.
+        """
+        save_directory = Path(save_directory)
+        save_directory.mkdir(parents=True, exist_ok=True)
+        self._save_pretrained(save_directory, state_dict=state_dict)
+        if push_to_hub:
+            if repo_id is None:
+                repo_id = save_directory.name
+            return self.push_to_hub(repo_id=repo_id, card_kwargs=card_kwargs, **push_to_hub_kwargs)
+        return None
+
+    def _save_pretrained(self, save_directory: Path, state_dict: dict[str, Tensor] | None = None) -> None:
         self.config._save_pretrained(save_directory)
         model_to_save = self.module if hasattr(self, "module") else self
-        save_model_as_safetensor(model_to_save, str(save_directory / SAFETENSORS_SINGLE_FILE))
+        if state_dict is None:
+            save_model_as_safetensor(model_to_save, str(save_directory / SAFETENSORS_SINGLE_FILE))
+            return
+        # A pre-gathered (e.g. FSDP full) state dict was supplied: write it directly.
+        # `save_torch_state_dict` discards shared-tensor duplicates just like `save_model` does;
+        # pin `max_shard_size` above the total size so the output stays a single `model.safetensors`
+        total_bytes = sum(t.numel() * t.element_size() for t in state_dict.values())
+        save_torch_state_dict(state_dict, str(save_directory), max_shard_size=max(total_bytes, 1))
 
     @classmethod
     def from_pretrained(
@@ -192,7 +226,12 @@ class PreTrainedRewardModel(nn.Module, HubMixin, abc.ABC):
         """
         return type(self).forward is not PreTrainedRewardModel.forward
 
-    def push_model_to_hub(self, cfg: "TrainPipelineConfig"):
+    def push_model_to_hub(
+        self,
+        cfg: "TrainPipelineConfig",
+        state_dict: dict[str, Tensor] | None = None,
+        dataset_meta: "LeRobotDatasetMetadata | None" = None,
+    ):
         api = HfApi()
         repo_id = api.create_repo(
             repo_id=self.config.repo_id, private=self.config.private, exist_ok=True
@@ -202,7 +241,9 @@ class PreTrainedRewardModel(nn.Module, HubMixin, abc.ABC):
         with TemporaryDirectory(ignore_cleanup_errors=True) as tmp:
             saved_path = Path(tmp) / repo_id
 
-            self.save_pretrained(saved_path)  # Calls _save_pretrained and stores model tensors
+            # Calls _save_pretrained and stores model tensors (a pre-gathered FSDP
+            # state dict is written directly when provided)
+            self.save_pretrained(saved_path, state_dict=state_dict)
 
             card = self.generate_model_card(
                 cfg.dataset.repo_id, self.config.type, self.config.license, self.config.tags

--- a/src/lerobot/rewards/topreward/modeling_topreward.py
+++ b/src/lerobot/rewards/topreward/modeling_topreward.py
@@ -77,6 +77,7 @@ from lerobot.utils.import_utils import _transformers_available, require_package
 
 if TYPE_CHECKING:
     from lerobot.configs.train import TrainPipelineConfig
+    from lerobot.datasets.lerobot_dataset import LeRobotDatasetMetadata
 
 if TYPE_CHECKING or _transformers_available:
     from transformers import Qwen3VLForConditionalGeneration
@@ -206,8 +207,18 @@ class TOPRewardModel(PreTrainedRewardModel):
         instance.eval()
         return instance
 
-    def push_model_to_hub(self, cfg: TrainPipelineConfig):
-        """Push the TOPReward ``config.json`` + model card to the Hub."""
+    def push_model_to_hub(
+        self,
+        cfg: TrainPipelineConfig,
+        state_dict: dict[str, Tensor] | None = None,
+        dataset_meta: LeRobotDatasetMetadata | None = None,
+    ):
+        """Push the TOPReward ``config.json`` + model card to the Hub.
+
+        `state_dict` and `dataset_meta` are accepted for caller compatibility with
+        `PreTrainedPolicy.push_model_to_hub`; TOPReward pushes no tensors (the base
+        VLM weights are referenced by name), so they are unused.
+        """
         api = HfApi()
         repo_id = api.create_repo(
             repo_id=self.config.repo_id, private=self.config.private, exist_ok=True

--- a/tests/rewards/test_reward_model_base.py
+++ b/tests/rewards/test_reward_model_base.py
@@ -445,3 +445,56 @@ def test_reward_model_push_model_to_hub_uploads_expected_files(monkeypatch, _off
     assert TRAIN_CONFIG_NAME in uploaded["files"]  # train_config.json
     assert "README.md" in uploaded["files"]
     assert any(name.endswith(".safetensors") for name in uploaded["files"])
+
+
+def test_reward_model_push_model_to_hub_accepts_trainer_kwargs(monkeypatch, _offline_model_card):
+    """Regression test for #4011: ``lerobot-train`` calls ``push_model_to_hub`` with
+    the policy-style ``state_dict``/``dataset_meta`` keywords. Reward models must
+    accept them (and write a pre-gathered state dict directly, as under FSDP)."""
+    from lerobot.configs.default import DatasetConfig
+    from lerobot.configs.train import TrainPipelineConfig
+
+    model, _ = _make_dummy_reward_model(
+        repo_id="user/my_reward",
+        license="apache-2.0",
+    )
+    train_cfg = TrainPipelineConfig(
+        dataset=DatasetConfig(repo_id="user/my_dataset"),
+        reward_model=model.config,
+    )
+
+    uploaded: dict = {}
+    fake_commit_info = SimpleNamespace(repo_url=SimpleNamespace(url="https://huggingface.co/user/my_reward"))
+
+    class _FakeHfApi:
+        def create_repo(self, repo_id, private=None, exist_ok=False):
+            return SimpleNamespace(repo_id=repo_id)
+
+        def upload_folder(self, *, folder_path, **_kwargs):
+            uploaded["files"] = sorted(p.name for p in Path(folder_path).iterdir())
+            return fake_commit_info
+
+    from lerobot.rewards import pretrained as reward_pretrained
+
+    monkeypatch.setattr(reward_pretrained, "HfApi", lambda *a, **kw: _FakeHfApi())
+
+    # Exact call shape used by the end-of-training block in lerobot_train.py.
+    model.push_model_to_hub(train_cfg, state_dict=model.state_dict(), dataset_meta=None)
+
+    assert any(name.endswith(".safetensors") for name in uploaded["files"])
+
+
+def test_reward_model_save_pretrained_writes_supplied_state_dict(tmp_path):
+    """A pre-gathered state dict passed to ``save_pretrained`` must be written
+    verbatim (single ``model.safetensors``), bypassing ``self.state_dict()``."""
+    import safetensors.torch
+
+    model, _ = _make_dummy_reward_model()
+    state_dict = {k: torch.full_like(v, 7.0) for k, v in model.state_dict().items()}
+
+    model.save_pretrained(tmp_path, state_dict=state_dict)
+
+    saved = safetensors.torch.load_file(tmp_path / "model.safetensors")
+    assert set(saved) == set(state_dict)
+    for key, tensor in saved.items():
+        assert torch.equal(tensor, state_dict[key])


### PR DESCRIPTION
## Summary

`lerobot-train` crashes at the end of reward-model training when `reward_model.push_to_hub=true`: the shared end-of-training block calls `push_model_to_hub(cfg, state_dict=..., dataset_meta=...)` (the policy signature), but `PreTrainedRewardModel.push_model_to_hub` and the TOPReward override only accept `cfg`, raising `TypeError`.

Fixes #4011

## What changed

- `PreTrainedRewardModel.push_model_to_hub` now accepts `state_dict`/`dataset_meta`, mirroring `PreTrainedPolicy.push_model_to_hub`.
- `PreTrainedRewardModel.save_pretrained`/`_save_pretrained` gained the same `state_dict` passthrough as the policy base class, so a pre-gathered FSDP full state dict is written directly instead of saving sharded tensors.
- `TOPRewardModel.push_model_to_hub` accepts the kwargs for caller compatibility (it pushes no tensors, so they are unused).

## How was this tested

- `uv run pytest tests/rewards/test_reward_model_base.py -q` — 21 passed, including two new regression tests: one mirroring the exact trainer call shape from `lerobot_train.py`, one verifying a supplied state dict is written verbatim to `model.safetensors`.
- `uv run pre-commit run --files <changed files>` — clean.

## Community review
Reviewed #4002 as part of this contribution.