### PR TITLE
feat(vla_jepa): add multi-horizon world model training

### DIFF
--- a/docs/source/vla_jepa.mdx
+++ b/docs/source/vla_jepa.mdx
@@ -64,26 +64,58 @@ All checkpoints use `Qwen/Qwen3-VL-2B-Instruct` as the language backbone.
 
 Key parameters in `VLAJEPAConfig`:
 
-| Parameter                 | Default | Description                                                                                                                                                                     |
-| ------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `chunk_size`              | 7       | Number of actions predicted per inference call                                                                                                                                  |
-| `n_action_steps`          | 7       | Steps executed from the predicted chunk before re-planning                                                                                                                      |
-| `num_video_frames`        | 8       | Video clip length fed to the world model                                                                                                                                        |
-| `enable_world_model`      | `True`  | Whether to load and train the V-JEPA2 predictor                                                                                                                                 |
-| `world_model_loss_weight` | 0.1     | Weight of the JEPA prediction loss relative to the action loss                                                                                                                  |
-| `num_inference_timesteps` | 4       | Euler integration steps for action denoising                                                                                                                                    |
-| `freeze_qwen`             | `False` | Freeze the Qwen3-VL backbone and only train the action head                                                                                                                     |
-| `reinit_modules`          | `None`  | Key prefixes allowed to be randomly re-initialised on load (for cross-embodiment transfer, see [Fine-tuning on a different embodiment](#fine-tuning-on-a-different-embodiment)) |
-| `gripper_dim`             | 6       | Index of the gripper dimension in the action vector (e.g. 6 for a 7-DoF arm with gripper as the last joint)                                                                     |
-| `gripper_threshold`       | 0.5     | Threshold used by `pre_snap_gripper_action` and `binarize_gripper_action` to binarize the gripper dimension                                                                     |
-| `pre_snap_gripper_action` | `True`  | Snap the gripper dim to {0, 1} before unnormalization. Set to `False` for robots without a binary gripper                                                                       |
-| `binarize_gripper_action` | `True`  | Binarize the gripper dim to {-1, 1} after unnormalization. Set to `False` for robots without a binary gripper                                                                   |
+| Parameter                     | Default | Description                                                                                                                                                                     |
+| ----------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `chunk_size`                  | 7       | Number of actions predicted per inference call                                                                                                                                  |
+| `n_action_steps`              | 7       | Steps executed from the predicted chunk before re-planning                                                                                                                      |
+| `num_video_frames`            | 8       | Video clip length fed to the world model                                                                                                                                        |
+| `enable_world_model`          | `True`  | Whether to load and train the V-JEPA2 predictor                                                                                                                                 |
+| `world_model_loss_weight`     | 0.1     | Weight of the JEPA prediction loss relative to the action loss                                                                                                                  |
+| `prediction_horizons`         | `None`  | Optional encoded-position horizons for experimental multi-horizon world-model training; supported values are 1 and 2                                                            |
+| `temporal_consistency_weight` | 0.0     | Weight of the recursive one-step versus direct two-step consistency loss; requires prediction horizons 1 and 2                                                                  |
+| `num_inference_timesteps`     | 4       | Euler integration steps for action denoising                                                                                                                                    |
+| `freeze_qwen`                 | `False` | Freeze the Qwen3-VL backbone and only train the action head                                                                                                                     |
+| `reinit_modules`              | `None`  | Key prefixes allowed to be randomly re-initialised on load (for cross-embodiment transfer, see [Fine-tuning on a different embodiment](#fine-tuning-on-a-different-embodiment)) |
+| `gripper_dim`                 | 6       | Index of the gripper dimension in the action vector (e.g. 6 for a 7-DoF arm with gripper as the last joint)                                                                     |
+| `gripper_threshold`           | 0.5     | Threshold used by `pre_snap_gripper_action` and `binarize_gripper_action` to binarize the gripper dimension                                                                     |
+| `pre_snap_gripper_action`     | `True`  | Snap the gripper dim to {0, 1} before unnormalization. Set to `False` for robots without a binary gripper                                                                       |
+| `binarize_gripper_action`     | `True`  | Binarize the gripper dim to {-1, 1} after unnormalization. Set to `False` for robots without a binary gripper                                                                   |
 
 ---
 
 ## Training
 
 Number of training steps may vary based on dataset size and compute budget. The original paper pretrained for 50k on ssv2 + droid jointly, then additional 30k steps for LIBERO, but fewer steps may still yield good performance when fine-tuning from the provided pretrained checkpoints.
+
+### Experimental multi-horizon world-model training
+
+Set `prediction_horizons` to opt in to direct latent prediction at multiple temporal
+horizons:
+
+```bash
+lerobot-train \
+  --policy.path=lerobot/VLA-JEPA-Pretrain \
+  --policy.repo_id=your_org/your_repo \
+  --policy.prediction_horizons='[1,2]' \
+  --policy.temporal_consistency_weight=0.1 \
+  --dataset.repo_id=your_org/your_dataset
+```
+
+Horizons are measured in **encoded temporal positions**, not raw frames. One encoded
+position spans `jepa_tubelet_size` raw frames, so the default tubelet size of 2 makes
+horizons 1 and 2 correspond to 2 and 4 raw frames. Only horizons 1 and 2 are currently
+supported. A positive `temporal_consistency_weight` also requires both horizons: it
+compares the direct two-step prediction with a recursive one-step prediction.
+
+The mode excludes padded temporal spans from every loss. It logs `wm_loss_h1` and/or
+`wm_loss_h2`, their valid-origin counts (`wm_valid_h1` and `wm_valid_h2`), the combined
+`wm_direct_loss`, and `wm_consistency_loss` when consistency is enabled.
+
+This feature is disabled by default to preserve checkpoint and training behavior.
+V-JEPA2 uses bidirectional temporal attention, so the opt-in path encodes one raw-frame
+prefix per encoded temporal position to prevent target leakage. This is substantially
+more expensive than the legacy single full-clip encoder call: with the default 8 frames
+and tubelet size 2, the video encoder runs four times per clip.
 
 ### Full training from scratch
 

--- a/src/lerobot/policies/vla_jepa/configuration_vla_jepa.py
+++ b/src/lerobot/policies/vla_jepa/configuration_vla_jepa.py
@@ -14,7 +14,9 @@
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass, field
+from numbers import Integral
 
 from lerobot.configs.policies import PreTrainedConfig
 from lerobot.configs.types import NormalizationMode
@@ -81,6 +83,8 @@ class VLAJEPAConfig(PreTrainedConfig):
     predictor_dropout: float = 0.0
     world_model_loss_weight: float = 0.1
     jepa_tubelet_size: int = 2  # must match the encoder (e.g. 2 for vjepa2-vitl-fpc64-256)
+    prediction_horizons: tuple[int, ...] | None = None
+    temporal_consistency_weight: float = 0.0
     repeated_diffusion_steps: int = 8  # independent noise draws per batch item (CogACT-style)
 
     resize_images_to: tuple[int, int] | None = None
@@ -112,6 +116,39 @@ class VLAJEPAConfig(PreTrainedConfig):
                 f"`video_horizon` ({self.num_video_frames}) must be >= 2 * `jepa_tubelet_size` "
                 f"({self.jepa_tubelet_size}) to have at least one context and one GT temporal position."
             )
+        if not math.isfinite(self.temporal_consistency_weight) or self.temporal_consistency_weight < 0:
+            raise ValueError("`temporal_consistency_weight` must be finite and >= 0.")
+        if self.prediction_horizons is None:
+            if self.temporal_consistency_weight > 0:
+                raise ValueError("Positive temporal consistency requires `prediction_horizons`.")
+            return
+
+        self.prediction_horizons = tuple(self.prediction_horizons)
+        if not self.enable_world_model:
+            raise ValueError("`prediction_horizons` requires `enable_world_model=True`.")
+        if not self.prediction_horizons:
+            raise ValueError("`prediction_horizons` must not be empty when enabled.")
+        if any(
+            isinstance(horizon, bool) or not isinstance(horizon, Integral)
+            for horizon in self.prediction_horizons
+        ):
+            raise ValueError("`prediction_horizons` must contain only positive integers.")
+        self.prediction_horizons = tuple(int(horizon) for horizon in self.prediction_horizons)
+        if any(horizon <= 0 for horizon in self.prediction_horizons):
+            raise ValueError("`prediction_horizons` must contain only positive integers.")
+        if tuple(sorted(set(self.prediction_horizons))) != self.prediction_horizons:
+            raise ValueError("`prediction_horizons` must be strictly increasing and unique.")
+        if self.prediction_horizons[-1] > 2:
+            raise ValueError("Only encoded temporal horizons 1 and 2 are supported.")
+        if self.num_video_frames % self.jepa_tubelet_size != 0:
+            raise ValueError(
+                "`num_video_frames` must be divisible by `jepa_tubelet_size` in multi-horizon mode."
+            )
+        num_encoded_frames = self.num_video_frames // self.jepa_tubelet_size
+        if self.prediction_horizons[-1] >= num_encoded_frames:
+            raise ValueError("Every prediction horizon must be smaller than the encoded video length.")
+        if self.temporal_consistency_weight > 0 and not {1, 2}.issubset(self.prediction_horizons):
+            raise ValueError("Positive temporal consistency requires prediction horizons 1 and 2.")
 
     def validate_features(self) -> None:
         if not self.image_features:

--- a/src/lerobot/policies/vla_jepa/modeling_vla_jepa.py
+++ b/src/lerobot/policies/vla_jepa/modeling_vla_jepa.py
@@ -39,6 +39,62 @@ from .configuration_vla_jepa import VLAJEPAConfig
 from .qwen_interface import Qwen3VLInterface
 from .world_model import ActionConditionedVideoPredictor
 
+
+def _encoded_video_validity(video_is_pad: Tensor, tubelet_size: int) -> Tensor:
+    """Combine view/tubelet padding and invalidate every position after the first invalid one."""
+    if video_is_pad.ndim != 3:
+        raise ValueError("`video_is_pad` must have shape [B, V, T].")
+    if tubelet_size <= 0 or video_is_pad.shape[-1] % tubelet_size != 0:
+        raise ValueError("Video mask length must be divisible by a positive tubelet size.")
+
+    batch_size, num_views, num_frames = video_is_pad.shape
+    num_encoded_frames = num_frames // tubelet_size
+    grouped = video_is_pad.to(dtype=torch.bool).reshape(
+        batch_size, num_views, num_encoded_frames, tubelet_size
+    )
+    encoded_valid = (~grouped).all(dim=3).all(dim=1)
+    return encoded_valid.cumprod(dim=1).bool()
+
+
+def _horizon_validity(encoded_valid: Tensor, horizon: int) -> Tensor:
+    """Return valid origins whose complete context-to-target span is valid."""
+    if encoded_valid.ndim != 2:
+        raise ValueError("`encoded_valid` must have shape [B, T].")
+    if horizon <= 0 or horizon >= encoded_valid.shape[1]:
+        raise ValueError("Horizon must be positive and smaller than the encoded sequence length.")
+    return encoded_valid.unfold(dimension=1, size=horizon + 1, step=1).all(dim=2)
+
+
+def _masked_l1_components(prediction: Tensor, target: Tensor, valid_origins: Tensor) -> tuple[Tensor, Tensor]:
+    """Return an L1 numerator and scalar-element denominator for masked latent states."""
+    if prediction.shape != target.shape or prediction.ndim != 4:
+        raise ValueError("Prediction and target must share shape [B, T, P, D].")
+    if valid_origins.shape != prediction.shape[:2]:
+        raise ValueError("`valid_origins` must match the prediction batch and temporal dimensions.")
+    error = (prediction - target).abs()
+    mask = valid_origins.to(device=error.device, dtype=torch.bool)[:, :, None, None].expand_as(error)
+    numerator = error.masked_select(mask).sum()
+    denominator = mask.sum().to(error.dtype)
+    return numerator, denominator
+
+
+def _safe_ratio(numerator: Tensor, denominator: Tensor) -> Tensor:
+    """Divide masked loss components while returning differentiable zero when all entries are invalid."""
+    return numerator / denominator.clamp_min(1)
+
+
+def _action_token_windows(action_tokens: Tensor, horizon: int, num_origins: int) -> Tensor:
+    """Collect ordered Qwen transition-token groups for each prediction origin."""
+    if action_tokens.ndim != 4:
+        raise ValueError("`action_tokens` must have shape [B, T-1, A, Q].")
+    if horizon <= 0 or num_origins <= 0 or num_origins + horizon - 1 > action_tokens.shape[1]:
+        raise ValueError("Action-token sequence is too short for the requested horizon and origins.")
+    windows = torch.stack(
+        [action_tokens[:, offset : offset + num_origins] for offset in range(horizon)], dim=2
+    )
+    return windows.flatten(2, 3)
+
+
 # ============================================================================
 # Native VLA-JEPA Model - follows original starVLA VLA_JEPA.py implementation
 # ============================================================================
@@ -92,6 +148,11 @@ class VLAJEPAModel(nn.Module):
             self.video_processor = AutoVideoProcessor.from_pretrained(config.jepa_encoder_name)
             num_views = config.jepa_tubelet_size
             tubelet_size = self.video_encoder.config.tubelet_size
+            if config.prediction_horizons is not None and tubelet_size != config.jepa_tubelet_size:
+                raise ValueError(
+                    "Multi-horizon mode requires `jepa_tubelet_size` to match the video encoder's "
+                    f"tubelet size ({tubelet_size})."
+                )
             image_size = getattr(self.video_encoder.config, "image_size", None)
             if image_size is None:
                 first_image_shape = next(iter(config.image_features.values())).shape
@@ -194,15 +255,157 @@ class VLAJEPAModel(nn.Module):
             )
         return embodied_action_tokens, action_tokens
 
-    def _world_model_loss(self, videos: Tensor, action_tokens: Tensor) -> Tensor:
+    def _multi_horizon_world_model_loss(
+        self,
+        video_embeddings: Tensor,
+        action_tokens: Tensor,
+        video_is_pad: Tensor,
+        tubelet_size: int,
+    ) -> tuple[Tensor, dict[str, Tensor]]:
+        """Compute direct encoded-position losses for the configured research horizons."""
+        horizons = self.config.prediction_horizons
+        if horizons is None:
+            raise ValueError("Multi-horizon loss requires configured prediction horizons.")
+
+        batch_size = video_embeddings.shape[0]
+        num_encoded_frames = self.config.num_video_frames // tubelet_size
+        if video_embeddings.shape[1] % num_encoded_frames != 0:
+            raise ValueError("Video-embedding tokens must divide evenly into encoded temporal positions.")
+        tokens_per_frame = video_embeddings.shape[1] // num_encoded_frames
+        states = video_embeddings.reshape(
+            batch_size, num_encoded_frames, tokens_per_frame, video_embeddings.shape[2]
+        ).float()
+
+        tokens_per_action = self.config.num_action_tokens_per_timestep
+        expected_action_tokens = (num_encoded_frames - 1) * tokens_per_action
+        if action_tokens.shape[1] != expected_action_tokens:
+            raise ValueError(
+                "Multi-horizon mode requires exactly "
+                f"{expected_action_tokens} Qwen action tokens, got {action_tokens.shape[1]}."
+            )
+        action_tokens = action_tokens.reshape(
+            batch_size, num_encoded_frames - 1, tokens_per_action, action_tokens.shape[2]
+        )
+
+        encoded_valid = _encoded_video_validity(video_is_pad, tubelet_size)
+        numerators: list[Tensor] = []
+        denominators: list[Tensor] = []
+        metrics: dict[str, Tensor] = {}
+        direct_predictions: dict[int, Tensor] = {}
+        valid_origins_by_horizon: dict[int, Tensor] = {}
+
+        for horizon in horizons:
+            num_origins = num_encoded_frames - horizon
+            context = states[:, :num_origins]
+            target = states[:, horizon:]
+            conditioning = _action_token_windows(action_tokens, horizon, num_origins)
+            prediction = self.video_predictor(
+                context.flatten(1, 2), conditioning.flatten(1, 2).float()
+            ).reshape_as(target)
+            valid_origins = _horizon_validity(encoded_valid, horizon)
+            direct_predictions[horizon] = prediction
+            valid_origins_by_horizon[horizon] = valid_origins
+            numerator, denominator = _masked_l1_components(prediction, target, valid_origins)
+            numerators.append(numerator)
+            denominators.append(denominator)
+            metrics[f"wm_loss_h{horizon}"] = _safe_ratio(numerator, denominator).detach()
+            metrics[f"wm_valid_h{horizon}"] = valid_origins.sum().to(prediction.dtype)
+
+        direct_loss = _safe_ratio(torch.stack(numerators).sum(), torch.stack(denominators).sum())
+        metrics["wm_direct_loss"] = direct_loss.detach()
+        if self.config.temporal_consistency_weight == 0:
+            return direct_loss, metrics
+
+        num_recursive_origins = num_encoded_frames - 2
+        recursive_input = direct_predictions[1][:, :num_recursive_origins].detach()
+        recursive_action_tokens = action_tokens[:, 1 : 1 + num_recursive_origins]
+        with torch.no_grad():
+            recursive_prediction = self.video_predictor(
+                recursive_input.flatten(1, 2), recursive_action_tokens.flatten(1, 2).float()
+            ).reshape_as(direct_predictions[2])
+        consistency_numerator, consistency_denominator = _masked_l1_components(
+            direct_predictions[2], recursive_prediction.detach(), valid_origins_by_horizon[2]
+        )
+        consistency_loss = _safe_ratio(consistency_numerator, consistency_denominator)
+        metrics["wm_consistency_loss"] = consistency_loss.detach()
+        return direct_loss + self.config.temporal_consistency_weight * consistency_loss, metrics
+
+    def _causal_video_embeddings(
+        self,
+        video_pixels: Tensor,
+        batch_size: int,
+        num_views: int,
+        tubelet_size: int,
+    ) -> Tensor:
+        """Encode every temporal position from only its raw-frame prefix."""
+        if video_pixels.ndim != 5:
+            raise ValueError("Processed videos must have shape [B*V, T, C, H, W].")
+        if video_pixels.shape[0] != batch_size * num_views:
+            raise ValueError("Processed video batch must equal batch size times the number of views.")
+        if video_pixels.shape[1] != self.config.num_video_frames:
+            raise ValueError("Processed video length must match configured `num_video_frames`.")
+        if tubelet_size <= 0 or video_pixels.shape[1] % tubelet_size != 0:
+            raise ValueError("Processed video length must be divisible by a positive tubelet size.")
+
+        num_encoded_frames = video_pixels.shape[1] // tubelet_size
+        causal_positions: list[Tensor] = []
+        tokens_per_position: int | None = None
+        hidden_size: int | None = None
+        for position in range(num_encoded_frames):
+            prefix_frames = (position + 1) * tubelet_size
+            prefix_embeddings = self.video_encoder.get_vision_features(
+                pixel_values_videos=video_pixels[:, :prefix_frames]
+            )
+            if prefix_embeddings.ndim != 3 or prefix_embeddings.shape[0] != video_pixels.shape[0]:
+                raise ValueError("Video encoder must return embeddings with shape [B*V, tokens, D].")
+            if prefix_embeddings.shape[1] % (position + 1) != 0:
+                raise ValueError("Video-embedding tokens must divide evenly across encoded positions.")
+
+            current_tokens_per_position = prefix_embeddings.shape[1] // (position + 1)
+            if tokens_per_position is None:
+                tokens_per_position = current_tokens_per_position
+                hidden_size = prefix_embeddings.shape[2]
+            elif (
+                current_tokens_per_position != tokens_per_position
+                or prefix_embeddings.shape[2] != hidden_size
+            ):
+                raise ValueError("Video encoder must keep spatial token and hidden dimensions stable.")
+            # Clone the suffix so the list does not retain every larger prefix tensor's storage.
+            causal_positions.append(prefix_embeddings[:, -current_tokens_per_position:].clone())
+
+        causal_embeddings = torch.stack(causal_positions, dim=1)
+        causal_embeddings = causal_embeddings.reshape(
+            batch_size,
+            num_views,
+            num_encoded_frames,
+            causal_embeddings.shape[2],
+            causal_embeddings.shape[3],
+        )
+        causal_embeddings = causal_embeddings.permute(0, 2, 3, 1, 4).flatten(3, 4)
+        return causal_embeddings.flatten(1, 2)
+
+    def _world_model_loss(
+        self, videos: Tensor, action_tokens: Tensor, video_is_pad: Tensor | None = None
+    ) -> Tensor | tuple[Tensor, dict[str, Tensor]]:
         """JEPA encode + predictor L1 loss. `videos` is [B, V, T, C, H, W] float in [0, 1]."""
+        if self.config.prediction_horizons is not None:
+            if video_is_pad is None:
+                video_is_pad = torch.zeros(videos.shape[:3], dtype=torch.bool, device=videos.device)
+            if video_is_pad.shape != videos.shape[:3]:
+                raise ValueError("`video_is_pad` must match video batch, view, and temporal dimensions.")
+            video_is_pad = video_is_pad.to(device=videos.device, dtype=torch.bool)
+
         # Match the world model's expected view count: pad with the first view, or trim extras.
         num_views = self.config.jepa_tubelet_size
         if videos.shape[1] < num_views:
             missing = num_views - videos.shape[1]
             videos = torch.cat([videos, videos[:, :1].repeat(1, missing, 1, 1, 1, 1)], dim=1)
+            if video_is_pad is not None:
+                video_is_pad = torch.cat([video_is_pad, video_is_pad[:, :1].repeat(1, missing, 1)], dim=1)
         elif videos.shape[1] > num_views:
             videos = videos[:, :num_views]
+            if video_is_pad is not None:
+                video_is_pad = video_is_pad[:, :num_views]
 
         b, v, t_frames, c, h_img, w_img = videos.shape
         flat = videos.reshape(b * v, t_frames, c, h_img, w_img)
@@ -214,12 +417,27 @@ class VLAJEPAModel(nn.Module):
             do_rescale=False,
         )["pixel_values_videos"]  # [B*V, T, C, H, W]
 
-        with torch.no_grad():
-            video_embeddings = self.video_encoder.get_vision_features(pixel_values_videos=video_pixels)
-            # Merge views: [B*V, ...] -> [B, ..., V*embed_dim]
-            video_embeddings = torch.cat(torch.chunk(video_embeddings, chunks=v, dim=0), dim=2)
-
         tubelet_size = self.video_encoder.config.tubelet_size
+        with torch.no_grad():
+            if self.config.prediction_horizons is None:
+                video_embeddings = self.video_encoder.get_vision_features(pixel_values_videos=video_pixels)
+                # Preserve the legacy checkpoint path exactly when the research feature is disabled.
+                video_embeddings = torch.cat(torch.chunk(video_embeddings, chunks=v, dim=0), dim=2)
+            else:
+                # V-JEPA2 uses bidirectional temporal attention. Encode one raw-frame prefix per
+                # temporal position so context latents cannot observe future targets or padding.
+                video_embeddings = self._causal_video_embeddings(
+                    video_pixels,
+                    batch_size=b,
+                    num_views=v,
+                    tubelet_size=tubelet_size,
+                )
+
+        if self.config.prediction_horizons is not None:
+            return self._multi_horizon_world_model_loss(
+                video_embeddings, action_tokens, video_is_pad, tubelet_size
+            )
+
         # num_video_frames raw frames → t_enc_total temporal positions after tubelet compression
         t_enc_total = self.config.num_video_frames // tubelet_size
         if t_enc_total < 2:
@@ -267,22 +485,32 @@ class VLAJEPAModel(nn.Module):
         actions: Tensor | None = None,
         state: Tensor | None = None,
         action_is_pad: Tensor | None = None,
+        video_is_pad: Tensor | None = None,
     ) -> dict[str, Tensor]:
         """Native forward: Qwen encode → optional world-model loss → optional action-head loss."""
         embodied_action_tokens, action_tokens = self._encode_qwen(
             images, instructions, need_action_tokens=self.config.enable_world_model
         )
 
