### PR TITLE
feat(peft): add LoRA+ differential learning rates

### DIFF
--- a/docs/source/peft_training.mdx
+++ b/docs/source/peft_training.mdx
@@ -39,6 +39,12 @@ instead of the full weight matrix. This rank can be specified using the `--peft.
 `--peft.lora_alpha` (where `scaling = lora_alpha / r`). The higher the rank
 the closer you get to full fine-tuning
 
+To speed up convergence you can enable [LoRA+](https://arxiv.org/abs/2402.12354) by adding
+`--peft.loraplus_lr_ratio=16` to the command above. LoRA+ trains the LoRA `B` matrices at
+`lr * loraplus_lr_ratio` while the `A` matrices keep the base learning rate, which can improve
+convergence at no extra compute cost. The ratio must be greater than 0; leaving it unset keeps
+standard LoRA with a single learning rate.
+
 There are more complex methods that have more parameters. These are not yet supported, feel free to raise an issue
 if you want to see a specific PEFT method supported.
 

--- a/src/lerobot/configs/default.py
+++ b/src/lerobot/configs/default.py
@@ -146,6 +146,13 @@ class PeftConfig:
     # Common values are r (alpha == rank) or 2*r.
     lora_alpha: int | None = None
 
+    # LoRA+ (https://arxiv.org/abs/2402.12354): trains the LoRA B matrices with a higher learning
+    # rate than the A matrices, which can speed up convergence at no extra cost. When set, the B
+    # matrices use `lr * loraplus_lr_ratio` and the A matrices (and any other trainable parameters)
+    # use the base `lr`. `None` keeps standard LoRA (a single learning rate). A typical value is 16;
+    # must be > 0.
+    loraplus_lr_ratio: float | None = None
+
 
 @dataclass
 class JobConfig:

--- a/src/lerobot/optim/factory.py
+++ b/src/lerobot/optim/factory.py
@@ -15,11 +15,52 @@
 # limitations under the License.
 
 
+from typing import Any
+
+import torch
 from torch.optim import Optimizer
 from torch.optim.lr_scheduler import LRScheduler
 
 from lerobot.configs.train import TrainPipelineConfig
 from lerobot.policies import PreTrainedPolicy
+
+
+def make_loraplus_param_groups(
+    model: torch.nn.Module, lr: float, loraplus_lr_ratio: float
+) -> list[dict[str, Any]]:
+    """Split a PEFT model's trainable parameters into LoRA+ learning-rate groups.
+
+    LoRA+ (https://arxiv.org/abs/2402.12354) trains the LoRA ``B`` matrices at
+    ``lr * loraplus_lr_ratio`` while the ``A`` matrices and any other trainable parameters keep the
+    base ``lr``, which can speed up convergence at no extra compute cost.
+
+    Args:
+        model: The (PEFT-wrapped) policy whose ``named_parameters`` are grouped.
+        lr: Base learning rate used for the A matrices and any other trainable parameters.
+        loraplus_lr_ratio: Multiplier applied to ``lr`` for the LoRA B matrices. Must be > 0.
+
+    Returns:
+        Parameter groups (with per-group ``lr``) suitable for an optimizer's ``build`` method.
+    """
+    if loraplus_lr_ratio <= 0:
+        raise ValueError(f"`loraplus_lr_ratio` must be > 0, got {loraplus_lr_ratio}.")
+
+    lora_b_params: list[torch.nn.Parameter] = []
+    other_params: list[torch.nn.Parameter] = []
+    for name, param in model.named_parameters():
+        if not param.requires_grad:
+            continue
+        if "lora_B" in name or "lora_embedding_B" in name:
+            lora_b_params.append(param)
+        else:
+            other_params.append(param)
+
+    param_groups: list[dict[str, Any]] = []
+    if other_params:
+        param_groups.append({"params": other_params, "lr": lr})
+    if lora_b_params:
+        param_groups.append({"params": lora_b_params, "lr": lr * loraplus_lr_ratio})
+    return param_groups
 
 
 def make_optimizer_and_scheduler(
@@ -34,9 +75,14 @@ def make_optimizer_and_scheduler(
     Returns:
         tuple[Optimizer, LRScheduler | None]: The couple (Optimizer, Scheduler). Scheduler can be `None`.
     """
-    params = policy.get_optim_params() if cfg.use_policy_training_preset else policy.parameters()
     if cfg.optimizer is None:
         raise ValueError("Optimizer config is required but not provided in TrainPipelineConfig")
+
+    if cfg.peft is not None and cfg.peft.loraplus_lr_ratio is not None:
+        params = make_loraplus_param_groups(policy, cfg.optimizer.lr, cfg.peft.loraplus_lr_ratio)
+    else:
+        params = policy.get_optim_params() if cfg.use_policy_training_preset else policy.parameters()
+
     optimizer = cfg.optimizer.build(params)
     lr_scheduler = cfg.scheduler.build(optimizer, cfg.steps) if cfg.scheduler is not None else None
     return optimizer, lr_scheduler

--- a/src/lerobot/optim/factory.py
+++ b/src/lerobot/optim/factory.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 
+import logging
 from typing import Any
 
 import torch
@@ -23,6 +24,18 @@ from torch.optim.lr_scheduler import LRScheduler
 
 from lerobot.configs.train import TrainPipelineConfig
 from lerobot.policies import PreTrainedPolicy
+
+
+def _scale_group_lr(group: dict[str, Any], loraplus_lr_ratio: float) -> None:
+    """Scale a parameter group's learning rate, keeping ``initial_lr`` in sync.
+
+    LR schedulers stamp ``initial_lr`` on each group and anneal from it, so a group whose ``lr`` is
+    scaled must have its ``initial_lr`` scaled by the same factor, otherwise the scheduler would
+    reset the group back to the unscaled learning rate.
+    """
+    group["lr"] = group["lr"] * loraplus_lr_ratio
+    if "initial_lr" in group:
+        group["initial_lr"] = group["initial_lr"] * loraplus_lr_ratio
 
 
 def apply_loraplus_lr_ratio(optimizer: Optimizer, model: torch.nn.Module, loraplus_lr_ratio: float) -> None:
@@ -50,6 +63,10 @@ def apply_loraplus_lr_ratio(optimizer: Optimizer, model: torch.nn.Module, lorapl
         if param.requires_grad and ("lora_B" in name or "lora_embedding_B" in name)
     }
     if not lora_b_param_ids:
+        logging.warning(
+            "`loraplus_lr_ratio` is set but no trainable LoRA B parameters were found, so LoRA+ has "
+            "no effect. Check that a LoRA adapter is attached (e.g. `--peft.method_type=LORA`)."
+        )
         return
 
     scaled_b_groups: list[dict[str, Any]] = []
@@ -60,13 +77,13 @@ def apply_loraplus_lr_ratio(optimizer: Optimizer, model: torch.nn.Module, lorapl
         other_params = [p for p in group["params"] if id(p) not in lora_b_param_ids]
         if not other_params:
             # The whole group is LoRA B: scale its learning rate in place.
-            group["lr"] = group["lr"] * loraplus_lr_ratio
+            _scale_group_lr(group, loraplus_lr_ratio)
             continue
         # Keep the non-B params in this group and move the B params to a scaled sibling group.
         group["params"] = other_params
         b_group = {key: value for key, value in group.items() if key != "params"}
         b_group["params"] = b_params
-        b_group["lr"] = group["lr"] * loraplus_lr_ratio
+        _scale_group_lr(b_group, loraplus_lr_ratio)
         scaled_b_groups.append(b_group)
 
     for b_group in scaled_b_groups:

--- a/src/lerobot/optim/factory.py
+++ b/src/lerobot/optim/factory.py
@@ -25,42 +25,52 @@ from lerobot.configs.train import TrainPipelineConfig
 from lerobot.policies import PreTrainedPolicy
 
 
-def make_loraplus_param_groups(
-    model: torch.nn.Module, lr: float, loraplus_lr_ratio: float
-) -> list[dict[str, Any]]:
-    """Split a PEFT model's trainable parameters into LoRA+ learning-rate groups.
+def apply_loraplus_lr_ratio(optimizer: Optimizer, model: torch.nn.Module, loraplus_lr_ratio: float) -> None:
+    """Give the LoRA B matrices a higher learning rate (LoRA+) on an already-built optimizer.
 
     LoRA+ (https://arxiv.org/abs/2402.12354) trains the LoRA ``B`` matrices at
-    ``lr * loraplus_lr_ratio`` while the ``A`` matrices and any other trainable parameters keep the
-    base ``lr``, which can speed up convergence at no extra compute cost.
+    ``lr * loraplus_lr_ratio`` while the ``A`` matrices keep the base ``lr``, which can speed up
+    convergence at no extra compute cost. Rather than replacing the optimizer's inputs, this splits
+    the ``B`` parameters out of each existing parameter group into a sibling group with the scaled
+    learning rate. It therefore composes with any optimizer, including presets that build their own
+    (named-parameter) groups such as ``XVLAAdamWConfig``.
 
     Args:
-        model: The (PEFT-wrapped) policy whose ``named_parameters`` are grouped.
-        lr: Base learning rate used for the A matrices and any other trainable parameters.
-        loraplus_lr_ratio: Multiplier applied to ``lr`` for the LoRA B matrices. Must be > 0.
-
-    Returns:
-        Parameter groups (with per-group ``lr``) suitable for an optimizer's ``build`` method.
+        optimizer: An optimizer already built from the model's parameters.
+        model: The (PEFT-wrapped) policy, used to identify the LoRA B parameters by name.
+        loraplus_lr_ratio: Multiplier applied to each group's ``lr`` for its LoRA B matrices.
+            Must be > 0.
     """
     if loraplus_lr_ratio <= 0:
         raise ValueError(f"`loraplus_lr_ratio` must be > 0, got {loraplus_lr_ratio}.")
 
-    lora_b_params: list[torch.nn.Parameter] = []
-    other_params: list[torch.nn.Parameter] = []
-    for name, param in model.named_parameters():
-        if not param.requires_grad:
-            continue
-        if "lora_B" in name or "lora_embedding_B" in name:
-            lora_b_params.append(param)
-        else:
-            other_params.append(param)
+    lora_b_param_ids = {
+        id(param)
+        for name, param in model.named_parameters()
+        if param.requires_grad and ("lora_B" in name or "lora_embedding_B" in name)
+    }
+    if not lora_b_param_ids:
+        return
 
-    param_groups: list[dict[str, Any]] = []
-    if other_params:
-        param_groups.append({"params": other_params, "lr": lr})
-    if lora_b_params:
-        param_groups.append({"params": lora_b_params, "lr": lr * loraplus_lr_ratio})
-    return param_groups
+    scaled_b_groups: list[dict[str, Any]] = []
+    for group in optimizer.param_groups:
+        b_params = [p for p in group["params"] if id(p) in lora_b_param_ids]
+        if not b_params:
+            continue
+        other_params = [p for p in group["params"] if id(p) not in lora_b_param_ids]
+        if not other_params:
+            # The whole group is LoRA B: scale its learning rate in place.
+            group["lr"] = group["lr"] * loraplus_lr_ratio
+            continue
+        # Keep the non-B params in this group and move the B params to a scaled sibling group.
+        group["params"] = other_params
+        b_group = {key: value for key, value in group.items() if key != "params"}
+        b_group["params"] = b_params
+        b_group["lr"] = group["lr"] * loraplus_lr_ratio
+        scaled_b_groups.append(b_group)
+
+    for b_group in scaled_b_groups:
+        optimizer.add_param_group(b_group)
 
 
 def make_optimizer_and_scheduler(
@@ -78,11 +88,15 @@ def make_optimizer_and_scheduler(
     if cfg.optimizer is None:
         raise ValueError("Optimizer config is required but not provided in TrainPipelineConfig")
 
-    if cfg.peft is not None and cfg.peft.loraplus_lr_ratio is not None:
-        params = make_loraplus_param_groups(policy, cfg.optimizer.lr, cfg.peft.loraplus_lr_ratio)
-    else:
-        params = policy.get_optim_params() if cfg.use_policy_training_preset else policy.parameters()
-
+    params = policy.get_optim_params() if cfg.use_policy_training_preset else policy.parameters()
     optimizer = cfg.optimizer.build(params)
+
+    if cfg.peft is not None and cfg.peft.loraplus_lr_ratio is not None:
+        if not isinstance(optimizer, Optimizer):
+            raise ValueError(
+                "LoRA+ (`peft.loraplus_lr_ratio`) is not supported with multi-optimizer configs."
+            )
+        apply_loraplus_lr_ratio(optimizer, policy, cfg.peft.loraplus_lr_ratio)
+
     lr_scheduler = cfg.scheduler.build(optimizer, cfg.steps) if cfg.scheduler is not None else None
     return optimizer, lr_scheduler

--- a/tests/optim/test_optimizers.py
+++ b/tests/optim/test_optimizers.py
@@ -11,10 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import logging
+from types import SimpleNamespace
+
 import pytest
 import torch
 
-from lerobot.optim.factory import apply_loraplus_lr_ratio
+from lerobot.configs.default import PeftConfig
+from lerobot.optim.factory import apply_loraplus_lr_ratio, make_optimizer_and_scheduler
 from lerobot.optim.optimizers import (
     AdamConfig,
     AdamWConfig,
@@ -24,6 +28,7 @@ from lerobot.optim.optimizers import (
     load_optimizer_state_dict,
     save_optimizer_state,
 )
+from lerobot.optim.schedulers import ConstantWithWarmupSchedulerConfig
 from lerobot.utils.constants import (
     OPTIMIZER_PARAM_GROUPS,
     OPTIMIZER_STATE,
@@ -337,3 +342,67 @@ def test_apply_loraplus_lr_ratio_rejects_non_positive():
     optimizer = torch.optim.AdamW([p for p in model.parameters() if p.requires_grad], lr=1e-4)
     with pytest.raises(ValueError):
         apply_loraplus_lr_ratio(optimizer, model, 0.0)
+
+
+def test_apply_loraplus_lr_ratio_keeps_initial_lr_in_sync():
+    # LR schedulers stamp `initial_lr` on each group and anneal from it, so a scaled group must
+    # carry a scaled `initial_lr` instead of inheriting the unscaled one.
+    model = _DummyLoRA()
+    lr = 1e-4
+    ratio = 16.0
+
+    optimizer = torch.optim.AdamW([p for p in model.parameters() if p.requires_grad], lr=lr)
+    for group in optimizer.param_groups:
+        group["initial_lr"] = group["lr"]
+
+    apply_loraplus_lr_ratio(optimizer, model, ratio)
+
+    assert sorted(g["lr"] for g in optimizer.param_groups) == [lr, lr * ratio]
+    for group in optimizer.param_groups:
+        assert group["initial_lr"] == group["lr"]
+
+
+def test_apply_loraplus_lr_ratio_composes_with_scheduler():
+    model = _DummyLoRA()
+    lr = 1e-4
+    ratio = 16.0
+
+    optimizer = torch.optim.AdamW([p for p in model.parameters() if p.requires_grad], lr=lr)
+    apply_loraplus_lr_ratio(optimizer, model, ratio)
+    scheduler = ConstantWithWarmupSchedulerConfig(num_warmup_steps=0).build(optimizer, num_training_steps=10)
+
+    # The scheduler anneals from the scaled B learning rate, not the unscaled base one.
+    assert sorted(scheduler.base_lrs) == [lr, lr * ratio]
+    optimizer.step()
+    scheduler.step()
+    assert sorted(g["lr"] for g in optimizer.param_groups) == [lr, lr * ratio]
+
+
+def test_apply_loraplus_lr_ratio_warns_without_lora_params(caplog):
+    model = torch.nn.Linear(4, 4)  # no adapters attached
+    optimizer = torch.optim.AdamW(model.parameters(), lr=1e-4)
+
+    with caplog.at_level(logging.WARNING):
+        apply_loraplus_lr_ratio(optimizer, model, 16.0)
+
+    assert "no trainable LoRA B parameters" in caplog.text
+    assert [g["lr"] for g in optimizer.param_groups] == [1e-4]
+
+
+def test_make_optimizer_and_scheduler_rejects_loraplus_with_multi_optimizer():
+    model = _DummyLoRA()
+    trainable = [p for p in model.parameters() if p.requires_grad]
+    cfg = SimpleNamespace(
+        optimizer=MultiAdamConfig(lr=1e-4, optimizer_groups={"default": {"lr": 1e-4}}),
+        peft=PeftConfig(loraplus_lr_ratio=16.0),
+        use_policy_training_preset=True,
+        scheduler=None,
+        steps=100,
+    )
+    policy = SimpleNamespace(
+        get_optim_params=lambda: {"default": trainable},
+        named_parameters=model.named_parameters,
+    )
+
+    with pytest.raises(ValueError, match="multi-optimizer"):
+        make_optimizer_and_scheduler(cfg, policy)

--- a/tests/optim/test_optimizers.py
+++ b/tests/optim/test_optimizers.py
@@ -14,7 +14,7 @@
 import pytest
 import torch
 
-from lerobot.optim.factory import make_loraplus_param_groups
+from lerobot.optim.factory import apply_loraplus_lr_ratio
 from lerobot.optim.optimizers import (
     AdamConfig,
     AdamWConfig,
@@ -282,30 +282,58 @@ def test_save_and_load_empty_multi_optimizer_state(base_params_dict, tmp_path):
         )
 
 
-def test_make_loraplus_param_groups():
-    class _DummyLoRA(torch.nn.Module):
-        def __init__(self):
-            super().__init__()
-            self.base = torch.nn.Linear(4, 4)  # frozen base weights
-            self.lora_A = torch.nn.Linear(4, 2, bias=False)
-            self.lora_B = torch.nn.Linear(2, 4, bias=False)
-            self.base.requires_grad_(False)
+class _DummyLoRA(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.base = torch.nn.Linear(4, 4)  # frozen base weights
+        self.q_lora_A = torch.nn.Linear(4, 2, bias=False)
+        self.q_lora_B = torch.nn.Linear(2, 4, bias=False)
+        self.v_lora_A = torch.nn.Linear(4, 2, bias=False)
+        self.v_lora_B = torch.nn.Linear(2, 4, bias=False)
+        self.base.requires_grad_(False)
 
+
+def test_apply_loraplus_lr_ratio_single_group():
     model = _DummyLoRA()
     lr = 1e-4
     ratio = 16.0
-    groups = make_loraplus_param_groups(model, lr=lr, loraplus_lr_ratio=ratio)
 
-    # Frozen base params are excluded; A and B are split into two learning-rate groups.
-    all_params = [p for group in groups for p in group["params"]]
-    assert len(all_params) == 2
-    assert sorted(group["lr"] for group in groups) == [lr, lr * ratio]
+    trainable = [p for p in model.parameters() if p.requires_grad]
+    optimizer = torch.optim.AdamW(trainable, lr=lr)
+    apply_loraplus_lr_ratio(optimizer, model, ratio)
 
-    a_group = next(group for group in groups if group["lr"] == lr)
-    b_group = next(group for group in groups if group["lr"] == lr * ratio)
-    assert model.lora_A.weight in a_group["params"]
-    assert model.lora_B.weight in b_group["params"]
+    # The B matrices are pulled into their own group at lr * ratio; A matrices keep the base lr.
+    assert sorted(g["lr"] for g in optimizer.param_groups) == [lr, lr * ratio]
+    b_group = next(g for g in optimizer.param_groups if g["lr"] == lr * ratio)
+    a_group = next(g for g in optimizer.param_groups if g["lr"] == lr)
+    b_ids = {id(p) for p in b_group["params"]}
+    a_ids = {id(p) for p in a_group["params"]}
+    assert {id(model.q_lora_B.weight), id(model.v_lora_B.weight)} == b_ids
+    assert {id(model.q_lora_A.weight), id(model.v_lora_A.weight)} == a_ids
 
-    # A non-positive ratio is rejected.
+
+def test_apply_loraplus_lr_ratio_composes_with_named_groups():
+    # Presets like XVLAAdamWConfig build their own groups with different per-group lrs. LoRA+ should
+    # layer on top: within each group the B matrices get that group's lr * ratio, A keeps the base.
+    model = _DummyLoRA()
+    lr = 1e-4
+    ratio = 16.0
+
+    optimizer = torch.optim.AdamW(
+        [
+            {"params": [model.q_lora_A.weight, model.q_lora_B.weight], "lr": lr, "name": "q"},
+            {"params": [model.v_lora_A.weight, model.v_lora_B.weight], "lr": lr * 0.1, "name": "v"},
+        ]
+    )
+    apply_loraplus_lr_ratio(optimizer, model, ratio)
+
+    assert sorted(g["lr"] for g in optimizer.param_groups) == sorted(
+        [lr, lr * ratio, lr * 0.1, lr * 0.1 * ratio]
+    )
+
+
+def test_apply_loraplus_lr_ratio_rejects_non_positive():
+    model = _DummyLoRA()
+    optimizer = torch.optim.AdamW([p for p in model.parameters() if p.requires_grad], lr=1e-4)
     with pytest.raises(ValueError):
-        make_loraplus_param_groups(model, lr=lr, loraplus_lr_ratio=0.0)
+        apply_loraplus_lr_ratio(optimizer, model, 0.0)

--- a/tests/optim/test_optimizers.py
+++ b/tests/optim/test_optimizers.py
@@ -14,6 +14,7 @@
 import pytest
 import torch
 
+from lerobot.optim.factory import make_loraplus_param_groups
 from lerobot.optim.optimizers import (
     AdamConfig,
     AdamWConfig,
@@ -279,3 +280,32 @@ def test_save_and_load_empty_multi_optimizer_state(base_params_dict, tmp_path):
         torch.testing.assert_close(
             optimizer.state_dict()["param_groups"], loaded_optimizers[name].state_dict()["param_groups"]
         )
+
+
+def test_make_loraplus_param_groups():
+    class _DummyLoRA(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.base = torch.nn.Linear(4, 4)  # frozen base weights
+            self.lora_A = torch.nn.Linear(4, 2, bias=False)
+            self.lora_B = torch.nn.Linear(2, 4, bias=False)
+            self.base.requires_grad_(False)
+
+    model = _DummyLoRA()
+    lr = 1e-4
+    ratio = 16.0
+    groups = make_loraplus_param_groups(model, lr=lr, loraplus_lr_ratio=ratio)
+
+    # Frozen base params are excluded; A and B are split into two learning-rate groups.
+    all_params = [p for group in groups for p in group["params"]]
+    assert len(all_params) == 2
+    assert sorted(group["lr"] for group in groups) == [lr, lr * ratio]
+
+    a_group = next(group for group in groups if group["lr"] == lr)
+    b_group = next(group for group in groups if group["lr"] == lr * ratio)
+    assert model.lora_A.weight in a_group["params"]
+    assert model.lora_B.weight in b_group["params"]
+
+    # A non-positive ratio is rejected.
+    with pytest.raises(ValueError):
+        make_loraplus_param_groups(model, lr=lr, loraplus_lr_ratio=0.0)


### PR DESCRIPTION
## Summary / Motivation

Implements LoRA+ (https://arxiv.org/abs/2402.12354), requested in #3575. LoRA+ trains the LoRA `B` matrices with a higher learning rate than the `A` matrices (`lr_B = lr * loraplus_lr_ratio`), which improves convergence speed at the same compute cost. `PeftConfig` currently only exposes a single learning rate for LoRA.

## Related issues

- Closes: #3575

## What changed

- Added `PeftConfig.loraplus_lr_ratio: float | None` (default `None` keeps standard single-lr LoRA).
- Added `make_loraplus_param_groups(model, lr, loraplus_lr_ratio)` in `optim/factory.py`, which splits the PEFT model's trainable parameters into two learning-rate groups: LoRA `B` matrices at `lr * loraplus_lr_ratio`, everything else (A matrices + `modules_to_save`) at the base `lr`.
- `make_optimizer_and_scheduler` uses these groups when `peft.loraplus_lr_ratio` is set, so LoRA+ composes with the existing scheduler/checkpoint flow and works with any optimizer.
- Documented `--peft.loraplus_lr_ratio` in the PEFT training guide.

## How was this tested (or how to run locally)

- Added `test_make_loraplus_param_groups` in `tests/optim/test_optimizers.py`: checks that frozen base params are excluded, that B vs A/other land in the correct lr groups, and that a non-positive ratio is rejected.
- `pytest -q tests/optim/test_optimizers.py` → 14 passed.
- `pre-commit run` on the changed files → all hooks pass (ruff, mypy, prettier, bandit).
- Example run: `lerobot-train ... --peft.method_type=LORA --peft.loraplus_lr_ratio=16`.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit`)
- [x] All tests pass locally (`pytest tests/optim/test_optimizers.py`)
- [x] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: #

## Reviewer notes

- I build the LR split in the optimizer factory (grouping by `lora_B`/`lora_embedding_B` in the parameter name) rather than via PEFT's `create_loraplus_optimizer`, so it stays inside `OptimizerConfig.build` and composes with the scheduler/checkpoint/preset flow and any optimizer. Happy to switch to `peft.optimizers.create_loraplus_optimizer` instead if you'd rather reuse PEFT's grouping (including its embedding/decay handling) — I raised this trade-off in #3575.
- `loraplus_lr_ratio` lives on `PeftConfig` next to `lora_alpha`; it's consumed at optimizer construction, not passed to `get_peft_model`.
