### PR TITLE
fix(datasets): fix batched video encoding on fresh and resumed recordings

### DIFF
--- a/src/lerobot/datasets/dataset_metadata.py
+++ b/src/lerobot/datasets/dataset_metadata.py
@@ -195,6 +195,19 @@ class LeRobotDatasetMetadata:
             writer.close()
             self._pq_writer = None
 
+    def flush(self) -> None:
+        """Make all episode metadata saved so far readable from disk.
+
+        Flushes the metadata buffer, closes the parquet writer (an open writer
+        holds a file with no footer, which is unreadable), reloads
+        ``self.episodes`` from disk and resets ``latest_episode`` so the next
+        episode save re-anchors on the on-disk state and starts a new file
+        instead of truncating the one just closed.
+        """
+        self._close_writer()
+        self.latest_episode = None
+        self.episodes = load_episodes(self.root)
+
     def finalize(self) -> None:
         """Flush metadata buffer and close the parquet writer.
 

--- a/src/lerobot/datasets/dataset_writer.py
+++ b/src/lerobot/datasets/dataset_writer.py
@@ -402,12 +402,39 @@ class DatasetWriter:
             f"Batch encoding {self._batch_encoding_size} videos for episodes {start_episode} to {end_episode - 1}"
         )
 
+        # Episodes saved since the last flush only exist in the metadata buffer
+        # and in a parquet file whose writer is still open (no footer yet), so
+        # `self._meta.episodes` does not contain them and the file itself is
+        # not readable. Flush so the per-episode rows indexed below exist on
+        # disk.
+        self._meta.flush()
+
         chunk_idx = self._meta.episodes[start_episode]["data/chunk_index"]
         file_idx = self._meta.episodes[start_episode]["data/file_index"]
         episode_df_path = self._root / DEFAULT_EPISODES_PATH.format(
             chunk_index=chunk_idx, file_index=file_idx
         )
-        episode_df = pd.read_parquet(episode_df_path)
+        episode_df = pd.read_parquet(episode_df_path, dtype_backend="pyarrow")
+        # Index by episode so the video-metadata merge below aligns on the
+        # global episode index; positional alignment silently corrupts any
+        # episodes file that does not start at episode 0 (resumed datasets).
+        episode_df = episode_df.set_index("episode_index", drop=False).rename_axis(None)
+
+        # Video packing appends each episode onto the previous one's video
+        # file, so track where the last encoded episode ended. The anchor is
+        # the episode just before this batch (None when the dataset has no
+        # encoded videos yet). `self._meta.latest_episode` cannot be used as-is
+        # for this: it holds the last *saved* episode, whose video columns are
+        # exactly the ones this batch is about to fill in.
+        video_anchor = None
+        if start_episode > 0:
+            prev_ep = self._meta.episodes[start_episode - 1]
+            if prev_ep.get(f"videos/{self._meta.video_keys[0]}/chunk_index") is not None:
+                video_anchor = {
+                    f"videos/{key}/{field}": [prev_ep[f"videos/{key}/{field}"]]
+                    for key in self._meta.video_keys
+                    for field in ("chunk_index", "file_index", "to_timestamp")
+                }
 
         for ep_idx in range(start_episode, end_episode):
             logger.info(f"Encoding videos for episode {ep_idx}")
@@ -416,7 +443,7 @@ class DatasetWriter:
                 self._meta.episodes[ep_idx]["data/chunk_index"] != chunk_idx
                 or self._meta.episodes[ep_idx]["data/file_index"] != file_idx
             ):
-                episode_df.to_parquet(episode_df_path)
+                episode_df.to_parquet(episode_df_path, index=False)
                 self._meta.episodes = load_episodes(self._root)
 
                 chunk_idx = self._meta.episodes[ep_idx]["data/chunk_index"]
@@ -424,19 +451,31 @@ class DatasetWriter:
                 episode_df_path = self._root / DEFAULT_EPISODES_PATH.format(
                     chunk_index=chunk_idx, file_index=file_idx
                 )
-                episode_df = pd.read_parquet(episode_df_path)
+                episode_df = pd.read_parquet(episode_df_path, dtype_backend="pyarrow")
+                episode_df = episode_df.set_index("episode_index", drop=False).rename_axis(None)
 
+            self._meta.latest_episode = video_anchor
             video_ep_metadata = {}
             for video_key in self._meta.video_keys:
                 video_ep_metadata.update(self._save_episode_video(video_key, ep_idx))
+            video_anchor = {
+                f"videos/{key}/{field}": [video_ep_metadata[f"videos/{key}/{field}"]]
+                for key in self._meta.video_keys
+                for field in ("chunk_index", "file_index", "to_timestamp")
+            }
             video_ep_metadata.pop("episode_index")
             video_ep_df = pd.DataFrame(video_ep_metadata, index=[ep_idx]).convert_dtypes(
                 dtype_backend="pyarrow"
             )
 
             episode_df = episode_df.combine_first(video_ep_df)
-            episode_df.to_parquet(episode_df_path)
+            episode_df.to_parquet(episode_df_path, index=False)
             self._meta.episodes = load_episodes(self._root)
+
+        # Leave a clean slate: the next episode save must not mistake the
+        # anchor for a fully saved episode. With latest_episode unset, the
+        # metadata writer re-anchors on the (now complete) on-disk episodes.
+        self._meta.latest_episode = None
 
     def _save_episode_data(self, episode_buffer: dict) -> dict:
         """Save episode data to a parquet file."""
@@ -524,11 +563,15 @@ class DatasetWriter:
         ):
             chunk_idx, file_idx = 0, 0
             if self._meta.episodes is not None and len(self._meta.episodes) > 0:
-                old_chunk_idx = self._meta.episodes[-1][f"videos/{video_key}/chunk_index"]
-                old_file_idx = self._meta.episodes[-1][f"videos/{video_key}/file_index"]
-                chunk_idx, file_idx = update_chunk_file_indices(
-                    old_chunk_idx, old_file_idx, self._meta.chunks_size
-                )
+                old_chunk_idx = self._meta.episodes[-1].get(f"videos/{video_key}/chunk_index")
+                old_file_idx = self._meta.episodes[-1].get(f"videos/{video_key}/file_index")
+                # The last episode row may predate its video encoding (batched
+                # encoding fills the video columns in later): null indices mean
+                # no video file exists yet, so start at chunk 0 / file 0.
+                if old_chunk_idx is not None and old_file_idx is not None:
+                    chunk_idx, file_idx = update_chunk_file_indices(
+                        old_chunk_idx, old_file_idx, self._meta.chunks_size
+                    )
             latest_duration_in_s = 0.0
             new_path = self._root / self._meta.video_path.format(
                 video_key=video_key, chunk_index=chunk_idx, file_index=file_idx

--- a/src/lerobot/datasets/dataset_writer.py
+++ b/src/lerobot/datasets/dataset_writer.py
@@ -23,11 +23,12 @@ import logging
 import shutil
 import tempfile
 from pathlib import Path
+from typing import Any
 
 import datasets
 import numpy as np
-import pandas as pd
 import PIL.Image
+import pyarrow as pa
 import pyarrow.parquet as pq
 import torch
 
@@ -96,6 +97,30 @@ def _encode_video_worker(
     )
     shutil.rmtree(img_dir)
     return temp_path
+
+
+def _attach_video_metadata(path: Path, rows: dict[int, dict[str, Any]]) -> None:
+    """Write video metadata columns into an episodes parquet, matching rows by
+    episode_index. Only existing rows are touched: an episode missing from the
+    file is a bookkeeping error and must fail loudly rather than be appended as
+    a row without an episode_index.
+    """
+    table = pq.read_table(path)
+    position = {ep: i for i, ep in enumerate(table["episode_index"].to_pylist())}
+    missing = sorted(set(rows) - set(position))
+    if missing:
+        raise RuntimeError(f"episodes {missing} are not in {path}; cannot attach their video metadata")
+    for col in sorted({col for values in rows.values() for col in values}):
+        values = table[col].to_pylist() if col in table.column_names else [None] * table.num_rows
+        for ep, ep_values in rows.items():
+            values[position[ep]] = ep_values[col]
+        dtype = pa.int64() if col.endswith(("chunk_index", "file_index")) else pa.float64()
+        array = pa.array(values, type=dtype)
+        if col in table.column_names:
+            table = table.set_column(table.column_names.index(col), col, array)
+        else:
+            table = table.append_column(col, array)
+    pq.write_table(table.replace_schema_metadata(None), path)
 
 
 class DatasetWriter:
@@ -409,17 +434,6 @@ class DatasetWriter:
         # disk.
         self._meta.flush()
 
-        chunk_idx = self._meta.episodes[start_episode]["data/chunk_index"]
-        file_idx = self._meta.episodes[start_episode]["data/file_index"]
-        episode_df_path = self._root / DEFAULT_EPISODES_PATH.format(
-            chunk_index=chunk_idx, file_index=file_idx
-        )
-        episode_df = pd.read_parquet(episode_df_path, dtype_backend="pyarrow")
-        # Index by episode so the video-metadata merge below aligns on the
-        # global episode index; positional alignment silently corrupts any
-        # episodes file that does not start at episode 0 (resumed datasets).
-        episode_df = episode_df.set_index("episode_index", drop=False).rename_axis(None)
-
         # Video packing appends each episode onto the previous one's video
         # file, so track where the last encoded episode ended. The anchor is
         # the episode just before this batch (None when the dataset has no
@@ -436,23 +450,19 @@ class DatasetWriter:
                     for field in ("chunk_index", "file_index", "to_timestamp")
                 }
 
+        # Video metadata per episodes parquet file, attached after encoding.
+        updates: dict[Path, dict[int, dict[str, Any]]] = {}
         for ep_idx in range(start_episode, end_episode):
             logger.info(f"Encoding videos for episode {ep_idx}")
-
-            if (
-                self._meta.episodes[ep_idx]["data/chunk_index"] != chunk_idx
-                or self._meta.episodes[ep_idx]["data/file_index"] != file_idx
-            ):
-                episode_df.to_parquet(episode_df_path, index=False)
-                self._meta.episodes = load_episodes(self._root)
-
-                chunk_idx = self._meta.episodes[ep_idx]["data/chunk_index"]
-                file_idx = self._meta.episodes[ep_idx]["data/file_index"]
-                episode_df_path = self._root / DEFAULT_EPISODES_PATH.format(
-                    chunk_index=chunk_idx, file_index=file_idx
-                )
-                episode_df = pd.read_parquet(episode_df_path, dtype_backend="pyarrow")
-                episode_df = episode_df.set_index("episode_index", drop=False).rename_axis(None)
+            ep_row = self._meta.episodes[ep_idx]
+            # The episodes parquet holding this row is addressed by the
+            # *metadata* file indices. The data file indices are a different
+            # sequence (the two writers roll over independently), even though
+            # both start at chunk 0 / file 0.
+            episode_df_path = self._root / DEFAULT_EPISODES_PATH.format(
+                chunk_index=ep_row["meta/episodes/chunk_index"],
+                file_index=ep_row["meta/episodes/file_index"],
+            )
 
             self._meta.latest_episode = video_anchor
             video_ep_metadata = {}
@@ -464,13 +474,11 @@ class DatasetWriter:
                 for field in ("chunk_index", "file_index", "to_timestamp")
             }
             video_ep_metadata.pop("episode_index")
-            video_ep_df = pd.DataFrame(video_ep_metadata, index=[ep_idx]).convert_dtypes(
-                dtype_backend="pyarrow"
-            )
+            updates.setdefault(episode_df_path, {})[ep_idx] = video_ep_metadata
 
-            episode_df = episode_df.combine_first(video_ep_df)
-            episode_df.to_parquet(episode_df_path, index=False)
-            self._meta.episodes = load_episodes(self._root)
+        for path, rows in updates.items():
+            _attach_video_metadata(path, rows)
+        self._meta.episodes = load_episodes(self._root)
 
         # Leave a clean slate: the next episode save must not mistake the
         # anchor for a fully saved episode. With latest_episode unset, the

--- a/tests/datasets/test_dataset_writer.py
+++ b/tests/datasets/test_dataset_writer.py
@@ -272,6 +272,23 @@ def test_batched_encoding_staging_survives_save(tmp_path):
     assert staging_dir.is_dir() and any(staging_dir.iterdir())
 
 
+def _assert_video_metadata_consistent(dataset: LeRobotDataset) -> None:
+    """Every episode row carries its own index and a video segment exactly as
+    long as the episode. Catches orphan rows (video metadata attached to the
+    wrong file) and misaligned merges, which decoding a single frame may not.
+    """
+    from lerobot.datasets.io_utils import load_episodes
+
+    episodes = load_episodes(dataset.root)
+    assert len(episodes) == dataset.meta.total_episodes
+    for row in episodes:
+        assert row["episode_index"] is not None
+        expected = row["length"] / dataset.meta.fps
+        for key in dataset.meta.video_keys:
+            duration = row[f"videos/{key}/to_timestamp"] - row[f"videos/{key}/from_timestamp"]
+            assert abs(duration - expected) < 1e-3, (row["episode_index"], key, duration, expected)
+
+
 def test_batched_encoding_end_to_end(tmp_path):
     """Recording with ``batch_encoding_size > 1`` produces a loadable dataset.
 
