### PR TITLE
fix(teleoperators): make the module pass mypy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -549,9 +549,9 @@ ignore_errors = false
 # module = "lerobot.robots.*"
 # ignore_errors = false
 
-# [[tool.mypy.overrides]]
-# module = "lerobot.teleoperators.*"
-# ignore_errors = false
+[[tool.mypy.overrides]]
+module = "lerobot.teleoperators.*"
+ignore_errors = false
 
 # [[tool.mypy.overrides]]
 # module = "lerobot.policies.*"

--- a/src/lerobot/teleoperators/gamepad/teleop_gamepad.py
+++ b/src/lerobot/teleoperators/gamepad/teleop_gamepad.py
@@ -57,7 +57,7 @@ class GamepadTeleop(Teleoperator):
         self.config = config
         self.robot_type = config.type
 
-        self.gamepad = None
+        self.gamepad: Any = None
 
         self.hidapi_fallback = config.hidapi_fallback
         if sys.platform == "darwin" and not self.hidapi_fallback:
@@ -85,13 +85,20 @@ class GamepadTeleop(Teleoperator):
     def feedback_features(self) -> dict:
         return {}
 
-    def connect(self) -> None:
+    def connect(self, calibrate: bool = True) -> None:
+        # `calibrate` is part of the Teleoperator interface and is passed by
+        # `lerobot-calibrate`; a gamepad has nothing to calibrate, so it is ignored.
+        gamepad_cls: type[Any]
         if self.hidapi_fallback:
-            from .gamepad_utils import GamepadControllerHID as Gamepad
-        else:
-            from .gamepad_utils import GamepadController as Gamepad
+            from .gamepad_utils import GamepadControllerHID
 
-        self.gamepad = Gamepad()
+            gamepad_cls = GamepadControllerHID
+        else:
+            from .gamepad_utils import GamepadController
+
+            gamepad_cls = GamepadController
+
+        self.gamepad = gamepad_cls()
         self.gamepad.start()
 
     @check_if_not_connected
@@ -120,7 +127,7 @@ class GamepadTeleop(Teleoperator):
 
         return action_dict
 
