### PR TITLE
feat(docker): add ROCm dockerfile for AMD Instinct GPUs

### DIFF
--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -1,0 +1,68 @@
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# GPU image for AMD Instinct accelerators. Unlike Dockerfile.internal, the base image
+# already ships a ROCm build of PyTorch, and that build is authoritative: lerobot pins
+# torch<2.12 / torchvision<0.27 / numpy<2.3, all below what current ROCm images carry,
+# and [tool.uv.sources] resolves torch from the CUDA cu128 index. Installing normally
+# would swap in CUDA wheels and leave the GPUs unusable.
+#
+# The fix follows the same pattern as Dockerfile.benchmark.robomme: pin the conflicting
+# packages with `uv pip install --override` so the rest of the tree resolves normally
+# against whatever the base image provides.
+
+# Build:  docker build -f docker/Dockerfile.rocm -t lerobot-rocm .
+
+# Any ROCm PyTorch image works if it was compiled for your architecture; this default
+# targets gfx942/gfx950 (MI300X / MI308X / MI325X / MI350X).
+ARG BASE_IMAGE=rocm/primus:v26.4
+FROM ${BASE_IMAGE}
+
+# Generated from the base image rather than hardcoded, so bumping BASE_IMAGE does not
+# require editing this file.
+ARG ROCM_OVERRIDES=/etc/rocm-overrides.txt
+RUN pip install --no-cache-dir uv \
+    && for pkg in torch torchvision torchaudio numpy triton; do \
+        version=$(python -c "import importlib.metadata as m; print(m.version('$pkg'))" 2>/dev/null) \
+        && echo "$pkg==$version"; \
+    done > "${ROCM_OVERRIDES}" \
+    && cat "${ROCM_OVERRIDES}"
+
+# Exported only after the file exists, so that later `uv pip install` / `pip install`
+# calls inside the container are held to the same ROCm stack instead of replacing it.
+ENV UV_OVERRIDE=${ROCM_OVERRIDES} \
+    PIP_CONSTRAINT=${ROCM_OVERRIDES} \
+    ROCPROFILER_LOG_LEVEL=fatal
+
+WORKDIR /lerobot
+COPY . .
+
+# [pi] pulls transformers/scipy, [training] pulls the dataset, wandb and accelerate
+# extras. Everything except the overridden packages resolves from pyproject as usual,
+# so this image does not carry a second copy of the dependency list.
+RUN uv pip install --no-cache --python "$(which python)" -e ".[pi,training]"
+
+# Fail the build rather than ship an image whose GPUs are unusable. Runs without a GPU,
+# so it only checks that the ROCm build survived resolution; torch.cuda.is_available()
+# needs the devices and is covered by the smoke test in docker/README.md.
+RUN python -c "\
+import numpy, torch, torchvision;\
+from lerobot.policies.factory import get_policy_class;\
+print('torch', torch.__version__, '| hip', torch.version.hip);\
+print('torchvision', torchvision.__version__, '| numpy', numpy.__version__);\
+assert torch.version.hip, 'ROCm torch was replaced by a CUDA build';\
+assert '+rocm' in torchvision.__version__, 'torchvision was replaced by a CUDA build';\
+print('policy factory OK:', get_policy_class('pi05').__name__)"
+
+CMD ["/bin/bash"]

--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -48,10 +48,12 @@ ENV UV_OVERRIDE=${ROCM_OVERRIDES} \
 WORKDIR /lerobot
 COPY . .
 
-# [pi] pulls transformers/scipy, [training] pulls the dataset, wandb and accelerate
-# extras. Everything except the overridden packages resolves from pyproject as usual,
-# so this image does not carry a second copy of the dependency list.
-RUN uv pip install --no-cache --python "$(which python)" -e ".[pi,training]"
+# `all` matches Dockerfile.internal and Dockerfile.user, so the ROCm image is not a
+# reduced-capability variant. Everything except the overridden packages resolves from
+# pyproject as usual, so this image carries no second copy of the dependency list.
+# Narrow it when a smaller image matters, e.g. --build-arg LEROBOT_EXTRAS=pi,training.
+ARG LEROBOT_EXTRAS=all
+RUN uv pip install --no-cache --python "$(which python)" -e ".[${LEROBOT_EXTRAS}]"
 
 # Fail the build rather than ship an image whose GPUs are unusable. Runs without a GPU,
 # so it only checks that the ROCm build survived resolution; torch.cuda.is_available()

--- a/docker/README.md
+++ b/docker/README.md
@@ -72,7 +72,7 @@ docker run -it --rm --ipc=host --shm-size 16gb --device=/dev/kfd --device=/dev/d
 
 ### Multi-GPU training
 
