### PR TITLE
test: add doctest infrastructure

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -56,3 +56,35 @@ jobs:
         uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  # v3.0.1
         with:
           extra_args: --all-files --show-diff-on-failure --color=always
+
+  # This job runs the examples in our docstrings and validates the doctest allowlist.
+  # See docs/source/writing_docstrings.mdx for the standard these enforce.
+  doc-checks:
+    name: Run Documentation Checks (Doctests)
+    runs-on: ubuntu-latest
+    env:
+      # Examples that need a physical robot, a serial port or a Hub download are skipped by content.
+      # Everything else has to actually run. See src/lerobot/utils/doctest_utils.py.
+      SKIP_HARDWARE_DOCTEST: "1"
+      SKIP_CUDA_DOCTEST: "1"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup uv and Python
+        uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
+        with:
+          enable-cache: true
+          version: "0.11.30"
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv sync --locked --extra test --extra dataset
+
+      - name: Check the doctest list is sorted and its paths exist
+        run: make check-doctest-list
+
+      - name: Run doctests
+        run: make doctest

--- a/Makefile
+++ b/Makefile
@@ -184,3 +184,17 @@ test-smolvla-ete-eval:
 # backend, so it does not require a real model checkpoint or GPU.
 annotation-e2e:
 	uv run python -m tests.annotations.run_e2e_smoke
+
+# Docstring & doctest checks. See docs/source/writing_docstrings.mdx for the standard these enforce.
+
+# Run the examples in the docstrings listed in utils/documentation_tests.txt. Hardware and GPU examples are
+# skipped by content (see src/lerobot/utils/doctest_utils.py); CI sets both flags.
+doctest:
+	SKIP_HARDWARE_DOCTEST=1 uv run pytest --doctest-modules --no-header -q \
+		$$(grep -v '^\s*#' utils/documentation_tests.txt | grep -v '^\s*$$')
+
+check-doctest-list:
+	uv run python utils/check_doctest_list.py
+
+fix-doctest-list:
+	uv run python utils/check_doctest_list.py --fix_and_overwrite

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,60 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Root conftest: makes doctest collection use LeRobot's parser.
+
+This only affects `--doctest-modules` runs (see `make doctest`). The test suite itself is configured by
+`tests/conftest.py`.
+"""
+
+import doctest
+
+import _pytest.doctest
+
+from lerobot.utils.doctest_utils import LeRobotDoctestModule, LeRobotDocTestParser
+
+# Lets an example opt out of output comparison with `# doctest: +IGNORE_RESULT`, for calls whose output is
+# a progress bar or otherwise not reproducible.
+IGNORE_RESULT = doctest.register_optionflag("IGNORE_RESULT")
+
+OutputChecker = doctest.OutputChecker
+
+
+class CustomOutputChecker(OutputChecker):
+    """An output checker that honours the `IGNORE_RESULT` flag."""
+
+    def check_output(self, want, got, optionflags):
+        """Return `True` when `IGNORE_RESULT` is set, otherwise defer to stdlib.
+
+        Args:
+            want (`str`):
+                The expected output.
+            got (`str`):
+                The actual output.
+            optionflags (`int`):
+                Bitmask of active doctest option flags.
+
+        Returns:
+            `bool`: Whether the output is considered a match.
+        """
+        if IGNORE_RESULT & optionflags:
+            return True
+        return OutputChecker.check_output(self, want, got, optionflags)
+
+
+# Reassigning these module attributes is how doctest behaviour is customised; mypy sees it as assigning to
+# a type, which is exactly what is intended here.
+doctest.OutputChecker = CustomOutputChecker  # type: ignore[misc]
+_pytest.doctest.DoctestModule = LeRobotDoctestModule
+doctest.DocTestParser = LeRobotDocTestParser  # type: ignore[misc]

--- a/docs/source/writing_docstrings.mdx
+++ b/docs/source/writing_docstrings.mdx
@@ -147,8 +147,8 @@ The `<Tip>` component is legacy per doc-builder; don't add new ones.
 
 ### Examples must be fenced
 
-An example lives inside a fenced ` ```python ` block containing `>>> `. That fence is literally what the
-doctest preprocessor's regex matches:
+An example lives inside a fenced ` ```python ` block containing `>>> `. The fence is what makes it render
+as a code block, and it is what the doctest preprocessor's regex looks for:
 
 ````python
     Example:
@@ -161,8 +161,8 @@ doctest preprocessor's regex matches:
 ````
 
 > [!WARNING]
-> A bare `>>>` outside a fenced block is **never collected**. It silently never runs, and you get no signal
-> that your example is broken.
+> An unfenced `>>>` is still collected — doctest finds prompts anywhere in a docstring. What you lose is the
+> rendering, so it shows up as a wall of prose on the page. Every example needs the fence.
 
 Every example either executes in CI or carries `# doctest: +SKIP`. Anything that touches hardware, a GPU, or
 downloads from the Hub gets `+SKIP`:

--- a/src/lerobot/motors/motors_bus.py
+++ b/src/lerobot/motors/motors_bus.py
@@ -314,11 +314,16 @@ class SerialMotorsBus(MotorsBusBase):
     To find the port, you can run our utility script:
     ```bash
     lerobot-find-port.py
-    >>> Finding all available ports for the MotorsBus.
-    >>> ["/dev/tty.usbmodem575E0032081", "/dev/tty.usbmodem575E0031751"]
-    >>> Remove the usb cable from your MotorsBus and press Enter when done.
-    >>> The port of this MotorsBus is /dev/tty.usbmodem575E0031751.
-    >>> Reconnect the usb cable.
+    ```
+
+    which prints:
+
+    ```
+    Finding all available ports for the MotorsBus.
+    ["/dev/tty.usbmodem575E0032081", "/dev/tty.usbmodem575E0031751"]
+    Remove the usb cable from your MotorsBus and press Enter when done.
+    The port of this MotorsBus is /dev/tty.usbmodem575E0031751.
+    Reconnect the usb cable.
     ```
 
     Example of usage for 1 Feetech sts3215 motor connected to the bus:
@@ -679,10 +684,12 @@ class SerialMotorsBus(MotorsBusBase):
 
         This helper is useful to temporarily disable torque when configuring motors.
 
-        Examples:
-            >>> with bus.torque_disabled():
+        Example:
+            ```python
+            >>> with bus.torque_disabled():  # doctest: +SKIP
             ...     # Safe operations here
             ...     pass
+            ```
         """
         self.disable_torque(motors)
         try:

--- a/src/lerobot/robots/utils.py
+++ b/src/lerobot/robots/utils.py
@@ -91,7 +91,35 @@ def make_robot_from_config(config: RobotConfig) -> Robot:
 def ensure_safe_goal_position(
     goal_present_pos: dict[str, tuple[float, float]], max_relative_target: float | dict[str, float]
 ) -> dict[str, float]:
-    """Caps relative action target magnitude for safety."""
+    """Cap the magnitude of a relative action target for safety.
+
+    Used by [`~robots.Robot.send_action`] implementations to stop a large jump between the present and goal
+    positions from being written straight to the motors.
+
+    Args:
+        goal_present_pos (`dict[str, tuple[float, float]]`):
+            Maps motor name to a `(goal_position, present_position)` pair.
+        max_relative_target (`float | dict[str, float]`):
+            The largest change from the present position that may be applied. A float caps every motor
+            equally; a dict gives a per-motor cap and must have exactly the same keys as
+            `goal_present_pos`.
+
+    Returns:
+        `dict[str, float]`: The capped goal position for each motor.
+
+    Raises:
+        ValueError: If `max_relative_target` is a dict whose keys differ from those of `goal_present_pos`.
+        TypeError: If `max_relative_target` is neither a float nor a dict.
+
+    Example:
+        ```python
+        >>> from lerobot.robots.utils import ensure_safe_goal_position
+        >>> ensure_safe_goal_position({"shoulder_pan": (50.0, 10.0)}, 5.0)
+        {'shoulder_pan': 15.0}
+        >>> ensure_safe_goal_position({"shoulder_pan": (12.0, 10.0)}, 5.0)
+        {'shoulder_pan': 12.0}
+        ```
+    """
 
     if isinstance(max_relative_target, float):
         diff_cap = dict.fromkeys(goal_present_pos, max_relative_target)

