### PR TITLE
fix(peft): allow fresh LoRA fine-tuning from a base-model checkpoint

### DIFF
--- a/docs/source/lingbot_va.mdx
+++ b/docs/source/lingbot_va.mdx
@@ -111,16 +111,25 @@ Requirements:
 - The block-causal masks use PyTorch **flex-attention**, so build the policy with
   `--policy.attn_mode=flex` for training (the default `torch` SDPA is inference-only).
 - The full 5B DiT does not fit a single 24–32 GB GPU under AdamW; fine-tune with **LoRA**
-  (`--policy.use_peft=true`) and/or optimizer offload. `get_optim_params` returns only the
-  trainable (e.g. adapter) parameters; the VAE + UMT5 text encoder stay frozen.
+  (`--peft.method_type=LORA`) and/or optimizer offload. `get_optim_params` returns only the
+  trainable (e.g. adapter) parameters; the VAE + UMT5 text encoder stay frozen. Install the
+  `lerobot[peft]` extra to enable PEFT support (see the [PEFT training guide](./peft_training)).
 
 ```bash
 lerobot-train \
   --policy.path=lerobot/lingbot_va_libero_long --policy.attn_mode=flex \
-  --policy.use_peft=true \
+  --peft.method_type=LORA --peft.r=32 --peft.lora_alpha=32 \
+  --peft.target_modules='transformer\.blocks\.\d+\.attn[12]\.(to_q|to_v)' \
   --dataset.repo_id=<your LeRobot-format dataset> \
   --batch_size=1 --steps=... --output_dir=outputs/train/lingbot_va
 ```
+
+Unlike SmolVLA / π₀, LingBot-VA does not ship built-in default LoRA targets, so you must pass
+`--peft.target_modules` explicitly. Only `self.transformer` (the dual-stream Wan transformer) is
+trainable; the example above adapts the query/value projections of both its self-attention
+(`attn1`) and cross-attention (`attn2`) blocks — the standard LoRA target set. Broaden it (e.g.
+add `to_k`/`to_out`, or the `ffn` layers) if you need a higher-capacity adapter. Passing
+`--peft.method_type` implies PEFT, so `--policy.use_peft=true` is not required.
 
 The dataset must provide camera clips (a temporal window per camera, VAE-encoded to
 `frame_chunk_size` latent frames) and `frame_chunk_size * action_per_frame` action steps per item.

--- a/docs/source/peft_training.mdx
+++ b/docs/source/peft_training.mdx
@@ -62,3 +62,10 @@ to the `--peft.full_training_modules` parameter:
 
 The learning rate and the scheduled target learning rate can usually be scaled by a factor of 10 compared to the
 learning rate used for full fine-tuning (e.g., 1e-4 normal, so 1e-3 using LoRA).
+
+## Other policies
+
+The same `--peft.*` flags work for any pre-trained policy. Some policies (SmolVLA, π₀, π₀.₅) ship
+built-in default `target_modules`, so `--peft.method_type=LORA` is enough. Others do not, and will
+ask you to pass `--peft.target_modules` explicitly — for example LingBot-VA, whose recommended
+targets are documented in its [dedicated guide](./lingbot_va#training--fine-tuning).

--- a/src/lerobot/configs/train.py
+++ b/src/lerobot/configs/train.py
@@ -221,6 +221,11 @@ class TrainPipelineConfig(HubMixin):
             )
 
         active_cfg = self.trainable_config
