### PR TITLE
fix(rollout): apply torch compile mode correctly

### DIFF
--- a/src/lerobot/rollout/context.py
+++ b/src/lerobot/rollout/context.py
@@ -22,7 +22,7 @@ and :class:`DatasetContext` — assembled into :class:`RolloutContext`.
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from threading import Event
 
 import torch
@@ -58,6 +58,31 @@ from .inference import (
 from .robot_wrapper import ThreadSafeRobot
 
 logger = logging.getLogger(__name__)
+
+
+def _compile_predict_action_chunk(
+    policy: PreTrainedPolicy,
+    *,
+    backend: str,
+    mode: str,
+) -> bool:
+    """Compile a policy action function and report whether compilation was applied."""
+    if not hasattr(torch, "compile"):
+        logger.warning("torch.compile is not available in this PyTorch build")
+        return False
+
+    try:
+        policy.predict_action_chunk = torch.compile(
+            policy.predict_action_chunk,
+            backend=backend,
+            mode=mode,
+        )
+    except Exception as exc:
+        logger.warning("Failed to apply torch.compile: %s", exc)
+        return False
+
+    logger.info("torch.compile applied to predict_action_chunk")
+    return True
 
 
 def _resolve_action_key_order(
@@ -208,18 +233,16 @@ def build_rollout_context(
     policy.eval()
     logger.info("Policy loaded: type=%s, device=%s", policy_config.type, cfg.device)
 
+    torch_compile_active = cfg.use_torch_compile
     if cfg.use_torch_compile and policy.type not in ("pi0", "pi05"):
-        try:
-            if hasattr(torch, "compile"):
-                compile_kwargs = {
-                    "backend": cfg.torch_compile_backend,
-                    "mode": cfg.torch_compile_mode,
-                    "options": {"triton.cudagraphs": False},
-                }
-                policy.predict_action_chunk = torch.compile(policy.predict_action_chunk, **compile_kwargs)
-                logger.info("torch.compile applied to predict_action_chunk")
-        except Exception as e:
-            logger.warning("Failed to apply torch.compile: %s", e)
+        torch_compile_active = _compile_predict_action_chunk(
+            policy,
+            backend=cfg.torch_compile_backend,
+            mode=cfg.torch_compile_mode,
+        )
+
+    if cfg.use_torch_compile and not torch_compile_active:
+        cfg = replace(cfg, use_torch_compile=False)
 
     # --- 2. Robot-side processors (user-supplied or defaults) --------
     if (
@@ -426,7 +449,7 @@ def build_rollout_context(
         task=task_str,
         fps=cfg.fps,
         device=cfg.device,
-        use_torch_compile=cfg.use_torch_compile,
+        use_torch_compile=torch_compile_active,
         compile_warmup_inferences=cfg.compile_warmup_inferences,
         shutdown_event=shutdown_event,
     )

--- a/tests/test_rollout.py
+++ b/tests/test_rollout.py
@@ -343,6 +343,38 @@ def test_dagger_events_reset():
 # ---------------------------------------------------------------------------
 
 
+def test_compile_predict_action_chunk_uses_mode_without_options(monkeypatch):
+    from lerobot.rollout.context import _compile_predict_action_chunk
+
+    policy = MagicMock()
+    original_predict = policy.predict_action_chunk
+    compiled_predict = MagicMock()
+    compile_mock = MagicMock(return_value=compiled_predict)
+    monkeypatch.setattr(torch, "compile", compile_mock)
+
+    applied = _compile_predict_action_chunk(policy, backend="inductor", mode="reduce-overhead")
+
+    assert applied is True
+    assert policy.predict_action_chunk is compiled_predict
+    compile_mock.assert_called_once_with(
+        original_predict,
+        backend="inductor",
+        mode="reduce-overhead",
+    )
+
+
+def test_compile_predict_action_chunk_reports_failure(monkeypatch, caplog):
+    from lerobot.rollout.context import _compile_predict_action_chunk
+
+    policy = MagicMock()
+    monkeypatch.setattr(torch, "compile", MagicMock(side_effect=RuntimeError("compile failed")))
+
+    applied = _compile_predict_action_chunk(policy, backend="inductor", mode="default")
+
+    assert applied is False
+    assert "Failed to apply torch.compile: compile failed" in caplog.text
+
+
 def test_rollout_context_fields():
     from lerobot.rollout import RolloutContext
 


### PR DESCRIPTION
## Summary / Motivation

`lerobot-rollout --use_torch_compile=true` currently passes both `mode` and `options` to `torch.compile`, although PyTorch treats those arguments as mutually exclusive. The compile call fails and rollout silently continues in eager mode while RTC still receives the requested compile flag.

This change applies the configured backend and mode without the conflicting options, and tracks whether compilation was actually applied so downstream warm-up behavior reflects reality.

## Related issues

- Fixes #4114

## What changed

- compile `predict_action_chunk` with the configured backend and mode only
- return an explicit success state from the compilation boundary
- disable compile-dependent RTC warm-up behavior when compilation is unavailable or raises
- cover the successful compiler call and failure reporting with regression tests

No public API changes.

## How was this tested

- `uv run pytest -q tests/test_rollout.py` — 26 passed
- `uv run pre-commit run --files src/lerobot/rollout/context.py tests/test_rollout.py` — all applicable hooks passed, including Ruff, typos, secret detection, Bandit, and mypy
- `uv run ruff format --check src/lerobot/rollout/context.py tests/test_rollout.py`
- `git diff --check`

## Checklist

- [x] Linting and formatting run
- [x] Relevant tests pass locally
- [x] Documentation not required; behavior and CLI surface are unchanged
- [ ] CI is green
- [x] Community review completed: #4112

## Reviewer notes

Please focus on the effective compile-state propagation into RTC warm-up. AI assistance was used to draft the implementation and tests; the patch was then validated with the repository's targeted tests and full file-level pre-commit gate.
