### PR TITLE
fix(smolvla): normalize uint8 images before resizing

### DIFF
--- a/src/lerobot/policies/smolvla/modeling_smolvla.py
+++ b/src/lerobot/policies/smolvla/modeling_smolvla.py
@@ -347,6 +347,8 @@ class SmolVLAPolicy(PreTrainedPolicy):
         # Preprocess image features present in the batch
         for key in present_img_keys:
             img = batch[key][:, -1, :, :, :] if batch[key].ndim == 5 else batch[key]
+            if img.dtype == torch.uint8:
+                img = img.to(torch.float32) / 255.0
             if self.config.resize_imgs_with_padding is not None:
                 # SmolVLA stores the target as (width, height); the shared helper expects (height, width).
                 img = resize_with_pad(

--- a/tests/policies/smolvla/test_modeling_smolvla.py
+++ b/tests/policies/smolvla/test_modeling_smolvla.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from lerobot.policies.smolvla.modeling_smolvla import SmolVLAPolicy
+
+
+@pytest.mark.parametrize("resize", [(4, 4), None])
+def test_prepare_images_normalizes_uint8_inputs_before_resizing(resize):
+    policy = SimpleNamespace(
+        config=SimpleNamespace(
+            image_features={"observation.images.camera": object()},
+            resize_imgs_with_padding=resize,
+            empty_cameras=0,
+        )
+    )
+    image = torch.tensor([[[[0, 255], [128, 64]]]], dtype=torch.uint8).repeat(1, 3, 1, 1)
+
+    images, image_masks = SmolVLAPolicy.prepare_images(policy, {"observation.images.camera": image})
+
+    assert images[0].dtype == torch.float32
+    assert images[0].min() >= -1.0
+    assert images[0].max() <= 1.0
+    assert image_masks[0].tolist() == [True]
+    if resize is None:
+        torch.testing.assert_close(images[0], image.float() / 255.0 * 2.0 - 1.0)


### PR DESCRIPTION
## Summary / Motivation

Manually constructed SmolVLA inference batches can contain `uint8` images. ROCm does not support bilinear interpolation for that dtype, and the later SigLIP normalization also receives the wrong value range. Converting images at the SmolVLA preprocessing boundary fixes both paths without changing the shared resize helper or XVLA behavior.

## Related issues

- Fixes / Closes: #4205
- Related: None.

## What changed

- Normalize `uint8` SmolVLA image inputs to `float32` in the `[0, 1]` range before resizing.
- Cover both resized and non-resized image paths with a focused unit test.
- Keep the shared resize helper and XVLA behavior unchanged.
- No breaking changes.

## How was this tested (or how to run locally)

- Tests added: `tests/policies/smolvla/test_modeling_smolvla.py`
- `uv run --extra smolvla --extra test pytest tests/policies/smolvla/test_modeling_smolvla.py`
- `uv run ruff check src/lerobot/policies/smolvla/modeling_smolvla.py tests/policies/smolvla/test_modeling_smolvla.py`
- `uv run ruff format --check src/lerobot/policies/smolvla/modeling_smolvla.py tests/policies/smolvla/test_modeling_smolvla.py`

- Full base CI tier: `uv run pytest tests -vv --maxfail=10` (1156 passed, 348 skipped).

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated (not applicable; this is a preprocessing regression fix)
- [ ] CI is green
- [x] Community Review: I reviewed #4288: https://github.com/huggingface/lerobot/pull/4288#pullrequestreview-4839262965

## Reviewer notes

Please focus on the preprocessing boundary, the `uint8` conversion range, and whether any supported image path can bypass this normalization.

Significant AI assistance was used to investigate the bug, implement the fix and tests, and draft this PR description. Anyone in the community is free to review the PR.

