### PR TITLE
fix(video): only default to torchcodec when it can actually be loaded

### DIFF
--- a/src/lerobot/utils/import_utils.py
+++ b/src/lerobot/utils/import_utils.py
@@ -72,7 +72,19 @@ def is_package_available(
 def get_safe_default_video_backend():
     logger = logging.getLogger(__name__)
     if importlib.util.find_spec("torchcodec"):
-        return "torchcodec"
+        # Installed is not the same as loadable: torchcodec needs FFmpeg shared
+        # libraries at runtime (commonly absent on Windows), so probe the actual
+        # import rather than trusting find_spec, otherwise decoding crashes on
+        # first use with the torchcodec default.
+        try:
+            importlib.import_module("torchcodec.decoders")
+            return "torchcodec"
+        except (ImportError, OSError) as e:
+            logger.warning(
+                f"'torchcodec' is installed but cannot be loaded ({e}); falling back to 'pyav' as a "
+                "default decoder. Installing FFmpeg shared libraries usually enables torchcodec."
+            )
+            return "pyav"
     else:
         logger.warning(
             "'torchcodec' is not available in your platform, falling back to 'pyav' as a default decoder"

--- a/tests/utils/test_import_utils.py
+++ b/tests/utils/test_import_utils.py
@@ -1,0 +1,39 @@
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import lerobot.utils.import_utils as import_utils
+
+
+def test_get_safe_default_video_backend_pyav_when_absent(monkeypatch):
+    monkeypatch.setattr(import_utils.importlib.util, "find_spec", lambda name: None)
+    assert import_utils.get_safe_default_video_backend() == "pyav"
+
+
+def test_get_safe_default_video_backend_torchcodec_when_loadable(monkeypatch):
+    monkeypatch.setattr(import_utils.importlib.util, "find_spec", lambda name: object())
+    monkeypatch.setattr(import_utils.importlib, "import_module", lambda name, *a, **k: object())
+    assert import_utils.get_safe_default_video_backend() == "torchcodec"
+
+
+def test_get_safe_default_video_backend_pyav_when_installed_but_unloadable(monkeypatch):
+    # find_spec succeeds (the package is installed) but the runtime import fails,
+    # as on Windows when the FFmpeg shared libraries torchcodec links against are
+    # missing. The default must fall back to pyav instead of crashing at decode time.
+    monkeypatch.setattr(import_utils.importlib.util, "find_spec", lambda name: object())
+
+    def raise_import_error(name, *args, **kwargs):
+        raise ImportError("DLL load failed while importing _core: module not found")
+
+    monkeypatch.setattr(import_utils.importlib, "import_module", raise_import_error)
+    assert import_utils.get_safe_default_video_backend() == "pyav"


### PR DESCRIPTION
﻿## What this does

Fixes the issue above: `get_safe_default_video_backend()` now probes the actual `import torchcodec.decoders` instead of trusting `find_spec`, and falls back to pyav with an actionable warning when the package is installed but cannot load (missing FFmpeg shared libraries). On healthy installs the probed module is exactly what decoding imports anyway, so nothing extra is loaded.

## How it was tested

Repro'd on Windows 11 (Python 3.12, torchcodec installed via the dataset extra, no FFmpeg shared libraries): dataset video decode with defaults previously crashed and now works. New `tests/utils/test_import_utils.py` covers the three cases: torchcodec absent, loadable, and installed-but-unloadable → 3 passed.

Closes #4176
