### PR TITLE
feat(rollout): add action_horizon to RolloutConfig

### DIFF
--- a/docs/source/inference.mdx
+++ b/docs/source/inference.mdx
@@ -243,22 +243,23 @@ See the [Real-Time Chunking](./rtc) guide for details on tuning RTC parameters.
 
 ## Common Flags
 
-| Flag                              | Description                                                       | Default |
-| --------------------------------- | ----------------------------------------------------------------- | ------- |
-| `--policy.path`                   | **Required.** HF Hub model ID or local checkpoint path            | --      |
-| `--robot.type`                    | **Required.** Robot type (e.g. `so100_follower`, `koch_follower`) | --      |
-| `--robot.port`                    | Serial port for the robot                                         | --      |
-| `--robot.cameras`                 | Camera configuration (JSON dict)                                  | --      |
-| `--fps`                           | Control loop frequency                                            | 30      |
-| `--duration`                      | Run time in seconds (0 = infinite)                                | 0       |
-| `--device`                        | Torch device (`cpu`, `cuda`, `mps`)                               | auto    |
-| `--task`                          | Task description (used when no dataset is provided)               | --      |
-| `--display_data`                  | Stream telemetry to Rerun visualization                           | false   |
-| `--display_ip` / `--display_port` | Remote Rerun server address                                       | --      |
-| `--interpolation_multiplier`      | Action interpolation factor                                       | 1       |
-| `--use_torch_compile`             | Enable `torch.compile` for inference                              | false   |
-| `--resume`                        | Resume a previous recording session                               | false   |
-| `--play_sounds`                   | Vocal synthesis for events                                        | true    |
+| Flag                              | Description                                                           | Default |
+| --------------------------------- | --------------------------------------------------------------------- | ------- |
+| `--policy.path`                   | **Required.** HF Hub model ID or local checkpoint path                | --      |
+| `--robot.type`                    | **Required.** Robot type (e.g. `so100_follower`, `koch_follower`)     | --      |
+| `--robot.port`                    | Serial port for the robot                                             | --      |
+| `--robot.cameras`                 | Camera configuration (JSON dict)                                      | --      |
+| `--fps`                           | Control loop frequency                                                | 30      |
+| `--duration`                      | Run time in seconds (0 = infinite)                                    | 0       |
+| `--action_horizon`                | Maximum number of interpolated control actions to send (0 = infinite) | 0       |
+| `--device`                        | Torch device (`cpu`, `cuda`, `mps`)                                   | auto    |
+| `--task`                          | Task description (used when no dataset is provided)                   | --      |
+| `--display_data`                  | Stream telemetry to Rerun visualization                               | false   |
+| `--display_ip` / `--display_port` | Remote Rerun server address                                           | --      |
+| `--interpolation_multiplier`      | Action interpolation factor                                           | 1       |
+| `--use_torch_compile`             | Enable `torch.compile` for inference                                  | false   |
+| `--resume`                        | Resume a previous recording session                                   | false   |
+| `--play_sounds`                   | Vocal synthesis for events                                            | true    |
 
 ---
 

--- a/docs/source/inference.mdx
+++ b/docs/source/inference.mdx
@@ -243,23 +243,23 @@ See the [Real-Time Chunking](./rtc) guide for details on tuning RTC parameters.
 
 ## Common Flags
 
