### PR TITLE
Fix annotation example

### DIFF
--- a/examples/annotations/run_hf_job.py
+++ b/examples/annotations/run_hf_job.py
@@ -46,8 +46,11 @@ CMD = (
     "apt-get update -qq && apt-get install -y -qq git ffmpeg && "
     "pip install --no-deps "
     "'lerobot @ git+https://github.com/huggingface/lerobot.git@main' && "
+    # Pins mirror pyproject.toml — unpinned installs pull av 18 / datasets 5 /
+    # draccus 0.11, which break lerobot at import time.
     "pip install --upgrade-strategy only-if-needed "
-    "datasets pyarrow av jsonlines draccus gymnasium torchcodec mergedeep pyyaml-include toml typing-inspect "
+    "'datasets>=4.7.0,<5.0.0' 'pyarrow>=21.0.0,<30.0.0' 'av>=15.0.0,<16.0.0' 'draccus==0.10.0' "
+    "'pandas>=2.0.0,<3.0.0' jsonlines gymnasium torchcodec mergedeep pyyaml-include toml typing-inspect "
     "openai && "
     "export VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=0 && "
     "export VLLM_VIDEO_BACKEND=pyav && "


### PR DESCRIPTION
Running examples/annotations/run_hf_job.py on HF Jobs currently crashes at import time: the job installs lerobot with --no-deps and then installs its dependencies unpinned, so pip pulls the latest av (18.0.0), which no longer exposes av.option (lerobot requires av>=15,<16). Other packages also drifted past lerobot's constraints (datasets 5.0, draccus 0.11, pandas 3.0).

This pins the job's pip install to the same version ranges as pyproject.toml, so the example works again.