### PR TITLE
feat(eval): multi-seed evaluation with a Wilson confidence interval

### DIFF
--- a/src/lerobot/eval/__init__.py
+++ b/src/lerobot/eval/__init__.py
@@ -1,0 +1,22 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .multi_seed import MultiSeedResult, SeedResult, run_multi_seed_eval, wilson_ci
+
+__all__ = [
+    "MultiSeedResult",
+    "SeedResult",
+    "run_multi_seed_eval",
+    "wilson_ci",
+]

--- a/src/lerobot/eval/multi_seed.py
+++ b/src/lerobot/eval/multi_seed.py
@@ -1,0 +1,300 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Run a policy across several seeds and report a success rate with a confidence interval.
+
+`eval_policy` (in `lerobot.scripts.lerobot_eval`) evaluates a policy over a batch of episodes seeded from a
+single `start_seed`. A single-seed point estimate is fragile: simulator initial conditions, GPU
+non-determinism, and the policy's own stochasticity all move the number, and a reported `pc_success`
+without an interval can hide a 10+ point swing between seeds.
+
+This module adds the missing orchestration layer: evaluate over a list of seeds, collect the per-episode
+success outcomes, and aggregate them into a single success rate with a Wilson score confidence interval. It
+is a thin loop over the existing `eval_policy` — it does not reimplement the rollout.
+
+Seeding contract: for each seed `s` in `seeds`, `set_seed(s)` is called once before that seed's episodes
+run (fixing the Python / NumPy / Torch global RNGs, which is what makes the policy's own stochasticity
+reproducible), and the environments are reset from `start_seed=s` so episode `e` of that seed uses
+environment seed `s + e`. The torch generator is *not* re-seeded between episodes within a seed, so only
+the `(policy, env, seed)` cell as a whole is reproducible, not individual episodes within it.
+
+The confidence interval is the textbook Wilson score interval over the flat list of per-episode binary
+outcomes — the unit of resampling is the *episode*, not the seed. Resampling over the handful of seeds
+instead would inflate the interval and is the common mistake this helper is meant to avoid. Richer
+machinery (bootstrap and paired-bootstrap intervals, paired policy-vs-policy ranking) lives in the
+Embodimetry benchmark (https://github.com/thrmnn/embodimetry) where this module originated, and is out of
+scope here.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from statistics import NormalDist
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from lerobot.policies import PreTrainedPolicy
+from lerobot.scripts.lerobot_eval import eval_policy
+from lerobot.utils.random_utils import set_seed
+
+if TYPE_CHECKING:
+    import gymnasium as gym
+
+    from lerobot.lerobot_types import PolicyAction
+    from lerobot.processor import PolicyProcessorPipeline
+
+
+@dataclass(frozen=True)
+class SeedResult:
+    """Outcome of evaluating one seed.
+
+    Args:
+        seed (`int`):
+            The seed this cell was evaluated under.
+        n_episodes (`int`):
+            Number of episodes run for this seed.
+        n_successes (`int`):
+            Number of successful episodes.
+        success_rate (`float`):
+            `n_successes / n_episodes`.
+        avg_sum_reward (`float`):
+            Mean per-episode summed reward, as reported by `eval_policy`.
+        avg_max_reward (`float`):
+            Mean per-episode maximum reward, as reported by `eval_policy`.
+        successes (`tuple[bool, ...]`):
+            Per-episode success outcomes, in episode order.
+    """
+
+    seed: int
+    n_episodes: int
+    n_successes: int
+    success_rate: float
+    avg_sum_reward: float
+    avg_max_reward: float
+    successes: tuple[bool, ...]
+
+
+@dataclass(frozen=True)
+class MultiSeedResult:
+    """Aggregated outcome across all seeds.
+
+    Args:
+        seeds (`tuple[int, ...]`):
+            The seeds that were evaluated, in order.
+        episodes_per_seed (`int`):
+            Number of episodes run for each seed.
+        n_episodes (`int`):
+            Total number of episodes, i.e. `len(seeds) * episodes_per_seed`.
+        n_successes (`int`):
+            Total number of successful episodes across all seeds.
+        success_rate (`float`):
+            Pooled success rate over all episodes.
+        ci_low (`float`):
+            Lower bound of the Wilson confidence interval.
+        ci_high (`float`):
+            Upper bound of the Wilson confidence interval.
+        ci_level (`float`):
+            Confidence level of the interval, e.g. `0.95`.
+        per_seed (`tuple[SeedResult, ...]`):
+            The individual [`SeedResult`] for each seed, in order.
+    """
+
+    seeds: tuple[int, ...]
+    episodes_per_seed: int
+    n_episodes: int
+    n_successes: int
+    success_rate: float
+    ci_low: float
+    ci_high: float
+    ci_level: float
+    per_seed: tuple[SeedResult, ...]
+
+    @property
+    def all_successes(self) -> np.ndarray:
+        """The flat `(n_episodes,)` boolean array of per-episode outcomes, in seed then episode order."""
+        return np.concatenate([np.asarray(s.successes, dtype=bool) for s in self.per_seed])
+
+
+def wilson_ci(n_successes: int, n_trials: int, *, ci_level: float = 0.95) -> tuple[float, float]:
+    """Wilson score interval for a Bernoulli success proportion.
+
+    The Wilson interval (Wilson, 1927) is a closed-form binomial confidence interval that, unlike the
+    normal (Wald) approximation, stays inside `[0, 1]` and behaves well for small `n` and for proportions
+    near 0 or 1 — exactly the regime success-rate evaluation lives in.
+
+    Args:
+        n_successes (`int`):
+            Number of successes; must satisfy `0 <= n_successes <= n_trials`.
+        n_trials (`int`):
+            Number of trials; must be positive.
+        ci_level (`float`, *optional*, defaults to 0.95):
+            Confidence level, in `(0, 1)`.
+
+    Returns:
+        `tuple[float, float]`: The `(low, high)` bounds of the interval, both clamped to `[0, 1]`.
+
+    Raises:
+        ValueError: If `n_trials` is not positive, `n_successes` is out of range, or `ci_level` is not in
+            `(0, 1)`.
+
+    Example:
+        ```python
+        >>> from lerobot.eval import wilson_ci
+        >>> low, high = wilson_ci(50, 100)
+        >>> (round(low, 3), round(high, 3))
+        (0.404, 0.596)
+        ```
+    """
+    if n_trials <= 0:
+        raise ValueError(f"n_trials must be positive, got {n_trials}")
+    if not 0 <= n_successes <= n_trials:
+        raise ValueError(f"n_successes={n_successes} not in [0, {n_trials}]")
+    if not 0.0 < ci_level < 1.0:
+        raise ValueError(f"ci_level must be in (0, 1), got {ci_level}")
+
+    z = NormalDist().inv_cdf((1.0 + ci_level) / 2.0)
+    p_hat = n_successes / n_trials
+    z2_n = z * z / n_trials
+    center = (p_hat + z2_n / 2.0) / (1.0 + z2_n)
+    half = (z * math.sqrt((p_hat * (1.0 - p_hat) + z2_n / 4.0) / n_trials)) / (1.0 + z2_n)
+    # At the boundaries the Wilson bounds are exactly 0 and 1; pin them so floating-point residue from
+    # `center - half` cannot leak a bound like 1e-17.
+    low = 0.0 if n_successes == 0 else max(0.0, center - half)
+    high = 1.0 if n_successes == n_trials else min(1.0, center + half)
+    return low, high
+
+
+def run_multi_seed_eval(
+    env: gym.vector.VectorEnv,
+    policy: PreTrainedPolicy,
+    *,
+    env_preprocessor: PolicyProcessorPipeline[dict[str, Any], dict[str, Any]],
+    env_postprocessor: PolicyProcessorPipeline[dict[str, Any], dict[str, Any]],
+    preprocessor: PolicyProcessorPipeline[dict[str, Any], dict[str, Any]],
+    postprocessor: PolicyProcessorPipeline[PolicyAction, PolicyAction],
+    seeds: Sequence[int],
+    episodes_per_seed: int,
+    ci_level: float = 0.95,
+    videos_dir: Path | None = None,
+    max_episodes_rendered: int = 0,
+) -> MultiSeedResult:
+    """Evaluate `policy` on `env` across `seeds` and aggregate with a confidence interval.
+
+    For each seed, `set_seed(seed)` is applied and then `eval_policy` runs `episodes_per_seed` episodes
+    with `start_seed=seed`, so episode `e` of that seed uses environment seed `seed + e`. The per-episode
+    success outcomes from every seed are pooled, and a Wilson score interval is computed over the pooled
+    outcomes. See the module docstring for the full seeding contract and for what statistics intentionally
+    live elsewhere.
+
+    Args:
+        env (`gym.vector.VectorEnv`):
+            The batch of environments, as built by `lerobot.envs.make_env`.
+        policy (`PreTrainedPolicy`):
+            The policy to evaluate.
+        env_preprocessor (`PolicyProcessorPipeline`):
+            Environment-side preprocessor pipeline, passed through to `eval_policy`.
+        env_postprocessor (`PolicyProcessorPipeline`):
+            Environment-side postprocessor pipeline, passed through to `eval_policy`.
+        preprocessor (`PolicyProcessorPipeline`):
+            Policy input preprocessor pipeline, passed through to `eval_policy`.
+        postprocessor (`PolicyProcessorPipeline`):
+            Policy action postprocessor pipeline, passed through to `eval_policy`.
+        seeds (`Sequence[int]`):
+            The seeds to evaluate. Must be non-empty.
+        episodes_per_seed (`int`):
+            Episodes to run for each seed. Must be positive.
+        ci_level (`float`, *optional*, defaults to 0.95):
+            Confidence level for the Wilson interval.
+        videos_dir (`Path`, *optional*):
+            Where to save rendered videos, if any.
+        max_episodes_rendered (`int`, *optional*, defaults to 0):
+            Maximum number of episodes to render into videos, per seed.
+
+    Returns:
+        [`MultiSeedResult`]: The pooled success rate, its Wilson interval, and the per-seed breakdown.
+
+    Raises:
+        ValueError: If `seeds` is empty, `episodes_per_seed` is not positive, or `ci_level` is not in
+            `(0, 1)`.
+
+    Example:
+        ```python
+        >>> from lerobot.eval import run_multi_seed_eval
+        >>> result = run_multi_seed_eval(  # doctest: +SKIP
+        ...     env,
+        ...     policy,
+        ...     env_preprocessor=env_preprocessor,
+        ...     env_postprocessor=env_postprocessor,
+        ...     preprocessor=preprocessor,
+        ...     postprocessor=postprocessor,
+        ...     seeds=[1000, 2000, 3000],
+        ...     episodes_per_seed=50,
+        ... )
+        >>> print(f"{result.success_rate:.2f} [{result.ci_low:.2f}, {result.ci_high:.2f}]")  # doctest: +SKIP
+        0.62 [0.54, 0.69]
+        ```
+    """
+    if len(seeds) == 0:
+        raise ValueError("seeds must be non-empty")
+    if episodes_per_seed <= 0:
+        raise ValueError(f"episodes_per_seed must be positive, got {episodes_per_seed}")
+    if not 0.0 < ci_level < 1.0:
+        raise ValueError(f"ci_level must be in (0, 1), got {ci_level}")
+
+    per_seed: list[SeedResult] = []
+    for seed in seeds:
+        set_seed(seed)
+        info = eval_policy(
+            env,
+            policy,
+            env_preprocessor=env_preprocessor,
+            env_postprocessor=env_postprocessor,
+            preprocessor=preprocessor,
+            postprocessor=postprocessor,
+            n_episodes=episodes_per_seed,
+            max_episodes_rendered=max_episodes_rendered,
+            videos_dir=videos_dir,
+            start_seed=seed,
+        )
+        successes = tuple(bool(ep["success"]) for ep in info["per_episode"])
+        per_seed.append(
+            SeedResult(
+                seed=seed,
+                n_episodes=len(successes),
+                n_successes=sum(successes),
+                success_rate=sum(successes) / len(successes),
+                avg_sum_reward=float(info["aggregated"]["avg_sum_reward"]),
+                avg_max_reward=float(info["aggregated"]["avg_max_reward"]),
+                successes=successes,
+            )
+        )
+
+    n_episodes = sum(s.n_episodes for s in per_seed)
+    n_successes = sum(s.n_successes for s in per_seed)
+    ci_low, ci_high = wilson_ci(n_successes, n_episodes, ci_level=ci_level)
+    return MultiSeedResult(
+        seeds=tuple(seeds),
+        episodes_per_seed=episodes_per_seed,
+        n_episodes=n_episodes,
+        n_successes=n_successes,
+        success_rate=n_successes / n_episodes,
+        ci_low=ci_low,
+        ci_high=ci_high,
+        ci_level=ci_level,
+        per_seed=tuple(per_seed),
+    )

--- a/tests/eval/test_multi_seed.py
+++ b/tests/eval/test_multi_seed.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import pytest
+
+# lerobot.eval.multi_seed imports eval_policy from lerobot.scripts.lerobot_eval, which needs the dataset
+# extra at import time.
+pytest.importorskip("datasets", reason="datasets is required (install lerobot[dataset])")
+
+import lerobot.eval.multi_seed as multi_seed  # noqa: E402
+from lerobot.eval import MultiSeedResult, run_multi_seed_eval, wilson_ci  # noqa: E402
+
+
+def _fake_eval_policy_factory(success_by_seed):
+    """Return a stub for `eval_policy` that emits a fixed pattern of successes per seed.
+
+    `success_by_seed` maps a `start_seed` to the list of per-episode booleans to report. This lets the
+    orchestration be tested without a simulator, GPU, or a real policy.
+    """
+
+    def _fake_eval_policy(env, policy, *, n_episodes, start_seed, **kwargs):
+        successes = success_by_seed[start_seed]
+        assert len(successes) == n_episodes
+        return {
+            "per_episode": [{"success": s, "seed": start_seed + i} for i, s in enumerate(successes)],
+            "aggregated": {
+                "avg_sum_reward": float(np.mean(successes)),
+                "avg_max_reward": float(np.max(successes)),
+                "pc_success": float(np.mean(successes) * 100),
+            },
+        }
+
+    return _fake_eval_policy
+
+
+@pytest.fixture
+def patched_run(monkeypatch):
+    """`run_multi_seed_eval` with `eval_policy` stubbed and the processor args set to None."""
+
+    def _run(success_by_seed, **kwargs):
+        monkeypatch.setattr(multi_seed, "eval_policy", _fake_eval_policy_factory(success_by_seed))
+        return run_multi_seed_eval(
+            env=None,
+            policy=None,
+            env_preprocessor=None,
+            env_postprocessor=None,
+            preprocessor=None,
+            postprocessor=None,
+            seeds=list(success_by_seed),
+            episodes_per_seed=len(next(iter(success_by_seed.values()))),
+            **kwargs,
+        )
+
+    return _run
+
+
+# ---------------------------------------------------------------------- #
+# wilson_ci                                                              #
+# ---------------------------------------------------------------------- #
+
+
+def test_wilson_ci_brackets_point_estimate():
+    lo, hi = wilson_ci(7, 10)
+    assert 0.0 <= lo <= 0.7 <= hi <= 1.0
+
+
+def test_wilson_ci_stays_in_unit_interval_at_extremes():
+    lo, hi = wilson_ci(0, 20)
+    assert lo == 0.0 and 0.0 < hi < 1.0
+    lo, hi = wilson_ci(20, 20)
+    assert 0.0 < lo < 1.0 and hi == 1.0
+
+
+def test_wilson_ci_narrows_with_more_trials():
+    def width(n):
+        lo, hi = wilson_ci(n // 2, n)
+        return hi - lo
+
+    assert width(20) > width(200)
+
+
+def test_wilson_ci_matches_known_reference():
+    # 50 of 100 -> the 0.95 Wilson interval is approximately (0.404, 0.596).
+    lo, hi = wilson_ci(50, 100, ci_level=0.95)
+    assert lo == pytest.approx(0.4038, abs=1e-3)
+    assert hi == pytest.approx(0.5962, abs=1e-3)
+
+
+def test_wilson_ci_level_monotonicity():
+    # A higher confidence level must give a wider interval.
+    lo90, hi90 = wilson_ci(30, 50, ci_level=0.90)
+    lo99, hi99 = wilson_ci(30, 50, ci_level=0.99)
+    assert lo99 < lo90 and hi90 < hi99
+
+
+@pytest.mark.parametrize(
+    ("n_successes", "n_trials"),
+    [(-1, 10), (11, 10), (5, 0)],
+)
+def test_wilson_ci_rejects_invalid_counts(n_successes, n_trials):
+    with pytest.raises(ValueError):
+        wilson_ci(n_successes, n_trials)
+
+
+def test_wilson_ci_rejects_invalid_ci_level():
+    with pytest.raises(ValueError):
+        wilson_ci(5, 10, ci_level=1.0)
+
+
+# ---------------------------------------------------------------------- #
+# run_multi_seed_eval                                                    #
+# ---------------------------------------------------------------------- #
+
+
+def test_pools_outcomes_across_seeds(patched_run):
+    result = patched_run({0: [True, False], 1: [True, True]})
+    assert isinstance(result, MultiSeedResult)
+    assert result.seeds == (0, 1)
+    assert result.episodes_per_seed == 2
+    assert result.n_episodes == 4
+    assert result.n_successes == 3
+    assert result.success_rate == pytest.approx(0.75)
+
+
+def test_per_seed_breakdown_is_preserved(patched_run):
+    result = patched_run({0: [True, False, False], 7: [True, True, False]})
+    assert tuple(s.seed for s in result.per_seed) == (0, 7)
+    assert result.per_seed[0].n_successes == 1
+    assert result.per_seed[1].n_successes == 2
+    assert result.per_seed[0].successes == (True, False, False)
+
+
+def test_all_successes_is_flat_and_ordered(patched_run):
+    result = patched_run({0: [True, False], 1: [False, True]})
+    np.testing.assert_array_equal(result.all_successes, np.array([True, False, False, True]))
+
+
+def test_ci_brackets_pooled_rate(patched_run):
+    result = patched_run({0: [True] * 5, 1: [False] * 5})
+    assert result.success_rate == pytest.approx(0.5)
+    assert result.ci_low < 0.5 < result.ci_high
+
+
+def test_pooled_ci_matches_wilson_over_flat_episodes(patched_run):
+    result = patched_run({0: [True] * 4 + [False], 1: [True] * 3 + [False] * 2})
+    lo, hi = wilson_ci(result.n_successes, result.n_episodes, ci_level=result.ci_level)
+    assert result.ci_low == pytest.approx(lo)
+    assert result.ci_high == pytest.approx(hi)
+
+
+def test_seeding_contract_applies_set_seed_per_seed(patched_run, monkeypatch):
+    seen = []
+    monkeypatch.setattr(multi_seed, "set_seed", lambda s: seen.append(s))
+    patched_run({3: [True], 9: [False], 1: [True]})
+    assert seen == [3, 9, 1]
+
+
+def test_rejects_empty_seeds(monkeypatch):
+    monkeypatch.setattr(multi_seed, "eval_policy", _fake_eval_policy_factory({}))
+    with pytest.raises(ValueError, match="seeds must be non-empty"):
+        run_multi_seed_eval(
+            env=None,
+            policy=None,
+            env_preprocessor=None,
+            env_postprocessor=None,
+            preprocessor=None,
+            postprocessor=None,
+            seeds=[],
+            episodes_per_seed=5,
+        )
+
+
+def test_rejects_nonpositive_episodes(monkeypatch):
+    monkeypatch.setattr(multi_seed, "eval_policy", _fake_eval_policy_factory({0: [True]}))
+    with pytest.raises(ValueError, match="episodes_per_seed must be positive"):
+        run_multi_seed_eval(
+            env=None,
+            policy=None,
+            env_preprocessor=None,
+            env_postprocessor=None,
+            preprocessor=None,
+            postprocessor=None,
+            seeds=[0],
+            episodes_per_seed=0,
+        )

--- a/utils/check_docstrings.py
+++ b/utils/check_docstrings.py
@@ -59,6 +59,7 @@ PATH_TO_LEROBOT = PATH_TO_REPO / "src" / "lerobot"
 
 # Modules whose public objects are checked. Add a module here once its docstrings follow the standard.
 MODULES_TO_CHECK = [
+    "lerobot.eval",
     "lerobot.robots",
 ]
 

--- a/utils/documentation_tests.txt
+++ b/utils/documentation_tests.txt
@@ -10,3 +10,4 @@
 # `utils/check_doctest_list.py` does not care which way round it is.
 #
 # Keep alphabetically sorted: `make check-doctest-list` enforces it, `make fix-docstrings` sorts it.
+src/lerobot/eval/multi_seed.py


### PR DESCRIPTION
# feat(eval): multi-seed evaluation with a Wilson confidence interval

## Summary / Motivation

`lerobot-eval` reports `pc_success` from episodes seeded off a single `start_seed`. That point estimate is fragile: simulator initial conditions, GPU non-determinism, and the policy's own stochasticity all move it, and in our benchmarking we have measured 10+ point swings between seeds for the same checkpoint. This PR adds the missing orchestration layer as a small `lerobot.eval` package: evaluate over a list of seeds, pool the per-episode outcomes, and report one success rate with a Wilson score confidence interval. It is a thin loop over the existing `eval_policy` — no rollout logic is reimplemented, no new dependency is added (the z-quantile comes from `statistics.NormalDist` in the stdlib).

This module is extracted from the [Embodimetry benchmark](https://github.com/thrmnn/embodimetry), where it is the scoring path for the v1 results matrix (110 cell-seed runs, as reported in that repo's README); the seeding contract below is the benchmark's own, and a scored sample of the matrix is committed there at `examples/results-mini.parquet`.

```python
from lerobot.eval import run_multi_seed_eval

result = run_multi_seed_eval(
    env, policy,
    env_preprocessor=env_preprocessor, env_postprocessor=env_postprocessor,
    preprocessor=preprocessor, postprocessor=postprocessor,
    seeds=[1000, 2000, 3000], episodes_per_seed=50,
)
print(f"{result.success_rate:.2f} [{result.ci_low:.2f}, {result.ci_high:.2f}]")
```

**Seeding contract.** For each seed `s`, `set_seed(s)` is applied once (fixing the Python/NumPy/Torch global RNGs), then `eval_policy(..., start_seed=s)` runs `episodes_per_seed` episodes, so episode `e` of seed `s` uses environment seed `s + e`. Only the `(policy, env, seed)` cell as a whole is reproducible, not individual episodes within it — this is documented in the module docstring.

**Statistics scope.** The interval is the textbook Wilson score interval over the flat list of per-episode binary outcomes: the resampling unit is the episode, not the seed. Resampling over the handful of seeds would inflate the interval, which is the common mistake this helper is meant to prevent.

## Related issues

- None found; happy to link if there is prior discussion I missed.

## What changed

- New `src/lerobot/eval/` package: `run_multi_seed_eval`, `wilson_ci`, and frozen `MultiSeedResult` / `SeedResult` dataclasses (pooled rate, interval, per-seed breakdown).
- Docstrings follow `docs/source/writing_docstrings.mdx`; `lerobot.eval` is added to the `check_docstrings` ratchet and `src/lerobot/eval/multi_seed.py` to the doctest allowlist (its `wilson_ci` example executes in CI).
- No changes to `eval_policy`, `eval_policy_all`, or any existing public API. No CLI wiring in this PR — `run_multi_seed_eval` is a library entry point; a `lerobot-eval` flag can be a follow-up if there is interest.

Deliberately excluded (they live in the benchmark, out of scope here): bootstrap and paired-bootstrap intervals, paired policy-vs-policy ranking, minimum-detectable-effect calibration.

## How was this tested (or how to run locally)

- `tests/eval/test_multi_seed.py` (17 tests): Wilson math against a known reference value, boundary exactness at 0/all successes, level monotonicity, input validation, seed accounting (`set_seed` applied per seed, in order), pooling/aggregation, and the pooled-CI-equals-flat-episode-Wilson invariant. `eval_policy` is stubbed, so no simulator or GPU is needed: `uv run pytest tests/eval -q`
- The module needs the `dataset` extra at import time (via `lerobot.scripts.lerobot_eval`), so the test module guards with `pytest.importorskip("datasets", ...)`; verified it skips cleanly in a tier-1 env (`uv sync --locked --extra test` only).
- `pre-commit run` on all touched files, `make check-docstrings`, `make check-doctest-list`, `make doctest`, and the interrogate coverage gate all pass locally.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: #

## Reviewer notes

- The one design decision worth a look: `wilson_ci` pins the bounds to exactly `0.0` / `1.0` at zero / all successes (mathematically exact for Wilson; avoids leaking `1e-17`-style bounds).
- `run_multi_seed_eval` mirrors `eval_policy`'s parameter names and passes the processor pipelines straight through, so it stays compatible with any future `eval_policy` signature work.