-| Flag                              | Description                                                           | Default |
-| --------------------------------- | --------------------------------------------------------------------- | ------- |
-| `--policy.path`                   | **Required.** HF Hub model ID or local checkpoint path                | --      |
-| `--robot.type`                    | **Required.** Robot type (e.g. `so100_follower`, `koch_follower`)     | --      |
-| `--robot.port`                    | Serial port for the robot                                             | --      |
-| `--robot.cameras`                 | Camera configuration (JSON dict)                                      | --      |
-| `--fps`                           | Control loop frequency                                                | 30      |
-| `--duration`                      | Run time in seconds (0 = infinite)                                    | 0       |
-| `--action_horizon`                | Maximum number of interpolated control actions to send (0 = infinite) | 0       |
-| `--device`                        | Torch device (`cpu`, `cuda`, `mps`)                                   | auto    |
-| `--task`                          | Task description (used when no dataset is provided)                   | --      |
-| `--display_data`                  | Stream telemetry to Rerun visualization                               | false   |
-| `--display_ip` / `--display_port` | Remote Rerun server address                                           | --      |
-| `--interpolation_multiplier`      | Action interpolation factor                                           | 1       |
-| `--use_torch_compile`             | Enable `torch.compile` for inference                                  | false   |
-| `--resume`                        | Resume a previous recording session                                   | false   |
-| `--play_sounds`                   | Vocal synthesis for events                                            | true    |
+| Flag                              | Description                                                       | Default |
+| --------------------------------- | ----------------------------------------------------------------- | ------- |
+| `--policy.path`                   | **Required.** HF Hub model ID or local checkpoint path            | --      |
+| `--robot.type`                    | **Required.** Robot type (e.g. `so100_follower`, `koch_follower`) | --      |
+| `--robot.port`                    | Serial port for the robot                                         | --      |
+| `--robot.cameras`                 | Camera configuration (JSON dict)                                  | --      |
+| `--fps`                           | Control loop frequency                                            | 30      |
+| `--duration`                      | Run time in seconds (0 = infinite)                                | 0       |
+| `--action_horizon`                | Maximum number of control actions to send (0 = infinite)          | 0       |
+| `--device`                        | Torch device (`cpu`, `cuda`, `mps`)                               | auto    |
+| `--task`                          | Task description (used when no dataset is provided)               | --      |
+| `--display_data`                  | Stream telemetry to Rerun visualization                           | false   |
+| `--display_ip` / `--display_port` | Remote Rerun server address                                       | --      |
+| `--interpolation_multiplier`      | Action interpolation factor                                       | 1       |
+| `--use_torch_compile`             | Enable `torch.compile` for inference                              | false   |
+| `--resume`                        | Resume a previous recording session                               | false   |
+| `--play_sounds`                   | Vocal synthesis for events                                        | true    |
 
 ---
 

--- a/src/lerobot/rollout/configs.py
+++ b/src/lerobot/rollout/configs.py
@@ -239,6 +239,7 @@ class RolloutConfig:
     # Runtime
     fps: float = 30.0
     duration: float = 0.0  # 0 = infinite (24/7 mode)
+    action_horizon: int = 0  # 0 = infinite (24/7 mode)
     interpolation_multiplier: int = 1
     device: str | None = None
     task: str = ""
@@ -381,6 +382,10 @@ class RolloutConfig:
             else:
                 self.device = auto_select_torch_device().type
                 logger.info("No policy config to resolve device from; auto-selected device: %s", self.device)
+
+        # --- Rollout length ---
+        if self.duration != 0 and self.action_horizon != 0:
+            raise ValueError("Cannot specify both --duration and --action_horizon")
 
     @classmethod
     def __get_path_fields__(cls) -> list[str]:

--- a/src/lerobot/rollout/configs.py
+++ b/src/lerobot/rollout/configs.py
@@ -384,6 +384,10 @@ class RolloutConfig:
                 logger.info("No policy config to resolve device from; auto-selected device: %s", self.device)
 
         # --- Rollout length ---
+        if self.duration < 0:
+            raise ValueError("--duration must be >= 0")
+        if self.action_horizon < 0:
+            raise ValueError("--action_horizon must be >= 0")
         if self.duration != 0 and self.action_horizon != 0:
             raise ValueError("Cannot specify both --duration and --action_horizon")
 

--- a/src/lerobot/rollout/strategies/base.py
+++ b/src/lerobot/rollout/strategies/base.py
@@ -49,6 +49,7 @@ class BaseStrategy(RolloutStrategy):
         control_interval = interpolator.get_control_interval(cfg.fps)
 
         start_time = time.perf_counter()
+        actions_sent = 0
         engine.resume()
         logger.info("Base strategy control loop started")
 
@@ -58,6 +59,9 @@ class BaseStrategy(RolloutStrategy):
             if cfg.duration > 0 and (time.perf_counter() - start_time) >= cfg.duration:
                 logger.info("Duration limit reached (%.0fs)", cfg.duration)
                 break
+            elif cfg.action_horizon > 0 and actions_sent >= cfg.action_horizon:
+                logger.info("Action horizon reached (%d)", cfg.action_horizon)
+                break
 
             obs = robot.get_observation()
             obs_processed = self._process_observation_and_notify(ctx.processors, obs)
@@ -66,6 +70,8 @@ class BaseStrategy(RolloutStrategy):
                 continue
 
             action_dict = send_next_action(obs_processed, obs, ctx, interpolator)
