### PR TITLE
Allow injecting the events dict into record()

### DIFF
--- a/src/lerobot/scripts/lerobot_record.py
+++ b/src/lerobot/scripts/lerobot_record.py
@@ -364,6 +364,7 @@ def record(
     teleop_action_processor: RobotProcessorPipeline | None = None,
     robot_action_processor: RobotProcessorPipeline | None = None,
     robot_observation_processor: RobotProcessorPipeline | None = None,
+    events: dict | None = None,
 ) -> LeRobotDataset:
     init_logging()
     logging.info(pformat(asdict(cfg)))
@@ -457,7 +458,12 @@ def record(
         if teleop is not None:
             teleop.connect()
 
-        listener, events = init_keyboard_listener()
+        # Fall back to the keyboard listener when the caller doesn't supply events.
+        # An injected events dict lets alternative controls (gamepad, foot pedal,
+        # GUI, another process) drive the same exit_early / rerecord_episode /
+        # stop_recording flags without reimplementing the recording loop.
+        if events is None:
+            listener, events = init_keyboard_listener()
 
         if not cfg.dataset.streaming_encoding:
             logging.info(

--- a/tests/test_control_robot.py
+++ b/tests/test_control_robot.py
@@ -89,6 +89,33 @@ def test_record_and_resume(tmp_path):
     assert dataset.meta.total_tasks == 1
 
 
+def test_record_with_injected_events(tmp_path):
+    robot_cfg = MockRobotConfig()
+    teleop_cfg = MockTeleopConfig()
+    dataset_cfg = DatasetRecordConfig(
+        repo_id=DUMMY_REPO_ID,
+        single_task="Dummy task",
+        root=tmp_path / "record",
+        num_episodes=1,
+        episode_time_s=0.1,
+        reset_time_s=0,
+        push_to_hub=False,
+    )
+    cfg = RecordConfig(
+        robot=robot_cfg,
+        dataset=dataset_cfg,
+        teleop=teleop_cfg,
+        play_sounds=False,
+    )
+
+    events = {"exit_early": False, "rerecord_episode": False, "stop_recording": False}
+    with patch("lerobot.scripts.lerobot_record.init_keyboard_listener") as mock_init_listener:
+        dataset = record(cfg, events=events)
+
+    mock_init_listener.assert_not_called()
+    assert dataset.meta.total_episodes == dataset.num_episodes == 1
+
+
 def test_record_and_replay(tmp_path):
     robot_cfg = MockRobotConfig()
     teleop_cfg = MockTeleopConfig()


### PR DESCRIPTION
# Allow injecting the `events` dict into `record()`

## What this does

Adds an optional `events` parameter to `record()` in
`src/lerobot/scripts/lerobot_record.py`. When the caller supplies a dict, the
built-in keyboard listener is not started and the caller's dict drives the
existing `exit_early` / `rerecord_episode` / `stop_recording` flags. When the
parameter is omitted (the default, and the CLI path), behavior is unchanged:
`init_keyboard_listener()` is created exactly as before.

## Why

`record()` already accepts injectable processor pipelines
(`teleop_action_processor`, `robot_action_processor`,
`robot_observation_processor`) with sensible fallbacks, so the function is
clearly meant to be callable as an API, not only via the CLI. Episode control
is the one remaining hardwired input: anyone who wants to drive recording from
a gamepad, a foot pedal, a teleoperator's own buttons, a GUI, or another
process currently has to reimplement `record()`'s outer episode loop around
`record_loop()` just to get past `init_keyboard_listener()`.

Since `record_loop()` already treats `events` as plain data (a mutable dict it
polls each tick), letting callers pass it in closes that gap with a two-line
change and no behavior change for existing users. It also helps headless /
embedded setups where no keyboard backend is available at all.

## Changes

- `record(cfg, ..., events: dict | None = None)` — falls back to
  `init_keyboard_listener()` when `None`. `listener` stays `None` for injected
  events, so the existing `finally` teardown is untouched.
- Test: `tests/test_control_robot.py::test_record_with_injected_events` —
  records an episode with an injected dict and asserts
  `init_keyboard_listener` is never called.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