+        wm_metrics: dict[str, Tensor] = {}
         if self.config.enable_world_model and videos is not None:
-            wm_loss = self._world_model_loss(videos, action_tokens)
+            wm_result = self._world_model_loss(videos, action_tokens, video_is_pad)
+            if isinstance(wm_result, tuple):
+                wm_loss, wm_metrics = wm_result
+            else:
+                wm_loss = wm_result
         else:
             wm_loss = torch.zeros((), device=embodied_action_tokens.device)
 
         if actions is None:
-            return {"wm_loss": wm_loss}
+            return {"wm_loss": wm_loss, **wm_metrics}
 
         action_loss = self._action_loss(embodied_action_tokens, actions, state, action_is_pad)
-        return {"action_loss": action_loss, "wm_loss": wm_loss * self.config.world_model_loss_weight}
+        return {
+            "action_loss": action_loss,
+            "wm_loss": wm_loss * self.config.world_model_loss_weight,
+            **wm_metrics,
+        }
 
     # ---- Native predict_action (follows original VLA_JEPA.predict_action) ----
 
@@ -389,6 +617,20 @@ class VLAJEPAPolicy(PreTrainedPolicy):
         if self.model.config.enable_world_model and training:
             views = [batch[k].unsqueeze(1) if batch[k].ndim == 4 else batch[k] for k in image_keys]
             inputs["videos"] = self.model.qwen.to_pixel_values(torch.stack(views, dim=1))
