### PR TITLE
refactor(processor): change processors authority

### DIFF
--- a/src/lerobot/async_inference/policy_server.py
+++ b/src/lerobot/async_inference/policy_server.py
@@ -40,7 +40,7 @@ import torch
 
 from lerobot.lerobot_types import PolicyAction
 from lerobot.policies import get_policy_class, make_pre_post_processors
-from lerobot.processor import PolicyProcessorPipeline
+from lerobot.processor import PolicyProcessorPipeline, ProcessorBuildContext
 from lerobot.transport import (
     services_pb2,  # type: ignore
     services_pb2_grpc,  # type: ignore
@@ -152,16 +152,16 @@ class PolicyServer(services_pb2_grpc.AsyncInferenceServicer):
         self.policy = policy_class.from_pretrained(policy_specs.pretrained_name_or_path)
         self.policy.to(self.device)
 
-        # Load preprocessor and postprocessor, overriding device to match requested device
-        device_override = {"device": self.device}
+        # The pipelines are rebuilt from this config, so pointing it at the requested device is
+        # enough. Note that the device is deliberately *not* forced onto the postprocessor: its only
+        # device step exists to bring actions back to CPU for the wire, and overriding that step (as
+        # this call used to) left actions on the GPU.
+        self.policy.config.device = str(self.device)
+        self.policy.config.rename_map = dict(policy_specs.rename_map or {})
         self.preprocessor, self.postprocessor = make_pre_post_processors(
             self.policy.config,
             pretrained_path=policy_specs.pretrained_name_or_path,
-            preprocessor_overrides={
-                "device_processor": device_override,
-                "rename_observations_processor": {"rename_map": policy_specs.rename_map},
-            },
-            postprocessor_overrides={"device_processor": device_override},
+            context=ProcessorBuildContext(),
         )
 
         end = time.perf_counter()

--- a/src/lerobot/configs/policies.py
+++ b/src/lerobot/configs/policies.py
@@ -59,6 +59,21 @@ class PreTrainedConfig(draccus.ChoiceRegistry, HubMixin, abc.ABC):  # type: igno
     input_features: dict[str, PolicyFeature] | None = field(default_factory=dict)
     output_features: dict[str, PolicyFeature] | None = field(default_factory=dict)
 
+    # Maps dataset/environment feature keys onto the names this policy expects (e.g. "left" ->
+    # "camera1"). Lives here rather than only on the CLI config so that a processor pipeline rebuilt
+    # from this config renames the same keys the pipeline saved in a checkpoint did.
+    rename_map: dict[str, str] = field(default_factory=dict)
+
+    # Relative actions: express actions relative to the current state. Policy-independent — composed
+    # into any policy's pipeline by `RelativeActionsFeature`, so these live on the base config rather
+    # than being re-declared per policy. They belong to the config (not to a per-run context) because
+    # training this way changes what the model learned, so eval must match.
+    use_relative_actions: bool = False
+    # Joint names to keep absolute. Empty list = every dimension is made relative.
+    relative_exclude_joints: list[str] = field(default_factory=lambda: ["gripper"])
+    # Populated at runtime from dataset metadata by `make_policy`.
+    action_feature_names: list[str] | None = None
+
     device: str | None = None  # e.g. "cuda", "cuda:0", "cpu", or "mps"
     # `use_amp` determines whether to use Automatic Mixed Precision (AMP) for training and evaluation. With AMP,
     # automatic gradient scaling is used.

--- a/src/lerobot/policies/evo1/processor_evo1.py
+++ b/src/lerobot/policies/evo1/processor_evo1.py
@@ -23,32 +23,26 @@ import torch
 from lerobot.configs import FeatureType, PipelineFeatureType, PolicyFeature
 from lerobot.lerobot_types import EnvTransition, TransitionKey
 from lerobot.processor import (
-    AddBatchDimensionProcessorStep,
     DeviceProcessorStep,
     NormalizerProcessorStep,
     ObservationProcessorStep,
     PolicyAction,
     PolicyActionProcessorStep,
     PolicyProcessorPipeline,
+    ProcessorBuildContext,
     ProcessorStep,
     ProcessorStepRegistry,
-    RenameObservationsProcessorStep,
     UnnormalizerProcessorStep,
+    make_default_policy_processor_steps,
+    make_policy_processor_pipelines,
 )
-from lerobot.processor.converters import (
-    batch_to_transition,
-    create_transition,
-    policy_action_to_transition,
-    transition_to_policy_action,
-)
+from lerobot.processor.converters import batch_to_transition, create_transition
 from lerobot.utils.constants import (
     ACTION,
     DONE,
     INFO,
     OBS_PREFIX,
     OBS_STATE,
-    POLICY_POSTPROCESSOR_DEFAULT_NAME,
-    POLICY_PREPROCESSOR_DEFAULT_NAME,
     REWARD,
     TRUNCATED,
 )
@@ -302,92 +296,28 @@ def _pad_evo1_stats(
     return padded_stats
 
 
-def _refresh_evo1_normalization_steps(
-    config: Evo1Config,
-    preprocessor: PolicyProcessorPipeline,
-    postprocessor: PolicyProcessorPipeline,
-) -> None:
-    """Re-pad checkpoint-loaded (un)normalizer stats/features to EVO1's fixed widths.
-
-    Loading a checkpoint injects the raw dataset stats (unpadded to max_state_dim/max_action_dim)
-    into the (un)normalizer via the generic override path in make_pre_post_processors. Those stats
-    and their declared features must be re-padded/reshaped to EVO1's fixed widths, otherwise
-    normalization fails against the padded state/action tensors (e.g. state padded to 24 vs. 8-dim
-    LIBERO stats). Padding is a no-op when stats are already at the target width.
-    """
-    normalization_features = _evo1_normalization_features(config)
-    action_features = _evo1_action_features(config)
-    for step in preprocessor.steps:
-        if isinstance(step, NormalizerProcessorStep):
-            step.features = normalization_features
-            step.stats = _pad_evo1_stats(config, step.stats)
-            step.to(device=step.device, dtype=step.dtype)
-    for step in postprocessor.steps:
-        if isinstance(step, UnnormalizerProcessorStep):
-            step.features = action_features
-            step.stats = _pad_evo1_stats(config, step.stats)
-            step.to(device=step.device, dtype=step.dtype)
-
-
-def reconcile_evo1_processors(
-    config: Evo1Config,
-    preprocessor: PolicyProcessorPipeline,
-    postprocessor: PolicyProcessorPipeline,
-) -> tuple[PolicyProcessorPipeline, PolicyProcessorPipeline]:
-    """Reconcile checkpoint-loaded pipelines with the current EVO1 config.
-
-    Three things cannot be restored from a serialized pipeline alone: the EVO1 batch converter
-    (converters are plain functions and are never serialized), eval-time CLI overrides of the
-    action postprocessing flags (`postprocess_action_dim`, `binarize_gripper`, `gripper_*`), and the
-    (un)normalizer stats/features when the generic override path injects raw, unpadded dataset
-    stats. This restores the converter, re-pads the normalization stats to EVO1's fixed widths, and
-    rebuilds the action step from the current config so those overrides take effect.
-    """
-    # Pipelines reloaded from a checkpoint come back with the default batch converter, which drops
-    # non-observation extras (embodiment_id, state_mask, custom task fields) needed by EVO1.
-    preprocessor.to_transition = evo1_batch_to_transition
-
-    _refresh_evo1_normalization_steps(config, preprocessor, postprocessor)
-
-    action_step = Evo1ActionProcessorStep(
-        action_dim=_evo1_action_dim(config),
-        binarize_gripper=config.binarize_gripper,
-        gripper_index=config.gripper_index,
-        gripper_threshold=config.gripper_threshold,
-        gripper_below_threshold_value=config.gripper_below_threshold_value,
-        gripper_above_threshold_value=config.gripper_above_threshold_value,
-    )
-    steps = list(postprocessor.steps)
-    action_step_idx = next(
-        (idx for idx, step in enumerate(steps) if isinstance(step, Evo1ActionProcessorStep)), None
-    )
-    if action_step_idx is None:
-        insert_idx = next(
-            (idx + 1 for idx, step in enumerate(steps) if isinstance(step, UnnormalizerProcessorStep)),
-            0,
-        )
-        steps.insert(insert_idx, action_step)
-    else:
-        steps[action_step_idx] = action_step
-    postprocessor.steps = steps
-
-    return preprocessor, postprocessor
-
-
 def make_evo1_pre_post_processors(
     config: Evo1Config,
-    dataset_stats: dict[str, dict[str, torch.Tensor]] | None = None,
+    context: ProcessorBuildContext,
 ) -> tuple[
     PolicyProcessorPipeline[dict[str, Any], dict[str, Any]],
     PolicyProcessorPipeline[PolicyAction, PolicyAction],
 ]:
+    """Build EVO1's pipelines.
+
+    EVO1 pads state and action to fixed widths (`max_state_dim`/`max_action_dim`) inside the
+    preprocessor, so its (un)normalizers must carry stats and declared features at those widths, not
+    the dataset's. Owning that here — rather than having dataset-width stats injected afterwards and
+    re-padded — is what makes the padding correct on every build, checkpoint or not (issue #4006).
+    """
+    steps = make_default_policy_processor_steps(config, context.dataset_stats)
     normalization_features = _evo1_normalization_features(config)
     action_features = _evo1_action_features(config)
-    normalization_stats = _pad_evo1_stats(config, dataset_stats)
+    normalization_stats = _pad_evo1_stats(config, context.dataset_stats)
 
     input_steps = [
-        RenameObservationsProcessorStep(rename_map={}),
-        AddBatchDimensionProcessorStep(),
+        steps.rename_observations,
+        steps.add_batch_dim,
         Evo1PadStateProcessorStep(max_state_dim=config.max_state_dim),
         Evo1PadActionProcessorStep(max_action_dim=config.max_action_dim),
         NormalizerProcessorStep(
@@ -415,16 +345,8 @@ def make_evo1_pre_post_processors(
         DeviceProcessorStep(device="cpu", float_dtype="float32"),
     ]
 
-    return (
-        PolicyProcessorPipeline[dict[str, Any], dict[str, Any]](
-            steps=input_steps,
-            name=POLICY_PREPROCESSOR_DEFAULT_NAME,
-            to_transition=evo1_batch_to_transition,
-        ),
-        PolicyProcessorPipeline[PolicyAction, PolicyAction](
-            steps=output_steps,
-            name=POLICY_POSTPROCESSOR_DEFAULT_NAME,
-            to_transition=policy_action_to_transition,
-            to_output=transition_to_policy_action,
-        ),
+    return make_policy_processor_pipelines(
+        input_steps=input_steps,
+        output_steps=output_steps,
+        preprocessor_to_transition=evo1_batch_to_transition,
     )

--- a/src/lerobot/policies/factory.py
+++ b/src/lerobot/policies/factory.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import importlib
 import inspect
 import logging
+from dataclasses import replace
 from typing import TYPE_CHECKING, Any, TypedDict, Unpack
 
 import torch
@@ -29,15 +30,9 @@ if TYPE_CHECKING:
 from lerobot.configs import FeatureType, PreTrainedConfig
 from lerobot.envs import EnvConfig, env_to_policy_features
 from lerobot.lerobot_types import PolicyAction
-from lerobot.processor import (
-    AbsoluteActionsProcessorStep,
-    PolicyProcessorPipeline,
-    RelativeActionsProcessorStep,
-    batch_to_transition,
-    policy_action_to_transition,
-    transition_to_batch,
-    transition_to_policy_action,
-)
+from lerobot.processor import PolicyProcessorPipeline
+from lerobot.processor.context import ProcessorBuildContext, apply_checkpoint_rename_map
+from lerobot.processor.features import apply_policy_features
 from lerobot.utils.constants import (
     ACTION,
     POLICY_POSTPROCESSOR_DEFAULT_NAME,
@@ -46,8 +41,6 @@ from lerobot.utils.constants import (
 from lerobot.utils.feature_utils import dataset_to_policy_features
 from lerobot.utils.import_utils import _peft_available, require_package
 
-from .evo1.configuration_evo1 import Evo1Config
-from .groot.configuration_groot import GrootConfig
 from .pretrained import PreTrainedPolicy
 from .utils import validate_visual_features_consistency
 
@@ -56,24 +49,6 @@ if TYPE_CHECKING or _peft_available:
 else:
     PeftConfig = None
     PeftModel = None
-
-
-def _reconnect_relative_absolute_steps(
-    preprocessor: PolicyProcessorPipeline, postprocessor: PolicyProcessorPipeline
-) -> None:
-    """Wire AbsoluteActionsProcessorStep.relative_step to the RelativeActionsProcessorStep after deserialization.
-
-    After a policy is loaded from disk, the preprocessor and postprocessor are reconstructed
-    independently from their configs. AbsoluteActionsProcessorStep needs a live reference to
-    the RelativeActionsProcessorStep so it can read the cached state at inference time.
-    That reference is not serializable, so we re-establish it here after loading.
-    """
-    relative_step = next((s for s in preprocessor.steps if isinstance(s, RelativeActionsProcessorStep)), None)
-    if relative_step is None:
-        return
-    for step in postprocessor.steps:
-        if isinstance(step, AbsoluteActionsProcessorStep) and step.relative_step is None:
-            step.relative_step = relative_step
 
 
 def get_policy_class(name: str) -> type[PreTrainedPolicy]:
@@ -132,13 +107,18 @@ class ProcessorConfigKwargs(TypedDict, total=False):
     improving code clarity and enabling static analysis.
 
     Attributes:
+        context: The preferred way to pass per-run build inputs. Supersedes `dataset_stats`,
+            `dataset_meta` and the two override dicts.
         preprocessor_config_filename: The filename for the preprocessor configuration.
         postprocessor_config_filename: The filename for the postprocessor configuration.
-        preprocessor_overrides: A dictionary of overrides for the preprocessor configuration.
-        postprocessor_overrides: A dictionary of overrides for the postprocessor configuration.
-        dataset_stats: Dataset statistics for normalization.
+        preprocessor_overrides: Deprecated. Step-level overrides; values the policy config now owns
+            (`device`, `rename_map`) are applied to it, the rest are ignored with a warning.
+        postprocessor_overrides: Deprecated. See `preprocessor_overrides`.
+        dataset_stats: Dataset statistics for normalization. Prefer `context.dataset_stats`.
+        dataset_meta: Dataset metadata. Prefer `context.dataset_meta`.
     """
 
+    context: ProcessorBuildContext | None
     preprocessor_config_filename: str | None
     postprocessor_config_filename: str | None
     preprocessor_overrides: dict[str, Any] | None
@@ -157,84 +137,132 @@ def make_pre_post_processors(
     PolicyProcessorPipeline[PolicyAction, PolicyAction],
 ]:
     """
-    Create or load pre- and post-processor pipelines for a given policy.
+    Create pre- and post-processor pipelines for a given policy.
 
-    This function acts as a factory. It can either load existing processor pipelines
-    from a pretrained path or create new ones from scratch based on the policy
-    configuration. Each policy type has a dedicated factory function for its
-    processors (e.g., `make_tdmpc_pre_post_processors`).
+    There is one construction path: the policy's own factory
+    (e.g. `make_tdmpc_pre_post_processors`, resolved by naming convention) builds the pipelines from
+    `policy_cfg`. When `pretrained_path` is given, the checkpoint contributes only its *tensor state*
+    — normalization statistics and the like — which is loaded into those freshly built steps.
+
+    That split is the authority rule for the whole processor system:
+
+    - **Structure and shape belong to the code.** A `--policy.*` flag reconfigures a step even when
+      the checkpoint predates it, and a policy whose pipeline reshapes tensors internally (EVO1
+      padding state to `max_state_dim`) keeps its own shape instead of having dataset-derived widths
+      forced onto it. Deserializing structure is what previously required per-policy reconciliation
+      after loading.
+    - **Statistics belong to whoever supplied them.** Passing `context.dataset_stats` makes the
+      dataset authoritative (the finetune case); omitting it keeps the checkpoint's saved stats (eval
+      and resume). `NormalizerProcessorStep` already implements exactly this precedence via
+      `_stats_explicitly_provided`.
+
+    To deserialize a saved pipeline wholesale instead — structure included — use
+    `PolicyProcessorPipeline.from_pretrained` directly.
 
     Args:
         policy_cfg: The configuration of the policy for which to create processors.
-        pretrained_path: An optional path to load pretrained processor pipelines from.
-            If provided, pipelines are loaded from this path.
+        pretrained_path: Optional checkpoint whose step state should be loaded into the pipelines.
+        pretrained_revision: Optional Hub revision for `pretrained_path`.
         **kwargs: Keyword arguments for processor configuration, as defined in
-            `ProcessorConfigKwargs`.
+            `ProcessorConfigKwargs`. Prefer passing `context=ProcessorBuildContext(...)`; the
+            `preprocessor_overrides`/`postprocessor_overrides` dicts are deprecated.
 
     Returns:
         A tuple containing the input (pre-processor) and output (post-processor) pipelines.
 
     Raises:
-        ValueError: If no processor factory exists for the given policy configuration type.
+        ValueError: If no processor factory exists for the given policy configuration type, or if the
+            checkpoint carries state for a step the policy config does not build.
     """
-    if pretrained_path:
-        if isinstance(policy_cfg, GrootConfig):
-            from .groot.processor_groot import make_groot_pre_post_processors_from_pretrained
-
-            return make_groot_pre_post_processors_from_pretrained(
-                config=policy_cfg,
-                pretrained_path=pretrained_path,
-                revision=pretrained_revision,
-                dataset_stats=kwargs.get("dataset_stats"),
-                dataset_meta=kwargs.get("dataset_meta"),
-                preprocessor_overrides=kwargs.get("preprocessor_overrides"),
-                postprocessor_overrides=kwargs.get("postprocessor_overrides"),
-                preprocessor_config_filename=kwargs.get(
-                    "preprocessor_config_filename", f"{POLICY_PREPROCESSOR_DEFAULT_NAME}.json"
-                ),
-                postprocessor_config_filename=kwargs.get(
-                    "postprocessor_config_filename", f"{POLICY_POSTPROCESSOR_DEFAULT_NAME}.json"
-                ),
-            )
-
-        preprocessor = PolicyProcessorPipeline.from_pretrained(
-            pretrained_model_name_or_path=pretrained_path,
-            config_filename=kwargs.get(
-                "preprocessor_config_filename", f"{POLICY_PREPROCESSOR_DEFAULT_NAME}.json"
-            ),
-            overrides=kwargs.get("preprocessor_overrides", {}),
-            to_transition=batch_to_transition,
-            to_output=transition_to_batch,
-            revision=pretrained_revision,
-        )
-        postprocessor = PolicyProcessorPipeline.from_pretrained(
-            pretrained_model_name_or_path=pretrained_path,
-            config_filename=kwargs.get(
-                "postprocessor_config_filename", f"{POLICY_POSTPROCESSOR_DEFAULT_NAME}.json"
-            ),
-            overrides=kwargs.get("postprocessor_overrides", {}),
-            to_transition=policy_action_to_transition,
-            to_output=transition_to_policy_action,
-            revision=pretrained_revision,
-        )
-        _reconnect_relative_absolute_steps(preprocessor, postprocessor)
-        if isinstance(policy_cfg, Evo1Config):
-            from .evo1.processor_evo1 import reconcile_evo1_processors
-
-            preprocessor, postprocessor = reconcile_evo1_processors(
-                policy_cfg,
-                preprocessor,
-                postprocessor,
-            )
-        return preprocessor, postprocessor
-
-    # Create new processors from the policy config, resolving the per-policy factory
-    # function by naming convention (lazy import keeps optional dependencies optional).
-    return _make_processors_from_policy_config(
-        config=policy_cfg,
-        dataset_stats=kwargs.get("dataset_stats"),
-        dataset_meta=kwargs.get("dataset_meta"),
+    context = kwargs.get("context")
+    if context is None:
+        context = ProcessorBuildContext.from_legacy_kwargs(dict(kwargs), policy_cfg)
+    pre_filename = kwargs.get("preprocessor_config_filename") or f"{POLICY_PREPROCESSOR_DEFAULT_NAME}.json"
+    post_filename = kwargs.get("postprocessor_config_filename") or f"{POLICY_POSTPROCESSOR_DEFAULT_NAME}.json"
+    context = replace(
+        context,
+        pretrained_path=str(pretrained_path) if pretrained_path else None,
+        pretrained_revision=pretrained_revision,
     )
+
+    if pretrained_path and _uses_legacy_pretrained_loader(policy_cfg):
+        # GR00T has not been migrated to the rule above and still deserializes its saved pipelines,
+        # then repairs them. See `_uses_legacy_pretrained_loader`.
+        from .groot.processor_groot import make_groot_pre_post_processors_from_pretrained
+
+        return make_groot_pre_post_processors_from_pretrained(
+            config=policy_cfg,
+            pretrained_path=pretrained_path,
+            revision=pretrained_revision,
+            dataset_stats=context.dataset_stats,
+            dataset_meta=context.dataset_meta,
+            preprocessor_overrides=kwargs.get("preprocessor_overrides"),
+            postprocessor_overrides=kwargs.get("postprocessor_overrides"),
+            preprocessor_config_filename=pre_filename,
+            postprocessor_config_filename=post_filename,
+        )
+
+    if pretrained_path:
+        # Read the saved preprocessor before building, only to recover a rename map the caller did
+        # not supply. Everything else about the pipeline comes from the config.
+        apply_checkpoint_rename_map(
+            policy_cfg, _peek_pipeline_config(pretrained_path, pre_filename, pretrained_revision)
+        )
+
+    preprocessor, postprocessor = _make_processors_from_policy_config(
+        config=policy_cfg,
+        context=context,
+    )
+
+    if pretrained_path:
+        # Structure and shape came from the config above; only tensors come from the checkpoint.
+        preprocessor.load_pretrained_state(pretrained_path, pre_filename, revision=pretrained_revision)
+        postprocessor.load_pretrained_state(pretrained_path, post_filename, revision=pretrained_revision)
+
+    return preprocessor, postprocessor
+
+
+def _uses_legacy_pretrained_loader(policy_cfg: PreTrainedConfig) -> bool:
+    """Whether this policy still deserializes its saved pipelines instead of rebuilding them.
+
+    Only GR00T does. Rebuilding its pipelines from the config is not yet possible: two of its steps
+    are stateful, and for checkpoints converted from a raw N1.7 release the values those steps need
+    (``raw_stats``, ``modality_config``, ``video_modality_keys``) exist *only* inside the serialized
+    pipeline JSON — there is no sidecar and no config field to rebuild them from. Migrating GR00T
+    therefore means teaching its config to carry those values plus a reader for checkpoints that
+    predate them, and that cannot be validated without the gated backbone its tests download.
+
+    Resolved by attribute rather than by importing `GrootConfig`, so the check stays lazy and this
+    module keeps its no-eager-policy-imports property.
+    """
+    return policy_cfg.type == "groot"
+
+
+def _peek_pipeline_config(
+    pretrained_path: str, config_filename: str, revision: str | None
+) -> dict[str, Any] | None:
+    """Load a checkpoint's serialized pipeline config, or None if it cannot be read.
+
+    Best-effort by design: this only feeds the rename-map carry-over, and a checkpoint without a
+    readable processor config is handled with a proper error by `load_pretrained_state` later.
+    """
+    try:
+        loaded_config, _ = PolicyProcessorPipeline._load_config(
+            str(pretrained_path),
+            config_filename,
+            {
+                "force_download": False,
+                "resume_download": None,
+                "proxies": None,
+                "token": None,
+                "cache_dir": None,
+                "local_files_only": False,
+                "revision": revision,
+            },
+        )
+        return loaded_config
+    except Exception:  # noqa: BLE001 - advisory read; the authoritative error comes from loading state
+        return None
 
 
 def make_policy(
@@ -309,13 +337,16 @@ def make_policy(
 
     if rename_map:
         features = {rename_map.get(key, key): feature for key, feature in features.items()}
+        # Record it on the config so a processor pipeline built from this config later renames the
+        # same keys, without the caller having to pass the map a second time.
+        cfg.rename_map = dict(rename_map)
 
     cfg.output_features = {key: ft for key, ft in features.items() if ft.type is FeatureType.ACTION}
     if not cfg.input_features:
         cfg.input_features = {key: ft for key, ft in features.items() if key not in cfg.output_features}
 
     # Store action feature names for relative_exclude_joints support
-    if ds_meta is not None and hasattr(cfg, "action_feature_names"):
+    if ds_meta is not None:
         raw_action_feature = next(
             (
                 feature
@@ -461,19 +492,25 @@ def _get_policy_cls_from_policy_name(name: str) -> type[PreTrainedPolicy]:
 
 def _make_processors_from_policy_config(
     config: PreTrainedConfig,
-    dataset_stats: dict[str, dict[str, torch.Tensor]] | None = None,
-    dataset_meta: Any | None = None,
+    context: ProcessorBuildContext,
 ) -> tuple[Any, Any]:
     """Create pre- and post-processors from a policy configuration using dynamic imports.
 
     Resolves ``make_{type}_pre_post_processors`` from the policy's ``processor_*`` module
     by naming convention. Works for built-in policies and 3rd party lerobot plugins.
 
+    Two factory signatures are supported, distinguished by parameter name:
+
+    - ``(config, context)`` — the current contract.
+    - ``(config, dataset_stats=None[, dataset_meta=None])`` — the older one, still used by most
+      policies. Those values are unpacked from the context, so such factories need no edit. Anything
+      else a context carries (``training``, ``pretrained_path``) is unavailable to them, which is
+      fine: nothing that ignores it needs it.
+
     Args:
         config: The policy configuration object.
-        dataset_stats: Dataset statistics for normalization.
-        dataset_meta: Dataset metadata, forwarded only to factories that declare a
-            ``dataset_meta`` parameter (e.g. groot, molmoact2).
+        context: Per-run build inputs.
+
     Returns:
         A tuple containing the input (pre-processor) and output (post-processor) pipelines.
     """
@@ -498,7 +535,14 @@ def _make_processors_from_policy_config(
     function = getattr(module, function_name, None)
     if function is None:
         raise ValueError(f"Processor for policy type '{policy_type}' is not implemented.")
-    call_kwargs: dict[str, Any] = {"dataset_stats": dataset_stats}
-    if "dataset_meta" in inspect.signature(function).parameters:
-        call_kwargs["dataset_meta"] = dataset_meta
-    return function(config, **call_kwargs)
+    parameters = inspect.signature(function).parameters
+    if "context" in parameters:
+        preprocessor, postprocessor = function(config, context=context)
+    else:
+        call_kwargs: dict[str, Any] = {"dataset_stats": context.dataset_stats}
+        if "dataset_meta" in parameters:
+            call_kwargs["dataset_meta"] = context.dataset_meta
+        preprocessor, postprocessor = function(config, **call_kwargs)
+
+    apply_policy_features(config, context, preprocessor, postprocessor)
+    return preprocessor, postprocessor

--- a/src/lerobot/policies/pi0/configuration_pi0.py
+++ b/src/lerobot/policies/pi0/configuration_pi0.py
@@ -49,13 +49,6 @@ class PI0Config(PreTrainedConfig):
     min_period: float = 4e-3
     max_period: float = 4.0
 
-    # Relative actions: converts absolute actions to relative (relative to state).
-    use_relative_actions: bool = False
-    # Joint names to exclude from relative (kept absolute). Empty list = all dims relative.
-    relative_exclude_joints: list[str] = field(default_factory=lambda: ["gripper"])
-    # Populated at runtime from dataset metadata by make_policy.
-    action_feature_names: list[str] | None = None
-
     # Real-Time Chunking (RTC) configuration
     rtc_config: RTCConfig | None = None
 

--- a/src/lerobot/policies/pi0/processor_pi0.py
+++ b/src/lerobot/policies/pi0/processor_pi0.py
@@ -20,13 +20,11 @@ import torch
 
 from lerobot.configs import PipelineFeatureType, PolicyFeature
 from lerobot.processor import (
-    AbsoluteActionsProcessorStep,
     ComplementaryDataProcessorStep,
     PolicyAction,
     PolicyProcessorPipeline,
     ProcessorStep,
     ProcessorStepRegistry,
-    RelativeActionsProcessorStep,
     TokenizerProcessorStep,
     make_default_policy_processor_steps,
     make_policy_processor_pipelines,
@@ -124,15 +122,12 @@ def make_pi0_pre_post_processors(
         A tuple containing the configured pre-processor and post-processor pipelines.
     """
 
-    relative_step = RelativeActionsProcessorStep(
-        enabled=config.use_relative_actions,
-        exclude_joints=getattr(config, "relative_exclude_joints", []),
-        action_names=getattr(config, "action_feature_names", None),
-    )
-
     steps = make_default_policy_processor_steps(config, dataset_stats)
 
-    # OpenPI order: raw → relative → normalize → model → unnormalize → absolute
+    # OpenPI order: raw → [relative] → normalize → model → unnormalize → [absolute].
+    # The bracketed steps are composed in by `RelativeActionsFeature` when
+    # `config.use_relative_actions` is set; they are anchored around the (un)normalizer, so the
+    # relative conversion sees raw values.
     input_steps: list[ProcessorStep] = [
         steps.rename_observations,  # To mimic the same processor as pretrained one
         steps.add_batch_dim,
@@ -144,13 +139,11 @@ def make_pi0_pre_post_processors(
             padding="max_length",
         ),
         steps.to_device,
-        relative_step,
         steps.normalize,
     ]
 
     output_steps: list[ProcessorStep] = [
         steps.unnormalize,
-        AbsoluteActionsProcessorStep(enabled=config.use_relative_actions, relative_step=relative_step),
         steps.to_cpu,
     ]
 

--- a/src/lerobot/policies/pi05/configuration_pi05.py
+++ b/src/lerobot/policies/pi05/configuration_pi05.py
@@ -64,13 +64,6 @@ class PI05Config(PreTrainedConfig):
     min_period: float = 4e-3
     max_period: float = 4.0
 
-    # Relative actions: converts absolute actions to relative (relative to state).
-    use_relative_actions: bool = False
-    # Joint names to exclude from relative (kept absolute). Empty list = all dims relative.
-    relative_exclude_joints: list[str] = field(default_factory=lambda: ["gripper"])
-    # Populated at runtime from dataset metadata by make_policy.
-    action_feature_names: list[str] | None = None
-
     # Real-Time Chunking (RTC) configuration
     rtc_config: RTCConfig | None = None
 

--- a/src/lerobot/policies/pi05/processor_pi05.py
+++ b/src/lerobot/policies/pi05/processor_pi05.py
@@ -24,12 +24,10 @@ import torch
 from lerobot.configs import PipelineFeatureType, PolicyFeature
 from lerobot.lerobot_types import EnvTransition, TransitionKey
 from lerobot.processor import (
-    AbsoluteActionsProcessorStep,
     PolicyAction,
     PolicyProcessorPipeline,
     ProcessorStep,
     ProcessorStepRegistry,
-    RelativeActionsProcessorStep,
     TokenizerProcessorStep,
     make_default_policy_processor_steps,
     make_policy_processor_pipelines,
@@ -130,19 +128,15 @@ def make_pi05_pre_post_processors(
         A tuple containing the configured pre-processor and post-processor pipelines.
     """
 
-    relative_step = RelativeActionsProcessorStep(
-        enabled=config.use_relative_actions,
-        exclude_joints=getattr(config, "relative_exclude_joints", []),
-        action_names=getattr(config, "action_feature_names", None),
-    )
-
     steps = make_default_policy_processor_steps(config, dataset_stats)
 
-    # OpenPI order: raw → relative → normalize → model → unnormalize → absolute
+    # OpenPI order: raw → [relative] → normalize → model → unnormalize → [absolute].
+    # The bracketed steps are composed in by `RelativeActionsFeature` when
+    # `config.use_relative_actions` is set; they are anchored around the (un)normalizer, so the
+    # relative conversion sees raw values.
     input_steps: list[ProcessorStep] = [
         steps.rename_observations,  # To mimic the same processor as pretrained one
         steps.add_batch_dim,
-        relative_step,
         # NOTE: NormalizerProcessorStep MUST come before Pi05PrepareStateTokenizerProcessorStep
         # because the tokenizer step expects normalized state in [-1, 1] range for discretization
         steps.normalize,
@@ -161,7 +155,6 @@ def make_pi05_pre_post_processors(
 
     output_steps: list[ProcessorStep] = [
         steps.unnormalize,
-        AbsoluteActionsProcessorStep(enabled=config.use_relative_actions, relative_step=relative_step),
         steps.to_cpu,
     ]
 

--- a/src/lerobot/policies/pi0_fast/configuration_pi0_fast.py
+++ b/src/lerobot/policies/pi0_fast/configuration_pi0_fast.py
@@ -40,13 +40,6 @@ class PI0FastConfig(PreTrainedConfig):
     max_action_dim: int = 32
     max_action_tokens: int = 256
 
-    # Relative actions: converts absolute actions to relative (relative to state).
-    use_relative_actions: bool = False
-    # Joint names to exclude from relative (kept absolute). Empty list = all dims relative.
-    relative_exclude_joints: list[str] = field(default_factory=lambda: ["gripper"])
-    # Populated at runtime from dataset metadata by make_policy.
-    action_feature_names: list[str] | None = None
-
     # Real-Time Chunking (RTC) configuration
     rtc_config: RTCConfig | None = None
 

--- a/src/lerobot/policies/pi0_fast/processor_pi0_fast.py
+++ b/src/lerobot/policies/pi0_fast/processor_pi0_fast.py
@@ -24,13 +24,11 @@ import torch
 from lerobot.configs import PipelineFeatureType, PolicyFeature
 from lerobot.lerobot_types import EnvTransition, TransitionKey
 from lerobot.processor import (
-    AbsoluteActionsProcessorStep,
     ActionTokenizerProcessorStep,
     PolicyAction,
     PolicyProcessorPipeline,
     ProcessorStep,
     ProcessorStepRegistry,
-    RelativeActionsProcessorStep,
     TokenizerProcessorStep,
     make_default_policy_processor_steps,
     make_policy_processor_pipelines,
@@ -120,26 +118,18 @@ def make_pi0_fast_pre_post_processors(
     Returns:
         A tuple containing the configured pre-processor and post-processor pipelines.
     """
-    relative_step = RelativeActionsProcessorStep(
-        enabled=config.use_relative_actions,
-        exclude_joints=getattr(config, "relative_exclude_joints", []),
-        action_names=getattr(config, "action_feature_names", None),
-    )
-
     steps = make_default_policy_processor_steps(config, dataset_stats)
 
-    # Pi0Fast order: relative → normalize → tokenize → model → unnormalize → absolute
-    # This matches pi0/pi0.5: RelativeActionsProcessorStep runs first on raw absolute actions,
-    # caching the raw state. NormalizerProcessorStep then normalizes the raw relative actions,
-    # so the normalizer (and action tokenizer) sees delta values — relative stats are required.
-    # NOTE: RelativeActionsProcessorStep only modifies the action in the transition; it reads
-    # state from the observation but does not change it. NormalizerProcessorStep still runs
-    # before Pi0FastPrepareStateAndLanguageTokenizerProcessorStep, so the state tokenizer
-    # continues to receive normalized state in [-1, 1] as expected.
+    # Pi0Fast order: [relative] → normalize → tokenize → model → unnormalize → [absolute].
+    # The bracketed steps are composed in by `RelativeActionsFeature` when
+    # `config.use_relative_actions` is set, anchored around the (un)normalizer. So the relative
+    # conversion sees raw absolute actions and the normalizer (and action tokenizer) sees delta
+    # values — relative stats are required. The relative step only rewrites the action, leaving
+    # the observation's state untouched, so the state tokenizer below still receives normalized
+    # state in [-1, 1] as expected.
     input_steps: list[ProcessorStep] = [
         steps.rename_observations,  # To mimic the same processor as pretrained one
         steps.add_batch_dim,
-        relative_step,
         steps.normalize,
         Pi0FastPrepareStateAndLanguageTokenizerProcessorStep(max_state_dim=config.max_state_dim),
         TokenizerProcessorStep(
@@ -159,7 +149,6 @@ def make_pi0_fast_pre_post_processors(
 
     output_steps: list[ProcessorStep] = [
         steps.unnormalize,
-        AbsoluteActionsProcessorStep(enabled=config.use_relative_actions, relative_step=relative_step),
         steps.to_cpu,
     ]
 

--- a/src/lerobot/policies/pretrained.py
+++ b/src/lerobot/policies/pretrained.py
@@ -245,6 +245,23 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
             elif queue is not None:
                 queue.clear()
 
+    def queued_action_count(self) -> int:
+        """Number of actions already computed and waiting to be served.
+
+        0 for a policy that keeps no action queue (never chunks) or whose queue is
+        currently empty (about to compute a fresh chunk). Reads the same queues
+        :meth:`drop_queued_actions` clears, named in :attr:`_action_queue_attrs`.
+        """
+        total = 0
+        for attr in self._action_queue_attrs:
+            queue = getattr(self, attr, None)
+            if isinstance(queue, dict):
+                action_queue = queue.get(ACTION)
+                total += len(action_queue) if action_queue is not None else 0
+            elif queue is not None:
+                total += len(queue)
+        return total
+
     def supports_rtc(self) -> bool:
         """Whether this policy implements Real-Time Chunking inference semantics."""
         return False

--- a/src/lerobot/processor/__init__.py
+++ b/src/lerobot/processor/__init__.py
@@ -24,6 +24,7 @@ from lerobot.lerobot_types import (
 )
 
 from .batch_processor import AddBatchDimensionProcessorStep
+from .context import ProcessorBuildContext, apply_checkpoint_rename_map
 from .converters import (
     batch_to_transition,
     create_transition,
@@ -50,6 +51,14 @@ from .factory import (
     make_default_robot_observation_processor,
     make_default_teleop_action_processor,
     make_policy_processor_pipelines,
+)
+from .features import (
+    DEFAULT_POLICY_FEATURES,
+    AnchoredStep,
+    ProcessorFeature,
+    RelativeActionsFeature,
+    apply_policy_features,
+    splice_anchored_steps,
 )
 from .gym_action_processor import (
     Numpy2TorchActionProcessorStep,
@@ -108,6 +117,14 @@ from .tokenizer_processor import ActionTokenizerProcessorStep, TokenizerProcesso
 
 __all__ = [
     "ActionProcessorStep",
+    "apply_checkpoint_rename_map",
+    "ProcessorBuildContext",
+    "AnchoredStep",
+    "ProcessorFeature",
+    "RelativeActionsFeature",
+    "DEFAULT_POLICY_FEATURES",
+    "apply_policy_features",
+    "splice_anchored_steps",
     "AddTeleopActionAsComplimentaryDataStep",
     "AddTeleopEventsAsInfoStep",
     "ComplementaryDataProcessorStep",

--- a/src/lerobot/processor/context.py
+++ b/src/lerobot/processor/context.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Build-time inputs for policy processor factories."""
+
+from __future__ import annotations
+
+import logging
+import warnings
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import torch
+
+if TYPE_CHECKING:
+    from lerobot.configs.policies import PreTrainedConfig
+    from lerobot.datasets import LeRobotDatasetMetadata
+
+# Legacy step-override keys whose value now lives on the policy config, and the config field each
+# one sets. These reach every policy's factory because every factory already receives the config.
+_CONFIG_OWNED_OVERRIDES: dict[tuple[str, str], str] = {
+    ("device_processor", "device"): "device",
+    ("rename_observations_processor", "rename_map"): "rename_map",
+}
+
+
+@dataclass(frozen=True, kw_only=True)
+class ProcessorBuildContext:
+    """Per-run inputs a policy's processor factory needs that its config does not carry.
+
+    This deliberately does **not** include `features`, `norm_map`, or anything else describing the
+    *shape* of the pipeline: those belong to the policy's factory, the only thing that knows whether a
+    policy reshapes tensors internally (EVO1 padding state to `max_state_dim`, for instance).
+    Force-feeding dataset-derived shapes past a factory that pads is what made issue #4006 possible.
+
+    Values that every policy's factory must see, like the device and the rename map, live on
+    `PreTrainedConfig` instead — a factory already receives the config, so putting them there reaches
+    all policies without changing 14 factory signatures.
+
+    Frozen on purpose: a mistyped field is a `TypeError` at the call site, replacing the load-time
+    `KeyError` that the step-override dicts used to raise.
+
+    Attributes:
+        dataset_stats: Statistics to normalize against. Supplying them makes the *dataset*
+            authoritative over the checkpoint's saved stats; leaving them `None` keeps the
+            checkpoint's. That is the whole finetune-vs-eval distinction — see
+            `NormalizerProcessorStep._stats_explicitly_provided`.
+        dataset_meta: Dataset metadata, for factories that derive steps from it.
+        training: Whether the pipeline is being built for training. Explicit, rather than inferred
+            from `dataset_meta is not None`.
+        pretrained_path: Checkpoint the pipeline's state will be loaded from, if any.
+        pretrained_revision: Hub revision of `pretrained_path`.
+    """
+
+    dataset_stats: dict[str, dict[str, torch.Tensor]] | None = None
+    dataset_meta: LeRobotDatasetMetadata | None = None
+    training: bool = False
+    pretrained_path: str | None = None
+    pretrained_revision: str | None = None
+
+    @classmethod
+    def from_legacy_kwargs(
+        cls, kwargs: dict[str, Any], policy_cfg: PreTrainedConfig
+    ) -> ProcessorBuildContext:
+        """Build a context from the older `ProcessorConfigKwargs` shape, applying config-owned values.
+
+        Kept so out-of-tree callers passing `preprocessor_overrides`/`postprocessor_overrides` keep
+        working. Keys whose value now lives on the config are written to `policy_cfg`; keys describing
+        pipeline shape are reported once and ignored, because the policy factory now decides them.
+        """
+        overrides: dict[str, Any] = {}
+        for key in ("preprocessor_overrides", "postprocessor_overrides"):
+            overrides.update(kwargs.get(key) or {})
+
+        ignored: list[str] = []
+        for step_key, step_overrides in overrides.items():
+            for param, value in (step_overrides or {}).items():
+                config_field = _CONFIG_OWNED_OVERRIDES.get((step_key, param))
+                if config_field is not None:
+                    setattr(policy_cfg, config_field, value)
+                else:
+                    ignored.append(f"{step_key}.{param}")
+
+        dataset_stats = kwargs.get("dataset_stats")
+        if dataset_stats is None:
+            # A caller that passed stats only as a step override still means "normalize against
+            # these", so honour it rather than silently dropping normalization.
+            stats_override = (overrides.get("normalizer_processor") or {}).get("stats")
+            if stats_override is not None:
+                dataset_stats = stats_override
+                ignored = [key for key in ignored if key != "normalizer_processor.stats"]
+
+        if ignored:
+            warnings.warn(
+                "Step-level processor overrides are deprecated and were ignored: "
+                f"{sorted(ignored)}. Pipeline structure and shape now come from the policy config "
+                "and its processor factory; pass per-run values via ProcessorBuildContext.",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+
+        return cls(
+            dataset_stats=dataset_stats,
+            dataset_meta=kwargs.get("dataset_meta"),
+        )
+
+
+def apply_checkpoint_rename_map(
+    policy_cfg: PreTrainedConfig, preprocessor_config: dict[str, Any] | None
+) -> None:
+    """Fill an unset `policy_cfg.rename_map` from a checkpoint's serialized preprocessor.
+
+    A rename map is a dataset-to-policy key binding that exists nowhere but the CLI, so before this
+    refactor an eval run that passed none silently inherited the one baked into the saved pipeline.
+    Rebuilding from the config would drop it, so it is carried over here — and only here. Everything
+    else about the pipeline is rebuilt from the config on purpose.
+    """
+    if getattr(policy_cfg, "rename_map", None) or not preprocessor_config:
+        return
+
+    for step_entry in preprocessor_config.get("steps", []):
+        if step_entry.get("registry_name") != "rename_observations_processor":
+            continue
+        rename_map = (step_entry.get("config") or {}).get("rename_map")
+        if rename_map:
+            logging.info("Using the rename map recorded in the checkpoint's preprocessor: %s", rename_map)
+            policy_cfg.rename_map = dict(rename_map)
+        return

--- a/src/lerobot/processor/factory.py
+++ b/src/lerobot/processor/factory.py
@@ -14,13 +14,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
 import torch
 
 from lerobot.configs.policies import PreTrainedConfig
-from lerobot.lerobot_types import PolicyAction, RobotAction, RobotObservation
+from lerobot.lerobot_types import EnvTransition, PolicyAction, RobotAction, RobotObservation
 from lerobot.utils.constants import POLICY_POSTPROCESSOR_DEFAULT_NAME, POLICY_PREPROCESSOR_DEFAULT_NAME
 
 from .batch_processor import AddBatchDimensionProcessorStep
@@ -106,14 +107,14 @@ def make_default_policy_processor_steps(
     """Construct the canonical policy processor steps from a policy config.
 
     Args:
-        config: A `PreTrainedConfig` providing `device`, `input_features`,
+        config: A `PreTrainedConfig` providing `device`, `rename_map`, `input_features`,
             `output_features` and `normalization_mapping`.
         dataset_stats: Dataset statistics used for (un)normalization.
         normalizer_device: Device passed to `NormalizerProcessorStep` (some policies pin
             their normalization stats to the policy device; most leave it unset).
     """
     return DefaultPolicyProcessorSteps(
-        rename_observations=RenameObservationsProcessorStep(rename_map={}),
+        rename_observations=RenameObservationsProcessorStep(rename_map=dict(config.rename_map)),
         add_batch_dim=AddBatchDimensionProcessorStep(),
         to_device=DeviceProcessorStep(device=config.device),
         normalize=NormalizerProcessorStep(
@@ -132,6 +133,8 @@ def make_default_policy_processor_steps(
 def make_policy_processor_pipelines(
     input_steps: list[ProcessorStep],
     output_steps: list[ProcessorStep],
+    *,
+    preprocessor_to_transition: Callable[[dict[str, Any]], EnvTransition] | None = None,
 ) -> tuple[
     PolicyProcessorPipeline[dict[str, Any], dict[str, Any]],
     PolicyProcessorPipeline[PolicyAction, PolicyAction],
@@ -140,11 +143,24 @@ def make_policy_processor_pipelines(
 
     Uses the standard pipeline names (which determine the serialized JSON filenames on
     the Hub) and the standard policy-action converters on the postprocessor.
+
+    Args:
+        input_steps: The preprocessor's steps, in order.
+        output_steps: The postprocessor's steps, in order.
+        preprocessor_to_transition: Converter from a batch to an `EnvTransition`, for policies whose
+            batches carry keys the default converter drops (EVO1's `embodiment_id`/`state_mask`).
+            Converters are plain functions and are never serialized, so a policy that needs a custom
+            one must set it here on every build rather than expecting a checkpoint to restore it.
     """
     return (
         PolicyProcessorPipeline[dict[str, Any], dict[str, Any]](
             steps=input_steps,
             name=POLICY_PREPROCESSOR_DEFAULT_NAME,
+            **(
+                {"to_transition": preprocessor_to_transition}
+                if preprocessor_to_transition is not None
+                else {}
+            ),
         ),
         PolicyProcessorPipeline[PolicyAction, PolicyAction](
             steps=output_steps,

--- a/src/lerobot/processor/features.py
+++ b/src/lerobot/processor/features.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Cross-cutting pipeline features: steps that belong to no particular policy.
+
+Some processing is orthogonal to the model. Converting actions to be relative to the current state
+needs nothing but `observation.state` and `action`, so it should work with ACT without ACT knowing
+what a relative action is. Before this existed, each policy that wanted the behaviour hand-placed the
+steps and re-declared the config flags, which is why the same five-line block appeared in four
+policies.
+
+A feature declares what it builds and where the steps attach; `apply_policy_features` composes them
+into whatever pipeline the policy's factory produced, which is why this reaches every policy —
+including third-party plugins — without any of them referring to the feature.
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, ClassVar, Literal
+
+from .pipeline import ProcessorStep
+from .relative_action_processor import AbsoluteActionsProcessorStep, RelativeActionsProcessorStep
+
+if TYPE_CHECKING:
+    from lerobot.configs.policies import PreTrainedConfig
+
+    from .context import ProcessorBuildContext
+
+
+@dataclass(frozen=True)
+class AnchoredStep:
+    """A step plus where it attaches, expressed relative to another step's class.
+
+    Anchoring by class rather than by index keeps a feature working across policies that order their
+    pipelines differently. Resolution requires *exactly one* match: a feature that cannot be placed
+    unambiguously is an error, never a silent fallback to position 0.
+    """
+
+    step: ProcessorStep
+    anchor: type[ProcessorStep]
+    position: Literal["before", "after"]
+
+
+class ProcessorFeature(ABC):
+    """A policy-independent addition to a policy's pre/post-processor pipelines.
+
+    Subclasses declare `owner`, which says where their parameters come from — and, by extension,
+    whether they persist with the checkpoint:
+
+    - ``"config"`` — training-semantic. The parameters live on `PreTrainedConfig` and are saved in
+      ``config.json``, because training with the feature changes what the model learned, so eval
+      **must** match. Relative actions are this kind.
+    - ``"context"`` — deployment or embodiment. The parameters come from `ProcessorBuildContext` and
+      are deliberately not persisted, because the same checkpoint runs on different hardware. The
+      end-effector kinematics steps in ``lerobot.robots.so_follower.robot_kinematic_processor`` are
+      this kind; they are not wired up as a feature yet (they carry a live solver object and no
+      ``get_config``), but the distinction is what they will need.
+    """
+
+    name: ClassVar[str]
+    owner: ClassVar[Literal["config", "context"]]
+
+    @abstractmethod
+    def enabled_for(self, config: PreTrainedConfig, context: ProcessorBuildContext) -> bool:
+        """Whether this feature should be composed into the pipelines at all."""
+
+    @abstractmethod
+    def build(
+        self, config: PreTrainedConfig, context: ProcessorBuildContext
+    ) -> tuple[list[AnchoredStep], list[AnchoredStep]]:
+        """Return the (preprocessor, postprocessor) steps to splice in, with their anchors."""
+
+
+class RelativeActionsFeature(ProcessorFeature):
+    """Express actions relative to the current state, for any policy.
+
+    The pair is built together so `AbsoluteActionsProcessorStep` gets a live reference to the
+    preprocessor's step. That reference is not serializable, which used to require re-linking the two
+    after every checkpoint load; building both here means there is nothing to re-link.
+    """
+
+    name = "relative_actions"
+    owner = "config"
+
+    def enabled_for(self, config: PreTrainedConfig, context: ProcessorBuildContext) -> bool:
+        return bool(config.use_relative_actions)
+
+    def build(
+        self, config: PreTrainedConfig, context: ProcessorBuildContext
+    ) -> tuple[list[AnchoredStep], list[AnchoredStep]]:
+        # Imported here: these live in the same package, and importing at module scope would make
+        # `processor.factory` -> `processor.features` -> `processor.normalize_processor` a cycle.
+        from .normalize_processor import NormalizerProcessorStep, UnnormalizerProcessorStep
+
+        relative_step = RelativeActionsProcessorStep(
+            enabled=True,
+            exclude_joints=list(config.relative_exclude_joints or []),
+            action_names=config.action_feature_names,
+        )
+        absolute_step = AbsoluteActionsProcessorStep(enabled=True, relative_step=relative_step)
+        return (
+            # Relative offsets must be computed on raw values, so this goes before normalization.
+            [AnchoredStep(relative_step, NormalizerProcessorStep, "before")],
+            # ...and reversed after unnormalization, back in the same raw units.
+            [AnchoredStep(absolute_step, UnnormalizerProcessorStep, "after")],
+        )
+
+
+#: Features every policy gets when its config enables them. A policy that places these steps itself
+#: is detected and left alone (see `apply_policy_features`).
+DEFAULT_POLICY_FEATURES: tuple[ProcessorFeature, ...] = (RelativeActionsFeature(),)
+
+
+def apply_policy_features(
+    config: PreTrainedConfig,
+    context: ProcessorBuildContext,
+    preprocessor,
+    postprocessor,
+    features: Sequence[ProcessorFeature] | None = None,
+) -> None:
+    """Compose the enabled cross-cutting features into a freshly built pipeline pair, in place.
+
+    Called by the policy processor dispatcher right after a policy's factory returns, so features
+    reach every policy — including third-party plugins and the few policies that assemble their
+    pipelines without the shared builders — without any of them mentioning the feature.
+
+    A feature is skipped when the policy's factory already placed its steps, which is how a policy
+    that wants bespoke placement (GR00T positions its own relative/absolute pair) keeps control
+    without being special-cased by name here.
+
+    Args:
+        config: The policy config, source of parameters for `owner="config"` features.
+        context: Per-run build inputs, source of parameters for `owner="context"` features.
+        preprocessor: The freshly built preprocessor pipeline.
+        postprocessor: The freshly built postprocessor pipeline.
+        features: Features to consider. Defaults to `DEFAULT_POLICY_FEATURES`.
+    """
+    for feature in DEFAULT_POLICY_FEATURES if features is None else features:
+        if not feature.enabled_for(config, context):
+            continue
+
+        pre_anchored, post_anchored = feature.build(config, context)
+        already_placed = {type(entry.step) for entry in (*pre_anchored, *post_anchored)}
+        if any(
+            isinstance(step, tuple(already_placed)) for step in (*preprocessor.steps, *postprocessor.steps)
+        ):
+            logging.debug(
+                "Skipping the '%s' feature: %s already places its steps itself.",
+                feature.name,
+                type(config).__name__,
+            )
+            continue
+
+        preprocessor.steps = splice_anchored_steps(list(preprocessor.steps), pre_anchored)
+        postprocessor.steps = splice_anchored_steps(list(postprocessor.steps), post_anchored)
+
+
+def splice_anchored_steps(steps: list[ProcessorStep], anchored: list[AnchoredStep]) -> list[ProcessorStep]:
+    """Insert anchored steps into `steps`, resolving each anchor to exactly one position.
+
+    Args:
+        steps: The pipeline's steps, in order.
+        anchored: Steps to splice in.
+
+    Returns:
+        A new list with the anchored steps inserted.
+
+    Raises:
+        ValueError: If an anchor matches no step or more than one, either of which would make the
+            placement a guess.
+    """
+    result = list(steps)
+    for entry in anchored:
+        matches = [index for index, step in enumerate(result) if isinstance(step, entry.anchor)]
+        if len(matches) != 1:
+            raise ValueError(
+                f"Cannot place {type(entry.step).__name__}: its anchor "
+                f"{entry.anchor.__name__} matched {len(matches)} steps in "
+                f"{[type(step).__name__ for step in result]}, but exactly one is required. "
+                f"Place the step explicitly in the policy's processor factory instead."
+            )
+        index = matches[0] if entry.position == "before" else matches[0] + 1
+        result.insert(index, entry.step)
+    return result

--- a/src/lerobot/processor/pipeline.py
+++ b/src/lerobot/processor/pipeline.py
@@ -822,6 +822,121 @@ class DataProcessorPipeline[TInput, TOutput](HubMixin):
 
         return pipeline
 
+    @staticmethod
+    def _step_entry_key(step_entry: dict[str, Any]) -> str:
+        """Return the key a saved step entry is addressed by: registry name, else bare class name.
+
+        This is the same identity `_resolve_step_class` derives and `overrides` are matched against.
+        """
+        registry_name = step_entry.get("registry_name")
+        if registry_name:
+            return registry_name
+        return step_entry["class"].rsplit(".", 1)[1]
+
+    def load_pretrained_state(
+        self,
+        pretrained_model_name_or_path: str | Path,
+        config_filename: str,
+        *,
+        force_download: bool = False,
+        resume_download: bool | None = None,
+        proxies: dict[str, str] | None = None,
+        token: str | bool | None = None,
+        cache_dir: str | Path | None = None,
+        local_files_only: bool = False,
+        revision: str | None = None,
+    ) -> None:
+        """Restore a checkpoint's serialized step state into this already-built pipeline.
+
+        The counterpart to `from_pretrained`, for callers that own the pipeline's *structure*. Where
+        `from_pretrained` reconstructs the steps from the saved JSON — making the checkpoint
+        authoritative over the code — this keeps the steps built from the live config and takes only
+        the tensors from disk.
+
+        Steps are paired to saved entries greedily, in order, by step key, so a step inserted or
+        removed since the checkpoint was written no longer shifts the pairing of every later step.
+        That matters because state filenames embed the step *index*
+        (`_get_state_filename`), which `load_state_dict` cannot see past.
+
+        A built step with no saved counterpart is skipped: it is a step the current config adds, and
+        adding one is the normal case this method exists to support. A *stateful* saved entry with no
+        built counterpart raises instead — silently discarding checkpoint tensors is the one failure
+        mode here that would surface as bad numbers at inference rather than as an error.
+
+        Args:
+            pretrained_model_name_or_path: Hub repo id, local directory, or a config file path.
+            config_filename: The pipeline's JSON config filename. Required, as for `from_pretrained`,
+                so preprocessor and postprocessor configs are never confused.
+            force_download: Whether to force (re)downloading the files.
+            resume_download: Whether to resume a previously interrupted download.
+            proxies: A dictionary of proxy servers to use.
+            token: The token to use as HTTP bearer authorization for private Hub repositories.
+            cache_dir: The path to a specific cache folder to store downloaded files.
+            local_files_only: If True, avoid downloading files from the Hub.
+            revision: The specific model version to use.
+
+        Raises:
+            FileNotFoundError: If the config or a declared state file cannot be found.
+            ValueError: If the checkpoint carries state for a step this pipeline does not build.
+            ProcessorMigrationError: If the checkpoint predates the processor format.
+        """
+        model_id = str(pretrained_model_name_or_path)
+        model_path = Path(model_id)
+        is_local_source = model_path.is_dir() or model_path.is_file()
+        hub_download_kwargs = {
+            "force_download": force_download,
+            "resume_download": resume_download,
+            "proxies": proxies,
+            "token": token,
+            "cache_dir": cache_dir,
+            "local_files_only": local_files_only,
+            "revision": revision,
+        }
+
+        cls = type(self)
+        # Routed through the same two helpers `from_pretrained` uses, so a pre-processor-era
+        # checkpoint still raises ProcessorMigrationError with its actionable command rather than a
+        # confusing KeyError from the pairing below.
+        loaded_config, base_path = cls._load_config(model_id, config_filename, hub_download_kwargs)
+        cls._validate_loaded_config(model_id, loaded_config, config_filename)
+
+        unmatched: list[dict[str, Any]] = list(loaded_config["steps"])
+        for step in self.steps:
+            step_key = getattr(type(step), "_registry_name", None) or type(step).__name__
+            entry = next(
+                (candidate for candidate in unmatched if cls._step_entry_key(candidate) == step_key),
+                None,
+            )
+            if entry is None:
+                continue
+            # Popping makes duplicate keys (a pipeline's two `device_processor` steps, say) pair by
+            # ordinal rather than both matching the first entry.
+            unmatched.remove(entry)
+            cls._load_step_state(
+                step,
+                entry,
+                model_id,
+                base_path,
+                config_filename,
+                hub_download_kwargs,
+                is_local_source,
+            )
+
+        orphaned = [cls._step_entry_key(entry) for entry in unmatched if entry.get("state_file")]
+        if orphaned:
+            raise ValueError(
+                f"Checkpoint '{model_id}' carries state for step(s) {orphaned} that this pipeline does "
+                f"not build, so their tensors would be silently discarded. Built steps: "
+                f"{[type(step).__name__ for step in self.steps]}. Either build a pipeline containing "
+                f"those steps, or deserialize the saved pipeline wholesale with "
+                f"{cls.__name__}.from_pretrained()."
+            )
+
+        # Deliberately left unset: the filenames just consumed describe the *checkpoint's* step
+        # indices, which need not match this pipeline's. Leaving it None makes `state_dict()` and
+        # `load_state_dict()` re-derive from the current steps, keeping a later save self-consistent.
+        self._serialized_state_filenames = None
+
     @classmethod
     def _load_config(
         cls,
@@ -1172,7 +1287,7 @@ class DataProcessorPipeline[TInput, TOutput](HubMixin):
         if "registry_name" in step_entry:
             try:
                 step_class = ProcessorStepRegistry.get(step_entry["registry_name"])
-                return step_class, step_entry["registry_name"]
+                return step_class, cls._step_entry_key(step_entry)
             except KeyError as e:
                 raise ImportError(f"Failed to load processor step from registry. {str(e)}") from e
         else:
@@ -1183,7 +1298,7 @@ class DataProcessorPipeline[TInput, TOutput](HubMixin):
             try:
                 module = importlib.import_module(module_path)
                 step_class = getattr(module, class_name)
-                return step_class, class_name
+                return step_class, cls._step_entry_key(step_entry)
             except (ImportError, AttributeError) as e:
                 raise ImportError(
                     f"Failed to load processor step '{full_class_path}'. "
@@ -1377,9 +1492,7 @@ class DataProcessorPipeline[TInput, TOutput](HubMixin):
         if not remaining_override_keys:
             return
 
-        available_keys = [
-            step.get("registry_name") or step["class"].rsplit(".", 1)[1] for step in loaded_config["steps"]
-        ]
+        available_keys = [cls._step_entry_key(step) for step in loaded_config["steps"]]
 
         raise KeyError(
             f"Override keys {list(remaining_override_keys)} do not match any step in the saved configuration. "

--- a/src/lerobot/processor/relative_action_processor.py
+++ b/src/lerobot/processor/relative_action_processor.py
@@ -126,7 +126,7 @@ class RelativeActionsProcessorStep(ProcessorStep):
         observation = transition.get(TransitionKey.OBSERVATION, {})
         state = observation.get(OBS_STATE) if observation else None
 
-        # Always cache state for the paired AbsoluteActionsProcessorStep
+        # Always cache state for the paired AbsoluteActionsProcessorStep.
         if state is not None:
             self._last_state = state
 
@@ -145,6 +145,11 @@ class RelativeActionsProcessorStep(ProcessorStep):
     def get_cached_state(self) -> torch.Tensor | None:
         """Return the cached ``observation.state`` used as the reference point for relative/absolute action conversions."""
         return self._last_state
+
+    def set_cached_state(self, state: torch.Tensor | None) -> None:
+        """Override the cached anchor state, e.g. to re-pin a chunk's anchor after the
+        per-tick pipeline overwrote it (see ``SyncInferenceEngine``)."""
+        self._last_state = state
 
     def get_config(self) -> dict[str, Any]:
         return {

--- a/src/lerobot/rollout/context.py
+++ b/src/lerobot/rollout/context.py
@@ -46,7 +46,6 @@ from lerobot.processor import (
     make_default_processors,
     rename_stats,
 )
-from lerobot.processor.relative_action_processor import RelativeActionsProcessorStep
 from lerobot.robots import make_robot_from_config
 from lerobot.teleoperators import Teleoperator, make_teleoperator_from_config
 from lerobot.utils.feature_utils import combine_feature_dicts, hw_to_dataset_features
@@ -56,7 +55,6 @@ from .configs import BaseStrategyConfig, DAggerStrategyConfig, RolloutConfig
 from .inference import (
     InferenceEngine,
     RTCInferenceConfig,
-    SyncInferenceConfig,
     create_inference_engine,
 )
 from .inference.rtc import supports_rtc_inference
@@ -508,15 +506,6 @@ def build_rollout_context(
             "rename_observations_processor": {"rename_map": cfg.rename_map},
         },
     )
-
-    if isinstance(cfg.inference, SyncInferenceConfig) and any(
-        isinstance(step, RelativeActionsProcessorStep) and step.enabled
-        for step in getattr(preprocessor, "steps", ())
-    ):
-        raise NotImplementedError(
-            "SyncInferenceEngine does not support policies with relative actions for now."
-            "Use --inference.type=rtc or remove relative action processor steps from the policy pipeline."
-        )
 
     # --- 7. Inference strategy (needs policy + pre/post + hardware) --
     logger.info(

--- a/src/lerobot/rollout/context.py
+++ b/src/lerobot/rollout/context.py
@@ -40,6 +40,7 @@ from lerobot.policies import get_policy_class, make_pre_post_processors
 from lerobot.policies.pretrained import PreTrainedPolicy
 from lerobot.processor import (
     PolicyProcessorPipeline,
+    ProcessorBuildContext,
     RobotAction,
     RobotObservation,
     RobotProcessorPipeline,
@@ -496,15 +497,16 @@ def build_rollout_context(
             cfg.rename_map,
         )
 
+    # The pipelines are rebuilt from this config, so the device and rename map are set on it rather
+    # than injected as step overrides.
+    policy_config.device = cfg.device
+    policy_config.rename_map = dict(cfg.rename_map)
+
     preprocessor, postprocessor = make_pre_post_processors(
         policy_cfg=policy_config,
         pretrained_path=cfg.policy.pretrained_path,
         pretrained_revision=policy_config.pretrained_revision,
-        dataset_stats=dataset_stats,
-        preprocessor_overrides={
-            "device_processor": {"device": cfg.device},
-            "rename_observations_processor": {"rename_map": cfg.rename_map},
-        },
+        context=ProcessorBuildContext(dataset_stats=dataset_stats),
     )
 
     # --- 7. Inference strategy (needs policy + pre/post + hardware) --

--- a/src/lerobot/rollout/inference/sync.py
+++ b/src/lerobot/rollout/inference/sync.py
@@ -24,7 +24,7 @@ import torch
 
 from lerobot.policies.pretrained import PreTrainedPolicy
 from lerobot.policies.utils import make_robot_action, prepare_observation_for_inference
-from lerobot.processor import PolicyProcessorPipeline
+from lerobot.processor import PolicyProcessorPipeline, RelativeActionsProcessorStep
 from lerobot.utils.constants import OBS_STR
 from lerobot.utils.feature_utils import build_dataset_frame
 
@@ -33,19 +33,14 @@ from .base import InferenceEngine, PolicyQuery
 logger = logging.getLogger(__name__)
 
 
-# TODO(Steven): support relative-action policies.  The per-tick flow refreshes
-# ``RelativeActionsProcessorStep._last_state`` every call, so cached chunk
-# actions popped on later ticks get reanchored to the *current* robot state and
-# absolute targets drift through the chunk.  Relative-action policies are
-# rejected at context-build time today; RTC postprocesses the whole chunk and
-# is unaffected.
-#
-# Candidate fix: drive the policy via ``predict_action_chunk`` and serve a
-# local FIFO of postprocessed actions.  Eliminates drift by construction and
-# saves per-tick pre/post work, but bypasses ``select_action`` — needs
-# fallbacks for SAC (raises), ACT temporal ensembling (ensembler lives in
-# ``select_action``), and Diffusion-family (obs-history queues populated as a
-# side effect of ``select_action``).
+# Relative-action support: a predicted chunk of offsets is anchored to the robot
+# state at prediction time, but the sync engine reruns the pre/post pipeline every
+# tick, so ``RelativeActionsProcessorStep`` would re-anchor cached actions to the
+# current (moved) state and drift through the chunk. We pin the anchor per chunk:
+# a probe on the policy's public ``predict_action_chunk`` flags the ticks that
+# predict a fresh chunk; on the others the engine restores the anchor the relative
+# step overwrote. ``select_action`` stays on the hot path, so per-tick side effects
+# (e.g. LingBot-VA keyframe feedback) are preserved.
 
 
 class SyncInferenceEngine(InferenceEngine):
@@ -75,6 +70,31 @@ class SyncInferenceEngine(InferenceEngine):
         self._ordered_action_keys = ordered_action_keys
         self._device = torch.device(device or "cpu")
         self._robot_type = robot_type
+
+        # Find an enabled RelativeActionsProcessorStep to pin its anchor per chunk
+        # (see module comment), mirroring the RTC engine.
+        self._relative_step = next(
+            (
+                s
+                for s in getattr(preprocessor, "steps", ())
+                if isinstance(s, RelativeActionsProcessorStep) and s.enabled
+            ),
+            None,
+        )
+        # Set by the probe for the current tick / ever, respectively.
+        self._chunk_predicted = False
+        self._ever_predicted_chunk = False
+        self._original_predict_action_chunk = None  # set while the probe is installed
+        if self._relative_step is not None:
+            # ``action_names`` is optional on the step; fill it lazily from the
+            # policy/dataset so the relative<->absolute mask is built correctly. This is
+            # a deliberate engine->step side effect (the step is configured by its consumer).
+            if self._relative_step.action_names is None:
+                cfg_names = getattr(policy.config, "action_feature_names", None)
+                self._relative_step.action_names = list(cfg_names) if cfg_names else list(ordered_action_keys)
+            self._install_chunk_probe()
+            logger.info("Relative actions enabled: chunk anchor pinned per predicted chunk")
+
         logger.info(
             "SyncInferenceEngine initialized (device=%s, action_keys=%d)",
             self._device,
@@ -87,6 +107,11 @@ class SyncInferenceEngine(InferenceEngine):
 
     def stop(self) -> None:
         """No background resources to stop."""
+        # Undo the probe so the policy object isn't left permanently patched
+        # (it may outlive this engine or be reused by another).
+        if self._original_predict_action_chunk is not None:
+            self._policy.predict_action_chunk = self._original_predict_action_chunk
+            self._original_predict_action_chunk = None
         logger.info("SyncInferenceEngine stopped")
 
     def reset(self) -> None:
@@ -97,6 +122,27 @@ class SyncInferenceEngine(InferenceEngine):
         self._postprocessor.reset()
         # The policy was just reset, so a pending task change has nothing stale to flush.
         self._discard_task_change()
+        # New episode: the next tick predicts a fresh chunk and re-anchors.
+        self._chunk_predicted = False
+        self._ever_predicted_chunk = False
+
+    def _install_chunk_probe(self) -> None:
+        """Wrap the policy's public ``predict_action_chunk`` so we learn which ticks
+        predict a fresh chunk (when the anchor must advance) without introspecting any
+        private action queue. Chunking policies call it from ``select_action``.
+
+        Wraps whatever callable is currently bound (e.g. an already-``torch.compile``d
+        one, since ``build_rollout_context`` compiles before building the engine); undone
+        in ``stop()``."""
+        self._original_predict_action_chunk = self._policy.predict_action_chunk
+        inner = self._original_predict_action_chunk
+
+        def probe(*args, **kwargs):
+            self._chunk_predicted = True
+            self._ever_predicted_chunk = True
+            return inner(*args, **kwargs)
+
+        self._policy.predict_action_chunk = probe
 
     def get_action(self, obs_frame: dict | None) -> torch.Tensor | None:
         """Run the full inference pipeline on ``obs_frame`` and return an action tensor."""
@@ -112,6 +158,15 @@ class SyncInferenceEngine(InferenceEngine):
             else nullcontext()
         )
         task, task_changed = self._take_task()
+        # Snapshot the chunk anchor before the preprocessor overwrites it with this
+        # tick's state; restore it below if this tick only served a cached action.
+        # ``clone`` so the snapshot survives even if the cached tensor is ever mutated
+        # in place (today it is only rebound, but the copy is cheap for a state vector).
+        anchor_before = None
+        if self._relative_step is not None:
+            cached = self._relative_step.get_cached_state()
+            anchor_before = cached.clone() if cached is not None else None
+        self._chunk_predicted = False
         with torch.inference_mode(), autocast_ctx:
             if task_changed:
                 # Chunking policies queue actions computed under the previous instruction,
@@ -122,6 +177,10 @@ class SyncInferenceEngine(InferenceEngine):
             observation = prepare_observation_for_inference(observation, self._device, task, self._robot_type)
             observation = self._preprocessor(observation)
             action = self._policy.select_action(observation)
+            # Hold the anchor only for a chunking policy serving a cached action this
+            # tick; policies that never chunk or that recomputed keep refreshing.
+            if self._relative_step is not None and self._ever_predicted_chunk and not self._chunk_predicted:
+                self._relative_step.set_cached_state(anchor_before)
             action = self._postprocessor(action)
         action_tensor = action.squeeze(0).cpu()
 

--- a/src/lerobot/rollout/inference/sync.py
+++ b/src/lerobot/rollout/inference/sync.py
@@ -37,10 +37,10 @@ logger = logging.getLogger(__name__)
 # state at prediction time, but the sync engine reruns the pre/post pipeline every
 # tick, so ``RelativeActionsProcessorStep`` would re-anchor cached actions to the
 # current (moved) state and drift through the chunk. We pin the anchor per chunk:
-# a probe on the policy's public ``predict_action_chunk`` flags the ticks that
-# predict a fresh chunk; on the others the engine restores the anchor the relative
-# step overwrote. ``select_action`` stays on the hot path, so per-tick side effects
-# (e.g. LingBot-VA keyframe feedback) are preserved.
+# ``PreTrainedPolicy.queued_action_count()`` reports whether this tick will serve an
+# already-computed action (hold the anchor) or force a fresh prediction (let it
+# advance). ``select_action`` stays on the hot path, so per-tick side effects (e.g.
+# LingBot-VA keyframe feedback) are preserved.
 
 
 class SyncInferenceEngine(InferenceEngine):
@@ -81,10 +81,6 @@ class SyncInferenceEngine(InferenceEngine):
             ),
             None,
         )
-        # Set by the probe for the current tick / ever, respectively.
-        self._chunk_predicted = False
-        self._ever_predicted_chunk = False
-        self._original_predict_action_chunk = None  # set while the probe is installed
         if self._relative_step is not None:
             # ``action_names`` is optional on the step; fill it lazily from the
             # policy/dataset so the relative<->absolute mask is built correctly. This is
@@ -92,7 +88,6 @@ class SyncInferenceEngine(InferenceEngine):
             if self._relative_step.action_names is None:
                 cfg_names = getattr(policy.config, "action_feature_names", None)
                 self._relative_step.action_names = list(cfg_names) if cfg_names else list(ordered_action_keys)
-            self._install_chunk_probe()
             logger.info("Relative actions enabled: chunk anchor pinned per predicted chunk")
 
         logger.info(
@@ -107,11 +102,6 @@ class SyncInferenceEngine(InferenceEngine):
 
     def stop(self) -> None:
         """No background resources to stop."""
-        # Undo the probe so the policy object isn't left permanently patched
-        # (it may outlive this engine or be reused by another).
-        if self._original_predict_action_chunk is not None:
-            self._policy.predict_action_chunk = self._original_predict_action_chunk
-            self._original_predict_action_chunk = None
         logger.info("SyncInferenceEngine stopped")
 
     def reset(self) -> None:
@@ -122,27 +112,6 @@ class SyncInferenceEngine(InferenceEngine):
         self._postprocessor.reset()
         # The policy was just reset, so a pending task change has nothing stale to flush.
         self._discard_task_change()
-        # New episode: the next tick predicts a fresh chunk and re-anchors.
-        self._chunk_predicted = False
-        self._ever_predicted_chunk = False
-
-    def _install_chunk_probe(self) -> None:
-        """Wrap the policy's public ``predict_action_chunk`` so we learn which ticks
-        predict a fresh chunk (when the anchor must advance) without introspecting any
-        private action queue. Chunking policies call it from ``select_action``.
-
-        Wraps whatever callable is currently bound (e.g. an already-``torch.compile``d
-        one, since ``build_rollout_context`` compiles before building the engine); undone
-        in ``stop()``."""
-        self._original_predict_action_chunk = self._policy.predict_action_chunk
-        inner = self._original_predict_action_chunk
-
-        def probe(*args, **kwargs):
-            self._chunk_predicted = True
-            self._ever_predicted_chunk = True
-            return inner(*args, **kwargs)
-
-        self._policy.predict_action_chunk = probe
 
     def get_action(self, obs_frame: dict | None) -> torch.Tensor | None:
         """Run the full inference pipeline on ``obs_frame`` and return an action tensor."""
@@ -158,15 +127,6 @@ class SyncInferenceEngine(InferenceEngine):
             else nullcontext()
         )
         task, task_changed = self._take_task()
-        # Snapshot the chunk anchor before the preprocessor overwrites it with this
-        # tick's state; restore it below if this tick only served a cached action.
-        # ``clone`` so the snapshot survives even if the cached tensor is ever mutated
-        # in place (today it is only rebound, but the copy is cheap for a state vector).
-        anchor_before = None
-        if self._relative_step is not None:
-            cached = self._relative_step.get_cached_state()
-            anchor_before = cached.clone() if cached is not None else None
-        self._chunk_predicted = False
         with torch.inference_mode(), autocast_ctx:
             if task_changed:
                 # Chunking policies queue actions computed under the previous instruction,
@@ -174,12 +134,19 @@ class SyncInferenceEngine(InferenceEngine):
                 # than ``policy.reset``: observation history and other episode state stay.
                 logger.info("Task changed to '%s' — dropping precomputed actions", task)
                 self._policy.drop_queued_actions()
+            # A non-empty queue means this tick will serve an already-computed action, so
+            # the anchor must hold; snapshot it before the preprocessor overwrites it below.
+            # ``clone`` so the snapshot survives even if the cached tensor is ever mutated
+            # in place (today it is only rebound, but the copy is cheap for a state vector).
+            will_drain_cached = self._relative_step is not None and self._policy.queued_action_count() > 0
+            anchor_before = None
+            if will_drain_cached:
+                cached = self._relative_step.get_cached_state()
+                anchor_before = cached.clone() if cached is not None else None
             observation = prepare_observation_for_inference(observation, self._device, task, self._robot_type)
             observation = self._preprocessor(observation)
             action = self._policy.select_action(observation)
-            # Hold the anchor only for a chunking policy serving a cached action this
-            # tick; policies that never chunk or that recomputed keep refreshing.
-            if self._relative_step is not None and self._ever_predicted_chunk and not self._chunk_predicted:
+            if will_drain_cached:
                 self._relative_step.set_cached_state(anchor_before)
             action = self._postprocessor(action)
         action_tensor = action.squeeze(0).cpu()

--- a/src/lerobot/scripts/lerobot_eval.py
+++ b/src/lerobot/scripts/lerobot_eval.py
@@ -85,7 +85,7 @@ from lerobot.envs import (
 from lerobot.envs.utils import NEW_ROLLOUT_OPTION
 from lerobot.lerobot_types import PolicyAction
 from lerobot.policies import PreTrainedPolicy, make_policy, make_pre_post_processors
-from lerobot.processor import PolicyProcessorPipeline
+from lerobot.processor import PolicyProcessorPipeline, ProcessorBuildContext
 from lerobot.utils.constants import ACTION, DONE, OBS_IMAGE, OBS_IMAGES, OBS_STR, REWARD
 from lerobot.utils.device_utils import get_safe_torch_device
 from lerobot.utils.import_utils import _peft_available, register_third_party_plugins, require_package
@@ -767,16 +767,17 @@ def eval_main(cfg: EvalPipelineConfig):
 
     policy.eval()
 
-    # The inference device is automatically set to match the detected hardware, overriding any previous device settings from training to ensure compatibility.
-    preprocessor_overrides = {
-        "device_processor": {"device": str(policy.config.device)},
-        "rename_observations_processor": {"rename_map": cfg.rename_map},
-    }
+    # The inference device is automatically set to match the detected hardware, overriding any
+    # previous device settings from training to ensure compatibility. The pipelines are rebuilt from
+    # this config, so setting it here is all that is needed. No dataset stats are supplied, which is
+    # what keeps the checkpoint's own normalization statistics authoritative.
+    cfg.policy.device = str(policy.config.device)
+    cfg.policy.rename_map = dict(cfg.rename_map)
 
     preprocessor, postprocessor = make_pre_post_processors(
         policy_cfg=cfg.policy,
         pretrained_path=cfg.policy.pretrained_path,
-        preprocessor_overrides=preprocessor_overrides,
+        context=ProcessorBuildContext(),
     )
 
     # Create environment-specific preprocessor and postprocessor (e.g., for LIBERO environments)

--- a/src/lerobot/scripts/lerobot_train.py
+++ b/src/lerobot/scripts/lerobot_train.py
@@ -74,6 +74,7 @@ from lerobot.jobs import submit_to_hf
 from lerobot.optim.factory import make_optimizer_and_scheduler
 from lerobot.policies import PreTrainedPolicy, make_policy, make_pre_post_processors
 from lerobot.policies.factory import ProcessorConfigKwargs
+from lerobot.processor import ProcessorBuildContext
 from lerobot.processor.rename_processor import rename_batch_keys, rename_stats
 from lerobot.rewards import make_reward_pre_post_processors
 from lerobot.utils.collate import lerobot_collate_fn
@@ -496,55 +497,34 @@ def train(cfg: TrainPipelineConfig):
     active_cfg = cfg.trainable_config
     processor_pretrained_path = active_cfg.pretrained_path
 
-    processor_kwargs = ProcessorConfigKwargs()
     processor_dataset_stats = rename_stats(dataset.meta.stats, cfg.rename_map)
-    if (processor_pretrained_path and not cfg.resume) or not processor_pretrained_path:
-        processor_kwargs["dataset_stats"] = processor_dataset_stats
-    if cfg.is_reward_model_training:
-        processor_kwargs["dataset_meta"] = dataset.meta
-    if not cfg.is_reward_model_training and processor_pretrained_path is not None:
-        preprocessor_overrides = {
-            "device_processor": {"device": device.type},
-            "normalizer_processor": {
-                "features": {**policy.config.input_features, **policy.config.output_features},
-                "norm_map": policy.config.normalization_mapping,
-            },
-            "rename_observations_processor": {"rename_map": cfg.rename_map},
-        }
-        postprocessor_overrides = {
-            "unnormalizer_processor": {
-                "features": policy.config.output_features,
-                "norm_map": policy.config.normalization_mapping,
-            },
-        }
-        # On resume, the checkpoint's saved processor stats are authoritative: they may have
-        # been adapted by the policy (e.g. EVO1 pads state/action stats to max_state_dim),
-        # and force-feeding raw dataset stats over them crashes normalization (#4006).
-        # This mirrors the `dataset_stats` kwarg above, which is also skipped on resume.
-        if not cfg.resume:
-            preprocessor_overrides["normalizer_processor"]["stats"] = processor_dataset_stats
-            postprocessor_overrides["unnormalizer_processor"]["stats"] = processor_dataset_stats
-        if getattr(active_cfg, "use_relative_actions", False):
-            preprocessor_overrides["relative_actions_processor"] = {
-                "enabled": True,
-                "exclude_joints": getattr(active_cfg, "relative_exclude_joints", []),
-                "action_names": getattr(active_cfg, "action_feature_names", None),
-            }
-            postprocessor_overrides["absolute_actions_processor"] = {"enabled": True}
-        processor_kwargs["preprocessor_overrides"] = preprocessor_overrides
-        processor_kwargs["postprocessor_overrides"] = postprocessor_overrides
+    # Supplying stats is what makes the dataset authoritative over a checkpoint's saved stats. On
+    # resume the checkpoint's are authoritative instead: they may have been adapted by the policy
+    # (EVO1 pads state/action stats to max_state_dim), and overwriting them with raw dataset stats
+    # crashes normalization (#4006). Structure and shape always come from the policy config, so
+    # nothing here names a processor step.
+    supply_dataset_stats = not (processor_pretrained_path and cfg.resume)
 
     if cfg.is_reward_model_training:
+        reward_kwargs = ProcessorConfigKwargs(dataset_meta=dataset.meta)
+        if supply_dataset_stats:
+            reward_kwargs["dataset_stats"] = processor_dataset_stats
         preprocessor, postprocessor = make_reward_pre_post_processors(
             cfg.reward_model,
-            **processor_kwargs,
+            **reward_kwargs,
         )
     else:
+        cfg.policy.device = device.type
+        cfg.policy.rename_map = dict(cfg.rename_map)
         preprocessor, postprocessor = make_pre_post_processors(
             policy_cfg=cfg.policy,
             pretrained_path=processor_pretrained_path,
             pretrained_revision=getattr(cfg.policy, "pretrained_revision", None),
-            **processor_kwargs,
+            context=ProcessorBuildContext(
+                dataset_stats=processor_dataset_stats if supply_dataset_stats else None,
+                dataset_meta=dataset.meta,
+                training=True,
+            ),
         )
 
     # Created BEFORE prepare on the unsharded parameters — accelerate's FSDP2 path requires the

--- a/tests/artifacts/processors/generate_golden_processor_configs.py
+++ b/tests/artifacts/processors/generate_golden_processor_configs.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pin the serialized shape of every policy's pre/post-processor pipelines.
+
+These fixtures are the reference for the processor refactor that makes the policy config
+authoritative over a checkpoint's saved pipeline (see `tests/policies/test_processor_authority.py`).
+Rebuilding a pipeline from a config must produce the same structure the old deserializing loader
+produced, and that can only be verified against output captured *before* the refactor landed.
+
+Regenerate deliberately, never to make a failing test pass:
+
+    uv run python tests/artifacts/processors/generate_golden_processor_configs.py
+
+Check the working tree against the committed fixtures (what CI does):
+
+    uv run python tests/artifacts/processors/generate_golden_processor_configs.py --check
+
+A policy that cannot be built offline is recorded in `manifest.json` with its reason instead of
+being silently dropped, so the coverage gap stays visible.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+
+import torch
+
+from lerobot.configs.policies import PreTrainedConfig
+from lerobot.configs.types import FeatureType, PolicyFeature
+from lerobot.policies.factory import make_policy_config, make_pre_post_processors
+from lerobot.utils.constants import ACTION, OBS_IMAGE, OBS_IMAGES, OBS_STATE
+
+GOLDEN_DIR = Path(__file__).parent / "golden"
+MANIFEST_PATH = GOLDEN_DIR / "manifest.json"
+
+# Deliberately small and fixed. The fixtures pin pipeline *structure*, so the only thing these
+# numbers have to do is be shaped plausibly and never change.
+STATE_DIM = 6
+ACTION_DIM = 6
+IMAGE_SHAPE = (3, 96, 96)
+CAMERA_NAME = "cam"
+
+
+def _synthetic_features() -> tuple[dict[str, PolicyFeature], dict[str, PolicyFeature]]:
+    """Feature dicts covering both image key conventions, since policies disagree on which they use."""
+    input_features = {
+        OBS_STATE: PolicyFeature(type=FeatureType.STATE, shape=(STATE_DIM,)),
+        f"{OBS_IMAGE}.{CAMERA_NAME}": PolicyFeature(type=FeatureType.VISUAL, shape=IMAGE_SHAPE),
+        f"{OBS_IMAGES}.{CAMERA_NAME}": PolicyFeature(type=FeatureType.VISUAL, shape=IMAGE_SHAPE),
+    }
+    output_features = {ACTION: PolicyFeature(type=FeatureType.ACTION, shape=(ACTION_DIM,))}
+    return input_features, output_features
+
+
+def _synthetic_stats(features: dict[str, PolicyFeature]) -> dict[str, dict[str, torch.Tensor]]:
+    """Stats for every feature, covering all stat names any `NormalizationMode` may ask for."""
+    stats: dict[str, dict[str, torch.Tensor]] = {}
+    for key, feature in features.items():
+        if feature.type is FeatureType.VISUAL:
+            # Per-channel, in the (C, 1, 1) layout the normalizer reshapes visual stats into.
+            shape: tuple[int, ...] = (feature.shape[0], 1, 1)
+        else:
+            shape = feature.shape
+        stats[key] = {
+            "mean": torch.zeros(shape),
+            "std": torch.ones(shape),
+            "min": -torch.ones(shape),
+            "max": torch.ones(shape),
+            "q01": -torch.ones(shape),
+            "q99": torch.ones(shape),
+            "q10": -torch.ones(shape),
+            "q90": torch.ones(shape),
+        }
+    return stats
+
+
+def _build_configs(policy_type: str) -> dict[str, Any]:
+    """Build one policy's pipelines and return both serialized configs.
+
+    Raises whatever the policy's factory raises; the caller records it as a skip.
+    """
+    input_features, output_features = _synthetic_features()
+    config = make_policy_config(policy_type, push_to_hub=False)
+    config.input_features = dict(input_features)
+    config.output_features = dict(output_features)
+    # cpu keeps `device_processor` output identical regardless of the generating machine.
+    config.device = "cpu"
+
+    stats = _synthetic_stats({**input_features, **output_features})
+    preprocessor, postprocessor = make_pre_post_processors(config, dataset_stats=stats)
+    # Canonicalize through JSON: what these fixtures pin is the on-disk contract, and `get_config()`
+    # returns Python objects that JSON flattens (feature shapes are tuples in memory, lists on disk).
+    # Comparing the in-memory form against a parsed fixture would report a difference on every shape.
+    return {
+        "pre": _as_serialized(preprocessor.get_config()),
+        "post": _as_serialized(postprocessor.get_config()),
+    }
+
+
+def _as_serialized(config: dict[str, Any]) -> dict[str, Any]:
+    """Return `config` as it would come back after `save_pretrained` and a reload."""
+    return json.loads(json.dumps(config))
+
+
+def _generate() -> tuple[dict[str, dict[str, Any]], dict[str, str]]:
+    built: dict[str, dict[str, Any]] = {}
+    skipped: dict[str, str] = {}
+    for policy_type in sorted(PreTrainedConfig.get_known_choices()):
+        try:
+            built[policy_type] = _build_configs(policy_type)
+        except Exception as exc:  # noqa: BLE001 - any failure is a recorded skip, never fatal
+            skipped[policy_type] = f"{type(exc).__name__}: {exc}"
+            logging.warning("skipped %s: %s", policy_type, skipped[policy_type].splitlines()[0])
+    return built, skipped
+
+
+def _write(built: dict[str, dict[str, Any]], skipped: dict[str, str]) -> None:
+    GOLDEN_DIR.mkdir(parents=True, exist_ok=True)
+    for policy_type, configs in built.items():
+        for role, config in configs.items():
+            path = GOLDEN_DIR / f"{policy_type}_{role}.json"
+            path.write_text(json.dumps(config, indent=2, sort_keys=True) + "\n")
+    manifest = {
+        "covered": sorted(built),
+        "skipped": {key: skipped[key] for key in sorted(skipped)},
+    }
+    MANIFEST_PATH.write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n")
+
+
+def _is_missing_optional_dependency(reason: str) -> bool:
+    """Whether a build failure is this environment lacking an extra, rather than a real regression.
+
+    The fixture set is the union across environments — policies behind extras (scipy for pi0_fast and
+    molmoact2, for instance) are covered when generated in a fuller env. A check run can only verify
+    what it can import, so those are skips. Anything else is a genuine failure to build.
+    """
+    return reason.startswith(("ImportError:", "ModuleNotFoundError:"))
+
+
+def _check(built: dict[str, dict[str, Any]], skipped: dict[str, str]) -> int:
+    """Compare freshly built configs against the committed fixtures. Returns an exit code."""
+    if not MANIFEST_PATH.exists():
+        logging.error("no fixtures committed yet; run without --check first")
+        return 1
+    covered = json.loads(MANIFEST_PATH.read_text())["covered"]
+    mismatched: list[str] = []
+    for policy_type in covered:
+        if policy_type not in built:
+            reason = skipped.get(policy_type, "not built, and no reason recorded")
+            if _is_missing_optional_dependency(reason):
+                logging.info("skipping %s: not installed in this environment", policy_type)
+            else:
+                mismatched.append(f"{policy_type}: covered by the fixtures but no longer builds: {reason}")
+            continue
+        for role, config in built[policy_type].items():
+            path = GOLDEN_DIR / f"{policy_type}_{role}.json"
+            expected = json.loads(path.read_text())
+            if config != expected:
+                mismatched.append(f"{policy_type} ({role}): differs from {path.name}")
+    for line in mismatched:
+        logging.error("%s", line)
+    return 1 if mismatched else 0
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="compare against the committed fixtures instead of rewriting them",
+    )
+    args = parser.parse_args()
+
+    built, skipped = _generate()
+    logging.info("built %d policies, skipped %d", len(built), len(skipped))
+    if args.check:
+        return _check(built, skipped)
+    _write(built, skipped)
+    logging.info("wrote fixtures for %s", ", ".join(sorted(built)))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/artifacts/processors/golden/act_post.json
+++ b/tests/artifacts/processors/golden/act_post.json
@@ -1,0 +1,32 @@
+{
+  "name": "policy_postprocessor",
+  "steps": [
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          }
+        },
+        "norm_map": {
+          "ACTION": "MEAN_STD",
+          "STATE": "MEAN_STD",
+          "VISUAL": "MEAN_STD"
+        }
+      },
+      "registry_name": "unnormalizer_processor",
+      "state_file": "policy_postprocessor_step_0_unnormalizer_processor.safetensors"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/act_pre.json
+++ b/tests/artifacts/processors/golden/act_pre.json
@@ -1,0 +1,64 @@
+{
+  "name": "policy_preprocessor",
+  "steps": [
+    {
+      "config": {
+        "rename_map": {}
+      },
+      "registry_name": "rename_observations_processor"
+    },
+    {
+      "config": {},
+      "registry_name": "to_batch_processor"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    },
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          },
+          "observation.image.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.images.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.state": {
+            "shape": [
+              6
+            ],
+            "type": "STATE"
+          }
+        },
+        "norm_map": {
+          "ACTION": "MEAN_STD",
+          "STATE": "MEAN_STD",
+          "VISUAL": "MEAN_STD"
+        }
+      },
+      "registry_name": "normalizer_processor",
+      "state_file": "policy_preprocessor_step_3_normalizer_processor.safetensors"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/diffusion_post.json
+++ b/tests/artifacts/processors/golden/diffusion_post.json
@@ -1,0 +1,32 @@
+{
+  "name": "policy_postprocessor",
+  "steps": [
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          }
+        },
+        "norm_map": {
+          "ACTION": "MIN_MAX",
+          "STATE": "MIN_MAX",
+          "VISUAL": "MEAN_STD"
+        }
+      },
+      "registry_name": "unnormalizer_processor",
+      "state_file": "policy_postprocessor_step_0_unnormalizer_processor.safetensors"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/diffusion_pre.json
+++ b/tests/artifacts/processors/golden/diffusion_pre.json
@@ -1,0 +1,64 @@
+{
+  "name": "policy_preprocessor",
+  "steps": [
+    {
+      "config": {
+        "rename_map": {}
+      },
+      "registry_name": "rename_observations_processor"
+    },
+    {
+      "config": {},
+      "registry_name": "to_batch_processor"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    },
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          },
+          "observation.image.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.images.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.state": {
+            "shape": [
+              6
+            ],
+            "type": "STATE"
+          }
+        },
+        "norm_map": {
+          "ACTION": "MIN_MAX",
+          "STATE": "MIN_MAX",
+          "VISUAL": "MEAN_STD"
+        }
+      },
+      "registry_name": "normalizer_processor",
+      "state_file": "policy_preprocessor_step_3_normalizer_processor.safetensors"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/eo1_post.json
+++ b/tests/artifacts/processors/golden/eo1_post.json
@@ -1,0 +1,32 @@
+{
+  "name": "policy_postprocessor",
+  "steps": [
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          }
+        },
+        "norm_map": {
+          "ACTION": "MEAN_STD",
+          "STATE": "MEAN_STD",
+          "VISUAL": "IDENTITY"
+        }
+      },
+      "registry_name": "unnormalizer_processor",
+      "state_file": "policy_postprocessor_step_0_unnormalizer_processor.safetensors"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/eo1_pre.json
+++ b/tests/artifacts/processors/golden/eo1_pre.json
@@ -1,0 +1,103 @@
+{
+  "name": "policy_preprocessor",
+  "steps": [
+    {
+      "config": {
+        "rename_map": {}
+      },
+      "registry_name": "rename_observations_processor"
+    },
+    {
+      "config": {},
+      "registry_name": "to_batch_processor"
+    },
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          },
+          "observation.image.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.images.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.state": {
+            "shape": [
+              6
+            ],
+            "type": "STATE"
+          }
+        },
+        "norm_map": {
+          "ACTION": "MEAN_STD",
+          "STATE": "MEAN_STD",
+          "VISUAL": "IDENTITY"
+        }
+      },
+      "registry_name": "normalizer_processor",
+      "state_file": "policy_preprocessor_step_2_normalizer_processor.safetensors"
+    },
+    {
+      "config": {
+        "chunk_size": 8,
+        "input_features": {
+          "observation.image.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.images.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.state": {
+            "shape": [
+              6
+            ],
+            "type": "STATE"
+          }
+        }
+      },
+      "registry_name": "eo1_conversation_template_processor"
+    },
+    {
+      "config": {
+        "image_max_pixels": 100352,
+        "image_min_pixels": 50176,
+        "processor_name": "Qwen/Qwen2.5-VL-3B-Instruct",
+        "use_fast_processor": false
+      },
+      "registry_name": "eo1_qwen_processor"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/evo1_post.json
+++ b/tests/artifacts/processors/golden/evo1_post.json
@@ -1,0 +1,43 @@
+{
+  "name": "policy_postprocessor",
+  "steps": [
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              24
+            ],
+            "type": "ACTION"
+          }
+        },
+        "norm_map": {
+          "ACTION": "MIN_MAX",
+          "STATE": "MIN_MAX",
+          "VISUAL": "IDENTITY"
+        }
+      },
+      "registry_name": "unnormalizer_processor",
+      "state_file": "policy_postprocessor_step_0_unnormalizer_processor.safetensors"
+    },
+    {
+      "config": {
+        "action_dim": 6,
+        "binarize_gripper": false,
+        "gripper_above_threshold_value": -1.0,
+        "gripper_below_threshold_value": 1.0,
+        "gripper_index": 6,
+        "gripper_threshold": 0.5
+      },
+      "registry_name": "evo1_action_processor"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": "float32"
+      },
+      "registry_name": "device_processor"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/evo1_pre.json
+++ b/tests/artifacts/processors/golden/evo1_pre.json
@@ -1,0 +1,76 @@
+{
+  "name": "policy_preprocessor",
+  "steps": [
+    {
+      "config": {
+        "rename_map": {}
+      },
+      "registry_name": "rename_observations_processor"
+    },
+    {
+      "config": {},
+      "registry_name": "to_batch_processor"
+    },
+    {
+      "config": {
+        "max_state_dim": 24
+      },
+      "registry_name": "evo1_pad_state_processor"
+    },
+    {
+      "config": {
+        "max_action_dim": 24
+      },
+      "registry_name": "evo1_pad_action_processor"
+    },
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              24
+            ],
+            "type": "ACTION"
+          },
+          "observation.image.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.images.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.state": {
+            "shape": [
+              24
+            ],
+            "type": "STATE"
+          }
+        },
+        "norm_map": {
+          "ACTION": "MIN_MAX",
+          "STATE": "MIN_MAX",
+          "VISUAL": "IDENTITY"
+        }
+      },
+      "registry_name": "normalizer_processor",
+      "state_file": "policy_preprocessor_step_4_normalizer_processor.safetensors"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/fastwam_post.json
+++ b/tests/artifacts/processors/golden/fastwam_post.json
@@ -1,0 +1,32 @@
+{
+  "name": "policy_postprocessor",
+  "steps": [
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          }
+        },
+        "norm_map": {
+          "ACTION": "MEAN_STD",
+          "STATE": "MEAN_STD",
+          "VISUAL": "IDENTITY"
+        }
+      },
+      "registry_name": "unnormalizer_processor",
+      "state_file": "policy_postprocessor_step_0_unnormalizer_processor.safetensors"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/fastwam_pre.json
+++ b/tests/artifacts/processors/golden/fastwam_pre.json
@@ -1,0 +1,64 @@
+{
+  "name": "policy_preprocessor",
+  "steps": [
+    {
+      "config": {
+        "rename_map": {}
+      },
+      "registry_name": "rename_observations_processor"
+    },
+    {
+      "config": {},
+      "registry_name": "to_batch_processor"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    },
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          },
+          "observation.image.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.images.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.state": {
+            "shape": [
+              6
+            ],
+            "type": "STATE"
+          }
+        },
+        "norm_map": {
+          "ACTION": "MEAN_STD",
+          "STATE": "MEAN_STD",
+          "VISUAL": "IDENTITY"
+        }
+      },
+      "registry_name": "normalizer_processor",
+      "state_file": "policy_preprocessor_step_3_normalizer_processor.safetensors"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/gaussian_actor_post.json
+++ b/tests/artifacts/processors/golden/gaussian_actor_post.json
@@ -1,0 +1,33 @@
+{
+  "name": "policy_postprocessor",
+  "steps": [
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          }
+        },
+        "norm_map": {
+          "ACTION": "MIN_MAX",
+          "ENV": "MIN_MAX",
+          "STATE": "MIN_MAX",
+          "VISUAL": "MEAN_STD"
+        }
+      },
+      "registry_name": "unnormalizer_processor",
+      "state_file": "policy_postprocessor_step_0_unnormalizer_processor.safetensors"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/gaussian_actor_pre.json
+++ b/tests/artifacts/processors/golden/gaussian_actor_pre.json
@@ -1,0 +1,65 @@
+{
+  "name": "policy_preprocessor",
+  "steps": [
+    {
+      "config": {
+        "rename_map": {}
+      },
+      "registry_name": "rename_observations_processor"
+    },
+    {
+      "config": {},
+      "registry_name": "to_batch_processor"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    },
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          },
+          "observation.image.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.images.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.state": {
+            "shape": [
+              6
+            ],
+            "type": "STATE"
+          }
+        },
+        "norm_map": {
+          "ACTION": "MIN_MAX",
+          "ENV": "MIN_MAX",
+          "STATE": "MIN_MAX",
+          "VISUAL": "MEAN_STD"
+        }
+      },
+      "registry_name": "normalizer_processor",
+      "state_file": "policy_preprocessor_step_3_normalizer_processor.safetensors"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/groot_post.json
+++ b/tests/artifacts/processors/golden/groot_post.json
@@ -1,0 +1,23 @@
+{
+  "name": "policy_postprocessor",
+  "steps": [
+    {
+      "config": {
+        "clip_normalized_action": true,
+        "env_action_dim": 6,
+        "libero_gripper_action": false,
+        "libero_gripper_binarize": true,
+        "normalize_min_max": true
+      },
+      "registry_name": "groot_action_unpack_unnormalize_v2",
+      "state_file": "policy_postprocessor_step_0_groot_action_unpack_unnormalize_v2.safetensors"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/groot_pre.json
+++ b/tests/artifacts/processors/golden/groot_pre.json
@@ -1,0 +1,78 @@
+{
+  "name": "policy_preprocessor",
+  "steps": [
+    {
+      "config": {
+        "rename_map": {}
+      },
+      "registry_name": "rename_observations_processor"
+    },
+    {
+      "config": {},
+      "registry_name": "to_batch_processor"
+    },
+    {
+      "config": {
+        "action_horizon": 40,
+        "clip_outliers": true,
+        "embodiment_mapping": {
+          "libero_sim": 2,
+          "new_embodiment": 10,
+          "oxe_droid_relative_eef_relative_joint": 24,
+          "real_g1_relative_eef_relative_joints": 25,
+          "real_r1_pro_sharpa_relative_eef": 26,
+          "real_r1_pro_sharpa_relative_eef_human": 26,
+          "real_r1_pro_sharpa_relative_eef_maxinsights": 26,
+          "real_r1_pro_sharpa_relative_eef_mecka": 26,
+          "simpler_env_google": 0,
+          "simpler_env_widowx": 1,
+          "unitree_g1_full_body_with_waist_height_nav_cmd": 25,
+          "xdof_relative_eef_relative_joint": 27,
+          "xdof_relative_eef_relative_joint_subtask": 27
+        },
+        "embodiment_tag": "new_embodiment",
+        "formalize_language": true,
+        "language_key": "task",
+        "max_action_dim": 132,
+        "max_state_dim": 132,
+        "modality_config": null,
+        "normalize_min_max": true,
+        "raw_stats": null,
+        "state_dropout_prob": 0.0,
+        "state_horizon": 1,
+        "use_percentiles": false,
+        "valid_action_horizon": 40,
+        "video_horizon": null,
+        "video_modality_keys": null
+      },
+      "registry_name": "groot_n1_7_pack_inputs_v1",
+      "state_file": "policy_preprocessor_step_2_groot_n1_7_pack_inputs_v1.safetensors"
+    },
+    {
+      "config": {
+        "crop_fraction": null,
+        "device": "cpu",
+        "image_crop_size": [
+          230,
+          230
+        ],
+        "image_target_size": [
+          256,
+          256
+        ],
+        "letter_box_transform": false,
+        "model_name": "nvidia/Cosmos-Reason2-2B",
+        "shortest_image_edge": null,
+        "use_albumentations": false
+      },
+      "registry_name": "groot_n1_7_vlm_encode_v1"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/lingbot_va_post.json
+++ b/tests/artifacts/processors/golden/lingbot_va_post.json
@@ -1,0 +1,30 @@
+{
+  "name": "policy_postprocessor",
+  "steps": [
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          }
+        },
+        "norm_map": {
+          "ACTION": "QUANTILES"
+        }
+      },
+      "registry_name": "unnormalizer_processor",
+      "state_file": "policy_postprocessor_step_0_unnormalizer_processor.safetensors"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/lingbot_va_pre.json
+++ b/tests/artifacts/processors/golden/lingbot_va_pre.json
@@ -1,0 +1,64 @@
+{
+  "name": "policy_preprocessor",
+  "steps": [
+    {
+      "config": {
+        "rename_map": {}
+      },
+      "registry_name": "rename_observations_processor"
+    },
+    {
+      "config": {},
+      "registry_name": "to_batch_processor"
+    },
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          },
+          "observation.image.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.images.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.state": {
+            "shape": [
+              6
+            ],
+            "type": "STATE"
+          }
+        },
+        "norm_map": {
+          "ACTION": "IDENTITY",
+          "STATE": "IDENTITY",
+          "VISUAL": "IDENTITY"
+        }
+      },
+      "registry_name": "normalizer_processor",
+      "state_file": "policy_preprocessor_step_2_normalizer_processor.safetensors"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/manifest.json
+++ b/tests/artifacts/processors/golden/manifest.json
@@ -1,0 +1,24 @@
+{
+  "covered": [
+    "act",
+    "diffusion",
+    "eo1",
+    "evo1",
+    "fastwam",
+    "gaussian_actor",
+    "groot",
+    "lingbot_va",
+    "molmoact2",
+    "multi_task_dit",
+    "pi0",
+    "pi05",
+    "pi0_fast",
+    "smolvla",
+    "tdmpc",
+    "vla_jepa",
+    "vqbet",
+    "wall_x",
+    "xvla"
+  ],
+  "skipped": {}
+}

--- a/tests/artifacts/processors/golden/molmoact2_post.json
+++ b/tests/artifacts/processors/golden/molmoact2_post.json
@@ -1,0 +1,43 @@
+{
+  "name": "policy_postprocessor",
+  "steps": [
+    {
+      "config": {},
+      "registry_name": "molmoact2_clamp_action"
+    },
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          }
+        },
+        "norm_map": {
+          "ACTION": "QUANTILES",
+          "STATE": "QUANTILES",
+          "VISUAL": "IDENTITY"
+        }
+      },
+      "registry_name": "molmoact2_masked_unnormalizer",
+      "state_file": "policy_postprocessor_step_1_molmoact2_masked_unnormalizer.safetensors"
+    },
+    {
+      "config": {
+        "joint_offsets": null,
+        "joint_signs": null
+      },
+      "registry_name": "molmoact2_action_frame_transform"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/molmoact2_pre.json
+++ b/tests/artifacts/processors/golden/molmoact2_pre.json
@@ -1,0 +1,100 @@
+{
+  "name": "policy_preprocessor",
+  "steps": [
+    {
+      "config": {
+        "rename_map": {}
+      },
+      "registry_name": "rename_observations_processor"
+    },
+    {
+      "config": {},
+      "registry_name": "to_batch_processor"
+    },
+    {
+      "config": {
+        "joint_offsets": null,
+        "joint_signs": null
+      },
+      "registry_name": "molmoact2_state_frame_transform"
+    },
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          },
+          "observation.image.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.images.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.state": {
+            "shape": [
+              6
+            ],
+            "type": "STATE"
+          }
+        },
+        "norm_map": {
+          "ACTION": "QUANTILES",
+          "STATE": "QUANTILES",
+          "VISUAL": "IDENTITY"
+        }
+      },
+      "registry_name": "molmoact2_masked_normalizer",
+      "state_file": "policy_preprocessor_step_3_molmoact2_masked_normalizer.safetensors"
+    },
+    {
+      "config": {},
+      "registry_name": "molmoact2_clamp_normalized"
+    },
+    {
+      "config": {
+        "action_mode": "both",
+        "add_control_tokens": true,
+        "add_setup_tokens": true,
+        "allow_image_key_fallback": true,
+        "checkpoint_force_download": false,
+        "checkpoint_path": "allenai/MolmoAct2",
+        "checkpoint_revision": null,
+        "chunk_size": 30,
+        "control_mode": "",
+        "discrete_action_tokenizer": "allenai/MolmoAct2-FAST-Tokenizer",
+        "env_action_dim": 6,
+        "image_keys": [
+          "observation.image.cam",
+          "observation.images.cam"
+        ],
+        "max_action_dim": 32,
+        "max_sequence_length": null,
+        "normalize_language": true,
+        "num_state_tokens": 256,
+        "setup_type": ""
+      },
+      "registry_name": "molmoact2_pack_inputs"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/multi_task_dit_post.json
+++ b/tests/artifacts/processors/golden/multi_task_dit_post.json
@@ -1,0 +1,32 @@
+{
+  "name": "policy_postprocessor",
+  "steps": [
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          }
+        },
+        "norm_map": {
+          "ACTION": "MIN_MAX",
+          "STATE": "MIN_MAX",
+          "VISUAL": "MEAN_STD"
+        }
+      },
+      "registry_name": "unnormalizer_processor",
+      "state_file": "policy_postprocessor_step_0_unnormalizer_processor.safetensors"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/multi_task_dit_pre.json
+++ b/tests/artifacts/processors/golden/multi_task_dit_pre.json
@@ -1,0 +1,75 @@
+{
+  "name": "policy_preprocessor",
+  "steps": [
+    {
+      "config": {
+        "rename_map": {}
+      },
+      "registry_name": "rename_observations_processor"
+    },
+    {
+      "config": {},
+      "registry_name": "to_batch_processor"
+    },
+    {
+      "config": {
+        "max_length": 77,
+        "padding": "max_length",
+        "padding_side": "right",
+        "task_key": "task",
+        "tokenizer_name": "openai/clip-vit-base-patch16",
+        "truncation": true
+      },
+      "registry_name": "tokenizer_processor"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    },
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          },
+          "observation.image.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.images.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.state": {
+            "shape": [
+              6
+            ],
+            "type": "STATE"
+          }
+        },
+        "norm_map": {
+          "ACTION": "MIN_MAX",
+          "STATE": "MIN_MAX",
+          "VISUAL": "MEAN_STD"
+        }
+      },
+      "registry_name": "normalizer_processor",
+      "state_file": "policy_preprocessor_step_4_normalizer_processor.safetensors"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/pi05_post.json
+++ b/tests/artifacts/processors/golden/pi05_post.json
@@ -1,0 +1,32 @@
+{
+  "name": "policy_postprocessor",
+  "steps": [
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          }
+        },
+        "norm_map": {
+          "ACTION": "QUANTILES",
+          "STATE": "QUANTILES",
+          "VISUAL": "IDENTITY"
+        }
+      },
+      "registry_name": "unnormalizer_processor",
+      "state_file": "policy_postprocessor_step_0_unnormalizer_processor.safetensors"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/pi05_pre.json
+++ b/tests/artifacts/processors/golden/pi05_pre.json
@@ -1,0 +1,79 @@
+{
+  "name": "policy_preprocessor",
+  "steps": [
+    {
+      "config": {
+        "rename_map": {}
+      },
+      "registry_name": "rename_observations_processor"
+    },
+    {
+      "config": {},
+      "registry_name": "to_batch_processor"
+    },
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          },
+          "observation.image.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.images.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.state": {
+            "shape": [
+              6
+            ],
+            "type": "STATE"
+          }
+        },
+        "norm_map": {
+          "ACTION": "QUANTILES",
+          "STATE": "QUANTILES",
+          "VISUAL": "IDENTITY"
+        }
+      },
+      "registry_name": "normalizer_processor",
+      "state_file": "policy_preprocessor_step_2_normalizer_processor.safetensors"
+    },
+    {
+      "config": {},
+      "registry_name": "pi05_prepare_state_tokenizer_processor_step"
+    },
+    {
+      "config": {
+        "max_length": 200,
+        "padding": "max_length",
+        "padding_side": "right",
+        "task_key": "task",
+        "tokenizer_name": "google/paligemma-3b-pt-224",
+        "truncation": true
+      },
+      "registry_name": "tokenizer_processor"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/pi0_fast_post.json
+++ b/tests/artifacts/processors/golden/pi0_fast_post.json
@@ -1,0 +1,32 @@
+{
+  "name": "policy_postprocessor",
+  "steps": [
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          }
+        },
+        "norm_map": {
+          "ACTION": "MEAN_STD",
+          "STATE": "MEAN_STD",
+          "VISUAL": "IDENTITY"
+        }
+      },
+      "registry_name": "unnormalizer_processor",
+      "state_file": "policy_postprocessor_step_0_unnormalizer_processor.safetensors"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/pi0_fast_pre.json
+++ b/tests/artifacts/processors/golden/pi0_fast_pre.json
@@ -1,0 +1,90 @@
+{
+  "name": "policy_preprocessor",
+  "steps": [
+    {
+      "config": {
+        "rename_map": {}
+      },
+      "registry_name": "rename_observations_processor"
+    },
+    {
+      "config": {},
+      "registry_name": "to_batch_processor"
+    },
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          },
+          "observation.image.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.images.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.state": {
+            "shape": [
+              6
+            ],
+            "type": "STATE"
+          }
+        },
+        "norm_map": {
+          "ACTION": "MEAN_STD",
+          "STATE": "MEAN_STD",
+          "VISUAL": "IDENTITY"
+        }
+      },
+      "registry_name": "normalizer_processor",
+      "state_file": "policy_preprocessor_step_2_normalizer_processor.safetensors"
+    },
+    {
+      "config": {},
+      "registry_name": "pi0_fast_prepare_state_tokenizer_processor_step"
+    },
+    {
+      "config": {
+        "max_length": 200,
+        "padding": "max_length",
+        "padding_side": "right",
+        "task_key": "task",
+        "tokenizer_name": "google/paligemma-3b-pt-224",
+        "truncation": true
+      },
+      "registry_name": "tokenizer_processor"
+    },
+    {
+      "config": {
+        "action_tokenizer_name": "lerobot/fast-action-tokenizer",
+        "allow_truncation": true,
+        "fast_skip_tokens": 128,
+        "max_action_tokens": 256,
+        "paligemma_tokenizer_name": "google/paligemma-3b-pt-224",
+        "trust_remote_code": true
+      },
+      "registry_name": "action_tokenizer_processor"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/pi0_post.json
+++ b/tests/artifacts/processors/golden/pi0_post.json
@@ -1,0 +1,32 @@
+{
+  "name": "policy_postprocessor",
+  "steps": [
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          }
+        },
+        "norm_map": {
+          "ACTION": "MEAN_STD",
+          "STATE": "MEAN_STD",
+          "VISUAL": "IDENTITY"
+        }
+      },
+      "registry_name": "unnormalizer_processor",
+      "state_file": "policy_postprocessor_step_0_unnormalizer_processor.safetensors"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/pi0_pre.json
+++ b/tests/artifacts/processors/golden/pi0_pre.json
@@ -1,0 +1,79 @@
+{
+  "name": "policy_preprocessor",
+  "steps": [
+    {
+      "config": {
+        "rename_map": {}
+      },
+      "registry_name": "rename_observations_processor"
+    },
+    {
+      "config": {},
+      "registry_name": "to_batch_processor"
+    },
+    {
+      "config": {},
+      "registry_name": "pi0_new_line_processor"
+    },
+    {
+      "config": {
+        "max_length": 48,
+        "padding": "max_length",
+        "padding_side": "right",
+        "task_key": "task",
+        "tokenizer_name": "google/paligemma-3b-pt-224",
+        "truncation": true
+      },
+      "registry_name": "tokenizer_processor"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    },
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          },
+          "observation.image.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.images.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.state": {
+            "shape": [
+              6
+            ],
+            "type": "STATE"
+          }
+        },
+        "norm_map": {
+          "ACTION": "MEAN_STD",
+          "STATE": "MEAN_STD",
+          "VISUAL": "IDENTITY"
+        }
+      },
+      "registry_name": "normalizer_processor",
+      "state_file": "policy_preprocessor_step_5_normalizer_processor.safetensors"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/smolvla_post.json
+++ b/tests/artifacts/processors/golden/smolvla_post.json
@@ -1,0 +1,32 @@
+{
+  "name": "policy_postprocessor",
+  "steps": [
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          }
+        },
+        "norm_map": {
+          "ACTION": "MEAN_STD",
+          "STATE": "MEAN_STD",
+          "VISUAL": "IDENTITY"
+        }
+      },
+      "registry_name": "unnormalizer_processor",
+      "state_file": "policy_postprocessor_step_0_unnormalizer_processor.safetensors"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/smolvla_pre.json
+++ b/tests/artifacts/processors/golden/smolvla_pre.json
@@ -1,0 +1,79 @@
+{
+  "name": "policy_preprocessor",
+  "steps": [
+    {
+      "config": {
+        "rename_map": {}
+      },
+      "registry_name": "rename_observations_processor"
+    },
+    {
+      "config": {},
+      "registry_name": "to_batch_processor"
+    },
+    {
+      "config": {},
+      "registry_name": "smolvla_new_line_processor"
+    },
+    {
+      "config": {
+        "max_length": 48,
+        "padding": "longest",
+        "padding_side": "right",
+        "task_key": "task",
+        "tokenizer_name": "HuggingFaceTB/SmolVLM2-500M-Video-Instruct",
+        "truncation": true
+      },
+      "registry_name": "tokenizer_processor"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    },
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          },
+          "observation.image.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.images.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.state": {
+            "shape": [
+              6
+            ],
+            "type": "STATE"
+          }
+        },
+        "norm_map": {
+          "ACTION": "MEAN_STD",
+          "STATE": "MEAN_STD",
+          "VISUAL": "IDENTITY"
+        }
+      },
+      "registry_name": "normalizer_processor",
+      "state_file": "policy_preprocessor_step_5_normalizer_processor.safetensors"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/tdmpc_post.json
+++ b/tests/artifacts/processors/golden/tdmpc_post.json
@@ -1,0 +1,33 @@
+{
+  "name": "policy_postprocessor",
+  "steps": [
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          }
+        },
+        "norm_map": {
+          "ACTION": "MIN_MAX",
+          "ENV": "IDENTITY",
+          "STATE": "IDENTITY",
+          "VISUAL": "IDENTITY"
+        }
+      },
+      "registry_name": "unnormalizer_processor",
+      "state_file": "policy_postprocessor_step_0_unnormalizer_processor.safetensors"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/tdmpc_pre.json
+++ b/tests/artifacts/processors/golden/tdmpc_pre.json
@@ -1,0 +1,65 @@
+{
+  "name": "policy_preprocessor",
+  "steps": [
+    {
+      "config": {
+        "rename_map": {}
+      },
+      "registry_name": "rename_observations_processor"
+    },
+    {
+      "config": {},
+      "registry_name": "to_batch_processor"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    },
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          },
+          "observation.image.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.images.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.state": {
+            "shape": [
+              6
+            ],
+            "type": "STATE"
+          }
+        },
+        "norm_map": {
+          "ACTION": "MIN_MAX",
+          "ENV": "IDENTITY",
+          "STATE": "IDENTITY",
+          "VISUAL": "IDENTITY"
+        }
+      },
+      "registry_name": "normalizer_processor",
+      "state_file": "policy_preprocessor_step_3_normalizer_processor.safetensors"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/vla_jepa_post.json
+++ b/tests/artifacts/processors/golden/vla_jepa_post.json
@@ -1,0 +1,66 @@
+{
+  "name": "policy_postprocessor",
+  "steps": [
+    {
+      "config": {},
+      "registry_name": "vla_jepa_clip_actions"
+    },
+    {
+      "config": {},
+      "registry_name": "vla_jepa_pre_snap_gripper"
+    },
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          },
+          "observation.image.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.images.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.state": {
+            "shape": [
+              6
+            ],
+            "type": "STATE"
+          }
+        },
+        "norm_map": {
+          "ACTION": "MIN_MAX",
+          "STATE": "MEAN_STD",
+          "VISUAL": "IDENTITY"
+        }
+      },
+      "registry_name": "unnormalizer_processor",
+      "state_file": "policy_postprocessor_step_2_unnormalizer_processor.safetensors"
+    },
+    {
+      "config": {},
+      "registry_name": "vla_jepa_binarize_gripper"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/vla_jepa_pre.json
+++ b/tests/artifacts/processors/golden/vla_jepa_pre.json
@@ -1,0 +1,64 @@
+{
+  "name": "policy_preprocessor",
+  "steps": [
+    {
+      "config": {
+        "rename_map": {}
+      },
+      "registry_name": "rename_observations_processor"
+    },
+    {
+      "config": {},
+      "registry_name": "to_batch_processor"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    },
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          },
+          "observation.image.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.images.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.state": {
+            "shape": [
+              6
+            ],
+            "type": "STATE"
+          }
+        },
+        "norm_map": {
+          "ACTION": "MIN_MAX",
+          "STATE": "MEAN_STD",
+          "VISUAL": "IDENTITY"
+        }
+      },
+      "registry_name": "normalizer_processor",
+      "state_file": "policy_preprocessor_step_3_normalizer_processor.safetensors"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/vqbet_post.json
+++ b/tests/artifacts/processors/golden/vqbet_post.json
@@ -1,0 +1,32 @@
+{
+  "name": "policy_postprocessor",
+  "steps": [
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          }
+        },
+        "norm_map": {
+          "ACTION": "MIN_MAX",
+          "STATE": "MIN_MAX",
+          "VISUAL": "IDENTITY"
+        }
+      },
+      "registry_name": "unnormalizer_processor",
+      "state_file": "policy_postprocessor_step_0_unnormalizer_processor.safetensors"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/vqbet_pre.json
+++ b/tests/artifacts/processors/golden/vqbet_pre.json
@@ -1,0 +1,64 @@
+{
+  "name": "policy_preprocessor",
+  "steps": [
+    {
+      "config": {
+        "rename_map": {}
+      },
+      "registry_name": "rename_observations_processor"
+    },
+    {
+      "config": {},
+      "registry_name": "to_batch_processor"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    },
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          },
+          "observation.image.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.images.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.state": {
+            "shape": [
+              6
+            ],
+            "type": "STATE"
+          }
+        },
+        "norm_map": {
+          "ACTION": "MIN_MAX",
+          "STATE": "MIN_MAX",
+          "VISUAL": "IDENTITY"
+        }
+      },
+      "registry_name": "normalizer_processor",
+      "state_file": "policy_preprocessor_step_3_normalizer_processor.safetensors"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/wall_x_post.json
+++ b/tests/artifacts/processors/golden/wall_x_post.json
@@ -1,0 +1,32 @@
+{
+  "name": "policy_postprocessor",
+  "steps": [
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          }
+        },
+        "norm_map": {
+          "ACTION": "MEAN_STD",
+          "STATE": "MEAN_STD",
+          "VISUAL": "IDENTITY"
+        }
+      },
+      "registry_name": "unnormalizer_processor",
+      "state_file": "policy_postprocessor_step_0_unnormalizer_processor.safetensors"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/wall_x_pre.json
+++ b/tests/artifacts/processors/golden/wall_x_pre.json
@@ -1,0 +1,68 @@
+{
+  "name": "policy_preprocessor",
+  "steps": [
+    {
+      "config": {
+        "rename_map": {}
+      },
+      "registry_name": "rename_observations_processor"
+    },
+    {
+      "config": {},
+      "registry_name": "to_batch_processor"
+    },
+    {
+      "config": {},
+      "registry_name": "wall_x_task_processor"
+    },
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          },
+          "observation.image.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.images.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.state": {
+            "shape": [
+              6
+            ],
+            "type": "STATE"
+          }
+        },
+        "norm_map": {
+          "ACTION": "MEAN_STD",
+          "STATE": "MEAN_STD",
+          "VISUAL": "IDENTITY"
+        }
+      },
+      "registry_name": "normalizer_processor",
+      "state_file": "policy_preprocessor_step_3_normalizer_processor.safetensors"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/xvla_post.json
+++ b/tests/artifacts/processors/golden/xvla_post.json
@@ -1,0 +1,32 @@
+{
+  "name": "policy_postprocessor",
+  "steps": [
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          }
+        },
+        "norm_map": {
+          "ACTION": "IDENTITY",
+          "STATE": "IDENTITY",
+          "VISUAL": "IDENTITY"
+        }
+      },
+      "registry_name": "unnormalizer_processor",
+      "state_file": "policy_postprocessor_step_0_unnormalizer_processor.safetensors"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/xvla_pre.json
+++ b/tests/artifacts/processors/golden/xvla_pre.json
@@ -1,0 +1,94 @@
+{
+  "name": "policy_preprocessor",
+  "steps": [
+    {
+      "config": {
+        "rename_map": {}
+      },
+      "registry_name": "rename_observations_processor"
+    },
+    {
+      "config": {},
+      "registry_name": "to_batch_processor"
+    },
+    {
+      "config": {
+        "max_length": 64,
+        "padding": "max_length",
+        "padding_side": "right",
+        "task_key": "task",
+        "tokenizer_name": "facebook/bart-large",
+        "truncation": true
+      },
+      "registry_name": "tokenizer_processor"
+    },
+    {
+      "config": {
+        "image_keys": null,
+        "validate_range": true
+      },
+      "registry_name": "xvla_image_to_float"
+    },
+    {
+      "config": {
+        "image_keys": null
+      },
+      "registry_name": "xvla_imagenet_normalize"
+    },
+    {
+      "config": {
+        "domain_id": 0
+      },
+      "registry_name": "xvla_add_domain_id"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    },
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          },
+          "observation.image.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.images.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.state": {
+            "shape": [
+              6
+            ],
+            "type": "STATE"
+          }
+        },
+        "norm_map": {
+          "ACTION": "IDENTITY",
+          "STATE": "IDENTITY",
+          "VISUAL": "IDENTITY"
+        }
+      },
+      "registry_name": "normalizer_processor",
+      "state_file": "policy_preprocessor_step_7_normalizer_processor.safetensors"
+    }
+  ]
+}

