### PR TITLE
fix(rollout): tolerate stale frames during compile warmup

### DIFF
--- a/src/lerobot/rollout/strategies/base.py
+++ b/src/lerobot/rollout/strategies/base.py
@@ -59,7 +59,11 @@ class BaseStrategy(RolloutStrategy):
                 logger.info("Duration limit reached (%.0fs)", cfg.duration)
                 break
 
-            obs = robot.get_observation()
+            obs = self._get_observation_or_wait_for_warmup(
+                robot, cfg.use_torch_compile, loop_start, control_interval
+            )
+            if obs is None:
+                continue
             obs_processed = self._process_observation_and_notify(ctx.processors, obs)
 
             if self._handle_warmup(cfg.use_torch_compile, loop_start, control_interval):

--- a/src/lerobot/rollout/strategies/core.py
+++ b/src/lerobot/rollout/strategies/core.py
@@ -50,6 +50,7 @@ class RolloutStrategy(abc.ABC):
         self._engine: InferenceEngine | None = None
         self._interpolator: ActionInterpolator | None = None
         self._warmup_flushed: bool = False
+        self._warmup_observation_timeout_logged: bool = False
         self._cached_obs_processed: dict | None = None
 
     def _init_engine(self, ctx: RolloutContext) -> None:
@@ -66,6 +67,7 @@ class RolloutStrategy(abc.ABC):
         self._engine.reset()
         self._engine.start()
         self._warmup_flushed = False
+        self._warmup_observation_timeout_logged = False
         self._cached_obs_processed = None
         logger.info("Inference engine started")
 
@@ -104,9 +106,7 @@ class RolloutStrategy(abc.ABC):
         if not use_torch_compile:
             return False
         if not engine.ready:
-            dt = time.perf_counter() - loop_start
-            if (sleep_t := control_interval - dt) > 0:
-                precise_sleep(sleep_t)
+            self._wait_for_next_tick(loop_start, control_interval)
             return True
         if not self._warmup_flushed:
             logger.info("Warmup complete — flushing stale state and resuming engine")
@@ -115,6 +115,34 @@ class RolloutStrategy(abc.ABC):
             self._warmup_flushed = True
             engine.resume()
         return False
+
+    @staticmethod
+    def _wait_for_next_tick(loop_start: float, control_interval: float) -> None:
+        """Sleep for the remainder of the current control tick."""
+        dt = time.perf_counter() - loop_start
+        if (sleep_t := control_interval - dt) > 0:
+            precise_sleep(sleep_t)
+
+    def _get_observation_or_wait_for_warmup(
+        self, robot, use_torch_compile: bool, loop_start: float, control_interval: float
+    ) -> dict | None:
+        """Read an observation, tolerating stale camera frames during compile warmup.
+
+        Torch compilation can hold the GIL long enough for camera background threads
+        to miss the freshness watchdog. A successful observation is still required to
+        start warmup, so retry only a stale-frame timeout while the engine is not ready.
+        """
+        try:
+            return robot.get_observation()
+        except TimeoutError:
+            if not use_torch_compile or self._engine.ready:
+                raise
+
+            if not self._warmup_observation_timeout_logged:
+                logger.warning("Camera observation timed out during torch.compile warmup; retrying")
+                self._warmup_observation_timeout_logged = True
+            self._wait_for_next_tick(loop_start, control_interval)
+            return None
 
     def _teardown_hardware(self, hw: HardwareContext, return_to_initial_position: bool = True) -> None:
         """Stop the inference engine, optionally return robot to initial position, and disconnect hardware."""

--- a/src/lerobot/rollout/strategies/dagger.py
+++ b/src/lerobot/rollout/strategies/dagger.py
@@ -377,7 +377,11 @@ class DAggerStrategy(RolloutStrategy):
                             last_action = None
 
                     phase = events.phase
