### PR TITLE
fix(eval): exclude post-terminal steps from metrics

### DIFF
--- a/src/lerobot/scripts/lerobot_eval.py
+++ b/src/lerobot/scripts/lerobot_eval.py
@@ -411,6 +411,14 @@ def rollout(
     return ret
 
 
+def _get_episode_end_indices_and_mask(done: Tensor) -> tuple[Tensor, Tensor]:
+    """Return each episode's first done index and a mask including that step."""
+    done_indices = torch.argmax(done.to(int), dim=1)
+    steps = torch.arange(done.shape[1], device=done.device)
+    mask = steps[None, :] <= done_indices[:, None]
+    return done_indices, mask
+
+
 def eval_policy(
     env: gym.vector.VectorEnv,
     policy: PreTrainedPolicy,
@@ -550,17 +558,15 @@ def eval_policy(
 
         # Figure out where in each rollout sequence the first done condition was encountered (results after
         # this won't be included).
-        n_steps = rollout_data["done"].shape[1]
         # Note: this relies on a property of argmax: that it returns the first occurrence as a tiebreaker.
-        done_indices = torch.argmax(rollout_data["done"].to(int), dim=1)
+        done_indices, mask = _get_episode_end_indices_and_mask(rollout_data["done"])
 
-        # Make a mask with shape (batch, n_steps) to mask out rollout data after the first done
-        # (batch-element-wise). Note the `done_indices + 1` to make sure to keep the data from the done step.
-        mask = (torch.arange(n_steps) <= einops.repeat(done_indices + 1, "b -> b s", s=n_steps)).int()
+        # Mask out rollout data after the first done, keeping the done step itself.
         # Extend metrics.
         batch_sum_rewards = einops.reduce((rollout_data["reward"] * mask), "b n -> b", "sum")
         sum_rewards.extend(batch_sum_rewards.tolist())
-        batch_max_rewards = einops.reduce((rollout_data["reward"] * mask), "b n -> b", "max")
+        valid_rewards = rollout_data["reward"].masked_fill(~mask, -torch.inf)
+        batch_max_rewards = einops.reduce(valid_rewards, "b n -> b", "max")
         max_rewards.extend(batch_max_rewards.tolist())
         batch_successes = einops.reduce((rollout_data["success"] * mask), "b n -> b", "any")
         all_successes.extend(batch_successes.tolist())

--- a/tests/scripts/test_lerobot_eval.py
+++ b/tests/scripts/test_lerobot_eval.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import MagicMock
+
+import torch
+
+from lerobot.policies.pretrained import PreTrainedPolicy
+from lerobot.scripts import lerobot_eval
+from lerobot.scripts.lerobot_eval import _get_episode_end_indices_and_mask
+
+
+def test_episode_mask_excludes_steps_after_first_done():
+    done = torch.tensor(
+        [
+            [False, True, True],
+            [False, False, True],
+        ]
+    )
+
+    done_indices, mask = _get_episode_end_indices_and_mask(done)
+
+    torch.testing.assert_close(done_indices, torch.tensor([1, 2]))
+    torch.testing.assert_close(
+        mask,
+        torch.tensor(
+            [
+                [True, True, False],
+                [True, True, True],
+            ]
+        ),
+    )
+
+
+def test_eval_policy_ignores_padded_steps_in_metrics(monkeypatch):
+    rollout_data = {
+        "done": torch.tensor(
+            [
+                [False, True, True],
+                [False, False, True],
+            ]
+        ),
+        "reward": torch.tensor(
+            [
+                [-2.0, -1.0, 0.0],
+                [1.0, 2.0, 3.0],
+            ]
+        ),
+        "success": torch.tensor(
+            [
+                [False, False, True],
+                [False, False, True],
+            ]
+        ),
+    }
+    monkeypatch.setattr(lerobot_eval, "rollout", lambda **_: rollout_data)
+
+    env = MagicMock()
+    env.num_envs = 2
+    policy = MagicMock(spec=PreTrainedPolicy)
+    policy.training = True
+
+    result = lerobot_eval.eval_policy(
+        env=env,
+        policy=policy,
+        env_preprocessor=None,
+        env_postprocessor=None,
+        preprocessor=None,
+        postprocessor=None,
+        n_episodes=2,
+    )
+
+    assert result["per_episode"][0] == {
+        "episode_ix": 0,
+        "sum_reward": -3.0,
+        "max_reward": -1.0,
+        "success": False,
+        "seed": None,
+    }
+    assert result["per_episode"][1]["sum_reward"] == 6.0
+    assert result["per_episode"][1]["max_reward"] == 3.0
+    assert result["per_episode"][1]["success"] is True


### PR DESCRIPTION
## Summary / Motivation

Evaluation rollouts latch `done=True` while the remaining vector environments
finish. The metrics mask currently includes one step after the first done, and
zero-filling masked rewards before `max` can turn an all-negative episode's
maximum reward into `0`. This makes per-episode and aggregate evaluation metrics
depend on padded transitions.

## Related issues

- Fixes / Closes: none (locally discovered)
- Related: none

## What changed

- Build the valid-step mask through the first cumulative `done=True` step,
  excluding all later padded transitions.
- Mask invalid rewards with negative infinity before computing `max_reward`, so
  padded zero rewards cannot dominate valid negative rewards.
- Add regression coverage for the mask and the public `eval_policy` metrics.
- No breaking API changes.

## How was this tested (or how to run locally)

- `python -m pytest -q tests/scripts/test_lerobot_eval.py tests/envs/test_freeze_after_episode_end.py tests/datasets/test_compute_stats.py` (`51 passed`)
- `python -m pytest -q tests/scripts tests/envs/test_freeze_after_episode_end.py` (`43 passed, 1 skipped`)
- `ruff check src/lerobot/scripts/lerobot_eval.py tests/scripts/test_lerobot_eval.py`
- `ruff format --check src/lerobot/scripts/lerobot_eval.py tests/scripts/test_lerobot_eval.py`
- `mypy --config-file=pyproject.toml src/lerobot/scripts/lerobot_eval.py`

## Checklist (required before merge)

- [ ] Linting/formatting run (`pre-commit run -a`): touched-file Ruff and Mypy checks pass; the isolated pre-commit hook download timed out locally.
- [ ] All tests pass locally (`pytest`): focused and adjacent suites pass; the full hardware/optional-dependency suite was not run.
- [x] Documentation updated: no user-facing API or documentation change.
- [ ] CI is green.
- [x] Community Review: reviewed [#4479](https://github.com/huggingface/lerobot/pull/4479#pullrequestreview-4979073152).

## Reviewer notes

For a cumulative done row `[False, True, True]` with rewards
`[-2.0, -1.0, 0.0]`, the valid maximum is `-1.0`; the previous mask included
the padded final zero and reported `0.0`.

Significant AI assistance disclosure: OpenAI Codex assisted with repository
search, test drafting, and implementation. I reviewed the control flow and
verified the behavior with the commands above.
