### PR TITLE
feat(smolvla): add gradient checkpointing support

### DIFF
--- a/docs/source/smolvla.mdx
+++ b/docs/source/smolvla.mdx
@@ -65,6 +65,8 @@ cd lerobot && lerobot-train \
   --wandb.enable=true
 ```
 
+If you're constrained by GPU memory, add `--policy.gradient_checkpointing=true` to trade some training speed for a significantly larger batch size.
+
 <Tip>
   You can start with a small batch size and increase it incrementally, if the
   GPU allows it, as long as loading times remain short.

--- a/src/lerobot/policies/smolvla/configuration_smolvla.py
+++ b/src/lerobot/policies/smolvla/configuration_smolvla.py
@@ -105,6 +105,7 @@ class SmolVLAConfig(PreTrainedConfig):
 
     compile_model: bool = False  # Whether to use torch.compile for model optimization
     compile_mode: str = "max-autotune"  # Torch compile mode
+    gradient_checkpointing: bool = False  # Enable gradient checkpointing on the VLM+expert layer loop
 
     def __post_init__(self):
         super().__post_init__()

--- a/src/lerobot/policies/smolvla/modeling_smolvla.py
+++ b/src/lerobot/policies/smolvla/modeling_smolvla.py
@@ -505,6 +505,8 @@ class VLAFlowMatching(nn.Module):
             expert_width_multiplier=self.config.expert_width_multiplier,
             device=self.config.device if self.config.device is not None else "auto",
         )
+        if self.config.gradient_checkpointing:
+            self.vlm_with_expert.gradient_checkpointing_enable()
         self.state_proj = nn.Linear(
             self.config.max_state_dim, self.vlm_with_expert.config.text_config.hidden_size
         )

--- a/src/lerobot/policies/smolvla/modeling_smolvla.py
+++ b/src/lerobot/policies/smolvla/modeling_smolvla.py
@@ -502,6 +502,8 @@ class VLAFlowMatching(nn.Module):
             expert_width_multiplier=self.config.expert_width_multiplier,
             device=self.config.device if self.config.device is not None else "auto",
         )
+        if self.config.gradient_checkpointing:
+            self.vlm_with_expert.gradient_checkpointing_enable()
         self.state_proj = nn.Linear(
             self.config.max_state_dim, self.vlm_with_expert.config.text_config.hidden_size
         )

--- a/src/lerobot/policies/smolvla/smolvlm_with_expert.py
+++ b/src/lerobot/policies/smolvla/smolvlm_with_expert.py
@@ -146,6 +146,22 @@ class SmolVLMWithExpertModel(nn.Module):
         self.expert_hidden_size = lm_expert_config.hidden_size
         self.set_requires_grad()
 
+        # Gradient checkpointing flag. Note: the vision encoder (`embed_image`, called separately from
+        # `forward` below) is intentionally NOT checkpointed here. With the default
+        # `freeze_vision_encoder=True` / `train_expert_only=True`, none of its inputs or parameters require
+        # grad, so PyTorch's autograd never builds a graph for it in the first place (nothing to save,
+        # nothing for checkpointing to trade away). Checkpointing targets the joint VLM+expert layer loop in
+        # `forward`, where the trainable expert actually needs backward activations.
+        self.gradient_checkpointing_enabled = False
+
+    def gradient_checkpointing_enable(self) -> None:
+        """Enable gradient checkpointing for memory optimization."""
+        self.gradient_checkpointing_enabled = True
+
+    def gradient_checkpointing_disable(self) -> None:
+        """Disable gradient checkpointing."""
+        self.gradient_checkpointing_enabled = False
+
     def get_vlm_model(self):
         return self.vlm.model
 
@@ -398,6 +414,86 @@ class SmolVLMWithExpertModel(nn.Module):
             expert_layers.append(expert_layer)
         return [vlm_layers, expert_layers]
 
+    def _compute_layer(
+        self,
+        model_layers,
+        inputs_embeds,
+        layer_idx,
+        position_ids,
+        attention_mask,
+        batch_size,
+        head_dim,
+        use_cache,
+        fill_kv_cache,
+        past_key_values,
+    ):
+        """One VLM+expert transformer layer (joint attention + per-stream residual/MLP).
+
+        Factored out of `forward` so it can be wrapped in `torch.utils.checkpoint`. Only called under
+        checkpointing when `not use_cache` (see `forward`), so the `past_key_values.update(...)`
+        mutation inside `forward_attn_layer` never actually fires in that path (it's gated on
+        `use_cache`) — safe to recompute.
+        """
+        if (
+            fill_kv_cache
+            or "cross" not in self.attention_mode
+            or (self.self_attn_every_n_layers > 0 and layer_idx % self.self_attn_every_n_layers == 0)
+        ):
+            att_outputs, past_key_values = self.forward_attn_layer(
+                model_layers,
+                inputs_embeds,
+                layer_idx,
+                position_ids,
+                attention_mask,
+                batch_size,
+                head_dim,
+                use_cache=use_cache,
+                past_key_values=past_key_values,
+            )
+        else:
+            att_outputs, past_key_values = self.forward_cross_attn_layer(
+                model_layers,
+                inputs_embeds,
+                layer_idx,
+                position_ids,
+                attention_mask,
+                batch_size,
+                head_dim,
+                use_cache=use_cache,
+                past_key_values=past_key_values,
+            )
+        outputs_embeds = []
+        start = 0
+        for i, hidden_states in enumerate(inputs_embeds):
+            layer = model_layers[i][layer_idx]
+            att_output = att_outputs[i] if i < len(att_outputs) else att_outputs[0]  # in case of self_attn
+            if hidden_states is not None:
+                if layer is None:
+                    outputs_embeds.append(hidden_states)
+                    continue
+                end = start + hidden_states.shape[1]
+
+                if att_output.dtype != layer.self_attn.o_proj.weight.dtype:
+                    att_output = att_output.to(layer.self_attn.o_proj.weight.dtype)
+                att_out = att_output[:, start:end]
+                out_emb = layer.self_attn.o_proj(att_out)
+
+                out_emb += hidden_states
+                after_first_residual = out_emb.clone()
+
+                out_emb = layer.post_attention_layernorm(out_emb)
+                out_emb = layer.mlp(out_emb)
+
+                out_emb += after_first_residual
+
+                outputs_embeds.append(out_emb)
+
+                start = end if len(att_outputs) == 1 else 0
+            else:
+                outputs_embeds.append(None)
+
+        return outputs_embeds, past_key_values
+
     def forward(
         self,
         attention_mask: torch.Tensor | None = None,
@@ -426,13 +522,14 @@ class SmolVLMWithExpertModel(nn.Module):
         # RMSNorm
         num_layers = self.num_vlm_layers
         head_dim = self.vlm.config.text_config.head_dim
+        # Checkpointing is only safe when `not use_cache`: the KV-cache mutation inside `_compute_layer`
+        # is gated on `use_cache`, so it never fires here, and recomputing during backward is side-effect
+        # free. `use_cache=True` is only used for inference/generation, never for the training forward pass.
+        checkpoint_layers = self.gradient_checkpointing_enabled and self.training and not use_cache
         for layer_idx in range(num_layers):
-            if (
-                fill_kv_cache
-                or "cross" not in self.attention_mode
-                or (self.self_attn_every_n_layers > 0 and layer_idx % self.self_attn_every_n_layers == 0)
-            ):
-                att_outputs, past_key_values = self.forward_attn_layer(
+            if checkpoint_layers:
+                outputs_embeds, past_key_values = torch.utils.checkpoint.checkpoint(
+                    self._compute_layer,
                     model_layers,
                     inputs_embeds,
                     layer_idx,
@@ -440,11 +537,14 @@ class SmolVLMWithExpertModel(nn.Module):
                     attention_mask,
                     batch_size,
                     head_dim,
-                    use_cache=use_cache,
-                    past_key_values=past_key_values,
+                    use_cache,
+                    fill_kv_cache,
+                    past_key_values,
+                    use_reentrant=False,
+                    preserve_rng_state=False,  # no dropout/randomness anywhere in _compute_layer
                 )
             else:
-                att_outputs, past_key_values = self.forward_cross_attn_layer(
+                outputs_embeds, past_key_values = self._compute_layer(
                     model_layers,
                     inputs_embeds,
                     layer_idx,
@@ -452,40 +552,10 @@ class SmolVLMWithExpertModel(nn.Module):
                     attention_mask,
                     batch_size,
                     head_dim,
-                    use_cache=use_cache,
-                    past_key_values=past_key_values,
+                    use_cache,
+                    fill_kv_cache,
+                    past_key_values,
                 )
-            outputs_embeds = []
-            start = 0
-            for i, hidden_states in enumerate(inputs_embeds):
-                layer = model_layers[i][layer_idx]
-                att_output = (
-                    att_outputs[i] if i < len(att_outputs) else att_outputs[0]
-                )  # in case of self_attn
-                if hidden_states is not None:
-                    if layer is None:
-                        outputs_embeds.append(hidden_states)
-                        continue
-                    end = start + hidden_states.shape[1]
-
-                    if att_output.dtype != layer.self_attn.o_proj.weight.dtype:
-                        att_output = att_output.to(layer.self_attn.o_proj.weight.dtype)
-                    att_out = att_output[:, start:end]
-                    out_emb = layer.self_attn.o_proj(att_out)
-
-                    out_emb += hidden_states
-                    after_first_residual = out_emb.clone()
-
-                    out_emb = layer.post_attention_layernorm(out_emb)
-                    out_emb = layer.mlp(out_emb)
-
-                    out_emb += after_first_residual
-
-                    outputs_embeds.append(out_emb)
-
-                    start = end if len(att_outputs) == 1 else 0
-                else:
-                    outputs_embeds.append(None)
 
             inputs_embeds = outputs_embeds
 

--- a/src/lerobot/policies/smolvla/smolvlm_with_expert.py
+++ b/src/lerobot/policies/smolvla/smolvlm_with_expert.py
@@ -146,6 +146,22 @@ class SmolVLMWithExpertModel(nn.Module):
         self.expert_hidden_size = lm_expert_config.hidden_size
         self.set_requires_grad()
 
+        # Gradient checkpointing flag. Note: the vision encoder (`embed_image`, called separately from
+        # `forward` below) is intentionally NOT checkpointed here. With the default
+        # `freeze_vision_encoder=True` / `train_expert_only=True`, none of its inputs or parameters require
+        # grad, so PyTorch's autograd never builds a graph for it in the first place (nothing to save,
+        # nothing for checkpointing to trade away). Checkpointing targets the joint VLM+expert layer loop in
+        # `forward`, where the trainable expert actually needs backward activations.
+        self.gradient_checkpointing_enabled = False
+
+    def gradient_checkpointing_enable(self) -> None:
+        """Enable gradient checkpointing for memory optimization."""
+        self.gradient_checkpointing_enabled = True
+
+    def gradient_checkpointing_disable(self) -> None:
+        """Disable gradient checkpointing."""
+        self.gradient_checkpointing_enabled = False
+
     def get_vlm_model(self):
         return self.vlm.model
 
@@ -407,6 +423,86 @@ class SmolVLMWithExpertModel(nn.Module):
             expert_layers.append(expert_layer)
         return [vlm_layers, expert_layers]
 
+    def _compute_layer(
+        self,
+        model_layers,
+        inputs_embeds,
+        layer_idx,
+        position_ids,
+        attention_mask,
+        batch_size,
+        head_dim,
+        use_cache,
+        fill_kv_cache,
+        past_key_values,
+    ):
+        """One VLM+expert transformer layer (joint attention + per-stream residual/MLP).
+
+        Factored out of `forward` so it can be wrapped in `torch.utils.checkpoint`. Only called under
+        checkpointing when `not use_cache` (see `forward`), so the `past_key_values.update(...)`
+        mutation inside `forward_attn_layer` never actually fires in that path (it's gated on
+        `use_cache`) — safe to recompute.
+        """
+        if (
+            fill_kv_cache
+            or "cross" not in self.attention_mode
+            or (self.self_attn_every_n_layers > 0 and layer_idx % self.self_attn_every_n_layers == 0)
+        ):
+            att_outputs, past_key_values = self.forward_attn_layer(
+                model_layers,
+                inputs_embeds,
+                layer_idx,
+                position_ids,
+                attention_mask,
+                batch_size,
+                head_dim,
+                use_cache=use_cache,
+                past_key_values=past_key_values,
+            )
+        else:
+            att_outputs, past_key_values = self.forward_cross_attn_layer(
+                model_layers,
+                inputs_embeds,
+                layer_idx,
+                position_ids,
+                attention_mask,
+                batch_size,
+                head_dim,
+                use_cache=use_cache,
+                past_key_values=past_key_values,
+            )
+        outputs_embeds = []
+        start = 0
+        for i, hidden_states in enumerate(inputs_embeds):
+            layer = model_layers[i][layer_idx]
+            att_output = att_outputs[i] if i < len(att_outputs) else att_outputs[0]  # in case of self_attn
+            if hidden_states is not None:
+                if layer is None:
+                    outputs_embeds.append(hidden_states)
+                    continue
+                end = start + hidden_states.shape[1]
+
+                if att_output.dtype != layer.self_attn.o_proj.weight.dtype:
+                    att_output = att_output.to(layer.self_attn.o_proj.weight.dtype)
+                att_out = att_output[:, start:end]
+                out_emb = layer.self_attn.o_proj(att_out)
+
+                out_emb += hidden_states
+                after_first_residual = out_emb.clone()
+
+                out_emb = layer.post_attention_layernorm(out_emb)
+                out_emb = layer.mlp(out_emb)
+
+                out_emb += after_first_residual
+
+                outputs_embeds.append(out_emb)
+
+                start = end if len(att_outputs) == 1 else 0
+            else:
+                outputs_embeds.append(None)
+
+        return outputs_embeds, past_key_values
+
     def forward(
         self,
         attention_mask: torch.Tensor | None = None,
@@ -435,13 +531,14 @@ class SmolVLMWithExpertModel(nn.Module):
         # RMSNorm
         num_layers = self.num_vlm_layers
         head_dim = self.vlm.config.text_config.head_dim
+        # Checkpointing is only safe when `not use_cache`: the KV-cache mutation inside `_compute_layer`
+        # is gated on `use_cache`, so it never fires here, and recomputing during backward is side-effect
+        # free. `use_cache=True` is only used for inference/generation, never for the training forward pass.
+        checkpoint_layers = self.gradient_checkpointing_enabled and self.training and not use_cache
         for layer_idx in range(num_layers):
-            if (
-                fill_kv_cache
-                or "cross" not in self.attention_mode
-                or (self.self_attn_every_n_layers > 0 and layer_idx % self.self_attn_every_n_layers == 0)
-            ):
-                att_outputs, past_key_values = self.forward_attn_layer(
+            if checkpoint_layers:
+                outputs_embeds, past_key_values = torch.utils.checkpoint.checkpoint(
+                    self._compute_layer,
                     model_layers,
                     inputs_embeds,
                     layer_idx,
@@ -449,11 +546,14 @@ class SmolVLMWithExpertModel(nn.Module):
                     attention_mask,
                     batch_size,
                     head_dim,
-                    use_cache=use_cache,
-                    past_key_values=past_key_values,
+                    use_cache,
+                    fill_kv_cache,
+                    past_key_values,
+                    use_reentrant=False,
+                    preserve_rng_state=False,  # no dropout/randomness anywhere in _compute_layer
                 )
             else:
-                att_outputs, past_key_values = self.forward_cross_attn_layer(
+                outputs_embeds, past_key_values = self._compute_layer(
                     model_layers,
                     inputs_embeds,
                     layer_idx,
@@ -461,40 +561,10 @@ class SmolVLMWithExpertModel(nn.Module):
                     attention_mask,
                     batch_size,
                     head_dim,
-                    use_cache=use_cache,
-                    past_key_values=past_key_values,
+                    use_cache,
+                    fill_kv_cache,
+                    past_key_values,
                 )
-            outputs_embeds = []
-            start = 0
-            for i, hidden_states in enumerate(inputs_embeds):
-                layer = model_layers[i][layer_idx]
-                att_output = (
-                    att_outputs[i] if i < len(att_outputs) else att_outputs[0]
-                )  # in case of self_attn
-                if hidden_states is not None:
-                    if layer is None:
-                        outputs_embeds.append(hidden_states)
-                        continue
-                    end = start + hidden_states.shape[1]
-
-                    if att_output.dtype != layer.self_attn.o_proj.weight.dtype:
-                        att_output = att_output.to(layer.self_attn.o_proj.weight.dtype)
-                    att_out = att_output[:, start:end]
-                    out_emb = layer.self_attn.o_proj(att_out)
-
-                    out_emb += hidden_states
-                    after_first_residual = out_emb.clone()
-
-                    out_emb = layer.post_attention_layernorm(out_emb)
-                    out_emb = layer.mlp(out_emb)
-
-                    out_emb += after_first_residual
-
-                    outputs_embeds.append(out_emb)
-
-                    start = end if len(att_outputs) == 1 else 0
-                else:
-                    outputs_embeds.append(None)
 
             inputs_embeds = outputs_embeds
 

--- a/tests/policies/smolvla/test_smolvla_gradient_checkpointing.py
+++ b/tests/policies/smolvla/test_smolvla_gradient_checkpointing.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python
+
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Verify that enabling gradient checkpointing on SmolVLA does not change numerics.
+
+Gradient checkpointing recomputes the joint VLM+expert transformer layer loop
+(`SmolVLMWithExpertModel._compute_layer`) during the backward pass instead of storing its activations.
+It must be a pure memory/compute trade-off: given identical weights and identical inputs, the loss and
+every parameter gradient must match a non-checkpointed run.
+
+No dropout exists anywhere in `SmolVLMWithExpertModel`, so `preserve_rng_state=False` is used and no
+special stochasticity handling is needed in the test config (contrast with ACT, which needs
+`dropout=0.0`).
+
+Uses `load_vlm_weights=False` (random-init architecture, not the pretrained 500M weights) and small
+`num_vlm_layers`/`num_expert_layers` to keep this fast; still exercises the real SmolVLM2 config/tokenizer
+path via `AutoConfig.from_pretrained`, so it needs network access (or an HF cache hit) and `transformers`.
+"""
+
+import pytest
+import torch
+
+from lerobot.configs.types import FeatureType, PolicyFeature
+from lerobot.policies.smolvla.configuration_smolvla import SmolVLAConfig
+from lerobot.utils.constants import ACTION, OBS_LANGUAGE_ATTENTION_MASK, OBS_LANGUAGE_TOKENS, OBS_STATE
+from tests.utils import require_cuda, skip_if_package_missing
+
+OBS_IMAGE = "observation.images.base_0_rgb"
+
+
+def make_config(*, gradient_checkpointing: bool) -> SmolVLAConfig:
+    """A small, fast, offline-safe (given HF cache) SmolVLAConfig for unit testing."""
+    config = SmolVLAConfig(
+        input_features={
+            OBS_STATE: PolicyFeature(type=FeatureType.STATE, shape=(6,)),
+            OBS_IMAGE: PolicyFeature(type=FeatureType.VISUAL, shape=(3, 64, 64)),
+        },
+        output_features={
+            ACTION: PolicyFeature(type=FeatureType.ACTION, shape=(6,)),
+        },
+        chunk_size=4,
+        n_action_steps=4,
+        max_state_dim=6,
+        max_action_dim=6,
+        resize_imgs_with_padding=(64, 64),
+        tokenizer_max_length=8,
+        load_vlm_weights=False,  # random-init architecture, not the pretrained 500M weights
+        num_vlm_layers=2,
+        num_expert_layers=2,
+        self_attn_every_n_layers=1,
+        expert_width_multiplier=0.5,
+        gradient_checkpointing=gradient_checkpointing,
+    )
+    return config
+
+
+def make_batch(config: SmolVLAConfig, batch_size: int = 2) -> dict[str, torch.Tensor]:
+    return {
+        OBS_STATE: torch.randn(batch_size, 6),
+        OBS_IMAGE: torch.rand(batch_size, 3, 64, 64),
+        ACTION: torch.randn(batch_size, config.chunk_size, 6),
+        "action_is_pad": torch.zeros(batch_size, config.chunk_size, dtype=torch.bool),
+        OBS_LANGUAGE_TOKENS: torch.randint(1, 100, (batch_size, config.tokenizer_max_length)),
+        OBS_LANGUAGE_ATTENTION_MASK: torch.ones(batch_size, config.tokenizer_max_length, dtype=torch.bool),
+    }
+
+
+@skip_if_package_missing("transformers")
+@require_cuda
+def test_smolvla_gradient_checkpointing_matches_non_checkpointed():
+    from lerobot.policies.smolvla.modeling_smolvla import SmolVLAPolicy
+
+    policy_a = SmolVLAPolicy(make_config(gradient_checkpointing=False)).to("cuda")
+    policy_b = SmolVLAPolicy(make_config(gradient_checkpointing=True)).to("cuda")
+    policy_b.load_state_dict(policy_a.state_dict())
+
+    assert policy_a.model.vlm_with_expert.gradient_checkpointing_enabled is False
+    assert policy_b.model.vlm_with_expert.gradient_checkpointing_enabled is True
+
+    policy_a.train()
+    policy_b.train()  # must be train() mode: the checkpoint gate is `... and self.training`
+
+    batch = {k: v.to("cuda") for k, v in make_batch(policy_a.config).items()}
+
+    torch.manual_seed(123)
+    noise = policy_a.model.sample_noise(
+        (batch[ACTION].shape[0], policy_a.config.chunk_size, policy_a.config.max_action_dim), "cuda"
+    )
+    time = policy_a.model.sample_time(batch[ACTION].shape[0], "cuda")
+
+    loss_a, _ = policy_a(dict(batch), noise=noise.clone(), time=time.clone())
+    loss_a.backward()
+
+    loss_b, _ = policy_b(dict(batch), noise=noise.clone(), time=time.clone())
+    loss_b.backward()
+
+    torch.testing.assert_close(loss_a, loss_b, rtol=1e-4, atol=1e-5)
+
+    for (name_a, p_a), (name_b, p_b) in zip(
+        policy_a.named_parameters(), policy_b.named_parameters(), strict=True
+    ):
+        assert name_a == name_b
+        if p_a.grad is None:
+            assert p_b.grad is None, f"{name_a}: grad present in checkpointed run but not baseline"
+            continue
+        if p_b.grad is None:
+            pytest.fail(f"{name_a}: grad present in baseline but not checkpointed run")
+        torch.testing.assert_close(p_a.grad, p_b.grad, rtol=1e-3, atol=1e-4, msg=f"grad mismatch at {name_a}")
+
+
+@skip_if_package_missing("transformers")
+@require_cuda
+def test_smolvla_gradient_checkpointing_enable_disable_toggle():
+    from lerobot.policies.smolvla.modeling_smolvla import SmolVLAPolicy
+
+    policy = SmolVLAPolicy(make_config(gradient_checkpointing=False)).to("cuda")
+    policy.train()
+    batch = {k: v.to("cuda") for k, v in make_batch(policy.config).items()}
+
+    noise = policy.model.sample_noise(
+        (batch[ACTION].shape[0], policy.config.chunk_size, policy.config.max_action_dim), "cuda"
+    )
+    time = policy.model.sample_time(batch[ACTION].shape[0], "cuda")
+
+    assert policy.model.vlm_with_expert.gradient_checkpointing_enabled is False
+    loss_before, _ = policy(dict(batch), noise=noise.clone(), time=time.clone())
+
+    policy.model.vlm_with_expert.gradient_checkpointing_enable()
+    assert policy.model.vlm_with_expert.gradient_checkpointing_enabled is True
+    loss_after, _ = policy(dict(batch), noise=noise.clone(), time=time.clone())
+
+    torch.testing.assert_close(loss_before, loss_after, rtol=1e-4, atol=1e-5)
+
+    policy.model.vlm_with_expert.gradient_checkpointing_disable()
+    assert policy.model.vlm_with_expert.gradient_checkpointing_enabled is False
+
+
+@skip_if_package_missing("transformers")
+@require_cuda
+def test_smolvla_gradient_checkpointing_not_used_during_inference():
+    """Checkpointing must never engage for KV-cached inference (use_cache=True) even if enabled."""
+    from lerobot.policies.smolvla.modeling_smolvla import SmolVLAPolicy
+
+    policy = SmolVLAPolicy(make_config(gradient_checkpointing=True)).to("cuda")
+    policy.eval()
+    assert policy.model.vlm_with_expert.gradient_checkpointing_enabled is True
+
+    batch = {k: v.to("cuda") for k, v in make_batch(policy.config).items()}
+    with torch.no_grad():
+        actions = policy.predict_action_chunk(dict(batch))
+    assert actions.shape[0] == batch[OBS_STATE].shape[0]


### PR DESCRIPTION
## Summary / Motivation

Gradient checkpointing is already implemented for the larger VLA policies in this repo (Pi0, Pi0Fast, Pi0.5, GR00T, XVLA, EO1, MolmoAct2, Evo1, FastWAM, VLA-JEPA, LingbotVA) but was completely absent from SmolVLA. On a 12GB consumer GPU, SmolVLA's usable batch size is limited well below what fits once activation memory is reclaimed via recomputation — internal testing also found that LoRA (which only shrinks optimizer-state memory) does not move SmolVLA's OOM point at all, confirming activation memory, not weight/optimizer memory, is the real bottleneck here. This adds the same `gradient_checkpointing: bool` config field + enable/disable pattern already used by Pi0, applied to `SmolVLMWithExpertModel`'s per-layer forward loop.

## Related issues

- Fixes / Closes: # (none — found via internal memory-budget testing, not a reported bug)
- Related: # (none)

## What changed

- `configuration_smolvla.py`: added `gradient_checkpointing: bool = False` field.
- `modeling_smolvla.py`: added a one-line `gradient_checkpointing_enable()` hook in `VLAFlowMatching.__init__`.
- `smolvlm_with_expert.py`: extracted the per-layer loop body of `SmolVLMWithExpertModel.forward` into `_compute_layer`; wrapped it in `torch.utils.checkpoint.checkpoint(..., preserve_rng_state=False)` (no dropout anywhere in this model, so this is safe), gated on `self.gradient_checkpointing_enabled and self.training and not use_cache`. The `not use_cache` guard is required: the loop mutates a KV-cache object as a side effect, which would double-fire on checkpoint recompute — verified the training call path (`VLAFlowMatching.forward`) always passes `use_cache=False`, so checkpointing never engages on the cache-mutating branch. Vision encoder (`embed_image`) deliberately left uncheckpointed: `freeze_vision_encoder=True`/`train_expert_only=True` are both defaults, so no backward graph is built for it — nothing there for checkpointing to save.
- `docs/source/smolvla.mdx`: added a line pointing at the new flag for memory-constrained setups, matching the existing documented pattern for Pi0.
- No breaking changes — flag defaults to `False`, existing behavior unchanged when unset.

## How was this tested (or how to run locally)

- New tests: `tests/policies/smolvla/test_smolvla_gradient_checkpointing.py` — checkpointed vs. non-checkpointed runs produce matching loss/gradients, plus an enable/disable toggle test and a check that the `not use_cache` gate is respected. Run: `pytest -q tests/policies/smolvla/test_smolvla_gradient_checkpointing.py`
- GPU verification on a real training run (SO-101 arm, `so101_screwdriver_pickplace_v2` dataset, `lerobot/smolvla_base`, single 12GB consumer GPU):
  - Batch-size ceiling (15-step smoke runs): 40 reliable / 41 reliably OOMs without checkpointing → 176 reliable / 184 reliably OOM with checkpointing — **~4.4x**.
  - Peak memory at production batch=32 (training script's own `mem_gb`): 7.84GB → 2.32GB (**~70% reduction**).
  - Step time at fixed batch=32 (steady-state, same session): ~1.035s → ~1.21s (**~17% slower per step** — smallest compute penalty of the checkpointing efforts done on this codebase's smaller policies).
  - Correctness verified on 60 real training steps at production batch=32 (`--seed=1000`): loss and gradient norm were **bit-identical** at every logged step, with and without checkpointing.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`) — clean on all changed files
- [x] All tests pass locally (`pytest`) — new test file passes; correctness also verified on real training steps on real hardware (see above)
- [x] Documentation updated — `docs/source/smolvla.mdx`
- [ ] CI is green — not yet run (pending push)
- [x] Community Review: I have reviewed another contributor's open PR and linked it here: #4112

## Reviewer notes

- Companion PR: ACT gradient checkpointing (same motivation), filed alongside this one.
- The KV-cache gating (`not use_cache`) is the key correctness guard in this PR — please double check it if reviewing the checkpoint boundary, since the same loop path is reused for KV-cached generation/inference, where checkpointing must never engage.
- **AI-assistance disclosure (per `AI_POLICY.md`):** this implementation, its tests, and this PR description were developed substantially with Claude Code (Anthropic's AI coding assistant). All GPU verification was run and inspected firsthand on real hardware and a real dataset by the author, who directed the design and reviewed all code before submission.
