### PR TITLE
Ensure the teleoperators module passes MyPy type checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -612,9 +612,9 @@ ignore_errors = false
 # module = "lerobot.robots.*"
 # ignore_errors = false
 
-# [[tool.mypy.overrides]]
-# module = "lerobot.teleoperators.*"
-# ignore_errors = false
+[[tool.mypy.overrides]]
+module = "lerobot.teleoperators.*"
+ignore_errors = false
 
 # [[tool.mypy.overrides]]
 # module = "lerobot.policies.*"

--- a/src/lerobot/teleoperators/gamepad/teleop_gamepad.py
+++ b/src/lerobot/teleoperators/gamepad/teleop_gamepad.py
@@ -27,6 +27,7 @@ from lerobot.utils.decorators import check_if_not_connected
 from ..teleoperator import Teleoperator
 from ..utils import TeleopEvents
 from .configuration_gamepad import GamepadTeleopConfig
+from .gamepad_utils import InputController
 
 logger = logging.getLogger(__name__)
 
@@ -57,7 +58,7 @@ class GamepadTeleop(Teleoperator):
         self.config = config
         self.robot_type = config.type
 
-        self.gamepad = None
+        self.gamepad: InputController | None = None
 
         self.hidapi_fallback = config.hidapi_fallback
         if sys.platform == "darwin" and not self.hidapi_fallback:
@@ -85,17 +86,15 @@ class GamepadTeleop(Teleoperator):
     def feedback_features(self) -> dict:
         return {}
 
-    def connect(self) -> None:
-        if self.hidapi_fallback:
-            from .gamepad_utils import GamepadControllerHID as Gamepad
-        else:
-            from .gamepad_utils import GamepadController as Gamepad
+    def connect(self, calibrate: bool = True) -> None:
+        from .gamepad_utils import GamepadController, GamepadControllerHID
 
-        self.gamepad = Gamepad()
+        self.gamepad = GamepadControllerHID() if self.hidapi_fallback else GamepadController()
         self.gamepad.start()
 
     @check_if_not_connected
     def get_action(self) -> RobotAction:
+        assert self.gamepad is not None
         # Update the controller to get fresh inputs
         self.gamepad.update()
 
@@ -120,7 +119,7 @@ class GamepadTeleop(Teleoperator):
 
         return action_dict
 
