### PR TITLE
fix(processor): make trainer-injected processor overrides best-effort

### DIFF
--- a/src/lerobot/policies/factory.py
+++ b/src/lerobot/policies/factory.py
@@ -266,6 +266,7 @@ class ProcessorConfigKwargs(TypedDict, total=False):
     postprocessor_config_filename: str | None
     preprocessor_overrides: dict[str, Any] | None
     postprocessor_overrides: dict[str, Any] | None
+    strict_overrides: bool
     dataset_stats: dict[str, dict[str, torch.Tensor]] | None
     dataset_meta: Any | None
 
@@ -326,6 +327,7 @@ def make_pre_post_processors(
                 "preprocessor_config_filename", f"{POLICY_PREPROCESSOR_DEFAULT_NAME}.json"
             ),
             overrides=kwargs.get("preprocessor_overrides", {}),
+            strict_overrides=kwargs.get("strict_overrides", True),
             to_transition=batch_to_transition,
             to_output=transition_to_batch,
             revision=pretrained_revision,
@@ -336,6 +338,7 @@ def make_pre_post_processors(
                 "postprocessor_config_filename", f"{POLICY_POSTPROCESSOR_DEFAULT_NAME}.json"
             ),
             overrides=kwargs.get("postprocessor_overrides", {}),
+            strict_overrides=kwargs.get("strict_overrides", True),
             to_transition=policy_action_to_transition,
             to_output=transition_to_policy_action,
             revision=pretrained_revision,

--- a/src/lerobot/processor/pipeline.py
+++ b/src/lerobot/processor/pipeline.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 
 import importlib
 import json
+import logging
 import re
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable, Sequence
@@ -622,6 +623,7 @@ class DataProcessorPipeline[TInput, TOutput](HubMixin):
         local_files_only: bool = False,
         revision: str | None = None,
         overrides: dict[str, Any] | None = None,
+        strict_overrides: bool = True,
         to_transition: Callable[[TInput], EnvTransition] | None = None,
         to_output: Callable[[EnvTransition], TOutput] | None = None,
         **kwargs,
@@ -735,7 +737,7 @@ class DataProcessorPipeline[TInput, TOutput](HubMixin):
         )
 
         # 4. Validate that all overrides were used
