### PR TITLE
feat: add TLabel tactile data format conversion example

### DIFF
--- a/examples/tlabel/README.md
+++ b/examples/tlabel/README.md
@@ -1,0 +1,95 @@
+# TLabel Tactile Data → LeRobot Conversion
+
+This example demonstrates how to convert [TLabel](https://github.com/liesliy/tlabel) tactile sensor datasets into [LeRobotDataset](https://github.com/huggingface/lerobot) v3.0 format.
+
+## Why TLabel?
+
+[TLabel](https://github.com/liesliy/tlabel) (PyPI: `tlabel`) is a sensor-agnostic tactile data annotation toolkit that provides:
+
+- **Unified 22-dimension annotation schema** (TLabel Format v2)
+- Support for multiple tactile sensors: GelSight, DIGIT, PaXini, Daimon, Touchd, UniVTAC, VTAC
+- Standardized data export (JSON/CSV)
+- Quality grading and event-based annotation
+
+## Installation
+
+```bash
+pip install tlabel lerobot
+```
+
+## Quick Start
+
+```bash
+python convert_tlabel_to_lerobot.py \
+    --input-dir /path/to/tlabel_dataset/ \
+    --repo-id username/tactile_dataset \
+    --fps 30 \
+    --sensor-type gelsight
+```
+
+### Options
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--input-dir` | Path to TLabel exported dataset | Required |
+| `--repo-id` | LeRobot dataset repo ID (e.g. `user/dataset`) | Required |
+| `--fps` | Sampling rate in Hz | 30 |
+| `--sensor-type` | Sensor type: `gelsight`, `paxini`, `daimon`, `touchd`, `univtac`, `vtac` | `gelsight` |
+| `--output-dir` | Local output directory (instead of pushing to Hub) | `./lerobot_data/` |
+| `--push-to-hub` | Push dataset to Hugging Face Hub | Flag |
+| `--task` | Task description string | `"tactile manipulation"` |
+| `--config` | Path to custom feature config YAML | None (uses defaults) |
+
+## Feature Mapping
+
+TLabel's unified 22-dim schema maps to LeRobot features as follows:
+
+| TLabel Dimension | LeRobot Feature Key | Shape |
+|---|---|---|
+| `contact` | `observation.tactile.contact` | (1,) |
+| `force_magnitude`, `force_direction`, `force_peak` | `observation.tactile.force` | (3,) |
+| `deformation_magnitude`, `temporal_deformation_rate` | `observation.tactile.deformation` | (2,) |
+| `slip_entropy`, `slip_event` | `observation.tactile.slip` | (2,) |
+| `texture_energy` | `observation.tactile.texture` | (1,) |
+| `contact_area`, `centroid_x`, `centroid_y` | `observation.tactile.contact_geometry` | (3,) |
+| `normal_mag`, `normal_var`, `shear_mag`, `shear_dir` | `observation.tactile.field` | (4,) |
+| `delta_normal`, `delta_shear`, `friction_cone_ratio` | `observation.tactile.dynamics` | (3,) |
+| tactile image (visual sensors only) | `observation.images.tactile` | (H, W, 3) video |
+
+### Sensor-Specific Behavior
+
+- **GelSight / DIGIT** (visual): All 22 dims + tactile images as video
+- **PaXini** (force): 20 dims (no optical flow), no images
+- **Daimon** (magnetic): 22 dims, no images
+- **Touchd / UniVTAC / VTAC**: Depends on sensor config
+
+## Custom Feature Config
+
+Override the default feature mapping by providing a YAML config:
+
+```bash
+python convert_tlabel_to_lerobot.py \
+    --input-dir ./data/ \
+    --repo-id user/dataset \
+    --config config/tlabel_default_features.yaml
+```
+
+See `config/tlabel_default_features.yaml` for the full default configuration.
+
+## Integration with Training
+
+Once converted, the dataset works with any LeRobot-compatible training pipeline:
+
+```python
+from lerobot.common.datasets.lerobot_dataset import LeRobotDataset
+
+dataset = LeRobotDataset("username/tactile_dataset")
+print(dataset.features)  # Includes observation.tactile.* features
+```
+
+## References
+
+- [TLabel GitHub](https://github.com/liesliy/tlabel)
+- [TLabel PyPI](https://pypi.org/project/tlabel/)
+- [LeRobot Documentation](https://github.com/huggingface/lerobot)
+- [LeFlexiTac](https://tna001-ai.github.io/LeFlexiTac/index.html) — Tactile + LeRobot integration example

--- a/examples/tlabel/README.md
+++ b/examples/tlabel/README.md
@@ -81,7 +81,7 @@ See `config/tlabel_default_features.yaml` for the full default configuration.
 Once converted, the dataset works with any LeRobot-compatible training pipeline:
 
 ```python
-from lerobot.common.datasets.lerobot_dataset import LeRobotDataset
+from lerobot.datasets import LeRobotDataset
 
 dataset = LeRobotDataset("username/tactile_dataset")
 print(dataset.features)  # Includes observation.tactile.* features

--- a/examples/tlabel/config/tlabel_default_features.yaml
+++ b/examples/tlabel/config/tlabel_default_features.yaml
@@ -1,0 +1,51 @@
+# TLabel Tactile Features -> LeRobot Dataset Feature Mapping
+# Default configuration for tlabel -> lerobot conversion
+#
+# Customize this file to include only the features you need,
+# or to remap TLabel dimensions to different LeRobot feature keys.
+#
+# Usage:
+#   python convert_tlabel_to_lerobot.py \
+#       --input-dir ./data/ \
+#       --repo-id user/dataset \
+#       --config config/tlabel_default_features.yaml
+
+observation.tactile.contact:
+  dtype: float32
+  shape: [1]
+  names: [contact]
+
+observation.tactile.force:
+  dtype: float32
+  shape: [3]
+  names: [magnitude, direction, peak]
+
+observation.tactile.deformation:
+  dtype: float32
+  shape: [2]
+  names: [magnitude, rate]
+
+observation.tactile.slip:
+  dtype: float32
+  shape: [2]
+  names: [entropy, event]
+
+observation.tactile.texture:
+  dtype: float32
+  shape: [1]
+  names: [energy]
+
+observation.tactile.contact_geometry:
+  dtype: float32
+  shape: [3]
+  names: [area, centroid_x, centroid_y]
+
+observation.tactile.field:
+  dtype: float32
+  shape: [4]
+  names: [normal_mag, normal_var, shear_mag, shear_dir]
+
+observation.tactile.dynamics:
+  dtype: float32
+  shape: [3]
+  names: [delta_normal, delta_shear, friction_cone]

--- a/examples/tlabel/convert_tlabel_to_lerobot.py
+++ b/examples/tlabel/convert_tlabel_to_lerobot.py
@@ -1,0 +1,376 @@
+#!/usr/bin/env python3
+"""
+Convert TLabel tactile sensor datasets to LeRobotDataset v3.0 format.
+
+Usage:
+    python convert_tlabel_to_lerobot.py \
+        --input-dir /path/to/tlabel_dataset/ \
+        --repo-id username/tactile_dataset \
+        --fps 30 \
+        --sensor-type gelsight
+
+Requirements:
+    pip install tlabel lerobot
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    print("PyYAML is required: pip install pyyaml")
+    sys.exit(1)
+
+try:
+    import numpy as np
+except ImportError:
+    print("NumPy is required: pip install numpy")
+    sys.exit(1)
+
+
+# Default feature configuration for tactile data (22-dim unified schema)
+DEFAULT_TACTILE_FEATURES = {
+    "observation.tactile.contact": {
+        "dtype": "float32",
+        "shape": [1],
+        "names": ["contact"],
+    },
+    "observation.tactile.force": {
+        "dtype": "float32",
+        "shape": [3],
+        "names": ["magnitude", "direction", "peak"],
+    },
+    "observation.tactile.deformation": {
+        "dtype": "float32",
+        "shape": [2],
+        "names": ["magnitude", "rate"],
+    },
+    "observation.tactile.slip": {
+        "dtype": "float32",
+        "shape": [2],
+        "names": ["entropy", "event"],
+    },
+    "observation.tactile.texture": {
+        "dtype": "float32",
+        "shape": [1],
+        "names": ["energy"],
+    },
+    "observation.tactile.contact_geometry": {
+        "dtype": "float32",
+        "shape": [3],
+        "names": ["area", "centroid_x", "centroid_y"],
+    },
+    "observation.tactile.field": {
+        "dtype": "float32",
+        "shape": [4],
+        "names": ["normal_mag", "normal_var", "shear_mag", "shear_dir"],
+    },
+    "observation.tactile.dynamics": {
+        "dtype": "float32",
+        "shape": [3],
+        "names": ["delta_normal", "delta_shear", "friction_cone"],
+    },
+}
+
+# Base LeRobot features (required for all datasets)
+BASE_FEATURES = {
+    "timestamp": {"dtype": "float32", "shape": [1], "names": None},
+    "episode_index": {"dtype": "int64", "shape": [1], "names": None},
+    "frame_index": {"dtype": "int64", "shape": [1], "names": None},
+    "index": {"dtype": "int64", "shape": [1], "names": None},
+    "task_index": {"dtype": "int64", "shape": [1], "names": None},
+}
+
+# Sensor-specific feature overrides
+SENSOR_CONFIGS = {
+    "gelsight": {"has_image": True, "image_key": "observation.images.tactile"},
+    "digit": {"has_image": True, "image_key": "observation.images.tactile"},
+    "paxini": {"has_image": False},
+    "daimon": {"has_image": False},
+    "touchd": {"has_image": False},
+    "univtac": {"has_image": False},
+    "vtac": {"has_image": False},
+}
+
+
+def load_tlabel_data(input_dir: Path) -> dict:
+    """Load TLabel exported dataset.
+
+    Supports both JSON and CSV formats from tlabel.export().
+    Returns a dict with episodes and their frame data.
+    """
+    try:
+        import tlabel
+        print(f"Loading TLabel data from {input_dir}...")
+        dataset = tlabel.load(str(input_dir))
+        return dataset
+    except ImportError:
+        print("tlabel not found. Install with: pip install tlabel")
+        print("Falling back to manual JSON/CSV loading...")
+        return _load_manual(input_dir)
+
+
+def _load_manual(input_dir: Path) -> dict:
+    """Manual loading fallback when tlabel package is not available."""
+    data_file = input_dir / "tlabel_export.json"
+    if not data_file.exists():
+        csv_files = list(input_dir.glob("*.csv"))
+        if not csv_files:
+            raise FileNotFoundError(
+                f"No TLabel data found in {input_dir}. "
+                "Expected tlabel_export.json or *.csv files."
+            )
+        return _load_csv_episodes(csv_files)
+
+    with open(data_file) as f:
+        raw = json.load(f)
+
+    episodes = {}
+    for frame in raw.get("frames", []):
+        ep_idx = frame.get("episode_index", 0)
+        if ep_idx not in episodes:
+            episodes[ep_idx] = []
+        episodes[ep_idx].append(frame)
+
+    return {"episodes": episodes, "metadata": raw.get("metadata", {})}
+
+
+def _load_csv_episodes(csv_files: list) -> dict:
+    """Load episodes from CSV files."""
+    import csv
+
+    episodes = {}
+    for csv_file in csv_files:
+        with open(csv_file) as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                ep_idx = int(row.get("episode_index", 0))
+                if ep_idx not in episodes:
+                    episodes[ep_idx] = []
+                frame = {}
+                for k, v in row.items():
+                    try:
+                        frame[k] = float(v)
+                    except (ValueError, TypeError):
+                        frame[k] = v
+                episodes[ep_idx].append(frame)
+
+    return {"episodes": episodes, "metadata": {}}
+
+
+def build_features(sensor_type: str, config_path: str = None, has_image: bool = False) -> dict:
+    """Build the complete feature dict for LeRobotDataset."""
+    features = {}
+    features.update(BASE_FEATURES)
+
+    if config_path and Path(config_path).exists():
+        with open(config_path) as f:
+            custom_features = yaml.safe_load(f)
+        if custom_features:
+            features.update(custom_features)
+        else:
+            features.update(DEFAULT_TACTILE_FEATURES)
+    else:
+        features.update(DEFAULT_TACTILE_FEATURES)
+
+    sensor_config = SENSOR_CONFIGS.get(sensor_type, SENSOR_CONFIGS["gelsight"])
+    if sensor_config.get("has_image") or has_image:
+        image_key = sensor_config.get("image_key", "observation.images.tactile")
+        features[image_key] = {
+            "dtype": "video",
+            "shape": [480, 640, 3],
+            "names": ["height", "width", "channels"],
+        }
+
+    return features
+
+
+def extract_tactile_features(frame_data: dict, sensor_type: str) -> dict:
+    """Extract tactile feature values from a TLabel frame.
+
+    Maps TLabel 22-dim schema to LeRobot feature keys.
+    """
+    features = {}
+
+    features["observation.tactile.contact"] = [
+        float(frame_data.get("contact", 0.0))
+    ]
+
+    features["observation.tactile.force"] = [
+        float(frame_data.get("force_magnitude", 0.0)),
+        float(frame_data.get("force_direction", 0.0)),
+        float(frame_data.get("force_peak", 0.0)),
+    ]
+
+    features["observation.tactile.deformation"] = [
+        float(frame_data.get("deformation_magnitude", 0.0)),
+        float(frame_data.get("temporal_deformation_rate", 0.0)),
+    ]
+
+    features["observation.tactile.slip"] = [
+        float(frame_data.get("slip_entropy", 0.0)),
+        float(frame_data.get("slip_event", 0.0)),
+    ]
+
+    features["observation.tactile.texture"] = [
+        float(frame_data.get("texture_energy", 0.0))
+    ]
+
+    features["observation.tactile.contact_geometry"] = [
+        float(frame_data.get("contact_area", 0.0)),
+        float(frame_data.get("centroid_x", 0.0)),
+        float(frame_data.get("centroid_y", 0.0)),
+    ]
+
+    features["observation.tactile.field"] = [
+        float(frame_data.get("normal_mag", 0.0)),
+        float(frame_data.get("normal_var", 0.0)),
+        float(frame_data.get("shear_mag", 0.0)),
+        float(frame_data.get("shear_dir", 0.0)),
+    ]
+
+    features["observation.tactile.dynamics"] = [
+        float(frame_data.get("delta_normal", 0.0)),
+        float(frame_data.get("delta_shear", 0.0)),
+        float(frame_data.get("friction_cone_ratio", 0.0)),
+    ]
+
+    return features
+
+
+def convert(
+    input_dir: Path,
+    repo_id: str,
+    fps: int = 30,
+    sensor_type: str = "gelsight",
+    output_dir: str = None,
+    push_to_hub: bool = False,
+    task: str = "tactile manipulation",
+    config_path: str = None,
+):
+    """Main conversion function."""
+    try:
+        from lerobot.common.datasets.lerobot_dataset import LeRobotDataset
+    except ImportError:
+        print("lerobot not found. Install with: pip install lerobot")
+        sys.exit(1)
+
+    data = load_tlabel_data(input_dir)
+    episodes = data["episodes"]
+    print(f"Found {len(episodes)} episodes")
+
+    has_image = False
+    sensor_config = SENSOR_CONFIGS.get(sensor_type, {})
+    if sensor_config.get("has_image", False):
+        for ep_frames in episodes.values():
+            if ep_frames and "tactile_image" in ep_frames[0]:
+                has_image = True
+                break
+
+    features = build_features(sensor_type, config_path, has_image)
+    use_videos = has_image
+
+    print(f"Sensor: {sensor_type}")
+    print(f"Features: {len(features)} keys")
+    print(f"Video features: {use_videos}")
+
+    root = output_dir or "./lerobot_data"
+    dataset = LeRobotDataset.create(
+        repo_id=repo_id,
+        fps=fps,
+        features=features,
+        robot_type=sensor_type,
+        root=root,
+        use_videos=use_videos,
+    )
+
+    for ep_idx, frames in sorted(episodes.items()):
+        print(f"  Episode {ep_idx}: {len(frames)} frames")
+
+        for frame_data in frames:
+            frame = {}
+            tactile = extract_tactile_features(frame_data, sensor_type)
+            frame.update(tactile)
+            frame["task"] = task
+
+            if has_image and "tactile_image" in frame_data:
+                img = frame_data["tactile_image"]
+                if isinstance(img, str):
+                    img_path = input_dir / img
+                    if img_path.exists():
+                        from PIL import Image
+                        frame["observation.images.tactile"] = np.array(
+                            Image.open(img_path)
+                        )
+                elif isinstance(img, np.ndarray):
+                    frame["observation.images.tactile"] = img
+
+            dataset.add_frame(frame)
+
+        dataset.save_episode(task=task)
+
+    dataset.finalize()
+    print(f"\nDataset saved to: {root}/{repo_id}")
+
+    if push_to_hub:
+        print("Pushing to Hugging Face Hub...")
+        dataset.push_to_hub()
+        print(f"Pushed: https://huggingface.co/datasets/{repo_id}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Convert TLabel tactile data to LeRobotDataset format"
+    )
+    parser.add_argument(
+        "--input-dir", type=str, required=True,
+        help="Path to TLabel exported dataset directory"
+    )
+    parser.add_argument(
+        "--repo-id", type=str, required=True,
+        help="LeRobot dataset repo ID (e.g., username/dataset_name)"
+    )
+    parser.add_argument(
+        "--fps", type=int, default=30,
+        help="Sampling rate in Hz (default: 30)"
+    )
+    parser.add_argument(
+        "--sensor-type", type=str, default="gelsight",
+        choices=list(SENSOR_CONFIGS.keys()),
+        help="Tactile sensor type (default: gelsight)"
+    )
+    parser.add_argument(
+        "--output-dir", type=str, default=None,
+        help="Local output directory (default: ./lerobot_data/)"
+    )
+    parser.add_argument(
+        "--push-to-hub", action="store_true",
+        help="Push dataset to Hugging Face Hub"
+    )
+    parser.add_argument(
+        "--task", type=str, default="tactile manipulation",
+        help="Task description string"
+    )
+    parser.add_argument(
+        "--config", type=str, default=None,
+        help="Path to custom feature config YAML"
+    )
+
+    args = parser.parse_args()
+    convert(
+        input_dir=Path(args.input_dir),
+        repo_id=args.repo_id,
+        fps=args.fps,
+        sensor_type=args.sensor_type,
+        output_dir=args.output_dir,
+        push_to_hub=args.push_to_hub,
+        task=args.task,
+        config_path=args.config,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/tlabel/convert_tlabel_to_lerobot.py
+++ b/examples/tlabel/convert_tlabel_to_lerobot.py
@@ -484,7 +484,7 @@ def convert(
 
             dataset.add_frame(frame)
 
-        dataset.save_episode(task=task)
+        dataset.save_episode()
 
     dataset.finalize()
     print(f"\nDataset saved to: {root}/{repo_id}")

--- a/examples/tlabel/convert_tlabel_to_lerobot.py
+++ b/examples/tlabel/convert_tlabel_to_lerobot.py
@@ -117,8 +117,7 @@ def _load_manual(input_dir: Path) -> dict:
         csv_files = list(input_dir.glob("*.csv"))
         if not csv_files:
             raise FileNotFoundError(
-                f"No TLabel data found in {input_dir}. "
-                "Expected tlabel_export.json or *.csv files."
+                f"No TLabel data found in {input_dir}. Expected tlabel_export.json or *.csv files."
             )
         return _load_csv_episodes(csv_files)
 
@@ -184,9 +183,7 @@ def detect_image_dimensions(input_dir: Path, episodes: dict) -> tuple | None:
     return None
 
 
-def validate_image_consistency(
-    input_dir: Path, episodes: dict, expected_shape: tuple
-) -> list:
+def validate_image_consistency(input_dir: Path, episodes: dict, expected_shape: tuple) -> list:
     """Validate all image frames for existence, shape consistency, and RGB channels.
 
     Only validates frames that have a 'tactile_image' key with a non-None value.
@@ -214,20 +211,14 @@ def validate_image_consistency(
 
             if isinstance(img, np.ndarray):
                 if img.ndim < 2:
-                    issues.append(
-                        f"{prefix}: array has <2 dims, shape={img.shape}"
-                    )
+                    issues.append(f"{prefix}: array has <2 dims, shape={img.shape}")
                     continue
                 h, w = img.shape[0], img.shape[1]
                 channels = img.shape[2] if img.ndim == 3 else 1
                 if (h, w) != (exp_h, exp_w):
-                    issues.append(
-                        f"{prefix}: shape ({h}, {w}) != expected ({exp_h}, {exp_w})"
-                    )
+                    issues.append(f"{prefix}: shape ({h}, {w}) != expected ({exp_h}, {exp_w})")
                 if channels != 3:
-                    issues.append(
-                        f"{prefix}: {channels} channel(s), expected 3 (RGB)"
-                    )
+                    issues.append(f"{prefix}: {channels} channel(s), expected 3 (RGB)")
 
             elif isinstance(img, str):
                 img_path = input_dir / img
@@ -241,14 +232,9 @@ def validate_image_consistency(
                         w, h = im.size
                         mode = im.mode
                     if (h, w) != (exp_h, exp_w):
-                        issues.append(
-                            f"{prefix}: {img} is ({h}, {w}) != expected "
-                            f"({exp_h}, {exp_w})"
-                        )
+                        issues.append(f"{prefix}: {img} is ({h}, {w}) != expected ({exp_h}, {exp_w})")
                     if mode not in ("RGB",):
-                        issues.append(
-                            f"{prefix}: {img} mode='{mode}', expected 'RGB'"
-                        )
+                        issues.append(f"{prefix}: {img} mode='{mode}', expected 'RGB'")
                 except OSError as e:
                     issues.append(f"{prefix}: cannot read {img}: {e}")
 
@@ -471,14 +457,10 @@ def convert(
                 if isinstance(img, str):
                     img_path = input_dir / img
                     if not img_path.exists():
-                        raise FileNotFoundError(
-                            f"Episode {ep_idx}: image file not found: {img_path}"
-                        )
+                        raise FileNotFoundError(f"Episode {ep_idx}: image file not found: {img_path}")
                     from PIL import Image
 
-                    frame["observation.images.tactile"] = np.array(
-                        Image.open(img_path)
-                    )
+                    frame["observation.images.tactile"] = np.array(Image.open(img_path))
                 elif isinstance(img, np.ndarray):
                     frame["observation.images.tactile"] = img
 
@@ -496,9 +478,7 @@ def convert(
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        description="Convert TLabel tactile data to LeRobotDataset format"
-    )
+    parser = argparse.ArgumentParser(description="Convert TLabel tactile data to LeRobotDataset format")
     parser.add_argument(
         "--input-dir",
         type=str,
@@ -511,9 +491,7 @@ def main():
         required=True,
         help="LeRobot dataset repo ID (e.g., username/dataset_name)",
     )
-    parser.add_argument(
-        "--fps", type=int, default=30, help="Sampling rate in Hz (default: 30)"
-    )
+    parser.add_argument("--fps", type=int, default=30, help="Sampling rate in Hz (default: 30)")
     parser.add_argument(
         "--sensor-type",
         type=str,

--- a/examples/tlabel/convert_tlabel_to_lerobot.py
+++ b/examples/tlabel/convert_tlabel_to_lerobot.py
@@ -18,16 +18,12 @@ import json
 import sys
 from pathlib import Path
 
+import numpy as np
+
 try:
     import yaml
 except ImportError:
     print("PyYAML is required: pip install pyyaml")
-    sys.exit(1)
-
-try:
-    import numpy as np
-except ImportError:
-    print("NumPy is required: pip install numpy")
     sys.exit(1)
 
 
@@ -104,6 +100,7 @@ def load_tlabel_data(input_dir: Path) -> dict:
     """
     try:
         import tlabel
+
         print(f"Loading TLabel data from {input_dir}...")
         dataset = tlabel.load(str(input_dir))
         return dataset
@@ -128,12 +125,10 @@ def _load_manual(input_dir: Path) -> dict:
     with open(data_file) as f:
         raw = json.load(f)
 
-    episodes = {}
+    episodes: dict[int, list] = {}
     for frame in raw.get("frames", []):
-        ep_idx = frame.get("episode_index", 0)
-        if ep_idx not in episodes:
-            episodes[ep_idx] = []
-        episodes[ep_idx].append(frame)
+        ep = frame.get("episode_index", 0)
+        episodes.setdefault(ep, []).append(frame)
 
     return {"episodes": episodes, "metadata": raw.get("metadata", {})}
 
@@ -142,21 +137,19 @@ def _load_csv_episodes(csv_files: list) -> dict:
     """Load episodes from CSV files."""
     import csv
 
-    episodes = {}
+    episodes: dict[int, list] = {}
     for csv_file in csv_files:
         with open(csv_file) as f:
             reader = csv.DictReader(f)
             for row in reader:
-                ep_idx = int(row.get("episode_index", 0))
-                if ep_idx not in episodes:
-                    episodes[ep_idx] = []
+                ep = int(row.get("episode_index", 0))
                 frame = {}
                 for k, v in row.items():
                     try:
                         frame[k] = float(v)
                     except (ValueError, TypeError):
                         frame[k] = v
-                episodes[ep_idx].append(frame)
+                episodes.setdefault(ep, []).append(frame)
 
     return {"episodes": episodes, "metadata": {}}
 
@@ -172,21 +165,19 @@ def detect_image_dimensions(input_dir: Path, episodes: dict) -> tuple | None:
             if img is None:
                 continue
 
-            # Handle numpy array
-            if isinstance(img, np.ndarray):
-                if img.ndim >= 2:
-                    return (img.shape[0], img.shape[1])
+            if isinstance(img, np.ndarray) and img.ndim >= 2:
+                return (img.shape[0], img.shape[1])
 
-            # Handle file path string
             if isinstance(img, str):
                 img_path = input_dir / img
                 if img_path.exists():
                     try:
                         from PIL import Image
+
                         with Image.open(img_path) as im:
                             w, h = im.size
                             return (h, w)
-                    except Exception as e:
+                    except OSError as e:
                         print(f"Warning: Could not read image {img_path}: {e}")
                         continue
 
@@ -198,10 +189,9 @@ def validate_image_consistency(
 ) -> list:
     """Validate all image frames for existence, shape consistency, and RGB channels.
 
-    Checks every frame that declares a tactile_image field:
-    - File must exist (for path-based images)
-    - Shape must match expected (H, W)
-    - Must have exactly 3 channels (RGB), not grayscale or RGBA
+    Only validates frames that have a 'tactile_image' key with a non-None value.
+    Frames without the key or with None are silently skipped (the caller decides
+    whether that constitutes an error).
 
     Args:
         input_dir: Base directory for resolving relative image paths.
@@ -224,7 +214,9 @@ def validate_image_consistency(
 
             if isinstance(img, np.ndarray):
                 if img.ndim < 2:
-                    issues.append(f"{prefix}: array has <2 dims, shape={img.shape}")
+                    issues.append(
+                        f"{prefix}: array has <2 dims, shape={img.shape}"
+                    )
                     continue
                 h, w = img.shape[0], img.shape[1]
                 channels = img.shape[2] if img.ndim == 3 else 1
@@ -257,13 +249,18 @@ def validate_image_consistency(
                         issues.append(
                             f"{prefix}: {img} mode='{mode}', expected 'RGB'"
                         )
-                except Exception as e:
+                except OSError as e:
                     issues.append(f"{prefix}: cannot read {img}: {e}")
 
     return issues
 
 
-def build_features(sensor_type: str, config_path: str = None, has_image: bool = False, image_shape: tuple = None) -> dict:
+def build_features(
+    sensor_type: str,
+    config_path: str | None = None,
+    has_image: bool = False,
+    image_shape: tuple | None = None,
+) -> dict:
     """Build the complete feature dict for LeRobotDataset.
 
     Args:
@@ -290,11 +287,10 @@ def build_features(sensor_type: str, config_path: str = None, has_image: bool = 
     if sensor_config.get("has_image") or has_image:
         image_key = sensor_config.get("image_key", "observation.images.tactile")
 
-        # Determine image shape dynamically or fall back to default
         if image_shape is not None:
             h, w = image_shape
         else:
-            h, w = 480, 640  # default fallback
+            h, w = 480, 640
 
         features[image_key] = {
             "dtype": "video",
@@ -309,51 +305,70 @@ def extract_tactile_features(frame_data: dict, sensor_type: str) -> dict:
     """Extract tactile feature values from a TLabel frame.
 
     Maps TLabel 22-dim schema to LeRobot feature keys.
+    All values are returned as np.ndarray (float32) as required by LeRobot.
     """
     features = {}
 
-    features["observation.tactile.contact"] = [
-        float(frame_data.get("contact", 0.0))
-    ]
+    features["observation.tactile.contact"] = np.asarray(
+        [float(frame_data.get("contact", 0.0))], dtype=np.float32
+    )
 
-    features["observation.tactile.force"] = [
-        float(frame_data.get("force_magnitude", 0.0)),
-        float(frame_data.get("force_direction", 0.0)),
-        float(frame_data.get("force_peak", 0.0)),
-    ]
+    features["observation.tactile.force"] = np.asarray(
+        [
+            float(frame_data.get("force_magnitude", 0.0)),
+            float(frame_data.get("force_direction", 0.0)),
+            float(frame_data.get("force_peak", 0.0)),
+        ],
+        dtype=np.float32,
+    )
 
-    features["observation.tactile.deformation"] = [
-        float(frame_data.get("deformation_magnitude", 0.0)),
-        float(frame_data.get("temporal_deformation_rate", 0.0)),
-    ]
+    features["observation.tactile.deformation"] = np.asarray(
+        [
+            float(frame_data.get("deformation_magnitude", 0.0)),
+            float(frame_data.get("temporal_deformation_rate", 0.0)),
+        ],
+        dtype=np.float32,
+    )
 
-    features["observation.tactile.slip"] = [
-        float(frame_data.get("slip_entropy", 0.0)),
-        float(frame_data.get("slip_event", 0.0)),
-    ]
+    features["observation.tactile.slip"] = np.asarray(
+        [
+            float(frame_data.get("slip_entropy", 0.0)),
+            float(frame_data.get("slip_event", 0.0)),
+        ],
+        dtype=np.float32,
+    )
 
-    features["observation.tactile.texture"] = [
-        float(frame_data.get("texture_energy", 0.0))
-    ]
+    features["observation.tactile.texture"] = np.asarray(
+        [float(frame_data.get("texture_energy", 0.0))], dtype=np.float32
+    )
 
-    features["observation.tactile.contact_geometry"] = [
-        float(frame_data.get("contact_area", 0.0)),
-        float(frame_data.get("centroid_x", 0.0)),
-        float(frame_data.get("centroid_y", 0.0)),
-    ]
+    features["observation.tactile.contact_geometry"] = np.asarray(
+        [
+            float(frame_data.get("contact_area", 0.0)),
+            float(frame_data.get("centroid_x", 0.0)),
+            float(frame_data.get("centroid_y", 0.0)),
+        ],
+        dtype=np.float32,
+    )
 
-    features["observation.tactile.field"] = [
-        float(frame_data.get("normal_mag", 0.0)),
-        float(frame_data.get("normal_var", 0.0)),
-        float(frame_data.get("shear_mag", 0.0)),
-        float(frame_data.get("shear_dir", 0.0)),
-    ]
+    features["observation.tactile.field"] = np.asarray(
+        [
+            float(frame_data.get("normal_mag", 0.0)),
+            float(frame_data.get("normal_var", 0.0)),
+            float(frame_data.get("shear_mag", 0.0)),
+            float(frame_data.get("shear_dir", 0.0)),
+        ],
+        dtype=np.float32,
+    )
 
-    features["observation.tactile.dynamics"] = [
-        float(frame_data.get("delta_normal", 0.0)),
-        float(frame_data.get("delta_shear", 0.0)),
-        float(frame_data.get("friction_cone_ratio", 0.0)),
-    ]
+    features["observation.tactile.dynamics"] = np.asarray(
+        [
+            float(frame_data.get("delta_normal", 0.0)),
+            float(frame_data.get("delta_shear", 0.0)),
+            float(frame_data.get("friction_cone_ratio", 0.0)),
+        ],
+        dtype=np.float32,
+    )
 
     return features
 
@@ -363,17 +378,13 @@ def convert(
     repo_id: str,
     fps: int = 30,
     sensor_type: str = "gelsight",
-    output_dir: str = None,
+    output_dir: str | None = None,
     push_to_hub: bool = False,
     task: str = "tactile manipulation",
-    config_path: str = None,
+    config_path: str | None = None,
 ):
     """Main conversion function."""
-    try:
-        from lerobot.datasets import LeRobotDataset
-    except ImportError:
-        print("lerobot not found. Install with: pip install lerobot")
-        sys.exit(1)
+    from lerobot.datasets import LeRobotDataset
 
     data = load_tlabel_data(input_dir)
     episodes = data["episodes"]
@@ -392,30 +403,44 @@ def convert(
     # Detect actual image dimensions from data if images are present
     image_shape = None
     if has_image:
-        detected = detect_image_dimensions(input_dir, episodes)
-        if detected is not None:
-            image_shape = detected
-            print(f"Detected image dimensions: {image_shape[0]}x{image_shape[1]}")
+        # Pre-check: ensure every frame has a tactile_image value
+        missing = []
+        for ep_idx, ep_frames in sorted(episodes.items()):
+            for frame_idx, frame_data in enumerate(ep_frames):
+                img = frame_data.get("tactile_image")
+                if img is None:
+                    missing.append(f"Episode {ep_idx}, frame {frame_idx}")
+        if missing:
+            raise ValueError(
+                f"Image feature is declared but {len(missing)} frame(s) have no "
+                f"tactile_image: {missing[:5]}{'...' if len(missing) > 5 else ''}"
+            )
 
-            # Validate all frames for consistency
-            issues = validate_image_consistency(input_dir, episodes, image_shape)
-            if issues:
-                print(f"Image validation found {len(issues)} issue(s):")
-                for issue in issues:
-                    print(f"  - {issue}")
-                raise ValueError(
-                    f"Inconsistent images detected ({len(issues)} issue(s)). "
-                    "All tactile images must be RGB with uniform (H, W)."
-                )
-        else:
-            print("Warning: Could not detect image dimensions, using default 480x640")
+        detected = detect_image_dimensions(input_dir, episodes)
+        if detected is None:
+            raise ValueError(
+                "Data declares tactile_image but no readable images were found. "
+                "Check that image file paths are correct and files exist."
+            )
+        image_shape = detected
+        print(f"Detected image dimensions: {image_shape[0]}x{image_shape[1]}")
+
+        # Validate all frames for consistency
+        issues = validate_image_consistency(input_dir, episodes, image_shape)
+        if issues:
+            print(f"Image validation found {len(issues)} issue(s):")
+            for issue in issues:
+                print(f"  - {issue}")
+            raise ValueError(
+                f"Inconsistent or missing images ({len(issues)} issue(s)). "
+                "All frames must have valid RGB tactile images with uniform (H, W)."
+            )
 
     features = build_features(sensor_type, config_path, has_image, image_shape)
-    use_videos = has_image
 
     print(f"Sensor: {sensor_type}")
     print(f"Features: {len(features)} keys")
-    print(f"Video features: {use_videos}")
+    print(f"Video features: {has_image}")
 
     root = output_dir or "./lerobot_data"
     dataset = LeRobotDataset.create(
@@ -424,7 +449,7 @@ def convert(
         features=features,
         robot_type=sensor_type,
         root=root,
-        use_videos=use_videos,
+        use_videos=has_image,
     )
 
     for ep_idx, frames in sorted(episodes.items()):
@@ -436,15 +461,24 @@ def convert(
             frame.update(tactile)
             frame["task"] = task
 
-            if has_image and "tactile_image" in frame_data:
-                img = frame_data["tactile_image"]
+            if has_image:
+                img = frame_data.get("tactile_image")
+                if img is None:
+                    raise ValueError(
+                        f"Episode {ep_idx}: frame has no tactile_image but image "
+                        "feature is declared. All frames must have images."
+                    )
                 if isinstance(img, str):
                     img_path = input_dir / img
-                    if img_path.exists():
-                        from PIL import Image
-                        frame["observation.images.tactile"] = np.array(
-                            Image.open(img_path)
+                    if not img_path.exists():
+                        raise FileNotFoundError(
+                            f"Episode {ep_idx}: image file not found: {img_path}"
                         )
+                    from PIL import Image
+
+                    frame["observation.images.tactile"] = np.array(
+                        Image.open(img_path)
+                    )
                 elif isinstance(img, np.ndarray):
                     frame["observation.images.tactile"] = img
 
@@ -466,37 +500,49 @@ def main():
         description="Convert TLabel tactile data to LeRobotDataset format"
     )
     parser.add_argument(
-        "--input-dir", type=str, required=True,
-        help="Path to TLabel exported dataset directory"
+        "--input-dir",
+        type=str,
+        required=True,
+        help="Path to TLabel exported dataset directory",
     )
     parser.add_argument(
-        "--repo-id", type=str, required=True,
-        help="LeRobot dataset repo ID (e.g., username/dataset_name)"
+        "--repo-id",
+        type=str,
+        required=True,
+        help="LeRobot dataset repo ID (e.g., username/dataset_name)",
     )
     parser.add_argument(
-        "--fps", type=int, default=30,
-        help="Sampling rate in Hz (default: 30)"
+        "--fps", type=int, default=30, help="Sampling rate in Hz (default: 30)"
     )
     parser.add_argument(
-        "--sensor-type", type=str, default="gelsight",
+        "--sensor-type",
+        type=str,
+        default="gelsight",
         choices=list(SENSOR_CONFIGS.keys()),
-        help="Tactile sensor type (default: gelsight)"
+        help="Tactile sensor type (default: gelsight)",
     )
     parser.add_argument(
-        "--output-dir", type=str, default=None,
-        help="Local output directory (default: ./lerobot_data/)"
+        "--output-dir",
+        type=str,
+        default=None,
+        help="Local output directory (default: ./lerobot_data/)",
     )
     parser.add_argument(
-        "--push-to-hub", action="store_true",
-        help="Push dataset to Hugging Face Hub"
+        "--push-to-hub",
+        action="store_true",
+        help="Push dataset to Hugging Face Hub",
     )
     parser.add_argument(
-        "--task", type=str, default="tactile manipulation",
-        help="Task description string"
+        "--task",
+        type=str,
+        default="tactile manipulation",
+        help="Task description string",
     )
     parser.add_argument(
-        "--config", type=str, default=None,
-        help="Path to custom feature config YAML"
+        "--config",
+        type=str,
+        default=None,
+        help="Path to custom feature config YAML",
     )
 
     args = parser.parse_args()

--- a/examples/tlabel/convert_tlabel_to_lerobot.py
+++ b/examples/tlabel/convert_tlabel_to_lerobot.py
@@ -193,6 +193,76 @@ def detect_image_dimensions(input_dir: Path, episodes: dict) -> tuple | None:
     return None
 
 
+def validate_image_consistency(
+    input_dir: Path, episodes: dict, expected_shape: tuple
+) -> list:
+    """Validate all image frames for existence, shape consistency, and RGB channels.
+
+    Checks every frame that declares a tactile_image field:
+    - File must exist (for path-based images)
+    - Shape must match expected (H, W)
+    - Must have exactly 3 channels (RGB), not grayscale or RGBA
+
+    Args:
+        input_dir: Base directory for resolving relative image paths.
+        episodes: Dict mapping episode index to list of frame dicts.
+        expected_shape: (height, width) from detect_image_dimensions().
+
+    Returns:
+        List of issue description strings. Empty list means all frames are valid.
+    """
+    issues = []
+    exp_h, exp_w = expected_shape
+
+    for ep_idx, ep_frames in sorted(episodes.items()):
+        for frame_idx, frame_data in enumerate(ep_frames):
+            img = frame_data.get("tactile_image")
+            if img is None:
+                continue
+
+            prefix = f"Episode {ep_idx}, frame {frame_idx}"
+
+            if isinstance(img, np.ndarray):
+                if img.ndim < 2:
+                    issues.append(f"{prefix}: array has <2 dims, shape={img.shape}")
+                    continue
+                h, w = img.shape[0], img.shape[1]
+                channels = img.shape[2] if img.ndim == 3 else 1
+                if (h, w) != (exp_h, exp_w):
+                    issues.append(
+                        f"{prefix}: shape ({h}, {w}) != expected ({exp_h}, {exp_w})"
+                    )
+                if channels != 3:
+                    issues.append(
+                        f"{prefix}: {channels} channel(s), expected 3 (RGB)"
+                    )
+
+            elif isinstance(img, str):
+                img_path = input_dir / img
+                if not img_path.exists():
+                    issues.append(f"{prefix}: image file not found: {img}")
+                    continue
+                try:
+                    from PIL import Image
+
+                    with Image.open(img_path) as im:
+                        w, h = im.size
+                        mode = im.mode
+                    if (h, w) != (exp_h, exp_w):
+                        issues.append(
+                            f"{prefix}: {img} is ({h}, {w}) != expected "
+                            f"({exp_h}, {exp_w})"
+                        )
+                    if mode not in ("RGB",):
+                        issues.append(
+                            f"{prefix}: {img} mode='{mode}', expected 'RGB'"
+                        )
+                except Exception as e:
+                    issues.append(f"{prefix}: cannot read {img}: {e}")
+
+    return issues
+
+
 def build_features(sensor_type: str, config_path: str = None, has_image: bool = False, image_shape: tuple = None) -> dict:
     """Build the complete feature dict for LeRobotDataset.
 
@@ -309,13 +379,15 @@ def convert(
     episodes = data["episodes"]
     print(f"Found {len(episodes)} episodes")
 
+    # Check if any frame across ALL episodes has images (not just first frame)
     has_image = False
-    sensor_config = SENSOR_CONFIGS.get(sensor_type, {})
-    if sensor_config.get("has_image", False):
-        for ep_frames in episodes.values():
-            if ep_frames and "tactile_image" in ep_frames[0]:
+    for ep_frames in episodes.values():
+        for frame_data in ep_frames:
+            if "tactile_image" in frame_data:
                 has_image = True
                 break
+        if has_image:
+            break
 
     # Detect actual image dimensions from data if images are present
     image_shape = None
@@ -324,6 +396,17 @@ def convert(
         if detected is not None:
             image_shape = detected
             print(f"Detected image dimensions: {image_shape[0]}x{image_shape[1]}")
+
+            # Validate all frames for consistency
+            issues = validate_image_consistency(input_dir, episodes, image_shape)
+            if issues:
+                print(f"Image validation found {len(issues)} issue(s):")
+                for issue in issues:
+                    print(f"  - {issue}")
+                raise ValueError(
+                    f"Inconsistent images detected ({len(issues)} issue(s)). "
+                    "All tactile images must be RGB with uniform (H, W)."
+                )
         else:
             print("Warning: Could not detect image dimensions, using default 480x640")
 

--- a/examples/tlabel/convert_tlabel_to_lerobot.py
+++ b/examples/tlabel/convert_tlabel_to_lerobot.py
@@ -161,8 +161,48 @@ def _load_csv_episodes(csv_files: list) -> dict:
     return {"episodes": episodes, "metadata": {}}
 
 
-def build_features(sensor_type: str, config_path: str = None, has_image: bool = False) -> dict:
-    """Build the complete feature dict for LeRobotDataset."""
+def detect_image_dimensions(input_dir: Path, episodes: dict) -> tuple | None:
+    """Detect actual image dimensions from the first available tactile image.
+
+    Returns (height, width) or None if no images found.
+    """
+    for ep_frames in episodes.values():
+        for frame_data in ep_frames:
+            img = frame_data.get("tactile_image")
+            if img is None:
+                continue
+
+            # Handle numpy array
+            if isinstance(img, np.ndarray):
+                if img.ndim >= 2:
+                    return (img.shape[0], img.shape[1])
+
+            # Handle file path string
+            if isinstance(img, str):
+                img_path = input_dir / img
+                if img_path.exists():
+                    try:
+                        from PIL import Image
+                        with Image.open(img_path) as im:
+                            w, h = im.size
+                            return (h, w)
+                    except Exception as e:
+                        print(f"Warning: Could not read image {img_path}: {e}")
+                        continue
+
+    return None
+
+
+def build_features(sensor_type: str, config_path: str = None, has_image: bool = False, image_shape: tuple = None) -> dict:
+    """Build the complete feature dict for LeRobotDataset.
+
+    Args:
+        sensor_type: Type of tactile sensor.
+        config_path: Optional path to custom feature config YAML.
+        has_image: Whether to include image features.
+        image_shape: Optional (height, width) for tactile images. If None and
+                     has_image is True, uses default (480, 640).
+    """
     features = {}
     features.update(BASE_FEATURES)
 
@@ -179,9 +219,16 @@ def build_features(sensor_type: str, config_path: str = None, has_image: bool = 
     sensor_config = SENSOR_CONFIGS.get(sensor_type, SENSOR_CONFIGS["gelsight"])
     if sensor_config.get("has_image") or has_image:
         image_key = sensor_config.get("image_key", "observation.images.tactile")
+
+        # Determine image shape dynamically or fall back to default
+        if image_shape is not None:
+            h, w = image_shape
+        else:
+            h, w = 480, 640  # default fallback
+
         features[image_key] = {
             "dtype": "video",
-            "shape": [480, 640, 3],
+            "shape": [h, w, 3],
             "names": ["height", "width", "channels"],
         }
 
@@ -253,7 +300,7 @@ def convert(
 ):
     """Main conversion function."""
     try:
-        from lerobot.common.datasets.lerobot_dataset import LeRobotDataset
+        from lerobot.datasets import LeRobotDataset
     except ImportError:
         print("lerobot not found. Install with: pip install lerobot")
         sys.exit(1)
@@ -270,7 +317,17 @@ def convert(
                 has_image = True
                 break
 
-    features = build_features(sensor_type, config_path, has_image)
+    # Detect actual image dimensions from data if images are present
+    image_shape = None
+    if has_image:
+        detected = detect_image_dimensions(input_dir, episodes)
+        if detected is not None:
+            image_shape = detected
+            print(f"Detected image dimensions: {image_shape[0]}x{image_shape[1]}")
+        else:
+            print("Warning: Could not detect image dimensions, using default 480x640")
+
+    features = build_features(sensor_type, config_path, has_image, image_shape)
     use_videos = has_image
 
     print(f"Sensor: {sensor_type}")

--- a/tests/test_tlabel_conversion.py
+++ b/tests/test_tlabel_conversion.py
@@ -1,0 +1,179 @@
+"""Tests for TLabel to LeRobot conversion."""
+import json
+from pathlib import Path
+
+import pytest
+
+# Skip all tests if tlabel or lerobot not installed
+tlabel = pytest.importorskip("tlabel")
+lerobot = pytest.importorskip("lerobot")
+
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "examples", "tlabel"))
+
+from convert_tlabel_to_lerobot import (
+    DEFAULT_TACTILE_FEATURES,
+    SENSOR_CONFIGS,
+    build_features,
+    extract_tactile_features,
+    _load_manual,
+    _load_csv_episodes,
+)
+
+
+class TestFeatureBuilding:
+    """Test feature dict construction."""
+
+    def test_default_features(self):
+        """Default features include all 8 tactile groups + base features."""
+        features = build_features("gelsight")
+        assert "timestamp" in features
+        assert "episode_index" in features
+        assert "frame_index" in features
+        assert "index" in features
+        assert "task_index" in features
+        assert "observation.tactile.contact" in features
+        assert "observation.tactile.force" in features
+        assert "observation.tactile.deformation" in features
+        assert "observation.tactile.slip" in features
+        assert "observation.tactile.texture" in features
+        assert "observation.tactile.contact_geometry" in features
+        assert "observation.tactile.field" in features
+        assert "observation.tactile.dynamics" in features
+
+    def test_gelsight_has_image(self):
+        """GelSight sensor includes tactile image feature."""
+        features = build_features("gelsight", has_image=True)
+        assert "observation.images.tactile" in features
+        assert features["observation.images.tactile"]["dtype"] == "video"
+
+    def test_paxini_no_image(self):
+        """PaXini sensor does not include image feature."""
+        features = build_features("paxini", has_image=False)
+        assert "observation.images.tactile" not in features
+
+    def test_custom_config(self, tmp_path):
+        """Custom YAML config overrides defaults."""
+        config = tmp_path / "custom.yaml"
+        config.write_text(
+            "observation.tactile.contact:\n"
+            "  dtype: float32\n"
+            "  shape: [1]\n"
+            "  names: [contact]\n"
+        )
+        features = build_features("gelsight", config_path=str(config))
+        assert "observation.tactile.contact" in features
+
+
+class TestFeatureExtraction:
+    """Test TLabel frame to LeRobot feature extraction."""
+
+    def test_basic_extraction(self):
+        """Extract features from a minimal frame."""
+        frame = {
+            "contact": 1.0,
+            "force_magnitude": 2.5,
+            "force_direction": 0.3,
+            "force_peak": 3.1,
+            "deformation_magnitude": 0.1,
+            "temporal_deformation_rate": 0.05,
+            "slip_entropy": 0.8,
+            "slip_event": 1.0,
+            "texture_energy": 0.2,
+            "contact_area": 100.0,
+            "centroid_x": 50.0,
+            "centroid_y": 75.0,
+            "normal_mag": 1.5,
+            "normal_var": 0.1,
+            "shear_mag": 0.3,
+            "shear_dir": 1.2,
+            "delta_normal": 0.2,
+            "delta_shear": 0.1,
+            "friction_cone_ratio": 0.7,
+        }
+        result = extract_tactile_features(frame, "gelsight")
+
+        assert result["observation.tactile.contact"] == [1.0]
+        assert result["observation.tactile.force"] == [2.5, 0.3, 3.1]
+        assert result["observation.tactile.deformation"] == [0.1, 0.05]
+        assert result["observation.tactile.slip"] == [0.8, 1.0]
+        assert result["observation.tactile.texture"] == [0.2]
+        assert result["observation.tactile.contact_geometry"] == [100.0, 50.0, 75.0]
+        assert result["observation.tactile.field"] == [1.5, 0.1, 0.3, 1.2]
+        assert result["observation.tactile.dynamics"] == [0.2, 0.1, 0.7]
+
+    def test_missing_values_default_to_zero(self):
+        """Missing fields default to 0.0."""
+        frame = {"contact": 1.0}
+        result = extract_tactile_features(frame, "paxini")
+
+        assert result["observation.tactile.contact"] == [1.0]
+        assert result["observation.tactile.force"] == [0.0, 0.0, 0.0]
+        assert result["observation.tactile.deformation"] == [0.0, 0.0]
+
+    def test_empty_frame(self):
+        """Empty frame returns all zeros."""
+        result = extract_tactile_features({}, "gelsight")
+        for key, value in result.items():
+            assert all(v == 0.0 for v in value), f"{key} has non-zero values: {value}"
+
+
+class TestSensorConfigs:
+    """Test sensor-specific configurations."""
+
+    def test_known_sensors(self):
+        """All documented sensors are in config."""
+        expected = {"gelsight", "digit", "paxini", "daimon", "touchd", "univtac", "vtac"}
+        assert set(SENSOR_CONFIGS.keys()) == expected
+
+    def test_visual_sensors_have_images(self):
+        """Visual tactile sensors have image capability."""
+        assert SENSOR_CONFIGS["gelsight"]["has_image"] is True
+        assert SENSOR_CONFIGS["digit"]["has_image"] is True
+
+    def test_force_sensors_no_images(self):
+        """Force-based sensors have no image capability."""
+        assert SENSOR_CONFIGS["paxini"]["has_image"] is False
+        assert SENSOR_CONFIGS["daimon"]["has_image"] is False
+
+
+class TestDataLoading:
+    """Test manual data loading fallback."""
+
+    def test_load_json(self, tmp_path):
+        """Load from tlabel_export.json."""
+        data = {
+            "metadata": {"sensor": "gelsight", "fps": 30},
+            "frames": [
+                {"episode_index": 0, "contact": 1.0, "force_magnitude": 2.0},
+                {"episode_index": 0, "contact": 0.0, "force_magnitude": 0.0},
+                {"episode_index": 1, "contact": 1.0, "force_magnitude": 1.5},
+            ],
+        }
+        json_file = tmp_path / "tlabel_export.json"
+        json_file.write_text(json.dumps(data))
+
+        result = _load_manual(tmp_path)
+        assert len(result["episodes"]) == 2
+        assert len(result["episodes"][0]) == 2
+        assert len(result["episodes"][1]) == 1
+
+    def test_load_csv(self, tmp_path):
+        """Load from CSV files."""
+        csv_file = tmp_path / "data.csv"
+        csv_file.write_text(
+            "episode_index,contact,force_magnitude\n"
+            "0,1.0,2.5\n"
+            "0,0.0,0.0\n"
+            "1,1.0,1.0\n"
+        )
+
+        result = _load_csv_episodes([csv_file])
+        assert len(result["episodes"]) == 2
+        assert result["episodes"][0][0]["contact"] == 1.0
+
+    def test_no_data_raises(self, tmp_path):
+        """Missing data files raises FileNotFoundError."""
+        with pytest.raises(FileNotFoundError):
+            _load_manual(tmp_path)

--- a/tests/test_tlabel_conversion.py
+++ b/tests/test_tlabel_conversion.py
@@ -427,9 +427,9 @@ class TestRoundTrip:
         """Round-trip test without images (paxini sensor)."""
         pytest.importorskip("lerobot")
         pytest.importorskip("av")
-        from lerobot.datasets import LeRobotDataset
-
         from convert_tlabel_to_lerobot import convert
+
+        from lerobot.datasets import LeRobotDataset
 
         output_dir = str(tmp_path / "output")
         convert(
@@ -456,14 +456,14 @@ class TestRoundTrip:
         """Round-trip test with numpy array images (gelsight sensor)."""
         pytest.importorskip("lerobot")
         pytest.importorskip("av")
-        from lerobot.datasets import LeRobotDataset
-
         from convert_tlabel_to_lerobot import (
             _load_manual,
             build_features,
             detect_image_dimensions,
             extract_tactile_features,
         )
+
+        from lerobot.datasets import LeRobotDataset
 
         json_file = sample_data / "tlabel_export.json"
         json_file.write_text(
@@ -501,7 +501,7 @@ class TestRoundTrip:
             use_videos=True,
         )
 
-        for ep_idx, frames in sorted(episodes.items()):
+        for _, frames in sorted(episodes.items()):
             for frame_data in frames:
                 frame = {}
                 tactile = extract_tactile_features(frame_data, "gelsight")
@@ -509,7 +509,7 @@ class TestRoundTrip:
                 frame["task"] = "test"
                 frame["observation.images.tactile"] = frame_data["tactile_image"]
                 dataset.add_frame(frame)
-            dataset.save_episode(task="test")
+            dataset.save_episode()
 
         dataset.finalize()
 
@@ -521,10 +521,10 @@ class TestRoundTrip:
         """End-to-end round-trip: file-backed images go through convert()."""
         pytest.importorskip("lerobot")
         pytest.importorskip("av")
-        from lerobot.datasets import LeRobotDataset
+        from convert_tlabel_to_lerobot import convert
         from PIL import Image
 
-        from convert_tlabel_to_lerobot import convert
+        from lerobot.datasets import LeRobotDataset
 
         img_dir = tmp_path / "images"
         img_dir.mkdir()

--- a/tests/test_tlabel_conversion.py
+++ b/tests/test_tlabel_conversion.py
@@ -9,7 +9,6 @@ import pytest
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "examples", "tlabel"))
 
 from convert_tlabel_to_lerobot import (
-    DEFAULT_TACTILE_FEATURES,
     SENSOR_CONFIGS,
     _load_csv_episodes,
     _load_manual,
@@ -108,29 +107,52 @@ class TestFeatureExtraction:
         }
         result = extract_tactile_features(frame, "gelsight")
 
-        assert result["observation.tactile.contact"] == [1.0]
-        assert result["observation.tactile.force"] == [2.5, 0.3, 3.1]
-        assert result["observation.tactile.deformation"] == [0.1, 0.05]
-        assert result["observation.tactile.slip"] == [0.8, 1.0]
-        assert result["observation.tactile.texture"] == [0.2]
-        assert result["observation.tactile.contact_geometry"] == [100.0, 50.0, 75.0]
-        assert result["observation.tactile.field"] == [1.5, 0.1, 0.3, 1.2]
-        assert result["observation.tactile.dynamics"] == [0.2, 0.1, 0.7]
+        assert result["observation.tactile.contact"].tolist() == pytest.approx([1.0])
+        assert result["observation.tactile.force"].tolist() == pytest.approx(
+            [2.5, 0.3, 3.1]
+        )
+        assert result["observation.tactile.deformation"].tolist() == pytest.approx(
+            [0.1, 0.05]
+        )
+        assert result["observation.tactile.slip"].tolist() == pytest.approx(
+            [0.8, 1.0]
+        )
+        assert result["observation.tactile.texture"].tolist() == pytest.approx([0.2])
+        assert result["observation.tactile.contact_geometry"].tolist() == pytest.approx(
+            [100.0, 50.0, 75.0]
+        )
+        assert result["observation.tactile.field"].tolist() == pytest.approx(
+            [1.5, 0.1, 0.3, 1.2]
+        )
+        assert result["observation.tactile.dynamics"].tolist() == pytest.approx(
+            [0.2, 0.1, 0.7]
+        )
+
+    def test_returns_numpy_arrays(self):
+        """All feature values are np.ndarray with float32 dtype."""
+        result = extract_tactile_features({"contact": 1.0}, "paxini")
+        for key, value in result.items():
+            assert isinstance(value, np.ndarray), f"{key} is not np.ndarray: {type(value)}"
+            assert value.dtype == np.float32, f"{key} dtype is {value.dtype}, expected float32"
 
     def test_missing_values_default_to_zero(self):
         """Missing fields default to 0.0."""
         frame = {"contact": 1.0}
         result = extract_tactile_features(frame, "paxini")
 
-        assert result["observation.tactile.contact"] == [1.0]
-        assert result["observation.tactile.force"] == [0.0, 0.0, 0.0]
-        assert result["observation.tactile.deformation"] == [0.0, 0.0]
+        assert result["observation.tactile.contact"].tolist() == pytest.approx([1.0])
+        assert result["observation.tactile.force"].tolist() == pytest.approx(
+            [0.0, 0.0, 0.0]
+        )
+        assert result["observation.tactile.deformation"].tolist() == pytest.approx(
+            [0.0, 0.0]
+        )
 
     def test_empty_frame(self):
         """Empty frame returns all zeros."""
         result = extract_tactile_features({}, "gelsight")
         for key, value in result.items():
-            assert all(v == 0.0 for v in value), f"{key} has non-zero values: {value}"
+            assert np.allclose(value, 0.0), f"{key} has non-zero values: {value}"
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -218,7 +240,6 @@ class TestImageDimensionDetection:
         except ImportError:
             pytest.skip("PIL not available")
 
-        # Create a test image
         img_array = np.zeros((100, 200, 3), dtype=np.uint8)
         img = Image.fromarray(img_array)
         img_path = tmp_path / "test_image.png"
@@ -303,12 +324,10 @@ class TestImageConsistencyValidation:
         except ImportError:
             pytest.skip("PIL not available")
 
-        # Create two valid RGB images
         for name in ["frame_000.png", "frame_001.png"]:
             img = Image.fromarray(np.zeros((100, 200, 3), dtype=np.uint8))
             img.save(tmp_path / name)
 
-        # Create one wrong-size image
         bad_img = Image.fromarray(np.zeros((50, 80, 3), dtype=np.uint8))
         bad_img.save(tmp_path / "frame_002.png")
 
@@ -336,16 +355,31 @@ class TestImageConsistencyValidation:
         assert "not found" in issues[0]
 
     def test_no_image_frames_no_issues(self, tmp_path):
-        """Frames without tactile_image produce no issues."""
+        """Frames without tactile_image key are skipped by validate_image_consistency."""
         episodes = {
             0: [{"contact": 1.0}, {"contact": 0.0}],
         }
         issues = validate_image_consistency(tmp_path, episodes, (100, 200))
         assert issues == []
 
+    def test_none_tactile_image_skipped(self, tmp_path):
+        """Frames with tactile_image=None are skipped by validate_image_consistency.
+
+        The convert() function performs its own pre-validation to reject missing
+        images before this function is called.
+        """
+        episodes = {
+            0: [
+                {"tactile_image": np.zeros((100, 200, 3), dtype=np.uint8)},
+                {"tactile_image": None},
+            ],
+        }
+        issues = validate_image_consistency(tmp_path, episodes, (100, 200))
+        assert issues == []
+
 
 # ──────────────────────────────────────────────────────────────────────
-# End-to-end round-trip test (requires lerobot; tlabel mocked)
+# End-to-end round-trip test (requires lerobot)
 # ──────────────────────────────────────────────────────────────────────
 class TestRoundTrip:
     """End-to-end round-trip: create dataset, add frames, finalize, reload."""
@@ -391,7 +425,8 @@ class TestRoundTrip:
 
     def test_roundtrip_no_image(self, sample_data, tmp_path):
         """Round-trip test without images (paxini sensor)."""
-        lerobot = pytest.importorskip("lerobot")
+        pytest.importorskip("lerobot")
+        pytest.importorskip("av")
         from lerobot.datasets import LeRobotDataset
 
         from convert_tlabel_to_lerobot import convert
@@ -406,37 +441,23 @@ class TestRoundTrip:
             task="test task",
         )
 
-        # Reload and verify
-        dataset = LeRobotDataset(
-            "test/tactile_roundtrip",
-            root=output_dir,
-        )
-        dataset.finalize()  # ensure finalized for reading
+        dataset = LeRobotDataset("test/tactile_roundtrip", root=output_dir)
+        dataset.finalize()
 
         assert len(dataset) == 2
         assert dataset.fps == 30
         assert "observation.tactile.contact" in dataset.features
 
-        # Verify first frame data
         frame0 = dataset[0]
         assert frame0["observation.tactile.contact"].item() == pytest.approx(1.0)
         assert frame0["observation.tactile.force"][0].item() == pytest.approx(2.5)
 
     def test_roundtrip_with_numpy_images(self, sample_data, tmp_path):
         """Round-trip test with numpy array images (gelsight sensor)."""
-        lerobot = pytest.importorskip("lerobot")
+        pytest.importorskip("lerobot")
+        pytest.importorskip("av")
         from lerobot.datasets import LeRobotDataset
 
-        # Add image data to sample
-        json_file = sample_data / "tlabel_export.json"
-        data = json.loads(json_file.read_text())
-
-        # Replace with image data
-        for frame in data["frames"]:
-            frame["tactile_image"] = np.zeros((120, 160, 3), dtype=np.uint8)
-
-        # Need to use direct construction since images are numpy arrays
-        # Write as numpy references in a custom way
         from convert_tlabel_to_lerobot import (
             _load_manual,
             build_features,
@@ -444,9 +465,7 @@ class TestRoundTrip:
             extract_tactile_features,
         )
 
-        output_dir = str(tmp_path / "output_img")
-
-        # Load data manually
+        json_file = sample_data / "tlabel_export.json"
         json_file.write_text(
             json.dumps(
                 {
@@ -462,7 +481,6 @@ class TestRoundTrip:
         manual_data = _load_manual(sample_data)
         episodes = manual_data["episodes"]
 
-        # Add numpy images
         for ep_frames in episodes.values():
             for f in ep_frames:
                 f["tactile_image"] = np.zeros((120, 160, 3), dtype=np.uint8)
@@ -473,6 +491,7 @@ class TestRoundTrip:
         features = build_features("gelsight", has_image=True, image_shape=image_shape)
         assert features["observation.images.tactile"]["shape"] == [120, 160, 3]
 
+        output_dir = str(tmp_path / "output_img")
         dataset = LeRobotDataset.create(
             repo_id="test/tactile_img_roundtrip",
             fps=30,
@@ -494,31 +513,25 @@ class TestRoundTrip:
 
         dataset.finalize()
 
-        # Reload and verify
         reloaded = LeRobotDataset("test/tactile_img_roundtrip", root=output_dir)
         assert len(reloaded) == 2
         assert "observation.images.tactile" in reloaded.features
 
     def test_roundtrip_file_images_through_convert(self, tmp_path):
-        """End-to-end round-trip: file-backed images go through convert().
-
-        This test creates actual image files on disk and calls convert()
-        directly, exercising the full image loading + validation pipeline.
-        """
-        lerobot = pytest.importorskip("lerobot")
+        """End-to-end round-trip: file-backed images go through convert()."""
+        pytest.importorskip("lerobot")
+        pytest.importorskip("av")
         from lerobot.datasets import LeRobotDataset
         from PIL import Image
 
         from convert_tlabel_to_lerobot import convert
 
-        # Create image files
         img_dir = tmp_path / "images"
         img_dir.mkdir()
         for i in range(3):
             arr = np.random.randint(0, 255, (60, 80, 3), dtype=np.uint8)
             Image.fromarray(arr).save(img_dir / f"frame_{i:03d}.png")
 
-        # Create TLabel JSON with file-backed image references
         data = {
             "metadata": {"sensor": "gelsight", "fps": 30},
             "frames": [
@@ -534,7 +547,6 @@ class TestRoundTrip:
         json_file = tmp_path / "tlabel_export.json"
         json_file.write_text(json.dumps(data))
 
-        # Run full conversion
         output_dir = str(tmp_path / "output_file_rt")
         convert(
             input_dir=tmp_path,
@@ -545,13 +557,11 @@ class TestRoundTrip:
             task="file image round-trip test",
         )
 
-        # Reload and verify
         dataset = LeRobotDataset("test/tactile_file_roundtrip", root=output_dir)
         assert len(dataset) == 3
         assert "observation.images.tactile" in dataset.features
         assert dataset.fps == 30
 
-        # Verify tactile data survived the round-trip
         frame0 = dataset[0]
         assert frame0["observation.tactile.contact"].item() == pytest.approx(1.0)
         assert frame0["observation.tactile.force"][0].item() == pytest.approx(2.0)

--- a/tests/test_tlabel_conversion.py
+++ b/tests/test_tlabel_conversion.py
@@ -1,4 +1,5 @@
 """Tests for TLabel to LeRobot conversion."""
+
 import json
 import os
 import sys
@@ -67,10 +68,7 @@ class TestFeatureBuilding:
         """Custom YAML config overrides defaults."""
         config = tmp_path / "custom.yaml"
         config.write_text(
-            "observation.tactile.contact:\n"
-            "  dtype: float32\n"
-            "  shape: [1]\n"
-            "  names: [contact]\n"
+            "observation.tactile.contact:\n  dtype: float32\n  shape: [1]\n  names: [contact]\n"
         )
         features = build_features("gelsight", config_path=str(config))
         assert "observation.tactile.contact" in features
@@ -108,25 +106,13 @@ class TestFeatureExtraction:
         result = extract_tactile_features(frame, "gelsight")
 
         assert result["observation.tactile.contact"].tolist() == pytest.approx([1.0])
-        assert result["observation.tactile.force"].tolist() == pytest.approx(
-            [2.5, 0.3, 3.1]
-        )
-        assert result["observation.tactile.deformation"].tolist() == pytest.approx(
-            [0.1, 0.05]
-        )
-        assert result["observation.tactile.slip"].tolist() == pytest.approx(
-            [0.8, 1.0]
-        )
+        assert result["observation.tactile.force"].tolist() == pytest.approx([2.5, 0.3, 3.1])
+        assert result["observation.tactile.deformation"].tolist() == pytest.approx([0.1, 0.05])
+        assert result["observation.tactile.slip"].tolist() == pytest.approx([0.8, 1.0])
         assert result["observation.tactile.texture"].tolist() == pytest.approx([0.2])
-        assert result["observation.tactile.contact_geometry"].tolist() == pytest.approx(
-            [100.0, 50.0, 75.0]
-        )
-        assert result["observation.tactile.field"].tolist() == pytest.approx(
-            [1.5, 0.1, 0.3, 1.2]
-        )
-        assert result["observation.tactile.dynamics"].tolist() == pytest.approx(
-            [0.2, 0.1, 0.7]
-        )
+        assert result["observation.tactile.contact_geometry"].tolist() == pytest.approx([100.0, 50.0, 75.0])
+        assert result["observation.tactile.field"].tolist() == pytest.approx([1.5, 0.1, 0.3, 1.2])
+        assert result["observation.tactile.dynamics"].tolist() == pytest.approx([0.2, 0.1, 0.7])
 
     def test_returns_numpy_arrays(self):
         """All feature values are np.ndarray with float32 dtype."""
@@ -141,12 +127,8 @@ class TestFeatureExtraction:
         result = extract_tactile_features(frame, "paxini")
 
         assert result["observation.tactile.contact"].tolist() == pytest.approx([1.0])
-        assert result["observation.tactile.force"].tolist() == pytest.approx(
-            [0.0, 0.0, 0.0]
-        )
-        assert result["observation.tactile.deformation"].tolist() == pytest.approx(
-            [0.0, 0.0]
-        )
+        assert result["observation.tactile.force"].tolist() == pytest.approx([0.0, 0.0, 0.0])
+        assert result["observation.tactile.deformation"].tolist() == pytest.approx([0.0, 0.0])
 
     def test_empty_frame(self):
         """Empty frame returns all zeros."""
@@ -204,12 +186,7 @@ class TestDataLoading:
     def test_load_csv(self, tmp_path):
         """Load from CSV files."""
         csv_file = tmp_path / "data.csv"
-        csv_file.write_text(
-            "episode_index,contact,force_magnitude\n"
-            "0,1.0,2.5\n"
-            "0,0.0,0.0\n"
-            "1,1.0,1.0\n"
-        )
+        csv_file.write_text("episode_index,contact,force_magnitude\n0,1.0,2.5\n0,0.0,0.0\n1,1.0,1.0\n")
 
         result = _load_csv_episodes([csv_file])
         assert len(result["episodes"]) == 2

--- a/tests/test_tlabel_conversion.py
+++ b/tests/test_tlabel_conversion.py
@@ -1,12 +1,10 @@
 """Tests for TLabel to LeRobot conversion."""
 import json
 from pathlib import Path
+from unittest.mock import patch, MagicMock
 
 import pytest
-
-# Skip all tests if tlabel or lerobot not installed
-tlabel = pytest.importorskip("tlabel")
-lerobot = pytest.importorskip("lerobot")
+import numpy as np
 
 import sys
 import os
@@ -17,11 +15,15 @@ from convert_tlabel_to_lerobot import (
     SENSOR_CONFIGS,
     build_features,
     extract_tactile_features,
+    detect_image_dimensions,
     _load_manual,
     _load_csv_episodes,
 )
 
 
+# ──────────────────────────────────────────────────────────────────────
+# Feature building tests (no tlabel/lerobot dependency)
+# ──────────────────────────────────────────────────────────────────────
 class TestFeatureBuilding:
     """Test feature dict construction."""
 
@@ -48,6 +50,16 @@ class TestFeatureBuilding:
         assert "observation.images.tactile" in features
         assert features["observation.images.tactile"]["dtype"] == "video"
 
+    def test_gelsight_default_image_shape(self):
+        """Default image shape is 480x640 when no image_shape provided."""
+        features = build_features("gelsight", has_image=True)
+        assert features["observation.images.tactile"]["shape"] == [480, 640, 3]
+
+    def test_gelsight_custom_image_shape(self):
+        """Image shape is correctly set when image_shape is provided."""
+        features = build_features("gelsight", has_image=True, image_shape=(240, 320))
+        assert features["observation.images.tactile"]["shape"] == [240, 320, 3]
+
     def test_paxini_no_image(self):
         """PaXini sensor does not include image feature."""
         features = build_features("paxini", has_image=False)
@@ -66,6 +78,9 @@ class TestFeatureBuilding:
         assert "observation.tactile.contact" in features
 
 
+# ──────────────────────────────────────────────────────────────────────
+# Feature extraction tests (no tlabel/lerobot dependency)
+# ──────────────────────────────────────────────────────────────────────
 class TestFeatureExtraction:
     """Test TLabel frame to LeRobot feature extraction."""
 
@@ -119,6 +134,9 @@ class TestFeatureExtraction:
             assert all(v == 0.0 for v in value), f"{key} has non-zero values: {value}"
 
 
+# ──────────────────────────────────────────────────────────────────────
+# Sensor config tests (no tlabel/lerobot dependency)
+# ──────────────────────────────────────────────────────────────────────
 class TestSensorConfigs:
     """Test sensor-specific configurations."""
 
@@ -138,6 +156,9 @@ class TestSensorConfigs:
         assert SENSOR_CONFIGS["daimon"]["has_image"] is False
 
 
+# ──────────────────────────────────────────────────────────────────────
+# Data loading tests (no tlabel/lerobot dependency)
+# ──────────────────────────────────────────────────────────────────────
 class TestDataLoading:
     """Test manual data loading fallback."""
 
@@ -177,3 +198,197 @@ class TestDataLoading:
         """Missing data files raises FileNotFoundError."""
         with pytest.raises(FileNotFoundError):
             _load_manual(tmp_path)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Image dimension detection tests (no tlabel/lerobot dependency)
+# ──────────────────────────────────────────────────────────────────────
+class TestImageDimensionDetection:
+    """Test dynamic image dimension detection."""
+
+    def test_detect_from_numpy_array(self, tmp_path):
+        """Detect dimensions from numpy array images."""
+        episodes = {
+            0: [{"tactile_image": np.zeros((240, 320, 3), dtype=np.uint8)}]
+        }
+        result = detect_image_dimensions(tmp_path, episodes)
+        assert result == (240, 320)
+
+    def test_detect_from_file(self, tmp_path):
+        """Detect dimensions from image file path."""
+        try:
+            from PIL import Image
+        except ImportError:
+            pytest.skip("PIL not available")
+
+        # Create a test image
+        img_array = np.zeros((100, 200, 3), dtype=np.uint8)
+        img = Image.fromarray(img_array)
+        img_path = tmp_path / "test_image.png"
+        img.save(img_path)
+
+        episodes = {0: [{"tactile_image": "test_image.png"}]}
+        result = detect_image_dimensions(tmp_path, episodes)
+        assert result == (100, 200)
+
+    def test_no_images_returns_none(self, tmp_path):
+        """Return None when no images found."""
+        episodes = {0: [{"contact": 1.0}]}
+        result = detect_image_dimensions(tmp_path, episodes)
+        assert result is None
+
+    def test_empty_episodes_returns_none(self, tmp_path):
+        """Return None for empty episodes."""
+        result = detect_image_dimensions(tmp_path, {})
+        assert result is None
+
+
+# ──────────────────────────────────────────────────────────────────────
+# End-to-end round-trip test (requires lerobot; tlabel mocked)
+# ──────────────────────────────────────────────────────────────────────
+class TestRoundTrip:
+    """End-to-end round-trip: create dataset, add frames, finalize, reload."""
+
+    @pytest.fixture
+    def sample_data(self, tmp_path):
+        """Create sample TLabel JSON data for testing."""
+        data = {
+            "metadata": {"sensor": "paxini", "fps": 30},
+            "frames": [
+                {
+                    "episode_index": 0,
+                    "contact": 1.0,
+                    "force_magnitude": 2.5,
+                    "force_direction": 0.3,
+                    "force_peak": 3.1,
+                    "deformation_magnitude": 0.1,
+                    "temporal_deformation_rate": 0.05,
+                    "slip_entropy": 0.8,
+                    "slip_event": 1.0,
+                    "texture_energy": 0.2,
+                    "contact_area": 100.0,
+                    "centroid_x": 50.0,
+                    "centroid_y": 75.0,
+                    "normal_mag": 1.5,
+                    "normal_var": 0.1,
+                    "shear_mag": 0.3,
+                    "shear_dir": 1.2,
+                    "delta_normal": 0.2,
+                    "delta_shear": 0.1,
+                    "friction_cone_ratio": 0.7,
+                },
+                {
+                    "episode_index": 0,
+                    "contact": 0.0,
+                    "force_magnitude": 0.0,
+                },
+            ],
+        }
+        json_file = tmp_path / "tlabel_export.json"
+        json_file.write_text(json.dumps(data))
+        return tmp_path
+
+    def test_roundtrip_no_image(self, sample_data, tmp_path):
+        """Round-trip test without images (paxini sensor)."""
+        lerobot = pytest.importorskip("lerobot")
+        from lerobot.datasets import LeRobotDataset
+
+        from convert_tlabel_to_lerobot import convert
+
+        output_dir = str(tmp_path / "output")
+        convert(
+            input_dir=sample_data,
+            repo_id="test/tactile_roundtrip",
+            fps=30,
+            sensor_type="paxini",
+            output_dir=output_dir,
+            task="test task",
+        )
+
+        # Reload and verify
+        dataset = LeRobotDataset(
+            "test/tactile_roundtrip",
+            root=output_dir,
+        )
+        dataset.finalize()  # ensure finalized for reading
+
+        assert len(dataset) == 2
+        assert dataset.fps == 30
+        assert "observation.tactile.contact" in dataset.features
+
+        # Verify first frame data
+        frame0 = dataset[0]
+        assert frame0["observation.tactile.contact"].item() == pytest.approx(1.0)
+        assert frame0["observation.tactile.force"][0].item() == pytest.approx(2.5)
+
+    def test_roundtrip_with_numpy_images(self, sample_data, tmp_path):
+        """Round-trip test with numpy array images (gelsight sensor)."""
+        lerobot = pytest.importorskip("lerobot")
+        from lerobot.datasets import LeRobotDataset
+
+        # Add image data to sample
+        json_file = sample_data / "tlabel_export.json"
+        data = json.loads(json_file.read_text())
+
+        # Replace with image data
+        for frame in data["frames"]:
+            frame["tactile_image"] = np.zeros((120, 160, 3), dtype=np.uint8)
+
+        # Need to use direct construction since images are numpy arrays
+        # Write as numpy references in a custom way
+        from convert_tlabel_to_lerobot import (
+            build_features,
+            extract_tactile_features,
+            _load_manual,
+        )
+
+        output_dir = str(tmp_path / "output_img")
+
+        # Load data manually
+        json_file.write_text(json.dumps({
+            "metadata": {"sensor": "gelsight", "fps": 30},
+            "frames": [
+                {"episode_index": 0, "contact": 1.0, "force_magnitude": 2.0},
+                {"episode_index": 0, "contact": 0.5, "force_magnitude": 1.0},
+            ],
+        }))
+
+        manual_data = _load_manual(sample_data)
+        episodes = manual_data["episodes"]
+
+        # Add numpy images
+        for ep_frames in episodes.values():
+            for f in ep_frames:
+                f["tactile_image"] = np.zeros((120, 160, 3), dtype=np.uint8)
+
+        image_shape = detect_image_dimensions(sample_data, episodes)
+        assert image_shape == (120, 160)
+
+        features = build_features("gelsight", has_image=True, image_shape=image_shape)
+        assert features["observation.images.tactile"]["shape"] == [120, 160, 3]
+
+        dataset = LeRobotDataset.create(
+            repo_id="test/tactile_img_roundtrip",
+            fps=30,
+            features=features,
+            robot_type="gelsight",
+            root=output_dir,
+            use_videos=True,
+        )
+
+        for ep_idx, frames in sorted(episodes.items()):
+            for frame_data in frames:
+                frame = {}
+                tactile = extract_tactile_features(frame_data, "gelsight")
+                frame.update(tactile)
+                frame["task"] = "test"
+                frame["observation.images.tactile"] = frame_data["tactile_image"]
+                dataset.add_frame(frame)
+            dataset.save_episode(task="test")
+
+        dataset.finalize()
+
+        # Reload and verify
+        reloaded = LeRobotDataset("test/tactile_img_roundtrip", root=output_dir)
+        assert len(reloaded) == 2
+        assert "observation.images.tactile" in reloaded.features

--- a/tests/test_tlabel_conversion.py
+++ b/tests/test_tlabel_conversion.py
@@ -1,23 +1,22 @@
 """Tests for TLabel to LeRobot conversion."""
 import json
-from pathlib import Path
-from unittest.mock import patch, MagicMock
-
-import pytest
-import numpy as np
-
-import sys
 import os
+import sys
+
+import numpy as np
+import pytest
+
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "examples", "tlabel"))
 
 from convert_tlabel_to_lerobot import (
     DEFAULT_TACTILE_FEATURES,
     SENSOR_CONFIGS,
-    build_features,
-    extract_tactile_features,
-    detect_image_dimensions,
-    _load_manual,
     _load_csv_episodes,
+    _load_manual,
+    build_features,
+    detect_image_dimensions,
+    extract_tactile_features,
+    validate_image_consistency,
 )
 
 
@@ -208,9 +207,7 @@ class TestImageDimensionDetection:
 
     def test_detect_from_numpy_array(self, tmp_path):
         """Detect dimensions from numpy array images."""
-        episodes = {
-            0: [{"tactile_image": np.zeros((240, 320, 3), dtype=np.uint8)}]
-        }
+        episodes = {0: [{"tactile_image": np.zeros((240, 320, 3), dtype=np.uint8)}]}
         result = detect_image_dimensions(tmp_path, episodes)
         assert result == (240, 320)
 
@@ -241,6 +238,110 @@ class TestImageDimensionDetection:
         """Return None for empty episodes."""
         result = detect_image_dimensions(tmp_path, {})
         assert result is None
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Image consistency validation tests (no tlabel/lerobot dependency)
+# ──────────────────────────────────────────────────────────────────────
+class TestImageConsistencyValidation:
+    """Test that all frames are validated, not just the first one."""
+
+    def test_all_frames_consistent_numpy(self, tmp_path):
+        """All numpy frames with same shape pass validation."""
+        episodes = {
+            0: [
+                {"tactile_image": np.zeros((100, 200, 3), dtype=np.uint8)},
+                {"tactile_image": np.zeros((100, 200, 3), dtype=np.uint8)},
+            ],
+            1: [
+                {"tactile_image": np.zeros((100, 200, 3), dtype=np.uint8)},
+            ],
+        }
+        issues = validate_image_consistency(tmp_path, episodes, (100, 200))
+        assert issues == []
+
+    def test_later_frame_wrong_shape_numpy(self, tmp_path):
+        """Detect resolution mismatch in a later frame (not just first)."""
+        episodes = {
+            0: [
+                {"tactile_image": np.zeros((100, 200, 3), dtype=np.uint8)},
+                {"tactile_image": np.zeros((50, 80, 3), dtype=np.uint8)},
+            ],
+        }
+        issues = validate_image_consistency(tmp_path, episodes, (100, 200))
+        assert len(issues) == 1
+        assert "50, 80" in issues[0]
+
+    def test_grayscale_numpy_detected(self, tmp_path):
+        """Detect grayscale (2D) numpy arrays."""
+        episodes = {
+            0: [
+                {"tactile_image": np.zeros((100, 200, 3), dtype=np.uint8)},
+                {"tactile_image": np.zeros((100, 200), dtype=np.uint8)},
+            ],
+        }
+        issues = validate_image_consistency(tmp_path, episodes, (100, 200))
+        assert len(issues) == 1
+        assert "1 channel" in issues[0]
+
+    def test_rgba_numpy_detected(self, tmp_path):
+        """Detect RGBA (4-channel) numpy arrays."""
+        episodes = {
+            0: [
+                {"tactile_image": np.zeros((100, 200, 3), dtype=np.uint8)},
+                {"tactile_image": np.zeros((100, 200, 4), dtype=np.uint8)},
+            ],
+        }
+        issues = validate_image_consistency(tmp_path, episodes, (100, 200))
+        assert len(issues) == 1
+        assert "4 channel" in issues[0]
+
+    def test_file_backed_consistency(self, tmp_path):
+        """Validate file-backed images for consistency."""
+        try:
+            from PIL import Image
+        except ImportError:
+            pytest.skip("PIL not available")
+
+        # Create two valid RGB images
+        for name in ["frame_000.png", "frame_001.png"]:
+            img = Image.fromarray(np.zeros((100, 200, 3), dtype=np.uint8))
+            img.save(tmp_path / name)
+
+        # Create one wrong-size image
+        bad_img = Image.fromarray(np.zeros((50, 80, 3), dtype=np.uint8))
+        bad_img.save(tmp_path / "frame_002.png")
+
+        episodes = {
+            0: [
+                {"tactile_image": "frame_000.png"},
+                {"tactile_image": "frame_001.png"},
+                {"tactile_image": "frame_002.png"},
+            ],
+        }
+        issues = validate_image_consistency(tmp_path, episodes, (100, 200))
+        assert len(issues) == 1
+        assert "frame_002.png" in issues[0]
+
+    def test_missing_file_detected(self, tmp_path):
+        """Detect missing image file in later frames."""
+        episodes = {
+            0: [
+                {"tactile_image": np.zeros((100, 200, 3), dtype=np.uint8)},
+                {"tactile_image": "nonexistent.png"},
+            ],
+        }
+        issues = validate_image_consistency(tmp_path, episodes, (100, 200))
+        assert len(issues) == 1
+        assert "not found" in issues[0]
+
+    def test_no_image_frames_no_issues(self, tmp_path):
+        """Frames without tactile_image produce no issues."""
+        episodes = {
+            0: [{"contact": 1.0}, {"contact": 0.0}],
+        }
+        issues = validate_image_consistency(tmp_path, episodes, (100, 200))
+        assert issues == []
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -337,21 +438,26 @@ class TestRoundTrip:
         # Need to use direct construction since images are numpy arrays
         # Write as numpy references in a custom way
         from convert_tlabel_to_lerobot import (
-            build_features,
-            extract_tactile_features,
             _load_manual,
+            build_features,
+            detect_image_dimensions,
+            extract_tactile_features,
         )
 
         output_dir = str(tmp_path / "output_img")
 
         # Load data manually
-        json_file.write_text(json.dumps({
-            "metadata": {"sensor": "gelsight", "fps": 30},
-            "frames": [
-                {"episode_index": 0, "contact": 1.0, "force_magnitude": 2.0},
-                {"episode_index": 0, "contact": 0.5, "force_magnitude": 1.0},
-            ],
-        }))
+        json_file.write_text(
+            json.dumps(
+                {
+                    "metadata": {"sensor": "gelsight", "fps": 30},
+                    "frames": [
+                        {"episode_index": 0, "contact": 1.0, "force_magnitude": 2.0},
+                        {"episode_index": 0, "contact": 0.5, "force_magnitude": 1.0},
+                    ],
+                }
+            )
+        )
 
         manual_data = _load_manual(sample_data)
         episodes = manual_data["episodes"]
@@ -392,3 +498,60 @@ class TestRoundTrip:
         reloaded = LeRobotDataset("test/tactile_img_roundtrip", root=output_dir)
         assert len(reloaded) == 2
         assert "observation.images.tactile" in reloaded.features
+
+    def test_roundtrip_file_images_through_convert(self, tmp_path):
+        """End-to-end round-trip: file-backed images go through convert().
+
+        This test creates actual image files on disk and calls convert()
+        directly, exercising the full image loading + validation pipeline.
+        """
+        lerobot = pytest.importorskip("lerobot")
+        from lerobot.datasets import LeRobotDataset
+        from PIL import Image
+
+        from convert_tlabel_to_lerobot import convert
+
+        # Create image files
+        img_dir = tmp_path / "images"
+        img_dir.mkdir()
+        for i in range(3):
+            arr = np.random.randint(0, 255, (60, 80, 3), dtype=np.uint8)
+            Image.fromarray(arr).save(img_dir / f"frame_{i:03d}.png")
+
+        # Create TLabel JSON with file-backed image references
+        data = {
+            "metadata": {"sensor": "gelsight", "fps": 30},
+            "frames": [
+                {
+                    "episode_index": 0,
+                    "contact": 1.0,
+                    "force_magnitude": 2.0,
+                    "tactile_image": f"images/frame_{i:03d}.png",
+                }
+                for i in range(3)
+            ],
+        }
+        json_file = tmp_path / "tlabel_export.json"
+        json_file.write_text(json.dumps(data))
+
+        # Run full conversion
+        output_dir = str(tmp_path / "output_file_rt")
+        convert(
+            input_dir=tmp_path,
+            repo_id="test/tactile_file_roundtrip",
+            fps=30,
+            sensor_type="gelsight",
+            output_dir=output_dir,
+            task="file image round-trip test",
+        )
+
+        # Reload and verify
+        dataset = LeRobotDataset("test/tactile_file_roundtrip", root=output_dir)
+        assert len(dataset) == 3
+        assert "observation.images.tactile" in dataset.features
+        assert dataset.fps == 30
+
+        # Verify tactile data survived the round-trip
+        frame0 = dataset[0]
+        assert frame0["observation.tactile.contact"].item() == pytest.approx(1.0)
+        assert frame0["observation.tactile.force"][0].item() == pytest.approx(2.0)


### PR DESCRIPTION
## Summary

This PR adds an example script for converting [TLabel](https://github.com/liesliy/tlabel) tactile sensor datasets to LeRobotDataset format, enabling the LeRobot ecosystem to natively work with tactile sensing data.

## Motivation

Tactile sensing is a critical modality for contact-rich manipulation tasks, but there is no standardized way to bring tactile data into the LeRobot ecosystem. Recent community efforts like [LeFlexiTac](https://tna001-ai.github.io/LeFlexiTac/index.html) and the [ManiSkill-ViTac Challenge 2026](https://callmeray.github.io/Mani_ViTac_Challenge_2026_page/doc.html) have demonstrated strong demand for tactile-visual policies in LeRobot, but each project had to build its own data pipeline from scratch.

[TLabel](https://github.com/liesliy/tlabel) (PyPI: `tlabel`, v0.10.2) is a sensor-agnostic tactile data annotation toolkit that supports GelSight, DIGIT, PaXini, Daimon and more. It provides a unified 22-dimension annotation schema (TLabel Format v2), making it an ideal source format for LeRobot integration.

## What's included

- `examples/tlabel/convert_tlabel_to_lerobot.py` — CLI script for TLabel → LeRobotDataset conversion
- `examples/tlabel/README.md` — Usage guide with feature mapping documentation
- `examples/tlabel/config/tlabel_default_features.yaml` — Default feature configuration
- `tests/test_tlabel_conversion.py` — Pytest tests

## Feature mapping

| TLabel Dimension (22-dim) | LeRobot Feature Key | Shape |
|---|---|---|
| contact | `observation.tactile.contact` | (1,) |
| force_magnitude, force_direction, force_peak | `observation.tactile.force` | (3,) |
| deformation_magnitude, temporal_deformation_rate | `observation.tactile.deformation` | (2,) |
| slip_entropy, slip_event | `observation.tactile.slip` | (2,) |
| texture_energy | `observation.tactile.texture` | (1,) |
| contact_area, centroid_x, centroid_y | `observation.tactile.contact_geometry` | (3,) |
| normal_mag, normal_var, shear_mag, shear_dir | `observation.tactile.field` | (4,) |
| delta_normal, delta_shear, friction_cone_ratio | `observation.tactile.dynamics` | (3,) |
| optical_flow (image sensors only) | `observation.images.tactile` | (H, W, 3) video |

## Usage

```bash
pip install tlabel lerobot
python examples/tlabel/convert_tlabel_to_lerobot.py \
    --input-dir ./tlabel_data/ \
    --repo-id username/tactile_dataset \
    --fps 30 \
    --sensor-type gelsight
```

## Testing

```bash
pytest tests/test_tlabel_conversion.py -v
```

## Checklist

- [x] Follows the existing examples/ directory structure
- [x] Compatible with LeRobotDataset v3.0
- [x] No modification to core library code
- [x] Tests included
- [x] README with usage instructions
