### PR TITLE
fix(eval): make LIBERO initial-state allocation deterministic

### DIFF
--- a/src/lerobot/envs/libero.py
+++ b/src/lerobot/envs/libero.py
@@ -329,14 +329,30 @@ class LiberoEnv(gym.Env):
             "Please switch to an image-based obs_type (e.g. 'pixels', 'pixels_agent_pos')."
         )
 
-    def reset(self, seed=None, **kwargs):
+    def reset(self, seed=None, options: Mapping[str, Any] | None = None):
         self._ensure_env()
-        super().reset(seed=seed)
+        assert self._env is not None
+        super().reset(seed=seed, options=options)
         self._env.seed(seed)
         raw_obs = self._env.reset()
         if self.init_states and self._init_states is not None:
-            raw_obs = self._env.set_init_state(self._init_states[self.init_state_id % len(self._init_states)])
-            self.init_state_id += self._reset_stride  # Change init_state_id when reset
+            initial_state_index = self.init_state_id
+
+            if options is not None and "initial_state_indices" in options:
+                initial_state_indices = options["initial_state_indices"]
+
+                if self.episode_index >= len(initial_state_indices):
+                    raise ValueError(
+                        "Missing initial state index for LIBERO vector slot "
+                        f"{self.episode_index}. Received {len(initial_state_indices)} indices."
+                    )
+
+                initial_state_index = int(initial_state_indices[self.episode_index])
+
+            raw_obs = self._env.set_init_state(
+                self._init_states[initial_state_index % len(self._init_states)]
+            )
+            self.init_state_id = initial_state_index + self._reset_stride
 
         # After reset, objects may be unstable (slightly floating, intersecting, etc.).
         # Step the simulator with a no-op action for a few frames so everything settles.

