### PR TITLE
fix(async_inference): do not resize camera frames to the dataset resolution

### DIFF
--- a/src/lerobot/async_inference/helpers.py
+++ b/src/lerobot/async_inference/helpers.py
@@ -46,7 +46,7 @@ RawObservation = dict[str, Any]
 # observation as those recorded in LeRobot dataset (keys are different)
 LeRobotObservation = dict[str, torch.Tensor]
 
-# observation, ready for policy inference (image keys resized)
+# observation, ready for policy inference (images as (B, C, H, W) float32 in [0, 1])
 Observation = dict[str, torch.Tensor]
 
 
@@ -71,28 +71,14 @@ def is_image_key(k: str) -> bool:
     return k.startswith(OBS_IMAGES)
 
 
-def resize_robot_observation_image(image: torch.tensor, resize_dims: tuple[int, int, int]) -> torch.tensor:
-    assert image.ndim == 3, f"Image must be (C, H, W)! Received {image.shape}"
-    # (H, W, C) -> (C, H, W) for resizing from robot obsevation resolution to policy image resolution
-    image = image.permute(2, 0, 1)
-    dims = (resize_dims[1], resize_dims[2])
-    # Add batch dimension for interpolate: (C, H, W) -> (1, C, H, W)
-    image_batched = image.unsqueeze(0)
-    # Interpolate and remove batch dimension: (1, C, H, W) -> (C, H, W)
-    resized = torch.nn.functional.interpolate(image_batched, size=dims, mode="bilinear", align_corners=False)
-
-    return resized.squeeze(0)
-
-
 # TODO(Steven): Consider implementing a pipeline step for this
 def raw_observation_to_observation(
     raw_observation: RawObservation,
     lerobot_features: dict[str, dict],
-    policy_image_features: dict[str, PolicyFeature],
 ) -> Observation:
     observation = {}
 
-    observation = prepare_raw_observation(raw_observation, lerobot_features, policy_image_features)
+    observation = prepare_raw_observation(raw_observation, lerobot_features)
     for k, v in observation.items():
         if isinstance(v, torch.Tensor):  # VLAs present natural-language instructions in observations
             if "image" in k:
@@ -128,9 +114,26 @@ def extract_state_from_raw_observation(
 def extract_images_from_raw_observation(
     lerobot_obs: RawObservation,
     camera_key: str,
-) -> dict[str, torch.Tensor]:
-    """Extract the images from a raw observation."""
-    return torch.tensor(lerobot_obs[camera_key])
+) -> torch.Tensor:
+    """Extract one camera image from a raw observation, as a (C, H, W) tensor.
+
+    Only the (H, W, C) -> (C, H, W) transposition is applied: the camera's native resolution is
+    preserved, so the policy's own aspect-ratio-preserving resize (e.g. `resize_with_pad`) sees
+    exactly the same input it would see during sync inference. Resizing here to
+    `policy.config.image_features` -- the resolution the training *dataset* was recorded at, which
+    has nothing to do with the camera resolution used at inference time -- used to distort the
+    aspect ratio and short-circuit that internal resize. See #2980.
+    """
+    image = torch.tensor(lerobot_obs[camera_key])
+    # Checking ndim alone isn't enough: an already channel-first (C, H, W) frame also has
+    # ndim == 3 and would silently permute into a nonsense shape below. Channel-last with 1
+    # (depth) or 3 (RGB) channels is the only layout cameras produce (see `hw_to_dataset_features`).
+    if image.ndim != 3 or image.shape[-1] not in (1, 3):
+        raise ValueError(
+            f"Camera image must be (H, W, C) with 1 or 3 channels! Received {tuple(image.shape)} for {camera_key}"
+        )
+
+    return image.permute(2, 0, 1)
 
 
 def make_lerobot_observation(
@@ -144,10 +147,8 @@ def make_lerobot_observation(
 def prepare_raw_observation(
     robot_obs: RawObservation,
     lerobot_features: dict[str, dict],
-    policy_image_features: dict[str, PolicyFeature],
 ) -> Observation:
-    """Matches keys from the raw robot_obs dict to the keys expected by a given policy (passed as
-    policy_image_features)."""
+    """Matches keys from the raw robot_obs dict to the keys expected by the policy."""
     # 1. {motor.pos1:value1, motor.pos2:value2, ..., laptop:np.ndarray} ->
     # -> {observation.state:[value1,value2,...], observation.images.laptop:np.ndarray}
     lerobot_obs = make_lerobot_observation(robot_obs, lerobot_features)
@@ -156,15 +157,9 @@ def prepare_raw_observation(
     image_keys = list(filter(is_image_key, lerobot_obs))
     # state's shape is expected as (B, state_dim)
     state_dict = {OBS_STATE: extract_state_from_raw_observation(lerobot_obs)}
+    # image's shape is (C, H, W), at the camera's native resolution
     image_dict = {
         image_k: extract_images_from_raw_observation(lerobot_obs, image_k) for image_k in image_keys
-    }
-
-    # Turns the image features to (C, H, W) with H, W matching the policy image features.
-    # This reduces the resolution of the images
-    image_dict = {
-        key: resize_robot_observation_image(torch.tensor(lerobot_obs[key]), policy_image_features[key].shape)
-        for key in image_keys
     }
 
     if "task" in robot_obs:

--- a/src/lerobot/async_inference/policy_server.py
+++ b/src/lerobot/async_inference/policy_server.py
@@ -92,10 +92,6 @@ class PolicyServer(services_pb2_grpc.AsyncInferenceServicer):
     def running(self):
         return not self.shutdown_event.is_set()
 
-    @property
-    def policy_image_features(self):
-        return self.policy.config.image_features
-
     def _reset_server(self) -> None:
         """Flushes server state when new client connects."""
         # only running inference on the latest observation received by the server
@@ -342,7 +338,6 @@ class PolicyServer(services_pb2_grpc.AsyncInferenceServicer):
         observation: Observation = raw_observation_to_observation(
             observation_t.get_observation(),
             self.lerobot_features,
-            self.policy_image_features,
         )
         prepare_time = time.perf_counter() - start_prepare
 

--- a/tests/async_inference/test_helpers.py
+++ b/tests/async_inference/test_helpers.py
@@ -31,9 +31,8 @@ from lerobot.async_inference.helpers import (  # noqa: E402
     prepare_image,
     prepare_raw_observation,
     raw_observation_to_observation,
-    resize_robot_observation_image,
 )
-from lerobot.configs.types import FeatureType, PolicyFeature
+from lerobot.policies.utils import build_inference_frame  # noqa: E402
 from lerobot.utils.constants import OBS_IMAGES, OBS_STATE
 
 # ---------------------------------------------------------------------
@@ -245,20 +244,6 @@ def _create_mock_lerobot_features():
     }
 
 
-def _create_mock_policy_image_features():
-    """Create mock policy image features with different resolutions."""
-    return {
-        f"{OBS_IMAGES}.laptop": PolicyFeature(
-            type=FeatureType.VISUAL,
-            shape=(3, 224, 224),  # Policy expects smaller resolution
-        ),
-        f"{OBS_IMAGES}.phone": PolicyFeature(
-            type=FeatureType.VISUAL,
-            shape=(3, 160, 160),  # Different resolution for second camera
-        ),
-    }
-
-
 def test_prepare_image():
     """Test image preprocessing: int8 → float32, normalization to [0,1]."""
     # Create mock int8 image data
@@ -283,32 +268,12 @@ def test_prepare_image():
     assert processed.is_contiguous()
 
 
-def test_resize_robot_observation_image():
-    """Test image resizing from robot resolution to policy resolution."""
-    # Create mock image: (H=480, W=640, C=3)
-    original_image = torch.randint(0, 256, size=(480, 640, 3), dtype=torch.uint8)
-    target_shape = (3, 224, 224)  # (C, H, W)
-
-    resized = resize_robot_observation_image(original_image, target_shape)
-
-    # Check output shape matches target
-    assert resized.shape == target_shape
-
-    # Check that original image had different dimensions
-    assert original_image.shape != resized.shape
-
-    # Check that resizing preserves value range
-    assert resized.min() >= 0
-    assert resized.max() <= 255
-
-
 def test_prepare_raw_observation():
     """Test the preparation of raw robot observation to lerobot format."""
     robot_obs = _create_mock_robot_observation()
     lerobot_features = _create_mock_lerobot_features()
-    policy_image_features = _create_mock_policy_image_features()
 
-    prepared = prepare_raw_observation(robot_obs, lerobot_features, policy_image_features)
+    prepared = prepare_raw_observation(robot_obs, lerobot_features)
 
     # Check that state is properly extracted and batched
     assert OBS_STATE in prepared
@@ -316,29 +281,85 @@ def test_prepare_raw_observation():
     assert isinstance(state, torch.Tensor)
     assert state.shape == (1, 4)  # Batched state
 
-    # Check that images are processed and resized
+    # Check that images are present
     assert f"{OBS_IMAGES}.laptop" in prepared
     assert f"{OBS_IMAGES}.phone" in prepared
 
     laptop_img = prepared[f"{OBS_IMAGES}.laptop"]
     phone_img = prepared[f"{OBS_IMAGES}.phone"]
 
-    # Check image shapes match policy requirements
-    assert laptop_img.shape == policy_image_features[f"{OBS_IMAGES}.laptop"].shape
-    assert phone_img.shape == policy_image_features[f"{OBS_IMAGES}.phone"].shape
+    # Images are only transposed to (C, H, W): the camera resolution is preserved, and no
+    # resizing to `policy.config.image_features` happens here anymore (#2980). dtype stays
+    # uint8 until `prepare_image` converts it.
+    assert laptop_img.shape == (3, 480, 640)
+    assert phone_img.shape == (3, 480, 640)
+    assert laptop_img.dtype == torch.uint8
+    assert phone_img.dtype == torch.uint8
 
     # Check that images are tensors
     assert isinstance(laptop_img, torch.Tensor)
     assert isinstance(phone_img, torch.Tensor)
 
 
+def test_prepare_raw_observation_rejects_non_hwc_image():
+    """A (H, W) grayscale frame cannot be transposed to (C, H, W): fail loudly, not silently."""
+    robot_obs = {
+        "shoulder": 1.0,
+        "elbow": 2.0,
+        "wrist": 3.0,
+        "gripper": 0.5,
+        "laptop": np.zeros((480, 640), dtype=np.uint8),
+    }
+    lerobot_features = {
+        OBS_STATE: {
+            "dtype": "float32",
+            "shape": [4],
+            "names": ["shoulder", "elbow", "wrist", "gripper"],
+        },
+        f"{OBS_IMAGES}.laptop": {
+            "dtype": "image",
+            "shape": [480, 640],
+            "names": ["height", "width"],
+        },
+    }
+
+    with pytest.raises(ValueError, match="H, W, C"):
+        prepare_raw_observation(robot_obs, lerobot_features)
+
+
+def test_prepare_raw_observation_rejects_channel_first_image():
+    """A frame that is already (C, H, W) also has ndim == 3: checking ndim alone would let it
+    through and silently permute it into a nonsense (W, C, H) shape instead of raising."""
+    robot_obs = {
+        "shoulder": 1.0,
+        "elbow": 2.0,
+        "wrist": 3.0,
+        "gripper": 0.5,
+        "laptop": np.zeros((3, 480, 640), dtype=np.uint8),
+    }
+    lerobot_features = {
+        OBS_STATE: {
+            "dtype": "float32",
+            "shape": [4],
+            "names": ["shoulder", "elbow", "wrist", "gripper"],
+        },
+        f"{OBS_IMAGES}.laptop": {
+            "dtype": "image",
+            "shape": [3, 480, 640],
+            "names": ["channels", "height", "width"],
+        },
+    }
+
+    with pytest.raises(ValueError, match="H, W, C"):
+        prepare_raw_observation(robot_obs, lerobot_features)
+
+
 def test_raw_observation_to_observation_basic():
     """Test the main raw_observation_to_observation function."""
     robot_obs = _create_mock_robot_observation()
     lerobot_features = _create_mock_lerobot_features()
-    policy_image_features = _create_mock_policy_image_features()
 
-    observation = raw_observation_to_observation(robot_obs, lerobot_features, policy_image_features)
+    observation = raw_observation_to_observation(robot_obs, lerobot_features)
 
     # Check that all expected keys are present
     assert OBS_STATE in observation
@@ -354,9 +375,9 @@ def test_raw_observation_to_observation_basic():
     laptop_img = observation[f"{OBS_IMAGES}.laptop"]
     phone_img = observation[f"{OBS_IMAGES}.phone"]
 
-    # Images should have batch dimension: (B, C, H, W)
-    assert laptop_img.shape == (1, 3, 224, 224)
-    assert phone_img.shape == (1, 3, 160, 160)
+    # Images keep the camera resolution and gain a batch dimension: (B, C, H, W)
+    assert laptop_img.shape == (1, 3, 480, 640)
+    assert phone_img.shape == (1, 3, 480, 640)
 
     # Check image dtype and range (should be float32 in [0, 1])
     assert laptop_img.dtype == torch.float32
@@ -371,9 +392,8 @@ def test_raw_observation_to_observation_with_non_tensor_data():
     robot_obs["task"] = "pick up the red cube"  # Add string instruction
 
     lerobot_features = _create_mock_lerobot_features()
-    policy_image_features = _create_mock_policy_image_features()
 
-    observation = raw_observation_to_observation(robot_obs, lerobot_features, policy_image_features)
+    observation = raw_observation_to_observation(robot_obs, lerobot_features)
 
     # Check that task string is preserved
     assert "task" in observation
@@ -386,9 +406,8 @@ def test_raw_observation_to_observation_device_handling():
     """Test that tensors are created (device placement is handled by preprocessor)."""
     robot_obs = _create_mock_robot_observation()
     lerobot_features = _create_mock_lerobot_features()
-    policy_image_features = _create_mock_policy_image_features()
 
-    observation = raw_observation_to_observation(robot_obs, lerobot_features, policy_image_features)
+    observation = raw_observation_to_observation(robot_obs, lerobot_features)
 
     # Check that all expected keys produce tensors (device placement handled by preprocessor later)
     for key, value in observation.items():
@@ -400,11 +419,10 @@ def test_raw_observation_to_observation_deterministic():
     """Test that the function produces consistent results for the same input."""
     robot_obs = _create_mock_robot_observation()
     lerobot_features = _create_mock_lerobot_features()
-    policy_image_features = _create_mock_policy_image_features()
 
     # Run twice with same input
-    obs1 = raw_observation_to_observation(robot_obs, lerobot_features, policy_image_features)
-    obs2 = raw_observation_to_observation(robot_obs, lerobot_features, policy_image_features)
+    obs1 = raw_observation_to_observation(robot_obs, lerobot_features)
+    obs2 = raw_observation_to_observation(robot_obs, lerobot_features)
 
     # Results should be identical
     assert set(obs1.keys()) == set(obs2.keys())
@@ -435,20 +453,77 @@ def test_image_processing_pipeline_preserves_content():
             "names": ["height", "width", "channels"],
         },
     }