--- a/tests/policies/evo1/test_evo1.py
+++ b/tests/policies/evo1/test_evo1.py
@@ -36,29 +36,20 @@ from lerobot.policies.evo1.processor_evo1 import (
     Evo1PadStateProcessorStep,
     evo1_batch_to_transition,
     make_evo1_pre_post_processors,
-    reconcile_evo1_processors,
 )
-from lerobot.policies.factory import get_policy_class, make_policy_config
+from lerobot.policies.factory import get_policy_class, make_policy_config, make_pre_post_processors
 from lerobot.policies.rtc.configuration_rtc import RTCConfig
 from lerobot.policies.rtc.modeling_rtc import RTCProcessor
 from lerobot.processor import (
     DeviceProcessorStep,
     NormalizerProcessorStep,
-    PolicyProcessorPipeline,
+    ProcessorBuildContext,
     UnnormalizerProcessorStep,
-)
-from lerobot.processor.converters import (
-    batch_to_transition,
-    policy_action_to_transition,
-    transition_to_batch,
-    transition_to_policy_action,
 )
 from lerobot.utils.constants import (
     ACTION,
     OBS_IMAGES,
     OBS_STATE,
-    POLICY_POSTPROCESSOR_DEFAULT_NAME,
-    POLICY_PREPROCESSOR_DEFAULT_NAME,
 )
 
 STATE_DIM = 4
