### PR TITLE
fix(dataset): map DROID task category correctly

### DIFF
--- a/examples/port_datasets/port_droid.py
+++ b/examples/port_datasets/port_droid.py
@@ -250,7 +250,7 @@ def is_episode_successful(tf_episode_metadata):
 def generate_lerobot_frames(tf_episode):
     m = tf_episode["episode_metadata"]
     frame_meta = {
-        "task_category": m["building"].numpy().decode(),
+        "task_category": m["task_category"].numpy().decode(),
         "building": m["building"].numpy().decode(),
         "collector_id": m["collector_id"].numpy().decode(),
         "date": m["date"].numpy().decode(),


### PR DESCRIPTION
## Summary

- populate the DROID task_category field from source task_category instead of source building
- keep the date defect separate because its code-level substitution point is not yet pinned

## Evidence

At immutable dataset revision 0eabc778f959c54b8c5aa3626cc1128d2d2e54d4, an exact scan of all 86 episode-referenced Parquets found task_category equal to building on 27,630,375 of 27,630,375 rows. The current converter mapping at lines 250-256 directly explains that collision.

Full reproducible evidence, source manifests, checksums, and a source-backed 100-episode repair slice:
https://github.com/sawhney17/droid-semantic-repair/releases/tag/v0.1.0

Tracking issue: https://github.com/huggingface/lerobot/issues/4402

## Validation

- changed-file pre-commit hooks pass
- independent exact-generation replay reproduced all 100 repair entries
- all 133 available pinned raw metadata objects passed identity validation

This intentionally changes only the source-visible task-category miswire. It does not try to infer a fix for date, and it does not claim state/action/video corruption or measured policy impact.