### PR TITLE
feat(smolvla): add MEM visual memory

### DIFF
--- a/docs/source/multi_gpu_training.mdx
+++ b/docs/source/multi_gpu_training.mdx
@@ -113,6 +113,19 @@ accelerate launch --num_processes=2 $(which lerobot-train) \
   --policy.type=act
 ```
 
+When the desired global batch is larger than the per-GPU batch that fits in memory, use gradient
+accumulation. `steps` continues to count optimizer updates:
+
+```bash
+# 8 samples/GPU × 4 GPUs × 2 microbatches = effective global batch 64.
+accelerate launch --num_processes=4 $(which lerobot-train) \
+  --batch_size=8 \
+  --gradient_accumulation_steps=2 \
+  --steps=80000 \
+  --dataset.repo_id=lerobot/pusht \
+  --policy.type=act
+```
+
 ## Training Large Models with FSDP
 
 DDP replicates the full model on every GPU, so a model that doesn't fit on one GPU won't fit under

--- a/docs/source/robomme.mdx
+++ b/docs/source/robomme.mdx
@@ -44,6 +44,18 @@ docker build -f docker/Dockerfile.benchmark.robomme -t lerobot-robomme .
 
 The `docker/Dockerfile.benchmark.robomme` image overrides `gymnasium==0.29.1` and `numpy==1.26.4` after lerobot's install. Both versions are runtime-safe for lerobot's actual API usage.
 
+When evaluating a checkpoint saved on the host, run the container with the host UID. Checkpoint weights are intentionally private by default (`0600`), so the image's built-in user cannot otherwise read a bind-mounted `model.safetensors` file. Mount the Hugging Face cache at an accessible path as well:
+
+```bash
+docker run --gpus all --rm --ipc=host \
+  --user "$(id -u):$(id -g)" \
+  -e HF_HOME=/tmp/hf-cache \
+  -v "$HOME/.cache/huggingface:/tmp/hf-cache:ro" \
+  -v "$PWD/outputs:/results" \
+  lerobot-robomme \
+  lerobot-eval --policy.path=/results/<checkpoint>/pretrained_model # ...
+```
+
 ## Running Evaluation
 
 ### Default (single task, single episode)

--- a/docs/source/robomme.mdx
+++ b/docs/source/robomme.mdx
@@ -145,6 +145,26 @@ execution boundary while preserving earlier frames for temporal observation delt
 training split this keeps 476,857 execution targets out of 768,897 total frames. One execution-target
 epoch therefore takes `ceil(476857 / effective_batch_size)` optimizer steps.
 
+For a sample-matched SmolVLA visual-memory ablation, use
+`examples/robomme/smolvla_visual_memory_ablation.sh`. `TARGET_SAMPLES` counts examples across all
+GPUs, and `NUM_PROCESSES` is included when the script converts that target into optimizer steps. For
+example, the following reproduces 5.12 million example exposures (the exposure of RoboMME's
+80,000-step, global-batch-64 memory-policy recipe) with four GPUs and a global batch of 48:
+
+```bash
+TARGET_SAMPLES=5120000 \
+NUM_PROCESSES=4 \
+BATCH_SIZE=12 \
+VARIANT=visual-memory \
+RUN_EVAL=false \
+bash examples/robomme/smolvla_visual_memory_ablation.sh
+```
+
+This becomes 106,667 optimizer steps, or about 10.74 execution-target epochs. Run the baseline with
+the same `TARGET_SAMPLES`, effective batch size, seed, and scheduler settings to isolate the visual
+memory change. RoboMME's released baseline uses a different global batch (128), so its nominal
+80,000-step recipe is not sample-matched to its global-batch-64 memory recipe.
+
 At evaluation time the environment wrapper has already converted observations to canonical keys. Only the two camera suffixes need to be aligned with the checkpoint:
 
 ```bash

--- a/docs/source/robomme.mdx
+++ b/docs/source/robomme.mdx
@@ -61,7 +61,7 @@ lerobot-eval \
 
 ### Multi-task evaluation
 
-Evaluate multiple tasks in one run by comma-separating task names. Use `task_ids` to control which episodes are evaluated per task. Recommended: 50 episodes per task for the test split.
+Evaluate multiple tasks in one run by comma-separating task names. Use `task_ids` to select the dataset-backed episodes evaluated for every task. For the standard 50-episode test protocol, select IDs 0 through 49 and run each selected episode once.
 
 ```bash
 lerobot-eval \
@@ -69,20 +69,22 @@ lerobot-eval \
     --env.type=robomme \
     --env.task=PickXtimes,BinFill,StopCube,MoveCube,InsertPeg \
     --env.dataset_split=test \
-    --env.task_ids=[0,1,2,3,4,5,6,7,8,9] \
+    --env.task_ids=[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49] \
     --eval.batch_size=1 \
-    --eval.n_episodes=50
+    --eval.n_episodes=1
 ```
 
 ### Key CLI options for `env.type=robomme`
 
-| Option               | Default       | Description                                        |
-| -------------------- | ------------- | -------------------------------------------------- |
-| `env.task`           | `PickXtimes`  | Any of the 16 task names above (comma-separated)   |
-| `env.dataset_split`  | `test`        | `train`, `val`, or `test`                          |
-| `env.action_space`   | `joint_angle` | `joint_angle` (8-D) or `ee_pose` (7-D)             |
-| `env.episode_length` | `300`         | Max steps per episode                              |
-| `env.task_ids`       | `null`        | List of episode indices to evaluate (null = `[0]`) |
+| Option               | Default       | Description                                      |
+| -------------------- | ------------- | ------------------------------------------------ |
+| `env.task`           | `PickXtimes`  | Any of the 16 task names above (comma-separated) |
+| `env.dataset_split`  | `test`        | `train`, `val`, or `test`                        |
+| `env.action_space`   | `joint_angle` | `joint_angle` (8-D) or `ee_pose` (7-D)           |
+| `env.episode_length` | `300`         | Max steps per episode                            |
+| `env.task_ids`       | `null`        | Dataset episode indices (null = `[0]`)           |
+
+`eval.n_episodes` repeats each selected `task_id`; it does not advance to the next dataset episode. Keep it at `1` when enumerating the 50 distinct test episodes with `env.task_ids`.
 
 ## Dataset
 

--- a/docs/source/robomme.mdx
+++ b/docs/source/robomme.mdx
@@ -110,16 +110,18 @@ dataset = LeRobotDataset("lerobot/robomme")
 
 ### Dataset features
 
-| Feature            | Shape         | Description                     |
-| ------------------ | ------------- | ------------------------------- |
-| `image`            | (256, 256, 3) | Front camera RGB                |
-| `wrist_image`      | (256, 256, 3) | Wrist camera RGB                |
-| `actions`          | (8,)          | Joint angles + gripper          |
-| `state`            | (8,)          | Joint positions + gripper state |
-| `simple_subgoal`   | str           | High-level language annotation  |
-| `grounded_subgoal` | str           | Grounded language annotation    |
-| `episode_index`    | int           | Episode ID                      |
-| `frame_index`      | int           | Frame within episode            |
+| Feature            | Shape         | Description                      |
+| ------------------ | ------------- | -------------------------------- |
+| `image`            | (256, 256, 3) | Front camera RGB                 |
+| `wrist_image`      | (256, 256, 3) | Wrist camera RGB                 |
+| `actions`          | (8,)          | Joint angles + gripper           |
+| `state`            | (8,)          | Joint positions + gripper state  |
+| `simple_subgoal`   | str           | High-level language annotation   |
+| `grounded_subgoal` | str           | Grounded language annotation     |
+| `exec_start_idx`   | scalar        | First action-execution frame     |
+| `is_demo`          | bool          | Video-demonstration prefix frame |
+| `episode_index`    | int           | Episode ID                       |
+| `frame_index`      | int           | Frame within episode             |
 
 ### Feature key alignment (training)
 
@@ -132,8 +134,16 @@ uv run lerobot-train \
   --policy.path=lerobot/smolvla_base \
   --policy.empty_cameras=1 \
   --dataset.repo_id=lerobot/robomme \
+  --dataset.training_target_start_feature=exec_start_idx \
   '--rename_map={"image":"observation.images.camera1","wrist_image":"observation.images.camera2","state":"observation.state","actions":"action"}'
 ```
+
+RoboMME episodes begin with video-demonstration/context frames that should remain available to a
+memory policy but should not be sampled as action-training targets. Setting
+`dataset.training_target_start_feature=exec_start_idx` starts target sampling at each episode's
+execution boundary while preserving earlier frames for temporal observation deltas. In the published
+training split this keeps 476,857 execution targets out of 768,897 total frames. One execution-target
+epoch therefore takes `ceil(476857 / effective_batch_size)` optimizer steps.
 
 At evaluation time the environment wrapper has already converted observations to canonical keys. Only the two camera suffixes need to be aligned with the checkpoint:
 

--- a/docs/source/robomme.mdx
+++ b/docs/source/robomme.mdx
@@ -149,18 +149,20 @@ For a sample-matched SmolVLA visual-memory ablation, use
 `examples/robomme/smolvla_visual_memory_ablation.sh`. `TARGET_SAMPLES` counts examples across all
 GPUs, and `NUM_PROCESSES` is included when the script converts that target into optimizer steps. For
 example, the following reproduces 5.12 million example exposures (the exposure of RoboMME's
-80,000-step, global-batch-64 memory-policy recipe) with four GPUs and a global batch of 48:
+80,000-step, global-batch-64 memory-policy recipe) with four GPUs, two accumulated microbatches,
+and an effective global batch of 64:
 
 ```bash
 TARGET_SAMPLES=5120000 \
 NUM_PROCESSES=4 \
