### PR TITLE
Fix tuple-typed config fields breaking migrate_policy_normalization.py

### DIFF
--- a/src/lerobot/processor/migrate_policy_normalization.py
+++ b/src/lerobot/processor/migrate_policy_normalization.py
@@ -471,6 +471,20 @@ def load_model_from_hub(
     return state_dict, config, train_config
 
 
+def _is_tuple_type(declared_type: Any) -> bool:
+    if typing.get_origin(declared_type) is tuple:
+        return True
+    return any(typing.get_origin(arg) is tuple for arg in typing.get_args(declared_type))
+
+
+def _coerce_tuple_fields(config: Any) -> None:
+    type_hints = typing.get_type_hints(type(config))
+    for field in dataclasses.fields(config):
+        value = getattr(config, field.name)
+        if isinstance(value, list) and _is_tuple_type(type_hints.get(field.name, field.type)):
+            setattr(config, field.name, tuple(value))
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Migrate policy models with normalization layers to new pipeline system"
@@ -591,17 +605,7 @@ def main():
     # Create policy configuration using the factory
     print(f"Creating {policy_type} policy configuration...")
     policy_config = make_policy_config(policy_type, **cleaned_config)
-
-    type_hints = typing.get_type_hints(type(policy_config))
-    for field in dataclasses.fields(policy_config):
-        value = getattr(policy_config, field.name)
-        if not isinstance(value, list):
-            continue
-        declared_type = type_hints.get(field.name, field.type)
-        for candidate in typing.get_args(declared_type) or (declared_type,):
-            if typing.get_origin(candidate) is tuple:
-                setattr(policy_config, field.name, tuple(value))
-                break
+    _coerce_tuple_fields(policy_config)
 
     # Create policy instance using the factory
     print(f"Instantiating {policy_type} policy...")

--- a/src/lerobot/processor/migrate_policy_normalization.py
+++ b/src/lerobot/processor/migrate_policy_normalization.py
@@ -48,8 +48,10 @@ with the new PolicyProcessorPipeline architecture.
 """
 
 import argparse
+import dataclasses
 import json
 import os
+import typing
 from pathlib import Path
 from typing import Any
 
@@ -589,6 +591,21 @@ def main():
     # Create policy configuration using the factory
     print(f"Creating {policy_type} policy configuration...")
     policy_config = make_policy_config(policy_type, **cleaned_config)
+
+    # config.json was loaded via plain json.load(), so JSON arrays became lists even for
+    # fields declared as tuples (e.g. DiffusionConfig.crop_shape). draccus later fails to
+    # re-encode those as JSON ("Couldn't encode <item>") because the runtime value doesn't
+    # match the declared tuple type. Coerce them back before the config is saved.
+    type_hints = typing.get_type_hints(type(policy_config))
+    for field in dataclasses.fields(policy_config):
+        value = getattr(policy_config, field.name)
+        if not isinstance(value, list):
+            continue
+        declared_type = type_hints.get(field.name, field.type)
+        for candidate in typing.get_args(declared_type) or (declared_type,):
+            if typing.get_origin(candidate) is tuple:
+                setattr(policy_config, field.name, tuple(value))
+                break
 
     # Create policy instance using the factory
     print(f"Instantiating {policy_type} policy...")

--- a/src/lerobot/processor/migrate_policy_normalization.py
+++ b/src/lerobot/processor/migrate_policy_normalization.py
@@ -592,10 +592,6 @@ def main():
     print(f"Creating {policy_type} policy configuration...")
     policy_config = make_policy_config(policy_type, **cleaned_config)
 
-    # config.json was loaded via plain json.load(), so JSON arrays became lists even for
-    # fields declared as tuples (e.g. DiffusionConfig.crop_shape). draccus later fails to
-    # re-encode those as JSON ("Couldn't encode <item>") because the runtime value doesn't
-    # match the declared tuple type. Coerce them back before the config is saved.
     type_hints = typing.get_type_hints(type(policy_config))
     for field in dataclasses.fields(policy_config):
         value = getattr(policy_config, field.name)

--- a/tests/processor/test_migrate_policy_normalization.py
+++ b/tests/processor/test_migrate_policy_normalization.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+
+# Copyright 2024 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import dataclasses
+
+import draccus
+import pytest
+
+from lerobot.configs.policies import PreTrainedConfig
+from lerobot.policies.diffusion.configuration_diffusion import DiffusionConfig
+from lerobot.processor.migrate_policy_normalization import _coerce_tuple_fields
+
+
+def test_coerce_tuple_fields_converts_optional_tuple():
+    config = DiffusionConfig()
+    config.crop_shape = [84, 84]  # what json.load() produces for a JSON array
+
+    _coerce_tuple_fields(config)
+
+    assert config.crop_shape == (84, 84)
+    assert isinstance(config.crop_shape, tuple)
+
+
+def test_coerce_tuple_fields_converts_variadic_tuple():
+    config = DiffusionConfig()
+    config.down_dims = [512, 1024, 2048]
+
+    _coerce_tuple_fields(config)
+
+    assert config.down_dims == (512, 1024, 2048)
+    assert isinstance(config.down_dims, tuple)
+
+
+def test_coerce_tuple_fields_leaves_none_untouched():
+    config = DiffusionConfig()
+    assert config.crop_shape is None
+
+    _coerce_tuple_fields(config)
+
+    assert config.crop_shape is None
+
+
+def test_coerce_tuple_fields_leaves_list_fields_as_lists():
+    @dataclasses.dataclass
+    class DummyConfig:
+        crop_shape: tuple[int, int] | None = None
+        tags: list[str] | None = None
+
+    config = DummyConfig(crop_shape=[84, 84], tags=["a", "b"])
+
+    _coerce_tuple_fields(config)
+
+    assert config.crop_shape == (84, 84)
+    assert isinstance(config.crop_shape, tuple)
+    assert config.tags == ["a", "b"]
+    assert isinstance(config.tags, list)
+
+
+def test_uncoerced_list_fails_draccus_encode():
+    """Without coercion, encoding a list against a declared tuple[...] type crashes.
+    This is the bug migrate_policy_normalization.py hit when config.json was loaded
+    via plain json.load()."""
+    config = DiffusionConfig()
+    config.crop_shape = [84, 84]
+
+    with pytest.raises(Exception, match="Couldn't encode"):
+        draccus.encode(config, PreTrainedConfig)
+
+
+def test_coerced_config_saves_with_draccus():
+    config = DiffusionConfig()
+    config.crop_shape = [84, 84]
+    config.down_dims = [512, 1024, 2048]
+
+    _coerce_tuple_fields(config)
+    encoded = draccus.encode(config, PreTrainedConfig)
+
+    assert encoded["crop_shape"] == [84, 84]
+    assert encoded["down_dims"] == [512, 1024, 2048]


### PR DESCRIPTION
## Summary

`migrate_policy_normalization.py` loads a legacy checkpoint's `config.json` via plain `json.load()`, so JSON arrays become Python lists even for fields declared as tuples in the policy config dataclass (e.g. `DiffusionConfig.crop_shape: tuple[int, int]`). The resulting `policy_config` is built directly from that dict without correcting the type.

When the script later saves the migrated config, `draccus` fails to re-encode these fields because the runtime value (`list`) doesn't match the declared type (`tuple`), raising `Exception: Couldn't encode <item>` instead of writing `config.json`. The preprocessor and postprocessor save fine — it's specifically `policy.save_pretrained()` → `config._save_pretrained()` that crashes.

## What doesn't work today

`lerobot-eval` against a legacy checkpoint like `lerobot/diffusion_pusht` (predates the processor-pipeline format) fails immediately:

```
lerobot-eval --policy.path=lerobot/diffusion_pusht --env.type=pusht --eval.n_episodes=2
```

```
huggingface_hub.errors.RemoteEntryNotFoundError: 404 Client Error. ...
Entry Not Found for url: https://huggingface.co/lerobot/diffusion_pusht/resolve/main/policy_preprocessor.json.
...
lerobot.processor.pipeline.ProcessorMigrationError: Model 'lerobot/diffusion_pusht' requires migration to processor format. Run: python src/lerobot/processor/migrate_policy_normalization.py --pretrained-path lerobot/diffusion_pusht

Original error: Config file 'policy_preprocessor.json' not found on the Hugging Face Hub
```

That error message tells you to run the migration script — but on `main`, the migration script itself crashes before finishing, so there's currently no way to get this checkpoint (or any of the other affected policy types below) working with `lerobot-eval`:

```
python src/lerobot/processor/migrate_policy_normalization.py --pretrained-path lerobot/diffusion_pusht
```

Preprocessor/postprocessor/model state dict all save successfully ("all keys matched"), then:

```
Exception: Couldn't encode 84
```

(`84` comes from `crop_shape=[84, 84]`.)

## Affected policy types

At least 5 policy configs have tuple-typed image-shape fields and hit the same failure when migrating a legacy checkpoint of that type:

- `diffusion` — `crop_shape`, `resize_shape`
- `multi_task_dit` — `image_crop_shape`, `image_resize_shape`
- `vla_jepa` — `resize_images_to`
- `vqbet` — `crop_shape`
- `xvla` — `resize_imgs_with_padding`

## Fix

After building `policy_config` from the loaded dict, walk its dataclass fields via `typing.get_type_hints` and coerce any `list` value whose declared type is `tuple[...]` back into a `tuple` before the config is saved, via a new `_coerce_tuple_fields()` helper. This makes the runtime value match what `draccus` expects for that field, so it takes the tuple-encoding path instead of falling through to the failing bare-`int` case.

`_coerce_tuple_fields()` uses `_is_tuple_type()` to detect two distinct field shapes, both present in `DiffusionConfig`:

- Bare tuple fields, e.g. `down_dims: tuple[int, ...]` — `typing.get_origin(declared_type) is tuple`.
- Optional tuple fields, e.g. `crop_shape: tuple[int, int] | None` — `tuple` shows up as `typing.get_origin(arg)` for one of `typing.get_args(declared_type)`'s `Union` members.

An earlier version of this fix only checked the second (`Optional`) shape, so `crop_shape` coerced correctly but `down_dims` silently stayed a `list` and would still crash `draccus.encode()` later. Caught by writing the regression tests below — see [inline review discussion](https://github.com/huggingface/lerobot/pull/4457#discussion_r3789929561).

## Test coverage

`tests/processor/test_migrate_policy_normalization.py` (6 tests, added in 7ad63547):

- `_coerce_tuple_fields` converts an `Optional[tuple[...]]` field (`crop_shape`)
- `_coerce_tuple_fields` converts a bare/variadic `tuple[...]` field (`down_dims`)
- `_coerce_tuple_fields` leaves `None` untouched
- `_coerce_tuple_fields` leaves a `list[str]`-annotated control field as a `list` (does not over-coerce)
- Encoding an uncoerced `list` against a declared `tuple[...]` type reproduces the original `Couldn't encode` crash via `draccus.encode()` directly
- Encoding a coerced config succeeds via `draccus.encode()`

## Related

- #4047 — the parent issue: official checkpoints breaking `lerobot-eval` due to missing processor-pipeline files. Adjacent, not a duplicate: its thread is about the Hub-side `FileNotFoundError`/`ProcessorMigrationError` shown above, and doesn't get as far as the save-time crash this PR fixes.
- #3001 — a different, non-overlapping fix for the same `lerobot-eval` symptom: adds runtime auto-migration inside `make_pre_post_processors()` that builds processors in-memory on `ProcessorMigrationError`, without ever calling `policy.save_pretrained()`. That's why it doesn't hit this bug — it never goes through the `config._save_pretrained()` → draccus-encode path this PR fixes. This PR remains needed independent of #3001 landing: anyone running `migrate_policy_normalization.py` directly to produce a persisted, re-uploadable migrated checkpoint (rather than relying on #3001's in-memory workaround at eval time) still hits this crash.
- #4300 — a warning-only PR for a different code path (legacy in-policy normalization keys dropped during `from_pretrained`). Notes that re-uploading migrated official checkpoints "still needs org write access, out of scope" — i.e. the standalone migration script this PR fixes remains the sanctioned path to produce one.

## Test plan

- [x] Ran `lerobot-eval --policy.path=lerobot/diffusion_pusht --env.type=pusht` on `main` — reproduced the `ProcessorMigrationError` above.
- [x] Ran the migration script it points to, on `main` — reproduced the `Couldn't encode 84` crash.
- [x] Applied this fix, reran the migration script — completes, `config.json` is written and non-empty, `crop_shape` round-trips as `(84, 84)` and `down_dims` as `(512, 1024, 2048)`.
- [x] Reran `lerobot-eval --policy.path=<migrated-dir> --env.type=pusht` against the migrated checkpoint — completed a real rollout successfully (100% success over 2 episodes, `avg_max_reward: 1.0`).
- [x] `pytest tests/processor/test_migrate_policy_normalization.py tests/processor/test_migration_detection.py` — 23 passed (6 new + 17 pre-existing, no regressions).