### PR TITLE
feat(act): add gradient checkpointing support

### DIFF
--- a/docs/source/act.mdx
+++ b/docs/source/act.mdx
@@ -69,6 +69,7 @@ lerobot-train \
 1. **Start with defaults**: ACT's default hyperparameters work well for most tasks
 2. **Training duration**: Expect a few hours for 100k training steps on a single GPU
 3. **Batch size**: Start with batch size 8 and adjust based on your GPU memory
+4. **Memory-constrained GPUs**: Add `--policy.gradient_checkpointing=true` to trade some training speed for a significantly larger batch size that fits in memory
 
 ### Train using Google Colab
 

--- a/src/lerobot/policies/act/configuration_act.py
+++ b/src/lerobot/policies/act/configuration_act.py
@@ -78,6 +78,9 @@ class ACTConfig(PreTrainedConfig):
         dropout: Dropout to use in the transformer layers (see code for details).
         kl_weight: The weight to use for the KL-divergence component of the loss if the variational objective
             is enabled. Loss is then calculated as: `reconstruction_loss + kl_weight * kld_loss`.
+        gradient_checkpointing: Whether to use gradient checkpointing on the vision backbone and the
+            transformer encoder/decoder layers to trade compute for memory during training (recomputes
+            forward activations in the backward pass instead of storing them).
     """
 
     # Input / output structure.
@@ -121,6 +124,9 @@ class ACTConfig(PreTrainedConfig):
     # Training and loss computation.
     dropout: float = 0.1
     kl_weight: float = 10.0
+
+    # Optimization
+    gradient_checkpointing: bool = False  # Enable gradient checkpointing for memory optimization
 
     # Training preset
     optimizer_lr: float = 1e-5

--- a/src/lerobot/policies/act/modeling_act.py
+++ b/src/lerobot/policies/act/modeling_act.py
@@ -64,6 +64,9 @@ class ACTPolicy(PreTrainedPolicy):
 
         self.model = ACT(config)
 
+        if config.gradient_checkpointing:
+            self.model.gradient_checkpointing_enable()
+
         if config.temporal_ensemble_coeff is not None:
             self.temporal_ensembler = ACTTemporalEnsembler(config.temporal_ensemble_coeff, config.chunk_size)
 
@@ -255,6 +258,14 @@ class ACTTemporalEnsembler:
         return action
 
 
+def _backbone_forward(backbone: nn.Module, img: Tensor) -> Tensor:
+    """Vision backbone forward pass, factored out so it can be wrapped in `torch.utils.checkpoint`.
+
+    `backbone` is an `IntermediateLayerGetter` returning a dict; checkpoint needs a plain tensor output.
+    """
+    return backbone(img)["feature_map"]
+
+
 class ACT(nn.Module):
     """Action Chunking Transformer: The underlying neural network for ACTPolicy.
 
@@ -371,11 +382,30 @@ class ACT(nn.Module):
 
         self._reset_parameters()
 
+        # Gradient checkpointing flag for the vision backbone (encoder/decoder flags live on those submodules).
+        self.gradient_checkpointing_enabled = False
+
     def _reset_parameters(self):
         """Xavier-uniform initialization of the transformer parameters as in the original code."""
         for p in chain(self.encoder.parameters(), self.decoder.parameters()):
             if p.dim() > 1:
                 nn.init.xavier_uniform_(p)
