### PR TITLE
fix(libero): don't reset inside step() on termination

### DIFF
--- a/src/lerobot/envs/libero.py
+++ b/src/lerobot/envs/libero.py
@@ -377,8 +377,11 @@ class LiberoEnv(gym.Env):
             }
         )
         observation = self._format_raw_obs(raw_obs)
-        if terminated:
-            self.reset()
+        # No reset here. `observation` above is the terminal observation, so a reset's
+        # return value would be discarded -- and Gymnasium's vector envs default to
+        # AutoresetMode.NEXT_STEP, which resets this sub-env on the following step
+        # anyway. Resetting here made every termination pay two full resets and
+        # advance `init_state_id` twice, skipping an initial state per episode.
         truncated = False
         return observation, reward, terminated, truncated, info
 

--- a/tests/envs/test_libero_termination.py
+++ b/tests/envs/test_libero_termination.py
@@ -1,0 +1,98 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""`LiberoEnv.step` must not reset on termination.
+
+Gymnasium's vector envs default to `AutoresetMode.NEXT_STEP`, so a sub-env that
+resets itself inside `step()` is reset twice per termination -- once by itself and
+once by the vector env on the following step. Besides the wasted work, each reset
+advances `init_state_id` by `_reset_stride`, so the self-reset silently skipped an
+initial state per episode.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import Mock
+
+import gymnasium as gym
+import numpy as np
+import pytest
+
+from lerobot.envs import libero as libero_env
+
+
+class _FakeTask:
+    name = "fake_task"
+    language = "do the thing"
+    problem_folder = "fake_folder"
+    bddl_file = "fake.bddl"
+
+
+class _FakeTaskSuite:
+    def get_task(self, task_id: int) -> _FakeTask:  # noqa: ARG002
+        return _FakeTask()
+
+
+def _make_env(monkeypatch: pytest.MonkeyPatch, *, n_envs: int = 1) -> Any:
+    """A LiberoEnv whose simulator is a mock that always reports success."""
+    inner = Mock(name="OffScreenRenderEnv")
+    inner.step.return_value = ({"agentview_image": np.zeros((256, 256, 3), dtype=np.uint8)}, 0.0, False, {})
+    inner.check_success.return_value = True
+    inner.robots = []
+
+    monkeypatch.setattr(libero_env, "OffScreenRenderEnv", Mock(return_value=inner))
+    monkeypatch.setattr(libero_env, "get_libero_path", lambda _key: "/tmp/libero")
+    monkeypatch.setattr(
+        libero_env, "get_task_init_states", lambda *_a, **_k: np.zeros((8, 4), dtype=np.float64)
+    )
+
+    env = libero_env.LiberoEnv(
+        task_suite=_FakeTaskSuite(),
+        task_id=0,
+        task_suite_name="libero_spatial",
+        n_envs=n_envs,
+        obs_type="pixels",
+        camera_name="agentview_image",
+        camera_name_mapping={"agentview_image": "image"},
+    )
+    env._env = inner
+    return env
+
+
+def test_step_does_not_reset_on_termination(monkeypatch: pytest.MonkeyPatch) -> None:
+    env = _make_env(monkeypatch)
+    reset_calls = Mock(wraps=env.reset)
+    monkeypatch.setattr(env, "reset", reset_calls)
+
+    _, _, terminated, _, _ = env.step(np.zeros(7, dtype=np.float32))
+
+    assert terminated is True
+    assert reset_calls.call_count == 0, (
+        "step() must leave the reset to the caller; the vector env autoresets on the next step"
+    )
+
+
+def test_termination_does_not_skip_an_initial_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Each reset advances `init_state_id` by `_reset_stride`; stepping must not."""
+    env = _make_env(monkeypatch, n_envs=4)
+    before = env.init_state_id
+
+    env.step(np.zeros(7, dtype=np.float32))
+
+    assert env.init_state_id == before
+
+
+def test_gymnasium_vector_envs_autoreset_on_the_next_step() -> None:
+    """Pins the assumption this fix relies on, so a Gymnasium bump can't silently break it."""
+    assert gym.vector.AutoresetMode.NEXT_STEP.value == "NextStep"

--- a/tests/envs/test_libero_termination.py
+++ b/tests/envs/test_libero_termination.py
@@ -22,6 +22,7 @@ initial state per episode.
 
 from __future__ import annotations
 
+import inspect
 from typing import Any
 from unittest.mock import Mock
 
@@ -66,6 +67,11 @@ def _make_env(monkeypatch: pytest.MonkeyPatch, *, n_envs: int = 1) -> Any:
         camera_name="agentview_image",
         camera_name_mapping={"agentview_image": "image"},
     )
+    # Not redundant with the monkeypatched factory above: `LiberoEnv.__init__` defers
+    # simulator creation (`self._env = None`), so nothing is constructed until
+    # `_ensure_env()` runs on first use. Pre-binding it here keeps `_ensure_env()` a
+    # no-op, so `step()` is exercised without a stray `env.reset()` on the mock
+    # polluting the call counts these tests assert on.
     env._env = inner
     return env
 
