### PR TITLE
feat(pi05): add optional visual and proprioceptive MEM

### DIFF
--- a/docs/source/pi05.mdx
+++ b/docs/source/pi05.mdx
@@ -231,6 +231,13 @@ frame. Visual and proprioceptive memory use the same `memory_frames` and
 or finetune with the selected memory options; enabling them only at inference
 does not give a single-frame checkpoint learned memory behavior.
 
+At inference, MEM keeps one batched history queue and assumes every batch row
+shares episode boundaries. `lerobot-eval` satisfies this by calling
+`policy.reset()` before each batched rollout and before resetting the vector
+environment. Independently autoresetting rows in an asynchronous vector batch
+is not supported; start a new rollout so the complete policy and action queues
+are reset together.
+
 ## Relative Actions
 
 By default, π₀.₅ predicts absolute actions. You can enable **relative actions** so the model predicts offsets relative to the current robot state. This can improve training stability for certain setups.

--- a/docs/source/pi05.mdx
+++ b/docs/source/pi05.mdx
@@ -187,6 +187,50 @@ Passing a `--rename_map` alongside `--policy.pretrained_path` renames the batch 
 
 **💡 Tip**: Setting `train_expert_only=true` freezes the VLM and trains only the action expert and projections, allowing finetuning with reduced memory usage.
 
