### PR TITLE
docs(annotations): write the API reference docstrings

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -215,4 +215,6 @@
     title: Environments
   - local: api/configs
     title: Configuration
+  - local: api/annotations
+    title: Annotations
   title: "API Reference"

--- a/docs/source/api/annotations.mdx
+++ b/docs/source/api/annotations.mdx
@@ -1,0 +1,93 @@
+# Annotations
+
+`src/lerobot/annotations/` implements the steerable annotation pipeline invoked by `lerobot-annotate`:
+a local or remote VLM watches each episode's video and writes `language_persistent` (subtasks, plan,
+memory, task augmentation) and `language_events` (interjections, speech, VQA) columns onto the
+dataset's parquet shards.
+
+The pipeline runs three independent modules (`plan`, `interjections`, `vqa`) over per-episode staged
+JSONL, then validates and rewrites the parquet shards.
+
+## Configuration
+
+[[autodoc]] lerobot.annotations.steerable_pipeline.config.AnnotationPipelineConfig
+
+[[autodoc]] lerobot.annotations.steerable_pipeline.config.PlanConfig
+
+[[autodoc]] lerobot.annotations.steerable_pipeline.config.TaskAugAxesConfig
+
+[[autodoc]] lerobot.annotations.steerable_pipeline.config.InterjectionsConfig
+
+[[autodoc]] lerobot.annotations.steerable_pipeline.config.VqaConfig
+
+[[autodoc]] lerobot.annotations.steerable_pipeline.config.VlmConfig
+
+[[autodoc]] lerobot.annotations.steerable_pipeline.config.ExecutorConfig
+
+[[autodoc]] lerobot.annotations.steerable_pipeline.config.AnnotationJobConfig
+
+## Executor
+
+Runs the six annotation phases (plan → interjections → plan-update → vqa → validate → write)
+in-process, with episode-level concurrency.
+
+[[autodoc]] lerobot.annotations.steerable_pipeline.executor.Executor
+    - all
+
+[[autodoc]] lerobot.annotations.steerable_pipeline.executor.PhaseResult
+
+[[autodoc]] lerobot.annotations.steerable_pipeline.executor.PipelineRunSummary
+
+## Modules
+
+Each module reads/writes per-episode staged JSONL via `EpisodeStaging` and implements the same
+`enabled` / `run_episode` contract.
+
+[[autodoc]] lerobot.annotations.steerable_pipeline.modules.plan_subtasks_memory.PlanSubtasksMemoryModule
+    - all
+
+[[autodoc]] lerobot.annotations.steerable_pipeline.modules.interjections_and_speech.InterjectionsAndSpeechModule
+    - all
+
+[[autodoc]] lerobot.annotations.steerable_pipeline.modules.general_vqa.GeneralVqaModule
+    - all
+
+## Frame providers
+
+Decode keyframes from a dataset's `observation.images.*` streams, shared across modules within one
+episode.
+
+[[autodoc]] lerobot.annotations.steerable_pipeline.frames.FrameProvider
+
+[[autodoc]] lerobot.annotations.steerable_pipeline.frames.VideoFrameProvider
+    - all
+
+[[autodoc]] lerobot.annotations.steerable_pipeline.frames.make_frame_provider
+
+## VLM client
+
+[[autodoc]] lerobot.annotations.steerable_pipeline.vlm_client.VlmClient
+
+[[autodoc]] lerobot.annotations.steerable_pipeline.vlm_client.StubVlmClient
+
+[[autodoc]] lerobot.annotations.steerable_pipeline.vlm_client.make_vlm_client
+
+## Staging, validation, and writing
+
+[[autodoc]] lerobot.annotations.steerable_pipeline.staging.EpisodeStaging
+    - all
+
+[[autodoc]] lerobot.annotations.steerable_pipeline.validator.StagingValidator
+    - all
+
+[[autodoc]] lerobot.annotations.steerable_pipeline.validator.ValidationReport
+    - all
+
+[[autodoc]] lerobot.annotations.steerable_pipeline.writer.LanguageColumnsWriter
+    - all
+
+## Reader
+
+[[autodoc]] lerobot.annotations.steerable_pipeline.reader.EpisodeRecord
+
+[[autodoc]] lerobot.annotations.steerable_pipeline.reader.iter_episodes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -440,7 +440,6 @@ ignore = [
 # Vendored from transformers; keeps its upstream docstring style so syncs stay clean.
 "src/lerobot/policies/molmoact2/molmoact2_hf_model/**" = ["D"]
 # Awaiting conversion, one PR per module.
-"src/lerobot/annotations/**" = ["D"]
 "src/lerobot/async_inference/**" = ["D"]
 "src/lerobot/cameras/**" = ["D"]
 "src/lerobot/common/**" = ["D"]
@@ -520,7 +519,7 @@ ignore-private = false
 ignore-property-decorators = false
 ignore-module = false
 ignore-setters = false
-fail-under = 55
+fail-under = 56.2
 output-format = "term-missing"
 color = true
 paths = ["src/lerobot"]

--- a/src/lerobot/annotations/steerable_pipeline/__init__.py
+++ b/src/lerobot/annotations/steerable_pipeline/__init__.py
@@ -13,8 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Steerable annotation pipeline producing ``language_persistent`` and
-``language_events`` columns for LeRobot datasets.
+"""Steerable annotation pipeline producing ``language_persistent`` and ``language_events`` columns.
 
 The pipeline is decomposed into three independently runnable modules whose
 outputs are staged per-episode before a final parquet rewrite:

--- a/src/lerobot/annotations/steerable_pipeline/config.py
+++ b/src/lerobot/annotations/steerable_pipeline/config.py
@@ -111,10 +111,11 @@ class PlanConfig:
 
 @dataclass
 class TaskAugAxesConfig:
-    """5-axis t=0 task augmentation (EgoMimic-style): synonym / omit_arm /
-    omit_orientation / omit_grasp_method / combined. Replaces n_task_rephrasings
-    when enabled; each variant becomes a ``task_aug`` row. Axes with nothing to
-    omit emit fewer entries. Defaults (3+3+2+2+2) match EgoMimic."""
+    """5-axis t=0 task augmentation (EgoMimic-style): synonym / omit_arm / omit_orientation / etc.
+
+    Replaces n_task_rephrasings when enabled; each variant becomes a ``task_aug`` row. Axes with
+    nothing to omit emit fewer entries. Defaults (3+3+2+2+2) match EgoMimic.
+    """
 
     enabled: bool = False
 
@@ -249,4 +250,12 @@ class AnnotationPipelineConfig:
     push_commit_message: str | None = None
 
     def resolved_staging_dir(self, root: Path) -> Path:
+        """Return `self.staging_dir`, defaulting to `root / ".annotate_staging"` when unset.
+
+        Args:
+            root (`Path`): Dataset root directory.
+
+        Returns:
+            `Path`: Staging directory to write intermediate annotation outputs to.
+        """
         return self.staging_dir if self.staging_dir is not None else root / ".annotate_staging"

--- a/src/lerobot/annotations/steerable_pipeline/executor.py
+++ b/src/lerobot/annotations/steerable_pipeline/executor.py
@@ -90,6 +90,18 @@ class Executor:
     validator: StagingValidator
 
     def run(self, root: Path) -> PipelineRunSummary:
+        """Run all six annotation phases over the dataset at `root`.
+
+        Args:
+            root (`Path`): Dataset root directory.
+
+        Returns:
+            `PipelineRunSummary`: Per-phase results, written shard paths, and the validation report.
+
+        Raises:
+            ValueError: If no episodes are found under `root/data/`.
+            RuntimeError: If validation fails and `self.config.skip_validation` is `False`.
+        """
         records = list(iter_episodes(root, only_episodes=self.config.only_episodes))
         n = len(records)
         if n == 0:
@@ -179,6 +191,19 @@ class Executor:
         staging_dir: Path,
         module: Any,
     ) -> PhaseResult:
+        """Run `module.run_episode` over every record, in parallel up to `episode_parallelism`.
+
+        Args:
+            name (`str`): Phase name, used in progress logging and the returned `PhaseResult`.
+            records (`list[EpisodeRecord]`): Episodes to process.
+            staging_dir (`Path`): Directory holding per-episode staged annotation rows.
+            module (`Any`): Annotation module to run (`PlanSubtasksMemoryModule`,
+                `InterjectionsAndSpeechModule`, or `GeneralVqaModule`); skipped entirely when
+                `module.enabled` is `False`.
+
+        Returns:
+            `PhaseResult`: Summary of episodes processed vs. skipped for this phase.
+        """
         if not module.enabled:
             print(f"[annotate] phase={name} skipped (module disabled)", flush=True)
             return PhaseResult(name=name, episodes_processed=0, episodes_skipped=len(records))
@@ -191,6 +216,11 @@ class Executor:
         t0 = time.time()
 
         def _do(idx_record: tuple[int, EpisodeRecord]) -> tuple[int, int, float]:
+            """Run `module.run_episode` on one `(submission_order, record)` pair, timing it.
+
+            Returns:
+                `tuple[int, int, float]`: `(submission_order, episode_index, elapsed_seconds)`.
+            """
             i, record = idx_record
             ep_start = time.time()
             staging = EpisodeStaging(staging_dir, record.episode_index)

--- a/src/lerobot/annotations/steerable_pipeline/frames.py
+++ b/src/lerobot/annotations/steerable_pipeline/frames.py
@@ -91,6 +91,7 @@ class _NullProvider:
 
     @property
     def camera_keys(self) -> list[str]:
+        """Always empty: this provider has no cameras."""
         return []
 
     def frames_at(
@@ -99,6 +100,7 @@ class _NullProvider:
         timestamps: list[float],
         camera_key: str | None = None,
     ) -> list[Any]:
+        """Always returns `[]`."""
         return []
 
     def video_for_episode(
@@ -107,10 +109,12 @@ class _NullProvider:
         max_frames: int,
         camera_key: str | None = None,
     ) -> list[Any]:
+        """Always returns `[]`."""
         return []
 
 
 def null_provider() -> FrameProvider:
+    """Return a `_NullProvider`, for datasets with no video keys (or in tests)."""
     return _NullProvider()
 
 
@@ -156,6 +160,13 @@ class VideoFrameProvider:
     _warned_decode_fail: bool = field(default=False, init=False, repr=False)
 
     def __post_init__(self) -> None:
+        """Resolve the dataset's decodable camera keys and default `camera_key`.
+
+        Raises:
+            Exception: Propagates whatever `LeRobotDatasetMetadata` raises if the dataset at
+                `self.root` can't be loaded; `make_frame_provider` catches this and falls back to
+                a `_NullProvider`.
+        """
         from lerobot.datasets.dataset_metadata import LeRobotDatasetMetadata  # noqa: PLC0415
 
         self._meta = LeRobotDatasetMetadata(repo_id="local", root=self.root)
@@ -187,6 +198,17 @@ class VideoFrameProvider:
         timestamps: list[float],
         camera_key: str | None = None,
     ) -> list[Any]:
+        """Return one decoded frame per timestamp, snapped to the nearest real frame and cached.
+
+        Args:
+            record (`EpisodeRecord`): Episode to decode from.
+            timestamps (`list[float]`): Episode-relative timestamps, in seconds, to decode.
+            camera_key (`str | None`, *optional*): Camera to decode from. Defaults to `self.camera_key`.
+
+        Returns:
+            `list[Any]`: One `torch.Tensor` (`C, H, W` uint8) per successfully decoded timestamp;
+                shorter than `timestamps` when some decodes fail.
+        """
         target = camera_key if camera_key is not None else self.camera_key
         if not timestamps or target is None:
             return []

--- a/src/lerobot/annotations/steerable_pipeline/modules/general_vqa.py
+++ b/src/lerobot/annotations/steerable_pipeline/modules/general_vqa.py
@@ -99,9 +99,16 @@ class GeneralVqaModule:
 
     @property
     def enabled(self) -> bool:
+        """Whether `self.config.enabled` is set."""
         return self.config.enabled
 
     def run_episode(self, record: EpisodeRecord, staging: EpisodeStaging) -> None:
+        """Emit grounded VQA `(user, assistant)` pairs for one episode and write them to staging.
+
+        Args:
+            record (`EpisodeRecord`): Episode to annotate.
+            staging (`EpisodeStaging`): Staging area to write the `"vqa"` rows to.
+        """
         if not record.frame_timestamps:
             staging.write("vqa", [])
             return
@@ -212,6 +219,17 @@ class GeneralVqaModule:
         frame_timestamp: float,
         camera_key: str,
     ) -> list[dict[str, Any]]:
+        """Build the VLM chat message asking a `question_type` VQA question about one frame.
+
+        Args:
+            record (`EpisodeRecord`): Episode the frame belongs to.
+            question_type (`str`): Question type to ask (bbox, keypoint, count, attribute, spatial).
+            frame_timestamp (`float`): Episode-relative timestamp of the frame to ground on.
+            camera_key (`str`): Camera to decode the frame from.
+
+        Returns:
+            `list[dict[str, Any]]`: A single-message chat payload for `VlmClient.generate_json`.
+        """
         prompt = load_prompt("vqa").format(
             episode_task=record.episode_task,
             question_type=question_type,
@@ -221,6 +239,15 @@ class GeneralVqaModule:
         return [{"role": "user", "content": content}]
 
     def _postprocess(self, result: Any) -> tuple[str, dict[str, Any]] | None:
+        """Validate and extract `(question, answer)` from one VLM `generate_json` result.
+
+        Args:
+            result (`Any`): Raw parsed JSON result from the VLM.
+
+        Returns:
+            `tuple[str, dict[str, Any]] | None`: The question and answer dict, or `None` if `result`
+                doesn't have the expected shape or its answer doesn't match a known VQA answer type.
+        """
         if not isinstance(result, dict):
             return None
         question = result.get("question")

--- a/src/lerobot/annotations/steerable_pipeline/modules/interjections_and_speech.py
+++ b/src/lerobot/annotations/steerable_pipeline/modules/interjections_and_speech.py
@@ -57,9 +57,17 @@ class InterjectionsAndSpeechModule:
 
     @property
     def enabled(self) -> bool:
+        """Whether `self.config.enabled` is set."""
         return self.config.enabled
 
     def run_episode(self, record: EpisodeRecord, staging: EpisodeStaging) -> None:
+        """Emit the initial speech atom and mid-episode interjection/speech pairs for one episode.
+
+        Args:
+            record (`EpisodeRecord`): Episode to annotate.
+            staging (`EpisodeStaging`): Staging area; reads the `"plan"` module's subtask spans and
+                writes the `"interjections"` rows.
+        """
         rows: list[dict[str, Any]] = []
         if record.frame_timestamps:
             t0 = float(record.frame_timestamps[0])
@@ -76,6 +84,16 @@ class InterjectionsAndSpeechModule:
 
     @staticmethod
     def _subtask_at(spans: Sequence[dict[str, Any]], t: float) -> str | None:
+        """Return the text of the subtask span active at time `t`.
+
+        Args:
+            spans (`Sequence[dict[str, Any]]`): Subtask spans, each with `"start"` and `"text"`,
+                in chronological order.
+            t (`float`): Episode-relative timestamp to look up.
+
+        Returns:
+            `str | None`: The active span's text, or `None` if `t` precedes every span.
+        """
         current: str | None = None
         for span in spans:
             if float(span["start"]) <= t:
@@ -85,6 +103,14 @@ class InterjectionsAndSpeechModule:
         return current
 
     def _initial_speech(self, record: EpisodeRecord) -> str | None:
+        """Generate the task-start speech acknowledgement text for `record`.
+
+        Args:
+            record (`EpisodeRecord`): Episode to generate the acknowledgement for.
+
+        Returns:
+            `str | None`: The acknowledgement text, or `None` if the VLM returned no usable text.
+        """
         prompt = load_prompt("interjections_initial_speech").format(
             episode_task=record.episode_task,
         )

--- a/src/lerobot/annotations/steerable_pipeline/modules/plan_subtasks_memory.py
+++ b/src/lerobot/annotations/steerable_pipeline/modules/plan_subtasks_memory.py
@@ -40,6 +40,14 @@ logger = logging.getLogger(__name__)
 # timestamped contact-sheet grids, not a single video, and reads the burned-in
 # per-tile timestamp when choosing boundaries.
 def _contact_sheet_preamble(columns: int) -> str:
+    """Return the prompt preamble explaining how to read timestamped contact-sheet grids.
+
+    Args:
+        columns (`int`): Number of frames per row in the contact sheet.
+
+    Returns:
+        `str`: Preamble text to prepend to a describe/segment prompt.
+    """
     return (
         "CONTACT SHEETS — how to read the images below:\n"
         f"- Each image is a grid of sampled video frames, {columns} per row, "
@@ -95,9 +103,16 @@ class PlanSubtasksMemoryModule:
 
     @property
     def enabled(self) -> bool:
+        """Whether `self.config.enabled` is set."""
         return self.config.enabled
 
     def run_episode(self, record: EpisodeRecord, staging: EpisodeStaging) -> None:
+        """Generate task-aug, subtask, plan, and memory rows for one episode.
+
+        Args:
+            record (`EpisodeRecord`): Episode to annotate.
+            staging (`EpisodeStaging`): Staging area to write the `"plan"` rows to.
+        """
         rows: list[dict[str, Any]] = []
         # Task driving every plan-module prompt: canonical episode_task, or a
         # video-derived one when it's empty/placeholder (see derive_task_*).
@@ -211,6 +226,7 @@ class PlanSubtasksMemoryModule:
         return canonical
 
     def _task_seems_bad(self, task: str) -> bool:
+        """Whether `task` is too short or a known placeholder, and should be re-derived from video."""
         if not task:
             return True
         if len(task.split()) < int(self.config.derive_task_min_words):
@@ -817,6 +833,19 @@ class PlanSubtasksMemoryModule:
         *,
         task: str | None = None,
     ) -> str:
+        """Generate the memory text summarizing progress at one subtask boundary.
+
+        Args:
+            record (`EpisodeRecord`): Episode being annotated.
+            prior_memory (`str`): Previous memory text, or `""` at the first boundary.
+            completed (`str`): Text of the just-completed subtask.
+            remaining (`Sequence[str]`): Texts of the still-todo subtasks.
+            task (`str | None`, *optional*): Task string to use in the prompt. Defaults to
+                `record.episode_task` when unset.
+
+        Returns:
+            `str`: The generated memory text, or `""` if the VLM returned nothing usable.
+        """
         prompt = load_prompt("plan_memory").format(
             episode_task=(task if task is not None else record.episode_task),
             prior_memory=prior_memory or "(none)",

--- a/src/lerobot/annotations/steerable_pipeline/reader.py
+++ b/src/lerobot/annotations/steerable_pipeline/reader.py
@@ -149,6 +149,16 @@ def iter_episodes(root: Path, *, only_episodes: tuple[int, ...] | None = None) -
 
 
 def _iter_one_path(path: Path, tasks: dict[int, str], only_set: set[int] | None) -> Iterator[EpisodeRecord]:
+    """Yield an `EpisodeRecord` per episode found in one parquet shard, in row order.
+
+    Args:
+        path (`Path`): Parquet shard to scan.
+        tasks (`dict[int, str]`): `task_index -> task` lookup, as returned by `_load_tasks_lookup`.
+        only_set (`set[int] | None`): When set, only yield episodes whose index is in this set.
+
+    Yields:
+        `EpisodeRecord` for each qualifying episode in `path`.
+    """
     table = pq.read_table(path)
     names = table.column_names
     if "episode_index" not in names:
@@ -170,6 +180,19 @@ def _iter_one_path(path: Path, tasks: dict[int, str], only_set: set[int] | None)
         ts_buf: list[float],
         fi_buf: list[int],
     ) -> EpisodeRecord | None:
+        """Build an `EpisodeRecord` for one accumulated episode's row range, or `None` if filtered out.
+
+        Args:
+            ep (`int`): Episode index.
+            start (`int`): Row offset within `path` where the episode starts.
+            end (`int`): Row offset (exclusive) where the episode ends.
+            task_idx (`int | None`): Task index for the episode, or `None` if absent.
+            ts_buf (`list[float]`): Accumulated frame timestamps for the episode.
+            fi_buf (`list[int]`): Accumulated frame indices for the episode.
+
+        Returns:
+            `EpisodeRecord | None`: The record, or `None` when `ep` isn't in `only_set`.
+        """
         if only_set is not None and ep not in only_set:
             return None
         task = tasks.get(task_idx, "") if task_idx is not None else ""

--- a/src/lerobot/annotations/steerable_pipeline/staging.py
+++ b/src/lerobot/annotations/steerable_pipeline/staging.py
@@ -51,14 +51,35 @@ class EpisodeStaging:
 
     @property
     def episode_dir(self) -> Path:
+        """This episode's staging directory: `<root>/episode_<index:06d>/`."""
         return self.root / f"episode_{self.episode_index:06d}"
 
     def path_for(self, module: ModuleName) -> Path:
+        """Return the JSONL path for one module's staged output.
+
+        Args:
+            module (`ModuleName`): Module name (`"plan"`, `"interjections"`, or `"vqa"`).
+
+        Returns:
+            `Path`: The module's `<episode_dir>/<module>.jsonl` path.
+
+        Raises:
+            ValueError: If `module` isn't a known module name.
+        """
         if module not in _MODULES:
             raise ValueError(f"Unknown module {module!r}; expected one of {_MODULES}")
         return self.episode_dir / f"{module}.jsonl"
 
     def write(self, module: ModuleName, rows: Iterable[dict[str, Any]]) -> Path:
+        """Atomically write `rows` as JSONL to `module`'s staging file.
+
+        Args:
+            module (`ModuleName`): Module name to write output for.
+            rows (`Iterable[dict[str, Any]]`): Rows to write, one JSON object per line.
+
+        Returns:
+            `Path`: The written file's path.
+        """
         path = self.path_for(module)
         path.parent.mkdir(parents=True, exist_ok=True)
         # Atomic replace: a crash mid-write would otherwise leave a
@@ -74,6 +95,14 @@ class EpisodeStaging:
         return path
 
     def read(self, module: ModuleName) -> list[dict[str, Any]]:
+        """Read `module`'s staged JSONL rows.
+
+        Args:
+            module (`ModuleName`): Module name to read output for.
+
+        Returns:
+            `list[dict[str, Any]]`: Staged rows, or `[]` if the module hasn't written yet.
+        """
         path = self.path_for(module)
         if not path.exists():
             return []
@@ -86,7 +115,13 @@ class EpisodeStaging:
         return out
 
     def read_all(self) -> dict[ModuleName, list[dict[str, Any]]]:
+        """Read every module's staged rows.
+
+        Returns:
+            `dict[ModuleName, list[dict[str, Any]]]`: Staged rows keyed by module name.
+        """
         return {m: self.read(m) for m in _MODULES}
 
     def has(self, module: ModuleName) -> bool:
+        """Whether `module` has already written its staging file."""
         return self.path_for(module).exists()

--- a/src/lerobot/annotations/steerable_pipeline/validator.py
+++ b/src/lerobot/annotations/steerable_pipeline/validator.py
@@ -63,15 +63,19 @@ class ValidationReport:
 
     @property
     def ok(self) -> bool:
+        """Whether validation found no errors (warnings are non-blocking)."""
         return not self.errors
 
     def add_error(self, message: str) -> None:
+        """Record a blocking validation error."""
         self.errors.append(message)
 
     def add_warning(self, message: str) -> None:
+        """Record a non-blocking validation warning."""
         self.warnings.append(message)
 
     def summary(self) -> str:
+        """Return a one-line `checked=.. errors=.. warnings=..` summary."""
         return f"checked={self.episodes_checked} errors={len(self.errors)} warnings={len(self.warnings)}"
 
 
@@ -111,6 +115,15 @@ class StagingValidator:
         records: Sequence[EpisodeRecord],
         staging_dir: Path,
     ) -> ValidationReport:
+        """Validate every episode's staged output.
+
+        Args:
+            records (`Sequence[EpisodeRecord]`): Episodes to validate.
+            staging_dir (`Path`): Directory holding per-episode staged annotation rows.
+
+        Returns:
+            `ValidationReport`: Aggregated errors/warnings across all episodes.
+        """
         report = ValidationReport()
         for record in records:
             self._validate_episode(record, staging_dir, report)
@@ -123,6 +136,13 @@ class StagingValidator:
         staging_dir: Path,
         report: ValidationReport,
     ) -> None:
+        """Run every check on one episode's staged rows, recording findings on `report`.
+
+        Args:
+            record (`EpisodeRecord`): Episode to validate.
+            staging_dir (`Path`): Directory holding per-episode staged annotation rows.
+            report (`ValidationReport`): Report to append errors/warnings to.
+        """
         staging = EpisodeStaging(staging_dir, record.episode_index)
         staged = staging.read_all()
         all_rows: list[dict[str, Any]] = []
@@ -209,6 +229,13 @@ class StagingValidator:
         report: ValidationReport,
         episode_index: int,
     ) -> None:
+        """Check that `row`'s style routes to the persistent/events column its module owns.
+
+        Args:
+            row (`dict[str, Any]`): Staged row, tagged with `"_module"`.
+            report (`ValidationReport`): Report to append errors to.
+            episode_index (`int`): Episode index, for error messages.
+        """
         style = row.get("style")
         module = row.get("_module")
         try:
@@ -232,6 +259,14 @@ class StagingValidator:
         report: ValidationReport,
         episode_index: int,
     ) -> None:
+        """Check that an event row's timestamp matches (or is within tolerance of) a source frame.
+
+        Args:
+            row (`dict[str, Any]`): Event-column row to check.
+            frame_ts (`set[float]`): Source frame timestamps for the episode.
+            report (`ValidationReport`): Report to append errors to.
+            episode_index (`int`): Episode index, for error messages.
+        """
         ts = row.get("timestamp")
         if ts is None:
             report.add_error(f"ep={episode_index}: event row missing timestamp: {row!r}")
@@ -253,6 +288,13 @@ class StagingValidator:
         report: ValidationReport,
         episode_index: int,
     ) -> None:
+        """Check that every interjection row has a co-timestamped speech atom.
+
+        Args:
+            events (`Iterable[dict[str, Any]]`): Events-column rows for one episode.
+            report (`ValidationReport`): Report to append errors to.
+            episode_index (`int`): Episode index, for error messages.
+        """
         speech_ts: dict[float, int] = {}
         interjection_ts: dict[float, int] = {}
         for row in events:
@@ -276,6 +318,17 @@ class StagingValidator:
         report: ValidationReport,
         episode_index: int,
     ) -> None:
+        """Check plan/memory/subtask/interjection emission consistency.
+
+        Warns if persistent rows exist with no plan, or if memory rows land off a subtask
+        boundary. Errors if an interjection has no co-timestamped plan refresh.
+
+        Args:
+            persistent (`Sequence[dict[str, Any]]`): Persistent-column rows for one episode.
+            events (`Sequence[dict[str, Any]]`): Events-column rows for one episode.
+            report (`ValidationReport`): Report to append errors/warnings to.
+            episode_index (`int`): Episode index, for error messages.
+        """
         plan_ts = sorted({float(r["timestamp"]) for r in persistent if r.get("style") == "plan"})
         memory_ts = sorted({float(r["timestamp"]) for r in persistent if r.get("style") == "memory"})
         subtask_ts = sorted({float(r["timestamp"]) for r in persistent if r.get("style") == "subtask"})
@@ -309,6 +362,13 @@ class StagingValidator:
         report: ValidationReport,
         episode_index: int,
     ) -> None:
+        """Check that every VQA assistant row's content is valid JSON matching a known answer shape.
+
+        Args:
+            events (`Iterable[dict[str, Any]]`): Events-column rows for one episode.
+            report (`ValidationReport`): Report to append errors to.
+            episode_index (`int`): Episode index, for error messages.
+        """
         for row in events:
             if row.get("style") != "vqa" or row.get("role") != "assistant":
                 continue

