### PR TITLE
put image data to cpu before send to Qwen2_5_VLProcessor

### DIFF
--- a/src/lerobot/policies/eo1/processor_eo1.py
+++ b/src/lerobot/policies/eo1/processor_eo1.py
@@ -103,7 +103,7 @@ class EO1ConversationTemplateStep(ComplementaryDataProcessorStep):
         # LeRobot visual observations reach in processor as float32 tensors in [0, 1].
         # Convert to uint8 in [0, 255] to meet the input requirement of Qwen2.5-VL-3B-Instruct.
         images = {
-            key: observation[key].clamp(0, 1).mul(255.0).round().to(torch.uint8) for key in self._image_keys
+            key: observation[key].clamp(0, 1).mul(255.0).round().to(torch.uint8).cpu() for key in self._image_keys
         }
         messages = []
         for i in range(len(tasks)):


### PR DESCRIPTION
## Title

put image data to cpu before send to Qwen2_5_VLProcessor

## Summary / Motivation

- Qwen2_5_VLProcessor.apply_chat_template can only process data in cpu, if not, it will get error "can't convert cuda:0 device type tensor to numpy. Use Tensor.cpu() to copy the tensor to host memory first."

## Related issues

- no

## What changed

- Short, concrete bullets explaining the functional changes (how the behavior or output differs now).
- Short note if this introduces breaking changes and migration steps.

## How was this tested (or how to run locally)

- Manual checks / dataset runs performed.


## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated
- [x] CI is green
- [x] Community Review: I have reviewed another contributor's open PR and linked it here: # (insert PR number/link)

## Reviewer notes

- Anything the reviewer should focus on (performance, edge-cases, specific files) or general notes.
- Anyone in the community is free to review the PR.
