### PR TITLE
docs: fix RoboMME Docker build command

### DIFF
--- a/docs/source/robomme.mdx
+++ b/docs/source/robomme.mdx
@@ -35,14 +35,11 @@ pip install --override <(printf 'gymnasium==0.29.1\nnumpy==1.26.4\n') \
 ### Docker (recommended)
 
 ```bash
-# Build base image first (from repo root)
-docker build -f docker/Dockerfile.eval-base -t lerobot-eval-base .
-
-# Build RoboMME eval image (applies gymnasium + numpy pin overrides)
-docker build -f docker/Dockerfile.benchmark.robomme -t lerobot-robomme .
+# Build the RoboMME evaluation image from the repo root
+docker build -f docker/Dockerfile.benchmark.robomme -t lerobot-benchmark-robomme .
 ```
 
-The `docker/Dockerfile.benchmark.robomme` image overrides `gymnasium==0.29.1` and `numpy==1.26.4` after lerobot's install. Both versions are runtime-safe for lerobot's actual API usage.
+The benchmark Dockerfile extends the published `huggingface/lerobot-gpu:latest` image, then overrides `gymnasium==0.29.1` and `numpy==1.26.4`. Both versions are runtime-safe for lerobot's actual API usage.
 
 ## Running Evaluation
 


### PR DESCRIPTION
## Summary / Motivation

The RoboMME guide tells readers to build `docker/Dockerfile.eval-base`, which is not present in the repository. The benchmark Dockerfile already extends the published LeRobot GPU image, so the extra base-image build step cannot run and is unnecessary.

## Related issues

- None.

## What changed

- Remove the command that references the missing `Dockerfile.eval-base`.
- Use the image tag documented by `Dockerfile.benchmark.robomme` and the benchmark CI.
- Clarify that the benchmark image extends `huggingface/lerobot-gpu:latest`.

This is documentation-only and has no runtime or API impact.

## How was this tested (or how to run locally)

- Confirmed `docker/Dockerfile.benchmark.robomme` exists and `docker/Dockerfile.eval-base` does not.
- Confirmed the benchmark Dockerfile uses `FROM huggingface/lerobot-gpu:latest`.
- Checked the documented Dockerfile path and tag against `.github/workflows/benchmark_tests.yml`.
- Ran `git diff --check`.

I did not build the GPU image locally.

## Checklist (required before merge)

- [ ] Linting/formatting run (`pre-commit run -a`)
- [ ] All tests pass locally (`pytest`)
- [x] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here.

## Reviewer notes

Please check that the guide should continue to use the published nightly GPU image as its base.

AI assistance disclosure: I used Codex to inspect the repository and draft this documentation fix. I verified every changed command and reference against the Dockerfile and CI configuration.
