### PR TITLE
perf(dataset): read episodes metadata once per file when reindexing

### DIFF
--- a/src/lerobot/datasets/dataset_tools.py
+++ b/src/lerobot/datasets/dataset_tools.py
@@ -82,12 +82,20 @@ from .video_utils import (
 )
 
 
-def _load_episode_with_stats(src_dataset: LeRobotDataset, episode_idx: int) -> dict:
+def _load_episode_with_stats(
+    src_dataset: LeRobotDataset,
+    episode_idx: int,
+    cache: dict[Path, pd.DataFrame] | None = None,
+) -> dict:
     """Load a single episode's metadata including stats from parquet file.
 
     Args:
         src_dataset: Source dataset
         episode_idx: Episode index to load
+        cache: Optional single-slot cache holding the last episodes metadata file read. Callers
+            looping over many episodes should create one dict and pass it to every call: episodes
+            are laid out in file order, so this turns one parquet read per episode into one per
+            metadata file. Only the most recent file is kept, so peak memory stays at one file.
 
     Returns:
         dict containing episode metadata and stats
@@ -97,7 +105,17 @@ def _load_episode_with_stats(src_dataset: LeRobotDataset, episode_idx: int) -> d
     file_idx = ep_meta["meta/episodes/file_index"]
 
     parquet_path = src_dataset.root / DEFAULT_EPISODES_PATH.format(chunk_index=chunk_idx, file_index=file_idx)
-    df = pd.read_parquet(parquet_path)
+
+    if cache is None:
+        df = pd.read_parquet(parquet_path)
+    elif parquet_path in cache:
+        df = cache[parquet_path]
+    else:
+        df = pd.read_parquet(parquet_path)
+        # Drop the previous file before caching the new one: episodes are visited in file order,
+        # so an older entry is never read again and would only pin memory.
+        cache.clear()
+        cache[parquet_path] = df
 
     episode_row = df[df["episode_index"] == episode_idx].iloc[0]
 
@@ -870,11 +888,12 @@ def _copy_and_reindex_episodes_metadata(
 
     all_stats = []
     total_frames = 0
+    episodes_df_cache: dict[Path, pd.DataFrame] = {}
 
     for old_idx, new_idx in tqdm(
         sorted(episode_mapping.items(), key=lambda x: x[1]), desc="Processing episodes metadata"
     ):
-        src_episode_full = _load_episode_with_stats(src_dataset, old_idx)
+        src_episode_full = _load_episode_with_stats(src_dataset, old_idx, episodes_df_cache)
 
         src_episode = src_dataset.meta.episodes[old_idx]
 

--- a/tests/datasets/test_dataset_tools.py
+++ b/tests/datasets/test_dataset_tools.py
@@ -18,6 +18,7 @@
 from unittest.mock import patch
 
 import numpy as np
+import pandas as pd
 import pytest
 import torch
 
@@ -26,6 +27,7 @@ pytest.importorskip("datasets", reason="datasets is required (install lerobot[da
 
 from lerobot.configs import DepthEncoderConfig, RGBEncoderConfig
 from lerobot.datasets.dataset_tools import (
+    _load_episode_with_stats,
     add_features,
     convert_image_to_video_dataset,
     delete_episodes,
@@ -36,7 +38,7 @@ from lerobot.datasets.dataset_tools import (
     remove_feature,
     split_dataset,
 )
-from lerobot.datasets.io_utils import load_info
+from lerobot.datasets.io_utils import load_episodes, load_info
 from tests.datasets.test_video_encoding import require_h264, require_hevc, require_libsvtav1
 from tests.fixtures.constants import DUMMY_DEPTH_FEATURES, DUMMY_DEPTH_KEY
 from tests.fixtures.dataset_factories import add_frames
@@ -1555,3 +1557,30 @@ def test_reencode_dataset_multi_key_multiprocessing(
     for vk in dataset.meta.video_keys:
         persisted_encoder = RGBEncoderConfig.from_video_info(persisted_info.features[vk].get("info", {}))
         assert persisted_encoder == target_cfg
+
+
+def test_load_episode_with_stats_reads_each_metadata_file_once(sample_dataset):
+    """The optional cache reads a metadata file once per file instead of once per episode.
+
+    Without it, editing a dataset re-read the whole episodes metadata parquet for every episode,
+    which dominates runtime on datasets with many episodes.
+    """
+    num_episodes = sample_dataset.meta.total_episodes
+    if sample_dataset.meta.episodes is None:
+        sample_dataset.meta.episodes = load_episodes(sample_dataset.meta.root)
+
+    uncached = [_load_episode_with_stats(sample_dataset, idx) for idx in range(num_episodes)]
+
+    cache = {}
+    with patch("lerobot.datasets.dataset_tools.pd.read_parquet", wraps=pd.read_parquet) as spy_read_parquet:
+        cached = [_load_episode_with_stats(sample_dataset, idx, cache) for idx in range(num_episodes)]
+
+    # The fixture's episodes all live in a single metadata file, so one read covers all of them.
+    assert spy_read_parquet.call_count == 1
+    assert len(cache) == 1
+
+    assert [row["episode_index"] for row in cached] == list(range(num_episodes))
+    for cached_row, uncached_row in zip(cached, uncached, strict=True):
+        assert cached_row.keys() == uncached_row.keys()
+        for key in cached_row:
+            np.testing.assert_array_equal(cached_row[key], uncached_row[key])


### PR DESCRIPTION
## Summary / Motivation

`_copy_and_reindex_episodes_metadata` calls `_load_episode_with_stats` once per episode, and that
helper re-read the **entire** episodes metadata parquet file on every call. Cost therefore scaled
with `episodes × file size` instead of with the data actually needed. As reported in #3596, on a
~10k-episode dataset whose metadata file is ~130 MB, `delete_episodes` / `split_dataset` spent
around 8 hours in this loop.

Episodes are laid out in file order and both callers build `episode_mapping` from ascending source
indices, so the loop visits metadata files monotonically. Caching just the **last** file read is
therefore enough to collapse the reads to one per metadata file.

I kept the cache to a single slot rather than accumulating every file: an older entry can never be
read again given the iteration order, so keeping it would only pin memory. Peak memory stays at one
metadata file instead of growing with the dataset — worth noting because the surrounding loop
already accumulates per-episode stats in `all_stats`.

The cache is an optional argument, so `_load_episode_with_stats` keeps its previous behaviour when
called without one. If the iteration order ever stops being file-monotonic, the cache simply misses
and the function falls back to today's behaviour — it cannot return a stale row.

## Related issues

- Fixes: #3596

## What changed

- `_load_episode_with_stats` accepts an optional single-slot `cache` mapping the metadata parquet
  path to its loaded `DataFrame`. Without it, behaviour is unchanged.
- `_copy_and_reindex_episodes_metadata` creates one cache for its loop, so each episodes metadata
  file is read once instead of once per episode. This is the path used by `delete_episodes` and
  `split_dataset`.
- No public API or on-disk format change; no migration needed.

## How was this tested (or how to run locally)

- Added `test_load_episode_with_stats_reads_each_metadata_file_once`, which asserts the metadata
  file is read once for a 5-episode fixture, that the cache holds a single entry, and that every
  cached row is element-wise identical to the uncached row (so the speedup cannot mask a wrong row).

```bash
pytest -q tests/datasets/test_dataset_tools.py -k load_episode_with_stats
```

- The new test was confirmed to fail on `main` without the fix (`assert 5 == 1`, i.e. one read per
  episode) and to pass with it.
- Full file green locally: `pytest -q tests/datasets/test_dataset_tools.py` → 61 passed.
- `ruff check` and `ruff format` clean on both changed files.

## Checklist (required before merge)

- [x] Linting/formatting run (`ruff check` / `ruff format` on the changed files)
- [x] All tests pass locally (`pytest -q tests/datasets/test_dataset_tools.py` → 61 passed)
- [ ] Documentation updated — n/a, internal helper with no doc surface
- [ ] CI is green
- [x] Community Review: I have reviewed another contributor's open PR and linked it here: #4172

## Reviewer notes

- The correctness argument rests on the loop visiting metadata files monotonically. Both callers
  (`delete_episodes`, `split_dataset`) build `episode_mapping` from ascending source episode
  indices and the loop sorts by destination index, so ascending destination implies ascending
  source. Worth a second pair of eyes in case a future caller breaks that assumption — the failure
  mode is only a lost speedup, never a wrong row, but it is the load-bearing assumption.
- Note that `pre-commit run -a` was not run in full: this machine could not install the complete
  dev environment, so the ruff check/format hooks were run directly on the changed files instead.
- Community review done: I reviewed #4172 (quantile aggregation in `compute_stats.py`).

---

Disclosure per [AI_POLICY.md](https://github.com/huggingface/lerobot/blob/main/AI_POLICY.md): this
change was written with AI assistance, then reviewed and tested locally as described above.

