### PR TITLE
fix(processor): keep declared feature names through normalization migration

### DIFF
--- a/src/lerobot/processor/migrate_policy_normalization.py
+++ b/src/lerobot/processor/migrate_policy_normalization.py
@@ -50,6 +50,7 @@ with the new PolicyProcessorPipeline architecture.
 import argparse
 import json
 import os
+from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
 
@@ -62,7 +63,9 @@ from lerobot.policies import get_policy_class, make_policy_config, make_pre_post
 from lerobot.utils.constants import ACTION
 
 
-def extract_normalization_stats(state_dict: dict[str, torch.Tensor]) -> dict[str, dict[str, torch.Tensor]]:
+def extract_normalization_stats(
+    state_dict: dict[str, torch.Tensor], feature_names: Iterable[str] | None = None
+) -> dict[str, dict[str, torch.Tensor]]:
     """
     Scans a model's state_dict to find and extract normalization statistics.
 
@@ -72,6 +75,13 @@ def extract_normalization_stats(state_dict: dict[str, torch.Tensor]) -> dict[str
 
     Args:
         state_dict: The state dictionary of a pretrained policy model.
+        feature_names: The feature names the policy declares, used to recover names that a
+            buffer key cannot express. A buffer stores a feature name with its dots flattened
+            to underscores, and that is not reversible from the string alone:
+            `observation.environment_state` and `observation.environment.state` both flatten to
+            `observation_environment_state`. When a name is not declared (or none are supplied,
+            as for a checkpoint whose config predates `input_features`), every underscore is
+            read back as a dot.
 
     Returns:
         A nested dictionary where outer keys are feature names (e.g.,
@@ -79,6 +89,9 @@ def extract_normalization_stats(state_dict: dict[str, torch.Tensor]) -> dict[str
         mapping to their corresponding tensor values.
     """
     stats = {}