-    policy_image_features = {
-        f"{OBS_IMAGES}.laptop": PolicyFeature(
-            type=FeatureType.VISUAL,
-            shape=(3, 50, 50),  # Downsamples from 100x100
-        )
-    }
 
-    observation = raw_observation_to_observation(robot_obs, lerobot_features, policy_image_features)
+    observation = raw_observation_to_observation(robot_obs, lerobot_features)
 
     processed_img = observation[f"{OBS_IMAGES}.laptop"].squeeze(0)  # Remove batch dim
 
+    # Resolution is preserved end-to-end; only dtype/layout change.
+    assert processed_img.shape == (3, 100, 100)
+
     # Check that the center region has higher values than corners
-    # Due to bilinear interpolation, exact values will change but pattern should remain
-    center_val = processed_img[:, 25, 25].mean()  # Center of 50x50 image
-    corner_val = processed_img[:, 5, 5].mean()  # Corner
+    center_val = processed_img[:, 50, 50].mean()  # Inside the white square
+    corner_val = processed_img[:, 5, 5].mean()  # Outside it
 
     assert center_val > corner_val, "Image processing should preserve recognizable patterns"
+
+
+# ---------------------------------------------------------------------
+# sync/async preprocessing parity  (regression guard for #2980 / #2475)
+# ---------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "camera_shapes",
+    [
+        {"laptop": (480, 640, 3)},
+        {"laptop": (720, 1280, 3)},
+        {"laptop": (480, 640, 3), "phone": (720, 1280, 3)},
+    ],
+    ids=["480p", "720p", "mixed_resolution"],
+)
+def test_sync_and_async_preprocessing_are_identical(camera_shapes):
+    """The async server must hand the policy exactly what sync inference hands it.
+
+    `build_inference_frame` is what `SyncInferenceEngine` uses; `raw_observation_to_observation`
+    is what `PolicyServer._predict_action_chunk` uses. Given the same robot observation they must
+    produce bit-identical tensors, otherwise the same checkpoint behaves differently depending on
+    which inference backend runs it -- which is exactly what #2980 reported: async used to resize
+    camera frames down to `policy.config.image_features` (the *dataset recording* resolution),
+    squashing the aspect ratio and defeating the policy's internal `resize_with_pad`.
+    """
+    rng = np.random.default_rng(0)
+    motor_names = ["shoulder", "elbow", "wrist", "gripper"]
+    task = "pick up the red cube"
+
+    robot_obs = {name: float(i) for i, name in enumerate(motor_names)}
+    # `RobotClient.control_loop_observation` always sets this key, even for non-VLA policies.
+    robot_obs["task"] = task
+    lerobot_features = {
+        OBS_STATE: {"dtype": "float32", "shape": [len(motor_names)], "names": motor_names},
+    }
+    for camera, shape in camera_shapes.items():
+        robot_obs[camera] = rng.integers(0, 256, size=shape, dtype=np.uint8)
+        lerobot_features[f"{OBS_IMAGES}.{camera}"] = {
+            "dtype": "image",
+            "shape": list(shape),
+            "names": ["height", "width", "channels"],
+        }
+
+    sync_observation = build_inference_frame(
+        dict(robot_obs), torch.device("cpu"), lerobot_features, task=task
+    )
+    async_observation = raw_observation_to_observation(dict(robot_obs), lerobot_features)
+
+    # `robot_type` is sync-only bookkeeping: nothing downstream reads it back off the observation.
+    shared_keys = set(sync_observation) - {"robot_type"}
+    assert shared_keys == set(async_observation)
+
+    for key in sorted(shared_keys):
+        expected, actual = sync_observation[key], async_observation[key]
+        if isinstance(expected, torch.Tensor):
+            assert actual.shape == expected.shape, key
+            assert actual.dtype == expected.dtype, key
+            torch.testing.assert_close(actual, expected, rtol=0, atol=0, msg=f"mismatch for {key}")
+        else:
+            assert actual == expected, key


