### PR TITLE
feat(pi05): add optional training-time RTC

### DIFF
--- a/docs/source/inference.mdx
+++ b/docs/source/inference.mdx
@@ -230,12 +230,13 @@ lerobot-rollout \
     --device=cuda
 ```
 
-| Flag                                        | Description                                                    |
-| ------------------------------------------- | -------------------------------------------------------------- |
-| `--inference.rtc.execution_horizon`         | Steps to blend with previous chunk (default: varies by policy) |
-| `--inference.rtc.max_guidance_weight`       | Consistency enforcement strength (default: varies by policy)   |
-| `--inference.rtc.prefix_attention_schedule` | Blend schedule: `LINEAR`, `EXP`, `ONES`, `ZEROS`               |
-| `--inference.queue_threshold`               | Max queue size before backpressure (default: 30)               |
+| Flag                                        | Description                                                                    |
+| ------------------------------------------- | ------------------------------------------------------------------------------ |
+| `--inference.rtc.execution_horizon`         | Steps to blend with previous chunk (default: varies by policy)                 |
+| `--inference.rtc.mode`                      | `guided` (default) or trained-prefix `trained` for compatible Pi05 checkpoints |
+| `--inference.rtc.max_guidance_weight`       | Consistency enforcement strength (default: varies by policy)                   |
+| `--inference.rtc.prefix_attention_schedule` | Blend schedule: `LINEAR`, `EXP`, `ONES`, `ZEROS`                               |
+| `--inference.queue_threshold`               | Backpressure threshold; trained RTC requires at least its maximum delay        |
 
 See the [Real-Time Chunking](./rtc) guide for details on tuning RTC parameters.
 

--- a/docs/source/pi05.mdx
+++ b/docs/source/pi05.mdx
@@ -207,9 +207,11 @@ lerobot-rollout \
     --device=cuda
 ```
 
-Set both `inference.rtc.execution_horizon` and `inference.queue_threshold` to at
-least the checkpoint's `rtc_training_max_delay`. Rollout stops with an explicit
-error if measured latency exceeds that trained range. The default
+Set `inference.rtc.execution_horizon` between the checkpoint's
+`rtc_training_max_delay` and `chunk_size - rtc_training_max_delay`, and
+`inference.queue_threshold` to at least `rtc_training_max_delay`. A one-off
+latency spike past the trained range discards that chunk and retries; rollout
+stops with an explicit error only if the delay stays out of range. The default
 `--inference.rtc.mode=guided` remains available for ordinary checkpoints.
 
 ### Loading a checkpoint

