### PR TITLE
fix(safetensors): expand bare "cuda" to current device for safetensors loads

### DIFF
--- a/src/lerobot/policies/pretrained.py
+++ b/src/lerobot/policies/pretrained.py
@@ -32,6 +32,7 @@ from torch import Tensor, nn
 from lerobot.__version__ import __version__
 from lerobot.configs import PreTrainedConfig
 from lerobot.configs.train import TrainPipelineConfig
+from lerobot.utils.device_utils import resolve_safetensors_device
 from lerobot.utils.hub import HubMixin
 
 from .utils import log_model_loading_keys
@@ -220,7 +221,7 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
     @classmethod
     def _load_as_safetensor(cls, model: T, model_file: str, map_location: str, strict: bool) -> T:
         missing_keys, unexpected_keys = load_model_as_safetensor(
-            model, model_file, strict=strict, device=map_location
+            model, model_file, strict=strict, device=resolve_safetensors_device(map_location)
         )
         log_model_loading_keys(missing_keys, unexpected_keys)
         return model

--- a/src/lerobot/rewards/pretrained.py
+++ b/src/lerobot/rewards/pretrained.py
@@ -28,6 +28,7 @@ from safetensors.torch import load_model as load_model_as_safetensor, save_model
 from torch import Tensor, nn
 
 from lerobot.configs.rewards import RewardModelConfig
+from lerobot.utils.device_utils import resolve_safetensors_device
 from lerobot.utils.hub import HubMixin
 
 if TYPE_CHECKING:
@@ -128,7 +129,7 @@ class PreTrainedRewardModel(nn.Module, HubMixin, abc.ABC):
     @classmethod
     def _load_as_safetensor(cls, model: T, model_file: str, map_location: str, strict: bool) -> T:
         missing_keys, unexpected_keys = load_model_as_safetensor(
-            model, model_file, strict=strict, device=map_location
+            model, model_file, strict=strict, device=resolve_safetensors_device(map_location)
         )
         if missing_keys:
             logging.warning(f"Missing key(s) when loading model: {missing_keys}")

--- a/src/lerobot/utils/device_utils.py
+++ b/src/lerobot/utils/device_utils.py
@@ -59,6 +59,20 @@ def get_safe_torch_device(try_device: str, log: bool = False) -> torch.device:
     return device
 
 
+def resolve_safetensors_device(map_location: str | torch.device) -> str:
+    """Resolve a device string for a safetensors load, working around a device-mapping quirk.
+
+    safetensors' load maps the bare string "cuda" to cuda:0 regardless of the current device
+    (unlike torch's .to("cuda"), which honors torch.cuda.current_device()). Under multi-GPU
+    accelerate/FSDP every rank would then load its weights onto GPU 0, OOMing it before sharding.
+    Resolve "cuda" to the concrete current-device index so each rank loads onto its own GPU.
+    """
+    map_location = str(map_location)
+    if map_location == "cuda" and torch.cuda.is_available():
+        return f"cuda:{torch.cuda.current_device()}"
+    return map_location
+
+
 def get_safe_dtype(dtype: torch.dtype, device: str | torch.device):
     """
     mps is currently not compatible with float64


### PR DESCRIPTION
## Fix safetensors cuda current device

### the problem
safetensors maps the bare string `"cuda"` to the first visible GPU (index 0), not `current_device()`. For example under FSDP with  `fsdp_cpu_ram_efficient_loading: false`, all N local ranks load the full checkpoint onto GPU 0 before sharding instead of loading to their respective device.

### the fix
This simply rewrites the `"cuda"` into `cuda:{torch.cuda.current_device()}` (which resolves to the local rank), so each rank loads into its own GPU.

### How was it tested
Ran on multi node jobs, looked carefully at the initial ram spike, no spike / oom anymore
<img width="511" height="448" alt="image" src="https://github.com/user-attachments/assets/928a6d27-f967-4167-8780-e2609df7eb33" />
