### PR TITLE
feat(dataset): add GStreamer encoding backend

### DIFF
--- a/docs/source/streaming_video_encoding.mdx
+++ b/docs/source/streaming_video_encoding.mdx
@@ -98,6 +98,57 @@ Use HW encoding when:
 > [!NOTE]
 > `libsvtav1` is the default because it provides the best training performance; other vcodecs can reduce CPU usage and be faster, but they typically produce larger files and may affect training time.
 
+### GStreamer Encoders
+
+The encoders above are FFmpeg encoders, reached through PyAV. Some platforms
+expose their video encoder only as GStreamer elements and have no FFmpeg
+encoder at all, so no `vcodec` value can select them. Setting
+`video_backend="gstreamer"` switches to a GStreamer pipeline for encoding. The
+output is an ordinary MP4, identical in kind to what the PyAV backend writes.
+
+NVIDIA Jetson is the current case. Its encoder is provided by the
+`nvvideo4linux2` plugin:
+
+| Encoder | Platform | CLI Value |
+| ------- | -------- | --------- |
+| `nvv4l2av1enc` | NVIDIA Jetson | `--dataset.rgb_encoder.vcodec=nvv4l2av1enc --dataset.rgb_encoder.video_backend=gstreamer` |
+| `nvv4l2h265enc` | NVIDIA Jetson | `--dataset.rgb_encoder.vcodec=nvv4l2h265enc --dataset.rgb_encoder.video_backend=gstreamer` |
+| `nvv4l2h264enc` | NVIDIA Jetson | `--dataset.rgb_encoder.vcodec=nvv4l2h264enc --dataset.rgb_encoder.video_backend=gstreamer` |
+
+`vcodec=auto` works on this backend too and probes the GStreamer encoders
+rather than the FFmpeg ones.
+
+```bash
+lerobot-record \
+  --dataset.rgb_encoder.video_backend=gstreamer \
+  --dataset.rgb_encoder.vcodec=auto \
+  --dataset.streaming_encoding=true ...
+```
+
+> [!NOTE]
+> On Jetson, `vcodec=auto` with the default `pyav` backend selects
+> `h264_nvenc` and then fails to open it. PyAV reports that encoder as
+> available because it is compiled into the bundled FFmpeg, but Jetson's
+> encoder is not reachable through the desktop NVENC API. Use
+> `video_backend=gstreamer` there.
+
+> [!NOTE]
+> This backend requires the GStreamer Python bindings and the platform's
+> encoder plugins — on Debian/Ubuntu, `python3-gi`, `gir1.2-gstreamer-1.0` and
+> `gir1.2-gst-plugins-base-1.0`. These are system packages, so a virtualenv
+> must be created with `--system-site-packages` to see them.
+
+> [!NOTE]
+> `crf` maps to a fixed quantizer range on encoders that expose one. Encoders
+> that only accept a bitrate (such as `nvv4l2av1enc`) derive a target from
+> `crf` and the frame size; pass
+> `--dataset.rgb_encoder.extra_options='{"bitrate": 20000000}'` to set one
+> explicitly. Hardware encoders also reject frame sizes below a
+> device-specific minimum.
+
+> [!NOTE]
+> Depth features are encoded with PyAV regardless of this setting.
+
 ## 5. Troubleshooting
 
 | Symptom                                                            | Likely Cause                                 | Fix                                                                                                                                                                                                                                                                                              |

--- a/docs/source/streaming_video_encoding.mdx
+++ b/docs/source/streaming_video_encoding.mdx
@@ -109,9 +109,9 @@ output is an ordinary MP4, identical in kind to what the PyAV backend writes.
 NVIDIA Jetson is the current case. Its encoder is provided by the
 `nvvideo4linux2` plugin:
 
-| Encoder | Platform | CLI Value |
-| ------- | -------- | --------- |
-| `nvv4l2av1enc` | NVIDIA Jetson | `--dataset.rgb_encoder.vcodec=nvv4l2av1enc --dataset.rgb_encoder.video_backend=gstreamer` |
+| Encoder         | Platform      | CLI Value                                                                                  |
+| --------------- | ------------- | ------------------------------------------------------------------------------------------ |
+| `nvv4l2av1enc`  | NVIDIA Jetson | `--dataset.rgb_encoder.vcodec=nvv4l2av1enc --dataset.rgb_encoder.video_backend=gstreamer`  |
 | `nvv4l2h265enc` | NVIDIA Jetson | `--dataset.rgb_encoder.vcodec=nvv4l2h265enc --dataset.rgb_encoder.video_backend=gstreamer` |
 | `nvv4l2h264enc` | NVIDIA Jetson | `--dataset.rgb_encoder.vcodec=nvv4l2h264enc --dataset.rgb_encoder.video_backend=gstreamer` |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -454,6 +454,8 @@ default.extend-ignore-identifiers-re = [
     "OT_VALUE",
     "VanderBilt",
     "seperated_timestep",
+    "gir",
+    "trak",
 ]
 
 # TODO: Uncomment when ready to use

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -499,6 +499,8 @@ default.extend-ignore-identifiers-re = [
     "OT_VALUE",
     "VanderBilt",
     "seperated_timestep",
+    "gir",
+    "trak",
 ]
 
 # Docstring coverage gate. `fail-under` is a RATCHET, not a target: it is set just below the currently

--- a/src/lerobot/configs/video.py
+++ b/src/lerobot/configs/video.py
@@ -38,8 +38,10 @@ HW_VIDEO_CODECS = [
     "h264_vaapi",  # Linux Intel/AMD
     "h264_qsv",  # Intel Quick Sync
 ]
+GST_VIDEO_CODECS: list[str] = ["nvv4l2av1enc", "nvv4l2h265enc", "nvv4l2h264enc"]
+
 VALID_VIDEO_CODECS: frozenset[str] = frozenset(
-    {"h264", "hevc", "libsvtav1", "libaom-av1", "auto", *HW_VIDEO_CODECS}
+    {"h264", "hevc", "libsvtav1", "libaom-av1", "auto", *HW_VIDEO_CODECS, *GST_VIDEO_CODECS}
 )
 # Aliases for legacy video codec names.
 VIDEO_CODECS_ALIASES: dict[str, str] = {"av1": "libsvtav1"}
@@ -94,7 +96,7 @@ class VideoEncoderConfig:
     fast_decode: int = 0  # Fast-decode tuning. Accepted values are codec-specific, 0 disables it.
     # TODO(CarolinePascal): add torchcodec support + find a way to unify the
     # two backends (encoding and decoding).
-    video_backend: str = "pyav"  # Encoding backend. Only "pyav" is currently supported.
+    video_backend: str = "pyav"  # Encoding backend: "pyav" or "gstreamer".
     # Extra codec options merged last, e.g. {"tune": "film"}.
     extra_options: dict[str, Any] = field(default_factory=dict)
 
@@ -155,6 +157,10 @@ class VideoEncoderConfig:
             from lerobot.datasets import detect_available_encoders_pyav
 
             return detect_available_encoders_pyav(encoders)
+        if self.video_backend == "gstreamer":
+            from lerobot.datasets.gstreamer_utils import detect_available_encoders_gst
+
+            return detect_available_encoders_gst(encoders)
         return []
 
     def validate(self) -> None:
@@ -166,6 +172,14 @@ class VideoEncoderConfig:
             check_video_encoder_parameters_pyav(
                 self.vcodec, self.pix_fmt, self.get_codec_options(), channels=self._DEFAULT_CHANNELS
             )
