### PR TITLE
fix(examples): keep SO-101 XR re-clutch joint-continuous

### DIFF
--- a/examples/isaac_teleop_to_so101/common.py
+++ b/examples/isaac_teleop_to_so101/common.py
@@ -163,6 +163,89 @@ MAX_EE_STEP_M = 0.1
 # Soft-orientation IK weight: small but nonzero so the wrist follows the hand while position
 # dominates (the 5-DOF SO-101 cannot realize an arbitrary orientation). 0.0 = position-only.
 IK_ORIENTATION_WEIGHT = 0.01
+# Placo-native dq regularization keeps the 5-DOF arm on the local joint branch near
+# singular/under-constrained poses. Unlike an output slew clamp, the solver itself chooses
+# the smallest local joint update and can converge smoothly over subsequent control frames.
+IK_REGULARIZATION_WEIGHT = 0.001
+IK_ENGAGE_MAX_ITERATIONS = 100
+IK_ENGAGE_CONVERGENCE_DEG = 1e-6
+
+
+def build_xr_kinematics(motor_names: list[str]) -> RobotKinematics:
+    """Build the shared SO-101 kinematics solver with local-solution regularization."""
+    kinematics = RobotKinematics(
+        urdf_path=_ensure_so101_urdf(),
+        target_frame_name="gripper_frame_link",
+        joint_names=motor_names,
+    )
+    kinematics.solver.add_regularization_task(IK_REGULARIZATION_WEIGHT)
+    return kinematics
+
+
+def initialize_ik_engage(
+    processor,
+    ee_action: RobotAction,
+    observation: RobotObservation,
+    motor_names: list[str],
+) -> RobotAction:
+    """Converge the hidden IK seed at the same pose before latching its joint baseline.
+
+    No intermediate solution is returned to the robot. This matters when measured calibrated
+    joints are outside nominal URDF limits: Placo may need several solves to settle on its
+    feasible same-pose projection, and latching the first solve would create a delayed jump.
+    """
+    previous: np.ndarray | None = None
+    output: RobotAction | None = None
+    arm_names = [name for name in motor_names if name != "gripper"]
+    for _ in range(IK_ENGAGE_MAX_ITERATIONS):
+        action_input = {
+            "ee_pose": np.asarray(ee_action["ee_pose"], dtype=np.float32).copy(),
+            "closedness": float(ee_action["closedness"]),
+        }
+        output = processor((action_input, observation))
+        current = np.array([float(output[f"{name}.pos"]) for name in arm_names])
+        if previous is not None and float(np.max(np.abs(current - previous))) <= IK_ENGAGE_CONVERGENCE_DEG:
+            break
+        previous = current
+    if output is None:
+        raise RuntimeError("IK engage initialization produced no action")
+    return output
+
+
+class IKJointRebase:
+    """Rebase solver-space arm targets onto the measured joints at clutch engage.
+
+    A calibrated physical joint can sit slightly outside the nominal URDF limits. In that
+    case Placo projects even ``IK(q, FK(q))`` back into its feasible joint space, so sending
+    the nominal same-pose solution causes a visible engage jump.  Latch that solver-space
+    projection on engage and command only subsequent IK deltas relative to it.
+
+    The gripper is intentionally excluded: its action is an absolute LeRobot 0..100 target.
+    """
+
+    def __init__(self, motor_names: list[str]):
+        self._arm_names = [name for name in motor_names if name != "gripper"]
+        self._offsets = dict.fromkeys(self._arm_names, 0.0)
+
+    def engage(self, ik_action: RobotAction, observation: RobotObservation) -> RobotAction:
+        """Latch measured-minus-IK offsets and return an exactly measured arm target."""
+        self._offsets = {
+            name: float(observation[f"{name}.pos"]) - float(ik_action[f"{name}.pos"])
+            for name in self._arm_names
+        }
+        action = self.apply(ik_action)
+        # Assign measurements directly, rather than relying on cancellation roundoff: the
+        # engage frame is a strict joint-space hold while the solver baseline is initialized.
+        for name in self._arm_names:
+            action[f"{name}.pos"] = float(observation[f"{name}.pos"])
+        return action
+
+    def apply(self, ik_action: RobotAction) -> RobotAction:
+        """Map an IK target into the measured/calibrated joint space; preserve gripper."""
+        action = dict(ik_action)
+        for name in self._arm_names:
+            action[f"{name}.pos"] = float(action[f"{name}.pos"]) + self._offsets[name]
+        return action
 
 
 def _ensure_so101_urdf() -> str:
@@ -301,11 +384,7 @@ def _wait_for_xr_controller(teleop_device: XRController) -> None:
 
 def setup_xr(cfg: LoopConfig, robot, motor_names: list[str]) -> Device:
     """Build the XR controller device bundle (clutch + soft-orientation IK pipeline)."""
-    kinematics_solver = RobotKinematics(
-        urdf_path=_ensure_so101_urdf(),
-        target_frame_name="gripper_frame_link",
-        joint_names=motor_names,
-    )
+    kinematics_solver = build_xr_kinematics(motor_names)
 
     teleop_config = cfg.teleop  # XRControllerConfig (selected via --teleop.type=xr_controller)
     teleop_device = XRController(teleop_config)
@@ -339,6 +418,7 @@ def setup_xr(cfg: LoopConfig, robot, motor_names: list[str]) -> Device:
     # The clutch is built in startup() (after the optional reset slew, seeded from the
     # post-slew MEASURED pose) and shared with compute() via nonlocal.
     clutch: Clutch | None = None
+    joint_rebase = IKJointRebase(motor_names)
     prev_enabled = False
 
     def startup() -> None:
@@ -405,7 +485,14 @@ def setup_xr(cfg: LoopConfig, robot, motor_names: list[str]) -> Device:
             "ee_pose": np.concatenate([ee_pos, ee_quat]).astype(np.float32),
             "closedness": trigger,
         }
-        return xr_to_robot_joints_processor((ee_action, robot_obs))
+        ik_action = (
+            initialize_ik_engage(xr_to_robot_joints_processor, ee_action, robot_obs, motor_names)
+            if is_engage_frame
+            else xr_to_robot_joints_processor((ee_action, robot_obs))
+        )
+        if is_engage_frame:
+            return joint_rebase.engage(ik_action, robot_obs)
+        return joint_rebase.apply(ik_action)
 
     return Device(compute=compute, startup=startup, cleanup=teleop_device.disconnect)
 

--- a/examples/isaac_teleop_to_so101/isaac_teleop/clutch.py
+++ b/examples/isaac_teleop_to_so101/isaac_teleop/clutch.py
@@ -37,9 +37,8 @@ class Clutch:
     - ``_last_commanded_pos`` / ``_last_commanded_rot``: last commanded EE pose; held
       while disengaged so the arm freezes where it was left.
     - ``_home_pos`` / ``_home_rot``: latched on engage — the EE pose the delta applies to.
-      The position comes from the arm's MEASURED pose when the caller provides it (so an
-      arm that moved while disengaged is not snapped back to a stale command); the
-      orientation always comes from the last commanded rotation (see NOTE below).
+      Both come from the arm's MEASURED pose when the caller provides it, so the first IK
+      target after re-clutch exactly matches the current FK pose.
     - ``_origin_pos`` / ``_origin_rot``: latched on engage — the controller pose the delta
       is measured against.
 
@@ -52,11 +51,9 @@ class Clutch:
     delta is left-composed (base frame), so hand rotation about base Z maps to EE rotation
     about base Z. A re-clutch latches a fresh home/origin.
 
-    NOTE: ``_home_rot`` is the last *commanded* orientation even when the measured pose is
-    supplied: the 5-DOF SO-101 tracks orientation only softly, so its measured wrist
-    orientation persistently differs from the command, and latching the measurement would
-    inject that offset into the commanded signal on every re-clutch. Position has no such
-    tracking gap, and there latching the measurement is what prevents the snap-back.
+    Re-anchoring measured orientation matters on this 5-DOF arm: carrying a stale soft
+    orientation target across a processor reset can select a very different IK solution even
+    when Cartesian position is continuous.
     """
 
     def __init__(self, home_base_T_ee: np.ndarray):  # noqa: N803
@@ -78,17 +75,18 @@ class Clutch:
     ) -> None:
         """Latch the engage home (where the arm is now) and controller origin.
 
