### PR TITLE
fix: verify real importability of optional dependencies beyond find_spec

### DIFF
--- a/src/lerobot/utils/import_utils.py
+++ b/src/lerobot/utils/import_utils.py
@@ -62,6 +62,19 @@ def is_package_available(
             else:
                 # For packages other than "torch", don't attempt the fallback and set as not available
                 package_exists = False
+
+        # Verify the package can actually be imported — find_spec only checks
+        # that the distribution metadata exists, not that the package is
+        # loadable at runtime (e.g. a dependency conflict can leave a package
+        # installed but broken, as with transformers + huggingface-hub on
+        # ROCm cloud images).
+        if package_exists:
+            try:
+                importlib.import_module(import_name)
+            except Exception:
+                package_exists = False
+                package_version = "N/A"
+
         logging.debug(f"Detected {pkg_name} version: {package_version}")
     if return_version:
         return package_exists, package_version


### PR DESCRIPTION
## Problem

`is_package_available()` in `lerobot/utils/import_utils.py` uses `importlib.util.find_spec()` to detect optional dependencies. `find_spec` only checks that the distribution metadata exists — it does **not** verify that the package can actually be loaded at runtime.

This causes a cryptic crash for all users who never requested transformers:

1. ROCm cloud images pre-install `transformers 4.x` (requires `huggingface-hub<1.0`)
2. User pip-installs LeRobot → pip upgrades `huggingface-hub>=1.0` for LeRobot
3. `transformers` is now broken (version conflict on `huggingface-hub`), but `find_spec("transformers")` still returns `True`
4. `_transformers_available = True` → `lerobot.processor` / `lerobot.datasets` crash at import

## Root cause

`find_spec` checks for distribution metadata (`.dist-info`), not actual importability. An installed-but-broken package passes the guard.

## Fix

Add a `try/except` around `importlib.import_module(import_name)` after `find_spec` succeeds. This matches the pattern already used for `torchcodec` in `get_safe_default_video_backend()` (lines 76-83).

## Reproduction (from the ROCm cloud)

```bash
pip install transformers==4.47.0
pip install "huggingface-hub>=1.0"
python -c "from lerobot.utils.import_utils import _transformers_available; print(_transformers_available)"
# Before fix: True (wrong — crashes downstream)
# After fix:  False (correct — package is broken)
```

## Testing

- `python -c "from lerobot.utils.import_utils import _transformers_available"` — no crash
- Existing CI should pass — this only adds a safety net, no behavior change for healthy installs

Closes #4332