### PR TITLE
docs(utils): write the API reference docstrings

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -215,4 +215,6 @@
     title: Environments
   - local: api/configs
     title: Configuration
+  - local: api/utils
+    title: Utils
   title: "API Reference"

--- a/docs/source/api/utils.mdx
+++ b/docs/source/api/utils.mdx
@@ -1,0 +1,114 @@
+# Utils
+
+`src/lerobot/utils/` holds shared infrastructure used across the codebase: errors, device/RNG
+helpers, logging and timing, Hub upload/download, visualization, keyboard input, and small
+math/data helpers.
+
+## Errors and connection decorators
+
+[[autodoc]] lerobot.utils.errors.DeviceNotConnectedError
+
+[[autodoc]] lerobot.utils.errors.DeviceAlreadyConnectedError
+
+[[autodoc]] lerobot.utils.decorators.check_if_not_connected
+
+[[autodoc]] lerobot.utils.decorators.check_if_already_connected
+
+## Devices and reproducibility
+
+[[autodoc]] lerobot.utils.device_utils.is_torch_device_available
+
+[[autodoc]] lerobot.utils.device_utils.is_amp_available
+
+[[autodoc]] lerobot.utils.device_utils.get_safe_dtype
+
+[[autodoc]] lerobot.utils.random_utils.set_seed
+
+[[autodoc]] lerobot.utils.random_utils.get_rng_state
+
+[[autodoc]] lerobot.utils.random_utils.set_rng_state
+
+[[autodoc]] lerobot.utils.random_utils.seeded_context
+
+## Logging and metrics
+
+[[autodoc]] lerobot.utils.utils.init_logging
+
+[[autodoc]] lerobot.utils.utils.log_say
+
+[[autodoc]] lerobot.utils.utils.TimerManager
+    - all
+
+[[autodoc]] lerobot.utils.logging_utils.AverageMeter
+    - all
+
+[[autodoc]] lerobot.utils.logging_utils.MetricsTracker
+    - all
+
+## Hugging Face Hub
+
+[[autodoc]] lerobot.utils.hub.HubMixin
+    - all
+
+[[autodoc]] lerobot.utils.hub.find_latest_hub_checkpoint
+
+## Sample weighting
+
+[[autodoc]] lerobot.utils.sample_weighting.SampleWeighter
+    - all
+
+[[autodoc]] lerobot.utils.sample_weighting.SampleWeightingConfig
+
+[[autodoc]] lerobot.utils.sample_weighting.make_sample_weighter
+
+## Visualization
+
+Backend-agnostic entry points that dispatch to Rerun or Foxglove based on `display_mode`.
+
+[[autodoc]] lerobot.utils.visualization_utils.init_visualization
+
+[[autodoc]] lerobot.utils.visualization_utils.log_visualization_data
+
+[[autodoc]] lerobot.utils.visualization_utils.shutdown_visualization
+
+## Keyboard and pedal input
+
+[[autodoc]] lerobot.utils.keyboard_input.create_key_listener
+
+[[autodoc]] lerobot.utils.keyboard_input.init_keyboard_listener
+
+[[autodoc]] lerobot.utils.keyboard_input.TerminalKeyListener
+    - all
+
+[[autodoc]] lerobot.utils.pedal.start_pedal_listener
+
+## Bimanual robots and teleoperators
+
+[[autodoc]] lerobot.utils.bimanual.BimanualMixin
+    - all
+
+## Data and math helpers
+
+[[autodoc]] lerobot.utils.transition.Transition
+
+[[autodoc]] lerobot.utils.transition.move_transition_to_device
+
+[[autodoc]] lerobot.utils.collate.lerobot_collate_fn
+
+[[autodoc]] lerobot.utils.action_interpolator.ActionInterpolator
+    - all
+
+[[autodoc]] lerobot.utils.rotation.Rotation
+    - all
+
+## I/O
+
+[[autodoc]] lerobot.utils.io_utils.load_json
+
+[[autodoc]] lerobot.utils.io_utils.write_json
+
+[[autodoc]] lerobot.utils.io_utils.write_video
+
+## Robot timing
+
+[[autodoc]] lerobot.utils.robot_utils.precise_sleep

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -462,7 +462,6 @@ ignore = [
 "src/lerobot/teleoperators/**" = ["D"]
 "src/lerobot/transforms/**" = ["D"]
 "src/lerobot/transport/**" = ["D"]
-"src/lerobot/utils/**" = ["D"]
 "src/lerobot/lerobot_types.py" = ["D"]
 [tool.ruff.lint.isort]
 combine-as-imports = true
@@ -520,7 +519,7 @@ ignore-private = false
 ignore-property-decorators = false
 ignore-module = false
 ignore-setters = false
-fail-under = 55
+fail-under = 56.2
 output-format = "term-missing"
 color = true
 paths = ["src/lerobot"]

--- a/src/lerobot/utils/__init__.py
+++ b/src/lerobot/utils/__init__.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Public API for lightweight, base-dependency-only utilities.
+"""Public API for lightweight, base-dependency-only utilities.
 
 Heavy cross-cutting modules (train_utils, control_utils) have been moved
 to ``lerobot.common``. ``visualization_utils`` remains here but is

--- a/src/lerobot/utils/bimanual.py
+++ b/src/lerobot/utils/bimanual.py
@@ -38,26 +38,45 @@ class BimanualMixin:
 
     @property
     def is_connected(self) -> bool:
+        """Whether both `left_arm` and `right_arm` are connected.
+
+        Returns:
+            `bool`: `True` only if both arms report connected.
+        """
         return self.left_arm.is_connected and self.right_arm.is_connected
 
     @property
     def is_calibrated(self) -> bool:
+        """Whether both `left_arm` and `right_arm` are calibrated.
+
+        Returns:
+            `bool`: `True` only if both arms report calibrated.
+        """
         return self.left_arm.is_calibrated and self.right_arm.is_calibrated
 
     @check_if_already_connected
     def connect(self, calibrate: bool = True) -> None:
+        """Connect both arms.
+
+        Args:
+            calibrate (`bool`, *optional*, defaults to `True`): Whether to automatically calibrate
+                each arm after connecting, if it is not calibrated or needs recalibration.
+        """
         self.left_arm.connect(calibrate)
         self.right_arm.connect(calibrate)
 
     def calibrate(self) -> None:
+        """Calibrate both arms."""
         self.left_arm.calibrate()
         self.right_arm.calibrate()
 
     def configure(self) -> None:
+        """Apply configuration to both arms."""
         self.left_arm.configure()
         self.right_arm.configure()
 
     @check_if_not_connected
     def disconnect(self) -> None:
+        """Disconnect both arms."""
         self.left_arm.disconnect()
         self.right_arm.disconnect()

--- a/src/lerobot/utils/decorators.py
+++ b/src/lerobot/utils/decorators.py
@@ -20,8 +20,11 @@ from .errors import DeviceAlreadyConnectedError, DeviceNotConnectedError
 
 
 def check_if_not_connected(func):
+    """Decorate a device method to raise `DeviceNotConnectedError` if `self.is_connected` is `False`."""
+
     @wraps(func)
     def wrapper(self, *args, **kwargs):
+        """Call `func`, raising `DeviceNotConnectedError` first if `self` isn't connected."""
         if not self.is_connected:
             raise DeviceNotConnectedError(
                 f"{self.__class__.__name__} is not connected. Run `.connect()` first."
@@ -32,8 +35,11 @@ def check_if_not_connected(func):
 
 
 def check_if_already_connected(func):
+    """Decorate a device method to raise `DeviceAlreadyConnectedError` if `self.is_connected` is `True`."""
+
     @wraps(func)
     def wrapper(self, *args, **kwargs):
+        """Call `func`, raising `DeviceAlreadyConnectedError` first if `self` is already connected."""
         if self.is_connected:
             raise DeviceAlreadyConnectedError(f"{self.__class__.__name__} is already connected.")
         return func(self, *args, **kwargs)

--- a/src/lerobot/utils/device_utils.py
+++ b/src/lerobot/utils/device_utils.py
@@ -83,8 +83,15 @@ def resolve_safetensors_device(map_location: str | torch.device) -> str:
 
 
 def get_safe_dtype(dtype: torch.dtype, device: str | torch.device):
-    """
-    mps is currently not compatible with float64
+    """Downgrade `float64` to `float32` on devices that don't support double precision.
+
+    Args:
+        dtype (`torch.dtype`): Requested dtype.
+        device (`str | torch.device`): Target device.
+
+    Returns:
+        `torch.dtype`: `dtype`, or `float32` if `dtype` is `float64` and `device` (mps, or xpu
+            without FP64 support) can't handle it.
     """
     if isinstance(device, torch.device):
         device = device.type
@@ -110,6 +117,18 @@ def get_safe_dtype(dtype: torch.dtype, device: str | torch.device):
 
 
 def is_torch_device_available(try_device: str) -> bool:
+    """Whether `try_device` (cuda/mps/xpu/cpu) is available on this machine.
+
+    Args:
+        try_device (`str`): Device type to check, one of `"cuda"` (or `"cuda:<n>"`), `"mps"`,
+            `"xpu"`, `"cpu"`.
+
+    Returns:
+        `bool`: Whether the device is available.
+
+    Raises:
+        ValueError: If `try_device` isn't one of the supported device types.
+    """
     try_device = str(try_device)  # Ensure try_device is a string
     if try_device.startswith("cuda"):
         return torch.cuda.is_available()
@@ -124,6 +143,17 @@ def is_torch_device_available(try_device: str) -> bool:
 
 
 def is_amp_available(device: str):
+    """Whether automatic mixed precision is supported on `device`.
+
+    Args:
+        device (`str`): Device type: `"cuda"`, `"xpu"`, `"cpu"`, or `"mps"`.
+
+    Returns:
+        `bool`: Whether AMP is supported (always `False` for `"mps"`).
+
+    Raises:
+        ValueError: If `device` isn't one of the supported device types.
+    """
     if device in ["cuda", "xpu", "cpu"]:
         return True
     elif device == "mps":

--- a/src/lerobot/utils/doctest_utils.py
+++ b/src/lerobot/utils/doctest_utils.py
@@ -167,6 +167,7 @@ class LeRobotDoctestModule(DoctestModule):
             # property-heavy (`observation_features`, `is_connected`, ...), so a wrong line number here
             # would point every failure at the decorator. https://github.com/python/cpython/issues/61648
             def _find_lineno(self, obj, source_lines):
+                """Unwrap `property`/`functools.wraps` objects before locating their source line."""
                 if isinstance(obj, property):
                     obj = getattr(obj, "fget", obj)
                 if hasattr(obj, "__wrapped__"):
@@ -177,6 +178,7 @@ class LeRobotDoctestModule(DoctestModule):
                 # `cached_property` is otherwise never considered part of the current module and its
                 # examples are silently skipped. https://github.com/python/cpython/issues/107995
                 def _from_module(self, module, object):
+                    """Treat a `cached_property` as belonging to `module` via its underlying function."""
                     if isinstance(object, functools.cached_property):
                         object = object.func
                     return super()._from_module(module, object)

--- a/src/lerobot/utils/errors.py
+++ b/src/lerobot/utils/errors.py
@@ -17,6 +17,11 @@ class DeviceNotConnectedError(ConnectionError):
     """Exception raised when the device is not connected."""
 
     def __init__(self, message="This device is not connected. Try calling `connect()` first."):
+        """Initialize the error.
+
+        Args:
+            message (`str`, *optional*): Error message.
+        """
         self.message = message
         super().__init__(self.message)
 
@@ -28,5 +33,10 @@ class DeviceAlreadyConnectedError(ConnectionError):
         self,
         message="This device is already connected. Try not calling `connect()` twice.",
     ):
+        """Initialize the error.
+
+        Args:
+            message (`str`, *optional*): Error message.
+        """
         self.message = message
         super().__init__(self.message)

--- a/src/lerobot/utils/errors.py
+++ b/src/lerobot/utils/errors.py
@@ -14,29 +14,29 @@
 
 
 class DeviceNotConnectedError(ConnectionError):
-    """Exception raised when the device is not connected."""
+    # no-format
+    """Exception raised when the device is not connected.
+
+    Args:
+        message (`str`, *optional*): Error message.
+    """
 
     def __init__(self, message="This device is not connected. Try calling `connect()` first."):
-        """Initialize the error.
-
-        Args:
-            message (`str`, *optional*): Error message.
-        """
         self.message = message
         super().__init__(self.message)
 
 
 class DeviceAlreadyConnectedError(ConnectionError):
-    """Exception raised when the device is already connected."""
+    # no-format
+    """Exception raised when the device is already connected.
+
+    Args:
+        message (`str`, *optional*): Error message.
+    """
 
     def __init__(
         self,
         message="This device is already connected. Try not calling `connect()` twice.",
     ):
-        """Initialize the error.
-
-        Args:
-            message (`str`, *optional*): Error message.
-        """
         self.message = message
         super().__init__(self.message)

--- a/src/lerobot/utils/feature_utils.py
+++ b/src/lerobot/utils/feature_utils.py
@@ -60,7 +60,7 @@ def hw_to_dataset_features(
             joints) or shape (tuple for images).
         prefix (str): The prefix to add to the feature keys (e.g., "observation"
             or "action").
-        use_video (bool): If True, image features are marked as "video", otherwise "image".
+        use_video (bool, *optional*, defaults to `True`): If True, image features are marked as "video", otherwise "image".
 
     Returns:
         dict: A LeRobot features dictionary. Depth cameras carry ``info["is_depth_map"] = True``.
@@ -189,7 +189,8 @@ def combine_feature_dicts(*dicts: dict) -> dict:
     - For others (e.g. `observation.images.*`), the last one wins (if they are identical).
 
     Args:
-        *dicts: A variable number of LeRobot feature dictionaries to merge.
+        dicts (`dict`): Grouped feature dicts to merge, in order (later dicts take precedence for
+            non-mergeable specs).
 
     Returns:
         dict: A single merged feature dictionary.

--- a/src/lerobot/utils/foxglove_visualization.py
+++ b/src/lerobot/utils/foxglove_visualization.py
@@ -67,23 +67,22 @@ _SCALARS_SCHEMA = {
 
 
 def _is_scalar(x):
+    """Whether `x` is a Python/NumPy scalar number, or a zero-dimensional NumPy array."""
     return isinstance(x, (float | numbers.Real | np.integer | np.floating)) or (
         isinstance(x, np.ndarray) and x.ndim == 0
     )
 
 
 def init_foxglove(host: str = "127.0.0.1", port: int | None = 8765) -> None:
-    """
-    Starts a Foxglove WebSocket server for visualizing the control loop.
+    """Starts a Foxglove WebSocket server for visualizing the control loop.
 
     Connect to it from the Foxglove app at ``ws://<host>:<port>``. Calling this
     more than once is a no-op while a server is already running.
 
     Args:
-        host: Host interface to bind the WebSocket server to.
-        port: Port to bind the WebSocket server to (defaults to 8765).
+        host (`str`, *optional*, defaults to `"127.0.0.1"`): Interface to bind the WebSocket server to.
+        port (`int | None`, *optional*, defaults to 8765): Port to bind the WebSocket server to.
     """
-
     require_package("foxglove-sdk", extra="viz", import_name="foxglove")
     import foxglove
 
@@ -98,7 +97,6 @@ def init_foxglove(host: str = "127.0.0.1", port: int | None = 8765) -> None:
 
 def shutdown_foxglove() -> None:
     """Stops the Foxglove WebSocket server and clears cached channels."""
-
     server = getattr(log_foxglove_data, "server", None)
     if server is not None:
         server.stop()
@@ -112,7 +110,6 @@ def _foxglove_safe_name(name: str) -> str:
     Foxglove treats ``.`` as a path separator, so an unsanitized name like ``observation.images.front``
     would split into nested segments instead of naming one topic.
     """
-
     return name.replace(".", "_")
 
 
@@ -123,7 +120,6 @@ def _foxglove_topic(key: str, *, is_image: bool = False) -> str:
     share one aggregate topic per source: ``/observation/state`` for observations, ``/action/state``
     for actions.
     """
-
     if is_image:
         name = str(key)
         for prefix in (f"{OBS_IMAGES}.", OBS_PREFIX):
@@ -147,7 +143,6 @@ def _log_foxglove_scalars(
     :func:`log_foxglove_data`; dataset playback passes its own local cache to stay self-contained).
     ``log_time`` is the message time in nanoseconds; when ``None`` the server's receive time is used.
     """
-
     if not values:
         return
 
@@ -167,7 +162,6 @@ def _log_foxglove_scalars(
 
 def _labeled_scalars(name: str, values, labels: list[str] | None = None) -> dict[str, float]:
     """Expand a 1D sequence into ``{label: value}`` entries with a consistent fallback."""
-
     flat = [float(v) for v in values]
     if labels is None or len(labels) != len(flat):
         labels = [f"{name}_{i}" for i in range(len(flat))]
@@ -206,7 +200,6 @@ def _log_foxglove_image(
             range, else the frame's own min/max is used. Ignored for ``mono8``/``rgb8``/``rgba8``.
         raw_depth_values: If True, depth values are not rescaled and are logged as is.
     """
-
     from foxglove.channels import CompressedImageChannel, RawImageChannel
     from foxglove.messages import CompressedImage, RawImage, Timestamp
 
@@ -285,8 +278,7 @@ def log_foxglove_data(
     action: RobotAction | None = None,
     compress_images: bool = False,
 ) -> None:
-    """
-    Logs observation and action data to a Foxglove WebSocket server for real-time visualization.
+    """Logs observation and action data to a Foxglove WebSocket server for real-time visualization.
 
     Mirrors ``log_rerun_data`` but emits Foxglove messages over the server started by
     :func:`init_foxglove`. Data is mapped as follows:
@@ -300,12 +292,11 @@ def log_foxglove_data(
       ``CompressedImage`` when ``compress_images`` is True).
 
     Args:
-        observation: An optional dictionary containing observation data to log.
-        action: An optional dictionary containing action data to log.
-        compress_images: Whether to JPEG-compress images before logging to save bandwidth in exchange
-            for CPU and quality.
+        observation (`dict[str, typing.Any] | None`, *optional*): Observation dict to log.
+        action (`dict[str, typing.Any] | None`, *optional*): Action dict to log.
+        compress_images (`bool`, *optional*, defaults to `False`): Whether to log images as JPEG
+            `CompressedImage` instead of raw `RawImage`.
     """
-
     require_package("foxglove-sdk", extra="viz", import_name="foxglove")
 
     if getattr(log_foxglove_data, "server", None) is None:
@@ -361,7 +352,6 @@ def _feature_dim_names(feature: dict | None) -> list[str] | None:
     (``{"delta_x": 0, "delta_y": 1}``). Each is handled, but labels are only returned when their count
     matches the feature's 1D shape, so a malformed/mismatched ``names`` can't silently mislabel series.
     """
-
     if not feature:
         return None
     shape = feature.get("shape")
@@ -389,7 +379,6 @@ def _frame_to_scalars(sample: dict, key: str, labels: list[str] | None = None) -
     live stream so series names agree. A scalar feature becomes a single entry. Missing or ``None``
     features yield an empty mapping.
     """
-
     v = sample.get(key)
     if v is None:
         return {}
@@ -422,15 +411,15 @@ def serve_foxglove_dataset_playback(
     their dataset timestamps, so the user can scrub anywhere in the episode. Blocks until interrupted.
 
     Args:
-        dataset: A ``LeRobotDataset`` loaded for the single episode to visualize.
-        episode_index: Index of the episode being visualized (used only for the session name).
-        host: Host interface to bind the WebSocket server to.
-        port: Port to bind the WebSocket server to.
-        compress_images: Whether to JPEG-compress camera frames before logging.
-        autoplay: If True, start playing automatically as soon as a client connects, instead of
-            waiting for the user to press play in the Foxglove app.
+        dataset (`LeRobotDataset`): Dataset to serve an episode from.
+        episode_index (`int`): Episode index to serve.
+        host (`str`, *optional*, defaults to `"127.0.0.1"`): Interface to bind the WebSocket server to.
+        port (`int`, *optional*, defaults to 8765): Port to bind the WebSocket server to.
+        compress_images (`bool`, *optional*, defaults to `False`): Whether to log images as JPEG
+            `CompressedImage` instead of raw `RawImage`.
+        autoplay (`bool`, *optional*, defaults to `True`): Whether playback starts automatically
+            once a client connects.
     """
-
     require_package("foxglove-sdk", extra="viz", import_name="foxglove")
     import bisect
     import threading
@@ -526,13 +515,17 @@ def serve_foxglove_dataset_playback(
     }
 
     def index_at(t_ns: int) -> int:
+        """Return the frame index whose timestamp is at or immediately before `t_ns`."""
         return max(0, min(n_frames - 1, bisect.bisect_right(times_ns, t_ns) - 1))
 
     # One-shot latch so autoplay fires only on the first client subscription.
     autoplay_started = threading.Event()
 
     class _PlaybackListener(ServerListener):
+        """Handles client subscription and playback-control requests from the Foxglove server."""
+
         def on_subscribe(self, client, channel):
+            """Start autoplay on the first client subscription, if `autoplay` is enabled."""
             # Start playing automatically once a client actually connects (subscribes). Using the
             # subscribe hook, rather than starting in Playing up front, means the timeline doesn't
             # advance before anyone is watching. Fires once; the user can still pause/seek after.
@@ -547,6 +540,11 @@ def serve_foxglove_dataset_playback(
             server.broadcast_playback_state(PlaybackState(PlaybackStatus.Playing, cursor, speed, False, ""))
 
         def on_playback_control_request(self, req: PlaybackControlRequest):
+            """Apply a seek/play/pause/speed request from the client to the shared playback state.
+
+            Returns:
+                `PlaybackState`: The resulting playback status, cursor, speed, and seek flag.
+            """
             # Only mutate state here; the playback loop performs all frame emission.
             with lock:
                 did_seek = False
@@ -580,6 +578,7 @@ def serve_foxglove_dataset_playback(
     )
 
     def playback_loop() -> None:
+        """Advance the playback cursor and emit frames at the configured speed, until stopped."""
         # Cap how far the cursor may advance in a single tick. A slow frame decode (or any stall)
         # would otherwise make ``dt`` huge and produce one enormous catch-up batch; clamping it makes
         # playback trail wall-clock under a slow decoder while each tick emits a bounded frame range.

--- a/src/lerobot/utils/hub.py
+++ b/src/lerobot/utils/hub.py
@@ -42,9 +42,9 @@ def find_latest_hub_checkpoint(
 
     Args:
         repo_id (str): The Hub model repo to inspect.
-        token (str | bool | None): Hub authentication token. Defaults to None (the token
+        token (str | bool | None, *optional*): Hub authentication token. Defaults to None (the token
             cached by `huggingface-cli login`).
-        revision (str | None): Repo revision to list. Defaults to None (the default branch).
+        revision (str | None, *optional*): Repo revision to list. Defaults to None (the default branch).
 
     Returns:
         str | None: The repo-relative path `checkpoints/<highest-step>`, or None if the repo
@@ -61,8 +61,7 @@ def find_latest_hub_checkpoint(
 
 
 class HubMixin:
-    """
-    A Mixin containing the functionality to push an object to the hub.
+    """A Mixin containing the functionality to push an object to the hub.
 
     This is similar to huggingface_hub.ModelHubMixin but is lighter and makes less assumptions about its
     subclasses (in particular, the fact that it's not necessarily a model).
@@ -79,8 +78,7 @@ class HubMixin:
         card_kwargs: dict[str, Any] | None = None,
         **push_to_hub_kwargs,
     ) -> str | None:
-        """
-        Save object in local directory.
+        """Save object in local directory.
 
         Args:
             save_directory (`str` or `Path`):
@@ -94,6 +92,7 @@ class HubMixin:
                 Additional arguments passed to the card template to customize the card.
             push_to_hub_kwargs:
                 Additional key word arguments passed along to the [`~HubMixin.push_to_hub`] method.
+
         Returns:
             `str` or `None`: url of the commit on the Hub if `push_to_hub=True`, `None` otherwise.
         """
@@ -111,8 +110,7 @@ class HubMixin:
         return None
 
     def _save_pretrained(self, save_directory: Path) -> None:
-        """
-        Overwrite this method in subclass to define how to save your object.
+        """Overwrite this method in subclass to define how to save your object.
 
         Args:
             save_directory (`str` or `Path`):
@@ -135,8 +133,7 @@ class HubMixin:
         revision: str | None = None,
         **kwargs,
     ) -> T:
-        """
-        Download the object from the Huggingface Hub and instantiate it.
+        """Download the object from the Huggingface Hub and instantiate it.
 
         Args:
             pretrained_name_or_path (`str`, `Path`):
@@ -148,6 +145,9 @@ class HubMixin:
                 Defaults to the latest commit on `main` branch.
             force_download (`bool`, *optional*, defaults to `False`):
                 Whether to force (re-)downloading the files from the Hub, overriding the existing cache.
+            resume_download (`bool`, *optional*):
+                Deprecated by `huggingface_hub`; downloads always resume when possible. Kept for
+                backward compatibility with callers that still pass it.
             proxies (`Dict[str, str]`, *optional*):
                 A dictionary of proxy servers to use by protocol or endpoint, e.g., `{'http': 'foo.bar:3128',
                 'http://hostname': 'foo.bar:4012'}`. The proxies are used on every request.
@@ -178,8 +178,7 @@ class HubMixin:
         delete_patterns: list[str] | str | None = None,
         card_kwargs: dict[str, Any] | None = None,
     ) -> str | None:
-        """
-        Upload model checkpoint to the Hub.
+        """Upload model checkpoint to the Hub.
 
         Use `allow_patterns` and `ignore_patterns` to precisely filter which files should be pushed to the hub. Use
         `delete_patterns` to delete existing remote files in the same commit. See [`upload_folder`] reference for more

--- a/src/lerobot/utils/import_utils.py
+++ b/src/lerobot/utils/import_utils.py
@@ -24,14 +24,14 @@ from draccus.choice_types import ChoiceRegistry
 def is_package_available(
     pkg_name: str, import_name: str | None = None, return_version: bool = False
 ) -> tuple[bool, str] | bool:
-    """
-    Check if the package spec exists and grab its version to avoid importing a local directory.
+    """Check if the package spec exists and grab its version to avoid importing a local directory.
 
     Args:
-        pkg_name: The name of the package as installed via pip (e.g. "python-can").
-        import_name: The actual name used to import the package (e.g. "can").
-                     Defaults to pkg_name if not provided.
-        return_version: Whether to return the version string.
+        pkg_name (`str`): Distribution name to look up the version for, e.g. `"torch"`.
+        import_name (`str | None`, *optional*): Module name to check importability of, when it
+            differs from `pkg_name`. Defaults to `pkg_name`.
+        return_version (`bool`, *optional*, defaults to `False`): Whether to also return the
+            detected version string.
     """
     if import_name is None:
         import_name = pkg_name
@@ -70,6 +70,11 @@ def is_package_available(
 
 
 def get_safe_default_video_backend():
+    """Return `"torchcodec"` if installed and loadable, else `"pyav"`.
+
+    Returns:
+        `str`: `"torchcodec"` or `"pyav"`.
+    """
     logger = logging.getLogger(__name__)
     if importlib.util.find_spec("torchcodec"):
         # Despite being installed, torchcodec may not be loadable at runtime.
@@ -156,8 +161,7 @@ _wallx_deps_available = (
 
 
 def make_device_from_device_class(config: ChoiceRegistry) -> Any:
-    """
-    Dynamically instantiates an object from its `ChoiceRegistry` configuration.
+    """Dynamically instantiates an object from its `ChoiceRegistry` configuration.
 
     This factory uses the module path and class name from the `config` object's
     type to locate and instantiate the corresponding device class (not the config).
@@ -221,8 +225,7 @@ def make_device_from_device_class(config: ChoiceRegistry) -> Any:
 
 
 def register_third_party_plugins() -> None:
-    """
-    Discover and import third-party LeRobot plugins so they can register themselves.
+    """Discover and import third-party LeRobot plugins so they can register themselves.
 
     This function uses `importlib.metadata` to find packages installed in the environment
     (including editable installs) starting with 'lerobot_robot_', 'lerobot_camera_',
@@ -239,6 +242,7 @@ def register_third_party_plugins() -> None:
     failed: list[str] = []
 
     def attempt_import(module_name: str):
+        """Import `module_name`, recording it as imported or failed."""
         try:
             importlib.import_module(module_name)
             imported.append(module_name)

--- a/src/lerobot/utils/io_utils.py
+++ b/src/lerobot/utils/io_utils.py
@@ -42,8 +42,8 @@ def write_json(data: JsonLike, fpath: Path) -> None:
     Creates parent directories if they don't exist.
 
     Args:
-        data: JSON-serializable data to write.
-        fpath (Path): The path to the output JSON file.
+        data (`JsonLike`): Data to serialize.
+        fpath (`Path`): The path to the output JSON file.
     """
     fpath.parent.mkdir(exist_ok=True, parents=True)
     with open(fpath, "w", encoding="utf-8") as f:
@@ -54,9 +54,9 @@ def write_video(video_path: str | Path, stacked_frames: list, fps: int) -> None:
     """Write a sequence of RGB frames to an MP4 video file using libx264.
 
     Args:
-        video_path: Output file path.
-        stacked_frames: List of HWC uint8 numpy arrays (RGB).
-        fps: Frames per second for the output video.
+        video_path (`str | pathlib.Path`): Output file path.
+        stacked_frames (`list`): RGB frames, each an `(H, W, 3)` array.
+        fps (`int`): Frame rate to encode at.
     """
     from .import_utils import require_package
 
@@ -91,22 +91,20 @@ def write_video(video_path: str | Path, stacked_frames: list, fps: int) -> None:
 
 
 def deserialize_json_into_object[T: JsonLike](fpath: Path, obj: T) -> T:
-    """
-    Loads the JSON data from `fpath` and recursively fills `obj` with the
-    corresponding values (strictly matching structure and types).
-    Tuples in `obj` are expected to be lists in the JSON data, which will be
-    converted back into tuples.
+    """Load the JSON data from `fpath` and recursively fill `obj` with the corresponding values.
+
+    Strictly matches structure and types. Tuples in `obj` are expected to be lists in the JSON
+    data, which are converted back into tuples.
     """
     with open(fpath, encoding="utf-8") as f:
         data = json.load(f)
 
     def _deserialize(target, source):
-        """
-        Recursively overwrite the structure in `target` with data from `source`,
-        performing strict checks on structure and type.
-        Returns the updated version of `target` (especially important for tuples).
-        """
+        """Recursively overwrite `target`'s structure with data from `source`.
 
+        Performs strict checks on structure and type. Returns the updated version of `target`
+        (especially important for tuples).
+        """
         # If the target is a dictionary, source must be a dictionary as well.
         if isinstance(target, dict):
             if not isinstance(source, dict):

--- a/src/lerobot/utils/keyboard_input.py
+++ b/src/lerobot/utils/keyboard_input.py
@@ -198,15 +198,13 @@ class TerminalKeyListener:
     crash or Ctrl-C never leaves the shell in a no-echo cbreak state. POSIX-only
     (``termios`` / ``tty`` / ``select``); those modules are imported lazily so this
     file stays importable on Windows (where ``pynput`` is used instead).
+
+    Args:
+        on_key (`Callable[[str], None]`): Called with each decoded key name once `start()`
+            begins reading. Runs on the reader thread.
     """
 
     def __init__(self, on_key: Callable[[str], None]):
-        """Initialize the listener.
-
-        Args:
-            on_key (`Callable[[str], None]`): Called with each decoded key name once `start()`
-                begins reading. Runs on the reader thread.
-        """
         self._on_key = on_key
         self._running = False
         self._thread: threading.Thread | None = None

--- a/src/lerobot/utils/keyboard_input.py
+++ b/src/lerobot/utils/keyboard_input.py
@@ -201,6 +201,12 @@ class TerminalKeyListener:
     """
 
     def __init__(self, on_key: Callable[[str], None]):
+        """Initialize the listener.
+
+        Args:
+            on_key (`Callable[[str], None]`): Called with each decoded key name once `start()`
+                begins reading. Runs on the reader thread.
+        """
         self._on_key = on_key
         self._running = False
         self._thread: threading.Thread | None = None
@@ -248,6 +254,7 @@ class TerminalKeyListener:
         return None
 
     def _run(self) -> None:
+        """Read and decode key bytes from the TTY in a loop, dispatching to `self._on_key`."""
         while self._running:
             ch = self._read_char(timeout=0.05)
             if ch is None:
@@ -361,6 +368,7 @@ def create_key_listener(dispatch: Callable[[str], None], *, controls_help: str =
     if pynput_can_capture() and keyboard is not None:
 
         def on_press(key):
+            """Resolve a pynput key event to its canonical name and forward it to `dispatch`."""
             with contextlib.suppress(Exception):
                 name = _resolve_pynput_key(key)
                 if name is not None:
@@ -427,6 +435,7 @@ def init_keyboard_listener():
     # letters are immune to the escape-sequence split/delay/interception that affects arrows
     # over laggy SSH/VNC links. Case-insensitive so Shift+letter still works.
     def on_key(name: str) -> None:
+        """Map a decoded key name (arrow or letter equivalent) to a recording control."""
         key = name.lower()
         if key in ("right", "n"):
             apply_recording_control("right", events)

--- a/src/lerobot/utils/logging_utils.py
+++ b/src/lerobot/utils/logging_utils.py
@@ -37,14 +37,12 @@ class AverageMeter:
             `"max"`, `"mean"`, or `"sum"`. Use `"max"` for bottleneck-style metrics (e.g.
             dataloading or update wall time) so multi-GPU runs report the slowest rank rather than
             rank 0.
+
+    Raises:
+        ValueError: If `reduction` isn't one of `"none"`, `"max"`, `"mean"`, `"sum"`.
     """
 
     def __init__(self, name: str, fmt: str = ":f", reduction: str = "none"):
-        """Initialize the meter and reset it to zero.
-
-        Raises:
-            ValueError: If `reduction` isn't one of `"none"`, `"max"`, `"mean"`, `"sum"`.
-        """
         if reduction not in _VALID_REDUCTIONS:
             raise ValueError(
                 f"Invalid reduction {reduction!r} for AverageMeter; expected one of {_VALID_REDUCTIONS}."
@@ -148,7 +146,6 @@ class MetricsTracker:
         initial_step: int = 0,
         dp_world_size: int = 1,
     ):
-        """Initialize the tracker's step/sample/episode/epoch counters from `initial_step`."""
         self.__dict__.update(dict.fromkeys(self.__keys__))
         self._batch_size = batch_size
         self._num_frames = num_frames

--- a/src/lerobot/utils/logging_utils.py
+++ b/src/lerobot/utils/logging_utils.py
@@ -25,20 +25,26 @@ _VALID_REDUCTIONS = ("none", "max", "mean", "sum")
 
 
 class AverageMeter:
-    """
-    Computes and stores the average and current value
+    """Computes and stores the average and current value.
+
     Adapted from https://github.com/pytorch/examples/blob/main/imagenet/main.py
 
     Args:
-        name: Display name of the metric.
-        fmt: Format string used when rendering the metric.
-        reduction: Cross-process reduction applied by :meth:`MetricsTracker.reduce_across_ranks`
-            before logging. One of ``"none"`` (per-rank value, default), ``"max"``, ``"mean"``,
-            or ``"sum"``. Use ``"max"`` for bottleneck-style metrics (e.g. dataloading or
-            update wall time) so multi-GPU runs report the slowest rank rather than rank 0.
+        name (`str`): Display name of the metric.
+        fmt (`str`, *optional*, defaults to `":f"`): Format string used when rendering the metric.
+        reduction (`str`, *optional*, defaults to `"none"`): Cross-process reduction applied by
+            `MetricsTracker.reduce_across_ranks` before logging. One of `"none"` (per-rank value),
+            `"max"`, `"mean"`, or `"sum"`. Use `"max"` for bottleneck-style metrics (e.g.
+            dataloading or update wall time) so multi-GPU runs report the slowest rank rather than
+            rank 0.
     """
 
     def __init__(self, name: str, fmt: str = ":f", reduction: str = "none"):
+        """Initialize the meter and reset it to zero.
+
+        Raises:
+            ValueError: If `reduction` isn't one of `"none"`, `"max"`, `"mean"`, `"sum"`.
+        """
         if reduction not in _VALID_REDUCTIONS:
             raise ValueError(
                 f"Invalid reduction {reduction!r} for AverageMeter; expected one of {_VALID_REDUCTIONS}."
@@ -49,37 +55,44 @@ class AverageMeter:
         self.reset()
 
     def reset(self) -> None:
+        """Reset `val`/`avg`/`sum`/`count` to zero."""
         self.val = 0.0
         self.avg = 0.0
         self.sum = 0.0
         self.count = 0.0
 
     def update(self, val: float, n: int = 1) -> None:
+        """Accumulate one observation into the running sum/count/average.
+
+        Args:
+            val (`float`): Observed value.
+            n (`int`, *optional*, defaults to 1): Weight (e.g. batch size) of this observation.
+        """
         self.val = val
         self.sum += val * n
         self.count += n
         self.avg = self.sum / self.count
 
     def __str__(self):
+        """Render as `"<name>:<avg>"`, formatted with `self.fmt`."""
         fmtstr = "{name}:{avg" + self.fmt + "}"
         return fmtstr.format(**self.__dict__)
 
 
 class MetricsTracker:
-    """
-    A helper class to track and log metrics over time.
+    """A helper class to track and log metrics over time.
 
     Args:
-        batch_size (int): Per-process batch size (samples per micro-batch on each
+        batch_size (`int`): Per-process batch size (samples per micro-batch on each
             data-parallel worker).
-        num_frames (int): Total number of frames in the training dataset.
-        num_episodes (int): Total number of episodes in the training dataset.
-        metrics (dict[str, AverageMeter]): The meters to track, keyed by metric name.
-        initial_step (int): Step counter to start from (non-zero when resuming a run).
-            Defaults to 0.
-        dp_world_size (int): Number of distinct data-parallel workers
+        num_frames (`int`): Total number of frames in the training dataset.
+        num_episodes (`int`): Total number of episodes in the training dataset.
+        metrics (`dict[str, AverageMeter]`): The meters to track, keyed by metric name.
+        initial_step (`int`, *optional*, defaults to 0): Step counter to start from (non-zero when
+            resuming a run).
+        dp_world_size (`int`, *optional*, defaults to 1): Number of distinct data-parallel workers
             (`dp_replicate * dp_shard`), used to scale sample accounting; context-parallel
-            peers consume the same batch and must not be double counted. Defaults to 1.
+            peers consume the same batch and must not be double counted.
 
     Usage pattern:
 
@@ -135,6 +148,7 @@ class MetricsTracker:
         initial_step: int = 0,
         dp_world_size: int = 1,
     ):
+        """Initialize the tracker's step/sample/episode/epoch counters from `initial_step`."""
         self.__dict__.update(dict.fromkeys(self.__keys__))
         self._batch_size = batch_size
         self._num_frames = num_frames
@@ -157,6 +171,11 @@ class MetricsTracker:
         self._caller_metrics: set[str] = set(self.metrics)
 
     def __getattr__(self, name: str) -> int | dict[str, AverageMeter] | AverageMeter | Any:
+        """Fall back to `self.metrics[name]` for attributes not in `self.__dict__`.
+
+        Raises:
+            AttributeError: If `name` is in neither `self.__dict__` nor `self.metrics`.
+        """
         if name in self.__dict__:
             return self.__dict__[name]
         elif name in self.metrics:
@@ -165,6 +184,11 @@ class MetricsTracker:
             raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{name}'")
 
     def __setattr__(self, name: str, value: Any) -> None:
+        """Route assignment to a tracked metric name into `self.metrics[name].update(value)`.
+
+        Raises:
+            AttributeError: If `name` is in neither `self.__dict__` nor `self.metrics`.
+        """
         if name in self.__dict__:
             super().__setattr__(name, value)
         elif name in self.metrics:
@@ -173,9 +197,7 @@ class MetricsTracker:
             raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{name}'")
 
     def step(self) -> None:
-        """
-        Updates metrics that depend on 'step' for one step.
-        """
+        """Update metrics that depend on 'step' for one step."""
         self.steps += 1
         self.samples += self._batch_size * self._dp_world_size
         self.episodes = self.samples / self._avg_samples_per_ep
@@ -197,11 +219,10 @@ class MetricsTracker:
             self.metrics[name].update(float(value))
 
     def reduce_across_ranks(self) -> None:
-        """
-        Synchronises the running averages of every metric whose ``reduction`` is not ``"none"``
-        across all distributed processes (in-place).
+        """Synchronize the running averages of every non-`"none"`-reduction metric, in-place.
 
-        This is a collective operation and MUST be invoked on every rank — typically just before
+        Synchronizes across all distributed processes. This is a collective operation and MUST
+        be invoked on every rank — typically just before
         logging. Outside distributed runs it is a no-op. Without it, metrics reported by the
         main process only reflect rank 0; for bottleneck-style timings (``dataloading_s``,
         ``update_s``, ...) that means the slowest worker's stall is invisible.
@@ -242,6 +263,7 @@ class MetricsTracker:
                 meter.sum = value * meter.count
 
     def __str__(self) -> str:
+        """Render step/samples/episodes/epochs plus every tracked metric as one line."""
         display_list = [
             f"step:{format_big_number(self.steps)}",
             # number of samples seen during training
@@ -255,9 +277,7 @@ class MetricsTracker:
         return " ".join(display_list)
 
     def to_dict(self, use_avg: bool = True) -> dict[str, int | float]:
-        """
-        Returns the current metric values (or averages if `use_avg=True`) as a dict.
-        """
+        """Return the current metric values (or averages if `use_avg=True`) as a dict."""
         return {
             "steps": self.steps,
             "samples": self.samples,

--- a/src/lerobot/utils/pedal.py
+++ b/src/lerobot/utils/pedal.py
@@ -37,19 +37,16 @@ def start_pedal_listener(
 ) -> threading.Thread | None:
     """Spawn a daemon thread that forwards pedal key-press codes to ``on_press``.
 
-    Parameters
-    ----------
-    on_press:
-        Callback invoked with the pressed key code string (e.g. ``"KEY_A"``)
-        on each pedal press event.  The callback runs in the listener thread
-        and must be thread-safe.
-    device_path:
-        Linux input device path (e.g. ``/dev/input/by-id/...``).
+    Args:
+        on_press (`Callable[[str], None]`): Callback invoked with the pressed key code string
+            (e.g. `"KEY_A"`) on each pedal press event. Runs in the listener thread and must be
+            thread-safe.
+        device_path (`str`, *optional*, defaults to `"/dev/input/by-id/usb-PCsensor_FootSwitch-event-kbd"`): Linux input device
+            path (e.g. `/dev/input/by-id/...`).
 
-    Returns
-    -------
-    The started daemon :class:`threading.Thread`, or ``None`` when
-    :mod:`evdev` is not installed (optional dependency; silent no-op).
+    Returns:
+        `threading.Thread | None`: The started daemon thread, or `None` when `evdev` is not
+            installed (optional dependency; silent no-op).
     """
     try:
         from evdev import InputDevice, categorize, ecodes
@@ -57,6 +54,7 @@ def start_pedal_listener(
         return None
 
     def pedal_reader() -> None:
+        """Read pedal key events from `device_path` in a loop, forwarding presses to `on_press`."""
         try:
             dev = InputDevice(device_path)
             logger.info("Pedal connected: %s", dev.name)

--- a/src/lerobot/utils/process.py
+++ b/src/lerobot/utils/process.py
@@ -55,19 +55,17 @@ class ProcessSignalHandler:
     The class exposes a shutdown_event attribute that is set when a shutdown
     signal is received. A counter tracks how many shutdown signals have been
     caught. On the second signal the process exits with status 1.
+
+    Args:
+        use_threads (`bool`): Whether `shutdown_event` should be a `threading.Event` (`True`) or a
+            `multiprocessing.Event` (`False`).
+        display_pid (`bool`, *optional*, defaults to `False`): Whether to prefix shutdown log
+            messages with the process's PID.
     """
 
     _SUPPORTED_SIGNALS = ("SIGINT", "SIGTERM", "SIGHUP", "SIGQUIT")
 
     def __init__(self, use_threads: bool, display_pid: bool = False):
-        """Register shutdown signal handlers.
-
-        Args:
-            use_threads (`bool`): Whether `shutdown_event` should be a `threading.Event` (`True`)
-                or a `multiprocessing.Event` (`False`).
-            display_pid (`bool`, *optional*, defaults to `False`): Whether to prefix shutdown log
-                messages with the process's PID.
-        """
         # TODO: Check if we can use Event from threading since Event from
         # multiprocessing is the a clone of threading.Event.
         # https://docs.python.org/3/library/multiprocessing.html#multiprocessing.Event

--- a/src/lerobot/utils/process.py
+++ b/src/lerobot/utils/process.py
@@ -60,6 +60,14 @@ class ProcessSignalHandler:
     _SUPPORTED_SIGNALS = ("SIGINT", "SIGTERM", "SIGHUP", "SIGQUIT")
 
     def __init__(self, use_threads: bool, display_pid: bool = False):
+        """Register shutdown signal handlers.
+
+        Args:
+            use_threads (`bool`): Whether `shutdown_event` should be a `threading.Event` (`True`)
+                or a `multiprocessing.Event` (`False`).
+            display_pid (`bool`, *optional*, defaults to `False`): Whether to prefix shutdown log
+                messages with the process's PID.
+        """
         # TODO: Check if we can use Event from threading since Event from
         # multiprocessing is the a clone of threading.Event.
         # https://docs.python.org/3/library/multiprocessing.html#multiprocessing.Event
@@ -83,6 +91,7 @@ class ProcessSignalHandler:
         """Attach the internal _signal_handler to a subset of POSIX signals."""
 
         def _signal_handler(signum, frame):
+            """Set `self.shutdown_event`, and force-exit on a second signal."""
             pid_str = ""
             if self._display_pid:
                 pid_str = f"[PID: {os.getpid()}]"

--- a/src/lerobot/utils/random_utils.py
+++ b/src/lerobot/utils/random_utils.py
@@ -28,10 +28,7 @@ from .utils import flatten_dict, unflatten_dict
 
 
 def serialize_python_rng_state() -> dict[str, torch.Tensor]:
-    """
-    Returns the rng state for `random` in the form of a flat dict[str, torch.Tensor] to be saved using
-    `safetensors.save_file()` or `torch.save()`.
-    """
+    """Return `random`'s rng state as a flat `dict[str, torch.Tensor]`, saveable via safetensors."""
     py_state = random.getstate()
     return {
         "py_rng_version": torch.tensor([py_state[0]], dtype=torch.int64),
@@ -40,18 +37,13 @@ def serialize_python_rng_state() -> dict[str, torch.Tensor]:
 
 
 def deserialize_python_rng_state(rng_state_dict: dict[str, torch.Tensor]) -> None:
-    """
-    Restores the rng state for `random` from a dictionary produced by `serialize_python_rng_state()`.
-    """
+    """Restore `random`'s rng state from a dict produced by `serialize_python_rng_state`."""
     py_state = (rng_state_dict["py_rng_version"].item(), tuple(rng_state_dict["py_rng_state"].tolist()), None)
     random.setstate(py_state)
 
 
 def serialize_numpy_rng_state() -> dict[str, torch.Tensor]:
-    """
-    Returns the rng state for `numpy` in the form of a flat dict[str, torch.Tensor] to be saved using
-    `safetensors.save_file()` or `torch.save()`.
-    """
+    """Return `numpy`'s rng state as a flat `dict[str, torch.Tensor]`, saveable via safetensors."""
     np_state = np.random.get_state()
     # Ensure no breaking changes from numpy
     assert np_state[0] == "MT19937"
@@ -64,9 +56,7 @@ def serialize_numpy_rng_state() -> dict[str, torch.Tensor]:
 
 
 def deserialize_numpy_rng_state(rng_state_dict: dict[str, torch.Tensor]) -> None:
-    """
-    Restores the rng state for `numpy` from a dictionary produced by `serialize_numpy_rng_state()`.
-    """
+    """Restore `numpy`'s rng state from a dict produced by `serialize_numpy_rng_state`."""
     np_state = (
         "MT19937",
         rng_state_dict["np_rng_state_values"].numpy(),
@@ -78,10 +68,7 @@ def deserialize_numpy_rng_state(rng_state_dict: dict[str, torch.Tensor]) -> None
 
 
 def serialize_torch_rng_state() -> dict[str, torch.Tensor]:
-    """
-    Returns the rng state for `torch` in the form of a flat dict[str, torch.Tensor] to be saved using
-    `safetensors.save_file()` or `torch.save()`.
-    """
+    """Return `torch`'s rng state as a flat `dict[str, torch.Tensor]`, saveable via safetensors."""
     torch_rng_state_dict = {"torch_rng_state": torch.get_rng_state()}
     if torch.cuda.is_available():
         torch_rng_state_dict["torch_cuda_rng_state"] = torch.cuda.get_rng_state()
@@ -91,9 +78,7 @@ def serialize_torch_rng_state() -> dict[str, torch.Tensor]:
 
 
 def deserialize_torch_rng_state(rng_state_dict: dict[str, torch.Tensor]) -> None:
-    """
-    Restores the rng state for `torch` from a dictionary produced by `serialize_torch_rng_state()`.
-    """
+    """Restore `torch`'s rng state from a dict produced by `serialize_torch_rng_state`."""
     torch.set_rng_state(rng_state_dict["torch_rng_state"])
     if torch.cuda.is_available() and "torch_cuda_rng_state" in rng_state_dict:
         torch.cuda.set_rng_state(rng_state_dict["torch_cuda_rng_state"])
@@ -102,9 +87,9 @@ def deserialize_torch_rng_state(rng_state_dict: dict[str, torch.Tensor]) -> None
 
 
 def serialize_rng_state() -> dict[str, torch.Tensor]:
-    """
-    Returns the rng state for `random`, `numpy`, and `torch`, in the form of a flat
-    dict[str, torch.Tensor] to be saved using `safetensors.save_file()` `torch.save()`.
+    """Return `random`/`numpy`/`torch`'s rng state as a flat `dict[str, torch.Tensor]`.
+
+    Saveable via safetensors.
     """
     py_rng_state_dict = serialize_python_rng_state()
     np_rng_state_dict = serialize_numpy_rng_state()
@@ -118,10 +103,7 @@ def serialize_rng_state() -> dict[str, torch.Tensor]:
 
 
 def deserialize_rng_state(rng_state_dict: dict[str, torch.Tensor]) -> None:
-    """
-    Restores the rng state for `random`, `numpy`, and `torch` from a dictionary produced by
-    `serialize_rng_state()`.
-    """
+    """Restore `random`/`numpy`/`torch`'s rng state from a dict produced by `serialize_rng_state`."""
     py_rng_state_dict = {k: v for k, v in rng_state_dict.items() if k.startswith("py")}
     np_rng_state_dict = {k: v for k, v in rng_state_dict.items() if k.startswith("np")}
     torch_rng_state_dict = {k: v for k, v in rng_state_dict.items() if k.startswith("torch")}
@@ -132,12 +114,22 @@ def deserialize_rng_state(rng_state_dict: dict[str, torch.Tensor]) -> None:
 
 
 def save_rng_state(save_dir: Path) -> None:
+    """Serialize and save `random`/`numpy`/`torch` RNG state to `save_dir`.
+
+    Args:
+        save_dir (`Path`): Directory to write the RNG state safetensors file to.
+    """
     rng_state_dict = serialize_rng_state()
     flat_rng_state_dict = flatten_dict(rng_state_dict)
     save_file(flat_rng_state_dict, save_dir / RNG_STATE)
 
 
 def load_rng_state(save_dir: Path) -> None:
+    """Restore `random`/`numpy`/`torch` RNG state from `save_dir`, as saved by `save_rng_state`.
+
+    Args:
+        save_dir (`Path`): Directory the RNG state safetensors file was saved to.
+    """
     flat_rng_state_dict = load_file(save_dir / RNG_STATE)
     rng_state_dict = unflatten_dict(flat_rng_state_dict)
     deserialize_rng_state(rng_state_dict)
@@ -159,7 +151,7 @@ def set_rng_state(random_state_dict: dict[str, Any]):
     """Set the random state for `random`, `numpy`, and `torch`.
 
     Args:
-        random_state_dict: A dictionary of the form returned by `get_rng_state`.
+        random_state_dict (`dict[str, Any]`): A dictionary of the form returned by `get_rng_state`.
     """
     random.setstate(random_state_dict["random_state"])
     np.random.set_state(random_state_dict["numpy_random_state"])

--- a/src/lerobot/utils/rerun_visualization.py
+++ b/src/lerobot/utils/rerun_visualization.py
@@ -32,6 +32,7 @@ from .import_utils import require_package
 
 
 def _is_scalar(x):
+    """Whether `x` is a Python/NumPy scalar number, or a zero-dimensional NumPy array."""
     return isinstance(x, (float | numbers.Real | np.integer | np.floating)) or (
         isinstance(x, np.ndarray) and x.ndim == 0
     )
@@ -40,15 +41,14 @@ def _is_scalar(x):
 def init_rerun(
     session_name: str = "lerobot_control_loop", ip: str | None = None, port: int | None = None
 ) -> None:
-    """
-    Initializes the Rerun SDK for visualizing the control loop.
+    """Initializes the Rerun SDK for visualizing the control loop.
 
     Args:
-        session_name: Name of the Rerun session.
-        ip: Optional IP for connecting to a Rerun server.
-        port: Optional port for connecting to a Rerun server.
+        session_name (`str`, *optional*, defaults to `"lerobot_control_loop"`): Name of the Rerun
+            session.
+        ip (`str | None`, *optional*): IP for connecting to a Rerun server.
+        port (`int | None`, *optional*): Port for connecting to a Rerun server.
     """
-
     require_package("rerun-sdk", extra="viz", import_name="rerun")
     import rerun as rr
 
@@ -66,7 +66,6 @@ def init_rerun(
 
 def shutdown_rerun() -> None:
     """Shuts down the Rerun SDK gracefully."""
-
     require_package("rerun-sdk", extra="viz", import_name="rerun")
     import rerun as rr
 
@@ -78,7 +77,6 @@ def _build_blueprint(observation_paths: set[str], action_paths: set[str], image_
 
     Camera images, observation and action scalars are arranged in a grid.
     """
-
     # Safe + zero-overhead: `log_rerun_data` already ran the `require_package` guard and imported rerun.
     import rerun.blueprint as rrb
 
@@ -113,8 +111,7 @@ def log_rerun_data(
     action: RobotAction | None = None,
     compress_images: bool = False,
 ) -> None:
-    """
-    Logs observation and action data to Rerun for real-time visualization.
+    """Logs observation and action data to Rerun for real-time visualization.
 
     This function iterates through the provided observation and action dictionaries and sends their contents
     to the Rerun viewer. It handles different data types appropriately:
@@ -131,11 +128,11 @@ def log_rerun_data(
     time-series views and each image gets its own spatial view.
 
     Args:
-        observation: An optional dictionary containing observation data to log.
-        action: An optional dictionary containing action data to log.
-        compress_images: Whether to compress images before logging to save bandwidth & memory in exchange for cpu and quality.
+        observation (`dict[str, typing.Any] | None`, *optional*): Observation dict to log.
+        action (`dict[str, typing.Any] | None`, *optional*): Action dict to log.
+        compress_images (`bool`, *optional*, defaults to `False`): Whether to log images as
+            compressed JPEG instead of raw.
     """
-
     require_package("rerun-sdk", extra="viz", import_name="rerun")
     import rerun as rr
 

--- a/src/lerobot/utils/robot_utils.py
+++ b/src/lerobot/utils/robot_utils.py
@@ -17,13 +17,14 @@ import time
 
 
 def precise_sleep(seconds: float, spin_threshold: float = 0.010, sleep_margin: float = 0.005):
-    """
-    Wait for `seconds` with better precision than time.sleep alone at the expense of more CPU usage.
+    """Wait for `seconds` with better precision than time.sleep alone at the expense of more CPU usage.
 
-    Parameters:
-      - seconds: duration to wait
-      - spin_threshold: if remaining <= spin_threshold -> spin; otherwise sleep (seconds). Default 10ms
-      - sleep_margin: when sleeping leave this much time before deadline to avoid oversleep. Default 5ms
+    Args:
+        seconds (`float`): Duration to wait, in seconds.
+        spin_threshold (`float`, *optional*, defaults to 0.01): Below this many seconds remaining,
+            spin-wait instead of sleeping, for tighter timing accuracy.
+        sleep_margin (`float`, *optional*, defaults to 0.005): Seconds left un-slept before the
+            spin phase, to avoid oversleeping past the target.
 
     Note:
         The default parameters are chosen to prioritize timing accuracy over CPU usage for the common 30 FPS use case.

--- a/src/lerobot/utils/rotation.py
+++ b/src/lerobot/utils/rotation.py
@@ -20,8 +20,7 @@ import numpy as np
 
 
 class Rotation:
-    """
-    Custom rotation class that provides a subset of scipy.spatial.transform.Rotation functionality.
+    """Custom rotation class that provides a subset of scipy.spatial.transform.Rotation functionality.
 
     Supports conversions between rotation vectors, rotation matrices, and quaternions.
     """
@@ -39,8 +38,7 @@ class Rotation:
 
     @classmethod
     def from_rotvec(cls, rotvec: np.ndarray) -> "Rotation":
-        """
-        Create rotation from rotation vector using Rodrigues' formula.
+        """Create rotation from rotation vector using Rodrigues' formula.
 
         Args:
             rotvec: Rotation vector [x, y, z] where magnitude is angle in radians
@@ -67,8 +65,7 @@ class Rotation:
 
     @classmethod
     def from_matrix(cls, matrix: np.ndarray) -> "Rotation":
-        """
-        Create rotation from 3x3 rotation matrix.
+        """Create rotation from 3x3 rotation matrix.
 
         Args:
             matrix: 3x3 rotation matrix
@@ -111,8 +108,7 @@ class Rotation:
 
     @classmethod
     def from_quat(cls, quat: np.ndarray) -> "Rotation":
-        """
-        Create rotation from quaternion.
+        """Create rotation from quaternion.
 
         Args:
             quat: Quaternion [x, y, z, w] or [w, x, y, z] (specify convention in docstring)
@@ -124,8 +120,7 @@ class Rotation:
         return cls(quat)
 
     def as_matrix(self) -> np.ndarray:
-        """
-        Convert rotation to 3x3 rotation matrix.
+        """Convert rotation to 3x3 rotation matrix.
 
         Returns:
             3x3 rotation matrix
@@ -143,8 +138,7 @@ class Rotation:
         )
 
     def as_rotvec(self) -> np.ndarray:
-        """
-        Convert rotation to rotation vector.
+        """Convert rotation to rotation vector.
 
         Returns:
             Rotation vector [x, y, z] where magnitude is angle in radians
@@ -168,8 +162,7 @@ class Rotation:
         return angle * axis
 
     def as_quat(self) -> np.ndarray:
-        """
-        Get quaternion representation.
+        """Get quaternion representation.
 
         Returns:
             Quaternion [x, y, z, w]
@@ -177,8 +170,7 @@ class Rotation:
         return self._quat.copy()
 
     def apply(self, vectors: np.ndarray, inverse: bool = False) -> np.ndarray:
-        """
-        Apply this rotation to a set of vectors.
+        """Apply this rotation to a set of vectors.
 
         This is equivalent to applying the rotation matrix to the vectors:
         self.as_matrix() @ vectors (or self.as_matrix().T @ vectors if inverse=True).
@@ -225,8 +217,7 @@ class Rotation:
         return rotated_vectors
 
     def inv(self) -> "Rotation":
-        """
-        Invert this rotation.
+        """Invert this rotation.
 
         Composition of a rotation with its inverse results in an identity transformation.
 
@@ -241,8 +232,7 @@ class Rotation:
         return Rotation(inverse_quat)
 
     def __mul__(self, other: "Rotation") -> "Rotation":
-        """
-        Compose this rotation with another rotation using the * operator.
+        """Compose this rotation with another rotation using the * operator.
 
         The composition `r2 * r1` means "apply r1 first, then r2".
         This is equivalent to applying rotation matrices: r2.as_matrix() @ r1.as_matrix()

--- a/src/lerobot/utils/sample_weighting.py
+++ b/src/lerobot/utils/sample_weighting.py
@@ -197,6 +197,9 @@ class UniformWeighter(SampleWeighter):
     Useful as a baseline or when you want to disable weighting without
     changing the training code structure.
 
+    Args:
+        device (`torch.device`): Device to allocate weight tensors on.
+
     Note:
         Batch size is determined by looking for tensor values in the batch
         dictionary. The method checks common keys like "action", "index",
@@ -204,11 +207,6 @@ class UniformWeighter(SampleWeighter):
     """
 
     def __init__(self, device: torch.device):
-        """Initialize the weighter.
-
-        Args:
-            device (`torch.device`): Device to allocate weight tensors on.
-        """
         self.device = device
 
     def compute_batch_weights(self, batch: dict) -> tuple[torch.Tensor, dict]:

--- a/src/lerobot/utils/sample_weighting.py
+++ b/src/lerobot/utils/sample_weighting.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Sample weighting abstraction for training.
+"""Sample weighting abstraction for training.
 
 This module provides an abstract base class for sample weighting strategies (e.g., RA-BC)
 that can be used during training without polluting the training script with
@@ -47,9 +46,9 @@ if TYPE_CHECKING:
 
 
 class SampleWeighter(ABC):
-    """
-    Implementations compute per-sample weights that can be used to weight
-    the loss during training. This enables techniques like:
+    """Implementations compute per-sample loss weights for training.
+
+    This enables techniques like:
     - RA-BC (Reward-Aligned Behavior Cloning)
     - Importance sampling
     - Curriculum learning
@@ -58,25 +57,24 @@ class SampleWeighter(ABC):
 
     @abstractmethod
     def compute_batch_weights(self, batch: dict) -> tuple[torch.Tensor, dict]:
-        """
-        Compute per-sample weights for a training batch.
+        """Compute per-sample weights for a training batch.
 
         Args:
-            batch: Training batch dictionary containing at minimum an "index" key
-                   with global frame indices.
+            batch (`dict`): Training batch dictionary containing at minimum an `"index"` key
+                with global frame indices.
+
+        Returns:
+            `tuple[torch.Tensor, dict]`: Per-sample weights, and a stats dict.
         """
 
     @abstractmethod
     def get_stats(self) -> dict:
-        """
-        Get global statistics about the weighting strategy.
-        """
+        """Get global statistics about the weighting strategy."""
 
 
 @dataclass
 class SampleWeightingConfig:
-    """
-    Configuration for sample weighting during training.
+    """Configuration for sample weighting during training.
 
     This is a generic config that supports multiple weighting strategies.
     The `type` field determines which implementation to use, and `extra_params`
@@ -107,17 +105,25 @@ def make_sample_weighter(
     dataset_root: str | None = None,
     dataset_repo_id: str | None = None,
 ) -> SampleWeighter | None:
-    """
-    Factory function to create a SampleWeighter from config.
+    """Factory function to create a SampleWeighter from config.
 
     This keeps policy-specific initialization logic out of the training script.
 
     Args:
-        config: Sample weighting configuration, or None to disable weighting.
-        policy: The policy being trained (used to extract chunk_size, etc.)
-        device: Device to place weight tensors on.
-        dataset_root: Local path to dataset root (for auto-detecting progress_path).
-        dataset_repo_id: HuggingFace repo ID (for auto-detecting progress_path).
+        config (`SampleWeightingConfig | None`): Sample weighting configuration. `None` disables
+            weighting.
+        policy (`PreTrainedPolicy`): The policy being trained.
+        device (`torch.device`): Device to place weight tensors on.
+        dataset_root (`str | None`, *optional*): Local path to dataset root, for auto-detecting
+            `progress_path` when using RABC.
+        dataset_repo_id (`str | None`, *optional*): Hugging Face repo ID, for auto-detecting
+            `progress_path` when using RABC.
+
+    Returns:
+        `SampleWeighter | None`: The constructed weighter, or `None` if `config` is `None`.
+
+    Raises:
+        ValueError: If `config.type` isn't `"rabc"` or `"uniform"`.
     """
     if config is None:
         return None
@@ -186,8 +192,7 @@ def _make_rabc_weighter(
 
 
 class UniformWeighter(SampleWeighter):
-    """
-    No-op sample weighter that returns uniform weights.
+    """No-op sample weighter that returns uniform weights.
 
     Useful as a baseline or when you want to disable weighting without
     changing the training code structure.
@@ -199,6 +204,11 @@ class UniformWeighter(SampleWeighter):
     """
 
     def __init__(self, device: torch.device):
+        """Initialize the weighter.
+
+        Args:
+            device (`torch.device`): Device to allocate weight tensors on.
+        """
         self.device = device
 
     def compute_batch_weights(self, batch: dict) -> tuple[torch.Tensor, dict]:
@@ -210,8 +220,7 @@ class UniformWeighter(SampleWeighter):
         return weights, stats
 
     def _determine_batch_size(self, batch: dict) -> int:
-        """
-        Determine batch size from the batch dictionary.
+        """Determine batch size from the batch dictionary.
 
         Checks common keys first, then scans all values for tensors.
 

--- a/src/lerobot/utils/transition.py
+++ b/src/lerobot/utils/transition.py
@@ -22,6 +22,19 @@ from .constants import ACTION
 
 
 class Transition(TypedDict):
+    """One RL environment transition.
+
+    Args:
+        state (`dict[str, torch.Tensor]`): Observation before the action.
+        action (`torch.Tensor`): Action taken.
+        reward (`float`): Reward received.
+        next_state (`dict[str, torch.Tensor]`): Observation after the action.
+        done (`bool`): Whether the episode terminated.
+        truncated (`bool`): Whether the episode was truncated (time limit).
+        complementary_info (`dict[str, torch.Tensor | float | int] | None`, *optional*): Extra
+            per-transition metadata (e.g. for reward shaping or debugging).
+    """
+
     state: dict[str, torch.Tensor]
     action: torch.Tensor
     reward: float
@@ -32,6 +45,18 @@ class Transition(TypedDict):
 
 
 def move_transition_to_device(transition: Transition, device: str = "cpu") -> Transition:
+    """Move every tensor field of `transition` (in place) to `device`.
+
+    Args:
+        transition (`Transition`): Transition to move.
+        device (`str`, *optional*, defaults to `"cpu"`): Target device.
+
+    Returns:
+        `Transition`: The same `transition` dict, mutated in place.
+
+    Raises:
+        ValueError: If a `complementary_info` value isn't a tensor, `int`, `float`, or `bool`.
+    """
     device = torch.device(device)
     non_blocking = device.type == "cuda"
 
@@ -71,9 +96,14 @@ def move_transition_to_device(transition: Transition, device: str = "cpu") -> Tr
 
 
 def move_state_dict_to_device(state_dict, device="cpu"):
-    """
-    Recursively move all tensors in a (potentially) nested
-    dict/list/tuple structure to the CPU.
+    """Recursively move all tensors in a (potentially) nested dict/list/tuple structure to `device`.
+
+    Args:
+        state_dict (`Any`): A tensor, or a nested dict/list/tuple structure containing tensors.
+        device (`str`, *optional*, defaults to `"cpu"`): Target device.
+
+    Returns:
+        `Any`: The same structure, with every tensor moved to `device`.
     """
     if isinstance(state_dict, torch.Tensor):
         return state_dict.to(device)

--- a/src/lerobot/utils/utils.py
+++ b/src/lerobot/utils/utils.py
@@ -386,6 +386,12 @@ class SuppressProgressBars:
 class TimerManager:
     """Lightweight utility to measure elapsed time.
 
+    Args:
+        label (`str`, *optional*, defaults to `"Elapsed-time"`): Label prepended to log lines.
+        log (`bool`, *optional*, defaults to `True`): Whether to log each measured duration.
+        logger (`logging.Logger | None`, *optional*): Logger to use. Defaults to the root
+            logger when unset.
+
     Examples:
     --------
     ```python
@@ -413,14 +419,6 @@ class TimerManager:
         log: bool = True,
         logger: logging.Logger | None = None,
     ):
-        """Initialize the timer with no recorded history.
-
-        Args:
-            label (`str`, *optional*, defaults to `"Elapsed-time"`): Label prepended to log lines.
-            log (`bool`, *optional*, defaults to `True`): Whether to log each measured duration.
-            logger (`logging.Logger | None`, *optional*): Logger to use. Defaults to the root
-                logger when unset.
-        """
         self.label = label
         self.log = log
         self.logger = logger

--- a/src/lerobot/utils/utils.py
+++ b/src/lerobot/utils/utils.py
@@ -35,7 +35,7 @@ if TYPE_CHECKING:
 
 
 def inside_slurm():
-    """Check whether the python process was launched through slurm"""
+    """Check whether the python process was launched through slurm."""
     # TODO(rcadene): return False for interactive mode `--pty bash`
     return "SLURM_JOB_ID" in os.environ
 
@@ -53,15 +53,20 @@ def init_logging(
     Non-main processes have console logging suppressed but can still log to file.
 
     Args:
-        log_file: Optional file path to write logs to
-        display_pid: Include process ID in log messages (useful for debugging multi-process)
-        console_level: Logging level for console output
-        file_level: Logging level for file output
-        accelerator: Optional Accelerator instance (for multi-GPU detection)
+        log_file (`Path | None`, *optional*): File path to write logs to.
+        display_pid (`bool`, *optional*, defaults to `False`): Include process ID in log messages
+            (useful for debugging multi-process).
+        console_level (`str`, *optional*, defaults to `"INFO"`): Logging level for console output.
+        file_level (`str`, *optional*, defaults to `"DEBUG"`): Logging level for file output.
+        accelerator (`Accelerator | None`, *optional*): Accelerator instance, for multi-GPU
+            detection.
     """
 
     class LeRobotFormatter(logging.Formatter):
+        """A `logging.Formatter` that adds `lerobot_location` and `lerobot_pid` record fields."""
+
         def format(self, record: logging.LogRecord) -> str:
+            """Populate `record.lerobot_location`/`lerobot_pid` before formatting."""
             record.lerobot_location = f"{record.pathname}:{record.lineno}"[-15:]
             record.lerobot_pid = f"[PID: {os.getpid()}] " if display_pid else ""
             return super().format(record)
@@ -101,6 +106,15 @@ def init_logging(
 
 
 def format_big_number(num, precision=0):
+    """Format a large number with a metric suffix (K/M/B/T/Q).
+
+    Args:
+        num (`float`): Number to format.
+        precision (`int`, *optional*, defaults to 0): Decimal places to keep.
+
+    Returns:
+        `str | float`: The formatted string, or `num` unchanged if it exceeds every suffix's range.
+    """
     suffixes = ["", "K", "M", "B", "T", "Q"]
     divisor = 1000.0
 
@@ -113,6 +127,15 @@ def format_big_number(num, precision=0):
 
 
 def say(text: str, blocking: bool = False):
+    """Speak `text` aloud using the OS's text-to-speech command.
+
+    Args:
+        text (`str`): Text to speak.
+        blocking (`bool`, *optional*, defaults to `False`): Whether to wait for speech to finish.
+
+    Raises:
+        RuntimeError: If the OS isn't macOS, Linux, or Windows.
+    """
     system = platform.system()
 
     if system == "Darwin":
@@ -144,6 +167,13 @@ def say(text: str, blocking: bool = False):
 
 
 def log_say(text: str, play_sounds: bool = True, blocking: bool = False):
+    """Log `text` at INFO level and, optionally, speak it aloud.
+
+    Args:
+        text (`str`): Text to log (and optionally speak).
+        play_sounds (`bool`, *optional*, defaults to `True`): Whether to also speak `text` via `say`.
+        blocking (`bool`, *optional*, defaults to `False`): Whether to wait for speech to finish.
+    """
     logging.info(text)
 
     if play_sounds:
@@ -151,6 +181,17 @@ def log_say(text: str, play_sounds: bool = True, blocking: bool = False):
 
 
 def get_channel_first_image_shape(image_shape: tuple) -> tuple:
+    """Reorder an image shape to channel-first (`C, H, W`), if it isn't already.
+
+    Args:
+        image_shape (`tuple`): Image shape, either `(H, W, C)` or `(C, H, W)`.
+
+    Returns:
+        `tuple`: The shape in `(C, H, W)` order.
+
+    Raises:
+        ValueError: If `image_shape` isn't recognizable as either layout.
+    """
     shape = copy(image_shape)
     if shape[2] < shape[0] and shape[2] < shape[1]:  # (h, w, c) -> (c, h, w)
         shape = (shape[2], shape[0], shape[1])
@@ -161,6 +202,7 @@ def get_channel_first_image_shape(image_shape: tuple) -> tuple:
 
 
 def has_method(cls: object, method_name: str) -> bool:
+    """Whether `cls` has a callable attribute named `method_name`."""
     return hasattr(cls, method_name) and callable(getattr(cls, method_name))
 
 
@@ -184,9 +226,7 @@ def unwrap_scalar(value: Any) -> Any:
 
 
 def is_valid_numpy_dtype_string(dtype_str: str) -> bool:
-    """
-    Return True if a given string can be converted to a numpy dtype.
-    """
+    """Return True if a given string can be converted to a numpy dtype."""
     try:
         # Attempt to convert the string to a numpy dtype
         np.dtype(dtype_str)
@@ -197,6 +237,11 @@ def is_valid_numpy_dtype_string(dtype_str: str) -> bool:
 
 
 def enter_pressed() -> bool:
+    """Whether the Enter key was pressed on stdin, without blocking.
+
+    Returns:
+        `bool`: `True` if a bare Enter keypress is available to read.
+    """
     if platform.system() == "Windows":
         import msvcrt
 
@@ -214,6 +259,14 @@ def move_cursor_up(lines):
 
 
 def get_elapsed_time_in_days_hours_minutes_seconds(elapsed_time_s: float):
+    """Break a duration in seconds into `(days, hours, minutes, seconds)`.
+
+    Args:
+        elapsed_time_s (`float`): Duration, in seconds.
+
+    Returns:
+        `tuple[int, int, int, float]`: `(days, hours, minutes, seconds)`.
+    """
     days = int(elapsed_time_s // (24 * 3600))
     elapsed_time_s %= 24 * 3600
     hours = int(elapsed_time_s // 3600)
@@ -232,12 +285,13 @@ def flatten_dict(d: dict, parent_key: str = "", sep: str = "/") -> dict:
         {'a/b': 1, 'a/c/d': 2, 'e': 3}
 
     Args:
-        d (dict): The dictionary to flatten.
-        parent_key (str): The base key to prepend to the keys in this level.
-        sep (str): The separator to use between keys.
+        d (`dict`): The dictionary to flatten.
+        parent_key (`str`, *optional*, defaults to `""`): The base key to prepend to the keys in
+            this level.
+        sep (`str`, *optional*, defaults to `"/"`): The separator to use between keys.
 
     Returns:
-        dict: A flattened dictionary.
+        `dict`: A flattened dictionary.
     """
     items = []
     for k, v in d.items():
@@ -258,11 +312,11 @@ def unflatten_dict(d: dict, sep: str = "/") -> dict:
         {'a': {'b': 1, 'c': {'d': 2}}, 'e': 3}
 
     Args:
-        d (dict): A dictionary with flattened keys.
-        sep (str): The separator used in the keys.
+        d (`dict`): A dictionary with flattened keys.
+        sep (`str`, *optional*, defaults to `"/"`): The separator used in the keys.
 
     Returns:
-        dict: A nested dictionary.
+        `dict`: A nested dictionary.
     """
     outdict = {}
     for key, value in d.items():
@@ -284,7 +338,7 @@ def cycle(iterable: Any) -> Iterator[Any]:
     See https://github.com/pytorch/pytorch/issues/23900 for details.
 
     Args:
-        iterable: The iterable to cycle over.
+        iterable (`Any`): The iterable to cycle over.
 
     Yields:
         Items from the iterable, restarting from the beginning when exhausted.
@@ -298,10 +352,9 @@ def cycle(iterable: Any) -> Iterator[Any]:
 
 
 class SuppressProgressBars:
-    """
-    Context manager to suppress progress bars.
+    """Context manager to suppress progress bars.
 
-    Example
+    Example:
     --------
     ```python
     with SuppressProgressBars():
@@ -310,6 +363,7 @@ class SuppressProgressBars:
     """
 
     def __enter__(self):
+        """Disable `datasets`' progress bars, if `datasets` is installed."""
         try:
             from datasets.utils.logging import disable_progress_bar
 
@@ -320,6 +374,7 @@ class SuppressProgressBars:
             )
 
     def __exit__(self, exc_type, exc_val, exc_tb):
+        """Re-enable `datasets`' progress bars, if `datasets` is installed."""
         try:
             from datasets.utils.logging import enable_progress_bar
 
@@ -329,10 +384,9 @@ class SuppressProgressBars:
 
 
 class TimerManager:
-    """
-    Lightweight utility to measure elapsed time.
+    """Lightweight utility to measure elapsed time.
 
-    Examples
+    Examples:
     --------
     ```python
     # Example 1: Using context manager
@@ -359,6 +413,14 @@ class TimerManager:
         log: bool = True,
         logger: logging.Logger | None = None,
     ):
+        """Initialize the timer with no recorded history.
+
+        Args:
+            label (`str`, *optional*, defaults to `"Elapsed-time"`): Label prepended to log lines.
+            log (`bool`, *optional*, defaults to `True`): Whether to log each measured duration.
+            logger (`logging.Logger | None`, *optional*): Logger to use. Defaults to the root
+                logger when unset.
+        """
         self.label = label
         self.log = log
         self.logger = logger
@@ -366,16 +428,31 @@ class TimerManager:
         self._history: list[float] = []
 
     def __enter__(self):
+        """Start timing and return `self`."""
         return self.start()
 
     def __exit__(self, exc_type, exc_val, exc_tb):
+        """Stop timing, recording the elapsed duration."""
         self.stop()
 
     def start(self):
+        """Start timing.
+
+        Returns:
+            `TimerManager`: `self`, for chaining.
+        """
         self._start = time.perf_counter()
         return self
 
     def stop(self) -> float:
+        """Stop timing and record the elapsed duration.
+
+        Returns:
+            `float`: Elapsed time, in seconds, since `start()`.
+
+        Raises:
+            RuntimeError: If the timer was never started.
+        """
         if self._start is None:
             raise RuntimeError("Timer was never started.")
         elapsed = time.perf_counter() - self._start
@@ -389,47 +466,51 @@ class TimerManager:
         return elapsed
 
     def reset(self):
+        """Clear all recorded durations."""
         self._history.clear()
 
     @property
     def last(self) -> float:
+        """The most recently recorded duration, in seconds (`0.0` if none recorded)."""
         return self._history[-1] if self._history else 0.0
 
     @property
     def avg(self) -> float:
+        """The average recorded duration, in seconds (`0.0` if none recorded)."""
         return mean(self._history) if self._history else 0.0
 
     @property
     def total(self) -> float:
+        """The sum of every recorded duration, in seconds."""
         return sum(self._history)
 
     @property
     def count(self) -> int:
+        """The number of recorded durations."""
         return len(self._history)
 
     @property
     def history(self) -> list[float]:
+        """A copy of every recorded duration, in seconds, oldest first."""
         return deepcopy(self._history)
 
     @property
     def fps_last(self) -> float:
+        """`1 / last`, or `0.0` if `last` is zero."""
         return 0.0 if self.last == 0 else 1.0 / self.last
 
     @property
     def fps_avg(self) -> float:
+        """`1 / avg`, or `0.0` if `avg` is zero."""
         return 0.0 if self.avg == 0 else 1.0 / self.avg
 
     def percentile(self, p: float) -> float:
-        """
-        Return the p-th percentile of recorded times.
-        """
+        """Return the p-th percentile of recorded times."""
         if not self._history:
             return 0.0
         return float(np.percentile(self._history, p))
 
     def fps_percentile(self, p: float) -> float:
-        """
-        FPS corresponding to the p-th percentile time.
-        """
+        """FPS corresponding to the p-th percentile time."""
         val = self.percentile(p)
         return 0.0 if val == 0 else 1.0 / val

--- a/src/lerobot/utils/visualization_utils.py
+++ b/src/lerobot/utils/visualization_utils.py
@@ -43,7 +43,6 @@ def init_visualization(
     ``ip`` is the interface to bind the WebSocket server to (``127.0.0.1`` for local only, ``0.0.0.0``
     for all interfaces) and ``port`` is its port.
     """
-
     if display_mode == "rerun":
         init_rerun(session_name=session_name, ip=ip, port=port)
     elif display_mode == "foxglove":
@@ -59,7 +58,6 @@ def log_visualization_data(
     compress_images: bool = False,
 ) -> None:
     """Logs observation/action data to the backend selected by ``display_mode``."""
-
     if display_mode == "rerun":
         log_rerun_data(observation=observation, action=action, compress_images=compress_images)
     elif display_mode == "foxglove":
@@ -70,7 +68,6 @@ def log_visualization_data(
 
 def shutdown_visualization(display_mode: str) -> None:
     """Shuts down the backend selected by ``display_mode``."""
-
     if display_mode == "rerun":
         shutdown_rerun()
     elif display_mode == "foxglove":

--- a/utils/check_docstrings.py
+++ b/utils/check_docstrings.py
@@ -60,6 +60,7 @@ PATH_TO_LEROBOT = PATH_TO_REPO / "src" / "lerobot"
 # Modules whose public objects are checked. Add a module here once its docstrings follow the standard.
 MODULES_TO_CHECK = [
     "lerobot.robots",
+    "lerobot.utils",
 ]
 
 # Objects that do not yet follow the standard, so the check can be green from day one. Removing an entry


### PR DESCRIPTION
## Summary
- Brings `src/lerobot/utils/` to 100% public docstring coverage per `docs/source/writing_docstrings.mdx`: Google-style sections + HF-style type formatting across errors, connection decorators, device/RNG helpers, logging/metrics (`AverageMeter`, `MetricsTracker`, `TimerManager`), `HubMixin`, sample weighting, visualization (rerun/foxglove dispatch), keyboard/pedal input, `BimanualMixin`, `Transition`, and rotation/collate helpers.
- Along the way, fixed two pre-existing inaccuracies found while converting: `move_state_dict_to_device`'s docstring claimed it always moves "to the CPU" regardless of its `device` argument, and `robot_utils.precise_sleep` used a non-standard `Parameters:` header instead of `Args:`.
- Also discovered and worked around the same nested-closure AST-scanner blind spot as the `annotations` PR (functions defined inside a `for`/`if` block aren't direct AST children of their enclosing function) — re-verified this module with a full `ast.walk` scan.
- Adds `docs/source/api/utils.mdx`, documenting the module's most reusable pieces (grouped: errors/decorators, device & reproducibility, logging & metrics, Hub, sample weighting, visualization, keyboard/pedal input, bimanual mixin, data/math helpers, I/O).
- Removes `"src/lerobot/utils/**" = ["D"]` from `pyproject.toml`'s ruff per-file-ignores; adds `"lerobot.utils"` to `check_docstrings.py`'s `MODULES_TO_CHECK` ratchet; raises `interrogate`'s `fail-under` from 55 to 56.2 (actual: 56.4%).
- Docstrings-only — zero behavioral change.

## Test plan
- [x] `ruff check src/lerobot/utils/` — clean.
- [x] `python utils/check_docstrings.py` — clean.
- [x] `interrogate --config=pyproject.toml` — PASSED (56.2% min, 56.4% actual).
- [x] `python utils/check_doctest_list.py` — clean.
- [x] `doc-builder build lerobot docs/source/` — renders cleanly (74 autodoc blocks), no dead cross-refs or `<fill_docstring>` placeholders.
- [x] `pre-commit run --all-files` — green (reverted the unrelated `tests/policies/vla_jepa/test_*.py` ruff import-order churn).