+            if self.model.config.prediction_horizons is not None:
+                view_masks = [
+                    batch.get(
+                        f"{key}_is_pad",
+                        torch.zeros(
+                            batch_size,
+                            view.shape[1],
+                            dtype=torch.bool,
+                            device=view.device,
+                        ),
+                    )
+                    for key, view in zip(image_keys, views, strict=True)
+                ]
+                inputs["video_is_pad"] = torch.stack(view_masks, dim=1)
 
         actions = batch.get(ACTION)
         if actions is not None:

--- a/tests/policies/vla_jepa/test_configuration.py
+++ b/tests/policies/vla_jepa/test_configuration.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import draccus
 import pytest
 from conftest import ACTION_DIM, ACTION_HORIZON, IMAGE_SIZE, NUM_VIDEO_FRAMES, STATE_DIM, make_config
 
@@ -55,3 +56,42 @@ def test_validate_features_sets_action_dim_from_feature() -> None:
     config = make_config(action_dim=6, state_dim=10)
     assert config.action_dim == 6
     assert config.state_dim == 10
+
+
+def test_legacy_config_omission_disables_multihorizon() -> None:
+    config = draccus.decode(VLAJEPAConfig, {"device": "cpu"})
+    assert config.prediction_horizons is None
+    assert config.temporal_consistency_weight == 0.0
+
+
+def test_multihorizon_tuple_serializes_as_json_list() -> None:
+    config = VLAJEPAConfig(device="cpu", prediction_horizons=[1, 2])
+    assert config.prediction_horizons == (1, 2)
+    assert draccus.encode(config)["prediction_horizons"] == [1, 2]
+
+
+@pytest.mark.parametrize(
+    "kwargs,match",
+    [
+        ({"prediction_horizons": []}, "must not be empty"),
+        ({"prediction_horizons": [0, 1]}, "positive integers"),
+        ({"prediction_horizons": [1.5]}, "positive integers"),
+        ({"prediction_horizons": [True]}, "positive integers"),
+        ({"prediction_horizons": [2, 1]}, "strictly increasing"),
+        ({"prediction_horizons": [1, 1]}, "strictly increasing"),
+        ({"prediction_horizons": [1, 3]}, "Only encoded temporal horizons 1 and 2"),
+        ({"prediction_horizons": [1], "enable_world_model": False}, "enable_world_model"),
+        ({"prediction_horizons": [1], "num_video_frames": 5}, "divisible"),
+        ({"prediction_horizons": [1, 2], "num_video_frames": 4}, "encoded video length"),
+        ({"temporal_consistency_weight": -0.1}, "finite and >= 0"),
+        ({"temporal_consistency_weight": float("nan")}, "finite and >= 0"),
+        ({"temporal_consistency_weight": 0.1}, "requires `prediction_horizons`"),
+        (
+            {"prediction_horizons": [1], "temporal_consistency_weight": 0.1},
+            "requires prediction horizons 1 and 2",
+        ),
+    ],
+)
+def test_multihorizon_config_validation(kwargs: dict, match: str) -> None:
+    with pytest.raises(ValueError, match=match):
+        VLAJEPAConfig(device="cpu", **kwargs)