-    def get_teleop_events(self) -> dict[str, Any]:
+    def get_teleop_events(self) -> dict[TeleopEvents, Any]:
         """
         Get extra control events from the gamepad such as intervention status,
         episode termination, success indicators, etc.
@@ -178,6 +185,7 @@ class GamepadTeleop(Teleoperator):
         # No calibration needed for gamepad
         pass
 
+    @property
     def is_calibrated(self) -> bool:
         """Check if gamepad is calibrated."""
         # Gamepad doesn't require calibration

--- a/src/lerobot/teleoperators/homunculus/homunculus_arm.py
+++ b/src/lerobot/teleoperators/homunculus/homunculus_arm.py
@@ -17,6 +17,7 @@
 import logging
 import threading
 from collections import deque
+from collections.abc import Mapping
 from pprint import pformat
 from typing import TYPE_CHECKING
 
@@ -65,7 +66,7 @@ class HomunculusArm(Teleoperator):
         self.n: int = n
         self.alpha: float = 2 / (n + 1)
         # one deque *per joint* so we can inspect raw history if needed
-        self._buffers: dict[str, deque[int]] = {
+        self._buffers: dict[str, deque[float]] = {
             joint: deque(maxlen=n)
             for joint in (
                 "shoulder_pitch",
@@ -166,8 +167,8 @@ class HomunculusArm(Teleoperator):
         display_len = max(len(key) for key in joints)
 
         start_positions = self._read(joints, normalize=False)
-        mins = start_positions.copy()
-        maxes = start_positions.copy()
+        mins = {joint: int(v) for joint, v in start_positions.items()}
+        maxes = {joint: int(v) for joint, v in start_positions.items()}
 
         user_pressed_enter = False
         while not user_pressed_enter:
@@ -200,7 +201,7 @@ class HomunculusArm(Teleoperator):
         pass
 
     # TODO(Steven): This function is copy/paste from the `HomunculusGlove` class. Consider moving it to an utility to reduce duplicated code.
-    def _normalize(self, values: dict[str, int]) -> dict[str, float]:
+    def _normalize(self, values: Mapping[str, float]) -> dict[str, float]:
         if not self.calibration:
             raise RuntimeError(f"{self} has no calibration registered.")
 
@@ -220,7 +221,7 @@ class HomunculusArm(Teleoperator):
 
         return normalized_values
 
-    def _apply_ema(self, raw: dict[str, int]) -> dict[str, float]:
+    def _apply_ema(self, raw: Mapping[str, float]) -> dict[str, float]:
         """Update buffers & running EMA values; return smoothed dict."""
         smoothed: dict[str, float] = {}
         for joint, value in raw.items():
@@ -228,12 +229,13 @@ class HomunculusArm(Teleoperator):
             self._buffers[joint].append(value)
 
             # initialise on first run
-            if self._ema[joint] is None:
+            previous = self._ema[joint]
+            if previous is None:
                 self._ema[joint] = float(value)
             else:
-                self._ema[joint] = self.alpha * value + (1 - self.alpha) * self._ema[joint]
+                self._ema[joint] = self.alpha * value + (1 - self.alpha) * previous
 
-            smoothed[joint] = self._ema[joint]
+            smoothed[joint] = float(self._ema[joint] or 0.0)
         return smoothed
 
     def _read(

--- a/src/lerobot/teleoperators/homunculus/homunculus_glove.py
+++ b/src/lerobot/teleoperators/homunculus/homunculus_glove.py
@@ -17,6 +17,7 @@
 import logging
 import threading
 from collections import deque
+from collections.abc import Mapping
 from pprint import pformat
 from typing import TYPE_CHECKING
 
@@ -102,7 +103,7 @@ class HomunculusGlove(Teleoperator):
         self.n: int = n
         self.alpha: float = 2 / (n + 1)
         # one deque *per joint* so we can inspect raw history if needed
-        self._buffers: dict[str, deque[int]] = {joint: deque(maxlen=n) for joint in self.joints}
+        self._buffers: dict[str, deque[float]] = {joint: deque(maxlen=n) for joint in self.joints}
         # running EMA value per joint – lazily initialised on first read
         self._ema: dict[str, float | None] = dict.fromkeys(self._buffers)
 
@@ -197,8 +198,8 @@ class HomunculusGlove(Teleoperator):
         display_len = max(len(key) for key in joints)
 
         start_positions = self._read(joints, normalize=False)
-        mins = start_positions.copy()
-        maxes = start_positions.copy()
+        mins = {joint: int(v) for joint, v in start_positions.items()}
+        maxes = {joint: int(v) for joint, v in start_positions.items()}
 
         user_pressed_enter = False
         while not user_pressed_enter:
@@ -231,7 +232,7 @@ class HomunculusGlove(Teleoperator):
         pass
 
     # TODO(Steven): This function is copy/paste from the `HomunculusArm` class. Consider moving it to an utility to reduce duplicated code.
-    def _normalize(self, values: dict[str, int]) -> dict[str, float]:
+    def _normalize(self, values: Mapping[str, float]) -> dict[str, float]:
         if not self.calibration:
             raise RuntimeError(f"{self} has no calibration registered.")
 
@@ -251,7 +252,7 @@ class HomunculusGlove(Teleoperator):
 
         return normalized_values
 
-    def _apply_ema(self, raw: dict[str, int]) -> dict[str, int]:
+    def _apply_ema(self, raw: Mapping[str, float]) -> dict[str, int]:
         """Update buffers & running EMA values; return smoothed dict as integers."""
         smoothed: dict[str, int] = {}
         for joint, value in raw.items():
@@ -259,13 +260,14 @@ class HomunculusGlove(Teleoperator):
             self._buffers[joint].append(value)
 
             # initialise on first run
-            if self._ema[joint] is None:
+            previous = self._ema[joint]
+            if previous is None:
                 self._ema[joint] = float(value)
             else:
-                self._ema[joint] = self.alpha * value + (1 - self.alpha) * self._ema[joint]
+                self._ema[joint] = self.alpha * value + (1 - self.alpha) * previous
 
             # Convert back to int for compatibility with normalization
-            smoothed[joint] = int(round(self._ema[joint]))
+            smoothed[joint] = int(round(self._ema[joint] or 0.0))
         return smoothed
 
     def _read(
@@ -290,13 +292,14 @@ class HomunculusGlove(Teleoperator):
             state = {k: v for k, v in state.items() if k in joints}
 
         # Apply EMA smoothing to raw values first
-        state = self._apply_ema(state)
+        smoothed: dict[str, int | float] = dict(self._apply_ema(state))
 
-        # Then normalize if requested
+        # Then normalize if requested. `dict` is invariant, so returning each branch
+        # directly avoids re-binding a dict[str, int] to a dict[str, float] name.
         if normalize:
-            state = self._normalize(state)
+            return self._normalize(smoothed)
 
-        return state
+        return smoothed
 
     def _read_loop(self):
         """

