### PR TITLE
Make LeKiwi arm tracking gains configurable

### DIFF
--- a/src/lerobot/robots/lekiwi/config_lekiwi.py
+++ b/src/lerobot/robots/lekiwi/config_lekiwi.py
@@ -48,6 +48,15 @@ class LeKiwiConfig(RobotConfig):
     # Set to `True` for backward compatibility with previous policies/dataset
     use_degrees: bool = True
 
+    # Arm servo tracking gains, written by `configure()` on every connect.
+    # Defaults are the values previously hard-coded there, so behaviour is unchanged
+    # unless a user sets them. Exposed because the right gains depend on the arm's load:
+    # a higher P is needed for a shoulder that must climb against gravity, while a lower
+    # one avoids shakiness on a lightly loaded arm.
+    arm_p_coefficient: int = 16
+    arm_i_coefficient: int = 0
+    arm_d_coefficient: int = 32
+
 
 @dataclass
 class LeKiwiHostConfig:

--- a/src/lerobot/robots/lekiwi/config_lekiwi.py
+++ b/src/lerobot/robots/lekiwi/config_lekiwi.py
@@ -49,13 +49,18 @@ class LeKiwiConfig(RobotConfig):
     use_degrees: bool = True
 
     # Arm servo tracking gains, written by `configure()` on every connect.
-    # Defaults are the values previously hard-coded there, so behaviour is unchanged
-    # unless a user sets them. Exposed because the right gains depend on the arm's load:
-    # a higher P is needed for a shoulder that must climb against gravity, while a lower
-    # one avoids shakiness on a lightly loaded arm.
-    arm_p_coefficient: int = 16
-    arm_i_coefficient: int = 0
-    arm_d_coefficient: int = 32
+    # Set a scalar to use one value for every arm motor, or a dict mapping motor name
+    # to value, following the same convention as `max_relative_target` above.
+    # Defaults are the values previously hard-coded in `configure()`, so behaviour is
+    # unchanged unless a user sets them.
+    #
+    # Exposed because the right gains depend on the arm's load, and can differ per joint:
+    # a shoulder climbing against gravity needs a higher P, while a gripper whose job is
+    # to stall against an object should usually keep I at 0, since integral action winds
+    # up against a blocked joint.
+    arm_p_coefficient: int | dict[str, int] = 16
+    arm_i_coefficient: int | dict[str, int] = 0
+    arm_d_coefficient: int | dict[str, int] = 32
 
 
 @dataclass

--- a/src/lerobot/robots/lekiwi/lekiwi.py
+++ b/src/lerobot/robots/lekiwi/lekiwi.py
@@ -193,11 +193,11 @@ class LeKiwi(Robot):
         self.bus.configure_motors()
         for name in self.arm_motors:
             self.bus.write("Operating_Mode", name, OperatingMode.POSITION.value)
-            # Set P_Coefficient to lower value to avoid shakiness (Default is 32)
-            self.bus.write("P_Coefficient", name, 16)
-            # Set I_Coefficient and D_Coefficient to default value 0 and 32
-            self.bus.write("I_Coefficient", name, 0)
-            self.bus.write("D_Coefficient", name, 32)
+            # Tracking gains from the config; defaults match the
+            # previously hard-coded 16/0/32, so unset behaviour is unchanged.
+            self.bus.write("P_Coefficient", name, self.config.arm_p_coefficient)
+            self.bus.write("I_Coefficient", name, self.config.arm_i_coefficient)
+            self.bus.write("D_Coefficient", name, self.config.arm_d_coefficient)
 
         for name in self.base_motors:
             self.bus.write("Operating_Mode", name, OperatingMode.VELOCITY.value)

--- a/src/lerobot/robots/lekiwi/lekiwi.py
+++ b/src/lerobot/robots/lekiwi/lekiwi.py
@@ -193,11 +193,15 @@ class LeKiwi(Robot):
         self.bus.configure_motors()
         for name in self.arm_motors:
             self.bus.write("Operating_Mode", name, OperatingMode.POSITION.value)
-            # Tracking gains from the config; defaults match the
-            # previously hard-coded 16/0/32, so unset behaviour is unchanged.
-            self.bus.write("P_Coefficient", name, self.config.arm_p_coefficient)
-            self.bus.write("I_Coefficient", name, self.config.arm_i_coefficient)
-            self.bus.write("D_Coefficient", name, self.config.arm_d_coefficient)
+            # Tracking gains from the config. A scalar applies to
+            # every arm motor; a dict maps motor name to value. Defaults match
+            # the previously hard-coded 16/0/32, so behaviour is unchanged.
+            for register, setting in (
+                ("P_Coefficient", self.config.arm_p_coefficient),
+                ("I_Coefficient", self.config.arm_i_coefficient),
+                ("D_Coefficient", self.config.arm_d_coefficient),
+            ):
+                self.bus.write(register, name, setting[name] if isinstance(setting, dict) else setting)
 
         for name in self.base_motors:
             self.bus.write("Operating_Mode", name, OperatingMode.VELOCITY.value)


### PR DESCRIPTION
Fixes the reset half of #4309's neighbourhood: `LeKiwi.configure()` hard-codes the arm servo
tracking gains, and `configure()` is called from `connect()`, so any user-tuned value is silently
rewritten on every connect.

```python
# lekiwi.py, LeKiwi.configure()
# Set P_Coefficient to lower value to avoid shakiness (Default is 32)
self.bus.write("P_Coefficient", name, 16)
# Set I_Coefficient and D_Coefficient to default value 0 and 32
self.bus.write("I_Coefficient", name, 0)
self.bus.write("D_Coefficient", name, 32)
```

### Why it matters

The right gains depend on the arm's load, so there is no single correct value.

On our LeKiwi the shoulder has to climb against gravity under the arm's own weight. Measured, on a
commanded 4 degree climb from ~78 degrees:

| | achieved | residual |
|---|---|---|
| P=16 I=0 | 0.80 (20%) | 3.20 |
| P=32 I=0 | 2.37 (59%) | 1.63 |
| P=48 I=0 | 2.55 (64%) | 1.45 |
| P=48 I=4 | 4.00 (100%) | 0.00 |

At the current hard-coded 16 the shoulder descends freely but cannot climb back. On a lightly
loaded arm the existing 16 is the better choice and avoids shakiness, which is exactly why this
proposes a configurable default rather than a different constant.

We spent a while measuring a follower that would not track before finding that `connect()` was
resetting the gains we had set — the values are only observable by reading the registers back off
the servos, so this is quiet when it happens.

### The change

Adds `arm_p_coefficient`, `arm_i_coefficient` and `arm_d_coefficient` to `LeKiwiConfig`, defaulting
to **exactly** the values `configure()` wrote before (16 / 0 / 32), and reads them there.

**Behaviour is unchanged unless a user sets them.** No default moves.

Happy to adjust the naming or fold the three into a single dataclass if you would prefer that shape.
