### PR TITLE
feat(pi052): add training-time RTC

### DIFF
--- a/docs/source/inference.mdx
+++ b/docs/source/inference.mdx
@@ -274,12 +274,13 @@ lerobot-rollout \
     --device=cuda
 ```
 
-| Flag                                        | Description                                                    |
-| ------------------------------------------- | -------------------------------------------------------------- |
-| `--inference.rtc.execution_horizon`         | Steps to blend with previous chunk (default: varies by policy) |
-| `--inference.rtc.max_guidance_weight`       | Consistency enforcement strength (default: varies by policy)   |
-| `--inference.rtc.prefix_attention_schedule` | Blend schedule: `LINEAR`, `EXP`, `ONES`, `ZEROS`               |
-| `--inference.queue_threshold`               | Max queue size before backpressure (default: 30)               |
+| Flag                                        | Description                                                                     |
+| ------------------------------------------- | ------------------------------------------------------------------------------- |
+| `--inference.rtc.execution_horizon`         | Steps to blend with previous chunk (default: varies by policy)                  |
+| `--inference.rtc.mode`                      | `guided` (default) or trained-prefix `trained` for compatible Pi052 checkpoints |
+| `--inference.rtc.max_guidance_weight`       | Consistency enforcement strength (default: varies by policy)                    |
+| `--inference.rtc.prefix_attention_schedule` | Blend schedule: `LINEAR`, `EXP`, `ONES`, `ZEROS`                                |
+| `--inference.queue_threshold`               | Max queue size before backpressure (default: 30)                                |
 
 See the [Real-Time Chunking](./rtc) guide for details on tuning RTC parameters.
 

--- a/docs/source/inference.mdx
+++ b/docs/source/inference.mdx
@@ -280,7 +280,7 @@ lerobot-rollout \
 | `--inference.rtc.mode`                      | `guided` (default) or trained-prefix `trained` for compatible Pi052 checkpoints |
 | `--inference.rtc.max_guidance_weight`       | Consistency enforcement strength (default: varies by policy)                    |
 | `--inference.rtc.prefix_attention_schedule` | Blend schedule: `LINEAR`, `EXP`, `ONES`, `ZEROS`                                |
-| `--inference.queue_threshold`               | Max queue size before backpressure (default: 30)                                |
+| `--inference.queue_threshold`               | Backpressure threshold; trained RTC requires at least its maximum delay         |
 
 See the [Real-Time Chunking](./rtc) guide for details on tuning RTC parameters.
 

--- a/docs/source/pi052.mdx
+++ b/docs/source/pi052.mdx
@@ -116,11 +116,70 @@ the expected prompt, text target, and action endpoints before scaling up.
 | `policy.fast_action_loss_weight` |                      `1.0` | FAST cross-entropy weight                                      |
 | `policy.knowledge_insulation`    |                     `true` | Blocks action-loss gradients through the VLM K/V path          |
 | `policy.flow_num_repeats`        |                        `5` | Reuses one VLM prefix for independent denoising targets        |
+| `policy.rtc_training_max_delay`  |                        `0` | Maximum clean-prefix delay; `0` disables training-time RTC     |
 | `policy.lm_head_lr_scale`        |                      `1.0` | Scales language-head learning rate; `1.0` uses the base rate   |
 
 The loss weights are starting points, not dataset-independent constants. Track
 flow loss and text/FAST losses separately, and inspect generated subtasks rather
 than selecting a checkpoint from total loss alone.
+
+### Training-time RTC
+
+Pi052 optionally supports training-time action conditioning from
+[Training-Time Action Conditioning for Efficient Real-Time Chunking](https://arxiv.org/abs/2512.05964).
+It simulates inference latency by sampling a clean action prefix for every flow
+draw, passing a per-action flow timestep to the action expert, and computing the
+flow loss only on the remaining postfix. The default value of `0` leaves the
+standard Pi052 objective unchanged.
+
+```bash
+lerobot-train \
+    --dataset.repo_id=${HF_USER}/my_language_annotated_dataset \
+    --policy.type=pi052 \
+    --policy.pretrained_path=lerobot/pi05_base \
+    --policy.recipe_path=recipes/subtask_mem.yaml \
+    --policy.rtc_training_max_delay=10 \
+    --policy.dtype=bfloat16 \
+    --policy.device=cuda \
+    --batch_size=8 \
+    --steps=30000 \
+    --output_dir=outputs/pi052_rtc \
+    --job_name=pi052_rtc
+```
+
+`rtc_training_max_delay` is measured in controller steps and must be smaller
+than `chunk_size`. Choose it to cover the largest inference latency expected at
+deployment: at 50 Hz, for example, 10 steps correspond to 200 ms. A delay of
+zero is included in the uniform sampling distribution, so the checkpoint also
+continues to receive ordinary flow-matching examples. Set rollout's
+`inference.rtc.execution_horizon` to at least this maximum so the previous
+chunk cache retains enough actions to construct every supported prefix.
+
+Run the resulting checkpoint with the asynchronous `lerobot-rollout` backend
+and select the trained-prefix path explicitly:
+
+```bash
+lerobot-rollout \
+    --strategy.type=base \
+    --policy.path=outputs/pi052_rtc/checkpoints/last/pretrained_model \
+    --inference.type=rtc \
+    --inference.rtc.mode=trained \
+    --inference.rtc.execution_horizon=10 \
+    --robot.type=so100_follower \
+    --robot.port=/dev/ttyACM0 \
+    --task="pick up the cube" \
+    --fps=50 \
+    --device=cuda
+```
+
+The rollout engine measures latency continuously, carries the still-unexecuted
+actions from the previous chunk into the next prediction, and discards the
+prefix that elapsed during inference. If the measured delay exceeds the
+checkpoint's `rtc_training_max_delay`, rollout stops with an explicit error
+instead of silently extrapolating beyond the training distribution. Use
+`--inference.rtc.mode=guided` for the original Jacobian-guided RTC path; it does
+not require a training-time RTC checkpoint but adds backward-pass work during
+denoising.
 
 ### Dataset-specific FAST tokenizer
 

--- a/docs/source/pi052.mdx
+++ b/docs/source/pi052.mdx
@@ -152,8 +152,9 @@ than `chunk_size`. Choose it to cover the largest inference latency expected at
 deployment: at 50 Hz, for example, 10 steps correspond to 200 ms. A delay of
 zero is included in the uniform sampling distribution, so the checkpoint also
 continues to receive ordinary flow-matching examples. Set rollout's
-`inference.rtc.execution_horizon` to at least this maximum so the previous
-chunk cache retains enough actions to construct every supported prefix.
+`inference.rtc.execution_horizon` and `inference.queue_threshold` to at least
+this maximum so inference starts early enough and the previous chunk retains
+every action needed for the committed prefix.
 
 Run the resulting checkpoint with the asynchronous `lerobot-rollout` backend
 and select the trained-prefix path explicitly:

--- a/docs/source/rtc.mdx
+++ b/docs/source/rtc.mdx
@@ -97,6 +97,10 @@ for step in range(num_steps):
 - `guided` (default) applies the original Jacobian guidance during denoising and works with ordinary flow-matching checkpoints.
 - `trained` hard-inpaints the previous chunk's prefix with per-action flow timesteps. It currently requires a Pi052 checkpoint trained with `policy.rtc_training_max_delay > 0` and avoids the guidance backward pass.
 
+For trained mode, both `execution_horizon` and the rollout backend's
+`inference.queue_threshold` must be at least the checkpoint's
+`rtc_training_max_delay`; rollout validates this before connecting the robot.
+
 **`execution_horizon`**: How many timesteps from the previous chunk to maintain consistency with. Higher values mean smoother transitions but potentially less reactivity.
 
 Typical values: 8-12 steps
@@ -128,6 +132,10 @@ python examples/rtc/eval_dataset.py \
     --rtc.max_guidance_weight=10.0 \
     --device=cuda
 ```
