### PR TITLE
fix(datasets): stop frame errors being treated as shard exhaustion in StreamingLeRobotDataset

### DIFF
--- a/src/lerobot/datasets/streaming_dataset.py
+++ b/src/lerobot/datasets/streaming_dataset.py
@@ -409,11 +409,13 @@ class StreamingLeRobotDataset(torch.utils.data.IterableDataset):
                     else:
                         frames_buffer.append(frame)
                     break  # random shard sampled, switch shard
-            except (
-                RuntimeError,
-                StopIteration,
-            ):  # NOTE: StopIteration inside a generator throws a RuntimeError since python 3.7
-                del idx_to_backtrack_dataset[shard_key]  # Remove exhausted shard, onto another shard
+            except RuntimeError as e:
+                # shard exhaustion appeared as a RuntimeError(PEP 479) with StopIteration as cause,
+                # any other RuntimeError(e.g. video decode failure) should be raised
+                if isinstance(e.__cause__, StopIteration):
+                    del idx_to_backtrack_dataset[shard_key]  # Remove exhausted shard, onto another shard
+                else:
+                    raise
 
         # Once shards are all exhausted, shuffle the buffer and yield the remaining frames
         rng.shuffle(frames_buffer)

--- a/tests/datasets/test_streaming.py
+++ b/tests/datasets/test_streaming.py
@@ -214,6 +214,35 @@ def test_frames_order_with_shards(tmp_path, lerobot_dataset_factory, shuffle):
             assert frames_match
 
 
+def test_iter_raises_on_frame_error(tmp_path, lerobot_dataset_factory, monkeypatch):
+    """A failure while building a frame (e.g. video decode failure)
+    must propagate instead of being silently ignored.
+    Test for https://github.com/huggingface/lerobot/issues/4066"""
+    ds_num_frames = 20
+    ds_num_episodes = 2
+    buffer_size = 10
+
+    local_path = tmp_path / "test"
+    repo_id = f"{DUMMY_REPO_ID}"
+
+    lerobot_dataset_factory(
+        root=local_path,
+        repo_id=repo_id,
+        total_episodes=ds_num_episodes,
+        total_frames=ds_num_frames,
+    )
+
+    streaming_ds = StreamingLeRobotDataset(repo_id=repo_id, root=local_path, buffer_size=buffer_size)
+
+    def broken_video_decode(item):
+        raise RuntimeError("Could not load libtorchcodec")
+
+    monkeypatch.setattr("lerobot.datasets.streaming_dataset.item_to_torch", broken_video_decode)
+
+    with pytest.raises(RuntimeError, match="libtorchcodec"):
+        next(iter(streaming_ds))
+
+
 @pytest.mark.parametrize(
     "state_deltas, action_deltas",
     [


### PR DESCRIPTION
## Title

fix(datasets): stop frame errors being treated as shard exhaustion in StreamingLeRobotDataset

## Summary / Motivation

`StreamingLeRobotDataset.__iter__` caught every `RuntimeError` while pulling frames and treated all of them as "this shard is exhausted". A real error like a video decode failure (torchcodec raises `RuntimeError` when it can't load FFmpeg) made every shard get dropped on its first frame, so iterating the dataset yielded zero frames with no error, while metadata (`num_frames`, `fps`, etc.) still looked fine. Very easy to misread as a broken dataset instead of a broken decode environment.

The catch was there as genuine shard exhaustion is a `StopIteration` raised inside the `make_frame` generator, which Python converts to a `RuntimeError` (PEP 479). But that conversion attaches the original `StopIteration` as `__cause__`, so the two cases are distinguishable.

## Related issues

- Fixes / Closes: #4066 

## What changed

- `__iter__` now only treats a `RuntimeError` whose `__cause__` is a `StopIteration`  as shard exhaustion. Any other  `RuntimeError` (e.g. decode failure) is re-raised instead of being consumed.
- No behavior change for healthy datasets, no breaking changes.

## How was this tested (or how to run locally)

- Added `test_iter_raises_on_frame_error` in `tests/datasets/test_streaming.py`: injects a decode failure via monkeypatch and asserts iteration raises. It fails on `main` (iteration silently ends, `next()` gives `StopIteration`) and passes with this fix.
- Full streaming suite passes locally: `pytest -q tests/datasets/test_streaming.py` (14 passed).
- Manual check on a machine with torchcodec installed but no matching FFmpeg shared libraries: streaming `lerobot/pusht` on `main` yields 0 frames with exit code 0; with this fix it raises the actual `RuntimeError: Could not load libtorchcodec` immediately. The non-streaming `LeRobotDataset` already surfaced this error loudly, so this makes the two behave consistently.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated N/A 
- [ ] CI is green
- [x] Community Review: I have reviewed another contributor's open PR and linked it here: #4069 

## Reviewer notes

- Change is ~6 lines in `__iter__`. I checked all error paths to see that only `make_frame` will produce a RuntimeError with StopIteration cause.  Buffer index generators are infinite, and other errors from delta queries are handled in `_get_delta_frames`.
