### PR TITLE
feat(robots): add opt-in SO follower stall protection

### DIFF
--- a/docs/source/so101.mdx
+++ b/docs/source/so101.mdx
@@ -444,6 +444,20 @@ leader.disconnect()
 </hfoption>
 </hfoptions>
 
+### Optional stall protection
+
+SO-100 and SO-101 followers can monitor motor current while executing actions and disable torque when a
+joint remains both heavily loaded and far from its commanded position. The protection is opt-in because
+current varies with the arm, payload, and task. Configure only the motors you want to monitor by passing a
+motor-to-threshold mapping to `--robot.stall_current_thresholds`. Thresholds use the raw
+`Present_Current` register units and must be measured on your own hardware under its expected payload.
+`--robot.stall_position_tolerance` and `--robot.stall_timeout_s` control how far and how long a motor must
+miss its target before the high-current condition trips.
+
+When protection trips, `send_action()` raises `MotorStallError` and remains latched until the robot
+reconnects. Do not use this host-side check as a substitute for an emergency stop or the motor controller's
+own protections.
+
 Congrats 🎉, your robot is all set to learn a task on its own. Start training it by following this tutorial: [Getting started with real-world robots](./il_robots)
 
 > [!TIP]

--- a/src/lerobot/robots/so_follower/__init__.py
+++ b/src/lerobot/robots/so_follower/__init__.py
@@ -20,7 +20,7 @@ from .config_so_follower import (
     SOFollowerConfig,
     SOFollowerRobotConfig,
 )
