### PR TITLE
fix(datasets): omit invalid aggregated quantiles

### DIFF
--- a/src/lerobot/datasets/compute_stats.py
+++ b/src/lerobot/datasets/compute_stats.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 import logging
+import warnings
 
 import numpy as np
 
@@ -607,14 +608,19 @@ def aggregate_feature_stats(stats_ft_list: list[dict[str, dict]]) -> dict[str, d
         "count": total_count,
     }
 
-    if stats_ft_list:
-        quantile_keys = [k for k in stats_ft_list[0] if k.startswith("q") and k[1:].isdigit()]
+    quantile_keys = [k for k in stats_ft_list[0] if k.startswith("q") and k[1:].isdigit()]
+    common_quantile_keys = [q_key for q_key in quantile_keys if all(q_key in s for s in stats_ft_list)]
 
-        for q_key in quantile_keys:
-            if all(q_key in s for s in stats_ft_list):
-                quantile_values = np.stack([s[q_key] for s in stats_ft_list])
-                weighted_quantiles = quantile_values * counts
-                aggregated[q_key] = weighted_quantiles.sum(axis=0) / total_count
+    if len(stats_ft_list) == 1:
+        for q_key in common_quantile_keys:
+            aggregated[q_key] = stats_ft_list[0][q_key].copy()
+    elif common_quantile_keys:
+        warnings.warn(
+            "Quantiles cannot be combined accurately from per-source summary statistics; "
+            "omitting aggregated quantiles. Recompute them from raw samples instead.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
 
     return aggregated
 

--- a/src/lerobot/datasets/compute_stats.py
+++ b/src/lerobot/datasets/compute_stats.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 import logging
+import warnings
 
 import numpy as np
 
@@ -607,21 +608,19 @@ def aggregate_feature_stats(stats_ft_list: list[dict[str, dict]]) -> dict[str, d
         "count": total_count,
     }
 
-    if stats_ft_list:
-        quantile_keys = [k for k in stats_ft_list[0] if k.startswith("q") and k[1:].isdigit()]
+    quantile_keys = [k for k in stats_ft_list[0] if k.startswith("q") and k[1:].isdigit()]
+    common_quantile_keys = [q_key for q_key in quantile_keys if all(q_key in s for s in stats_ft_list)]
 
-        for q_key in quantile_keys:
-            if all(q_key in s for s in stats_ft_list):
-                quantile_values = np.stack([s[q_key] for s in stats_ft_list])
-                # Exact global quantiles cannot be recovered from quantile summaries.
-                # Keep a conservative envelope of the available estimates: min
-                # for lower quantiles and max for upper quantiles. The resulting
-                # values are bounds across the inputs, not global quantile estimates.
-                q_percent = int(q_key[1:])
-                if q_percent <= 50:
-                    aggregated[q_key] = np.min(quantile_values, axis=0)
-                else:
-                    aggregated[q_key] = np.max(quantile_values, axis=0)
+    if len(stats_ft_list) == 1:
+        for q_key in common_quantile_keys:
+            aggregated[q_key] = stats_ft_list[0][q_key].copy()
+    elif common_quantile_keys:
+        warnings.warn(
+            "Quantiles cannot be combined accurately from per-source summary statistics; "
+            "omitting aggregated quantiles. Recompute them from raw samples instead.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
 
     return aggregated
 

--- a/tests/datasets/test_compute_stats.py
+++ b/tests/datasets/test_compute_stats.py
@@ -687,8 +687,7 @@ def test_compute_episode_stats_string_features_skipped():
     assert "q01" in stats["action"]
 
 
-def test_aggregate_feature_stats_with_quantiles():
-    """Test aggregating feature stats that include quantiles."""
+def test_aggregate_feature_stats_omits_non_composable_quantiles():
     stats_ft_list = [
         {
             "min": np.array([1.0]),
@@ -710,18 +709,11 @@ def test_aggregate_feature_stats_with_quantiles():
         },
     ]
 
-    result = aggregate_feature_stats(stats_ft_list)
+    with pytest.warns(RuntimeWarning, match="cannot be combined accurately"):
+        result = aggregate_feature_stats(stats_ft_list)
 
-    # Should preserve quantiles
-    assert "q01" in result
-    assert "q99" in result
-
-    # Verify quantile aggregation (weighted average)
-    expected_q01 = (1.5 * 100 + 2.5 * 150) / 250  # ≈ 2.1
-    expected_q99 = (9.5 * 100 + 11.5 * 150) / 250  # ≈ 10.7
-
-    np.testing.assert_allclose(result["q01"], np.array([expected_q01]), atol=1e-6)
-    np.testing.assert_allclose(result["q99"], np.array([expected_q99]), atol=1e-6)
+    assert "q01" not in result
+    assert "q99" not in result
 
 
 def test_aggregate_stats_mixed_quantiles():
@@ -878,3 +870,54 @@ def test_fixed_quantiles_always_computed():
         for q_key in expected_quantiles:
             assert q_key in episode_stats[key]
             assert episode_stats[key][q_key].shape == (features[key]["shape"][0],)
+
+
+def test_aggregate_stats_omits_non_composable_quantiles():
+    stats_1 = {
+        "observation.image": {
+            "min": np.array([0.0, 0.0, 0.0]).reshape(3, 1, 1),
+            "max": np.array([1.0, 1.0, 1.0]).reshape(3, 1, 1),
+            "mean": np.array([0.4, 0.4, 0.4]).reshape(3, 1, 1),
+            "std": np.array([0.1, 0.1, 0.1]).reshape(3, 1, 1),
+            "count": np.array([100]),
+            "q01": np.array([0.1, 0.1, 0.1]).reshape(3, 1, 1),
+            "q99": np.array([0.9, 0.9, 0.9]).reshape(3, 1, 1),
+        }
+    }
+    stats_2 = {
+        "observation.image": {
+            "min": np.array([0.0, 0.0, 0.0]).reshape(3, 1, 1),
+            "max": np.array([1.0, 1.0, 1.0]).reshape(3, 1, 1),
+            "mean": np.array([0.6, 0.6, 0.6]).reshape(3, 1, 1),
+            "std": np.array([0.1, 0.1, 0.1]).reshape(3, 1, 1),
+            "count": np.array([200]),
+            "q01": np.array([0.2, 0.2, 0.2]).reshape(3, 1, 1),
+            "q99": np.array([0.95, 0.95, 0.95]).reshape(3, 1, 1),
+        }
+    }
+
+    with pytest.warns(RuntimeWarning, match="cannot be combined accurately"):
+        result = aggregate_stats([stats_1, stats_2])
+
+    image_stats = result["observation.image"]
+    assert "q01" not in image_stats
+    assert "q99" not in image_stats
+    np.testing.assert_allclose(image_stats["mean"], np.full((3, 1, 1), 8 / 15))
+    np.testing.assert_array_equal(image_stats["count"], np.array([300]))
+
+
+def test_aggregate_stats_preserves_single_source_quantiles():
+    image_stats = {
+        "min": np.zeros((3, 1, 1)),
+        "max": np.ones((3, 1, 1)),
+        "mean": np.full((3, 1, 1), 0.4),
+        "std": np.full((3, 1, 1), 0.1),
+        "count": np.array([100]),
+        "q01": np.full((3, 1, 1), 0.1),
+        "q99": np.full((3, 1, 1), 0.9),
+    }
+
+    result = aggregate_stats([{"observation.image": image_stats}])
+
+    np.testing.assert_array_equal(result["observation.image"]["q01"], image_stats["q01"])
+    np.testing.assert_array_equal(result["observation.image"]["q99"], image_stats["q99"])

--- a/tests/datasets/test_compute_stats.py
+++ b/tests/datasets/test_compute_stats.py
@@ -687,8 +687,7 @@ def test_compute_episode_stats_string_features_skipped():
     assert "q01" in stats["action"]
 
 
-def test_aggregate_feature_stats_with_quantiles():
-    """Test aggregating feature stats that include quantiles uses conservative bounds."""
+def test_aggregate_feature_stats_omits_non_composable_quantiles():
     stats_ft_list = [
         {
             "min": np.array([1.0]),
@@ -716,14 +715,11 @@ def test_aggregate_feature_stats_with_quantiles():
         },
     ]
 
-    result = aggregate_feature_stats(stats_ft_list)
+    with pytest.warns(RuntimeWarning, match="cannot be combined accurately"):
+        result = aggregate_feature_stats(stats_ft_list)
 
-    # Lower quantiles use min; upper quantiles use max, regardless of counts.
-    np.testing.assert_allclose(result["q01"], np.array([1.5]), atol=1e-6)
-    np.testing.assert_allclose(result["q10"], np.array([2.0]), atol=1e-6)
-    np.testing.assert_allclose(result["q50"], np.array([5.0]), atol=1e-6)
-    np.testing.assert_allclose(result["q90"], np.array([11.0]), atol=1e-6)
-    np.testing.assert_allclose(result["q99"], np.array([11.5]), atol=1e-6)
+    assert "q01" not in result
+    assert "q99" not in result
 
 
 def test_aggregate_stats_mixed_quantiles():
@@ -882,58 +878,52 @@ def test_fixed_quantiles_always_computed():
             assert episode_stats[key][q_key].shape == (features[key]["shape"][0],)
 
 
-def test_aggregate_stats_incremental_resume():
-    """Verify conservative bounds remain associative across incremental additions."""
-    # Start with episode 1 stats (narrow distribution)
-    ep1_stats = {
-        "action": {
-            "min": np.array([-10.0, -5.0]),
-            "max": np.array([10.0, 5.0]),
-            "mean": np.array([0.0, 0.0]),
-            "std": np.array([3.0, 1.5]),
-            "count": np.array([500]),
-            "q01": np.array([-9.0, -4.5]),
-            "q99": np.array([9.0, 4.5]),
-        },
-    }
-
-    # Episode 2: wider distribution on dim 0
-    ep2_stats = {
-        "action": {
-            "min": np.array([-30.0, -5.0]),
-            "max": np.array([40.0, 6.0]),
-            "mean": np.array([5.0, 0.5]),
-            "std": np.array([15.0, 2.0]),
+def test_aggregate_stats_omits_non_composable_quantiles():
+    stats_1 = {
+        "observation.image": {
+            "min": np.array([0.0, 0.0, 0.0]).reshape(3, 1, 1),
+            "max": np.array([1.0, 1.0, 1.0]).reshape(3, 1, 1),
+            "mean": np.array([0.4, 0.4, 0.4]).reshape(3, 1, 1),
+            "std": np.array([0.1, 0.1, 0.1]).reshape(3, 1, 1),
             "count": np.array([100]),
-            "q01": np.array([-25.0, -4.0]),
-            "q99": np.array([35.0, 5.5]),
-        },
+            "q01": np.array([0.1, 0.1, 0.1]).reshape(3, 1, 1),
+            "q99": np.array([0.9, 0.9, 0.9]).reshape(3, 1, 1),
+        }
+    }
+    stats_2 = {
+        "observation.image": {
+            "min": np.array([0.0, 0.0, 0.0]).reshape(3, 1, 1),
+            "max": np.array([1.0, 1.0, 1.0]).reshape(3, 1, 1),
+            "mean": np.array([0.6, 0.6, 0.6]).reshape(3, 1, 1),
+            "std": np.array([0.1, 0.1, 0.1]).reshape(3, 1, 1),
+            "count": np.array([200]),
+            "q01": np.array([0.2, 0.2, 0.2]).reshape(3, 1, 1),
+            "q99": np.array([0.95, 0.95, 0.95]).reshape(3, 1, 1),
+        }
     }
 
-    # First aggregation: ep1 + ep2 (simulates save_episode for ep2)
-    cumulative = aggregate_stats([ep1_stats, ep2_stats])
+    with pytest.warns(RuntimeWarning, match="cannot be combined accurately"):
+        result = aggregate_stats([stats_1, stats_2])
 
-    # q01 should take min (conservative lower bound)
-    np.testing.assert_allclose(cumulative["action"]["q01"], np.array([-25.0, -4.5]))
-    # q99 should take max (conservative upper bound)
-    np.testing.assert_allclose(cumulative["action"]["q99"], np.array([35.0, 5.5]))
+    image_stats = result["observation.image"]
+    assert "q01" not in image_stats
+    assert "q99" not in image_stats
+    np.testing.assert_allclose(image_stats["mean"], np.full((3, 1, 1), 8 / 15))
+    np.testing.assert_array_equal(image_stats["count"], np.array([300]))
 
-    # Episode 3: even wider on dim 1
-    ep3_stats = {
-        "action": {
-            "min": np.array([-8.0, -20.0]),
-            "max": np.array([8.0, 25.0]),
-            "mean": np.array([0.0, 3.0]),
-            "std": np.array([2.0, 8.0]),
-            "count": np.array([50]),
-            "q01": np.array([-7.0, -18.0]),
-            "q99": np.array([7.0, 22.0]),
-        },
+
+def test_aggregate_stats_preserves_single_source_quantiles():
+    image_stats = {
+        "min": np.zeros((3, 1, 1)),
+        "max": np.ones((3, 1, 1)),
+        "mean": np.full((3, 1, 1), 0.4),
+        "std": np.full((3, 1, 1), 0.1),
+        "count": np.array([100]),
+        "q01": np.full((3, 1, 1), 0.1),
+        "q99": np.full((3, 1, 1), 0.9),
     }
 
-    # Second aggregation: cumulative + ep3 (simulates save_episode for ep3)
-    cumulative2 = aggregate_stats([cumulative, ep3_stats])
+    result = aggregate_stats([{"observation.image": image_stats}])
 
-    # Bounds should widen monotonically
-    np.testing.assert_allclose(cumulative2["action"]["q01"], np.array([-25.0, -18.0]))
-    np.testing.assert_allclose(cumulative2["action"]["q99"], np.array([35.0, 22.0]))
+    np.testing.assert_array_equal(result["observation.image"]["q01"], image_stats["q01"])
+    np.testing.assert_array_equal(result["observation.image"]["q99"], image_stats["q99"])

--- a/tests/datasets/test_quantiles_dataset_integration.py
+++ b/tests/datasets/test_quantiles_dataset_integration.py
@@ -204,11 +204,11 @@ def test_save_multiple_episodes_with_quantiles(tmp_path, simple_features):
             }
             dataset.add_frame(frame)
 
-        if episode_idx == 0:
-            dataset.save_episode()
-        else:
+        if episode_idx == 1:
             with pytest.warns(RuntimeWarning, match="cannot be combined accurately"):
                 dataset.save_episode()
+        else:
+            dataset.save_episode()
 
     # Quantiles from multiple episode summaries are not composable, so the
     # aggregate deliberately omits them while retaining valid summary stats.

--- a/tests/datasets/test_quantiles_dataset_integration.py
+++ b/tests/datasets/test_quantiles_dataset_integration.py
@@ -204,11 +204,17 @@ def test_save_multiple_episodes_with_quantiles(tmp_path, simple_features):
             }
             dataset.add_frame(frame)
 
-        dataset.save_episode()
+        if episode_idx == 0:
+            dataset.save_episode()
+        else:
+            with pytest.warns(RuntimeWarning, match="cannot be combined accurately"):
+                dataset.save_episode()
 
-    # Verify final stats include properly aggregated quantiles
+    # Quantiles from multiple episode summaries are not composable, so the
+    # aggregate deliberately omits them while retaining valid summary stats.
     stats = dataset.meta.stats
     for key in ["action", "observation.state"]:
         feature_stats = stats[key]
-        assert "q01" in feature_stats and "q99" in feature_stats
+        assert "q01" not in feature_stats
+        assert "q99" not in feature_stats
         assert feature_stats["count"][0] == 150  # 3 episodes * 50 frames


### PR DESCRIPTION
## Summary

Fixes #4156.

- Stop computing merged quantiles as frame-count-weighted averages of per-source quantiles. Quantiles are not linearly composable, so those values can be materially wrong.
- Preserve quantiles unchanged when a feature comes from a single statistics source.
- For multiple sources, omit common quantile fields and emit a clear `RuntimeWarning` directing callers to recompute them from raw samples.
- Leave the valid aggregation of `min`, `max`, `mean`, `std`, and `count` unchanged.

This follows the issue's fail-safe fallback for cases where neither raw samples nor a mergeable quantile sketch is available, instead of silently publishing fabricated normalization bounds.

## Validation

- `pytest tests/datasets/test_compute_stats.py -q` — 43 tests passed
- Ruff lint passed
- Ruff formatting passed

## AI assistance

AI tools assisted with implementation and review. The final diff was manually scoped, inspected, and validated against the issue and repository tests by the contributor.