-To select specific GPUs, set `CUDA_VISIBLE_DEVICES` when launching the container:
+To select specific GPUs, set `CUDA_VISIBLE_DEVICES` when launching the container (for AMD GPUs, `HIP_VISIBLE_DEVICES` is recommended):
 
 ```bash
 # Use 4 GPUs

--- a/docker/README.md
+++ b/docker/README.md
@@ -33,6 +33,12 @@ A lightweight image based on `python:3.12-slim`. Includes all Python dependencie
 
 A CUDA-enabled image based on `nvidia/cuda`. This is the image for training — mostly used for internal interactions with the GPU cluster.
 
+### `Dockerfile.rocm` (AMD GPU)
+
+An image for AMD Instinct accelerators, based on a ROCm PyTorch image (`rocm/primus` by default, override with `--build-arg BASE_IMAGE=...`). The base image owns the PyTorch install: LeRobot pins `torch<2.12`, `torchvision<0.27` and `numpy<2.3`, all below what current ROCm images ship, and `[tool.uv.sources]` resolves torch from the CUDA `cu128` index — installing normally would swap in CUDA wheels and leave the GPUs unusable. Those packages are therefore pinned with `uv pip install --override`, the same approach `Dockerfile.benchmark.robomme` uses for its own irreconcilable pins, and the rest of the dependency tree resolves from `pyproject.toml` as usual.
+
+The default base image is compiled for `gfx942`/`gfx950` (MI300X / MI308X / MI325X / MI350X). Other architectures need a base image built for them.
+
 ## Usage
 
 ### Running a pre-built image
@@ -57,6 +63,11 @@ docker run -it --rm lerobot-user
 # GPU
 docker build -f docker/Dockerfile.internal -t lerobot-internal .
 docker run -it --rm --gpus all --shm-size 16gb lerobot-internal
+
+# AMD GPU (ROCm)
+docker build -f docker/Dockerfile.rocm -t lerobot-rocm .
+# ROCm exposes GPUs through `/dev/kfd` and `/dev/dri` rather than `--gpus`, and the container needs the `video` and `render` groups.
+docker run -it --rm --ipc=host --shm-size 16gb --device=/dev/kfd --device=/dev/dri --group-add video --group-add render lerobot-rocm
 ```
 
 ### Multi-GPU training

--- a/docs/source/torch_accelerators.mdx
+++ b/docs/source/torch_accelerators.mdx
@@ -5,7 +5,7 @@ LeRobot supports multiple hardware acceleration options for both training and in
 These options include:
 
 - **CPU**: CPU executes all computations, no dedicated accelerator is used
