### PR TITLE
Fix: derive LIBERO initial state from the reset seed

### DIFF
--- a/src/lerobot/envs/libero.py
+++ b/src/lerobot/envs/libero.py
@@ -340,6 +340,15 @@ class LiberoEnv(gym.Env):
         self._ensure_env()
         super().reset(seed=seed)
         self._env.seed(seed)
+        # A supplied seed must determine which initial state is loaded. Without
+        # this, `init_state_id` advances purely as a per-reset counter, so
+        # `reset(seed=s)` returns a different scene depending on how many resets
+        # happened earlier in the process -- making individual trials
+        # irreproducible and causing a resumed or reordered evaluation to sample
+        # a different set of initial states than a single-pass one. When no seed
+        # is given the existing round-robin behaviour is preserved.
+        if seed is not None:
+            self.init_state_id = seed
         raw_obs = self._env.reset()
         if self.init_states and self._init_states is not None:
             raw_obs = self._env.set_init_state(self._init_states[self.init_state_id % len(self._init_states)])

--- a/src/lerobot/envs/libero.py
+++ b/src/lerobot/envs/libero.py
@@ -347,10 +347,22 @@ class LiberoEnv(gym.Env):
         # irreproducible and causing a resumed or reordered evaluation to sample
         # a different set of initial states than a single-pass one. When no seed
         # is given the existing round-robin behaviour is preserved.
+        #
+        # This moves one invariant to the caller: `init_state_id = episode_index`
+        # plus `+= _reset_stride` partitions the initial states so that no two
+        # sub-envs of a vectorised env share a scene, and a seeded reset
+        # overwrites that. The partition now holds only while the caller passes a
+        # distinct seed per sub-env, as `lerobot_eval` does
+        # (`start_seed + batch_ix * num_envs + i`); passing one seed to the whole
+        # vectorised env would put every sub-env on the same initial state.
         if seed is not None:
             self.init_state_id = seed
         raw_obs = self._env.reset()
         if self.init_states and self._init_states is not None:
+            # Periodic in len(self._init_states), which is 50 for the stock LIBERO
+            # suites: ids that far apart select the same initial state and differ
+            # only by simulator jitter. A sweep over more seeds than that revisits
+            # scenes rather than covering new ones.
             raw_obs = self._env.set_init_state(self._init_states[self.init_state_id % len(self._init_states)])
             self.init_state_id += self._reset_stride  # Change init_state_id when reset
 

--- a/tests/envs/test_libero_seed.py
+++ b/tests/envs/test_libero_seed.py
@@ -31,6 +31,19 @@ from lerobot.envs.factory import make_env  # noqa: E402
 
 RESOLUTION = 128
 
+# Resetting to the *same* initial state does not reproduce pixels exactly --
+# robosuite's placement sampler draws from global RNG, so two resets onto one
+# initial state still differ by a little. Mean absolute pixel difference at
+# 128x128 on libero_spatial, measured on two machines:
+#
+#                            CUDA (RTX 4070)      MPS (Apple Silicon)
+#   same initial state       median 1.79 max 2.65  median 1.16 max 2.88
+#   different initial state  median 5.38 min 4.42  median 5.80 min 4.97
+#
+# so this threshold separates the two with room on both. Asserting a magnitude
+# rather than mere inequality means the test cannot pass on jitter alone.
+DISTINCT_SCENE_THRESHOLD = 3.5
+
 
 @pytest.fixture(scope="module")
 def env():
@@ -52,6 +65,10 @@ def _first_frame(env, seed):
     return np.asarray(obs["pixels"]["image"])[0].copy()
 
 
+def _mean_abs_diff(a, b):
+    return float(np.abs(a.astype(np.float64) - b.astype(np.float64)).mean())
+
+
 def test_same_seed_gives_same_initial_state(env):
     """`reset(seed=s)` must be reproducible regardless of intervening resets."""
     first = _first_frame(env, 42)
@@ -68,8 +85,20 @@ def test_same_seed_gives_same_initial_state(env):
 
 
 def test_different_seeds_give_different_initial_states(env):
-    """Deriving the initial state from the seed must not collapse seeds together."""
-    assert not np.array_equal(_first_frame(env, 1), _first_frame(env, 2))
+    """Deriving the initial state from the seed must not collapse seeds together.
+
+    Note this is deliberately not a pair 50 apart: the index space is periodic in
+    `len(self._init_states)`, so seeds that far apart *do* share an initial state.
+    That is a property of the pre-existing `%`, not of deriving the id from the
+    seed, and pinning it here would make it harder to change later.
+    """
+    diff = _mean_abs_diff(_first_frame(env, 3), _first_frame(env, 17))
+    assert diff > DISTINCT_SCENE_THRESHOLD, (
+        f"seeds 3 and 17 differ by only {diff:.2f} mean pixel value, below the "
+        f"{DISTINCT_SCENE_THRESHOLD} threshold that separates two initial states "
+        "from two resets onto the same one -- the seed is likely not reaching "
+        "init_state_id"
+    )
 
 
 def test_unseeded_reset_still_advances(env):

