### PR TITLE
fix(envs): match RoboCasa eval task prompts to training ids

### DIFF
--- a/docs/source/robocasa.mdx
+++ b/docs/source/robocasa.mdx
@@ -84,7 +84,7 @@ All eval snippets below mirror the CI command (see `.github/workflows/benchmark_
 
 By default, each task uses the rollout horizon registered by RoboCasa. Set `--env.episode_length=<steps>` to apply the same explicit horizon to every selected task.
 
-Eval prompts default to the CamelCase env id (`CloseFridge`) so they match the `task` column used to train [`lerobot/smolvla_robocasa`](https://huggingface.co/lerobot/smolvla_robocasa) and the Hub datasets. To send the English sentence from RoboCasa episode metadata instead (`ep_meta["lang"]`, e.g. `Close the fridge doors.`), pass `--env.task_prompt=language`.
+Eval prompts default to the CamelCase env id (`CloseFridge`) so they match the `task` column used to train [`lerobot/smolvla_robocasa`](https://huggingface.co/lerobot/smolvla_robocasa) and the Hub datasets. To send the English sentence from RoboCasa episode metadata instead (`ep_meta["lang"]`, e.g. `Close the fridge doors.`), pass `--env.task_prompt_source=language`.
 
 ### Single-task evaluation (recommended for quick iteration)
 

--- a/docs/source/robocasa.mdx
+++ b/docs/source/robocasa.mdx
@@ -84,6 +84,8 @@ All eval snippets below mirror the CI command (see `.github/workflows/benchmark_
 
 By default, each task uses the rollout horizon registered by RoboCasa. Set `--env.episode_length=<steps>` to apply the same explicit horizon to every selected task.
 
+Eval prompts default to the CamelCase env id (`CloseFridge`) so they match the `task` column used to train [`lerobot/smolvla_robocasa`](https://huggingface.co/lerobot/smolvla_robocasa) and the Hub datasets. To send the English sentence from RoboCasa episode metadata instead (`ep_meta["lang"]`, e.g. `Close the fridge doors.`), pass `--env.task_prompt=language`.
+
 ### Single-task evaluation (recommended for quick iteration)
 
 ```bash

--- a/src/lerobot/envs/configs.py
+++ b/src/lerobot/envs/configs.py
@@ -526,6 +526,9 @@ class RoboCasaEnv(EnvConfig):
     # you've run `python -m robocasa.scripts.download_kitchen_assets
     # --type objaverse` locally.
     obj_registries: list[str] = field(default_factory=lambda: ["lightwheel"])
+    # Eval language prompt. "env_id" is the CamelCase task name used in Hub
+    # datasets and `lerobot/smolvla_robocasa`. "language" uses ep_meta["lang"].
+    task_prompt: str = "env_id"
     features: dict[str, PolicyFeature] = field(
         default_factory=lambda: {ACTION: PolicyFeature(type=FeatureType.ACTION, shape=(12,))}
     )
@@ -534,6 +537,8 @@ class RoboCasaEnv(EnvConfig):
     def __post_init__(self):
         if self.obs_type not in ("pixels", "pixels_agent_pos"):
             raise ValueError(f"Unsupported obs_type: {self.obs_type}")
+        if self.task_prompt not in ("env_id", "language"):
+            raise ValueError(f"Unsupported task_prompt: {self.task_prompt}. Use 'env_id' or 'language'.")
 
         # Preserve raw RoboCasa camera names end-to-end (e.g.
         # `observation.images.robot0_agentview_left`). This matches the
@@ -559,6 +564,7 @@ class RoboCasaEnv(EnvConfig):
             "observation_width": self.observation_width,
             "visualization_height": self.visualization_height,
             "visualization_width": self.visualization_width,
+            "task_prompt": self.task_prompt,
         }
         if self.split is not None:
             kwargs["split"] = self.split

--- a/src/lerobot/envs/configs.py
+++ b/src/lerobot/envs/configs.py
@@ -528,7 +528,7 @@ class RoboCasaEnv(EnvConfig):
     obj_registries: list[str] = field(default_factory=lambda: ["lightwheel"])
     # Eval language prompt. "env_id" is the CamelCase task name used in Hub
     # datasets and `lerobot/smolvla_robocasa`. "language" uses ep_meta["lang"].
-    task_prompt: str = "env_id"
+    task_prompt_source: str = "env_id"
     features: dict[str, PolicyFeature] = field(
         default_factory=lambda: {ACTION: PolicyFeature(type=FeatureType.ACTION, shape=(12,))}
     )
@@ -537,8 +537,10 @@ class RoboCasaEnv(EnvConfig):
     def __post_init__(self):
         if self.obs_type not in ("pixels", "pixels_agent_pos"):
             raise ValueError(f"Unsupported obs_type: {self.obs_type}")
-        if self.task_prompt not in ("env_id", "language"):
-            raise ValueError(f"Unsupported task_prompt: {self.task_prompt}. Use 'env_id' or 'language'.")
+        if self.task_prompt_source not in ("env_id", "language"):
+            raise ValueError(
+                f"Unsupported task_prompt_source: {self.task_prompt_source}. Use 'env_id' or 'language'."
+            )
 
         # Preserve raw RoboCasa camera names end-to-end (e.g.
         # `observation.images.robot0_agentview_left`). This matches the
@@ -564,7 +566,7 @@ class RoboCasaEnv(EnvConfig):
             "observation_width": self.observation_width,
             "visualization_height": self.visualization_height,
             "visualization_width": self.visualization_width,
-            "task_prompt": self.task_prompt,
+            "task_prompt_source": self.task_prompt_source,
         }
         if self.split is not None:
             kwargs["split"] = self.split

