### PR TITLE
fix(so_follower): check the observation for None before copying it

### DIFF
--- a/src/lerobot/robots/so_follower/robot_kinematic_processor.py
+++ b/src/lerobot/robots/so_follower/robot_kinematic_processor.py
@@ -77,10 +77,12 @@ class EEReferenceAndDelta(RobotActionProcessorStep):
     _command_when_disabled: np.ndarray | None = field(default=None, init=False, repr=False)
 
     def action(self, action: RobotAction) -> RobotAction:
-        observation = self.transition.get(TransitionKey.OBSERVATION).copy()
+        raw_observation = self.transition.get(TransitionKey.OBSERVATION)
 
-        if observation is None:
+        if raw_observation is None:
             raise ValueError("Joints observation is require for computing robot kinematics")
+
+        observation = raw_observation.copy()
 
         if self.use_ik_solution and "IK_solution" in self.transition.get(TransitionKey.COMPLEMENTARY_DATA):
             q_raw = self.transition.get(TransitionKey.COMPLEMENTARY_DATA)["IK_solution"]
@@ -311,9 +313,11 @@ class InverseKinematicsEEToJoints(RobotActionProcessorStep):
                 "Missing required end-effector pose components: ee.x, ee.y, ee.z, ee.wx, ee.wy, ee.wz, ee.gripper_pos must all be present in action"
             )
 
-        observation = self.transition.get(TransitionKey.OBSERVATION).copy()
-        if observation is None:
+        raw_observation = self.transition.get(TransitionKey.OBSERVATION)
+        if raw_observation is None:
             raise ValueError("Joints observation is require for computing robot kinematics")
