### PR TITLE
fix(policy): honor revisions when loading PEFT checkpoints

### DIFF
--- a/src/lerobot/policies/factory.py
+++ b/src/lerobot/policies/factory.py
@@ -339,7 +339,10 @@ def make_policy(
         logging.info("Loading policy's PEFT adapter.")
 
         peft_pretrained_path = str(cfg.pretrained_path)
-        peft_config = PeftConfig.from_pretrained(peft_pretrained_path)
+        peft_config = PeftConfig.from_pretrained(
+            peft_pretrained_path,
+            revision=cfg.pretrained_revision,
+        )
 
         kwargs["pretrained_name_or_path"] = peft_config.base_model_name_or_path
         if not kwargs["pretrained_name_or_path"]:
@@ -350,9 +353,14 @@ def make_policy(
                 "the adapter was trained."
             )
 
+        kwargs["revision"] = peft_config.revision
         policy = policy_cls.from_pretrained(**kwargs)
         policy = PeftModel.from_pretrained(
-            policy, peft_pretrained_path, config=peft_config, is_trainable=True
+            policy,
+            peft_pretrained_path,
+            config=peft_config,
+            revision=cfg.pretrained_revision,
+            is_trainable=True,
         )
 
     else:

--- a/tests/policies/test_factory_peft_revision.py
+++ b/tests/policies/test_factory_peft_revision.py
@@ -1,0 +1,79 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import torch
+
+import lerobot.policies.factory as policy_factory
+
+
+def test_make_policy_keeps_peft_adapter_and_base_revisions_separate(monkeypatch):
+    cfg = SimpleNamespace(
+        type="mock",
+        device="cpu",
+        pretrained_path="user/adapter",
+        pretrained_revision="adapter-sha",
+        use_peft=True,
+        input_features={},
+        output_features={},
+    )
+    dataset_meta = SimpleNamespace(features={}, stats={})
+
+    base_policy = torch.nn.Linear(1, 1)
+    policy_from_pretrained = MagicMock(return_value=base_policy)
+    policy_class = SimpleNamespace(from_pretrained=policy_from_pretrained)
+    monkeypatch.setattr(policy_factory, "get_policy_class", lambda _: policy_class)
+    monkeypatch.setattr(policy_factory, "dataset_to_policy_features", lambda _: {})
+    monkeypatch.setattr(policy_factory, "validate_visual_features_consistency", lambda *args: None)
+
+    peft_config = SimpleNamespace(
+        base_model_name_or_path="user/base-policy",
+        revision="base-sha",
+    )
+    peft_config_from_pretrained = MagicMock(return_value=peft_config)
+    adapted_policy = torch.nn.Linear(1, 1)
+    peft_model_from_pretrained = MagicMock(return_value=adapted_policy)
+    monkeypatch.setitem(
+        sys.modules,
+        "peft",
+        SimpleNamespace(
+            PeftConfig=SimpleNamespace(from_pretrained=peft_config_from_pretrained),
+            PeftModel=SimpleNamespace(from_pretrained=peft_model_from_pretrained),
+        ),
+    )
+
+    policy = policy_factory.make_policy(cfg, ds_meta=dataset_meta)
+
+    assert policy is adapted_policy
+    peft_config_from_pretrained.assert_called_once_with(
+        "user/adapter",
+        revision="adapter-sha",
+    )
+    policy_from_pretrained.assert_called_once_with(
+        config=cfg,
+        dataset_stats=dataset_meta.stats,
+        dataset_meta=dataset_meta,
+        pretrained_name_or_path="user/base-policy",
+        revision="base-sha",
+    )
+    peft_model_from_pretrained.assert_called_once_with(
+        base_policy,
+        "user/adapter",
+        config=peft_config,
+        revision="adapter-sha",
+        is_trainable=True,
+    )


### PR DESCRIPTION
## Title

fix(policy): honor revisions when loading PEFT checkpoints

## Summary / Motivation

Ensure `make_policy()` honors the requested Hub revision when loading PEFT checkpoints. Previously, `cfg.pretrained_revision` was ignored in the PEFT path, causing adapter files to load from the default branch. The adapter and base-model revisions must remain independent because they can belong to different repositories.

## Related issues

- Related: #4161 and #3549

## What changed

- Load the PEFT adapter configuration from cfg.pretrained_revision.
- Load the base policy from the revision recorded in peft_config.revision.
- Load adapter weights from cfg.pretrained_revision.
- Add a regression test covering all three revision arguments.

No breaking changes.

## How was this tested (or how to run locally)

- Added `tests/policies/test_factory_peft_revision.py`.
- Ran the relevant tests:
```bash
uv run pytest tests/policies/test_factory_peft_revision.py tests/test_rollout.py -q
```

- Result: 28 tests passed.
- Ruff linting and formatting checks passed.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [ ] CI is green