### PR TITLE
fix(envs): make MetaWorld task descriptions unique

### DIFF
--- a/src/lerobot/envs/metaworld_config.json
+++ b/src/lerobot/envs/metaworld_config.json
@@ -32,7 +32,7 @@
     "pick-place-wall-v3": "Pick a puck, bypass a wall and place the puck",
     "pick-out-of-hole-v3": "Pick up a puck from a hole",
     "reach-v3": "Reach a goal position",
-    "push-back-v3": "Push the puck to a goal",
+    "push-back-v3": "Push the puck back toward the robot to the goal",
     "push-v3": "Push the puck to a goal",
     "pick-place-v3": "Pick and place a puck to a goal",
     "plate-slide-v3": "Slide a plate into a cabinet",

--- a/tests/envs/test_metaworld_config.py
+++ b/tests/envs/test_metaworld_config.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+from pathlib import Path
+
+CONFIG_PATH = Path(__file__).resolve().parents[2] / "src" / "lerobot" / "envs" / "metaworld_config.json"
+
+
+def test_metaworld_task_descriptions_are_complete_and_unique() -> None:
+    config = json.loads(CONFIG_PATH.read_text())
+    descriptions = config["TASK_DESCRIPTIONS"]
+    task_ids = config["TASK_NAME_TO_ID"]
+
+    assert descriptions.keys() == task_ids.keys()
+    assert len(descriptions) == 50
+    assert set(task_ids.values()) == set(range(50))
+    assert len(set(descriptions.values())) == len(descriptions)
+    assert task_ids["push-back-v3"] == 37
+    assert task_ids["push-v3"] == 38
+    assert descriptions["push-back-v3"] != descriptions["push-v3"]


### PR DESCRIPTION
## Summary / Motivation

MetaWorld's `push-back-v3` and `push-v3` entries currently use the identical
description `Push the puck to a goal`.

`MetaWorldEnv.task_description` supplies the language task used during
evaluation and dataset collection, while LeRobot task registries are keyed by
description text. Future datasets can therefore collapse these two canonical
environments into one language label.

This patch gives `push-back-v3` a direction-specific description and adds
regression checks for the complete MT50 task registry.

The existing `lerobot/metaworld_mt50` Hub revision is not modified by this PR;
its repair is tracked separately in #4409.

## Related issues

- Related: #1578
- Related: #4409

Evidence and full-corpus audit:
https://github.com/sawhney17/metaworld-mt50-task-audit/releases/tag/v0.1.0

## What changed

- Changed `push-back-v3` to
  `Push the puck back toward the robot to the goal`.
- Added a config-only regression test asserting:
  - description and ID registries contain the same 50 keys;
  - canonical IDs are exactly 0–49;
  - all 50 descriptions are unique;
  - `push-back-v3` and `push-v3` remain IDs 37 and 38 and have distinct text.
- Did not change task IDs, action semantics, environment behavior, or existing
  Hub data.

The exact wording remains open to maintainer preference; uniqueness and
directional distinction are the required properties.

## How was this tested (or how to run locally)

- `pytest -q tests/envs/test_metaworld_config.py` — 1 passed.
- `pre-commit run -a` — all hooks passed.
- `git diff --check origin/main...HEAD` — passed.
- Separate hash-pinned audit of all 492 Parquets in the existing Hub dataset.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [ ] All tests pass locally (`pytest`) — targeted test passes; full suite/CI pending
- [x] Documentation updated — no separate user documentation is needed for this config-only correction
- [ ] CI is green
- [x] Community Review: https://github.com/huggingface/lerobot/pull/4391#pullrequestreview-4895247708

## Reviewer notes

Please focus on the exact instruction wording and the registry invariants.

The audit's historical boundary is explicit: the exact generator revision for
the existing dataset is not established. This PR prevents the duplicated
description in future collection/evaluation; it does not rewrite the
historical Hub dataset, claim missing trajectories, or claim a measured
benchmark improvement.