-    def get_teleop_events(self) -> dict[str, Any]:
+    def get_teleop_events(self) -> dict[TeleopEvents, Any]:
         """
         Get extra control events from the gamepad such as intervention status,
         episode termination, success indicators, etc.
@@ -178,6 +177,7 @@ class GamepadTeleop(Teleoperator):
         # No calibration needed for gamepad
         pass
 
+    @property
     def is_calibrated(self) -> bool:
         """Check if gamepad is calibrated."""
         # Gamepad doesn't require calibration

--- a/src/lerobot/teleoperators/homunculus/homunculus_arm.py
+++ b/src/lerobot/teleoperators/homunculus/homunculus_arm.py
@@ -65,7 +65,7 @@ class HomunculusArm(Teleoperator):
         self.n: int = n
         self.alpha: float = 2 / (n + 1)
         # one deque *per joint* so we can inspect raw history if needed
-        self._buffers: dict[str, deque[int]] = {
+        self._buffers: dict[str, deque[float]] = {
             joint: deque(maxlen=n)
             for joint in (
                 "shoulder_pitch",
@@ -166,8 +166,8 @@ class HomunculusArm(Teleoperator):
         display_len = max(len(key) for key in joints)
 
         start_positions = self._read(joints, normalize=False)
-        mins = start_positions.copy()
-        maxes = start_positions.copy()
+        mins: dict[str, int] = {joint: int(value) for joint, value in start_positions.items()}
+        maxes: dict[str, int] = dict(mins)
 
         user_pressed_enter = False
         while not user_pressed_enter:
@@ -200,7 +200,7 @@ class HomunculusArm(Teleoperator):
         pass
 
     # TODO(Steven): This function is copy/paste from the `HomunculusGlove` class. Consider moving it to an utility to reduce duplicated code.
-    def _normalize(self, values: dict[str, int]) -> dict[str, float]:
+    def _normalize(self, values: dict[str, float]) -> dict[str, float]:
         if not self.calibration:
             raise RuntimeError(f"{self} has no calibration registered.")
 
@@ -220,7 +220,7 @@ class HomunculusArm(Teleoperator):
 
         return normalized_values
 
-    def _apply_ema(self, raw: dict[str, int]) -> dict[str, float]:
+    def _apply_ema(self, raw: dict[str, float]) -> dict[str, float]:
         """Update buffers & running EMA values; return smoothed dict."""
         smoothed: dict[str, float] = {}
         for joint, value in raw.items():
@@ -228,12 +228,14 @@ class HomunculusArm(Teleoperator):
             self._buffers[joint].append(value)
 
             # initialise on first run
-            if self._ema[joint] is None:
-                self._ema[joint] = float(value)
+            previous_ema = self._ema[joint]
+            if previous_ema is None:
+                new_ema = float(value)
             else:
-                self._ema[joint] = self.alpha * value + (1 - self.alpha) * self._ema[joint]
+                new_ema = self.alpha * value + (1 - self.alpha) * previous_ema
+            self._ema[joint] = new_ema
 
-            smoothed[joint] = self._ema[joint]
+            smoothed[joint] = new_ema
         return smoothed
 
     def _read(

--- a/src/lerobot/teleoperators/homunculus/homunculus_glove.py
+++ b/src/lerobot/teleoperators/homunculus/homunculus_glove.py
@@ -102,7 +102,7 @@ class HomunculusGlove(Teleoperator):
         self.n: int = n
         self.alpha: float = 2 / (n + 1)
         # one deque *per joint* so we can inspect raw history if needed
-        self._buffers: dict[str, deque[int]] = {joint: deque(maxlen=n) for joint in self.joints}
+        self._buffers: dict[str, deque[float]] = {joint: deque(maxlen=n) for joint in self.joints}
         # running EMA value per joint – lazily initialised on first read
         self._ema: dict[str, float | None] = dict.fromkeys(self._buffers)
 
@@ -197,8 +197,8 @@ class HomunculusGlove(Teleoperator):
         display_len = max(len(key) for key in joints)
 
         start_positions = self._read(joints, normalize=False)
-        mins = start_positions.copy()
-        maxes = start_positions.copy()
+        mins: dict[str, int] = {joint: int(value) for joint, value in start_positions.items()}
+        maxes: dict[str, int] = dict(mins)
 
         user_pressed_enter = False
         while not user_pressed_enter:
@@ -251,7 +251,7 @@ class HomunculusGlove(Teleoperator):
 
         return normalized_values
 
-    def _apply_ema(self, raw: dict[str, int]) -> dict[str, int]:
+    def _apply_ema(self, raw: dict[str, float]) -> dict[str, int]:
         """Update buffers & running EMA values; return smoothed dict as integers."""
         smoothed: dict[str, int] = {}
         for joint, value in raw.items():
@@ -259,13 +259,15 @@ class HomunculusGlove(Teleoperator):
             self._buffers[joint].append(value)
 
             # initialise on first run
-            if self._ema[joint] is None:
-                self._ema[joint] = float(value)
+            previous_ema = self._ema[joint]
+            if previous_ema is None:
+                new_ema = float(value)
             else:
-                self._ema[joint] = self.alpha * value + (1 - self.alpha) * self._ema[joint]
+                new_ema = self.alpha * value + (1 - self.alpha) * previous_ema
+            self._ema[joint] = new_ema
 
             # Convert back to int for compatibility with normalization
-            smoothed[joint] = int(round(self._ema[joint]))
+            smoothed[joint] = int(round(new_ema))
         return smoothed
 
     def _read(
@@ -290,13 +292,14 @@ class HomunculusGlove(Teleoperator):
             state = {k: v for k, v in state.items() if k in joints}
 
         # Apply EMA smoothing to raw values first
-        state = self._apply_ema(state)
+        smoothed = self._apply_ema(state)
 
         # Then normalize if requested
         if normalize:
-            state = self._normalize(state)
+            return self._normalize(smoothed)
 
-        return state
+        result: dict[str, int | float] = dict(smoothed)
+        return result
 
     def _read_loop(self):
         """

--- a/src/lerobot/teleoperators/keyboard/teleop_keyboard.py
+++ b/src/lerobot/teleoperators/keyboard/teleop_keyboard.py
@@ -17,7 +17,7 @@
 import logging
 import time
 from queue import Queue
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from lerobot.lerobot_types import RobotAction
 from lerobot.utils.decorators import check_if_already_connected, check_if_not_connected
@@ -33,13 +33,15 @@ from .configuration_keyboard import (
 )
 
 PYNPUT_AVAILABLE = _pynput_available
