### PR TITLE
fix(rollout): carry --duration to dataset.episode_time_s for episodic

### DIFF
--- a/docs/source/inference.mdx
+++ b/docs/source/inference.mdx
@@ -190,7 +190,7 @@ Teleop is optional — if omitted the robot holds its position during the reset 
 | Flag                                            | Description                                                                                                                                                |
 | ----------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--dataset.num_episodes`                        | Number of episodes to record                                                                                                                               |
-| `--dataset.episode_time_s`                      | Duration of each recording episode in seconds                                                                                                              |
+| `--dataset.episode_time_s`                      | Duration of each recording episode in seconds. Defaults to `--duration` when that is set and this one is not                                               |
 | `--dataset.reset_time_s`                        | Duration of the reset phase between episodes in seconds                                                                                                    |
 | `--teleop.type`                                 | Optional. Teleoperator to drive the robot during resets                                                                                                    |
 | `--strategy.reset_to_initial_position`          | Whether to reset the robot to its initial position between episodes                                                                                        |

--- a/src/lerobot/rollout/configs.py
+++ b/src/lerobot/rollout/configs.py
@@ -128,6 +128,8 @@ class EpisodicStrategyConfig(RolloutStrategyConfig):
 
     Records ``dataset.num_episodes`` episodes of maximum ``dataset.episode_time_s`` each.
     After each episode, runs ``dataset.reset_time_s`` seconds of reset time.
+    ``--duration`` is a per-episode cap here: when set and ``dataset.episode_time_s``
+    is not, it is used as the episode length.
 
     Keyboard controls:
         Right arrow  — end current episode or reset phase early
@@ -343,6 +345,19 @@ class RolloutConfig:
                 raise ValueError(
                     "DAgger num_episodes must be set either via --strategy.num_episodes or --dataset.num_episodes"
                 )
+
+        # Episodic: --duration caps a single episode, not the whole session (the
+        # session ends after --dataset.num_episodes episodes).
+        if isinstance(self.strategy, EpisodicStrategyConfig) and self.duration > 0:
+            if parser.parse_arg("dataset.episode_time_s") is not None:
+                logger.warning(
+                    "Both --duration and --dataset.episode_time_s are set for the episodic strategy; "
+                    "using --dataset.episode_time_s=%s and ignoring --duration.",
+                    self.dataset.episode_time_s,
+                )
+            else:
+                logger.info("Propagating --duration=%s to --dataset.episode_time_s", self.duration)
+                self.dataset.episode_time_s = self.duration
 
         # --- Policy loading ---
         if self.robot is None:


### PR DESCRIPTION
## Summary / Motivation

The episodic strategy takes its episode length from `--dataset.episode_time_s` and never reads `--duration`, so `lerobot-rollout --strategy.type=episodic --duration=30` silently recorded 60 s episodes (the `DatasetRecordConfig` default). Unlike the other strategies, where `--duration` caps the whole session, an episodic session ends after `--dataset.num_episodes`, so `--duration` there naturally means the per-episode cap.
Propagated now, an explicit `--dataset.episode_time_s` still wins and logs a warning, so no existing command changes behavior.

## How was this tested (or how to run locally)

- no specific tests

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated
- [ ] CI is green

## Reviewer notes

- Semantics worth a sanity check: for episodic, `--duration` means *per episode*, not *whole session* (session length stays `num_episodes × (episode_time_s + reset_time_s)`).