--- a/src/lerobot/envs/robocasa.py
+++ b/src/lerobot/envs/robocasa.py
@@ -57,6 +57,11 @@ DEFAULT_CAMERAS = [
 # avoids the NaN and matches what the asset download provides.
 DEFAULT_OBJ_REGISTRIES: tuple[str, ...] = ("lightwheel",)
 
+# What `lerobot-eval` sends as the VLA language prompt. Hub datasets and
+# `lerobot/smolvla_robocasa` were trained on CamelCase env ids (`CloseFridge`),
+# not the English `ep_meta["lang"]` string (`Close the fridge doors.`).
+_TASK_PROMPT_VALUES = ("env_id", "language")
+
 # Task-group shortcuts accepted as `--env.task`. When the user passes one of
 # these names, we expand it to the upstream RoboCasa task list and auto-set
 # the dataset split. Individual task names (optionally comma-separated) still
@@ -149,9 +154,13 @@ class RoboCasaEnv(gym.Env):
         episode_length: int | None = None,
         obj_registries: Sequence[str] = DEFAULT_OBJ_REGISTRIES,
         episode_index: int = 0,
+        task_prompt: str = "env_id",
     ):
         super().__init__()
+        if task_prompt not in _TASK_PROMPT_VALUES:
+            raise ValueError(f"Unsupported task_prompt: {task_prompt!r}. Use one of {_TASK_PROMPT_VALUES}.")
         self.task = task
+        self.task_prompt = task_prompt
         self.obs_type = obs_type
         self.render_mode = render_mode
         self.observation_width = observation_width
@@ -172,7 +181,7 @@ class RoboCasaEnv(gym.Env):
         # Deferred — created on first reset() inside the worker subprocess
         # to avoid inheriting stale GPU/EGL contexts across fork().
         self._env: Any = None
