### PR TITLE
fix(windows): fall back to a directory junction for the `last` checkpoint link

### DIFF
--- a/src/lerobot/common/train_utils.py
+++ b/src/lerobot/common/train_utils.py
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
 from pathlib import Path
 
 from huggingface_hub import HfApi, snapshot_download
@@ -86,8 +87,24 @@ def update_last_checkpoint(checkpoint_dir: Path) -> Path:
     last_checkpoint_dir = checkpoint_dir.parent / LAST_CHECKPOINT_LINK
     if last_checkpoint_dir.is_symlink():
         last_checkpoint_dir.unlink()
+    elif last_checkpoint_dir.is_dir():
+        # A directory junction left by the Windows fallback below is not a symlink.
+        # os.rmdir removes the junction itself, never its contents, and refuses to
+        # remove a real non-empty directory, so genuine data cannot be clobbered.
+        os.rmdir(last_checkpoint_dir)
     relative_target = checkpoint_dir.relative_to(checkpoint_dir.parent)
-    last_checkpoint_dir.symlink_to(relative_target)
+    try:
+        last_checkpoint_dir.symlink_to(relative_target)
+    except OSError as e:
+        # Windows only allows symlink creation for administrators or users with
+        # Developer Mode enabled (WinError 1314). Fall back to a directory
+        # junction, which needs no privileges and resolves the same way.
+        if os.name == "nt" and getattr(e, "winerror", None) == 1314:
+            import _winapi
+
+            _winapi.CreateJunction(str(checkpoint_dir), str(last_checkpoint_dir))
+        else:
+            raise
 
 
 def save_checkpoint(

--- a/tests/utils/test_train_utils.py
+++ b/tests/utils/test_train_utils.py
@@ -91,12 +91,21 @@ def test_load_training_batch_size_absent_returns_none(tmp_path, optimizer, sched
 
 
 def test_update_last_checkpoint(tmp_path):
+    # On Windows without Developer Mode the link is a directory junction rather
+    # than a symlink, so assert on resolution rather than on the link type.
     checkpoint = tmp_path / "0005"
     checkpoint.mkdir()
     update_last_checkpoint(checkpoint)
     last_checkpoint = tmp_path / LAST_CHECKPOINT_LINK
-    assert last_checkpoint.is_symlink()
-    assert last_checkpoint.resolve() == checkpoint
+    assert last_checkpoint.resolve() == checkpoint.resolve()
+
+    # Updating to a newer checkpoint must replace the existing link.
+    checkpoint2 = tmp_path / "0010"
+    checkpoint2.mkdir()
+    update_last_checkpoint(checkpoint2)
+    assert last_checkpoint.resolve() == checkpoint2.resolve()
+    # The old checkpoint's contents are untouched by the replacement.
+    assert checkpoint.exists()
 
 
 @patch("lerobot.common.train_utils.save_training_state")
@@ -212,9 +221,10 @@ def test_resolve_resume_checkpoint_downloads_latest_and_links(tmp_path, monkeypa
 
     assert checkpoint_dir == out / CHECKPOINTS_DIR / "020000"
     last = out / CHECKPOINTS_DIR / LAST_CHECKPOINT_LINK
-    assert last.is_symlink()
-    # `last` points at the downloaded step dir.
-    assert (last.parent / last.readlink()).resolve() == checkpoint_dir.resolve()
+    # `last` points at the downloaded step dir. On Windows without Developer
+    # Mode the link is a directory junction rather than a symlink, so assert
+    # on resolution rather than on the link type (as in test_update_last_checkpoint).
+    assert last.resolve() == checkpoint_dir.resolve()
 
 
 def test_resolve_resume_checkpoint_raises_without_checkpoints(tmp_path, monkeypatch):


### PR DESCRIPTION
﻿## What this does

Windows only allows symlink creation for administrators or users with Developer Mode enabled. On a standard-user setup, `update_last_checkpoint()` crashes with `OSError: [WinError 1314]` at the first checkpoint save, and `tests/utils/test_train_utils.py` fails as reported in #4059.

- On WinError 1314, fall back to a **directory junction** via `_winapi.CreateJunction`: junctions need no privileges and resolve the same way for every read path (config loading, resume, `readlink`).
- Link replacement handles both kinds: symlinks are `unlink()`ed as before, and a junction (which is not a symlink) is removed with `os.rmdir` — which deletes only the junction itself and refuses to remove a real non-empty directory, so checkpoint data can never be clobbered.
- The two tests from #4059 now assert on link **resolution** rather than `is_symlink()`, so they pass on every platform regardless of which link type was produced; they also cover link replacement and old-checkpoint preservation.

## How it was tested

Windows 11, Python 3.12, standard user, Developer Mode off (the exact environment from #4059): `pytest tests/utils/test_train_utils.py` went from 2 failures (`WinError 1314` / `is_symlink` assertion) to **18 passed**. On Linux/macOS the symlink path is unchanged.

Closes #4059
