### PR TITLE
feat(envs): add task_prompt option to RoboCasa env for eval/train prompt parity

### DIFF
--- a/docs/source/robocasa.mdx
+++ b/docs/source/robocasa.mdx
@@ -82,6 +82,9 @@ By default the env samples objects only from the `lightwheel` registry (what `--
 
 All eval snippets below mirror the CI command (see `.github/workflows/benchmark_tests.yml`). The `--rename_map` argument maps RoboCasa's native camera keys (`robot0_agentview_left` / `robot0_eye_in_hand` / `robot0_agentview_right`) onto the three-camera (`camera1` / `camera2` / `camera3`) input layout the released `smolvla_robocasa` policy was trained on.
 
+> [!IMPORTANT]
+> **Task prompt format.** The released `lerobot/smolvla_robocasa` checkpoint was trained on CamelCase task IDs (e.g. `"CloseFridge"`), but the environment defaults to feeding RoboCasa's natural-language instruction (e.g. `"Close the fridge doors."`) to the policy at eval. This train/eval mismatch degrades measured performance. To reproduce the checkpoint's numbers, add `--env.task_prompt=task_id` so the policy receives the same CamelCase prompt it saw during training. Use the default `--env.task_prompt=lang` only for policies trained on the natural-language instructions.
+
 ### Single-task evaluation (recommended for quick iteration)
 
 ```bash
@@ -89,6 +92,7 @@ lerobot-eval \
   --policy.path=lerobot/smolvla_robocasa \
   --env.type=robocasa \
   --env.task=CloseFridge \
+  --env.task_prompt=task_id \
   --eval.batch_size=1 \
   --eval.n_episodes=20 \
   --eval.use_async_envs=false \

--- a/src/lerobot/envs/configs.py
+++ b/src/lerobot/envs/configs.py
@@ -518,6 +518,12 @@ class RoboCasaEnv(EnvConfig):
     # you've run `python -m robocasa.scripts.download_kitchen_assets
     # --type objaverse` locally.
     obj_registries: list[str] = field(default_factory=lambda: ["lightwheel"])
+    # Prompt exposed to the policy at eval as `task_description`.
+    #   "lang"    -> RoboCasa natural-language instruction (e.g. "Close the fridge doors.")
+    #   "task_id" -> CamelCase task name (e.g. "CloseFridge")
+    # The released `lerobot/smolvla_robocasa` checkpoint was trained on CamelCase
+    # task IDs, so reproducing its eval numbers requires `--env.task_prompt=task_id`.
+    task_prompt: str = "lang"
     features: dict[str, PolicyFeature] = field(
         default_factory=lambda: {ACTION: PolicyFeature(type=FeatureType.ACTION, shape=(12,))}
     )
@@ -526,6 +532,9 @@ class RoboCasaEnv(EnvConfig):
     def __post_init__(self):
         if self.obs_type not in ("pixels", "pixels_agent_pos"):
             raise ValueError(f"Unsupported obs_type: {self.obs_type}")
+
+        if self.task_prompt not in ("lang", "task_id"):
+            raise ValueError(f"Unsupported task_prompt: {self.task_prompt}. Use 'lang' or 'task_id'.")
 
         # Preserve raw RoboCasa camera names end-to-end (e.g.
         # `observation.images.robot0_agentview_left`). This matches the
@@ -551,6 +560,7 @@ class RoboCasaEnv(EnvConfig):
             "observation_width": self.observation_width,
             "visualization_height": self.visualization_height,
             "visualization_width": self.visualization_width,
+            "task_prompt": self.task_prompt,
         }
         if self.split is not None:
             kwargs["split"] = self.split

--- a/src/lerobot/envs/robocasa.py
+++ b/src/lerobot/envs/robocasa.py
@@ -136,9 +136,19 @@ class RoboCasaEnv(gym.Env):
         episode_length: int | None = None,
         obj_registries: Sequence[str] = DEFAULT_OBJ_REGISTRIES,
         episode_index: int = 0,
+        task_prompt: str = "lang",
     ):
         super().__init__()
         self.task = task