-                    obs = robot.get_observation()
+                    obs = self._get_observation_or_wait_for_warmup(
+                        robot, cfg.use_torch_compile, loop_start, control_interval
+                    )
+                    if obs is None:
+                        continue
 
                     # --- CORRECTING: human teleop control ---
                     # TODO(Steven): teleop runs at the same FPS as the policy. To
@@ -557,7 +561,11 @@ class DAggerStrategy(RolloutStrategy):
                         self._background_push(dataset, cfg)
 
                     phase = events.phase
-                    obs = robot.get_observation()
+                    obs = self._get_observation_or_wait_for_warmup(
+                        robot, cfg.use_torch_compile, loop_start, control_interval
+                    )
+                    if obs is None:
+                        continue
 
                     # --- CORRECTING: human teleop control + recording ---
                     # TODO(Steven): teleop runs at the same FPS as the policy. To

--- a/src/lerobot/rollout/strategies/episodic.py
+++ b/src/lerobot/rollout/strategies/episodic.py
@@ -229,7 +229,11 @@ class EpisodicStrategy(RolloutStrategy):
             if ctx.runtime.shutdown_event.is_set():
                 break
 
-            obs = robot.get_observation()
+            obs = self._get_observation_or_wait_for_warmup(
+                robot, ctx.runtime.cfg.use_torch_compile, loop_start, control_interval
+            )
+            if obs is None:
+                continue
             obs_processed = self._process_observation_and_notify(ctx.processors, obs)
 
             if self._handle_warmup(ctx.runtime.cfg.use_torch_compile, loop_start, control_interval):

--- a/src/lerobot/rollout/strategies/highlight.py
+++ b/src/lerobot/rollout/strategies/highlight.py
@@ -117,7 +117,11 @@ class HighlightStrategy(RolloutStrategy):
                         logger.info("Duration limit reached (%.0fs)", cfg.duration)
                         break
 
-                    obs = robot.get_observation()
+                    obs = self._get_observation_or_wait_for_warmup(
+                        robot, cfg.use_torch_compile, loop_start, control_interval
+                    )
+                    if obs is None:
+                        continue
                     obs_processed = self._process_observation_and_notify(ctx.processors, obs)
 
                     if self._handle_warmup(cfg.use_torch_compile, loop_start, control_interval):

--- a/src/lerobot/rollout/strategies/sentry.py
+++ b/src/lerobot/rollout/strategies/sentry.py
@@ -110,7 +110,11 @@ class SentryStrategy(RolloutStrategy):
                         logger.info("Duration limit reached (%.0fs)", cfg.duration)
                         break
 
-                    obs = robot.get_observation()
+                    obs = self._get_observation_or_wait_for_warmup(
+                        robot, cfg.use_torch_compile, loop_start, control_interval
+                    )
+                    if obs is None:
+                        continue
                     obs_processed = self._process_observation_and_notify(ctx.processors, obs)
 
                     if self._handle_warmup(cfg.use_torch_compile, loop_start, control_interval):

--- a/tests/test_rollout.py
+++ b/tests/test_rollout.py
@@ -108,6 +108,66 @@ def test_sentry_config_defaults():
     assert cfg.target_video_file_size_mb is None
 
 