+            if action_dict is not None:
+                actions_sent += 1
             self._log_telemetry(obs_processed, action_dict, ctx.runtime)
 
             dt = time.perf_counter() - loop_start

--- a/src/lerobot/rollout/strategies/dagger.py
+++ b/src/lerobot/rollout/strategies/dagger.py
@@ -347,6 +347,7 @@ class DAggerStrategy(RolloutStrategy):
         last_action: dict[str, Any] | None = None
         record_tick = 0
         start_time = time.perf_counter()
+        actions_sent = 0
         episode_start = time.perf_counter()
         episodes_since_push = 0
         episode_duration_s = self._episode_duration_s
@@ -359,6 +360,9 @@ class DAggerStrategy(RolloutStrategy):
 
                     if cfg.duration > 0 and (time.perf_counter() - start_time) >= cfg.duration:
                         logger.info("Duration limit reached (%.0fs)", cfg.duration)
+                        break
+                    elif cfg.action_horizon > 0 and actions_sent >= cfg.action_horizon:
+                        logger.info("Action horizon reached (%d)", cfg.action_horizon)
                         break
 
                     # Process transitions
@@ -417,6 +421,7 @@ class DAggerStrategy(RolloutStrategy):
 
                         action_dict = send_next_action(obs_processed, obs, ctx, interpolator)
                         if action_dict is not None:
+                            actions_sent += 1
                             self._log_telemetry(obs_processed, action_dict, ctx.runtime)
                             last_action = ctx.processors.robot_action_processor((action_dict, obs))
                             if record_tick % record_stride == 0:
@@ -503,6 +508,7 @@ class DAggerStrategy(RolloutStrategy):
 
         last_action: dict[str, Any] | None = None
         start_time = time.perf_counter()
+        actions_sent = 0
         record_tick = 0
         recorded = 0
         logger.info(
@@ -520,6 +526,9 @@ class DAggerStrategy(RolloutStrategy):
 
                     if cfg.duration > 0 and (time.perf_counter() - start_time) >= cfg.duration:
                         logger.info("Duration limit reached (%.0fs)", cfg.duration)
+                        break
+                    elif cfg.action_horizon > 0 and actions_sent >= cfg.action_horizon:
+                        logger.info("Action horizon reached (%d)", cfg.action_horizon)
                         break
 
                     # Process transitions
@@ -599,6 +608,7 @@ class DAggerStrategy(RolloutStrategy):
 
                         action_dict = send_next_action(obs_processed, obs, ctx, interpolator)
                         if action_dict is not None:
+                            actions_sent += 1
                             self._log_telemetry(obs_processed, action_dict, ctx.runtime)
                             last_action = ctx.processors.robot_action_processor((action_dict, obs))
 

--- a/src/lerobot/rollout/strategies/dagger.py
+++ b/src/lerobot/rollout/strategies/dagger.py
@@ -393,6 +393,7 @@ class DAggerStrategy(RolloutStrategy):
                         processed_teleop = ctx.processors.teleop_action_processor((teleop_action, obs))
                         robot_action_to_send = ctx.processors.robot_action_processor((processed_teleop, obs))
                         robot.send_action(robot_action_to_send)
+                        actions_sent += 1
                         last_action = robot_action_to_send
                         self._log_telemetry(obs_processed, processed_teleop, ctx.runtime)
                         if record_tick % record_stride == 0:
@@ -411,6 +412,7 @@ class DAggerStrategy(RolloutStrategy):
                     elif phase == DAggerPhase.PAUSED:
                         if last_action:
                             robot.send_action(last_action)
+                            actions_sent += 1
 
                     # --- AUTONOMOUS: policy control ---
                     else:
@@ -578,6 +580,7 @@ class DAggerStrategy(RolloutStrategy):
                         processed_teleop = ctx.processors.teleop_action_processor((teleop_action, obs))
                         robot_action_to_send = ctx.processors.robot_action_processor((processed_teleop, obs))
                         robot.send_action(robot_action_to_send)
+                        actions_sent += 1
                         last_action = robot_action_to_send
                         self._log_telemetry(obs_processed, processed_teleop, ctx.runtime)
 
@@ -598,6 +601,7 @@ class DAggerStrategy(RolloutStrategy):
                     elif phase == DAggerPhase.PAUSED:
                         if last_action:
                             robot.send_action(last_action)
+                            actions_sent += 1
 
                     # --- AUTONOMOUS: policy control (no recording) ---
                     else:

--- a/src/lerobot/rollout/strategies/episodic.py
+++ b/src/lerobot/rollout/strategies/episodic.py
@@ -213,10 +213,12 @@ class EpisodicStrategy(RolloutStrategy):
         single_task: str,
     ) -> None:
         """Policy-driven recording loop for a single episode."""