--- a/src/lerobot/scripts/lerobot_eval.py
+++ b/src/lerobot/scripts/lerobot_eval.py
@@ -171,6 +171,7 @@ def rollout(
     preprocessor: PolicyProcessorPipeline[dict[str, Any], dict[str, Any]],
     postprocessor: PolicyProcessorPipeline[PolicyAction, PolicyAction],
     seeds: list[int] | None = None,
+    initial_state_indices: list[int] | None = None,
     return_observations: bool = False,
     render_callback: Callable[[gym.vector.VectorEnv], None] | None = None,
     recording_dir: Path | None = None,
@@ -203,6 +204,8 @@ def rollout(
         policy: The policy. Must be a PyTorch nn module.
         seeds: The environments are seeded once at the start of the rollout. If provided, this argument
             specifies the seeds for each of the environments.
+        initial_state_indices: Optional initial-state indices for each vector environment slot. They are
+            forwarded through the environment reset options.
         return_observations: Whether to include all observations in the returned rollout data. Observations
             are returned optionally because they typically take more memory to cache. Defaults to False.
         render_callback: Optional rendering callback to be used after the environments are reset, and after
@@ -217,7 +220,10 @@ def rollout(
 
     # Reset the policy and environments.
     policy.reset()
-    observation, info = env.reset(seed=seeds)
+    reset_options = (
+        {"initial_state_indices": initial_state_indices} if initial_state_indices is not None else None
+    )
+    observation, info = env.reset(seed=seeds, options=reset_options)
     if render_callback is not None:
         render_callback(env)
 
@@ -528,6 +534,9 @@ def eval_policy(
             seeds = range(
                 start_seed + (batch_ix * env.num_envs), start_seed + ((batch_ix + 1) * env.num_envs)
             )
+
+        initial_state_indices = list(range(batch_ix * env.num_envs, (batch_ix + 1) * env.num_envs))
+
         rollout_data = rollout(
             env=env,
             policy=policy,
@@ -536,6 +545,7 @@ def eval_policy(
             preprocessor=preprocessor,
             postprocessor=postprocessor,
             seeds=list(seeds) if seeds else None,
+            initial_state_indices=initial_state_indices,
             return_observations=return_episode_data,
             render_callback=render_frame if max_episodes_rendered > 0 else None,
             recording_dir=recording_dir,

--- a/tests/envs/test_libero.py
+++ b/tests/envs/test_libero.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import gymnasium as gym
+import numpy as np
+import pytest
+
+pytest.importorskip("libero")
+
+from lerobot.envs.libero import LiberoEnv
+
+
+class _FakeController:
+    def __init__(self) -> None:
+        self.use_delta: bool | None = None
+
+
+class _FakeRobot:
+    def __init__(self) -> None:
+        self.controller = _FakeController()
+
+
+class _FakeInnerEnv:
+    def __init__(self) -> None:
+        self.robots = [_FakeRobot()]
+        self.selected_state: int | None = None
+
+    def seed(self, seed: int | None) -> None:
+        pass
+
+    def reset(self) -> dict:
+        return {}
+
+    def set_init_state(self, state: np.integer) -> dict:
+        self.selected_state = int(state)
+        return {"selected_state": self.selected_state}
+
+
+def _make_libero_env(episode_index: int, n_envs: int) -> tuple[LiberoEnv, _FakeInnerEnv]:
+    env = LiberoEnv.__new__(LiberoEnv)
+    gym.Env.__init__(env)
+
+    inner_env = _FakeInnerEnv()
+
+    env._env = inner_env
+    env._ensure_env = lambda: None
+    env._format_raw_obs = lambda raw_obs: raw_obs
+
+    env.init_states = True
+    env._init_states = np.arange(20)
+    env.init_state_id = episode_index
+    env._reset_stride = n_envs
+    env.episode_index = episode_index
+    env.num_steps_wait = 0
+    env.control_mode = "relative"
+
+    return env, inner_env
+
+
+def test_reset_uses_explicit_initial_state_index_for_vector_slot() -> None:
+    env, inner_env = _make_libero_env(episode_index=1, n_envs=2)
+
+    env.reset(options={"initial_state_indices": [4, 5]})
+
+    assert inner_env.selected_state == 5
+
+
+def _collect_evaluated_initial_states(extra_resets_between_batches: int) -> list[int]:
+    env, inner_env = _make_libero_env(episode_index=1, n_envs=2)
+    evaluated_states: list[int] = []
+
+    env.reset(options={"initial_state_indices": [0, 1]})
+    assert inner_env.selected_state is not None
+    evaluated_states.append(inner_env.selected_state)
+
+    # Simulate additional resets caused by earlier policy termination or
+    # vector-environment autoreset behavior.
+    for _ in range(extra_resets_between_batches):
+        env.reset()
+
+    env.reset(options={"initial_state_indices": [2, 3]})
+    assert inner_env.selected_state is not None
+    evaluated_states.append(inner_env.selected_state)
+
+    return evaluated_states
+
+
+def test_explicit_initial_state_sequence_is_independent_of_extra_resets() -> None:
+    sequence_without_extra_resets = _collect_evaluated_initial_states(extra_resets_between_batches=0)
+    sequence_with_extra_resets = _collect_evaluated_initial_states(extra_resets_between_batches=2)
+
+    assert sequence_without_extra_resets == [1, 3]
+    assert sequence_with_extra_resets == sequence_without_extra_resets

--- a/tests/scripts/test_lerobot_eval_reset_options.py
+++ b/tests/scripts/test_lerobot_eval_reset_options.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import torch
+from torch import nn
+
+import lerobot.scripts.lerobot_eval as eval_module
+from lerobot.scripts.lerobot_eval import rollout
+from lerobot.utils.constants import ACTION
+
+
+class _IdentityProcessor:
+    def __call__(self, value: Any) -> Any:
+        return value
+
+
+class _FakePolicy(nn.Module):
+    def reset(self) -> None:
+        pass
+
+    def select_action(self, observation: dict[str, Any]) -> torch.Tensor:
+        return torch.zeros((2, 1), dtype=torch.float32)
+
+
+class _FakeVectorEnv:
+    num_envs = 2
+
+    def __init__(self) -> None:
+        self.reset_options: dict[str, Any] | None = None
+
+    def reset(
+        self,
+        *,
+        seed: list[int] | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> tuple[dict[str, np.ndarray], dict]:
+        self.reset_options = options
+        observation = {"observation.state": np.zeros((self.num_envs, 1), dtype=np.float32)}
+        return observation, {}
+
+    def call(self, name: str):
+        if name == "_max_episode_steps":
+            return [1] * self.num_envs
+        if name in {"task_description", "task"}:
+            return [""] * self.num_envs
+        raise AttributeError(name)
+
+    def step(self, action: np.ndarray):
+        observation = {"observation.state": np.zeros((self.num_envs, 1), dtype=np.float32)}
+        reward = np.zeros(self.num_envs, dtype=np.float32)
+        terminated = np.ones(self.num_envs, dtype=bool)
+        truncated = np.zeros(self.num_envs, dtype=bool)
+        info = {"is_success": np.zeros(self.num_envs, dtype=bool)}
+        return observation, reward, terminated, truncated, info
+
+
+def test_rollout_forwards_initial_state_indices_to_reset(monkeypatch) -> None:
+    monkeypatch.setattr(
+        eval_module,
+        "check_env_attributes_and_types",
+        lambda env: None,
+    )
+    monkeypatch.setattr(
+        eval_module,
+        "preprocess_observation",
+        lambda observation: observation,
+    )
+
+    env = _FakeVectorEnv()
+    identity = _IdentityProcessor()
+
+    rollout(
+        env=env,
+        policy=_FakePolicy(),
+        env_preprocessor=identity,
+        env_postprocessor=identity,
+        preprocessor=identity,
+        postprocessor=identity,
+        initial_state_indices=[4, 5],
+    )
+
+    assert env.reset_options == {"initial_state_indices": [4, 5]}
+
+
+def test_eval_policy_assigns_initial_state_indices_per_batch(monkeypatch) -> None:
+    captured_initial_state_indices: list[list[int] | None] = []
+
+    def fake_rollout(**kwargs):
+        captured_initial_state_indices.append(kwargs.get("initial_state_indices"))
+        return {
+            ACTION: torch.zeros((2, 1, 1), dtype=torch.float32),
+            "reward": torch.zeros((2, 1), dtype=torch.float32),
+            "success": torch.zeros((2, 1), dtype=torch.bool),
+            "done": torch.ones((2, 1), dtype=torch.bool),
+        }
+
+    monkeypatch.setattr(eval_module, "PreTrainedPolicy", nn.Module)
+    monkeypatch.setattr(eval_module, "rollout", fake_rollout)
+
+    class _FakeProgress:
+        def __init__(self, count: int) -> None:
+            self._values = range(count)
+
+        def __iter__(self):
+            return iter(self._values)
+
+        def set_postfix(self, *_args, **_kwargs) -> None:
+            pass
+
+    monkeypatch.setattr(
+        eval_module,
+        "trange",
+        lambda count, **kwargs: _FakeProgress(count),
+    )
+
+    env = _FakeVectorEnv()
+    identity = _IdentityProcessor()
+
+    eval_module.eval_policy(
+        env=env,
+        policy=_FakePolicy(),
+        env_preprocessor=identity,
+        env_postprocessor=identity,
+        preprocessor=identity,
+        postprocessor=identity,
+        n_episodes=4,
+    )
+
+    assert captured_initial_state_indices == [[0, 1], [2, 3]]


### PR DESCRIPTION
## Summary / Motivation

LIBERO currently advances its initial-state selection whenever an environment is reset. Early policy termination and vector-environment autoreset can therefore change the initial states used by later evaluation batches.

This change makes LIBERO initial-state allocation derive from evaluated episode indices instead of reset counts, so equivalent evaluations receive the same per-slot initial-state sequence regardless of policy termination timing.

## Related issues

Closes #4152

## What changed

- Generate contiguous initial-state indices for each evaluation batch in `eval_policy()`.
- Forward those indices through `rollout()` using environment reset options.
- Update `LiberoEnv.reset()` to select the requested index for its vector slot.
- Preserve the existing counter-based behavior when explicit indices are not supplied.
- Add regression tests covering:
  - per-slot initial-state selection;
  - reset-option forwarding;
  - per-batch index allocation;
  - independence from additional timing-dependent resets.

No public configuration changes are required.

## How was this tested

Formatting, linting and type checking:

```bash
pre-commit run --files \
src/lerobot/envs/libero.py \
src/lerobot/scripts/lerobot_eval.py \
tests/envs/test_libero.py \
tests/scripts/test_lerobot_eval_reset_options.py
```

Relevant tests:

```bash
pytest -q \
tests/envs/test_libero.py \
tests/envs/test_dispatch.py \
tests/envs/test_envs.py \
tests/scripts/test_lerobot_eval_reset_options.py \
-x
```

Result:

```text
33 passed, 2 skipped
```

The new regression tests isolate the initial-state bookkeeping without requiring a complete policy evaluation run.

## Checklist

- [x] Linting, formatting and type checking passed for the changed files
- [x] Relevant tests pass locally
- [x] Documentation updated
- [ ] CI is green
- [x] Community Review: reviewed #4221

## Reviewer notes

The main design choice is that `eval_policy()` owns the evaluated episode indices and forwards them through Gymnasium reset options. Review feedback on whether this is the preferred ownership point would be especially useful.

Anyone in the community is welcome to review this PR.