+# ---------------------------------------------------------------------------
+# Compile warmup camera watchdog
+# ---------------------------------------------------------------------------
+
+
+def test_warmup_observation_timeout_retries_on_next_tick(monkeypatch):
+    import lerobot.rollout.strategies.core as core
+    from lerobot.rollout import BaseStrategyConfig
+    from lerobot.rollout.strategies import BaseStrategy
+
+    strategy = BaseStrategy(BaseStrategyConfig())
+    strategy._engine = SimpleNamespace(ready=False)
+    robot = MagicMock()
+    robot.get_observation.side_effect = TimeoutError("latest frame is too old")
+    sleep = MagicMock()
+    monkeypatch.setattr(core, "precise_sleep", sleep)
+    monkeypatch.setattr(core.time, "perf_counter", lambda: 0.0)
+
+    observation = strategy._get_observation_or_wait_for_warmup(
+        robot, use_torch_compile=True, loop_start=0.0, control_interval=1.0
+    )
+
+    assert observation is None
+    robot.get_observation.assert_called_once_with()
+    sleep.assert_called_once()
+
+
+def test_warmup_observation_read_starts_compile():
+    from lerobot.rollout import BaseStrategyConfig
+    from lerobot.rollout.strategies import BaseStrategy
+
+    strategy = BaseStrategy(BaseStrategyConfig())
+    strategy._engine = SimpleNamespace(ready=False)
+    robot = MagicMock()
+    expected_observation = {"camera": object()}
+    robot.get_observation.return_value = expected_observation
+
+    observation = strategy._get_observation_or_wait_for_warmup(
+        robot, use_torch_compile=True, loop_start=0.0, control_interval=1.0
+    )
+
+    assert observation is expected_observation
+
+
+@pytest.mark.parametrize("use_torch_compile, engine_ready", [(False, False), (True, True)])
+def test_observation_timeout_propagates_outside_compile_warmup(use_torch_compile, engine_ready):
+    from lerobot.rollout import BaseStrategyConfig
+    from lerobot.rollout.strategies import BaseStrategy
+
+    strategy = BaseStrategy(BaseStrategyConfig())
+    strategy._engine = SimpleNamespace(ready=engine_ready)
+    robot = MagicMock()
+    robot.get_observation.side_effect = TimeoutError("latest frame is too old")
+
+    with pytest.raises(TimeoutError, match="latest frame"):
+        strategy._get_observation_or_wait_for_warmup(
+            robot, use_torch_compile=use_torch_compile, loop_start=0.0, control_interval=1.0
+        )
+
+
 def test_rollout_config_passes_policy_pretrained_revision(monkeypatch):
     from lerobot.configs import PreTrainedConfig, parser
     from lerobot.rollout import RolloutConfig


### PR DESCRIPTION
## Summary / Motivation

The rollout loops read from the robot before checking whether the inference engine has finished compiling. On slow hardware, compilation can starve camera background threads long enough for the freshness watchdog to raise `TimeoutError`, which terminates rollout before warmup completes. This change retries that specific failure only while `torch.compile` warmup is incomplete.

## Related issues

- Fixes / Closes: #4115
- Related: None.

## What changed

- Retry a stale camera-frame `TimeoutError` only while `torch.compile` warmup is incomplete.
- Use the shared retry path in Base, Episodic, DAgger, Highlight, and Sentry strategies.
- Log the warmup timeout once, then retry on later control ticks.
- Preserve normal timeout propagation when compilation is disabled or warmup is complete.
- Add regression tests for warmup retries, the first successful read, and normal timeout propagation.
- No breaking changes.

## How was this tested (or how to run locally)

- Tests added: `tests/test_rollout.py`
- `uv run --extra dataset --extra test pytest tests/test_rollout.py`
- `uv run --extra dev pre-commit run --files src/lerobot/rollout/strategies/core.py src/lerobot/rollout/strategies/base.py src/lerobot/rollout/strategies/episodic.py src/lerobot/rollout/strategies/dagger.py src/lerobot/rollout/strategies/highlight.py src/lerobot/rollout/strategies/sentry.py tests/test_rollout.py`

- Full base CI tier: `uv run pytest tests -vv --maxfail=10` (1154 passed, 348 skipped).

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated (not applicable; this is a rollout error-handling fix)
- [ ] CI is green
- [x] Community Review: I reviewed #4288: https://github.com/huggingface/lerobot/pull/4288#pullrequestreview-4839262965

## Reviewer notes

Please focus on the retry condition and whether `TimeoutError` can be raised for a reason that should still abort during compile warmup.

Significant AI assistance was used to investigate the bug, implement the fix and tests, and draft this PR description. Anyone in the community is free to review the PR.