@@ -307,6 +324,7 @@ def test_batched_encoding_end_to_end(tmp_path):
     assert reloaded.meta.total_episodes == 5
     assert reloaded.num_frames == 15
     assert reloaded[reloaded.num_frames - 1][video_key].shape[-2:] == (64, 96)
+    _assert_video_metadata_consistent(reloaded)
 
 
 def test_batched_encoding_on_resumed_dataset(tmp_path):
@@ -356,6 +374,43 @@ def test_batched_encoding_on_resumed_dataset(tmp_path):
     assert reloaded.num_frames == 21
     assert reloaded[0][video_key].shape[-2:] == (64, 96)
     assert reloaded[reloaded.num_frames - 1][video_key].shape[-2:] == (64, 96)
+    _assert_video_metadata_consistent(reloaded)
+
+
+def test_batched_encoding_across_two_resumed_sessions(tmp_path):
+    """Metadata files roll over per batch while data files roll over per
+    session, so their indices diverge after the first batch of a resumed
+    session. The episodes parquet must be addressed by the metadata indices.
+    """
+    video_key = "observation.images.cam"
+    features = {
+        video_key: {
+            "dtype": "video",
+            "shape": (64, 96, 3),
+            "names": ["height", "width", "channels"],
+        },
+        "action": {"dtype": "float32", "shape": (2,), "names": None},
+    }
+    dataset = LeRobotDataset.create(
+        repo_id=DUMMY_REPO_ID, fps=DEFAULT_FPS, features=features, root=tmp_path / "ds", use_videos=True
+    )
+    for _ in range(2):
+        for _ in range(3):
+            dataset.add_frame(_make_frame(features))
+        dataset.save_episode()
+    dataset.finalize()
+
+    for _session in range(2):
+        dataset = LeRobotDataset.resume(repo_id=DUMMY_REPO_ID, root=tmp_path / "ds", batch_encoding_size=2)
+        for _ in range(5):  # two full batches + one remainder per session
+            for _ in range(3):
+                dataset.add_frame(_make_frame(features))
+            dataset.save_episode()
+        dataset.finalize()
+
+    reloaded = LeRobotDataset(DUMMY_REPO_ID, root=tmp_path / "ds")
+    assert reloaded.meta.total_episodes == 12
+    _assert_video_metadata_consistent(reloaded)
 
 
 def test_finalize_is_idempotent(tmp_path):