--- a/tests/envs/test_libero_seed.py
+++ b/tests/envs/test_libero_seed.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Reproducibility of `LiberoEnv.reset(seed=...)`.
+
+`init_state_id` selects which of the pre-generated initial states a rollout
+starts from. It advances on every reset, so unless it is derived from the seed
+the same seed yields a different scene depending on how many resets the process
+performed earlier.
+"""
+
+import numpy as np
+import pytest
+
+libero = pytest.importorskip("libero.libero", reason="LIBERO is not installed")
+
+from lerobot.envs.configs import LiberoEnv as LiberoEnvConfig  # noqa: E402
+from lerobot.envs.factory import make_env  # noqa: E402
+
+RESOLUTION = 128
+
+
+@pytest.fixture(scope="module")
+def env():
+    cfg = LiberoEnvConfig(
+        task="libero_spatial",
+        task_ids=[0],
+        observation_height=RESOLUTION,
+        observation_width=RESOLUTION,
+        episode_length=10,
+    )
+    envs = make_env(cfg, n_envs=1)
+    e = envs["libero_spatial"][0]
+    yield e
+    e.close()
+
+
+def _first_frame(env, seed):
+    obs, _ = env.reset(seed=seed)
+    return np.asarray(obs["pixels"]["image"])[0].copy()
+
+
+def test_same_seed_gives_same_initial_state(env):
+    """`reset(seed=s)` must be reproducible regardless of intervening resets."""
+    first = _first_frame(env, 42)
+    _first_frame(env, 7)  # unrelated reset in between
+    second = _first_frame(env, 42)
+
+    np.testing.assert_array_equal(
+        first,
+        second,
+        err_msg=(
+            "reset(seed=42) produced two different scenes; init_state_id advanced independently of the seed"
+        ),
+    )
+
+
+def test_different_seeds_give_different_initial_states(env):
+    """Deriving the initial state from the seed must not collapse seeds together."""
+    assert not np.array_equal(_first_frame(env, 1), _first_frame(env, 2))
+
+
+def test_unseeded_reset_still_advances(env):
+    """Callers that rely on cycling through initial states are unaffected."""
+    env.reset(seed=0)
+    assert not np.array_equal(_first_frame(env, None), _first_frame(env, None))


### PR DESCRIPTION
## Problem

`LiberoEnv.reset(seed=...)` forwards the seed to the underlying simulator, but which of the pre-generated initial states is loaded comes from `init_state_id` — a counter that advances on every reset and is never derived from the seed:

https://github.com/huggingface/lerobot/blob/main/src/lerobot/envs/libero.py#L345-L346

So `reset(seed=s)` returns a different scene depending on how many resets the process happened to perform earlier. Two consequences, neither of which raises an error:

1. An individual trial cannot be reproduced in isolation.
2. An evaluation that is **resumed, reordered, or split across processes** samples a different set of initial states than a single-pass run, while appearing to use the same seeds.

The second one is the reason I hit this: a resumable perturbation sweep silently changed which scenes it sampled depending on where it was interrupted, which showed up as unexplained variance between runs rather than as an error.

## Reproduction on `main`

```python
a = env.reset(seed=42)   # scene A
    env.reset(seed=7)    # unrelated reset in between
c = env.reset(seed=42)   # scene B, not A
```

Mean pixel difference between the two `seed=42` frames at 128×128: **3.77**.
With this change: **0.00**.

## Fix

Set `init_state_id` from the seed when one is supplied; leave the existing round-robin untouched when it is not. Callers that rely on cycling through initial states across resets are unaffected.

## Tests

Adds `tests/envs/test_libero_seed.py` (skips when LIBERO is not installed):

- `test_same_seed_gives_same_initial_state` — **fails on `main`**, passes with this change
- `test_different_seeds_give_different_initial_states` — guards against the fix collapsing every seed onto one scene
- `test_unseeded_reset_still_advances` — guards the existing round-robin behaviour

Verified locally: 1 failed / 2 passed before the change, 3 passed after.

## Compatibility: this changes which initial states a seeded evaluation visits

Worth stating explicitly, because it does not surface as an error. `init_state_id` indexes `self._init_states` modulo its length — 50 for the stock LIBERO suites. On `main` it starts at `episode_index` and advances by `_reset_stride`; with this change a seeded reset sets it to the seed, which `lerobot_eval` hands out as `start_seed + batch_ix * num_envs + i`.

For the default single-env eval at `--seed=42`, 10 episodes:

```
main      init states visited: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
this PR   init states visited: [42, 43, 44, 45, 46, 47, 48, 49, 0, 1]
overlap:  2 of 10
```

So a LIBERO success rate produced before this merges is not directly comparable to one produced after — the two are computed over mostly different scenes. @saime428 measured the size of it on `lerobot/smolvla_libero`, `libero_spatial` tasks 0-3, 10 episodes each, seed 42: **72.5% → 75.0%** overall, with individual tasks moving by 2-3 episodes. The aggregate barely moves while the per-task numbers swing, which makes it easy to miss rather than harmless.

Happy to put this in a changelog too, if there's one I should be editing.

## Notes

Happy to adjust the approach — an alternative would be leaving `reset()` alone and documenting that callers must set `init_state_id` themselves, but that seems surprising given `reset()` already accepts a seed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
