### PR TITLE
SmolVLA: validate VLM backbone selection + document supported backbones (#2104)

### DIFF
--- a/docs/source/policy_smolvla_README.md
+++ b/docs/source/policy_smolvla_README.md
@@ -1,3 +1,31 @@
+## Selecting the VLM backbone
+
+`SmolVLAConfig.vlm_model_name` selects the vision-language backbone. It defaults to
+`HuggingFaceTB/SmolVLM2-500M-Video-Instruct`.
+
+| Backbone | Params | Supported today | Notes |
+|---|---|---|---|
+| `HuggingFaceTB/SmolVLM2-500M-Video-Instruct` | 500M | ✅ default | pretrained SmolVLA checkpoints available on the Hub |
+| `HuggingFaceTB/SmolVLM2-2.2B-Instruct` | 2.2B | ✅ (train from scratch) | more capacity; slower; no pretrained SmolVLA checkpoint |
+| `google/paligemma-3b-pt-224` | 3B | ⚠️ not yet — see [#2104](https://github.com/huggingface/lerobot/issues/2104) | the action-expert wiring assumes the SmolVLM architecture |
+
+**Caveats**
+
+- **Switching the backbone requires training from scratch.** The encoder architecture and feature
+  dimensions change, so you cannot fine-tune `smolvla-base` on a different backbone.
+- Set `load_vlm_weights=True` only when initializing from pretrained SmolVLA weights; use `False`
+  when training the expert from scratch.
+- Larger backbones increase memory use and inference latency, which matters for real-time control
+  on a physical arm (SO-101, etc.).
+
+**Example**
+
+```bash
+lerobot-train --policy.type=smolvla \
+  --policy.vlm_model_name=HuggingFaceTB/SmolVLM2-2.2B-Instruct \
+  --policy.load_vlm_weights=false
+```
+
 ## Paper
 
 https://arxiv.org/abs/2506.01844

--- a/src/lerobot/policies/smolvla/configuration_smolvla.py
+++ b/src/lerobot/policies/smolvla/configuration_smolvla.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 from dataclasses import dataclass, field
 
 from lerobot.configs import FeatureType, NormalizationMode, PolicyFeature, PreTrainedConfig
@@ -19,6 +20,15 @@ from lerobot.optim import AdamWConfig, CosineDecayWithWarmupSchedulerConfig
 from lerobot.utils.constants import OBS_IMAGES
 
 from ..rtc.configuration_rtc import RTCConfig
+
+# Backbones the SmolVLA action-expert wiring has been validated against. The construction in
+# smolvlm_with_expert.py assumes the SmolVLM architecture (`.text_model.layers`, nested
+# `config.text_config`), so other VLMs are not yet supported for from-scratch training.
+# See https://github.com/huggingface/lerobot/issues/2104
+SUPPORTED_VLM_BACKBONES = (
+    "HuggingFaceTB/SmolVLM2-500M-Video-Instruct",
+    "HuggingFaceTB/SmolVLM2-2.2B-Instruct",
+)
 
 
 @PreTrainedConfig.register_subclass("smolvla")
@@ -118,6 +128,14 @@ class SmolVLAConfig(PreTrainedConfig):
         if self.use_delta_joint_actions_aloha:
             raise NotImplementedError(
                 "`use_delta_joint_actions_aloha` is used by smolvla for aloha real models. It is not ported yet in LeRobot."
+            )
+        if self.vlm_model_name not in SUPPORTED_VLM_BACKBONES:
+            logging.warning(
+                f"`vlm_model_name={self.vlm_model_name!r}` is not a validated SmolVLA backbone. "
+                f"The action-expert construction currently assumes the SmolVLM architecture "
+                f"(`.text_model.layers`, `config.text_config`), so non-SmolVLM VLMs (e.g. "
+                f"PaliGemma) may fail during model init. Validated backbones: "
+                f"{SUPPORTED_VLM_BACKBONES}. See issue #2104 and the SmolVLA README."
             )
 
     def validate_features(self) -> None:

--- a/tests/policies/smolvla/test_smolvla_backbone.py
+++ b/tests/policies/smolvla/test_smolvla_backbone.py
@@ -1,0 +1,35 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from lerobot.policies.smolvla.configuration_smolvla import (
+    SUPPORTED_VLM_BACKBONES,
+    SmolVLAConfig,
+)
+
+
+def test_default_backbone_is_supported():
+    cfg = SmolVLAConfig()
+    assert cfg.vlm_model_name in SUPPORTED_VLM_BACKBONES
+
+
+def test_unsupported_vlm_backbone_warns(caplog):
+    with caplog.at_level("WARNING"):
+        SmolVLAConfig(vlm_model_name="google/paligemma-3b-pt-224")
+    assert "not a validated SmolVLA backbone" in caplog.text
+
+
+def test_supported_backbone_does_not_warn(caplog):
+    with caplog.at_level("WARNING"):
+        SmolVLAConfig(vlm_model_name="HuggingFaceTB/SmolVLM2-2.2B-Instruct")
+    assert "not a validated SmolVLA backbone" not in caplog.text


### PR DESCRIPTION
## What & why

Fixes the recurring confusion in #2104 about selecting the SmolVLA VLM backbone.

On the from-scratch path (`load_vlm_weights=False`), the action-expert wiring in
`smolvlm_with_expert.py` is coupled to the SmolVLM architecture:

- L100 hard-codes `SmolVLMForConditionalGeneration(config=config)` regardless of `model_id`
- L104–105 access `.text_model.layers` (a SmolVLM-specific attribute)
- L108 assumes a nested `config.text_config`

So the advice to "just set `--policy.vlm_model_name=google/paligemma-3b-pt-224` and train from
scratch" currently fails during model init rather than swapping the backbone.

## Changes

- Add a `SUPPORTED_VLM_BACKBONES` allowlist and a **non-breaking** `logging.warning` in
  `SmolVLAConfig.__post_init__` when an unvalidated backbone is selected — a clear message
  instead of a cryptic crash deeper in the forward pass.
- Document backbone selection + the "retrain from scratch" caveat in the SmolVLA README.
- Add tests for the warning behavior.

I used `logging.warning` rather than a hard `raise` so this doesn't regress anyone already
running a custom-but-working SmolVLM variant. Happy to switch to a hard error on the
`load_vlm_weights=False` path if you'd prefer, and to follow up with a larger PR that
generalizes the expert wiring to non-SmolVLM VLMs.

Closes #2104
