### PR TITLE
fix(async-inference): register ZMQ camera config

### DIFF
--- a/src/lerobot/async_inference/robot_client.py
+++ b/src/lerobot/async_inference/robot_client.py
@@ -49,6 +49,7 @@ import torch
 
 from lerobot.cameras.opencv import OpenCVCameraConfig  # noqa: F401
 from lerobot.cameras.realsense import RealSenseCameraConfig  # noqa: F401
+from lerobot.cameras.zmq import ZMQCameraConfig  # noqa: F401
 from lerobot.robots import (  # noqa: F401
     Robot,
     RobotConfig,

--- a/tests/async_inference/test_robot_client.py
+++ b/tests/async_inference/test_robot_client.py
@@ -269,3 +269,19 @@ def test_robot_client_registers_builtin_robot_types():
             f"Ensure the corresponding module is imported in robot_client.py. "
             f"Known choices: {sorted(known_choices)}"
         )
+
+
+def test_robot_client_registers_builtin_camera_types():
+    """Importing robot_client must populate CameraConfig's ChoiceRegistry."""
+    import lerobot.async_inference.robot_client  # noqa: F401
+    from lerobot.cameras.configs import CameraConfig
+
+    known_choices = CameraConfig.get_known_choices()
+
+    expected_camera_types = ["opencv", "intelrealsense", "zmq"]
+    for camera_type in expected_camera_types:
+        assert camera_type in known_choices, (
+            f"Camera type '{camera_type}' is not registered in CameraConfig's ChoiceRegistry. "
+            f"Ensure the corresponding module is imported in robot_client.py. "
+            f"Known choices: {sorted(known_choices)}"
+        )


### PR DESCRIPTION
## Summary / Motivation

The async inference robot client imports the built-in camera config modules to populate `CameraConfig`'s choice registry before CLI parsing. It currently registers OpenCV and RealSense, but omits ZMQ, so a valid `--robot.cameras.*.type=zmq` configuration is rejected as an unknown choice. This adds the missing registration import and regression coverage for all three built-in camera types used by the client.

## Related issues

- Fixes: #4383

## What changed

- Import `ZMQCameraConfig` alongside the other built-in camera configs in `robot_client.py`, triggering its registry decorator before configuration parsing.
- Add a regression test that verifies importing the async robot client registers `opencv`, `intelrealsense`, and `zmq` camera choices.
- No breaking changes.

## How was this tested (or how to run locally)

- `uv run --frozen pytest -q tests/async_inference/test_robot_client.py` - 25 passed.
- `uv run --frozen pytest -q tests/async_inference/test_robot_client.py -k camera` - 1 passed, 24 deselected.
- `uv run --frozen pre-commit run --all-files` - all hooks passed, including Ruff, typos, pyupgrade, gitleaks, Bandit, and mypy.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All relevant tests pass locally (`pytest`)
- [x] Documentation updated (not applicable: this restores an already supported config choice)
- [ ] CI is green
- [x] Community Review: reviewed #4382 and reproduced its targeted tests locally (35 passed): https://github.com/huggingface/lerobot/pull/4382#pullrequestreview-4892027102

## Reviewer notes

- The camera config classes use import-time registration, mirroring the existing robot registry regression test in the same file.
- AI assistance was used to help analyze the registry failure and prepare this patch. The diff was reviewed and all tests and checks listed above were executed locally.