+        elif self.video_backend == "gstreamer":
+            from lerobot.datasets.gstreamer_utils import GST_VIDEO_CODECS as _GST_ELEMENTS
+
+            if self.vcodec not in _GST_ELEMENTS:
+                raise ValueError(
+                    f"vcodec {self.vcodec!r} is not a GStreamer encoder. With "
+                    f"video_backend='gstreamer', use one of {sorted(_GST_ELEMENTS)}."
+                )
 
     def resolve_vcodec(self) -> None:
         """Check ``vcodec`` and, when it is ``"auto"``, pick a concrete encoder.
@@ -180,8 +194,9 @@ class VideoEncoderConfig:
         if self.vcodec not in VALID_VIDEO_CODECS:
             raise ValueError(f"Invalid vcodec '{self.vcodec}'. Must be one of: {sorted(VALID_VIDEO_CODECS)}")
         if self.vcodec == "auto":
-            available = self.detect_available_encoders(HW_VIDEO_CODECS)
-            for encoder in HW_VIDEO_CODECS:
+            candidates = GST_VIDEO_CODECS if self.video_backend == "gstreamer" else HW_VIDEO_CODECS
+            available = self.detect_available_encoders(candidates)
+            for encoder in candidates:
                 if encoder in available:
                     logger.info(f"Auto-selected video codec: {encoder}")
                     self.vcodec = encoder
@@ -213,6 +228,12 @@ class VideoEncoderConfig:
         def set_if(key: str, value: Any) -> None:
             if value is not None:
                 opts[key] = value if not as_strings else str(value)
+
+        if self.video_backend == "gstreamer":
+            from lerobot.datasets.gstreamer_utils import gst_codec_options
+
+            gst_opts = gst_codec_options(self.vcodec, self.crf, self.preset, self.g, self.extra_options)
+            return {k: str(v) for k, v in gst_opts.items()} if as_strings else gst_opts
 
         # GOP size is not a codec-specific option, so it is always set.
         set_if("g", self.g)

--- a/src/lerobot/datasets/gstreamer_utils.py
+++ b/src/lerobot/datasets/gstreamer_utils.py
@@ -1,0 +1,323 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""GStreamer encoding backend.
+
+Every entry in :data:`lerobot.configs.video.HW_VIDEO_CODECS` is an FFmpeg
+encoder name, reached through PyAV. Some platforms expose their video encoder
+only as GStreamer elements and have no FFmpeg encoder at all, so no ``vcodec``
+value can select them. This module is a second implementation behind
+:attr:`~lerobot.configs.video.VideoEncoderConfig.video_backend` for those
+platforms.
+
+NVIDIA Jetson is the current case. Its encoder is provided by the
+``nvvideo4linux2`` GStreamer plugin. PyAV reports ``h264_nvenc`` as available
+there because it is compiled into the bundled FFmpeg, but opening it fails
+with ``OpenEncodeSessionEx: unsupported device``, so ``vcodec="auto"`` on the
+PyAV backend selects an encoder that cannot run rather than falling back to
+software.
+
+The output is an ordinary MP4, identical in kind to what the PyAV backend
+produces. Only the way the encoder is driven differs.
+
+Requires the GStreamer Python bindings (``python3-gi``,
+``gir1.2-gstreamer-1.0``) and the platform's encoder plugins.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+GST_VIDEO_CODECS: dict[str, str] = {
+    "nvv4l2h264enc": "h264parse",
+    "nvv4l2h265enc": "h265parse",
+    "nvv4l2av1enc": "av1parse",
+}
+
+GST_HW_CODEC_PREFERENCE: list[str] = ["nvv4l2av1enc", "nvv4l2h265enc", "nvv4l2h264enc"]
+
+GST_BITRATE_ONLY_CODECS: frozenset[str] = frozenset({"nvv4l2av1enc"})
+
+_EOS_TIMEOUT_NS = 30 * 1_000_000_000
+
+_BPP_AT_CRF30 = 0.89
+
+_GST_INITIALISED = False
+
+
+def _gst():
+    """Import and initialise GStreamer once, raising ImportError if unavailable."""
+    global _GST_INITIALISED
+    try:
+        import gi
+
+        gi.require_version("Gst", "1.0")
+        from gi.repository import Gst  # noqa: N806
+    except (ImportError, ValueError) as e:
+        raise ImportError(
+            "The GStreamer encoding backend requires the GStreamer Python bindings. "
+            "On Debian/Ubuntu: apt install python3-gi gir1.2-gstreamer-1.0 "
+            "gir1.2-gst-plugins-base-1.0. These are system packages, so a virtualenv "
+            "must be created with --system-site-packages to see them."
+        ) from e
+
+    if not _GST_INITIALISED:
+        Gst.init(None)
+        _GST_INITIALISED = True
+    return Gst
+
+
+def is_gstreamer_available() -> bool:
+    """Whether the GStreamer backend can be used on this machine."""
+    try:
+        _gst()
+    except ImportError:
+        return False
+    return True
+
+
+def detect_available_encoders_gst(encoders: list[str] | str) -> list[str]:
+    """Return the subset of ``encoders`` that can be instantiated on this machine.
+
+    Both registration and instantiation are checked, so an element whose plugin
+    is installed but whose device is absent is reported as unavailable.
+    """
+    if isinstance(encoders, str):
+        encoders = [encoders]
+    try:
+        gst = _gst()
+    except ImportError:
+        return []
+
+    available = []
+    for name in encoders:
+        factory = gst.ElementFactory.find(name)
+        if factory is None:
+            continue
+        element = factory.create(None)
+        if element is None:
+            continue
+        available.append(name)
+    return available
+
+
+def gst_codec_options(
+    vcodec: str,
+    crf: int | float | None,
+    preset: int | str | None,
+    g: int | None,
+    extra_options: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Translate encoder settings into GStreamer element properties.
+
+    ``g`` maps to ``iframeinterval`` and ``idrinterval``.
+
+    ``crf`` maps to a fixed ``qp-range`` with ``control-rate=0`` on elements
+    that expose a quantizer. Elements in :data:`GST_BITRATE_ONLY_CODECS` expose
+    only ``bitrate``; for those the mapping needs the frame size and rate and is
+    applied by :class:`GStreamerVideoWriter`. Pass
+    ``extra_options={"bitrate": ...}`` to set a target explicitly.
+
+    ``preset`` maps to ``preset-level``, accepting either the integer the
+    element takes or one of ``ultrafast``/``fast``/``medium``/``slow``.
+    """
+    opts: dict[str, Any] = {}
+
+    if g is not None:
+        opts["iframeinterval"] = int(g)
+        opts["idrinterval"] = int(g)
+
+    if vcodec not in GST_BITRATE_ONLY_CODECS and crf is not None:
+        qp = max(0, min(51, int(crf)))
+        opts["control-rate"] = 0
+        opts["qp-range"] = f"{qp},{qp}:{qp},{qp}:{qp},{qp}"
+
+    if preset is not None:
+        named = {"ultrafast": 1, "fast": 2, "medium": 3, "slow": 4}
+        opts["preset-level"] = int(preset) if not isinstance(preset, str) else named.get(preset, 4)
+
+    for k, v in (extra_options or {}).items():
+        opts.setdefault(k, v)
+    return opts
+
+
+def default_bitrate_for_crf(width: int, height: int, fps: float, crf: int | float | None) -> int:
+    """Bitrate target for elements that expose no quantizer control.
+
+    Scales bits-per-pixel with ``crf`` so the setting keeps its usual direction.
+    The curve is anchored on the rate ``libsvtav1`` produces at the same ``crf``
+    on camera footage, so switching a dataset to a bitrate-only encoder lands
+    near the size it had before rather than silently much smaller.
+
+    This is a heuristic, not an equivalence: the rate a quantizer produces
+    depends on the content, and easy footage will undershoot the target. Set
+    ``extra_options={"bitrate": ...}`` when the rate matters.
+    """
+    crf = 30 if crf is None else float(crf)
+    bpp = _BPP_AT_CRF30 * (0.5 ** ((crf - 30.0) / 8.0))
+    return max(100_000, int(width * height * fps * bpp))
+
+
+class GStreamerVideoWriter:
+    """Encode RGB frames to an MP4 through a GStreamer pipeline.
+
+    Construct, :meth:`write` frames in order, then :meth:`close`. The pipeline is
+    ``appsrc -> <converter> -> <encoder> -> <parser> -> mp4mux -> filesink``.
+
+    Where ``nvvidconv`` is available it transfers frames into the memory the
+    encoder reads from; otherwise the pipeline stays in system memory.
+    """
+
+    def __init__(
+        self,
+        video_path: str | Path,
+        fps: int,
+        width: int,
+        height: int,
+        vcodec: str,
+        options: dict[str, Any] | None = None,
+        crf: int | float | None = None,
+    ):
+        gst = _gst()
+        self._gst = gst
+        self.video_path = Path(video_path)
+        self.fps = int(fps)
+        self.width = int(width)
+        self.height = int(height)
+        self.vcodec = vcodec
+        self.frame_count = 0
+        self._closed = False
+        self._use_nvmm = gst.ElementFactory.find("nvvidconv") is not None
+
+        if vcodec not in GST_VIDEO_CODECS:
+            raise ValueError(
+                f"Unsupported GStreamer video codec {vcodec!r}. Supported: {sorted(GST_VIDEO_CODECS)}"
+            )
+
+        opts = dict(options or {})
+        if vcodec in GST_BITRATE_ONLY_CODECS and "bitrate" not in opts:
+            opts["bitrate"] = default_bitrate_for_crf(self.width, self.height, self.fps, crf)
+            opts.setdefault("control-rate", 0)
+        self.options = opts
+
+        self.video_path.parent.mkdir(parents=True, exist_ok=True)
+        self._build_pipeline()
+
+    def _build_pipeline(self) -> None:
+        gst = self._gst
+        parser = GST_VIDEO_CODECS[self.vcodec]
+        props = " ".join(f"{k}={v}" for k, v in self.options.items())
+        convert = "videoconvert ! video/x-raw,format=NV12 ! "
+        if self._use_nvmm:
+            convert += "nvvidconv ! video/x-raw(memory:NVMM),format=NV12 ! "
+        desc = (
+            f"appsrc name=src is-live=false block=true format=time "
+            f"caps=video/x-raw,format=RGB,width={self.width},height={self.height},"
+            f"framerate={self.fps}/1 "
+            f"! {convert}"
+            f"{self.vcodec} {props} ! {parser} ! mp4mux ! "
+            f"filesink location={self.video_path} sync=false"
+        )
+        logger.debug("GStreamer encode pipeline: %s", desc)
+        self.pipeline = gst.parse_launch(desc)
+        self.appsrc = self.pipeline.get_by_name("src")
+        self.appsrc.set_property("max-bytes", 8 * self.width * self.height * 3)
+
+        ret = self.pipeline.set_state(gst.State.PLAYING)
+        if ret == gst.StateChangeReturn.FAILURE:
+            self.pipeline.set_state(gst.State.NULL)
+            self._drain_errors(raise_on_error=True)
+            raise RuntimeError(f"GStreamer pipeline failed to start for {self.video_path}")
+
+    def _drain_errors(self, raise_on_error: bool = False) -> None:
+        """Surface pipeline errors, which GStreamer reports on the bus."""
+        gst = self._gst
+        bus = self.pipeline.get_bus()
+        while True:
+            msg = bus.pop_filtered(gst.MessageType.ERROR | gst.MessageType.WARNING)
+            if msg is None:
+                return
+            err, debug = msg.parse_error() if msg.type == gst.MessageType.ERROR else msg.parse_warning()
+            text = f"GStreamer ({self.vcodec}): {err.message} [{debug}]"
+            if msg.type == gst.MessageType.ERROR:
+                if raise_on_error:
+                    raise RuntimeError(text)
+                logger.error(text)
+            else:
+                logger.warning(text)
+
+    def write(self, frame_rgb: np.ndarray) -> None:
+        """Push one HWC uint8 RGB frame."""
+        if self._closed:
+            raise RuntimeError("write() called after close()")
+        gst = self._gst
+        if frame_rgb.shape[:2] != (self.height, self.width):
+            raise ValueError(
+                f"frame is {frame_rgb.shape[1]}x{frame_rgb.shape[0]}, "
+                f"pipeline expects {self.width}x{self.height}"
+            )
+        data = np.ascontiguousarray(frame_rgb, dtype=np.uint8).tobytes()
+        buf = gst.Buffer.new_wrapped(data)
+        duration = int(gst.SECOND / self.fps)
+        buf.pts = self.frame_count * duration
+        buf.dts = buf.pts
+        buf.duration = duration
+        ret = self.appsrc.emit("push-buffer", buf)
+        if ret != gst.FlowReturn.OK:
+            self._drain_errors()
+            raise RuntimeError(f"GStreamer push-buffer returned {ret!r} for {self.video_path}")
+        self.frame_count += 1
+        self._raise_if_failed()
+
+    def _raise_if_failed(self) -> None:
+        """Encoders can fail asynchronously once data flows, which a successful
+        ``push-buffer`` does not reveal. Polling the bus is non-blocking."""
+        gst = self._gst
+        msg = self.pipeline.get_bus().pop_filtered(gst.MessageType.ERROR)
+        if msg is None:
+            return
+        err, debug = msg.parse_error()
+        raise RuntimeError(
+            f"GStreamer encoder {self.vcodec} failed for {self.width}x{self.height}: "
+            f"{err.message} [{debug}]. Hardware encoders reject frame sizes below their "
+            f"supported minimum; try a larger resolution or a different vcodec."
+        )
+
+    def close(self) -> None:
+        """Flush the encoder and finalise the container. Idempotent."""
+        if self._closed:
+            return
+        self._closed = True
+        gst = self._gst
+        self.appsrc.emit("end-of-stream")
+        bus = self.pipeline.get_bus()
+        msg = bus.timed_pop_filtered(_EOS_TIMEOUT_NS, gst.MessageType.EOS | gst.MessageType.ERROR)
+        self.pipeline.set_state(gst.State.NULL)
+        if msg is None:
+            raise RuntimeError(f"GStreamer encode timed out finalising {self.video_path}")
+        if msg.type == gst.MessageType.ERROR:
+            err, debug = msg.parse_error()
+            raise RuntimeError(f"GStreamer encode failed: {err.message} [{debug}]")
+
+    def __enter__(self) -> GStreamerVideoWriter:
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self.close()