@@ -398,7 +389,9 @@ def test_evo1_policy_processors_pad_state_crop_action_and_binarize_gripper():
     )
     stats = make_stats(action_dim=libero_action_dim)
 
-    preprocessor, postprocessor = make_evo1_pre_post_processors(config, dataset_stats=stats)
+    preprocessor, postprocessor = make_evo1_pre_post_processors(
+        config, ProcessorBuildContext(dataset_stats=stats)
+    )
 
     assert isinstance(preprocessor.steps[2], Evo1PadStateProcessorStep)
     assert isinstance(preprocessor.steps[3], Evo1PadActionProcessorStep)
@@ -446,7 +439,9 @@ def test_evo1_policy_processors_pad_state_crop_action_and_binarize_gripper():
 
 def test_evo1_postprocessor_returns_float32_for_bf16_actions():
     config = make_config()
-    _preprocessor, postprocessor = make_evo1_pre_post_processors(config, dataset_stats=make_stats())
+    _preprocessor, postprocessor = make_evo1_pre_post_processors(
+        config, ProcessorBuildContext(dataset_stats=make_stats())
+    )
 
     processed = postprocessor(torch.zeros(2, MAX_ACTION_DIM, dtype=torch.bfloat16))
     assert processed.dtype == torch.float32
@@ -454,26 +449,18 @@ def test_evo1_postprocessor_returns_float32_for_bf16_actions():
 
 def test_evo1_processor_save_load_round_trip_applies_config_overrides(tmp_path):
     train_config = make_config()
