### PR TITLE
feat(scripts): soft-start smooth handover for teleoperate/record/replay

### DIFF
--- a/src/lerobot/common/control_utils.py
+++ b/src/lerobot/common/control_utils.py
@@ -229,3 +229,86 @@ def follower_smooth_move_to(
         interp = {k: current[k] * (1 - t) + target[k] * t if k in target else current[k] for k in current}
         robot.send_action(interp)
         time.sleep(1 / fps)
+
+
+def _joint_pos_from_observation(observation: dict, action_keys: dict | None = None) -> dict:
+    """Extract joint position targets from a robot observation.
+
+    Prefers keys that also appear in ``action_keys`` (robot action space). Falls back to
+    every observation key ending with ``.pos``.
+    """
+    if action_keys is not None:
+        keys = [k for k in action_keys if k in observation]
+        if keys:
+            return {k: observation[k] for k in keys}
+    return {k: v for k, v in observation.items() if isinstance(k, str) and k.endswith(".pos")}
+
+
+def smooth_teleop_session_start(
+    robot,
+    teleop,
+    *,
+    robot_action_processor=None,
+    duration_s: float = 2.0,
+    fps: int = 30,
+) -> None:
+    """Soft-start a teleoperate/record session so the first controlled frame does not jerk.
+
+    - Actuated teleops (feedback support): slide the leader to the follower's current joints.
+    - Non-actuated teleops: slide the follower to the teleoperator's current command (processed
+      into robot action space when ``robot_action_processor`` is provided).
+
+    No-ops harmlessly if required poses cannot be inferred.
+    """
+    if duration_s <= 0:
+        return
+
+    obs = robot.get_observation()
+    action_keys = getattr(robot, "action_features", None)
+    follower_pos = _joint_pos_from_observation(obs, action_keys)
+
+    if teleop_supports_feedback(teleop):
+        if not follower_pos:
+            return
+        teleop_smooth_move_to(teleop, follower_pos, duration_s=duration_s, fps=fps)
+        return
+
+    # Non-actuated: bring follower to teleop pose
+    raw = teleop.get_action()
+    if robot_action_processor is not None:
+        target = robot_action_processor((raw, obs))
+    else:
+        target = raw
+    if not isinstance(target, dict) or not target or not follower_pos:
+        return
+    # Align on overlapping numeric keys
+    common = {k: target[k] for k in target if k in follower_pos}
+    if not common:
+        return
+    current = {k: follower_pos[k] for k in common}
+    follower_smooth_move_to(robot, current, common, duration_s=duration_s, fps=fps)
+
+
+def smooth_follower_to_action(
+    robot,
+    target_action: dict,
+    *,
+    duration_s: float = 1.0,
+    fps: int = 30,
+) -> None:
+    """Slide the follower from its current joint observation toward ``target_action``."""
+    if duration_s <= 0 or not target_action:
+        return
+    obs = robot.get_observation()
+    action_keys = getattr(robot, "action_features", None)
+    current_full = _joint_pos_from_observation(obs, action_keys)
+    common_keys = [k for k in target_action if k in current_full]
+    if not common_keys:
+        # target may use dataset FEATURE names without .pos; try mapping observation only
+        common_keys = [k for k in current_full if k in target_action]
+    if not common_keys:
+        return
+    current = {k: current_full[k] for k in common_keys}
+    target = {k: target_action[k] for k in common_keys}
+    follower_smooth_move_to(robot, current, target, duration_s=duration_s, fps=fps)
+

--- a/src/lerobot/common/control_utils.py
+++ b/src/lerobot/common/control_utils.py
@@ -311,4 +311,3 @@ def smooth_follower_to_action(
     current = {k: current_full[k] for k in common_keys}
     target = {k: target_action[k] for k in common_keys}
     follower_smooth_move_to(robot, current, target, duration_s=duration_s, fps=fps)
-

--- a/src/lerobot/common/control_utils.py
+++ b/src/lerobot/common/control_utils.py
@@ -275,10 +275,7 @@ def smooth_teleop_session_start(
 
     # Non-actuated: bring follower to teleop pose
     raw = teleop.get_action()
-    if robot_action_processor is not None:
-        target = robot_action_processor((raw, obs))
-    else:
-        target = raw
+    target = robot_action_processor((raw, obs)) if robot_action_processor is not None else raw
     if not isinstance(target, dict) or not target or not follower_pos:
         return
     # Align on overlapping numeric keys

--- a/src/lerobot/scripts/lerobot_record.py
+++ b/src/lerobot/scripts/lerobot_record.py
@@ -99,7 +99,10 @@ from lerobot.cameras.opencv import OpenCVCameraConfig  # noqa: F401
 from lerobot.cameras.reachy2_camera import Reachy2CameraConfig  # noqa: F401
 from lerobot.cameras.realsense import RealSenseCameraConfig  # noqa: F401
 from lerobot.cameras.zmq import ZMQCameraConfig  # noqa: F401
-from lerobot.common.control_utils import sanity_check_dataset_robot_compatibility
+from lerobot.common.control_utils import (
+    sanity_check_dataset_robot_compatibility,
+    smooth_teleop_session_start,
+)
 from lerobot.configs import parser
 from lerobot.configs.dataset import DatasetRecordConfig
 from lerobot.datasets import (
@@ -188,6 +191,9 @@ class RecordConfig:
     play_sounds: bool = True
     # Resume recording on an existing dataset.
     resume: bool = False
+    # Soft-start handover before the first recorded frame (0 disables).
+    smooth_handover_duration_s: float = 2.0
+    smooth_handover_fps: int = 30
 
     def __post_init__(self):
         if self.teleop is None:
@@ -482,6 +488,19 @@ def record(
         if teleop is not None:
             teleop.connect()
         robot.connect()
+        if cfg.smooth_handover_duration_s > 0:
+            logging.info(
+                "Smooth handover at record start (%.2fs @ %d Hz)",
+                cfg.smooth_handover_duration_s,
+                cfg.smooth_handover_fps,
+            )
+            smooth_teleop_session_start(
+                robot,
+                teleop,
+                robot_action_processor=robot_action_processor,
+                duration_s=cfg.smooth_handover_duration_s,
+                fps=cfg.smooth_handover_fps,
+            )
 
         listener, events = init_keyboard_listener()
 

--- a/src/lerobot/scripts/lerobot_record.py
+++ b/src/lerobot/scripts/lerobot_record.py
@@ -99,7 +99,10 @@ from lerobot.cameras.opencv import OpenCVCameraConfig  # noqa: F401
 from lerobot.cameras.reachy2_camera import Reachy2CameraConfig  # noqa: F401
 from lerobot.cameras.realsense import RealSenseCameraConfig  # noqa: F401
 from lerobot.cameras.zmq import ZMQCameraConfig  # noqa: F401
-from lerobot.common.control_utils import sanity_check_dataset_robot_compatibility
+from lerobot.common.control_utils import (
+    sanity_check_dataset_robot_compatibility,
+    smooth_teleop_session_start,
+)
 from lerobot.configs import parser
 from lerobot.configs.dataset import DatasetRecordConfig
 from lerobot.datasets import (
@@ -188,6 +191,9 @@ class RecordConfig:
     play_sounds: bool = True
     # Resume recording on an existing dataset.
     resume: bool = False
+    # Soft-start handover before the first recorded frame (0 disables).
+    smooth_handover_duration_s: float = 2.0
+    smooth_handover_fps: int = 30
 
     def __post_init__(self):
         if self.teleop is None:
@@ -458,6 +464,19 @@ def record(
         if teleop is not None:
             teleop.connect()
         robot.connect()
+        if cfg.smooth_handover_duration_s > 0:
+            logging.info(
+                "Smooth handover at record start (%.2fs @ %d Hz)",
+                cfg.smooth_handover_duration_s,
+                cfg.smooth_handover_fps,
+            )
+            smooth_teleop_session_start(
+                robot,
+                teleop,
+                robot_action_processor=robot_action_processor,
+                duration_s=cfg.smooth_handover_duration_s,
+                fps=cfg.smooth_handover_fps,
+            )
 
         listener, events = init_keyboard_listener()
 

--- a/src/lerobot/scripts/lerobot_replay.py
+++ b/src/lerobot/scripts/lerobot_replay.py
@@ -47,6 +47,7 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from pprint import pformat
 
+from lerobot.common.control_utils import smooth_follower_to_action
 from lerobot.configs import parser
 from lerobot.datasets import LeRobotDataset
 from lerobot.processor import (
@@ -70,7 +71,6 @@ from lerobot.robots import (  # noqa: F401
     so_follower,
     unitree_g1,
 )
-from lerobot.common.control_utils import smooth_follower_to_action
 from lerobot.utils.constants import ACTION
 from lerobot.utils.import_utils import register_third_party_plugins
 from lerobot.utils.robot_utils import precise_sleep
@@ -123,19 +123,13 @@ def replay(cfg: ReplayConfig):
     if cfg.smooth_handover_duration_s > 0 and dataset.num_frames > 0:
         robot_obs = robot.get_observation()
         action_keys = getattr(robot, "action_features", {}) or {}
-        pre_replay_pose = {
-            k: robot_obs[k]
-            for k in action_keys
-            if k in robot_obs
-        }
+        pre_replay_pose = {k: robot_obs[k] for k in action_keys if k in robot_obs}
         if not pre_replay_pose:
             pre_replay_pose = {
                 k: v for k, v in robot_obs.items() if isinstance(k, str) and k.endswith(".pos")
             }
         action_array0 = actions[0][ACTION]
-        action0 = {
-            name: action_array0[i] for i, name in enumerate(dataset.features[ACTION]["names"])
-        }
+        action0 = {name: action_array0[i] for i, name in enumerate(dataset.features[ACTION]["names"])}
         first_processed = robot_action_processor((action0, robot_obs))
         logging.info(
             "Smooth handover to episode start (%.2fs @ %d Hz)",
@@ -168,11 +162,7 @@ def replay(cfg: ReplayConfig):
             dt_s = time.perf_counter() - start_episode_t
             precise_sleep(max(1 / dataset.fps - dt_s, 0.0))
     finally:
-        if (
-            cfg.smooth_handover_duration_s > 0
-            and pre_replay_pose
-            and robot.is_connected
-        ):
+        if cfg.smooth_handover_duration_s > 0 and pre_replay_pose and robot.is_connected:
             logging.info(
                 "Smooth return to pre-replay pose (%.2fs @ %d Hz)",
                 cfg.smooth_handover_duration_s,

--- a/src/lerobot/scripts/lerobot_replay.py
+++ b/src/lerobot/scripts/lerobot_replay.py
@@ -69,6 +69,7 @@ from lerobot.robots import (  # noqa: F401
     so_follower,
     unitree_g1,
 )
+from lerobot.common.control_utils import smooth_follower_to_action
 from lerobot.utils.constants import ACTION
 from lerobot.utils.cycle_timer import CycleTimer
 from lerobot.utils.import_utils import register_third_party_plugins
@@ -96,6 +97,9 @@ class ReplayConfig:
     dataset: DatasetReplayConfig
     # Use vocal synthesis to read events.
     play_sounds: bool = True
+    # Smoothly move to episode start (and back on exit). Set 0 to disable.
+    smooth_handover_duration_s: float = 1.0
+    smooth_handover_fps: int = 30
 
 
 @parser.wrap()
@@ -116,6 +120,38 @@ def replay(cfg: ReplayConfig):
     # wrong speed.  It writes nothing, so a missed deadline is a control-stability
     # problem only.
     timer = CycleTimer(dataset.fps, records_data=False)
+
+    # Capture pre-replay pose for optional soft return.
+    pre_replay_pose = None
+    first_processed = None
+    if cfg.smooth_handover_duration_s > 0 and dataset.num_frames > 0:
+        robot_obs = robot.get_observation()
+        action_keys = getattr(robot, "action_features", {}) or {}
+        pre_replay_pose = {
+            k: robot_obs[k]
+            for k in action_keys
+            if k in robot_obs
+        }
+        if not pre_replay_pose:
+            pre_replay_pose = {
+                k: v for k, v in robot_obs.items() if isinstance(k, str) and k.endswith(".pos")
+            }
+        action_array0 = actions[0][ACTION]
+        action0 = {
+            name: action_array0[i] for i, name in enumerate(dataset.features[ACTION]["names"])
+        }
+        first_processed = robot_action_processor((action0, robot_obs))
+        logging.info(
+            "Smooth handover to episode start (%.2fs @ %d Hz)",
+            cfg.smooth_handover_duration_s,
+            cfg.smooth_handover_fps,
+        )
+        smooth_follower_to_action(
+            robot,
+            first_processed,
+            duration_s=cfg.smooth_handover_duration_s,
+            fps=cfg.smooth_handover_fps,
+        )
 
     try:
         log_say("Replaying episode", cfg.play_sounds, blocking=True)
@@ -138,6 +174,25 @@ def replay(cfg: ReplayConfig):
             timer.wait()
     finally:
         timer.log_run_summary()
+        if (
+            cfg.smooth_handover_duration_s > 0
+            and pre_replay_pose
+            and robot.is_connected
+        ):
+            logging.info(
+                "Smooth return to pre-replay pose (%.2fs @ %d Hz)",
+                cfg.smooth_handover_duration_s,
+                cfg.smooth_handover_fps,
+            )
+            try:
+                smooth_follower_to_action(
+                    robot,
+                    pre_replay_pose,
+                    duration_s=cfg.smooth_handover_duration_s,
+                    fps=cfg.smooth_handover_fps,
+                )
+            except Exception:
+                logging.exception("Smooth return to pre-replay pose failed; disconnecting anyway")
         robot.disconnect()
 
 

--- a/src/lerobot/scripts/lerobot_replay.py
+++ b/src/lerobot/scripts/lerobot_replay.py
@@ -70,6 +70,7 @@ from lerobot.robots import (  # noqa: F401
     so_follower,
     unitree_g1,
 )
+from lerobot.common.control_utils import smooth_follower_to_action
 from lerobot.utils.constants import ACTION
 from lerobot.utils.import_utils import register_third_party_plugins
 from lerobot.utils.robot_utils import precise_sleep
@@ -97,6 +98,9 @@ class ReplayConfig:
     dataset: DatasetReplayConfig
     # Use vocal synthesis to read events.
     play_sounds: bool = True
+    # Smoothly move to episode start (and back on exit). Set 0 to disable.
+    smooth_handover_duration_s: float = 1.0
+    smooth_handover_fps: int = 30
 
 
 @parser.wrap()
@@ -112,6 +116,38 @@ def replay(cfg: ReplayConfig):
     actions = dataset.select_columns(ACTION)
 
     robot.connect()
+
+    # Capture pre-replay pose for optional soft return.
+    pre_replay_pose = None
+    first_processed = None
+    if cfg.smooth_handover_duration_s > 0 and dataset.num_frames > 0:
+        robot_obs = robot.get_observation()
+        action_keys = getattr(robot, "action_features", {}) or {}
+        pre_replay_pose = {
+            k: robot_obs[k]
+            for k in action_keys
+            if k in robot_obs
+        }
+        if not pre_replay_pose:
+            pre_replay_pose = {
+                k: v for k, v in robot_obs.items() if isinstance(k, str) and k.endswith(".pos")
+            }
+        action_array0 = actions[0][ACTION]
+        action0 = {
+            name: action_array0[i] for i, name in enumerate(dataset.features[ACTION]["names"])
+        }
+        first_processed = robot_action_processor((action0, robot_obs))
+        logging.info(
+            "Smooth handover to episode start (%.2fs @ %d Hz)",
+            cfg.smooth_handover_duration_s,
+            cfg.smooth_handover_fps,
+        )
+        smooth_follower_to_action(
+            robot,
+            first_processed,
+            duration_s=cfg.smooth_handover_duration_s,
+            fps=cfg.smooth_handover_fps,
+        )
 
     try:
         log_say("Replaying episode", cfg.play_sounds, blocking=True)
@@ -132,6 +168,25 @@ def replay(cfg: ReplayConfig):
             dt_s = time.perf_counter() - start_episode_t
             precise_sleep(max(1 / dataset.fps - dt_s, 0.0))
     finally:
+        if (
+            cfg.smooth_handover_duration_s > 0
+            and pre_replay_pose
+            and robot.is_connected
+        ):
+            logging.info(
+                "Smooth return to pre-replay pose (%.2fs @ %d Hz)",
+                cfg.smooth_handover_duration_s,
+                cfg.smooth_handover_fps,
+            )
+            try:
+                smooth_follower_to_action(
+                    robot,
+                    pre_replay_pose,
+                    duration_s=cfg.smooth_handover_duration_s,
+                    fps=cfg.smooth_handover_fps,
+                )
+            except Exception:
+                logging.exception("Smooth return to pre-replay pose failed; disconnecting anyway")
         robot.disconnect()
 
 

--- a/src/lerobot/scripts/lerobot_replay.py
+++ b/src/lerobot/scripts/lerobot_replay.py
@@ -46,6 +46,7 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from pprint import pformat
 
+from lerobot.common.control_utils import smooth_follower_to_action
 from lerobot.configs import parser
 from lerobot.datasets import LeRobotDataset
 from lerobot.processor import (
@@ -69,7 +70,6 @@ from lerobot.robots import (  # noqa: F401
     so_follower,
     unitree_g1,
 )
-from lerobot.common.control_utils import smooth_follower_to_action
 from lerobot.utils.constants import ACTION
 from lerobot.utils.cycle_timer import CycleTimer
 from lerobot.utils.import_utils import register_third_party_plugins
@@ -127,19 +127,13 @@ def replay(cfg: ReplayConfig):
     if cfg.smooth_handover_duration_s > 0 and dataset.num_frames > 0:
         robot_obs = robot.get_observation()
         action_keys = getattr(robot, "action_features", {}) or {}
-        pre_replay_pose = {
-            k: robot_obs[k]
-            for k in action_keys
-            if k in robot_obs
-        }
+        pre_replay_pose = {k: robot_obs[k] for k in action_keys if k in robot_obs}
         if not pre_replay_pose:
             pre_replay_pose = {
                 k: v for k, v in robot_obs.items() if isinstance(k, str) and k.endswith(".pos")
             }
         action_array0 = actions[0][ACTION]
-        action0 = {
-            name: action_array0[i] for i, name in enumerate(dataset.features[ACTION]["names"])
-        }
+        action0 = {name: action_array0[i] for i, name in enumerate(dataset.features[ACTION]["names"])}
         first_processed = robot_action_processor((action0, robot_obs))
         logging.info(
             "Smooth handover to episode start (%.2fs @ %d Hz)",
@@ -174,11 +168,7 @@ def replay(cfg: ReplayConfig):
             timer.wait()
     finally:
         timer.log_run_summary()
-        if (
-            cfg.smooth_handover_duration_s > 0
-            and pre_replay_pose
-            and robot.is_connected
-        ):
+        if cfg.smooth_handover_duration_s > 0 and pre_replay_pose and robot.is_connected:
             logging.info(
                 "Smooth return to pre-replay pose (%.2fs @ %d Hz)",
                 cfg.smooth_handover_duration_s,

--- a/src/lerobot/scripts/lerobot_teleoperate.py
+++ b/src/lerobot/scripts/lerobot_teleoperate.py
@@ -121,6 +121,7 @@ from lerobot.teleoperators import (  # noqa: F401
     so_leader,
     unitree_g1,
 )
+from lerobot.common.control_utils import smooth_teleop_session_start
 from lerobot.utils.import_utils import register_third_party_plugins
 from lerobot.utils.robot_utils import precise_sleep
 from lerobot.utils.utils import init_logging, move_cursor_up
@@ -150,6 +151,10 @@ class TeleoperateConfig:
     display_port: int | None = None
     # Whether to display compressed (JPEG) images instead of raw frames
     display_compressed_images: bool = False
+    # Soft-start: smoothly align leader/follower before the control loop (set 0 to disable).
+    smooth_handover_duration_s: float = 2.0
+    # Control rate used during the soft-start interpolation.
+    smooth_handover_fps: int = 30
 
 
 def teleop_loop(
@@ -259,6 +264,19 @@ def teleoperate(cfg: TeleoperateConfig):
     robot.connect()
 
     try:
+        if cfg.smooth_handover_duration_s > 0:
+            logging.info(
+                "Smooth handover at session start (%.2fs @ %d Hz)",
+                cfg.smooth_handover_duration_s,
+                cfg.smooth_handover_fps,
+            )
+            smooth_teleop_session_start(
+                robot,
+                teleop,
+                robot_action_processor=robot_action_processor,
+                duration_s=cfg.smooth_handover_duration_s,
+                fps=cfg.smooth_handover_fps,
+            )
         teleop_loop(
             teleop=teleop,
             robot=robot,

--- a/src/lerobot/scripts/lerobot_teleoperate.py
+++ b/src/lerobot/scripts/lerobot_teleoperate.py
@@ -121,6 +121,7 @@ from lerobot.teleoperators import (  # noqa: F401
     so_leader,
     unitree_g1,
 )
+from lerobot.common.control_utils import smooth_teleop_session_start
 from lerobot.utils.cycle_timer import CycleTimer
 from lerobot.utils.import_utils import register_third_party_plugins
 from lerobot.utils.utils import init_logging, move_cursor_up
@@ -150,6 +151,10 @@ class TeleoperateConfig:
     display_port: int | None = None
     # Whether to display compressed (JPEG) images instead of raw frames
     display_compressed_images: bool = False
+    # Soft-start: smoothly align leader/follower before the control loop (set 0 to disable).
+    smooth_handover_duration_s: float = 2.0
+    # Control rate used during the soft-start interpolation.
+    smooth_handover_fps: int = 30
 
 
 def teleop_loop(
@@ -271,6 +276,19 @@ def teleoperate(cfg: TeleoperateConfig):
     robot.connect()
 
     try:
+        if cfg.smooth_handover_duration_s > 0:
+            logging.info(
+                "Smooth handover at session start (%.2fs @ %d Hz)",
+                cfg.smooth_handover_duration_s,
+                cfg.smooth_handover_fps,
+            )
+            smooth_teleop_session_start(
+                robot,
+                teleop,
+                robot_action_processor=robot_action_processor,
+                duration_s=cfg.smooth_handover_duration_s,
+                fps=cfg.smooth_handover_fps,
+            )
         teleop_loop(
             teleop=teleop,
             robot=robot,

--- a/src/lerobot/scripts/lerobot_teleoperate.py
+++ b/src/lerobot/scripts/lerobot_teleoperate.py
@@ -77,6 +77,7 @@ from pprint import pformat
 from lerobot.cameras.opencv import OpenCVCameraConfig  # noqa: F401
 from lerobot.cameras.realsense import RealSenseCameraConfig  # noqa: F401
 from lerobot.cameras.zmq import ZMQCameraConfig  # noqa: F401
+from lerobot.common.control_utils import smooth_teleop_session_start
 from lerobot.configs import parser
 from lerobot.processor import (
     RobotAction,
@@ -121,7 +122,6 @@ from lerobot.teleoperators import (  # noqa: F401
     so_leader,
     unitree_g1,
 )
-from lerobot.common.control_utils import smooth_teleop_session_start
 from lerobot.utils.import_utils import register_third_party_plugins
 from lerobot.utils.robot_utils import precise_sleep
 from lerobot.utils.utils import init_logging, move_cursor_up

--- a/src/lerobot/scripts/lerobot_teleoperate.py
+++ b/src/lerobot/scripts/lerobot_teleoperate.py
@@ -77,6 +77,7 @@ from pprint import pformat
 from lerobot.cameras.opencv import OpenCVCameraConfig  # noqa: F401
 from lerobot.cameras.realsense import RealSenseCameraConfig  # noqa: F401
 from lerobot.cameras.zmq import ZMQCameraConfig  # noqa: F401
+from lerobot.common.control_utils import smooth_teleop_session_start
 from lerobot.configs import parser
 from lerobot.processor import (
     RobotAction,

--- a/tests/common/test_smooth_handover.py
+++ b/tests/common/test_smooth_handover.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for shared smooth-handover helpers used by teleoperate / record / replay."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from lerobot.common.control_utils import (
+    _joint_pos_from_observation,
+    follower_smooth_move_to,
+    smooth_follower_to_action,
+    smooth_teleop_session_start,
+    teleop_smooth_move_to,
+    teleop_supports_feedback,
+)
+
+
+def test_joint_pos_from_observation_prefers_action_keys():
+    obs = {"shoulder.pos": 1.0, "camera": "img", "other": 3}
+    keys = {"shoulder.pos": float, "elbow.pos": float}
+    assert _joint_pos_from_observation(obs, keys) == {"shoulder.pos": 1.0}
+
+
+def test_joint_pos_from_observation_fallback_dot_pos():
+    obs = {"a.pos": 0.1, "b.pos": 0.2, "cam": object()}
+    assert _joint_pos_from_observation(obs, None) == {"a.pos": 0.1, "b.pos": 0.2}
+
+
+def test_teleop_supports_feedback_requires_torque_apis():
+    good = SimpleNamespace(
+        feedback_features={"m.pos": float},
+        enable_torque=lambda: None,
+        disable_torque=lambda: None,
+    )
+    assert teleop_supports_feedback(good) is True
+
+    no_torque = SimpleNamespace(feedback_features={"m.pos": float})
+    assert teleop_supports_feedback(no_torque) is False
+
+    empty = SimpleNamespace(feedback_features={}, enable_torque=lambda: None, disable_torque=lambda: None)
+    assert teleop_supports_feedback(empty) is False
+
+
+def test_follower_smooth_move_to_interpolates_and_sends(monkeypatch):
+    sleeps: list[float] = []
+    monkeypatch.setattr("lerobot.common.control_utils.time.sleep", lambda s: sleeps.append(s))
+
+    robot = MagicMock()
+    current = {"j.pos": 0.0}
+    target = {"j.pos": 10.0}
+    follower_smooth_move_to(robot, current, target, duration_s=0.1, fps=10)
+
+    assert robot.send_action.call_count == 2  # steps = max(int(0.1*10),1)=1 → range(2)
+    first = robot.send_action.call_args_list[0].args[0]
+    last = robot.send_action.call_args_list[-1].args[0]
+    assert first["j.pos"] == pytest.approx(0.0)
+    assert last["j.pos"] == pytest.approx(10.0)
+    assert len(sleeps) == 2
+
+
+def test_teleop_smooth_move_to_enables_torque(monkeypatch):
+    monkeypatch.setattr("lerobot.common.control_utils.time.sleep", lambda s: None)
+    teleop = MagicMock()
+    teleop.get_action.return_value = {"j.pos": 0.0}
+    teleop_smooth_move_to(teleop, {"j.pos": 5.0}, duration_s=0.05, fps=20)
+    teleop.enable_torque.assert_called_once()
+    assert teleop.send_feedback.call_count >= 2
+    assert teleop.send_feedback.call_args_list[-1].args[0]["j.pos"] == pytest.approx(5.0)
+
+
+def test_smooth_teleop_session_start_actuated_moves_leader(monkeypatch):
+    monkeypatch.setattr("lerobot.common.control_utils.time.sleep", lambda s: None)
+    robot = MagicMock()
+    robot.get_observation.return_value = {"m1.pos": 3.0, "m2.pos": 4.0}
+    robot.action_features = {"m1.pos": float, "m2.pos": float}
+
+    teleop = MagicMock()
+    teleop.feedback_features = {"m1.pos": float, "m2.pos": float}
+    teleop.enable_torque = MagicMock()
+    teleop.disable_torque = MagicMock()
+    teleop.get_action.return_value = {"m1.pos": 0.0, "m2.pos": 0.0}
+
+    smooth_teleop_session_start(robot, teleop, duration_s=0.1, fps=10)
+    teleop.enable_torque.assert_called()
+    assert teleop.send_feedback.called
+    final = teleop.send_feedback.call_args_list[-1].args[0]
+    assert final["m1.pos"] == pytest.approx(3.0)
+    assert final["m2.pos"] == pytest.approx(4.0)
+    robot.send_action.assert_not_called()
+
+
+def test_smooth_teleop_session_start_non_actuated_moves_follower(monkeypatch):
+    monkeypatch.setattr("lerobot.common.control_utils.time.sleep", lambda s: None)
+    robot = MagicMock()
+    robot.get_observation.return_value = {"m1.pos": 0.0}
+    robot.action_features = {"m1.pos": float}
+
+    teleop = MagicMock()
+    teleop.feedback_features = {}  # non-actuated
+    teleop.get_action.return_value = {"m1.pos": 9.0}
+
+    def identity_processor(pair):
+        action, _obs = pair
+        return action
+
+    smooth_teleop_session_start(
+        robot, teleop, robot_action_processor=identity_processor, duration_s=0.1, fps=10
+    )
+    assert robot.send_action.called
+    assert robot.send_action.call_args_list[-1].args[0]["m1.pos"] == pytest.approx(9.0)
+    teleop.enable_torque.assert_not_called()
+
+
+def test_smooth_teleop_session_start_duration_zero_is_noop(monkeypatch):
+    robot = MagicMock()
+    teleop = MagicMock()
+    smooth_teleop_session_start(robot, teleop, duration_s=0.0)
+    robot.get_observation.assert_not_called()
+
+
+def test_smooth_follower_to_action(monkeypatch):
+    monkeypatch.setattr("lerobot.common.control_utils.time.sleep", lambda s: None)
+    robot = MagicMock()
+    robot.get_observation.return_value = {"j.pos": 1.0, "cam": "x"}
+    robot.action_features = {"j.pos": float}
+    smooth_follower_to_action(robot, {"j.pos": 5.0}, duration_s=0.1, fps=10)
+    assert robot.send_action.call_args_list[-1].args[0]["j.pos"] == pytest.approx(5.0)

--- a/tests/test_control_robot.py
+++ b/tests/test_control_robot.py
@@ -44,6 +44,7 @@ def test_teleoperate():
         robot=robot_cfg,
         teleop=teleop_cfg,
         teleop_time_s=0.1,
+        smooth_handover_duration_s=0.0,
     )
     teleoperate(cfg)
 
@@ -65,6 +66,7 @@ def test_record_and_resume(tmp_path):
         dataset=dataset_cfg,
         teleop=teleop_cfg,
         play_sounds=False,
+        smooth_handover_duration_s=0.0,
     )
 
     dataset = record(cfg)
@@ -115,6 +117,7 @@ def test_record_and_replay(tmp_path):
         robot=robot_cfg,
         dataset=replay_dataset_cfg,
         play_sounds=False,
+        smooth_handover_duration_s=0.0,
     )
 
     record(record_cfg)

--- a/tests/test_control_robot.py
+++ b/tests/test_control_robot.py
@@ -58,6 +58,7 @@ def test_teleoperate(cadence_log):
         teleop=teleop_cfg,
         fps=30,
         teleop_time_s=0.1,
+        smooth_handover_duration_s=0.0,
     )
     teleoperate(cfg)
 
@@ -86,6 +87,7 @@ def test_record_and_resume(tmp_path):
         dataset=dataset_cfg,
         teleop=teleop_cfg,
         play_sounds=False,
+        smooth_handover_duration_s=0.0,
     )
 
     dataset = record(cfg)
@@ -136,6 +138,7 @@ def test_record_and_replay(tmp_path, cadence_log):
         robot=robot_cfg,
         dataset=replay_dataset_cfg,
         play_sounds=False,
+        smooth_handover_duration_s=0.0,
     )
 
     record(record_cfg)


### PR DESCRIPTION
## Summary
Wires the existing soft-handover helpers (`teleop_smooth_move_to` / `follower_smooth_move_to` in `lerobot.common.control_utils`) into the standard hardware CLIs so sessions **do not snap** on the first controlled frame (and replay returns cleanly).

- **`lerobot-teleoperate` / `lerobot-record`**: optional session start soft-start via `smooth_teleop_session_start` (actuated teleop → slide leader to follower; non-actuated → slide follower to teleop command).
- **`lerobot-replay`**: optional soft move to episode start action, then soft return to pre-replay pose in `finally` (including Ctrl-C / abort).
- High-level helpers: `smooth_teleop_session_start`, `smooth_follower_to_action`, `_joint_pos_from_observation`.
- Config flags: `--smooth_handover_duration_s` (default >0) and `--smooth_handover_fps`; set duration to `0` to disable.

## Motivation
Closes #3537. Smooth-move already exists for DAgger / episodic rollout, but teleoperate, record, and replay still sent the first action at full speed — a common source of gear slap and harsh starts. Prior full-stack attempt (#3538) was closed in favor of rollout work; the CLI gap remained.

Related but intentionally separate: #3954 (startup joint-mismatch *guard* / hard stop). This PR is soft *interpolation*, not a first-frame abort.

## Implementation
| Area | Change |
|------|--------|
| `src/lerobot/common/control_utils.py` | Session-level helpers on top of Maxime’s slerp-style linear joint moves |
| `lerobot_teleoperate.py` / `lerobot_record.py` | Call soft-start after connect |
| `lerobot_replay.py` | Soft-start to first frame + soft return in `finally` |
| `tests/common/test_smooth_handover.py` | Unit coverage (actuated / non-actuated / duration=0 / interpolation) |
| `tests/test_control_robot.py` | Duration 0 so integration stays fast |

## Testing
```bash
pytest -sv tests/common/test_smooth_handover.py
# 9 passed locally
```

Integration scripts: not re-run full hardware suite here (needs `deepdiff`/hardware extras); duration-0 keeps mock teleop/record paths cheap.

## Checklist
- [x] Rebased on latest `upstream/main`
- [x] Tests + no new third-party deps
- [x] Default-on soft-start with explicit disable (`duration_s=0`)
- [x] Does not duplicate #3954’s mismatch guard