### PR TITLE
feat(so_leader): optional sprung gripper trigger for SO leader arms

### DIFF
--- a/src/lerobot/teleoperators/so_leader/config_so_leader.py
+++ b/src/lerobot/teleoperators/so_leader/config_so_leader.py
@@ -34,7 +34,11 @@ class SOLeaderConfig:
 @TeleoperatorConfig.register_subclass("so100_leader")
 @dataclass
 class SOLeaderTeleopConfig(TeleoperatorConfig, SOLeaderConfig):
-    pass
+    # Hold the gripper at its open position with a torque-capped P controller,
+    # so the trigger resists progressively when squeezed and springs back when
+    # released. Servo settings are tuned for the STS3215 gripper and live in
+    # SOLeader.configure().
+    sprung_gripper: bool = False
 
 
 SO100LeaderConfig = SOLeaderTeleopConfig

--- a/src/lerobot/teleoperators/so_leader/so_leader.py
+++ b/src/lerobot/teleoperators/so_leader/so_leader.py
@@ -129,6 +129,16 @@ class SOLeader(Teleoperator):
         self.bus.configure_motors()
         for motor in self.bus.motors:
             self.bus.write("Operating_Mode", motor, OperatingMode.POSITION.value)
+        if self.config.sprung_gripper:
+            # A low P gain makes resistance grow gradually with squeeze depth.
+            # The torque cap sets both the maximum squeeze resistance and the
+            # return force — they cannot be tuned independently. The P write
+            # persists in the servo's EPROM.
+            self.bus.write("P_Coefficient", "gripper", 8, normalize=False)
+            self.bus.write("Acceleration", "gripper", 0, normalize=False)  # 0 = fastest ramp
+            self.bus.write("Torque_Limit", "gripper", 75, normalize=False)
+            self.bus.enable_torque("gripper")
+            self.bus.write("Goal_Position", "gripper", 100.0)  # normalized: fully open
 
     def enable_torque(self) -> None:
         self.bus.enable_torque()


### PR DESCRIPTION
Closes #4080 

### What this does

the SO-arm equivalent of the Koch leader's current-based-position gripper trigger, emulated in position mode since the STS3215 has no current control.

Adds an opt-in `sprung_gripper: bool = False` to `SOLeaderTeleopConfig`. When enabled, `configure()` holds the leader gripper at its calibrated open position with a soft, torque-capped P controller: the trigger resists progressively as you squeeze and springs back to open when released.

### Why these exact values

I tuned them by hand on my SO-101 leader, live on the bus, over ~14 rounds. 

`P=8` is what makes it feel like a spring rather than too hard to squeeze.

`Torque_Limit=75` is the narrow sweet spot where squeezing stays comfortable *and* the return still completes against gearbox friction. 

### How it was tested

- On hardware (SO-101 leader): squeeze feel, abrupt-release return to open, and `get_action()` reads through the armed hold (positions report identically).

### Notes for reviewers

- The flag lives on the shared SO-100/SO-101 config on purpose, both use the same STS3215 gripper servo.
- Torque is released on disconnect via the existing `bus.disconnect()` default
- With the flag off, default behavior is unchanged.