+
+        observation = raw_observation.copy()
 
         q_raw = np.array(
             [float(v) for k, v in observation.items() if isinstance(k, str) and k.endswith(".pos")],
@@ -391,12 +395,14 @@ class GripperVelocityToJoint(RobotActionProcessorStep):
     discrete_gripper: bool = False
 
     def action(self, action: RobotAction) -> RobotAction:
-        observation = self.transition.get(TransitionKey.OBSERVATION).copy()
+        raw_observation = self.transition.get(TransitionKey.OBSERVATION)
 
         gripper_vel = action.pop("ee.gripper_vel")
 
-        if observation is None:
+        if raw_observation is None:
             raise ValueError("Joints observation is require for computing robot kinematics")
+
+        observation = raw_observation.copy()
 
         q_raw = np.array(
             [float(v) for k, v in observation.items() if isinstance(k, str) and k.endswith(".pos")],
@@ -583,9 +589,11 @@ class InverseKinematicsRLStep(ProcessorStep):
                 "Missing required end-effector pose components: ee.x, ee.y, ee.z, ee.wx, ee.wy, ee.wz, ee.gripper_pos must all be present in action"
             )
 
-        observation = new_transition.get(TransitionKey.OBSERVATION).copy()
-        if observation is None:
+        raw_observation = new_transition.get(TransitionKey.OBSERVATION)
+        if raw_observation is None:
             raise ValueError("Joints observation is require for computing robot kinematics")
+
+        observation = raw_observation.copy()
 
         q_raw = np.array(
             [float(v) for k, v in observation.items() if isinstance(k, str) and k.endswith(".pos")],

--- a/tests/robots/test_robot_kinematic_processor.py
+++ b/tests/robots/test_robot_kinematic_processor.py
@@ -17,9 +17,14 @@
 import pytest
 
 from lerobot.configs import FeatureType, PipelineFeatureType, PolicyFeature
+from lerobot.processor.converters import create_transition
 from lerobot.robots.so_follower.robot_kinematic_processor import (
+    EEReferenceAndDelta,
     ForwardKinematicsJointsToEEAction,
     ForwardKinematicsJointsToEEObservation,
+    GripperVelocityToJoint,
+    InverseKinematicsEEToJoints,
+    InverseKinematicsRLStep,
 )
 
 MOTOR_NAMES = ["shoulder_pan", "shoulder_lift", "elbow_flex", "wrist_flex", "wrist_roll", "gripper"]
@@ -43,3 +48,38 @@ def test_fk_feature_schema(step_cls, bucket, feature_type):
     out = step_cls(kinematics=None, motor_names=MOTOR_NAMES).transform_features(features)[bucket]
     assert set(out) == EE_KEYS
     assert {feature.type for feature in out.values()} == {feature_type}
+
+
+EE_ACTION = dict.fromkeys(EE_KEYS, 0.0)
+
+
+@pytest.mark.parametrize(
+    ("step", "action"),
+    [
+        (
+            EEReferenceAndDelta(kinematics=None, end_effector_step_sizes={}, motor_names=MOTOR_NAMES),
+            dict(EE_ACTION),
+        ),
+        (InverseKinematicsEEToJoints(kinematics=None, motor_names=MOTOR_NAMES), dict(EE_ACTION)),
+        (GripperVelocityToJoint(), {**EE_ACTION, "ee.gripper_vel": 0.0}),
+        (InverseKinematicsRLStep(kinematics=None, motor_names=MOTOR_NAMES), dict(EE_ACTION)),
+    ],
+    ids=[
+        "ee_reference_and_delta",
+        "inverse_kinematics_ee_to_joints",
+        "gripper_velocity_to_joint",
+        "inverse_kinematics_rl_step",
+    ],
+)
+def test_missing_observation_raises_value_error(step, action):
+    """A transition without an observation must surface the documented ValueError.
+
+    `RobotProcessorPipeline.process_action` builds its transition with
+    `create_transition(action=...)`, which sets `TransitionKey.OBSERVATION` to None.
+    These steps used to call `.copy()` on that before the None check, so the guard
+    below them was unreachable and an AttributeError escaped instead.
+    """
+    transition = create_transition(action=action)
+
+    with pytest.raises(ValueError, match="Joints observation"):
+        step(transition)


### PR DESCRIPTION
## Summary / Motivation

Four kinematic processor steps read the observation like this:

```python
observation = self.transition.get(TransitionKey.OBSERVATION).copy()

if observation is None:
    raise ValueError("Joints observation is require for computing robot kinematics")
```

`.copy()` runs before the check, so the guard underneath it can never fire. A transition without an observation raises `AttributeError: 'NoneType' object has no attribute 'copy'` and the intended message is never seen.

That transition is not hypothetical. `RobotProcessorPipeline.process_action` — the documented "process only the action" entry point — builds one with `create_transition(action=action)`, and `create_transition` sets `TransitionKey.OBSERVATION` to `None` (`processor/converters.py:207`). So putting any of these steps in an action-only pipeline surfaces the wrong error.

## Related issues

None open that I could find — spotted while enabling mypy on `lerobot.robots.*` for #1719.

## What changed

Read the value, check it, then copy. Four call sites, one file:

| class | line |
|---|---|
| `EEReferenceAndDelta` | `action()` |
| `InverseKinematicsEEToJoints` | `action()` |
| `GripperVelocityToJoint` | `action()` |
| `InverseKinematicsRLStep` | `__call__()` |

No behaviour change on the happy path: the same dict is copied, just after the check instead of before. The only difference is which exception a caller sees when the observation is missing.

**Not touched, but noticed while in here** — say the word and I'll fold either in:

- The message reads `"Joints observation is require for..."` (missing `d`) at all four sites plus three more. Left alone so the diff stays purely about the guard ordering.
- Three further `if q_raw is None:` checks (lines 101, 326, 411) sit directly after `q_raw = np.array(...)`, which never returns `None`, so those guards are dead too. Harmless, unlike this one.
- `GripperVelocityToJoint`'s docstring documents a `motor_names` attribute the dataclass doesn't have.

## How was this tested

Added `test_missing_observation_raises_value_error` to `tests/robots/test_robot_kinematic_processor.py`, parametrised over all four steps, feeding each an action-only transition built exactly the way `process_action` builds one.

Reverting the source change makes every case fail with the bug:

```console
$ pytest tests/robots/test_robot_kinematic_processor.py -q   # source reverted to main
>       observation = self.transition.get(TransitionKey.OBSERVATION).copy()
E       AttributeError: 'NoneType' object has no attribute 'copy'

FAILED ...::test_missing_observation_raises_value_error[ee_reference_and_delta]
FAILED ...::test_missing_observation_raises_value_error[inverse_kinematics_ee_to_joints]
FAILED ...::test_missing_observation_raises_value_error[gripper_velocity_to_joint]
FAILED ...::test_missing_observation_raises_value_error[inverse_kinematics_rl_step]
4 failed, 2 passed
```

With the fix:

```console
$ pytest tests/robots -q
19 passed, 2 skipped
```

`ruff check` and `ruff format --check` clean on both changed files.

## Checklist

- [x] Linting/formatting run (`ruff check`, `ruff format --check`)
- [x] All tests pass locally (`pytest tests/robots`)
- [ ] Documentation updated — n/a
- [ ] CI is green — will watch
- [x] Community Review: reviewed https://github.com/huggingface/lerobot/pull/4224 and https://github.com/huggingface/lerobot/pull/4242

## Reviewer notes

The whole change is moving `.copy()` three lines down, four times. The test is the part worth reading — it pins the exact pipeline path (`create_transition(action=...)`) that reaches these steps without an observation.
