### PR TITLE
fix(train): support checkpoint latest links on Windows

### DIFF
--- a/src/lerobot/common/train_utils.py
+++ b/src/lerobot/common/train_utils.py
@@ -13,6 +13,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
+import stat
+import subprocess
+import uuid
+from contextlib import suppress
 from pathlib import Path
 
 from huggingface_hub import HfApi, snapshot_download
@@ -82,12 +87,98 @@ def load_training_batch_size(checkpoint_dir: Path) -> int | None:
     return load_json(checkpoint_dir / TRAINING_STATE_DIR / TRAINING_STEP).get("batch_size")
 
 
+WINDOWS_SYMLINK_PRIVILEGE_ERROR = 1314
+
+
+def _is_windows_symlink_privilege_error(exc: BaseException) -> bool:
+    """Return True only for Windows ERROR_PRIVILEGE_NOT_HELD (WinError 1314)."""
+    return os.name == "nt" and getattr(exc, "winerror", None) == WINDOWS_SYMLINK_PRIVILEGE_ERROR
+
+
+def _remove_latest_checkpoint_link(link_path: Path) -> None:
+    """Remove an existing latest-checkpoint pointer without deleting real checkpoint trees.
+
+    Handles symlinks, Windows directory junctions, regular files, and empty directories.
+    Refuses to recursively delete a non-empty real directory at the link path.
+    """
+    if link_path.is_symlink():
+        link_path.unlink()
+        return
+    if not os.path.lexists(link_path):
+        return
+    try:
+        mode = os.lstat(link_path).st_mode
+    except FileNotFoundError:
+        return
+    if stat.S_ISDIR(mode):
+        # Directory junctions and empty dirs are removed with rmdir; the junction
+        # target (the real step checkpoint) is left intact.
+        try:
+            os.rmdir(link_path)
+        except OSError as exc:
+            raise OSError(
+                f"Refusing to remove non-empty directory at latest checkpoint link path: {link_path}"
+            ) from exc
+        return
+    link_path.unlink()
+
+
+def _create_directory_junction(link_path: Path, target_path: Path) -> None:
+    """Create a Windows directory junction from link_path to target_path via mklink /J."""
+    if os.name != "nt":
+        raise OSError("Directory junctions are only supported on Windows.")
+
+    # abspath works for not-yet-created link paths; list args preserve spaces safely.
+    link = os.path.abspath(str(link_path))
+    target = os.path.abspath(str(target_path))
+    result = subprocess.run(
+        ["cmd", "/c", "mklink", "/J", link, target],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        details = (result.stderr or result.stdout or "").strip() or f"exit code {result.returncode}"
+        raise OSError(f"Failed to create directory junction '{link}' -> '{target}': {details}")
+
+
+def _link_latest_checkpoint(link_path: Path, target_dir: Path) -> None:
+    """Point link_path at target_dir, preferring a relative directory symlink.
+
+    On Windows, if symlink creation fails with WinError 1314 (missing
+    SeCreateSymbolicLinkPrivilege / Developer Mode), fall back to a directory
+    junction. All other errors are re-raised unchanged.
+    """
+    if not target_dir.is_dir():
+        raise NotADirectoryError(f"Checkpoint target must be a directory: {target_dir}")
+    relative_target = target_dir.relative_to(link_path.parent)
+    try:
+        link_path.symlink_to(relative_target, target_is_directory=True)
+    except OSError as exc:
+        if not _is_windows_symlink_privilege_error(exc):
+            raise
+        _create_directory_junction(link_path, target_dir)
+
+
 def update_last_checkpoint(checkpoint_dir: Path) -> Path:
-    last_checkpoint_dir = checkpoint_dir.parent / LAST_CHECKPOINT_LINK
-    if last_checkpoint_dir.is_symlink():
-        last_checkpoint_dir.unlink()
-    relative_target = checkpoint_dir.relative_to(checkpoint_dir.parent)
-    last_checkpoint_dir.symlink_to(relative_target)
+    """Update the ``last`` pointer under the checkpoints directory to ``checkpoint_dir``.
+
+    Prefers a relative directory symlink. On Windows without symlink privilege
+    (WinError 1314), falls back to a directory junction. The public path name
+    remains ``checkpoints/last``; checkpoint trees are never copied.
+    """
+    checkpoints_dir = checkpoint_dir.parent
+    last_checkpoint_dir = checkpoints_dir / LAST_CHECKPOINT_LINK
+    temp_checkpoint_dir = checkpoints_dir / f"{LAST_CHECKPOINT_LINK}.tmp-{uuid.uuid4().hex}"
+    try:
+        _link_latest_checkpoint(temp_checkpoint_dir, checkpoint_dir)
+        _remove_latest_checkpoint_link(last_checkpoint_dir)
+        os.replace(temp_checkpoint_dir, last_checkpoint_dir)
+    except Exception:
+        with suppress(OSError):
+            _remove_latest_checkpoint_link(temp_checkpoint_dir)
+        raise
+    return last_checkpoint_dir
 
 
 def save_checkpoint(

--- a/tests/utils/test_train_utils.py
+++ b/tests/utils/test_train_utils.py
@@ -14,12 +14,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from pathlib import Path
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
+from lerobot.common import train_utils as train_utils_module
 from lerobot.common.train_utils import (
+    _is_windows_symlink_privilege_error,
+    _link_latest_checkpoint,
     get_step_checkpoint_dir,
     get_step_identifier,
     load_training_batch_size,
@@ -42,6 +46,34 @@ from lerobot.utils.constants import (
     TRAINING_STATE_DIR,
     TRAINING_STEP,
 )
+
+
+def _make_winerror(code: int, message: str) -> OSError:
+    exc = OSError(message)
+    exc.winerror = code
+    return exc
+
+
+def test_is_windows_symlink_privilege_error_true_on_nt_with_1314(monkeypatch):
+    monkeypatch.setattr(train_utils_module.os, "name", "nt")
+    assert _is_windows_symlink_privilege_error(_make_winerror(1314, "privilege not held"))
+
+
+def test_is_windows_symlink_privilege_error_false_for_other_winerror(monkeypatch):
+    monkeypatch.setattr(train_utils_module.os, "name", "nt")
+    assert not _is_windows_symlink_privilege_error(_make_winerror(183, "already exists"))
+
+
+def test_is_windows_symlink_privilege_error_false_on_non_windows(monkeypatch):
+    monkeypatch.setattr(train_utils_module.os, "name", "posix")
+    assert not _is_windows_symlink_privilege_error(_make_winerror(1314, "privilege not held"))
+
+
+def _assert_last_points_to(last: Path, checkpoint: Path) -> None:
+    assert last.exists()
+    assert last.is_dir()
+    assert last.resolve() == checkpoint.resolve()
+    assert os.path.samefile(last, checkpoint)
 
 
 def test_get_step_identifier():
@@ -95,8 +127,129 @@ def test_update_last_checkpoint(tmp_path):
     checkpoint.mkdir()
     update_last_checkpoint(checkpoint)
     last_checkpoint = tmp_path / LAST_CHECKPOINT_LINK
-    assert last_checkpoint.is_symlink()
-    assert last_checkpoint.resolve() == checkpoint
+    _assert_last_points_to(last_checkpoint, checkpoint)
+    if os.name != "nt" or last_checkpoint.is_symlink():
+        assert last_checkpoint.is_symlink()
+
+
+def test_link_latest_checkpoint_falls_back_to_junction_on_winerror_1314(tmp_path, monkeypatch):
+    checkpoint = tmp_path / "0005"
+    checkpoint.mkdir()
+    link = tmp_path / "last"
+    junction_mock = MagicMock()
+
+    def symlink_side_effect(self, target, target_is_directory=False):
+        raise _make_winerror(1314, "A required privilege is not held by the client")
+
+    monkeypatch.setattr(Path, "symlink_to", symlink_side_effect)
+    monkeypatch.setattr("lerobot.common.train_utils._create_directory_junction", junction_mock)
+    monkeypatch.setattr(
+        "lerobot.common.train_utils._is_windows_symlink_privilege_error",
+        lambda exc: getattr(exc, "winerror", None) == 1314,
+    )
+
+    _link_latest_checkpoint(link, checkpoint)
+
+    junction_mock.assert_called_once_with(link, checkpoint)
+
+
+def test_link_latest_checkpoint_reraises_non_privilege_oserror(tmp_path, monkeypatch):
+    checkpoint = tmp_path / "0005"
+    checkpoint.mkdir()
+    link = tmp_path / "last"
+    junction_mock = MagicMock()
+    original_error = _make_winerror(183, "Cannot create a file when that file already exists")
+
+    def symlink_side_effect(self, target, target_is_directory=False):
+        raise original_error
+
+    monkeypatch.setattr(Path, "symlink_to", symlink_side_effect)
+    monkeypatch.setattr("lerobot.common.train_utils._create_directory_junction", junction_mock)
+    monkeypatch.setattr("lerobot.common.train_utils._is_windows_symlink_privilege_error", lambda exc: False)
+
+    with pytest.raises(OSError) as exc_info:
+        _link_latest_checkpoint(link, checkpoint)
+    assert exc_info.value is original_error
+    junction_mock.assert_not_called()
+
+
+def test_link_latest_checkpoint_non_privilege_error_does_not_call_junction(tmp_path, monkeypatch):
+    checkpoint = tmp_path / "0005"
+    checkpoint.mkdir()
+    link = tmp_path / "last"
+    junction_mock = MagicMock()
+
+    def symlink_side_effect(self, target, target_is_directory=False):
+        raise OSError("permission denied")
+
+    monkeypatch.setattr(Path, "symlink_to", symlink_side_effect)
+    monkeypatch.setattr("lerobot.common.train_utils._create_directory_junction", junction_mock)
+    monkeypatch.setattr("lerobot.common.train_utils._is_windows_symlink_privilege_error", lambda exc: False)
+
+    with pytest.raises(OSError, match="permission denied"):
+        _link_latest_checkpoint(link, checkpoint)
+    junction_mock.assert_not_called()
+
+
+def test_update_last_checkpoint_replaces_existing_pointer(tmp_path):
+    ckpt1 = tmp_path / "0005"
+    ckpt2 = tmp_path / "0010"
+    ckpt1.mkdir()
+    ckpt2.mkdir()
+    update_last_checkpoint(ckpt1)
+    update_last_checkpoint(ckpt2)
+    _assert_last_points_to(tmp_path / LAST_CHECKPOINT_LINK, ckpt2)
+
+
+def test_update_last_checkpoint_readable_via_last_pointer(tmp_path):
+    checkpoint = tmp_path / "0005"
+    checkpoint.mkdir()
+    update_last_checkpoint(checkpoint)
+    last = tmp_path / LAST_CHECKPOINT_LINK
+    save_training_step(42, last)
+    assert load_training_step(last) == 42
+
+
+def test_update_last_checkpoint_does_not_copy_checkpoint_dir(tmp_path):
+    checkpoint = tmp_path / "0005"
+    checkpoint.mkdir()
+    marker = checkpoint / "marker.txt"
+    marker.write_text("original")
+    update_last_checkpoint(checkpoint)
+    last = tmp_path / LAST_CHECKPOINT_LINK
+    _assert_last_points_to(last, checkpoint)
+    assert (last / "marker.txt").read_text() == "original"
+    (last / "marker.txt").write_text("updated")
+    assert marker.read_text() == "updated"
+    assert {path.name for path in tmp_path.iterdir()} == {checkpoint.name, LAST_CHECKPOINT_LINK}
+
+
+def test_update_last_checkpoint_path_with_spaces(tmp_path):
+    checkpoints_dir = tmp_path / "my checkpoints"
+    checkpoints_dir.mkdir()
+    checkpoint = checkpoints_dir / "0005"
+    checkpoint.mkdir()
+    update_last_checkpoint(checkpoint)
+    _assert_last_points_to(checkpoints_dir / LAST_CHECKPOINT_LINK, checkpoint)
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows junction integration")
+def test_update_last_checkpoint_real_junction_without_symlink_privilege(tmp_path, monkeypatch):
+    checkpoint = tmp_path / "0005"
+    checkpoint.mkdir()
+
+    def symlink_side_effect(self, target, target_is_directory=False):
+        raise _make_winerror(1314, "A required privilege is not held by the client")
+
+    monkeypatch.setattr(Path, "symlink_to", symlink_side_effect)
+
+    update_last_checkpoint(checkpoint)
+    last = tmp_path / LAST_CHECKPOINT_LINK
+    _assert_last_points_to(last, checkpoint)
+    assert not last.is_symlink()
+    assert (last / "..").resolve() == tmp_path.resolve()
+    save_training_step(42, last)
+    assert load_training_step(last) == 42
 
 
 @patch("lerobot.common.train_utils.save_training_state")
@@ -212,9 +365,9 @@ def test_resolve_resume_checkpoint_downloads_latest_and_links(tmp_path, monkeypa
 
     assert checkpoint_dir == out / CHECKPOINTS_DIR / "020000"
     last = out / CHECKPOINTS_DIR / LAST_CHECKPOINT_LINK
-    assert last.is_symlink()
-    # `last` points at the downloaded step dir.
-    assert (last.parent / last.readlink()).resolve() == checkpoint_dir.resolve()
+    _assert_last_points_to(last, checkpoint_dir)
+    if last.is_symlink():
+        assert (last.parent / last.readlink()).resolve() == checkpoint_dir.resolve()
 
 
 def test_resolve_resume_checkpoint_raises_without_checkpoints(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

* keep using directory symlinks for `checkpoints/last` when they’re supported
* fall back to a Windows directory junction if symlink creation fails with `ERROR_PRIVILEGE_NOT_HELD` (`WinError 1314`)
* create the new pointer under a temporary name before swapping it into `last`
* update tests so they accept either a symlink or a junction
* add regression coverage for the Windows fallback path

Fixes #4059

## Why

Right now, creating `checkpoints/last` on Windows requires symlink privileges. In a typical non-admin terminal with Developer Mode turned off, `Path.symlink_to()` throws `WinError 1314`, which blocks checkpoint creation and breaks the related training utility tests.

Directory junctions behave the same way for our use case, but don’t require special privileges or copying any checkpoint data.

The fallback only applies on Windows and only for `WinError 1314`. Any other filesystem errors are left untouched.

## Tests

- `pytest tests/utils/test_train_utils.py -q` — 29 passed
- `pre-commit run --files src/lerobot/common/train_utils.py tests/utils/test_train_utils.py`
- verified creating, updating, and reading the checkpoint pointer on Windows in a standard non-admin terminal with Developer Mode disabled
- confirmed the fallback creates a junction instead of copying the checkpoint directory