### PR TITLE
perf(smolvla): precompute the RoPE sin/cos cache instead of rebuilding it per call

### DIFF
--- a/src/lerobot/policies/smolvla/smolvlm_with_expert.py
+++ b/src/lerobot/policies/smolvla/smolvlm_with_expert.py
@@ -38,30 +38,64 @@ else:
     SmolVLMForConditionalGeneration = None
 
 
-def apply_rope(x, positions, max_wavelength=10_000):
+class RotaryPositionalEmbeddings(nn.Module):
+    """Rotary Positional Embeddings (RoPE) with the sin/cos tables precomputed up to
+    ``max_seq_len`` and indexed by position id at rotation time.
+
+    Keeps the split-half pairing SmolVLA checkpoints were trained with (dim ``j`` rotates
+    with dim ``j + dim/2``). Position ids are integers, so the lookup is exact: for ids in
+    ``[0, max_seq_len)`` the output is bitwise-identical to rebuilding the tables per call.
+
+    Args:
+        dim: head dimension the rotation is applied over.
+        max_seq_len: largest position id the cache covers (SmolVLA sequences are ~700
+            tokens); larger ids raise an indexing error.
+        base: base of the geometric progression of rotation frequencies.
     """
-    Applies RoPE positions [B, L] to x [B, L, H, D].
-    """
-    d_half = x.shape[-1] // 2
-    device = x.device
-    dtype = x.dtype
-    x = x.to(torch.float32)
 
-    freq_exponents = (2.0 / x.shape[-1]) * torch.arange(d_half, dtype=torch.float32, device=device)
-    timescale = max_wavelength**freq_exponents
-    radians = positions[..., None].to(torch.float32) / timescale[None, None, :].to(torch.float32)
+    def __init__(self, dim: int, max_seq_len: int = 8192, base: int = 10_000):
+        super().__init__()
+        self.dim = dim
+        self.max_seq_len = max_seq_len
+        self.base = base
+        self.rope_init()
 
-    radians = radians[..., None, :]
+    def rope_init(self) -> None:
+        """(Re)build the sin/cos cache on the module's current device."""
+        device = self.sin.device if hasattr(self, "sin") else None
+        freq_exponents = (2.0 / self.dim) * torch.arange(self.dim // 2, dtype=torch.float32, device=device)
+        timescale = self.base**freq_exponents
+        positions = torch.arange(self.max_seq_len, dtype=torch.float32, device=device)
+        radians = positions[:, None] / timescale[None, :]
+        self.register_buffer("sin", torch.sin(radians), persistent=False)  # [max_seq_len, dim/2]
+        self.register_buffer("cos", torch.cos(radians), persistent=False)
 
-    sin = torch.sin(radians)  # .to(dtype=dtype)
-    cos = torch.cos(radians)  # .to(dtype=dtype)
+    def _apply(self, fn, recurse=True):
+        # Rebuild on every move/cast: sin/cos kernels differ across devices at the ulp level.
+        ret = super()._apply(fn, recurse)
+        self.rope_init()
+        return ret
 
-    x1, x2 = x.split(d_half, dim=-1)
-    res = torch.empty_like(x)
-    res[..., :d_half] = x1 * cos - x2 * sin
-    res[..., d_half:] = x2 * cos + x1 * sin
+    def forward(self, x: torch.Tensor, positions: torch.Tensor, rebase: bool = False) -> torch.Tensor:
+        """Rotate ``x`` [B, L, H, D] at ``positions`` [B, L].
 
-    return res.to(dtype)
+        With ``rebase=True``, positions are first shifted to start at 0 (the
+        action expert's convention for its cross-attention query).
+        """
+        if rebase:
+            positions = positions - torch.min(positions, dim=1, keepdim=True).values
+        sin = self.sin[positions][:, :, None, :]  # [B, L, 1, dim/2]
+        cos = self.cos[positions][:, :, None, :]
+
+        d_half = self.dim // 2
+        dtype = x.dtype
+        x = x.to(torch.float32)
+        x1, x2 = x.split(d_half, dim=-1)
+        res = torch.empty_like(x)
+        res[..., :d_half] = x1 * cos - x2 * sin
+        res[..., d_half:] = x2 * cos + x1 * sin
+
+        return res.to(dtype)
 
 
 def get_intermediate_size(hidden_dim, ffn_dim_multiplier=4, multiple_of=256):
@@ -145,6 +179,7 @@ class SmolVLMWithExpertModel(nn.Module):
         self.attention_mode = attention_mode
         self.expert_hidden_size = lm_expert_config.hidden_size
         self.set_requires_grad()
+        self.rope = RotaryPositionalEmbeddings(config.text_config.head_dim)
 
     def get_vlm_model(self):
         return self.vlm.model
@@ -266,8 +301,8 @@ class SmolVLMWithExpertModel(nn.Module):
         attention_mask_ = _attention_mask
         position_ids_ = _position_ids
 
-        query_states = apply_rope(query_states, position_ids_)
-        key_states = apply_rope(key_states, position_ids_)
+        query_states = self.rope(query_states, position_ids_)
+        key_states = self.rope(key_states, position_ids_)
 
         if use_cache:
             # `DynamicCache` stores tensors as [batch, heads, seq, head_dim]; this module works with
@@ -325,8 +360,8 @@ class SmolVLMWithExpertModel(nn.Module):
             value_states = layer.self_attn.v_proj(hidden_states).view(hidden_shape)
 
             # B,L,H,D with L sequence length, H number of heads, D head dim
-            query_states = apply_rope(query_state, position_id)
-            key_states = apply_rope(key_state, position_id)
+            query_states = self.rope(query_state, position_id)
+            key_states = self.rope(key_state, position_id)
 
             att_output = attention_interface(
                 prefix_attention_mask, batch_size, head_dim, query_states, key_states, value_states
@@ -369,14 +404,12 @@ class SmolVLMWithExpertModel(nn.Module):
                 *_value_states.shape[:-1], -1, expert_layer.self_attn.head_dim
             )
 
-            expert_position_id = (
-                expert_position_id - torch.min(expert_position_id, dim=1, keepdim=True).values
-            )  # start from 0
             expert_attention_mask = attention_mask[
                 :, -inputs_embeds[1].shape[1] :, : expert_key_states.shape[1] :
             ]  # take into account kv
 
-            expert_query_states = apply_rope(expert_query_state, expert_position_id)
+            # rebase=True: expert positions start from 0
+            expert_query_states = self.rope(expert_query_state, expert_position_id, rebase=True)
 
             att_output = attention_interface(
                 expert_attention_mask,

--- a/tests/policies/smolvla/test_smolvla_rope.py
+++ b/tests/policies/smolvla/test_smolvla_rope.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python
+
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test that the cached SmolVLA RoPE matches the closed form it replaces."""
+
+import pytest
+import torch
+
+from lerobot.policies.smolvla.smolvlm_with_expert import RotaryPositionalEmbeddings
+from lerobot.utils.random_utils import set_seed
+
+
+def apply_rope_reference(x, positions, max_wavelength=10_000):
+    """The per-call implementation `RotaryPositionalEmbeddings` replaces, kept verbatim."""
+    d_half = x.shape[-1] // 2
+    device = x.device
+    dtype = x.dtype
+    x = x.to(torch.float32)
+
+    freq_exponents = (2.0 / x.shape[-1]) * torch.arange(d_half, dtype=torch.float32, device=device)
+    timescale = max_wavelength**freq_exponents
+    radians = positions[..., None].to(torch.float32) / timescale[None, None, :].to(torch.float32)
+
+    radians = radians[..., None, :]
+
+    sin = torch.sin(radians)
+    cos = torch.cos(radians)
+
+    x1, x2 = x.split(d_half, dim=-1)
+    res = torch.empty_like(x)
+    res[..., :d_half] = x1 * cos - x2 * sin
+    res[..., d_half:] = x2 * cos + x1 * sin
+
+    return res.to(dtype)
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+@pytest.mark.parametrize("head_dim", [64, 128])
+def test_rope_cache_matches_closed_form(dtype, head_dim):
+    """Cached lookups are bitwise-identical to recomputing the tables per call."""
+    set_seed(1000)
+    batch, seq_len, num_heads = 2, 48, 4
+    x = torch.randn(batch, seq_len, num_heads, head_dim, dtype=dtype)
+    positions = torch.arange(seq_len).unsqueeze(0).expand(batch, seq_len)
+
+    rope = RotaryPositionalEmbeddings(head_dim)
+
+    assert torch.equal(rope(x, positions), apply_rope_reference(x, positions))
+
+
+def test_rope_cache_matches_closed_form_with_offset_positions():
+    """Position ids of a suffix (offset, non-contiguous across the batch) also match."""
+    set_seed(1000)
+    head_dim = 64
+    x = torch.randn(2, 8, 4, head_dim)
+    positions = torch.tensor([[600, 601, 602, 603, 604, 605, 606, 607], [12, 13, 14, 15, 16, 17, 18, 19]])
+
+    rope = RotaryPositionalEmbeddings(head_dim)
+
+    assert torch.equal(rope(x, positions), apply_rope_reference(x, positions))
+
+
+def test_rope_rebase_matches_explicit_shift():
+    """`rebase=True` is the caller-side `positions - positions.min()` it replaces."""
+    set_seed(1000)
+    head_dim = 64
+    x = torch.randn(2, 8, 4, head_dim)
+    positions = torch.tensor([[600, 601, 602, 603, 604, 605, 606, 607], [12, 13, 14, 15, 16, 17, 18, 19]])
+    shifted = positions - torch.min(positions, dim=1, keepdim=True).values
+
+    rope = RotaryPositionalEmbeddings(head_dim)
+
+    assert torch.equal(rope(x, positions, rebase=True), apply_rope_reference(x, shifted))
+
+
+def test_rope_cache_is_not_in_state_dict():
+    """The cache is derived from position ids only, so checkpoints stay unchanged."""
+    rope = RotaryPositionalEmbeddings(64)
+
+    assert rope.state_dict() == {}
+
+
+def test_rope_cache_survives_dtype_cast():
+    """A cast rebuilds the cache in float32, keeping the rotation exact in low precision."""
+    set_seed(1000)
+    head_dim = 64
+    x = torch.randn(2, 16, 4, head_dim, dtype=torch.bfloat16)
+    positions = torch.arange(16).unsqueeze(0).expand(2, 16)
+
+    rope = RotaryPositionalEmbeddings(head_dim).to(torch.bfloat16)
+
+    assert rope.sin.dtype == torch.float32
+    assert torch.equal(rope(x, positions), apply_rope_reference(x, positions))


### PR DESCRIPTION
## Summary / Motivation

**Precomputes the SmolVLA RoPE once instead of rebuilding them on every flow matching step. 
`-11.6%` inference latency at batch size 1.**

- **Motivation:** `apply_rope` is a table build (`arange`, `pow`, `div`, `sin`, `cos`) glued to the rotation itself. The build runs **272 times per action chunk** for only **3 distinct position tensors**, and at batch size 1 SmolVLA is dispatch-bound, so those rebuilds are visible latency.
- **Shape:** the tables are a pure function of **integer** position ids, so precompute them to `max_seq_len` and index by position id at rotation time. 

## Related issues

- Fixes / Closes: #4374

- Related: #4181 — **does not depend on it**; this PR touches only `apply_rope`, and the two merge cleanly in either order.

## What changed

- **`apply_rope` → `RotaryPositionalEmbeddings`** (`smolvlm_with_expert.py`), one module owned by `SmolVLMWithExpertModel` and shared by the VLM and expert paths (both use `text_config.head_dim`). The caller-side `positions - positions.min()` at the expert cross-attention query becomes `rebase=True`.
- **Compatibility:** **no breaking changes.** The cache is a **non-persistent buffer**, so checkpoints load with 0 missing / 0 unexpected keys and no migration. The module-level `apply_rope` name is removed; nothing in `src/` or `tests/` imported it.

## Results

| check | result |
|---|---|
| Action chunk, `torch.equal` | **True**, max abs diff **0.0** — both `cross_attn` and `self_attn` modes |
| Checkpoint load, `strict=True` | **0 missing / 0 unexpected keys**, no `rope` key in `state_dict` |
| Training, 200 steps (fine-tuned ckpt, bs 8) | **loss and grad norm identical** at all 20 logged steps [2] |

Performance — mean ± std over **3 rounds**, arms alternated within each round, H100:

| setting | main | this PR | delta |
|---|---:|---:|---|
| **Inference, batch 1** (ms/chunk) | 161.4 ± 2.7 | **142.7 ± 2.1** | **−11.6%** (≈7σ) |
| LIBERO eval, batch 20 (ms/call, CUDA-synced) | 258.4 ± 3.0 | 234.8 ± 1.4 | −9.1% |
| Compiled training (ms/step) | 24.7 ± 0.2 | 24.8 ± 0.5 | **±0**, as expected — inductor fuses the rebuild |
| Training, 500 steps (`updt_s`, ms) | 115.8 ± 2.5 | 111.2 ± 0.6 | −4.0% nominal |

## How was this tested (or how to run locally)

- **New tests:** `tests/policies/smolvla/test_smolvla_rope.py` (8) — parity with the closed form across dtypes and head dims, offset and rebased position ids, an empty `state_dict`, and a dtype cast (which exercises the cache rebuild on device/dtype moves).

  ```bash
  pytest -q tests/policies/smolvla/ tests/processor/test_smolvla_processor.py
  ```

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run --files`, both changed files)
- [x] All tests pass locally (`pytest tests/policies/smolvla/ tests/processor/test_smolvla_processor.py`)
- [ ] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: # (insert PR number/link)

## Reviewer notes

1. **`max_seq_len=8192`** covers SmolVLA's ~700-token sequences with room to spare, at 2 MB fp32. 
2. **`rebase=True` still calls `torch.min` per cross-attention layer.** 