### PR TITLE
docs: fix Sphinx roles and Attributes sections for doc-builder

### DIFF
--- a/src/lerobot/cameras/camera.py
+++ b/src/lerobot/cameras/camera.py
@@ -33,10 +33,10 @@ class Camera(abc.ABC):
     - Connection/disconnection
     - Frame capture (sync/async/latest)
 
-    Attributes:
-        fps (int | None): Configured frames per second
-        width (int | None): Frame width in pixels
-        height (int | None): Frame height in pixels
+    **Attributes**:
+        - **fps** (`int | None`) -- Configured frames per second.
+        - **width** (`int | None`) -- Frame width in pixels.
+        - **height** (`int | None`) -- Frame height in pixels.
     """
 
     def __init__(self, config: CameraConfig):

--- a/src/lerobot/cameras/opencv/configuration_opencv.py
+++ b/src/lerobot/cameras/opencv/configuration_opencv.py
@@ -40,17 +40,20 @@ class OpenCVCameraConfig(CameraConfig):
     OpenCVCameraConfig(0, 30, 1280, 720, fourcc="YUYV")     # With YUYV format
     ```
 
-    Attributes:
-        index_or_path: Either an integer representing the camera device index,
-                      or a Path object pointing to a video file.
-        fps: Requested frames per second for the color stream.
-        width: Requested frame width in pixels for the color stream.
-        height: Requested frame height in pixels for the color stream.
-        color_mode: Color mode for image output (RGB or BGR). Defaults to RGB.
-        rotation: Image rotation setting (0°, 90°, 180°, or 270°). Defaults to no rotation.
-        warmup_s: Time reading frames before returning from connect (in seconds)
-        fourcc: FOURCC code for video format (e.g., "MJPG", "YUYV", "I420"). Defaults to None (auto-detect).
-        backend: OpenCV backend identifier (https://docs.opencv.org/3.4/d4/d15/group__videoio__flags__base.html). Defaults to ANY.
+    **Attributes**:
+        - **index_or_path** (`int | Path`) -- Either an integer representing the camera device index, or a
+          Path object pointing to a video file.
+        - **fps** -- Requested frames per second for the color stream.
+        - **width** -- Requested frame width in pixels for the color stream.
+        - **height** -- Requested frame height in pixels for the color stream.
+        - **color_mode** (`ColorMode`) -- Color mode for image output (RGB or BGR). Defaults to RGB.
+        - **rotation** (`Cv2Rotation`) -- Image rotation setting (0°, 90°, 180°, or 270°). Defaults to no
+          rotation.
+        - **warmup_s** (`int`) -- Time reading frames before returning from connect (in seconds)
+        - **fourcc** (`str | None`) -- FOURCC code for video format (e.g., "MJPG", "YUYV", "I420"). Defaults
+          to None (auto-detect).
+        - **backend** (`Cv2Backends`) -- OpenCV backend identifier
+          (https://docs.opencv.org/3.4/d4/d15/group__videoio__flags__base.html). Defaults to ANY.
 
     Note:
         - Only 3-channel color output (RGB/BGR) is currently supported.

--- a/src/lerobot/cameras/reachy2_camera/configuration_reachy2_camera.py
+++ b/src/lerobot/cameras/reachy2_camera/configuration_reachy2_camera.py
@@ -43,16 +43,16 @@ class Reachy2CameraConfig(CameraConfig):
     )  # Left teleop camera, 640x480 @ 30FPS
     ```
 
-    Attributes:
-        name: Name of the camera device. Can be "teleop" or "depth".
-        image_type: Type of image stream. For "teleop" camera, can be "left" or "right".
-                    For "depth" camera, can be "rgb" or "depth". (depth is not supported yet)
-        fps: Requested frames per second for the color stream. Not configurable for Reachy 2 cameras.
-        width: Requested frame width in pixels for the color stream.
-        height: Requested frame height in pixels for the color stream.
-        color_mode: Color mode for image output (RGB or BGR). Defaults to RGB.
-        ip_address: IP address of the robot. Defaults to "localhost".
-        port: Port number for the camera server. Defaults to 50065.
+    **Attributes**:
+        - **name** (`str`) -- Name of the camera device. Can be "teleop" or "depth".
+        - **image_type** (`str`) -- Type of image stream. For "teleop" camera, can be "left" or "right". For
+          "depth" camera, can be "rgb" or "depth". (depth is not supported yet)
+        - **fps** -- Requested frames per second for the color stream. Not configurable for Reachy 2 cameras.
+        - **width** -- Requested frame width in pixels for the color stream.
+        - **height** -- Requested frame height in pixels for the color stream.
+        - **color_mode** (`ColorMode`) -- Color mode for image output (RGB or BGR). Defaults to RGB.
+        - **ip_address** (`str | None`) -- IP address of the robot. Defaults to "localhost".
+        - **port** (`int`) -- Port number for the camera server. Defaults to 50065.
 
     Note:
         - Only 3-channel color output (RGB/BGR) is currently supported.

--- a/src/lerobot/cameras/realsense/configuration_realsense.py
+++ b/src/lerobot/cameras/realsense/configuration_realsense.py
@@ -36,27 +36,28 @@ class RealSenseCameraConfig(CameraConfig):
     RealSenseCameraConfig("0123456789", 30, 640, 480, rotation=Cv2Rotation.ROTATE_90)  # With 90° rotation
     ```
 
-    Attributes:
-        fps: Requested frames per second for the color stream.
-        width: Requested frame width in pixels for the color stream.
-        height: Requested frame height in pixels for the color stream.
-        serial_number_or_name: Unique serial number or human-readable name to identify the camera.
-        color_mode: Color mode for image output (RGB or BGR). Defaults to RGB.
-        use_rgb: Whether to enable the color stream. Defaults to True.
-        use_depth: Whether to enable depth stream. Defaults to False.
-        rotation: Image rotation setting (0°, 90°, 180°, or 270°). Defaults to no rotation.
-        warmup_s: Time reading frames before returning from connect (in seconds)
-        exposure: Manual exposure value for the color sensor. When set, auto-exposure is
-            disabled and this fixed value is used. Valid ranges are camera-model specific
-            and reported if the value is rejected. Defaults to None (leave unchanged).
-        gain: Manual gain value for the color sensor. When set, auto-exposure is disabled
-            and this fixed gain is used, which also freezes exposure at its current value
-            when no exposure is configured. Valid ranges are camera-model specific and
-            reported if the value is rejected. Defaults to None (leave unchanged).
-        white_balance: Manual white balance value for the color sensor. When set, auto
-            white balance is disabled and this fixed value is used. Valid ranges are
-            camera-model specific and reported if the value is rejected. Defaults to None
-            (leave unchanged).
+    **Attributes**:
+        - **fps** -- Requested frames per second for the color stream.
+        - **width** -- Requested frame width in pixels for the color stream.
+        - **height** -- Requested frame height in pixels for the color stream.
+        - **serial_number_or_name** (`str`) -- Unique serial number or human-readable name to identify the
+          camera.
+        - **color_mode** (`ColorMode`) -- Color mode for image output (RGB or BGR). Defaults to RGB.
+        - **use_rgb** (`bool`) -- Whether to enable the color stream. Defaults to True.
+        - **use_depth** (`bool`) -- Whether to enable depth stream. Defaults to False.
+        - **rotation** (`Cv2Rotation`) -- Image rotation setting (0°, 90°, 180°, or 270°). Defaults to no
+          rotation.
+        - **warmup_s** (`int`) -- Time reading frames before returning from connect (in seconds)
+        - **exposure** (`int | None`) -- Manual exposure value for the color sensor. When set, auto-exposure
+          is disabled and this fixed value is used. Valid ranges are camera-model specific and reported if the
+          value is rejected. Defaults to None (leave unchanged).
+        - **gain** (`int | None`) -- Manual gain value for the color sensor. When set, auto-exposure is
+          disabled and this fixed gain is used, which also freezes exposure at its current value when no
+          exposure is configured. Valid ranges are camera-model specific and reported if the value is
+          rejected. Defaults to None (leave unchanged).
+        - **white_balance** (`int | None`) -- Manual white balance value for the color sensor. When set, auto
+          white balance is disabled and this fixed value is used. Valid ranges are camera-model specific and
+          reported if the value is rejected. Defaults to None (leave unchanged).
 
     Note:
         - Either name or serial_number must be specified.

--- a/src/lerobot/motors/motors_bus.py
+++ b/src/lerobot/motors/motors_bus.py
@@ -595,7 +595,7 @@ class SerialMotorsBus(MotorsBusBase):
         ID, and finally programs the bus' default baud-rate.
 
         Args:
-            motor (str): Key of the motor in :pyattr:`motors`.
+            motor (str): Key of the motor in `motors`.
             initial_baudrate (int | None, optional): Current baud-rate (skips scanning when provided).
                 Defaults to None.
             initial_id (int | None, optional): Current ID (skips scanning when provided). Defaults to None.
@@ -666,7 +666,7 @@ class SerialMotorsBus(MotorsBusBase):
         """Enable torque on selected motors.
 
         Args:
-            motors (int | str | list[str] | None, optional): Same semantics as :pymeth:`disable_torque`.
+            motors (int | str | list[str] | None, optional): Same semantics as [`~motors.motors_bus.MotorsBus.disable_torque`].
                 Defaults to `None`.
             num_retry (int, optional): Number of additional retry attempts on communication failure.
                 Defaults to 0.
@@ -695,7 +695,7 @@ class SerialMotorsBus(MotorsBusBase):
 
         Args:
             timeout_ms (int | None, optional): Timeout in *milliseconds*. If `None` (default) the method falls
-                back to :pyattr:`default_timeout`.
+                back to `default_timeout`.
         """
         timeout_ms = timeout_ms if timeout_ms is not None else self.default_timeout
         self.port_handler.setPacketTimeoutMillis(timeout_ms)
@@ -746,8 +746,8 @@ class SerialMotorsBus(MotorsBusBase):
 
         Args:
             calibration_dict (dict[str, MotorCalibration]): Calibration obtained from
-                :pymeth:`read_calibration` or crafted by the user.
-            cache (bool, optional): Save the calibration to :pyattr:`calibration`. Defaults to True.
+                [`~motors.motors_bus.MotorsBus.read_calibration`] or crafted by the user.
+            cache (bool, optional): Save the calibration to `calibration`. Defaults to True.
         """
         pass
 
@@ -755,7 +755,7 @@ class SerialMotorsBus(MotorsBusBase):
         """Restore factory calibration for the selected motors.
 
         Homing offset is set to ``0`` and min/max position limits are set to the full usable range.
-        The in-memory :pyattr:`calibration` is cleared.
+        The in-memory `calibration` is cleared.
 
         Args:
             motors (NameOrID | Sequence[NameOrID] | None, optional): Selection of motors. `None` (default)
@@ -1069,9 +1069,9 @@ class SerialMotorsBus(MotorsBusBase):
     ) -> None:
         """Write a value to a single motor's register.
 
-        Contrary to :pymeth:`sync_write`, this expects a response status packet emitted by the motor, which
+        Contrary to [`~motors.motors_bus.MotorsBus.sync_write`], this expects a response status packet emitted by the motor, which
         provides a guarantee that the value was written to the register successfully. In consequence, it is
-        slower than :pymeth:`sync_write` but it is more reliable. It should typically be used when configuring
+        slower than [`~motors.motors_bus.MotorsBus.sync_write`] but it is more reliable. It should typically be used when configuring
         motors.
 
         Args:
@@ -1228,8 +1228,8 @@ class SerialMotorsBus(MotorsBusBase):
     ) -> None:
         """Write the same register on multiple motors.
 
-        Contrary to :pymeth:`write`, this *does not* expects a response status packet emitted by the motor, which
-        can allow for lost packets. It is faster than :pymeth:`write` and should typically be used when
+        Contrary to [`~motors.motors_bus.MotorsBus.write`], this *does not* expects a response status packet emitted by the motor, which
+        can allow for lost packets. It is faster than [`~motors.motors_bus.MotorsBus.write`] and should typically be used when
         frequency matters and losing some packets is acceptable (e.g. teleoperation loops).
 
         Args:

--- a/src/lerobot/policies/factory.py
+++ b/src/lerobot/policies/factory.py
@@ -131,12 +131,16 @@ class ProcessorConfigKwargs(TypedDict, total=False):
     This provides type hints for the optional arguments passed to `make_pre_post_processors`,
     improving code clarity and enabling static analysis.
 
-    Attributes:
-        preprocessor_config_filename: The filename for the preprocessor configuration.
-        postprocessor_config_filename: The filename for the postprocessor configuration.
-        preprocessor_overrides: A dictionary of overrides for the preprocessor configuration.
-        postprocessor_overrides: A dictionary of overrides for the postprocessor configuration.
-        dataset_stats: Dataset statistics for normalization.
+    **Attributes**:
+        - **preprocessor_config_filename** (`str | None`) -- The filename for the preprocessor configuration.
+        - **postprocessor_config_filename** (`str | None`) -- The filename for the postprocessor
+          configuration.
+        - **preprocessor_overrides** (`dict[str, Any] | None`) -- A dictionary of overrides for the
+          preprocessor configuration.
+        - **postprocessor_overrides** (`dict[str, Any] | None`) -- A dictionary of overrides for the
+          postprocessor configuration.
+        - **dataset_stats** (`dict[str, dict[str, torch.Tensor]] | None`) -- Dataset statistics for
+          normalization.
     """
 
     preprocessor_config_filename: str | None

--- a/src/lerobot/policies/rtc/action_queue.py
+++ b/src/lerobot/policies/rtc/action_queue.py
@@ -46,10 +46,11 @@ class ActionQueue:
     Args:
         cfg (RTCConfig): Configuration for Real-Time Chunking behavior.
 
-    Attributes:
-        queue (Tensor | None): Processed actions for robot rollout (time_steps, action_dim).
-        original_queue (Tensor | None): Original actions for RTC computation (time_steps, action_dim).
-        last_index (int): Current consumption index in the queue.
+    **Attributes**:
+        - **queue** (`Tensor | None`) -- Processed actions for robot rollout (time_steps, action_dim).
+        - **original_queue** (`Tensor | None`) -- Original actions for RTC computation (time_steps,
+          action_dim).
+        - **last_index** (`int`) -- Current consumption index in the queue.
     """
 
     def __init__(self, cfg: RTCConfig):

--- a/src/lerobot/policies/rtc/debug_tracker.py
+++ b/src/lerobot/policies/rtc/debug_tracker.py
@@ -27,19 +27,19 @@ from torch import Tensor
 class DebugStep:
     """Container for debug information from a single denoising step.
 