--- a/src/lerobot/teleoperators/keyboard/teleop_keyboard.py
+++ b/src/lerobot/teleoperators/keyboard/teleop_keyboard.py
@@ -33,13 +33,18 @@ from .configuration_keyboard import (
 )
 
 PYNPUT_AVAILABLE = _pynput_available
-keyboard = None
+# `pynput` is an optional dependency, so the module object is only bound when the
+# import succeeds. Importing under an alias and assigning afterwards keeps a single
+# binding for `keyboard` (no redefinition) while still allowing it to stay None.
+keyboard: Any = None
 if PYNPUT_AVAILABLE:
     try:
-        from pynput import keyboard
+        from pynput import keyboard as _pynput_keyboard
     except Exception as e:
         PYNPUT_AVAILABLE = False
         logging.info("Could not import pynput keyboard backend: %s", e)
+    else:
+        keyboard = _pynput_keyboard
 
 
 class KeyboardTeleop(Teleoperator):
@@ -56,18 +61,17 @@ class KeyboardTeleop(Teleoperator):
         self.config = config
         self.robot_type = config.type
 
-        self.event_queue = Queue()
-        self.current_pressed = {}
-        self.listener = None
-        self.logs = {}
+        self.event_queue: Queue[tuple[Any, bool]] = Queue()
+        self.current_pressed: dict[Any, bool] = {}
+        self.listener: Any = None
+        self.logs: dict[str, Any] = {}
 
     @property
     def action_features(self) -> dict:
-        return {
-            "dtype": "float32",
-            "shape": (len(self.arm),),
-            "names": {"motors": list(self.arm.motors)},
-        }
+        # `get_action` returns one entry per key that is currently held down, so the
+        # set of action names is not known ahead of time. Subclasses that emit a fixed
+        # action vector (end-effector, rover) override this with a concrete spec.
+        return {}
 
     @property
     def feedback_features(self) -> dict:
@@ -79,7 +83,8 @@ class KeyboardTeleop(Teleoperator):
 
     @property
     def is_calibrated(self) -> bool:
-        pass
+        """Keyboard teleop doesn't require calibration."""
+        return True
 
     @check_if_already_connected
     def connect(self) -> None:
@@ -158,7 +163,7 @@ class KeyboardEndEffectorTeleop(KeyboardTeleop):
     def __init__(self, config: KeyboardEndEffectorTeleopConfig):
         super().__init__(config)
         self.config = config
-        self.misc_keys_queue = Queue()
+        self.misc_keys_queue: Queue[Any] = Queue()
 
     @property
     def action_features(self) -> dict:
@@ -219,7 +224,7 @@ class KeyboardEndEffectorTeleop(KeyboardTeleop):
 
         return action_dict
 
