### PR TITLE
perf(libero): skip the discarded scene rebuild on reset

### DIFF
--- a/src/lerobot/envs/libero.py
+++ b/src/lerobot/envs/libero.py
@@ -265,6 +265,24 @@ class LiberoEnv(gym.Env):
             camera_heights=self.observation_height,
             camera_widths=self.observation_width,
             control_freq=self.control_freq,
+            # LIBERO defaults to hard_reset=True, which makes every reset() free the
+            # MjSim, re-serialise the scene with model.get_xml(), recompile it with
+            # MjSim.from_xml_string(), build a fresh offscreen GL context and re-wire
+            # every observable. When init states are in use, reset() is immediately
+            # followed by set_init_state(), which overwrites the whole sim state, so
+            # all of that work is discarded. Measured 1.0-1.5 s/episode across the four
+            # suites. Without init states the randomisation performed by reset() is the
+            # only thing placing the objects, so it must be kept.
+            #
+            # Equivalence, measured: immediately after set_init_state, qpos, qvel, ctrl
+            # and act are bit-identical between the two paths. After the 10 settle steps
+            # 9 of 41 qpos entries differ -- robot0_joint1..7 and the two gripper finger
+            # joints -- by at most 2.1e-4 rad. No object joint differs on any suite. The
+            # drift comes from the settle action's gripper command ([0]*6 + [-1]); with a
+            # zero action the two paths stay bit-identical. Wrist-camera pixels can differ
+            # by up to ~87/255 because a sub-millimetre finger shift crosses rasterisation
+            # boundaries at 256x256, so pixel deltas overstate the physical difference.
+            hard_reset=not self.init_states,
         )
         env.reset()
         self._env = env

--- a/tests/envs/test_libero_reset.py
+++ b/tests/envs/test_libero_reset.py
@@ -1,0 +1,94 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Reset-path behaviour of `LiberoEnv`.
+
+`reset()` is immediately followed by `set_init_state()` whenever init states are
+in use, so the scene rebuild that LIBERO's default `hard_reset=True` performs is
+discarded. These tests pin the resulting wiring: soft reset when init states
+place the objects, hard reset when `reset()` is the only thing that does.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import Mock
+
+import numpy as np
+import pytest
+
+from lerobot.envs import libero as libero_env
+
+
+class _FakeTask:
+    name = "fake_task"
+    language = "do the thing"
+    problem_folder = "fake_folder"
+    bddl_file = "fake.bddl"
+
+
+class _FakeTaskSuite:
+    def get_task(self, task_id: int) -> _FakeTask:  # noqa: ARG002
+        return _FakeTask()
+
+
+def _build_env(monkeypatch: pytest.MonkeyPatch, *, init_states: bool) -> tuple[Any, Mock]:
+    """Instantiate a `LiberoEnv` with the simulator stubbed out.
+
+    Returns the env plus the `OffScreenRenderEnv` mock, so the constructor kwargs
+    can be inspected without allocating a MuJoCo model or a GL context.
+    """
+    offscreen = Mock(name="OffScreenRenderEnv")
+    monkeypatch.setattr(libero_env, "OffScreenRenderEnv", offscreen)
+    monkeypatch.setattr(libero_env, "get_libero_path", lambda _key: "/tmp/libero")
+    monkeypatch.setattr(
+        libero_env, "get_task_init_states", lambda *_a, **_k: np.zeros((2, 8), dtype=np.float64)
+    )
+
+    env = libero_env.LiberoEnv(
+        task_suite=_FakeTaskSuite(),
+        task_id=0,
+        task_suite_name="libero_spatial",
+        init_states=init_states,
+    )
+    env._ensure_env()
+    return env, offscreen
+
+
+def test_init_states_use_a_soft_reset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With init states, `set_init_state()` overwrites the state `reset()` produced.
+
+    The model rebuild, GL-context recreation and observable re-wiring that
+    `hard_reset=True` performs are therefore pure overhead (measured 1.0-1.5 s per
+    episode across the four suites).
+
+    This test pins the wiring only. End-to-end equivalence is NOT established: the
+    two paths agree bit-for-bit with `num_steps_wait=0` but diverge with the default
+    of 10, and that is unresolved.
+    """
+    _, offscreen = _build_env(monkeypatch, init_states=True)
+
+    assert offscreen.call_count == 1
+    assert offscreen.call_args.kwargs["hard_reset"] is False
+
+
+def test_without_init_states_the_hard_reset_is_kept(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without init states, `reset()` is the only thing placing the objects.
+
+    Model-level randomisation happens in `_load_model()`, which a soft reset skips,
+    so the hard reset has to stay.
+    """
+    _, offscreen = _build_env(monkeypatch, init_states=False)
+
+    assert offscreen.call_count == 1
+    assert offscreen.call_args.kwargs["hard_reset"] is True


