### PR TITLE
fix(processor): diagnose legacy Hub checkpoints

### DIFF
--- a/src/lerobot/processor/pipeline.py
+++ b/src/lerobot/processor/pipeline.py
@@ -42,6 +42,7 @@ from typing import Any, TypedDict, TypeVar, cast
 
 import torch
 from huggingface_hub import hf_hub_download
+from huggingface_hub.errors import HfHubHTTPError
 from safetensors.torch import load_file, save_file
 
 from lerobot.configs import PipelineFeatureType, PolicyFeature
@@ -864,6 +865,11 @@ class DataProcessorPipeline[TInput, TOutput](HubMixin):
                     return json.load(f), Path(config_path).parent
 
             except Exception as e:
+                if cls._hub_model_requires_migration(model_id, hub_download_kwargs):
+                    cls._suggest_processor_migration(
+                        model_id,
+                        f"Config file '{config_filename}' not found on the Hugging Face Hub",
+                    )
                 raise FileNotFoundError(
                     f"Could not find '{config_filename}' on the HuggingFace Hub at '{model_id}'"
                 ) from e
@@ -1315,6 +1321,43 @@ class DataProcessorPipeline[TInput, TOutput](HubMixin):
 
         # Have JSON files but no processor configs - suggest migration
         return True
+
+    @classmethod
+    def _hub_model_requires_migration(cls, model_id: str, hub_download_kwargs: dict[str, Any]) -> bool:
+        """Check whether a Hub repository contains a legacy LeRobot policy config.
+
+        A missing processor file is not sufficient evidence by itself: the repository
+        may be private, unavailable, or unrelated to LeRobot. This method therefore
+        fetches the policy's ``config.json`` and checks for the feature declarations
+        that identify a LeRobot policy checkpoint. Any lookup or parsing failure is
+        ignored so the original processor-file error remains visible.
+
+        Args:
+            model_id: Hugging Face Hub model repository ID.
+            hub_download_kwargs: Authentication, cache, and revision arguments used
+                for the original processor lookup.
+
+        Returns:
+            True when the repository has a legacy LeRobot policy configuration.
+        """
+        try:
+            config_path = hf_hub_download(
+                repo_id=model_id,
+                filename="config.json",
+                repo_type="model",
+                **hub_download_kwargs,
+            )
+            with open(config_path) as f:
+                config = json.load(f)
+        except (HfHubHTTPError, json.JSONDecodeError, OSError):
+            return False
+
+        return (
+            isinstance(config, dict)
+            and isinstance(config.get("type"), str)
+            and isinstance(config.get("input_features"), dict)
+            and isinstance(config.get("output_features"), dict)
+        )
 
     @classmethod
     def _is_processor_config(cls, config: Any) -> bool:

--- a/tests/processor/test_pipeline_from_pretrained_helpers.py
+++ b/tests/processor/test_pipeline_from_pretrained_helpers.py
@@ -27,6 +27,7 @@ from pathlib import Path
 
 import pytest
 
+import lerobot.processor.pipeline as pipeline_module
 from lerobot.processor.pipeline import DataProcessorPipeline, ProcessorMigrationError
 
 # Simplified Config Loading Tests
@@ -96,6 +97,64 @@ def test_load_config_nonexistent_path_tries_hub():
     # This path doesn't exist locally, should try Hub
     with pytest.raises(FileNotFoundError, match="on the HuggingFace Hub"):
         DataProcessorPipeline._load_config("nonexistent/path", "processor.json", {})