-from .so_follower import SO100Follower, SO101Follower, SOFollower
+from .so_follower import MotorStallError, SO100Follower, SO101Follower, SOFollower
 
 __all__ = [
     "SO100Follower",
@@ -30,4 +30,5 @@ __all__ = [
     "SOFollower",
     "SOFollowerConfig",
     "SOFollowerRobotConfig",
+    "MotorStallError",
 ]

--- a/src/lerobot/robots/so_follower/config_so_follower.py
+++ b/src/lerobot/robots/so_follower/config_so_follower.py
@@ -52,12 +52,29 @@ class SOFollowerConfig:
     # failure, so the steady-state read cost is unchanged.
     num_read_retries: int = 2
 
+    # Optional host-side stall protection. Keys select the motors to monitor and values are thresholds in
+    # raw Present_Current register units. Protection remains disabled when this is None. When a monitored
+    # motor stays above its threshold while missing its last commanded position, torque is disabled for the
+    # whole arm and send_action raises MotorStallError.
+    stall_current_thresholds: dict[str, float] | None = None
+    stall_position_tolerance: float = 2.0
+    stall_timeout_s: float = 0.5
+
 
 @RobotConfig.register_subclass("so101_follower")
 @RobotConfig.register_subclass("so100_follower")
 @dataclass
 class SOFollowerRobotConfig(RobotConfig, SOFollowerConfig):
-    pass
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        if self.stall_current_thresholds is not None and any(
+            threshold <= 0 for threshold in self.stall_current_thresholds.values()
+        ):
+            raise ValueError("stall_current_thresholds values must be positive")
+        if self.stall_position_tolerance <= 0:
+            raise ValueError("stall_position_tolerance must be positive")
+        if self.stall_timeout_s <= 0:
+            raise ValueError("stall_timeout_s must be positive")
 
 
 SO100FollowerConfig = SOFollowerRobotConfig

--- a/src/lerobot/robots/so_follower/so_follower.py
+++ b/src/lerobot/robots/so_follower/so_follower.py
@@ -34,6 +34,10 @@ from .config_so_follower import SOFollowerRobotConfig
 logger = logging.getLogger(__name__)
 
 
+class MotorStallError(RuntimeError):
+    """Raised after SO follower stall protection disables motor torque."""
+
+
 class SOFollower(Robot):
     """
     Generic SO follower base implementing common functionality for SO-100/101/10X.
@@ -61,6 +65,15 @@ class SOFollower(Robot):
             calibration=self.calibration,
         )
         self.cameras = make_cameras_from_configs(config.cameras)
+        self._last_goal_pos: dict[str, float] | None = None
+        self._stall_started_at: dict[str, float] = {}
+        self._stall_protection_tripped = False
+
+        unknown_stall_motors = set(config.stall_current_thresholds or {}) - set(self.bus.motors)
+        if unknown_stall_motors:
+            raise ValueError(
+                f"stall_current_thresholds contains unknown motors: {', '.join(sorted(unknown_stall_motors))}"
+            )
 
     @property
     def _motors_ft(self) -> dict[str, type]:
@@ -95,6 +108,9 @@ class SOFollower(Robot):
         and torque can be safely disabled to run calibration.
         """
 
+        self._last_goal_pos = None
+        self._stall_started_at.clear()
+        self._stall_protection_tripped = False
         self.bus.connect()
         if not self.is_calibrated and calibrate:
             logger.info(
@@ -216,18 +232,74 @@ class SOFollower(Robot):
             RobotAction: the action sent to the motors, potentially clipped.
         """
 
+        if self._stall_protection_tripped:
+            raise MotorStallError("SO follower stall protection is latched; reconnect the robot to reset it")
+
         goal_pos = {key.removesuffix(".pos"): val for key, val in action.items() if key.endswith(".pos")}
+
+        present_pos = None
+        if self.config.max_relative_target is not None or self.config.stall_current_thresholds:
+            present_pos = self.bus.sync_read("Present_Position", num_retry=self.config.num_read_retries)
+
+        if self.config.stall_current_thresholds and self._last_goal_pos is not None:
+            assert present_pos is not None
+            self._check_for_stall(present_pos)
 
         # Cap goal position when too far away from present position.
         # /!\ Slower fps expected due to reading from the follower.
         if self.config.max_relative_target is not None:
-            present_pos = self.bus.sync_read("Present_Position", num_retry=self.config.num_read_retries)
+            assert present_pos is not None
             goal_present_pos = {key: (g_pos, present_pos[key]) for key, g_pos in goal_pos.items()}
             goal_pos = ensure_safe_goal_position(goal_present_pos, self.config.max_relative_target)
 
         # Send goal position to the arm
         self.bus.sync_write("Goal_Position", goal_pos)
+        self._last_goal_pos = goal_pos.copy()
         return {f"{motor}.pos": val for motor, val in goal_pos.items()}
+
+    def _check_for_stall(self, present_pos: dict[str, float]) -> None:
+        """Disable torque when high current and position error persist together."""
+        assert self.config.stall_current_thresholds is not None
+        assert self._last_goal_pos is not None
+
+        present_current = self.bus.sync_read("Present_Current", num_retry=self.config.num_read_retries)
+        now = time.perf_counter()
+        stalled: dict[str, tuple[float, float]] = {}
+
+        for motor, current_threshold in self.config.stall_current_thresholds.items():
+            if motor not in self._last_goal_pos:
+                self._stall_started_at.pop(motor, None)
+                continue
+
+            current = abs(float(present_current[motor]))
+            position_error = abs(float(self._last_goal_pos[motor]) - float(present_pos[motor]))
+            is_stalling = (
+                current >= current_threshold and position_error >= self.config.stall_position_tolerance
+            )
+            if not is_stalling:
+                self._stall_started_at.pop(motor, None)
+                continue
+
+            started_at = self._stall_started_at.setdefault(motor, now)
+            if now - started_at >= self.config.stall_timeout_s:
+                stalled[motor] = (current, position_error)
+
+        if not stalled:
+            return
+
+        details = ", ".join(
+            f"{motor} (current={current:g}, position_error={position_error:g})"
+            for motor, (current, position_error) in stalled.items()
+        )
+        self._stall_protection_tripped = True
+        logger.error("SO follower stall protection tripped: %s", details)
+        try:
+            self.bus.disable_torque(num_retry=self.config.num_read_retries)
+        except Exception as exc:
+            raise MotorStallError(
+                f"SO follower stall protection tripped but torque disable failed: {details}"
+            ) from exc
+        raise MotorStallError(f"SO follower stall protection disabled torque: {details}")
 
     @check_if_not_connected
     def disconnect(self):

--- a/tests/robots/test_so100_follower.py
+++ b/tests/robots/test_so100_follower.py
@@ -20,6 +20,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from lerobot.robots.so_follower import (
+    MotorStallError,
     SO100Follower,
     SO100FollowerConfig,
 )
@@ -149,3 +150,98 @@ def test_configure_writes_position_pid_coefficients():
     bus_mock.write.assert_any_call("P_Coefficient", "shoulder_pan", 32)
     bus_mock.write.assert_any_call("I_Coefficient", "shoulder_pan", 1)
     bus_mock.write.assert_any_call("D_Coefficient", "shoulder_pan", 16)
+
+
+def test_stall_protection_disables_torque_after_persistent_current(monkeypatch, follower):
+    follower.config.stall_current_thresholds = {"shoulder_pan": 100}
+    follower.config.stall_position_tolerance = 5
+    follower.config.stall_timeout_s = 0.5
+    follower.connect()
+
+    positions = dict.fromkeys(follower.bus.motors, 0)
+    currents = dict.fromkeys(follower.bus.motors, 0)
+    currents["shoulder_pan"] = 120
+    follower.bus.sync_read.side_effect = lambda register, **_: (
+        positions if register == "Present_Position" else currents
+    )
+    times = iter([10.0, 10.6])
+    monkeypatch.setattr("lerobot.robots.so_follower.so_follower.time.perf_counter", lambda: next(times))
+
+    action = {f"{motor}.pos": (20 if motor == "shoulder_pan" else 0) for motor in follower.bus.motors}
+    follower.send_action(action)
+    follower.send_action(action)
+
+    with pytest.raises(MotorStallError, match="disabled torque.*shoulder_pan"):
+        follower.send_action(action)
+
+    follower.bus.disable_torque.assert_called_once_with(num_retry=follower.config.num_read_retries)
+    assert follower.bus.sync_write.call_count == 2
+
+    with pytest.raises(MotorStallError, match="latched"):
+        follower.send_action(action)
+
+
+def test_stall_protection_requires_current_and_position_error(monkeypatch, follower):
+    follower.config.stall_current_thresholds = {"shoulder_pan": 100}
+    follower.config.stall_position_tolerance = 5
+    follower.config.stall_timeout_s = 0.5
+    follower.connect()
+
+    positions = dict.fromkeys(follower.bus.motors, 0)
+    currents = dict.fromkeys(follower.bus.motors, 0)
+    currents["shoulder_pan"] = 120
+    follower.bus.sync_read.side_effect = lambda register, **_: (
+        positions if register == "Present_Position" else currents
+    )
+    times = iter([10.0, 11.0])
+    monkeypatch.setattr("lerobot.robots.so_follower.so_follower.time.perf_counter", lambda: next(times))
+
+    action = {f"{motor}.pos": 0 for motor in follower.bus.motors}
+    follower.send_action(action)
+    follower.send_action(action)
+    follower.send_action(action)
+
+    follower.bus.disable_torque.assert_not_called()
+    assert follower.bus.sync_write.call_count == 3
+
+
+def test_stall_protection_requires_a_continuous_high_current_window(monkeypatch, follower):
+    follower.config.stall_current_thresholds = {"shoulder_pan": 100}
+    follower.config.stall_position_tolerance = 5
+    follower.config.stall_timeout_s = 0.5
+    follower.connect()
+
+    positions = dict.fromkeys(follower.bus.motors, 0)
+    high_current = dict.fromkeys(follower.bus.motors, 0)
+    high_current["shoulder_pan"] = 120
+    low_current = dict.fromkeys(follower.bus.motors, 0)
+    current_samples = iter([high_current, low_current, high_current, high_current])
+    follower.bus.sync_read.side_effect = lambda register, **_: (
+        positions if register == "Present_Position" else next(current_samples)
+    )
+    times = iter([10.0, 10.2, 10.4, 11.0])
+    monkeypatch.setattr("lerobot.robots.so_follower.so_follower.time.perf_counter", lambda: next(times))
+
+    action = {f"{motor}.pos": (20 if motor == "shoulder_pan" else 0) for motor in follower.bus.motors}
+    follower.send_action(action)
+    follower.send_action(action)  # Start the first high-current window.
+    follower.send_action(action)  # Low current resets it.
+    follower.send_action(action)  # Start a new window.
+
+    with pytest.raises(MotorStallError):
+        follower.send_action(action)
+
+    follower.bus.disable_torque.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"stall_current_thresholds": {"shoulder_pan": 0}}, "must be positive"),
+        ({"stall_position_tolerance": 0}, "must be positive"),
+        ({"stall_timeout_s": 0}, "must be positive"),
+    ],
+)
+def test_stall_protection_config_validation(kwargs, message):
+    with pytest.raises(ValueError, match=message):
+        SO100FollowerConfig(port="/dev/null", **kwargs)


### PR DESCRIPTION
## Summary / Motivation

SO-100/101 followers currently limit relative target size, but they do not stop when a motor keeps drawing high current while failing to reach its commanded position. Repeated position commands can therefore keep an arm pushing against a hard obstruction.

This adds opt-in, per-motor stall protection in the SO follower driver. It combines current, position error, and persistence instead of reacting to a single current spike. The default behavior is unchanged. When enabled, each action adds a position read and a current read; if `max_relative_target` is also enabled, its existing position read is reused.

## Related issues

- Related: #1314 (earlier force-feedback experiment and current-sensing discussion)

## What changed

- Added `stall_current_thresholds`, `stall_position_tolerance`, and `stall_timeout_s` to `SOFollowerRobotConfig`.
- Monitors only explicitly configured motors; no hardware-specific current thresholds are built into LeRobot.
- Requires high current and unresolved position error to persist for the configured interval.
- Disables torque for the arm, raises `MotorStallError`, and latches the stop until reconnect.
- Added configuration validation, regression tests, and SO-101 documentation.

This is backward compatible: stall protection is disabled unless `stall_current_thresholds` is configured.

## How was this tested (or how to run locally)

- `pytest -q tests/robots/test_so100_follower.py` — 12 passed.
- `pre-commit run --from-ref origin/main --to-ref HEAD` — all applicable hooks passed.
- Hardware validation on an SO-101 with STS3215 motors:
  - read real `Present_Position` and `Present_Current` values;
  - created an unresolved-target detector state without sending a motion target;
  - verified the persistent condition raised `MotorStallError`;
  - read back `Torque_Enable == 0` for all six motors.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a` equivalent on the changed range)
- [ ] All tests pass locally (targeted tests pass; full suite not run)
- [x] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: #

## Reviewer notes

- Please review whether whole-arm torque disable is the desired stop behavior when one monitored joint trips.
- Thresholds intentionally remain installation-specific because current varies with motor, payload, and task.
- The detector is placed in `send_action()` so teleoperate, record, replay, and rollout paths share the same protection.
- Significant AI assistance was used; the contributor reviewed and hardware-tested the change.