--- a/src/lerobot/datasets/gstreamer_utils.py
+++ b/src/lerobot/datasets/gstreamer_utils.py
@@ -165,7 +165,7 @@ def gst_codec_options(
 
     The codec's parameter-set repetition (``insert-sps-pps`` / ``insert-seq-hdr``)
     is enabled for every element in :data:`GST_HEADER_INSERTION_PROPERTY`. It is
-    not optional: without it the file plays but cannot be seeked, so a dataset
+    not optional: without it the file plays but seeking fails, so a dataset
     recorded through this backend cannot be trained on.
 
     ``crf`` maps to a fixed ``qp-range`` with ``control-rate=0`` on elements
@@ -187,7 +187,7 @@ def gst_codec_options(
 
     # Repeat the parameter set at every IDR so the sync samples the muxer
     # advertises are genuinely decodable. Without this the output plays but
-    # cannot be seeked, and therefore cannot be trained on.
+    # does not support seeking, and therefore cannot be trained on.
     header_property = GST_HEADER_INSERTION_PROPERTY.get(vcodec)
     if header_property is not None:
         opts[header_property] = 1

--- a/src/lerobot/datasets/gstreamer_utils.py
+++ b/src/lerobot/datasets/gstreamer_utils.py
@@ -56,6 +56,29 @@ GST_HW_CODEC_PREFERENCE: list[str] = ["nvv4l2av1enc", "nvv4l2h265enc", "nvv4l2h2
 
 GST_BITRATE_ONLY_CODECS: frozenset[str] = frozenset({"nvv4l2av1enc"})
 
+# The nvv4l2 encoders write the codec's parameter set ONCE, at the start of the
+# stream: insert-sps-pps (H.264/H.265) and insert-seq-hdr (AV1) both default to
+# false. The muxer still lists every intra frame in the container's stss table as
+# a sync sample, so the file advertises random access it cannot honour -- a
+# decoder that jumps to one of those frames has never seen the parameter set and
+# fails with "Invalid data found when processing input".
+#
+# Playback is unaffected, because playing starts at frame 0 and picks the header
+# up there. Only seeking breaks. That makes the failure invisible at record time
+# and invisible in a dataset viewer, and it surfaces only when something trains
+# on the data -- which is random access by definition.
+GST_HEADER_INSERTION_PROPERTY: dict[str, str] = {
+    "nvv4l2h264enc": "insert-sps-pps",
+    "nvv4l2h265enc": "insert-sps-pps",
+    "nvv4l2av1enc": "insert-seq-hdr",
+}
+
+# idrinterval defaults to 256 on these elements while iframeinterval defaults to
+# 30. Repeating the parameter set only helps at IDR frames, so leaving the two
+# mismatched means a seek still decodes up to 255 frames to reach its target.
+# Matching them makes each intra frame a real random-access point.
+GST_DEFAULT_GOP: int = 30
+
 _EOS_TIMEOUT_NS = 30 * 1_000_000_000
 
 _BPP_AT_CRF30 = 0.89
@@ -136,7 +159,14 @@ def gst_codec_options(
 ) -> dict[str, Any]:
     """Translate encoder settings into GStreamer element properties.
 
-    ``g`` maps to ``iframeinterval`` and ``idrinterval``.
+    ``g`` maps to ``iframeinterval`` and ``idrinterval``, which are set together
+    even when ``g`` is ``None`` so the element's mismatched defaults (30 and 256)
+    do not make seeking needlessly slow.
+
+    The codec's parameter-set repetition (``insert-sps-pps`` / ``insert-seq-hdr``)
+    is enabled for every element in :data:`GST_HEADER_INSERTION_PROPERTY`. It is
+    not optional: without it the file plays but cannot be seeked, so a dataset
+    recorded through this backend cannot be trained on.
 
     ``crf`` maps to a fixed ``qp-range`` with ``control-rate=0`` on elements
     that expose a quantizer. Elements in :data:`GST_BITRATE_ONLY_CODECS` expose
@@ -149,9 +179,18 @@ def gst_codec_options(
     """
     opts: dict[str, Any] = {}
 
-    if g is not None:
-        opts["iframeinterval"] = int(g)
-        opts["idrinterval"] = int(g)
+    # Always set both, even when the caller passed no ``g``: the element defaults
+    # (iframeinterval 30, idrinterval 256) disagree, and the gap costs seek time.
+    gop = GST_DEFAULT_GOP if g is None else int(g)
+    opts["iframeinterval"] = gop
+    opts["idrinterval"] = gop
+
+    # Repeat the parameter set at every IDR so the sync samples the muxer
+    # advertises are genuinely decodable. Without this the output plays but
+    # cannot be seeked, and therefore cannot be trained on.
+    header_property = GST_HEADER_INSERTION_PROPERTY.get(vcodec)
+    if header_property is not None:
+        opts[header_property] = 1
 
     if vcodec not in GST_BITRATE_ONLY_CODECS and crf is not None:
         qp = max(0, min(51, int(crf)))

--- a/src/lerobot/datasets/gstreamer_utils.py
+++ b/src/lerobot/datasets/gstreamer_utils.py
@@ -61,6 +61,12 @@ _BPP_AT_CRF30 = 0.89
 
 _MP4_TIMESCALE = 12000
 
+
+def _gst_quote(value: Any) -> str:
+    escaped = str(value).replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
 _GST_INITIALISED = False
 
 
@@ -236,7 +242,7 @@ class GStreamerVideoWriter:
             f"! {convert}"
             f"{self.vcodec} {props} ! {parser} ! "
             f"mp4mux trak-timescale={_MP4_TIMESCALE} ! "
-            f"filesink location={self.video_path} sync=false"
+            f"filesink location={_gst_quote(self.video_path)} sync=false"
         )
         logger.debug("GStreamer encode pipeline: %s", desc)
         self.pipeline = gst.parse_launch(desc)

--- a/src/lerobot/datasets/gstreamer_utils.py
+++ b/src/lerobot/datasets/gstreamer_utils.py
@@ -325,6 +325,25 @@ class GStreamerVideoWriter:
             err, debug = msg.parse_error()
             raise RuntimeError(f"GStreamer encode failed: {err.message} [{debug}]")
 
+    def __del__(self) -> None:
+        """Return the pipeline to NULL if it is dropped without close().
+
+        GStreamer requires elements to reach the NULL state before the final
+        reference goes away. Dropping a PLAYING pipeline aborts the process, so
+        a caller that raises between construction and close() would take the
+        interpreter down with it rather than surface the error.
+        """
+        if getattr(self, "_closed", True):
+            return
+        pipeline = getattr(self, "pipeline", None)
+        gst = getattr(self, "_gst", None)
+        if pipeline is None or gst is None:
+            return
+        try:
+            pipeline.set_state(gst.State.NULL)
+        except Exception:
+            pass
+
     def __enter__(self) -> GStreamerVideoWriter:
         return self
 

--- a/src/lerobot/datasets/gstreamer_utils.py
+++ b/src/lerobot/datasets/gstreamer_utils.py
@@ -59,6 +59,8 @@ _EOS_TIMEOUT_NS = 30 * 1_000_000_000
 
 _BPP_AT_CRF30 = 0.89
 
+_MP4_TIMESCALE = 12000
+
 _GST_INITIALISED = False
 
 
@@ -232,7 +234,8 @@ class GStreamerVideoWriter:
             f"caps=video/x-raw,format=RGB,width={self.width},height={self.height},"
             f"framerate={self.fps}/1 "
             f"! {convert}"
-            f"{self.vcodec} {props} ! {parser} ! mp4mux ! "
+            f"{self.vcodec} {props} ! {parser} ! "
+            f"mp4mux trak-timescale={_MP4_TIMESCALE} ! "
             f"filesink location={self.video_path} sync=false"
         )
         logger.debug("GStreamer encode pipeline: %s", desc)

--- a/src/lerobot/datasets/gstreamer_utils.py
+++ b/src/lerobot/datasets/gstreamer_utils.py
@@ -37,6 +37,7 @@ Requires the GStreamer Python bindings (``python3-gi``,
 
 from __future__ import annotations
 
+import contextlib
 import logging
 from pathlib import Path
 from typing import Any
@@ -339,10 +340,8 @@ class GStreamerVideoWriter:
         gst = getattr(self, "_gst", None)
         if pipeline is None or gst is None:
             return
-        try:
+        with contextlib.suppress(Exception):
             pipeline.set_state(gst.State.NULL)
-        except Exception:
-            pass
 
     def __enter__(self) -> GStreamerVideoWriter:
         return self

--- a/src/lerobot/datasets/video_utils.py
+++ b/src/lerobot/datasets/video_utils.py
@@ -492,6 +492,25 @@ def encode_video_frames(
     with Image.open(input_list[0]) as dummy_image:
         width, height = dummy_image.size
 
+    if video_encoder.video_backend == "gstreamer":
+        if is_depth:
+            raise NotImplementedError("Depth encoding is only supported with video_backend='pyav'.")
+        from .gstreamer_utils import GStreamerVideoWriter
+
+        with GStreamerVideoWriter(
+            video_path=video_path,
+            fps=fps,
+            width=width,
+            height=height,
+            vcodec=vcodec,
+            options=video_encoder.get_codec_options(encoder_threads),
+            crf=video_encoder.crf,
+        ) as writer:
+            for path in input_list:
+                with Image.open(path) as img:
+                    writer.write(np.asarray(img.convert("RGB")))
+        return
+
     video_options = video_encoder.get_codec_options(encoder_threads, as_strings=True)
 
     # Set logging level
@@ -782,6 +801,8 @@ class _CameraEncoderThread(threading.Thread):
 
         container = None
         output_stream = None
+        gst_writer = None
+        use_gstreamer = self.video_encoder.video_backend == "gstreamer" and not self.is_depth
         stats_tracker = RunningQuantileStats()
         frame_count = 0
 
@@ -808,8 +829,22 @@ class _CameraEncoderThread(threading.Thread):
                     if not self.is_depth and frame_data.dtype != np.uint8:
                         frame_data = (frame_data * 255).astype(np.uint8)
 
+                if use_gstreamer and gst_writer is None:
+                    from .gstreamer_utils import GStreamerVideoWriter
+
+                    height, width = frame_data.shape[:2]
+                    gst_writer = GStreamerVideoWriter(
+                        video_path=self.video_path,
+                        fps=self.fps,
+                        width=width,
+                        height=height,
+                        vcodec=self.video_encoder.vcodec,
+                        options=self.video_encoder.get_codec_options(self.encoder_threads),
+                        crf=self.video_encoder.crf,
+                    )
+
                 # Open container on first frame (to get width/height)
-                if container is None:
+                if container is None and not use_gstreamer:
                     height, width = frame_data.shape[:2]
                     Path(self.video_path).parent.mkdir(parents=True, exist_ok=True)
                     container = av.open(str(self.video_path), "w")
@@ -824,7 +859,9 @@ class _CameraEncoderThread(threading.Thread):
                     output_stream.time_base = Fraction(1, self.fps)
 
                 # Encode frame with explicit timestamps
-                if not self.is_depth:
+                if use_gstreamer:
+                    gst_writer.write(frame_data)
+                elif not self.is_depth:
                     pil_img = Image.fromarray(frame_data)
                     video_frame = av.VideoFrame.from_image(pil_img)
                 else:
@@ -836,11 +873,12 @@ class _CameraEncoderThread(threading.Thread):
                         use_log=self.video_encoder.use_log,
                         video_backend=self.video_encoder.video_backend,
                     )
-                video_frame.pts = frame_count
-                video_frame.time_base = Fraction(1, self.fps)
-                packet = output_stream.encode(video_frame)
-                if packet:
-                    container.mux(packet)
+                if not use_gstreamer:
+                    video_frame.pts = frame_count
+                    video_frame.time_base = Fraction(1, self.fps)
+                    packet = output_stream.encode(video_frame)
+                    if packet:
+                        container.mux(packet)
 
                 # Update stats with downsampled frame (per-channel stats like compute_episode_stats)
                 img_chw = frame_data.transpose(2, 0, 1)  # HWC -> CHW
@@ -853,6 +891,9 @@ class _CameraEncoderThread(threading.Thread):
                 frame_count += 1
 
             # Flush encoder
+            if gst_writer is not None:
+                gst_writer.close()
+
             if output_stream is not None:
                 packet = output_stream.encode()
                 if packet:
@@ -875,6 +916,9 @@ class _CameraEncoderThread(threading.Thread):
             if container is not None:
                 with contextlib.suppress(Exception):
                     container.close()
+            if gst_writer is not None:
+                with contextlib.suppress(Exception):
+                    gst_writer.close()
             self.result_queue.put(("error", str(e)))
 
 

--- a/tests/datasets/test_datasets.py
+++ b/tests/datasets/test_datasets.py
@@ -1553,7 +1553,10 @@ def test_valid_video_codecs_constant():
     assert "h264_qsv" in VALID_VIDEO_CODECS
     assert "hevc_videotoolbox" in VALID_VIDEO_CODECS
     assert "hevc_nvenc" in VALID_VIDEO_CODECS
-    assert len(VALID_VIDEO_CODECS) == 11
+    assert "nvv4l2h264enc" in VALID_VIDEO_CODECS
+    assert "nvv4l2h265enc" in VALID_VIDEO_CODECS
+    assert "nvv4l2av1enc" in VALID_VIDEO_CODECS
+    assert len(VALID_VIDEO_CODECS) == 14
 
 
 def test_delta_timestamps_with_episodes_filter(tmp_path, empty_lerobot_dataset_factory):

--- a/tests/datasets/test_gstreamer_dataset_trainable.py
+++ b/tests/datasets/test_gstreamer_dataset_trainable.py
@@ -28,13 +28,12 @@ ROOT = Path(tempfile.gettempdir()) / "nvenc_seek_validation"
 REPO = "turnkeyrobo/nvenc_seek_validation"
 W, H, FPS = 640, 360, 30
 EPISODES, FRAMES = 4, 90
-CAMERAS = ["observation.images.left_wrist", "observation.images.right_wrist",
-           "observation.images.top"]
+CAMERAS = ["observation.images.left_wrist", "observation.images.right_wrist", "observation.images.top"]
 FAILURES: list[str] = []
 
 
 def check(name, ok, detail=""):
-    print("  %s  %s%s" % ("PASS" if ok else "FAIL", name, ("  " + detail) if detail else ""))
+    print("  {}  {}{}".format("PASS" if ok else "FAIL", name, ("  " + detail) if detail else ""))
     if not ok:
         FAILURES.append(name)
 
@@ -56,17 +55,19 @@ def main() -> None:
 
     features = {
         "action": {"dtype": "float32", "shape": [14], "names": [f"j{i}" for i in range(14)]},
-        "observation.state": {"dtype": "float32", "shape": [14],
-                              "names": [f"j{i}" for i in range(14)]},
+        "observation.state": {"dtype": "float32", "shape": [14], "names": [f"j{i}" for i in range(14)]},
     }
     for cam in CAMERAS:
-        features[cam] = {"dtype": "video", "shape": [H, W, 3],
-                         "names": ["height", "width", "channels"]}
+        features[cam] = {"dtype": "video", "shape": [H, W, 3], "names": ["height", "width", "channels"]}
 
     print("=== writing a dataset through the production path (gstreamer/NVENC) ===")
     ds = LeRobotDataset.create(
-        repo_id=REPO, fps=FPS, features=features, root=str(ROOT),
-        robot_type="tkr_yam", use_videos=True,
+        repo_id=REPO,
+        fps=FPS,
+        features=features,
+        root=str(ROOT),
+        robot_type="tkr_yam",
+        use_videos=True,
         rgb_encoder=RGBEncoderConfig(video_backend="gstreamer", vcodec="nvv4l2av1enc", crf=30),
     )
     for ep in range(EPISODES):
@@ -82,18 +83,20 @@ def main() -> None:
         # Serialise the per-camera encoders: three concurrent NVENC sessions
         # exhaust the Orin's encoder and fail with 'Cuda failure: status=3'.
         ds.save_episode(parallel_encoding=False)
-        print("    episode %d written" % ep)
+        print(f"    episode {ep} written")
     ds.finalize()
 
     print("=== the encoder actually used ===")
     import glob
+
     vids = sorted(glob.glob(str(ROOT / "videos" / "**" / "*.mp4"), recursive=True))
-    check("videos were produced", len(vids) >= 3, "%d files" % len(vids))
+    check("videos were produced", len(vids) >= 3, f"{len(vids)} files")
     for v in vids[:3]:
-        print("    %s  %.1f MB" % (Path(v).name, Path(v).stat().st_size / 1e6))
+        print(f"    {Path(v).name}  {Path(v).stat().st_size / 1e6:.1f} MB")
 
     print("=== every video seeks (this is what was broken) ===")
     from torchcodec.decoders import VideoDecoder
+
     all_ok = True
     for v in vids:
         d = VideoDecoder(v)
@@ -106,16 +109,17 @@ def main() -> None:
                 bad.append(t)
         all_ok &= not bad
         if bad:
-            print("    %s FAILED at %s" % (Path(v).name, bad))
+            print(f"    {Path(v).name} FAILED at {bad}")
     check("all videos seekable", all_ok)
 
     print("=== reload and read in SHUFFLED order, as training does ===")
     ds2 = LeRobotDataset(REPO, root=str(ROOT))
-    check("frame count", len(ds2) == EPISODES * FRAMES, "%d" % len(ds2))
+    check("frame count", len(ds2) == EPISODES * FRAMES, f"{len(ds2)}")
 
     g = torch.Generator().manual_seed(0)
-    dl = torch.utils.data.DataLoader(ds2, batch_size=8, shuffle=True, num_workers=2,
-                                     generator=g, drop_last=True)
+    dl = torch.utils.data.DataLoader(
+        ds2, batch_size=8, shuffle=True, num_workers=2, generator=g, drop_last=True
+    )
     seen, batches = 0, 0
     try:
         for batch in dl:
@@ -130,7 +134,7 @@ def main() -> None:
     except Exception as e:
         ok = False
         err = str(e).splitlines()[-1][:90]
-    check("shuffled DataLoader reads batches", ok, err or "%d batches, %d samples" % (batches, seen))
+    check("shuffled DataLoader reads batches", ok, err or f"{batches} batches, {seen} samples")
 
     print("=== random single-frame access matches sequential ===")
     idx = [7, 45, 130, 200, 310]
@@ -146,7 +150,7 @@ def main() -> None:
 
     print()
     if FAILURES:
-        print("FAILED: %d" % len(FAILURES))
+        print(f"FAILED: {len(FAILURES)}")
         for f in FAILURES:
             print("  -", f)
         raise SystemExit(1)

--- a/tests/datasets/test_gstreamer_dataset_trainable.py
+++ b/tests/datasets/test_gstreamer_dataset_trainable.py
@@ -19,7 +19,11 @@ import tempfile
 from pathlib import Path
 
 import numpy as np
+import pytest
 import torch
+
+pytest.importorskip("datasets", reason="datasets is required (install lerobot[dataset])")
+
 
 from lerobot.configs.video import RGBEncoderConfig
 from lerobot.datasets.lerobot_dataset import LeRobotDataset
@@ -39,7 +43,7 @@ def check(name, ok, detail=""):
 
 
 def frame(ep: int, i: int, cam: int) -> np.ndarray:
-    """Distinct per (episode, frame, camera) so a mis-seek is detectable."""
+    """Distinct per (episode, frame, camera) so a bad seek is detectable."""
     rng = np.random.default_rng(ep * 100000 + i * 10 + cam)
     x = np.linspace(0, 255, W, dtype=np.float32)[None, :]
     y = np.linspace(0, 255, H, dtype=np.float32)[:, None]

--- a/tests/datasets/test_gstreamer_dataset_trainable.py
+++ b/tests/datasets/test_gstreamer_dataset_trainable.py
@@ -1,0 +1,157 @@
+"""End-to-end validation: can a dataset written through the NVENC path be TRAINED on?
+
+The encoder-level test proves seeking works. This proves the thing that actually
+matters: a LeRobotDataset written by the production code path
+(LeRobotDataset.create -> add_frame -> save_episode, video_backend="gstreamer")
+can be read by a shuffled DataLoader, which is how training reads it.
+
+Requires hardware with an nvv4l2 encoder. Synthetic frames are sufficient because
+the bug is in the encoder, not in the pixel content.
+
+Encoders are serialised (parallel_encoding=False): three concurrent NVENC
+sessions exhaust the Orin's encoder and fail with "Cuda failure: status=3".
+"""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import torch
+
+from lerobot.configs.video import RGBEncoderConfig
+from lerobot.datasets.lerobot_dataset import LeRobotDataset
+
+ROOT = Path(tempfile.gettempdir()) / "nvenc_seek_validation"
+REPO = "turnkeyrobo/nvenc_seek_validation"
+W, H, FPS = 640, 360, 30
+EPISODES, FRAMES = 4, 90
+CAMERAS = ["observation.images.left_wrist", "observation.images.right_wrist",
+           "observation.images.top"]
+FAILURES: list[str] = []
+
+
+def check(name, ok, detail=""):
+    print("  %s  %s%s" % ("PASS" if ok else "FAIL", name, ("  " + detail) if detail else ""))
+    if not ok:
+        FAILURES.append(name)
+
+
+def frame(ep: int, i: int, cam: int) -> np.ndarray:
+    """Distinct per (episode, frame, camera) so a mis-seek is detectable."""
+    rng = np.random.default_rng(ep * 100000 + i * 10 + cam)
+    x = np.linspace(0, 255, W, dtype=np.float32)[None, :]
+    y = np.linspace(0, 255, H, dtype=np.float32)[:, None]
+    base = ((x + y + i * 4 + ep * 40 + cam * 80) % 256).astype(np.uint8)
+    rgb = np.stack([base, np.roll(base, i * 2, 1), np.roll(base, -i * 2, 0)], -1)
+    rgb = np.clip(rgb.astype(np.int16) + rng.integers(-6, 6, rgb.shape), 0, 255)
+    return rgb.astype(np.uint8)
+
+
+def main() -> None:
+    if ROOT.exists():
+        shutil.rmtree(ROOT)
+
+    features = {
+        "action": {"dtype": "float32", "shape": [14], "names": [f"j{i}" for i in range(14)]},
+        "observation.state": {"dtype": "float32", "shape": [14],
+                              "names": [f"j{i}" for i in range(14)]},
+    }
+    for cam in CAMERAS:
+        features[cam] = {"dtype": "video", "shape": [H, W, 3],
+                         "names": ["height", "width", "channels"]}
+
+    print("=== writing a dataset through the production path (gstreamer/NVENC) ===")
+    ds = LeRobotDataset.create(
+        repo_id=REPO, fps=FPS, features=features, root=str(ROOT),
+        robot_type="tkr_yam", use_videos=True,
+        rgb_encoder=RGBEncoderConfig(video_backend="gstreamer", vcodec="nvv4l2av1enc", crf=30),
+    )
+    for ep in range(EPISODES):
+        for i in range(FRAMES):
+            f = {
+                "action": np.full(14, ep + i * 0.001, dtype=np.float32),
+                "observation.state": np.full(14, ep + i * 0.001, dtype=np.float32),
+                "task": "nvenc seek validation",
+            }
+            for c, cam in enumerate(CAMERAS):
+                f[cam] = frame(ep, i, c)
+            ds.add_frame(f)
+        # Serialise the per-camera encoders: three concurrent NVENC sessions
+        # exhaust the Orin's encoder and fail with 'Cuda failure: status=3'.
+        ds.save_episode(parallel_encoding=False)
+        print("    episode %d written" % ep)
+    ds.finalize()
+
+    print("=== the encoder actually used ===")
+    import glob
+    vids = sorted(glob.glob(str(ROOT / "videos" / "**" / "*.mp4"), recursive=True))
+    check("videos were produced", len(vids) >= 3, "%d files" % len(vids))
+    for v in vids[:3]:
+        print("    %s  %.1f MB" % (Path(v).name, Path(v).stat().st_size / 1e6))
+
+    print("=== every video seeks (this is what was broken) ===")
+    from torchcodec.decoders import VideoDecoder
+    all_ok = True
+    for v in vids:
+        d = VideoDecoder(v)
+        n = d.metadata.num_frames
+        bad = []
+        for t in [t for t in (5, 30, 60, 89, n - 2) if 0 <= t < n]:
+            try:
+                d.get_frames_at(indices=[t])
+            except Exception:
+                bad.append(t)
+        all_ok &= not bad
+        if bad:
+            print("    %s FAILED at %s" % (Path(v).name, bad))
+    check("all videos seekable", all_ok)
+
+    print("=== reload and read in SHUFFLED order, as training does ===")
+    ds2 = LeRobotDataset(REPO, root=str(ROOT))
+    check("frame count", len(ds2) == EPISODES * FRAMES, "%d" % len(ds2))
+
+    g = torch.Generator().manual_seed(0)
+    dl = torch.utils.data.DataLoader(ds2, batch_size=8, shuffle=True, num_workers=2,
+                                     generator=g, drop_last=True)
+    seen, batches = 0, 0
+    try:
+        for batch in dl:
+            batches += 1
+            seen += batch["action"].shape[0]
+            for cam in CAMERAS:
+                assert cam in batch, cam
+            if batches >= 12:
+                break
+        ok = True
+        err = ""
+    except Exception as e:
+        ok = False
+        err = str(e).splitlines()[-1][:90]
+    check("shuffled DataLoader reads batches", ok, err or "%d batches, %d samples" % (batches, seen))
+
+    print("=== random single-frame access matches sequential ===")
+    idx = [7, 45, 130, 200, 310]
+    mism = []
+    for i in idx:
+        if i >= len(ds2):
+            continue
+        a = ds2[i][CAMERAS[0]]
+        b = ds2[i][CAMERAS[0]]
+        if not torch.allclose(a, b):
+            mism.append(i)
+    check("repeated random access is deterministic", not mism, str(mism))
+
+    print()
+    if FAILURES:
+        print("FAILED: %d" % len(FAILURES))
+        for f in FAILURES:
+            print("  -", f)
+        raise SystemExit(1)
+    print("DATASET WRITTEN THROUGH NVENC IS TRAINABLE")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/datasets/test_gstreamer_encoder.py
+++ b/tests/datasets/test_gstreamer_encoder.py
@@ -19,6 +19,8 @@
 import numpy as np
 import pytest
 
+pytest.importorskip("datasets", reason="datasets is required (install lerobot[dataset])")
+
 from lerobot.configs.video import GST_VIDEO_CODECS, RGBEncoderConfig
 from lerobot.datasets.gstreamer_utils import (
     GST_BITRATE_ONLY_CODECS,

--- a/tests/datasets/test_gstreamer_encoder.py
+++ b/tests/datasets/test_gstreamer_encoder.py
@@ -219,6 +219,33 @@ class TestEncoding:
                 tmp_path / "o.mp4", fps=10, width=FRAME_W, height=FRAME_H, vcodec="libsvtav1"
             )
 
+    def test_output_can_be_concatenated_repeatedly(self, tmp_path, codec, frames):
+        """A dataset grows by remuxing: each episode is concatenated onto the
+        accumulated file, so this writer's output becomes an input to the next
+        concatenation. Two generations is the case that matters — the first
+        append can succeed while the second fails, if the muxer and the remux
+        disagree on the track timescale."""
+        av = pytest.importorskip("av")
+        from lerobot.datasets.gstreamer_utils import GStreamerVideoWriter
+        from lerobot.datasets.video_utils import concatenate_video_files
+
+        def clip(path):
+            with GStreamerVideoWriter(path, fps=10, width=FRAME_W, height=FRAME_H,
+                                      vcodec=codec, crf=30) as w:
+                for frame in frames:
+                    w.write(frame)
+            return path
+
+        acc = clip(tmp_path / "e1.mp4")
+        for episode in range(2, 4):
+            out = tmp_path / f"acc{episode}.mp4"
+            concatenate_video_files([acc, clip(tmp_path / f"e{episode}.mp4")],
+                                    out, compatibility_check=False)
+            acc = out
+
+        with av.open(str(acc)) as container:
+            assert sum(1 for _ in container.decode(video=0)) == 3 * len(frames)
+
     def test_auto_selects_an_available_encoder(self):
         cfg = RGBEncoderConfig(vcodec="auto", video_backend="gstreamer")
         assert cfg.vcodec in _available_gst_encoders()

--- a/tests/datasets/test_gstreamer_encoder.py
+++ b/tests/datasets/test_gstreamer_encoder.py
@@ -230,8 +230,7 @@ class TestEncoding:
         from lerobot.datasets.video_utils import concatenate_video_files
 
         def clip(path):
-            with GStreamerVideoWriter(path, fps=10, width=FRAME_W, height=FRAME_H,
-                                      vcodec=codec, crf=30) as w:
+            with GStreamerVideoWriter(path, fps=10, width=FRAME_W, height=FRAME_H, vcodec=codec, crf=30) as w:
                 for frame in frames:
                     w.write(frame)
             return path
@@ -239,8 +238,7 @@ class TestEncoding:
         acc = clip(tmp_path / "e1.mp4")
         for episode in range(2, 4):
             out = tmp_path / f"acc{episode}.mp4"
-            concatenate_video_files([acc, clip(tmp_path / f"e{episode}.mp4")],
-                                    out, compatibility_check=False)
+            concatenate_video_files([acc, clip(tmp_path / f"e{episode}.mp4")], out, compatibility_check=False)
             acc = out
 
         with av.open(str(acc)) as container:
@@ -253,8 +251,7 @@ class TestEncoding:
         from lerobot.datasets.gstreamer_utils import GStreamerVideoWriter
 
         out = tmp_path / "a directory" / "a file.mp4"
-        with GStreamerVideoWriter(out, fps=10, width=FRAME_W, height=FRAME_H,
-                                  vcodec=codec, crf=30) as writer:
+        with GStreamerVideoWriter(out, fps=10, width=FRAME_W, height=FRAME_H, vcodec=codec, crf=30) as writer:
             for frame in frames:
                 writer.write(frame)
         assert out.stat().st_size > 0

--- a/tests/datasets/test_gstreamer_encoder.py
+++ b/tests/datasets/test_gstreamer_encoder.py
@@ -16,6 +16,10 @@
 
 """Tests for the GStreamer encoding backend."""
 
+import subprocess
+import sys
+import textwrap
+
 import numpy as np
 import pytest
 
@@ -201,6 +205,30 @@ class TestEncoding:
         writer.write(frames[0])
         writer.close()
         writer.close()
+
+    def test_dropping_a_writer_without_closing_does_not_abort(self, tmp_path, codec):
+        """Runs out of process: the failure this guards against is a SIGSEGV."""
+        script = textwrap.dedent(f"""
+            import gc
+            import numpy as np
+            from lerobot.datasets.gstreamer_utils import GStreamerVideoWriter
+
+            frame = np.zeros(({FRAME_H}, {FRAME_W}, 3), dtype=np.uint8)
+            for i in range(3):
+                path = r"{tmp_path}" + "/drop_%d.mp4" % i
+                w = GStreamerVideoWriter(
+                    path, fps=10, width={FRAME_W}, height={FRAME_H},
+                    vcodec="{codec}", crf=30)
+                w.write(frame)
+                del w
+                gc.collect()
+            print("survived")
+        """)
+        result = subprocess.run(
+            [sys.executable, "-c", script], capture_output=True, text=True, timeout=60
+        )
+        assert result.returncode == 0, f"exit {result.returncode}: {result.stderr[-2000:]}"
+        assert "survived" in result.stdout
 
     def test_write_after_close_raises(self, tmp_path, codec, frames):
         from lerobot.datasets.gstreamer_utils import GStreamerVideoWriter

--- a/tests/datasets/test_gstreamer_encoder.py
+++ b/tests/datasets/test_gstreamer_encoder.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the GStreamer encoding backend."""
+
+import numpy as np
+import pytest
+
+from lerobot.configs.video import GST_VIDEO_CODECS, RGBEncoderConfig
+from lerobot.datasets.gstreamer_utils import (
+    GST_BITRATE_ONLY_CODECS,
+    default_bitrate_for_crf,
+    detect_available_encoders_gst,
+    gst_codec_options,
+    is_gstreamer_available,
+)
+
+FRAME_W, FRAME_H = 320, 256
+
+_gst_missing = pytest.mark.skipif(
+    not is_gstreamer_available(), reason="GStreamer Python bindings are not installed"
+)
+
+
+def _available_gst_encoders() -> list[str]:
+    if not is_gstreamer_available():
+        return []
+    return detect_available_encoders_gst(GST_VIDEO_CODECS)
+
+
+_no_gst_encoder = pytest.mark.skipif(
+    len(_available_gst_encoders()) == 0,
+    reason="no GStreamer hardware encoder available on this machine",
+)
+
+
+class TestCodecOptions:
+    """Option translation is pure, so it is testable without an encoder."""
+
+    def test_gop_maps_to_iframe_interval(self):
+        opts = gst_codec_options("nvv4l2h265enc", crf=None, preset=None, g=2)
+        assert opts["iframeinterval"] == 2
+        assert opts["idrinterval"] == 2
+
+    def test_crf_maps_to_fixed_qp_range(self):
+        opts = gst_codec_options("nvv4l2h265enc", crf=28, preset=None, g=None)
+        assert opts["control-rate"] == 0
+        assert opts["qp-range"] == "28,28:28,28:28,28"
+
+    def test_crf_is_clamped_to_the_valid_quantizer_range(self):
+        assert gst_codec_options("nvv4l2h265enc", crf=999, preset=None, g=None)["qp-range"].startswith("51,")
+        assert gst_codec_options("nvv4l2h265enc", crf=-5, preset=None, g=None)["qp-range"].startswith("0,")
+
+    def test_bitrate_only_codecs_get_no_qp_range(self):
+        for codec in GST_BITRATE_ONLY_CODECS:
+            opts = gst_codec_options(codec, crf=30, preset=None, g=2)
+            assert "qp-range" not in opts
+
+    def test_named_and_numeric_presets(self):
+        assert gst_codec_options("nvv4l2h265enc", None, "ultrafast", None)["preset-level"] == 1
+        assert gst_codec_options("nvv4l2h265enc", None, 3, None)["preset-level"] == 3
+
+    def test_extra_options_do_not_override_derived_ones(self):
+        opts = gst_codec_options(
+            "nvv4l2h265enc", crf=30, preset=None, g=2, extra_options={"iframeinterval": 60, "vbv-size": 4}
+        )
+        assert opts["iframeinterval"] == 2
+        assert opts["vbv-size"] == 4
+
+    def test_default_bitrate_falls_with_rising_crf(self):
+        high = default_bitrate_for_crf(1920, 1080, 30, crf=10)
+        low = default_bitrate_for_crf(1920, 1080, 30, crf=45)
+        assert high > low
+        assert low >= 100_000
+
+    def test_default_bitrate_scales_with_pixel_rate(self):
+        small = default_bitrate_for_crf(640, 480, 30, crf=30)
+        big = default_bitrate_for_crf(1920, 1080, 30, crf=30)
+        assert big > small
+
+
+class TestConfigIntegration:
+    def test_gstreamer_codecs_are_valid_vcodec_values(self):
+        cfg = RGBEncoderConfig(vcodec="nvv4l2h265enc", video_backend="gstreamer")
+        assert cfg.vcodec == "nvv4l2h265enc"
+
+    def test_ffmpeg_codec_is_rejected_on_the_gstreamer_backend(self):
+        with pytest.raises(ValueError):
+            RGBEncoderConfig(vcodec="libsvtav1", video_backend="gstreamer")
+
+    def test_get_codec_options_returns_gstreamer_properties(self):
+        cfg = RGBEncoderConfig(vcodec="nvv4l2h265enc", video_backend="gstreamer", crf=30, g=2)
+        opts = cfg.get_codec_options()
+        assert "iframeinterval" in opts
+        assert "crf" not in opts
+
+    def test_as_strings_stringifies_every_value(self):
+        cfg = RGBEncoderConfig(vcodec="nvv4l2h265enc", video_backend="gstreamer", crf=30, g=2)
+        assert all(isinstance(v, str) for v in cfg.get_codec_options(as_strings=True).values())
+
+    def test_pyav_backend_is_unaffected(self):
+        cfg = RGBEncoderConfig(vcodec="libsvtav1")
+        opts = cfg.get_codec_options()
+        assert opts["crf"] == 30
+        assert "iframeinterval" not in opts
+
+
+@_gst_missing
+class TestEncoderDetection:
+    def test_detection_returns_a_subset_of_what_was_asked_for(self):
+        found = detect_available_encoders_gst(GST_VIDEO_CODECS)
+        assert set(found).issubset(set(GST_VIDEO_CODECS))
+
+    def test_unknown_element_is_not_reported_available(self):
+        assert detect_available_encoders_gst(["definitely_not_an_element"]) == []
+
+    def test_a_bare_string_is_accepted(self):
+        assert isinstance(detect_available_encoders_gst("definitely_not_an_element"), list)
+
+
+@_gst_missing
+@_no_gst_encoder
+class TestEncoding:
+    """Round trips against a real encoder, skipped where none exists."""
+
+    @pytest.fixture
+    def codec(self):
+        return _available_gst_encoders()[0]
+
+    @pytest.fixture
+    def frames(self):
+        rng = np.random.default_rng(0)
+        base = rng.integers(0, 255, (FRAME_H, FRAME_W, 3), dtype=np.uint8)
+        return [np.roll(base, i, axis=1) for i in range(20)]
+
+    def test_writes_a_decodable_video_with_every_frame(self, tmp_path, codec, frames):
+        av = pytest.importorskip("av")
+        from lerobot.datasets.gstreamer_utils import GStreamerVideoWriter
+
+        out = tmp_path / "out.mp4"
+        h, w, _ = frames[0].shape
+        with GStreamerVideoWriter(out, fps=10, width=w, height=h, vcodec=codec, crf=30) as writer:
+            for frame in frames:
+                writer.write(frame)
+
+        assert out.stat().st_size > 0
+        with av.open(str(out)) as container:
+            stream = container.streams.video[0]
+            assert (stream.codec_context.width, stream.codec_context.height) == (w, h)
+            assert sum(1 for _ in container.decode(video=0)) == len(frames)
+
+    def test_streaming_encoder_end_to_end(self, tmp_path, codec, frames):
+        av = pytest.importorskip("av")
+        from lerobot.datasets.video_utils import StreamingVideoEncoder
+
+        encoder = StreamingVideoEncoder(
+            fps=10,
+            rgb_encoder=RGBEncoderConfig(vcodec=codec, video_backend="gstreamer", crf=30),
+        )
+        key = "observation.images.cam"
+        encoder.start_episode([key], tmp_path)
+        for frame in frames:
+            encoder.feed_frame(key, frame)
+        results = encoder.finish_episode()
+        encoder.close()
+
+        path, _ = results[key]
+        with av.open(str(path)) as container:
+            assert sum(1 for _ in container.decode(video=0)) == len(frames)
+
+    def test_wrong_frame_size_is_rejected(self, tmp_path, codec, frames):
+        from lerobot.datasets.gstreamer_utils import GStreamerVideoWriter
+
+        with (
+            GStreamerVideoWriter(
+                tmp_path / "o.mp4", fps=10, width=FRAME_W, height=FRAME_H, vcodec=codec
+            ) as writer,
+            pytest.raises(ValueError, match="pipeline expects"),
+        ):
+            writer.write(np.zeros((10, 10, 3), dtype=np.uint8))
+
+    def test_close_is_idempotent(self, tmp_path, codec, frames):
+        from lerobot.datasets.gstreamer_utils import GStreamerVideoWriter
+
+        writer = GStreamerVideoWriter(tmp_path / "o.mp4", fps=10, width=FRAME_W, height=FRAME_H, vcodec=codec)
+        writer.write(frames[0])
+        writer.close()
+        writer.close()
+
+    def test_write_after_close_raises(self, tmp_path, codec, frames):
+        from lerobot.datasets.gstreamer_utils import GStreamerVideoWriter
+
+        writer = GStreamerVideoWriter(tmp_path / "o.mp4", fps=10, width=FRAME_W, height=FRAME_H, vcodec=codec)
+        writer.write(frames[0])
+        writer.close()
+        with pytest.raises(RuntimeError, match="after close"):
+            writer.write(frames[0])
+
+    def test_unsupported_codec_name_raises(self, tmp_path):
+        from lerobot.datasets.gstreamer_utils import GStreamerVideoWriter
+
+        with pytest.raises(ValueError, match="Unsupported GStreamer video codec"):
+            GStreamerVideoWriter(
+                tmp_path / "o.mp4", fps=10, width=FRAME_W, height=FRAME_H, vcodec="libsvtav1"
+            )
+
+    def test_auto_selects_an_available_encoder(self):
+        cfg = RGBEncoderConfig(vcodec="auto", video_backend="gstreamer")
+        assert cfg.vcodec in _available_gst_encoders()

--- a/tests/datasets/test_gstreamer_encoder.py
+++ b/tests/datasets/test_gstreamer_encoder.py
@@ -99,6 +99,15 @@ class TestCodecOptions:
 
 
 class TestConfigIntegration:
+    @pytest.fixture(autouse=True)
+    def _encoders_available(self, monkeypatch):
+        """Whether an encoder exists is a property of the machine, not of the config."""
+        monkeypatch.setattr(
+            RGBEncoderConfig,
+            "detect_available_encoders",
+            lambda self, encoders: [encoders] if isinstance(encoders, str) else list(encoders),
+        )
+
     def test_gstreamer_codecs_are_valid_vcodec_values(self):
         cfg = RGBEncoderConfig(vcodec="nvv4l2h265enc", video_backend="gstreamer")
         assert cfg.vcodec == "nvv4l2h265enc"
@@ -224,9 +233,7 @@ class TestEncoding:
                 gc.collect()
             print("survived")
         """)
-        result = subprocess.run(
-            [sys.executable, "-c", script], capture_output=True, text=True, timeout=60
-        )
+        result = subprocess.run([sys.executable, "-c", script], capture_output=True, text=True, timeout=60)
         assert result.returncode == 0, f"exit {result.returncode}: {result.stderr[-2000:]}"
         assert "survived" in result.stdout
 

--- a/tests/datasets/test_gstreamer_encoder.py
+++ b/tests/datasets/test_gstreamer_encoder.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the GStreamer encoding backend."""
+
+import numpy as np
+import pytest
+
+from lerobot.configs.video import GST_VIDEO_CODECS, RGBEncoderConfig
+from lerobot.datasets.gstreamer_utils import (
+    GST_BITRATE_ONLY_CODECS,
+    default_bitrate_for_crf,
+    detect_available_encoders_gst,
+    gst_codec_options,
+    is_gstreamer_available,
+)
+
+FRAME_W, FRAME_H = 320, 256
+
+_gst_missing = pytest.mark.skipif(
+    not is_gstreamer_available(), reason="GStreamer Python bindings are not installed"
+)
+
+
+def _available_gst_encoders() -> list[str]:
+    if not is_gstreamer_available():
+        return []
+    return detect_available_encoders_gst(GST_VIDEO_CODECS)
+
+
+_no_gst_encoder = pytest.mark.skipif(
+    len(_available_gst_encoders()) == 0,
+    reason="no GStreamer hardware encoder available on this machine",
+)
+
+
+class TestCodecOptions:
+    """Option translation is pure, so it is testable without an encoder."""
+
+    def test_gop_maps_to_iframe_interval(self):
+        opts = gst_codec_options("nvv4l2h265enc", crf=None, preset=None, g=2)
+        assert opts["iframeinterval"] == 2
+        assert opts["idrinterval"] == 2
+
+    def test_crf_maps_to_fixed_qp_range(self):
+        opts = gst_codec_options("nvv4l2h265enc", crf=28, preset=None, g=None)
+        assert opts["control-rate"] == 0
+        assert opts["qp-range"] == "28,28:28,28:28,28"
+
+    def test_crf_is_clamped_to_the_valid_quantizer_range(self):
+        assert gst_codec_options("nvv4l2h265enc", crf=999, preset=None, g=None)["qp-range"].startswith("51,")
+        assert gst_codec_options("nvv4l2h265enc", crf=-5, preset=None, g=None)["qp-range"].startswith("0,")
+
+    def test_bitrate_only_codecs_skip_qp_range(self):
+        for codec in GST_BITRATE_ONLY_CODECS:
+            opts = gst_codec_options(codec, crf=30, preset=None, g=2)
+            assert "qp-range" not in opts
+
+    def test_named_and_numeric_presets(self):
+        assert gst_codec_options("nvv4l2h265enc", None, "ultrafast", None)["preset-level"] == 1
+        assert gst_codec_options("nvv4l2h265enc", None, 3, None)["preset-level"] == 3
+
+    def test_extra_options_do_not_override_derived_ones(self):
+        opts = gst_codec_options(
+            "nvv4l2h265enc", crf=30, preset=None, g=2, extra_options={"iframeinterval": 60, "vbv-size": 4}
+        )
+        assert opts["iframeinterval"] == 2
+        assert opts["vbv-size"] == 4
+
+    def test_default_bitrate_falls_with_rising_crf(self):
+        high = default_bitrate_for_crf(1920, 1080, 30, crf=10)
+        low = default_bitrate_for_crf(1920, 1080, 30, crf=45)
+        assert high > low
+        assert low >= 100_000
+
+    def test_default_bitrate_scales_with_pixel_rate(self):
+        small = default_bitrate_for_crf(640, 480, 30, crf=30)
+        big = default_bitrate_for_crf(1920, 1080, 30, crf=30)
+        assert big > small
+
+
+class TestConfigIntegration:
+    def test_gstreamer_codecs_are_valid_vcodec_values(self):
+        cfg = RGBEncoderConfig(vcodec="nvv4l2h265enc", video_backend="gstreamer")
+        assert cfg.vcodec == "nvv4l2h265enc"
+
+    def test_ffmpeg_codec_is_rejected_on_the_gstreamer_backend(self):
+        with pytest.raises(ValueError):
+            RGBEncoderConfig(vcodec="libsvtav1", video_backend="gstreamer")
+
+    def test_get_codec_options_returns_gstreamer_properties(self):
+        cfg = RGBEncoderConfig(vcodec="nvv4l2h265enc", video_backend="gstreamer", crf=30, g=2)
+        opts = cfg.get_codec_options()
+        assert "iframeinterval" in opts
+        assert "crf" not in opts
+
+    def test_as_strings_stringifies_every_value(self):
+        cfg = RGBEncoderConfig(vcodec="nvv4l2h265enc", video_backend="gstreamer", crf=30, g=2)
+        assert all(isinstance(v, str) for v in cfg.get_codec_options(as_strings=True).values())
+
+    def test_pyav_backend_is_unaffected(self):
+        cfg = RGBEncoderConfig(vcodec="libsvtav1")
+        opts = cfg.get_codec_options()
+        assert opts["crf"] == 30
+        assert "iframeinterval" not in opts
+
+
+@_gst_missing
+class TestEncoderDetection:
+    def test_detection_returns_a_subset_of_what_was_asked_for(self):
+        found = detect_available_encoders_gst(GST_VIDEO_CODECS)
+        assert set(found).issubset(set(GST_VIDEO_CODECS))
+
+    def test_unknown_element_is_not_reported_available(self):
+        assert detect_available_encoders_gst(["definitely_not_an_element"]) == []
+
+    def test_a_bare_string_is_accepted(self):
+        assert isinstance(detect_available_encoders_gst("definitely_not_an_element"), list)
+
+
+@_gst_missing
+@_no_gst_encoder
+class TestEncoding:
+    """Round trips against a real encoder, skipped where none exists."""
+
+    @pytest.fixture
+    def codec(self):
+        return _available_gst_encoders()[0]
+
+    @pytest.fixture
+    def frames(self):
+        rng = np.random.default_rng(0)
+        base = rng.integers(0, 255, (FRAME_H, FRAME_W, 3), dtype=np.uint8)
+        return [np.roll(base, i, axis=1) for i in range(20)]
+
+    def test_writes_a_decodable_video_with_every_frame(self, tmp_path, codec, frames):
+        av = pytest.importorskip("av")
+        from lerobot.datasets.gstreamer_utils import GStreamerVideoWriter
+
+        out = tmp_path / "out.mp4"
+        h, w, _ = frames[0].shape
+        with GStreamerVideoWriter(out, fps=10, width=w, height=h, vcodec=codec, crf=30) as writer:
+            for frame in frames:
+                writer.write(frame)
+
+        assert out.stat().st_size > 0
+        with av.open(str(out)) as container:
+            stream = container.streams.video[0]
+            assert (stream.codec_context.width, stream.codec_context.height) == (w, h)
+            assert sum(1 for _ in container.decode(video=0)) == len(frames)
+
+    def test_streaming_encoder_end_to_end(self, tmp_path, codec, frames):
+        av = pytest.importorskip("av")
+        from lerobot.datasets.video_utils import StreamingVideoEncoder
+
+        encoder = StreamingVideoEncoder(
+            fps=10,
+            rgb_encoder=RGBEncoderConfig(vcodec=codec, video_backend="gstreamer", crf=30),
+        )
+        key = "observation.images.cam"
+        encoder.start_episode([key], tmp_path)
+        for frame in frames:
+            encoder.feed_frame(key, frame)
+        results = encoder.finish_episode()
+        encoder.close()
+
+        path, _ = results[key]
+        with av.open(str(path)) as container:
+            assert sum(1 for _ in container.decode(video=0)) == len(frames)
+
+    def test_wrong_frame_size_is_rejected(self, tmp_path, codec, frames):
+        from lerobot.datasets.gstreamer_utils import GStreamerVideoWriter
+
+        with (
+            GStreamerVideoWriter(
+                tmp_path / "o.mp4", fps=10, width=FRAME_W, height=FRAME_H, vcodec=codec
+            ) as writer,
+            pytest.raises(ValueError, match="pipeline expects"),
+        ):
+            writer.write(np.zeros((10, 10, 3), dtype=np.uint8))
+
+    def test_close_is_idempotent(self, tmp_path, codec, frames):
+        from lerobot.datasets.gstreamer_utils import GStreamerVideoWriter
+
+        writer = GStreamerVideoWriter(tmp_path / "o.mp4", fps=10, width=FRAME_W, height=FRAME_H, vcodec=codec)
+        writer.write(frames[0])
+        writer.close()
+        writer.close()
+
+    def test_write_after_close_raises(self, tmp_path, codec, frames):
+        from lerobot.datasets.gstreamer_utils import GStreamerVideoWriter
+
+        writer = GStreamerVideoWriter(tmp_path / "o.mp4", fps=10, width=FRAME_W, height=FRAME_H, vcodec=codec)
+        writer.write(frames[0])
+        writer.close()
+        with pytest.raises(RuntimeError, match="after close"):
+            writer.write(frames[0])
+
+    def test_unsupported_codec_name_raises(self, tmp_path):
+        from lerobot.datasets.gstreamer_utils import GStreamerVideoWriter
+
+        with pytest.raises(ValueError, match="Unsupported GStreamer video codec"):
+            GStreamerVideoWriter(
+                tmp_path / "o.mp4", fps=10, width=FRAME_W, height=FRAME_H, vcodec="libsvtav1"
+            )
+
+    def test_auto_selects_an_available_encoder(self):
+        cfg = RGBEncoderConfig(vcodec="auto", video_backend="gstreamer")
+        assert cfg.vcodec in _available_gst_encoders()

--- a/tests/datasets/test_gstreamer_encoder.py
+++ b/tests/datasets/test_gstreamer_encoder.py
@@ -246,6 +246,19 @@ class TestEncoding:
         with av.open(str(acc)) as container:
             assert sum(1 for _ in container.decode(video=0)) == 3 * len(frames)
 
+    def test_path_containing_spaces(self, tmp_path, codec, frames):
+        """The pipeline is built as a text description, so an unquoted path
+        with a space ends the property and the remainder parses as another
+        element — failing with something misleading like `no element "my"`."""
+        from lerobot.datasets.gstreamer_utils import GStreamerVideoWriter
+
+        out = tmp_path / "a directory" / "a file.mp4"
+        with GStreamerVideoWriter(out, fps=10, width=FRAME_W, height=FRAME_H,
+                                  vcodec=codec, crf=30) as writer:
+            for frame in frames:
+                writer.write(frame)
+        assert out.stat().st_size > 0
+
     def test_auto_selects_an_available_encoder(self):
         cfg = RGBEncoderConfig(vcodec="auto", video_backend="gstreamer")
         assert cfg.vcodec in _available_gst_encoders()

--- a/tests/datasets/test_gstreamer_seekable.py
+++ b/tests/datasets/test_gstreamer_seekable.py
@@ -1,0 +1,141 @@
+"""Verify that the GStreamer backend's DEFAULT settings produce seekable video.
+
+This exercises the path a recording actually takes -- gst_codec_options() with no
+explicit overrides -- rather than hand-passing properties, because the bug was
+precisely that the defaults were wrong.
+
+A dataset is only usable for training if frames can be fetched in shuffled order,
+so "can I jump to an arbitrary frame" is the property under test, not "does it
+play".
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+import numpy as np
+from PIL import Image
+
+sys.path.insert(0, "/home/tk/lerobot/src")
+from lerobot.datasets.gstreamer_utils import (  # noqa: E402
+    GST_HEADER_INSERTION_PROPERTY,
+    GStreamerVideoWriter,
+    gst_codec_options,
+)
+
+W, H, FPS, N = 640, 360, 30, 240
+FAILURES: list[str] = []
+
+
+def check(name: str, ok: bool, detail: str = "") -> None:
+    print("  %s  %s%s" % ("PASS" if ok else "FAIL", name, ("  " + detail) if detail else ""))
+    if not ok:
+        FAILURES.append(name)
+
+
+def make_frames(d: Path) -> None:
+    rng = np.random.default_rng(0)
+    for i in range(N):
+        x = np.linspace(0, 255, W, dtype=np.float32)[None, :]
+        y = np.linspace(0, 255, H, dtype=np.float32)[:, None]
+        img = ((x + y + i * 3) % 256).astype(np.uint8)
+        rgb = np.stack([img, np.roll(img, i, axis=1), np.roll(img, -i, axis=0)], -1)
+        rgb = np.clip(rgb.astype(np.int16) + rng.integers(-8, 8, rgb.shape), 0, 255)
+        Image.fromarray(rgb.astype(np.uint8)).save(d / ("frame-%06d.png" % i))
+
+
+def seek_test(path: Path) -> tuple[bool, list[int]]:
+    from torchcodec.decoders import VideoDecoder
+
+    d = VideoDecoder(str(path))
+    n = d.metadata.num_frames or N
+    targets = [t for t in (31, 60, 97, 150, 200, n - 2) if 0 <= t < n]
+    failed = []
+    for t in targets:
+        try:
+            d.get_frames_at(indices=[t])
+        except Exception:
+            failed.append(t)
+    # batched, the way the dataloader asks
+    try:
+        d.get_frames_at(indices=[t for t in (45, 46, 120, 199) if t < n])
+    except Exception:
+        failed.append(-1)
+    return (not failed, failed)
+
+
+def main() -> None:
+    print("=== the option mapping is populated for every nvv4l2 encoder ===")
+    for codec, prop in sorted(GST_HEADER_INSERTION_PROPERTY.items()):
+        print("    %-18s -> %s" % (codec, prop))
+    check("all three nvv4l2 encoders covered", len(GST_HEADER_INSERTION_PROPERTY) == 3)
+
+    print("=== defaults now request header repetition + a matched GOP ===")
+    for codec in ("nvv4l2av1enc", "nvv4l2h264enc", "nvv4l2h265enc"):
+        opts = gst_codec_options(codec, crf=30, preset=None, g=None)
+        prop = GST_HEADER_INSERTION_PROPERTY[codec]
+        check("%s sets %s" % (codec, prop), opts.get(prop) == 1, str(opts.get(prop)))
+        check("%s idrinterval == iframeinterval" % codec,
+              opts.get("idrinterval") == opts.get("iframeinterval"),
+              "idr=%s iframe=%s" % (opts.get("idrinterval"), opts.get("iframeinterval")))
+
+    # extra_options is applied with setdefault, so it FILLS GAPS rather than
+    # overriding anything the function computed -- the same treatment crf, preset
+    # and g already get. Header insertion is therefore not disableable this way,
+    # which is intended: without it the output cannot be trained on, and the
+    # bitrate cost of repeating a header every 30 frames is a few dozen bytes.
+    print("=== header insertion is not silently overridable (by design) ===")
+    o = gst_codec_options("nvv4l2av1enc", crf=30, preset=None, g=None,
+                          extra_options={"insert-seq-hdr": 0})
+    check("extra_options cannot disable header insertion",
+          o.get("insert-seq-hdr") == 1, str(o.get("insert-seq-hdr")))
+    o = gst_codec_options("nvv4l2av1enc", crf=30, preset=None, g=90)
+    check("explicit g still honoured", o.get("idrinterval") == 90, str(o.get("idrinterval")))
+
+    print("=== end-to-end: encode with the DEFAULTS and seek ===")
+    tmp = Path(tempfile.mkdtemp(prefix="seekfix-"))
+    imgs = tmp / "imgs"
+    imgs.mkdir()
+    make_frames(imgs)
+
+    out = tmp / "default.mp4"
+    opts = gst_codec_options("nvv4l2av1enc", crf=30, preset=None, g=None)
+    with GStreamerVideoWriter(video_path=out, fps=FPS, width=W, height=H,
+                              vcodec="nvv4l2av1enc", options=opts, crf=30) as wr:
+        for p in sorted(imgs.glob("frame-*.png")):
+            with Image.open(p) as im:
+                wr.write(np.asarray(im.convert("RGB")))
+
+    ok, failed = seek_test(out)
+    check("seeking works with default options", ok, "" if ok else "failed at %s" % failed)
+
+    print("=== and the frames are real (not a decoder returning garbage) ===")
+    from torchcodec.decoders import VideoDecoder
+    d = VideoDecoder(str(out))
+    a = d.get_frames_at(indices=[100]).data[0].float()
+    b = d.get_frames_at(indices=[101]).data[0].float()
+    seq = None
+    for i, fr in enumerate(d):
+        if i == 100:
+            seq = fr.float()
+            break
+    diff_neighbour = float((a - b).abs().mean())
+    diff_vs_seq = float((a - seq).abs().mean()) if seq is not None else 999.0
+    check("seeked frame matches the same frame read sequentially",
+          diff_vs_seq < 2.0, "mean abs diff %.3f" % diff_vs_seq)
+    check("consecutive frames actually differ", diff_neighbour > 0.5,
+          "mean abs diff %.3f" % diff_neighbour)
+
+    print()
+    if FAILURES:
+        print("FAILED: %d" % len(FAILURES))
+        for f in FAILURES:
+            print("  -", f)
+        raise SystemExit(1)
+    print("ALL CHECKS PASSED")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/datasets/test_gstreamer_seekable.py
+++ b/tests/datasets/test_gstreamer_seekable.py
@@ -30,7 +30,7 @@ FAILURES: list[str] = []
 
 
 def check(name: str, ok: bool, detail: str = "") -> None:
-    print("  %s  %s%s" % ("PASS" if ok else "FAIL", name, ("  " + detail) if detail else ""))
+    print("  {}  {}{}".format("PASS" if ok else "FAIL", name, ("  " + detail) if detail else ""))
     if not ok:
         FAILURES.append(name)
 
@@ -43,7 +43,7 @@ def make_frames(d: Path) -> None:
         img = ((x + y + i * 3) % 256).astype(np.uint8)
         rgb = np.stack([img, np.roll(img, i, axis=1), np.roll(img, -i, axis=0)], -1)
         rgb = np.clip(rgb.astype(np.int16) + rng.integers(-8, 8, rgb.shape), 0, 255)
-        Image.fromarray(rgb.astype(np.uint8)).save(d / ("frame-%06d.png" % i))
+        Image.fromarray(rgb.astype(np.uint8)).save(d / f"frame-{i:06d}.png")
 
 
 def seek_test(path: Path) -> tuple[bool, list[int]]:
@@ -69,17 +69,19 @@ def seek_test(path: Path) -> tuple[bool, list[int]]:
 def main() -> None:
     print("=== the option mapping is populated for every nvv4l2 encoder ===")
     for codec, prop in sorted(GST_HEADER_INSERTION_PROPERTY.items()):
-        print("    %-18s -> %s" % (codec, prop))
+        print(f"    {codec:<18} -> {prop}")
     check("all three nvv4l2 encoders covered", len(GST_HEADER_INSERTION_PROPERTY) == 3)
 
     print("=== defaults now request header repetition + a matched GOP ===")
     for codec in ("nvv4l2av1enc", "nvv4l2h264enc", "nvv4l2h265enc"):
         opts = gst_codec_options(codec, crf=30, preset=None, g=None)
         prop = GST_HEADER_INSERTION_PROPERTY[codec]
-        check("%s sets %s" % (codec, prop), opts.get(prop) == 1, str(opts.get(prop)))
-        check("%s idrinterval == iframeinterval" % codec,
-              opts.get("idrinterval") == opts.get("iframeinterval"),
-              "idr=%s iframe=%s" % (opts.get("idrinterval"), opts.get("iframeinterval")))
+        check(f"{codec} sets {prop}", opts.get(prop) == 1, str(opts.get(prop)))
+        check(
+            f"{codec} idrinterval == iframeinterval",
+            opts.get("idrinterval") == opts.get("iframeinterval"),
+            "idr={} iframe={}".format(opts.get("idrinterval"), opts.get("iframeinterval")),
+        )
 
     # extra_options is applied with setdefault, so it FILLS GAPS rather than
     # overriding anything the function computed -- the same treatment crf, preset
@@ -87,10 +89,12 @@ def main() -> None:
     # which is intended: without it the output cannot be trained on, and the
     # bitrate cost of repeating a header every 30 frames is a few dozen bytes.
     print("=== header insertion is not silently overridable (by design) ===")
-    o = gst_codec_options("nvv4l2av1enc", crf=30, preset=None, g=None,
-                          extra_options={"insert-seq-hdr": 0})
-    check("extra_options cannot disable header insertion",
-          o.get("insert-seq-hdr") == 1, str(o.get("insert-seq-hdr")))
+    o = gst_codec_options("nvv4l2av1enc", crf=30, preset=None, g=None, extra_options={"insert-seq-hdr": 0})
+    check(
+        "extra_options cannot disable header insertion",
+        o.get("insert-seq-hdr") == 1,
+        str(o.get("insert-seq-hdr")),
+    )
     o = gst_codec_options("nvv4l2av1enc", crf=30, preset=None, g=90)
     check("explicit g still honoured", o.get("idrinterval") == 90, str(o.get("idrinterval")))
 
@@ -102,17 +106,19 @@ def main() -> None:
 
     out = tmp / "default.mp4"
     opts = gst_codec_options("nvv4l2av1enc", crf=30, preset=None, g=None)
-    with GStreamerVideoWriter(video_path=out, fps=FPS, width=W, height=H,
-                              vcodec="nvv4l2av1enc", options=opts, crf=30) as wr:
+    with GStreamerVideoWriter(
+        video_path=out, fps=FPS, width=W, height=H, vcodec="nvv4l2av1enc", options=opts, crf=30
+    ) as wr:
         for p in sorted(imgs.glob("frame-*.png")):
             with Image.open(p) as im:
                 wr.write(np.asarray(im.convert("RGB")))
 
     ok, failed = seek_test(out)
-    check("seeking works with default options", ok, "" if ok else "failed at %s" % failed)
+    check("seeking works with default options", ok, "" if ok else f"failed at {failed}")
 
     print("=== and the frames are real (not a decoder returning garbage) ===")
     from torchcodec.decoders import VideoDecoder
+
     d = VideoDecoder(str(out))
     a = d.get_frames_at(indices=[100]).data[0].float()
     b = d.get_frames_at(indices=[101]).data[0].float()
@@ -123,14 +129,16 @@ def main() -> None:
             break
     diff_neighbour = float((a - b).abs().mean())
     diff_vs_seq = float((a - seq).abs().mean()) if seq is not None else 999.0
-    check("seeked frame matches the same frame read sequentially",
-          diff_vs_seq < 2.0, "mean abs diff %.3f" % diff_vs_seq)
-    check("consecutive frames actually differ", diff_neighbour > 0.5,
-          "mean abs diff %.3f" % diff_neighbour)
+    check(
+        "seeked frame matches the same frame read sequentially",
+        diff_vs_seq < 2.0,
+        f"mean abs diff {diff_vs_seq:.3f}",
+    )
+    check("consecutive frames actually differ", diff_neighbour > 0.5, f"mean abs diff {diff_neighbour:.3f}")
 
     print()
     if FAILURES:
-        print("FAILED: %d" % len(FAILURES))
+        print(f"FAILED: {len(FAILURES)}")
         for f in FAILURES:
             print("  -", f)
         raise SystemExit(1)

--- a/tests/datasets/test_gstreamer_seekable.py
+++ b/tests/datasets/test_gstreamer_seekable.py
@@ -11,14 +11,15 @@ play".
 
 from __future__ import annotations
 
-import sys
 import tempfile
 from pathlib import Path
 
 import numpy as np
+import pytest
 from PIL import Image
 
-sys.path.insert(0, "/home/tk/lerobot/src")
+pytest.importorskip("datasets", reason="datasets is required (install lerobot[dataset])")
+
 from lerobot.datasets.gstreamer_utils import (  # noqa: E402
     GST_HEADER_INSERTION_PROPERTY,
     GStreamerVideoWriter,
@@ -130,7 +131,7 @@ def main() -> None:
     diff_neighbour = float((a - b).abs().mean())
     diff_vs_seq = float((a - seq).abs().mean()) if seq is not None else 999.0
     check(
-        "seeked frame matches the same frame read sequentially",
+        "frame fetched by seeking matches the same frame read sequentially",
         diff_vs_seq < 2.0,
         f"mean abs diff {diff_vs_seq:.3f}",
     )


### PR DESCRIPTION
## Type / Scope

- **Type**: Feature
- **Scope**: datasets

## Summary / Motivation

Every encoder in `HW_VIDEO_CODECS` is an FFmpeg encoder name, reached through PyAV. That covers desktop GPUs, VideoToolbox, VAAPI and QSV, but it leaves out platforms whose video engine has **no FFmpeg encoder at all** — for those, no `vcodec` value can select the hardware, and streaming encoding falls back to CPU.

NVIDIA Jetson is the motivating case. Its encoder is provided by the `nvvideo4linux2` GStreamer plugin and is not exposed through FFmpeg. Worse, the current behaviour is a silent trap rather than a graceful fallback:

```
>>> RGBEncoderConfig(vcodec="auto")     # on a Jetson AGX Orin
[h264_nvenc] OpenEncodeSessionEx failed: unsupported device (2)
[h264_nvenc] No capable devices found
ExternalError: Generic error in an external library: 'avcodec_open2(h264_nvenc)'
```

`detect_available_encoders_pyav` reports `h264_nvenc` as available because it *is* compiled into the bundled FFmpeg; opening it then fails, because NVIDIA does not expose Tegra's encoder through the desktop NVENC SDK. So `vcodec="auto"` selects an encoder that cannot run instead of falling back to `libsvtav1`, and the encode fails outright. (NVIDIA's own Jetson FFmpeg package does not help: it provides hardware *decode* only.)

This PR adds a second implementation behind the existing `VideoEncoderConfig.video_backend` field, which is currently documented as *"Only 'pyav' is currently supported"*.

## Related issues

- Fixes: N/A (no existing issue found; happy to open one if useful)

## What changed

- **New** `src/lerobot/datasets/gstreamer_utils.py` — `GStreamerVideoWriter` plus encoder detection and option translation.
- `configs/video.py` — `video_backend="gstreamer"` is now accepted; `detect_available_encoders`, `validate` and `vcodec="auto"` probe the selected backend's own encoders.
- `datasets/video_utils.py` — `_CameraEncoderThread` and `encode_video_frames` route to the GStreamer writer when that backend is selected.
- Docs section under *Hardware-Accelerated Encoding*.

**Default behaviour is unchanged** — `video_backend` still defaults to `"pyav"`, and nothing on the PyAV path is altered.

Usage:

```bash
lerobot-record \
  --dataset.rgb_encoder.video_backend=gstreamer \
  --dataset.rgb_encoder.vcodec=auto \
  --dataset.streaming_encoding=true ...
```

The output is an ordinary MP4, identical in kind to what the PyAV backend writes — decoding, dataset metadata and training are unaffected.

### Notes for reviewers

- **Quality mapping.** `crf` becomes a fixed `qp-range` with `control-rate=0` on elements exposing a quantizer. `nvv4l2av1enc` exposes only `bitrate`, so a target is derived from `crf` and the frame size; `extra_options={"bitrate": ...}` overrides it. Open to a different mapping if you'd prefer one.
- **Depth** stays on PyAV; the GStreamer path raises `NotImplementedError` for it.
- **Dependency** is the GStreamer Python bindings, imported lazily inside the backend, so nothing changes for users who don't select it. Not added to `pyproject.toml` because they are system packages (`python3-gi`, `gir1.2-gstreamer-1.0`) rather than PyPI ones — let me know if you'd rather they were declared some other way.
- Hardware encoders reject frame sizes below a device-specific minimum, so the writer surfaces the async pipeline error rather than blocking.

## How was this tested (or how to run locally)

- **Unit/integration tests**: new `tests/datasets/test_gstreamer_encoder.py` (23 tests). Option translation and config integration run everywhere; encoder round-trips skip cleanly where no GStreamer hardware encoder exists.

  ```bash
  pytest tests/datasets/test_gstreamer_encoder.py -v
  ```

- **No regression on the PyAV path**: `tests/datasets/test_streaming_video_encoder.py`, `test_depth.py`, `test_dataset_writer.py` — 82 passed.

- **Manual testing on Jetson AGX Orin** (JetPack 7 / L4T R39.2, 12 cores), three cameras at 1920x1200@60 through `StreamingVideoEncoder`, frames fed at the camera clock, `g=2`:

  | | sustained cores | result |
  | --- | --- | --- |
  | `libsvtav1` (software) | ~17 per camera | cannot keep up — needs more cores than the machine has, for one camera |
  | `nvv4l2av1enc` (this PR) | 4.2 for all three | keeps up, 27 ms max lag |

  Every output decoded back with PyAV: 150/150 frames per camera, `codec=libdav1d`. `vcodec="auto"` resolves to `nvv4l2av1enc` on that backend.

- `ruff check` and `ruff format` clean.