@@ -94,5 +100,21 @@ def test_termination_does_not_skip_an_initial_state(monkeypatch: pytest.MonkeyPa
 
 
 def test_gymnasium_vector_envs_autoreset_on_the_next_step() -> None:
-    """Pins the assumption this fix relies on, so a Gymnasium bump can't silently break it."""
-    assert gym.vector.AutoresetMode.NEXT_STEP.value == "NextStep"
+    """Pins the assumption this fix relies on, so a Gymnasium bump can't silently break it.
+
+    The assumption is that vector envs *default* to `NEXT_STEP` -- not that the enum
+    member is spelled a particular way. Asserting `NEXT_STEP.value == "NextStep"` would
+    keep passing if a future Gymnasium flipped the default to `SAME_STEP`, and the bug
+    this fixes would come back as a *missing* reset instead of a double one.
+    """
+    env = gym.vector.SyncVectorEnv([lambda: gym.make("CartPole-v1")])
+    try:
+        assert env.metadata["autoreset_mode"] is gym.vector.AutoresetMode.NEXT_STEP
+    finally:
+        env.close()
+
+    # AsyncVectorEnv is what the LIBERO path actually uses, but constructing one spawns
+    # subprocesses; its constructor default carries the same guarantee.
+    for cls in (gym.vector.SyncVectorEnv, gym.vector.AsyncVectorEnv):
+        default = inspect.signature(cls.__init__).parameters["autoreset_mode"].default
+        assert default is gym.vector.AutoresetMode.NEXT_STEP, f"{cls.__name__} default changed"

--- a/tests/envs/test_libero_termination.py
+++ b/tests/envs/test_libero_termination.py
@@ -67,12 +67,10 @@ def _make_env(monkeypatch: pytest.MonkeyPatch, *, n_envs: int = 1) -> Any:
         camera_name="agentview_image",
         camera_name_mapping={"agentview_image": "image"},
     )
-    # Not redundant with the monkeypatched factory above: `LiberoEnv.__init__` defers
-    # simulator creation (`self._env = None`), so nothing is constructed until
-    # `_ensure_env()` runs on first use. Pre-binding it here keeps `_ensure_env()` a
-    # no-op, so `step()` is exercised without a stray `env.reset()` on the mock
-    # polluting the call counts these tests assert on.
-    env._env = inner
+    # No need to bind `env._env` here. `LiberoEnv.__init__` defers simulator creation
+    # (`self._env = None`, libero.py:180) so each worker subprocess gets its own EGL
+    # context; the monkeypatched factory above supplies `inner` when `_ensure_env()`
+    # runs on the first `step()`.
     return env
 
 


### PR DESCRIPTION
## Title

fix(libero): don't reset inside `step()` on termination

## Summary / Motivation

`LiberoEnv.step()` calls `self.reset()` when an episode terminates. Gymnasium's
vector envs default to `AutoresetMode.NEXT_STEP`, so the vector env resets that
sub-env **again** on the following step. Every termination therefore pays two full
LIBERO resets.

The self-reset is also pure waste: `observation` is built from the terminal
`raw_obs` on the line above it, so the reset's return value is discarded outright.

And it has a correctness cost. `LiberoEnv.reset()` advances `init_state_id` by
`_reset_stride`, so the extra reset **skips an initial state on every episode**.

## Related issues

- Related: #4224 — that PR makes initial-state allocation independent of reset
  count. This removes one of the reasons the counts drift in the first place; the
  two are complementary.
- Related: #4239 (makes each of these resets ~8× cheaper; independent of this)

## What changed

- Removed `if terminated: self.reset()` from `LiberoEnv.step()`, with a comment
  explaining the autoreset contract.

**Behaviour change:** standalone (non-vectorised) users must now call `reset()`
themselves after termination. That is the Gymnasium contract — a terminated env is
the caller's responsibility — but it is a change for anyone driving `LiberoEnv`
directly. Vectorised users (i.e. `lerobot-eval`) are unaffected except that the
duplicate reset disappears.

**There are no in-tree callers affected.** Worth stating explicitly, because
grepping is misleading here: there are two classes named `LiberoEnv` - the gym env
at `src/lerobot/envs/libero.py:107` and the config dataclass at
`src/lerobot/envs/configs.py:322`. `tests/envs/test_dispatch.py` constructs the
config one. The only construction of the gym env is `_make_env` at `libero.py:414`,
and every factory it produces is handed to `SyncVectorEnv` / `AsyncVectorEnv` /
`_LazyAsyncVectorEnv` (`libero.py:512`, `libero.py:519`). So nothing in the repo
drives a bare `LiberoEnv` through a termination, and the change is confined to
out-of-tree users. (Thanks to @noron12234 for pointing this out.)

## Measured

A counting subclass under `SyncVectorEnv`, gymnasium 1.3.0, real terminations via
`check_success`, terminating every 4 steps over a 14-step loop:

| | before | after |
|---|---|---|
| n_envs=1, 3 terminations | **6** resets | **3** resets |
| n_envs=2, 6 terminations | **12** resets | **6** resets |

Before: `initial + one self-reset per termination + one autoreset per termination`
(the final termination's autoreset does not fire before the loop ends, hence 6 and
12 rather than 7 and 14).
After: `initial + autoresets` only.

Each `LiberoEnv.reset()` is a full LIBERO reset plus `num_steps_wait` settle steps.
On the current default reset path that is roughly 1.3 s duplicated per termination.

## How was this tested

- New `tests/envs/test_libero_termination.py` (3 tests):
  - `step()` does not call `reset()` on termination
  - a termination does not advance `init_state_id`
  - pins `AutoresetMode.NEXT_STEP`, so a Gymnasium bump cannot silently invalidate
    the assumption this relies on
- Reset counts re-measured with the fix applied (table above).
- `ruff format` / `ruff check` clean.

## Checklist (required before merge)

- [x] Linting/formatting run
- [x] Tests pass locally (`pytest tests/envs/test_libero_termination.py` → 3 passed)
- [ ] Documentation updated (no user-facing config change)
- [ ] CI is green
- [ ] Community Review — happy to do one, tell me which PR would be most useful

## Reviewer notes

- The standalone-usage behaviour change is the thing worth a decision. If you would
  rather keep the convenience reset for direct users, an alternative is to gate it on
  an `autoreset: bool = False` constructor flag — say the word and I'll switch.