+
+        # Keep the policy-level `use_peft` flag in sync with the presence of a `--peft.*` config.
+        if self.peft is not None and self.policy is not None:
+            self.policy.use_peft = True
+
         if self.rename_map and active_cfg.pretrained_path is None:
             raise ValueError(
                 "`rename_map` requires a pretrained policy checkpoint. "

--- a/src/lerobot/policies/factory.py
+++ b/src/lerobot/policies/factory.py
@@ -513,6 +513,37 @@ def make_pre_post_processors(
     return processors
 
 
+def _has_peft_adapter_config(
+    pretrained_path: str,
+    revision: str | None = None,
+) -> bool:
+    """Return whether ``pretrained_path`` points to an existing PEFT adapter.
+
+    A PEFT adapter checkpoint always ships an ``adapter_config.json``.
+    A plain base-model checkpoint does not. This distinction lets us tell apart
+    two very different ``use_peft=True`` scenarios that both set ``pretrained_path``:
+
+    * loading/resuming a previously trained adapter (config lives at ``pretrained_path``)
+    * starting a *fresh* PEFT fine-tune on top of a base model
+
+    Works for both local directories and Hub repo ids.
+    """
+    import os
+
+    adapter_config_name = "adapter_config.json"
+
+    if os.path.isdir(pretrained_path):
+        return os.path.isfile(os.path.join(pretrained_path, adapter_config_name))
+
+    from huggingface_hub import file_exists
+    from huggingface_hub.errors import HfHubHTTPError
+
+    try:
+        return file_exists(pretrained_path, adapter_config_name, revision=revision)
+    except (HfHubHTTPError, OSError):
+        return False
+
+
 def make_policy(
     cfg: PreTrainedConfig,
     ds_meta: LeRobotDatasetMetadata | None = None,
@@ -607,13 +638,24 @@ def make_policy(
             "the PEFT config parameters to be set. For training with PEFT, see `lerobot_train.py` on how to do that."
         )
 
-    if cfg.pretrained_path and not cfg.use_peft:
+    # When `use_peft=True` and a checkpoint is given, the checkpoint can be one of two things:
+    # 1. A base model checkpoint (e.g., a pretrained policy) on which we want to start a fresh PEFT fine-tune.
+    # 2. A PEFT adapter checkpoint (e.g., a previously trained PEFT adapter)
+    # We distinguish between these two cases
+    load_existing_adapter = (
+        cfg.pretrained_path
+        and cfg.use_peft
+        and _has_peft_adapter_config(str(cfg.pretrained_path), cfg.pretrained_revision)
+    )
+
+    if cfg.pretrained_path and not load_existing_adapter:
         # Load a pretrained policy and override the config if needed (for example, if there are inference-time
-        # hyperparameters that we want to vary).
+        # hyperparameters that we want to vary). This also covers starting a fresh PEFT fine-tune on top of a
+        # base model: the base weights are loaded here and `wrap_with_peft` builds the adapter afterwards.
         kwargs["pretrained_name_or_path"] = cfg.pretrained_path
         kwargs["revision"] = cfg.pretrained_revision
         policy = policy_cls.from_pretrained(**kwargs)
-    elif cfg.pretrained_path and cfg.use_peft:
+    elif load_existing_adapter:
         # Load a pretrained PEFT model on top of the policy. The pretrained path points to the folder/repo
         # of the adapter and the adapter's config contains the path to the base policy. So we need the
         # adapter config first, then load the correct policy and then apply PEFT.

--- a/tests/policies/test_peft_base_model_loading.py
+++ b/tests/policies/test_peft_base_model_loading.py
@@ -1,0 +1,142 @@
+# Copyright 2024 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Regression tests for PEFT loading when the checkpoint is a base model (see issue #3975).
+
+Starting a fresh LoRA/PEFT fine-tune points ``--policy.path`` at a *base model* (no
+``adapter_config.json``) while also setting ``use_peft=True``. This must NOT be mistaken for
+loading an existing PEFT adapter. These tests lock in the base-model vs. adapter distinction
+made by ``lerobot.policies.factory._has_peft_adapter_config`` and the branch it drives in
+``make_policy``. They are pure/fast (no network, no ``peft``), so they run in CI.
+"""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import torch
+from huggingface_hub.errors import HfHubHTTPError
+
+from lerobot.policies.factory import _has_peft_adapter_config
+
+
+def test_local_base_model_dir_has_no_adapter_config(tmp_path):
+    # A base-model checkpoint directory (only model weights, no adapter config).
+    (tmp_path / "model.safetensors").write_bytes(b"")
+    (tmp_path / "config.json").write_text("{}")
+    assert _has_peft_adapter_config(str(tmp_path)) is False
+
+
+def test_local_adapter_dir_has_adapter_config(tmp_path):
+    (tmp_path / "adapter_config.json").write_text(json.dumps({"peft_type": "LORA"}))
+    (tmp_path / "adapter_model.safetensors").write_bytes(b"")
+    assert _has_peft_adapter_config(str(tmp_path)) is True
+
+
+def test_hub_base_model_repo_has_no_adapter_config():
+    with patch("huggingface_hub.file_exists", return_value=False) as mock_exists:
+        assert _has_peft_adapter_config("lerobot/lingbot_va_base") is False
+    mock_exists.assert_called_once()
+    assert mock_exists.call_args.args[1] == "adapter_config.json"
+
+
+def test_hub_adapter_repo_has_adapter_config():
+    with patch("huggingface_hub.file_exists", return_value=True):
+        assert _has_peft_adapter_config("some/adapter-repo", revision="main") is True
+
+
+def test_hub_lookup_error_falls_back_to_base_model():
+    # Offline / private / transient Hub errors must not crash; treat as "not an adapter".
+    with patch(
+        "huggingface_hub.file_exists",
+        side_effect=HfHubHTTPError("boom", response=MagicMock()),
+    ):
+        assert _has_peft_adapter_config("some/private-repo") is False
+    with patch("huggingface_hub.file_exists", side_effect=OSError("offline")):
+        assert _has_peft_adapter_config("some/repo") is False
+
+
+def _make_dummy_policy_cfg(pretrained_path, use_peft):
+    cfg = MagicMock()
+    cfg.type = "act"
+    cfg.device = "cpu"
+    cfg.pretrained_path = pretrained_path
+    cfg.pretrained_revision = None
+    cfg.use_peft = use_peft
+    cfg.input_features = {}
+    cfg.output_features = {}
+    return cfg
+
+
+@patch("lerobot.policies.factory.validate_visual_features_consistency")
+@patch("lerobot.policies.factory.env_to_policy_features", return_value={})
+@patch("lerobot.policies.factory.get_policy_class")
+def test_make_policy_base_model_with_use_peft_loads_base_not_adapter(
+    mock_get_cls, _mock_features, _mock_validate
+):
+    """`use_peft=True` on a base model must load the base weights, not a PEFT adapter.
+
+    Before the #3975 fix this went down the ``PeftConfig.from_pretrained`` path and failed
+    looking for a non-existent ``adapter_config.json``.
+    """
+    from lerobot.policies import factory
+
+    policy_cls = MagicMock()
+    loaded_policy = torch.nn.Linear(1, 1)  # a real nn.Module so make_policy's assert passes
+    policy_cls.from_pretrained.return_value = loaded_policy
+    mock_get_cls.return_value = policy_cls
+
+    cfg = _make_dummy_policy_cfg(pretrained_path="lerobot/lingbot_va_base", use_peft=True)
+    env_cfg = MagicMock()
+
+    with patch.object(factory, "_has_peft_adapter_config", return_value=False) as mock_has_adapter:
+        policy = factory.make_policy(cfg=cfg, env_cfg=env_cfg)
+
+    mock_has_adapter.assert_called_once()
+    # Base model is loaded via the normal pretrained path...
+    policy_cls.from_pretrained.assert_called_once()
+    assert policy_cls.from_pretrained.call_args.kwargs["pretrained_name_or_path"] == (
+        "lerobot/lingbot_va_base"
+    )
+    # ...and PEFT adapter loading is NOT attempted (would need peft + adapter_config.json).
+    assert policy is loaded_policy
+
+
+@patch("lerobot.policies.factory.validate_visual_features_consistency")
+@patch("lerobot.policies.factory.env_to_policy_features", return_value={})
+@patch("lerobot.policies.factory.get_policy_class")
+def test_make_policy_existing_adapter_uses_peft_loading(mock_get_cls, _mock_features, _mock_validate):
+    """A real adapter checkpoint (has ``adapter_config.json``) must go through PEFT loading."""
+    from lerobot.policies import factory
+
+    policy_cls = MagicMock()
+    mock_get_cls.return_value = policy_cls
+
+    cfg = _make_dummy_policy_cfg(pretrained_path="some/adapter-repo", use_peft=True)
+    env_cfg = MagicMock()
+
+    policy_cls.from_pretrained.return_value = torch.nn.Linear(1, 1)
+
+    fake_peft = MagicMock()
+    fake_peft_config = MagicMock()
+    fake_peft_config.base_model_name_or_path = "lerobot/lingbot_va_base"
+    fake_peft.PeftConfig.from_pretrained.return_value = fake_peft_config
+    fake_peft.PeftModel.from_pretrained.return_value = torch.nn.Linear(1, 1)
+
+    with (
+        patch.object(factory, "_has_peft_adapter_config", return_value=True),
+        patch.dict("sys.modules", {"peft": fake_peft}),
+    ):
+        factory.make_policy(cfg=cfg, env_cfg=env_cfg)
+
+    fake_peft.PeftConfig.from_pretrained.assert_called_once_with("some/adapter-repo")
+    fake_peft.PeftModel.from_pretrained.assert_called_once()


### PR DESCRIPTION
## Summary / Motivation

Fine-tuning a base model with LoRA (`--policy.path=<base> --policy.use_peft=true --peft.method_type=LORA`) crashed because `make_policy` assumed any `use_peft=True` checkpoint was an existing PEFT adapter and looked for a non-existent `adapter_config.json`. The fix tells the two cases apart by checking for an actual `adapter_config.json`. This affected every PEFT-capable policy, not just LingBot-VA.

## Related issues

- Fixes / Closes: #3975

## What changed

- Load a base model normally when there's no `adapter_config.json`; only use the adapter path for a real adapter.
- `--peft.*` now implies `policy.use_peft=True`.
- Fixed the LingBot-VA docs example (it triggered the crash and never actually applied LoRA).
- Added a regression test.

## How was this tested (or how to run locally)

- `pytest tests/policies/test_peft_base_model_loading.py`
- Ran a small end-to-end PEFT training from `lerobot/smolvla_base` with `--policy.use_peft=true --peft.method_type=LORA` for 1 step: loads fine, wraps with LoRA (371K/450M params), saves a valid adapter.

## Reviewer notes

- Key files: `factory.py` (branch condition) and `train.py` (`use_peft` sync).
- On a Hub lookup error, `_has_peft_adapter_config` falls back to "base model", a real adapter fails loudly
