### PR TITLE
fix(envs): fail fast when the LIBERO simulator is missing (#4388)

### DIFF
--- a/src/lerobot/envs/configs.py
+++ b/src/lerobot/envs/configs.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import abc
+import importlib
 import importlib.util
 from dataclasses import dataclass, field, fields
 from typing import Any

--- a/src/lerobot/envs/configs.py
+++ b/src/lerobot/envs/configs.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 import abc
-import importlib
+import importlib.util
 from dataclasses import dataclass, field, fields
 from typing import Any
 
@@ -317,6 +317,19 @@ class HILSerlRobotEnvConfig(EnvConfig):
         return {}
 
 
+# The LIBERO simulator ships in the `hf-libero` package, which carries a
+# `sys_platform == 'linux'` marker in the `lerobot[libero]` extra. On non-Linux
+# platforms `pip install 'lerobot[libero]'` resolves cleanly but silently omits it,
+# so the failure would otherwise surface much later as a cryptic ModuleNotFoundError
+# from deep inside the `lerobot.envs.libero` import. See #4388.
+LIBERO_SIMULATOR_MISSING_MSG = (
+    "The LIBERO simulator is not installed. LIBERO is Linux-only: the 'hf-libero' "
+    "package carries a sys_platform == 'linux' marker, so `pip install 'lerobot[libero]'` "
+    "resolves cleanly but silently omits the simulator on non-Linux platforms. "
+    "Install it on Linux (or in a Linux container) to run LIBERO environments."
+)
+
+
 @EnvConfig.register_subclass("libero")
 @dataclass
 class LiberoEnv(EnvConfig):
@@ -426,6 +439,12 @@ class LiberoEnv(EnvConfig):
         return kwargs
 
     def create_envs(self, n_envs: int, use_async_envs: bool = False):
+        # Fail fast at env-construction time with an actionable message when the
+        # simulator was silently omitted (e.g. a non-Linux install), instead of
+        # letting a cryptic ModuleNotFoundError surface from the import below (#4388).
+        if importlib.util.find_spec("libero") is None:
+            raise ModuleNotFoundError(LIBERO_SIMULATOR_MISSING_MSG)
+
         from .libero import create_libero_envs
 
         if self.task is None:

--- a/tests/envs/test_dispatch.py
+++ b/tests/envs/test_dispatch.py
@@ -46,6 +46,31 @@ def test_libero_rejects_nonpositive_fps():
         LiberoEnv(fps=0)
 
 
+def test_libero_create_envs_without_simulator_raises_clear_error(monkeypatch):
+    """When the LIBERO simulator package is absent — the stock situation on non-Linux
+    installs, where ``hf-libero``'s ``sys_platform == 'linux'`` marker makes
+    ``pip install 'lerobot[libero]'`` silently omit it — ``create_envs()`` must fail
+    fast with an actionable message instead of a cryptic ``ModuleNotFoundError`` raised
+    deep inside the ``lerobot.envs.libero`` import. Regression test for #4388."""
+    import importlib.util as importlib_util
+
+    real_find_spec = importlib_util.find_spec
+
+    def fake_find_spec(name, *args, **kwargs):
+        if name == "libero":
+            return None
+        return real_find_spec(name, *args, **kwargs)
+
+    monkeypatch.setattr(importlib_util, "find_spec", fake_find_spec)
+
+    with pytest.raises(ImportError, match="Linux") as exc_info:
+        LiberoEnv().create_envs(n_envs=1)
+
+    message = str(exc_info.value)
+    assert "hf-libero" in message
+    assert "lerobot[libero]" in message
+
+
 def test_identity_processors():
     """Base class get_env_processors() returns identity pipelines."""
     cfg = make_env_config("aloha")

--- a/tests/envs/test_dispatch.py
+++ b/tests/envs/test_dispatch.py
@@ -63,7 +63,7 @@ def test_libero_create_envs_without_simulator_raises_clear_error(monkeypatch):
 
     monkeypatch.setattr(importlib_util, "find_spec", fake_find_spec)
 
-    with pytest.raises(ImportError, match="Linux") as exc_info:
+    with pytest.raises(ModuleNotFoundError, match="Linux") as exc_info:
         LiberoEnv().create_envs(n_envs=1)
 
     message = str(exc_info.value)


### PR DESCRIPTION
## Summary / Motivation

On non-Linux platforms `pip install 'lerobot[libero]'` succeeds but installs no
simulator: the `hf-libero` dependency carries a `sys_platform == 'linux'` marker in
the `libero` extra, so pip resolves the extra cleanly and silently omits the only
package that provides the simulator (exit 0, no warning).

`LiberoEnv.create_envs()` then reaches `from .libero import create_libero_envs`, whose
module does a top-level `from libero.libero import ...`. The result is a cryptic
`ModuleNotFoundError: No module named 'libero'` far from the real cause.

This makes environment construction fail with an actionable platform explanation.

## Related issues

- Fixes #4388

## What changed

- `LiberoEnv.create_envs()` checks `importlib.util.find_spec("libero")` before the
  simulator import and raises `ModuleNotFoundError` with a clear message when absent.
- Both `importlib` and `importlib.util` are imported explicitly because the module uses
  `import_module` and `util.find_spec` independently.
- The regression test asserts the promised `ModuleNotFoundError` type and message.
- `__post_init__` remains metadata-only, so config and dataset metadata inspection can
  still work without the simulator.

## How was this tested (RED → GREEN)

RED — the regression test on rebased upstream `main`:

```text
E       AssertionError: Regex pattern did not match.
E         Expected regex: 'Linux'
E         Actual message: "No module named 'libero'"
1 failed
```

GREEN — the complete dispatch test module on Python 3.12:

```text
Testing with DEVICE='cpu'
.............                                                            [100%]
13 passed in 0.35s
```

Quality checks:

```text
ruff check: All checks passed!
ruff format --check: 2 files already formatted
fresh import check (`python -S`): passed
changed executable lines exercised by coverage: 3/3
```

## Full local suite

The base-dependency suite was replayed on both upstream `main` and this branch. Both
runs stopped after the same 10 OpenCV camera failures because this clone contains LFS
pointer files instead of the camera PNG artifacts (`12 passed, 103 skipped` before the
stop). The branch introduced no new failure or changed failure signature. The affected
dispatch module passes in full (`13 passed`).

## Scope note

In `lerobot-train`, dataset construction currently occurs before the first evaluation
environment is created. This guard therefore improves the environment-construction
error but does not move LIBERO availability validation ahead of dataset setup. Adding a
separate runtime-validation hook would broaden this focused fix and is left for
maintainer direction.

## Checklist

- [x] Linting/formatting run
- [x] Relevant tests pass locally
- [x] Documentation/description matches the runtime boundary

## Reviewer notes

- Guard placement remains `create_envs()` rather than `__post_init__`, preserving
  metadata-only use on machines without LIBERO.
- `LiberoPlusEnv` inherits `create_envs`, so the same guard covers it.
- Significant AI assistance was used and independently reviewed; the behavior was
  reproduced and validated locally.
