### PR TITLE
fix(async): separate observation receive timing

### DIFF
--- a/src/lerobot/async_inference/policy_server.py
+++ b/src/lerobot/async_inference/policy_server.py
@@ -175,13 +175,16 @@ class PolicyServer(services_pb2_grpc.AsyncInferenceServicer):
         client_id = context.peer()
         self.logger.debug(f"Receiving observations from {client_id}")
 
-        receive_time = time.time()  # comparing timestamps so need time.time()
-        start_deserialize = time.perf_counter()
+        start_receive = time.perf_counter()
         received_bytes = receive_bytes_in_chunks(
             request_iterator, None, self.shutdown_event, self.logger
         )  # blocking call while looping over request_iterator
+        receive_duration = time.perf_counter() - start_receive
+
+        receive_time = time.time()  # comparing timestamps so need time.time()
+        start_deserialize = time.perf_counter()
         timed_observation = pickle.loads(received_bytes)  # nosec
-        deserialize_time = time.perf_counter() - start_deserialize
+        deserialize_duration = time.perf_counter() - start_deserialize
 
         self.logger.debug(f"Received observation #{timed_observation.get_timestep()}")
 
@@ -201,7 +204,9 @@ class PolicyServer(services_pb2_grpc.AsyncInferenceServicer):
         self.logger.debug(
             f"Server timestamp: {receive_time:.6f} | "
             f"Client timestamp: {obs_timestamp:.6f} | "
-            f"Deserialization time: {deserialize_time:.6f}s"
+            f"Receive time: {receive_duration:.6f}s | "
+            f"Deserialization time: {deserialize_duration:.6f}s | "
+            f"Payload size: {len(received_bytes)} bytes"
         )
 
         if not self._enqueue_observation(

--- a/tests/async_inference/test_policy_server.py
+++ b/tests/async_inference/test_policy_server.py
@@ -17,6 +17,7 @@ Monkey-patch the `policy` attribute with a stub so that no real model inference 
 
 from __future__ import annotations
 
+import pickle
 import time
 
 import pytest
@@ -187,6 +188,30 @@ def test_obs_sanity_checks(policy_server):
     # Case 3 – genuinely new & dissimilar observation passes
     obs_ok = _make_obs(torch.ones(6) * 5, timestep=3)
     assert policy_server._obs_sanity_checks(obs_ok, prev) is True
+
+
+def test_send_observations_logs_receive_and_decode_separately(monkeypatch, policy_server):
+    """Transport wait time must not be attributed to pickle deserialization."""
+    import lerobot.async_inference.policy_server as policy_server_module
+
+    observation = _make_obs(torch.zeros(6), must_go=True)
+    payload = pickle.dumps(observation)
+    messages = []
+    perf_counter_values = iter((10.0, 12.0, 12.0, 12.01))
+
+    monkeypatch.setattr(policy_server_module, "receive_bytes_in_chunks", lambda *_: payload)
+    monkeypatch.setattr(policy_server_module.time, "perf_counter", lambda: next(perf_counter_values))
+    monkeypatch.setattr(policy_server.logger, "debug", messages.append)
+
+    class Context:
+        def peer(self):
+            return "test-client"
+
+    policy_server.SendObservations(iter(()), Context())
+
+    assert any("Receive time: 2.000000s" in message for message in messages)
+    assert any("Deserialization time: 0.010000s" in message for message in messages)
+    assert any(f"Payload size: {len(payload)} bytes" in message for message in messages)
 
 
 def test_predict_action_chunk(monkeypatch, policy_server):


### PR DESCRIPTION
## Summary

Async-inference logs now distinguish time spent receiving an observation stream from time spent decoding it, and include the payload size. This prevents multi-second transport stalls from being reported as pickle deserialization and provides the measurements needed to investigate huggingface/lerobot#2458.

## Tests

- `PYTHONPATH=src uv run --extra async --extra test pytest tests/async_inference -q`
- `PYTHONPATH=src uv run --extra async --extra test --extra dev ruff check src/lerobot/async_inference/policy_server.py tests/async_inference/test_policy_server.py`

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/Codex-000000)
