### PR TITLE
test(processor): pin policy pipeline structure and save/load contract

### DIFF
--- a/.github/workflows/fast_tests.yml
+++ b/.github/workflows/fast_tests.yml
@@ -104,25 +104,25 @@ jobs:
           uv run hf auth whoami
 
       - name: "Tier 1 — Test: base"
-        run: uv run pytest tests -vv --maxfail=10
+        run: uv run pytest tests -vv --maxfail=10 -m "not all_extras"
 
       # ── Tier 2: Dataset ──────────────────────────────────
       - name: "Tier 2 — Install: dataset"
         run: uv sync --locked --extra test --extra dataset
 
       - name: "Tier 2 — Test: dataset"
-        run: uv run pytest tests -vv --maxfail=10
+        run: uv run pytest tests -vv --maxfail=10 -m "not all_extras"
 
       # ── Tier 3: Hardware ─────────────────────────────────
       - name: "Tier 3 — Install: hardware"
         run: uv sync --locked --extra test --extra hardware
 
       - name: "Tier 3 — Test: hardware"
-        run: uv run pytest tests -vv --maxfail=10
+        run: uv run pytest tests -vv --maxfail=10 -m "not all_extras"
 
       # ── Tier 4: Viz ──────────────────────────────────────
       - name: "Tier 4 — Install: viz"
         run: uv sync --locked --extra test --extra viz
 
       - name: "Tier 4 — Test: viz"
-        run: uv run pytest tests -vv --maxfail=10
+        run: uv run pytest tests -vv --maxfail=10 -m "not all_extras"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -527,6 +527,7 @@ exclude = ["src/lerobot/policies/molmoact2/molmoact2_hf_model"]
 markers = [
     "multigpu: distributed tests needing 2-4 GPUs (CI: docker_publish.yml lane)",
     "multigpu_heavy: 8-GPU sweeps and soak tests; never run in CI",
+    "all_extras: needs `--extra all` and network access; runs in full_tests.yml only",
 ]
 
 [tool.mypy]

--- a/tests/artifacts/processors/generate_golden_processor_configs.py
+++ b/tests/artifacts/processors/generate_golden_processor_configs.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pin the serialized shape of every policy's pre/post-processor pipelines.
+
+These fixtures are the reference for the processor refactor that makes the policy config
+authoritative over a checkpoint's saved pipeline (see `tests/policies/test_processor_authority.py`).
+Rebuilding a pipeline from a config must produce the same structure the old deserializing loader
+produced, and that can only be verified against output captured *before* the refactor landed.
+
+Regenerate deliberately, never to make a failing test pass:
+
+    uv run python tests/artifacts/processors/generate_golden_processor_configs.py
+
+Check the working tree against the committed fixtures (what CI does):
+
+    uv run python tests/artifacts/processors/generate_golden_processor_configs.py --check
+
+A policy that cannot be built offline is recorded in `manifest.json` with its reason instead of
+being silently dropped, so the coverage gap stays visible.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+
+import torch
+
+from lerobot.configs.policies import PreTrainedConfig
+from lerobot.configs.types import FeatureType, PolicyFeature
+from lerobot.policies.factory import make_policy_config, make_pre_post_processors
+from lerobot.utils.constants import ACTION, OBS_IMAGE, OBS_IMAGES, OBS_STATE
+
+GOLDEN_DIR = Path(__file__).parent / "golden"
+MANIFEST_PATH = GOLDEN_DIR / "manifest.json"
+
+# Deliberately small and fixed. The fixtures pin pipeline *structure*, so the only thing these
+# numbers have to do is be shaped plausibly and never change.
+STATE_DIM = 6
+ACTION_DIM = 6
+IMAGE_SHAPE = (3, 96, 96)
+CAMERA_NAME = "cam"
+
+
+def _synthetic_features() -> tuple[dict[str, PolicyFeature], dict[str, PolicyFeature]]:
+    """Feature dicts covering both image key conventions, since policies disagree on which they use."""
+    input_features = {
+        OBS_STATE: PolicyFeature(type=FeatureType.STATE, shape=(STATE_DIM,)),
+        f"{OBS_IMAGE}.{CAMERA_NAME}": PolicyFeature(type=FeatureType.VISUAL, shape=IMAGE_SHAPE),
+        f"{OBS_IMAGES}.{CAMERA_NAME}": PolicyFeature(type=FeatureType.VISUAL, shape=IMAGE_SHAPE),
+    }
+    output_features = {ACTION: PolicyFeature(type=FeatureType.ACTION, shape=(ACTION_DIM,))}
+    return input_features, output_features
+
+
+def _synthetic_stats(features: dict[str, PolicyFeature]) -> dict[str, dict[str, torch.Tensor]]:
+    """Stats for every feature, covering all stat names any `NormalizationMode` may ask for."""
+    stats: dict[str, dict[str, torch.Tensor]] = {}
+    for key, feature in features.items():
+        if feature.type is FeatureType.VISUAL:
+            # Per-channel, in the (C, 1, 1) layout the normalizer reshapes visual stats into.
+            shape: tuple[int, ...] = (feature.shape[0], 1, 1)
+        else:
+            shape = feature.shape
+        stats[key] = {
+            "mean": torch.zeros(shape),
+            "std": torch.ones(shape),
+            "min": -torch.ones(shape),
+            "max": torch.ones(shape),
+            "q01": -torch.ones(shape),
+            "q99": torch.ones(shape),
+            "q10": -torch.ones(shape),
+            "q90": torch.ones(shape),
+        }
+    return stats
+
+
+def _build_pipelines(policy_type: str):
+    """Build one policy's pre/post-processor pipelines from its config alone.
+
+    Raises whatever the policy's factory raises; the caller records it as a skip.
+    """
+    input_features, output_features = _synthetic_features()
+    config = make_policy_config(policy_type, push_to_hub=False)
+    config.input_features = dict(input_features)
+    config.output_features = dict(output_features)
+    # cpu keeps `device_processor` output identical regardless of the generating machine.
+    config.device = "cpu"
+
+    stats = _synthetic_stats({**input_features, **output_features})
+    return make_pre_post_processors(config, dataset_stats=stats)
+
+
+def _build_configs(policy_type: str) -> dict[str, Any]:
+    """Build one policy's pipelines and return both serialized configs."""
+    preprocessor, postprocessor = _build_pipelines(policy_type)
+    # Canonicalize through JSON: what these fixtures pin is the on-disk contract, and `get_config()`
+    # returns Python objects that JSON flattens (feature shapes are tuples in memory, lists on disk).
+    # Comparing the in-memory form against a parsed fixture would report a difference on every shape.
+    return {
+        "pre": _as_serialized(preprocessor.get_config()),
+        "post": _as_serialized(postprocessor.get_config()),
+    }
+
+
+def _as_serialized(config: dict[str, Any]) -> dict[str, Any]:
+    """Return `config` as it would come back after `save_pretrained` and a reload."""
+    return json.loads(json.dumps(config))
+
+
+def _generate() -> dict[str, dict[str, Any]]:
+    """Build every known policy. A failure is fatal, including a missing optional dependency.
+
+    Skipping was tempting and wrong: `_write` records only what it built, so regenerating in an
+    environment missing an extra silently drops those policies from `covered` and the fixture set
+    shrinks without anyone noticing. Run this with `--extra all`.
+    """
+    return {
+        policy_type: _build_configs(policy_type)
+        for policy_type in sorted(PreTrainedConfig.get_known_choices())
+    }
+
+
+def _write(built: dict[str, dict[str, Any]]) -> None:
+    GOLDEN_DIR.mkdir(parents=True, exist_ok=True)
+    for policy_type, configs in built.items():
+        for role, config in configs.items():
+            path = GOLDEN_DIR / f"{policy_type}_{role}.json"
+            path.write_text(json.dumps(config, indent=2, sort_keys=True) + "\n")
+    MANIFEST_PATH.write_text(json.dumps({"covered": sorted(built)}, indent=2, sort_keys=True) + "\n")
+
+
+def _check(built: dict[str, dict[str, Any]]) -> int:
+    """Compare freshly built configs against the committed fixtures. Returns an exit code."""
+    if not MANIFEST_PATH.exists():
+        logging.error("no fixtures committed yet; run without --check first")
+        return 1
+    covered = json.loads(MANIFEST_PATH.read_text())["covered"]
+    mismatched: list[str] = []
+    for policy_type in covered:
+        if policy_type not in built:
+            mismatched.append(f"{policy_type}: covered by the fixtures but no longer builds")
+            continue
+        for role, config in built[policy_type].items():
+            path = GOLDEN_DIR / f"{policy_type}_{role}.json"
+            expected = json.loads(path.read_text())
+            if config != expected:
+                mismatched.append(f"{policy_type} ({role}): differs from {path.name}")
+    for line in mismatched:
+        logging.error("%s", line)
+    return 1 if mismatched else 0
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="compare against the committed fixtures instead of rewriting them",
+    )
+    args = parser.parse_args()
+
+    built = _generate()
+    logging.info("built %d policies", len(built))
+    if args.check:
+        return _check(built)
+    _write(built)
+    logging.info("wrote fixtures for %s", ", ".join(sorted(built)))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/artifacts/processors/generate_golden_processor_configs.py
+++ b/tests/artifacts/processors/generate_golden_processor_configs.py
@@ -16,11 +16,6 @@
 
 """Pin the serialized shape of every policy's pre/post-processor pipelines.
 
-These fixtures are the reference for the processor refactor that makes the policy config
-authoritative over a checkpoint's saved pipeline (see `tests/policies/test_processor_authority.py`).
-Rebuilding a pipeline from a config must produce the same structure the old deserializing loader
-produced, and that can only be verified against output captured *before* the refactor landed.
-
 Regenerate deliberately, never to make a failing test pass:
 
     uv run python tests/artifacts/processors/generate_golden_processor_configs.py
@@ -28,9 +23,6 @@ Regenerate deliberately, never to make a failing test pass:
 Check the working tree against the committed fixtures (what CI does):
 
     uv run python tests/artifacts/processors/generate_golden_processor_configs.py --check
-
-A policy that cannot be built offline is recorded in `manifest.json` with its reason instead of
-being silently dropped, so the coverage gap stays visible.
 """
 
 from __future__ import annotations
