### PR TITLE
feat(pi05): piR2 inference engine

### DIFF
--- a/src/lerobot/policies/common/flow_matching.py
+++ b/src/lerobot/policies/common/flow_matching.py
@@ -58,6 +58,77 @@ def sample_time_beta(bsize: int, device, *, alpha: float, beta: float, scale: fl
     return time.to(dtype=torch.float32, device=device)
 
 
+def staircase_time(delay: int, horizon: int, *, device, dtype: torch.dtype = torch.float32) -> Tensor:
+    """Per-position flow timestep of the piR2 staircase (arXiv 2607.26055, Eq. 3).
+
+    The paper states the schedule as three regions with tau=1 clean and tau=0 noise. Under this
+    module's convention (t=1 noise, t=0 clean) the clean front and the pure-noise tail are just
+    where the interior ramp saturates, so a single clamped ramp reproduces all three.
+
+    Args:
+        delay: Number of in-flight actions ``d``; also the number of slots emitted per call.
+        horizon: Chunk length ``H``.
+
+    Returns:
+        Shape ``(horizon,)``: ``0`` over the clean front, a linear ramp of slope
+        ``1 / (H - 2d)`` across the interior, and ``1`` over the pure-noise tail.
+    """
+    positions = torch.arange(horizon, device=device, dtype=dtype)
+    interior = max(horizon - 2 * delay, 1)
+    return ((positions - delay) / interior).clamp(0.0, 1.0)
+
+
+def staircase_substep(
+    denoise_fn: Callable[[Tensor, Tensor], Tensor],
+    x_t: Tensor,
+    delay: int,
+    *,
+    noise: Tensor | None = None,
+) -> tuple[Tensor, Tensor]:
+    """One piR2 inference call: advance the buffer, emit ``delay`` actions, slide (Eq. 4, Fig. 2).
+
+    A single velocity evaluation shifts the whole schedule right by ``delay`` positions, which
+    carries positions ``[delay, 2 * delay)`` all the way to clean. Those are handed to the robot,
+    the buffer slides forward, and ``delay`` fresh-noise slots are appended, leaving the schedule
+    identical to the one this call started from.
+
+    Args:
+        denoise_fn: Maps ``(x_t, per_position_time)`` to a velocity of the same shape as ``x_t``.
+        x_t: Buffer of shape ``(batch, horizon, action_dim)`` sitting at ``staircase_time(delay, ...)``.
+        delay: Measured inference delay in control steps; must be at least 1 to emit anything.
+        noise: Optional tail noise of shape ``(batch, delay, action_dim)``, for deterministic tests.
+
+    Returns:
+        ``(emitted, next_buffer)`` where ``emitted`` is ``(batch, delay, action_dim)`` of finished
+        actions and ``next_buffer`` has the same shape as ``x_t``.
+    """
+    if x_t.ndim != 3:
+        raise ValueError(f"Expected a (batch, horizon, action_dim) buffer, got {tuple(x_t.shape)}")
+    horizon = x_t.shape[1]
+    if delay < 1:
+        raise ValueError(
+            f"staircase_substep emits `delay` actions per call, so delay must be >= 1, got {delay}"
+        )
+    if 2 * delay > horizon:
+        raise ValueError(f"delay ({delay}) must satisfy 2 * delay <= horizon ({horizon})")
+
+    time = staircase_time(delay, horizon, device=x_t.device, dtype=x_t.dtype)
+    # Shifting the schedule right by `delay` is what defines the per-position advance: each
+    # position inherits the noise level of the one `delay` slots behind it, and the front of the
+    # ramp lands on zero.
+    shifted_index = (torch.arange(horizon, device=x_t.device) - delay).clamp(min=0)
+    dt = time[shifted_index] - time
+
+    v_t = denoise_fn(x_t, time.unsqueeze(0).expand(x_t.shape[0], horizon))
+    x_t = x_t + dt[None, :, None] * v_t
+
+    emitted = x_t[:, delay : 2 * delay]
+    if noise is None:
+        noise = sample_noise((x_t.shape[0], delay, x_t.shape[2]), x_t.device).to(dtype=x_t.dtype)
+    next_buffer = torch.cat([x_t[:, delay:], noise], dim=1)
+    return emitted, next_buffer
+
+
 def euler_integrate(
     denoise_fn: Callable[[Tensor, Tensor], Tensor],
     noise: Tensor,

--- a/src/lerobot/policies/pi05/configuration_pi05.py
+++ b/src/lerobot/policies/pi05/configuration_pi05.py
@@ -75,6 +75,17 @@ class PI05Config(PreTrainedConfig):
     rtc_config: RTCConfig | None = None
     # Maximum clean action-prefix length sampled during training. Zero disables trained RTC.
     rtc_training_max_delay: int = 0
+    # Per-position noise schedule used once ``rtc_training_max_delay > 0``:
+    #   "prefix"    -- training-time RTC: clean front, one shared noise level behind it.
+    #   "staircase" -- piR2 (arXiv 2607.26055): clean front, linear ramp, pure-noise tail.
+    # The staircase is a diffusion-forcing generalization of "prefix"; it is what lets a
+    # single denoising step emit ``delay`` finished actions at inference.
+    rtc_training_schedule: str = "prefix"
+    # Fraction of staircase batches replaced by a standard shared-timestep flow batch, so the
+    # same weights can still denoise a full chunk from pure noise to warm-start the buffer.
+    staircase_warmup_prob: float = 0.2
+    # Symmetric per-position jitter added to the staircase to absorb per-call delay variation.
+    staircase_time_jitter: float = 0.0
 
     image_resolution: tuple[int, int] = (
         DEFAULT_IMAGE_SIZE,
@@ -131,6 +142,25 @@ class PI05Config(PreTrainedConfig):
                 "rtc_training_max_delay must satisfy "
                 f"0 <= delay < chunk_size ({self.chunk_size}), got {self.rtc_training_max_delay}"
             )
+        if self.rtc_training_schedule not in ("prefix", "staircase"):
+            raise ValueError(
+                f"rtc_training_schedule must be 'prefix' or 'staircase', got {self.rtc_training_schedule!r}"
+            )
+        if self.rtc_training_schedule == "staircase":
+            if self.rtc_training_max_delay <= 0:
+                raise ValueError("rtc_training_schedule='staircase' requires rtc_training_max_delay > 0.")
+            # The ramp spans chunk_size - 2 * delay positions, so the widest sampled delay must
+            # still leave a non-empty interior between the clean front and the pure-noise tail.
+            if self.chunk_size - 2 * self.rtc_training_max_delay < 1:
+                raise ValueError(
+                    "rtc_training_schedule='staircase' requires "
+                    f"chunk_size - 2 * rtc_training_max_delay >= 1, got "
+                    f"{self.chunk_size} - 2 * {self.rtc_training_max_delay}"
+                )
+        if not 0.0 <= self.staircase_warmup_prob <= 1.0:
+            raise ValueError(f"staircase_warmup_prob must be in [0, 1], got {self.staircase_warmup_prob}")
+        if not 0.0 <= self.staircase_time_jitter <= 1.0:
+            raise ValueError(f"staircase_time_jitter must be in [0, 1], got {self.staircase_time_jitter}")
 
         if self.paligemma_variant not in ["gemma_300m", "gemma_2b"]:
             raise ValueError(f"Invalid paligemma_variant: {self.paligemma_variant}")

--- a/src/lerobot/policies/pi05/modeling_pi05.py
+++ b/src/lerobot/policies/pi05/modeling_pi05.py
@@ -146,7 +146,7 @@ def _sample_training_rtc_prefix_mask(
 
 
 @dataclass
-class PiR2SlowChannel:
+class CachedPrefix:
     """Cached vision-language prefix, valid across many action-expert calls.
 
     Holding this instead of re-running the backbone every call is what takes the VLM off the
@@ -910,9 +910,9 @@ class PI05Pytorch(nn.Module):  # see openpi `PI0Pytorch`
     def prefill_prefix(self, images, img_masks, tokens, masks, states=None, state_masks=None):
         """Run the vision-language prefix once and return its attention mask and KV cache.
 
-        This is piR2's slow channel (arXiv 2607.26055): the cache is valid for as many action
-        expert calls as you care to make against it, so a background thread can refresh it on
-        its own cadence while the expert keeps denoising against the last one.
+        The cache stays valid for as many action-expert calls as you care to make against it, so
+        a background thread can refresh it as fast as the backbone allows while the expert keeps
+        denoising against the newest one available (arXiv 2607.26055, Sec. 3.2).
         """
         prefix_embs, prefix_pad_masks, prefix_att_masks = self.embed_prefix(
             images, img_masks, tokens, masks, states, state_masks
@@ -1476,7 +1476,7 @@ class PI05Policy(PreTrainedPolicy):
         return actions
 
     @torch.no_grad()
-    def encode_slow_channel(self, batch: dict[str, Tensor]) -> PiR2SlowChannel:
+    def encode_prefix(self, batch: dict[str, Tensor]) -> CachedPrefix:
         """Run the vision-language prefix and return a cache the action expert can reuse.
 
         In piR2 this is the only work that scales with backbone size, and it is meant to run on
@@ -1489,29 +1489,29 @@ class PI05Policy(PreTrainedPolicy):
         prefix_pad_masks, past_key_values = self.model.prefill_prefix(
             images, img_masks, tokens, masks, states, state_masks
         )
-        return PiR2SlowChannel(
+        return CachedPrefix(
             prefix_pad_masks=prefix_pad_masks,
             past_key_values=past_key_values,
             captured_at=time.perf_counter(),
         )
 
     @torch.no_grad()
-    def warm_start_realtime_buffer(self, slow: PiR2SlowChannel, delay: int) -> Tensor:
+    def warm_start_realtime_buffer(self, prefix: CachedPrefix, delay: int) -> Tensor:
         """Build the initial action buffer at episode start, when nothing is in flight yet."""
         self.eval()
-        return self.model.warm_start_staircase_buffer(slow.prefix_pad_masks, slow.past_key_values, delay)
+        return self.model.warm_start_staircase_buffer(prefix.prefix_pad_masks, prefix.past_key_values, delay)
 
     @torch.no_grad()
-    def realtime_substep(self, slow: PiR2SlowChannel, buffer: Tensor, delay: int) -> tuple[Tensor, Tensor]:
+    def realtime_substep(self, prefix: CachedPrefix, buffer: Tensor, delay: int) -> tuple[Tensor, Tensor]:
         """Advance the buffer by one denoising step, returning ``delay`` finished actions.
 
-        ``slow`` may have been encoded several control steps ago; the clamped clean front of
+        ``prefix`` may have been encoded several control steps ago; the clamped clean front of
         ``buffer`` is what tells the expert where the robot currently is.
         """
         self.eval()
         emitted, next_buffer = self.model.staircase_denoise_step(
-            slow.prefix_pad_masks,
-            slow.past_key_values,
+            prefix.prefix_pad_masks,
+            prefix.past_key_values,
             buffer,
             delay,
         )

--- a/src/lerobot/policies/pi05/modeling_pi05.py
+++ b/src/lerobot/policies/pi05/modeling_pi05.py
@@ -16,7 +16,9 @@
 
 import builtins
 import logging
+import time
 from collections import deque
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, TypedDict, Unpack
 
@@ -52,7 +54,13 @@ from lerobot.utils.constants import (
     OBS_STATE,
 )
 
-from ..common.flow_matching import euler_integrate, sample_noise, sample_time_beta
+from ..common.flow_matching import (
+    euler_integrate,
+    sample_noise,
+    sample_time_beta,
+    staircase_substep,
+    staircase_time,
+)
 from ..common.vla_utils import (
     clone_past_key_values,
     create_sinusoidal_pos_embedding,
@@ -137,14 +145,79 @@ def _sample_training_rtc_prefix_mask(
     return positions.unsqueeze(0) < delays.unsqueeze(1)
 
 
+@dataclass
+class PiR2SlowChannel:
+    """Cached vision-language prefix, valid across many action-expert calls.
+
+    Holding this instead of re-running the backbone every call is what takes the VLM off the
+    control-rate critical path (arXiv 2607.26055, Sec. 3.2).
+    """
+
+    prefix_pad_masks: Tensor
+    past_key_values: object
+    # ``time.perf_counter()`` at capture, so the engine can tell the expert how stale this is.
+    captured_at: float | None = None
+
+
+def _build_staircase_schedule(
+    batch_size: int,
+    action_horizon: int,
+    max_delay: int,
+    shared_time: Tensor,
+    *,
+    time_jitter: float = 0.0,
+    warmup_prob: float = 0.0,
+) -> tuple[Tensor, Tensor]:
+    """Sample the piR2 latency-adaptive staircase (arXiv 2607.26055, Eq. 3).
+
+    The paper writes the schedule with tau=1 clean and tau=0 noise, in three regions: a clean
+    front of ``delay`` in-flight actions, a linear ramp across the interior, and a pure-noise
+    tail of ``delay`` freshly appended slots. Under this file's opposite convention (t=0 clean,
+    t=1 noise) all three collapse into one clamped ramp, since the clamp reproduces the flat
+    front and tail exactly.
+
+    Returns ``(prefix_mask, position_time)``: the front positions to clamp and drop from the
+    loss, and the per-position flow timestep.
+    """
+    device = shared_time.device
+    delays = torch.randint(0, max_delay + 1, (batch_size, 1), device=device)
+    positions = torch.arange(action_horizon, device=device).unsqueeze(0)
+    # Ramp slope 1 / (H - 2d); the widest delay is validated to leave a non-empty interior.
+    interior = (action_horizon - 2 * delays).clamp(min=1)
+    position_time = ((positions - delays) / interior).clamp(0.0, 1.0).to(shared_time.dtype)
+
+    if time_jitter > 0.0:
+        # Paper Alg. 1 line 11 jitters every position, including the front, and then overwrites
+        # the front with ground-truth actions without restoring its timestep.
+        jitter = torch.empty_like(position_time).uniform_(-time_jitter, time_jitter)
+        position_time = (position_time + jitter).clamp(0.0, 1.0)
+
+    prefix_mask = positions < delays
+
+    if warmup_prob > 0.0:
+        # Warm-up branch: a standard shared-timestep flow batch with no clamped front, so the
+        # same weights can still denoise a chunk from pure noise to initialize the buffer.
+        # The paper draws this once per batch; drawing per example gives the same expectation
+        # with lower variance.
+        is_warmup = torch.rand((batch_size, 1), device=device) < warmup_prob
+        position_time = torch.where(is_warmup, shared_time[:, None].expand_as(position_time), position_time)
+        prefix_mask = prefix_mask & ~is_warmup
+
+    return prefix_mask, position_time
+
+
 def _build_flow_matching_inputs(
     actions: Tensor,
     noise: Tensor,
     time: Tensor,
     prefix_mask: Tensor | None,
+    position_time: Tensor | None = None,
 ) -> tuple[Tensor, Tensor]:
     """Keep the sampled RTC prefix clean while noising the remaining action chunk."""
-    if prefix_mask is None:
+    if position_time is not None:
+        model_time = position_time
+        expanded_time = position_time.unsqueeze(-1)
+    elif prefix_mask is None:
         model_time = time
         expanded_time = time[:, None, None]
     else:
@@ -152,6 +225,10 @@ def _build_flow_matching_inputs(
         model_time = torch.where(prefix_mask, torch.zeros_like(model_time), model_time)
         expanded_time = model_time.unsqueeze(-1)
     x_t = expanded_time * noise + (1 - expanded_time) * actions
+    if position_time is not None and prefix_mask is not None:
+        # A jittered front carries a timestep slightly off zero, so the clean values have to be
+        # written in explicitly rather than falling out of the interpolation.
+        x_t = torch.where(prefix_mask.unsqueeze(-1), actions, x_t)
     return x_t, model_time
 
 
@@ -715,9 +792,10 @@ class PI05Pytorch(nn.Module):  # see openpi `PI0Pytorch`
         prefix_mask: Tensor | None = None,
         states=None,
         state_masks=None,
+        position_time: Tensor | None = None,
     ) -> Tensor:
         """Do a full training forward pass and compute the loss."""
-        x_t, model_time = _build_flow_matching_inputs(actions, noise, time, prefix_mask)
+        x_t, model_time = _build_flow_matching_inputs(actions, noise, time, prefix_mask, position_time)
         u_t = noise - actions
 
         prefix_embs, prefix_pad_masks, prefix_att_masks = self.embed_prefix(
@@ -794,21 +872,8 @@ class PI05Pytorch(nn.Module):  # see openpi `PI0Pytorch`
             )  # Use config max_action_dim for internal processing
             noise = self.sample_noise(actions_shape, device)
 
-        prefix_embs, prefix_pad_masks, prefix_att_masks = self.embed_prefix(
+        prefix_pad_masks, past_key_values = self.prefill_prefix(
             images, img_masks, tokens, masks, states, state_masks
-        )
-        prefix_att_2d_masks = make_att_2d_masks(prefix_pad_masks, prefix_att_masks)
-        prefix_position_ids = torch.cumsum(prefix_pad_masks, dim=1) - 1
-
-        prefix_att_2d_masks_4d = prepare_attention_masks_4d(prefix_att_2d_masks)
-        self.paligemma_with_expert.paligemma.model.language_model.config._attn_implementation = "eager"  # noqa: SLF001
-
-        _, past_key_values = self.paligemma_with_expert.forward(
-            attention_mask=prefix_att_2d_masks_4d,
-            position_ids=prefix_position_ids,
-            past_key_values=None,
-            inputs_embeds=[prefix_embs, None],
-            use_cache=True,
         )
 
         rtc_mode = "guided"
@@ -830,12 +895,7 @@ class PI05Pytorch(nn.Module):  # see openpi `PI0Pytorch`
                 )
 
         return euler_integrate(
-            lambda input_x_t, current_timestep: self.denoise_step(
-                prefix_pad_masks=prefix_pad_masks,
-                past_key_values=past_key_values,
-                x_t=input_x_t,
-                timestep=current_timestep,
-            ),
+            self._prefix_denoise_fn(prefix_pad_masks, past_key_values),
             noise,
             num_steps,
             rtc_processor=self.rtc_processor,
@@ -845,6 +905,76 @@ class PI05Pytorch(nn.Module):  # see openpi `PI0Pytorch`
             execution_horizon=kwargs.get("execution_horizon"),
             hard_prefix=trained_prefix,
             hard_prefix_mask=trained_prefix_mask,
+        )
+
+    def prefill_prefix(self, images, img_masks, tokens, masks, states=None, state_masks=None):
+        """Run the vision-language prefix once and return its attention mask and KV cache.
+
+        This is piR2's slow channel (arXiv 2607.26055): the cache is valid for as many action
+        expert calls as you care to make against it, so a background thread can refresh it on
+        its own cadence while the expert keeps denoising against the last one.
+        """
+        prefix_embs, prefix_pad_masks, prefix_att_masks = self.embed_prefix(
+            images, img_masks, tokens, masks, states, state_masks
+        )
+        prefix_att_2d_masks = make_att_2d_masks(prefix_pad_masks, prefix_att_masks)
+        prefix_position_ids = torch.cumsum(prefix_pad_masks, dim=1) - 1
+
+        prefix_att_2d_masks_4d = prepare_attention_masks_4d(prefix_att_2d_masks)
+        self.paligemma_with_expert.paligemma.model.language_model.config._attn_implementation = "eager"  # noqa: SLF001
+
+        _, past_key_values = self.paligemma_with_expert.forward(
+            attention_mask=prefix_att_2d_masks_4d,
+            position_ids=prefix_position_ids,
+            past_key_values=None,
+            inputs_embeds=[prefix_embs, None],
+            use_cache=True,
+        )
+        return prefix_pad_masks, past_key_values
+
+    def _prefix_denoise_fn(self, prefix_pad_masks, past_key_values):
+        return lambda x_t, timestep: self.denoise_step(
+            prefix_pad_masks=prefix_pad_masks,
+            past_key_values=past_key_values,
+            x_t=x_t,
+            timestep=timestep,
+        )
+
+    def warm_start_staircase_buffer(
+        self,
+        prefix_pad_masks,
+        past_key_values,
+        delay,
+        *,
+        noise=None,
+        num_steps=None,
+    ) -> Tensor:
+        """Denoise a full chunk from pure noise, then re-noise it onto the staircase.
+
+        Episode start has no in-flight actions to condition on, so piR2 falls back to a standard
+        full denoise and then puts the result back at the per-position noise levels the steady
+        state expects. The 20% shared-timestep branch during training is what keeps the weights
+        able to do this first pass.
+        """
+        if num_steps is None:
+            num_steps = self.config.num_inference_steps
+        if noise is None:
+            shape = (prefix_pad_masks.shape[0], self.config.chunk_size, self.config.max_action_dim)
+            noise = self.sample_noise(shape, prefix_pad_masks.device)
+
+        clean = euler_integrate(self._prefix_denoise_fn(prefix_pad_masks, past_key_values), noise, num_steps)
+
+        time = staircase_time(delay, clean.shape[1], device=clean.device, dtype=clean.dtype)
+        fresh = self.sample_noise(clean.shape, clean.device).to(dtype=clean.dtype)
+        return time[None, :, None] * fresh + (1 - time[None, :, None]) * clean
+
+    def staircase_denoise_step(self, prefix_pad_masks, past_key_values, x_t, delay, *, noise=None):
+        """One piR2 call against a cached prefix: emit ``delay`` actions and slide the buffer."""
+        return staircase_substep(
+            self._prefix_denoise_fn(prefix_pad_masks, past_key_values),
+            x_t,
+            delay,
+            noise=noise,
         )
 
     def denoise_step(
@@ -1345,6 +1475,49 @@ class PI05Policy(PreTrainedPolicy):
 
         return actions
 
+    @torch.no_grad()
+    def encode_slow_channel(self, batch: dict[str, Tensor]) -> PiR2SlowChannel:
+        """Run the vision-language prefix and return a cache the action expert can reuse.
+
+        In piR2 this is the only work that scales with backbone size, and it is meant to run on
+        a background thread at whatever rate it can manage while the expert keeps stepping.
+        """
+        self.eval()
+        images, img_masks = self._preprocess_images(batch)
+        states, state_masks = self._prepare_memory_states(batch)
+        tokens, masks = batch[f"{OBS_LANGUAGE_TOKENS}"], batch[f"{OBS_LANGUAGE_ATTENTION_MASK}"]
+        prefix_pad_masks, past_key_values = self.model.prefill_prefix(
+            images, img_masks, tokens, masks, states, state_masks
+        )
+        return PiR2SlowChannel(
+            prefix_pad_masks=prefix_pad_masks,
+            past_key_values=past_key_values,
+            captured_at=time.perf_counter(),
+        )
+
+    @torch.no_grad()
+    def warm_start_realtime_buffer(self, slow: PiR2SlowChannel, delay: int) -> Tensor:
+        """Build the initial action buffer at episode start, when nothing is in flight yet."""
+        self.eval()
+        return self.model.warm_start_staircase_buffer(slow.prefix_pad_masks, slow.past_key_values, delay)
+
+    @torch.no_grad()
+    def realtime_substep(self, slow: PiR2SlowChannel, buffer: Tensor, delay: int) -> tuple[Tensor, Tensor]:
+        """Advance the buffer by one denoising step, returning ``delay`` finished actions.
+
+        ``slow`` may have been encoded several control steps ago; the clamped clean front of
+        ``buffer`` is what tells the expert where the robot currently is.
+        """
+        self.eval()
+        emitted, next_buffer = self.model.staircase_denoise_step(
+            slow.prefix_pad_masks,
+            slow.past_key_values,
+            buffer,
+            delay,
+        )
+        original_action_dim = self.config.output_features[ACTION].shape[0]
+        return emitted[:, :, :original_action_dim], next_buffer
+
     def forward(self, batch: dict[str, Tensor], reduction: str = "mean") -> tuple[Tensor, dict]:
         """Run the batch through the model and compute the loss for training.
 
@@ -1363,12 +1536,23 @@ class PI05Policy(PreTrainedPolicy):
 
         noise = self.model.sample_noise(actions.shape, actions.device)
         time = self.model.sample_time(actions.shape[0], actions.device)
-        prefix_mask = _sample_training_rtc_prefix_mask(
-            actions.shape[0],
-            actions.shape[1],
-            self.config.rtc_training_max_delay,
-            actions.device,
-        )
+        position_time = None
+        if self.config.rtc_training_schedule == "staircase" and self.config.rtc_training_max_delay > 0:
+            prefix_mask, position_time = _build_staircase_schedule(
+                actions.shape[0],
+                actions.shape[1],
+                self.config.rtc_training_max_delay,
+                time,
+                time_jitter=self.config.staircase_time_jitter,
+                warmup_prob=self.config.staircase_warmup_prob,
+            )
+        else:
+            prefix_mask = _sample_training_rtc_prefix_mask(
+                actions.shape[0],
+                actions.shape[1],
+                self.config.rtc_training_max_delay,
+                actions.device,
+            )
 
         # Compute loss (no separate state needed for PI05)
         losses = self.model.forward(
@@ -1382,6 +1566,7 @@ class PI05Policy(PreTrainedPolicy):
             prefix_mask=prefix_mask,
             states=states,
             state_masks=state_masks,
+            position_time=position_time,
         )
 
         # Truncate losses to actual action dimensions

--- a/src/lerobot/rollout/inference/__init__.py
+++ b/src/lerobot/rollout/inference/__init__.py
@@ -21,16 +21,20 @@ rollout strategies never branch on which backend is in use.
 from .base import InferenceEngine, PolicyQuery, QueryAnswer, QueryKind
 from .factory import (
     InferenceEngineConfig,
+    PiR2InferenceConfig,
     RTCInferenceConfig,
     SyncInferenceConfig,
     create_inference_engine,
 )
+from .pir2 import PiR2InferenceEngine
 from .rtc import RTCInferenceEngine
 from .sync import SyncInferenceEngine
 
 __all__ = [
     "InferenceEngine",
     "InferenceEngineConfig",
+    "PiR2InferenceConfig",
+    "PiR2InferenceEngine",
     "PolicyQuery",
     "QueryAnswer",
     "QueryKind",

--- a/src/lerobot/rollout/inference/factory.py
+++ b/src/lerobot/rollout/inference/factory.py
@@ -14,7 +14,7 @@
 
 """Inference engine configs and factory.
 
-Selection is explicit via ``--inference.type=sync|rtc``.  Adding a new
+Selection is explicit via ``--inference.type=sync|rtc|pir2``.  Adding a new
 backend requires registering its config subclass and dispatching it in
 :func:`create_inference_engine`.
 """
@@ -34,6 +34,7 @@ from lerobot.processor import PolicyProcessorPipeline
 
 from ..robot_wrapper import ThreadSafeRobot
 from .base import InferenceEngine
+from .pir2 import PiR2InferenceEngine
 from .rtc import RTCInferenceEngine
 from .sync import SyncInferenceEngine
 
@@ -72,6 +73,17 @@ class RTCInferenceConfig(InferenceEngineConfig):
     # (e.g. ``--inference.rtc.execution_horizon=...``).
     rtc: RTCConfig = field(default_factory=RTCConfig)
     queue_threshold: int = 30
+
+
+@InferenceEngineConfig.register_subclass("pir2")
+@dataclass
+class PiR2InferenceConfig(InferenceEngineConfig):
+    """piR2: one denoising step per call over a continuously sliding action buffer."""
+
+    # Rolling window of action-head call latencies used to derive the per-call delay.
+    latency_window: int = 20
+    # Upper bound on that delay. ``None`` uses the largest the schedule allows (chunk_size // 2).
+    max_delay: int | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -123,6 +135,20 @@ def create_inference_engine(
             use_torch_compile=use_torch_compile,
             compile_warmup_inferences=compile_warmup_inferences,
             rtc_queue_threshold=config.queue_threshold,
+            shutdown_event=shutdown_event,
+        )
+    if isinstance(config, PiR2InferenceConfig):
+        return PiR2InferenceEngine(
+            policy=policy,
+            preprocessor=preprocessor,
+            postprocessor=postprocessor,
+            robot_wrapper=robot_wrapper,
+            hw_features=hw_features,
+            task=task,
+            fps=fps,
+            device=device,
+            latency_window=config.latency_window,
+            max_delay=config.max_delay,
             shutdown_event=shutdown_event,
         )
     raise ValueError(f"Unknown inference engine type: {type(config).__name__}")

--- a/src/lerobot/rollout/inference/pir2.py
+++ b/src/lerobot/rollout/inference/pir2.py
@@ -22,13 +22,13 @@ denoising step on it, hands the finished front to the robot, slides the buffer f
 appends fresh noise at the back -- so the schedule reproduces itself and the robot is fed
 continuously without ever waiting for a full chunk.
 
-The vision-language prefix is refreshed by its own thread and reused by every denoising step in
-between, so conditioning updates at the backbone's rate rather than once per chunk. pi0.5
-discretizes proprioception into the tokenized prompt, so a cached prefix holds stale joint state
-as well; what keeps the expert anchored is the clamped clean front of the buffer, which is the
-positions the robot is being commanded to right now. That covers where the arm is, but not the
-gap between commanded and actual, so this engine does not react to external disturbance the way
-the paper's separate proprioception channel does (arXiv 2607.26055, Sec. 3.2).
+The vision-language prefix runs on its own thread as fast as the backbone allows, and each
+denoising step conditions on whichever cache is newest. On pi0.5 that prefix carries joint state
+too, since proprioception is discretized into the tokenized prompt; the clamped clean front of
+the buffer is what keeps the expert anchored to where the robot actually is. That covers
+configuration but not the gap between commanded and actual position, so this engine will not
+react to an external disturbance the way a dedicated proprioception channel would
+(arXiv 2607.26055, Sec. 3.2).
 """
 
 from __future__ import annotations
@@ -54,6 +54,8 @@ logger = logging.getLogger(__name__)
 _IDLE_SLEEP_S = 0.001
 _JOIN_TIMEOUT_S = 5.0
 _MAX_CONSECUTIVE_ERRORS = 3
+# Floor for the finished-action cushion, so a d=1 schedule still absorbs one slow call.
+_MIN_PENDING_ACTIONS = 2
 
 
 def estimate_pir2_delay(latencies: deque[float], time_per_step: float, max_delay: int) -> int:
@@ -87,7 +89,7 @@ class PiR2InferenceEngine(InferenceEngine):
         shutdown_event: Event | None = None,
     ) -> None:
         required_methods = (
-            "encode_slow_channel",
+            "encode_prefix",
             "warm_start_realtime_buffer",
             "realtime_substep",
         )
@@ -126,8 +128,8 @@ class PiR2InferenceEngine(InferenceEngine):
         self._last_stale_warning = 0.0
 
         self._buffer: torch.Tensor | None = None
-        self._slow: Any = None
-        self._slow_lock = Lock()
+        self._prefix: Any = None
+        self._prefix_lock = Lock()
         self._emitted: deque[torch.Tensor] = deque()
         self._emitted_lock = Lock()
         self._obs_holder: dict[str, Any] = {}
@@ -191,8 +193,8 @@ class PiR2InferenceEngine(InferenceEngine):
         self._postprocessor.reset()
         self._buffer = None
         self._latencies.clear()
-        with self._slow_lock:
-            self._slow = None
+        with self._prefix_lock:
+            self._prefix = None
         with self._emitted_lock:
             self._emitted.clear()
 
@@ -244,23 +246,23 @@ class PiR2InferenceEngine(InferenceEngine):
                 if obs is None:
                     time.sleep(_IDLE_SLEEP_S)
                     continue
-                slow = self._policy.encode_slow_channel(self._prepare_batch(obs))
-                with self._slow_lock:
-                    self._slow = slow
+                prefix = self._policy.encode_prefix(self._prepare_batch(obs))
+                with self._prefix_lock:
+                    self._prefix = prefix
         except Exception:
             logger.exception("piR2 VLM thread terminating")
             self._error.set()
             if self._global_shutdown_event is not None:
                 self._global_shutdown_event.set()
 
-    def _current_slow_channel(self) -> Any | None:
+    def _current_prefix(self) -> Any | None:
         """Return the newest prefix cache, warning when it falls badly behind."""
-        with self._slow_lock:
-            slow = self._slow
-        if slow is None:
+        with self._prefix_lock:
+            prefix = self._prefix
+        if prefix is None:
             return None
         now = time.perf_counter()
-        age_s = 0.0 if slow.captured_at is None else now - slow.captured_at
+        age_s = 0.0 if prefix.captured_at is None else now - prefix.captured_at
         age_steps = int(age_s * self._fps)
         if age_steps > self._stale_prefix_steps and now - self._last_stale_warning > 5.0:
             self._last_stale_warning = now
@@ -270,7 +272,7 @@ class PiR2InferenceEngine(InferenceEngine):
                 age_steps,
                 age_s,
             )
-        return slow
+        return prefix
 
     def _denoise_loop(self) -> None:
         try:
@@ -283,21 +285,30 @@ class PiR2InferenceEngine(InferenceEngine):
                     continue
 
                 try:
-                    started = time.perf_counter()
                     delay = estimate_pir2_delay(self._latencies, time_per_step, self._max_delay)
 
-                    slow = self._current_slow_channel()
-                    if slow is None:
-                        # The VLM thread has not produced its first cache yet.
+                    # A substep emits `delay` actions but can finish in less than the `delay`
+                    # control ticks the robot needs to consume them, so the expert outruns the
+                    # control loop. Running ahead buys nothing: it only makes each executed action
+                    # older, which is what this engine exists to avoid. Hold one substep of
+                    # cushion against latency jitter and idle otherwise.
+                    if self.pending_actions() >= max(2 * delay, _MIN_PENDING_ACTIONS):
                         time.sleep(_IDLE_SLEEP_S)
                         continue
 
+                    prefix = self._current_prefix()
+                    if prefix is None:
+                        # The vision-language thread has not produced its first cache yet.
+                        time.sleep(_IDLE_SLEEP_S)
+                        continue
+
+                    started = time.perf_counter()
                     if self._buffer is None:
                         # Episode start: nothing is in flight, so fall back to a full denoise
                         # and re-noise the result onto the staircase.
-                        self._buffer = self._policy.warm_start_realtime_buffer(slow, delay)
+                        self._buffer = self._policy.warm_start_realtime_buffer(prefix, delay)
 
-                    emitted, self._buffer = self._policy.realtime_substep(slow, self._buffer, delay)
+                    emitted, self._buffer = self._policy.realtime_substep(prefix, self._buffer, delay)
                     self._publish(emitted)
 
                     self._latencies.append(time.perf_counter() - started)

--- a/src/lerobot/rollout/inference/pir2.py
+++ b/src/lerobot/rollout/inference/pir2.py
@@ -155,6 +155,11 @@ class PiR2InferenceEngine(InferenceEngine):
         """True if the background thread exited due to an unrecoverable error."""
         return self._error.is_set()
 
+    @property
+    def control_thread_owns_policy(self) -> bool:
+        """The VLM thread owns the policy; it services queries in ``_vlm_loop``."""
+        return False
+
     def start(self) -> None:
         """Launch the background denoising thread and the vision-language thread."""
         self._obs_holder = {"obs": None, "robot_type": self._robot.robot_type}
@@ -246,6 +251,10 @@ class PiR2InferenceEngine(InferenceEngine):
                 if obs is None:
                     time.sleep(_IDLE_SLEEP_S)
                     continue
+                # Served here because this is the thread that owns the policy.  Ahead of the
+                # refresh below on purpose: this loop never blocks on its own, so a query
+                # queued behind it would otherwise never be picked up.
+                self._service_query(obs)
                 prefix = self._policy.encode_prefix(self._prepare_batch(obs))
                 with self._prefix_lock:
                     self._prefix = prefix

--- a/src/lerobot/rollout/inference/pir2.py
+++ b/src/lerobot/rollout/inference/pir2.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""piR2 real-time inference (arXiv 2607.26055, Sec. 3.3).
+
+Where :mod:`.rtc` denoises a whole chunk per call and splices it into a queue, this engine
+keeps one partially-denoised buffer alive for the whole episode. Every call spends a single
+denoising step on it, hands the finished front to the robot, slides the buffer forward, and
+appends fresh noise at the back -- so the schedule reproduces itself and the robot is fed
+continuously without ever waiting for a full chunk.
+
+The vision-language prefix is refreshed by its own thread and reused by every denoising step in
+between, so conditioning updates at the backbone's rate rather than once per chunk. pi0.5
+discretizes proprioception into the tokenized prompt, so a cached prefix holds stale joint state
+as well; what keeps the expert anchored is the clamped clean front of the buffer, which is the
+positions the robot is being commanded to right now. That covers where the arm is, but not the
+gap between commanded and actual, so this engine does not react to external disturbance the way
+the paper's separate proprioception channel does (arXiv 2607.26055, Sec. 3.2).
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections import deque
+from threading import Event, Lock, Thread
+from typing import Any
+
+import torch
+
+from lerobot.policies.pretrained import PreTrainedPolicy
+from lerobot.policies.utils import prepare_observation_for_inference
+from lerobot.processor import PolicyProcessorPipeline
+from lerobot.utils.feature_utils import build_dataset_frame
+
+from ..robot_wrapper import ThreadSafeRobot
+from .base import InferenceEngine
+
+logger = logging.getLogger(__name__)
+
+_IDLE_SLEEP_S = 0.001
+_JOIN_TIMEOUT_S = 5.0
+_MAX_CONSECUTIVE_ERRORS = 3
+
+
+def estimate_pir2_delay(latencies: deque[float], time_per_step: float, max_delay: int) -> int:
+    """Derive the per-call delay ``d`` from a rolling window of action-head latencies.
+
+    The paper takes the mean of the window rather than a maximum: overshooting ``d`` costs
+    reactivity on every subsequent call, whereas a single slow call just means the buffer is
+    slightly behind its schedule for one cycle, which the next step absorbs.
+    """
+    if not latencies:
+        return 1
+    mean_latency = sum(latencies) / len(latencies)
+    return max(1, min(max_delay, round(mean_latency / time_per_step)))
+
+
+class PiR2InferenceEngine(InferenceEngine):
+    """Async piR2 inference: a background thread advances one shared action buffer."""
+
+    def __init__(
+        self,
+        policy: PreTrainedPolicy,
+        preprocessor: PolicyProcessorPipeline,
+        postprocessor: PolicyProcessorPipeline,
+        robot_wrapper: ThreadSafeRobot,
+        hw_features: dict,
+        task: str,
+        fps: float,
+        device: str | None,
+        latency_window: int = 20,
+        max_delay: int | None = None,
+        shutdown_event: Event | None = None,
+    ) -> None:
+        required_methods = (
+            "encode_slow_channel",
+            "warm_start_realtime_buffer",
+            "realtime_substep",
+        )
+        for required in required_methods:
+            if not hasattr(policy, required):
+                raise NotImplementedError(
+                    f"{type(policy).__name__} does not support piR2 inference (missing "
+                    f"{required!r}). Train a pi0.5 checkpoint with "
+                    "--policy.rtc_training_schedule=staircase and use it here."
+                )
+        if getattr(policy.config, "rtc_training_schedule", "prefix") != "staircase":
+            raise ValueError(
+                "piR2 inference requires a checkpoint trained with "
+                "--policy.rtc_training_schedule=staircase; this one reports "
+                f"{getattr(policy.config, 'rtc_training_schedule', 'prefix')!r}. A prefix-trained "
+                "checkpoint has never seen a ramped noise schedule and will not denoise it."
+            )
+
+        self._policy = policy
+        self._preprocessor = preprocessor
+        self._postprocessor = postprocessor
+        self._robot = robot_wrapper
+        self._hw_features = hw_features
+        self._task = task
+        self._fps = fps
+        self._device = device or "cpu"
+
+        chunk_size = int(policy.config.chunk_size)
+        # 2 * d <= H is what keeps a non-empty ramp between the clean front and the noise tail.
+        self._max_delay = min(max_delay or chunk_size // 2, chunk_size // 2)
+        self._latencies: deque[float] = deque(maxlen=latency_window)
+
+        # A prefix older than the chunk it is steering is worth surfacing: the clean front can
+        # only anchor the expert for so long before the plan behind it is answering a dead question.
+        self._stale_prefix_steps = chunk_size
+        self._last_stale_warning = 0.0
+
+        self._buffer: torch.Tensor | None = None
+        self._slow: Any = None
+        self._slow_lock = Lock()
+        self._emitted: deque[torch.Tensor] = deque()
+        self._emitted_lock = Lock()
+        self._obs_holder: dict[str, Any] = {}
+        self._obs_lock = Lock()
+        self._policy_active = Event()
+        self._shutdown_event = Event()
+        self._error = Event()
+        self._global_shutdown_event = shutdown_event
+        self._thread: Thread | None = None
+        self._vlm_thread: Thread | None = None
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    @property
+    def ready(self) -> bool:
+        """True once the buffer has been warm-started and actions are flowing."""
+        return self._buffer is not None
+
+    @property
+    def failed(self) -> bool:
+        """True if the background thread exited due to an unrecoverable error."""
+        return self._error.is_set()
+
+    def start(self) -> None:
+        """Launch the background denoising thread and the vision-language thread."""
+        self._obs_holder = {"obs": None, "robot_type": self._robot.robot_type}
+        self._shutdown_event.clear()
+        self._thread = Thread(target=self._denoise_loop, daemon=True, name="PiR2Inference")
+        self._thread.start()
+        self._vlm_thread = Thread(target=self._vlm_loop, daemon=True, name="PiR2VLM")
+        self._vlm_thread.start()
+        logger.info("piR2 inference started (max delay %d)", self._max_delay)
+
+    def stop(self) -> None:
+        """Signal the background threads to stop and wait for them."""
+        self._shutdown_event.set()
+        self._policy_active.clear()
+        for name, thread in (("denoise", self._thread), ("VLM", self._vlm_thread)):
+            if thread is not None and thread.is_alive():
+                thread.join(timeout=_JOIN_TIMEOUT_S)
+                if thread.is_alive():
+                    logger.warning("piR2 %s thread did not join within %.1fs", name, _JOIN_TIMEOUT_S)
+        self._thread = None
+        self._vlm_thread = None
+
+    def pause(self) -> None:
+        """Pause background denoising."""
+        self._policy_active.clear()
+
+    def resume(self) -> None:
+        """Resume background denoising."""
+        self._policy_active.set()
+
+    def reset(self) -> None:
+        """Drop the buffer so the next episode warm-starts from pure noise."""
+        logger.info("Resetting piR2 inference state (policy + processors + buffer)")
+        self._policy.reset()
+        self._preprocessor.reset()
+        self._postprocessor.reset()
+        self._buffer = None
+        self._latencies.clear()
+        with self._slow_lock:
+            self._slow = None
+        with self._emitted_lock:
+            self._emitted.clear()
+
+    # ------------------------------------------------------------------
+    # Action production (called from the main thread)
+    # ------------------------------------------------------------------
+
+    def get_action(self, obs_frame: dict | None) -> torch.Tensor | None:
+        """Pop the next finished action (ignores ``obs_frame``)."""
+        with self._emitted_lock:
+            if not self._emitted:
+                return None
+            return self._emitted.popleft()
+
+    def notify_observation(self, obs: dict) -> None:
+        """Publish the latest observation for the denoising thread to consume."""
+        with self._obs_lock:
+            self._obs_holder["obs"] = obs
+
+    def pending_actions(self) -> int:
+        """Number of emitted actions not yet sent to the robot."""
+        with self._emitted_lock:
+            return len(self._emitted)
+
+    # ------------------------------------------------------------------
+    # Background denoising thread
+    # ------------------------------------------------------------------
+
+    def _prepare_batch(self, obs: dict) -> dict:
+        """Turn a raw observation into a policy batch (normalize, tokenize, move to device)."""
+        obs_batch = build_dataset_frame(self._hw_features, obs, prefix="observation")
+        obs_batch = prepare_observation_for_inference(
+            obs_batch, torch.device(self._device), self._task, self._robot.robot_type
+        )
+        return self._preprocessor(obs_batch)
+
+    def _latest_observation(self) -> dict | None:
+        with self._obs_lock:
+            return self._obs_holder.get("obs")
+
+    def _vlm_loop(self) -> None:
+        """Refresh the vision-language cache as fast as the backbone allows, off the critical path."""
+        try:
+            while not self._shutdown_event.is_set():
+                if not self._policy_active.is_set():
+                    time.sleep(_IDLE_SLEEP_S)
+                    continue
+                obs = self._latest_observation()
+                if obs is None:
+                    time.sleep(_IDLE_SLEEP_S)
+                    continue
+                slow = self._policy.encode_slow_channel(self._prepare_batch(obs))
+                with self._slow_lock:
+                    self._slow = slow
+        except Exception:
+            logger.exception("piR2 VLM thread terminating")
+            self._error.set()
+            if self._global_shutdown_event is not None:
+                self._global_shutdown_event.set()
+
+    def _current_slow_channel(self) -> Any | None:
+        """Return the newest prefix cache, warning when it falls badly behind."""
+        with self._slow_lock:
+            slow = self._slow
+        if slow is None:
+            return None
+        now = time.perf_counter()
+        age_s = 0.0 if slow.captured_at is None else now - slow.captured_at
+        age_steps = int(age_s * self._fps)
+        if age_steps > self._stale_prefix_steps and now - self._last_stale_warning > 5.0:
+            self._last_stale_warning = now
+            logger.warning(
+                "piR2 vision-language prefix is %d control steps old (%.2fs); the expert is "
+                "steering on stale vision. Reduce image resolution or camera count.",
+                age_steps,
+                age_s,
+            )
+        return slow
+
+    def _denoise_loop(self) -> None:
+        try:
+            time_per_step = 1.0 / self._fps
+            consecutive_errors = 0
+
+            while not self._shutdown_event.is_set():
+                if not self._policy_active.is_set():
+                    time.sleep(_IDLE_SLEEP_S)
+                    continue
+
+                try:
+                    started = time.perf_counter()
+                    delay = estimate_pir2_delay(self._latencies, time_per_step, self._max_delay)
+
+                    slow = self._current_slow_channel()
+                    if slow is None:
+                        # The VLM thread has not produced its first cache yet.
+                        time.sleep(_IDLE_SLEEP_S)
+                        continue
+
+                    if self._buffer is None:
+                        # Episode start: nothing is in flight, so fall back to a full denoise
+                        # and re-noise the result onto the staircase.
+                        self._buffer = self._policy.warm_start_realtime_buffer(slow, delay)
+
+                    emitted, self._buffer = self._policy.realtime_substep(slow, self._buffer, delay)
+                    self._publish(emitted)
+
+                    self._latencies.append(time.perf_counter() - started)
+                    consecutive_errors = 0
+                except Exception:
+                    consecutive_errors += 1
+                    logger.exception("piR2 denoising step failed (%d)", consecutive_errors)
+                    if consecutive_errors >= _MAX_CONSECUTIVE_ERRORS:
+                        raise
+                    time.sleep(_IDLE_SLEEP_S)
+        except Exception:
+            logger.exception("piR2 inference thread terminating")
+            self._error.set()
+            if self._global_shutdown_event is not None:
+                self._global_shutdown_event.set()
+
+    def _publish(self, emitted: torch.Tensor) -> None:
+        """Post-process the finished actions and queue them for the control loop."""
+        processed = self._postprocessor(emitted).squeeze(0)
+        with self._emitted_lock:
+            for step in range(processed.shape[0]):
+                self._emitted.append(processed[step])

--- a/tests/policies/common/test_flow_matching.py
+++ b/tests/policies/common/test_flow_matching.py
@@ -21,6 +21,7 @@ smolvla sampling loop (including its RTC hook semantics): any divergence from th
 reference is a behavior change for released checkpoints.
 """
 
+import pytest
 import torch
 
 from lerobot.policies.common.flow_matching import (
@@ -28,6 +29,8 @@ from lerobot.policies.common.flow_matching import (
     sample_beta,
     sample_noise,
     sample_time_beta,
+    staircase_substep,
+    staircase_time,
 )
 
 
@@ -213,3 +216,98 @@ def test_euler_integrate_clamps_trained_rtc_prefix_and_sets_clean_time():
 
     torch.testing.assert_close(out[:, :2], hard_prefix[:, :2])
     assert all(torch.equal(time[:, :2], torch.zeros(1, 2)) for time in seen_times)
+
+
+# ---------------------------------------------------------------------------
+# piR2 staircase schedule (arXiv 2607.26055)
+# ---------------------------------------------------------------------------
+
+
+def _reference_staircase(delay: int, horizon: int) -> torch.Tensor:
+    """Eq. 3 written out region by region, converted to the t=0-clean convention."""
+    values = []
+    for position in range(horizon):
+        if position < delay:
+            tau = 1.0
+        elif position < horizon - delay:
+            tau = 1.0 - (position - delay) / (horizon - 2 * delay)
+        else:
+            tau = 0.0
+        values.append(1.0 - tau)
+    return torch.tensor(values)
+
+
+@pytest.mark.parametrize(("delay", "horizon"), [(1, 16), (2, 16), (5, 50), (3, 12)])
+def test_staircase_time_matches_paper_equation(delay, horizon):
+    torch.testing.assert_close(
+        staircase_time(delay, horizon, device="cpu"), _reference_staircase(delay, horizon)
+    )
+
+
+def test_staircase_substep_emits_exact_actions_under_an_oracle_velocity():
+    batch, horizon, dim, delay = 2, 16, 3, 2
+    actions = torch.randn(batch, horizon, dim)
+    noise = torch.randn(batch, horizon, dim)
+    time = staircase_time(delay, horizon, device="cpu")
+    x_t = time[None, :, None] * noise + (1 - time[None, :, None]) * actions
+
+    # The exact conditional velocity, so one substep must land on the analytic solution.
+    emitted, next_buffer = staircase_substep(
+        lambda x, t: noise - actions, x_t, delay, noise=torch.zeros(batch, delay, dim)
+    )
+
+    # Positions [delay, 2 * delay) are the ones the shift carries to t=0.
+    torch.testing.assert_close(emitted, actions[:, delay : 2 * delay], atol=1e-6, rtol=0)
+    # And the just-emitted actions become the next call's clamped front.
+    torch.testing.assert_close(next_buffer[:, :delay], actions[:, delay : 2 * delay], atol=1e-6, rtol=0)
+
+
+def test_staircase_substep_moves_every_position_to_the_shifted_schedule():
+    batch, horizon, dim, delay = 2, 16, 3, 3
+    actions = torch.randn(batch, horizon, dim)
+    noise = torch.randn(batch, horizon, dim)
+    time = staircase_time(delay, horizon, device="cpu")
+    x_t = time[None, :, None] * noise + (1 - time[None, :, None]) * actions
+
+    _, next_buffer = staircase_substep(
+        lambda x, t: noise - actions, x_t, delay, noise=torch.zeros(batch, delay, dim)
+    )
+
+    shifted = time[(torch.arange(horizon) - delay).clamp(min=0)]
+    expected = shifted[None, :, None] * noise + (1 - shifted[None, :, None]) * actions
+    # Compare before the slide drops the front `delay` positions.
+    torch.testing.assert_close(next_buffer[:, : horizon - delay], expected[:, delay:], atol=1e-6, rtol=0)
+
+
+def test_staircase_substep_appends_fresh_noise_to_the_tail():
+    batch, horizon, dim, delay = 2, 12, 3, 2
+    tail = torch.full((batch, delay, dim), 7.0)
+
+    _, next_buffer = staircase_substep(
+        lambda x, t: torch.zeros_like(x), torch.zeros(batch, horizon, dim), delay, noise=tail
+    )
+
+    assert next_buffer.shape == (batch, horizon, dim)
+    torch.testing.assert_close(next_buffer[:, -delay:], tail)
+
+
+def test_staircase_substep_advance_never_moves_away_from_clean():
+    seen = {}
+
+    def denoise_fn(x_t, time_tensor):
+        seen["time"] = time_tensor
+        return torch.zeros_like(x_t)
+
+    x_t = torch.zeros(1, 16, 2)
+    before, _ = staircase_substep(denoise_fn, x_t, 2)
+    torch.testing.assert_close(seen["time"][0], staircase_time(2, 16, device="cpu"))
+    assert before.shape == (1, 2, 2)
+
+
+@pytest.mark.parametrize(
+    ("delay", "horizon", "match"),
+    [(0, 16, "delay must be >= 1"), (9, 16, r"2 \* delay <= horizon")],
+)
+def test_staircase_substep_rejects_unusable_delays(delay, horizon, match):
+    with pytest.raises(ValueError, match=match):
+        staircase_substep(lambda x, t: torch.zeros_like(x), torch.zeros(1, horizon, 2), delay)

--- a/tests/policies/pi0_pi05/test_pi05_staircase_schedule.py
+++ b/tests/policies/pi0_pi05/test_pi05_staircase_schedule.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the piR2 latency-adaptive staircase schedule (arXiv 2607.26055)."""
+
+import pytest
+import torch
+
+from lerobot.policies.pi05.configuration_pi05 import PI05Config
+from lerobot.policies.pi05.modeling_pi05 import (
+    _build_flow_matching_inputs,
+    _build_staircase_schedule,
+)
+
+
+def _expected_staircase(delay: int, horizon: int) -> torch.Tensor:
+    """Eq. 3 written out literally, converted to this file's t=0-clean convention."""
+    values = []
+    for position in range(horizon):
+        if position < delay:
+            tau = 1.0
+        elif position < horizon - delay:
+            tau = 1.0 - (position - delay) / (horizon - 2 * delay)
+        else:
+            tau = 0.0
+        values.append(1.0 - tau)
+    return torch.tensor(values)
+
+
+@pytest.mark.parametrize("horizon", [16, 50])
+def test_staircase_matches_paper_equation(horizon):
+    torch.manual_seed(0)
+    prefix_mask, position_time = _build_staircase_schedule(
+        batch_size=64, action_horizon=horizon, max_delay=5, shared_time=torch.rand(64)
+    )
+
+    delays = prefix_mask.sum(dim=1)
+    assert delays.max() <= 5, "sampled delay must respect max_delay"
+    for row, delay in enumerate(delays.tolist()):
+        expected = _expected_staircase(delay, horizon)
+        torch.testing.assert_close(position_time[row], expected, atol=1e-6, rtol=0)
+
+
+def test_staircase_regions_are_clean_front_ramp_and_noise_tail():
+    torch.manual_seed(0)
+    horizon, max_delay = 16, 4
+    prefix_mask, position_time = _build_staircase_schedule(
+        batch_size=32, action_horizon=horizon, max_delay=max_delay, shared_time=torch.rand(32)
+    )
+
+    # Monotone non-decreasing from clean to noise, which is what makes one denoising step
+    # able to finish the front while the tail is still pure noise.
+    assert (position_time.diff(dim=1) >= 0).all()
+
+    for row, delay in enumerate(prefix_mask.sum(dim=1).tolist()):
+        assert (position_time[row, :delay] == 0.0).all(), "front must be clean"
+        if delay > 0:
+            assert (position_time[row, horizon - delay :] == 1.0).all(), "tail must be pure noise"
+
+
+def test_prefix_mask_marks_exactly_the_clamped_front():
+    torch.manual_seed(0)
+    horizon = 16
+    prefix_mask, position_time = _build_staircase_schedule(
+        batch_size=32, action_horizon=horizon, max_delay=4, shared_time=torch.rand(32)
+    )
+
+    # The loss mask (Alg. 1 line 14) must select a contiguous front, otherwise the model is
+    # scored on positions it was handed as ground truth.
+    assert (prefix_mask.int().diff(dim=1) <= 0).all()
+    assert (position_time[prefix_mask] == 0.0).all()
+
+    # Eq. 3 evaluates the ramp to tau=1 at its left endpoint, so the first *supervised*
+    # position is also fully clean. Pinned deliberately: it means one position per sample is
+    # trained at exactly t=0, where the velocity target a - eps is pure noise in expectation.
+    for row, delay in enumerate(prefix_mask.sum(dim=1).tolist()):
+        if delay < horizon:
+            assert position_time[row, delay] == 0.0
+
+
+def test_front_is_exactly_ground_truth_even_when_jittered():
+    torch.manual_seed(0)
+    batch, horizon, dim = 8, 16, 4
+    actions = torch.randn(batch, horizon, dim)
+    noise = torch.randn(batch, horizon, dim)
+    prefix_mask, position_time = _build_staircase_schedule(
+        batch_size=batch,
+        action_horizon=horizon,
+        max_delay=4,
+        shared_time=torch.rand(batch),
+        time_jitter=0.1,
+    )
+
+    x_t, model_time = _build_flow_matching_inputs(
+        actions, noise, torch.rand(batch), prefix_mask, position_time
+    )
+
+    assert (x_t[prefix_mask] == actions[prefix_mask]).all()
+    torch.testing.assert_close(model_time, position_time)
+
+
+def test_warmup_branch_reproduces_the_standard_flow_path():
+    torch.manual_seed(0)
+    batch, horizon, dim = 8, 16, 4
+    actions = torch.randn(batch, horizon, dim)
+    noise = torch.randn(batch, horizon, dim)
+    time = torch.rand(batch)
+
+    prefix_mask, position_time = _build_staircase_schedule(
+        batch_size=batch,
+        action_horizon=horizon,
+        max_delay=4,
+        shared_time=time,
+        warmup_prob=1.0,
+    )
+
+    assert not prefix_mask.any(), "the warm-up branch must not clamp a front"
+    staircase_x_t, _ = _build_flow_matching_inputs(actions, noise, time, prefix_mask, position_time)
+    standard_x_t, _ = _build_flow_matching_inputs(actions, noise, time, None)
+    torch.testing.assert_close(staircase_x_t, standard_x_t)
+
+
+def test_jitter_stays_within_bounds_and_is_off_by_default():
+    torch.manual_seed(0)
+    kwargs = {
+        "batch_size": 32,
+        "action_horizon": 16,
+        "max_delay": 4,
+        "shared_time": torch.rand(32),
+    }
+    _, plain = _build_staircase_schedule(**kwargs)
+    torch.manual_seed(0)
+    _, jittered = _build_staircase_schedule(**kwargs, time_jitter=0.2)
+
+    assert not torch.equal(plain, jittered)
+    assert jittered.min() >= 0.0 and jittered.max() <= 1.0
+
+
+def test_config_rejects_staircase_without_a_delay_budget():
+    with pytest.raises(ValueError, match="requires rtc_training_max_delay > 0"):
+        PI05Config(rtc_training_schedule="staircase", rtc_training_max_delay=0)
+
+
+def test_config_rejects_a_delay_that_leaves_no_ramp():
+    # chunk_size - 2 * max_delay < 1 would collapse the interior the ramp is defined on.
+    with pytest.raises(ValueError, match="chunk_size - 2 \\* rtc_training_max_delay"):
+        PI05Config(
+            chunk_size=8, n_action_steps=8, rtc_training_schedule="staircase", rtc_training_max_delay=4
+        )
+
+
+def test_config_rejects_unknown_schedule():
+    with pytest.raises(ValueError, match="must be 'prefix' or 'staircase'"):
+        PI05Config(rtc_training_schedule="linear")
+
+
+def test_default_config_keeps_the_prefix_schedule():
+    assert PI05Config().rtc_training_schedule == "prefix"

--- a/tests/test_pir2_inference_engine.py
+++ b/tests/test_pir2_inference_engine.py
@@ -24,12 +24,16 @@ delay estimation, emission counts, guards) rather than anything about denoising 
 import logging
 import time
 from collections import deque
-from threading import Event
+from threading import Event, Timer
 
 import pytest
 import torch
 
-from lerobot.rollout.inference.pir2 import PiR2InferenceEngine, estimate_pir2_delay
+from lerobot.rollout.inference.pir2 import (
+    _MIN_PENDING_ACTIONS,
+    PiR2InferenceEngine,
+    estimate_pir2_delay,
+)
 
 CHUNK_SIZE = 16
 ACTION_DIM = 6
@@ -41,7 +45,7 @@ class _FakeConfig:
         self.rtc_training_schedule = "staircase"
 
 
-class _FakeSlowChannel:
+class _FakePrefix:
     def __init__(self, captured_at):
         self.captured_at = captured_at
 
@@ -53,23 +57,23 @@ class _FakePolicy:
         self.config = _FakeConfig()
         self.warm_starts = 0
         self.substep_delays: list[int] = []
-        self.slow_channel_calls = 0
+        self.prefix_encode_calls = 0
         self.seen_prefixes: list[object] = []
 
     def reset(self):
         pass
 
-    def encode_slow_channel(self, batch):
-        self.slow_channel_calls += 1
-        return _FakeSlowChannel(captured_at=time.perf_counter())
+    def encode_prefix(self, batch):
+        self.prefix_encode_calls += 1
+        return _FakePrefix(captured_at=time.perf_counter())
 
-    def warm_start_realtime_buffer(self, slow, delay):
+    def warm_start_realtime_buffer(self, prefix, delay):
         self.warm_starts += 1
         return torch.zeros(1, CHUNK_SIZE, ACTION_DIM)
 
-    def realtime_substep(self, slow, buffer, delay):
+    def realtime_substep(self, prefix, buffer, delay):
         self.substep_delays.append(delay)
-        self.seen_prefixes.append(slow)
+        self.seen_prefixes.append(prefix)
         # Tag every emitted action with the call index so the test can spot duplicates.
         emitted = torch.full((1, delay, ACTION_DIM), float(len(self.substep_delays)))
         return emitted, buffer
@@ -169,16 +173,24 @@ def test_max_delay_never_exceeds_half_the_chunk():
 
 
 def _run_iterations(engine, policy, iterations):
-    """Drive the loop body directly, avoiding thread-timing flakiness in tests."""
+    """Drive the loop body directly, avoiding thread-timing flakiness in tests.
+
+    Returns every action the (simulated) robot consumed, in order.
+    """
     engine._obs_holder = {"obs": {}, "robot_type": "fake"}  # noqa: SLF001
     engine.notify_observation({})
     engine.resume()
-    if engine._slow is None:  # noqa: SLF001
+    if engine._prefix is None:  # noqa: SLF001
         # Stand in for the VLM thread, which the loop cannot run without.
-        engine._slow = policy.encode_slow_channel({})  # noqa: SLF001
+        engine._prefix = policy.encode_prefix({})  # noqa: SLF001
+    consumed = []
     for _ in range(iterations):
         engine._shutdown_event.clear()  # noqa: SLF001
         _single_iteration(engine)
+        # Stand in for the robot: with no consumer, backpressure stalls the loop.
+        while (action := engine.get_action(None)) is not None:
+            consumed.append(action)
+    return consumed
 
 
 def _single_iteration(engine):
@@ -208,17 +220,16 @@ def test_buffer_is_warm_started_once_and_then_carried_across_calls():
 
 
 def test_substeps_reuse_one_cached_prefix_instead_of_re_encoding():
-    # The whole point of the slow channel: the backbone runs on its own thread, and the denoising
-    # loop never pays for it.
+    # The backbone runs on its own thread, so the denoising loop never pays for it.
     policy = _FakePolicy()
     engine = _make_engine(policy=policy)
-    engine._slow = policy.encode_slow_channel({})  # noqa: SLF001
+    engine._prefix = policy.encode_prefix({})  # noqa: SLF001
 
     _run_iterations(engine, policy, 3)
 
-    assert policy.slow_channel_calls == 1
+    assert policy.prefix_encode_calls == 1
     assert len(policy.substep_delays) == 3
-    assert all(prefix is engine._slow for prefix in policy.seen_prefixes)  # noqa: SLF001
+    assert all(prefix is engine._prefix for prefix in policy.seen_prefixes)  # noqa: SLF001
 
 
 def test_denoise_loop_waits_for_the_first_cache():
@@ -231,7 +242,7 @@ def test_denoise_loop_waits_for_the_first_cache():
     engine._shutdown_event.set()  # noqa: SLF001
     engine._denoise_loop()  # noqa: SLF001
 
-    assert policy.slow_channel_calls == 0
+    assert policy.prefix_encode_calls == 0
     assert policy.substep_delays == []
 
 
@@ -239,7 +250,7 @@ def test_a_badly_stale_prefix_is_reported(caplog):
     policy = _FakePolicy()
     engine = _make_engine(policy=policy)
     # Older than a whole chunk at 30 fps, so the plan behind the clean front is out of date.
-    engine._slow = _FakeSlowChannel(captured_at=time.perf_counter() - 2 * CHUNK_SIZE / 30.0)  # noqa: SLF001
+    engine._prefix = _FakePrefix(captured_at=time.perf_counter() - 2 * CHUNK_SIZE / 30.0)  # noqa: SLF001
 
     with caplog.at_level(logging.WARNING):
         _run_iterations(engine, policy, 1)
@@ -262,24 +273,40 @@ def test_a_fresh_prefix_is_not_reported_as_stale(caplog):
 def test_every_substep_emits_exactly_delay_actions():
     policy = _FakePolicy()
     engine = _make_engine(policy=policy)
-    _run_iterations(engine, policy, 2)
+    consumed = _run_iterations(engine, policy, 2)
 
-    assert engine.pending_actions() == sum(policy.substep_delays)
-    action = engine.get_action(None)
-    assert action.shape == (ACTION_DIM,)
+    assert len(consumed) == sum(policy.substep_delays)
+    assert consumed[0].shape == (ACTION_DIM,)
 
 
 def test_emitted_actions_are_handed_out_in_order_without_duplicates():
     policy = _FakePolicy()
     engine = _make_engine(policy=policy)
-    _run_iterations(engine, policy, 3)
+    consumed = _run_iterations(engine, policy, 3)
 
     # Each fake substep tags its actions with its call index, so the tags must be non-decreasing.
-    tags = []
-    while (action := engine.get_action(None)) is not None:
-        tags.append(action[0].item())
+    tags = [action[0].item() for action in consumed]
     assert tags == sorted(tags)
     assert len(tags) == sum(policy.substep_delays)
+
+
+def test_the_loop_stops_denoising_while_the_robot_is_behind():
+    # Running ahead of the robot buys nothing and only ages the actions it will execute, so a
+    # backed-up queue must idle the expert rather than grow without bound.
+    policy = _FakePolicy()
+    engine = _make_engine(policy=policy)
+    engine._obs_holder = {"obs": {}, "robot_type": "fake"}  # noqa: SLF001
+    engine.notify_observation({})
+    engine.resume()
+    engine._prefix = policy.encode_prefix({})  # noqa: SLF001
+
+    # Nothing consumes, so the loop should fill its cushion and then spin without substepping.
+    engine._shutdown_event.clear()  # noqa: SLF001
+    Timer(1.0, engine._shutdown_event.set).start()  # noqa: SLF001
+    engine._denoise_loop()  # noqa: SLF001
+
+    assert engine.pending_actions() == _MIN_PENDING_ACTIONS
+    assert len(policy.substep_delays) == _MIN_PENDING_ACTIONS
 
 
 def test_get_action_returns_none_when_nothing_has_been_emitted():

--- a/tests/test_pir2_inference_engine.py
+++ b/tests/test_pir2_inference_engine.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the piR2 inference engine, driven by a fake policy and robot.
+
+The engine's contract is that a background thread keeps one buffer alive and streams finished
+actions to the control loop, so these tests check the loop's bookkeeping (warm start once,
+delay estimation, emission counts, guards) rather than anything about denoising quality.
+"""
+
+import logging
+import time
+from collections import deque
+from threading import Event
+
+import pytest
+import torch
+
+from lerobot.rollout.inference.pir2 import PiR2InferenceEngine, estimate_pir2_delay
+
+CHUNK_SIZE = 16
+ACTION_DIM = 6
+
+
+class _FakeConfig:
+    def __init__(self):
+        self.chunk_size = CHUNK_SIZE
+        self.rtc_training_schedule = "staircase"
+
+
+class _FakeSlowChannel:
+    def __init__(self, captured_at):
+        self.captured_at = captured_at
+
+
+class _FakePolicy:
+    """Stands in for a staircase-trained pi0.5: records calls, returns recognizable actions."""
+
+    def __init__(self):
+        self.config = _FakeConfig()
+        self.warm_starts = 0
+        self.substep_delays: list[int] = []
+        self.slow_channel_calls = 0
+        self.seen_prefixes: list[object] = []
+
+    def reset(self):
+        pass
+
+    def encode_slow_channel(self, batch):
+        self.slow_channel_calls += 1
+        return _FakeSlowChannel(captured_at=time.perf_counter())
+
+    def warm_start_realtime_buffer(self, slow, delay):
+        self.warm_starts += 1
+        return torch.zeros(1, CHUNK_SIZE, ACTION_DIM)
+
+    def realtime_substep(self, slow, buffer, delay):
+        self.substep_delays.append(delay)
+        self.seen_prefixes.append(slow)
+        # Tag every emitted action with the call index so the test can spot duplicates.
+        emitted = torch.full((1, delay, ACTION_DIM), float(len(self.substep_delays)))
+        return emitted, buffer
+
+
+class _IdentityProcessor:
+    def __init__(self):
+        self.steps = []
+
+    def __call__(self, batch):
+        return batch
+
+    def reset(self):
+        pass
+
+
+class _FakeRobot:
+    robot_type = "fake"
+    action_features = {f"joint_{i}.pos": float for i in range(ACTION_DIM)}
+
+
+def _make_engine(policy=None, **kwargs):
+    return PiR2InferenceEngine(
+        policy=policy or _FakePolicy(),
+        preprocessor=_IdentityProcessor(),
+        postprocessor=_IdentityProcessor(),
+        robot_wrapper=_FakeRobot(),
+        hw_features={},
+        task="do the thing",
+        fps=30.0,
+        device="cpu",
+        shutdown_event=Event(),
+        **kwargs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Delay estimation
+# ---------------------------------------------------------------------------
+
+
+def test_delay_estimate_is_one_before_any_measurement():
+    assert estimate_pir2_delay(deque(), 1 / 30, 8) == 1
+
+
+@pytest.mark.parametrize(
+    ("latency_s", "expected"),
+    [
+        (0.003, 1),  # Faster than a control tick still emits one action per call.
+        (0.033, 1),
+        (0.070, 2),
+        (0.100, 3),
+    ],
+)
+def test_delay_estimate_rounds_latency_to_control_steps(latency_s, expected):
+    assert estimate_pir2_delay(deque([latency_s] * 5), 1 / 30, 8) == expected
+
+
+def test_delay_estimate_is_clamped_to_the_schedule_limit():
+    assert estimate_pir2_delay(deque([10.0]), 1 / 30, 8) == 8
+
+
+def test_delay_estimate_uses_the_mean_not_the_max():
+    # One slow call among fast ones should not permanently inflate d.
+    window = deque([0.003] * 9 + [0.3])
+    assert estimate_pir2_delay(window, 1 / 30, 25) == 1
+
+
+# ---------------------------------------------------------------------------
+# Construction guards
+# ---------------------------------------------------------------------------
+
+
+def test_engine_rejects_a_policy_without_the_pir2_entry_points():
+    class _Bare:
+        config = _FakeConfig()
+
+    with pytest.raises(NotImplementedError, match="does not support piR2"):
+        _make_engine(policy=_Bare())
+
+
+def test_engine_rejects_a_prefix_trained_checkpoint():
+    policy = _FakePolicy()
+    policy.config.rtc_training_schedule = "prefix"
+    with pytest.raises(ValueError, match="rtc_training_schedule=staircase"):
+        _make_engine(policy=policy)
+
+
+def test_max_delay_never_exceeds_half_the_chunk():
+    engine = _make_engine(max_delay=CHUNK_SIZE)
+    assert engine._max_delay == CHUNK_SIZE // 2  # noqa: SLF001
+
+
+# ---------------------------------------------------------------------------
+# Loop behavior
+# ---------------------------------------------------------------------------
+
+
+def _run_iterations(engine, policy, iterations):
+    """Drive the loop body directly, avoiding thread-timing flakiness in tests."""
+    engine._obs_holder = {"obs": {}, "robot_type": "fake"}  # noqa: SLF001
+    engine.notify_observation({})
+    engine.resume()
+    if engine._slow is None:  # noqa: SLF001
+        # Stand in for the VLM thread, which the loop cannot run without.
+        engine._slow = policy.encode_slow_channel({})  # noqa: SLF001
+    for _ in range(iterations):
+        engine._shutdown_event.clear()  # noqa: SLF001
+        _single_iteration(engine)
+
+
+def _single_iteration(engine):
+    """One pass of ``_denoise_loop``, stopped after a single substep."""
+    stop_after_one = Event()
+    original = engine._policy.realtime_substep  # noqa: SLF001
+
+    def wrapped(*args, **kwargs):
+        result = original(*args, **kwargs)
+        stop_after_one.set()
+        engine._shutdown_event.set()  # noqa: SLF001
+        return result
+
+    engine._policy.realtime_substep = wrapped  # noqa: SLF001
+    engine._denoise_loop()  # noqa: SLF001
+    engine._policy.realtime_substep = original  # noqa: SLF001
+    assert stop_after_one.is_set()
+
+
+def test_buffer_is_warm_started_once_and_then_carried_across_calls():
+    policy = _FakePolicy()
+    engine = _make_engine(policy=policy)
+    _run_iterations(engine, policy, 3)
+
+    assert policy.warm_starts == 1
+    assert len(policy.substep_delays) == 3
+
+
+def test_substeps_reuse_one_cached_prefix_instead_of_re_encoding():
+    # The whole point of the slow channel: the backbone runs on its own thread, and the denoising
+    # loop never pays for it.
+    policy = _FakePolicy()
+    engine = _make_engine(policy=policy)
+    engine._slow = policy.encode_slow_channel({})  # noqa: SLF001
+
+    _run_iterations(engine, policy, 3)
+
+    assert policy.slow_channel_calls == 1
+    assert len(policy.substep_delays) == 3
+    assert all(prefix is engine._slow for prefix in policy.seen_prefixes)  # noqa: SLF001
+
+
+def test_denoise_loop_waits_for_the_first_cache():
+    policy = _FakePolicy()
+    engine = _make_engine(policy=policy)
+    engine._obs_holder = {"obs": {}, "robot_type": "fake"}  # noqa: SLF001
+    engine.resume()
+
+    # No cache published: the loop must not invent one by calling the backbone itself.
+    engine._shutdown_event.set()  # noqa: SLF001
+    engine._denoise_loop()  # noqa: SLF001
+
+    assert policy.slow_channel_calls == 0
+    assert policy.substep_delays == []
+
+
+def test_a_badly_stale_prefix_is_reported(caplog):
+    policy = _FakePolicy()
+    engine = _make_engine(policy=policy)
+    # Older than a whole chunk at 30 fps, so the plan behind the clean front is out of date.
+    engine._slow = _FakeSlowChannel(captured_at=time.perf_counter() - 2 * CHUNK_SIZE / 30.0)  # noqa: SLF001
+
+    with caplog.at_level(logging.WARNING):
+        _run_iterations(engine, policy, 1)
+
+    assert "control steps old" in caplog.text
+    # Stale is degraded, not fatal: the substep still runs.
+    assert len(policy.substep_delays) == 1
+
+
+def test_a_fresh_prefix_is_not_reported_as_stale(caplog):
+    policy = _FakePolicy()
+    engine = _make_engine(policy=policy)
+
+    with caplog.at_level(logging.WARNING):
+        _run_iterations(engine, policy, 1)
+
+    assert "control steps old" not in caplog.text
+
+
+def test_every_substep_emits_exactly_delay_actions():
+    policy = _FakePolicy()
+    engine = _make_engine(policy=policy)
+    _run_iterations(engine, policy, 2)
+
+    assert engine.pending_actions() == sum(policy.substep_delays)
+    action = engine.get_action(None)
+    assert action.shape == (ACTION_DIM,)
+
+
+def test_emitted_actions_are_handed_out_in_order_without_duplicates():
+    policy = _FakePolicy()
+    engine = _make_engine(policy=policy)
+    _run_iterations(engine, policy, 3)
+
+    # Each fake substep tags its actions with its call index, so the tags must be non-decreasing.
+    tags = []
+    while (action := engine.get_action(None)) is not None:
+        tags.append(action[0].item())
+    assert tags == sorted(tags)
+    assert len(tags) == sum(policy.substep_delays)
+
+
+def test_get_action_returns_none_when_nothing_has_been_emitted():
+    engine = _make_engine()
+    assert engine.get_action(None) is None
+
+
+def test_reset_drops_the_buffer_so_the_next_episode_warm_starts_again():
+    policy = _FakePolicy()
+    engine = _make_engine(policy=policy)
+    _run_iterations(engine, policy, 1)
+    assert engine.ready
+
+    engine.reset()
+    assert not engine.ready
+    assert engine.get_action(None) is None
+
+    _run_iterations(engine, policy, 1)
+    assert policy.warm_starts == 2


### PR DESCRIPTION
Implements πR² ([arXiv 2607.26055](https://arxiv.org/abs/2607.26055)) for pi0.5: a latency-adaptive
staircase noise schedule at training time, and an inference engine that spends one denoising step
per call and streams actions out continuously instead of planning a chunk at a time.

## The idea

Training-time RTC marks the last `d` action of the previous chunk (those actions that occurred during inference) clean and denoises the rest at one shared
noise level. Here there are no action chunks, instead we present the model with one clean action (`t=1`) at the front, and pure noise at the back, with actions in between having incremental levels of noise: this reflects the inherent uncertainty in future actions. At inference we shift that schedule right by `d` carries positions
`[d, 2d)` to clean, so **a single denoising step finishes `d` actions**, a la LLM. Emit them, slide the
buffer, append `d` fresh-noise slots, and the schedule reproduces itself — it is a fixed point
under steady `d`. The robot is fed continuously and never waits for a chunk.

`d` is the stride (can be 1) and the latency measurement at once: it is how many actions the robot consumes
while a call is in flight, which is what makes the schedule latency-adaptive.

## Measured on pi0.5

RTX 5090 Laptop, batch 1, 2 cameras @ 224×224, `chunk_size=50`, `dtype=bfloat16`, 30 fps.
Vision path assumes the SigLIP inference fix (separate PR).

| | ms | control ticks @ 30 fps |
| --- | --- | --- |
| synchronous `sample_actions` (prefix + 10 steps) | 272.0 | 8.2 |
| one action-expert step against a cached prefix | 12.0 | 0.36 |
| VLM prefix (Gemma 87.6 + vision 18.9) | 106.5 | 3.2 |

So the expert step fits inside a tick with room to spare and `d` bottoms out at 1: one action
emitted per call, replanning every control step. The prefix refreshes on its own thread at ~9.4 Hz.

## What is in the diff

- `flow_matching.py`: `staircase_time` (Eq. 3) and `staircase_substep` (Eq. 4 / Fig. 2). Under this
  repo's `t=0`-clean convention the paper's three regions collapse into one clamped ramp.
- `configuration_pi05.py`: `rtc_training_schedule: "prefix" | "staircase"`, `staircase_warmup_prob`,
  `staircase_time_jitter`, and validation that the ramp cannot collapse.
- `modeling_pi05.py`: the training-side schedule sampler (per-example random `d`, plus a
  shared-timestep warm-up branch so the weights can still denoise a chunk from pure noise), and the
  inference primitives — `prefill_prefix`, `warm_start_realtime_buffer`, `realtime_substep`.
- `rollout/inference/pir2.py`: `--inference.type=pir2`. Two threads, one refreshing the prefix cache
  as fast as the backbone allows, one substepping against the newest cache. `d` comes from the
  rolling mean rather than RTC's sticky max: overshooting costs reactivity on every later call,
  while one slow call just leaves the buffer a cycle behind. Refuses prefix-trained checkpoints,
  whose weights have never seen a ramped schedule.

## Deviation from the paper

The paper splits conditioning into a fast proprioception channel refreshed every step and a slow
vision-language channel. pi0.5 discretizes joint state into the tokenized prompt, so a cached
prefix freezes state along with vision — there is no separable fast channel without changing the
prompt format and retraining. This PR does not attempt that. What anchors the expert instead is the
clamped clean front, which is the positions the robot is being commanded to right now. That covers
configuration but not the gap between commanded and actual, so it will not react to an external
disturbance the way the paper's Mod 1 does.

I built the fast channel (state in the suffix + learned delay embedding) and then removed it: it
needs a prompt-format change, so no pretrained pi0.5 checkpoint can be used as-is, and the
conditioning refresh it buys is only worth its cost if the prefix is slow. At 9.4 Hz it isn't
especially. Easy to reinstate if a fine-tune shows the reactivity gap matters.

## Training smoke run

The staircase objective trains. Loss is finite and descends from 1.103 to 0.058 over 1450 steps,
at the same 1.18 s/step and 45.96 GB per GPU as an ordinary pi0.5 fine-tune, so the per-position
schedule costs nothing measurable. Nothing under `src/` had to be changed to make it run: the
three flags are the whole diff in the invocation.

This is a smoke run, not an evaluation. It fine-tunes an existing folding checkpoint on its own
dataset, changing only the noise schedule, and it was cut short by a lost session at step ~1450 of
4000 — 50 steps before the first checkpoint — so **no weights were written**. Rerun with a smaller
`--save_freq` if a checkpoint is wanted.

### Setup

8×H100 80GB, one node, `accelerate` with 8 processes, per-GPU batch 12 for an effective batch of 96.
Branch at `78d23ee980d50bc60556db1ded6709ce8850e405`.

| | |
| --- | --- |
| base checkpoint | `lerobot-data-collection/folding_final` @ `695abe40dbf3aac04efda59c1501d748681fa0fb` |
| dataset | `lerobot-data-collection/level2_final_quality3_t_0_hil_data_c` @ `2496db53d330c360f910d095e13698d968c56fc6`, 1319 episodes, 3,414,338 frames |
| `chunk_size` | 30, so the ramp spans 30 positions |
| relative actions | enabled; `folding_final` predates the `delta_actions_processor` → `relative_actions_processor` rename, so that string is patched in a staged copy of the snapshot before training |

`staircase_warmup_prob` was left at its 0.2 default.

### Command

```bash
accelerate launch \
  --num_machines=1 \
  --num_processes=8 \
  --main_process_port=30263 \
  /fsx/martino/miniforge3/envs/lerobot-hf/bin/lerobot-train \
  --policy.path=/fsx/martino/.tmp/pir2-staircase-30763/model \
  --policy.rtc_training_schedule=staircase \
  --policy.rtc_training_max_delay=1 \
  --policy.staircase_time_jitter=0.1 \
  --policy.device=cuda \
  --policy.dtype=bfloat16 \
  --policy.gradient_checkpointing=true \
  --policy.compile_model=false \
  --policy.push_to_hub=false \
  --policy.scheduler_warmup_steps=400 \
  --policy.scheduler_decay_steps=4000 \
  --dataset.repo_id=lerobot-data-collection/level2_final_quality3_t_0_hil_data_c \
  --dataset.root=/fsx/martino/hf_cache/hub/datasets--lerobot-data-collection--level2_final_quality3_t_0_hil_data_c/snapshots/2496db53d330c360f910d095e13698d968c56fc6 \
  --dataset.use_imagenet_stats=false \
  --output_dir=/fsx/martino/outputs/pir2-staircase-4k \
  --job_name=pir2-staircase-smoke \
  --batch_size=12 \
  --steps=4000 \
  --num_workers=8 \
  --save_freq=1500 \
  --log_freq=25 \
  --seed=1000 \
  --wandb.enable=true \
  --wandb.project=pir2-staircase \
  --wandb.disable_artifact=true
```

`--policy.compile_model=false` is not incidental: `folding_final` carries `compile_model: true`
with `max-autotune`, which triton on this cluster cannot lower (`KeyError: 'cubin'`).

### Result

| step | 25 | 125 | 225 | 425 | 625 | 825 | 1025 | 1225 | 1450 |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| loss | 1.103 | 0.142 | 0.100 | 0.076 | 0.067 | 0.065 | 0.065 | 0.062 | 0.058 |
| grad norm | 10.18 | 0.80 | 0.70 | 0.44 | 0.32 | 0.33 | 0.31 | 0.28 | 0.29 |

Monotone apart from sampling noise, no spikes, no NaNs, gradient norm settling near 0.29.

The loss starts far above the prefix-schedule equivalent, which under the same conditions begins at
0.428 and reaches 0.020 by step 3800. That is expected rather than a regression — the back of the
ramp is being asked to denoise from near-pure noise on every example, so the two objectives are not
on a common scale and their absolute values should not be compared.

<img width="2388" height="623" alt="image" src="https://github.com/user-attachments/assets/d692525c-cc2d-4601-b6c0-6c74414b95a0" />

