### PR TITLE
feat(dataset): add distributed dataset read and write

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -37,6 +37,8 @@
 - sections:
   - local: lerobot-dataset-v3
     title: Using LeRobotDataset
+  - local: distributed_dataset
+    title: Distributed Datasets
   - local: porting_datasets_v3
     title: Porting Large Datasets
   - local: using_dataset_tools

--- a/docs/source/distributed_dataset.mdx
+++ b/docs/source/distributed_dataset.mdx
@@ -1,0 +1,349 @@
+# Distributed Datasets
+
+LeRobot Dataset v3.0 supports distributed **reading** and controlled distributed **writing**.
+
+## Supported Modes
+
+- Map-style multi-GPU training is already sharded by Accelerate after `accelerator.prepare()`.
+- `StreamingLeRobotDataset` assigns Hugging Face source shards to a unique combination of distributed rank and PyTorch `DataLoader` worker.
+- Distributed writes support a new empty dataset, one driver, and one or more workers that share the target storage.
+
+Distributed writes do not support concurrent append to an existing dataset, two drivers, or mixing `save_episode()` with distributed workers.
+
+## Distributed Writes
+
+The driver allocates every episode and output file before any worker writes data. A worker owns exactly one `DistributedEpisodeSpec`, writes its own Parquet and MP4 files, and returns a result. Only the driver publishes `meta/`.
+
+```python
+from lerobot.datasets.distributed import DistributedWritePlan
+from lerobot.datasets.lerobot_dataset import LeRobotDataset
+
+driver = LeRobotDataset.create(
+    repo_id="my-org/assembled-dataset",
+    fps=30,
+    features=features,
+    root="/shared/assembled-dataset",
+)
+
+plan = DistributedWritePlan.from_episode_lengths(
+    episode_lengths=[len(frames) for frames in all_episodes],
+    episode_tasks=[[frame["task"] for frame in frames] for frames in all_episodes],
+    chunks_size=driver.meta.chunks_size,
+    video_keys=list(driver.meta.video_keys),
+)
+
+def write_episode(spec, frames):
+    worker = LeRobotDataset.open_distributed_writer(
+        repo_id="my-org/assembled-dataset",
+        root="/shared/assembled-dataset",
+    )
+    worker.start_distributed_episode(spec)
+    for frame in frames:
+        worker.add_frame(frame)
+    result = worker.save_distributed_episode(spec)
+    worker.finalize()
+    return result
+
+results = [
+    write_episode(spec, frames)
+    for spec, frames in zip(plan.episodes, all_episodes, strict=True)
+]
+driver.commit_distributed_results(plan, results)
+driver.finalize()
+```
+
+`start_distributed_episode(spec)` is required before the first `add_frame()`. It assigns the worker's temporary camera directory to the planned episode, preventing video-frame staging collisions.
+
+Each distributed episode receives a unique data file and, for each video feature, a unique MP4 file. This avoids distributed file locks and makes an individual failed worker retryable.
+
+## Multiprocessing and Ray
+
+The scheduling layer only needs to pass a spec and its frames to each worker:
+
+```python
+from multiprocessing import get_context
+
+with get_context("spawn").Pool(processes=4) as pool:
+    results = pool.starmap(
+        write_episode,
+        zip(plan.episodes, all_episodes, strict=True),
+    )
+
+driver.commit_distributed_results(plan, results)
+```
+
+Ray can use the same protocol:
+
+```python
+import ray
+
+@ray.remote
+def write_episode_remote(spec, frames):
+    return write_episode(spec, frames)
+
+results = ray.get(
+    [
+        write_episode_remote.remote(spec, frames)
+        for spec, frames in zip(plan.episodes, all_episodes, strict=True)
+    ]
+)
+driver.commit_distributed_results(plan, results)
+```
+
+LeRobot does not import or require Ray; Ray is only one possible scheduler.
+
+### Complete Ray Write Example
+
+The following script creates a small dataset using two or more Ray workers. The
+driver creates the empty dataset and the plan, workers write only their assigned
+episodes, and the driver publishes the metadata after every worker succeeds.
+
+All Ray workers must be able to read and write the same `ROOT` directory. In a
+Kubernetes deployment, mount the same read-write-many PVC at that path in the
+driver and every worker pod.
+
+```python
+# distributed_write_ray.py
+from pathlib import Path
+
+import numpy as np
+import ray
+
+from lerobot.datasets.distributed import DistributedWritePlan
+from lerobot.datasets.lerobot_dataset import LeRobotDataset
+
+REPO_ID = "my-org/distributed-demo"
+ROOT = Path("/shared/lerobot-demo")
+
+FEATURES = {
+    "observation.state": {"dtype": "float32", "shape": (2,), "names": None},
+    "action": {"dtype": "float32", "shape": (2,), "names": None},
+}
+
+# Replace this with frames from collection or conversion jobs. Every frame must
+# contain the features declared above and a string-valued "task".
+EPISODES = [
+    [
+        {
+            "observation.state": np.array([frame_index, 1], dtype=np.float32),
+            "action": np.array([frame_index, 2], dtype=np.float32),
+            "task": "pick",
+        }
+        for frame_index in range(3)
+    ],
+    [
+        {
+            "observation.state": np.array([frame_index, 3], dtype=np.float32),
+            "action": np.array([frame_index, 4], dtype=np.float32),
+            "task": "place",
+        }
+        for frame_index in range(2)
+    ],
+]
+
+
+@ray.remote(num_cpus=1)
+def write_one_episode(spec, frames, session):
+    worker = LeRobotDataset.open_distributed_writer(REPO_ID, root=ROOT, session=session)
+    try:
+        # Required before add_frame(): it gives this worker a unique staging
+        # directory for the episode's images and videos.
+        worker.start_distributed_episode(spec)
+        for frame in frames:
+            worker.add_frame(frame)
+
+        # This writes only the files allocated by spec. It does not update meta/.
+        return worker.save_distributed_episode(spec)
+    finally:
+        worker.finalize()
+
+
+def main():
+    ray.init(address="auto")
+
+    # Only the driver creates the dataset. Distributed writes require it to be
+    # a newly created, empty dataset.
+    driver = LeRobotDataset.create(
+        REPO_ID,
+        root=ROOT,
+        fps=30,
+        features=FEATURES,
+        use_videos=False,
+    )
+
+    # Allocate global frame indexes, task indexes, and unique chunk/file paths
+    # before starting any worker.
+    plan = DistributedWritePlan.from_episode_lengths(
+        episode_lengths=[len(episode) for episode in EPISODES],
+        episode_tasks=[
+            [frame["task"] for frame in episode]
+            for episode in EPISODES
+        ],
+        chunks_size=driver.meta.chunks_size,
+        video_keys=list(driver.meta.video_keys),
+    )
+    session = driver.create_distributed_write_session(plan)
+
+    ray.get(
+        [
+            write_one_episode.remote(spec, frames, session)
+            for spec, frames in zip(plan.episodes, EPISODES, strict=True)
+        ]
+    )
+
+    # Only the driver commits: it validates all returned artifacts and atomically
+    # makes the global meta/ directory visible.
+    driver.commit_distributed_results(session.plan, session.load_results())
+    driver.finalize()
+
+
+if __name__ == "__main__":
+    main()
+```
+
+Start Ray first, then run the script in the driver environment:
+
+```bash
+ray start --head
+python distributed_write_ray.py
+```
+
+For a remote driver, use `ray.init(address="auto")` and submit the same script
+from a Ray Job or run it in the head pod. When the dataset includes video
+features, retain `video_keys=list(driver.meta.video_keys)` in the plan. Each
+worker then writes one independent MP4 for each video feature.
+
+## Failure Recovery
+
+`DistributedWriteSession` persists the plan and one atomic success record per
+worker below `<dataset-root>/.distributed-write-session/`. It does not retry
+workers itself. Instead, it lets a driver, Ray Job, or external orchestrator
+resume an interrupted run without repeating verified episodes.
+
+On the first run, create the session before dispatching any workers. Pass it to
+each worker writer so `save_distributed_episode()` records a result only after
+the worker has finished its planned artifacts:
+
+```python
+session = driver.create_distributed_write_session(plan)
+
+worker = LeRobotDataset.open_distributed_writer(
+    REPO_ID,
+    root=ROOT,
+    session=session,
+)
+```
+
+After a driver, worker, or cluster interruption, load the session from the same
+shared root. Only dispatch the returned `pending_specs()`; completed specs with
+a valid result record and valid artifacts are omitted:
+
+```python
+session = LeRobotDataset.resume_distributed_write_session(ROOT)
+
+# Do not automatically delete files. Call this explicit recovery operation if
+# an interrupted worker left an unrecorded, missing, or corrupt planned output.
+session.cleanup_orphaned_artifacts()
+
+for spec in session.pending_specs():
+    submit_to_your_scheduler(spec, session=session)
+
+# When no spec remains pending, load both old and newly persisted results.
+driver.commit_distributed_results(session.plan, session.load_results())
+driver.finalize()
+```
+
+`cleanup_orphaned_artifacts()` only removes output paths allocated to specs that
+do not have a valid persistent success record. It preserves artifacts referenced
+by a record whose data Parquet, frame range, episode index, and video outputs
+all validate. This makes an explicit retry safe after a process is killed
+between writing a file and recording success.
+
+Do not call `commit_distributed_results()` until the session has one valid
+result for every plan entry. A rejected commit leaves the existing public
+`meta/` directory unchanged. Always retry with the original
+`DistributedEpisodeSpec`; do not create a replacement plan.
+
+## Storage Requirements
+
+All workers and the driver need access to the same dataset root. This can be a shared filesystem or a shared object-store mount with atomic directory rename semantics for the final metadata publication.
+
+Do not enable batch video encoding or streaming video encoding for distributed workers. A distributed worker writes one complete planned episode at a time.
+
+## Streaming Reads
+
+For streaming training, LeRobot computes a global consumer id:
+
+```text
+consumer_id = rank * dataloader_num_workers + dataloader_worker_id
+consumer_count = world_size * dataloader_num_workers
+```
+
+A consumer reads only source shards where:
+
+```text
+source_shard_index % consumer_count == consumer_id
+```
+
+This prevents duplicated streamed samples across ranks and DataLoader workers. Consumers with no assigned source shard finish normally.
+
+### `torchrun` Streaming Read Example
+
+`StreamingLeRobotDataset` discovers the initialized PyTorch distributed rank and
+the current `DataLoader` worker automatically. Application code should create
+the dataset normally; it must not manually filter shards by rank.
+
+```python
+# distributed_stream_read.py
+import torch
+import torch.distributed as dist
+from torch.utils.data import DataLoader
+
+from lerobot.datasets.streaming_dataset import StreamingLeRobotDataset
+
+REPO_ID = "my-org/distributed-demo"
+ROOT = "/shared/lerobot-demo"
+
+
+def main():
+    dist.init_process_group(backend="nccl" if torch.cuda.is_available() else "gloo")
+    rank = dist.get_rank()
+
+    dataset = StreamingLeRobotDataset(
+        REPO_ID,
+        root=ROOT,
+        max_num_shards=32,
+        buffer_size=256,
+        shuffle=True,
+    )
+    dataloader = DataLoader(
+        dataset,
+        batch_size=32,
+        num_workers=4,
+        persistent_workers=True,
+    )
+
+    try:
+        for batch in dataloader:
+            # Replace this with model forward/backward/optimizer work. Each rank
+            # receives only its own streaming source shards.
+            print(f"rank={rank}, frame_indexes={batch['index'].tolist()}")
+            break
+    finally:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()
+```
+
+Launch two processes on one node:
+
+```bash
+torchrun --standalone --nproc-per-node=2 distributed_stream_read.py
+```
+
+For multi-node training, use the regular `torchrun --nnodes`, `--node-rank`,
+and rendezvous options. With two ranks and four `DataLoader` workers per rank,
+LeRobot creates eight consumers and assigns every source shard to exactly one
+of them.

--- a/docs/source/distributed_dataset.mdx
+++ b/docs/source/distributed_dataset.mdx
@@ -1,0 +1,124 @@
+# Distributed Datasets
+
+LeRobot Dataset v3.0 supports distributed **reading** and controlled distributed **writing**.
+
+## Supported Modes
+
+- Map-style multi-GPU training is already sharded by Accelerate after `accelerator.prepare()`.
+- `StreamingLeRobotDataset` assigns Hugging Face source shards to a unique combination of distributed rank and PyTorch `DataLoader` worker.
+- Distributed writes support a new empty dataset, one driver, and one or more workers that share the target storage.
+
+Distributed writes do not support concurrent append to an existing dataset, two drivers, or mixing `save_episode()` with distributed workers.
+
+## Distributed Writes
+
+The driver allocates every episode and output file before any worker writes data. A worker owns exactly one `DistributedEpisodeSpec`, writes its own Parquet and MP4 files, and returns a result. Only the driver publishes `meta/`.
+
+```python
+from lerobot.datasets.distributed import DistributedWritePlan
+from lerobot.datasets.lerobot_dataset import LeRobotDataset
+
+driver = LeRobotDataset.create(
+    repo_id="my-org/assembled-dataset",
+    fps=30,
+    features=features,
+    root="/shared/assembled-dataset",
+)
+
+plan = DistributedWritePlan.from_episode_lengths(
+    episode_lengths=[len(frames) for frames in all_episodes],
+    episode_tasks=[[frame["task"] for frame in frames] for frames in all_episodes],
+    chunks_size=driver.meta.chunks_size,
+    video_keys=list(driver.meta.video_keys),
+)
+
+def write_episode(spec, frames):
+    worker = LeRobotDataset.open_distributed_writer(
+        repo_id="my-org/assembled-dataset",
+        root="/shared/assembled-dataset",
+    )
+    worker.start_distributed_episode(spec)
+    for frame in frames:
+        worker.add_frame(frame)
+    result = worker.save_distributed_episode(spec)
+    worker.finalize()
+    return result
+
+results = [
+    write_episode(spec, frames)
+    for spec, frames in zip(plan.episodes, all_episodes, strict=True)
+]
+driver.commit_distributed_results(plan, results)
+driver.finalize()
+```
+
+`start_distributed_episode(spec)` is required before the first `add_frame()`. It assigns the worker's temporary camera directory to the planned episode, preventing video-frame staging collisions.
+
+Each distributed episode receives a unique data file and, for each video feature, a unique MP4 file. This avoids distributed file locks and makes an individual failed worker retryable.
+
+## Multiprocessing and Ray
+
+The scheduling layer only needs to pass a spec and its frames to each worker:
+
+```python
+from multiprocessing import get_context
+
+with get_context("spawn").Pool(processes=4) as pool:
+    results = pool.starmap(
+        write_episode,
+        zip(plan.episodes, all_episodes, strict=True),
+    )
+
+driver.commit_distributed_results(plan, results)
+```
+
+Ray can use the same protocol:
+
+```python
+import ray
+
+@ray.remote
+def write_episode_remote(spec, frames):
+    return write_episode(spec, frames)
+
+results = ray.get(
+    [
+        write_episode_remote.remote(spec, frames)
+        for spec, frames in zip(plan.episodes, all_episodes, strict=True)
+    ]
+)
+driver.commit_distributed_results(plan, results)
+```
+
+LeRobot does not import or require Ray; Ray is only one possible scheduler.
+
+## Failure Recovery
+
+- Do not call `commit_distributed_results()` until the driver has one result for every plan entry.
+- The driver validates the result count, episode/frame ranges, task sequence, artifact paths, and Parquet contents before publishing metadata.
+- A rejected commit leaves the existing public `meta/` directory unchanged.
+- Retry a failed worker using the same `DistributedEpisodeSpec`; do not create a replacement spec.
+- Remove unreferenced worker files only after deciding not to retry the plan.
+
+## Storage Requirements
+
+All workers and the driver need access to the same dataset root. This can be a shared filesystem or a shared object-store mount with atomic directory rename semantics for the final metadata publication.
+
+Do not enable batch video encoding or streaming video encoding for distributed workers. A distributed worker writes one complete planned episode at a time.
+
+## Streaming Reads
+
+For streaming training, LeRobot computes a global consumer id:
+
+```text
+consumer_id = rank * dataloader_num_workers + dataloader_worker_id
+consumer_count = world_size * dataloader_num_workers
+```
+
+A consumer reads only source shards where:
+
+```text
+source_shard_index % consumer_count == consumer_id
+```
+
+This prevents duplicated streamed samples across ranks and DataLoader workers. Consumers with no assigned source shard finish normally.

