### PR TITLE
fix(rollout): feed fresh observation to the engine on DAgger resume

### DIFF
--- a/src/lerobot/rollout/strategies/dagger.py
+++ b/src/lerobot/rollout/strategies/dagger.py
@@ -696,6 +696,17 @@ class DAggerStrategy(RolloutStrategy):
             logger.info("Resuming autonomous mode - resetting engine and interpolator")
             interpolator.reset()
             engine.reset()
+            # Feed a fresh observation before resuming: observations are only
+            # published to the engine during AUTONOMOUS ticks, so after a
+            # correction the engine still holds the pre-correction observation.
+            # The RTC background thread wakes on resume() and can start
+            # inference from that stale observation before the main loop's
+            # next notify, producing a chunk that snaps the arm back toward
+            # its pre-correction pose (#3747). Notify before resume closes
+            # the race entirely; for engines without background inference
+            # notify_observation is a no-op.
+            fresh_obs = robot.get_observation()
+            engine.notify_observation(ctx.processors.robot_observation_processor(fresh_obs))
             engine.resume()
 
             # release teleop before resuming the policy

--- a/tests/test_rollout.py
+++ b/tests/test_rollout.py
@@ -429,6 +429,60 @@ def test_dagger_full_transition_cycle():
     assert (old, new) == (DAggerPhase.PAUSED, DAggerPhase.AUTONOMOUS)
 
 
+def test_dagger_resume_feeds_fresh_observation_before_resume():
+    """PAUSED -> AUTONOMOUS must publish a fresh (post-correction) observation
+    to the engine after reset and before resume.
+
+    Regression test for #3747: observations are only published during
+    AUTONOMOUS ticks, so after a correction the engine still holds the
+    pre-correction observation. The RTC background thread wakes on resume()
+    and can start inference from that stale observation before the main
+    loop's next notify, producing a chunk that snaps the arm back toward its
+    pre-correction pose.
+    """
+    from lerobot.rollout import DAggerStrategyConfig
+    from lerobot.rollout.strategies import DAggerPhase
+    from lerobot.rollout.strategies.dagger import DAggerStrategy
+
+    strategy = DAggerStrategy(DAggerStrategyConfig())
+
+    engine = MagicMock()
+    interpolator = MagicMock()
+
+    teleop = MagicMock()
+    teleop.feedback_features = {}  # non-actuated: skip smooth-handover branches
+
+    fresh_obs = {"joint_pos": 1.23}
+    processed_obs = {"observation.state": torch.tensor([1.23])}
+    robot = MagicMock()
+    robot.get_observation.return_value = fresh_obs
+    processors = MagicMock()
+    processors.robot_observation_processor.return_value = processed_obs
+
+    ctx = SimpleNamespace(
+        hardware=SimpleNamespace(teleop=teleop, robot_wrapper=robot),
+        processors=processors,
+    )
+
+    strategy._apply_transition(
+        DAggerPhase.PAUSED,
+        DAggerPhase.AUTONOMOUS,
+        engine,
+        interpolator,
+        ctx,
+        prev_action=None,
+    )
+
+    processors.robot_observation_processor.assert_called_once_with(fresh_obs)
+    engine.notify_observation.assert_called_once_with(processed_obs)
+
+    # The stale-observation race is only closed if the fresh observation is
+    # published after the engine reset and before the background thread is
+    # allowed to run again.
+    call_order = [name for name, _, _ in engine.mock_calls]
+    assert call_order.index("reset") < call_order.index("notify_observation") < call_order.index("resume")
+
+
 def test_dagger_invalid_transition_ignored():
     from lerobot.rollout.strategies import DAggerEvents, DAggerPhase
 


### PR DESCRIPTION
## Summary / Motivation

Implements the fix for #3747 (DAgger resume: RTC engine uses stale observation after correction, causing snap-back), which @pkooij confirmed as the right approach back in June but never got a PR. Full credit for the root-cause analysis and the fix approach goes to @anikita — this PR implements it with a regression test so the issue can be closed.

Root cause (verified against current `main`): observations are only published to the engine during AUTONOMOUS ticks (`_process_observation_and_notify`), and `engine.reset()` does not clear `_obs_holder`. On `PAUSED → AUTONOMOUS` the RTC background thread wakes on `resume()` (idle sleep is a few ms) and reads the pre-correction observation before the main loop's next notify — so the first chunk targets the pre-correction pose and the arm snaps back. Given the thread timing this is near-deterministic, not an occasional race.

## Related issues

- Fixes: #3747

## What changed

- `DAggerStrategy._apply_transition()`, `PAUSED → AUTONOMOUS` branch: publish a fresh processed observation between `engine.reset()` and `engine.resume()`. Notifying *before* resume closes the race entirely (the background thread can never observe the stale value while active).
- No behavior change for engines without background inference: `notify_observation` has a no-op default on the base engine interface.

## How was this tested (or how to run locally)

- New regression test `test_dagger_resume_feeds_fresh_observation_before_resume` (tests/test_rollout.py): drives the `PAUSED → AUTONOMOUS` transition with a mocked engine/robot/processors and asserts the fresh observation is processed and published, and that the call order is `reset → notify_observation → resume`. **Verified the test fails on unfixed `main`** and passes with the fix.
- `pytest -q tests/test_rollout.py` — 28 passed.
- `pre-commit run --files <changed files>` — all hooks pass.
- No leader/follower hardware available to me at the moment, so no on-robot check from my side — though the original reporter validated this exact approach on SO-101 hardware in the issue.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated (inline comment documents the race; no user-facing docs affected)
- [ ] CI is green
- [x] Community Review: I have reviewed another contributor's open PR and linked it here: #4223

## Reviewer notes

- The fix reuses the exact processing chain the AUTONOMOUS loop uses (`robot.get_observation()` → `ctx.processors.robot_observation_processor` → `engine.notify_observation`), so the engine sees the same observation format in both paths.
- The strategy-level `_cached_obs_processed` is also stale after a correction, but `interpolator.reset()` already forces a refresh on the next tick, so no change is needed there.
