### PR TITLE
fix: Fix a spelling typo in the RTC evaluation docstring.

### DIFF
--- a/examples/rtc/eval_dataset.py
+++ b/examples/rtc/eval_dataset.py
@@ -417,7 +417,7 @@ class RTCEvaluator:
     def run_evaluation(self):
         """Run evaluation on two random dataset samples using three separate policies.
 
-        Note: Policies are deinitalized after each step to free memory. Large models
+        Note: Policies are deinitialized after each step to free memory. Large models
         (e.g., VLA models with billions of parameters) cannot fit three instances in
         memory simultaneously. By deleting and garbage collecting after each step,
         we ensure only one policy is loaded at a time.

--- a/src/lerobot/policies/molmoact2/molmoact2_hf_model/modeling_molmoact2.py
+++ b/src/lerobot/policies/molmoact2/molmoact2_hf_model/modeling_molmoact2.py
@@ -1801,7 +1801,7 @@ class MolmoAct2VisionBackbone(nn.Module):
         valid = pooled_patches_idx >= 0
         valid_token = torch.any(valid, -1)
 
-        # Use `pooled_patches_idx` to arange the features for image pooling
+        # Use `pooled_patches_idx` to arrange the features for image pooling
         batch_idx = torch.arange(
             pooled_patches_idx.shape[0],
             dtype=torch.long,


### PR DESCRIPTION
## PR Title
docs: fix typo in RTC eval docstring

## Summary
- Fix a spelling typo in the RTC evaluation docstring.

## Changes
- Updated one word in [examples/rtc/eval_dataset.py#L420](http://_vscodecontentref_/0):
  - deinitalized -> deinitialized

## Impact
- Documentation-only change.
- No behavior or API changes.

cc @imstevenpmwork, could you please take a look when you have a chance? Thank you!