### PR TITLE
feat(datasets): add non-dropping mode to streaming video encoder

### DIFF
--- a/docs/source/streaming_video_encoding.mdx
+++ b/docs/source/streaming_video_encoding.mdx
@@ -16,7 +16,7 @@ This makes `save_episode()` near-instant (the video is already encoded by the ti
 
 | Parameter               | CLI Flag                          | Type          | Default       | Description                                                       |
 | ----------------------- | --------------------------------- | ------------- | ------------- | ----------------------------------------------------------------- |
-| `streaming_encoding`    | `--dataset.streaming_encoding`    | `bool`        | `True`        | Enable real-time encoding during capture                          |
+| `streaming_encoding`    | `--dataset.streaming_encoding`    | `bool`        | `False`       | Enable real-time encoding during capture                          |
 | `vcodec`                | `--dataset.rgb_encoder.vcodec`    | `str`         | `"libsvtav1"` | Video codec. `"auto"` detects best HW encoder                     |
 | `encoder_threads`       | `--dataset.encoder_threads`       | `int \| None` | `None` (auto) | Threads per encoder instance. `None` will leave the vcoded decide |
 | `encoder_queue_maxsize` | `--dataset.encoder_queue_maxsize` | `int`         | `30`          | Max buffered frames per camera (~1s at 30fps). Consumes RAM       |
@@ -46,7 +46,7 @@ This parameter controls how many threads each encoder instance uses internally:
 - **Lower values** (e.g., 1-2): Less CPU per camera, freeing cores for capture and visualization. Good for low-res images and capable CPUs.
 - **`None` (default)**: Lets the codec decide. Information available in the codec logs.
 
-### Backpressure and Frame Dropping
+### Frame Dropping and Backpressure
 
 Each camera has a bounded queue (`encoder_queue_maxsize`, default 30 frames). When the encoder can't keep up:
 
@@ -54,6 +54,22 @@ Each camera has a bounded queue (`encoder_queue_maxsize`, default 30 frames). Wh
 2. New frames are **dropped** (not blocked) — the capture loop continues uninterrupted
 3. A warning is logged: `"Encoder queue full for {camera}, dropped N frame(s)"`
 4. At episode end, total dropped frames per camera are reported
+
+Dropping, rather than blocking, is what keeps a live capture loop on schedule: a stalled `add_frame` would delay the next robot command, and some rollout strategies rely on it never blocking. The cost is that a dropped frame leaves the video shorter than the recorded data.
+
+Offline dataset conversion has no such deadline, and there a dropped frame is silent data loss. Pass `encoder_drop_on_full=False` to `LeRobotDataset.create()` or `.resume()` to get real backpressure instead — feeding a frame then waits for the encoder to free a slot, so no frame is ever lost:
+
+```python
+dataset = LeRobotDataset.create(
+    repo_id="user/converted_dataset",
+    fps=30,
+    features=features,
+    streaming_encoding=True,
+    encoder_drop_on_full=False,
+)
+```
+
+This option is deliberately not exposed as a CLI flag, since live recording should keep the default. With it enabled, `encoder_queue_maxsize` no longer has to be large enough to absorb the encoder falling behind, so it can stay small to keep peak memory down.
 
 ### Symptoms of Encoder Falling Behind
 

--- a/src/lerobot/datasets/lerobot_dataset.py
+++ b/src/lerobot/datasets/lerobot_dataset.py
@@ -349,6 +349,7 @@ class LeRobotDataset(torch.utils.data.Dataset):
         depth_encoder: DepthEncoderConfig | None,
         encoder_queue_maxsize: int,
         encoder_threads: int | None,
+        drop_on_full: bool = True,
     ) -> StreamingVideoEncoder:
         return StreamingVideoEncoder(
             fps=fps,
@@ -356,6 +357,7 @@ class LeRobotDataset(torch.utils.data.Dataset):
             depth_encoder=depth_encoder,
             queue_maxsize=encoder_queue_maxsize,
             encoder_threads=encoder_threads,
+            drop_on_full=drop_on_full,
         )
 
     # ── Metadata properties ───────────────────────────────────────────
@@ -700,6 +702,7 @@ class LeRobotDataset(torch.utils.data.Dataset):
         metadata_buffer_size: int = 10,
         streaming_encoding: bool = False,
         encoder_queue_maxsize: int = 30,
