### PR TITLE
docs: add small Dataset v3 porting example

### DIFF
--- a/docs/source/porting_datasets_v3.mdx
+++ b/docs/source/porting_datasets_v3.mdx
@@ -58,6 +58,89 @@ Before porting large datasets, ensure you have:
 - **Cluster access** (recommended for large datasets): SLURM or similar job scheduler
 - **Dataset-specific dependencies**: For DROID, you'll need TensorFlow Dataset utilities
 
+## Start with a Small Local Dataset
+
+Before scaling to a cluster, validate the mapping on a few local episodes. A simple
+JSON Lines interchange works well for this: keep one frame per line, keep frames from
+the same episode contiguous, and include the task with every frame.
+
+```json
+{"episode_index": 0, "task": "move forward", "observation.state": [0.0, 0.1], "action": [0.2, 0.3]}
+```
+
+The following minimal converter writes a local Dataset v3 without uploading data:
+
+```python
+import json
+from itertools import chain
+from pathlib import Path
+
+import numpy as np
+
+from lerobot.datasets import LeRobotDataset
+
+
+def read_jsonl(path: Path):
+    with path.open(encoding="utf-8") as stream:
+        for line in stream:
+            if line.strip():
+                yield json.loads(line)
+
+
+records = read_jsonl(Path("records.jsonl"))
+try:
+    first = next(records)
+except StopIteration as exc:
+    raise ValueError("records.jsonl is empty") from exc
+
+state_size = len(first["observation.state"])
+action_size = len(first["action"])
+features = {
+    "observation.state": {
+        "dtype": "float32",
+        "shape": (state_size,),
+        "names": {"axes": [f"state_{index}" for index in range(state_size)]},
+    },
+    "action": {
+        "dtype": "float32",
+        "shape": (action_size,),
+        "names": {"axes": [f"action_{index}" for index in range(action_size)]},
+    },
+}
+
+dataset = LeRobotDataset.create(
+    repo_id="local/vendor_log",
+    root=Path("converted/vendor_log"),
+    fps=30,
+    features=features,
+    use_videos=False,
+)
+
+current_episode = None
+for record in chain([first], records):
+    episode_index = int(record["episode_index"])
+    if current_episode is not None and episode_index != current_episode:
+        if episode_index < current_episode:
+            raise ValueError("episode_index must be monotonic")
+        dataset.save_episode()
+
+    dataset.add_frame(
+        {
+            "task": record["task"],
+            "observation.state": np.asarray(record["observation.state"], dtype=np.float32),
+            "action": np.asarray(record["action"], dtype=np.float32),
+        }
+    )
+    current_episode = episode_index
+
+dataset.save_episode()
+dataset.finalize()
+```
+
+Replace the placeholder axis names with the source device's documented joint or control
+order. Keep the original logs alongside the converted dataset so unsupported fields remain
+available for later migrations. Once this small conversion loads correctly, move to the
+DROID/SLURM workflow below for sharded or multi-terabyte datasets.
 ## Understanding the DROID Dataset
 
 [DROID 1.0.1](https://droid-dataset.github.io/droid/the-droid-dataset) is an excellent example of a large-scale robotic dataset:


### PR DESCRIPTION
## Summary / Motivation

The Dataset v3 porting guide currently begins with a multi-terabyte DROID/SLURM workflow. Add a small, local JSONL example so contributors can validate state/action mappings and episode boundaries before scaling out.

## Related issues

- Related: #4258

## What changed

- Document a minimal one-frame-per-line JSONL interchange.
- Show a streaming conversion through the public `LeRobotDataset` v3 API.
- Use `names.axes` for state/action metadata and preserve original logs for fields that are not mapped.
- Connect the small local workflow to the existing DROID/SLURM guide.

## How was this tested

- Extracted the Python block from the rendered source and parsed it with `ast.parse`.
- Verified the fork is exactly one commit ahead and changes only `docs/source/porting_datasets_v3.mdx`.
- Full runtime tests were not run because this draft changes documentation only and the local LeRobot clone was not available.

## Checklist

- [ ] Linting/formatting run (`pre-commit run -a`)
- [ ] All tests pass locally (`pytest`)
- [x] Documentation updated
- [ ] CI is green
- [ ] Community Review: I will review another contributor's open PR and link it here before requesting maintainer review.

## AI assistance disclosure

This documentation draft was prepared with substantial Codex assistance. I reviewed the existing Dataset v3 API and guide, limited the change to a single public documentation file, inspected the full diff, and syntax-checked the embedded Python example.

## Reviewer notes

The main design question is whether this small JSONL example belongs in the large-dataset guide or should be a separate page. The PR is intentionally draft while CI and maintainer direction are pending.