### PR TITLE
fix(legacy depth markers): unifying legacy depth markers across the codebase

### DIFF
--- a/src/lerobot/configs/__init__.py
+++ b/src/lerobot/configs/__init__.py
@@ -44,6 +44,7 @@ from .video import (
     depth_encoder_defaults,
     encoder_config_from_video_info,
     infer_depth_unit,
+    is_depth_map,
     rgb_encoder_defaults,
 )
 
@@ -75,6 +76,7 @@ __all__ = [
     # Factories
     "encoder_config_from_video_info",
     "infer_depth_unit",
+    "is_depth_map",
     # Constants
     "DEFAULT_DEPTH_UNIT",
     "DEPTH_METER_UNIT",

--- a/src/lerobot/configs/video.py
+++ b/src/lerobot/configs/video.py
@@ -320,6 +320,23 @@ def depth_encoder_defaults() -> DepthEncoderConfig:
     return DepthEncoderConfig()
 
 
+def is_depth_map(feature: dict | None) -> bool:
+    """Return whether a feature is flagged as a depth map.
+
+    Depth maps are flagged canonically via ``feature['info']['is_depth_map']`` or through the
+    legacy ``video.is_depth_map`` key, which may live in ``feature['info']`` or in a separate
+    ``feature['video_info']`` dict.
+    """
+    feature = feature or {}
+    info = feature.get("info") or {}
+    video_info = feature.get("video_info")
+    return bool(
+        info.get("is_depth_map")
+        or info.get("video.is_depth_map")
+        or (isinstance(video_info, dict) and video_info.get("video.is_depth_map"))
+    )
+
+
 def encoder_config_from_video_info(video_info: dict | None) -> VideoEncoderConfig:
     """Build the appropriate encoder config from a feature's ``info`` block.
 
@@ -336,6 +353,7 @@ def encoder_config_from_video_info(video_info: dict | None) -> VideoEncoderConfi
         :class:`RGBEncoderConfig`.
     """
     video_info = video_info or {}
-    is_depth = bool(video_info.get("is_depth_map") or video_info.get("video.is_depth_map"))
-    cls: type[VideoEncoderConfig] = DepthEncoderConfig if is_depth else RGBEncoderConfig
+    cls: type[VideoEncoderConfig] = (
+        DepthEncoderConfig if is_depth_map({"info": video_info}) else RGBEncoderConfig
+    )
     return cls.from_video_info(video_info)

--- a/src/lerobot/datasets/aggregate.py
+++ b/src/lerobot/datasets/aggregate.py
@@ -30,7 +30,7 @@ from lerobot.configs import VIDEO_ENCODER_INFO_KEYS
 
 from .compute_stats import aggregate_stats
 from .dataset_metadata import LeRobotDatasetMetadata
-from .feature_utils import features_equal_for_merge, get_hf_features_from_features
+from .feature_utils import canonicalize_depth_marker, features_equal_for_merge, get_hf_features_from_features
 from .io_utils import (
     get_file_size_in_mb,
     get_parquet_file_size_in_mb,
@@ -114,6 +114,8 @@ def merge_video_feature_info_for_aggregate(all_metadata: list[LeRobotDatasetMeta
         merged_info[vk]["info"] = {**base_video_info, **merged_encoder_info}
         # TODO(CarolinePascal): make this variable once we have support for other video backends.
         merged_info[vk]["info"]["video.video_backend"] = "pyav"
+        # Persist the canonical depth marker even when a source used a legacy key.
+        canonicalize_depth_marker(merged_info[vk])
 
     return merged_info
 

--- a/src/lerobot/datasets/compute_stats.py
+++ b/src/lerobot/datasets/compute_stats.py
@@ -19,6 +19,7 @@ import logging
 
 import numpy as np
 
+from lerobot.configs import is_depth_map
 from lerobot.processor import RelativeActionsProcessorStep
 from lerobot.utils.constants import ACTION, OBS_STATE
 
@@ -533,9 +534,7 @@ def compute_episode_stats(
         )
 
         if features[key]["dtype"] in ["image", "video"]:
-            normalization_factor = (
-                255.0 if not (features[key].get("info") or {}).get("is_depth_map", False) else 1.0
-            )
+            normalization_factor = 1.0 if is_depth_map(features[key]) else 255.0
             ep_stats[key] = {
                 k: v if k == "count" else np.squeeze(v / normalization_factor, axis=0)
                 for k, v in ep_stats[key].items()

--- a/src/lerobot/datasets/dataset_metadata.py
+++ b/src/lerobot/datasets/dataset_metadata.py
@@ -35,7 +35,7 @@ from lerobot.utils.utils import flatten_dict
 
 from .compute_stats import aggregate_stats
 from .depth_utils import MM_PER_METRE
-from .feature_utils import create_empty_dataset_info
+from .feature_utils import canonicalize_depth_marker, create_empty_dataset_info
 from .io_utils import (
     get_file_size_in_mb,
     load_episodes,
@@ -712,19 +712,22 @@ class LeRobotDatasetMetadata:
         video_keys = [video_key] if video_key is not None else self.video_keys
         preserve_set = set(preserve_keys or ())
         for key in video_keys:
-            existing = self.features[key].get("info") or {}
+            feature = self.info.features[key]
+            existing = feature.get("info") or {}
             video_path = self.root / self.video_path.format(video_key=key, chunk_index=0, file_index=0)
             new_info = get_video_info(video_path, video_encoder=video_encoder)
             # Drop preserved keys so the existing values win on merge.
             new_info = {k: v for k, v in new_info.items() if k not in preserve_set}
-            merged = {**existing, **new_info}
-            # Migrate the legacy depth marker to the canonical key.
-            if "video.is_depth_map" in merged:
-                logging.warning(
-                    f"Migrating legacy 'video.is_depth_map' to 'is_depth_map' for feature {key!r}."
-                )
-                merged.setdefault("is_depth_map", merged.pop("video.is_depth_map"))
-            self.info.features[key]["info"] = merged
+            feature["info"] = {**existing, **new_info}
+            # Migrate any legacy depth marker (in ``info`` or a separate ``video_info`` dict)
+            # to the canonical ``is_depth_map`` key.
+            video_info = feature.get("video_info")
+            had_legacy = "video.is_depth_map" in feature["info"] or (
+                isinstance(video_info, dict) and "video.is_depth_map" in video_info
+            )
+            canonicalize_depth_marker(feature)
+            if had_legacy:
+                logging.warning(f"Migrated legacy depth marker to 'is_depth_map' for feature {key!r}.")
 
     def update_chunk_settings(
         self,

--- a/src/lerobot/datasets/dataset_metadata.py
+++ b/src/lerobot/datasets/dataset_metadata.py
@@ -28,7 +28,7 @@ import pyarrow.parquet as pq
 from huggingface_hub import snapshot_download, sync_bucket
 from huggingface_hub.utils import WeakFileLock
 
-from lerobot.configs import DEPTH_METER_UNIT, VideoEncoderConfig
+from lerobot.configs import DEPTH_METER_UNIT, VideoEncoderConfig, is_depth_map
 from lerobot.utils.constants import DEFAULT_FEATURES, HF_LEROBOT_HOME, HF_LEROBOT_HUB_CACHE
 from lerobot.utils.feature_utils import _validate_feature_names
 from lerobot.utils.utils import flatten_dict
@@ -400,16 +400,7 @@ class LeRobotDatasetMetadata:
         (or the legacy ``"video.is_depth_map"`` inside ``info`` or ``video_info``).
         """
 
-        def _is_depth(ft: dict) -> bool:
-            info = ft.get("info") or {}
-            video_info = ft.get("video_info") or {}
-            return (
-                info.get("is_depth_map", False)
-                or info.get("video.is_depth_map", False)
-                or video_info.get("video.is_depth_map", False)
-            )
-
-        return [key for key, ft in self.features.items() if _is_depth(ft)]
+        return [key for key, ft in self.features.items() if is_depth_map(ft)]
 
     def rescale_depth_stats(self, output_unit: str) -> None:
         """Rescale depth feature stats in place from their recorded unit to ``output_unit``.

--- a/src/lerobot/datasets/feature_utils.py
+++ b/src/lerobot/datasets/feature_utils.py
@@ -140,8 +140,7 @@ def canonicalize_depth_marker(feature: dict) -> None:
         video_info.pop("video.is_depth_map", None)
     if not video_info:
         feature.pop("video_info", None)
-    if depth:
-        info["is_depth_map"] = True
+    info["is_depth_map"] = depth
 
 
 def features_equal_for_merge(features_a: dict[str, dict], features_b: dict[str, dict]) -> bool:

--- a/src/lerobot/datasets/feature_utils.py
+++ b/src/lerobot/datasets/feature_utils.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import logging
+from copy import deepcopy
 from pprint import pformat
 
 import datasets
@@ -122,23 +123,44 @@ def create_empty_dataset_info(
     )
 
 
+def canonicalize_depth_marker(feature: dict) -> None:
+    """Fold a feature's legacy depth marker into the canonical ``info['is_depth_map']``.
+
+    Depth maps can be flagged in three ways across dataset versions: the canonical
+    ``feature['info']['is_depth_map']``, the legacy ``feature['info']['video.is_depth_map']``,
+    or a legacy ``feature['video_info']['video.is_depth_map']`` in a separate dict. This mutates
+    ``feature`` in place, dropping the legacy keys.
+    """
+    info = feature.get("info") or {}
+    feature["info"] = info
+    video_info = feature.get("video_info")
+    legacy = info.pop("video.is_depth_map", None)
+    if isinstance(video_info, dict):
+        legacy = video_info.pop("video.is_depth_map", None) or legacy
+    if info.get("is_depth_map") or legacy:
+        info["is_depth_map"] = True
+
+
 def features_equal_for_merge(features_a: dict[str, dict], features_b: dict[str, dict]) -> bool:
     """Return whether two LeRobotDatasetMetadata ``features`` dicts are compatible for aggregation.
 
     For video features, keys under ``info`` related to video encoding parameters are ignored during
-    comparison as they do not prevent aggregation.
+    comparison as they do not prevent aggregation. The legacy depth marker (``video.is_depth_map``,
+    in ``info`` or a separate ``video_info`` dict) is canonicalized so datasets that only differ in
+    how they flag depth remain mergeable.
     """
 
-    def _without_encoder_info_keys(feature: dict) -> dict:
-        filtered = dict(feature)
-        filtered_info = filtered.get("info")
-        if isinstance(filtered_info, dict):
-            filtered["info"] = {
-                info_key: info_value
-                for info_key, info_value in filtered_info.items()
-                if info_key not in VIDEO_ENCODER_INFO_KEYS
-            }
-        return filtered
+    def _normalized(feature: dict) -> dict:
+        normalized = deepcopy(feature)
+        canonicalize_depth_marker(normalized)
+        normalized["info"] = {
+            info_key: info_value
+            for info_key, info_value in normalized["info"].items()
+            if info_key not in VIDEO_ENCODER_INFO_KEYS
+        }
+        if not normalized.get("video_info"):
+            normalized.pop("video_info", None)
+        return normalized
 
     if set(features_a) != set(features_b):
         return False
@@ -147,12 +169,7 @@ def features_equal_for_merge(features_a: dict[str, dict], features_b: dict[str, 
         fb_key = features_b[key]
         if fa_key.get("dtype") != fb_key.get("dtype"):
             return False
-        if fa_key.get("dtype") != "video":
-            if fa_key != fb_key:
-                return False
-            continue
-
-        if _without_encoder_info_keys(fa_key) != _without_encoder_info_keys(fb_key):
+        if _normalized(fa_key) != _normalized(fb_key):
             return False
     return True
 

--- a/src/lerobot/datasets/feature_utils.py
+++ b/src/lerobot/datasets/feature_utils.py
@@ -138,6 +138,8 @@ def canonicalize_depth_marker(feature: dict) -> None:
     info.pop("video.is_depth_map", None)
     if isinstance(video_info, dict):
         video_info.pop("video.is_depth_map", None)
+    if not video_info:
+        feature.pop("video_info", None)
     if depth:
         info["is_depth_map"] = True
 
@@ -159,8 +161,6 @@ def features_equal_for_merge(features_a: dict[str, dict], features_b: dict[str, 
             for info_key, info_value in normalized["info"].items()
             if info_key not in VIDEO_ENCODER_INFO_KEYS
         }
-        if not normalized.get("video_info"):
-            normalized.pop("video_info", None)
         return normalized
 
     if set(features_a) != set(features_b):

--- a/src/lerobot/datasets/feature_utils.py
+++ b/src/lerobot/datasets/feature_utils.py
@@ -21,7 +21,7 @@ import datasets
 import numpy as np
 from PIL import Image as PILImage
 
-from lerobot.configs import VIDEO_ENCODER_INFO_KEYS
+from lerobot.configs import VIDEO_ENCODER_INFO_KEYS, is_depth_map
 from lerobot.utils.constants import DEFAULT_FEATURES
 from lerobot.utils.utils import is_valid_numpy_dtype_string
 
@@ -134,10 +134,11 @@ def canonicalize_depth_marker(feature: dict) -> None:
     info = feature.get("info") or {}
     feature["info"] = info
     video_info = feature.get("video_info")
-    legacy = info.pop("video.is_depth_map", None)
+    depth = is_depth_map(feature)
+    info.pop("video.is_depth_map", None)
     if isinstance(video_info, dict):
-        legacy = video_info.pop("video.is_depth_map", None) or legacy
-    if info.get("is_depth_map") or legacy:
+        video_info.pop("video.is_depth_map", None)
+    if depth:
         info["is_depth_map"] = True
 
 

--- a/tests/datasets/test_aggregate.py
+++ b/tests/datasets/test_aggregate.py
@@ -317,6 +317,7 @@ def test_depth_marker_legacy_names(legacy_info, legacy_video_info):
     merged = merge_video_feature_info_for_aggregate([meta_legacy, meta_recent])
     assert merged[key]["info"]["is_depth_map"] is True
     assert "video.is_depth_map" not in merged[key]["info"]
+    assert "video_info" not in merged[key]
 
 
 def test_aggregate_datasets(tmp_path, lerobot_dataset_factory):

--- a/tests/datasets/test_aggregate.py
+++ b/tests/datasets/test_aggregate.py
@@ -312,6 +312,13 @@ def test_depth_marker_legacy_names(legacy_info, legacy_video_info):
     assert features_equal_for_merge({key: canonical}, {key: legacy})
     assert not features_equal_for_merge({key: canonical}, {key: _feature({})})
 
+    # Non-depth features must stay mergeable regardless of how "not depth" is spelled:
+    # legacy ``video.is_depth_map: False``, explicit ``is_depth_map: False``, or no marker.
+    assert features_equal_for_merge(
+        {key: _feature({"video.is_depth_map": False})}, {key: _feature({"is_depth_map": False})}
+    )
+    assert features_equal_for_merge({key: _feature({"is_depth_map": False})}, {key: _feature({})})
+
     meta_legacy = SimpleNamespace(features={key: legacy})
     meta_recent = SimpleNamespace(features={key: canonical})
     merged = merge_video_feature_info_for_aggregate([meta_legacy, meta_recent])

--- a/tests/datasets/test_aggregate.py
+++ b/tests/datasets/test_aggregate.py
@@ -16,6 +16,7 @@
 
 import json
 import logging
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -28,12 +29,14 @@ import pandas as pd
 import torch
 
 from lerobot.configs import VIDEO_ENCODER_INFO_KEYS
-from lerobot.datasets.aggregate import aggregate_datasets
+from lerobot.datasets.aggregate import aggregate_datasets, merge_video_feature_info_for_aggregate
 from lerobot.datasets.feature_utils import features_equal_for_merge
 from lerobot.datasets.lerobot_dataset import LeRobotDataset
 from lerobot.datasets.utils import EPISODES_DIR
 from tests.fixtures.constants import (
     DUMMY_CAMERA_FEATURES_WITH_DEPTH,
+    DUMMY_DEPTH_FEATURES,
+    DUMMY_DEPTH_KEY,
     DUMMY_REPO_ID,
 )
 
@@ -283,6 +286,37 @@ def assert_video_timestamps_within_bounds(aggr_ds):
                 raise AssertionError(
                     f"Failed to verify timestamps for episode {ep_idx}, {vid_key}: {e}"
                 ) from e
+
+
+@pytest.mark.parametrize(
+    "legacy_info, legacy_video_info",
+    [
+        ({"video.is_depth_map": True}, None),  # legacy marker inside info
+        ({}, {"video.is_depth_map": True}),  # legacy marker in separate video_info dict
+    ],
+)
+def test_depth_marker_legacy_names(legacy_info, legacy_video_info):
+    """A recent (canonical) depth dataset stays mergeable with legacy marker forms, and the
+    merged metadata is canonicalized. A genuine non-depth feature stays a mismatch."""
+
+    def _feature(info: dict, video_info: dict | None = None) -> dict:
+        ft = {**DUMMY_DEPTH_FEATURES[DUMMY_DEPTH_KEY], "info": dict(info)}
+        if video_info is not None:
+            ft["video_info"] = dict(video_info)
+        return ft
+
+    key = DUMMY_DEPTH_KEY
+    canonical = _feature({"is_depth_map": True})
+    legacy = _feature(legacy_info, legacy_video_info)
+
+    assert features_equal_for_merge({key: canonical}, {key: legacy})
+    assert not features_equal_for_merge({key: canonical}, {key: _feature({})})
+
+    meta_legacy = SimpleNamespace(features={key: legacy})
+    meta_recent = SimpleNamespace(features={key: canonical})
+    merged = merge_video_feature_info_for_aggregate([meta_legacy, meta_recent])
+    assert merged[key]["info"]["is_depth_map"] is True
+    assert "video.is_depth_map" not in merged[key]["info"]
 
 
 def test_aggregate_datasets(tmp_path, lerobot_dataset_factory):


### PR DESCRIPTION
## Summary / Motivation

This PR fixes an aggregation bug where two datasets could not be merged if one of them had a legacy depth frames marker ( `video_info.video.is_depth_map` or `info.video.is_depth_map`). It also fixes the following aggregation by removing the legacy marker and only keeping the canonical one (`info.is_depth_map`) and unifies the way depth markers are handled across the codebase.

## Related issues

- Fixes / Closes: # (if any)
- Related: # (if any)

## What changed

- A new utility function `canonicalize_depth_marker` is added to consistently turn legacy depth markers into the canonical form. It's now used in `merge_video_feature_info_for_aggregate` and `features_equal_for_merge` but also `LeRobotMetadata.update_video_info`.

## How was this tested (or how to run locally)

- Tests added: `test_depth_marker_legacy_names` in `test_aggregate.py

## Checklist (required before merge)

- [ ] Linting/formatting run (`pre-commit run -a`)
- [ ] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: # (insert PR number/link)

## Reviewer notes

- Anything the reviewer should focus on (performance, edge-cases, specific files) or general notes.
- Anyone in the community is free to review the PR.