-    def get_teleop_events(self) -> dict[str, Any]:
+    def get_teleop_events(self) -> dict[TeleopEvents, Any]:
         """
         Get extra control events from the keyboard such as intervention status,
         episode termination, success indicators, etc.

--- a/src/lerobot/teleoperators/koch_leader/koch_leader.py
+++ b/src/lerobot/teleoperators/koch_leader/koch_leader.py
@@ -122,9 +122,9 @@ class KochLeader(Teleoperator):
             self.calibration[motor] = MotorCalibration(
                 id=m.id,
                 drive_mode=drive_modes[motor],
-                homing_offset=homing_offsets[motor],
-                range_min=range_mins[motor],
-                range_max=range_maxes[motor],
+                homing_offset=int(homing_offsets[motor]),
+                range_min=int(range_mins[motor]),
+                range_max=int(range_maxes[motor]),
             )
 
         self.bus.write_calibration(self.calibration)

--- a/src/lerobot/teleoperators/openarm_leader/openarm_leader.py
+++ b/src/lerobot/teleoperators/openarm_leader/openarm_leader.py
@@ -200,11 +200,11 @@ class OpenArmLeader(Teleoperator):
         # Use sync_read_all_states to get pos/vel/torque in one go
         states = self.bus.sync_read_all_states()
         for motor in self.bus.motors:
-            state = states.get(motor, {})
-            action_dict[f"{motor}.pos"] = state.get("position")
+            state = states.get(motor)
+            action_dict[f"{motor}.pos"] = state.get("position") if state else None
             if self.config.use_velocity_and_torque:
-                action_dict[f"{motor}.vel"] = state.get("velocity")
-                action_dict[f"{motor}.torque"] = state.get("torque")
+                action_dict[f"{motor}.vel"] = state.get("velocity") if state else None
+                action_dict[f"{motor}.torque"] = state.get("torque") if state else None
 
         dt_ms = (time.perf_counter() - start) * 1e3
         logger.debug(f"{self} read state: {dt_ms:.1f}ms")

--- a/src/lerobot/teleoperators/openarm_mini/openarm_mini.py
+++ b/src/lerobot/teleoperators/openarm_mini/openarm_mini.py
@@ -155,7 +155,7 @@ class OpenArmMini(Teleoperator):
         motor_resolution = self.bus.model_resolution_table[list(self.bus.motors.values())[0].model]
         max_res = motor_resolution - 1
 
-        for motor_name, motor in self.bus.motors.items():
+        for motor_name, motor_obj in self.bus.motors.items():
             if motor_name == "gripper":
                 input(
                     "\nGripper Calibration\n"
@@ -189,9 +189,9 @@ class OpenArmMini(Teleoperator):
                 logger.info(f"  {motor_name}: range set to [0, {max_res}] (full motor range)")
 
             self.calibration[motor_name] = MotorCalibration(
-                id=motor.id,
+                id=motor_obj.id,
                 drive_mode=drive_mode,
-                homing_offset=homing_offsets[motor_name],
+                homing_offset=int(homing_offsets[motor_name]),
                 range_min=range_min,
                 range_max=range_max,
             )

--- a/src/lerobot/teleoperators/phone/teleop_phone.py
+++ b/src/lerobot/teleoperators/phone/teleop_phone.py
@@ -21,7 +21,7 @@
 import logging
 import threading
 import time
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
@@ -69,7 +69,7 @@ class BasePhone:
     @property
     def feedback_features(self) -> dict[str, type]:
         # No haptic or other feedback implemented yet
-        pass
+        return {}
 
     def configure(self) -> None:
         # No additional configuration required for phone teleop
@@ -88,14 +88,14 @@ class IOSPhone(BasePhone, Teleoperator):
         require_package("teleop", extra="phone")
         super().__init__(config)
         self.config = config
-        self._group = None
+        self._group: Any = None
 
     @property
     def is_connected(self) -> bool:
         return self._group is not None
 
     @check_if_already_connected
-    def connect(self) -> None:
+    def connect(self, calibrate: bool = True) -> None:
         logger.info("Connecting to IPhone, make sure to open the HEBI Mobile I/O app.")
         lookup = hebi.Lookup()
         time.sleep(2.0)
@@ -132,7 +132,7 @@ class IOSPhone(BasePhone, Teleoperator):
         """
         while True:
             has_pose, position, rotation, fb_pose = self._read_current_pose()
-            if not has_pose:
+            if not has_pose or position is None or rotation is None:
                 time.sleep(0.01)
                 continue
 
@@ -184,7 +184,7 @@ class IOSPhone(BasePhone, Teleoperator):
     @check_if_not_connected
     def get_action(self) -> dict:
         has_pose, raw_position, raw_rotation, fb_pose = self._read_current_pose()
-        if not has_pose or not self.is_calibrated:
+        if not has_pose or raw_position is None or raw_rotation is None or not self.is_calibrated:
             return {}
 
         # Collect raw inputs (B1 / analogs on iOS, move/scale on Android)
@@ -209,9 +209,12 @@ class IOSPhone(BasePhone, Teleoperator):
         if enable and not self._enabled:
             self._reapply_position_calibration(raw_position)
 
