### PR TITLE
fix(rollout): align state order with checkpoint

### DIFF
--- a/src/lerobot/rollout/context.py
+++ b/src/lerobot/rollout/context.py
@@ -119,6 +119,31 @@ def _resolve_action_key_order(
     return policy_action_names
 
 
+def _align_state_feature_order(
+    observation_features_hw: dict[str, type | tuple], policy_action_names: list[str] | None
+) -> dict[str, type | tuple]:
+    """Order scalar state features to match the checkpoint's joint order."""
+    if not policy_action_names:
+        return observation_features_hw
+
+    scalar_names = [
+        name for name, feature in observation_features_hw.items() if not isinstance(feature, tuple)
+    ]
+    if set(scalar_names) != set(policy_action_names) or scalar_names == policy_action_names:
+        return observation_features_hw
+
+    reordered = {name: observation_features_hw[name] for name in policy_action_names}
+    reordered.update(
+        {name: feature for name, feature in observation_features_hw.items() if name not in reordered}
+    )
+    logger.warning(
+        "Robot state order %s differs from checkpoint joint order %s; reordering state",
+        scalar_names,
+        policy_action_names,
+    )
+    return reordered
+
+
 # ---------------------------------------------------------------------------
 # Sub-contexts
 # ---------------------------------------------------------------------------
@@ -350,6 +375,11 @@ def build_rollout_context(
         for k, v in all_obs_features.items()
         if isinstance(v, tuple) or (v is float and k.endswith((".pos", ".vel")))
     }
+    policy_action_names = getattr(policy_config, "action_feature_names", None)
+    observation_features_hw = _align_state_feature_order(
+        observation_features_hw,
+        list(policy_action_names) if policy_action_names else None,
+    )
     # Keep both joint-position (.pos) and base-velocity (.vel) action features so
     # mobile manipulators command the base too (e.g. LeKiwi: 6 arm .pos +
     # x/y/theta.vel = 9-dim action). Pure-arm robots have no .vel keys, so this is
@@ -373,7 +403,6 @@ def build_rollout_context(
     dataset_features = combine_feature_dicts(action_dataset_features, observation_dataset_features)
     hw_features = hw_to_dataset_features(observation_features_hw, "observation")
     raw_action_keys = list(action_features_hw.keys())
-    policy_action_names = getattr(policy_config, "action_feature_names", None)
     ordered_action_keys = _resolve_action_key_order(
         list(policy_action_names) if policy_action_names else None,
         raw_action_keys,

--- a/tests/test_rollout.py
+++ b/tests/test_rollout.py
@@ -368,6 +368,55 @@ def test_create_inference_engine_sync():
 # ---------------------------------------------------------------------------
 
 
+def test_align_state_feature_order_matches_checkpoint_and_preserves_cameras(caplog):
+    from lerobot.rollout.context import _align_state_feature_order
+    from lerobot.utils.feature_utils import build_dataset_frame, hw_to_dataset_features
+
+    features = {
+        "wrist_camera": (480, 640, 3),
+        "joint_b.pos": float,
+        "joint_a.pos": float,
+    }
+
+    aligned = _align_state_feature_order(features, ["joint_a.pos", "joint_b.pos"])
+
+    assert list(aligned) == ["joint_a.pos", "joint_b.pos", "wrist_camera"]
+    assert aligned["wrist_camera"] == (480, 640, 3)
+    assert "reordering state" in caplog.text
+
+    dataset_features = hw_to_dataset_features(aligned, "observation")
+    frame = build_dataset_frame(
+        dataset_features,
+        {"joint_a.pos": 1.0, "joint_b.pos": 2.0, "wrist_camera": object()},
+        "observation",
+    )
+    assert frame["observation.state"].tolist() == [1.0, 2.0]
+
+
+@pytest.mark.parametrize(
+    ("policy_action_names", "feature_names"),
+    [
+        (None, ["joint_b.pos", "joint_a.pos", "wrist_camera"]),
+        (["joint_b.pos", "joint_a.pos"], ["joint_b.pos", "joint_a.pos", "wrist_camera"]),
+        (["joint_a.pos"], ["joint_b.pos", "joint_a.pos", "wrist_camera"]),
+        (["joint_a.pos", "gripper.pos"], ["joint_b.pos", "joint_a.pos", "wrist_camera"]),
+    ],
+)
+def test_align_state_feature_order_is_noop_without_an_exact_name_match(policy_action_names, feature_names):
+    from lerobot.rollout.context import _align_state_feature_order
+
+    features = {
+        "joint_b.pos": float,
+        "joint_a.pos": float,
+        "wrist_camera": (480, 640, 3),
+    }
+
+    aligned = _align_state_feature_order(features, policy_action_names)
+
+    assert aligned is features
+    assert list(aligned) == feature_names
+
+
 def test_estimate_max_episode_seconds_no_video():
     from lerobot.rollout.strategies import estimate_max_episode_seconds
 


### PR DESCRIPTION
## Summary

- reorder policy-facing scalar observation features to the checkpoint action-name order when both schemas contain exactly the same names
- apply the alignment for absolute- and relative-action policies before rollout feature aggregation
- preserve camera features and leave missing, partial, or mismatched schemas unchanged
- test the resulting packed `observation.state` tensor, camera preservation, and all no-op cases

## Why

`build_dataset_frame` packs `observation.state` in feature-name order. When robot hardware reports the same joints in a different order from `policy.action_feature_names`, normalization and policy inference receive permuted state values. This affects absolute actions as well as relative actions.

This extracts the general ordering fix requested in the review of #4056 into a small prerequisite PR, avoiding coupling it to training-time RTC and reducing overlap with #4057.

## Validation

- `pytest tests/test_rollout.py -q` — 32 passed
- `pre-commit run --files src/lerobot/rollout/context.py tests/test_rollout.py` — passed