### PR TITLE
fix(robots): keep depth keys of top-level cameras unprefixed in bimanual robots

### DIFF
--- a/src/lerobot/robots/bi_openarm_follower/bi_openarm_follower.py
+++ b/src/lerobot/robots/bi_openarm_follower/bi_openarm_follower.py
@@ -50,6 +50,10 @@ class BiOpenArmFollower(BimanualMixin, Robot):
             raise ValueError(
                 f"Top-level camera names collide with per-arm camera names: {sorted(_collisions)}"
             )
+        # Depth streams ("cam" -> "cam_depth") of top-level cameras must stay unprefixed too.
+        self._top_level_cam_keys |= {
+            f"{cam}_depth" for cam, cam_cfg in config.cameras.items() if getattr(cam_cfg, "use_depth", False)
+        }
         left_arm_cameras = {**config.left_arm_config.cameras, **config.cameras}
 
         left_arm_config = OpenArmFollowerConfig(

--- a/src/lerobot/robots/bi_rebot_b601_follower/bi_rebot_b601_follower.py
+++ b/src/lerobot/robots/bi_rebot_b601_follower/bi_rebot_b601_follower.py
@@ -52,6 +52,10 @@ class BiRebotB601Follower(BimanualMixin, Robot):
             raise ValueError(
                 f"Top-level camera names collide with per-arm camera names: {sorted(_collisions)}"
             )
+        # Depth streams ("cam" -> "cam_depth") of top-level cameras must stay unprefixed too.
+        self._top_level_cam_keys |= {
+            f"{cam}_depth" for cam, cam_cfg in config.cameras.items() if getattr(cam_cfg, "use_depth", False)
+        }
         left_arm_cameras = {**config.left_arm_config.cameras, **config.cameras}
 
         left_arm_config = RebotB601FollowerRobotConfig(

--- a/src/lerobot/robots/bi_so_follower/bi_so_follower.py
+++ b/src/lerobot/robots/bi_so_follower/bi_so_follower.py
@@ -50,6 +50,10 @@ class BiSOFollower(BimanualMixin, Robot):
             raise ValueError(
                 f"Top-level camera names collide with per-arm camera names: {sorted(_collisions)}"
             )
+        # Depth streams ("cam" -> "cam_depth") of top-level cameras must stay unprefixed too.
+        self._top_level_cam_keys |= {
+            f"{cam}_depth" for cam, cam_cfg in config.cameras.items() if getattr(cam_cfg, "use_depth", False)
+        }
         left_arm_cameras = {**config.left_arm_config.cameras, **config.cameras}
 
         left_arm_config = SOFollowerRobotConfig(

--- a/tests/robots/test_bi_so_follower.py
+++ b/tests/robots/test_bi_so_follower.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import MagicMock, patch
+
+from lerobot.cameras.opencv import OpenCVCameraConfig
+from lerobot.cameras.realsense import RealSenseCameraConfig
+from lerobot.robots.bi_so_follower import BiSOFollower, BiSOFollowerConfig
+from lerobot.robots.so_follower import SOFollowerConfig
+
+_SO_FOLLOWER_MODULE = "lerobot.robots.so_follower.so_follower"
+
+
+def _camera_config(index: int) -> OpenCVCameraConfig:
+    return OpenCVCameraConfig(index_or_path=index, width=640, height=480, fps=30)
+
+
+def _depth_camera_config(serial: str) -> RealSenseCameraConfig:
+    return RealSenseCameraConfig(serial_number_or_name=serial, width=640, height=480, fps=30, use_depth=True)
+
+
+def _fake_make_cameras(configs):
+    """Build camera stubs mirroring the config, without touching camera SDKs."""
+    cameras = {}
+    for name, cfg in configs.items():
+        cam = MagicMock()
+        cam.height, cam.width = cfg.height, cfg.width
+        cam.use_rgb = True
+        cam.use_depth = getattr(cfg, "use_depth", False)
+        cameras[name] = cam
+    return cameras
+
+
+def _make_robot(cameras: dict) -> BiSOFollower:
+    bus_mock = MagicMock()
+    bus_mock.motors = ["shoulder_pan", "shoulder_lift", "elbow_flex", "wrist_flex", "wrist_roll", "gripper"]
+    with (
+        patch(f"{_SO_FOLLOWER_MODULE}.FeetechMotorsBus", return_value=bus_mock),
+        patch(f"{_SO_FOLLOWER_MODULE}.make_cameras_from_configs", _fake_make_cameras),
+    ):
+        cfg = BiSOFollowerConfig(
+            left_arm_config=SOFollowerConfig(port="/dev/null0"),
+            right_arm_config=SOFollowerConfig(port="/dev/null1"),
+            cameras=cameras,
+        )
+        return BiSOFollower(cfg)
+
+
+def test_top_level_camera_key_stays_unprefixed():
+    robot = _make_robot(cameras={"top": _camera_config(0)})
+    assert set(robot._cameras_ft) == {"top"}
+
+
+def test_top_level_depth_key_stays_unprefixed():
+    """The depth sibling of a top-level camera must not get an arm prefix (regression:
+    a top-level depth camera produced ``left_top_depth`` instead of ``top_depth``)."""
+    robot = _make_robot(cameras={"top": _depth_camera_config("111")})
+    assert set(robot._cameras_ft) == {"top", "top_depth"}


### PR DESCRIPTION
## Summary / Motivation

Bimanual robots (`bi_so_follower`, `bi_openarm_follower`, `bi_rebot_b601_follower`) track top-level cameras (`--robot.cameras`) by their base names in `_top_level_cam_keys` to keep their observation keys unprefixed. However, depth-enabled cameras emit an extra `{cam}_depth` key from the arm that opens them (e.g. `so_follower.py`), and that sibling key is not in the set — so it incorrectly receives the `left_` arm prefix.

Recording with a top-level RealSense camera `top` with `use_depth: true` produces the dataset features:

- `observation.images.top` — correct
- `observation.images.left_top_depth` — wrong, expected `observation.images.top_depth`

## Related issues

None filed.

## What changed

- In all three bimanual robots' `__init__`, after the camera-name collision check, `_top_level_cam_keys` is extended with `{cam}_depth` for every top-level camera config with `use_depth` enabled. Both `_cameras_ft` and `get_observation` consult this set, so feature names and recorded observations are fixed together.
- Per-arm cameras (`{left,right}_arm_config.cameras`) are unaffected: their RGB and depth keys were already prefixed consistently.
- Not breaking for correctly-named datasets. Datasets recorded with top-level depth cameras before this fix carry the doubled prefix and won't match newly recorded key names; the underlying frames are correct, only the keys were wrong.

## How was this tested (or how to run locally)

Tests added: `tests/robots/test_bi_so_follower.py` — a mocked `BiSOFollower` with a depth-enabled top-level camera `top` must expose the camera features `{"top", "top_depth"}`. On `main` this fails, producing `left_top_depth` instead of `top_depth`, which reproduces the bug.

```bash
uv run pytest tests/robots/test_bi_so_follower.py -q
```

Also reproduced with `lerobot-record` on a `bi_so_follower` with a top-level RealSense camera:

```bash
lerobot-record ... \
  --robot.cameras="{top: {type: intelrealsense, serial_number_or_name: '...', width: 640, height: 480, fps: 30, use_depth: true}}"
```

Before the fix the recorded dataset contains `observation.images.left_top_depth`; after the fix it contains `observation.images.top_depth`.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated (not needed — behavior now matches the documented naming)
- [ ] CI is green
- [x] Community Review: I have reviewed another contributor's open PR and linked it here: #4376 ([review comment](https://github.com/huggingface/lerobot/pull/4376#issuecomment-5293749997))

## Reviewer notes

- The identical four-line change is applied to all three bimanual robots because the top-level-camera logic is copy-pasted across them and each single-arm counterpart emits `{cam}_depth` keys.
- `use_depth` is read from the camera *config* via `getattr(..., False)`, matching the existing idiom in `rebot_b601_follower` / `omx_follower` / `unitree_g1` feature code.

---

Disclosure per [AI_POLICY.md](https://github.com/huggingface/lerobot/blob/main/AI_POLICY.md): this PR was written with AI assistance (Claude Code), then reviewed and tested locally as described above.