--- a/src/lerobot/utils/doctest_utils.py
+++ b/src/lerobot/utils/doctest_utils.py
@@ -1,0 +1,205 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Doctest plumbing so the examples in our docstrings actually run.
+
+Adapted from `transformers.testing_utils`. Two stdlib limitations make this necessary:
+
+1. Ruff is configured with `docstring-code-format = true`, which reformats code inside docstrings and
+   removes the blank line before the closing fence. stdlib's `_EXAMPLE_RE` then swallows the ` ``` ` into
+   the expected-output group, so every example that has output fails. [`LeRobotDocTestParser`] patches the
+   regex to stop at a fence.
+2. `doctest.DocTestFinder` reports the wrong line number for `@property` and `functools.wraps` objects
+   (https://bugs.python.org/issue17446). Our hardware API is property-heavy — `observation_features`,
+   `action_features`, `is_connected`, `is_calibrated` are all abstract properties — so
+   [`LeRobotDoctestModule`] unwraps them before locating the example.
+
+Two environment variables skip whole example blocks by content:
+
+- `SKIP_CUDA_DOCTEST=1` skips examples that need a GPU.
+- `SKIP_HARDWARE_DOCTEST=1` skips examples that need a physical robot or a Hub download.
+
+Both are heuristics over the example source. They are deliberately blunt: an example that is skipped
+needlessly costs nothing, whereas one that runs on a machine without the hardware hangs or fails.
+"""
+
+import doctest
+import functools
+import inspect
+import os
+import re
+import sys
+from collections.abc import Iterable
+
+from _pytest.doctest import (
+    DoctestItem,
+    DoctestModule,
+    _get_checker,
+    _get_continue_on_failure,
+    _get_runner,
+    get_optionflags,
+)
+from _pytest.nodes import Collector
+from _pytest.outcomes import skip
+
+# Calls whose progress bars would otherwise be compared against the expected output. The lookahead leaves
+# lines that already carry a directive alone.
+_NOISY_CALL_PATTERN = re.compile(r"(>>> (?!.*# doctest:).*(?:load_dataset|LeRobotDataset)\(.*)")
+
+_CUDA_PATTERN = re.compile(r"cuda|to\(0\)|device=0")
+
+# Serial ports, video devices, and the connect/scan calls that talk to real hardware.
+_HARDWARE_PATTERN = re.compile(r"/dev/tty|/dev/video|COM\d|\.connect\(|find_cameras\(|find_port\(")
+
+# Anything that reaches the Hub over the network.
+_HUB_PATTERN = re.compile(r"from_pretrained\(|push_to_hub\(|snapshot_download\(|load_dataset\(")
+
+
+def preprocess_string(string: str, skip_cuda_tests: bool, skip_hardware_tests: bool) -> str:
+    """Prepare a docstring or `.mdx` file to be run by doctest.
+
+    Args:
+        string (`str`):
+            A whole file's contents for `.mdx`, or a single docstring for a Python file. Either may hold
+            several fenced examples.
+        skip_cuda_tests (`bool`):
+            Whether to drop examples that look like they need a GPU.
+        skip_hardware_tests (`bool`):
+            Whether to drop examples that look like they need a robot or a Hub download.
+
+    Returns:
+        `str`: The input with `# doctest: +IGNORE_RESULT` injected on noisy calls, or an empty string if
+        the examples were skipped — in which case no doctest is collected for it at all.
+    """
+    # Match against the example lines only, not the surrounding prose, so that a docstring merely
+    # *describing* CUDA or a serial port is not mistaken for one that uses them.
+    example_lines = "\n".join(
+        line for line in string.splitlines() if line.lstrip().startswith((">>>", "..."))
+    )
+    if not example_lines:
+        return string
+
+    if skip_cuda_tests and _CUDA_PATTERN.search(example_lines):
+        return ""
+    if skip_hardware_tests and (
+        _HARDWARE_PATTERN.search(example_lines) or _HUB_PATTERN.search(example_lines)
+    ):
+        return ""
+
+    return _NOISY_CALL_PATTERN.sub(r"\1 # doctest: +IGNORE_RESULT", string)
+
+
+class LeRobotDocTestParser(doctest.DocTestParser):
+    """A `DocTestParser` that understands fenced, auto-formatted code blocks.
+
+    Ruff's `docstring-code-format` removes the blank line before a closing fence, after which stdlib's
+    `_EXAMPLE_RE` reads the fence itself as part of the expected output and every example with output
+    fails. The regex below is the stdlib one plus a clause that stops matching at a fence.
+    """
+
+    # fmt: off
+    _EXAMPLE_RE = re.compile(r'''
+        # Source consists of a PS1 line followed by zero or more PS2 lines.
+        (?P<source>
+            (?:^(?P<indent> [ ]*) >>>    .*)    # PS1 line
+            (?:\n           [ ]*  \.\.\. .*)*)  # PS2 lines
+        \n?
+        # Want consists of any non-blank lines that do not start with PS1.
+        (?P<want> (?:(?![ ]*$)    # Not a blank line
+             (?![ ]*>>>)          # Not a line starting with PS1
+             (?:(?!```).)*        # Stop at a closing fence: formatting drops the blank line before it
+             (?:\n|$)  # Match a new line or end of string
+          )*)
+        ''', re.MULTILINE | re.VERBOSE
+    )
+    # fmt: on
+
+    skip_cuda_tests: bool = os.environ.get("SKIP_CUDA_DOCTEST", "0") == "1"
+    skip_hardware_tests: bool = os.environ.get("SKIP_HARDWARE_DOCTEST", "0") == "1"
+
+    def parse(self, string, name="<string>"):
+        """Preprocess `string`, then parse it as stdlib would.
+
+        Args:
+            string (`str`):
+                The docstring or file contents to parse.
+            name (`str`, *optional*, defaults to `"<string>"`):
+                Name used in failure messages.
+
+        Returns:
+            `list`: The examples and interleaved text, as returned by `doctest.DocTestParser.parse`.
+        """
+        string = preprocess_string(string, self.skip_cuda_tests, self.skip_hardware_tests)
+        return super().parse(string, name)
+
+
+class LeRobotDoctestModule(DoctestModule):
+    """A pytest `DoctestModule` that collects with [`LeRobotDocTestParser`].
+
+    `doctest.DocTestFinder` binds its default parser at class-definition time, so patching
+    `doctest.DocTestParser` in `conftest.py` does not reach the finder pytest builds. The parser has to be
+    passed in explicitly, which means reimplementing `collect`. It mirrors pytest's own implementation.
+    """
+
+    def collect(self) -> Iterable[DoctestItem]:
+        """Collect the doctests in this module.
+
+        Returns:
+            `Iterable[DoctestItem]`: One item per example-bearing docstring. Docstrings whose examples were
+            dropped by `preprocess_string` yield nothing.
+        """
+
+        class MockAwareDocTestFinder(doctest.DocTestFinder):
+            """A doctest finder that reports correct line numbers for properties and wrapped callables."""
+
+            # Fixed upstream in CPython 3.11.9 / 3.12.3; kept for older interpreters. Our hardware API is
+            # property-heavy (`observation_features`, `is_connected`, ...), so a wrong line number here
+            # would point every failure at the decorator. https://github.com/python/cpython/issues/61648
+            def _find_lineno(self, obj, source_lines):
+                if isinstance(obj, property):
+                    obj = getattr(obj, "fget", obj)
+                if hasattr(obj, "__wrapped__"):
+                    obj = inspect.unwrap(obj)
+                return super()._find_lineno(obj, source_lines)
+
+            if sys.version_info < (3, 13):
+                # `cached_property` is otherwise never considered part of the current module and its
+                # examples are silently skipped. https://github.com/python/cpython/issues/107995
+                def _from_module(self, module, object):
+                    if isinstance(object, functools.cached_property):
+                        object = object.func
+                    return super()._from_module(module, object)
+
+        try:
+            module = self.obj
+        except Collector.CollectError:
+            if self.config.getvalue("doctest_ignore_import_errors"):
+                skip(f"unable to import module {self.path!r}")
+            else:
+                raise
+
+        # Doctests support fixtures via `getfixture` and autouse.
+        self.session._fixturemanager.parsefactories(self)
+
+        finder = MockAwareDocTestFinder(parser=LeRobotDocTestParser())
+        optionflags = get_optionflags(self.config)
+        runner = _get_runner(
+            verbose=False,
+            optionflags=optionflags,
+            checker=_get_checker(),
+            continue_on_failure=_get_continue_on_failure(self.config),
+        )
+        for test in finder.find(module, module.__name__):
+            if test.examples:  # Skip docstrings with no examples, and blocks dropped by the parser.
+                yield DoctestItem.from_parent(self, name=test.name, runner=runner, dtest=test)

--- a/tests/utils/test_doctest_utils.py
+++ b/tests/utils/test_doctest_utils.py
@@ -1,0 +1,111 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import doctest
+
+from lerobot.utils.doctest_utils import LeRobotDocTestParser, preprocess_string
+
+# An example with expected output, formatted the way ruff's `docstring-code-format` leaves it: no blank
+# line between the last output line and the closing fence. This is the exact shape that breaks stdlib.
+FORMATTED_EXAMPLE = """Summary.
+
+Example:
+    ```python
+    >>> 1 + 1
+    2
+    ```
+"""
+
+
+def test_stdlib_parser_swallows_the_closing_fence():
+    """Guards the premise of the port: without the patch, the fence lands in the expected output.
+
+    Uses the base class rather than `doctest.DocTestParser`, which the root `conftest.py` has already
+    replaced with ours by the time this runs.
+    """
+    stdlib_parser = LeRobotDocTestParser.__bases__[0]()
+    (example,) = (e for e in stdlib_parser.parse(FORMATTED_EXAMPLE) if isinstance(e, doctest.Example))
+    assert "```" in example.want
+
+
+def test_parser_stops_at_the_closing_fence():
+    """The whole reason `LeRobotDocTestParser` exists: `want` must be the output and nothing else."""
+    (example,) = (
+        e for e in LeRobotDocTestParser().parse(FORMATTED_EXAMPLE) if isinstance(e, doctest.Example)
+    )
+    assert example.source == "1 + 1\n"
+    assert example.want == "2\n"
+
+
+def test_example_with_output_passes_end_to_end():
+    """A formatted example with output should actually run green."""
+    runner = doctest.DocTestRunner()
+    test = LeRobotDocTestParser().get_doctest(FORMATTED_EXAMPLE, {}, "formatted", None, 0)
+    results = runner.run(test, out=lambda _: None)
+    assert results.failed == 0
+    assert results.attempted == 1
+
+
+def test_noisy_calls_get_ignore_result():
+    string = """
+    ```python
+    >>> ds = load_dataset("lerobot/pusht")
+    ```
+    """
+    assert "# doctest: +IGNORE_RESULT" in preprocess_string(string, False, False)
+
+
+def test_ignore_result_is_not_added_twice():
+    string = """
+    ```python
+    >>> ds = load_dataset("lerobot/pusht")  # doctest: +IGNORE_RESULT
+    ```
+    """
+    assert preprocess_string(string, False, False).count("# doctest: +IGNORE_RESULT") == 1
+
+
+def test_cuda_examples_are_dropped_when_requested():
+    string = """
+    ```python
+    >>> model.to("cuda")
+    ```
+    """
+    assert preprocess_string(string, True, False) == ""
+    assert preprocess_string(string, False, False) != ""
+
+
+def test_hardware_examples_are_dropped_when_requested():
+    """Serial ports, connect calls and Hub downloads all need real resources."""
+    for source in [
+        '>>> robot = SO101Follower(SO101FollowerConfig(port="/dev/ttyACM0"))',
+        ">>> robot.connect()",
+        '>>> policy = ACTPolicy.from_pretrained("lerobot/act")',
+    ]:
+        string = f"""
+    ```python
+    {source}
+    ```
+    """
+        assert preprocess_string(string, False, True) == "", source
+        assert preprocess_string(string, False, False) != "", source
+
+
+def test_plain_examples_survive_both_skips():
+    string = """
+    ```python
+    >>> 1 + 1
+    2
+    ```
+    """
+    assert preprocess_string(string, True, True) == string

--- a/utils/check_doctest_list.py
+++ b/utils/check_doctest_list.py
@@ -1,0 +1,109 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Keep the doctest list honest: every path exists, and the file stays sorted.
+
+Adapted from `transformers/utils/check_doctest_list.py`. It is agnostic to whether the list is an allowlist
+(what we have now) or a denylist (where transformers ended up), so it survives that inversion unchanged.
+
+Check, as CI does:
+
+```bash
+python utils/check_doctest_list.py
+```
+
+Sort in place:
+
+```bash
+python utils/check_doctest_list.py --fix_and_overwrite
+```
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+REPO_PATH = Path(__file__).resolve().parent.parent
+DOCTEST_FILE_PATHS = ["documentation_tests.txt"]
+
+
+def split_header(lines: list[str]) -> tuple[list[str], list[str]]:
+    """Split a list file into its leading comment header and its path entries.
+
+    Args:
+        lines (`list[str]`):
+            The file's lines, without trailing newlines.
+
+    Returns:
+        `tuple[list[str], list[str]]`: The leading comment/blank lines, and the remaining lines.
+    """
+    for i, line in enumerate(lines):
+        if line.strip() and not line.lstrip().startswith("#"):
+            return lines[:i], lines[i:]
+    return lines, []
+
+
+def clean_doctest_list(doctest_file: Path, overwrite: bool = False) -> None:
+    """Check, and optionally fix, one doctest list file.
+
+    Args:
+        doctest_file (`Path`):
+            The list file to check or clean.
+        overwrite (`bool`, *optional*, defaults to `False`):
+            Whether to fix problems in place. When `False`, raises instead.
+
+    Raises:
+        ValueError: If the file lists a path that does not exist, or is not alphabetically sorted and
+            `overwrite` is `False`.
+    """
+    lines = doctest_file.read_text(encoding="utf-8").splitlines()
+    header, entries = split_header(lines)
+    paths = [line.strip().split(" ")[0] for line in entries if line.strip()]
+
+    non_existent = [p for p in paths if not (REPO_PATH / p).exists()]
+    if non_existent:
+        listed = "\n".join(f"- {p}" for p in non_existent)
+        raise ValueError(f"`{doctest_file.name}` contains non-existent paths:\n{listed}")
+
+    if paths != sorted(paths):
+        if not overwrite:
+            raise ValueError(
+                f"Files in `{doctest_file.name}` are not in alphabetical order, run "
+                "`make fix-docstrings` to fix this automatically."
+            )
+        doctest_file.write_text("\n".join(header + sorted(paths)) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    """Run the check over every doctest list file.
+
+    Returns:
+        `int`: A process exit code — `0` when every file is clean, `1` otherwise.
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--fix_and_overwrite", action="store_true", help="Whether to fix inconsistencies.")
+    args = parser.parse_args()
+
+    failed = False
+    for name in DOCTEST_FILE_PATHS:
+        try:
+            clean_doctest_list(REPO_PATH / "utils" / name, args.fix_and_overwrite)
+        except ValueError as error:
+            print(error, file=sys.stderr)
+            failed = True
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/utils/documentation_tests.txt
+++ b/utils/documentation_tests.txt
@@ -1,0 +1,16 @@
+# Files whose docstring examples are executed by `make doctest`.
+#
+# This is an ALLOWLIST: only the paths below are collected. transformers started the same way and has since
+# inverted to a denylist (`utils/not_doctested.txt`), which is the better end state — it makes a new file
+# tested by default. LeRobot cannot start there: at the time of writing, public docstring coverage is under
+# 50% and only a handful of files carry any example at all, so a denylist would need hundreds of entries on
+# day one and would say nothing about what is actually verified.
+#
+# Invert once coverage is high enough that the exclusions are the short list.
+# `utils/check_doctest_list.py` does not care which way round it is.
+#
+# Keep alphabetically sorted: `make check-doctest-list` enforces it, `make fix-docstrings` sorts it.
+src/lerobot/motors/motors_bus.py
+src/lerobot/robots/robot.py
+src/lerobot/robots/utils.py
+src/lerobot/teleoperators/teleoperator.py


### PR DESCRIPTION
> **Stacked on #4350.** Review the earlier PRs in the stack first; this PR targets that branch, so the diff here is only its own commit.

## Summary / Motivation

Makes the examples in our docstrings executable, so they cannot silently rot.

## Related issues

- Related: #4350

## What changed

**`LeRobotDocTestParser` is the load-bearing piece.** Ruff is configured with `docstring-code-format = true`, which reformats code inside docstrings and drops the blank line before the closing fence; stdlib's `_EXAMPLE_RE` then reads the fence itself as part of the expected output and **every example with output fails**. The parser patches the regex to stop at a fence. `tests/utils/test_doctest_utils.py` asserts both halves of that: the stdlib parser puts ` ``` ` in `want`, ours does not, and a formatted example with output runs green.

**`LeRobotDoctestModule`** exists because `doctest.DocTestFinder` binds its default parser at class-definition time, so patching `doctest.DocTestParser` in conftest never reaches the finder pytest builds — the parser has to be passed explicitly. It is written against the **installed** pytest rather than copied from `transformers`, whose version predates several changes: pytest 9 requires `consider_namespace_packages` on `import_path` (which it no longer uses here), already fixes the `@property` line-number bug for Python ≥ 3.12.3, and handles `cached_property`. The property fix is kept for older interpreters, since our hardware API surface is mostly properties.

**`preprocess_string` diverges from the original deliberately.** That version splits on fenced blocks and then matches `>>>` within each chunk, but the split captures the fence *and its first prompt* into one group, so for a single-line example the code lands in a chunk with no `>>>` in it and neither the CUDA skip nor the `+IGNORE_RESULT` injection fires. Matching against the example lines directly is both simpler and correct, and means a docstring that merely mentions CUDA in prose is no longer mistaken for one that uses it.

**Two skip flags:** `SKIP_CUDA_DOCTEST` for GPU examples and `SKIP_HARDWARE_DOCTEST` for serial ports, connect calls and Hub downloads. CI sets both.

**The allowlist** starts with four files and documents why it is an allowlist rather than the denylist `transformers` ended up with: under 50% docstring coverage means a denylist would need hundreds of entries and would say nothing about what is actually verified. `utils/check_doctest_list.py` is agnostic to which way round it is, so it survives the eventual inversion; it also gained support for a comment header, which the original would have read as a path.

**Two pre-existing docstring bugs surfaced immediately, which is the point:**

- `SerialMotorsBus`'s class docstring used `>>>` inside a ` ```bash ` block to show CLI output. doctest read it as Python and raised `SyntaxError`. Rewritten as a plain output block.
- `MotorsBus.torque_disabled`'s example referenced an undefined `bus` and was neither fenced nor skipped. Now fenced with `# doctest: +SKIP`.

`ensure_safe_goal_position` gains a documented, genuinely executing example so the gate is not vacuous — without it every collected example is `+SKIP` and `make doctest` would pass while verifying nothing. Confirmed it fails when the expected output is wrong.

## How was this tested (or how to run locally)

```bash
make check-doctest-list
make doctest
uv run pytest tests/utils/test_doctest_utils.py -q
```

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: #

## Reviewer notes

Also corrects a claim in the docstring standard from the first PR in this stack. It said a bare `>>>` outside a fence is never collected; doctest finds prompts anywhere in a docstring, so an unfenced example still runs. What the fence actually buys is the rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