--- a/tests/policies/vla_jepa/test_multihorizon.py
+++ b/tests/policies/vla_jepa/test_multihorizon.py
@@ -1,0 +1,450 @@
+#!/usr/bin/env python
+
+from __future__ import annotations
+
+import pytest
+import torch
+from conftest import (
+    BATCH_SIZE,
+    QWEN_HIDDEN_SIZE,
+    _FakeVideoEncoder,
+    make_config,
+    make_inference_batch,
+    make_train_batch,
+)
+
+from lerobot.configs.types import FeatureType, PolicyFeature
+from lerobot.policies.vla_jepa import modeling_vla_jepa
+from lerobot.policies.vla_jepa.modeling_vla_jepa import (
+    VLAJEPAPolicy,
+    _action_token_windows,
+    _encoded_video_validity,
+    _horizon_validity,
+    _masked_l1_components,
+    _safe_ratio,
+)
+from lerobot.utils.constants import OBS_IMAGES
+
+
+def test_encoded_video_validity_combines_views_tubelets_and_prefix_closes() -> None:
+    video_is_pad = torch.tensor(
+        [
+            [[False, False, False, False], [False, False, False, False]],
+            [[False, False, True, True], [False, False, False, False]],
+            [[False, True, False, False], [False, False, False, False]],
+        ]
+    )
+    expected = torch.tensor([[True, True], [True, False], [False, False]])
+    assert torch.equal(_encoded_video_validity(video_is_pad, tubelet_size=2), expected)
+
+
+def test_horizon_validity_requires_complete_span() -> None:
+    encoded_valid = torch.tensor([[True, True, True, False], [True, False, False, False]])
+    expected = torch.tensor([[True, False], [False, False]])
+    assert torch.equal(_horizon_validity(encoded_valid, horizon=2), expected)
+
+
+def test_masked_l1_components_use_scalar_latent_denominator() -> None:
+    prediction = torch.ones(1, 2, 2, 3)
+    target = torch.zeros_like(prediction)
+    valid = torch.tensor([[True, False]])
+    numerator, denominator = _masked_l1_components(prediction, target, valid)
+    assert numerator.item() == 6
+    assert denominator.item() == 6
+    assert _safe_ratio(numerator, denominator).item() == 1
+
+
+def test_all_invalid_mask_returns_differentiable_zero() -> None:
+    prediction = torch.full((2, 3, 2, 4), float("nan"), requires_grad=True)
+    numerator, denominator = _masked_l1_components(
+        prediction, torch.zeros_like(prediction), torch.zeros(2, 3, dtype=torch.bool)
+    )
+    loss = _safe_ratio(numerator, denominator)
+    loss.backward()
+    assert loss.item() == 0
+    assert torch.equal(prediction.grad, torch.zeros_like(prediction))
+
+
+def test_action_token_windows_preserve_origin_and_transition_order() -> None:
+    action_tokens = torch.arange(1 * 3 * 2 * 1).reshape(1, 3, 2, 1)
+    windows = _action_token_windows(action_tokens, horizon=2, num_origins=2)
+    assert windows.tolist() == [[[[0], [1], [2], [3]], [[2], [3], [4], [5]]]]
+
+
+def test_opt_in_multiview_merge_does_not_mix_batch_samples(
+    monkeypatch: pytest.MonkeyPatch, patch_vla_jepa_external_models: None
+) -> None:
+    class TubeletVideoEncoder(_FakeVideoEncoder):
+        def __init__(self) -> None:
+            super().__init__(tubelet_size=2)
+
+        def get_vision_features(self, pixel_values_videos: torch.Tensor) -> torch.Tensor:
+            batch_size, num_frames = pixel_values_videos.shape[:2]
+            values = pixel_values_videos.float().mean(dim=(2, 3, 4))
+            values = values.reshape(batch_size, num_frames // 2, 2).mean(dim=2)
+            return values[:, :, None].expand(batch_size, num_frames // 2, self.config.hidden_size)
+
+    monkeypatch.setattr(
+        modeling_vla_jepa.AutoModel, "from_pretrained", lambda *args, **kwargs: TubeletVideoEncoder()
+    )
+    config = make_config(num_video_frames=6)
+    config.input_features[f"{OBS_IMAGES}.second"] = PolicyFeature(type=FeatureType.VISUAL, shape=(3, 8, 8))
+    config.jepa_tubelet_size = 2
+    config.prediction_horizons = (1, 2)
+    policy = VLAJEPAPolicy(config)
+    captured_frames: list[torch.Tensor] = []
+
+    def capture_predictor(frame_tokens: torch.Tensor, action_tokens: torch.Tensor) -> torch.Tensor:
+        del action_tokens
+        captured_frames.append(frame_tokens.detach().clone())
+        return torch.zeros_like(frame_tokens)
+
+    monkeypatch.setattr(policy.model.video_predictor, "forward", capture_predictor)
+    videos = torch.empty(BATCH_SIZE, 2, 6, 3, 8, 8)
+    videos[0, 0].fill_(1)
+    videos[0, 1].fill_(2)
+    videos[1, 0].fill_(10)
+    videos[1, 1].fill_(20)
+    action_tokens = torch.randn(BATCH_SIZE, 4, QWEN_HIDDEN_SIZE)
+    video_is_pad = torch.zeros(BATCH_SIZE, 2, 6, dtype=torch.bool)
+
+    policy.model._world_model_loss(videos, action_tokens, video_is_pad)
+
+    horizon_one_frames = captured_frames[0]
+    assert torch.equal(horizon_one_frames[0, 0, :8], torch.ones(8))
+    assert torch.equal(horizon_one_frames[0, 0, 8:], torch.full((8,), 2.0))
+    assert torch.equal(horizon_one_frames[1, 0, :8], torch.full((8,), 10.0))
+    assert torch.equal(horizon_one_frames[1, 0, 8:], torch.full((8,), 20.0))
+
+
+def test_direct_multihorizon_forward_contracts_and_gradients(
+    monkeypatch: pytest.MonkeyPatch, patch_vla_jepa_external_models: None
+) -> None:
+    config = make_config(num_video_frames=4)
+    config.prediction_horizons = (1, 2)
+    policy = VLAJEPAPolicy(config)
+    calls: list[tuple[tuple[int, ...], tuple[int, ...], tuple[int, ...]]] = []
+    original_forward = policy.model.video_predictor.forward
+
+    def capture_forward(frame_tokens: torch.Tensor, action_tokens: torch.Tensor) -> torch.Tensor:
+        output = original_forward(frame_tokens, action_tokens)
+        calls.append((tuple(frame_tokens.shape), tuple(action_tokens.shape), tuple(output.shape)))
+        return output
+
+    monkeypatch.setattr(policy.model.video_predictor, "forward", capture_forward)
+    loss, logs = policy.forward(make_train_batch(num_video_frames=4))
+    loss.backward()
+
+    assert calls == [
+        ((BATCH_SIZE, 3, 8), (BATCH_SIZE, 6, QWEN_HIDDEN_SIZE), (BATCH_SIZE, 3, 8)),
+        ((BATCH_SIZE, 2, 8), (BATCH_SIZE, 8, QWEN_HIDDEN_SIZE), (BATCH_SIZE, 2, 8)),
+    ]
+    assert set(logs) == {
+        "action_loss",
+        "wm_loss",
+        "wm_loss_h1",
+        "wm_valid_h1",
+        "wm_loss_h2",
+        "wm_valid_h2",
+        "wm_direct_loss",
+        "loss",
+    }
+    assert torch.isfinite(loss)
+    assert any(
+        parameter.grad is not None and torch.isfinite(parameter.grad).all()
+        for parameter in policy.model.video_predictor.parameters()
+    )
+
+
+def test_positive_consistency_adds_one_recursive_call_and_metric(
+    monkeypatch: pytest.MonkeyPatch, patch_vla_jepa_external_models: None
+) -> None:
+    config = make_config(num_video_frames=4)
+    config.prediction_horizons = (1, 2)
+    config.temporal_consistency_weight = 0.5
+    policy = VLAJEPAPolicy(config)
+    calls: list[tuple[tuple[int, ...], tuple[int, ...]]] = []
+    outputs: list[torch.Tensor] = []
+    original_forward = policy.model.video_predictor.forward
+
+    def capture_forward(frame_tokens: torch.Tensor, action_tokens: torch.Tensor) -> torch.Tensor:
+        output = original_forward(frame_tokens, action_tokens)
+        calls.append((tuple(frame_tokens.shape), tuple(action_tokens.shape)))
+        outputs.append(output)
+        if output.requires_grad:
+            output.retain_grad()
+        return output
+
+    monkeypatch.setattr(policy.model.video_predictor, "forward", capture_forward)
+    loss, logs = policy.forward(make_train_batch(num_video_frames=4))
+    loss.backward()
+
+    assert calls == [
+        ((BATCH_SIZE, 3, 8), (BATCH_SIZE, 6, QWEN_HIDDEN_SIZE)),
+        ((BATCH_SIZE, 2, 8), (BATCH_SIZE, 8, QWEN_HIDDEN_SIZE)),
+        ((BATCH_SIZE, 2, 8), (BATCH_SIZE, 4, QWEN_HIDDEN_SIZE)),
+    ]
+    assert set(logs) == {
+        "action_loss",
+        "wm_loss",
+        "wm_loss_h1",
+        "wm_valid_h1",
+        "wm_loss_h2",
+        "wm_valid_h2",
+        "wm_direct_loss",
+        "wm_consistency_loss",
+        "loss",
+    }
+    assert logs["wm_consistency_loss"] >= 0
+    assert outputs[0].requires_grad and outputs[0].grad is not None
+    assert outputs[1].requires_grad and outputs[1].grad is not None
+    assert not outputs[2].requires_grad
+
+
+def test_recursive_step_uses_next_action_token_group(
+    monkeypatch: pytest.MonkeyPatch, patch_vla_jepa_external_models: None
+) -> None:
+    config = make_config(num_video_frames=4)
+    config.prediction_horizons = (1, 2)
+    config.temporal_consistency_weight = 0.5
+    policy = VLAJEPAPolicy(config)
+    captured_actions: list[torch.Tensor] = []
+
+    def capture_predictor(frame_tokens: torch.Tensor, action_tokens: torch.Tensor) -> torch.Tensor:
+        captured_actions.append(action_tokens.detach().clone())
+        return frame_tokens
+
+    monkeypatch.setattr(policy.model.video_predictor, "forward", capture_predictor)
+    video_embeddings = torch.randn(BATCH_SIZE, 4, 8)
+    flat_action_tokens = torch.arange(BATCH_SIZE * 3 * 2 * QWEN_HIDDEN_SIZE).reshape(
+        BATCH_SIZE, 6, QWEN_HIDDEN_SIZE
+    )
+    video_is_pad = torch.zeros(BATCH_SIZE, 1, 4, dtype=torch.bool)
+
+    policy.model._multi_horizon_world_model_loss(
+        video_embeddings, flat_action_tokens, video_is_pad, tubelet_size=1
+    )
+
+    grouped_actions = flat_action_tokens.reshape(BATCH_SIZE, 3, 2, QWEN_HIDDEN_SIZE)
+    expected_recursive_actions = grouped_actions[:, 1:3].flatten(1, 2)
+    assert len(captured_actions) == 3
+    assert torch.equal(captured_actions[2], expected_recursive_actions)
+
+
+def test_all_invalid_consistency_loss_is_finite_zero(
+    patch_vla_jepa_external_models: None,
+) -> None:
+    config = make_config(num_video_frames=4)
+    config.prediction_horizons = (1, 2)
+    config.temporal_consistency_weight = 0.5
+    policy = VLAJEPAPolicy(config)
+    action_tokens = torch.randn(BATCH_SIZE, 6, QWEN_HIDDEN_SIZE)
+    videos = torch.rand(BATCH_SIZE, 1, 4, 3, 8, 8)
+    video_is_pad = torch.ones(BATCH_SIZE, 1, 4, dtype=torch.bool)
+
+    loss, metrics = policy.model._world_model_loss(videos, action_tokens, video_is_pad)
+    loss.backward()
+
+    assert loss.item() == 0
+    assert metrics["wm_consistency_loss"].item() == 0
+    assert torch.isfinite(loss)
+
+
+def test_prepare_model_inputs_propagates_per_view_video_padding(
+    patch_vla_jepa_external_models: None,
+) -> None:
+    config = make_config(num_video_frames=4)
+    config.prediction_horizons = (1, 2)
+    policy = VLAJEPAPolicy(config)
+    batch = make_train_batch(num_video_frames=4)
+    image_key = f"{OBS_IMAGES}.laptop"
+    batch[f"{image_key}_is_pad"] = torch.tensor([[False, False, False, True], [False, False, True, True]])
+    inputs = policy._prepare_model_inputs(batch)
+    assert torch.equal(inputs["video_is_pad"], batch[f"{image_key}_is_pad"].unsqueeze(1))
+
+
+def test_padding_and_missing_horizons_are_excluded(
+    monkeypatch: pytest.MonkeyPatch,
+    patch_vla_jepa_external_models: None,
+) -> None:
+    encoded_prefix_lengths: list[int] = []
+
+    class BidirectionalVideoEncoder(_FakeVideoEncoder):
+        def get_vision_features(self, pixel_values_videos: torch.Tensor) -> torch.Tensor:
+            batch_size, num_frames = pixel_values_videos.shape[:2]
+            encoded_prefix_lengths.append(num_frames)
+            frame_values = pixel_values_videos.float().mean(dim=(2, 3, 4))
+            contextual_values = frame_values + frame_values.mean(dim=1, keepdim=True)
+            return contextual_values[:, :, None].expand(batch_size, num_frames, self.config.hidden_size)
+
+    monkeypatch.setattr(
+        modeling_vla_jepa.AutoModel,
+        "from_pretrained",
+        lambda *args, **kwargs: BidirectionalVideoEncoder(),
+    )
+    config = make_config(num_video_frames=4)
+    config.prediction_horizons = (1, 2)
+    policy = VLAJEPAPolicy(config)
+    action_tokens = torch.randn(BATCH_SIZE, 6, QWEN_HIDDEN_SIZE)
+    videos = torch.rand(BATCH_SIZE, 1, 4, 3, 8, 8)
+    video_is_pad = torch.tensor([[[False, False, False, True]], [[False, False, True, True]]])
+
+    loss, metrics = policy.model._world_model_loss(videos, action_tokens, video_is_pad)
+    changed_padding = videos.clone()
+    changed_padding[:, :, -1] = 100
+    changed_loss, changed_metrics = policy.model._world_model_loss(
+        changed_padding, action_tokens, video_is_pad
+    )
+
+    assert torch.allclose(loss, changed_loss)
+    assert metrics["wm_valid_h1"].item() == 3
+    assert metrics["wm_valid_h2"].item() == 1
+    assert metrics.keys() == changed_metrics.keys()
+    assert encoded_prefix_lengths == [1, 2, 3, 4, 1, 2, 3, 4]
+
+
+def test_horizon_with_no_valid_targets_does_not_dilute_direct_loss(
+    patch_vla_jepa_external_models: None,
+) -> None:
+    config = make_config(num_video_frames=4)
+    config.prediction_horizons = (1, 2)
+    policy = VLAJEPAPolicy(config)
+    action_tokens = torch.randn(BATCH_SIZE, 6, QWEN_HIDDEN_SIZE)
+    videos = torch.rand(BATCH_SIZE, 1, 4, 3, 8, 8)
+    video_is_pad = torch.tensor([[[False, False, True, True]]] * BATCH_SIZE)
+
+    loss, metrics = policy.model._world_model_loss(videos, action_tokens, video_is_pad)
+
+    assert metrics["wm_valid_h1"].item() == BATCH_SIZE
+    assert metrics["wm_valid_h2"].item() == 0
+    assert metrics["wm_loss_h2"].item() == 0
+    assert torch.allclose(loss, metrics["wm_loss_h1"])
+
+
+def test_multihorizon_rejects_missing_qwen_action_tokens(
+    patch_vla_jepa_external_models: None,
+) -> None:
+    config = make_config(num_video_frames=4)
+    config.prediction_horizons = (1, 2)
+    policy = VLAJEPAPolicy(config)
+    videos = torch.rand(BATCH_SIZE, 1, 4, 3, 8, 8)
+    too_few_action_tokens = torch.randn(BATCH_SIZE, 5, QWEN_HIDDEN_SIZE)
+
+    with pytest.raises(ValueError, match="exactly 6 Qwen action tokens"):
+        policy.model._world_model_loss(videos, too_few_action_tokens)
+
+
+def test_all_invalid_direct_multihorizon_loss_is_zero(
+    patch_vla_jepa_external_models: None,
+) -> None:
+    config = make_config(num_video_frames=4)
+    config.prediction_horizons = (1, 2)
+    policy = VLAJEPAPolicy(config)
+    action_tokens = torch.randn(BATCH_SIZE, 6, QWEN_HIDDEN_SIZE)
+    videos = torch.rand(BATCH_SIZE, 1, 4, 3, 8, 8)
+    video_is_pad = torch.ones(BATCH_SIZE, 1, 4, dtype=torch.bool)
+
+    loss, metrics = policy.model._world_model_loss(videos, action_tokens, video_is_pad)
+    loss.backward()
+
+    assert loss.item() == 0
+    assert metrics["wm_valid_h1"].item() == 0
+    assert metrics["wm_valid_h2"].item() == 0
+
+
+def test_multihorizon_opt_in_does_not_change_inference(
+    monkeypatch: pytest.MonkeyPatch, patch_vla_jepa_external_models: None
+) -> None:
+    config = make_config(num_video_frames=4)
+    config.prediction_horizons = (1, 2)
+    policy = VLAJEPAPolicy(config)
+
+    def unexpected_predictor_call(*args, **kwargs):
+        raise AssertionError("World predictor must not run during inference")
+
+    monkeypatch.setattr(policy.model.video_predictor, "forward", unexpected_predictor_call)
+    actions = policy.predict_action_chunk(make_inference_batch())
+    assert actions.shape == (BATCH_SIZE, config.chunk_size, config.action_dim)
+
+
+def test_multihorizon_reuses_legacy_state_dict_keys(patch_vla_jepa_external_models: None) -> None:
+    legacy = VLAJEPAPolicy(make_config(num_video_frames=4))
+    opt_in_config = make_config(num_video_frames=4)
+    opt_in_config.prediction_horizons = (1, 2)
+    opt_in = VLAJEPAPolicy(opt_in_config)
+    assert legacy.state_dict().keys() == opt_in.state_dict().keys()
+    load_result = opt_in.load_state_dict(legacy.state_dict(), strict=True)
+    assert not load_result.missing_keys
+    assert not load_result.unexpected_keys
+
+
+def test_single_horizon_tuple_is_opt_in_not_legacy(
+    patch_vla_jepa_external_models: None,
+) -> None:
+    config = make_config(num_video_frames=4)
+    config.prediction_horizons = (1,)
+    policy = VLAJEPAPolicy(config)
+
+    _, logs = policy.forward(make_train_batch(num_video_frames=4))
+
+    assert set(logs) == {
+        "action_loss",
+        "wm_loss",
+        "wm_loss_h1",
+        "wm_valid_h1",
+        "wm_direct_loss",
+        "loss",
+    }
+
+
+def test_legacy_world_model_keeps_one_full_clip_encoder_call(
+    monkeypatch: pytest.MonkeyPatch,
+    patch_vla_jepa_external_models: None,
+) -> None:
+    policy = VLAJEPAPolicy(make_config(num_video_frames=4))
+    prefix_lengths: list[int] = []
+    original_encode = policy.model.video_encoder.get_vision_features
+
+    def capture_encode(pixel_values_videos: torch.Tensor) -> torch.Tensor:
+        prefix_lengths.append(pixel_values_videos.shape[1])
+        return original_encode(pixel_values_videos)
+
+    monkeypatch.setattr(policy.model.video_encoder, "get_vision_features", capture_encode)
+    videos = torch.rand(BATCH_SIZE, 1, 4, 3, 8, 8)
+    action_tokens = torch.randn(BATCH_SIZE, 6, QWEN_HIDDEN_SIZE)
+
+    loss = policy.model._world_model_loss(videos, action_tokens)
+
+    assert torch.isfinite(loss)
+    assert prefix_lengths == [4]
+
+
+def test_legacy_input_path_does_not_add_video_padding_contract(
+    patch_vla_jepa_external_models: None,
+) -> None:
+    policy = VLAJEPAPolicy(make_config(num_video_frames=4))
+    assert "video_is_pad" not in policy._prepare_model_inputs(make_train_batch(num_video_frames=4))
+
+
+@pytest.mark.parametrize(
+    "video_is_pad,tubelet_size,match",
+    [
+        (torch.zeros(2, 4, dtype=torch.bool), 2, "shape"),
+        (torch.zeros(1, 1, 3, dtype=torch.bool), 2, "divisible"),
+        (torch.zeros(1, 1, 4, dtype=torch.bool), 0, "positive tubelet"),
+    ],
+)
+def test_encoded_video_validity_rejects_invalid_contracts(
+    video_is_pad: torch.Tensor, tubelet_size: int, match: str
+) -> None:
+    with pytest.raises(ValueError, match=match):
+        _encoded_video_validity(video_is_pad, tubelet_size)
+
+
+@pytest.mark.parametrize("dtype", [torch.int64, torch.float32])
+def test_encoded_video_validity_coerces_numeric_masks(dtype: torch.dtype) -> None:
+    video_is_pad = torch.tensor([[[0, 0, 1, 1]]], dtype=dtype)
+    assert torch.equal(
+        _encoded_video_validity(video_is_pad, tubelet_size=2),
+        torch.tensor([[True, False]]),
+    )


### PR DESCRIPTION
## Summary / Motivation

Add an opt-in multi-horizon training objective for the VLA-JEPA world model. The feature predicts future encoded video states at horizons 1 and 2 and can additionally regularize the direct two-step prediction against a recursive one-step prediction.

The default remains disabled, so existing checkpoints and legacy training behavior are unchanged. The opt-in path encodes one raw-frame prefix per encoded temporal position to prevent V-JEPA2's bidirectional attention from leaking future target information. This improves causal correctness at a significant training-time cost: the default 8-frame, tubelet-size-2 setup performs four video-encoder calls instead of one.

## Related issues

- Fixes / Closes: N/A
- Related: N/A

## What changed

- Add validated `prediction_horizons` and `temporal_consistency_weight` configuration fields.
- Compute padding-aware direct losses for encoded horizons 1 and 2.
- Add optional temporal consistency between direct two-step and recursive one-step predictions.
- Preserve the legacy state dict, inference path, and single full-clip encoder call when the feature is disabled.
- Document configuration, metrics, padding semantics, causal prefix encoding, and performance trade-offs.
- Add configuration, masking, causality, gradient, compatibility, logging, and integration tests.

This change is backward compatible because multi-horizon training is disabled by default.

## How was this tested (or how to run locally)

- `uv run pytest -q tests/policies/vla_jepa` — 94 passed, 9 skipped.
- `uv run pytest -q -W error -W "ignore:In CPU autocast:UserWarning" tests/policies/vla_jepa` — 94 passed, 9 skipped. The ignored warning is the existing CPU float32-autocast warning tracked separately from this feature.
- All configured hooks applicable to the five changed files passed with `SKIP=gitleaks`; this includes Ruff, Prettier, typos, pyupgrade, Bandit, and mypy.
- Full test collection succeeds after excluding three unrelated Windows/environment modules: TorchCodec without full-shared FFmpeg, an uninstalled SARM optional dependency, and a Unix-only `signal.SIGHUP` test.
- Additional causal-prefix and masked-loss contract probes were run with a tiny Transformers VJEPA2 configuration.

## Checklist (required before merge)

- [ ] Linting/formatting run (`pre-commit run -a`) — relevant-file hooks pass, but the Gitleaks environment could not install because `proxy.golang.org` was unreachable.
- [ ] All tests pass locally (`pytest`) — focused tests pass; the full Windows collection has the three unrelated environment/platform limitations described above.
- [x] Documentation updated
- [x] CI is green
- [x] Community Review: I reviewed [#4106](https://github.com/huggingface/lerobot/pull/4106#issuecomment-5055740356).

## Reviewer notes

- Please focus on the causal prefix-encoding strategy and the additional video-encoder cost.
- The public metric keys are `wm_loss_h{h}`, `wm_valid_h{h}`, `wm_direct_loss`, and optionally `wm_consistency_loss`.
- Significant OpenAI Codex assistance was used for the implementation, tests, review, and documentation.
- A real-checkpoint performance smoke test was not run locally because the available environment is CPU-only; reviewer and CI validation are requested.
