### PR TITLE
fix(datasets): answer delta queries through cached single-column views

### DIFF
--- a/src/lerobot/datasets/dataset_reader.py
+++ b/src/lerobot/datasets/dataset_reader.py
@@ -156,6 +156,8 @@ class DatasetReader(BaseDatasetReader):
 
         self.hf_dataset: datasets.Dataset | None = None
         self._absolute_to_relative_idx: dict[int, int] | None = None
+        self._column_views: dict[str, datasets.Dataset] = {}
+        self._column_views_source: datasets.Dataset | None = None
 
         # Setup delta_indices (doesn't depend on hf_dataset)
         self.delta_indices = None
@@ -324,14 +326,35 @@ class DatasetReader(BaseDatasetReader):
             if query_indices is not None and key in query_indices:
                 if self._absolute_to_relative_idx is not None:
                     relative_indices = [self._absolute_to_relative_idx[idx] for idx in query_indices[key]]
-                    timestamps = self.hf_dataset[relative_indices]["timestamp"]
+                    timestamps = self._column_view("timestamp")[relative_indices]["timestamp"]
                 else:
-                    timestamps = self.hf_dataset[query_indices[key]]["timestamp"]
+                    timestamps = self._column_view("timestamp")[query_indices[key]]["timestamp"]
                 query_timestamps[key] = torch.stack(timestamps).tolist()
             else:
                 query_timestamps[key] = [current_ts]
 
         return query_timestamps
+
+    def _column_view(self, key: str) -> datasets.Dataset:
+        """Return a cached single-column view of ``hf_dataset``.
+
+        ``select_columns`` is a zero-copy schema projection: row queries on the
+        view fetch and decode only ``key``. By contrast, ``hf_dataset[indices]``
+        (and, since a custom transform disables the lazy-``Column`` fast path in
+        ``datasets`` >= 4.4, also ``hf_dataset[key][indices]``) fetches and
+        decodes entire rows. On image datasets that decodes every embedded
+        camera image of every queried row just to read a low-dimensional column
+        like ``action`` (#2895). The view keeps the ``hf_transform_to_torch``
+        transform, which is column-wise, so outputs are identical to a plain
+        row query.
+        """
+        if self._column_views_source is not self.hf_dataset:
+            # hf_dataset was (re)loaded: drop views built from the previous one
+            self._column_views = {}
+            self._column_views_source = self.hf_dataset
+        if key not in self._column_views:
+            self._column_views[key] = self.hf_dataset.select_columns(key)
+        return self._column_views[key]
 
     def _query_hf_dataset(self, query_indices: dict[str, list[int]]) -> dict:
         """Query dataset for indices across keys, skipping video keys."""
@@ -344,10 +367,7 @@ class DatasetReader(BaseDatasetReader):
                 if self._absolute_to_relative_idx is None
                 else [self._absolute_to_relative_idx[idx] for idx in q_idx]
             )
-            try:
-                result[key] = torch.stack(self.hf_dataset[key][relative_indices])
-            except (KeyError, TypeError, IndexError):
-                result[key] = torch.stack(self.hf_dataset[relative_indices][key])
+            result[key] = torch.stack(self._column_view(key)[relative_indices][key])
         return result
 
     def _query_videos(self, query_timestamps: dict[str, list[float]], ep_idx: int) -> dict[str, torch.Tensor]:

--- a/src/lerobot/datasets/dataset_reader.py
+++ b/src/lerobot/datasets/dataset_reader.py
@@ -158,6 +158,7 @@ class DatasetReader(BaseDatasetReader):
         self._absolute_to_relative_idx: dict[int, int] | None = None
         self._column_views: dict[str, datasets.Dataset] = {}
         self._column_views_source: datasets.Dataset | None = None
+        self._column_views_transform: Callable | None = None
 
         # Setup delta_indices (doesn't depend on hf_dataset)
         self.delta_indices = None
