### PR TITLE
feat(datasets): add bimanual TUM dataset porting example

### DIFF
--- a/examples/port_datasets/README_tum_bimanual.md
+++ b/examples/port_datasets/README_tum_bimanual.md
@@ -1,0 +1,165 @@
+# Port a bimanual TUM-style dataset to LeRobot v3
+
+`port_tum_bimanual.py` converts synchronized bimanual recordings into LeRobot
+Dataset v3. One complete `session_*` directory becomes one episode.
+
+The example is intended for a specific, documented source contract. It does
+not infer arbitrary directory layouts or column orders.
+
+## Source layout
+
+```text
+raw_root/
+└── session_000001/
+    ├── relative_transforms_left_to_right.txt
+    ├── left_hand_device_a/
+    │   ├── Calibration/rgb_intrinsic.json
+    │   ├── Clamp_Data/clamp_data_tum.txt
+    │   ├── IMU/imu.txt
+    │   ├── Merged_Trajectory/merged_trajectory.txt
+    │   └── RGB_Images/
+    │       ├── timestamps.csv
+    │       └── video.mp4
+    └── right_hand_device_a/
+        └── ...
+```
+
+Each session must contain exactly one `left_hand_*` directory and one
+`right_hand_*` directory. Camera dimensions must match across both hands and
+all converted sessions.
+
+The input must be an extracted directory. ZIP files are not read directly.
+
+## Numeric files
+
+TUM poses use:
+
+```text
+timestamp tx ty tz qx qy qz qw
+```
+
+This format is used for both hand trajectories and the left-to-right relative
+pose. The relative-pose timestamps are stream-local: the converter aligns the
+first relative-pose timestamp to the first left-hand trajectory timestamp and
+preserves all relative time differences.
+
+Gripper files use:
+
+```text
+timestamp value
+```
+
+IMU files use:
+
+```text
+timestamp gyro_x gyro_y gyro_z accel_x accel_y accel_z
+```
+
+Two parenthesized covariance tuples may appear after the gyroscope and
+accelerometer triples. They are ignored.
+
+RGB timestamps support either:
+
+```csv
+timestamp
+0.0
+0.5
+```
+
+or:
+
+```csv
+frame_index,seq,header_stamp
+0,10,0.0
+1,11,0.5
+```
+
+In the indexed form, `frame_index` must start at zero and remain contiguous.
+There must be one timestamp for each decoded source frame used by the
+conversion.
+
+## Convert locally
+
+```bash
+python examples/port_datasets/port_tum_bimanual.py \
+  --raw-dir /path/to/raw_root \
+  --repo-id namespace/dataset_name \
+  --root /path/to/output \
+  --fps 60 \
+  --task "bimanual hand manipulation"
+```
+
+Existing output is rejected unless `--overwrite` is present. Input and output
+paths may not overlap. Use `--skip-invalid-session` to record and skip an
+invalid session while retaining valid sessions.
+
+To publish after successful local finalization:
+
+```bash
+python examples/port_datasets/port_tum_bimanual.py \
+  --raw-dir /path/to/raw_root \
+  --repo-id namespace/dataset_name \
+  --root /path/to/output \
+  --push-to-hub
+```
+
+Authentication is handled by the normal Hugging Face Hub configuration. The
+script never accepts or stores a token.
+
+## Synchronization
+
+The converter intersects the time coverage of both videos, both hand poses,
+both gripper streams, both IMU streams, and the relative-pose stream. It does
+not extrapolate.
+
+- RGB uses the nearest source frame; an exact tie selects the earlier frame.
+- Translation, gripper, gyroscope, and acceleration use linear interpolation.
+- Quaternions use normalized, shortest-path SLERP.
+- Output timestamps form a fixed-rate timeline at `--fps`.
+
+## Output schema
+
+- `observation.images.left_hand`: left RGB video.
+- `observation.images.right_hand`: right RGB video.
+- `observation.state`: `float32[16]`.
+- `observation.imu`: `float32[12]`.
+- `observation.relative_pose`: `float32[7]`.
+- `action`: `float32[16]`.
+- `source_timestamp`: `float64[1]`.
+
+State and action order:
+
+```text
+left_tx, left_ty, left_tz,
+left_qx, left_qy, left_qz, left_qw,
+left_gripper,
+right_tx, right_ty, right_tz,
+right_qx, right_qy, right_qz, right_qw,
+right_gripper
+```
+
+IMU order:
+
+```text
+left_gyro_x, left_gyro_y, left_gyro_z,
+left_accel_x, left_accel_y, left_accel_z,
+right_gyro_x, right_gyro_y, right_gyro_z,
+right_accel_x, right_accel_y, right_accel_z
+```
+
+Actions follow the next-state convention:
+
+```text
+action[t] = observation.state[t + 1]
+action[last] = observation.state[last]
+```
+
+Gripper values retain the source unit and range. The example does not
+normalize or convert units.
+
+## Data review before upload
+
+Before using `--push-to-hub`, verify that you have the rights to publish every
+recording and that frames, task text, paths, and metadata do not contain
+personal, confidential, or organization-specific information. The converter
+does not copy optional session metadata into the output.

