### PR TITLE
fix(datasets): delete video frame staging when discarding an episode

### DIFF
--- a/src/lerobot/datasets/dataset_writer.py
+++ b/src/lerobot/datasets/dataset_writer.py
@@ -369,7 +369,11 @@ class DatasetWriter:
                 self._episodes_since_last_encoding = 0
 
         if episode_data is None:
-            self.clear_episode_buffer(delete_images=len(self._meta.image_keys) > 0)
+            # Keep video staging frames: they are still needed by (batched) video
+            # encoding and are deleted by the encoder once each video is written.
+            self.clear_episode_buffer(
+                delete_images=len(self._meta.image_keys) > 0, preserve_video_frames=True
+            )
 
     def _batch_save_episode_video(self, start_episode: int, end_episode: int | None = None) -> None:
         """Batch save videos for multiple episodes."""
@@ -560,12 +564,20 @@ class DatasetWriter:
         }
         return metadata
 
-    def clear_episode_buffer(self, delete_images: bool = True) -> None:
+    def clear_episode_buffer(self, delete_images: bool = True, preserve_video_frames: bool = False) -> None:
         """Discard the current episode buffer and optionally delete temp images.
 
         Args:
             delete_images: If ``True``, remove temporary image directories
                 written for the current episode.
+            preserve_video_frames: If ``True``, keep the temporary frame
+                directories of ``dtype="video"`` cameras. This is only meant
+                for the post-``save_episode()`` clear, where those frames are
+                still needed by (possibly batched) video encoding and are
+                deleted by the encoder itself. When discarding an episode
+                (e.g. re-recording), leave this ``False`` so the staging
+                frames are removed — otherwise they are picked up by the next
+                take's video encode, which globs the whole directory.
         """
         # Cancel streaming encoder if active
         if self._streaming_encoder is not None:
@@ -579,7 +591,8 @@ class DatasetWriter:
             # save_episode() mutates the buffer. Handle both types here.
             if isinstance(episode_index, np.ndarray):
                 episode_index = episode_index.item() if episode_index.size == 1 else episode_index[0]
-            for cam_key in self._meta.image_keys:
+            cam_keys = self._meta.image_keys if preserve_video_frames else self._meta.camera_keys
+            for cam_key in cam_keys:
                 img_dir = self._get_image_file_dir(episode_index, cam_key)
                 if img_dir.is_dir():
                     shutil.rmtree(img_dir)

--- a/tests/datasets/test_dataset_writer.py
+++ b/tests/datasets/test_dataset_writer.py
@@ -204,6 +204,61 @@ def test_clear_resets_buffer(tmp_path):
     assert dataset.writer.episode_buffer["size"] == 0
 
 
