### PR TITLE
docs: dedicated page for LeRobot and ROS 2 integrations (P1 of #4368)

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -167,6 +167,8 @@
     title: reBot B601-DM
   - local: third_party_robots
     title: Third-Party Robots & Teleoperators
+  - local: third_party_ros2
+    title: LeRobot and ROS 2
   title: "Robots"
 - sections:
   - local: phone_teleop

--- a/docs/source/third_party_robots.mdx
+++ b/docs/source/third_party_robots.mdx
@@ -313,26 +313,7 @@ lerobot-record \
 
 ## ROS 2 Bridges
 
-<!-- prettier-ignore -->
-<table width="100%" style="display:table; width:100%; table-layout:fixed;">
-  <colgroup>
-    <col width="30%" />
-    <col width="70%" />
-  </colgroup>
-  <thead style="border:0">
-    <tr style="border:0"><th>Project</th><th>Description</th></tr>
-  </thead>
-  <tbody>
-    <tr style="border:0">
-      <td><a href="https://github.com/ngres/leros2">leros2</a></td>
-      <td>Plugin bridging ROS 2 topics and actions to LeRobot robots and teleoperators.</td>
-    </tr>
-    <tr style="border:0">
-      <td><a href="https://github.com/ROBOTIS-GIT/lerobot_robot_ros2_zenoh">lerobot_robot_ros2_zenoh</a></td>
-      <td>Plugin bridging ROS 2 robots to LeRobot over <a href="https://zenoh.io">Zenoh</a> pub/sub transport.</td>
-    </tr>
-  </tbody>
-</table>
+Community integrations between LeRobot and ROS 2, including robot bridges and dataset converters, are listed on the dedicated [LeRobot and ROS 2](./third_party_ros2) page.
 
 ## Contributing
 

--- a/docs/source/third_party_ros2.mdx
+++ b/docs/source/third_party_ros2.mdx
@@ -42,6 +42,10 @@ Plugins follow LeRobot's auto-discovery convention (`lerobot_robot_*`, `lerobot_
       <td><a href="https://github.com/astroyat/lerobot-ros">lerobot-ros (astroyat)</a> ⚠️</td>
       <td>LeKiwi mobile base over <code>/cmd_vel</code> with LIDAR streaming, odometry, and SLAM Toolbox + Nav2 bringup. Requires a patched LeRobot fork.</td>
     </tr>
+<tr style="border:0">
+  <td><a href="https://github.com/una-auxme/ros2smolvla_interface_camera">ros2smolvla_interface_camera</a></td>
+  <td>Camera adapter exposing ROS 2 image topics (compressed, or raw + depth) as a LeRobot camera. Part of the <a href="https://github.com/una-auxme/ros2smolvla_docker">ROS2SmolVLA</a> stack (SmolVLA on a UR10e), usable wherever image topics are available.</td>
+</tr>
   </tbody>
 </table>
 

--- a/docs/source/third_party_ros2.mdx
+++ b/docs/source/third_party_ros2.mdx
@@ -1,0 +1,79 @@
+# LeRobot and ROS 2
+
+[ROS 2](https://www.ros.org/) is where many deployed robots, lab setups, and simulation stacks live, and the community has built several integrations connecting it to LeRobot. They come in two shapes: **plugins**, which expose a ROS 2 robot to standard LeRobot commands like `lerobot-record` and `lerobot-teleoperate`, and **standalone ROS 2 packages**, which run LeRobot recording and inference as nodes inside an existing ROS 2 workspace. This page also lists **dataset converters** between `rosbag2` and `LeRobotDataset`.
+
+> [!IMPORTANT]
+> These projects are developed and maintained by third parties. Please refer to each repository for installation instructions, hardware requirements, supported ROS 2 distros, and support.
+
+> [!TIP]
+> ⚠️ marks projects that require a patched or pinned version of LeRobot rather than working with a current, unmodified install. Check each repository's declared `lerobot` version range before installing.
+
+## Robot Bridges
+
+Plugins follow LeRobot's auto-discovery convention (`lerobot_robot_*`, `lerobot_teleoperator_*`); standalone packages are built with colcon into a ROS 2 workspace and are driven with `ros2 run` and service calls instead of LeRobot commands.
+
+<!-- prettier-ignore -->
+<table width="100%" style="display:table; width:100%; table-layout:fixed;">
+  <colgroup>
+    <col width="30%" />
+    <col width="70%" />
+  </colgroup>
+  <thead style="border:0">
+    <tr style="border:0"><th>Project</th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr style="border:0">
+      <td><a href="https://github.com/ngres/leros2">leros2</a></td>
+      <td>Plugins (<code>lerobot_robot_ros2</code>, <code>lerobot_teleoperator_ros2</code>) with a composable, config-driven mapping between ROS 2 topics and LeRobot features: joint positions, end-effector poses, torques/wrenches, grippers, and compressed images. Also ships <code>leros2-convert</code> for bag-to-dataset conversion (see below). Installs from source.</td>
+    </tr>
+    <tr style="border:0">
+      <td><a href="https://github.com/ycheng517/lerobot-ros">lerobot-ros (ycheng517)</a> ⚠️</td>
+      <td>Plugin wrapping any <a href="https://control.ros.org/">ros2_control</a> / <a href="https://moveit.ai/">MoveIt</a> arm, with joint position, joint trajectory, and MoveIt Servo end-effector velocity modes, plus gamepad and keyboard teleoperators. Targets lerobot 0.4.x and ROS 2 Jazzy.</td>
+    </tr>
+    <tr style="border:0">
+      <td><a href="https://github.com/ROBOTIS-GIT/lerobot_robot_ros2_zenoh">lerobot_robot_ros2_zenoh</a></td>
+      <td>Plugin bridging ROS 2 robots to LeRobot over <a href="https://zenoh.io">Zenoh</a> pub/sub transport, so the LeRobot side needs no ROS 2 installation. Joint states in, joint trajectories out, ROS image topics as cameras. Alpha status, requires a Zenoh router and an SDK installed from source.</td>
+    </tr>
+    <tr style="border:0">
+      <td><a href="https://github.com/sacovo/lerobot_ros">lerobot_ros (sacovo)</a></td>
+      <td>Standalone ROS 2 package running LeRobot inside a colcon workspace: a <code>dataset_recorder</code> node records LeRobotDatasets from arbitrary configured topics via service calls, and a <code>policy_controller</code> node runs any LeRobot policy with topics as observations and actions, with replay and SO-101 example nodes.</td>
+    </tr>
+    <tr style="border:0">
+      <td><a href="https://github.com/astroyat/lerobot-ros">lerobot-ros (astroyat)</a> ⚠️</td>
+      <td>LeKiwi mobile base over <code>/cmd_vel</code> with LIDAR streaming, odometry, and SLAM Toolbox + Nav2 bringup. Requires a patched LeRobot fork.</td>
+    </tr>
+  </tbody>
+</table>
+
+## Dataset Converters
+
+Offline conversion between `rosbag2` recordings and `LeRobotDataset`, usable without a live robot.
+
+<!-- prettier-ignore -->
+<table width="100%" style="display:table; width:100%; table-layout:fixed;">
+  <colgroup>
+    <col width="30%" />
+    <col width="70%" />
+  </colgroup>
+  <thead style="border:0">
+    <tr style="border:0"><th>Project</th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr style="border:0">
+      <td><a href="https://github.com/arpitg1304/forge">forge</a></td>
+      <td>Multi-format toolkit (<code>pip install forge-robotics</code>) converting between RLDS, LeRobot v2/v3, HDF5, MCAP, Zarr, and ROS 1/ROS 2 bags through a shared intermediate representation, with episode quality scoring.</td>
+    </tr>
+    <tr style="border:0">
+      <td><a href="https://pypi.org/project/openral-dataset/">openral-dataset</a></td>
+      <td>Recorder with pluggable sinks: a LeRobotDataset v3 sink writing through the <code>LeRobotDataset</code> API, and a rosbag2/MCAP sink.</td>
+    </tr>
+    <tr style="border:0">
+      <td><a href="https://github.com/ngres/leros2">leros2-convert</a></td>
+      <td>CLI shipped with leros2 (see above) converting a ROS 2 bag into a LeRobotDataset using the same topic-to-feature configuration as its plugins.</td>
+    </tr>
+  </tbody>
+</table>
+
+## Contributing
+
+Built a ROS 2 integration for LeRobot? Check out the [Bring Your Own Hardware](./integrate_hardware) guide for the plugin conventions, and share your project with the community! An open discussion on a unified ROS 2 integration strategy is running in [RFC #4368](https://github.com/huggingface/lerobot/issues/4368).

--- a/docs/source/third_party_ros2.mdx
+++ b/docs/source/third_party_ros2.mdx
@@ -6,7 +6,7 @@
 > These projects are developed and maintained by third parties. Please refer to each repository for installation instructions, hardware requirements, supported ROS 2 distros, and support.
 
 > [!TIP]
-> ⚠️ marks projects that require a patched or pinned version of LeRobot rather than working with a current, unmodified install. Check each repository's declared `lerobot` version range before installing.
+> ⚠️ marks projects that are forks/extensions of LeRobot. They may require custom setup rather than working with an unmodified install. LeRobot moves quickly, so check each project's declared `lerobot` version range against your installed version before installing.
 
 ## Robot Bridges
 
@@ -27,7 +27,7 @@ Plugins follow LeRobot's auto-discovery convention (`lerobot_robot_*`, `lerobot_
       <td>Plugins (<code>lerobot_robot_ros2</code>, <code>lerobot_teleoperator_ros2</code>) with a composable, config-driven mapping between ROS 2 topics and LeRobot features: joint positions, end-effector poses, torques/wrenches, grippers, and compressed images. Also ships <code>leros2-convert</code> for bag-to-dataset conversion (see below). Installs from source.</td>
     </tr>
     <tr style="border:0">
-      <td><a href="https://github.com/ycheng517/lerobot-ros">lerobot-ros (ycheng517)</a> ⚠️</td>
+      <td><a href="https://github.com/ycheng517/lerobot-ros">lerobot-ros (ycheng517)</a></td>
       <td>Plugin wrapping any <a href="https://control.ros.org/">ros2_control</a> / <a href="https://moveit.ai/">MoveIt</a> arm, with joint position, joint trajectory, and MoveIt Servo end-effector velocity modes, plus gamepad and keyboard teleoperators. Targets lerobot 0.4.x and ROS 2 Jazzy.</td>
     </tr>
     <tr style="border:0">


### PR DESCRIPTION
## Summary / Motivation

#4026 added a ROS 2 Bridges section to the third-party robots page listing two projects. The ecosystem survey in RFC #4368 found six community projects connecting LeRobot and ROS 2, including dataset converters that do not fit a robots-and-teleoperators page. This PR moves the section to a dedicated page and completes it, keeping it descriptive only: no compatibility promises, all facts taken from each project's repository (README, package metadata), checked Aug 2026. Design note: the ⚠️ marker keeps the same semantics as the other third-party pages (forks/extensions requiring custom setup). Version constraints (e.g. a project targeting lerobot 0.4.x) are recorded in each entry's description rather than encoded in the marker: a compatibility-based marker would become inaccurate at each LeRobot release, while a version statement in the description remains a verifiable fact. This is deliverable P1 of the RFC.

## Related issues

- Related: #4368 (RFC: ROS 2 integration strategy, this is P1)
- Related: #4026 (added the original ROS 2 Bridges section)

## What changed

- New docs page `docs/source/third_party_ros2.mdx` ("LeRobot and ROS 2"): robot bridges (plugins and standalone ROS 2 packages) and dataset converters, following the format of the existing third-party pages.
- `docs/source/third_party_robots.mdx`: the ROS 2 Bridges section becomes a pointer to the new page. The two existing entries move there with expanded descriptions, nothing is removed.
- `docs/source/_toctree.yml`: one entry for the new page, under Robots next to Third-Party Robots & Teleoperators.
- No code changes, no breaking changes.

## How was this tested (or how to run locally)

- Docs-only change, no tests added.
- All links checked manually against each repository.
- Rendered locally with the docs preview to verify tables, banners, and toctree entry.

## Checklist (required before merge)

- [ ] Linting/formatting run (`pre-commit run -a`)
- [ ] All tests pass locally (`pytest`)
- [x] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: #

## Reviewer notes

- Two placement judgment calls, both cheap to change: (1) dedicated page vs folding the content back into `third_party_robots.mdx` in place; (2) toctree position under Robots vs elsewhere (e.g. Resources), given the page also lists dataset converters.
- The Contributing footer links RFC #4368; strike that sentence if linking an open issue from docs is unwanted.
- Content-wise, the rows for leros2 and lerobot_robot_ros2_zenoh expand the one-line descriptions from #4026; authors of all listed projects were pinged for corrections in the RFC thread.

## AI Disclosure
This PR was developed with significant assistance from Claude (Anthropic). All docs modifications have been reviewed, and validated by the author.