### PR TITLE
fix(windows): keep Hub repo ids and allow_patterns posix-formed

### DIFF
--- a/src/lerobot/configs/policies.py
+++ b/src/lerobot/configs/policies.py
@@ -29,7 +29,7 @@ from huggingface_hub.errors import HfHubHTTPError
 from lerobot.optim import LRSchedulerConfig, OptimizerConfig
 from lerobot.utils.constants import ACTION, OBS_STATE
 from lerobot.utils.device_utils import auto_select_torch_device, is_amp_available, is_torch_device_available
-from lerobot.utils.hub import HubMixin
+from lerobot.utils.hub import HubMixin, hub_safe_id
 
 from .types import FeatureType, PolicyFeature
 
@@ -180,7 +180,7 @@ class PreTrainedConfig(draccus.ChoiceRegistry, HubMixin, abc.ABC):  # type: igno
         revision: str | None = None,
         **policy_kwargs: Any,
     ) -> T:
-        model_id = str(pretrained_name_or_path)
+        model_id = hub_safe_id(pretrained_name_or_path)
         config_file: str | None = None
         if Path(model_id).is_dir():
             if CONFIG_NAME in os.listdir(model_id):

--- a/src/lerobot/datasets/dataset_reader.py
+++ b/src/lerobot/datasets/dataset_reader.py
@@ -200,10 +200,13 @@ class DatasetReader:
         Used to build the ``allow_patterns`` list for ``snapshot_download``.
         """
         episodes = self.episodes if self.episodes is not None else list(range(self._meta.total_episodes))
-        fpaths = [str(self._meta.get_data_file_path(ep_idx)) for ep_idx in episodes]
+        # as_posix: these paths are matched against Hub-side file names (forward slashes) as
+        # snapshot_download allow_patterns -- str(Path) would produce backslashes on Windows,
+        # matching nothing and silently downloading zero files.
+        fpaths = [self._meta.get_data_file_path(ep_idx).as_posix() for ep_idx in episodes]
         if len(self._meta.video_keys) > 0:
             video_files = [
-                str(self._meta.get_video_file_path(ep_idx, vid_key))
+                self._meta.get_video_file_path(ep_idx, vid_key).as_posix()
                 for vid_key in self._meta.video_keys
                 for ep_idx in episodes
             ]

--- a/src/lerobot/policies/pretrained.py
+++ b/src/lerobot/policies/pretrained.py
@@ -33,7 +33,7 @@ from lerobot.__version__ import __version__
 from lerobot.configs import PreTrainedConfig
 from lerobot.configs.train import TrainPipelineConfig
 from lerobot.utils.device_utils import resolve_safetensors_device
-from lerobot.utils.hub import HubMixin
+from lerobot.utils.hub import HubMixin, hub_safe_id
 
 from .utils import log_model_loading_keys
 
@@ -189,7 +189,7 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
                 revision=revision,
                 **kwargs,
             )
-        model_id = str(pretrained_name_or_path)
+        model_id = hub_safe_id(pretrained_name_or_path)
         instance = cls(config, **kwargs)
         if os.path.isdir(model_id):
             print("Loading weights from local directory")

--- a/src/lerobot/processor/pipeline.py
+++ b/src/lerobot/processor/pipeline.py
@@ -47,7 +47,7 @@ from safetensors.torch import load_file, save_file
 from lerobot.configs import PipelineFeatureType, PolicyFeature
 from lerobot.types import EnvAction, EnvTransition, PolicyAction, RobotAction, RobotObservation, TransitionKey
 from lerobot.utils.constants import HF_LEROBOT_HOME
-from lerobot.utils.hub import HubMixin
+from lerobot.utils.hub import HubMixin, hub_safe_id
 
 from .converters import batch_to_transition, create_transition, transition_to_batch
 
@@ -712,7 +712,7 @@ class DataProcessorPipeline[TInput, TOutput](HubMixin):
             KeyError: If an override key doesn't match any step in the pipeline.
             ProcessorMigrationError: If the model requires migration to processor format.
         """