-    preprocessor, postprocessor = make_evo1_pre_post_processors(train_config, dataset_stats=make_stats())
+    preprocessor, postprocessor = make_evo1_pre_post_processors(
+        train_config, ProcessorBuildContext(dataset_stats=make_stats())
+    )
     preprocessor.save_pretrained(tmp_path)
     postprocessor.save_pretrained(tmp_path)
 
-    loaded_pre = PolicyProcessorPipeline.from_pretrained(
-        tmp_path,
-        config_filename=f"{POLICY_PREPROCESSOR_DEFAULT_NAME}.json",
-        to_transition=batch_to_transition,
-        to_output=transition_to_batch,
-    )
-    loaded_post = PolicyProcessorPipeline.from_pretrained(
-        tmp_path,
-        config_filename=f"{POLICY_POSTPROCESSOR_DEFAULT_NAME}.json",
-        to_transition=policy_action_to_transition,
-        to_output=transition_to_policy_action,
-    )
-
-    # Simulate eval-time CLI overrides applied on top of the loaded pipelines.
+    # Eval-time CLI overrides: these reach the pipeline because it is rebuilt from the config, with
+    # only the checkpoint's tensor state loaded into it.
     eval_config = make_config(binarize_gripper=True, postprocess_action_dim=ACTION_DIM)