+VIDEO_FEATURES = {
+    **SIMPLE_FEATURES,
+    "observation.images.cam": {"dtype": "video", "shape": (32, 32, 3), "names": ["h", "w", "c"]},
+}
+
+
+def test_clear_removes_video_frame_staging(tmp_path):
+    """Discarding an episode must delete the staging frames of video cameras.
+
+    Staging frames of ``dtype="video"`` cameras live in a per-episode directory
+    that the encoder globs in full. If a discarded take leaves frames behind,
+    the re-recorded take (same episode index, same directory) is encoded with
+    the discarded take's frames appended, so the video no longer matches the
+    episode's parquet data.
+    """
+    dataset = LeRobotDataset.create(
+        repo_id=DUMMY_REPO_ID, fps=DEFAULT_FPS, features=VIDEO_FEATURES, root=tmp_path / "ds"
+    )
+    for _ in range(3):
+        dataset.add_frame(_make_frame(VIDEO_FEATURES))
+
+    writer = dataset.writer
+    staging_dir = writer._get_image_file_dir(0, "observation.images.cam")
+    assert staging_dir.is_dir() and any(staging_dir.iterdir())
+
+    dataset.clear_episode_buffer()  # discard, as on re-record
+
+    assert not staging_dir.exists()
+
+
+def test_save_episode_keeps_video_frame_staging_for_batched_encoding(tmp_path):
+    """The post-save clear must NOT delete video staging frames.
+
+    With ``batch_encoding_size > 1`` the frames of already-saved episodes stay
+    on disk until the batch encode runs; the encoder deletes them afterwards.
+    """
+    dataset = LeRobotDataset.create(
+        repo_id=DUMMY_REPO_ID,
+        fps=DEFAULT_FPS,
+        features=VIDEO_FEATURES,
+        root=tmp_path / "ds",
+        batch_encoding_size=2,
+    )
+    for _ in range(3):
+        dataset.add_frame(_make_frame(VIDEO_FEATURES))
+
+    writer = dataset.writer
+    staging_dir = writer._get_image_file_dir(0, "observation.images.cam")
+    assert staging_dir.is_dir()
+
+    dataset.save_episode()  # first of a batch of 2: no encoding yet
+
+    assert staging_dir.is_dir() and any(staging_dir.iterdir())
+
+
 def test_finalize_is_idempotent(tmp_path):
     """Calling finalize() twice does not raise."""
     dataset = LeRobotDataset.create(


### PR DESCRIPTION
## Summary / Motivation

When an episode is discarded (e.g. re-recording with the left-arrow key in `lerobot-record`), `clear_episode_buffer()` iterates `meta.image_keys` to remove temporary frame directories. For cameras stored as `dtype="video"` (the default), `image_keys` is empty, so the staging PNG frames of the discarded take are never deleted. The re-recorded take reuses the same episode index and directory, and video encoding globs the whole directory — so if the discarded take was longer, its tail frames are appended to the new take's video. The episode's parquet `length` and the encoded video then disagree, and the `to_timestamp` window extends past the episode's actual end.

Measured impact on one of our SO-101 team collections (25 datasets / 758 episodes, recorded with re-recording in the workflow): **235 episodes (31.0%) carried appended frames from discarded takes, adding +32.5% of video duration (1,698.5 s)**. We verified at frame level that the excess content is the discarded take: motion energy matches the main take, with a hard cut at the boundary.

A bare `image_keys` → `camera_keys` swap would break batched encoding: after `save_episode()`, video staging frames must survive until the (possibly batched) encoder consumes and deletes them (#2592). The fix keeps the two call paths apart instead: discarding deletes staging for **all** camera keys, while the post-save clear passes `preserve_video_frames=True` and behaves exactly as before.

## Related issues

- Related: #2592 (batched-encoding behavior this change preserves)

## What changed

- `DatasetWriter.clear_episode_buffer()` gains `preserve_video_frames: bool = False`. The default (discard path — `lerobot_record`, rollout strategies, public `LeRobotDataset.clear_episode_buffer()`) now removes staging directories for all camera keys, video included.
- `save_episode()` calls it with `preserve_video_frames=True`: staging frames of saved episodes are still consumed and deleted by the encoder (immediately, or at batch time with `batch_encoding_size > 1`). No behavior change on the save path.
- No public API break: new keyword argument with a default.
- This also brings the discard path in line with `cleanup_interrupted_episode()`, which already iterates `camera_keys`.

## How was this tested (or how to run locally)

- Tests added (`pytest -q tests/datasets/test_dataset_writer.py -k staging`):
  - `test_clear_removes_video_frame_staging` — discarding deletes video staging. **Fails on current main**, passes with this fix.
  - `test_save_episode_keeps_video_frame_staging_for_batched_encoding` — the post-save clear keeps staging while a batch encode is pending (guards the #2592 behavior).
- The 758-episode measurement above compared parquet `length` against encoded video duration (ffprobe) across the full collection.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest -q tests/datasets/test_dataset_writer.py`)
- [ ] Documentation updated (n/a — behavior fix, docstring updated in-place)
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: #

## Reviewer notes

- The asymmetry (discard deletes, save preserves) is deliberate: after save, the encoder owns the staging directory; after discard, nothing else will ever clean it.