### PR DESCRIPTION
## Title

perf(libero): skip the discarded scene rebuild on reset

## Summary / Motivation

`LiberoEnv.reset()` calls `self._env.reset()` and then immediately calls
`set_init_state()`, which overwrites the entire simulator state. Because LIBERO's
`OffScreenRenderEnv` inherits `hard_reset=True`, that `reset()` does a lot of work
that is then thrown away — per episode, per environment:

- `_destroy_sim()` frees the `MjSim` and the offscreen render context
- `_load_model()` rebuilds the scene and re-runs the placement sampler
- `_initialize_sim()` serialises the whole model with `model.get_xml()` and
  recompiles it via `MjSim.from_xml_string()`, reloading mesh assets
- `_reset_internal()` then constructs a **fresh `MjRenderContextOffscreen`**
- `_setup_observables()` re-wires every observable

This passes `hard_reset=not init_states`. When init states are in use (the default)
the objects are placed by `set_init_state()`, so the rebuild is redundant. When they
are not, `reset()`'s randomisation is the only thing placing objects, so the hard
reset is kept.

Trade-off: this is **not bit-identical end to end** — see the equivalence section
below. The difference is 0.012° of gripper drift and does not touch object placement.
I'd rather put that in front of a reviewer than bury it.

## Related issues

- Related: #4224 (also touches `LiberoEnv.reset()`, for init-state index allocation —
  no functional overlap, but they will conflict textually)
- Context for the reproducibility reports: #2354, #2533, #3638, #4206, #3633

## What changed

- `LiberoEnv._ensure_env()` now passes `hard_reset=not self.init_states` to
  `OffScreenRenderEnv`.
- No configuration or public API change.

## Measured

RTX 3060 Ti, EGL, robosuite 1.4.0, mujoco 3.2.7, 256×256 ×2 cameras. Timed through
`LiberoEnv.reset()`, fresh env per arm, warmup discarded, arms alternated:

| suite | hard | soft | saved |
|---|---|---|---|
| libero_spatial | 1697 ms | 233 ms | **1464 ms** |
| libero_object | 1394 ms | 172 ms | 1222 ms |
| libero_goal | 1177 ms | 164 ms | 1013 ms |
| libero_10 | 1528 ms | 207 ms | 1321 ms |

The isolated `reset()` + `set_init_state()` call alone is 32–104× cheaper; end to end
the ratio is ~7–8× because the `num_steps_wait=10` settle steps are unchanged.

This matters most for fast policies. For a 3B VLA at ~50 s/episode it is ~2% of
wall-clock; for ACT it is closer to 20%.

## Equivalence

Immediately after `set_init_state()`, `qpos`, `qvel`, `ctrl` and `act` are
**bit-identical** between the two paths on all four suites.

After the 10 settle steps that `reset()` runs, 9 of 41 `qpos` entries differ:

| entry | max delta |
|---|---|
| `robot0_joint1..7` | ≤ 2.4e-5 rad |
| `gripper0_finger_joint1/2` | ≤ 2.1e-4 rad (0.012°) |
| any object joint | **0** on every suite |

The drift is driven by the gripper component of the settle action
(`get_libero_dummy_action()` → `[0,0,0,0,0,0,-1]`). Replacing it with zeros keeps the
two paths bit-identical for 12 further steps, and with `num_steps_wait=0` there is no
divergence at all.

Wrist-camera pixels can differ by up to ~87/255. That number is misleading: a
sub-millimetre finger displacement crosses rasterisation boundaries at 256×256 on a
camera mounted centimetres away. `qpos` is the honest metric here.

Each path is internally deterministic — repeated runs within an arm are bit-identical.

**For reviewers:** the judgement call is whether 0.012° of gripper drift during the
settle phase is acceptable. It does not change object placement, which is what the
fixed init states exist to control. If you would rather it were exactly bit-identical,
the alternative is to zero the gripper component of the settle action, which is a
larger behavioural change than this PR.

## How was this tested

- New `tests/envs/test_libero_reset.py` (2 tests) pinning the wiring in both
  directions — soft reset with init states, hard reset without.
  `pytest tests/envs/test_libero_reset.py`
- Equivalence and timing measured end to end through `LiberoEnv.reset()` on all four
  suites, as above.
- `ruff format --check` and `ruff check` clean on both files.

## Checklist (required before merge)

- [x] Linting/formatting run (`ruff format --check`, `ruff check` — both clean)
- [x] Tests pass locally (`pytest tests/envs/test_libero_reset.py` → 2 passed)
- [ ] Documentation updated (no user-facing behaviour change)
- [ ] CI is green
- [ ] Community Review — happy to do one, tell me which PR would be most useful

## Reviewer notes

- The equivalence section is the part worth your attention, not the timings.
- This conflicts textually with #4224; I'm happy to rebase after that lands.