-    Attributes:
-        step_idx (int): Step index/counter.
-        x_t (Tensor | None): Current latent/state tensor.
-        v_t (Tensor | None): Velocity from denoiser.
-        x1_t (Tensor | None): Denoised prediction (x_t - time * v_t).
-        correction (Tensor | None): Correction gradient tensor.
-        err (Tensor | None): Weighted error term.
-        weights (Tensor | None): Prefix attention weights.
-        guidance_weight (float | Tensor | None): Applied guidance weight.
-        time (float | Tensor | None): Time parameter.
-        inference_delay (int | None): Inference delay parameter.
-        execution_horizon (int | None): Execution horizon parameter.
-        metadata (dict[str, Any]): Additional metadata.
+    **Attributes**:
+        - **step_idx** (`int`) -- Step index/counter.
+        - **x_t** (`Tensor | None`) -- Current latent/state tensor.
+        - **v_t** (`Tensor | None`) -- Velocity from denoiser.
+        - **x1_t** (`Tensor | None`) -- Denoised prediction (x_t - time * v_t).
+        - **correction** (`Tensor | None`) -- Correction gradient tensor.
+        - **err** (`Tensor | None`) -- Weighted error term.
+        - **weights** (`Tensor | None`) -- Prefix attention weights.
+        - **guidance_weight** (`float | Tensor | None`) -- Applied guidance weight.
+        - **time** (`float | Tensor | None`) -- Time parameter.
+        - **inference_delay** (`int | None`) -- Inference delay parameter.
+        - **execution_horizon** (`int | None`) -- Execution horizon parameter.
+        - **metadata** (`dict[str, Any]`) -- Additional metadata.
     """
 
     step_idx: int = 0

--- a/src/lerobot/processor/batch_processor.py
+++ b/src/lerobot/processor/batch_processor.py
@@ -217,10 +217,12 @@ class AddBatchDimensionProcessorStep(ProcessorStep):
     This step combines individual processors for actions, observations, and complementary data
     to create a batched transition (batch size 1) from a single-instance transition.
 
-    Attributes:
-        to_batch_action_processor: Processor for the action component.
-        to_batch_observation_processor: Processor for the observation component.
-        to_batch_complementary_data_processor: Processor for the complementary data component.
+    **Attributes**:
+        - **to_batch_action_processor** (`AddBatchDimensionActionStep`) -- Processor for the action component.
+        - **to_batch_observation_processor** (`AddBatchDimensionObservationStep`) -- Processor for the
+          observation component.
+        - **to_batch_complementary_data_processor** (`AddBatchDimensionComplementaryDataStep`) -- Processor
+          for the complementary data component.
     """
 
     to_batch_action_processor: AddBatchDimensionActionStep = field(

--- a/src/lerobot/processor/delta_action_processor.py
+++ b/src/lerobot/processor/delta_action_processor.py
@@ -32,9 +32,8 @@ class MapTensorToDeltaActionDictStep(ActionProcessorStep):
     It decomposes the vector into named components for delta movements of the
     end-effector (x, y, z) and optionally the gripper.
 
-    Attributes:
-        use_gripper: If True, assumes the 4th element of the tensor is the
-                     gripper action.
+    **Attributes**:
+        - **use_gripper** (`bool`) -- If True, assumes the 4th element of the tensor is the gripper action.
     """
 
     use_gripper: bool = True
@@ -81,10 +80,10 @@ class MapDeltaActionToRobotActionStep(RobotActionProcessorStep):
     into a target action format that includes an "enabled" flag and target
     end-effector positions. It also handles scaling and noise filtering.
 
-    Attributes:
-        position_scale: A factor to scale the delta position inputs.
-        noise_threshold: The magnitude below which delta inputs are considered noise
-                         and do not trigger an "enabled" state.
+    **Attributes**:
+        - **position_scale** (`float`) -- A factor to scale the delta position inputs.
+        - **noise_threshold** (`float`) -- The magnitude below which delta inputs are considered noise and do
+          not trigger an "enabled" state.
     """
 
     # Scale factors for delta movements

--- a/src/lerobot/processor/device_processor.py
+++ b/src/lerobot/processor/device_processor.py
@@ -40,10 +40,10 @@ class DeviceProcessorStep(ProcessorStep):
 
     This is crucial for preparing data for model training or inference on hardware like GPUs.
 
-    Attributes:
-        device: The target device for tensors (e.g., "cpu", "cuda", "cuda:0").
-        float_dtype: The target floating-point dtype as a string (e.g., "float32", "float16", "bfloat16").
-                     If None, the dtype is not changed.
+    **Attributes**:
+        - **device** (`str`) -- The target device for tensors (e.g., "cpu", "cuda", "cuda:0").
+        - **float_dtype** (`str | None`) -- The target floating-point dtype as a string (e.g., "float32",
+          "float16", "bfloat16"). If None, the dtype is not changed.
     """
 
     device: str = "cpu"

--- a/src/lerobot/processor/gym_action_processor.py
+++ b/src/lerobot/processor/gym_action_processor.py
@@ -33,10 +33,9 @@ class Torch2NumpyActionProcessorStep(ActionProcessorStep):
     This step is useful when the output of a policy (typically a torch.Tensor)
     needs to be passed to an environment or component that expects a NumPy array.
 
-    Attributes:
-        squeeze_batch_dim: If True, removes the first dimension of the array
-                           if it is of size 1. This is useful for converting a
-                           batched action of size (1, D) to a single action of size (D,).
+    **Attributes**:
+        - **squeeze_batch_dim** (`bool`) -- If True, removes the first dimension of the array if it is of size
+          1. This is useful for converting a batched action of size (1, D) to a single action of size (D,).
     """
 
     squeeze_batch_dim: bool = True

--- a/src/lerobot/processor/hil_processor.py
+++ b/src/lerobot/processor/hil_processor.py
@@ -101,8 +101,8 @@ class AddTeleopActionAsComplimentaryDataStep(ComplementaryDataProcessorStep):
     be available to downstream processors, for example, to override a policy's action
     during an intervention.
 
-    Attributes:
-        teleop_device: The teleoperator instance to get the action from.
+    **Attributes**:
+        - **teleop_device** (`Teleoperator`) -- The teleoperator instance to get the action from.
     """
 
     teleop_device: "Teleoperator"
@@ -137,9 +137,9 @@ class AddTeleopEventsAsInfoStep(InfoProcessorStep):
     This step extracts control events from teleoperators that support event-based
     interaction, making these signals available to other parts of the system.
 
-    Attributes:
-        teleop_device: An instance of a teleoperator that implements the
-                       `HasTeleopEvents` protocol.
+    **Attributes**:
+        - **teleop_device** (`TeleopWithEvents`) -- An instance of a teleoperator that implements the
+          `HasTeleopEvents` protocol.
     """
 
     teleop_device: TeleopWithEvents
@@ -180,10 +180,10 @@ class ImageCropResizeProcessorStep(ObservationProcessorStep):
     the specified transformations. It handles device placement, moving tensors to the
     CPU if necessary for operations not supported on certain accelerators like MPS.
 
-    Attributes:
-        crop_params_dict: A dictionary mapping image keys to cropping parameters
-                          (top, left, height, width).
-        resize_size: A tuple (height, width) to resize all images to.
+    **Attributes**:
+        - **crop_params_dict** (`dict[str, tuple[int, int, int, int]] | None`) -- A dictionary mapping image
+          keys to cropping parameters (top, left, height, width).
+        - **resize_size** (`tuple[int, int] | None`) -- A tuple (height, width) to resize all images to.
     """
 
     crop_params_dict: dict[str, tuple[int, int, int, int]] | None = None
@@ -267,9 +267,9 @@ class TimeLimitProcessorStep(TruncatedProcessorStep):
     """
     Tracks episode steps and enforces a time limit by truncating the episode.
 
-    Attributes:
-        max_episode_steps: The maximum number of steps allowed per episode.
-        current_step: The current step count for the active episode.
+    **Attributes**:
+        - **max_episode_steps** (`int`) -- The maximum number of steps allowed per episode.
+        - **current_step** (`int`) -- The current step count for the active episode.
     """
 
     max_episode_steps: int
@@ -358,11 +358,11 @@ class GripperPenaltyProcessorStep(ProcessorStep):
     This discourages gripper oscillation while leaving "stay" and saturating-further
     commands unpenalized.
 
-    Attributes:
-        penalty: The negative reward value to apply.
-        max_gripper_pos: The maximum position value for the gripper, used for normalization.
-        open_threshold: Normalized state below which the gripper is considered "open".
-        closed_threshold: Normalized state above which the gripper is considered "closed".
+    **Attributes**:
+        - **penalty** (`float`) -- The negative reward value to apply.
+        - **max_gripper_pos** (`float`) -- The maximum position value for the gripper, used for normalization.
+        - **open_threshold** (`float`) -- Normalized state below which the gripper is considered "open".
+        - **closed_threshold** (`float`) -- Normalized state above which the gripper is considered "closed".
     """
 
     penalty: float = -0.02
@@ -456,10 +456,10 @@ class InterventionActionProcessorStep(ProcessorStep):
     this step replaces the policy's action with the human's teleoperated action.
     It also processes signals to terminate the episode or flag success.
 
-    Attributes:
-        use_gripper: Whether to include the gripper in the teleoperated action.
-        terminate_on_success: If True, automatically sets the `done` flag when a
-                              `success` event is received.
+    **Attributes**:
+        - **use_gripper** (`bool`) -- Whether to include the gripper in the teleoperated action.
+        - **terminate_on_success** (`bool`) -- If True, automatically sets the `done` flag when a `success`
+          event is received.
     """
 
     use_gripper: bool = False
@@ -557,13 +557,13 @@ class RewardClassifierProcessorStep(ProcessorStep):
     This step uses a model to determine if the current state is successful, updating
     the reward and potentially terminating the episode.
 
-    Attributes:
-        pretrained_path: Path to the pretrained reward classifier model.
-        device: The device to run the classifier on.
-        success_threshold: The probability threshold to consider a prediction as successful.
-        success_reward: The reward value to assign on success.
-        terminate_on_success: If True, terminates the episode upon successful classification.
-        reward_classifier: The loaded classifier model instance.
+    **Attributes**:
+        - **pretrained_path** (`str | None`) -- Path to the pretrained reward classifier model.
+        - **device** (`str`) -- The device to run the classifier on.
+        - **success_threshold** (`float`) -- The probability threshold to consider a prediction as successful.
+        - **success_reward** (`float`) -- The reward value to assign on success.
+        - **terminate_on_success** (`bool`) -- If True, terminates the episode upon successful classification.
+        - **reward_classifier** (`Any`) -- The loaded classifier model instance.
     """
 
     pretrained_path: str | None = None

--- a/src/lerobot/processor/normalize_processor.py
+++ b/src/lerobot/processor/normalize_processor.py
@@ -71,22 +71,23 @@ class _NormalizationMixin:
         )
         ```
 
-    Attributes:
-        features: A dictionary mapping feature names to `PolicyFeature` objects, defining
-            the data structure to be processed.
-        norm_map: A dictionary mapping `FeatureType` to `NormalizationMode`, specifying
-            which normalization method to use for each type of feature.
-        stats: A dictionary containing the normalization statistics (e.g., mean, std,
-            min, max) for each feature.
-        device: The PyTorch device on which to store and perform tensor operations.
-        eps: A small epsilon value to prevent division by zero in normalization
-            calculations.
-        normalize_observation_keys: An optional set of keys to selectively apply
-            normalization to specific observation features.
-        _tensor_stats: An internal dictionary holding the normalization statistics as
-            PyTorch tensors.
-        _stats_explicitly_provided: Internal flag tracking whether stats were explicitly
-            provided during construction (used for override preservation).
+    **Attributes**:
+        - **features** (`dict[str, PolicyFeature]`) -- A dictionary mapping feature names to `PolicyFeature`
+          objects, defining the data structure to be processed.
+        - **norm_map** (`dict[FeatureType, NormalizationMode]`) -- A dictionary mapping `FeatureType` to
+          `NormalizationMode`, specifying which normalization method to use for each type of feature.
+        - **stats** (`dict[str, dict[str, Any]] | None`) -- A dictionary containing the normalization
+          statistics (e.g., mean, std, min, max) for each feature.
+        - **device** (`torch.device | str | None`) -- The PyTorch device on which to store and perform tensor
+          operations.
+        - **eps** (`float`) -- A small epsilon value to prevent division by zero in normalization
+          calculations.
+        - **normalize_observation_keys** (`set[str] | None`) -- An optional set of keys to selectively apply
+          normalization to specific observation features.
+        - **_tensor_stats** (`dict[str, dict[str, Tensor]]`) -- An internal dictionary holding the
+          normalization statistics as PyTorch tensors.
+        - **_stats_explicitly_provided** (`bool`) -- Internal flag tracking whether stats were explicitly
+          provided during construction (used for override preservation).
     """
 
     features: dict[str, PolicyFeature]

--- a/src/lerobot/processor/pipeline.py
+++ b/src/lerobot/processor/pipeline.py
@@ -269,13 +269,18 @@ class DataProcessorPipeline[TInput, TOutput](HubMixin):
     data processing workflow. It's generic, allowing for custom input and output types,
     which are handled by the `to_transition` and `to_output` converters.
 
-    Attributes:
-        steps: A sequence of `ProcessorStep` objects that make up the pipeline.
-        name: A descriptive name for the pipeline.
-        to_transition: A function to convert raw input data into the standardized `EnvTransition` format.
-        to_output: A function to convert the final `EnvTransition` into the desired output format.
-        before_step_hooks: A list of functions to be called before each step is executed.
-        after_step_hooks: A list of functions to be called after each step is executed.
+    **Attributes**:
+        - **steps** (`Sequence[ProcessorStep]`) -- A sequence of `ProcessorStep` objects that make up the
+          pipeline.
+        - **name** (`str`) -- A descriptive name for the pipeline.
+        - **to_transition** (`Callable[[TInput], EnvTransition]`) -- A function to convert raw input data into
+          the standardized `EnvTransition` format.
+        - **to_output** (`Callable[[EnvTransition], TOutput]`) -- A function to convert the final
+          `EnvTransition` into the desired output format.
+        - **before_step_hooks** (`list[Callable[[int, EnvTransition], None]]`) -- A list of functions to be
+          called before each step is executed.
+        - **after_step_hooks** (`list[Callable[[int, EnvTransition], None]]`) -- A list of functions to be
+          called after each step is executed.
     """
 
     steps: Sequence[ProcessorStep] = field(default_factory=list)

--- a/src/lerobot/processor/relative_action_processor.py
+++ b/src/lerobot/processor/relative_action_processor.py
@@ -91,11 +91,11 @@ class RelativeActionsProcessorStep(ProcessorStep):
     Caches the last seen state so a paired AbsoluteActionsProcessorStep can reverse
     the conversion during postprocessing.
 
-    Attributes:
-        enabled: Whether to apply the relative conversion.
-        exclude_joints: Joint names to keep absolute (not converted to relative).
-        action_names: Action dimension names from dataset metadata, used to build
-            the mask from exclude_joints. If None, all dims are converted.
+    **Attributes**:
+        - **enabled** (`bool`) -- Whether to apply the relative conversion.
+        - **exclude_joints** (`list[str]`) -- Joint names to keep absolute (not converted to relative).
+        - **action_names** (`list[str] | None`) -- Action dimension names from dataset metadata, used to build
+          the mask from exclude_joints. If None, all dims are converted.
     """
 
     enabled: bool = False
@@ -168,9 +168,10 @@ class AbsoluteActionsProcessorStep(ProcessorStep):
     predicted relative offsets are converted back to absolute positions for execution.
     Reads the cached state from its paired RelativeActionsProcessorStep.
 
-    Attributes:
-        enabled: Whether to apply the absolute conversion.
-        relative_step: Reference to the paired RelativeActionsProcessorStep that caches state.
+    **Attributes**:
+        - **enabled** (`bool`) -- Whether to apply the absolute conversion.
+        - **relative_step** (`RelativeActionsProcessorStep | None`) -- Reference to the paired
+          RelativeActionsProcessorStep that caches state.
     """
 
     enabled: bool = False

--- a/src/lerobot/processor/rename_processor.py
+++ b/src/lerobot/processor/rename_processor.py
@@ -32,10 +32,9 @@ class RenameObservationsProcessorStep(ObservationProcessorStep):
     from an environment's format to the format expected by a LeRobot policy or
     other downstream components.
 
-    Attributes:
-        rename_map: A dictionary mapping from old key names to new key names.
-                    Keys present in an observation that are not in this map will
-                    be kept with their original names.
+    **Attributes**:
+        - **rename_map** (`dict[str, str]`) -- A dictionary mapping from old key names to new key names. Keys
+          present in an observation that are not in this map will be kept with their original names.
     """
 
     rename_map: dict[str, str] = field(default_factory=dict)

--- a/src/lerobot/processor/tokenizer_processor.py
+++ b/src/lerobot/processor/tokenizer_processor.py
@@ -65,15 +65,17 @@ class TokenizerProcessorStep(ObservationProcessorStep):
 
     Requires the `transformers` library to be installed.
 
-    Attributes:
-        tokenizer_name: The name of a pretrained tokenizer from the Hugging Face Hub (e.g., "bert-base-uncased").
-        tokenizer: A pre-initialized tokenizer object. If provided, `tokenizer_name` is ignored.
-        max_length: The maximum length to pad or truncate sequences to.
-        task_key: The key in `complementary_data` where the task string is stored.
-        padding_side: The side to pad on ('left' or 'right').
-        padding: The padding strategy ('max_length', 'longest', etc.).
-        truncation: Whether to truncate sequences longer than `max_length`.
-        input_tokenizer: The internal tokenizer instance, loaded during initialization.
+    **Attributes**:
+        - **tokenizer_name** (`str | None`) -- The name of a pretrained tokenizer from the Hugging Face Hub
+          (e.g., "bert-base-uncased").
+        - **tokenizer** (`Any | None`) -- A pre-initialized tokenizer object. If provided, `tokenizer_name` is
+          ignored.
+        - **max_length** (`int`) -- The maximum length to pad or truncate sequences to.
+        - **task_key** (`str`) -- The key in `complementary_data` where the task string is stored.
+        - **padding_side** (`str`) -- The side to pad on ('left' or 'right').
+        - **padding** (`str`) -- The padding strategy ('max_length', 'longest', etc.).
+        - **truncation** (`bool`) -- Whether to truncate sequences longer than `max_length`.
+        - **input_tokenizer** (`Any`) -- The internal tokenizer instance, loaded during initialization.
     """
 
     tokenizer_name: str | None = None
@@ -346,12 +348,17 @@ class ActionTokenizerProcessorStep(ActionProcessorStep):
 
     Requires the `transformers` library to be installed.
 
-    Attributes:
-        tokenizer_name: The name of a pretrained processor from the Hugging Face Hub (e.g., "lerobot/fast-action-tokenizer").
-        tokenizer: A pre-initialized processor/tokenizer object. If provided, `tokenizer_name` is ignored.
-        trust_remote_code: Whether to trust remote code when loading the tokenizer (required for some tokenizers).
-        action_tokenizer: The internal tokenizer/processor instance, loaded during initialization.
-        paligemma_tokenizer_name: The name of a pretrained PaliGemma tokenizer from the Hugging Face Hub (e.g., "google/paligemma-3b-pt-224").
+    **Attributes**:
+        - **tokenizer_name** -- The name of a pretrained processor from the Hugging Face Hub (e.g.,
+          "lerobot/fast-action-tokenizer").
+        - **tokenizer** -- A pre-initialized processor/tokenizer object. If provided, `tokenizer_name` is
+          ignored.
+        - **trust_remote_code** (`bool`) -- Whether to trust remote code when loading the tokenizer (required
+          for some tokenizers).
+        - **action_tokenizer** (`Any`) -- The internal tokenizer/processor instance, loaded during
+          initialization.
+        - **paligemma_tokenizer_name** (`str`) -- The name of a pretrained PaliGemma tokenizer from the
+          Hugging Face Hub (e.g., "google/paligemma-3b-pt-224").
     """
 
     action_tokenizer_name: str | None = None

--- a/src/lerobot/rl/joint_observations_processor.py
+++ b/src/lerobot/rl/joint_observations_processor.py
@@ -38,11 +38,11 @@ class JointVelocityProcessorStep(ObservationProcessorStep):
     difference between the current and the last observed joint positions. The
     resulting velocity vector is then concatenated to the original state vector.
 
-    Attributes:
-        dt: The time step (delta time) in seconds between observations, used for
-            calculating velocity.
-        last_joint_positions: Stores the joint positions from the previous step
-                              to enable velocity calculation.
+    **Attributes**:
+        - **dt** (`float`) -- The time step (delta time) in seconds between observations, used for calculating
+          velocity.
+        - **last_joint_positions** (`torch.Tensor | None`) -- Stores the joint positions from the previous
+          step to enable velocity calculation.
     """
 
     dt: float = 0.1
@@ -138,9 +138,9 @@ class MotorCurrentProcessorStep(ObservationProcessorStep):
     This step queries the robot's hardware interface to get the present current
     for each motor and concatenates this information to the existing state vector.
 
-    Attributes:
-        robot: An instance of a `lerobot` Robot class that provides access to
-               the hardware bus.
+    **Attributes**:
+        - **robot** (`Robot | None`) -- An instance of a `lerobot` Robot class that provides access to the
+          hardware bus.
     """
 
     robot: Robot | None = None

--- a/src/lerobot/robots/earthrover_mini_plus/config_earthrover_mini_plus.py
+++ b/src/lerobot/robots/earthrover_mini_plus/config_earthrover_mini_plus.py
@@ -28,8 +28,8 @@ class EarthRoverMiniPlusConfig(RobotConfig):
     This robot uses cloud-based control via the Frodobots SDK HTTP API.
     Camera frames are accessed directly through SDK HTTP endpoints.
 
-    Attributes:
-        sdk_url: URL of the Frodobots SDK server (default: http://localhost:8000)
+    **Attributes**:
+        - **sdk_url** (`str`) -- URL of the Frodobots SDK server (default: http://localhost:8000)
     """
 
     sdk_url: str = "http://localhost:8000"

--- a/src/lerobot/robots/earthrover_mini_plus/robot_earthrover_mini_plus.py
+++ b/src/lerobot/robots/earthrover_mini_plus/robot_earthrover_mini_plus.py
@@ -82,9 +82,9 @@ class EarthRoverMiniPlus(Robot):
     - Linear and angular velocity control
     - Battery and orientation telemetry
 
-    Attributes:
-        config: Robot configuration
-        sdk_base_url: URL of the Frodobots SDK server (default: http://localhost:8000)
+    **Attributes**:
+        - **config** -- Robot configuration
+        - **sdk_base_url** -- URL of the Frodobots SDK server (default: http://localhost:8000)
     """
 
     config_class = EarthRoverMiniPlusConfig

--- a/src/lerobot/robots/robot.py
+++ b/src/lerobot/robots/robot.py
@@ -28,15 +28,22 @@ from .config import RobotConfig
 # TODO(aliberts): action/obs typing such as Generic[ObsType, ActType] similar to gym.Env ?
 # https://github.com/Farama-Foundation/Gymnasium/blob/3287c869f9a48d99454306b0d4b4ec537f0f35e3/gymnasium/core.py#L23
 class Robot(abc.ABC):
-    """
-    The base abstract class for all LeRobot-compatible robots.
+    """The base abstract class for all LeRobot-compatible robots.
 
-    This class provides a standardized interface for interacting with physical robots.
-    Subclasses must implement all abstract methods and properties to be usable.
+    This class provides a standardized interface for interacting with physical robots. Subclasses must
+    implement all abstract methods and properties to be usable.
 
-    Attributes:
-        config_class (RobotConfig): The expected configuration class for this robot.
-        name (str): The unique robot name used to identify this robot type.
+    Used as a context manager, a robot connects on entry and disconnects on exit even if the body raises:
+
+    ```python
+    >>> with SO101Follower(config) as robot:  # doctest: +SKIP
+    ...     obs = robot.get_observation()
+    ...     robot.send_action(action)
+    ```
+
+    **Attributes**:
+        - **config_class** (`type[RobotConfig]`) -- The expected configuration class for this robot.
+        - **name** (`str`) -- The unique robot name used to identify this robot type.
     """
 
     # Set these in ALL subclasses
@@ -59,25 +66,16 @@ class Robot(abc.ABC):
         return f"{self.id} {self.__class__.__name__}"
 
     def __enter__(self):
-        """
-        Context manager entry.
-        Automatically connects to the camera.
-        """
+        """Context manager entry. Automatically connects to the robot."""
         self.connect()
         return self
 
     def __exit__(self, exc_type, exc_value, traceback) -> None:
-        """
-        Context manager exit.
-        Automatically disconnects, ensuring resources are released even on error.
-        """
+        """Context manager exit. Disconnects, ensuring resources are released even on error."""
         self.disconnect()
 
     def __del__(self) -> None:
-        """
-        Destructor safety net.
-        Attempts to disconnect if the object is garbage collected without cleanup.
-        """
+        """Destructor safety net. Disconnects if the object is garbage collected without cleanup."""
         try:
             if self.is_connected:
                 self.disconnect()
@@ -88,83 +86,102 @@ class Robot(abc.ABC):
     @property
     @abc.abstractmethod
     def observation_features(self) -> dict:
-        """
-        A dictionary describing the structure and types of the observations produced by the robot.
-        Its structure (keys) should match the structure of what is returned by :pymeth:`get_observation`.
-        Values for the dict should either be:
-            - The type of the value if it's a simple value, e.g. `float` for single proprioceptive value (a joint's position/velocity)
-            - A tuple representing the shape if it's an array-type value, e.g. `(height, width, channel)` for images
+        """A dictionary describing the structure and types of the observations produced by the robot.
 
-        Note: this property should be able to be called regardless of whether the robot is connected or not.
+        Its keys should match the structure of what is returned by [`~robots.Robot.get_observation`]. Values
+        should either be:
+
+        - the type of the value if it's a simple value, e.g. `float` for a single proprioceptive value
+          (a joint's position or velocity)
+        - a tuple representing the shape if it's an array-type value, e.g. `(height, width, channel)` for
+          images
+
+        > [!NOTE]
+        > This property must be callable regardless of whether the robot is connected.
+
+        Returns:
+            `dict`: Observation names mapped to their type or shape.
         """
         pass
 
     @property
     @abc.abstractmethod
     def action_features(self) -> dict:
-        """
-        A dictionary describing the structure and types of the actions expected by the robot. Its structure
-        (keys) should match the structure of what is passed to :pymeth:`send_action`. Values for the dict
-        should be the type of the value if it's a simple value, e.g. `float` for single proprioceptive value
-        (a joint's goal position/velocity)
+        """A dictionary describing the structure and types of the actions expected by the robot.
 
-        Note: this property should be able to be called regardless of whether the robot is connected or not.
+        Its keys should match the structure of what is passed to [`~robots.Robot.send_action`]. Values should
+        be the type of the value if it's a simple value, e.g. `float` for a single proprioceptive value
+        (a joint's goal position or velocity).
+
+        > [!NOTE]
+        > This property must be callable regardless of whether the robot is connected.
+
+        Returns:
+            `dict`: Action names mapped to their type or shape.
         """
         pass
 
     @property
     @abc.abstractmethod
     def is_connected(self) -> bool:
-        """
-        Whether the robot is currently connected or not. If `False`, calling :pymeth:`get_observation` or
-        :pymeth:`send_action` should raise an error.
+        """Whether the robot is currently connected.
+
+        If `False`, calling [`~robots.Robot.get_observation`] or [`~robots.Robot.send_action`] should raise
+        an error.
+
+        Returns:
+            `bool`: `True` if communication with the robot is established.
         """
         pass
 
     @abc.abstractmethod
     def connect(self, calibrate: bool = True) -> None:
-        """
-        Establish communication with the robot.
+        """Establish communication with the robot.
 
         Args:
-            calibrate (bool): If True, automatically calibrate the robot after connecting if it's not
-                calibrated or needs calibration (this is hardware-dependant).
+            calibrate (`bool`, *optional*, defaults to `True`):
+                Whether to automatically calibrate the robot after connecting, if it is not calibrated or
+                needs recalibration. Whether calibration is needed is hardware-dependent.
         """
         pass
 
     @property
     @abc.abstractmethod
     def is_calibrated(self) -> bool:
-        """Whether the robot is currently calibrated or not. Should be always `True` if not applicable"""
+        """Whether the robot is currently calibrated.
+
+        Returns:
+            `bool`: `True` if the robot is calibrated. Always `True` for robots where calibration does not
+            apply.
+        """
         pass
 
     @abc.abstractmethod
     def calibrate(self) -> None:
-        """
-        Calibrate the robot if applicable. If not, this should be a no-op.
+        """Calibrate the robot if applicable. If not, this should be a no-op.
 
-        This method should collect any necessary data (e.g., motor offsets) and update the
-        :pyattr:`calibration` dictionary accordingly.
+        This method should collect any necessary data (e.g. motor offsets) and update the `calibration`
+        dictionary accordingly.
         """
         pass
 
     def _load_calibration(self, fpath: Path | None = None) -> None:
-        """
-        Helper to load calibration data from the specified file.
+        """Helper to load calibration data from the specified file.
 
         Args:
-            fpath (Path | None): Optional path to the calibration file. Defaults to `self.calibration_fpath`.
+            fpath (`Path`, *optional*):
+                Path to the calibration file. Defaults to `self.calibration_fpath`.
         """
         fpath = self.calibration_fpath if fpath is None else fpath
         with open(fpath) as f, draccus.config_type("json"):
             self.calibration = draccus.load(dict[str, MotorCalibration], f)
 
     def _save_calibration(self, fpath: Path | None = None) -> None:
-        """
-        Helper to save calibration data to the specified file.
+        """Helper to save calibration data to the specified file.
 
         Args:
-            fpath (Path | None): Optional path to save the calibration file. Defaults to `self.calibration_fpath`.
+            fpath (`Path`, *optional*):
+                Path to save the calibration file to. Defaults to `self.calibration_fpath`.
         """
         fpath = self.calibration_fpath if fpath is None else fpath
         with open(fpath, "w") as f, draccus.config_type("json"):
@@ -172,36 +189,40 @@ class Robot(abc.ABC):
 
     @abc.abstractmethod
     def configure(self) -> None:
-        """
-        Apply any one-time or runtime configuration to the robot.
+        """Apply any one-time or runtime configuration to the robot.
+
         This may include setting motor parameters, control modes, or initial state.
         """
         pass
 
     @abc.abstractmethod
     def get_observation(self) -> RobotObservation:
-        """
-        Retrieve the current observation from the robot.
+        """Retrieve the current observation from the robot.
 
         Returns:
-            RobotObservation: A flat dictionary representing the robot's current sensory state. Its structure
-                should match :pymeth:`observation_features`.
+            `dict[str, Any]`: A flat dictionary representing the robot's current sensory state. Its structure
+            should match [`~robots.Robot.observation_features`].
+
+        Raises:
+            DeviceNotConnectedError: If [`~robots.Robot.connect`] has not been called.
         """
 
         pass
 
     @abc.abstractmethod
     def send_action(self, action: RobotAction) -> RobotAction:
-        """
-        Send an action command to the robot.
+        """Send an action command to the robot.
 
         Args:
-            action (RobotAction): Dictionary representing the desired action. Its structure should match
-                :pymeth:`action_features`.
+            action (`dict[str, Any]`):
+                The desired action. Its structure should match [`~robots.Robot.action_features`].
 
         Returns:
-            RobotAction: The action actually sent to the motors potentially clipped or modified, e.g. by
-                safety limits on velocity.
+            `dict[str, Any]`: The action actually sent to the motors, potentially clipped or modified, e.g.
+            by safety limits on velocity. Prefer this over the requested action when logging or recording.
+
+        Raises:
+            DeviceNotConnectedError: If [`~robots.Robot.connect`] has not been called.
         """
         pass
 

--- a/src/lerobot/robots/so_follower/robot_kinematic_processor.py
+++ b/src/lerobot/robots/so_follower/robot_kinematic_processor.py
@@ -53,15 +53,16 @@ class EEReferenceAndDelta(RobotActionProcessorStep):
     2.  `use_latched_reference=False`: The reference pose is updated to the robot's current pose at
         every step.
 
-    Attributes:
-        kinematics: The robot's kinematic model for forward kinematics.
-        end_effector_step_sizes: A dictionary scaling the input delta commands.
-        motor_names: A list of motor names required for forward kinematics.
-        use_latched_reference: If True, latch the reference pose on enable; otherwise, always use the
-            current pose as the reference.
-        reference_ee_pose: Internal state storing the latched reference pose.
-        _prev_enabled: Internal state to detect the rising edge of the enable signal.
-        _command_when_disabled: Internal state to hold the last command while disabled.
+    **Attributes**:
+        - **kinematics** (`RobotKinematics`) -- The robot's kinematic model for forward kinematics.
+        - **end_effector_step_sizes** (`dict`) -- A dictionary scaling the input delta commands.
+        - **motor_names** (`list[str]`) -- A list of motor names required for forward kinematics.
+        - **use_latched_reference** (`bool`) -- If True, latch the reference pose on enable; otherwise, always
+          use the current pose as the reference.
+        - **reference_ee_pose** (`np.ndarray | None`) -- Internal state storing the latched reference pose.
+        - **_prev_enabled** (`bool`) -- Internal state to detect the rising edge of the enable signal.
+        - **_command_when_disabled** (`np.ndarray | None`) -- Internal state to hold the last command while
+          disabled.
     """
 
     kinematics: RobotKinematics
@@ -196,15 +197,14 @@ class EEBoundsAndSafety(RobotActionProcessorStep):
     This step ensures that the target end-effector pose remains within a safe operational workspace.
     It also moderates the command to prevent large, sudden movements between consecutive steps.
 
-    Attributes:
-        end_effector_bounds: A dictionary with "min" and "max" keys for position clipping.
-        max_ee_step_m: The maximum allowed change in position (in meters) between steps.
-        raise_on_jump: When ``True`` (default) an over-limit per-frame step raises
-            ``ValueError`` (aborting the control loop). When ``False`` the step is
-            rate-limited to ``max_ee_step_m`` and a warning is logged instead — the
-            safer choice for live teleoperation, where a transient tracking glitch
-            should not crash the loop and leave the robot uncontrolled.
-        _last_pos: Internal state storing the last commanded position.
+    **Attributes**:
+        - **end_effector_bounds** (`dict`) -- A dictionary with "min" and "max" keys for position clipping.
+        - **max_ee_step_m** (`float`) -- The maximum allowed change in position (in meters) between steps.
+        - **raise_on_jump** (`bool`) -- When ``True`` (default) an over-limit per-frame step raises
+          ``ValueError`` (aborting the control loop). When ``False`` the step is rate-limited to
+          ``max_ee_step_m`` and a warning is logged instead — the safer choice for live teleoperation, where a
+          transient tracking glitch should not crash the loop and leave the robot uncontrolled.
+        - **_last_pos** (`np.ndarray | None`) -- Internal state storing the last commanded position.
     """
 
     end_effector_bounds: dict
@@ -280,17 +280,18 @@ class InverseKinematicsEEToJoints(RobotActionProcessorStep):
     This step translates a Cartesian command (position and orientation of the end-effector) into
     the corresponding joint-space commands for each motor.
 
-    Attributes:
-        kinematics: The robot's kinematic model for inverse kinematics.
-        motor_names: A list of motor names for which to compute joint positions.
-        q_curr: Internal state storing the last joint positions, used as an initial guess for the IK solver.
-        initial_guess_current_joints: If True, use the robot's current joint state as the IK guess.
-            If False, use the solution from the previous step.
-        orientation_weight: Weight for the orientation constraint passed to
-            ``RobotKinematics.inverse_kinematics``. Defaults to ``0.01`` (matching the solver
-            default, so existing callers are unchanged). Set to ``0.0`` for position-only IK on
-            under-actuated arms; a small nonzero weight gives soft-orientation IK on the 5-DOF
-            SO-101, where the wrist tracks orientation only partially (position dominates).
+    **Attributes**:
+        - **kinematics** (`RobotKinematics`) -- The robot's kinematic model for inverse kinematics.
+        - **motor_names** (`list[str]`) -- A list of motor names for which to compute joint positions.
+        - **q_curr** (`np.ndarray | None`) -- Internal state storing the last joint positions, used as an
+          initial guess for the IK solver.
+        - **initial_guess_current_joints** (`bool`) -- If True, use the robot's current joint state as the IK
+          guess. If False, use the solution from the previous step.
+        - **orientation_weight** (`float`) -- Weight for the orientation constraint passed to
+          ``RobotKinematics.inverse_kinematics``. Defaults to ``0.01`` (matching the solver default, so
+          existing callers are unchanged). Set to ``0.0`` for position-only IK on under-actuated arms; a small
+          nonzero weight gives soft-orientation IK on the 5-DOF SO-101, where the wrist tracks orientation
+          only partially (position dominates).
     """
 
     kinematics: RobotKinematics
@@ -380,13 +381,14 @@ class GripperVelocityToJoint(RobotActionProcessorStep):
     taking the current gripper position as a starting point. It also supports a discrete mode
     where integer actions map to open, close, or no-op.
 
-    Attributes:
-        motor_names: A list of motor names, which must include 'gripper'.
-        speed_factor: A scaling factor to convert the normalized velocity command to a position change.
-        clip_min: The minimum allowed gripper joint position.
-        clip_max: The maximum allowed gripper joint position.
-        discrete_gripper: If True, interpret the input as a discrete class index
-            {0 = close, 1 = stay, 2 = open}, matching `GamepadTeleop.GripperAction`.
+    **Attributes**:
+        - **motor_names** -- A list of motor names, which must include 'gripper'.
+        - **speed_factor** (`float`) -- A scaling factor to convert the normalized velocity command to a
+          position change.
+        - **clip_min** (`float`) -- The minimum allowed gripper joint position.
+        - **clip_max** (`float`) -- The maximum allowed gripper joint position.
+        - **discrete_gripper** (`bool`) -- If True, interpret the input as a discrete class index {0 = close,
+          1 = stay, 2 = open}, matching `GamepadTeleop.GripperAction`.
     """
 
     speed_factor: float = 20.0
@@ -467,8 +469,8 @@ class ForwardKinematicsJointsToEEObservation(ObservationProcessorStep):
     This step is typically used to add the robot's Cartesian pose to the observation space,
     which can be useful for visualization or as an input to a policy.
 
-    Attributes:
-        kinematics: The robot's kinematic model.
+    **Attributes**:
+        - **kinematics** (`RobotKinematics`) -- The robot's kinematic model.
     """
 
     kinematics: RobotKinematics
@@ -500,8 +502,8 @@ class ForwardKinematicsJointsToEEAction(RobotActionProcessorStep):
     This step is typically used to add the robot's Cartesian pose to the observation space,
     which can be useful for visualization or as an input to a policy.
 
-    Attributes:
-        kinematics: The robot's kinematic model.
+    **Attributes**:
+        - **kinematics** (`RobotKinematics`) -- The robot's kinematic model.
     """
 
     kinematics: RobotKinematics

--- a/src/lerobot/teleoperators/keyboard/configuration_keyboard.py
+++ b/src/lerobot/teleoperators/keyboard/configuration_keyboard.py
@@ -35,8 +35,8 @@ class KeyboardEndEffectorTeleopConfig(KeyboardTeleopConfig):
 
     Used for controlling robot end-effectors with keyboard inputs.
 
-    Attributes:
-        use_gripper: Whether to include gripper control in actions
+    **Attributes**:
+        - **use_gripper** (`bool`) -- Whether to include gripper control in actions
     """
 
     use_gripper: bool = True
@@ -49,14 +49,14 @@ class KeyboardRoverTeleopConfig(TeleoperatorConfig):
 
     Used for controlling mobile robots like EarthRover Mini Plus with WASD controls.
 
-    Attributes:
-        linear_speed: Default linear velocity magnitude (-1 to 1 range for SDK robots)
-        angular_speed: Default angular velocity magnitude (-1 to 1 range for SDK robots)
-        speed_increment: Amount to increase/decrease speed with +/- keys
-        turn_assist_ratio: Forward motion multiplier when turning with A/D keys (0.0-1.0)
-        angular_speed_ratio: Ratio of angular to linear speed for synchronized adjustments
-        min_linear_speed: Minimum linear speed when decreasing (prevents zero speed)
-        min_angular_speed: Minimum angular speed when decreasing (prevents zero speed)
+    **Attributes**:
+        - **linear_speed** (`float`) -- Default linear velocity magnitude (-1 to 1 range for SDK robots)
+        - **angular_speed** (`float`) -- Default angular velocity magnitude (-1 to 1 range for SDK robots)
+        - **speed_increment** (`float`) -- Amount to increase/decrease speed with +/- keys
+        - **turn_assist_ratio** (`float`) -- Forward motion multiplier when turning with A/D keys (0.0-1.0)
+        - **angular_speed_ratio** (`float`) -- Ratio of angular to linear speed for synchronized adjustments
+        - **min_linear_speed** (`float`) -- Minimum linear speed when decreasing (prevents zero speed)
+        - **min_angular_speed** (`float`) -- Minimum angular speed when decreasing (prevents zero speed)
     """
 
     linear_speed: float = 1.0

--- a/src/lerobot/teleoperators/keyboard/teleop_keyboard.py
+++ b/src/lerobot/teleoperators/keyboard/teleop_keyboard.py
@@ -312,10 +312,10 @@ class KeyboardRoverTeleop(KeyboardTeleop):
         System:
             - ESC: Disconnect teleoperator
 
-    Attributes:
-        config: Teleoperator configuration
-        current_linear_speed: Current linear velocity magnitude
-        current_angular_speed: Current angular velocity magnitude
+    **Attributes**:
+        - **config** -- Teleoperator configuration
+        - **current_linear_speed** -- Current linear velocity magnitude
+        - **current_angular_speed** -- Current angular velocity magnitude
 
     Example:
         ```python