@@ -348,10 +349,12 @@ class DatasetReader(BaseDatasetReader):
         transform, which is column-wise, so outputs are identical to a plain
         row query.
         """
-        if self._column_views_source is not self.hf_dataset:
-            # hf_dataset was (re)loaded: drop views built from the previous one
+        transform = self.hf_dataset.format["format_kwargs"].get("transform")
+        if self._column_views_source is not self.hf_dataset or self._column_views_transform is not transform:
+            # hf_dataset was (re)loaded or its transform changed: drop stale views
             self._column_views = {}
             self._column_views_source = self.hf_dataset
+            self._column_views_transform = transform
         if key not in self._column_views:
             self._column_views[key] = self.hf_dataset.select_columns(key)
         return self._column_views[key]

--- a/src/lerobot/datasets/dataset_reader.py
+++ b/src/lerobot/datasets/dataset_reader.py
@@ -94,6 +94,8 @@ class DatasetReader:
 
         self.hf_dataset: datasets.Dataset | None = None
         self._absolute_to_relative_idx: dict[int, int] | None = None
+        self._column_views: dict[str, datasets.Dataset] = {}
+        self._column_views_source: datasets.Dataset | None = None
 
         # Setup delta_indices (doesn't depend on hf_dataset)
         self.delta_indices = None
@@ -241,14 +243,35 @@ class DatasetReader:
             if query_indices is not None and key in query_indices:
                 if self._absolute_to_relative_idx is not None:
                     relative_indices = [self._absolute_to_relative_idx[idx] for idx in query_indices[key]]
-                    timestamps = self.hf_dataset[relative_indices]["timestamp"]
+                    timestamps = self._column_view("timestamp")[relative_indices]["timestamp"]
                 else:
-                    timestamps = self.hf_dataset[query_indices[key]]["timestamp"]
+                    timestamps = self._column_view("timestamp")[query_indices[key]]["timestamp"]
                 query_timestamps[key] = torch.stack(timestamps).tolist()
             else:
                 query_timestamps[key] = [current_ts]
 
         return query_timestamps
+
+    def _column_view(self, key: str) -> datasets.Dataset:
+        """Return a cached single-column view of ``hf_dataset``.
+
+        ``select_columns`` is a zero-copy schema projection: row queries on the
+        view fetch and decode only ``key``. By contrast, ``hf_dataset[indices]``
+        (and, since a custom transform disables the lazy-``Column`` fast path in
+        ``datasets`` >= 4.4, also ``hf_dataset[key][indices]``) fetches and
+        decodes entire rows. On image datasets that decodes every embedded
+        camera image of every queried row just to read a low-dimensional column
+        like ``action`` (#2895). The view keeps the ``hf_transform_to_torch``
+        transform, which is column-wise, so outputs are identical to a plain
+        row query.
+        """
+        if self._column_views_source is not self.hf_dataset:
+            # hf_dataset was (re)loaded: drop views built from the previous one
+            self._column_views = {}
+            self._column_views_source = self.hf_dataset
+        if key not in self._column_views:
+            self._column_views[key] = self.hf_dataset.select_columns(key)
+        return self._column_views[key]
 
     def _query_hf_dataset(self, query_indices: dict[str, list[int]]) -> dict:
         """Query dataset for indices across keys, skipping video keys."""
@@ -261,10 +284,7 @@ class DatasetReader:
                 if self._absolute_to_relative_idx is None
                 else [self._absolute_to_relative_idx[idx] for idx in q_idx]
             )
-            try:
-                result[key] = torch.stack(self.hf_dataset[key][relative_indices])
-            except (KeyError, TypeError, IndexError):
-                result[key] = torch.stack(self.hf_dataset[relative_indices][key])
+            result[key] = torch.stack(self._column_view(key)[relative_indices][key])
         return result
 
     def _query_videos(self, query_timestamps: dict[str, list[float]], ep_idx: int) -> dict[str, torch.Tensor]:

--- a/tests/datasets/test_dataset_reader.py
+++ b/tests/datasets/test_dataset_reader.py
@@ -16,11 +16,14 @@
 """Contract tests for DatasetReader."""
 
 import pytest
+import torch
 
 pytest.importorskip("datasets", reason="datasets is required (install lerobot[dataset])")
 
 from lerobot.datasets.dataset_reader import DatasetReader
+from lerobot.datasets.io_utils import hf_transform_to_torch
 from lerobot.utils.import_utils import get_safe_default_video_backend
+from tests.fixtures.constants import DEFAULT_FPS
 
 # ── Loading ──────────────────────────────────────────────────────────
 
@@ -170,3 +173,63 @@ def test_get_episodes_file_paths_includes_video_paths(tmp_path, lerobot_dataset_
     if len(dataset.meta.video_keys) > 0:
         paths = dataset.reader.get_episodes_file_paths()
         assert any("video" in str(p).lower() for p in paths)
+
+
+# ── Delta queries ────────────────────────────────────────────────────
+
+
+def test_query_hf_dataset_matches_row_query(tmp_path, lerobot_dataset_factory):
+    """Delta queries answered through cached column views match a plain row query bit for bit."""
+    # A window reaching 2 frames back and 2 forward crosses the episode
+    # boundaries at both ends, covering the clamped-index padding cases.
+    delta_timestamps = {"action": [i / DEFAULT_FPS for i in range(-2, 3)]}
+    dataset = lerobot_dataset_factory(
+        root=tmp_path / "ds",
+        total_episodes=2,
+        total_frames=20,
+        use_videos=False,
+        delta_timestamps=delta_timestamps,
+    )
+    reader = dataset.reader
+
+    for abs_idx in range(reader.num_frames):
+        ep_idx = int(reader.hf_dataset[abs_idx]["episode_index"])
+        query_indices, _ = reader._get_query_indices(abs_idx, ep_idx)
+        result = reader._query_hf_dataset(query_indices)
+        for key, q_idx in query_indices.items():
+            expected = torch.stack(reader.hf_dataset[q_idx][key])
+            assert torch.equal(result[key], expected)
+
+
+def test_delta_query_transform_receives_only_requested_column(tmp_path, lerobot_dataset_factory):
+    """During a delta query, the transform receives only the requested column.
+
+    This is the contract that makes single-column views safe:
+    hf_transform_to_torch is column-wise, so feeding it one column cannot
+    change outputs. It also guarantees embedded camera images are not
+    fetched and decoded when only a low-dimensional column is queried.
+    """
+    delta_timestamps = {"action": [i / DEFAULT_FPS for i in range(-1, 2)]}
+    dataset = lerobot_dataset_factory(
+        root=tmp_path / "ds",
+        total_episodes=1,
+        total_frames=10,
+        use_videos=False,
+        delta_timestamps=delta_timestamps,
+    )
+    reader = dataset.reader
+    seen_key_sets = []
+
+    def spy_transform(items_dict):
+        seen_key_sets.append(set(items_dict))
+        return hf_transform_to_torch(items_dict)
+
+    # Set the spy before the first query: column views are built lazily, so
+    # they inherit it.
+    reader.hf_dataset.set_transform(spy_transform)
+
+    query_indices, _ = reader._get_query_indices(5, 0)
+    reader._query_hf_dataset(query_indices)
+
+    assert seen_key_sets, "expected the transform to be invoked"
+    assert all(keys == {"action"} for keys in seen_key_sets)

--- a/tests/datasets/test_dataset_reader.py
+++ b/tests/datasets/test_dataset_reader.py
@@ -26,10 +26,11 @@ pytest.importorskip("datasets", reason="datasets is required (install lerobot[da
 
 from lerobot.datasets import LeRobotDataset, register_dataset_reader
 from lerobot.datasets.dataset_reader import DatasetReader
+from lerobot.datasets.io_utils import hf_transform_to_torch
 from lerobot.datasets.language import LANGUAGE_EVENTS
 from lerobot.datasets.storage import _DATASET_READER_MODULES, DEFAULT_STORAGE_FORMAT, localize_remote_root
 from lerobot.utils.import_utils import get_safe_default_video_backend
-from tests.fixtures.constants import DUMMY_REPO_ID
+from tests.fixtures.constants import DEFAULT_FPS, DUMMY_REPO_ID
 
 # ── Loading ──────────────────────────────────────────────────────────
 
@@ -250,3 +251,63 @@ def test_register_dataset_reader(tmp_path, lerobot_dataset_factory, monkeypatch)
         assert localize_remote_root(DUMMY_REPO_ID, "s3://bucket/ds") == root
     finally:
         _DATASET_READER_MODULES.pop("toyfmt", None)
+
+
+# ── Delta queries ────────────────────────────────────────────────────
+
+
+def test_query_hf_dataset_matches_row_query(tmp_path, lerobot_dataset_factory):
+    """Delta queries answered through cached column views match a plain row query bit for bit."""
+    # A window reaching 2 frames back and 2 forward crosses the episode
+    # boundaries at both ends, covering the clamped-index padding cases.
+    delta_timestamps = {"action": [i / DEFAULT_FPS for i in range(-2, 3)]}
+    dataset = lerobot_dataset_factory(
+        root=tmp_path / "ds",
+        total_episodes=2,
+        total_frames=20,
+        use_videos=False,
+        delta_timestamps=delta_timestamps,
+    )
+    reader = dataset.reader
+
+    for abs_idx in range(reader.num_frames):
+        ep_idx = int(reader.hf_dataset[abs_idx]["episode_index"])
+        query_indices, _ = reader._get_query_indices(abs_idx, ep_idx)
+        result = reader._query_hf_dataset(query_indices)
+        for key, q_idx in query_indices.items():
+            expected = torch.stack(reader.hf_dataset[q_idx][key])
+            assert torch.equal(result[key], expected)
+
+
+def test_delta_query_transform_receives_only_requested_column(tmp_path, lerobot_dataset_factory):
+    """During a delta query, the transform receives only the requested column.
+
+    This is the contract that makes single-column views safe:
+    hf_transform_to_torch is column-wise, so feeding it one column cannot
+    change outputs. It also guarantees embedded camera images are not
+    fetched and decoded when only a low-dimensional column is queried.
+    """
+    delta_timestamps = {"action": [i / DEFAULT_FPS for i in range(-1, 2)]}
+    dataset = lerobot_dataset_factory(
+        root=tmp_path / "ds",
+        total_episodes=1,
+        total_frames=10,
+        use_videos=False,
+        delta_timestamps=delta_timestamps,
+    )
+    reader = dataset.reader
+    seen_key_sets = []
+
+    def spy_transform(items_dict):
+        seen_key_sets.append(set(items_dict))
+        return hf_transform_to_torch(items_dict)
+
+    # Set the spy before the first query: column views are built lazily, so
+    # they inherit it.
+    reader.hf_dataset.set_transform(spy_transform)
+
+    query_indices, _ = reader._get_query_indices(5, 0)
+    reader._query_hf_dataset(query_indices)
+
+    assert seen_key_sets, "expected the transform to be invoked"
+    assert all(keys == {"action"} for keys in seen_key_sets)

--- a/tests/datasets/test_dataset_reader.py
+++ b/tests/datasets/test_dataset_reader.py
@@ -311,3 +311,33 @@ def test_delta_query_transform_receives_only_requested_column(tmp_path, lerobot_
 
     assert seen_key_sets, "expected the transform to be invoked"
     assert all(keys == {"action"} for keys in seen_key_sets)
+
+
+def test_column_views_are_rebuilt_after_set_transform(tmp_path, lerobot_dataset_factory):
+    """Cached column views must not outlive a set_transform() on hf_dataset.
+
+    set_transform() mutates the dataset in place, so dataset identity alone
+    cannot invalidate the cache: a view built under the previous transform
+    would keep answering delta queries with it.
+    """
+    delta_timestamps = {"action": [i / DEFAULT_FPS for i in range(-1, 2)]}
+    dataset = lerobot_dataset_factory(
+        root=tmp_path / "ds",
+        total_episodes=1,
+        total_frames=10,
+        use_videos=False,
+        delta_timestamps=delta_timestamps,
+    )
+    reader = dataset.reader
+
+    query_indices, _ = reader._get_query_indices(5, 0)
+    baseline = reader._query_hf_dataset(query_indices)
+
+    def doubling_transform(items_dict):
+        items = hf_transform_to_torch(items_dict)
+        return {key: [2 * value for value in values] for key, values in items.items()}
+
+    reader.hf_dataset.set_transform(doubling_transform)
+
+    result = reader._query_hf_dataset(query_indices)
+    assert torch.equal(result["action"], 2 * baseline["action"])


### PR DESCRIPTION
## Summary / Motivation

Since `datasets` 4.4, setting a custom transform disables the lazy-`Column` fast path, so both `hf_dataset[key][indices]` and `hf_dataset[indices][key]` fetch and decode entire rows. LeRobot always sets `hf_transform_to_torch`, so every delta query pays full-row cost: on image datasets (embedded images in parquet) that means decoding `chunk_size x n_cameras` images per sample just to read a small float column like `action`. Full root-cause analysis with `datasets` source references is in https://github.com/huggingface/lerobot/issues/2895#issuecomment-5060174507 (the guard is unchanged as of `datasets` 5.0.0, so no upgrade fixes it).

This PR routes delta queries through cached per-key `select_columns` views. `select_columns` is a zero-copy schema projection, so row queries on the view fetch and decode only the requested column. The view keeps the `hf_transform_to_torch` transform, which is column-wise, so outputs are unchanged.

Design notes:

- The views rely on schema projection plus index-based row gather, both stable public `datasets` semantics, rather than on which internal path `ds[key][idx]` takes in a given release. This is what made the previous code flip between fast and slow across `datasets` versions (#2408, #2549, #3210, #3523).
- The try/except fallback in `_query_hf_dataset` is no longer needed: the view path is the row-query semantics, on a one-column schema.
- If `datasets` later ships a column-safe transform declaration (discussed with @lhoestq in #2895), the cached views can be replaced by a one-line declaration at `set_transform` time. The workaround has a clear retirement path.

## Related issues

- Fixes: #2895
- Related: #3523 (benchmarks the `datasets` 4.3 to 4.4 cliff), #3558 (orthogonal: hoists deduplicated row-batch fetches; the two compose), #2408 (introduced the column-first attempt), #2549 (the pre-4.0 flavor of this bug)

## What changed

- `DatasetReader._column_view(key)`: builds and caches a single-column `select_columns` view per queried key; the cache is invalidated when `hf_dataset` is reloaded.
- `_query_hf_dataset` answers delta queries through the view instead of try/except between two equally slow full-row paths.
- `_get_query_timestamps` uses the same view for the `timestamp` column.
- No behavior change: outputs are bit-identical (see tests).

## How was this tested (or how to run locally)

- Tests added in `tests/datasets/test_dataset_reader.py`:
  - `test_query_hf_dataset_matches_row_query`: bit-identical (`torch.equal`) against a plain row query, over every frame of an image-type dataset, with a delta window that crosses episode boundaries on both ends (padding/clamping cases).
  - `test_delta_query_transform_receives_only_requested_column`: contract test asserting the transform only ever receives the requested column during delta queries.
- `pytest -q tests/datasets/test_dataset_reader.py`
- Benchmark (lerobot 0.6.0 + this patch backported, datasets 4.8.5, `HuggingFaceVLA/libero`, 273,465 rows, 2 embedded-image cameras, 50-index `action` chunk query, median of 12 interleaved rounds): 165.0 ms (current) to 0.8 ms (this PR), ~200x. End-to-end `__getitem__` per sample: 200.7 ms to 4.4 ms (46x). In a 2xA800 DDP SmolVLA fine-tuning run, dataloader wait dropped from 38% of wall-clock to ~1%.
- Production validation: outputs bit-identical against the old path over 324 samples including 24 episode-boundary cases.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated (n/a: no public API change)
- [ ] CI is green
- [x] Community Review: I have reviewed another contributor's open PR and linked it here: #3558

## Reviewer notes

- The one subtle point is transform semantics: the view carries `hf_transform_to_torch`, which processes each column independently (`for key in items_dict` in `io_utils.py`), so feeding it a single-column batch cannot change outputs. The contract test pins this down.
- `_column_view` invalidates by identity check on `hf_dataset`, covering `try_load` / `load_and_activate` reloads. In-place `set_transform` on an already-queried reader is not a supported pattern today; views built afterwards would keep the old transform.
