### PR TITLE
fix(envs): type fixed_reset_joint_positions as list[float]

### DIFF
--- a/src/lerobot/envs/configs.py
+++ b/src/lerobot/envs/configs.py
@@ -281,7 +281,7 @@ class GripperConfig:
 class ResetConfig:
     """Configuration for environment reset behavior."""
 
-    fixed_reset_joint_positions: Any | None = None
+    fixed_reset_joint_positions: list[float] | None = None
     reset_time_s: float = 5.0
     control_time_s: float = 20.0
     terminate_on_success: bool = True


### PR DESCRIPTION
## Summary / Motivation

`ResetConfig.fixed_reset_joint_positions` is annotated `Any | None`. draccus cannot encode a field annotated `Any`: `draccus.parsers.encoding.encode` calls `isinstance(value, typing.get_origin(t) or t)`, and `typing.Any` cannot be used with `isinstance`. Any config that sets a reset pose fails with:

```
TypeError: typing.Any cannot be used with isinstance()
```

This happens at `learner.py:166` (`logging.info(pformat(cfg.to_dict()))`), the first statement after config parsing, before the dataset, policy or gRPC server exist. Every HIL-SERL config sets a reset pose, so the learner cannot start at all, in simulation or on hardware. `lerobot_train.py:272` makes the same call.

Reproduced on `main` @ `8135a8a8` with draccus 0.11.6, the version pinned in both `pyproject.toml` and `uv.lock`.

## Related issues

Related: #2692, #2472. Both report failures in the "Train RL in Simulation" path. Different root causes, but this removes one blocker from it.

## What changed

`fixed_reset_joint_positions: Any | None` becomes `list[float] | None`.

No behaviour change. The field is only read by `gym_manipulator.make_robot_env`, which passes it to `RobotEnv(reset_pose=...)`, and every shipped config supplies a list of joint positions (7 floats for `gym_hil`, 6 for SO-100/SO-101). `Any` is still imported and used elsewhere in the file.

## How was this tested (or how to run locally)

```bash
curl -LO https://huggingface.co/datasets/lerobot/config_examples/resolve/main/rl/gym_hil/train_config.json
python -m lerobot.rl.learner --config_path train_config.json --wandb.enable=false
```

Before: `TypeError` at `learner.py:166`.
After: the learner reaches `Starting learner thread`, with the gRPC server up and the offline buffer loaded with 458 transitions.

* `pytest tests/envs tests/configs`: 75 passed, 11 skipped
* `pytest tests/rl tests/processor`: 559 passed, 14 skipped
* `ruff check` and `ruff format --check` clean on the changed file

Ubuntu 24.04, Python 3.12, torch 2.11.0+cu128, draccus 0.11.6.

No tests added, since this is a type annotation fix with no new branch to cover.

## Checklist (required before merge)

- [x] Linting/formatting run (`ruff check` / `ruff format --check` on the changed file)
- [x] Relevant tests pass locally (`tests/envs`, `tests/configs`, `tests/rl`, `tests/processor`, not the full suite)
- [ ] Documentation updated (n/a, no user-facing behaviour change)
- [ ] CI is green
- [x] Community Review: reviewed #4177 at https://github.com/huggingface/lerobot/pull/4177#pullrequestreview-4839106950

## Reviewer notes

`ResetConfig` is the only dataclass in `envs/configs.py` with an `Any`-annotated field, so nothing else is affected. It might be worth a lint rule to prevent `Any` on draccus-encoded dataclass fields in future.

Disclosure per AI_POLICY.md: I used AI assistance to draft this description. I reproduced the failure and verified the fix locally.
