### PR TITLE
fix(envs): correct RoboTwin joint action bounds

### DIFF
--- a/docs/source/robotwin.mdx
+++ b/docs/source/robotwin.mdx
@@ -11,15 +11,15 @@ RoboTwin 2.0 is a **large-scale dual-arm manipulation benchmark** built on the S
 
 ## Overview
 
-| Property      | Value                                                    |
-| ------------- | -------------------------------------------------------- |
-| Tasks         | 50 dual-arm manipulation tasks                           |
-| Robot         | Aloha-AgileX bimanual (14 DOF, 7 per arm)                |
-| Action space  | 14-dim joint-space, continuous in `[-1, 1]`              |
-| Cameras       | `head_camera`, `left_camera`, `right_camera`             |
-| Simulator     | SAPIEN (not MuJoCo)                                      |
-| Eval protocol | 100 episodes/task, 50 demo_clean demonstrations          |
-| Eval settings | **Easy** (`demo_clean`) and **Hard** (`demo_randomized`) |
+| Property      | Value                                                                                                         |
+| ------------- | ------------------------------------------------------------------------------------------------------------- |
+| Tasks         | 50 dual-arm manipulation tasks                                                                                |
+| Robot         | Aloha-AgileX bimanual (14 DOF, 7 per arm)                                                                     |
+| Action modes  | `joint` (default): 14-d absolute qpos (`[-10, 10]` arms, `[0, 1]` grippers); `ee`: 16-d `[-1, 1]` pose deltas |
+| Cameras       | `head_camera`, `left_camera`, `right_camera`                                                                  |
+| Simulator     | SAPIEN (not MuJoCo)                                                                                           |
+| Eval protocol | 100 episodes/task, 50 demo_clean demonstrations                                                               |
+| Eval settings | **Easy** (`demo_clean`) and **Hard** (`demo_randomized`)                                                      |
 
 ## Available tasks
 
