### PR TITLE
docs: move optional encoder comments outside continued commands

### DIFF
--- a/docs/source/earthrover_mini_plus.mdx
+++ b/docs/source/earthrover_mini_plus.mdx
@@ -194,8 +194,8 @@ lerobot-record \
     --dataset.single_task="Navigate around obstacles" \
     --dataset.streaming_encoding=true \
     --dataset.encoder_threads=2 \
-    # --dataset.rgb_encoder.vcodec=auto \
     --display_data=true
+# Optional: --dataset.rgb_encoder.vcodec=auto
 ```
 
 Replace `your_username/dataset_name` with your Hugging Face username and a name for your dataset.

--- a/docs/source/hope_jr.mdx
+++ b/docs/source/hope_jr.mdx
@@ -232,8 +232,8 @@ lerobot-record \
     --dataset.private=true \
     --dataset.streaming_encoding=true \
     --dataset.encoder_threads=2 \
-    # --dataset.rgb_encoder.vcodec=auto \
     --display_data=true
+# Optional: --dataset.rgb_encoder.vcodec=auto
 ```
 
 ### Replay
@@ -278,6 +278,6 @@ lerobot-record \
   --dataset.num_episodes=10 \
   --dataset.streaming_encoding=true \
   --dataset.encoder_threads=2 \
-  # --dataset.rgb_encoder.vcodec=auto \
   --policy.path=outputs/train/hopejr_hand/checkpoints/last/pretrained_model
+# Optional: --dataset.rgb_encoder.vcodec=auto
 ```

--- a/docs/source/il_robots.mdx
+++ b/docs/source/il_robots.mdx
@@ -207,8 +207,8 @@ lerobot-record \
     --dataset.num_episodes=5 \
     --dataset.single_task="Grab the black cube" \
     --dataset.streaming_encoding=true \
-    # --dataset.rgb_encoder.vcodec=auto \
     --dataset.encoder_threads=2
+# Optional: --dataset.rgb_encoder.vcodec=auto
 ```
 </hfoption>
 <hfoption id="API example">

--- a/docs/source/lerobot-dataset-v3.mdx
+++ b/docs/source/lerobot-dataset-v3.mdx
@@ -44,8 +44,8 @@ lerobot-record \
   --dataset.num_episodes=5 \
   --dataset.single_task="Grab the black cube" \
   --dataset.streaming_encoding=true \
-  # --dataset.rgb_encoder.vcodec=auto \
   --dataset.encoder_threads=2
+# Optional: --dataset.rgb_encoder.vcodec=auto
 ```
 
 See the [recording guide](./il_robots#record-a-dataset) for more details.


### PR DESCRIPTION
## Summary / Motivation

Several `lerobot-record` examples place a commented optional argument after a line ending in `\`. In POSIX shells, the escaped newline joins the comment to the active command, which comments out the remainder and leaves the following option as a separate command.

This moves each optional encoder hint after its command so the examples remain copy-pasteable while preserving the hint.

## Related issues

- Fixes / Closes: N/A
- Related: N/A

## What changed

- Moved five optional `--dataset.rgb_encoder.vcodec=auto` comments outside continued commands.
- Updated four documentation files.
- No runtime or API behavior changes.

## How was this tested (or how to run locally)

- Ran `git diff --check`.
- Ran the repository's Prettier hook on all four changed MDX files.
- Ran the repository's `typos` hook on all four changed files.
- Verified that no comment remains between continued options in the changed commands.

## Checklist (required before merge)

- [ ] Linting/formatting run (`pre-commit run -a`)
- [ ] All tests pass locally (`pytest`)
- [x] Documentation updated
- [ ] CI is green
- [x] Community Review: I have reviewed another contributor's open PR and linked it here: [#4424](https://github.com/huggingface/lerobot/pull/4424#pullrequestreview-4948734345)

## Reviewer notes

- Documentation-only change; reviewers can focus on the shell continuation semantics.
- This change was prepared with Codex assistance. I reviewed the affected commands, complete diff, and validation results.