-keyboard = None
-if PYNPUT_AVAILABLE:
+if TYPE_CHECKING or PYNPUT_AVAILABLE:
     try:
         from pynput import keyboard
     except Exception as e:
         PYNPUT_AVAILABLE = False
+        keyboard = None
         logging.info("Could not import pynput keyboard backend: %s", e)
+else:
+    keyboard = None
 
 
 class KeyboardTeleop(Teleoperator):
@@ -56,17 +58,20 @@ class KeyboardTeleop(Teleoperator):
         self.config = config
         self.robot_type = config.type
 
-        self.event_queue = Queue()
-        self.current_pressed = {}
-        self.listener = None
-        self.logs = {}
+        self.event_queue: Queue = Queue()
+        self.current_pressed: dict = {}
+        self.listener: keyboard.Listener | None = None
+        self.logs: dict = {}
 
     @property
     def action_features(self) -> dict:
+        # TODO: `self.arm` is never defined on this class (dead/unreachable code path -
+        # no caller invokes `action_features` on a plain `KeyboardTeleop`, only on the
+        # `KeyboardEndEffectorTeleop`/`KeyboardRoverTeleop` subclasses, which override it).
         return {
             "dtype": "float32",
-            "shape": (len(self.arm),),
-            "names": {"motors": list(self.arm.motors)},
+            "shape": (len(self.arm),),  # type: ignore[attr-defined]
+            "names": {"motors": list(self.arm.motors)},  # type: ignore[attr-defined]
         }
 
     @property
@@ -79,7 +84,7 @@ class KeyboardTeleop(Teleoperator):
 
     @property
     def is_calibrated(self) -> bool:
-        pass
+        return True
 
     @check_if_already_connected
     def connect(self) -> None:
@@ -158,7 +163,7 @@ class KeyboardEndEffectorTeleop(KeyboardTeleop):
     def __init__(self, config: KeyboardEndEffectorTeleopConfig):
         super().__init__(config)
         self.config = config
-        self.misc_keys_queue = Queue()
+        self.misc_keys_queue: Queue = Queue()
 
     @property
     def action_features(self) -> dict:
@@ -219,7 +224,7 @@ class KeyboardEndEffectorTeleop(KeyboardTeleop):
 
         return action_dict
 
-    def get_teleop_events(self) -> dict[str, Any]:
+    def get_teleop_events(self) -> dict[TeleopEvents, Any]:
         """
         Get extra control events from the keyboard such as intervention status,
         episode termination, success indicators, etc.

--- a/src/lerobot/teleoperators/koch_leader/koch_leader.py
+++ b/src/lerobot/teleoperators/koch_leader/koch_leader.py
@@ -122,9 +122,9 @@ class KochLeader(Teleoperator):
             self.calibration[motor] = MotorCalibration(
                 id=m.id,
                 drive_mode=drive_modes[motor],
-                homing_offset=homing_offsets[motor],
-                range_min=range_mins[motor],
-                range_max=range_maxes[motor],
+                homing_offset=int(homing_offsets[motor]),
+                range_min=int(range_mins[motor]),
+                range_max=int(range_maxes[motor]),
             )
 
         self.bus.write_calibration(self.calibration)

--- a/src/lerobot/teleoperators/openarm_leader/openarm_leader.py
+++ b/src/lerobot/teleoperators/openarm_leader/openarm_leader.py
@@ -200,7 +200,7 @@ class OpenArmLeader(Teleoperator):
         # Use sync_read_all_states to get pos/vel/torque in one go
         states = self.bus.sync_read_all_states()
         for motor in self.bus.motors:
-            state = states.get(motor, {})
+            state: Any = states.get(motor, {})
             action_dict[f"{motor}.pos"] = state.get("position")
             if self.config.use_velocity_and_torque:
                 action_dict[f"{motor}.vel"] = state.get("velocity")

--- a/src/lerobot/teleoperators/openarm_mini/openarm_mini.py
+++ b/src/lerobot/teleoperators/openarm_mini/openarm_mini.py
@@ -130,11 +130,11 @@ class OpenArmMini(Teleoperator):
         self.bus.disable_torque()
 
         logger.info("Setting Phase to 12 for all motors...")
-        for motor in self.bus.motors:
-            self.bus.write("Phase", motor, 12)
+        for motor_name in self.bus.motors:
+            self.bus.write("Phase", motor_name, 12)
 
-        for motor in self.bus.motors:
-            self.bus.write("Operating_Mode", motor, OperatingMode.POSITION.value)
+        for motor_name in self.bus.motors:
+            self.bus.write("Operating_Mode", motor_name, OperatingMode.POSITION.value)
 
         input(
             "\nCalibration: Zero Position\n"
@@ -191,7 +191,7 @@ class OpenArmMini(Teleoperator):
             self.calibration[motor_name] = MotorCalibration(
                 id=motor.id,
                 drive_mode=drive_mode,
-                homing_offset=homing_offsets[motor_name],
+                homing_offset=int(homing_offsets[motor_name]),
                 range_min=range_min,
                 range_max=range_max,
             )

--- a/src/lerobot/teleoperators/phone/teleop_phone.py
+++ b/src/lerobot/teleoperators/phone/teleop_phone.py
@@ -69,7 +69,7 @@ class BasePhone:
     @property
     def feedback_features(self) -> dict[str, type]:
         # No haptic or other feedback implemented yet
-        pass
+        return {}
 
     def configure(self) -> None:
         # No additional configuration required for phone teleop
@@ -88,7 +88,7 @@ class IOSPhone(BasePhone, Teleoperator):
         require_package("teleop", extra="phone")
         super().__init__(config)
         self.config = config
-        self._group = None
+        self._group: hebi.Group | None = None
 
     @property
     def is_connected(self) -> bool:
@@ -142,6 +142,7 @@ class IOSPhone(BasePhone, Teleoperator):
             if button_b is not None:
                 button_b1_pressed = bool(button_b.get_int(1))
             if button_b1_pressed:
+                assert position is not None and rotation is not None
                 return position, rotation
 
             time.sleep(0.01)
@@ -162,6 +163,7 @@ class IOSPhone(BasePhone, Teleoperator):
             - The orientation as a `Rotation` object, or None if not available.
             - The raw HEBI feedback object for accessing other data like button presses.
         """
