### PR TITLE
Add OpenARM v1 Dynamixel leader teleoperator

### DIFF
--- a/src/lerobot/scripts/lerobot_calibrate.py
+++ b/src/lerobot/scripts/lerobot_calibrate.py
@@ -63,6 +63,7 @@ from lerobot.teleoperators import (  # noqa: F401
     omx_leader,
     openarm_leader,
     openarm_mini,
+    openarm_v1_dynamixel,
     rebot_102_leader,
     so_leader,
     unitree_g1,

--- a/src/lerobot/scripts/lerobot_find_joint_limits.py
+++ b/src/lerobot/scripts/lerobot_find_joint_limits.py
@@ -66,6 +66,7 @@ from lerobot.teleoperators import (  # noqa: F401
     omx_leader,
     openarm_leader,
     openarm_mini,
+    openarm_v1_dynamixel,
     rebot_102_leader,
     so_leader,
 )

--- a/src/lerobot/scripts/lerobot_record.py
+++ b/src/lerobot/scripts/lerobot_record.py
@@ -145,6 +145,7 @@ from lerobot.teleoperators import (  # noqa: F401
     omx_leader,
     openarm_leader,
     openarm_mini,
+    openarm_v1_dynamixel,
     reachy2_teleoperator,
     rebot_102_leader,
     so_leader,

--- a/src/lerobot/scripts/lerobot_rollout.py
+++ b/src/lerobot/scripts/lerobot_rollout.py
@@ -186,6 +186,7 @@ from lerobot.teleoperators import (  # noqa: F401
     omx_leader,
     openarm_leader,
     openarm_mini,
+    openarm_v1_dynamixel,
     reachy2_teleoperator,
     rebot_102_leader,
     so_leader,

--- a/src/lerobot/scripts/lerobot_setup_motors.py
+++ b/src/lerobot/scripts/lerobot_setup_motors.py
@@ -48,6 +48,7 @@ from lerobot.teleoperators import (  # noqa: F401
     make_teleoperator_from_config,
     omx_leader,
     openarm_mini,
+    openarm_v1_dynamixel,
     rebot_102_leader,
     so_leader,
 )

--- a/src/lerobot/scripts/lerobot_teleoperate.py
+++ b/src/lerobot/scripts/lerobot_teleoperate.py
@@ -116,6 +116,7 @@ from lerobot.teleoperators import (  # noqa: F401
     omx_leader,
     openarm_leader,
     openarm_mini,
+    openarm_v1_dynamixel,
     reachy2_teleoperator,
     rebot_102_leader,
     so_leader,

--- a/src/lerobot/teleoperators/openarm_v1_dynamixel/__init__.py
+++ b/src/lerobot/teleoperators/openarm_v1_dynamixel/__init__.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .config_openarm_v1_dynamixel import OpenArmV1DynamixelConfig, OpenArmV1DynamixelConfigBase
+from .openarm_v1_dynamixel import OpenArmV1Dynamixel
+
+__all__ = ["OpenArmV1Dynamixel", "OpenArmV1DynamixelConfig", "OpenArmV1DynamixelConfigBase"]

--- a/src/lerobot/teleoperators/openarm_v1_dynamixel/config_openarm_v1_dynamixel.py
+++ b/src/lerobot/teleoperators/openarm_v1_dynamixel/config_openarm_v1_dynamixel.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+
+from ..config import TeleoperatorConfig
+
+
+@dataclass
+class OpenArmV1DynamixelConfigBase:
+    """Base configuration for the OpenARM v1 Dynamixel leader (XL330-M288, 2x7DOF + 2 grippers).
+
+    Unlike :class:`OpenArmMiniConfig`, which drives one arm per serial port, this leader
+    carries **both arms on a single bus**: an OpenRB-150 board hosts all 16 servos
+    (right arm ids 1-8, left arm ids 9-16). One instance therefore emits actions for
+    both arms, and there is no bimanual wrapper.
+    """
+
+    # Serial port for the OpenRB-150 board hosting all 16 servos
+    # (e.g. "/dev/serial/by-id/usb-ROBOTIS_OpenRB-150_...-if00").
+    port: str
+
+    # Emit joint positions in degrees. Grippers are always normalised to 0-100
+    # and converted to follower degrees on readout.
+    use_degrees: bool = True
+
+    # Emit the two gripper joints alongside the 14 arm joints. Turn off when the
+    # follower is configured without grippers (7 axes per arm).
+    include_gripper: bool = True
+
+
+@TeleoperatorConfig.register_subclass("openarm_v1_dynamixel")
+@dataclass
+class OpenArmV1DynamixelConfig(TeleoperatorConfig, OpenArmV1DynamixelConfigBase):
+    pass

--- a/src/lerobot/teleoperators/openarm_v1_dynamixel/openarm_v1_dynamixel.py
+++ b/src/lerobot/teleoperators/openarm_v1_dynamixel/openarm_v1_dynamixel.py
@@ -18,9 +18,9 @@ import logging
 import time
 from typing import Any
 
+from lerobot.lerobot_types import RobotAction
 from lerobot.motors import Motor, MotorCalibration, MotorNormMode
 from lerobot.motors.dynamixel import DynamixelMotorsBus, OperatingMode
-from lerobot.types import RobotAction
 from lerobot.utils.decorators import check_if_already_connected, check_if_not_connected
 
 from ..teleoperator import Teleoperator

--- a/src/lerobot/teleoperators/openarm_v1_dynamixel/openarm_v1_dynamixel.py
+++ b/src/lerobot/teleoperators/openarm_v1_dynamixel/openarm_v1_dynamixel.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import time
+from typing import Any
+
+from lerobot.motors import Motor, MotorCalibration, MotorNormMode
+from lerobot.motors.dynamixel import DynamixelMotorsBus, OperatingMode
+from lerobot.types import RobotAction
+from lerobot.utils.decorators import check_if_already_connected, check_if_not_connected
+
+from ..teleoperator import Teleoperator
+from .config_openarm_v1_dynamixel import OpenArmV1DynamixelConfig
+
+logger = logging.getLogger(__name__)
+
+MODEL = "xl330-m288"
+
+ARM_JOINTS = [f"joint_{i}" for i in range(1, 8)]
+
+# First servo id of each arm. Both arms are daisy-chained onto one OpenRB-150 bus:
+# right arm ids 1-8, left arm ids 9-16 (7 joints + gripper each).
+SIDE_BASE_ID = {"right": 1, "left": 9}
+
+# Per-side motor direction flips applied during readout. Some servos are mounted
+# mirrored, so the leader reads the opposite sign from what the follower expects.
+# These are fixed by the mechanics, not measured during calibration.
+SIDE_MOTORS_TO_FLIP: dict[str, list[str]] = {
+    "right": ["joint_2", "joint_4", "joint_7"],
+    "left": ["joint_2", "joint_7"],
+}
+
+# Gripper goes out as follower degrees: teleop 0 (closed) -> 0 deg,
+# teleop 100 (fully open) -> -65 deg. Same convention as `openarm_mini`,
+# so either leader can drive the same follower.
+GRIPPER_TELEOP_TO_DEGREES = -0.65
+
+
+class OpenArmV1Dynamixel(Teleoperator):
+    """OpenARM v1 Dynamixel leader (XL330-M288, both arms on one OpenRB-150 bus).
+
+    This is the bimanual device itself, not a single arm: all 16 servos share one
+    serial port, so a single instance reads both arms and emits
+    ``{side}_{joint}.pos`` actions for a ``bi_openarm_follower``.
+
+    For the Feetech variant, which uses one port per arm, see :class:`OpenArmMini`
+    and :class:`BiOpenArmMini`.
+    """
+
+    config_class = OpenArmV1DynamixelConfig
+    name = "openarm_v1_dynamixel"
+
+    def __init__(self, config: OpenArmV1DynamixelConfig):
+        super().__init__(config)
+        self.config = config
+
+        norm_mode_body = MotorNormMode.DEGREES if config.use_degrees else MotorNormMode.RANGE_M100_100
+        motors: dict[str, Motor] = {}
+        for side, base_id in SIDE_BASE_ID.items():
+            for offset, joint in enumerate(ARM_JOINTS):
+                motors[f"{side}_{joint}"] = Motor(base_id + offset, MODEL, norm_mode_body)
+            motors[f"{side}_gripper"] = Motor(base_id + 7, MODEL, MotorNormMode.RANGE_0_100)
+
+        self.bus = DynamixelMotorsBus(
+            port=self.config.port,
+            motors=motors,
+            calibration=self.calibration,
+        )
+
+    @property
+    def _motors_to_flip(self) -> set[str]:
+        return {f"{side}_{j}" for side, joints in SIDE_MOTORS_TO_FLIP.items() for j in joints}
+
+    @property
+    def _emitted_motors(self) -> list[str]:
+        if self.config.include_gripper:
+            return list(self.bus.motors)
+        return [m for m in self.bus.motors if not m.endswith("_gripper")]
+
+    @property
+    def action_features(self) -> dict[str, type]:
+        return {f"{motor}.pos": float for motor in self._emitted_motors}
+
+    @property
+    def feedback_features(self) -> dict[str, type]:
+        return {}
+
+    @property
+    def is_connected(self) -> bool:
+        return self.bus.is_connected
+
+    @check_if_already_connected
+    def connect(self, calibrate: bool = True) -> None:
+        self.bus.connect()
+        if not self.is_calibrated and calibrate:
+            self.calibrate()
+
+        self.configure()
+        logger.info(f"{self} connected.")
+
+    @property
+    def is_calibrated(self) -> bool:
+        return self.bus.is_calibrated
+
+    def calibrate(self) -> None:
+        """Run calibration for both arms.
+
+        1. Disable torque so the arms can be moved by hand
+        2. Ask the operator for the home pose (both arms hanging, grippers closed)
+        3. Set that as zero via half-turn homing
+        4. Capture each gripper's closed/open range
+        5. Save
+
+        The leader is never driven, so torque stays off for the whole procedure.
+        """
+        if self.calibration:
+            user_input = input(
+                f"Press ENTER to use existing calibration for {self.id}, "
+                f"or type 'c' and press ENTER to run new calibration: "
+            )
+            if user_input.strip().lower() != "c":
+                logger.info(f"Using existing calibration for {self.id}")
+                self.bus.write_calibration(self.calibration)
+                return
+
+        logger.info(f"\nRunning calibration for {self}")
+
+        self.bus.disable_torque()
+        # EXTENDED_POSITION, not POSITION: in single-turn position mode a Dynamixel
+        # silently ignores a Homing_Offset outside +/-1024 pulses, which would leave the
+        # arm calibrated to the wrong zero with no error. The other Dynamixel leaders
+        # upstream do the same (`koch_leader`, `omx_leader`); the Feetech ones
+        # (`so_leader`, `openarm_mini`) use POSITION because that limit is Dynamixel-only.
+        for motor in self.bus.motors:
+            self.bus.write("Operating_Mode", motor, OperatingMode.EXTENDED_POSITION.value)
+
+        input(
+            "\nCalibration: Zero Position\n"
+            "Position both arms in the following configuration:\n"
+            "  - Both arms hanging straight down, elbows not bent\n"
+            "  - Both grippers closed\n"
+            "  - Let go of the arms before pressing ENTER\n"
+            "Press ENTER when ready..."
+        )
+
+        homing_offsets = self.bus.set_half_turn_homings()
+        logger.info("Zero position set for both arms.")
+
+        if self.calibration is None:
+            self.calibration = {}
+
+        motor_resolution = self.bus.model_resolution_table[MODEL]
+        max_res = motor_resolution - 1
+
+        for motor_name, motor in self.bus.motors.items():
+            if motor_name.endswith("_gripper"):
+                side = motor_name.rsplit("_", 1)[0]
+                input(
+                    f"\nGripper Calibration ({side})\n"
+                    f"Step 1: CLOSE the {side} gripper fully\n"
+                    "Press ENTER when it is closed..."
+                )
+                closed_pos = self.bus.read("Present_Position", motor_name, normalize=False)
+
+                input(
+                    f"\nStep 2: OPEN the {side} gripper fully\n"
+                    "Open it all the way -- this travel becomes the whole gripper range.\n"
+                    "Press ENTER when it is fully open..."
+                )
+                open_pos = self.bus.read("Present_Position", motor_name, normalize=False)
+
+                if closed_pos < open_pos:
+                    range_min, range_max, drive_mode = int(closed_pos), int(open_pos), 0
+                else:
+                    range_min, range_max, drive_mode = int(open_pos), int(closed_pos), 1
+
+                if range_min == range_max:
+                    raise ValueError(
+                        f"{motor_name}: closed and open positions are identical ({range_min}). "
+                        "The gripper did not move -- check its servo and calibrate again."
+                    )
+                logger.info(
+                    f"  {motor_name}: range set to [{range_min}, {range_max}] "
+                    f"(0=closed, 100=open, drive_mode={drive_mode})"
+                )
+            else:
+                range_min, range_max, drive_mode = 0, max_res, 0
+                logger.info(f"  {motor_name}: range set to [0, {max_res}] (full motor range)")
+
+            self.calibration[motor_name] = MotorCalibration(
+                id=motor.id,
+                drive_mode=drive_mode,
+                homing_offset=homing_offsets[motor_name],
+                range_min=range_min,
+                range_max=range_max,
+            )
+
+        self.bus.write_calibration(self.calibration)
+        self._save_calibration()
+        print(f"\nCalibration complete and saved to {self.calibration_fpath}")
+
+    def configure(self) -> None:
+        """Leave the leader limp so the operator can move it by hand.
+
+        Torque is never enabled on this device -- there is deliberately no
+        ``enable_torque``. If the arms feel stiff, another program is holding the bus.
+        """
+        self.bus.disable_torque()
+        self.bus.configure_motors()
+        for motor in self.bus.motors:
+            self.bus.write("Operating_Mode", motor, OperatingMode.EXTENDED_POSITION.value)
+
+    def setup_motors(self) -> None:
+        for motor in reversed(list(self.bus.motors)):
+            input(f"Connect the controller board to the '{motor}' motor only and press enter.")
+            self.bus.setup_motor(motor)
+            print(f"'{motor}' motor id set to {self.bus.motors[motor].id}")
+
+    @check_if_not_connected
+    def get_action(self) -> RobotAction:
+        start = time.perf_counter()
+
+        positions = self.bus.sync_read("Present_Position")
+
+        emitted = set(self._emitted_motors)
+        to_flip = self._motors_to_flip
+        action: dict[str, Any] = {}
+        for motor, val in positions.items():
+            if motor not in emitted:
+                continue
+            if motor.endswith("_gripper"):
+                # A gripper whose encoder counts *down* as it opens is recorded with
+                # drive_mode=1 during calibration. `DynamixelMotorsBus` sets
+                # `apply_drive_mode = False` (unlike the Feetech bus), so the RANGE_0_100
+                # normalisation never applies that flip for us -- undo it here, otherwise
+                # a fully open leader gripper would command the follower to clamp shut.
+                if self.calibration and self.calibration[motor].drive_mode:
+                    val = 100.0 - val
+                # teleop 0-100 -> follower degrees: 0 -> 0 deg, 100 -> -65 deg
+                action[f"{motor}.pos"] = val * GRIPPER_TELEOP_TO_DEGREES
+            else:
+                action[f"{motor}.pos"] = -val if motor in to_flip else val
+
+        dt_ms = (time.perf_counter() - start) * 1e3
+        logger.debug(f"{self} read action: {dt_ms:.1f}ms")
+        return action
+
+    def disable_torque(self) -> None:
+        self.bus.disable_torque()
+
+    @check_if_not_connected
+    def send_feedback(self, feedback: dict[str, float]) -> None:
+        raise NotImplementedError("The OpenARM v1 Dynamixel leader has no force feedback -- it is read-only.")
+
+    @check_if_not_connected
+    def disconnect(self) -> None:
+        self.bus.disconnect()
+        logger.info(f"{self} disconnected.")

--- a/src/lerobot/teleoperators/utils.py
+++ b/src/lerobot/teleoperators/utils.py
@@ -103,6 +103,10 @@ def make_teleoperator_from_config(config: TeleoperatorConfig) -> "Teleoperator":
         from .bi_openarm_mini import BiOpenArmMini
 
         return BiOpenArmMini(config)
+    elif config.type == "openarm_v1_dynamixel":
+        from .openarm_v1_dynamixel import OpenArmV1Dynamixel
+
+        return OpenArmV1Dynamixel(config)
     elif config.type == "rebot_102_leader":
         from .rebot_102_leader import RebotArm102Leader
 

--- a/tests/teleoperators/test_openarm_v1_dynamixel.py
+++ b/tests/teleoperators/test_openarm_v1_dynamixel.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from lerobot.motors import MotorCalibration
+from lerobot.teleoperators.openarm_v1_dynamixel import (
+    OpenArmV1Dynamixel,
+    OpenArmV1DynamixelConfig,
+)
+from lerobot.teleoperators.openarm_v1_dynamixel.openarm_v1_dynamixel import (
+    GRIPPER_TELEOP_TO_DEGREES,
+    SIDE_BASE_ID,
+    SIDE_MOTORS_TO_FLIP,
+)
+
+_MODULE = "lerobot.teleoperators.openarm_v1_dynamixel.openarm_v1_dynamixel"
+
+ALL_MOTORS = [
+    f"{side}_{joint}"
+    for side in ("right", "left")
+    for joint in [f"joint_{i}" for i in range(1, 8)] + ["gripper"]
+]
+
+
+def _make_leader(calibration: dict | None = None, **cfg_kwargs) -> OpenArmV1Dynamixel:
+    """Build a leader with the Dynamixel bus mocked out -- no hardware, no serial port."""
+    with patch(f"{_MODULE}.DynamixelMotorsBus") as bus_cls:
+        bus = bus_cls.return_value
+        bus.motors = {
+            name: MagicMock(id=SIDE_BASE_ID[name.split("_")[0]] + (i % 8))
+            for i, name in enumerate(ALL_MOTORS)
+        }
+        bus.is_connected = True
+        leader = OpenArmV1Dynamixel(
+            OpenArmV1DynamixelConfig(port="/dev/null", id="test_leader", **cfg_kwargs)
+        )
+    leader.calibration = calibration or {}
+    return leader
+
+
+def test_all_sixteen_servos_share_one_bus():
+    """Both arms hang off a single OpenRB-150 bus: right ids 1-8, left ids 9-16."""
+    leader = _make_leader()
+    assert len(leader.bus.motors) == 16
+    assert "right_joint_1" in leader.bus.motors
+    assert "left_gripper" in leader.bus.motors
+
+
+def test_action_features_cover_both_arms():
+    features = _make_leader().action_features
+    assert len(features) == 16
+    assert "right_joint_1.pos" in features
+    assert "left_gripper.pos" in features
+
+
+def test_include_gripper_false_drops_only_grippers():
+    features = _make_leader(include_gripper=False).action_features
+    assert len(features) == 14
+    assert not any("gripper" in key for key in features)
+
+
+def test_get_action_flips_mirrored_joints():
+    """Mirror-mounted servos read the opposite sign from what the follower expects."""
+    leader = _make_leader()
+    leader.bus.sync_read.return_value = dict.fromkeys(ALL_MOTORS, 10.0)
+
+    action = leader.get_action()
+
+    for side, joints in SIDE_MOTORS_TO_FLIP.items():
+        for joint in joints:
+            assert action[f"{side}_{joint}.pos"] == -10.0, f"{side}_{joint} should be flipped"
+    assert action["right_joint_1.pos"] == 10.0  # not in the flip list
+
+
+@pytest.mark.parametrize(
+    ("drive_mode", "raw", "expected_degrees"),
+    [
+        # Normally wired gripper: teleop 0 = closed -> 0 deg, 100 = open -> -65 deg.
+        (0, 0.0, 0.0),
+        (0, 100.0, -65.0),
+        # Reverse-wired gripper (encoder counts down while opening). `DynamixelMotorsBus`
+        # sets apply_drive_mode = False, so normalisation does NOT undo this for us --
+        # the teleoperator must, or a fully open leader gripper would clamp the follower.
+        (1, 100.0, 0.0),
+        (1, 0.0, -65.0),
+    ],
+)
+def test_gripper_drive_mode_applied_by_teleoperator(drive_mode, raw, expected_degrees):
+    calibration = {
+        "right_gripper": MotorCalibration(
+            id=8, drive_mode=drive_mode, homing_offset=0, range_min=0, range_max=4095
+        )
+    }
+    leader = _make_leader(calibration=calibration)
+    leader.bus.sync_read.return_value = {"right_gripper": raw}
+
+    action = leader.get_action()
+
+    assert action["right_gripper.pos"] == pytest.approx(expected_degrees)
+
+
+def test_gripper_scale_matches_openarm_mini():
+    """Both leaders drive the same follower, so the gripper scale must be identical."""
+    from lerobot.teleoperators.openarm_mini.openarm_mini import (
+        GRIPPER_TELEOP_TO_DEGREES as MINI_SCALE,
+    )
+
+    assert GRIPPER_TELEOP_TO_DEGREES == MINI_SCALE
+
+
+def test_calibration_uses_extended_position_mode():
+    """Single-turn POSITION silently ignores |Homing_Offset| > 1024 on Dynamixel."""
+    from lerobot.motors.dynamixel import OperatingMode
+
+    leader = _make_leader()
+    leader.bus.read.side_effect = [0, 100] * 2  # gripper closed/open captures
+    leader.bus.set_half_turn_homings.return_value = dict.fromkeys(ALL_MOTORS, 0)
+    leader.bus.model_resolution_table = {"xl330-m288": 4096}
+    leader.calibration = {}
+
+    with patch("builtins.input", return_value=""), patch.object(leader, "_save_calibration"):
+        leader.calibrate()
+
+    modes = {call.args[2] for call in leader.bus.write.call_args_list if call.args[0] == "Operating_Mode"}
+    assert modes == {OperatingMode.EXTENDED_POSITION.value}
+
+
+def test_send_feedback_not_implemented():
+    with pytest.raises(NotImplementedError):
+        _make_leader().send_feedback({})
+
+
+def test_resolvable_from_cli_type_string():
+    """`--teleop.type=openarm_v1_dynamixel` must reach the factory."""
+    from lerobot.teleoperators.utils import make_teleoperator_from_config
+
+    with patch(f"{_MODULE}.DynamixelMotorsBus"):
+        teleop = make_teleoperator_from_config(OpenArmV1DynamixelConfig(port="/dev/null", id="test_leader"))
+    assert isinstance(teleop, OpenArmV1Dynamixel)


### PR DESCRIPTION
## What this does

Adds `openarm_v1_dynamixel`, the Dynamixel variant of the OpenARM v1 leader arm. It drives the same `bi_openarm_follower` as the existing Feetech `openarm_mini`, so users can pick either leader for the same robot.

```bash
lerobot-teleoperate \
  --robot.type=bi_openarm_follower \
  --robot.left_arm_config.port=can1 --robot.left_arm_config.side=left \
  --robot.right_arm_config.port=can0 --robot.right_arm_config.side=right \
  --robot.id=openarm_v1 \
  --teleop.type=openarm_v1_dynamixel \
  --teleop.port=/dev/serial/by-id/usb-ROBOTIS_OpenRB-150_...-if00 \
  --teleop.id=openarm_v1_leader
```

## Why it isn't just another `openarm_mini`

`openarm_mini` uses one serial port per arm and composes two instances through `bi_openarm_mini`. This leader carries **both arms on a single bus**: an OpenRB-150 board hosts all 16 XL330-M288 servos (right arm ids 1-8, left arm ids 9-16). A single instance therefore reads both arms and emits `{side}_{joint}.pos`, and there is no bimanual wrapper to add.

## Two Dynamixel-specific details

These differ from the Feetech reference and are easy to get wrong, so they are called out in comments:

- **Calibration uses `EXTENDED_POSITION`, not `POSITION`.** In single-turn position mode a Dynamixel silently ignores a `Homing_Offset` outside ±1024 pulses, which would leave the arm calibrated to the wrong zero with no error. `koch_leader` and `omx_leader` already do this; the Feetech leaders use `POSITION` because the limit is Dynamixel-only.
- **The gripper `drive_mode` flip is applied in `get_action`.** `DynamixelMotorsBus` sets `apply_drive_mode = False`, so the `RANGE_0_100` normalisation never applies the flip that the Feetech bus does. Without undoing it here, a reverse-wired gripper would make a fully open leader command the follower to clamp shut.

The gripper scale (`0 -> 0°`, `100 -> -65°`) is identical to `openarm_mini`, so either leader drives the same follower consistently — there is a test asserting the two constants stay in sync.

## Safety

The leader is read-only and stays torque-off throughout. There is deliberately no `enable_torque`, and `feedback_features` is empty so `teleop_smooth_move_to` never engages it.

## Testing

`tests/teleoperators/test_openarm_v1_dynamixel.py` — 12 tests against a mocked bus, covering the bus layout, action features, `include_gripper`, per-side joint flips, both gripper drive modes, the `EXTENDED_POSITION` requirement, and CLI type resolution.

```
pytest tests/teleoperators/ -q
17 passed, 2 skipped
```

`ruff check` and `ruff format --check` are clean.

**Not yet exercised on hardware.** The mocked tests cover the logic; the calibration flow against real XL330-M288 servos has not been run. Happy to hold this until I can report a hardware run if you would prefer that.