-        # Apply calibration
-        pos_cal = self._calib_rot_inv.apply(raw_position - self._calib_pos)
-        rot_cal = self._calib_rot_inv * raw_rotation
+        # Apply calibration. The `is_calibrated` check above already guarantees both
+        # are set; binding them to locals is what lets the type checker see that.
+        calib_pos, calib_rot_inv = self._calib_pos, self._calib_rot_inv
+        assert calib_pos is not None and calib_rot_inv is not None
+        pos_cal = calib_rot_inv.apply(raw_position - calib_pos)
+        rot_cal = calib_rot_inv * raw_rotation
 
         self._enabled = enable
 
@@ -235,10 +238,10 @@ class AndroidPhone(BasePhone, Teleoperator):
         require_package("teleop", extra="phone")
         super().__init__(config)
         self.config = config
-        self._teleop = None
-        self._teleop_thread = None
-        self._latest_pose = None
-        self._latest_message = None
+        self._teleop: Any = None
+        self._teleop_thread: threading.Thread | None = None
+        self._latest_pose: Any = None
+        self._latest_message: dict[str, Any] | None = None
         self._android_lock = threading.Lock()
 
     @property
@@ -246,7 +249,7 @@ class AndroidPhone(BasePhone, Teleoperator):
         return self._teleop is not None
 
     @check_if_already_connected
-    def connect(self) -> None:
+    def connect(self, calibrate: bool = True) -> None:
         logger.info("Starting teleop stream for Android...")
         self._teleop = Teleop()
         self._teleop.subscribe(self._android_callback)
@@ -287,7 +290,7 @@ class AndroidPhone(BasePhone, Teleoperator):
 
             if bool(msg.get("move", False)):
                 ok, pos, rot, _pose = self._read_current_pose()
-                if ok:
+                if ok and pos is not None and rot is not None:
                     return pos, rot
 
             time.sleep(0.01)
@@ -337,7 +340,7 @@ class AndroidPhone(BasePhone, Teleoperator):
     @check_if_not_connected
     def get_action(self) -> dict:
         ok, raw_pos, raw_rot, pose = self._read_current_pose()
-        if not ok or not self.is_calibrated:
+        if not ok or raw_pos is None or raw_rot is None or not self.is_calibrated:
             return {}
 
         # Collect raw inputs (B1 / analogs on iOS, move/scale on Android)
@@ -354,9 +357,12 @@ class AndroidPhone(BasePhone, Teleoperator):
         if enable and not self._enabled:
             self._reapply_position_calibration(raw_pos)
 
-        # Apply calibration
-        pos_cal = self._calib_rot_inv.apply(raw_pos - self._calib_pos)
-        rot_cal = self._calib_rot_inv * raw_rot
+        # Apply calibration. The `is_calibrated` check above already guarantees both
+        # are set; binding them to locals is what lets the type checker see that.
+        calib_pos, calib_rot_inv = self._calib_pos, self._calib_rot_inv
+        assert calib_pos is not None and calib_rot_inv is not None
+        pos_cal = calib_rot_inv.apply(raw_pos - calib_pos)
+        rot_cal = calib_rot_inv * raw_rot
 
         self._enabled = enable
 
@@ -405,7 +411,7 @@ class Phone(Teleoperator):
     def is_connected(self) -> bool:
         return self._phone_impl.is_connected
 
-    def connect(self) -> None:
+    def connect(self, calibrate: bool = True) -> None:
         return self._phone_impl.connect()
 
     def calibrate(self) -> None:

--- a/src/lerobot/teleoperators/reachy2_teleoperator/reachy2_teleoperator.py
+++ b/src/lerobot/teleoperators/reachy2_teleoperator/reachy2_teleoperator.py
@@ -148,6 +148,9 @@ class Reachy2Teleoperator(Teleoperator):
 
     @check_if_not_connected
     def get_action(self) -> dict[str, float]:
+        if self.reachy is None:
+            raise DeviceNotConnectedError(f"{self} is not connected.")
+
         start = time.perf_counter()
 
         joint_action: dict[str, float] = {}
@@ -173,5 +176,5 @@ class Reachy2Teleoperator(Teleoperator):
         raise NotImplementedError
 
     def disconnect(self) -> None:
-        if self.is_connected:
+        if self.is_connected and self.reachy is not None:
             self.reachy.disconnect()

