### PR TITLE
docs: clarify setup and Windows CUDA installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Learn how to implement your own simulation environment or benchmark and distribu
 ## Resources
 
 - **[Documentation](https://huggingface.co/docs/lerobot/index):** The complete guide to tutorials & API.
-- **[Chinese Tutorials: LeRobot+SO-ARM101中文教程-同济子豪兄](https://zihao-ai.feishu.cn/wiki/space/7589642043471924447)** Detailed doc for assembling, teleoperate, dataset, train, deploy. Verified by Seed Studio and 5 global hackathon players.
+- **[Chinese Tutorials: LeRobot+SO-ARM101中文教程-同济子豪兄](https://zihao-ai.feishu.cn/wiki/space/7589642043471924447)** Detailed guide for assembly, teleoperation, datasets, training, and deployment. Verified by Seeed Studio and five global hackathon participants.
 - **[Discord](https://discord.gg/q8Dzzpym3f):** Join the `LeRobot` server to discuss with the community.
 - **[X](https://x.com/LeRobotHF):** Follow us on X to stay up-to-date with the latest developments.
 - **[Robot Learning Tutorial](https://huggingface.co/spaces/lerobot/robot-learning-tutorial):** A free, hands-on course to learn robot learning using LeRobot.

--- a/docs/source/installation.mdx
+++ b/docs/source/installation.mdx
@@ -207,9 +207,9 @@ pip install 'lerobot[feetech]'        # Feetech motor support
 
 _Multiple extras can be combined (e.g., `.[core_scripts,pi,pusht]`). For a full list of available extras, refer to `pyproject.toml`._
 
-### PyTorch CUDA variant (Linux only)
+### PyTorch CUDA variants
 
-On Linux, the install path determines which CUDA wheel you get. macOS and Windows installs use the PyPI default (MPS / CPU / CUDA-Windows wheel respectively) and can skip this section.
+On Linux, the install path determines which CUDA wheel you get. macOS uses the PyPI default with MPS support. On Windows, follow the [Windows with NVIDIA CUDA](#windows-with-nvidia-cuda) instructions below when you need CUDA support.
 
 <!-- prettier-ignore-start -->
 
@@ -256,6 +256,23 @@ Supported values include `auto`, `cpu`, `cu126`, `cu128`, `cu129`, `cu130`, plus
 </hfoption>
 </hfoptions>
 <!-- prettier-ignore-end -->
+
+#### Windows with NVIDIA CUDA
+
+For source installs on Windows, `uv sync` installs the default PyTorch build, which can be CPU-only. To use an NVIDIA GPU, select **Windows**, **Pip**, your Python version, and a supported CUDA version on the [PyTorch installation page](https://pytorch.org/get-started/locally). Then run the selected command with `uv pip` after syncing LeRobot:
+
+```powershell
+uv sync
+uv pip install --force-reinstall torch torchvision --index-url <pytorch-selector-index-url>
+```
+
+Verify that PyTorch can access the GPU:
+
+```powershell
+uv run python -c "import torch; print(torch.__version__); print(torch.version.cuda); print(torch.cuda.is_available())"
+```
+
+The final command should print `True`. Repeat the PyTorch installation command after recreating the environment or running a full dependency sync that replaces the selected wheels.
 
 ### Troubleshooting
 

--- a/docs/source/koch.mdx
+++ b/docs/source/koch.mdx
@@ -16,7 +16,7 @@ For a visual walkthrough of the assembly process, you can refer to [this video t
 
 ## Install LeRobot 🤗
 
-To install LeRobot follow, our [Installation Guide](./installation)
+To install LeRobot, follow our [Installation Guide](./installation).
 
 In addition to these instructions, you need to install the Dynamixel SDK:
 

--- a/docs/source/lekiwi.mdx
+++ b/docs/source/lekiwi.mdx
@@ -119,7 +119,7 @@ Where the found port is: `/dev/ttyACM0` corresponding to your board.
 
 The instructions for configuring the motors can be found in the SO101 [docs](./so101#configure-the-motors). Besides the ids for the arm motors, we also need to set the motor ids for the mobile base. These need to be in a specific order to work. Below an image of the motor ids and motor mounting positions for the mobile base. Note that we only use one Motor Control board on LeKiwi. This means the motor ids for the wheels are 7, 8 and 9.
 
-You can run this command to setup motors for LeKiwi. It will first setup the motors for arm (id 6..1) and then setup motors for wheels (9,8,7)
+You can run this command to set up the motors for LeKiwi. It first sets up the arm motors (IDs 6 through 1), then the wheel motors (IDs 9, 8, and 7).
 
 ```bash
 lerobot-setup-motors \

--- a/docs/source/so100.mdx
+++ b/docs/source/so100.mdx
@@ -4,7 +4,7 @@ In the steps below, we explain how to assemble the SO-100 robot.
 
 ## Source the parts
 
-Follow this [README](https://github.com/TheRobotStudio/SO-ARM100/blob/main/SO100.md). It contains the bill of materials, with a link to source the parts, as well as the instructions to 3D print the parts. And advise if it's your first time printing or if you don't own a 3D printer.
+Follow this [README](https://github.com/TheRobotStudio/SO-ARM100/blob/main/SO100.md). It contains the bill of materials, with a link to source the parts, as well as instructions for 3D printing the parts. It also provides advice for first-time 3D printing and for people who do not own a 3D printer.
 
 ## Install LeRobot 🤗
 

--- a/docs/source/so101.mdx
+++ b/docs/source/so101.mdx
@@ -17,8 +17,7 @@ In the steps below, we explain how to assemble our flagship robot, the SO-101.
 
 ## Source the parts
 
-Follow this [README](https://github.com/TheRobotStudio/SO-ARM100). It contains the bill of materials, with a link to source the parts, as well as the instructions to 3D print the parts.
-And advise if it's your first time printing or if you don't own a 3D printer.
+Follow this [README](https://github.com/TheRobotStudio/SO-ARM100). It contains the bill of materials, with a link to source the parts, as well as instructions for 3D printing the parts. It also provides advice for first-time 3D printing and for people who do not own a 3D printer.
 
 ## Install LeRobot 🤗
 

--- a/docs/source/torch_accelerators.mdx
+++ b/docs/source/torch_accelerators.mdx
@@ -16,6 +16,8 @@ To use particular accelerator, a suitable version of PyTorch should be installed
 For CPU, CUDA, and MPS backends follow instructions provided on [PyTorch installation page](https://pytorch.org/get-started/locally).
 For XPU backend, follow instructions from [PyTorch documentation](https://docs.pytorch.org/docs/stable/notes/get_start_xpu.html).
 
+On Windows with an NVIDIA GPU, source installs using `uv sync` may require an explicit PyTorch CUDA wheel. See [Windows with NVIDIA CUDA](./installation#windows-with-nvidia-cuda).
+
 ### Verifying the installation
 
 After installation, accelerator availability can be verified by running


### PR DESCRIPTION
## Summary / Motivation

This PR cleans up grammar and terminology across the resource list and the Koch, SO-100, SO-101, and LeKiwi setup guides. It also corrects the Windows installation guidance: a source install can leave Windows users with a CPU-only PyTorch build, so the CUDA setup and verification steps need to be explicit.

## Related issues

- Fixes / Closes: None.
- Related: None.

## What changed

- Corrected grammar and terminology in the README and hardware setup guides.
- Clarified 3D-printing and motor-setup wording without changing the procedures.
- Added Windows instructions for installing a CUDA-enabled PyTorch build after `uv sync`.
- Added a command to verify that PyTorch can access the GPU.
- Corrected the outdated claim that Windows receives a CUDA wheel by default.
- No breaking changes.

## How was this tested (or how to run locally)

- `uv run pre-commit run --files docs/source/installation.mdx docs/source/torch_accelerators.mdx`
- `uv run --extra dev pre-commit run typos --files README.md docs/source/koch.mdx docs/source/lekiwi.mdx docs/source/so100.mdx docs/source/so101.mdx`
- `uv run --extra dev pre-commit run prettier --files README.md docs/source/koch.mdx docs/source/lekiwi.mdx docs/source/so100.mdx docs/source/so101.mdx`

- Full base CI tier: `uv run pytest tests -vv --maxfail=10` (1154 passed, 348 skipped).

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated
- [ ] CI is green
- [x] Community Review: I reviewed #4288: https://github.com/huggingface/lerobot/pull/4288#pullrequestreview-4839262965

## Reviewer notes

Please focus on whether the Windows CUDA instructions match the supported `uv` workflow and whether the wording changes preserve the original procedures.

AI assistance (Codex) was used to research the installation behavior, edit the documentation, and draft this PR description.

