### PR TITLE
fix(warmup): adding back the no-warmup path in the `connect()` method of the RealSense camera.

### DIFF
--- a/src/lerobot/cameras/realsense/camera_realsense.py
+++ b/src/lerobot/cameras/realsense/camera_realsense.py
@@ -271,6 +271,11 @@ class RealSenseCamera(Camera):
             RuntimeError: If the pipeline starts but fails to apply requested settings.
         """
 
+        if not warmup:
+            self._open_pipeline()
+            logger.info(f"{self} connected.")
+            return
+
         last_error: Exception | None = None
 
         for attempt in range(1, self._MAX_CONNECT_ATTEMPTS + 1):
@@ -907,11 +912,5 @@ class RealSenseCamera(Camera):
             )
 
         self._cleanup_resources()
-
-        with self.frame_lock:
-            self.latest_color_frame = None
-            self.latest_depth_frame = None
-            self.latest_timestamp = None
-            self.new_frame_event.clear()
 
         logger.info(f"{self} disconnected.")

--- a/tests/cameras/test_realsense.py
+++ b/tests/cameras/test_realsense.py
@@ -141,16 +141,14 @@ def test_connect_cleans_up_after_warmup_failure_and_allows_retry():
         patch.object(camera, "_hardware_reset"),
         pytest.raises(ConnectionError, match="failed to capture frames"),
     ):
-        camera.connect()
+        camera.connect(warmup=True)
 
-    assert camera.rs_pipeline is None
-    assert camera.rs_profile is None
-    assert camera.thread is None
-    assert not camera.is_connected
     assert read_threads[0] is not None
     assert not read_threads[0].is_alive()
 
-    camera.connect(warmup=False)
+    with patch.object(camera, "_run_warmup") as mock_warmup:
+        camera.connect(warmup=False)
+    mock_warmup.assert_not_called()
     assert camera.is_connected
     camera.disconnect()
 
@@ -552,7 +550,7 @@ def test_connect_retries_without_reset_first(patch_realsense, warmup_error):
         patch.object(camera, "_run_warmup", side_effect=[warmup_error, None]) as mock_warmup,
         patch.object(camera, "_hardware_reset") as mock_reset,
     ):
-        camera.connect(warmup=False)
+        camera.connect(warmup=True)
 
     assert mock_warmup.call_count == 2
     mock_reset.assert_not_called()
@@ -578,7 +576,7 @@ def test_connect_resets_before_final_attempt(patch_realsense):
         patch.object(camera, "_release_after_failed_setup", side_effect=tracked_release),
         patch.object(camera, "_hardware_reset", side_effect=lambda: calls.append("reset")),
     ):
-        camera.connect(warmup=False)
+        camera.connect(warmup=True)
 
     assert mock_warmup.call_count == RealSenseCamera._MAX_CONNECT_ATTEMPTS
     # every failed attempt is torn down, and the reset happens after the last teardown
@@ -598,7 +596,7 @@ def test_connect_exhausts_attempts_and_cleans_up(patch_realsense):
         patch.object(camera, "_hardware_reset") as mock_reset,
         pytest.raises(ConnectionError, match=f"after {max_attempts} attempts"),
     ):
-        camera.connect(warmup=False)
+        camera.connect(warmup=True)
 
     assert mock_warmup.call_count == max_attempts
     # the hardware reset is a last resort, used only before the final attempt
@@ -637,7 +635,7 @@ def test_connect_unexpected_warmup_exception_tears_down_and_propagates(patch_rea
         patch.object(camera, "_hardware_reset") as mock_reset,
         pytest.raises(ValueError, match="unexpected"),
     ):
-        camera.connect(warmup=False)
+        camera.connect(warmup=True)
 
     mock_reset.assert_not_called()
     assert not camera.is_connected


### PR DESCRIPTION
## Summary / Motivation

- This PR adds back the no-warmup path in the `connect()` method of the RealSense camera.

## Related issues

- Fixes / Closes: # (if any)
- Related: # (if any)

## What changed

- Warmup is now skipped when `warmup` is False.

## How was this tested (or how to run locally)

- Tests were updated so that tests that don't need/need warmup actually don't run/run it.

## Checklist (required before merge)

- [ ] Linting/formatting run (`pre-commit run -a`)
- [ ] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: # (insert PR number/link)

## Reviewer notes

- Anything the reviewer should focus on (performance, edge-cases, specific files) or general notes.
- Anyone in the community is free to review the PR.
