### PR TITLE
Warn when freezing VLA-JEPA Qwen conditioning

### DIFF
--- a/src/lerobot/policies/vla_jepa/configuration_vla_jepa.py
+++ b/src/lerobot/policies/vla_jepa/configuration_vla_jepa.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -22,6 +23,8 @@ from lerobot.configs.types import FeatureType, NormalizationMode, PolicyFeature
 from lerobot.optim.optimizers import AdamWConfig
 from lerobot.optim.schedulers import CosineDecayWithWarmupSchedulerConfig
 from lerobot.utils.constants import OBS_STATE
+
+logger = logging.getLogger(__name__)
 
 
 @PreTrainedConfig.register_subclass("vla_jepa")
@@ -107,6 +110,14 @@ class VLAJEPAConfig(PreTrainedConfig):
         if self.freeze_qwen and self.enable_world_model:
             # freezing qwen backbone makes world model training irrelevant since no grad flows
             self.enable_world_model = False
+        if self.freeze_qwen:
+            logger.warning(
+                "freeze_qwen=True: action-head conditioning is read from %s positions at the last "
+                "decoder layer. These learned readouts stay fixed from the source checkpoint and "
+                "cannot adapt to a new embodiment while the Qwen backbone is frozen, so conditioning "
+                "quality may degrade under domain shift.",
+                self.embodied_action_token,
+            )
         if self.n_action_steps > self.chunk_size:
             raise ValueError("`n_action_steps` must be <= `chunk_size`.")
         if self.num_video_frames < 2 * self.jepa_tubelet_size:

--- a/tests/policies/vla_jepa/test_configuration.py
+++ b/tests/policies/vla_jepa/test_configuration.py
@@ -31,6 +31,17 @@ def test_too_few_video_frames_raises() -> None:
         )
 
 
+def test_freeze_qwen_warns_about_fixed_embodied_action_readouts(caplog: pytest.LogCaptureFixture) -> None:
+    with caplog.at_level("WARNING", logger="lerobot.policies.vla_jepa.configuration_vla_jepa"):
+        config = VLAJEPAConfig(freeze_qwen=True)
+
+    assert not config.enable_world_model
+    assert "freeze_qwen=True" in caplog.text
+    assert "<|embodied_action|>" in caplog.text
+    assert "source checkpoint" in caplog.text
+    assert "domain shift" in caplog.text
+
+
 def test_validate_features_no_image_raises() -> None:
     config = VLAJEPAConfig(
         input_features={OBS_STATE: PolicyFeature(type=FeatureType.STATE, shape=(STATE_DIM,))},


### PR DESCRIPTION
## Summary / Motivation

Warn users when `VLAJEPAConfig.freeze_qwen=True`, because the action head still reads conditioning from learned `<|embodied_action|>` readouts at the last decoder layer. With the Qwen backbone frozen, those readouts remain fixed from the source checkpoint and cannot adapt to a new embodiment.

Fixes #4414

## What changed

- Add a `freeze_qwen=True` warning in `VLAJEPAConfig.__post_init__`.
- Keep the existing behavior that disables the world model when Qwen is frozen.
- Add regression coverage for the warning text and world-model fallback.

## How was this tested

- `uv run pytest tests/policies/vla_jepa/test_configuration.py -q`
- `uv run --extra dev ruff check src/lerobot/policies/vla_jepa/configuration_vla_jepa.py tests/policies/vla_jepa/test_configuration.py`
- `uv run --extra dev ruff format --check src/lerobot/policies/vla_jepa/configuration_vla_jepa.py tests/policies/vla_jepa/test_configuration.py`
- `git diff --check`