### PR TITLE
chore: sort imports in vla_jepa tests

### DIFF
--- a/tests/policies/vla_jepa/test_action_head.py
+++ b/tests/policies/vla_jepa/test_action_head.py
@@ -16,7 +16,6 @@ from conftest import (
     make_config,
     set_seed_all,
 )  # noqa: E402
-
 from lerobot.policies.vla_jepa.action_head import (  # noqa: E402
     VLAJEPAActionHead,
 )

--- a/tests/policies/vla_jepa/test_configuration.py
+++ b/tests/policies/vla_jepa/test_configuration.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import pytest
-from conftest import ACTION_DIM, ACTION_HORIZON, IMAGE_SIZE, NUM_VIDEO_FRAMES, STATE_DIM, make_config
 
+from conftest import ACTION_DIM, ACTION_HORIZON, IMAGE_SIZE, NUM_VIDEO_FRAMES, STATE_DIM, make_config
 from lerobot.configs.types import FeatureType, PolicyFeature
 from lerobot.policies.vla_jepa.configuration_vla_jepa import VLAJEPAConfig
 from lerobot.utils.constants import ACTION, OBS_IMAGES, OBS_STATE

--- a/tests/policies/vla_jepa/test_vla_jepa.py
+++ b/tests/policies/vla_jepa/test_vla_jepa.py
@@ -32,7 +32,6 @@ from conftest import (  # noqa: E402
     make_train_batch,
     set_seed_all,
 )
-
 from lerobot.policies.vla_jepa.configuration_vla_jepa import VLAJEPAConfig  # noqa: E402
 from lerobot.policies.vla_jepa.modeling_vla_jepa import VLAJEPAPolicy  # noqa: E402
 from lerobot.utils.constants import ACTION  # noqa: E402


### PR DESCRIPTION
## Summary / Motivation

Three pre-existing `I001` (unsorted imports) violations that `pre-commit run --all-files` auto-fixes. Confirmed present on `main` before this change.

Split out as a standalone PR so the six-PR documentation-infrastructure stack keeps a diff containing only documentation work.

## Related issues

- Related: # (none)

## What changed

Import blocks sorted in three `tests/policies/vla_jepa/` test files. No functional change — the fix is exactly what the repo's own ruff hook produces.

## How was this tested (or how to run locally)

```bash
pre-commit run --all-files
uv run pytest tests/policies/vla_jepa -q
```

`pre-commit run --all-files` is green after this change and red before it.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [ ] Documentation updated (n/a)
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: #

## Reviewer notes

Trivial and mechanical; merge whenever convenient.