@@ -127,12 +119,7 @@ def _as_serialized(config: dict[str, Any]) -> dict[str, Any]:
 
 
 def _generate() -> dict[str, dict[str, Any]]:
-    """Build every known policy. A failure is fatal, including a missing optional dependency.
-
-    Skipping was tempting and wrong: `_write` records only what it built, so regenerating in an
-    environment missing an extra silently drops those policies from `covered` and the fixture set
-    shrinks without anyone noticing. Run this with `--extra all`.
-    """
+    """Build every known policy"""
     return {
         policy_type: _build_configs(policy_type)
         for policy_type in sorted(PreTrainedConfig.get_known_choices())

--- a/tests/artifacts/processors/golden/act_post.json
+++ b/tests/artifacts/processors/golden/act_post.json
@@ -1,0 +1,32 @@
+{
+  "name": "policy_postprocessor",
+  "steps": [
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          }
+        },
+        "norm_map": {
+          "ACTION": "MEAN_STD",
+          "STATE": "MEAN_STD",
+          "VISUAL": "MEAN_STD"
+        }
+      },
+      "registry_name": "unnormalizer_processor",
+      "state_file": "policy_postprocessor_step_0_unnormalizer_processor.safetensors"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/act_pre.json
+++ b/tests/artifacts/processors/golden/act_pre.json
@@ -1,0 +1,64 @@
+{
+  "name": "policy_preprocessor",
+  "steps": [
+    {
+      "config": {
+        "rename_map": {}
+      },
+      "registry_name": "rename_observations_processor"
+    },
+    {
+      "config": {},
+      "registry_name": "to_batch_processor"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    },
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          },
+          "observation.image.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.images.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.state": {
+            "shape": [
+              6
+            ],
+            "type": "STATE"
+          }
+        },
+        "norm_map": {
+          "ACTION": "MEAN_STD",
+          "STATE": "MEAN_STD",
+          "VISUAL": "MEAN_STD"
+        }
+      },
+      "registry_name": "normalizer_processor",
+      "state_file": "policy_preprocessor_step_3_normalizer_processor.safetensors"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/diffusion_post.json
+++ b/tests/artifacts/processors/golden/diffusion_post.json
@@ -1,0 +1,32 @@
+{
+  "name": "policy_postprocessor",
+  "steps": [
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          }
+        },
+        "norm_map": {
+          "ACTION": "MIN_MAX",
+          "STATE": "MIN_MAX",
+          "VISUAL": "MEAN_STD"
+        }
+      },
+      "registry_name": "unnormalizer_processor",
+      "state_file": "policy_postprocessor_step_0_unnormalizer_processor.safetensors"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/diffusion_pre.json
+++ b/tests/artifacts/processors/golden/diffusion_pre.json
@@ -1,0 +1,64 @@
+{
+  "name": "policy_preprocessor",
+  "steps": [
+    {
+      "config": {
+        "rename_map": {}
+      },
+      "registry_name": "rename_observations_processor"
+    },
+    {
+      "config": {},
+      "registry_name": "to_batch_processor"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    },
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          },
+          "observation.image.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.images.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.state": {
+            "shape": [
+              6
+            ],
+            "type": "STATE"
+          }
+        },
+        "norm_map": {
+          "ACTION": "MIN_MAX",
+          "STATE": "MIN_MAX",
+          "VISUAL": "MEAN_STD"
+        }
+      },
+      "registry_name": "normalizer_processor",
+      "state_file": "policy_preprocessor_step_3_normalizer_processor.safetensors"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/eo1_post.json
+++ b/tests/artifacts/processors/golden/eo1_post.json
@@ -1,0 +1,32 @@
+{
+  "name": "policy_postprocessor",
+  "steps": [
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          }
+        },
+        "norm_map": {
+          "ACTION": "MEAN_STD",
+          "STATE": "MEAN_STD",
+          "VISUAL": "IDENTITY"
+        }
+      },
+      "registry_name": "unnormalizer_processor",
+      "state_file": "policy_postprocessor_step_0_unnormalizer_processor.safetensors"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/eo1_pre.json
+++ b/tests/artifacts/processors/golden/eo1_pre.json
@@ -1,0 +1,103 @@
+{
+  "name": "policy_preprocessor",
+  "steps": [
+    {
+      "config": {
+        "rename_map": {}
+      },
+      "registry_name": "rename_observations_processor"
+    },
+    {
+      "config": {},
+      "registry_name": "to_batch_processor"
+    },
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          },
+          "observation.image.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.images.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.state": {
+            "shape": [
+              6
+            ],
+            "type": "STATE"
+          }
+        },
+        "norm_map": {
+          "ACTION": "MEAN_STD",
+          "STATE": "MEAN_STD",
+          "VISUAL": "IDENTITY"
+        }
+      },
+      "registry_name": "normalizer_processor",
+      "state_file": "policy_preprocessor_step_2_normalizer_processor.safetensors"
+    },
+    {
+      "config": {
+        "chunk_size": 8,
+        "input_features": {
+          "observation.image.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.images.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.state": {
+            "shape": [
+              6
+            ],
+            "type": "STATE"
+          }
+        }
+      },
+      "registry_name": "eo1_conversation_template_processor"
+    },
+    {
+      "config": {
+        "image_max_pixels": 100352,
+        "image_min_pixels": 50176,
+        "processor_name": "Qwen/Qwen2.5-VL-3B-Instruct",
+        "use_fast_processor": false
+      },
+      "registry_name": "eo1_qwen_processor"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/evo1_post.json
+++ b/tests/artifacts/processors/golden/evo1_post.json
@@ -1,0 +1,43 @@
+{
+  "name": "policy_postprocessor",
+  "steps": [
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              24
+            ],
+            "type": "ACTION"
+          }
+        },
+        "norm_map": {
+          "ACTION": "MIN_MAX",
+          "STATE": "MIN_MAX",
+          "VISUAL": "IDENTITY"
+        }
+      },
+      "registry_name": "unnormalizer_processor",
+      "state_file": "policy_postprocessor_step_0_unnormalizer_processor.safetensors"
+    },
+    {
+      "config": {
+        "action_dim": 6,
+        "binarize_gripper": false,
+        "gripper_above_threshold_value": -1.0,
+        "gripper_below_threshold_value": 1.0,
+        "gripper_index": 6,
+        "gripper_threshold": 0.5
+      },
+      "registry_name": "evo1_action_processor"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": "float32"
+      },
+      "registry_name": "device_processor"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/evo1_pre.json
+++ b/tests/artifacts/processors/golden/evo1_pre.json
@@ -1,0 +1,76 @@
+{
+  "name": "policy_preprocessor",
+  "steps": [
+    {
+      "config": {
+        "rename_map": {}
+      },
+      "registry_name": "rename_observations_processor"
+    },
+    {
+      "config": {},
+      "registry_name": "to_batch_processor"
+    },
+    {
+      "config": {
+        "max_state_dim": 24
+      },
+      "registry_name": "evo1_pad_state_processor"
+    },
+    {
+      "config": {
+        "max_action_dim": 24
+      },
+      "registry_name": "evo1_pad_action_processor"
+    },
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              24
+            ],
+            "type": "ACTION"
+          },
+          "observation.image.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.images.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.state": {
+            "shape": [
+              24
+            ],
+            "type": "STATE"
+          }
+        },
+        "norm_map": {
+          "ACTION": "MIN_MAX",
+          "STATE": "MIN_MAX",
+          "VISUAL": "IDENTITY"
+        }
+      },
+      "registry_name": "normalizer_processor",
+      "state_file": "policy_preprocessor_step_4_normalizer_processor.safetensors"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/fastwam_post.json
+++ b/tests/artifacts/processors/golden/fastwam_post.json
@@ -1,0 +1,32 @@
+{
+  "name": "policy_postprocessor",
+  "steps": [
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          }
+        },
+        "norm_map": {
+          "ACTION": "MEAN_STD",
+          "STATE": "MEAN_STD",
+          "VISUAL": "IDENTITY"
+        }
+      },
+      "registry_name": "unnormalizer_processor",
+      "state_file": "policy_postprocessor_step_0_unnormalizer_processor.safetensors"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/fastwam_pre.json
+++ b/tests/artifacts/processors/golden/fastwam_pre.json
@@ -1,0 +1,64 @@
+{
+  "name": "policy_preprocessor",
+  "steps": [
+    {
+      "config": {
+        "rename_map": {}
+      },
+      "registry_name": "rename_observations_processor"
+    },
+    {
+      "config": {},
+      "registry_name": "to_batch_processor"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    },
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          },
+          "observation.image.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.images.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.state": {
+            "shape": [
+              6
+            ],
+            "type": "STATE"
+          }
+        },
+        "norm_map": {
+          "ACTION": "MEAN_STD",
+          "STATE": "MEAN_STD",
+          "VISUAL": "IDENTITY"
+        }
+      },
+      "registry_name": "normalizer_processor",
+      "state_file": "policy_preprocessor_step_3_normalizer_processor.safetensors"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/gaussian_actor_post.json
+++ b/tests/artifacts/processors/golden/gaussian_actor_post.json
@@ -1,0 +1,33 @@
+{
+  "name": "policy_postprocessor",
+  "steps": [
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          }
+        },
+        "norm_map": {
+          "ACTION": "MIN_MAX",
+          "ENV": "MIN_MAX",
+          "STATE": "MIN_MAX",
+          "VISUAL": "MEAN_STD"
+        }
+      },
+      "registry_name": "unnormalizer_processor",
+      "state_file": "policy_postprocessor_step_0_unnormalizer_processor.safetensors"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/gaussian_actor_pre.json
+++ b/tests/artifacts/processors/golden/gaussian_actor_pre.json
@@ -1,0 +1,65 @@
+{
+  "name": "policy_preprocessor",
+  "steps": [
+    {
+      "config": {
+        "rename_map": {}
+      },
+      "registry_name": "rename_observations_processor"
+    },
+    {
+      "config": {},
+      "registry_name": "to_batch_processor"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    },
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          },
+          "observation.image.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.images.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.state": {
+            "shape": [
+              6
+            ],
+            "type": "STATE"
+          }
+        },
+        "norm_map": {
+          "ACTION": "MIN_MAX",
+          "ENV": "MIN_MAX",
+          "STATE": "MIN_MAX",
+          "VISUAL": "MEAN_STD"
+        }
+      },
+      "registry_name": "normalizer_processor",
+      "state_file": "policy_preprocessor_step_3_normalizer_processor.safetensors"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/groot_post.json
+++ b/tests/artifacts/processors/golden/groot_post.json
@@ -1,0 +1,23 @@
+{
+  "name": "policy_postprocessor",
+  "steps": [
+    {
+      "config": {
+        "clip_normalized_action": true,
+        "env_action_dim": 6,
+        "libero_gripper_action": false,
+        "libero_gripper_binarize": true,
+        "normalize_min_max": true
+      },
+      "registry_name": "groot_action_unpack_unnormalize_v2",
+      "state_file": "policy_postprocessor_step_0_groot_action_unpack_unnormalize_v2.safetensors"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/groot_pre.json
+++ b/tests/artifacts/processors/golden/groot_pre.json
@@ -1,0 +1,78 @@
+{
+  "name": "policy_preprocessor",
+  "steps": [
+    {
+      "config": {
+        "rename_map": {}
+      },
+      "registry_name": "rename_observations_processor"
+    },
+    {
+      "config": {},
+      "registry_name": "to_batch_processor"
+    },
+    {
+      "config": {
+        "action_horizon": 40,
+        "clip_outliers": true,
+        "embodiment_mapping": {
+          "libero_sim": 2,
+          "new_embodiment": 10,
+          "oxe_droid_relative_eef_relative_joint": 24,
+          "real_g1_relative_eef_relative_joints": 25,
+          "real_r1_pro_sharpa_relative_eef": 26,
+          "real_r1_pro_sharpa_relative_eef_human": 26,
+          "real_r1_pro_sharpa_relative_eef_maxinsights": 26,
+          "real_r1_pro_sharpa_relative_eef_mecka": 26,
+          "simpler_env_google": 0,
+          "simpler_env_widowx": 1,
+          "unitree_g1_full_body_with_waist_height_nav_cmd": 25,
+          "xdof_relative_eef_relative_joint": 27,
+          "xdof_relative_eef_relative_joint_subtask": 27
+        },
+        "embodiment_tag": "new_embodiment",
+        "formalize_language": true,
+        "language_key": "task",
+        "max_action_dim": 132,
+        "max_state_dim": 132,
+        "modality_config": null,
+        "normalize_min_max": true,
+        "raw_stats": null,
+        "state_dropout_prob": 0.0,
+        "state_horizon": 1,
+        "use_percentiles": false,
+        "valid_action_horizon": 40,
+        "video_horizon": null,
+        "video_modality_keys": null
+      },
+      "registry_name": "groot_n1_7_pack_inputs_v1",
+      "state_file": "policy_preprocessor_step_2_groot_n1_7_pack_inputs_v1.safetensors"
+    },
+    {
+      "config": {
+        "crop_fraction": null,
+        "device": "cpu",
+        "image_crop_size": [
+          230,
+          230
+        ],
+        "image_target_size": [
+          256,
+          256
+        ],
+        "letter_box_transform": false,
+        "model_name": "nvidia/Cosmos-Reason2-2B",
+        "shortest_image_edge": null,
+        "use_albumentations": false
+      },
+      "registry_name": "groot_n1_7_vlm_encode_v1"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/lingbot_va_post.json
+++ b/tests/artifacts/processors/golden/lingbot_va_post.json
@@ -1,0 +1,30 @@
+{
+  "name": "policy_postprocessor",
+  "steps": [
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          }
+        },
+        "norm_map": {
+          "ACTION": "QUANTILES"
+        }
+      },
+      "registry_name": "unnormalizer_processor",
+      "state_file": "policy_postprocessor_step_0_unnormalizer_processor.safetensors"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/lingbot_va_pre.json
+++ b/tests/artifacts/processors/golden/lingbot_va_pre.json
@@ -1,0 +1,64 @@
+{
+  "name": "policy_preprocessor",
+  "steps": [
+    {
+      "config": {
+        "rename_map": {}
+      },
+      "registry_name": "rename_observations_processor"
+    },
+    {
+      "config": {},
+      "registry_name": "to_batch_processor"
+    },
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          },
+          "observation.image.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.images.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.state": {
+            "shape": [
+              6
+            ],
+            "type": "STATE"
+          }
+        },
+        "norm_map": {
+          "ACTION": "IDENTITY",
+          "STATE": "IDENTITY",
+          "VISUAL": "IDENTITY"
+        }
+      },
+      "registry_name": "normalizer_processor",
+      "state_file": "policy_preprocessor_step_2_normalizer_processor.safetensors"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/manifest.json
+++ b/tests/artifacts/processors/golden/manifest.json
@@ -1,0 +1,23 @@
+{
+  "covered": [
+    "act",
+    "diffusion",
+    "eo1",
+    "evo1",
+    "fastwam",
+    "gaussian_actor",
+    "groot",
+    "lingbot_va",
+    "molmoact2",
+    "multi_task_dit",
+    "pi0",
+    "pi05",
+    "pi0_fast",
+    "smolvla",
+    "tdmpc",
+    "vla_jepa",
+    "vqbet",
+    "wall_x",
+    "xvla"
+  ]
+}

--- a/tests/artifacts/processors/golden/molmoact2_post.json
+++ b/tests/artifacts/processors/golden/molmoact2_post.json
@@ -1,0 +1,43 @@
+{
+  "name": "policy_postprocessor",
+  "steps": [
+    {
+      "config": {},
+      "registry_name": "molmoact2_clamp_action"
+    },
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          }
+        },
+        "norm_map": {
+          "ACTION": "QUANTILES",
+          "STATE": "QUANTILES",
+          "VISUAL": "IDENTITY"
+        }
+      },
+      "registry_name": "molmoact2_masked_unnormalizer",
+      "state_file": "policy_postprocessor_step_1_molmoact2_masked_unnormalizer.safetensors"
+    },
+    {
+      "config": {
+        "joint_offsets": null,
+        "joint_signs": null
+      },
+      "registry_name": "molmoact2_action_frame_transform"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/molmoact2_pre.json
+++ b/tests/artifacts/processors/golden/molmoact2_pre.json
@@ -1,0 +1,100 @@
+{
+  "name": "policy_preprocessor",
+  "steps": [
+    {
+      "config": {
+        "rename_map": {}
+      },
+      "registry_name": "rename_observations_processor"
+    },
+    {
+      "config": {},
+      "registry_name": "to_batch_processor"
+    },
+    {
+      "config": {
+        "joint_offsets": null,
+        "joint_signs": null
+      },
+      "registry_name": "molmoact2_state_frame_transform"
+    },
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          },
+          "observation.image.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.images.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.state": {
+            "shape": [
+              6
+            ],
+            "type": "STATE"
+          }
+        },
+        "norm_map": {
+          "ACTION": "QUANTILES",
+          "STATE": "QUANTILES",
+          "VISUAL": "IDENTITY"
+        }
+      },
+      "registry_name": "molmoact2_masked_normalizer",
+      "state_file": "policy_preprocessor_step_3_molmoact2_masked_normalizer.safetensors"
+    },
+    {
+      "config": {},
+      "registry_name": "molmoact2_clamp_normalized"
+    },
+    {
+      "config": {
+        "action_mode": "both",
+        "add_control_tokens": true,
+        "add_setup_tokens": true,
+        "allow_image_key_fallback": true,
+        "checkpoint_force_download": false,
+        "checkpoint_path": "allenai/MolmoAct2",
+        "checkpoint_revision": null,
+        "chunk_size": 30,
+        "control_mode": "",
+        "discrete_action_tokenizer": "allenai/MolmoAct2-FAST-Tokenizer",
+        "env_action_dim": 6,
+        "image_keys": [
+          "observation.image.cam",
+          "observation.images.cam"
+        ],
+        "max_action_dim": 32,
+        "max_sequence_length": null,
+        "normalize_language": true,
+        "num_state_tokens": 256,
+        "setup_type": ""
+      },
+      "registry_name": "molmoact2_pack_inputs"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/multi_task_dit_post.json
+++ b/tests/artifacts/processors/golden/multi_task_dit_post.json
@@ -1,0 +1,32 @@
+{
+  "name": "policy_postprocessor",
+  "steps": [
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          }
+        },
+        "norm_map": {
+          "ACTION": "MIN_MAX",
+          "STATE": "MIN_MAX",
+          "VISUAL": "MEAN_STD"
+        }
+      },
+      "registry_name": "unnormalizer_processor",
+      "state_file": "policy_postprocessor_step_0_unnormalizer_processor.safetensors"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/multi_task_dit_pre.json
+++ b/tests/artifacts/processors/golden/multi_task_dit_pre.json
@@ -1,0 +1,75 @@
+{
+  "name": "policy_preprocessor",
+  "steps": [
+    {
+      "config": {
+        "rename_map": {}
+      },
+      "registry_name": "rename_observations_processor"
+    },
+    {
+      "config": {},
+      "registry_name": "to_batch_processor"
+    },
+    {
+      "config": {
+        "max_length": 77,
+        "padding": "max_length",
+        "padding_side": "right",
+        "task_key": "task",
+        "tokenizer_name": "openai/clip-vit-base-patch16",
+        "truncation": true
+      },
+      "registry_name": "tokenizer_processor"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    },
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          },
+          "observation.image.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.images.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.state": {
+            "shape": [
+              6
+            ],
+            "type": "STATE"
+          }
+        },
+        "norm_map": {
+          "ACTION": "MIN_MAX",
+          "STATE": "MIN_MAX",
+          "VISUAL": "MEAN_STD"
+        }
+      },
+      "registry_name": "normalizer_processor",
+      "state_file": "policy_preprocessor_step_4_normalizer_processor.safetensors"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/pi05_post.json
+++ b/tests/artifacts/processors/golden/pi05_post.json
@@ -1,0 +1,38 @@
+{
+  "name": "policy_postprocessor",
+  "steps": [
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          }
+        },
+        "norm_map": {
+          "ACTION": "QUANTILES",
+          "STATE": "QUANTILES",
+          "VISUAL": "IDENTITY"
+        }
+      },
+      "registry_name": "unnormalizer_processor",
+      "state_file": "policy_postprocessor_step_0_unnormalizer_processor.safetensors"
+    },
+    {
+      "config": {
+        "enabled": false
+      },
+      "registry_name": "absolute_actions_processor"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/pi05_pre.json
+++ b/tests/artifacts/processors/golden/pi05_pre.json
@@ -1,0 +1,89 @@
+{
+  "name": "policy_preprocessor",
+  "steps": [
+    {
+      "config": {
+        "rename_map": {}
+      },
+      "registry_name": "rename_observations_processor"
+    },
+    {
+      "config": {},
+      "registry_name": "to_batch_processor"
+    },
+    {
+      "config": {
+        "action_names": null,
+        "enabled": false,
+        "exclude_joints": [
+          "gripper"
+        ]
+      },
+      "registry_name": "relative_actions_processor"
+    },
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          },
+          "observation.image.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.images.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.state": {
+            "shape": [
+              6
+            ],
+            "type": "STATE"
+          }
+        },
+        "norm_map": {
+          "ACTION": "QUANTILES",
+          "STATE": "QUANTILES",
+          "VISUAL": "IDENTITY"
+        }
+      },
+      "registry_name": "normalizer_processor",
+      "state_file": "policy_preprocessor_step_3_normalizer_processor.safetensors"
+    },
+    {
+      "config": {},
+      "registry_name": "pi05_prepare_state_tokenizer_processor_step"
+    },
+    {
+      "config": {
+        "max_length": 200,
+        "padding": "max_length",
+        "padding_side": "right",
+        "task_key": "task",
+        "tokenizer_name": "google/paligemma-3b-pt-224",
+        "truncation": true
+      },
+      "registry_name": "tokenizer_processor"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/pi0_fast_post.json
+++ b/tests/artifacts/processors/golden/pi0_fast_post.json
@@ -1,0 +1,38 @@
+{
+  "name": "policy_postprocessor",
+  "steps": [
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          }
+        },
+        "norm_map": {
+          "ACTION": "MEAN_STD",
+          "STATE": "MEAN_STD",
+          "VISUAL": "IDENTITY"
+        }
+      },
+      "registry_name": "unnormalizer_processor",
+      "state_file": "policy_postprocessor_step_0_unnormalizer_processor.safetensors"
+    },
+    {
+      "config": {
+        "enabled": false
+      },
+      "registry_name": "absolute_actions_processor"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/pi0_fast_pre.json
+++ b/tests/artifacts/processors/golden/pi0_fast_pre.json
@@ -1,0 +1,100 @@
+{
+  "name": "policy_preprocessor",
+  "steps": [
+    {
+      "config": {
+        "rename_map": {}
+      },
+      "registry_name": "rename_observations_processor"
+    },
+    {
+      "config": {},
+      "registry_name": "to_batch_processor"
+    },
+    {
+      "config": {
+        "action_names": null,
+        "enabled": false,
+        "exclude_joints": [
+          "gripper"
+        ]
+      },
+      "registry_name": "relative_actions_processor"
+    },
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          },
+          "observation.image.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.images.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.state": {
+            "shape": [
+              6
+            ],
+            "type": "STATE"
+          }
+        },
+        "norm_map": {
+          "ACTION": "MEAN_STD",
+          "STATE": "MEAN_STD",
+          "VISUAL": "IDENTITY"
+        }
+      },
+      "registry_name": "normalizer_processor",
+      "state_file": "policy_preprocessor_step_3_normalizer_processor.safetensors"
+    },
+    {
+      "config": {},
+      "registry_name": "pi0_fast_prepare_state_tokenizer_processor_step"
+    },
+    {
+      "config": {
+        "max_length": 200,
+        "padding": "max_length",
+        "padding_side": "right",
+        "task_key": "task",
+        "tokenizer_name": "google/paligemma-3b-pt-224",
+        "truncation": true
+      },
+      "registry_name": "tokenizer_processor"
+    },
+    {
+      "config": {
+        "action_tokenizer_name": "lerobot/fast-action-tokenizer",
+        "allow_truncation": true,
+        "fast_skip_tokens": 128,
+        "max_action_tokens": 256,
+        "paligemma_tokenizer_name": "google/paligemma-3b-pt-224",
+        "trust_remote_code": true
+      },
+      "registry_name": "action_tokenizer_processor"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/pi0_post.json
+++ b/tests/artifacts/processors/golden/pi0_post.json
@@ -1,0 +1,38 @@
+{
+  "name": "policy_postprocessor",
+  "steps": [
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          }
+        },
+        "norm_map": {
+          "ACTION": "MEAN_STD",
+          "STATE": "MEAN_STD",
+          "VISUAL": "IDENTITY"
+        }
+      },
+      "registry_name": "unnormalizer_processor",
+      "state_file": "policy_postprocessor_step_0_unnormalizer_processor.safetensors"
+    },
+    {
+      "config": {
+        "enabled": false
+      },
+      "registry_name": "absolute_actions_processor"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/pi0_pre.json
+++ b/tests/artifacts/processors/golden/pi0_pre.json
@@ -1,0 +1,89 @@
+{
+  "name": "policy_preprocessor",
+  "steps": [
+    {
+      "config": {
+        "rename_map": {}
+      },
+      "registry_name": "rename_observations_processor"
+    },
+    {
+      "config": {},
+      "registry_name": "to_batch_processor"
+    },
+    {
+      "config": {},
+      "registry_name": "pi0_new_line_processor"
+    },
+    {
+      "config": {
+        "max_length": 48,
+        "padding": "max_length",
+        "padding_side": "right",
+        "task_key": "task",
+        "tokenizer_name": "google/paligemma-3b-pt-224",
+        "truncation": true
+      },
+      "registry_name": "tokenizer_processor"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    },
+    {
+      "config": {
+        "action_names": null,
+        "enabled": false,
+        "exclude_joints": [
+          "gripper"
+        ]
+      },
+      "registry_name": "relative_actions_processor"
+    },
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          },
+          "observation.image.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.images.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.state": {
+            "shape": [
+              6
+            ],
+            "type": "STATE"
+          }
+        },
+        "norm_map": {
+          "ACTION": "MEAN_STD",
+          "STATE": "MEAN_STD",
+          "VISUAL": "IDENTITY"
+        }
+      },
+      "registry_name": "normalizer_processor",
+      "state_file": "policy_preprocessor_step_6_normalizer_processor.safetensors"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/smolvla_post.json
+++ b/tests/artifacts/processors/golden/smolvla_post.json
@@ -1,0 +1,32 @@
+{
+  "name": "policy_postprocessor",
+  "steps": [
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          }
+        },
+        "norm_map": {
+          "ACTION": "MEAN_STD",
+          "STATE": "MEAN_STD",
+          "VISUAL": "IDENTITY"
+        }
+      },
+      "registry_name": "unnormalizer_processor",
+      "state_file": "policy_postprocessor_step_0_unnormalizer_processor.safetensors"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/smolvla_pre.json
+++ b/tests/artifacts/processors/golden/smolvla_pre.json
@@ -1,0 +1,79 @@
+{
+  "name": "policy_preprocessor",
+  "steps": [
+    {
+      "config": {
+        "rename_map": {}
+      },
+      "registry_name": "rename_observations_processor"
+    },
+    {
+      "config": {},
+      "registry_name": "to_batch_processor"
+    },
+    {
+      "config": {},
+      "registry_name": "smolvla_new_line_processor"
+    },
+    {
+      "config": {
+        "max_length": 48,
+        "padding": "longest",
+        "padding_side": "right",
+        "task_key": "task",
+        "tokenizer_name": "HuggingFaceTB/SmolVLM2-500M-Video-Instruct",
+        "truncation": true
+      },
+      "registry_name": "tokenizer_processor"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    },
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          },
+          "observation.image.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.images.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.state": {
+            "shape": [
+              6
+            ],
+            "type": "STATE"
+          }
+        },
+        "norm_map": {
+          "ACTION": "MEAN_STD",
+          "STATE": "MEAN_STD",
+          "VISUAL": "IDENTITY"
+        }
+      },
+      "registry_name": "normalizer_processor",
+      "state_file": "policy_preprocessor_step_5_normalizer_processor.safetensors"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/tdmpc_post.json
+++ b/tests/artifacts/processors/golden/tdmpc_post.json
@@ -1,0 +1,33 @@
+{
+  "name": "policy_postprocessor",
+  "steps": [
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          }
+        },
+        "norm_map": {
+          "ACTION": "MIN_MAX",
+          "ENV": "IDENTITY",
+          "STATE": "IDENTITY",
+          "VISUAL": "IDENTITY"
+        }
+      },
+      "registry_name": "unnormalizer_processor",
+      "state_file": "policy_postprocessor_step_0_unnormalizer_processor.safetensors"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/tdmpc_pre.json
+++ b/tests/artifacts/processors/golden/tdmpc_pre.json
@@ -1,0 +1,65 @@
+{
+  "name": "policy_preprocessor",
+  "steps": [
+    {
+      "config": {
+        "rename_map": {}
+      },
+      "registry_name": "rename_observations_processor"
+    },
+    {
+      "config": {},
+      "registry_name": "to_batch_processor"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    },
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          },
+          "observation.image.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.images.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.state": {
+            "shape": [
+              6
+            ],
+            "type": "STATE"
+          }
+        },
+        "norm_map": {
+          "ACTION": "MIN_MAX",
+          "ENV": "IDENTITY",
+          "STATE": "IDENTITY",
+          "VISUAL": "IDENTITY"
+        }
+      },
+      "registry_name": "normalizer_processor",
+      "state_file": "policy_preprocessor_step_3_normalizer_processor.safetensors"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/vla_jepa_post.json
+++ b/tests/artifacts/processors/golden/vla_jepa_post.json
@@ -6,10 +6,6 @@
       "registry_name": "vla_jepa_clip_actions"
     },
     {
-      "config": {},
-      "registry_name": "vla_jepa_pre_snap_gripper"
-    },
-    {
       "config": {
         "eps": 1e-08,
         "features": {
@@ -49,11 +45,13 @@
         }
       },
       "registry_name": "unnormalizer_processor",
-      "state_file": "policy_postprocessor_step_2_unnormalizer_processor.safetensors"
+      "state_file": "policy_postprocessor_step_1_unnormalizer_processor.safetensors"
     },
     {
-      "config": {},
-      "registry_name": "vla_jepa_binarize_gripper"
+      "config": {
+        "enabled": false
+      },
+      "registry_name": "absolute_actions_processor"
     },
     {
       "config": {

--- a/tests/artifacts/processors/golden/vla_jepa_post.json
+++ b/tests/artifacts/processors/golden/vla_jepa_post.json
@@ -1,0 +1,66 @@
+{
+  "name": "policy_postprocessor",
+  "steps": [
+    {
+      "config": {},
+      "registry_name": "vla_jepa_clip_actions"
+    },
+    {
+      "config": {},
+      "registry_name": "vla_jepa_pre_snap_gripper"
+    },
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          },
+          "observation.image.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.images.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.state": {
+            "shape": [
+              6
+            ],
+            "type": "STATE"
+          }
+        },
+        "norm_map": {
+          "ACTION": "MIN_MAX",
+          "STATE": "MEAN_STD",
+          "VISUAL": "IDENTITY"
+        }
+      },
+      "registry_name": "unnormalizer_processor",
+      "state_file": "policy_postprocessor_step_2_unnormalizer_processor.safetensors"
+    },
+    {
+      "config": {},
+      "registry_name": "vla_jepa_binarize_gripper"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/vla_jepa_pre.json
+++ b/tests/artifacts/processors/golden/vla_jepa_pre.json
@@ -1,0 +1,64 @@
+{
+  "name": "policy_preprocessor",
+  "steps": [
+    {
+      "config": {
+        "rename_map": {}
+      },
+      "registry_name": "rename_observations_processor"
+    },
+    {
+      "config": {},
+      "registry_name": "to_batch_processor"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    },
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          },
+          "observation.image.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.images.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.state": {
+            "shape": [
+              6
+            ],
+            "type": "STATE"
+          }
+        },
+        "norm_map": {
+          "ACTION": "MIN_MAX",
+          "STATE": "MEAN_STD",
+          "VISUAL": "IDENTITY"
+        }
+      },
+      "registry_name": "normalizer_processor",
+      "state_file": "policy_preprocessor_step_3_normalizer_processor.safetensors"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/vla_jepa_pre.json
+++ b/tests/artifacts/processors/golden/vla_jepa_pre.json
@@ -20,6 +20,23 @@
     },
     {
       "config": {
+        "expand_channels": true,
+        "resize_to": null
+      },
+      "registry_name": "vla_jepa_image_prep"
+    },
+    {
+      "config": {
+        "action_names": null,
+        "enabled": false,
+        "exclude_joints": [
+          "gripper"
+        ]
+      },
+      "registry_name": "relative_actions_processor"
+    },
+    {
+      "config": {
         "eps": 1e-08,
         "features": {
           "action": {
@@ -58,7 +75,7 @@
         }
       },
       "registry_name": "normalizer_processor",
-      "state_file": "policy_preprocessor_step_3_normalizer_processor.safetensors"
+      "state_file": "policy_preprocessor_step_5_normalizer_processor.safetensors"
     }
   ]
 }