+        encoder_drop_on_full: bool = True,
         encoder_threads: int | None = None,
         video_files_size_in_mb: int | None = None,
         data_files_size_in_mb: int | None = None,
@@ -739,6 +742,11 @@ class LeRobotDataset(torch.utils.data.Dataset):
                 during capture instead of writing images first.
             encoder_queue_maxsize: Max buffered frames per camera when using
                 streaming encoding.
+            encoder_drop_on_full: When ``True`` (default), streaming encoding
+                drops frames rather than blocking once a camera's queue is full,
+                so a slow encoder cannot stall a live capture loop. Set to
+                ``False`` for offline conversion, where waiting is harmless but a
+                dropped frame silently shortens the video.
 
         Returns:
             A new :class:`LeRobotDataset` in write mode.
@@ -775,7 +783,12 @@ class LeRobotDataset(torch.utils.data.Dataset):
         streaming_enc = None
         if streaming_encoding and len(obj.meta.video_keys) > 0:
             streaming_enc = cls._build_streaming_encoder(
-                fps, rgb_encoder, depth_encoder, encoder_queue_maxsize, encoder_threads
+                fps,
+                rgb_encoder,
+                depth_encoder,
+                encoder_queue_maxsize,
+                encoder_threads,
+                encoder_drop_on_full,
             )
         obj.writer = DatasetWriter(
             meta=obj.meta,
@@ -811,6 +824,7 @@ class LeRobotDataset(torch.utils.data.Dataset):
         image_writer_threads: int = 0,
         streaming_encoding: bool = False,
         encoder_queue_maxsize: int = 30,
+        encoder_drop_on_full: bool = True,
         *,
         token: str | bool | None = None,
     ) -> "LeRobotDataset":
@@ -846,6 +860,10 @@ class LeRobotDataset(torch.utils.data.Dataset):
             streaming_encoding: If ``True``, encode video in real-time during
                 capture.
             encoder_queue_maxsize: Max buffered frames per camera for streaming.
+            encoder_drop_on_full: When ``True`` (default), streaming encoding drops
+                frames rather than blocking once a camera's queue is full. Set to
+                ``False`` for offline conversion, where a dropped frame silently
+                shortens the video.
             token: Authentication token used if metadata must be downloaded
                 from the Hub. The token is not retained on the dataset instance.
 
@@ -892,7 +910,12 @@ class LeRobotDataset(torch.utils.data.Dataset):
         streaming_enc = None
         if streaming_encoding and len(obj.meta.video_keys) > 0:
             streaming_enc = cls._build_streaming_encoder(
-                obj.meta.fps, rgb_encoder, depth_encoder, encoder_queue_maxsize, encoder_threads
+                obj.meta.fps,
+                rgb_encoder,
+                depth_encoder,
+                encoder_queue_maxsize,
+                encoder_threads,
+                encoder_drop_on_full,
             )
         obj.writer = DatasetWriter(
             meta=obj.meta,

--- a/src/lerobot/datasets/video_utils.py
+++ b/src/lerobot/datasets/video_utils.py
@@ -897,6 +897,7 @@ class StreamingVideoEncoder:
         depth_encoder: DepthEncoderConfig | None = None,
         queue_maxsize: int = 30,
         encoder_threads: int | None = None,
+        drop_on_full: bool = True,
     ):
         """
         Args:
@@ -906,16 +907,23 @@ class StreamingVideoEncoder:
             depth_encoder: Video encoder settings applied to all depth cameras,
                 including the depth quantization parameters. When ``None``,
                 :func:`depth_encoder_defaults` is used.
-            queue_maxsize: Max frames to buffer per camera before
-                back-pressure drops frames.
+            queue_maxsize: Max frames to buffer per camera.
             encoder_threads: Number of encoder threads (global setting).
                 ``None`` lets the codec decide.
+            drop_on_full: What to do when a camera's queue is full. ``True``
+                (default) drops the frame, keeping :meth:`feed_frame`
+                non-blocking for live capture, where stalling the control loop
+                is worse than losing a frame. ``False`` waits for a free slot
+                instead, which offline conversion needs: it has no real-time
+                deadline, and a dropped frame there leaves the video shorter
+                than the recorded data.
         """
         self.fps = fps
         self._rgb_encoder = rgb_encoder or rgb_encoder_defaults()
         self._depth_encoder = depth_encoder or depth_encoder_defaults()
         self._encoder_threads = encoder_threads
         self.queue_maxsize = queue_maxsize