-        Pass ``measured_base_T_ee`` (FK of the measured joints) so the home POSITION is
+        Pass ``measured_base_T_ee`` (FK of the measured joints) so the complete home pose is
         where the arm physically is — if the arm moved while disengaged (gravity sag,
         external contact), latching the stale last-commanded position would make the
-        first engaged frame command a full-speed jump back to it. The home ORIENTATION
-        always stays the last commanded one (see the class NOTE).
+        first engaged frame command a jump back to it.
         """
         if measured_base_T_ee is not None:
-            self._home_pos = np.asarray(measured_base_T_ee, dtype=float)[:3, 3].copy()
+            measured = np.asarray(measured_base_T_ee, dtype=float)
+            self._home_pos = measured[:3, 3].copy()
+            self._home_rot = Rotation.from_matrix(measured[:3, :3])
         else:
             self._home_pos = self._last_commanded_pos.copy()
-        self._home_rot = self._last_commanded_rot
+            self._home_rot = self._last_commanded_rot
         self._origin_pos = np.asarray(grip_pos, dtype=float).copy()
         self._origin_rot = Rotation.from_quat(np.asarray(grip_quat, dtype=float))
 

--- a/examples/isaac_teleop_to_so101/reclutch_joint_continuity_test.py
+++ b/examples/isaac_teleop_to_so101/reclutch_joint_continuity_test.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python
+
+"""Deterministic SO-101 XR re-clutch continuity regression without hardware or MuJoCo."""
+
+from __future__ import annotations
+
+import numpy as np
+from scipy.spatial.transform import Rotation
+
+from lerobot.processor import (
+    RobotProcessorPipeline,
+    robot_action_observation_to_transition,
+    transition_to_robot_action,
+)
+from lerobot.robots.so_follower.robot_kinematic_processor import (
+    EEBoundsAndSafety,
+    InverseKinematicsEEToJoints,
+)
+from lerobot.types import RobotAction, RobotObservation
+
+from .common import (
+    IK_ORIENTATION_WEIGHT,
+    MAX_EE_STEP_M,
+    IKJointRebase,
+    build_xr_kinematics,
+    initialize_ik_engage,
+)
+from .isaac_teleop import Clutch, MapXRControllerActionToRobotAction
+
+MOTOR_NAMES = (
+    "shoulder_pan",
+    "shoulder_lift",
+    "elbow_flex",
+    "wrist_flex",
+    "wrist_roll",
+    "gripper",
+)
+POSES_DEG = (
+    (15.0, -60.0, 70.0, 25.0, 30.0, 40.0),
+    (-35.0, 45.0, -55.0, -30.0, -80.0, 65.0),
+    (70.0, -20.0, 10.0, 60.0, 120.0, 10.0),
+    # Calibrated reset pose used by the example. shoulder_lift is intentionally 3 degrees
+    # outside the nominal URDF limit, exercising Placo's feasible-space projection.
+    (-4.0, -103.0, 97.0, 78.0, -65.0, 25.0),
+)
+SMALL_DELTAS_M = (
+    np.array([0.005, 0.0, 0.0]),
+    np.array([0.0, 0.005, 0.0]),
+    np.array([0.0, 0.0, 0.005]),
+)
+GRIP_POS = np.array([0.20, -0.10, 0.25])
+GRIP_QUAT = np.array([0.0, 0.0, 0.0, 1.0])
+
+
+def observation(q: np.ndarray) -> RobotObservation:
+    return {f"{name}.pos": float(value) for name, value in zip(MOTOR_NAMES, q, strict=True)}
+
+
+def build_processor(kinematics):
+    return RobotProcessorPipeline[tuple[RobotAction, RobotObservation], RobotAction](
+        steps=[
+            MapXRControllerActionToRobotAction(),
+            EEBoundsAndSafety(
+                end_effector_bounds={"min": [-1.0, -1.0, 0.0], "max": [1.0, 1.0, 1.0]},
+                max_ee_step_m=MAX_EE_STEP_M,
+                raise_on_jump=False,
+            ),
+            InverseKinematicsEEToJoints(
+                kinematics=kinematics,
+                motor_names=list(MOTOR_NAMES),
+                initial_guess_current_joints=False,
+                orientation_weight=IK_ORIENTATION_WEIGHT,
+            ),
+        ],
+        to_transition=robot_action_observation_to_transition,
+        to_output=transition_to_robot_action,
+    )
+
+
+def ee_action(position: np.ndarray, quaternion: np.ndarray) -> RobotAction:
+    return {
+        "ee_pose": np.concatenate([position, quaternion]).astype(np.float32),
+        "closedness": 0.3,
+    }
+
+
+def arm_vector(action: RobotAction) -> np.ndarray:
+    return np.array([float(action[f"{name}.pos"]) for name in MOTOR_NAMES[:5]])
+
+
+def main() -> None:
+    max_position_reanchor_m = 0.0
+    max_rotation_reanchor = 0.0
+    max_engage_jump_deg = 0.0
+    max_static_jump_deg = 0.0
+    max_small_motion_deg = 0.0
+
+    for pose_index, pose_values in enumerate(POSES_DEG):
+        q = np.array(pose_values)
+        obs = observation(q)
+        stale_q = np.array(POSES_DEG[(pose_index + 1) % len(POSES_DEG)])
+
+        for delta in SMALL_DELTAS_M:
+            kinematics = build_xr_kinematics(list(MOTOR_NAMES))
+            stale_pose = kinematics.forward_kinematics(stale_q)
+            measured_pose = kinematics.forward_kinematics(q)
+            processor = build_processor(kinematics)
+
+            # Start from a deliberately stale command pose. engage() must replace both its
+            # position and orientation with the complete measured FK pose.
+            clutch = Clutch(stale_pose)
+            clutch.engage(GRIP_POS, GRIP_QUAT, measured_base_T_ee=measured_pose)
+            processor.reset()
+            base_pos, base_quat = clutch.rebase(GRIP_POS, GRIP_QUAT)
+            position_reanchor = float(np.linalg.norm(base_pos - measured_pose[:3, 3]))
+            rotation_reanchor = float(
+                np.max(np.abs(Rotation.from_quat(base_quat).as_matrix() - measured_pose[:3, :3]))
+            )
+
+            base_action = ee_action(base_pos, base_quat)
+            ik_engage = initialize_ik_engage(processor, base_action, obs, list(MOTOR_NAMES))
+            joint_rebase = IKJointRebase(list(MOTOR_NAMES))
+            engage = joint_rebase.engage(ik_engage, obs)
+            static = joint_rebase.apply(processor((ee_action(base_pos, base_quat), obs)))
+
+            moved_pos, moved_quat = clutch.rebase(GRIP_POS + delta, GRIP_QUAT)
+            moved = joint_rebase.apply(processor((ee_action(moved_pos, moved_quat), obs)))
+
+            engage_jump = float(np.max(np.abs(arm_vector(engage) - q[:5])))
+            static_jump = float(np.max(np.abs(arm_vector(static) - q[:5])))
+            small_motion = float(np.max(np.abs(arm_vector(moved) - arm_vector(static))))
+
+            max_position_reanchor_m = max(max_position_reanchor_m, position_reanchor)
+            max_rotation_reanchor = max(max_rotation_reanchor, rotation_reanchor)
+            max_engage_jump_deg = max(max_engage_jump_deg, engage_jump)
+            max_static_jump_deg = max(max_static_jump_deg, static_jump)
+            max_small_motion_deg = max(max_small_motion_deg, small_motion)
+
+            if not np.isclose(float(engage["gripper.pos"]), 70.0):
+                raise SystemExit("FAIL: engage changed absolute gripper semantics")
+
+    print(f"PASS poses={len(POSES_DEG)} directions={len(SMALL_DELTAS_M)}")
+    print(f"reanchor_position={max_position_reanchor_m:.9f}m reanchor_rotation={max_rotation_reanchor:.9f}")
+    print(
+        f"engage_jump={max_engage_jump_deg:.6f}deg "
+        f"static_jump={max_static_jump_deg:.6f}deg "
+        f"max_5mm_joint_step={max_small_motion_deg:.3f}deg"
+    )
+    if max_position_reanchor_m > 1e-9 or max_rotation_reanchor > 1e-9:
+        raise SystemExit("FAIL: clutch did not re-anchor the complete measured FK pose")
+    if max_engage_jump_deg > 1e-9:
+        raise SystemExit("FAIL: engage frame did not strictly hold measured joints")
+    if max_static_jump_deg > 1e-3:
+        raise SystemExit("FAIL: stationary post-engage frame changed joints")
+    if max_small_motion_deg > 5.0:
+        raise SystemExit("FAIL: first 5 mm motion selected a discontinuous IK solution")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This PR fixes a joint discontinuity that can occur when re-engaging the XR Grip/Squeeze clutch while teleoperating a physical SO-101.

The observed failure had two forms:

- a sudden joint change while moving with Grip held;
- a downward elbow/wrist jump after releasing Grip, keeping the controller still, and pressing Grip again.

Related reproduction report and videos: [NVIDIA/IsaacTeleop#790](https://github.com/NVIDIA/IsaacTeleop/issues/790).

This change is independent of the MuJoCo teleoperation example in #4043 and changes only:

- `examples/isaac_teleop_to_so101/common.py`
- `examples/isaac_teleop_to_so101/isaac_teleop/clutch.py`
- `examples/isaac_teleop_to_so101/reclutch_joint_continuity_test.py`

## Root cause

A calibrated physical joint configuration can lie slightly outside the nominal URDF limits. One reproduced configuration had `shoulder_lift = -103 deg`, while the URDF lower limit is approximately `-100 deg`.

When Placo solves the forward-kinematics pose of that measured configuration, it projects the solution back into its feasible joint space. A nominally identical Cartesian pose therefore does not necessarily reproduce the measured joints. Same-pose IK can also require multiple solves to converge, and the SO-101's five arm joints leave the full Cartesian pose under-constrained near limits or singular configurations.

Re-anchoring only the measured end-effector position while retaining the previous commanded orientation made the discontinuity more visible across clutch cycles.

## Fix

On every clutch engage, the implementation now:

1. re-anchors the clutch using the complete measured FK pose, including position and orientation;
2. resets the action processor;
3. adds Placo-native `dq` regularization with weight `0.001`;
4. pre-converges the same-pose IK state;
5. builds a fixed arm-joint rebase from `measured joints - converged solver joints`;
6. outputs the measured arm joints unchanged on the engage frame;
7. applies subsequent solver increments relative to that measured configuration.

The gripper is excluded from the joint rebase and retains its absolute `0-100` command semantics.

No Grip debounce, output rate limiting, orientation-weight removal, or motor-side workaround is added.

## Validation

### Standalone IK regression

Four representative arm configurations, including the `-103 deg` out-of-nominal-limit pose, were tested in X/Y/Z with a 5 mm Cartesian command:

- maximum engage-frame joint jump: `0.000000 deg`;
- maximum stationary next-frame change: `0.000001 deg`;
- maximum first 5 mm motion step: `2.791 deg`;
- gripper absolute-command behavior preserved.

### Physical SO-101 regression

Tested with a Quest 3S controller through CloudXR and Isaac Teleop:

- 47 physical engage events;
- engage-frame maximum joint jump for all 47 events: `0.000000 deg`;
- final 20 stationary re-engage trials had a maximum next-frame step of `0.126126 deg`, with most results between `0` and `0.1 deg`;
- no recurrence of the previous rapid elbow/wrist jump;
- 5 mm and larger Cartesian motions completed without observed IK branch jumps;
- Trigger open/half-open/closed behavior and released-Grip hold both passed;
- no IK, end-effector rate-limit, or XR-disconnect errors occurred during the regression.

The physical test did not run motor setup, change IDs, flash firmware, use a leader arm, connect cameras, or record data.

## Related

- Reproduction videos and upstream report: [NVIDIA/IsaacTeleop#790](https://github.com/NVIDIA/IsaacTeleop/issues/790)
- Independent MuJoCo XR example: #4043
