### PR TITLE
fix(policies): raise clear error on checkpoint/model dimension mismatch

### DIFF
--- a/src/lerobot/policies/pretrained.py
+++ b/src/lerobot/policies/pretrained.py
@@ -206,9 +206,21 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
 
     @classmethod
     def _load_as_safetensor(cls, model: T, model_file: str, map_location: str, strict: bool) -> T:
-        missing_keys, unexpected_keys = load_model_as_safetensor(
-            model, model_file, strict=strict, device=resolve_safetensors_device(map_location)
-        )
+        try:
+            missing_keys, unexpected_keys = load_model_as_safetensor(
+                model, model_file, strict=strict, device=resolve_safetensors_device(map_location)
+            )
+        except RuntimeError as e:
+            if "size mismatch" in str(e):
+                raise RuntimeError(
+                    f"{e}\n\nThe checkpoint's weights have different shapes than this model expects, "
+                    "most likely because the model's action/state feature dimensions (derived from its "
+                    "config or the dataset it was built for) don't match the ones the checkpoint was "
+                    "trained with. Verify that the checkpoint and the dataset/config you're loading it "
+                    "with are compatible (e.g. same robot, same number of joints/cameras), or use a "
+                    "checkpoint fine-tuned for your dataset instead."
+                ) from e
+            raise
         log_model_loading_keys(missing_keys, unexpected_keys)
         return model
 

--- a/tests/policies/test_policies.py
+++ b/tests/policies/test_policies.py
@@ -328,6 +328,32 @@ def test_save_pretrained_single_file_artifact(dummy_dataset_metadata, tmp_path):
     torch.testing.assert_close(list(policy.parameters()), list(loaded_policy.parameters()), rtol=0, atol=0)
 
 
+def test_load_pretrained_dimension_mismatch_error(dummy_dataset_metadata, tmp_path):
+    """Loading a checkpoint into a model with different action/state dims should raise a clear error."""
+    policy_cls = get_policy_class("act")
+    policy_cfg = make_policy_config("act")
+    features = dataset_to_policy_features(dummy_dataset_metadata.features)
+    policy_cfg.output_features = {key: ft for key, ft in features.items() if ft.type is FeatureType.ACTION}
+    policy_cfg.input_features = {
+        key: ft for key, ft in features.items() if key not in policy_cfg.output_features
+    }
+    policy = policy_cls(policy_cfg)
+    policy.to(policy_cfg.device)
+    save_dir = tmp_path / "dimension_mismatch"
+    policy.save_pretrained(save_dir)
+
+    # A config whose action dimension differs from the saved checkpoint's, simulating loading a
+    # checkpoint trained for one robot's action/state dims into a model built for another's.
+    mismatched_cfg = deepcopy(policy_cfg)
+    mismatched_cfg.output_features = {
+        key: PolicyFeature(type=ft.type, shape=(ft.shape[0] * 2,))
+        for key, ft in policy_cfg.output_features.items()
+    }
+
+    with pytest.raises(RuntimeError, match="action/state feature dimensions"):
+        policy_cls.from_pretrained(save_dir, config=mismatched_cfg)
+
+
 @pytest.mark.parametrize("multikey", [True, False])
 def test_multikey_construction(multikey: bool):
     """


### PR DESCRIPTION
## Summary

Loading a pretrained checkpoint into a policy whose action/state feature dimensions differ from the checkpoint's currently surfaces a raw PyTorch error like:

```
size mismatch for model.action_in_proj.weight: copying a param with shape torch.Size([1024, 32]) from checkpoint, the shape in current model is torch.Size([1024, 8])
```

with no indication of what caused it or how to fix it. This is exactly what happens in #2963: `pi05_base` was trained on Aloha's 32-dim action/state, and the official Quick Start example pairs it with the 8-dim `lerobot/libero` dataset.

This PR catches that `RuntimeError` in `PreTrainedPolicy._load_as_safetensor` (`src/lerobot/policies/pretrained.py`) and re-raises it with an explanation of the likely cause and a suggested fix. The fix is generic — it applies to any policy/checkpoint combination with mismatched dimensions, not just `pi05_base` + `lerobot/libero`.

Closes #2963

## Test plan

- [x] Added `test_load_pretrained_dimension_mismatch_error` in `tests/policies/test_policies.py`, which saves an `act` checkpoint and loads it into a config with doubled action dims, asserting the new error message is raised.
- [x] `uv run pytest tests/policies/test_policies.py -svv --maxfail=10` — 16 passed, 11 skipped (pre-existing skips, unrelated to this change).
- [x] `uv run ruff check` / `ruff format --check` on changed files — clean.