-    loaded_pre, loaded_post = reconcile_evo1_processors(eval_config, loaded_pre, loaded_post)
+    loaded_pre, loaded_post = make_pre_post_processors(
+        eval_config, pretrained_path=str(tmp_path), context=ProcessorBuildContext()
+    )
 
     assert loaded_pre.to_transition is evo1_batch_to_transition
     assert sum(isinstance(step, Evo1ActionProcessorStep) for step in loaded_post.steps) == 1
@@ -496,42 +483,27 @@ def test_evo1_processor_save_load_round_trip_applies_config_overrides(tmp_path):
     assert "embodiment_id" in processed
 
 
-def test_reconcile_evo1_processors_repads_overridden_stats(tmp_path):
-    """Loading a checkpoint and injecting raw (unpadded) dataset stats must be re-padded.
+def test_evo1_finetune_from_checkpoint_pads_raw_dataset_stats(tmp_path):
+    """Raw (unpadded) dataset stats must be padded to EVO1's fixed widths. Regression test for #4006.
 
-    Regression test: lerobot-train passes the raw dataset stats as normalizer/unnormalizer
-    overrides when resuming from a checkpoint (e.g. stage2 from a stage1 checkpoint). Those stats
-    are at the dataset dims (e.g. LIBERO state=8/action=7), but EVO1 pads state/action to
-    max_state_dim/max_action_dim before normalization, so reconcile_evo1_processors must re-pad the
-    stats or normalization crashes with a shape mismatch.
+    Finetuning from a checkpoint supplies the new dataset's raw stats, which are at the dataset dims
+    (LIBERO state=8/action=7). EVO1 pads state/action to max_state_dim/max_action_dim before
+    normalization, so unpadded stats crash with a shape mismatch. The factory owns the padding, so it
+    applies on this path as much as on a from-scratch build.
     """
     config = make_config()
-    preprocessor, postprocessor = make_evo1_pre_post_processors(config, dataset_stats=make_stats())
+    preprocessor, postprocessor = make_evo1_pre_post_processors(
+        config, ProcessorBuildContext(dataset_stats=make_stats())
+    )
     preprocessor.save_pretrained(tmp_path)
     postprocessor.save_pretrained(tmp_path)
 
-    # Reload with the generic override path injecting raw, unpadded dataset stats.
-    raw_stats = make_stats()
-    loaded_pre = PolicyProcessorPipeline.from_pretrained(
-        tmp_path,
-        config_filename=f"{POLICY_PREPROCESSOR_DEFAULT_NAME}.json",
-        overrides={"normalizer_processor": {"stats": raw_stats}},
-        to_transition=batch_to_transition,
-        to_output=transition_to_batch,
+    # The finetune case: the caller hands over raw, unpadded dataset stats.
+    loaded_pre, loaded_post = make_pre_post_processors(
+        config,
+        pretrained_path=str(tmp_path),
+        context=ProcessorBuildContext(dataset_stats=make_stats()),
     )
-    loaded_post = PolicyProcessorPipeline.from_pretrained(
-        tmp_path,
-        config_filename=f"{POLICY_POSTPROCESSOR_DEFAULT_NAME}.json",
-        overrides={"unnormalizer_processor": {"stats": raw_stats}},
-        to_transition=policy_action_to_transition,
-        to_output=transition_to_policy_action,
-    )
-
-    # Sanity: the override really injected unpadded stats before reconciliation.
-    normalizer = next(step for step in loaded_pre.steps if isinstance(step, NormalizerProcessorStep))
-    assert normalizer._tensor_stats[OBS_STATE]["min"].shape == (STATE_DIM,)
-
-    loaded_pre, loaded_post = reconcile_evo1_processors(config, loaded_pre, loaded_post)
 
     normalizer = next(step for step in loaded_pre.steps if isinstance(step, NormalizerProcessorStep))
     unnormalizer = next(step for step in loaded_post.steps if isinstance(step, UnnormalizerProcessorStep))
@@ -553,7 +525,9 @@ def test_reconcile_evo1_processors_repads_overridden_stats(tmp_path):
 def test_evo1_policy_forward_and_inference_use_batched_embedding(monkeypatch):
     monkeypatch.setattr(modeling_evo1, "Evo1Model", DummyEvo1Model)
     policy = modeling_evo1.Evo1Policy(make_config())
-    preprocessor, _postprocessor = make_evo1_pre_post_processors(policy.config, dataset_stats=make_stats())
+    preprocessor, _postprocessor = make_evo1_pre_post_processors(
+        policy.config, ProcessorBuildContext(dataset_stats=make_stats())
+    )
     training_batch = preprocessor(make_batch(include_action=True))
 
     assert training_batch[ACTION].shape == (2, CHUNK_SIZE, MAX_ACTION_DIM)

--- a/tests/policies/test_pretrained_interactive_contracts.py
+++ b/tests/policies/test_pretrained_interactive_contracts.py
@@ -86,6 +86,25 @@ def test_drop_queued_actions_forces_fresh_forward_on_real_chunking_policy():
     assert len(forwards) == 2, "drop_queued_actions() did not force a fresh forward"
 
 
+def test_queued_action_count_tracks_the_real_chunking_policy_queue():
+    """The sync engine's relative-action anchor hold reads this count directly: it must
+    reflect the same queue drop_queued_actions() clears, at every point in the chunk cycle."""
+    policy = _tiny_act_policy()
+    policy.reset()
+    batch = {OBS_STATE: torch.zeros(1, 4), OBS_ENV_STATE: torch.zeros(1, 4)}
+
+    assert policy.queued_action_count() == 0  # nothing computed yet
+
+    with torch.no_grad():
+        policy.select_action(batch)  # fills the queue with a fresh chunk, pops one
+    assert policy.queued_action_count() == 7  # chunk_size=8 minus the one just served
+
+    with torch.no_grad():
+        for _ in range(7):
+            policy.select_action(batch)
+    assert policy.queued_action_count() == 0  # queue drained -> next tick predicts fresh
+
+
 @pytest.mark.parametrize("via_mixin", [False, True], ids=["own-method", "mixin-supplied"])
 def test_generate_text_override_without_flag_fails_at_class_definition(via_mixin):
     """Without the guard the text head exists but supports_text_generation() stays False, so

