### PR TITLE
fix(lekiwi): handle per-motor relative targets

### DIFF
--- a/src/lerobot/robots/lekiwi/lekiwi.py
+++ b/src/lerobot/robots/lekiwi/lekiwi.py
@@ -400,7 +400,8 @@ class LeKiwi(Robot):
 
         # Cap goal position when too far away from present position.
         # /!\ Slower fps expected due to reading from the follower.
-        if self.config.max_relative_target is not None:
+        max_relative_target = self.config.max_relative_target
+        if max_relative_target is not None:
             present_pos = self.bus.sync_read(
                 "Present_Position", self.arm_motors, num_retry=self.config.num_read_retries
             )
@@ -408,8 +409,9 @@ class LeKiwi(Robot):
             goal_present_pos = {
                 key: (g_pos, present_pos[key.removesuffix(".pos")]) for key, g_pos in arm_goal_pos.items()
             }
-            arm_safe_goal_pos = ensure_safe_goal_position(goal_present_pos, self.config.max_relative_target)
-            arm_goal_pos = arm_safe_goal_pos
+            if isinstance(max_relative_target, dict):
+                max_relative_target = {f"{motor}.pos": limit for motor, limit in max_relative_target.items()}
+            arm_goal_pos = ensure_safe_goal_position(goal_present_pos, max_relative_target)
 
         # Send goal position to the actuators
         arm_goal_pos_raw = {k.replace(".pos", ""): v for k, v in arm_goal_pos.items()}

--- a/tests/robots/test_lekiwi.py
+++ b/tests/robots/test_lekiwi.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from lerobot.robots.lekiwi import LeKiwi, LeKiwiConfig
+
+_MODULE = "lerobot.robots.lekiwi.lekiwi"
+
+
+@pytest.fixture
+def lekiwi(tmp_path):
+    bus_mock = MagicMock(name="FeetechBusMock")
+    bus_mock.is_connected = True
+
+    def _bus_side_effect(*_args, **kwargs):
+        bus_mock.motors = kwargs["motors"]
+        bus_mock.sync_read.return_value = dict.fromkeys(bus_mock.motors, 0.0)
+        return bus_mock
+
+    with patch(f"{_MODULE}.FeetechMotorsBus", side_effect=_bus_side_effect):
+        yield LeKiwi(LeKiwiConfig(port="/dev/null", calibration_dir=tmp_path, cameras={}))
+
+
+def _action(lekiwi, arm_target: float = 100.0) -> dict[str, float]:
+    return {
+        **{f"{motor}.pos": arm_target for motor in lekiwi.arm_motors},
+        "x.vel": 0.0,
+        "y.vel": 0.0,
+        "theta.vel": 0.0,
+    }
+
+
+def test_send_action_clamps_scalar_relative_target(lekiwi):
+    lekiwi.config.max_relative_target = 10.0
+    lekiwi.config.num_read_retries = 7
+
+    returned = lekiwi.send_action(_action(lekiwi))
+
+    assert {key: returned[key] for key in returned if key.endswith(".pos")} == {
+        f"{motor}.pos": 10.0 for motor in lekiwi.arm_motors
+    }
+    lekiwi.bus.sync_read.assert_called_once_with("Present_Position", lekiwi.arm_motors, num_retry=7)
+    lekiwi.bus.sync_write.assert_any_call("Goal_Position", dict.fromkeys(lekiwi.arm_motors, 10.0))
+
+
+def test_send_action_clamps_per_motor_relative_target(lekiwi):
+    relative_limits = {motor: float(index) for index, motor in enumerate(lekiwi.arm_motors, 1)}
+    lekiwi.config.max_relative_target = relative_limits
+
+    returned = lekiwi.send_action(_action(lekiwi))
+
+    assert {key: returned[key] for key in returned if key.endswith(".pos")} == {
+        f"{motor}.pos": limit for motor, limit in relative_limits.items()
+    }
+    lekiwi.bus.sync_write.assert_any_call("Goal_Position", relative_limits)


### PR DESCRIPTION
## Summary / Motivation

#4281 fixed the scalar `max_relative_target` path, but dictionary-valued limits still use bare motor names while LeKiwi passes `.pos` action keys to `ensure_safe_goal_position`. That causes the helper's key validation to reject the documented per-motor configuration.

## What changed

- Rebase onto `main` after #4281.
- Add `.pos` to dictionary limit keys at the safety-helper boundary.
- Add regression coverage for scalar and per-motor relative target limits.
- No breaking changes.

## How was this tested

- `uv run --extra test pytest tests/robots/test_lekiwi.py -q`
- `uv run ruff check src/lerobot/robots/lekiwi/lekiwi.py tests/robots/test_lekiwi.py`
- `uv run ruff format --check src/lerobot/robots/lekiwi/lekiwi.py tests/robots/test_lekiwi.py`

## Checklist

- [x] Linting and formatting pass locally
- [x] Focused tests pass locally
- [ ] CI is green
- [x] Community Review: I reviewed #4288: https://github.com/huggingface/lerobot/pull/4288#pullrequestreview-4839262965

## Reviewer notes

The production change is limited to adapting dictionary keys before the existing safety helper call. Scalar behavior remains the implementation from #4281.

Significant AI assistance was used to investigate the bug, implement the fix and tests, and draft this PR description. Anyone in the community is free to review the PR.