### PR TITLE
fix(groot): resize mixed-resolution cameras before stacking

### DIFF
--- a/src/lerobot/policies/groot/processor_groot.py
+++ b/src/lerobot/policies/groot/processor_groot.py
@@ -1368,8 +1368,8 @@ def _align_video_horizon(video: np.ndarray, horizon: int | None) -> np.ndarray:
     return np.concatenate([pad, video], axis=1)
 
 
-def _resize_video_to_image_target(video: np.ndarray, image_target_size: list[int] | None) -> np.ndarray:
-    """Resize a ``(B, T, H, W, C)`` camera stream so heterogeneous views can be stacked."""
+def _letterbox_video_to_image_target(video: np.ndarray, image_target_size: list[int] | None) -> np.ndarray:
+    """Fit a ``(B, T, H, W, C)`` camera stream to a common canvas without distortion."""
 
     if image_target_size is None:
         return video
@@ -1379,17 +1379,28 @@ def _resize_video_to_image_target(video: np.ndarray, image_target_size: list[int
     target_w = int(target_w)
     if target_h <= 0 or target_w <= 0:
         raise ValueError(f"image_target_size must contain positive dimensions, got {image_target_size}")
-    if tuple(video.shape[-3:-1]) == (target_h, target_w):
+    source_h, source_w = video.shape[-3:-1]
+    if (source_h, source_w) == (target_h, target_w):
         return video
 
+    scale = min(target_h / float(source_h), target_w / float(source_w))
+    resized_h = min(target_h, max(1, int(round(source_h * scale))))
+    resized_w = min(target_w, max(1, int(round(source_w * scale))))
+
     flat_video = video.reshape(-1, *video.shape[-3:])
-    resized_frames = []
+    letterboxed_frames = []
     for frame in flat_video:
-        resized = cv2.resize(frame, (target_w, target_h), interpolation=cv2.INTER_AREA)
+        resized = cv2.resize(frame, (resized_w, resized_h), interpolation=cv2.INTER_AREA)
         if resized.ndim == 2:
             resized = resized[:, :, None]
-        resized_frames.append(resized)
-    return np.stack(resized_frames, axis=0).reshape(*video.shape[:-3], target_h, target_w, video.shape[-1])
+        canvas = np.zeros((target_h, target_w, video.shape[-1]), dtype=video.dtype)
+        top = (target_h - resized_h) // 2
+        left = (target_w - resized_w) // 2
+        canvas[top : top + resized_h, left : left + resized_w] = resized
+        letterboxed_frames.append(canvas)
+    return np.stack(letterboxed_frames, axis=0).reshape(
+        *video.shape[:-3], target_h, target_w, video.shape[-1]
+    )
 
 
 def _build_n1_7_processor(model_name: str = GROOT_N1_7_BACKBONE_MODEL) -> ProcessorMixin:
@@ -1880,7 +1891,7 @@ class GrootN17PackInputsStep(ProcessorStep):
         if img_keys:
             cams = [_align_video_horizon(_to_uint8_np_bthwc(obs[k]), self.video_horizon) for k in img_keys]
             if len({cam.shape[-3:] for cam in cams}) > 1:
-                cams = [_resize_video_to_image_target(camera, self.image_target_size) for camera in cams]
+                cams = [_letterbox_video_to_image_target(camera, self.image_target_size) for camera in cams]
             video = np.stack(cams, axis=2)  # (B, T, V, H, W, C)
             obs["video"] = video
             image_keys_to_remove = [key for key in obs if key.startswith(OBS_IMAGES)]

--- a/src/lerobot/policies/groot/processor_groot.py
+++ b/src/lerobot/policies/groot/processor_groot.py
@@ -1206,6 +1206,26 @@ def make_groot_pre_post_processors(
     formalize_language = checkpoint_assets.formalize_language if checkpoint_assets is not None else True
     clip_outliers = checkpoint_assets.clip_outliers if checkpoint_assets is not None else True
     video_modality_keys = checkpoint_assets.video_modality_keys if checkpoint_assets is not None else None
+
+    # Resolve the image preprocessing geometry. Honor the checkpoint's processor_config
+    # when it provides an image_target_size; otherwise fall back to the geometry the
+    # N1.7 backbone was trained on. Without this fallback a raw base checkpoint with no
+    # processor_config image sizing (e.g. fine-tuning nvidia/GR00T-N1.7-3B with a new
+    # embodiment, where checkpoint_assets is None) would patchify full-resolution camera
+    # frames, inflating the VLM token count and feeding the model a resolution it was not trained on.
+    if checkpoint_assets is not None and checkpoint_assets.image_target_size is not None:
+        image_target_size = checkpoint_assets.image_target_size
+        image_crop_size = checkpoint_assets.image_crop_size
+        shortest_image_edge = checkpoint_assets.shortest_image_edge
+        crop_fraction = checkpoint_assets.crop_fraction
+    else:
+        image_target_size = list(N1_7_DEFAULT_IMAGE_TARGET_SIZE)
+        image_crop_size = list(N1_7_DEFAULT_IMAGE_CROP_SIZE)
+        shortest_image_edge = None
+        crop_fraction = None
+    use_albumentations = checkpoint_assets.use_albumentations if checkpoint_assets is not None else False
+    letter_box_transform = checkpoint_assets.letter_box_transform if checkpoint_assets is not None else False
+
     try:
         env_action_dim = int(config.output_features[ACTION].shape[0])
     except Exception:
@@ -1227,29 +1247,11 @@ def make_groot_pre_post_processors(
         stats=padded_stats,
         clip_outliers=clip_outliers,
         video_modality_keys=video_modality_keys,
+        image_target_size=image_target_size,
         raw_stats=checkpoint_assets.raw_stats if checkpoint_assets is not None else None,
         use_percentiles=checkpoint_assets.use_percentiles if checkpoint_assets is not None else False,
         modality_config=checkpoint_assets.modality_config if checkpoint_assets is not None else None,
     )
-
-    # Resolve the image preprocessing geometry. Honor the checkpoint's processor_config
-    # when it provides an image_target_size; otherwise fall back to the geometry the
-    # N1.7 backbone was trained on. Without this fallback a raw base checkpoint with no
-    # processor_config image sizing (e.g. fine-tuning nvidia/GR00T-N1.7-3B with a new
-    # embodiment, where checkpoint_assets is None) would patchify full-resolution camera
-    # frames, inflating the VLM token count and feeding the model a resolution it was not trained on.
-    if checkpoint_assets is not None and checkpoint_assets.image_target_size is not None:
-        image_target_size = checkpoint_assets.image_target_size
-        image_crop_size = checkpoint_assets.image_crop_size
-        shortest_image_edge = checkpoint_assets.shortest_image_edge
-        crop_fraction = checkpoint_assets.crop_fraction
-    else:
-        image_target_size = list(N1_7_DEFAULT_IMAGE_TARGET_SIZE)
-        image_crop_size = list(N1_7_DEFAULT_IMAGE_CROP_SIZE)
-        shortest_image_edge = None
-        crop_fraction = None
-    use_albumentations = checkpoint_assets.use_albumentations if checkpoint_assets is not None else False
-    letter_box_transform = checkpoint_assets.letter_box_transform if checkpoint_assets is not None else False
 
     input_steps: list[ProcessorStep] = [
         RenameObservationsProcessorStep(rename_map={}),
@@ -1364,6 +1366,30 @@ def _align_video_horizon(video: np.ndarray, horizon: int | None) -> np.ndarray:
         return video[:, -horizon:]
     pad = np.repeat(video[:, :1], horizon - current, axis=1)
     return np.concatenate([pad, video], axis=1)
+
+
+def _resize_video_to_image_target(video: np.ndarray, image_target_size: list[int] | None) -> np.ndarray:
+    """Resize a ``(B, T, H, W, C)`` camera stream so heterogeneous views can be stacked."""
+
+    if image_target_size is None:
+        return video
+
+    target_h, target_w = image_target_size
+    target_h = int(target_h)
+    target_w = int(target_w)
+    if target_h <= 0 or target_w <= 0:
+        raise ValueError(f"image_target_size must contain positive dimensions, got {image_target_size}")
+    if tuple(video.shape[-3:-1]) == (target_h, target_w):
+        return video
+
+    flat_video = video.reshape(-1, *video.shape[-3:])
+    resized_frames = []
+    for frame in flat_video:
+        resized = cv2.resize(frame, (target_w, target_h), interpolation=cv2.INTER_AREA)
+        if resized.ndim == 2:
+            resized = resized[:, :, None]
+        resized_frames.append(resized)
+    return np.stack(resized_frames, axis=0).reshape(*video.shape[:-3], target_h, target_w, video.shape[-1])
 
 
 def _build_n1_7_processor(model_name: str = GROOT_N1_7_BACKBONE_MODEL) -> ProcessorMixin:
@@ -1555,6 +1581,7 @@ class GrootN17PackInputsStep(ProcessorStep):
     clip_outliers: bool = True
     use_percentiles: bool = False
     video_modality_keys: list[str] | None = None
+    image_target_size: list[int] | None = None
     raw_stats: dict[str, Any] | None = None
     modality_config: dict[str, Any] | None = None
     _last_raw_state: dict[str, np.ndarray] | None = field(default=None, init=False, repr=False)
@@ -1852,6 +1879,8 @@ class GrootN17PackInputsStep(ProcessorStep):
         img_keys = self._ordered_image_keys(obs)
         if img_keys:
             cams = [_align_video_horizon(_to_uint8_np_bthwc(obs[k]), self.video_horizon) for k in img_keys]
+            if len({cam.shape[-3:] for cam in cams}) > 1:
+                cams = [_resize_video_to_image_target(camera, self.image_target_size) for camera in cams]
             video = np.stack(cams, axis=2)  # (B, T, V, H, W, C)
             obs["video"] = video
             image_keys_to_remove = [key for key in obs if key.startswith(OBS_IMAGES)]
@@ -2004,6 +2033,7 @@ class GrootN17PackInputsStep(ProcessorStep):
             "clip_outliers": self.clip_outliers,
             "use_percentiles": self.use_percentiles,
             "video_modality_keys": self.video_modality_keys,
+            "image_target_size": self.image_target_size,
             "raw_stats": self.raw_stats,
             "modality_config": self.modality_config,
         }

--- a/tests/policies/groot/test_groot_n1_7.py
+++ b/tests/policies/groot/test_groot_n1_7.py
@@ -1256,7 +1256,7 @@ def test_groot_n1_7_pack_inputs_orders_video_by_checkpoint_modality_keys():
     assert f"{OBS_IMAGES}.image2" not in output[TransitionKey.OBSERVATION]
 
 
-def test_groot_n1_7_pack_inputs_resizes_mixed_resolution_cameras_before_stack():
+def test_groot_n1_7_pack_inputs_letterboxes_mixed_resolution_cameras_before_stack():
     step = GrootN17PackInputsStep(
         normalize_min_max=False,
         video_modality_keys=["left_wrist", "right_wrist", "base"],
@@ -1275,9 +1275,18 @@ def test_groot_n1_7_pack_inputs_resizes_mixed_resolution_cameras_before_stack():
 
     video = output[TransitionKey.OBSERVATION]["video"]
     assert video.shape == (1, 1, 3, 256, 256, 3)
-    assert np.unique(video[0, 0, 0]).tolist() == [11]
-    assert np.unique(video[0, 0, 1]).tolist() == [22]
-    assert np.unique(video[0, 0, 2]).tolist() == [33]
+    # 16:9 wrist views retain a 256:144 content region; the 4:3 base view
+    # retains a 256:192 region. Black bars fill the remaining canvas instead
+    # of stretching either camera to a square.
+    assert np.all(video[0, 0, 0, :56] == 0)
+    assert np.all(video[0, 0, 0, 56:200] == 11)
+    assert np.all(video[0, 0, 0, 200:] == 0)
+    assert np.all(video[0, 0, 1, :56] == 0)
+    assert np.all(video[0, 0, 1, 56:200] == 22)
+    assert np.all(video[0, 0, 1, 200:] == 0)
+    assert np.all(video[0, 0, 2, :32] == 0)
+    assert np.all(video[0, 0, 2, 32:224] == 33)
+    assert np.all(video[0, 0, 2, 224:] == 0)
     assert f"{OBS_IMAGES}.left_wrist" not in output[TransitionKey.OBSERVATION]
     assert f"{OBS_IMAGES}.right_wrist" not in output[TransitionKey.OBSERVATION]
     assert f"{OBS_IMAGES}.base" not in output[TransitionKey.OBSERVATION]

--- a/tests/policies/groot/test_groot_n1_7.py
+++ b/tests/policies/groot/test_groot_n1_7.py
@@ -606,6 +606,7 @@ def test_raw_n1_7_libero_checkpoint_processors_use_checkpoint_assets(tmp_path):
         106.0,
     ]
     assert pack_inputs.stats[ACTION]["min"] == [11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0]
+    assert pack_inputs.image_target_size == [256, 256]
     assert vlm_encode.image_crop_size == [230, 230]
     assert vlm_encode.image_target_size == [256, 256]
     assert vlm_encode.shortest_image_edge == 256
@@ -1253,6 +1254,55 @@ def test_groot_n1_7_pack_inputs_orders_video_by_checkpoint_modality_keys():
     assert f"{OBS_IMAGES}.zz_extra" not in output[TransitionKey.OBSERVATION]
     assert f"{OBS_IMAGES}.image" not in output[TransitionKey.OBSERVATION]
     assert f"{OBS_IMAGES}.image2" not in output[TransitionKey.OBSERVATION]
+
+
+def test_groot_n1_7_pack_inputs_resizes_mixed_resolution_cameras_before_stack():
+    step = GrootN17PackInputsStep(
+        normalize_min_max=False,
+        video_modality_keys=["left_wrist", "right_wrist", "base"],
+        image_target_size=[256, 256],
+    )
+    transition = {
+        TransitionKey.OBSERVATION: {
+            f"{OBS_IMAGES}.left_wrist": torch.full((1, 3, 720, 1280), 11, dtype=torch.uint8),
+            f"{OBS_IMAGES}.right_wrist": torch.full((1, 3, 720, 1280), 22, dtype=torch.uint8),
+            f"{OBS_IMAGES}.base": torch.full((1, 3, 480, 640), 33, dtype=torch.uint8),
+        },
+        TransitionKey.COMPLEMENTARY_DATA: {"task": ["Move"]},
+    }
+
+    output = step(transition)
+
+    video = output[TransitionKey.OBSERVATION]["video"]
+    assert video.shape == (1, 1, 3, 256, 256, 3)
+    assert np.unique(video[0, 0, 0]).tolist() == [11]
+    assert np.unique(video[0, 0, 1]).tolist() == [22]
+    assert np.unique(video[0, 0, 2]).tolist() == [33]
+    assert f"{OBS_IMAGES}.left_wrist" not in output[TransitionKey.OBSERVATION]
+    assert f"{OBS_IMAGES}.right_wrist" not in output[TransitionKey.OBSERVATION]
+    assert f"{OBS_IMAGES}.base" not in output[TransitionKey.OBSERVATION]
+    assert output[TransitionKey.COMPLEMENTARY_DATA]["language"] == ["move"]
+
+
+def test_groot_n1_7_pack_inputs_keeps_uniform_camera_resolution_before_vlm_transform():
+    step = GrootN17PackInputsStep(
+        normalize_min_max=False,
+        image_target_size=[256, 256],
+    )
+    transition = {
+        TransitionKey.OBSERVATION: {
+            f"{OBS_IMAGES}.left": torch.full((1, 3, 4, 6), 11, dtype=torch.uint8),
+            f"{OBS_IMAGES}.right": torch.full((1, 3, 4, 6), 22, dtype=torch.uint8),
+        },
+        TransitionKey.COMPLEMENTARY_DATA: {"task": ["Move"]},
+    }
+
+    output = step(transition)
+
+    video = output[TransitionKey.OBSERVATION]["video"]
+    assert video.shape == (1, 1, 2, 4, 6, 3)
+    assert np.unique(video[0, 0, 0]).tolist() == [11]
+    assert np.unique(video[0, 0, 1]).tolist() == [22]
 
 
 def test_groot_n1_7_postprocessor_clips_normalized_action_before_unnormalizing():


### PR DESCRIPTION
## Summary / Motivation

GR00T N1.7 currently stacks camera streams before image preprocessing, so ordinary datasets with cameras at different resolutions fail immediately with `ValueError: all input arrays must have the same shape`. This change gives the pack step the checkpoint-resolved image target and normalizes heterogeneous camera shapes before stacking.

Each heterogeneous camera is resized to fit the target canvas while preserving its aspect ratio, then centered with black letterbox padding. This mirrors the geometry-preserving behavior used by the official Isaac-GR00T processor instead of stretching every view to a square. The fallback target remains the N1.7 default; the deprecated `GrootConfig.image_size` field is not used.

To avoid changing established behavior, pre-stack letterboxing only runs when the selected cameras have different frame shapes. Uniform-resolution inputs continue to reach the existing VLM image transform unchanged.

## Related issues

- Fixes #4117

## What changed

- Resolve checkpoint/default N1.7 image geometry before constructing `GrootN17PackInputsStep`.
- Fit heterogeneous camera streams into `image_target_size` with an aspect-ratio-preserving OpenCV `INTER_AREA` resize and centered black padding before `np.stack`.
- Serialize the pack step's target size and verify checkpoint geometry propagation.
- Add regressions for the reported 720p wrist / 480p base-camera layout, preserved 16:9 and 4:3 content geometry, and unchanged uniform-camera inputs.

No public API or migration change is introduced.

## How was this tested (or how to run locally)

- `uv run pytest tests/policies/groot/test_groot_n1_7.py -q` — 79 passed.
- `uv run pre-commit run --files src/lerobot/policies/groot/processor_groot.py tests/policies/groot/test_groot_n1_7.py` — all applicable hooks passed.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit` on changed files)
- [ ] All tests pass locally (the complete GR00T N1.7 test file passes; the full repository suite was not run)
- [x] Documentation updated (not required; internal bug fix with regression coverage)
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: pending

## Reviewer notes

- Please review the choice to normalize only heterogeneous inputs. It fixes the failing stack, preserves each camera's geometry, and keeps the existing transform path byte-for-byte for uniform-resolution datasets.
- This draft was developed with substantial Codex assistance. The implementation was inspected against the processor pipeline and validated with the tests and hooks listed above.
