### PR TITLE
perf(docker): split dependency install from source copy for CI layer caching

### DIFF
--- a/docker/Dockerfile.internal
+++ b/docker/Dockerfile.internal
@@ -68,17 +68,21 @@ ENV HOME=/home/user_lerobot \
 # issues with MuJoCo and OpenGL drivers.
 RUN uv venv --python python${PYTHON_VERSION}
 
-# Install Python dependencies for caching
-COPY --chown=user_lerobot:user_lerobot setup.py pyproject.toml uv.lock README.md MANIFEST.in ./
-COPY --chown=user_lerobot:user_lerobot src/ src/
-
-RUN uv sync --locked --extra all --no-cache
+# Install third-party dependencies in a layer whose cache key is the lockfile ONLY.
+# Because src/ is NOT copied here, editing source code no longer invalidates this
+# layer — torch + all extras stay cached across builds (huge CI speedup). Without
+# --no-install-project, uv would need src/ and the cache would bust on every commit.
+COPY --chown=user_lerobot:user_lerobot pyproject.toml uv.lock README.md ./
+RUN uv sync --locked --extra all --no-install-project --no-cache
 
 RUN chmod +x /lerobot/.venv/lib/python${PYTHON_VERSION}/site-packages/triton/backends/nvidia/bin/ptxas
 
-# Copy the rest of the application source code
+# Copy the rest of the application source code and install the local project itself.
+# Third-party deps are already present above, so this step is fast and is the only
+# one that re-runs when source changes.
 # Make sure to have the git-LFS files for testing
 COPY --chown=user_lerobot:user_lerobot . .
+RUN uv sync --locked --extra all --no-cache
 
 # Set the default command
 CMD ["/bin/bash"]

--- a/docker/Dockerfile.internal
+++ b/docker/Dockerfile.internal
@@ -68,18 +68,13 @@ ENV HOME=/home/user_lerobot \
 # issues with MuJoCo and OpenGL drivers.
 RUN uv venv --python python${PYTHON_VERSION}
 
-# Install third-party dependencies in a layer whose cache key is the lockfile ONLY.
-# Because src/ is NOT copied here, editing source code no longer invalidates this
-# layer — torch + all extras stay cached across builds (huge CI speedup). Without
-# --no-install-project, uv would need src/ and the cache would bust on every commit.
-COPY --chown=user_lerobot:user_lerobot pyproject.toml uv.lock README.md ./
+# Install third-party dependencies separately for layer caching
+COPY --chown=user_lerobot:user_lerobot setup.py pyproject.toml uv.lock README.md MANIFEST.in ./
 RUN uv sync --locked --extra all --no-install-project --no-cache
 
 RUN chmod +x /lerobot/.venv/lib/python${PYTHON_VERSION}/site-packages/triton/backends/nvidia/bin/ptxas
 
-# Copy the rest of the application source code and install the local project itself.
-# Third-party deps are already present above, so this step is fast and is the only
-# one that re-runs when source changes.
+# Copy the application source code and install the local project
 # Make sure to have the git-LFS files for testing
 COPY --chown=user_lerobot:user_lerobot . .
 RUN uv sync --locked --extra all --no-cache

--- a/docker/Dockerfile.user
+++ b/docker/Dockerfile.user
@@ -60,15 +60,19 @@ ENV HOME=/home/user_lerobot \
 # run other Python projects in the same container without dependency conflicts.
 RUN uv venv
 
-# Install Python dependencies for caching
-COPY --chown=user_lerobot:user_lerobot setup.py pyproject.toml uv.lock README.md MANIFEST.in ./
-COPY --chown=user_lerobot:user_lerobot src/ src/
+# Install third-party dependencies in a layer whose cache key is the lockfile ONLY.
+# Because src/ is NOT copied here, editing source code no longer invalidates this
+# layer — torch + all extras stay cached across builds (huge CI speedup). Without
+# --no-install-project, uv would need src/ and the cache would bust on every commit.
+COPY --chown=user_lerobot:user_lerobot pyproject.toml uv.lock README.md ./
+RUN uv sync --locked --extra all --no-install-project --no-cache
 
-RUN uv sync --locked --extra all --no-cache
-
-# Copy the rest of the application code
+# Copy the rest of the application code and install the local project itself.
+# Third-party deps are already present above, so this step is fast and is the only
+# one that re-runs when source changes.
 # Make sure to have the git-LFS files for testing
 COPY --chown=user_lerobot:user_lerobot . .
+RUN uv sync --locked --extra all --no-cache
 
 # Set the default command
 CMD ["/bin/bash"]

--- a/docker/Dockerfile.user
+++ b/docker/Dockerfile.user
@@ -60,16 +60,11 @@ ENV HOME=/home/user_lerobot \
 # run other Python projects in the same container without dependency conflicts.
 RUN uv venv
 
-# Install third-party dependencies in a layer whose cache key is the lockfile ONLY.
-# Because src/ is NOT copied here, editing source code no longer invalidates this
-# layer — torch + all extras stay cached across builds (huge CI speedup). Without
-# --no-install-project, uv would need src/ and the cache would bust on every commit.
-COPY --chown=user_lerobot:user_lerobot pyproject.toml uv.lock README.md ./
+# Install third-party dependencies separately for layer caching
+COPY --chown=user_lerobot:user_lerobot setup.py pyproject.toml uv.lock README.md MANIFEST.in ./
 RUN uv sync --locked --extra all --no-install-project --no-cache
 
-# Copy the rest of the application code and install the local project itself.
-# Third-party deps are already present above, so this step is fast and is the only
-# one that re-runs when source changes.
+# Copy the application code and install the local project
 # Make sure to have the git-LFS files for testing
 COPY --chown=user_lerobot:user_lerobot . .
 RUN uv sync --locked --extra all --no-cache


### PR DESCRIPTION
Supersedes https://github.com/huggingface/lerobot/pull/3892

Follows uv recommendation: https://docs.astral.sh/uv/guides/integration/docker/#intermediate-layers