--- a/src/lerobot/teleoperators/rebot_102_leader/rebot_102_leader.py
+++ b/src/lerobot/teleoperators/rebot_102_leader/rebot_102_leader.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING
 from lerobot.lerobot_types import RobotAction
 from lerobot.motors import MotorCalibration
 from lerobot.utils.decorators import check_if_already_connected, check_if_not_connected
+from lerobot.utils.errors import DeviceNotConnectedError
 from lerobot.utils.import_utils import _motorbridge_smart_servo_available, require_package
 
 from ..teleoperator import Teleoperator
@@ -98,6 +99,9 @@ class RebotArm102Leader(Teleoperator):
         return bool(self.calibration) and set(self.calibration) == set(self.motor_names)
 
     def calibrate(self) -> None:
+        if self.bus is None:
+            raise DeviceNotConnectedError(f"{self} is not connected.")
+
         if self.calibration:
             user_input = input(
                 f"Press ENTER to use provided calibration file associated with the id {self.id}, "
@@ -132,6 +136,9 @@ class RebotArm102Leader(Teleoperator):
         logger.info(f"Calibration saved to {self.calibration_fpath}")
 
     def configure(self) -> None:
+        if self.bus is None:
+            raise DeviceNotConnectedError(f"{self} is not connected.")
+
         for motor_id in self.config.joint_ids.values():
             self.bus.unlock(motor_id)
             time.sleep(_SETTLE_SEC)
@@ -140,6 +147,9 @@ class RebotArm102Leader(Teleoperator):
             self.bus.reset_multi_turn(motor_id)
 
     def _read_raw_positions(self) -> dict[str, float]:
+        if self.bus is None:
+            raise DeviceNotConnectedError(f"{self} is not connected.")
+
         result: dict[int, ServoMonitor | None] = self.bus.sync_monitor(list(self.config.joint_ids.values()))
         id_to_name = {v: k for k, v in self.config.joint_ids.items()}
         raw_positions: dict[str, float] = {}
@@ -202,6 +212,9 @@ class RebotArm102Leader(Teleoperator):
 
     @check_if_not_connected
     def disconnect(self) -> None:
+        if self.bus is None:
+            raise DeviceNotConnectedError(f"{self} is not connected.")
+
         self.bus.close()
         self.bus = None
         logger.info(f"{self} disconnected.")

--- a/src/lerobot/teleoperators/so_leader/so_leader.py
+++ b/src/lerobot/teleoperators/so_leader/so_leader.py
@@ -115,9 +115,9 @@ class SOLeader(Teleoperator):
             self.calibration[motor] = MotorCalibration(
                 id=m.id,
                 drive_mode=0,
-                homing_offset=homing_offsets[motor],
-                range_min=range_mins[motor],
-                range_max=range_maxes[motor],
+                homing_offset=int(homing_offsets[motor]),
+                range_min=int(range_mins[motor]),
+                range_max=int(range_maxes[motor]),
             )
 
         self.bus.write_calibration(self.calibration)

--- a/src/lerobot/teleoperators/unitree_g1/exo_calib.py
+++ b/src/lerobot/teleoperators/unitree_g1/exo_calib.py
@@ -152,9 +152,13 @@ def run_exo_calibration(
     side: str,
     save_path: Path,
     params: CalibParams | None = None,
-) -> ExoskeletonCalibration:
+) -> ExoskeletonCalibration | None:
     """
     Run interactive calibration for an exoskeleton arm.
+
+    Returns the calibration once every joint has been captured, or None if the plot
+    window is closed before the procedure finishes. `ExoSerial.calibrate` already
+    treats a falsy calibration as "not calibrated".
     """
     require_package("pyserial", extra="unitree_g1", import_name="serial")
     try:
@@ -256,7 +260,7 @@ def run_exo_calibration(
     joint_idx = 0
     phase = "ellipse"
     advance_requested = False
-    zero_samples = []
+    zero_samples: list[float] = []
 
     def on_key(event):
         nonlocal advance_requested
@@ -454,3 +458,6 @@ def run_exo_calibration(
 
     finally:
         plt.close(fig)
+
+    # The plot window was closed before every joint was captured.
+    return None

--- a/src/lerobot/teleoperators/unitree_g1/exo_ik.py
+++ b/src/lerobot/teleoperators/unitree_g1/exo_ik.py
@@ -22,6 +22,7 @@ visualizing the result in meshcat after calibration.
 import logging
 import os
 from dataclasses import dataclass
+from typing import Any
 
 import numpy as np
 
@@ -136,10 +137,10 @@ class ExoskeletonIKHelper:
             ),
         ]
 
