### PR TITLE
Align PI0-FAST semantics with OpenPI

### DIFF
--- a/docs/source/pi0fast.mdx
+++ b/docs/source/pi0fast.mdx
@@ -43,12 +43,6 @@ This approach can transform **any existing VLM** into a VLA by training it to pr
    pip install -e ".[pi]"
    ```
 
-> [!WARNING]
-> PI0-FAST now follows OpenPI's token and normalization semantics exactly. Checkpoints and
-> saved preprocessors created with the previous LeRobot implementation are incompatible and
-> must be retrained or regenerated. In particular, do not reuse `MEAN_STD` statistics or a
-> processor that inserts a second BOS token before `Action:`.
-
 ## Training a Custom FAST Tokenizer
 
 You have two options for the FAST tokenizer:

--- a/docs/source/pi0fast.mdx
+++ b/docs/source/pi0fast.mdx
@@ -43,6 +43,12 @@ This approach can transform **any existing VLM** into a VLA by training it to pr
    pip install -e ".[pi]"
    ```
 
+> [!WARNING]
+> PI0-FAST now follows OpenPI's token and normalization semantics exactly. Checkpoints and
+> saved preprocessors created with the previous LeRobot implementation are incompatible and
+> must be retrained or regenerated. In particular, do not reuse `MEAN_STD` statistics or a
+> processor that inserts a second BOS token before `Action:`.
+
 ## Training a Custom FAST Tokenizer
 
 You have two options for the FAST tokenizer:
@@ -114,7 +120,7 @@ lerobot-train \
 | `--policy.gradient_checkpointing=true` | Reduces memory usage significantly during training | `false`                         |
 | `--policy.dtype=bfloat16`              | Use mixed precision training for efficiency        | `float32`                       |
 | `--policy.chunk_size`                  | Number of action steps to predict (action horizon) | `50`                            |
-| `--policy.n_action_steps`              | Number of action steps to execute                  | `50`                            |
+| `--policy.n_action_steps`              | Number of decoded action steps to execute          | `50`                            |
 | `--policy.max_action_tokens`           | Maximum number of FAST tokens per action chunk     | `256`                           |
 | `--policy.action_tokenizer_name`       | FAST tokenizer to use                              | `lerobot/fast-action-tokenizer` |
 | `--policy.compile_model=true`          | Enable torch.compile for faster training           | `false`                         |
@@ -150,6 +156,9 @@ actions = policy.predict_action_chunk(batch)
 - **Language Model**: Gemma 2B for processing language instructions and predicting action tokens
 
 The model takes images, text instructions, and robot state as input, and outputs discrete FAST tokens that are decoded back to continuous actions.
+
+PI0-FAST always decodes a complete `chunk_size` action chunk. `n_action_steps` controls only
+how many actions from that chunk are executed before the policy predicts again.
 
 ## Configuration Options
 

--- a/src/lerobot/policies/pi0_fast/configuration_pi0_fast.py
+++ b/src/lerobot/policies/pi0_fast/configuration_pi0_fast.py
@@ -65,17 +65,14 @@ class PI0FastConfig(PreTrainedConfig):
     max_decoding_steps: int = 256
     fast_skip_tokens: int = 128
 
-    # Whether to validate that decoded action tokens start with "Action: " prefix
-    validate_action_token_prefix: bool = True
-
     # Whether to use KV cache for faster autoregressive decoding
     use_kv_cache: bool = True
 
     normalization_mapping: dict[str, NormalizationMode] = field(
         default_factory=lambda: {
             "VISUAL": NormalizationMode.IDENTITY,
-            "STATE": NormalizationMode.MEAN_STD,  # Pi0Fast uses quantiles for state
-            "ACTION": NormalizationMode.MEAN_STD,  # Pi0Fast uses quantiles for action
+            "STATE": NormalizationMode.QUANTILES,
+            "ACTION": NormalizationMode.QUANTILES,
         }
     )
 

--- a/src/lerobot/policies/pi0_fast/modeling_pi0_fast.py
+++ b/src/lerobot/policies/pi0_fast/modeling_pi0_fast.py
@@ -25,13 +25,7 @@ import torch
 import torch.nn.functional as F  # noqa: N812
 from torch import Tensor, nn
 
-from lerobot.utils.import_utils import _scipy_available, _transformers_available, require_package
-
-# Conditional import for type checking and lazy loading
-if TYPE_CHECKING or _scipy_available:
-    from scipy.fftpack import idct
-else:
-    idct = None
+from lerobot.utils.import_utils import _transformers_available, require_package
 
 if TYPE_CHECKING or _transformers_available:
     from transformers import AutoProcessor, AutoTokenizer
@@ -76,6 +70,32 @@ def pad_vector(vector, new_dim):
     if vector.shape[-1] >= new_dim:
         return vector
     return F.pad(vector, (0, new_dim - vector.shape[-1]))