### PR DESCRIPTION

## Summary / Motivation

Async inference resized camera frames to `policy.config.image_features` before passing them to the policy. This shape comes from the resolution used when recording the training dataset and is not necessarily related to the camera resolution used during inference. The resize also changed the aspect ratio because it used plain bilinear interpolation. This interfered with the aspect ratio preserving resize inside each policy, such as `resize_with_pad` and `resize_with_pad_torch`.

For pi0, pi05, and pi0_fast, `image_resolution` is square. Resizing to that shape before policy preprocessing caused the policy's internal resize to be skipped completely.

This issue was reported in #2980. With the same hardware and task, a SmolVLA checkpoint fine tuned on the current dataset format achieved an 80 to 90 percent success rate with sync inference and approximately 0 percent with async inference.

The resize was performed by:

`prepare_raw_observation()` → `resize_robot_observation_image()` in `helpers.py`

Sync inference does not resize camera frames before passing them to the policy. This behavior existed only in async inference.

I measured the output against sync inference using the same configuration as #2980:

* SmolVLA
* 1280x720 camera
* `input_features=(3,256,256)`
* `resize_imgs_with_padding=(512,512)`

| Implementation | Result against sync inference |
|---|---:|
| Current `main` | 8.38 dB PSNR |
| #3158 with center padding | 7.95 dB PSNR |
| This PR | Bit identical |