--- a/docs/source/pi05.mdx
+++ b/docs/source/pi05.mdx
@@ -164,6 +164,54 @@ lerobot-train \
   - [lerobot/pi05_base](https://huggingface.co/lerobot/pi05_base)
   - [lerobot/pi05_libero_base](https://huggingface.co/lerobot/pi05_libero_base) (specifically trained on the Libero dataset)
 
+### Optional training-time RTC
+
+Pi05 can optionally learn action-prefix conditioning for efficient
+[Real-Time Chunking](./rtc), following
+[Training-Time Action Conditioning for Efficient Real-Time Chunking](https://arxiv.org/abs/2512.05964).
+Set `policy.rtc_training_max_delay` to the largest expected inference delay in
+controller steps:
+
+```bash
+lerobot-train \
+    --dataset.repo_id=${HF_USER}/my_dataset \
+    --policy.type=pi05 \
+    --policy.pretrained_path=lerobot/pi05_base \
+    --policy.rtc_training_max_delay=10 \
+    --policy.dtype=bfloat16 \
+    --policy.device=cuda \
+    --batch_size=8 \
+    --steps=30000 \
+    --output_dir=outputs/pi05_rtc \
+    --job_name=pi05_rtc
+```
+
+The default is `0`, which disables training-time RTC and leaves the standard
+Pi05 objective unchanged. The configured delay must be smaller than
+`chunk_size`. During training, Pi05 samples a clean prefix length independently
+for each example and computes flow loss only on the remaining postfix.
+
+Use the resulting checkpoint with trained RTC explicitly:
+
+```bash
+lerobot-rollout \
+    --strategy.type=base \
+    --policy.path=outputs/pi05_rtc/checkpoints/last/pretrained_model \
+    --inference.type=rtc \
+    --inference.rtc.mode=trained \
+    --inference.rtc.execution_horizon=10 \
+    --robot.type=so100_follower \
+    --robot.port=/dev/ttyACM0 \
+    --task="pick up the cube" \
+    --fps=50 \
+    --device=cuda
+```
+
+Set both `inference.rtc.execution_horizon` and `inference.queue_threshold` to at
+least the checkpoint's `rtc_training_max_delay`. Rollout stops with an explicit
+error if measured latency exceeds that trained range. The default
+`--inference.rtc.mode=guided` remains available for ordinary checkpoints.
+
 ### Loading a checkpoint
 
 The two forms are not interchangeable:

--- a/docs/source/rtc.mdx
+++ b/docs/source/rtc.mdx
@@ -99,7 +99,9 @@ for step in range(num_steps):
 
 For trained mode, both `execution_horizon` and the rollout backend's
 `inference.queue_threshold` must be at least the checkpoint's
-`rtc_training_max_delay`; rollout validates this before connecting the robot.
+`rtc_training_max_delay`, and `execution_horizon` must not exceed
+`chunk_size - rtc_training_max_delay` (the `d <= s <= H - d` bound from the RTC
+paper); rollout validates this before connecting the robot.
 
 **`execution_horizon`**: How many timesteps from the previous chunk to maintain consistency with. Higher values mean smoother transitions but potentially less reactivity.
 

--- a/docs/source/rtc.mdx
+++ b/docs/source/rtc.mdx
@@ -1,6 +1,6 @@
 # Real-Time Chunking (RTC)
 
-Real-Time Chunking (RTC) is an inference-time method that allows large, flow-matching based robotic policies, such as [Pi0](./pi0), [Pi0.5](./pi05), and [SmolVLA](./smolvla), to produce smooth, continuous, and reactive motion despite having high inference latency.
+Real-Time Chunking (RTC) allows large, flow-matching based robotic policies, such as [Pi0](./pi0), [Pi0.5](./pi05), and [SmolVLA](./smolvla), to produce smooth, continuous, and reactive motion despite having high inference latency. LeRobot provides the original inference-time guided mode and, for compatible Pi05 checkpoints, training-time action conditioning with cheap hard-prefix inference.
 
 These policies generate chunks of future actions (e.g., 50 steps at a time) instead of single actions.
 Because the models are large, producing each chunk takes longer than the time it takes the robot to execute it.
@@ -92,6 +92,15 @@ for step in range(num_steps):
 
 `RTCConfig` has the following parameters to tune:
 
+**`mode`** selects the action-prefix conditioning method:
+
+- `guided` (default) applies the original Jacobian guidance during denoising and works with ordinary flow-matching checkpoints.
+- `trained` hard-inpaints the previous chunk's prefix with per-action flow timesteps. It currently requires a Pi05 checkpoint trained with `policy.rtc_training_max_delay > 0` and avoids the guidance backward pass.
+
+For trained mode, both `execution_horizon` and the rollout backend's
+`inference.queue_threshold` must be at least the checkpoint's
+`rtc_training_max_delay`; rollout validates this before connecting the robot.
+
 **`execution_horizon`**: How many timesteps from the previous chunk to maintain consistency with. Higher values mean smoother transitions but potentially less reactivity.
 
 Typical values: 8-12 steps
@@ -124,6 +133,10 @@ python examples/rtc/eval_dataset.py \
     --device=cuda
 ```
 
+Add `--rtc.mode=trained` when evaluating a compatible training-time RTC Pi05
+checkpoint. Unsupported policies reject trained mode instead of falling back to
+guided RTC.
+
 The script generates a visualization of the denoising process, comparing standard generation (left) with RTC (right). In the RTC plots, you can see how the first few steps (blue/purple lines) are guided to match the red ground truth trajectory (previous chunk's tail), ensuring a smooth transition between chunks.
 
 <p align="center">
@@ -141,11 +154,30 @@ lerobot-rollout \
     --strategy.type=base \
     --policy.path=${HF_USERNAME}/policy_repo_id \
     --inference.type=rtc \
+    --inference.rtc.mode=guided \
     --inference.rtc.execution_horizon=10 \
     --inference.rtc.max_guidance_weight=10.0 \
     --robot.type=so100_follower \
     --robot.port=/dev/tty.usbmodem58FA0834591 \
     --robot.cameras="{ gripper: {type: opencv, index_or_path: 1, width: 640, height: 480, fps: 30}, front: {type: opencv, index_or_path: 0, width: 640, height: 480, fps: 30}}" \
+    --task="Move green small object into the purple platform" \
+    --duration=120 \
+    --device=cuda
+```
+
+For a training-time RTC Pi05 checkpoint, change the mode to `trained`. The
+checkpoint records its maximum supported delay, and rollout validates measured
+latency against it:
+
+```bash
+lerobot-rollout \
+    --strategy.type=base \
+    --policy.path=${HF_USERNAME}/pi05_training_rtc \
+    --inference.type=rtc \
+    --inference.rtc.mode=trained \
+    --inference.rtc.execution_horizon=10 \
+    --robot.type=so100_follower \
+    --robot.port=/dev/tty.usbmodem58FA0834591 \
     --task="Move green small object into the purple platform" \
     --duration=120 \
     --device=cuda
@@ -189,3 +221,5 @@ See `examples/rtc/eval_dataset.py` for a complete example of offline RTC visuali
 - [Smooth-As-Butter Robot Policies](https://alexander-soare.github.io/robotics/2025/08/05/smooth-as-butter-robot-policies.html) - Excellent technical explanation with real robot results
 - [Physical Intelligence - Real-Time Chunking](https://www.physicalintelligence.company/research/real_time_chunking) - Original paper and research
 - [Kinetix RTC Implementation](https://github.com/Physical-Intelligence/real-time-chunking-kinetix) - Reference implementation from Physical Intelligence
+- [Training-Time Action Conditioning](https://arxiv.org/abs/2512.05964) - Efficient RTC with clean-prefix conditioning during training
+- [RLDX-1](https://github.com/RLWRLD/RLDX-1) - PyTorch reference used for the training-time RTC integration

--- a/examples/rtc/eval_dataset.py
+++ b/examples/rtc/eval_dataset.py
@@ -306,6 +306,7 @@ class RTCEvaluator:
         # Configure RTC
         rtc_config = RTCConfig(
             enabled=rtc_enabled,
+            mode=self.cfg.rtc.mode,
             execution_horizon=self.cfg.rtc.execution_horizon,
             max_guidance_weight=self.cfg.rtc.max_guidance_weight,
             prefix_attention_schedule=self.cfg.rtc.prefix_attention_schedule,

--- a/src/lerobot/policies/common/flow_matching.py
+++ b/src/lerobot/policies/common/flow_matching.py
@@ -68,6 +68,8 @@ def euler_integrate(
     inference_delay: int | None = None,
     prev_chunk_left_over: Tensor | None = None,
     execution_horizon: int | None = None,
+    hard_prefix: Tensor | None = None,
+    hard_prefix_mask: Tensor | None = None,
 ) -> Tensor:
     """Forward-Euler integration of a velocity field from t=1 (noise) to t=0 (actions).
 
@@ -89,6 +91,8 @@ def euler_integrate(
         inference_delay: RTC guidance parameter, forwarded verbatim.
         prev_chunk_left_over: RTC guidance parameter, forwarded verbatim.
         execution_horizon: RTC guidance parameter, forwarded verbatim.
+        hard_prefix: Optional clean action prefix to clamp throughout denoising.
+        hard_prefix_mask: Boolean mask selecting the values clamped from ``hard_prefix``.
     """
     bsize = noise.shape[0]
     device = noise.device
@@ -98,6 +102,13 @@ def euler_integrate(
     for step in range(num_steps):
         time = 1.0 + step * dt
         time_tensor = torch.tensor(time, dtype=torch.float32, device=device).expand(bsize)
+
+        if hard_prefix is not None:
+            if hard_prefix_mask is None:
+                raise ValueError("hard_prefix_mask is required when hard_prefix is provided")
+            x_t = torch.where(hard_prefix_mask, hard_prefix, x_t)
+            time_tensor = time_tensor[:, None].expand(bsize, x_t.shape[1]).clone()
+            time_tensor[hard_prefix_mask[..., 0]] = 0.0
 
         def denoise_step_partial_call(input_x_t, current_timestep=time_tensor):
             return denoise_fn(input_x_t, current_timestep)
@@ -115,6 +126,9 @@ def euler_integrate(
             v_t = denoise_step_partial_call(x_t)
 
         x_t = x_t + dt * v_t
+
+        if hard_prefix is not None:
+            x_t = torch.where(hard_prefix_mask, hard_prefix, x_t)
 
         if rtc_processor is not None and rtc_processor.is_debug_enabled():
             rtc_processor.track(time=time, x_t=x_t, v_t=v_t)

--- a/src/lerobot/policies/common/vla_utils.py
+++ b/src/lerobot/policies/common/vla_utils.py
@@ -41,21 +41,20 @@ else:
 def create_sinusoidal_pos_embedding(  # see openpi `create_sinusoidal_pos_embedding` (exact copy)
     time: torch.Tensor, dimension: int, min_period: float, max_period: float, device="cpu"
 ) -> Tensor:
-    """Computes sine-cosine positional embedding vectors for scalar positions."""
+    """Compute sine-cosine embeddings for scalar or per-action positions."""
     if dimension % 2 != 0:
         raise ValueError(f"dimension ({dimension}) must be divisible by 2")
 
-    if time.ndim != 1:
-        raise ValueError("The time tensor is expected to be of shape `(batch_size, )`.")
+    if time.ndim not in (1, 2):
+        raise ValueError("The time tensor must have shape (batch_size,) or (batch_size, action_horizon).")
 
     dtype = get_safe_dtype(torch.float64, device.type)
     fraction = torch.linspace(0.0, 1.0, dimension // 2, dtype=dtype, device=device)
     period = min_period * (max_period / min_period) ** fraction
 
-    # Compute the outer product
     scaling_factor = 1.0 / period * 2 * math.pi
-    sin_input = scaling_factor[None, :] * time[:, None]
-    return torch.cat([torch.sin(sin_input), torch.cos(sin_input)], dim=1)
+    sin_input = time[..., None] * scaling_factor
+    return torch.cat([torch.sin(sin_input), torch.cos(sin_input)], dim=-1)
 
 
 def make_att_2d_masks(pad_masks: Tensor, att_masks: Tensor) -> Tensor:  # see openpi (exact copy)

--- a/src/lerobot/policies/pi05/configuration_pi05.py
+++ b/src/lerobot/policies/pi05/configuration_pi05.py
@@ -58,6 +58,8 @@ class PI05Config(PreTrainedConfig):
 
     # Real-Time Chunking (RTC) configuration
     rtc_config: RTCConfig | None = None
+    # Maximum clean action-prefix length sampled during training. Zero disables trained RTC.
+    rtc_training_max_delay: int = 0
 
     image_resolution: tuple[int, int] = (
         DEFAULT_IMAGE_SIZE,
@@ -110,6 +112,11 @@ class PI05Config(PreTrainedConfig):
         if self.n_action_steps > self.chunk_size:
             raise ValueError(
                 f"n_action_steps ({self.n_action_steps}) cannot be greater than chunk_size ({self.chunk_size})"
+            )
+        if not 0 <= self.rtc_training_max_delay < self.chunk_size:
+            raise ValueError(
+                "rtc_training_max_delay must satisfy "
+                f"0 <= delay < chunk_size ({self.chunk_size}), got {self.rtc_training_max_delay}"
             )
 
         if self.paligemma_variant not in ["gemma_300m", "gemma_2b"]:

--- a/src/lerobot/policies/pi05/configuration_pi05.py
+++ b/src/lerobot/policies/pi05/configuration_pi05.py
@@ -103,8 +103,6 @@ class PI05Config(PreTrainedConfig):
     scheduler_decay_steps: int = 30_000
     scheduler_decay_lr: float = 2.5e-6
 
-    tokenizer_max_length: int = 200  # see openpi `__post_init__`
-
     def __post_init__(self):
         super().__post_init__()
 

--- a/src/lerobot/policies/pi05/modeling_pi05.py
+++ b/src/lerobot/policies/pi05/modeling_pi05.py
@@ -71,6 +71,107 @@ class ActionSelectKwargs(TypedDict, total=False):
     execution_horizon: int | None
 
 
+def _prepare_trained_rtc_prefix(
+    x_t: Tensor,
+    prev_chunk_left_over: Tensor | None,
+    inference_delay: int,
+    training_max_delay: int,
+) -> tuple[Tensor | None, Tensor | None]:
+    """Pad and validate a hard prefix for training-time RTC inference."""
+    if prev_chunk_left_over is None or inference_delay <= 0:
+        return None, None
+    if training_max_delay <= 0:
+        raise ValueError(
+            "RTC mode='trained' requires a checkpoint trained with policy.rtc_training_max_delay > 0."
+        )
+    if inference_delay > training_max_delay:
+        raise ValueError(
+            f"Measured RTC inference delay ({inference_delay}) exceeds the checkpoint's "
+            f"rtc_training_max_delay ({training_max_delay})."
+        )
+    if inference_delay >= x_t.shape[1]:
+        raise ValueError(
+            f"RTC inference delay ({inference_delay}) must be smaller than chunk_size ({x_t.shape[1]})."
+        )
+
+    previous = prev_chunk_left_over.to(device=x_t.device, dtype=x_t.dtype)
+    if not torch.isfinite(previous).all():
+        raise ValueError("RTC prefix contains NaN or Inf values.")
+    if previous.ndim == 2:
+        previous = previous.unsqueeze(0)
+    if previous.ndim != 3:
+        raise ValueError(f"Expected RTC prefix shape (B, T, A), got {tuple(previous.shape)}")
+    if previous.shape[0] == 1 and x_t.shape[0] > 1:
+        previous = previous.expand(x_t.shape[0], -1, -1)
+    if previous.shape[0] != x_t.shape[0]:
+        raise ValueError(
+            f"RTC prefix batch size ({previous.shape[0]}) does not match policy batch ({x_t.shape[0]})."
+        )
+    if previous.shape[1] < inference_delay:
+        raise ValueError(f"RTC prefix has {previous.shape[1]} steps, but inference_delay={inference_delay}.")
+    if previous.shape[2] > x_t.shape[2]:
+        raise ValueError(
+            f"RTC prefix action dimension ({previous.shape[2]}) exceeds model dimension ({x_t.shape[2]})."
+        )
+
+    padded_prefix = torch.zeros_like(x_t)
+    padded_prefix[:, :inference_delay, : previous.shape[2]] = previous[:, :inference_delay]
+    prefix_mask = torch.arange(x_t.shape[1], device=x_t.device) < inference_delay
+    prefix_mask = prefix_mask[None, :, None].expand(x_t.shape[0], -1, x_t.shape[2])
+    return padded_prefix, prefix_mask
+
+
+def _sample_training_rtc_prefix_mask(
+    batch_size: int,
+    action_horizon: int,
+    max_delay: int,
+    device: torch.device,
+) -> Tensor | None:
+    """Sample a clean action-prefix length independently for each training example."""
+    if max_delay <= 0:
+        return None
+    delays = torch.randint(0, max_delay + 1, (batch_size,), device=device)
+    positions = torch.arange(action_horizon, device=device)
+    return positions.unsqueeze(0) < delays.unsqueeze(1)
+
+
+def _build_flow_matching_inputs(
+    actions: Tensor,
+    noise: Tensor,
+    time: Tensor,
+    prefix_mask: Tensor | None,
+) -> tuple[Tensor, Tensor]:
+    """Keep the sampled RTC prefix clean while noising the remaining action chunk."""
+    if prefix_mask is None:
+        model_time = time
+        expanded_time = time[:, None, None]
+    else:
+        model_time = time[:, None].expand_as(prefix_mask)
+        model_time = torch.where(prefix_mask, torch.zeros_like(model_time), model_time)
+        expanded_time = model_time.unsqueeze(-1)
+    x_t = expanded_time * noise + (1 - expanded_time) * actions
+    return x_t, model_time
+
+
+def _reduce_training_rtc_loss(
+    losses: Tensor,
+    prefix_mask: Tensor | None,
+    reduction: str,
+) -> Tensor:
+    """Average flow loss over predicted postfix actions, excluding the clean RTC prefix."""
+    if reduction not in {"mean", "none"}:
+        raise ValueError(f"Unsupported loss reduction: {reduction!r}")
+    if prefix_mask is None:
+        return losses.mean() if reduction == "mean" else losses.mean(dim=(1, 2))
+
+    postfix_mask = (~prefix_mask).unsqueeze(-1).expand_as(losses)
+    if reduction == "none":
+        numerator = (losses * postfix_mask).sum(dim=(1, 2))
+        denominator = postfix_mask.sum(dim=(1, 2))
+        return numerator / denominator.clamp(min=1)
+    return (losses * postfix_mask).sum() / postfix_mask.sum().clamp(min=1)
+
+
 # Define the complete layer computation function for gradient checkpointing
 def compute_layer_complete(inputs_embeds, attention_mask, position_ids, adarms_cond, layers, rotary_emb):
     query_states = []
@@ -561,14 +662,23 @@ class PI05Pytorch(nn.Module):  # see openpi `PI0Pytorch`
 
         return action_emb, pad_masks, att_masks, adarms_cond
 
-    def forward(self, images, img_masks, tokens, masks, actions, noise, time) -> Tensor:
+    def forward(
+        self,
+        images,
+        img_masks,
+        tokens,
+        masks,
+        actions,
+        noise,
+        time,
+        prefix_mask: Tensor | None = None,
+    ) -> Tensor:
         """Do a full training forward pass and compute the loss."""
-        time_expanded = time[:, None, None]
-        x_t = time_expanded * noise + (1 - time_expanded) * actions
+        x_t, model_time = _build_flow_matching_inputs(actions, noise, time, prefix_mask)
         u_t = noise - actions
 
         prefix_embs, prefix_pad_masks, prefix_att_masks = self.embed_prefix(images, img_masks, tokens, masks)
-        suffix_embs, suffix_pad_masks, suffix_att_masks, adarms_cond = self.embed_suffix(x_t, time)
+        suffix_embs, suffix_pad_masks, suffix_att_masks, adarms_cond = self.embed_suffix(x_t, model_time)
 
         if (
             self.paligemma_with_expert.paligemma.model.language_model.layers[0].self_attn.q_proj.weight.dtype
@@ -652,6 +762,24 @@ class PI05Pytorch(nn.Module):  # see openpi `PI0Pytorch`
             use_cache=True,
         )
 
+        rtc_mode = "guided"
+        trained_prefix = trained_prefix_mask = None
+        if self._rtc_enabled():
+            rtc_mode = self.rtc_processor.rtc_config.mode
+            if rtc_mode == "trained":
+                training_max_delay = int(getattr(self.config, "rtc_training_max_delay", 0))
+                if training_max_delay <= 0:
+                    raise ValueError(
+                        "RTC mode='trained' requires a checkpoint trained with "
+                        "policy.rtc_training_max_delay > 0."
+                    )
+                trained_prefix, trained_prefix_mask = _prepare_trained_rtc_prefix(
+                    noise,
+                    kwargs.get("prev_chunk_left_over"),
+                    int(kwargs.get("inference_delay") or 0),
+                    training_max_delay,
+                )
+
         return euler_integrate(
             lambda input_x_t, current_timestep: self.denoise_step(
                 prefix_pad_masks=prefix_pad_masks,
@@ -662,10 +790,12 @@ class PI05Pytorch(nn.Module):  # see openpi `PI0Pytorch`
             noise,
             num_steps,
             rtc_processor=self.rtc_processor,
-            rtc_enabled=self._rtc_enabled(),
+            rtc_enabled=self._rtc_enabled() and rtc_mode == "guided",
             inference_delay=kwargs.get("inference_delay"),
             prev_chunk_left_over=kwargs.get("prev_chunk_left_over"),
             execution_horizon=kwargs.get("execution_horizon"),
+            hard_prefix=trained_prefix,
+            hard_prefix_mask=trained_prefix_mask,
         )
 
     def denoise_step(
@@ -940,7 +1070,10 @@ class PI05Policy(PreTrainedPolicy):
         # Create processor if config provided
         # If RTC is not enabled - we can still track the denoising data
         if self.config.rtc_config is not None:
-            self.rtc_processor = RTCProcessor(self.config.rtc_config)
+            self.rtc_processor = RTCProcessor(
+                self.config.rtc_config,
+                trained_mode_supported=int(getattr(self.config, "rtc_training_max_delay", 0)) > 0,
+            )
 
             model_value = getattr(self, "model", None)
             if model_value is not None:
@@ -1072,28 +1205,35 @@ class PI05Policy(PreTrainedPolicy):
 
         noise = self.model.sample_noise(actions.shape, actions.device)
         time = self.model.sample_time(actions.shape[0], actions.device)
+        prefix_mask = _sample_training_rtc_prefix_mask(
+            actions.shape[0],
+            actions.shape[1],
+            self.config.rtc_training_max_delay,
+            actions.device,
+        )
 
         # Compute loss (no separate state needed for PI05)
-        losses = self.model.forward(images, img_masks, tokens, masks, actions, noise, time)
+        losses = self.model.forward(images, img_masks, tokens, masks, actions, noise, time, prefix_mask)
 
         # Truncate losses to actual action dimensions
         original_action_dim = self.config.output_features[ACTION].shape[0]
         losses = losses[:, :, :original_action_dim]
 
-        loss_dict = {
-            "loss_per_dim": losses.mean(dim=[0, 1]).detach().cpu().numpy().tolist(),
-        }
+        if prefix_mask is None:
+            loss_per_dim = losses.mean(dim=(0, 1))
+        else:
+            postfix_mask = (~prefix_mask).unsqueeze(-1).expand_as(losses)
+            loss_per_dim = (losses * postfix_mask).sum(dim=(0, 1)) / postfix_mask.sum(dim=(0, 1)).clamp(min=1)
+        loss_dict = {"loss_per_dim": loss_per_dim.detach().cpu().numpy().tolist()}
 
         if reduction == "none":
-            # Return per-sample losses (B,) by averaging over time and action dims
-            per_sample_loss = losses.mean(dim=(1, 2))
+            per_sample_loss = _reduce_training_rtc_loss(losses, prefix_mask, reduction="none")
             loss_dict["loss"] = per_sample_loss.mean().item()
             return per_sample_loss, loss_dict
-        else:
-            # Default: return scalar mean loss
-            loss = losses.mean()
-            loss_dict["loss"] = loss.item()
-            return loss, loss_dict
+
+        loss = _reduce_training_rtc_loss(losses, prefix_mask, reduction="mean")
+        loss_dict["loss"] = loss.item()
+        return loss, loss_dict
 
     def _get_default_peft_targets(self) -> dict[str, any]:
         """Return default PEFT target modules for PI0.5 fine-tuning."""

--- a/src/lerobot/policies/pi_gemma.py
+++ b/src/lerobot/policies/pi_gemma.py
@@ -87,6 +87,11 @@ class PiGemmaRMSNorm(nn.Module):
     Adaptive RMSNorm for PI Gemma (AdaRMS).
     When cond_dim is set, uses cond to modulate scale/shift/gate; otherwise behaves like standard GemmaRMSNorm.
     forward(x, cond=None) returns (output, gate) for use with _gated_residual.
+
+    ``cond`` may be ``(batch_size, cond_dim)`` — one modulation shared by every token — or
+    ``(batch_size, seq_len, cond_dim)``, which lets scale/shift/gate differ per token. The
+    per-token form is what training-time RTC needs to mark the clean action prefix with its
+    own flow timestep (arXiv 2512.05964); it adds no parameters.
     """
 
     def __init__(self, dim: int, eps: float = 1e-6, cond_dim: int | None = None):
@@ -120,8 +125,16 @@ class PiGemmaRMSNorm(nn.Module):
             return normed.type_as(x), None
         if cond.shape[-1] != self.cond_dim:
             raise ValueError(f"Expected cond dim {self.cond_dim}, got {cond.shape[-1]}")
+        if cond.ndim not in (2, 3):
+            raise ValueError(f"cond must be (B, cond_dim) or (B, T, cond_dim), got {tuple(cond.shape)}")
+        if x.ndim == 3 and cond.ndim == 3 and cond.shape[1] != x.shape[1]:
+            raise ValueError(
+                f"Per-token cond has {cond.shape[1]} tokens but x has {x.shape[1]}; shapes must match."
+            )
         modulation = self.dense(cond)
-        if len(x.shape) == 3:
+        if x.ndim == 3 and modulation.ndim == 2:
+            # Scalar-per-sample cond: add the token axis so one modulation broadcasts over
+            # all tokens. A per-token cond already carries that axis and must not gain another.
             modulation = modulation.unsqueeze(1)
         scale, shift, gate = modulation.chunk(3, dim=-1)
         normed = normed * (1 + scale.float()) + shift.float()
@@ -224,8 +237,9 @@ class PiGemmaModel(GemmaModel):  # type: ignore[misc]
         **kwargs,
     ) -> BaseModelOutputWithPast:
         """
-        adarms_cond (`torch.Tensor` of shape `(batch_size, cond_dim)`, *optional*):
-            Condition for ADARMS.
+        adarms_cond (`torch.Tensor` of shape `(batch_size, cond_dim)` or
+            `(batch_size, seq_len, cond_dim)`, *optional*):
+            Condition for ADARMS. The per-token form drives training-time RTC.
         """
         output_attentions = (
             output_attentions if output_attentions is not None else self.config.output_attentions

--- a/src/lerobot/policies/rtc/configuration_rtc.py
+++ b/src/lerobot/policies/rtc/configuration_rtc.py
@@ -37,6 +37,10 @@ class RTCConfig:
     # Infrastructure
     enabled: bool = True
 
+    # ``guided`` is the original inference-time Jacobian guidance. ``trained``
+    # hard-inpaints a prefix and requires a compatible training-time RTC checkpoint.
+    mode: str = "guided"
+
     # Core RTC settings
     # Todo change to exp
     prefix_attention_schedule: RTCAttentionSchedule = RTCAttentionSchedule.LINEAR
@@ -49,6 +53,8 @@ class RTCConfig:
 
     def __post_init__(self):
         """Validate RTC configuration parameters."""
+        if self.mode not in {"guided", "trained"}:
+            raise ValueError(f"mode must be 'guided' or 'trained', got {self.mode!r}")
         if self.max_guidance_weight <= 0:
             raise ValueError(f"max_guidance_weight must be positive, got {self.max_guidance_weight}")
         if self.debug_maxlen <= 0:

--- a/src/lerobot/policies/rtc/modeling_rtc.py
+++ b/src/lerobot/policies/rtc/modeling_rtc.py
@@ -42,7 +42,12 @@ class RTCProcessor:
     prefix attention, and adaptive chunk processing.
     """
 
-    def __init__(self, rtc_config: RTCConfig):
+    def __init__(self, rtc_config: RTCConfig, *, trained_mode_supported: bool = False):
+        if rtc_config.enabled and rtc_config.mode == "trained" and not trained_mode_supported:
+            raise ValueError(
+                "RTC mode='trained' requires a PI05-compatible checkpoint trained with "
+                "rtc_training_max_delay > 0."
+            )
         self.rtc_config = rtc_config
 
         self.tracker = None

--- a/src/lerobot/rollout/context.py
+++ b/src/lerobot/rollout/context.py
@@ -128,6 +128,16 @@ def _validate_trained_rtc_rollout_config(policy_config, inference_config: RTCInf
             f"checkpoint's rtc_training_max_delay ({training_max_delay})."
         )
 
+    # RTC requires d <= s <= H - d (arXiv 2506.07339): an execution horizon past H - d would
+    # commit actions the next chunk can no longer re-plan, so the overlap never closes.
+    chunk_size = int(getattr(policy_config, "chunk_size", 0))
+    if chunk_size and rtc.execution_horizon > chunk_size - training_max_delay:
+        raise ValueError(
+            f"--inference.rtc.execution_horizon ({rtc.execution_horizon}) must be at most "
+            f"chunk_size - rtc_training_max_delay ({chunk_size} - {training_max_delay} = "
+            f"{chunk_size - training_max_delay})."
+        )
+
 
 def _resolve_action_key_order(
     policy_action_names: list[str] | None, dataset_action_names: list[str]

--- a/src/lerobot/rollout/context.py
+++ b/src/lerobot/rollout/context.py
@@ -48,6 +48,7 @@ from lerobot.processor import (
 from lerobot.processor.relative_action_processor import RelativeActionsProcessorStep
 from lerobot.robots import make_robot_from_config
 from lerobot.teleoperators import Teleoperator, make_teleoperator_from_config
+from lerobot.utils.constants import OBS_STATE
 from lerobot.utils.feature_utils import combine_feature_dicts, hw_to_dataset_features
 from lerobot.utils.import_utils import _peft_available, require_package
 
@@ -99,6 +100,35 @@ def _wrap_predict_action_chunk_with_torch_compile(
     return True
 
 
+def _validate_trained_rtc_rollout_config(policy_config, inference_config: RTCInferenceConfig) -> None:
+    """Fail fast when rollout cannot retain every trained RTC prefix."""
+    rtc = inference_config.rtc
+    if not rtc.enabled or rtc.mode != "trained":
+        return
+    if policy_config.type != "pi05":
+        raise ValueError(
+            "--inference.rtc.mode=trained currently requires a PI05 checkpoint; "
+            f"got policy type {policy_config.type!r}."
+        )
+
+    training_max_delay = int(getattr(policy_config, "rtc_training_max_delay", 0))
+    if training_max_delay <= 0:
+        raise ValueError(
+            "--inference.rtc.mode=trained requires a checkpoint trained with "
+            "--policy.rtc_training_max_delay > 0."
+        )
+    if rtc.execution_horizon < training_max_delay:
+        raise ValueError(
+            f"--inference.rtc.execution_horizon ({rtc.execution_horizon}) must be at least the "
+            f"checkpoint's rtc_training_max_delay ({training_max_delay})."
+        )
+    if inference_config.queue_threshold < training_max_delay:
+        raise ValueError(
+            f"--inference.queue_threshold ({inference_config.queue_threshold}) must be at least the "
+            f"checkpoint's rtc_training_max_delay ({training_max_delay})."
+        )
+
+
 def _resolve_action_key_order(
     policy_action_names: list[str] | None, dataset_action_names: list[str]
 ) -> list[str]:
@@ -117,6 +147,26 @@ def _resolve_action_key_order(
         logger.warning("policy.action_feature_names keys don't match dataset; using dataset order")
         return dataset_action_names
     return policy_action_names
+
+
+def _align_relative_state_feature_order(
+    hw_features: dict[str, dict], policy_action_names: list[str] | None
+) -> dict[str, dict]:
+    """Align policy-facing state with named relative-action dimensions."""
+    if not policy_action_names or OBS_STATE not in hw_features:
+        return hw_features
+
+    state_feature = hw_features[OBS_STATE]
+    state_names = state_feature.get("names")
+    if not state_names or len(state_names) != len(policy_action_names):
+        return hw_features
+    if set(state_names) != set(policy_action_names) or state_names == policy_action_names:
+        return hw_features
+
+    aligned = dict(hw_features)
+    aligned[OBS_STATE] = {**state_feature, "names": list(policy_action_names)}
+    logger.info("Aligned relative-action state order with checkpoint action names")
+    return aligned
 
 
 # ---------------------------------------------------------------------------
@@ -244,6 +294,9 @@ def build_rollout_context(
     # --- 1. Policy (heavy I/O, but no hardware yet) -------------------
     logger.info("Loading policy from '%s'...", cfg.policy.pretrained_path)
     policy_config = cfg.policy
+
+    if is_rtc:
+        _validate_trained_rtc_rollout_config(policy_config, cfg.inference)
 
     if hasattr(policy_config, "compile_model"):
         policy_config.compile_model = cfg.use_torch_compile
@@ -474,10 +527,22 @@ def build_rollout_context(
         },
     )
 
-    if isinstance(cfg.inference, SyncInferenceConfig) and any(
-        isinstance(step, RelativeActionsProcessorStep) and step.enabled
-        for step in getattr(preprocessor, "steps", ())
-    ):
+    relative_action_step = next(
+        (
+            step
+            for step in getattr(preprocessor, "steps", ())
+            if isinstance(step, RelativeActionsProcessorStep) and step.enabled
+        ),
+        None,
+    )
+    if relative_action_step is not None:
+        relative_action_names = relative_action_step.action_names or policy_action_names
+        hw_features = _align_relative_state_feature_order(
+            hw_features,
+            list(relative_action_names) if relative_action_names else None,
+        )
+
+    if isinstance(cfg.inference, SyncInferenceConfig) and relative_action_step is not None:
         raise NotImplementedError(
             "SyncInferenceEngine does not support policies with relative actions for now."
             "Use --inference.type=rtc or remove relative action processor steps from the policy pipeline."

--- a/src/lerobot/rollout/context.py
+++ b/src/lerobot/rollout/context.py
@@ -119,6 +119,31 @@ def _resolve_action_key_order(
     return policy_action_names
 
 
+def _align_state_feature_order(
+    observation_features_hw: dict[str, type | tuple], policy_action_names: list[str] | None
+) -> dict[str, type | tuple]:
+    """Order scalar state features to match the checkpoint's joint order."""
+    if not policy_action_names:
+        return observation_features_hw
+
+    scalar_names = [
+        name for name, feature in observation_features_hw.items() if not isinstance(feature, tuple)
+    ]
+    if set(scalar_names) != set(policy_action_names) or scalar_names == policy_action_names:
+        return observation_features_hw
+
+    reordered = {name: observation_features_hw[name] for name in policy_action_names}
+    reordered.update(
+        {name: feature for name, feature in observation_features_hw.items() if name not in reordered}
+    )
+    logger.warning(
+        "Robot state order %s differs from checkpoint joint order %s; reordering state",
+        scalar_names,
+        policy_action_names,
+    )
+    return reordered
+
+
 # ---------------------------------------------------------------------------
 # Sub-contexts
 # ---------------------------------------------------------------------------
@@ -350,6 +375,11 @@ def build_rollout_context(
         for k, v in all_obs_features.items()
         if isinstance(v, tuple) or (v is float and k.endswith((".pos", ".vel")))
     }
+    policy_action_names = getattr(policy_config, "action_feature_names", None)
+    observation_features_hw = _align_state_feature_order(
+        observation_features_hw,
+        list(policy_action_names) if policy_action_names else None,
+    )
     # Keep both joint-position (.pos) and base-velocity (.vel) action features so
     # mobile manipulators command the base too (e.g. LeKiwi: 6 arm .pos +
     # x/y/theta.vel = 9-dim action). Pure-arm robots have no .vel keys, so this is
@@ -373,7 +403,6 @@ def build_rollout_context(
     dataset_features = combine_feature_dicts(action_dataset_features, observation_dataset_features)
     hw_features = hw_to_dataset_features(observation_features_hw, "observation")
     raw_action_keys = list(action_features_hw.keys())
-    policy_action_names = getattr(policy_config, "action_feature_names", None)
     ordered_action_keys = _resolve_action_key_order(
         list(policy_action_names) if policy_action_names else None,
         raw_action_keys,

--- a/src/lerobot/rollout/inference/rtc.py
+++ b/src/lerobot/rollout/inference/rtc.py
@@ -58,6 +58,18 @@ _RTC_MAX_CONSECUTIVE_ERRORS: int = 10
 _RTC_JOIN_TIMEOUT_S: float = 3.0
 
 
+class _FatalRTCInferenceError(RuntimeError):
+    """Base class for RTC errors that cannot become valid after a retry."""
+
+
+class _TrainedRTCDelayExceededError(_FatalRTCInferenceError):
+    """Raised when measured latency exceeds a trained RTC checkpoint's support."""
+
+
+class _TrainedRTCPrefixUnavailableError(_FatalRTCInferenceError):
+    """Raised when the queue cannot provide the prefix used for conditioning."""
+
+
 # ---------------------------------------------------------------------------
 # RTC helpers
 # ---------------------------------------------------------------------------
@@ -92,6 +104,50 @@ def _normalize_prev_actions_length(prev_actions: torch.Tensor, target_steps: int
     padded = torch.zeros((target_steps, action_dim), dtype=prev_actions.dtype, device=prev_actions.device)
     padded[:steps] = prev_actions
     return padded
+
+
+def _trained_rtc_chunk_can_merge(
+    *,
+    conditioned_delay: int,
+    measured_delay: int,
+    training_max_delay: int,
+    has_previous_actions: bool,
+) -> bool:
+    """Check that a trained RTC chunk covers the overlap observed during inference."""
+    if not has_previous_actions:
+        return True
+    if measured_delay > training_max_delay:
+        raise _TrainedRTCDelayExceededError(
+            f"Measured RTC inference delay ({measured_delay}) exceeds the checkpoint's "
+            f"rtc_training_max_delay ({training_max_delay})."
+        )
+    return measured_delay <= conditioned_delay
+
+
+def _estimate_rtc_delay(
+    *,
+    latency: float,
+    time_per_step: float,
+    mode: str,
+    training_max_delay: int,
+    has_previous_actions: bool,
+) -> int:
+    """Estimate overlap, using the trained capacity to bootstrap the first transition."""
+    if latency:
+        return math.ceil(latency / time_per_step)
+    if mode == "trained" and has_previous_actions:
+        return training_max_delay
+    return 0
+
+
+def _validate_trained_rtc_prefix_available(*, conditioned_delay: int, available_steps: int) -> None:
+    """Reject hard-prefix inference when the real queue is shorter than its delay."""
+    if conditioned_delay > available_steps:
+        raise _TrainedRTCPrefixUnavailableError(
+            f"Trained RTC needs {conditioned_delay} committed prefix actions, but the queue has "
+            f"only {available_steps}. Increase --inference.queue_threshold and "
+            "--inference.rtc.execution_horizon."
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -290,9 +346,23 @@ class RTCInferenceEngine(InferenceEngine):
                         current_time = time.perf_counter()
                         idx_before = queue.get_action_index()
                         prev_actions = queue.get_left_over()
+                        has_previous_actions = prev_actions is not None and prev_actions.numel() > 0
 
+                        training_max_delay = int(getattr(self._policy.config, "rtc_training_max_delay", 0))
                         latency = latency_tracker.max()
-                        delay = math.ceil(latency / time_per_chunk) if latency else 0
+                        delay = _estimate_rtc_delay(
+                            latency=latency,
+                            time_per_step=time_per_chunk,
+                            mode=self._rtc_config.mode,
+                            training_max_delay=training_max_delay,
+                            has_previous_actions=has_previous_actions,
+                        )
+                        if self._rtc_config.mode == "trained" and delay > 0:
+                            available_steps = 0 if prev_actions is None else prev_actions.shape[0]
+                            _validate_trained_rtc_prefix_available(
+                                conditioned_delay=delay,
+                                available_steps=available_steps,
+                            )
 
                         obs_batch = build_dataset_frame(self._hw_features, obs, prefix="observation")
                         obs_batch = prepare_observation_for_inference(
@@ -334,10 +404,31 @@ class RTCInferenceEngine(InferenceEngine):
                         inference_count += 1
                         consecutive_errors = 0
                         is_warmup = self._use_torch_compile and inference_count <= warmup_required
-                        if is_warmup:
+                        is_initial_trained_chunk = (
+                            self._rtc_config.mode == "trained" and not has_previous_actions
+                        )
+                        if is_warmup or is_initial_trained_chunk:
                             latency_tracker.reset()
                         else:
                             latency_tracker.add(new_latency)
+
+                        if (
+                            not is_warmup
+                            and self._rtc_config.mode == "trained"
+                            and not _trained_rtc_chunk_can_merge(
+                                conditioned_delay=delay,
+                                measured_delay=new_delay,
+                                training_max_delay=training_max_delay,
+                                has_previous_actions=has_previous_actions,
+                            )
+                        ):
+                            logger.warning(
+                                "Discarding trained RTC chunk: measured delay %d exceeded "
+                                "conditioned delay %d; retrying with updated latency",
+                                new_delay,
+                                delay,
+                            )
+                            continue
 
                         queue.merge(original, processed, new_delay, idx_before)
 
@@ -351,6 +442,8 @@ class RTCInferenceEngine(InferenceEngine):
 
                         logger.debug("RTC inference latency=%.2fs, queue=%d", new_latency, queue.qsize())
 
+                    except _FatalRTCInferenceError:
+                        raise
                     except Exception as e:
                         consecutive_errors += 1
                         logger.error(

--- a/src/lerobot/rollout/inference/rtc.py
+++ b/src/lerobot/rollout/inference/rtc.py
@@ -54,6 +54,8 @@ _RTC_IDLE_SLEEP_S: float = 0.01
 _RTC_ERROR_RETRY_DELAY_S: float = 0.5
 # Consecutive transient errors tolerated before giving up and propagating shutdown.
 _RTC_MAX_CONSECUTIVE_ERRORS: int = 10
+# Consecutive unusable trained-RTC chunks tolerated before declaring the delay unsupportable.
+_RTC_MAX_CONSECUTIVE_DISCARDS: int = 5
 # Hard timeout for joining the RTC thread on stop().
 _RTC_JOIN_TIMEOUT_S: float = 3.0
 
@@ -63,11 +65,7 @@ class _FatalRTCInferenceError(RuntimeError):
 
 
 class _TrainedRTCDelayExceededError(_FatalRTCInferenceError):
-    """Raised when measured latency exceeds a trained RTC checkpoint's support."""
-
-
-class _TrainedRTCPrefixUnavailableError(_FatalRTCInferenceError):
-    """Raised when the queue cannot provide the prefix used for conditioning."""
+    """Raised when measured latency persistently exceeds a trained RTC checkpoint's support."""
 
 
 # ---------------------------------------------------------------------------
@@ -113,14 +111,17 @@ def _trained_rtc_chunk_can_merge(
     training_max_delay: int,
     has_previous_actions: bool,
 ) -> bool:
-    """Check that a trained RTC chunk covers the overlap observed during inference."""
+    """Whether a trained RTC chunk still covers the overlap that actually elapsed.
+
+    A chunk is unusable either because inference outran the prefix it was conditioned on, or
+    because the elapsed delay left the range the checkpoint was trained for. Both are transient
+    by nature (a latency spike), so this reports them the same way and lets the caller retry;
+    only a persistent run of unusable chunks is fatal.
+    """
     if not has_previous_actions:
         return True
     if measured_delay > training_max_delay:
-        raise _TrainedRTCDelayExceededError(
-            f"Measured RTC inference delay ({measured_delay}) exceeds the checkpoint's "
-            f"rtc_training_max_delay ({training_max_delay})."
-        )
+        return False
     return measured_delay <= conditioned_delay
 
 
@@ -140,14 +141,28 @@ def _estimate_rtc_delay(
     return 0
 
 
-def _validate_trained_rtc_prefix_available(*, conditioned_delay: int, available_steps: int) -> None:
-    """Reject hard-prefix inference when the real queue is shorter than its delay."""
-    if conditioned_delay > available_steps:
-        raise _TrainedRTCPrefixUnavailableError(
-            f"Trained RTC needs {conditioned_delay} committed prefix actions, but the queue has "
-            f"only {available_steps}. Increase --inference.queue_threshold and "
-            "--inference.rtc.execution_horizon."
+def _clamp_trained_rtc_delay(*, conditioned_delay: int, available_steps: int, training_max_delay: int) -> int:
+    """Clamp the hard prefix to what both the checkpoint and the queue can back.
+
+    Past ``training_max_delay`` the model has never seen a prefix that long, and past
+    ``available_steps`` ``_normalize_prev_actions_length`` zero-pads the tail, so the extra
+    steps would be inpainted as if zeros were committed actions. Clamping keeps the chunk
+    usable; ``_trained_rtc_chunk_can_merge`` still discards it if the delay that actually
+    elapsed outran this prefix.
+    """
+    clamped = min(conditioned_delay, training_max_delay, available_steps)
+    if clamped < conditioned_delay:
+        logger.warning(
+            "Trained RTC wanted a %d-step prefix but the checkpoint supports %d and the queue "
+            "holds %d committed actions; conditioning on %d. Raise --inference.queue_threshold "
+            "and --inference.rtc.execution_horizon, or retrain with a larger "
+            "--policy.rtc_training_max_delay, to keep the full overlap.",
+            conditioned_delay,
+            training_max_delay,
+            available_steps,
+            clamped,
         )
+    return clamped
 
 
 # ---------------------------------------------------------------------------
@@ -328,6 +343,7 @@ class RTCInferenceEngine(InferenceEngine):
             warmup_required = max(1, self._compile_warmup_inferences) if self._use_torch_compile else 0
             inference_count = 0
             consecutive_errors = 0
+            consecutive_discards = 0
 
             while not self._shutdown_event.is_set():
                 if not self._policy_active.is_set():
@@ -358,10 +374,10 @@ class RTCInferenceEngine(InferenceEngine):
                             has_previous_actions=has_previous_actions,
                         )
                         if self._rtc_config.mode == "trained" and delay > 0:
-                            available_steps = 0 if prev_actions is None else prev_actions.shape[0]
-                            _validate_trained_rtc_prefix_available(
+                            delay = _clamp_trained_rtc_delay(
                                 conditioned_delay=delay,
-                                available_steps=available_steps,
+                                available_steps=0 if prev_actions is None else prev_actions.shape[0],
+                                training_max_delay=training_max_delay,
                             )
 
                         obs_batch = build_dataset_frame(self._hw_features, obs, prefix="observation")
@@ -422,14 +438,28 @@ class RTCInferenceEngine(InferenceEngine):
                                 has_previous_actions=has_previous_actions,
                             )
                         ):
+                            consecutive_discards += 1
                             logger.warning(
-                                "Discarding trained RTC chunk: measured delay %d exceeded "
-                                "conditioned delay %d; retrying with updated latency",
+                                "Discarding trained RTC chunk (%d/%d): measured delay %d exceeded "
+                                "conditioned delay %d (checkpoint supports %d); retrying with "
+                                "updated latency",
+                                consecutive_discards,
+                                _RTC_MAX_CONSECUTIVE_DISCARDS,
                                 new_delay,
                                 delay,
+                                training_max_delay,
                             )
+                            if consecutive_discards >= _RTC_MAX_CONSECUTIVE_DISCARDS:
+                                raise _TrainedRTCDelayExceededError(
+                                    f"Measured RTC inference delay ({new_delay}) stayed above the "
+                                    f"usable overlap for {consecutive_discards} consecutive chunks; "
+                                    f"the checkpoint supports rtc_training_max_delay="
+                                    f"{training_max_delay}. Retrain with a larger delay, lower "
+                                    "--fps, or switch to --inference.rtc.mode=guided."
+                                )
                             continue
 
+                        consecutive_discards = 0
                         queue.merge(original, processed, new_delay, idx_before)
 
                         if (

--- a/tests/policies/common/test_flow_matching.py
+++ b/tests/policies/common/test_flow_matching.py
@@ -191,3 +191,25 @@ def test_euler_integrate_debug_tracking_fires_even_when_rtc_disabled():
     assert len(proc.tracked) == 4
     # track() receives the POST-update x_t; the last one is the returned sample.
     assert torch.equal(proc.tracked[-1]["x_t"], out)
+
+
+def test_euler_integrate_clamps_trained_rtc_prefix_and_sets_clean_time():
+    noise = torch.ones(1, 4, 1)
+    hard_prefix = torch.tensor([[[2.0], [3.0], [0.0], [0.0]]])
+    hard_prefix_mask = torch.tensor([[[True], [True], [False], [False]]])
+    seen_times = []
+
+    def denoise_fn(x_t, time_tensor):
+        seen_times.append(time_tensor.clone())
+        return torch.ones_like(x_t)
+
+    out = euler_integrate(
+        denoise_fn,
+        noise,
+        2,
+        hard_prefix=hard_prefix,
+        hard_prefix_mask=hard_prefix_mask,
+    )
+
+    torch.testing.assert_close(out[:, :2], hard_prefix[:, :2])
+    assert all(torch.equal(time[:, :2], torch.zeros(1, 2)) for time in seen_times)

--- a/tests/policies/common/test_vla_utils.py
+++ b/tests/policies/common/test_vla_utils.py
@@ -56,8 +56,8 @@ def test_create_sinusoidal_pos_embedding_matches_openpi_formula():
 def test_create_sinusoidal_pos_embedding_validation():
     with pytest.raises(ValueError, match="divisible by 2"):
         create_sinusoidal_pos_embedding(torch.zeros(2), 7, 4e-3, 4.0, device=torch.device("cpu"))
-    with pytest.raises(ValueError, match="batch_size"):
-        create_sinusoidal_pos_embedding(torch.zeros(2, 2), 8, 4e-3, 4.0, device=torch.device("cpu"))
+    with pytest.raises(ValueError, match="must have shape"):
+        create_sinusoidal_pos_embedding(torch.zeros(2, 2, 2), 8, 4e-3, 4.0, device=torch.device("cpu"))
 
 
 def test_make_att_2d_masks_docstring_cases():

--- a/tests/policies/common/test_vla_utils.py
+++ b/tests/policies/common/test_vla_utils.py
@@ -53,6 +53,19 @@ def test_create_sinusoidal_pos_embedding_matches_openpi_formula():
     torch.testing.assert_close(emb, expected, rtol=1e-9, atol=1e-9)
 
 
+def test_create_sinusoidal_pos_embedding_per_action_time_matches_scalar():
+    """Per-action time (training-time RTC) must embed each row exactly like the scalar path."""
+    dim, min_period, max_period = 8, 4e-3, 4.0
+    per_action = torch.tensor([[0.0, 0.25, 0.25], [1.0, 0.5, 0.5]])
+    emb = create_sinusoidal_pos_embedding(per_action, dim, min_period, max_period, device=torch.device("cpu"))
+
+    assert emb.shape == (2, 3, dim)
+    flat = create_sinusoidal_pos_embedding(
+        per_action.reshape(-1), dim, min_period, max_period, device=torch.device("cpu")
+    )
+    torch.testing.assert_close(emb.reshape(-1, dim), flat)
+
+
 def test_create_sinusoidal_pos_embedding_validation():
     with pytest.raises(ValueError, match="divisible by 2"):
         create_sinusoidal_pos_embedding(torch.zeros(2), 7, 4e-3, 4.0, device=torch.device("cpu"))

--- a/tests/policies/pi0_pi05/test_pi05_training_time_rtc.py
+++ b/tests/policies/pi0_pi05/test_pi05_training_time_rtc.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+import pytest
+import torch
+
+pytest.importorskip("transformers")
+
+from lerobot.policies.pi05.configuration_pi05 import PI05Config  # noqa: E402
+from lerobot.policies.pi05.modeling_pi05 import (  # noqa: E402
+    _build_flow_matching_inputs,
+    _reduce_training_rtc_loss,
+)
+
+
+def test_pi05_training_rtc_uses_clean_prefix_and_per_token_time():
+    actions = torch.tensor([[[1.0], [2.0], [3.0], [4.0]]])
+    noise = torch.tensor([[[10.0], [20.0], [30.0], [40.0]]])
+    time = torch.tensor([0.25])
+    prefix_mask = torch.tensor([[True, True, False, False]])
+
+    x_t, model_time = _build_flow_matching_inputs(actions, noise, time, prefix_mask)
+
+    assert model_time.tolist() == [[0.0, 0.0, 0.25, 0.25]]
+    assert torch.equal(x_t[:, :2], actions[:, :2])
+    assert torch.equal(x_t[:, 2:], 0.25 * noise[:, 2:] + 0.75 * actions[:, 2:])
+
+
+def test_pi05_training_rtc_loss_excludes_clean_prefix():
+    losses = torch.tensor([[[100.0], [100.0], [2.0], [4.0]]])
+    prefix_mask = torch.tensor([[True, True, False, False]])
+
+    loss = _reduce_training_rtc_loss(losses, prefix_mask, reduction="mean")
+
+    assert loss.item() == pytest.approx(3.0)
+
+
+@pytest.mark.parametrize("max_delay", [-1, 5])
+def test_pi05_config_rejects_invalid_training_rtc_delay(max_delay):
+    with pytest.raises(ValueError, match="rtc_training_max_delay"):
+        PI05Config(chunk_size=5, n_action_steps=5, rtc_training_max_delay=max_delay)

--- a/tests/policies/pi0_pi05/test_pi05_training_time_rtc.py
+++ b/tests/policies/pi0_pi05/test_pi05_training_time_rtc.py
@@ -10,11 +10,16 @@ import torch
 
 pytest.importorskip("transformers")
 
+from transformers.models.gemma.configuration_gemma import GemmaConfig  # noqa: E402
+from transformers.models.gemma.modeling_gemma import GemmaRotaryEmbedding  # noqa: E402
+
 from lerobot.policies.pi05.configuration_pi05 import PI05Config  # noqa: E402
 from lerobot.policies.pi05.modeling_pi05 import (  # noqa: E402
     _build_flow_matching_inputs,
     _reduce_training_rtc_loss,
+    compute_layer_complete,
 )
+from lerobot.policies.pi_gemma import _get_pi_gemma_decoder_layer_base  # noqa: E402
 
 
 def test_pi05_training_rtc_uses_clean_prefix_and_per_token_time():
@@ -43,3 +48,92 @@ def test_pi05_training_rtc_loss_excludes_clean_prefix():
 def test_pi05_config_rejects_invalid_training_rtc_delay(max_delay):
     with pytest.raises(ValueError, match="rtc_training_max_delay"):
         PI05Config(chunk_size=5, n_action_steps=5, rtc_training_max_delay=max_delay)
+
+
+# ``compute_layer_complete`` hardcodes 8 attention heads when reshaping the joint
+# attention output, so the miniature stack below has to match that.
+_HEADS, _HEAD_DIM = 8, 4
+_WIDTH = _HEADS * _HEAD_DIM
+
+
+def _mini_gemma_config(use_adarms: bool) -> GemmaConfig:
+    config = GemmaConfig(
+        hidden_size=_WIDTH,
+        intermediate_size=2 * _WIDTH,
+        num_hidden_layers=1,
+        num_attention_heads=_HEADS,
+        num_key_value_heads=_HEADS,
+        head_dim=_HEAD_DIM,
+        vocab_size=32,
+    )
+    config.use_adarms = use_adarms
+    config.adarms_cond_dim = _WIDTH if use_adarms else None
+    config._attn_implementation = "eager"  # noqa: SLF001
+    return config
+
+
+def _mini_two_stream_layers() -> tuple:
+    """VLM stream without AdaRMS, action-expert stream with it — the pi05 layout."""
+    layer_cls = _get_pi_gemma_decoder_layer_base()
+    vlm_config = _mini_gemma_config(use_adarms=False)
+    expert_config = _mini_gemma_config(use_adarms=True)
+    layers = (layer_cls(vlm_config, 0), layer_cls(expert_config, 0))
+    return layers, GemmaRotaryEmbedding(vlm_config)
+
+
+def test_pi05_expert_layer_accepts_per_action_time_conditioning():
+    """The pi05 training path feeds a (B, chunk, width) AdaRMS cond to the action expert.
+
+    pi05 injects the flow timestep only through AdaRMS, so training-time RTC's per-action
+    timesteps have to survive this two-stream layer unchanged in shape.
+    """
+    torch.manual_seed(0)
+    batch, prefix_tokens, chunk = 2, 3, 4
+    layers, rotary_emb = _mini_two_stream_layers()
+
+    inputs_embeds = [torch.randn(batch, prefix_tokens, _WIDTH), torch.randn(batch, chunk, _WIDTH)]
+    total = prefix_tokens + chunk
+    position_ids = torch.arange(total)[None].expand(batch, total)
+    attention_mask = torch.zeros(batch, 1, total, total)
+    # Expert stream only: prefix (VLM) tokens keep the plain norm, as in PI05FlowMatching.
+    adarms_cond = [None, torch.randn(batch, chunk, _WIDTH)]
+
+    out_prefix, out_suffix = compute_layer_complete(
+        inputs_embeds,
+        attention_mask,
+        position_ids,
+        adarms_cond,
+        layers=layers,
+        rotary_emb=rotary_emb,
+    )
+
+    assert out_prefix.shape == (batch, prefix_tokens, _WIDTH)
+    assert out_suffix.shape == (batch, chunk, _WIDTH)
+
+
+def test_pi05_expert_layer_per_action_time_matches_scalar_when_uniform():
+    """A per-action cond repeated across the chunk must reproduce the scalar-cond output."""
+    torch.manual_seed(0)
+    batch, prefix_tokens, chunk = 2, 3, 4
+    layers, rotary_emb = _mini_two_stream_layers()
+    # dense is zero-initialised by design; give it signal so a broken modulation shows up.
+    torch.nn.init.normal_(layers[1].input_layernorm.dense.weight, std=0.02)
+    torch.nn.init.normal_(layers[1].post_attention_layernorm.dense.weight, std=0.02)
+
+    inputs_embeds = [torch.randn(batch, prefix_tokens, _WIDTH), torch.randn(batch, chunk, _WIDTH)]
+    total = prefix_tokens + chunk
+    position_ids = torch.arange(total)[None].expand(batch, total)
+    attention_mask = torch.zeros(batch, 1, total, total)
+    cond = torch.randn(batch, _WIDTH)
+
+    def run(expert_cond):
+        return compute_layer_complete(
+            [t.clone() for t in inputs_embeds],
+            attention_mask,
+            position_ids,
+            [None, expert_cond],
+            layers=layers,
+            rotary_emb=rotary_emb,
+        )[1]
+
+    torch.testing.assert_close(run(cond[:, None, :].expand(batch, chunk, _WIDTH)), run(cond))

--- a/tests/policies/rtc/test_configuration_rtc.py
+++ b/tests/policies/rtc/test_configuration_rtc.py
@@ -16,6 +16,8 @@
 
 """Tests for RTC configuration module."""
 
+import pytest
+
 from lerobot.configs.types import RTCAttentionSchedule
 from lerobot.policies.rtc.configuration_rtc import RTCConfig
 
@@ -27,6 +29,7 @@ def test_rtc_config_default_initialization():
     config = RTCConfig()
 
     assert config.enabled is True
+    assert config.mode == "guided"
     assert config.prefix_attention_schedule == RTCAttentionSchedule.LINEAR
     assert config.max_guidance_weight == 10.0
     assert config.execution_horizon == 10
@@ -34,10 +37,16 @@ def test_rtc_config_default_initialization():
     assert config.debug_maxlen == 100
 
 
+def test_rtc_config_rejects_unknown_mode():
+    with pytest.raises(ValueError, match="mode must be"):
+        RTCConfig(mode="unknown")
+
+
 def test_rtc_config_custom_initialization():
     """Test RTCConfig initializes with custom values."""
     config = RTCConfig(
         enabled=True,
+        mode="trained",
         prefix_attention_schedule=RTCAttentionSchedule.EXP,
         max_guidance_weight=5.0,
         execution_horizon=20,
@@ -46,6 +55,7 @@ def test_rtc_config_custom_initialization():
     )
 
     assert config.enabled is True
+    assert config.mode == "trained"
     assert config.prefix_attention_schedule == RTCAttentionSchedule.EXP
     assert config.max_guidance_weight == 5.0
     assert config.execution_horizon == 20

--- a/tests/policies/rtc/test_modeling_rtc.py
+++ b/tests/policies/rtc/test_modeling_rtc.py
@@ -93,6 +93,19 @@ def test_rtc_processor_initialization_without_debug(rtc_config_debug_disabled):
     assert processor.tracker is None
 
 
+def test_rtc_processor_rejects_trained_mode_when_policy_does_not_support_it():
+    config = RTCConfig(mode="trained")
+
+    with pytest.raises(ValueError, match="requires a PI05-compatible checkpoint"):
+        RTCProcessor(config)
+
+    processor = RTCProcessor(config, trained_mode_supported=True)
+    assert processor.rtc_config.mode == "trained"
+
+    disabled = RTCProcessor(RTCConfig(enabled=False, mode="trained"))
+    assert disabled.rtc_config.enabled is False
+
+
 # ====================== Tracker Proxy Methods Tests ======================
 
 

--- a/tests/policies/test_pi_gemma.py
+++ b/tests/policies/test_pi_gemma.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""AdaRMS conditioning tests for the shared PI Gemma blocks.
+
+pi05 feeds the flow-matching timestep to the action expert *only* through AdaRMS, so
+training-time RTC (arXiv 2512.05964) needs scale/shift/gate to vary per token. These
+tests pin both conditioning shapes: the scalar-per-sample form used by ordinary
+training, and the per-token form that marks the clean action prefix.
+"""
+
+import pytest
+import torch
+
+pytest.importorskip("transformers")
+
+from transformers.models.gemma.configuration_gemma import GemmaConfig  # noqa: E402
+
+from lerobot.policies.pi_gemma import (  # noqa: E402
+    PiGemmaRMSNorm,
+    _get_pi_gemma_decoder_layer_base,
+)
+
+BATCH, TOKENS, HIDDEN = 2, 4, 16
+
+
+def _decoder_layer() -> torch.nn.Module:
+    config = GemmaConfig(
+        hidden_size=HIDDEN,
+        intermediate_size=2 * HIDDEN,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        head_dim=8,
+        vocab_size=32,
+    )
+    config.use_adarms = True
+    config.adarms_cond_dim = HIDDEN
+    config._attn_implementation = "eager"  # noqa: SLF001
+    return _get_pi_gemma_decoder_layer_base()(config, 0)
+
+
+def test_adarms_per_token_cond_keeps_sequence_shape():
+    norm = PiGemmaRMSNorm(HIDDEN, cond_dim=HIDDEN)
+    x = torch.randn(BATCH, TOKENS, HIDDEN)
+
+    out, gate = norm(x, cond=torch.randn(BATCH, TOKENS, HIDDEN))
+
+    assert out.shape == (BATCH, TOKENS, HIDDEN)
+    assert gate.shape == (BATCH, TOKENS, HIDDEN)
+
+
+def test_adarms_constant_per_token_cond_matches_scalar_cond():
+    """A per-token cond repeated across tokens must reproduce the scalar-cond result."""
+    torch.manual_seed(0)
+    norm = PiGemmaRMSNorm(HIDDEN, cond_dim=HIDDEN)
+    torch.nn.init.normal_(norm.dense.weight)  # zero-init would hide any modulation bug
+    x = torch.randn(BATCH, TOKENS, HIDDEN)
+    cond = torch.randn(BATCH, HIDDEN)
+
+    scalar_out, scalar_gate = norm(x, cond=cond)
+    token_out, token_gate = norm(x, cond=cond[:, None, :].expand(BATCH, TOKENS, HIDDEN))
+
+    torch.testing.assert_close(token_out, scalar_out)
+    torch.testing.assert_close(token_gate, scalar_gate.expand_as(token_gate))
+
+
+def test_adarms_per_token_cond_actually_varies_per_token():
+    torch.manual_seed(0)
+    norm = PiGemmaRMSNorm(HIDDEN, cond_dim=HIDDEN)
+    torch.nn.init.normal_(norm.dense.weight)
+    x = torch.zeros(BATCH, TOKENS, HIDDEN)  # isolate the shift term
+
+    cond = torch.zeros(BATCH, TOKENS, HIDDEN)
+    cond[:, 0] = 1.0  # only the first token (the RTC prefix marker) is conditioned
+    out, _ = norm(x, cond=cond)
+
+    assert not torch.allclose(out[:, 0], out[:, 1])
+    torch.testing.assert_close(out[:, 1], out[:, 2])
+
+
+def test_adarms_rejects_token_count_mismatch():
+    norm = PiGemmaRMSNorm(HIDDEN, cond_dim=HIDDEN)
+
+    with pytest.raises(ValueError, match="must match"):
+        norm(torch.randn(BATCH, TOKENS, HIDDEN), cond=torch.randn(BATCH, TOKENS + 1, HIDDEN))
+
+
+@pytest.mark.parametrize("cond_shape", [(BATCH, HIDDEN), (BATCH, TOKENS, HIDDEN)])
+def test_pi_gemma_decoder_layer_accepts_both_cond_shapes(cond_shape):
+    """Regression: a per-token cond used to broadcast into (B, B, T, D) and blow up."""
+    layer = _decoder_layer()
+    hidden = torch.randn(BATCH, TOKENS, HIDDEN)
+
+    out = layer(
+        hidden,
+        attention_mask=torch.zeros(BATCH, 1, TOKENS, TOKENS),
+        position_ids=torch.arange(TOKENS)[None].expand(BATCH, TOKENS),
+        position_embeddings=(torch.ones(BATCH, TOKENS, 8), torch.zeros(BATCH, TOKENS, 8)),
+        adarms_cond=torch.randn(*cond_shape),
+    )
+    out = out[0] if isinstance(out, tuple) else out
+
+    assert out.shape == (BATCH, TOKENS, HIDDEN)

--- a/tests/test_rollout.py
+++ b/tests/test_rollout.py
@@ -368,6 +368,55 @@ def test_create_inference_engine_sync():
 # ---------------------------------------------------------------------------
 
 
+def test_align_state_feature_order_matches_checkpoint_and_preserves_cameras(caplog):
+    from lerobot.rollout.context import _align_state_feature_order
+    from lerobot.utils.feature_utils import build_dataset_frame, hw_to_dataset_features
+
+    features = {
+        "wrist_camera": (480, 640, 3),
+        "joint_b.pos": float,
+        "joint_a.pos": float,
+    }
+
+    aligned = _align_state_feature_order(features, ["joint_a.pos", "joint_b.pos"])
+
+    assert list(aligned) == ["joint_a.pos", "joint_b.pos", "wrist_camera"]
+    assert aligned["wrist_camera"] == (480, 640, 3)
+    assert "reordering state" in caplog.text
+
+    dataset_features = hw_to_dataset_features(aligned, "observation")
+    frame = build_dataset_frame(
+        dataset_features,
+        {"joint_a.pos": 1.0, "joint_b.pos": 2.0, "wrist_camera": object()},
+        "observation",
+    )
+    assert frame["observation.state"].tolist() == [1.0, 2.0]
+
+
+@pytest.mark.parametrize(
+    ("policy_action_names", "feature_names"),
+    [
+        (None, ["joint_b.pos", "joint_a.pos", "wrist_camera"]),
+        (["joint_b.pos", "joint_a.pos"], ["joint_b.pos", "joint_a.pos", "wrist_camera"]),
+        (["joint_a.pos"], ["joint_b.pos", "joint_a.pos", "wrist_camera"]),
+        (["joint_a.pos", "gripper.pos"], ["joint_b.pos", "joint_a.pos", "wrist_camera"]),
+    ],
+)
+def test_align_state_feature_order_is_noop_without_an_exact_name_match(policy_action_names, feature_names):
+    from lerobot.rollout.context import _align_state_feature_order
+
+    features = {
+        "joint_b.pos": float,
+        "joint_a.pos": float,
+        "wrist_camera": (480, 640, 3),
+    }
+
+    aligned = _align_state_feature_order(features, policy_action_names)
+
+    assert aligned is features
+    assert list(aligned) == feature_names
+
+
 def test_estimate_max_episode_seconds_no_video():
     from lerobot.rollout.strategies import estimate_max_episode_seconds
 

--- a/tests/test_rollout.py
+++ b/tests/test_rollout.py
@@ -142,29 +142,28 @@ def test_trained_rtc_bootstraps_first_overlap_with_checkpoint_capacity():
     )
 
 
-def test_trained_rtc_rejects_measured_delay_above_checkpoint_support():
-    from lerobot.rollout.inference.rtc import (
-        _trained_rtc_chunk_can_merge,
-        _TrainedRTCDelayExceededError,
+def test_trained_rtc_discards_chunk_measured_above_checkpoint_support():
+    """A latency spike past the trained delay discards the chunk; it must not kill the rollout."""
+    from lerobot.rollout.inference.rtc import _trained_rtc_chunk_can_merge
+
+    assert not _trained_rtc_chunk_can_merge(
+        conditioned_delay=3,
+        measured_delay=5,
+        training_max_delay=4,
+        has_previous_actions=True,
     )
 
-    with pytest.raises(_TrainedRTCDelayExceededError, match="rtc_training_max_delay"):
-        _trained_rtc_chunk_can_merge(
-            conditioned_delay=3,
-            measured_delay=5,
-            training_max_delay=4,
-            has_previous_actions=True,
-        )
 
+def test_trained_rtc_clamps_prefix_to_checkpoint_and_queue():
+    """Conditioning past the queue tail would hard-inpaint zero padding, so clamp instead."""
+    from lerobot.rollout.inference.rtc import _clamp_trained_rtc_delay
 
-def test_trained_rtc_rejects_prefix_shorter_than_conditioned_delay():
-    from lerobot.rollout.inference.rtc import (
-        _TrainedRTCPrefixUnavailableError,
-        _validate_trained_rtc_prefix_available,
-    )
-
-    with pytest.raises(_TrainedRTCPrefixUnavailableError, match="only 2"):
-        _validate_trained_rtc_prefix_available(conditioned_delay=4, available_steps=2)
+    # Queue tail is the binding limit.
+    assert _clamp_trained_rtc_delay(conditioned_delay=4, available_steps=2, training_max_delay=10) == 2
+    # Trained capacity is the binding limit.
+    assert _clamp_trained_rtc_delay(conditioned_delay=12, available_steps=30, training_max_delay=10) == 10
+    # Neither binds.
+    assert _clamp_trained_rtc_delay(conditioned_delay=4, available_steps=30, training_max_delay=10) == 4
 
 
 @pytest.mark.parametrize(
@@ -172,6 +171,8 @@ def test_trained_rtc_rejects_prefix_shorter_than_conditioned_delay():
     [
         (3, 4, "execution_horizon"),
         (4, 3, "queue_threshold"),
+        # RTC needs d <= s <= H - d; s = 17 exceeds chunk_size - max_delay = 16.
+        (17, 20, "at most"),
     ],
 )
 def test_trained_rtc_rollout_requires_capacity_for_max_delay(execution_horizon, queue_threshold, match):
@@ -179,7 +180,7 @@ def test_trained_rtc_rollout_requires_capacity_for_max_delay(execution_horizon, 
     from lerobot.rollout.context import _validate_trained_rtc_rollout_config
     from lerobot.rollout.inference import RTCInferenceConfig
 
-    policy_config = SimpleNamespace(type="pi05", rtc_training_max_delay=4)
+    policy_config = SimpleNamespace(type="pi05", rtc_training_max_delay=4, chunk_size=20)
     inference_config = RTCInferenceConfig(
         rtc=RTCConfig(mode="trained", execution_horizon=execution_horizon),
         queue_threshold=queue_threshold,
@@ -187,6 +188,20 @@ def test_trained_rtc_rollout_requires_capacity_for_max_delay(execution_horizon, 
 
     with pytest.raises(ValueError, match=match):
         _validate_trained_rtc_rollout_config(policy_config, inference_config)
+
+
+def test_trained_rtc_rollout_accepts_valid_capacity():
+    from lerobot.policies.rtc.configuration_rtc import RTCConfig
+    from lerobot.rollout.context import _validate_trained_rtc_rollout_config
+    from lerobot.rollout.inference import RTCInferenceConfig
+
+    policy_config = SimpleNamespace(type="pi05", rtc_training_max_delay=4, chunk_size=50)
+    inference_config = RTCInferenceConfig(
+        rtc=RTCConfig(mode="trained", execution_horizon=10),
+        queue_threshold=30,
+    )
+
+    _validate_trained_rtc_rollout_config(policy_config, inference_config)
 
 
 def test_relative_state_order_follows_checkpoint_action_names():

--- a/tests/test_rollout.py
+++ b/tests/test_rollout.py
@@ -100,6 +100,131 @@ def test_inference_config_types():
     assert rtc.rtc is not None
 
 
+def test_trained_rtc_retries_chunk_when_measured_delay_exceeds_conditioning():
+    from lerobot.rollout.inference.rtc import _trained_rtc_chunk_can_merge
+
+    assert not _trained_rtc_chunk_can_merge(
+        conditioned_delay=2,
+        measured_delay=3,
+        training_max_delay=4,
+        has_previous_actions=True,
+    )
+    assert _trained_rtc_chunk_can_merge(
+        conditioned_delay=2,
+        measured_delay=5,
+        training_max_delay=4,
+        has_previous_actions=False,
+    )
+
+
+def test_trained_rtc_bootstraps_first_overlap_with_checkpoint_capacity():
+    from lerobot.rollout.inference.rtc import _estimate_rtc_delay
+
+    assert (
+        _estimate_rtc_delay(
+            latency=0,
+            time_per_step=1 / 30,
+            mode="trained",
+            training_max_delay=10,
+            has_previous_actions=False,
+        )
+        == 0
+    )
+    assert (
+        _estimate_rtc_delay(
+            latency=0,
+            time_per_step=1 / 30,
+            mode="trained",
+            training_max_delay=10,
+            has_previous_actions=True,
+        )
+        == 10
+    )
+
+
+def test_trained_rtc_rejects_measured_delay_above_checkpoint_support():
+    from lerobot.rollout.inference.rtc import (
+        _trained_rtc_chunk_can_merge,
+        _TrainedRTCDelayExceededError,
+    )
+
+    with pytest.raises(_TrainedRTCDelayExceededError, match="rtc_training_max_delay"):
+        _trained_rtc_chunk_can_merge(
+            conditioned_delay=3,
+            measured_delay=5,
+            training_max_delay=4,
+            has_previous_actions=True,
+        )
+
+
+def test_trained_rtc_rejects_prefix_shorter_than_conditioned_delay():
+    from lerobot.rollout.inference.rtc import (
+        _TrainedRTCPrefixUnavailableError,
+        _validate_trained_rtc_prefix_available,
+    )
+
+    with pytest.raises(_TrainedRTCPrefixUnavailableError, match="only 2"):
+        _validate_trained_rtc_prefix_available(conditioned_delay=4, available_steps=2)
+
+
+@pytest.mark.parametrize(
+    ("execution_horizon", "queue_threshold", "match"),
+    [
+        (3, 4, "execution_horizon"),
+        (4, 3, "queue_threshold"),
+    ],
+)
+def test_trained_rtc_rollout_requires_capacity_for_max_delay(execution_horizon, queue_threshold, match):
+    from lerobot.policies.rtc.configuration_rtc import RTCConfig
+    from lerobot.rollout.context import _validate_trained_rtc_rollout_config
+    from lerobot.rollout.inference import RTCInferenceConfig
+
+    policy_config = SimpleNamespace(type="pi05", rtc_training_max_delay=4)
+    inference_config = RTCInferenceConfig(
+        rtc=RTCConfig(mode="trained", execution_horizon=execution_horizon),
+        queue_threshold=queue_threshold,
+    )
+
+    with pytest.raises(ValueError, match=match):
+        _validate_trained_rtc_rollout_config(policy_config, inference_config)
+
+
+def test_relative_state_order_follows_checkpoint_action_names():
+    from lerobot.rollout.context import _align_relative_state_feature_order
+    from lerobot.utils.constants import OBS_STATE
+    from lerobot.utils.feature_utils import build_dataset_frame
+
+    hw_features = {
+        OBS_STATE: {
+            "dtype": "float32",
+            "shape": (4,),
+            "names": ["left_joint.pos", "left_gripper.pos", "right_joint.pos", "right_gripper.pos"],
+        }
+    }
+    checkpoint_order = [
+        "right_joint.pos",
+        "right_gripper.pos",
+        "left_joint.pos",
+        "left_gripper.pos",
+    ]
+
+    aligned = _align_relative_state_feature_order(hw_features, checkpoint_order)
+    frame = build_dataset_frame(
+        aligned,
+        {
+            "left_joint.pos": 1.0,
+            "left_gripper.pos": 2.0,
+            "right_joint.pos": 3.0,
+            "right_gripper.pos": 4.0,
+        },
+        prefix="observation",
+    )
+
+    assert aligned[OBS_STATE]["names"] == checkpoint_order
+    assert frame[OBS_STATE].tolist() == [3.0, 4.0, 1.0, 2.0]
+    assert hw_features[OBS_STATE]["names"][0] == "left_joint.pos"
+
+
 def test_sentry_config_defaults():
     from lerobot.rollout import SentryStrategyConfig
 


### PR DESCRIPTION
## Summary

Adds opt-in training-time Real-Time Chunking (RTC) to Pi05 via `policy.rtc_training_max_delay`.

The default remains `0`, so ordinary Pi05 training and inference are unchanged. When enabled, training samples a clean action prefix per example, supplies per-action flow timesteps, and computes flow loss only on the generated postfix.

## Inference

Trained checkpoints can use the asynchronous rollout backend with:

```bash
--inference.type=rtc \
--inference.rtc.mode=trained \
--inference.rtc.execution_horizon=10
```

The rollout path validates checkpoint compatibility, retained-prefix capacity, and measured inference delay. The existing Jacobian-guided RTC mode remains the default for ordinary checkpoints.

## Additional fixes

- Align policy-facing relative state dimensions with the checkpoint action-name order without changing robot or recording order.
- Ignore unconditioned cold-start latency and bootstrap the first real overlap at the trained delay capacity.
- Retry or fail explicitly when the measured delay cannot be represented safely.

## Validation

- Focused Pi05, RTC, flow-matching, and rollout suites: `98 passed, 3 skipped`.
- Targeted pre-commit hooks passed, including Ruff, Prettier, typos, Bandit, and mypy.
- No model training was run.