-        model_id = str(pretrained_model_name_or_path)
+        model_id = hub_safe_id(pretrained_model_name_or_path)
         hub_download_kwargs = {
             "force_download": force_download,
             "resume_download": resume_download,

--- a/src/lerobot/utils/hub.py
+++ b/src/lerobot/utils/hub.py
@@ -47,6 +47,16 @@ def find_latest_hub_checkpoint(
     return f"{CHECKPOINTS_DIR}/{max(steps, key=int)}"
 
 
+def hub_safe_id(pretrained_name_or_path: str | Path) -> str:
+    """Return ``pretrained_name_or_path`` as a string valid both as a local path and a Hub repo id.
+
+    On Windows, ``str(Path("lerobot/smolvla_base"))`` yields ``"lerobot\\smolvla_base"``, which
+    ``huggingface_hub`` rejects as an invalid repo id. Forward slashes remain valid in local
+    Windows paths, so the posix form is safe for both uses (no-op on other platforms).
+    """
+    return Path(pretrained_name_or_path).as_posix()
+
+
 class HubMixin:
     """
     A Mixin containing the functionality to push an object to the hub.

--- a/tests/utils/test_hub.py
+++ b/tests/utils/test_hub.py
@@ -12,9 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+from pathlib import Path
 from unittest.mock import MagicMock
 
-from lerobot.utils.hub import find_latest_hub_checkpoint
+import pytest
+
+from lerobot.utils.hub import find_latest_hub_checkpoint, hub_safe_id
 
 
 def _patch_list_files(monkeypatch, files):
@@ -52,3 +56,18 @@ def test_find_latest_hub_checkpoint_ignores_non_step_entries(monkeypatch):
 def test_find_latest_hub_checkpoint_none_when_no_checkpoints(monkeypatch):
     _patch_list_files(monkeypatch, ["config.json", "model.safetensors"])
     assert find_latest_hub_checkpoint("u/run") is None
+
+
+def test_hub_safe_id_preserves_repo_ids():
+    # Repo ids must keep their forward slash on every platform.
+    assert hub_safe_id("lerobot/smolvla_base") == "lerobot/smolvla_base"
+    assert hub_safe_id(Path("lerobot/smolvla_base")) == "lerobot/smolvla_base"
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="backslash separators only occur on Windows")
+def test_hub_safe_id_normalizes_windows_separators():
+    # On Windows, Path("lerobot/smolvla_base") stringifies to "lerobot\\smolvla_base",
+    # which huggingface_hub rejects as a repo id (#2552). hub_safe_id restores posix form.
+    assert str(Path("lerobot/smolvla_base")) == "lerobot\\smolvla_base"
+    assert hub_safe_id(Path("lerobot/smolvla_base")) == "lerobot/smolvla_base"
+    assert hub_safe_id("lerobot\\smolvla_base") == "lerobot/smolvla_base"


### PR DESCRIPTION
﻿## What this does

On Windows, `str(Path("lerobot/smolvla_base"))` yields `lerobot\smolvla_base`, which breaks two Hub interactions:

- `PreTrainedConfig.from_pretrained` / `PreTrainedPolicy.from_pretrained` / `DataProcessorPipeline.from_pretrained` all do `model_id = str(...)`, so any `--policy.path` Hub repo id fails with `HFValidationError` (#2552 — `pretrained_path` is stored as a `Path` by `configs/train.py` and `configs/eval.py`).
- `DatasetReader.get_episodes_file_paths()` builds `snapshot_download` `allow_patterns` via `str(Path)`, producing backslash patterns that match no Hub files: `LeRobotDataset(..., episodes=[...])` silently downloads zero data/video files and then fails with `FileNotFoundError`.

This adds `hub_safe_id()` (posix-forming; a no-op on non-Windows and on plain repo-id strings) at the three `from_pretrained` entry points, and posix-forms the reader's `allow_patterns`. Forward slashes remain valid Windows local paths, so local-directory loading is unaffected.

Credit to @DanielBryars for the correct diagnosis of the `policy.path` manifestation.

## How it was tested

On Windows 11 (Python 3.12, standard user):
- `--policy.path=lerobot/smolvla_base` previously raised `HFValidationError`; works with this change.
- Episode-filtered `LeRobotDataset` downloads previously fetched zero files; work with this change.
- New unit tests in `tests/utils/test_hub.py`: repo-id preservation cross-platform, plus a win32-only test documenting the separator normalization. `pytest tests/utils/test_hub.py` → 5 passed.

Closes #2552