-        self.exo = {}  # side -> pin.RobotWrapper
-        self.q_exo = {}  # side -> q
-        self.ee_id_exo = {}  # side -> frame id
-        self.qmap = {}  # side -> {joint_name: q_idx}
+        self.exo: dict[str, Any] = {}  # side -> pin.RobotWrapper
+        self.q_exo: dict[str, Any] = {}  # side -> q
+        self.ee_id_exo: dict[str, Any] = {}  # side -> frame id
+        self.qmap: dict[str, dict[str, int]] = {}  # side -> {joint_name: q_idx}
         self.ee_id_g1 = {}  # side -> frame id
 
         self._load_exo_models(assets_dir)
@@ -149,7 +150,7 @@ class ExoskeletonIKHelper:
         self.viewer = None
         self.markers: Markers | None = None
         self.viz_g1 = None
-        self.viz_exo = {}  # side -> viz
+        self.viz_exo: dict[str, Any] = {}  # side -> viz
 
     def _frozen_joint_indices(self) -> dict[str, int]:
         out = {}

--- a/src/lerobot/teleoperators/unitree_g1/unitree_g1.py
+++ b/src/lerobot/teleoperators/unitree_g1/unitree_g1.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Any
 
 from lerobot.robots.unitree_g1.g1_utils import REMOTE_AXES, G1_29_JointArmIndex
 from lerobot.utils.constants import HF_LEROBOT_CALIBRATION, TELEOPERATORS
+from lerobot.utils.errors import DeviceNotConnectedError
 from lerobot.utils.import_utils import _unitree_sdk_available
 
 if TYPE_CHECKING or _unitree_sdk_available:
@@ -208,7 +209,7 @@ class UnitreeG1Teleoperator(Teleoperator):
 
     @cached_property
     def action_features(self) -> dict[str, type]:
-        remote_features = dict.fromkeys(self.remote_controller.remote_action, float)
+        remote_features: dict[str, type] = dict.fromkeys(self.remote_controller.remote_action, float)
         if not self._arm_control_enabled:
             return remote_features
         joint_features = {f"{name}.q": float for name in self._g1_arm_joint_names}
@@ -269,10 +270,13 @@ class UnitreeG1Teleoperator(Teleoperator):
         pass
 
     def get_action(self) -> dict[str, float]:
-        joint_action = {}
+        joint_action: dict[str, float] = {}
         left_raw = None
         right_raw = None
         if self._arm_control_enabled:
+            if self.ik_helper is None:
+                raise DeviceNotConnectedError(f"{self} arm control is enabled but the IK helper is missing.")
+
             left_raw = self.left_arm.read_raw()
             right_raw = self.right_arm.read_raw()
 


### PR DESCRIPTION
## Summary / Motivation

Ticks `Teleoperators` off the module checklist in #1719: uncomments the `lerobot.teleoperators.*` override in `pyproject.toml` and fixes the 95 errors that surfaced. Most of the diff is annotations, but enabling the checker also surfaced seven real defects, listed below — that section is where reviewer attention is best spent.

No `# type: ignore` was added anywhere.

## Related issues

- Closes: #1726
- Part of: #1719

## Real bugs the checker surfaced

These change behaviour. Everything else in the diff is annotation-only.

| # | Where | Defect |
|---|---|---|
| 1 | `keyboard/teleop_keyboard.py` `KeyboardTeleop.action_features` | Read `self.arm`, which is never assigned in `__init__`. Touching the property raised `AttributeError`. |
| 2 | same file, `KeyboardTeleop.is_calibrated` | Declared `-> bool`, body was `pass`, so it returned `None`. |
| 3 | `phone/teleop_phone.py` `BasePhone.feedback_features` | Declared `-> dict[str, type]`, body was `pass`, so it returned `None`. |
| 4 | `gamepad/teleop_gamepad.py` `is_calibrated` | A plain method while the base declares a `@property`, so `teleop.is_calibrated` evaluated to a **bound method** and was always truthy. |
| 5 | `gamepad` + all three `Phone` classes, `connect` | Dropped the `calibrate` parameter from `Teleoperator.connect`. |
| 6 | `unitree_g1/exo_calib.py` `run_exo_calibration` | Declared `-> ExoskeletonCalibration` but falls through to an implicit `None`. |
| 7 | `openarm_mini/openarm_mini.py` `calibrate` | Reuses the name `motor` for both a motor name (`str`) and a `Motor` object in one scope. |

