### PR TITLE
feat(policies): support relative end-effector actions

### DIFF
--- a/src/lerobot/datasets/factory.py
+++ b/src/lerobot/datasets/factory.py
@@ -28,6 +28,7 @@ from lerobot.utils.constants import ACTION, IMAGENET_STATS, OBS_PREFIX, REWARD
 from .dataset_metadata import LeRobotDatasetMetadata
 from .lerobot_dataset import LeRobotDataset
 from .multi_dataset import MultiLeRobotDataset
+from .relative_ee_stats import compute_relative_ee_stats
 from .streaming_dataset import StreamingLeRobotDataset
 
 
@@ -66,7 +67,32 @@ def resolve_delta_timestamps(
     return delta_timestamps
 
 
-def make_dataset(cfg: TrainPipelineConfig) -> LeRobotDataset | MultiLeRobotDataset:
+def _validate_relative_ee_dataset(cfg: TrainPipelineConfig, ds_meta: LeRobotDatasetMetadata) -> None:
+    if cfg.trainable_config.type not in {"act", "smolvla", "pi05"}:
+        raise ValueError("Relative EE training is supported for ACT, SmolVLA, and π0.5")
+    if cfg.dataset.streaming:
+        raise ValueError("Relative EE statistics require a non-streaming dataset")
+    action_feature = ds_meta.features.get(ACTION)
+    action_shape = None if action_feature is None else tuple(action_feature["shape"])
+    if action_shape != (7,):
+        raise ValueError(
+            f"Relative EE requires raw action shape [7] with [xyz, axis-angle, gripper], got {action_shape}"
+        )
+
+
+def _prepare_relative_ee_stats(
+    dataset: LeRobotDataset,
+    chunk_size: int,
+    stats: dict | None = None,
+) -> dict:
+    derived_stats = compute_relative_ee_stats(dataset.hf_dataset, chunk_size) if stats is None else stats
+    dataset.meta.stats.update(derived_stats)
+    return derived_stats
+
+
+def make_dataset(
+    cfg: TrainPipelineConfig, *, prepare_relative_ee: bool = True
+) -> LeRobotDataset | MultiLeRobotDataset:
     """Handles the logic of setting up delta timestamps and image transforms before creating a dataset.
 
     Args:
@@ -82,10 +108,13 @@ def make_dataset(cfg: TrainPipelineConfig) -> LeRobotDataset | MultiLeRobotDatas
         ImageTransforms(cfg.dataset.image_transforms) if cfg.dataset.image_transforms.enable else None
     )
 
+    use_relative_ee = bool(getattr(cfg.trainable_config, "use_relative_ee", False))
     if isinstance(cfg.dataset.repo_id, str):
         ds_meta = LeRobotDatasetMetadata(
             cfg.dataset.repo_id, root=cfg.dataset.root, revision=cfg.dataset.revision
         )
+        if use_relative_ee:
+            _validate_relative_ee_dataset(cfg, ds_meta)
         delta_timestamps = resolve_delta_timestamps(cfg.trainable_config, ds_meta)
         if not cfg.dataset.streaming:
             dataset = LeRobotDataset(
@@ -133,6 +162,9 @@ def make_dataset(cfg: TrainPipelineConfig) -> LeRobotDataset | MultiLeRobotDatas
             for stats_type, stats in IMAGENET_STATS.items():
                 dataset.meta.stats[key][stats_type] = torch.tensor(stats, dtype=torch.float32)
 
+    if use_relative_ee and prepare_relative_ee:
+        _prepare_relative_ee_stats(dataset, cfg.trainable_config.chunk_size)
+
     return dataset
 
 
@@ -144,10 +176,10 @@ def make_train_eval_datasets(
     The last ceil(n_episodes * eval_split) episodes per task are held out for evaluation.
     If eval_split == 0.0, returns (full_dataset, None).
     """
-    full_dataset = make_dataset(cfg)
-
     if cfg.dataset.eval_split == 0.0:
-        return full_dataset, None
+        return make_dataset(cfg), None
+
+    full_dataset = make_dataset(cfg, prepare_relative_ee=False)
 
     base_episodes = (
         full_dataset.episodes if full_dataset.episodes is not None else list(range(full_dataset.num_episodes))
@@ -210,5 +242,9 @@ def make_train_eval_datasets(
             for key in ds.meta.camera_keys:
                 for stats_type, stats in IMAGENET_STATS.items():
                     ds.meta.stats[key][stats_type] = torch.tensor(stats, dtype=torch.float32)
+
+    if getattr(cfg.trainable_config, "use_relative_ee", False):
+        derived_stats = _prepare_relative_ee_stats(train_dataset, cfg.trainable_config.chunk_size)
+        _prepare_relative_ee_stats(eval_dataset, cfg.trainable_config.chunk_size, derived_stats)
 
     return train_dataset, eval_dataset

--- a/src/lerobot/datasets/relative_ee_stats.py
+++ b/src/lerobot/datasets/relative_ee_stats.py
@@ -1,0 +1,84 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Statistics for processor-derived relative end-effector features."""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+import torch
+
+from lerobot.processor.relative_ee_processor import absolute_ee_to_relative
+from lerobot.utils.constants import ACTION, OBS_STATE
+
+from .compute_stats import RunningQuantileStats
+
+logger = logging.getLogger(__name__)
+
+
+def compute_relative_ee_stats(hf_dataset, chunk_size: int) -> dict[str, dict[str, np.ndarray]]:
+    """Compute statistics for the model-facing relative EE action and state."""
+    actions = np.asarray(hf_dataset[ACTION], dtype=np.float32)
+    if actions.ndim != 2 or actions.shape[1] != 7:
+        raise ValueError(
+            "Relative EE requires action shape [frames, 7] with [xyz, axis-angle, gripper], "
+            f"got {actions.shape}"
+        )
+    if chunk_size < 1:
+        raise ValueError(f"Relative EE requires chunk_size >= 1, got {chunk_size}")
+
+    episode_indices = np.asarray(hf_dataset["episode_index"])
+    action_stats = RunningQuantileStats()
+    state_stats = RunningQuantileStats()
+    num_action_targets = 0
+    num_states = 0
+
+    for episode_index in np.unique(episode_indices):
+        frame_indices = np.flatnonzero(episode_indices == episode_index)
+        if len(frame_indices) == 0:
+            continue
+        episode_actions = torch.from_numpy(actions[frame_indices])
+
+        previous_indices = torch.arange(len(frame_indices)).sub(1).clamp_min(0)
+        state_pair = torch.stack([episode_actions[previous_indices], episode_actions], dim=1)
+        current = episode_actions[:, None, :].expand_as(state_pair)
+        relative_state = absolute_ee_to_relative(current, state_pair).flatten(start_dim=1)
+        state_stats.update(relative_state.numpy())
+        num_states += len(relative_state)
+
+        for batch_start in range(0, len(frame_indices), 20_000):
+            base_indices = torch.arange(batch_start, min(batch_start + 20_000, len(frame_indices)))
+            offsets = torch.arange(chunk_size)
+            target_indices = base_indices[:, None] + offsets[None, :]
+            valid = target_indices < len(frame_indices)
+            targets = episode_actions[target_indices[valid]]
+            references = episode_actions[base_indices[:, None].expand_as(target_indices)[valid]]
+            relative_actions = absolute_ee_to_relative(references, targets)
+            action_stats.update(relative_actions.numpy())
+            num_action_targets += len(relative_actions)
+
+    if num_states < 2 or num_action_targets < 2:
+        raise ValueError("Relative EE statistics require at least two selected dataset frames")
+
+    logger.info(
+        "Computed relative EE statistics from %d states and %d unpadded action targets",
+        num_states,
+        num_action_targets,
+    )
+    return {
+        ACTION: action_stats.get_statistics(),
+        OBS_STATE: state_stats.get_statistics(),
+    }

--- a/src/lerobot/policies/act/configuration_act.py
+++ b/src/lerobot/policies/act/configuration_act.py
@@ -85,6 +85,9 @@ class ACTConfig(PreTrainedConfig):
     chunk_size: int = 100
     n_action_steps: int = 100
 
+    # Train on fixed-reference relative end-effector action chunks.
+    use_relative_ee: bool = False
+
     normalization_mapping: dict[str, NormalizationMode] = field(
         default_factory=lambda: {
             "VISUAL": NormalizationMode.MEAN_STD,
@@ -131,6 +134,10 @@ class ACTConfig(PreTrainedConfig):
         super().__post_init__()
 
         """Input validation (not exhaustive)."""
+        if self.use_relative_ee:
+            self.normalization_mapping["STATE"] = NormalizationMode.MIN_MAX
+            self.normalization_mapping["ACTION"] = NormalizationMode.MIN_MAX
+
         if not self.vision_backbone.startswith("resnet"):
             raise ValueError(
                 f"`vision_backbone` must be one of the ResNet variants. Got {self.vision_backbone}."
@@ -169,6 +176,8 @@ class ACTConfig(PreTrainedConfig):
 
     @property
     def action_delta_indices(self) -> list:
+        if self.use_relative_ee:
+            return [-1, *range(self.chunk_size)]
         return list(range(self.chunk_size))
 
     @property

--- a/src/lerobot/policies/act/processor_act.py
+++ b/src/lerobot/policies/act/processor_act.py
@@ -18,9 +18,15 @@ from typing import Any
 import torch
 
 from lerobot.processor import (
+    AbsoluteEEActionsStep,
     PolicyAction,
     PolicyProcessorPipeline,
+    RelativeEEActionsStep,
+    RelativeEEDeriveStateStep,
+    RelativeEEStateStep,
+    make_default_policy_processor_steps,
     make_default_pre_post_processors,
+    make_policy_processor_pipelines,
 )
 
 from .configuration_act import ACTConfig
@@ -47,4 +53,19 @@ def make_act_pre_post_processors(
         tuple[PolicyProcessorPipeline[dict[str, Any], dict[str, Any]], PolicyProcessorPipeline[PolicyAction, PolicyAction]]: A tuple containing the
         pre-processor pipeline and the post-processor pipeline.
     """
+    if config.use_relative_ee:
+        steps = make_default_policy_processor_steps(config, dataset_stats, normalizer_device=config.device)
+        relative_step = RelativeEEActionsStep()
+        return make_policy_processor_pipelines(
+            input_steps=[
+                steps.rename_observations,
+                steps.add_batch_dim,
+                steps.to_device,
+                RelativeEEDeriveStateStep(),
+                relative_step,
+                RelativeEEStateStep(),
+                steps.normalize,
+            ],
+            output_steps=[steps.unnormalize, AbsoluteEEActionsStep(relative_step), steps.to_cpu],
+        )
     return make_default_pre_post_processors(config, dataset_stats, normalizer_device=config.device)

--- a/src/lerobot/policies/factory.py
+++ b/src/lerobot/policies/factory.py
@@ -26,13 +26,15 @@ import torch
 if TYPE_CHECKING:
     from lerobot.datasets import LeRobotDatasetMetadata
 
-from lerobot.configs import FeatureType, PreTrainedConfig
+from lerobot.configs import FeatureType, PolicyFeature, PreTrainedConfig
 from lerobot.envs import EnvConfig, env_to_policy_features
 from lerobot.lerobot_types import PolicyAction
 from lerobot.processor import (
     AbsoluteActionsProcessorStep,
+    AbsoluteEEActionsStep,
     PolicyProcessorPipeline,
     RelativeActionsProcessorStep,
+    RelativeEEActionsStep,
     batch_to_transition,
     policy_action_to_transition,
     transition_to_batch,
@@ -40,6 +42,7 @@ from lerobot.processor import (
 )
 from lerobot.utils.constants import (
     ACTION,
+    OBS_STATE,
     POLICY_POSTPROCESSOR_DEFAULT_NAME,
     POLICY_PREPROCESSOR_DEFAULT_NAME,
 )
@@ -69,11 +72,16 @@ def _reconnect_relative_absolute_steps(
     That reference is not serializable, so we re-establish it here after loading.
     """
     relative_step = next((s for s in preprocessor.steps if isinstance(s, RelativeActionsProcessorStep)), None)
-    if relative_step is None:
-        return
-    for step in postprocessor.steps:
-        if isinstance(step, AbsoluteActionsProcessorStep) and step.relative_step is None:
-            step.relative_step = relative_step
+    if relative_step is not None:
+        for step in postprocessor.steps:
+            if isinstance(step, AbsoluteActionsProcessorStep) and step.relative_step is None:
+                step.relative_step = relative_step
+
+    relative_ee_step = next((s for s in preprocessor.steps if isinstance(s, RelativeEEActionsStep)), None)
+    if relative_ee_step is not None:
+        for step in postprocessor.steps:
+            if isinstance(step, AbsoluteEEActionsStep) and step.relative_step is None:
+                step.relative_step = relative_ee_step
 
 
 def get_policy_class(name: str) -> type[PreTrainedPolicy]:
@@ -301,9 +309,22 @@ def make_policy(
             raise ValueError("env_cfg cannot be None when ds_meta is not provided")
         features = env_to_policy_features(env_cfg)
 
+    use_relative_ee = getattr(cfg, "use_relative_ee", False)
+    if use_relative_ee:
+        action_feature = features.get(ACTION)
+        if action_feature is None or action_feature.shape != (7,):
+            raise ValueError("Relative EE policies require an action feature with shape (7,).")
+        features = {
+            **features,
+            ACTION: PolicyFeature(type=FeatureType.ACTION, shape=(10,)),
+            OBS_STATE: PolicyFeature(type=FeatureType.STATE, shape=(20,)),
+        }
+
     cfg.output_features = {key: ft for key, ft in features.items() if ft.type is FeatureType.ACTION}
     if not cfg.input_features:
         cfg.input_features = {key: ft for key, ft in features.items() if key not in cfg.output_features}
+    elif use_relative_ee:
+        cfg.input_features = {**cfg.input_features, OBS_STATE: features[OBS_STATE]}
 
     # Store action feature names for relative_exclude_joints support
     if ds_meta is not None and hasattr(cfg, "action_feature_names"):

--- a/src/lerobot/policies/pi05/configuration_pi05.py
+++ b/src/lerobot/policies/pi05/configuration_pi05.py
@@ -56,6 +56,9 @@ class PI05Config(PreTrainedConfig):
     # Populated at runtime from dataset metadata by make_policy.
     action_feature_names: list[str] | None = None
 
+    # Train on fixed-reference relative end-effector action chunks.
+    use_relative_ee: bool = False
+
     # Real-Time Chunking (RTC) configuration
     rtc_config: RTCConfig | None = None
 
@@ -107,6 +110,13 @@ class PI05Config(PreTrainedConfig):
         super().__post_init__()
 
         # Validate configuration
+        if self.use_relative_ee and self.use_relative_actions:
+            raise ValueError("use_relative_ee and use_relative_actions are mutually exclusive")
+        if self.use_relative_ee and self.n_obs_steps != 1:
+            raise ValueError("Relative EE mode requires n_obs_steps=1")
+        if self.use_relative_ee and (self.max_state_dim < 20 or self.max_action_dim < 10):
+            raise ValueError("Relative EE mode requires max_state_dim>=20 and max_action_dim>=10")
+
         if self.n_action_steps > self.chunk_size:
             raise ValueError(
                 f"n_action_steps ({self.n_action_steps}) cannot be greater than chunk_size ({self.chunk_size})"
@@ -168,6 +178,8 @@ class PI05Config(PreTrainedConfig):
 
     @property
     def action_delta_indices(self) -> list:
+        if self.use_relative_ee:
+            return [-1, *range(self.chunk_size)]
         return list(range(self.chunk_size))
 
     @property

--- a/src/lerobot/policies/pi05/processor_pi05.py
+++ b/src/lerobot/policies/pi05/processor_pi05.py
@@ -25,11 +25,15 @@ from lerobot.configs import PipelineFeatureType, PolicyFeature
 from lerobot.lerobot_types import EnvTransition, TransitionKey
 from lerobot.processor import (
     AbsoluteActionsProcessorStep,
+    AbsoluteEEActionsStep,
     PolicyAction,
     PolicyProcessorPipeline,
     ProcessorStep,
     ProcessorStepRegistry,
     RelativeActionsProcessorStep,
+    RelativeEEActionsStep,
+    RelativeEEDeriveStateStep,
+    RelativeEEStateStep,
     TokenizerProcessorStep,
     make_default_policy_processor_steps,
     make_policy_processor_pipelines,
@@ -120,11 +124,22 @@ def make_pi05_pre_post_processors(
         A tuple containing the configured pre-processor and post-processor pipelines.
     """
 
-    relative_step = RelativeActionsProcessorStep(
-        enabled=config.use_relative_actions,
-        exclude_joints=getattr(config, "relative_exclude_joints", []),
-        action_names=getattr(config, "action_feature_names", None),
-    )
+    if config.use_relative_ee:
+        relative_step = RelativeEEActionsStep()
+        derive_state_step = RelativeEEDeriveStateStep()
+        relative_state_step = RelativeEEStateStep()
+        absolute_step = AbsoluteEEActionsStep(relative_step)
+    else:
+        relative_step = RelativeActionsProcessorStep(
+            enabled=config.use_relative_actions,
+            exclude_joints=getattr(config, "relative_exclude_joints", []),
+            action_names=getattr(config, "action_feature_names", None),
+        )
+        derive_state_step = None
+        relative_state_step = None
+        absolute_step = AbsoluteActionsProcessorStep(
+            enabled=config.use_relative_actions, relative_step=relative_step
+        )
 
     steps = make_default_policy_processor_steps(config, dataset_stats)
 
@@ -132,7 +147,9 @@ def make_pi05_pre_post_processors(
     input_steps: list[ProcessorStep] = [
         steps.rename_observations,  # To mimic the same processor as pretrained one
         steps.add_batch_dim,
+        *([derive_state_step] if derive_state_step is not None else []),
         relative_step,
+        *([relative_state_step] if relative_state_step is not None else []),
         # NOTE: NormalizerProcessorStep MUST come before Pi05PrepareStateTokenizerProcessorStep
         # because the tokenizer step expects normalized state in [-1, 1] range for discretization
         steps.normalize,
@@ -148,7 +165,7 @@ def make_pi05_pre_post_processors(
 
     output_steps: list[ProcessorStep] = [
         steps.unnormalize,
-        AbsoluteActionsProcessorStep(enabled=config.use_relative_actions, relative_step=relative_step),
+        absolute_step,
         steps.to_cpu,
     ]
 

--- a/src/lerobot/policies/rtc/__init__.py
+++ b/src/lerobot/policies/rtc/__init__.py
@@ -19,7 +19,7 @@ from .action_queue import ActionQueue
 from .configuration_rtc import RTCConfig
 from .latency_tracker import LatencyTracker
 from .modeling_rtc import RTCProcessor
-from .relative import reanchor_relative_rtc_prefix
+from .relative import reanchor_relative_ee_rtc_prefix, reanchor_relative_rtc_prefix
 
 __all__ = [
     "ActionInterpolator",
@@ -27,5 +27,6 @@ __all__ = [
     "LatencyTracker",
     "RTCConfig",
     "RTCProcessor",
+    "reanchor_relative_ee_rtc_prefix",
     "reanchor_relative_rtc_prefix",
 ]

--- a/src/lerobot/policies/rtc/action_queue.py
+++ b/src/lerobot/policies/rtc/action_queue.py
@@ -144,6 +144,13 @@ class ActionQueue:
                 return None
             return self.queue[self.last_index :].clone()
 
+    def get_left_over_snapshot(self) -> tuple[int, Tensor | None, Tensor | None]:
+        """Return an atomic snapshot of the index and both leftover queues."""
+        with self.lock:
+            original = None if self.original_queue is None else self.original_queue[self.last_index :].clone()
+            processed = None if self.queue is None else self.queue[self.last_index :].clone()
+            return self.last_index, original, processed
+
     def merge(
         self,
         original_actions: Tensor,

--- a/src/lerobot/policies/rtc/relative.py
+++ b/src/lerobot/policies/rtc/relative.py
@@ -26,6 +26,7 @@ from lerobot.processor import (
     TransitionKey,
     create_transition,
     to_relative_actions,
+    to_relative_ee_actions,
 )
 
 
@@ -55,4 +56,30 @@ def reanchor_relative_rtc_prefix(
     if normalizer_step is not None:
         transition = normalizer_step(transition)
 
+    return transition[TransitionKey.ACTION].to(policy_device)
+
+
+def reanchor_relative_ee_rtc_prefix(
+    prev_actions_absolute: torch.Tensor,
+    current_state: torch.Tensor,
+    normalizer_step: NormalizerProcessorStep | None,
+    policy_device: torch.device | str,
+) -> torch.Tensor:
+    """Re-express absolute EE leftovers in the current chunk reference frame."""
+    actions = prev_actions_absolute.detach().cpu()
+    state = current_state.detach().cpu()
+    if actions.ndim not in (2, 3) or actions.shape[-1] != 7:
+        raise ValueError(
+            f"Relative EE RTC leftovers must have shape [T, 7] or [B, T, 7], got {tuple(actions.shape)}"
+        )
+    if actions.ndim == 2 and state.ndim == 2:
+        if state.shape[0] != 1:
+            raise ValueError(
+                f"Unbatched relative EE leftovers require exactly one current state, got {tuple(state.shape)}"
+            )
+        state = state[0]
+
+    transition = create_transition(action=to_relative_ee_actions(actions, state))
+    if normalizer_step is not None:
+        transition = normalizer_step(transition)
     return transition[TransitionKey.ACTION].to(policy_device)

--- a/src/lerobot/policies/smolvla/configuration_smolvla.py
+++ b/src/lerobot/policies/smolvla/configuration_smolvla.py
@@ -29,6 +29,9 @@ class SmolVLAConfig(PreTrainedConfig):
     chunk_size: int = 50
     n_action_steps: int = 50
 
+    # Train on fixed-reference relative end-effector action chunks.
+    use_relative_ee: bool = False
+
     normalization_mapping: dict[str, NormalizationMode] = field(
         default_factory=lambda: {
             "VISUAL": NormalizationMode.IDENTITY,
@@ -110,6 +113,14 @@ class SmolVLAConfig(PreTrainedConfig):
         super().__post_init__()
 
         """Input validation (not exhaustive)."""
+        if self.use_relative_ee:
+            if self.n_obs_steps != 1:
+                raise ValueError("Relative EE mode requires n_obs_steps=1")
+            if self.max_state_dim < 20 or self.max_action_dim < 10:
+                raise ValueError("Relative EE mode requires max_state_dim>=20 and max_action_dim>=10")
+            self.normalization_mapping["STATE"] = NormalizationMode.MIN_MAX
+            self.normalization_mapping["ACTION"] = NormalizationMode.MIN_MAX
+
         if self.n_action_steps > self.chunk_size:
             raise ValueError(
                 f"The chunk size is the upper bound for the number of action steps per model invocation. Got "
@@ -152,6 +163,8 @@ class SmolVLAConfig(PreTrainedConfig):
 
     @property
     def action_delta_indices(self) -> list:
+        if self.use_relative_ee:
+            return [-1, *range(self.chunk_size)]
         return list(range(self.chunk_size))
 
     @property

--- a/src/lerobot/policies/smolvla/processor_smolvla.py
+++ b/src/lerobot/policies/smolvla/processor_smolvla.py
@@ -19,9 +19,13 @@ from typing import Any
 import torch
 
 from lerobot.processor import (
+    AbsoluteEEActionsStep,
     NewLineTaskProcessorStep,
     PolicyAction,
     PolicyProcessorPipeline,
+    RelativeEEActionsStep,
+    RelativeEEDeriveStateStep,
+    RelativeEEStateStep,
     TokenizerProcessorStep,
     make_default_policy_processor_steps,
     make_policy_processor_pipelines,
@@ -61,6 +65,7 @@ def make_smolvla_pre_post_processors(
     """
 
     steps = make_default_policy_processor_steps(config, dataset_stats)
+    relative_step = RelativeEEActionsStep()
 
     input_steps = [
         steps.rename_observations,  # To mimic the same processor as pretrained one
@@ -73,10 +78,16 @@ def make_smolvla_pre_post_processors(
             max_length=config.tokenizer_max_length,
         ),
         steps.to_device,
+        *(
+            [RelativeEEDeriveStateStep(), relative_step, RelativeEEStateStep()]
+            if config.use_relative_ee
+            else []
+        ),
         steps.normalize,
     ]
     output_steps = [
         steps.unnormalize,
+        *([AbsoluteEEActionsStep(relative_step)] if config.use_relative_ee else []),
         steps.to_cpu,
     ]
     return make_policy_processor_pipelines(input_steps=input_steps, output_steps=output_steps)

--- a/src/lerobot/processor/__init__.py
+++ b/src/lerobot/processor/__init__.py
@@ -96,6 +96,21 @@ from .relative_action_processor import (
     to_absolute_actions,
     to_relative_actions,
 )
+from .relative_ee_processor import (
+    AbsoluteEEActionsStep,
+    RelativeEEActionsStep,
+    RelativeEEDeriveStateStep,
+    RelativeEEStateStep,
+    absolute_ee_to_relative,
+    axis_angle_to_matrix,
+    matrix_to_axis_angle,
+    matrix_to_rotation_6d,
+    relative_ee_to_absolute,
+    rotation_6d_to_matrix,
+    to_absolute_ee_actions,
+    to_relative_ee_actions,
+    to_relative_ee_state,
+)
 from .rename_processor import RenameObservationsProcessorStep, rename_stats
 from .tokenizer_processor import ActionTokenizerProcessorStep, TokenizerProcessorStep
 
@@ -142,7 +157,11 @@ __all__ = [
     "make_default_robot_observation_processor",
     "make_policy_processor_pipelines",
     "AbsoluteActionsProcessorStep",
+    "AbsoluteEEActionsStep",
     "RelativeActionsProcessorStep",
+    "RelativeEEActionsStep",
+    "RelativeEEDeriveStateStep",
+    "RelativeEEStateStep",
     "MapDeltaActionToRobotActionStep",
     "MapTensorToDeltaActionDictStep",
     "NewLineTaskProcessorStep",
@@ -176,8 +195,17 @@ __all__ = [
     "transition_to_batch",
     "TransitionKey",
     "TruncatedProcessorStep",
+    "absolute_ee_to_relative",
+    "axis_angle_to_matrix",
+    "matrix_to_axis_angle",
+    "matrix_to_rotation_6d",
+    "relative_ee_to_absolute",
+    "rotation_6d_to_matrix",
     "to_absolute_actions",
+    "to_absolute_ee_actions",
     "to_relative_actions",
+    "to_relative_ee_actions",
+    "to_relative_ee_state",
     "UnnormalizerProcessorStep",
     "VanillaObservationProcessorStep",
 ]

--- a/src/lerobot/processor/relative_ee_processor.py
+++ b/src/lerobot/processor/relative_ee_processor.py
@@ -1,0 +1,342 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Processor steps for fixed-reference relative end-effector action chunks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import torch
+from torch import Tensor
+
+from lerobot.configs import PipelineFeatureType, PolicyFeature
+from lerobot.lerobot_types import EnvTransition, TransitionKey
+from lerobot.utils.constants import ACTION, OBS_STATE
+
+from .pipeline import ProcessorStep, ProcessorStepRegistry
+
+
+def axis_angle_to_matrix(axis_angle: Tensor) -> Tensor:
+    """Convert axis-angle vectors to rotation matrices."""
+    theta_sq = (axis_angle * axis_angle).sum(dim=-1, keepdim=True)
+    theta = theta_sq.sqrt()
+    small = theta_sq < 1e-8
+    theta_sq_safe = theta_sq.clamp_min(1e-16)
+    theta_safe = theta.clamp_min(1e-8)
+    sin_over_theta = torch.where(
+        small,
+        1 - theta_sq / 6 + theta_sq * theta_sq / 120,
+        torch.sin(theta) / theta_safe,
+    )
+    one_minus_cos_over_theta_sq = torch.where(
+        small,
+        0.5 - theta_sq / 24 + theta_sq * theta_sq / 720,
+        (1 - torch.cos(theta)) / theta_sq_safe,
+    )
+
+    x, y, z = axis_angle.unbind(dim=-1)
+    zero = torch.zeros_like(x)
+    skew = torch.stack([zero, -z, y, z, zero, -x, -y, x, zero], dim=-1).reshape(*axis_angle.shape[:-1], 3, 3)
+    identity = torch.eye(3, dtype=axis_angle.dtype, device=axis_angle.device)
+    return (
+        identity
+        + sin_over_theta.unsqueeze(-1) * skew
+        + one_minus_cos_over_theta_sq.unsqueeze(-1) * (skew @ skew)
+    )
+
+
+def _sqrt_positive_part(value: Tensor) -> Tensor:
+    return torch.sqrt(torch.clamp(value, min=0))
+
+
+def matrix_to_axis_angle(matrix: Tensor) -> Tensor:
+    """Convert rotation matrices to canonical axis-angle vectors."""
+    if matrix.shape[-2:] != (3, 3):
+        raise ValueError(f"Rotation matrices must have shape [..., 3, 3], got {tuple(matrix.shape)}")
+
+    m00, m01, m02 = matrix[..., 0, 0], matrix[..., 0, 1], matrix[..., 0, 2]
+    m10, m11, m12 = matrix[..., 1, 0], matrix[..., 1, 1], matrix[..., 1, 2]
+    m20, m21, m22 = matrix[..., 2, 0], matrix[..., 2, 1], matrix[..., 2, 2]
+    quaternion_abs = _sqrt_positive_part(
+        torch.stack(
+            [
+                1 + m00 + m11 + m22,
+                1 + m00 - m11 - m22,
+                1 - m00 + m11 - m22,
+                1 - m00 - m11 + m22,
+            ],
+            dim=-1,
+        )
+    )
+    quaternion_candidates = torch.stack(
+        [
+            torch.stack([quaternion_abs[..., 0] ** 2, m21 - m12, m02 - m20, m10 - m01], dim=-1),
+            torch.stack([m21 - m12, quaternion_abs[..., 1] ** 2, m10 + m01, m02 + m20], dim=-1),
+            torch.stack([m02 - m20, m10 + m01, quaternion_abs[..., 2] ** 2, m12 + m21], dim=-1),
+            torch.stack([m10 - m01, m20 + m02, m21 + m12, quaternion_abs[..., 3] ** 2], dim=-1),
+        ],
+        dim=-2,
+    )
+    candidates = quaternion_candidates / (2 * quaternion_abs).clamp_min(0.1).unsqueeze(-1)
+    best = quaternion_abs.argmax(dim=-1)
+    gather_index = best[..., None, None].expand(*best.shape, 1, 4)
+    quaternion = candidates.gather(dim=-2, index=gather_index).squeeze(-2)
+    quaternion = torch.where(quaternion[..., :1] < 0, -quaternion, quaternion)
+
+    vector = quaternion[..., 1:]
+    vector_norm = torch.linalg.vector_norm(vector, dim=-1, keepdim=True)
+    half_angle = torch.atan2(vector_norm, quaternion[..., :1])
+    angle = 2 * half_angle
+    small = angle.abs() < 1e-6
+    sin_half_over_angle = torch.where(
+        small,
+        0.5 - angle * angle / 48,
+        torch.sin(half_angle) / angle.clamp_min(1e-8),
+    )
+    return vector / sin_half_over_angle.clamp_min(1e-8)
+
+
+def matrix_to_rotation_6d(matrix: Tensor) -> Tensor:
+    """Return the first two rows of a rotation matrix."""
+    if matrix.shape[-2:] != (3, 3):
+        raise ValueError(f"Rotation matrices must have shape [..., 3, 3], got {tuple(matrix.shape)}")
+    return matrix[..., :2, :].clone().reshape(*matrix.shape[:-2], 6)
+
+
+def rotation_6d_to_matrix(rotation_6d: Tensor) -> Tensor:
+    """Convert the row-based 6D rotation representation to a matrix."""
+    if rotation_6d.shape[-1] != 6:
+        raise ValueError(f"6D rotations must have shape [..., 6], got {tuple(rotation_6d.shape)}")
+    row0 = torch.nn.functional.normalize(rotation_6d[..., :3], dim=-1)
+    row1 = rotation_6d[..., 3:] - (row0 * rotation_6d[..., 3:]).sum(dim=-1, keepdim=True) * row0
+    row1 = torch.nn.functional.normalize(row1, dim=-1)
+    row2 = torch.cross(row0, row1, dim=-1)
+    return torch.stack([row0, row1, row2], dim=-2)
+
+
+def absolute_ee_to_relative(reference: Tensor, target: Tensor) -> Tensor:
+    """Express absolute 7D EE targets in a reference EE frame as 10D poses."""
+    if reference.shape[-1] != 7 or target.shape[-1] != 7:
+        raise ValueError(
+            "Relative EE requires 7D [xyz, axis-angle, gripper] poses; "
+            f"got reference={reference.shape[-1]}D and target={target.shape[-1]}D"
+        )
+    reference_rotation = axis_angle_to_matrix(reference[..., 3:6])
+    target_rotation = axis_angle_to_matrix(target[..., 3:6])
+    reference_rotation_t = reference_rotation.transpose(-2, -1)
+    relative_rotation = reference_rotation_t @ target_rotation
+    relative_translation = (
+        reference_rotation_t @ (target[..., :3] - reference[..., :3]).unsqueeze(-1)
+    ).squeeze(-1)
+    return torch.cat(
+        [relative_translation, matrix_to_rotation_6d(relative_rotation), target[..., 6:7]], dim=-1
+    )
+
+
+def relative_ee_to_absolute(relative: Tensor, reference: Tensor) -> Tensor:
+    """Convert relative 10D EE poses to absolute 7D EE targets."""
+    if relative.shape[-1] != 10 or reference.shape[-1] != 7:
+        raise ValueError(
+            "Relative EE requires 10D actions and a 7D reference pose; "
+            f"got action={relative.shape[-1]}D and reference={reference.shape[-1]}D"
+        )
+    reference_rotation = axis_angle_to_matrix(reference[..., 3:6])
+    absolute_rotation = reference_rotation @ rotation_6d_to_matrix(relative[..., 3:9])
+    absolute_translation = reference[..., :3] + (
+        reference_rotation @ relative[..., :3].unsqueeze(-1)
+    ).squeeze(-1)
+    return torch.cat(
+        [absolute_translation, matrix_to_axis_angle(absolute_rotation), relative[..., 9:10]], dim=-1
+    )
+
+
+def to_relative_ee_actions(actions: Tensor, state: Tensor) -> Tensor:
+    """Convert absolute action chunks using one reference pose per batch item."""
+    if actions.shape[-1] != 7 or state.shape[-1] != 7:
+        raise ValueError(
+            "Relative EE requires 7D [xyz, axis-angle, gripper] input; "
+            f"got action={actions.shape[-1]}D and state={state.shape[-1]}D"
+        )
+    if state.ndim == 3:
+        state = state[:, -1]
+    state = state.to(device=actions.device, dtype=actions.dtype)
+    if actions.ndim == 3:
+        state = state.unsqueeze(1).expand(*actions.shape[:-1], 7)
+    return absolute_ee_to_relative(state, actions)
+
+
+def to_absolute_ee_actions(actions: Tensor, state: Tensor) -> Tensor:
+    """Convert relative action chunks back to absolute EE targets."""
+    if actions.shape[-1] != 10 or state.shape[-1] != 7:
+        raise ValueError(
+            "Relative EE requires 10D actions and a 7D reference state; "
+            f"got action={actions.shape[-1]}D and state={state.shape[-1]}D"
+        )
+    if state.ndim == 3:
+        state = state[:, -1]
+    state = state.to(device=actions.device, dtype=actions.dtype)
+    if actions.ndim == 3:
+        state = state.unsqueeze(1).expand(*actions.shape[:-1], 7)
+    return relative_ee_to_absolute(actions, state)
+
+
+def to_relative_ee_state(state: Tensor) -> Tensor:
+    """Convert ``[previous, current]`` absolute poses to a flattened 20D state."""
+    if state.ndim != 3 or state.shape[-2:] != (2, 7):
+        raise ValueError(f"Relative EE state must have shape [batch, 2, 7], got {tuple(state.shape)}")
+    current = state[:, -1:].expand_as(state)
+    return absolute_ee_to_relative(current, state).flatten(start_dim=-2)
+
+
+@ProcessorStepRegistry.register("relative_ee_derive_state")
+@dataclass
+class RelativeEEDeriveStateStep(ProcessorStep):
+    """Derive ``[previous, current]`` state from the leading two actions."""
+
+    def __call__(self, transition: EnvTransition) -> EnvTransition:
+        action = transition.get(TransitionKey.ACTION)
+        if action is None or action.ndim < 3:
+            return transition
+        if action.shape[-2] < 2:
+            raise ValueError("Relative EE training requires at least two queried action poses")
+        result = transition.copy()
+        observation = dict(result.get(TransitionKey.OBSERVATION) or {})
+        observation[OBS_STATE] = action[..., :2, :]
+        result[TransitionKey.OBSERVATION] = observation
+        result[TransitionKey.ACTION] = action[..., 1:, :]
+
+        complementary = dict(result.get(TransitionKey.COMPLEMENTARY_DATA, {}))
+        for container in (result, complementary):
+            padding = container.get("action_is_pad")
+            if isinstance(padding, Tensor) and padding.ndim >= 2:
+                container["action_is_pad"] = padding[..., 1:]
+        if complementary:
+            result[TransitionKey.COMPLEMENTARY_DATA] = complementary
+        return result
+
+    def transform_features(self, features):
+        return features
+
+
+@ProcessorStepRegistry.register("relative_ee_actions")
+@dataclass
+class RelativeEEActionsStep(ProcessorStep):
+    """Convert absolute action chunks to fixed-base relative EE chunks."""
+
+    _last_state: Tensor | None = field(default=None, init=False, repr=False)
+
+    def __call__(self, transition: EnvTransition) -> EnvTransition:
+        observation = transition.get(TransitionKey.OBSERVATION, {})
+        raw_state = observation.get(OBS_STATE) if observation else None
+        state = raw_state[..., -1, :] if raw_state is not None and raw_state.ndim >= 3 else raw_state
+        if state is not None:
+            self._last_state = state.detach().clone()
+        action = transition.get(TransitionKey.ACTION)
+        if action is None or state is None:
+            return transition
+        result = transition.copy()
+        result[TransitionKey.ACTION] = to_relative_ee_actions(action, state)
+        return result
+
+    def get_cached_state(self) -> Tensor | None:
+        return self._last_state
+
+    def reset(self) -> None:
+        self._last_state = None
+
+    def transform_features(
+        self, features: dict[PipelineFeatureType, dict[str, PolicyFeature]]
+    ) -> dict[PipelineFeatureType, dict[str, PolicyFeature]]:
+        result = {feature_type: dict(values) for feature_type, values in features.items()}
+        action_features = result.get(PipelineFeatureType.ACTION, {})
+        if ACTION in action_features:
+            feature = action_features[ACTION]
+            action_features[ACTION] = PolicyFeature(type=feature.type, shape=(10,))
+        return result
+
+
+@ProcessorStepRegistry.register("relative_ee_state")
+@dataclass
+class RelativeEEStateStep(ProcessorStep):
+    """Convert raw EE observations to a two-pose, current-relative state."""
+
+    _previous_state: Tensor | None = field(default=None, init=False, repr=False)
+
+    def __call__(self, transition: EnvTransition) -> EnvTransition:
+        observation = transition.get(TransitionKey.OBSERVATION, {})
+        state = observation.get(OBS_STATE) if observation else None
+        if state is None:
+            return transition
+        if state.ndim == 2:
+            previous = state if self._previous_state is None else self._previous_state.to(state)
+            state_pair = torch.stack([previous, state], dim=1)
+            self._previous_state = state.detach().clone()
+        elif state.ndim == 3 and state.shape[1] == 2:
+            state_pair = state
+        else:
+            raise ValueError(f"Relative EE state must be [B, 7] or [B, 2, 7], got {tuple(state.shape)}")
+        result = transition.copy()
+        result_observation = dict(observation)
+        result_observation[OBS_STATE] = to_relative_ee_state(state_pair)
+        result[TransitionKey.OBSERVATION] = result_observation
+        return result
+
+    def reset(self) -> None:
+        self._previous_state = None
+
+    def transform_features(
+        self, features: dict[PipelineFeatureType, dict[str, PolicyFeature]]
+    ) -> dict[PipelineFeatureType, dict[str, PolicyFeature]]:
+        result = {feature_type: dict(values) for feature_type, values in features.items()}
+        observation_features = result.get(PipelineFeatureType.OBSERVATION, {})
+        if OBS_STATE in observation_features:
+            feature = observation_features[OBS_STATE]
+            observation_features[OBS_STATE] = PolicyFeature(type=feature.type, shape=(20,))
+        return result
+
+
+@ProcessorStepRegistry.register("absolute_ee_actions")
+@dataclass
+class AbsoluteEEActionsStep(ProcessorStep):
+    """Convert model-relative actions back to absolute EE targets."""
+
+    relative_step: RelativeEEActionsStep | None = field(default=None, repr=False)
+
+    def __call__(self, transition: EnvTransition) -> EnvTransition:
+        if self.relative_step is None:
+            raise RuntimeError("AbsoluteEEActionsStep requires a paired RelativeEEActionsStep")
+        state = self.relative_step.get_cached_state()
+        if state is None:
+            raise RuntimeError("Relative EE postprocessing requires the preprocessor to run first")
+        action = transition.get(TransitionKey.ACTION)
+        if action is None:
+            return transition
+        result = transition.copy()
+        result[TransitionKey.ACTION] = to_absolute_ee_actions(action, state)
+        return result
+
+    def get_config(self) -> dict[str, Any]:
+        return {}
+
+    def transform_features(
+        self, features: dict[PipelineFeatureType, dict[str, PolicyFeature]]
+    ) -> dict[PipelineFeatureType, dict[str, PolicyFeature]]:
+        result = {feature_type: dict(values) for feature_type, values in features.items()}
+        action_features = result.get(PipelineFeatureType.ACTION, {})
+        if ACTION in action_features:
+            feature = action_features[ACTION]
+            action_features[ACTION] = PolicyFeature(type=feature.type, shape=(7,))
+        return result

--- a/src/lerobot/rollout/context.py
+++ b/src/lerobot/rollout/context.py
@@ -38,6 +38,7 @@ from lerobot.policies import get_policy_class, make_pre_post_processors
 from lerobot.policies.pretrained import PreTrainedPolicy
 from lerobot.processor import (
     PolicyProcessorPipeline,
+    RelativeEEActionsStep,
     RobotAction,
     RobotObservation,
     RobotProcessorPipeline,
@@ -444,12 +445,13 @@ def build_rollout_context(
     )
 
     if isinstance(cfg.inference, SyncInferenceConfig) and any(
-        isinstance(step, RelativeActionsProcessorStep) and step.enabled
+        isinstance(step, RelativeEEActionsStep)
+        or (isinstance(step, RelativeActionsProcessorStep) and step.enabled)
         for step in getattr(preprocessor, "steps", ())
     ):
         raise NotImplementedError(
-            "SyncInferenceEngine does not support policies with relative actions for now."
-            "Use --inference.type=rtc or remove relative action processor steps from the policy pipeline."
+            "SyncInferenceEngine does not support relative-action policies. "
+            "Use --inference.type=rtc or remove relative processor steps from the policy pipeline."
         )
 
     # --- 7. Inference strategy (needs policy + pre/post + hardware) --

--- a/src/lerobot/rollout/inference/rtc.py
+++ b/src/lerobot/rollout/inference/rtc.py
@@ -33,13 +33,19 @@ from typing import Any
 import torch
 
 from lerobot.policies.pretrained import PreTrainedPolicy
-from lerobot.policies.rtc import ActionQueue, LatencyTracker, reanchor_relative_rtc_prefix
+from lerobot.policies.rtc import (
+    ActionQueue,
+    LatencyTracker,
+    reanchor_relative_ee_rtc_prefix,
+    reanchor_relative_rtc_prefix,
+)
 from lerobot.policies.rtc.configuration_rtc import RTCConfig
 from lerobot.policies.utils import prepare_observation_for_inference
 from lerobot.processor import (
     NormalizerProcessorStep,
     PolicyProcessorPipeline,
     RelativeActionsProcessorStep,
+    RelativeEEActionsStep,
 )
 from lerobot.utils.feature_utils import build_dataset_frame
 
@@ -161,6 +167,10 @@ class RTCInferenceEngine(InferenceEngine):
             (s for s in preprocessor.steps if isinstance(s, RelativeActionsProcessorStep) and s.enabled),
             None,
         )
+        self._relative_ee_step = next(
+            (s for s in preprocessor.steps if isinstance(s, RelativeEEActionsStep)),
+            None,
+        )
         self._normalizer_step = next(
             (s for s in preprocessor.steps if isinstance(s, NormalizerProcessorStep)),
             None,
@@ -175,6 +185,8 @@ class RTCInferenceEngine(InferenceEngine):
                         k for k in robot_wrapper.action_features if k.endswith(".pos")
                     ]
             logger.info("Relative actions enabled: RTC prefix will be re-anchored")
+        if self._relative_ee_step is not None:
+            logger.info("Relative EE enabled: RTC prefix will be re-anchored in SE(3)")
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -288,8 +300,7 @@ class RTCInferenceEngine(InferenceEngine):
                 if queue.qsize() <= self._rtc_queue_threshold:
                     try:
                         current_time = time.perf_counter()
-                        idx_before = queue.get_action_index()
-                        prev_actions = queue.get_left_over()
+                        idx_before, prev_actions, prev_abs = queue.get_left_over_snapshot()
 
                         latency = latency_tracker.max()
                         delay = math.ceil(latency / time_per_chunk) if latency else 0
@@ -302,13 +313,26 @@ class RTCInferenceEngine(InferenceEngine):
 
                         preprocessed = self._preprocessor(obs_batch)
 
-                        if prev_actions is not None and self._relative_step is not None:
-                            # Rebase against the raw cached state so the leftover tail stays in
-                            # the training-time coordinate frame.
-                            raw_state = self._relative_step.get_cached_state()
-                            if raw_state is not None:
-                                prev_abs = queue.get_processed_left_over()
-                                if prev_abs is not None and prev_abs.numel() > 0:
+                        if prev_actions is not None and self._rtc_config.enabled:
+                            if self._relative_ee_step is not None:
+                                raw_state = self._relative_ee_step.get_cached_state()
+                                if raw_state is None:
+                                    raise RuntimeError(
+                                        "Relative EE RTC re-anchoring requires a cached current EE state"
+                                    )
+                                if prev_abs is None or prev_abs.numel() == 0:
+                                    raise RuntimeError(
+                                        "Relative EE RTC re-anchoring requires absolute leftovers"
+                                    )
+                                prev_actions = reanchor_relative_ee_rtc_prefix(
+                                    prev_actions_absolute=prev_abs,
+                                    current_state=raw_state,
+                                    normalizer_step=self._normalizer_step,
+                                    policy_device=policy_device,
+                                )
+                            elif self._relative_step is not None:
+                                raw_state = self._relative_step.get_cached_state()
+                                if raw_state is not None and prev_abs is not None and prev_abs.numel() > 0:
                                     prev_actions = reanchor_relative_rtc_prefix(
                                         prev_actions_absolute=prev_abs,
                                         current_state=raw_state,

--- a/src/lerobot/scripts/lerobot_train.py
+++ b/src/lerobot/scripts/lerobot_train.py
@@ -337,6 +337,8 @@ def train(cfg: TrainPipelineConfig, accelerator: "Accelerator | None" = None):
 
     active_cfg = cfg.trainable_config
     processor_pretrained_path = active_cfg.pretrained_path
+    if getattr(active_cfg, "use_relative_ee", False) and not cfg.resume:
+        processor_pretrained_path = None
 
     processor_kwargs = {}
     if (processor_pretrained_path and not cfg.resume) or not processor_pretrained_path:

--- a/tests/policies/rtc/test_rtc_relative_actions.py
+++ b/tests/policies/rtc/test_rtc_relative_actions.py
@@ -29,6 +29,7 @@ from lerobot.processor.relative_action_processor import (
     RelativeActionsProcessorStep,
     to_relative_actions,
 )
+from lerobot.processor.relative_ee_processor import to_relative_ee_actions
 from lerobot.utils.constants import ACTION, OBS_STATE
 
 
@@ -54,6 +55,7 @@ RTCProcessor = _rtc_mod.RTCProcessor
 
 _rtc_relative_mod = _import_rtc_module("lerobot.policies.rtc.relative", "relative.py")
 reanchor_relative_rtc_prefix = _rtc_relative_mod.reanchor_relative_rtc_prefix
+reanchor_relative_ee_rtc_prefix = _rtc_relative_mod.reanchor_relative_ee_rtc_prefix
 
 ACTION_DIM = 6
 CHUNK_SIZE = 50
@@ -710,3 +712,37 @@ class TestMultiChunkConsistency:
         )
 
         assert result.shape == x_t.shape
+
+
+def test_relative_ee_rtc_prefix_is_reanchored_from_absolute_leftovers():
+    current_state = torch.tensor([[1.0, 2.0, 3.0, 0.1, -0.2, 0.3, 0.5]])
+    absolute_actions = torch.tensor(
+        [
+            [1.1, 2.0, 3.0, 0.2, -0.1, 0.3, 0.1],
+            [1.2, 2.1, 3.0, 0.3, 0.0, 0.2, 0.9],
+        ]
+    )
+
+    actual = reanchor_relative_ee_rtc_prefix(
+        prev_actions_absolute=absolute_actions,
+        current_state=current_state,
+        normalizer_step=None,
+        policy_device="cpu",
+    )
+
+    torch.testing.assert_close(actual, to_relative_ee_actions(absolute_actions, current_state[0]))
+
+
+def test_action_queue_leftover_snapshot_is_consistent():
+    queue = ActionQueue(_make_rtc_config())
+    original = torch.randn(5, 10)
+    processed = torch.randn(5, 7)
+    queue.merge(original, processed, real_delay=0)
+    queue.get()
+    queue.get()
+
+    index, original_leftover, processed_leftover = queue.get_left_over_snapshot()
+
+    assert index == 2
+    torch.testing.assert_close(original_leftover, original[2:])
+    torch.testing.assert_close(processed_leftover, processed[2:])

--- a/tests/policies/test_factory_peft_revision.py
+++ b/tests/policies/test_factory_peft_revision.py
@@ -18,6 +18,8 @@ from unittest.mock import MagicMock
 import torch
 
 import lerobot.policies.factory as policy_factory
+from lerobot.configs import FeatureType, PolicyFeature
+from lerobot.utils.constants import ACTION, OBS_STATE
 
 
 def test_make_policy_keeps_peft_adapter_and_base_revisions_separate(monkeypatch):
@@ -81,3 +83,30 @@ def test_make_policy_keeps_peft_adapter_and_base_revisions_separate(monkeypatch)
         revision="adapter-sha",
         is_trainable=True,
     )
+
+
+def test_make_policy_uses_model_facing_relative_ee_shapes(monkeypatch):
+    cfg = SimpleNamespace(
+        type="mock",
+        device="cpu",
+        pretrained_path=None,
+        pretrained_revision=None,
+        use_peft=False,
+        use_relative_ee=True,
+        input_features={},
+        output_features={},
+    )
+    dataset_meta = SimpleNamespace(features={}, stats={})
+    policy_class = MagicMock(return_value=torch.nn.Linear(1, 1))
+    raw_features = {
+        OBS_STATE: PolicyFeature(FeatureType.STATE, (7,)),
+        ACTION: PolicyFeature(FeatureType.ACTION, (7,)),
+    }
+    monkeypatch.setattr(policy_factory, "get_policy_class", lambda _: policy_class)
+    monkeypatch.setattr(policy_factory, "dataset_to_policy_features", lambda _: raw_features)
+    monkeypatch.setattr(policy_factory, "validate_visual_features_consistency", lambda *args: None)
+
+    policy_factory.make_policy(cfg, ds_meta=dataset_meta)
+
+    assert cfg.input_features[OBS_STATE].shape == (20,)
+    assert cfg.output_features[ACTION].shape == (10,)

--- a/tests/processor/test_act_processor.py
+++ b/tests/processor/test_act_processor.py
@@ -23,11 +23,14 @@ import torch
 from lerobot.configs.types import FeatureType, NormalizationMode, PolicyFeature
 from lerobot.policies.act.configuration_act import ACTConfig
 from lerobot.policies.act.processor_act import make_act_pre_post_processors
+from lerobot.policies.factory import make_pre_post_processors
 from lerobot.processor import (
+    AbsoluteEEActionsStep,
     AddBatchDimensionProcessorStep,
     DataProcessorPipeline,
     DeviceProcessorStep,
     NormalizerProcessorStep,
+    RelativeEEActionsStep,
     RenameObservationsProcessorStep,
     TransitionKey,
     UnnormalizerProcessorStep,
@@ -410,3 +413,27 @@ def test_act_processor_bfloat16_device_float32_normalizer():
     assert normalizer_step.dtype == torch.bfloat16
     for stat_tensor in normalizer_step._tensor_stats[OBS_STATE].values():
         assert stat_tensor.dtype == torch.bfloat16
+
+
+def test_relative_ee_processors_save_load_and_reconnect():
+    config = ACTConfig(use_relative_ee=True, device="cpu")
+    config.input_features = {OBS_STATE: PolicyFeature(FeatureType.STATE, (20,))}
+    config.output_features = {ACTION: PolicyFeature(FeatureType.ACTION, (10,))}
+    stats = {
+        OBS_STATE: {"min": torch.zeros(20), "max": torch.ones(20)},
+        ACTION: {"min": torch.zeros(10), "max": torch.ones(10)},
+    }
+    preprocessor, postprocessor = make_act_pre_post_processors(config, stats)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        preprocessor.save_pretrained(tmpdir)
+        postprocessor.save_pretrained(tmpdir)
+        loaded_preprocessor, loaded_postprocessor = make_pre_post_processors(config, pretrained_path=tmpdir)
+
+    relative_step = next(
+        step for step in loaded_preprocessor.steps if isinstance(step, RelativeEEActionsStep)
+    )
+    absolute_step = next(
+        step for step in loaded_postprocessor.steps if isinstance(step, AbsoluteEEActionsStep)
+    )
+    assert absolute_step.relative_step is relative_step

--- a/tests/processor/test_relative_ee_policy_processors.py
+++ b/tests/processor/test_relative_ee_policy_processors.py
@@ -1,0 +1,60 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+pytest.importorskip("transformers")
+
+from lerobot.configs import FeatureType, PolicyFeature  # noqa: E402
+from lerobot.policies.act.configuration_act import ACTConfig  # noqa: E402
+from lerobot.policies.act.processor_act import make_act_pre_post_processors  # noqa: E402
+from lerobot.policies.pi05.configuration_pi05 import PI05Config  # noqa: E402
+from lerobot.policies.pi05.processor_pi05 import make_pi05_pre_post_processors  # noqa: E402
+from lerobot.policies.smolvla.configuration_smolvla import SmolVLAConfig  # noqa: E402
+from lerobot.policies.smolvla.processor_smolvla import make_smolvla_pre_post_processors  # noqa: E402
+from lerobot.processor import (  # noqa: E402
+    AbsoluteEEActionsStep,
+    RelativeEEActionsStep,
+    RelativeEEDeriveStateStep,
+    RelativeEEStateStep,
+    tokenizer_processor,  # noqa: E402
+)
+from lerobot.utils.constants import ACTION, OBS_STATE  # noqa: E402
+
+
+def test_relative_ee_policy_pipelines(monkeypatch):
+    monkeypatch.setattr(
+        tokenizer_processor.AutoTokenizer, "from_pretrained", lambda *_args, **_kwargs: object()
+    )
+    stats = {
+        OBS_STATE: {"min": torch.zeros(20), "max": torch.ones(20)},
+        ACTION: {"min": torch.zeros(10), "max": torch.ones(10)},
+    }
+    configs_and_builders = [
+        (ACTConfig(use_relative_ee=True, device="cpu"), make_act_pre_post_processors),
+        (SmolVLAConfig(use_relative_ee=True, device="cpu"), make_smolvla_pre_post_processors),
+        (PI05Config(use_relative_ee=True, device="cpu"), make_pi05_pre_post_processors),
+    ]
+
+    for config, builder in configs_and_builders:
+        config.input_features = {OBS_STATE: PolicyFeature(FeatureType.STATE, (20,))}
+        config.output_features = {ACTION: PolicyFeature(FeatureType.ACTION, (10,))}
+        preprocessor, postprocessor = builder(config, stats)
+
+        assert config.action_delta_indices == [-1, *range(config.chunk_size)]
+        assert any(isinstance(step, RelativeEEDeriveStateStep) for step in preprocessor.steps)
+        assert any(isinstance(step, RelativeEEActionsStep) for step in preprocessor.steps)
+        assert any(isinstance(step, RelativeEEStateStep) for step in preprocessor.steps)
+        assert any(isinstance(step, AbsoluteEEActionsStep) for step in postprocessor.steps)

--- a/tests/processor/test_relative_ee_processor.py
+++ b/tests/processor/test_relative_ee_processor.py
@@ -1,0 +1,124 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import torch
+
+from lerobot.datasets.relative_ee_stats import compute_relative_ee_stats
+from lerobot.processor import (
+    RelativeEEActionsStep,
+    RelativeEEDeriveStateStep,
+    RelativeEEStateStep,
+    TransitionKey,
+    axis_angle_to_matrix,
+    batch_to_transition,
+    to_absolute_ee_actions,
+    to_relative_ee_actions,
+)
+from lerobot.utils.constants import ACTION, OBS_STATE
+
+
+def _pose(xyz, axis_angle, gripper):
+    return torch.tensor([*xyz, *axis_angle, gripper], dtype=torch.float32)
+
+
+def test_relative_ee_roundtrip_uses_one_reference_per_chunk():
+    references = torch.stack(
+        [
+            _pose([0.2, -0.1, 0.3], [0.0, 0.0, 0.0], 0.1),
+            _pose([-0.4, 0.2, 0.1], [0.3, -0.2, 0.1], 0.5),
+            _pose([0.0, 0.0, 0.0], [torch.pi - 1e-4, 0.0, 0.0], 0.9),
+        ]
+    )
+    actions = torch.stack(
+        [torch.stack([reference, reference + 0.05, reference - 0.03]) for reference in references]
+    )
+    actions[..., 6] = torch.tensor([0.2, 0.4, 0.6])
+
+    relative = to_relative_ee_actions(actions, references)
+    recovered = to_absolute_ee_actions(relative, references)
+
+    assert relative.shape == (3, 3, 10)
+    torch.testing.assert_close(recovered[..., :3], actions[..., :3], atol=1e-5, rtol=1e-5)
+    torch.testing.assert_close(recovered[..., 6], actions[..., 6])
+    torch.testing.assert_close(
+        axis_angle_to_matrix(recovered[..., 3:6]),
+        axis_angle_to_matrix(actions[..., 3:6]),
+        atol=2e-4,
+        rtol=2e-4,
+    )
+
+
+def test_relative_ee_training_steps_derive_state_and_shift_padding():
+    actions = torch.stack(
+        [
+            _pose([0.0, 0.0, 0.0], [0.0, 0.0, 0.0], 0.0),
+            _pose([0.1, 0.0, 0.0], [0.0, 0.0, 0.1], 0.1),
+            _pose([0.2, 0.0, 0.0], [0.0, 0.0, 0.2], 0.2),
+        ]
+    ).unsqueeze(0)
+    transition = batch_to_transition(
+        {
+            ACTION: actions,
+            "action_is_pad": torch.tensor([[True, False, False]]),
+        }
+    )
+
+    derived = RelativeEEDeriveStateStep()(transition)
+    processed = RelativeEEStateStep()(RelativeEEActionsStep()(derived))
+
+    assert derived[TransitionKey.ACTION].shape == (1, 2, 7)
+    assert derived[TransitionKey.OBSERVATION][OBS_STATE].shape == (1, 2, 7)
+    assert processed[TransitionKey.ACTION].shape == (1, 2, 10)
+    assert processed[TransitionKey.OBSERVATION][OBS_STATE].shape == (1, 20)
+    torch.testing.assert_close(processed[TransitionKey.ACTION][0, 0, :3], torch.zeros(3))
+
+
+def test_relative_ee_state_step_tracks_previous_observation_and_resets():
+    step = RelativeEEStateStep()
+    first = _pose([0.0, 0.0, 0.0], [0.0, 0.0, 0.0], 0.0).unsqueeze(0)
+    second = _pose([0.1, 0.0, 0.0], [0.0, 0.0, 0.2], 0.5).unsqueeze(0)
+
+    first_result = step(batch_to_transition({OBS_STATE: first}))
+    second_result = step(batch_to_transition({OBS_STATE: second}))
+    step.reset()
+    reset_result = step(batch_to_transition({OBS_STATE: second}))
+
+    first_state = first_result[TransitionKey.OBSERVATION][OBS_STATE]
+    second_state = second_result[TransitionKey.OBSERVATION][OBS_STATE]
+    reset_state = reset_result[TransitionKey.OBSERVATION][OBS_STATE]
+    torch.testing.assert_close(first_state[:, :9], first_state[:, 10:19])
+    assert not torch.allclose(second_state[:, :3], torch.zeros(1, 3))
+    torch.testing.assert_close(reset_state[:, :9], reset_state[:, 10:19])
+
+
+def test_relative_ee_stats_do_not_cross_episode_boundaries():
+    actions = np.array(
+        [
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.2],
+            [10.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.4],
+            [11.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.6],
+        ],
+        dtype=np.float32,
+    )
+    stats = compute_relative_ee_stats(
+        {ACTION: actions, "episode_index": np.array([0, 0, 1, 1])},
+        chunk_size=2,
+    )
+
+    np.testing.assert_allclose(stats[ACTION]["mean"][0], 1 / 3, atol=1e-6)
+    np.testing.assert_allclose(stats[OBS_STATE]["mean"][0], -0.5, atol=1e-6)
+    assert stats[ACTION]["mean"].shape == (10,)
+    assert stats[OBS_STATE]["mean"].shape == (20,)


### PR DESCRIPTION
## Summary / Motivation

Add an opt-in, hardware-agnostic processor path for UMI-style relative end-effector actions. Existing datasets can keep raw 7D pose actions while ACT, SmolVLA, and PI0.5 train in a relative 10D action representation and deployment reconstructs absolute end-effector commands. The feature is disabled by default and does not require support for a specific robot platform.

## Related issues

- Related: #3157

## What changed

- Add reusable processor steps for relative translation, row-based 6D rotation, gripper passthrough, and current/previous end-effector state construction.
- Derive relative-action normalization statistics from dataset episodes without crossing episode boundaries or counting padded tail actions.
- Add opt-in `use_relative_ee` processor wiring for ACT, SmolVLA, and PI0.5.
- Re-anchor RTC leftover prefixes in the current end-effector frame before guidance.
- Keep existing behavior unchanged when the option is disabled; no robot-specific dependency or Piper integration is introduced.

## How was this tested (or how to run locally)

- `pre-commit run --all-files`
- `pytest tests/policies/rtc tests/policies/test_factory_peft_revision.py tests/processor/test_act_processor.py tests/processor/test_relative_ee_policy_processors.py tests/processor/test_relative_ee_processor.py -svv --maxfail=1` (227 passed, 1 skipped)
- SmolVLA RTC initialization tests passed; PI0.5 model initialization was additionally attempted but the shared GPU was out of memory due to other running jobs.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [ ] All tests pass locally (`pytest`)
- [ ] Documentation updated (not included to keep this opt-in change minimal)
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor open PR and linked it here: pending

## Reviewer notes

- Please focus on the action/state representation, dataset statistics calculation, and RTC prefix re-anchoring.
- The implementation is intentionally hardware-agnostic and does not add or require Piper support.
- AI assistance was used during implementation and validation. I have personally reviewed the changes and understand the submitted code.
- Anyone in the community is free to review the PR.