### PR TITLE
fix(train): honor `policy.use_amp` when the policy has no `dtype` field

### DIFF
--- a/src/lerobot/scripts/lerobot_train.py
+++ b/src/lerobot/scripts/lerobot_train.py
@@ -214,9 +214,15 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
         # Accelerate auto-detects the device based on the available hardware and ignores the policy.device setting.
         # Force the device to be CPU when the active config's device is set to CPU (works for both policy and reward model training).
         force_cpu = cfg.trainable_config.device == "cpu"
-        # Drive Accelerate's autocast from policy.dtype (bf16/fp16 activate it; float32/absent -> launcher default).
+        # Drive Accelerate's autocast from policy.dtype (bf16/fp16 activate it; float32 -> full precision).
         policy_dtype = getattr(cfg.trainable_config, "dtype", None)
         mixed_precision = {"bfloat16": "bf16", "float16": "fp16", "float32": "no"}.get(policy_dtype)
+        # Policies without a `dtype` field fall back to `use_amp`, which would otherwise be
+        # silently ignored here while lerobot-eval honors it (bf16 where supported, else fp16
+        # to match torch.autocast's cuda default).
+        if mixed_precision is None and getattr(cfg.trainable_config, "use_amp", False):
+            use_bf16 = torch.cuda.is_available() and torch.cuda.is_bf16_supported()
+            mixed_precision = "bf16" if use_bf16 else "fp16"
         accelerator = Accelerator(
             step_scheduler_with_optimizer=False,
             mixed_precision=mixed_precision,


### PR DESCRIPTION

## Summary / Motivation

`--policy.use_amp=true` is silently ignored by `lerobot-train` for every policy that does not expose a string `dtype` config field (`act`, `diffusion`, `multi_task_dit`, ...). #3912 wires Accelerate's `mixed_precision` from `policy.dtype`; policies without that field resolve to `None`, so `accelerator.autocast()` stays a no-op and they always train in full fp32 — as was already the case before #3912, whose description notes that autocast "was always a no-op". This PR falls back to `use_amp` in that case.

This matters because the flag is documented and advertised as working: `lerobot-eval` honors `use_amp` (`lerobot_eval.py`: `torch.autocast(device_type=device.type) if cfg.policy.use_amp else nullcontext()`), `PreTrainedConfig.use_amp` is documented as applying to "training and evaluation", and several docs recipes (e.g. the Multitask DiT LIBERO command) recommend passing `--policy.use_amp=true`. Users who set it reasonably believe AMP is active during training when it is not.

Trade-off / design note: this changes numerics for users who explicitly set `use_amp=true` (they move from silent fp32 to real mixed precision — the behavior they asked for). The `use_amp=false` default is untouched, as is the `dtype`-based path from #3912. An alternative would be to deprecate `use_amp` in favor of `policy.dtype`; that seemed more invasive given most built-in policies do not define `dtype` and `use_amp` has been the documented interface since #199 (2024). Happy to switch approaches if maintainers prefer.

## Related issues

- Fixes / Closes: # (none open — reporting and fixing together)
- Related: #3912 (introduced the `dtype`-based wiring), #199 (introduced `use_amp`)

## What changed

- `lerobot_train.py`: when `getattr(cfg.trainable_config, "dtype", None)` yields no mapping (policy has no `dtype` field), `mixed_precision` now falls back to `use_amp` — `"bf16"` where supported, `"fp16"` otherwise, matching the `torch.autocast` CUDA default that `lerobot-eval` already uses.
- Policies that do expose `dtype` (e.g. pi05) are unaffected: `use_amp` is not consulted for them.
- No breaking change: `use_amp` defaults to `False`, so default training runs keep today's behavior exactly. Only runs that explicitly opt into AMP change, and they change toward the documented semantics.
- `PreTrainedConfig.validate()` already forces `use_amp = False` on devices without AMP support (`is_amp_available`), so the fallback cannot activate on unsupported hardware.

```python
policy_dtype = getattr(cfg.trainable_config, "dtype", None)
mixed_precision = {"bfloat16": "bf16", "float16": "fp16", "float32": "no"}.get(policy_dtype)
if mixed_precision is None and getattr(cfg.trainable_config, "use_amp", False):
    use_bf16 = torch.cuda.is_available() and torch.cuda.is_bf16_supported()
    mixed_precision = "bf16" if use_bf16 else "fp16"
```

## How was this tested (or how to run locally)

Measured on `multi_task_dit` / `lerobot/pusht`, batch 256, 1x H100-SXM, identical training step (AdamW, grad clip), comparing peak `torch.cuda.max_memory_allocated()`:

| Precision | Peak allocated |
|---|---|
| fp32 (current behavior, with `use_amp=true` set) | ~75 GiB |
| bf16 autocast (this PR) | ~46.5 GiB |

That is ~60% extra memory today, and a correspondingly reduced max batch size (256 vs 384 on an 80 GB card) for users who believe AMP is enabled because they set the documented flag.

Reproduce the "before" state on any policy without a `dtype` field:

```bash
lerobot-train --policy.type=multi_task_dit --dataset.repo_id=lerobot/pusht \
  --policy.use_amp=true --batch_size=256 --steps=10 --wandb.enable=false
# main: gpu_mem_gb ~75 (fp32); with this PR: ~46.5 (bf16 autocast)
```

- [ ] Tests added: none yet — happy to add a unit test asserting `Accelerator.mixed_precision` resolves as expected for (no `dtype` + `use_amp=true`), (no `dtype` + `use_amp=false`), and (`dtype=bfloat16`) if maintainers want it.
- [ ] `use_amp=false` default path re-verified unchanged.
- [ ] Policy with `dtype=bfloat16` (pi05) re-verified unchanged from #3912 behavior.

## Checklist (required before merge)

- [ ] Linting/formatting run (`pre-commit run -a`)
- [ ] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: # (insert PR number/link)

## Reviewer notes

- Main thing to confirm: the bf16-vs-fp16 choice for the fallback. I matched `lerobot-eval`'s `torch.autocast` CUDA default (fp16) but preferred bf16 where the hardware supports it, since fp16 without a `GradScaler` risks underflow. Accelerate handles scaling for `fp16`, but if maintainers would rather the fallback be bf16-only (and leave `use_amp` inert on pre-Ampere hardware), that is a one-line change.
- Second question: whether a `logging.warning` is wanted when `use_amp=true` is set on a policy that *does* define `dtype` (currently silently ignored there too, by design of #3912).
- Files: `src/lerobot/scripts/lerobot_train.py` only.
