### PR TITLE
fix(utils): treat an installed-but-broken transformers as unavailable

### DIFF
--- a/src/lerobot/utils/import_utils.py
+++ b/src/lerobot/utils/import_utils.py
@@ -104,13 +104,32 @@ def require_package(pkg_name: str, extra: str, import_name: str | None = None) -
         )
 
 
+def _try_import(module_name: str) -> bool:
+    """Return True only if the module actually imports.
+
+    A find_spec-based check passes for installed-but-broken packages (e.g. a
+    transformers whose own dependency pins are violated by the environment), and
+    the ImportError raised at import time then escapes the optional-dependency
+    guard in tokenizer_processor and takes down lerobot.datasets with it.
+    """
+    try:
+        importlib.import_module(module_name)
+        return True
+    except Exception as e:
+        logging.warning(
+            f"'{module_name}' is installed but failed to import and will be "
+            f"treated as unavailable: {type(e).__name__}: {e}"
+        )
+        return False
+
+
 # ── Centralised availability flags ────────────────────────────────────────
 # Every optional-dependency check lives here so that the rest of the codebase
 # can simply ``from lerobot.utils.import_utils import _foo_available``.
 # Do NOT define ad-hoc ``is_package_available(...)`` calls in other modules.
 
 # ML / training
-_transformers_available = is_package_available("transformers")
+_transformers_available = is_package_available("transformers") and _try_import("transformers")
 _peft_available = is_package_available("peft")
 _scipy_available = is_package_available("scipy")
 _diffusers_available = is_package_available("diffusers")

--- a/tests/utils/test_import_utils.py
+++ b/tests/utils/test_import_utils.py
@@ -1,0 +1,27 @@
+import importlib.util
+import sys
+
+from lerobot.utils.import_utils import _try_import
+
+
+def test_try_import_real_module():
+    assert _try_import("json") is True
+
+
+def test_try_import_missing_module():
+    assert _try_import("definitely_not_a_real_module_xyz") is False
+
+
+def test_present_but_broken_package(tmp_path, caplog):
+    pkg = tmp_path / "broken_pkg"
+    pkg.mkdir()
+    (pkg / "__init__.py").write_text('raise ImportError("dependency pins violated")\n')
+    sys.path.insert(0, str(tmp_path))
+    try:
+        # find_spec sees it — this is exactly the state the old check trusted
+        assert importlib.util.find_spec("broken_pkg") is not None
+        assert _try_import("broken_pkg") is False
+        assert "broken_pkg" in caplog.text
+    finally:
+        sys.path.remove(str(tmp_path))
+        sys.modules.pop("broken_pkg", None)


### PR DESCRIPTION
_transformers_available was computed with find_spec, which passes for a package that cannot actually be imported. Probe the real import instead, so a broken transformers (e.g. huggingface-hub pin violations on images that pre-install transformers 4.x) no longer crashes lerobot.processor and lerobot.datasets for users who never requested it.

Fixes #4332

## Title

Short, imperative summary (e.g., "fix(robots): handle None in sensor parser"). See [CONTRIBUTING.md](../CONTRIBUTING.md) for PR conventions.

## Summary / Motivation

- One-paragraph description of what changes and why.
- Why this change is needed and any trade-offs or design notes.

## Related issues

- Fixes / Closes: # (if any)
- Related: # (if any)

## What changed

- Short, concrete bullets explaining the functional changes (how the behavior or output differs now).
- Short note if this introduces breaking changes and migration steps.

## How was this tested (or how to run locally)

- Tests added: list new tests or test files. `pytest -q tests/ -k <keyword>`
- Manual checks / dataset runs performed.
- Instructions for the reviewer for reproducing with a quick example or CLI (if applicable)

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: # (insert PR number/link)

## Reviewer notes

- Anything the reviewer should focus on (performance, edge-cases, specific files) or general notes.
- Anyone in the community is free to review the PR.
