### PR TITLE
fix(robots): allow plugin motor setup

### DIFF
--- a/src/lerobot/scripts/lerobot_setup_motors.py
+++ b/src/lerobot/scripts/lerobot_setup_motors.py
@@ -51,19 +51,7 @@ from lerobot.teleoperators import (  # noqa: F401
     rebot_102_leader,
     so_leader,
 )
-
-COMPATIBLE_DEVICES = [
-    "koch_follower",
-    "koch_leader",
-    "omx_follower",
-    "omx_leader",
-    "openarm_mini",
-    "so100_follower",
-    "so100_leader",
-    "so101_follower",
-    "so101_leader",
-    "lekiwi",
-]
+from lerobot.utils.import_utils import register_third_party_plugins
 
 
 @dataclass
@@ -80,18 +68,19 @@ class SetupConfig:
 
 @draccus.wrap()
 def setup_motors(cfg: SetupConfig):
-    if cfg.device.type not in COMPATIBLE_DEVICES:
-        raise NotImplementedError
-
     if isinstance(cfg.device, RobotConfig):
         device = make_robot_from_config(cfg.device)
     else:
         device = make_teleoperator_from_config(cfg.device)
 
-    device.setup_motors()
+    setup_device = getattr(device, "setup_motors", None)
+    if setup_device is None:
+        raise NotImplementedError(f"Motor setup is not supported for device type '{cfg.device.type}'.")
+    setup_device()
 
 
 def main():
+    register_third_party_plugins()
     setup_motors()
 
 

--- a/src/lerobot/scripts/lerobot_setup_motors.py
+++ b/src/lerobot/scripts/lerobot_setup_motors.py
@@ -15,6 +15,10 @@
 """
 Helper to set motor ids and baudrate.
 
+Installed third-party robot and teleoperator plugins are discovered before
+configuration parsing. Any registered device with a callable
+``setup_motors()`` method can use this command.
+
 Example:
 
 ```shell
@@ -74,7 +78,7 @@ def setup_motors(cfg: SetupConfig):
         device = make_teleoperator_from_config(cfg.device)
 
     setup_device = getattr(device, "setup_motors", None)
-    if setup_device is None:
+    if not callable(setup_device):
         raise NotImplementedError(f"Motor setup is not supported for device type '{cfg.device.type}'.")
     setup_device()
 

--- a/tests/scripts/test_lerobot_setup_motors.py
+++ b/tests/scripts/test_lerobot_setup_motors.py
@@ -46,9 +46,11 @@ def test_setup_motors_reports_devices_without_setup_support():
     config.type = "camera_only_robot"
     device = MagicMock(spec=[])
 
-    with patch("lerobot.scripts.lerobot_setup_motors.make_robot_from_config", return_value=device):
-        with pytest.raises(NotImplementedError, match="camera_only_robot"):
-            setup_motors(SetupConfig(robot=config))
+    with (
+        patch("lerobot.scripts.lerobot_setup_motors.make_robot_from_config", return_value=device),
+        pytest.raises(NotImplementedError, match="camera_only_robot"),
+    ):
+        setup_motors(SetupConfig(robot=config))
 
 
 def test_main_registers_third_party_plugins_before_parsing():

--- a/tests/scripts/test_lerobot_setup_motors.py
+++ b/tests/scripts/test_lerobot_setup_motors.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from lerobot.robots import RobotConfig
+from lerobot.scripts.lerobot_setup_motors import SetupConfig, main, setup_motors
+from lerobot.teleoperators import TeleoperatorConfig
+
+
+@pytest.mark.parametrize(
+    ("field", "config_class", "factory_name"),
+    [
+        ("robot", RobotConfig, "make_robot_from_config"),
+        ("teleop", TeleoperatorConfig, "make_teleoperator_from_config"),
+    ],
+)
+def test_setup_motors_accepts_registered_device_types(field, config_class, factory_name):
+    config = MagicMock(spec=config_class)
+    config.type = "third_party_device"
+    device = MagicMock()
+
+    with patch(f"lerobot.scripts.lerobot_setup_motors.{factory_name}", return_value=device):
+        setup_motors(SetupConfig(**{field: config}))
+
+    device.setup_motors.assert_called_once_with()
+
+
+def test_setup_motors_reports_devices_without_setup_support():
+    config = MagicMock(spec=RobotConfig)
+    config.type = "camera_only_robot"
+    device = MagicMock(spec=[])
+
+    with patch("lerobot.scripts.lerobot_setup_motors.make_robot_from_config", return_value=device):
+        with pytest.raises(NotImplementedError, match="camera_only_robot"):
+            setup_motors(SetupConfig(robot=config))
+
+
+def test_main_registers_third_party_plugins_before_parsing():
+    manager = MagicMock()
+    with (
+        patch(
+            "lerobot.scripts.lerobot_setup_motors.register_third_party_plugins",
+            side_effect=lambda: manager.mock_calls.append(call.register()),
+        ),
+        patch(
+            "lerobot.scripts.lerobot_setup_motors.setup_motors",
+            side_effect=lambda: manager.mock_calls.append(call.parse()),
+        ),
+    ):
+        main()
+
+    assert manager.mock_calls == [call.register(), call.parse()]


### PR DESCRIPTION
## Summary / Motivation

`lerobot-setup-motors` currently bypasses LeRobot's third-party plugin discovery and rejects every device type outside a hard-coded allow-list. This prevents normally installed robot and teleoperator plugins from using their public `setup_motors()` implementation, even though calibration and teleoperation discover the same plugins correctly.

This change brings motor setup in line with the other device commands: discover installed plugins before parsing, instantiate through the existing public factories, and check the resulting device for the setup capability instead of checking its registered name.

## Related issues

- Fixes / Closes: no matching issue found
- Related: #2400 established reliable discovery for installed third-party plugins; this PR makes `lerobot-setup-motors` invoke that discovery path

## What changed

- Register third-party LeRobot plugins before parsing motor-setup configuration.
- Remove the closed `COMPATIBLE_DEVICES` name list.
- Report a descriptive error when an instantiated device does not implement motor setup.
- Add robot, teleoperator, unsupported-device, and registration-order regression tests.

This is backward-compatible for existing supported devices.

## How was this tested (or how to run locally)

- `uv run pytest -q tests/scripts/test_lerobot_setup_motors.py` — 4 passed.
- `uv run pre-commit run --all-files` — all hooks passed.
- Installed the external `lerobot_robot_evolution_droid` plugin and confirmed `uv run lerobot-setup-motors --help` lists its `ev101_leader` and `ev101_follower` types.
- `uv run pytest -sv ./tests` — 1,193 passed and 233 skipped; 21 failures plus 1 error were unrelated environment/optional-extra failures (private Hub fixture access and missing policy/dataset extras). Installing `--extra all` is not possible on this aarch64 runner because the locked `pyrealsense2==2.56.5.9235` has no compatible wheel.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [ ] All tests pass locally (`pytest`) — focused tests pass; full-suite environment limitations are documented above
- [x] Documentation updated — CLI behavior and unsupported-device error are documented in the script; no user migration is required
- [ ] CI is green
- [x] Community Review: I reviewed #4048 and requested that its documented regression test be committed: https://github.com/huggingface/lerobot/pull/4048#pullrequestreview-4723794607

## Reviewer notes

Please focus on whether capability detection should remain a runtime callable check or become an explicit base-class protocol in a follow-up. The runtime check keeps this bugfix small and supports already-published plugins.

AI assistance was used to implement tests and draft this PR. I reviewed the complete diff, reproduced the original failure against an installed external plugin, and ran the validation described above.
