### PR TITLE
Add tactile sensor module with unified point-set interface (roadmap #3832)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,6 +168,7 @@ timm-dep = ["timm>=1.0.0,<1.1.0"]
 
 # Motors
 feetech = ["feetech-servo-sdk>=1.0.0,<2.0.0", "lerobot[pyserial-dep]", "lerobot[deepdiff-dep]"]
+paxini = ["lerobot[pyserial-dep]"]
 dynamixel = ["dynamixel-sdk>=3.7.31,<3.9.0", "lerobot[pyserial-dep]", "lerobot[deepdiff-dep]"]
 damiao = ["lerobot[can-dep]"]
 robstride = ["lerobot[can-dep]"]

--- a/src/lerobot/tactile/__init__.py
+++ b/src/lerobot/tactile/__init__.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tactile sensor module for LeRobot.
+
+This module provides a unified interface for tactile sensors, following the same
+design pattern as the cameras module. Tactile data is represented as a point set
+where each sensing point is a fixed-dimension vector, selected by
+``TactileDataType``:
+
+- ``displacement``: per-point 3D displacement ``[dx, dy, dz]`` (optical sensors)
+- ``force``: per-point 3D force ``[Fx, Fy, Fz]`` (taxel arrays, per-fingertip resultants)
+- ``full``: per-point 6D ``[dx, dy, dz, Fx, Fy, Fz]`` (optical sensors with force fields)
+- ``wrench``: per-point 6D force-torque ``[Fx, Fy, Fz, Mx, My, Mz]`` (F/T-style sensors)
+
+Supported backends:
+    - simulated: Simulated tactile sensor for testing and development
+    - paxini: PaXini multi-fingertip force sensor arrays (serial)
+
+Example:
+    ```python
+    from lerobot.tactile.simulated import SimulatedTactile, SimulatedTactileConfig
+
+    config = SimulatedTactileConfig(num_points=400, fps=30)
+    with SimulatedTactile(config) as sensor:
+        data = sensor.read()  # Returns (400, 6) array
+    ```
+"""
+
+from .configs import TactileDataType, TactileSensorConfig
+from .tactile import TactileSensor
+from .utils import make_tactile_sensors_from_configs
+
+__all__ = [
+    "TactileDataType",
+    "TactileSensor",
+    "TactileSensorConfig",
+    "make_tactile_sensors_from_configs",
+]

--- a/src/lerobot/tactile/configs.py
+++ b/src/lerobot/tactile/configs.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Configuration classes for tactile sensors."""
+
+import abc
+from dataclasses import dataclass
+from enum import Enum
+
+import draccus  # type: ignore  # TODO: add type stubs for draccus
+
+
+class TactileDataType(str, Enum):  # noqa: UP042
+    """Supported tactile data types determining the dimensionality per point.
+
+    Covers the three sensing families found in practice:
+    optical elastomer sensors (displacement and optionally dense force fields),
+    taxel/force-distribution arrays (per-point 3D force), and
+    force-torque style outputs (per-point 6D wrench).
+    """
+
+    DISPLACEMENT = "displacement"  # 3D displacement field (dx, dy, dz)
+    FORCE = "force"  # 3D force distribution (Fx, Fy, Fz)
+    FULL = "full"  # Displacement and force (6D: dx, dy, dz, Fx, Fy, Fz)
+    WRENCH = "wrench"  # Force-torque (6D: Fx, Fy, Fz, Mx, My, Mz)
+
+    @classmethod
+    def _missing_(cls, value: object) -> None:
+        raise ValueError(f"`data_type` is expected to be in {list(cls)}, but {value} is provided.")
+
+
+@dataclass(kw_only=True)
+class TactileSensorConfig(draccus.ChoiceRegistry, abc.ABC):
+    """Base configuration class for tactile sensors.
+
+    This abstract base class defines the common configuration parameters for all
+    tactile sensor implementations, following the same pattern as CameraConfig.
+
+    Attributes:
+        fps: Frames per second for data acquisition. Defaults to 30.
+        num_points: Number of tactile sensing points (e.g., 400 for a 20x20 array,
+            or 5 for one resultant point per fingertip of a five-finger hand).
+        data_type: Type of tactile data to capture. Defaults to FULL (6D).
+
+    Example:
+        ```python
+        # Create a simulated tactile sensor
+        from lerobot.tactile.simulated import SimulatedTactile, SimulatedTactileConfig
+
+        config = SimulatedTactileConfig(num_points=400)
+        with SimulatedTactile(config) as sensor:
+            data = sensor.read()
+        ```
+    """
+
+    fps: int = 30
+    num_points: int = 400
+    data_type: TactileDataType = TactileDataType.FULL
+
+    def __post_init__(self) -> None:
+        """Validate and coerce configuration values."""
+        self.data_type = TactileDataType(self.data_type)
+
+        if self.fps <= 0:
+            raise ValueError(f"`fps` must be positive, got {self.fps}")
+        if self.num_points <= 0:
+            raise ValueError(f"`num_points` must be positive, got {self.num_points}")
+
+    @property
+    def type(self) -> str:
+        """Return the sensor type identifier."""
+        return str(self.get_choice_name(self.__class__))
+
+    @property
+    def data_dim(self) -> int:
+        """Return the dimensionality of tactile data per point.
+
+        Returns:
+            int: 3 for displacement-only or force-only, 6 for full or wrench data.
+        """
+        dim_map = {
+            TactileDataType.DISPLACEMENT: 3,
+            TactileDataType.FORCE: 3,
+            TactileDataType.FULL: 6,
+            TactileDataType.WRENCH: 6,
+        }
+        return dim_map[self.data_type]
+
+    @property
+    def expected_shape(self) -> tuple[int, ...]:
+        """Return the expected shape of tactile data.
+
+        Returns:
+            tuple: Shape as (num_points, data_dim).
+        """
+        return (self.num_points, self.data_dim)

--- a/src/lerobot/tactile/paxini/__init__.py
+++ b/src/lerobot/tactile/paxini/__init__.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .configuration_paxini import PaxiniTactileConfig
+from .tactile_paxini import PaxiniTactile
+
+__all__ = ["PaxiniTactile", "PaxiniTactileConfig"]

--- a/src/lerobot/tactile/paxini/configuration_paxini.py
+++ b/src/lerobot/tactile/paxini/configuration_paxini.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Configuration for PaXini multi-fingertip tactile force sensors."""
+
+from dataclasses import dataclass
+
+from ..configs import TactileDataType, TactileSensorConfig
+
+__all__ = ["PaxiniTactileConfig"]
+
+
+@TactileSensorConfig.register_subclass("paxini")
+@dataclass
+class PaxiniTactileConfig(TactileSensorConfig):
+    """Configuration for PaXini fingertip force sensor arrays.
+
+    PaXini sensors are taxel-based force-distribution sensors commonly mounted
+    on the fingertips of dexterous hands (up to five sensors on one serial hub).
+    The hub streams per-fingertip resultant 3D forces ``[Fx, Fy, Fz]``, so the
+    natural configuration is ``data_type=FORCE`` with one point per fingertip.
+
+    Note:
+        Only ``data_type=FORCE`` is supported: the hub streams 3D force vectors.
+        Displacement and wrench outputs are not provided by this hardware.
+
+    Attributes:
+        port: Serial port of the sensor hub (e.g., "/dev/ttyACM1").
+        baudrate: Serial baudrate. Defaults to 921600.
+        timeout_ms: Timeout for frame reception in milliseconds. Defaults to 1000.
+        tare_on_connect: Whether to zero readings on connect. Defaults to True.
+
+    Example:
+        ```python
+        from lerobot.tactile.paxini import PaxiniTactile, PaxiniTactileConfig
+
+        config = PaxiniTactileConfig(port="/dev/ttyACM1", num_points=5)
+        with PaxiniTactile(config) as sensor:
+            data = sensor.read()  # (5, 3) array, one [Fx, Fy, Fz] per fingertip
+        ```
+    """
+
+    port: str = "/dev/ttyACM1"
+    baudrate: int = 921600
+    timeout_ms: float = 1000.0
+    tare_on_connect: bool = True
+
+    num_points: int = 5
+    data_type: TactileDataType = TactileDataType.FORCE
+    fps: int = 90
+
+    def __post_init__(self) -> None:
+        """Validate PaXini-specific configuration."""
+        super().__post_init__()
+
+        if self.data_type != TactileDataType.FORCE:
+            raise ValueError(
+                f"PaXini sensors only support data_type=FORCE (3D per point), got {self.data_type}. "
+                "The hub streams per-fingertip resultant force vectors."
+            )
+        if not 1 <= self.num_points <= 5:
+            raise ValueError(f"PaXini hubs support 1-5 fingertip sensors, got {self.num_points}")

--- a/src/lerobot/tactile/paxini/tactile_paxini.py
+++ b/src/lerobot/tactile/paxini/tactile_paxini.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""PaXini fingertip tactile sensor implementation.
+
+Speaks the PaXini serial hub wire format directly (pyserial), no vendor SDK
+required. The hub streams auto frames containing one resultant 3D force vector
+per connected fingertip sensor.
+
+Wire format (little-endian):
+    Register request:  55 AA | 00 | func | addr(2) | count(2) | LRC
+    Register response: AA 55 | 00 | func | addr(2) | nbytes(2) | data | LRC
+    Auto stream frame: AA 56 | 00 | eff_len(2) | payload | LRC
+    LRC = two's complement of the low byte of the sum of all preceding bytes.
+    Resultant payload: 6 bytes per sensor; each axis occupies a 2-byte slot with
+    data in the low byte (int8 Fx, int8 Fy, uint8 Fz), 0.1 N per LSB.
+"""
+
+import logging
+import threading
+import time
+from queue import Empty, Queue
+from typing import Any
+
+import numpy as np
+from numpy.typing import NDArray
+
+from lerobot.utils.import_utils import is_package_available
+
+from ..tactile import TactileSensor
+from .configuration_paxini import PaxiniTactileConfig
+
+logger = logging.getLogger(__name__)
+
+HEADER_REQUEST = bytes([0x55, 0xAA])
+HEADER_RESPONSE = bytes([0xAA, 0x55])
+HEADER_AUTO = bytes([0xAA, 0x56])
+FUNC_READ = 0x03
+FUNC_WRITE = 0x10
+ADDR_CONNECTED_SENSORS = 0x0010
+ADDR_AUTO_DATA_TYPE = 0x0016
+ADDR_AUTO_ENABLE = 0x0017
+AUTO_DATA_RESULTANT = 0x01
+BYTES_PER_RESULTANT = 6
+NEWTON_PER_LSB = 0.1
+# Hardware-fixed (byte_idx, bit_pos) of each fingertip slot in the
+# connected-sensors register.
+SLOT_CONNECTED_BITS = [(0, 2), (0, 6), (1, 2), (1, 6), (2, 2)]
+
+
+def checksum(frame: bytes) -> int:
+    """LRC checksum: two's complement of the low byte of the sum."""
+    return (0x100 - (sum(frame) & 0xFF)) & 0xFF
+
+
+def build_read_request(address: int, count: int) -> bytes:
+    body = HEADER_REQUEST + bytes([0x00, FUNC_READ]) + address.to_bytes(2, "little")
+    body += count.to_bytes(2, "little")
+    return body + bytes([checksum(body)])
+
+
+def build_write_request(address: int, data: bytes) -> bytes:
+    body = HEADER_REQUEST + bytes([0x00, FUNC_WRITE]) + address.to_bytes(2, "little")
+    body += len(data).to_bytes(2, "little") + data
+    return body + bytes([checksum(body)])
+
+
+def decode_resultant_payload(payload: bytes, num_sensors: int) -> NDArray[np.float64]:
+    """Decode an auto-stream resultant payload into an (N, 3) force array in Newtons."""
+    expected = num_sensors * BYTES_PER_RESULTANT
+    if len(payload) != expected:
+        raise ValueError(f"Resultant payload size mismatch: expected {expected}, got {len(payload)}")
+    out = np.empty((num_sensors, 3), dtype=np.float64)
+    for i in range(num_sensors):
+        off = i * BYTES_PER_RESULTANT
+        fx, fy, fz = payload[off], payload[off + 2], payload[off + 4]
+        out[i, 0] = (fx - 256 if fx > 127 else fx) * NEWTON_PER_LSB
+        out[i, 1] = (fy - 256 if fy > 127 else fy) * NEWTON_PER_LSB
+        out[i, 2] = fz * NEWTON_PER_LSB
+    return out
+
+
+def parse_connected_slots(register: bytes) -> list[int]:
+    """Return indices of fingertip slots reported connected by the hub."""
+    slots = []
+    for slot, (byte_idx, bit_pos) in enumerate(SLOT_CONNECTED_BITS):
+        if byte_idx < len(register) and register[byte_idx] & (1 << bit_pos):
+            slots.append(slot)
+    return slots
+
+
+class PaxiniTactile(TactileSensor):
+    """PaXini fingertip force sensor hub implementation.
+
+    Streams per-fingertip resultant 3D forces from up to five taxel-array
+    sensors connected to one serial hub.
+
+    Example:
+        ```python
+        from lerobot.tactile.paxini import PaxiniTactile, PaxiniTactileConfig
+
+        config = PaxiniTactileConfig(port="/dev/ttyACM1", num_points=5)
+        with PaxiniTactile(config) as sensor:
+            data = sensor.read()  # (5, 3) array
+        ```
+    """
+
+    def __init__(self, config: PaxiniTactileConfig):
+        super().__init__(config)
+        self.config = config
+        self._serial: Any = None
+        self._is_connected = False
+        self._frame_queue: Queue[NDArray[np.float64]] = Queue(maxsize=2)
+        self._capture_thread: threading.Thread | None = None
+        self._stop_event = threading.Event()
+        self._latest_frame: NDArray[np.float64] | None = None
+        self._latest_ts: float = 0.0
+        self._tare_offset: NDArray[np.float64] | None = None
+
+    @property
+    def is_connected(self) -> bool:
+        return self._is_connected
+
+    @staticmethod
+    def find_sensors() -> list[dict[str, Any]]:
+        """Detect serial ports that may host a PaXini hub."""
+        if not is_package_available("serial"):
+            logger.warning("pyserial is not installed. Cannot detect PaXini sensors.")
+            return []
+        from serial.tools import list_ports
+
+        found = []
+        for p in list_ports.comports():
+            found.append({"id": p.device, "type": "paxini", "description": p.description})
+        return found
+
+    def connect(self, warmup: bool = True) -> None:
+        """Open the serial port, enable the resultant auto stream and start capture.
+
+        Raises:
+            ImportError: If pyserial is not installed.
+            ConnectionError: If already connected or the hub does not respond.
+        """
+        if self._is_connected:
+            raise ConnectionError("Sensor is already connected.")
+        try:
+            import serial
+        except ImportError as e:
+            raise ImportError(
+                "pyserial is required for PaXini sensors. Install with: pip install 'lerobot[paxini]'"
+            ) from e
+
+        self._serial = serial.Serial(self.config.port, self.config.baudrate, timeout=0.1)
+        # Stop any previous stream, then configure resultant-only auto streaming.
+        self._write_register(ADDR_AUTO_ENABLE, bytes([0x00]))
+        connected = parse_connected_slots(self._read_register(ADDR_CONNECTED_SENSORS, 4))
+        if len(connected) < self.config.num_points:
+            self._serial.close()
+            raise ConnectionError(
+                f"Hub reports {len(connected)} connected fingertip sensors "
+                f"({connected}), but num_points={self.config.num_points}."
+            )
+        self._write_register(ADDR_AUTO_DATA_TYPE, bytes([AUTO_DATA_RESULTANT]))
+        self._write_register(ADDR_AUTO_ENABLE, bytes([0x01]))
+
+        self._is_connected = True
+        self._stop_event.clear()
+        self._capture_thread = threading.Thread(target=self._capture_loop, daemon=True)
+        self._capture_thread.start()
+
+        if warmup:
+            deadline = time.perf_counter() + self.config.timeout_ms / 1000.0
+            while self._latest_frame is None and time.perf_counter() < deadline:
+                time.sleep(0.01)
+        if self.config.tare_on_connect:
+            self.tare()
+        logger.info(f"PaXini hub connected on {self.config.port} ({self.config.num_points} sensors)")
+
+    def disconnect(self) -> None:
+        """Stop streaming and release the serial port."""
+        self._stop_event.set()
+        if self._capture_thread is not None:
+            self._capture_thread.join(timeout=2.0)
+            self._capture_thread = None
+        if self._serial is not None:
+            try:
+                self._write_register(ADDR_AUTO_ENABLE, bytes([0x00]))
+            except Exception:  # nosec B110
+                pass
+            self._serial.close()
+            self._serial = None
+        self._is_connected = False
+        logger.info("PaXini hub disconnected")
+
+    def read(self) -> NDArray[np.float64]:
+        """Capture a single tactile frame synchronously.
+
+        Returns:
+            np.ndarray: Force data with shape (num_points, 3), Newtons.
+        """
+        if not self._is_connected:
+            raise ConnectionError("Sensor is not connected. Call connect() first.")
+        try:
+            frame = self._frame_queue.get(timeout=self.config.timeout_ms / 1000.0)
+        except Empty as e:
+            raise TimeoutError(f"No frame received within {self.config.timeout_ms}ms") from e
+        return self._apply_tare(frame)
+
+    def async_read(self, timeout_ms: float = 1000.0) -> NDArray[np.float64]:
+        """Return the most recent new tactile frame."""
+        if not self._is_connected:
+            raise ConnectionError("Sensor is not connected.")
+        try:
+            frame = self._frame_queue.get(timeout=timeout_ms / 1000.0)
+        except Empty as e:
+            raise TimeoutError(f"No frame received within {timeout_ms}ms") from e
+        return self._apply_tare(frame)
+
+    def read_latest(self, max_age_ms: int = 500) -> NDArray[np.float64]:
+        """Return the most recent frame immediately (non-blocking)."""
+        if not self._is_connected:
+            raise ConnectionError("Sensor is not connected.")
+        if self._latest_frame is None:
+            raise RuntimeError("No frames captured yet.")
+        age_ms = (time.perf_counter() - self._latest_ts) * 1000.0
+        if age_ms > max_age_ms:
+            raise TimeoutError(f"Latest frame is {age_ms:.0f}ms old (max {max_age_ms}ms)")
+        return self._apply_tare(self._latest_frame)
+
+    def tare(self, num_samples: int = 10) -> None:
+        """Zero the readings by averaging the next ``num_samples`` frames."""
+        if not self._is_connected:
+            raise ConnectionError("Cannot tare: sensor is not connected")
+        samples = []
+        for i in range(num_samples):
+            try:
+                samples.append(self._frame_queue.get(timeout=self.config.timeout_ms / 1000.0))
+            except Empty as e:
+                raise RuntimeError(f"Failed to capture tare sample {i}") from e
+        self._tare_offset = np.mean(samples, axis=0)
+
+    def _apply_tare(self, frame: NDArray[np.float64]) -> NDArray[np.float64]:
+        if self._tare_offset is not None:
+            return frame - self._tare_offset
+        return frame
+
+    def _read_register(self, address: int, count: int) -> bytes:
+        self._serial.reset_input_buffer()
+        self._serial.write(build_read_request(address, count))
+        frame = self._read_response_frame()
+        nbytes = int.from_bytes(frame[6:8], "little")
+        return frame[8 : 8 + nbytes]
+
+    def _write_register(self, address: int, data: bytes) -> None:
+        self._serial.reset_input_buffer()
+        self._serial.write(build_write_request(address, data))
+        self._read_response_frame()
+
+    def _read_response_frame(self) -> bytes:
+        """Read one AA 55 response frame, skipping any interleaved auto frames."""
+        deadline = time.perf_counter() + self.config.timeout_ms / 1000.0
+        while time.perf_counter() < deadline:
+            header = self._resync_to_header()
+            if header == HEADER_AUTO:
+                meta = self._read_exact(3)
+                eff_len = int.from_bytes(meta[1:3], "little")
+                self._read_exact(eff_len + 1)  # payload + LRC
+                continue
+            meta = self._read_exact(6)
+            nbytes = int.from_bytes(meta[4:6], "little")
+            body = self._read_exact(nbytes + 1)
+            frame = header + meta + body
+            if frame[-1] != checksum(frame[:-1]):
+                raise OSError("Register response LRC mismatch")
+            return frame
+        raise TimeoutError("No register response from PaXini hub")
+
+    def _resync_to_header(self) -> bytes:
+        """Scan the byte stream until a response or auto-frame header is found."""
+        prev = b""
+        deadline = time.perf_counter() + self.config.timeout_ms / 1000.0
+        while time.perf_counter() < deadline:
+            b1 = self._serial.read(1)
+            if not b1:
+                continue
+            pair = prev + b1
+            if pair in (HEADER_RESPONSE, HEADER_AUTO):
+                return pair
+            prev = b1
+        raise TimeoutError("Could not sync to PaXini frame header")
+
+    def _read_exact(self, n: int) -> bytes:
+        buf = b""
+        deadline = time.perf_counter() + self.config.timeout_ms / 1000.0
+        while len(buf) < n and time.perf_counter() < deadline:
+            chunk = self._serial.read(n - len(buf))
+            if chunk:
+                buf += chunk
+        if len(buf) < n:
+            raise TimeoutError(f"Expected {n} bytes, got {len(buf)}")
+        return buf
+
+    def _capture_loop(self) -> None:
+        """Background thread: parse auto-stream frames into the queue."""
+        expected = self.config.num_points * BYTES_PER_RESULTANT
+        while not self._stop_event.is_set():
+            try:
+                header = self._resync_to_header()
+                if header != HEADER_AUTO:
+                    # Register response consumed by main thread paths only pre-stream;
+                    # here we just skip it.
+                    meta = self._read_exact(6)
+                    nbytes = int.from_bytes(meta[4:6], "little")
+                    self._read_exact(nbytes + 1)
+                    continue
+                meta = self._read_exact(3)
+                eff_len = int.from_bytes(meta[1:3], "little")
+                payload_and_lrc = self._read_exact(eff_len + 1)
+                payload, lrc = payload_and_lrc[:-1], payload_and_lrc[-1]
+                if checksum(header + meta + payload) != lrc:
+                    logger.debug("Auto frame LRC mismatch, dropping frame")
+                    continue
+                if len(payload) < expected:
+                    continue
+                frame = decode_resultant_payload(payload[:expected], self.config.num_points)
+                self._latest_frame = frame
+                self._latest_ts = time.perf_counter()
+                if self._frame_queue.full():
+                    try:
+                        self._frame_queue.get_nowait()
+                    except Empty:  # nosec B110
+                        pass
+                self._frame_queue.put_nowait(frame)
+            except TimeoutError:
+                continue
+            except Exception as e:
+                if not self._stop_event.is_set():
+                    logger.warning(f"PaXini capture error: {e}")

--- a/src/lerobot/tactile/simulated/__init__.py
+++ b/src/lerobot/tactile/simulated/__init__.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+
+# Copyright 2024 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .configuration_simulated import SimulatedTactileConfig
+from .tactile_simulated import SimulatedTactile
+
+__all__ = ["SimulatedTactile", "SimulatedTactileConfig"]

--- a/src/lerobot/tactile/simulated/configuration_simulated.py
+++ b/src/lerobot/tactile/simulated/configuration_simulated.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+
+# Copyright 2024 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Configuration for simulated tactile sensors."""
+
+from dataclasses import dataclass
+
+from ..configs import TactileSensorConfig
+
+__all__ = ["SimulatedTactileConfig"]
+
+
+@TactileSensorConfig.register_subclass("simulated")
+@dataclass
+class SimulatedTactileConfig(TactileSensorConfig):
+    """Configuration for simulated tactile sensors.
+
+    Used for testing and development without physical hardware.
+
+    Attributes:
+        noise_std: Standard deviation of simulated Gaussian noise. Defaults to 0.01.
+        seed: Random seed for reproducible simulation. Defaults to 42.
+        warmup_frames: Number of frames to discard on connect. Defaults to 5.
+        simulate_delay: Whether to simulate realistic frame timing. Defaults to False.
+
+    Example:
+        ```python
+        config = SimulatedTactileConfig(num_points=400, fps=30)
+        with SimulatedTactile(config) as sensor:
+            data = sensor.read()  # (400, 6) array
+        ```
+    """
+
+    noise_std: float = 0.01
+    seed: int = 42
+    warmup_frames: int = 5
+    simulate_delay: bool = False

--- a/src/lerobot/tactile/simulated/tactile_simulated.py
+++ b/src/lerobot/tactile/simulated/tactile_simulated.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python
+
+# Copyright 2024 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Simulated tactile sensor for testing and development."""
+
+import time
+from typing import Any
+
+import numpy as np
+from numpy.typing import NDArray
+
+from ..tactile import TactileSensor
+from .configuration_simulated import SimulatedTactileConfig
+
+
+class SimulatedTactile(TactileSensor):
+    """Simulated tactile sensor for testing and development.
+
+    Generates random tactile data with optional noise, useful for testing
+    pipelines without physical hardware.
+
+    Example:
+        ```python
+        config = SimulatedTactileConfig(num_points=400, seed=42)
+        with SimulatedTactile(config) as sensor:
+            data = sensor.read()  # (400, 6) array
+        ```
+    """
+
+    def __init__(self, config: SimulatedTactileConfig):
+        super().__init__(config)
+        self.config = config
+        self._rng = np.random.default_rng(config.seed)
+        self._is_connected = False
+
+    @property
+    def is_connected(self) -> bool:
+        return self._is_connected
+
+    @staticmethod
+    def find_sensors() -> list[dict[str, Any]]:
+        """Return a single simulated sensor.
+
+        Returns:
+            list: Single simulated sensor entry.
+        """
+        return [{"id": "simulated_0", "type": "simulated"}]
+
+    def connect(self, warmup: bool = True) -> None:
+        """Connect to the simulated sensor.
+
+        Args:
+            warmup: If True, generates warmup frames to simulate real sensor behavior.
+        """
+        self._is_connected = True
+
+        if warmup:
+            for _ in range(self.config.warmup_frames):
+                self._generate_frame()
+                if self.config.simulate_delay:
+                    time.sleep(1.0 / self.fps)
+
+    def disconnect(self) -> None:
+        """Disconnect from the simulated sensor."""
+        self._is_connected = False
+
+    def read(self) -> NDArray[np.float64]:
+        """Generate and return a simulated tactile frame.
+
+        Returns:
+            np.ndarray: Simulated tactile data with shape (num_points, data_dim).
+
+        Raises:
+            ConnectionError: If sensor is not connected.
+        """
+        if not self._is_connected:
+            raise ConnectionError("Sensor is not connected. Call connect() first.")
+
+        frame = self._generate_frame()
+        if self.config.simulate_delay:
+            time.sleep(1.0 / self.fps)
+        return frame
+
+    def async_read(self, timeout_ms: float = 1000.0) -> NDArray[np.float64]:
+        """Return the most recent simulated frame.
+
+        For the simulated sensor, this behaves identically to read().
+
+        Args:
+            timeout_ms: Ignored for simulated sensor.
+
+        Returns:
+            np.ndarray: Simulated tactile data.
+        """
+        return self.read()
+
+    def _generate_frame(self) -> NDArray[np.float64]:
+        """Generate a single simulated tactile frame.
+
+        Returns:
+            np.ndarray: Generated frame with shape (num_points, data_dim).
+        """
+        # Generate base random data
+        frame = self._rng.standard_normal((self.num_points, self.data_dim)) * 0.1
+
+        # Add noise
+        if self.config.noise_std > 0:
+            frame += self._rng.standard_normal(frame.shape) * self.config.noise_std
+
+        # For full 6D data, scale displacement and force differently
+        if self.data_dim == 6:
+            frame[:, :3] *= 2.0  # Displacement in mm range
+            frame[:, 3:6] *= 0.5  # Force in N range
+
+        return frame.astype(np.float64)

--- a/src/lerobot/tactile/tactile.py
+++ b/src/lerobot/tactile/tactile.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python
+
+# Copyright 2024 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Base tactile sensor interface for LeRobot."""
+
+import abc
+import warnings
+from typing import Any
+
+import numpy as np
+from numpy.typing import NDArray  # type: ignore  # TODO: add type stubs for numpy.typing
+
+from .configs import TactileSensorConfig
+
+
+class TactileSensor(abc.ABC):
+    """Base class for tactile sensor implementations.
+
+    Defines a standard interface for tactile sensor operations across different backends,
+    following the same design pattern as Camera. Subclasses must implement all abstract methods.
+
+    Tactile sensors provide high-resolution contact information as point clouds,
+    where each sensing point is represented as a 6D vector [dx, dy, dz, Fx, Fy, Fz]
+    capturing both 3D displacement and 3D force information.
+
+    Attributes:
+        fps (int | None): Configured frames per second
+        num_points (int | None): Number of sensing points in the sensor array
+        data_dim (int | None): Dimensionality of data per point (3 or 6)
+    """
+
+    def __init__(self, config: TactileSensorConfig):
+        """Initialize the tactile sensor with the given configuration.
+
+        Args:
+            config: TactileSensorConfig containing sensor parameters.
+        """
+        self.fps: int | None = config.fps
+        self.num_points: int | None = config.num_points
+        self.data_dim: int | None = config.data_dim
+
+    def __enter__(self):
+        """Context manager entry. Automatically connects to the sensor."""
+        self.connect()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        """Context manager exit. Automatically disconnects."""
+        self.disconnect()
+
+    def __del__(self) -> None:
+        """Destructor safety net."""
+        try:
+            if self.is_connected:
+                self.disconnect()
+        except Exception:  # nosec B110
+            pass
+
+    @property
+    @abc.abstractmethod
+    def is_connected(self) -> bool:
+        """Check if the sensor is currently connected.
+
+        Returns:
+            bool: True if sensor is connected and ready, False otherwise.
+        """
+        pass
+
+    @staticmethod
+    @abc.abstractmethod
+    def find_sensors() -> list[dict[str, Any]]:
+        """Detect available tactile sensors connected to the system.
+
+        Returns:
+            list[dict[str, Any]]: List of dictionaries containing information
+                about each detected sensor.
+        """
+        pass
+
+    @abc.abstractmethod
+    def connect(self, warmup: bool = True) -> None:
+        """Establish connection to the tactile sensor.
+
+        Args:
+            warmup: If True, captures a warmup frame before returning.
+        """
+        pass
+
+    @abc.abstractmethod
+    def read(self) -> NDArray[np.float64]:
+        """Capture and return a single tactile frame synchronously.
+
+        Returns:
+            np.ndarray: Tactile data array with shape (num_points, data_dim).
+                For full 6D data: (N, 6) where each row is [dx, dy, dz, Fx, Fy, Fz].
+
+        Raises:
+            ConnectionError: If the sensor is not connected.
+            TimeoutError: If data cannot be read within the timeout period.
+        """
+        pass
+
+    @abc.abstractmethod
+    def async_read(self, timeout_ms: float = 1000.0) -> NDArray[np.float64]:
+        """Return the most recent new tactile frame.
+
+        Blocks up to timeout_ms waiting for a new frame if none available.
+
+        Args:
+            timeout_ms: Maximum time to wait for a new frame in milliseconds.
+
+        Returns:
+            np.ndarray: Tactile data array with shape (num_points, data_dim).
+
+        Raises:
+            TimeoutError: If no new frame arrives within timeout_ms.
+            ConnectionError: If the sensor is not connected.
+        """
+        pass
+
+    def read_latest(self, max_age_ms: int = 500) -> NDArray[np.float64]:
+        """Return the most recent frame immediately (non-blocking).
+
+        This method returns whatever is currently in the buffer without waiting.
+        The frame may be stale (captured some time ago).
+
+        Usage:
+            Ideal for scenarios requiring zero latency or decoupled frequencies,
+            such as visualization or non-critical monitoring.
+
+        Args:
+            max_age_ms: Maximum acceptable age of the frame in milliseconds.
+                Raises TimeoutError if the latest frame is older than this.
+
+        Returns:
+            np.ndarray: The latest tactile data frame.
+
+        Raises:
+            TimeoutError: If the latest frame is older than max_age_ms.
+            ConnectionError: If the sensor is not connected.
+            RuntimeError: If no frames have been captured yet.
+        """
+        # Default implementation: delegates to async_read
+        # Subclasses may override for true non-blocking behavior
+        warnings.warn(
+            f"{self.__class__.__name__}.read_latest() default implementation "
+            "calls async_read(). Override for true non-blocking behavior.",
+            FutureWarning,
+            stacklevel=2,
+        )
+        return self.async_read(timeout_ms=max_age_ms)
+
+    @abc.abstractmethod
+    def disconnect(self) -> None:
+        """Disconnect from the sensor and release all resources."""
+        pass

--- a/src/lerobot/tactile/utils.py
+++ b/src/lerobot/tactile/utils.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+
+# Copyright 2024 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Utility functions for tactile sensors."""
+
+from typing import cast
+
+from lerobot.utils.import_utils import make_device_from_device_class
+
+from .configs import TactileSensorConfig
+from .tactile import TactileSensor
+
+
+def make_tactile_sensors_from_configs(
+    tactile_configs: dict[str, TactileSensorConfig],
+) -> dict[str, TactileSensor]:
+    """Create tactile sensor instances from configuration dictionary.
+
+    Args:
+        tactile_configs: Dictionary mapping sensor names to their configurations.
+
+    Returns:
+        Dictionary mapping sensor names to instantiated TactileSensor objects.
+
+    Example:
+        ```python
+        configs = {
+            "left_hand": PaxiniTactileConfig(port="/dev/ttyACM1"),
+            "right_hand": PaxiniTactileConfig(port="/dev/ttyACM2"),
+        }
+        sensors = make_tactile_sensors_from_configs(configs)
+        ```
+    """
+    sensors: dict[str, TactileSensor] = {}
+
+    for key, cfg in tactile_configs.items():
+        if cfg.type == "simulated":
+            from .simulated import SimulatedTactile
+
+            sensors[key] = SimulatedTactile(cfg)
+
+        elif cfg.type == "paxini":
+            from .paxini import PaxiniTactile
+
+            sensors[key] = PaxiniTactile(cfg)
+
+        else:
+            try:
+                sensors[key] = cast(TactileSensor, make_device_from_device_class(cfg))
+            except Exception as e:
+                raise ValueError(f"Error creating tactile sensor {key} with config {cfg}: {e}") from e
+
+    return sensors

--- a/tests/tactile/test_tactile_sensor.py
+++ b/tests/tactile/test_tactile_sensor.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for tactile sensor module."""
+
+import numpy as np
+import pytest
+
+from lerobot.tactile.configs import TactileDataType
+from lerobot.tactile.paxini.tactile_paxini import (
+    HEADER_AUTO,
+    build_read_request,
+    build_write_request,
+    checksum,
+    decode_resultant_payload,
+    parse_connected_slots,
+)
+from lerobot.tactile.simulated import SimulatedTactile, SimulatedTactileConfig
+
+
+class TestTactileSensorConfig:
+    """Test tactile sensor configuration classes."""
+
+    def test_simulated_config_defaults(self):
+        config = SimulatedTactileConfig()
+        assert config.fps == 30
+        assert config.num_points == 400
+        assert config.data_type == TactileDataType.FULL
+        assert config.data_dim == 6
+        assert config.expected_shape == (400, 6)
+
+    def test_data_type_dimension(self):
+        assert SimulatedTactileConfig(data_type=TactileDataType.DISPLACEMENT).data_dim == 3
+        assert SimulatedTactileConfig(data_type=TactileDataType.FORCE).data_dim == 3
+        assert SimulatedTactileConfig(data_type=TactileDataType.FULL).data_dim == 6
+        assert SimulatedTactileConfig(data_type=TactileDataType.WRENCH).data_dim == 6
+
+    def test_expected_shape(self):
+        config = SimulatedTactileConfig(num_points=100, data_type=TactileDataType.FULL)
+        assert config.expected_shape == (100, 6)
+
+    def test_wrench_shape(self):
+        config = SimulatedTactileConfig(num_points=5, data_type=TactileDataType.WRENCH)
+        assert config.expected_shape == (5, 6)
+
+    def test_config_type(self):
+        assert SimulatedTactileConfig().type == "simulated"
+
+    def test_invalid_data_type(self):
+        with pytest.raises(ValueError, match="expected to be in"):
+            SimulatedTactileConfig(data_type="invalid")
+
+    def test_invalid_fps(self):
+        with pytest.raises(ValueError, match="fps.*must be positive"):
+            SimulatedTactileConfig(fps=0)
+
+    def test_invalid_num_points(self):
+        with pytest.raises(ValueError, match="num_points.*must be positive"):
+            SimulatedTactileConfig(num_points=-1)
+
+    def test_data_type_string_coercion(self):
+        assert SimulatedTactileConfig(data_type="full").data_type == TactileDataType.FULL
+        assert SimulatedTactileConfig(data_type="wrench").data_type == TactileDataType.WRENCH
+
+
+class TestSimulatedTactile:
+    """Test simulated tactile sensor."""
+
+    def test_connect_disconnect(self):
+        sensor = SimulatedTactile(SimulatedTactileConfig())
+        assert not sensor.is_connected
+        sensor.connect(warmup=False)
+        assert sensor.is_connected
+        sensor.disconnect()
+        assert not sensor.is_connected
+
+    def test_context_manager(self):
+        with SimulatedTactile(SimulatedTactileConfig()) as sensor:
+            assert sensor.is_connected
+        assert not sensor.is_connected
+
+    def test_read_shape(self):
+        with SimulatedTactile(SimulatedTactileConfig()) as sensor:
+            data = sensor.read()
+            assert data.shape == (400, 6)
+            assert data.dtype == np.float64
+
+    def test_read_without_connect_raises(self):
+        sensor = SimulatedTactile(SimulatedTactileConfig())
+        with pytest.raises(ConnectionError):
+            sensor.read()
+
+    def test_find_sensors(self):
+        sensors = SimulatedTactile.find_sensors()
+        assert len(sensors) >= 1
+        assert sensors[0]["type"] == "simulated"
+
+    def test_reproducible_with_seed(self):
+        with (
+            SimulatedTactile(SimulatedTactileConfig(seed=42)) as s1,
+            SimulatedTactile(SimulatedTactileConfig(seed=42)) as s2,
+        ):
+            np.testing.assert_array_almost_equal(s1.read(), s2.read())
+
+    def test_different_data_types(self):
+        for data_type, expected_dim in [
+            (TactileDataType.DISPLACEMENT, 3),
+            (TactileDataType.FORCE, 3),
+            (TactileDataType.FULL, 6),
+            (TactileDataType.WRENCH, 6),
+        ]:
+            with SimulatedTactile(SimulatedTactileConfig(data_type=data_type)) as sensor:
+                assert sensor.read().shape == (400, expected_dim)
+
+    def test_no_delay_by_default(self):
+        import time
+
+        with SimulatedTactile(SimulatedTactileConfig(simulate_delay=False)) as sensor:
+            start = time.perf_counter()
+            for _ in range(10):
+                sensor.read()
+            assert time.perf_counter() - start < 1.0
+
+
+class TestPaxiniCodec:
+    """Test the PaXini wire-format codec (pure functions, no hardware)."""
+
+    def test_checksum_roundtrip(self):
+        frame = bytes([0xAA, 0x56, 0x00, 0x06, 0x00, 1, 2, 3, 4, 5, 6])
+        lrc = checksum(frame)
+        assert (sum(frame) + lrc) & 0xFF == 0
+
+    def test_build_read_request_layout(self):
+        req = build_read_request(0x0010, 4)
+        assert req[:2] == bytes([0x55, 0xAA])
+        assert req[3] == 0x03
+        assert int.from_bytes(req[4:6], "little") == 0x0010
+        assert int.from_bytes(req[6:8], "little") == 4
+        assert req[-1] == checksum(req[:-1])
+
+    def test_build_write_request_layout(self):
+        req = build_write_request(0x0017, bytes([0x01]))
+        assert req[:2] == bytes([0x55, 0xAA])
+        assert req[3] == 0x10
+        assert int.from_bytes(req[4:6], "little") == 0x0017
+        assert req[8] == 0x01
+        assert req[-1] == checksum(req[:-1])
+
+    def test_decode_resultant_payload(self):
+        # Two sensors: (+1.2N, -0.5N, 2.0N) and (0, 0, 0.1N)
+        payload = bytes([12, 0, 251, 0xFF, 20, 0]) + bytes([0, 0, 0, 0, 1, 0])
+        out = decode_resultant_payload(payload, 2)
+        np.testing.assert_allclose(out[0], [1.2, -0.5, 2.0], atol=1e-9)
+        np.testing.assert_allclose(out[1], [0.0, 0.0, 0.1], atol=1e-9)
+
+    def test_decode_resultant_size_mismatch(self):
+        with pytest.raises(ValueError, match="size mismatch"):
+            decode_resultant_payload(bytes(5), 1)
+
+    def test_parse_connected_slots(self):
+        # Slots at (0,2),(0,6),(1,2),(1,6),(2,2): set slot0, slot2, slot4
+        register = bytes([0b0000_0100, 0b0000_0100, 0b0000_0100, 0x00])
+        assert parse_connected_slots(register) == [0, 2, 4]
+
+    def test_auto_frame_lrc(self):
+        payload = bytes(6)
+        meta = bytes([0x00]) + len(payload).to_bytes(2, "little")
+        frame_wo_lrc = HEADER_AUTO + meta + payload
+        assert checksum(frame_wo_lrc) == (0x100 - (sum(frame_wo_lrc) & 0xFF)) & 0xFF
+
+
+class TestPaxiniConfig:
+    """Test PaXini configuration validation."""
+
+    def test_defaults(self):
+        from lerobot.tactile.paxini import PaxiniTactileConfig
+
+        config = PaxiniTactileConfig()
+        assert config.num_points == 5
+        assert config.data_type == TactileDataType.FORCE
+        assert config.expected_shape == (5, 3)
+        assert config.type == "paxini"
+
+    def test_rejects_non_force(self):
+        from lerobot.tactile.paxini import PaxiniTactileConfig
+
+        with pytest.raises(ValueError, match="only support data_type=FORCE"):
+            PaxiniTactileConfig(data_type=TactileDataType.FULL)
+
+    def test_rejects_bad_num_points(self):
+        from lerobot.tactile.paxini import PaxiniTactileConfig
+
+        with pytest.raises(ValueError, match="1-5 fingertip"):
+            PaxiniTactileConfig(num_points=6)


### PR DESCRIPTION
## What this PR does

Implements the **"New sensor support (force, tactile)"** item from the 0.7.0 roadmap (#3832), as offered in [this comment](https://github.com/huggingface/lerobot/issues/3832#issuecomment-5312894071).

It revives the unified point-set design of the closed PR #3175 (following the `cameras` module pattern) and extends it to cover the sensing families found in commercial tactile hardware:

- **`lerobot/tactile/` module**: abstract `TactileSensor` base + config registry, mirroring `cameras`
- **`TactileDataType`**: `displacement` / `force` (3D point sets) / `full` (6D optical, as in #3175) / **`wrench` (6D force-torque)** — covers optical, force-array and F/T sensor families with one interface
- **`simulated` backend** for hardware-free CI
- **`paxini` backend**: serial fingertip force-array hubs (PaXini PX-6AX family), self-contained wire codec, no vendor SDK dependency — validated daily on our MagusHand dexterous hand (five fingertip force arrays)
- **27 hardware-free unit tests**, `pyproject` extra, full type annotations

## What we'd like to iterate on with the team

- How `observation.tactile.*` should land in `LeRobotDataset` features (schema follow-up)
- Whether the point-set `[dx, dy, dz, Fx, Fy, Fz]` layout from #3175 should stay the canonical on-disk form
- Naming/registry conventions for third-party tactile plugin packages

Happy to split this into smaller PRs if preferred.