+
+    def gradient_checkpointing_enable(self) -> None:
+        """Enable gradient checkpointing for memory optimization (backbone + transformer layers)."""
+        self.gradient_checkpointing_enabled = True
+        if self.config.use_vae:
+            self.vae_encoder.gradient_checkpointing_enable()
+        self.encoder.gradient_checkpointing_enable()
+        self.decoder.gradient_checkpointing_enable()
+
+    def gradient_checkpointing_disable(self) -> None:
+        """Disable gradient checkpointing."""
+        self.gradient_checkpointing_enabled = False
+        if self.config.use_vae:
+            self.vae_encoder.gradient_checkpointing_disable()
+        self.encoder.gradient_checkpointing_disable()
+        self.decoder.gradient_checkpointing_disable()
 
     def forward(self, batch: dict[str, Tensor]) -> tuple[Tensor, tuple[Tensor, Tensor] | tuple[None, None]]:
         """A forward pass through the Action Chunking Transformer (with optional VAE encoder).
@@ -472,7 +502,12 @@ class ACT(nn.Module):
             # NOTE: If modifying this section, verify on MPS devices that
             # gradients remain stable (no explosions or NaNs).
             for img in batch[OBS_IMAGES]:
-                cam_features = self.backbone(img)["feature_map"]
+                if self.gradient_checkpointing_enabled and self.training:
+                    cam_features = torch.utils.checkpoint.checkpoint(
+                        _backbone_forward, self.backbone, img, use_reentrant=False, preserve_rng_state=False
+                    )
+                else:
+                    cam_features = _backbone_forward(self.backbone, img)
                 cam_pos_embed = self.encoder_cam_feat_pos_embed(cam_features).to(dtype=cam_features.dtype)
                 cam_features = self.encoder_img_feat_input_proj(cam_features)
 
@@ -521,12 +556,31 @@ class ACTEncoder(nn.Module):
         num_layers = config.n_vae_encoder_layers if self.is_vae_encoder else config.n_encoder_layers
         self.layers = nn.ModuleList([ACTEncoderLayer(config) for _ in range(num_layers)])
         self.norm = nn.LayerNorm(config.dim_model) if config.pre_norm else nn.Identity()
+        self.gradient_checkpointing_enabled = False
+
+    def gradient_checkpointing_enable(self) -> None:
+        self.gradient_checkpointing_enabled = True
+
+    def gradient_checkpointing_disable(self) -> None:
+        self.gradient_checkpointing_enabled = False
 
     def forward(
         self, x: Tensor, pos_embed: Tensor | None = None, key_padding_mask: Tensor | None = None
     ) -> Tensor:
         for layer in self.layers:
-            x = layer(x, pos_embed=pos_embed, key_padding_mask=key_padding_mask)
+            if self.gradient_checkpointing_enabled and self.training:
+                # preserve_rng_state=True: layers contain dropout, so backward-pass recompute must draw the
+                # same dropout mask as the original forward pass.
+                x = torch.utils.checkpoint.checkpoint(
+                    layer,
+                    x,
+                    pos_embed=pos_embed,
+                    key_padding_mask=key_padding_mask,
+                    use_reentrant=False,
+                    preserve_rng_state=True,
+                )
+            else:
+                x = layer(x, pos_embed=pos_embed, key_padding_mask=key_padding_mask)
         x = self.norm(x)
         return x
 
@@ -576,6 +630,13 @@ class ACTDecoder(nn.Module):
         super().__init__()
         self.layers = nn.ModuleList([ACTDecoderLayer(config) for _ in range(config.n_decoder_layers)])
         self.norm = nn.LayerNorm(config.dim_model)
+        self.gradient_checkpointing_enabled = False
+
+    def gradient_checkpointing_enable(self) -> None:
+        self.gradient_checkpointing_enabled = True
+
+    def gradient_checkpointing_disable(self) -> None:
+        self.gradient_checkpointing_enabled = False
 
     def forward(
         self,
@@ -585,9 +646,22 @@ class ACTDecoder(nn.Module):
         encoder_pos_embed: Tensor | None = None,
     ) -> Tensor:
         for layer in self.layers:
-            x = layer(
-                x, encoder_out, decoder_pos_embed=decoder_pos_embed, encoder_pos_embed=encoder_pos_embed
-            )
+            if self.gradient_checkpointing_enabled and self.training:
+                # preserve_rng_state=True: layers contain dropout, so backward-pass recompute must draw the
+                # same dropout mask as the original forward pass.
+                x = torch.utils.checkpoint.checkpoint(
+                    layer,
+                    x,
+                    encoder_out,
+                    decoder_pos_embed=decoder_pos_embed,
+                    encoder_pos_embed=encoder_pos_embed,
+                    use_reentrant=False,
+                    preserve_rng_state=True,
+                )
+            else:
+                x = layer(
+                    x, encoder_out, decoder_pos_embed=decoder_pos_embed, encoder_pos_embed=encoder_pos_embed
+                )
         if self.norm is not None:
             x = self.norm(x)
         return x

--- a/src/lerobot/policies/act/modeling_act.py
+++ b/src/lerobot/policies/act/modeling_act.py
@@ -66,6 +66,9 @@ class ACTPolicy(PreTrainedPolicy):
 
         self.model = ACT(config)
 
+        if config.gradient_checkpointing:
+            self.model.gradient_checkpointing_enable()
+
         if config.temporal_ensemble_coeff is not None:
             self.temporal_ensembler = ACTTemporalEnsembler(config.temporal_ensemble_coeff, config.chunk_size)
 
@@ -257,6 +260,14 @@ class ACTTemporalEnsembler:
         return action
 
 
+def _backbone_forward(backbone: nn.Module, img: Tensor) -> Tensor:
+    """Vision backbone forward pass, factored out so it can be wrapped in `torch.utils.checkpoint`.
+
+    `backbone` is an `IntermediateLayerGetter` returning a dict; checkpoint needs a plain tensor output.
+    """
+    return backbone(img)["feature_map"]
+
+
 class ACT(nn.Module):
     """Action Chunking Transformer: The underlying neural network for ACTPolicy.
 