--- a/tests/policies/test_processor_authority.py
+++ b/tests/policies/test_processor_authority.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""The config-vs-checkpoint authority rule for policy processor pipelines.
+
+`make_pre_post_processors` always builds structure from the policy config and takes only tensor state
+from a checkpoint. These tests pin both halves of that rule, plus the one value deliberately carried
+over from the checkpoint (the rename map).
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+
+from lerobot.configs.policies import PreTrainedConfig
+from lerobot.configs.types import FeatureType, PolicyFeature
+from lerobot.policies.factory import make_policy_config, make_pre_post_processors
+from lerobot.processor import NormalizerProcessorStep, ProcessorBuildContext, UnnormalizerProcessorStep
+from lerobot.utils.constants import (
+    ACTION,
+    OBS_IMAGE,
+    OBS_STATE,
+    POLICY_POSTPROCESSOR_DEFAULT_NAME,
+    POLICY_PREPROCESSOR_DEFAULT_NAME,
+)
+
+ARTIFACTS_DIR = Path(__file__).parents[1] / "artifacts" / "processors"
+sys.path.insert(0, str(ARTIFACTS_DIR))
+from generate_golden_processor_configs import (  # noqa: E402
+    _build_configs,
+    _is_missing_optional_dependency,
+)
+
+PRE_FILENAME = f"{POLICY_PREPROCESSOR_DEFAULT_NAME}.json"
+POST_FILENAME = f"{POLICY_POSTPROCESSOR_DEFAULT_NAME}.json"
+
+STATE_DIM = 6
+ACTION_DIM = 6
+
+
+def _act_config(**overrides):
+    config = make_policy_config("act", push_to_hub=False)
+    config.input_features = {
+        OBS_STATE: PolicyFeature(type=FeatureType.STATE, shape=(STATE_DIM,)),
+        f"{OBS_IMAGE}.cam": PolicyFeature(type=FeatureType.VISUAL, shape=(3, 96, 96)),
+    }
+    config.output_features = {ACTION: PolicyFeature(type=FeatureType.ACTION, shape=(ACTION_DIM,))}
+    config.device = "cpu"
+    for key, value in overrides.items():
+        setattr(config, key, value)
+    return config
+
+
+def _stats(fill: float) -> dict[str, dict[str, torch.Tensor]]:
+    """Stats whose values identify which source they came from."""
+
+    def block(shape):
+        return {
+            "mean": torch.full(shape, fill),
+            "std": torch.ones(shape),
+            "min": torch.full(shape, -fill),
+            "max": torch.full(shape, fill),
+        }
+
+    return {
+        OBS_STATE: block((STATE_DIM,)),
+        ACTION: block((ACTION_DIM,)),
+        f"{OBS_IMAGE}.cam": block((3, 1, 1)),
+    }
+
+
+def _save_checkpoint(tmp_path: Path, config, stats) -> None:
+    preprocessor, postprocessor = make_pre_post_processors(
+        config, context=ProcessorBuildContext(dataset_stats=stats)
+    )
+    preprocessor.save_pretrained(tmp_path, config_filename=PRE_FILENAME)
+    postprocessor.save_pretrained(tmp_path, config_filename=POST_FILENAME)
+
+
+def _normalizer(pipeline):
+    return next(step for step in pipeline.steps if isinstance(step, NormalizerProcessorStep))
+
+
+def _unnormalizer(pipeline):
+    return next(step for step in pipeline.steps if isinstance(step, UnnormalizerProcessorStep))
+
+
+def test_config_beats_checkpoint_for_structure(tmp_path):
+    """A config value changed since the checkpoint was written takes effect on load.
+
+    Under the old deserializing loader the saved pipeline was authoritative, so a `--policy.*` flag
+    that should reconfigure a step silently did nothing.
+    """
+    if not torch.cuda.is_available():
+        pytest.skip("needs a second real device to tell the config's choice from the checkpoint's")
+
+    _save_checkpoint(tmp_path, _act_config(device="cpu"), _stats(1.0))
+
+    reloaded, _ = make_pre_post_processors(
+        _act_config(device="cuda"), pretrained_path=str(tmp_path), context=ProcessorBuildContext()
+    )
+
+    device_steps = [step for step in reloaded.steps if getattr(step, "device", None) is not None]
+    assert device_steps, "expected the preprocessor to contain a device step"
+    assert all("cuda" in str(step.device) for step in device_steps)
+
+
+def test_finetune_stats_from_dataset_beat_checkpoint(tmp_path):
+    """Supplying dataset stats makes the dataset authoritative — the finetune case."""
+    _save_checkpoint(tmp_path, _act_config(), _stats(1.0))
+
+    reloaded, _ = make_pre_post_processors(
+        _act_config(),
+        pretrained_path=str(tmp_path),
+        context=ProcessorBuildContext(dataset_stats=_stats(9.0)),
+    )
+
+    assert torch.allclose(
+        _normalizer(reloaded)._tensor_stats[OBS_STATE]["mean"], torch.full((STATE_DIM,), 9.0)
+    )
+
+
+def test_resume_stats_come_from_checkpoint(tmp_path):
+    """Omitting dataset stats keeps the checkpoint's — the eval and resume case."""
+    _save_checkpoint(tmp_path, _act_config(), _stats(1.0))
+
+    pre, post = make_pre_post_processors(
+        _act_config(), pretrained_path=str(tmp_path), context=ProcessorBuildContext()
+    )
+
+    assert torch.allclose(_normalizer(pre)._tensor_stats[OBS_STATE]["mean"], torch.full((STATE_DIM,), 1.0))
+    assert torch.allclose(_unnormalizer(post)._tensor_stats[ACTION]["mean"], torch.full((ACTION_DIM,), 1.0))
+
+
+def test_rename_map_is_carried_over_from_the_checkpoint(tmp_path):
+    """A rename map exists only on the CLI, so rebuilding must not drop the checkpoint's."""
+    _save_checkpoint(tmp_path, _act_config(rename_map={"left": "cam"}), _stats(1.0))
+
+    config = _act_config()
+    assert config.rename_map == {}
+    reloaded, _ = make_pre_post_processors(
+        config, pretrained_path=str(tmp_path), context=ProcessorBuildContext()
+    )
+
+    rename_step = reloaded.steps[0]
+    assert rename_step.rename_map == {"left": "cam"}
+
+
+def test_rename_map_from_the_config_wins(tmp_path):
+    """An explicitly supplied rename map is not overwritten by the checkpoint's."""
+    _save_checkpoint(tmp_path, _act_config(rename_map={"left": "cam"}), _stats(1.0))
+
+    reloaded, _ = make_pre_post_processors(
+        _act_config(rename_map={"right": "cam"}),
+        pretrained_path=str(tmp_path),
+        context=ProcessorBuildContext(),
+    )
+
+    assert reloaded.steps[0].rename_map == {"right": "cam"}
+
+
+def test_legacy_step_overrides_still_apply_with_a_deprecation_warning(tmp_path):
+    """Out-of-tree callers passing the old override dicts keep working."""
+    _save_checkpoint(tmp_path, _act_config(), _stats(1.0))
+
+    with pytest.warns(DeprecationWarning, match="Step-level processor overrides"):
+        reloaded, _ = make_pre_post_processors(
+            _act_config(),
+            pretrained_path=str(tmp_path),
+            preprocessor_overrides={
+                "rename_observations_processor": {"rename_map": {"left": "cam"}},
+                # Shape is owned by the policy factory now; this key must be ignored, not fatal.
+                "normalizer_processor": {"features": {}},
+            },
+        )
+
+    assert reloaded.steps[0].rename_map == {"left": "cam"}
+    # The ignored key must not have wiped the features the factory computed.
+    assert _normalizer(reloaded).features
+
+
+def test_checkpoint_state_for_an_unbuilt_step_is_not_silently_dropped(tmp_path):
+    """The one failure mode that would otherwise surface as bad numbers rather than an error."""
+    _save_checkpoint(tmp_path, _act_config(), _stats(1.0))
+
+    # Drop the action feature so the config builds an unnormalizer with no ACTION stats to load,
+    # then hand the postprocessor's checkpoint to a pipeline that has no unnormalizer at all.
+    pre_config = json.loads((tmp_path / PRE_FILENAME).read_text())
+    pre_config["steps"].append(
+        {"registry_name": "unnormalizer_processor", "config": {}, "state_file": "nonexistent.safetensors"}
+    )
+    (tmp_path / PRE_FILENAME).write_text(json.dumps(pre_config))
+
+    with pytest.raises(ValueError, match="silently discarded"):
+        make_pre_post_processors(
+            _act_config(), pretrained_path=str(tmp_path), context=ProcessorBuildContext()
+        )
+
+
+def test_state_loads_when_the_checkpoints_step_indices_have_shifted(tmp_path):
+    """State filenames embed the step index, so removing a step renames every later state file.
+
+    Real case: pi0 pipelines used to carry a disabled `relative_actions_processor` ahead of the
+    normalizer, putting its stats in `..._step_6_normalizer_processor.safetensors`. Rebuilding from
+    the config now produces that normalizer at index 5. Pairing saved entries to built steps by step
+    key rather than by position is what keeps those stats landing on the right step.
+    """
+    _save_checkpoint(tmp_path, _act_config(), _stats(1.0))
+
+    # Simulate the checkpoint having been written with an extra stateless step up front.
+    config_path = tmp_path / PRE_FILENAME
+    saved = json.loads(config_path.read_text())
+    normalizer_entry = next(s for s in saved["steps"] if s["registry_name"] == "normalizer_processor")
+    old_state_file = normalizer_entry["state_file"]
+    shifted_state_file = old_state_file.replace("_step_3_", "_step_9_")
+    (tmp_path / shifted_state_file).write_bytes((tmp_path / old_state_file).read_bytes())
+    normalizer_entry["state_file"] = shifted_state_file
+    saved["steps"].insert(0, {"registry_name": "identity_processor", "config": {}})
+    config_path.write_text(json.dumps(saved))
+
+    pre, _post = make_pre_post_processors(
+        _act_config(), pretrained_path=str(tmp_path), context=ProcessorBuildContext()
+    )
+
+    # The stats still land, despite the index in the filename not matching the rebuilt position.
+    assert torch.allclose(_normalizer(pre)._tensor_stats[OBS_STATE]["mean"], torch.full((STATE_DIM,), 1.0))
+
+
+@pytest.mark.parametrize("policy_type", sorted(PreTrainedConfig.get_known_choices()))
+def test_every_policy_builds_from_config_alone(policy_type):
+    """Every policy must build on the path eval and inference now use: config + bare context.
+
+    This is the de-risking test for the policies the refactor does not touch.
+    """
+    try:
+        _build_configs(policy_type)
+    except Exception as exc:  # noqa: BLE001
+        reason = f"{type(exc).__name__}: {exc}"
+        if _is_missing_optional_dependency(reason):
+            pytest.skip(f"{policy_type} is not installed in this environment")
+        raise
+
+
+@pytest.mark.parametrize(
+    "policy_type", sorted(json.loads((ARTIFACTS_DIR / "golden" / "manifest.json").read_text())["covered"])
+)
+def test_serialized_pipeline_matches_the_golden_fixture(policy_type):
+    """Rebuilding from the config must reproduce the structure captured before the refactor."""
+    try:
+        built = _build_configs(policy_type)
+    except Exception as exc:  # noqa: BLE001
+        reason = f"{type(exc).__name__}: {exc}"
+        if _is_missing_optional_dependency(reason):
+            pytest.skip(f"{policy_type} is not installed in this environment")
+        raise
+
+    for role, config in built.items():
+        expected = json.loads((ARTIFACTS_DIR / "golden" / f"{policy_type}_{role}.json").read_text())
+        assert config == expected, f"{policy_type} {role} pipeline drifted from its golden fixture"