+        cfg = ctx.runtime.cfg
         interpolator = self._interpolator
         control_interval = interpolator.get_control_interval(fps)
 
         timestamp = 0.0
+        actions_sent = 0
         start_t = time.perf_counter()
 
         while timestamp < control_time_s:
@@ -229,6 +231,10 @@ class EpisodicStrategy(RolloutStrategy):
             if ctx.runtime.shutdown_event.is_set():
                 break
 
+            if cfg.action_horizon > 0 and actions_sent >= cfg.action_horizon:
+                logger.info("Action horizon reached (%d)", cfg.action_horizon)
+                break
+
             obs = robot.get_observation()
             obs_processed = self._process_observation_and_notify(ctx.processors, obs)
 
@@ -238,6 +244,7 @@ class EpisodicStrategy(RolloutStrategy):
             action_dict = send_next_action(obs_processed, obs, ctx, interpolator)
 
             if action_dict is not None:
+                actions_sent += 1
                 obs_frame = build_dataset_frame(features, obs_processed, prefix=OBS_STR)
                 action_frame = build_dataset_frame(features, action_dict, prefix=ACTION)
                 dataset.add_frame({**obs_frame, **action_frame, "task": single_task})

--- a/src/lerobot/rollout/strategies/highlight.py
+++ b/src/lerobot/rollout/strategies/highlight.py
@@ -105,6 +105,7 @@ class HighlightStrategy(RolloutStrategy):
         play_sounds = cfg.play_sounds
 
         start_time = time.perf_counter()
+        actions_sent = 0
         task_str = cfg.dataset.single_task if cfg.dataset else cfg.task
         logger.info("Highlight strategy recording started (press '%s' to save)", self.config.save_key)
 
@@ -116,6 +117,9 @@ class HighlightStrategy(RolloutStrategy):
                     if cfg.duration > 0 and (time.perf_counter() - start_time) >= cfg.duration:
                         logger.info("Duration limit reached (%.0fs)", cfg.duration)
                         break
+                    elif cfg.action_horizon > 0 and actions_sent >= cfg.action_horizon:
+                        logger.info("Action horizon reached (%d)", cfg.action_horizon)
+                        break
 
                     obs = robot.get_observation()
                     obs_processed = self._process_observation_and_notify(ctx.processors, obs)
@@ -126,6 +130,7 @@ class HighlightStrategy(RolloutStrategy):
                     action_dict = send_next_action(obs_processed, obs, ctx, interpolator)
 
                     if action_dict is not None:
+                        actions_sent += 1
                         self._log_telemetry(obs_processed, action_dict, ctx.runtime)
                         obs_frame = build_dataset_frame(features, obs_processed, prefix=OBS_STR)
                         action_frame = build_dataset_frame(features, action_dict, prefix=ACTION)

--- a/src/lerobot/rollout/strategies/sentry.py
+++ b/src/lerobot/rollout/strategies/sentry.py
@@ -96,6 +96,7 @@ class SentryStrategy(RolloutStrategy):
         episode_duration_s = self._episode_duration_s
 
         start_time = time.perf_counter()
+        actions_sent = 0
         episode_start = time.perf_counter()
         episodes_since_push = 0
         task_str = cfg.dataset.single_task if cfg.dataset else cfg.task
@@ -109,6 +110,9 @@ class SentryStrategy(RolloutStrategy):
                     if cfg.duration > 0 and (time.perf_counter() - start_time) >= cfg.duration:
                         logger.info("Duration limit reached (%.0fs)", cfg.duration)
                         break
+                    elif cfg.action_horizon > 0 and actions_sent >= cfg.action_horizon:
+                        logger.info("Action horizon reached (%d)", cfg.action_horizon)
+                        break
 
                     obs = robot.get_observation()
                     obs_processed = self._process_observation_and_notify(ctx.processors, obs)
@@ -119,6 +123,7 @@ class SentryStrategy(RolloutStrategy):
                     action_dict = send_next_action(obs_processed, obs, ctx, interpolator)
 
                     if action_dict is not None:
+                        actions_sent += 1
                         self._log_telemetry(obs_processed, action_dict, ctx.runtime)
                         obs_frame = build_dataset_frame(features, obs_processed, prefix=OBS_STR)
                         action_frame = build_dataset_frame(features, action_dict, prefix=ACTION)

--- a/src/lerobot/scripts/lerobot_rollout.py
+++ b/src/lerobot/scripts/lerobot_rollout.py
@@ -221,11 +221,19 @@ def rollout(cfg: RolloutConfig):
 
     strategy = create_strategy(cfg.strategy)
     logger.info("Rollout strategy: %s", cfg.strategy.type)
+    has_action_horizon = cfg.action_horizon > 0
     logger.info(
-        "Robot: %s | FPS: %.0f | Duration: %s",
+        "Robot: %s | FPS: %.0f | %s: %s",
         cfg.robot.type if cfg.robot else "?",
         cfg.fps,
-        f"{cfg.duration}s" if cfg.duration > 0 else "infinite",
+        "Action horizon" if has_action_horizon else "Duration",
+        (
+            cfg.action_horizon
+            if has_action_horizon
+            else f"{cfg.duration}s"
+            if cfg.duration > 0
+            else "infinite"
+        ),
     )
 
     try:

--- a/tests/test_rollout.py
+++ b/tests/test_rollout.py
@@ -89,6 +89,59 @@ def test_dagger_config_defaults():
     assert cfg.input_device == "keyboard"
 
 
+def test_base_strategy_stops_at_action_horizon(monkeypatch):
+    import lerobot.rollout.strategies.base as base_module
+    from lerobot.rollout import BaseStrategy, BaseStrategyConfig
+
+    action_horizon = 3
+    # side_next_action may return None
+    side_next_action_returns = [{"action": 1.0}, None, {"action": 1.0}, None, {"action": 1.0}]
+    send_next_action = MagicMock(
+        side_effect=side_next_action_returns,
+    )
+    monkeypatch.setattr(base_module, "send_next_action", send_next_action)
+
+    strategy = BaseStrategy(BaseStrategyConfig())
+    strategy._engine = MagicMock()
+    strategy._interpolator = MagicMock()
+    strategy._interpolator.get_control_interval.return_value = 0
+    strategy._process_observation_and_notify = MagicMock(return_value={})
+    strategy._log_telemetry = MagicMock()
+    ctx = SimpleNamespace(
+        runtime=SimpleNamespace(
+            cfg=SimpleNamespace(
+                fps=30,
+                duration=0,
+                action_horizon=action_horizon,
+                use_torch_compile=False,
+            ),
+            shutdown_event=SimpleNamespace(is_set=lambda: False),
+        ),
+        hardware=SimpleNamespace(robot_wrapper=MagicMock()),
+        processors=MagicMock(),
+    )
+
+    strategy.run(ctx)
+
+    assert send_next_action.call_count == len(side_next_action_returns)
+
+
+def test_rollout_config_rejects_duration_and_action_horizon(monkeypatch):
+    from lerobot.configs import parser
+    from lerobot.rollout import RolloutConfig
+    from tests.mocks.mock_robot import MockRobotConfig
+
+    monkeypatch.setattr(parser, "get_path_arg", lambda _: None)
+
+    with pytest.raises(ValueError, match="Cannot specify both --duration and --action_horizon"):
+        RolloutConfig(
+            robot=MockRobotConfig(),
+            policy=SimpleNamespace(device="cpu"),
+            duration=1,
+            action_horizon=1,
+        )
+
+
 def test_inference_config_types():
     from lerobot.rollout import RTCInferenceConfig, SyncInferenceConfig
 


### PR DESCRIPTION
## Title

feat(rollout): add action_horizon to RolloutConfig

## Summary / Motivation

Currently the only option to limit a `lerobot-rollout` rollout length is to set walltime `--duration`. This adds an option to limit a rollout by number of actions executed (after any interpolation) instead.

## Related issues

- Fixes / Closes: # (if any)
- Related: # (if any)

## What changed

- Added `action_horizon` to `RolloutConfig`

## How was this tested (or how to run locally)

- Added tests in `tests/test_rollout.py` counting `send_next_action` calls

## Checklist (required before merge)

- [ ] Linting/formatting run (`pre-commit run -a`)
- [ ] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: # (insert PR number/link)

## Reviewer notes

- Anything the reviewer should focus on (performance, edge-cases, specific files) or general notes.
- Anyone in the community is free to review the PR.
