### PR TITLE
feat(rollout): allow third-party inference engines

### DIFF
--- a/docs/source/inference.mdx
+++ b/docs/source/inference.mdx
@@ -240,6 +240,49 @@ lerobot-rollout \
 
 See the [Real-Time Chunking](./rtc) guide for details on tuning RTC parameters.
 
+### Third-party inference backends
+
+Installed LeRobot plugins can add an inference backend without modifying the
+factory. Define a named config and register a builder when the plugin module is
+imported:
+
+```python
+from dataclasses import dataclass
+
+from lerobot.rollout import (
+    InferenceEngineConfig,
+    register_inference_engine,
+)
+
+
+@InferenceEngineConfig.register_subclass("my_backend")
+@dataclass
+class MyBackendConfig(InferenceEngineConfig):
+    queue_size: int = 30
+
+
+@register_inference_engine(MyBackendConfig)
+def build_my_backend(config: MyBackendConfig, **context):
+    return MyInferenceEngine(
+        config=config,
+        policy=context["policy"],
+        preprocessor=context["preprocessor"],
+        postprocessor=context["postprocessor"],
+        robot_wrapper=context["robot_wrapper"],
+        shutdown_event=context["shutdown_event"],
+    )
+```
+
+Package the module under one of the names discovered by
+`register_third_party_plugins` (for example, `lerobot_policy_my_backend`). The
+plugin is imported before CLI parsing, so its config is available as
+`--inference.type=my_backend`.
+
+Registration uses the exact config type and rejects duplicates. A plugin
+cannot silently replace `sync`, `rtc`, or another installed backend. Builders
+receive the rollout construction context as keyword arguments; use only the
+fields the backend needs.
+
 ---
 
 ## Interactive Sessions