-BATCH_SIZE=12 \
+BATCH_SIZE=8 \
+GRADIENT_ACCUMULATION_STEPS=2 \
 VARIANT=visual-memory \
 RUN_EVAL=false \
 bash examples/robomme/smolvla_visual_memory_ablation.sh
 ```
 
-This becomes 106,667 optimizer steps, or about 10.74 execution-target epochs. Run the baseline with
+This becomes 80,000 optimizer steps, or about 10.74 execution-target epochs. Run the baseline with
 the same `TARGET_SAMPLES`, effective batch size, seed, and scheduler settings to isolate the visual
 memory change. RoboMME's released baseline uses a different global batch (128), so its nominal
 80,000-step recipe is not sample-matched to its global-batch-64 memory recipe.

--- a/docs/source/robomme.mdx
+++ b/docs/source/robomme.mdx
@@ -111,7 +111,21 @@ dataset = LeRobotDataset("lerobot/robomme")
 
 The env wrapper exposes `pixels/image` and `pixels/wrist_image` as observation keys. The `features_map` in `RoboMMEEnv` maps these to `observation.images.image` and `observation.images.wrist_image` for the policy. State is exposed as `agent_pos` and maps to `observation.state`.
 
-The dataset's `image` and `wrist_image` columns already align with the policy input keys, so no renaming is needed when fine-tuning.
+The published dataset uses the raw keys shown above. Policies that expect canonical LeRobot keys should map them at training time. For example, the pretrained SmolVLA checkpoint expects three cameras, while RoboMME provides two:
+
+```bash
+uv run lerobot-train \
+  --policy.path=lerobot/smolvla_base \
+  --policy.empty_cameras=1 \
+  --dataset.repo_id=lerobot/robomme \
+  '--rename_map={"image":"observation.images.camera1","wrist_image":"observation.images.camera2","state":"observation.state","actions":"action"}'
+```
+
+At evaluation time the environment wrapper has already converted observations to canonical keys. Only the two camera suffixes need to be aligned with the checkpoint:
+
+```bash
+'--rename_map={"observation.images.image":"observation.images.camera1","observation.images.wrist_image":"observation.images.camera2"}'
+```
 
 ## Action Spaces
 

--- a/docs/source/smolvla.mdx
+++ b/docs/source/smolvla.mdx
@@ -76,6 +76,37 @@ Fine-tuning is an art. For a complete overview of the options for finetuning, ru
 lerobot-train --help
 ```
 
+### Experimental MEM visual memory
+
+SmolVLA can optionally fuse a short history of camera frames using the
+space-time separable vision encoder from [MEM](https://arxiv.org/abs/2603.03596).
+Every fourth SigLIP layer adds causal attention across time for matching image
+patches. Historical tokens are discarded inside the vision tower, so the VLM
+receives the same number of image tokens as the baseline policy.
+
+The option is disabled by default. The following example uses six observations
+spaced one second apart for a 10 fps dataset:
+
+```bash
+lerobot-train \
+  --policy.path=lerobot/smolvla_base \
+  --policy.use_visual_memory=true \
+  --policy.visual_memory_frames=6 \
+  --policy.visual_memory_stride=10 \
+  --policy.visual_memory_temporal_attention_every=4 \
+  --policy.freeze_vision_encoder=false \
+  --policy.train_expert_only=false \
+  --dataset.repo_id=${HF_USER}/mydataset \
+  --output_dir=outputs/train/my_smolvla_mem
+```
+
+`visual_memory_stride` is measured in dataset or environment steps. Keep all
+other settings and the random seed fixed when comparing against a baseline.
+Because the public SmolVLA checkpoint was not pretrained with this temporal
+attention pattern, this is a post-training-only MEM ablation; the MEM paper
+reports that memory-aware pretraining performs better than introducing visual
+memory only during task-specific fine-tuning.
+
 <p align="center">
   <img
     src="https://cdn-uploads.huggingface.co/production/uploads/640e21ef3c82bd463ee5a76d/S-3vvVCulChREwHDkquoc.gif"

--- a/examples/robomme/smolvla_visual_memory_ablation.sh
+++ b/examples/robomme/smolvla_visual_memory_ablation.sh
@@ -58,7 +58,7 @@ if [[ "${RUN_EVAL}" == "true" ]]; then
       --env.task_ids="${TASK_IDS}" \
       '--rename_map={"observation.images.image":"observation.images.camera1","observation.images.wrist_image":"observation.images.camera2"}' \
       --eval.batch_size=1 \
-      --eval.n_episodes=50 \
+      --eval.n_episodes=1 \
       --seed="${SEED}" \
       --output_dir="${OUTPUT_ROOT}/eval-${variant}"
   done

--- a/examples/robomme/smolvla_visual_memory_ablation.sh
+++ b/examples/robomme/smolvla_visual_memory_ablation.sh
@@ -76,9 +76,14 @@ for variant in ("baseline", "visual-memory"):
         continue
     with result_path.open() as handle:
         info = json.load(handle)
-    overall = info["aggregated"]
+    overall = info["overall"]
     print(
         f"{variant}: success={overall['pc_success']:.2f}% "
         f"avg_reward={overall['avg_sum_reward']:.4f}"
     )
+    for task, metrics in info["per_group"].items():
+        print(
+            f"  {task}: success={metrics['pc_success']:.2f}% "
+            f"avg_reward={metrics['avg_sum_reward']:.4f}"
+        )
 PY

--- a/examples/robomme/smolvla_visual_memory_ablation.sh
+++ b/examples/robomme/smolvla_visual_memory_ablation.sh
@@ -5,17 +5,47 @@
 set -euo pipefail
 
 BATCH_SIZE="${BATCH_SIZE:-4}"
+NUM_PROCESSES="${NUM_PROCESSES:-1}"
 # The published training split has 476,857 execution frames. By default, train on one
 # execution-frame epoch; set STEPS explicitly to use a different optimizer-step budget.
 TARGET_SAMPLES="${TARGET_SAMPLES:-476857}"
-STEPS="${STEPS:-$(((TARGET_SAMPLES + BATCH_SIZE - 1) / BATCH_SIZE))}"
+EFFECTIVE_BATCH_SIZE=$((BATCH_SIZE * NUM_PROCESSES))
+STEPS="${STEPS:-$(((TARGET_SAMPLES + EFFECTIVE_BATCH_SIZE - 1) / EFFECTIVE_BATCH_SIZE))}"
+SCHEDULER_WARMUP_STEPS="${SCHEDULER_WARMUP_STEPS:-$(((STEPS + 29) / 30))}"
+SCHEDULER_DECAY_STEPS="${SCHEDULER_DECAY_STEPS:-${STEPS}}"
 SEED="${SEED:-1000}"
 OUTPUT_ROOT="${OUTPUT_ROOT:-outputs/robomme-smolvla-mem-ablation}"
 WANDB_ENABLE="${WANDB_ENABLE:-false}"
 RUN_TRAIN="${RUN_TRAIN:-true}"
 RUN_EVAL="${RUN_EVAL:-true}"
+VARIANT="${VARIANT:-both}"
 TASKS="BinFill,PickXtimes,SwingXtimes,StopCube,VideoUnmask,VideoUnmaskSwap,ButtonUnmask,ButtonUnmaskSwap,PickHighlight,VideoRepick,VideoPlaceButton,VideoPlaceOrder,MoveCube,InsertPeg,PatternLock,RouteStick"
 TASK_IDS="[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49]"
+
+case "${VARIANT}" in
+  baseline) VARIANTS=(baseline) ;;
+  visual-memory) VARIANTS=(visual-memory) ;;
+  both) VARIANTS=(baseline visual-memory) ;;
+  *) echo "VARIANT must be baseline, visual-memory, or both" >&2; exit 2 ;;
+esac
+
+TRAIN_COMMAND=()
+if [[ "${RUN_TRAIN}" == "true" ]]; then
+  if ((NUM_PROCESSES > 1)); then
+    TRAIN_ENTRYPOINT="$(uv run which lerobot-train)"
+    TRAIN_COMMAND=(
+      uv run accelerate launch
+      --multi_gpu
+      --num_processes="${NUM_PROCESSES}"
+      --mixed_precision=bf16
+      "${TRAIN_ENTRYPOINT}"
+    )
+  else
+    TRAIN_COMMAND=(uv run lerobot-train)
+  fi
+fi
+
+echo "Training ${VARIANT}: ${TARGET_SAMPLES} target samples, global batch ${EFFECTIVE_BATCH_SIZE}, ${STEPS} optimizer steps"
 
 COMMON_TRAIN_ARGS=(
   --policy.path=lerobot/smolvla_base
@@ -29,6 +59,8 @@ COMMON_TRAIN_ARGS=(
   '--rename_map={"image":"observation.images.camera1","wrist_image":"observation.images.camera2","state":"observation.state","actions":"action"}'
   --batch_size="${BATCH_SIZE}"
   --steps="${STEPS}"
+  --policy.scheduler_warmup_steps="${SCHEDULER_WARMUP_STEPS}"
+  --policy.scheduler_decay_steps="${SCHEDULER_DECAY_STEPS}"
   --seed="${SEED}"
   --env_eval_freq=0
   --save_freq=5000
@@ -36,24 +68,26 @@ COMMON_TRAIN_ARGS=(
 )
 
 if [[ "${RUN_TRAIN}" == "true" ]]; then
-  uv run lerobot-train \
-    "${COMMON_TRAIN_ARGS[@]}" \
-    --policy.use_visual_memory=false \
-    --output_dir="${OUTPUT_ROOT}/baseline" \
-    --job_name=robomme-smolvla-baseline
-
-  uv run lerobot-train \
-    "${COMMON_TRAIN_ARGS[@]}" \
-    --policy.use_visual_memory=true \
-    --policy.visual_memory_frames=6 \
-    --policy.visual_memory_stride=10 \
-    --policy.visual_memory_temporal_attention_every=4 \
-    --output_dir="${OUTPUT_ROOT}/visual-memory" \
-    --job_name=robomme-smolvla-visual-memory
+  for variant in "${VARIANTS[@]}"; do
+    MEMORY_ARGS=(--policy.use_visual_memory=false)
+    if [[ "${variant}" == "visual-memory" ]]; then
+      MEMORY_ARGS=(
+        --policy.use_visual_memory=true
+        --policy.visual_memory_frames=6
+        --policy.visual_memory_stride=10
+        --policy.visual_memory_temporal_attention_every=4
+      )
+    fi
+    "${TRAIN_COMMAND[@]}" \
+      "${COMMON_TRAIN_ARGS[@]}" \
+      "${MEMORY_ARGS[@]}" \
+      --output_dir="${OUTPUT_ROOT}/${variant}" \
+      --job_name="robomme-smolvla-${variant}"
+  done
 fi
 
 if [[ "${RUN_EVAL}" == "true" ]]; then
-  for variant in baseline visual-memory; do
+  for variant in "${VARIANTS[@]}"; do
     uv run lerobot-eval \
       --policy.path="${OUTPUT_ROOT}/${variant}/checkpoints/last/pretrained_model" \
       --env.type=robomme \
@@ -68,7 +102,8 @@ if [[ "${RUN_EVAL}" == "true" ]]; then
   done
 fi
 
-uv run python - "${OUTPUT_ROOT}" <<'PY'
+if [[ "${RUN_EVAL}" == "true" ]]; then
+  uv run python - "${OUTPUT_ROOT}" <<'PY'
 import json
 import pathlib
 import sys
@@ -91,3 +126,4 @@ for variant in ("baseline", "visual-memory"):
             f"avg_reward={metrics['avg_sum_reward']:.4f}"
         )
 PY
+fi

--- a/examples/robomme/smolvla_visual_memory_ablation.sh
+++ b/examples/robomme/smolvla_visual_memory_ablation.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Matched SmolVLA ablation for the 10 fps lerobot/robomme dataset.
+# Run from the LeRobot repository root on a CUDA machine.
+
+set -euo pipefail
+
+STEPS="${STEPS:-30000}"
+BATCH_SIZE="${BATCH_SIZE:-4}"
+SEED="${SEED:-1000}"
+OUTPUT_ROOT="${OUTPUT_ROOT:-outputs/robomme-smolvla-mem-ablation}"
+WANDB_ENABLE="${WANDB_ENABLE:-false}"
+RUN_TRAIN="${RUN_TRAIN:-true}"
+RUN_EVAL="${RUN_EVAL:-true}"
+TASKS="BinFill,PickXtimes,SwingXtimes,StopCube,VideoUnmask,VideoUnmaskSwap,ButtonUnmask,ButtonUnmaskSwap,PickHighlight,VideoRepick,VideoPlaceButton,VideoPlaceOrder,MoveCube,InsertPeg,PatternLock,RouteStick"
+TASK_IDS="[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49]"
+
+COMMON_TRAIN_ARGS=(
+  --policy.path=lerobot/smolvla_base
+  --policy.device=cuda
+  --policy.push_to_hub=false
+  --policy.empty_cameras=1
+  --policy.freeze_vision_encoder=false
+  --policy.train_expert_only=false
+  --dataset.repo_id=lerobot/robomme
+  '--rename_map={"image":"observation.images.camera1","wrist_image":"observation.images.camera2","state":"observation.state","actions":"action"}'
+  --batch_size="${BATCH_SIZE}"
+  --steps="${STEPS}"
+  --seed="${SEED}"
+  --env_eval_freq=0
+  --save_freq=5000
+  --wandb.enable="${WANDB_ENABLE}"
+)
+
+if [[ "${RUN_TRAIN}" == "true" ]]; then
+  uv run lerobot-train \
+    "${COMMON_TRAIN_ARGS[@]}" \
+    --policy.use_visual_memory=false \
+    --output_dir="${OUTPUT_ROOT}/baseline" \
+    --job_name=robomme-smolvla-baseline
+
+  uv run lerobot-train \
+    "${COMMON_TRAIN_ARGS[@]}" \
+    --policy.use_visual_memory=true \
+    --policy.visual_memory_frames=6 \
+    --policy.visual_memory_stride=10 \
+    --policy.visual_memory_temporal_attention_every=4 \
+    --output_dir="${OUTPUT_ROOT}/visual-memory" \
+    --job_name=robomme-smolvla-visual-memory
+fi
+
+if [[ "${RUN_EVAL}" == "true" ]]; then
+  for variant in baseline visual-memory; do
+    uv run lerobot-eval \
+      --policy.path="${OUTPUT_ROOT}/${variant}/checkpoints/last/pretrained_model" \
+      --env.type=robomme \
+      --env.task="${TASKS}" \
+      --env.dataset_split=test \
+      --env.task_ids="${TASK_IDS}" \
+      '--rename_map={"observation.images.image":"observation.images.camera1","observation.images.wrist_image":"observation.images.camera2"}' \
+      --eval.batch_size=1 \
+      --eval.n_episodes=50 \
+      --seed="${SEED}" \
+      --output_dir="${OUTPUT_ROOT}/eval-${variant}"
+  done
+fi
+
+uv run python - "${OUTPUT_ROOT}" <<'PY'
+import json
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1])
+for variant in ("baseline", "visual-memory"):
+    result_path = root / f"eval-{variant}" / "eval_info.json"
+    if not result_path.exists():
+        continue
+    with result_path.open() as handle:
+        info = json.load(handle)
+    overall = info["aggregated"]
+    print(
+        f"{variant}: success={overall['pc_success']:.2f}% "
+        f"avg_reward={overall['avg_sum_reward']:.4f}"
+    )
+PY