--- a/tests/artifacts/processors/golden/vqbet_post.json
+++ b/tests/artifacts/processors/golden/vqbet_post.json
@@ -1,0 +1,32 @@
+{
+  "name": "policy_postprocessor",
+  "steps": [
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          }
+        },
+        "norm_map": {
+          "ACTION": "MIN_MAX",
+          "STATE": "MIN_MAX",
+          "VISUAL": "IDENTITY"
+        }
+      },
+      "registry_name": "unnormalizer_processor",
+      "state_file": "policy_postprocessor_step_0_unnormalizer_processor.safetensors"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/vqbet_pre.json
+++ b/tests/artifacts/processors/golden/vqbet_pre.json
@@ -1,0 +1,64 @@
+{
+  "name": "policy_preprocessor",
+  "steps": [
+    {
+      "config": {
+        "rename_map": {}
+      },
+      "registry_name": "rename_observations_processor"
+    },
+    {
+      "config": {},
+      "registry_name": "to_batch_processor"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    },
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          },
+          "observation.image.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.images.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.state": {
+            "shape": [
+              6
+            ],
+            "type": "STATE"
+          }
+        },
+        "norm_map": {
+          "ACTION": "MIN_MAX",
+          "STATE": "MIN_MAX",
+          "VISUAL": "IDENTITY"
+        }
+      },
+      "registry_name": "normalizer_processor",
+      "state_file": "policy_preprocessor_step_3_normalizer_processor.safetensors"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/wall_x_post.json
+++ b/tests/artifacts/processors/golden/wall_x_post.json
@@ -1,0 +1,32 @@
+{
+  "name": "policy_postprocessor",
+  "steps": [
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          }
+        },
+        "norm_map": {
+          "ACTION": "MEAN_STD",
+          "STATE": "MEAN_STD",
+          "VISUAL": "IDENTITY"
+        }
+      },
+      "registry_name": "unnormalizer_processor",
+      "state_file": "policy_postprocessor_step_0_unnormalizer_processor.safetensors"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/wall_x_pre.json
+++ b/tests/artifacts/processors/golden/wall_x_pre.json
@@ -1,0 +1,68 @@
+{
+  "name": "policy_preprocessor",
+  "steps": [
+    {
+      "config": {
+        "rename_map": {}
+      },
+      "registry_name": "rename_observations_processor"
+    },
+    {
+      "config": {},
+      "registry_name": "to_batch_processor"
+    },
+    {
+      "config": {},
+      "registry_name": "wall_x_task_processor"
+    },
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          },
+          "observation.image.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.images.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.state": {
+            "shape": [
+              6
+            ],
+            "type": "STATE"
+          }
+        },
+        "norm_map": {
+          "ACTION": "MEAN_STD",
+          "STATE": "MEAN_STD",
+          "VISUAL": "IDENTITY"
+        }
+      },
+      "registry_name": "normalizer_processor",
+      "state_file": "policy_preprocessor_step_3_normalizer_processor.safetensors"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/xvla_post.json
+++ b/tests/artifacts/processors/golden/xvla_post.json
@@ -1,0 +1,32 @@
+{
+  "name": "policy_postprocessor",
+  "steps": [
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          }
+        },
+        "norm_map": {
+          "ACTION": "IDENTITY",
+          "STATE": "IDENTITY",
+          "VISUAL": "IDENTITY"
+        }
+      },
+      "registry_name": "unnormalizer_processor",
+      "state_file": "policy_postprocessor_step_0_unnormalizer_processor.safetensors"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    }
+  ]
+}