## Related issues

* Fixes #2980
* Fixes #2475
* Supersedes #3158. Thanks to @jashshah999 for the earlier attempt.
* Related to #3832

## What changed

* Camera frames are now passed to the policy at their native resolution, matching sync inference.
* Removed `resize_robot_observation_image()`.
* Removed the unused `policy_image_features` argument from `prepare_raw_observation`.
* Removed the unused `policy_image_features` argument from `raw_observation_to_observation`.
* Removed `PolicyServer.policy_image_features`.
* Added validation that raises `ValueError` when a camera frame does not have the expected `(H, W, C)` shape.
* This does not introduce a user facing breaking change.

## How was this tested (or how to run locally)

* Ran `pre-commit run -a`.
* Ran `pytest tests/async_inference`.
* Added `test_sync_and_async_preprocessing_are_identical`.
* Tested 480p, 720p, and mixed resolution camera inputs.
* Verified that `build_inference_frame` for sync inference and `raw_observation_to_observation` for async inference produce bit identical tensors from the same robot observation.
* Verified that the new parity test fails against `main` because the old function signature still requires the resize argument, and passes with this change.
* Updated existing tests for the native, unresized camera frame shapes.
* Added a test that verifies an invalid camera frame shape raises `ValueError`.

## Checklist (required before merge)

