### PR TITLE
feat(runtime): add LeRobot Playground

### DIFF
--- a/docs/source/inference.mdx
+++ b/docs/source/inference.mdx
@@ -237,9 +237,19 @@ MUJOCO_GL=egl lerobot-rollout \
     --mode=action --ctrl_hz=20
 ```
 
-Open `http://localhost:8010` for the live simulator view. Add
-`--sim.direct_subtask` to bypass the language planner and make each typed prompt
-the action policy's current subtask.
+Open `http://localhost:8010` for **LeRobot Playground**, a full-screen live
+simulator with task controls and a collapsible chat panel. The chat can pause or
+steer the rollout, ask the policy grounded questions about the current view,
+and attach a public image URL as the visual input for VQA. Its optional
+high-level planner periodically turns the current goal and view into the next
+subtask. The Blog button embeds the language-policy article; override its URL
+with `--sim.blog_url`.
+
+Add `--sim.direct_subtask` to bypass the language planner and make each typed
+prompt the action policy's current subtask. The initial browser UI supports the
+same RoboCasa runtime as the terminal. LIBERO and RoboTwin are shown as the next
+benchmark adapters but remain disabled until their persistent-environment
+backends implement this runtime contract.
 
 ---
 

--- a/docs/source/inference.mdx
+++ b/docs/source/inference.mdx
@@ -242,8 +242,10 @@ simulator with task controls and a collapsible chat panel. The chat can pause or
 steer the rollout, ask the policy grounded questions about the current view,
 and attach a public image URL as the visual input for VQA. Its optional
 high-level planner periodically turns the current goal and view into the next
-subtask. The Blog button embeds the language-policy article; override its URL
-with `--sim.blog_url`.
+subtask. It defaults to `Qwen/Qwen3.5-2B`, remains unloaded until you enable it,
+and can be changed or disabled with `--planner.path` (pass an empty value to
+disable) and `--planner.device`. The Blog button embeds the language-policy
+article; override its URL with `--sim.blog_url`.
 
 Add `--sim.direct_subtask` to bypass the language planner and make each typed
 prompt the action policy's current subtask. The initial browser UI supports the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -374,7 +374,11 @@ torch = [{ index = "pytorch-cu128", marker = "sys_platform == 'linux'" }]
 torchvision = [{ index = "pytorch-cu128", marker = "sys_platform == 'linux'" }]
 
 [tool.setuptools.package-data]