--- a/src/lerobot/rollout/__init__.py
+++ b/src/lerobot/rollout/__init__.py
@@ -62,6 +62,7 @@ from .inference import (
     SyncInferenceConfig,
     SyncInferenceEngine,
     create_inference_engine,
+    register_inference_engine,
 )
 from .interactive import InteractiveSession
 from .strategies import (
@@ -112,4 +113,5 @@ __all__ = [
     "build_rollout_context",
     "create_inference_engine",
     "create_strategy",
+    "register_inference_engine",
 ]

--- a/src/lerobot/rollout/inference/__init__.py
+++ b/src/lerobot/rollout/inference/__init__.py
@@ -24,6 +24,7 @@ from .factory import (
     RTCInferenceConfig,
     SyncInferenceConfig,
     create_inference_engine,
+    register_inference_engine,
 )
 from .rtc import RTCInferenceEngine
 from .sync import SyncInferenceEngine
@@ -39,4 +40,5 @@ __all__ = [
     "SyncInferenceConfig",
     "SyncInferenceEngine",
     "create_inference_engine",
+    "register_inference_engine",
 ]

--- a/src/lerobot/rollout/inference/factory.py
+++ b/src/lerobot/rollout/inference/factory.py
@@ -14,15 +14,15 @@
 
 """Inference engine configs and factory.
 
-Selection is explicit via ``--inference.type=sync|rtc``.  Adding a new
-backend requires registering its config subclass and dispatching it in
-:func:`create_inference_engine`.
+Selection is explicit via ``--inference.type=<name>``. Built-in and third-party
+backends register a config subclass and an inference-engine builder.
 """
 
 from __future__ import annotations
 
 import abc
 import logging
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from threading import Event
 
@@ -75,6 +75,79 @@ class RTCInferenceConfig(InferenceEngineConfig):
 
 
 # ---------------------------------------------------------------------------
+# Third-party engine builders
+# ---------------------------------------------------------------------------
+
+
+InferenceEngineBuilder = Callable[..., InferenceEngine]
+_INFERENCE_ENGINE_BUILDERS: dict[type[InferenceEngineConfig], InferenceEngineBuilder] = {}
+
+
+def register_inference_engine(
+    config_type: type[InferenceEngineConfig],
+) -> Callable[[InferenceEngineBuilder], InferenceEngineBuilder]:
+    """Register the builder for an inference config type.
+
+    LeRobot already discovers third-party packages before parsing ``lerobot-rollout``
+    arguments.  Keeping engine dispatch in this registry lets those packages add an
+    ``InferenceEngineConfig`` choice without patching this factory's ``isinstance``
+    chain.  Registration is deliberately exact-type and duplicate-safe so a plugin
+    cannot silently replace a built-in backend.
+    """
+    if not issubclass(config_type, InferenceEngineConfig):
+        raise TypeError("config_type must inherit InferenceEngineConfig")
+
+    def decorator(builder: InferenceEngineBuilder) -> InferenceEngineBuilder:
+        if config_type in _INFERENCE_ENGINE_BUILDERS:
+            raise ValueError(f"Inference engine already registered for {config_type.__name__}")
+        _INFERENCE_ENGINE_BUILDERS[config_type] = builder
+        return builder
+
+    return decorator
+
+
+@register_inference_engine(SyncInferenceConfig)
+def _build_sync_inference_engine(
+    config: SyncInferenceConfig,
+    **kwargs,
+) -> InferenceEngine:
+    del config
+    robot_wrapper = kwargs["robot_wrapper"]
+    return SyncInferenceEngine(
+        policy=kwargs["policy"],
+        preprocessor=kwargs["preprocessor"],
+        postprocessor=kwargs["postprocessor"],
+        dataset_features=kwargs["dataset_features"],
+        ordered_action_keys=kwargs["ordered_action_keys"],
+        task=kwargs["task"],
+        device=kwargs["device"],
+        robot_type=robot_wrapper.robot_type,
+    )
+
+
+@register_inference_engine(RTCInferenceConfig)
+def _build_rtc_inference_engine(
+    config: RTCInferenceConfig,
+    **kwargs,
+) -> InferenceEngine:
+    return RTCInferenceEngine(
+        policy=kwargs["policy"],
+        preprocessor=kwargs["preprocessor"],
+        postprocessor=kwargs["postprocessor"],
+        robot_wrapper=kwargs["robot_wrapper"],
+        rtc_config=config.rtc,
+        hw_features=kwargs["hw_features"],
+        task=kwargs["task"],
+        fps=kwargs["fps"],
+        device=kwargs["device"],
+        use_torch_compile=kwargs["use_torch_compile"],
+        compile_warmup_inferences=kwargs["compile_warmup_inferences"],
+        rtc_queue_threshold=config.queue_threshold,
+        shutdown_event=kwargs["shutdown_event"],
+    )
+
+
+# ---------------------------------------------------------------------------
 # Factory
 # ---------------------------------------------------------------------------
 
@@ -98,31 +171,25 @@ def create_inference_engine(
 ) -> InferenceEngine:
     """Instantiate the appropriate inference engine from a config object."""
     logger.info("Creating inference engine: %s", config.type)
-    if isinstance(config, SyncInferenceConfig):
-        return SyncInferenceEngine(
-            policy=policy,
-            preprocessor=preprocessor,
-            postprocessor=postprocessor,
-            dataset_features=dataset_features,
-            ordered_action_keys=ordered_action_keys,
-            task=task,
-            device=device,
-            robot_type=robot_wrapper.robot_type,
+    builder = _INFERENCE_ENGINE_BUILDERS.get(type(config))
+    if builder is None:
+        raise ValueError(
+            f"No inference engine registered for config type: {type(config).__name__}. "
+            "Third-party configs must register a builder with register_inference_engine()."
         )
-    if isinstance(config, RTCInferenceConfig):
-        return RTCInferenceEngine(
-            policy=policy,
-            preprocessor=preprocessor,
-            postprocessor=postprocessor,
-            robot_wrapper=robot_wrapper,
-            rtc_config=config.rtc,
-            hw_features=hw_features,
-            task=task,
-            fps=fps,
-            device=device,
-            use_torch_compile=use_torch_compile,
-            compile_warmup_inferences=compile_warmup_inferences,
-            rtc_queue_threshold=config.queue_threshold,
-            shutdown_event=shutdown_event,
-        )
-    raise ValueError(f"Unknown inference engine type: {type(config).__name__}")
+    return builder(
+        config=config,
+        policy=policy,
+        preprocessor=preprocessor,
+        postprocessor=postprocessor,
+        robot_wrapper=robot_wrapper,
+        hw_features=hw_features,
+        dataset_features=dataset_features,
+        ordered_action_keys=ordered_action_keys,
+        task=task,
+        fps=fps,
+        device=device,
+        use_torch_compile=use_torch_compile,
+        compile_warmup_inferences=compile_warmup_inferences,
+        shutdown_event=shutdown_event,
+    )

--- a/tests/test_rollout.py
+++ b/tests/test_rollout.py
@@ -485,6 +485,87 @@ def test_create_inference_engine_sync():
     assert isinstance(engine, SyncInferenceEngine)
 
 
+def test_third_party_inference_engine_builder_dispatches_without_factory_patch():
+    from lerobot.rollout import (
+        InferenceEngineConfig,
+        create_inference_engine,
+        register_inference_engine,
+    )
+
+    @InferenceEngineConfig.register_subclass("test_extension")
+    @dataclasses.dataclass
+    class TestExtensionConfig(InferenceEngineConfig):
+        marker: str = "plugin"
+
+    sentinel = object()
+
+    @register_inference_engine(TestExtensionConfig)
+    def build_test_extension(config, **kwargs):
+        assert config.marker == "plugin"
+        assert kwargs["task"] == "test"
+        return sentinel
+
+    engine = create_inference_engine(
+        TestExtensionConfig(),
+        policy=MagicMock(),
+        preprocessor=MagicMock(),
+        postprocessor=MagicMock(),
+        robot_wrapper=MagicMock(robot_type="mock"),
+        hw_features={},
+        dataset_features={},
+        ordered_action_keys=["k"],
+        task="test",
+        fps=30.0,
+        device="cpu",
+    )
+
+    assert engine is sentinel
+
+
+def test_inference_engine_builder_rejects_duplicate_registration():
+    from lerobot.rollout import InferenceEngineConfig, register_inference_engine
+
+    @InferenceEngineConfig.register_subclass("test_duplicate")
+    @dataclasses.dataclass
+    class TestDuplicateConfig(InferenceEngineConfig):
+        pass
+
+    register_inference_engine(TestDuplicateConfig)(lambda **_kwargs: object())
+    with pytest.raises(ValueError, match="already registered"):
+        register_inference_engine(TestDuplicateConfig)(lambda **_kwargs: object())
+
+
+def test_inference_engine_builder_rejects_invalid_config_type():
+    from lerobot.rollout import register_inference_engine
+
+    with pytest.raises(TypeError, match="must inherit InferenceEngineConfig"):
+        register_inference_engine(object)  # type: ignore[arg-type]
+
+
+def test_create_inference_engine_reports_unregistered_config():
+    from lerobot.rollout import InferenceEngineConfig, create_inference_engine
+
+    @InferenceEngineConfig.register_subclass("test_unregistered")
+    @dataclasses.dataclass
+    class TestUnregisteredConfig(InferenceEngineConfig):
+        pass
+
+    with pytest.raises(ValueError, match="No inference engine registered"):
+        create_inference_engine(
+            TestUnregisteredConfig(),
+            policy=MagicMock(),
+            preprocessor=MagicMock(),
+            postprocessor=MagicMock(),
+            robot_wrapper=MagicMock(robot_type="mock"),
+            hw_features={},
+            dataset_features={},
+            ordered_action_keys=["k"],
+            task="test",
+            fps=30.0,
+            device="cpu",
+        )
+
+
 # ---------------------------------------------------------------------------
 # Pure functions
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary / Motivation

LeRobot discovers third-party config subclasses before parsing `lerobot-rollout` arguments, but its inference factory hard-codes built-in config types. This adds an exact-type builder registry so external packages can provide an `InferenceEngineConfig` without patching the factory. Built-in sync and RTC behavior remains registered by LeRobot.

## What changed

- export `register_inference_engine(ConfigType)`
- route built-in sync and RTC construction through the registry
- reject invalid, duplicate, and unregistered config types
- document third-party backend packaging and registration
- add dispatch and failure-path tests

No CLI syntax or built-in behavior changes.

## Testing

Validated after rebasing onto current `main` (`223a8ad1`):

- `uv sync --locked --extra test --extra dataset --extra dev`
- `pytest tests/test_rollout.py tests/test_interactive_rollout.py`: **111 passed**
- doc/doctest/config-docstring checks: passed
- `interrogate --config=pyproject.toml`: passed (53.3%, minimum 52%)
- every configured pre-commit hook on the changed files: passed
- downstream ActionStream plugin-discovery and backend-contract tests: passed

The all-files Windows pre-commit run reached every hook; its only rewrite was Windows' representation of 27 repository symlinks, excluded from this PR. A Windows full base-tier pytest probe also hit unrelated OpenCV camera fixture channel-shape failures. Neither affected the changed rollout tests; Linux upstream CI remains authoritative.

## Checklist

- [x] rebased onto current `main` (`223a8ad1`)
- [x] relevant rollout and interactive-rollout tests pass locally (111)
- [x] documentation and quality checks pass locally
- [ ] upstream Quality and Fast Tests approved/run by a maintainer
- [ ] upstream Full Tests approved/run
- [ ] community review completed (required by `CONTRIBUTING.md` before maintainer attention)

Reviewer focus: whether exact config-type dispatch is the preferred extension boundary. The downstream engine is intentionally outside this PR.

Significant AI assistance was used to draft and test this change. The author reviewed the diff and validated it with the tests above.