### PR TITLE
feat(train): add a "static" sample weighter — precomputed per-frame weights from a file

### DIFF
--- a/src/lerobot/utils/sample_weighting.py
+++ b/src/lerobot/utils/sample_weighting.py
@@ -35,6 +35,7 @@ Example usage:
 
 from __future__ import annotations
 
+import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -83,8 +84,11 @@ class SampleWeightingConfig:
     contains additional type-specific parameters.
 
     Attributes:
-        type: Weighting strategy type ("rabc", "uniform", etc.)
+        type: Weighting strategy type ("rabc", "static", "uniform", etc.)
         progress_path: Path to precomputed progress values (for RABC)
+        weights_path: Path to precomputed per-frame weights (for the static
+            weighter): a parquet with an "index" column (global frame index,
+            matching the batch's "index" key) and a "weight" column.
         head_mode: Which model head to use for progress ("sparse" or "dense")
         kappa: Hard threshold for high-quality samples (RABC-specific)
         epsilon: Small constant for numerical stability
@@ -93,6 +97,7 @@ class SampleWeightingConfig:
 
     type: str = "rabc"
     progress_path: str | None = None
+    weights_path: str | None = None
     head_mode: str = "sparse"
     kappa: float = 0.01
     epsilon: float = 1e-6
@@ -125,11 +130,26 @@ def make_sample_weighter(
     if config.type == "rabc":
         return _make_rabc_weighter(config, policy, device, dataset_root, dataset_repo_id)
 
+    if config.type == "static":
+        if not config.weights_path:
+            raise ValueError(
+                "Static sample weighting requires 'weights_path' to be set: a "
+                "parquet with 'index' (global frame index) and 'weight' columns."
+            )
+        return StaticWeights(
+            weights_path=config.weights_path,
+            device=device,
+            epsilon=config.epsilon,
+            **config.extra_params,
+        )
+
     if config.type == "uniform":
         # No-op weighter that returns uniform weights
         return UniformWeighter(device=device)
 
-    raise ValueError(f"Unknown sample weighting type: '{config.type}'. Supported types: 'rabc', 'uniform'")
+    raise ValueError(
+        f"Unknown sample weighting type: '{config.type}'. Supported types: 'rabc', 'static', 'uniform'"
+    )
 
 
 def _make_rabc_weighter(
@@ -237,3 +257,114 @@ class UniformWeighter(SampleWeighter):
     def get_stats(self) -> dict:
         """Return empty stats for uniform weighting."""
         return {"type": "uniform"}
+
+
+class StaticWeights(SampleWeighter):
+    """
+    Sample weighter that reads precomputed per-frame weights from a file.
+
+    The generic half of the abstraction's stated motivation (importance
+    sampling, curriculum learning, quality-based filtering): any pipeline that
+    can score frames offline — data-quality classifiers, DAgger human/policy
+    provenance, curriculum schedules — writes one parquet and trains with it,
+    no new weighter class needed.
+
+    The file is a parquet with two required columns:
+        - "index": global frame index (the same value the training batch
+          carries under its "index" key)
+        - "weight": non-negative float weight for that frame
+
+    Frames absent from the file receive ``fallback_weight`` (default 1.0), so
+    a partial file up- or down-weights only the frames it names. Batch weights
+    are normalized to sum to the batch size, matching the training loop's
+    expectation (weighted loss keeps gradient scale when some weights are 0).
+    """
+
+    def __init__(
+        self,
+        weights_path: str,
+        device: torch.device,
+        epsilon: float = 1e-6,
+        fallback_weight: float = 1.0,
+    ):
+        import pandas as pd
+
+        self.device = device
+        self.epsilon = epsilon
+        self.fallback_weight = float(fallback_weight)
+
+        logging.info(f"Loading static sample weights from {weights_path}")
+        df = pd.read_parquet(weights_path)
+        for column in ("index", "weight"):
+            if column not in df.columns:
+                raise ValueError(
+                    f"Column '{column}' not found in {weights_path}. Available columns: {list(df.columns)}"
+                )
+
+        self.weight_lookup: dict[int, float] = {}
+        for _, row in df.iterrows():
+            weight = float(row["weight"])
+            if weight < 0:
+                raise ValueError(
+                    f"Negative weight {weight} for frame index {int(row['index'])} "
+                    f"in {weights_path}; weights must be >= 0."
+                )
+            self.weight_lookup[int(row["index"])] = weight
+
+        logging.info(f"Loaded {len(self.weight_lookup)} static frame weights")
+
+    def compute_batch_weights(self, batch: dict) -> tuple[torch.Tensor, dict]:
+        """Look up each sample's weight by its global frame index."""
+        indices = batch.get("index")
+        if indices is None:
+            logging.warning("StaticWeights: batch missing 'index' key, using uniform weights")
+            batch_size = self._determine_batch_size(batch)
+            stats = {"mean_weight": 1.0, "num_zero_weight": 0, "num_missing": batch_size}
+            return torch.ones(batch_size, device=self.device), stats
+
+        if isinstance(indices, torch.Tensor):
+            indices = indices.cpu().tolist()
+
+        weights = []
+        num_missing = 0
+        for idx in indices:
+            weight = self.weight_lookup.get(int(idx))
+            if weight is None:
+                num_missing += 1
+                weight = self.fallback_weight
+            weights.append(weight)
+
+        weights_tensor = torch.tensor(weights, device=self.device, dtype=torch.float32)
+        stats = {
+            "mean_weight": float(weights_tensor.mean()),
+            "num_zero_weight": int((weights_tensor == 0).sum()),
+            "num_missing": num_missing,
+        }
+
+        # Normalize to sum to batch_size (see the training loop's weighted
+        # loss: zero-weight samples shift their share to the rest).
+        batch_size = len(weights)
+        weights_tensor = weights_tensor * batch_size / (weights_tensor.sum() + self.epsilon)
+        return weights_tensor, stats
+
+    def _determine_batch_size(self, batch: dict) -> int:
+        for key in ["action", "index", "observation.state"]:
+            if key in batch and isinstance(batch[key], torch.Tensor):
+                return batch[key].shape[0]
+        for value in batch.values():
+            if isinstance(value, torch.Tensor) and value.ndim >= 1:
+                return value.shape[0]
+        return 1
+
+    def get_stats(self) -> dict:
+        """Global statistics about the loaded weight table."""
+        if not self.weight_lookup:
+            return {"type": "static", "num_frames": 0}
+        values = list(self.weight_lookup.values())
+        return {
+            "type": "static",
+            "num_frames": len(values),
+            "mean_weight": float(sum(values) / len(values)),
+            "num_zero_weight": sum(1 for v in values if v == 0),
+            "fallback_weight": self.fallback_weight,
+        }

--- a/tests/utils/test_sample_weighting.py
+++ b/tests/utils/test_sample_weighting.py
@@ -399,3 +399,121 @@ def test_rabc_weights_normalization(sample_progress_parquet):
     # Weights should be normalized to sum approximately to batch_size
     batch_size = 4
     assert abs(weights.sum().item() - batch_size) < 0.1
+
+
+# =============================================================================
+# StaticWeights Tests
+# =============================================================================
+
+
+@pytest.fixture
+def sample_weights_parquet(tmp_path):
+    """Create a sample static-weights parquet file for testing."""
+    import pandas as pd
+
+    # Frames 0..9: even frames weighted 1.0, odd frames 0.0, frame 4 boosted.
+    data = {
+        "index": list(range(10)),
+        "weight": [1.0, 0.0, 1.0, 0.0, 3.0, 0.0, 1.0, 0.0, 1.0, 0.0],
+    }
+    parquet_path = tmp_path / "sample_weights.parquet"
+    pd.DataFrame(data).to_parquet(parquet_path)
+    return parquet_path
+
+
+def test_static_weights_is_sample_weighter(sample_weights_parquet):
+    from lerobot.utils.sample_weighting import StaticWeights
+
+    weighter = StaticWeights(weights_path=str(sample_weights_parquet), device=torch.device("cpu"))
+    assert isinstance(weighter, SampleWeighter)
+
+
+def test_factory_creates_static_weighter(sample_weights_parquet):
+    from lerobot.utils.sample_weighting import StaticWeights
+
+    config = SampleWeightingConfig(type="static", weights_path=str(sample_weights_parquet))
+    weighter = make_sample_weighter(config, Mock(), torch.device("cpu"))
+    assert isinstance(weighter, StaticWeights)
+
+
+def test_factory_static_requires_weights_path():
+    config = SampleWeightingConfig(type="static")
+    with pytest.raises(ValueError, match="weights_path"):
+        make_sample_weighter(config, Mock(), torch.device("cpu"))
+
+
+def test_static_weights_requires_columns(tmp_path):
+    import pandas as pd
+
+    from lerobot.utils.sample_weighting import StaticWeights
+
+    path = tmp_path / "bad.parquet"
+    pd.DataFrame({"index": [0], "value": [1.0]}).to_parquet(path)
+    with pytest.raises(ValueError, match="Column 'weight' not found"):
+        StaticWeights(weights_path=str(path), device=torch.device("cpu"))
+
+
+def test_static_weights_rejects_negative_weights(tmp_path):
+    import pandas as pd
+
+    from lerobot.utils.sample_weighting import StaticWeights
+
+    path = tmp_path / "neg.parquet"
+    pd.DataFrame({"index": [0], "weight": [-0.5]}).to_parquet(path)
+    with pytest.raises(ValueError, match="Negative weight"):
+        StaticWeights(weights_path=str(path), device=torch.device("cpu"))
+
+
+def test_static_weights_lookup_normalization_and_stats(sample_weights_parquet):
+    from lerobot.utils.sample_weighting import StaticWeights
+
+    weighter = StaticWeights(weights_path=str(sample_weights_parquet), device=torch.device("cpu"))
+    # Frames 2 (w=1), 3 (w=0), 4 (w=3): zero-weight samples shift their share
+    # to the rest; weights normalize to sum to batch_size.
+    batch = {"index": torch.tensor([2, 3, 4])}
+    weights, stats = weighter.compute_batch_weights(batch)
+
+    assert weights.shape == (3,)
+    torch.testing.assert_close(weights.sum(), torch.tensor(3.0), atol=1e-4, rtol=0)
+    assert weights[1] == 0.0
+    # Frame 4 carries 3x frame 2's weight, before and after normalization.
+    torch.testing.assert_close(weights[2] / weights[0], torch.tensor(3.0))
+    assert stats["num_zero_weight"] == 1
+    assert stats["num_missing"] == 0
+
+
+def test_static_weights_missing_indices_use_fallback(sample_weights_parquet):
+    from lerobot.utils.sample_weighting import StaticWeights
+
+    weighter = StaticWeights(
+        weights_path=str(sample_weights_parquet),
+        device=torch.device("cpu"),
+        fallback_weight=1.0,
+    )
+    # Frame 999 is absent from the file → fallback weight, counted in stats.
+    batch = {"index": torch.tensor([0, 999])}
+    weights, stats = weighter.compute_batch_weights(batch)
+    assert stats["num_missing"] == 1
+    # Both effective raw weights are 1.0 → equal after normalization.
+    torch.testing.assert_close(weights[0], weights[1])
+
+
+def test_static_weights_batch_without_index_degrades_to_uniform(sample_weights_parquet):
+    from lerobot.utils.sample_weighting import StaticWeights
+
+    weighter = StaticWeights(weights_path=str(sample_weights_parquet), device=torch.device("cpu"))
+    batch = {"action": torch.zeros(4, 2)}
+    weights, stats = weighter.compute_batch_weights(batch)
+    assert weights.shape == (4,)
+    assert torch.all(weights == 1.0)
+    assert stats["num_missing"] == 4
+
+
+def test_static_weights_get_stats(sample_weights_parquet):
+    from lerobot.utils.sample_weighting import StaticWeights
+
+    weighter = StaticWeights(weights_path=str(sample_weights_parquet), device=torch.device("cpu"))
+    stats = weighter.get_stats()
+    assert stats["type"] == "static"
+    assert stats["num_frames"] == 10
+    assert stats["num_zero_weight"] == 5


### PR DESCRIPTION
### What
A third `sample_weighting` type, `static`: precomputed per-frame weights read from a parquet with `index` (global frame index, matching the batch's `index` key) and `weight` (≥ 0) columns.

```yaml
sample_weighting:
  type: static
  weights_path: hf://datasets/<repo>/sample_weights.parquet
```

This completes the generic half of the abstraction's stated motivation (#2781: "importance sampling, curriculum learning, quality-based filtering") and the "IL (sample weighting)" axis of #3143: any pipeline that can score frames offline writes one file and trains with it — no new weighter class per scoring scheme. Our own driver is HIL-DAgger: per-frame human/policy provenance stamped at recording time, corrections weighted above policy self-play.

Companion to #4221 (`ACTPolicy.forward(reduction="none")`), which makes the weighted path usable with ACT.

### Design
* Keyed on the batch's `index` exactly like `RABCWeights`; frames absent from the file take a configurable `fallback_weight` (default 1.0), so a partial file up-/down-weights only the frames it names.
* Batch weights are normalized to sum to `batch_size`, matching the weighted-loss expectation documented in `update_policy` (zero-weight samples shift their share to the rest, preserving gradient scale).
* Negative weights and missing columns fail at load with actionable errors. Zero training-loop changes; `utils/sample_weighting.py` only (nothing RA-BC-flavored added under `utils/`).
* Also adds the `import logging` the module was missing.
* Naming: happy to rename to `precomputed`/`file` if preferred.

### Tests
Extends `tests/utils/test_sample_weighting.py` (8 new): factory dispatch + required-config validation, column/negative-weight validation, lookup + zero-weight renormalization ratios, fallback + missing-index stats, index-less batch degradation, `get_stats`. Full file: 31 passed, ruff check/format clean.