--- a/tests/datasets/test_dataset_writer.py
+++ b/tests/datasets/test_dataset_writer.py
@@ -272,6 +272,92 @@ def test_batched_encoding_staging_survives_save(tmp_path):
     assert staging_dir.is_dir() and any(staging_dir.iterdir())
 
 
+def test_batched_encoding_end_to_end(tmp_path):
+    """Recording with ``batch_encoding_size > 1`` produces a loadable dataset.
+
+    Regression test: the batch encoder indexed ``meta.episodes`` — a view of
+    the on-disk state that lags the session (episodes live in the metadata
+    buffer until flushed) — so any fresh recording with a batch size above 1
+    crashed on its first batch (#2404, #2509).
+    """
+    video_key = "observation.images.cam"
+    features = {
+        video_key: {
+            "dtype": "video",
+            "shape": (64, 96, 3),
+            "names": ["height", "width", "channels"],
+        },
+        "action": {"dtype": "float32", "shape": (2,), "names": None},
+    }
+    dataset = LeRobotDataset.create(
+        repo_id=DUMMY_REPO_ID,
+        fps=DEFAULT_FPS,
+        features=features,
+        root=tmp_path / "ds",
+        use_videos=True,
+        batch_encoding_size=2,
+    )
+    for _ in range(5):  # two full batches + one remainder encoded at finalize
+        for _ in range(3):
+            dataset.add_frame(_make_frame(features))
+        dataset.save_episode()
+    dataset.finalize()
+
+    reloaded = LeRobotDataset(DUMMY_REPO_ID, root=tmp_path / "ds")
+    assert reloaded.meta.total_episodes == 5
+    assert reloaded.num_frames == 15
+    assert reloaded[reloaded.num_frames - 1][video_key].shape[-2:] == (64, 96)
+
+
+def test_batched_encoding_on_resumed_dataset(tmp_path):
+    """Batch encoding works when appending to an existing dataset via resume().
+
+    Regression test: on a resumed dataset, ``meta.episodes`` only covered the
+    episodes recorded in previous sessions, so the first batch of a resumed
+    session crashed with an IndexError. The video-metadata merge also aligned
+    on the dataframe's positional index, corrupting any episodes file that
+    does not start at episode 0.
+    """
+    video_key = "observation.images.cam"
+    features = {
+        video_key: {
+            "dtype": "video",
+            "shape": (64, 96, 3),
+            "names": ["height", "width", "channels"],
+        },
+        "action": {"dtype": "float32", "shape": (2,), "names": None},
+    }
+    dataset = LeRobotDataset.create(
+        repo_id=DUMMY_REPO_ID,
+        fps=DEFAULT_FPS,
+        features=features,
+        root=tmp_path / "ds",
+        use_videos=True,
+    )
+    for _ in range(3):
+        for _ in range(3):
+            dataset.add_frame(_make_frame(features))
+        dataset.save_episode()
+    dataset.finalize()
+
+    dataset = LeRobotDataset.resume(
+        repo_id=DUMMY_REPO_ID,
+        root=tmp_path / "ds",
+        batch_encoding_size=2,
+    )
+    for _ in range(4):
+        for _ in range(3):
+            dataset.add_frame(_make_frame(features))
+        dataset.save_episode()
+    dataset.finalize()
+
+    reloaded = LeRobotDataset(DUMMY_REPO_ID, root=tmp_path / "ds")
+    assert reloaded.meta.total_episodes == 7
+    assert reloaded.num_frames == 21
+    assert reloaded[0][video_key].shape[-2:] == (64, 96)
+    assert reloaded[reloaded.num_frames - 1][video_key].shape[-2:] == (64, 96)
+
+
 def test_finalize_is_idempotent(tmp_path):
     """Calling finalize() twice does not raise."""
     dataset = LeRobotDataset.create(


### PR DESCRIPTION
## Summary / Motivation

`batch_encoding_size > 1` crashes on the first batch. On a fresh dataset it fails with `TypeError: 'NoneType' object is not subscriptable`, on a resumed one with `IndexError: Invalid key: N is out of bounds for size N`. I hit this while recording a dataset on a Raspberry Pi 5, where the per episode AV1 encode takes minutes, so batching matters.

The root cause is that `_batch_save_episode_video` reads `meta.episodes`, a view of the on-disk state that lags the live session. Two more problems sit behind it: the video packing position is derived from episode rows whose video columns are still empty, and the metadata merge aligns on the positional index of the dataframe, which silently corrupts episodes files on resumed datasets.

## Related issues

- Fixes: #2404
- Related: #2509, #2836 (same root cause), #2379 (fixes the stale view part; this PR also covers the packing position and merge alignment problems reported in the follow-up testing on #2404)

## What changed

- `_batch_save_episode_video` flushes the metadata writer before encoding, so the per episode rows exist on disk and the view can be reloaded. New `LeRobotDatasetMetadata.flush()` method.
- The video packing position is tracked explicitly while the batch runs instead of being read from the last episode row.
- The video metadata merge aligns on `episode_index` instead of the positional index, reads with `dtype_backend="pyarrow"` so index columns stay integers, and writes without the pandas index.
- No breaking changes. The default `batch_encoding_size=1` path is untouched.

## How was this tested (or how to run locally)

- Tests added: `test_batched_encoding_end_to_end` and `test_batched_encoding_on_resumed_dataset` in `tests/datasets/test_dataset_writer.py`. Both fail on main with the exact errors above and pass with this change. `pytest -q tests/datasets -k batch`
- Full `tests/datasets` suite: 667 passed.
- Repro script below runs both cases without hardware, crashes on main and passes on this branch.

<details><summary>repro</summary>

```python
import shutil, sys
import numpy as np
from pathlib import Path
from lerobot.datasets.lerobot_dataset import LeRobotDataset

base = Path(sys.argv[1])
shutil.rmtree(base, ignore_errors=True)

features = {
    "observation.state": {"dtype": "float32", "shape": (2,), "names": ["a", "b"]},
    "observation.images.cam": {"dtype": "video", "shape": (96, 128, 3), "names": ["height", "width", "channels"]},
    "action": {"dtype": "float32", "shape": (2,), "names": ["a", "b"]},
}

def add_eps(ds, n):
    for _ in range(n):
        for _ in range(10):
            ds.add_frame({
                "observation.state": np.zeros(2, dtype=np.float32),
                "observation.images.cam": np.random.randint(0, 255, (96, 128, 3), dtype=np.uint8),
                "action": np.zeros(2, dtype=np.float32),
                "task": "test",
            })
        ds.save_episode(parallel_encoding=False)

# Caso A: create direto com batch=2
ds = LeRobotDataset.create(repo_id="test/batch_create", fps=5, features=features,
                           root=base/"create", use_videos=True,
                           image_writer_threads=2, batch_encoding_size=2)
add_eps(ds, 5)
ds.finalize()
check = LeRobotDataset("test/batch_create", root=base/"create")
assert check.meta.total_episodes == 5, check.meta.total_episodes
_ = check[len(check) - 1]
print("CASO A OK: create+batch=2, 5 eps, decode ok", flush=True)

# Caso B: create batch=1, depois resume com batch=2
ds = LeRobotDataset.create(repo_id="test/batch_resume", fps=5, features=features,
                           root=base/"resume", use_videos=True, image_writer_threads=2)
add_eps(ds, 3)
ds.finalize()
ds = LeRobotDataset.resume(repo_id="test/batch_resume", root=base/"resume",
                           image_writer_threads=2, batch_encoding_size=2)
add_eps(ds, 4)
ds.finalize()
check = LeRobotDataset("test/batch_resume", root=base/"resume")
assert check.meta.total_episodes == 7, check.meta.total_episodes
_ = check[len(check) - 1]
first = check[0]
print("CASO B OK: resume+batch=2, 7 eps, decode ok", flush=True)
print("PASS", flush=True)
```

</details>

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [ ] Documentation updated (not applicable, no user facing API change)
- [ ] CI is green
- [x] Community Review: I reviewed #4070 (hardware validated review of the Robstride bus)

## Reviewer notes

The repro in the details block is the quickest way to check both failure modes on main. The behavior change is confined to the batched path, the default `batch_encoding_size=1` flow does not go through any of the modified code.