### PR TITLE
fix(setup): script abort in case of connection error with moroe

### DIFF
--- a/src/lerobot/motors/motors_bus.py
+++ b/src/lerobot/motors/motors_bus.py
@@ -630,6 +630,27 @@ class SerialMotorsBus(MotorsBusBase):
 
         self.set_baudrate(self.default_baudrate)
 
+    def setup_motor_interactive(self, motor: str) -> None:
+        """Prompt the user to connect `motor` alone, then set it up, retrying on failure.
+
+        Unlike :pymeth:`setup_motor`, a failure (motor not found, communication error) does not
+        propagate: the error is displayed and the user is asked to fix the connection and press
+        enter to retry the same motor. Press Ctrl-C to abort.
+
+        Args:
+            motor (str): Key of the motor in :pyattr:`motors`.
+        """
+        while True:
+            input(f"Connect the controller board to the '{motor}' motor only and press enter.")
+            try:
+                self.setup_motor(motor)
+            except (RuntimeError, ConnectionError) as e:
+                print(f"Setting up '{motor}' motor failed: {e}")
+                print("Check that only this motor is connected and powered, then press enter to retry.")
+            else:
+                print(f"'{motor}' motor id set to {self.motors[motor].id}")
+                return
+
     @abc.abstractmethod
     def _find_single_motor(self, motor: str, initial_baudrate: int | None = None) -> tuple[int, int]:
         pass

--- a/src/lerobot/robots/hope_jr/hope_jr_arm.py
+++ b/src/lerobot/robots/hope_jr/hope_jr_arm.py
@@ -128,9 +128,7 @@ class HopeJrArm(Robot):
     def setup_motors(self) -> None:
         # TODO: add docstring
         for motor in reversed(self.bus.motors):
-            input(f"Connect the controller board to the '{motor}' motor only and press enter.")
-            self.bus.setup_motor(motor)
-            print(f"'{motor}' motor id set to {self.bus.motors[motor].id}")
+            self.bus.setup_motor_interactive(motor)
 
     @check_if_not_connected
     def get_observation(self) -> RobotObservation:

--- a/src/lerobot/robots/hope_jr/hope_jr_hand.py
+++ b/src/lerobot/robots/hope_jr/hope_jr_hand.py
@@ -158,9 +158,7 @@ class HopeJrHand(Robot):
     def setup_motors(self) -> None:
         # TODO: add docstring
         for motor in self.bus.motors:
-            input(f"Connect the controller board to the '{motor}' motor only and press enter.")
-            self.bus.setup_motor(motor)
-            print(f"'{motor}' motor id set to {self.bus.motors[motor].id}")
+            self.bus.setup_motor_interactive(motor)
 
     @check_if_not_connected
     def get_observation(self) -> RobotObservation:

--- a/src/lerobot/robots/koch_follower/koch_follower.py
+++ b/src/lerobot/robots/koch_follower/koch_follower.py
@@ -182,9 +182,7 @@ class KochFollower(Robot):
 
     def setup_motors(self) -> None:
         for motor in reversed(self.bus.motors):
-            input(f"Connect the controller board to the '{motor}' motor only and press enter.")
-            self.bus.setup_motor(motor)
-            print(f"'{motor}' motor id set to {self.bus.motors[motor].id}")
+            self.bus.setup_motor_interactive(motor)
 
     @check_if_not_connected
     def get_observation(self) -> RobotObservation:

--- a/src/lerobot/robots/lekiwi/lekiwi.py
+++ b/src/lerobot/robots/lekiwi/lekiwi.py
@@ -206,9 +206,7 @@ class LeKiwi(Robot):
 
     def setup_motors(self) -> None:
         for motor in chain(reversed(self.arm_motors), reversed(self.base_motors)):
-            input(f"Connect the controller board to the '{motor}' motor only and press enter.")
-            self.bus.setup_motor(motor)
-            print(f"'{motor}' motor id set to {self.bus.motors[motor].id}")
+            self.bus.setup_motor_interactive(motor)
 
     @staticmethod
     def _degps_to_raw(degps: float) -> int:

--- a/src/lerobot/robots/omx_follower/omx_follower.py
+++ b/src/lerobot/robots/omx_follower/omx_follower.py
@@ -165,9 +165,7 @@ class OmxFollower(Robot):
 
     def setup_motors(self) -> None:
         for motor in reversed(self.bus.motors):
-            input(f"Connect the controller board to the '{motor}' motor only and press enter.")
-            self.bus.setup_motor(motor)
-            print(f"'{motor}' motor id set to {self.bus.motors[motor].id}")
+            self.bus.setup_motor_interactive(motor)
 
     @check_if_not_connected
     def get_observation(self) -> RobotObservation:

--- a/src/lerobot/robots/so_follower/so_follower.py
+++ b/src/lerobot/robots/so_follower/so_follower.py
@@ -172,9 +172,7 @@ class SOFollower(Robot):
 
     def setup_motors(self) -> None:
         for motor in reversed(self.bus.motors):
-            input(f"Connect the controller board to the '{motor}' motor only and press enter.")
-            self.bus.setup_motor(motor)
-            print(f"'{motor}' motor id set to {self.bus.motors[motor].id}")
+            self.bus.setup_motor_interactive(motor)
 
     @check_if_not_connected
     def get_observation(self) -> RobotObservation:

--- a/src/lerobot/teleoperators/koch_leader/koch_leader.py
+++ b/src/lerobot/teleoperators/koch_leader/koch_leader.py
@@ -155,9 +155,7 @@ class KochLeader(Teleoperator):
 
     def setup_motors(self) -> None:
         for motor in reversed(self.bus.motors):
-            input(f"Connect the controller board to the '{motor}' motor only and press enter.")
-            self.bus.setup_motor(motor)
-            print(f"'{motor}' motor id set to {self.bus.motors[motor].id}")
+            self.bus.setup_motor_interactive(motor)
 
     @check_if_not_connected
     def get_action(self) -> dict[str, float]:

--- a/src/lerobot/teleoperators/omx_leader/omx_leader.py
+++ b/src/lerobot/teleoperators/omx_leader/omx_leader.py
@@ -144,9 +144,7 @@ class OmxLeader(Teleoperator):
 
     def setup_motors(self) -> None:
         for motor in reversed(self.bus.motors):
-            input(f"Connect the controller board to the '{motor}' motor only and press enter.")
-            self.bus.setup_motor(motor)
-            print(f"'{motor}' motor id set to {self.bus.motors[motor].id}")
+            self.bus.setup_motor_interactive(motor)
 
     @check_if_not_connected
     def get_action(self) -> dict[str, float]:

--- a/src/lerobot/teleoperators/openarm_mini/openarm_mini.py
+++ b/src/lerobot/teleoperators/openarm_mini/openarm_mini.py
@@ -208,9 +208,7 @@ class OpenArmMini(Teleoperator):
 
     def setup_motors(self) -> None:
         for motor in reversed(self.bus.motors):
-            input(f"Connect the controller board to the '{motor}' motor only and press enter.")
-            self.bus.setup_motor(motor)
-            print(f"'{motor}' motor id set to {self.bus.motors[motor].id}")
+            self.bus.setup_motor_interactive(motor)
 
     @check_if_not_connected
     def get_action(self) -> RobotAction:

--- a/src/lerobot/teleoperators/so_leader/so_leader.py
+++ b/src/lerobot/teleoperators/so_leader/so_leader.py
@@ -138,9 +138,7 @@ class SOLeader(Teleoperator):
 
     def setup_motors(self) -> None:
         for motor in reversed(self.bus.motors):
-            input(f"Connect the controller board to the '{motor}' motor only and press enter.")
-            self.bus.setup_motor(motor)
-            print(f"'{motor}' motor id set to {self.bus.motors[motor].id}")
+            self.bus.setup_motor_interactive(motor)
 
     @check_if_not_connected
     def get_action(self) -> dict[str, float]:

--- a/tests/motors/test_motors_bus.py
+++ b/tests/motors/test_motors_bus.py
@@ -358,3 +358,22 @@ def test_sync_write_by_value_dict(data_name, ids_values, dummy_motors):
     mock__encode_sign.assert_called_once_with(data_name, ids_values)
     if data_name in bus.normalized_data:
         mock__unnormalize.assert_called_once_with(ids_values)
+
+
+def test_setup_motor_interactive_retries_on_failure(dummy_motors, capsys):
+    bus = MockMotorsBus("/dev/dummy-port", dummy_motors)
+
+    with (
+        patch("builtins.input", return_value=""),
+        patch.object(
+            MockMotorsBus,
+            "setup_motor",
+            side_effect=[RuntimeError("Motor 'dummy_1' not found"), None],
+        ) as mock_setup_motor,
+    ):
+        bus.setup_motor_interactive("dummy_1")
+
+    assert mock_setup_motor.call_count == 2
+    captured = capsys.readouterr()
+    assert "Setting up 'dummy_1' motor failed" in captured.out
+    assert "'dummy_1' motor id set to 1" in captured.out


### PR DESCRIPTION
## Title

fix(motors): make motor setup retry after a failure

## Summary / Motivation

`lerobot-setup-motors` stopped at the first motor that failed, for example with `RuntimeError: Motor not found`. The user lost all progress and had to start again from the first motor. Motor setup is an interactive process. The user connects the motors one by one, and a wiring error is frequent. A wiring error must not stop the session. This PR adds one shared helper, `MotorsBus.setup_motor_interactive()`. The helper catches the error, shows the cause, and asks the user to retry the same motor. The helper also replaces the same three-line loop that was in 10 device classes.

## Related issues

- Fixes / Closes: #
- Related: #

## What changed

- Added `MotorsBus.setup_motor_interactive(motor)` in `src/lerobot/motors/mosks the user to connect the motor, then calls `setup_motor()`. If the callcauses a `RuntimeError` or a `ConnectionError`, the helper shows the error and asks the user to retry. Ctrl-C stops the program.
- Changed all `setup_motors()` implementations to use the new helper: `so_foh_follower`, `koch_leader`, `omx_follower`, `omx_leader`, `openarm_mini`,`hope_jr_arm`, `hope_jr_hand`, and `lekiwi`. The bi-arm devices call these classes, so this change also applies to them. The CAN devices (`openarm_leader`, `openarm_follower`) are
not changed.
- This change is not a breaking change. The motor sequence, the prompts, and the success output are the same. Only the failure path is different: the program retries and does not
stop. Motors that are already configured keep their IDs.

## How was this tested (or how to run locally)

- New test: `test_setup_motor_interactive_retries_on_failure` in `tests/motoe test makes the first call fail and makes sure that the helper retries.
- Run: `uv run --extra test --extra hardware pytest -q tests/motors/test_motors_bus.py tests/scripts/test_setup_motors.py`. Result: 37 passed.
- To see the new behavior, run `lerobot-setup-motors --robot.type=so101_foll Press enter with the motor disconnected. The script shows the error and asks again. It does not stop.

## Checklist (required before merge)

- [x] Linting/formatting run (`ruff check` and `ruff format --check` on the changed files. One `UP042` warning in `motors_bus.py` is older than this PR.)
- [x] All tests pass locally (`tests/motors/` and `tests/scripts/test_setup_ was not run.)
- [ ] Documentation updated (not applicable — the CLI usage and the prompts are the same)
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: #

## Reviewer notes

- The behavior change is only in `src/lerobot/motors/motors_bus.py`. The 10 device files get the same one-line replacement.
- Look at the exception types. Other exceptions, for example `KeyboardInterr caught. A retry is correct only for a motor that is not found or acommunication error.  