### PR TITLE
docs(async_inference): write the API reference docstrings

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -215,4 +215,6 @@
     title: Environments
   - local: api/configs
     title: Configuration
+  - local: api/async_inference
+    title: Async Inference
   title: "API Reference"

--- a/docs/source/api/async_inference.mdx
+++ b/docs/source/api/async_inference.mdx
@@ -1,0 +1,28 @@
+# Async Inference
+
+`src/lerobot/async_inference/` runs policy inference on a remote `PolicyServer` over gRPC, so a
+robot's control loop doesn't block on (slow) policy calls: a `RobotClient` streams observations to
+the server and receives predicted action chunks back, queuing them locally for the control loop to
+consume.
+
+## RobotClient
+
+[[autodoc]] lerobot.async_inference.robot_client.RobotClient
+    - all
+
+[[autodoc]] lerobot.async_inference.configs.RobotClientConfig
+
+## PolicyServer
+
+[[autodoc]] lerobot.async_inference.policy_server.PolicyServer
+    - all
+
+[[autodoc]] lerobot.async_inference.configs.PolicyServerConfig
+
+## Shared types
+
+[[autodoc]] lerobot.async_inference.helpers.TimedAction
+
+[[autodoc]] lerobot.async_inference.helpers.TimedObservation
+
+[[autodoc]] lerobot.async_inference.helpers.RemotePolicyConfig

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -441,7 +441,6 @@ ignore = [
 "src/lerobot/policies/molmoact2/molmoact2_hf_model/**" = ["D"]
 # Awaiting conversion, one PR per module.
 "src/lerobot/annotations/**" = ["D"]
-"src/lerobot/async_inference/**" = ["D"]
 "src/lerobot/cameras/**" = ["D"]
 "src/lerobot/common/**" = ["D"]
 "src/lerobot/configs/**" = ["D"]
@@ -520,7 +519,7 @@ ignore-private = false
 ignore-property-decorators = false
 ignore-module = false
 ignore-setters = false
-fail-under = 55
+fail-under = 55.5
 output-format = "term-missing"
 color = true
 paths = ["src/lerobot"]

--- a/src/lerobot/async_inference/__init__.py
+++ b/src/lerobot/async_inference/__init__.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Async inference server/client.
+"""Async inference server/client.
 
 Requires: ``pip install 'lerobot[async]'``
 

--- a/src/lerobot/async_inference/configs.py
+++ b/src/lerobot/async_inference/configs.py
@@ -85,7 +85,7 @@ class PolicyServerConfig:
 
     @property
     def environment_dt(self) -> float:
-        """Environment time step, in seconds"""
+        """Environment time step, in seconds."""
         return 1 / self.fps
 
     def to_dict(self) -> dict:
@@ -150,7 +150,7 @@ class RobotClientConfig:
 
     @property
     def environment_dt(self) -> float:
-        """Environment time step, in seconds"""
+        """Environment time step, in seconds."""
         return 1 / self.fps
 
     def __post_init__(self):

--- a/src/lerobot/async_inference/constants.py
+++ b/src/lerobot/async_inference/constants.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Client side: The environment evolves with a time resolution equal to 1/fps"""
+"""Client side: The environment evolves with a time resolution equal to 1/fps."""
 
 DEFAULT_FPS = 30
 

--- a/src/lerobot/async_inference/helpers.py
+++ b/src/lerobot/async_inference/helpers.py
@@ -51,6 +51,11 @@ Observation = dict[str, torch.Tensor]
 
 
 def visualize_action_queue_size(action_queue_size: list[int]) -> None:
+    """Plot the client's action queue size over environment steps.
+
+    Args:
+        action_queue_size (`list[int]`): Queue size recorded at each environment step.
+    """
     import matplotlib.pyplot as plt
 
     _, ax = plt.subplots()
@@ -64,14 +69,32 @@ def visualize_action_queue_size(action_queue_size: list[int]) -> None:
 
 
 def map_robot_keys_to_lerobot_features(robot: Robot) -> dict[str, dict]:
+    """Convert `robot`'s observation feature schema to LeRobot dataset feature keys/dtypes.
+
+    Args:
+        robot (`Robot`): Robot whose observation features to map.
+
+    Returns:
+        `dict[str, dict]`: Feature schema keyed by LeRobot observation feature name.
+    """
     return hw_to_dataset_features(robot.observation_features, OBS_STR, use_video=False)
 
 
 def is_image_key(k: str) -> bool:
+    """Whether `k` is a LeRobot observation-image feature key."""
     return k.startswith(OBS_IMAGES)
 
 
 def resize_robot_observation_image(image: torch.tensor, resize_dims: tuple[int, int, int]) -> torch.tensor:
+    """Resize a channel-last robot observation image to the policy's expected channel-first size.
+
+    Args:
+        image (`torch.Tensor`): Image tensor of shape `(H, W, C)`.
+        resize_dims (`tuple[int, int, int]`): Target `(C, H, W)` shape; only `H`/`W` are used.
+
+    Returns:
+        `torch.Tensor`: Resized image, shape `(C, H, W)`.
+    """
     assert image.ndim == 3, f"Image must be (C, H, W)! Received {image.shape}"
     # (H, W, C) -> (C, H, W) for resizing from robot obsevation resolution to policy image resolution
     image = image.permute(2, 0, 1)
@@ -90,6 +113,18 @@ def raw_observation_to_observation(
     lerobot_features: dict[str, dict],
     policy_image_features: dict[str, PolicyFeature],
 ) -> Observation:
+    """Convert a raw robot observation into a policy-ready observation.
+
+    Args:
+        raw_observation (`RawObservation`): Observation as received from the robot.
+        lerobot_features (`dict[str, dict]`): Feature schema mapping robot keys to LeRobot dataset
+            feature keys, as returned by `map_robot_keys_to_lerobot_features`.
+        policy_image_features (`dict[str, PolicyFeature]`): Policy's expected image feature shapes,
+            used to resize observation images.
+
+    Returns:
+        `Observation`: Observation with resized, batched image tensors, ready for policy inference.
+    """
     observation = {}
 
     observation = prepare_raw_observation(raw_observation, lerobot_features, policy_image_features)
@@ -105,7 +140,7 @@ def raw_observation_to_observation(
 
 
 def prepare_image(image: torch.Tensor) -> torch.Tensor:
-    """Minimal preprocessing to turn RGB uint8 images to float32 in [0, 1], and create a memory-contiguous tensor"""
+    """Minimal preprocessing to turn RGB uint8 images to float32 in [0, 1], and create a memory-contiguous tensor."""
     if image.dtype == torch.uint8:
         image = image.type(torch.float32) / 255
     image = image.contiguous()
@@ -146,8 +181,10 @@ def prepare_raw_observation(
     lerobot_features: dict[str, dict],
     policy_image_features: dict[str, PolicyFeature],
 ) -> Observation:
-    """Matches keys from the raw robot_obs dict to the keys expected by a given policy (passed as
-    policy_image_features)."""
+    """Match keys from the raw `robot_obs` dict to the keys expected by a given policy.
+
+    The policy's expected keys are passed via `policy_image_features`.
+    """
     # 1. {motor.pos1:value1, motor.pos2:value2, ..., laptop:np.ndarray} ->
     # -> {observation.state:[value1,value2,...], observation.images.laptop:np.ndarray}
     lerobot_obs = make_lerobot_observation(robot_obs, lerobot_features)
@@ -174,15 +211,14 @@ def prepare_raw_observation(
 
 
 def get_logger(name: str, log_to_file: bool = True) -> logging.Logger:
-    """
-    Get a logger using the standardized logging setup from utils.py.
+    """Get a logger using the standardized logging setup from utils.py.
 
     Args:
-        name: Logger name (e.g., 'policy_server', 'robot_client')
-        log_to_file: Whether to also log to a file
+        name (`str`): Logger name (e.g. `"policy_server"`, `"robot_client"`).
+        log_to_file (`bool`, *optional*, defaults to `True`): Whether to also log to a file.
 
     Returns:
-        Configured logger instance
+        `logging.Logger`: Configured logger instance.
     """
     # Create logs directory if logging to file
     if log_to_file:
@@ -203,35 +239,56 @@ class TimedData:
     """A data object with timestamp and timestep information.
 
     Args:
-        timestamp: Unix timestamp relative to data's creation.
-        data: The actual data to wrap a timestamp around.
-        timestep: The timestep of the data.
+        timestamp (`float`): Unix timestamp relative to the data's creation.
+        timestep (`int`): The timestep of the data.
     """
 
     timestamp: float
     timestep: int
 
     def get_timestamp(self):
+        """Return `self.timestamp`."""
         return self.timestamp
 
     def get_timestep(self):
+        """Return `self.timestep`."""
         return self.timestep
 
 
 @dataclass
 class TimedAction(TimedData):
+    """A predicted action, timestamped and timestepped.
+
+    Args:
+        timestamp (`float`): Unix timestamp relative to the action's creation.
+        timestep (`int`): The timestep of the action.
+        action (`Action`): The predicted action tensor.
+    """
+
     action: Action
 
     def get_action(self):
+        """Return `self.action`."""
         return self.action
 
 
 @dataclass
 class TimedObservation(TimedData):
+    """An observation, timestamped and timestepped.
+
+    Args:
+        timestamp (`float`): Unix timestamp relative to the observation's creation.
+        timestep (`int`): The timestep of the observation.
+        observation (`RawObservation`): The raw observation, as received from the robot.
+        must_go (`bool`, *optional*, defaults to `False`): Whether this observation must be processed
+            even if a newer one has since arrived (e.g. the first observation of an episode).
+    """
+
     observation: RawObservation
     must_go: bool = False
 
     def get_observation(self):
+        """Return `self.observation`."""
         return self.observation
 
 
@@ -244,7 +301,7 @@ class FPSTracker:
     total_obs_count: int = 0
 
     def calculate_fps_metrics(self, current_timestamp: float) -> dict[str, float]:
-        """Calculate average FPS vs target"""
+        """Calculate average FPS vs target."""
         self.total_obs_count += 1
 
         # Initialize first observation time
@@ -258,13 +315,24 @@ class FPSTracker:
         return {"avg_fps": avg_fps, "target_fps": self.target_fps}
 
     def reset(self):
-        """Reset the FPS tracker state"""
+        """Reset the FPS tracker state."""
         self.first_timestamp = None
         self.total_obs_count = 0
 
 
 @dataclass
 class RemotePolicyConfig:
+    """Configuration sent by the `RobotClient` to instantiate a policy on the `PolicyServer`.
+
+    Args:
+        policy_type (`str`): Registered policy type (e.g. `"act"`, `"pi0"`).
+        pretrained_name_or_path (`str`): Local path or Hub repo id of the pretrained policy.
+        lerobot_features (`dict[str, PolicyFeature]`): Feature schema the policy was trained with.
+        actions_per_chunk (`int`): Number of actions the policy predicts per inference call.
+        device (`str`, *optional*, defaults to `"cpu"`): Device to load the policy onto.
+        rename_map (`dict[str, str]`, *optional*): Feature-key rename map applied before inference.
+    """
+
     policy_type: str
     pretrained_name_or_path: str
     lerobot_features: dict[str, PolicyFeature]
@@ -274,15 +342,17 @@ class RemotePolicyConfig:
 
 
 def _compare_observation_states(obs1_state: torch.Tensor, obs2_state: torch.Tensor, atol: float) -> bool:
-    """Check if two observation states are similar, under a tolerance threshold"""
+    """Check if two observation states are similar, under a tolerance threshold."""
     return bool(torch.linalg.norm(obs1_state - obs2_state) < atol)
 
 
 def observations_similar(
     obs1: TimedObservation, obs2: TimedObservation, lerobot_features: dict[str, dict], atol: float = 1
 ) -> bool:
-    """Check if two observations are similar, under a tolerance threshold. Measures distance between
-    observations as the difference in joint-space between the two observations.
+    """Check if two observations are similar, under a tolerance threshold.
+
+    Measures distance between observations as the difference in joint-space between the two
+    observations.
 
     NOTE(fracapuano): This is a very simple check, and it is enough for the current use case.
     An immediate next step is to use (fast) perceptual difference metrics comparing some camera views,

--- a/src/lerobot/async_inference/policy_server.py
+++ b/src/lerobot/async_inference/policy_server.py
@@ -66,17 +66,17 @@ class PolicyServer(services_pb2_grpc.AsyncInferenceServicer):
     """gRPC servicer that runs policy inference on behalf of a remote `RobotClient`.
 
     Receives observations, runs the configured policy, and streams back predicted action chunks.
+    Initializing an instance starts the server with no policy loaded; a client selects one via
+    `SendPolicyInstructions`.
+
+    Args:
+        config (`PolicyServerConfig`): Server configuration (host, port, fps, timeouts).
     """
 
     prefix = "policy_server"
     logger = get_logger(prefix)
 
     def __init__(self, config: PolicyServerConfig):
-        """Initialize the server with no policy loaded; a client selects one via `SendPolicyInstructions`.
-
-        Args:
-            config (`PolicyServerConfig`): Server configuration (host, port, fps, timeouts).
-        """
         self.config = config
         self.shutdown_event = threading.Event()
 

--- a/src/lerobot/async_inference/policy_server.py
+++ b/src/lerobot/async_inference/policy_server.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
+r"""Run the async-inference policy server.
+
 Example:
 ```shell
 python -m lerobot.async_inference.policy_server \
@@ -62,10 +63,20 @@ from .helpers import (
 
 
 class PolicyServer(services_pb2_grpc.AsyncInferenceServicer):
+    """gRPC servicer that runs policy inference on behalf of a remote `RobotClient`.
+
+    Receives observations, runs the configured policy, and streams back predicted action chunks.
+    """
+
     prefix = "policy_server"
     logger = get_logger(prefix)
 
     def __init__(self, config: PolicyServerConfig):
+        """Initialize the server with no policy loaded; a client selects one via `SendPolicyInstructions`.
+
+        Args:
+            config (`PolicyServerConfig`): Server configuration (host, port, fps, timeouts).
+        """
         self.config = config
         self.shutdown_event = threading.Event()
 
@@ -90,10 +101,12 @@ class PolicyServer(services_pb2_grpc.AsyncInferenceServicer):
 
     @property
     def running(self):
+        """Whether the server is currently accepting/processing observations."""
         return not self.shutdown_event.is_set()
 
     @property
     def policy_image_features(self):
+        """The loaded policy's expected image feature shapes."""
         return self.policy.config.image_features
 
     def _reset_server(self) -> None:
@@ -106,6 +119,15 @@ class PolicyServer(services_pb2_grpc.AsyncInferenceServicer):
             self._predicted_timesteps = set()
 
     def Ready(self, request, context):  # noqa: N802
+        """Handle a client's readiness handshake: reset server state and clear the shutdown flag.
+
+        Args:
+            request (`services_pb2.Empty`): Unused.
+            context (`grpc.ServicerContext`): gRPC call context, used to identify the client.
+
+        Returns:
+            `services_pb2.Empty`: Empty acknowledgement.
+        """
         client_id = context.peer()
         self.logger.info(f"Client {client_id} connected and ready")
         self._reset_server()
@@ -114,8 +136,7 @@ class PolicyServer(services_pb2_grpc.AsyncInferenceServicer):
         return services_pb2.Empty()
 
     def SendPolicyInstructions(self, request, context):  # noqa: N802
-        """Receive policy instructions from the robot client"""
-
+        """Receive policy instructions from the robot client."""
         if not self.running:
             self.logger.warning("Server is not running. Ignoring policy instructions.")
             return services_pb2.Empty()
@@ -171,7 +192,7 @@ class PolicyServer(services_pb2_grpc.AsyncInferenceServicer):
         return services_pb2.Empty()
 
     def SendObservations(self, request_iterator, context):  # noqa: N802
-        """Receive observations from the robot client"""
+        """Receive observations from the robot client."""
         client_id = context.peer()
         self.logger.debug(f"Receiving observations from {client_id}")
 
@@ -212,8 +233,10 @@ class PolicyServer(services_pb2_grpc.AsyncInferenceServicer):
         return services_pb2.Empty()
 
     def GetActions(self, request, context):  # noqa: N802
-        """Returns actions to the robot client. Actions are sent as a single
-        chunk, containing multiple actions."""
+        """Return actions to the robot client.
+
+        Actions are sent as a single chunk, containing multiple actions.
+        """
         client_id = context.peer()
         self.logger.debug(f"Client {client_id} connected for action streaming")
 
@@ -266,7 +289,7 @@ class PolicyServer(services_pb2_grpc.AsyncInferenceServicer):
             return services_pb2.Empty()
 
     def _obs_sanity_checks(self, obs: TimedObservation, previous_obs: TimedObservation) -> bool:
-        """Check if the observation is valid to be processed by the policy"""
+        """Check if the observation is valid to be processed by the policy."""
         with self._predicted_timesteps_lock:
             predicted_timesteps = self._predicted_timesteps
 
@@ -285,8 +308,9 @@ class PolicyServer(services_pb2_grpc.AsyncInferenceServicer):
 
     def _enqueue_observation(self, obs: TimedObservation) -> bool:
         """Enqueue an observation if it must go through processing, otherwise skip it.
-        Observations not in queue are never run through the policy network"""
 
+        Observations not in queue are never run through the policy network.
+        """
         if (
             obs.must_go
             or self.last_processed_obs is None
@@ -310,9 +334,10 @@ class PolicyServer(services_pb2_grpc.AsyncInferenceServicer):
         return False
 
     def _time_action_chunk(self, t_0: float, action_chunk: list[torch.Tensor], i_0: int) -> list[TimedAction]:
-        """Turn a chunk of actions into a list of TimedAction instances,
-        with the first action corresponding to t_0 and the rest corresponding to
-        t_0 + i*environment_dt for i in range(len(action_chunk))
+        """Turn a chunk of actions into a list of `TimedAction` instances.
+
+        The first action corresponds to `t_0`, and the rest to `t_0 + i * environment_dt` for
+        `i in range(len(action_chunk))`.
         """
         return [
             TimedAction(timestamp=t_0 + i * self.config.environment_dt, timestep=i_0 + i, action=action)
@@ -320,7 +345,14 @@ class PolicyServer(services_pb2_grpc.AsyncInferenceServicer):
         ]
 
     def _get_action_chunk(self, observation: dict[str, torch.Tensor]) -> torch.Tensor:
-        """Get an action chunk from the policy. The chunk contains only"""
+        """Get an action chunk from the policy, truncated to `self.actions_per_chunk` actions.
+
+        Args:
+            observation (`dict[str, torch.Tensor]`): Preprocessed observation to predict from.
+
+        Returns:
+            `torch.Tensor`: Predicted actions, shape `(B, actions_per_chunk, action_dim)`.
+        """
         chunk = self.policy.predict_action_chunk(observation)
         if chunk.ndim != 3:
             chunk = chunk.unsqueeze(0)  # adding batch dimension, now shape is (B, chunk_size, action_dim)
@@ -405,7 +437,7 @@ class PolicyServer(services_pb2_grpc.AsyncInferenceServicer):
         return action_chunk
 
     def stop(self):
-        """Stop the server"""
+        """Stop the server."""
         self._reset_server()
         self.logger.info("Server stopping...")
 
@@ -415,7 +447,7 @@ def serve(cfg: PolicyServerConfig):
     """Start the PolicyServer with the given configuration.
 
     Args:
-        config: PolicyServerConfig instance. If None, uses default configuration.
+        cfg (`PolicyServerConfig`): Server configuration.
     """
     logging.info(pformat(asdict(cfg)))
 

--- a/src/lerobot/async_inference/robot_client.py
+++ b/src/lerobot/async_inference/robot_client.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
+r"""Run the async-inference robot client.
+
 Example command:
 ```shell
 python src/lerobot/async_inference/robot_client.py \
@@ -81,14 +82,20 @@ from .helpers import (
 
 
 class RobotClient:
+    """Connects a robot to a remote `PolicyServer`: streams observations, receives action chunks.
+
+    Runs two threads: one that sends observations and receives predicted action chunks, and one
+    that runs the robot control loop, consuming actions from the local queue.
+    """
+
     prefix = "robot_client"
     logger = get_logger(prefix)
 
     def __init__(self, config: RobotClientConfig):
-        """Initialize RobotClient with unified configuration.
+        """Initialize the client and connect to `config.robot`.
 
         Args:
-            config: RobotClientConfig containing all configuration parameters
+            config (`RobotClientConfig`): Client configuration (robot, policy, server address, fps).
         """
         # Store configuration
         self.config = config
@@ -138,10 +145,11 @@ class RobotClient:
 
     @property
     def running(self):
+        """Whether the client is currently connected and processing observations/actions."""
         return not self.shutdown_event.is_set()
 
     def start(self):
-        """Start the robot client and connect to the policy server"""
+        """Start the robot client and connect to the policy server."""
         try:
             # client-server handshake
             start_time = time.perf_counter()
@@ -171,7 +179,7 @@ class RobotClient:
             return False
 
     def stop(self):
-        """Stop the robot client"""
+        """Stop the robot client."""
         self.shutdown_event.set()
 
         self.robot.disconnect()
@@ -184,8 +192,18 @@ class RobotClient:
         self,
         obs: TimedObservation,
     ) -> bool:
-        """Send observation to the policy server.
-        Returns True if the observation was sent successfully, False otherwise."""
+        """Send an observation to the policy server.
+
+        Args:
+            obs (`TimedObservation`): Observation to send.
+
+        Returns:
+            `bool`: Whether the observation was sent successfully.
+
+        Raises:
+            RuntimeError: If the client isn't running (call `start()` first).
+            ValueError: If `obs` isn't a `TimedObservation`.
+        """
         if not self.running:
             raise RuntimeError("Client not running. Run RobotClient.start() before sending observations.")
 
@@ -215,6 +233,11 @@ class RobotClient:
             return False
 
     def _inspect_action_queue(self):
+        """Return the local action queue's current size and sorted timesteps, for logging.
+
+        Returns:
+            `tuple[int, list[int]]`: Queue size and the sorted timesteps of its contents.
+        """
         with self.action_queue_lock:
             queue_size = self.action_queue.qsize()
             timestamps = sorted([action.get_timestep() for action in self.action_queue.queue])
@@ -226,7 +249,7 @@ class RobotClient:
         incoming_actions: list[TimedAction],
         aggregate_fn: Callable[[torch.Tensor, torch.Tensor], torch.Tensor] | None = None,
     ):
-        """Finds the same timestep actions in the queue and aggregates them using the aggregate_fn"""
+        """Finds the same timestep actions in the queue and aggregates them using the aggregate_fn."""
         if aggregate_fn is None:
             # default aggregate function: take the latest action
             def aggregate_fn(x1, x2):
@@ -267,7 +290,7 @@ class RobotClient:
             self.action_queue = future_action_queue
 
     def receive_actions(self, verbose: bool = False):
-        """Receive actions from the policy server"""
+        """Receive actions from the policy server."""
         # Wait at barrier for synchronized start
         self.start_barrier.wait()
         self.logger.info("Action receiving thread starting")
@@ -359,17 +382,24 @@ class RobotClient:
                 self.logger.error(f"Error receiving actions: {e}")
 
     def actions_available(self):
-        """Check if there are actions available in the queue"""
+        """Check if there are actions available in the queue."""
         with self.action_queue_lock:
             return not self.action_queue.empty()
 
     def _action_tensor_to_action_dict(self, action_tensor: torch.Tensor) -> dict[str, float]:
+        """Convert a flat predicted action tensor into `self.robot`'s action feature dict.
+
+        Args:
+            action_tensor (`torch.Tensor`): Predicted action, ordered like `self.robot.action_features`.
+
+        Returns:
+            `dict[str, float]`: Action keyed by `self.robot`'s action feature names.
+        """
         action = {key: action_tensor[i].item() for i, key in enumerate(self.robot.action_features)}
         return action
 
     def control_loop_action(self, verbose: bool = False) -> dict[str, Any]:
-        """Reading and performing actions in local queue"""
-
+        """Reading and performing actions in local queue."""
         # Lock only for queue operations
         get_start = time.perf_counter()
         with self.action_queue_lock:
@@ -401,11 +431,20 @@ class RobotClient:
         return _performed_action
 
     def _ready_to_send_observation(self):
-        """Flags when the client is ready to send an observation"""
+        """Flags when the client is ready to send an observation."""
         with self.action_queue_lock:
             return self.action_queue.qsize() / self.action_chunk_size <= self._chunk_size_threshold
 
     def control_loop_observation(self, task: str, verbose: bool = False) -> RawObservation:
+        """Capture a robot observation, timestamp it, and send it to the policy server.
+
+        Args:
+            task (`str`): Task description attached to the observation.
+            verbose (`bool`, *optional*, defaults to `False`): Whether to log detailed timing info.
+
+        Returns:
+            `RawObservation`: The raw observation captured from the robot.
+        """
         try:
             # Get serialized observation bytes from the function
             start_time = time.perf_counter()
@@ -456,7 +495,7 @@ class RobotClient:
             self.logger.error(f"Error in observation sender: {e}")
 
     def control_loop(self, task: str, verbose: bool = False) -> tuple[Observation, Action]:
-        """Combined function for executing actions and streaming observations"""
+        """Combined function for executing actions and streaming observations."""
         # Wait at barrier for synchronized start
         self.start_barrier.wait()
         self.logger.info("Control loop thread starting")
@@ -483,6 +522,11 @@ class RobotClient:
 
 @draccus.wrap()
 def async_client(cfg: RobotClientConfig):
+    """CLI entry point: connect `cfg.robot` to a `PolicyServer` and run the async control loop.
+
+    Args:
+        cfg (`RobotClientConfig`): Parsed from the CLI.
+    """
     logging.info(pformat(asdict(cfg)))
 
     # TODO: Assert if checking robot support is still needed with the plugin system

--- a/src/lerobot/async_inference/robot_client.py
+++ b/src/lerobot/async_inference/robot_client.py
@@ -85,18 +85,17 @@ class RobotClient:
     """Connects a robot to a remote `PolicyServer`: streams observations, receives action chunks.
 
     Runs two threads: one that sends observations and receives predicted action chunks, and one
-    that runs the robot control loop, consuming actions from the local queue.
+    that runs the robot control loop, consuming actions from the local queue. Initializing an
+    instance connects to `config.robot`.
+
+    Args:
+        config (`RobotClientConfig`): Client configuration (robot, policy, server address, fps).
     """
 
     prefix = "robot_client"
     logger = get_logger(prefix)
 
     def __init__(self, config: RobotClientConfig):
-        """Initialize the client and connect to `config.robot`.
-
-        Args:
-            config (`RobotClientConfig`): Client configuration (robot, policy, server address, fps).
-        """
         # Store configuration
         self.config = config
         self.robot = make_robot_from_config(config.robot)

--- a/utils/check_docstrings.py
+++ b/utils/check_docstrings.py
@@ -60,6 +60,7 @@ PATH_TO_LEROBOT = PATH_TO_REPO / "src" / "lerobot"
 # Modules whose public objects are checked. Add a module here once its docstrings follow the standard.
 MODULES_TO_CHECK = [
     "lerobot.robots",
+    "lerobot.async_inference",
 ]
 
 # Objects that do not yet follow the standard, so the check can be green from day one. Removing an entry


### PR DESCRIPTION
## Summary
- Brings `src/lerobot/async_inference/` to 100% public docstring coverage per `docs/source/writing_docstrings.mdx`: Google-style sections + HF-style type formatting for `RobotClient`, `PolicyServer`, and the shared `TimedAction`/`TimedObservation`/`RemotePolicyConfig`/`TimedData` types in `helpers.py`.
- Fixes a pre-existing truncated docstring on `PolicyServer._get_action_chunk` (`"...The chunk contains only"`) found while converting the file.
- Adds `docs/source/api/async_inference.mdx`, documenting `RobotClient`, `PolicyServer`, their configs, and the shared timed-data types.
- Removes `"src/lerobot/async_inference/**" = ["D"]` from `pyproject.toml`'s ruff per-file-ignores; adds `"lerobot.async_inference"` to `check_docstrings.py`'s `MODULES_TO_CHECK` ratchet; raises `interrogate`'s `fail-under` from 55 to 55.5 (actual: 55.7%).
- Docstrings-only — zero behavioral change.

## Test plan
- [x] `ruff check src/lerobot/async_inference/` — clean.
- [x] `python utils/check_docstrings.py` — clean.
- [x] `interrogate --config=pyproject.toml` — PASSED (55.5% min, 55.7% actual).
- [x] `python utils/check_doctest_list.py` — clean.
- [x] `doc-builder build lerobot docs/source/` — renders cleanly, no dead cross-refs or `<fill_docstring>` placeholders.
- [x] `pre-commit run --all-files` — green (reverted the unrelated `tests/policies/vla_jepa/test_*.py` ruff import-order churn).