### PR TITLE
fix(policies): warn on legacy normalization keys during from_pretrained

### DIFF
--- a/docs/source/backwardcomp.mdx
+++ b/docs/source/backwardcomp.mdx
@@ -23,7 +23,7 @@
 Use the migration script to convert models with embedded normalization:
 
 ```shell
-python src/lerobot/processor/migrate_policy_normalization.py \
+python -m lerobot.processor.migrate_policy_normalization \
     --pretrained-path lerobot/act_aloha_sim_transfer_cube_human \
     --push-to-hub \
     --branch migrated

--- a/src/lerobot/policies/fastwam/modeling_fastwam.py
+++ b/src/lerobot/policies/fastwam/modeling_fastwam.py
@@ -96,6 +96,7 @@ class FastWAMPolicy(PreTrainedPolicy):
         strict: bool,
         *,
         pretrained_name_or_path: str | None = None,
+        revision: str | None = None,
     ):
         """Shape-aware load that supports cross-embodiment fine-tuning.
 
@@ -127,6 +128,7 @@ class FastWAMPolicy(PreTrainedPolicy):
                 map_location,
                 strict,
                 pretrained_name_or_path=pretrained_name_or_path,
+                revision=revision,
             )
         if strict:
             raise RuntimeError(
@@ -149,7 +151,10 @@ class FastWAMPolicy(PreTrainedPolicy):
             state_dict.pop(key, None)
         missing_keys, unexpected_keys = model.load_state_dict(state_dict, strict=False)
         log_model_loading_keys(
-            missing_keys, unexpected_keys, pretrained_name_or_path=pretrained_name_or_path
+            missing_keys,
+            unexpected_keys,
+            pretrained_name_or_path=pretrained_name_or_path,
+            revision=revision,
         )
         if map_location and map_location != "cpu":
             model.to(map_location)

--- a/src/lerobot/policies/fastwam/modeling_fastwam.py
+++ b/src/lerobot/policies/fastwam/modeling_fastwam.py
@@ -88,7 +88,15 @@ class FastWAMPolicy(PreTrainedPolicy):
         self.reset()
 
     @classmethod
-    def _load_as_safetensor(cls, model, model_file: str, map_location: str, strict: bool):
+    def _load_as_safetensor(
+        cls,
+        model,
+        model_file: str,
+        map_location: str,
+        strict: bool,
+        *,
+        pretrained_name_or_path: str | None = None,
+    ):
         """Shape-aware load that supports cross-embodiment fine-tuning.
 
         `safetensors.load_model(strict=False)` ignores missing/unexpected keys but
@@ -113,7 +121,13 @@ class FastWAMPolicy(PreTrainedPolicy):
                     mismatched.append(key)
 
         if not mismatched:
-            return super()._load_as_safetensor(model, model_file, map_location, strict)
+            return super()._load_as_safetensor(
+                model,
+                model_file,
+                map_location,
+                strict,
+                pretrained_name_or_path=pretrained_name_or_path,
+            )
         if strict:
             raise RuntimeError(
                 f"FastWAM: {len(mismatched)} checkpoint tensors have a shape mismatch under "

--- a/src/lerobot/policies/fastwam/modeling_fastwam.py
+++ b/src/lerobot/policies/fastwam/modeling_fastwam.py
@@ -136,6 +136,8 @@ class FastWAMPolicy(PreTrainedPolicy):
 
         from safetensors.torch import load_file
 
+        from lerobot.policies.utils import log_model_loading_keys
+
         logging.warning(
             "FastWAM cross-embodiment load: reinitializing %d shape-mismatched tensor(s), keeping "
             "every compatible weight: %s",
@@ -145,7 +147,10 @@ class FastWAMPolicy(PreTrainedPolicy):
         state_dict = load_file(model_file, device="cpu")
         for key in mismatched:
             state_dict.pop(key, None)
-        model.load_state_dict(state_dict, strict=False)
+        missing_keys, unexpected_keys = model.load_state_dict(state_dict, strict=False)
+        log_model_loading_keys(
+            missing_keys, unexpected_keys, pretrained_name_or_path=pretrained_name_or_path
+        )
         if map_location and map_location != "cpu":
             model.to(map_location)
         return model

--- a/src/lerobot/policies/fastwam/modeling_fastwam.py
+++ b/src/lerobot/policies/fastwam/modeling_fastwam.py
@@ -88,16 +88,7 @@ class FastWAMPolicy(PreTrainedPolicy):
         self.reset()
 
     @classmethod
-    def _load_as_safetensor(
-        cls,
-        model,
-        model_file: str,
-        map_location: str,
-        strict: bool,
-        *,
-        pretrained_name_or_path: str | None = None,
-        revision: str | None = None,
-    ):
+    def _load_as_safetensor(cls, model, model_file: str, map_location: str, strict: bool):
         """Shape-aware load that supports cross-embodiment fine-tuning.
 
         `safetensors.load_model(strict=False)` ignores missing/unexpected keys but
@@ -122,14 +113,7 @@ class FastWAMPolicy(PreTrainedPolicy):
                     mismatched.append(key)
 
         if not mismatched:
-            return super()._load_as_safetensor(
-                model,
-                model_file,
-                map_location,
-                strict,
-                pretrained_name_or_path=pretrained_name_or_path,
-                revision=revision,
-            )
+            return super()._load_as_safetensor(model, model_file, map_location, strict)
         if strict:
             raise RuntimeError(
                 f"FastWAM: {len(mismatched)} checkpoint tensors have a shape mismatch under "
@@ -150,12 +134,7 @@ class FastWAMPolicy(PreTrainedPolicy):
         for key in mismatched:
             state_dict.pop(key, None)
         missing_keys, unexpected_keys = model.load_state_dict(state_dict, strict=False)
-        log_model_loading_keys(
-            missing_keys,
-            unexpected_keys,
-            pretrained_name_or_path=pretrained_name_or_path,
-            revision=revision,
-        )
+        log_model_loading_keys(missing_keys, unexpected_keys)
         if map_location and map_location != "cpu":
             model.to(map_location)
         return model

--- a/src/lerobot/policies/pretrained.py
+++ b/src/lerobot/policies/pretrained.py
@@ -203,7 +203,12 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
             print("Loading weights from local directory")
             model_file = os.path.join(model_id, SAFETENSORS_SINGLE_FILE)
             policy = cls._load_as_safetensor(
-                instance, model_file, config.device, strict, pretrained_name_or_path=model_id
+                instance,
+                model_file,
+                config.device,
+                strict,
+                pretrained_name_or_path=model_id,
+                revision=revision,
             )
         else:
             try:
@@ -219,7 +224,12 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
                     local_files_only=local_files_only,
                 )
                 policy = cls._load_as_safetensor(
-                    instance, model_file, config.device, strict, pretrained_name_or_path=model_id
+                    instance,
+                    model_file,
+                    config.device,
+                    strict,
+                    pretrained_name_or_path=model_id,
+                    revision=revision,
                 )
             except HfHubHTTPError as e:
                 raise FileNotFoundError(
@@ -239,12 +249,16 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
         strict: bool,
         *,
         pretrained_name_or_path: str | None = None,
+        revision: str | None = None,
     ) -> T:
         missing_keys, unexpected_keys = load_model_as_safetensor(
             model, model_file, strict=strict, device=resolve_safetensors_device(map_location)
         )
         log_model_loading_keys(
-            missing_keys, unexpected_keys, pretrained_name_or_path=pretrained_name_or_path
+            missing_keys,
+            unexpected_keys,
+            pretrained_name_or_path=pretrained_name_or_path,
+            revision=revision,
         )
         return model
 

--- a/src/lerobot/policies/pretrained.py
+++ b/src/lerobot/policies/pretrained.py
@@ -202,7 +202,9 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
         if os.path.isdir(model_id):
             print("Loading weights from local directory")
             model_file = os.path.join(model_id, SAFETENSORS_SINGLE_FILE)
-            policy = cls._load_as_safetensor(instance, model_file, config.device, strict)
+            policy = cls._load_as_safetensor(
+                instance, model_file, config.device, strict, pretrained_name_or_path=model_id
+            )
         else:
             try:
                 model_file = hf_hub_download(
@@ -216,7 +218,9 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
                     token=token,
                     local_files_only=local_files_only,
                 )
-                policy = cls._load_as_safetensor(instance, model_file, config.device, strict)
+                policy = cls._load_as_safetensor(
+                    instance, model_file, config.device, strict, pretrained_name_or_path=model_id
+                )
             except HfHubHTTPError as e:
                 raise FileNotFoundError(
                     f"{SAFETENSORS_SINGLE_FILE} not found on the HuggingFace Hub in {model_id}"
@@ -227,11 +231,21 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
         return policy
 
     @classmethod
-    def _load_as_safetensor(cls, model: T, model_file: str, map_location: str, strict: bool) -> T:
+    def _load_as_safetensor(
+        cls,
+        model: T,
+        model_file: str,
+        map_location: str,
+        strict: bool,
+        *,
+        pretrained_name_or_path: str | None = None,
+    ) -> T:
         missing_keys, unexpected_keys = load_model_as_safetensor(
             model, model_file, strict=strict, device=resolve_safetensors_device(map_location)
         )
-        log_model_loading_keys(missing_keys, unexpected_keys)
+        log_model_loading_keys(
+            missing_keys, unexpected_keys, pretrained_name_or_path=pretrained_name_or_path
+        )
         return model
 
     @abc.abstractmethod

--- a/src/lerobot/policies/pretrained.py
+++ b/src/lerobot/policies/pretrained.py
@@ -202,14 +202,8 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
         if os.path.isdir(model_id):
             print("Loading weights from local directory")
             model_file = os.path.join(model_id, SAFETENSORS_SINGLE_FILE)
-            policy = cls._load_as_safetensor(
-                instance,
-                model_file,
-                config.device,
-                strict,
-                pretrained_name_or_path=model_id,
-                revision=revision,
-            )
+            cls._warn_legacy_normalization(model_file, model_id, revision)
+            policy = cls._load_as_safetensor(instance, model_file, config.device, strict)
         else:
             try:
                 model_file = hf_hub_download(
@@ -223,14 +217,8 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
                     token=token,
                     local_files_only=local_files_only,
                 )
-                policy = cls._load_as_safetensor(
-                    instance,
-                    model_file,
-                    config.device,
-                    strict,
-                    pretrained_name_or_path=model_id,
-                    revision=revision,
-                )
+                cls._warn_legacy_normalization(model_file, model_id, revision)
+                policy = cls._load_as_safetensor(instance, model_file, config.device, strict)
             except HfHubHTTPError as e:
                 raise FileNotFoundError(
                     f"{SAFETENSORS_SINGLE_FILE} not found on the HuggingFace Hub in {model_id}"
@@ -241,25 +229,36 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
         return policy
 
     @classmethod
-    def _load_as_safetensor(
+    def _warn_legacy_normalization(
         cls,
-        model: T,
         model_file: str,
-        map_location: str,
-        strict: bool,
-        *,
-        pretrained_name_or_path: str | None = None,
-        revision: str | None = None,
-    ) -> T:
-        missing_keys, unexpected_keys = load_model_as_safetensor(
-            model, model_file, strict=strict, device=resolve_safetensors_device(map_location)
-        )
-        log_model_loading_keys(
-            missing_keys,
-            unexpected_keys,
+        pretrained_name_or_path: str,
+        revision: str | None,
+    ) -> None:
+        """Inspect safetensors keys before the policy-specific loader runs.
+
+        Checking the file header up front keeps the legacy-migration warning working
+        even when a subclass overrides ``_load_as_safetensor`` and never calls
+        :func:`log_model_loading_keys`, without changing that protected hook's signature.
+        """
+        from safetensors import safe_open
+
+        from .utils import warn_legacy_normalization_keys
+
+        with safe_open(model_file, framework="pt") as f:
+            checkpoint_keys = list(f.keys())
+        warn_legacy_normalization_keys(
+            checkpoint_keys,
             pretrained_name_or_path=pretrained_name_or_path,
             revision=revision,
         )
+
+    @classmethod
+    def _load_as_safetensor(cls, model: T, model_file: str, map_location: str, strict: bool) -> T:
+        missing_keys, unexpected_keys = load_model_as_safetensor(
+            model, model_file, strict=strict, device=resolve_safetensors_device(map_location)
+        )
+        log_model_loading_keys(missing_keys, unexpected_keys)
         return model
 
     @abc.abstractmethod

--- a/src/lerobot/policies/utils.py
+++ b/src/lerobot/policies/utils.py
@@ -80,17 +80,52 @@ def get_output_shape(module: nn.Module, input_shape: tuple) -> tuple:
     return tuple(output.shape)
 
 
-def log_model_loading_keys(missing_keys: list[str], unexpected_keys: list[str]) -> None:
+# State-dict prefixes used by pre-0.6 in-policy Normalizer modules. When these appear as
+# unexpected keys, normalization stats were dropped at load time and the checkpoint needs
+# migration to the external processor pipeline.
+LEGACY_NORMALIZATION_KEY_PREFIXES: tuple[str, ...] = (
+    "normalize_inputs.buffer_",
+    "unnormalize_outputs.buffer_",
+    "normalize_targets.buffer_",
+    "unnormalize_targets.buffer_",
+)
+
+
+def has_legacy_normalization_keys(keys: list[str]) -> bool:
+    """Return True when keys include legacy in-policy normalization buffers."""
+    return any(key.startswith(prefix) for key in keys for prefix in LEGACY_NORMALIZATION_KEY_PREFIXES)
+
+
+def log_model_loading_keys(
+    missing_keys: list[str],
+    unexpected_keys: list[str],
+    *,
+    pretrained_name_or_path: str | None = None,
+) -> None:
     """Log missing and unexpected keys when loading a model.
 
     Args:
         missing_keys (list[str]): Keys that were expected but not found.
         unexpected_keys (list[str]): Keys that were found but not expected.
+        pretrained_name_or_path: Optional checkpoint id/path used to build a
+            concrete migration command when legacy normalization keys are detected.
     """
     if missing_keys:
         logging.warning(f"Missing key(s) when loading model: {missing_keys}")
     if unexpected_keys:
         logging.warning(f"Unexpected key(s) when loading model: {unexpected_keys}")
+        if has_legacy_normalization_keys(unexpected_keys):
+            checkpoint = pretrained_name_or_path or "<checkpoint>"
+            migration_command = (
+                f"python src/lerobot/processor/migrate_policy_normalization.py --pretrained-path {checkpoint}"
+            )
+            logging.warning(
+                "This checkpoint still uses the legacy in-policy normalization system "
+                "(unexpected keys like 'normalize_inputs.buffer_*'). Those stats are not "
+                "loaded into the current policy, so inference/eval can silently degrade. "
+                "Migrate with: %s",
+                migration_command,
+            )
 
 
 # TODO(Steven): Move this function to a proper preprocessor step

--- a/src/lerobot/policies/utils.py
+++ b/src/lerobot/policies/utils.py
@@ -101,6 +101,7 @@ def log_model_loading_keys(
     unexpected_keys: list[str],
     *,
     pretrained_name_or_path: str | None = None,
+    revision: str | None = None,
 ) -> None:
     """Log missing and unexpected keys when loading a model.
 
@@ -109,6 +110,8 @@ def log_model_loading_keys(
         unexpected_keys (list[str]): Keys that were found but not expected.
         pretrained_name_or_path: Optional checkpoint id/path used to build a
             concrete migration command when legacy normalization keys are detected.
+        revision: Optional Hub revision that was loaded; included in the migration
+            command so users migrate the same checkpoint they actually used.
     """
     if missing_keys:
         logging.warning(f"Missing key(s) when loading model: {missing_keys}")
@@ -119,6 +122,8 @@ def log_model_loading_keys(
             migration_command = (
                 f"python src/lerobot/processor/migrate_policy_normalization.py --pretrained-path {checkpoint}"
             )
+            if revision is not None:
+                migration_command += f" --revision {revision}"
             logging.warning(
                 "This checkpoint still uses the legacy in-policy normalization system "
                 "(unexpected keys like 'normalize_inputs.buffer_*'). Those stats are not "

--- a/src/lerobot/policies/utils.py
+++ b/src/lerobot/policies/utils.py
@@ -80,9 +80,9 @@ def get_output_shape(module: nn.Module, input_shape: tuple) -> tuple:
     return tuple(output.shape)
 
 
-# State-dict prefixes used by pre-0.6 in-policy Normalizer modules. When these appear as
-# unexpected keys, normalization stats were dropped at load time and the checkpoint needs
-# migration to the external processor pipeline.
+# State-dict prefixes used by pre-0.6 in-policy Normalizer modules. When these appear in a
+# checkpoint, normalization stats are not loaded into the current policy and the checkpoint
+# needs migration to the external processor pipeline.
 LEGACY_NORMALIZATION_KEY_PREFIXES: tuple[str, ...] = (
     "normalize_inputs.buffer_",
     "unnormalize_outputs.buffer_",
@@ -96,41 +96,44 @@ def has_legacy_normalization_keys(keys: list[str]) -> bool:
     return any(key.startswith(prefix) for key in keys for prefix in LEGACY_NORMALIZATION_KEY_PREFIXES)
 
 
-def log_model_loading_keys(
-    missing_keys: list[str],
-    unexpected_keys: list[str],
+def warn_legacy_normalization_keys(
+    keys: list[str],
     *,
     pretrained_name_or_path: str | None = None,
     revision: str | None = None,
 ) -> None:
+    """Warn when a checkpoint still embeds legacy in-policy normalization buffers.
+
+    Intended to run against safetensors keys *before* dispatching to a policy-specific
+    ``_load_as_safetensor`` hook, so the warning is emitted even when a custom loader
+    does not call :func:`log_model_loading_keys`.
+    """
+    if not has_legacy_normalization_keys(keys):
+        return
+
+    from lerobot.processor.pipeline import build_processor_migration_command
+
+    checkpoint = pretrained_name_or_path or "<checkpoint>"
+    migration_command = build_processor_migration_command(checkpoint, revision=revision)
+    logging.warning(
+        "This checkpoint still uses the legacy in-policy normalization system "
+        "(keys like 'normalize_inputs.buffer_*'). Those stats are not loaded into the "
+        "current policy, so inference/eval can silently degrade. Migrate with: %s",
+        migration_command,
+    )
+
+
+def log_model_loading_keys(missing_keys: list[str], unexpected_keys: list[str]) -> None:
     """Log missing and unexpected keys when loading a model.
 
     Args:
         missing_keys (list[str]): Keys that were expected but not found.
         unexpected_keys (list[str]): Keys that were found but not expected.
-        pretrained_name_or_path: Optional checkpoint id/path used to build a
-            concrete migration command when legacy normalization keys are detected.
-        revision: Optional Hub revision that was loaded; included in the migration
-            command so users migrate the same checkpoint they actually used.
     """
     if missing_keys:
         logging.warning(f"Missing key(s) when loading model: {missing_keys}")
     if unexpected_keys:
         logging.warning(f"Unexpected key(s) when loading model: {unexpected_keys}")
-        if has_legacy_normalization_keys(unexpected_keys):
-            checkpoint = pretrained_name_or_path or "<checkpoint>"
-            migration_command = (
-                f"python src/lerobot/processor/migrate_policy_normalization.py --pretrained-path {checkpoint}"
-            )
-            if revision is not None:
-                migration_command += f" --revision {revision}"
-            logging.warning(
-                "This checkpoint still uses the legacy in-policy normalization system "
-                "(unexpected keys like 'normalize_inputs.buffer_*'). Those stats are not "
-                "loaded into the current policy, so inference/eval can silently degrade. "
-                "Migrate with: %s",
-                migration_command,
-            )
 
 
 # TODO(Steven): Move this function to a proper preprocessor step

--- a/src/lerobot/policies/vla_jepa/modeling_vla_jepa.py
+++ b/src/lerobot/policies/vla_jepa/modeling_vla_jepa.py
@@ -475,6 +475,7 @@ class VLAJEPAPolicy(PreTrainedPolicy):
         strict: bool,
         *,
         pretrained_name_or_path: str | None = None,
+        revision: str | None = None,
     ) -> T:
         reinit_prefixes = model.config.reinit_modules
         if not reinit_prefixes:
@@ -484,6 +485,7 @@ class VLAJEPAPolicy(PreTrainedPolicy):
                 map_location,
                 strict,
                 pretrained_name_or_path=pretrained_name_or_path,
+                revision=revision,
             )
 
         from safetensors.torch import load_file
@@ -516,6 +518,9 @@ class VLAJEPAPolicy(PreTrainedPolicy):
 
         missing_keys, unexpected_keys = model.load_state_dict(filtered, strict=False)
         log_model_loading_keys(
-            missing_keys, unexpected_keys, pretrained_name_or_path=pretrained_name_or_path
+            missing_keys,
+            unexpected_keys,
+            pretrained_name_or_path=pretrained_name_or_path,
+            revision=revision,
         )
         return model

--- a/src/lerobot/policies/vla_jepa/modeling_vla_jepa.py
+++ b/src/lerobot/policies/vla_jepa/modeling_vla_jepa.py
@@ -467,26 +467,10 @@ class VLAJEPAPolicy(PreTrainedPolicy):
         return super().from_pretrained(pretrained_name_or_path, **kwargs)
 
     @classmethod
-    def _load_as_safetensor(
-        cls,
-        model: T,
-        model_file: str,
-        map_location: str,
-        strict: bool,
-        *,
-        pretrained_name_or_path: str | None = None,
-        revision: str | None = None,
-    ) -> T:
+    def _load_as_safetensor(cls, model: T, model_file: str, map_location: str, strict: bool) -> T:
         reinit_prefixes = model.config.reinit_modules
         if not reinit_prefixes:
-            return super()._load_as_safetensor(
-                model,
-                model_file,
-                map_location,
-                strict,
-                pretrained_name_or_path=pretrained_name_or_path,
-                revision=revision,
-            )
+            return super()._load_as_safetensor(model, model_file, map_location, strict)
 
         from safetensors.torch import load_file
 
@@ -517,10 +501,5 @@ class VLAJEPAPolicy(PreTrainedPolicy):
         from lerobot.policies.utils import log_model_loading_keys
 
         missing_keys, unexpected_keys = model.load_state_dict(filtered, strict=False)
-        log_model_loading_keys(
-            missing_keys,
-            unexpected_keys,
-            pretrained_name_or_path=pretrained_name_or_path,
-            revision=revision,
-        )
+        log_model_loading_keys(missing_keys, unexpected_keys)
         return model

--- a/src/lerobot/policies/vla_jepa/modeling_vla_jepa.py
+++ b/src/lerobot/policies/vla_jepa/modeling_vla_jepa.py
@@ -467,10 +467,24 @@ class VLAJEPAPolicy(PreTrainedPolicy):
         return super().from_pretrained(pretrained_name_or_path, **kwargs)
 
     @classmethod
-    def _load_as_safetensor(cls, model: T, model_file: str, map_location: str, strict: bool) -> T:
+    def _load_as_safetensor(
+        cls,
+        model: T,
+        model_file: str,
+        map_location: str,
+        strict: bool,
+        *,
+        pretrained_name_or_path: str | None = None,
+    ) -> T:
         reinit_prefixes = model.config.reinit_modules
         if not reinit_prefixes:
-            return super()._load_as_safetensor(model, model_file, map_location, strict)
+            return super()._load_as_safetensor(
+                model,
+                model_file,
+                map_location,
+                strict,
+                pretrained_name_or_path=pretrained_name_or_path,
+            )
 
         from safetensors.torch import load_file
 
@@ -501,5 +515,7 @@ class VLAJEPAPolicy(PreTrainedPolicy):
         from lerobot.policies.utils import log_model_loading_keys
 
         missing_keys, unexpected_keys = model.load_state_dict(filtered, strict=False)
-        log_model_loading_keys(missing_keys, unexpected_keys)
+        log_model_loading_keys(
+            missing_keys, unexpected_keys, pretrained_name_or_path=pretrained_name_or_path
+        )
         return model

--- a/src/lerobot/processor/migrate_policy_normalization.py
+++ b/src/lerobot/processor/migrate_policy_normalization.py
@@ -33,7 +33,7 @@ This script performs the following steps:
 6.  Optionally pushes all the new artifacts to the Hugging Face Hub.
 
 Usage:
-    python src/lerobot/processor/migrate_policy_normalization.py \
+    python -m lerobot.processor.migrate_policy_normalization \
         --pretrained-path lerobot/act_aloha_sim_transfer_cube_human \
         --push-to-hub \
         --branch main

--- a/src/lerobot/processor/pipeline.py
+++ b/src/lerobot/processor/pipeline.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 import importlib
 import json
 import re
+import shlex
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable, Sequence
 from copy import deepcopy
@@ -242,6 +243,28 @@ class ProcessorKwargs(TypedDict, total=False):
     name: str | None
     before_step_hooks: list[Callable[[int, EnvTransition], None]] | None
     after_step_hooks: list[Callable[[int, EnvTransition], None]] | None
+
+
+def build_processor_migration_command(
+    pretrained_path: str | Path,
+    *,
+    revision: str | None = None,
+) -> str:
+    """Build a portable, shell-quoted migration command for a legacy checkpoint.
+
+    Uses module execution so the command works regardless of working directory,
+    and quotes arguments so local paths with spaces remain copy-pasteable.
+    """
+    cmd = [
+        "python",
+        "-m",
+        "lerobot.processor.migrate_policy_normalization",
+        "--pretrained-path",
+        str(pretrained_path),
+    ]
+    if revision is not None:
+        cmd.extend(["--revision", str(revision)])
+    return shlex.join(cmd)
 
 
 class ProcessorMigrationError(Exception):
@@ -1494,9 +1517,9 @@ class DataProcessorPipeline[TInput, TOutput](HubMixin):
 
         **Migration Command Generation**:
         - Constructs exact command user needs to run
-        - Uses the migration script: migrate_policy_normalization.py
-        - Includes the model path automatically
-        - Example: "python src/lerobot/processor/migrate_policy_normalization.py --pretrained-path /models/old_model"
+        - Uses module execution: ``python -m lerobot.processor.migrate_policy_normalization``
+        - Includes the model path automatically (shell-quoted for spaces)
+        - Example: ``python -m lerobot.processor.migrate_policy_normalization --pretrained-path /models/old_model``
 
         **Error Structure**:
         - **Always raises**: ProcessorMigrationError (never returns)
@@ -1519,13 +1542,11 @@ class DataProcessorPipeline[TInput, TOutput](HubMixin):
         Raises:
             ProcessorMigrationError: Always raised (this method never returns normally)
         """
-        migration_command = (
-            f"python src/lerobot/processor/migrate_policy_normalization.py --pretrained-path {model_path}"
+        raise ProcessorMigrationError(
+            model_path,
+            build_processor_migration_command(model_path, revision=revision),
+            original_error,
         )
-        if revision is not None:
-            migration_command += f" --revision {revision}"
-
-        raise ProcessorMigrationError(model_path, migration_command, original_error)
 
     def __len__(self) -> int:
         """Returns the number of steps in the pipeline."""

--- a/tests/policies/test_legacy_normalization_warning.py
+++ b/tests/policies/test_legacy_normalization_warning.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for legacy in-policy normalization detection during checkpoint load."""
+
+import logging
+
+from lerobot.policies.utils import has_legacy_normalization_keys, log_model_loading_keys
+
+
+def test_has_legacy_normalization_keys_detects_buffer_prefixes():
+    assert has_legacy_normalization_keys(["normalize_inputs.buffer_observation_image.mean", "model.weight"])
+    assert has_legacy_normalization_keys(["unnormalize_outputs.buffer_action.std"])
+    assert not has_legacy_normalization_keys(["model.weight", "model.bias"])
+
+
+def test_log_model_loading_keys_warns_with_migration_command(caplog):
+    unexpected = [
+        "normalize_inputs.buffer_observation_state.mean",
+        "unnormalize_outputs.buffer_action.std",
+    ]
+
+    with caplog.at_level(logging.WARNING):
+        log_model_loading_keys(
+            [],
+            unexpected,
+            pretrained_name_or_path="lerobot/diffusion_pusht",
+        )
+
+    joined = "\n".join(record.getMessage() for record in caplog.records)
+    assert "Unexpected key(s) when loading model" in joined
+    assert "legacy in-policy normalization" in joined
+    assert "migrate_policy_normalization.py" in joined
+    assert "--pretrained-path lerobot/diffusion_pusht" in joined
+
+
+def test_log_model_loading_keys_skips_migration_warning_for_unrelated_keys(caplog):
+    with caplog.at_level(logging.WARNING):
+        log_model_loading_keys([], ["some_other.unexpected.key"])
+
+    joined = "\n".join(record.getMessage() for record in caplog.records)
+    assert "Unexpected key(s) when loading model" in joined
+    assert "legacy in-policy normalization" not in joined

--- a/tests/policies/test_legacy_normalization_warning.py
+++ b/tests/policies/test_legacy_normalization_warning.py
@@ -17,8 +17,14 @@
 """Tests for legacy in-policy normalization detection during checkpoint load."""
 
 import logging
+import shlex
 
-from lerobot.policies.utils import has_legacy_normalization_keys, log_model_loading_keys
+from lerobot.policies.utils import (
+    has_legacy_normalization_keys,
+    log_model_loading_keys,
+    warn_legacy_normalization_keys,
+)
+from lerobot.processor.pipeline import build_processor_migration_command
 
 
 def test_has_legacy_normalization_keys_detects_buffer_prefixes():
@@ -27,33 +33,45 @@ def test_has_legacy_normalization_keys_detects_buffer_prefixes():
     assert not has_legacy_normalization_keys(["model.weight", "model.bias"])
 
 
-def test_log_model_loading_keys_warns_with_migration_command(caplog):
+def test_build_processor_migration_command_uses_module_execution():
+    command = build_processor_migration_command("lerobot/diffusion_pusht")
+    assert command.startswith("python -m lerobot.processor.migrate_policy_normalization ")
+    assert "--pretrained-path lerobot/diffusion_pusht" in command
+    assert "--revision" not in command
+
+
+def test_build_processor_migration_command_quotes_paths_with_spaces():
+    path_with_spaces = "/models/old policy"
+    command = build_processor_migration_command(path_with_spaces, revision="legacy-branch")
+    assert "python -m lerobot.processor.migrate_policy_normalization" in command
+    assert f"--pretrained-path {shlex.quote(path_with_spaces)}" in command
+    assert "--revision legacy-branch" in command
+
+
+def test_warn_legacy_normalization_keys_emits_migration_command(caplog):
     unexpected = [
         "normalize_inputs.buffer_observation_state.mean",
         "unnormalize_outputs.buffer_action.std",
     ]
 
     with caplog.at_level(logging.WARNING):
-        log_model_loading_keys(
-            [],
+        warn_legacy_normalization_keys(
             unexpected,
             pretrained_name_or_path="lerobot/diffusion_pusht",
         )
 
     joined = "\n".join(record.getMessage() for record in caplog.records)
-    assert "Unexpected key(s) when loading model" in joined
     assert "legacy in-policy normalization" in joined
-    assert "migrate_policy_normalization.py" in joined
+    assert "python -m lerobot.processor.migrate_policy_normalization" in joined
     assert "--pretrained-path lerobot/diffusion_pusht" in joined
     assert "--revision" not in joined
 
 
-def test_log_model_loading_keys_includes_revision_in_migration_command(caplog):
+def test_warn_legacy_normalization_keys_includes_revision_in_migration_command(caplog):
     unexpected = ["normalize_inputs.buffer_observation_state.mean"]
 
     with caplog.at_level(logging.WARNING):
-        log_model_loading_keys(
-            [],
+        warn_legacy_normalization_keys(
             unexpected,
             pretrained_name_or_path="lerobot/diffusion_pusht",
             revision="legacy-branch",
@@ -64,9 +82,34 @@ def test_log_model_loading_keys_includes_revision_in_migration_command(caplog):
     assert "--revision legacy-branch" in joined
 
 
-def test_log_model_loading_keys_skips_migration_warning_for_unrelated_keys(caplog):
+def test_warn_legacy_normalization_keys_quotes_local_paths_with_spaces(caplog):
+    path_with_spaces = "/models/old policy"
+    unexpected = ["normalize_inputs.buffer_observation_state.mean"]
+
     with caplog.at_level(logging.WARNING):
-        log_model_loading_keys([], ["some_other.unexpected.key"])
+        warn_legacy_normalization_keys(
+            unexpected,
+            pretrained_name_or_path=path_with_spaces,
+        )
+
+    joined = "\n".join(record.getMessage() for record in caplog.records)
+    assert f"--pretrained-path {shlex.quote(path_with_spaces)}" in joined
+
+
+def test_warn_legacy_normalization_keys_skips_unrelated_keys(caplog):
+    with caplog.at_level(logging.WARNING):
+        warn_legacy_normalization_keys(["some_other.unexpected.key"])
+
+    joined = "\n".join(record.getMessage() for record in caplog.records)
+    assert "legacy in-policy normalization" not in joined
+
+
+def test_log_model_loading_keys_does_not_emit_migration_warning(caplog):
+    """Legacy migration is handled via pre-dispatch inspection, not key logging."""
+    unexpected = ["normalize_inputs.buffer_observation_state.mean"]
+
+    with caplog.at_level(logging.WARNING):
+        log_model_loading_keys([], unexpected)
 
     joined = "\n".join(record.getMessage() for record in caplog.records)
     assert "Unexpected key(s) when loading model" in joined

--- a/tests/policies/test_legacy_normalization_warning.py
+++ b/tests/policies/test_legacy_normalization_warning.py
@@ -45,6 +45,23 @@ def test_log_model_loading_keys_warns_with_migration_command(caplog):
     assert "legacy in-policy normalization" in joined
     assert "migrate_policy_normalization.py" in joined
     assert "--pretrained-path lerobot/diffusion_pusht" in joined
+    assert "--revision" not in joined
+
+
+def test_log_model_loading_keys_includes_revision_in_migration_command(caplog):
+    unexpected = ["normalize_inputs.buffer_observation_state.mean"]
+
+    with caplog.at_level(logging.WARNING):
+        log_model_loading_keys(
+            [],
+            unexpected,
+            pretrained_name_or_path="lerobot/diffusion_pusht",
+            revision="legacy-branch",
+        )
+
+    joined = "\n".join(record.getMessage() for record in caplog.records)
+    assert "--pretrained-path lerobot/diffusion_pusht" in joined
+    assert "--revision legacy-branch" in joined
 
 
 def test_log_model_loading_keys_skips_migration_warning_for_unrelated_keys(caplog):

--- a/tests/processor/test_migration_detection.py
+++ b/tests/processor/test_migration_detection.py
@@ -19,6 +19,7 @@ Tests for processor migration detection functionality.
 """
 
 import json
+import shlex
 import tempfile
 from pathlib import Path
 
@@ -222,7 +223,7 @@ def test_from_pretrained_multiple_json_files_migration_error():
         # Check the error details
         error = exc_info.value
         assert str(tmp_path) in str(error.model_path)
-        assert "migrate_policy_normalization.py" in error.migration_command
+        assert "python -m lerobot.processor.migrate_policy_normalization" in error.migration_command
         assert "not a valid processor configuration" in error.original_error
 
 
@@ -244,7 +245,7 @@ def test_from_pretrained_no_processor_config_migration_error():
         # Check the error details
         error = exc_info.value
         assert str(tmp_path) in str(error.model_path)
-        assert "migrate_policy_normalization.py" in error.migration_command
+        assert "python -m lerobot.processor.migrate_policy_normalization" in error.migration_command
         assert "not a valid processor configuration" in error.original_error
 
 
@@ -324,7 +325,18 @@ def test_migration_suggestion_raises_error():
     error = exc_info.value
     assert "/test/path" in str(error.model_path)
     assert "Test error" in error.original_error
-    assert "migrate_policy_normalization.py" in error.migration_command
+    assert "python -m lerobot.processor.migrate_policy_normalization" in error.migration_command
+
+
+def test_migration_suggestion_quotes_paths_with_spaces():
+    """Migration command must remain copy-pasteable for local paths with spaces."""
+    model_path = "/models/old policy"
+    with pytest.raises(ProcessorMigrationError) as exc_info:
+        DataProcessorPipeline._suggest_processor_migration(model_path, "Test error")
+
+    command = exc_info.value.migration_command
+    assert "python -m lerobot.processor.migrate_policy_normalization" in command
+    assert f"--pretrained-path {shlex.quote(model_path)}" in command
 
 
 def test_migration_error_always_raised_for_invalid_configs():

--- a/tests/processor/test_pipeline_from_pretrained_helpers.py
+++ b/tests/processor/test_pipeline_from_pretrained_helpers.py
@@ -134,7 +134,7 @@ def test_load_config_legacy_hub_policy_suggests_revision_aware_migration(tmp_pat
 
     error = exc_info.value
     assert error.model_path == "lerobot/diffusion_pusht"
-    assert "migrate_policy_normalization.py" in error.migration_command
+    assert "python -m lerobot.processor.migrate_policy_normalization" in error.migration_command
     assert "--revision legacy" in error.migration_command
     assert "policy_preprocessor.json" in error.original_error
 

--- a/tests/processor/test_pipeline_from_pretrained_helpers.py
+++ b/tests/processor/test_pipeline_from_pretrained_helpers.py
@@ -108,6 +108,7 @@ def test_load_config_nonexistent_path_tries_hub():
 
 
 def test_load_config_legacy_hub_policy_suggests_revision_aware_migration(tmp_path, monkeypatch):
+    """Test that a missing Hub processor config identifies a legacy LeRobot policy."""
     config_path = tmp_path / "config.json"
     config_path.write_text(
         json.dumps(
@@ -131,7 +132,27 @@ def test_load_config_legacy_hub_policy_suggests_revision_aware_migration(tmp_pat
             "lerobot/diffusion_pusht", "policy_preprocessor.json", {"revision": "legacy"}
         )
 
-    assert "--revision legacy" in exc_info.value.migration_command
+    error = exc_info.value
+    assert error.model_path == "lerobot/diffusion_pusht"
+    assert "migrate_policy_normalization.py" in error.migration_command
+    assert "--revision legacy" in error.migration_command
+    assert "policy_preprocessor.json" in error.original_error
+
+
+def test_load_config_missing_hub_processor_does_not_misclassify_other_models(tmp_path, monkeypatch):
+    """Test that non-LeRobot Hub configs retain the original missing-file error."""
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({"architectures": ["SomeModel"]}))
+
+    def fake_hf_hub_download(*, filename, **kwargs):  # noqa: ARG001
+        if filename == "config.json":
+            return str(config_path)
+        raise FileNotFoundError(filename)
+
+    monkeypatch.setattr("lerobot.processor.pipeline.hf_hub_download", fake_hf_hub_download)
+
+    with pytest.raises(FileNotFoundError, match="on the HuggingFace Hub"):
+        DataProcessorPipeline._load_config("someone/model", "policy_preprocessor.json", {})
 
 
 def test_hub_migration_detection_is_conservative(tmp_path, monkeypatch):


### PR DESCRIPTION
﻿## Summary
- When `from_pretrained` drops legacy in-policy normalization keys (`normalize_*.buffer_*`), emit an actionable warning pointing at `migrate_policy_normalization.py`.
- Include Hub `--revision` in that migration command when a non-default revision was loaded.
- Add focused unit tests for the warning path (Hub-side `ProcessorMigrationError` already landed in #4261).

Complements #4261 / addresses the silent-failure path discussed in #4047.

## Test plan
- [x] `pytest tests/policies/test_legacy_normalization_warning.py`
- [x] Related processor Hub helper tests
- [ ] CI green on this PR

Note: Re-uploading migrated official `lerobot/*` Hub checkpoints still needs org write access (out of scope).