### On #5 — this one is user-reachable

`lerobot_calibrate.py:96` does `device.connect(calibrate=False)` on whatever `make_teleoperator_from_config` returns, and both classes are registered types (`@TeleoperatorConfig.register_subclass("gamepad")`, `("phone")`). So `lerobot-calibrate --device.type=gamepad` raised `TypeError`. Signature check against `main`:

```console
# on main
TypeError: got an unexpected keyword argument 'calibrate'
# with this PR
bind ok
```

They accept and ignore the argument now — neither device has anything to calibrate.

### On #1 — what `action_features` should be

`KeyboardTeleop.get_action` returns `dict.fromkeys(<keys currently held down>, None)`, so the action names aren't knowable up front. It now returns `{}`, matching `feedback_features` right below it. `KeyboardEndEffectorTeleop` and `KeyboardRoverTeleop` already override it with concrete specs, so nothing that emits a fixed action vector is affected. Say the word if you'd rather it describe something else.

### On #6 — kept non-breaking

`run_exo_calibration` returns the calibration once every joint is captured, and falls through if the plot window is closed first. Rather than change that, the signature is now `-> ExoskeletonCalibration | None` with an explicit `return None`, which is what `ExoSerial.calibrate` already copes with (`if not self.calibration: raise RuntimeError(...)`).

Also folded in: `MotorCalibration` takes `int`s, but koch / so / openarm leaders passed `int | float` readings straight through. Now coerced, matching what `rebot_102_leader` already did.

## What changed

- `pyproject.toml`: uncomment the `lerobot.teleoperators.*` override (`ignore_errors = false`).
- 14 source files under `src/lerobot/teleoperators/`: the seven fixes above, plus annotations. Optional handles are narrowed with the explicit `if x is None: raise DeviceNotConnectedError(...)` shape already used in `cameras/opencv/camera_opencv.py` rather than widening to `Any`. `_normalize` / `_apply_ema` in the homunculus devices take `Mapping[str, float]` so the invariant `dict` value type stops fighting the int→float pipeline.

**Breaking changes:** none for callers going through the documented interface. #4 makes `GamepadTeleop.is_calibrated` an attribute instead of a callable; nothing in `src/`, `tests/` or `examples/` calls it as `is_calibrated()`.

## How was this tested

- `mypy --config-file=pyproject.toml src/lerobot/teleoperators` → **95 errors → 0**.
- `mypy --config-file=pyproject.toml src/lerobot` → **`Success: no issues found in 490 source files`**. Worth doing both: checking the directory alone reports clean while the whole-package run still had 14 errors, because cross-module types degrade to `Any` under `follow_imports = "skip"`. Those 14 are fixed here too.
- `ruff check` and `ruff format --check` clean on every changed file.
- `pytest tests/teleoperators -q` → `5 passed, 2 skipped`, identical to `main`.
- Behaviour diff against `main`, via `inspect`:

| check | `main` | this PR |
|---|---|---|
| `GamepadTeleop.connect` signature | `(self)` | `(self, calibrate: bool = True)` |
| `Phone.connect` signature | `(self)` | `(self, calibrate: bool = True)` |
| `GamepadTeleop.is_calibrated` is a `property` | **False** | True |
| `KeyboardTeleop.action_features` references `self.arm` | **True** | False |

mypy pinned to `1.19.1` to match `.pre-commit-config.yaml`.

## Checklist

- [x] Linting/formatting run (`ruff check` + `ruff format --check`; mypy at the pinned version)
- [x] Tests pass locally (`pytest tests/teleoperators`)
- [ ] Documentation updated — n/a, no user-facing API docs touched
- [ ] CI is green — will watch
- [x] Community Review: reviewed https://github.com/huggingface/lerobot/pull/4242

## Reviewer notes

The seven-row table is the whole risk surface; the rest is annotations. #1, #4 and #6 are the ones where I picked a behaviour and would rather be corrected than guess — all three are one-liners to change if you prefer a different answer.