@@ -373,11 +384,30 @@ class ACT(nn.Module):
 
         self._reset_parameters()
 
+        # Gradient checkpointing flag for the vision backbone (encoder/decoder flags live on those submodules).
+        self.gradient_checkpointing_enabled = False
+
     def _reset_parameters(self):
         """Xavier-uniform initialization of the transformer parameters as in the original code."""
         for p in chain(self.encoder.parameters(), self.decoder.parameters()):
             if p.dim() > 1:
                 nn.init.xavier_uniform_(p)
+
+    def gradient_checkpointing_enable(self) -> None:
+        """Enable gradient checkpointing for memory optimization (backbone + transformer layers)."""
+        self.gradient_checkpointing_enabled = True
+        if self.config.use_vae:
+            self.vae_encoder.gradient_checkpointing_enable()
+        self.encoder.gradient_checkpointing_enable()
+        self.decoder.gradient_checkpointing_enable()
+
+    def gradient_checkpointing_disable(self) -> None:
+        """Disable gradient checkpointing."""
+        self.gradient_checkpointing_enabled = False
+        if self.config.use_vae:
+            self.vae_encoder.gradient_checkpointing_disable()
+        self.encoder.gradient_checkpointing_disable()
+        self.decoder.gradient_checkpointing_disable()
 
     def forward(self, batch: dict[str, Tensor]) -> tuple[Tensor, tuple[Tensor, Tensor] | tuple[None, None]]:
         """A forward pass through the Action Chunking Transformer (with optional VAE encoder).
@@ -474,7 +504,12 @@ class ACT(nn.Module):
             # NOTE: If modifying this section, verify on MPS devices that
             # gradients remain stable (no explosions or NaNs).
             for img in batch[OBS_IMAGES]:
-                cam_features = self.backbone(img)["feature_map"]
+                if self.gradient_checkpointing_enabled and self.training:
+                    cam_features = torch.utils.checkpoint.checkpoint(
+                        _backbone_forward, self.backbone, img, use_reentrant=False, preserve_rng_state=False
+                    )
+                else:
+                    cam_features = _backbone_forward(self.backbone, img)
                 cam_pos_embed = self.encoder_cam_feat_pos_embed(cam_features).to(dtype=cam_features.dtype)
                 cam_features = self.encoder_img_feat_input_proj(cam_features)
 
@@ -523,12 +558,31 @@ class ACTEncoder(nn.Module):
         num_layers = config.n_vae_encoder_layers if self.is_vae_encoder else config.n_encoder_layers
         self.layers = nn.ModuleList([ACTEncoderLayer(config) for _ in range(num_layers)])
         self.norm = nn.LayerNorm(config.dim_model) if config.pre_norm else nn.Identity()
+        self.gradient_checkpointing_enabled = False
+
+    def gradient_checkpointing_enable(self) -> None:
+        self.gradient_checkpointing_enabled = True
+
+    def gradient_checkpointing_disable(self) -> None:
+        self.gradient_checkpointing_enabled = False
 
     def forward(
         self, x: Tensor, pos_embed: Tensor | None = None, key_padding_mask: Tensor | None = None
     ) -> Tensor:
         for layer in self.layers:
-            x = layer(x, pos_embed=pos_embed, key_padding_mask=key_padding_mask)
+            if self.gradient_checkpointing_enabled and self.training:
+                # preserve_rng_state=True: layers contain dropout, so backward-pass recompute must draw the
+                # same dropout mask as the original forward pass.
+                x = torch.utils.checkpoint.checkpoint(
+                    layer,
+                    x,
+                    pos_embed=pos_embed,
+                    key_padding_mask=key_padding_mask,
+                    use_reentrant=False,
+                    preserve_rng_state=True,
+                )
+            else:
+                x = layer(x, pos_embed=pos_embed, key_padding_mask=key_padding_mask)
         x = self.norm(x)
         return x
 
@@ -578,6 +632,13 @@ class ACTDecoder(nn.Module):
         super().__init__()
         self.layers = nn.ModuleList([ACTDecoderLayer(config) for _ in range(config.n_decoder_layers)])
         self.norm = nn.LayerNorm(config.dim_model)
+        self.gradient_checkpointing_enabled = False
+
+    def gradient_checkpointing_enable(self) -> None:
+        self.gradient_checkpointing_enabled = True
+
+    def gradient_checkpointing_disable(self) -> None:
+        self.gradient_checkpointing_enabled = False
 
     def forward(
         self,
@@ -587,9 +648,22 @@ class ACTDecoder(nn.Module):
         encoder_pos_embed: Tensor | None = None,
     ) -> Tensor:
         for layer in self.layers:
-            x = layer(
-                x, encoder_out, decoder_pos_embed=decoder_pos_embed, encoder_pos_embed=encoder_pos_embed
-            )
+            if self.gradient_checkpointing_enabled and self.training:
+                # preserve_rng_state=True: layers contain dropout, so backward-pass recompute must draw the
+                # same dropout mask as the original forward pass.
+                x = torch.utils.checkpoint.checkpoint(
+                    layer,
+                    x,
+                    encoder_out,
+                    decoder_pos_embed=decoder_pos_embed,
+                    encoder_pos_embed=encoder_pos_embed,
+                    use_reentrant=False,
+                    preserve_rng_state=True,
+                )
+            else:
+                x = layer(
+                    x, encoder_out, decoder_pos_embed=decoder_pos_embed, encoder_pos_embed=encoder_pos_embed
+                )
         if self.norm is not None:
             x = self.norm(x)
         return x

--- a/tests/policies/test_act_gradient_checkpointing.py
+++ b/tests/policies/test_act_gradient_checkpointing.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python
+
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Verify that enabling gradient checkpointing on ACTPolicy does not change numerics.
+
+Gradient checkpointing recomputes the vision backbone and transformer encoder/decoder forward
+passes during the backward pass instead of storing their activations. It must be a pure
+memory/compute trade-off: given identical weights and identical inputs, the loss and every
+parameter gradient must match a non-checkpointed run.
+
+`dropout=0.0` is used in the test config: the transformer layers use `nn.Dropout` and
+`nn.MultiheadAttention`'s internal dropout, and `preserve_rng_state=True` (required precisely
+because of this dropout) only guarantees a matching *mask*, not the absence of one — an
+`.eval()`-mode comparison would trivially disable dropout, but the checkpoint gate itself
+requires `self.training=True`, so dropout must be removed at the config level instead.
+"""
+
+import torch
+
+from lerobot.configs.types import FeatureType, NormalizationMode, PolicyFeature
+from lerobot.policies.act.configuration_act import ACTConfig
+from lerobot.policies.act.modeling_act import ACTPolicy
+from lerobot.utils.constants import ACTION, OBS_IMAGE, OBS_STATE
+
+
+def make_config(*, gradient_checkpointing: bool) -> ACTConfig:
+    """A small, CPU-fast, offline-safe ACTConfig for unit testing."""
+    return ACTConfig(
+        input_features={
+            OBS_STATE: PolicyFeature(type=FeatureType.STATE, shape=(4,)),
+            OBS_IMAGE: PolicyFeature(type=FeatureType.VISUAL, shape=(3, 64, 64)),
+        },
+        output_features={
+            ACTION: PolicyFeature(type=FeatureType.ACTION, shape=(3,)),
+        },
+        normalization_mapping={
+            FeatureType.VISUAL: NormalizationMode.IDENTITY,
+            FeatureType.STATE: NormalizationMode.IDENTITY,
+            FeatureType.ACTION: NormalizationMode.IDENTITY,
+        },
+        device="cpu",
+        chunk_size=8,
+        n_action_steps=8,
+        dim_model=32,
+        n_heads=4,
+        dim_feedforward=64,
+        n_encoder_layers=2,
+        n_decoder_layers=2,
+        n_vae_encoder_layers=2,
+        latent_dim=8,
+        dropout=0.0,  # remove stochasticity; preserve_rng_state=True only matches the *mask*, not zero-dropout
+        pretrained_backbone_weights=None,  # avoid downloading ImageNet weights in tests
+        gradient_checkpointing=gradient_checkpointing,
+    )
+
+
+def make_batch(config: ACTConfig, batch_size: int = 2) -> dict[str, torch.Tensor]:
+    return {
+        OBS_STATE: torch.randn(batch_size, 4),
+        OBS_IMAGE: torch.rand(batch_size, 3, 64, 64),
+        ACTION: torch.randn(batch_size, config.chunk_size, 3),
+        "action_is_pad": torch.zeros(batch_size, config.chunk_size, dtype=torch.bool),
+    }
+
+
+def test_act_gradient_checkpointing_matches_non_checkpointed():
+    policy_a = ACTPolicy(make_config(gradient_checkpointing=False))
+    policy_b = ACTPolicy(make_config(gradient_checkpointing=True))
+    policy_b.load_state_dict(policy_a.state_dict())
+
+    assert policy_a.model.gradient_checkpointing_enabled is False
+    assert policy_b.model.gradient_checkpointing_enabled is True
+    assert policy_a.model.encoder.gradient_checkpointing_enabled is False
+    assert policy_b.model.encoder.gradient_checkpointing_enabled is True
+    assert policy_b.model.decoder.gradient_checkpointing_enabled is True
+    assert policy_b.model.vae_encoder.gradient_checkpointing_enabled is True
+
+    policy_a.train()
+    policy_b.train()  # must be train() mode: the checkpoint gate is `... and self.training`
+
+    batch = make_batch(policy_a.config)
+
+    torch.manual_seed(123)
+    loss_a, _ = policy_a(batch)
+    loss_a.backward()
+
+    torch.manual_seed(123)
+    loss_b, _ = policy_b(batch)
+    loss_b.backward()
+
+    torch.testing.assert_close(loss_a, loss_b, rtol=1e-6, atol=1e-7)
+
+    for (name_a, p_a), (name_b, p_b) in zip(
+        policy_a.named_parameters(), policy_b.named_parameters(), strict=True
+    ):
+        assert name_a == name_b
+        if p_a.grad is None:
+            assert p_b.grad is None
+            continue
+        torch.testing.assert_close(p_a.grad, p_b.grad, rtol=1e-5, atol=1e-6, msg=f"grad mismatch at {name_a}")
+
+
+def test_act_gradient_checkpointing_enable_disable_toggle():
+    policy = ACTPolicy(make_config(gradient_checkpointing=False))
+    policy.train()
+    batch = make_batch(policy.config)
+
+    assert policy.model.gradient_checkpointing_enabled is False
+    torch.manual_seed(7)
+    loss_before, _ = policy(batch)
+
+    policy.model.gradient_checkpointing_enable()
+    assert policy.model.gradient_checkpointing_enabled is True
+    assert policy.model.encoder.gradient_checkpointing_enabled is True
+    torch.manual_seed(7)
+    loss_after, _ = policy(batch)
+
+    torch.testing.assert_close(loss_before, loss_after, rtol=1e-6, atol=1e-7)
+
+    policy.model.gradient_checkpointing_disable()
+    assert policy.model.gradient_checkpointing_enabled is False
+    assert policy.model.encoder.gradient_checkpointing_enabled is False


