### PR TITLE
fix(processor): stop silently skipping normalization for multi-dataset checkpoints

### DIFF
--- a/examples/tutorial/smolvla/using_smolvla_example.py
+++ b/examples/tutorial/smolvla/using_smolvla_example.py
@@ -17,6 +17,16 @@ def main():
 
     model = SmolVLAPolicy.from_pretrained(model_id)
 
+    # NOTE: a checkpoint trained on several datasets stores one set of normalization
+    # statistics per dataset, and which one to normalize with cannot be inferred here.
+    # Loading such a checkpoint without supplying statistics raises a ValueError listing
+    # the datasets it holds. Pass the statistics of the dataset you are actually running
+    # against, e.g. from a local dataset:
+    #
+    #     from lerobot.datasets.lerobot_dataset import LeRobotDataset
+    #     stats = LeRobotDataset("<your-dataset-repo-id>").meta.stats
+    #     preprocessor_overrides={..., "normalizer_processor": {"stats": stats}}
+    #     postprocessor_overrides={"unnormalizer_processor": {"stats": stats}}
     preprocess, postprocess = make_pre_post_processors(
         model.config,
         model_id,

--- a/src/lerobot/processor/migrate_policy_normalization.py
+++ b/src/lerobot/processor/migrate_policy_normalization.py
@@ -62,6 +62,34 @@ from lerobot.policies import get_policy_class, make_policy_config, make_pre_post
 from lerobot.utils.constants import ACTION
 
 
+def split_dataset_prefix(buffer_name: str) -> tuple[str | None, str]:
+    """
+    Splits a normalization buffer name into its dataset prefix and feature name.
+
+    Policies trained on a single dataset name their buffers `'buffer_<feature>'`.
+    Policies trained on several datasets register one buffer per dataset instead,
+    named `'<dataset>_buffer_<feature>'`. Keeping the dataset name inside the feature
+    name would produce keys such as `'so100.buffer.action'`, which never match the
+    `'action'` key the normalization step looks up at inference time.
+
+    Args:
+        buffer_name: The buffer name, with any module prefix already removed.
+
+    Returns:
+        A tuple of the dataset name (`None` when the buffer is not dataset-scoped)
+        and the feature name, still using `'_'` as its separator.
+    """
+    marker = "_buffer_"
+    if buffer_name.startswith("buffer_"):
+        return None, buffer_name[len("buffer_") :]
+
+    dataset, sep, feature_name = buffer_name.partition(marker)
+    if sep:
+        return dataset, feature_name
+
+    return None, buffer_name
+
+
 def extract_normalization_stats(state_dict: dict[str, torch.Tensor]) -> dict[str, dict[str, torch.Tensor]]:
     """
     Scans a model's state_dict to find and extract normalization statistics.
@@ -70,6 +98,9 @@ def extract_normalization_stats(state_dict: dict[str, torch.Tensor]) -> dict[str
     for mean, std, min, max) based on a set of predefined patterns and organizes
     them into a nested dictionary.
 
+    Dataset-scoped buffers are recognised and their prefix is stripped, so that the
+    resulting keys match the feature names used at inference time.
+
     Args:
         state_dict: The state dictionary of a pretrained policy model.
 
@@ -77,8 +108,14 @@ def extract_normalization_stats(state_dict: dict[str, torch.Tensor]) -> dict[str
         A nested dictionary where outer keys are feature names (e.g.,
         'observation.state') and inner keys are statistic types ('mean', 'std'),
         mapping to their corresponding tensor values.
+
+    Raises:
+        ValueError: If the state dict holds statistics for more than one dataset.
+            The processor pipeline stores a single set of statistics per feature, so
+            there is no correct way to pick one of them here.
     """
     stats = {}
+    datasets: set[str] = set()
 
     # Define patterns to match and their prefixes to remove
     normalization_patterns = [
@@ -89,7 +126,7 @@ def extract_normalization_stats(state_dict: dict[str, torch.Tensor]) -> dict[str
         "unnormalize.",  # Must come after unnormalize_* patterns
         "input_normalizer.",
         "output_normalizer.",
-        "normalalize_inputs.",
+        "normalize_inputs.",
         "unnormalize_outputs.",
         "normalize_targets.",
         "unnormalize_targets.",
@@ -108,8 +145,11 @@ def extract_normalization_stats(state_dict: dict[str, torch.Tensor]) -> dict[str
                 if len(parts) >= 2:
                     # Last part is the stat type (mean, std, min, max, etc.)
                     stat_type = parts[-1]
-                    # Everything else is the feature name
-                    feature_name = ".".join(parts[:-1]).replace("_", ".")
+                    # Everything else is the buffer name, possibly dataset-scoped
+                    dataset, buffer_name = split_dataset_prefix(".".join(parts[:-1]))
+                    feature_name = buffer_name.replace("_", ".")
+                    if dataset is not None:
+                        datasets.add(dataset)
 
                     # Add to stats
                     if feature_name not in stats:
@@ -118,6 +158,16 @@ def extract_normalization_stats(state_dict: dict[str, torch.Tensor]) -> dict[str
 
                 # Only process the first matching pattern
                 break
+
+    if len(datasets) > 1:
+        raise ValueError(
+            f"This checkpoint holds normalization statistics for {len(datasets)} datasets "
+            f"({', '.join(sorted(datasets))}), but a processor pipeline stores a single set of "
+            "statistics per feature. Migrating would keep whichever dataset happens to be read "
+            "last and silently normalize with the wrong values. Migrate the checkpoint once per "
+            "dataset, or attach the statistics of the dataset you intend to use at load time via "
+            'overrides={"normalizer_processor": {"stats": dataset.meta.stats}}.'
+        )
 
     return stats
 

--- a/src/lerobot/processor/normalize_processor.py
+++ b/src/lerobot/processor/normalize_processor.py
@@ -184,6 +184,12 @@ class _NormalizationMixin:
         the plain feature name (e.g. `'action'`). A prefixed key is remapped onto the
         feature name when exactly one candidate exists.
 
+        Candidates are matched on the `'.buffer.'` marker rather than on the feature name
+        alone: every legacy normalization buffer is named `'buffer_<feature>'`, so a
+        dataset-scoped key always carries `'.buffer.'` between the dataset and the feature.
+        Matching the bare suffix would also accept an unrelated feature that merely ends
+        with the same segment (e.g. `'observation.state'` for the key `'state'`).
+
         Raises:
             ValueError: If several datasets provide stats for the same feature. Picking
                 one of them would silently apply the wrong statistics, so the caller has
@@ -195,7 +201,9 @@ class _NormalizationMixin:
         for key in sorted(required):
             if key in self._tensor_stats:
                 continue
-            candidates = sorted(k for k in self._tensor_stats if k.endswith(f".{key}") and k not in required)
+            candidates = sorted(
+                k for k in self._tensor_stats if k.endswith(f".buffer.{key}") and k not in required
+            )
             if len(candidates) == 1:
                 self._tensor_stats[key] = self._tensor_stats.pop(candidates[0])
             elif len(candidates) > 1:

--- a/src/lerobot/processor/normalize_processor.py
+++ b/src/lerobot/processor/normalize_processor.py
@@ -17,6 +17,7 @@
 
 from __future__ import annotations
 
+import logging
 from copy import deepcopy
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
@@ -153,6 +154,82 @@ class _NormalizationMixin:
                     continue
                 self._tensor_stats[key][stat_name] = stat_tensor.reshape(-1, 1, 1)
 
+    def _required_stats_keys(self) -> list[str]:
+        """Returns the keys this step will look up in `_tensor_stats` at runtime.
+
+        Only features whose `FeatureType` maps to a non-identity `NormalizationMode`
+        need statistics. Actions are always transformed under the canonical `ACTION`
+        key by `_normalize_action`, whatever name they carry in `features`.
+        """
+        required: list[str] = []
+        has_action = False
+        for key, feature in self.features.items():
+            if self.norm_map.get(feature.type, NormalizationMode.IDENTITY) == NormalizationMode.IDENTITY:
+                continue
+            if feature.type == FeatureType.ACTION:
+                has_action = True
+                continue
+            if self.normalize_observation_keys is not None and key not in self.normalize_observation_keys:
+                continue
+            required.append(key)
+        if has_action:
+            required.append(ACTION)
+        return required
+
+    def _resolve_prefixed_stats_keys(self) -> None:
+        """Strips dataset prefixes from loaded stats keys when the mapping is unambiguous.
+
+        Checkpoints whose normalization layers were kept per dataset store their stats
+        under prefixed keys (e.g. `'so100.buffer.action'`), while lookups happen under
+        the plain feature name (e.g. `'action'`). A prefixed key is remapped onto the
+        feature name when exactly one candidate exists.
+
+        Raises:
+            ValueError: If several datasets provide stats for the same feature. Picking
+                one of them would silently apply the wrong statistics, so the caller has
+                to supply the stats explicitly instead.
+        """
+        required = set(self._required_stats_keys())
+        ambiguous: dict[str, list[str]] = {}
+
+        for key in sorted(required):
+            if key in self._tensor_stats:
+                continue
+            candidates = sorted(k for k in self._tensor_stats if k.endswith(f".{key}") and k not in required)
+            if len(candidates) == 1:
+                self._tensor_stats[key] = self._tensor_stats.pop(candidates[0])
+            elif len(candidates) > 1:
+                ambiguous[key] = candidates
+
+        if ambiguous:
+            details = "\n".join(f"  {key}: {', '.join(cands)}" for key, cands in ambiguous.items())
+            raise ValueError(
+                "Normalization stats are stored under several dataset-prefixed keys, so the "
+                f"statistics to use cannot be determined:\n{details}\n"
+                "This happens with checkpoints trained on multiple datasets. Choose the stats "
+                "explicitly, for instance with "
+                'from_pretrained(..., overrides={"normalizer_processor": {"stats": dataset.meta.stats}}).'
+            )
+
+    def _warn_on_missing_stats(self) -> None:
+        """Logs the features that will be passed through unchanged for lack of stats.
+
+        `_apply_transform` returns its input untouched when a key has no statistics,
+        which is indistinguishable from a correctly normalized tensor. Reporting it once
+        at load time keeps an incomplete checkpoint from silently degrading inference.
+        """
+        missing = sorted(key for key in self._required_stats_keys() if key not in self._tensor_stats)
+        if not missing:
+            return
+        logging.warning(
+            "%s has no normalization stats for: %s. These features are passed through unchanged, "
+            "so a policy trained on normalized data will receive (or produce) values on the wrong "
+            "scale. Provide the stats explicitly through the processor overrides if this is "
+            "unexpected.",
+            type(self).__name__,
+            ", ".join(missing),
+        )
+
     def to(
         self, device: torch.device | str | None = None, dtype: torch.dtype | None = None
     ) -> _NormalizationMixin:
@@ -206,9 +283,21 @@ class _NormalizationMixin:
         model to a new dataset with different statistics without retraining the entire
         model.
 
+        **Dataset-Prefixed Keys:**
+        Checkpoints that kept one normalization layer per training dataset store their
+        stats under prefixed keys (e.g. `'so100.buffer.action'`). Such a key is remapped
+        onto the feature name it ends with when it is the only candidate; when several
+        datasets provide stats for the same feature, a `ValueError` is raised rather than
+        picking one arbitrarily. Features left without stats are reported via a warning,
+        since they would otherwise be passed through unchanged and unnoticed.
+
         Args:
             state: A flat state dictionary with keys in the format
                    `'feature_name.stat_name'`.
+
+        Raises:
+            ValueError: If a feature's stats are only available under several different
+                dataset prefixes.
 
         Note:
             When stats are preserved due to explicit provision, only the tensor
@@ -221,6 +310,7 @@ class _NormalizationMixin:
             # But ensure _tensor_stats is properly initialized
             self._tensor_stats = to_tensor(self.stats, device=self.device, dtype=self.dtype)  # type: ignore[assignment]
             self._reshape_visual_stats()
+            self._warn_on_missing_stats()
             return
 
         # Normal behavior: load stats from state_dict
@@ -231,6 +321,7 @@ class _NormalizationMixin:
             self._tensor_stats.setdefault(key, {})[stat_name] = tensor.to(
                 dtype=torch.float32, device=self.device
             )
+        self._resolve_prefixed_stats_keys()
         self._reshape_visual_stats()
 
         # Reconstruct the original stats dict from tensor stats for compatibility with to() method
@@ -241,6 +332,8 @@ class _NormalizationMixin:
             for stat_name, tensor in tensor_dict.items():
                 # Convert tensor back to python/numpy format
                 self.stats[key][stat_name] = from_tensor_to_numpy(tensor)
+
+        self._warn_on_missing_stats()
 
     def get_config(self) -> dict[str, Any]:
         """
@@ -327,7 +420,11 @@ class _NormalizationMixin:
             ValueError: If an unsupported normalization mode is encountered.
         """
         norm_mode = self.norm_map.get(feature_type, NormalizationMode.IDENTITY)
-        if norm_mode == NormalizationMode.IDENTITY or key not in self._tensor_stats:
+        if norm_mode == NormalizationMode.IDENTITY:
+            return tensor
+        if key not in self._tensor_stats:
+            # Missing stats are reported once by `_warn_on_missing_stats` when the state
+            # is loaded; this path stays quiet so inference does not flood the logs.
             return tensor
 
         if norm_mode not in (

--- a/tests/processor/test_migrate_policy_normalization.py
+++ b/tests/processor/test_migrate_policy_normalization.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for the extraction of normalization statistics out of legacy checkpoints.
+"""
+
+import pytest
+import torch
+
+from lerobot.processor.migrate_policy_normalization import (
+    extract_normalization_stats,
+    split_dataset_prefix,
+)
+from lerobot.utils.constants import ACTION, OBS_STATE
+
+
+def test_split_dataset_prefix_plain_buffer():
+    assert split_dataset_prefix("buffer_observation_state") == (None, "observation_state")
+
+
+def test_split_dataset_prefix_dataset_scoped_buffer():
+    assert split_dataset_prefix("so100_buffer_action") == ("so100", "action")
+    assert split_dataset_prefix("so100-blue_buffer_observation_state") == (
+        "so100-blue",
+        "observation_state",
+    )
+
+
+def test_split_dataset_prefix_without_buffer_marker():
+    assert split_dataset_prefix("observation_state") == (None, "observation_state")
+
+
+def test_extract_normalization_stats_ignores_unrelated_keys():
+    state_dict = {
+        "normalize_inputs.buffer_observation_state.mean": torch.zeros(6),
+        "normalize_inputs.buffer_observation_state.std": torch.ones(6),
+        "unnormalize_outputs.buffer_action.mean": torch.zeros(6),
+        "unnormalize_outputs.buffer_action.std": torch.ones(6),
+        "model.layers.0.weight": torch.ones(2, 2),
+    }
+
+    stats = extract_normalization_stats(state_dict)
+
+    assert set(stats) == {OBS_STATE, ACTION}
+    assert set(stats[ACTION]) == {"mean", "std"}
+
+
+def test_extract_normalization_stats_matches_plain_input_prefix():
+    """`normalize_inputs.` used to be misspelled, which dropped every observation stat."""
+    state_dict = {
+        "normalize_inputs.so100_buffer_observation_state.mean": torch.zeros(6),
+        "normalize_inputs.so100_buffer_observation_state.std": torch.ones(6),
+    }
+
+    stats = extract_normalization_stats(state_dict)
+
+    assert OBS_STATE in stats
+
+
+def test_extract_normalization_stats_strips_dataset_prefix():
+    """A dataset-scoped buffer yields `action`, not `so100.buffer.action`."""
+    state_dict = {
+        "normalize_inputs.so100_buffer_observation_state.mean": torch.zeros(6),
+        "normalize_inputs.so100_buffer_observation_state.std": torch.ones(6),
+        "normalize_targets.so100_buffer_action.mean": torch.zeros(6),
+        "unnormalize_outputs.so100_buffer_action.std": torch.ones(6),
+    }
+
+    stats = extract_normalization_stats(state_dict)
+
+    assert set(stats) == {OBS_STATE, ACTION}
+
+
+def test_extract_normalization_stats_rejects_several_datasets():
+    """Keeping one dataset at random would silently normalize with the wrong values."""
+    state_dict = {}
+    for dataset in ("so100", "so100-red", "so100-blue"):
+        state_dict[f"normalize_targets.{dataset}_buffer_action.mean"] = torch.zeros(6)
+        state_dict[f"normalize_targets.{dataset}_buffer_action.std"] = torch.ones(6)
+
+    with pytest.raises(ValueError, match="3 datasets"):
+        extract_normalization_stats(state_dict)

--- a/tests/processor/test_normalize_processor.py
+++ b/tests/processor/test_normalize_processor.py
@@ -2169,6 +2169,31 @@ def test_load_state_dict_resolves_single_dataset_prefix():
     torch.testing.assert_close(unnormalized, torch.tensor([11.0, 11.0, 11.0]))
 
 
+def test_load_state_dict_does_not_resolve_across_unrelated_feature_suffix(caplog):
+    """A longer feature name ending with a shorter one must not be mistaken for its stats.
+
+    Candidates are matched on the `.buffer.` marker that every legacy normalization buffer
+    carries, so `observation.state` is not a candidate for a feature named `state`.
+    """
+    features = {"state": PolicyFeature(FeatureType.STATE, (3,))}
+    norm_map = {FeatureType.STATE: NormalizationMode.MEAN_STD}
+    normalizer = NormalizerProcessorStep(features=features, norm_map=norm_map, stats={})
+
+    # Not a dataset-prefixed buffer for `state` — it is a different feature entirely.
+    state_dict = {
+        "observation.state.mean": torch.tensor([10.0, 10.0, 10.0]),
+        "observation.state.std": torch.tensor([2.0, 2.0, 2.0]),
+    }
+
+    with caplog.at_level(logging.WARNING):
+        normalizer.load_state_dict(state_dict)
+
+    # `state` stays unresolved rather than silently adopting `observation.state`'s values.
+    assert "state" not in normalizer._tensor_stats
+    assert "observation.state" in normalizer._tensor_stats
+    assert "state" in caplog.text
+
+
 def test_load_state_dict_raises_on_ambiguous_dataset_prefixes():
     unnormalizer = _action_only_step(UnnormalizerProcessorStep)
     state_dict = _prefixed_action_state_dict(["so100", "so100-blue", "so100-red"])

--- a/tests/processor/test_normalize_processor.py
+++ b/tests/processor/test_normalize_processor.py
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import logging
 from unittest.mock import Mock
 
 import numpy as np
@@ -2135,3 +2136,82 @@ def test_stats_reconstruction_after_load_state_dict():
         new_result[TransitionKey.OBSERVATION][OBS_STATE],
     )
     torch.testing.assert_close(original_result[TransitionKey.ACTION], new_result[TransitionKey.ACTION])
+
+
+def _prefixed_action_state_dict(prefixes: list[str]) -> dict[str, torch.Tensor]:
+    """Builds a state dict mimicking a checkpoint with one normalization layer per dataset."""
+    state = {}
+    for prefix in prefixes:
+        state[f"{prefix}.buffer.action.mean"] = torch.tensor([10.0, 10.0, 10.0])
+        state[f"{prefix}.buffer.action.std"] = torch.tensor([2.0, 2.0, 2.0])
+    return state
+
+
+def _action_only_step(step_cls):
+    features = {ACTION: PolicyFeature(FeatureType.ACTION, (3,))}
+    norm_map = {FeatureType.ACTION: NormalizationMode.MEAN_STD}
+    return step_cls(features=features, norm_map=norm_map, stats={})
+
+
+def test_load_state_dict_resolves_single_dataset_prefix():
+    unnormalizer = _action_only_step(UnnormalizerProcessorStep)
+
+    unnormalizer.load_state_dict(_prefixed_action_state_dict(["so100"]))
+
+    # The prefixed key is remapped onto the key the action lookup actually uses.
+    assert ACTION in unnormalizer._tensor_stats
+    assert "so100.buffer.action" not in unnormalizer._tensor_stats
+
+    transition = create_transition(action=torch.tensor([0.5, 0.5, 0.5]))
+    unnormalized = unnormalizer(transition)[TransitionKey.ACTION]
+
+    # action * std + mean, i.e. the transform is no longer skipped.
+    torch.testing.assert_close(unnormalized, torch.tensor([11.0, 11.0, 11.0]))
+
+
+def test_load_state_dict_raises_on_ambiguous_dataset_prefixes():
+    unnormalizer = _action_only_step(UnnormalizerProcessorStep)
+    state_dict = _prefixed_action_state_dict(["so100", "so100-blue", "so100-red"])
+
+    with pytest.raises(ValueError, match="several dataset-prefixed keys"):
+        unnormalizer.load_state_dict(state_dict)
+
+
+def test_load_state_dict_warns_on_missing_stats(caplog):
+    features = {
+        OBS_STATE: PolicyFeature(FeatureType.STATE, (3,)),
+        ACTION: PolicyFeature(FeatureType.ACTION, (3,)),
+    }
+    norm_map = {
+        FeatureType.STATE: NormalizationMode.MEAN_STD,
+        FeatureType.ACTION: NormalizationMode.MEAN_STD,
+    }
+    normalizer = NormalizerProcessorStep(features=features, norm_map=norm_map, stats={})
+
+    with caplog.at_level(logging.WARNING):
+        normalizer.load_state_dict(_prefixed_action_state_dict(["so100"]))
+
+    # The action stats resolve, the observation stats are absent from the checkpoint.
+    assert ACTION in normalizer._tensor_stats
+    assert OBS_STATE not in normalizer._tensor_stats
+    assert OBS_STATE in caplog.text
+
+
+def test_load_state_dict_does_not_warn_when_stats_are_complete(caplog):
+    normalizer = _action_only_step(NormalizerProcessorStep)
+
+    with caplog.at_level(logging.WARNING):
+        normalizer.load_state_dict(_prefixed_action_state_dict(["so100"]))
+
+    assert "no normalization stats" not in caplog.text
+
+
+def test_identity_features_do_not_require_stats(caplog):
+    features = {ACTION: PolicyFeature(FeatureType.ACTION, (3,))}
+    norm_map = {FeatureType.ACTION: NormalizationMode.IDENTITY}
+    normalizer = NormalizerProcessorStep(features=features, norm_map=norm_map, stats={})
+
+    with caplog.at_level(logging.WARNING):
+        normalizer.load_state_dict({})
+
+    assert "no normalization stats" not in caplog.text


### PR DESCRIPTION
## Summary / Motivation

After the Pipeline migration, normalization and unnormalization are silently skipped at inference for models trained on several datasets. `lerobot/smolvla_base` stores its statistics under `so100.buffer.action`, while `_normalize_action` looks them up under `action`. The lookup misses, `_apply_transform` returns the tensor untouched, and the policy runs on values that are on the wrong scale — with no error and no warning.

The root cause is in the migration script, and the reason it went unnoticed is in the processor. This PR fixes both, and makes the failure mode visible rather than silent.

The trade-off worth flagging: two paths that used to "succeed" now raise. That is deliberate. Both of them were producing or consuming statistics that cannot be correct, and continuing quietly is what let this reach a published checkpoint.

## Related issues

- Related: #4415

## Root cause

Legacy checkpoints trained on several datasets register one buffer per dataset, named `<dataset>_buffer_<feature>` rather than `buffer_<feature>`. Confirmed against the pre-migration revision of `lerobot/smolvla_base` (`3326b100`, the commit before *Convert smolvla with Pipeline (#11)*):

```
normalize_inputs.so100-blue_buffer_observation_state.mean
normalize_targets.so100_buffer_action.mean
unnormalize_outputs.so100-red_buffer_action.mean
```

Running those keys through the old pattern list in `extract_normalization_stats`:

| Key | Matched pattern | Result |
| --- | --- | --- |
| `normalize_inputs.so100_buffer_observation_state.mean` | none | silently discarded |
| `normalize_targets.so100_buffer_action.mean` | `normalize_targets.` | `so100.buffer.action` |
| `unnormalize_outputs.so100_buffer_action.mean` | `unnormalize_outputs.` | `so100.buffer.action` |

Two independent defects combined:

1. `normalize_inputs.buffer_` requires `buffer_` immediately after the module name, so it does not match a dataset-scoped buffer — and the plain `normalize_inputs.` prefix was misspelled `normalalize_inputs.`, so it could never match anything. With both input patterns dead, **every observation statistic was dropped**, while the action statistics survived through the correctly spelled `unnormalize_outputs.` and `normalize_targets.` patterns.
2. `.replace("_", ".")` was applied to the whole buffer name, turning `so100_buffer_action` into the feature name `so100.buffer.action`.

This accounts for all three observed symptoms: the prefix shape, the action statistics surviving, and the observation statistics being absent. The migrated files on the Hub contain exactly six tensors — `{so100, so100-red, so100-blue} × action × {mean, std}` — and nothing else.

## What changed

**`normalize_processor.py`** — make the miss visible and resolvable

- `_required_stats_keys()` lists the keys a step actually looks up at runtime: identity-mapped features and those excluded by `normalize_observation_keys` are skipped, and actions are folded onto the canonical `ACTION` key regardless of the name they carry in `features`.
- `_resolve_prefixed_stats_keys()` runs during `load_state_dict` and remaps a dataset-prefixed key onto the feature name it ends with **when it is the only candidate**. When several datasets provide statistics for the same feature it raises, listing the candidates, instead of picking one arbitrarily — suffix matching alone would have turned a silent skip into a silent application of another dataset's statistics, which is harder to notice, not easier.
- `_warn_on_missing_stats()` reports, once at load time, any feature that will be passed through unchanged for lack of statistics.
- `_apply_transform` splits `norm_mode == IDENTITY or key not in self._tensor_stats` into two branches. Behaviour is unchanged (the hot path stays quiet so inference does not flood the logs), but a deliberate pass-through is now distinguishable in the source from one caused by missing statistics.

**`migrate_policy_normalization.py`** — fix the artifacts at the source

- New `split_dataset_prefix()` separates `<dataset>_buffer_<feature>` into its two parts before the feature name is derived, so the dataset name no longer leaks into it. Single-dataset checkpoints (`buffer_<feature>`) are unaffected.
- Fixed the `normalalize_inputs.` typo, so observation statistics are no longer discarded.
- `extract_normalization_stats` now raises when the state dict holds statistics for more than one dataset. A pipeline stores one set of statistics per feature, so the previous behaviour was "whichever dataset is read last wins".
- Incidental fix: checkpoints using `normalize.buffer_<feature>` previously migrated to the feature name `buffer.action`; they now migrate to `action`.

### Breaking changes

- Loading a multi-dataset checkpoint without supplying statistics now raises instead of returning a silently mis-normalized policy. The message points at `overrides={"normalizer_processor": {"stats": dataset.meta.stats}}`. The standard fine-tuning path is unaffected: it passes `dataset_stats`, which takes the override branch of `load_state_dict` and never reaches this code.
- Migrating a multi-dataset checkpoint now raises. Migrate once per dataset, or attach the statistics at load time.

## How was this tested (or how to run locally)

```
uv run pre-commit run --all-files
uv run pytest tests/processor tests/policies -q
```

On macOS arm64 / MPS, Python 3.14, at `959e0a77`, with `--extra test --extra dev --extra dataset`:

| Check | Result |
| --- | --- |
| `pre-commit run` (touched files) | all hooks pass (ruff, typos, pyupgrade, gitleaks, bandit, mypy) |
| `pytest tests/processor` | 420 passed, 105 skipped |
| `pytest tests/policies` | 434 passed, 83 skipped |

Two notes for anyone reproducing this: the pre-commit hook environments pin `python3.12`, so `uv python install 3.12` is needed if the working interpreter is newer; and these counts are higher than the ones reported earlier in this PR because installing the `dataset` extra unskips a large block of tests.

Tests added:

- `tests/processor/test_normalize_processor.py` — single prefix resolved (asserting the values are actually transformed, not merely that the key exists), several prefixes rejected, missing statistics warned about, no warning when statistics are complete, identity features needing none.
- `tests/processor/test_migrate_policy_normalization.py` (new file) — prefix splitting for plain, dataset-scoped and marker-less buffers; unrelated keys ignored; the plain `normalize_inputs.` prefix matched; the dataset prefix stripped; several datasets rejected.
- `test_load_state_dict_does_not_resolve_across_unrelated_feature_suffix` (added in `b7ba5fca`, from review) — a feature named `state` must not adopt `observation.state`'s statistics. Written before the fix and confirmed to fail against the previous matching, which resolved it to the wrong key.

The existing regression tests around `load_state_dict` (`test_state_dict_save_load`, `test_stats_override_preservation_in_load_state_dict`, `test_stats_reconstruction_after_load_state_dict`) and the `hotswap_stats` suite pass unchanged, and no warning noise appears in their output.

Rebased against `upstream/main` (`d0af0577`): no conflicts, and none of the commits landed since branching touch the files in this PR.

Not run: the full `pytest tests` suite, which needs hardware and simulator extras this machine does not have.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`) — `tests/processor` and `tests/policies`; the full suite needs extras unavailable here
- [x] Documentation updated — docstrings updated; no user-facing docs affected
- [ ] CI is green — the workflows are held at `action_required` pending maintainer approval
- [x] Community Review: I have reviewed another contributor's open PR and linked it here: #4441

## Reviewer notes

- **The main judgement call is raising rather than guessing.** Both new exceptions replace a path that previously "worked". If you would rather these degrade to warnings, the two call sites are `_resolve_prefixed_stats_keys` and the tail of `extract_normalization_stats`.
- **`lerobot/smolvla_base` is not repaired by this PR.** Its observation statistics are gone from the published artifact and cannot be recovered by any key-resolution logic — re-running the fixed migration against `3326b100` is required. That run will now stop on the multi-dataset guard, which is correct: deciding which of `so100` / `so100-red` / `so100-blue` to publish (or whether to publish three variants) is a call for the maintainers, not the script.
- Worth a close look: `_required_stats_keys()`'s handling of `normalize_observation_keys` and of action features named something other than `action`, since that set drives both the resolution and the warning.
- `split_dataset_prefix` splits on the first `_buffer_`. A feature name legitimately containing that substring would be mis-split; I judged this unlikely enough not to warrant a more elaborate scheme, but flagging it.
- **Left deliberately unfixed:** `feature_name = buffer_name.replace("_", ".")` is still unconditional after the prefix is split off, so a feature whose name legitimately contains an underscore is mangled independently of any dataset prefix — `observation.environment_state` (`OBS_ENV_STATE`, used by ACT, TDMPC and gaussian_actor) migrates to `observation.environment.state` and is then never found at runtime. That is a third distinct defect in this function, it hits single-dataset checkpoints too, and resolving it unambiguously needs the policy's declared feature keys threaded into `extract_normalization_stats`. Keeping it out of this PR so the dataset-prefix change stays reviewable on its own. Filed as #4451.

### Known consequence for inference call sites

These build processors from a pretrained path without passing `dataset_stats`, so they raise against the current `lerobot/smolvla_base` artifact once this lands:

- `src/lerobot/scripts/lerobot_eval.py:776`
- `src/lerobot/async_inference/policy_server.py:157`

This is not new breakage — it is #4415's already-broken artifact surfacing instead of silently propagating a wrong normalization. Resolving it properly is either a re-migrated Hub artifact (fixes every caller at once) or an explicit stats-override path at these call sites; both are maintainer calls, so they are flagged rather than patched here. The training path (`lerobot_train.py:502`) and `rollout/context.py:495` pass `dataset_stats` and are unaffected.

`examples/tutorial/smolvla/using_smolvla_example.py` is self-contained, so it is documented inline instead (`959e0a77`). No statistics are hardcoded there on purpose: the right values depend on which of `so100` / `so100-red` / `so100-blue` the reader runs against, and inventing numbers in an example that drives real hardware would be worse than the bug this PR fixes.

Thanks to @waterEand for catching all of the above in review.

