### PR TITLE
Fix duplicate loss logging for π0 and π0.5²

### DIFF
--- a/src/lerobot/policies/pi0/modeling_pi0.py
+++ b/src/lerobot/policies/pi0/modeling_pi0.py
@@ -1312,12 +1312,10 @@ class PI0Policy(PreTrainedPolicy):
         if reduction == "none":
             # Return per-sample losses (B,) by averaging over time and action dims
             per_sample_loss = losses.mean(dim=(1, 2))
-            loss_dict["loss"] = per_sample_loss.mean().item()
             return per_sample_loss, loss_dict
         else:
             # Default: return scalar mean loss
             loss = losses.mean()
-            loss_dict["loss"] = loss.item()
             return loss, loss_dict
 
     def _get_default_peft_targets(self) -> dict[str, any]:

--- a/src/lerobot/policies/pi05/modeling_pi05.py
+++ b/src/lerobot/policies/pi05/modeling_pi05.py
@@ -1359,12 +1359,10 @@ class PI05Policy(PreTrainedPolicy):
         if reduction == "none":
             # Return per-sample losses (B,) by averaging over time and action dims
             per_sample_loss = losses.mean(dim=(1, 2))
-            loss_dict["loss"] = per_sample_loss.mean().item()
             return per_sample_loss, loss_dict
         else:
             # Default: return scalar mean loss
             loss = losses.mean()
-            loss_dict["loss"] = loss.item()
             return loss, loss_dict
 
     def _get_default_peft_targets(self) -> dict[str, any]:

--- a/src/lerobot/policies/pi052/modeling_pi052.py
+++ b/src/lerobot/policies/pi052/modeling_pi052.py
@@ -1006,8 +1006,6 @@ class PI052Policy(PI05Policy):
                 "nothing to train."
             )
 
-        # Keep metrics detached on-device until logging to avoid extra CUDA synchronization.
-        loss_dict["loss"] = total.detach().mean()
         return total, loss_dict
 
     def _compute_all_losses_fused(


### PR DESCRIPTION
## Summary

- stop π0 from returning the total loss in its metrics dictionary
- stop π0.5² from returning the total loss in both its delegated and composite-loss paths
- retain component diagnostics such as `loss_per_dim`, `flow_loss`, `text_loss`, and `fast_action_loss`

## Why

The training loop already records the loss returned by `policy.forward()` as the canonical `train/loss`, averaged over the logging window. These policies also returned the same total under `output_dict["loss"]`. When the dictionaries were merged, the policy metric overwrote the trainer average with the most recent batch value. This explains why one observed loss trace was smooth while the other was substantially spikier.

After this change, the training loop is the sole owner of `train/loss` for π0 and π0.5².

## Validation

- `pre-commit run --files src/lerobot/policies/pi0/modeling_pi0.py src/lerobot/policies/pi052/modeling_pi052.py` — passed
