### PR TITLE
fix(datasets): support multi-dimensional per-frame features in add_features

### DIFF
--- a/src/lerobot/datasets/dataset_tools.py
+++ b/src/lerobot/datasets/dataset_tools.py
@@ -1045,10 +1045,12 @@ def _copy_data_with_feature_changes(
                     df[feature_name] = feature_values
                 else:
                     feature_slice = values[frame_idx:end_idx]
-                    if len(feature_slice.shape) > 1 and feature_slice.shape[1] == 1:
+                    if feature_slice.ndim == 1:
+                        df[feature_name] = feature_slice
+                    elif feature_slice.ndim == 2 and feature_slice.shape[1] == 1:
                         df[feature_name] = feature_slice.flatten()
                     else:
-                        df[feature_name] = feature_slice
+                        df[feature_name] = list(feature_slice)
             frame_idx = end_idx
 
         # Write using the same chunk/file structure as source

--- a/tests/datasets/test_dataset_tools.py
+++ b/tests/datasets/test_dataset_tools.py
@@ -381,7 +381,7 @@ def test_add_features_with_callable(sample_dataset, tmp_path):
 def test_add_features_with_multidimensional_values(sample_dataset, tmp_path):
     """Test adding a multi-dimensional per-frame feature."""
     num_frames = sample_dataset.meta.total_frames
-    latent_values = np.random.randn(num_frames, 1, 4).astype(np.float32)
+    feature_values = np.random.randn(num_frames, 1, 4).astype(np.float32)
 
     feature_info = {
         "dtype": "float32",
@@ -389,7 +389,7 @@ def test_add_features_with_multidimensional_values(sample_dataset, tmp_path):
         "names": None,
     }
     features = {
-        "latent_vectors": (latent_values, feature_info),
+        "multi_dim_feature": (feature_values, feature_info),
     }
 
     with (
@@ -397,19 +397,19 @@ def test_add_features_with_multidimensional_values(sample_dataset, tmp_path):
         patch("lerobot.datasets.dataset_metadata.snapshot_download") as mock_snapshot_download,
     ):
         mock_get_safe_version.return_value = "v3.0"
-        mock_snapshot_download.return_value = str(tmp_path / "with_latents")
+        mock_snapshot_download.return_value = str(tmp_path / "with_multi_dim_feature")
 
         new_dataset = add_features(
             dataset=sample_dataset,
             features=features,
-            output_dir=tmp_path / "with_latents",
+            output_dir=tmp_path / "with_multi_dim_feature",
         )
 
-    assert "latent_vectors" in new_dataset.meta.features
+    assert "multi_dim_feature" in new_dataset.meta.features
     sample_item = new_dataset[0]
-    assert "latent_vectors" in sample_item
-    assert isinstance(sample_item["latent_vectors"], torch.Tensor)
-    assert tuple(sample_item["latent_vectors"].shape) == (1, 4)
+    assert "multi_dim_feature" in sample_item
+    assert isinstance(sample_item["multi_dim_feature"], torch.Tensor)
+    assert tuple(sample_item["multi_dim_feature"].shape) == (1, 4)
 
 
 def test_add_existing_feature(sample_dataset, tmp_path):

--- a/tests/datasets/test_dataset_tools.py
+++ b/tests/datasets/test_dataset_tools.py
@@ -378,6 +378,40 @@ def test_add_features_with_callable(sample_dataset, tmp_path):
     assert float(first_frame["reward"]) == 0.0
 
 
+def test_add_features_with_multidimensional_values(sample_dataset, tmp_path):
+    """Test adding a multi-dimensional per-frame feature."""
+    num_frames = sample_dataset.meta.total_frames
+    latent_values = np.random.randn(num_frames, 1, 4).astype(np.float32)
+
+    feature_info = {
+        "dtype": "float32",
+        "shape": (1, 4),
+        "names": None,
+    }
+    features = {
+        "latent_vectors": (latent_values, feature_info),
+    }
+
+    with (
+        patch("lerobot.datasets.dataset_metadata.get_safe_version") as mock_get_safe_version,
+        patch("lerobot.datasets.dataset_metadata.snapshot_download") as mock_snapshot_download,
+    ):
+        mock_get_safe_version.return_value = "v3.0"
+        mock_snapshot_download.return_value = str(tmp_path / "with_latents")
+
+        new_dataset = add_features(
+            dataset=sample_dataset,
+            features=features,
+            output_dir=tmp_path / "with_latents",
+        )
+
+    assert "latent_vectors" in new_dataset.meta.features
+    sample_item = new_dataset[0]
+    assert "latent_vectors" in sample_item
+    assert isinstance(sample_item["latent_vectors"], torch.Tensor)
+    assert tuple(sample_item["latent_vectors"].shape) == (1, 4)
+
+
 def test_add_existing_feature(sample_dataset, tmp_path):
     """Test error when adding an existing feature."""
     feature_info = {"dtype": "float32", "shape": (1,)}

--- a/tests/datasets/test_dataset_tools.py
+++ b/tests/datasets/test_dataset_tools.py
@@ -382,6 +382,7 @@ def test_add_features_with_callable(sample_dataset, tmp_path):
     assert first_frame["frame_index"] == 0
     assert float(first_frame["reward"]) == 0.0
 
+
 def test_add_existing_feature(sample_dataset, tmp_path):
     """Test error when adding an existing feature."""
     feature_info = {"dtype": "float32", "shape": (1,)}

--- a/tests/datasets/test_dataset_tools.py
+++ b/tests/datasets/test_dataset_tools.py
@@ -304,40 +304,45 @@ def test_merge_empty_list(tmp_path):
         merge_datasets([], output_repo_id="merged", output_dir=tmp_path)
 
 
-def test_add_features_with_values(sample_dataset, tmp_path):
-    """Test adding a feature with pre-computed values."""
+@pytest.mark.parametrize(
+    "values, feature_shape, expected_item_shape",
+    [
+        (np.random.randn(50).astype(np.float32), (1,), ()),
+        (np.random.randn(50, 1).astype(np.float32), (1,), ()),
+        (np.random.randn(50, 7).astype(np.float32), (7,), (7,)),
+        (np.random.randn(50, 1, 4).astype(np.float32), (1, 4), (1, 4)),
+    ],
+    ids=["scalar_1d", "scalar_2d", "vector", "matrix"],
+)
+def test_add_features_with_values(sample_dataset, tmp_path, values, feature_shape, expected_item_shape):
+    """Test adding a pre-computed feature across supported per-frame shapes."""
     num_frames = sample_dataset.meta.total_frames
-    reward_values = np.random.randn(num_frames, 1).astype(np.float32)
+    assert len(values) == num_frames
 
-    feature_info = {
-        "dtype": "float32",
-        "shape": (1,),
-        "names": None,
-    }
-    features = {
-        "reward": (reward_values, feature_info),
-    }
+    feature_info = {"dtype": "float32", "shape": feature_shape, "names": None}
+    features = {"new_feature": (values, feature_info)}
 
     with (
         patch("lerobot.datasets.dataset_metadata.get_safe_version") as mock_get_safe_version,
         patch("lerobot.datasets.dataset_metadata.snapshot_download") as mock_snapshot_download,
     ):
         mock_get_safe_version.return_value = "v3.0"
-        mock_snapshot_download.return_value = str(tmp_path / "with_reward")
+        mock_snapshot_download.return_value = str(tmp_path / "with_feature")
 
         new_dataset = add_features(
             dataset=sample_dataset,
             features=features,
-            output_dir=tmp_path / "with_reward",
+            output_dir=tmp_path / "with_feature",
         )
 
-    assert "reward" in new_dataset.meta.features
-    assert new_dataset.meta.features["reward"] == feature_info
+    assert "new_feature" in new_dataset.meta.features
+    assert new_dataset.meta.features["new_feature"] == feature_info
 
     assert len(new_dataset) == num_frames
     sample_item = new_dataset[0]
-    assert "reward" in sample_item
-    assert isinstance(sample_item["reward"], torch.Tensor)
+    assert "new_feature" in sample_item
+    assert isinstance(sample_item["new_feature"], torch.Tensor)
+    assert tuple(sample_item["new_feature"].shape) == expected_item_shape
 
 
 def test_add_features_with_callable(sample_dataset, tmp_path):
@@ -376,41 +381,6 @@ def test_add_features_with_callable(sample_dataset, tmp_path):
     first_frame = first_episode_items[0]
     assert first_frame["frame_index"] == 0
     assert float(first_frame["reward"]) == 0.0
-
-
-def test_add_features_with_multidimensional_values(sample_dataset, tmp_path):
-    """Test adding a multi-dimensional per-frame feature."""
-    num_frames = sample_dataset.meta.total_frames
-    feature_values = np.random.randn(num_frames, 1, 4).astype(np.float32)
-
-    feature_info = {
-        "dtype": "float32",
-        "shape": (1, 4),
-        "names": None,
-    }
-    features = {
-        "multi_dim_feature": (feature_values, feature_info),
-    }
-
-    with (
-        patch("lerobot.datasets.dataset_metadata.get_safe_version") as mock_get_safe_version,
-        patch("lerobot.datasets.dataset_metadata.snapshot_download") as mock_snapshot_download,
-    ):
-        mock_get_safe_version.return_value = "v3.0"
-        mock_snapshot_download.return_value = str(tmp_path / "with_multi_dim_feature")
-
-        new_dataset = add_features(
-            dataset=sample_dataset,
-            features=features,
-            output_dir=tmp_path / "with_multi_dim_feature",
-        )
-
-    assert "multi_dim_feature" in new_dataset.meta.features
-    sample_item = new_dataset[0]
-    assert "multi_dim_feature" in sample_item
-    assert isinstance(sample_item["multi_dim_feature"], torch.Tensor)
-    assert tuple(sample_item["multi_dim_feature"].shape) == (1, 4)
-
 
 def test_add_existing_feature(sample_dataset, tmp_path):
     """Test error when adding an existing feature."""


### PR DESCRIPTION
Supersedes #3194

## Summary / Motivation

This PR ensures multi-dimensional features are correctly registered when calling `add_features`.

## Related issues

- Fixes / Closes: # (if any)
- Related: # (if any)

## What changed

- Features with 1 dimension are kept as is, features with 2 dimensions out of which one is 1 are flattened, and all other features are cast into `list`.
- Tests were updated accordingly to test all possible use cases : scalars (true scalars and arrays of length 1), vector, matrices.

## How was this tested (or how to run locally)

- Tests modified: `test_add_features_with_values` in test_dataset_tools.py 

## Checklist (required before merge)

- [ ] Linting/formatting run (`pre-commit run -a`)
- [ ] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: # (insert PR number/link)

## Reviewer notes

- Anything the reviewer should focus on (performance, edge-cases, specific files) or general notes.
- Anyone in the community is free to review the PR.