--- a/tests/artifacts/processors/golden/xvla_pre.json
+++ b/tests/artifacts/processors/golden/xvla_pre.json
@@ -1,0 +1,94 @@
+{
+  "name": "policy_preprocessor",
+  "steps": [
+    {
+      "config": {
+        "rename_map": {}
+      },
+      "registry_name": "rename_observations_processor"
+    },
+    {
+      "config": {},
+      "registry_name": "to_batch_processor"
+    },
+    {
+      "config": {
+        "max_length": 64,
+        "padding": "max_length",
+        "padding_side": "right",
+        "task_key": "task",
+        "tokenizer_name": "facebook/bart-large",
+        "truncation": true
+      },
+      "registry_name": "tokenizer_processor"
+    },
+    {
+      "config": {
+        "image_keys": null,
+        "validate_range": true
+      },
+      "registry_name": "xvla_image_to_float"
+    },
+    {
+      "config": {
+        "image_keys": null
+      },
+      "registry_name": "xvla_imagenet_normalize"
+    },
+    {
+      "config": {
+        "domain_id": 0
+      },
+      "registry_name": "xvla_add_domain_id"
+    },
+    {
+      "config": {
+        "device": "cpu",
+        "float_dtype": null
+      },
+      "registry_name": "device_processor"
+    },
+    {
+      "config": {
+        "eps": 1e-08,
+        "features": {
+          "action": {
+            "shape": [
+              6
+            ],
+            "type": "ACTION"
+          },
+          "observation.image.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.images.cam": {
+            "shape": [
+              3,
+              96,
+              96
+            ],
+            "type": "VISUAL"
+          },
+          "observation.state": {
+            "shape": [
+              6
+            ],
+            "type": "STATE"
+          }
+        },
+        "norm_map": {
+          "ACTION": "IDENTITY",
+          "STATE": "IDENTITY",
+          "VISUAL": "IDENTITY"
+        }
+      },
+      "registry_name": "normalizer_processor",
+      "state_file": "policy_preprocessor_step_7_normalizer_processor.safetensors"
+    }
+  ]
+}