-lerobot = ["envs/*.json", "annotations/steerable_pipeline/prompts/*.txt"]
+lerobot = [
+    "envs/*.json",
+    "annotations/steerable_pipeline/prompts/*.txt",
+    "runtime/playground_assets/*",
+]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/lerobot/runtime/cli.py
+++ b/src/lerobot/runtime/cli.py
@@ -214,6 +214,23 @@ def _parse_args(argv: list[str] | None = None, *, prog: str | None = None) -> ar
         help="Optional article URL shown in the Playground's collapsible Blog panel.",
     )
     p.add_argument(
+        "--planner.path",
+        dest="planner_path",
+        type=str,
+        default="Qwen/Qwen3.5-2B",
+        help=(
+            "Optional visual high-level planner used by the Playground. "
+            "The default Qwen3.5-2B weights load lazily only after enabling the planner."
+        ),
+    )
+    p.add_argument(
+        "--planner.device",
+        dest="planner_device",
+        type=str,
+        default=None,
+        help="Device for the optional high-level planner (default: cuda when available, otherwise cpu).",
+    )
+    p.add_argument(
         "--chunk_hz",
         type=float,
         default=1.0,
@@ -633,11 +650,24 @@ def _process_playground_commands(
                 continue
             image_url = str(payload.get("image_url") or "").strip() or None
             controller.add_message("user", text, image_url=image_url, kind=command.kind)
+            planner_prompt = str(payload.get("planner_prompt") or "").strip()
             if command.kind == "planner":
-                planner_prompt = str(payload.get("planner_prompt") or "").strip()
-                if planner_prompt:
-                    text = f"{planner_prompt}\n\nHigh-level goal: {text}\nReturn the next subtask only."
-            answer = _ask_runtime(runtime, text, image_url=image_url)
+                planner = getattr(controller, "planner", None)
+                if planner is None:
+                    raise ValueError("no high-level planner is configured")
+                observation = runtime._current_observation()
+                if image_url:
+                    from .playground import replace_observation_image_from_url  # noqa: PLC0415
+
+                    observation = replace_observation_image_from_url(observation, image_url)
+                answer = planner.plan(
+                    text,
+                    observation,
+                    system_prompt=planner_prompt
+                    or "You are a high-level robot planner. Return only the next concrete subtask.",
+                )
+            else:
+                answer = _ask_runtime(runtime, text, image_url=image_url)
             controller.add_message("assistant", answer or "The policy returned no answer.", kind=command.kind)
             if command.kind == "planner" and answer:
                 runtime.state.set_context("subtask", answer)
@@ -861,7 +891,11 @@ def run(
     sim_holder: dict[str, Any] = {"backend": None}
     playground_controller = None
     if sim_mode:
-        from lerobot.runtime.playground import PlaygroundController, start_playground_server  # noqa: PLC0415
+        from lerobot.runtime.playground import (  # noqa: PLC0415
+            LazyQwenPlanner,
+            PlaygroundController,
+            start_playground_server,
+        )
         from lerobot.runtime.sim_robocasa import create_sim_env  # noqa: PLC0415
 
         # Start the live viewer first so the port listens during the ~60s model
@@ -871,6 +905,9 @@ def run(
                 policy_path=args.policy_path,
                 benchmark="robocasa",
                 blog_url=args.sim_blog_url,
+                planner=LazyQwenPlanner(args.planner_path, device=args.planner_device)
+                if args.planner_path
+                else None,
             )
             sim_stream_server = start_playground_server(
                 args.sim_stream_port,

--- a/src/lerobot/runtime/cli.py
+++ b/src/lerobot/runtime/cli.py
@@ -201,10 +201,17 @@ def _parse_args(argv: list[str] | None = None, *, prog: str | None = None) -> ar
         type=int,
         default=8010,
         help=(
-            "Port for the live MJPEG viewer (default: 8010; 0 disables). "
+            "Port for the LeRobot Playground and live MJPEG viewer (default: 8010; 0 disables). "
             "Open http://localhost:<port> in a browser; over SSH forward it with "
             "ssh -L <port>:localhost:<port> <host>."
         ),
+    )
+    p.add_argument(
+        "--sim.blog_url",
+        dest="sim_blog_url",
+        type=str,
+        default="https://lerobot-language-conditioned-policies.hf.space/blog/",
+        help="Optional article URL shown in the Playground's collapsible Blog panel.",
     )
     p.add_argument(
         "--chunk_hz",
@@ -553,7 +560,7 @@ def _clear_action_queue(runtime: Any) -> None:
             queue.clear()
 
 
-def _ask_runtime(runtime: Any, question: str) -> str:
+def _ask_runtime(runtime: Any, question: str, *, image_url: str | None = None) -> str:
     """Pause action dispatch and ask the adapter a grounded VQA question."""
     question = question.strip()
     if not question:
@@ -567,6 +574,10 @@ def _ask_runtime(runtime: Any, question: str) -> str:
         print("[runtime] this policy adapter does not support text generation", flush=True)
         return ""
     observation = runtime._current_observation()
+    if image_url:
+        from .playground import replace_observation_image_from_url  # noqa: PLC0415
+
+        observation = replace_observation_image_from_url(observation, image_url)
     try:
         answer = generate_text("vqa", observation, runtime.state, user_text=question)
     except Exception as exc:  # noqa: BLE001
@@ -578,6 +589,65 @@ def _ask_runtime(runtime: Any, question: str) -> str:
         return ""
     print(f"[policy] {answer}", flush=True)
     return answer
+
+
+def _process_playground_commands(
+    controller: Any,
+    runtime: Any,
+    sim_backend: Any,
+    *,
+    direct_subtask: bool,
+) -> None:
+    """Run queued browser commands on the simulator's main thread."""
+    while (command := controller.next_command()) is not None:
+        payload = command.payload
+        try:
+            if command.kind == "pause":
+                runtime.state["mode"] = "paused"
+                runtime.state["action_deadline"] = None
+                _clear_action_queue(runtime)
+                controller.finish(command, result={"mode": "paused"})
+                continue
+            if command.kind == "reset":
+                sim_backend.reset_scene()
+                _clear_action_queue(runtime)
+                runtime.state.set_context("subtask", None)
+                if hasattr(runtime.policy, "reset"):
+                    runtime.policy.reset()
+                controller.finish(command, result={"reset": True})
+                continue
+            text = str(payload.get("text") or "").strip()
+            if not text:
+                raise ValueError("message text cannot be empty")
+            if command.kind == "action":
+                runtime.set_task(text)
+                runtime.state.set_context("subtask", text if direct_subtask else None)
+                _clear_action_queue(runtime)
+                adapter = getattr(runtime, "policy_adapter", None)
+                if adapter is not None and hasattr(adapter, "_chunks_until_regen"):
+                    adapter._chunks_until_regen = 0
+                runtime._language_gate.rearm()
+                runtime.state["mode"] = "action"
+                controller.add_message("user", text, kind="action")
+                controller.finish(command, result={"mode": "action", "task": text})
+                continue
+            image_url = str(payload.get("image_url") or "").strip() or None
+            controller.add_message("user", text, image_url=image_url, kind=command.kind)
+            if command.kind == "planner":
+                planner_prompt = str(payload.get("planner_prompt") or "").strip()
+                if planner_prompt:
+                    text = f"{planner_prompt}\n\nHigh-level goal: {text}\nReturn the next subtask only."
+            answer = _ask_runtime(runtime, text, image_url=image_url)
+            controller.add_message("assistant", answer or "The policy returned no answer.", kind=command.kind)
+            if command.kind == "planner" and answer:
+                runtime.state.set_context("subtask", answer)
+                _clear_action_queue(runtime)
+                runtime._language_gate.rearm()
+                runtime.state["mode"] = "action"
+            controller.finish(command, result={"answer": answer})
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("playground command failed: %s", exc, exc_info=logger.isEnabledFor(logging.DEBUG))
+            controller.finish(command, error=f"{type(exc).__name__}: {exc}")
 
 
 def _handle_slash_command(runtime: Any, line: str) -> bool:
@@ -789,15 +859,23 @@ def run(
     sim_obs = None
     sim_stream_server = None
     sim_holder: dict[str, Any] = {"backend": None}
+    playground_controller = None
     if sim_mode:
-        from lerobot.runtime.sim_robocasa import create_sim_env, start_mjpeg_server  # noqa: PLC0415
+        from lerobot.runtime.playground import PlaygroundController, start_playground_server  # noqa: PLC0415
+        from lerobot.runtime.sim_robocasa import create_sim_env  # noqa: PLC0415
 
         # Start the live viewer first so the port listens during the ~60s model
         # load (browsers get a loading page instead of connection-refused).
         if args.sim_stream_port:
-            sim_stream_server = start_mjpeg_server(
+            playground_controller = PlaygroundController(
+                policy_path=args.policy_path,
+                benchmark="robocasa",
+                blog_url=args.sim_blog_url,
+            )
+            sim_stream_server = start_playground_server(
                 args.sim_stream_port,
                 lambda: sim_holder["backend"]._latest_frame if sim_holder["backend"] else None,
+                playground_controller,
             )
         print(
             f"[runtime] starting RoboCasa sim scene={args.sim_task!r} split={args.sim_split!r}",
@@ -928,6 +1006,8 @@ def run(
     # Let the sim backend read live task/subtask/memory for the video overlay.
     if sim_backend is not None:
         sim_backend.bind_runtime(runtime)
+        if playground_controller is not None:
+            playground_controller.attach(runtime, sim_backend)
         # Keep EGL rendering on the main thread.
         return _run_sim_interactive(
             runtime,
@@ -936,6 +1016,7 @@ def run(
             max_ticks=args.max_ticks,
             panel_label=panel_label,
             direct_subtask=_direct_subtask_enabled(args),
+            playground_controller=playground_controller,
         )
 
     if autonomous_mode:
@@ -963,6 +1044,7 @@ def _run_sim_interactive(
     max_ticks: int | None,
     panel_label: str = "Runtime",
     direct_subtask: bool = False,
+    playground_controller: Any | None = None,
 ) -> int:
     """Keep RoboCasa rendering on the main thread while polling stdin."""
     import select  # noqa: PLC0415
@@ -1001,6 +1083,13 @@ def _run_sim_interactive(
     stdin_open = True
     try:
         while True:
+            if playground_controller is not None:
+                _process_playground_commands(
+                    playground_controller,
+                    runtime,
+                    sim_backend,
+                    direct_subtask=direct_subtask,
+                )
             # Non-blocking stdin: a full line (canonical-mode terminal) is read
             # only when Enter is pressed, so line editing works normally.
             if stdin_open and select.select([sys.stdin], [], [], 0)[0]:

--- a/src/lerobot/runtime/playground.py
+++ b/src/lerobot/runtime/playground.py
@@ -1,0 +1,343 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Browser controls for an interactive language-conditioned rollout.
+
+The server intentionally uses the standard library so the runtime does not gain
+another required web-framework dependency.  It owns no policy or simulator
+state: commands are queued for the simulator's main thread, where inference and
+MuJoCo rendering already run safely.
+"""
+
+from __future__ import annotations
+
+import io
+import ipaddress
+import json
+import queue
+import socket
+import threading
+import time
+from dataclasses import dataclass, field
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from importlib.resources import files
+from typing import Any
+from urllib.parse import urlsplit
+from urllib.request import HTTPRedirectHandler, Request, build_opener
+
+import numpy as np
+import torch
+from PIL import Image
+
+
+@dataclass
+class PlaygroundCommand:
+    """One browser request awaiting execution on the simulator thread."""
+
+    kind: str
+    payload: dict[str, Any] = field(default_factory=dict)
+    completed: threading.Event = field(default_factory=threading.Event, repr=False)
+    result: dict[str, Any] | None = None
+    error: str | None = None
+
+
+class PlaygroundController:
+    """Thread-safe bridge between the HTTP server and a live runtime."""
+
+    def __init__(self, *, policy_path: str, benchmark: str = "robocasa", blog_url: str = "") -> None:
+        self.policy_path = policy_path
+        self.benchmark = benchmark
+        self.blog_url = blog_url
+        self.runtime: Any | None = None
+        self.sim_backend: Any | None = None
+        self._commands: queue.Queue[PlaygroundCommand] = queue.Queue()
+        self._messages: list[dict[str, Any]] = []
+        self._message_id = 0
+        self._lock = threading.RLock()
+        self.started_at = time.time()
+
+    def attach(self, runtime: Any, sim_backend: Any) -> None:
+        """Attach live objects after policy construction has completed."""
+        with self._lock:
+            self.runtime = runtime
+            self.sim_backend = sim_backend
+
+    def enqueue(self, kind: str, payload: dict[str, Any] | None = None) -> PlaygroundCommand:
+        command = PlaygroundCommand(kind=kind, payload=payload or {})
+        self._commands.put(command)
+        return command
+
+    def next_command(self) -> PlaygroundCommand | None:
+        try:
+            return self._commands.get_nowait()
+        except queue.Empty:
+            return None
+
+    def finish(
+        self, command: PlaygroundCommand, *, result: dict[str, Any] | None = None, error: str | None = None
+    ) -> None:
+        command.result = result or {}
+        command.error = error
+        command.completed.set()
+
+    def add_message(
+        self, role: str, text: str, *, image_url: str | None = None, kind: str = "chat"
+    ) -> dict[str, Any]:
+        with self._lock:
+            self._message_id += 1
+            message = {
+                "id": self._message_id,
+                "role": role,
+                "text": text,
+                "kind": kind,
+                "created_at": time.time(),
+            }
+            if image_url:
+                message["image_url"] = image_url
+            self._messages.append(message)
+            self._messages = self._messages[-100:]
+            return message
+
+    def snapshot(self) -> dict[str, Any]:
+        runtime = self.runtime
+        if runtime is None:
+            state: dict[str, Any] = {}
+        else:
+            with runtime.state.lock:
+                state = {
+                    "mode": runtime.state.get("mode", "paused"),
+                    "task": runtime.state.get("task") or "",
+                    "language_context": dict(runtime.state.get("language_context") or {}),
+                    "queued_actions": len(runtime.state.get("action_queue") or []),
+                    "actions_dispatched": int(runtime.state.get("actions_dispatched") or 0),
+                    "revision": int(runtime.state.get("revision") or 0),
+                }
+        with self._lock:
+            messages = list(self._messages)
+        return {
+            "connected": runtime is not None,
+            "policy_path": self.policy_path,
+            "benchmark": self.benchmark,
+            "blog_url": self.blog_url,
+            "uptime_seconds": max(0, int(time.time() - self.started_at)),
+            "state": state,
+            "messages": messages,
+            "capabilities": {
+                "benchmarks": {
+                    "robocasa": {"available": True, "label": "RoboCasa"},
+                    "libero": {"available": False, "label": "LIBERO"},
+                    "robotwin": {"available": False, "label": "RoboTwin"},
+                },
+                "vqa": True,
+                "remote_image": True,
+                "planner": True,
+            },
+        }
+
+
+def _json_bytes(payload: Any) -> bytes:
+    return json.dumps(payload, separators=(",", ":")).encode()
+
+
+def _asset_bytes(name: str) -> bytes:
+    return files("lerobot.runtime.playground_assets").joinpath(name).read_bytes()
+
+
+def _validate_remote_image_url(image_url: str) -> str:
+    """Reject non-HTTP and local/private targets before fetching a VQA image."""
+    parsed = urlsplit(image_url)
+    if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+        raise ValueError("image URL must use http or https")
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    for info in socket.getaddrinfo(parsed.hostname, port, type=socket.SOCK_STREAM):
+        address = ipaddress.ip_address(info[4][0])
+        if not address.is_global:
+            raise ValueError("image URL must resolve to a public address")
+    return image_url
+
+
+class _SafeImageRedirectHandler(HTTPRedirectHandler):
+    """Apply the same public-address restriction to every redirect hop."""
+
+    def redirect_request(self, req: Any, fp: Any, code: int, msg: str, headers: Any, newurl: str) -> Any:
+        return super().redirect_request(req, fp, code, msg, headers, _validate_remote_image_url(newurl))
+
+
+def replace_observation_image_from_url(
+    observation: dict[str, Any] | None,
+    image_url: str,
+    *,
+    max_bytes: int = 12_000_000,
+) -> dict[str, Any]:
+    """Replace the first tensor image input with a safely fetched remote image."""
+    if not observation:
+        raise ValueError("the runtime has no current observation")
+    request = Request(  # noqa: S310
+        _validate_remote_image_url(image_url),
+        headers={"User-Agent": "LeRobot-Playground/1.0"},
+    )
+    with build_opener(_SafeImageRedirectHandler()).open(request, timeout=8) as response:  # noqa: S310
+        content_type = str(response.headers.get("Content-Type") or "")
+        if not content_type.lower().startswith("image/"):
+            raise ValueError("remote URL did not return an image")
+        data = response.read(max_bytes + 1)
+    if len(data) > max_bytes:
+        raise ValueError("remote image is larger than 12 MB")
+    with Image.open(io.BytesIO(data)) as opened:
+        rgb = opened.convert("RGB")
+
+    target_key = next(
+        (
+            key
+            for key, value in observation.items()
+            if isinstance(key, str)
+            and ("image" in key or "pixel" in key)
+            and isinstance(value, torch.Tensor)
+            and value.ndim in {3, 4}
+        ),
+        None,
+    )
+    if target_key is None:
+        raise ValueError("this policy observation has no replaceable image input")
+    target = observation[target_key]
+    batched = target.ndim == 4
+    sample = target[0] if batched else target
+    channel_first = sample.shape[0] in {1, 3, 4}
+    height, width = (
+        (sample.shape[-2], sample.shape[-1]) if channel_first else (sample.shape[0], sample.shape[1])
+    )
+    rgb = rgb.resize((int(width), int(height)), Image.Resampling.LANCZOS)
+    replacement = torch.from_numpy(np.asarray(rgb).copy()).to(dtype=torch.float32) / 255
+    if channel_first:
+        replacement = replacement.permute(2, 0, 1)
+    replacement = replacement.to(device=target.device, dtype=target.dtype)
+    if batched:
+        replacement = replacement.unsqueeze(0).expand(target.shape[0], *replacement.shape)
+    updated = dict(observation)
+    updated[target_key] = replacement
+    return updated
+
+
+def start_playground_server(
+    port: int,
+    get_frame: Any,
+    controller: PlaygroundController,
+) -> ThreadingHTTPServer | None:
+    """Serve the full-screen playground, its API, and the live MJPEG stream."""
+
+    placeholder = Image.new("RGB", (640, 400), (15, 18, 22))
+    assets = {
+        "/": ("text/html; charset=utf-8", _asset_bytes("index.html")),
+        "/index.html": ("text/html; charset=utf-8", _asset_bytes("index.html")),
+        "/playground.css": ("text/css; charset=utf-8", _asset_bytes("playground.css")),
+        "/playground.js": ("text/javascript; charset=utf-8", _asset_bytes("playground.js")),
+    }
+
+    class Handler(BaseHTTPRequestHandler):
+        server_version = "LeRobotPlayground/1"
+
+        def log_message(self, *_args: Any) -> None:
+            pass
+
+        def _send_json(self, status: HTTPStatus, payload: Any) -> None:
+            data = _json_bytes(payload)
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(data)))
+            self.send_header("Cache-Control", "no-store")
+            self.end_headers()
+            self.wfile.write(data)
+
+        def _read_json(self) -> dict[str, Any]:
+            length = int(self.headers.get("Content-Length", "0"))
+            if length <= 0 or length > 1_000_000:
+                raise ValueError("request body is empty or too large")
+            payload = json.loads(self.rfile.read(length))
+            if not isinstance(payload, dict):
+                raise ValueError("request body must be a JSON object")
+            return payload
+
+        def do_GET(self) -> None:  # noqa: N802
+            path = urlsplit(self.path).path
+            if path in assets:
+                content_type, data = assets[path]
+                self.send_response(HTTPStatus.OK)
+                self.send_header("Content-Type", content_type)
+                self.send_header("Content-Length", str(len(data)))
+                self.send_header("Cache-Control", "no-store")
+                self.end_headers()
+                self.wfile.write(data)
+                return
+            if path == "/api/state":
+                self._send_json(HTTPStatus.OK, controller.snapshot())
+                return
+            if path == "/health":
+                self._send_json(HTTPStatus.OK, {"ok": True})
+                return
+            if path != "/stream":
+                self._send_json(HTTPStatus.NOT_FOUND, {"error": "not found"})
+                return
+            self.send_response(HTTPStatus.OK)
+            self.send_header("Content-Type", "multipart/x-mixed-replace; boundary=frame")
+            self.send_header("Cache-Control", "no-store")
+            self.end_headers()
+            try:
+                while True:
+                    frame = get_frame()
+                    image = Image.fromarray(frame) if frame is not None else placeholder
+                    buffer = io.BytesIO()
+                    image.save(buffer, format="JPEG", quality=82)
+                    data = buffer.getvalue()
+                    self.wfile.write(
+                        b"--frame\r\nContent-Type: image/jpeg\r\nContent-Length: "
+                        + str(len(data)).encode()
+                        + b"\r\n\r\n"
+                        + data
+                        + b"\r\n"
+                    )
+                    time.sleep(0.05)
+            except (BrokenPipeError, ConnectionResetError):
+                return
+
+        def do_POST(self) -> None:  # noqa: N802
+            path = urlsplit(self.path).path
+            if path not in {"/api/command", "/api/chat"}:
+                self._send_json(HTTPStatus.NOT_FOUND, {"error": "not found"})
+                return
+            try:
+                payload = self._read_json()
+                kind = str(payload.get("kind") or ("chat" if path == "/api/chat" else "")).strip()
+                if kind not in {"action", "pause", "reset", "chat", "vqa", "planner"}:
+                    raise ValueError(f"unsupported command: {kind!r}")
+                command = controller.enqueue(kind, payload)
+                timeout = 180 if kind in {"chat", "vqa", "planner"} else 15
+                if not command.completed.wait(timeout):
+                    self._send_json(HTTPStatus.GATEWAY_TIMEOUT, {"error": "runtime did not respond"})
+                    return
+                if command.error:
+                    self._send_json(HTTPStatus.BAD_REQUEST, {"error": command.error})
+                    return
+                self._send_json(HTTPStatus.OK, {"ok": True, **(command.result or {})})
+            except (ValueError, json.JSONDecodeError) as exc:
+                self._send_json(HTTPStatus.BAD_REQUEST, {"error": str(exc)})
+            except Exception as exc:  # noqa: BLE001
+                self._send_json(HTTPStatus.INTERNAL_SERVER_ERROR, {"error": str(exc)})
+
+    try:
+        server = ThreadingHTTPServer(("0.0.0.0", port), Handler)  # nosec B104
+    except OSError:
+        return None
+    threading.Thread(target=server.serve_forever, daemon=True, name="lerobot-playground").start()
+    return server

--- a/src/lerobot/runtime/playground.py
+++ b/src/lerobot/runtime/playground.py
@@ -29,6 +29,7 @@ import queue
 import socket
 import threading
 import time
+from base64 import b64encode
 from dataclasses import dataclass, field
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -56,10 +57,18 @@ class PlaygroundCommand:
 class PlaygroundController:
     """Thread-safe bridge between the HTTP server and a live runtime."""
 
-    def __init__(self, *, policy_path: str, benchmark: str = "robocasa", blog_url: str = "") -> None:
+    def __init__(
+        self,
+        *,
+        policy_path: str,
+        benchmark: str = "robocasa",
+        blog_url: str = "",
+        planner: Any | None = None,
+    ) -> None:
         self.policy_path = policy_path
         self.benchmark = benchmark
         self.blog_url = blog_url
+        self.planner = planner
         self.runtime: Any | None = None
         self.sim_backend: Any | None = None
         self._commands: queue.Queue[PlaygroundCommand] = queue.Queue()
@@ -142,7 +151,11 @@ class PlaygroundController:
                 },
                 "vqa": True,
                 "remote_image": True,
-                "planner": True,
+                "planner": {
+                    "available": self.planner is not None,
+                    "model": getattr(self.planner, "model_path", None),
+                    "loaded": bool(getattr(self.planner, "loaded", False)),
+                },
             },
         }
 
@@ -153,6 +166,103 @@ def _json_bytes(payload: Any) -> bytes:
 
 def _asset_bytes(name: str) -> bytes:
     return files("lerobot.runtime.playground_assets").joinpath(name).read_bytes()
+
+
+def _observation_image(observation: dict[str, Any] | None) -> Image.Image:
+    """Convert the first image tensor in a policy observation to RGB."""
+    if not observation:
+        raise ValueError("the runtime has no current observation")
+    source = next(
+        (
+            value
+            for key, value in observation.items()
+            if isinstance(key, str)
+            and ("image" in key or "pixel" in key)
+            and isinstance(value, torch.Tensor)
+            and value.ndim in {3, 4}
+        ),
+        None,
+    )
+    if source is None:
+        raise ValueError("this policy observation has no image input")
+    sample = source[0] if source.ndim == 4 else source
+    if sample.shape[0] in {1, 3, 4}:
+        sample = sample[:3].permute(1, 2, 0)
+    sample = sample.detach().to(device="cpu", dtype=torch.float32)
+    if float(sample.max()) > 1.5:
+        sample = sample / 255
+    if float(sample.min()) < 0:
+        sample = (sample + 1) / 2
+    array = (sample.clamp(0, 1).numpy() * 255).astype(np.uint8)
+    if array.shape[-1] == 1:
+        array = np.repeat(array, 3, axis=-1)
+    return Image.fromarray(array, mode="RGB")
+
+
+class LazyQwenPlanner:
+    """Lazily load Qwen3.5 as an optional visual high-level planner."""
+
+    def __init__(self, model_path: str = "Qwen/Qwen3.5-2B", *, device: str | None = None) -> None:
+        self.model_path = model_path
+        self.device = device
+        self.model: Any | None = None
+        self.processor: Any | None = None
+        self._lock = threading.RLock()
+
+    @property
+    def loaded(self) -> bool:
+        return self.model is not None and self.processor is not None
+
+    def _ensure_loaded(self) -> None:
+        if self.loaded:
+            return
+        with self._lock:
+            if self.loaded:
+                return
+            from transformers import AutoModelForMultimodalLM, AutoProcessor  # noqa: PLC0415
+
+            device = self.device or ("cuda" if torch.cuda.is_available() else "cpu")
+            self.processor = AutoProcessor.from_pretrained(self.model_path)
+            self.model = AutoModelForMultimodalLM.from_pretrained(self.model_path, dtype="auto").to(device)
+            self.model.eval()
+
+    def plan(
+        self,
+        goal: str,
+        observation: dict[str, Any] | None,
+        *,
+        system_prompt: str,
+    ) -> str:
+        """Return the next low-level subtask from the current view and goal."""
+        self._ensure_loaded()
+        image = _observation_image(observation)
+        buffer = io.BytesIO()
+        image.save(buffer, format="PNG")
+        image_url = f"data:image/png;base64,{b64encode(buffer.getvalue()).decode()}"
+        messages = [
+            {"role": "system", "content": system_prompt},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image", "url": image_url},
+                    {
+                        "type": "text",
+                        "text": f"High-level goal: {goal}\nReturn only the next concrete robot subtask.",
+                    },
+                ],
+            },
+        ]
+        inputs = self.processor.apply_chat_template(
+            messages,
+            add_generation_prompt=True,
+            tokenize=True,
+            return_dict=True,
+            return_tensors="pt",
+        ).to(self.model.device)
+        with torch.inference_mode():
+            outputs = self.model.generate(**inputs, max_new_tokens=80, do_sample=False)
+        prompt_length = inputs["input_ids"].shape[-1]
+        return self.processor.decode(outputs[0][prompt_length:], skip_special_tokens=True).strip()
 
 
 def _validate_remote_image_url(image_url: str) -> str:
@@ -220,6 +330,8 @@ def replace_observation_image_from_url(
     )
     rgb = rgb.resize((int(width), int(height)), Image.Resampling.LANCZOS)
     replacement = torch.from_numpy(np.asarray(rgb).copy()).to(dtype=torch.float32) / 255
+    if torch.is_floating_point(target) and float(target.min()) < 0:
+        replacement = replacement * 2 - 1
     if channel_first:
         replacement = replacement.permute(2, 0, 1)
     replacement = replacement.to(device=target.device, dtype=target.dtype)
@@ -322,7 +434,7 @@ def start_playground_server(
                 if kind not in {"action", "pause", "reset", "chat", "vqa", "planner"}:
                     raise ValueError(f"unsupported command: {kind!r}")
                 command = controller.enqueue(kind, payload)
-                timeout = 180 if kind in {"chat", "vqa", "planner"} else 15
+                timeout = 600 if kind == "planner" else (180 if kind in {"chat", "vqa"} else 15)
                 if not command.completed.wait(timeout):
                     self._send_json(HTTPStatus.GATEWAY_TIMEOUT, {"error": "runtime did not respond"})
                     return

--- a/src/lerobot/runtime/playground_assets/__init__.py
+++ b/src/lerobot/runtime/playground_assets/__init__.py
@@ -1,0 +1,1 @@
+"""Static assets for the LeRobot Playground."""

--- a/src/lerobot/runtime/playground_assets/index.html
+++ b/src/lerobot/runtime/playground_assets/index.html
@@ -1,0 +1,122 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <meta name="color-scheme" content="dark" />
+    <title>LeRobot Playground</title>
+    <link rel="stylesheet" href="/playground.css" />
+  </head>
+  <body>
+    <div class="app-shell" data-chat-open="true" data-blog-open="false">
+      <header class="topbar">
+        <a class="brand" href="https://github.com/huggingface/lerobot" target="_blank" rel="noreferrer">
+          <span class="brand-mark">L</span>
+          <span><strong>LeRobot</strong><small>Playground</small></span>
+        </a>
+        <div class="selectors">
+          <label>Policy
+            <select id="policy">
+              <option value="runtime">Connected checkpoint</option>
+              <option value="pi05">π0.5</option>
+              <option value="smolvla">SmolVLA</option>
+              <option value="molmoact2">MolmoAct2</option>
+              <option value="groot">GR00T N1.7</option>
+            </select>
+          </label>
+          <label>Benchmark
+            <select id="benchmark">
+              <option value="robocasa">RoboCasa</option>
+              <option value="libero">LIBERO · coming next</option>
+              <option value="robotwin">RoboTwin · coming next</option>
+            </select>
+          </label>
+          <label>Scene
+            <select id="task">
+              <option>CloseFridge</option>
+              <option>OpenDrawer</option>
+              <option>LoadDishwasher</option>
+              <option>TurnOnSinkFaucet</option>
+              <option>PickPlaceCounterToCabinet</option>
+            </select>
+          </label>
+        </div>
+        <div class="header-actions">
+          <button id="blog-toggle" class="ghost" aria-expanded="false">Blog</button>
+          <button id="chat-toggle" class="ghost" aria-expanded="true">Chat</button>
+        </div>
+      </header>
+
+      <main class="stage">
+        <section class="viewer" aria-label="Robot simulation">
+          <img id="stream" src="/stream" alt="Live robot simulation" />
+          <div class="viewer-gradient"></div>
+          <div class="viewer-head">
+            <div class="live-pill"><span></span><b id="connection">Connecting</b></div>
+            <div class="camera-tabs">
+              <button class="active">Composite</button><button>Left</button><button>Wrist</button><button>Right</button>
+            </div>
+          </div>
+          <div class="runtime-card">
+            <p class="eyebrow">Runtime</p>
+            <div><span>Task</span><b id="active-task">No task selected</b></div>
+            <div><span>Subtask</span><b id="subtask">Waiting for policy</b></div>
+            <div><span>Memory</span><b id="memory">No observations yet</b></div>
+          </div>
+          <div class="transport">
+            <button id="pause" class="transport-button" title="Pause">Ⅱ</button>
+            <div class="prompt-wrap">
+              <input id="prompt" value="Close the refrigerator door" readonly />
+              <button id="unfreeze" class="mini-button">Unfreeze</button>
+            </div>
+            <button id="run" class="run-button">Run policy <span>→</span></button>
+            <button id="reset" class="transport-button" title="Reset scene">↻</button>
+          </div>
+        </section>
+
+        <aside class="chat-panel">
+          <div class="panel-header">
+            <div><p class="eyebrow">Language runtime</p><h2>Ask, steer, inspect</h2></div>
+            <button id="chat-close" class="icon-button" aria-label="Collapse chat">×</button>
+          </div>
+          <div class="planner-card">
+            <div>
+              <span class="planner-icon">✦</span>
+              <div><b>High-level planner</b><small>Qwen/Qwen3.5-2B · every <input id="planner-rate" type="number" value="1" min=".1" max="60" step=".1" />s</small></div>
+            </div>
+            <label class="switch"><input id="planner-enabled" type="checkbox" /><span></span></label>
+            <textarea id="planner-prompt">You are a high-level robot planner. Inspect the current camera image and goal, then emit only the next concrete subtask for the low-level VLA.</textarea>
+          </div>
+          <div id="messages" class="messages">
+            <article class="message assistant">
+              <span>LR</span><div><b>LeRobot</b><p>I’m connected to the live rollout. Ask about the current view, attach an image URL for VQA, or send a new instruction.</p></div>
+            </article>
+          </div>
+          <form id="chat-form" class="composer">
+            <div id="image-preview" class="image-preview" hidden><img alt="" /><span></span><button type="button">×</button></div>
+            <div id="image-row" class="image-row" hidden>
+              <input id="image-url" type="url" placeholder="https://…/image.jpg" />
+              <button id="attach-url" type="button">Attach</button>
+            </div>
+            <div class="composer-main">
+              <button id="image-button" type="button" class="icon-button" title="Add image from the internet">＋</button>
+              <textarea id="chat-input" rows="1" placeholder="Ask about the scene or steer the policy…"></textarea>
+              <select id="chat-mode" aria-label="Message mode"><option value="vqa">Ask</option><option value="action">Act</option></select>
+              <button class="send-button" aria-label="Send">↑</button>
+            </div>
+          </form>
+        </aside>
+
+        <aside class="blog-panel">
+          <div class="panel-header">
+            <div><p class="eyebrow">Deep dive</p><h2>Language-conditioned policies</h2></div>
+            <button id="blog-close" class="icon-button" aria-label="Collapse blog">×</button>
+          </div>
+          <iframe id="blog-frame" title="LeRobot language policy article"></iframe>
+        </aside>
+      </main>
+      <div id="toast" role="status"></div>
+    </div>
+    <script type="module" src="/playground.js"></script>
+  </body>
+</html>

--- a/src/lerobot/runtime/playground_assets/playground.css
+++ b/src/lerobot/runtime/playground_assets/playground.css
@@ -1,0 +1,115 @@
+:root {
+  --bg: #090b0e;
+  --panel: #11151a;
+  --panel-2: #171c22;
+  --line: rgba(255, 255, 255, 0.1);
+  --muted: #8b949e;
+  --text: #f4f7fa;
+  --yellow: #ffd21c;
+  --yellow-2: #f1b800;
+  font: 14px/1.4 Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* { box-sizing: border-box; }
+html, body { margin: 0; width: 100%; height: 100%; overflow: hidden; background: var(--bg); color: var(--text); }
+button, input, select, textarea { font: inherit; }
+button { cursor: pointer; }
+
+.app-shell { height: 100vh; display: grid; grid-template-rows: 72px minmax(0, 1fr); }
+.topbar { display: flex; align-items: center; gap: 24px; padding: 0 18px; border-bottom: 1px solid var(--line); background: rgba(9, 11, 14, .94); backdrop-filter: blur(20px); z-index: 20; }
+.brand { min-width: 175px; display: flex; align-items: center; gap: 11px; color: inherit; text-decoration: none; }
+.brand-mark { width: 38px; height: 38px; display: grid; place-items: center; border-radius: 11px; background: var(--yellow); color: #111; font-weight: 900; font-size: 20px; transform: rotate(-4deg); }
+.brand strong, .brand small { display: block; }
+.brand strong { font-size: 17px; letter-spacing: -.02em; }
+.brand small { color: var(--muted); font-size: 11px; text-transform: uppercase; letter-spacing: .13em; }
+.selectors { display: flex; gap: 8px; flex: 1; }
+.selectors label { color: var(--muted); font-size: 10px; text-transform: uppercase; letter-spacing: .11em; }
+.selectors select { display: block; width: 190px; margin-top: 3px; padding: 5px 28px 5px 0; color: var(--text); background: transparent; border: 0; outline: 0; font-weight: 650; text-transform: none; letter-spacing: 0; }
+.header-actions { display: flex; gap: 8px; }
+.ghost, .icon-button, .mini-button { color: var(--text); background: rgba(255,255,255,.05); border: 1px solid var(--line); border-radius: 9px; }
+.ghost { padding: 9px 14px; }
+.ghost[aria-expanded="true"] { color: #111; background: var(--yellow); border-color: var(--yellow); }
+
+.stage { min-height: 0; display: grid; grid-template-columns: minmax(0, 1fr) 390px 0; transition: grid-template-columns .35s cubic-bezier(.2,.7,.2,1); }
+.app-shell[data-chat-open="false"] .stage { grid-template-columns: minmax(0, 1fr) 0 0; }
+.app-shell[data-blog-open="true"] .stage { grid-template-columns: minmax(480px, 1fr) 0 minmax(430px, 46vw); }
+.app-shell[data-blog-open="true"][data-chat-open="true"] .stage { grid-template-columns: minmax(480px, 1fr) 390px minmax(430px, 40vw); }
+.viewer { position: relative; min-width: 0; overflow: hidden; background: radial-gradient(circle at 50% 30%, #26313c, #0d1014 64%); }
+.viewer::before { content:""; position:absolute; inset:0; opacity:.15; background-image: linear-gradient(rgba(255,255,255,.08) 1px,transparent 1px),linear-gradient(90deg,rgba(255,255,255,.08) 1px,transparent 1px); background-size: 48px 48px; }
+#stream, #demo-stream { position: absolute; inset: 0; width: 100%; height: 100%; object-fit: contain; }
+.viewer-gradient { position: absolute; inset: 0; pointer-events: none; background: linear-gradient(to bottom, rgba(4,6,8,.48), transparent 22%, transparent 62%, rgba(4,6,8,.8)); }
+.viewer-head { position: absolute; inset: 18px 20px auto; display: flex; justify-content: space-between; align-items: center; }
+.live-pill { display: flex; align-items: center; gap: 8px; padding: 7px 11px; border-radius: 999px; background: rgba(6,9,12,.7); border: 1px solid var(--line); backdrop-filter: blur(10px); font-size: 11px; text-transform: uppercase; letter-spacing: .08em; }
+.live-pill span { width: 7px; height: 7px; border-radius: 50%; background: #f97316; box-shadow: 0 0 0 4px rgba(249,115,22,.14); }
+.live-pill.connected span { background: #53d789; box-shadow: 0 0 0 4px rgba(83,215,137,.14); }
+.camera-tabs { display: flex; padding: 4px; border-radius: 10px; background: rgba(6,9,12,.7); border: 1px solid var(--line); backdrop-filter: blur(10px); }
+.camera-tabs button { border: 0; color: var(--muted); background: transparent; padding: 5px 9px; border-radius: 7px; font-size: 11px; }
+.camera-tabs .active { color: var(--text); background: rgba(255,255,255,.11); }
+.runtime-card { position: absolute; left: 20px; bottom: 106px; width: min(350px, calc(100% - 40px)); padding: 15px 17px; border: 1px solid var(--line); border-radius: 13px; background: rgba(9,12,16,.72); backdrop-filter: blur(14px); }
+.eyebrow { margin: 0 0 8px; color: var(--yellow); font-size: 9px; font-weight: 800; text-transform: uppercase; letter-spacing: .17em; }
+.runtime-card div { display: grid; grid-template-columns: 62px 1fr; gap: 8px; padding: 3px 0; }
+.runtime-card span { color: var(--muted); font-size: 11px; }
+.runtime-card b { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 12px; font-weight: 540; }
+.transport { position: absolute; left: 50%; bottom: 24px; transform: translateX(-50%); width: min(760px, calc(100% - 40px)); display: flex; gap: 8px; padding: 7px; border: 1px solid var(--line); border-radius: 15px; background: rgba(9,12,16,.82); backdrop-filter: blur(18px); }
+.transport-button { flex: 0 0 43px; border: 0; border-radius: 10px; color: var(--text); background: rgba(255,255,255,.07); font-size: 18px; }
+.prompt-wrap { position: relative; flex: 1; min-width: 0; }
+.prompt-wrap input { width: 100%; height: 44px; padding: 0 82px 0 13px; color: var(--text); background: var(--panel-2); border: 1px solid var(--line); border-radius: 10px; outline: 0; }
+.prompt-wrap input:not([readonly]) { border-color: rgba(255,210,28,.55); }
+.mini-button { position: absolute; right: 6px; top: 6px; height: 32px; padding: 0 9px; color: var(--yellow); font-size: 11px; }
+.run-button { border: 0; border-radius: 10px; padding: 0 18px; color: #111; background: var(--yellow); font-weight: 800; }
+.run-button:hover { background: #ffe15d; }
+
+.chat-panel, .blog-panel { min-width: 0; overflow: hidden; background: var(--panel); border-left: 1px solid var(--line); }
+.chat-panel { display: grid; grid-template-rows: auto auto minmax(0,1fr) auto; }
+.blog-panel { display: grid; grid-template-rows: auto minmax(0,1fr); }
+.panel-header { min-width: 360px; padding: 18px; display: flex; align-items: center; justify-content: space-between; border-bottom: 1px solid var(--line); }
+.panel-header .eyebrow { margin-bottom: 2px; }
+.panel-header h2 { margin: 0; font-size: 16px; letter-spacing: -.02em; }
+.icon-button { width: 34px; height: 34px; font-size: 18px; }
+.planner-card { min-width: 360px; margin: 14px; padding: 13px; border: 1px solid rgba(255,210,28,.2); border-radius: 12px; background: linear-gradient(135deg, rgba(255,210,28,.08), rgba(255,255,255,.03)); }
+.planner-card > div:first-child { display: flex; align-items: center; gap: 9px; padding-right: 42px; }
+.planner-icon { width: 28px; height: 28px; display: grid; place-items:center; border-radius: 8px; color: #111; background: var(--yellow); }
+.planner-card b, .planner-card small { display: block; }
+.planner-card small { color: var(--muted); font-size: 10px; }
+.planner-card small input { width: 36px; color: var(--text); background: transparent; border: 0; border-bottom: 1px solid var(--line); }
+.switch { position: absolute; margin: -27px 0 0 310px; }
+.switch input { display: none; }
+.switch span { display:block; width: 34px; height: 20px; border-radius:999px; background:#343a42; padding:3px; transition:.2s; }
+.switch span::before { content:""; display:block; width:14px; height:14px; border-radius:50%; background:white; transition:.2s; }
+.switch input:checked + span { background:var(--yellow); }
+.switch input:checked + span::before { transform:translateX(14px); background:#111; }
+.planner-card textarea { display:none; width:100%; height:74px; margin-top:12px; padding:9px; resize:none; color:var(--text); background:rgba(0,0,0,.24); border:1px solid var(--line); border-radius:8px; font-size:11px; }
+.planner-card:has(input:checked) textarea { display:block; }
+.messages { min-width: 360px; overflow-y: auto; padding: 4px 16px 18px; }
+.message { display: flex; gap: 10px; margin: 16px 0; }
+.message > span { flex: 0 0 28px; height: 28px; display:grid; place-items:center; border-radius:8px; background:var(--yellow); color:#111; font-size:10px; font-weight:900; }
+.message.user > span { background:#363e47; color:var(--text); }
+.message b { font-size:11px; }
+.message p { margin:4px 0 0; color:#d5d9df; font-size:12px; white-space:pre-wrap; }
+.message img { display:block; max-width:180px; max-height:120px; object-fit:cover; margin-top:7px; border-radius:8px; border:1px solid var(--line); }
+.composer { min-width:360px; padding:12px; border-top:1px solid var(--line); }
+.composer-main { display:flex; align-items:flex-end; gap:7px; padding:7px; background:var(--panel-2); border:1px solid var(--line); border-radius:12px; }
+.composer textarea { flex:1; max-height:100px; resize:none; color:var(--text); background:transparent; border:0; outline:0; padding:7px 3px; font-size:12px; }
+.composer select { align-self:center; color:var(--muted); background:transparent; border:0; outline:0; font-size:11px; }
+.send-button { flex:0 0 34px; height:34px; border:0; border-radius:9px; color:#111; background:var(--yellow); font-weight:900; }
+.image-row { display:flex; gap:7px; margin-bottom:8px; }
+.image-row input { flex:1; min-width:0; color:var(--text); background:var(--panel-2); border:1px solid var(--line); border-radius:8px; padding:8px; }
+.image-row button { color:#111; background:var(--yellow); border:0; border-radius:8px; font-weight:700; }
+.image-preview { align-items:center; gap:8px; margin-bottom:8px; padding:7px; border:1px solid var(--line); border-radius:9px; background:var(--panel-2); }
+.image-preview:not([hidden]) { display:flex; }
+.image-preview img { width:42px; height:42px; object-fit:cover; border-radius:6px; }
+.image-preview span { flex:1; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; color:var(--muted); font-size:10px; }
+.image-preview button { border:0; color:var(--text); background:transparent; }
+.blog-panel iframe { width:100%; height:100%; border:0; background:white; }
+#toast { position:fixed; left:50%; bottom:28px; z-index:50; transform:translate(-50%,18px); opacity:0; pointer-events:none; padding:10px 14px; border-radius:9px; color:var(--text); background:#242a31; border:1px solid var(--line); transition:.2s; }
+#toast.show { transform:translate(-50%,0); opacity:1; }
+
+@media (max-width: 900px) {
+  .topbar { gap:10px; }
+  .selectors label:not(:first-child) { display:none; }
+  .selectors select { width:150px; }
+  .stage, .app-shell[data-chat-open="true"] .stage, .app-shell[data-blog-open="true"] .stage { grid-template-columns: minmax(0,1fr); }
+  .chat-panel, .blog-panel { position:absolute; inset:72px 0 0; z-index:15; }
+  .app-shell[data-chat-open="false"] .chat-panel, .app-shell[data-blog-open="false"] .blog-panel { display:none; }
+  .runtime-card { bottom:112px; }
+}

--- a/src/lerobot/runtime/playground_assets/playground.js
+++ b/src/lerobot/runtime/playground_assets/playground.js
@@ -215,6 +215,11 @@ async function refresh() {
     $("#subtask").textContent = state.language_context?.subtask || "Waiting for policy";
     $("#memory").textContent = state.language_context?.memory || "No observations yet";
     $("#policy").selectedOptions[0].textContent = data.policy_path || "Connected checkpoint";
+    const planner = data.capabilities?.planner;
+    if (planner?.model) {
+      document.querySelector(".planner-card small").childNodes[0].textContent = `${planner.model} · every `;
+    }
+    $("#planner-enabled").disabled = planner?.available === false;
     if (data.blog_url && !$("#blog-frame").src) $("#blog-frame").src = data.blog_url;
   } catch {
     activateDemoMode();

--- a/src/lerobot/runtime/playground_assets/playground.js
+++ b/src/lerobot/runtime/playground_assets/playground.js
@@ -1,0 +1,224 @@
+const shell = document.querySelector(".app-shell");
+const $ = (selector) => document.querySelector(selector);
+let attachedImage = "";
+let toastTimer;
+let plannerTimer;
+let plannerBusy = false;
+let demoMode = false;
+
+function toast(text) {
+  const node = $("#toast");
+  node.textContent = text;
+  node.classList.add("show");
+  clearTimeout(toastTimer);
+  toastTimer = setTimeout(() => node.classList.remove("show"), 2600);
+}
+
+async function api(path, payload) {
+  if (demoMode) {
+    await new Promise((resolve) => setTimeout(resolve, 350));
+    if (payload.kind === "vqa") {
+      return { answer: payload.image_url
+        ? "I can see the attached reference image. Connect a VQA-capable checkpoint to ground this answer in model inference."
+        : "This Space is showing a recorded rollout preview. Start a live language runtime to ground answers in the current camera frame." };
+    }
+    if (payload.kind === "planner") return { answer: "Move the gripper toward the target handle." };
+    return { ok: true };
+  }
+  const response = await fetch(path, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  const data = await response.json();
+  if (!response.ok) throw new Error(data.error || "Request failed");
+  return data;
+}
+
+function activateDemoMode() {
+  if (demoMode) return;
+  demoMode = true;
+  const stream = $("#stream");
+  const video = document.createElement("video");
+  video.id = "demo-stream";
+  video.src = "/playground-demo.mp4";
+  video.autoplay = true;
+  video.loop = true;
+  video.muted = true;
+  video.playsInline = true;
+  stream.replaceWith(video);
+  $("#connection").textContent = "Preview · replay";
+  $(".live-pill").classList.remove("connected");
+  $("#active-task").textContent = $("#prompt").value;
+  $("#subtask").textContent = "Recorded policy rollout";
+  $("#memory").textContent = "Connect the runtime for live state";
+  $("#policy").selectedOptions[0].textContent = "Preview checkpoint";
+}
+
+function setPanel(name, open) {
+  if (name === "chat" && open) {
+    shell.dataset.blogOpen = "false";
+    $("#blog-toggle").setAttribute("aria-expanded", "false");
+  }
+  if (name === "blog" && open) {
+    shell.dataset.chatOpen = "false";
+    $("#chat-toggle").setAttribute("aria-expanded", "false");
+  }
+  shell.dataset[`${name}Open`] = String(open);
+  $(`#${name}-toggle`).setAttribute("aria-expanded", String(open));
+}
+
+$("#chat-toggle").onclick = () => setPanel("chat", shell.dataset.chatOpen !== "true");
+$("#chat-close").onclick = () => setPanel("chat", false);
+$("#blog-toggle").onclick = () => setPanel("blog", shell.dataset.blogOpen !== "true");
+$("#blog-close").onclick = () => setPanel("blog", false);
+
+$("#unfreeze").onclick = () => {
+  const input = $("#prompt");
+  const willUnlock = input.hasAttribute("readonly");
+  input.toggleAttribute("readonly", !willUnlock);
+  $("#unfreeze").textContent = willUnlock ? "Lock" : "Unfreeze";
+  if (willUnlock) input.focus();
+};
+
+$("#run").onclick = async () => {
+  const task = $("#prompt").value.trim();
+  if (!task) return toast("Enter a task first");
+  try {
+    await api("/api/command", { kind: "action", text: task, scene: $("#task").value });
+    toast("Policy running");
+  } catch (error) { toast(error.message); }
+};
+$("#pause").onclick = () => api("/api/command", { kind: "pause" }).then(() => toast("Paused")).catch((e) => toast(e.message));
+$("#reset").onclick = () => api("/api/command", { kind: "reset" }).then(() => toast("Scene reset")).catch((e) => toast(e.message));
+$("#task").onchange = (event) => {
+  const readable = event.target.selectedOptions[0].text.replace(/([a-z])([A-Z])/g, "$1 $2");
+  $("#prompt").value = readable;
+};
+$("#benchmark").onchange = (event) => {
+  if (event.target.value !== "robocasa") {
+    toast(`${event.target.selectedOptions[0].textContent} is catalogued but not enabled by this runtime`);
+    event.target.value = "robocasa";
+  }
+};
+$("#policy").onchange = (event) => {
+  if (event.target.value !== "runtime") {
+    toast("Checkpoint hot-swap requires starting a new runtime session");
+    event.target.value = "runtime";
+  }
+};
+
+function addMessage(role, text, imageUrl = "") {
+  const article = document.createElement("article");
+  article.className = `message ${role}`;
+  const avatar = document.createElement("span");
+  avatar.textContent = role === "user" ? "YOU" : "LR";
+  const body = document.createElement("div");
+  const name = document.createElement("b");
+  name.textContent = role === "user" ? "You" : "LeRobot";
+  const copy = document.createElement("p");
+  copy.textContent = text;
+  body.append(name, copy);
+  if (imageUrl) {
+    const image = document.createElement("img");
+    image.src = imageUrl;
+    image.alt = "VQA attachment";
+    body.append(image);
+  }
+  article.append(avatar, body);
+  $("#messages").append(article);
+  $("#messages").scrollTop = $("#messages").scrollHeight;
+}
+
+$("#image-button").onclick = () => {
+  $("#image-row").hidden = !$("#image-row").hidden;
+  if (!$("#image-row").hidden) $("#image-url").focus();
+};
+$("#attach-url").onclick = () => {
+  const value = $("#image-url").value.trim();
+  try { new URL(value); } catch { return toast("Enter a valid image URL"); }
+  attachedImage = value;
+  $("#image-preview img").src = value;
+  $("#image-preview span").textContent = value;
+  $("#image-preview").hidden = false;
+  $("#image-row").hidden = true;
+};
+$("#image-preview button").onclick = () => {
+  attachedImage = "";
+  $("#image-preview").hidden = true;
+  $("#image-url").value = "";
+};
+
+$("#chat-form").onsubmit = async (event) => {
+  event.preventDefault();
+  const input = $("#chat-input");
+  const text = input.value.trim();
+  if (!text) return;
+  const kind = $("#chat-mode").value;
+  const imageUrl = attachedImage;
+  addMessage("user", text, imageUrl);
+  input.value = "";
+  $("#image-preview button").click();
+  try {
+    if (kind === "action") {
+      await api("/api/command", { kind: "action", text });
+      addMessage("assistant", `Running: ${text}`);
+    } else {
+      const response = await api("/api/chat", { kind: "vqa", text, image_url: imageUrl || undefined });
+      addMessage("assistant", response.answer || "The policy returned no answer.");
+    }
+  } catch (error) {
+    addMessage("assistant", `I couldn't complete that request: ${error.message}`);
+  }
+};
+
+function configurePlanner() {
+  clearInterval(plannerTimer);
+  plannerTimer = undefined;
+  if (!$("#planner-enabled").checked) return;
+  const intervalMs = Math.max(250, Number($("#planner-rate").value || 1) * 1000);
+  const plan = async () => {
+    if (plannerBusy) return;
+    plannerBusy = true;
+    try {
+      const response = await api("/api/chat", {
+        kind: "planner",
+        text: $("#prompt").value.trim(),
+        planner_prompt: $("#planner-prompt").value.trim(),
+      });
+      if (response.answer) {
+        $("#subtask").textContent = response.answer;
+        addMessage("assistant", `Next subtask: ${response.answer}`);
+      }
+    } catch (error) {
+      $("#planner-enabled").checked = false;
+      clearInterval(plannerTimer);
+      toast(`Planner stopped: ${error.message}`);
+    } finally {
+      plannerBusy = false;
+    }
+  };
+  plan();
+  plannerTimer = setInterval(plan, intervalMs);
+}
+$("#planner-enabled").onchange = configurePlanner;
+$("#planner-rate").onchange = configurePlanner;
+
+async function refresh() {
+  try {
+    const response = await fetch("/api/state", { cache: "no-store" });
+    const data = await response.json();
+    const state = data.state || {};
+    $(".live-pill").classList.toggle("connected", Boolean(data.connected));
+    $("#connection").textContent = data.connected ? (state.mode === "action" ? "Live · running" : "Live · paused") : "Waiting for runtime";
+    $("#active-task").textContent = state.task || "No task selected";
+    $("#subtask").textContent = state.language_context?.subtask || "Waiting for policy";
+    $("#memory").textContent = state.language_context?.memory || "No observations yet";
+    $("#policy").selectedOptions[0].textContent = data.policy_path || "Connected checkpoint";
+    if (data.blog_url && !$("#blog-frame").src) $("#blog-frame").src = data.blog_url;
+  } catch {
+    activateDemoMode();
+  }
+}
+refresh();
+setInterval(refresh, 900);

--- a/tests/runtime/test_playground.py
+++ b/tests/runtime/test_playground.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import sys
 import threading
 from types import SimpleNamespace
 from urllib.request import urlopen
@@ -10,6 +11,7 @@ import torch
 from PIL import Image
 
 from lerobot.runtime.playground import (
+    LazyQwenPlanner,
     PlaygroundController,
     replace_observation_image_from_url,
     start_playground_server,
@@ -28,7 +30,11 @@ def test_controller_exposes_runtime_state_and_messages():
             "revision": 3,
         }.get(key, default),
     )
-    controller = PlaygroundController(policy_path="lerobot/test-policy", blog_url="/blog/")
+    controller = PlaygroundController(
+        policy_path="lerobot/test-policy",
+        blog_url="/blog/",
+        planner=LazyQwenPlanner(),
+    )
     controller.attach(SimpleNamespace(state=state), SimpleNamespace())
     controller.add_message("user", "What is open?")
 
@@ -39,6 +45,11 @@ def test_controller_exposes_runtime_state_and_messages():
     assert snapshot["state"]["queued_actions"] == 2
     assert snapshot["messages"][0]["text"] == "What is open?"
     assert snapshot["blog_url"] == "/blog/"
+    assert snapshot["capabilities"]["planner"] == {
+        "available": True,
+        "model": "Qwen/Qwen3.5-2B",
+        "loaded": False,
+    }
 
 
 def test_command_queue_round_trip():
@@ -68,6 +79,70 @@ def test_server_serves_playground_and_state():
 
     assert "<title>LeRobot Playground</title>" in page
     assert '"policy_path":"lerobot/test-policy"' in state
+
+
+def test_qwen_planner_loads_lazily_and_generates_subtask(monkeypatch):
+    calls = {}
+
+    class Inputs(dict):
+        def to(self, device):
+            calls["input_device"] = str(device)
+            return self
+
+    class Processor:
+        @classmethod
+        def from_pretrained(cls, path):
+            calls["processor_path"] = path
+            return cls()
+
+        def apply_chat_template(self, messages, **kwargs):
+            calls["messages"] = messages
+            calls["template_kwargs"] = kwargs
+            return Inputs(input_ids=torch.zeros((1, 3), dtype=torch.long))
+
+        def decode(self, tokens, **kwargs):
+            calls["decoded_tokens"] = tokens
+            calls["decode_kwargs"] = kwargs
+            return "grasp the refrigerator handle"
+
+    class Model:
+        device = torch.device("cpu")
+
+        @classmethod
+        def from_pretrained(cls, path, **kwargs):
+            calls["model_path"] = path
+            calls["model_kwargs"] = kwargs
+            return cls()
+
+        def to(self, device):
+            self.device = torch.device(device)
+            return self
+
+        def eval(self):
+            calls["eval"] = True
+
+        def generate(self, **kwargs):
+            calls["generate_kwargs"] = kwargs
+            return torch.tensor([[0, 0, 0, 7]])
+
+    monkeypatch.setitem(
+        sys.modules,
+        "transformers",
+        SimpleNamespace(AutoModelForMultimodalLM=Model, AutoProcessor=Processor),
+    )
+    planner = LazyQwenPlanner(device="cpu")
+
+    answer = planner.plan(
+        "close the fridge",
+        {"observation.images.main": torch.zeros((1, 3, 8, 8))},
+        system_prompt="Return the next subtask.",
+    )
+
+    assert answer == "grasp the refrigerator handle"
+    assert planner.loaded is True
+    assert calls["model_path"] == "Qwen/Qwen3.5-2B"
+    assert calls["messages"][1]["content"][0]["url"].startswith("data:image/png;base64,")
+    assert calls["generate_kwargs"]["max_new_tokens"] == 80
 
 
 def test_remote_image_replaces_first_observation_image(monkeypatch):

--- a/tests/runtime/test_playground.py
+++ b/tests/runtime/test_playground.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python
+
+import threading
+from types import SimpleNamespace
+from urllib.request import urlopen
+
+import numpy as np
+import pytest
+import torch
+from PIL import Image
+
+from lerobot.runtime.playground import (
+    PlaygroundController,
+    replace_observation_image_from_url,
+    start_playground_server,
+)
+
+
+def test_controller_exposes_runtime_state_and_messages():
+    state = SimpleNamespace(
+        lock=threading.RLock(),
+        get=lambda key, default=None: {
+            "mode": "paused",
+            "task": "close the fridge",
+            "language_context": {"subtask": "reach for the handle"},
+            "action_queue": [1, 2],
+            "actions_dispatched": 7,
+            "revision": 3,
+        }.get(key, default),
+    )
+    controller = PlaygroundController(policy_path="lerobot/test-policy", blog_url="/blog/")
+    controller.attach(SimpleNamespace(state=state), SimpleNamespace())
+    controller.add_message("user", "What is open?")
+
+    snapshot = controller.snapshot()
+
+    assert snapshot["connected"] is True
+    assert snapshot["state"]["task"] == "close the fridge"
+    assert snapshot["state"]["queued_actions"] == 2
+    assert snapshot["messages"][0]["text"] == "What is open?"
+    assert snapshot["blog_url"] == "/blog/"
+
+
+def test_command_queue_round_trip():
+    controller = PlaygroundController(policy_path="lerobot/test-policy")
+    command = controller.enqueue("pause")
+
+    assert controller.next_command() is command
+    controller.finish(command, result={"mode": "paused"})
+
+    assert command.completed.is_set()
+    assert command.result == {"mode": "paused"}
+    assert command.error is None
+
+
+def test_server_serves_playground_and_state():
+    controller = PlaygroundController(policy_path="lerobot/test-policy")
+    server = start_playground_server(0, lambda: None, controller)
+    assert server is not None
+    port = server.server_address[1]
+    try:
+        with urlopen(f"http://127.0.0.1:{port}/", timeout=2) as response:  # noqa: S310
+            page = response.read().decode()
+        with urlopen(f"http://127.0.0.1:{port}/api/state", timeout=2) as response:  # noqa: S310
+            state = response.read().decode()
+    finally:
+        server.shutdown()
+
+    assert "<title>LeRobot Playground</title>" in page
+    assert '"policy_path":"lerobot/test-policy"' in state
+
+
+def test_remote_image_replaces_first_observation_image(monkeypatch):
+    image = Image.new("RGB", (16, 8), (255, 0, 0))
+    buffer = __import__("io").BytesIO()
+    image.save(buffer, format="PNG")
+
+    class Response:
+        headers = {"Content-Type": "image/png"}
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def read(self, _size):
+            return buffer.getvalue()
+
+    monkeypatch.setattr(
+        "lerobot.runtime.playground.socket.getaddrinfo",
+        lambda *_args, **_kwargs: [(None, None, None, None, ("93.184.216.34", 443))],
+    )
+    monkeypatch.setattr(
+        "lerobot.runtime.playground.build_opener",
+        lambda *_args, **_kwargs: SimpleNamespace(open=lambda *_args, **_kwargs: Response()),
+    )
+    observation = {
+        "observation.images.main": torch.zeros((1, 3, 4, 6)),
+        "observation.state": torch.zeros((1, 7)),
+    }
+
+    result = replace_observation_image_from_url(observation, "https://example.com/frame.png")
+
+    assert result is not observation
+    assert result["observation.images.main"].shape == (1, 3, 4, 6)
+    assert torch.allclose(result["observation.images.main"][:, 0], torch.ones((1, 4, 6)))
+    assert torch.count_nonzero(result["observation.images.main"][:, 1:]) == 0
+    assert result["observation.state"] is observation["observation.state"]
+
+
+@pytest.mark.parametrize(
+    "resolved_address",
+    ["127.0.0.1", "10.0.0.2", "169.254.169.254", "::1"],
+)
+def test_remote_image_rejects_private_targets(monkeypatch, resolved_address):
+    monkeypatch.setattr(
+        "lerobot.runtime.playground.socket.getaddrinfo",
+        lambda *_args, **_kwargs: [(None, None, None, None, (resolved_address, 80))],
+    )
+
+    with pytest.raises(ValueError, match="public address"):
+        replace_observation_image_from_url(
+            {"observation.images.main": torch.zeros((1, 3, 4, 6))},
+            "http://example.test/frame.png",
+        )
+
+
+def test_remote_image_supports_channel_last_observation(monkeypatch):
+    image = Image.fromarray(np.full((2, 2, 3), 127, dtype=np.uint8))
+    buffer = __import__("io").BytesIO()
+    image.save(buffer, format="PNG")
+
+    class Response:
+        headers = {"Content-Type": "image/png"}
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def read(self, _size):
+            return buffer.getvalue()
+
+    monkeypatch.setattr(
+        "lerobot.runtime.playground.socket.getaddrinfo",
+        lambda *_args, **_kwargs: [(None, None, None, None, ("93.184.216.34", 443))],
+    )
+    monkeypatch.setattr(
+        "lerobot.runtime.playground.build_opener",
+        lambda *_args, **_kwargs: SimpleNamespace(open=lambda *_args, **_kwargs: Response()),
+    )
+
+    result = replace_observation_image_from_url(
+        {"observation.image": torch.zeros((8, 10, 3))},
+        "https://example.com/frame.png",
+    )
+
+    assert result["observation.image"].shape == (8, 10, 3)


### PR DESCRIPTION
## Summary

- add a full-screen browser playground on top of the language runtime from #4183
- replace the simulator's minimal MJPEG page with task, pause/resume, reset, and live runtime-state controls
- add a collapsible right-side chat for grounded VQA and direct action steering
- support public image URLs as VQA observations with private/local-address and redirect validation
- add a lazily loaded `Qwen/Qwen3.5-2B` visual planner that turns the current frame and goal into timed low-level subtasks
- keep the planner disabled by default and add a collapsible language-policy blog
- package the browser assets in the LeRobot wheel and document the simulator workflow

## Stack

This PR is intentionally based on `codex/language-runtime` / #4183. It should be reviewed and merged after that PR.

## Benchmark scope

RoboCasa is live because #4183 already provides its persistent-environment backend. LIBERO and RoboTwin are visible as upcoming adapters but remain disabled until their persistent simulator backends implement the same runtime contract; the UI does not pretend those environments are currently executable.

## Space

The existing `lerobot/language-conditioned-policies` Space is renamed to **LeRobot Playground**. Its CPU deployment uses a recorded RoboCasa rollout preview and keeps the existing article at `/blog/`; a live GPU runtime uses this PR's `/api/*` controller and MJPEG stream.

## Validation

- `uv run ruff check src/lerobot/runtime/playground.py src/lerobot/runtime/cli.py tests/runtime/test_playground.py`
- `uv run --extra test pytest tests/runtime/test_playground.py tests/runtime/test_cli.py tests/runtime/test_sim_robocasa.py -q` — 16 passed
- `uv build --wheel` and verified the wheel contains all Playground assets
- local Astro production build and browser interaction checks for the Space shell, chat/blog drawers, and image URL attachment
