### PR TITLE
feat(teleoperators): add accessible_teleop for operators without a leader arm

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -167,6 +167,8 @@
     title: reBot B601-DM
   title: "Robots"
 - sections:
+  - local: accessible_teleop
+    title: Accessible Teleoperation
   - local: phone_teleop
     title: Phone
   - local: isaac_teleop

--- a/docs/source/accessible_teleop.mdx
+++ b/docs/source/accessible_teleop.mdx
@@ -63,10 +63,29 @@ The control page opens automatically at `http://127.0.0.1:8777`. `connect()` blo
    joint feels twitchy, and lower the speed on joints that carry the arm's weight.
 4. **Drive.** Press **Engage control** or the space bar. Press it again, or **Stop**, to release.
 
+A few things about the page are worth knowing before you use it:
+
+- **Joysticks are relative.** Wherever you press becomes the zero point, and the command is your
+  offset from there. Nothing jumps when you make contact, and **Movement needed for full speed** sets
+  how far you have to travel — lower it if your comfortable range is small.
+- **A pad only appears once something is bound to it**, and a pad with a single bound axis is drawn as
+  a track along that axis. The other axis is ignored, so a wobble cannot leak into a joint you did not
+  mean to drive.
+- **Robot view** shows any camera attached to the machine, opened by the browser rather than relayed
+  through Python. In fullscreen the joysticks come with you and the space bar still works.
+- **One page drives at a time.** Open several and the one holding its clutch closed wins; the others
+  say so in the header. A page that is hidden or backgrounded releases its clutch, because its update
+  loop stops and it can no longer be steering.
+- **A joint at its limit says which way it cannot go**, so a control that appears dead is
+  distinguishable from one that is refusing to push a joint further into a mechanical stop.
+
 The profile is saved automatically to
 `~/.cache/huggingface/lerobot/calibration/teleoperators/accessible_teleop/<id>.json` whenever you
 change it, and reloaded on the next run. It holds both the bindings and the captured ranges, so it is
 the thing to copy between machines or to hand to someone setting up the same operator elsewhere.
+
+It sits alongside the motor calibration files but is not one: it describes an operator rather than a
+piece of hardware. Nothing about it is specific to the arm you happen to be driving.
 
 ## Available channels
 
@@ -88,11 +107,14 @@ and the two directions of a movement land on opposite signs.
 This teleoperator commands absolute joint positions it integrates itself, so it has to be careful
 about where it thinks the robot is.
 
