### PR TITLE
fix(rl): guard learner checkpoint saving against non-positive save_freq

### DIFF
--- a/src/lerobot/rl/learner.py
+++ b/src/lerobot/rl/learner.py
@@ -76,6 +76,7 @@ from lerobot.common.train_utils import (
     get_step_checkpoint_dir,
     load_training_metadata,
     save_checkpoint,
+    should_save_checkpoint,
     update_last_checkpoint,
 )
 from lerobot.common.wandb_utils import WandBLogger
@@ -457,7 +458,7 @@ def add_actor_information_and_train(
             logging.info(f"[LEARNER] Number of optimization step: {optimization_step}")
 
         # Save checkpoint at specified intervals
-        if saving_checkpoint and (optimization_step % save_freq == 0 or optimization_step == online_steps):
+        if saving_checkpoint and should_save_checkpoint(optimization_step, save_freq, online_steps):
             save_training_checkpoint(
                 cfg=cfg,
                 optimization_step=optimization_step,


### PR DESCRIPTION
## Summary / Motivation

`save_freq` is documented as "a non-positive value disables periodic saving, keeping only the final checkpoint" (`configs/train.py:152-154`), and `TrainRLServerPipelineConfig` inherits the field from `TrainPipelineConfig` (`rl/train_rl.py:30`).

#4112 fixed exactly in `lerobot_train.py` and introduced `should_save_checkpoint()`, but the RL learner was not looked at. This PR applies the same helper there.

## Related issues

#4112 (the same fix for `lerobot_train.py`).

## What changed

`rl/learner.py:460` now calls `should_save_checkpoint(optimization_step, save_freq, online_steps)` instead of `optimization_step % save_freq == 0 or optimization_step == online_steps`.

## How was this tested (or how to run locally)

```bash
uv sync --locked --extra test --extra dataset --extra grpcio-dep
uv run pytest tests/rl tests/utils/test_train_utils.py -q
```
83 passed.

## Checklist (required before merge)

- [x] Linting/formatting run: `pre-commit run --files src/lerobot/rl/learner.py`, all hooks pass
- [x] Tests pass locally: see above
- [ ] Documentation updated: not needed
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: #