* [x] Linting/formatting run (`pre-commit run -a`)
* [x] All tests pass locally (`pytest`)
  * The async inference test suite passes with `pytest tests/async_inference`.
* [x] Documentation updated
  * No documentation update is required because this does not change the public API or user workflow.
* [ ] CI is green
* [x] Community Review: I reviewed #3158 and left feedback there.

## Reviewer notes

Please focus on whether camera preprocessing should remain fully owned by each policy.

I also checked pi0 and pi05. When `helpers.py` resizes the image first, their internal resize becomes a no op. The padding method selected in `helpers.py` therefore becomes the final preprocessing result.

The required behavior differs between policy families:

* SmolVLA and XVLA use top left padding.
* pi0, pi05, and pi0_fast use center padding.
* GR00T uses shortest edge resizing and cropping.
* EVO1 and MolmoAct2 do not perform an internal resize.

Because of these differences, there is no single resize or padding rule in `helpers.py` that is correct for every policy.

There is no additional network cost. The previous resize happened on the server in `PolicyServer._predict_action_chunk`, after the observation had already been received over gRPC.

The additional server CPU cost is approximately 0.1 to 1.2 ms per frame, depending on the camera resolution. This is small compared with the policy forward time.

AI disclosure: I used Claude Code for the investigation, implementation, tests, and numeric verification, including the PSNR and parity measurements. I reviewed the code, test results, and measurements myself.