### PR TITLE
fix(datasets): Pass the required response argument to RevisionNotFoundError

### DIFF
--- a/src/lerobot/datasets/utils.py
+++ b/src/lerobot/datasets/utils.py
@@ -24,6 +24,7 @@ from pathlib import Path
 import datasets
 import numpy as np
 import packaging.version
+import requests
 import torch
 from huggingface_hub import DatasetCard, DatasetCardData, HfApi
 from huggingface_hub.errors import RevisionNotFoundError
@@ -49,6 +50,17 @@ or open an [issue on GitHub](https://github.com/huggingface/lerobot/issues/new/c
 FUTURE_MESSAGE = """
 The dataset you requested ({repo_id}) is only available in {version} format.
 As we cannot ensure forward compatibility with it, please update your current version of lerobot.
+"""
+
+MISSING_VERSION_TAG_MESSAGE = """
+Your dataset must be tagged with a codebase version.
+Assuming _version_ is the codebase_version value in the info.json, you can run this:
+```python
+from huggingface_hub import HfApi
+
+hub_api = HfApi()
+hub_api.create_tag("{repo_id}", tag="_version_", repo_type="dataset")
+```
 """
 
 
@@ -379,15 +391,8 @@ def get_safe_version(
 
     if not hub_versions:
         raise RevisionNotFoundError(
-            f"""Your dataset must be tagged with a codebase version.
-            Assuming _version_ is the codebase_version value in the info.json, you can run this:
-            ```python
-            from huggingface_hub import HfApi
-
-            hub_api = HfApi()
-            hub_api.create_tag("{repo_id}", tag="_version_", repo_type="dataset")
-            ```
-            """
+            MISSING_VERSION_TAG_MESSAGE.format(repo_id=repo_id),
+            response=requests.Response(),
         )
 
     if target_version in hub_versions:

--- a/tests/datasets/test_dataset_utils.py
+++ b/tests/datasets/test_dataset_utils.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 from types import SimpleNamespace
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 import torch
@@ -25,12 +25,14 @@ pytest.importorskip("datasets", reason="datasets is required (install lerobot[da
 
 from datasets import Dataset  # noqa: E402
 from huggingface_hub import DatasetCard
+from huggingface_hub.errors import RevisionNotFoundError
 
 import lerobot.datasets.utils as dataset_utils
 from lerobot.datasets.io_utils import hf_transform_to_torch
 from lerobot.datasets.utils import create_lerobot_dataset_card, get_repo_versions, get_safe_version
 from lerobot.utils.constants import ACTION, OBS_IMAGES
 from lerobot.utils.feature_utils import combine_feature_dicts
+from tests.fixtures.constants import DUMMY_REPO_ID
 
 
 def calculate_episode_data_index(hf_dataset: Dataset) -> dict[str, torch.Tensor]:
@@ -180,3 +182,21 @@ def test_non_dict_passthrough_last_wins():
     out = combine_feature_dicts(g1, g2)
     # For non-dict entries the last one wins
     assert out["misc"] == 456
+
+
+def test_get_safe_version_raises_on_repo_without_version_tags():
+    with (
+        patch("lerobot.datasets.utils.get_repo_versions", return_value=[]),
+        pytest.raises(RevisionNotFoundError, match="must be tagged with a codebase version"),
+    ):
+        get_safe_version(DUMMY_REPO_ID, "v3.0")
+
+
+def test_get_safe_version_error_reports_repo_id():
+    with (
+        patch("lerobot.datasets.utils.get_repo_versions", return_value=[]),
+        pytest.raises(RevisionNotFoundError) as exc_info,
+    ):
+        get_safe_version(DUMMY_REPO_ID, "v3.0")
+
+    assert DUMMY_REPO_ID in str(exc_info.value)


### PR DESCRIPTION
### What does this PR do?

The following issue was identified and fixed in this PR:

→ Passes the required `response` argument to the [RevisionNotFoundError raised by get_safe_version()](https://github.com/huggingface/lerobot/blob/main/src/lerobot/datasets/utils.py#L372-L382) so the branch raises instead of dying with a `TypeError`, relocates its message to `MISSING_VERSION_TAG_MESSAGE` beside [V30_MESSAGE and FUTURE_MESSAGE](https://github.com/huggingface/lerobot/blob/main/src/lerobot/datasets/utils.py#L33-L52) so the guidance renders without the inline f-string's source indentation.
→ Adds `test_get_safe_version_raises_on_repo_without_version_tags` and `test_get_safe_version_error_reports_repo_id` to `tests/datasets/test_dataset_utils.py`, covering a branch that had no tests; both fail on `main` with the `TypeError` and pass with the fix. Verified that there are no regressions on the testing suites.

Fixes [#4138](https://github.com/huggingface/lerobot/issues/4138)

cc: @Maximellerbach @pkooij @CarolinePascal @imstevenpmwork

```
uv run pytest tests/datasets/test_dataset_utils.py -q
uv run pytest tests/datasets/ tests/scripts/test_lerobot_annotate.py -q
```

<img src="https://github.com/user-attachments/assets/23a63993-be08-4f47-8b25-117f86b1ca79" />

### Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [ ] CI is green