### PR TITLE
fix(tests): patch factory PEFT globals instead of sys.modules

### DIFF
--- a/tests/policies/test_factory_peft_revision.py
+++ b/tests/policies/test_factory_peft_revision.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -47,13 +46,12 @@ def test_make_policy_keeps_peft_adapter_and_base_revisions_separate(monkeypatch)
     peft_config_from_pretrained = MagicMock(return_value=peft_config)
     adapted_policy = torch.nn.Linear(1, 1)
     peft_model_from_pretrained = MagicMock(return_value=adapted_policy)
-    monkeypatch.setitem(
-        sys.modules,
-        "peft",
-        SimpleNamespace(
-            PeftConfig=SimpleNamespace(from_pretrained=peft_config_from_pretrained),
-            PeftModel=SimpleNamespace(from_pretrained=peft_model_from_pretrained),
-        ),
+    monkeypatch.setattr(policy_factory, "require_package", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        policy_factory, "PeftConfig", SimpleNamespace(from_pretrained=peft_config_from_pretrained)
+    )
+    monkeypatch.setattr(
+        policy_factory, "PeftModel", SimpleNamespace(from_pretrained=peft_model_from_pretrained)
     )
 
     policy = policy_factory.make_policy(cfg, ds_meta=dataset_meta)


### PR DESCRIPTION
## Summary / Motivation

`main` has been red on fast test since ec2dbc1c9 (#4189). The Tier 1 (base) job fails with:

```
FAILED tests/policies/test_factory_peft_revision.py::test_make_policy_keeps_peft_adapter_and_base_revisions_separate - ValueError: peft.__spec__ is not set
=========== 1 failed, 1121 passed, 346 skipped in 15.79s ===========
```

Every branch that merges `main` after that point inherits the failure.

This is a semantic conflict between two PRs that were each green on their own base:

- #4188 (`d526785e4`) moved `from peft import PeftConfig, PeftModel` out of `make_policy` into a module-level conditional binding, and added `require_package("peft", extra="peft")` inside `make_policy`.
- #4189 (`ec2dbc1c9`) added `tests/policies/test_factory_peft_revision.py`, which fakes peft with `monkeypatch.setitem(sys.modules, "peft", SimpleNamespace(...))`.

The `sys.modules` stub was written against the code before #4188, where the local `from peft import ...` resolved through `sys.modules`. In the current code, it breaks in two independent ways:

1. `require_package("peft")` -> `is_package_available()` -> `importlib.util.find_spec("peft")`. `find_spec` sees `"peft"` in `sys.modules` and reads `module.__spec__`; a `SimpleNamespace` has none, so it raises `ValueError` instead of returning `None`.
2. Even with `__spec__` set, `factory.PeftConfig` / `factory.PeftModel` are module globals bound at import time and are `None` whenever peft is not installed, which is the case in every fast test tier. The `sys.modules` stub no longer reaches the code under test at all.

This patches `policy_factory.PeftConfig` / `policy_factory.PeftModel` directly and stubs `policy_factory.require_package`. There are no `src/` changes and the assertions are untouched, so the revision-plumbing behaviour added in #4189 stays fully covered.

## How was this tested (or how to run locally)

On `main` @ `413972c81`, in an environment without `peft` installed (matching the Tier 1 base install):

```
pytest tests/policies/test_factory_peft_revision.py
```

- before: `ValueError: peft.__spec__ is not set`, identical to the CI failure
- after: `1 passed`

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated
- [ ] CI is green
- [x] Community Review: I have reviewed another contributor's open PR and linked it here: #3749