### PR DESCRIPTION
## Summary / Motivation

Gradient checkpointing (recomputing activations during backward instead of storing them) is already implemented for the larger VLA policies in this repo (Pi0, Pi0Fast, Pi0.5, GR00T, XVLA, EO1, MolmoAct2, Evo1, FastWAM, VLA-JEPA, LingbotVA) but was completely absent from ACT. On a 12GB consumer GPU, ACT's usable batch size is limited well below what fits once activation memory is reclaimed via recomputation. This adds the same `gradient_checkpointing: bool` config field + `gradient_checkpointing_enable()`/`disable()` pattern already used by Pi0, and additionally checkpoints the vision backbone (not just the transformer encoder/decoder layers) — safe here because ACT's default backbone uses `torchvision.ops.misc.FrozenBatchNorm2d` (pure function of input + fixed buffers, no running-stat mutation, no randomness), unlike policies whose default backbone uses trainable `BatchNorm2d`, where checkpointing under pretrained weights is not safe. Checkpointing the backbone is what delivers the large real-world win below.

## Related issues

- Fixes / Closes: # (none — found via internal memory-budget testing, not a reported bug)
- Related: #4127 (a related fix for a different policy that hit the same BatchNorm-safety consideration; not fixing the same code)

## What changed

- `configuration_act.py`: added `gradient_checkpointing: bool = False` field.
- `modeling_act.py`: added `gradient_checkpointing_enable()`/`disable()` methods; wrapped the `ACTEncoder`/`ACTDecoder` per-layer forward calls and the vision backbone forward (`self.backbone(img)`, via a `_backbone_forward` helper) in `torch.utils.checkpoint.checkpoint`, gated on `self.gradient_checkpointing_enabled and self.training`. `preserve_rng_state=True` for encoder/decoder/VAE-encoder layers (dropout present there); `preserve_rng_state=False` for the backbone (no dropout, `FrozenBatchNorm2d` only — verified by reading its `forward()`).
- `docs/source/act.mdx`: added a training-tips line pointing at the new flag, matching the existing documented pattern for Pi0.
- No breaking changes — flag defaults to `False`, existing behavior unchanged when unset.