--- a/examples/robomme/smolvla_visual_memory_ablation.sh
+++ b/examples/robomme/smolvla_visual_memory_ablation.sh
@@ -6,10 +6,11 @@ set -euo pipefail
 
 BATCH_SIZE="${BATCH_SIZE:-4}"
 NUM_PROCESSES="${NUM_PROCESSES:-1}"
+GRADIENT_ACCUMULATION_STEPS="${GRADIENT_ACCUMULATION_STEPS:-1}"
 # The published training split has 476,857 execution frames. By default, train on one
 # execution-frame epoch; set STEPS explicitly to use a different optimizer-step budget.
 TARGET_SAMPLES="${TARGET_SAMPLES:-476857}"
-EFFECTIVE_BATCH_SIZE=$((BATCH_SIZE * NUM_PROCESSES))
+EFFECTIVE_BATCH_SIZE=$((BATCH_SIZE * NUM_PROCESSES * GRADIENT_ACCUMULATION_STEPS))
 STEPS="${STEPS:-$(((TARGET_SAMPLES + EFFECTIVE_BATCH_SIZE - 1) / EFFECTIVE_BATCH_SIZE))}"
 SCHEDULER_WARMUP_STEPS="${SCHEDULER_WARMUP_STEPS:-$(((STEPS + 29) / 30))}"
 SCHEDULER_DECAY_STEPS="${SCHEDULER_DECAY_STEPS:-${STEPS}}"
