### PR TITLE
fix(rtc): prevent violent robot jumps from delay mis-estimation in chunk merging

### DIFF
--- a/src/lerobot/policies/rtc/action_queue.py
+++ b/src/lerobot/policies/rtc/action_queue.py
@@ -219,20 +219,28 @@ class ActionQueue:
     def _check_and_resolve_delays(
         self, real_delay: int, action_index_before_inference: int | None = None
     ) -> int:
-        """Validate that computed delays match expectations.
+        """Resolve how many leading actions of the new chunk to discard.
 
-        Compares the delay computed from inference latency with the actual
-        number of actions consumed during inference.
+        The purpose of the discard is to stay aligned with the actions the robot
+        actually executed while inference was running, so the number of actions
+        consumed since inference started is authoritative. The latency-based
+        estimate (``real_delay``) is only a proxy and is used when consumption
+        cannot be measured (``action_index_before_inference`` is None).
+
+        The two can diverge legitimately — most notably on the first chunk of an
+        episode: the robot sits idle on an empty queue (zero actions consumed)
+        while the latency estimate is large. Trusting the estimate there skips
+        deep into the fresh chunk and commands a far-future action from
+        standstill, causing a violent jump. Skipping only what was actually
+        consumed keeps the commanded position continuous in every case.
 
         Args:
             real_delay: Delay computed from inference latency.
             action_index_before_inference: Action index when inference started.
 
         Returns:
