### PR TITLE
fix(act): support forward(reduction="none") for sample weighting

### DIFF
--- a/src/lerobot/policies/act/modeling_act.py
+++ b/src/lerobot/policies/act/modeling_act.py
@@ -134,8 +134,16 @@ class ACTPolicy(PreTrainedPolicy):
         actions = self.model(batch)[0]
         return actions
 
-    def forward(self, batch: dict[str, Tensor]) -> tuple[Tensor, dict]:
-        """Run the batch through the model and compute the loss for training or validation."""
+    def forward(self, batch: dict[str, Tensor], reduction: str = "mean") -> tuple[Tensor, dict]:
+        """Run the batch through the model and compute the loss for training or validation.
+
+        Args:
+            batch: Training batch containing observations and actions.
+            reduction: How to reduce the loss. Options:
+                - "mean": Return scalar mean loss (default, backward compatible)
+                - "none": Return per-sample losses of shape (batch_size,) for sample
+                  weighting (e.g. RA-BC — see `lerobot.utils.sample_weighting`)
+        """
         if self.config.image_features:
             batch = dict(batch)  # shallow copy so that adding a key doesn't modify the original
             batch[OBS_IMAGES] = [batch[key] for key in self.config.image_features]
@@ -144,6 +152,25 @@ class ACTPolicy(PreTrainedPolicy):
 
         abs_err = F.l1_loss(batch[ACTION], actions_hat, reduction="none")
         valid_mask = ~batch["action_is_pad"].unsqueeze(-1)
+
+        if reduction == "none":
+            # Per-sample mean over valid (time, action) entries — the same
+            # normalization as the scalar path, applied per batch element.
+            num_valid = (valid_mask.sum(dim=(1, 2)) * abs_err.shape[-1]).clamp_min(1)
+            l1_loss = (abs_err * valid_mask).sum(dim=(1, 2)) / num_valid
+
+            loss_dict = {"l1_loss": l1_loss.mean().item()}
+            if self.config.use_vae and log_sigma_x2_hat is not None:
+                # Per-element KL: sum over the latent dimension only (the scalar
+                # path additionally means over the batch).
+                kld = (-0.5 * (1 + log_sigma_x2_hat - mu_hat.pow(2) - (log_sigma_x2_hat).exp())).sum(-1)
+                loss_dict["kld_loss"] = kld.mean().item()
+                loss = l1_loss + kld * self.config.kl_weight
+            else:
+                loss = l1_loss
+
+            return loss, loss_dict
+
         num_valid = valid_mask.sum() * abs_err.shape[-1]
         l1_loss = (abs_err * valid_mask).sum() / num_valid.clamp_min(1)
 


### PR DESCRIPTION
### What
`ACTPolicy.forward` gains the `reduction: str = "mean"` argument the training loop already requires: `update_policy` calls `policy.forward(batch, reduction="none")` whenever a `SampleWeighter` is configured, so any `sample_weighting` config with ACT currently crashes with `TypeError: forward() got an unexpected keyword argument 'reduction'` — while `_make_rabc_weighter`'s own error message names ACT as an intended target ("…like ACT, Diffusion, PI0…").

### How
Mirrors the SmolVLA implementation from #2639: `reduction="none"` returns per-sample losses of shape `(B,)` — the masked per-sample mean over valid (time, action) entries, using the same `action_is_pad` normalization as the scalar path. VAE runs keep the KL per batch element (summed over the latent dimension, scaled by `kl_weight`). The default (`"mean"`) path is unchanged line-for-line; no training-loop changes.

### Reproduction
On current `main`, with a real (tiny) ACTPolicy — the exact call `update_policy` makes when `sample_weighting` is configured:

```python
import torch
from lerobot.configs.types import FeatureType, PolicyFeature
from lerobot.policies.act.configuration_act import ACTConfig
from lerobot.policies.act.modeling_act import ACTPolicy
from lerobot.utils.constants import ACTION, OBS_ENV_STATE, OBS_STATE

config = ACTConfig(
    input_features={
        OBS_STATE: PolicyFeature(type=FeatureType.STATE, shape=(4,)),
        OBS_ENV_STATE: PolicyFeature(type=FeatureType.ENV, shape=(4,)),
    },
    output_features={ACTION: PolicyFeature(type=FeatureType.ACTION, shape=(3,))},
    chunk_size=8, n_action_steps=8, dim_model=32, n_heads=2,
    dim_feedforward=64, n_encoder_layers=1, n_decoder_layers=1,
    n_vae_encoder_layers=1, use_vae=False,
)
policy = ACTPolicy(config)
batch = {
    OBS_STATE: torch.randn(2, 4),
    OBS_ENV_STATE: torch.randn(2, 4),
    ACTION: torch.randn(2, 8, 3),
    "action_is_pad": torch.zeros(2, 8, dtype=torch.bool),
}
policy.forward(batch)                    # OK (scalar)
policy.forward(batch, reduction="none")  # TypeError: ACTPolicy.forward() got
                                         # an unexpected keyword argument 'reduction'
```

With this PR the same call returns per-sample losses of shape `(2,)`.

### Tests
`tests/policies/test_act_reduction_none.py` (math-only stubbed policy, no weights loaded — same idiom as the molmoact2 reduction tests): per-sample shape and hand-computed masked means per element; a fully padded sample yields 0, not NaN; `per_sample.mean() == scalar` when unpadded, with and without VAE; the no-argument call keeps the exact scalar contract.

Part of the IL (sample weighting) axis of #3143; a companion PR adds a generic precomputed-weights `SampleWeighter` type.
