### PR TITLE
Fix/aggregate video fast fail

### DIFF
--- a/src/lerobot/datasets/aggregate.py
+++ b/src/lerobot/datasets/aggregate.py
@@ -49,7 +49,7 @@ from .utils import (
     DEFAULT_VIDEO_PATH,
     update_chunk_file_indices,
 )
-from .video_utils import concatenate_video_files, get_video_duration_in_s
+from .video_utils import check_video_files_compatibility, concatenate_video_files, get_video_duration_in_s
 
 logger = logging.getLogger(__name__)
 
@@ -490,6 +490,18 @@ def aggregate_videos(
             }
         )
 
+        if concatenate_videos:
+            all_src_paths = [
+                src_meta.root
+                / DEFAULT_VIDEO_PATH.format(
+                    video_key=key,
+                    chunk_index=src_chunk_idx,
+                    file_index=src_file_idx,
+                )
+                for src_chunk_idx, src_file_idx in unique_chunk_file_pairs
+            ]
+            check_video_files_compatibility(all_src_paths)
+
         chunk_idx = video_idx["chunk"]
         file_idx = video_idx["file"]
         dst_file_durations = video_idx["dst_file_durations"]
@@ -546,11 +558,9 @@ def aggregate_videos(
                 current_dst_duration = dst_file_durations.get(dst_key, 0)
                 videos_idx[key]["src_to_offset"][(src_chunk_idx, src_file_idx)] = current_dst_duration
                 videos_idx[key]["src_to_dst"][(src_chunk_idx, src_file_idx)] = dst_key
-                # TODO(CarolinePascal): Move the check before the loop to avoid failing in the middle + add possibility to re-encode the video if the check fails
                 concatenate_video_files(
                     [dst_path, src_path],
                     dst_path,
-                    compatibility_check=True,
                 )
                 # Update duration of this destination file
                 dst_file_durations[dst_key] = current_dst_duration + src_duration

--- a/src/lerobot/datasets/video_utils.py
+++ b/src/lerobot/datasets/video_utils.py
@@ -645,6 +645,26 @@ def reencode_video(
         raise OSError(f"Video re-encoding did not work. File not found: {output_video_path}.")
 
 
+def check_video_files_compatibility(input_video_paths: list[Path | str]) -> None:
+    """Probes all input videos and raises ValueError upfront if any mismatch."""
+    if len(input_video_paths) <= 1:
+        return
+
+    reference_video_info = get_video_info(input_video_paths[0])
+    for input_path in input_video_paths[1:]:
+        video_info = get_video_info(input_path)
+        if (
+            video_info["video.height"] != reference_video_info["video.height"]
+            or video_info["video.width"] != reference_video_info["video.width"]
+            or video_info["video.fps"] != reference_video_info["video.fps"]
+            or video_info["video.codec"] != reference_video_info["video.codec"]
+            or video_info["video.pix_fmt"] != reference_video_info["video.pix_fmt"]
+        ):
+            raise ValueError(
+                f"Input video {input_path} is not compatible with the reference video {input_video_paths[0]}."
+            )
+
+
 def concatenate_video_files(
     input_video_paths: list[Path | str],
     output_video_path: Path,
@@ -683,19 +703,7 @@ def concatenate_video_files(
 
     # This check may be skipped at recording time as videos are encoded with the same encoder config.
     if compatibility_check:
-        reference_video_info = get_video_info(input_video_paths[0])
-        for input_path in input_video_paths[1:]:
-            video_info = get_video_info(input_path)
-            if (
-                video_info["video.height"] != reference_video_info["video.height"]
-                or video_info["video.width"] != reference_video_info["video.width"]
-                or video_info["video.fps"] != reference_video_info["video.fps"]
-                or video_info["video.codec"] != reference_video_info["video.codec"]
-                or video_info["video.pix_fmt"] != reference_video_info["video.pix_fmt"]
-            ):
-                raise ValueError(
-                    f"Input video {input_path} is not compatible with the reference video {input_video_paths[0]}."
-                )
+        check_video_files_compatibility(input_video_paths)
 
     # Create a temporary .ffconcat file to list the input video paths
     with tempfile.NamedTemporaryFile(mode="w", suffix=".ffconcat", delete=False) as tmp_concatenate_file:

--- a/tests/datasets/test_aggregate.py
+++ b/tests/datasets/test_aggregate.py
@@ -22,6 +22,8 @@ import pytest
 
 pytest.importorskip("datasets", reason="datasets is required (install lerobot[dataset])")
 
+from unittest.mock import MagicMock
+
 import datasets  # noqa: E402
 import numpy as np
 import pandas as pd
@@ -922,3 +924,44 @@ def test_aggregate_updates_per_episode_stats(tmp_path):
             else:
                 expected = base
             assert np.allclose(got, expected), f"ep{ep} {col}: {got} != {expected}"
+
+
+def test_aggregate_videos_fails_upfront_on_incompatible_videos(tmp_path):
+    """Upfront compatibility check fails before any copying or concatenation starts."""
+    from lerobot.datasets.aggregate import aggregate_videos
+
+    src_meta = MagicMock()
+    src_meta.root = tmp_path / "src"
+    src_meta.episodes = {
+        "videos/observation.images.cam/chunk_index": [0, 0],
+        "videos/observation.images.cam/file_index": [0, 1],
+    }
+
+    dst_meta = MagicMock()
+    dst_meta.root = tmp_path / "dst"
+
+    videos_idx = {
+        "observation.images.cam": {
+            "chunk": 0,
+            "file": 0,
+            "latest_duration": 0,
+            "episode_duration": 0,
+            "dst_file_durations": {},
+        }
+    }
+
+    with patch("lerobot.datasets.aggregate.check_video_files_compatibility") as mock_check:
+        mock_check.side_effect = ValueError("Input video is not compatible.")
+        with pytest.raises(ValueError, match="not compatible"):
+            aggregate_videos(
+                src_meta=src_meta,
+                dst_meta=dst_meta,
+                videos_idx=videos_idx,
+                video_files_size_in_mb=100.0,
+                chunk_size=10,
+                concatenate_videos=True,
+            )
+
+        # Assert check was called upfront before any shutil.copy or destination file creation
+        assert mock_check.called
+        assert not (dst_meta.root / "videos").exists()

--- a/tests/datasets/test_video_encoding.py
+++ b/tests/datasets/test_video_encoding.py
@@ -32,6 +32,7 @@ from lerobot.datasets.lerobot_dataset import LeRobotDataset
 from lerobot.datasets.pyav_utils import get_codec
 from lerobot.datasets.utils import INFO_PATH
 from lerobot.datasets.video_utils import (
+    check_video_files_compatibility,
     concatenate_video_files,
     encode_video_frames,
     get_video_info,
@@ -586,6 +587,12 @@ class TestConcatenateVideoFiles:
                 tmp_path / "out.mp4",
                 compatibility_check=True,
             )
+
+
+class TestCheckVideoFilesCompatibility:
+    def test_empty_or_single_list_does_not_raise(self):
+        check_video_files_compatibility([])
+        check_video_files_compatibility(["some/dummy/path.mp4"])
 
 
 class TestEncoderConfigPersistence:


### PR DESCRIPTION
## Title

 Perform video compatibility validation upfront in `aggregate_videos` to fail fast before starting video copying and concatenation loops.

## Summary / Motivation

 Previously, "aggregate_videos" performed video compatibility checks iteratively inside the file concatenation loop (`concatenate_video_files). If an incompatible video file (e.g. mismatched resolution, fps, codec, or pixel format) was encountered midway through processing a dataset, the function would fail halfway, leaving partially   copied/concatenated video files and destination states in an inconsistent state.
  
This PR addresses the TODO in aggregate_videos by extracting the video compatibility check into a dedicated helper and performing validation on all source video files prior to executing file modifications.

## What changed

• **Extracted Video Compatibility Check:** Created check_video_files_compatibility(input_video_paths) in video_utils.py to inspect and validate video stream parameters (height, width, fps, 
  codec, pixel format) across input paths.

  • **Upfront Fail-Fast in aggregate_videos**: Updated aggregate.py to run check_video_files_compatibility on all source video paths upfront before starting any file copying or concatenation  loops. This prevents partial aggregations and corrupted destination state when an incompatible video file exists midway through dataset aggregation.

  • **Removed Redundant Checks:** Removed redundant compatibility_check=True calls inside the per-file concatenation loop in aggregate_videos, since candidate videos are pre-validated before 
  the loop starts.

  • **Breaking Changes**: None. This is a non-breaking internal optimization that improves error handling timing.

## How was this tested (or how to run locally)

• Tests added:
      •     test_aggregate_videos_fails_upfront_on_incompatible_videos in test_aggregate.py: Asserts that video incompatibility raises ValueError upfront before destination directories or    
      files are created/copied.
      •    TestCheckVideoFilesCompatibility in test_video_encoding.py: Verifies edge cases (empty list or single file list) execute without raising errors.

- Local test commands:
-     uv run pytest tests/datasets/test_aggregate.py -k test_aggregate_videos_fails_upfront_on_incompatible_videos
- 
- Pre-commit checks:
-     uv run pre-commit run --files src/lerobot/datasets/aggregate.py src/lerobot/datasets/video_utils.py tests/datasets/test_aggregate.py tests/datasets/test_video_encoding.py      

## Checklist 
- [✓ ] Linting/formatting run (`pre-commit run -a`)
- [✓ ] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: # (insert PR number/link)

## Reviewer notes

Key Focus Areas:
      **• aggregate.py:** Verify the position of check_video_files_compatibility(all_src_paths) before dst_file_durations updates and copying operations.
      **• video_utils.py:** Verify extracted check_video_files_compatibility logic reused by concatenate_video_files.
  • Edge cases covered: Lists with ≤1 video return early without unnecessary stream metadata extraction overhead.