-- **CUDA**: acceleration with NVIDIA & AMD GPUs
+- **CUDA**: acceleration with NVIDIA GPUs, and with AMD GPUs through ROCm (see [AMD GPUs](#amd-gpus-rocm))
 - **MPS**: acceleration with Apple Silicon GPUs
 - **XPU**: acceleration with Intel integrated and discrete GPUs
 
@@ -15,6 +15,22 @@ To use particular accelerator, a suitable version of PyTorch should be installed
 
 For CPU, CUDA, and MPS backends follow instructions provided on [PyTorch installation page](https://pytorch.org/get-started/locally).
 For XPU backend, follow instructions from [PyTorch documentation](https://docs.pytorch.org/docs/stable/notes/get_start_xpu.html).
+
+### AMD GPUs (ROCm)
+
+ROCm builds of PyTorch expose the HIP runtime through the `torch.cuda` namespace, so
+`--policy.device=cuda` selects an AMD GPU and no LeRobot-side change is needed. Use
+`HIP_VISIBLE_DEVICES` rather than `CUDA_VISIBLE_DEVICES` to select specific cards.
+
+Installing LeRobot on top of an existing ROCm PyTorch needs care: LeRobot pins
+`torch<2.12`, `torchvision<0.27` and `numpy<2.3`, all below what current ROCm images
+ship, and `[tool.uv.sources]` resolves torch from the CUDA `cu128` index, so an
+unconstrained install replaces the ROCm build and leaves the GPUs unusable. Pin those
+packages with `uv pip install --override` so the rest of the tree resolves normally.
+[`docker/Dockerfile.rocm`](https://github.com/huggingface/lerobot/blob/main/docker/Dockerfile.rocm)
+does this and is the quickest way to a working environment; see
+[docker/README.md](https://github.com/huggingface/lerobot/blob/main/docker/README.md)
+for the run flags ROCm requires.
 
 ### Verifying the installation
 

--- a/docs/source/torch_accelerators.mdx
+++ b/docs/source/torch_accelerators.mdx
@@ -19,8 +19,7 @@ For XPU backend, follow instructions from [PyTorch documentation](https://docs.p
 ### AMD GPUs (ROCm)
 
 ROCm builds of PyTorch expose the HIP runtime through the `torch.cuda` namespace, so
-`--policy.device=cuda` selects an AMD GPU and no LeRobot-side change is needed. Use
-`HIP_VISIBLE_DEVICES` rather than `CUDA_VISIBLE_DEVICES` to select specific cards.
+`--policy.device=cuda` selects an AMD GPU and no LeRobot-side change is needed. `HIP_VISIBLE_DEVICES` is preferred over `CUDA_VISIBLE_DEVICES` when selecting specific cards.
 
 Installing LeRobot on top of an existing ROCm PyTorch needs care: LeRobot pins
 `torch<2.12`, `torchvision<0.27` and `numpy<2.3`, all below what current ROCm images


### PR DESCRIPTION
## Title

feat(docker): add ROCm dockerfile for AMD Instinct GPUs

## Summary / Motivation

LeRobot runs unmodified on AMD Instinct accelerators — ROCm builds of PyTorch expose HIP through the `torch.cuda` namespace, so `--policy.device=cuda` already selects an AMD GPU — but getting to a working environment is the hard part, and it fails in a way that is easy to misdiagnose. LeRobot pins `torch>=2.7,<2.12`, `torchvision>=0.22,<0.27` and `numpy>=2.0,<2.3`, all of which are *below* what current ROCm PyTorch images ship, and `[tool.uv.sources]` resolves `torch` from the CUDA `cu128` index. A plain `pip install -e ".[pi]"` inside a ROCm container therefore replaces the ROCm build with CUDA wheels and leaves the GPUs silently unusable: `torch.cuda.is_available()` returns `False` on a machine with eight working accelerators.

This PR adds `docker/Dockerfile.rocm`, which resolves that conflict the same way `Dockerfile.benchmark.robomme` already resolves its own irreconcilable pins — with `uv pip install --override` — plus the ROCm-specific runtime documentation. No Python code, no `pyproject.toml` change, and no new dependency on the maintainers to keep a second copy of the dependency list in sync.

Design notes and trade-offs:

- **The base image owns PyTorch.** The overrides file is *generated at build time* from whatever `torch`/`torchvision`/`torchaudio`/`numpy`/`triton` the base image ships, so bumping `--build-arg BASE_IMAGE=...` needs no edit to the Dockerfile. Everything else resolves from `pyproject.toml` as usual, so the image does not duplicate the dependency list and cannot drift from it.
- **`UV_OVERRIDE` / `PIP_CONSTRAINT` are exported into the image**, so a user who later runs `pip install something` inside the container cannot accidentally pull CUDA wheels over the ROCm stack either.
- **The build fails rather than shipping a broken image.** A final `RUN` asserts `torch.version.hip` is set and `torchvision` still carries the `+rocm` tag, which is the failure mode that is otherwise only discovered at training time.

## Related issues

- Fixes / Closes: _none_
- Related: #1347 — an earlier ROCm Dockerfile PR, still open. It targets **Radeon consumer** cards rather than Instinct, places files in a `docker/lerobot-rocm/` subdirectory instead of the current `docker/Dockerfile.<name>` layout.
- Related: #4330 — documents the ROCm PyTorch index in `installation.mdx`; complementary to the accelerator docs touched here.
- Related: #4205 / #4324 — a ROCm-specific runtime bug, unaffected by this PR.

## What changed

- **New `docker/Dockerfile.rocm`.** Builds on a ROCm PyTorch base (`rocm/primus:v26.4` by default, overridable with `--build-arg BASE_IMAGE=...`), installs `-e ".[pi,training]"` through `uv pip install --override`, and asserts the ROCm stack survived resolution. Follows the existing `docker/Dockerfile.<name>` naming and the `# Build:` comment convention used by the benchmark images.
- **`docker/README.md`.** Adds a `Dockerfile.rocm` entry under *Dockerfiles*, the build command under *Building locally*, a *Running on AMD GPUs (ROCm)* section covering the four device/group flags ROCm requires, and a `HIP_VISIBLE_DEVICES` example alongside the existing `CUDA_VISIBLE_DEVICES` one under *Multi-GPU training*.
- **`docs/source/torch_accelerators.mdx`.** The bullet list already claimed CUDA covers "NVIDIA & AMD GPUs" without saying how; it now links to a new *AMD GPUs (ROCm)* subsection explaining that `--policy.device=cuda` is correct on ROCm, that `HIP_VISIBLE_DEVICES` replaces `CUDA_VISIBLE_DEVICES`, and why an unconstrained install breaks the environment.
- **No breaking changes.** Nothing outside `docker/` and `docs/` is touched, no existing file's behaviour changes, and no migration is required.

## How was this tested (or how to run locally)

- **Tests added: none.** This PR adds no Python code — one Dockerfile and two docs files — so there is no unit-testable surface. Existing tests are unaffected. Manual verification has been done on 8× AMD Instinct MI308X (gfx942).

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`) — run as `pre-commit run --files docker/Dockerfile.rocm docker/README.md docs/source/torch_accelerators.mdx`; every applicable hook passed (`typos`, `prettier`, `end-of-file-fixer`, `trailing-whitespace`, `gitleaks`), the rest were skipped as no Python/YAML/TOML changed. I did not run `-a` across the whole tree so as not to restage unrelated files.
- [ ] All tests pass locally (`pytest`)
- [x] Documentation updated — `docker/README.md` and `docs/source/torch_accelerators.mdx`.
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: # (insert PR number/link)

## Reviewer notes
- None