## How was this tested (or how to run locally)

- New test: `tests/policies/test_act_gradient_checkpointing.py` (2 tests) — checkpointed vs. non-checkpointed runs produce matching loss/gradients across every parameter at tight tolerance, plus an enable/disable toggle test. Run: `pytest -q tests/policies/test_act_gradient_checkpointing.py`
- GPU verification on a real training run (SO-101 arm, `so101_screwdriver_pickplace_v2` dataset, single 12GB consumer GPU):
  - Batch-size ceiling (20-step smoke runs): 22 reliable / 23 OOMs without checkpointing → 86 reliable (87-88 flaky, ≥90 solid OOM) with checkpointing — **~3.9x** on a reliable-to-reliable basis.
  - Peak memory at production batch=16 (training script's own `mem_gb`): 6.85GB → 2.18GB (**~68% reduction**).
  - Step time at fixed batch=16 (steady-state): 0.476-0.481s → 0.639-0.654s (**~35% slower per step** — the expected cost of recomputing forward activations; the win is a much larger batch fitting at all, not faster training at a fixed batch).
  - Correctness re-verified on 100 real training steps at production batch=16 (`--seed=1000`): loss matched to 3 decimals at every logged step; gradient norm matched to 4-5 significant figures (the small residual is floating-point accumulation-order noise from recomputation, not an algorithmic difference).
  - Caveat: only 1 of the intended decoder layers runs by default (a pre-existing, separate upstream bug in `configuration_act.py`), so decoder-side checkpointing has negligible benefit under default config — the encoder (4 layers) and the backbone are where the real value is.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`) — clean on all changed files
- [x] All tests pass locally (`pytest`) — new test file passes; correctness also re-verified on real training steps on real hardware (see above)
- [x] Documentation updated — `docs/source/act.mdx`
- [ ] CI is green — not yet run (pending push)
- [x] Community Review: I have reviewed another contributor's open PR and linked it here: #4112

## Reviewer notes

- Companion PR: SmolVLA gradient checkpointing (same motivation), filed alongside this one.
- Diffusion Policy was also scoped for the same treatment but not filed: internal testing found the checkpointed region there isn't the actual memory bottleneck (the vision encoder is, and it can't be safely checkpointed under default pretrained `BatchNorm2d` weights) — #4127 has since landed upstream with an equivalent finding for that policy.
- The ~35% per-step slowdown at fixed batch is real and expected — please weigh this as "unlocks a much larger batch," not "makes training faster at the same batch."
- **AI-assistance disclosure (per `AI_POLICY.md`):** this implementation, its tests, and this PR description were developed substantially with Claude Code (Anthropic's AI coding assistant). All GPU verification was run and inspected firsthand on real hardware and a real dataset by the author, who directed the design and reviewed all code before submission.