-        cls._validate_overrides_used(validated_overrides, loaded_config)
+        cls._validate_overrides_used(validated_overrides, loaded_config, strict=strict_overrides)
 
         # 5. Construct and return the final pipeline instance
         pipeline = cls(
@@ -1204,7 +1206,7 @@ class DataProcessorPipeline[TInput, TOutput](HubMixin):
 
     @classmethod
     def _validate_overrides_used(
-        cls, remaining_override_keys: set[str], loaded_config: dict[str, Any]
+        cls, remaining_override_keys: set[str], loaded_config: dict[str, Any], strict: bool = True
     ) -> None:
         """Validate that all provided overrides were used.
 
@@ -1240,6 +1242,11 @@ class DataProcessorPipeline[TInput, TOutput](HubMixin):
         Args:
             remaining_override_keys: Override keys that weren't matched to any step
             loaded_config: The loaded processor configuration (contains "steps" list)
+            strict: When True (default), unmatched keys raise. When False, they are
+                logged as a warning and skipped — for callers that inject best-effort
+                overrides for steps a pipeline may legitimately not contain (e.g. the
+                trainer's ``normalizer_processor`` override on policies with custom
+                normalization steps).
 
         Raises:
             KeyError: If any override keys were not used, with helpful error message
@@ -1250,6 +1257,13 @@ class DataProcessorPipeline[TInput, TOutput](HubMixin):
         available_keys = [
             step.get("registry_name") or step["class"].rsplit(".", 1)[1] for step in loaded_config["steps"]
         ]
+
+        if not strict:
+            logging.warning(
+                f"Override keys {list(remaining_override_keys)} do not match any step in the saved "
+                f"configuration and were skipped. Available step keys: {available_keys}."
+            )
+            return
 
         raise KeyError(
             f"Override keys {list(remaining_override_keys)} do not match any step in the saved configuration. "

--- a/src/lerobot/scripts/lerobot_train.py
+++ b/src/lerobot/scripts/lerobot_train.py
@@ -347,6 +347,10 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
             postprocessor_overrides["absolute_actions_processor"] = {"enabled": True}
         processor_kwargs["preprocessor_overrides"] = preprocessor_overrides
         processor_kwargs["postprocessor_overrides"] = postprocessor_overrides
+        # These overrides are best-effort: policies with custom normalization steps
+        # (e.g. molmoact2's masked normalizer) do not contain a `normalizer_processor`
+        # step, so unmatched keys are skipped with a warning instead of raising.
+        processor_kwargs["strict_overrides"] = False
 
     if cfg.is_reward_model_training:
         preprocessor, postprocessor = make_reward_pre_post_processors(

--- a/tests/processor/test_pipeline.py
+++ b/tests/processor/test_pipeline.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import json
+import logging
 import tempfile
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -1188,6 +1189,31 @@ def test_from_pretrained_invalid_override_key():
             DataProcessorPipeline.from_pretrained(
                 tmp_dir, config_filename="dataprocessorpipeline.json", overrides=overrides
             )
+
+
+def test_from_pretrained_invalid_override_key_non_strict_warns(caplog):
+    """Regression test for #3998: with strict_overrides=False, unmatched override
+    keys (e.g. the trainer's `normalizer_processor` on a policy whose pipeline uses
+    a custom normalization step) are skipped with a warning instead of raising."""
+    step = MockStepWithNonSerializableParam()
+    pipeline = DataProcessorPipeline([step])
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        pipeline.save_pretrained(tmp_dir)
+
+        overrides = {"normalizer_processor": {"stats": {"x": 1.0}}}
+
+        with caplog.at_level(logging.WARNING):
+            loaded = DataProcessorPipeline.from_pretrained(
+                tmp_dir,
+                config_filename="dataprocessorpipeline.json",
+                overrides=overrides,
+                strict_overrides=False,
+            )
+
+    assert len(loaded.steps) == 1
+    assert "normalizer_processor" in caplog.text
+    assert "were skipped" in caplog.text
 
 
 def test_from_pretrained_multiple_invalid_override_keys():


### PR DESCRIPTION
## Summary

Finetuning MolmoAct2 (`--policy.path=...`) crashes before training starts: `lerobot-train` unconditionally injects `normalizer_processor`/`unnormalizer_processor` overrides into the loaded processor pipelines, but MolmoAct2's saved pipeline uses custom normalization steps (`molmoact2_masked_normalizer`, ...), so the strict override validation raises `KeyError`.

Fixes #3998

## What changed

- `DataProcessorPipeline.from_pretrained` gained a `strict_overrides: bool = True` flag; when `False`, unmatched override keys are logged as a warning and skipped instead of raising. Default behavior is unchanged, so user-typed overrides still fail fast on typos.
- `make_pre_post_processors` forwards `strict_overrides` (new `ProcessorConfigKwargs` key).
- `lerobot_train.py` passes `strict_overrides=False` for its infrastructure-injected overrides only.

Skipping the stats override is the correct behavior for MolmoAct2: its masked normalizer resolves stats from the checkpoint's `norm_stats.json` tags by design, not from the finetune dataset.

## How was this tested

- `uv run pytest tests/processor/test_pipeline.py tests/processor/test_pipeline_from_pretrained_helpers.py -q` — 96 passed, including a new regression test that loads a pipeline without a `normalizer_processor` step under `strict_overrides=False` and asserts a warning instead of a raise.
- `uv run pre-commit run --files <changed files>` — clean (mypy included).

## Community review
Reviewed #4019 as part of this contribution.