### PR TITLE
perf(policies): move prepare_observation_for_inference's image conversion to GPU

### DIFF
--- a/src/lerobot/policies/utils.py
+++ b/src/lerobot/policies/utils.py
@@ -122,15 +122,32 @@ def prepare_observation_for_inference(
         A dictionary where values are PyTorch tensors preprocessed for
         inference, residing on the target device. Image tensors are reshaped
         to (C, H, W) and normalized to a [0, 1] range.
+
+    Performance note (2026-08-05): for image keys, the device transfer happens *before* the
+    uint8->float32 conversion and the channel permute, not after, even though the return value is
+    identical either way (dtype conversion, permute, and device placement all commute freely here
+    -- none of them are order-dependent for the final values). Doing it in this order transfers
+    4x fewer bytes over PCIe (uint8 is 1 byte/pixel vs. float32's 4) and lets the (much faster)
+    GPU do the elementwise divide and the memory copy `.contiguous()` forces, instead of the CPU.
+    Measured live on real SO-101 hardware (`Experiments/engineering/Engineering.md`, 2026-08-05):
+    this function was the single largest cost in the rollout control loop by a wide margin (~67%
+    of total loop time, ~4x the trained model's own forward pass) -- profile before assuming a
+    change like this actually matters for your workload, but it did for this one.
     """
     for name in observation:
-        observation[name] = torch.from_numpy(observation[name])
+        tensor = torch.from_numpy(observation[name])
+        tensor = tensor.unsqueeze(0)
         if "image" in name:
-            if observation[name].dtype == torch.uint8:
-                observation[name] = observation[name].type(torch.float32) / 255
-            observation[name] = observation[name].permute(2, 0, 1).contiguous()
-        observation[name] = observation[name].unsqueeze(0)
-        observation[name] = observation[name].to(device)
+            tensor = tensor.to(device, non_blocking=True)
+            if tensor.dtype == torch.uint8:
+                tensor = tensor.type(torch.float32) / 255
+            # Original permuted (H, W, C) -> (C, H, W) before its own unsqueeze; the unsqueeze
+            # above already ran, so the equivalent axis order including the batch dim is
+            # (1, H, W, C) -> (1, C, H, W).
+            tensor = tensor.permute(0, 3, 1, 2).contiguous()
+        else:
+            tensor = tensor.to(device, non_blocking=True)
+        observation[name] = tensor
 
     observation["task"] = task if task else ""
     observation["robot_type"] = robot_type if robot_type else ""

--- a/tests/policies/test_utils.py
+++ b/tests/policies/test_utils.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Correctness tests for `prepare_observation_for_inference`'s reordered image pipeline
+(2026-08-05): device transfer moved before the uint8->float32 conversion and channel permute,
+instead of after, for real measured performance reasons (see the function's own docstring and
+`Experiments/engineering/Engineering.md` in the parent research repo). These tests pin that the
+reordering is a pure performance change, not a behavior change: a local copy of the *original*
+step order is kept below as a ground-truth oracle, and every test compares the real function's
+output against it, rather than against hand-picked expected values that could drift.
+"""
+
+import numpy as np
+import pytest
+import torch
+
+from lerobot.policies.utils import prepare_observation_for_inference
+
+
+def _reference_prepare_observation_for_inference(observation, device, task=None, robot_type=None):
+    """The pre-2026-08-05 implementation, kept verbatim as a ground-truth oracle. Deliberately
+    duplicated rather than imported (there's nothing left to import it from) or reconstructed from
+    the new code (that would make the test circular)."""
+    observation = dict(observation)
+    for name in observation:
+        observation[name] = torch.from_numpy(observation[name])
+        if "image" in name:
+            if observation[name].dtype == torch.uint8:
+                observation[name] = observation[name].type(torch.float32) / 255
+            observation[name] = observation[name].permute(2, 0, 1).contiguous()
+        observation[name] = observation[name].unsqueeze(0)
+        observation[name] = observation[name].to(device)
+    observation["task"] = task if task else ""
+    observation["robot_type"] = robot_type if robot_type else ""
+    return observation
+
+
+def _make_observation():
+    rng = np.random.default_rng(0)
+    return {
+        "observation.images.front": rng.integers(0, 256, size=(480, 640, 3), dtype=np.uint8),
+        "observation.images.wrist": rng.integers(0, 256, size=(480, 640, 3), dtype=np.uint8),
+        "observation.state": rng.uniform(-1, 1, size=(6,)).astype(np.float32),
+    }
+
+
+DEVICES = ["cpu"] + (["cuda"] if torch.cuda.is_available() else [])
+
+
+@pytest.mark.parametrize("device_str", DEVICES)
+def test_matches_reference_implementation_exactly(device_str):
+    device = torch.device(device_str)
+    obs_a = _make_observation()
+    obs_b = {k: v.copy() for k, v in obs_a.items()}
+
+    actual = prepare_observation_for_inference(
+        obs_a, device, task="pick up the screwdriver", robot_type="so101"
+    )
+    expected = _reference_prepare_observation_for_inference(
+        obs_b, device, task="pick up the screwdriver", robot_type="so101"
+    )
+
+    for key in ("observation.images.front", "observation.images.wrist", "observation.state"):
+        # Exact (rtol=0, atol=0) on CPU: both implementations do the /255 divide on the same
+        # device with the same op, so there's no source of divergence at all. On CUDA, the divide
+        # now happens on-GPU instead of on-CPU (that's the whole point of the reordering) --
+        # CPU and GPU floating-point division aren't guaranteed bit-identical (different hardware
+        # implementations of the same IEEE754 operation), so a tiny, real, expected tolerance is
+        # correct here, not a sign of a bug. Observed magnitude on this hardware: ~6e-8, i.e.
+        # utterly negligible against a uint8 image's own ~0.0039 quantization step.
+        tol = {"rtol": 0, "atol": 0} if device.type == "cpu" else {"rtol": 1e-5, "atol": 1e-6}
+        torch.testing.assert_close(actual[key], expected[key], **tol)
+        assert actual[key].device.type == device.type
+        assert actual[key].shape == expected[key].shape
+        assert actual[key].dtype == expected[key].dtype
+
+    assert actual["task"] == expected["task"] == "pick up the screwdriver"
+    assert actual["robot_type"] == expected["robot_type"] == "so101"
+
+
+def test_image_normalized_to_unit_range_and_chw():
+    obs = _make_observation()
+    result = prepare_observation_for_inference(obs, torch.device("cpu"))
+    img = result["observation.images.front"]
+    assert img.shape == (1, 3, 480, 640)  # (batch, C, H, W)
+    assert img.dtype == torch.float32
+    assert img.min() >= 0.0
+    assert img.max() <= 1.0
+
+
+def test_image_tensor_is_contiguous():
+    """The permute alone would leave a non-contiguous view; `.contiguous()` must still run after
+    the reordering, not get lost in the process of moving the device transfer earlier."""
+    obs = _make_observation()
+    result = prepare_observation_for_inference(obs, torch.device("cpu"))
+    assert result["observation.images.front"].is_contiguous()
+
+
+def test_non_image_key_gets_batch_dim_and_device_but_no_normalization():
+    obs = _make_observation()
+    original_state = obs["observation.state"].copy()
+    result = prepare_observation_for_inference(obs, torch.device("cpu"))
+    state = result["observation.state"]
+    assert state.shape == (1, 6)
+    torch.testing.assert_close(state.squeeze(0), torch.from_numpy(original_state), rtol=0, atol=0)
+
+
+def test_missing_task_and_robot_type_default_to_empty_string():
+    obs = _make_observation()
+    result = prepare_observation_for_inference(obs, torch.device("cpu"))
+    assert result["task"] == ""
+    assert result["robot_type"] == ""
+
+
+def test_already_float_image_is_not_renormalized():
+    """An already-float image (dtype != uint8) must skip the /255 step entirely, same as the
+    original implementation's `if observation[name].dtype == torch.uint8` guard."""
+    obs = {
+        "observation.images.front": np.full((4, 4, 3), 0.5, dtype=np.float32),
+    }
+    result = prepare_observation_for_inference(obs, torch.device("cpu"))
+    torch.testing.assert_close(
+        result["observation.images.front"], torch.full((1, 3, 4, 4), 0.5), rtol=0, atol=0
+    )


### PR DESCRIPTION
## Summary / Motivation

`prepare_observation_for_inference` converts image observations from uint8 numpy arrays to normalized float32 tensors on the device. Currently, for image keys, it does the uint8→float32 conversion and the `permute(2,0,1).contiguous()` channel reorder **on the CPU, before** the device transfer. That means:
- float32 data (4 bytes/pixel) gets shipped over PCIe instead of uint8 (1 byte/pixel) — 4x more bytes than necessary.
- The CPU does the elementwise divide and the `.contiguous()` memory copy, both of which the GPU is faster at.

Moving `.to(device)` earlier — before the dtype conversion and permute, instead of after — fixes both. Dtype conversion, permute, and device placement all commute freely here (none are order-dependent for the final tensor values), so this is a pure performance change, not a behavior change.

**Real-world impact, measured live on SO-101 hardware** (not synthetic-only): this function was profiled as the single largest cost in a real rollout control loop — ~67% of total per-step time, ~4x the trained model's own forward pass. After this fix, on the same hardware/checkpoint: the function itself dropped from ~35.6ms to ~0.3ms per call (**~113x**), and the rollout's achieved control frequency went from a median of 18.3Hz to a median of 70.0Hz (0/459 → 459/459 steps clearing a 30Hz target). The function is called from every inference path (`SyncInferenceEngine`, RTC, `control_utils`), so this benefits any policy, not a specific one.

## Related issues

- Related: none filed separately — found via live hardware profiling of a rollout control loop.

## What changed

- `src/lerobot/policies/utils.py`: `prepare_observation_for_inference` now moves `.to(device)` before the uint8→float32 conversion and channel permute for image keys, instead of after. No change to non-image keys beyond harmless reordering (unsqueeze then transfer, same as before). No change to the function's signature, return shape, dtype, or semantics.
- `tests/policies/test_utils.py` (new — no test existed for this function before): 7 tests, including an exact-equivalence check against a locally-kept copy of the *original* step order (kept as a ground-truth oracle, not hand-picked expected values), covering CPU (exact) and CUDA (near-exact, ~1e-5 tolerance — real, expected CPU/GPU floating-point division rounding differences, not a bug), plus shape/dtype/contiguity/already-float-image/missing-task-default checks.

No breaking changes — same function signature, same output shape/dtype/semantics.

## How was this tested (or how to run locally)

- Tests added: `pytest -q tests/policies/test_utils.py` (7 new, all passing)
- Full existing rollout suite re-run for regressions: `pytest -q tests/test_rollout.py` (27 pre-existing, all passing)
- Synthetic microbenchmark (this hardware, CUDA): 3.05x speedup on the function in isolation (3.02ms → 0.99ms/call, 300 iterations)
- **Live hardware verification**: re-ran an actual rollout against a trained ACT checkpoint on a real SO-101 arm, before and after this fix, with added timing instrumentation (not part of this PR) to measure real per-step phase costs. Real result far exceeded the synthetic estimate (~113x vs. ~3x) — likely because the original CPU-bound conversion was contending with camera-capture background threads for CPU time on the live system, which an isolated synthetic benchmark can't reproduce.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [ ] Documentation updated — not applicable, no public API/config surface changed
- [ ] CI is green
- [x] Community Review: I have reviewed another contributor's open PR and linked it here: #4112

## Reviewer notes

- The core change is small and mechanical (reordering existing operations), but please double check the axis math in the permute: the original permuted `(H,W,C)→(C,H,W)` *before* its own `unsqueeze(0)`; since `unsqueeze` now runs first, the equivalent permute with the batch dim already present is `permute(0,3,1,2)` instead of `permute(2,0,1)` — verified via the exact-equivalence test, but worth a second look given the axis indices with the batch dim are the easiest place to get subtly wrong.
- The CUDA test tolerance (`rtol=1e-5`) is intentional, not a cop-out — CPU-vs-GPU floating point division for the same op isn't guaranteed bit-identical, and the observed divergence (~6e-8) is many orders of magnitude below anything that could matter (a uint8 image's own quantization step is ~0.0039).

---
*Significant AI assistance was used in developing this PR (profiling, implementation, and test-writing), per LeRobot's AI Usage Policy. I've reviewed and understand the change, verified it against a locally-kept ground-truth oracle for the original behavior, and confirmed the real-world performance impact on my own SO-101 hardware before submitting.*