--- a/src/lerobot/teleoperators/phone/phone_processor.py
+++ b/src/lerobot/teleoperators/phone/phone_processor.py
@@ -35,9 +35,9 @@ class MapPhoneActionToRobotAction(RobotActionProcessorStep):
     necessary axis inversions and swaps. It also interprets platform-specific
     button presses to generate a gripper command.
 
-    Attributes:
-        platform: The operating system of the phone (iOS or Android), used
-            to determine the correct button mappings for the gripper.
+    **Attributes**:
+        - **platform** (`PhoneOS`) -- The operating system of the phone (iOS or Android), used to determine
+          the correct button mappings for the gripper.
     """
 
     # TODO(Steven): Gripper vel could be output of phone_teleop directly

--- a/src/lerobot/teleoperators/teleoperator.py
+++ b/src/lerobot/teleoperators/teleoperator.py
@@ -27,15 +27,22 @@ from .config import TeleoperatorConfig
 
 
 class Teleoperator(abc.ABC):
-    """
-    The base abstract class for all LeRobot-compatible teleoperation devices.
+    """The base abstract class for all LeRobot-compatible teleoperation devices.
 
-    This class provides a standardized interface for interacting with physical teleoperators.
-    Subclasses must implement all abstract methods and properties to be usable.
+    This class provides a standardized interface for interacting with physical teleoperators. Subclasses
+    must implement all abstract methods and properties to be usable.
 
-    Attributes:
-        config_class (RobotConfig): The expected configuration class for this teleoperator.
-        name (str): The unique name used to identify this teleoperator type.
+    Used as a context manager, a teleoperator connects on entry and disconnects on exit, even on error:
+
+    ```python
+    >>> with SO101Leader(config) as teleop:  # doctest: +SKIP
+    ...     action = teleop.get_action()
+    ```
+
+    **Attributes**:
+        - **config_class** (`type[TeleoperatorConfig]`) -- The expected configuration class for this
+          teleoperator.
+        - **name** (`str`) -- The unique name used to identify this teleoperator type.
     """
 
     # Set these in ALL subclasses
