### PR TITLE
fix(eval): isolate policy state per worker thread in eval_policy_all

### DIFF
--- a/src/lerobot/envs/configs.py
+++ b/src/lerobot/envs/configs.py
@@ -58,6 +58,8 @@ class EnvConfig(draccus.ChoiceRegistry, abc.ABC):
     fps: int = 30
     features: dict[str, PolicyFeature] = field(default_factory=dict)
     features_map: dict[str, str] = field(default_factory=dict)
+    # Evaluate this many tasks concurrently in eval_policy_all. Each worker thread deep-copies the
+    # policy and processors on first use, so memory scales with this value, not with the task count.
     max_parallel_tasks: int = 1
     disable_env_checker: bool = True
 

--- a/src/lerobot/scripts/lerobot_eval.py
+++ b/src/lerobot/scripts/lerobot_eval.py
@@ -945,6 +945,69 @@ def run_one(
     return task_group, task_id, metrics
 
 
+def _make_threaded_task_runner(
+    policy,
+    env_preprocessor,
+    env_postprocessor,
+    preprocessor,
+    postprocessor,
+    **shared_run_one_kwargs: Any,
+) -> Callable[[str, int, Any], tuple[str, int, dict]]:
+    """
+    Builds a `(task_group, task_id, env) -> (task_group, task_id, metrics)` callable for parallel tasks.
+
+    `run_one` drives `policy.reset()` followed by repeated `policy.select_action()` calls. Every supported
+    policy class keeps its rollout state (action queues, ACT's temporal ensembler, RTC processor state, ...)
+    directly on the policy instance, so sharing one `policy` object across `ThreadPoolExecutor` workers lets
+    one task's `reset()` clobber another task's in-flight queue mid-rollout, silently corrupting both (see
+    https://github.com/huggingface/lerobot/issues/4327 — every task returns near-0% success with no error).
+
+    Each worker thread lazily deep-copies the policy and processors the first time it runs a task, and reuses
+    that copy for every later task scheduled on the same thread. This bounds the extra memory to one copy per
+    worker thread (`max_parallel_tasks` copies total), not one per task.
+    """
+    thread_local = threading.local()
+
+    def _thread_context():
+        ctx = getattr(thread_local, "eval_ctx", None)
+        if ctx is None:
+            try:
+                ctx = (
+                    deepcopy(policy),
+                    deepcopy(env_preprocessor),
+                    deepcopy(env_postprocessor),
+                    deepcopy(preprocessor),
+                    deepcopy(postprocessor),
+                )
+            except Exception as e:
+                raise RuntimeError(
+                    "eval_policy_all(max_parallel_tasks>1) gives each worker thread its own deep copy of "
+                    "the policy, because rollout state (action queues, temporal ensembling, ...) lives on "
+                    "the policy instance and cannot be shared safely across threads. This policy failed to "
+                    f"deep-copy: {e!r}. Set max_parallel_tasks=1 to evaluate it sequentially instead."
+                ) from e
+            thread_local.eval_ctx = ctx
+        return ctx
+
+    def _run(task_group: str, task_id: int, env: Any) -> tuple[str, int, dict]:
+        th_policy, th_env_preprocessor, th_env_postprocessor, th_preprocessor, th_postprocessor = (
+            _thread_context()
+        )
+        return run_one(
+            task_group,
+            task_id,
+            env,
+            policy=th_policy,
+            env_preprocessor=th_env_preprocessor,
+            env_postprocessor=th_env_postprocessor,
+            preprocessor=th_preprocessor,
+            postprocessor=th_postprocessor,
+            **shared_run_one_kwargs,
+        )
+
+    return _run
+
+
 def eval_policy_all(
     envs: dict[str, dict[int, gym.vector.VectorEnv]],
     policy,
@@ -970,6 +1033,11 @@ def eval_policy_all(
     accumulates per-group and overall statistics, and returns the same aggregate metrics
     schema as the single-env evaluator (avg_sum_reward / avg_max_reward / pc_success / timings)
     plus per-task infos.
+
+    With `max_parallel_tasks > 1`, each worker thread evaluates against its own deep copy of `policy`
+    and the processors (see `_make_threaded_task_runner`), since rollout state such as action queues
+    lives on the policy instance and cannot be shared across threads without corrupting it. This costs
+    one extra copy of the policy's memory per worker thread.
     """
     start_t = time.time()
 
@@ -1051,10 +1119,29 @@ def eval_policy_all(
                             prefetch_thread = threading.Thread(target=next_env._ensure, daemon=True)
                             prefetch_thread.start()
         else:
+            # Each worker thread gets its own deep copy of the policy and processors (see
+            # `_make_threaded_task_runner`) instead of the `task_runner` above, which binds the single
+            # shared `policy` object and would let concurrent tasks corrupt each other's rollout state.
+            threaded_task_runner = _make_threaded_task_runner(
+                policy,
+                env_preprocessor,
+                env_postprocessor,
+                preprocessor,
+                postprocessor,
+                n_episodes=n_episodes,
+                max_episodes_rendered=max_episodes_rendered,
+                videos_dir=videos_dir,
+                return_episode_data=return_episode_data,
+                start_seed=start_seed,
+                recording_dir=recording_dir,
+                env_features=env_features,
+                recording_repo_id=recording_repo_id,
+                recording_private=recording_private,
+            )
             with cf.ThreadPoolExecutor(max_workers=max_parallel_tasks) as executor:
                 fut2meta = {}
                 for task_group, task_id, env in tasks:
-                    fut = executor.submit(task_runner, task_group, task_id, env)
+                    fut = executor.submit(threaded_task_runner, task_group, task_id, env)
                     fut2meta[fut] = (task_group, task_id, env)
                 for fut in cf.as_completed(fut2meta):
                     tg, tid, env = fut2meta[fut]

--- a/tests/scripts/test_lerobot_eval.py
+++ b/tests/scripts/test_lerobot_eval.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Regression tests for `eval_policy_all`'s parallel-task dispatch (issue #4327).
+
+`eval_policy_all(max_parallel_tasks > 1)` used to hand every `ThreadPoolExecutor` worker the *same*
+`policy` object. Every supported policy class keeps its rollout state (action queues populated by
+`select_action`, reset by `reset()`) directly on the instance, so two tasks running concurrently would
+clobber each other's queue mid-rollout with no error — every task silently returned near-0% success.
+"""
+
+import threading
+import time
+from typing import Any
+
+import pytest
+import torch
+from torch import nn
+
+pytest.importorskip("datasets", reason="datasets is required (install lerobot[dataset])")
+
+from lerobot.scripts import lerobot_eval as eval_module  # noqa: E402
+
+
+class _FakeEnv:
+    """Stand-in for a `gym.vector.VectorEnv`: only `.close()` is touched by `eval_policy_all`."""
+
+    def __init__(self, token: str):
+        self.token = token
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+
+class _QueuePolicy(nn.Module):
+    """Minimal reduction of the real bug: rollout state lives directly on the policy instance.
+
+    `reset()` reassigns `self._queue` to a fresh object (as every real policy's `reset()` reassigns
+    `self._queues`), and `select_action()` stamps and re-reads it after yielding the GIL. If two threads
+    share one instance, one thread's `reset()`/`select_action()` can land between the other thread's
+    stamp and re-read, so the re-read observes the wrong token.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self._queue: dict[str, str | None] = {}
+
+    def reset(self):
+        self._queue = {"token": None}
+
+    def select_action(self, batch: dict[str, str]) -> torch.Tensor:
+        token = batch["token"]
+        self._queue["token"] = token
+        time.sleep(0.005)  # yield the GIL so a concurrent reset()/select_action() can interleave
+        seen = self._queue["token"]
+        if seen != token:
+            raise AssertionError(f"cross-task interference: expected token {token!r}, saw {seen!r}")
+        return torch.zeros(1)
+
+
+def _fake_eval_one(env: _FakeEnv, *, policy: _QueuePolicy, n_episodes: int, **_ignored: Any) -> dict:
+    for _ in range(n_episodes):
+        policy.reset()
+        policy.select_action({"token": env.token})
+    return {
+        "sum_rewards": [0.0] * n_episodes,
+        "max_rewards": [0.0] * n_episodes,
+        "successes": [True] * n_episodes,
+    }
+
+
+def test_eval_policy_all_parallel_tasks_do_not_share_policy_state(monkeypatch):
+    """Each worker thread must get its own policy copy, not the shared instance (see #4327)."""
+    monkeypatch.setattr(eval_module, "eval_one", _fake_eval_one)
+
+    policy = _QueuePolicy()
+    envs = {"group": {i: _FakeEnv(token=f"task-{i}") for i in range(8)}}
+
+    result = eval_module.eval_policy_all(
+        envs,
+        policy,
+        env_preprocessor=lambda x: x,
+        env_postprocessor=lambda x: x,
+        preprocessor=lambda x: x,
+        postprocessor=lambda x: x,
+        n_episodes=20,
+        max_parallel_tasks=4,
+    )
+
+    assert result["overall"]["n_episodes"] == 8 * 20
+    assert result["overall"]["pc_success"] == 100.0
+    assert all(env.closed for group in envs.values() for env in group.values())
+
+
+def test_eval_policy_all_threaded_reuses_one_copy_per_worker_thread(monkeypatch):
+    """Memory should scale with `max_parallel_tasks`, not with the number of tasks."""
+    monkeypatch.setattr(eval_module, "eval_one", _fake_eval_one)
+
+    seen_instance_ids: set[int] = set()
+    lock = threading.Lock()
+
+    def _tracking_eval_one(env: _FakeEnv, *, policy: _QueuePolicy, n_episodes: int, **_ignored: Any) -> dict:
+        with lock:
+            seen_instance_ids.add(id(policy))
+        return _fake_eval_one(env, policy=policy, n_episodes=n_episodes)
+
+    monkeypatch.setattr(eval_module, "eval_one", _tracking_eval_one)
+
+    policy = _QueuePolicy()
+    envs = {"group": {i: _FakeEnv(token=f"task-{i}") for i in range(6)}}
+
+    eval_module.eval_policy_all(
+        envs,
+        policy,
+        env_preprocessor=lambda x: x,
+        env_postprocessor=lambda x: x,
+        preprocessor=lambda x: x,
+        postprocessor=lambda x: x,
+        n_episodes=1,
+        max_parallel_tasks=2,
+    )
+
+    # 6 tasks funnel through at most 2 worker threads, so at most 2 distinct deep copies are made,
+    # never one per task and never the original shared instance.
+    assert 1 <= len(seen_instance_ids) <= 2
+    assert id(policy) not in seen_instance_ids
+
+
+def test_eval_policy_all_sequential_reuses_shared_policy(monkeypatch):
+    """`max_parallel_tasks<=1` should keep using the original policy directly (no copying overhead)."""
+    seen_instance_ids: set[int] = set()
+
+    def _tracking_eval_one(env: _FakeEnv, *, policy: _QueuePolicy, n_episodes: int, **_ignored: Any) -> dict:
+        seen_instance_ids.add(id(policy))
+        return _fake_eval_one(env, policy=policy, n_episodes=n_episodes)
+
+    monkeypatch.setattr(eval_module, "eval_one", _tracking_eval_one)
+
+    policy = _QueuePolicy()
+    envs = {"group": {i: _FakeEnv(token=f"task-{i}") for i in range(3)}}
+
+    eval_module.eval_policy_all(
+        envs,
+        policy,
+        env_preprocessor=lambda x: x,
+        env_postprocessor=lambda x: x,
+        preprocessor=lambda x: x,
+        postprocessor=lambda x: x,
+        n_episodes=1,
+        max_parallel_tasks=1,
+    )
+
+    assert seen_instance_ids == {id(policy)}


### PR DESCRIPTION
## Summary / Motivation

`eval_policy_all(max_parallel_tasks > 1)` dispatches tasks to a `ThreadPoolExecutor`, but every worker thread was calling `run_one` with the *same* `policy` object. Every policy class in this repo keeps its rollout state — action queues populated by `select_action`, `deque`s reset by `reset()`, ACT's temporal ensembler, RTC processor state — directly on the policy instance. With no synchronization, one task's `policy.reset()` clobbers another task's in-flight action queue mid-rollout.

There is no crash and no warning. Every task just returns collapsed, near-0% success, silently.

## Related issues

- Fixes #4327

## Root cause

Confirmed by reading every policy's `reset()`/`select_action()` (ACT, diffusion, TD-MPC, VQ-BeT, pi0, pi0_fast, pi05, SmolVLA, VLA-JEPA, wall_x, xvla, multi_task_dit): all store their rollout state as a plain top-level attribute on the policy instance (`self._queues`, `self._action_queue`, `self.temporal_ensembler`), never behind any lock. `eval_policy_all`'s threaded branch built one `task_runner` bound to the single shared `policy` via `functools.partial` and submitted it to every worker:

```python
task_runner = partial(run_one, policy=policy, ...)
...
with cf.ThreadPoolExecutor(max_workers=max_parallel_tasks) as executor:
    for task_group, task_id, env in tasks:
        fut = executor.submit(task_runner, task_group, task_id, env)
```

`policy.eval()`/`policy.train(was_training)` were already correctly scoped around the whole parallel dispatch (set once before submitting, restored once after all futures complete), so training-mode races aren't possible. The bug is specifically the shared *rollout* state consumed inside each task.

## What changed

**`lerobot_eval.py`** — `_make_threaded_task_runner` gives each worker thread its own deep copy of the policy and the four processors (`preprocessor`, `postprocessor`, `env_preprocessor`, `env_postprocessor`), created lazily the first time that thread runs a task and reused for every later task scheduled on it via `threading.local()`. This bounds the extra memory to one copy per worker thread — i.e. `max_parallel_tasks` copies total — not one per task, regardless of how many tasks there are.

- The sequential path (`max_parallel_tasks <= 1`) is untouched: it still uses the original shared `policy` directly, no copying overhead.
- If a policy can't be deep-copied (e.g. some `torch.compile`d or otherwise non-picklable wrapper), the new code raises a clear `RuntimeError` pointing at `max_parallel_tasks=1` instead of a confusing deep-copy traceback.
- Processors are deep-copied too, defensively — normalization stats are read-only in practice, but nothing rules out a future stateful processor step, and the copy cost is negligible next to the policy's weights.

**`envs/configs.py`** — documented the memory trade-off directly on `EnvConfig.max_parallel_tasks`, since this is the first time that field's cost has been more than "spin up more environments."

### Trade-off worth flagging

Deep-copying the policy per worker thread duplicates its memory (weights included) by up to `max_parallel_tasks`×. For large policies (VLA-style, billions of params) this can be a meaningful GPU memory cost at high parallelism. I considered a lock-based alternative that would serialize only `policy.reset()`/`select_action()` calls while letting env stepping run concurrently — that would keep memory flat, but env stepping is the likely dominant cost for physics-heavy sims (LIBERO/MuJoCo) at batch size 1, so it's plausible it would have recovered most of the wall-clock benefit `max_parallel_tasks` is meant to provide. I went with deep-copy because:

- it needs zero per-policy-type knowledge — every current and future policy is covered without special-casing which nested objects hold mutable state (a lock only fixes the top-level `_queues`/`temporal_ensembler`/etc. race, but I could not rule out mutable state further inside a policy's submodules for every current and future policy type)
- it is strictly correct, not "correct for what I checked today"

If reviewers would rather trade correctness-by-construction for flat memory, the lock-based approach is a smaller diff and I'm happy to switch.

## How was this tested

```
uv run pytest tests/scripts/test_lerobot_eval.py tests/envs -q
uv run pre-commit run --files src/lerobot/scripts/lerobot_eval.py src/lerobot/envs/configs.py tests/scripts/test_lerobot_eval.py
```

New file `tests/scripts/test_lerobot_eval.py` adds a `_QueuePolicy` that reduces the real bug to its essence: `reset()` reassigns a dict-backed "queue" attribute, `select_action()` stamps a per-task token into it, yields the GIL, and re-reads it — raising if another thread's `reset()`/`select_action()` interleaved in between. Three tests:

- 8 parallel tasks × 20 episodes each, `max_parallel_tasks=4`, asserts no cross-task interference and 100% "success". **Verified this fails against the pre-fix code**, deterministically reproducing the exact failure mode from the issue (`cross-task interference: expected token 'task-0', saw 'task-1'`), and passes reliably (5 consecutive runs, no flakes) against the fix.
- Asserts the number of distinct policy instances used across 6 tasks on `max_parallel_tasks=2` is bounded by 2 (one per worker thread), not 6 (one per task) and not 1 (the shared original) — pins the "copy once per thread, not per task" memory claim.
- Asserts the sequential path (`max_parallel_tasks<=1`) keeps using the original shared instance directly, with zero copying.

`tests/envs` (52 passed, 11 skipped) and pre-commit (all 19 hooks) are clean on the touched files. `tests/scripts/test_edit_dataset_parsing.py` and `test_train_remote_dispatch.py` fail in this sandbox on a `libtorchcodec` load error unrelated to this change — confirmed identical on `main` without this patch, so not a regression.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a` on touched files)
- [x] All tests pass locally (`pytest`) — `tests/scripts/test_lerobot_eval.py` and `tests/envs`; the full suite needs hardware/simulator extras unavailable on this machine
- [x] Documentation updated — docstrings and the `EnvConfig.max_parallel_tasks` field comment
- [ ] CI is green
- [x] Community Review: I have reviewed another contributor's open PR and linked it here: #4441

## Reviewer notes

- **The main judgement call is deep-copy vs. lock**, discussed above — happy to go either way.
- `_make_threaded_task_runner` is module-level and separate from `run_one`/`task_runner` specifically so the sequential path keeps zero copying overhead; the two code paths only share `run_one`.
- Not addressed here, out of scope: I did not audit whether `env_preprocessor`/`env_postprocessor`/`preprocessor`/`postprocessor` currently ship any stateful step in practice — I deep-copy them defensively rather than proving they're stateless today.
