### PR TITLE
feat(act): expand single-channel cameras so depth maps can share the RGB backbone

### DIFF
--- a/src/lerobot/policies/act/modeling_act.py
+++ b/src/lerobot/policies/act/modeling_act.py
@@ -474,6 +474,14 @@ class ACT(nn.Module):
             # NOTE: If modifying this section, verify on MPS devices that
             # gradients remain stable (no explosions or NaNs).
             for img in batch[OBS_IMAGES]:
+                # Single-channel cameras (e.g. depth maps, which the dataset
+                # layer already dequantizes to physical units and which
+                # `dataset_to_policy_features` classifies as FeatureType.VISUAL)
+                # are expanded to 3 channels so they can share the RGB backbone.
+                # `expand` is a zero-copy view. Mirrors
+                # Qwen3VLInterface.to_pixel_values in policies/vla_jepa.
+                if img.shape[-3] == 1:
+                    img = img.expand(*img.shape[:-3], 3, *img.shape[-2:])
                 cam_features = self.backbone(img)["feature_map"]
                 cam_pos_embed = self.encoder_cam_feat_pos_embed(cam_features).to(dtype=cam_features.dtype)
                 cam_features = self.encoder_img_feat_input_proj(cam_features)

--- a/tests/policies/test_policies.py
+++ b/tests/policies/test_policies.py
@@ -35,7 +35,7 @@ from lerobot.envs.factory import make_env, make_env_config
 from lerobot.envs.utils import close_envs, preprocess_observation
 from lerobot.optim.factory import make_optimizer_and_scheduler
 from lerobot.policies.act.configuration_act import ACTConfig
-from lerobot.policies.act.modeling_act import ACTTemporalEnsembler
+from lerobot.policies.act.modeling_act import ACT, ACTTemporalEnsembler
 from lerobot.policies.factory import (
     get_policy_class,
     make_policy,
@@ -374,6 +374,50 @@ def test_multikey_construction(multikey: bool):
     assert action_condition, (
         f"Discrepancy detected. Action feature is {config.action_feature} but policy expects {output_features[ACTION]}"
     )
+
+
+@pytest.mark.parametrize("camera_channels", [1, 3])
+def test_act_single_channel_camera_shares_rgb_backbone(camera_channels: int):
+    """A single-channel camera (e.g. a depth map) shares ACT's RGB backbone.
+
+    `dataset_to_policy_features` classifies every image/video feature as
+    FeatureType.VISUAL, depth maps included, so a depth camera reaches the
+    backbone as a (B, 1, H, W) tensor and would otherwise raise a channel
+    mismatch in the backbone's first convolution.
+    """
+    h, w, batch_size, chunk_size, dim = 96, 128, 2, 4, 6
+    config = ACTConfig(
+        chunk_size=chunk_size,
+        n_action_steps=chunk_size,
+        pretrained_backbone_weights=None,
+        input_features={
+            OBS_STATE: PolicyFeature(type=FeatureType.STATE, shape=(dim,)),
+            f"{OBS_IMAGES}.top": PolicyFeature(type=FeatureType.VISUAL, shape=(3, h, w)),
+            f"{OBS_IMAGES}.top_depth": PolicyFeature(
+                type=FeatureType.VISUAL, shape=(camera_channels, h, w)
+            ),
+        },
+        output_features={ACTION: PolicyFeature(type=FeatureType.ACTION, shape=(dim,))},
+    )
+    model = ACT(config)
+    camera = torch.rand(batch_size, camera_channels, h, w, requires_grad=True)
+    batch = {
+        OBS_STATE: torch.randn(batch_size, dim),
+        ACTION: torch.randn(batch_size, chunk_size, dim),
+        "action_is_pad": torch.zeros(batch_size, chunk_size, dtype=torch.bool),
+        OBS_IMAGES: [torch.rand(batch_size, 3, h, w), camera],
+    }
+
+    actions, _ = model(batch)
+    assert actions.shape == (batch_size, chunk_size, dim)
+
+    # The RGB stem is reused as-is, so pretrained backbone weights stay valid.
+    assert model.backbone.conv1.in_channels == 3
+
+    # Gradients still reach the single-channel input.
+    actions.sum().backward()
+    assert camera.grad is not None
+    assert torch.isfinite(camera.grad).all()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What this does

Lets ACT consume a single-channel camera — in practice a depth map — by expanding
it to 3 channels so it can share the existing RGB backbone.

## Why

`dataset_to_policy_features` classifies **every** `image`/`video` feature as
`FeatureType.VISUAL`, depth maps included — there is no depth filter. So a depth
camera recorded with `DepthEncoderConfig` lands in `ACTConfig.image_features`
and reaches the backbone as a `(B, 1, H, W)` tensor. ACT builds one shared
torchvision ResNet (`modeling_act.py`) whose `conv1` takes 3 channels, so the
forward pass raises:

```
RuntimeError: Given groups=1, weight of size [64, 3, 7, 7],
expected input[2, 1, 480, 640] to have 3 channels, but got 1 channels instead
```

The result is that the dataset layer's depth support — 12-bit quantization,
lossless HEVC storage, dequantization to physical units on read, depth-aware
stats (`compute_stats`), and the deliberate exclusion of depth from ImageNet
stats in `datasets/factory.py` — stops exactly at the policy boundary. Depth can
be recorded and loaded, but no policy can be trained on it.

## Precedent

This is not a new idea in the codebase — `Qwen3VLInterface.to_pixel_values` in
`policies/vla_jepa` already does the same expansion, for the same reason
("A single channel is expanded to 3 to match the RGB processors"). This PR makes
ACT consistent with that.

## Approach

```python
if img.shape[-3] == 1:
    img = img.expand(*img.shape[:-3], 3, *img.shape[-2:])
```

- **`expand`, not `repeat`** — a zero-copy view, verified bit-identical to
  `repeat` through the backbone.
- **`conv1` stays at 3 input channels**, so pretrained backbone weights remain
  valid. No weight surgery, no checkpoint shape change.
- **RGB is untouched** — the branch is only taken for `C == 1`.
- Indexed on `shape[-3]` so it holds for any channels-first layout.

I deliberately did not add a 4-channel stem or a separate depth backbone: both
change checkpoint shape and forfeit pretrained-weight reuse, and neither is
needed to make depth usable at all. This is the minimal change that unblocks it.

## Testing

`test_act_single_channel_camera_shares_rgb_backbone`, parametrized over
`camera_channels in [1, 3]`, builds an ACT with one RGB and one depth-shaped
camera and asserts:

1. the forward pass produces the expected action shape,
2. `backbone.conv1.in_channels == 3` (pretrained weights stay valid),
3. gradients reach the single-channel input and are finite.

Verified the test actually catches the bug: with the source change reverted the
`[1]` case fails with the exact `RuntimeError` above, while `[3]` still passes —
confirming no RGB regression. `tests/processor/test_act_processor.py` and the
local ACT tests in `tests/policies/test_policies.py` are green.

## Notes for reviewers

- Should this live in a shared helper rather than inline, given `vla_jepa` has
  its own copy? Happy to factor it out if you'd prefer one implementation.
- Depth arrives from the reader in **physical units** (mm by default), not
  `[0, 1]`. That is handled correctly today by `VISUAL: MEAN_STD` normalization
  plus `factory.py`'s exclusion of depth from ImageNet stats, so no change was
  needed there — flagging it only because it is easy to assume otherwise.