+        self.drop_on_full = drop_on_full
 
         self._frame_queues: dict[str, queue.Queue] = {}
         self._result_queues: dict[str, queue.Queue] = {}
@@ -979,7 +987,8 @@ class StreamingVideoEncoder:
         A copy of the image is made before enqueueing to prevent race conditions
         with camera drivers that may reuse buffers. If the encoder queue is full
         (encoder can't keep up), the frame is dropped with a warning instead of
-        crashing the recording session.
+        crashing the recording session, unless ``drop_on_full=False`` was passed
+        to the constructor, in which case this blocks until a slot frees up.
 
         Args:
             video_key: The video feature key
@@ -1002,8 +1011,23 @@ class StreamingVideoEncoder:
                 pass
             raise RuntimeError(f"Encoder thread for {video_key} is not alive")
 
+        frame = image.copy()
+
+        if not self.drop_on_full:
+            # Poll rather than block indefinitely: an encoder thread that dies while the
+            # queue is full would otherwise never drain it, hanging the caller forever.
+            while True:
+                try:
+                    self._frame_queues[video_key].put(frame, timeout=1.0)
+                    return
+                except queue.Full:
+                    if not thread.is_alive():
+                        raise RuntimeError(
+                            f"Encoder thread for {video_key} died while waiting to enqueue a frame"
+                        ) from None
+
         try:
-            self._frame_queues[video_key].put(image.copy(), timeout=0.1)
+            self._frame_queues[video_key].put(frame, timeout=0.1)
         except queue.Full:
             self._dropped_frames[video_key] = self._dropped_frames.get(video_key, 0) + 1
             count = self._dropped_frames[video_key]
@@ -1011,7 +1035,8 @@ class StreamingVideoEncoder:
             if count == 1 or count % 10 == 0:
                 logger.warning(
                     f"Encoder queue full for {video_key}, dropped {count} frame(s). "
-                    f"Consider using vcodec='auto' for hardware encoding or increasing encoder_queue_maxsize."
+                    f"Consider using vcodec='auto' for hardware encoding, increasing "
+                    f"encoder_queue_maxsize, or drop_on_full=False when not capturing live."
                 )
 
     def finish_episode(self) -> dict[str, tuple[Path, dict | None]]:

--- a/tests/datasets/test_streaming_video_encoder.py
+++ b/tests/datasets/test_streaming_video_encoder.py
@@ -18,6 +18,7 @@
 
 import queue
 import threading
+import time
 
 import numpy as np
 import pytest
@@ -437,11 +438,89 @@ class TestStreamingVideoEncoder:
         mp4_path, _ = results[f"{OBS_IMAGES}.cam"]
         assert mp4_path.exists()
 
-        # Some frames should have been dropped (queue was tiny)
+        # Whether the tiny queue actually overflows depends on how fast the encoder
+        # drains it, so assert the invariant instead: every fed frame is either encoded
+        # or accounted for as dropped.
         dropped = encoder._dropped_frames.get(f"{OBS_IMAGES}.cam", 0)
-        # We can't guarantee drops but can verify no crash occurred
-        assert dropped >= 0
+        with av.open(str(mp4_path)) as container:
+            stream = container.streams.video[0]
+            encoded_frames = sum(1 for _ in container.decode(stream))
+        assert encoded_frames + dropped == num_frames
 
+        encoder.close()
+
+    def _stall_queue(self, encoder, video_key, maxsize=1):
+        """Swap in a frame queue the encoder thread never drains.
+
+        A real encoder keeps consuming at whatever rate the codec manages, so a test
+        cannot reliably fill its queue; small frames never overflow even a queue of 1.
+        Replacing the queue after ``start_episode`` makes "full" deterministic while
+        leaving the thread alive, so ``feed_frame`` takes the queue-full path rather
+        than the dead-thread one.
+        """
+        stalled: queue.Queue = queue.Queue(maxsize=maxsize)
+        encoder._frame_queues[video_key] = stalled
+        return stalled
+
+    def test_stalled_queue_drops_by_default(self, tmp_path):
+        """Test that a full queue drops frames instead of blocking the caller."""
+        video_key = f"{OBS_IMAGES}.cam"
+        encoder = StreamingVideoEncoder(
+            fps=30,
+            rgb_encoder=self._make_encoder_config(
+                vcodec="libsvtav1", pix_fmt="yuv420p", g=2, crf=30, preset=13
+            ),
+            queue_maxsize=1,
+        )
+        encoder.start_episode([video_key], tmp_path)
+        self._stall_queue(encoder, video_key)
+
+        num_frames = 5
+        for _ in range(num_frames):
+            encoder.feed_frame(video_key, np.zeros((64, 96, 3), dtype=np.uint8))
+
+        # Only the first frame fits the queue; every later one times out and is dropped.
+        assert encoder._dropped_frames[video_key] == num_frames - 1
+
+        encoder.cancel_episode()
+        encoder.close()
+
+    def test_stalled_queue_waits_when_not_dropping(self, tmp_path):
+        """Test that drop_on_full=False waits for a slot instead of losing frames."""
+        video_key = f"{OBS_IMAGES}.cam"
+        encoder = StreamingVideoEncoder(
+            fps=30,
+            rgb_encoder=self._make_encoder_config(
+                vcodec="libsvtav1", pix_fmt="yuv420p", g=2, crf=30, preset=13
+            ),
+            queue_maxsize=1,
+            drop_on_full=False,
+        )
+        encoder.start_episode([video_key], tmp_path)
+        stalled = self._stall_queue(encoder, video_key)
+
+        num_frames = 5
+        drained = []
+
+        def drain():
+            for _ in range(num_frames):
+                # Slower than the 0.1s drop timeout, so every frame but the first has
+                # to wait for a slot: dropping would lose frames the drainer expects.
+                time.sleep(0.15)
+                drained.append(stalled.get(timeout=10))
+
+        drainer = threading.Thread(target=drain, daemon=True)
+        drainer.start()
+
+        for _ in range(num_frames):
+            encoder.feed_frame(video_key, np.zeros((64, 96, 3), dtype=np.uint8))
+
+        drainer.join(timeout=10)
+        assert not drainer.is_alive()
+        assert len(drained) == num_frames
+        assert encoder._dropped_frames.get(video_key, 0) == 0
+
+        encoder.cancel_episode()
         encoder.close()
 
 
@@ -494,6 +573,37 @@ class TestStreamingEncoderIntegration:
         assert "action" in dataset.meta.stats
 
         dataset.finalize()
+
+    def test_create_forwards_drop_on_full(self, tmp_path):
+        """Test that create() forwards encoder_drop_on_full to the streaming encoder."""
+        from lerobot.datasets.lerobot_dataset import LeRobotDataset
+
+        features = {
+            "observation.images.cam": {
+                "dtype": "video",
+                "shape": (64, 96, 3),
+                "names": ["height", "width", "channels"],
+            },
+        }
+
+        def make(root, **kwargs):
+            return LeRobotDataset.create(
+                repo_id="test/drop_on_full",
+                fps=30,
+                features=features,
+                root=tmp_path / root,
+                use_videos=True,
+                streaming_encoding=True,
+                **kwargs,
+            )
+
+        default = make("default")
+        assert default.writer._streaming_encoder.drop_on_full is True
+        default.finalize()
+
+        blocking = make("blocking", encoder_drop_on_full=False)
+        assert blocking.writer._streaming_encoder.drop_on_full is False
+        blocking.finalize()
 
     def test_streaming_disabled_creates_pngs(self, tmp_path):
         """Test that disabling streaming encoding falls back to PNG path."""


### PR DESCRIPTION
## Summary / Motivation

`StreamingVideoEncoder.feed_frame()` drops a frame when a camera's queue stays full for 100ms rather than blocking. That is the right call for live capture — `rollout/strategies/highlight.py` and `sentry.py` explicitly document that they depend on `add_frame` being a non-blocking queue put so the control loop never stalls, and `rollout/configs.py` force-enables streaming encoding for them. At a fixed capture fps the encoder normally keeps up anyway.

Offline dataset conversion has the opposite requirement. Feeding frames from HDF5 or RLDS files runs as fast as the disk and decoder allow, with no fps ceiling, so the queue fills up routinely — and a dropped frame there is silent data corruption: the MP4 ends up with fewer frames than the parquet has rows, and nothing fails. Converting a real robot dataset with the default queue of 30, one camera lost 2 of 72649 frames, discoverable only by counting frames back out of the video afterwards.

This PR adds an opt-in `drop_on_full` flag. The default is unchanged, so live recording behaves exactly as before; offline converters can set it to `False` and get real backpressure instead of frame loss.

## Related issues

- None.

## What changed

- `StreamingVideoEncoder.__init__` takes `drop_on_full: bool = True` (`src/lerobot/datasets/video_utils.py`). When `False`, `feed_frame()` waits for a free slot instead of dropping and warning. It polls with a 1s timeout rather than blocking outright, so an encoder thread that dies while the queue is full raises instead of hanging the caller forever.
- `LeRobotDataset.create()` and `.resume()` forward the flag as `encoder_drop_on_full`. The deprecated `__init__` write path keeps the default.
- The queue-full warning now also mentions `drop_on_full=False` as an option for non-live capture.
- Docs (`docs/source/streaming_video_encoding.mdx`): document the new flag, and correct the options table, which listed `streaming_encoding` as defaulting to `True` while the code defaults to `False`. Renamed the section to "Frame Dropping and Backpressure", since dropping frames is load shedding rather than backpressure.
- No breaking changes, and no behaviour change on the live-recording path.

## How was this tested (or how to run locally)

`pytest tests/datasets/test_streaming_video_encoder.py -v` — 23 passed.

New tests in `tests/datasets/test_streaming_video_encoder.py`:

- `test_stalled_queue_drops_by_default`: with a stalled queue of 1, feeding 5 frames drops exactly 4.
- `test_stalled_queue_waits_when_not_dropping`: same setup with `drop_on_full=False` plus a drainer slower than the 0.1s drop timeout — all 5 frames arrive, none dropped.
- `test_create_forwards_drop_on_full`: `create()` propagates the flag (and its default) to the encoder.
- `test_graceful_frame_dropping` (existing) asserted `dropped >= 0`, which is always true. It now asserts the conservation invariant instead: encoded frames + dropped frames == frames fed.

Also run, since the live path must be unaffected: `tests/datasets/test_dataset_writer.py`, `tests/datasets/test_lerobot_dataset.py`, `tests/datasets/test_video_encoding.py` (131 passed, 5 skipped together with the above) and `tests/test_rollout.py` (50 passed). `pre-commit run --all-files` is clean.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated
- [ ] CI is green
- [x] Community Review: I have reviewed another contributor's open PR and linked it here: https://github.com/huggingface/lerobot/pull/4446#pullrequestreview-4946521534

## Reviewer notes

- The default stays `True` deliberately: `highlight.py` and `sentry.py` require `add_frame` to be non-blocking, so making blocking the default would stall control loops.
- The flag is intentionally *not* exposed on `DatasetRecordConfig` — live recording has no use for it, and leaving it out keeps the CLI surface unchanged.
- The new tests replace the encoder's frame queue after `start_episode` with one the encoder thread never drains. This looks roundabout, but a real encoder cannot be reliably saturated from a test: at 64x96 even `queue_maxsize=1` never overflows, and measuring both modes with 50 frames gives 0 dropped either way — which is presumably why the pre-existing drop test could only assert `dropped >= 0`. Stalling the queue makes "full" deterministic while leaving the thread alive, so `feed_frame` takes the queue-full path rather than the dead-thread one.
- Both new tests were mutation-checked: replacing `if not self.drop_on_full:` with `if False:` fails only `test_stalled_queue_waits_when_not_dropping` and leaves the drop-path test passing.
- With blocking enabled, `encoder_queue_maxsize` no longer needs to be sized to the longest episode, which keeps peak memory down for converters.
- `create()` takes the new parameter between `encoder_queue_maxsize` and `encoder_threads` for readability. Every call site in the repo passes at most `repo_id` and `fps` positionally, so no positional call is affected; happy to move it to the end if you prefer a stricter guarantee.
