### PR TITLE
fix(processor): preserve dataset-prefixed state stats

### DIFF
--- a/src/lerobot/processor/migrate_policy_normalization.py
+++ b/src/lerobot/processor/migrate_policy_normalization.py
@@ -83,6 +83,7 @@ def extract_normalization_stats(state_dict: dict[str, torch.Tensor]) -> dict[str
     # Define patterns to match and their prefixes to remove
     normalization_patterns = [
         "normalize_inputs.buffer_",
+        "normalize_inputs.",  # Also handles dataset-prefixed legacy keys
         "unnormalize_outputs.buffer_",
         "normalize_targets.buffer_",
         "normalize.",  # Must come after normalize_* patterns

--- a/src/lerobot/processor/migrate_policy_normalization.py
+++ b/src/lerobot/processor/migrate_policy_normalization.py
@@ -90,7 +90,6 @@ def extract_normalization_stats(state_dict: dict[str, torch.Tensor]) -> dict[str
         "unnormalize.",  # Must come after unnormalize_* patterns
         "input_normalizer.",
         "output_normalizer.",
-        "normalalize_inputs.",
         "unnormalize_outputs.",
         "normalize_targets.",
         "unnormalize_targets.",

--- a/tests/processor/test_migrate_policy_normalization.py
+++ b/tests/processor/test_migrate_policy_normalization.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+
+from lerobot.processor.migrate_policy_normalization import extract_normalization_stats
+
+
+def test_extracts_dataset_prefixed_state_stats():
+    state_dict = {
+        "normalize_inputs.so100_buffer_observation_state.mean": torch.tensor([1.0, 2.0]),
+        "normalize_inputs.so100_buffer_observation_state.std": torch.tensor([3.0, 4.0]),
+        "normalize_inputs.so100-blue_buffer_observation_state.mean": torch.tensor([5.0, 6.0]),
+        "normalize_inputs.so100-blue_buffer_observation_state.std": torch.tensor([7.0, 8.0]),
+    }
+
+    stats = extract_normalization_stats(state_dict)
+
+    torch.testing.assert_close(stats["so100.buffer.observation.state"]["mean"], torch.tensor([1.0, 2.0]))
+    torch.testing.assert_close(stats["so100.buffer.observation.state"]["std"], torch.tensor([3.0, 4.0]))
+    torch.testing.assert_close(stats["so100-blue.buffer.observation.state"]["mean"], torch.tensor([5.0, 6.0]))
+    torch.testing.assert_close(stats["so100-blue.buffer.observation.state"]["std"], torch.tensor([7.0, 8.0]))

--- a/tests/processor/test_migration_detection.py
+++ b/tests/processor/test_migration_detection.py
@@ -23,7 +23,9 @@ import tempfile
 from pathlib import Path
 
 import pytest
+import torch
 
+from lerobot.processor.migrate_policy_normalization import extract_normalization_stats
 from lerobot.processor.pipeline import DataProcessorPipeline, ProcessorMigrationError
 from lerobot.utils.constants import ACTION, OBS_STATE
 
@@ -59,6 +61,22 @@ def test_is_processor_config_invalid_configs():
         assert not DataProcessorPipeline._is_processor_config(config), (
             f"Invalid config {i} should not be detected as processor config: {config}"
         )
+
+
+def test_extracts_dataset_prefixed_state_stats():
+    state_dict = {
+        "normalize_inputs.so100_buffer_observation_state.mean": torch.tensor([1.0, 2.0]),
+        "normalize_inputs.so100_buffer_observation_state.std": torch.tensor([3.0, 4.0]),
+        "normalize_inputs.so100-blue_buffer_observation_state.mean": torch.tensor([5.0, 6.0]),
+        "normalize_inputs.so100-blue_buffer_observation_state.std": torch.tensor([7.0, 8.0]),
+    }
+
+    stats = extract_normalization_stats(state_dict)
+
+    torch.testing.assert_close(stats["so100.buffer.observation.state"]["mean"], torch.tensor([1.0, 2.0]))
+    torch.testing.assert_close(stats["so100.buffer.observation.state"]["std"], torch.tensor([3.0, 4.0]))
+    torch.testing.assert_close(stats["so100-blue.buffer.observation.state"]["mean"], torch.tensor([5.0, 6.0]))
+    torch.testing.assert_close(stats["so100-blue.buffer.observation.state"]["std"], torch.tensor([7.0, 8.0]))
 
 
 def test_should_suggest_migration_with_processor_config():

--- a/tests/processor/test_migration_detection.py
+++ b/tests/processor/test_migration_detection.py
@@ -23,9 +23,7 @@ import tempfile
 from pathlib import Path
 
 import pytest
-import torch
 
-from lerobot.processor.migrate_policy_normalization import extract_normalization_stats
 from lerobot.processor.pipeline import DataProcessorPipeline, ProcessorMigrationError
 from lerobot.utils.constants import ACTION, OBS_STATE
 
@@ -61,22 +59,6 @@ def test_is_processor_config_invalid_configs():
         assert not DataProcessorPipeline._is_processor_config(config), (
             f"Invalid config {i} should not be detected as processor config: {config}"
         )
-
-
-def test_extracts_dataset_prefixed_state_stats():
-    state_dict = {
-        "normalize_inputs.so100_buffer_observation_state.mean": torch.tensor([1.0, 2.0]),
-        "normalize_inputs.so100_buffer_observation_state.std": torch.tensor([3.0, 4.0]),
-        "normalize_inputs.so100-blue_buffer_observation_state.mean": torch.tensor([5.0, 6.0]),
-        "normalize_inputs.so100-blue_buffer_observation_state.std": torch.tensor([7.0, 8.0]),
-    }
-
-    stats = extract_normalization_stats(state_dict)
-
-    torch.testing.assert_close(stats["so100.buffer.observation.state"]["mean"], torch.tensor([1.0, 2.0]))
-    torch.testing.assert_close(stats["so100.buffer.observation.state"]["std"], torch.tensor([3.0, 4.0]))
-    torch.testing.assert_close(stats["so100-blue.buffer.observation.state"]["mean"], torch.tensor([5.0, 6.0]))
-    torch.testing.assert_close(stats["so100-blue.buffer.observation.state"]["std"], torch.tensor([7.0, 8.0]))
 
 
 def test_should_suggest_migration_with_processor_config():


### PR DESCRIPTION
## Summary / Motivation

The normalization migration script does not extract legacy dataset-prefixed state statistics such as `normalize_inputs.so100_buffer_observation_state.mean`. As a result, migrated multi-dataset policies can lose their state normalization stats even when those tensors exist in the source checkpoint. This restores extraction of those stats without changing runtime dataset selection behavior.

## Related issues

- Related: #4415

## What changed

- Match the general `normalize_inputs.` prefix after the existing `normalize_inputs.buffer_` pattern, so dataset-scoped keys stop falling through. `normalize_inputs.buffer_` still comes first and the loop breaks on the first match, so a single-dataset checkpoint still migrates to `observation.state` and `action` exactly as before.
- Remove the misspelled `"normalalize_inputs."` pattern. No checkpoint key can start with that spelling, and it is the only occurrence in the repository, so leaving it beside the correctly spelled entry would mean two patterns for one intent, one of which never fires.
- Add regression coverage for `so100` and `so100-blue` dataset-prefixed state statistics, in a new `tests/processor/test_migrate_policy_normalization.py` alongside the unit it exercises. (`test_migration_detection.py` covers `DataProcessorPipeline._is_processor_config`.)

### One behavior change worth stating explicitly

No runtime API or checkpoint format changes. The **migrated artifact does change**, though, for a checkpoint whose config carries no `normalization_mapping`: `detect_features_and_norm_modes` infers the mode from the extracted statistics, so restoring the state stats changes what the migration writes.

Measured against a state dict with `so100`-scoped input and output buffers and an empty config:

```
         stats keys                                          norm_modes STATE
before   ['so100.buffer.action']                             MIN_MAX
after    ['so100.buffer.action',                             MEAN_STD
          'so100.buffer.observation.state']
```

This is a fix rather than a regression — the checkpoint stored `mean`/`std`, so `MEAN_STD` is the mode it was trained under, and the previous `MIN_MAX` was the hardcoded default at `migrate_policy_normalization.py:242-243` winning by absence. It is called out here because it changes the migrated config for every such checkpoint, which the original description did not say.

## How was this tested (or how to run locally)

- `uv run --extra test --no-sync pytest tests/processor/test_migration_detection.py tests/processor/test_migrate_policy_normalization.py tests/processor/test_normalize_processor.py -q` — 82 passed, 1 skipped.
- `ruff check` passed for the changed files.
- `ruff format --check` passed for the changed files.
- `python -m compileall` passed for the changed files.
- `git diff --check` passed.

## Checklist (required before merge)

- [x] Linting/formatting run for changed files (`ruff check`, `ruff format --check`)
- [x] Targeted tests pass locally
- [ ] Documentation updated
- [x] CI is green — 6 checks pass; Build Main Docs was skipped
- [x] Community Review: I have reviewed another contributor's open PR and linked it here: #4285

## Reviewer notes

This is intentionally limited to migration-time extraction. It does not resolve runtime selection among multiple dataset-prefixed stats; choosing a dataset-specific stat still requires separate dataset context and should not silently select the first match.

Two consequences of the same config-inference fallback, both verified, neither a blocker:

- A restored `so100.buffer.observation.state` is also registered as a *feature* and written into the saved processor config, even though it names no real feature. It is inert at runtime: `NormalizerProcessorStep._normalize_observation` (`normalize_processor.py:278-281`) iterates `self.features` but only acts on a key present in the observation, and this one never is.
- The statistics land under `so100.buffer.observation.state` while the runtime looks up `observation.state`. So this PR stops the tensors from being discarded, but does not by itself make #4415's reproduction pass. Whether the dataset prefix should be preserved (as here) or stripped at migration time (as in #4446) is a single decision worth settling once, and I am happy to follow whichever the maintainers prefer.

AI assistance was used during development; the change was reviewed and tested by the contributor.