+        # Which string to expose as ``task_description`` (the prompt fed to the
+        # policy at eval). "lang" uses RoboCasa's natural-language instruction
+        # (e.g. "Close the fridge doors."); "task_id" uses the CamelCase task
+        # name (e.g. "CloseFridge"). The released `lerobot/smolvla_robocasa`
+        # checkpoint was trained on CamelCase task IDs, so reproducing its
+        # numbers requires "task_id".
+        if task_prompt not in ("lang", "task_id"):
+            raise ValueError(f"Unsupported task_prompt '{task_prompt}'. Use 'lang' or 'task_id'.")
+        self.task_prompt = task_prompt
         self.obs_type = obs_type
         self.render_mode = render_mode
         self.observation_width = observation_width
@@ -219,7 +229,19 @@ class RoboCasaEnv(gym.Env):
         )
 
         ep_meta = self._env.env.get_ep_meta()
-        self.task_description = ep_meta.get("lang", self.task)
+        self.task_description = self._resolve_task_description(ep_meta)
+
+    def _resolve_task_description(self, ep_meta: dict[str, Any]) -> str:
+        """Pick the prompt exposed to the policy based on ``task_prompt``.
+
+        "task_id" returns the CamelCase task name (matching how the released
+        RoboCasa checkpoints were trained); "lang" returns RoboCasa's
+        natural-language instruction, falling back to the task name when the
+        episode metadata has no ``lang`` entry.
+        """
+        if self.task_prompt == "task_id":
+            return self.task
+        return ep_meta.get("lang", self.task)
 
     def _format_raw_obs(self, raw_obs: dict) -> RobotObservation:
         """Convert RoboCasaGymEnv observation dict to LeRobot format."""
@@ -261,7 +283,7 @@ class RoboCasaEnv(gym.Env):
         raw_obs, info = self._env.reset(seed=worker_seed)
 
         ep_meta = self._env.env.get_ep_meta()
-        self.task_description = ep_meta.get("lang", self.task)
+        self.task_description = self._resolve_task_description(ep_meta)
 
         observation = self._format_raw_obs(raw_obs)
         info = {"is_success": False}
