### PR TITLE
chore: add docstring consistency checker and enable the gates

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -86,5 +86,11 @@ jobs:
       - name: Check the doctest list is sorted and its paths exist
         run: make check-doctest-list
 
+      - name: Check documented arguments match their signatures
+        run: make check-docstrings
+
+      - name: Check docstring coverage has not regressed
+        run: uv run --with interrogate interrogate --config=pyproject.toml
+
       - name: Run doctests
         run: make doctest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -108,8 +108,13 @@ repos:
   #       args: ["--docstring-style", "google", "-v", "2"]
   #       exclude: ^tests/.*$
 
+  # interrogate runs in CI (quality.yml, doc-checks job) rather than here. Its 1.7.0 release still imports
+  # the deprecated `py` package, which resolves against whatever `py` happens to be importable in
+  # pre-commit's isolated env — on a machine with miniconda on the path that is a stray `py.py` and the
+  # hook dies before it reads any config. The gate is the same either way; the CI step is just reliable.
   # - repo: https://github.com/econchick/interrogate
   #   rev: 1.7.0
   #   hooks:
   #     - id: interrogate
-  #       args: ["-vv", "--config=pyproject.toml"]
+  #       args: ["--config=pyproject.toml"]
+  #       pass_filenames: false

--- a/Makefile
+++ b/Makefile
@@ -198,3 +198,11 @@ check-doctest-list:
 
 fix-doctest-list:
 	uv run python utils/check_doctest_list.py --fix_and_overwrite