+        assert self._group is not None
         fbk = self._group.get_next_feedback()
         pose = fbk[0]
         ar_pos = getattr(pose, "ar_position", None)
@@ -186,6 +188,8 @@ class IOSPhone(BasePhone, Teleoperator):
         has_pose, raw_position, raw_rotation, fb_pose = self._read_current_pose()
         if not has_pose or not self.is_calibrated:
             return {}
+        assert raw_position is not None and raw_rotation is not None
+        assert self._calib_pos is not None and self._calib_rot_inv is not None
 
         # Collect raw inputs (B1 / analogs on iOS, move/scale on Android)
         raw_inputs: dict[str, float | int | bool] = {}
@@ -235,10 +239,10 @@ class AndroidPhone(BasePhone, Teleoperator):
         require_package("teleop", extra="phone")
         super().__init__(config)
         self.config = config
-        self._teleop = None
-        self._teleop_thread = None
-        self._latest_pose = None
-        self._latest_message = None
+        self._teleop: Teleop | None = None
+        self._teleop_thread: threading.Thread | None = None
+        self._latest_pose: np.ndarray | None = None
+        self._latest_message: dict | None = None
         self._android_lock = threading.Lock()
 
     @property
@@ -283,11 +287,12 @@ class AndroidPhone(BasePhone, Teleoperator):
         """
         while True:
             with self._android_lock:
-                msg = self._latest_message or {}
+                msg: dict = self._latest_message or {}
 
             if bool(msg.get("move", False)):
                 ok, pos, rot, _pose = self._read_current_pose()
                 if ok:
+                    assert pos is not None and rot is not None
                     return pos, rot
 
             time.sleep(0.01)
@@ -339,10 +344,12 @@ class AndroidPhone(BasePhone, Teleoperator):
         ok, raw_pos, raw_rot, pose = self._read_current_pose()
         if not ok or not self.is_calibrated:
             return {}
+        assert raw_pos is not None and raw_rot is not None
+        assert self._calib_pos is not None and self._calib_rot_inv is not None
 
         # Collect raw inputs (B1 / analogs on iOS, move/scale on Android)
         raw_inputs: dict[str, float | int | bool] = {}
-        msg = self._latest_message or {}
+        msg: dict = self._latest_message or {}
         raw_inputs["move"] = bool(msg.get("move", False))
         raw_inputs["scale"] = float(msg.get("scale", 1.0))
         raw_inputs["reservedButtonA"] = bool(msg.get("reservedButtonA", False))
@@ -405,7 +412,7 @@ class Phone(Teleoperator):
     def is_connected(self) -> bool:
         return self._phone_impl.is_connected
 
-    def connect(self) -> None:
+    def connect(self, calibrate: bool = True) -> None:
         return self._phone_impl.connect()
 
     def calibrate(self) -> None:

--- a/src/lerobot/teleoperators/reachy2_teleoperator/reachy2_teleoperator.py
+++ b/src/lerobot/teleoperators/reachy2_teleoperator/reachy2_teleoperator.py
@@ -148,6 +148,7 @@ class Reachy2Teleoperator(Teleoperator):
 
     @check_if_not_connected
     def get_action(self) -> dict[str, float]:
+        assert self.reachy is not None
         start = time.perf_counter()
 
         joint_action: dict[str, float] = {}
@@ -174,4 +175,5 @@ class Reachy2Teleoperator(Teleoperator):
 
     def disconnect(self) -> None:
         if self.is_connected:
+            assert self.reachy is not None
             self.reachy.disconnect()

--- a/src/lerobot/teleoperators/rebot_102_leader/rebot_102_leader.py
+++ b/src/lerobot/teleoperators/rebot_102_leader/rebot_102_leader.py
@@ -114,6 +114,7 @@ class RebotArm102Leader(Teleoperator):
             "Press ENTER when ready..."
         )
 
+        assert self.bus is not None
         self.calibration = {}
         for motor_name, motor_id in self.config.joint_ids.items():
             self.bus.unlock(motor_id)
@@ -132,6 +133,7 @@ class RebotArm102Leader(Teleoperator):
         logger.info(f"Calibration saved to {self.calibration_fpath}")
 
     def configure(self) -> None:
+        assert self.bus is not None
         for motor_id in self.config.joint_ids.values():
             self.bus.unlock(motor_id)
             time.sleep(_SETTLE_SEC)
@@ -140,6 +142,7 @@ class RebotArm102Leader(Teleoperator):
             self.bus.reset_multi_turn(motor_id)
 
     def _read_raw_positions(self) -> dict[str, float]:
+        assert self.bus is not None
         result: dict[int, ServoMonitor | None] = self.bus.sync_monitor(list(self.config.joint_ids.values()))
         id_to_name = {v: k for k, v in self.config.joint_ids.items()}
         raw_positions: dict[str, float] = {}
@@ -202,6 +205,7 @@ class RebotArm102Leader(Teleoperator):
 
     @check_if_not_connected
     def disconnect(self) -> None:
+        assert self.bus is not None
         self.bus.close()
         self.bus = None
         logger.info(f"{self} disconnected.")

--- a/src/lerobot/teleoperators/so_leader/so_leader.py
+++ b/src/lerobot/teleoperators/so_leader/so_leader.py
@@ -115,9 +115,9 @@ class SOLeader(Teleoperator):
             self.calibration[motor] = MotorCalibration(
                 id=m.id,
                 drive_mode=0,
-                homing_offset=homing_offsets[motor],
-                range_min=range_mins[motor],
-                range_max=range_maxes[motor],
+                homing_offset=int(homing_offsets[motor]),
+                range_min=int(range_mins[motor]),
+                range_max=int(range_maxes[motor]),
             )
 
         self.bus.write_calibration(self.calibration)

--- a/src/lerobot/teleoperators/unitree_g1/exo_calib.py
+++ b/src/lerobot/teleoperators/unitree_g1/exo_calib.py
@@ -256,7 +256,7 @@ def run_exo_calibration(
     joint_idx = 0
     phase = "ellipse"
     advance_requested = False
-    zero_samples = []
+    zero_samples: list[float] = []
 
     def on_key(event):
         nonlocal advance_requested
@@ -452,5 +452,6 @@ def run_exo_calibration(
 
             plt.pause(0.001)
 
+        raise RuntimeError(f"Calibration window closed before all {len(joint_list)} joints were calibrated.")
     finally:
         plt.close(fig)

--- a/src/lerobot/teleoperators/unitree_g1/exo_ik.py
+++ b/src/lerobot/teleoperators/unitree_g1/exo_ik.py
@@ -22,6 +22,7 @@ visualizing the result in meshcat after calibration.
 import logging
 import os
 from dataclasses import dataclass
+from typing import Any
 
 import numpy as np
 
@@ -136,10 +137,10 @@ class ExoskeletonIKHelper:
             ),
         ]
 
-        self.exo = {}  # side -> pin.RobotWrapper
-        self.q_exo = {}  # side -> q
-        self.ee_id_exo = {}  # side -> frame id
-        self.qmap = {}  # side -> {joint_name: q_idx}
+        self.exo: dict[str, Any] = {}  # side -> pin.RobotWrapper
+        self.q_exo: dict[str, Any] = {}  # side -> q
+        self.ee_id_exo: dict[str, int] = {}  # side -> frame id
+        self.qmap: dict[str, dict[str, int]] = {}  # side -> {joint_name: q_idx}
         self.ee_id_g1 = {}  # side -> frame id
 
         self._load_exo_models(assets_dir)
@@ -149,7 +150,7 @@ class ExoskeletonIKHelper:
         self.viewer = None
         self.markers: Markers | None = None
         self.viz_g1 = None
-        self.viz_exo = {}  # side -> viz
+        self.viz_exo: dict[str, Any] = {}  # side -> viz
 
     def _frozen_joint_indices(self) -> dict[str, int]:
         out = {}

--- a/src/lerobot/teleoperators/unitree_g1/unitree_g1.py
+++ b/src/lerobot/teleoperators/unitree_g1/unitree_g1.py
@@ -208,7 +208,7 @@ class UnitreeG1Teleoperator(Teleoperator):
 
     @cached_property
     def action_features(self) -> dict[str, type]:
-        remote_features = dict.fromkeys(self.remote_controller.remote_action, float)
+        remote_features: dict[str, type] = dict.fromkeys(self.remote_controller.remote_action, float)
         if not self._arm_control_enabled:
             return remote_features
         joint_features = {f"{name}.q": float for name in self._g1_arm_joint_names}
@@ -269,7 +269,7 @@ class UnitreeG1Teleoperator(Teleoperator):
         pass
 
     def get_action(self) -> dict[str, float]:
-        joint_action = {}
+        joint_action: dict[str, float] = {}
         left_raw = None
         right_raw = None
         if self._arm_control_enabled:
@@ -278,6 +278,7 @@ class UnitreeG1Teleoperator(Teleoperator):
 
             left_angles = self.left_arm.get_angles()
             right_angles = self.right_arm.get_angles()
+            assert self.ik_helper is not None
             joint_action = self.ik_helper.compute_g1_joints_from_exo(left_angles, right_angles)
 
         # Wireless remote has priority when non-zero; otherwise, use exo joystick.


### PR DESCRIPTION
## Summary

Closes #1726. Part of the broader mypy-compliance effort tracked in #1719 (most sibling modules — policies, robots, datasets, motors, cameras, processing, environments, optim, config, transport, model — are already merged).

- Enables the `lerobot.teleoperators.*` mypy override (`ignore_errors = false`) in `pyproject.toml`.
- Fixes all resulting mypy errors across the module: missing/incorrect variable and attribute type annotations, `assert self.x is not None` narrowing for hardware handles that are `None` until `connect()` assigns them (matching the existing style used in the already-merged sibling modules), and a few real small bugs mypy surfaced along the way:
  - `unitree_g1/exo_calib.py`: `run_exo_calibration` had a code path (closing the calibration window before finishing all joints) that fell off the end of the function returning `None` instead of its declared `ExoskeletonCalibration` — now raises a `RuntimeError` explaining what happened.
  - `gamepad/teleop_gamepad.py`: `is_calibrated` was missing its `@property` decorator (so `teleop.is_calibrated` returned a bound method instead of a bool wherever it might be used polymorphically), and `connect()`'s signature didn't accept the base `Teleoperator.connect(self, calibrate: bool = True)` interface's `calibrate` argument.
  - `openarm_mini.py`: a loop-variable name collision — `motor` was used both as a motor-name string (`for motor in self.bus.motors`) and, in a later loop within the same method, as a `Motor` object (`for motor_name, motor in self.bus.motors.items()`), which mypy correctly flagged as two incompatible types for the same name.

No behavior changes beyond the two fixes called out above; everything else is annotations/narrowing only.

## Test plan
- [x] `pre-commit run mypy --all-files` passes (the exact check CI's `quality.yml` runs)
- [x] `pre-commit run ruff --all-files` / `ruff-format` pass
- [x] `pytest tests/teleoperators` — 5 passed, 2 skipped (hardware-dependent)
- [x] All touched modules import cleanly (`python -c "import ..."` smoke test)