@@ -313,6 +335,7 @@ def _make_env_fns(
     split: str | None,
     episode_length: int | None,
     obj_registries: Sequence[str],
+    task_prompt: str,
 ) -> list[Callable[[], RoboCasaEnv]]:
     """Build n_envs factory callables for a single task.
 
@@ -335,6 +358,7 @@ def _make_env_fns(
             episode_length=episode_length,
             obj_registries=obj_registries,
             episode_index=episode_index,
+            task_prompt=task_prompt,
         )
 
     return [partial(_make_env, i) for i in range(n_envs)]
@@ -375,6 +399,7 @@ def create_robocasa_envs(
     visualization_width = gym_kwargs.pop("visualization_width", 512)
     visualization_height = gym_kwargs.pop("visualization_height", 512)
     split = gym_kwargs.pop("split", None)
+    task_prompt = gym_kwargs.pop("task_prompt", "lang")
 
     camera_names = parse_camera_names(camera_name)
     task_names, group_split = _resolve_tasks(str(task))
@@ -409,6 +434,7 @@ def create_robocasa_envs(
             split=split,
             episode_length=episode_length,
             obj_registries=obj_registries,
+            task_prompt=task_prompt,
         )
 
         if is_async:

--- a/tests/envs/test_robocasa.py
+++ b/tests/envs/test_robocasa.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for the RoboCasa `task_prompt` option.
+
+The released `lerobot/smolvla_robocasa` checkpoint was trained on CamelCase
+task IDs (e.g. "CloseFridge") but the wrapper defaults to feeding RoboCasa's
+natural-language instruction (e.g. "Close the fridge doors.") at eval. These
+tests pin the prompt-selection behaviour. They construct the `RoboCasaEnv`
+wrapper directly and mock the inner env, so they run without the full
+`robocasa` installation.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from lerobot.envs.configs import RoboCasaEnv as RoboCasaEnvConfig
+from lerobot.envs.robocasa import RoboCasaEnv
+
+LANG = "Close the fridge doors."
+TASK = "CloseFridge"
+
+
+def test_resolve_task_description_task_id_uses_camelcase():
+    env = RoboCasaEnv(task=TASK, task_prompt="task_id")
+    assert env._resolve_task_description({"lang": LANG}) == TASK
+
+
+def test_resolve_task_description_lang_uses_instruction():
+    env = RoboCasaEnv(task=TASK, task_prompt="lang")
+    assert env._resolve_task_description({"lang": LANG}) == LANG
+
+
+def test_resolve_task_description_lang_falls_back_to_task():
+    env = RoboCasaEnv(task=TASK, task_prompt="lang")
+    assert env._resolve_task_description({}) == TASK
+
+
+def test_wrapper_rejects_unknown_task_prompt():
+    with pytest.raises(ValueError, match="task_prompt"):
+        RoboCasaEnv(task=TASK, task_prompt="bogus")
+
+
+@pytest.mark.parametrize(
+    "task_prompt, expected",
+    [("task_id", TASK), ("lang", LANG)],
+)
+def test_reset_sets_task_description_from_prompt(task_prompt, expected):
+    """reset() must expose the prompt selected by `task_prompt`."""
+    env = RoboCasaEnv(task=TASK, task_prompt=task_prompt)
+    # Pre-populate `_env` so `_ensure_env()` short-circuits and no real
+    # robocasa runtime is created.
+    inner = MagicMock()
+    inner.reset.return_value = ({}, {})
+    inner.env.get_ep_meta.return_value = {"lang": LANG}
+    env._env = inner
+
+    env.reset(seed=0)
+    assert env.task_description == expected
+
+
+def test_config_default_prompt_is_lang():
+    cfg = RoboCasaEnvConfig(task=TASK)
+    assert cfg.task_prompt == "lang"
+    assert cfg.gym_kwargs["task_prompt"] == "lang"
+
+
+def test_config_exposes_task_prompt_in_gym_kwargs():
+    cfg = RoboCasaEnvConfig(task=TASK, task_prompt="task_id")
+    assert cfg.gym_kwargs["task_prompt"] == "task_id"
+
+
+def test_config_rejects_unknown_task_prompt():
+    with pytest.raises(ValueError, match="task_prompt"):
+        RoboCasaEnvConfig(task=TASK, task_prompt="bad")


### PR DESCRIPTION
## Motivation

At eval, the RoboCasa env gave the policy a natural-language prompt (`ep_meta["lang"]`, e.g. `"Close the fridge doors."`). But the `lerobot/smolvla_robocasa` checkpoint was trained on CamelCase task IDs (e.g. `"CloseFridge"`). So the policy sees a prompt it never trained on, and scores lower. This adds a `--env.task_prompt` option so eval can use the same prompt as training.

## Related issues

- Fixes: #4045 

## What changed

- New `--env.task_prompt` option (`"lang"` | `"task_id"`) that picks the `task_description` sent to the policy:
  - `"lang"` (default): natural-language prompt (unchanged); falls back to the task name if there's no `"lang"`.
  - `"task_id"`: CamelCase task name, matching training.
- Checked in both the config and the wrapper; passed through `gym_kwargs -> create_robocasa_envs -> _make_env_fns -> RoboCasaEnv`; both `task_description` sites now use one shared helper.
- Docs updated with the flag.
- No breaking changes (default is unchanged).

## How was this tested (or how to run locally)

- Added `tests/envs/test_robocasa.py` (prompt selection, `reset()`, config validation). No `robocasa` install needed.
  ```bash
  pytest -q tests/envs/test_robocasa.py
  ```
- Match the checkpoint's training prompt:
  ```bash
  lerobot-eval --policy.path=lerobot/smolvla_robocasa \
    --env.type=robocasa --env.task=CloseFridge --env.task_prompt=task_id ...
  ```

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: #

## Reviewer notes

- Should the default stay `"lang"` or switch to `"task_id"` so the checkpoint works out of the box?