+
+check-docstrings:
+	uv run python utils/check_docstrings.py
+	uv run python utils/check_config_docstrings.py
+
+fix-docstrings:
+	uv run python utils/check_docstrings.py --fix_and_overwrite
+	uv run python utils/check_doctest_list.py --fix_and_overwrite

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -401,7 +401,7 @@ exclude = ["tests/artifacts/**/*.safetensors", "*_pb2.py", "*_pb2_grpc.py"]
 # N: pep8-naming
 # TODO: Uncomment rules when ready to use
 select = [
-    "E", "W", "F", "I", "B", "C4", "T20", "N", "UP", "SIM" #, "A", "S", "D", "RUF"
+    "E", "W", "F", "I", "B", "C4", "T20", "N", "UP", "SIM", "D" #, "A", "S", "RUF"
 ]
 ignore = [
     "E501", # Line too long
@@ -411,9 +411,50 @@ ignore = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"__init__.py" = ["F401", "F403", "E402"]
+"__init__.py" = ["F401", "F403", "E402", "D104"]
 # E402: conditional-import guards (TYPE_CHECKING / is_package_available) must precede the imports they protect
 "src/lerobot/scripts/convert_dataset_v21_to_v30.py" = ["E402"]
+
+# D (pydocstyle) is enabled globally, but only holds for code that has been converted to the docstring
+# standard in docs/source/writing_docstrings.mdx. Every module below is still on the old style; each entry
+# is deleted as that module is converted, and this block can be removed once it is empty.
+#
+# Not part of the API reference and not planned for conversion: tests, examples, benchmarks, templates,
+# CI helper scripts and the packaging shim.
+"tests/**" = ["D"]
+"examples/**" = ["D"]
+"benchmarks/**" = ["D"]
+"scripts/**" = ["D"]
+"setup.py" = ["D"]
+"src/lerobot/templates/**" = ["D"]
+# Vendored from transformers; keeps its upstream docstring style so syncs stay clean.
+"src/lerobot/policies/molmoact2/molmoact2_hf_model/**" = ["D"]
+# Awaiting conversion, one PR per module.
+"src/lerobot/annotations/**" = ["D"]
+"src/lerobot/async_inference/**" = ["D"]
+"src/lerobot/cameras/**" = ["D"]
+"src/lerobot/common/**" = ["D"]
+"src/lerobot/configs/**" = ["D"]
+"src/lerobot/data_processing/**" = ["D"]
+"src/lerobot/datasets/**" = ["D"]
+"src/lerobot/distributed/**" = ["D"]
+"src/lerobot/envs/**" = ["D"]
+"src/lerobot/jobs/**" = ["D"]
+"src/lerobot/model/**" = ["D"]
+"src/lerobot/motors/**" = ["D"]
+"src/lerobot/optim/**" = ["D"]
+"src/lerobot/policies/**" = ["D"]
+"src/lerobot/processor/**" = ["D"]
+"src/lerobot/rewards/**" = ["D"]
+"src/lerobot/rl/**" = ["D"]
+"src/lerobot/robots/**" = ["D"]
+"src/lerobot/rollout/**" = ["D"]
+"src/lerobot/scripts/**" = ["D"]
+"src/lerobot/teleoperators/**" = ["D"]
+"src/lerobot/transforms/**" = ["D"]
+"src/lerobot/transport/**" = ["D"]
+"src/lerobot/utils/**" = ["D"]
+"src/lerobot/lerobot_types.py" = ["D"]
 [tool.ruff.lint.isort]
 combine-as-imports = true
 known-first-party = ["lerobot"]
@@ -457,21 +498,24 @@ default.extend-ignore-identifiers-re = [
     "seperated_timestep",
 ]
 
-# TODO: Uncomment when ready to use
-# [tool.interrogate]
-# ignore-init-module = true
-# ignore-init-method = true
-# ignore-nested-functions = false
-# ignore-magic = false
-# ignore-semiprivate = false
-# ignore-private = false
-# ignore-property-decorators = false
-# ignore-module = false
-# ignore-setters = false
-# fail-under = 80
-# output-format = "term-missing"
-# color = true
-# paths = ["src/lerobot"]
+# Docstring coverage gate. `fail-under` is a RATCHET, not a target: it is set just below the currently
+# measured coverage so it passes today, and is raised in the same PR that documents a module. Never set it
+# to a value that fails on main. The destination is 100; see docs/source/writing_docstrings.mdx.
+[tool.interrogate]
+ignore-init-module = true
+ignore-init-method = true
+ignore-nested-functions = false
+ignore-magic = false
+ignore-semiprivate = false
+ignore-private = false
+ignore-property-decorators = false
+ignore-module = false
+ignore-setters = false
+fail-under = 52
+output-format = "term-missing"
+color = true
+paths = ["src/lerobot"]
+exclude = ["src/lerobot/policies/molmoact2/molmoact2_hf_model"]
 
 # TODO: Enable mypy gradually module by module across multiple PRs
 # Uncomment [tool.mypy] first, then uncomment individual module overrides as they get proper type annotations

--- a/src/lerobot/__init__.py
+++ b/src/lerobot/__init__.py
@@ -14,8 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-LeRobot -- PyTorch library for real-world robotics.
+"""LeRobot -- PyTorch library for real-world robotics.
 
 Provides datasets, pretrained policies, and tools for training, evaluation,
 data collection, and robot control. Integrates with Hugging Face Hub for

--- a/src/lerobot/__version__.py
+++ b/src/lerobot/__version__.py
@@ -13,7 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""To enable `lerobot.__version__`"""
+"""To enable `lerobot.__version__`."""
 
 from importlib.metadata import PackageNotFoundError, version
 

--- a/src/lerobot/robots/unitree_g1/unitree_sdk2_socket.py
+++ b/src/lerobot/robots/unitree_g1/unitree_sdk2_socket.py
@@ -107,8 +107,10 @@ def ChannelFactoryInitialize(domain_id: int = 0, config: Any = None) -> None:  #
     ZMQ sockets to connect to the robot server bridge instead of DDS.
 
     Args:
-        domain_id: Ignored (for API compatibility with Unitree SDK)
-        config: UnitreeG1Config instance with robot_ip
+        domain_id (`int`, *optional*, defaults to 0):
+            Ignored. Accepted only for API compatibility with the Unitree SDK.
+        config (`Any`, *optional*):
+            A `UnitreeG1Config` supplying `robot_ip`. Defaults to a fresh `UnitreeG1Config` when `None`.
     """
     global _ctx, _lowcmd_sock, _lowstate_sock
 

--- a/utils/check_config_docstrings.py
+++ b/utils/check_config_docstrings.py
@@ -1,0 +1,153 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Check that every registered hardware config documents the fields users have to get right.
+
+Modelled on `transformers/utils/check_config_docstrings.py`, which checks that every model config links a
+checkpoint. LeRobot's equivalent question is the one every new user hits: which port is the device on, and
+what happens on calibration. A config that leaves those undocumented sends people to the source.
+
+Only fields the config actually declares are required — a config without a `port` is not asked to document
+one.
+
+```bash
+python utils/check_config_docstrings.py
+```
+"""
+
+import inspect
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from check_docstrings import _re_args, _re_parse_arg, find_indent, iter_objects_to_check  # noqa: E402
+
+# Fields whose semantics are not obvious from the name and that a user must set correctly on first run.
+REQUIRED_FIELDS = ["port"]
+
+# A config must say something about calibration if it participates in it at all.
+CALIBRATION_PATTERN = re.compile(r"calibrat", re.IGNORECASE)
+
+MODULES_TO_CHECK = ["lerobot.robots"]
+
+# Configs that document their fields with `#` comments above each field, which doc-builder cannot see.
+# Each entry is removed as that config's comments are converted to an `Args:` block.
+OBJECTS_TO_IGNORE: set[str] = {
+    "BiOpenArmFollowerConfig",
+    "BiRebotB601FollowerConfig",
+    "BiSOFollowerConfig",
+    "EarthRoverMiniPlusConfig",
+    "HopeJrArmConfig",
+    "HopeJrHandConfig",
+    "KochFollowerConfig",
+    "LeKiwiConfig",
+    "OmxFollowerConfig",
+    "OpenArmFollowerConfig",
+    "Reachy2RobotConfig",
+    "RebotB601FollowerRobotConfig",
+    "SOFollowerRobotConfig",
+}
+
+
+def documented_args(obj: object) -> set[str]:
+    """Return the argument names documented in an object's `Args:` block.
+
+    Args:
+        obj (`object`):
+            The class to inspect.
+
+    Returns:
+        `set[str]`: The documented argument names, empty if there is no `Args:` section.
+    """
+    doc = getattr(obj, "__doc__", None)
+    if not doc:
+        return set()
+
+    lines = doc.split("\n")
+    idx = 0
+    while idx < len(lines) and _re_args.search(lines[idx]) is None:
+        idx += 1
+    if idx == len(lines):
+        return set()
+
+    indent = find_indent(lines[idx])
+    names = set()
+    idx += 1
+    while idx < len(lines) and (len(lines[idx].strip()) == 0 or find_indent(lines[idx]) > indent):
+        if find_indent(lines[idx]) == indent + 4:
+            match = _re_parse_arg.search(lines[idx])
+            if match is not None:
+                names.add(match.groups()[1])
+        idx += 1
+    return names
+
+
+def check_config_docstrings() -> list[str]:
+    """Check every registered config in `MODULES_TO_CHECK`.
+
+    Returns:
+        `list[str]`: One message per config that is missing a required field or calibration semantics.
+    """
+    from lerobot.robots import RobotConfig
+
+    failures = []
+    for module_name in MODULES_TO_CHECK:
+        for obj in iter_objects_to_check(module_name):
+            if not inspect.isclass(obj) or not issubclass(obj, RobotConfig) or obj is RobotConfig:
+                continue
+            if inspect.isabstract(obj) or obj.__qualname__ in OBJECTS_TO_IGNORE:
+                continue
+
+            try:
+                fields = set(inspect.signature(obj).parameters)
+            except (TypeError, ValueError):
+                continue
+
+            doc = getattr(obj, "__doc__", "") or ""
+            documented = documented_args(obj)
+            name = f"{obj.__module__}.{obj.__qualname__}"
+
+            for field in REQUIRED_FIELDS:
+                if field in fields and field not in documented:
+                    failures.append(f"{name}: does not document `{field}`")
+
+            if "calibration_dir" in fields and CALIBRATION_PATTERN.search(doc) is None:
+                failures.append(f"{name}: says nothing about calibration")
+
+    return failures
+
+
+def main() -> int:
+    """Run the check.
+
+    Returns:
+        `int`: `0` when every registered config is documented, `1` otherwise.
+    """
+    failures = check_config_docstrings()
+    if failures:
+        print(
+            "The following robot configs are missing documentation a user needs on first run. See "
+            "docs/source/writing_docstrings.mdx:",
+            file=sys.stderr,
+        )
+        for failure in failures:
+            print(f"- {failure}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/utils/check_docstrings.py
+++ b/utils/check_docstrings.py
@@ -1,0 +1,551 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Check that documented arguments match the real signature.
+
+Adapted from the core of `transformers/utils/check_docstrings.py`. The parts of that file bound to
+transformers internals — the `@auto_docstring` decorator system, modular-file propagation, `ModelArgs`,
+GitPython — are deliberately not ported.
+
+What this enforces, for every public object in `MODULES_TO_CHECK`:
+
+- every parameter in the signature has an `Args:` entry, in signature order;
+- no `Args:` entry names a parameter that does not exist;
+- the `*optional*, defaults to `X`` clause matches the real default.
+
+That last one is why the clause is not decorative. See docs/source/writing_docstrings.mdx.
+
+Check, as CI does:
+
+```bash
+python utils/check_docstrings.py
+```
+
+Rewrite the `Args:` blocks to match the signatures, inserting `<fill_docstring>` placeholders for
+parameters that are missing entirely:
+
+```bash
+python utils/check_docstrings.py --fix_and_overwrite
+```
+
+`MODULES_TO_CHECK` is the ratchet: add a module once its docstrings are converted.
+"""
+
+import argparse
+import ast
+import enum
+import importlib
+import inspect
+import operator as op
+import pkgutil
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+PATH_TO_REPO = Path(__file__).resolve().parent.parent
+PATH_TO_LEROBOT = PATH_TO_REPO / "src" / "lerobot"
+
+# Modules whose public objects are checked. Add a module here once its docstrings follow the standard.
+MODULES_TO_CHECK = [
+    "lerobot.robots",
+]
+
+# Objects that do not yet follow the standard, so the check can be green from day one. Removing an entry
+# and running `--fix_and_overwrite` is how a module gets converted.
+OBJECTS_TO_IGNORE: set[str] = set()
+
+OPTIONAL_KEYWORD = "*optional*"
+
+_re_args = re.compile(r"^\s*(Args?|Arguments?|Attributes?|Params?|Parameters?):\s*$")
+_re_parse_arg = re.compile(r"^(\s*)(\S+)\s+\((.+)\)(?:\:|$)")
+_re_parse_description = re.compile(r"\*optional\*, defaults to (.*)$")
+
+MATH_OPERATORS = {
+    ast.Add: op.add,
+    ast.Sub: op.sub,
+    ast.Mult: op.mul,
+    ast.Div: op.truediv,
+    ast.Pow: op.pow,
+    ast.BitXor: op.xor,
+    ast.USub: op.neg,
+}
+
+
+def find_indent(line: str) -> int:
+    """Return the number of spaces a line is indented by.
+
+    Args:
+        line (`str`):
+            The line to measure.
+
+    Returns:
+        `int`: The indentation width.
+    """
+    search = re.search(r"^(\s*)(?:\S|$)", line)
+    return 0 if search is None else len(search.groups()[0])
+
+
+def is_dataclass_factory_default(default: Any) -> bool:
+    """Whether a signature default came from a dataclass `field(default_factory=...)`.
+
+    `inspect.signature` renders those as a `<factory>` sentinel, which must not be written into a
+    docstring as a literal default.
+
+    Args:
+        default (`Any`):
+            The default value taken from the signature.
+
+    Returns:
+        `bool`: `True` for the factory sentinel.
+    """
+    return repr(default) == "<factory>"
+
+
+def stringify_default(default: Any) -> str:
+    """Render a default value the way a docstring should show it.
+
+    Args:
+        default (`Any`):
+            The default value to process.
+
+    Returns:
+        `str`: Numbers are left bare, everything else is wrapped in backticks.
+    """
+    if isinstance(default, bool):
+        # Must precede the int check: a bool passes isinstance(x, int).
+        return f"`{default}`"
+    elif isinstance(default, enum.Enum):
+        # Must also precede the int check: an IntEnum passes isinstance(x, int).
+        return f"`{str(default)}`"
+    elif isinstance(default, int):
+        return str(default)
+    elif isinstance(default, float):
+        result = str(default)
+        return str(round(default, 2)) if len(result) > 6 else result
+    elif isinstance(default, str):
+        return str(default) if default.isnumeric() else f'`"{default}"`'
+    elif isinstance(default, type):
+        return f"`{default.__name__}`"
+    else:
+        return f"`{default}`"
+
+
+def eval_node(node):
+    """Evaluate one node of a arithmetic-only AST.
+
+    Args:
+        node (`ast.AST`):
+            The node to evaluate.
+
+    Returns:
+        `float | int | complex`: The node's value.
+
+    Raises:
+        TypeError: If the node is not a number or a supported arithmetic operation.
+    """
+    if isinstance(node, ast.Constant) and type(node.value) in (int, float, complex):
+        return node.value
+    elif isinstance(node, ast.BinOp):
+        return MATH_OPERATORS[type(node.op)](eval_node(node.left), eval_node(node.right))
+    elif isinstance(node, ast.UnaryOp):
+        return MATH_OPERATORS[type(node.op)](eval_node(node.operand))
+    else:
+        raise TypeError(node)
+
+
+def eval_math_expression(expression: str) -> float | int | None:
+    """Safely evaluate an arithmetic expression found in a docstring.
+
+    Docstrings often document a default as an expression (`1 / 255` is the classic), which should be left
+    alone rather than replaced by its computed value.
+
+    Args:
+        expression (`str`):
+            The expression to evaluate.
+
+    Returns:
+        `float | int | None`: The value, or `None` if it is not a plain arithmetic expression.
+    """
+    try:
+        return eval_node(ast.parse(expression, mode="eval").body)
+    except (TypeError, SyntaxError, KeyError, ZeroDivisionError):
+        return None
+
+
+def replace_default_in_arg_description(description: str, default: Any) -> str:
+    """Rewrite the `*optional*, defaults to X` clause of one argument description.
+
+    Args:
+        description (`str`):
+            The argument description from the docstring, without the name.
+        default (`Any`):
+            The real default from the signature, or `inspect._empty` if the argument is required.
+
+    Returns:
+        `str`: The description with its optional/default clause matching the signature.
+    """
+    # Plenty of docstrings use `optional` or **optional** instead of *optional*.
+    description = description.replace("`optional`", OPTIONAL_KEYWORD)
+    description = description.replace("**optional**", OPTIONAL_KEYWORD)
+
+    if default is inspect._empty:
+        # Required: the description must not claim otherwise.
+        idx = description.find(OPTIONAL_KEYWORD)
+        if idx != -1:
+            description = description[:idx].rstrip().removesuffix(",").rstrip()
+    elif default is None or is_dataclass_factory_default(default):
+        # A `None` default is not spelled out, and a `default_factory` has no literal value to show.
+        idx = description.find(OPTIONAL_KEYWORD)
+        if idx == -1:
+            description = f"{description}, {OPTIONAL_KEYWORD}"
+        elif re.search(r"defaults to `?None`?", description) is not None:
+            description = description[: idx + len(OPTIONAL_KEYWORD)]
+    else:
+        str_default = None
+        documented_match = re.search("defaults to `?(.*?)(?:`|$)", description)
+        if isinstance(default, (int, float)) and documented_match is not None:
+            documented = documented_match.groups()[0]
+            if default == eval_math_expression(documented):
+                try:
+                    # Directly convertible means it was a plain literal.
+                    str_default = str(type(default)(documented))
+                except (TypeError, ValueError):
+                    # Otherwise it was an expression; keep it as written.
+                    str_default = f"`{documented}`"
+
+        if str_default is None:
+            str_default = stringify_default(default)
+
+        if OPTIONAL_KEYWORD not in description:
+            description = f"{description}, {OPTIONAL_KEYWORD}, defaults to {str_default}"
+        elif _re_parse_description.search(description) is None:
+            idx = description.find(OPTIONAL_KEYWORD)
+            description = f"{description[: idx + len(OPTIONAL_KEYWORD)]}, defaults to {str_default}"
+        else:
+            description = _re_parse_description.sub(f"*optional*, defaults to {str_default}", description)
+
+    return description
+
+
+def get_default_description(arg: inspect.Parameter) -> str:
+    """Build the parenthesised type-and-default part for an undocumented parameter.
+
+    Args:
+        arg (`inspect.Parameter`):
+            The parameter to describe.
+
+    Returns:
+        `str`: Something like ``` `int`, *optional*, defaults to 3 ```.
+    """
+    if arg.annotation is inspect._empty:
+        arg_type = "<fill_type>"
+    elif hasattr(arg.annotation, "__name__"):
+        arg_type = arg.annotation.__name__
+    else:
+        arg_type = str(arg.annotation)
+
+    if arg.default is inspect._empty:
+        return f"`{arg_type}`"
+    elif arg.default is None or is_dataclass_factory_default(arg.default):
+        return f"`{arg_type}`, {OPTIONAL_KEYWORD}"
+    else:
+        return f"`{arg_type}`, {OPTIONAL_KEYWORD}, defaults to {stringify_default(arg.default)}"
+
+
+def find_source_file(obj: Any) -> Path:
+    """Locate the file an object is defined in.
+
+    Args:
+        obj (`Any`):
+            The object to locate.
+
+    Returns:
+        `Path`: The source file.
+    """
+    obj_file = PATH_TO_LEROBOT
+    for part in obj.__module__.split(".")[1:]:
+        obj_file = obj_file / part
+    return obj_file.with_suffix(".py")
+
+
+def match_docstring_with_signature(obj: Any) -> tuple[str, str] | None:
+    """Compare an object's documented arguments against its signature.
+
+    Dataclasses need no special handling: `inspect.signature` resolves the generated `__init__`, inherited
+    fields included, which is exactly the set a reader sees on the rendered page.
+
+    Args:
+        obj (`Any`):
+            The class or function to check.
+
+    Returns:
+        `tuple[str, str] | None`: The current `Args:` block and the one matching the signature, or `None`
+        when there is nothing to compare — no docstring, no documented arguments, or an unsupported
+        signature.
+    """
+    if not getattr(obj, "__doc__", None):
+        return None
+
+    try:
+        source, _ = inspect.getsourcelines(obj)
+    except (OSError, TypeError):
+        source = []
+
+    idx = 0
+    while idx < len(source) and '"""' not in source[idx]:
+        idx += 1
+
+    ignore_order = False
+    if idx < len(source) and idx > 0:
+        line_before_docstring = source[idx - 1]
+        if re.search(r"^\s*#\s*no-format\s*$", line_before_docstring):
+            return None
+        elif re.search(r"^\s*#\s*ignore-order\s*$", line_before_docstring):
+            ignore_order = True
+
+    try:
+        signature = inspect.signature(obj).parameters
+    except (ValueError, TypeError):
+        return None
+
+    obj_doc_lines = obj.__doc__.split("\n")
+    idx = 0
+    while idx < len(obj_doc_lines) and _re_args.search(obj_doc_lines[idx]) is None:
+        idx += 1
+    if idx == len(obj_doc_lines):
+        # No arguments documented; coverage is interrogate's job, not this check's.
+        return None
+
+    if "kwargs" in signature and signature["kwargs"].annotation != inspect._empty:
+        # Typed **kwargs are not introspectable in a useful way here.
+        return None
+
+    indent = find_indent(obj_doc_lines[idx])
+    arguments: dict[str, Any] = {}
+    current_arg = None
+    idx += 1
+    start_idx = idx
+    # Consume until a non-empty line returns to the section's own indent, or the docstring ends.
+    while idx < len(obj_doc_lines) and (
+        len(obj_doc_lines[idx].strip()) == 0 or find_indent(obj_doc_lines[idx]) > indent
+    ):
+        if find_indent(obj_doc_lines[idx]) == indent + 4:
+            re_search_arg = _re_parse_arg.search(obj_doc_lines[idx])
+            if re_search_arg is not None:
+                _, name, description = re_search_arg.groups()
+                current_arg = name
+                if name in signature:
+                    default = signature[name].default
+                    if signature[name].kind is inspect._ParameterKind.VAR_KEYWORD:
+                        default = None
+                    new_description = replace_default_in_arg_description(description, default)
+                else:
+                    new_description = description
+                arguments[current_arg] = [
+                    _re_parse_arg.sub(rf"\1\2 ({new_description}):", obj_doc_lines[idx])
+                ]
+        elif current_arg is not None:
+            arguments[current_arg].append(obj_doc_lines[idx])
+        idx += 1
+
+    # Walk back over the trailing blank lines we consumed.
+    idx -= 1
+    if current_arg:
+        while len(obj_doc_lines[idx].strip()) == 0:
+            arguments[current_arg] = arguments[current_arg][:-1]
+            idx -= 1
+    idx += 1
+
+    old_doc_arg = "\n".join(obj_doc_lines[start_idx:idx])
+
+    old_arguments = list(arguments.keys())
+    arguments = {name: "\n".join(doc) for name, doc in arguments.items()}
+    for name in set(signature.keys()) - set(arguments.keys()):
+        arg = signature[name]
+        # Private parameters and *args/**kwargs are only documented if the author chose to.
+        if name.startswith("_") or arg.kind in [
+            inspect._ParameterKind.VAR_KEYWORD,
+            inspect._ParameterKind.VAR_POSITIONAL,
+        ]:
+            arguments[name] = ""
+        else:
+            arguments[name] = (
+                " " * (indent + 4) + f"{name} ({get_default_description(arg)}): <fill_docstring>"
+            )
+
+    if ignore_order:
+        new_param_docs = [arguments[name] for name in old_arguments if name in signature]
+        missing = set(signature.keys()) - set(old_arguments)
+        new_param_docs.extend([arguments[name] for name in missing if len(arguments[name]) > 0])
+    else:
+        new_param_docs = [arguments[name] for name in signature if len(arguments[name]) > 0]
+
+    return old_doc_arg, "\n".join(new_param_docs)
+
+
+def fix_docstring(obj: Any, old_doc_args: str, new_doc_args: str) -> None:
+    """Rewrite an object's `Args:` block in its source file.
+
+    Args:
+        obj (`Any`):
+            The object whose docstring is being fixed.
+        old_doc_args (`str`):
+            The current `Args:` block, as returned by [`match_docstring_with_signature`].
+        new_doc_args (`str`):
+            The replacement block, as returned by [`match_docstring_with_signature`].
+
+    Raises:
+        ValueError: If the block found in the source does not match the one parsed from `__doc__`, which
+            means the boundaries were identified wrongly and rewriting would corrupt the file.
+    """
+    source, line_number = inspect.getsourcelines(obj)
+
+    idx = 0
+    while idx < len(source) and _re_args.search(source[idx]) is None:
+        idx += 1
+    if idx == len(source):
+        # Inherited docstring: do not rewrite it on the child.
+        return
+
+    indent = find_indent(source[idx])
+    idx += 1
+    start_idx = idx
+    while idx < len(source) and (len(source[idx].strip()) == 0 or find_indent(source[idx]) > indent):
+        idx += 1
+    idx -= 1
+    while len(source[idx].strip()) == 0:
+        idx -= 1
+    idx += 1
+
+    # `old_doc_args` comes from `__doc__`, whose indentation differs from the raw source lines.
+    source_args_as_str = "".join(source[start_idx:idx])
+    if inspect.cleandoc(source_args_as_str) != inspect.cleandoc(old_doc_args):
+        raise ValueError(
+            f"Cannot fix the docstring of {obj.__name__} in {find_source_file(obj)}: the argument section "
+            f"in the source does not match the one parsed from __doc__, so the block boundaries are "
+            f"wrong and rewriting it would corrupt the file.\n\n"
+            f"Parsed:\n{old_doc_args!r}\n\nFound in source:\n{source_args_as_str.rstrip()!r}\n"
+        )
+
+    obj_file = find_source_file(obj)
+    lines = obj_file.read_text(encoding="utf-8").split("\n")
+    # `new_doc_args` is built from `__doc__`, and Python keeps every line after the first at its exact
+    # source indentation, so the block is already correctly indented for the file. transformers re-indents
+    # here because its docstrings are often assembled by decorators and no longer match the source.
+    lines = lines[: line_number + start_idx - 1] + [new_doc_args] + lines[line_number + idx - 1 :]
+
+    print(f"Fixing the docstring of {obj.__name__} in {obj_file}.")
+    obj_file.write_text("\n".join(lines), encoding="utf-8")
+
+
+def iter_objects_to_check(module_name: str):
+    """Yield the public classes and functions defined in a package.
+
+    Args:
+        module_name (`str`):
+            An importable package name, e.g. `"lerobot.robots"`.
+
+    Yields:
+        `Any`: Each public class or function whose `__module__` is inside the package, deduplicated so
+        that aliases (`SO101Follower = SOFollower`) are visited once.
+    """
+    package = importlib.import_module(module_name)
+    module_names = [module_name]
+    if hasattr(package, "__path__"):
+        module_names += [
+            name for _, name, _ in pkgutil.walk_packages(package.__path__, prefix=f"{module_name}.")
+        ]
+
+    seen = set()
+    for name in module_names:
+        try:
+            module = importlib.import_module(name)
+        except Exception as error:  # An optional extra is missing; not this check's problem.
+            print(f"Skipping {name}: {type(error).__name__}: {error}", file=sys.stderr)
+            continue
+        for attr_name, obj in vars(module).items():
+            if attr_name.startswith("_") or not (inspect.isclass(obj) or inspect.isfunction(obj)):
+                continue
+            if not getattr(obj, "__module__", "").startswith(module_name):
+                continue
+            key = f"{obj.__module__}.{obj.__qualname__}"
+            if key in seen or obj.__qualname__ in OBJECTS_TO_IGNORE or key in OBJECTS_TO_IGNORE:
+                continue
+            seen.add(key)
+            yield obj
+
+
+def check_docstrings(overwrite: bool = False) -> list[str]:
+    """Check every object in `MODULES_TO_CHECK`.
+
+    Args:
+        overwrite (`bool`, *optional*, defaults to `False`):
+            Whether to rewrite mismatched `Args:` blocks in place.
+
+    Returns:
+        `list[str]`: The names of objects whose documented arguments do not match their signature. Empty
+        when everything is consistent.
+    """
+    failures = []
+    hard_failures = []
+    for module_name in MODULES_TO_CHECK:
+        for obj in iter_objects_to_check(module_name):
+            try:
+                result = match_docstring_with_signature(obj)
+            except Exception as error:
+                hard_failures.append(f"{obj.__qualname__}: {type(error).__name__}: {error}")
+                continue
+            if result is None:
+                continue
+            old_doc, new_doc = result
+            if old_doc == new_doc:
+                continue
+            if overwrite:
+                fix_docstring(obj, old_doc, new_doc)
+            else:
+                failures.append(f"{obj.__module__}.{obj.__qualname__}")
+
+    if hard_failures:
+        print("The following objects could not be processed:", file=sys.stderr)
+        for failure in hard_failures:
+            print(f"- {failure}", file=sys.stderr)
+    return failures
+
+
+def main() -> int:
+    """Run the check.
+
+    Returns:
+        `int`: `0` when every documented argument matches its signature, `1` otherwise.
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--fix_and_overwrite", action="store_true", help="Whether to fix inconsistencies.")
+    args = parser.parse_args()
+
+    failures = check_docstrings(overwrite=args.fix_and_overwrite)
+    if failures:
+        print(
+            "The docstrings of the following objects do not match their signature. Run "
+            "`make fix-docstrings` to rewrite them, then fill in any `<fill_docstring>` placeholders:",
+            file=sys.stderr,
+        )
+        for failure in failures:
+            print(f"- {failure}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
> **Stacked on #4351.** Review the earlier PRs in the stack first; this PR targets that branch, so the diff here is only its own commit.

## Summary / Motivation

Makes the `*optional*, defaults to X` clause worth writing, by checking it against the real signature. Adds the Makefile targets and CI gates the rest of the rollout ratchets against.

## Related issues

- Related: #4351

## What changed

**`utils/check_docstrings.py`** compares documented arguments against real signatures: every parameter has an `Args:` entry in signature order, no entry names a parameter that does not exist, and the documented default matches the actual one.

It is the ~300-line core of the transformers original, not the whole 2203-line file. The `@auto_docstring` decorator system, modular-file propagation, `ModelArgs`/`ConfigArgs`, `direct_transformers_import` and the GitPython dependency have no LeRobot analogue and are not ported; neither is `utils/checkers.py`, whose content-hash caching and parallel dispatch is sized for a 400-model repo.

Two deliberate divergences, both found by running it:

- **No special dataclass path.** `inspect.signature` on a dataclass already resolves the generated `__init__` including inherited fields, which is exactly the set doc-builder renders — verified on `SOFollowerRobotConfig`, where it returns all eleven fields including `id` and `calibration_dir` from `RobotConfig`. What did need handling is `field(default_factory=...)`, which `inspect` reports as a `<factory>` sentinel that must not be written into a docstring as a literal default.
- **`fix_docstring` does not re-indent** the block it writes. Python keeps every docstring line after the first at its exact source indentation, so the block built from `__doc__` is already correct for the file; the original re-indents because transformers assembles many docstrings via decorators. Keeping that step produced twelve-space indentation for an eight-space block.

**`utils/check_config_docstrings.py`** answers the LeRobot version of the question transformers asks about checkpoints: does a hardware config document the things a user must get right on the first run — which port the device is on, and what happens at calibration. It only requires a field the config actually declares. It currently reports thirteen robot configs whose fields are documented with `#` comments doc-builder cannot see; they are listed in `OBJECTS_TO_IGNORE`, and that list is emptied by the next PR in this stack.

**Gates:**

- `make check-docstrings`, `make fix-docstrings`, `make check-doctest-list`, `make fix-doctest-list`, wired into the quality workflow's doc-checks job.
- **Ruff `D` enabled globally**, with per-file-ignores for every module still on the old style. **This is the coordination seam for the parallel docstring rollout: each module's PR deletes its own entry, and the block goes away when it is empty.** Tests, examples, benchmarks, CI scripts, templates and the vendored molmoact2 files are excluded permanently.
- `[tool.interrogate]` uncommented with `fail-under = 52` against a measured 52.1%. **The pre-designed value of 80 would have failed on main immediately.** This is a ratchet: raise it in the same PR that documents a module, never to a value that fails today.

Two one-line docstring fixes in `src/lerobot/__init__.py` and `__version__.py` so `D` is clean without ignoring the package root.

## How was this tested (or how to run locally)

```bash
make check-docstrings
make check-doctest-list
uv run --with interrogate interrogate --config=pyproject.toml
uv run ruff check .
```

`--fix_and_overwrite` was exercised on the one object that failed, generating `<fill_docstring>` placeholders with correct types and defaults from the signature; the prose was then filled in by hand.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: #

## Reviewer notes

interrogate runs as a CI step rather than a pre-commit hook: 1.7.0 imports the deprecated `py` package, which in pre-commit's isolated env resolves against whatever `py` is importable and dies before reading any config on a machine with miniconda on the path.

The twelve non-`D` ruff findings that `ruff check .` reports are pre-existing; confirmed identical on a stashed tree. Three of them are fixed in a separate standalone PR so this stack keeps a clean diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