+
+    declared_names = set(feature_names or ())
+    declared_by_flattened = {name.replace(".", "_"): name for name in declared_names}
 
     # Define patterns to match and their prefixes to remove
     normalization_patterns = [
@@ -108,8 +121,12 @@ def extract_normalization_stats(state_dict: dict[str, torch.Tensor]) -> dict[str
                 if len(parts) >= 2:
                     # Last part is the stat type (mean, std, min, max, etc.)
                     stat_type = parts[-1]
-                    # Everything else is the feature name
-                    feature_name = ".".join(parts[:-1]).replace("_", ".")
+                    # Everything else is the feature name, as the buffer stored it
+                    stored_name = ".".join(parts[:-1])
+                    if stored_name in declared_names:
+                        feature_name = stored_name
+                    else:
+                        feature_name = declared_by_flattened.get(stored_name, stored_name.replace("_", "."))
 
                     # Add to stats
                     if feature_name not in stats:
@@ -525,7 +542,10 @@ def main():
 
     # Extract normalization statistics
     print("Extracting normalization statistics...")
-    stats = extract_normalization_stats(state_dict)
+    # `input_features` / `output_features` name features unambiguously; configs old enough to
+    # omit them leave the buffer key as the only source, with the ambiguity that implies.
+    declared_feature_names = [*config.get("input_features", {}), *config.get("output_features", {})]
+    stats = extract_normalization_stats(state_dict, feature_names=declared_feature_names)
 
     print(f"Found normalization statistics for: {list(stats.keys())}")
 

--- a/src/lerobot/processor/migrate_policy_normalization.py
+++ b/src/lerobot/processor/migrate_policy_normalization.py
@@ -80,7 +80,8 @@ def extract_normalization_stats(
             to underscores, and that is not reversible from the string alone:
             `observation.environment_state` and `observation.environment.state` both flatten to
             `observation_environment_state`. When a name is not declared (or none are supplied,
-            as for a checkpoint whose config predates `input_features`), every underscore is
+            as for a checkpoint whose config has no supported feature declarations), every
+            underscore is
             read back as a dot.
 
     Returns:
@@ -137,6 +138,12 @@ def extract_normalization_stats(
                 break
 
     return stats
+
+
+def get_declared_feature_names(config: dict[str, Any]) -> list[str]:
+    """Collect feature names from current and legacy policy config fields."""
+    fields = ("input_features", "output_features", "input_shapes", "output_shapes", "features")
+    return [name for field in fields for name in (config.get(field) or {})]
 
 
 def detect_features_and_norm_modes(
@@ -542,9 +549,9 @@ def main():
 
     # Extract normalization statistics
     print("Extracting normalization statistics...")
-    # `input_features` / `output_features` name features unambiguously; configs old enough to
-    # omit them leave the buffer key as the only source, with the ambiguity that implies.
-    declared_feature_names = [*config.get("input_features", {}), *config.get("output_features", {})]
+    # Current and legacy config fields name features unambiguously; configs without any of them
+    # leave the buffer key as the only source, with the ambiguity that implies.
+    declared_feature_names = get_declared_feature_names(config)
     stats = extract_normalization_stats(state_dict, feature_names=declared_feature_names)
 
     print(f"Found normalization statistics for: {list(stats.keys())}")

--- a/tests/processor/test_migrate_policy_normalization.py
+++ b/tests/processor/test_migrate_policy_normalization.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for normalization statistic extraction during policy migration.
+"""
+
+import torch
+
+from lerobot.processor.migrate_policy_normalization import extract_normalization_stats
+
+
+def _buffer(feature_name: str, prefix: str = "normalize_inputs.buffer_") -> dict[str, torch.Tensor]:
+    """A checkpoint's stat buffers for one feature, keyed the way the old modules stored them."""
+    flattened = feature_name.replace(".", "_")
+    return {
+        f"{prefix}{flattened}.mean": torch.tensor([1.0]),
+        f"{prefix}{flattened}.std": torch.tensor([2.0]),
+    }
+
+
+def test_declared_name_with_an_underscore_survives():
+    """Guards #4451: `observation.environment_state` must not migrate to
+    `observation.environment.state`, which the runtime never looks up."""
+    state_dict = _buffer("observation.environment_state")
+
+    stats = extract_normalization_stats(state_dict, feature_names=["observation.environment_state"])
+
+    assert set(stats) == {"observation.environment_state"}
+    assert set(stats["observation.environment_state"]) == {"mean", "std"}
+
+
+def test_declared_names_disambiguate_a_shared_flattened_form():
+    """`observation.environment_state` and `observation.environment.state` flatten identically,
+    so only the declared name decides which one a buffer meant."""
+    state_dict = _buffer("observation.environment.state")
+
+    stats = extract_normalization_stats(state_dict, feature_names=["observation.environment.state"])
+
+    assert set(stats) == {"observation.environment.state"}
+
+
+def test_undeclared_name_keeps_the_historical_reading():
+    """A config too old to declare features leaves the buffer key as the only source."""
+    state_dict = _buffer("observation.environment_state")
+
+    stats = extract_normalization_stats(state_dict)
+
+    assert set(stats) == {"observation.environment.state"}
+
+
+def test_declared_names_do_not_disturb_names_without_underscores():
+    state_dict = {**_buffer("observation.state"), **_buffer("action")}
+
+    stats = extract_normalization_stats(state_dict, feature_names=["observation.state", "action"])
+
+    assert set(stats) == {"observation.state", "action"}
+
+
+def test_dot_preserving_prefix_keeps_a_declared_underscore():
+    """`normalize.` and friends store the name with its dots intact, so the lookup has to match
+    the stored form as well as the flattened one."""
+    state_dict = _buffer("observation.environment_state", prefix="normalize.")
+    state_dict = {
+        key.replace("observation_environment_state", "observation.environment_state"): value
+        for key, value in state_dict.items()
+    }
+
+    stats = extract_normalization_stats(state_dict, feature_names=["observation.environment_state"])
+
+    assert set(stats) == {"observation.environment_state"}
+
+
+def test_a_feature_the_config_does_not_declare_still_migrates():
+    """An undeclared buffer is not dropped; it falls back rather than disappearing."""
+    state_dict = {**_buffer("observation.environment_state"), **_buffer("observation.state")}
+
+    stats = extract_normalization_stats(state_dict, feature_names=["observation.environment_state"])
+
+    assert set(stats) == {"observation.environment_state", "observation.state"}

--- a/tests/processor/test_migrate_policy_normalization.py
+++ b/tests/processor/test_migrate_policy_normalization.py
@@ -20,7 +20,10 @@ Tests for normalization statistic extraction during policy migration.
 
 import torch
 
-from lerobot.processor.migrate_policy_normalization import extract_normalization_stats
+from lerobot.processor.migrate_policy_normalization import (
+    extract_normalization_stats,
+    get_declared_feature_names,
+)
 
 
 def _buffer(feature_name: str, prefix: str = "normalize_inputs.buffer_") -> dict[str, torch.Tensor]:
@@ -91,3 +94,12 @@ def test_a_feature_the_config_does_not_declare_still_migrates():
     stats = extract_normalization_stats(state_dict, feature_names=["observation.environment_state"])
 
     assert set(stats) == {"observation.environment_state", "observation.state"}
+
+
+def test_legacy_config_fields_declare_feature_names():
+    config = {"input_shapes": {"observation.environment_state": (2,)}}
+    state_dict = _buffer("observation.environment_state")
+
+    stats = extract_normalization_stats(state_dict, feature_names=get_declared_feature_names(config))
+
+    assert set(stats) == {"observation.environment_state"}


### PR DESCRIPTION
## Summary / Motivation

Migrating an ACT, TDMPC or gaussian_actor checkpoint silently leaves `observation.environment_state` unnormalized. Nothing raises. The policy runs on unnormalized input and the only symptom is that it behaves worse than it should.

What happens on a plain single-dataset checkpoint, no multi-dataset prefix involved:

| step | value |
| --- | --- |
| the policy declares | `observation.environment_state` |
| migration writes the stats under | `observation.environment.state` |
| the normalizer looks up | `observation.environment_state` |
| result | no match, feature goes through unnormalized, no error |

The reproduction from #4451, before and after this change:

```
no declared names : ['observation.environment.state']
config declares it: ['observation.environment_state']
```

The cause is in `extract_normalization_stats`, which rebuilt a feature name from a checkpoint buffer key with an unconditional `replace("_", ".")`. Any feature whose own name contains an underscore is mangled, and `OBS_ENV_STATE` is the one that ships.

The flattening is not reversible from the string alone: `observation.environment_state` and `observation.environment.state` both flatten to `observation_environment_state`. The only source of truth is the set of names the policy declares, so the caller now passes them in and they win.

## Related issues

- Fixes: #4451

## What changed

- `extract_normalization_stats` takes an optional `feature_names`. A stored name that matches a declared name is used as-is; otherwise a declared name whose dots flatten to the stored form wins; otherwise the previous reading (every underscore becomes a dot) applies.
- `main()` passes the names the config declares. `get_declared_feature_names` collects them from `input_features` / `output_features` and from the legacy `input_shapes` / `output_shapes` / `features` fields, so a checkpoint whose config still uses `input_shapes` (the case @algattik raised in review) is covered too.
- No behaviour change for a checkpoint whose config has none of those fields: with no declared names, extraction reads exactly as before. Such checkpoints have no config-level source of truth, and inventing a different heuristic would only move which names it gets wrong, which is the same gap `detect_features_and_norm_modes`'s stats-based fallback already has.

The third case is needed in practice: the `normalize.` / `input_normalizer.` family of prefixes stores the name with its dots intact, so `normalize.observation.environment_state.mean` arrives as `observation.environment_state` and matches no flattened key. Without the direct match it would fall through and be mangled again.

## How was this tested (or how to run locally)

Tests added in `tests/processor/test_migrate_policy_normalization.py`, 7 cases: the underscore name survives; declared names disambiguate the shared flattened form; an undeclared name keeps the historical reading; names without underscores are undisturbed; the dot-preserving prefix keeps a declared underscore; an undeclared feature still migrates rather than being dropped; a legacy `input_shapes` config declares feature names.

```
pytest -q tests/processor/test_migrate_policy_normalization.py
```

With `migrate_policy_normalization.py` reverted to the branch point, the six original cases go 5 failed, 1 passed; the one that stays green is `test_undeclared_name_keeps_the_historical_reading`, which pins the unchanged fallback. The seventh case imports `get_declared_feature_names`, so with the source reverted the module does not import at all.

`pytest -q tests/processor` gives 503 passed, 14 skipped, 2 failed. The two failures are `test_pi0_processor_inputs_match_openpi_reference` and its pi05 counterpart, which raise `OSError` fetching the gated `google/paligemma-3b-pt-224`. They fail identically with this change reverted.

## Checklist (required before merge)

- [x] Linting/formatting run: `ruff check` and `ruff format` on the touched files; I did not run the full `pre-commit run -a`
- [x] All tests pass locally: `tests/processor`, apart from the two pre-existing gated-repo failures noted above
- [ ] Documentation updated: none needed; the argument is documented on the function
- [x] CI is green: 6 checks pass; Build Main Docs was skipped
- [x] Community Review: #4285

## Reviewer notes

`extract_normalization_stats` is also touched by #4446 (@takashi-jp), which handles dataset-prefix cases and deliberately leaves this bug alone. Adjacent lines, orthogonal logic, and I am happy to rebase whichever lands second.

I previously had a third PR on this function, #4441. I closed it on 2026-09-08, so the add/add conflict on `tests/processor/test_migrate_policy_normalization.py` that it would have created is gone.

The case worth a second opinion is the fallback for old configs, described under *What changed*.