--- a/examples/port_datasets/port_tum_bimanual.py
+++ b/examples/port_datasets/port_tum_bimanual.py
@@ -1,0 +1,854 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Port generic bimanual TUM-style captures to LeRobot Dataset v3."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import os
+import re
+import shutil
+import sys
+import traceback
+from collections.abc import Iterator, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+_PARENTHESIZED = re.compile(r"\([^)]*\)")
+
+
+class PortingError(RuntimeError):
+    """An expected source-format or conversion error."""
+
+
+@dataclass(frozen=True)
+class HandPaths:
+    root: Path
+    trajectory: Path
+    clamp: Path
+    imu: Path
+    video: Path
+    video_timestamps: Path
+    intrinsics: Path
+
+    @property
+    def name(self) -> str:
+        return self.root.name
+
+
+@dataclass(frozen=True)
+class SessionPaths:
+    root: Path
+    left: HandPaths
+    right: HandPaths
+    relative_pose: Path
+
+    @property
+    def name(self) -> str:
+        return self.root.name
+
+
+@dataclass(frozen=True)
+class TimedArray:
+    timestamps: np.ndarray
+    values: np.ndarray
+
+
+@dataclass(frozen=True)
+class HandData:
+    video_path: Path
+    video_timestamps: np.ndarray
+    trajectory: TimedArray
+    clamp: TimedArray
+    imu: TimedArray
+    image_size: tuple[int, int]
+
+
+@dataclass(frozen=True)
+class SessionData:
+    name: str
+    left: HandData
+    right: HandData
+    relative_pose: TimedArray
+
+
+@dataclass(frozen=True)
+class SyncedEpisode:
+    name: str
+    timestamps: np.ndarray
+    left_video_indices: np.ndarray
+    right_video_indices: np.ndarray
+    states: np.ndarray
+    actions: np.ndarray
+    imu: np.ndarray
+    relative_pose: np.ndarray
+    metrics: dict[str, float | int]
+
+
+@dataclass(frozen=True)
+class PortOptions:
+    raw_dir: Path
+    repo_id: str
+    root: Path | None = None
+    fps: int = 60
+    task: str = "bimanual hand manipulation"
+    push_to_hub: bool = False
+    overwrite: bool = False
+    skip_invalid_session: bool = False
+
+
+def _one_directory(session_root: Path, pattern: str, label: str) -> Path:
+    matches = sorted(path for path in session_root.glob(pattern) if path.is_dir())
+    if len(matches) != 1:
+        raise PortingError(
+            f"{session_root.name}: expected exactly one {label} directory, found {len(matches)}"
+        )
+    return matches[0]
+
+
+def _hand_paths(root: Path) -> HandPaths:
+    return HandPaths(
+        root=root,
+        trajectory=root / "Merged_Trajectory" / "merged_trajectory.txt",
+        clamp=root / "Clamp_Data" / "clamp_data_tum.txt",
+        imu=root / "IMU" / "imu.txt",
+        video=root / "RGB_Images" / "video.mp4",
+        video_timestamps=root / "RGB_Images" / "timestamps.csv",
+        intrinsics=root / "Calibration" / "rgb_intrinsic.json",
+    )
+
+
+def _build_session_paths(root: Path) -> SessionPaths:
+    left = _one_directory(root, "left_hand_*", "left_hand")
+    right = _one_directory(root, "right_hand_*", "right_hand")
+    return SessionPaths(
+        root=root,
+        left=_hand_paths(left),
+        right=_hand_paths(right),
+        relative_pose=root / "relative_transforms_left_to_right.txt",
+    )
+
+
+def discover_sessions(raw_dir: Path) -> list[SessionPaths]:
+    """Discover sorted, structurally complete session directories."""
+
+    raw_dir = raw_dir.expanduser().resolve()
+    if not raw_dir.is_dir():
+        raise PortingError(f"raw directory does not exist: {raw_dir}")
+    session_roots = sorted(path for path in raw_dir.glob("session_*") if path.is_dir())
+    if not session_roots:
+        raise PortingError(f"no session_* directories found: {raw_dir}")
+    return [_build_session_paths(path) for path in session_roots]
+
+
+def _validate_series(path: Path, timestamps: np.ndarray, values: np.ndarray) -> TimedArray:
+    timestamps = np.asarray(timestamps, dtype=np.float64)
+    values = np.asarray(values, dtype=np.float64)
+    if timestamps.ndim != 1 or timestamps.size == 0:
+        raise PortingError(f"{path}: empty timestamp series")
+    if values.ndim != 2 or values.shape[0] != timestamps.size:
+        raise PortingError(f"{path}: invalid value matrix")
+    if not np.all(np.isfinite(timestamps)) or not np.all(np.isfinite(values)):
+        raise PortingError(f"{path}: values must be finite")
+    if timestamps.size > 1 and not np.all(np.diff(timestamps) > 0):
+        raise PortingError(f"{path}: timestamps must be strictly increasing")
+    return TimedArray(timestamps=timestamps, values=values)
+
+
+def _numeric_rows(path: Path, value_width: int) -> TimedArray:
+    timestamps: list[float] = []
+    values: list[list[float]] = []
+    try:
+        with path.open("r", encoding="utf-8") as stream:
+            for line_number, raw in enumerate(stream, start=1):
+                line = raw.strip()
+                if not line or line.startswith("#"):
+                    continue
+                fields = line.split()
+                if len(fields) != value_width + 1:
+                    raise PortingError(
+                        f"{path}: expected {value_width + 1} numeric columns at line {line_number}"
+                    )
+                timestamps.append(float(fields[0]))
+                values.append([float(item) for item in fields[1:]])
+    except OSError as error:
+        raise PortingError(f"{path}: unable to read source file") from error
+    except ValueError as error:
+        raise PortingError(f"{path}: invalid numeric value") from error
+    return _validate_series(path, np.asarray(timestamps), np.asarray(values))
+
+
+def read_tum_pose(path: Path) -> TimedArray:
+    series = _numeric_rows(path, value_width=7)
+    quaternions = series.values[:, 3:7]
+    norms = np.linalg.norm(quaternions, axis=1, keepdims=True)
+    if np.any(norms <= 1e-12):
+        raise PortingError(f"{path}: quaternion has zero norm")
+    values = series.values.copy()
+    values[:, 3:7] = quaternions / norms
+    return TimedArray(series.timestamps, values)
+
+
+def read_clamp(path: Path) -> TimedArray:
+    return _numeric_rows(path, value_width=1)
+
+
+def read_imu(path: Path) -> TimedArray:
+    timestamps: list[float] = []
+    values: list[list[float]] = []
+    try:
+        with path.open("r", encoding="utf-8") as stream:
+            for line_number, raw in enumerate(stream, start=1):
+                line = raw.strip()
+                if not line or line.startswith("#"):
+                    continue
+                fields = _PARENTHESIZED.sub("", line).split()
+                if len(fields) != 7:
+                    raise PortingError(f"{path}: expected timestamp, gyro3 and accel3 at line {line_number}")
+                timestamps.append(float(fields[0]))
+                values.append([float(item) for item in fields[1:]])
+    except OSError as error:
+        raise PortingError(f"{path}: unable to read source file") from error
+    except ValueError as error:
+        raise PortingError(f"{path}: invalid numeric value") from error
+    return _validate_series(path, np.asarray(timestamps), np.asarray(values))
+
+
+def read_video_timestamps(path: Path) -> np.ndarray:
+    try:
+        with path.open("r", encoding="utf-8", newline="") as stream:
+            reader = csv.DictReader(stream)
+            if reader.fieldnames == ["timestamp"]:
+                timestamps = [float(row["timestamp"]) for row in reader]
+                indices = list(range(len(timestamps)))
+            elif reader.fieldnames == ["frame_index", "seq", "header_stamp"]:
+                rows = list(reader)
+                indices = [int(row["frame_index"]) for row in rows]
+                timestamps = [float(row["header_stamp"]) for row in rows]
+            else:
+                raise PortingError(f"{path}: unsupported timestamp CSV header")
+    except OSError as error:
+        raise PortingError(f"{path}: unable to read source file") from error
+    except (KeyError, TypeError, ValueError) as error:
+        raise PortingError(f"{path}: invalid timestamp CSV value") from error
+    if indices != list(range(len(indices))):
+        raise PortingError(f"{path}: frame_index must be zero-based and contiguous")
+    series = _validate_series(
+        path,
+        np.asarray(timestamps),
+        np.asarray(indices, dtype=np.float64).reshape(-1, 1),
+    )
+    return series.timestamps
+
+
+def read_intrinsics(path: Path) -> tuple[int, int]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        height = payload["height"]
+        width = payload["width"]
+    except (OSError, json.JSONDecodeError, KeyError, TypeError) as error:
+        raise PortingError(f"{path}: invalid camera intrinsics JSON") from error
+    if (
+        not isinstance(height, int)
+        or isinstance(height, bool)
+        or not isinstance(width, int)
+        or isinstance(width, bool)
+        or height <= 0
+        or width <= 0
+    ):
+        raise PortingError(f"{path}: camera width and height must be positive integers")
+    return height, width
+
+
+def _read_hand(paths: HandPaths) -> HandData:
+    return HandData(
+        video_path=paths.video,
+        video_timestamps=read_video_timestamps(paths.video_timestamps),
+        trajectory=read_tum_pose(paths.trajectory),
+        clamp=read_clamp(paths.clamp),
+        imu=read_imu(paths.imu),
+        image_size=read_intrinsics(paths.intrinsics),
+    )
+
+
+def read_session(paths: SessionPaths) -> SessionData:
+    left = _read_hand(paths.left)
+    right = _read_hand(paths.right)
+    relative = read_tum_pose(paths.relative_pose)
+    relative = TimedArray(
+        timestamps=(left.trajectory.timestamps[0] + relative.timestamps - relative.timestamps[0]),
+        values=relative.values,
+    )
+    return SessionData(
+        name=paths.name,
+        left=left,
+        right=right,
+        relative_pose=relative,
+    )
+
+
+def nearest_indices(source_timestamps: np.ndarray, target_timestamps: np.ndarray) -> np.ndarray:
+    source = np.asarray(source_timestamps, dtype=np.float64)
+    target = np.asarray(target_timestamps, dtype=np.float64)
+    if source.ndim != 1 or source.size == 0:
+        raise PortingError("source timestamp series is empty")
+    if target.ndim != 1 or target.size == 0:
+        raise PortingError("target timestamp series is empty")
+    right = np.searchsorted(source, target, side="left")
+    right = np.clip(right, 0, source.size - 1)
+    left = np.clip(right - 1, 0, source.size - 1)
+    choose_right = np.abs(source[right] - target) < np.abs(source[left] - target)
+    return np.where(choose_right, right, left).astype(np.int64)
+
+
+def _validate_target(series: TimedArray, target: np.ndarray) -> np.ndarray:
+    target = np.asarray(target, dtype=np.float64)
+    if target.ndim != 1 or target.size == 0:
+        raise PortingError("resampling target is empty")
+    if target[0] < series.timestamps[0] - 1e-9 or target[-1] > series.timestamps[-1] + 1e-9:
+        raise PortingError("resampling would require extrapolation")
+    return target
+
+
+def linear_series(series: TimedArray, target: np.ndarray) -> np.ndarray:
+    target = _validate_target(series, target)
+    return np.column_stack(
+        [
+            np.interp(target, series.timestamps, series.values[:, column])
+            for column in range(series.values.shape[1])
+        ]
+    )
+
+
+def _normalize_quaternions(values: np.ndarray) -> np.ndarray:
+    values = np.asarray(values, dtype=np.float64)
+    norms = np.linalg.norm(values, axis=1, keepdims=True)
+    if np.any(~np.isfinite(values)) or np.any(norms <= 1e-12):
+        raise PortingError("quaternion is non-finite or has zero norm")
+    return values / norms
+
+
+def slerp_series(series: TimedArray, target: np.ndarray) -> np.ndarray:
+    target = _validate_target(series, target)
+    quaternions = _normalize_quaternions(series.values)
+    if quaternions.shape[1] != 4:
+        raise PortingError("SLERP input must contain four quaternion values")
+    if len(series.timestamps) == 1:
+        return np.repeat(quaternions, len(target), axis=0)
+
+    right_indices = np.searchsorted(series.timestamps, target, side="right")
+    right_indices = np.clip(right_indices, 1, len(series.timestamps) - 1)
+    left_indices = right_indices - 1
+    left_times = series.timestamps[left_indices]
+    right_times = series.timestamps[right_indices]
+    alpha = ((target - left_times) / (right_times - left_times)).reshape(-1, 1)
+
+    left = quaternions[left_indices]
+    right = quaternions[right_indices]
+    dots = np.sum(left * right, axis=1, keepdims=True)
+    right = np.where(dots < 0, -right, right)
+    dots = np.abs(dots)
+
+    linear = _normalize_quaternions((1.0 - alpha) * left + alpha * right)
+    theta = np.arccos(np.clip(dots, -1.0, 1.0))
+    sin_theta = np.sin(theta)
+    safe_denominator = np.where(np.abs(sin_theta) < 1e-12, 1.0, sin_theta)
+    spherical = (
+        np.sin((1.0 - alpha) * theta) / safe_denominator * left
+        + np.sin(alpha * theta) / safe_denominator * right
+    )
+    result = np.where(dots > 0.9995, linear, spherical)
+    return _normalize_quaternions(result)
+
+
+def _pose_series(series: TimedArray, target: np.ndarray) -> np.ndarray:
+    translation = linear_series(TimedArray(series.timestamps, series.values[:, :3]), target)
+    quaternion = slerp_series(TimedArray(series.timestamps, series.values[:, 3:7]), target)
+    return np.concatenate([translation, quaternion], axis=1)
+
+
+def _build_actions(states: np.ndarray) -> np.ndarray:
+    actions = np.empty_like(states)
+    actions[:-1] = states[1:]
+    actions[-1] = states[-1]
+    return actions
+
+
+def sync_session(data: SessionData, fps: int) -> SyncedEpisode:
+    if fps <= 0:
+        raise PortingError("fps must be positive")
+    required = [
+        data.left.video_timestamps,
+        data.right.video_timestamps,
+        data.left.trajectory.timestamps,
+        data.right.trajectory.timestamps,
+        data.left.clamp.timestamps,
+        data.right.clamp.timestamps,
+        data.left.imu.timestamps,
+        data.right.imu.timestamps,
+        data.relative_pose.timestamps,
+    ]
+    start = max(float(values[0]) for values in required)
+    end = min(float(values[-1]) for values in required)
+    if not np.isfinite(start) or not np.isfinite(end) or end < start:
+        raise PortingError(f"{data.name}: sensor streams have no common time range")
+    count = int(np.floor((end - start) * fps + 1e-9)) + 1
+    if count < 2:
+        raise PortingError(f"{data.name}: common time range has fewer than two frames")
+    target = start + np.arange(count, dtype=np.float64) / fps
+
+    left_pose = _pose_series(data.left.trajectory, target)
+    right_pose = _pose_series(data.right.trajectory, target)
+    left_gripper = linear_series(data.left.clamp, target)
+    right_gripper = linear_series(data.right.clamp, target)
+    left_imu = linear_series(data.left.imu, target)
+    right_imu = linear_series(data.right.imu, target)
+    relative_pose = _pose_series(data.relative_pose, target)
+
+    states = np.concatenate([left_pose, left_gripper, right_pose, right_gripper], axis=1).astype(np.float32)
+    imu = np.concatenate([left_imu, right_imu], axis=1).astype(np.float32)
+    relative_pose = relative_pose.astype(np.float32)
+    if not all(np.all(np.isfinite(values)) for values in (states, imu, relative_pose)):
+        raise PortingError(f"{data.name}: synchronized values must be finite")
+
+    left_indices = nearest_indices(data.left.video_timestamps, target)
+    right_indices = nearest_indices(data.right.video_timestamps, target)
+    left_errors = np.abs(data.left.video_timestamps[left_indices] - target)
+    right_errors = np.abs(data.right.video_timestamps[right_indices] - target)
+    metrics: dict[str, float | int] = {
+        "common_start": float(start),
+        "common_end": float(target[-1]),
+        "output_frames": int(count),
+        "left_video_max_match_error_s": float(left_errors.max()),
+        "right_video_max_match_error_s": float(right_errors.max()),
+    }
+    return SyncedEpisode(
+        name=data.name,
+        timestamps=target,
+        left_video_indices=left_indices,
+        right_video_indices=right_indices,
+        states=states,
+        actions=_build_actions(states),
+        imu=imu,
+        relative_pose=relative_pose,
+        metrics=metrics,
+    )
+
+
+STATE_NAMES = (
+    "left_tx",
+    "left_ty",
+    "left_tz",
+    "left_qx",
+    "left_qy",
+    "left_qz",
+    "left_qw",
+    "left_gripper",
+    "right_tx",
+    "right_ty",
+    "right_tz",
+    "right_qx",
+    "right_qy",
+    "right_qz",
+    "right_qw",
+    "right_gripper",
+)
+
+IMU_NAMES = (
+    "left_gyro_x",
+    "left_gyro_y",
+    "left_gyro_z",
+    "left_accel_x",
+    "left_accel_y",
+    "left_accel_z",
+    "right_gyro_x",
+    "right_gyro_y",
+    "right_gyro_z",
+    "right_accel_x",
+    "right_accel_y",
+    "right_accel_z",
+)
+
+
+def make_features(height: int, width: int) -> dict[str, dict]:
+    if height <= 0 or width <= 0:
+        raise PortingError("camera dimensions must be positive")
+    image = {
+        "dtype": "video",
+        "shape": (height, width, 3),
+        "names": ["height", "width", "channel"],
+    }
+    return {
+        "observation.images.left_hand": dict(image),
+        "observation.images.right_hand": dict(image),
+        "observation.state": {
+            "dtype": "float32",
+            "shape": (16,),
+            "names": list(STATE_NAMES),
+        },
+        "observation.imu": {
+            "dtype": "float32",
+            "shape": (12,),
+            "names": list(IMU_NAMES),
+        },
+        "observation.relative_pose": {
+            "dtype": "float32",
+            "shape": (7,),
+            "names": ["tx", "ty", "tz", "qx", "qy", "qz", "qw"],
+        },
+        "action": {
+            "dtype": "float32",
+            "shape": (16,),
+            "names": list(STATE_NAMES),
+        },
+        "source_timestamp": {
+            "dtype": "float64",
+            "shape": (1,),
+            "names": ["device_time_s"],
+        },
+    }
+
+
+def read_video_indices(path: Path, indices: np.ndarray) -> Iterator[np.ndarray]:
+    requested = np.asarray(indices)
+    if requested.ndim != 1 or requested.size == 0:
+        raise PortingError(f"{path}: requested video indices are empty")
+    if not np.issubdtype(requested.dtype, np.integer):
+        raise PortingError(f"{path}: video indices must be integers")
+    requested = requested.astype(np.int64)
+    if np.any(requested < 0) or np.any(np.diff(requested) < 0):
+        raise PortingError(f"{path}: video indices must be nonnegative and nondecreasing")
+
+    capture = cv2.VideoCapture(str(path))
+    if not capture.isOpened():
+        raise PortingError(f"{path}: unable to open video")
+    decoded_index = -1
+    cached_index = -1
+    cached_rgb: np.ndarray | None = None
+    try:
+        for wanted in requested:
+            if int(wanted) == cached_index and cached_rgb is not None:
+                yield cached_rgb.copy()
+                continue
+            while decoded_index < int(wanted):
+                ok, frame = capture.read()
+                if not ok:
+                    raise PortingError(f"{path}: unable to decode requested frame {int(wanted)}")
+                decoded_index += 1
+            cached_index = decoded_index
+            cached_rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+            yield cached_rgb.copy()
+    finally:
+        capture.release()
+
+
+def _build_frame(
+    episode: SyncedEpisode,
+    index: int,
+    left_rgb: np.ndarray,
+    right_rgb: np.ndarray,
+    task: str,
+) -> dict:
+    if not task.strip():
+        raise PortingError(f"{episode.name}: task text cannot be empty")
+    if (
+        left_rgb.dtype != np.uint8
+        or right_rgb.dtype != np.uint8
+        or left_rgb.ndim != 3
+        or right_rgb.ndim != 3
+        or left_rgb.shape[2] != 3
+        or right_rgb.shape[2] != 3
+        or left_rgb.shape != right_rgb.shape
+    ):
+        raise PortingError(f"{episode.name}: camera frames must be matching RGB uint8")
+    return {
+        "observation.images.left_hand": left_rgb,
+        "observation.images.right_hand": right_rgb,
+        "observation.state": episode.states[index],
+        "observation.imu": episode.imu[index],
+        "observation.relative_pose": episode.relative_pose[index],
+        "action": episode.actions[index],
+        "source_timestamp": np.asarray([episode.timestamps[index]], dtype=np.float64),
+        "task": task,
+    }
+
+
+def _video_frame_count(path: Path) -> int:
+    capture = cv2.VideoCapture(str(path))
+    if not capture.isOpened():
+        raise PortingError(f"{path}: unable to open video")
+    try:
+        count = int(round(capture.get(cv2.CAP_PROP_FRAME_COUNT)))
+    finally:
+        capture.release()
+    if count <= 0:
+        raise PortingError(f"{path}: video contains no decodable frames")
+    return count
+
+
+def _validate_video_timestamp_counts(data: SessionData) -> None:
+    for label, hand in (("left", data.left), ("right", data.right)):
+        frame_count = _video_frame_count(hand.video_path)
+        timestamp_count = len(hand.video_timestamps)
+        if frame_count != timestamp_count:
+            raise PortingError(
+                f"{data.name}: {label} video frames ({frame_count}) do not match "
+                f"timestamps ({timestamp_count})"
+            )
+
+
+def _source_ranges(data: SessionData) -> dict[str, list[float]]:
+    streams = {
+        "left_video": data.left.video_timestamps,
+        "right_video": data.right.video_timestamps,
+        "left_trajectory": data.left.trajectory.timestamps,
+        "right_trajectory": data.right.trajectory.timestamps,
+        "left_gripper": data.left.clamp.timestamps,
+        "right_gripper": data.right.clamp.timestamps,
+        "left_imu": data.left.imu.timestamps,
+        "right_imu": data.right.imu.timestamps,
+        "relative_pose": data.relative_pose.timestamps,
+    }
+    return {name: [float(timestamps[0]), float(timestamps[-1])] for name, timestamps in streams.items()}
+
+
+def _configure_local_dataset_cache(output_root: Path) -> None:
+    cache_root = output_root.parent / ".cache" / "lerobot"
+    datasets_cache = cache_root / "datasets"
+    datasets_cache.mkdir(parents=True, exist_ok=True)
+    os.environ["HF_HOME"] = str(cache_root)
+    os.environ["HF_DATASETS_CACHE"] = str(datasets_cache)
+    try:
+        import datasets.config
+
+        datasets.config.HF_DATASETS_CACHE = datasets_cache
+    except ImportError:
+        pass
+
+
+def prepare_output(raw_dir: Path, root: Path | None, overwrite: bool) -> tuple[Path, Path | None]:
+    raw_dir = raw_dir.expanduser().resolve()
+    if root is None:
+        return raw_dir, None
+    root = root.expanduser().resolve()
+    if raw_dir == root or raw_dir in root.parents or root in raw_dir.parents:
+        raise PortingError("raw and output paths overlap")
+    if root.exists():
+        if not overwrite:
+            raise PortingError(f"output already exists: {root}")
+        if root == Path("/") or root == root.parent:
+            raise PortingError(f"refusing to remove unsafe output path: {root}")
+        shutil.rmtree(root)
+    root.parent.mkdir(parents=True, exist_ok=True)
+    return raw_dir, root
+
+
+def _sanitized_error(error: Exception, raw_dir: Path) -> str:
+    return str(error).replace(str(raw_dir), "<raw_dir>")
+
+
+def convert_dataset(options: PortOptions) -> dict:
+    try:
+        from lerobot.configs.video import RGBEncoderConfig
+        from lerobot.datasets import LeRobotDataset
+    except ImportError as error:
+        raise PortingError("LeRobot with dataset support is required") from error
+
+    raw_dir, output_root = prepare_output(options.raw_dir, options.root, options.overwrite)
+    paths = discover_sessions(raw_dir)
+    sessions: list[SessionData] = []
+    report_by_name: dict[str, dict] = {}
+    expected_size: tuple[int, int] | None = None
+    for session_paths in paths:
+        try:
+            data = read_session(session_paths)
+            if data.left.image_size != data.right.image_size:
+                raise PortingError(f"{data.name}: left and right camera dimensions differ")
+            _validate_video_timestamp_counts(data)
+            if expected_size is None:
+                expected_size = data.left.image_size
+            elif data.left.image_size != expected_size:
+                raise PortingError(f"{data.name}: camera dimensions differ from earlier sessions")
+            sessions.append(data)
+        except Exception as error:
+            if not options.skip_invalid_session:
+                raise
+            report_by_name[session_paths.name] = {
+                "session": session_paths.name,
+                "status": "failed",
+                "error": _sanitized_error(error, raw_dir),
+            }
+    if not sessions or expected_size is None:
+        raise PortingError("no valid sessions to convert")
+    height, width = expected_size
+    if output_root is not None:
+        _configure_local_dataset_cache(output_root)
+
+    dataset = LeRobotDataset.create(
+        repo_id=options.repo_id,
+        root=output_root,
+        fps=options.fps,
+        robot_type="generic_bimanual_tum",
+        features=make_features(height, width),
+        use_videos=True,
+        image_writer_processes=0,
+        image_writer_threads=4,
+        streaming_encoding=True,
+        encoder_queue_maxsize=30,
+        rgb_encoder=RGBEncoderConfig(
+            vcodec="h264",
+            pix_fmt="yuv420p",
+            g=2,
+            crf=23,
+            preset="veryfast",
+        ),
+        encoder_threads=4,
+    )
+
+    frames_total = 0
+    try:
+        for data in sessions:
+            try:
+                episode = sync_session(data, options.fps)
+                left_frames = read_video_indices(data.left.video_path, episode.left_video_indices)
+                right_frames = read_video_indices(data.right.video_path, episode.right_video_indices)
+                for index, (left_rgb, right_rgb) in enumerate(zip(left_frames, right_frames, strict=True)):
+                    dataset.add_frame(
+                        _build_frame(
+                            episode,
+                            index,
+                            left_rgb,
+                            right_rgb,
+                            options.task,
+                        )
+                    )
+                dataset.save_episode(parallel_encoding=False)
+                frames_total += len(episode.timestamps)
+                report_by_name[data.name] = {
+                    "session": data.name,
+                    "status": "success",
+                    "frames": len(episode.timestamps),
+                    "metrics": episode.metrics,
+                    "source_ranges": _source_ranges(data),
+                }
+            except Exception as error:
+                if not options.skip_invalid_session:
+                    raise
+                dataset.clear_episode_buffer(delete_images=True)
+                report_by_name[data.name] = {
+                    "session": data.name,
+                    "status": "failed",
+                    "error": _sanitized_error(error, raw_dir),
+                }
+    finally:
+        dataset.finalize()
+
+    reports = [report_by_name[item.name] for item in paths]
+    episode_count = sum(item["status"] == "success" for item in reports)
+    if episode_count == 0:
+        raise PortingError("no sessions were written successfully")
+    output_root = Path(dataset.root)
+    loaded = LeRobotDataset(repo_id=options.repo_id, root=output_root)
+    if int(loaded.num_episodes) != episode_count or len(loaded) != frames_total:
+        raise PortingError("output dataset episode or frame count validation failed")
+    required_video_keys = {
+        "observation.images.left_hand",
+        "observation.images.right_hand",
+    }
+    if not required_video_keys.issubset(loaded.features):
+        raise PortingError("output dataset is missing required video features")
+    for index in sorted({0, len(loaded) - 1}):
+        frame = loaded[index]
+        if not required_video_keys.issubset(frame):
+            raise PortingError("output dataset video decoding validation failed")
+    validation = {
+        "loadable": True,
+        "episodes": int(loaded.num_episodes),
+        "frames": len(loaded),
+    }
+    if options.push_to_hub:
+        dataset.push_to_hub()
+    report = {
+        "format": "LeRobotDataset v3",
+        "repo_id": options.repo_id,
+        "fps": options.fps,
+        "episodes": episode_count,
+        "frames": frames_total,
+        "sessions": reports,
+        "validation": validation,
+    }
+    (output_root / "conversion_report.json").write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return report
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return parsed
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Port generic bimanual TUM-style captures to LeRobot Dataset v3."
+    )
+    parser.add_argument("--raw-dir", type=Path, required=True)
+    parser.add_argument("--repo-id", required=True)
+    parser.add_argument("--root", type=Path)
+    parser.add_argument("--fps", type=_positive_int, default=60)
+    parser.add_argument("--task", default="bimanual hand manipulation")
+    parser.add_argument("--push-to-hub", action="store_true")
+    parser.add_argument("--overwrite", action="store_true")
+    parser.add_argument("--skip-invalid-session", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        report = convert_dataset(
+            PortOptions(
+                raw_dir=args.raw_dir,
+                repo_id=args.repo_id,
+                root=args.root,
+                fps=args.fps,
+                task=args.task,
+                push_to_hub=args.push_to_hub,
+                overwrite=args.overwrite,
+                skip_invalid_session=args.skip_invalid_session,
+            )
+        )
+    except PortingError as error:
+        print(f"porting error: {error}", file=sys.stderr)
+        return 2
+    except Exception:
+        traceback.print_exc()
+        return 1
+    print(
+        f"port complete: repo_id={report['repo_id']} episodes={report['episodes']} frames={report['frames']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_port_tum_bimanual.py
+++ b/tests/test_port_tum_bimanual.py
@@ -1,0 +1,592 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+from pathlib import Path
+
+import cv2
+import numpy as np
+import pytest
+
+from examples.port_datasets.port_tum_bimanual import (
+    HandData,
+    PortingError,
+    PortOptions,
+    SessionData,
+    TimedArray,
+    build_parser,
+    convert_dataset,
+    discover_sessions,
+    main,
+    make_features,
+    nearest_indices,
+    prepare_output,
+    read_clamp,
+    read_imu,
+    read_intrinsics,
+    read_session,
+    read_tum_pose,
+    read_video_indices,
+    read_video_timestamps,
+    slerp_series,
+    sync_session,
+)
+from lerobot.datasets import LeRobotDataset
+
+
+def create_hand_tree(session: Path, hand_name: str) -> Path:
+    hand = session / hand_name
+    (hand / "Calibration").mkdir(parents=True)
+    (hand / "Clamp_Data").mkdir()
+    (hand / "IMU").mkdir()
+    (hand / "Merged_Trajectory").mkdir()
+    (hand / "RGB_Images").mkdir()
+    return hand
+
+
+def write_text(path: Path, text: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def test_discover_sessions_returns_sorted_complete_sessions(tmp_path: Path) -> None:
+    create_hand_tree(tmp_path / "session_000002", "left_hand_device_b")
+    create_hand_tree(tmp_path / "session_000002", "right_hand_device_b")
+    create_hand_tree(tmp_path / "session_000001", "left_hand_device_a")
+    create_hand_tree(tmp_path / "session_000001", "right_hand_device_a")
+
+    sessions = discover_sessions(tmp_path)
+
+    assert [item.name for item in sessions] == ["session_000001", "session_000002"]
+    assert sessions[0].left.name == "left_hand_device_a"
+    assert sessions[0].right.name == "right_hand_device_a"
+
+
+def test_discover_sessions_rejects_missing_right_hand(tmp_path: Path) -> None:
+    create_hand_tree(tmp_path / "session_000001", "left_hand_device_a")
+
+    with pytest.raises(PortingError, match="exactly one right_hand"):
+        discover_sessions(tmp_path)
+
+
+def test_discover_sessions_rejects_no_sessions(tmp_path: Path) -> None:
+    with pytest.raises(PortingError, match="no session_"):
+        discover_sessions(tmp_path)
+
+
+def test_read_tum_pose_normalizes_quaternion(tmp_path: Path) -> None:
+    path = write_text(
+        tmp_path / "pose.txt",
+        "0.0 1 2 3 0 0 0 2\n1.0 2 3 4 0 0 0 2\n",
+    )
+
+    series = read_tum_pose(path)
+
+    np.testing.assert_allclose(series.values[:, 3:], [[0, 0, 0, 1]] * 2)
+
+
+def test_numeric_reader_rejects_non_monotonic_timestamps(tmp_path: Path) -> None:
+    path = write_text(
+        tmp_path / "pose.txt",
+        "1.0 1 2 3 0 0 0 1\n0.0 2 3 4 0 0 0 1\n",
+    )
+
+    with pytest.raises(PortingError, match="strictly increasing"):
+        read_tum_pose(path)
+
+
+@pytest.mark.parametrize(
+    "content, message",
+    [
+        ("", "empty"),
+        ("0 1 2\n", "expected 2 numeric columns"),
+        ("0 nan\n", "finite"),
+    ],
+)
+def test_read_clamp_rejects_invalid_rows(tmp_path: Path, content: str, message: str) -> None:
+    path = write_text(tmp_path / "clamp.txt", content)
+
+    with pytest.raises(PortingError, match=message):
+        read_clamp(path)
+
+
+def test_read_tum_pose_rejects_zero_norm_quaternion(tmp_path: Path) -> None:
+    path = write_text(tmp_path / "pose.txt", "0 1 2 3 0 0 0 0\n")
+
+    with pytest.raises(PortingError, match="zero norm"):
+        read_tum_pose(path)
+
+
+def test_read_imu_accepts_compact_and_covariance_rows(tmp_path: Path) -> None:
+    compact = write_text(
+        tmp_path / "compact.txt",
+        "0 1 2 3 4 5 6\n1 2 3 4 5 6 7\n",
+    )
+    covariance = write_text(
+        tmp_path / "covariance.txt",
+        "0 1 2 3 (0, 0, 0, 0, 0, 0, 0, 0, 0) "
+        "4 5 6 (0, 0, 0, 0, 0, 0, 0, 0, 0)\n"
+        "1 2 3 4 (0, 0, 0, 0, 0, 0, 0, 0, 0) "
+        "5 6 7 (0, 0, 0, 0, 0, 0, 0, 0, 0)\n",
+    )
+
+    np.testing.assert_allclose(read_imu(compact).values[0], [1, 2, 3, 4, 5, 6])
+    np.testing.assert_allclose(read_imu(covariance).values[0], [1, 2, 3, 4, 5, 6])
+
+
+def test_read_video_timestamps_accepts_supported_headers_and_rejects_nan(
+    tmp_path: Path,
+) -> None:
+    simple = write_text(tmp_path / "simple.csv", "timestamp\n0.0\n0.5\n")
+    indexed = write_text(
+        tmp_path / "indexed.csv",
+        "frame_index,seq,header_stamp\n0,10,0.0\n1,11,0.5\n",
+    )
+    np.testing.assert_allclose(read_video_timestamps(simple), [0.0, 0.5])
+    np.testing.assert_allclose(read_video_timestamps(indexed), [0.0, 0.5])
+
+    invalid = write_text(tmp_path / "bad.csv", "timestamp\n0.0\nnan\n")
+    with pytest.raises(PortingError, match="finite"):
+        read_video_timestamps(invalid)
+
+
+def test_read_video_timestamps_requires_contiguous_frame_indices(
+    tmp_path: Path,
+) -> None:
+    path = write_text(
+        tmp_path / "timestamps.csv",
+        "frame_index,seq,header_stamp\n0,10,0.0\n2,11,0.5\n",
+    )
+
+    with pytest.raises(PortingError, match="contiguous"):
+        read_video_timestamps(path)
+
+
+def test_read_intrinsics_requires_positive_integer_dimensions(tmp_path: Path) -> None:
+    valid = write_text(tmp_path / "valid.json", '{"width": 10, "height": 8}')
+    assert read_intrinsics(valid) == (8, 10)
+
+    invalid = write_text(tmp_path / "invalid.json", '{"width": 0, "height": 8}')
+    with pytest.raises(PortingError, match="positive integer"):
+        read_intrinsics(invalid)
+
+
+def _write_hand_streams(hand: Path, start: float) -> None:
+    write_text(
+        hand / "Merged_Trajectory" / "merged_trajectory.txt",
+        f"{start} 0 0 0 0 0 0 1\n{start + 1} 1 0 0 0 0 0 1\n",
+    )
+    write_text(
+        hand / "Clamp_Data" / "clamp_data_tum.txt",
+        f"{start} 0\n{start + 1} 1\n",
+    )
+    write_text(
+        hand / "IMU" / "imu.txt",
+        f"{start} 1 2 3 4 5 6\n{start + 1} 2 3 4 5 6 7\n",
+    )
+    write_text(
+        hand / "RGB_Images" / "timestamps.csv",
+        f"timestamp\n{start}\n{start + 1}\n",
+    )
+    write_text(
+        hand / "Calibration" / "rgb_intrinsic.json",
+        '{"width": 10, "height": 8}',
+    )
+
+
+def test_read_session_aligns_relative_time_to_left_trajectory(
+    tmp_path: Path,
+) -> None:
+    session = tmp_path / "session_000001"
+    left = create_hand_tree(session, "left_hand_device_a")
+    right = create_hand_tree(session, "right_hand_device_a")
+    _write_hand_streams(left, start=10.0)
+    _write_hand_streams(right, start=10.0)
+    write_text(
+        session / "relative_transforms_left_to_right.txt",
+        "1000.0 0 0 0 0 0 0 1\n1001.0 1 0 0 0 0 0 1\n",
+    )
+
+    data = read_session(discover_sessions(tmp_path)[0])
+
+    np.testing.assert_allclose(data.relative_pose.timestamps, [10.0, 11.0])
+
+
+def _pose_series(start: float, end: float) -> TimedArray:
+    return TimedArray(
+        timestamps=np.array([start, end], dtype=np.float64),
+        values=np.array(
+            [
+                [0, 0, 0, 0, 0, 0, 1],
+                [1, 2, 3, 0, 0, 0, 1],
+            ],
+            dtype=np.float64,
+        ),
+    )
+
+
+def _vector_series(start: float, end: float, width: int) -> TimedArray:
+    return TimedArray(
+        timestamps=np.array([start, end], dtype=np.float64),
+        values=np.vstack(
+            [
+                np.arange(width, dtype=np.float64),
+                np.arange(width, dtype=np.float64) + 1,
+            ]
+        ),
+    )
+
+
+def synthetic_session_data(
+    left_video_range: tuple[float, float] = (0.0, 2.0),
+    right_video_range: tuple[float, float] = (0.0, 2.0),
+    relative_pose_range: tuple[float, float] = (0.0, 2.0),
+) -> SessionData:
+    left = HandData(
+        video_path=Path("left.mp4"),
+        video_timestamps=np.array(left_video_range),
+        trajectory=_pose_series(0.0, 2.0),
+        clamp=_vector_series(0.0, 2.0, 1),
+        imu=_vector_series(0.0, 2.0, 6),
+        image_size=(8, 10),
+    )
+    right = HandData(
+        video_path=Path("right.mp4"),
+        video_timestamps=np.array(right_video_range),
+        trajectory=_pose_series(0.25, 1.75),
+        clamp=_vector_series(0.25, 1.75, 1),
+        imu=_vector_series(0.25, 1.75, 6),
+        image_size=(8, 10),
+    )
+    return SessionData(
+        name="session_000001",
+        left=left,
+        right=right,
+        relative_pose=_pose_series(*relative_pose_range),
+    )
+
+
+def test_nearest_indices_breaks_ties_toward_earlier_frame() -> None:
+    result = nearest_indices(np.array([0.0, 1.0]), np.array([0.5]))
+    np.testing.assert_array_equal(result, [0])
+
+
+def test_slerp_uses_shortest_path_and_unit_norm() -> None:
+    series = TimedArray(
+        np.array([0.0, 1.0]),
+        np.array([[0.0, 0.0, 0.0, 1.0], [0.0, 0.0, 0.0, -1.0]]),
+    )
+
+    result = slerp_series(series, np.array([0.5]))
+
+    np.testing.assert_allclose(result, [[0.0, 0.0, 0.0, 1.0]], atol=1e-6)
+    np.testing.assert_allclose(np.linalg.norm(result, axis=1), [1.0], atol=1e-6)
+
+
+def test_sync_session_uses_common_overlap_without_extrapolation() -> None:
+    data = synthetic_session_data(
+        left_video_range=(0.0, 2.0),
+        right_video_range=(0.25, 1.75),
+        relative_pose_range=(0.5, 1.5),
+    )
+
+    episode = sync_session(data, fps=2)
+
+    np.testing.assert_allclose(episode.timestamps, [0.5, 1.0, 1.5])
+
+
+def test_actions_are_next_state_with_last_state_repeated() -> None:
+    episode = sync_session(synthetic_session_data(), fps=2)
+
+    np.testing.assert_array_equal(episode.actions[:-1], episode.states[1:])
+    np.testing.assert_array_equal(episode.actions[-1], episode.states[-1])
+
+
+def test_features_match_documented_shapes() -> None:
+    features = make_features(8, 10)
+
+    assert features["observation.state"]["shape"] == (16,)
+    assert features["observation.imu"]["shape"] == (12,)
+    assert features["observation.relative_pose"]["shape"] == (7,)
+    assert features["action"]["shape"] == (16,)
+    assert features["source_timestamp"]["shape"] == (1,)
+    assert features["observation.images.left_hand"]["shape"] == (8, 10, 3)
+    assert features["observation.images.right_hand"]["shape"] == (8, 10, 3)
+
+
+def test_sync_session_rejects_non_positive_fps_and_empty_overlap() -> None:
+    with pytest.raises(PortingError, match="positive"):
+        sync_session(synthetic_session_data(), fps=0)
+
+    data = synthetic_session_data(relative_pose_range=(3.0, 4.0))
+    with pytest.raises(PortingError, match="common time"):
+        sync_session(data, fps=2)
+
+
+def write_test_video(path: Path, colors_bgr: list[tuple[int, int, int]], fps: float = 2.0) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    writer = cv2.VideoWriter(
+        str(path),
+        cv2.VideoWriter_fourcc(*"mp4v"),
+        fps,
+        (10, 8),
+    )
+    assert writer.isOpened()
+    try:
+        for color in colors_bgr:
+            frame = np.empty((8, 10, 3), dtype=np.uint8)
+            frame[:] = color
+            writer.write(frame)
+    finally:
+        writer.release()
+    return path
+
+
+def create_complete_synthetic_source(raw_dir: Path) -> Path:
+    session = raw_dir / "session_000001"
+    left = create_hand_tree(session, "left_hand_device_a")
+    right = create_hand_tree(session, "right_hand_device_a")
+    for hand, offset in ((left, 0.0), (right, 0.25)):
+        write_text(
+            hand / "Merged_Trajectory" / "merged_trajectory.txt",
+            f"0.0 {offset} 0 0 0 0 0 1\n0.5 {offset + 0.5} 0 0 0 0 0 1\n1.0 {offset + 1.0} 0 0 0 0 0 1\n",
+        )
+        write_text(
+            hand / "Clamp_Data" / "clamp_data_tum.txt",
+            "0.0 0\n0.5 0.5\n1.0 1\n",
+        )
+        write_text(
+            hand / "IMU" / "imu.txt",
+            "0.0 1 2 3 4 5 6\n0.5 2 3 4 5 6 7\n1.0 3 4 5 6 7 8\n",
+        )
+        write_text(
+            hand / "RGB_Images" / "timestamps.csv",
+            "frame_index,seq,header_stamp\n0,10,0.0\n1,11,0.5\n2,12,1.0\n",
+        )
+        write_text(
+            hand / "Calibration" / "rgb_intrinsic.json",
+            '{"width": 10, "height": 8}',
+        )
+        write_test_video(
+            hand / "RGB_Images" / "video.mp4",
+            [(0, 0, 255), (0, 255, 0), (255, 0, 0)],
+        )
+    write_text(
+        session / "relative_transforms_left_to_right.txt",
+        "1000.0 0 0 0 0 0 0 1\n1000.5 0.5 0 0 0 0 0 1\n1001.0 1 0 0 0 0 0 1\n",
+    )
+    return raw_dir
+
+
+def test_read_video_indices_returns_rgb_in_requested_order(tmp_path: Path) -> None:
+    video = write_test_video(tmp_path / "video.mp4", colors_bgr=[(0, 0, 255), (0, 255, 0)])
+
+    frames = list(read_video_indices(video, np.array([0, 1])))
+
+    assert frames[0].shape == (8, 10, 3)
+    assert frames[0].dtype == np.uint8
+    assert int(frames[0][0, 0, 0]) > int(frames[0][0, 0, 1])
+    assert int(frames[1][0, 0, 1]) > int(frames[1][0, 0, 0])
+
+
+def test_read_video_indices_rejects_decreasing_indices(tmp_path: Path) -> None:
+    video = write_test_video(tmp_path / "video.mp4", colors_bgr=[(0, 0, 255), (0, 255, 0)])
+
+    with pytest.raises(PortingError, match="nondecreasing"):
+        list(read_video_indices(video, np.array([1, 0])))
+
+
+def test_convert_dataset_round_trips_one_synthetic_episode(
+    tmp_path: Path,
+) -> None:
+    raw_dir = create_complete_synthetic_source(tmp_path / "raw")
+    output = tmp_path / "dataset"
+
+    report = convert_dataset(
+        PortOptions(
+            raw_dir=raw_dir,
+            repo_id="namespace/synthetic_bimanual",
+            root=output,
+            fps=2,
+            task="move both hands",
+        )
+    )
+    dataset = LeRobotDataset(
+        repo_id="namespace/synthetic_bimanual",
+        root=output,
+    )
+
+    assert dataset.num_episodes == 1
+    assert len(dataset) == 3
+    assert report["episodes"] == 1
+    assert report["frames"] == 3
+    assert report["validation"] == {
+        "loadable": True,
+        "episodes": 1,
+        "frames": 3,
+    }
+    assert report["sessions"][0]["source_ranges"]["left_video"] == [0.0, 1.0]
+    assert (output / "meta" / "info.json").is_file()
+    assert (output / "conversion_report.json").is_file()
+    assert "observation.images.left_hand" in dataset.features
+    assert "observation.images.right_hand" in dataset.features
+
+
+def test_convert_dataset_rejects_video_timestamp_count_mismatch(
+    tmp_path: Path,
+) -> None:
+    raw_dir = create_complete_synthetic_source(tmp_path / "raw")
+    timestamps = raw_dir / "session_000001" / "left_hand_device_a" / "RGB_Images" / "timestamps.csv"
+    write_text(
+        timestamps,
+        "frame_index,seq,header_stamp\n0,10,0.0\n1,11,0.5\n2,12,1.0\n3,13,1.5\n",
+    )
+
+    with pytest.raises(PortingError, match="video frames.*timestamps"):
+        convert_dataset(
+            PortOptions(
+                raw_dir=raw_dir,
+                repo_id="namespace/mismatch",
+                root=tmp_path / "dataset",
+                fps=2,
+            )
+        )
+
+
+def test_parser_exposes_upstream_style_arguments() -> None:
+    args = build_parser().parse_args(
+        [
+            "--raw-dir",
+            "/path/to/raw_root",
+            "--repo-id",
+            "namespace/dataset_name",
+            "--root",
+            "/path/to/output",
+            "--fps",
+            "30",
+            "--task",
+            "move both hands",
+            "--push-to-hub",
+        ]
+    )
+
+    assert args.repo_id == "namespace/dataset_name"
+    assert args.fps == 30
+    assert args.push_to_hub is True
+
+
+def test_conversion_rejects_overlapping_input_and_output(tmp_path: Path) -> None:
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+
+    with pytest.raises(PortingError, match="overlap"):
+        prepare_output(raw_dir, raw_dir / "output", overwrite=False)
+
+
+def test_existing_output_requires_explicit_overwrite(tmp_path: Path) -> None:
+    raw_dir = tmp_path / "raw"
+    output = tmp_path / "output"
+    raw_dir.mkdir()
+    output.mkdir()
+
+    with pytest.raises(PortingError, match="already exists"):
+        prepare_output(raw_dir, output, overwrite=False)
+
+
+def test_explicit_overwrite_recreates_only_the_output_path(tmp_path: Path) -> None:
+    raw_dir = tmp_path / "raw"
+    output = tmp_path / "output"
+    sibling = tmp_path / "keep.txt"
+    raw_dir.mkdir()
+    output.mkdir()
+    write_text(output / "old.txt", "old")
+    write_text(sibling, "keep")
+
+    _, resolved_output = prepare_output(raw_dir, output, overwrite=True)
+
+    assert resolved_output == output.resolve()
+    assert not output.exists()
+    assert sibling.read_text(encoding="utf-8") == "keep"
+
+
+def test_skip_invalid_session_converts_valid_session_and_reports_failure(
+    tmp_path: Path,
+) -> None:
+    raw_dir = create_complete_synthetic_source(tmp_path / "raw")
+    invalid = raw_dir / "session_000002"
+    create_hand_tree(invalid, "left_hand_device_b")
+    create_hand_tree(invalid, "right_hand_device_b")
+    write_text(
+        invalid / "relative_transforms_left_to_right.txt",
+        "0 0 0 0 0 0 0 1\n1 0 0 0 0 0 0 1\n",
+    )
+    output = tmp_path / "dataset"
+
+    report = convert_dataset(
+        PortOptions(
+            raw_dir=raw_dir,
+            repo_id="namespace/synthetic_skip",
+            root=output,
+            fps=2,
+            skip_invalid_session=True,
+        )
+    )
+
+    assert report["episodes"] == 1
+    assert [item["status"] for item in report["sessions"]] == [
+        "success",
+        "failed",
+    ]
+    assert report["sessions"][1]["session"] == "session_000002"
+    assert "<raw_dir>" in report["sessions"][1]["error"]
+
+
+def test_main_returns_data_error_exit_code(tmp_path: Path, capsys) -> None:
+    exit_code = main(
+        [
+            "--raw-dir",
+            str(tmp_path / "missing"),
+            "--repo-id",
+            "namespace/missing",
+            "--root",
+            str(tmp_path / "output"),
+        ]
+    )
+
+    assert exit_code == 2
+    assert "porting error:" in capsys.readouterr().err
+
+
+def test_contribution_contains_no_private_or_production_identifiers() -> None:
+    root = Path(__file__).resolve().parents[1]
+    contribution_files = (
+        root / "examples" / "port_datasets" / "port_tum_bimanual.py",
+        root / "examples" / "port_datasets" / "README_tum_bimanual.md",
+        Path(__file__).resolve(),
+    )
+    assert all(path.is_file() for path in contribution_files)
+
+    forbidden_literals = (
+        "/Us" + "ers/",
+        "xwe" + "chat_files",
+        "session_" + "115",
+    )
+    forbidden_brand = "lu" + "ming"
+    for path in contribution_files:
+        text = path.read_text(encoding="utf-8").lower()
+        assert forbidden_brand not in text
+        for literal in forbidden_literals:
+            assert literal.lower() not in text
+        assert re.search(r"(?<!\d)\d{12,}(?!\d)", text) is None


### PR DESCRIPTION
## Title

feat(datasets): add bimanual TUM dataset porting example

## Summary / Motivation

Add a generic example for converting timestamped bimanual TUM-style captures
to LeRobot Dataset v3. The example covers a source layout with two RGB videos,
two hand trajectories, two gripper streams, two IMU streams, and a
left-to-right relative pose stream.

This fills a gap between the existing large-dataset porting examples and
smaller local multimodal capture folders. It uses only public LeRobot Dataset
v3 APIs and does not modify core dataset behavior.

The conversion uses nearest-frame RGB sampling, linear numeric interpolation,
shortest-path quaternion SLERP, and next-state actions. Source gripper units
are preserved.

## Related issues

- Related: none yet

## What changed

- Add `examples/port_datasets/port_tum_bimanual.py`.
- Add a documented generic source contract and CLI examples.
- Add synthetic tests for discovery, parsing, synchronization, video decoding,
  path safety, privacy checks, and a real LeRobot Dataset v3 round trip.
- Validate video/timestamp counts, output episode/frame counts, and boundary
  frame decoding.
- Support optional Hub upload only after local dataset finalization and
  validation.

This introduces no breaking change.

## How was this tested (or how to run locally)

```bash
PYTHONPATH=src python -m pytest -v tests/test_port_tum_bimanual.py
```

Result: `31 passed`.

The three contribution files also passed:

- Ruff formatting and linting;
- Pyupgrade, Typos, Prettier, Bandit, and applicable pre-commit hooks;
- Gitleaks 8.30.1 file scans (`no leaks found` for all three files).

The round-trip test generates deterministic temporary videos and sensor
streams, creates a two-camera LeRobot Dataset v3, finalizes it, reloads it
through the public loader, and decodes its boundary frames.

No private recording or derived source data is included.

## Checklist (required before merge)

- [x] Linting/formatting run on the contribution files
- [ ] Full repository test suite passes locally
- [x] Documentation updated
- [ ] CI is green
- [x] Community Review: I reviewed
      [#4032](https://github.com/huggingface/lerobot/pull/4032#pullrequestreview-4808925269)

## Reviewer notes

Please focus on:

- whether `examples/port_datasets/` is the preferred location;
- the documented relative-pose clock rebasing rule;
- the next-state action convention;
- whether maintainers prefer the example to remain standalone or be split into
  smaller helper modules.