@@ -59,25 +66,16 @@ class Teleoperator(abc.ABC):
         return f"{self.id} {self.__class__.__name__}"
 
     def __enter__(self):
-        """
-        Context manager entry.
-        Automatically connects to the camera.
-        """
+        """Context manager entry. Automatically connects to the teleoperator."""
         self.connect()
         return self
 
     def __exit__(self, exc_type, exc_value, traceback) -> None:
-        """
-        Context manager exit.
-        Automatically disconnects, ensuring resources are released even on error.
-        """
+        """Context manager exit. Disconnects, ensuring resources are released even on error."""
         self.disconnect()
 
     def __del__(self) -> None:
-        """
-        Destructor safety net.
-        Attempts to disconnect if the object is garbage collected without cleanup.
-        """
+        """Destructor safety net. Disconnects if the object is garbage collected without cleanup."""
         try:
             if self.is_connected:
                 self.disconnect()
@@ -87,82 +85,98 @@ class Teleoperator(abc.ABC):
     @property
     @abc.abstractmethod
     def action_features(self) -> dict:
-        """
-        A dictionary describing the structure and types of the actions produced by the teleoperator. Its
-        structure (keys) should match the structure of what is returned by :pymeth:`get_action`. Values for
-        the dict should be the type of the value if it's a simple value, e.g. `float` for single
-        proprioceptive value (a joint's goal position/velocity)
+        """A dictionary describing the structure and types of the actions produced by the teleoperator.
 