+
+Add `--rtc.mode=trained` when evaluating a compatible training-time RTC Pi052
+checkpoint. Unsupported policies reject trained mode instead of falling back to
+guided RTC.
 
 The script generates a visualization of the denoising process, comparing standard generation (left) with RTC (right). In the RTC plots, you can see how the first few steps (blue/purple lines) are guided to match the red ground truth trajectory (previous chunk's tail), ensuring a smooth transition between chunks.
 

--- a/docs/source/rtc.mdx
+++ b/docs/source/rtc.mdx
@@ -1,6 +1,6 @@
 # Real-Time Chunking (RTC)
 
-Real-Time Chunking (RTC) is an inference-time method that allows large, flow-matching based robotic policies, such as [Pi0](./pi0), [Pi0.5](./pi05), and [SmolVLA](./smolvla), to produce smooth, continuous, and reactive motion despite having high inference latency.
+Real-Time Chunking (RTC) allows large, flow-matching based robotic policies, such as [Pi0](./pi0), [Pi0.5](./pi05), and [SmolVLA](./smolvla), to produce smooth, continuous, and reactive motion despite having high inference latency. LeRobot provides the original inference-time guided mode and, for compatible Pi052 checkpoints, training-time action conditioning with cheap hard-prefix inference.
 
 These policies generate chunks of future actions (e.g., 50 steps at a time) instead of single actions.
 Because the models are large, producing each chunk takes longer than the time it takes the robot to execute it.
@@ -92,6 +92,11 @@ for step in range(num_steps):
 
 `RTCConfig` has the following parameters to tune:
 
+**`mode`** selects the action-prefix conditioning method:
+
+- `guided` (default) applies the original Jacobian guidance during denoising and works with ordinary flow-matching checkpoints.
+- `trained` hard-inpaints the previous chunk's prefix with per-action flow timesteps. It currently requires a Pi052 checkpoint trained with `policy.rtc_training_max_delay > 0` and avoids the guidance backward pass.
+
 **`execution_horizon`**: How many timesteps from the previous chunk to maintain consistency with. Higher values mean smoother transitions but potentially less reactivity.
 
 Typical values: 8-12 steps
@@ -141,11 +146,30 @@ lerobot-rollout \
     --strategy.type=base \
     --policy.path=${HF_USERNAME}/policy_repo_id \
     --inference.type=rtc \
+    --inference.rtc.mode=guided \
     --inference.rtc.execution_horizon=10 \
     --inference.rtc.max_guidance_weight=10.0 \
     --robot.type=so100_follower \
     --robot.port=/dev/tty.usbmodem58FA0834591 \
     --robot.cameras="{ gripper: {type: opencv, index_or_path: 1, width: 640, height: 480, fps: 30}, front: {type: opencv, index_or_path: 0, width: 640, height: 480, fps: 30}}" \
+    --task="Move green small object into the purple platform" \
+    --duration=120 \
+    --device=cuda
+```
+
+For a training-time RTC Pi052 checkpoint, change the mode to `trained`. The
+checkpoint records its maximum supported delay, and rollout validates measured
+latency against it:
+
+```bash
+lerobot-rollout \
+    --strategy.type=base \
+    --policy.path=${HF_USERNAME}/pi052_training_rtc \
+    --inference.type=rtc \
+    --inference.rtc.mode=trained \
+    --inference.rtc.execution_horizon=10 \
+    --robot.type=so100_follower \
+    --robot.port=/dev/tty.usbmodem58FA0834591 \
     --task="Move green small object into the purple platform" \
     --duration=120 \
     --device=cuda
@@ -189,3 +213,5 @@ See `examples/rtc/eval_dataset.py` for a complete example of offline RTC visuali
 - [Smooth-As-Butter Robot Policies](https://alexander-soare.github.io/robotics/2025/08/05/smooth-as-butter-robot-policies.html) - Excellent technical explanation with real robot results
 - [Physical Intelligence - Real-Time Chunking](https://www.physicalintelligence.company/research/real_time_chunking) - Original paper and research
 - [Kinetix RTC Implementation](https://github.com/Physical-Intelligence/real-time-chunking-kinetix) - Reference implementation from Physical Intelligence
+- [Training-Time Action Conditioning](https://arxiv.org/abs/2512.05964) - Efficient RTC with clean-prefix conditioning during training
+- [RLDX-1](https://github.com/RLWRLD/RLDX-1) - PyTorch reference used for the training-time RTC integration

--- a/examples/rtc/eval_dataset.py
+++ b/examples/rtc/eval_dataset.py
@@ -306,6 +306,7 @@ class RTCEvaluator:
         # Configure RTC
         rtc_config = RTCConfig(
             enabled=rtc_enabled,
+            mode=self.cfg.rtc.mode,
             execution_horizon=self.cfg.rtc.execution_horizon,
             max_guidance_weight=self.cfg.rtc.max_guidance_weight,
             prefix_attention_schedule=self.cfg.rtc.prefix_attention_schedule,

--- a/src/lerobot/policies/pi05/configuration_pi05.py
+++ b/src/lerobot/policies/pi05/configuration_pi05.py
@@ -58,6 +58,8 @@ class PI05Config(PreTrainedConfig):
 
     # Real-Time Chunking (RTC) configuration
     rtc_config: RTCConfig | None = None
+    # Maximum clean action-prefix length sampled during training. Zero disables trained RTC.
+    rtc_training_max_delay: int = 0
 
     image_resolution: tuple[int, int] = (
         DEFAULT_IMAGE_SIZE,
@@ -110,6 +112,11 @@ class PI05Config(PreTrainedConfig):
         if self.n_action_steps > self.chunk_size:
             raise ValueError(
                 f"n_action_steps ({self.n_action_steps}) cannot be greater than chunk_size ({self.chunk_size})"
+            )
+        if not 0 <= self.rtc_training_max_delay < self.chunk_size:
+            raise ValueError(
+                "rtc_training_max_delay must satisfy "
+                f"0 <= delay < chunk_size ({self.chunk_size}), got {self.rtc_training_max_delay}"
             )
 
         if self.paligemma_variant not in ["gemma_300m", "gemma_2b"]:

--- a/src/lerobot/policies/pi05/modeling_pi05.py
+++ b/src/lerobot/policies/pi05/modeling_pi05.py
@@ -70,6 +70,54 @@ class ActionSelectKwargs(TypedDict, total=False):
     execution_horizon: int | None
 
 
+def _prepare_trained_rtc_prefix(
+    x_t: Tensor,
+    prev_chunk_left_over: Tensor | None,
+    inference_delay: int,
+    training_max_delay: int,
+) -> tuple[Tensor | None, Tensor | None]:
+    """Pad and validate a hard prefix for training-time RTC inference."""
+    if prev_chunk_left_over is None or inference_delay <= 0:
+        return None, None
+    if training_max_delay <= 0:
+        raise ValueError(
+            "RTC mode='trained' requires a Pi052 checkpoint trained with policy.rtc_training_max_delay > 0."
+        )
+    if inference_delay > training_max_delay:
+        raise ValueError(
+            f"Measured RTC inference delay ({inference_delay}) exceeds the checkpoint's "
+            f"rtc_training_max_delay ({training_max_delay})."
+        )
+    if inference_delay >= x_t.shape[1]:
+        raise ValueError(
+            f"RTC inference delay ({inference_delay}) must be smaller than chunk_size ({x_t.shape[1]})."
+        )
+
+    previous = prev_chunk_left_over.to(device=x_t.device, dtype=x_t.dtype)
+    if previous.ndim == 2:
+        previous = previous.unsqueeze(0)
+    if previous.ndim != 3:
+        raise ValueError(f"Expected RTC prefix shape (B, T, A), got {tuple(previous.shape)}")
+    if previous.shape[0] == 1 and x_t.shape[0] > 1:
+        previous = previous.expand(x_t.shape[0], -1, -1)
+    if previous.shape[0] != x_t.shape[0]:
+        raise ValueError(
+            f"RTC prefix batch size ({previous.shape[0]}) does not match policy batch ({x_t.shape[0]})."
+        )
+    if previous.shape[1] < inference_delay:
+        raise ValueError(f"RTC prefix has {previous.shape[1]} steps, but inference_delay={inference_delay}.")
+    if previous.shape[2] > x_t.shape[2]:
+        raise ValueError(
+            f"RTC prefix action dimension ({previous.shape[2]}) exceeds model dimension ({x_t.shape[2]})."
+        )
+
+    padded_prefix = torch.zeros_like(x_t)
+    padded_prefix[:, :inference_delay, : previous.shape[2]] = previous[:, :inference_delay]
+    prefix_mask = torch.arange(x_t.shape[1], device=x_t.device) < inference_delay
+    prefix_mask = prefix_mask[None, :, None].expand(x_t.shape[0], -1, x_t.shape[2])
+    return padded_prefix, prefix_mask
+
+
 _SAFETENSORS_FILE = "model.safetensors"
 _SAFETENSORS_INDEX = "model.safetensors.index.json"
 
@@ -164,21 +212,21 @@ def get_safe_dtype(target_dtype, device_type):
 def create_sinusoidal_pos_embedding(  # see openpi `create_sinusoidal_pos_embedding` (exact copy)
     time: torch.Tensor, dimension: int, min_period: float, max_period: float, device="cpu"
 ) -> Tensor:
-    """Computes sine-cosine positional embedding vectors for scalar positions."""
+    """Computes sine-cosine embeddings for scalar or per-action positions."""
     if dimension % 2 != 0:
         raise ValueError(f"dimension ({dimension}) must be divisible by 2")
 
-    if time.ndim != 1:
-        raise ValueError("The time tensor is expected to be of shape `(batch_size, )`.")
+    if time.ndim not in (1, 2):
+        raise ValueError("The time tensor must have shape (batch_size,) or (batch_size, action_horizon).")
 
     dtype = get_safe_dtype(torch.float64, device.type)
     fraction = torch.linspace(0.0, 1.0, dimension // 2, dtype=dtype, device=device)
     period = min_period * (max_period / min_period) ** fraction
 
-    # Compute the outer product
+    # Broadcast the frequency dimension over either (B,) or (B, H).
     scaling_factor = 1.0 / period * 2 * math.pi
-    sin_input = scaling_factor[None, :] * time[:, None]
-    return torch.cat([torch.sin(sin_input), torch.cos(sin_input)], dim=1)
+    sin_input = time[..., None] * scaling_factor
+    return torch.cat([torch.sin(sin_input), torch.cos(sin_input)], dim=-1)
 
 
 def sample_beta(alpha, beta, bsize, device):  # see openpi `sample_beta` (exact copy)
@@ -948,6 +996,24 @@ class PI05Pytorch(nn.Module):  # see openpi `PI0Pytorch`
             )
 
         x_t = noise
+        rtc_mode = "guided"
+        trained_prefix = trained_prefix_mask = None
+        if self._rtc_enabled():
+            rtc_mode = self.rtc_processor.rtc_config.mode
+            if rtc_mode == "trained":
+                training_max_delay = int(getattr(self.config, "rtc_training_max_delay", 0))
+                if training_max_delay <= 0:
+                    raise ValueError(
+                        "RTC mode='trained' requires a Pi052 checkpoint trained with "
+                        "policy.rtc_training_max_delay > 0."
+                    )
+                trained_prefix, trained_prefix_mask = _prepare_trained_rtc_prefix(
+                    x_t,
+                    kwargs.get("prev_chunk_left_over"),
+                    int(kwargs.get("inference_delay") or 0),
+                    training_max_delay,
+                )
+
         for step in range(num_steps):
             time = 1.0 + step * dt
             if times is None:
@@ -955,7 +1021,13 @@ class PI05Pytorch(nn.Module):  # see openpi `PI0Pytorch`
             else:
                 time_tensor = times[step].expand(bsize)
 
-            def denoise_step_partial_call(input_x_t, current_timestep=time_tensor):
+            denoise_timestep = time_tensor
+            if trained_prefix is not None:
+                x_t = torch.where(trained_prefix_mask, trained_prefix, x_t)
+                denoise_timestep = time_tensor[:, None].expand(bsize, x_t.shape[1]).clone()
+                denoise_timestep[trained_prefix_mask[..., 0]] = 0.0
+
+            def denoise_step_partial_call(input_x_t, current_timestep=denoise_timestep):
                 return self.denoise_step(
                     prefix_pad_masks=prefix_pad_masks,
                     past_key_values=past_key_values,
@@ -963,7 +1035,7 @@ class PI05Pytorch(nn.Module):  # see openpi `PI0Pytorch`
                     timestep=current_timestep,
                 )
 
-            if self._rtc_enabled():
+            if self._rtc_enabled() and rtc_mode == "guided":
                 inference_delay = kwargs.get("inference_delay")
                 prev_chunk_left_over = kwargs.get("prev_chunk_left_over")
                 execution_horizon = kwargs.get("execution_horizon")
@@ -980,6 +1052,8 @@ class PI05Pytorch(nn.Module):  # see openpi `PI0Pytorch`
                 v_t = denoise_step_partial_call(x_t)
 
             x_t = x_t + dt * v_t
+            if trained_prefix is not None:
+                x_t = torch.where(trained_prefix_mask, trained_prefix, x_t)
 
             if self.rtc_processor is not None and self.rtc_processor.is_debug_enabled():
                 self.rtc_processor.track(time=time, x_t=x_t, v_t=v_t)

--- a/src/lerobot/policies/pi05/modeling_pi05.py
+++ b/src/lerobot/policies/pi05/modeling_pi05.py
@@ -81,7 +81,7 @@ def _prepare_trained_rtc_prefix(
         return None, None
     if training_max_delay <= 0:
         raise ValueError(
-            "RTC mode='trained' requires a Pi052 checkpoint trained with policy.rtc_training_max_delay > 0."
+            "RTC mode='trained' requires a checkpoint trained with policy.rtc_training_max_delay > 0."
         )
     if inference_delay > training_max_delay:
         raise ValueError(
@@ -118,6 +118,57 @@ def _prepare_trained_rtc_prefix(
     prefix_mask = torch.arange(x_t.shape[1], device=x_t.device) < inference_delay
     prefix_mask = prefix_mask[None, :, None].expand(x_t.shape[0], -1, x_t.shape[2])
     return padded_prefix, prefix_mask
+
+
+def _sample_training_rtc_prefix_mask(
+    batch_size: int,
+    action_horizon: int,
+    max_delay: int,
+    device: torch.device,
+) -> Tensor | None:
+    """Sample a clean action-prefix length independently for each training example."""
+    if max_delay <= 0:
+        return None
+    delays = torch.randint(0, max_delay + 1, (batch_size,), device=device)
+    positions = torch.arange(action_horizon, device=device)
+    return positions.unsqueeze(0) < delays.unsqueeze(1)
+
+
+def _build_flow_matching_inputs(
+    actions: Tensor,
+    noise: Tensor,
+    time: Tensor,
+    prefix_mask: Tensor | None,
+) -> tuple[Tensor, Tensor]:
+    """Keep the sampled RTC prefix clean while noising the remaining action chunk."""
+    if prefix_mask is None:
+        model_time = time
+        expanded_time = time[:, None, None]
+    else:
+        model_time = time[:, None].expand_as(prefix_mask)
+        model_time = torch.where(prefix_mask, torch.zeros_like(model_time), model_time)
+        expanded_time = model_time.unsqueeze(-1)
+    x_t = expanded_time * noise + (1 - expanded_time) * actions
+    return x_t, model_time
+
+
+def _reduce_training_rtc_loss(
+    losses: Tensor,
+    prefix_mask: Tensor | None,
+    reduction: str,
+) -> Tensor:
+    """Average flow loss over predicted postfix actions, excluding the clean RTC prefix."""
+    if reduction not in {"mean", "none"}:
+        raise ValueError(f"Unsupported loss reduction: {reduction!r}")
+    if prefix_mask is None:
+        return losses.mean() if reduction == "mean" else losses.mean(dim=(1, 2))
+
+    postfix_mask = (~prefix_mask).unsqueeze(-1).expand_as(losses)
+    if reduction == "none":
+        numerator = (losses * postfix_mask).sum(dim=(1, 2))
+        denominator = postfix_mask.sum(dim=(1, 2))
+        return numerator / denominator.clamp(min=1)
+    return (losses * postfix_mask).sum() / postfix_mask.sum().clamp(min=1)
 
 
 _SAFETENSORS_FILE = "model.safetensors"
@@ -897,14 +948,23 @@ class PI05Pytorch(nn.Module):  # see openpi `PI0Pytorch`
 
         return embs, pad_masks, att_masks, adarms_cond
 
-    def forward(self, images, img_masks, tokens, masks, actions, noise, time) -> Tensor:
+    def forward(
+        self,
+        images,
+        img_masks,
+        tokens,
+        masks,
+        actions,
+        noise,
+        time,
+        prefix_mask: Tensor | None = None,
+    ) -> Tensor:
         """Do a full training forward pass and compute the loss."""
-        time_expanded = time[:, None, None]
-        x_t = time_expanded * noise + (1 - time_expanded) * actions
+        x_t, model_time = _build_flow_matching_inputs(actions, noise, time, prefix_mask)
         u_t = noise - actions
 
         prefix_embs, prefix_pad_masks, prefix_att_masks = self.embed_prefix(images, img_masks, tokens, masks)
-        suffix_embs, suffix_pad_masks, suffix_att_masks, adarms_cond = self.embed_suffix(x_t, time)
+        suffix_embs, suffix_pad_masks, suffix_att_masks, adarms_cond = self.embed_suffix(x_t, model_time)
 
         if (
             self.paligemma_with_expert.paligemma.model.language_model.layers[0].self_attn.q_proj.weight.dtype
@@ -1423,28 +1483,37 @@ class PI05Policy(PreTrainedPolicy):
 
         noise = self.model.sample_noise(actions.shape, actions.device)
         time = self.model.sample_time(actions.shape[0], actions.device)
+        prefix_mask = _sample_training_rtc_prefix_mask(
+            actions.shape[0],
+            actions.shape[1],
+            self.config.rtc_training_max_delay,
+            actions.device,
+        )
 
         # Compute loss (no separate state needed for PI05)
-        losses = self.model.forward(images, img_masks, tokens, masks, actions, noise, time)
+        losses = self.model.forward(images, img_masks, tokens, masks, actions, noise, time, prefix_mask)
 
         # Truncate losses to actual action dimensions
         original_action_dim = self.config.output_features[ACTION].shape[0]
         losses = losses[:, :, :original_action_dim]
 
-        loss_dict = {
-            "loss_per_dim": losses.mean(dim=[0, 1]).detach().cpu().numpy().tolist(),
-        }
+        if prefix_mask is None:
+            loss_per_dim = losses.mean(dim=(0, 1))
+        else:
+            postfix_mask = (~prefix_mask).unsqueeze(-1).expand_as(losses)
+            loss_per_dim = (losses * postfix_mask).sum(dim=(0, 1)) / postfix_mask.sum(
+                dim=(0, 1)
+            ).clamp(min=1)
+        loss_dict = {"loss_per_dim": loss_per_dim.detach().cpu().numpy().tolist()}
 
         if reduction == "none":
-            # Return per-sample losses (B,) by averaging over time and action dims
-            per_sample_loss = losses.mean(dim=(1, 2))
+            per_sample_loss = _reduce_training_rtc_loss(losses, prefix_mask, reduction="none")
             loss_dict["loss"] = per_sample_loss.mean().item()
             return per_sample_loss, loss_dict
-        else:
-            # Default: return scalar mean loss
-            loss = losses.mean()
-            loss_dict["loss"] = loss.item()
-            return loss, loss_dict
+
+        loss = _reduce_training_rtc_loss(losses, prefix_mask, reduction="mean")
+        loss_dict["loss"] = loss.item()
+        return loss, loss_dict
 
     def _get_default_peft_targets(self) -> dict[str, any]:
         """Return default PEFT target modules for PI0.5 fine-tuning."""

--- a/src/lerobot/policies/pi05/modeling_pi05.py
+++ b/src/lerobot/policies/pi05/modeling_pi05.py
@@ -1284,7 +1284,10 @@ class PI05Policy(PreTrainedPolicy):
         # Create processor if config provided
         # If RTC is not enabled - we can still track the denoising data
         if self.config.rtc_config is not None:
-            self.rtc_processor = RTCProcessor(self.config.rtc_config)
+            self.rtc_processor = RTCProcessor(
+                self.config.rtc_config,
+                trained_mode_supported=int(getattr(self.config, "rtc_training_max_delay", 0)) > 0,
+            )
 
             model_value = getattr(self, "model", None)
             if model_value is not None:

--- a/src/lerobot/policies/pi05/modeling_pi05.py
+++ b/src/lerobot/policies/pi05/modeling_pi05.py
@@ -94,6 +94,8 @@ def _prepare_trained_rtc_prefix(
         )
 
     previous = prev_chunk_left_over.to(device=x_t.device, dtype=x_t.dtype)
+    if not torch.isfinite(previous).all():
+        raise ValueError("RTC prefix contains NaN or Inf values.")
     if previous.ndim == 2:
         previous = previous.unsqueeze(0)
     if previous.ndim != 3:

--- a/src/lerobot/policies/pi052/configuration_pi052.py
+++ b/src/lerobot/policies/pi052/configuration_pi052.py
@@ -121,6 +121,15 @@ class PI052Config(PI05Config):
     # Reuse each VLM prefix across independent denoising draws; 1 restores single-draw flow.
     flow_num_repeats: int = 5
 
+    # Training-time RTC (arXiv:2512.05964). Zero preserves standard flow matching.
+    rtc_training_max_delay: int = 0
+    """Largest clean action-prefix length sampled during training.
+
+    A value greater than zero enables training-time action conditioning. Each
+    flow draw samples a delay uniformly from ``[0, rtc_training_max_delay]``;
+    the corresponding action prefix stays clean and is excluded from the loss.
+    """
+
     # PaLM-style z-loss stabilizes large-vocabulary CE; 0 disables it.
     text_ce_z_loss_weight: float = 1e-4
 
@@ -151,6 +160,11 @@ class PI052Config(PI05Config):
             self.train_expert_only = False
         if self.flow_num_repeats < 1:
             raise ValueError(f"flow_num_repeats must be >= 1, got {self.flow_num_repeats}")
+        if not 0 <= self.rtc_training_max_delay < self.chunk_size:
+            raise ValueError(
+                "rtc_training_max_delay must satisfy "
+                f"0 <= delay < chunk_size ({self.chunk_size}), got {self.rtc_training_max_delay}"
+            )
         if self.manual_attention_scope not in {"all", "action"}:
             raise ValueError(
                 f"manual_attention_scope must be 'all' or 'action', got {self.manual_attention_scope!r}"

--- a/src/lerobot/policies/pi052/configuration_pi052.py
+++ b/src/lerobot/policies/pi052/configuration_pi052.py
@@ -123,12 +123,7 @@ class PI052Config(PI05Config):
 
     # Training-time RTC (arXiv:2512.05964). Zero preserves standard flow matching.
     rtc_training_max_delay: int = 0
-    """Largest clean action-prefix length sampled during training.
-
-    A value greater than zero enables training-time action conditioning. Each
-    flow draw samples a delay uniformly from ``[0, rtc_training_max_delay]``;
-    the corresponding action prefix stays clean and is excluded from the loss.
-    """
+    """Maximum clean-prefix delay sampled for training-time RTC; zero disables it."""
 
     # PaLM-style z-loss stabilizes large-vocabulary CE; 0 disables it.
     text_ce_z_loss_weight: float = 1e-4

--- a/src/lerobot/policies/pi052/modeling_pi052.py
+++ b/src/lerobot/policies/pi052/modeling_pi052.py
@@ -187,6 +187,54 @@ def _reduce_action_loss(per_sample: Tensor, predict_actions_t: Tensor | None, re
     return (per_sample * mask).sum() / mask.sum().clamp(min=1.0)
 
 
+def _sample_training_rtc_prefix_mask(
+    batch_size: int,
+    action_horizon: int,
+    max_delay: int,
+    device: torch.device,
+) -> Tensor | None:
+    """Sample per-draw clean prefixes for training-time RTC."""
+    if max_delay <= 0:
+        return None
+    delays = torch.randint(0, max_delay + 1, (batch_size,), device=device)
+    positions = torch.arange(action_horizon, device=device)
+    return positions.unsqueeze(0) < delays.unsqueeze(1)
+
+
+def _build_flow_matching_inputs(
+    actions: Tensor,
+    noise: Tensor,
+    time: Tensor,
+    prefix_mask: Tensor | None,
+) -> tuple[Tensor, Tensor]:
+    """Build noisy actions and scalar/per-token flow times.
+
+    LeRobot's PI0.5 flow uses ``t=0`` for clean data and ``t=1`` for
+    noise, the reverse of the notation in arXiv:2512.05964. Consequently,
+    clean RTC prefix tokens receive ``t=0`` here.
+    """
+    if prefix_mask is None:
+        model_time = time
+        expanded_time = time[:, None, None]
+    else:
+        model_time = time[:, None].expand_as(prefix_mask)
+        model_time = torch.where(prefix_mask, torch.zeros_like(model_time), model_time)
+        expanded_time = model_time.unsqueeze(-1)
+    x_t = expanded_time * noise + (1 - expanded_time) * actions
+    return x_t, model_time
+
+
+def _flow_loss_per_sample(flow_per_dim: Tensor, prefix_mask: Tensor | None) -> Tensor:
+    """Average each draw over postfix action positions and dimensions only."""
+    if prefix_mask is None:
+        return flow_per_dim.flatten(start_dim=1).mean(dim=1)
+    postfix = (~prefix_mask).unsqueeze(-1).expand_as(flow_per_dim)
+    reduce_dims = tuple(range(1, flow_per_dim.ndim))
+    numerator = (flow_per_dim * postfix).sum(dim=reduce_dims)
+    denominator = postfix.sum(dim=reduce_dims).clamp(min=1)
+    return numerator / denominator
+
+
 # Materialized logits win at VLA token counts; larger dense targets use Liger.
 _LOGITS_CE_MAX_POSITIONS = 2048
 
@@ -928,6 +976,7 @@ class PI052Policy(PI05Policy):
             text_labels is None
             and predict_actions_t is None
             and not getattr(self.config, "enable_fast_action_loss", False)
+            and self.config.rtc_training_max_delay == 0
         ):
             return super().forward(batch, reduction=reduction)
 
@@ -1118,12 +1167,17 @@ class PI052Policy(PI05Policy):
 
         noise = self.model.sample_noise(actions.shape, actions.device)
         time = self.model.sample_time(actions.shape[0], actions.device)
-        time_expanded = time[:, None, None]
-        x_t = time_expanded * noise + (1 - time_expanded) * actions
+        prefix_mask = _sample_training_rtc_prefix_mask(
+            actions.shape[0],
+            actions.shape[1],
+            self.config.rtc_training_max_delay,
+            actions.device,
+        )
+        x_t, model_time = _build_flow_matching_inputs(actions, noise, time, prefix_mask)
         u_t = noise - actions
 
         # ---- suffix: noisy actions ----------------------------------
-        suffix_embs, suffix_pad, suffix_att, adarms_cond = self.model.embed_suffix(x_t, time)
+        suffix_embs, suffix_pad, suffix_att, adarms_cond = self.model.embed_suffix(x_t, model_time)
 
         # ---- bf16 alignment (mirrors PI05Pytorch.forward) -----------
         first_layer = self.model.paligemma_with_expert.paligemma.model.language_model.layers[0]
@@ -1169,7 +1223,7 @@ class PI052Policy(PI05Policy):
         # internally to max_action_dim).
         original_action_dim = self.config.output_features[ACTION].shape[0]
         flow_per_dim = flow_per_dim[:, :, :original_action_dim]
-        per_sample_flow = flow_per_dim.mean(dim=(1, 2))
+        per_sample_flow = _flow_loss_per_sample(flow_per_dim, prefix_mask)
         flow_loss = _reduce_action_loss(per_sample_flow, predict_actions_t, reduction)
         return prefix_out, flow_loss
 
@@ -1216,10 +1270,15 @@ class PI052Policy(PI05Policy):
         noise = model.sample_noise((k * batch_size, *actions.shape[1:]), actions.device)
         time = model.sample_time(k * batch_size, actions.device)
         actions_rep = actions.repeat(k, 1, 1)  # (k*B, chunk, motor_dim)
-        time_expanded = time[:, None, None]
-        x_t = time_expanded * noise + (1 - time_expanded) * actions_rep
+        prefix_mask_flat = _sample_training_rtc_prefix_mask(
+            k * batch_size,
+            chunk,
+            self.config.rtc_training_max_delay,
+            actions.device,
+        )
+        x_t, model_time = _build_flow_matching_inputs(actions_rep, noise, time, prefix_mask_flat)
         u_t = (noise - actions_rep).view(k, batch_size, chunk, -1).transpose(0, 1)  # (B, k, chunk, motor)
-        s_embs, suffix_pad, suffix_att, adarms = model.embed_suffix(x_t, time)
+        s_embs, suffix_pad, suffix_att, adarms = model.embed_suffix(x_t, model_time)
         if use_bf16:
             s_embs = s_embs.to(dtype=torch.bfloat16)
         suffix_pad = suffix_pad[:batch_size]
@@ -1228,9 +1287,10 @@ class PI052Policy(PI05Policy):
             s_embs.view(k, batch_size, chunk, -1).transpose(0, 1).reshape(batch_size, k * chunk, -1)
         )  # (B, k*chunk, D)
         # Broadcast each draw's AdaRMS condition over its action chunk.
+        if adarms.ndim == 2:
+            adarms = adarms[:, None, :].expand(-1, chunk, -1)
         adarms_cond = (
-            adarms.view(k, batch_size, 1, adarms.shape[-1])
-            .expand(k, batch_size, chunk, adarms.shape[-1])
+            adarms.view(k, batch_size, chunk, adarms.shape[-1])
             .transpose(0, 1)
             .reshape(batch_size, k * chunk, adarms.shape[-1])
         )  # (B, k*chunk, cond_dim)
@@ -1300,7 +1360,10 @@ class PI052Policy(PI05Policy):
         v_t = model.action_out_proj(suffix_out.to(dtype=torch.float32))
         v_t = v_t.view(batch_size, k, chunk, -1)  # (B, k, chunk, motor)
         flow_per_dim = functional.mse_loss(u_t, v_t, reduction="none")[..., :original_action_dim]
-        per_sample_flow = flow_per_dim.mean(dim=(1, 2, 3))
+        prefix_mask = None
+        if prefix_mask_flat is not None:
+            prefix_mask = prefix_mask_flat.view(k, batch_size, chunk).transpose(0, 1)
+        per_sample_flow = _flow_loss_per_sample(flow_per_dim, prefix_mask)
         flow_loss = _reduce_action_loss(per_sample_flow, predict_actions_t, reduction)
         return prefix_out, flow_loss
 

--- a/src/lerobot/policies/pi052/modeling_pi052.py
+++ b/src/lerobot/policies/pi052/modeling_pi052.py
@@ -177,16 +177,6 @@ def _enable_hf_kernels() -> None:
     logger.info("PI052: HF kernels (Liger) enabled — rope, geglu fused.")
 
 
-def _reduce_action_loss(per_sample: Tensor, predict_actions_t: Tensor | None, reduction: str) -> Tensor:
-    """Mask non-action samples and apply the requested batch reduction."""
-    if predict_actions_t is None:
-        return per_sample if reduction == "none" else per_sample.mean()
-    mask = predict_actions_t.to(per_sample.dtype)
-    if reduction == "none":
-        return per_sample * mask
-    return (per_sample * mask).sum() / mask.sum().clamp(min=1.0)
-
-
 def _sample_training_rtc_prefix_mask(
     batch_size: int,
     action_horizon: int,
@@ -224,15 +214,42 @@ def _build_flow_matching_inputs(
     return x_t, model_time
 
 
-def _flow_loss_per_sample(flow_per_dim: Tensor, prefix_mask: Tensor | None) -> Tensor:
-    """Average each draw over postfix action positions and dimensions only."""
+def _flow_loss_components(flow_per_dim: Tensor, prefix_mask: Tensor | None) -> tuple[Tensor, Tensor]:
+    """Return each sample's postfix loss sum and valid-element count."""
     if prefix_mask is None:
-        return flow_per_dim.flatten(start_dim=1).mean(dim=1)
-    postfix = (~prefix_mask).unsqueeze(-1).expand_as(flow_per_dim)
+        flattened = flow_per_dim.flatten(start_dim=1)
+        numerator = flattened.sum(dim=1)
+        denominator = torch.full_like(numerator, flattened.shape[1])
+        return numerator, denominator
+
+    postfix = (~prefix_mask).unsqueeze(-1).expand_as(flow_per_dim).to(flow_per_dim.dtype)
     reduce_dims = tuple(range(1, flow_per_dim.ndim))
     numerator = (flow_per_dim * postfix).sum(dim=reduce_dims)
-    denominator = postfix.sum(dim=reduce_dims).clamp(min=1)
-    return numerator / denominator
+    denominator = postfix.sum(dim=reduce_dims)
+    return numerator, denominator
+
+
+def _flow_loss_per_sample(flow_per_dim: Tensor, prefix_mask: Tensor | None) -> Tensor:
+    """Average each sample over postfix action positions and dimensions only."""
+    numerator, denominator = _flow_loss_components(flow_per_dim, prefix_mask)
+    return numerator / denominator.clamp(min=1)
+
+
+def _reduce_flow_loss(
+    flow_per_dim: Tensor,
+    prefix_mask: Tensor | None,
+    predict_actions_t: Tensor | None,
+    reduction: str,
+) -> Tensor:
+    """Apply action routing and RLDX-compatible postfix normalization."""
+    numerator, denominator = _flow_loss_components(flow_per_dim, prefix_mask)
+    if predict_actions_t is not None:
+        action_mask = predict_actions_t.to(numerator.dtype)
+        numerator = numerator * action_mask
+        denominator = denominator * action_mask
+    if reduction == "none":
+        return numerator / denominator.clamp(min=1)
+    return numerator.sum() / denominator.sum().clamp(min=1)
 
 
 # Materialized logits win at VLA token counts; larger dense targets use Liger.
@@ -1223,8 +1240,7 @@ class PI052Policy(PI05Policy):
         # internally to max_action_dim).
         original_action_dim = self.config.output_features[ACTION].shape[0]
         flow_per_dim = flow_per_dim[:, :, :original_action_dim]
-        per_sample_flow = _flow_loss_per_sample(flow_per_dim, prefix_mask)
-        flow_loss = _reduce_action_loss(per_sample_flow, predict_actions_t, reduction)
+        flow_loss = _reduce_flow_loss(flow_per_dim, prefix_mask, predict_actions_t, reduction)
         return prefix_out, flow_loss
 
     def _ki_forward_kwargs(self, suppress_prefix_grads: bool = False, flex_masks=None) -> dict[str, Any]:
@@ -1363,8 +1379,7 @@ class PI052Policy(PI05Policy):
         prefix_mask = None
         if prefix_mask_flat is not None:
             prefix_mask = prefix_mask_flat.view(k, batch_size, chunk).transpose(0, 1)
-        per_sample_flow = _flow_loss_per_sample(flow_per_dim, prefix_mask)
-        flow_loss = _reduce_action_loss(per_sample_flow, predict_actions_t, reduction)
+        flow_loss = _reduce_flow_loss(flow_per_dim, prefix_mask, predict_actions_t, reduction)
         return prefix_out, flow_loss
 
     def _prefix_ce_losses(

--- a/src/lerobot/policies/rtc/configuration_rtc.py
+++ b/src/lerobot/policies/rtc/configuration_rtc.py
@@ -37,6 +37,10 @@ class RTCConfig:
     # Infrastructure
     enabled: bool = True
 
+    # ``guided`` is the original inference-time Jacobian guidance. ``trained``
+    # hard-inpaints a prefix and requires a compatible training-time RTC checkpoint.
+    mode: str = "guided"
+
     # Core RTC settings
     # Todo change to exp
     prefix_attention_schedule: RTCAttentionSchedule = RTCAttentionSchedule.LINEAR
@@ -49,6 +53,8 @@ class RTCConfig:
 
     def __post_init__(self):
         """Validate RTC configuration parameters."""
+        if self.mode not in {"guided", "trained"}:
+            raise ValueError(f"mode must be 'guided' or 'trained', got {self.mode!r}")
         if self.max_guidance_weight <= 0:
             raise ValueError(f"max_guidance_weight must be positive, got {self.max_guidance_weight}")
         if self.debug_maxlen <= 0:

--- a/src/lerobot/policies/rtc/modeling_rtc.py
+++ b/src/lerobot/policies/rtc/modeling_rtc.py
@@ -42,7 +42,11 @@ class RTCProcessor:
     prefix attention, and adaptive chunk processing.
     """
 
-    def __init__(self, rtc_config: RTCConfig):
+    def __init__(self, rtc_config: RTCConfig, *, trained_mode_supported: bool = False):
+        if rtc_config.enabled and rtc_config.mode == "trained" and not trained_mode_supported:
+            raise ValueError(
+                "RTC mode='trained' requires a Pi052 checkpoint trained with rtc_training_max_delay > 0."
+            )
         self.rtc_config = rtc_config
 
         self.tracker = None

--- a/src/lerobot/policies/rtc/modeling_rtc.py
+++ b/src/lerobot/policies/rtc/modeling_rtc.py
@@ -45,7 +45,8 @@ class RTCProcessor:
     def __init__(self, rtc_config: RTCConfig, *, trained_mode_supported: bool = False):
         if rtc_config.enabled and rtc_config.mode == "trained" and not trained_mode_supported:
             raise ValueError(
-                "RTC mode='trained' requires a Pi052 checkpoint trained with rtc_training_max_delay > 0."
+                "RTC mode='trained' requires a PI05-compatible checkpoint trained with "
+                "rtc_training_max_delay > 0."
             )
         self.rtc_config = rtc_config
 

--- a/src/lerobot/rollout/context.py
+++ b/src/lerobot/rollout/context.py
@@ -178,6 +178,18 @@ def build_rollout_context(
     policy_config = cfg.policy
     policy_class = get_policy_class(policy_config.type)
 
+    if is_rtc and cfg.inference.rtc.enabled and cfg.inference.rtc.mode == "trained":
+        if policy_config.type != "pi052":
+            raise ValueError(
+                "--inference.rtc.mode=trained currently requires a Pi052 checkpoint; "
+                f"got policy type {policy_config.type!r}."
+            )
+        if int(getattr(policy_config, "rtc_training_max_delay", 0)) <= 0:
+            raise ValueError(
+                "--inference.rtc.mode=trained requires a checkpoint trained with "
+                "--policy.rtc_training_max_delay > 0."
+            )
+
     if hasattr(policy_config, "compile_model"):
         policy_config.compile_model = cfg.use_torch_compile
 

--- a/src/lerobot/rollout/context.py
+++ b/src/lerobot/rollout/context.py
@@ -65,9 +65,9 @@ def _validate_trained_rtc_rollout_config(policy_config, inference_config: RTCInf
     rtc = inference_config.rtc
     if not rtc.enabled or rtc.mode != "trained":
         return
-    if policy_config.type != "pi052":
+    if policy_config.type not in {"pi05", "pi052"}:
         raise ValueError(
-            "--inference.rtc.mode=trained currently requires a Pi052 checkpoint; "
+            "--inference.rtc.mode=trained currently requires a PI05-compatible checkpoint; "
             f"got policy type {policy_config.type!r}."
         )
 

--- a/src/lerobot/rollout/context.py
+++ b/src/lerobot/rollout/context.py
@@ -60,6 +60,35 @@ from .robot_wrapper import ThreadSafeRobot
 logger = logging.getLogger(__name__)
 
 
+def _validate_trained_rtc_rollout_config(policy_config, inference_config: RTCInferenceConfig) -> None:
+    """Fail fast when rollout cannot retain every trained RTC prefix."""
+    rtc = inference_config.rtc
+    if not rtc.enabled or rtc.mode != "trained":
+        return
+    if policy_config.type != "pi052":
+        raise ValueError(
+            "--inference.rtc.mode=trained currently requires a Pi052 checkpoint; "
+            f"got policy type {policy_config.type!r}."
+        )
+
+    training_max_delay = int(getattr(policy_config, "rtc_training_max_delay", 0))
+    if training_max_delay <= 0:
+        raise ValueError(
+            "--inference.rtc.mode=trained requires a checkpoint trained with "
+            "--policy.rtc_training_max_delay > 0."
+        )
+    if rtc.execution_horizon < training_max_delay:
+        raise ValueError(
+            f"--inference.rtc.execution_horizon ({rtc.execution_horizon}) must be at least the "
+            f"checkpoint's rtc_training_max_delay ({training_max_delay})."
+        )
+    if inference_config.queue_threshold < training_max_delay:
+        raise ValueError(
+            f"--inference.queue_threshold ({inference_config.queue_threshold}) must be at least the "
+            f"checkpoint's rtc_training_max_delay ({training_max_delay})."
+        )
+
+
 def _resolve_action_key_order(
     policy_action_names: list[str] | None, dataset_action_names: list[str]
 ) -> list[str]:
@@ -178,17 +207,8 @@ def build_rollout_context(
     policy_config = cfg.policy
     policy_class = get_policy_class(policy_config.type)
 
-    if is_rtc and cfg.inference.rtc.enabled and cfg.inference.rtc.mode == "trained":
-        if policy_config.type != "pi052":
-            raise ValueError(
-                "--inference.rtc.mode=trained currently requires a Pi052 checkpoint; "
-                f"got policy type {policy_config.type!r}."
-            )
-        if int(getattr(policy_config, "rtc_training_max_delay", 0)) <= 0:
-            raise ValueError(
-                "--inference.rtc.mode=trained requires a checkpoint trained with "
-                "--policy.rtc_training_max_delay > 0."
-            )
+    if is_rtc:
+        _validate_trained_rtc_rollout_config(policy_config, cfg.inference)
 
     if hasattr(policy_config, "compile_model"):
         policy_config.compile_model = cfg.use_torch_compile

--- a/src/lerobot/rollout/inference/rtc.py
+++ b/src/lerobot/rollout/inference/rtc.py
@@ -57,8 +57,16 @@ _RTC_MAX_CONSECUTIVE_ERRORS: int = 10
 _RTC_JOIN_TIMEOUT_S: float = 3.0
 
 
-class _TrainedRTCDelayExceededError(RuntimeError):
+class _FatalRTCInferenceError(RuntimeError):
+    """Base class for RTC errors that cannot become valid after a retry."""
+
+
+class _TrainedRTCDelayExceededError(_FatalRTCInferenceError):
     """Raised when measured latency exceeds a trained RTC checkpoint's support."""
+
+
+class _TrainedRTCPrefixUnavailableError(_FatalRTCInferenceError):
+    """Raised when the queue cannot provide the prefix used for conditioning."""
 
 
 # ---------------------------------------------------------------------------
@@ -94,6 +102,16 @@ def _trained_rtc_chunk_can_merge(
             f"rtc_training_max_delay ({training_max_delay})."
         )
     return not has_previous_actions or measured_delay <= conditioned_delay
+
+
+def _validate_trained_rtc_prefix_available(*, conditioned_delay: int, available_steps: int) -> None:
+    """Reject hard-prefix inference when the real queue is shorter than its delay."""
+    if conditioned_delay > available_steps:
+        raise _TrainedRTCPrefixUnavailableError(
+            f"Trained RTC needs {conditioned_delay} committed prefix actions, but the queue has "
+            f"only {available_steps}. Increase --inference.queue_threshold and "
+            "--inference.rtc.execution_horizon."
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -296,6 +314,12 @@ class RTCInferenceEngine(InferenceEngine):
 
                         latency = latency_tracker.max()
                         delay = math.ceil(latency / time_per_chunk) if latency else 0
+                        if self._rtc_config.mode == "trained" and delay > 0:
+                            available_steps = 0 if prev_actions is None else prev_actions.shape[0]
+                            _validate_trained_rtc_prefix_available(
+                                conditioned_delay=delay,
+                                available_steps=available_steps,
+                            )
 
                         obs_batch = build_dataset_frame(self._hw_features, obs, prefix="observation")
                         obs_batch = prepare_observation_for_inference(
@@ -372,7 +396,7 @@ class RTCInferenceEngine(InferenceEngine):
 
                         logger.debug("RTC inference latency=%.2fs, queue=%d", new_latency, queue.qsize())
 
-                    except _TrainedRTCDelayExceededError:
+                    except _FatalRTCInferenceError:
                         raise
                     except Exception as e:
                         consecutive_errors += 1

--- a/src/lerobot/rollout/inference/rtc.py
+++ b/src/lerobot/rollout/inference/rtc.py
@@ -57,6 +57,10 @@ _RTC_MAX_CONSECUTIVE_ERRORS: int = 10
 _RTC_JOIN_TIMEOUT_S: float = 3.0
 
 
+class _TrainedRTCDelayExceededError(RuntimeError):
+    """Raised when measured latency exceeds a trained RTC checkpoint's support."""
+
+
 # ---------------------------------------------------------------------------
 # RTC helpers
 # ---------------------------------------------------------------------------
@@ -74,6 +78,22 @@ def _normalize_prev_actions_length(prev_actions: torch.Tensor, target_steps: int
     padded = torch.zeros((target_steps, action_dim), dtype=prev_actions.dtype, device=prev_actions.device)
     padded[:steps] = prev_actions
     return padded
+
+
+def _trained_rtc_chunk_can_merge(
+    *,
+    conditioned_delay: int,
+    measured_delay: int,
+    training_max_delay: int,
+    has_previous_actions: bool,
+) -> bool:
+    """Check that a trained RTC chunk covers the overlap observed during inference."""
+    if measured_delay > training_max_delay:
+        raise _TrainedRTCDelayExceededError(
+            f"Measured RTC inference delay ({measured_delay}) exceeds the checkpoint's "
+            f"rtc_training_max_delay ({training_max_delay})."
+        )
+    return not has_previous_actions or measured_delay <= conditioned_delay
 
 
 # ---------------------------------------------------------------------------
@@ -272,6 +292,7 @@ class RTCInferenceEngine(InferenceEngine):
                         current_time = time.perf_counter()
                         idx_before = queue.get_action_index()
                         prev_actions = queue.get_left_over()
+                        has_previous_actions = prev_actions is not None and prev_actions.numel() > 0
 
                         latency = latency_tracker.max()
                         delay = math.ceil(latency / time_per_chunk) if latency else 0
@@ -321,6 +342,24 @@ class RTCInferenceEngine(InferenceEngine):
                         else:
                             latency_tracker.add(new_latency)
 
+                        if not is_warmup and self._rtc_config.mode == "trained":
+                            training_max_delay = int(
+                                getattr(self._policy.config, "rtc_training_max_delay", 0)
+                            )
+                            if not _trained_rtc_chunk_can_merge(
+                                conditioned_delay=delay,
+                                measured_delay=new_delay,
+                                training_max_delay=training_max_delay,
+                                has_previous_actions=has_previous_actions,
+                            ):
+                                logger.warning(
+                                    "Discarding trained RTC chunk: measured delay %d exceeded "
+                                    "conditioned delay %d; retrying with updated latency",
+                                    new_delay,
+                                    delay,
+                                )
+                                continue
+
                         queue.merge(original, processed, new_delay, idx_before)
 
                         if (
@@ -333,6 +372,8 @@ class RTCInferenceEngine(InferenceEngine):
 
                         logger.debug("RTC inference latency=%.2fs, queue=%d", new_latency, queue.qsize())
 
+                    except _TrainedRTCDelayExceededError:
+                        raise
                     except Exception as e:
                         consecutive_errors += 1
                         logger.error(

--- a/tests/policies/pi052/test_pi052_training_time_rtc.py
+++ b/tests/policies/pi052/test_pi052_training_time_rtc.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""Unit coverage for Pi052 training-time RTC conditioning."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch import nn
+
+pytest.importorskip("transformers")
+
+from lerobot.policies.pi05.modeling_pi05 import (  # noqa: E402
+    _prepare_trained_rtc_prefix,
+    create_sinusoidal_pos_embedding,
+)
+from lerobot.policies.pi052.configuration_pi052 import PI052Config  # noqa: E402
+from lerobot.policies.pi052.modeling_pi052 import (  # noqa: E402
+    PI05Pytorch as PI052Pytorch,
+    _build_flow_matching_inputs,
+    _flow_loss_per_sample,
+)
+
+
+def test_training_rtc_uses_clean_prefix_and_per_token_time():
+    actions = torch.tensor([[[1.0], [2.0], [3.0], [4.0]]])
+    noise = torch.tensor([[[10.0], [20.0], [30.0], [40.0]]])
+    time = torch.tensor([0.25])
+    prefix_mask = torch.tensor([[True, True, False, False]])
+
+    x_t, model_time = _build_flow_matching_inputs(actions, noise, time, prefix_mask)
+
+    assert model_time.tolist() == [[0.0, 0.0, 0.25, 0.25]]
+    assert torch.equal(x_t[:, :2], actions[:, :2])
+    assert torch.equal(x_t[:, 2:], 0.25 * noise[:, 2:] + 0.75 * actions[:, 2:])
+
+
+def test_training_rtc_loss_averages_over_postfix_only():
+    flow_loss = torch.tensor([[[100.0], [100.0], [2.0], [4.0]]])
+    prefix_mask = torch.tensor([[True, True, False, False]])
+
+    per_sample = _flow_loss_per_sample(flow_loss, prefix_mask)
+
+    assert per_sample.tolist() == [3.0]
+
+
+def test_per_token_time_embedding_preserves_action_axis():
+    time = torch.tensor([[0.0, 0.5, 1.0]])
+
+    embedding = create_sinusoidal_pos_embedding(time, 8, 4e-3, 4.0, time.device)
+
+    assert embedding.shape == (1, 3, 8)
+    assert not torch.equal(embedding[:, 0], embedding[:, 1])
+
+
+def test_action_expert_embeds_per_token_flow_times():
+    model = PI052Pytorch.__new__(PI052Pytorch)
+    nn.Module.__init__(model)
+    model.config = SimpleNamespace(chunk_size=3, min_period=4e-3, max_period=4.0)
+    model.gradient_checkpointing_enabled = False
+    model.action_in_proj = nn.Linear(2, 8)
+    model.time_mlp_in = nn.Linear(8, 8)
+    model.time_mlp_out = nn.Linear(8, 8)
+
+    suffix, _, _, adarms_cond = model.embed_suffix(
+        torch.randn(2, 3, 2),
+        torch.tensor([[0.0, 0.5, 0.5], [0.0, 0.0, 0.5]]),
+    )
+
+    assert suffix.shape == (2, 3, 8)
+    assert adarms_cond.shape == (2, 3, 8)
+
+
+def test_trained_rtc_prefix_is_padded_and_masked():
+    x_t = torch.randn(1, 5, 4)
+    previous = torch.tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]])
+
+    prefix, mask = _prepare_trained_rtc_prefix(x_t, previous, inference_delay=2, training_max_delay=3)
+
+    assert prefix.shape == x_t.shape
+    assert mask.shape == x_t.shape
+    assert torch.equal(prefix[0, :2, :2], previous[:2])
+    assert torch.count_nonzero(prefix[0, :2, 2:]) == 0
+    assert mask[0, :2].all()
+    assert not mask[0, 2:].any()
+
+
+def test_trained_rtc_rejects_delay_outside_training_distribution():
+    with pytest.raises(ValueError, match="exceeds the checkpoint"):
+        _prepare_trained_rtc_prefix(
+            torch.randn(1, 5, 4),
+            torch.randn(4, 2),
+            inference_delay=4,
+            training_max_delay=3,
+        )
+
+
+@pytest.mark.parametrize("max_delay", [-1, 5])
+def test_pi052_config_rejects_invalid_training_rtc_delay(max_delay):
+    with pytest.raises(ValueError, match="rtc_training_max_delay"):
+        PI052Config(chunk_size=5, n_action_steps=5, rtc_training_max_delay=max_delay)

--- a/tests/policies/pi052/test_pi052_training_time_rtc.py
+++ b/tests/policies/pi052/test_pi052_training_time_rtc.py
@@ -24,6 +24,7 @@ from lerobot.policies.pi052.modeling_pi052 import (  # noqa: E402
     PI05Pytorch as PI052Pytorch,
     _build_flow_matching_inputs,
     _flow_loss_per_sample,
+    _reduce_flow_loss,
 )
 
 
@@ -47,6 +48,25 @@ def test_training_rtc_loss_averages_over_postfix_only():
     per_sample = _flow_loss_per_sample(flow_loss, prefix_mask)
 
     assert per_sample.tolist() == [3.0]
+
+
+def test_training_rtc_mean_loss_uses_global_postfix_normalization():
+    flow_loss = torch.tensor(
+        [
+            [[1.0], [1.0], [1.0], [1.0]],
+            [[9.0], [9.0], [9.0], [9.0]],
+        ]
+    )
+    prefix_mask = torch.tensor(
+        [
+            [False, False, False, False],
+            [True, True, True, False],
+        ]
+    )
+
+    loss = _reduce_flow_loss(flow_loss, prefix_mask, predict_actions_t=None, reduction="mean")
+
+    assert loss.item() == pytest.approx(13 / 5)
 
 
 def test_per_token_time_embedding_preserves_action_axis():
@@ -96,6 +116,20 @@ def test_trained_rtc_rejects_delay_outside_training_distribution():
             torch.randn(1, 5, 4),
             torch.randn(4, 2),
             inference_delay=4,
+            training_max_delay=3,
+        )
+
+
+@pytest.mark.parametrize("non_finite", [float("nan"), float("inf")])
+def test_trained_rtc_rejects_non_finite_prefix(non_finite):
+    previous = torch.randn(4, 2)
+    previous[0, 0] = non_finite
+
+    with pytest.raises(ValueError, match="NaN or Inf"):
+        _prepare_trained_rtc_prefix(
+            torch.randn(1, 5, 4),
+            previous,
+            inference_delay=2,
             training_max_delay=3,
         )
 

--- a/tests/policies/pi0_pi05/test_pi05_training_time_rtc.py
+++ b/tests/policies/pi0_pi05/test_pi05_training_time_rtc.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+import pytest
+import torch
+
+pytest.importorskip("transformers")
+
+from lerobot.policies.pi05.configuration_pi05 import PI05Config  # noqa: E402
+from lerobot.policies.pi05.modeling_pi05 import (  # noqa: E402
+    _build_flow_matching_inputs,
+    _reduce_training_rtc_loss,
+)
+
+
+def test_pi05_training_rtc_uses_clean_prefix_and_per_token_time():
+    actions = torch.tensor([[[1.0], [2.0], [3.0], [4.0]]])
+    noise = torch.tensor([[[10.0], [20.0], [30.0], [40.0]]])
+    time = torch.tensor([0.25])
+    prefix_mask = torch.tensor([[True, True, False, False]])
+
+    x_t, model_time = _build_flow_matching_inputs(actions, noise, time, prefix_mask)
+
+    assert model_time.tolist() == [[0.0, 0.0, 0.25, 0.25]]
+    assert torch.equal(x_t[:, :2], actions[:, :2])
+    assert torch.equal(x_t[:, 2:], 0.25 * noise[:, 2:] + 0.75 * actions[:, 2:])
+
+
+def test_pi05_training_rtc_loss_excludes_clean_prefix():
+    losses = torch.tensor([[[100.0], [100.0], [2.0], [4.0]]])
+    prefix_mask = torch.tensor([[True, True, False, False]])
+
+    loss = _reduce_training_rtc_loss(losses, prefix_mask, reduction="mean")
+
+    assert loss.item() == pytest.approx(3.0)
+
+
+@pytest.mark.parametrize("max_delay", [-1, 5])
+def test_pi05_config_rejects_invalid_training_rtc_delay(max_delay):
+    with pytest.raises(ValueError, match="rtc_training_max_delay"):
+        PI05Config(chunk_size=5, n_action_steps=5, rtc_training_max_delay=max_delay)

--- a/tests/policies/rtc/test_configuration_rtc.py
+++ b/tests/policies/rtc/test_configuration_rtc.py
@@ -16,6 +16,8 @@
 
 """Tests for RTC configuration module."""
 
+import pytest
+
 from lerobot.configs.types import RTCAttentionSchedule
 from lerobot.policies.rtc.configuration_rtc import RTCConfig
 
@@ -27,6 +29,7 @@ def test_rtc_config_default_initialization():
     config = RTCConfig()
 
     assert config.enabled is True
+    assert config.mode == "guided"
     assert config.prefix_attention_schedule == RTCAttentionSchedule.LINEAR
     assert config.max_guidance_weight == 10.0
     assert config.execution_horizon == 10
@@ -34,10 +37,16 @@ def test_rtc_config_default_initialization():
     assert config.debug_maxlen == 100
 
 
+def test_rtc_config_rejects_unknown_mode():
+    with pytest.raises(ValueError, match="mode must be"):
+        RTCConfig(mode="unknown")
+
+
 def test_rtc_config_custom_initialization():
     """Test RTCConfig initializes with custom values."""
     config = RTCConfig(
         enabled=True,
+        mode="trained",
         prefix_attention_schedule=RTCAttentionSchedule.EXP,
         max_guidance_weight=5.0,
         execution_horizon=20,
@@ -46,6 +55,7 @@ def test_rtc_config_custom_initialization():
     )
 
     assert config.enabled is True
+    assert config.mode == "trained"
     assert config.prefix_attention_schedule == RTCAttentionSchedule.EXP
     assert config.max_guidance_weight == 5.0
     assert config.execution_horizon == 20

--- a/tests/policies/rtc/test_modeling_rtc.py
+++ b/tests/policies/rtc/test_modeling_rtc.py
@@ -96,7 +96,7 @@ def test_rtc_processor_initialization_without_debug(rtc_config_debug_disabled):
 def test_rtc_processor_rejects_trained_mode_when_policy_does_not_support_it():
     config = RTCConfig(mode="trained")
 
-    with pytest.raises(ValueError, match="requires a Pi052 checkpoint"):
+    with pytest.raises(ValueError, match="requires a PI05-compatible checkpoint"):
         RTCProcessor(config)
 
     processor = RTCProcessor(config, trained_mode_supported=True)

--- a/tests/policies/rtc/test_modeling_rtc.py
+++ b/tests/policies/rtc/test_modeling_rtc.py
@@ -93,6 +93,19 @@ def test_rtc_processor_initialization_without_debug(rtc_config_debug_disabled):
     assert processor.tracker is None
 
 
+def test_rtc_processor_rejects_trained_mode_when_policy_does_not_support_it():
+    config = RTCConfig(mode="trained")
+
+    with pytest.raises(ValueError, match="requires a Pi052 checkpoint"):
+        RTCProcessor(config)
+
+    processor = RTCProcessor(config, trained_mode_supported=True)
+    assert processor.rtc_config.mode == "trained"
+
+    disabled = RTCProcessor(RTCConfig(enabled=False, mode="trained"))
+    assert disabled.rtc_config.enabled is False
+
+
 # ====================== Tracker Proxy Methods Tests ======================
 
 

--- a/tests/test_rollout.py
+++ b/tests/test_rollout.py
@@ -98,6 +98,38 @@ def test_inference_config_types():
     assert rtc.rtc is not None
 
 
+def test_trained_rtc_retries_chunk_when_measured_delay_exceeds_conditioning():
+    from lerobot.rollout.inference.rtc import _trained_rtc_chunk_can_merge
+
+    assert not _trained_rtc_chunk_can_merge(
+        conditioned_delay=2,
+        measured_delay=3,
+        training_max_delay=4,
+        has_previous_actions=True,
+    )
+    assert _trained_rtc_chunk_can_merge(
+        conditioned_delay=2,
+        measured_delay=3,
+        training_max_delay=4,
+        has_previous_actions=False,
+    )
+
+
+def test_trained_rtc_rejects_measured_delay_above_checkpoint_support():
+    from lerobot.rollout.inference.rtc import (
+        _trained_rtc_chunk_can_merge,
+        _TrainedRTCDelayExceededError,
+    )
+
+    with pytest.raises(_TrainedRTCDelayExceededError, match="rtc_training_max_delay"):
+        _trained_rtc_chunk_can_merge(
+            conditioned_delay=3,
+            measured_delay=5,
+            training_max_delay=4,
+            has_previous_actions=True,
+        )
+
+
 def test_sentry_config_defaults():
     from lerobot.rollout import SentryStrategyConfig
 

--- a/tests/test_rollout.py
+++ b/tests/test_rollout.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import dataclasses
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -128,6 +129,38 @@ def test_trained_rtc_rejects_measured_delay_above_checkpoint_support():
             training_max_delay=4,
             has_previous_actions=True,
         )
+
+
+def test_trained_rtc_rejects_prefix_shorter_than_conditioned_delay():
+    from lerobot.rollout.inference.rtc import (
+        _TrainedRTCPrefixUnavailableError,
+        _validate_trained_rtc_prefix_available,
+    )
+
+    with pytest.raises(_TrainedRTCPrefixUnavailableError, match="only 2"):
+        _validate_trained_rtc_prefix_available(conditioned_delay=4, available_steps=2)
+
+
+@pytest.mark.parametrize(
+    ("execution_horizon", "queue_threshold", "match"),
+    [
+        (3, 4, "execution_horizon"),
+        (4, 3, "queue_threshold"),
+    ],
+)
+def test_trained_rtc_rollout_requires_capacity_for_max_delay(execution_horizon, queue_threshold, match):
+    from lerobot.policies.rtc.configuration_rtc import RTCConfig
+    from lerobot.rollout.context import _validate_trained_rtc_rollout_config
+    from lerobot.rollout.inference import RTCInferenceConfig
+
+    policy_config = SimpleNamespace(type="pi052", rtc_training_max_delay=4)
+    inference_config = RTCInferenceConfig(
+        rtc=RTCConfig(mode="trained", execution_horizon=execution_horizon),
+        queue_threshold=queue_threshold,
+    )
+
+    with pytest.raises(ValueError, match=match):
+        _validate_trained_rtc_rollout_config(policy_config, inference_config)
 
 
 def test_sentry_config_defaults():


### PR DESCRIPTION
## Summary

- add opt-in training-time RTC for Pi052 via `policy.rtc_training_max_delay`
- condition the action expert on clean action prefixes with per-action flow timesteps and postfix-only loss
- add `guided` and `trained` rollout RTC modes, including hard-prefix inference for compatible checkpoints
- validate checkpoint compatibility and measured inference delays before trained RTC rollout
- document training, delay selection, and `lerobot-rollout` usage in the Pi052, RTC, and inference guides

## Why

The existing RTC path uses inference-time Jacobian guidance, which adds backward-pass work to every denoising step. Training-time action conditioning teaches Pi052 to consume a committed action prefix directly, following *Training-Time Action Conditioning for Efficient Real-Time Chunking* and the RLDX-1 reference implementation. This keeps ordinary RTC behavior unchanged by default while enabling cheaper trained-prefix inference for checkpoints that opt in.

LeRobot's flow coordinate runs from noise at `t=1` to clean data at `t=0`, so the paper's clean-prefix timestep is represented as `t=0` in this implementation.

## User impact

Training-time RTC remains disabled by default. Users can enable it with:

```bash
--policy.rtc_training_max_delay=10
```

A compatible checkpoint can then be deployed asynchronously with:

```bash
--inference.type=rtc \
--inference.rtc.mode=trained \
--inference.rtc.execution_horizon=10
```

The rollout fails explicitly if trained mode is selected for an incompatible policy/checkpoint or if measured latency exceeds the checkpoint's trained delay range.

## Validation

- `uv run pytest tests/policies/pi052 -q`
- `uv run pytest tests/policies/rtc -q`
- Pi0.5 RTC and compile compatibility tests
- `uv run pytest tests/test_rollout.py -q`
- repository pre-commit hooks on all changed files (ruff, mypy, typos, Bandit, Prettier, and safety checks)

GPU-only cases were skipped on the MPS development machine. No model training was run.