-            int: Delay to use.
+            int: Number of actions to discard from the start of the new chunk.
         """
-        effective_delay = max(0, real_delay)
-
         if action_index_before_inference is not None:
             indexes_diff = max(0, self.last_index - action_index_before_inference)
             if indexes_diff != real_delay:
@@ -241,6 +249,6 @@ class ActionQueue:
                     indexes_diff,
                     real_delay,
                 )
-                return real_delay
+            return indexes_diff
 
-        return effective_delay
+        return max(0, real_delay)

--- a/src/lerobot/policies/rtc/latency_tracker.py
+++ b/src/lerobot/policies/rtc/latency_tracker.py
@@ -36,7 +36,6 @@ class LatencyTracker:
     def reset(self) -> None:
         """Clear all recorded latencies."""
         self._values.clear()
-        self.max_latency = 0.0
 
     def add(self, latency: float) -> None:
         """Add a latency sample (seconds)."""
@@ -46,14 +45,19 @@ class LatencyTracker:
         if val < 0:
             return
         self._values.append(val)
-        self.max_latency = max(self.max_latency, val)
 
     def __len__(self) -> int:
         return len(self._values)
 
-    def max(self) -> float | None:
-        """Return the maximum latency or None if empty."""
-        return self.max_latency
+    def max(self) -> float:
+        """Return the maximum latency within the sliding window, or 0.0 if empty.
+
+        Computed over the retained window so that a stale spike (e.g. a one-time
+        warm-up inference) stops inflating the delay estimate once it is evicted.
+        """
+        if not self._values:
+            return 0.0
+        return max(self._values)
 
     def percentile(self, q: float) -> float | None:
         """Return the q-quantile (q in [0,1]) of recorded latencies or None if empty."""
@@ -63,7 +67,7 @@ class LatencyTracker:
         if q <= 0.0:
             return min(self._values)
         if q >= 1.0:
-            return self.max_latency
+            return self.max()
         vals = np.array(list(self._values), dtype=np.float32)
         return float(np.quantile(vals, q))
 

--- a/src/lerobot/rollout/inference/rtc.py
+++ b/src/lerobot/rollout/inference/rtc.py
@@ -251,7 +251,10 @@ class RTCInferenceEngine(InferenceEngine):
             time_per_chunk = 1.0 / self._fps
             policy_device = torch.device(self._device)
 
-            warmup_required = max(1, self._compile_warmup_inferences) if self._use_torch_compile else 0
+            # The first inference carries one-time lazy-initialization cost (CUDA graph
+            # capture, allocator warm-up, ...) regardless of torch.compile, so its latency
+            # is never representative — keep it out of the delay estimate in both modes.
+            warmup_required = max(1, self._compile_warmup_inferences) if self._use_torch_compile else 1
             inference_count = 0
             consecutive_errors = 0
 
@@ -315,7 +318,7 @@ class RTCInferenceEngine(InferenceEngine):
 
                         inference_count += 1
                         consecutive_errors = 0
-                        is_warmup = self._use_torch_compile and inference_count <= warmup_required
+                        is_warmup = inference_count <= warmup_required
                         if is_warmup:
                             latency_tracker.reset()
                         else:

--- a/tests/policies/rtc/test_action_queue.py
+++ b/tests/policies/rtc/test_action_queue.py
@@ -486,6 +486,47 @@ def test_merge_no_warning_when_delays_match(action_queue_rtc_enabled, sample_act
     assert "Indexes diff is not equal to real delay" not in caplog.text
 
 
+def test_merge_uses_actual_consumption_on_mismatch(action_queue_rtc_enabled, sample_actions):
+    """Test merge() discards by actual consumption, not the latency estimate, on mismatch."""
+    action_queue_rtc_enabled.merge(sample_actions["short"], sample_actions["short"], real_delay=0)
+
+    # Robot consumed 5 actions while inference was running
+    for _ in range(5):
+        action_queue_rtc_enabled.get()
+
+    action_queue_rtc_enabled.merge(
+        sample_actions["original"],
+        sample_actions["processed"],
+        real_delay=8,  # over-estimate: trusting it would skip 3 not-yet-executed actions
+        action_index_before_inference=0,
+    )
+
+    # First served action must be the one right after the 5 actually-consumed steps
+    assert action_queue_rtc_enabled.qsize() == len(sample_actions["original"]) - 5
+    first_action = action_queue_rtc_enabled.get()
+    assert torch.equal(first_action, sample_actions["processed"][5])
+
+
+def test_merge_first_chunk_on_idle_robot_starts_at_beginning(action_queue_rtc_enabled, sample_actions):
+    """Test the first chunk of an episode is not truncated by warm-up latency.
+
+    Regression test: with an empty queue the robot is standing still (zero
+    actions consumed), but the first inference latency can be large (warm-up).
+    Trusting the latency estimate skips deep into the chunk and commands a
+    far-future action from standstill — a violent position jump on real robots.
+    """
+    action_queue_rtc_enabled.merge(
+        sample_actions["original"],
+        sample_actions["processed"],
+        real_delay=21,  # large warm-up latency estimate
+        action_index_before_inference=0,  # but nothing was consumed
+    )
+
+    assert action_queue_rtc_enabled.qsize() == len(sample_actions["original"])
+    first_action = action_queue_rtc_enabled.get()
+    assert torch.equal(first_action, sample_actions["processed"][0])
+
+
 def test_merge_skips_validation_when_action_index_none(action_queue_rtc_enabled, sample_actions, caplog):
     """Test merge() skips delay validation when action_index_before_inference is None."""
     import logging
@@ -790,8 +831,10 @@ def test_typical_rtc_workflow(action_queue_rtc_enabled, sample_actions):
 
     assert action_queue_rtc_enabled.qsize() == 40
 
-    # Second inference with delay
+    # Second inference starts; robot keeps executing 5 actions while it runs
     action_index_before = action_queue_rtc_enabled.get_action_index()
+    for _ in range(5):
+        action_queue_rtc_enabled.get()
 
     action_queue_rtc_enabled.merge(
         sample_actions["original"],
@@ -800,7 +843,7 @@ def test_typical_rtc_workflow(action_queue_rtc_enabled, sample_actions):
         action_index_before_inference=action_index_before,
     )
 
-    # Queue should be replaced, minus delay
+    # Queue should be replaced, minus the actions consumed during inference
     assert action_queue_rtc_enabled.qsize() == 45
     assert action_queue_rtc_enabled.get_action_index() == 0
 

--- a/tests/policies/rtc/test_latency_tracker.py
+++ b/tests/policies/rtc/test_latency_tracker.py
@@ -42,7 +42,6 @@ def test_latency_tracker_initialization():
     """Test LatencyTracker initializes correctly."""
     tracker = LatencyTracker(maxlen=50)
     assert len(tracker) == 0
-    assert tracker.max_latency == 0.0
     assert tracker.max() == 0.0
 
 
@@ -100,16 +99,16 @@ def test_add_converts_to_float(tracker):
     assert tracker.max() == 5.0
 
 
-def test_add_updates_max_latency(tracker):
-    """Test that max_latency is updated correctly."""
+def test_add_updates_max(tracker):
+    """Test that max() is updated correctly as samples are added."""
     tracker.add(0.5)
-    assert tracker.max_latency == 0.5
+    assert tracker.max() == 0.5
 
     tracker.add(0.3)
-    assert tracker.max_latency == 0.5  # Should not decrease
+    assert tracker.max() == 0.5  # Should not decrease while 0.5 is in window
 
     tracker.add(0.9)
-    assert tracker.max_latency == 0.9  # Should increase
+    assert tracker.max() == 0.9  # Should increase
 
 
 # ====================== reset() Tests ======================
@@ -124,16 +123,16 @@ def test_reset_clears_values(tracker):
 
     tracker.reset()
     assert len(tracker) == 0
-    assert tracker.max_latency == 0.0
+    assert tracker.max() == 0.0
 
 
-def test_reset_clears_max_latency(tracker):
-    """Test reset() resets max_latency."""
+def test_reset_clears_max(tracker):
+    """Test reset() resets max()."""
     tracker.add(1.5)
-    assert tracker.max_latency == 1.5
+    assert tracker.max() == 1.5
 
     tracker.reset()
-    assert tracker.max_latency == 0.0
+    assert tracker.max() == 0.0
 
 
 def test_reset_allows_new_values(tracker):
@@ -163,18 +162,19 @@ def test_max_returns_maximum_value(tracker):
     assert tracker.max() == 0.8
 
 
-def test_max_persists_after_sliding_window(small_tracker):
-    """Test max() persists even after values slide out of window."""
-    # Add values that will exceed maxlen=5
-    small_tracker.add(0.1)
-    small_tracker.add(0.9)  # This is max
-    small_tracker.add(0.2)
-    small_tracker.add(0.3)
-    small_tracker.add(0.4)
-    small_tracker.add(0.5)  # This pushes out 0.1
+def test_max_respects_sliding_window(small_tracker):
+    """Test max() drops a stale spike once it slides out of the window.
 