@@ -56,7 +56,7 @@ The RoboTwin 2.0 dataset is available in **LeRobot v3.0 format** on the Hugging 
 lerobot/robotwin_unified
 ```
 
-It contains over 100,000 pre-collected trajectories across all 50 tasks (79.6 GB, Apache 2.0 license). No format conversion is needed — it is already in the correct LeRobot v3.0 schema with video observations and action labels.
+The LeRobot conversion contains 27,500 episodes and 6,075,103 frames (79.5 GB, Apache 2.0 license). The broader upstream RoboTwin release advertises over 100,000 trajectories, but that count does not describe this Hub dataset. No format conversion is needed — it is already in the correct LeRobot v3.0 schema with video observations and action labels.
 
 You can load it directly with the HF Datasets library:
 
@@ -206,11 +206,16 @@ Key parameters for `RoboTwinEnvConfig`:
 | -------------------- | ---------------------------------------- | ---------------------------------- |
 | `task`               | `"beat_block_hammer"`                    | Comma-separated task name(s)       |
 | `fps`                | `25`                                     | Simulation FPS                     |
-| `episode_length`     | `300`                                    | Max steps per episode              |
+| `episode_length`     | `1200`                                   | Max steps per episode              |
 | `obs_type`           | `"pixels_agent_pos"`                     | `"pixels"` or `"pixels_agent_pos"` |
 | `camera_names`       | `"head_camera,left_camera,right_camera"` | Comma-separated active cameras     |
 | `observation_height` | `240`                                    | Camera pixel height                |
 | `observation_width`  | `320`                                    | Camera pixel width                 |
+| `action_mode`        | `"joint"`                                | `"joint"` or `"ee"`                |
+
+In the default `joint` mode, each action contains six absolute joint targets and one normalized gripper target per arm. The Aloha-AgileX runtime asset bounds the joint coordinates to `[-10, 10]` and the grippers to `[0, 1]`. The Hub dataset stores absolute next-step qpos targets; the wrapper does not normalize joint targets to `[-1, 1]`.
+
+The optional `ee` mode keeps its separate 16-dimensional `[-1, 1]` action space for per-arm `xyz + quaternion + gripper` deltas, which are composed onto the episode's initial end-effector poses before CuRobo IK.
 
 ## Leaderboard submission
 

--- a/src/lerobot/envs/configs.py
+++ b/src/lerobot/envs/configs.py
@@ -776,8 +776,8 @@ class RoboTwinEnvConfig(EnvConfig):
     # must equal what SAPIEN actually renders.
     observation_height: int = 240
     observation_width: int = 320
-    # "joint": 14-d joint-space control. "ee": 16-d end-effector-pose deltas executed via CuRobo IK
-    # (for world-model policies like LingBot-VA that predict per-arm xyz+quaternion+gripper poses).
+    # "joint": 14-d absolute joint/gripper targets. "ee": 16-d end-effector-pose deltas executed
+    # via CuRobo IK (for world-model policies like LingBot-VA that predict per-arm poses).
     action_mode: str = "joint"
     features: dict[str, PolicyFeature] = field(
         default_factory=lambda: {

--- a/src/lerobot/envs/robotwin.py
+++ b/src/lerobot/envs/robotwin.py
@@ -54,8 +54,12 @@ ACTION_DIM = 14  # 7 DOF × 2 arms (joint-space control mode)
 # End-effector-pose control mode: per arm [x, y, z, qx, qy, qz, qw, gripper] = 8, dual-arm = 16.
 # Used by world-model policies (e.g. LingBot-VA) that predict eef-pose deltas executed via CuRobo IK.
 EEF_ACTION_DIM = 16
-ACTION_LOW = -1.0
-ACTION_HIGH = 1.0
+EEF_ACTION_LOW = -1.0
+EEF_ACTION_HIGH = 1.0
+# qpos mode uses six arm joints plus one normalized gripper per side. These arm limits mirror the
+# Aloha-AgileX URDF selected by RoboTwin's demo_clean config; grippers are normalized by RoboTwin.
+JOINT_ACTION_LOW = np.array(([-10.0] * 6 + [0.0]) * 2, dtype=np.float32)
+JOINT_ACTION_HIGH = np.array(([10.0] * 6 + [1.0]) * 2, dtype=np.float32)
 DEFAULT_EPISODE_LENGTH = 1200
 OFFICIAL_INSTRUCTION_ENV = "LEROBOT_ROBOTWIN_OFFICIAL_INSTRUCTION"
 OFFICIAL_INSTRUCTION_TYPE_ENV = "LEROBOT_ROBOTWIN_INSTRUCTION_TYPE"
@@ -336,7 +340,10 @@ class RoboTwinEnv(gym.Env):
 
     Actions
     -------
-    14-dim float32 array in ``[-1, 1]`` (joint-space, 7 DOF per arm).
+    ``joint`` (default) accepts 14-dim float32 absolute qpos targets: six
+    joint targets in ``[-10, 10]`` plus one ``[0, 1]`` gripper target per arm,
+    matching the Aloha-AgileX runtime asset. ``ee`` accepts 16-dim float32
+    end-effector-pose deltas in ``[-1, 1]``.
 
     Autograd
     --------
@@ -403,9 +410,19 @@ class RoboTwinEnv(gym.Env):
                 "agent_pos": spaces.Box(low=-np.inf, high=np.inf, shape=(ACTION_DIM,), dtype=np.float32),
             }
         )
-        self.action_space = spaces.Box(
-            low=ACTION_LOW, high=ACTION_HIGH, shape=(self._action_dim,), dtype=np.float32
-        )
+        if self.action_mode == "ee":
+            self.action_space = spaces.Box(
+                low=EEF_ACTION_LOW,
+                high=EEF_ACTION_HIGH,
+                shape=(EEF_ACTION_DIM,),
+                dtype=np.float32,
+            )
+        else:
+            self.action_space = spaces.Box(
+                low=JOINT_ACTION_LOW,
+                high=JOINT_ACTION_HIGH,
+                dtype=np.float32,
+            )
 
     def _ensure_env(self) -> None:
         """Create the SAPIEN environment on first use.

--- a/tests/envs/test_robotwin.py
+++ b/tests/envs/test_robotwin.py
@@ -31,6 +31,7 @@ import pytest
 
 from lerobot.envs.robotwin import (
     ACTION_DIM,
+    EEF_ACTION_DIM,
     ROBOTWIN_CAMERA_NAMES,
     ROBOTWIN_TASKS,
     RoboTwinEnv,
@@ -113,10 +114,37 @@ class TestRoboTwinEnv:
         assert pixels_space["left_camera"].shape == (h, w, 3)
         assert "right_camera" not in pixels_space
 
-    def test_action_space(self):
+    def test_joint_action_space_accepts_absolute_qpos_targets(self):
         env = RoboTwinEnv(task_name="beat_block_hammer")
+
+        assert env.action_mode == "joint"
         assert env.action_space.shape == (ACTION_DIM,)
         assert env.action_space.dtype == np.float32
+        np.testing.assert_array_equal(
+            env.action_space.low,
+            np.array(([-10.0] * 6 + [0.0]) * 2, dtype=np.float32),
+        )
+        np.testing.assert_array_equal(
+            env.action_space.high,
+            np.array(([10.0] * 6 + [1.0]) * 2, dtype=np.float32),
+        )
+
+        # Absolute qpos values outside [-1, 1] are valid inputs in RoboTwin's default mode.
+        absolute_qpos = np.array([2.0] * 6 + [0.5] + [-2.0] * 6 + [0.5], dtype=np.float32)
+        assert env.action_space.contains(absolute_qpos)
+
+    def test_ee_action_space_stays_bounded(self):
+        env = RoboTwinEnv(task_name="beat_block_hammer", action_mode="ee")
+
+        assert env.action_mode == "ee"
+        assert env.action_space.shape == (EEF_ACTION_DIM,)
+        assert env.action_space.dtype == np.float32
+        np.testing.assert_array_equal(env.action_space.low, np.full(EEF_ACTION_DIM, -1.0))
+        np.testing.assert_array_equal(env.action_space.high, np.full(EEF_ACTION_DIM, 1.0))
+
+    def test_unknown_action_mode_raises(self):
+        with pytest.raises(ValueError, match="action_mode must be 'joint' or 'ee'"):
+            RoboTwinEnv(task_name="beat_block_hammer", action_mode="normalized_joint")
 
     def test_reset_returns_correct_obs_keys(self):
         mock_task = _make_mock_task_env()


### PR DESCRIPTION
## Summary / Motivation

Correct RoboTwin's default 14-D joint-mode Gym action space so it describes the absolute qpos
targets the wrapper already dispatches to RoboTwin. A pinned full scan of
`lerobot/robotwin_unified` found that the current `[-1, 1]^14` declaration rejects
5,589,701 / 6,075,103 actions (92.0099790901%) and at least one action in every episode.

This changes the declared interface, not action dispatch or trajectory values. Joint mode already
passes qpos through to `take_action`; EE mode retains its separate 16-D delta contract.

Exact evidence and reproducer:

- https://github.com/sawhney17/robotwin-action-contract-audit
- https://github.com/sawhney17/robotwin-action-contract-audit/releases/tag/v0.1.0

## Related issues

- Fixes / Closes: #4404
- Related: #3315, #3731

## What changed

- Declare fixed Aloha-AgileX joint-mode bounds as six `[-10, 10]` arm joints plus one `[0, 1]`
  normalized gripper per side, in the published motor order.
- Keep `ee` mode as its existing 16-D `[-1, 1]` Box.
- Add exact bounds/dtype/shape assertions and a representative absolute-qpos containment test.
- Document joint-vs-EE action semantics and the pinned Hub conversion's exact
  27,500-episode / 6,075,103-frame size.
- Correct the nearby documented default episode length from 300 to the existing runtime default
  of 1200.

No vector shape or runtime dispatch path changes. Consumers that inspect, sample, normalize, or
validate against `action_space` will now see the corrected joint/qpos bounds; that observable
contract correction is intentional.

## How was this tested (or how to run locally)

- `pytest -q tests/envs/test_robotwin.py` — 21 passed.
- Changed-file pre-commit hooks passed: Ruff, formatting, typos, pyupgrade, Prettier, secret scan,
  Bandit, and mypy.
- Exact full-corpus check: 6,075,103 / 6,075,103 stored actions fit the proposed Box.
- Semantic control: 6,047,603 / 6,047,603 nonterminal actions equal the next stored state
  bit-exactly.
- EE-mode regression assertions confirm its bounds remain unchanged.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run` on all changed files)
- [x] All relevant tests pass locally (`pytest -q tests/envs/test_robotwin.py`)
- [x] Documentation updated
- [ ] CI is green
- [x] Community Review: reviewed #4391 and its registration/test path:
  https://github.com/huggingface/lerobot/pull/4391#pullrequestreview-4895247708

## Reviewer notes

- The finite arm limits come from the official Aloha-AgileX URDF selected by RoboTwin's config;
  normalized gripper limits come from RoboTwin's `set_gripper` API. They are not fitted dataset
  extrema.
- RoboTwin source is pinned in the benchmark image, but its asset downloader is not. The evidence
  release pins asset revision `e04cff1…`, archive SHA-256 `6b87d7d5…`, and the selected config/URDF
  hashes for review.
- The current joint runtime does not clip against the old Gym Box, so this PR does not claim a
  measured rollout or policy-score improvement. It repairs validation, sampling, normalization,
  adapter, and exported-interface behavior.
- PR #3315 by @pkooij introduced the integration; #3731 added the distinct EE path. This patch
  preserves both control modes and credits that prior work.
