### PR TITLE
fix(eval): give each parallel task its own policy state

### DIFF
--- a/src/lerobot/scripts/lerobot_eval.py
+++ b/src/lerobot/scripts/lerobot_eval.py
@@ -945,6 +945,31 @@ def run_one(
     return task_group, task_id, metrics
 
 
+def _policy_view_for_task(policy):
+    """Return a per-task view of `policy` that shares weights but owns its episode state.
+
+    `eval_one` calls `policy.reset()` at the start of every rollout, and `select_action`
+    mutates per-episode state as it goes (action-chunk queues, temporal ensembler,
+    KV caches). Sharing one instance across thread-pool workers lets one task's `reset()`
+    wipe the action chunk another task is halfway through consuming, so every task returns
+    garbage actions -- silently, with no crash and no warning.
+
+    Parameters and buffers are seeded into the deepcopy memo, so the view reuses the
+    original tensors: it costs no extra device memory, only the Python-level module graph.
+    """
+    memo = {id(t): t for t in (*policy.parameters(), *policy.buffers())}
+    try:
+        view = deepcopy(policy, memo)
+    except Exception as e:
+        raise RuntimeError(
+            f"Cannot evaluate {type(policy).__name__} with max_parallel_tasks > 1: it carries "
+            f"per-episode state that must not be shared across threads, and it could not be "
+            f"copied ({e}). Re-run with max_parallel_tasks=1."
+        ) from e
+    view.reset()
+    return view
+
+
 def eval_policy_all(
     envs: dict[str, dict[int, gym.vector.VectorEnv]],
     policy,
@@ -1054,7 +1079,11 @@ def eval_policy_all(
             with cf.ThreadPoolExecutor(max_workers=max_parallel_tasks) as executor:
                 fut2meta = {}
                 for task_group, task_id, env in tasks:
-                    fut = executor.submit(task_runner, task_group, task_id, env)
+                    # Override the shared policy bound into `task_runner`: workers must not
+                    # share per-episode state (see `_policy_view_for_task`).
+                    fut = executor.submit(
+                        task_runner, task_group, task_id, env, policy=_policy_view_for_task(policy)
+                    )
                     fut2meta[fut] = (task_group, task_id, env)
                 for fut in cf.as_completed(fut2meta):
                     tg, tid, env = fut2meta[fut]

--- a/tests/scripts/test_lerobot_eval.py
+++ b/tests/scripts/test_lerobot_eval.py
@@ -1,0 +1,130 @@
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for `eval_policy_all` task parallelism.
+
+These cover policy-state isolation only, so they need no environment and no GPU.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("gymnasium", reason="gymnasium is required (install lerobot[evaluation])")
+pytest.importorskip("datasets", reason="datasets is required (install lerobot[dataset])")
+
+from torch import nn  # noqa: E402
+
+from lerobot.scripts import lerobot_eval  # noqa: E402
+
+
+class _FakePolicy(nn.Module):
+    """Minimal stand-in for a chunked policy: per-episode queue, reassigned by `reset`."""
+
+    def __init__(self):
+        super().__init__()
+        self.layer = nn.Linear(2, 2)  # so the policy owns parameters to share
+        self._action_queue: list[int] = []
+
+    def reset(self):
+        self._action_queue = []
+
+
+class _StubEnv:
+    def close(self):
+        pass
+
+
+def _run_eval(policy, n_tasks, max_parallel_tasks):
+    envs = {"group": {i: _StubEnv() for i in range(n_tasks)}}
+    return lerobot_eval.eval_policy_all(
+        envs,
+        policy,
+        MagicMock(),
+        MagicMock(),
+        MagicMock(),
+        MagicMock(),
+        n_episodes=1,
+        max_parallel_tasks=max_parallel_tasks,
+    )
+
+
+def _metrics(success):
+    return {"sum_rewards": 0.0, "max_rewards": 0.0, "successes": [success]}
+
+
+def test_parallel_tasks_get_isolated_policy_state(monkeypatch):
+    """Each worker must get its own policy view, or tasks clobber each other's action queue."""
+    policy = _FakePolicy()
+    seen_ids = []
+    queue_intact = []
+
+    def fake_run_one(task_group, task_id, env, *, policy, **kwargs):
+        seen_ids.append(id(policy))
+        policy.reset()
+        policy._action_queue.append(task_id)
+        # Long enough that a shared policy is reset by a sibling task before we look again.
+        time.sleep(0.05)
+        queue_intact.append(policy._action_queue == [task_id])
+        return task_group, task_id, _metrics(queue_intact[-1])
+
+    monkeypatch.setattr(lerobot_eval, "run_one", fake_run_one)
+    _run_eval(policy, n_tasks=4, max_parallel_tasks=4)
+
+    assert len(set(seen_ids)) == 4, "tasks shared a policy instance"
+    assert id(policy) not in seen_ids, "the caller's policy was handed to a worker"
+    assert all(queue_intact), "a task's action queue was reset by a concurrent task"
+
+
+def test_policy_view_shares_parameters():
+    """Views must reuse the original tensors so parallel eval costs no extra device memory."""
+    policy = _FakePolicy()
+    view = lerobot_eval._policy_view_for_task(policy)
+
+    assert view is not policy
+    assert view.layer.weight is policy.layer.weight
+    assert view._action_queue is not policy._action_queue
+
+
+def test_sequential_path_still_uses_the_original_policy(monkeypatch):
+    """`max_parallel_tasks=1` is already safe; it must not pay for copies."""
+    policy = _FakePolicy()
+    seen = []
+
+    def fake_run_one(task_group, task_id, env, *, policy, **kwargs):
+        seen.append(policy)
+        return task_group, task_id, _metrics(True)
+
+    monkeypatch.setattr(lerobot_eval, "run_one", fake_run_one)
+    _run_eval(policy, n_tasks=2, max_parallel_tasks=1)
+
+    assert seen == [policy, policy]
+
+
+def test_uncopyable_policy_raises_actionable_error(monkeypatch):
+    """A policy that cannot be copied must fail loudly, not silently return garbage."""
+
+    class _Uncopyable(_FakePolicy):
+        def __deepcopy__(self, memo):
+            raise TypeError("cannot pickle 'tokenizers.Tokenizer' object")
+
+    def fake_run_one(task_group, task_id, env, *, policy, **kwargs):
+        return task_group, task_id, _metrics(True)
+
+    monkeypatch.setattr(lerobot_eval, "run_one", fake_run_one)
+    with pytest.raises(RuntimeError, match="max_parallel_tasks=1"):
+        _run_eval(_Uncopyable(), n_tasks=2, max_parallel_tasks=2)


### PR DESCRIPTION
## Summary / Motivation

`eval_policy_all` binds one policy instance into the task runner and shares it across
`ThreadPoolExecutor` workers. `eval_one` calls `policy.reset()` at the start of every rollout, and
every policy's `reset()` reassigns its action-chunk queues (`self._action_queue = deque(...)`). With
`max_parallel_tasks > 1`, one task's reset wipes the chunk another task is halfway through consuming,
so tasks return garbage actions — silently, no crash, exit code 0.

Measurements from the issue (`lerobot/smolvla_libero`, `libero_spatial`, 4 tasks x 5 episodes, seed 42):

| configuration | success | wall clock |
|---|---|---|
| `max_parallel_tasks=1` | 85% | 890s |
| `max_parallel_tasks=4` | **0%** | 303s |

The existing code already hoists one shared-state hazard out of the workers — the comment above
`policy.eval()` notes that restoring train/eval mode inside a task would let one task flip the mode
while another is still evaluating. The per-episode queue state has exactly the same problem and was
missed.

## Related issues

- Fixes: #4327

## What changed

- New `_policy_view_for_task()`: `deepcopy` with the policy's parameters and buffers seeded into the
  memo, so the copy reuses the original tensors. Weights stay shared — no extra device memory — and
  only the Python-level module graph and per-episode state are duplicated.
- The threaded branch now submits a per-task view, overriding the shared policy bound into the
  `task_runner` partial.
- A policy that cannot be deep-copied raises a `RuntimeError` naming the policy and pointing at
  `max_parallel_tasks=1`, instead of silently producing garbage rollouts.
- The sequential path (`max_parallel_tasks <= 1`) is unchanged and still uses the caller's policy.

No breaking changes.

## How was this tested (or how to run locally)

Tests added: `tests/scripts/test_lerobot_eval.py` — the module had no tests. CPU-only, no environment
and no GPU required.

```
pytest -q tests/scripts/test_lerobot_eval.py
```

Four cases: per-task isolation under real thread contention, parameter sharing between view and
original, sequential path unchanged, and the uncopyable-policy error path.

Reverting only the change to `lerobot_eval.py` makes 3 of the 4 fail; the sequential-path test still
passes, as expected.

**Verified end to end on a GPU** (RTX 4070, LIBERO, `lerobot/smolvla_libero`). Three runs of 4 tasks
x 10 episodes, seed 42; baseline is this PR's parent commit `64b2317`, so the patch is the only
difference between runs 2 and 3:

| run | commit | `max_parallel_tasks` | success | eval_s | VRAM peak |
|---|---|---|---|---|---|
| 1 | `64b2317` (parent) | 1 | **72.5%** (29/40) | 655 s | 5423 MiB |
| 2 | `64b2317` (parent) | 4 | **0.0%** (0/40) | 1147 s | 6702 MiB |
| 3 | this PR | 4 | **72.5%** (29/40) | 479 s | 6833 MiB |

Run 3 matches run 1 task for task (8/10, 7/10, 6/10, 8/10), so the fixed parallel path is equivalent
to the sequential one, not merely close to it. Absolute rates are 72.5% here against the issue's 85%
— different machine and episode count — but that is constant across runs 1 and 3.

Runs 2 and 3 are both `max_parallel_tasks=4`, which isolates the memory claim: peak VRAM moves
6702 → 6833 MiB (+131 MiB, +2.0%) while mean moves 6495 → 6296 MiB (−199 MiB, −3.1%). The two deltas
point opposite ways, so this is allocator noise, not per-view cost — three extra copies of a ~450M
parameter model would be measured in GB. Full command and per-task breakdown in the comments.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run --files` on the two changed files)
- [x] Tests pass locally — `pytest -q tests/scripts/test_lerobot_eval.py` (4 passed), plus the end-to-end
      LIBERO eval above.
- [ ] Documentation updated — n/a, no user-facing behaviour or CLI surface changes
- [x] CI is green — all 12 checks pass, including the 8 simulator eval jobs
- [x] Community Review: I have reviewed another contributor's open PR and linked it here: #4285

## Reviewer notes

- Design point worth a second opinion: the view is built **per task** (`len(tasks)` copies) rather
  than per worker thread. Copies are cheap because tensors are shared, and it keeps the diff small,
  but a `threading.local` cache would cut it to `max_parallel_tasks`. Happy to switch if preferred.
- The shared processors (`preprocessor` / `postprocessor` / `env_preprocessor` / `env_postprocessor`)
  are deliberately left alone here. If any processor step carries per-episode state it has the same
  hazard — out of scope for this fix, but probably worth a look.