-- **It stays silent until you engage.** `get_action()` returns an empty dict until the operator engages
-  the clutch for the first time.
-- **The first engaged command is the start pose.** The follower may be somewhere else entirely. Either
-  run with `--robot.max_relative_target` so the robot rate-limits the approach, or feed the follower's
-  observation back with [`send_feedback`](#anchoring-on-the-robots-real-position) before engaging.
+- **Nothing moves until you engage.** The commanded pose only changes while the clutch is held closed,
+  so until then every cycle repeats the same action and the arm holds still.
+- **It anchors on where the arm really is.** `lerobot-teleoperate` and `lerobot-record` hand this
+  teleoperator the follower's observation before reading each action, so the pose it holds is the
+  pose the arm is already in and engaging cannot produce a jump. Drive it from your own loop without
+  doing that and it starts from `start_pose` instead, which the follower may be far away from — see
+  [anchoring](#anchoring-on-the-robots-real-position). Run with `--robot.max_relative_target` either
+  way, so the robot rate-limits any approach.
 - **Silence stops the robot.** If no input frame arrives within `input_timeout_s` (0.5 s by default) the
   clutch is released, so a closed tab, a crashed browser, or a dead Wi-Fi link cannot leave a joint
   travelling.
@@ -128,9 +150,9 @@ Leave a few degrees of margin, and remember the gripper is a percentage rather t
 
 ### Anchoring on the robot's real position
 
-`send_feedback` accepts the follower's observation and re-anchors the commanded pose, which removes
-the jump on first engage. The stock `lerobot-teleoperate` loop does not call it, so wire it up
-yourself when you need it:
+`send_feedback` accepts the follower's observation and re-anchors the commanded pose, which is what
+removes the jump on first engage. The stock loops do this for you. In a loop of your own, call it
+before `get_action()` on every cycle:
 
 ```python
 from lerobot.robots.so_follower import SO101Follower, SOFollowerRobotConfig
@@ -144,9 +166,7 @@ teleop.connect()
 while True:
     observation = robot.get_observation()
     teleop.send_feedback(observation)  # ignored while the clutch is engaged
-    action = teleop.get_action()
-    if action:
-        robot.send_action(action)
+    robot.send_action(teleop.get_action())
 ```
 
 ## Configuring it from the command line
@@ -171,23 +191,24 @@ lerobot-teleoperate \
 A saved profile takes precedence over these values, because it represents what the operator actually
 tuned. Delete the calibration file to start from the config again.
 
-| Option              | Default               | Purpose                                         |
-| ------------------- | --------------------- | ----------------------------------------------- |
-| `joints`            | the six SO-101 joints | Which joints to command, in page order          |
-| `bindings`          | all unbound           | Per-joint input and tuning                      |
-| `joint_limits`      | ±75°, gripper 0–100   | Travel limit in the follower's normalized units |
-| `start_pose`        | mid-range, gripper 50 | Pose commanded on first engage                  |
-| `host` / `web_port` | `127.0.0.1` / `8777`  | Where the page is served                        |
-| `open_browser`      | `true`                | Open the page automatically                     |
-| `connect_timeout_s` | `180`                 | How long `connect` waits for the page           |
-| `input_timeout_s`   | `0.5`                 | Silence tolerated before the clutch is released |
-| `max_step_s`        | `0.06`                | Largest integration step honoured               |
-| `face_tracking`     | `true`                | Serve the face channels at all                  |
+| Option              | Default               | Purpose                                           |
+| ------------------- | --------------------- | ------------------------------------------------- |
+| `joints`            | the six SO-101 joints | Which joints to command, in page order            |
+| `bindings`          | all unbound           | Per-joint input and tuning                        |
+| `joint_limits`      | ±75°, gripper 0–100   | Travel limit in the follower's normalized units   |
+| `start_pose`        | mid-range, gripper 50 | Pose held until the robot's own position is known |
+| `host` / `web_port` | `127.0.0.1` / `8777`  | Where the page is served                          |
+| `open_browser`      | `true`                | Open the page automatically                       |
+| `connect_timeout_s` | `180`                 | How long `connect` waits for the page             |
+| `input_timeout_s`   | `0.5`                 | Silence tolerated before the clutch is released   |
+| `max_step_s`        | `0.06`                | Largest integration step honoured                 |
+| `face_tracking`     | `true`                | Serve the face channels at all                    |
 
 ## Recording datasets
 
-The teleoperator emits the same `{joint}.pos` action keys as a leader arm, so `lerobot-record` works
-unchanged:
+The teleoperator emits the same `{joint}.pos` action keys as a leader arm, and holds a steady pose
+whenever the clutch is open, so `lerobot-record` works unchanged. Episodes recorded before the
+operator engages contain that held pose rather than a gap:
 
 ```bash
 lerobot-record \

--- a/docs/source/accessible_teleop.mdx
+++ b/docs/source/accessible_teleop.mdx
@@ -1,0 +1,203 @@
+# Accessible Teleoperation
+
+Most teleoperation in LeRobot assumes an operator who can hold a leader arm, work a gamepad, or type
+on a keyboard. `accessible_teleop` is for operators who cannot. It lets one person bind each robot
+joint, one at a time, to whatever small movement they can produce reliably: a facial movement read by
+a webcam, a single key, or an on-screen joystick reachable with a mouse, a trackball, or a head
+pointer.
+
+Two ideas make a few millimetres of usable movement enough to drive a whole arm:
+
+- **Control is joint-space and velocity-integrated.** Deflecting an input moves a joint while it is
+  held and stops when the input returns to neutral. Nothing maps operator position directly onto
+  joint angle, so a small range of motion still reaches the whole workspace.
+- **Every channel is calibrated to the person, not the device.** Each input has its own neutral point
+  and its own comfortable range in each direction, and each joint has its own dead zone, gain,
+  smoothing, and speed. An operator whose eyebrows travel further than their lips does not have to
+  compromise on one to use the other.
+
+A browser page served on loopback is the input surface. It reports raw sensor readings and lets the
+operator edit their mapping live; all conditioning, integration, and limiting happens in Python, so a
+stalled tab or a dropped socket stops the robot rather than surprising it.
+
+## Installation
+
+```bash
+pip install 'lerobot[accessible-teleop,feetech]'
+```
+
+Face tracking loads MediaPipe from a CDN the first time the page runs, then the browser caches it.
+The joystick and keyboard channels work with no network access at all; set
+`--teleop.face_tracking=false` to skip MediaPipe entirely, or point `--teleop.mediapipe_base_url` and
+`--teleop.face_landmarker_url` at a local mirror.
+
+## Running it
+
+```bash
+lerobot-teleoperate \
+    --robot.type=so101_follower \
+    --robot.port=/dev/tty.usbmodem58760431541 \
+    --robot.id=my_arm \
+    --robot.max_relative_target=5 \
+    --teleop.type=accessible_teleop \
+    --teleop.id=my_profile
+```
+
+The control page opens automatically at `http://127.0.0.1:8777`. `connect()` blocks until it attaches.
+
+<Tip warning={true}>
+  Keep the page on `127.0.0.1` or `localhost`. Browsers only grant camera access
+  to secure contexts, and a bare LAN address is not one. Reaching the page from
+  another device needs a TLS terminator in front of it.
+</Tip>
+
+## Setting up a profile
+
+1. **Bind a joint.** Pick an input for it from the dropdown. Nothing is bound by default, because the
+   right mapping is personal and six live axes at once is not a reasonable starting point.
+2. **Calibrate face channels.** Start the camera, relax, press **Calibrate**, and move that one feature
+   through the range you can hold comfortably for five seconds. Each direction is measured separately.
+   A face channel produces no motion until it has been calibrated.
+3. **Tune it.** Raise the dead zone until tremor and involuntary movement stop reaching the robot.
+   Raise the gain so you reach full speed without exhausting your range. Raise the smoothing if the
+   joint feels twitchy, and lower the speed on joints that carry the arm's weight.
+4. **Drive.** Press **Engage control** or the space bar. Press it again, or **Stop**, to release.
+
+The profile is saved automatically to
+`~/.cache/huggingface/lerobot/calibration/teleoperators/accessible_teleop/<id>.json` whenever you
+change it, and reloaded on the next run. It holds both the bindings and the captured ranges, so it is
+the thing to copy between machines or to hand to someone setting up the same operator elsewhere.
+
+## Available channels
+
+| Channel                                    | What it reads                                                               |
+| ------------------------------------------ | --------------------------------------------------------------------------- |
+| `face.brow_vertical`                       | Eyebrows lowered against eyebrows raised                                    |
+| `face.lip_lateral`                         | Lips moved left against right                                               |
+| `face.mouth_open`                          | Jaw open against mouth closed                                               |
+| `face.mouth_shape`                         | Pucker against smile                                                        |
+| `face.eye_wink`                            | Left eye squeeze against right, so an ordinary two-eye blink mostly cancels |
+| `pad_a.x`, `pad_a.y`, `pad_b.x`, `pad_b.y` | Two on-screen joysticks, draggable or arrow-key driven                      |
+| Any two keys                               | Chosen per joint; one drives it positive, the other negative                |
+
+Face channels are signed differences between MediaPipe blendshapes, so a relaxed face sits near zero
+and the two directions of a movement land on opposite signs.
+
+## Safety
+
+This teleoperator commands absolute joint positions it integrates itself, so it has to be careful
+about where it thinks the robot is.
+
+- **It stays silent until you engage.** `get_action()` returns an empty dict until the operator engages
+  the clutch for the first time.
+- **The first engaged command is the start pose.** The follower may be somewhere else entirely. Either
+  run with `--robot.max_relative_target` so the robot rate-limits the approach, or feed the follower's
+  observation back with [`send_feedback`](#anchoring-on-the-robots-real-position) before engaging.
+- **Silence stops the robot.** If no input frame arrives within `input_timeout_s` (0.5 s by default) the
+  clutch is released, so a closed tab, a crashed browser, or a dead Wi-Fi link cannot leave a joint
+  travelling.
+- **Losing your face is not losing control.** When tracking drops, face-driven joints stop while
+  keyboard and joystick joints keep working.
+- **Steps are bounded.** The integrator honours at most `max_step_s` (60 ms) of elapsed time per cycle,
+  so a stalled loop or a suspended laptop cannot turn into one large jump.
+- **Travel is limited, but limits never force motion.** A joint cannot be driven further outside
+  `joint_limits`, yet a joint that starts outside them — parked against a mechanical stop, or left
+  there when you tightened the limits — can still be driven back in. Clamping outright would command
+  a jump nobody asked for.
+
+These are software limits, not a hardware safety system. Clear the workspace before you engage.
+
+### Setting the limits for your arm
+
+Every SO-101 has a slightly different usable range, because calibration records it by driving each
+joint into its mechanical stop. Commanding past that range presses the joint into the stop, so
+`joint_limits` defaults to a cautious ±75° on the arm joints. Read your own from
+`~/.cache/huggingface/lerobot/calibration/robots/so_follower/<id>.json`, where the half-range in
+degrees is `(range_max - range_min) / 2 * 360 / 4095`:
+
+```python
+import json
+
+calibration = json.load(open("~/.cache/huggingface/lerobot/calibration/robots/so_follower/my_arm.json"))
+for joint, values in calibration.items():
+    half = (values["range_max"] - values["range_min"]) / 2 * 360 / 4095
+    print(f"{joint}: +/-{half:.0f} deg")
+```
+
+Leave a few degrees of margin, and remember the gripper is a percentage rather than an angle.
+
+### Anchoring on the robot's real position
+
+`send_feedback` accepts the follower's observation and re-anchors the commanded pose, which removes
+the jump on first engage. The stock `lerobot-teleoperate` loop does not call it, so wire it up
+yourself when you need it:
+
+```python
+from lerobot.robots.so_follower import SO101Follower, SOFollowerRobotConfig
+from lerobot.teleoperators.accessible_teleop import AccessibleTeleop, AccessibleTeleopConfig
+
+robot = SO101Follower(SOFollowerRobotConfig(port="/dev/tty.usbmodem58760431541", id="my_arm"))
+teleop = AccessibleTeleop(AccessibleTeleopConfig(id="my_profile"))
+robot.connect()
+teleop.connect()
+
+while True:
+    observation = robot.get_observation()
+    teleop.send_feedback(observation)  # ignored while the clutch is engaged
+    action = teleop.get_action()
+    if action:
+        robot.send_action(action)
+```
+
+## Configuring it from the command line
+
+Bindings can be set without touching the page, which is useful for reproducing a known-good profile:
+
+```bash
+lerobot-teleoperate \
+    --robot.type=so101_follower \
+    --robot.port=/dev/tty.usbmodem58760431541 \
+    --robot.id=my_arm \
+    --teleop.type=accessible_teleop \
+    --teleop.id=my_profile \
+    --teleop.bindings='{
+      shoulder_pan: {source: joystick, channel: pad_a.x, speed: 25},
+      shoulder_lift: {source: joystick, channel: pad_a.y, speed: 20},
+      elbow_flex: {source: keyboard, positive_key: KeyF, negative_key: KeyG},
+      gripper: {source: face, channel: face.mouth_open, speed: 60}
+    }'
+```
+
+A saved profile takes precedence over these values, because it represents what the operator actually
+tuned. Delete the calibration file to start from the config again.
+
+| Option              | Default               | Purpose                                         |
+| ------------------- | --------------------- | ----------------------------------------------- |
+| `joints`            | the six SO-101 joints | Which joints to command, in page order          |
+| `bindings`          | all unbound           | Per-joint input and tuning                      |
+| `joint_limits`      | ±75°, gripper 0–100   | Travel limit in the follower's normalized units |
+| `start_pose`        | mid-range, gripper 50 | Pose commanded on first engage                  |
+| `host` / `web_port` | `127.0.0.1` / `8777`  | Where the page is served                        |
+| `open_browser`      | `true`                | Open the page automatically                     |
+| `connect_timeout_s` | `180`                 | How long `connect` waits for the page           |
+| `input_timeout_s`   | `0.5`                 | Silence tolerated before the clutch is released |
+| `max_step_s`        | `0.06`                | Largest integration step honoured               |
+| `face_tracking`     | `true`                | Serve the face channels at all                  |
+
+## Recording datasets
+
+The teleoperator emits the same `{joint}.pos` action keys as a leader arm, so `lerobot-record` works
+unchanged:
+
+```bash
+lerobot-record \
+    --robot.type=so101_follower \
+    --robot.port=/dev/tty.usbmodem58760431541 \
+    --robot.id=my_arm \
+    --robot.cameras='{front: {type: opencv, index_or_path: 0, width: 640, height: 480, fps: 30}}' \
+    --teleop.type=accessible_teleop \
+    --teleop.id=my_profile \
+    --dataset.repo_id=${HF_USER}/accessible-pick-place \
+    --dataset.num_episodes=20 \
+    --dataset.single_task="Pick up the cube"
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,6 +162,7 @@ pyserial-dep = ["pyserial>=3.5,<4.0"]
 deepdiff-dep = ["deepdiff>=7.0.1,<9.0.0"]
 pynput-dep = ["pynput>=1.7.8,<1.9.0"]
 pyzmq-dep = ["pyzmq>=26.2.1,<28.0.0"]
+websockets-dep = ["websockets>=13.0,<17.0"]
 motorbridge-dep = ["motorbridge>=0.3.2,<0.4.0"]
 motorbridge-smart-servo-dep = ["motorbridge-smart-servo>=0.0.4,<0.1.0"]
 timm-dep = ["timm>=1.0.0,<1.1.0"]
@@ -202,6 +203,10 @@ intelrealsense = [
     "pyrealsense2-macosx>=2.54,<2.57.0 ; sys_platform == 'darwin'",
 ]
 phone = ["hebi-py>=2.8.0,<2.12.0", "teleop>=0.1.0,<0.2.0", "fastapi<1.0", "lerobot[scipy-dep]"]
+# Browser-driven teleoperation for operators who cannot use a leader arm. The control page
+# loads MediaPipe from a CDN on first use, so face tracking needs network access once; the
+# joystick and keyboard channels work fully offline.
+accessible-teleop = ["lerobot[websockets-dep]"]
 
 # Policies
 diffusion = ["lerobot[diffusers-dep]"]
@@ -301,6 +306,7 @@ all = [
     "lerobot[feetech]",
     "lerobot[damiao]",
     "lerobot[robstride]",
+    "lerobot[accessible-teleop]",
     "lerobot[gamepad]",
     "lerobot[hopejr]",
     "lerobot[lekiwi]",
@@ -374,7 +380,11 @@ torch = [{ index = "pytorch-cu128", marker = "sys_platform == 'linux'" }]
 torchvision = [{ index = "pytorch-cu128", marker = "sys_platform == 'linux'" }]
 
 [tool.setuptools.package-data]
-lerobot = ["envs/*.json", "annotations/steerable_pipeline/prompts/*.txt"]
+lerobot = [
+    "envs/*.json",
+    "annotations/steerable_pipeline/prompts/*.txt",
+    "teleoperators/accessible_teleop/assets/*.html",
+]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/lerobot/scripts/lerobot_calibrate.py
+++ b/src/lerobot/scripts/lerobot_calibrate.py
@@ -53,6 +53,7 @@ from lerobot.robots import (  # noqa: F401
 from lerobot.teleoperators import (  # noqa: F401
     Teleoperator,
     TeleoperatorConfig,
+    accessible_teleop,
     bi_openarm_leader,
     bi_openarm_mini,
     bi_rebot_102_leader,

--- a/src/lerobot/scripts/lerobot_record.py
+++ b/src/lerobot/scripts/lerobot_record.py
@@ -135,6 +135,7 @@ from lerobot.robots import (  # noqa: F401
 from lerobot.teleoperators import (  # noqa: F401
     Teleoperator,
     TeleoperatorConfig,
+    accessible_teleop,
     bi_openarm_leader,
     bi_openarm_mini,
     bi_rebot_102_leader,

--- a/src/lerobot/scripts/lerobot_record.py
+++ b/src/lerobot/scripts/lerobot_record.py
@@ -298,6 +298,11 @@ def record_loop(
 
         # Get action from teleop
         if isinstance(teleop, Teleoperator):
+            # accessible_teleop has to be anchored on the measured pose *before* it produces
+            # an action, or its first engaged command would make the arm jump to the
+            # configured start pose.
+            if teleop.name == "accessible_teleop":
+                teleop.send_feedback(obs)
             act = teleop.get_action()
             if robot.name == "unitree_g1":
                 teleop.send_feedback(obs)

--- a/src/lerobot/scripts/lerobot_rollout.py
+++ b/src/lerobot/scripts/lerobot_rollout.py
@@ -177,6 +177,7 @@ from lerobot.rollout import RolloutConfig, build_rollout_context, create_strateg
 from lerobot.teleoperators import (  # noqa: F401
     Teleoperator,
     TeleoperatorConfig,
+    accessible_teleop,
     bi_openarm_leader,
     bi_openarm_mini,
     bi_rebot_102_leader,

--- a/src/lerobot/scripts/lerobot_teleoperate.py
+++ b/src/lerobot/scripts/lerobot_teleoperate.py
@@ -47,6 +47,19 @@ lerobot-teleoperate \
     --display_mode=foxglove
 ```
 
+Example teleoperation without a leader arm, driven from a browser page by whatever small
+movement the operator has (see ``docs/source/accessible_teleop.mdx``):
+
+```shell
+lerobot-teleoperate \
+    --robot.type=so101_follower \
+    --robot.port=/dev/tty.usbmodem58760431541 \
+    --robot.id=black \
+    --robot.max_relative_target=5 \
+    --teleop.type=accessible_teleop \
+    --teleop.id=my_profile
+```
+
 Example teleoperation with bimanual so100:
 
 ```shell
@@ -104,6 +117,7 @@ from lerobot.robots import (  # noqa: F401
 from lerobot.teleoperators import (  # noqa: F401
     Teleoperator,
     TeleoperatorConfig,
+    accessible_teleop,
     bi_openarm_leader,
     bi_openarm_mini,
     bi_rebot_102_leader,

--- a/src/lerobot/scripts/lerobot_teleoperate.py
+++ b/src/lerobot/scripts/lerobot_teleoperate.py
@@ -208,7 +208,10 @@ def teleop_loop(
         # given that it is the identity processor as default
         obs = robot.get_observation()
 
-        if robot.name == "unitree_g1":
+        # accessible_teleop integrates a velocity command into a position, so it needs the
+        # robot's measured pose to start from; without it the first engaged action would
+        # command its configured start pose and the arm would jump to reach it.
+        if robot.name == "unitree_g1" or teleop.name == "accessible_teleop":
             teleop.send_feedback(obs)
 
         # Get teleop action

--- a/src/lerobot/teleoperators/accessible_teleop/__init__.py
+++ b/src/lerobot/teleoperators/accessible_teleop/__init__.py
@@ -1,0 +1,33 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .accessible_teleop import AccessibleTeleop
+from .config_accessible_teleop import (
+    FACE_CHANNELS,
+    JOYSTICK_CHANNELS,
+    AccessibleTeleopConfig,
+    ChannelCalibration,
+    InputSource,
+    JointBinding,
+)
+
+__all__ = [
+    "FACE_CHANNELS",
+    "JOYSTICK_CHANNELS",
+    "AccessibleTeleop",
+    "AccessibleTeleopConfig",
+    "ChannelCalibration",
+    "InputSource",
+    "JointBinding",
+]

--- a/src/lerobot/teleoperators/accessible_teleop/accessible_teleop.py
+++ b/src/lerobot/teleoperators/accessible_teleop/accessible_teleop.py
@@ -1,0 +1,346 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import logging
+import time
+import webbrowser
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+from lerobot.utils.decorators import check_if_already_connected, check_if_not_connected
+
+from ..teleoperator import Teleoperator
+from .config_accessible_teleop import (
+    AccessibleTeleopConfig,
+    ChannelCalibration,
+    InputSource,
+    JointBinding,
+)
+from .control import InputFrame, JointController
+from .web_bridge import ControlBridge
+
+logger = logging.getLogger(__name__)
+
+
+class AccessibleTeleop(Teleoperator):
+    """Joint-space teleoperation driven by whatever movement the operator actually has.
+
+    This teleoperator exists for people who cannot use a leader arm. Instead of assuming a
+    pair of working hands, it lets the operator bind each robot joint, one at a time, to any
+    small input they can produce reliably: a facial movement picked up by the webcam, a
+    single key, or an on-screen joystick they can reach with a mouse, a trackball, or a head
+    pointer. Each binding is calibrated to that person's own comfortable range and tuned
+    separately for dead zone, gain, smoothing, and speed.
+
+    Control is joint-space and velocity-integrated. Deflecting an input moves a joint while
+    it is held and stops when the input returns to neutral, which is what makes a few
+    millimetres of usable movement enough to reach across the robot's whole range.
+
+    A browser page served on loopback is the input surface. It reports raw sensor readings
+    and lets the operator edit their mapping; the conditioning, integration, and limiting all
+    happen here, so a stalled tab or a dropped socket stops the robot rather than surprising
+    it.
+
+    Example:
+        ```python
+        from lerobot.teleoperators.accessible_teleop import AccessibleTeleop, AccessibleTeleopConfig
+
+        teleop = AccessibleTeleop(AccessibleTeleopConfig(id="my_profile"))
+        teleop.connect()
+        action = teleop.get_action()
+        ```
+
+    Safety:
+        The teleoperator returns an empty action until the operator engages the clutch on the
+        page. The first engaged action commands :pyattr:`AccessibleTeleopConfig.start_pose`,
+        which the follower may be far away from. Either call :pymeth:`send_feedback` with the
+        robot's current positions first, or run the follower with ``--robot.max_relative_target``
+        so that the approach is rate limited by the robot as well.
+    """
+
+    config_class = AccessibleTeleopConfig
+    name = "accessible_teleop"
+
+    def __init__(self, config: AccessibleTeleopConfig):
+        self.config = config
+        self.bindings: dict[str, JointBinding] = {
+            joint: config.bindings.get(joint, JointBinding()) for joint in config.joints
+        }
+        self.channel_calibrations: dict[str, ChannelCalibration] = {}
+
+        # Populates bindings and channel calibrations from the saved profile, if there is one.
+        super().__init__(config)
+
+        self.controller = JointController(
+            joints=config.joints,
+            bindings=self.bindings,
+            joint_limits={j: tuple(v) for j, v in config.joint_limits.items()},
+            start_pose=dict(config.start_pose),
+            calibrations=self.channel_calibrations,
+            max_step_s=config.max_step_s,
+        )
+        self._bridge: ControlBridge | None = None
+        self._last_step: float | None = None
+        self._armed = False
+        self._stale_logged = False
+
+    # ── features ─────────────────────────────────────────────────────────
+
+    @property
+    def action_features(self) -> dict[str, type]:
+        return {f"{joint}.pos": float for joint in self.config.joints}
+
+    @property
+    def feedback_features(self) -> dict[str, type]:
+        return self.action_features
+
+    # ── lifecycle ────────────────────────────────────────────────────────
+
+    @property
+    def is_connected(self) -> bool:
+        return self._bridge is not None and self._bridge.is_running
+
+    @check_if_already_connected
+    def connect(self, calibrate: bool = True) -> None:
+        self._bridge = ControlBridge(
+            config=self.config,
+            bindings=self.bindings,
+            calibrations=self.channel_calibrations,
+            on_profile_change=self._on_profile_change,
+        )
+        self._bridge.start()
+
+        if self.config.open_browser:
+            webbrowser.open(self._bridge.url)
+
+        print(f"\nOpen the accessible teleop control page at {self._bridge.url}")
+        print("Waiting for the page to connect...")
+        if not self._bridge.wait_for_client(self.config.connect_timeout_s):
+            self._bridge.stop()
+            self._bridge = None
+            raise TimeoutError(
+                f"No control page connected within {self.config.connect_timeout_s:.0f}s. "
+                f"Open {self.config.host}:{self.config.web_port} in a browser and retry."
+            )
+
+        if not self.is_calibrated and calibrate:
+            self.calibrate()
+
+        self.configure()
+        self._warn_about_start_pose()
+        logger.info(f"{self} connected.")
+
+    @check_if_not_connected
+    def disconnect(self) -> None:
+        self._bridge.release_clutch()
+        self._bridge.stop()
+        self._bridge = None
+        self._armed = False
+        self._last_step = None
+        logger.info(f"{self} disconnected.")
+
+    def configure(self) -> None:
+        self.controller.reset()
+
+    # ── calibration ──────────────────────────────────────────────────────
+
+    @property
+    def is_calibrated(self) -> bool:
+        """True when every face channel the operator has bound has a captured range.
+
+        Keyboard and joystick bindings need no calibration, so a profile that uses only
+        those is calibrated by definition.
+        """
+        return all(
+            self.channel_calibrations.get(binding.channel, ChannelCalibration()).ready
+            for binding in self.bindings.values()
+            if binding.source is InputSource.FACE and binding.channel
+        )
+
+    def calibrate(self) -> None:
+        """Wait for the operator to capture a range for each face channel they have bound.
+
+        Calibration happens in the page, where the operator can see their own movement, so
+        this only blocks until the page reports that the work is done.
+        """
+        pending = self._uncalibrated_channels()
+        if not pending:
+            logger.info(f"{self} has nothing to calibrate.")
+            return
+
+        print(f"\nRunning calibration of {self}")
+        print("In the control page, relax, press Calibrate on each channel below, then move")
+        print("that feature through the range you can hold comfortably:")
+        for channel in pending:
+            print(f"  - {channel}")
+        print("Press Ctrl+C to keep the ranges captured so far.\n")
+
+        try:
+            while self._uncalibrated_channels():
+                time.sleep(0.2)
+        except KeyboardInterrupt:
+            print("\nCalibration interrupted; uncalibrated channels will not move the robot.")
+            return
+
+        self._save_calibration()
+        print(f"Calibration saved to {self.calibration_fpath}")
+
+    def _uncalibrated_channels(self) -> list[str]:
+        return sorted(
+            {
+                binding.channel
+                for binding in self.bindings.values()
+                if binding.source is InputSource.FACE
+                and binding.channel
+                and not self.channel_calibrations.get(binding.channel, ChannelCalibration()).ready
+            }
+        )
+
+    def _load_calibration(self, fpath: Path | None = None) -> None:
+        """Load the operator's bindings and channel ranges.
+
+        This teleoperator has no motors, so it stores a control profile where other
+        teleoperators store motor offsets.
+        """
+        fpath = self.calibration_fpath if fpath is None else fpath
+        with open(fpath) as f:
+            profile = json.load(f)
+
+        for joint, raw in (profile.get("bindings") or {}).items():
+            if joint in self.bindings:
+                self.bindings[joint] = _binding_from_profile(raw)
+        for channel, raw in (profile.get("calibrations") or {}).items():
+            self.channel_calibrations[channel] = ChannelCalibration(**raw)
+        logger.info(f"Loaded accessible teleop profile from {fpath}")
+
+    def _save_calibration(self, fpath: Path | None = None) -> None:
+        fpath = self.calibration_fpath if fpath is None else fpath
+        profile = {
+            "bindings": {joint: _binding_to_profile(b) for joint, b in self.bindings.items()},
+            "calibrations": {ch: asdict(c) for ch, c in self.channel_calibrations.items()},
+        }
+        with open(fpath, "w") as f:
+            json.dump(profile, f, indent=4)
+
+    def _on_profile_change(self) -> None:
+        """Persist a mapping the operator edited in the page, so it survives a restart."""
+        try:
+            self._save_calibration()
+        except OSError as exc:
+            logger.warning(f"Could not save the control profile: {exc}")
+
+    # ── control ──────────────────────────────────────────────────────────
+
+    @check_if_not_connected
+    def get_action(self) -> dict[str, float]:
+        frame, age = self._bridge.read_frame()
+
+        if age is None or age > self.config.input_timeout_s:
+            # Losing the page mid-motion is the failure this teleoperator has to survive
+            # gracefully, so treat silence as a released clutch rather than as the last
+            # command repeating forever.
+            if frame.engaged and not self._stale_logged:
+                logger.warning("No input from the control page; holding position.")
+                self._stale_logged = True
+            self._bridge.release_clutch()
+            frame = InputFrame()
+        else:
+            self._stale_logged = False
+
+        if frame.engaged:
+            self._armed = True
+
+        now = time.perf_counter()
+        dt_s = 0.0 if self._last_step is None else now - self._last_step
+        self._last_step = now
+
+        pose = self.controller.step(frame, dt_s)
+        self._publish_state(frame, age)
+
+        if not self._armed:
+            # Nothing has been engaged yet, so there is no pose this teleoperator is
+            # entitled to command.
+            return {}
+
+        return {f"{joint}.pos": pose[joint] for joint in self.config.joints}
+
+    @check_if_not_connected
+    def send_feedback(self, feedback: dict[str, Any]) -> None:
+        """Anchor the commanded pose on the robot's measured positions.
+
+        Feeding the follower's observation back while the clutch is open removes the jump
+        that would otherwise happen the first time the operator engages, and keeps the
+        commanded pose honest if the robot was moved by hand.
+        """
+        positions = {
+            key.removesuffix(".pos"): float(value)
+            for key, value in feedback.items()
+            if key.endswith(".pos") and isinstance(value, (int, float))
+        }
+        if not positions:
+            return
+
+        frame, _ = self._bridge.read_frame()
+        if frame.engaged:
+            return
+
+        self.controller.reset(positions)
+
+    def sync_to(self, pose: dict[str, float]) -> None:
+        """Re-anchor the commanded pose without going through the feedback dict format."""
+        self.controller.reset(pose)
+
+    def _publish_state(self, frame: InputFrame, age: float | None) -> None:
+        limits = self.config.joint_limits
+        pose = self.controller.pose
+        self._bridge.publish_state(
+            {
+                "pose": pose,
+                "velocity": self.controller.velocity,
+                "atLimit": {
+                    joint: bool(
+                        joint in limits
+                        and (pose[joint] <= limits[joint][0] + 1e-6 or pose[joint] >= limits[joint][1] - 1e-6)
+                    )
+                    for joint in pose
+                },
+                "engaged": frame.engaged,
+                "armed": self._armed,
+                "inputAgeMs": None if age is None else round(age * 1000),
+            }
+        )
+
+    def _warn_about_start_pose(self) -> None:
+        pose = ", ".join(f"{j}={v:g}" for j, v in self.controller.pose.items())
+        print("\n" + "=" * 78)
+        print("The robot will move to the start pose the first time you engage the clutch.")
+        print(f"  start pose: {pose}")
+        print("Clear the workspace, and consider running the follower with a relative-target")
+        print("limit, for example --robot.max_relative_target=5.")
+        print("=" * 78 + "\n")
+
+
+def _binding_to_profile(binding: JointBinding) -> dict[str, Any]:
+    payload = asdict(binding)
+    payload["source"] = binding.source.value
+    return payload
+
+
+def _binding_from_profile(raw: dict[str, Any]) -> JointBinding:
+    payload = dict(raw)
+    payload["source"] = InputSource(payload.get("source", InputSource.NONE.value))
+    fields = JointBinding.__dataclass_fields__
+    return JointBinding(**{k: v for k, v in payload.items() if k in fields})

--- a/src/lerobot/teleoperators/accessible_teleop/accessible_teleop.py
+++ b/src/lerobot/teleoperators/accessible_teleop/accessible_teleop.py
@@ -28,6 +28,8 @@ from .config_accessible_teleop import (
     ChannelCalibration,
     InputSource,
     JointBinding,
+    binding_from_dict,
+    binding_to_dict,
 )
 from .control import InputFrame, JointController
 from .web_bridge import ControlBridge
@@ -64,11 +66,17 @@ class AccessibleTeleop(Teleoperator):
         ```
 
     Safety:
-        The teleoperator returns an empty action until the operator engages the clutch on the
-        page. The first engaged action commands :pyattr:`AccessibleTeleopConfig.start_pose`,
-        which the follower may be far away from. Either call :pymeth:`send_feedback` with the
-        robot's current positions first, or run the follower with ``--robot.max_relative_target``
-        so that the approach is rate limited by the robot as well.
+        The commanded pose only changes while the operator holds the clutch closed, so the
+        action is a steady hold until they ask for movement. What it holds *at* matters:
+        :pymeth:`send_feedback` anchors it on the follower's measured positions, and
+        ``lerobot-teleoperate`` and ``lerobot-record`` call it on every cycle before reading
+        the action, so the first engagement continues from wherever the arm actually is.
+
+        Drive this teleoperator from a loop that does not feed it the robot's observation and
+        it has nothing to anchor on: it starts from
+        :pyattr:`AccessibleTeleopConfig.start_pose`, which the follower may be far away from.
+        Run the follower with ``--robot.max_relative_target`` so that the approach is rate
+        limited by the robot as well.
     """
 
     config_class = AccessibleTeleopConfig
@@ -94,7 +102,7 @@ class AccessibleTeleop(Teleoperator):
         )
         self._bridge: ControlBridge | None = None
         self._last_step: float | None = None
-        self._armed = False
+        self._anchored = False
         self._stale_logged = False
 
     # ── features ─────────────────────────────────────────────────────────
@@ -148,7 +156,7 @@ class AccessibleTeleop(Teleoperator):
         self._bridge.release_clutch()
         self._bridge.stop()
         self._bridge = None
-        self._armed = False
+        self._anchored = False
         self._last_step = None
         logger.info(f"{self} disconnected.")
 
@@ -221,7 +229,7 @@ class AccessibleTeleop(Teleoperator):
 
         for joint, raw in (profile.get("bindings") or {}).items():
             if joint in self.bindings:
-                self.bindings[joint] = _binding_from_profile(raw)
+                self.bindings[joint] = binding_from_dict(raw)
         for channel, raw in (profile.get("calibrations") or {}).items():
             self.channel_calibrations[channel] = ChannelCalibration(**raw)
         logger.info(f"Loaded accessible teleop profile from {fpath}")
@@ -229,7 +237,7 @@ class AccessibleTeleop(Teleoperator):
     def _save_calibration(self, fpath: Path | None = None) -> None:
         fpath = self.calibration_fpath if fpath is None else fpath
         profile = {
-            "bindings": {joint: _binding_to_profile(b) for joint, b in self.bindings.items()},
+            "bindings": {joint: binding_to_dict(b) for joint, b in self.bindings.items()},
             "calibrations": {ch: asdict(c) for ch, c in self.channel_calibrations.items()},
         }
         with open(fpath, "w") as f:
@@ -260,9 +268,6 @@ class AccessibleTeleop(Teleoperator):
         else:
             self._stale_logged = False
 
-        if frame.engaged:
-            self._armed = True
-
         now = time.perf_counter()
         dt_s = 0.0 if self._last_step is None else now - self._last_step
         self._last_step = now
@@ -270,11 +275,9 @@ class AccessibleTeleop(Teleoperator):
         pose = self.controller.step(frame, dt_s)
         self._publish_state(frame, age)
 
-        if not self._armed:
-            # Nothing has been engaged yet, so there is no pose this teleoperator is
-            # entitled to command.
-            return {}
-
+        # Always a full action. Returning nothing would be the honest answer before the
+        # operator engages, but callers pass this straight to `send_action`, and an empty
+        # action reaches the motor bus as a write with no motors in it.
         return {f"{joint}.pos": pose[joint] for joint in self.config.joints}
 
     @check_if_not_connected
@@ -298,10 +301,12 @@ class AccessibleTeleop(Teleoperator):
             return
 
         self.controller.reset(positions)
+        self._anchored = True
 
     def sync_to(self, pose: dict[str, float]) -> None:
         """Re-anchor the commanded pose without going through the feedback dict format."""
         self.controller.reset(pose)
+        self._anchored = True
 
     def _publish_state(self, frame: InputFrame, age: float | None) -> None:
         limits = self.config.joint_limits
@@ -310,15 +315,13 @@ class AccessibleTeleop(Teleoperator):
             {
                 "pose": pose,
                 "velocity": self.controller.velocity,
-                "atLimit": {
-                    joint: bool(
-                        joint in limits
-                        and (pose[joint] <= limits[joint][0] + 1e-6 or pose[joint] >= limits[joint][1] - 1e-6)
-                    )
-                    for joint in pose
-                },
+                "atLimit": {joint: _blocked_direction(pose[joint], limits.get(joint)) != 0 for joint in pose},
+                # Which way the joint has stopped accepting commands. A joint resting against
+                # a mechanical stop still moves perfectly well in the other direction, and an
+                # operator who is not told that reasonably concludes their input is broken.
+                "blocked": {joint: _blocked_direction(pose[joint], limits.get(joint)) for joint in pose},
                 "engaged": frame.engaged,
-                "armed": self._armed,
+                "anchored": self._anchored,
                 "inputAgeMs": None if age is None else round(age * 1000),
             }
         )
@@ -326,21 +329,22 @@ class AccessibleTeleop(Teleoperator):
     def _warn_about_start_pose(self) -> None:
         pose = ", ".join(f"{j}={v:g}" for j, v in self.controller.pose.items())
         print("\n" + "=" * 78)
-        print("The robot will move to the start pose the first time you engage the clutch.")
+        print("Until this teleoperator is given the robot's measured positions, it commands")
+        print("the configured start pose, which the follower may be far away from:")
         print(f"  start pose: {pose}")
-        print("Clear the workspace, and consider running the follower with a relative-target")
-        print("limit, for example --robot.max_relative_target=5.")
+        print("lerobot-teleoperate and lerobot-record do this for you on every cycle. In your")
+        print("own loop, call send_feedback(robot.get_observation()) before get_action().")
+        print("Either way, run the follower with a limit such as --robot.max_relative_target=5.")
         print("=" * 78 + "\n")
 
 
-def _binding_to_profile(binding: JointBinding) -> dict[str, Any]:
-    payload = asdict(binding)
-    payload["source"] = binding.source.value
-    return payload
-
-
-def _binding_from_profile(raw: dict[str, Any]) -> JointBinding:
-    payload = dict(raw)
-    payload["source"] = InputSource(payload.get("source", InputSource.NONE.value))
-    fields = JointBinding.__dataclass_fields__
-    return JointBinding(**{k: v for k, v in payload.items() if k in fields})
+def _blocked_direction(position: float, limits: tuple[float, float] | None) -> int:
+    """Return +1 or -1 for the direction a joint can no longer travel, or 0 when it is free."""
+    if limits is None:
+        return 0
+    low, high = limits
+    if position >= high - 1e-6:
+        return 1
+    if position <= low + 1e-6:
+        return -1
+    return 0

--- a/src/lerobot/teleoperators/accessible_teleop/assets/index.html
+++ b/src/lerobot/teleoperators/accessible_teleop/assets/index.html
@@ -1,0 +1,999 @@
+<!doctype html>
+<!--
+Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>LeRobot accessible teleoperation</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        --bg: #0d1014;
+        --panel: #161b22;
+        --panel-2: #1d242d;
+        --line: #2c3540;
+        --text: #e8edf2;
+        --muted: #93a1b0;
+        --accent: #5ac8fa;
+        --live: #4ade80;
+        --warn: #fbbf24;
+        --stop: #f87171;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        background: var(--bg);
+        color: var(--text);
+        font: 15px/1.5 ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+      }
+      header {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 16px;
+        align-items: center;
+        justify-content: space-between;
+        padding: 16px 24px;
+        border-bottom: 1px solid var(--line);
+        background: var(--panel);
+        position: sticky;
+        top: 0;
+        z-index: 10;
+      }
+      h1 {
+        font-size: 17px;
+        margin: 0;
+        letter-spacing: 0.01em;
+      }
+      h2 {
+        font-size: 13px;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: var(--muted);
+        margin: 0 0 12px;
+      }
+      .sub {
+        color: var(--muted);
+        font-size: 13px;
+      }
+      main {
+        display: grid;
+        grid-template-columns: minmax(0, 1.15fr) minmax(340px, 0.85fr);
+        gap: 20px;
+        padding: 20px 24px 60px;
+        align-items: start;
+      }
+      @media (max-width: 1080px) {
+        main {
+          grid-template-columns: minmax(0, 1fr);
+        }
+      }
+      section {
+        background: var(--panel);
+        border: 1px solid var(--line);
+        border-radius: 12px;
+        padding: 18px;
+        margin-bottom: 20px;
+      }
+      button {
+        font: inherit;
+        color: inherit;
+        background: var(--panel-2);
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        padding: 9px 14px;
+        cursor: pointer;
+        min-height: 40px;
+      }
+      button:hover:not(:disabled) {
+        border-color: var(--accent);
+      }
+      button:disabled {
+        opacity: 0.45;
+        cursor: not-allowed;
+      }
+      button:focus-visible,
+      select:focus-visible,
+      input:focus-visible,
+      [tabindex]:focus-visible {
+        outline: 2px solid var(--accent);
+        outline-offset: 2px;
+      }
+      select,
+      input[type="text"] {
+        font: inherit;
+        color: inherit;
+        background: var(--panel-2);
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        padding: 8px 10px;
+        min-height: 40px;
+        width: 100%;
+      }
+      .clutch {
+        font-size: 16px;
+        font-weight: 600;
+        padding: 12px 22px;
+        min-height: 52px;
+        border-width: 2px;
+      }
+      .clutch.is-live {
+        background: rgba(74, 222, 128, 0.14);
+        border-color: var(--live);
+        color: var(--live);
+      }
+      .estop {
+        border-color: var(--stop);
+        color: var(--stop);
+        font-weight: 600;
+      }
+      .pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 7px;
+        font-size: 12px;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: var(--muted);
+      }
+      .dot {
+        width: 9px;
+        height: 9px;
+        border-radius: 50%;
+        background: var(--muted);
+      }
+      .dot.ok {
+        background: var(--live);
+      }
+      .dot.warn {
+        background: var(--warn);
+      }
+      .dot.bad {
+        background: var(--stop);
+      }
+      .joint {
+        border: 1px solid var(--line);
+        border-radius: 10px;
+        padding: 14px;
+        margin-bottom: 12px;
+        background: var(--panel-2);
+      }
+      .joint.is-live {
+        border-color: rgba(74, 222, 128, 0.5);
+      }
+      .joint-head {
+        display: flex;
+        align-items: baseline;
+        gap: 10px;
+        flex-wrap: wrap;
+        margin-bottom: 12px;
+      }
+      .joint-head strong {
+        font-size: 15px;
+      }
+      .joint-head .sub {
+        margin-left: auto;
+        font-variant-numeric: tabular-nums;
+      }
+      .row {
+        display: flex;
+        gap: 10px;
+        flex-wrap: wrap;
+        align-items: center;
+      }
+      .row > label {
+        flex: 1 1 200px;
+        min-width: 0;
+      }
+      .tune {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+        gap: 10px 16px;
+        margin-top: 12px;
+      }
+      .tune label {
+        display: block;
+        font-size: 12px;
+        color: var(--muted);
+      }
+      .tune span {
+        display: flex;
+        justify-content: space-between;
+        margin-bottom: 2px;
+      }
+      .tune output {
+        color: var(--text);
+        font-variant-numeric: tabular-nums;
+      }
+      input[type="range"] {
+        width: 100%;
+        accent-color: var(--accent);
+        height: 28px;
+      }
+      .bar {
+        position: relative;
+        height: 8px;
+        border-radius: 4px;
+        background: #10151b;
+        overflow: hidden;
+        margin-top: 8px;
+      }
+      .bar i {
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        background: var(--accent);
+      }
+      .bar b {
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        left: 50%;
+        width: 1px;
+        background: var(--line);
+      }
+      .pads {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 14px;
+      }
+      .pad {
+        position: relative;
+        aspect-ratio: 1;
+        border: 1px solid var(--line);
+        border-radius: 12px;
+        background: radial-gradient(circle at center, #141a21, #0e1319);
+        touch-action: none;
+        cursor: crosshair;
+      }
+      .pad.is-active {
+        border-color: var(--accent);
+      }
+      .pad i {
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        width: 34px;
+        height: 34px;
+        margin: -17px 0 0 -17px;
+        border-radius: 50%;
+        background: var(--accent);
+        opacity: 0.85;
+      }
+      .pad b {
+        position: absolute;
+        inset: 12px;
+        border: 1px dashed var(--line);
+        border-radius: 50%;
+      }
+      .keys {
+        display: flex;
+        gap: 8px;
+        margin-top: 10px;
+      }
+      .keycap {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        align-items: center;
+      }
+      .keycap.is-capturing {
+        border-color: var(--accent);
+        color: var(--accent);
+      }
+      .keycap kbd {
+        font: 600 15px ui-monospace, monospace;
+      }
+      .keycap small {
+        color: var(--muted);
+        font-size: 11px;
+      }
+      .channel {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        padding: 8px 0;
+        border-bottom: 1px solid var(--line);
+      }
+      .channel:last-child {
+        border-bottom: 0;
+      }
+      .channel .name {
+        flex: 1 1 auto;
+        min-width: 0;
+      }
+      .channel .bar {
+        flex: 1 1 120px;
+        margin: 0;
+      }
+      video {
+        width: 100%;
+        border-radius: 10px;
+        background: #000;
+        /* Mirrored so moving left on screen matches moving left in the room. */
+        transform: scaleX(-1);
+        display: block;
+      }
+      video[hidden] {
+        display: none;
+      }
+      .banner {
+        border-radius: 10px;
+        padding: 12px 14px;
+        margin-bottom: 14px;
+        font-size: 14px;
+        border: 1px solid var(--warn);
+        background: rgba(251, 191, 36, 0.1);
+        color: var(--warn);
+      }
+      .banner.bad {
+        border-color: var(--stop);
+        background: rgba(248, 113, 113, 0.1);
+        color: var(--stop);
+      }
+      code {
+        font: 12px ui-monospace, monospace;
+        color: var(--muted);
+      }
+      .visually-hidden {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        overflow: hidden;
+        clip: rect(0 0 0 0);
+        white-space: nowrap;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <div>
+        <h1>Accessible teleoperation &middot; LeRobot</h1>
+        <div class="sub" id="profile-name"></div>
+      </div>
+      <div class="row">
+        <span class="pill"><i class="dot" id="dot-link"></i><span id="link-text">connecting</span></span>
+        <span class="pill"><i class="dot" id="dot-face"></i><span id="face-text">camera off</span></span>
+        <button class="clutch" id="clutch" aria-pressed="false">Engage control</button>
+        <button class="estop" id="estop">Stop</button>
+      </div>
+    </header>
+
+    <main>
+      <div>
+        <section>
+          <h2>Joint and input map</h2>
+          <div id="arm-banner" class="banner">
+            Nothing has been sent to the robot yet. The first time you engage control, the arm
+            moves to its start pose. Clear the workspace first.
+          </div>
+          <div id="joints"></div>
+        </section>
+      </div>
+
+      <div>
+        <section>
+          <h2>On-screen joysticks</h2>
+          <div class="pads">
+            <div>
+              <div
+                class="pad"
+                id="pad_a"
+                role="application"
+                tabindex="0"
+                aria-label="Joystick A. Drag, or focus and use the arrow keys."
+              >
+                <b></b><i></i>
+              </div>
+              <div class="sub" style="margin-top: 6px">Pad A</div>
+            </div>
+            <div>
+              <div
+                class="pad"
+                id="pad_b"
+                role="application"
+                tabindex="0"
+                aria-label="Joystick B. Drag, or focus and use the arrow keys."
+              >
+                <b></b><i></i>
+              </div>
+              <div class="sub" style="margin-top: 6px">Pad B</div>
+            </div>
+          </div>
+        </section>
+
+        <section id="face-section">
+          <h2>Face channels</h2>
+          <div class="row" style="margin-bottom: 12px">
+            <button id="camera">Start camera</button>
+            <span class="sub" id="camera-note">Video stays in this tab.</span>
+          </div>
+          <video id="video" playsinline muted hidden></video>
+          <div id="channels"></div>
+        </section>
+
+        <section>
+          <h2>Commanded pose</h2>
+          <div id="pose"></div>
+        </section>
+      </div>
+    </main>
+
+    <div class="visually-hidden" role="status" aria-live="polite" id="announcer"></div>
+
+    <script type="module">
+      const BOOTSTRAP = __LEROBOT_BOOTSTRAP__;
+
+      const CAPTURE_MS = 5000;
+      const MIN_RANGE = 0.06;
+      const SEND_HZ = 60;
+      const RESERVED_KEYS = new Set(["Space"]);
+
+      const JOINT_LABELS = {
+        shoulder_pan: ["Shoulder pan", "left", "right"],
+        shoulder_lift: ["Shoulder lift", "down", "up"],
+        elbow_flex: ["Elbow flex", "fold", "extend"],
+        wrist_flex: ["Wrist flex", "down", "up"],
+        wrist_roll: ["Wrist roll", "left", "right"],
+        gripper: ["Gripper", "close", "open"],
+      };
+
+      const CHANNEL_LABELS = {
+        "face.brow_vertical": ["Eyebrows down / up", "Relax your mouth, then lower and raise both eyebrows."],
+        "face.lip_lateral": ["Lips left / right", "Move your lips comfortably left, then right."],
+        "face.mouth_open": ["Mouth close / open", "Gently close, then open your mouth."],
+        "face.mouth_shape": ["Pucker / smile", "Pucker, return to neutral, then smile."],
+        "face.eye_wink": ["Left / right eye squeeze", "Squeeze one eye, relax, then the other."],
+        "pad_a.x": ["Pad A left / right", ""],
+        "pad_a.y": ["Pad A down / up", ""],
+        "pad_b.x": ["Pad B left / right", ""],
+        "pad_b.y": ["Pad B down / up", ""],
+      };
+
+      const label = (id) => (CHANNEL_LABELS[id] ? CHANNEL_LABELS[id][0] : id);
+      const clamp = (v, lo, hi) => Math.min(hi, Math.max(lo, v));
+      const signed = (v, d = 1) => (v > 0 ? "+" : "") + v.toFixed(d);
+
+      const state = {
+        bindings: BOOTSTRAP.bindings,
+        calibrations: BOOTSTRAP.calibrations,
+        pads: { pad_a: { x: 0, y: 0 }, pad_b: { x: 0, y: 0 } },
+        faceSignals: {},
+        keys: {},
+        engaged: false,
+        tracking: false,
+        capture: null,
+        socket: null,
+        armed: false,
+      };
+
+      const $ = (id) => document.getElementById(id);
+      const announce = (text) => ($("announcer").textContent = text);
+
+      // ── connection ─────────────────────────────────────────────────────
+
+      function connect() {
+        const socket = new WebSocket(`ws://${location.host}/ws`);
+        state.socket = socket;
+
+        socket.addEventListener("open", () => {
+          setDot("link", "ok", "connected");
+          sendProfile();
+        });
+        socket.addEventListener("close", () => {
+          setDot("link", "bad", "disconnected");
+          setEngaged(false);
+          setTimeout(connect, 1000);
+        });
+        socket.addEventListener("message", (event) => {
+          const message = JSON.parse(event.data);
+          if (message.type === "state") renderState(message);
+        });
+      }
+
+      function send(payload) {
+        if (state.socket && state.socket.readyState === WebSocket.OPEN) {
+          state.socket.send(JSON.stringify(payload));
+        }
+      }
+
+      function sendProfile() {
+        send({ type: "profile", bindings: state.bindings, calibrations: state.calibrations });
+      }
+
+      function setDot(name, tone, text) {
+        $(`dot-${name}`).className = `dot ${tone}`;
+        $(`${name}-text`).textContent = text;
+      }
+
+      // ── clutch ─────────────────────────────────────────────────────────
+
+      function setEngaged(next) {
+        state.engaged = next;
+        const button = $("clutch");
+        button.classList.toggle("is-live", next);
+        button.setAttribute("aria-pressed", String(next));
+        button.textContent = next ? "Control is live \u00b7 press to hold" : "Engage control";
+        announce(next ? "Control engaged" : "Control released");
+      }
+
+      $("clutch").addEventListener("click", () => setEngaged(!state.engaged));
+      $("estop").addEventListener("click", () => {
+        setEngaged(false);
+        send({ type: "stop" });
+        announce("Stopped");
+      });
+
+      // ── joysticks ──────────────────────────────────────────────────────
+
+      for (const pad of ["pad_a", "pad_b"]) {
+        const element = $(pad);
+        const knob = element.querySelector("i");
+        let pointer = null;
+
+        const apply = (x, y) => {
+          const length = Math.hypot(x, y);
+          if (length > 1) {
+            x /= length;
+            y /= length;
+          }
+          state.pads[pad] = { x, y };
+          knob.style.transform = `translate(${x * 38}%, ${-y * 38}%)`;
+          element.classList.toggle("is-active", Math.hypot(x, y) > 0.02);
+        };
+        const fromPointer = (event) => {
+          const rect = element.getBoundingClientRect();
+          apply(
+            clamp(((event.clientX - rect.left) / rect.width) * 2 - 1, -1, 1),
+            clamp(1 - ((event.clientY - rect.top) / rect.height) * 2, -1, 1),
+          );
+        };
+        const release = () => {
+          pointer = null;
+          apply(0, 0);
+        };
+
+        element.addEventListener("pointerdown", (event) => {
+          pointer = event.pointerId;
+          element.setPointerCapture(event.pointerId);
+          fromPointer(event);
+        });
+        element.addEventListener("pointermove", (event) => {
+          if (pointer === event.pointerId) fromPointer(event);
+        });
+        element.addEventListener("pointerup", release);
+        element.addEventListener("pointercancel", release);
+        element.addEventListener("lostpointercapture", release);
+        element.addEventListener("blur", release);
+        element.addEventListener("keydown", (event) => {
+          const step = event.shiftKey ? 0.35 : 1;
+          const current = state.pads[pad];
+          if (event.key === "ArrowLeft") apply(-step, current.y);
+          else if (event.key === "ArrowRight") apply(step, current.y);
+          else if (event.key === "ArrowUp") apply(current.x, step);
+          else if (event.key === "ArrowDown") apply(current.x, -step);
+          else return;
+          event.preventDefault();
+          event.stopPropagation();
+        });
+        element.addEventListener("keyup", (event) => {
+          if (!event.key.startsWith("Arrow")) return;
+          event.preventDefault();
+          event.stopPropagation();
+          apply(0, 0);
+        });
+      }
+
+      // ── keyboard ───────────────────────────────────────────────────────
+
+      let capturingKey = null;
+
+      function keyCap(code) {
+        if (code.startsWith("Key")) return code.slice(3);
+        if (code.startsWith("Digit")) return code.slice(5);
+        return { ArrowUp: "\u2191", ArrowDown: "\u2193", ArrowLeft: "\u2190", ArrowRight: "\u2192" }[code] ?? code;
+      }
+
+      window.addEventListener("keydown", (event) => {
+        if (capturingKey) {
+          event.preventDefault();
+          if (event.code !== "Escape" && !RESERVED_KEYS.has(event.code)) {
+            state.bindings[capturingKey.joint][capturingKey.slot] = event.code;
+            sendProfile();
+          }
+          capturingKey = null;
+          renderJoints();
+          return;
+        }
+        if (event.code === "Space" && !event.repeat) {
+          event.preventDefault();
+          setEngaged(!state.engaged);
+          return;
+        }
+        state.keys[event.code] = true;
+      });
+      window.addEventListener("keyup", (event) => {
+        state.keys[event.code] = false;
+      });
+      window.addEventListener("blur", () => {
+        state.keys = {};
+        setEngaged(false);
+      });
+
+      // ── joint map ──────────────────────────────────────────────────────
+
+      const jointsRoot = $("joints");
+
+      function renderJoints() {
+        jointsRoot.replaceChildren();
+        for (const joint of BOOTSTRAP.joints) {
+          jointsRoot.appendChild(renderJoint(joint));
+        }
+      }
+
+      function renderJoint(joint) {
+        const binding = state.bindings[joint];
+        const [name, negative, positive] = JOINT_LABELS[joint] ?? [joint, "negative", "positive"];
+        const limits = BOOTSTRAP.jointLimits[joint] ?? [-100, 100];
+        const unit = joint === "gripper" ? "%" : "\u00b0";
+
+        const card = document.createElement("div");
+        card.className = "joint";
+        card.dataset.joint = joint;
+
+        const head = document.createElement("div");
+        head.className = "joint-head";
+        head.innerHTML =
+          `<strong>${name}</strong><span class="sub">${negative} \u2194 ${positive}</span>` +
+          `<span class="sub" data-role="readout">\u2014</span>`;
+        card.appendChild(head);
+
+        const row = document.createElement("div");
+        row.className = "row";
+
+        const select = document.createElement("select");
+        select.setAttribute("aria-label", `Input for ${name}`);
+        select.appendChild(new Option("No input", "none", false, binding.source === "none"));
+        const taken = takenChannels(joint);
+        const groups = [
+          ["On-screen joystick", BOOTSTRAP.joystickChannels.map((c) => [`joystick:${c}`, label(c), c])],
+          ["Keyboard", [["keyboard:", "Two keys \u00b7 choose your own", null]]],
+          ["Face movement", BOOTSTRAP.faceChannels.map((c) => [`face:${c}`, label(c), c])],
+        ];
+        const currentValue =
+          binding.source === "none" ? "none" : `${binding.source}:${binding.channel ?? ""}`;
+        for (const [groupName, options] of groups) {
+          if (!options.length) continue;
+          const group = document.createElement("optgroup");
+          group.label = groupName;
+          for (const [value, text, channel] of options) {
+            const busy = channel !== null && value !== currentValue && taken.has(channel);
+            const option = new Option(busy ? `${text} \u00b7 taken` : text, value, false, value === currentValue);
+            option.disabled = busy;
+            group.appendChild(option);
+          }
+          select.appendChild(group);
+        }
+        select.addEventListener("change", () => {
+          const [source, channel] = select.value === "none" ? ["none", null] : select.value.split(":");
+          Object.assign(binding, { source, channel: channel || null });
+          if (source !== "keyboard") {
+            binding.positive_key = null;
+            binding.negative_key = null;
+          }
+          sendProfile();
+          renderJoints();
+        });
+        const selectLabel = document.createElement("label");
+        selectLabel.appendChild(select);
+        row.appendChild(selectLabel);
+
+        const invert = document.createElement("button");
+        invert.textContent = "Invert";
+        invert.setAttribute("aria-pressed", String(binding.invert));
+        invert.style.borderColor = binding.invert ? "var(--accent)" : "";
+        invert.disabled = binding.source === "none";
+        invert.addEventListener("click", () => {
+          binding.invert = !binding.invert;
+          sendProfile();
+          renderJoints();
+        });
+        row.appendChild(invert);
+
+        if (binding.source === "face" && binding.channel) {
+          const calibrate = document.createElement("button");
+          const ready = state.calibrations[binding.channel]?.ready;
+          calibrate.textContent = ready ? "Recalibrate" : "Calibrate";
+          calibrate.disabled = !state.tracking;
+          calibrate.addEventListener("click", () => startCapture(binding.channel));
+          row.appendChild(calibrate);
+        }
+        card.appendChild(row);
+
+        if (binding.source === "keyboard") {
+          const keys = document.createElement("div");
+          keys.className = "keys";
+          for (const [slot, direction] of [
+            ["positive_key", positive],
+            ["negative_key", negative],
+          ]) {
+            const button = document.createElement("button");
+            button.className = "keycap";
+            const active = capturingKey?.joint === joint && capturingKey?.slot === slot;
+            button.classList.toggle("is-capturing", active);
+            button.innerHTML = active
+              ? `<kbd>press a key</kbd><small>${direction}</small>`
+              : `<kbd>${binding[slot] ? keyCap(binding[slot]) : "pick"}</kbd><small>${direction}</small>`;
+            button.addEventListener("click", () => {
+              capturingKey = active ? null : { joint, slot };
+              renderJoints();
+            });
+            keys.appendChild(button);
+          }
+          card.appendChild(keys);
+        }
+
+        const bar = document.createElement("div");
+        bar.className = "bar";
+        bar.innerHTML = "<b></b><i data-role='fill'></i>";
+        bar.dataset.low = String(limits[0]);
+        bar.dataset.high = String(limits[1]);
+        bar.dataset.unit = unit;
+        card.appendChild(bar);
+
+        const tune = document.createElement("div");
+        tune.className = "tune";
+        const controls = [
+          ["gain", "Gain", 0.5, 3.5, 0.1, (v) => `${v.toFixed(1)}\u00d7`],
+          ["deadzone", "Dead zone", 0.02, 0.4, 0.01, (v) => `${Math.round(v * 100)}%`],
+          ["smoothing", "Smoothing", 0.0, 0.95, 0.01, (v) => `${Math.round(v * 100)}%`],
+          ["speed", "Speed", 2, 120, 1, (v) => `${v.toFixed(0)} ${unit}/s`],
+        ];
+        for (const [key, text, min, max, step, format] of controls) {
+          const wrapper = document.createElement("label");
+          const output = document.createElement("output");
+          output.textContent = format(binding[key]);
+          const caption = document.createElement("span");
+          caption.append(text, output);
+          const slider = document.createElement("input");
+          Object.assign(slider, { type: "range", min, max, step, value: binding[key] });
+          slider.setAttribute("aria-label", `${text} for ${name}`);
+          slider.addEventListener("input", () => {
+            binding[key] = Number(slider.value);
+            output.textContent = format(binding[key]);
+          });
+          slider.addEventListener("change", sendProfile);
+          wrapper.append(caption, slider);
+          tune.appendChild(wrapper);
+        }
+        card.appendChild(tune);
+        return card;
+      }
+
+      function takenChannels(exceptJoint) {
+        const taken = new Set();
+        for (const [joint, binding] of Object.entries(state.bindings)) {
+          if (joint !== exceptJoint && binding.channel) taken.add(binding.channel);
+        }
+        return taken;
+      }
+
+      // ── face channels ──────────────────────────────────────────────────
+
+      const channelsRoot = $("channels");
+
+      function renderChannels() {
+        channelsRoot.replaceChildren();
+        for (const channel of BOOTSTRAP.faceChannels) {
+          const row = document.createElement("div");
+          row.className = "channel";
+          row.dataset.channel = channel;
+          const calibration = state.calibrations[channel];
+          row.innerHTML =
+            `<span class="name">${label(channel)}<br><code data-role="hint">` +
+            `${calibration?.ready ? "calibrated" : "not calibrated"}</code></span>` +
+            `<span class="bar"><b></b><i data-role="fill"></i></span>`;
+          channelsRoot.appendChild(row);
+        }
+      }
+
+      function startCapture(channel) {
+        const neutral = state.faceSignals[channel] ?? 0;
+        state.capture = { channel, neutral, min: 0, max: 0, until: performance.now() + CAPTURE_MS };
+        state.calibrations[channel] = {
+          neutral,
+          negative_range: MIN_RANGE,
+          positive_range: MIN_RANGE,
+          ready: false,
+        };
+        announce(`Calibrating ${label(channel)}. ${CHANNEL_LABELS[channel]?.[1] ?? ""}`);
+        renderJoints();
+      }
+
+      function stepCapture(now) {
+        const capture = state.capture;
+        if (!capture) return;
+        if (!state.tracking) {
+          state.capture = null;
+          announce("Calibration stopped: the camera lost your face.");
+          return;
+        }
+        const delta = (state.faceSignals[capture.channel] ?? 0) - capture.neutral;
+        capture.min = Math.min(capture.min, delta);
+        capture.max = Math.max(capture.max, delta);
+        if (now < capture.until) return;
+
+        state.calibrations[capture.channel] = {
+          neutral: capture.neutral,
+          negative_range: Math.max(Math.abs(capture.min), MIN_RANGE),
+          positive_range: Math.max(capture.max, MIN_RANGE),
+          ready: true,
+        };
+        state.capture = null;
+        sendProfile();
+        renderChannels();
+        renderJoints();
+        announce(`${label(capture.channel)} calibrated.`);
+      }
+
+      let landmarker = null;
+      const video = $("video");
+
+      $("camera").addEventListener("click", async () => {
+        const button = $("camera");
+        button.disabled = true;
+        button.textContent = "Starting\u2026";
+        try {
+          const { FaceLandmarker, FilesetResolver } = await import(
+            `${BOOTSTRAP.mediapipeBaseUrl}/vision_bundle.mjs`
+          );
+          const vision = await FilesetResolver.forVisionTasks(`${BOOTSTRAP.mediapipeBaseUrl}/wasm`);
+          landmarker = await FaceLandmarker.createFromOptions(vision, {
+            baseOptions: { modelAssetPath: BOOTSTRAP.faceLandmarkerUrl },
+            runningMode: "VIDEO",
+            numFaces: 1,
+            outputFaceBlendshapes: true,
+          });
+          video.srcObject = await navigator.mediaDevices.getUserMedia({
+            video: { width: 640, height: 480 },
+          });
+          video.hidden = false;
+          await video.play();
+          button.textContent = "Camera on";
+          $("camera-note").textContent = "Video stays in this tab; only the five channel values are sent.";
+        } catch (error) {
+          button.disabled = false;
+          button.textContent = "Start camera";
+          $("camera-note").textContent = `Camera unavailable: ${error.message}`;
+          setDot("face", "bad", "camera failed");
+        }
+      });
+
+      function readFaceSignals(timestamp) {
+        if (!landmarker || video.readyState < 2) return;
+        const result = landmarker.detectForVideo(video, timestamp);
+        const shapes = result.faceBlendshapes?.[0]?.categories;
+        if (!shapes) {
+          state.tracking = false;
+          setDot("face", "warn", "face not found");
+          return;
+        }
+        const score = Object.fromEntries(shapes.map((c) => [c.categoryName, c.score]));
+        const at = (name) => score[name] ?? 0;
+        state.faceSignals = {
+          "face.brow_vertical":
+            (at("browInnerUp") + at("browOuterUpLeft") + at("browOuterUpRight")) / 3 -
+            (at("browDownLeft") + at("browDownRight")) / 2,
+          "face.mouth_open": at("jawOpen") - at("mouthClose"),
+          "face.lip_lateral": at("mouthRight") - at("mouthLeft"),
+          "face.mouth_shape":
+            (at("mouthSmileLeft") + at("mouthSmileRight")) / 2 - at("mouthPucker"),
+          "face.eye_wink": at("eyeBlinkRight") - at("eyeBlinkLeft"),
+        };
+        state.tracking = true;
+        setDot("face", "ok", "tracking");
+      }
+
+      // ── readouts ───────────────────────────────────────────────────────
+
+      function fill(bar, fraction, negative) {
+        const element = bar.querySelector("[data-role='fill']");
+        const width = Math.abs(clamp(fraction, -1, 1)) * 50;
+        element.style.width = `${width}%`;
+        element.style.left = negative ? `${50 - width}%` : "50%";
+      }
+
+      function renderState(message) {
+        state.armed = message.armed;
+        $("arm-banner").hidden = message.armed;
+        for (const card of jointsRoot.children) {
+          const joint = card.dataset.joint;
+          const position = message.pose?.[joint];
+          if (position === undefined) continue;
+          const bar = card.querySelector(".bar");
+          const low = Number(bar.dataset.low);
+          const high = Number(bar.dataset.high);
+          const centre = (low + high) / 2;
+          const span = (high - low) / 2 || 1;
+          const offset = (position - centre) / span;
+          fill(bar, offset, offset < 0);
+          card.querySelector("[data-role='readout']").textContent =
+            `${signed(position)}${bar.dataset.unit}${message.atLimit?.[joint] ? " \u00b7 at limit" : ""}`;
+          card.classList.toggle("is-live", Math.abs(message.velocity?.[joint] ?? 0) > 0.01);
+        }
+        $("pose").innerHTML = Object.entries(message.pose ?? {})
+          .map(
+            ([joint, value]) =>
+              `<div class="channel"><span class="name">${JOINT_LABELS[joint]?.[0] ?? joint}</span>` +
+              `<code>${signed(value, 2)}</code></div>`,
+          )
+          .join("");
+      }
+
+      // ── loop ───────────────────────────────────────────────────────────
+
+      let lastSend = 0;
+
+      function tick(timestamp) {
+        requestAnimationFrame(tick);
+        readFaceSignals(timestamp);
+        stepCapture(timestamp);
+
+        for (const channel of BOOTSTRAP.faceChannels) {
+          const row = channelsRoot.querySelector(`[data-channel='${channel}']`);
+          if (!row) continue;
+          const calibration = state.calibrations[channel];
+          const raw = state.faceSignals[channel] ?? 0;
+          const delta = raw - (calibration?.neutral ?? 0);
+          const span =
+            (delta < 0 ? calibration?.negative_range : calibration?.positive_range) || 1;
+          const normalized = clamp(delta / span, -1, 1);
+          fill(row.querySelector(".bar"), normalized, normalized < 0);
+          if (state.capture?.channel === channel) {
+            row.querySelector("[data-role='hint']").textContent =
+              `capturing \u00b7 ${((state.capture.until - timestamp) / 1000).toFixed(1)}s`;
+          }
+        }
+
+        if (timestamp - lastSend < 1000 / SEND_HZ) return;
+        lastSend = timestamp;
+        send({
+          type: "input",
+          channels: {
+            ...state.faceSignals,
+            "pad_a.x": state.pads.pad_a.x,
+            "pad_a.y": state.pads.pad_a.y,
+            "pad_b.x": state.pads.pad_b.x,
+            "pad_b.y": state.pads.pad_b.y,
+          },
+          keys: state.keys,
+          engaged: state.engaged,
+          tracking: state.tracking,
+        });
+      }
+
+      $("profile-name").textContent = `Profile: ${BOOTSTRAP.robotId}`;
+      if (!BOOTSTRAP.faceTracking) $("face-section").hidden = true;
+      renderJoints();
+      renderChannels();
+      connect();
+      requestAnimationFrame(tick);
+    </script>
+  </body>
+</html>

--- a/src/lerobot/teleoperators/accessible_teleop/assets/index.html
+++ b/src/lerobot/teleoperators/accessible_teleop/assets/index.html
@@ -190,6 +190,10 @@ limitations under the License.
         margin-left: auto;
         font-variant-numeric: tabular-nums;
       }
+      .warn-text {
+        color: var(--warn);
+        margin: 8px 0 0;
+      }
       .row {
         display: flex;
         gap: 10px;
@@ -252,6 +256,52 @@ limitations under the License.
         grid-template-columns: 1fr 1fr;
         gap: 14px;
       }
+      .pads:has(> [hidden]) {
+        grid-template-columns: 1fr;
+      }
+      #scene-wrap {
+        position: relative;
+        overflow: hidden;
+        border: 1px solid var(--line);
+        border-radius: 12px;
+        background: #000;
+      }
+      #scene {
+        display: block;
+        width: 100%;
+        aspect-ratio: 16 / 9;
+        object-fit: contain;
+        background: #000;
+      }
+      #scene-wrap:fullscreen #scene {
+        width: 100vw;
+        height: 100vh;
+        aspect-ratio: auto;
+      }
+      #scene-overlay {
+        display: none;
+      }
+      /* The overlay only earns its space in fullscreen, where the rest of the page is gone
+         and the operator still needs the clutch state and their joysticks. */
+      #scene-wrap:fullscreen #scene-overlay {
+        position: absolute;
+        inset: auto 0 0 0;
+        display: flex;
+        gap: 32px;
+        align-items: flex-end;
+        justify-content: space-between;
+        padding: 24px;
+        background: linear-gradient(transparent, rgba(0, 0, 0, 0.8));
+      }
+      #scene-wrap:fullscreen .pads {
+        width: 340px;
+      }
+      #scene-status {
+        font-size: 18px;
+      }
+      #scene-status.is-live {
+        color: var(--live);
+      }
       .pad {
         position: relative;
         aspect-ratio: 1;
@@ -259,7 +309,24 @@ limitations under the License.
         border-radius: 12px;
         background: radial-gradient(circle at center, #141a21, #0e1319);
         touch-action: none;
-        cursor: crosshair;
+        cursor: grab;
+      }
+      /* One bound axis needs a track, not a square: the shape tells you which way it moves. */
+      .pad[data-axes="x"] {
+        aspect-ratio: 4 / 1;
+        border-radius: 999px;
+        cursor: ew-resize;
+      }
+      .pad[data-axes="y"] {
+        aspect-ratio: 1 / 3;
+        margin: 0 auto;
+        width: 90px;
+        border-radius: 999px;
+        cursor: ns-resize;
+      }
+      .pad.is-holding {
+        cursor: grabbing;
+        border-color: var(--accent);
       }
       .pad.is-active {
         border-color: var(--accent);
@@ -280,6 +347,24 @@ limitations under the License.
         inset: 12px;
         border: 1px dashed var(--line);
         border-radius: 50%;
+      }
+      .pad[data-axes="x"] b,
+      .pad[data-axes="y"] b {
+        inset: 6px;
+        border-radius: 999px;
+      }
+      /* Marks where the finger landed, so the operator can see what they are moving from. */
+      .pad u {
+        position: absolute;
+        width: 10px;
+        height: 10px;
+        margin: -5px 0 0 -5px;
+        border-radius: 50%;
+        background: var(--muted);
+        opacity: 0;
+      }
+      .pad.is-holding u {
+        opacity: 0.7;
       }
       .keys {
         display: flex;
@@ -380,42 +465,72 @@ limitations under the License.
         <section>
           <h2>Joint and input map</h2>
           <div id="arm-banner" class="banner">
-            Nothing has been sent to the robot yet. The first time you engage control, the arm
-            moves to its start pose. Clear the workspace first.
+            This teleoperator has not been told where the arm actually is, so it is holding
+            its configured start pose. Engaging control could move the arm there. Clear the
+            workspace first.
           </div>
           <div id="joints"></div>
         </section>
       </div>
 
       <div>
-        <section>
+        <section id="scene-section">
+          <h2>Robot view</h2>
+          <div class="row" style="margin-bottom: 12px">
+            <label>
+              <select id="scene-device" aria-label="Camera for the robot view"></select>
+            </label>
+            <button id="scene-start">Start view</button>
+            <button id="scene-full" disabled>Fullscreen</button>
+          </div>
+          <div id="scene-wrap">
+            <video id="scene" playsinline muted autoplay></video>
+            <div id="scene-overlay"><div id="scene-status" class="sub"></div></div>
+          </div>
+          <p class="sub" id="scene-note" style="margin: 10px 0 0">
+            Point a camera at the workspace. In fullscreen the joysticks come with you, and
+            Space still engages control.
+          </p>
+        </section>
+
+        <section id="pads-section">
           <h2>On-screen joysticks</h2>
-          <div class="pads">
-            <div>
+          <div class="pads" id="pads">
+            <div id="pad_a_wrap">
               <div
                 class="pad"
                 id="pad_a"
                 role="application"
                 tabindex="0"
-                aria-label="Joystick A. Drag, or focus and use the arrow keys."
+                aria-label="Joystick A. Press anywhere and move from there, or focus and use the arrow keys."
               >
-                <b></b><i></i>
+                <b></b><u></u><i></i>
               </div>
               <div class="sub" style="margin-top: 6px">Pad A</div>
             </div>
-            <div>
+            <div id="pad_b_wrap">
               <div
                 class="pad"
                 id="pad_b"
                 role="application"
                 tabindex="0"
-                aria-label="Joystick B. Drag, or focus and use the arrow keys."
+                aria-label="Joystick B. Press anywhere and move from there, or focus and use the arrow keys."
               >
-                <b></b><i></i>
+                <b></b><u></u><i></i>
               </div>
               <div class="sub" style="margin-top: 6px">Pad B</div>
             </div>
           </div>
+          <div class="tune" id="pads-tune" style="margin-top: 14px">
+            <label>
+              <span>Movement needed for full speed <b id="pad-travel-value">60 px</b></span>
+              <input id="pad-travel" type="range" min="15" max="200" step="5" value="60" />
+            </label>
+          </div>
+          <p class="sub" style="margin: 10px 0 0">
+            Press anywhere on the pad and move from that point; wherever you land becomes the
+            centre, so nothing jumps and a short movement can reach full speed.
+          </p>
         </section>
 
         <section id="face-section">
@@ -480,7 +595,7 @@ limitations under the License.
         tracking: false,
         capture: null,
         socket: null,
-        armed: false,
+        anchored: false,
       };
 
       const $ = (id) => document.getElementById(id);
@@ -542,12 +657,22 @@ limitations under the License.
 
       // ── joysticks ──────────────────────────────────────────────────────
 
+      // How far the finger travels for full deflection, in CSS pixels. Small values suit a
+      // small comfortable range of movement, which is the whole point of this teleoperator.
+      let padTravel = Number(localStorage.getItem("padTravel")) || 60;
+
       for (const pad of ["pad_a", "pad_b"]) {
         const element = $(pad);
         const knob = element.querySelector("i");
+        const origin = element.querySelector("u");
         let pointer = null;
+        let anchor = null;
 
         const apply = (x, y) => {
+          // An axis nothing is bound to should not be able to contribute a stray command.
+          const axes = padAxes(pad);
+          if (!axes.x) x = 0;
+          if (!axes.y) y = 0;
           const length = Math.hypot(x, y);
           if (length > 1) {
             x /= length;
@@ -557,22 +682,32 @@ limitations under the License.
           knob.style.transform = `translate(${x * 38}%, ${-y * 38}%)`;
           element.classList.toggle("is-active", Math.hypot(x, y) > 0.02);
         };
+        // Relative to where the finger landed, not to the centre of the pad. Absolute
+        // mapping means touching near an edge commands full speed instantly, and forces the
+        // operator to cross the whole pad to reach it.
         const fromPointer = (event) => {
-          const rect = element.getBoundingClientRect();
+          if (!anchor) return;
           apply(
-            clamp(((event.clientX - rect.left) / rect.width) * 2 - 1, -1, 1),
-            clamp(1 - ((event.clientY - rect.top) / rect.height) * 2, -1, 1),
+            clamp((event.clientX - anchor.x) / padTravel, -1, 1),
+            clamp(-(event.clientY - anchor.y) / padTravel, -1, 1),
           );
         };
         const release = () => {
           pointer = null;
+          anchor = null;
+          element.classList.remove("is-holding");
           apply(0, 0);
         };
 
         element.addEventListener("pointerdown", (event) => {
           pointer = event.pointerId;
+          anchor = { x: event.clientX, y: event.clientY };
           element.setPointerCapture(event.pointerId);
-          fromPointer(event);
+          element.classList.add("is-holding");
+          const rect = element.getBoundingClientRect();
+          origin.style.left = `${event.clientX - rect.left}px`;
+          origin.style.top = `${event.clientY - rect.top}px`;
+          apply(0, 0);
         });
         element.addEventListener("pointermove", (event) => {
           if (pointer === event.pointerId) fromPointer(event);
@@ -599,6 +734,16 @@ limitations under the License.
           apply(0, 0);
         });
       }
+
+      const padTravelInput = $("pad-travel");
+      padTravelInput.value = String(padTravel);
+      const showPadTravel = () => ($("pad-travel-value").textContent = `${padTravel} px`);
+      showPadTravel();
+      padTravelInput.addEventListener("input", () => {
+        padTravel = Number(padTravelInput.value);
+        localStorage.setItem("padTravel", String(padTravel));
+        showPadTravel();
+      });
 
       // ── keyboard ───────────────────────────────────────────────────────
 
@@ -635,6 +780,13 @@ limitations under the License.
         state.keys = {};
         setEngaged(false);
       });
+      document.addEventListener("visibilitychange", () => {
+        // A hidden tab stops running its loop, so it must not walk away still engaged.
+        if (document.hidden) {
+          state.keys = {};
+          setEngaged(false);
+        }
+      });
 
       // ── joint map ──────────────────────────────────────────────────────
 
@@ -645,6 +797,30 @@ limitations under the License.
         for (const joint of BOOTSTRAP.joints) {
           jointsRoot.appendChild(renderJoint(joint));
         }
+        syncPadVisibility();
+      }
+
+      /** Which axes of a pad any joint is actually bound to. */
+      function padAxes(pad) {
+        const bound = (axis) =>
+          Object.values(state.bindings).some(
+            (binding) => binding.source === "joystick" && binding.channel === `${pad}.${axis}`,
+          );
+        return { x: bound("x"), y: bound("y") };
+      }
+
+      /** Show a joystick only once a joint is bound to it; an unused pad is just clutter. */
+      function syncPadVisibility() {
+        let anyVisible = false;
+        for (const pad of ["pad_a", "pad_b"]) {
+          const axes = padAxes(pad);
+          const used = axes.x || axes.y;
+          $(`${pad}_wrap`).hidden = !used;
+          // A pad with one bound axis is drawn as a track along that axis.
+          $(pad).dataset.axes = axes.x && axes.y ? "xy" : axes.x ? "x" : "y";
+          anyVisible ||= used;
+        }
+        $("pads-section").hidden = !anyVisible;
       }
 
       function renderJoint(joint) {
@@ -719,12 +895,22 @@ limitations under the License.
         if (binding.source === "face" && binding.channel) {
           const calibrate = document.createElement("button");
           const ready = state.calibrations[binding.channel]?.ready;
+          calibrate.dataset.role = "calibrate";
           calibrate.textContent = ready ? "Recalibrate" : "Calibrate";
-          calibrate.disabled = !state.tracking;
           calibrate.addEventListener("click", () => startCapture(binding.channel));
           row.appendChild(calibrate);
         }
         card.appendChild(row);
+
+        if (binding.source === "face" && binding.channel && !state.calibrations[binding.channel]?.ready) {
+          // Silence here is the worst outcome: the joint looks bound but cannot move.
+          const warning = document.createElement("p");
+          warning.className = "sub warn-text";
+          warning.dataset.role = "face-warning";
+          card.appendChild(warning);
+        }
+
+        syncTrackingControls(card);
 
         if (binding.source === "keyboard") {
           const keys = document.createElement("div");
@@ -813,6 +999,36 @@ limitations under the License.
         }
       }
 
+      /**
+       * Reflect the current tracking state in the joint cards, in place.
+       *
+       * Whether a face channel can be calibrated depends on the camera, which starts long
+       * after the cards are built and drops out whenever the face leaves frame. Rebuilding
+       * the cards on every flip would throw away focus and interrupt whatever the operator
+       * is doing, so the few affected controls are updated directly instead.
+       */
+      function syncTrackingControls(root) {
+        for (const card of root ? [root] : jointsRoot.children) {
+          const calibrate = card.querySelector("[data-role='calibrate']");
+          if (calibrate) {
+            calibrate.disabled = !state.tracking;
+            calibrate.title = state.tracking ? "" : "Start the camera first";
+          }
+          const warning = card.querySelector("[data-role='face-warning']");
+          if (warning) {
+            warning.textContent = state.tracking
+              ? "This joint stays still until you calibrate the channel."
+              : "This joint stays still until you start the camera and calibrate the channel.";
+          }
+        }
+      }
+
+      function setTracking(next) {
+        if (state.tracking === next) return;
+        state.tracking = next;
+        syncTrackingControls();
+      }
+
       function startCapture(channel) {
         const neutral = state.faceSignals[channel] ?? 0;
         state.capture = { channel, neutral, min: 0, max: 0, until: performance.now() + CAPTURE_MS };
@@ -890,7 +1106,7 @@ limitations under the License.
         const result = landmarker.detectForVideo(video, timestamp);
         const shapes = result.faceBlendshapes?.[0]?.categories;
         if (!shapes) {
-          state.tracking = false;
+          setTracking(false);
           setDot("face", "warn", "face not found");
           return;
         }
@@ -906,9 +1122,82 @@ limitations under the License.
             (at("mouthSmileLeft") + at("mouthSmileRight")) / 2 - at("mouthPucker"),
           "face.eye_wink": at("eyeBlinkRight") - at("eyeBlinkLeft"),
         };
-        state.tracking = true;
+        setTracking(true);
         setDot("face", "ok", "tracking");
       }
+
+      // ── robot view ─────────────────────────────────────────────────────
+
+      // A camera watching the workspace is served straight to the page by the browser rather
+      // than relayed through Python: no extra latency, and no video on the control socket.
+
+      const scene = $("scene");
+      const sceneWrap = $("scene-wrap");
+      const sceneDevice = $("scene-device");
+      let sceneStream = null;
+
+      async function listSceneCameras() {
+        const devices = await navigator.mediaDevices.enumerateDevices();
+        const cameras = devices.filter((device) => device.kind === "videoinput");
+        const chosen = sceneDevice.value;
+        sceneDevice.replaceChildren();
+        for (const [index, camera] of cameras.entries()) {
+          // Labels stay empty until the user has granted camera access once.
+          const name = camera.label || `Camera ${index + 1}`;
+          sceneDevice.appendChild(new Option(name, camera.deviceId, false, camera.deviceId === chosen));
+        }
+        if (!cameras.length) sceneDevice.appendChild(new Option("No camera found", ""));
+      }
+
+      async function startScene() {
+        const deviceId = sceneDevice.value;
+        stopScene();
+        sceneStream = await navigator.mediaDevices.getUserMedia({
+          video: deviceId ? { deviceId: { exact: deviceId } } : true,
+        });
+        scene.srcObject = sceneStream;
+        await scene.play();
+        $("scene-full").disabled = false;
+        $("scene-start").textContent = "Restart view";
+        await listSceneCameras();
+      }
+
+      function stopScene() {
+        for (const track of sceneStream?.getTracks() ?? []) track.stop();
+        sceneStream = null;
+      }
+
+      $("scene-start").addEventListener("click", async () => {
+        $("scene-note").textContent = "Starting the camera\u2026";
+        try {
+          await startScene();
+          $("scene-note").textContent =
+            "In fullscreen the joysticks come with you, and Space still engages control.";
+        } catch (error) {
+          $("scene-note").textContent = `Camera unavailable: ${error.message}`;
+        }
+      });
+      sceneDevice.addEventListener("change", () => {
+        if (sceneStream) startScene().catch(() => {});
+      });
+      $("scene-full").addEventListener("click", () => {
+        if (document.fullscreenElement) document.exitFullscreen();
+        else sceneWrap.requestFullscreen();
+      });
+
+      // Carry the joysticks into fullscreen rather than duplicating them: moving the nodes
+      // keeps their pointer handlers and their current values intact.
+      const padsHome = $("pads");
+      document.addEventListener("fullscreenchange", () => {
+        if (document.fullscreenElement === sceneWrap) {
+          $("scene-overlay").appendChild(padsHome);
+        } else {
+          $("pads-section").appendChild(padsHome);
+        }
+        $("scene-full").textContent = document.fullscreenElement ? "Exit fullscreen" : "Fullscreen";
+      });
+
+      listSceneCameras().catch(() => {});
 
       // ── readouts ───────────────────────────────────────────────────────
 
@@ -920,8 +1209,18 @@ limitations under the License.
       }
 
       function renderState(message) {
-        state.armed = message.armed;
-        $("arm-banner").hidden = message.armed;
+        state.anchored = message.anchored;
+        $("arm-banner").hidden = message.anchored;
+        const status = $("scene-status");
+        status.classList.toggle("is-live", Boolean(message.engaged));
+        status.textContent = message.engaged
+          ? "Control is live \u00b7 Space to release"
+          : "Control released \u00b7 Space to engage";
+        if (message.clients > 1) {
+          setDot("link", "warn", `${message.clients} pages open \u00b7 close the others`);
+        } else {
+          setDot("link", "ok", "connected");
+        }
         for (const card of jointsRoot.children) {
           const joint = card.dataset.joint;
           const position = message.pose?.[joint];
@@ -933,8 +1232,11 @@ limitations under the License.
           const span = (high - low) / 2 || 1;
           const offset = (position - centre) / span;
           fill(bar, offset, offset < 0);
+          const blocked = message.blocked?.[joint] ?? 0;
+          const [, negative, positive] = JOINT_LABELS[joint] ?? [joint, "negative", "positive"];
+          const note = blocked ? ` \u00b7 at limit, cannot ${blocked > 0 ? positive : negative}` : "";
           card.querySelector("[data-role='readout']").textContent =
-            `${signed(position)}${bar.dataset.unit}${message.atLimit?.[joint] ? " \u00b7 at limit" : ""}`;
+            `${signed(position)}${bar.dataset.unit}${note}`;
           card.classList.toggle("is-live", Math.abs(message.velocity?.[joint] ?? 0) > 0.01);
         }
         $("pose").innerHTML = Object.entries(message.pose ?? {})

--- a/src/lerobot/teleoperators/accessible_teleop/config_accessible_teleop.py
+++ b/src/lerobot/teleoperators/accessible_teleop/config_accessible_teleop.py
@@ -1,0 +1,198 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+from ..config import TeleoperatorConfig
+
+
+class InputSource(StrEnum):
+    """Where a joint's motion command comes from."""
+
+    NONE = "none"
+    KEYBOARD = "keyboard"
+    JOYSTICK = "joystick"
+    FACE = "face"
+
+
+# Facial channels the browser page reports. Each is a signed difference between two
+# MediaPipe blendshapes, so a relaxed face sits near zero and the two directions of a
+# movement land on opposite signs.
+FACE_CHANNELS: tuple[str, ...] = (
+    "face.brow_vertical",
+    "face.lip_lateral",
+    "face.mouth_open",
+    "face.mouth_shape",
+    "face.eye_wink",
+)
+
+# On-screen joystick axes. Two pads give four independent axes.
+JOYSTICK_CHANNELS: tuple[str, ...] = ("pad_a.x", "pad_a.y", "pad_b.x", "pad_b.y")
+
+SO101_JOINTS: tuple[str, ...] = (
+    "shoulder_pan",
+    "shoulder_lift",
+    "elbow_flex",
+    "wrist_flex",
+    "wrist_roll",
+    "gripper",
+)
+
+
+def default_joints() -> list[str]:
+    return list(SO101_JOINTS)
+
+
+def default_joint_limits() -> dict[str, tuple[float, float]]:
+    """Conservative travel limits in the follower's normalized units.
+
+    The five arm joints are in degrees measured from the middle of their calibrated range,
+    which is what ``MotorNormMode.DEGREES`` expects; the gripper is a percentage of its
+    calibrated span.
+
+    Every SO-101 has a slightly different usable range, because the range is recorded by
+    driving each joint into its mechanical stop during calibration. Commanding past that
+    recorded range presses the joint into the stop, so the defaults sit inside the narrowest
+    range we have measured. Widen them per joint from your own calibration file, where the
+    half-range in degrees is ``(range_max - range_min) / 2 * 360 / 4095``.
+    """
+    return {
+        "shoulder_pan": (-75.0, 75.0),
+        "shoulder_lift": (-75.0, 75.0),
+        "elbow_flex": (-75.0, 75.0),
+        "wrist_flex": (-75.0, 75.0),
+        "wrist_roll": (-75.0, 75.0),
+        "gripper": (0.0, 100.0),
+    }
+
+
+def default_start_pose() -> dict[str, float]:
+    """Pose the teleoperator commands the moment the operator first engages the clutch."""
+    return {
+        "shoulder_pan": 0.0,
+        "shoulder_lift": 0.0,
+        "elbow_flex": 0.0,
+        "wrist_flex": 0.0,
+        "wrist_roll": 0.0,
+        "gripper": 50.0,
+    }
+
+
+@dataclass
+class ChannelCalibration:
+    """The comfortable range one operator can reach on one input channel.
+
+    Attributes:
+        neutral: The channel's reading when the operator is relaxed.
+        negative_range: How far below neutral the operator can comfortably reach.
+        positive_range: How far above neutral the operator can comfortably reach.
+        ready: Whether a range has actually been captured. Face channels produce no motion
+            until this is True.
+    """
+
+    neutral: float = 0.0
+    negative_range: float = 1.0
+    positive_range: float = 1.0
+    ready: bool = False
+
+
+@dataclass
+class JointBinding:
+    """How one robot joint is driven, and how firmly it responds.
+
+    Every joint is tuned separately. An operator whose eyebrows move further than their
+    lips needs different gain on each, and a joint that carries the arm's weight usually
+    wants a lower speed than the gripper.
+
+    Attributes:
+        source: Which kind of input drives this joint.
+        channel: Channel id for face and joystick sources, e.g. ``"face.mouth_open"``.
+        positive_key: ``KeyboardEvent.code`` that drives the joint positive, for keyboard
+            sources, e.g. ``"KeyF"``.
+        negative_key: ``KeyboardEvent.code`` that drives the joint negative.
+        invert: Swap the two directions.
+        gain: Multiplier applied above the dead zone. Above 1.0 the operator reaches full
+            speed without exhausting their full range of motion.
+        deadzone: Fraction of the calibrated range treated as no motion, which keeps tremor
+            and involuntary movement from reaching the robot.
+        smoothing: Weight of the previous command in the exponential moving average, from
+            0.0 for no smoothing to just under 1.0 for very heavy smoothing.
+        speed: Joint units per second at full deflection. Degrees per second for the arm
+            joints, percent per second for the gripper.
+    """
+
+    source: InputSource = InputSource.NONE
+    channel: str | None = None
+    positive_key: str | None = None
+    negative_key: str | None = None
+    invert: bool = False
+    gain: float = 1.7
+    deadzone: float = 0.12
+    smoothing: float = 0.72
+    speed: float = 30.0
+
+
+def default_bindings() -> dict[str, JointBinding]:
+    """No joint moves until the operator binds it, in the page or in the config.
+
+    Binding every joint by default would hand a new operator six live axes at once, and the
+    whole point of this teleoperator is that the right mapping is personal.
+    """
+    return {joint: JointBinding() for joint in SO101_JOINTS}
+
+
+@TeleoperatorConfig.register_subclass("accessible_teleop")
+@dataclass
+class AccessibleTeleopConfig(TeleoperatorConfig):
+    """Configuration for the browser-driven accessible teleoperator.
+
+    Attributes:
+        joints: Robot joints this teleoperator commands, in the order shown in the page.
+        bindings: Per-joint input binding and tuning.
+        joint_limits: Inclusive travel limits per joint, in the follower's normalized units.
+        start_pose: Pose commanded when the operator first engages the clutch.
+        host: Interface the control page is served on. Leave on loopback unless you have
+            arranged TLS: browsers only grant camera access to secure contexts, and
+            ``localhost`` counts as one while a bare LAN address does not.
+        web_port: TCP port for the control page and its WebSocket.
+        open_browser: Open the control page automatically on connect.
+        connect_timeout_s: How long ``connect`` waits for the page to attach.
+        input_timeout_s: If no input frame arrives within this window the teleoperator stops
+            commanding motion, so a closed tab or a dead Wi-Fi link cannot leave the robot
+            travelling.
+        max_step_s: Largest time step the integrator will honour, which bounds how far a
+            joint can move in a single control cycle.
+        face_tracking: Serve the face-tracking channels. Turning this off leaves the
+            joysticks and keyboard, and avoids loading MediaPipe entirely.
+        mediapipe_base_url: Where the page loads the MediaPipe tasks-vision bundle and its
+            WASM runtime from. Point this at a local mirror to work offline.
+        face_landmarker_url: Where the page loads the face landmarker model from.
+    """
+
+    joints: list[str] = field(default_factory=default_joints)
+    bindings: dict[str, JointBinding] = field(default_factory=default_bindings)
+    joint_limits: dict[str, tuple[float, float]] = field(default_factory=default_joint_limits)
+    start_pose: dict[str, float] = field(default_factory=default_start_pose)
+
+    host: str = "127.0.0.1"
+    web_port: int = 8777
+    open_browser: bool = True
+    connect_timeout_s: float = 180.0
+    input_timeout_s: float = 0.5
+    max_step_s: float = 0.06
+
+    face_tracking: bool = True
+    mediapipe_base_url: str = "https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.35"
+    face_landmarker_url: str = "https://storage.googleapis.com/mediapipe-models/face_landmarker/face_landmarker/float16/1/face_landmarker.task"

--- a/src/lerobot/teleoperators/accessible_teleop/config_accessible_teleop.py
+++ b/src/lerobot/teleoperators/accessible_teleop/config_accessible_teleop.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from enum import StrEnum
+from typing import Any
 
 from ..config import TeleoperatorConfig
 
@@ -142,6 +143,46 @@ class JointBinding:
     deadzone: float = 0.12
     smoothing: float = 0.72
     speed: float = 30.0
+
+
+def binding_to_dict(binding: JointBinding) -> dict[str, Any]:
+    """Convert a binding to JSON-safe primitives, for the page and the saved profile."""
+    payload = asdict(binding)
+    payload["source"] = binding.source.value
+    return payload
+
+
+def binding_from_dict(raw: dict[str, Any]) -> JointBinding:
+    """Rebuild a binding from JSON, falling back to defaults on anything unusable.
+
+    The two sources of these dicts are a browser and a file the operator may have edited by
+    hand, so neither is trusted. An unrecognised source leaves the joint unbound rather than
+    raising, which loses one binding instead of the whole profile.
+    """
+    defaults = JointBinding()
+    try:
+        source = InputSource(raw.get("source", InputSource.NONE.value))
+    except ValueError:
+        source = InputSource.NONE
+
+    def number(key: str, fallback: float) -> float:
+        value = raw.get(key, fallback)
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return fallback
+
+    return JointBinding(
+        source=source,
+        channel=raw.get("channel") or None,
+        positive_key=raw.get("positive_key") or None,
+        negative_key=raw.get("negative_key") or None,
+        invert=bool(raw.get("invert", False)),
+        gain=number("gain", defaults.gain),
+        deadzone=number("deadzone", defaults.deadzone),
+        smoothing=number("smoothing", defaults.smoothing),
+        speed=number("speed", defaults.speed),
+    )
 
 
 def default_bindings() -> dict[str, JointBinding]:

--- a/src/lerobot/teleoperators/accessible_teleop/control.py
+++ b/src/lerobot/teleoperators/accessible_teleop/control.py
@@ -1,0 +1,248 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Input conditioning and joint integration for the accessible teleoperator.
+
+This module is deliberately free of I/O and of third-party dependencies so that the
+behaviour an operator feels through the robot can be unit tested without a browser,
+a camera, or a motor bus.
+
+The pipeline for one joint is::
+
+    raw channel value
+      -> per-channel calibration (neutral, asymmetric comfortable range) -> [-1, 1]
+      -> dead zone + gain curve                                          -> [-1, 1]
+      -> exponential moving average                                      -> [-1, 1]
+      -> multiply by the joint's maximum speed                           -> units/s
+      -> integrate over a clamped time step and clamp to joint limits    -> units
+"""
+
+from dataclasses import dataclass, field
+
+from .config_accessible_teleop import (
+    ChannelCalibration,
+    InputSource,
+    JointBinding,
+)
+
+# Face channels rise and fall slowly compared with the control loop, so a small floor on
+# the calibrated range keeps a nearly motionless operator from producing full-scale output.
+MIN_CALIBRATED_RANGE = 1e-3
+
+# Above the dead zone the response is slightly expansive, which buys fine resolution near
+# neutral without giving up the top of the range.
+RESPONSE_EXPONENT = 1.35
+
+# Below this the smoothed axis is snapped to zero, so releasing an input actually stops the
+# joint instead of leaving it creeping on the tail of the exponential decay.
+AXIS_EPSILON = 1e-3
+
+
+def clamp(value: float, low: float, high: float) -> float:
+    return min(high, max(low, value))
+
+
+def normalize_channel(value: float, calibration: ChannelCalibration) -> float:
+    """Map a raw channel reading onto [-1, 1] using its calibrated comfortable range.
+
+    The negative and positive sides are scaled independently. Most people cannot move a
+    facial feature as far in one direction as the other, and forcing a symmetric range
+    would either waste the larger side or make the smaller side unreachable.
+    """
+    delta = value - calibration.neutral
+    span = calibration.negative_range if delta < 0 else calibration.positive_range
+    return clamp(delta / max(span, MIN_CALIBRATED_RANGE), -1.0, 1.0)
+
+
+def shape_axis(value: float, deadzone: float, gain: float) -> float:
+    """Apply the dead zone and gain curve to a normalized axis."""
+    magnitude = abs(value)
+    if magnitude <= deadzone:
+        return 0.0
+    normalized = clamp((magnitude - deadzone) / max(1.0 - deadzone, MIN_CALIBRATED_RANGE), 0.0, 1.0)
+    shaped = clamp(normalized**RESPONSE_EXPONENT * gain, 0.0, 1.0)
+    return shaped if value > 0 else -shaped
+
+
+@dataclass
+class InputFrame:
+    """One sample of everything the operator's input surface is reporting.
+
+    Attributes:
+        channels: Raw analog readings keyed by channel id, e.g. ``"face.mouth_open"`` or
+            ``"pad_a.y"``. Face channels are uncalibrated; joystick axes are already in
+            [-1, 1].
+        keys: Currently held keys, keyed by browser ``KeyboardEvent.code``.
+        engaged: Whether the operator has the clutch engaged. A frame that is not engaged
+            produces no motion.
+        tracking: Whether the camera is currently tracking a face. When this is False every
+            face-driven joint stops, but keyboard and joystick joints keep working.
+    """
+
+    channels: dict[str, float] = field(default_factory=dict)
+    keys: dict[str, bool] = field(default_factory=dict)
+    engaged: bool = False
+    tracking: bool = False
+
+
+class JointController:
+    """Turns operator input frames into absolute joint targets.
+
+    The controller owns the commanded pose. It integrates velocity rather than mapping input
+    position directly onto joint angle, because the operator's usable range of motion is far
+    smaller than the robot's and a direct map would make most of the workspace unreachable.
+    """
+
+    def __init__(
+        self,
+        joints: list[str],
+        bindings: dict[str, JointBinding],
+        joint_limits: dict[str, tuple[float, float]],
+        start_pose: dict[str, float],
+        calibrations: dict[str, ChannelCalibration] | None = None,
+        max_step_s: float = 0.06,
+    ):
+        self.joints = list(joints)
+        self.bindings = bindings
+        self.joint_limits = joint_limits
+        self.start_pose = start_pose
+        self.calibrations = calibrations if calibrations is not None else {}
+        self.max_step_s = max_step_s
+
+        self._pose: dict[str, float] = {}
+        self._smoothed: dict[str, float] = {}
+        self.reset()
+
+    @property
+    def pose(self) -> dict[str, float]:
+        return dict(self._pose)
+
+    @property
+    def velocity(self) -> dict[str, float]:
+        """Last commanded velocity per joint, in joint units per second."""
+        return {
+            joint: self._smoothed[joint] * self.bindings[joint].speed if joint in self.bindings else 0.0
+            for joint in self.joints
+        }
+
+    def reset(self, pose: dict[str, float] | None = None) -> None:
+        """Re-anchor the commanded pose and clear the smoothing state.
+
+        Args:
+            pose: Measured joint positions to anchor on, taken as given. A robot parked
+                outside the configured limits is a fact, not an error, and clamping it here
+                would turn re-anchoring into a movement command. Missing joints, and the
+                configured start pose, are clamped because those are values a human typed.
+        """
+        if pose is None:
+            self._pose = {
+                joint: self._clamp_to_limits(joint, self.start_pose.get(joint, 0.0)) for joint in self.joints
+            }
+        else:
+            self._pose = {
+                joint: pose[joint]
+                if joint in pose
+                else self._clamp_to_limits(joint, self.start_pose.get(joint, 0.0))
+                for joint in self.joints
+            }
+        self._smoothed = dict.fromkeys(self.joints, 0.0)
+
+    def axis_for_joint(self, joint: str, frame: InputFrame) -> float:
+        """Resolve a joint's binding against an input frame, returning a value in [-1, 1]."""
+        binding = self.bindings.get(joint)
+        if binding is None or binding.source is InputSource.NONE:
+            return 0.0
+
+        if binding.source is InputSource.KEYBOARD:
+            # Keys are all-or-nothing, so the dead zone and gain curve have nothing to act on.
+            value = 0.0
+            if binding.positive_key and frame.keys.get(binding.positive_key):
+                value += 1.0
+            if binding.negative_key and frame.keys.get(binding.negative_key):
+                value -= 1.0
+            value = clamp(value, -1.0, 1.0)
+        elif binding.source is InputSource.JOYSTICK:
+            if not binding.channel:
+                return 0.0
+            value = shape_axis(
+                clamp(frame.channels.get(binding.channel, 0.0), -1.0, 1.0),
+                binding.deadzone,
+                binding.gain,
+            )
+        elif binding.source is InputSource.FACE:
+            if not binding.channel:
+                return 0.0
+            # An uncalibrated channel has no meaningful neutral, so treating its raw value as
+            # a command would move the robot the instant a face appears.
+            calibration = self.calibrations.get(binding.channel)
+            if not frame.tracking or calibration is None or not calibration.ready:
+                return 0.0
+            value = shape_axis(
+                normalize_channel(frame.channels.get(binding.channel, 0.0), calibration),
+                binding.deadzone,
+                binding.gain,
+            )
+        else:
+            return 0.0
+
+        return -value if binding.invert else value
+
+    def step(self, frame: InputFrame, dt_s: float) -> dict[str, float]:
+        """Advance the commanded pose by one control step.
+
+        Args:
+            frame: The latest input sample.
+            dt_s: Elapsed time since the previous step. Clamped to ``max_step_s`` so that a
+                stalled loop, a backgrounded browser tab, or a debugger breakpoint cannot
+                turn into one large jump.
+
+        Returns:
+            The commanded joint positions, in the robot's normalized units.
+        """
+        dt_s = clamp(dt_s, 0.0, self.max_step_s)
+
+        for joint in self.joints:
+            binding = self.bindings.get(joint)
+            if binding is None:
+                continue
+
+            target = self.axis_for_joint(joint, frame) if frame.engaged else 0.0
+            smoothing = clamp(binding.smoothing, 0.0, 0.99)
+            smoothed = self._smoothed[joint] * smoothing + target * (1.0 - smoothing)
+            if abs(smoothed) < AXIS_EPSILON:
+                smoothed = 0.0
+            self._smoothed[joint] = smoothed
+
+            if smoothed:
+                current = self._pose[joint]
+                self._pose[joint] = self._limit_travel(
+                    joint, current, current + smoothed * binding.speed * dt_s
+                )
+
+        return self.pose
+
+    def _clamp_to_limits(self, joint: str, value: float) -> float:
+        low, high = self.joint_limits.get(joint, (-float("inf"), float("inf")))
+        return clamp(value, low, high)
+
+    def _limit_travel(self, joint: str, current: float, target: float) -> float:
+        """Stop a joint leaving its limits without ever forcing it back inside them.
+
+        A joint that starts beyond a limit, because the arm was parked at a mechanical stop
+        or the limits were tightened between sessions, can still be driven back into range;
+        it just cannot travel further out. Clamping outright would command a jump the
+        operator never asked for.
+        """
+        low, high = self.joint_limits.get(joint, (-float("inf"), float("inf")))
+        return clamp(target, min(low, current), max(high, current))

--- a/src/lerobot/teleoperators/accessible_teleop/web_bridge.py
+++ b/src/lerobot/teleoperators/accessible_teleop/web_bridge.py
@@ -1,0 +1,317 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Local web server carrying operator input from a browser page to the teleoperator.
+
+The page is served on loopback and talks over a WebSocket on the same port. The browser is
+only an input surface: it reports raw channel readings and lets the operator edit their
+mapping, while every decision that reaches a motor is taken in :mod:`.control`.
+"""
+
+import json
+import logging
+import threading
+import time
+from collections.abc import Callable
+from dataclasses import asdict
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from lerobot.utils.import_utils import _websockets_available, require_package
+
+from .config_accessible_teleop import (
+    FACE_CHANNELS,
+    JOYSTICK_CHANNELS,
+    AccessibleTeleopConfig,
+    ChannelCalibration,
+    InputSource,
+    JointBinding,
+)
+from .control import InputFrame
+
+if TYPE_CHECKING or _websockets_available:
+    from websockets.datastructures import Headers
+    from websockets.http11 import Response
+    from websockets.sync.server import Server, ServerConnection, serve
+else:
+    Headers = Response = Server = ServerConnection = serve = None
+
+logger = logging.getLogger(__name__)
+
+ASSETS_DIR = Path(__file__).parent / "assets"
+
+# Fast enough that the page feels attached to the robot, slow enough that the readout does
+# not dominate the socket when the control loop is running at 60 Hz.
+STATE_BROADCAST_HZ = 20.0
+
+
+class ControlBridge:
+    """Serves the control page and holds the most recent operator input.
+
+    Everything the page sends lands in this object under a lock; the teleoperator drains it
+    from the control loop thread.
+    """
+
+    def __init__(
+        self,
+        config: AccessibleTeleopConfig,
+        bindings: dict[str, JointBinding],
+        calibrations: dict[str, ChannelCalibration],
+        on_profile_change: Callable[[], None] | None = None,
+    ):
+        require_package("websockets", extra="accessible-teleop")
+        self.config = config
+        self.bindings = bindings
+        self.calibrations = calibrations
+        self._on_profile_change = on_profile_change
+
+        self._lock = threading.Lock()
+        self._frame = InputFrame()
+        self._frame_monotonic: float | None = None
+        self._clients = 0
+        self._client_seen = threading.Event()
+
+        self._server: Server | None = None
+        self._thread: threading.Thread | None = None
+        self._state: dict[str, Any] = {}
+
+    # ── lifecycle ────────────────────────────────────────────────────────
+
+    @property
+    def is_running(self) -> bool:
+        return self._server is not None
+
+    @property
+    def bound_port(self) -> int:
+        """Port the server actually listens on, which differs from the config when it is 0."""
+        if self._server is None:
+            return self.config.web_port
+        return self._server.socket.getsockname()[1]
+
+    @property
+    def url(self) -> str:
+        return f"http://{self.config.host}:{self.bound_port}/"
+
+    @property
+    def client_count(self) -> int:
+        with self._lock:
+            return self._clients
+
+    def start(self) -> None:
+        self._server = serve(
+            self._handle_connection,
+            self.config.host,
+            self.config.web_port,
+            process_request=self._process_request,
+        )
+        self._thread = threading.Thread(
+            target=self._server.serve_forever, name="accessible-teleop-web", daemon=True
+        )
+        self._thread.start()
+        logger.info(f"Accessible teleop control page served at {self.url}")
+
+    def stop(self) -> None:
+        if self._server is not None:
+            self._server.shutdown()
+            self._server = None
+        if self._thread is not None:
+            self._thread.join(timeout=2.0)
+            self._thread = None
+
+    def wait_for_client(self, timeout_s: float) -> bool:
+        """Block until the control page attaches, or the timeout expires."""
+        return self._client_seen.wait(timeout_s)
+
+    # ── operator input ───────────────────────────────────────────────────
+
+    def read_frame(self) -> tuple[InputFrame, float | None]:
+        """Return the latest input frame and its age in seconds.
+
+        The age is ``None`` when no frame has arrived yet. A stale frame is the caller's
+        problem to act on: the bridge never invents input.
+        """
+        with self._lock:
+            frame = InputFrame(
+                channels=dict(self._frame.channels),
+                keys=dict(self._frame.keys),
+                engaged=self._frame.engaged,
+                tracking=self._frame.tracking,
+            )
+            stamped = self._frame_monotonic
+        age = None if stamped is None else time.monotonic() - stamped
+        return frame, age
+
+    def release_clutch(self) -> None:
+        """Force the clutch open, e.g. because input went stale or the loop is shutting down."""
+        with self._lock:
+            self._frame.engaged = False
+
+    def publish_state(self, state: dict[str, Any]) -> None:
+        """Hand the page the robot-facing state it should display."""
+        with self._lock:
+            self._state = state
+
+    # ── HTTP ─────────────────────────────────────────────────────────────
+
+    def _process_request(self, connection: "ServerConnection", request: Any) -> "Response | None":
+        path = request.path.split("?", 1)[0]
+        if path == "/ws":
+            return None  # let websockets perform the upgrade
+        if path == "/":
+            return self._html_response()
+        return Response(404, "Not Found", Headers({"Content-Length": "0"}), b"")
+
+    def _html_response(self) -> "Response":
+        body = (ASSETS_DIR / "index.html").read_text(encoding="utf-8")
+        body = body.replace("__LEROBOT_BOOTSTRAP__", json.dumps(self._bootstrap()))
+        payload = body.encode("utf-8")
+        headers = Headers(
+            {
+                "Content-Type": "text/html; charset=utf-8",
+                "Content-Length": str(len(payload)),
+                "Cache-Control": "no-store",
+            }
+        )
+        return Response(200, "OK", headers, payload)
+
+    def _bootstrap(self) -> dict[str, Any]:
+        with self._lock:
+            bindings = {joint: _binding_to_json(b) for joint, b in self.bindings.items()}
+            calibrations = {ch: asdict(c) for ch, c in self.calibrations.items()}
+        return {
+            "joints": list(self.config.joints),
+            "jointLimits": {j: list(v) for j, v in self.config.joint_limits.items()},
+            "faceChannels": list(FACE_CHANNELS) if self.config.face_tracking else [],
+            "joystickChannels": list(JOYSTICK_CHANNELS),
+            "bindings": bindings,
+            "calibrations": calibrations,
+            "faceTracking": self.config.face_tracking,
+            "mediapipeBaseUrl": self.config.mediapipe_base_url,
+            "faceLandmarkerUrl": self.config.face_landmarker_url,
+            "robotId": self.config.id or "unnamed",
+        }
+
+    # ── WebSocket ────────────────────────────────────────────────────────
+
+    def _handle_connection(self, connection: "ServerConnection") -> None:
+        with self._lock:
+            self._clients += 1
+        self._client_seen.set()
+        logger.info("Control page connected")
+
+        state_period = 1.0 / STATE_BROADCAST_HZ
+        next_state = 0.0
+        try:
+            while True:
+                try:
+                    message = connection.recv(timeout=state_period)
+                except TimeoutError:
+                    message = None
+                if message is not None:
+                    self._handle_message(message)
+
+                now = time.monotonic()
+                if now >= next_state:
+                    next_state = now + state_period
+                    with self._lock:
+                        state = dict(self._state)
+                    if state:
+                        connection.send(json.dumps({"type": "state", **state}))
+        except Exception as exc:  # noqa: BLE001 - a dropped page must not kill the robot loop
+            logger.debug(f"Control page connection ended: {exc}")
+        finally:
+            with self._lock:
+                self._clients -= 1
+                remaining = self._clients
+                # A page that goes away can no longer hold the clutch open.
+                if remaining == 0:
+                    self._frame.engaged = False
+            logger.info("Control page disconnected")
+
+    def _handle_message(self, message: str | bytes) -> None:
+        try:
+            payload = json.loads(message)
+        except (TypeError, ValueError):
+            logger.warning("Discarding malformed message from control page")
+            return
+
+        kind = payload.get("type")
+        if kind == "input":
+            self._apply_input(payload)
+        elif kind == "profile":
+            self._apply_profile(payload)
+        elif kind == "stop":
+            self.release_clutch()
+        else:
+            logger.debug(f"Ignoring unknown message type from control page: {kind!r}")
+
+    def _apply_input(self, payload: dict[str, Any]) -> None:
+        channels = payload.get("channels") or {}
+        keys = payload.get("keys") or {}
+        frame = InputFrame(
+            channels={str(k): float(v) for k, v in channels.items() if _is_number(v)},
+            keys={str(k): bool(v) for k, v in keys.items()},
+            engaged=bool(payload.get("engaged", False)),
+            tracking=bool(payload.get("tracking", False)),
+        )
+        with self._lock:
+            self._frame = frame
+            self._frame_monotonic = time.monotonic()
+
+    def _apply_profile(self, payload: dict[str, Any]) -> None:
+        bindings = payload.get("bindings") or {}
+        calibrations = payload.get("calibrations") or {}
+        with self._lock:
+            for joint, raw in bindings.items():
+                if joint in self.bindings:
+                    self.bindings[joint] = _binding_from_json(raw)
+            for channel, raw in calibrations.items():
+                self.calibrations[channel] = ChannelCalibration(
+                    neutral=float(raw.get("neutral", 0.0)),
+                    negative_range=float(raw.get("negative_range", 1.0)),
+                    positive_range=float(raw.get("positive_range", 1.0)),
+                    ready=bool(raw.get("ready", False)),
+                )
+        logger.info("Applied updated control profile from the page")
+        if self._on_profile_change is not None:
+            self._on_profile_change()
+
+
+def _is_number(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def _binding_to_json(binding: JointBinding) -> dict[str, Any]:
+    payload = asdict(binding)
+    payload["source"] = binding.source.value
+    return payload
+
+
+def _binding_from_json(raw: dict[str, Any]) -> JointBinding:
+    defaults = JointBinding()
+    try:
+        source = InputSource(raw.get("source", InputSource.NONE.value))
+    except ValueError:
+        source = InputSource.NONE
+    return JointBinding(
+        source=source,
+        channel=raw.get("channel") or None,
+        positive_key=raw.get("positive_key") or None,
+        negative_key=raw.get("negative_key") or None,
+        invert=bool(raw.get("invert", False)),
+        gain=float(raw.get("gain", defaults.gain)),
+        deadzone=float(raw.get("deadzone", defaults.deadzone)),
+        smoothing=float(raw.get("smoothing", defaults.smoothing)),
+        speed=float(raw.get("speed", defaults.speed)),
+    )

--- a/src/lerobot/teleoperators/accessible_teleop/web_bridge.py
+++ b/src/lerobot/teleoperators/accessible_teleop/web_bridge.py
@@ -35,8 +35,9 @@ from .config_accessible_teleop import (
     JOYSTICK_CHANNELS,
     AccessibleTeleopConfig,
     ChannelCalibration,
-    InputSource,
     JointBinding,
+    binding_from_dict,
+    binding_to_dict,
 )
 from .control import InputFrame
 
@@ -77,9 +78,10 @@ class ControlBridge:
         self._on_profile_change = on_profile_change
 
         self._lock = threading.Lock()
-        self._frame = InputFrame()
-        self._frame_monotonic: float | None = None
-        self._clients = 0
+        # Input is tracked per page rather than globally: a second page left open on another
+        # screen must not be able to overwrite the input of the page actually being driven.
+        self._frames: dict[int, tuple[InputFrame, float | None]] = {}
+        self._next_client_id = 0
         self._client_seen = threading.Event()
 
         self._server: Server | None = None
@@ -106,7 +108,7 @@ class ControlBridge:
     @property
     def client_count(self) -> int:
         with self._lock:
-            return self._clients
+            return len(self._frames)
 
     def start(self) -> None:
         self._server = serve(
@@ -136,26 +138,39 @@ class ControlBridge:
     # ── operator input ───────────────────────────────────────────────────
 
     def read_frame(self) -> tuple[InputFrame, float | None]:
-        """Return the latest input frame and its age in seconds.
+        """Return the input frame in charge of the robot, and its age in seconds.
+
+        With several pages open, the one holding its clutch closed wins; among equals the
+        freshest frame wins. Without that rule an idle second page would overwrite the
+        driving page's input sixty times a second, and the clutch could never latch.
 
         The age is ``None`` when no frame has arrived yet. A stale frame is the caller's
         problem to act on: the bridge never invents input.
         """
+        now = time.monotonic()
         with self._lock:
+            stamped = [(frame, at) for frame, at in self._frames.values() if at is not None]
+            if not stamped:
+                return InputFrame(), None
+            # A page that stopped reporting, because it was backgrounded or its tab froze,
+            # must not keep the clutch it was holding when it went quiet.
+            fresh = [entry for entry in stamped if now - entry[1] <= self.config.input_timeout_s]
+            engaged = [entry for entry in fresh if entry[0].engaged]
+            frame, at = max(engaged or fresh or stamped, key=lambda entry: entry[1])
             frame = InputFrame(
-                channels=dict(self._frame.channels),
-                keys=dict(self._frame.keys),
-                engaged=self._frame.engaged,
-                tracking=self._frame.tracking,
+                channels=dict(frame.channels),
+                keys=dict(frame.keys),
+                engaged=frame.engaged,
+                tracking=frame.tracking,
             )
-            stamped = self._frame_monotonic
-        age = None if stamped is None else time.monotonic() - stamped
-        return frame, age
+        return frame, now - at
 
     def release_clutch(self) -> None:
         """Force the clutch open, e.g. because input went stale or the loop is shutting down."""
         with self._lock:
-            self._frame.engaged = False
+            for client_id, (frame, at) in self._frames.items():
+                frame.engaged = False
+                self._frames[client_id] = (frame, at)
 
     def publish_state(self, state: dict[str, Any]) -> None:
         """Hand the page the robot-facing state it should display."""
@@ -187,7 +202,7 @@ class ControlBridge:
 
     def _bootstrap(self) -> dict[str, Any]:
         with self._lock:
-            bindings = {joint: _binding_to_json(b) for joint, b in self.bindings.items()}
+            bindings = {joint: binding_to_dict(b) for joint, b in self.bindings.items()}
             calibrations = {ch: asdict(c) for ch, c in self.calibrations.items()}
         return {
             "joints": list(self.config.joints),
@@ -206,9 +221,17 @@ class ControlBridge:
 
     def _handle_connection(self, connection: "ServerConnection") -> None:
         with self._lock:
-            self._clients += 1
+            client_id = self._next_client_id
+            self._next_client_id += 1
+            self._frames[client_id] = (InputFrame(), None)
+            client_count = len(self._frames)
         self._client_seen.set()
         logger.info("Control page connected")
+        if client_count > 1:
+            logger.warning(
+                f"{client_count} control pages are open; only the one holding its clutch "
+                "closed drives the robot."
+            )
 
         state_period = 1.0 / STATE_BROADCAST_HZ
         next_state = 0.0
@@ -219,27 +242,25 @@ class ControlBridge:
                 except TimeoutError:
                     message = None
                 if message is not None:
-                    self._handle_message(message)
+                    self._handle_message(client_id, message)
 
                 now = time.monotonic()
                 if now >= next_state:
                     next_state = now + state_period
                     with self._lock:
                         state = dict(self._state)
+                        state["clients"] = len(self._frames)
                     if state:
                         connection.send(json.dumps({"type": "state", **state}))
         except Exception as exc:  # noqa: BLE001 - a dropped page must not kill the robot loop
             logger.debug(f"Control page connection ended: {exc}")
         finally:
+            # A page that goes away takes its input, and any clutch it was holding, with it.
             with self._lock:
-                self._clients -= 1
-                remaining = self._clients
-                # A page that goes away can no longer hold the clutch open.
-                if remaining == 0:
-                    self._frame.engaged = False
+                self._frames.pop(client_id, None)
             logger.info("Control page disconnected")
 
-    def _handle_message(self, message: str | bytes) -> None:
+    def _handle_message(self, client_id: int, message: str | bytes) -> None:
         try:
             payload = json.loads(message)
         except (TypeError, ValueError):
@@ -248,7 +269,7 @@ class ControlBridge:
 
         kind = payload.get("type")
         if kind == "input":
-            self._apply_input(payload)
+            self._apply_input(client_id, payload)
         elif kind == "profile":
             self._apply_profile(payload)
         elif kind == "stop":
@@ -256,7 +277,7 @@ class ControlBridge:
         else:
             logger.debug(f"Ignoring unknown message type from control page: {kind!r}")
 
-    def _apply_input(self, payload: dict[str, Any]) -> None:
+    def _apply_input(self, client_id: int, payload: dict[str, Any]) -> None:
         channels = payload.get("channels") or {}
         keys = payload.get("keys") or {}
         frame = InputFrame(
@@ -266,8 +287,7 @@ class ControlBridge:
             tracking=bool(payload.get("tracking", False)),
         )
         with self._lock:
-            self._frame = frame
-            self._frame_monotonic = time.monotonic()
+            self._frames[client_id] = (frame, time.monotonic())
 
     def _apply_profile(self, payload: dict[str, Any]) -> None:
         bindings = payload.get("bindings") or {}
@@ -275,7 +295,7 @@ class ControlBridge:
         with self._lock:
             for joint, raw in bindings.items():
                 if joint in self.bindings:
-                    self.bindings[joint] = _binding_from_json(raw)
+                    self.bindings[joint] = binding_from_dict(raw)
             for channel, raw in calibrations.items():
                 self.calibrations[channel] = ChannelCalibration(
                     neutral=float(raw.get("neutral", 0.0)),
@@ -290,28 +310,3 @@ class ControlBridge:
 
 def _is_number(value: Any) -> bool:
     return isinstance(value, (int, float)) and not isinstance(value, bool)
-
-
-def _binding_to_json(binding: JointBinding) -> dict[str, Any]:
-    payload = asdict(binding)
-    payload["source"] = binding.source.value
-    return payload
-
-
-def _binding_from_json(raw: dict[str, Any]) -> JointBinding:
-    defaults = JointBinding()
-    try:
-        source = InputSource(raw.get("source", InputSource.NONE.value))
-    except ValueError:
-        source = InputSource.NONE
-    return JointBinding(
-        source=source,
-        channel=raw.get("channel") or None,
-        positive_key=raw.get("positive_key") or None,
-        negative_key=raw.get("negative_key") or None,
-        invert=bool(raw.get("invert", False)),
-        gain=float(raw.get("gain", defaults.gain)),
-        deadzone=float(raw.get("deadzone", defaults.deadzone)),
-        smoothing=float(raw.get("smoothing", defaults.smoothing)),
-        speed=float(raw.get("speed", defaults.speed)),
-    )

--- a/src/lerobot/teleoperators/utils.py
+++ b/src/lerobot/teleoperators/utils.py
@@ -39,6 +39,10 @@ def make_teleoperator_from_config(config: TeleoperatorConfig) -> "Teleoperator":
         from .keyboard import KeyboardTeleop
 
         return KeyboardTeleop(config)
+    elif config.type == "accessible_teleop":
+        from .accessible_teleop import AccessibleTeleop
+
+        return AccessibleTeleop(config)
     elif config.type == "koch_leader":
         from .koch_leader import KochLeader
 

--- a/src/lerobot/utils/import_utils.py
+++ b/src/lerobot/utils/import_utils.py
@@ -125,6 +125,7 @@ _pyrealsense2_available = is_package_available("pyrealsense2") or is_package_ava
 _zmq_available = is_package_available("pyzmq", import_name="zmq")
 _hebi_available = is_package_available("hebi-py", import_name="hebi")
 _teleop_available = is_package_available("teleop")
+_websockets_available = is_package_available("websockets")
 _placo_available = is_package_available("placo")
 _hidapi_available = is_package_available("hidapi", import_name="hid")
 

--- a/tests/teleoperators/test_accessible_teleop.py
+++ b/tests/teleoperators/test_accessible_teleop.py
@@ -404,10 +404,14 @@ def test_control_page_is_served_and_drives_the_robot(connected_teleop):
         thread.join(timeout=10.0)
         assert teleop.is_connected
 
-        # Nothing has been engaged, so the teleoperator claims no pose.
+        # Nothing has been engaged, so the pose is held rather than withheld: callers pass
+        # this action straight to send_action, which cannot accept an empty one.
         socket.send(json.dumps({"type": "input", "keys": {"KeyF": False}, "engaged": False}))
         _wait_for_frame(teleop)
-        assert teleop.get_action() == {}
+        idle = teleop.get_action()
+        assert set(idle) == set(teleop.action_features)
+        time.sleep(0.05)
+        assert teleop.get_action() == pytest.approx(idle)
 
         socket.send(json.dumps({"type": "input", "keys": {"KeyF": True}, "engaged": True}))
         _wait_for_frame(teleop)
@@ -450,6 +454,108 @@ def test_stale_input_stops_the_robot(connected_teleop):
         held = teleop.get_action()["shoulder_pan.pos"]
         time.sleep(0.2)
         assert teleop.get_action()["shoulder_pan.pos"] == pytest.approx(held)
+
+
+@pytestmark_ws
+def test_every_action_is_complete_enough_for_a_motor_bus(connected_teleop):
+    """An action with no entries reaches the bus as a write addressed to no motors.
+
+    `MotorsBus.sync_write` takes the control table from the first motor in the request, so an
+    empty mapping raises StopIteration deep inside the transport. Nothing between this
+    teleoperator and the bus filters that out: the default processors are the identity, and
+    `send_action` forwards whatever it is given.
+    """
+    import threading
+
+    from websockets.sync.client import connect as ws_connect
+
+    teleop = connected_teleop
+    thread = threading.Thread(target=teleop.connect, kwargs={"calibrate": False}, daemon=True)
+    thread.start()
+
+    deadline = time.monotonic() + 10.0
+    while teleop._bridge is None or not teleop._bridge.is_running:
+        assert time.monotonic() < deadline, "bridge never started"
+        time.sleep(0.02)
+
+    with ws_connect(teleop._bridge.url.replace("http://", "ws://") + "ws") as socket:
+        thread.join(timeout=10.0)
+        # Before any input at all, while idle, and while driving.
+        assert set(teleop.get_action()) == set(teleop.action_features)
+
+        socket.send(json.dumps({"type": "input", "keys": {}, "engaged": False}))
+        _wait_for_frame(teleop)
+        assert set(teleop.get_action()) == set(teleop.action_features)
+
+        socket.send(json.dumps({"type": "input", "keys": {"KeyF": True}, "engaged": True}))
+        time.sleep(0.1)
+        assert set(teleop.get_action()) == set(teleop.action_features)
+
+
+@pytestmark_ws
+def test_an_idle_second_page_cannot_override_the_page_holding_the_clutch(connected_teleop):
+    import threading
+
+    from websockets.sync.client import connect as ws_connect
+
+    teleop = connected_teleop
+    thread = threading.Thread(target=teleop.connect, kwargs={"calibrate": False}, daemon=True)
+    thread.start()
+
+    deadline = time.monotonic() + 10.0
+    while teleop._bridge is None or not teleop._bridge.is_running:
+        assert time.monotonic() < deadline, "bridge never started"
+        time.sleep(0.02)
+    ws_url = teleop._bridge.url.replace("http://", "ws://") + "ws"
+
+    with ws_connect(ws_url) as driver, ws_connect(ws_url) as bystander:
+        thread.join(timeout=10.0)
+        driver.send(json.dumps({"type": "input", "keys": {"KeyF": True}, "engaged": True}))
+        _wait_for_frame(teleop)
+        # The second page reports after the first, and would win on recency alone.
+        bystander.send(json.dumps({"type": "input", "keys": {}, "engaged": False}))
+        time.sleep(0.1)
+
+        frame, _ = teleop._bridge.read_frame()
+        assert frame.engaged, "an idle page took the clutch away from the page being driven"
+        assert frame.keys.get("KeyF")
+
+        # Once the driving page releases, the freshest frame wins again.
+        driver.send(json.dumps({"type": "input", "keys": {}, "engaged": False}))
+        time.sleep(0.1)
+        frame, _ = teleop._bridge.read_frame()
+        assert not frame.engaged
+
+
+@pytestmark_ws
+def test_a_page_that_goes_quiet_loses_the_clutch_to_a_live_page(connected_teleop):
+    import threading
+
+    from websockets.sync.client import connect as ws_connect
+
+    teleop = connected_teleop
+    teleop.config.input_timeout_s = 0.1
+    thread = threading.Thread(target=teleop.connect, kwargs={"calibrate": False}, daemon=True)
+    thread.start()
+
+    deadline = time.monotonic() + 10.0
+    while teleop._bridge is None or not teleop._bridge.is_running:
+        assert time.monotonic() < deadline, "bridge never started"
+        time.sleep(0.02)
+    ws_url = teleop._bridge.url.replace("http://", "ws://") + "ws"
+
+    with ws_connect(ws_url) as frozen, ws_connect(ws_url) as live:
+        thread.join(timeout=10.0)
+        # A backgrounded tab stops its loop while still claiming the clutch.
+        frozen.send(json.dumps({"type": "input", "keys": {"KeyF": True}, "engaged": True}))
+        _wait_for_frame(teleop)
+        time.sleep(0.2)
+
+        live.send(json.dumps({"type": "input", "keys": {}, "engaged": False}))
+        time.sleep(0.05)
+        frame, age = teleop._bridge.read_frame()
+        assert not frame.engaged, "a frozen page kept the clutch closed"
+        assert age < teleop.config.input_timeout_s
 
 
 def _wait_for_frame(teleop: AccessibleTeleop, timeout_s: float = 5.0) -> None:

--- a/tests/teleoperators/test_accessible_teleop.py
+++ b/tests/teleoperators/test_accessible_teleop.py
@@ -1,0 +1,462 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import time
+
+import pytest
+
+from lerobot.teleoperators import make_teleoperator_from_config
+from lerobot.teleoperators.accessible_teleop import (
+    AccessibleTeleop,
+    AccessibleTeleopConfig,
+    ChannelCalibration,
+    InputSource,
+    JointBinding,
+)
+from lerobot.teleoperators.accessible_teleop.control import (
+    InputFrame,
+    JointController,
+    normalize_channel,
+    shape_axis,
+)
+from lerobot.utils.errors import DeviceNotConnectedError
+from lerobot.utils.import_utils import _websockets_available
+
+JOINTS = ["shoulder_pan", "gripper"]
+LIMITS = {"shoulder_pan": (-90.0, 90.0), "gripper": (0.0, 100.0)}
+START = {"shoulder_pan": 0.0, "gripper": 50.0}
+
+
+def make_controller(bindings: dict[str, JointBinding], **kwargs) -> JointController:
+    return JointController(
+        joints=JOINTS,
+        bindings=bindings,
+        joint_limits=LIMITS,
+        start_pose=START,
+        **kwargs,
+    )
+
+
+# ── signal conditioning ──────────────────────────────────────────────────
+
+
+def test_shape_axis_suppresses_the_dead_zone():
+    assert shape_axis(0.1, deadzone=0.2, gain=1.0) == 0.0
+    assert shape_axis(-0.2, deadzone=0.2, gain=1.0) == 0.0
+    assert shape_axis(0.21, deadzone=0.2, gain=1.0) > 0.0
+
+
+def test_shape_axis_is_sign_preserving_and_bounded():
+    for value in (-1.0, -0.5, 0.5, 1.0):
+        shaped = shape_axis(value, deadzone=0.05, gain=3.0)
+        assert (shaped > 0) == (value > 0)
+        assert abs(shaped) <= 1.0
+
+
+def test_shape_axis_gain_reaches_full_output_before_full_input():
+    modest = shape_axis(0.6, deadzone=0.1, gain=1.0)
+    amplified = shape_axis(0.6, deadzone=0.1, gain=2.5)
+    assert amplified > modest
+    assert amplified == pytest.approx(1.0)
+
+
+def test_normalize_channel_scales_each_direction_independently():
+    calibration = ChannelCalibration(neutral=0.2, negative_range=0.1, positive_range=0.4, ready=True)
+    assert normalize_channel(0.2, calibration) == pytest.approx(0.0)
+    assert normalize_channel(0.6, calibration) == pytest.approx(1.0)
+    assert normalize_channel(0.1, calibration) == pytest.approx(-1.0)
+    # Beyond the captured range the value saturates rather than growing.
+    assert normalize_channel(5.0, calibration) == pytest.approx(1.0)
+
+
+# ── binding resolution ───────────────────────────────────────────────────
+
+
+def test_keyboard_binding_reads_both_directions():
+    binding = JointBinding(source=InputSource.KEYBOARD, positive_key="KeyF", negative_key="KeyG")
+    controller = make_controller({"shoulder_pan": binding, "gripper": JointBinding()})
+
+    assert controller.axis_for_joint("shoulder_pan", InputFrame(keys={"KeyF": True})) == 1.0
+    assert controller.axis_for_joint("shoulder_pan", InputFrame(keys={"KeyG": True})) == -1.0
+    # Holding both keys is a wash rather than an error.
+    assert controller.axis_for_joint("shoulder_pan", InputFrame(keys={"KeyF": True, "KeyG": True})) == 0.0
+
+
+def test_invert_swaps_direction():
+    binding = JointBinding(source=InputSource.KEYBOARD, positive_key="KeyF", negative_key="KeyG", invert=True)
+    controller = make_controller({"shoulder_pan": binding, "gripper": JointBinding()})
+    assert controller.axis_for_joint("shoulder_pan", InputFrame(keys={"KeyF": True})) == -1.0
+
+
+def test_unbound_joint_never_moves():
+    controller = make_controller({"shoulder_pan": JointBinding(), "gripper": JointBinding()})
+    frame = InputFrame(channels={"pad_a.x": 1.0}, engaged=True, tracking=True)
+    for _ in range(50):
+        controller.step(frame, 0.05)
+    assert controller.pose == START
+
+
+def test_face_binding_is_inert_until_calibrated():
+    binding = JointBinding(source=InputSource.FACE, channel="face.mouth_open", deadzone=0.0)
+    controller = make_controller({"shoulder_pan": binding, "gripper": JointBinding()})
+    frame = InputFrame(channels={"face.mouth_open": 1.0}, engaged=True, tracking=True)
+
+    assert controller.axis_for_joint("shoulder_pan", frame) == 0.0
+
+    controller.calibrations["face.mouth_open"] = ChannelCalibration(
+        neutral=0.0, negative_range=0.5, positive_range=0.5, ready=True
+    )
+    assert controller.axis_for_joint("shoulder_pan", frame) > 0.0
+
+
+def test_face_binding_stops_when_tracking_is_lost():
+    binding = JointBinding(source=InputSource.FACE, channel="face.mouth_open", deadzone=0.0)
+    controller = make_controller(
+        {"shoulder_pan": binding, "gripper": JointBinding()},
+        calibrations={
+            "face.mouth_open": ChannelCalibration(
+                neutral=0.0, negative_range=0.5, positive_range=0.5, ready=True
+            )
+        },
+    )
+    channels = {"face.mouth_open": 1.0}
+    assert controller.axis_for_joint("shoulder_pan", InputFrame(channels=channels, tracking=True)) > 0.0
+    assert controller.axis_for_joint("shoulder_pan", InputFrame(channels=channels, tracking=False)) == 0.0
+
+
+def test_losing_tracking_leaves_other_sources_working():
+    controller = make_controller(
+        {
+            "shoulder_pan": JointBinding(source=InputSource.FACE, channel="face.mouth_open"),
+            "gripper": JointBinding(source=InputSource.KEYBOARD, positive_key="KeyF"),
+        }
+    )
+    frame = InputFrame(keys={"KeyF": True}, engaged=True, tracking=False)
+    assert controller.axis_for_joint("gripper", frame) == 1.0
+
+
+# ── integration ──────────────────────────────────────────────────────────
+
+
+def test_clutch_gates_all_motion():
+    binding = JointBinding(source=InputSource.KEYBOARD, positive_key="KeyF", smoothing=0.0, speed=30.0)
+    controller = make_controller({"shoulder_pan": binding, "gripper": JointBinding()})
+
+    controller.step(InputFrame(keys={"KeyF": True}, engaged=False), 0.1)
+    assert controller.pose["shoulder_pan"] == 0.0
+
+    controller.step(InputFrame(keys={"KeyF": True}, engaged=True), 0.05)
+    assert controller.pose["shoulder_pan"] > 0.0
+
+
+def test_velocity_integrates_at_the_configured_speed():
+    binding = JointBinding(source=InputSource.KEYBOARD, positive_key="KeyF", smoothing=0.0, speed=30.0)
+    controller = make_controller({"shoulder_pan": binding, "gripper": JointBinding()})
+    frame = InputFrame(keys={"KeyF": True}, engaged=True)
+
+    for _ in range(20):
+        controller.step(frame, 0.05)  # 20 steps x 0.05 s x 30 deg/s = 30 deg
+
+    assert controller.pose["shoulder_pan"] == pytest.approx(30.0)
+
+
+def test_step_is_clamped_so_a_stalled_loop_cannot_lurch():
+    binding = JointBinding(source=InputSource.KEYBOARD, positive_key="KeyF", smoothing=0.0, speed=60.0)
+    controller = make_controller({"shoulder_pan": binding, "gripper": JointBinding()}, max_step_s=0.06)
+
+    # The caller reports a 10 s gap, e.g. after a breakpoint or a suspended laptop.
+    controller.step(InputFrame(keys={"KeyF": True}, engaged=True), 10.0)
+
+    assert controller.pose["shoulder_pan"] == pytest.approx(60.0 * 0.06)
+
+
+def test_pose_never_leaves_the_joint_limits():
+    binding = JointBinding(source=InputSource.KEYBOARD, positive_key="KeyF", smoothing=0.0, speed=120.0)
+    negative = JointBinding(source=InputSource.KEYBOARD, negative_key="KeyG", smoothing=0.0, speed=120.0)
+    controller = make_controller({"shoulder_pan": binding, "gripper": negative})
+
+    for _ in range(200):
+        controller.step(InputFrame(keys={"KeyF": True, "KeyG": True}, engaged=True), 0.06)
+
+    assert controller.pose["shoulder_pan"] == pytest.approx(90.0)
+    assert controller.pose["gripper"] == pytest.approx(0.0)
+
+
+def test_smoothing_delays_full_speed_but_still_reaches_it():
+    smooth = JointBinding(source=InputSource.KEYBOARD, positive_key="KeyF", smoothing=0.9, speed=30.0)
+    sharp = JointBinding(source=InputSource.KEYBOARD, positive_key="KeyF", smoothing=0.0, speed=30.0)
+    smooth_controller = make_controller({"shoulder_pan": smooth, "gripper": JointBinding()})
+    sharp_controller = make_controller({"shoulder_pan": sharp, "gripper": JointBinding()})
+    frame = InputFrame(keys={"KeyF": True}, engaged=True)
+
+    smooth_controller.step(frame, 0.05)
+    sharp_controller.step(frame, 0.05)
+    assert smooth_controller.pose["shoulder_pan"] < sharp_controller.pose["shoulder_pan"]
+
+    for _ in range(60):
+        smooth_controller.step(frame, 0.05)
+    assert smooth_controller.velocity["shoulder_pan"] == pytest.approx(30.0, rel=1e-2)
+
+
+def test_releasing_an_input_actually_stops_the_joint():
+    binding = JointBinding(source=InputSource.KEYBOARD, positive_key="KeyF", smoothing=0.8, speed=30.0)
+    controller = make_controller({"shoulder_pan": binding, "gripper": JointBinding()})
+
+    for _ in range(20):
+        controller.step(InputFrame(keys={"KeyF": True}, engaged=True), 0.05)
+    for _ in range(200):
+        controller.step(InputFrame(engaged=True), 0.05)
+
+    assert controller.velocity["shoulder_pan"] == 0.0
+
+
+def test_reset_takes_a_measured_pose_as_given():
+    # Anchoring is a statement about where the robot is, so clamping it here would turn
+    # re-anchoring into a movement command.
+    controller = make_controller({"shoulder_pan": JointBinding(), "gripper": JointBinding()})
+    controller.reset({"shoulder_pan": -102.5, "gripper": 2.3})
+    assert controller.pose["shoulder_pan"] == pytest.approx(-102.5)
+    assert controller.pose["gripper"] == pytest.approx(2.3)
+
+
+def test_reset_clamps_the_configured_start_pose():
+    controller = JointController(
+        joints=JOINTS,
+        bindings={"shoulder_pan": JointBinding(), "gripper": JointBinding()},
+        joint_limits=LIMITS,
+        start_pose={"shoulder_pan": 500.0, "gripper": 50.0},
+    )
+    assert controller.pose["shoulder_pan"] == pytest.approx(90.0)
+
+
+def test_a_joint_parked_outside_its_limits_can_still_come_back():
+    binding = JointBinding(
+        source=InputSource.KEYBOARD,
+        positive_key="KeyF",
+        negative_key="KeyG",
+        smoothing=0.0,
+        speed=30.0,
+    )
+    controller = make_controller({"shoulder_pan": binding, "gripper": JointBinding()})
+    # The arm was parked against its mechanical stop, past the configured limit.
+    controller.reset({"shoulder_pan": 102.5, "gripper": 50.0})
+
+    controller.step(InputFrame(keys={"KeyF": True}, engaged=True), 0.05)
+    assert controller.pose["shoulder_pan"] == pytest.approx(102.5), "must not travel further out"
+
+    for _ in range(20):
+        controller.step(InputFrame(keys={"KeyG": True}, engaged=True), 0.05)
+    assert controller.pose["shoulder_pan"] < 102.5, "must be able to come back into range"
+
+
+# ── teleoperator ─────────────────────────────────────────────────────────
+
+
+def test_registered_in_the_teleoperator_factory():
+    config = AccessibleTeleopConfig(id="factory_check")
+    assert config.type == "accessible_teleop"
+    assert isinstance(make_teleoperator_from_config(config), AccessibleTeleop)
+
+
+def test_action_features_match_the_configured_joints():
+    teleop = AccessibleTeleop(AccessibleTeleopConfig(id="features", joints=list(JOINTS)))
+    assert set(teleop.action_features) == {"shoulder_pan.pos", "gripper.pos"}
+    assert teleop.feedback_features == teleop.action_features
+
+
+def test_get_action_requires_a_connection():
+    teleop = AccessibleTeleop(AccessibleTeleopConfig(id="disconnected"))
+    with pytest.raises(DeviceNotConnectedError):
+        teleop.get_action()
+
+
+def test_a_profile_with_only_keyboard_bindings_needs_no_calibration():
+    config = AccessibleTeleopConfig(
+        id="keys_only",
+        joints=list(JOINTS),
+        bindings={
+            "shoulder_pan": JointBinding(source=InputSource.KEYBOARD, positive_key="KeyF"),
+            "gripper": JointBinding(),
+        },
+    )
+    assert AccessibleTeleop(config).is_calibrated
+
+
+def test_a_bound_face_channel_must_be_calibrated():
+    config = AccessibleTeleopConfig(
+        id="face_bound",
+        joints=list(JOINTS),
+        bindings={
+            "shoulder_pan": JointBinding(source=InputSource.FACE, channel="face.mouth_open"),
+            "gripper": JointBinding(),
+        },
+    )
+    teleop = AccessibleTeleop(config)
+    assert not teleop.is_calibrated
+
+    teleop.channel_calibrations["face.mouth_open"] = ChannelCalibration(
+        neutral=0.0, negative_range=0.3, positive_range=0.3, ready=True
+    )
+    assert teleop.is_calibrated
+
+
+def test_profile_round_trips_through_the_calibration_file(tmp_path):
+    config = AccessibleTeleopConfig(
+        id="round_trip",
+        calibration_dir=tmp_path,
+        joints=list(JOINTS),
+        bindings={
+            "shoulder_pan": JointBinding(source=InputSource.JOYSTICK, channel="pad_a.x", speed=17.0),
+            "gripper": JointBinding(source=InputSource.FACE, channel="face.mouth_open", invert=True),
+        },
+    )
+    saved = AccessibleTeleop(config)
+    saved.channel_calibrations["face.mouth_open"] = ChannelCalibration(
+        neutral=0.1, negative_range=0.2, positive_range=0.4, ready=True
+    )
+    saved._save_calibration()
+
+    profile = json.loads((tmp_path / "round_trip.json").read_text())
+    assert profile["bindings"]["shoulder_pan"]["source"] == "joystick"
+
+    loaded = AccessibleTeleop(AccessibleTeleopConfig(id="round_trip", calibration_dir=tmp_path))
+    assert loaded.bindings["shoulder_pan"].channel == "pad_a.x"
+    assert loaded.bindings["shoulder_pan"].speed == pytest.approx(17.0)
+    assert loaded.bindings["gripper"].invert
+    assert loaded.channel_calibrations["face.mouth_open"].ready
+    assert loaded.is_calibrated
+
+
+def test_send_feedback_anchors_the_commanded_pose():
+    teleop = AccessibleTeleop(AccessibleTeleopConfig(id="anchor", joints=list(JOINTS)))
+    teleop.sync_to({"shoulder_pan": -33.0, "gripper": 12.0})
+    assert teleop.controller.pose["shoulder_pan"] == pytest.approx(-33.0)
+    assert teleop.controller.pose["gripper"] == pytest.approx(12.0)
+
+
+# ── web bridge ───────────────────────────────────────────────────────────
+
+pytestmark_ws = pytest.mark.skipif(not _websockets_available, reason="requires lerobot[accessible-teleop]")
+
+
+@pytest.fixture
+def connected_teleop(tmp_path):
+    config = AccessibleTeleopConfig(
+        id="bridge",
+        calibration_dir=tmp_path,
+        joints=list(JOINTS),
+        joint_limits=dict(LIMITS),
+        start_pose=dict(START),
+        bindings={
+            "shoulder_pan": JointBinding(
+                source=InputSource.KEYBOARD, positive_key="KeyF", smoothing=0.0, speed=30.0
+            ),
+            "gripper": JointBinding(),
+        },
+        host="127.0.0.1",
+        web_port=0,
+        open_browser=False,
+        connect_timeout_s=10.0,
+    )
+    teleop = AccessibleTeleop(config)
+    yield teleop
+    if teleop.is_connected:
+        teleop.disconnect()
+
+
+@pytestmark_ws
+def test_control_page_is_served_and_drives_the_robot(connected_teleop):
+    import threading
+    from urllib.request import urlopen
+
+    from websockets.sync.client import connect as ws_connect
+
+    teleop = connected_teleop
+    thread = threading.Thread(target=teleop.connect, kwargs={"calibrate": False}, daemon=True)
+    thread.start()
+
+    # Wait for the server socket before dialling it.
+    deadline = time.monotonic() + 10.0
+    while teleop._bridge is None or not teleop._bridge.is_running:
+        assert time.monotonic() < deadline, "bridge never started"
+        time.sleep(0.02)
+    url = teleop._bridge.url
+
+    page = urlopen(url, timeout=5).read().decode()  # noqa: S310 - loopback URL built above
+    assert "__LEROBOT_BOOTSTRAP__" not in page, "bootstrap placeholder was not substituted"
+    assert "shoulder_pan" in page
+
+    with ws_connect(url.replace("http://", "ws://") + "ws") as socket:
+        thread.join(timeout=10.0)
+        assert teleop.is_connected
+
+        # Nothing has been engaged, so the teleoperator claims no pose.
+        socket.send(json.dumps({"type": "input", "keys": {"KeyF": False}, "engaged": False}))
+        _wait_for_frame(teleop)
+        assert teleop.get_action() == {}
+
+        socket.send(json.dumps({"type": "input", "keys": {"KeyF": True}, "engaged": True}))
+        _wait_for_frame(teleop)
+        teleop.get_action()  # first engaged call only establishes the time base
+        time.sleep(0.05)
+        action = teleop.get_action()
+
+        assert set(action) == {"shoulder_pan.pos", "gripper.pos"}
+        assert action["shoulder_pan.pos"] > 0.0
+        assert action["gripper.pos"] == pytest.approx(50.0)
+
+
+@pytestmark_ws
+def test_stale_input_stops_the_robot(connected_teleop):
+    import threading
+
+    from websockets.sync.client import connect as ws_connect
+
+    teleop = connected_teleop
+    teleop.config.input_timeout_s = 0.1
+    thread = threading.Thread(target=teleop.connect, kwargs={"calibrate": False}, daemon=True)
+    thread.start()
+
+    deadline = time.monotonic() + 10.0
+    while teleop._bridge is None or not teleop._bridge.is_running:
+        assert time.monotonic() < deadline, "bridge never started"
+        time.sleep(0.02)
+
+    with ws_connect(teleop._bridge.url.replace("http://", "ws://") + "ws") as socket:
+        thread.join(timeout=10.0)
+        socket.send(json.dumps({"type": "input", "keys": {"KeyF": True}, "engaged": True}))
+        _wait_for_frame(teleop)
+        teleop.get_action()
+        time.sleep(0.05)
+        moving = teleop.get_action()["shoulder_pan.pos"]
+        assert moving > 0.0
+
+        # The page goes quiet: the joint must hold rather than keep travelling.
+        time.sleep(0.3)
+        held = teleop.get_action()["shoulder_pan.pos"]
+        time.sleep(0.2)
+        assert teleop.get_action()["shoulder_pan.pos"] == pytest.approx(held)
+
+
+def _wait_for_frame(teleop: AccessibleTeleop, timeout_s: float = 5.0) -> None:
+    deadline = time.monotonic() + timeout_s
+    while True:
+        _, age = teleop._bridge.read_frame()
+        if age is not None:
+            return
+        assert time.monotonic() < deadline, "no input frame arrived from the test client"
+        time.sleep(0.01)


### PR DESCRIPTION
## Summary / Motivation

Teleoperating an SO-101 currently means moving a leader arm, which rules out anyone who cannot. This adds `accessible_teleop`: a teleoperator that maps each joint to whichever input the operator can actually control — a facial movement, an on-screen joystick, or a pair of keys — and integrates that input into joint positions in Python.

The design point is that the browser is only an input surface. It reports raw sensor readings; every decision that reaches a motor happens in Python. That is what makes a closed tab or a dropped socket a stop rather than a surprise, and it is what makes the behaviour testable without a camera or a motor bus.

## What changed

- New `src/lerobot/teleoperators/accessible_teleop/`, emitting `{joint}.pos` so it is a drop-in replacement for a leader arm.
- Per-joint binding and tuning: calibration to a personal asymmetric range, dead zone, gain, EMA smoothing, per-joint speed. Nothing is bound by default.
- A self-contained control page served over loopback HTTP + WebSocket. No build step, no framework, no new runtime dependency beyond `websockets`.
- Safety: a held clutch, a stale-input timeout that releases it, a clamped integration step, and one-way travel limits — a joint parked past its limit can always come back in, because a limit that clamps would itself command motion.
- `lerobot-teleoperate` and `lerobot-record` now pass this teleoperator the robot's observation before reading each action, so the pose it holds is the pose the arm is already in and engaging cannot produce a jump.
- New optional extra `accessible-teleop`, included in `all`; docs page and `_toctree.yml` entry.

No breaking changes.

## How was this tested

- `tests/teleoperators/test_accessible_teleop.py`, 31 tests, hardware-free and skipped without the extra: `pytest -q tests/teleoperators/test_accessible_teleop.py`
- Full suite locally: 1223 passed, 342 skipped. `pre-commit run --all-files` clean.
- On a physical SO-101 with `--robot.max_relative_target`: joystick and keyboard channels drove the arm and held at their limits; unbound joints did not move.
- The `send_feedback` wiring was verified by running the real `teleop_loop` against a stub robot resting far from the configured start pose: 30 cycles at 30 Hz with no movement commanded.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: # (not yet — will do before asking for review time)

## Reviewer notes

**AI assistance disclosed per `AI_POLICY.md`:** a substantial portion of this code and its documentation was written with an AI assistant. I have driven, tested, and verified it against my own SO-101, and the safety behaviour in particular came out of hardware sessions rather than the model. Happy to walk through any part of it.

Two things worth your attention before the rest:

1. **`assets/index.html` is ~1000 lines** and no other in-tree teleoperator ships a bespoke page — `phone` delegates to the external `teleop` package. I kept it inline because it needs no build step and adds no runtime dependency, but I would rather hear early if you would prefer it factored out or slimmed down.
2. **The two script changes are the only edits outside the new module.** They exist because a velocity-integrating teleoperator has to know where the arm is before it can command a pose safely. I extended the existing `robot.name == "unitree_g1"` condition rather than introducing a new abstraction, but a capability flag on the base class would be cleaner if you want one.

Separately: `phone`'s `get_action` returns `{}` when uncalibrated, which reaches `sync_write` as a write addressed to no motors and raises `StopIteration`. I hit the same thing here and solved it by always commanding a pose. Happy to send a standalone fix for `phone` if that is useful.

Made with [Cursor](https://cursor.com)