--- a/tests/policies/test_relative_actions.py
+++ b/tests/policies/test_relative_actions.py
@@ -346,3 +346,10 @@ def test_state_not_modified_by_relative_processor(dataset, action_dim):
 
     result_state = result[TransitionKey.OBSERVATION][OBS_STATE]
     torch.testing.assert_close(result_state, original_state)
+
+
+def test_cached_anchor_not_in_config():
+    """The cached anchor is ephemeral runtime state and must not leak into the config."""
+    step = RelativeActionsProcessorStep(enabled=True)
+    step.set_cached_state(torch.tensor([[1.0, 2.0, 3.0, 4.0]]))
+    assert set(step.get_config()) == {"enabled", "exclude_joints", "action_names"}

--- a/tests/processor/test_pipeline_from_pretrained_helpers.py
+++ b/tests/processor/test_pipeline_from_pretrained_helpers.py
@@ -448,3 +448,157 @@ def test_simplified_three_way_loading():
         )
         assert loaded_config["name"] == "DirectoryTest"
         assert base_path == tmp_path
+
+
+# load_pretrained_state Tests
+#
+# `load_pretrained_state` is the counterpart to `from_pretrained` for callers that own the
+# pipeline's structure: the steps stay as built from the live policy config and only tensors come
+# from the checkpoint. These tests pin the pairing rule, which is what lets a pipeline gain or lose
+# a step relative to its checkpoint without the state landing on the wrong step.
+
+
+def _stateful_step_cls(registry_name: str):
+    """A step carrying one named tensor, so state landing on the wrong step is observable."""
+
+    @ProcessorStepRegistry.register(registry_name)
+    class CountingStep(ProcessorStep):
+        def __init__(self, value: float = 0.0):
+            self.value = float(value)
+
+        def __call__(self, transition: EnvTransition) -> EnvTransition:
+            return transition
+
+        def transform_features(
+            self, features: dict[PipelineFeatureType, dict[str, PolicyFeature]]
+        ) -> dict[PipelineFeatureType, dict[str, PolicyFeature]]:
+            return features
+
+        def get_config(self) -> dict[str, float]:
+            return {"value": self.value}
+
+        def state_dict(self) -> dict[str, torch.Tensor]:
+            return {"value": torch.tensor([self.value])}
+
+        def load_state_dict(self, state: dict[str, torch.Tensor]) -> None:
+            self.value = float(state["value"].item())
+
+    return CountingStep
+
+
+def _stateless_step_cls(registry_name: str):
+    @ProcessorStepRegistry.register(registry_name)
+    class MarkerStep(ProcessorStep):
+        def __call__(self, transition: EnvTransition) -> EnvTransition:
+            return transition
+
+        def transform_features(
+            self, features: dict[PipelineFeatureType, dict[str, PolicyFeature]]
+        ) -> dict[PipelineFeatureType, dict[str, PolicyFeature]]:
+            return features
+
+    return MarkerStep
+
+
+def test_load_pretrained_state_round_trip():
+    """State saved by one pipeline lands on a structurally identical rebuild."""
+    step_cls = _stateful_step_cls("round_trip_stateful_step")
+    try:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            saved = DataProcessorPipeline(steps=[step_cls(value=7.0)], name="proc")
+            saved.save_pretrained(tmp_dir, config_filename="processor.json")
+
+            rebuilt = DataProcessorPipeline(steps=[step_cls(value=0.0)], name="proc")
+            rebuilt.load_pretrained_state(tmp_dir, "processor.json")
+
+            assert rebuilt.steps[0].value == 7.0
+    finally:
+        ProcessorStepRegistry.unregister("round_trip_stateful_step")
+
+
+def test_load_pretrained_state_tolerates_inserted_step():
+    """A step added since the checkpoint must not shift state onto the wrong step.
+
+    State filenames embed the step index, so the stateful step sits at index 0 in the checkpoint and
+    index 1 in the rebuild. Pairing by step key rather than position is what makes this work.
+    """
+    step_cls = _stateful_step_cls("insertion_stateful_step")
+    marker_cls = _stateless_step_cls("insertion_marker_step")
+    try:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            saved = DataProcessorPipeline(steps=[step_cls(value=3.0)], name="proc")
+            saved.save_pretrained(tmp_dir, config_filename="processor.json")
+
+            # The new stateless step is prepended, so every later index shifts by one.
+            rebuilt = DataProcessorPipeline(steps=[marker_cls(), step_cls(value=0.0)], name="proc")
+            rebuilt.load_pretrained_state(tmp_dir, "processor.json")
+
+            assert rebuilt.steps[1].value == 3.0
+    finally:
+        ProcessorStepRegistry.unregister("insertion_stateful_step")
+        ProcessorStepRegistry.unregister("insertion_marker_step")
+
+
+def test_load_pretrained_state_pairs_duplicate_keys_by_ordinal():
+    """Two steps sharing a registry name each get their own state, in order."""
+    step_cls = _stateful_step_cls("duplicate_stateful_step")
+    try:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            saved = DataProcessorPipeline(steps=[step_cls(value=1.0), step_cls(value=2.0)], name="proc")
+            saved.save_pretrained(tmp_dir, config_filename="processor.json")
+
+            rebuilt = DataProcessorPipeline(steps=[step_cls(value=0.0), step_cls(value=0.0)], name="proc")
+            rebuilt.load_pretrained_state(tmp_dir, "processor.json")
+
+            assert [step.value for step in rebuilt.steps] == [1.0, 2.0]
+    finally:
+        ProcessorStepRegistry.unregister("duplicate_stateful_step")
+
+
+def test_load_pretrained_state_raises_on_orphaned_state():
+    """Checkpoint tensors that no built step claims must fail loudly, not vanish."""
+    step_cls = _stateful_step_cls("orphan_stateful_step")
+    marker_cls = _stateless_step_cls("orphan_marker_step")
+    try:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            saved = DataProcessorPipeline(steps=[step_cls(value=5.0)], name="proc")
+            saved.save_pretrained(tmp_dir, config_filename="processor.json")
+
+            rebuilt = DataProcessorPipeline(steps=[marker_cls()], name="proc")
+            with pytest.raises(ValueError, match="orphan_stateful_step.*silently discarded"):
+                rebuilt.load_pretrained_state(tmp_dir, "processor.json")
+    finally:
+        ProcessorStepRegistry.unregister("orphan_stateful_step")
+        ProcessorStepRegistry.unregister("orphan_marker_step")
+
+
+def test_load_pretrained_state_ignores_dropped_stateless_step():
+    """A stateless step the config no longer builds is not an error: nothing is lost."""
+    marker_cls = _stateless_step_cls("dropped_marker_step")
+    step_cls = _stateful_step_cls("dropped_stateful_step")
+    try:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            saved = DataProcessorPipeline(steps=[marker_cls(), step_cls(value=4.0)], name="proc")
+            saved.save_pretrained(tmp_dir, config_filename="processor.json")
+
+            rebuilt = DataProcessorPipeline(steps=[step_cls(value=0.0)], name="proc")
+            rebuilt.load_pretrained_state(tmp_dir, "processor.json")
+
+            assert rebuilt.steps[0].value == 4.0
+    finally:
+        ProcessorStepRegistry.unregister("dropped_marker_step")
+        ProcessorStepRegistry.unregister("dropped_stateful_step")
+
+
+def test_load_pretrained_state_suggests_migration_for_legacy_checkpoint():
+    """Pre-processor-era checkpoints keep their actionable migration error on this path too."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir)
+        # A legacy policy checkpoint: JSON present, but none of it is a processor config.
+        (tmp_path / "config.json").write_text(
+            json.dumps({"type": "act", "input_features": {}, "output_features": {}})
+        )
+
+        pipeline = DataProcessorPipeline(steps=[], name="proc")
+        with pytest.raises(ProcessorMigrationError, match="migrate_policy_normalization.py"):
+            pipeline.load_pretrained_state(tmp_path, "processor.json")

--- a/tests/processor/test_processor_features.py
+++ b/tests/processor/test_processor_features.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Cross-cutting pipeline features, and relative actions as the first of them.
+
+The headline property: a behaviour like relative actions works on a policy that contains no code
+referring to it. ACT is the test subject precisely because it knows nothing about relative actions.
+"""
+
+import pytest
+import torch
+
+from lerobot.configs.types import FeatureType, PolicyFeature
+from lerobot.policies.factory import make_policy_config, make_pre_post_processors
+from lerobot.processor import (
+    AbsoluteActionsProcessorStep,
+    AnchoredStep,
+    IdentityProcessorStep,
+    NormalizerProcessorStep,
+    ProcessorBuildContext,
+    ProcessorFeature,
+    RelativeActionsProcessorStep,
+    UnnormalizerProcessorStep,
+    splice_anchored_steps,
+)
+from lerobot.utils.constants import ACTION, OBS_IMAGE, OBS_STATE
+
+STATE_DIM = 4
+ACTION_DIM = 4
+
+
+def _act_config(**overrides):
+    config = make_policy_config("act", push_to_hub=False)
+    config.input_features = {
+        OBS_STATE: PolicyFeature(type=FeatureType.STATE, shape=(STATE_DIM,)),
+        f"{OBS_IMAGE}.cam": PolicyFeature(type=FeatureType.VISUAL, shape=(3, 32, 32)),
+    }
+    config.output_features = {ACTION: PolicyFeature(type=FeatureType.ACTION, shape=(ACTION_DIM,))}
+    config.device = "cpu"
+    for key, value in overrides.items():
+        setattr(config, key, value)
+    return config
+
+
+def _stats():
+    def block(shape):
+        return {"mean": torch.zeros(shape), "std": torch.ones(shape)}
+
+    return {
+        OBS_STATE: block((STATE_DIM,)),
+        ACTION: block((ACTION_DIM,)),
+        f"{OBS_IMAGE}.cam": block((3, 1, 1)),
+    }
+
+
+def _step_names(pipeline):
+    return [type(step).__name__ for step in pipeline.steps]
+
+
+def test_act_gets_relative_actions_without_any_act_specific_code():
+    """The acceptance test for 'policy-independent': ACT has no relative-action code at all."""
+    pre, post = make_pre_post_processors(
+        _act_config(use_relative_actions=True),
+        context=ProcessorBuildContext(dataset_stats=_stats()),
+    )
+
+    assert "RelativeActionsProcessorStep" in _step_names(pre)
+    assert "AbsoluteActionsProcessorStep" in _step_names(post)
+
+
+def test_relative_actions_are_absent_when_not_enabled():
+    """The default must leave every existing pipeline byte-identical."""
+    pre, post = make_pre_post_processors(_act_config(), context=ProcessorBuildContext(dataset_stats=_stats()))
+
+    assert "RelativeActionsProcessorStep" not in _step_names(pre)
+    assert "AbsoluteActionsProcessorStep" not in _step_names(post)
+
+
+def test_relative_step_is_anchored_before_normalization():
+    """Relative offsets must be computed on raw values, so ordering here is load-bearing."""
+    pre, post = make_pre_post_processors(
+        _act_config(use_relative_actions=True),
+        context=ProcessorBuildContext(dataset_stats=_stats()),
+    )
+
+    pre_names = _step_names(pre)
+    assert pre_names.index("RelativeActionsProcessorStep") < pre_names.index("NormalizerProcessorStep")
+
+    post_names = _step_names(post)
+    assert post_names.index("AbsoluteActionsProcessorStep") > post_names.index("UnnormalizerProcessorStep")
+
+
+def test_absolute_step_reference_is_live_without_any_relinking():
+    """The cross-pipeline reference is not serializable; building both together avoids re-linking."""
+    pre, post = make_pre_post_processors(
+        _act_config(use_relative_actions=True),
+        context=ProcessorBuildContext(dataset_stats=_stats()),
+    )
+
+    relative = next(step for step in pre.steps if isinstance(step, RelativeActionsProcessorStep))
+    absolute = next(step for step in post.steps if isinstance(step, AbsoluteActionsProcessorStep))
+    assert absolute.relative_step is relative
+
+
+def test_relative_actions_survive_a_checkpoint_round_trip(tmp_path):
+    """An old checkpoint has no such step; rebuilding from the config restores it."""
+    config = _act_config(use_relative_actions=True)
+    pre, post = make_pre_post_processors(config, context=ProcessorBuildContext(dataset_stats=_stats()))
+    pre.save_pretrained(tmp_path, config_filename="policy_preprocessor.json")
+    post.save_pretrained(tmp_path, config_filename="policy_postprocessor.json")
+
+    reloaded_pre, reloaded_post = make_pre_post_processors(
+        config, pretrained_path=str(tmp_path), context=ProcessorBuildContext()
+    )
+
+    assert "RelativeActionsProcessorStep" in _step_names(reloaded_pre)
+    relative = next(step for step in reloaded_pre.steps if isinstance(step, RelativeActionsProcessorStep))
+    absolute = next(step for step in reloaded_post.steps if isinstance(step, AbsoluteActionsProcessorStep))
+    assert absolute.relative_step is relative
+
+
+def test_finetuning_a_checkpoint_that_predates_the_step_does_not_raise(tmp_path):
+    """The finetune failure this refactor removes: the step is absent from the saved pipeline.
+
+    Previously `lerobot-train` emitted a `relative_actions_processor` override and
+    `_validate_overrides_used` raised `KeyError` because the checkpoint had no such step.
+    """
+    # A checkpoint written before relative actions existed for this policy.
+    plain = _act_config()
+    pre, post = make_pre_post_processors(plain, context=ProcessorBuildContext(dataset_stats=_stats()))
+    pre.save_pretrained(tmp_path, config_filename="policy_preprocessor.json")
+    post.save_pretrained(tmp_path, config_filename="policy_postprocessor.json")
+    assert "RelativeActionsProcessorStep" not in _step_names(pre)
+
+    # Finetuning it with relative actions on must now work.
+    reloaded_pre, _ = make_pre_post_processors(
+        _act_config(use_relative_actions=True),
+        pretrained_path=str(tmp_path),
+        context=ProcessorBuildContext(dataset_stats=_stats()),
+    )
+
+    assert "RelativeActionsProcessorStep" in _step_names(reloaded_pre)
+
+
+def test_relative_actions_round_trip_numerically():
+    """relative then absolute must return the original action."""
+    config = _act_config(use_relative_actions=True, relative_exclude_joints=[])
+    pre, post = make_pre_post_processors(config, context=ProcessorBuildContext(dataset_stats=_stats()))
+
+    state = torch.tensor([[1.0, 2.0, 3.0, 4.0]])
+    action = torch.tensor([[1.5, 2.5, 3.5, 4.5]])
+    processed = pre(
+        {
+            OBS_STATE: state,
+            f"{OBS_IMAGE}.cam": torch.rand(1, 3, 32, 32),
+            ACTION: action,
+        }
+    )
+    # The preprocessed action is a delta relative to the state.
+    assert torch.allclose(processed[ACTION], action - state, atol=1e-5)
+    # And the postprocessor puts it back.
+    assert torch.allclose(post(processed[ACTION]), action, atol=1e-5)
+
+
+def test_excluded_joints_stay_absolute():
+    config = _act_config(use_relative_actions=True, relative_exclude_joints=["gripper"])
+    config.action_feature_names = ["j0", "j1", "j2", "gripper"]
+    pre, _post = make_pre_post_processors(config, context=ProcessorBuildContext(dataset_stats=_stats()))
+
+    state = torch.tensor([[1.0, 2.0, 3.0, 4.0]])
+    action = torch.tensor([[1.5, 2.5, 3.5, 4.5]])
+    processed = pre({OBS_STATE: state, f"{OBS_IMAGE}.cam": torch.rand(1, 3, 32, 32), ACTION: action})
+
+    assert torch.allclose(processed[ACTION][:, :3], (action - state)[:, :3], atol=1e-5)
+    # The gripper dimension is untouched.
+    assert torch.allclose(processed[ACTION][:, 3], action[:, 3], atol=1e-5)
+
+
+def test_a_policy_that_places_the_steps_itself_is_left_alone():
+    """Bespoke placement wins, without the feature having to know which policy it is.
+
+    This is how GR00T keeps its own relative/absolute placement instead of being special-cased.
+    """
+    from lerobot.processor import apply_policy_features
+
+    # Build with the feature off, then hand-place the step where this "policy" wants it.
+    pre, post = make_pre_post_processors(_act_config(), context=ProcessorBuildContext(dataset_stats=_stats()))
+    hand_placed = RelativeActionsProcessorStep(enabled=True)
+    pre.steps = [hand_placed, *pre.steps]
+
+    # Now compose features with the flag on: the feature must notice and stand down.
+    apply_policy_features(_act_config(use_relative_actions=True), ProcessorBuildContext(), pre, post)
+
+    assert sum(isinstance(s, RelativeActionsProcessorStep) for s in pre.steps) == 1
+    assert pre.steps[0] is hand_placed
+    assert not any(isinstance(s, AbsoluteActionsProcessorStep) for s in post.steps)
+
+
+# Anchor resolution
+
+
+def test_splice_raises_when_the_anchor_is_missing():
+    steps = [IdentityProcessorStep()]
+    anchored = [AnchoredStep(IdentityProcessorStep(), NormalizerProcessorStep, "before")]
+
+    with pytest.raises(ValueError, match="matched 0 steps"):
+        splice_anchored_steps(steps, anchored)
+
+
+def test_splice_raises_when_the_anchor_is_ambiguous():
+    """Two candidate anchors means the position would be a guess, so it must fail."""
+    normalizer_args = {"features": {}, "norm_map": {}}
+    steps = [
+        NormalizerProcessorStep(**normalizer_args),
+        NormalizerProcessorStep(**normalizer_args),
+    ]
+    anchored = [AnchoredStep(IdentityProcessorStep(), NormalizerProcessorStep, "before")]
+
+    with pytest.raises(ValueError, match="matched 2 steps"):
+        splice_anchored_steps(steps, anchored)
+
+
+def test_splice_places_before_and_after():
+    normalizer = NormalizerProcessorStep(features={}, norm_map={})
+    marker = IdentityProcessorStep()
+
+    before = splice_anchored_steps([normalizer], [AnchoredStep(marker, NormalizerProcessorStep, "before")])
+    assert before == [marker, normalizer]
+
+    after = splice_anchored_steps([normalizer], [AnchoredStep(marker, NormalizerProcessorStep, "after")])
+    assert after == [normalizer, marker]
+
+
+def test_a_context_owned_feature_can_be_composed():
+    """The extension point the end-effector kinematics steps will use.
+
+    Its parameters come from the build context rather than the policy config, so they are not
+    persisted with the checkpoint — the same checkpoint may run on different hardware.
+    """
+
+    class MarkerFeature(ProcessorFeature):
+        name = "marker"
+        owner = "context"
+
+        def enabled_for(self, config, context):
+            return context.training
+
+        def build(self, config, context):
+            return (
+                [AnchoredStep(IdentityProcessorStep(), NormalizerProcessorStep, "before")],
+                [AnchoredStep(IdentityProcessorStep(), UnnormalizerProcessorStep, "after")],
+            )
+
+    from lerobot.processor import apply_policy_features
+
+    config = _act_config()
+    pre, post = make_pre_post_processors(config, context=ProcessorBuildContext(dataset_stats=_stats()))
+
+    # Disabled: the context says this is not a training build.
+    apply_policy_features(config, ProcessorBuildContext(training=False), pre, post, [MarkerFeature()])
+    assert "IdentityProcessorStep" not in _step_names(post)
+
+    apply_policy_features(config, ProcessorBuildContext(training=True), pre, post, [MarkerFeature()])
+    assert "IdentityProcessorStep" in _step_names(post)

