### PR TITLE
feat(rollout): add smooth_handover flag to episodic strategy config

### DIFF
--- a/docs/source/inference.mdx
+++ b/docs/source/inference.mdx
@@ -194,6 +194,7 @@ Teleop is optional — if omitted the robot holds its position during the reset 
 | `--teleop.type`                                 | Optional. Teleoperator to drive the robot during resets                    |
 | `--strategy.reset_to_initial_position`          | Whether to reset the robot to its initial position between episodes        |
 | `--strategy.smooth_leader_to_follower_handover` | Whether to turn on or off the leader -> follower smooth handover behavior. |
+| `--strategy.smooth_handover`                    | Smoothly hand control to the teleop at reset start (default: true). Disable for clutch-style teleops that re-reference at the current robot pose on engage |
 
 ---
 

--- a/src/lerobot/rollout/configs.py
+++ b/src/lerobot/rollout/configs.py
@@ -149,6 +149,15 @@ class EpisodicStrategyConfig(RolloutStrategyConfig):
     # Note that leader -> follower handover is only supported when the leader has `send_feedback` capability.
     smooth_leader_to_follower_handover: bool = True
 
+    # Whether to turn on or off the smooth handover behavior at the start of the
+    # reset phase: the leader is driven to the follower position (actuated
+    # teleops, see `smooth_leader_to_follower_handover`), or the follower is
+    # slid to the teleop pose (non-actuated teleops). Disable for clutch-style
+    # teleoperators (e.g. VR controllers) that re-reference at the current robot
+    # pose on engage: the handover is already continuous there, and the blocking
+    # interpolation only delays the start of the reset phase.
+    smooth_handover: bool = True
+
 
 @RolloutStrategyConfig.register_subclass("dagger")
 @dataclass

--- a/src/lerobot/rollout/strategies/episodic.py
+++ b/src/lerobot/rollout/strategies/episodic.py
@@ -144,21 +144,25 @@ class EpisodicStrategy(RolloutStrategy):
                             # position so the operator takes over without fighting the arm.
                             # For non-actuated teleops: slide the follower to the teleop's current
                             # pose instead, since the leader cannot be driven.
-                            obs = robot.get_observation()
-                            current_pos = {k: v for k, v in obs.items() if k.endswith(".pos")}
-                            if (
-                                teleop_supports_feedback(teleop)
-                                and self.config.smooth_leader_to_follower_handover
-                            ):
-                                logger.info("Smooth handover: moving leader arm to follower position")
-                                teleop_smooth_move_to(teleop, current_pos, duration_s=2)
-                                teleop.disable_torque()
-                            else:
-                                logger.info("Smooth handover: sliding follower to teleop position")
-                                teleop_action = teleop.get_action()
-                                processed = ctx.processors.teleop_action_processor((teleop_action, obs))
-                                target = ctx.processors.robot_action_processor((processed, obs))
-                                follower_smooth_move_to(robot, current_pos, target, duration_s=1)
+                            # Disabled entirely with --strategy.smooth_handover=false (useful for
+                            # clutch-style teleops that re-reference at the current robot pose on
+                            # engage).
+                            if self.config.smooth_handover:
+                                obs = robot.get_observation()
+                                current_pos = {k: v for k, v in obs.items() if k.endswith(".pos")}
+                                if (
+                                    teleop_supports_feedback(teleop)
+                                    and self.config.smooth_leader_to_follower_handover
+                                ):
+                                    logger.info("Smooth handover: moving leader arm to follower position")
+                                    teleop_smooth_move_to(teleop, current_pos, duration_s=2)
+                                    teleop.disable_torque()
+                                else:
+                                    logger.info("Smooth handover: sliding follower to teleop position")
+                                    teleop_action = teleop.get_action()
+                                    processed = ctx.processors.teleop_action_processor((teleop_action, obs))
+                                    target = ctx.processors.robot_action_processor((processed, obs))
+                                    follower_smooth_move_to(robot, current_pos, target, duration_s=1)
 
                         elif self.config.reset_to_initial_position:
                             # No teleop: return the robot to its startup position.


### PR DESCRIPTION
## Summary / Motivation

Follow-up to #3985, which added `--strategy.smooth_handover` to the DAgger strategy. Maximellerbach asked there whether the episodic strategy needs the same change — it does.

The episodic strategy's reset-phase handover has two gaps:

- Non-actuated teleops cannot skip the blocking ~1 s follower slide at all: the existing `smooth_leader_to_follower_handover` flag only gates the actuated branch.
- Setting `smooth_leader_to_follower_handover=false` on an actuated teleop does not skip the handover — it falls through to the other branch and slides the follower instead.

For clutch-style teleoperators (e.g. VR controllers that re-reference their command frame at the current robot pose on engage), the handover is already continuous by construction, and the blocking interpolation only delays the start of the reset phase.

## Related issues

- Follow-up to #3985

## What changed

- `EpisodicStrategyConfig` gains `smooth_handover: bool = True`, a master switch that skips the reset-phase handover entirely when false.
- `smooth_leader_to_follower_handover` keeps its existing meaning (which direction moves when the handover runs).
- Torque is untouched: `teleop_smooth_move_to` enables torque itself and the caller disables it after, so skipping the block leaves the leader torque-off as before.
- Documented the flag in `docs/source/inference.mdx` (episodic flags table).
- No breaking changes; the default preserves current behavior.

## How was this tested (or how to run locally)

- `ruff check` / `ruff format` pass on the changed files.
- Default-on path unchanged (flag not set → identical behavior).

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [ ] All tests pass locally (`pytest`)
- [x] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: #

🤖 Generated with [Claude Code](https://claude.com/claude-code)