### PR TITLE
fix(async_inference): register ZMQ camera config in robot_client

### DIFF
--- a/src/lerobot/async_inference/robot_client.py
+++ b/src/lerobot/async_inference/robot_client.py
@@ -49,6 +49,7 @@ import torch
 
 from lerobot.cameras.opencv import OpenCVCameraConfig  # noqa: F401
 from lerobot.cameras.realsense import RealSenseCameraConfig  # noqa: F401
+from lerobot.cameras.zmq import ZMQCameraConfig  # noqa: F401
 from lerobot.robots import (  # noqa: F401
     Robot,
     RobotConfig,


### PR DESCRIPTION
## Summary / Motivation

`ZMQCameraConfig` is registered with draccus through `@CameraConfig.register_subclass("zmq")`, which only runs if the module gets imported `robot_client.py` imports the OpenCV and RealSense configs but not the ZMQ one so starting a robot client against a config with `type: zmq` fails to resolve the camera type. Every other robot facing entry point (`lerobot_record`, `lerobot_teleoperate`, `lerobot_rollout`) already imports it.

## Related issues

- Fixes #4383
- Same class of problem as #3330

## What changed

- `src/lerobot/async_inference/robot_client.py`: added `from lerobot.cameras.zmq import ZMQCameraConfig  # noqa: F401`, matching what `lerobot_teleoperate.py` and `lerobot_rollout.py` already do.

## How was this tested (or how to run locally)

With only the imports `robot_client.py` had before this change:

```python
from lerobot.cameras import CameraConfig
import lerobot.cameras.opencv, lerobot.cameras.realsense

CameraConfig.get_choice_class("zmq")
# KeyError: 'zmq'

import lerobot.cameras.zmq
CameraConfig.get_choice_class("zmq")
# <class 'lerobot.cameras.zmq.configuration_zmq.ZMQCameraConfig'>
```

After the change `zmq` shows up in the registry when `lerobot.async_inference.robot_client` is imported:

```
choices reachable from robot_client: ['intelrealsense', 'opencv', 'zmq']
zmq resolves -> ZMQCameraConfig
```

`ruff check` and `ruff format --check` pass on the touched file.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [ ] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: #

## Reviewer notes

- Kept this to the ZMQ import only. `lerobot_record.py` also imports `Reachy2CameraConfig` which `robot_client.py` still lacks. I can add that as well if you want both entry points aligned. It is outside what the issue reports so I left it out.