-        Note: this property should be able to be called regardless of whether the robot is connected or not.
+        Its keys should match the structure of what is returned by [`~teleoperators.Teleoperator.get_action`].
+        Values should be the type of the value if it's a simple value, e.g. `float` for a single
+        proprioceptive value (a joint's goal position or velocity).
+
+        > [!NOTE]
+        > This property must be callable regardless of whether the teleoperator is connected.
+
+        Returns:
+            `dict`: Action names mapped to their type or shape.
         """
         pass
 
     @property
     @abc.abstractmethod
     def feedback_features(self) -> dict:
-        """
-        A dictionary describing the structure and types of the feedback actions expected by the robot. Its
-        structure (keys) should match the structure of what is passed to :pymeth:`send_feedback`. Values for
-        the dict should be the type of the value if it's a simple value, e.g. `float` for single
-        proprioceptive value (a joint's goal position/velocity)
+        """A dictionary describing the structure and types of the feedback actions the teleoperator accepts.
 
-        Note: this property should be able to be called regardless of whether the robot is connected or not.
+        Its keys should match the structure of what is passed to
+        [`~teleoperators.Teleoperator.send_feedback`]. Values should be the type of the value if it's a
+        simple value, e.g. `float` for a single proprioceptive value (a joint's goal position or velocity).
+
+        > [!NOTE]
+        > This property must be callable regardless of whether the teleoperator is connected.
+
+        Returns:
+            `dict`: Feedback names mapped to their type or shape.
         """
         pass
 
     @property
     @abc.abstractmethod
     def is_connected(self) -> bool:
-        """
-        Whether the teleoperator is currently connected or not. If `False`, calling :pymeth:`get_action`
-        or :pymeth:`send_feedback` should raise an error.
+        """Whether the teleoperator is currently connected.
+
+        If `False`, calling [`~teleoperators.Teleoperator.get_action`] or
+        [`~teleoperators.Teleoperator.send_feedback`] should raise an error.
+
+        Returns:
+            `bool`: `True` if communication with the teleoperator is established.
         """
         pass
 
     @abc.abstractmethod
     def connect(self, calibrate: bool = True) -> None:
-        """
-        Establish communication with the teleoperator.
+        """Establish communication with the teleoperator.
 
         Args:
-            calibrate (bool): If True, automatically calibrate the teleoperator after connecting if it's not
-                calibrated or needs calibration (this is hardware-dependant).
+            calibrate (`bool`, *optional*, defaults to `True`):
+                Whether to automatically calibrate the teleoperator after connecting, if it is not
+                calibrated or needs recalibration. Whether calibration is needed is hardware-dependent.
         """
         pass
 
     @property
     @abc.abstractmethod
     def is_calibrated(self) -> bool:
-        """Whether the teleoperator is currently calibrated or not. Should be always `True` if not applicable"""
+        """Whether the teleoperator is currently calibrated.
+
+        Returns:
+            `bool`: `True` if the teleoperator is calibrated. Always `True` for teleoperators where
+            calibration does not apply.
+        """
         pass
 
     @abc.abstractmethod
     def calibrate(self) -> None:
-        """
-        Calibrate the teleoperator if applicable. If not, this should be a no-op.
+        """Calibrate the teleoperator if applicable. If not, this should be a no-op.
 
-        This method should collect any necessary data (e.g., motor offsets) and update the
-        :pyattr:`calibration` dictionary accordingly.
+        This method should collect any necessary data (e.g. motor offsets) and update the `calibration`
+        dictionary accordingly.
         """
         pass
 
     def _load_calibration(self, fpath: Path | None = None) -> None:
-        """
-        Helper to load calibration data from the specified file.
+        """Helper to load calibration data from the specified file.
 
         Args:
-            fpath (Path | None): Optional path to the calibration file. Defaults to `self.calibration_fpath`.
+            fpath (`Path`, *optional*):
+                Path to the calibration file. Defaults to `self.calibration_fpath`.
         """
         fpath = self.calibration_fpath if fpath is None else fpath
         with open(fpath) as f, draccus.config_type("json"):
             self.calibration = draccus.load(dict[str, MotorCalibration], f)
 
     def _save_calibration(self, fpath: Path | None = None) -> None:
-        """
-        Helper to save calibration data to the specified file.
+        """Helper to save calibration data to the specified file.
 
         Args:
-            fpath (Path | None): Optional path to save the calibration file. Defaults to `self.calibration_fpath`.
+            fpath (`Path`, *optional*):
+                Path to save the calibration file to. Defaults to `self.calibration_fpath`.
         """
         fpath = self.calibration_fpath if fpath is None else fpath
         with open(fpath, "w") as f, draccus.config_type("json"):
@@ -170,35 +184,36 @@ class Teleoperator(abc.ABC):
 
     @abc.abstractmethod
     def configure(self) -> None:
-        """
-        Apply any one-time or runtime configuration to the teleoperator.
+        """Apply any one-time or runtime configuration to the teleoperator.
+
         This may include setting motor parameters, control modes, or initial state.
         """
         pass
 
     @abc.abstractmethod
     def get_action(self) -> RobotAction:
-        """
-        Retrieve the current action from the teleoperator.
+        """Retrieve the current action from the teleoperator.
 
         Returns:
-            RobotAction: A flat dictionary representing the teleoperator's current actions. Its
-                structure should match :pymeth:`observation_features`.
+            `dict[str, Any]`: A flat dictionary representing the teleoperator's current action. Its structure
+            should match [`~teleoperators.Teleoperator.action_features`].
+
+        Raises:
+            DeviceNotConnectedError: If [`~teleoperators.Teleoperator.connect`] has not been called.
         """
         pass
 
     @abc.abstractmethod
     def send_feedback(self, feedback: dict[str, Any]) -> None:
-        """
-        Send a feedback action command to the teleoperator.
+        """Send a feedback command to the teleoperator, e.g. force feedback on a leader arm.
 
         Args:
-            feedback (dict[str, Any]): Dictionary representing the desired feedback. Its structure should match
-                :pymeth:`feedback_features`.
+            feedback (`dict[str, Any]`):
+                The desired feedback. Its structure should match
+                [`~teleoperators.Teleoperator.feedback_features`].
 
-        Returns:
-            dict[str, Any]: The action actually sent to the motors potentially clipped or modified, e.g. by
-                safety limits on velocity.
+        Raises:
+            DeviceNotConnectedError: If [`~teleoperators.Teleoperator.connect`] has not been called.
         """
         pass
 

--- a/src/lerobot/utils/sample_weighting.py
+++ b/src/lerobot/utils/sample_weighting.py
@@ -82,13 +82,13 @@ class SampleWeightingConfig:
     The `type` field determines which implementation to use, and `extra_params`
     contains additional type-specific parameters.
 
-    Attributes:
-        type: Weighting strategy type ("rabc", "uniform", etc.)
-        progress_path: Path to precomputed progress values (for RABC)
-        head_mode: Which model head to use for progress ("sparse" or "dense")
-        kappa: Hard threshold for high-quality samples (RABC-specific)
-        epsilon: Small constant for numerical stability
-        extra_params: Additional type-specific parameters passed to the weighter
+    **Attributes**:
+        - **type** (`str`) -- Weighting strategy type ("rabc", "uniform", etc.)
+        - **progress_path** (`str | None`) -- Path to precomputed progress values (for RABC)
+        - **head_mode** (`str`) -- Which model head to use for progress ("sparse" or "dense")
+        - **kappa** (`float`) -- Hard threshold for high-quality samples (RABC-specific)
+        - **epsilon** (`float`) -- Small constant for numerical stability
+        - **extra_params** (`dict`) -- Additional type-specific parameters passed to the weighter
     """
 
     type: str = "rabc"


### PR DESCRIPTION
> **Stacked on #4348.** Review that one first; this PR targets its branch, so the diff here is only its own commit.

## Summary / Motivation

Sphinx roles and bare `Attributes:` sections both render incorrectly once `[[autodoc]]` is enabled, so they are fixed before that switch is flipped rather than after.

## Related issues

- Related: #4348

## What changed

**Sphinx roles (24 occurrences, 3 files).** Not supported by doc-builder; they render as literal `:pymeth:` text on the page. Method references become doc-builder cross-references. The handful that pointed at instance attributes (`motors`, `calibration`, `default_timeout`) become plain inline code instead, since attributes get no autodoc anchor and a cross-reference to one would be a dead link.

**`Attributes:` sections (43 sites, 27 files).** doc-builder parses a bare `Attributes:` as a synonym for `Parameters:`. Verified against a local build: `Robot`'s attributes rendered inside `<paramsdesc>`, presenting `config_class` and `name` to readers as constructor arguments when the actual constructor parameter is `config`. All are converted to the `**Attributes**:` bullet form with `--` separators. Where the original block carried no type, the type is taken from the real class-level annotation rather than invented.

**The four base classes** every other module inherits or cross-references — `robots/robot.py`, `teleoperators/teleoperator.py`, `motors/motors_bus.py`, `cameras/camera.py` — additionally get their abstract contracts rewritten in the new standard, since subclasses will document only their deviations from this text.

**Three docstring errors corrected in passing:**

- `Teleoperator.get_action` pointed readers at `observation_features`, which `Teleoperator` does not have; it is `action_features`.
- `Teleoperator.send_feedback` documented a `Returns:` block describing a dict, but the method returns `None`.
- `Teleoperator`'s class docstring typed `config_class` as `RobotConfig`; the annotation is `type[TeleoperatorConfig]`.

`motors_bus.py` keeps its existing argument formatting outside the docstrings touched here; converting that file wholesale belongs with the `motors/` module work.

## How was this tested (or how to run locally)

```bash
uv run pytest tests/robots tests/teleoperators tests/cameras tests/processor tests/motors tests/utils tests/policies -q
```

919 tests pass across the touched modules.

Verified mechanically that this is docstring-only: for all 28 changed files, the AST with docstrings stripped is byte-identical before and after.

```bash
grep -rn ':py[a-z]*:`' src/lerobot/ --include='*.py' | wc -l   # 0
grep -rn '^\s*Attributes:\s*$' src/lerobot/ --include='*.py' | wc -l   # 0
```

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: #

## Reviewer notes

The base-class rewrites are the part worth reading closely — that text is doing a lot of work, because every concrete robot, teleoperator and camera will document only what deviates from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