-    # Max should still be 0.9 even though only last 5 values kept
-    assert small_tracker.max() == 0.9
+    Regression test: a one-time warm-up inference spike must stop inflating
+    the RTC delay estimate after it is evicted from the recent-latency window.
+    """
+    small_tracker.add(0.9)  # warm-up spike (maxlen=5)
+    for val in (0.1, 0.2, 0.3, 0.4):
+        small_tracker.add(val)
+    assert small_tracker.max() == 0.9  # spike still inside the window
+
+    small_tracker.add(0.5)  # pushes the 0.9 spike out
+    assert small_tracker.max() == 0.5
 
 
 def test_max_after_reset(tracker):


### PR DESCRIPTION
## Summary / Motivation

Running RTC inference on a real SO-101 arm (MolmoAct2 checkpoint, 30 fps, ~0.3 s steady inference, ~0.7 s first-inference warm-up) produced violent arm jumps severe enough to abort the rollouts. Root-causing this surfaced two independent defects in how RTC handles inference delay, both of which make the executed trajectory discontinuous whenever the latency-based delay estimate diverges from what the robot actually executed:

1. **`ActionQueue.merge()` trusts the latency estimate over measured consumption.** The queue discards the first `real_delay` actions of a fresh chunk to stay aligned with what the robot executed during inference. On the first chunk of an episode the queue is empty — the robot is standing still (zero actions consumed) — but the first inference carries warm-up latency (21 ticks in our setup). Trusting the estimate skips 21 of 30 actions and commands a position 0.7 s deep into the trajectory from standstill. In steady state the same logic also skipped one extra not-yet-executed action per chunk (estimate/consumption off-by-one).
2. **The warm-up latency permanently inflates the delay estimate.** `LatencyTracker.max()` returned a running max that ignores its own sliding window, so the one-time warm-up spike was never evicted; additionally the rollout RTC engine only excluded warm-up inferences from the tracker when `torch.compile` was enabled, although the one-time lazy-initialization cost (CUDA graph capture, allocator warm-up) exists in eager mode too. With a stale delay larger than `execution_horizon`, `get_prefix_weights(start=min(delay, horizon), end=horizon)` degenerates to all-ones followed by a hard cut — the guidance taper disappears and every chunk hands off abruptly.

Trade-off note: skipping by measured consumption fails safe. If the two signals disagree, skipping too many actions causes a position jump (hardware hazard), while skipping too few merely replays ≤1 tick of the guided prefix and re-aligns on the next merge.

## Related issues

- Related: #2541 (reported cold-start latency inflating the RTC delay estimate)

## What changed

- `ActionQueue._check_and_resolve_delays()` now returns the measured consumption (`indexes_diff`) whenever `action_index_before_inference` is available, falling back to the latency estimate only when consumption cannot be measured. The mismatch warning is kept for observability.
- `LatencyTracker.max()` computes the max over the retained sliding window instead of keeping a running max (the `max_latency` attribute is removed); `percentile(q>=1)` now delegates to `max()`.
- The rollout RTC engine treats the first inference as warm-up unconditionally (previously only under `torch.compile`), keeping its unrepresentative latency out of the delay estimate. No behavior change for the compile path.
- No breaking changes to public APIs (`LatencyTracker.max_latency` was an undocumented attribute).

## How was this tested (or how to run locally)

- Tests added:
  - `test_merge_first_chunk_on_idle_robot_starts_at_beginning` — regression for the episode-start jump (empty queue + large warm-up delay must not truncate the first chunk).
  - `test_merge_uses_actual_consumption_on_mismatch` — merge discards by measured consumption when the estimate over-shoots.
  - `test_max_respects_sliding_window` — a stale latency spike stops inflating `max()` once evicted.
  - Updated existing tests that encoded the previous behavior (`test_typical_rtc_workflow` now consumes actions during the simulated inference; `LatencyTracker` tests use `max()` instead of the removed attribute).
- `pytest -q tests/policies/rtc tests/test_rollout.py` — 233 passed.
- `pre-commit run --files <changed files>` — all hooks pass.
- Real-robot check (SO-101, MolmoAct2, 30 fps): before the queue fix, episodes started with a violent lunge and logged `Indexes diff is not equal to real delay. indexes_diff=0, real_delay=21`; after the fix, episodes start smoothly and merges log the measured consumption.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [ ] Documentation updated (docstrings updated; no user-facing docs affected)
- [ ] CI is green
- [x] Community Review: I have reviewed another contributor's open PR and linked it here: #4179 (verified the compile-path usage claims across smolvla/pi0/pi05 and left a review)

## Reviewer notes

- The behavioral crux is `_check_and_resolve_delays()`: when measured consumption and the latency estimate disagree, which one should the merge trust? This PR argues for measured consumption because the discard exists precisely to mirror what the robot executed, and because the failure modes are asymmetric (see trade-off note above).
- `get_prefix_weights()` is untouched; with the delay estimate no longer stale, `start=min(delay, horizon)` behaves as designed.
- Worth a close look: interaction with `queue.clear()` mid-inference (consumption resets to 0 → merge skips nothing → the fresh chunk plays from its start, which is the safe outcome).