--- a/src/lerobot/datasets/__init__.py
+++ b/src/lerobot/datasets/__init__.py
@@ -35,6 +35,12 @@ from .dataset_tools import (
     remove_feature,
     split_dataset,
 )
+from .distributed import (
+    DistributedEpisodeResult,
+    DistributedEpisodeSpec,
+    DistributedWritePlan,
+    DistributedWriteSession,
+)
 from .factory import make_dataset, make_train_eval_datasets, resolve_delta_timestamps
 from .image_writer import safe_stop_image_writer
 from .io_utils import load_episodes, write_stats
@@ -63,6 +69,10 @@ __all__ = [
     "CODEBASE_VERSION",
     "DEFAULT_EPISODES_PATH",
     "DEFAULT_QUANTILES",
+    "DistributedEpisodeResult",
+    "DistributedEpisodeSpec",
+    "DistributedWritePlan",
+    "DistributedWriteSession",
     "EVENT_ONLY_STYLES",
     "EpisodeAwareSampler",
     "LANGUAGE_EVENTS",

--- a/src/lerobot/datasets/__init__.py
+++ b/src/lerobot/datasets/__init__.py
@@ -23,6 +23,7 @@ require_package("av", extra="dataset")
 from .aggregate import aggregate_datasets
 from .compute_stats import DEFAULT_QUANTILES, aggregate_stats, get_feature_stats
 from .dataset_metadata import CODEBASE_VERSION, LeRobotDatasetMetadata
+from .distributed import DistributedEpisodeResult, DistributedEpisodeSpec, DistributedWritePlan
 from .dataset_tools import (
     add_features,
     convert_image_to_video_dataset,
@@ -63,6 +64,9 @@ __all__ = [
     "CODEBASE_VERSION",
     "DEFAULT_EPISODES_PATH",
     "DEFAULT_QUANTILES",
+    "DistributedEpisodeResult",
+    "DistributedEpisodeSpec",
+    "DistributedWritePlan",
     "EVENT_ONLY_STYLES",
     "EpisodeAwareSampler",
     "LANGUAGE_EVENTS",

--- a/src/lerobot/datasets/dataset_writer.py
+++ b/src/lerobot/datasets/dataset_writer.py
@@ -42,6 +42,7 @@ from lerobot.configs import (
 
 from .compute_stats import compute_episode_stats
 from .dataset_metadata import LeRobotDatasetMetadata
+from .distributed import DistributedEpisodeResult, DistributedEpisodeSpec
 from .feature_utils import (
     get_hf_features_from_features,
     validate_episode_buffer,
@@ -65,6 +66,7 @@ from .video_utils import (
     concatenate_video_files,
     encode_video_frames,
     get_video_duration_in_s,
+    get_video_info,
 )
 
 logger = logging.getLogger(__name__)
@@ -152,6 +154,7 @@ class DatasetWriter:
         self._episodes_since_last_encoding: int = 0
         self._recorded_frames: int = initial_frames
         self._finalized = False
+        self._distributed_episode_started = False
 
     def _create_episode_buffer(self, episode_index: int | None = None) -> dict:
         current_ep_idx = self._meta.total_episodes if episode_index is None else episode_index
@@ -392,6 +395,144 @@ class DatasetWriter:
             if len(self._meta.image_keys) > 0:
                 self._delete_camera_frame_dirs(self._meta.image_keys)
             self.episode_buffer = self._create_episode_buffer()
+
+    def save_distributed_episode(
+        self, spec: DistributedEpisodeSpec, parallel_encoding: bool = True
+    ) -> DistributedEpisodeResult:
+        """Write one preallocated episode without updating global metadata.
+
+        Every distributed specification owns a unique data file, so this
+        method never appends to a shared Parquet writer or mutates
+        ``LeRobotDatasetMetadata``.
+        """
+        del parallel_encoding
+        episode_buffer = self.episode_buffer
+        if not self._distributed_episode_started:
+            raise RuntimeError(
+                "Call start_distributed_episode() before add_frame() and save_distributed_episode()."
+            )
+        if self._get_episode_buffer_index() != spec.episode_index:
+            raise ValueError(
+                f"Distributed worker buffer is assigned to episode {self._get_episode_buffer_index()}, "
+                f"but received specification for episode {spec.episode_index}. "
+                "Call start_distributed_episode() before add_frame()."
+            )
+        if episode_buffer["size"] != spec.length:
+            raise ValueError(
+                f"Distributed episode {spec.episode_index} length {episode_buffer['size']} "
+                f"does not match planned length {spec.length}."
+            )
+        if tuple(episode_buffer["task"]) != spec.tasks:
+            raise ValueError(
+                f"Distributed episode {spec.episode_index} task sequence does not match its plan."
+            )
+
+        episode_length = episode_buffer.pop("size")
+        episode_buffer.pop("task")
+        episode_buffer["index"] = np.arange(spec.dataset_from_index, spec.dataset_to_index, dtype=np.int64)
+        episode_buffer["episode_index"] = np.full((episode_length,), spec.episode_index, dtype=np.int64)
+        episode_buffer["task_index"] = np.asarray(spec.task_indices, dtype=np.int64)
+
+        for key, feature in self._meta.features.items():
+            if key in {"index", "episode_index", "task_index"} or feature["dtype"] in {"image", "video"}:
+                continue
+            values = np.stack(episode_buffer[key])
+            if tuple(feature["shape"]) == (1,) and feature["dtype"] != "string":
+                values = values.reshape(episode_length)
+            episode_buffer[key] = values
+
+        self._wait_image_writer()
+        stats = compute_episode_stats(episode_buffer, self._meta.features)
+        hf_features = get_hf_features_from_features(self._meta.features)
+        episode_dataset = datasets.Dataset.from_dict(
+            {key: episode_buffer[key] for key in hf_features},
+            features=hf_features,
+            split="train",
+        )
+        episode_dataset = embed_images(episode_dataset)
+        data_path = self._root / self._meta.data_path.format(
+            chunk_index=spec.data_chunk_index,
+            file_index=spec.data_file_index,
+        )
+        data_path.parent.mkdir(parents=True, exist_ok=True)
+        if data_path.exists():
+            raise FileExistsError(f"Distributed episode output already exists: {data_path}")
+
+        video_metadata: dict[str, object] = {}
+        video_info: dict[str, dict] = {}
+        video_paths: list[Path] = []
+        temporary_video_paths: list[Path] = []
+        try:
+            pq.write_table(
+                episode_dataset.with_format("arrow")[:],
+                data_path,
+                compression="snappy",
+                use_dictionary=True,
+            )
+            for video_key in self._meta.video_keys:
+                temporary_video_path = self._encode_temporary_episode_video(video_key, spec.episode_index)
+                temporary_video_paths.append(temporary_video_path)
+                video_path = self._root / self._meta.video_path.format(
+                    video_key=video_key,
+                    chunk_index=spec.data_chunk_index,
+                    file_index=spec.data_file_index,
+                )
+                video_path.parent.mkdir(parents=True, exist_ok=True)
+                if video_path.exists():
+                    raise FileExistsError(f"Distributed episode video output already exists: {video_path}")
+                video_duration_s = get_video_duration_in_s(temporary_video_path)
+                shutil.move(str(temporary_video_path), str(video_path))
+                temporary_video_paths.remove(temporary_video_path)
+                video_paths.append(video_path)
+                shutil.rmtree(temporary_video_path.parent, ignore_errors=True)
+                video_info[video_key] = get_video_info(
+                    video_path,
+                    video_encoder=self._depth_encoder
+                    if video_key in self._meta.depth_keys
+                    else self._rgb_encoder,
+                )
+                video_metadata.update(
+                    {
+                        f"videos/{video_key}/chunk_index": spec.data_chunk_index,
+                        f"videos/{video_key}/file_index": spec.data_file_index,
+                        f"videos/{video_key}/from_timestamp": 0.0,
+                        f"videos/{video_key}/to_timestamp": video_duration_s,
+                    }
+                )
+        except Exception:
+            data_path.unlink(missing_ok=True)
+            for video_path in video_paths:
+                video_path.unlink(missing_ok=True)
+            for temporary_video_path in temporary_video_paths:
+                temporary_video_path.unlink(missing_ok=True)
+                shutil.rmtree(temporary_video_path.parent, ignore_errors=True)
+            self._delete_camera_frame_dirs(self._meta.camera_keys)
+            self.episode_buffer = self._create_episode_buffer(spec.episode_index)
+            self._distributed_episode_started = False
+            raise
+
+        self.episode_buffer = self._create_episode_buffer(spec.episode_index + 1)
+        self._distributed_episode_started = False
+        return DistributedEpisodeResult(
+            episode_index=spec.episode_index,
+            dataset_from_index=spec.dataset_from_index,
+            dataset_to_index=spec.dataset_to_index,
+            tasks=spec.tasks,
+            task_indices=spec.task_indices,
+            data_chunk_index=spec.data_chunk_index,
+            data_file_index=spec.data_file_index,
+            data_path=data_path,
+            video_metadata=video_metadata,
+            video_info=video_info,
+            stats=stats,
+        )
+
+    def start_distributed_episode(self, spec: DistributedEpisodeSpec) -> None:
+        """Assign the next frame buffer and staging paths to one worker-owned episode."""
+        if self.episode_buffer["size"] != 0:
+            raise RuntimeError("Cannot start a distributed episode while the current buffer has frames.")
+        self.episode_buffer = self._create_episode_buffer(spec.episode_index)
+        self._distributed_episode_started = True
 
     def _batch_save_episode_video(self, start_episode: int, end_episode: int | None = None) -> None:
         """Batch save videos for multiple episodes."""

--- a/src/lerobot/datasets/distributed.py
+++ b/src/lerobot/datasets/distributed.py
@@ -1,0 +1,325 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Planning primitives for distributed LeRobot dataset writes."""
+
+from __future__ import annotations
+
+import os
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+import datasets
+import numpy as np
+import pandas as pd
+import pyarrow.parquet as pq
+
+from lerobot.utils.utils import flatten_dict
+
+from .compute_stats import aggregate_stats
+from .io_utils import write_info, write_stats, write_tasks
+from .utils import DEFAULT_EPISODES_PATH, update_chunk_file_indices
+
+
+@dataclass(frozen=True)
+class DistributedEpisodeSpec:
+    """The immutable output allocation for one distributed episode."""
+
+    episode_index: int
+    dataset_from_index: int
+    dataset_to_index: int
+    tasks: tuple[str, ...]
+    task_indices: tuple[int, ...]
+    data_chunk_index: int
+    data_file_index: int
+
+    @property
+    def length(self) -> int:
+        """Number of frames assigned to this episode."""
+        return self.dataset_to_index - self.dataset_from_index
+
+
+@dataclass(frozen=True)
+class DistributedEpisodeResult:
+    """Artifacts and statistics produced by one distributed worker."""
+
+    episode_index: int
+    dataset_from_index: int
+    dataset_to_index: int
+    tasks: tuple[str, ...]
+    task_indices: tuple[int, ...]
+    data_chunk_index: int
+    data_file_index: int
+    data_path: Path
+    video_metadata: dict[str, Any]
+    video_info: dict[str, dict[str, Any]]
+    stats: dict[str, dict[str, Any]]
+
+
+@dataclass(frozen=True)
+class DistributedWritePlan:
+    """A deterministic, driver-created allocation for distributed episode writes."""
+
+    episodes: tuple[DistributedEpisodeSpec, ...]
+    task_to_index: dict[str, int]
+    chunks_size: int
+    video_keys: tuple[str, ...] = ()
+
+    @classmethod
+    def from_episode_lengths(
+        cls,
+        *,
+        episode_lengths: list[int],
+        episode_tasks: list[list[str]],
+        chunks_size: int,
+        video_keys: list[str] | None = None,
+    ) -> DistributedWritePlan:
+        """Allocate contiguous global frame ranges and unique data files per episode."""
+        if not episode_lengths:
+            raise ValueError("A distributed write plan requires at least one episode.")
+        if len(episode_lengths) != len(episode_tasks):
+            raise ValueError("episode_lengths and episode_tasks must have the same length.")
+        if chunks_size <= 0:
+            raise ValueError("chunks_size must be positive.")
+
+        task_to_index: dict[str, int] = {}
+        episodes: list[DistributedEpisodeSpec] = []
+        dataset_from_index = 0
+        chunk_index = 0
+        file_index = 0
+
+        for episode_index, (episode_length, tasks) in enumerate(
+            zip(episode_lengths, episode_tasks, strict=True)
+        ):
+            if episode_length <= 0:
+                raise ValueError(f"Episode {episode_index} length must be positive.")
+            if len(tasks) != episode_length:
+                raise ValueError(
+                    f"Episode {episode_index} task sequence length {len(tasks)} does not match "
+                    f"episode length {episode_length}."
+                )
+            if not all(isinstance(task, str) and task for task in tasks):
+                raise ValueError(f"Episode {episode_index} tasks must be non-empty strings.")
+
+            for task in tasks:
+                task_to_index.setdefault(task, len(task_to_index))
+
+            dataset_to_index = dataset_from_index + episode_length
+            episodes.append(
+                DistributedEpisodeSpec(
+                    episode_index=episode_index,
+                    dataset_from_index=dataset_from_index,
+                    dataset_to_index=dataset_to_index,
+                    tasks=tuple(tasks),
+                    task_indices=tuple(task_to_index[task] for task in tasks),
+                    data_chunk_index=chunk_index,
+                    data_file_index=file_index,
+                )
+            )
+            dataset_from_index = dataset_to_index
+            chunk_index, file_index = update_chunk_file_indices(chunk_index, file_index, chunks_size)
+
+        return cls(
+            episodes=tuple(episodes),
+            task_to_index=task_to_index,
+            chunks_size=chunks_size,
+            video_keys=tuple(video_keys or ()),
+        )
+
+
+def validate_distributed_results(
+    root: Path,
+    data_path_template: str,
+    video_path_template: str | None,
+    plan: DistributedWritePlan,
+    results: list[DistributedEpisodeResult],
+) -> list[DistributedEpisodeResult]:
+    """Validate every worker result before any global metadata is written."""
+    if len(results) != len(plan.episodes):
+        raise ValueError(
+            f"Distributed plan has {len(plan.episodes)} episodes but received {len(results)} results."
+        )
+
+    result_by_episode: dict[int, DistributedEpisodeResult] = {}
+    for result in results:
+        if result.episode_index in result_by_episode:
+            raise ValueError(f"Duplicate distributed result for episode {result.episode_index}.")
+        result_by_episode[result.episode_index] = result
+
+    ordered_results = []
+    for spec in plan.episodes:
+        result = result_by_episode.pop(spec.episode_index, None)
+        if result is None:
+            raise ValueError(f"Missing distributed result for episode {spec.episode_index}.")
+        expected_fields = (
+            ("dataset_from_index", spec.dataset_from_index),
+            ("dataset_to_index", spec.dataset_to_index),
+            ("tasks", spec.tasks),
+            ("task_indices", spec.task_indices),
+            ("data_chunk_index", spec.data_chunk_index),
+            ("data_file_index", spec.data_file_index),
+        )
+        for field, expected in expected_fields:
+            if getattr(result, field) != expected:
+                raise ValueError(
+                    f"Distributed result for episode {spec.episode_index} has unexpected {field}: "
+                    f"{getattr(result, field)!r} != {expected!r}."
+                )
+        if not result.stats:
+            raise ValueError(f"Distributed result for episode {spec.episode_index} has no statistics.")
+
+        expected_path = root / data_path_template.format(
+            chunk_index=spec.data_chunk_index,
+            file_index=spec.data_file_index,
+        )
+        if result.data_path != expected_path:
+            raise ValueError(
+                f"Distributed result for episode {spec.episode_index} wrote unexpected path "
+                f"{result.data_path}; expected {expected_path}."
+            )
+        if not result.data_path.is_file():
+            raise ValueError(f"Distributed artifact is missing: {result.data_path}")
+
+        table = pq.read_table(result.data_path, columns=["index", "episode_index"])
+        expected_indices = list(range(spec.dataset_from_index, spec.dataset_to_index))
+        if table.num_rows != spec.length:
+            raise ValueError(
+                f"Distributed artifact {result.data_path} has {table.num_rows} rows; expected {spec.length}."
+            )
+        if table.column("index").to_pylist() != expected_indices:
+            raise ValueError(f"Distributed artifact {result.data_path} has an unexpected frame index range.")
+        if set(table.column("episode_index").to_pylist()) != {spec.episode_index}:
+            raise ValueError(f"Distributed artifact {result.data_path} has an unexpected episode index.")
+        for video_key in plan.video_keys:
+            if video_path_template is None:
+                raise ValueError(
+                    "Distributed plan includes videos but the dataset has no video path template."
+                )
+            expected_video_path = root / video_path_template.format(
+                video_key=video_key,
+                chunk_index=spec.data_chunk_index,
+                file_index=spec.data_file_index,
+            )
+            required_metadata = {
+                f"videos/{video_key}/chunk_index": spec.data_chunk_index,
+                f"videos/{video_key}/file_index": spec.data_file_index,
+            }
+            for key, expected in required_metadata.items():
+                if result.video_metadata.get(key) != expected:
+                    raise ValueError(
+                        f"Distributed result for episode {spec.episode_index} has unexpected {key}: "
+                        f"{result.video_metadata.get(key)!r} != {expected!r}."
+                    )
+            if not expected_video_path.is_file():
+                raise ValueError(f"Distributed video artifact is missing: {expected_video_path}")
+        ordered_results.append(result)
+
+    if result_by_episode:
+        unknown = sorted(result_by_episode)
+        raise ValueError(f"Results contain unknown distributed episode indexes: {unknown}.")
+    return ordered_results
+
+
+def write_distributed_metadata(
+    staging_root: Path,
+    info: Any,
+    plan: DistributedWritePlan,
+    results: list[DistributedEpisodeResult],
+) -> None:
+    """Write complete global metadata below an unpublished staging root."""
+    tasks = pd.DataFrame(
+        {"task_index": list(plan.task_to_index.values())},
+        index=pd.Index(plan.task_to_index.keys(), name="task"),
+    )
+    rows: list[dict[str, Any]] = []
+    for result in results:
+        flattened_stats = {
+            key: _normalize_metadata_stat_value(value)
+            for key, value in flatten_dict({"stats": result.stats}).items()
+        }
+        row = {
+            "episode_index": result.episode_index,
+            "tasks": list(result.tasks),
+            "length": result.dataset_to_index - result.dataset_from_index,
+            "data/chunk_index": result.data_chunk_index,
+            "data/file_index": result.data_file_index,
+            "dataset_from_index": result.dataset_from_index,
+            "dataset_to_index": result.dataset_to_index,
+            **flattened_stats,
+            **result.video_metadata,
+        }
+        rows.append(row)
+
+    staged_info = info
+    staged_info.total_episodes = len(results)
+    staged_info.total_frames = sum(result.dataset_to_index - result.dataset_from_index for result in results)
+    staged_info.total_tasks = len(tasks)
+    staged_info.splits = {"train": f"0:{len(results)}"}
+    if plan.video_keys:
+        if staged_info.video_path is None:
+            raise ValueError("Distributed plan includes videos but the dataset has no video path template.")
+        first_result = results[0]
+        for video_key in plan.video_keys:
+            if video_key not in first_result.video_info:
+                raise ValueError(
+                    f"Distributed result for episode {first_result.episode_index} has no video info "
+                    f"for {video_key!r}."
+                )
+            staged_info.features[video_key]["info"] = first_result.video_info[video_key]
+
+    write_info(staged_info, staging_root)
+    write_tasks(tasks, staging_root)
+    write_stats(aggregate_stats([result.stats for result in results]), staging_root)
+    for result, row in zip(results, rows, strict=True):
+        path = staging_root / DEFAULT_EPISODES_PATH.format(
+            chunk_index=result.data_chunk_index,
+            file_index=result.data_file_index,
+        )
+        path.parent.mkdir(parents=True, exist_ok=True)
+        datasets.Dataset.from_list([row]).to_parquet(path)
+
+
+def _normalize_metadata_stat_value(value: Any) -> Any:
+    """Keep one stable Arrow dtype per flattened per-episode statistic column."""
+    array = np.asarray(value)
+    if np.issubdtype(array.dtype, np.floating):
+        return array.astype(np.float64).tolist()
+    if np.issubdtype(array.dtype, np.integer):
+        return array.astype(np.int64).tolist()
+    return array.tolist()
+
+
+def publish_distributed_metadata(root: Path, staging_root: Path) -> None:
+    """Atomically publish staged metadata while retaining rollback on failure."""
+    source_meta = staging_root / "meta"
+    destination_meta = root / "meta"
+    backup_meta = root / f".meta-distributed-backup-{uuid4().hex}"
+    backup_restored = False
+    try:
+        os.replace(destination_meta, backup_meta)
+        os.replace(source_meta, destination_meta)
+    except Exception:
+        if backup_meta.exists() and not destination_meta.exists():
+            os.replace(backup_meta, destination_meta)
+            backup_restored = True
+        raise
+    finally:
+        if destination_meta.exists() or backup_restored:
+            shutil.rmtree(backup_meta, ignore_errors=True)

--- a/src/lerobot/datasets/distributed.py
+++ b/src/lerobot/datasets/distributed.py
@@ -1,0 +1,596 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team.
+# All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Planning primitives for distributed LeRobot dataset writes."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+import datasets
+import numpy as np
+import pandas as pd
+import pyarrow.parquet as pq
+
+from lerobot.utils.utils import flatten_dict
+
+from .compute_stats import aggregate_stats
+from .io_utils import cast_stats_to_numpy, write_info, write_stats, write_tasks
+from .utils import (
+    DEFAULT_DATA_PATH,
+    DEFAULT_DEPTH_PATH,
+    DEFAULT_EPISODES_PATH,
+    DEFAULT_IMAGE_PATH,
+    DEFAULT_VIDEO_PATH,
+    serialize_dict,
+    update_chunk_file_indices,
+)
+
+_SESSION_DIRECTORY = ".distributed-write-session"
+_PLAN_FILENAME = "plan.json"
+_RESULTS_DIRECTORY = "results"
+
+
+@dataclass(frozen=True)
+class DistributedEpisodeSpec:
+    """The immutable output allocation for one distributed episode."""
+
+    episode_index: int
+    dataset_from_index: int
+    dataset_to_index: int
+    tasks: tuple[str, ...]
+    task_indices: tuple[int, ...]
+    data_chunk_index: int
+    data_file_index: int
+
+    @property
+    def length(self) -> int:
+        """Number of frames assigned to this episode."""
+        return self.dataset_to_index - self.dataset_from_index
+
+
+@dataclass(frozen=True)
+class DistributedEpisodeResult:
+    """Artifacts and statistics produced by one distributed worker."""
+
+    episode_index: int
+    dataset_from_index: int
+    dataset_to_index: int
+    tasks: tuple[str, ...]
+    task_indices: tuple[int, ...]
+    data_chunk_index: int
+    data_file_index: int
+    data_path: Path
+    video_metadata: dict[str, Any]
+    video_info: dict[str, dict[str, Any]]
+    stats: dict[str, dict[str, Any]]
+
+
+@dataclass(frozen=True)
+class DistributedWritePlan:
+    """A deterministic, driver-created allocation for distributed episode writes."""
+
+    episodes: tuple[DistributedEpisodeSpec, ...]
+    task_to_index: dict[str, int]
+    chunks_size: int
+    video_keys: tuple[str, ...] = ()
+
+    @classmethod
+    def from_episode_lengths(
+        cls,
+        *,
+        episode_lengths: list[int],
+        episode_tasks: list[list[str]],
+        chunks_size: int,
+        video_keys: list[str] | None = None,
+    ) -> DistributedWritePlan:
+        """Allocate contiguous global frame ranges and unique data files per episode."""
+        if not episode_lengths:
+            raise ValueError("A distributed write plan requires at least one episode.")
+        if len(episode_lengths) != len(episode_tasks):
+            raise ValueError("episode_lengths and episode_tasks must have the same length.")
+        if chunks_size <= 0:
+            raise ValueError("chunks_size must be positive.")
+
+        task_to_index: dict[str, int] = {}
+        episodes: list[DistributedEpisodeSpec] = []
+        dataset_from_index = 0
+        chunk_index = 0
+        file_index = 0
+
+        for episode_index, (episode_length, tasks) in enumerate(
+            zip(episode_lengths, episode_tasks, strict=True)
+        ):
+            if episode_length <= 0:
+                raise ValueError(f"Episode {episode_index} length must be positive.")
+            if len(tasks) != episode_length:
+                raise ValueError(
+                    f"Episode {episode_index} task sequence length {len(tasks)} does not match "
+                    f"episode length {episode_length}."
+                )
+            if not all(isinstance(task, str) and task for task in tasks):
+                raise ValueError(f"Episode {episode_index} tasks must be non-empty strings.")
+
+            for task in tasks:
+                task_to_index.setdefault(task, len(task_to_index))
+
+            dataset_to_index = dataset_from_index + episode_length
+            episodes.append(
+                DistributedEpisodeSpec(
+                    episode_index=episode_index,
+                    dataset_from_index=dataset_from_index,
+                    dataset_to_index=dataset_to_index,
+                    tasks=tuple(tasks),
+                    task_indices=tuple(task_to_index[task] for task in tasks),
+                    data_chunk_index=chunk_index,
+                    data_file_index=file_index,
+                )
+            )
+            dataset_from_index = dataset_to_index
+            chunk_index, file_index = update_chunk_file_indices(chunk_index, file_index, chunks_size)
+
+        return cls(
+            episodes=tuple(episodes),
+            task_to_index=task_to_index,
+            chunks_size=chunks_size,
+            video_keys=tuple(video_keys or ()),
+        )
+
+
+class DistributedWriteSession:
+    """Persistent progress ledger for an explicitly resumable distributed write."""
+
+    def __init__(
+        self,
+        root: Path,
+        plan: DistributedWritePlan,
+        *,
+        data_path_template: str,
+        video_path_template: str | None,
+        camera_keys: tuple[str, ...],
+        depth_keys: tuple[str, ...],
+    ):
+        self.root = root
+        self.plan = plan
+        self.data_path_template = data_path_template
+        self.video_path_template = video_path_template
+        self.camera_keys = camera_keys
+        self.depth_keys = depth_keys
+        self.session_root = self.root / _SESSION_DIRECTORY
+        self.results_root = self.session_root / _RESULTS_DIRECTORY
+
+    @classmethod
+    def create(
+        cls,
+        root: str | Path,
+        plan: DistributedWritePlan,
+        *,
+        data_path_template: str = DEFAULT_DATA_PATH,
+        video_path_template: str | None = DEFAULT_VIDEO_PATH,
+        camera_keys: tuple[str, ...] = (),
+        depth_keys: tuple[str, ...] = (),
+    ) -> DistributedWriteSession:
+        session = cls(
+            Path(root),
+            plan,
+            data_path_template=data_path_template,
+            video_path_template=video_path_template,
+            camera_keys=camera_keys,
+            depth_keys=depth_keys,
+        )
+        if session.session_root.exists():
+            raise FileExistsError(
+                f"Distributed write session already exists: {session.session_root}. "
+                "Use DistributedWriteSession.resume() to continue it."
+            )
+        temporary_session_root = session.session_root.with_name(
+            f".{session.session_root.name}.{uuid4().hex}.tmp"
+        )
+        try:
+            temporary_session_root.mkdir(parents=True)
+            (temporary_session_root / _RESULTS_DIRECTORY).mkdir()
+            session._write_json_atomically(temporary_session_root / _PLAN_FILENAME, session._serialize())
+            os.replace(temporary_session_root, session.session_root)
+        finally:
+            shutil.rmtree(temporary_session_root, ignore_errors=True)
+        return session
+
+    @classmethod
+    def resume(cls, root: str | Path) -> DistributedWriteSession:
+        root = Path(root)
+        plan_path = root / _SESSION_DIRECTORY / _PLAN_FILENAME
+        if not plan_path.is_file():
+            raise FileNotFoundError(f"Distributed write session plan is missing: {plan_path}")
+        with plan_path.open(encoding="utf-8") as file:
+            payload = json.load(file)
+        return cls(
+            root,
+            _deserialize_plan(payload["plan"]),
+            data_path_template=payload["data_path_template"],
+            video_path_template=payload["video_path_template"],
+            camera_keys=tuple(payload["camera_keys"]),
+            depth_keys=tuple(payload["depth_keys"]),
+        )
+
+    def result_path(self, episode_index: int) -> Path:
+        return self.results_root / f"episode-{episode_index:06d}.json"
+
+    def pending_specs(self) -> list[DistributedEpisodeSpec]:
+        completed = {result.episode_index for result in self.load_results()}
+        return [spec for spec in self.plan.episodes if spec.episode_index not in completed]
+
+    def record_result(self, result: DistributedEpisodeResult) -> None:
+        spec = _get_plan_spec(self.plan, result.episode_index)
+        _validate_persisted_result(
+            self.root,
+            self.data_path_template,
+            self.video_path_template,
+            self.plan,
+            spec,
+            result,
+        )
+        self._write_json_atomically(self.result_path(result.episode_index), _serialize_result(result))
+
+    def load_results(self) -> list[DistributedEpisodeResult]:
+        results = []
+        for spec in self.plan.episodes:
+            result_path = self.result_path(spec.episode_index)
+            if not result_path.is_file():
+                continue
+            with result_path.open(encoding="utf-8") as file:
+                result = _deserialize_result(json.load(file))
+            _validate_persisted_result(
+                self.root,
+                self.data_path_template,
+                self.video_path_template,
+                self.plan,
+                spec,
+                result,
+            )
+            results.append(result)
+        return results
+
+    def cleanup_orphaned_artifacts(self) -> None:
+        """Remove planned output paths for specs without a durable success record."""
+        for spec in self.plan.episodes:
+            result_path = self.result_path(spec.episode_index)
+            if self._has_valid_result_record(spec, result_path):
+                continue
+            result_path.unlink(missing_ok=True)
+            self._cleanup_spec_artifacts(spec)
+
+    def _has_valid_result_record(self, spec: DistributedEpisodeSpec, result_path: Path) -> bool:
+        if not result_path.is_file():
+            return False
+        try:
+            with result_path.open(encoding="utf-8") as file:
+                result = _deserialize_result(json.load(file))
+            _validate_persisted_result(
+                self.root,
+                self.data_path_template,
+                self.video_path_template,
+                self.plan,
+                spec,
+                result,
+            )
+        except (FileNotFoundError, KeyError, TypeError, ValueError, json.JSONDecodeError):
+            return False
+        return result.data_path.is_file()
+
+    def _cleanup_spec_artifacts(self, spec: DistributedEpisodeSpec) -> None:
+        data_path = self.root / self.data_path_template.format(
+            chunk_index=spec.data_chunk_index,
+            file_index=spec.data_file_index,
+        )
+        data_path.unlink(missing_ok=True)
+        if self.video_path_template is not None:
+            for video_key in self.plan.video_keys:
+                video_path = self.root / self.video_path_template.format(
+                    video_key=video_key,
+                    chunk_index=spec.data_chunk_index,
+                    file_index=spec.data_file_index,
+                )
+                video_path.unlink(missing_ok=True)
+        for camera_key in self.camera_keys:
+            image_path_template = DEFAULT_DEPTH_PATH if camera_key in self.depth_keys else DEFAULT_IMAGE_PATH
+            image_dir = self.root / image_path_template.format(
+                image_key=camera_key,
+                episode_index=spec.episode_index,
+                frame_index=0,
+            )
+            shutil.rmtree(image_dir.parent, ignore_errors=True)
+
+    def _serialize(self) -> dict[str, Any]:
+        return {
+            "plan": _serialize_plan(self.plan),
+            "data_path_template": self.data_path_template,
+            "video_path_template": self.video_path_template,
+            "camera_keys": list(self.camera_keys),
+            "depth_keys": list(self.depth_keys),
+        }
+
+    @staticmethod
+    def _write_json_atomically(path: Path, payload: dict[str, Any]) -> None:
+        temporary_path = path.with_name(f".{path.name}.{uuid4().hex}.tmp")
+        try:
+            with temporary_path.open("x", encoding="utf-8") as file:
+                json.dump(payload, file, sort_keys=True)
+            os.replace(temporary_path, path)
+        finally:
+            temporary_path.unlink(missing_ok=True)
+
+
+def _get_plan_spec(plan: DistributedWritePlan, episode_index: int) -> DistributedEpisodeSpec:
+    for spec in plan.episodes:
+        if spec.episode_index == episode_index:
+            return spec
+    raise ValueError(f"Distributed result references unknown episode {episode_index}.")
+
+
+def _validate_result_matches_spec(spec: DistributedEpisodeSpec, result: DistributedEpisodeResult) -> None:
+    expected_fields = (
+        ("dataset_from_index", spec.dataset_from_index),
+        ("dataset_to_index", spec.dataset_to_index),
+        ("tasks", spec.tasks),
+        ("task_indices", spec.task_indices),
+        ("data_chunk_index", spec.data_chunk_index),
+        ("data_file_index", spec.data_file_index),
+    )
+    for field, expected in expected_fields:
+        if getattr(result, field) != expected:
+            raise ValueError(
+                f"Distributed result for episode {spec.episode_index} has unexpected {field}: "
+                f"{getattr(result, field)!r} != {expected!r}."
+            )
+
+
+def _serialize_plan(plan: DistributedWritePlan) -> dict[str, Any]:
+    return {
+        "episodes": [asdict(spec) for spec in plan.episodes],
+        "task_to_index": plan.task_to_index,
+        "chunks_size": plan.chunks_size,
+        "video_keys": list(plan.video_keys),
+    }
+
+
+def _deserialize_plan(payload: dict[str, Any]) -> DistributedWritePlan:
+    return DistributedWritePlan(
+        episodes=tuple(
+            DistributedEpisodeSpec(
+                **{
+                    **episode,
+                    "tasks": tuple(episode["tasks"]),
+                    "task_indices": tuple(episode["task_indices"]),
+                }
+            )
+            for episode in payload["episodes"]
+        ),
+        task_to_index=payload["task_to_index"],
+        chunks_size=payload["chunks_size"],
+        video_keys=tuple(payload["video_keys"]),
+    )
+
+
+def _serialize_result(result: DistributedEpisodeResult) -> dict[str, Any]:
+    payload = asdict(result)
+    payload["tasks"] = list(result.tasks)
+    payload["task_indices"] = list(result.task_indices)
+    payload["data_path"] = str(result.data_path)
+    payload["stats"] = serialize_dict(result.stats)
+    return payload
+
+
+def _deserialize_result(payload: dict[str, Any]) -> DistributedEpisodeResult:
+    return DistributedEpisodeResult(
+        **{
+            **payload,
+            "tasks": tuple(payload["tasks"]),
+            "task_indices": tuple(payload["task_indices"]),
+            "data_path": Path(payload["data_path"]),
+            "stats": cast_stats_to_numpy(payload["stats"]),
+        }
+    )
+
+
+def validate_distributed_results(
+    root: Path,
+    data_path_template: str,
+    video_path_template: str | None,
+    plan: DistributedWritePlan,
+    results: list[DistributedEpisodeResult],
+) -> list[DistributedEpisodeResult]:
+    """Validate every worker result before any global metadata is written."""
+    if len(results) != len(plan.episodes):
+        raise ValueError(
+            f"Distributed plan has {len(plan.episodes)} episodes but received {len(results)} results."
+        )
+
+    result_by_episode: dict[int, DistributedEpisodeResult] = {}
+    for result in results:
+        if result.episode_index in result_by_episode:
+            raise ValueError(f"Duplicate distributed result for episode {result.episode_index}.")
+        result_by_episode[result.episode_index] = result
+
+    ordered_results = []
+    for spec in plan.episodes:
+        result = result_by_episode.pop(spec.episode_index, None)
+        if result is None:
+            raise ValueError(f"Missing distributed result for episode {spec.episode_index}.")
+        _validate_persisted_result(
+            root,
+            data_path_template,
+            video_path_template,
+            plan,
+            spec,
+            result,
+        )
+        ordered_results.append(result)
+
+    if result_by_episode:
+        unknown = sorted(result_by_episode)
+        raise ValueError(f"Results contain unknown distributed episode indexes: {unknown}.")
+    return ordered_results
+
+
+def _validate_persisted_result(
+    root: Path,
+    data_path_template: str,
+    video_path_template: str | None,
+    plan: DistributedWritePlan,
+    spec: DistributedEpisodeSpec,
+    result: DistributedEpisodeResult,
+) -> None:
+    _validate_result_matches_spec(spec, result)
+    if not result.stats:
+        raise ValueError(f"Distributed result for episode {spec.episode_index} has no statistics.")
+
+    expected_path = root / data_path_template.format(
+        chunk_index=spec.data_chunk_index,
+        file_index=spec.data_file_index,
+    )
+    if result.data_path != expected_path:
+        raise ValueError(
+            f"Distributed result for episode {spec.episode_index} wrote unexpected path "
+            f"{result.data_path}; expected {expected_path}."
+        )
+    if not result.data_path.is_file():
+        raise ValueError(f"Distributed artifact is missing: {result.data_path}")
+
+    table = pq.read_table(result.data_path, columns=["index", "episode_index"])
+    expected_indices = list(range(spec.dataset_from_index, spec.dataset_to_index))
+    if table.num_rows != spec.length:
+        raise ValueError(
+            f"Distributed artifact {result.data_path} has {table.num_rows} rows; expected {spec.length}."
+        )
+    if table.column("index").to_pylist() != expected_indices:
+        raise ValueError(f"Distributed artifact {result.data_path} has an unexpected frame index range.")
+    if set(table.column("episode_index").to_pylist()) != {spec.episode_index}:
+        raise ValueError(f"Distributed artifact {result.data_path} has an unexpected episode index.")
+    for video_key in plan.video_keys:
+        if video_path_template is None:
+            raise ValueError("Distributed plan includes videos but the dataset has no video path template.")
+        expected_video_path = root / video_path_template.format(
+            video_key=video_key,
+            chunk_index=spec.data_chunk_index,
+            file_index=spec.data_file_index,
+        )
+        required_metadata = {
+            f"videos/{video_key}/chunk_index": spec.data_chunk_index,
+            f"videos/{video_key}/file_index": spec.data_file_index,
+        }
+        for key, expected in required_metadata.items():
+            if result.video_metadata.get(key) != expected:
+                raise ValueError(
+                    f"Distributed result for episode {spec.episode_index} has unexpected {key}: "
+                    f"{result.video_metadata.get(key)!r} != {expected!r}."
+                )
+        if not expected_video_path.is_file():
+            raise ValueError(f"Distributed video artifact is missing: {expected_video_path}")
+
+
+def write_distributed_metadata(
+    staging_root: Path,
+    info: Any,
+    plan: DistributedWritePlan,
+    results: list[DistributedEpisodeResult],
+) -> None:
+    """Write complete global metadata below an unpublished staging root."""
+    tasks = pd.DataFrame(
+        {"task_index": list(plan.task_to_index.values())},
+        index=pd.Index(plan.task_to_index.keys(), name="task"),
+    )
+    rows: list[dict[str, Any]] = []
+    for result in results:
+        flattened_stats = {
+            key: _normalize_metadata_stat_value(value)
+            for key, value in flatten_dict({"stats": result.stats}).items()
+        }
+        row = {
+            "episode_index": result.episode_index,
+            "tasks": list(result.tasks),
+            "length": result.dataset_to_index - result.dataset_from_index,
+            "data/chunk_index": result.data_chunk_index,
+            "data/file_index": result.data_file_index,
+            "dataset_from_index": result.dataset_from_index,
+            "dataset_to_index": result.dataset_to_index,
+            **flattened_stats,
+            **result.video_metadata,
+        }
+        rows.append(row)
+
+    staged_info = info
+    staged_info.total_episodes = len(results)
+    staged_info.total_frames = sum(result.dataset_to_index - result.dataset_from_index for result in results)
+    staged_info.total_tasks = len(tasks)
+    staged_info.splits = {"train": f"0:{len(results)}"}
+    if plan.video_keys:
+        if staged_info.video_path is None:
+            raise ValueError("Distributed plan includes videos but the dataset has no video path template.")
+        first_result = results[0]
+        for video_key in plan.video_keys:
+            if video_key not in first_result.video_info:
+                raise ValueError(
+                    f"Distributed result for episode {first_result.episode_index} has no video info "
+                    f"for {video_key!r}."
+                )
+            staged_info.features[video_key]["info"] = first_result.video_info[video_key]
+
+    write_info(staged_info, staging_root)
+    write_tasks(tasks, staging_root)
+    write_stats(aggregate_stats([result.stats for result in results]), staging_root)
+    for result, row in zip(results, rows, strict=True):
+        path = staging_root / DEFAULT_EPISODES_PATH.format(
+            chunk_index=result.data_chunk_index,
+            file_index=result.data_file_index,
+        )
+        path.parent.mkdir(parents=True, exist_ok=True)
+        datasets.Dataset.from_list([row]).to_parquet(path)
+
+
+def _normalize_metadata_stat_value(value: Any) -> Any:
+    """Keep one stable Arrow dtype per flattened per-episode statistic column."""
+    array = np.asarray(value)
+    if np.issubdtype(array.dtype, np.floating):
+        return array.astype(np.float64).tolist()
+    if np.issubdtype(array.dtype, np.integer):
+        return array.astype(np.int64).tolist()
+    return array.tolist()
+
+
+def publish_distributed_metadata(root: Path, staging_root: Path) -> None:
+    """Atomically publish staged metadata while retaining rollback on failure."""
+    source_meta = staging_root / "meta"
+    destination_meta = root / "meta"
+    backup_meta = root / f".meta-distributed-backup-{uuid4().hex}"
+    backup_restored = False
+    try:
+        os.replace(destination_meta, backup_meta)
+        os.replace(source_meta, destination_meta)
+    except Exception:
+        if backup_meta.exists() and not destination_meta.exists():
+            os.replace(backup_meta, destination_meta)
+            backup_restored = True
+        raise
+    finally:
+        if destination_meta.exists() or backup_restored:
+            shutil.rmtree(backup_meta, ignore_errors=True)

--- a/src/lerobot/datasets/lerobot_dataset.py
+++ b/src/lerobot/datasets/lerobot_dataset.py
@@ -15,8 +15,11 @@
 # limitations under the License.
 import contextlib
 import logging
+import shutil
 from collections.abc import Callable
+from copy import deepcopy
 from pathlib import Path
+from uuid import uuid4
 
 import datasets
 import torch
@@ -30,6 +33,14 @@ from lerobot.utils.constants import HF_LEROBOT_HUB_CACHE
 from .dataset_metadata import CODEBASE_VERSION, LeRobotDatasetMetadata
 from .dataset_reader import DatasetReader
 from .dataset_writer import DatasetWriter
+from .distributed import (
+    DistributedEpisodeResult,
+    DistributedEpisodeSpec,
+    DistributedWritePlan,
+    publish_distributed_metadata,
+    validate_distributed_results,
+    write_distributed_metadata,
+)
 from .utils import (
     create_lerobot_dataset_card,
     get_safe_version,
@@ -448,6 +459,58 @@ class LeRobotDataset(torch.utils.data.Dataset):
         """
         self._require_writer("save_episode")
         self.writer.save_episode(episode_data, parallel_encoding)
+
+    def save_distributed_episode(
+        self, spec: DistributedEpisodeSpec, parallel_encoding: bool = True
+    ) -> DistributedEpisodeResult:
+        """Write the worker-owned artifact for one preallocated episode."""
+        self._require_writer("save_distributed_episode")
+        if not getattr(self, "_is_distributed_writer", False):
+            raise RuntimeError(
+                "save_distributed_episode() requires LeRobotDataset.open_distributed_writer()."
+            )
+        return self.writer.save_distributed_episode(spec, parallel_encoding)
+
+    def start_distributed_episode(self, spec: DistributedEpisodeSpec) -> None:
+        """Bind the worker's frame staging directory to a preallocated episode."""
+        self._require_writer("start_distributed_episode")
+        if not getattr(self, "_is_distributed_writer", False):
+            raise RuntimeError(
+                "start_distributed_episode() requires LeRobotDataset.open_distributed_writer()."
+            )
+        self.writer.start_distributed_episode(spec)
+
+    def commit_distributed_results(
+        self, plan: DistributedWritePlan, results: list[DistributedEpisodeResult]
+    ) -> None:
+        """Validate worker artifacts and atomically publish their global metadata."""
+        self._require_writer("commit_distributed_results")
+        if self.meta.total_episodes or self.meta.total_frames:
+            raise ValueError("Distributed commits require a newly created empty dataset.")
+        if set(plan.video_keys) != set(self.meta.video_keys):
+            raise ValueError(
+                "Distributed write plan video_keys must match the dataset video feature keys: "
+                f"{sorted(plan.video_keys)!r} != {sorted(self.meta.video_keys)!r}."
+            )
+        ordered_results = validate_distributed_results(
+            self.root,
+            self.meta.data_path,
+            self.meta.video_path,
+            plan,
+            results,
+        )
+        staging_root = self.root / f".distributed-metadata-{uuid4().hex}"
+        try:
+            write_distributed_metadata(
+                staging_root,
+                deepcopy(self.meta.info),
+                plan,
+                ordered_results,
+            )
+            publish_distributed_metadata(self.root, staging_root)
+        finally:
+            shutil.rmtree(staging_root, ignore_errors=True)
+        self.meta._load_metadata()
 
     def clear_episode_buffer(self, delete_images: bool = True) -> None:
         """Discard the current episode buffer without saving.
@@ -910,3 +973,32 @@ class LeRobotDataset(torch.utils.data.Dataset):
         obj._is_finalized = False
 
         return obj
+
+    @classmethod
+    def open_distributed_writer(
+        cls,
+        repo_id: str,
+        root: str | Path,
+        *,
+        rgb_encoder: RGBEncoderConfig | None = None,
+        depth_encoder: DepthEncoderConfig | None = None,
+        encoder_threads: int | None = None,
+    ) -> "LeRobotDataset":
+        """Open a worker writer for a newly created, still-empty dataset."""
+        dataset = cls.resume(
+            repo_id,
+            root=root,
+            batch_encoding_size=1,
+            rgb_encoder=rgb_encoder,
+            depth_encoder=depth_encoder,
+            encoder_threads=encoder_threads,
+            streaming_encoding=False,
+        )
+        if dataset.meta.total_episodes or dataset.meta.total_frames:
+            dataset.finalize()
+            raise ValueError(
+                "Distributed workers only support a newly created empty dataset; "
+                "distributed append is not supported."
+            )
+        dataset._is_distributed_writer = True
+        return dataset

--- a/src/lerobot/datasets/lerobot_dataset.py
+++ b/src/lerobot/datasets/lerobot_dataset.py
@@ -15,8 +15,11 @@
 # limitations under the License.
 import contextlib
 import logging
+import shutil
 from collections.abc import Callable
+from copy import deepcopy
 from pathlib import Path
+from uuid import uuid4
 
 import datasets
 import torch
@@ -30,6 +33,15 @@ from lerobot.utils.constants import HF_LEROBOT_HUB_CACHE
 from .dataset_metadata import CODEBASE_VERSION, LeRobotDatasetMetadata
 from .dataset_reader import DatasetReader
 from .dataset_writer import DatasetWriter
+from .distributed import (
+    DistributedEpisodeResult,
+    DistributedEpisodeSpec,
+    DistributedWritePlan,
+    DistributedWriteSession,
+    publish_distributed_metadata,
+    validate_distributed_results,
+    write_distributed_metadata,
+)
 from .utils import (
     create_lerobot_dataset_card,
     get_safe_version,
@@ -448,6 +460,85 @@ class LeRobotDataset(torch.utils.data.Dataset):
         """
         self._require_writer("save_episode")
         self.writer.save_episode(episode_data, parallel_encoding)
+
+    def save_distributed_episode(
+        self, spec: DistributedEpisodeSpec, parallel_encoding: bool = True
+    ) -> DistributedEpisodeResult:
+        """Write the worker-owned artifact for one preallocated episode."""
+        self._require_writer("save_distributed_episode")
+        if not getattr(self, "_is_distributed_writer", False):
+            raise RuntimeError(
+                "save_distributed_episode() requires LeRobotDataset.open_distributed_writer()."
+            )
+        result = self.writer.save_distributed_episode(spec, parallel_encoding)
+        if self._distributed_write_session is not None:
+            self._distributed_write_session.record_result(result)
+        return result
+
+    def start_distributed_episode(self, spec: DistributedEpisodeSpec) -> None:
+        """Bind the worker's frame staging directory to a preallocated episode."""
+        self._require_writer("start_distributed_episode")
+        if not getattr(self, "_is_distributed_writer", False):
+            raise RuntimeError(
+                "start_distributed_episode() requires LeRobotDataset.open_distributed_writer()."
+            )
+        self.writer.start_distributed_episode(spec)
+
+    def create_distributed_write_session(self, plan: DistributedWritePlan) -> DistributedWriteSession:
+        """Persist a new distributed write plan for explicit recovery after interruption."""
+        self._require_writer("create_distributed_write_session")
+        if self.meta.total_episodes or self.meta.total_frames:
+            raise ValueError("Distributed write sessions require a newly created empty dataset.")
+        if set(plan.video_keys) != set(self.meta.video_keys):
+            raise ValueError(
+                "Distributed write plan video_keys must match the dataset video feature keys: "
+                f"{sorted(plan.video_keys)!r} != {sorted(self.meta.video_keys)!r}."
+            )
+        return DistributedWriteSession.create(
+            self.root,
+            plan,
+            data_path_template=self.meta.data_path,
+            video_path_template=self.meta.video_path,
+            camera_keys=tuple(self.meta.camera_keys),
+            depth_keys=tuple(self.meta.depth_keys),
+        )
+
+    @classmethod
+    def resume_distributed_write_session(cls, root: str | Path) -> DistributedWriteSession:
+        """Load persisted distributed progress and expose specs still requiring execution."""
+        return DistributedWriteSession.resume(root)
+
+    def commit_distributed_results(
+        self, plan: DistributedWritePlan, results: list[DistributedEpisodeResult]
+    ) -> None:
+        """Validate worker artifacts and atomically publish their global metadata."""
+        self._require_writer("commit_distributed_results")
+        if self.meta.total_episodes or self.meta.total_frames:
+            raise ValueError("Distributed commits require a newly created empty dataset.")
+        if set(plan.video_keys) != set(self.meta.video_keys):
+            raise ValueError(
+                "Distributed write plan video_keys must match the dataset video feature keys: "
+                f"{sorted(plan.video_keys)!r} != {sorted(self.meta.video_keys)!r}."
+            )
+        ordered_results = validate_distributed_results(
+            self.root,
+            self.meta.data_path,
+            self.meta.video_path,
+            plan,
+            results,
+        )
+        staging_root = self.root / f".distributed-metadata-{uuid4().hex}"
+        try:
+            write_distributed_metadata(
+                staging_root,
+                deepcopy(self.meta.info),
+                plan,
+                ordered_results,
+            )
+            publish_distributed_metadata(self.root, staging_root)
+        finally:
+            shutil.rmtree(staging_root, ignore_errors=True)
+        self.meta._load_metadata()
 
     def clear_episode_buffer(self, delete_images: bool = True) -> None:
         """Discard the current episode buffer without saving.
@@ -910,3 +1001,37 @@ class LeRobotDataset(torch.utils.data.Dataset):
         obj._is_finalized = False
 
         return obj
+
+    @classmethod
+    def open_distributed_writer(
+        cls,
+        repo_id: str,
+        root: str | Path,
+        *,
+        rgb_encoder: RGBEncoderConfig | None = None,
+        depth_encoder: DepthEncoderConfig | None = None,
+        encoder_threads: int | None = None,
+        session: DistributedWriteSession | None = None,
+    ) -> "LeRobotDataset":
+        """Open a worker writer for a newly created, still-empty dataset."""
+        root = Path(root)
+        if session is not None and session.root != root:
+            raise ValueError(f"Distributed session root {session.root} does not match writer root {root}.")
+        dataset = cls.resume(
+            repo_id,
+            root=root,
+            batch_encoding_size=1,
+            rgb_encoder=rgb_encoder,
+            depth_encoder=depth_encoder,
+            encoder_threads=encoder_threads,
+            streaming_encoding=False,
+        )
+        if dataset.meta.total_episodes or dataset.meta.total_frames:
+            dataset.finalize()
+            raise ValueError(
+                "Distributed workers only support a newly created empty dataset; "
+                "distributed append is not supported."
+            )
+        dataset._is_distributed_writer = True
+        dataset._distributed_write_session = session
+        return dataset

--- a/src/lerobot/datasets/streaming_dataset.py
+++ b/src/lerobot/datasets/streaming_dataset.py
@@ -63,6 +63,49 @@ class _ShardExhaustedError(Exception):
     """Raised when a streaming dataset shard has no more items."""
 
 
+def get_streaming_consumer_shards(
+    *,
+    num_source_shards: int,
+    rank: int,
+    world_size: int,
+    worker_id: int,
+    num_workers: int,
+) -> list[int]:
+    """Return source shards owned by one distributed rank and DataLoader worker."""
+    if num_source_shards < 0:
+        raise ValueError("num_source_shards must be non-negative.")
+    if world_size <= 0:
+        raise ValueError("world_size must be positive.")
+    if not 0 <= rank < world_size:
+        raise ValueError(f"rank must be in [0, {world_size}), got {rank}.")
+    if num_workers <= 0:
+        raise ValueError("num_workers must be positive.")
+    if not 0 <= worker_id < num_workers:
+        raise ValueError(f"worker_id must be in [0, {num_workers}), got {worker_id}.")
+
+    consumer_count = world_size * num_workers
+    consumer_id = rank * num_workers + worker_id
+    return [
+        source_shard
+        for source_shard in range(num_source_shards)
+        if source_shard % consumer_count == consumer_id
+    ]
+
+
+def get_streaming_consumer_identity() -> tuple[int, int, int, int]:
+    """Return ``(rank, world_size, worker_id, num_workers)`` for this iterator."""
+    worker_info = torch.utils.data.get_worker_info()
+    worker_id = worker_info.id if worker_info is not None else 0
+    num_workers = worker_info.num_workers if worker_info is not None else 1
+    if torch.distributed.is_available() and torch.distributed.is_initialized():
+        rank = torch.distributed.get_rank()
+        world_size = torch.distributed.get_world_size()
+    else:
+        rank = 0
+        world_size = 1
+    return rank, world_size, worker_id, num_workers
+
+
 class Backtrackable[T]:
     """
     Wrap any iterator/iterable so you can step back up to `history` items
@@ -423,9 +466,19 @@ class StreamingLeRobotDataset(torch.utils.data.IterableDataset):
 
         buffer_indices_generator = self._iter_random_indices(rng, self.buffer_size)
 
+        rank, world_size, worker_id, num_workers = get_streaming_consumer_identity()
+        assigned_shards = get_streaming_consumer_shards(
+            num_source_shards=self.num_shards,
+            rank=rank,
+            world_size=world_size,
+            worker_id=worker_id,
+            num_workers=num_workers,
+        )
         idx_to_backtrack_dataset = {
-            idx: self._make_backtrackable_dataset(safe_shard(self.hf_dataset, idx, self.num_shards))
-            for idx in range(self.num_shards)
+            shard_index: self._make_backtrackable_dataset(
+                safe_shard(self.hf_dataset, shard_index, self.num_shards)
+            )
+            for shard_index in assigned_shards
         }
 
         # This buffer is populated while iterating on the dataset's shards

--- a/tests/datasets/test_distributed.py
+++ b/tests/datasets/test_distributed.py
@@ -1,0 +1,621 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Contracts for distributed LeRobot dataset planning and writing."""
+
+import multiprocessing as mp
+from dataclasses import replace
+from pathlib import Path
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from lerobot.datasets.distributed import (
+    DistributedWritePlan,
+    DistributedWriteSession,
+    publish_distributed_metadata,
+)
+from lerobot.datasets.lerobot_dataset import LeRobotDataset
+
+FEATURES = {
+    "observation.state": {"dtype": "float32", "shape": (2,), "names": None},
+    "action": {"dtype": "float32", "shape": (2,), "names": None},
+}
+
+
+def add_episode_frames(dataset: LeRobotDataset, tasks: tuple[str, ...] | list[str]) -> None:
+    """Append deterministic numeric frames matching a task sequence."""
+    for frame_index, task in enumerate(tasks):
+        dataset.add_frame(
+            {
+                "observation.state": np.array([frame_index, 1], dtype=np.float32),
+                "action": np.array([frame_index, 2], dtype=np.float32),
+                "task": task,
+            }
+        )
+
+
+def add_video_frames(dataset: LeRobotDataset, tasks: tuple[str, ...] | list[str], video_key: str) -> None:
+    """Append deterministic RGB frames matching a task sequence."""
+    for frame_index, task in enumerate(tasks):
+        dataset.add_frame(
+            {
+                video_key: np.full((32, 32, 3), frame_index * 40, dtype=np.uint8),
+                "action": np.array([frame_index, 2], dtype=np.float32),
+                "task": task,
+            }
+        )
+
+
+def _write_distributed_spec(root: str, repo_id: str, spec, queue) -> None:
+    """Run one worker in an isolated spawned process."""
+    worker = LeRobotDataset.open_distributed_writer(repo_id, root=root)
+    worker.start_distributed_episode(spec)
+    add_episode_frames(worker, spec.tasks)
+    result = worker.save_distributed_episode(spec)
+    worker.finalize()
+    queue.put(result)
+
+
+def _write_distributed_spec_with_session(root: str, repo_id: str, spec, session, queue) -> None:
+    """Run one session-aware worker in an isolated spawned process."""
+    worker = LeRobotDataset.open_distributed_writer(repo_id, root=root, session=session)
+    worker.start_distributed_episode(spec)
+    add_episode_frames(worker, spec.tasks)
+    result = worker.save_distributed_episode(spec)
+    worker.finalize()
+    queue.put(result.episode_index)
+
+
+def write_specs_in_processes(root: Path, repo_id: str, plan: DistributedWritePlan):
+    """Write every plan entry with a separate spawned process."""
+    context = mp.get_context("spawn")
+    queue = context.Queue()
+    processes = [
+        context.Process(target=_write_distributed_spec, args=(str(root), repo_id, spec, queue))
+        for spec in plan.episodes
+    ]
+    for process in processes:
+        process.start()
+    results = [queue.get(timeout=30) for _ in processes]
+    for process in processes:
+        process.join(timeout=30)
+        assert process.exitcode == 0
+    return results
+
+
+def test_write_plan_allocates_contiguous_ranges_and_unique_files():
+    plan = DistributedWritePlan.from_episode_lengths(
+        episode_lengths=[3, 2, 4],
+        episode_tasks=[
+            ["pick"] * 3,
+            ["place"] * 2,
+            ["pick"] * 4,
+        ],
+        chunks_size=2,
+        video_keys=["observation.images.top"],
+    )
+
+    assert [
+        (spec.episode_index, spec.dataset_from_index, spec.dataset_to_index) for spec in plan.episodes
+    ] == [
+        (0, 0, 3),
+        (1, 3, 5),
+        (2, 5, 9),
+    ]
+    assert [(spec.data_chunk_index, spec.data_file_index) for spec in plan.episodes] == [
+        (0, 0),
+        (0, 1),
+        (1, 0),
+    ]
+    assert plan.task_to_index == {"pick": 0, "place": 1}
+
+
+@pytest.mark.parametrize(
+    ("episode_lengths", "episode_tasks", "message"),
+    [
+        ([], [], "at least one episode"),
+        ([0], [[]], "must be positive"),
+        ([2], [["pick"]], "length"),
+    ],
+)
+def test_write_plan_rejects_invalid_episode_specs(episode_lengths, episode_tasks, message):
+    with pytest.raises(ValueError, match=message):
+        DistributedWritePlan.from_episode_lengths(
+            episode_lengths=episode_lengths,
+            episode_tasks=episode_tasks,
+            chunks_size=2,
+        )
+
+
+def test_distributed_worker_writes_only_its_planned_artifact(tmp_path):
+    root = tmp_path / "dataset"
+    driver = LeRobotDataset.create(
+        "test/distributed",
+        fps=30,
+        features=FEATURES,
+        root=root,
+        use_videos=False,
+    )
+    plan = DistributedWritePlan.from_episode_lengths(
+        episode_lengths=[3],
+        episode_tasks=[["pick"] * 3],
+        chunks_size=1000,
+    )
+    worker = LeRobotDataset.open_distributed_writer("test/distributed", root=root)
+    worker.start_distributed_episode(plan.episodes[0])
+    add_episode_frames(worker, plan.episodes[0].tasks)
+
+    result = worker.save_distributed_episode(plan.episodes[0])
+    worker.finalize()
+
+    assert result.episode_index == 0
+    assert result.data_path == root / Path("data/chunk-000/file-000.parquet")
+    assert result.data_path.exists()
+    assert not (root / "meta" / "tasks.parquet").exists()
+    assert driver.meta.total_episodes == 0
+
+
+def test_distributed_write_session_persists_worker_result_and_resumes_pending_specs(tmp_path):
+    root = tmp_path / "dataset"
+    repo_id = "test/distributed-session"
+    driver = LeRobotDataset.create(repo_id, fps=30, features=FEATURES, root=root, use_videos=False)
+    plan = DistributedWritePlan.from_episode_lengths(
+        episode_lengths=[2, 2],
+        episode_tasks=[["pick"] * 2, ["place"] * 2],
+        chunks_size=1000,
+    )
+    session = driver.create_distributed_write_session(plan)
+
+    worker = LeRobotDataset.open_distributed_writer(repo_id, root=root, session=session)
+    worker.start_distributed_episode(plan.episodes[0])
+    add_episode_frames(worker, plan.episodes[0].tasks)
+    result = worker.save_distributed_episode(plan.episodes[0])
+    worker.finalize()
+
+    assert session.result_path(result.episode_index).is_file()
+
+    resumed = LeRobotDataset.resume_distributed_write_session(root)
+
+    assert resumed.plan == plan
+    restored_results = resumed.load_results()
+    assert len(restored_results) == 1
+    assert restored_results[0].episode_index == result.episode_index
+    assert restored_results[0].data_path == result.data_path
+    assert restored_results[0].tasks == result.tasks
+    assert restored_results[0].stats.keys() == result.stats.keys()
+    assert resumed.pending_specs() == [plan.episodes[1]]
+
+
+def test_distributed_write_session_publishes_plan_and_results_directory_atomically(tmp_path):
+    root = tmp_path / "dataset"
+    plan = DistributedWritePlan.from_episode_lengths(
+        episode_lengths=[2],
+        episode_tasks=[["pick"] * 2],
+        chunks_size=1000,
+    )
+
+    session = DistributedWriteSession.create(root, plan)
+
+    assert session.session_root.is_dir()
+    assert (session.session_root / "plan.json").is_file()
+    assert session.results_root.is_dir()
+    assert not list(root.glob(".distributed-write-session.*.tmp"))
+
+
+def test_distributed_write_session_persists_result_from_spawned_worker(tmp_path):
+    root = tmp_path / "dataset"
+    repo_id = "test/distributed-session"
+    driver = LeRobotDataset.create(repo_id, fps=30, features=FEATURES, root=root, use_videos=False)
+    plan = DistributedWritePlan.from_episode_lengths(
+        episode_lengths=[2, 2],
+        episode_tasks=[["pick"] * 2, ["place"] * 2],
+        chunks_size=1000,
+    )
+    session = driver.create_distributed_write_session(plan)
+    context = mp.get_context("spawn")
+    queue = context.Queue()
+    process = context.Process(
+        target=_write_distributed_spec_with_session,
+        args=(str(root), repo_id, plan.episodes[0], session, queue),
+    )
+
+    process.start()
+    assert queue.get(timeout=30) == plan.episodes[0].episode_index
+    process.join(timeout=30)
+    assert process.exitcode == 0
+
+    resumed = LeRobotDataset.resume_distributed_write_session(root)
+
+    assert [result.episode_index for result in resumed.load_results()] == [0]
+    assert resumed.pending_specs() == [plan.episodes[1]]
+
+
+def test_distributed_write_session_does_not_reuse_artifact_without_result_record(tmp_path):
+    root = tmp_path / "dataset"
+    repo_id = "test/distributed-session"
+    driver = LeRobotDataset.create(repo_id, fps=30, features=FEATURES, root=root, use_videos=False)
+    plan = DistributedWritePlan.from_episode_lengths(
+        episode_lengths=[2, 2],
+        episode_tasks=[["pick"] * 2, ["place"] * 2],
+        chunks_size=1000,
+    )
+    driver.create_distributed_write_session(plan)
+
+    worker = LeRobotDataset.open_distributed_writer(repo_id, root=root)
+    worker.start_distributed_episode(plan.episodes[0])
+    add_episode_frames(worker, plan.episodes[0].tasks)
+    worker.save_distributed_episode(plan.episodes[0])
+    worker.finalize()
+
+    resumed = DistributedWriteSession.resume(root)
+
+    assert resumed.pending_specs() == list(plan.episodes)
+    assert resumed.load_results() == []
+    assert (root / "data/chunk-000/file-000.parquet").is_file()
+
+
+def test_distributed_write_session_cleans_orphan_artifacts_for_pending_specs(tmp_path):
+    root = tmp_path / "dataset"
+    repo_id = "test/distributed-session"
+    driver = LeRobotDataset.create(repo_id, fps=30, features=FEATURES, root=root, use_videos=False)
+    plan = DistributedWritePlan.from_episode_lengths(
+        episode_lengths=[2],
+        episode_tasks=[["pick"] * 2],
+        chunks_size=1000,
+    )
+    session = driver.create_distributed_write_session(plan)
+
+    worker = LeRobotDataset.open_distributed_writer(repo_id, root=root)
+    worker.start_distributed_episode(plan.episodes[0])
+    add_episode_frames(worker, plan.episodes[0].tasks)
+    worker.save_distributed_episode(plan.episodes[0])
+    worker.finalize()
+
+    session.cleanup_orphaned_artifacts()
+
+    assert session.pending_specs() == list(plan.episodes)
+    assert not (root / "data/chunk-000/file-000.parquet").exists()
+
+
+def test_distributed_write_session_cleanup_discards_invalid_result_record(tmp_path):
+    root = tmp_path / "dataset"
+    repo_id = "test/distributed-session"
+    driver = LeRobotDataset.create(repo_id, fps=30, features=FEATURES, root=root, use_videos=False)
+    plan = DistributedWritePlan.from_episode_lengths(
+        episode_lengths=[2],
+        episode_tasks=[["pick"] * 2],
+        chunks_size=1000,
+    )
+    session = driver.create_distributed_write_session(plan)
+
+    worker = LeRobotDataset.open_distributed_writer(repo_id, root=root, session=session)
+    worker.start_distributed_episode(plan.episodes[0])
+    add_episode_frames(worker, plan.episodes[0].tasks)
+    result = worker.save_distributed_episode(plan.episodes[0])
+    worker.finalize()
+    result.data_path.unlink()
+
+    session.cleanup_orphaned_artifacts()
+
+    assert not session.result_path(result.episode_index).exists()
+    assert session.pending_specs() == list(plan.episodes)
+
+
+def test_distributed_write_session_cleanup_discards_corrupt_artifact_record(tmp_path):
+    root = tmp_path / "dataset"
+    repo_id = "test/distributed-session"
+    driver = LeRobotDataset.create(repo_id, fps=30, features=FEATURES, root=root, use_videos=False)
+    plan = DistributedWritePlan.from_episode_lengths(
+        episode_lengths=[2],
+        episode_tasks=[["pick"] * 2],
+        chunks_size=1000,
+    )
+    session = driver.create_distributed_write_session(plan)
+
+    worker = LeRobotDataset.open_distributed_writer(repo_id, root=root, session=session)
+    worker.start_distributed_episode(plan.episodes[0])
+    add_episode_frames(worker, plan.episodes[0].tasks)
+    result = worker.save_distributed_episode(plan.episodes[0])
+    worker.finalize()
+    result.data_path.write_text("corrupt")
+
+    session.cleanup_orphaned_artifacts()
+
+    assert not session.result_path(result.episode_index).exists()
+    assert not result.data_path.exists()
+    assert session.pending_specs() == list(plan.episodes)
+
+
+def test_distributed_write_session_resumes_and_commits_reused_worker_results(tmp_path):
+    root = tmp_path / "dataset"
+    repo_id = "test/distributed-session"
+    driver = LeRobotDataset.create(repo_id, fps=30, features=FEATURES, root=root, use_videos=False)
+    plan = DistributedWritePlan.from_episode_lengths(
+        episode_lengths=[2, 2],
+        episode_tasks=[["pick"] * 2, ["place"] * 2],
+        chunks_size=1000,
+    )
+    session = driver.create_distributed_write_session(plan)
+
+    first_worker = LeRobotDataset.open_distributed_writer(repo_id, root=root, session=session)
+    first_worker.start_distributed_episode(plan.episodes[0])
+    add_episode_frames(first_worker, plan.episodes[0].tasks)
+    first_worker.save_distributed_episode(plan.episodes[0])
+    first_worker.finalize()
+
+    resumed = LeRobotDataset.resume_distributed_write_session(root)
+    for spec in resumed.pending_specs():
+        worker = LeRobotDataset.open_distributed_writer(repo_id, root=root, session=resumed)
+        worker.start_distributed_episode(spec)
+        add_episode_frames(worker, spec.tasks)
+        worker.save_distributed_episode(spec)
+        worker.finalize()
+
+    driver.commit_distributed_results(resumed.plan, resumed.load_results())
+    driver.finalize()
+    loaded = LeRobotDataset(repo_id, root=root)
+
+    assert loaded.num_episodes == 2
+    assert loaded.num_frames == 4
+    assert [loaded[index]["task"] for index in range(len(loaded))] == [
+        "pick",
+        "pick",
+        "place",
+        "place",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("tasks", "message"),
+    [
+        (["pick"], "length"),
+        (["pick", "place"], "task sequence"),
+    ],
+)
+def test_distributed_worker_rejects_length_and_task_mismatch(tmp_path, tasks, message):
+    root = tmp_path / "dataset"
+    LeRobotDataset.create(
+        "test/distributed",
+        fps=30,
+        features=FEATURES,
+        root=root,
+        use_videos=False,
+    )
+    plan = DistributedWritePlan.from_episode_lengths(
+        episode_lengths=[2],
+        episode_tasks=[["pick", "pick"]],
+        chunks_size=1000,
+    )
+    worker = LeRobotDataset.open_distributed_writer("test/distributed", root=root)
+    worker.start_distributed_episode(plan.episodes[0])
+    add_episode_frames(worker, tasks)
+
+    with pytest.raises(ValueError, match=message):
+        worker.save_distributed_episode(plan.episodes[0])
+
+
+def test_distributed_worker_requires_explicit_episode_start(tmp_path):
+    root = tmp_path / "dataset"
+    LeRobotDataset.create(
+        "test/distributed",
+        fps=30,
+        features=FEATURES,
+        root=root,
+        use_videos=False,
+    )
+    plan = DistributedWritePlan.from_episode_lengths(
+        episode_lengths=[1],
+        episode_tasks=[["pick"]],
+        chunks_size=1000,
+    )
+    worker = LeRobotDataset.open_distributed_writer("test/distributed", root=root)
+    add_episode_frames(worker, plan.episodes[0].tasks)
+
+    with pytest.raises(RuntimeError, match="start_distributed_episode"):
+        worker.save_distributed_episode(plan.episodes[0])
+
+
+def test_distributed_worker_cleans_artifacts_when_video_encoding_fails(tmp_path):
+    video_key = "observation.images.top"
+    features = {
+        video_key: {"dtype": "video", "shape": (32, 32, 3), "names": None},
+        "action": {"dtype": "float32", "shape": (2,), "names": None},
+    }
+    root = tmp_path / "video-dataset"
+    LeRobotDataset.create("test/distributed-video", fps=10, features=features, root=root, use_videos=True)
+    plan = DistributedWritePlan.from_episode_lengths(
+        episode_lengths=[1],
+        episode_tasks=[["pick"]],
+        chunks_size=1000,
+        video_keys=[video_key],
+    )
+    worker = LeRobotDataset.open_distributed_writer("test/distributed-video", root=root)
+    worker.start_distributed_episode(plan.episodes[0])
+    add_video_frames(worker, plan.episodes[0].tasks, video_key)
+
+    with (
+        patch.object(
+            worker.writer, "_encode_temporary_episode_video", side_effect=RuntimeError("encode failed")
+        ),
+        pytest.raises(RuntimeError, match="encode failed"),
+    ):
+        worker.save_distributed_episode(plan.episodes[0])
+
+    assert not (root / "data/chunk-000/file-000.parquet").exists()
+    assert not (root / f"videos/{video_key}/chunk-000/file-000.mp4").exists()
+
+
+def test_metadata_publish_restores_previous_metadata_when_swap_fails(tmp_path, monkeypatch):
+    root = tmp_path / "dataset"
+    old_meta = root / "meta"
+    old_meta.mkdir(parents=True)
+    (old_meta / "marker.txt").write_text("old")
+    staging_root = root / "staging"
+    staged_meta = staging_root / "meta"
+    staged_meta.mkdir(parents=True)
+    (staged_meta / "marker.txt").write_text("new")
+
+    real_replace = __import__("os").replace
+
+    def fail_staged_publish(source, destination):
+        if Path(source) == staged_meta and Path(destination) == old_meta:
+            raise OSError("publish failed")
+        return real_replace(source, destination)
+
+    monkeypatch.setattr("lerobot.datasets.distributed.os.replace", fail_staged_publish)
+
+    with pytest.raises(OSError, match="publish failed"):
+        publish_distributed_metadata(root, staging_root)
+
+    assert (old_meta / "marker.txt").read_text() == "old"
+
+
+def test_driver_commits_concurrent_worker_results_into_readable_dataset(tmp_path):
+    root = tmp_path / "dataset"
+    repo_id = "test/distributed"
+    driver = LeRobotDataset.create(repo_id, fps=30, features=FEATURES, root=root, use_videos=False)
+    plan = DistributedWritePlan.from_episode_lengths(
+        episode_lengths=[3, 2, 4, 1],
+        episode_tasks=[
+            ["pick"] * 3,
+            ["place"] * 2,
+            ["pick", "pick", "place", "place"],
+            ["place"],
+        ],
+        chunks_size=2,
+    )
+    results = write_specs_in_processes(root, repo_id, plan)
+
+    driver.commit_distributed_results(plan, results)
+    driver.finalize()
+    loaded = LeRobotDataset(repo_id, root=root)
+
+    assert loaded.num_episodes == 4
+    assert loaded.num_frames == 10
+    expected_metadata_paths = [
+        root / "meta/episodes/chunk-000/file-000.parquet",
+        root / "meta/episodes/chunk-000/file-001.parquet",
+        root / "meta/episodes/chunk-001/file-000.parquet",
+        root / "meta/episodes/chunk-001/file-001.parquet",
+    ]
+    assert all(path.is_file() for path in expected_metadata_paths)
+    assert [loaded[index]["index"].item() for index in range(len(loaded))] == list(range(10))
+    assert [loaded[index]["task"] for index in range(len(loaded))] == [
+        "pick",
+        "pick",
+        "pick",
+        "place",
+        "place",
+        "pick",
+        "pick",
+        "place",
+        "place",
+        "place",
+    ]
+
+
+@pytest.mark.parametrize("tamper", ["missing", "duplicate", "wrong_range", "missing_artifact"])
+def test_driver_rejects_invalid_results_without_publishing_metadata(tmp_path, tamper):
+    root = tmp_path / "dataset"
+    repo_id = "test/distributed"
+    driver = LeRobotDataset.create(repo_id, fps=30, features=FEATURES, root=root, use_videos=False)
+    plan = DistributedWritePlan.from_episode_lengths(
+        episode_lengths=[2, 2],
+        episode_tasks=[["pick"] * 2, ["place"] * 2],
+        chunks_size=2,
+    )
+    results = write_specs_in_processes(root, repo_id, plan)
+
+    if tamper == "missing":
+        invalid_results = results[:-1]
+    elif tamper == "duplicate":
+        invalid_results = [results[0], results[0]]
+    elif tamper == "wrong_range":
+        invalid_results = [
+            replace(result, dataset_from_index=0) if result.episode_index == 1 else result
+            for result in results
+        ]
+    else:
+        results[0].data_path.unlink()
+        invalid_results = results
+
+    with pytest.raises(ValueError):
+        driver.commit_distributed_results(plan, invalid_results)
+
+    assert not (root / "meta" / "tasks.parquet").exists()
+    assert not (root / "meta" / "episodes").exists()
+
+
+def test_distributed_video_results_have_independent_files_and_readable_frames(tmp_path):
+    video_key = "observation.images.top"
+    features = {
+        video_key: {"dtype": "video", "shape": (32, 32, 3), "names": None},
+        "action": {"dtype": "float32", "shape": (2,), "names": None},
+    }
+    root = tmp_path / "video-dataset"
+    repo_id = "test/distributed-video"
+    driver = LeRobotDataset.create(repo_id, fps=10, features=features, root=root, use_videos=True)
+    plan = DistributedWritePlan.from_episode_lengths(
+        episode_lengths=[2, 2],
+        episode_tasks=[["pick"] * 2, ["place"] * 2],
+        chunks_size=1000,
+        video_keys=[video_key],
+    )
+    results = []
+    for spec in plan.episodes:
+        worker = LeRobotDataset.open_distributed_writer(repo_id, root=root)
+        worker.start_distributed_episode(spec)
+        add_video_frames(worker, spec.tasks, video_key)
+        results.append(worker.save_distributed_episode(spec))
+        worker.finalize()
+
+    driver.commit_distributed_results(plan, results)
+    driver.finalize()
+    loaded = LeRobotDataset(repo_id, root=root, video_backend="pyav")
+
+    video_paths = [loaded.root / loaded.meta.get_video_file_path(index, video_key) for index in range(2)]
+    assert video_paths[0] != video_paths[1]
+    assert all(path.exists() for path in video_paths)
+    assert results[0].video_info[video_key]["video.codec"]
+    assert loaded.meta.features[video_key]["info"]["video.codec"]
+    assert loaded[0][video_key].shape == (3, 32, 32)
+
+
+def test_driver_rejects_plan_with_video_keys_that_differ_from_dataset_schema(tmp_path):
+    video_key = "observation.images.top"
+    root = tmp_path / "video-dataset"
+    LeRobotDataset.create(
+        "test/distributed-video",
+        fps=10,
+        features={
+            video_key: {"dtype": "video", "shape": (32, 32, 3), "names": None},
+            "action": {"dtype": "float32", "shape": (2,), "names": None},
+        },
+        root=root,
+        use_videos=True,
+    )
+    driver = LeRobotDataset.open_distributed_writer("test/distributed-video", root=root)
+    plan = DistributedWritePlan.from_episode_lengths(
+        episode_lengths=[1],
+        episode_tasks=[["pick"]],
+        chunks_size=1000,
+        video_keys=[],
+    )
+
+    with pytest.raises(ValueError, match="video_keys"):
+        driver.commit_distributed_results(plan, [])

--- a/tests/datasets/test_distributed.py
+++ b/tests/datasets/test_distributed.py
@@ -1,0 +1,397 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Contracts for distributed LeRobot dataset planning and writing."""
+
+import multiprocessing as mp
+from dataclasses import replace
+from pathlib import Path
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from lerobot.datasets.distributed import DistributedWritePlan, publish_distributed_metadata
+from lerobot.datasets.lerobot_dataset import LeRobotDataset
+
+FEATURES = {
+    "observation.state": {"dtype": "float32", "shape": (2,), "names": None},
+    "action": {"dtype": "float32", "shape": (2,), "names": None},
+}
+
+
+def add_episode_frames(dataset: LeRobotDataset, tasks: tuple[str, ...] | list[str]) -> None:
+    """Append deterministic numeric frames matching a task sequence."""
+    for frame_index, task in enumerate(tasks):
+        dataset.add_frame(
+            {
+                "observation.state": np.array([frame_index, 1], dtype=np.float32),
+                "action": np.array([frame_index, 2], dtype=np.float32),
+                "task": task,
+            }
+        )
+
+
+def add_video_frames(dataset: LeRobotDataset, tasks: tuple[str, ...] | list[str], video_key: str) -> None:
+    """Append deterministic RGB frames matching a task sequence."""
+    for frame_index, task in enumerate(tasks):
+        dataset.add_frame(
+            {
+                video_key: np.full((32, 32, 3), frame_index * 40, dtype=np.uint8),
+                "action": np.array([frame_index, 2], dtype=np.float32),
+                "task": task,
+            }
+        )
+
+
+def _write_distributed_spec(root: str, repo_id: str, spec, queue) -> None:
+    """Run one worker in an isolated spawned process."""
+    worker = LeRobotDataset.open_distributed_writer(repo_id, root=root)
+    worker.start_distributed_episode(spec)
+    add_episode_frames(worker, spec.tasks)
+    result = worker.save_distributed_episode(spec)
+    worker.finalize()
+    queue.put(result)
+
+
+def write_specs_in_processes(root: Path, repo_id: str, plan: DistributedWritePlan):
+    """Write every plan entry with a separate spawned process."""
+    context = mp.get_context("spawn")
+    queue = context.Queue()
+    processes = [
+        context.Process(target=_write_distributed_spec, args=(str(root), repo_id, spec, queue))
+        for spec in plan.episodes
+    ]
+    for process in processes:
+        process.start()
+    results = [queue.get(timeout=30) for _ in processes]
+    for process in processes:
+        process.join(timeout=30)
+        assert process.exitcode == 0
+    return results
+
+
+def test_write_plan_allocates_contiguous_ranges_and_unique_files():
+    plan = DistributedWritePlan.from_episode_lengths(
+        episode_lengths=[3, 2, 4],
+        episode_tasks=[
+            ["pick"] * 3,
+            ["place"] * 2,
+            ["pick"] * 4,
+        ],
+        chunks_size=2,
+        video_keys=["observation.images.top"],
+    )
+
+    assert [
+        (spec.episode_index, spec.dataset_from_index, spec.dataset_to_index) for spec in plan.episodes
+    ] == [
+        (0, 0, 3),
+        (1, 3, 5),
+        (2, 5, 9),
+    ]
+    assert [(spec.data_chunk_index, spec.data_file_index) for spec in plan.episodes] == [
+        (0, 0),
+        (0, 1),
+        (1, 0),
+    ]
+    assert plan.task_to_index == {"pick": 0, "place": 1}
+
+
+@pytest.mark.parametrize(
+    ("episode_lengths", "episode_tasks", "message"),
+    [
+        ([], [], "at least one episode"),
+        ([0], [[]], "must be positive"),
+        ([2], [["pick"]], "length"),
+    ],
+)
+def test_write_plan_rejects_invalid_episode_specs(episode_lengths, episode_tasks, message):
+    with pytest.raises(ValueError, match=message):
+        DistributedWritePlan.from_episode_lengths(
+            episode_lengths=episode_lengths,
+            episode_tasks=episode_tasks,
+            chunks_size=2,
+        )
+
+
+def test_distributed_worker_writes_only_its_planned_artifact(tmp_path):
+    root = tmp_path / "dataset"
+    driver = LeRobotDataset.create(
+        "test/distributed",
+        fps=30,
+        features=FEATURES,
+        root=root,
+        use_videos=False,
+    )
+    plan = DistributedWritePlan.from_episode_lengths(
+        episode_lengths=[3],
+        episode_tasks=[["pick"] * 3],
+        chunks_size=1000,
+    )
+    worker = LeRobotDataset.open_distributed_writer("test/distributed", root=root)
+    worker.start_distributed_episode(plan.episodes[0])
+    add_episode_frames(worker, plan.episodes[0].tasks)
+
+    result = worker.save_distributed_episode(plan.episodes[0])
+    worker.finalize()
+
+    assert result.episode_index == 0
+    assert result.data_path == root / Path("data/chunk-000/file-000.parquet")
+    assert result.data_path.exists()
+    assert not (root / "meta" / "tasks.parquet").exists()
+    assert driver.meta.total_episodes == 0
+
+
+@pytest.mark.parametrize(
+    ("tasks", "message"),
+    [
+        (["pick"], "length"),
+        (["pick", "place"], "task sequence"),
+    ],
+)
+def test_distributed_worker_rejects_length_and_task_mismatch(tmp_path, tasks, message):
+    root = tmp_path / "dataset"
+    LeRobotDataset.create(
+        "test/distributed",
+        fps=30,
+        features=FEATURES,
+        root=root,
+        use_videos=False,
+    )
+    plan = DistributedWritePlan.from_episode_lengths(
+        episode_lengths=[2],
+        episode_tasks=[["pick", "pick"]],
+        chunks_size=1000,
+    )
+    worker = LeRobotDataset.open_distributed_writer("test/distributed", root=root)
+    worker.start_distributed_episode(plan.episodes[0])
+    add_episode_frames(worker, tasks)
+
+    with pytest.raises(ValueError, match=message):
+        worker.save_distributed_episode(plan.episodes[0])
+
+
+def test_distributed_worker_requires_explicit_episode_start(tmp_path):
+    root = tmp_path / "dataset"
+    LeRobotDataset.create(
+        "test/distributed",
+        fps=30,
+        features=FEATURES,
+        root=root,
+        use_videos=False,
+    )
+    plan = DistributedWritePlan.from_episode_lengths(
+        episode_lengths=[1],
+        episode_tasks=[["pick"]],
+        chunks_size=1000,
+    )
+    worker = LeRobotDataset.open_distributed_writer("test/distributed", root=root)
+    add_episode_frames(worker, plan.episodes[0].tasks)
+
+    with pytest.raises(RuntimeError, match="start_distributed_episode"):
+        worker.save_distributed_episode(plan.episodes[0])
+
+
+def test_distributed_worker_cleans_artifacts_when_video_encoding_fails(tmp_path):
+    video_key = "observation.images.top"
+    features = {
+        video_key: {"dtype": "video", "shape": (32, 32, 3), "names": None},
+        "action": {"dtype": "float32", "shape": (2,), "names": None},
+    }
+    root = tmp_path / "video-dataset"
+    LeRobotDataset.create("test/distributed-video", fps=10, features=features, root=root, use_videos=True)
+    plan = DistributedWritePlan.from_episode_lengths(
+        episode_lengths=[1],
+        episode_tasks=[["pick"]],
+        chunks_size=1000,
+        video_keys=[video_key],
+    )
+    worker = LeRobotDataset.open_distributed_writer("test/distributed-video", root=root)
+    worker.start_distributed_episode(plan.episodes[0])
+    add_video_frames(worker, plan.episodes[0].tasks, video_key)
+
+    with (
+        patch.object(
+            worker.writer, "_encode_temporary_episode_video", side_effect=RuntimeError("encode failed")
+        ),
+        pytest.raises(RuntimeError, match="encode failed"),
+    ):
+        worker.save_distributed_episode(plan.episodes[0])
+
+    assert not (root / "data/chunk-000/file-000.parquet").exists()
+    assert not (root / f"videos/{video_key}/chunk-000/file-000.mp4").exists()
+
+
+def test_metadata_publish_restores_previous_metadata_when_swap_fails(tmp_path, monkeypatch):
+    root = tmp_path / "dataset"
+    old_meta = root / "meta"
+    old_meta.mkdir(parents=True)
+    (old_meta / "marker.txt").write_text("old")
+    staging_root = root / "staging"
+    staged_meta = staging_root / "meta"
+    staged_meta.mkdir(parents=True)
+    (staged_meta / "marker.txt").write_text("new")
+
+    real_replace = __import__("os").replace
+
+    def fail_staged_publish(source, destination):
+        if Path(source) == staged_meta and Path(destination) == old_meta:
+            raise OSError("publish failed")
+        return real_replace(source, destination)
+
+    monkeypatch.setattr("lerobot.datasets.distributed.os.replace", fail_staged_publish)
+
+    with pytest.raises(OSError, match="publish failed"):
+        publish_distributed_metadata(root, staging_root)
+
+    assert (old_meta / "marker.txt").read_text() == "old"
+
+
+def test_driver_commits_concurrent_worker_results_into_readable_dataset(tmp_path):
+    root = tmp_path / "dataset"
+    repo_id = "test/distributed"
+    driver = LeRobotDataset.create(repo_id, fps=30, features=FEATURES, root=root, use_videos=False)
+    plan = DistributedWritePlan.from_episode_lengths(
+        episode_lengths=[3, 2, 4, 1],
+        episode_tasks=[
+            ["pick"] * 3,
+            ["place"] * 2,
+            ["pick", "pick", "place", "place"],
+            ["place"],
+        ],
+        chunks_size=2,
+    )
+    results = write_specs_in_processes(root, repo_id, plan)
+
+    driver.commit_distributed_results(plan, results)
+    driver.finalize()
+    loaded = LeRobotDataset(repo_id, root=root)
+
+    assert loaded.num_episodes == 4
+    assert loaded.num_frames == 10
+    expected_metadata_paths = [
+        root / "meta/episodes/chunk-000/file-000.parquet",
+        root / "meta/episodes/chunk-000/file-001.parquet",
+        root / "meta/episodes/chunk-001/file-000.parquet",
+        root / "meta/episodes/chunk-001/file-001.parquet",
+    ]
+    assert all(path.is_file() for path in expected_metadata_paths)
+    assert [loaded[index]["index"].item() for index in range(len(loaded))] == list(range(10))
+    assert [loaded[index]["task"] for index in range(len(loaded))] == [
+        "pick",
+        "pick",
+        "pick",
+        "place",
+        "place",
+        "pick",
+        "pick",
+        "place",
+        "place",
+        "place",
+    ]
+
+
+@pytest.mark.parametrize("tamper", ["missing", "duplicate", "wrong_range", "missing_artifact"])
+def test_driver_rejects_invalid_results_without_publishing_metadata(tmp_path, tamper):
+    root = tmp_path / "dataset"
+    repo_id = "test/distributed"
+    driver = LeRobotDataset.create(repo_id, fps=30, features=FEATURES, root=root, use_videos=False)
+    plan = DistributedWritePlan.from_episode_lengths(
+        episode_lengths=[2, 2],
+        episode_tasks=[["pick"] * 2, ["place"] * 2],
+        chunks_size=2,
+    )
+    results = write_specs_in_processes(root, repo_id, plan)
+
+    if tamper == "missing":
+        invalid_results = results[:-1]
+    elif tamper == "duplicate":
+        invalid_results = [results[0], results[0]]
+    elif tamper == "wrong_range":
+        invalid_results = [
+            replace(result, dataset_from_index=0) if result.episode_index == 1 else result
+            for result in results
+        ]
+    else:
+        results[0].data_path.unlink()
+        invalid_results = results
+
+    with pytest.raises(ValueError):
+        driver.commit_distributed_results(plan, invalid_results)
+
+    assert not (root / "meta" / "tasks.parquet").exists()
+    assert not (root / "meta" / "episodes").exists()
+
+
+def test_distributed_video_results_have_independent_files_and_readable_frames(tmp_path):
+    video_key = "observation.images.top"
+    features = {
+        video_key: {"dtype": "video", "shape": (32, 32, 3), "names": None},
+        "action": {"dtype": "float32", "shape": (2,), "names": None},
+    }
+    root = tmp_path / "video-dataset"
+    repo_id = "test/distributed-video"
+    driver = LeRobotDataset.create(repo_id, fps=10, features=features, root=root, use_videos=True)
+    plan = DistributedWritePlan.from_episode_lengths(
+        episode_lengths=[2, 2],
+        episode_tasks=[["pick"] * 2, ["place"] * 2],
+        chunks_size=1000,
+        video_keys=[video_key],
+    )
+    results = []
+    for spec in plan.episodes:
+        worker = LeRobotDataset.open_distributed_writer(repo_id, root=root)
+        worker.start_distributed_episode(spec)
+        add_video_frames(worker, spec.tasks, video_key)
+        results.append(worker.save_distributed_episode(spec))
+        worker.finalize()
+
+    driver.commit_distributed_results(plan, results)
+    driver.finalize()
+    loaded = LeRobotDataset(repo_id, root=root, video_backend="pyav")
+
+    video_paths = [loaded.root / loaded.meta.get_video_file_path(index, video_key) for index in range(2)]
+    assert video_paths[0] != video_paths[1]
+    assert all(path.exists() for path in video_paths)
+    assert results[0].video_info[video_key]["video.codec"]
+    assert loaded.meta.features[video_key]["info"]["video.codec"]
+    assert loaded[0][video_key].shape == (3, 32, 32)
+
+
+def test_driver_rejects_plan_with_video_keys_that_differ_from_dataset_schema(tmp_path):
+    video_key = "observation.images.top"
+    root = tmp_path / "video-dataset"
+    LeRobotDataset.create(
+        "test/distributed-video",
+        fps=10,
+        features={
+            video_key: {"dtype": "video", "shape": (32, 32, 3), "names": None},
+            "action": {"dtype": "float32", "shape": (2,), "names": None},
+        },
+        root=root,
+        use_videos=True,
+    )
+    driver = LeRobotDataset.open_distributed_writer("test/distributed-video", root=root)
+    plan = DistributedWritePlan.from_episode_lengths(
+        episode_lengths=[1],
+        episode_tasks=[["pick"]],
+        chunks_size=1000,
+        video_keys=[],
+    )
+
+    with pytest.raises(ValueError, match="video_keys"):
+        driver.commit_distributed_results(plan, [])

--- a/tests/datasets/test_streaming.py
+++ b/tests/datasets/test_streaming.py
@@ -24,10 +24,99 @@ pytest.importorskip("datasets", reason="datasets is required (install lerobot[da
 
 import lerobot.datasets.streaming_dataset as streaming_dataset_module
 from lerobot.datasets.dataset_metadata import LeRobotDatasetMetadata
-from lerobot.datasets.streaming_dataset import StreamingLeRobotDataset
+from lerobot.datasets.lerobot_dataset import LeRobotDataset
+from lerobot.datasets.streaming_dataset import StreamingLeRobotDataset, get_streaming_consumer_shards
 from lerobot.datasets.utils import safe_shard
 from lerobot.utils.constants import ACTION
 from tests.fixtures.constants import DUMMY_REPO_ID
+
+STREAMING_NUMERIC_FEATURES = {
+    "observation.state": {"dtype": "float32", "shape": (1,), "names": None},
+    "action": {"dtype": "float32", "shape": (1,), "names": None},
+}
+
+
+def test_streaming_consumer_shards_are_disjoint_and_complete():
+    assignments = [
+        set(
+            get_streaming_consumer_shards(
+                num_source_shards=7,
+                rank=rank,
+                world_size=2,
+                worker_id=worker_id,
+                num_workers=2,
+            )
+        )
+        for rank in range(2)
+        for worker_id in range(2)
+    ]
+
+    assert not any(
+        left & right for index, left in enumerate(assignments) for right in assignments[index + 1 :]
+    )
+    assert set().union(*assignments) == set(range(7))
+
+
+def test_streaming_consumer_with_no_source_shard_is_empty():
+    assert (
+        get_streaming_consumer_shards(
+            num_source_shards=2,
+            rank=1,
+            world_size=2,
+            worker_id=1,
+            num_workers=2,
+        )
+        == []
+    )
+
+
+def test_streaming_iteration_partitions_numeric_source_shards_across_consumers(tmp_path, monkeypatch):
+    root = tmp_path / "numeric-stream"
+    repo_id = "test/numeric-stream"
+    writer = LeRobotDataset.create(
+        repo_id,
+        fps=30,
+        features=STREAMING_NUMERIC_FEATURES,
+        root=root,
+        use_videos=False,
+        data_files_size_in_mb=0.0001,
+    )
+    for episode_index in range(4):
+        for frame_index in range(2):
+            writer.add_frame(
+                {
+                    "observation.state": np.array([episode_index], dtype=np.float32),
+                    "action": np.array([frame_index], dtype=np.float32),
+                    "task": "task",
+                }
+            )
+        writer.save_episode()
+    writer.finalize()
+
+    all_indices = set()
+    consumer_indices = []
+    for rank in range(2):
+        for worker_id in range(2):
+            monkeypatch.setattr(
+                streaming_dataset_module,
+                "get_streaming_consumer_identity",
+                lambda rank=rank, worker_id=worker_id: (rank, 2, worker_id, 2),
+            )
+            dataset = StreamingLeRobotDataset(
+                repo_id,
+                root=root,
+                buffer_size=16,
+                max_num_shards=4,
+                shuffle=False,
+            )
+            indices = {int(frame["index"]) for frame in dataset}
+            consumer_indices.append(indices)
+            all_indices.update(indices)
+
+    assert all_indices == set(range(8))
+    assert not any(
+        left & right for index, left in enumerate(consumer_indices) for right in consumer_indices[index + 1 :]
+    )
 
 
 def get_frames_expected_order(streaming_ds: StreamingLeRobotDataset) -> list[int]:


### PR DESCRIPTION
## Summary / Motivation

This PR adds safe distributed read and write support for LeRobot Dataset v3.0. Distributed dataset construction previously required callers to coordinate writes outside LeRobot because concurrent workers could race on data/video shards and global metadata. The new driver-planned protocol gives every worker exclusive episode artifacts and publishes metadata only after the driver validates all worker results.

The write path intentionally uses one data shard and one video shard per episode. This increases file count relative to serial recording, but avoids distributed file locks, allows retrying one failed worker with the same allocation, and preserves the existing v3.0 reader format.

## Related issues

- Fixes / Closes: N/A
- Related: N/A

## What changed

- Added `DistributedWritePlan`, `DistributedEpisodeSpec`, and `DistributedEpisodeResult` for deterministic episode, frame-range, task-index, and shard allocation.
- Added `LeRobotDataset.open_distributed_writer()`, `start_distributed_episode()`, and `save_distributed_episode()` for worker-only writes that do not modify global metadata.
- Added `commit_distributed_results()` for driver-side validation and atomic `meta/` publication with rollback protection.
- Added independent Parquet/MP4 artifacts per distributed episode, video metadata propagation, and cleanup of partially written artifacts after worker failures.
- Added streaming dataset source-shard ownership by distributed rank and PyTorch DataLoader worker to prevent duplicate streamed samples.
- Added distributed dataset documentation and focused multiprocessing, video, recovery, and streaming-sharding tests.

Breaking changes: none. Distributed writing is a new API. The initial scope supports new empty datasets with one driver and shared storage; concurrent append, multiple drivers, and mixing serial and distributed writers are explicitly unsupported.

## How was this tested (or how to run locally)

- Tests added: `tests/datasets/test_distributed.py` and streaming-sharding coverage in `tests/datasets/test_streaming.py`.
- Ran formatting and linting:
  ```bash
  uv run --python python3.12 --locked --extra dev --extra test --extra dataset python -m ruff format --check src/lerobot/datasets/distributed.py src/lerobot/datasets/dataset_writer.py src/lerobot/datasets/lerobot_dataset.py src/lerobot/datasets/streaming_dataset.py tests/datasets/test_distributed.py tests/datasets/test_streaming.py
  uv run --python python3.12 --locked --extra dev --extra test --extra dataset python -m ruff check src/lerobot/datasets/distributed.py src/lerobot/datasets/dataset_writer.py src/lerobot/datasets/lerobot_dataset.py src/lerobot/datasets/streaming_dataset.py tests/datasets/test_distributed.py tests/datasets/test_streaming.py
Ran focused write and regression tests: 57 passed.
Ran streaming consumer-sharding tests: 3 passed.
The full tests/datasets suite was attempted, but collection is blocked in the local environment before this PR's tests run: installed TorchCodec cannot load against system FFmpeg 5.1 (libavutil.so.57; the wheel probes incompatible FFmpeg ABI libraries). CI should run this suite in its supported runtime.
Quick reproduction is documented in docs/source/distributed_dataset.mdx: create a driver plan, send one spec to each multiprocessing/Ray worker, collect results, then call driver.commit_distributed_results(plan, results).

Checklist (required before merge)
[x] Linting/formatting run (ruff format/check; pre-commit run -a was not run)
[ ] All tests pass locally (focused coverage passes; full dataset suite is blocked by the local TorchCodec/FFmpeg ABI)
[x] Documentation updated
[ ] CI is green
[ ] Community Review: I have reviewed another contributor's open PR and linked it here: N/A
Reviewer notes

Please focus review on:
the driver/worker ownership boundary in src/lerobot/datasets/distributed.py;
artifact validation and atomic metadata publication/rollback;
the one-artifact-per-episode trade-off for retry safety;
rank × DataLoader-worker stream shard assignment in StreamingLeRobotDataset.
Anyone in the community is welcome to review this PR.