### PR TITLE
feat(teleoperators): add DAgger/HIL smooth handover support for BiSOLeader

### DIFF
--- a/docs/source/hil_data_collection.mdx
+++ b/docs/source/hil_data_collection.mdx
@@ -59,6 +59,7 @@ The `lerobot-rollout --strategy.type=dagger` mode requires **teleoperators with 
 
 - `bi_openarm_mini` - Bimanual OpenArm Mini
 - `so_leader` - SO100 / SO101 leader arm
+- `bi_so_leader` - Bimanual SO100 / SO101 leader arms
 
 > [!IMPORTANT]
 > The provided commands default to `bi_openarm_follower` + `bi_openarm_mini`.

--- a/src/lerobot/teleoperators/bi_so_leader/bi_so_leader.py
+++ b/src/lerobot/teleoperators/bi_so_leader/bi_so_leader.py
@@ -108,10 +108,10 @@ class BiSOLeader(BimanualMixin, Teleoperator):
     @check_if_not_connected
     def send_feedback(self, feedback: dict[str, float]) -> None:
         """Route bimanual feedback to left and right arms with proper prefix stripping.
-        
+
         Receives feedback dict with keys like: left_shoulder_pan.pos, right_shoulder_pan.pos, ...
         Splits and routes to each arm by removing the prefix.
-        
+
         This enables DAgger smooth handover: when transitioning from policy control to human
         intervention, both leader arms are commanded to the follower's current pose to avoid
         discontinuities.

--- a/src/lerobot/teleoperators/bi_so_leader/bi_so_leader.py
+++ b/src/lerobot/teleoperators/bi_so_leader/bi_so_leader.py
@@ -67,7 +67,15 @@ class BiSOLeader(BimanualMixin, Teleoperator):
 
     @cached_property
     def feedback_features(self) -> dict[str, type]:
-        return {}
+        # Bimanual teleop has feedback (can be actuated for handover).
+        # Return the same structure as action_features for consistency with left/right arms.
+        left_arm_features = self.left_arm.feedback_features
+        right_arm_features = self.right_arm.feedback_features
+
+        return {
+            **{f"left_{k}": v for k, v in left_arm_features.items()},
+            **{f"right_{k}": v for k, v in right_arm_features.items()},
+        }
 
     def setup_motors(self) -> None:
         self.left_arm.setup_motors()
@@ -87,6 +95,43 @@ class BiSOLeader(BimanualMixin, Teleoperator):
 
         return action_dict
 
+    def enable_torque(self) -> None:
+        """Enable torque on both leader arms for smooth handover."""
+        self.left_arm.enable_torque()
+        self.right_arm.enable_torque()
+
+    def disable_torque(self) -> None:
+        """Disable torque on both leader arms to allow human control."""
+        self.left_arm.disable_torque()
+        self.right_arm.disable_torque()
+
+    @check_if_not_connected
     def send_feedback(self, feedback: dict[str, float]) -> None:
-        # TODO: Implement force feedback
-        raise NotImplementedError
+        """Route bimanual feedback to left and right arms with proper prefix stripping.
+        
+        Receives feedback dict with keys like: left_shoulder_pan.pos, right_shoulder_pan.pos, ...
+        Splits and routes to each arm by removing the prefix.
+        
+        This enables DAgger smooth handover: when transitioning from policy control to human
+        intervention, both leader arms are commanded to the follower's current pose to avoid
+        discontinuities.
+        """
+        # Split feedback by arm prefix
+        left_feedback = {}
+        right_feedback = {}
+
+        for key, value in feedback.items():
+            if key.startswith("left_"):
+                # Strip "left_" prefix and pass to left arm
+                stripped_key = key[5:]  # len("left_") == 5
+                left_feedback[stripped_key] = value
+            elif key.startswith("right_"):
+                # Strip "right_" prefix and pass to right arm
+                stripped_key = key[6:]  # len("right_") == 6
+                right_feedback[stripped_key] = value
+
+        # Send to each arm
+        if left_feedback:
+            self.left_arm.send_feedback(left_feedback)
+        if right_feedback:
+            self.right_arm.send_feedback(right_feedback)


### PR DESCRIPTION
## Title

feat(teleoperators): add DAgger smooth handover support for BiSOLeader

## Summary / Motivation

This PR implements the feedback interface for `BiSOLeader` required by LeRobot's DAgger human-in-the-loop handover flow.

The current `BiSOLeader` wrapper does not expose the same feedback interface as `SOLeader`, preventing follower feedback from being applied during policy-to-human control transitions.

This change allows both leader arms to synchronize with the follower robot pose before human takeover, reducing discontinuities and enabling smoother DAgger data collection with bimanual SO follower + SO leader setups.

## Related issues

Related: #3330
Close: #3352 

## What changed

- Add `feedback_features` to enable DAgger's `teleop_supports_feedback()` check.
- Forward `enable_torque()` and `disable_torque()` to both underlying `SOLeader` instances.
- Implement `send_feedback()` to split and route feedback commands to the corresponding left and right `SOLeader` instances using the existing bimanual key prefixes.
- Keep the implementation consistent with the existing `SOLeader` feedback mechanism instead of introducing a separate synchronization system.
- Update the HIL documentation to list `bi_so_leader` as a compatible teleoperator.

No breaking changes are introduced.

## How was this tested (or how to run locally)

Manual validation was performed using:

- **Robot:** `bi_so_follower` (dual SO follower arms)
- **Teleoperator:** `bi_so_leader` (dual SO leader arms)
- **Policy:** ACT  [MrC4t/act_bimanual_bag](https://huggingface.co/MrC4t/act_bimanual_bag)
- **Strategy:** DAgger rollout

Test command:
```
lerobot-rollout   --strategy.type=dagger     --robot.type=bi_so_follower   --robot.left_arm_config.port=/dev/ttyACM1   --robot.right_arm_config.port=/dev/ttyACM0   --robot.id=my_bimanual_follower   --robot.calibration_dir=calib/     --teleop.type=bi_so_leader   --teleop.left_arm_config.port=/dev/ttyACM3   --teleop.right_arm_config.port=/dev/ttyACM2   --teleop.id=my_bimanual_leader   --teleop.calibration_dir=calib/     --robot.cameras='{
    head: {
      type: intelrealsense,
      serial_number_or_name: ************,
      width: 640,
      height: 480,
      fps: 30
    },
    left_wrist: {
      type: intelrealsense,
      serial_number_or_name: ************,
      width: 640,
      height: 480,
      fps: 30
    },
    right_wrist: {
      type: intelrealsense,
      serial_number_or_name: ************,
      width: 640,
      height: 480,
      fps: 30
    }
  }'     --policy.path=/home/katnips/bat/outputs/act_bimanual_bag/checkpoints/last/pretrained_model     --dataset.repo_id=local/rollout_bimanual_bag_hil1   --dataset.root=/home/katnips/.cache/huggingface/lerobot/local/rollout_bimanual_bag_hil1   --dataset.push_to_hub=false --resume=true --task="put object in bag"

```

Test procedure:

1. Start a DAgger rollout with the bimanual SO setup.
2. Let the policy control the bi_so_follower robot.
3. Pause the policy.
4. Verify that both leader arms receive follower feedback and move to the follower pose.
5. Continue teleoperation after handover.

Verified:

- `BiSOLeader` feedback features are detected correctly by the DAgger HIL flow.
- Left/right feedback routing works correctly between the bimanual leader arms.
- Leader arms synchronize with the follower pose during handover, reducing discontinuities at human takeover.

A demonstration video is attached to this PR.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [ ] All tests pass locally (`pytest`)
- [x] Documentation updated
- [ ] CI is green
- [x] Community Review: I have reviewed another contributor's open PR and linked it here: #3352

## Reviewer notes

The implementation is intentionally limited to the `BiSOLeader` wrapper.

It mirrors the existing `SOLeader` feedback API, making the bimanual teleoperator compatible with the current DAgger handover mechanism without introducing a separate synchronization path.

Suggested review focus:

- Feedback key routing between `left_` and `right_` prefixes.
- Consistency with the existing `SOLeader` feedback behavior.
- DAgger handover behavior during HIL rollouts.