@@ -58,6 +59,7 @@ COMMON_TRAIN_ARGS=(
   --dataset.training_target_start_feature=exec_start_idx
   '--rename_map={"image":"observation.images.camera1","wrist_image":"observation.images.camera2","state":"observation.state","actions":"action"}'
   --batch_size="${BATCH_SIZE}"
+  --gradient_accumulation_steps="${GRADIENT_ACCUMULATION_STEPS}"
   --steps="${STEPS}"
   --policy.scheduler_warmup_steps="${SCHEDULER_WARMUP_STEPS}"
   --policy.scheduler_decay_steps="${SCHEDULER_DECAY_STEPS}"

--- a/examples/robomme/smolvla_visual_memory_ablation.sh
+++ b/examples/robomme/smolvla_visual_memory_ablation.sh
@@ -4,8 +4,11 @@
 
 set -euo pipefail
 
-STEPS="${STEPS:-30000}"
 BATCH_SIZE="${BATCH_SIZE:-4}"
+# The published training split has 476,857 execution frames. By default, train on one
+# execution-frame epoch; set STEPS explicitly to use a different optimizer-step budget.
+TARGET_SAMPLES="${TARGET_SAMPLES:-476857}"
+STEPS="${STEPS:-$(((TARGET_SAMPLES + BATCH_SIZE - 1) / BATCH_SIZE))}"
 SEED="${SEED:-1000}"
 OUTPUT_ROOT="${OUTPUT_ROOT:-outputs/robomme-smolvla-mem-ablation}"
 WANDB_ENABLE="${WANDB_ENABLE:-false}"
@@ -22,6 +25,7 @@ COMMON_TRAIN_ARGS=(
   --policy.freeze_vision_encoder=false
   --policy.train_expert_only=false
   --dataset.repo_id=lerobot/robomme
+  --dataset.training_target_start_feature=exec_start_idx
   '--rename_map={"image":"observation.images.camera1","wrist_image":"observation.images.camera2","state":"observation.state","actions":"action"}'
   --batch_size="${BATCH_SIZE}"
   --steps="${STEPS}"

--- a/src/lerobot/configs/default.py
+++ b/src/lerobot/configs/default.py
@@ -33,6 +33,10 @@ class DatasetConfig:
     # looked up under $HF_LEROBOT_HOME/repo_id and Hub downloads use a revision-safe cache under $HF_LEROBOT_HOME/hub.
     root: str | None = None
     episodes: list[int] | None = None
+    # Optional per-frame feature containing the episode-relative index of the first frame that may be
+    # sampled as a training target. Earlier frames remain in the dataset and can still be loaded through
+    # temporal observation deltas. This is useful for datasets with demonstration/context prefixes.
+    training_target_start_feature: str | None = None
     image_transforms: ImageTransformsConfig = field(default_factory=ImageTransformsConfig)
     revision: str | None = None
     use_imagenet_stats: bool = True

--- a/src/lerobot/configs/train.py
+++ b/src/lerobot/configs/train.py
@@ -99,6 +99,9 @@ class TrainPipelineConfig(HubMixin):
     # Number of workers for the dataloader.
     num_workers: int = 4
     batch_size: int = 8
+    # Number of microbatches accumulated before each optimizer update. The effective global batch is
+    # batch_size * accelerator.num_processes * gradient_accumulation_steps.
+    gradient_accumulation_steps: int = 1
     prefetch_factor: int = 4
     persistent_workers: bool = True
     steps: int = 100_000
@@ -221,6 +224,8 @@ class TrainPipelineConfig(HubMixin):
             )
 
         active_cfg = self.trainable_config
+        if self.gradient_accumulation_steps < 1:
+            raise ValueError("gradient_accumulation_steps must be at least 1.")
         if self.rename_map and active_cfg.pretrained_path is None:
             raise ValueError(
                 "`rename_map` requires a pretrained policy checkpoint. "

--- a/src/lerobot/datasets/factory.py
+++ b/src/lerobot/datasets/factory.py
@@ -32,7 +32,9 @@ from .streaming_dataset import StreamingLeRobotDataset
 
 
 def resolve_delta_timestamps(
-    cfg: PreTrainedConfig | RewardModelConfig, ds_meta: LeRobotDatasetMetadata
+    cfg: PreTrainedConfig | RewardModelConfig,
+    ds_meta: LeRobotDatasetMetadata,
+    rename_map: dict[str, str] | None = None,
 ) -> dict[str, list] | None:
     """Resolves delta_timestamps by reading from the 'delta_indices' properties of the config.
 
@@ -53,11 +55,12 @@ def resolve_delta_timestamps(
     """
     delta_timestamps = {}
     for key in ds_meta.features:
-        if key == REWARD and cfg.reward_delta_indices is not None:
+        policy_key = (rename_map or {}).get(key, key)
+        if policy_key == REWARD and cfg.reward_delta_indices is not None:
             delta_timestamps[key] = [i / ds_meta.fps for i in cfg.reward_delta_indices]
-        if key == ACTION and cfg.action_delta_indices is not None:
+        if policy_key == ACTION and cfg.action_delta_indices is not None:
             delta_timestamps[key] = [i / ds_meta.fps for i in cfg.action_delta_indices]
-        if key.startswith(OBS_PREFIX) and cfg.observation_delta_indices is not None:
+        if policy_key.startswith(OBS_PREFIX) and cfg.observation_delta_indices is not None:
             delta_timestamps[key] = [i / ds_meta.fps for i in cfg.observation_delta_indices]
 
     if len(delta_timestamps) == 0:
@@ -86,7 +89,7 @@ def make_dataset(cfg: TrainPipelineConfig) -> LeRobotDataset | MultiLeRobotDatas
         ds_meta = LeRobotDatasetMetadata(
             cfg.dataset.repo_id, root=cfg.dataset.root, revision=cfg.dataset.revision
         )
-        delta_timestamps = resolve_delta_timestamps(cfg.trainable_config, ds_meta)
+        delta_timestamps = resolve_delta_timestamps(cfg.trainable_config, ds_meta, cfg.rename_map)
         if not cfg.dataset.streaming:
             dataset = LeRobotDataset(
                 cfg.dataset.repo_id,
@@ -130,6 +133,9 @@ def make_dataset(cfg: TrainPipelineConfig) -> LeRobotDataset | MultiLeRobotDatas
         for key in dataset.meta.camera_keys:
             if key in dataset.meta.depth_keys:
                 continue  # Exclude depth keys from ImageNet stats
+            # Some video-only datasets omit camera statistics entirely. Visual
+            # normalization can still use the requested ImageNet defaults.
+            dataset.meta.stats.setdefault(key, {})
             for stats_type, stats in IMAGENET_STATS.items():
                 dataset.meta.stats[key][stats_type] = torch.tensor(stats, dtype=torch.float32)
 
@@ -175,7 +181,7 @@ def make_train_eval_datasets(
         f"(eval_split={cfg.dataset.eval_split}, {len(task_to_episodes)} tasks)"
     )
 
-    delta_timestamps = resolve_delta_timestamps(cfg.trainable_config, full_dataset.meta)
+    delta_timestamps = resolve_delta_timestamps(cfg.trainable_config, full_dataset.meta, cfg.rename_map)
 
     train_image_transforms = (
         ImageTransforms(cfg.dataset.image_transforms) if cfg.dataset.image_transforms.enable else None

--- a/src/lerobot/datasets/sampler.py
+++ b/src/lerobot/datasets/sampler.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 import logging
 import math
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 
 import numpy as np
 import torch
@@ -49,7 +49,7 @@ class EpisodeAwareSampler:
         dataset_from_indices: list[int],
         dataset_to_indices: list[int],
         episode_indices_to_use: list | None = None,
-        drop_n_first_frames: int = 0,
+        drop_n_first_frames: int | Sequence[int] = 0,
         drop_n_last_frames: int = 0,
         shuffle: bool = False,
         seed: int = 0,
@@ -60,13 +60,12 @@ class EpisodeAwareSampler:
             dataset_from_indices: Start index of each episode in the dataset.
             dataset_to_indices: End index of each episode in the dataset.
             episode_indices_to_use: Episode indices to use; None means all.
-            drop_n_first_frames: Frames to drop from the start of each episode.
+            drop_n_first_frames: Frames to drop from the start of each episode. An integer applies the
+                same offset to every episode; a sequence supplies one offset per episode.
             drop_n_last_frames: Frames to drop from the end of each episode.
             shuffle: Whether to shuffle the indices.
             seed: Seed the permutation is derived from (together with the epoch).
         """
-        if drop_n_first_frames < 0:
-            raise ValueError(f"drop_n_first_frames must be >= 0, got {drop_n_first_frames}")
         if drop_n_last_frames < 0:
             raise ValueError(f"drop_n_last_frames must be >= 0, got {drop_n_last_frames}")
 
@@ -78,12 +77,27 @@ class EpisodeAwareSampler:
                 f"got {len(from_indices)} and {len(to_indices)}"
             )
 
+        if isinstance(drop_n_first_frames, int):
+            first_frame_offsets = np.full(len(from_indices), drop_n_first_frames, dtype=np.int64)
+        else:
+            first_frame_offsets = np.asarray(drop_n_first_frames, dtype=np.int64)
+            if first_frame_offsets.shape != from_indices.shape:
+                raise ValueError(
+                    "drop_n_first_frames must be an integer or have one value per episode; "
+                    f"got {len(first_frame_offsets)} values for {len(from_indices)} episodes"
+                )
+        if np.any(first_frame_offsets < 0):
+            raise ValueError(
+                "drop_n_first_frames must be >= 0, got "
+                f"{first_frame_offsets[first_frame_offsets < 0].tolist()}"
+            )
+
         used = np.ones(len(from_indices), dtype=bool)
         if episode_indices_to_use is not None:
             used = np.zeros(len(from_indices), dtype=bool)
             used[np.asarray(episode_indices_to_use, dtype=np.int64)] = True
 
-        starts = from_indices + drop_n_first_frames
+        starts = from_indices + first_frame_offsets
         lengths = to_indices - drop_n_last_frames - starts
         for episode_idx in np.flatnonzero(used & (lengths <= 0)):
             logger.warning(
@@ -91,7 +105,7 @@ class EpisodeAwareSampler:
                 "drop_n_last_frames=%d removes all frames. Skipping.",
                 episode_idx,
                 to_indices[episode_idx] - from_indices[episode_idx],
-                drop_n_first_frames,
+                first_frame_offsets[episode_idx],
                 drop_n_last_frames,
             )
         used &= lengths > 0

--- a/src/lerobot/envs/robomme.py
+++ b/src/lerobot/envs/robomme.py
@@ -63,6 +63,8 @@ class RoboMMEGymEnv(gym.Env):
         from robomme.env_record_wrapper import BenchmarkEnvBuilder
 
         self._task = task
+        self.task = task
+        self.task_description = task
         self._action_space_type = action_space_type
         self._dataset = dataset
         self._episode_idx = episode_idx
@@ -105,6 +107,12 @@ class RoboMMEGymEnv(gym.Env):
         )
         obs, info = self._env.reset()
         self._last_raw_obs = obs
+        task_goal = info.get("task_goal")
+        # RoboMME returns [simple_subgoal, grounded_subgoal]. The published
+        # LeRobot training dataset uses the simple subgoal as its `task` text.
+        if isinstance(task_goal, (list, tuple)):
+            task_goal = task_goal[0] if task_goal else ""
+        self.task_description = str(task_goal or self._task)
         return self._convert_obs(obs), self._convert_info(info)
 
     def step(self, action):

--- a/src/lerobot/policies/factory.py
+++ b/src/lerobot/policies/factory.py
@@ -623,6 +623,9 @@ def make_policy(
             raise ValueError("env_cfg cannot be None when ds_meta is not provided")
         features = env_to_policy_features(env_cfg)
 
+    if rename_map:
+        features = {rename_map.get(key, key): feature for key, feature in features.items()}
+
     cfg.output_features = {key: ft for key, ft in features.items() if ft.type is FeatureType.ACTION}
     if not cfg.input_features:
         cfg.input_features = {key: ft for key, ft in features.items() if key not in cfg.output_features}

--- a/src/lerobot/policies/smolvla/configuration_smolvla.py
+++ b/src/lerobot/policies/smolvla/configuration_smolvla.py
@@ -44,6 +44,14 @@ class SmolVLAConfig(PreTrainedConfig):
     # Image preprocessing
     resize_imgs_with_padding: tuple[int, int] = (512, 512)
 
+    # MEM short-horizon visual memory (https://arxiv.org/abs/2603.03596).
+    # Past frames are fused inside the vision tower and dropped before the VLM,
+    # keeping the number of prefix tokens identical to single-frame SmolVLA.
+    use_visual_memory: bool = False
+    visual_memory_frames: int = 6
+    visual_memory_stride: int = 10
+    visual_memory_temporal_attention_every: int = 4
+
     # Add empty images. Used by smolvla_aloha_sim which adds the empty
     # left and right wrist cameras in addition to the top camera.
     empty_cameras: int = 0
@@ -119,6 +127,12 @@ class SmolVLAConfig(PreTrainedConfig):
             raise NotImplementedError(
                 "`use_delta_joint_actions_aloha` is used by smolvla for aloha real models. It is not ported yet in LeRobot."
             )
+        if self.visual_memory_frames < 1:
+            raise ValueError("visual_memory_frames must be at least 1")
+        if self.visual_memory_stride < 1:
+            raise ValueError("visual_memory_stride must be at least 1")
+        if self.visual_memory_temporal_attention_every < 1:
+            raise ValueError("visual_memory_temporal_attention_every must be at least 1")
 
     def validate_features(self) -> None:
         for i in range(self.empty_cameras):
@@ -148,7 +162,10 @@ class SmolVLAConfig(PreTrainedConfig):
 
     @property
     def observation_delta_indices(self) -> list:
-        return [0]
+        if not self.use_visual_memory:
+            return [0]
+        horizon = (self.visual_memory_frames - 1) * self.visual_memory_stride
+        return list(range(-horizon, 1, self.visual_memory_stride))
 
     @property
     def action_delta_indices(self) -> list:

--- a/src/lerobot/policies/smolvla/modeling_smolvla.py
+++ b/src/lerobot/policies/smolvla/modeling_smolvla.py
@@ -71,6 +71,7 @@ from ..utils import (
 )
 from .configuration_smolvla import SmolVLAConfig
 from .smolvlm_with_expert import SmolVLMWithExpertModel
+from .visual_memory import sample_visual_history
 
 
 class ActionSelectKwargs(TypedDict, total=False):
@@ -253,6 +254,10 @@ class SmolVLAPolicy(PreTrainedPolicy):
         self._queues = {
             ACTION: deque(maxlen=self.config.n_action_steps),
         }
+        if self.config.use_visual_memory:
+            history_length = (self.config.visual_memory_frames - 1) * self.config.visual_memory_stride + 1
+            self._queues.update({key: deque(maxlen=history_length) for key in self.config.image_features})
+            self._visual_memory_steps_seen = 0
 
     def init_rtc_processor(self):
         """Initialize RTC processor if RTC is enabled in config."""
@@ -281,9 +286,15 @@ class SmolVLAPolicy(PreTrainedPolicy):
         # In the case of offline inference, we have the action in the batch
         # that why without the k != ACTION check, it will raise an error because we are trying to stack
         # on an empty container.
-        for k in batch:
+        for k in list(batch):
             if k in self._queues and k != ACTION:
-                batch[k] = torch.stack(list(self._queues[k]), dim=1)
+                history = list(self._queues[k])
+                batch[k], batch[f"{k}_is_pad"] = sample_visual_history(
+                    history,
+                    num_frames=self.config.visual_memory_frames,
+                    stride=self.config.visual_memory_stride,
+                    steps_seen=self._visual_memory_steps_seen,
+                )
 
         images, img_masks = self.prepare_images(batch)
         state = self.prepare_state(batch)
@@ -309,6 +320,11 @@ class SmolVLAPolicy(PreTrainedPolicy):
 
         return batch
 
+    def _populate_observation_queues(self, batch: dict[str, Tensor]) -> None:
+        self._queues = populate_queues(self._queues, batch, exclude_keys=[ACTION])
+        if self.config.use_visual_memory:
+            self._visual_memory_steps_seen += 1
+
     @torch.no_grad()
     def predict_action_chunk(
         self, batch: dict[str, Tensor], noise: Tensor | None = None, **kwargs: Unpack[ActionSelectKwargs]
@@ -316,7 +332,7 @@ class SmolVLAPolicy(PreTrainedPolicy):
         self.eval()
 
         batch = self._prepare_batch(batch)
-        self._queues = populate_queues(self._queues, batch, exclude_keys=[ACTION])
+        self._populate_observation_queues(batch)
 
         actions = self._get_action_chunk(batch, noise, **kwargs)
         return actions
@@ -338,7 +354,7 @@ class SmolVLAPolicy(PreTrainedPolicy):
 
         self.eval()
         batch = self._prepare_batch(batch)
-        self._queues = populate_queues(self._queues, batch, exclude_keys=[ACTION])
+        self._populate_observation_queues(batch)
 
         if self._check_get_actions_condition():
             actions = self._get_action_chunk(batch, noise)
@@ -427,19 +443,30 @@ class SmolVLAPolicy(PreTrainedPolicy):
             )
         # Preprocess image features present in the batch
         for key in present_img_keys:
-            img = batch[key][:, -1, :, :, :] if batch[key].ndim == 5 else batch[key]
+            img = batch[key]
+            if img.ndim == 5 and not self.config.use_visual_memory:
+                img = img[:, -1, :, :, :]
             if self.config.resize_imgs_with_padding is not None:
-                img = resize_with_pad(img, *self.config.resize_imgs_with_padding, pad_value=0)
+                if img.ndim == 5:
+                    batch_size, num_frames = img.shape[:2]
+                    img = resize_with_pad(
+                        img.flatten(0, 1), *self.config.resize_imgs_with_padding, pad_value=0
+                    ).unflatten(0, (batch_size, num_frames))
+                else:
+                    img = resize_with_pad(img, *self.config.resize_imgs_with_padding, pad_value=0)
 
             # Normalize from range [0,1] to [-1,1] as expacted by siglip
             img = img * 2.0 - 1.0
 
             bsize = img.shape[0]
             device = img.device
-            if f"{key}_padding_mask" in batch:
+            if f"{key}_is_pad" in batch:
+                mask = ~batch[f"{key}_is_pad"].bool()
+            elif f"{key}_padding_mask" in batch:
                 mask = batch[f"{key}_padding_mask"].bool()
             else:
-                mask = torch.ones(bsize, dtype=torch.bool, device=device)
+                mask_shape = img.shape[:2] if img.ndim == 5 else (bsize,)
+                mask = torch.ones(mask_shape, dtype=torch.bool, device=device)
             images.append(img)
             img_masks.append(mask)
 
@@ -662,7 +689,11 @@ class VLAFlowMatching(nn.Module):
                 embs.append(image_start_token)
                 pad_masks.append(image_start_mask)
 
-            img_emb = self.vlm_with_expert.embed_image(img)
+            img_emb = self.vlm_with_expert.embed_image(
+                img,
+                frame_mask=img_mask if img.ndim == 5 else None,
+                temporal_attention_every=self.config.visual_memory_temporal_attention_every,
+            )
             img_emb = img_emb
 
             # Normalize image embeddings
@@ -670,6 +701,8 @@ class VLAFlowMatching(nn.Module):
             img_emb = img_emb * torch.tensor(img_emb_dim**0.5, dtype=img_emb.dtype, device=img_emb.device)
 
             bsize, num_img_embs = img_emb.shape[:2]
+            if img_mask.ndim == 2:
+                img_mask = img_mask[:, -1]
             img_mask = img_mask[:, None].expand(bsize, num_img_embs)
 
             embs.append(img_emb)

--- a/src/lerobot/policies/smolvla/smolvlm_with_expert.py
+++ b/src/lerobot/policies/smolvla/smolvlm_with_expert.py
@@ -20,6 +20,8 @@ from torch import nn
 
 from lerobot.utils.import_utils import _transformers_available, require_package
 
+from .visual_memory import encode_video_with_mem
+
 if TYPE_CHECKING or _transformers_available:
     from transformers import (
         AutoConfig,
@@ -188,17 +190,31 @@ class SmolVLMWithExpertModel(nn.Module):
         if self.train_expert_only:
             self.vlm.eval()
 
-    def embed_image(self, image: torch.Tensor):
+    def embed_image(
+        self,
+        image: torch.Tensor,
+        *,
+        frame_mask: torch.Tensor | None = None,
+        temporal_attention_every: int = 4,
+    ):
         patch_attention_mask = None
         # Get sequence from the vision encoder
-        image_hidden_states = (
-            self.get_vlm_model()
-            .vision_model(
-                pixel_values=image.to(dtype=self.get_vlm_model().vision_model.dtype),
-                patch_attention_mask=patch_attention_mask,
+        vision_model = self.get_vlm_model().vision_model
+        image = image.to(dtype=vision_model.dtype)
+        if image.ndim == 5:
+            if frame_mask is None:
+                frame_mask = torch.ones(image.shape[:2], dtype=torch.bool, device=image.device)
+            image_hidden_states = encode_video_with_mem(
+                vision_model,
+                image,
+                frame_mask,
+                temporal_attention_every=temporal_attention_every,
             )
-            .last_hidden_state
-        )
+        else:
+            image_hidden_states = vision_model(
+                pixel_values=image,
+                patch_attention_mask=patch_attention_mask,
+            ).last_hidden_state
         # Modality projection & resampling
         image_hidden_states = self.get_vlm_model().connector(image_hidden_states)
         return image_hidden_states

--- a/src/lerobot/policies/smolvla/visual_memory.py
+++ b/src/lerobot/policies/smolvla/visual_memory.py
@@ -1,0 +1,161 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Short-horizon visual memory from MEM (arXiv:2603.03596).
+
+The encoder keeps SigLIP's pretrained parameters and alternates its ordinary
+per-frame spatial attention with causal attention across time for matching
+spatial patches. Only the current frame's patch tokens leave the vision tower,
+so enabling memory does not increase the VLM prefix length.
+"""
+
+import math
+
+import torch
+from torch import Tensor
+
+
+def sample_visual_history(
+    history: list[Tensor], *, num_frames: int, stride: int, steps_seen: int
+) -> tuple[Tensor, Tensor]:
+    """Subsample an inference queue and mark pre-episode padding frames."""
+    sampled = history[::stride][-num_frames:]
+    if len(sampled) != num_frames:
+        raise ValueError(f"visual history has {len(sampled)} samples, expected {num_frames}")
+    video = torch.stack(sampled, dim=1)
+    required_ages = range((num_frames - 1) * stride, -1, -stride)
+    valid = torch.tensor([steps_seen > age for age in required_ages], dtype=torch.bool, device=video.device)
+    padding_mask = (~valid)[None, :].expand(video.shape[0], -1)
+    return video, padding_mask
+
+
+def temporal_sinusoidal_embedding(
+    num_frames: int, hidden_size: int, *, device: torch.device, dtype: torch.dtype
+) -> Tensor:
+    """Return fixed temporal embeddings with an exactly-zero current position."""
+    if hidden_size % 2:
+        raise ValueError(f"hidden_size must be even, got {hidden_size}")
+
+    # History is ordered oldest -> current, matching t in [-K, 0] in MEM.
+    positions = torch.arange(1 - num_frames, 1, device=device, dtype=torch.float32)[:, None]
+    frequencies = torch.exp(
+        torch.arange(0, hidden_size, 2, device=device, dtype=torch.float32)
+        * (-math.log(10_000.0) / hidden_size)
+    )[None, :]
+    angles = positions * frequencies
+    embedding = torch.zeros(num_frames, hidden_size, device=device, dtype=torch.float32)
+    embedding[:, 0::2] = torch.sin(angles)
+    embedding[:, 1::2] = torch.cos(angles) - 1.0
+    return embedding.to(dtype=dtype)
+
+
+def causal_temporal_mask(frame_mask: Tensor, *, dtype: torch.dtype, num_patches: int) -> Tensor:
+    """Build an additive causal/key-padding mask for per-patch temporal attention."""
+    if frame_mask.ndim != 2:
+        raise ValueError(f"frame_mask must have shape (batch, frames), got {tuple(frame_mask.shape)}")
+
+    batch_size, num_frames = frame_mask.shape
+    allowed = torch.ones(num_frames, num_frames, dtype=torch.bool, device=frame_mask.device).tril()
+    allowed = allowed[None, :, :] & frame_mask[:, None, :].bool()
+    # The current frame is always present in normal use. Keeping the diagonal
+    # valid also prevents NaNs for fully padded historical query rows.
+    diagonal = torch.eye(num_frames, dtype=torch.bool, device=frame_mask.device)[None, :, :]
+    allowed = allowed | diagonal
+    mask = torch.zeros(batch_size, 1, num_frames, num_frames, dtype=dtype, device=frame_mask.device)
+    mask.masked_fill_(~allowed[:, None, :, :], torch.finfo(dtype).min)
+    return mask.repeat_interleave(num_patches, dim=0)
+
+
+def encode_video_with_mem(
+    vision_model,
+    pixel_values: Tensor,
+    frame_mask: Tensor,
+    *,
+    temporal_attention_every: int,
+) -> Tensor:
+    """Encode ``(B,T,C,H,W)`` video with MEM's space-time separable attention.
+
+    No modules or learnable parameters are added. At temporal layers, the same
+    layer-normalization and Q/K/V/out projections are reused for a second,
+    causal attention operation along time. For a one-frame input the temporal
+    branch is skipped, making this exactly equivalent to the original image
+    encoder.
+    """
+    if pixel_values.ndim != 5:
+        raise ValueError(f"pixel_values must have shape (B,T,C,H,W), got {tuple(pixel_values.shape)}")
+    if temporal_attention_every < 1:
+        raise ValueError("temporal_attention_every must be at least 1")
+
+    batch_size, num_frames, channels, height, width = pixel_values.shape
+    if frame_mask.shape != (batch_size, num_frames):
+        raise ValueError(
+            f"frame_mask must have shape {(batch_size, num_frames)}, got {tuple(frame_mask.shape)}"
+        )
+
+    required = ("embeddings", "encoder", "post_layernorm")
+    if any(not hasattr(vision_model, name) for name in required):
+        raise TypeError("MEM visual memory currently requires a SigLIP-compatible vision tower")
+
+    flat_pixels = pixel_values.reshape(batch_size * num_frames, channels, height, width)
+    if hasattr(vision_model, "patch_size"):
+        patch_size = vision_model.patch_size
+        patch_attention_mask = torch.ones(
+            batch_size * num_frames,
+            height // patch_size,
+            width // patch_size,
+            dtype=torch.bool,
+            device=pixel_values.device,
+        )
+        hidden_states = vision_model.embeddings(
+            pixel_values=flat_pixels,
+            patch_attention_mask=patch_attention_mask,
+        )
+    else:
+        hidden_states = vision_model.embeddings(flat_pixels)
+    num_patches, hidden_size = hidden_states.shape[1:]
+    hidden_states = hidden_states.reshape(batch_size, num_frames, num_patches, hidden_size)
+
+    temporal_positions = temporal_sinusoidal_embedding(
+        num_frames, hidden_size, device=hidden_states.device, dtype=hidden_states.dtype
+    )[None, :, None, :]
+    temporal_mask = causal_temporal_mask(frame_mask, dtype=hidden_states.dtype, num_patches=num_patches)
+
+    for layer_index, layer in enumerate(vision_model.encoder.layers):
+        spatial_input = hidden_states.reshape(batch_size * num_frames, num_patches, hidden_size)
+        if num_frames == 1 or (layer_index + 1) % temporal_attention_every:
+            hidden_states = layer(spatial_input, attention_mask=None).reshape(
+                batch_size, num_frames, num_patches, hidden_size
+            )
+            continue
+
+        residual = hidden_states
+        spatial_norm = layer.layer_norm1(spatial_input)
+        spatial_output, _ = layer.self_attn(hidden_states=spatial_norm, attention_mask=None)
+        spatial_output = spatial_output.reshape(batch_size, num_frames, num_patches, hidden_size)
+
+        temporal_input = (hidden_states + temporal_positions).permute(0, 2, 1, 3)
+        temporal_input = temporal_input.reshape(batch_size * num_patches, num_frames, hidden_size)
+        temporal_norm = layer.layer_norm1(temporal_input)
+        temporal_output, _ = layer.self_attn(
+            hidden_states=temporal_norm,
+            attention_mask=temporal_mask,
+        )
+        temporal_output = temporal_output.reshape(batch_size, num_patches, num_frames, hidden_size)
+        temporal_output = temporal_output.permute(0, 2, 1, 3)
+
+        hidden_states = residual + spatial_output + temporal_output
+        hidden_states = hidden_states + layer.mlp(layer.layer_norm2(hidden_states))
+
+    # MEM drops all historical tokens before the VLA backbone.
+    return vision_model.post_layernorm(hidden_states[:, -1])

--- a/src/lerobot/processor/rename_processor.py
+++ b/src/lerobot/processor/rename_processor.py
@@ -21,6 +21,23 @@ from lerobot.configs import PipelineFeatureType, PolicyFeature
 
 from .pipeline import ObservationProcessorStep, ProcessorStepRegistry
 
+_AUXILIARY_KEY_SUFFIXES = ("_is_pad", "_padding_mask")
+
+
+def rename_transition_key(key: str, rename_map: dict[str, str]) -> str:
+    """Rename a feature key and any sampling metadata derived from it."""
+    if key in rename_map:
+        return rename_map[key]
+    for suffix in _AUXILIARY_KEY_SUFFIXES:
+        if key.endswith(suffix) and key[: -len(suffix)] in rename_map:
+            return f"{rename_map[key[: -len(suffix)]]}{suffix}"
+    return key
+
+
+def rename_transition_keys(data: dict[str, Any], rename_map: dict[str, str]) -> dict[str, Any]:
+    """Rename all transition keys, including delta-sampling padding masks."""
+    return {rename_transition_key(key, rename_map): value for key, value in data.items()}
+
 
 @dataclass
 @ProcessorStepRegistry.register(name="rename_observations_processor")
@@ -41,14 +58,7 @@ class RenameObservationsProcessorStep(ObservationProcessorStep):
     rename_map: dict[str, str] = field(default_factory=dict)
 
     def observation(self, observation):
-        processed_obs = {}
-        for key, value in observation.items():
-            if key in self.rename_map:
-                processed_obs[self.rename_map[key]] = value
-            else:
-                processed_obs[key] = value
-
-        return processed_obs
+        return rename_transition_keys(observation, self.rename_map)
 
     def get_config(self) -> dict[str, Any]:
         return {"rename_map": self.rename_map}

--- a/src/lerobot/scripts/lerobot_train.py
+++ b/src/lerobot/scripts/lerobot_train.py
@@ -85,6 +85,7 @@ def update_policy(
     lock=None,
     sample_weighter=None,
     log_metrics: bool = True,
+    track_update_time: bool = True,
 ) -> tuple[MetricsTracker, dict | None]:
     """
     Performs a single training step to update the policy's weights.
@@ -148,13 +149,16 @@ def update_policy(
     # Use accelerator's backward method
     accelerator.backward(loss)
 
-    # Clip gradients if specified
-    if grad_clip_norm > 0:
-        grad_norm = accelerator.clip_grad_norm_(policy.parameters(), grad_clip_norm)
-    else:
-        grad_norm = torch.nn.utils.clip_grad_norm_(
-            policy.parameters(), float("inf"), error_if_nonfinite=False
-        )
+    # Accelerate suppresses gradient synchronization and optimizer updates on intermediate
+    # microbatches. Clip and report the norm only when the accumulated update is complete.
+    grad_norm = None
+    if accelerator.sync_gradients:
+        if grad_clip_norm > 0:
+            grad_norm = accelerator.clip_grad_norm_(policy.parameters(), grad_clip_norm)
+        else:
+            grad_norm = torch.nn.utils.clip_grad_norm_(
+                policy.parameters(), float("inf"), error_if_nonfinite=False
+            )
 
     # Optimizer step
     with lock if lock is not None else nullcontext():
@@ -163,19 +167,24 @@ def update_policy(
     optimizer.zero_grad()
 
     # Step through pytorch scheduler at every batch instead of epoch
-    if lr_scheduler is not None:
+    if lr_scheduler is not None and accelerator.sync_gradients:
         lr_scheduler.step()
 
     # Update internal buffers if policy has update method
-    if has_method(accelerator.unwrap_model(policy, keep_fp32_wrapper=True), "update"):
+    if accelerator.sync_gradients and has_method(
+        accelerator.unwrap_model(policy, keep_fp32_wrapper=True), "update"
+    ):
         accelerator.unwrap_model(policy, keep_fp32_wrapper=True).update()
 
-    train_metrics.lr = optimizer.param_groups[0]["lr"]
-    if torch.cuda.is_available():
+    if accelerator.sync_gradients:
+        train_metrics.lr = optimizer.param_groups[0]["lr"]
+    if torch.cuda.is_available() and accelerator.sync_gradients:
         train_metrics.gpu_mem_gb = torch.cuda.max_memory_allocated() / (1024**3)
     train_metrics.accumulate_tensor("loss", loss)
-    train_metrics.accumulate_tensor("grad_norm", grad_norm)
-    train_metrics.update_s = time.perf_counter() - start_time
+    if grad_norm is not None:
+        train_metrics.accumulate_tensor("grad_norm", grad_norm)
+    if track_update_time:
+        train_metrics.update_s = time.perf_counter() - start_time
     # Synchronize accumulated GPU metrics only when logging.
     if log_metrics:
         train_metrics.materialize_tensors()
@@ -238,6 +247,7 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
         mixed_precision = {"bfloat16": "bf16", "float16": "fp16", "float32": "no"}.get(policy_dtype)
         accelerator = Accelerator(
             step_scheduler_with_optimizer=False,
+            gradient_accumulation_steps=cfg.gradient_accumulation_steps,
             mixed_precision=mixed_precision,
             kwargs_handlers=[ddp_kwargs, ipg_kwargs],
             cpu=force_cpu,
@@ -439,8 +449,11 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
         logging.info(f"{dataset.num_frames=} ({format_big_number(dataset.num_frames)})")
         logging.info(f"{dataset.num_episodes=}")
         num_processes = accelerator.num_processes
-        effective_bs = cfg.batch_size * num_processes
-        logging.info(f"Effective batch size: {cfg.batch_size} x {num_processes} = {effective_bs}")
+        effective_bs = cfg.batch_size * num_processes * cfg.gradient_accumulation_steps
+        logging.info(
+            "Effective batch size: "
+            f"{cfg.batch_size} x {num_processes} x {cfg.gradient_accumulation_steps} = {effective_bs}"
+        )
         logging.info(f"{num_learnable_params=} ({format_big_number(num_learnable_params)})")
         logging.info(f"{num_total_params=} ({format_big_number(num_total_params)})")
 
@@ -520,7 +533,12 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
                     f"batch_size={saved_batch_size}. The data order resumes at the right epoch/offset, "
                     "but per-rank sample-exactness requires the same batch size."
                 )
-            sampler_state = compute_sampler_state(step, len(sampler), ckpt_batch_size, ckpt_num_processes)
+            sampler_state = compute_sampler_state(
+                step,
+                len(sampler),
+                ckpt_batch_size * cfg.gradient_accumulation_steps,
+                ckpt_num_processes,
+            )
             sampler.load_state_dict(sampler_state)
             if is_main_process:
                 logging.info(
@@ -617,9 +635,9 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
         train_metrics["gpu_mem_gb"] = AverageMeter("mem_gb", ":.2f", reduction="max")
 
     # Keep global batch size for logging; MetricsTracker handles world size internally.
-    effective_batch_size = cfg.batch_size * accelerator.num_processes
+    effective_batch_size = cfg.batch_size * accelerator.num_processes * cfg.gradient_accumulation_steps
     train_tracker = MetricsTracker(
-        cfg.batch_size,
+        cfg.batch_size * cfg.gradient_accumulation_steps,
         dataset.num_frames,
         dataset.num_episodes,
         train_metrics,
@@ -641,30 +659,42 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
         )
 
     for _ in range(step, cfg.steps):
-        start_time = time.perf_counter()
-        batch = next(dl_iter)
-        for cam_key in dataset.meta.camera_keys:
-            if cam_key in batch and batch[cam_key].dtype == torch.uint8:
-                batch[cam_key] = batch[cam_key].to(dtype=torch.float32) / 255.0
-        if cfg.rename_map:
-            batch = rename_transition_keys(batch, cfg.rename_map)
-        batch = preprocessor(batch)
-        train_tracker.dataloading_s = time.perf_counter() - start_time
+        update_start_time = time.perf_counter()
+        dataloading_s = 0.0
+        output_dict = None
+        for microbatch_idx in range(cfg.gradient_accumulation_steps):
+            start_time = time.perf_counter()
+            batch = next(dl_iter)
+            for cam_key in dataset.meta.camera_keys:
+                if cam_key in batch and batch[cam_key].dtype == torch.uint8:
+                    batch[cam_key] = batch[cam_key].to(dtype=torch.float32) / 255.0
+            if cfg.rename_map:
+                batch = rename_transition_keys(batch, cfg.rename_map)
+            batch = preprocessor(batch)
+            dataloading_s += time.perf_counter() - start_time
 
-        # Synchronize GPU metrics only for updates that will be logged.
-        log_metrics = cfg.log_freq > 0 and (step + 1) % cfg.log_freq == 0
+            # Synchronize GPU metrics only on the final microbatch of logged optimizer updates.
+            log_metrics = (
+                cfg.log_freq > 0
+                and (step + 1) % cfg.log_freq == 0
+                and microbatch_idx == cfg.gradient_accumulation_steps - 1
+            )
 
-        train_tracker, output_dict = update_policy(
-            train_tracker,
-            policy,
-            batch,
-            optimizer,
-            cfg.optimizer.grad_clip_norm,
-            accelerator=accelerator,
-            lr_scheduler=lr_scheduler,
-            sample_weighter=sample_weighter,
-            log_metrics=log_metrics,
-        )
+            with accelerator.accumulate(policy):
+                train_tracker, output_dict = update_policy(
+                    train_tracker,
+                    policy,
+                    batch,
+                    optimizer,
+                    cfg.optimizer.grad_clip_norm,
+                    accelerator=accelerator,
+                    lr_scheduler=lr_scheduler,
+                    sample_weighter=sample_weighter,
+                    log_metrics=log_metrics,
+                    track_update_time=False,
+                )
+        train_tracker.dataloading_s = dataloading_s
+        train_tracker.update_s = time.perf_counter() - update_start_time - dataloading_s
 
         # Note: eval and checkpoint happens *after* the `step`th training update has completed, so we
         # increment `step` here.

--- a/src/lerobot/scripts/lerobot_train.py
+++ b/src/lerobot/scripts/lerobot_train.py
@@ -57,6 +57,7 @@ from lerobot.envs import close_envs, make_env, make_env_pre_post_processors
 from lerobot.jobs import submit_to_hf
 from lerobot.optim.factory import make_optimizer_and_scheduler
 from lerobot.policies import PreTrainedPolicy, make_policy, make_pre_post_processors
+from lerobot.processor.rename_processor import rename_transition_keys
 from lerobot.rewards import make_reward_pre_post_processors
 from lerobot.utils.collate import lerobot_collate_fn
 from lerobot.utils.import_utils import register_third_party_plugins
@@ -610,7 +611,7 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
             if cam_key in batch and batch[cam_key].dtype == torch.uint8:
                 batch[cam_key] = batch[cam_key].to(dtype=torch.float32) / 255.0
         if cfg.rename_map:
-            batch = {cfg.rename_map.get(key, key): value for key, value in batch.items()}
+            batch = rename_transition_keys(batch, cfg.rename_map)
         batch = preprocessor(batch)
         train_tracker.dataloading_s = time.perf_counter() - start_time
 

--- a/src/lerobot/scripts/lerobot_train.py
+++ b/src/lerobot/scripts/lerobot_train.py
@@ -343,9 +343,10 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
         )
         processor_pretrained_path = None
 
+    dataset_stats = {cfg.rename_map.get(key, key): value for key, value in dataset.meta.stats.items()}
     processor_kwargs = {}
     if (processor_pretrained_path and not cfg.resume) or not processor_pretrained_path:
-        processor_kwargs["dataset_stats"] = dataset.meta.stats
+        processor_kwargs["dataset_stats"] = dataset_stats
 
     if cfg.is_reward_model_training:
         processor_kwargs["dataset_meta"] = dataset.meta
@@ -357,7 +358,7 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
         preprocessor_overrides = {
             "device_processor": {"device": device.type},
             "normalizer_processor": {
-                "stats": dataset.meta.stats,
+                "stats": dataset_stats,
                 "features": {**policy.config.input_features, **policy.config.output_features},
                 "norm_map": policy.config.normalization_mapping,
             },
@@ -365,7 +366,7 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
         }
         postprocessor_overrides = {
             "unnormalizer_processor": {
-                "stats": dataset.meta.stats,
+                "stats": dataset_stats,
                 "features": policy.config.output_features,
                 "norm_map": policy.config.normalization_mapping,
             },
@@ -608,6 +609,8 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
         for cam_key in dataset.meta.camera_keys:
             if cam_key in batch and batch[cam_key].dtype == torch.uint8:
                 batch[cam_key] = batch[cam_key].to(dtype=torch.float32) / 255.0
+        if cfg.rename_map:
+            batch = {cfg.rename_map.get(key, key): value for key, value in batch.items()}
         batch = preprocessor(batch)
         train_tracker.dataloading_s = time.perf_counter() - start_time
 

--- a/src/lerobot/scripts/lerobot_train.py
+++ b/src/lerobot/scripts/lerobot_train.py
@@ -455,10 +455,46 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
         to_indices = dataset.meta.episodes["dataset_to_index"]
         seed = cfg.seed if cfg.seed is not None else 0
 
+        drop_n_first_frames: int | list[int] = 0
+        target_start_feature = cfg.dataset.training_target_start_feature
+        if target_start_feature is not None:
+            if not hasattr(dataset, "hf_dataset"):
+                raise ValueError(
+                    "dataset.training_target_start_feature is only supported for a single map-style "
+                    "LeRobotDataset."
+                )
+            if target_start_feature not in dataset.hf_dataset.column_names:
+                raise ValueError(
+                    f"Training target start feature {target_start_feature!r} is not present in the dataset. "
+                    f"Available features: {dataset.hf_dataset.column_names}"
+                )
+            start_column = dataset.hf_dataset.data.column(target_start_feature)
+            absolute_to_relative_idx = dataset.absolute_to_relative_idx
+            episode_indices = dataset.episodes if dataset.episodes is not None else range(len(from_indices))
+            drop_n_first_frames = [0] * len(from_indices)
+            for episode_index in episode_indices:
+                absolute_index = int(from_indices[episode_index])
+                relative_index = (
+                    absolute_to_relative_idx[absolute_index]
+                    if absolute_to_relative_idx is not None
+                    else absolute_index
+                )
+                drop_n_first_frames[episode_index] = int(start_column[relative_index].as_py())
+            logging.info(
+                "Restricting training targets with %s: keeping %d of %d frames",
+                target_start_feature,
+                sum(
+                    int(to_indices[index]) - int(from_indices[index]) - drop_n_first_frames[index]
+                    for index in episode_indices
+                ),
+                sum(int(to_indices[index]) - int(from_indices[index]) for index in episode_indices),
+            )
+
         sampler = EpisodeAwareSampler(
             from_indices,
             to_indices,
             episode_indices_to_use=dataset.episodes,
+            drop_n_first_frames=drop_n_first_frames,
             drop_n_last_frames=getattr(active_cfg, "drop_n_last_frames", 0),
             shuffle=True,
             seed=seed,

--- a/tests/datasets/test_sampler.py
+++ b/tests/datasets/test_sampler.py
@@ -60,6 +60,26 @@ def test_drop_n_first_frames():
     assert list(sampler) == [1, 4, 5]
 
 
+def test_drop_different_number_of_first_frames_per_episode():
+    sampler = EpisodeAwareSampler(
+        dataset_from_indices=[0, 3, 5],
+        dataset_to_indices=[3, 5, 9],
+        drop_n_first_frames=[1, 0, 3],
+    )
+    assert sampler.indices == [1, 2, 3, 4, 8]
+    assert len(sampler) == 5
+
+
+def test_drop_first_frames_sequence_must_match_episode_count():
+    with pytest.raises(ValueError, match="one value per episode"):
+        EpisodeAwareSampler([0, 3], [3, 6], drop_n_first_frames=[1])
+
+
+def test_drop_first_frames_sequence_must_be_non_negative():
+    with pytest.raises(ValueError, match="must be >= 0"):
+        EpisodeAwareSampler([0, 3], [3, 6], drop_n_first_frames=[1, -1])
+
+
 def test_drop_n_last_frames():
     dataset = Dataset.from_dict(
         {

--- a/tests/policies/smolvla/test_visual_memory.py
+++ b/tests/policies/smolvla/test_visual_memory.py
@@ -1,0 +1,210 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+from lerobot.datasets.factory import resolve_delta_timestamps
+from lerobot.policies.smolvla.configuration_smolvla import SmolVLAConfig
+from lerobot.policies.smolvla.visual_memory import (
+    causal_temporal_mask,
+    encode_video_with_mem,
+    sample_visual_history,
+    temporal_sinusoidal_embedding,
+)
+
+
+def test_visual_memory_observation_delta_indices():
+    baseline = SmolVLAConfig()
+    memory = SmolVLAConfig(use_visual_memory=True, visual_memory_frames=6, visual_memory_stride=10)
+
+    assert baseline.observation_delta_indices == [0]
+    assert memory.observation_delta_indices == [-50, -40, -30, -20, -10, 0]
+
+
+def test_delta_timestamps_respect_raw_dataset_rename_map():
+    class RawMetadata:
+        fps = 10
+        features = {"image": {}, "state": {}, "actions": {}}
+
+    config = SmolVLAConfig(use_visual_memory=True, visual_memory_frames=3, visual_memory_stride=5)
+    delta_timestamps = resolve_delta_timestamps(
+        config,
+        RawMetadata(),
+        {
+            "image": "observation.images.camera1",
+            "state": "observation.state",
+            "actions": "action",
+        },
+    )
+
+    assert delta_timestamps["image"] == [-1.0, -0.5, 0.0]
+    assert delta_timestamps["state"] == [-1.0, -0.5, 0.0]
+    assert delta_timestamps["actions"] == [index / 10 for index in range(50)]
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("visual_memory_frames", 0),
+        ("visual_memory_stride", 0),
+        ("visual_memory_temporal_attention_every", 0),
+    ],
+)
+def test_visual_memory_config_rejects_non_positive_values(field, value):
+    with pytest.raises(ValueError, match=field):
+        SmolVLAConfig(**{field: value})
+
+
+def test_current_temporal_position_is_exactly_zero():
+    embedding = temporal_sinusoidal_embedding(4, 16, device=torch.device("cpu"), dtype=torch.float32)
+
+    torch.testing.assert_close(embedding[-1], torch.zeros(16))
+    assert torch.count_nonzero(embedding[:-1]) > 0
+
+
+def test_causal_temporal_mask_combines_causality_and_padding():
+    frame_mask = torch.tensor([[False, True, True]])
+    mask = causal_temporal_mask(frame_mask, dtype=torch.float32, num_patches=2)
+
+    assert mask.shape == (2, 1, 3, 3)
+    assert mask[0, 0, 1, 0] < -1e30
+    assert mask[0, 0, 1, 1] == 0
+    assert mask[0, 0, 1, 2] < -1e30
+    assert mask[0, 0, 2, 1] == 0
+
+
+def test_inference_history_matches_training_order_and_padding():
+    history = [torch.full((2, 1), value) for value in range(11)]
+
+    initial_video, initial_padding = sample_visual_history(history, num_frames=3, stride=5, steps_seen=1)
+    full_video, full_padding = sample_visual_history(history, num_frames=3, stride=5, steps_seen=11)
+
+    assert initial_video[:, :, 0].tolist() == [[0, 5, 10], [0, 5, 10]]
+    assert initial_padding.tolist() == [[True, True, False], [True, True, False]]
+    torch.testing.assert_close(full_video[:, :, 0], torch.tensor([[0, 5, 10], [0, 5, 10]]))
+    assert not full_padding.any()
+
+
+def test_single_frame_mem_matches_original_siglip_encoder():
+    transformers = pytest.importorskip("transformers")
+    config = transformers.SiglipVisionConfig(
+        image_size=16,
+        patch_size=8,
+        hidden_size=16,
+        intermediate_size=32,
+        num_hidden_layers=4,
+        num_attention_heads=4,
+        vision_use_head=False,
+    )
+    from transformers.models.siglip.modeling_siglip import SiglipVisionTransformer
+
+    model = SiglipVisionTransformer(config).eval()
+    image = torch.randn(2, 3, 16, 16)
+
+    expected = model(image).last_hidden_state
+    actual = encode_video_with_mem(
+        model,
+        image[:, None],
+        torch.ones(2, 1, dtype=torch.bool),
+        temporal_attention_every=4,
+    )
+
+    torch.testing.assert_close(actual, expected)
+
+
+def test_mem_video_encoder_compresses_time_without_new_parameters():
+    transformers = pytest.importorskip("transformers")
+    config = transformers.SiglipVisionConfig(
+        image_size=16,
+        patch_size=8,
+        hidden_size=16,
+        intermediate_size=32,
+        num_hidden_layers=4,
+        num_attention_heads=4,
+        vision_use_head=False,
+    )
+    from transformers.models.siglip.modeling_siglip import SiglipVisionTransformer
+
+    model = SiglipVisionTransformer(config)
+    parameter_ids = {id(parameter) for parameter in model.parameters()}
+    video = torch.randn(2, 3, 3, 16, 16, requires_grad=True)
+
+    output = encode_video_with_mem(
+        model,
+        video,
+        torch.ones(2, 3, dtype=torch.bool),
+        temporal_attention_every=4,
+    )
+    output.sum().backward()
+
+    assert output.shape == (2, 4, 16)
+    assert {id(parameter) for parameter in model.parameters()} == parameter_ids
+    assert video.grad is not None
+
+
+def test_mem_video_encoder_supports_smolvlm_vision_tower():
+    transformers = pytest.importorskip("transformers")
+    config = transformers.SmolVLMVisionConfig(
+        image_size=16,
+        patch_size=8,
+        hidden_size=16,
+        intermediate_size=32,
+        num_hidden_layers=4,
+        num_attention_heads=4,
+    )
+    from transformers.models.smolvlm.modeling_smolvlm import SmolVLMVisionTransformer
+
+    model = SmolVLMVisionTransformer(config).eval()
+    video = torch.randn(2, 3, 3, 16, 16)
+
+    output = encode_video_with_mem(
+        model,
+        video,
+        torch.ones(2, 3, dtype=torch.bool),
+        temporal_attention_every=4,
+    )
+    single_frame = encode_video_with_mem(
+        model,
+        video[:, -1:],
+        torch.ones(2, 1, dtype=torch.bool),
+        temporal_attention_every=4,
+    )
+
+    assert output.shape == (2, 4, 16)
+    torch.testing.assert_close(single_frame, model(video[:, -1]).last_hidden_state)
+
+
+def test_masked_history_cannot_change_current_embedding():
+    transformers = pytest.importorskip("transformers")
+    config = transformers.SmolVLMVisionConfig(
+        image_size=16,
+        patch_size=8,
+        hidden_size=16,
+        intermediate_size=32,
+        num_hidden_layers=4,
+        num_attention_heads=4,
+    )
+    from transformers.models.smolvlm.modeling_smolvlm import SmolVLMVisionTransformer
+
+    model = SmolVLMVisionTransformer(config).eval()
+    first_video = torch.randn(1, 3, 3, 16, 16)
+    second_video = first_video.clone()
+    second_video[:, :2] = torch.randn_like(second_video[:, :2]) * 100
+    frame_mask = torch.tensor([[False, False, True]])
+
+    first_output = encode_video_with_mem(model, first_video, frame_mask, temporal_attention_every=4)
+    second_output = encode_video_with_mem(model, second_video, frame_mask, temporal_attention_every=4)
+
+    torch.testing.assert_close(first_output, second_output)

--- a/tests/processor/test_rename_processor.py
+++ b/tests/processor/test_rename_processor.py
@@ -27,7 +27,7 @@ from lerobot.processor import (
     TransitionKey,
 )
 from lerobot.processor.converters import create_transition, identity_transition
-from lerobot.processor.rename_processor import rename_stats
+from lerobot.processor.rename_processor import rename_stats, rename_transition_keys
 from lerobot.utils.constants import ACTION, OBS_IMAGE, OBS_IMAGES, OBS_STATE
 from tests.conftest import assert_contract_is_typed
 
@@ -62,6 +62,22 @@ def test_basic_renaming():
 
     # Check unchanged key is preserved
     assert processed_obs["unchanged_key"] == "keep_me"
+
+
+def test_renaming_preserves_feature_suffixes_for_sampling_metadata():
+    data = {
+        "image": torch.zeros(1),
+        "image_is_pad": torch.ones(1, dtype=torch.bool),
+        "image_padding_mask": torch.ones(1, dtype=torch.bool),
+    }
+
+    result = rename_transition_keys(data, {"image": "observation.images.camera1"})
+
+    assert set(result) == {
+        "observation.images.camera1",
+        "observation.images.camera1_is_pad",
+        "observation.images.camera1_padding_mask",
+    }
 
 
 def test_empty_rename_map():

--- a/tests/test_robomme_env.py
+++ b/tests/test_robomme_env.py
@@ -44,7 +44,10 @@ def _install_robomme_stub():
                 "joint_state_list": [np.zeros(7, dtype=np.float32)],
                 "gripper_state_list": [np.zeros(2, dtype=np.float32)],
             }
-            env.reset.return_value = (obs, {"status": "ongoing", "task_goal": "pick the cube"})
+            env.reset.return_value = (
+                obs,
+                {"status": "ongoing", "task_goal": ["pick the cube", "pick the blue cube"]},
+            )
             env.step.return_value = (obs, 0.0, False, False, {"status": "ongoing", "task_goal": ""})
             return env
 
@@ -114,6 +117,21 @@ def test_robomme_features_action_dim_ee_pose():
 # ---------------------------------------------------------------------------
 # Obs conversion (pure Python, no sim)
 # ---------------------------------------------------------------------------
+
+
+def test_reset_exposes_episode_task_description():
+    """VLA evaluation receives the episode-specific language instruction."""
+    _install_robomme_stub()
+    try:
+        from lerobot.envs.robomme import RoboMMEGymEnv
+
+        env = RoboMMEGymEnv(task="PickXtimes")
+        env.reset()
+
+        assert env.task == "PickXtimes"
+        assert env.task_description == "pick the cube"
+    finally:
+        _uninstall_robomme_stub()
 
 
 def test_convert_obs_list_format():

--- a/tests/training/test_gradient_accumulation.py
+++ b/tests/training/test_gradient_accumulation.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+from accelerate import Accelerator
+from torch import nn
+
+from lerobot.scripts.lerobot_train import update_policy
+from lerobot.utils.logging_utils import AverageMeter, MetricsTracker
+
+
+class TinyPolicy(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.projection = nn.Linear(2, 1, bias=False)
+
+    def forward(self, batch):
+        loss = self.projection(batch["x"]).square().mean()
+        return loss, {}
+
+
+def test_gradient_accumulation_steps_optimizer_and_scheduler_once():
+    accelerator = Accelerator(
+        cpu=True,
+        gradient_accumulation_steps=2,
+        step_scheduler_with_optimizer=False,
+    )
+    policy = TinyPolicy()
+    optimizer = torch.optim.SGD(policy.parameters(), lr=0.1)
+    scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=1, gamma=0.5)
+    policy, optimizer, scheduler = accelerator.prepare(policy, optimizer, scheduler)
+    metrics = {
+        "loss": AverageMeter("loss"),
+        "grad_norm": AverageMeter("grad_norm"),
+        "lr": AverageMeter("lr"),
+        "update_s": AverageMeter("update_s"),
+    }
+    tracker = MetricsTracker(1, 2, 1, metrics, accelerator=accelerator)
+    batch = {"x": torch.ones(1, 2)}
+    before = policy.projection.weight.detach().clone()
+
+    with accelerator.accumulate(policy):
+        update_policy(
+            tracker,
+            policy,
+            batch,
+            optimizer,
+            grad_clip_norm=0,
+            accelerator=accelerator,
+            lr_scheduler=scheduler,
+            log_metrics=False,
+        )
+    after_first_microbatch = policy.projection.weight.detach().clone()
+
+    with accelerator.accumulate(policy):
+        update_policy(
+            tracker,
+            policy,
+            batch,
+            optimizer,
+            grad_clip_norm=0,
+            accelerator=accelerator,
+            lr_scheduler=scheduler,
+            log_metrics=False,
+        )
+    after_optimizer_step = policy.projection.weight.detach().clone()
+
+    torch.testing.assert_close(after_first_microbatch, before)
+    assert not torch.equal(after_optimizer_step, after_first_microbatch)
+    assert optimizer.param_groups[0]["lr"] == pytest.approx(0.05)


### PR DESCRIPTION
## Summary

Adds an opt-in, post-training-only implementation of the short-horizon visual-memory path from MEM to SmolVLA.

- adds configurable temporal visual context (`use_visual_memory`, frame count, stride, and temporal-attention frequency)
- applies causal temporal attention between matching image patches every fourth vision layer without adding learnable parameters
- keeps an inference-time image queue per camera and clears it on environment reset
- drops historical visual tokens before the VLA backbone, retaining only the contextualized current observation
- preserves the original single-frame path when visual memory is disabled
- adds sample-matched gradient accumulation and RoboMME training/evaluation fixes needed for the ablation
- documents and scripts the matched RoboMME experiment

This PR targets `feat/smolvla-on-steerable` because the SmolVLA implementation builds on that feature branch.

## RoboMME experiment

Both policies use the same SmolVLA initialization, execution targets, 80,000 optimizer steps, and effective global batch size of 64.

- baseline: 2 H100s, batch 32/GPU, no accumulation, visual memory disabled
- MEM: 4 H100s, batch 8/GPU, accumulation 2, visual memory enabled
- visual context: 6 frames at offsets `[-50, -40, -30, -20, -10, 0]` (5 seconds at 10 Hz)

The completed baseline RoboMME evaluation scored 67/800 successes (8.375%). The full matched MEM evaluation is still pending; its first attempt was interrupted by an unrelated concurrent evaluation on the 5090 before a valid task chunk was written.

## Validation

- focused test suite: 94 passed, 3 skipped
- pre-commit checks passed for changed files
- both 80k training jobs completed successfully