+
+
+def _gather_last_valid_language_hidden(
+    hidden_states: Tensor,
+    language_masks: Tensor,
+    image_token_count: int,
+) -> Tensor:
+    """Gather each sample's last non-padding language hidden state."""
+    last_language_indices = image_token_count + language_masks.long().sum(dim=1) - 1
+    if torch.any(last_language_indices < image_token_count):
+        raise ValueError("PI0-FAST requires at least one valid language token per sample")
+    batch_indices = torch.arange(hidden_states.shape[0], device=hidden_states.device)
+    return hidden_states[batch_indices, last_language_indices]
+
+
+def _reduce_fast_token_loss(token_loss: Tensor, token_mask: Tensor) -> Tensor:
+    """Give every sample equal weight regardless of its FAST token count."""
+    sample_loss = (token_loss * token_mask).sum(dim=1) / token_mask.sum(dim=1).clamp(min=1)
+    return sample_loss.mean()
+
+
+def _sample_next_token(logits: Tensor, temperature: float) -> Tensor:
+    if temperature > 0:
+        probabilities = torch.softmax(logits / temperature, dim=-1)
+        return torch.multinomial(probabilities, num_samples=1)
+    return torch.argmax(logits, dim=-1, keepdim=True)
 
 
 def resize_with_pad_torch(  # see openpi `resize_with_pad_torch` (exact copy)
@@ -326,7 +346,6 @@ class PI0FastPytorch(nn.Module):  # see openpi `PI0Pytorch`
         # Compile model if requested
         if config.compile_model:
             torch.set_float32_matmul_precision("high")
-            self.sample_actions_fast = torch.compile(self.sample_actions_fast, mode=config.compile_mode)
             self.forward = torch.compile(self.forward, mode=config.compile_mode)
 
     def gradient_checkpointing_enable(self):
@@ -561,18 +580,12 @@ class PI0FastPytorch(nn.Module):  # see openpi `PI0Pytorch`
         # only compute logits for the positions that predict FAST tokens
         lm_head = self.paligemma_with_expert.paligemma.lm_head
 
-        # Targets are the FAST action tokens
-        fast_targets = fast_action_tokens  # (B, num_fast_embs)
-
-        # extract logits for FAST token prediction
-        fast_hidden = prefix_out[:, -fast_targets.shape[1] :, :]
-        fast_logits_for_pred = lm_head(fast_hidden)  # (B, num_fast_embs, gemma_vocab_size)
-
-        # Shift left for next-step prediction and shift target
-        # logits[:, i] predicts targets[:, i+1]
-        fast_logits_for_pred = fast_logits_for_pred[:, :-1, :]  # shift logits left
-        fast_targets = fast_targets[:, 1:]  # shift targets right
-        fast_action_masks = fast_action_masks[:, 1:]  # shift masks to match targets
+        # The last valid prompt token predicts "Action:", then each FAST token predicts the next one.
+        fast_hidden = prefix_out[:, -num_fast_embs:, :]
+        last_language_hidden = _gather_last_valid_language_hidden(prefix_out, masks, total_t_images)
+        prediction_hidden = torch.cat([last_language_hidden[:, None], fast_hidden[:, :-1]], dim=1)
+        fast_logits_for_pred = lm_head(prediction_hidden)
+        fast_targets = fast_action_tokens
 
         # compute cross-entropy loss
         loss_fct = torch.nn.CrossEntropyLoss(reduction="none")
@@ -582,9 +595,7 @@ class PI0FastPytorch(nn.Module):  # see openpi `PI0Pytorch`
         fast_loss_per_token = loss_fct(fast_logits_flat, fast_targets_flat)
         fast_loss_per_token = fast_loss_per_token.reshape(fast_targets.shape)
 
-        # apply mask and compute mean loss
-        masked_fast_loss = fast_loss_per_token * fast_action_masks.float()
-        fast_loss = masked_fast_loss.sum() / fast_action_masks.sum().clamp(min=1)
+        fast_loss = _reduce_fast_token_loss(fast_loss_per_token, fast_action_masks.float())
 
         return {
             "ce_loss": fast_loss,
@@ -613,15 +624,7 @@ class PI0FastPytorch(nn.Module):  # see openpi `PI0Pytorch`
         device = tokens.device
         lm_head = self.paligemma_with_expert.paligemma.lm_head
 
-        # add bos token after tokens
-        bos_token = torch.full(
-            (bsize, 1), self._paligemma_tokenizer.bos_token_id, dtype=torch.long, device=device
-        )
-        tokens = torch.cat([tokens, bos_token], dim=1)
-        masks = torch.cat([masks, torch.ones((bsize, 1), dtype=torch.bool, device=device)], dim=1)
-
-        # 1. Initial Embedding (matches training prefix)
-        # prefix_embs will include [Images, Language Prompt, BOS]
+        # 1. Initial embedding: the prompt's existing BOS is the only BOS in the sequence.
         prefix_embs, prefix_pad_masks, prefix_att_masks, total_t_images, _ = self.embed_prefix_fast(
             images, img_masks, tokens, masks, fast_action_tokens=None, fast_action_masks=None
         )
@@ -633,6 +636,8 @@ class PI0FastPytorch(nn.Module):  # see openpi `PI0Pytorch`
             prefix_embs = prefix_embs.to(dtype=torch.bfloat16)
 
         generated_action_tokens = torch.zeros((bsize, max_decoding_steps), dtype=torch.long, device=device)
+        eos_token_id = self._paligemma_tokenizer.eos_token_id
+        finished = torch.zeros(bsize, dtype=torch.bool, device=device)
 
         # 2. Decoding Loop (each step re-computes full sequence)
         for t in range(max_decoding_steps):
@@ -650,16 +655,24 @@ class PI0FastPytorch(nn.Module):  # see openpi `PI0Pytorch`
                 adarms_cond=[None, None],
             )
 
-            # predict next token from the very last sequence position
-            last_logits = lm_head(prefix_out[:, -1:, :])  # (B, 1, vocab_size)
-
-            if temperature > 0:
-                probs = torch.softmax(last_logits[:, -1] / temperature, dim=-1)
-                next_token = torch.multinomial(probs, num_samples=1)
+            if t == 0:
+                prediction_hidden = _gather_last_valid_language_hidden(prefix_out, masks, total_t_images)
             else:
-                next_token = torch.argmax(last_logits[:, -1], dim=-1, keepdim=True)
+                prediction_hidden = prefix_out[:, -1]
+            next_token = _sample_next_token(lm_head(prediction_hidden), temperature)
 
-            generated_action_tokens[:, t] = next_token.squeeze(-1)
+            active = ~finished
+            generated_action_tokens[:, t] = torch.where(
+                active, next_token.squeeze(-1), torch.zeros_like(next_token.squeeze(-1))
+            )
+            finished |= active & next_token.squeeze(-1).eq(eos_token_id)
+            if finished.all():
+                break
+            next_token = torch.where(
+                finished[:, None],
+                torch.full_like(next_token, eos_token_id),
+                next_token,
+            )
 
             # 3. Update sequence for next iteration (unless it's the last step)
             if t < max_decoding_steps - 1:
@@ -706,20 +719,14 @@ class PI0FastPytorch(nn.Module):  # see openpi `PI0Pytorch`
         device = tokens.device
         lm_head = self.paligemma_with_expert.paligemma.lm_head
 
+        generated_action_tokens = torch.zeros((bsize, max_decoding_steps), dtype=torch.long, device=device)
+        if max_decoding_steps == 0:
+            return generated_action_tokens
+
         # --- 1. PREFILL PHASE ---
-        # Process Images + Text Prompt + BOS token once to populate the KV cache.
-
-        # Add BOS token to the prompt
-        bos_token = torch.full(
-            (bsize, 1), self._paligemma_tokenizer.bos_token_id, dtype=torch.long, device=device
-        )
-        tokens_in = torch.cat([tokens, bos_token], dim=1)
-        masks_in = torch.cat([masks, torch.ones((bsize, 1), dtype=torch.bool, device=device)], dim=1)
-
-        # Embed prefix [Images, Language, BOS]
         # fast_action_tokens=None means we are just embedding the condition (images+text)
         prefix_embs, prefix_pad_masks, prefix_att_masks, total_t_images, _ = self.embed_prefix_fast(
-            images, img_masks, tokens_in, masks_in, fast_action_tokens=None, fast_action_masks=None
+            images, img_masks, tokens, masks, fast_action_tokens=None, fast_action_masks=None
         )
 
         # Ensure correct precision (bfloat16/float32)
@@ -746,17 +753,18 @@ class PI0FastPytorch(nn.Module):  # see openpi `PI0Pytorch`
             adarms_cond=[None, None],
         )
 