--- a/tests/test_interactive_rollout.py
+++ b/tests/test_interactive_rollout.py
@@ -692,6 +692,30 @@ def test_drop_queued_actions_clears_the_queues_dict_convention():
     assert len(policy._queues["observation.state"]) == 1  # other episode state is left alone
 
 
+def test_queued_action_count_reads_both_queue_conventions():
+    """The sync engine keys the relative-action anchor hold off this count, so it must agree
+    with drop_queued_actions() on both the bare-deque and the ``_queues`` dict conventions."""
+    from collections import deque
+
+    from lerobot.policies.pretrained import PreTrainedPolicy
+    from lerobot.utils.constants import ACTION
+
+    bare_deque_policy = SimpleNamespace(  # act / pi0 / fastwam / lingbot-va style
+        _action_queue_attrs=PreTrainedPolicy._action_queue_attrs,
+        _action_queue=deque([1, 2, 3]),
+    )
+    assert PreTrainedPolicy.queued_action_count(bare_deque_policy) == 3
+
+    queues_dict_policy = SimpleNamespace(  # smolvla / diffusion / vqbet / wall_x style
+        _action_queue_attrs=PreTrainedPolicy._action_queue_attrs,
+        _queues={ACTION: deque([1, 2]), "observation.state": deque([9, 9, 9])},
+    )
+    assert PreTrainedPolicy.queued_action_count(queues_dict_policy) == 2  # history is not counted
+
+    never_chunks_policy = SimpleNamespace(_action_queue_attrs=PreTrainedPolicy._action_queue_attrs)
+    assert PreTrainedPolicy.queued_action_count(never_chunks_policy) == 0
+
+
 # --- Sentry strategy: restartable run() segments + dispatched-action task labels ---
 
 

--- a/tests/test_rollout.py
+++ b/tests/test_rollout.py
@@ -1020,3 +1020,200 @@ def test_episodic_run_reports_a_summary_per_episode_and_for_the_run(caplog):
     # Recording still lands once per interpolation cycle over the 8 ticks.
     assert _recorded_actions(dataset) == [1.0, 2.0, 3.0, 4.0]
     assert not _timer_warnings(caplog)
+
+
+# ---------------------------------------------------------------------------
+# Sync engine: relative-action anchoring (drift-free chunk execution)
+# ---------------------------------------------------------------------------
+
+_REL_ACTION_NAMES = ["j0.pos", "j1.pos", "j2.pos", "gripper.pos"]
+_REL_ACTION_DIM = len(_REL_ACTION_NAMES)
+
+
+def _relative_pre_post(exclude_joints=None):
+    """Pre/post processors wrapping the real relative (caches anchor) and absolute
+    (relative + cached state) steps, mirroring what the sync engine feeds them."""
+    from lerobot.processor import (
+        AbsoluteActionsProcessorStep,
+        RelativeActionsProcessorStep,
+        TransitionKey,
+        create_transition,
+    )
+    from lerobot.utils.constants import OBS_STATE
+
+    relative_step = RelativeActionsProcessorStep(
+        enabled=True, exclude_joints=exclude_joints or [], action_names=list(_REL_ACTION_NAMES)
+    )
+    absolute_step = AbsoluteActionsProcessorStep(enabled=True, relative_step=relative_step)
+
+    class _Pre:
+        steps = [relative_step]
+
+        def __call__(self, observation):
+            # Run the relative step so it caches the anchor, then pass the batch through.
+            transition = create_transition(observation={OBS_STATE: observation[OBS_STATE]})
+            relative_step(transition)
+            return observation
+
+        def reset(self):
+            pass
+
+    class _Post:
+        def __call__(self, action):
+            transition = create_transition(action=action)
+            return absolute_step(transition)[TransitionKey.ACTION]
+
+        def reset(self):
+            pass
+
+    return _Pre(), _Post(), relative_step
+
+
+def _fake_relative_policy(chunk_rel, n_action_steps, chunking=True):
+    """Fake relative-action policy for the sync engine.
+
+    ``chunking=True`` buffers a chunk and serves it one action per tick, calling the
+    public ``predict_action_chunk`` only on refill (pi0/fastwam/lingbot). ``False``
+    returns an action directly and never calls it. The engine's anchor probe keys off
+    that public call, so the fake routes through it rather than any private queue.
+    """
+    from collections import deque
+
+    policy = MagicMock()
+    policy.config.use_amp = False
+    policy.config.action_feature_names = list(_REL_ACTION_NAMES)
+    state = {"predict_calls": 0}
+    queue = deque(maxlen=n_action_steps)
+
+    def predict_action_chunk(_batch=None, **_kwargs):
+        state["predict_calls"] += 1
+        return chunk_rel.unsqueeze(0)  # [B=1, n, dim]
+
+    def select_action(_observation):
+        if not chunking:
+            return chunk_rel[0].unsqueeze(0)
+        if len(queue) == 0:
+            actions = policy.predict_action_chunk(_observation)
+            queue.extend(actions.transpose(0, 1))  # [n, 1, dim]
+        return queue.popleft()
+
+    policy.predict_action_chunk.side_effect = predict_action_chunk
+    policy.select_action.side_effect = select_action
+    policy.reset.side_effect = queue.clear
+    policy._predict_state = state
+    return policy
+
+
+def _build_sync_engine(policy, pre, post):
+    from lerobot.rollout import SyncInferenceEngine
+
+    return SyncInferenceEngine(
+        policy=policy,
+        preprocessor=pre,
+        postprocessor=post,
+        dataset_features={"action": {"names": list(_REL_ACTION_NAMES)}},
+        ordered_action_keys=list(_REL_ACTION_NAMES),
+        task="test",
+        device="cpu",
+        robot_type="mock",
+    )
+
+
+def _obs_frame(state_values):
+    import numpy as np
+
+    return {"observation.state": np.asarray(state_values, dtype=np.float32)}
+
+
+def test_sync_relative_holds_anchor_across_chunk():
+    """Every action popped within a chunk must anchor to the tick-0 state (no drift)."""
+    n = 4
+    # A distinct relative offset per chunk step so a wrong anchor would be visible.
+    chunk_rel = torch.stack([torch.full((_REL_ACTION_DIM,), 0.1 * (i + 1)) for i in range(n)])
+    pre, post, relative_step = _relative_pre_post()
+    policy = _fake_relative_policy(chunk_rel, n_action_steps=n)
+    engine = _build_sync_engine(policy, pre, post)
+
+    assert engine._relative_step is relative_step  # introspection wired the step
+
+    s0 = [1.0, 2.0, 3.0, 4.0]
+    outputs = []
+    for tick in range(n):
+        # Feed a *different* state each tick; a drifting anchor would use it.
+        state = [v + tick for v in s0]
+        outputs.append(engine.get_action(_obs_frame(state)))
+
+    # Exactly one chunk was predicted across the n ticks.
+    assert policy._predict_state["predict_calls"] == 1
+    for tick in range(n):
+        expected = torch.tensor(s0) + chunk_rel[tick]
+        torch.testing.assert_close(outputs[tick], expected)
+
+    # Next tick empties the queue -> fresh chunk -> anchor advances to the new state.
+    s_next = [10.0, 20.0, 30.0, 40.0]
+    out = engine.get_action(_obs_frame(s_next))
+    assert policy._predict_state["predict_calls"] == 2
+    torch.testing.assert_close(out, torch.tensor(s_next) + chunk_rel[0])
+    # The anchor now reflects the fresh-chunk state, not the held one.
+    torch.testing.assert_close(relative_step.get_cached_state(), torch.tensor([s_next]))
+
+
+def test_sync_relative_reset_reanchors_new_episode():
+    """After ``reset()`` the first tick of the next episode anchors to the new state."""
+    n = 3
+    chunk_rel = torch.stack([torch.full((_REL_ACTION_DIM,), 0.2) for _ in range(n)])
+    pre, post, relative_step = _relative_pre_post()
+    policy = _fake_relative_policy(chunk_rel, n_action_steps=n)
+    engine = _build_sync_engine(policy, pre, post)
+
+    # Episode 1: one tick anchors to s0 and leaves cached actions in the queue.
+    engine.get_action(_obs_frame([1.0, 1.0, 1.0, 1.0]))
+    assert policy._predict_state["predict_calls"] == 1
+
+    engine.reset()  # clears the queue and the per-episode chunk flags
+
+    # Episode 2: a fresh state must produce a fresh chunk anchored to that state,
+    # not carry over the previous episode's anchor.
+    s_new = [7.0, 8.0, 9.0, 10.0]
+    out = engine.get_action(_obs_frame(s_new))
+    assert policy._predict_state["predict_calls"] == 2
+    torch.testing.assert_close(out, torch.tensor(s_new) + chunk_rel[0])
+    torch.testing.assert_close(relative_step.get_cached_state(), torch.tensor([s_new]))
+
+
+def test_sync_relative_non_chunking_policy_refreshes_every_tick():
+    """A policy that never calls ``predict_action_chunk`` must not freeze the anchor."""
+    n = 3
+    chunk_rel = torch.stack([torch.full((_REL_ACTION_DIM,), 0.5) for _ in range(n)])
+    pre, post, _ = _relative_pre_post()
+    policy = _fake_relative_policy(chunk_rel, n_action_steps=n, chunking=False)
+    engine = _build_sync_engine(policy, pre, post)
+
+    s0 = [1.0, 1.0, 1.0, 1.0]
+    for tick in range(3):
+        state = [v + tick for v in s0]
+        out = engine.get_action(_obs_frame(state))
+        # Anchor must track the current state every tick (no chunk => no hold).
+        torch.testing.assert_close(out, torch.tensor(state) + chunk_rel[0])
+    assert policy._predict_state["predict_calls"] == 0
+
+
+def test_sync_engine_no_relative_step_is_none():
+    """Without an enabled relative step, the engine takes the plain select_action path."""
+    policy = MagicMock()
+    policy.config.use_amp = False
+    engine = _build_sync_engine(policy, MagicMock(steps=[]), MagicMock())
+    assert engine._relative_step is None
+
+
+def test_sync_relative_stop_restores_policy_method():
+    """``stop()`` un-patches the probe so the policy object isn't permanently modified."""
+    n = 3
+    chunk_rel = torch.stack([torch.full((_REL_ACTION_DIM,), 0.2) for _ in range(n)])
+    pre, post, _ = _relative_pre_post()
+    policy = _fake_relative_policy(chunk_rel, n_action_steps=n)
+    original = policy.predict_action_chunk
+    engine = _build_sync_engine(policy, pre, post)
+    assert policy.predict_action_chunk is not original  # probe installed
+    engine.stop()
+    assert policy.predict_action_chunk is original  # restored

--- a/tests/test_rollout.py
+++ b/tests/test_rollout.py
@@ -1072,10 +1072,11 @@ def _relative_pre_post(exclude_joints=None):
 def _fake_relative_policy(chunk_rel, n_action_steps, chunking=True):
     """Fake relative-action policy for the sync engine.
 
-    ``chunking=True`` buffers a chunk and serves it one action per tick, calling the
-    public ``predict_action_chunk`` only on refill (pi0/fastwam/lingbot). ``False``
-    returns an action directly and never calls it. The engine's anchor probe keys off
-    that public call, so the fake routes through it rather than any private queue.
+    ``chunking=True`` buffers a chunk and serves it one action per tick, computing a fresh
+    chunk only on refill (pi0/fastwam/lingbot/act). ``chunking=False`` returns an action
+    directly and never queues (e.g. ACT with temporal ensembling). ``queued_action_count()``
+    mirrors the real ``PreTrainedPolicy`` contract: it reads the same queue ``select_action``
+    drains, so the engine sees an accurate depth *before* this tick's call runs.
     """
     from collections import deque
 
@@ -1100,6 +1101,7 @@ def _fake_relative_policy(chunk_rel, n_action_steps, chunking=True):
     policy.predict_action_chunk.side_effect = predict_action_chunk
     policy.select_action.side_effect = select_action
     policy.reset.side_effect = queue.clear
+    policy.queued_action_count.side_effect = lambda: len(queue)
     policy._predict_state = state
     return policy
 
@@ -1170,7 +1172,7 @@ def test_sync_relative_reset_reanchors_new_episode():
     engine.get_action(_obs_frame([1.0, 1.0, 1.0, 1.0]))
     assert policy._predict_state["predict_calls"] == 1
 
-    engine.reset()  # clears the queue and the per-episode chunk flags
+    engine.reset()  # clears the policy's action queue via policy.reset()
 
     # Episode 2: a fresh state must produce a fresh chunk anchored to that state,
     # not carry over the previous episode's anchor.
@@ -1229,16 +1231,3 @@ def test_sync_relative_exclude_joints_stay_absolute():
         # relative dims: anchor held at s0; excluded gripper dim: raw predicted value.
         expected = chunk_rel[tick] + torch.tensor(s0) * mask
         torch.testing.assert_close(outputs[tick], expected)
-
-
-def test_sync_relative_stop_restores_policy_method():
-    """``stop()`` un-patches the probe so the policy object isn't permanently modified."""
-    n = 3
-    chunk_rel = torch.stack([torch.full((_REL_ACTION_DIM,), 0.2) for _ in range(n)])
-    pre, post, _ = _relative_pre_post()
-    policy = _fake_relative_policy(chunk_rel, n_action_steps=n)
-    original = policy.predict_action_chunk
-    engine = _build_sync_engine(policy, pre, post)
-    assert policy.predict_action_chunk is not original  # probe installed
-    engine.stop()
-    assert policy.predict_action_chunk is original  # restored

--- a/tests/test_rollout.py
+++ b/tests/test_rollout.py
@@ -1206,6 +1206,31 @@ def test_sync_engine_no_relative_step_is_none():
     assert engine._relative_step is None
 
 
+def test_sync_relative_exclude_joints_stay_absolute():
+    """With ``exclude_joints``, excluded dims pass through absolute while the relative
+    dims still hold the tick-0 anchor across the chunk."""
+    n = 4
+    # Distinct offset per step *and* per dim so a wrong anchor or a wrong mask shows up.
+    chunk_rel = torch.stack([torch.full((_REL_ACTION_DIM,), 0.1 * (i + 1)) for i in range(n)])
+    pre, post, relative_step = _relative_pre_post(exclude_joints=["gripper"])
+    policy = _fake_relative_policy(chunk_rel, n_action_steps=n)
+    engine = _build_sync_engine(policy, pre, post)
+
+    # gripper (last dim) is kept absolute; j0..j2 are relative.
+    mask = torch.tensor([1.0, 1.0, 1.0, 0.0])
+    s0 = [1.0, 2.0, 3.0, 4.0]
+    outputs = []
+    for tick in range(n):
+        state = [v + tick for v in s0]  # moving state; a drifting anchor would use it
+        outputs.append(engine.get_action(_obs_frame(state)))
+
+    assert policy._predict_state["predict_calls"] == 1  # one chunk held across n ticks
+    for tick in range(n):
+        # relative dims: anchor held at s0; excluded gripper dim: raw predicted value.
+        expected = chunk_rel[tick] + torch.tensor(s0) * mask
+        torch.testing.assert_close(outputs[tick], expected)
+
+
 def test_sync_relative_stop_restores_policy_method():
     """``stop()`` un-patches the probe so the policy object isn't permanently modified."""
     n = 3


### PR DESCRIPTION
Main idea is to decouple the relative action processors from the policy's processor, and at the same time refactor the way the preprocessors are loaded especially during finetunings where we would intuitively want to be able to override the baked in pre-processors. 

WIP