+
+
+def test_load_config_legacy_hub_policy_suggests_migration(tmp_path, monkeypatch):
+    """Test that a missing Hub processor config identifies a legacy LeRobot policy."""
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "type": "diffusion",
+                "input_features": {"observation.state": {"shape": [2], "type": "STATE"}},
+                "output_features": {"action": {"shape": [2], "type": "ACTION"}},
+            }
+        )
+    )
+
+    def fake_hf_hub_download(*, filename, **kwargs):  # noqa: ARG001
+        if filename == "config.json":
+            return str(config_path)
+        raise FileNotFoundError(filename)
+
+    monkeypatch.setattr(pipeline_module, "hf_hub_download", fake_hf_hub_download)
+
+    with pytest.raises(ProcessorMigrationError) as exc_info:
+        DataProcessorPipeline._load_config(
+            "lerobot/diffusion_pusht", "policy_preprocessor.json", {"revision": "main"}
+        )
+
+    error = exc_info.value
+    assert error.model_path == "lerobot/diffusion_pusht"
+    assert "migrate_policy_normalization.py" in error.migration_command
+    assert "policy_preprocessor.json" in error.original_error
+
+
+def test_load_config_missing_hub_processor_does_not_misclassify_other_models(tmp_path, monkeypatch):
+    """Test that non-LeRobot Hub configs retain the original missing-file error."""
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({"architectures": ["SomeModel"]}))
+
+    def fake_hf_hub_download(*, filename, **kwargs):  # noqa: ARG001
+        if filename == "config.json":
+            return str(config_path)
+        raise FileNotFoundError(filename)
+
+    monkeypatch.setattr(pipeline_module, "hf_hub_download", fake_hf_hub_download)
+
+    with pytest.raises(FileNotFoundError, match="on the HuggingFace Hub"):
+        DataProcessorPipeline._load_config("someone/model", "policy_preprocessor.json", {})
+
+
+def test_hub_migration_detection_ignores_config_lookup_errors(monkeypatch):
+    """Test that a failed diagnostic lookup never hides the original Hub error."""
+
+    def fake_hf_hub_download(**kwargs):  # noqa: ARG001
+        raise OSError("offline")
+
+    monkeypatch.setattr(pipeline_module, "hf_hub_download", fake_hf_hub_download)
+
+    assert not DataProcessorPipeline._hub_model_requires_migration("someone/model", {})
 
 
 # Config Validation Tests


### PR DESCRIPTION
## Summary / Motivation

Legacy LeRobot Hub checkpoints such as `lerobot/diffusion_pusht` predate the split processor files. Loading them currently fails with a generic missing `policy_preprocessor.json` error, even though LeRobot already ships a migration command for this exact format.

This change recognizes that case and raises `ProcessorMigrationError` with the actionable migration command. It deliberately does not create an empty runtime processor: normalization statistics are part of the checkpoint contract, so silently falling back could produce invalid policy inputs.

## Related issues

- Related: #4047

## What changed

- When a processor file is missing on the Hub, inspect the repository's `config.json` using the same revision/auth/cache arguments.
- Identify a legacy LeRobot policy only when `type`, `input_features`, and `output_features` have the expected shapes.
- Reuse the existing migration error and `migrate_policy_normalization.py` command.
- Preserve the original missing-file error for unrelated, inaccessible, offline, or malformed repositories.
- Add tests for legacy detection, unrelated model configs, and failed diagnostic lookups.

No serialized format or public API changes are introduced.

## How was this tested (or how to run locally)

- `uv run pytest tests/processor -q` — 312 passed, 107 skipped.
- `uv run pre-commit run --files src/lerobot/processor/pipeline.py tests/processor/test_pipeline_from_pretrained_helpers.py` — all applicable hooks passed.
- Manual Hub check against `lerobot/diffusion_pusht` at revision `main`: `_load_config(...)` now raises `ProcessorMigrationError` and recommends `python src/lerobot/processor/migrate_policy_normalization.py --pretrained-path lerobot/diffusion_pusht`.

## Checklist (required before merge)

- [x] Linting/formatting run on changed files
- [x] Relevant processor tests pass locally
- [x] No documentation update needed; the change improves an existing error path
- [ ] CI is green
- [x] Community Review: Reviewed [#4112](https://github.com/huggingface/lerobot/pull/4112#pullrequestreview-4760538462)

## Reviewer notes

Please focus on whether `type` plus input/output feature mappings is a sufficiently conservative legacy-policy signature. The diagnostic catches Hub/JSON/I/O failures so it cannot mask the original processor lookup error.

AI assistance disclosure: substantial AI assistance (OpenAI Codex) was used for issue investigation, implementation drafting, and test drafting. The contribution is being kept as a draft so the submitter can complete a line-by-line review before requesting maintainer review.