+## Visual Memory (MEM)
+
+Pi05 can optionally use short-horizon visual context based on
+[MEM](https://arxiv.org/abs/2603.03596). Visual memory is disabled by default,
+so existing checkpoints and training commands retain the single-frame Pi05
+behavior.
+
+Enable it while finetuning with:
+
+```bash
+lerobot-train \
+    --dataset.repo_id=your_dataset \
+    --policy.type=pi05 \
+    --policy.pretrained_path=lerobot/pi05_base \
+    --policy.use_visual_memory=true \
+    --policy.memory_frames=6 \
+    --policy.memory_stride=10 \
+    --policy.memory_temporal_attention_every=4 \
+    ...
+```
+
+`memory_frames` includes the current observation. `memory_stride` is measured
+in dataset frames, so the example above uses the current image plus five
+historical images spaced one second apart for a 10 Hz dataset. Every fourth
+SigLIP layer applies causal temporal attention between matching patch tokens.
+Only current-frame tokens leave the vision tower, keeping the downstream
+language/action prefix length unchanged.
+
+Unavailable history at the beginning of an episode is padded and masked. At
+inference, Pi05 maintains the same strided image history internally and clears
+it whenever the policy is reset.
+
+Historical proprioception is an independent option:
+
+```bash
+--policy.use_proprioceptive_memory=true
+```
+
+When enabled, one projected continuous state token is added for each retained
+frame. Visual and proprioceptive memory use the same `memory_frames` and
+`memory_stride` settings, but either path can be enabled independently. Train
+or finetune with the selected memory options; enabling them only at inference
+does not give a single-frame checkpoint learned memory behavior.
+
 ## Relative Actions
 
 By default, π₀.₅ predicts absolute actions. You can enable **relative actions** so the model predicts offsets relative to the current robot state. This can improve training stability for certain setups.

--- a/docs/source/pi05.mdx
+++ b/docs/source/pi05.mdx
@@ -179,15 +179,17 @@ lerobot-train \
 
 The two forms are not interchangeable:
 
-|                                        | `--policy.path`                                | `--policy.pretrained_path`           |
-| -------------------------------------- | ---------------------------------------------- | ------------------------------------ |
-| Loads                                  | weights **and** the checkpoint's `config.json` | weights only                         |
-| Feature names                          | from the checkpoint                            | from your dataset                    |
-| Stored settings, e.g. `n_action_steps` | inherited                                      | reset to the defaults                |
-| `--policy.type`                        | must be omitted                                | required                             |
-| `--rename_map`                         | needed when your camera keys differ            | never — the keys come from your data |
+|                                        | `--policy.path`                                | `--policy.pretrained_path`                |
+| -------------------------------------- | ---------------------------------------------- | ----------------------------------------- |
+| Loads                                  | weights **and** the checkpoint's `config.json` | weights only                              |
+| Feature names                          | from the checkpoint                            | from your dataset, after `--rename_map`   |
+| Stored settings, e.g. `n_action_steps` | inherited                                      | reset to the defaults                     |
+| `--policy.type`                        | must be omitted                                | required                                  |
+| `--rename_map`                         | needed when your camera keys differ            | supported for canonicalizing dataset keys |
 
-Passing a `--rename_map` alongside `--policy.pretrained_path` renames the batch away from those names, and the first batch fails with `All image features are missing from the batch`.
+Use `--rename_map` with either loading form when raw dataset feature names differ from the policy
+feature names. For example, the RoboMME fine-tuning command maps its raw `image`, `wrist_image`,
+`state`, and `actions` columns while initializing weights with `--policy.pretrained_path`.
 
 ### Training Parameters Explained
 

--- a/docs/source/pi05.mdx
+++ b/docs/source/pi05.mdx
@@ -187,12 +187,27 @@ Passing a `--rename_map` alongside `--policy.pretrained_path` renames the batch 
 
 **💡 Tip**: Setting `train_expert_only=true` freezes the VLM and trains only the action expert and projections, allowing finetuning with reduced memory usage.
 
-## Visual Memory (MEM)
+## Short-Horizon Observation Memory (MEM)
 
-Pi05 can optionally use short-horizon visual context based on
-[MEM](https://arxiv.org/abs/2603.03596). Visual memory is disabled by default,
-so existing checkpoints and training commands retain the single-frame Pi05
-behavior.
+Pi05 can optionally use short-horizon visual and proprioceptive context based on
+[MEM](https://arxiv.org/abs/2603.03596). Both paths are disabled by default, so
+existing checkpoints and training commands retain the single-frame Pi05 behavior.
+
+<Tip warning={true}>
+
+This implements MEM's short-horizon memory only — the video encoder of section
+III-C and the proprioceptive projection of section III-D. MEM's long-horizon
+_language_ memory (section III-B), in which a high-level policy predicts the next
+subtask and a compressed natural-language summary of what has happened so far, is
+not implemented. In the paper's ablations, video memory alone recovers only part
+of full MEM's task progress on long-horizon tasks.
+
+Introducing memory when finetuning from a checkpoint that was pretrained without
+it also corresponds to the paper's weaker `MEM-Posttrain-Only` ablation. MEM's
+headline results come from pretraining the video encoder on a diverse mixture of
+robot and non-robot video, which no public Pi05 checkpoint currently provides.
+
+</Tip>
 
 Enable it while finetuning with:
 
@@ -203,17 +218,23 @@ lerobot-train \
     --policy.pretrained_path=lerobot/pi05_base \
     --policy.use_visual_memory=true \
     --policy.memory_frames=6 \
-    --policy.memory_stride=10 \
+    --policy.memory_stride=30 \
     --policy.memory_temporal_attention_every=4 \
     ...
 ```
 
-`memory_frames` includes the current observation. `memory_stride` is measured
-in dataset frames, so the example above uses the current image plus five
-historical images spaced one second apart for a 10 Hz dataset. Every fourth
-SigLIP layer applies causal temporal attention between matching patch tokens.
-Only current-frame tokens leave the vision tower, keeping the downstream
-language/action prefix length unchanged.
+`memory_frames` includes the current observation. `memory_stride` is measured in
+**dataset frames**, not seconds, so scale it with your dataset's `fps`: MEM
+pretrains on six observations one second apart, which is `memory_stride=30` for a
+30 fps dataset (the default) but `memory_stride=10` for a 10 fps dataset such as
+`lerobot/robomme`.
+
+Every fourth SigLIP layer replaces its attention with MEM's composed space-time
+attention: causal temporal attention between matching patch tokens, composed with
+the standard spatial attention and reusing the pretrained projections, so no
+learnable parameters are added to the vision tower. Past-frame tokens are dropped
+once the last such layer has run, keeping the downstream language/action prefix
+length unchanged.
 
 Unavailable history at the beginning of an episode is padded and masked. At
 inference, Pi05 maintains the same strided image history internally and clears
@@ -226,10 +247,16 @@ Historical proprioception is an independent option:
 ```
 
 When enabled, one projected continuous state token is added for each retained
-frame. Visual and proprioceptive memory use the same `memory_frames` and
-`memory_stride` settings, but either path can be enabled independently. Train
-or finetune with the selected memory options; enabling them only at inference
-does not give a single-frame checkpoint learned memory behavior.
+frame, and the discretized state is removed from the text prompt so the state is
+represented exactly once (MEM section III-D). This changes the prompt format, so
+enable it from the start of training rather than partway through. Visual and
+proprioceptive memory use the same `memory_frames` and `memory_stride` settings,
+but either path can be enabled independently. Train or finetune with the selected
+memory options; enabling them only at inference does not give a single-frame
+checkpoint learned memory behavior.
+
+Under PEFT, `proprio_history_proj` is trained and saved in full via
+`modules_to_save`, since it has no pretrained weights to adapt.
 
 At inference, MEM keeps one batched history queue and assumes every batch row
 shares episode boundaries. `lerobot-eval` satisfies this by calling

--- a/docs/source/robomme.mdx
+++ b/docs/source/robomme.mdx
@@ -106,9 +106,15 @@ dataset = LeRobotDataset("lerobot/robomme")
 
 ### Feature key alignment (training)
 
-The env wrapper exposes `pixels/image` and `pixels/wrist_image` as observation keys. The `features_map` in `RoboMMEEnv` maps these to `observation.images.image` and `observation.images.wrist_image` for the policy. State is exposed as `agent_pos` and maps to `observation.state`.
+The env wrapper exposes its cameras under `pixels/<camera_name>`, named by `RoboMMEEnv.front_camera_name` and `RoboMMEEnv.wrist_camera_name` (`camera1` and `camera2` by default). The `features_map` in `RoboMMEEnv` maps these to `observation.images.camera1` and `observation.images.camera2` for the policy. State is exposed as `agent_pos` and maps to `observation.state`.
 
-The dataset's `image` and `wrist_image` columns already align with the policy input keys, so no renaming is needed when fine-tuning.
+The dataset's raw columns do not match those policy keys, so pass a `--rename_map` when fine-tuning:
+
+```bash
+--rename_map='{"image": "observation.images.camera1", "wrist_image": "observation.images.camera2", "state": "observation.state", "actions": "action"}'
+```
+
+Override `--env.front_camera_name` / `--env.wrist_camera_name` if you train against different key names, so evaluation observations match the keys the policy was trained on.
 
 ## Action Spaces
 

--- a/src/lerobot/datasets/factory.py
+++ b/src/lerobot/datasets/factory.py
@@ -23,7 +23,7 @@ from lerobot.configs import PreTrainedConfig
 from lerobot.configs.rewards import RewardModelConfig
 from lerobot.configs.train import TrainPipelineConfig
 from lerobot.transforms import ImageTransforms
-from lerobot.utils.constants import ACTION, IMAGENET_STATS, OBS_IMAGES, OBS_PREFIX, OBS_STATE, REWARD
+from lerobot.utils.constants import ACTION, IMAGENET_STATS, OBS_IMAGE, OBS_PREFIX, OBS_STATE, REWARD
 
 from .dataset_metadata import LeRobotDatasetMetadata
 from .lerobot_dataset import LeRobotDataset
@@ -54,21 +54,46 @@ def resolve_delta_timestamps(
             }
             returns `None` if the resulting dict is empty.
     """
+    # Only policies that opt into modality-specific history (currently Pi05 with MEM)
+    # define these; everything else falls back to the shared observation indices.
+    explicit_image_indices = getattr(cfg, "image_observation_delta_indices", None)
+    image_indices = (
+        explicit_image_indices if explicit_image_indices is not None else cfg.observation_delta_indices
+    )
+    explicit_state_indices = getattr(cfg, "state_observation_delta_indices", None)
+    state_indices = (
+        explicit_state_indices if explicit_state_indices is not None else cfg.observation_delta_indices
+    )
+
     delta_timestamps = {}
+    matched_image_keys = []
     for key in ds_meta.features:
         policy_key = (rename_map or {}).get(key, key)
         if policy_key == REWARD and cfg.reward_delta_indices is not None:
             delta_timestamps[key] = [i / ds_meta.fps for i in cfg.reward_delta_indices]
         if policy_key == ACTION and cfg.action_delta_indices is not None:
             delta_timestamps[key] = [i / ds_meta.fps for i in cfg.action_delta_indices]
-        if policy_key.startswith(OBS_IMAGES):
-            indices = getattr(cfg, "image_observation_delta_indices", cfg.observation_delta_indices)
+        # `OBS_IMAGE` matches both the `observation.image` and `observation.images.<cam>`
+        # conventions; matching `OBS_IMAGES` alone would silently give singular-key
+        # datasets no image history at all.
+        if policy_key.startswith(OBS_IMAGE):
+            indices = image_indices
+            matched_image_keys.append(key)
         elif policy_key == OBS_STATE:
-            indices = getattr(cfg, "state_observation_delta_indices", cfg.observation_delta_indices)
+            indices = state_indices
         else:
             indices = cfg.observation_delta_indices if policy_key.startswith(OBS_PREFIX) else None
         if indices is not None:
             delta_timestamps[key] = [i / ds_meta.fps for i in indices]
+
+    # A policy asking for an image history that no dataset key can supply would train
+    # on single frames without any error, so fail instead of degrading silently.
+    if explicit_image_indices is not None and len(explicit_image_indices) > 1 and not matched_image_keys:
+        raise ValueError(
+            f"{type(cfg).__name__} requests {len(explicit_image_indices)} history frames per camera, but no "
+            f"dataset feature maps to an image key. Dataset features: {sorted(ds_meta.features)}. "
+            "Image keys must be named `observation.image*` after applying `--rename_map`."
+        )
 
     if len(delta_timestamps) == 0:
         delta_timestamps = None

--- a/src/lerobot/datasets/factory.py
+++ b/src/lerobot/datasets/factory.py
@@ -23,7 +23,7 @@ from lerobot.configs import PreTrainedConfig
 from lerobot.configs.rewards import RewardModelConfig
 from lerobot.configs.train import TrainPipelineConfig
 from lerobot.transforms import ImageTransforms
-from lerobot.utils.constants import ACTION, IMAGENET_STATS, OBS_PREFIX, REWARD
+from lerobot.utils.constants import ACTION, IMAGENET_STATS, OBS_IMAGES, OBS_PREFIX, OBS_STATE, REWARD
 
 from .dataset_metadata import LeRobotDatasetMetadata
 from .lerobot_dataset import LeRobotDataset
@@ -33,7 +33,9 @@ from .utils import resolve_episode_indices
 
 
 def resolve_delta_timestamps(
-    cfg: PreTrainedConfig | RewardModelConfig, ds_meta: LeRobotDatasetMetadata
+    cfg: PreTrainedConfig | RewardModelConfig,
+    ds_meta: LeRobotDatasetMetadata,
+    rename_map: dict[str, str] | None = None,
 ) -> dict[str, list] | None:
     """Resolves delta_timestamps by reading from the 'delta_indices' properties of the config.
 
@@ -54,12 +56,19 @@ def resolve_delta_timestamps(
     """
     delta_timestamps = {}
     for key in ds_meta.features:
-        if key == REWARD and cfg.reward_delta_indices is not None:
+        policy_key = (rename_map or {}).get(key, key)
+        if policy_key == REWARD and cfg.reward_delta_indices is not None:
             delta_timestamps[key] = [i / ds_meta.fps for i in cfg.reward_delta_indices]
-        if key == ACTION and cfg.action_delta_indices is not None:
+        if policy_key == ACTION and cfg.action_delta_indices is not None:
             delta_timestamps[key] = [i / ds_meta.fps for i in cfg.action_delta_indices]
-        if key.startswith(OBS_PREFIX) and cfg.observation_delta_indices is not None:
-            delta_timestamps[key] = [i / ds_meta.fps for i in cfg.observation_delta_indices]
+        if policy_key.startswith(OBS_IMAGES):
+            indices = getattr(cfg, "image_observation_delta_indices", cfg.observation_delta_indices)
+        elif policy_key == OBS_STATE:
+            indices = getattr(cfg, "state_observation_delta_indices", cfg.observation_delta_indices)
+        else:
+            indices = cfg.observation_delta_indices if policy_key.startswith(OBS_PREFIX) else None
+        if indices is not None:
+            delta_timestamps[key] = [i / ds_meta.fps for i in indices]
 
     if len(delta_timestamps) == 0:
         delta_timestamps = None
@@ -90,7 +99,7 @@ def make_dataset(cfg: TrainPipelineConfig) -> LeRobotDataset | MultiLeRobotDatas
             revision=cfg.dataset.revision,
             repo_type=cfg.dataset.repo_type,
         )
-        delta_timestamps = resolve_delta_timestamps(cfg.trainable_config, ds_meta)
+        delta_timestamps = resolve_delta_timestamps(cfg.trainable_config, ds_meta, cfg.rename_map)
         episodes = resolve_episode_indices(
             cfg.dataset.episodes, ds_meta.total_episodes, cfg.dataset.exclude_episodes
         )
@@ -142,6 +151,7 @@ def make_dataset(cfg: TrainPipelineConfig) -> LeRobotDataset | MultiLeRobotDatas
         for key in dataset.meta.camera_keys:
             if key in dataset.meta.depth_keys:
                 continue  # Exclude depth keys from ImageNet stats
+            dataset.meta.stats.setdefault(key, {})
             for stats_type, stats in IMAGENET_STATS.items():
                 dataset.meta.stats[key][stats_type] = torch.tensor(stats, dtype=torch.float32)
 
@@ -187,7 +197,7 @@ def make_train_eval_datasets(
         f"(eval_split={cfg.dataset.eval_split}, {len(task_to_episodes)} tasks)"
     )
 
-    delta_timestamps = resolve_delta_timestamps(cfg.trainable_config, full_dataset.meta)
+    delta_timestamps = resolve_delta_timestamps(cfg.trainable_config, full_dataset.meta, cfg.rename_map)
 
     train_image_transforms = (
         ImageTransforms(cfg.dataset.image_transforms) if cfg.dataset.image_transforms.enable else None
@@ -220,6 +230,9 @@ def make_train_eval_datasets(
     if cfg.dataset.use_imagenet_stats:
         for ds in (train_dataset, eval_dataset):
             for key in ds.meta.camera_keys:
+                if key in ds.meta.depth_keys:
+                    continue
+                ds.meta.stats.setdefault(key, {})
                 for stats_type, stats in IMAGENET_STATS.items():
                     ds.meta.stats[key][stats_type] = torch.tensor(stats, dtype=torch.float32)
 

--- a/src/lerobot/envs/configs.py
+++ b/src/lerobot/envs/configs.py
@@ -862,23 +862,28 @@ class RoboMMEEnv(EnvConfig):
     action_space: str = "joint_angle"  # or "ee_pose" (7-D)
     dataset_split: str = "test"  # "train" | "val" | "test"
     task_ids: list[int] | None = None
+    front_camera_name: str = "camera1"
+    wrist_camera_name: str = "camera2"
     features: dict[str, PolicyFeature] = field(default_factory=dict)
-    features_map: dict[str, str] = field(
-        default_factory=lambda: {
-            ACTION: ACTION,
-            "pixels/image": f"{OBS_IMAGES}.image",
-            "pixels/wrist_image": f"{OBS_IMAGES}.wrist_image",
-            "agent_pos": OBS_STATE,
-        }
-    )
+    features_map: dict[str, str] = field(default_factory=dict)
 
     def __post_init__(self):
         action_dim = 8 if self.action_space == "joint_angle" else 7
+        if self.front_camera_name == self.wrist_camera_name:
+            raise ValueError("RoboMME front and wrist camera names must be distinct.")
+        front_camera_key = f"pixels/{self.front_camera_name}"
+        wrist_camera_key = f"pixels/{self.wrist_camera_name}"
         self.features = {
             ACTION: PolicyFeature(type=FeatureType.ACTION, shape=(action_dim,)),
-            "pixels/image": PolicyFeature(type=FeatureType.VISUAL, shape=(256, 256, 3)),
-            "pixels/wrist_image": PolicyFeature(type=FeatureType.VISUAL, shape=(256, 256, 3)),
+            front_camera_key: PolicyFeature(type=FeatureType.VISUAL, shape=(256, 256, 3)),
+            wrist_camera_key: PolicyFeature(type=FeatureType.VISUAL, shape=(256, 256, 3)),
             "agent_pos": PolicyFeature(type=FeatureType.STATE, shape=(8,)),
+        }
+        self.features_map = {
+            ACTION: ACTION,
+            front_camera_key: f"{OBS_IMAGES}.{self.front_camera_name}",
+            wrist_camera_key: f"{OBS_IMAGES}.{self.wrist_camera_name}",
+            "agent_pos": OBS_STATE,
         }
 
     @property
@@ -896,5 +901,7 @@ class RoboMMEEnv(EnvConfig):
             dataset=self.dataset_split,
             episode_length=self.episode_length,
             task_ids=self.task_ids,
+            front_camera_name=self.front_camera_name,
+            wrist_camera_name=self.wrist_camera_name,
             env_cls=env_cls,
         )

--- a/src/lerobot/envs/configs.py
+++ b/src/lerobot/envs/configs.py
@@ -879,12 +879,14 @@ class RoboMMEEnv(EnvConfig):
             wrist_camera_key: PolicyFeature(type=FeatureType.VISUAL, shape=(256, 256, 3)),
             "agent_pos": PolicyFeature(type=FeatureType.STATE, shape=(8,)),
         }
-        self.features_map = {
+        default_features_map = {
             ACTION: ACTION,
             front_camera_key: f"{OBS_IMAGES}.{self.front_camera_name}",
             wrist_camera_key: f"{OBS_IMAGES}.{self.wrist_camera_name}",
             "agent_pos": OBS_STATE,
         }
+        # Preserve explicit mappings while filling in the RoboMME defaults.
+        self.features_map = {**default_features_map, **self.features_map}
 
     @property
     def gym_kwargs(self) -> dict:

--- a/src/lerobot/envs/robomme.py
+++ b/src/lerobot/envs/robomme.py
@@ -58,16 +58,22 @@ class RoboMMEGymEnv(gym.Env):
         dataset: str = "test",
         episode_idx: int = 0,
         max_steps: int = 300,
+        front_camera_name: str = "camera1",
+        wrist_camera_name: str = "camera2",
     ):
         super().__init__()
         from robomme.env_record_wrapper import BenchmarkEnvBuilder
 
         self._task = task
+        self.task = task
+        self.task_description = task
         self._action_space_type = action_space_type
         self._dataset = dataset
         self._episode_idx = episode_idx
         self._max_steps = max_steps
         self._max_episode_steps = max_steps
+        self._front_camera_name = front_camera_name
+        self._wrist_camera_name = wrist_camera_name
 
         self._builder = BenchmarkEnvBuilder(
             env_id=task,
@@ -89,8 +95,8 @@ class RoboMMEGymEnv(gym.Env):
             {
                 "pixels": spaces.Dict(
                     {
-                        "image": spaces.Box(0, 255, shape=(256, 256, 3), dtype=np.uint8),
-                        "wrist_image": spaces.Box(0, 255, shape=(256, 256, 3), dtype=np.uint8),
+                        front_camera_name: spaces.Box(0, 255, shape=(256, 256, 3), dtype=np.uint8),
+                        wrist_camera_name: spaces.Box(0, 255, shape=(256, 256, 3), dtype=np.uint8),
                     }
                 ),
                 "agent_pos": spaces.Box(-np.inf, np.inf, shape=(8,), dtype=np.float32),
@@ -99,13 +105,30 @@ class RoboMMEGymEnv(gym.Env):
 
     def reset(self, *, seed=None, options=None):
         super().reset(seed=seed)
+        # A wrapper may be reset more than once when n_episodes > n_envs. Close
+        # the previous SAPIEN environment before replacing it; otherwise every
+        # reset retains Vulkan file descriptors and fence allocations.
+        self.close()
         self._env = self._builder.make_env_for_episode(
             episode_idx=self._episode_idx,
             max_steps=self._max_steps,
         )
         obs, info = self._env.reset()
         self._last_raw_obs = obs
+        task_goal = info.get("task_goal")
+        if isinstance(task_goal, list | tuple):
+            task_goal = task_goal[0] if task_goal else ""
+        self.task_description = str(task_goal or self._task)
         return self._convert_obs(obs), self._convert_info(info)
+
+    def close(self):
+        """Release the underlying ManiSkill/SAPIEN environment immediately."""
+        if self._env is not None:
+            try:
+                self._env.close()
+            finally:
+                self._env = None
+        self._last_raw_obs = None
 
     def step(self, action):
         obs, reward, terminated, truncated, info = self._env.step(action)
@@ -155,8 +178,10 @@ class RoboMMEGymEnv(gym.Env):
         gripper = np.asarray(gripper_state, dtype=np.float32).flatten()[:1]
         state = np.concatenate([joint, gripper])
 
+        front_camera_name = getattr(self, "_front_camera_name", "camera1")
+        wrist_camera_name = getattr(self, "_wrist_camera_name", "camera2")
         return {
-            "pixels": {"image": front_rgb, "wrist_image": wrist_rgb},
+            "pixels": {front_camera_name: front_rgb, wrist_camera_name: wrist_rgb},
             "agent_pos": state,
         }
 
@@ -175,6 +200,8 @@ def _make_env_fns(
     dataset: str,
     episode_length: int,
     task_id: int,
+    front_camera_name: str,
+    wrist_camera_name: str,
 ) -> list[Callable[[], RoboMMEGymEnv]]:
     """Build n_envs factory callables for one RoboMME task id."""
 
@@ -185,6 +212,8 @@ def _make_env_fns(
             dataset=dataset,
             episode_idx=episode_index,
             max_steps=episode_length,
+            front_camera_name=front_camera_name,
+            wrist_camera_name=wrist_camera_name,
         )
 
     return [partial(_make_one, task_id + i) for i in range(n_envs)]
@@ -197,6 +226,8 @@ def create_robomme_envs(
     dataset: str = "test",
     episode_length: int = 300,
     task_ids: list[int] | None = None,
+    front_camera_name: str = "camera1",
+    wrist_camera_name: str = "camera2",
     env_cls: Callable[[Sequence[Callable[[], Any]]], Any] | None = None,
 ) -> dict[str, dict[int, gym.vector.VectorEnv]]:
     """Create vectorized RoboMME environments for evaluation.
@@ -231,6 +262,8 @@ def create_robomme_envs(
                 dataset=dataset,
                 episode_length=episode_length,
                 task_id=task_id,
+                front_camera_name=front_camera_name,
+                wrist_camera_name=wrist_camera_name,
             )
             if is_async:
                 lazy = _LazyAsyncVectorEnv(fns, cached_obs_space, cached_act_space, cached_metadata)

--- a/src/lerobot/policies/factory.py
+++ b/src/lerobot/policies/factory.py
@@ -301,6 +301,9 @@ def make_policy(
             raise ValueError("env_cfg cannot be None when ds_meta is not provided")
         features = env_to_policy_features(env_cfg)
 
+    if rename_map:
+        features = {rename_map.get(key, key): feature for key, feature in features.items()}
+
     cfg.output_features = {key: ft for key, ft in features.items() if ft.type is FeatureType.ACTION}
     if not cfg.input_features:
         cfg.input_features = {key: ft for key, ft in features.items() if key not in cfg.output_features}

--- a/src/lerobot/policies/factory.py
+++ b/src/lerobot/policies/factory.py
@@ -316,7 +316,15 @@ def make_policy(
 
     # Store action feature names for relative_exclude_joints support
     if ds_meta is not None and hasattr(cfg, "action_feature_names"):
-        action_names = ds_meta.features.get(ACTION, {}).get("names")
+        raw_action_feature = next(
+            (
+                feature
+                for raw_key, feature in ds_meta.features.items()
+                if (rename_map or {}).get(raw_key, raw_key) == ACTION
+            ),
+            None,
+        )
+        action_names = raw_action_feature.get("names") if raw_action_feature is not None else None
         if action_names is not None:
             cfg.action_feature_names = list(action_names)
     if ds_meta is not None:

--- a/src/lerobot/policies/pi05/configuration_pi05.py
+++ b/src/lerobot/policies/pi05/configuration_pi05.py
@@ -36,6 +36,16 @@ class PI05Config(PreTrainedConfig):
     chunk_size: int = 50  # Number of action steps to predict, in openpi called "action_horizon"
     n_action_steps: int = 50  # Number of action steps to execute
 
+    # MEM short-horizon observation memory (https://arxiv.org/abs/2603.03596).
+    # Historical image tokens are fused inside SigLIP and dropped before the
+    # language backbone. Historical proprioceptive states become one continuous
+    # backbone token per frame. Both paths are opt-in and independent.
+    use_visual_memory: bool = False
+    use_proprioceptive_memory: bool = False
+    memory_frames: int = 6
+    memory_stride: int = 10
+    memory_temporal_attention_every: int = 4
+
     # Shorter state and action vectors will be padded to these dimensions
     max_state_dim: int = 32
     max_action_dim: int = 32
@@ -121,6 +131,13 @@ class PI05Config(PreTrainedConfig):
         if self.dtype not in ["bfloat16", "float32"]:
             raise ValueError(f"Invalid dtype: {self.dtype}")
 
+        if self.memory_frames < 1:
+            raise ValueError("memory_frames must be at least 1")
+        if self.memory_stride < 1:
+            raise ValueError("memory_stride must be at least 1")
+        if self.memory_temporal_attention_every < 1:
+            raise ValueError("memory_temporal_attention_every must be at least 1")
+
     def validate_features(self) -> None:
         """Validate and set up input/output features."""
         for i in range(self.empty_cameras):
@@ -165,6 +182,20 @@ class PI05Config(PreTrainedConfig):
     @property
     def observation_delta_indices(self) -> None:
         return None
+
+    @property
+    def image_observation_delta_indices(self) -> list[int] | None:
+        if not self.use_visual_memory:
+            return None
+        horizon = (self.memory_frames - 1) * self.memory_stride
+        return list(range(-horizon, 1, self.memory_stride))
+
+    @property
+    def state_observation_delta_indices(self) -> list[int] | None:
+        if not self.use_proprioceptive_memory:
+            return None
+        horizon = (self.memory_frames - 1) * self.memory_stride
+        return list(range(-horizon, 1, self.memory_stride))
 
     @property
     def action_delta_indices(self) -> list:

--- a/src/lerobot/policies/pi05/configuration_pi05.py
+++ b/src/lerobot/policies/pi05/configuration_pi05.py
@@ -40,10 +40,15 @@ class PI05Config(PreTrainedConfig):
     # Historical image tokens are fused inside SigLIP and dropped before the
     # language backbone. Historical proprioceptive states become one continuous
     # backbone token per frame. Both paths are opt-in and independent.
+    #
+    # MEM pre-trains on six observations spaced one second apart. `memory_stride` is
+    # counted in dataset frames, so the default matches that spacing only at 30 fps,
+    # the usual LeRobot recording rate. Scale it with the dataset: a 10 fps dataset
+    # such as `lerobot/robomme` needs `memory_stride=10` for the same one second.
     use_visual_memory: bool = False
     use_proprioceptive_memory: bool = False
     memory_frames: int = 6
-    memory_stride: int = 10
+    memory_stride: int = 30
     memory_temporal_attention_every: int = 4
 
     # Shorter state and action vectors will be padded to these dimensions
@@ -110,8 +115,6 @@ class PI05Config(PreTrainedConfig):
     scheduler_warmup_steps: int = 1_000
     scheduler_decay_steps: int = 30_000
     scheduler_decay_lr: float = 2.5e-6
-
-    tokenizer_max_length: int = 200  # see openpi `__post_init__`
 
     def __post_init__(self):
         super().__post_init__()

--- a/src/lerobot/policies/pi05/memory.py
+++ b/src/lerobot/policies/pi05/memory.py
@@ -1,0 +1,121 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Short-horizon visual and proprioceptive memory from MEM (arXiv:2603.03596)."""
+
+import math
+
+import torch
+from torch import Tensor
+
+
+def sample_observation_history(
+    history: list[Tensor], *, num_frames: int, stride: int, steps_seen: int
+) -> tuple[Tensor, Tensor]:
+    """Subsample an inference queue and mark repeated pre-episode padding."""
+    sampled = history[::stride][-num_frames:]
+    if len(sampled) != num_frames:
+        raise ValueError(f"observation history has {len(sampled)} samples, expected {num_frames}")
+    values = torch.stack(sampled, dim=1)
+    required_ages = range((num_frames - 1) * stride, -1, -stride)
+    valid = torch.tensor([steps_seen > age for age in required_ages], dtype=torch.bool, device=values.device)
+    padding_mask = (~valid)[None, :].expand(values.shape[0], -1)
+    return values, padding_mask
+
+
+def temporal_sinusoidal_embedding(
+    num_frames: int, hidden_size: int, *, device: torch.device, dtype: torch.dtype
+) -> Tensor:
+    """Return fixed temporal embeddings whose current position is exactly zero."""
+    if hidden_size % 2:
+        raise ValueError(f"hidden_size must be even, got {hidden_size}")
+    positions = torch.arange(1 - num_frames, 1, device=device, dtype=torch.float32)[:, None]
+    frequencies = torch.exp(
+        torch.arange(0, hidden_size, 2, device=device, dtype=torch.float32)
+        * (-math.log(10_000.0) / hidden_size)
+    )[None, :]
+    angles = positions * frequencies
+    embedding = torch.zeros(num_frames, hidden_size, device=device, dtype=torch.float32)
+    embedding[:, 0::2] = torch.sin(angles)
+    embedding[:, 1::2] = torch.cos(angles) - 1.0
+    return embedding.to(dtype=dtype)
+
+
+def causal_temporal_mask(frame_mask: Tensor, *, dtype: torch.dtype, num_patches: int) -> Tensor:
+    """Build an additive causal and key-padding mask for temporal attention."""
+    if frame_mask.ndim != 2:
+        raise ValueError(f"frame_mask must have shape (batch, frames), got {tuple(frame_mask.shape)}")
+    batch_size, num_frames = frame_mask.shape
+    allowed = torch.ones(num_frames, num_frames, dtype=torch.bool, device=frame_mask.device).tril()
+    allowed = allowed[None] & frame_mask[:, None, :].bool()
+    # Keep padded query rows numerically safe; valid queries still cannot see padded keys.
+    allowed |= torch.eye(num_frames, dtype=torch.bool, device=frame_mask.device)[None]
+    mask = torch.zeros(batch_size, 1, num_frames, num_frames, dtype=dtype, device=frame_mask.device)
+    mask.masked_fill_(~allowed[:, None], torch.finfo(dtype).min)
+    return mask.repeat_interleave(num_patches, dim=0)
+
+
+def encode_video_with_mem(
+    vision_model,
+    pixel_values: Tensor,
+    frame_mask: Tensor,
+    *,
+    temporal_attention_every: int,
+) -> Tensor:
+    """Encode ``(B,T,C,H,W)`` using MEM space-time separable attention.
+
+    The pretrained SigLIP projections are reused for causal temporal attention
+    between matching patches every Nth layer. Only current-frame tokens leave
+    the vision tower, so the downstream VLM prefix length does not grow.
+    """
+    if pixel_values.ndim != 5:
+        raise ValueError(f"pixel_values must have shape (B,T,C,H,W), got {tuple(pixel_values.shape)}")
+    if temporal_attention_every < 1:
+        raise ValueError("temporal_attention_every must be at least 1")
+
+    batch_size, num_frames, channels, height, width = pixel_values.shape
+    if frame_mask.shape != (batch_size, num_frames):
+        raise ValueError(
+            f"frame_mask must have shape {(batch_size, num_frames)}, got {tuple(frame_mask.shape)}"
+        )
+    if any(not hasattr(vision_model, name) for name in ("embeddings", "encoder", "post_layernorm")):
+        raise TypeError("MEM visual memory requires a SigLIP-compatible vision transformer")
+
+    flat_pixels = pixel_values.reshape(batch_size * num_frames, channels, height, width)
+    hidden_states = vision_model.embeddings(flat_pixels)
+    num_patches, hidden_size = hidden_states.shape[1:]
+    hidden_states = hidden_states.reshape(batch_size, num_frames, num_patches, hidden_size)
+    temporal_positions = temporal_sinusoidal_embedding(
+        num_frames, hidden_size, device=hidden_states.device, dtype=hidden_states.dtype
+    )[None, :, None]
+    temporal_mask = causal_temporal_mask(frame_mask, dtype=hidden_states.dtype, num_patches=num_patches)
+
+    for layer_index, layer in enumerate(vision_model.encoder.layers):
+        spatial_input = hidden_states.reshape(batch_size * num_frames, num_patches, hidden_size)
+        if num_frames == 1 or (layer_index + 1) % temporal_attention_every:
+            hidden_states = layer(spatial_input, attention_mask=None).reshape(
+                batch_size, num_frames, num_patches, hidden_size
+            )
+            continue
+
+        residual = hidden_states
+        spatial_norm = layer.layer_norm1(spatial_input)
+        spatial_output, _ = layer.self_attn(hidden_states=spatial_norm, attention_mask=None)
+        spatial_output = spatial_output.reshape(batch_size, num_frames, num_patches, hidden_size)
+
+        temporal_input = (hidden_states + temporal_positions).permute(0, 2, 1, 3)
+        temporal_input = temporal_input.reshape(batch_size * num_patches, num_frames, hidden_size)
+        temporal_norm = layer.layer_norm1(temporal_input)
+        temporal_output, _ = layer.self_attn(hidden_states=temporal_norm, attention_mask=temporal_mask)
+        temporal_output = temporal_output.reshape(batch_size, num_patches, num_frames, hidden_size)
+        temporal_output = temporal_output.permute(0, 2, 1, 3)
+
+        hidden_states = residual + spatial_output + temporal_output
+        hidden_states = hidden_states + layer.mlp(layer.layer_norm2(hidden_states))
+
+    return vision_model.post_layernorm(hidden_states[:, -1])

--- a/src/lerobot/policies/pi05/memory.py
+++ b/src/lerobot/policies/pi05/memory.py
@@ -208,6 +208,11 @@ def encode_video_with_mem(
         raise TypeError("MEM visual memory requires a SigLIP encoder exposing a layers collection")
 
     layers = vision_model.encoder.layers
+    if temporal_attention_every > len(layers):
+        raise ValueError(
+            f"temporal_attention_every ({temporal_attention_every}) must not exceed the number of "
+            f"SigLIP encoder layers ({len(layers)})"
+        )
     temporal_layers = [i for i in range(len(layers)) if (i + 1) % temporal_attention_every == 0]
     last_temporal_index = temporal_layers[-1] if (temporal_layers and num_frames > 1) else -1
 

--- a/src/lerobot/policies/pi05/memory.py
+++ b/src/lerobot/policies/pi05/memory.py
@@ -14,10 +14,36 @@ import torch
 from torch import Tensor
 
 
+def _hidden_tensor(output, *, source: str) -> Tensor:
+    """Normalize supported Transformers layer outputs and fail clearly on API drift."""
+    if isinstance(output, Tensor):
+        return output
+    if isinstance(output, tuple) and output and isinstance(output[0], Tensor):
+        return output[0]
+    raise TypeError(
+        f"{source} must return a Tensor or a tuple whose first item is a Tensor, got {type(output).__name__}"
+    )
+
+
+def _validate_siglip_layer(layer, *, layer_index: int) -> None:
+    """Validate the private SigLIP encoder-layer contract used by MEM."""
+    required = ("layer_norm1", "self_attn", "layer_norm2", "mlp")
+    missing = [name for name in required if not hasattr(layer, name)]
+    if missing:
+        raise TypeError(
+            "MEM visual memory requires SigLIP encoder layers exposing "
+            f"{required}; layer {layer_index} is missing {tuple(missing)}"
+        )
+
+
 def sample_observation_history(
     history: list[Tensor], *, num_frames: int, stride: int, steps_seen: int
 ) -> tuple[Tensor, Tensor]:
-    """Subsample an inference queue and mark repeated pre-episode padding."""
+    """Subsample a homogeneous-batch inference queue and mark pre-episode padding.
+
+    ``steps_seen`` applies to every batch row. Pi05 clears the queue at each
+    batched rollout boundary; independently resetting vector rows is unsupported.
+    """
     sampled = history[::stride][-num_frames:]
     if len(sampled) != num_frames:
         raise ValueError(f"observation history has {len(sampled)} samples, expected {num_frames}")
@@ -72,6 +98,10 @@ def encode_video_with_mem(
     The pretrained SigLIP projections are reused for causal temporal attention
     between matching patches every Nth layer. Only current-frame tokens leave
     the vision tower, so the downstream VLM prefix length does not grow.
+
+    This implementation intentionally relies on the Transformers SigLIP encoder
+    layer contract validated below. It forces eager attention because the MEM
+    temporal path uses an arbitrary 4-D additive mask unsupported by FlashAttention 2.
     """
     if pixel_values.ndim != 5:
         raise ValueError(f"pixel_values must have shape (B,T,C,H,W), got {tuple(pixel_values.shape)}")
@@ -85,6 +115,13 @@ def encode_video_with_mem(
         )
     if any(not hasattr(vision_model, name) for name in ("embeddings", "encoder", "post_layernorm")):
         raise TypeError("MEM visual memory requires a SigLIP-compatible vision transformer")
+    if not hasattr(vision_model.encoder, "layers"):
+        raise TypeError("MEM visual memory requires a SigLIP encoder exposing a layers collection")
+    if not hasattr(vision_model, "config"):
+        raise TypeError("MEM visual memory requires a SigLIP vision transformer with a config")
+
+    # SigLIP attention dispatch reads this config dynamically on every forward.
+    vision_model.config._attn_implementation = "eager"  # noqa: SLF001
 
     flat_pixels = pixel_values.reshape(batch_size * num_frames, channels, height, width)
     hidden_states = vision_model.embeddings(flat_pixels)
@@ -96,22 +133,31 @@ def encode_video_with_mem(
     temporal_mask = causal_temporal_mask(frame_mask, dtype=hidden_states.dtype, num_patches=num_patches)
 
     for layer_index, layer in enumerate(vision_model.encoder.layers):
+        _validate_siglip_layer(layer, layer_index=layer_index)
         spatial_input = hidden_states.reshape(batch_size * num_frames, num_patches, hidden_size)
         if num_frames == 1 or (layer_index + 1) % temporal_attention_every:
-            hidden_states = layer(spatial_input, attention_mask=None).reshape(
-                batch_size, num_frames, num_patches, hidden_size
+            layer_output = _hidden_tensor(
+                layer(spatial_input, attention_mask=None),
+                source=f"SigLIP encoder layer {layer_index}",
             )
+            hidden_states = layer_output.reshape(batch_size, num_frames, num_patches, hidden_size)
             continue
 
         residual = hidden_states
         spatial_norm = layer.layer_norm1(spatial_input)
-        spatial_output, _ = layer.self_attn(hidden_states=spatial_norm, attention_mask=None)
+        spatial_output = _hidden_tensor(
+            layer.self_attn(hidden_states=spatial_norm, attention_mask=None),
+            source=f"SigLIP self-attention layer {layer_index}",
+        )
         spatial_output = spatial_output.reshape(batch_size, num_frames, num_patches, hidden_size)
 
         temporal_input = (hidden_states + temporal_positions).permute(0, 2, 1, 3)
         temporal_input = temporal_input.reshape(batch_size * num_patches, num_frames, hidden_size)
         temporal_norm = layer.layer_norm1(temporal_input)
-        temporal_output, _ = layer.self_attn(hidden_states=temporal_norm, attention_mask=temporal_mask)
+        temporal_output = _hidden_tensor(
+            layer.self_attn(hidden_states=temporal_norm, attention_mask=temporal_mask),
+            source=f"SigLIP temporal self-attention layer {layer_index}",
+        )
         temporal_output = temporal_output.reshape(batch_size, num_patches, num_frames, hidden_size)
         temporal_output = temporal_output.permute(0, 2, 1, 3)
 

--- a/src/lerobot/policies/pi05/memory.py
+++ b/src/lerobot/policies/pi05/memory.py
@@ -5,13 +5,37 @@
 # You may obtain a copy of the License at
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """Short-horizon visual and proprioceptive memory from MEM (arXiv:2603.03596)."""
 
 import math
 
 import torch
+import torch.nn.functional as F  # noqa: N812
 from torch import Tensor
+
+# Attributes MEM reads off a `SiglipEncoderLayer` and its `SiglipAttention`. MEM
+# re-implements the attention sub-block to compose the spatial and temporal
+# attention weights (MEM appendix C, eq. 3), so it depends on these internals
+# rather than on `SiglipAttention.forward`. Validated per layer so a transformers
+# bump fails loudly instead of silently changing the architecture.
+_REQUIRED_LAYER_ATTRS = ("layer_norm1", "self_attn", "layer_norm2", "mlp")
+_REQUIRED_ATTENTION_ATTRS = (
+    "q_proj",
+    "k_proj",
+    "v_proj",
+    "out_proj",
+    "num_heads",
+    "head_dim",
+    "scale",
+    "dropout",
+)
 
 
 def _hidden_tensor(output, *, source: str) -> Tensor:
@@ -27,12 +51,17 @@ def _hidden_tensor(output, *, source: str) -> Tensor:
 
 def _validate_siglip_layer(layer, *, layer_index: int) -> None:
     """Validate the private SigLIP encoder-layer contract used by MEM."""
-    required = ("layer_norm1", "self_attn", "layer_norm2", "mlp")
-    missing = [name for name in required if not hasattr(layer, name)]
+    missing = [name for name in _REQUIRED_LAYER_ATTRS if not hasattr(layer, name)]
     if missing:
         raise TypeError(
             "MEM visual memory requires SigLIP encoder layers exposing "
-            f"{required}; layer {layer_index} is missing {tuple(missing)}"
+            f"{_REQUIRED_LAYER_ATTRS}; layer {layer_index} is missing {tuple(missing)}"
+        )
+    missing = [name for name in _REQUIRED_ATTENTION_ATTRS if not hasattr(layer.self_attn, name)]
+    if missing:
+        raise TypeError(
+            "MEM visual memory requires SigLIP self-attention exposing "
+            f"{_REQUIRED_ATTENTION_ATTRS}; layer {layer_index} is missing {tuple(missing)}"
         )
 
 
@@ -41,14 +70,20 @@ def sample_observation_history(
 ) -> tuple[Tensor, Tensor]:
     """Subsample a homogeneous-batch inference queue and mark pre-episode padding.
 
+    Frames are addressed by age relative to ``history[-1]``, the newest observation,
+    so the current frame is always the last sampled frame regardless of queue length.
+
     ``steps_seen`` applies to every batch row. Pi05 clears the queue at each
     batched rollout boundary; independently resetting vector rows is unsupported.
     """
-    sampled = history[::stride][-num_frames:]
-    if len(sampled) != num_frames:
-        raise ValueError(f"observation history has {len(sampled)} samples, expected {num_frames}")
-    values = torch.stack(sampled, dim=1)
-    required_ages = range((num_frames - 1) * stride, -1, -stride)
+    # Descending ages, so the returned frames run oldest -> current.
+    required_ages = list(range((num_frames - 1) * stride, -1, -stride))
+    if len(history) <= required_ages[0]:
+        raise ValueError(
+            f"observation history holds {len(history)} frames, need at least "
+            f"{required_ages[0] + 1} to sample {num_frames} frames at stride {stride}"
+        )
+    values = torch.stack([history[-1 - age] for age in required_ages], dim=1)
     valid = torch.tensor([steps_seen > age for age in required_ages], dtype=torch.bool, device=values.device)
     padding_mask = (~valid)[None, :].expand(values.shape[0], -1)
     return values, padding_mask
@@ -86,6 +121,59 @@ def causal_temporal_mask(frame_mask: Tensor, *, dtype: torch.dtype, num_patches:
     return mask.repeat_interleave(num_patches, dim=0)
 
 
+def space_time_attention(attention, hidden_states: Tensor, temporal_mask: Tensor) -> Tensor:
+    """Apply MEM's composed space-time attention (appendix C, eq. 3) to ``(B,T,P,D)``.
+
+    ``hidden_states`` must already carry the temporal position embedding, so one set
+    of the ViT's pretrained q/k/v projections serves both stages — MEM adds no
+    learnable parameters to the vision tower.
+
+    Eq. 3 composes the two attention operators, ``alpha_spatial[alpha_temporal[z]]``,
+    and then "follow[s] the standard computation of a transformer layer". Composing
+    the weights rather than stacking two attention sub-blocks matters twice over:
+    ``out_proj`` is applied once, and a softmax over a single timestep is the
+    identity, so ``T == 1`` reduces to stock SigLIP spatial attention by
+    construction. Applying the composition is just spatial attention whose values
+    are the temporally mixed ones, which keeps both stages on SDPA — no attention
+    matrix is ever materialized.
+    """
+    batch_size, num_frames, num_patches, _ = hidden_states.shape
+    heads, head_dim = attention.num_heads, attention.head_dim
+    projected_shape = (batch_size, num_frames, num_patches, heads, head_dim)
+    queries = attention.q_proj(hidden_states).view(projected_shape)
+    keys = attention.k_proj(hidden_states).view(projected_shape)
+    values = attention.v_proj(hidden_states).view(projected_shape)
+    dropout = attention.dropout if attention.training else 0.0
+
+    def as_temporal(tensor: Tensor) -> Tensor:
+        # (B,T,P,h,d) -> (B*P,h,T,d): one sequence per patch, over frames.
+        return tensor.permute(0, 2, 3, 1, 4).reshape(batch_size * num_patches, heads, num_frames, head_dim)
+
+    def as_spatial(tensor: Tensor) -> Tensor:
+        # (B,T,P,h,d) -> (B*T,h,P,d): one sequence per frame, over patches.
+        return tensor.permute(0, 1, 3, 2, 4).reshape(batch_size * num_frames, heads, num_patches, head_dim)
+
+    temporal = F.scaled_dot_product_attention(
+        as_temporal(queries),
+        as_temporal(keys),
+        as_temporal(values),
+        attn_mask=temporal_mask,
+        dropout_p=dropout,
+        scale=attention.scale,
+    )
+    temporal = temporal.reshape(batch_size, num_patches, heads, num_frames, head_dim).permute(0, 3, 1, 2, 4)
+
+    attended = F.scaled_dot_product_attention(
+        as_spatial(queries),
+        as_spatial(keys),
+        as_spatial(temporal),
+        dropout_p=dropout,
+        scale=attention.scale,
+    )
+    attended = attended.reshape(batch_size, num_frames, heads, num_patches, head_dim).permute(0, 1, 3, 2, 4)
+    return attention.out_proj(attended.reshape(batch_size, num_frames, num_patches, heads * head_dim))
+
+
 def encode_video_with_mem(
     vision_model,
     pixel_values: Tensor,
@@ -95,13 +183,14 @@ def encode_video_with_mem(
 ) -> Tensor:
     """Encode ``(B,T,C,H,W)`` using MEM space-time separable attention.
 
-    The pretrained SigLIP projections are reused for causal temporal attention
-    between matching patches every Nth layer. Only current-frame tokens leave
-    the vision tower, so the downstream VLM prefix length does not grow.
+    Every Nth layer replaces its attention sub-block with the composed space-time
+    attention of :func:`space_time_attention`, reusing the pretrained SigLIP
+    projections. Past-frame tokens are dropped once the last such layer has run —
+    no cross-frame mixing can happen above it — so the remaining layers and the
+    downstream VLM prefix see exactly the single-frame token count.
 
-    This implementation intentionally relies on the Transformers SigLIP encoder
-    layer contract validated below. It forces eager attention because the MEM
-    temporal path uses an arbitrary 4-D additive mask unsupported by FlashAttention 2.
+    Temporal layers call SDPA directly and therefore ignore the vision tower's
+    configured attention implementation; the spatial-only layers still use it.
     """
     if pixel_values.ndim != 5:
         raise ValueError(f"pixel_values must have shape (B,T,C,H,W), got {tuple(pixel_values.shape)}")
@@ -117,11 +206,10 @@ def encode_video_with_mem(
         raise TypeError("MEM visual memory requires a SigLIP-compatible vision transformer")
     if not hasattr(vision_model.encoder, "layers"):
         raise TypeError("MEM visual memory requires a SigLIP encoder exposing a layers collection")
-    if not hasattr(vision_model, "config"):
-        raise TypeError("MEM visual memory requires a SigLIP vision transformer with a config")
 
-    # SigLIP attention dispatch reads this config dynamically on every forward.
-    vision_model.config._attn_implementation = "eager"  # noqa: SLF001
+    layers = vision_model.encoder.layers
+    temporal_layers = [i for i in range(len(layers)) if (i + 1) % temporal_attention_every == 0]
+    last_temporal_index = temporal_layers[-1] if (temporal_layers and num_frames > 1) else -1
 
     flat_pixels = pixel_values.reshape(batch_size * num_frames, channels, height, width)
     hidden_states = vision_model.embeddings(flat_pixels)
@@ -132,36 +220,26 @@ def encode_video_with_mem(
     )[None, :, None]
     temporal_mask = causal_temporal_mask(frame_mask, dtype=hidden_states.dtype, num_patches=num_patches)
 
-    for layer_index, layer in enumerate(vision_model.encoder.layers):
+    for layer_index, layer in enumerate(layers):
         _validate_siglip_layer(layer, layer_index=layer_index)
-        spatial_input = hidden_states.reshape(batch_size * num_frames, num_patches, hidden_size)
-        if num_frames == 1 or (layer_index + 1) % temporal_attention_every:
+        active_frames = hidden_states.shape[1]
+        if active_frames == 1 or (layer_index + 1) % temporal_attention_every:
+            flat_hidden = hidden_states.reshape(batch_size * active_frames, num_patches, hidden_size)
             layer_output = _hidden_tensor(
-                layer(spatial_input, attention_mask=None),
+                layer(flat_hidden, attention_mask=None),
                 source=f"SigLIP encoder layer {layer_index}",
             )
-            hidden_states = layer_output.reshape(batch_size, num_frames, num_patches, hidden_size)
+            hidden_states = layer_output.reshape(batch_size, active_frames, num_patches, hidden_size)
             continue
 
-        residual = hidden_states
-        spatial_norm = layer.layer_norm1(spatial_input)
-        spatial_output = _hidden_tensor(
-            layer.self_attn(hidden_states=spatial_norm, attention_mask=None),
-            source=f"SigLIP self-attention layer {layer_index}",
+        # eq. 1: both stages derive q/k/v from z + e(t). The residual stays the
+        # layer input so the position signal does not accumulate across layers.
+        attended = space_time_attention(
+            layer.self_attn, layer.layer_norm1(hidden_states + temporal_positions), temporal_mask
         )
-        spatial_output = spatial_output.reshape(batch_size, num_frames, num_patches, hidden_size)
-
-        temporal_input = (hidden_states + temporal_positions).permute(0, 2, 1, 3)
-        temporal_input = temporal_input.reshape(batch_size * num_patches, num_frames, hidden_size)
-        temporal_norm = layer.layer_norm1(temporal_input)
-        temporal_output = _hidden_tensor(
-            layer.self_attn(hidden_states=temporal_norm, attention_mask=temporal_mask),
-            source=f"SigLIP temporal self-attention layer {layer_index}",
-        )
-        temporal_output = temporal_output.reshape(batch_size, num_patches, num_frames, hidden_size)
-        temporal_output = temporal_output.permute(0, 2, 1, 3)
-
-        hidden_states = residual + spatial_output + temporal_output
+        hidden_states = hidden_states + attended
         hidden_states = hidden_states + layer.mlp(layer.layer_norm2(hidden_states))
+        if layer_index == last_temporal_index:
+            hidden_states = hidden_states[:, -1:]
 
     return vision_model.post_layernorm(hidden_states[:, -1])

--- a/src/lerobot/policies/pi05/modeling_pi05.py
+++ b/src/lerobot/policies/pi05/modeling_pi05.py
@@ -195,6 +195,7 @@ class PaliGemmaWithExpertModel(
         image_size: int = DEFAULT_IMAGE_SIZE,
         freeze_vision_encoder: bool = False,
         train_expert_only: bool = False,
+        use_visual_memory: bool = False,
     ):
         if use_adarms is None:
             use_adarms = [False, False]
@@ -221,6 +222,9 @@ class PaliGemmaWithExpertModel(
         vlm_config_hf.vision_config.projection_dim = 2048
         vlm_config_hf.vision_config.projector_hidden_act = "gelu_fast"
         vlm_config_hf.vision_config.dtype = "float32"
+        if use_visual_memory:
+            # MEM uses a 4-D additive temporal mask, which FlashAttention 2 does not support.
+            vlm_config_hf.vision_config._attn_implementation = "eager"  # noqa: SLF001
 
         action_expert_config_hf = CONFIG_MAPPING["gemma"](
             head_dim=action_expert_config.head_dim,
@@ -442,6 +446,7 @@ class PI05Pytorch(nn.Module):  # see openpi `PI0Pytorch`
             image_size=config.image_resolution[0],
             freeze_vision_encoder=config.freeze_vision_encoder,
             train_expert_only=config.train_expert_only,
+            use_visual_memory=config.use_visual_memory,
         )
 
         self.action_in_proj = nn.Linear(config.max_action_dim, action_expert_config.width)
@@ -1000,7 +1005,12 @@ class PI05Policy(PreTrainedPolicy):
         return self.parameters()
 
     def reset(self):
-        """Reset internal state - called when environment resets."""
+        """Reset internal state at the shared boundary of a batched rollout.
+
+        ``lerobot-eval`` calls this before every rollout and before resetting the
+        vector environment. MEM inference queues therefore assume all batch rows
+        share episode boundaries; independently autoresetting rows is unsupported.
+        """
         self._action_queue = deque(maxlen=self.config.n_action_steps)
         self._queues = {
             ACTION: deque(maxlen=self.config.n_action_steps),
@@ -1014,6 +1024,7 @@ class PI05Policy(PreTrainedPolicy):
                 memory_keys.append(OBS_STATE)
             self._memory_queues = {key: deque(maxlen=history_length) for key in memory_keys}
             self._memory_steps_seen = 0
+            self._memory_batch_size = None
 
     def init_rtc_processor(self):
         """Initialize RTC processor if RTC is enabled in config."""
@@ -1124,7 +1135,7 @@ class PI05Policy(PreTrainedPolicy):
         return states, state_masks
 
     def _stack_inference_memory(self, batch: dict[str, Tensor]) -> dict[str, Tensor]:
-        """Record one environment observation and attach sampled MEM histories."""
+        """Record one homogeneous-batch observation and attach MEM histories."""
         if not (self.config.use_visual_memory or self.config.use_proprioceptive_memory):
             return batch
         result = dict(batch)
@@ -1132,10 +1143,18 @@ class PI05Policy(PreTrainedPolicy):
             if key not in batch:
                 continue
             value = batch[key]
+            batch_size = value.shape[0]
+            if self._memory_batch_size is None:
+                self._memory_batch_size = batch_size
+            elif batch_size != self._memory_batch_size:
+                raise ValueError(
+                    "MEM inference batch size changed without policy.reset(); "
+                    f"expected {self._memory_batch_size}, got {batch_size}"
+                )
             if not queue:
-                queue.extend([value] * queue.maxlen)
+                queue.extend(value.clone() for _ in range(queue.maxlen))
             else:
-                queue.append(value)
+                queue.append(value.clone())
             result[key], result[f"{key}_is_pad"] = sample_observation_history(
                 list(queue),
                 num_frames=self.config.memory_frames,

--- a/src/lerobot/policies/pi05/modeling_pi05.py
+++ b/src/lerobot/policies/pi05/modeling_pi05.py
@@ -195,7 +195,6 @@ class PaliGemmaWithExpertModel(
         image_size: int = DEFAULT_IMAGE_SIZE,
         freeze_vision_encoder: bool = False,
         train_expert_only: bool = False,
-        use_visual_memory: bool = False,
     ):
         if use_adarms is None:
             use_adarms = [False, False]
@@ -222,9 +221,6 @@ class PaliGemmaWithExpertModel(
         vlm_config_hf.vision_config.projection_dim = 2048
         vlm_config_hf.vision_config.projector_hidden_act = "gelu_fast"
         vlm_config_hf.vision_config.dtype = "float32"
-        if use_visual_memory:
-            # MEM uses a 4-D additive temporal mask, which FlashAttention 2 does not support.
-            vlm_config_hf.vision_config._attn_implementation = "eager"  # noqa: SLF001
 
         action_expert_config_hf = CONFIG_MAPPING["gemma"](
             head_dim=action_expert_config.head_dim,
@@ -446,7 +442,6 @@ class PI05Pytorch(nn.Module):  # see openpi `PI0Pytorch`
             image_size=config.image_resolution[0],
             freeze_vision_encoder=config.freeze_vision_encoder,
             train_expert_only=config.train_expert_only,
-            use_visual_memory=config.use_visual_memory,
         )
 
         self.action_in_proj = nn.Linear(config.max_action_dim, action_expert_config.width)
@@ -1016,6 +1011,11 @@ class PI05Policy(PreTrainedPolicy):
             ACTION: deque(maxlen=self.config.n_action_steps),
         }
         if self.config.use_visual_memory or self.config.use_proprioceptive_memory:
+            # The sampled ages are relative to the current step, so every step shifts
+            # all of them: a dense ring buffer spanning the whole horizon is the
+            # smallest structure that keeps inference aligned with the training
+            # `delta_indices`. Storing only `memory_frames` observations would pin the
+            # history to an absolute grid and drift up to `memory_stride` out of phase.
             history_length = (self.config.memory_frames - 1) * self.config.memory_stride + 1
             memory_keys = []
             if self.config.use_visual_memory:
@@ -1152,7 +1152,9 @@ class PI05Policy(PreTrainedPolicy):
                     f"expected {self._memory_batch_size}, got {batch_size}"
                 )
             if not queue:
-                queue.extend(value.clone() for _ in range(queue.maxlen))
+                # Queue entries are snapshots that are never mutated in place, so the
+                # pre-episode fill can share one clone instead of `maxlen` copies.
+                queue.extend([value.clone()] * queue.maxlen)
             else:
                 queue.append(value.clone())
             result[key], result[f"{key}_is_pad"] = sample_observation_history(
@@ -1276,7 +1278,12 @@ class PI05Policy(PreTrainedPolicy):
             "state_proj|action_in_proj|action_out_proj|action_time_mlp_in|action_time_mlp_out"
         )
         target_modules = rf"(.*\.gemma_expert\..*\.self_attn\.(q|v)_proj|model\.({common_projections}))"
+        # MEM's proprioceptive projection does not exist in `lerobot/pi05_base`, so a
+        # LoRA adapter cannot start from pretrained weights for it. Train and save it
+        # in full, otherwise it stays frozen at its random init and is absent from
+        # adapter checkpoints.
+        modules_to_save = ["model.proprio_history_proj"] if self.config.use_proprioceptive_memory else []
         return {
             "target_modules": target_modules,
-            "modules_to_save": [],
+            "modules_to_save": modules_to_save,
         }

--- a/src/lerobot/policies/pi05/modeling_pi05.py
+++ b/src/lerobot/policies/pi05/modeling_pi05.py
@@ -49,6 +49,7 @@ from lerobot.utils.constants import (
     ACTION,
     OBS_LANGUAGE_ATTENTION_MASK,
     OBS_LANGUAGE_TOKENS,
+    OBS_STATE,
 )
 
 from ..common.flow_matching import euler_integrate, sample_noise, sample_time_beta
@@ -63,6 +64,7 @@ from ..common.vla_utils import (
 from ..pretrained import PreTrainedPolicy, T
 from ..rtc.modeling_rtc import RTCProcessor
 from .configuration_pi05 import DEFAULT_IMAGE_SIZE, PI05Config
+from .memory import encode_video_with_mem, sample_observation_history
 
 
 class ActionSelectKwargs(TypedDict, total=False):
@@ -281,13 +283,31 @@ class PaliGemmaWithExpertModel(
         if self.train_expert_only:
             self.paligemma.eval()
 
-    def embed_image(self, image: torch.Tensor):
+    def embed_image(
+        self,
+        image: torch.Tensor,
+        *,
+        frame_mask: torch.Tensor | None = None,
+        temporal_attention_every: int = 4,
+    ):
         # Vision tower and multi_modal_projector are kept in float32 (params_to_keep_float32).
         out_dtype = image.dtype
         if image.dtype != torch.float32:
             image = image.to(torch.float32)
-        image_outputs = self.paligemma.model.get_image_features(image)
-        features = image_outputs.pooler_output
+        if image.ndim == 5:
+            if frame_mask is None:
+                frame_mask = torch.ones(image.shape[:2], dtype=torch.bool, device=image.device)
+            vision_transformer = self.paligemma.model.vision_tower.vision_model
+            features = encode_video_with_mem(
+                vision_transformer,
+                image,
+                frame_mask,
+                temporal_attention_every=temporal_attention_every,
+            )
+            features = self.paligemma.model.multi_modal_projector(features)
+        else:
+            image_outputs = self.paligemma.model.get_image_features(image)
+            features = image_outputs.pooler_output
         if features.dtype != out_dtype:
             features = features.to(out_dtype)
         return features
@@ -429,6 +449,11 @@ class PI05Pytorch(nn.Module):  # see openpi `PI0Pytorch`
 
         self.time_mlp_in = nn.Linear(action_expert_config.width, action_expert_config.width)
         self.time_mlp_out = nn.Linear(action_expert_config.width, action_expert_config.width)
+        self.proprio_history_proj = (
+            nn.Linear(config.max_state_dim, paligemma_config.width)
+            if config.use_proprioceptive_memory
+            else None
+        )
 
         # Initialize gradient checkpointing flag
         self.gradient_checkpointing_enabled = False
@@ -481,9 +506,9 @@ class PI05Pytorch(nn.Module):  # see openpi `PI0Pytorch`
         )
 
     def embed_prefix(
-        self, images, img_masks, tokens, masks
+        self, images, img_masks, tokens, masks, states=None, state_masks=None
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        """Embed images with SigLIP and language tokens with embedding layer."""
+        """Embed images, optional MEM state history, and language tokens."""
         embs = []
         pad_masks = []
         att_masks = []
@@ -491,15 +516,31 @@ class PI05Pytorch(nn.Module):  # see openpi `PI0Pytorch`
         # Process images
         for img, img_mask in zip(images, img_masks, strict=True):
 
-            def image_embed_func(img):
+            def image_embed_func(img, img_mask):
+                if img.ndim == 5:
+                    return self.paligemma_with_expert.embed_image(
+                        img,
+                        frame_mask=img_mask,
+                        temporal_attention_every=self.config.memory_temporal_attention_every,
+                    )
                 return self.paligemma_with_expert.embed_image(img)
 
-            img_emb = self._apply_checkpoint(image_embed_func, img)
+            img_emb = self._apply_checkpoint(image_embed_func, img, img_mask)
             bsize, num_img_embs = img_emb.shape[:2]
 
             embs.append(img_emb)
-            pad_masks.append(img_mask[:, None].expand(bsize, num_img_embs))
+            current_img_mask = img_mask[:, -1] if img_mask.ndim == 2 else img_mask
+            pad_masks.append(current_img_mask[:, None].expand(bsize, num_img_embs))
             att_masks += [0] * num_img_embs
+
+        proprio_history_proj = getattr(self, "proprio_history_proj", None)
+        if proprio_history_proj is not None:
+            if states is None or state_masks is None:
+                raise ValueError("proprioceptive memory requires states and state_masks")
+            state_embs = self._apply_checkpoint(proprio_history_proj, states)
+            embs.append(state_embs)
+            pad_masks.append(state_masks)
+            att_masks += [0] * state_embs.shape[1]
 
         # Process language tokens
         def lang_embed_func(tokens):
@@ -561,13 +602,26 @@ class PI05Pytorch(nn.Module):  # see openpi `PI0Pytorch`
 
         return action_emb, pad_masks, att_masks, adarms_cond
 
-    def forward(self, images, img_masks, tokens, masks, actions, noise, time) -> Tensor:
+    def forward(
+        self,
+        images,
+        img_masks,
+        tokens,
+        masks,
+        actions,
+        noise,
+        time,
+        states=None,
+        state_masks=None,
+    ) -> Tensor:
         """Do a full training forward pass and compute the loss."""
         time_expanded = time[:, None, None]
         x_t = time_expanded * noise + (1 - time_expanded) * actions
         u_t = noise - actions
 
-        prefix_embs, prefix_pad_masks, prefix_att_masks = self.embed_prefix(images, img_masks, tokens, masks)
+        prefix_embs, prefix_pad_masks, prefix_att_masks = self.embed_prefix(
+            images, img_masks, tokens, masks, states, state_masks
+        )
         suffix_embs, suffix_pad_masks, suffix_att_masks, adarms_cond = self.embed_suffix(x_t, time)
 
         if (
@@ -617,6 +671,8 @@ class PI05Pytorch(nn.Module):  # see openpi `PI0Pytorch`
         img_masks,
         tokens,
         masks,
+        states=None,
+        state_masks=None,
         noise=None,
         num_steps=None,
         **kwargs: Unpack[ActionSelectKwargs],
@@ -637,7 +693,9 @@ class PI05Pytorch(nn.Module):  # see openpi `PI0Pytorch`
             )  # Use config max_action_dim for internal processing
             noise = self.sample_noise(actions_shape, device)
 
-        prefix_embs, prefix_pad_masks, prefix_att_masks = self.embed_prefix(images, img_masks, tokens, masks)
+        prefix_embs, prefix_pad_masks, prefix_att_masks = self.embed_prefix(
+            images, img_masks, tokens, masks, states, state_masks
+        )
         prefix_att_2d_masks = make_att_2d_masks(prefix_pad_masks, prefix_att_masks)
         prefix_position_ids = torch.cumsum(prefix_pad_masks, dim=1) - 1
 
@@ -830,6 +888,8 @@ class PI05Policy(PreTrainedPolicy):
             if remap_count > 0:
                 print(f"Remapped {remap_count} state dict keys")
 
+            remapped_state_dict = model._prepare_pretrained_state_dict(remapped_state_dict)
+
             # Load the remapped state dict into the model
             missing_keys, unexpected_keys = model.load_state_dict(remapped_state_dict, strict=strict)
 
@@ -860,6 +920,19 @@ class PI05Policy(PreTrainedPolicy):
             print(f"Warning: Could not load state dict: {e}")
 
         return model
+
+    def _prepare_pretrained_state_dict(self, state_dict: dict[str, Tensor]) -> dict[str, Tensor]:
+        # MEM's continuous proprioceptive projection is new relative to
+        # lerobot/pi05_base. Preserve its fresh initialization on first load,
+        # while loading learned values from subsequent MEM checkpoints.
+        if getattr(self.config, "use_proprioceptive_memory", False):
+            current = self.state_dict()
+            for key in (
+                "model.proprio_history_proj.weight",
+                "model.proprio_history_proj.bias",
+            ):
+                state_dict.setdefault(key, current[key])
+        return state_dict
 
     def _fix_pytorch_state_dict_keys(
         self, state_dict, model_config
@@ -932,6 +1005,15 @@ class PI05Policy(PreTrainedPolicy):
         self._queues = {
             ACTION: deque(maxlen=self.config.n_action_steps),
         }
+        if self.config.use_visual_memory or self.config.use_proprioceptive_memory:
+            history_length = (self.config.memory_frames - 1) * self.config.memory_stride + 1
+            memory_keys = []
+            if self.config.use_visual_memory:
+                memory_keys.extend(self.config.image_features)
+            if self.config.use_proprioceptive_memory:
+                memory_keys.append(OBS_STATE)
+            self._memory_queues = {key: deque(maxlen=history_length) for key in memory_keys}
+            self._memory_steps_seen = 0
 
     def init_rtc_processor(self):
         """Initialize RTC processor if RTC is enabled in config."""
@@ -982,28 +1064,40 @@ class PI05Policy(PreTrainedPolicy):
             if img.dtype != torch.float32:
                 img = img.to(torch.float32)
 
-            # from openpi preprocess_observation_pytorch: Handle both [B, C, H, W] and [B, H, W, C] formats
-            is_channels_first = img.shape[1] == 3  # Check if channels are in dimension 1
+            # Handle [B,C,H,W], [B,H,W,C], and their [B,T,...] memory variants.
+            is_video = img.ndim == 5
+            channel_dim = 2 if is_video else 1
+            is_channels_first = img.shape[channel_dim] == 3
 
             if is_channels_first:
-                # Convert [B, C, H, W] to [B, H, W, C] for processing
-                img = img.permute(0, 2, 3, 1)
+                img = img.permute(0, 1, 3, 4, 2) if is_video else img.permute(0, 2, 3, 1)
 
             # from openpi preprocess_observation_pytorch: Resize with padding if needed
-            if img.shape[1:3] != self.config.image_resolution:
-                img = resize_with_pad_torch(img, *self.config.image_resolution)
+            spatial_shape = img.shape[2:4] if is_video else img.shape[1:3]
+            if spatial_shape != self.config.image_resolution:
+                if is_video:
+                    batch_size, num_frames = img.shape[:2]
+                    img = resize_with_pad_torch(img.flatten(0, 1), *self.config.image_resolution).unflatten(
+                        0, (batch_size, num_frames)
+                    )
+                else:
+                    img = resize_with_pad_torch(img, *self.config.image_resolution)
 
             # Normalize from [0,1] to [-1,1] as expected by siglip
             img = img * 2.0 - 1.0
 
             # from openpi preprocess_observation_pytorch: Convert back to [B, C, H, W] format if it was originally channels-first
             if is_channels_first:
-                img = img.permute(0, 3, 1, 2)  # [B, H, W, C] -> [B, C, H, W]
+                img = img.permute(0, 1, 4, 2, 3) if is_video else img.permute(0, 3, 1, 2)
 
             images.append(img)
-            # Create mask (all ones for real images)
             bsize = img.shape[0]
-            mask = torch.ones(bsize, dtype=torch.bool, device=device)
+            pad_key = f"{key}_is_pad"
+            if is_video and pad_key in batch:
+                mask = ~batch[pad_key].bool()
+            else:
+                mask_shape = img.shape[:2] if is_video else (bsize,)
+                mask = torch.ones(mask_shape, dtype=torch.bool, device=device)
             img_masks.append(mask)
 
         # Create image features not present in the batch as fully 0 padded images
@@ -1014,6 +1108,42 @@ class PI05Policy(PreTrainedPolicy):
             img_masks.append(mask)
 
         return images, img_masks
+
+    def _prepare_memory_states(self, batch: dict[str, Tensor]) -> tuple[Tensor | None, Tensor | None]:
+        if not self.config.use_proprioceptive_memory:
+            return None, None
+        states = pad_vector(batch[OBS_STATE], self.config.max_state_dim)
+        if states.ndim == 2:
+            states = states[:, None]
+        pad_key = f"{OBS_STATE}_is_pad"
+        state_masks = (
+            ~batch[pad_key].bool()
+            if pad_key in batch
+            else torch.ones(states.shape[:2], dtype=torch.bool, device=states.device)
+        )
+        return states, state_masks
+
+    def _stack_inference_memory(self, batch: dict[str, Tensor]) -> dict[str, Tensor]:
+        """Record one environment observation and attach sampled MEM histories."""
+        if not (self.config.use_visual_memory or self.config.use_proprioceptive_memory):
+            return batch
+        result = dict(batch)
+        for key, queue in self._memory_queues.items():
+            if key not in batch:
+                continue
+            value = batch[key]
+            if not queue:
+                queue.extend([value] * queue.maxlen)
+            else:
+                queue.append(value)
+            result[key], result[f"{key}_is_pad"] = sample_observation_history(
+                list(queue),
+                num_frames=self.config.memory_frames,
+                stride=self.config.memory_stride,
+                steps_seen=self._memory_steps_seen + 1,
+            )
+        self._memory_steps_seen += 1
+        return result
 
     def prepare_action(self, batch):
         """Pad action"""
@@ -1028,6 +1158,8 @@ class PI05Policy(PreTrainedPolicy):
         )
 
         self.eval()
+        if self.config.use_visual_memory or self.config.use_proprioceptive_memory:
+            batch = self._stack_inference_memory(batch)
 
         # Action queue logic for n_action_steps > 1
         if len(self._action_queue) == 0:
@@ -1042,12 +1174,25 @@ class PI05Policy(PreTrainedPolicy):
         """Predict a chunk of actions given environment observations."""
         self.eval()
 
+        # Direct chunk callers provide single observations. ``select_action``
+        # already supplies a temporal batch, so avoid recording it twice.
+        has_temporal_input = any(
+            key in batch and batch[key].ndim == 5 for key in self.config.image_features
+        ) or (OBS_STATE in batch and batch[OBS_STATE].ndim == 3)
+        if (
+            self.config.use_visual_memory or self.config.use_proprioceptive_memory
+        ) and not has_temporal_input:
+            batch = self._stack_inference_memory(batch)
+
         # Prepare inputs
         images, img_masks = self._preprocess_images(batch)
+        states, state_masks = self._prepare_memory_states(batch)
         tokens, masks = batch[f"{OBS_LANGUAGE_TOKENS}"], batch[f"{OBS_LANGUAGE_ATTENTION_MASK}"]
 
         # Sample actions using the model (pass through RTC kwargs, no separate state needed for PI05)
-        actions = self.model.sample_actions(images, img_masks, tokens, masks, **kwargs)
+        actions = self.model.sample_actions(
+            images, img_masks, tokens, masks, states=states, state_masks=state_masks, **kwargs
+        )
 
         # Unpad actions to actual action dimension
         original_action_dim = self.config.output_features[ACTION].shape[0]
@@ -1066,6 +1211,7 @@ class PI05Policy(PreTrainedPolicy):
         """
         # Prepare inputs
         images, img_masks = self._preprocess_images(batch)
+        states, state_masks = self._prepare_memory_states(batch)
         tokens, masks = batch[f"{OBS_LANGUAGE_TOKENS}"], batch[f"{OBS_LANGUAGE_ATTENTION_MASK}"]
 
         actions = self.prepare_action(batch)
@@ -1074,7 +1220,17 @@ class PI05Policy(PreTrainedPolicy):
         time = self.model.sample_time(actions.shape[0], actions.device)
 
         # Compute loss (no separate state needed for PI05)
-        losses = self.model.forward(images, img_masks, tokens, masks, actions, noise, time)
+        losses = self.model.forward(
+            images,
+            img_masks,
+            tokens,
+            masks,
+            actions,
+            noise,
+            time,
+            states=states,
+            state_masks=state_masks,
+        )
 
         # Truncate losses to actual action dimensions
         original_action_dim = self.config.output_features[ACTION].shape[0]

--- a/src/lerobot/policies/pi05/processor_pi05.py
+++ b/src/lerobot/policies/pi05/processor_pi05.py
@@ -64,7 +64,10 @@ class Pi05PrepareStateTokenizerProcessorStep(ProcessorStep):
 
         # State should already be normalized to [-1, 1] by the NormalizerProcessorStep that runs before this step
         # Discretize into 256 bins (see openpi `PaligemmaTokenizer.tokenize()`)
-        state_np = state.cpu().numpy()
+        # MEM retains the full normalized state history for continuous tokens,
+        # while the stock PI0.5 prompt continues to describe the current state.
+        prompt_state = state[:, -1] if state.ndim == 3 else state
+        state_np = prompt_state.cpu().numpy()
         discretized_states = np.digitize(state_np, bins=np.linspace(-1, 1, 256 + 1)[:-1]) - 1
 
         full_prompts = []

--- a/src/lerobot/policies/pi05/processor_pi05.py
+++ b/src/lerobot/policies/pi05/processor_pi05.py
@@ -48,6 +48,10 @@ class Pi05PrepareStateTokenizerProcessorStep(ProcessorStep):
 
     max_state_dim: int = 32
     task_key: str = "task"
+    # MEM section III-D represents proprioception with a linear projection into the
+    # backbone instead of discretized prompt tokens, so the state is carried once.
+    # Set from `PI05Config.use_proprioceptive_memory`; stock PI0.5 keeps it in the prompt.
+    include_state_in_prompt: bool = True
 
     def __call__(self, transition: EnvTransition) -> EnvTransition:
         transition = transition.copy()
@@ -62,19 +66,22 @@ class Pi05PrepareStateTokenizerProcessorStep(ProcessorStep):
         # TODO: check if this necessary
         state = deepcopy(state)
 
-        # State should already be normalized to [-1, 1] by the NormalizerProcessorStep that runs before this step
-        # Discretize into 256 bins (see openpi `PaligemmaTokenizer.tokenize()`)
-        # MEM retains the full normalized state history for continuous tokens,
-        # while the stock PI0.5 prompt continues to describe the current state.
-        prompt_state = state[:, -1] if state.ndim == 3 else state
-        state_np = prompt_state.cpu().numpy()
-        discretized_states = np.digitize(state_np, bins=np.linspace(-1, 1, 256 + 1)[:-1]) - 1
+        discretized_states = None
+        if self.include_state_in_prompt:
+            # State should already be normalized to [-1, 1] by the NormalizerProcessorStep that runs before this step
+            # Discretize into 256 bins (see openpi `PaligemmaTokenizer.tokenize()`)
+            prompt_state = state[:, -1] if state.ndim == 3 else state
+            state_np = prompt_state.cpu().numpy()
+            discretized_states = np.digitize(state_np, bins=np.linspace(-1, 1, 256 + 1)[:-1]) - 1
 
         full_prompts = []
         for i, task in enumerate(tasks):
             cleaned_text = task.strip().replace("_", " ").replace("\n", " ")
-            state_str = " ".join(map(str, discretized_states[i]))
-            full_prompt = f"Task: {cleaned_text}, State: {state_str};\nAction: "
+            if discretized_states is None:
+                full_prompt = f"Task: {cleaned_text};\nAction: "
+            else:
+                state_str = " ".join(map(str, discretized_states[i]))
+                full_prompt = f"Task: {cleaned_text}, State: {state_str};\nAction: "
             full_prompts.append(full_prompt)
 
         transition[TransitionKey.COMPLEMENTARY_DATA][self.task_key] = full_prompts
@@ -139,7 +146,10 @@ def make_pi05_pre_post_processors(
         # NOTE: NormalizerProcessorStep MUST come before Pi05PrepareStateTokenizerProcessorStep
         # because the tokenizer step expects normalized state in [-1, 1] range for discretization
         steps.normalize,
-        Pi05PrepareStateTokenizerProcessorStep(max_state_dim=config.max_state_dim),
+        Pi05PrepareStateTokenizerProcessorStep(
+            max_state_dim=config.max_state_dim,
+            include_state_in_prompt=not config.use_proprioceptive_memory,
+        ),
         TokenizerProcessorStep(
             tokenizer_name="google/paligemma-3b-pt-224",
             max_length=config.tokenizer_max_length,

--- a/src/lerobot/processor/rename_processor.py
+++ b/src/lerobot/processor/rename_processor.py
@@ -43,10 +43,7 @@ class RenameObservationsProcessorStep(ObservationProcessorStep):
     def observation(self, observation):
         processed_obs = {}
         for key, value in observation.items():
-            if key in self.rename_map:
-                processed_obs[self.rename_map[key]] = value
-            else:
-                processed_obs[key] = value
+            processed_obs[_rename_key_with_metadata(key, self.rename_map)] = value
 
         return processed_obs
 
@@ -91,3 +88,22 @@ def rename_stats(stats: dict[str, dict[str, Any]], rename_map: dict[str, str]) -
         new_key = rename_map.get(old_key, old_key)
         renamed[new_key] = deepcopy(sub_stats) if sub_stats is not None else {}
     return renamed
+
+
+def _rename_key_with_metadata(key: str, rename_map: dict[str, str]) -> str:
+    """Rename a feature key while preserving temporal sampling metadata suffixes."""
+    if key in rename_map:
+        return rename_map[key]
+    for suffix in ("_is_pad", "_padding_mask"):
+        if key.endswith(suffix):
+            base = key[: -len(suffix)]
+            if base in rename_map:
+                return f"{rename_map[base]}{suffix}"
+    return key
+
+
+def rename_batch_keys(batch: dict[str, Any], rename_map: dict[str, str] | None) -> dict[str, Any]:
+    """Canonicalize raw dataset keys before they are grouped into a transition."""
+    if not rename_map:
+        return batch
+    return {_rename_key_with_metadata(key, rename_map): value for key, value in batch.items()}

--- a/src/lerobot/scripts/lerobot_train.py
+++ b/src/lerobot/scripts/lerobot_train.py
@@ -57,6 +57,7 @@ from lerobot.envs import close_envs, make_env, make_env_pre_post_processors
 from lerobot.jobs import submit_to_hf
 from lerobot.optim.factory import make_optimizer_and_scheduler
 from lerobot.policies import PreTrainedPolicy, make_policy, make_pre_post_processors
+from lerobot.processor.rename_processor import rename_batch_keys, rename_stats
 from lerobot.rewards import make_reward_pre_post_processors
 from lerobot.utils.collate import lerobot_collate_fn
 from lerobot.utils.import_utils import _peft_available, register_third_party_plugins, require_package
@@ -347,8 +348,9 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
     processor_pretrained_path = active_cfg.pretrained_path
 
     processor_kwargs = {}
+    processor_dataset_stats = rename_stats(dataset.meta.stats, cfg.rename_map)
     if (processor_pretrained_path and not cfg.resume) or not processor_pretrained_path:
-        processor_kwargs["dataset_stats"] = dataset.meta.stats
+        processor_kwargs["dataset_stats"] = processor_dataset_stats
 
     if cfg.is_reward_model_training:
         processor_kwargs["dataset_meta"] = dataset.meta
@@ -373,8 +375,8 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
         # and force-feeding raw dataset stats over them crashes normalization (#4006).
         # This mirrors the `dataset_stats` kwarg above, which is also skipped on resume.
         if not cfg.resume:
-            preprocessor_overrides["normalizer_processor"]["stats"] = dataset.meta.stats
-            postprocessor_overrides["unnormalizer_processor"]["stats"] = dataset.meta.stats
+            preprocessor_overrides["normalizer_processor"]["stats"] = processor_dataset_stats
+            postprocessor_overrides["unnormalizer_processor"]["stats"] = processor_dataset_stats
         if getattr(active_cfg, "use_relative_actions", False):
             preprocessor_overrides["relative_actions_processor"] = {
                 "enabled": True,
@@ -604,6 +606,7 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
         for cam_key in dataset.meta.camera_keys:
             if cam_key in batch and batch[cam_key].dtype == torch.uint8:
                 batch[cam_key] = batch[cam_key].to(dtype=torch.float32) / 255.0
+        batch = rename_batch_keys(batch, cfg.rename_map)
         batch = preprocessor(batch)
         train_tracker.dataloading_s = time.perf_counter() - start_time
 

--- a/src/lerobot/scripts/lerobot_train.py
+++ b/src/lerobot/scripts/lerobot_train.py
@@ -125,6 +125,20 @@ def _make_eval_envs(cfg: TrainPipelineConfig) -> Iterator[dict[str, dict[int, An
         close_envs(envs)
 
 
+def _preprocess_dataset_batch(
+    batch: dict[str, Any],
+    camera_keys: list[str],
+    rename_map: dict[str, str],
+    preprocessor: Any,
+) -> Any:
+    """Prepare a raw dataset batch identically for training and held-out evaluation."""
+    for cam_key in camera_keys:
+        if cam_key in batch and batch[cam_key].dtype == torch.uint8:
+            batch[cam_key] = batch[cam_key].to(dtype=torch.float32) / 255.0
+    batch = rename_batch_keys(batch, rename_map)
+    return preprocessor(batch)
+
+
 def update_policy(
     train_metrics: MetricsTracker,
     policy: PreTrainedPolicy,
@@ -714,11 +728,7 @@ def train(cfg: TrainPipelineConfig):
         batch = next(dl_iter)
         preprocessing_start = time.perf_counter()
         train_tracker.dataloading_s = preprocessing_start - step_start
-        for cam_key in dataset.meta.camera_keys:
-            if cam_key in batch and batch[cam_key].dtype == torch.uint8:
-                batch[cam_key] = batch[cam_key].to(dtype=torch.float32) / 255.0
-        batch = rename_batch_keys(batch, cfg.rename_map)
-        batch = preprocessor(batch)
+        batch = _preprocess_dataset_batch(batch, dataset.meta.camera_keys, cfg.rename_map, preprocessor)
         train_tracker.preprocessing_s = time.perf_counter() - preprocessing_start
 
         train_tracker, _ = update_policy(
@@ -778,10 +788,9 @@ def train(cfg: TrainPipelineConfig):
             n_eval_batches = 0
             with torch.no_grad(), accelerator.autocast():
                 for eval_batch in eval_dataloader:
-                    for cam_key in dataset.meta.camera_keys:
-                        if cam_key in eval_batch and eval_batch[cam_key].dtype == torch.uint8:
-                            eval_batch[cam_key] = eval_batch[cam_key].to(dtype=torch.float32) / 255.0
-                    eval_batch = preprocessor(eval_batch)
+                    eval_batch = _preprocess_dataset_batch(
+                        eval_batch, dataset.meta.camera_keys, cfg.rename_map, preprocessor
+                    )
                     loss, _ = policy(eval_batch)  # __call__, so FSDP2 forward hooks run
                     eval_loss_sum += loss.item()
                     n_eval_batches += 1

--- a/tests/policies/pi0_pi05/test_pi05_memory.py
+++ b/tests/policies/pi0_pi05/test_pi05_memory.py
@@ -1,0 +1,177 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+from torch import nn
+
+from lerobot.datasets.factory import resolve_delta_timestamps
+from lerobot.policies.pi05.configuration_pi05 import PI05Config
+from lerobot.policies.pi05.memory import (
+    encode_video_with_mem,
+    sample_observation_history,
+    temporal_sinusoidal_embedding,
+)
+from lerobot.policies.pi05.modeling_pi05 import PI05Policy, PI05Pytorch
+
+
+def test_pi05_memory_delta_indices_are_modality_specific():
+    baseline = PI05Config()
+    memory = PI05Config(
+        use_visual_memory=True,
+        use_proprioceptive_memory=True,
+        memory_frames=6,
+        memory_stride=10,
+    )
+    assert baseline.image_observation_delta_indices is None
+    assert baseline.state_observation_delta_indices is None
+    assert memory.image_observation_delta_indices == [-50, -40, -30, -20, -10, 0]
+    assert memory.state_observation_delta_indices == [-50, -40, -30, -20, -10, 0]
+
+
+def test_delta_timestamps_respect_raw_robomme_rename_map():
+    metadata = SimpleNamespace(
+        fps=10,
+        features={"image": {}, "wrist_image": {}, "state": {}, "actions": {}},
+    )
+    config = PI05Config(
+        use_visual_memory=True,
+        use_proprioceptive_memory=True,
+        memory_frames=3,
+        memory_stride=5,
+    )
+    rename_map = {
+        "image": "observation.images.camera1",
+        "wrist_image": "observation.images.camera2",
+        "state": "observation.state",
+        "actions": "action",
+    }
+    deltas = resolve_delta_timestamps(config, metadata, rename_map)
+    assert deltas["image"] == [-1.0, -0.5, 0.0]
+    assert deltas["wrist_image"] == [-1.0, -0.5, 0.0]
+    assert deltas["state"] == [-1.0, -0.5, 0.0]
+    assert deltas["actions"] == [index / 10 for index in range(50)]
+
+
+@pytest.mark.parametrize(
+    "field",
+    ["memory_frames", "memory_stride", "memory_temporal_attention_every"],
+)
+def test_pi05_memory_config_rejects_non_positive_values(field):
+    with pytest.raises(ValueError, match=field):
+        PI05Config(**{field: 0})
+
+
+def test_inference_history_order_and_padding():
+    history = [torch.full((2, 1), value) for value in range(11)]
+    values, padding = sample_observation_history(history, num_frames=3, stride=5, steps_seen=1)
+    assert values[:, :, 0].tolist() == [[0, 5, 10], [0, 5, 10]]
+    assert padding.tolist() == [[True, True, False], [True, True, False]]
+
+
+def test_current_temporal_position_is_exactly_zero():
+    embedding = temporal_sinusoidal_embedding(4, 16, device=torch.device("cpu"), dtype=torch.float32)
+    torch.testing.assert_close(embedding[-1], torch.zeros(16))
+    assert torch.count_nonzero(embedding[:-1]) > 0
+
+
+def _tiny_siglip():
+    transformers = pytest.importorskip("transformers")
+    config = transformers.SiglipVisionConfig(
+        image_size=16,
+        patch_size=8,
+        hidden_size=16,
+        intermediate_size=32,
+        num_hidden_layers=4,
+        num_attention_heads=4,
+        vision_use_head=False,
+    )
+    from transformers.models.siglip.modeling_siglip import SiglipVisionTransformer
+
+    return SiglipVisionTransformer(config).eval()
+
+
+def test_single_frame_mem_matches_original_siglip():
+    model = _tiny_siglip()
+    image = torch.randn(2, 3, 16, 16)
+    expected = model(image).last_hidden_state
+    actual = encode_video_with_mem(
+        model,
+        image[:, None],
+        torch.ones(2, 1, dtype=torch.bool),
+        temporal_attention_every=4,
+    )
+    torch.testing.assert_close(actual, expected)
+
+
+def test_mem_video_encoder_compresses_time_and_backpropagates():
+    model = _tiny_siglip()
+    parameter_ids = {id(parameter) for parameter in model.parameters()}
+    video = torch.randn(2, 3, 3, 16, 16, requires_grad=True)
+    output = encode_video_with_mem(
+        model,
+        video,
+        torch.ones(2, 3, dtype=torch.bool),
+        temporal_attention_every=4,
+    )
+    output.sum().backward()
+    assert output.shape == (2, 4, 16)
+    assert {id(parameter) for parameter in model.parameters()} == parameter_ids
+    assert video.grad is not None
+
+
+def test_masked_history_cannot_change_current_embedding():
+    model = _tiny_siglip()
+    first = torch.randn(1, 3, 3, 16, 16)
+    second = first.clone()
+    second[:, :2] = torch.randn_like(second[:, :2]) * 100
+    frame_mask = torch.tensor([[False, False, True]])
+    first_output = encode_video_with_mem(model, first, frame_mask, temporal_attention_every=4)
+    second_output = encode_video_with_mem(model, second, frame_mask, temporal_attention_every=4)
+    torch.testing.assert_close(first_output, second_output)
+
+
+class _EmbeddingStub(nn.Module):
+    def embed_image(self, image, **kwargs):
+        return torch.zeros(image.shape[0], 2, 8)
+
+    def embed_language_tokens(self, tokens):
+        return torch.zeros(tokens.shape[0], tokens.shape[1], 8)
+
+
+def test_proprioceptive_history_adds_one_masked_token_per_frame():
+    model = PI05Pytorch.__new__(PI05Pytorch)
+    nn.Module.__init__(model)
+    model.config = SimpleNamespace(memory_temporal_attention_every=4)
+    model.gradient_checkpointing_enabled = False
+    model.paligemma_with_expert = _EmbeddingStub()
+    model.proprio_history_proj = nn.Linear(4, 8)
+    images = [torch.zeros(2, 3, 16, 16)]
+    image_masks = [torch.ones(2, dtype=torch.bool)]
+    states = torch.randn(2, 3, 4)
+    state_masks = torch.tensor([[False, True, True], [True, True, True]])
+    tokens = torch.ones(2, 5, dtype=torch.long)
+    token_masks = torch.ones(2, 5, dtype=torch.bool)
+    embeddings, padding, _ = model.embed_prefix(images, image_masks, tokens, token_masks, states, state_masks)
+    assert embeddings.shape == (2, 10, 8)
+    torch.testing.assert_close(padding[:, 2:5], state_masks)
+
+
+def test_pi05_base_checkpoint_keeps_fresh_proprio_memory_projection():
+    policy = PI05Policy.__new__(PI05Policy)
+    nn.Module.__init__(policy)
+    policy.config = SimpleNamespace(use_proprioceptive_memory=True)
+    policy.model = nn.Module()
+    policy.model.proprio_history_proj = nn.Linear(4, 8)
+
+    state_dict = policy._prepare_pretrained_state_dict({})
+
+    assert "model.proprio_history_proj.weight" in state_dict
+    assert "model.proprio_history_proj.bias" in state_dict

--- a/tests/policies/pi0_pi05/test_pi05_memory.py
+++ b/tests/policies/pi0_pi05/test_pi05_memory.py
@@ -247,6 +247,18 @@ def test_mem_rejects_incompatible_siglip_layer():
         )
 
 
+def test_mem_rejects_temporal_interval_larger_than_vision_depth():
+    model = _tiny_siglip()
+
+    with pytest.raises(ValueError, match=r"temporal_attention_every \(5\).*layers \(4\)"):
+        encode_video_with_mem(
+            model,
+            torch.randn(1, 3, 3, 16, 16),
+            torch.ones(1, 3, dtype=torch.bool),
+            temporal_attention_every=5,
+        )
+
+
 def test_mem_video_encoder_compresses_time_and_backpropagates():
     model = _tiny_siglip()
     parameter_ids = {id(parameter) for parameter in model.parameters()}

--- a/tests/policies/pi0_pi05/test_pi05_memory.py
+++ b/tests/policies/pi0_pi05/test_pi05_memory.py
@@ -5,6 +5,12 @@
 # You may obtain a copy of the License at
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 from types import SimpleNamespace
 
@@ -14,8 +20,10 @@ from torch import nn
 
 from lerobot.policies.pi05.configuration_pi05 import PI05Config
 from lerobot.policies.pi05.memory import (
+    causal_temporal_mask,
     encode_video_with_mem,
     sample_observation_history,
+    space_time_attention,
     temporal_sinusoidal_embedding,
 )
 from lerobot.policies.pi05.modeling_pi05 import PI05Policy, PI05Pytorch
@@ -78,6 +86,52 @@ def test_inference_history_order_and_padding():
     assert padding.tolist() == [[True, True, False], [True, True, False]]
 
 
+def test_inference_history_anchors_on_the_newest_frame():
+    """Ages are relative to the newest frame, so an over-long queue still ends at it."""
+    history = [torch.full((1, 1), value) for value in range(14)]
+    values, _ = sample_observation_history(history, num_frames=3, stride=5, steps_seen=99)
+    assert values[:, :, 0].tolist() == [[3, 8, 13]]
+
+
+def test_inference_history_rejects_a_too_short_queue():
+    history = [torch.zeros(1, 1) for _ in range(10)]
+    with pytest.raises(ValueError, match="need at least 11"):
+        sample_observation_history(history, num_frames=3, stride=5, steps_seen=99)
+
+
+def test_visual_memory_requires_a_matching_image_key():
+    pytest.importorskip("datasets")
+    from lerobot.datasets.factory import resolve_delta_timestamps
+
+    config = PI05Config(use_visual_memory=True, memory_frames=3, memory_stride=5)
+
+    # Singular `observation.image` is a valid LeRobot convention and must get history.
+    singular = SimpleNamespace(fps=10, features={"observation.image": {}, "action": {}})
+    assert resolve_delta_timestamps(config, singular)["observation.image"] == [-1.0, -0.5, 0.0]
+
+    # A dataset with no image key at all must fail instead of training single-frame.
+    stateless = SimpleNamespace(fps=10, features={"observation.state": {}, "action": {}})
+    with pytest.raises(ValueError, match="no dataset feature maps to an image key"):
+        resolve_delta_timestamps(config, stateless)
+
+
+def test_proprioceptive_memory_removes_the_state_from_the_prompt():
+    from lerobot.lerobot_types import TransitionKey
+    from lerobot.policies.pi05.processor_pi05 import Pi05PrepareStateTokenizerProcessorStep
+    from lerobot.utils.constants import OBS_STATE
+
+    def prompt_for(*, include_state: bool) -> str:
+        transition = {
+            TransitionKey.OBSERVATION: {OBS_STATE: torch.zeros(1, 2, 4)},
+            TransitionKey.COMPLEMENTARY_DATA: {"task": ["pick the cube"]},
+        }
+        step = Pi05PrepareStateTokenizerProcessorStep(include_state_in_prompt=include_state)
+        return step(transition)[TransitionKey.COMPLEMENTARY_DATA]["task"][0]
+
+    assert prompt_for(include_state=True) == "Task: pick the cube, State: 128 128 128 128;\nAction: "
+    assert prompt_for(include_state=False) == "Task: pick the cube;\nAction: "
+
+
 def test_current_temporal_position_is_exactly_zero():
     embedding = temporal_sinusoidal_embedding(4, 16, device=torch.device("cpu"), dtype=torch.float32)
     torch.testing.assert_close(embedding[-1], torch.zeros(16))
@@ -102,11 +156,9 @@ def _tiny_siglip():
 
 def test_single_frame_mem_matches_original_siglip():
     model = _tiny_siglip()
-    model.config._attn_implementation = "flash_attention_2"  # noqa: SLF001
+    model.config._attn_implementation = "sdpa"  # noqa: SLF001
     image = torch.randn(2, 3, 16, 16)
-    model.config._attn_implementation = "eager"  # noqa: SLF001
     expected = model(image).last_hidden_state
-    model.config._attn_implementation = "flash_attention_2"  # noqa: SLF001
     actual = encode_video_with_mem(
         model,
         image[:, None],
@@ -114,7 +166,51 @@ def test_single_frame_mem_matches_original_siglip():
         temporal_attention_every=4,
     )
     torch.testing.assert_close(actual, expected)
-    assert model.config._attn_implementation == "eager"  # noqa: SLF001
+    # MEM composes attention weights itself, so it must not downgrade the tower.
+    assert model.config._attn_implementation == "sdpa"  # noqa: SLF001
+
+
+def test_composed_space_time_attention_is_identity_over_one_frame():
+    """A softmax over a single timestep is the identity, so eq. 3 reduces to SigLIP."""
+    model = _tiny_siglip()
+    model.config._attn_implementation = "sdpa"  # noqa: SLF001
+    attention = model.encoder.layers[0].self_attn
+    hidden = torch.randn(2, 1, 4, 16)
+    mask = causal_temporal_mask(
+        torch.ones(2, 1, dtype=torch.bool), dtype=hidden.dtype, num_patches=hidden.shape[2]
+    )
+
+    composed = space_time_attention(attention, hidden, mask)
+    spatial_only = attention(hidden_states=hidden[:, 0], attention_mask=None)[0]
+
+    torch.testing.assert_close(composed[:, 0], spatial_only)
+
+
+def test_mem_drops_past_frames_after_the_last_temporal_layer():
+    model = _tiny_siglip()  # 4 layers; temporal_attention_every=3 -> temporal at index 2 only
+    batch_size, num_frames = 2, 3
+    # Spatial-only layers are invoked as whole layers with a (batch * frames) leading
+    # dim; temporal layers drive the sub-modules directly and so never fire this hook.
+    spatial_batches: list[int] = []
+    for layer in model.encoder.layers:
+        layer.register_forward_pre_hook(
+            lambda _module, args, sink=spatial_batches: sink.append(args[0].shape[0])
+        )
+
+    encode_video_with_mem(
+        model,
+        torch.randn(batch_size, num_frames, 3, 16, 16),
+        torch.ones(batch_size, num_frames, dtype=torch.bool),
+        temporal_attention_every=3,
+    )
+
+    # Layers 0 and 1 still see every frame; layer 3 sits above the last temporal layer,
+    # so it must only ever see the current frame.
+    assert spatial_batches == [
+        batch_size * num_frames,
+        batch_size * num_frames,
+        batch_size,
+    ]
 
 
 def test_mem_normalizes_tuple_encoder_layer_output(monkeypatch):

--- a/tests/policies/pi0_pi05/test_pi05_memory.py
+++ b/tests/policies/pi0_pi05/test_pi05_memory.py
@@ -100,8 +100,11 @@ def _tiny_siglip():
 
 def test_single_frame_mem_matches_original_siglip():
     model = _tiny_siglip()
+    model.config._attn_implementation = "flash_attention_2"  # noqa: SLF001
     image = torch.randn(2, 3, 16, 16)
+    model.config._attn_implementation = "eager"  # noqa: SLF001
     expected = model(image).last_hidden_state
+    model.config._attn_implementation = "flash_attention_2"  # noqa: SLF001
     actual = encode_video_with_mem(
         model,
         image[:, None],
@@ -109,6 +112,41 @@ def test_single_frame_mem_matches_original_siglip():
         temporal_attention_every=4,
     )
     torch.testing.assert_close(actual, expected)
+    assert model.config._attn_implementation == "eager"  # noqa: SLF001
+
+
+def test_mem_normalizes_tuple_encoder_layer_output(monkeypatch):
+    model = _tiny_siglip()
+    layer = model.encoder.layers[0]
+    original_forward = layer.forward
+
+    def tuple_forward(*args, **kwargs):
+        return (original_forward(*args, **kwargs),)
+
+    monkeypatch.setattr(layer, "forward", tuple_forward)
+    video = torch.randn(1, 1, 3, 16, 16)
+
+    output = encode_video_with_mem(
+        model,
+        video,
+        torch.ones(1, 1, dtype=torch.bool),
+        temporal_attention_every=4,
+    )
+
+    assert output.shape == (1, 4, 16)
+
+
+def test_mem_rejects_incompatible_siglip_layer():
+    model = _tiny_siglip()
+    model.encoder.layers[0] = nn.Identity()
+
+    with pytest.raises(TypeError, match="layer 0 is missing"):
+        encode_video_with_mem(
+            model,
+            torch.randn(1, 1, 3, 16, 16),
+            torch.ones(1, 1, dtype=torch.bool),
+            temporal_attention_every=4,
+        )
 
 
 def test_mem_video_encoder_compresses_time_and_backpropagates():
@@ -175,3 +213,41 @@ def test_pi05_base_checkpoint_keeps_fresh_proprio_memory_projection():
 
     assert "model.proprio_history_proj.weight" in state_dict
     assert "model.proprio_history_proj.bias" in state_dict
+
+
+def _make_inference_memory_policy() -> PI05Policy:
+    policy = PI05Policy.__new__(PI05Policy)
+    nn.Module.__init__(policy)
+    policy.config = SimpleNamespace(
+        n_action_steps=1,
+        use_visual_memory=True,
+        use_proprioceptive_memory=False,
+        memory_frames=3,
+        memory_stride=1,
+        image_features=["camera"],
+    )
+    policy.reset()
+    return policy
+
+
+def test_inference_memory_snapshots_observations_instead_of_storing_references():
+    policy = _make_inference_memory_policy()
+    observation = torch.ones(2, 1)
+
+    policy._stack_inference_memory({"camera": observation})
+    observation.fill_(9)
+    history = policy._stack_inference_memory({"camera": observation})["camera"]
+
+    assert history[:, :, 0].tolist() == [[1, 1, 9], [1, 1, 9]]
+
+
+def test_inference_memory_requires_reset_before_batch_size_changes():
+    policy = _make_inference_memory_policy()
+    policy._stack_inference_memory({"camera": torch.ones(2, 1)})
+
+    with pytest.raises(ValueError, match="without policy.reset"):
+        policy._stack_inference_memory({"camera": torch.ones(1, 1)})
+
+    policy.reset()
+    history = policy._stack_inference_memory({"camera": torch.ones(1, 1)})["camera"]
+    assert history.shape == (1, 3, 1)

--- a/tests/policies/pi0_pi05/test_pi05_memory.py
+++ b/tests/policies/pi0_pi05/test_pi05_memory.py
@@ -12,7 +12,6 @@ import pytest
 import torch
 from torch import nn
 
-from lerobot.datasets.factory import resolve_delta_timestamps
 from lerobot.policies.pi05.configuration_pi05 import PI05Config
 from lerobot.policies.pi05.memory import (
     encode_video_with_mem,
@@ -37,6 +36,9 @@ def test_pi05_memory_delta_indices_are_modality_specific():
 
 
 def test_delta_timestamps_respect_raw_robomme_rename_map():
+    pytest.importorskip("datasets")
+    from lerobot.datasets.factory import resolve_delta_timestamps
+
     metadata = SimpleNamespace(
         fps=10,
         features={"image": {}, "wrist_image": {}, "state": {}, "actions": {}},

--- a/tests/policies/test_factory_peft_revision.py
+++ b/tests/policies/test_factory_peft_revision.py
@@ -18,6 +18,8 @@ from unittest.mock import MagicMock
 import torch
 
 import lerobot.policies.factory as policy_factory
+from lerobot.configs import FeatureType
+from lerobot.utils.constants import ACTION
 
 
 def test_make_policy_keeps_peft_adapter_and_base_revisions_separate(monkeypatch):
@@ -81,3 +83,40 @@ def test_make_policy_keeps_peft_adapter_and_base_revisions_separate(monkeypatch)
         revision="adapter-sha",
         is_trainable=True,
     )
+
+
+def test_make_policy_reads_action_names_through_rename_map(monkeypatch):
+    cfg = SimpleNamespace(
+        type="mock",
+        device="cpu",
+        pretrained_path=None,
+        use_peft=False,
+        input_features={},
+        output_features={},
+        action_feature_names=None,
+    )
+    action_names = ["shoulder", "elbow", "gripper"]
+    dataset_meta = SimpleNamespace(
+        features={
+            "actions": {
+                "dtype": "float32",
+                "shape": (len(action_names),),
+                "names": action_names,
+            }
+        },
+        stats={},
+    )
+
+    policy = torch.nn.Linear(1, 1)
+    policy_class = MagicMock(return_value=policy)
+    monkeypatch.setattr(policy_factory, "get_policy_class", lambda _: policy_class)
+
+    result = policy_factory.make_policy(
+        cfg,
+        ds_meta=dataset_meta,
+        rename_map={"actions": ACTION},
+    )
+
+    assert result is policy
+    assert cfg.action_feature_names == action_names
+    assert cfg.output_features[ACTION].type is FeatureType.ACTION

--- a/tests/processor/test_rename_processor.py
+++ b/tests/processor/test_rename_processor.py
@@ -27,7 +27,7 @@ from lerobot.processor import (
     TransitionKey,
 )
 from lerobot.processor.converters import create_transition, identity_transition
-from lerobot.processor.rename_processor import rename_stats
+from lerobot.processor.rename_processor import rename_batch_keys, rename_stats
 from lerobot.utils.constants import ACTION, OBS_IMAGE, OBS_IMAGES, OBS_STATE
 from tests.conftest import assert_contract_is_typed
 
@@ -62,6 +62,44 @@ def test_basic_renaming():
 
     # Check unchanged key is preserved
     assert processed_obs["unchanged_key"] == "keep_me"
+
+
+def test_renaming_preserves_temporal_padding_suffixes():
+    processor = RenameObservationsProcessorStep(rename_map={"image": "observation.images.camera1"})
+    transition = create_transition(
+        observation={
+            "image": torch.zeros(1),
+            "image_is_pad": torch.ones(1, dtype=torch.bool),
+            "image_padding_mask": torch.ones(1, dtype=torch.bool),
+        }
+    )
+
+    processed = processor(transition)[TransitionKey.OBSERVATION]
+
+    assert set(processed) == {
+        "observation.images.camera1",
+        "observation.images.camera1_is_pad",
+        "observation.images.camera1_padding_mask",
+    }
+
+
+def test_raw_batch_keys_are_renamed_before_transition_grouping():
+    batch = {
+        "image": torch.zeros(1),
+        "image_is_pad": torch.ones(1, dtype=torch.bool),
+        "actions": torch.zeros(1),
+    }
+
+    renamed = rename_batch_keys(
+        batch,
+        {"image": "observation.images.camera1", "actions": "action"},
+    )
+
+    assert set(renamed) == {
+        "observation.images.camera1",
+        "observation.images.camera1_is_pad",
+        "action",
+    }
 
 
 def test_empty_rename_map():

--- a/tests/scripts/test_lerobot_train_batch_preprocessing.py
+++ b/tests/scripts/test_lerobot_train_batch_preprocessing.py
@@ -1,0 +1,46 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+pytest.importorskip("datasets", reason="datasets is required (install lerobot[dataset])")
+
+from lerobot.scripts.lerobot_train import _preprocess_dataset_batch  # noqa: E402
+from lerobot.utils.constants import ACTION, OBS_IMAGES  # noqa: E402
+
+
+def test_preprocess_dataset_batch_normalizes_and_renames_before_processor():
+    seen_batch = None
+
+    def preprocessor(batch):
+        nonlocal seen_batch
+        seen_batch = batch
+        return batch
+
+    batch = {
+        "image": torch.full((1, 3, 2, 2), 255, dtype=torch.uint8),
+        "actions": torch.ones(1, 2),
+    }
+    processed = _preprocess_dataset_batch(
+        batch,
+        camera_keys=["image"],
+        rename_map={"image": f"{OBS_IMAGES}.camera1", "actions": ACTION},
+        preprocessor=preprocessor,
+    )
+
+    assert seen_batch is processed
+    assert set(processed) == {f"{OBS_IMAGES}.camera1", ACTION}
+    assert processed[f"{OBS_IMAGES}.camera1"].dtype == torch.float32
+    torch.testing.assert_close(processed[f"{OBS_IMAGES}.camera1"], torch.ones(1, 3, 2, 2))

--- a/tests/test_robomme_env.py
+++ b/tests/test_robomme_env.py
@@ -25,6 +25,7 @@ from types import ModuleType
 from unittest.mock import MagicMock
 
 import numpy as np
+import pytest
 
 
 def _install_robomme_stub():
@@ -44,7 +45,10 @@ def _install_robomme_stub():
                 "joint_state_list": [np.zeros(7, dtype=np.float32)],
                 "gripper_state_list": [np.zeros(2, dtype=np.float32)],
             }
-            env.reset.return_value = (obs, {"status": "ongoing", "task_goal": "pick the cube"})
+            env.reset.return_value = (
+                obs,
+                {"status": "ongoing", "task_goal": ["pick the cube", "pick the blue cube"]},
+            )
             env.step.return_value = (obs, 0.0, False, False, {"status": "ongoing", "task_goal": ""})
             return env
 
@@ -89,9 +93,25 @@ def test_robomme_features_map():
 
     cfg = RoboMMEEnv()
     assert cfg.features_map[ACTION] == ACTION
+    assert cfg.features_map["pixels/camera1"] == f"{OBS_IMAGES}.camera1"
+    assert cfg.features_map["pixels/camera2"] == f"{OBS_IMAGES}.camera2"
+    assert cfg.features_map["agent_pos"] == OBS_STATE
+
+
+def test_robomme_rejects_duplicate_camera_names():
+    from lerobot.envs.configs import RoboMMEEnv
+
+    with pytest.raises(ValueError, match="camera names must be distinct"):
+        RoboMMEEnv(front_camera_name="camera", wrist_camera_name="camera")
+
+
+def test_robomme_camera_feature_names_are_configurable():
+    from lerobot.envs.configs import RoboMMEEnv
+    from lerobot.utils.constants import OBS_IMAGES
+
+    cfg = RoboMMEEnv(front_camera_name="image", wrist_camera_name="wrist_image")
     assert cfg.features_map["pixels/image"] == f"{OBS_IMAGES}.image"
     assert cfg.features_map["pixels/wrist_image"] == f"{OBS_IMAGES}.wrist_image"
-    assert cfg.features_map["agent_pos"] == OBS_STATE
 
 
 def test_robomme_features_action_dim_joint_angle():
@@ -116,9 +136,56 @@ def test_robomme_features_action_dim_ee_pose():
 # ---------------------------------------------------------------------------
 
 
+def test_reset_exposes_episode_task_description():
+    _install_robomme_stub()
+    try:
+        from lerobot.envs.robomme import RoboMMEGymEnv
+
+        env = RoboMMEGymEnv(task="PickXtimes")
+        env.reset()
+
+        assert env.task == "PickXtimes"
+        assert env.task_description == "pick the cube"
+    finally:
+        _uninstall_robomme_stub()
+
+
+def test_close_releases_underlying_simulator():
+    _install_robomme_stub()
+    try:
+        from lerobot.envs.robomme import RoboMMEGymEnv
+
+        env = RoboMMEGymEnv(task="PickXtimes")
+        env.reset()
+        simulator = env._env
+        env.close()
+
+        simulator.close.assert_called_once_with()
+        assert env._env is None
+        assert env._last_raw_obs is None
+    finally:
+        _uninstall_robomme_stub()
+
+
+def test_reset_closes_previous_simulator():
+    _install_robomme_stub()
+    try:
+        from lerobot.envs.robomme import RoboMMEGymEnv
+
+        env = RoboMMEGymEnv(task="PickXtimes")
+        env.reset()
+        first_simulator = env._env
+        env.reset()
+
+        first_simulator.close.assert_called_once_with()
+        assert env._env is not first_simulator
+    finally:
+        _uninstall_robomme_stub()
+
+
 def test_convert_obs_list_format():
     """_convert_obs takes the last element from list-format obs fields and
-    emits a nested ``pixels`` dict (image, wrist_image) plus ``agent_pos``.
+    emits a nested ``pixels`` dict using policy-aligned camera names plus ``agent_pos``.
 
     The nested layout is required so ``preprocess_observation()`` in
     ``envs/utils.py`` maps each camera to ``observation.images.<cam>``.
@@ -142,11 +209,17 @@ def test_convert_obs_list_format():
         }
 
         result = env._convert_obs(obs_raw)
-        np.testing.assert_array_equal(result["pixels"]["image"], front)
-        np.testing.assert_array_equal(result["pixels"]["wrist_image"], wrist)
+        np.testing.assert_array_equal(result["pixels"]["camera1"], front)
+        np.testing.assert_array_equal(result["pixels"]["camera2"], wrist)
         assert result["agent_pos"].shape == (8,)
         np.testing.assert_array_almost_equal(result["agent_pos"][:7], joints)
         assert result["agent_pos"][7] == gripper[0]
+
+        from lerobot.envs.utils import preprocess_observation
+
+        processed = preprocess_observation(result)
+        assert "observation.images.camera1" in processed
+        assert "observation.images.camera2" in processed
     finally:
         _uninstall_robomme_stub()
 
@@ -167,8 +240,8 @@ def test_convert_obs_array_format():
             "gripper_state_list": np.zeros(2, dtype=np.float32),
         }
         result = env._convert_obs(obs_raw)
-        assert result["pixels"]["image"].shape == (256, 256, 3)
-        assert result["pixels"]["wrist_image"].shape == (256, 256, 3)
+        assert result["pixels"]["camera1"].shape == (256, 256, 3)
+        assert result["pixels"]["camera2"].shape == (256, 256, 3)
         assert result["agent_pos"].shape == (8,)
     finally:
         _uninstall_robomme_stub()

--- a/tests/test_robomme_env.py
+++ b/tests/test_robomme_env.py
@@ -114,6 +114,24 @@ def test_robomme_camera_feature_names_are_configurable():
     assert cfg.features_map["pixels/wrist_image"] == f"{OBS_IMAGES}.wrist_image"
 
 
+def test_robomme_preserves_explicit_feature_mapping():
+    from lerobot.envs.configs import RoboMMEEnv
+    from lerobot.utils.constants import ACTION, OBS_IMAGES, OBS_STATE
+
+    cfg = RoboMMEEnv(
+        features_map={
+            "pixels/camera1": f"{OBS_IMAGES}.custom_front",
+            "custom": "observation.custom",
+        }
+    )
+
+    assert cfg.features_map["pixels/camera1"] == f"{OBS_IMAGES}.custom_front"
+    assert cfg.features_map["pixels/camera2"] == f"{OBS_IMAGES}.camera2"
+    assert cfg.features_map["agent_pos"] == OBS_STATE
+    assert cfg.features_map[ACTION] == ACTION
+    assert cfg.features_map["custom"] == "observation.custom"
+
+
 def test_robomme_features_action_dim_joint_angle():
     from lerobot.envs.configs import RoboMMEEnv
     from lerobot.utils.constants import ACTION


### PR DESCRIPTION
## Summary

Adds optional short-horizon visual and proprioceptive memory to Pi05, based on MEM.

Both paths are independently opt-in through `policy.use_visual_memory` and `policy.use_proprioceptive_memory`. Their defaults are `false`, so existing Pi05 checkpoints and configurations retain single-frame behavior.

## What changed

- Fuse historical image frames inside SigLIP with causal temporal attention between matching patch tokens.
- Return only current-frame vision tokens so the downstream language/action prefix length stays unchanged.
- Represent each retained proprioceptive state with one projected continuous token.
- Add configurable frame count, stride, temporal-attention frequency, episode reset, masked history padding, and strided inference queues.
- Preserve the new proprioceptive projection when initializing from a non-MEM Pi05 checkpoint.
- Resolve image and state history timestamps independently, including through dataset rename maps.
- Preserve temporal padding metadata and renamed normalization statistics through preprocessing.
- Include the RoboMME camera/task/resource-lifecycle fixes needed for memory-enabled Pi05 training and evaluation.

## Usage

```bash
--policy.use_visual_memory=true \
--policy.use_proprioceptive_memory=true \
--policy.memory_frames=6 \
--policy.memory_stride=10
```

Enable either memory path independently. Enabling neither leaves standard Pi05 behavior unchanged.

## RoboMME results

Both policies were initialized from `lerobot/pi05_base` and trained on `lerobot/robomme` for 30,000 steps using 8× H100 GPUs, batch size 24 per GPU (global batch size 192), flow-only training, and no subtasks. The benchmark used 50 task IDs for each of RoboMME’s 16 task groups: 800 matched episodes per policy and 1,600 rollouts total.

| Policy | Successes | Success rate |
| --- | ---: | ---: |
| Pi05 baseline (no memory) | 15 / 800 | 1.88% |
| Pi05 + visual and proprioceptive MEM | 146 / 800 | 18.25% |

MEM improved success by **+16.38 percentage points** and achieved a **9.73×** relative success rate. A paired bootstrap over matched episodes gives a 95% confidence interval of **[+13.63, +19.12] percentage points**. There were 138 MEM-only successes, 7 baseline-only successes, 8 successes from both policies, and 647 failures from both policies (exact paired McNemar `p ≈ 1.09e-32`).

| RoboMME task group | Baseline | Visual + proprio MEM |
| --- | ---: | ---: |
| BinFill | 0 / 50 (0%) | 8 / 50 (16%) |
| ButtonUnmask | 0 / 50 (0%) | 12 / 50 (24%) |
| ButtonUnmaskSwap | 0 / 50 (0%) | 0 / 50 (0%) |
| InsertPeg | 0 / 50 (0%) | 0 / 50 (0%) |
| MoveCube | 6 / 50 (12%) | 22 / 50 (44%) |
| PatternLock | 5 / 50 (10%) | 6 / 50 (12%) |
| PickHighlight | 0 / 50 (0%) | 14 / 50 (28%) |
| PickXtimes | 0 / 50 (0%) | 14 / 50 (28%) |
| RouteStick | 2 / 50 (4%) | 6 / 50 (12%) |
| StopCube | 2 / 50 (4%) | 4 / 50 (8%) |
| SwingXtimes | 0 / 50 (0%) | 5 / 50 (10%) |
| VideoPlaceButton | 0 / 50 (0%) | 12 / 50 (24%) |
| VideoPlaceOrder | 0 / 50 (0%) | 13 / 50 (26%) |
| VideoRepick | 0 / 50 (0%) | 5 / 50 (10%) |
| VideoUnmask | 0 / 50 (0%) | 9 / 50 (18%) |
| VideoUnmaskSwap | 0 / 50 (0%) | 16 / 50 (32%) |

These are single-training-seed results; additional seeds are needed to estimate training variance.

## Validation

- Focused Pi05 MEM, rename-processor, and RoboMME suites: `51 passed, 2 skipped`.
- Targeted pre-commit hooks passed, including Ruff, Prettier, typos, Bandit, and mypy.