-        self.task_description = ""
+        self.task_description = self.task
 
         images = {
             cam: spaces.Box(
@@ -231,8 +240,7 @@ class RoboCasaEnv(gym.Env):
             obj_registries=self.obj_registries,
         )
 
-        ep_meta = self._env.env.get_ep_meta()
-        self.task_description = ep_meta.get("lang", self.task)
+        self._update_task_description(self._env.env.get_ep_meta())
 
     def _format_raw_obs(self, raw_obs: dict) -> RobotObservation:
         """Convert RoboCasaGymEnv observation dict to LeRobot format."""
@@ -256,6 +264,15 @@ class RoboCasaEnv(gym.Env):
 
         return {"pixels": images, "agent_pos": agent_pos}
 
+    def _update_task_description(self, ep_meta: dict[str, Any] | None = None) -> None:
+        """Set `task_description` from the env id or RoboCasa `ep_meta["lang"]`."""
+        if self.task_prompt == "language" and ep_meta is not None:
+            lang = ep_meta.get("lang")
+            if isinstance(lang, str) and lang:
+                self.task_description = lang
+                return
+        self.task_description = self.task
+
     def render(self) -> np.ndarray:
         self._ensure_env()
         assert self._env is not None
@@ -273,8 +290,7 @@ class RoboCasaEnv(gym.Env):
         worker_seed = seed + self.episode_index if seed is not None else self.episode_index
         raw_obs, info = self._env.reset(seed=worker_seed)
 
-        ep_meta = self._env.env.get_ep_meta()
-        self.task_description = ep_meta.get("lang", self.task)
+        self._update_task_description(self._env.env.get_ep_meta())
 
         observation = self._format_raw_obs(raw_obs)
         info = {"is_success": False}
@@ -326,6 +342,7 @@ def _make_env_fns(
     split: str | None,
     episode_length: int | None,
     obj_registries: Sequence[str],
+    task_prompt: str,
 ) -> list[Callable[[], RoboCasaEnv]]:
     """Build n_envs factory callables for a single task.
 
@@ -348,6 +365,7 @@ def _make_env_fns(
             episode_length=episode_length,
             obj_registries=obj_registries,
             episode_index=episode_index,
+            task_prompt=task_prompt,
         )
 
     return [partial(_make_env, i) for i in range(n_envs)]
@@ -388,6 +406,7 @@ def create_robocasa_envs(
     visualization_width = gym_kwargs.pop("visualization_width", 512)
     visualization_height = gym_kwargs.pop("visualization_height", 512)
     split = gym_kwargs.pop("split", None)
+    task_prompt = gym_kwargs.pop("task_prompt", "env_id")
 
     camera_names = parse_camera_names(camera_name)
     task_names, group_split = _resolve_tasks(str(task))
@@ -422,6 +441,7 @@ def create_robocasa_envs(
             split=split,
             episode_length=episode_length,
             obj_registries=obj_registries,
+            task_prompt=task_prompt,
         )
 
         if is_async:

--- a/src/lerobot/envs/robocasa.py
+++ b/src/lerobot/envs/robocasa.py
@@ -154,13 +154,15 @@ class RoboCasaEnv(gym.Env):
         episode_length: int | None = None,
         obj_registries: Sequence[str] = DEFAULT_OBJ_REGISTRIES,
         episode_index: int = 0,
-        task_prompt: str = "env_id",
+        task_prompt_source: str = "env_id",
     ):
         super().__init__()
-        if task_prompt not in _TASK_PROMPT_VALUES:
-            raise ValueError(f"Unsupported task_prompt: {task_prompt!r}. Use one of {_TASK_PROMPT_VALUES}.")
+        if task_prompt_source not in _TASK_PROMPT_VALUES:
+            raise ValueError(
+                f"Unsupported task_prompt_source: {task_prompt_source!r}. Use one of {_TASK_PROMPT_VALUES}."
+            )
         self.task = task
-        self.task_prompt = task_prompt
+        self.task_prompt_source = task_prompt_source
         self.obs_type = obs_type
         self.render_mode = render_mode
         self.observation_width = observation_width
@@ -266,7 +268,7 @@ class RoboCasaEnv(gym.Env):
 
     def _update_task_description(self, ep_meta: dict[str, Any] | None = None) -> None:
         """Set `task_description` from the env id or RoboCasa `ep_meta["lang"]`."""
-        if self.task_prompt == "language" and ep_meta is not None:
+        if self.task_prompt_source == "language" and ep_meta is not None:
             lang = ep_meta.get("lang")
             if isinstance(lang, str) and lang:
                 self.task_description = lang
@@ -342,7 +344,7 @@ def _make_env_fns(
     split: str | None,
     episode_length: int | None,
     obj_registries: Sequence[str],
-    task_prompt: str,
+    task_prompt_source: str,
 ) -> list[Callable[[], RoboCasaEnv]]:
     """Build n_envs factory callables for a single task.
 
@@ -365,7 +367,7 @@ def _make_env_fns(
             episode_length=episode_length,
             obj_registries=obj_registries,
             episode_index=episode_index,
-            task_prompt=task_prompt,
+            task_prompt_source=task_prompt_source,
         )
 
     return [partial(_make_env, i) for i in range(n_envs)]
@@ -406,7 +408,7 @@ def create_robocasa_envs(
     visualization_width = gym_kwargs.pop("visualization_width", 512)
     visualization_height = gym_kwargs.pop("visualization_height", 512)
     split = gym_kwargs.pop("split", None)
-    task_prompt = gym_kwargs.pop("task_prompt", "env_id")
+    task_prompt_source = gym_kwargs.pop("task_prompt_source", "env_id")
 
     camera_names = parse_camera_names(camera_name)
     task_names, group_split = _resolve_tasks(str(task))
@@ -441,7 +443,7 @@ def create_robocasa_envs(
             split=split,
             episode_length=episode_length,
             obj_registries=obj_registries,
-            task_prompt=task_prompt,
+            task_prompt_source=task_prompt_source,
         )
 
         if is_async:

--- a/tests/envs/test_robocasa.py
+++ b/tests/envs/test_robocasa.py
@@ -49,3 +49,61 @@ def test_explicit_episode_length_overrides_registered_horizons(monkeypatch: pyte
     assert envs["CloseFridge"][0][0]._max_episode_steps == 1234
     assert envs["SearingMeat"][0][0]._max_episode_steps == 1234
     get_task_horizon.assert_not_called()
+
+
+def test_robocasa_config_defaults_task_prompt_to_env_id() -> None:
+    cfg = RoboCasaEnvConfig()
+    assert cfg.task_prompt == "env_id"
+    assert cfg.gym_kwargs["task_prompt"] == "env_id"
+
+
+def test_robocasa_config_rejects_unknown_task_prompt() -> None:
+    with pytest.raises(ValueError, match="task_prompt"):
+        RoboCasaEnvConfig(task_prompt="nope")
+
+
+def test_task_description_defaults_to_env_id(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(robocasa, "_get_task_horizon", Mock(return_value=100))
+    env = robocasa.RoboCasaEnv(task="CloseFridge")
+    assert env.task_prompt == "env_id"
+    assert env.task_description == "CloseFridge"
+    env._update_task_description({"lang": "Close the fridge doors."})
+    assert env.task_description == "CloseFridge"
+
+
+def test_task_description_language_uses_ep_meta_lang(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(robocasa, "_get_task_horizon", Mock(return_value=100))
+    env = robocasa.RoboCasaEnv(task="CloseFridge", task_prompt="language")
+    env._update_task_description({"lang": "Close the fridge doors."})
+    assert env.task_description == "Close the fridge doors."
+
+
+def test_task_description_language_falls_back_to_env_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(robocasa, "_get_task_horizon", Mock(return_value=100))
+    env = robocasa.RoboCasaEnv(task="CloseFridge", task_prompt="language")
+    env._update_task_description({})
+    assert env.task_description == "CloseFridge"
+
+
+def test_unknown_task_prompt_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(robocasa, "_get_task_horizon", Mock(return_value=100))
+    with pytest.raises(ValueError, match="task_prompt"):
+        robocasa.RoboCasaEnv(task="CloseFridge", task_prompt="nope")
+
+
+def test_create_envs_honors_task_prompt(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(robocasa, "_get_task_horizon", Mock(return_value=100))
+    envs = robocasa.create_robocasa_envs(
+        task="CloseFridge",
+        n_envs=1,
+        env_cls=_instantiate_envs,
+        gym_kwargs={"task_prompt": "language"},
+    )
+    env = envs["CloseFridge"][0][0]
+    assert env.task_prompt == "language"
+    env._update_task_description({"lang": "Close the fridge doors."})
+    assert env.task_description == "Close the fridge doors."

--- a/tests/envs/test_robocasa.py
+++ b/tests/envs/test_robocasa.py
@@ -51,21 +51,21 @@ def test_explicit_episode_length_overrides_registered_horizons(monkeypatch: pyte
     get_task_horizon.assert_not_called()
 
 
-def test_robocasa_config_defaults_task_prompt_to_env_id() -> None:
+def test_robocasa_config_defaults_task_prompt_source_to_env_id() -> None:
     cfg = RoboCasaEnvConfig()
-    assert cfg.task_prompt == "env_id"
-    assert cfg.gym_kwargs["task_prompt"] == "env_id"
+    assert cfg.task_prompt_source == "env_id"
+    assert cfg.gym_kwargs["task_prompt_source"] == "env_id"
 
 
-def test_robocasa_config_rejects_unknown_task_prompt() -> None:
-    with pytest.raises(ValueError, match="task_prompt"):
-        RoboCasaEnvConfig(task_prompt="nope")
+def test_robocasa_config_rejects_unknown_task_prompt_source() -> None:
+    with pytest.raises(ValueError, match="task_prompt_source"):
+        RoboCasaEnvConfig(task_prompt_source="nope")
 
 
 def test_task_description_defaults_to_env_id(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(robocasa, "_get_task_horizon", Mock(return_value=100))
     env = robocasa.RoboCasaEnv(task="CloseFridge")
-    assert env.task_prompt == "env_id"
+    assert env.task_prompt_source == "env_id"
     assert env.task_description == "CloseFridge"
     env._update_task_description({"lang": "Close the fridge doors."})
     assert env.task_description == "CloseFridge"
@@ -75,7 +75,7 @@ def test_task_description_language_uses_ep_meta_lang(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(robocasa, "_get_task_horizon", Mock(return_value=100))
-    env = robocasa.RoboCasaEnv(task="CloseFridge", task_prompt="language")
+    env = robocasa.RoboCasaEnv(task="CloseFridge", task_prompt_source="language")
     env._update_task_description({"lang": "Close the fridge doors."})
     assert env.task_description == "Close the fridge doors."
 
@@ -84,26 +84,26 @@ def test_task_description_language_falls_back_to_env_id(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(robocasa, "_get_task_horizon", Mock(return_value=100))
-    env = robocasa.RoboCasaEnv(task="CloseFridge", task_prompt="language")
+    env = robocasa.RoboCasaEnv(task="CloseFridge", task_prompt_source="language")
     env._update_task_description({})
     assert env.task_description == "CloseFridge"
 
 
-def test_unknown_task_prompt_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_unknown_task_prompt_source_raises(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(robocasa, "_get_task_horizon", Mock(return_value=100))
-    with pytest.raises(ValueError, match="task_prompt"):
-        robocasa.RoboCasaEnv(task="CloseFridge", task_prompt="nope")
+    with pytest.raises(ValueError, match="task_prompt_source"):
+        robocasa.RoboCasaEnv(task="CloseFridge", task_prompt_source="nope")
 
 
-def test_create_envs_honors_task_prompt(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_create_envs_honors_task_prompt_source(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(robocasa, "_get_task_horizon", Mock(return_value=100))
     envs = robocasa.create_robocasa_envs(
         task="CloseFridge",
         n_envs=1,
         env_cls=_instantiate_envs,
-        gym_kwargs={"task_prompt": "language"},
+        gym_kwargs={"task_prompt_source": "language"},
     )
     env = envs["CloseFridge"][0][0]
-    assert env.task_prompt == "language"
+    assert env.task_prompt_source == "language"
     env._update_task_description({"lang": "Close the fridge doors."})
     assert env.task_description == "Close the fridge doors."


### PR DESCRIPTION
## Summary / Motivation

Eval was sending RoboCasa `ep_meta["lang"]` (for example `Close the fridge doors.`) as the VLA prompt, while Hub datasets and `lerobot/smolvla_robocasa` were trained on CamelCase env ids (`CloseFridge`). Default `task_description` to the env id so eval matches training. `--env.task_prompt=language` keeps the English sentence for people who train on natural language.

This is scoped to the RoboCasa env. It does not change `lerobot_eval.py` or republish Hub datasets.

**AI assistance:** Cursor was used to draft the env flag, tests, docs note, and this PR text. I reviewed every changed line and ran the tests below.

## Related issues

- Fixes #4045

## What changed

- RoboCasa `task_description` now defaults to `self.task` (`env_id`).
- New `--env.task_prompt` with `env_id` (default) and `language`.
- Docs note in `docs/source/robocasa.mdx`.
- Unit tests with a mocked horizon (no RoboCasa/GPU).

No Hub dataset republish in this PR.

## How was this tested (or how to run locally)

- Tests added in `tests/envs/test_robocasa.py`: default env id vs language, invalid prompt, config default, factory `gym_kwargs` passthrough.
- `uv run --extra test pytest tests/envs/test_robocasa.py -v` (10 passed)
- `uvx pre-commit run --files docs/source/robocasa.mdx src/lerobot/envs/configs.py src/lerobot/envs/robocasa.py tests/envs/test_robocasa.py`

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated
- [ ] CI is green
- [x] Community Review: I have reviewed another contributor's open PR and linked it here: https://github.com/huggingface/lerobot/pull/4455

## Reviewer notes

I checked for an existing open PR against #4045 and did not find one.

Defaulting eval to env ids is a behavior change for anyone who already trained on English `ep_meta["lang"]`. That path is still available with `--env.task_prompt=language`.

Made with [Cursor](https://cursor.com)