--- a/tests/processor/test_golden_pipelines.py
+++ b/tests/processor/test_golden_pipelines.py
@@ -71,6 +71,7 @@ from generate_golden_processor_configs import (  # noqa: E402
 pytestmark = pytest.mark.all_extras
 
 GOLDEN_DIR = ARTIFACTS_DIR / "golden"
+GENERATOR_PATH = "tests/artifacts/processors/generate_golden_processor_configs.py"
 COVERED = sorted(json.loads((GOLDEN_DIR / "manifest.json").read_text())["covered"])
 
 # `save_pretrained` names each config file after the pipeline, so these are the filenames
@@ -83,8 +84,13 @@ ROLE_FILENAMES = {
 
 def test_the_fixtures_cover_every_known_policy():
     """`covered` must list every policy, so no policy can quietly fall out of the fixture set."""
-    assert sorted(PreTrainedConfig.get_known_choices()) == COVERED, (
-        "the golden fixtures no longer cover every known policy; regenerate them with --extra all"
+    known = set(PreTrainedConfig.get_known_choices())
+    missing = sorted(known - set(COVERED))
+    stale = sorted(set(COVERED) - known)
+    assert not (missing or stale), (
+        f"golden fixtures are out of sync with the policy registry: "
+        f"no fixture for {missing or 'nothing'}, fixture for unknown {stale or 'nothing'}. "
+        f"Regenerate with `uv run python {GENERATOR_PATH}` using --extra all."
     )
 
 

--- a/tests/processor/test_golden_pipelines.py
+++ b/tests/processor/test_golden_pipelines.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pin the serialized shape of every policy's processor pipelines, and its save/load contract.
+
+Touching a `ProcessorStep` — converting it to a specialized base, adding a field, changing what
+`get_config()` emits — changes what a checkpoint's pipeline looks like on disk. Those changes are
+mostly invisible: a step silently added to a pipeline is train/inference skew with no warning, and a
+`get_config()` key the constructor cannot accept only fails the next time somebody loads a
+checkpoint. These tests make both loud.
+
+Three guarantees, cheapest first:
+
+1. `test_every_policy_builds_from_config_alone` — the pipeline builds at all.
+2. `test_serialized_pipeline_matches_the_golden_fixture` — its serialized structure has not drifted
+   from the committed fixture (step list, per-step config, state files).
+3. `test_pipelines_survive_a_save_load_roundtrip` — `save_pretrained` output can actually be read
+   back by `from_pretrained`, and the reloaded pipeline serializes identically. This is the one that
+   catches a step which is registered but cannot be reconstructed from its own `get_config()`.
+
+**Marked `all_extras`, and deliberately without a skip path.** A missing dependency is a failure
+here, not a skip: the fixture set is only meaningful if it covers every policy, and a per-policy skip
+silently narrows coverage to whatever the runner happened to have installed. Building a pipeline is
+also not hermetic — `MolmoAct2PackInputsProcessorStep.__post_init__` calls `require_package("scipy")`,
+and `ActionTokenizerProcessorStep.__post_init__` reaches the Hub for a `trust_remote_code` processor —
+so these need `--extra all` plus network, which is `full_tests.yml`. `fast_tests.yml` deselects the
+marker.
+
+Fixtures live in `tests/artifacts/processors/golden/` and are regenerated deliberately:
+
+    uv run python tests/artifacts/processors/generate_golden_processor_configs.py
+
+Never regenerate to make a failing test pass. A diff here is a real change to the on-disk contract;
+the fixture update belongs in the same commit as the change that caused it, so review sees both.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from lerobot.configs.policies import PreTrainedConfig
+from lerobot.processor import PolicyProcessorPipeline
+from lerobot.utils.constants import (
+    POLICY_POSTPROCESSOR_DEFAULT_NAME,
+    POLICY_PREPROCESSOR_DEFAULT_NAME,
+)
+
+ARTIFACTS_DIR = Path(__file__).parents[1] / "artifacts" / "processors"
+sys.path.insert(0, str(ARTIFACTS_DIR))
+from generate_golden_processor_configs import (  # noqa: E402
+    _as_serialized,
+    _build_configs,
+    _build_pipelines,
+)
+
+pytestmark = pytest.mark.all_extras
+
+GOLDEN_DIR = ARTIFACTS_DIR / "golden"
+COVERED = sorted(json.loads((GOLDEN_DIR / "manifest.json").read_text())["covered"])
+
+# `save_pretrained` names each config file after the pipeline, so these are the filenames
+# `from_pretrained` has to be pointed at.
+ROLE_FILENAMES = {
+    "pre": f"{POLICY_PREPROCESSOR_DEFAULT_NAME}.json",
+    "post": f"{POLICY_POSTPROCESSOR_DEFAULT_NAME}.json",
+}
+
+
+def test_the_fixtures_cover_every_known_policy():
+    """`covered` must list every policy, so no policy can quietly fall out of the fixture set."""
+    assert sorted(PreTrainedConfig.get_known_choices()) == COVERED, (
+        "the golden fixtures no longer cover every known policy; regenerate them with --extra all"
+    )
+
+
+@pytest.mark.parametrize("policy_type", sorted(PreTrainedConfig.get_known_choices()))
+def test_every_policy_builds_from_config_alone(policy_type):
+    """Every policy must build its pipelines from its config, with no checkpoint involved."""
+    _build_configs(policy_type)
+
+
+@pytest.mark.parametrize("policy_type", COVERED)
+def test_serialized_pipeline_matches_the_golden_fixture(policy_type):
+    """The serialized pipeline structure must match the committed fixture, step for step."""
+    for role, config in _build_configs(policy_type).items():
+        expected = json.loads((GOLDEN_DIR / f"{policy_type}_{role}.json").read_text())
+        assert config == expected, (
+            f"{policy_type} {role} pipeline drifted from {policy_type}_{role}.json. "
+            "If the change is intended, regenerate the fixtures in this same commit."
+        )
+
+
+def _shape(config: dict) -> list[tuple[str | None, tuple[str, ...]]]:
+    """The part of a serialized pipeline a reload must reproduce: each step, and its config keys.
+
+    Config *values* are deliberately excluded, because a step is allowed to rewrite them when it
+    vendors an asset into the checkpoint. `TokenizerProcessorStep` does exactly that: it writes the
+    tokenizer files next to the config so the checkpoint loads offline, so on reload `tokenizer_name`
+    points at the vendored copy rather than the original Hub id. That rewrite is the feature. Exact
+    values are already pinned by `test_serialized_pipeline_matches_the_golden_fixture`.
+    """
+    return [
+        (step.get("registry_name") or step.get("class_name"), tuple(sorted(step.get("config", {}))))
+        for step in config["steps"]
+    ]
+
+
+@pytest.mark.parametrize("policy_type", COVERED)
+def test_pipelines_survive_a_save_load_roundtrip(policy_type, tmp_path):
+    """What `save_pretrained` writes must be readable back by `from_pretrained`.
+
+    A step can serialize fine and still be unloadable — if `get_config()` omits a required
+    constructor argument, or emits a key the constructor does not accept, the failure only surfaces
+    the next time somebody loads a checkpoint. `from_pretrained` raising is the primary assertion
+    here; comparing shapes then catches a step silently dropped or reconstructed differently.
+    """
+    preprocessor, postprocessor = _build_pipelines(policy_type)
+
+    for role, pipeline in (("pre", preprocessor), ("post", postprocessor)):
+        save_dir = tmp_path / f"{policy_type}_{role}"
+        pipeline.save_pretrained(save_dir)
+
+        reloaded = PolicyProcessorPipeline.from_pretrained(save_dir, config_filename=ROLE_FILENAMES[role])
+
+        expected = json.loads((GOLDEN_DIR / f"{policy_type}_{role}.json").read_text())
+        assert _shape(_as_serialized(reloaded.get_config())) == _shape(expected), (
+            f"{policy_type} {role} pipeline did not survive a save_pretrained/from_pretrained "
+            "roundtrip: the reloaded pipeline has a different step or config shape."
+        )


### PR DESCRIPTION
Touching a `ProcessorStep` changes what a checkpoint's pipeline looks like on disk, and today nothing catches it. A step silently added to a pipeline is train/inference skew with no warning, and a `get_config()` key the constructor cannot accept only fails the next time somebody loads a checkpoint.

Adds golden fixtures for all 19 policies' pre/post-processor pipelines, and three checks over them:

- the pipeline builds from its config alone
- its serialized structure matches the committed fixture, step for step
- what `save_pretrained` writes can be read back by `from_pretrained`

To regenerate the processors if there needs to be a change:

```
uv run python tests/artifacts/processors/generate_golden_processor_configs.py
```