-        # Sample the first action token from the last logit of the prefix
-        last_logits = lm_head(prefix_out[:, -1:, :])  # (B, 1, V)
-        if temperature > 0:
-            probs = torch.softmax(last_logits[:, -1] / temperature, dim=-1)
-            next_token = torch.multinomial(probs, num_samples=1)
-        else:
-            next_token = torch.argmax(last_logits[:, -1], dim=-1, keepdim=True)
-
-        # Initialize storage for generated tokens
-        generated_action_tokens = torch.zeros((bsize, max_decoding_steps), dtype=torch.long, device=device)
+        prediction_hidden = _gather_last_valid_language_hidden(prefix_out, masks, total_t_images)
+        next_token = _sample_next_token(lm_head(prediction_hidden), temperature)
         generated_action_tokens[:, 0] = next_token.squeeze(-1)
+        eos_token_id = self._paligemma_tokenizer.eos_token_id
+        finished = next_token.squeeze(-1).eq(eos_token_id)
+        if finished.all():
+            return generated_action_tokens
+        next_token = torch.where(
+            finished[:, None],
+            torch.full_like(next_token, eos_token_id),
+            next_token,
+        )
 
         # Track valid tokens mask (0 for pad, 1 for valid)
         # We need this to tell the new token what it can attend to (images + text + past actions)
@@ -797,15 +805,19 @@ class PI0FastPytorch(nn.Module):  # see openpi `PI0Pytorch`
                 adarms_cond=[None, None],
             )
 
-            # Sample next token
-            last_logits = lm_head(step_out[:, -1:, :])
-            if temperature > 0:
-                probs = torch.softmax(last_logits[:, -1] / temperature, dim=-1)
-                next_token = torch.multinomial(probs, num_samples=1)
-            else:
-                next_token = torch.argmax(last_logits[:, -1], dim=-1, keepdim=True)
-
-            generated_action_tokens[:, t] = next_token.squeeze(-1)
+            next_token = _sample_next_token(lm_head(step_out[:, -1]), temperature)
+            active = ~finished
+            generated_action_tokens[:, t] = torch.where(
+                active, next_token.squeeze(-1), torch.zeros_like(next_token.squeeze(-1))
+            )
+            finished |= active & next_token.squeeze(-1).eq(eos_token_id)
+            if finished.all():
+                break
+            next_token = torch.where(
+                finished[:, None],
+                torch.full_like(next_token, eos_token_id),
+                next_token,
+            )
 
         return generated_action_tokens
 
@@ -1118,7 +1130,7 @@ class PI0FastPolicy(PreTrainedPolicy):
         return self._paligemma_tokenizer.vocab_size - 1 - self.config.fast_skip_tokens - tokens
 
     def decode_actions_with_fast(
-        self, token_ids: list[int], time_horizon: int, action_dim: int, relaxed_decoding: bool = True
+        self, token_ids: list[Tensor], time_horizon: int, action_dim: int
     ) -> np.ndarray:
         """
         Decodes action token IDs back to continuous action values using the FAST tokenizer.
@@ -1127,8 +1139,6 @@ class PI0FastPolicy(PreTrainedPolicy):
             token_ids: List of token IDs to decode.
             time_horizon: The number of timesteps for actions.
             action_dim: The dimensionality of each action.
-            relaxed_decoding: Whether to use relaxed decoding (allows partial sequences).
-
         Returns:
             A numpy array representing the decoded actions.
         """
@@ -1136,40 +1146,23 @@ class PI0FastPolicy(PreTrainedPolicy):
 
         for token in token_ids:
             try:
-                decoded_tokens = self.action_tokenizer.bpe_tokenizer.decode(token)
-                decoded_dct_coeff = np.array(list(map(ord, decoded_tokens))) + self.action_tokenizer.min_token
-
-                if relaxed_decoding:
-                    # expected sequence length
-                    expected_seq_len = time_horizon * action_dim
-                    diff = expected_seq_len - decoded_dct_coeff.shape[0]
-
-                    # apply truncation if too long
-                    if diff < 0:
-                        decoded_dct_coeff = decoded_dct_coeff[:expected_seq_len]  # truncate on the right
-
-                    # apply padding if too short
-                    elif diff > 0:
-                        decoded_dct_coeff = np.pad(
-                            decoded_dct_coeff, (0, diff), mode="constant", constant_values=0
-                        )
-
-                decoded_dct_coeff = decoded_dct_coeff.reshape(-1, action_dim)
-                assert decoded_dct_coeff.shape == (
-                    time_horizon,
-                    action_dim,
-                ), (
-                    f"Decoded DCT coefficients have shape {decoded_dct_coeff.shape}, expected ({time_horizon}, {action_dim})"
+                expected_shape = (time_horizon, action_dim)
+                decoded_action = np.asarray(
+                    self.action_tokenizer.decode(
+                        [token.tolist()], time_horizon=time_horizon, action_dim=action_dim
+                    )[0],
+                    dtype=np.float32,
                 )
+                if decoded_action.shape != expected_shape:
+                    raise ValueError(
+                        f"decoded action shape {decoded_action.shape} does not match {expected_shape}"
+                    )
 
             except Exception as e:
-                logging.warning(f"Error decoding tokens: {e}")
-                logging.warning(f"Tokens: {token}")
-                decoded_dct_coeff = np.zeros((time_horizon, action_dim))
+                logging.warning("Invalid FAST action sequence; returning a zero action chunk: %s", e)
+                decoded_action = np.zeros((time_horizon, action_dim))
 
-            decoded_actions.append(
-                idct(decoded_dct_coeff / self.action_tokenizer.scale, axis=0, norm="ortho")
-            )
+            decoded_actions.append(decoded_action)
 
         return np.stack(decoded_actions)
 
@@ -1199,53 +1192,28 @@ class PI0FastPolicy(PreTrainedPolicy):
         if single_sample:
             tokens = tokens.unsqueeze(0)
 
-        # Convert token IDs to token strings
-        decoded_tokens = [self._paligemma_tokenizer.convert_ids_to_tokens(seq.tolist()) for seq in tokens]
-        # Get the token sequence for "Action: " to remove it
-        action_prefix_ids = self._paligemma_tokenizer.encode("Action: ", add_special_tokens=False)
-        action_prefix_tokens = self._paligemma_tokenizer.convert_ids_to_tokens(action_prefix_ids)
-        action_prefix_len = len(action_prefix_tokens)
-
-        # Clean tokens by removing everything after the first "|" (end-of-action marker)
-        # and removing all occurrences of "Action: " token sequence
-        # assert that beginning contain "Action: "
-        if self.config.validate_action_token_prefix:
-            for token_seq in decoded_tokens:
-                assert len(token_seq) >= 2 and token_seq[0] == "Action" and token_seq[1] == ":", (
-                    f"Token sequence does not start with ['Action', ':']: {token_seq}"
+        action_tokens = []
+        for token_sequence in tokens:
+            try:
+                token_ids = token_sequence.tolist()
+                eos_token_id = self._paligemma_tokenizer.eos_token_id
+                if eos_token_id in token_ids:
+                    token_ids = token_ids[: token_ids.index(eos_token_id) + 1]
+                decoded_text = self._paligemma_tokenizer.decode(token_ids)
+                if not decoded_text.startswith("Action: ") or "|" not in decoded_text:
+                    raise ValueError(f"expected 'Action: <codes>|', got {decoded_text!r}")
+                action_text = decoded_text.removeprefix("Action: ").split("|", maxsplit=1)[0]
+                raw_action_tokens = torch.tensor(
+                    self._paligemma_tokenizer.encode(action_text, add_special_tokens=False),
+                    dtype=torch.long,
+                    device=tokens.device,
                 )
-
-        cleaned_tokens = []
-        for token_seq in decoded_tokens:
-            # Remove everything after "|"
-            if "|" in token_seq:
-                token_seq = token_seq[: token_seq.index("|")]
-
-            # Remove all occurrences of "Action: " token sequence
-            i = 0
-            while i <= len(token_seq) - action_prefix_len:
-                if token_seq[i : i + action_prefix_len] == action_prefix_tokens:
-                    # Found a match, remove it
-                    token_seq = token_seq[:i] + token_seq[i + action_prefix_len :]
-                else:
-                    i += 1
-
-            cleaned_tokens.append(token_seq)
-
-        # Convert token strings back to IDs
-        raw_action_tokens = [
-            torch.tensor(
-                self._paligemma_tokenizer.convert_tokens_to_ids(token_seq),
-                dtype=torch.long,
-                device=tokens.device,
-            )
-            for token_seq in cleaned_tokens
-        ]
-
-        # Convert PaliGemma tokens to action tokens
-        action_tokens = [
-            self._paligemma_tokens_to_act_tokens(raw_action_token) for raw_action_token in raw_action_tokens
-        ]
+                if raw_action_tokens.numel() == 0:
+                    raise ValueError("empty FAST action payload")
+                action_tokens.append(self._paligemma_tokens_to_act_tokens(raw_action_tokens))
+            except Exception as e:
+                logging.warning("Invalid generated PI0-FAST text; returning zeros for this sample: %s", e)
+                action_tokens.append(torch.empty(0, dtype=torch.long, device=tokens.device))
 
         # Decode action tokens to continuous actions
         actions = self.decode_actions_with_fast(
@@ -1314,7 +1282,7 @@ class PI0FastPolicy(PreTrainedPolicy):
             )
 
         # Detokenize action tokens to continuous actions
-        action_horizon = self.config.n_action_steps
+        action_horizon = self.config.chunk_size
         action_dim = self.config.output_features[ACTION].shape[0]
 
         continuous_actions = self.detokenize_actions(

--- a/src/lerobot/policies/pi0_fast/processor_pi0_fast.py
+++ b/src/lerobot/policies/pi0_fast/processor_pi0_fast.py
@@ -79,7 +79,7 @@ class Pi0FastPrepareStateAndLanguageTokenizerProcessorStep(ProcessorStep):
 
         full_prompts = []
         for i, task in enumerate(tasks):
-            cleaned_text = task.strip().replace("_", " ").replace("\n", " ")
+            cleaned_text = task.strip().replace("_", " ").replace("\n", " ").lower()
             state_str = " ".join(map(str, discretized_states[i]))
             full_prompt = f"Task: {cleaned_text}, State: {state_str};\n"
             full_prompts.append(full_prompt)
@@ -164,6 +164,7 @@ def make_pi0_fast_pre_post_processors(
             max_action_tokens=config.max_action_tokens,
             fast_skip_tokens=config.fast_skip_tokens,
             paligemma_tokenizer_name=config.text_tokenizer_name,
+            prepend_bos=False,
         ),
         DeviceProcessorStep(device=config.device),
     ]

--- a/src/lerobot/processor/tokenizer_processor.py
+++ b/src/lerobot/processor/tokenizer_processor.py
@@ -349,6 +349,7 @@ class ActionTokenizerProcessorStep(ActionProcessorStep):
     max_action_tokens: int = 256
     fast_skip_tokens: int = 128
     paligemma_tokenizer_name: str = "google/paligemma-3b-pt-224"
+    prepend_bos: bool = True
     # Internal tokenizer instance (not part of the config)
     action_tokenizer: Any = field(default=None, init=False, repr=False)
     _paligemma_tokenizer: Any = field(default=None, init=False, repr=False)
@@ -476,11 +477,13 @@ class ActionTokenizerProcessorStep(ActionProcessorStep):
             if tokens.dim() > 1:
                 tokens = tokens.flatten()
 
-            bos_id = self._paligemma_tokenizer.bos_token_id
-            # add bos
-            tokens = torch.cat(
+            token_parts = []
+            if self.prepend_bos:
+                token_parts.append(
+                    torch.tensor([self._paligemma_tokenizer.bos_token_id], device=action.device)
+                )
+            token_parts.extend(
                 [
-                    torch.tensor([bos_id], device=action.device),
                     torch.tensor(
                         self._paligemma_tokenizer.encode("Action: ", add_special_tokens=False),
                         device=action.device,
@@ -489,6 +492,7 @@ class ActionTokenizerProcessorStep(ActionProcessorStep):
                     torch.tensor(self._paligemma_tokenizer.encode("|"), device=action.device),
                 ]
             )
+            tokens = torch.cat(token_parts)
 
             # Truncate or pad to max_action_tokens
             if len(tokens) > self.max_action_tokens:
@@ -550,6 +554,9 @@ class ActionTokenizerProcessorStep(ActionProcessorStep):
         config = {
             "trust_remote_code": self.trust_remote_code,
             "max_action_tokens": self.max_action_tokens,
+            "fast_skip_tokens": self.fast_skip_tokens,
+            "paligemma_tokenizer_name": self.paligemma_tokenizer_name,
+            "prepend_bos": self.prepend_bos,
         }
 
         # Only save tokenizer_name if it was used to create the tokenizer

--- a/tests/policies/pi0_fast/test_pi0_fast_original_vs_lerobot.py
+++ b/tests/policies/pi0_fast/test_pi0_fast_original_vs_lerobot.py
@@ -55,14 +55,7 @@ MODEL_PATH_LEROBOT = "lerobot/pi0fast-base"
 # Expected action token shape: (batch_size, max_decoding_steps)
 EXPECTED_ACTION_TOKENS_SHAPE = (1, 2)
 
-# Expected first 5 action tokens (for reproducibility check)
-EXPECTED_ACTION_TOKENS_FIRST_5 = torch.tensor([255020, 255589])
-
-# Expected actions after detokenization
 EXPECTED_ACTIONS_SHAPE = (1, 2, 32)  # (batch_size, n_action_steps, action_dim)
-EXPECTED_ACTIONS_MEAN = 0.046403881162405014
-EXPECTED_ACTIONS_STD = 0.2607129216194153
-EXPECTED_ACTIONS_FIRST_5 = torch.tensor([0.0000, 0.3536, 0.0707, 0.0000, 0.0000])
 
 
 @require_cuda
@@ -99,9 +92,8 @@ def instantiate_lerobot_pi0_fast(
             pretrained_name_or_path=model_path,
             strict=True,
         )
-        policy.config.validate_action_token_prefix = False
         policy.config.max_action_tokens = 2
-        policy.config.max_decoding_steps = 2
+        policy.config.max_decoding_steps = 256
         policy.config.chunk_size = 2
         policy.config.n_action_steps = 2
     else:
@@ -110,9 +102,8 @@ def instantiate_lerobot_pi0_fast(
             max_action_dim=DUMMY_ACTION_DIM,
             max_state_dim=DUMMY_STATE_DIM,
             device=DEVICE,
-            validate_action_token_prefix=False,
             max_action_tokens=2,
-            max_decoding_steps=2,
+            max_decoding_steps=256,
             chunk_size=2,
         )
         policy = PI0FastPolicy(config)
@@ -262,56 +253,11 @@ def test_pi0_fast_action_generation(policy, preprocessor):
     print(f"LeRobot actions std: {lerobot_actions.std().item():.6f}")
     print(f"LeRobot actions first 5: {lerobot_actions[0, 0, :5]}")
 
-    print("\nExpected values (from original PI0Fast):")
-    print(f"Expected actions shape: {EXPECTED_ACTIONS_SHAPE}")
-    print(f"Expected actions mean: {EXPECTED_ACTIONS_MEAN:.6f}")
-    print(f"Expected actions std: {EXPECTED_ACTIONS_STD:.6f}")
-    print(f"Expected actions first 5: {EXPECTED_ACTIONS_FIRST_5}")
-
-    print("\nAction Comparison:")
-    print("-" * 80)
-
-    # Compare shapes
     actual_shape = tuple(lerobot_actions.shape)
-    print(f"Actual shape: {actual_shape}")
-
     assert actual_shape == EXPECTED_ACTIONS_SHAPE, (
         f"Shape mismatch: {actual_shape} vs {EXPECTED_ACTIONS_SHAPE}"
     )
-    print(f"Shape matches: {actual_shape}")
-
-    # Compare statistics
-    actual_mean = lerobot_actions.mean().item()
-    actual_std = lerobot_actions.std().item()
-
-    print(f"\nMean: {actual_mean:.6f} (expected: {EXPECTED_ACTIONS_MEAN:.6f})")
-    print(f"Std: {actual_std:.6f} (expected: {EXPECTED_ACTIONS_STD:.6f})")
-
-    # Compare first 5 actions
-    actual_first_5 = lerobot_actions[0, 0, :5]
-    print("\nFirst 5 actions comparison:")
-    print(f"  Actual:   {actual_first_5}")
-    print(f"  Expected: {EXPECTED_ACTIONS_FIRST_5}")
-
-    first_5_diff = torch.abs(actual_first_5 - EXPECTED_ACTIONS_FIRST_5)
-    print(f"  Max diff: {first_5_diff.max().item():.6e}")
-    print(f"  Mean diff: {first_5_diff.mean().item():.6e}")
-
-    # Check with different tolerances
-    tolerances = [1e-5, 1e-4, 1e-3, 1e-2]
-    for tol in tolerances:
-        is_close = torch.allclose(actual_first_5, EXPECTED_ACTIONS_FIRST_5, atol=tol)
-        status = "Success" if is_close else "Failure"
-        print(f"{status}: First 5 actions close (atol={tol}): {is_close}")
-
-    # Assert with reasonable tolerance
-    tolerance = 1e-3
-    assert torch.allclose(actual_first_5, EXPECTED_ACTIONS_FIRST_5, atol=tolerance), (
-        f"First 5 actions differ by more than tolerance ({tolerance})"
-    )
-    print(f"\nSuccess: Actions match expected values within tolerance ({tolerance})!")
-
-    print("\nAction generation test completed (values printed for reference)!")
+    assert torch.isfinite(lerobot_actions).all()
 
 
 @require_cuda
@@ -442,10 +388,6 @@ def test_pi0_fast_action_token_sampling(policy, preprocessor):
     print(f"Action tokens shape: {action_tokens.shape}")
     print(f"Action tokens first 10: {action_tokens[0, :10].tolist()}")
 
-    print("\nExpected values (from original PI0Fast):")
-    print(f"Expected shape: {EXPECTED_ACTION_TOKENS_SHAPE}")
-    print(f"Expected first 5: {EXPECTED_ACTION_TOKENS_FIRST_5.tolist()}")
-
     # Verify shape
     actual_shape = tuple(action_tokens.shape)
     print(f"\nActual shape: {actual_shape}")
@@ -454,11 +396,8 @@ def test_pi0_fast_action_token_sampling(policy, preprocessor):
         f"Shape mismatch: {actual_shape} vs {EXPECTED_ACTION_TOKENS_SHAPE}"
     )
 
-    # Compare first 5 tokens
-    actual_first_5 = action_tokens[0, :5].cpu()
-    assert torch.equal(actual_first_5, EXPECTED_ACTION_TOKENS_FIRST_5), (
-        f"First 5 tokens mismatch: {actual_first_5} vs {EXPECTED_ACTION_TOKENS_FIRST_5}"
-    )
+    action_prefix = policy._paligemma_tokenizer.encode("Action: ", add_special_tokens=False)
+    assert action_tokens[0, : len(action_prefix)].tolist() == action_prefix
 
     print("\nAction token sampling test completed!")
 
@@ -500,19 +439,11 @@ def test_pi0_fast_detokenization(policy, preprocessor):
 
     # Detokenize
     print("\n[LeRobot] Detokenizing action tokens...")
-    action_horizon = policy.config.n_action_steps
+    action_horizon = policy.config.chunk_size
     action_dim = policy.config.output_features["action"].shape[0]
 
-    try:
-        continuous_actions = policy.detokenize_actions(
-            action_tokens, action_horizon=action_horizon, action_dim=action_dim
-        )
-        print(f"Continuous actions shape: {continuous_actions.shape}")
-        print(f"Continuous actions mean: {continuous_actions.mean().item():.6f}")
-        print(f"Continuous actions std: {continuous_actions.std().item():.6f}")
-        print(f"Continuous actions first 5: {continuous_actions[0, 0, :5]}")
-        print("\nDetokenization successful!")
-    except Exception as e:
-        print(f"\nDetokenization failed with error: {e}")
-        print("This may be expected if the action tokens are not valid FAST tokens.")
-        print("The test will pass as long as the sampling works correctly.")
+    continuous_actions = policy.detokenize_actions(
+        action_tokens, action_horizon=action_horizon, action_dim=action_dim
+    )
+    assert continuous_actions.shape == (1, action_horizon, action_dim)
+    assert torch.isfinite(continuous_actions).all()

--- a/tests/policies/pi0_fast/test_pi0_fast_parity.py
+++ b/tests/policies/pi0_fast/test_pi0_fast_parity.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+from torch import nn
+
+pytest.importorskip("transformers")
+pytest.importorskip("scipy")
+
+from lerobot.configs import NormalizationMode  # noqa: E402
+from lerobot.policies.pi0_fast.configuration_pi0_fast import PI0FastConfig  # noqa: E402
+from lerobot.policies.pi0_fast.modeling_pi0_fast import (  # noqa: E402
+    PI0FastPytorch,
+    PI0FastPolicy,
+    _gather_last_valid_language_hidden,
+    _reduce_fast_token_loss,
+)
+from lerobot.policies.pi0_fast.processor_pi0_fast import (  # noqa: E402
+    Pi0FastPrepareStateAndLanguageTokenizerProcessorStep,
+)
+from lerobot.processor.tokenizer_processor import ActionTokenizerProcessorStep  # noqa: E402
+from lerobot.types import TransitionKey  # noqa: E402
+from lerobot.utils.constants import OBS_LANGUAGE_ATTENTION_MASK, OBS_LANGUAGE_TOKENS  # noqa: E402
+
+
+class _FakePaliGemmaTokenizer:
+    vocab_size = 1000
+    bos_token_id = 2
+    eos_token_id = 1
+
+    def encode(self, text, add_special_tokens=True):
+        if text == "Action: ":
+            return [10, 11]
+        if text == "|":
+            return [12, self.eos_token_id] if add_special_tokens else [12]
+        return [900, 901]
+
+
+def test_pi0_fast_uses_openpi_quantile_normalization_by_default():
+    config = PI0FastConfig()
+
+    assert config.normalization_mapping == {
+        "VISUAL": NormalizationMode.IDENTITY,
+        "STATE": NormalizationMode.QUANTILES,
+        "ACTION": NormalizationMode.QUANTILES,
+    }
+
+
+def test_pi0_fast_action_tokens_have_no_second_bos():
+    step = ActionTokenizerProcessorStep.__new__(ActionTokenizerProcessorStep)
+    step.max_action_tokens = 8
+    step.fast_skip_tokens = 128
+    step.prepend_bos = False
+    step.action_tokenizer = lambda _: torch.tensor([4, 9])
+    step._paligemma_tokenizer = _FakePaliGemmaTokenizer()
+
+    tokens, mask = step._tokenize_action(torch.zeros(1, 2, 1))
+
+    mapped = [1000 - 1 - 128 - token for token in (4, 9)]
+    assert tokens[0, :6].tolist() == [10, 11, *mapped, 12, 1]
+    assert _FakePaliGemmaTokenizer.bos_token_id not in tokens[0, mask[0]].tolist()
+
+
+def test_action_tokenizer_serializes_bos_layout():
+    step = ActionTokenizerProcessorStep.__new__(ActionTokenizerProcessorStep)
+    step.trust_remote_code = True
+    step.max_action_tokens = 8
+    step.fast_skip_tokens = 128
+    step.paligemma_tokenizer_name = "paligemma"
+    step.prepend_bos = False
+    step.action_tokenizer_name = "fast"
+    step.action_tokenizer_input_object = None
+
+    assert step.get_config() == {
+        "trust_remote_code": True,
+        "max_action_tokens": 8,
+        "fast_skip_tokens": 128,
+        "paligemma_tokenizer_name": "paligemma",
+        "prepend_bos": False,
+        "action_tokenizer_name": "fast",
+    }
+
+
+def test_pi0_fast_prompt_canonicalizes_task_to_lowercase():
+    step = Pi0FastPrepareStateAndLanguageTokenizerProcessorStep()
+    transition = {
+        TransitionKey.OBSERVATION: {"observation.state": torch.zeros(1, 2)},
+        TransitionKey.COMPLEMENTARY_DATA: {"task": ["  Pick_UP\nCube  "]},
+    }
+
+    result = step(transition)
+
+    assert result[TransitionKey.COMPLEMENTARY_DATA]["task"] == ["Task: pick up cube, State: 128 128;\n"]
+
+
+def test_last_language_hidden_uses_attention_mask_not_padding():
+    hidden = torch.arange(2 * 7, dtype=torch.float32).reshape(2, 7, 1)
+    language_mask = torch.tensor([[True, True, False, False], [True, True, True, False]])
+
+    gathered = _gather_last_valid_language_hidden(hidden, language_mask, image_token_count=3)
+
+    assert gathered[:, 0].tolist() == [hidden[0, 4, 0].item(), hidden[1, 5, 0].item()]
+
+
+def test_fast_ce_averages_each_sample_before_the_batch():
+    token_loss = torch.tensor([[2.0, 99.0, 99.0], [6.0, 6.0, 6.0]])
+    mask = torch.tensor([[True, False, False], [True, True, True]])
+
+    loss = _reduce_fast_token_loss(token_loss, mask)
+
+    assert loss.item() == pytest.approx(4.0)
+
+
+class _TokenFromHiddenHead(nn.Module):
+    def forward(self, hidden):
+        logits = torch.full((*hidden.shape[:-1], 10), -100.0)
+        logits.scatter_(-1, hidden.long(), 100.0)
+        return logits
+
+
+class _ScriptedPaliGemma:
+    def __init__(self):
+        q_proj = SimpleNamespace(weight=torch.empty(1))
+        language_model = SimpleNamespace(
+            layers=[SimpleNamespace(self_attn=SimpleNamespace(q_proj=q_proj))]
+        )
+        self.paligemma = SimpleNamespace(
+            lm_head=_TokenFromHiddenHead(),
+            model=SimpleNamespace(language_model=language_model),
+        )
+        self.calls = 0
+
+    def forward(self, inputs_embeds, **_kwargs):
+        scripted_tokens = ([5, 6], [1, 7], [9, 1])
+        token_ids = torch.tensor(scripted_tokens[self.calls], dtype=torch.float32)
+        self.calls += 1
+        hidden = token_ids[:, None, None].expand(-1, inputs_embeds[0].shape[1], -1).clone()
+        return (hidden, None), object()
+
+    @staticmethod
+    def embed_language_tokens(tokens):
+        return tokens.to(dtype=torch.float32).unsqueeze(-1)
+
+
+def _make_scripted_generation_model(captured):
+    model = PI0FastPytorch.__new__(PI0FastPytorch)
+    nn.Module.__init__(model)
+    model.config = SimpleNamespace(max_action_tokens=4)
+    model._paligemma_tokenizer = SimpleNamespace(eos_token_id=1)
+    model.paligemma_with_expert = _ScriptedPaliGemma()
+    model._prepare_attention_masks_4d = lambda masks, dtype: masks
+
+    def embed_prefix(_images, _img_masks, tokens, masks, **_kwargs):
+        captured.append(tokens.clone())
+        image_masks = torch.ones(tokens.shape[0], 1, dtype=torch.bool)
+        pad_masks = torch.cat([image_masks, masks], dim=1)
+        embeddings = torch.zeros(tokens.shape[0], pad_masks.shape[1], 1)
+        attention = torch.ones(tokens.shape[0], pad_masks.shape[1], pad_masks.shape[1], dtype=torch.bool)
+        return embeddings, pad_masks, attention, 1, 0
+
+    model.embed_prefix_fast = embed_prefix
+    return model
+
+
+@pytest.mark.parametrize("sampler_name", ["sample_actions_fast", "sample_actions_fast_kv_cache"])
+def test_fast_generators_stop_each_sample_at_eos_without_boundary_bos(sampler_name):
+    captured = []
+    model = _make_scripted_generation_model(captured)
+    tokens = torch.tensor([[2, 3, 0, 0], [2, 3, 4, 0]])
+    masks = torch.tensor([[True, True, False, False], [True, True, True, False]])
+
+    generated = getattr(model, sampler_name)(
+        [], [], tokens, masks, max_decoding_steps=4, temperature=0.0
+    )
+
+    assert torch.equal(generated, torch.tensor([[5, 1, 0, 0], [6, 7, 1, 0]]))
+    assert torch.equal(captured[0], tokens)
+
+
+def test_predict_action_chunk_decodes_full_chunk(monkeypatch):
+    policy = PI0FastPolicy.__new__(PI0FastPolicy)
+    nn.Module.__init__(policy)
+    policy.config = SimpleNamespace(
+        chunk_size=8,
+        n_action_steps=3,
+        output_features={"action": SimpleNamespace(shape=(4,))},
+        temperature=0.0,
+        max_decoding_steps=16,
+        use_kv_cache=False,
+    )
+    policy.model = SimpleNamespace(
+        sample_actions_fast=lambda *args, **kwargs: torch.ones(1, 4, dtype=torch.long)
+    )
+    monkeypatch.setattr(policy, "_preprocess_images", lambda batch: ([], []))
+    captured = {}
+
+    def detokenize(tokens, action_horizon, action_dim):
+        captured["shape"] = (action_horizon, action_dim)
+        return torch.zeros(1, action_horizon, action_dim)
+
+    monkeypatch.setattr(policy, "detokenize_actions", detokenize)
+    batch = {
+        OBS_LANGUAGE_TOKENS: torch.ones(1, 2, dtype=torch.long),
+        OBS_LANGUAGE_ATTENTION_MASK: torch.ones(1, 2, dtype=torch.bool),
+    }
+
+    actions = policy.predict_action_chunk(batch)
+
+    assert captured["shape"] == (8, 4)
+    assert actions.shape == (1, 8, 4)
+
+
+class _FakeActionTokenizer:
+    @staticmethod
+    def decode(tokens, time_horizon, action_dim):
+        if tokens != [[-119]]:
+            raise ValueError("invalid FAST token")
+        return [np.arange(time_horizon * action_dim).reshape(time_horizon, action_dim)]
+
+
+class _FakeDecodeTokenizer(_FakePaliGemmaTokenizer):
+    decoded_text = ""
+
+    def decode(self, _tokens):
+        return self.decoded_text
+
+    def encode(self, text, add_special_tokens=True):
+        if text == "codes":
+            return [990]
+        return super().encode(text, add_special_tokens=add_special_tokens)
+
+
+@pytest.mark.parametrize("decoded_text", ["", "not an action", "Action: bad"])
+def test_malformed_fast_generation_returns_zero_actions(decoded_text):
+    policy = PI0FastPolicy.__new__(PI0FastPolicy)
+    nn.Module.__init__(policy)
+    tokenizer = _FakeDecodeTokenizer()
+    tokenizer.decoded_text = decoded_text
+    policy._paligemma_tokenizer = tokenizer
+    policy.action_tokenizer = _FakeActionTokenizer()
+    policy.config = SimpleNamespace(fast_skip_tokens=128)
+
+    actions = policy.detokenize_actions(torch.tensor([[7, 1, 0]]), action_horizon=2, action_dim=2)
+
+    assert actions.shape == (1, 2, 2)
+    assert torch.equal(actions, torch.zeros_like(actions))
+
+
+def test_valid_fast_generation_decodes_exact_shape():
+    policy = PI0FastPolicy.__new__(PI0FastPolicy)
+    nn.Module.__init__(policy)
+    tokenizer = _FakeDecodeTokenizer()
+    tokenizer.decoded_text = "Action: codes|"
+    policy._paligemma_tokenizer = tokenizer
+    policy.action_tokenizer = _FakeActionTokenizer()
+    policy.config = SimpleNamespace(fast_skip_tokens=128)
+
+    actions = policy.detokenize_actions(torch.tensor([[7, 1, 0]]), action_horizon=2, action_dim=2)
+
+    assert actions.shape == (1, 2, 2)
+    assert np.isfinite(actions.numpy()).all()

--- a/tests/policies/pi0_fast/test_pi0_fast_parity.py
+++ b/tests/policies/pi0_fast/test_pi0_fast_parity.py
@@ -18,8 +18,8 @@ pytest.importorskip("scipy")
 from lerobot.configs import NormalizationMode  # noqa: E402
 from lerobot.policies.pi0_fast.configuration_pi0_fast import PI0FastConfig  # noqa: E402
 from lerobot.policies.pi0_fast.modeling_pi0_fast import (  # noqa: E402
-    PI0FastPytorch,
     PI0FastPolicy,
+    PI0FastPytorch,
     _gather_last_valid_language_hidden,
     _reduce_fast_token_loss,
 )
@@ -129,9 +129,7 @@ class _TokenFromHiddenHead(nn.Module):
 class _ScriptedPaliGemma:
     def __init__(self):
         q_proj = SimpleNamespace(weight=torch.empty(1))
-        language_model = SimpleNamespace(
-            layers=[SimpleNamespace(self_attn=SimpleNamespace(q_proj=q_proj))]
-        )
+        language_model = SimpleNamespace(layers=[SimpleNamespace(self_attn=SimpleNamespace(q_proj=q_proj))])
         self.paligemma = SimpleNamespace(
             lm_head=_TokenFromHiddenHead(),
             model=SimpleNamespace(language_model=language_model),
@@ -177,9 +175,7 @@ def test_fast_generators_stop_each_sample_at_eos_without_boundary_bos(sampler_na
     tokens = torch.tensor([[2, 3, 0, 0], [2, 3, 4, 0]])
     masks = torch.tensor([[True, True, False, False], [True, True, True, False]])
 
-    generated = getattr(model, sampler_name)(
-        [], [], tokens, masks, max_decoding_steps=4, temperature=0.0
-    )
+    generated = getattr(model, sampler_name)([], [], tokens, masks, max_decoding_steps=4, temperature=0.0)
 
     assert torch.equal(generated, torch.tensor([[5, 1, 0, 0], [6, 7, 1, 0]]))
     assert torch.equal(captured[0], tokens)


### PR DESCRIPTION
## Summary
- align PI0-FAST quantile normalization, lowercase prompts, and single-BOS `Action: <codes>|<EOS>` token layout with OpenPI
- train the first action token from each sample's last valid prompt token, balance CE per sample, and decode the full action chunk with EOS-aware full/KV-cache generation
- strictly decode malformed FAST output to zero chunks and add focused parity regression coverage

## Test plan
- [x] `python -m pytest tests/policies/pi0_fast/test_pi0_fast_parity.py -q` (13 passed)
- [x] `python -m pytest tests/processor/test_tokenizer_processor.py -q` (52 passed, 6 skipped)
- [x] `python -m pytest tests/policies/pi0_fast/test_pi0_fast_original_vs_lerobot.py -q` (6 skipped; requires CUDA and an HF token)
- [x] `PRE_COMMIT_HOME=/tmp/precommit-pi0fast-ci pre-commit run --all-files`
- [x] reviewed behavior against OpenPI commit `15a9616a00943ada6c20a0f158e3adb39df2ccac`