### PR TITLE
fix(openarms): stop set_zero_position()ing on connect

### DIFF
--- a/src/lerobot/motors/damiao/damiao.py
+++ b/src/lerobot/motors/damiao/damiao.py
@@ -20,7 +20,6 @@ import logging
 import time
 from contextlib import contextmanager
 from copy import deepcopy
-from functools import cached_property
 from typing import TYPE_CHECKING, Any, TypedDict
 
 from lerobot.utils.decorators import check_if_already_connected, check_if_not_connected
@@ -854,7 +853,7 @@ class DamiaoMotorsBus(MotorsBusBase):
         else:
             raise ValueError(f"Motor {motor_obj} doesn't have a valid recv_id (None).")
 
-    @cached_property
+    @property
     def is_calibrated(self) -> bool:
         """Check if motors are calibrated."""
         return bool(self.calibration)

--- a/src/lerobot/robots/openarm_follower/openarm_follower.py
+++ b/src/lerobot/robots/openarm_follower/openarm_follower.py
@@ -150,9 +150,6 @@ class OpenArmFollower(Robot):
 
         self.configure()
 
-        if self.is_calibrated:
-            self.bus.set_zero_position()
-
         self.bus.enable_torque()
 
         logger.info(f"{self} connected.")


### PR DESCRIPTION
`is_calibrated` was a `@cached_property`, so it froze at its first-read value and never reflected later changes to `self.calibration` (set by connect/calibrate/load). This caused the OpenArm teleop to re-run calibration even when a calibration file existed, and to skip `set_zero_position()` after a fresh calibration.