--- a/src/lerobot/annotations/steerable_pipeline/vlm_client.py
+++ b/src/lerobot/annotations/steerable_pipeline/vlm_client.py
@@ -81,10 +81,33 @@ class StubVlmClient:
         max_new_tokens: int | None = None,
         temperature: float | None = None,
     ) -> list[Any]:
+        """Call `self.responder` on each messages list in `messages_batch`.
+
+        Args:
+            messages_batch (`Sequence[Sequence[dict[str, Any]]]`): Batch of chat message lists.
+            max_new_tokens (`int | None`, *optional*): Unused; accepted for protocol compatibility.
+            temperature (`float | None`, *optional*): Unused; accepted for protocol compatibility.
+
+        Returns:
+            `list[Any]`: One response per messages list, from `self.responder`.
+        """
         return [self.responder(list(messages)) for messages in messages_batch]
 
 
 def _strip_to_json(text: str) -> Any:
+    """Parse `text` as JSON, stripping `<think>` blocks and ```` ```json ```` fences first.
+
+    Falls back to extracting the first balanced `{...}` substring if direct parsing fails.
+
+    Args:
+        text (`str`): Raw VLM completion text.
+
+    Returns:
+        `Any`: The parsed JSON value.
+
+    Raises:
+        json.JSONDecodeError: If no valid JSON object can be found or parsed.
+    """
     text = text.strip()
     # Strip <think>...</think> blocks (Qwen3 Thinking style)
     while "<think>" in text and "</think>" in text:
@@ -109,8 +132,10 @@ def _strip_to_json(text: str) -> Any:
 
 
 def _extract_first_json_object(text: str) -> str | None:
-    """Return the first balanced ``{...}`` substring, ignoring braces in
-    string literals. Returns ``None`` if no balanced block is found."""
+    """Return the first balanced ``{...}`` substring, ignoring braces in string literals.
+
+    Returns ``None`` if no balanced block is found.
+    """
     start = text.find("{")
     if start < 0:
         return None
@@ -155,6 +180,17 @@ class _GenericTextClient:
         max_new_tokens: int | None = None,
         temperature: float | None = None,
     ) -> list[Any]:
+        """Generate text for each messages list and parse it as JSON, retrying once on failure.
+
+        Args:
+            messages_batch (`Sequence[Sequence[dict[str, Any]]]`): Batch of chat message lists.
+            max_new_tokens (`int | None`, *optional*): Overrides `self.config.max_new_tokens`.
+            temperature (`float | None`, *optional*): Overrides `self.config.temperature`.
+
+        Returns:
+            `list[Any]`: One parsed JSON value per input, or `None` for entries that still fail to
+                parse after the retry.
+        """
         max_tok = max_new_tokens if max_new_tokens is not None else self.config.max_new_tokens
         temp = temperature if temperature is not None else self.config.temperature
         raw = self.generate_text(messages_batch, max_tok, temp)
@@ -279,6 +315,11 @@ def _make_openai_client(config: VlmConfig) -> VlmClient:
     rr_lock = threading.Lock()
 
     def _one_call(messages: Sequence[dict[str, Any]], max_tok: int, temp: float) -> str:
+        """Send one chat-completion request (round-robined across `clients`) and return its text.
+
+        Returns:
+            `str`: The completion's text content, or `""` if the server returned no message.
+        """
         api_messages, mm_kwargs = _to_openai_messages(messages)
         kwargs: dict[str, Any] = {
             "model": config.model_id,
@@ -308,6 +349,11 @@ def _make_openai_client(config: VlmConfig) -> VlmClient:
         return (message.content if message is not None else None) or ""
 
     def _gen(batch: Sequence[Sequence[dict[str, Any]]], max_tok: int, temp: float) -> list[str]:
+        """Run `_one_call` over `batch`, fanning out concurrently when `client_concurrency > 1`.
+
+        Returns:
+            `list[str]`: One completion text per entry in `batch`.
+        """
         if len(batch) <= 1 or config.client_concurrency <= 1:
             return [_one_call(messages, max_tok, temp) for messages in batch]
         # Parallel fan-out — vllm batches these on the server side.
@@ -320,11 +366,12 @@ def _make_openai_client(config: VlmConfig) -> VlmClient:
 
 
 def _bind_serve_port(cmd: str, port: int) -> str:
-    """Bind a serve command to ``port``: substitute a ``{port}`` placeholder
-    if present, else append ``--port`` when the command omits it (leaving an
-    explicit ``--port`` untouched). Shared by the single- and parallel-server
-    paths so a serve_command never reaches the server with a literal
-    ``{port}``."""
+    """Bind a serve command to ``port``.
+
+    Substitutes a ``{port}`` placeholder if present, else appends ``--port`` when the command
+    omits it (leaving an explicit ``--port`` untouched). Shared by the single- and parallel-server
+    paths so a serve_command never reaches the server with a literal ``{port}``.
+    """
     if "{port}" in cmd:
         return cmd.replace("{port}", str(port))
     if "--port" not in cmd:
@@ -391,6 +438,7 @@ def _spawn_parallel_inference_servers(config: VlmConfig) -> list[str]:
         ready_events.append(ready)
 
         def _stream(idx: int, p: subprocess.Popen, ev: threading.Event) -> None:
+            """Stream server `idx`'s stdout to the console and set `ev` on a readiness marker."""
             # Read whole lines and emit each line atomically under the
             # shared print_lock so output from N servers stays readable.
             assert p.stdout is not None
@@ -406,6 +454,7 @@ def _spawn_parallel_inference_servers(config: VlmConfig) -> list[str]:
         threading.Thread(target=_stream, args=(i, proc, ready), daemon=True).start()
 
         def _probe(idx: int, base: str, ev: threading.Event, p: subprocess.Popen) -> None:
+            """Poll server `idx` at `base` until it answers, setting `ev` when it's up."""
             while not ev.is_set() and p.poll() is None:
                 if _server_is_up(base):
                     print(f"[server-{idx}] ready (http probe)", flush=True)
@@ -416,6 +465,7 @@ def _spawn_parallel_inference_servers(config: VlmConfig) -> list[str]:
         threading.Thread(target=_probe, args=(i, api_base, ready, proc), daemon=True).start()
 
     def _shutdown() -> None:
+        """Send SIGINT to every server replica and wait for it to exit (killing after 15s)."""
         for i, p in enumerate(procs):
             if p.poll() is None:
                 print(f"[server-{i}] stopping pid={p.pid}", flush=True)
@@ -458,12 +508,11 @@ def _server_is_up(api_base: str) -> bool:
 
 
 def _spawn_inference_server(config: VlmConfig) -> str:
-    """Spawn ``transformers serve`` (or ``serve_command``), wait until it
-    accepts ``/v1/models``, and register a shutdown hook.
+    """Spawn ``transformers serve`` (or ``serve_command``) and register a shutdown hook.
 
-    Streams the server's stdout/stderr to the parent terminal in
-    real-time on a background thread so users can see model-load
-    progress and errors as they happen.
+    Waits until the server accepts ``/v1/models``. Streams the server's stdout/stderr to the
+    parent terminal in real-time on a background thread so users can see model-load progress and
+    errors as they happen.
 
     Returns the full ``api_base`` URL the OpenAI client should use.
     """
@@ -502,6 +551,7 @@ def _spawn_inference_server(config: VlmConfig) -> str:
     )
 
     def _probe() -> None:
+        """Poll the server until it answers, setting `ready_event` when it's up."""
         while not ready_event.is_set() and proc.poll() is None:
             if _server_is_up(api_base):
                 print("[server] ready (http probe)", flush=True)
@@ -512,6 +562,7 @@ def _spawn_inference_server(config: VlmConfig) -> str:
     threading.Thread(target=_probe, daemon=True).start()
 
     def _stream_output() -> None:
+        """Stream the server's stdout to the console char-by-char, setting `ready_event` on a marker."""
         # Read raw chunks instead of iterating lines so tqdm progress
         # bars (which overwrite using \r) flush in real time.
         assert proc.stdout is not None
@@ -540,6 +591,7 @@ def _spawn_inference_server(config: VlmConfig) -> str:
     threading.Thread(target=_stream_output, daemon=True).start()
 
     def _shutdown() -> None:
+        """Send SIGINT to the server and wait for it to exit (killing after 15s)."""
         if proc.poll() is None:
             print(f"[server] stopping pid={proc.pid}", flush=True)
             proc.send_signal(signal.SIGINT)

--- a/src/lerobot/annotations/steerable_pipeline/writer.py
+++ b/src/lerobot/annotations/steerable_pipeline/writer.py
@@ -78,10 +78,12 @@ from lerobot.datasets.language import DEFAULT_TOOLS, SAY_TOOL_SCHEMA  # noqa: F4
 
 
 def _row_persistent_sort_key(row: dict[str, Any]) -> tuple:
+    """Sort key for persistent rows: `(timestamp, style, role)`."""
     return (float(row["timestamp"]), row.get("style") or "", row.get("role") or "")
 
 
 def _row_event_sort_key(row: dict[str, Any]) -> tuple:
+    """Sort key for event rows within one frame's bucket: `(style, role, camera)`."""
     # events are bucketed per-frame, but within a frame we still want determinism
     return (
         row.get("style") or "",
@@ -143,6 +145,17 @@ def _normalize_event_row(row: dict[str, Any]) -> dict[str, Any]:
 
 
 def _normalize_tool_calls(value: Any) -> list[Any] | None:
+    """Coerce a staged row's `tool_calls` field to `list | None`.
+
+    Args:
+        value (`Any`): Raw `tool_calls` value from a staged row.
+
+    Returns:
+        `list[Any] | None`: `None` unchanged, otherwise `value` as a plain `list`.
+
+    Raises:
+        ValueError: If `value` is neither `None` nor a `list`.
+    """
     if value is None:
         return None
     if not isinstance(value, list):
@@ -196,6 +209,16 @@ class LanguageColumnsWriter:
         staging_dir: Path,
         root: Path,
     ) -> list[Path]:
+        """Rewrite every parquet shard touched by `records` with the two language columns.
+
+        Args:
+            records (`Sequence[EpisodeRecord]`): Episodes to write annotations for.
+            staging_dir (`Path`): Directory holding per-episode staged annotation rows.
+            root (`Path`): Dataset root directory.
+
+        Returns:
+            `list[Path]`: Paths of the rewritten parquet shards.
+        """
         episodes_by_path: dict[Path, list[EpisodeRecord]] = defaultdict(list)
         for record in records:
             episodes_by_path[record.data_path].append(record)
@@ -213,6 +236,18 @@ class LanguageColumnsWriter:
         staging_dir: Path,
         root: Path,
     ) -> None:
+        """Rewrite one parquet shard in place with the two language columns.
+
+        Args:
+            path (`Path`): Parquet shard to rewrite.
+            episodes (`Sequence[EpisodeRecord]`): Episodes stored in `path`.
+            staging_dir (`Path`): Directory holding per-episode staged annotation rows.
+            root (`Path`): Dataset root directory. Unused directly; kept for signature symmetry
+                with `write_all`.
+
+        Raises:
+            ValueError: If `path`'s table is missing `episode_index` or `timestamp` columns.
+        """
         table = pq.read_table(path)
         n_rows = table.num_rows
 
@@ -290,6 +325,19 @@ class LanguageColumnsWriter:
         *,
         drop_old: bool,
     ) -> pa.Table:
+        """Rebuild `table` with the two language columns added and legacy columns dropped.
+
+        Args:
+            table (`pa.Table`): Source table to rebuild from.
+            persistent (`list[list[dict[str, Any]]]`): Per-row persistent-column values, one list
+                (broadcast across the episode) per table row.
+            events (`list[list[dict[str, Any]]]`): Per-row event-column values, one list per table
+                row (the rows whose timestamp exactly matches that frame's).
+            drop_old (`bool`): Whether to drop the legacy `subtask_index` column, if present.
+
+        Returns:
+            `pa.Table`: The rebuilt table, with `language_persistent`/`language_events` columns.
+        """
         cols = []
         names = []
         for name in table.column_names:

--- a/utils/check_docstrings.py
+++ b/utils/check_docstrings.py
@@ -60,6 +60,7 @@ PATH_TO_LEROBOT = PATH_TO_REPO / "src" / "lerobot"
 # Modules whose public objects are checked. Add a module here once its docstrings follow the standard.
 MODULES_TO_CHECK = [
     "lerobot.robots",
+    "lerobot.annotations",
 ]
 
 # Objects that do not yet follow the standard, so the check can be green from day one. Removing an entry


### PR DESCRIPTION
## Summary
- Brings `src/lerobot/annotations/` to 100% public docstring coverage per `docs/source/writing_docstrings.mdx`: Google-style sections + HF-style type formatting across the steerable annotation pipeline's `Executor`, the `plan`/`interjections`/`vqa` modules, frame providers (`VideoFrameProvider`, `_NullProvider`), the VLM client (`_GenericTextClient`, `StubVlmClient`, server spawn/probe helpers), `EpisodeStaging`, `StagingValidator`, and `LanguageColumnsWriter`.
- Along the way, discovered and fixed a scanner blind spot: helper functions nested inside a `for` loop or another closure (e.g. `_stream`/`_probe`/`_shutdown` in `vlm_client.py`'s server-spawning code) aren't direct AST children of their enclosing function, so a shallow scan missed them — caught by re-scanning with `ast.walk` instead.
- Adds `docs/source/api/annotations.mdx`, documenting the pipeline's configuration, executor, modules, frame providers, VLM client, and staging/validation/writer components.
- Removes `"src/lerobot/annotations/**" = ["D"]` from `pyproject.toml`'s ruff per-file-ignores; adds `"lerobot.annotations"` to `check_docstrings.py`'s `MODULES_TO_CHECK` ratchet; raises `interrogate`'s `fail-under` from 55 to 56.2 (actual: 56.4%).
- Docstrings-only — zero behavioral change.

## Test plan
- [x] `ruff check src/lerobot/annotations/` — clean.
- [x] `python utils/check_docstrings.py` — clean.
- [x] `interrogate --config=pyproject.toml` — PASSED (56.2% min, 56.4% actual).
- [x] `python utils/check_doctest_list.py` — clean.
- [x] `doc-builder build lerobot docs/source/` — renders cleanly (50 autodoc blocks), no dead cross-refs or `<fill_docstring>` placeholders.
- [x] `pre-commit run --all-files` — green (reverted the unrelated `tests/policies/vla_jepa/test_*.py` ruff import-order churn).