### PR TITLE
fix(policies): VLA-JEPA prepare model input to take state from index 0

### DIFF
--- a/src/lerobot/policies/vla_jepa/configuration_vla_jepa.py
+++ b/src/lerobot/policies/vla_jepa/configuration_vla_jepa.py
@@ -15,11 +15,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import Any
 
 from lerobot.configs.policies import PreTrainedConfig
-from lerobot.configs.types import NormalizationMode
+from lerobot.configs.types import FeatureType, NormalizationMode, PolicyFeature
 from lerobot.optim.optimizers import AdamWConfig
 from lerobot.optim.schedulers import CosineDecayWithWarmupSchedulerConfig
+from lerobot.utils.constants import OBS_STATE
 
 
 @PreTrainedConfig.register_subclass("vla_jepa")
@@ -121,6 +123,13 @@ class VLAJEPAConfig(PreTrainedConfig):
         self.action_dim = self.action_feature.shape[0]
         if self.robot_state_feature is not None:
             self.state_dim = self.robot_state_feature.shape[0]
+
+    def set_dataset_feature_metadata(self, dataset_features: dict[str, Any]) -> None:
+        """Add `observation.state` to `input_features` if missing, so it gets normalized."""
+        if OBS_STATE in self.input_features or OBS_STATE not in dataset_features:
+            return
+        shape = tuple(dataset_features[OBS_STATE]["shape"])
+        self.input_features[OBS_STATE] = PolicyFeature(type=FeatureType.STATE, shape=shape)
 
     def get_optimizer_preset(self) -> AdamWConfig:
         return AdamWConfig(

--- a/src/lerobot/policies/vla_jepa/modeling_vla_jepa.py
+++ b/src/lerobot/policies/vla_jepa/modeling_vla_jepa.py
@@ -399,7 +399,8 @@ class VLAJEPAPolicy(PreTrainedPolicy):
         state = batch.get(OBS_STATE)
         if state is not None:
             if state.ndim > 2:
-                state = state[:, -1, :]
+                # deltas are forward-looking here, so index 0 is the current observation, not -1.
+                state = state[:, 0, :]
             inputs["state"] = (state.unsqueeze(1) if state.ndim == 2 else state).float()  # [B, 1, dim]
 
         return inputs


### PR DESCRIPTION
## Fix VLA JEPA input state and normalization


## What changed
1. The state given to the model was actually the last state from the predicted chunk, resulting in non-sense during inference (especially when dealing with relative actions).
2. The `observation.state` was missing from the `input_features` of the processors from the [VLA-JEPA-Pretrain](https://huggingface.co/lerobot/VLA-JEPA-Pretrain) model. Adds it if missing 

## How was this tested?

A/B tested the model trained with and without the fix.

## Reviewer notes

Why didn't we notice it before? 
-> My guess is that in absolute action space, the model learnt mostly from the visual path and not really from the state given + the setup we tried didn't move.

