### PR TITLE
perf(fastwam): add compiled cached action inference

### DIFF
--- a/docs/source/fastwam.mdx
+++ b/docs/source/fastwam.mdx
@@ -122,6 +122,20 @@ FastWAM loads the Wan VAE, video DiT, text encoder, and tokenizer from the confi
 
 FastWAM's DiT uses PyTorch's `scaled_dot_product_attention` (SDPA) for all attention. It does **not** use FlashAttention: its Mixture-of-Transformers (MoT) routing needs arbitrary boolean `[query, key]` attention masks, which the FlashAttention varlen API cannot express. Installing the `flash-attn` package therefore has no effect on the FastWAM path. (Note that SDPA itself may still select PyTorch's own flash / memory-efficient / math kernel internally — this is unrelated to the `flash-attn` package.)
 
+### Compiled Action Inference
+
+FastWAM can compile its video-prefill and cached action-denoising graphs to reduce
+Python and CUDA kernel-launch overhead across the repeated inference steps:
+
+```bash
+--policy.compile_action_infer=true
+```
+
+The option is disabled by default. The first action prediction compiles a graph
+for the current input shapes and is therefore slower; later predictions with the
+same shapes reuse it. Shape changes may trigger recompilation. The eager path
+remains available on unsupported PyTorch or accelerator configurations.
+
 ### LIBERO Action Toggle
 
 FastWAM LIBERO checkpoints use `policy.toggle_action_dimensions=[-1]` by

--- a/src/lerobot/policies/fastwam/configuration_fastwam.py
+++ b/src/lerobot/policies/fastwam/configuration_fastwam.py
@@ -172,6 +172,9 @@ class FastWAMConfig(PreTrainedConfig):
         action_dit_config (dict[str, Any] | None): Action expert config.
         use_gradient_checkpointing (bool): Enable activation checkpointing in both DiT
             experts (trades compute for memory; propagated into the DiT configs).
+        compile_action_infer (bool): Compile the cached action-denoising path with
+            ``torch.compile`` in reduce-overhead mode. The first inference call incurs
+            compilation warm-up; subsequent calls with the same shapes reuse the graph.
         freeze_video_expert (bool): Freeze the ~5B Wan video expert
             (`model.video_expert`) so only the action expert + proprio encoder train.
             Cuts the AdamW optimizer footprint substantially; the video expert keeps its
@@ -207,6 +210,7 @@ class FastWAMConfig(PreTrainedConfig):
     sigma_shift: float | None = None
     tiled: bool = False
     fp32_attention: bool = True
+    compile_action_infer: bool = False
     use_gradient_checkpointing: bool = False
     freeze_video_expert: bool = False
     toggle_action_dimensions: list[int] = field(default_factory=list)

--- a/src/lerobot/policies/fastwam/modeling_fastwam.py
+++ b/src/lerobot/policies/fastwam/modeling_fastwam.py
@@ -314,6 +314,7 @@ def _batch_to_infer_kwargs(batch: dict[str, Tensor], config: FastWAMConfig) -> d
         "seed": batch.get("seed", config.inference_seed),
         "rand_device": batch.get("rand_device", config.rand_device),
         "tiled": bool(batch.get("tiled", config.tiled)),
+        "compile_action_infer": bool(batch.get("compile_action_infer", config.compile_action_infer)),
     }
 
 

--- a/src/lerobot/policies/fastwam/wan/modular.py
+++ b/src/lerobot/policies/fastwam/wan/modular.py
@@ -1799,6 +1799,7 @@ class FastWAM(torch.nn.Module):
         seed: int | None = None,
         rand_device: str = "cpu",
         tiled: bool = False,
+        compile_action_infer: bool = False,
     ) -> dict[str, Any]:
         self.eval()
         if str(getattr(self.video_expert, "video_attention_mask_mode", "")) != "first_frame_causal":
@@ -1834,7 +1835,27 @@ class FastWAM(torch.nn.Module):
             video_tokens_per_frame=int(video_pre["meta"]["tokens_per_frame"]),
             device=video_pre["tokens"].device,
         )
-        video_kv_cache = self.mot.prefill_video_cache(
+        video_prefiller = self.mot.prefill_video_cache
+        action_denoiser = self._predict_action_noise_with_cache
+        if compile_action_infer:
+            if not hasattr(self, "_compiled_video_prefiller"):
+                self._compiled_video_prefiller = torch.compile(
+                    self.mot.prefill_video_cache,
+                    mode="reduce-overhead",
+                    fullgraph=True,
+                )
+            if not hasattr(self, "_compiled_action_denoiser"):
+                self._compiled_action_denoiser = torch.compile(
+                    self._predict_action_noise_with_cache,
+                    mode="reduce-overhead",
+                    fullgraph=True,
+                )
+            video_prefiller = self._compiled_video_prefiller
+            action_denoiser = self._compiled_action_denoiser
+            if self.device.type == "cuda":
+                torch.compiler.cudagraph_mark_step_begin()
+
+        video_kv_cache = video_prefiller(
             video_tokens=video_pre["tokens"],
             video_freqs=video_pre["freqs"],
             video_t_mod=video_pre["t_mod"],
@@ -1844,6 +1865,14 @@ class FastWAM(torch.nn.Module):
             },
             video_attention_mask=attention_mask[:video_seq_len, :video_seq_len],
         )
+        if compile_action_infer:
+            # Inductor's reduce-overhead mode can return CUDA Graph-owned output
+            # buffers. The denoising graph replays repeatedly, so keep stable cache
+            # tensors that cannot be overwritten by a later graph replay.
+            video_kv_cache = [
+                {"k": layer_cache["k"].clone(), "v": layer_cache["v"].clone()}
+                for layer_cache in video_kv_cache
+            ]
 
         infer_timesteps_action, infer_deltas_action = self.infer_action_scheduler.build_inference_schedule(
             num_inference_steps=num_inference_steps,
@@ -1852,9 +1881,11 @@ class FastWAM(torch.nn.Module):
             shift_override=sigma_shift,
         )
         for step_t_action, step_delta_action in zip(infer_timesteps_action, infer_deltas_action, strict=True):
+            if compile_action_infer and self.device.type == "cuda":
+                torch.compiler.cudagraph_mark_step_begin()
             timestep_action = step_t_action.unsqueeze(0).to(dtype=latents_action.dtype, device=self.device)
 
-            pred_action = self._predict_action_noise_with_cache(
+            pred_action = action_denoiser(
                 latents_action=latents_action,
                 timestep_action=timestep_action,
                 context=context,

--- a/tests/policies/fastwam/test_fastwam_policy.py
+++ b/tests/policies/fastwam/test_fastwam_policy.py
@@ -28,6 +28,7 @@ from lerobot.configs import FeatureType, PolicyFeature, PreTrainedConfig
 from lerobot.policies import FastWAMConfig, get_policy_class, make_policy_config, make_pre_post_processors
 from lerobot.policies.fastwam.modeling_fastwam import FastWAMPolicy
 from lerobot.policies.fastwam.processor_fastwam import FastWAMActionToggleProcessorStep
+from lerobot.policies.fastwam.wan import ActionDiT, FastWAM, MoT
 from lerobot.utils.constants import ACTION, OBS_STATE
 
 
@@ -153,6 +154,7 @@ def test_policy_forward_and_predict_action_adapt_lerobot_batches(monkeypatch):
                     "image_shape": tuple(kwargs["input_image"].shape),
                     "proprio_shape": tuple(kwargs["proprio"].shape),
                     "prompt": kwargs["prompt"],
+                    "compile_action_infer": kwargs["compile_action_infer"],
                 }
             )
             return {"action": torch.full((1, kwargs["action_horizon"], 3), float(len(captured)))}
@@ -166,6 +168,7 @@ def test_policy_forward_and_predict_action_adapt_lerobot_batches(monkeypatch):
         num_video_frames=5,
         action_video_freq_ratio=1,
         image_size=(16, 16),
+        compile_action_infer=True,
         input_features={
             "observation.images.image": PolicyFeature(type=FeatureType.VISUAL, shape=(3, 16, 16)),
             OBS_STATE: PolicyFeature(type=FeatureType.STATE, shape=(2,)),
@@ -207,6 +210,84 @@ def test_policy_forward_and_predict_action_adapt_lerobot_batches(monkeypatch):
         cfg.prompt_template.format(task="task 0"),
         cfg.prompt_template.format(task="task 1"),
     ]
+    assert all(item["compile_action_infer"] for item in captured)
+
+
+def test_cached_inference_paths_support_fullgraph_compile():
+    torch.manual_seed(0)
+    expert_kwargs = {
+        "hidden_dim": 8,
+        "action_dim": 3,
+        "ffn_dim": 16,
+        "text_dim": 8,
+        "freq_dim": 8,
+        "eps": 1.0e-6,
+        "num_heads": 2,
+        "attn_head_dim": 4,
+        "num_layers": 1,
+        "fp32_attention": False,
+    }
+    video_expert = ActionDiT(**expert_kwargs)
+    action_expert = ActionDiT(**expert_kwargs)
+    mot = MoT(
+        mixtures={"video": video_expert, "action": action_expert},
+        mot_checkpoint_mixed_attn=False,
+    ).eval()
+    model = FastWAM(
+        video_expert=video_expert,
+        action_expert=action_expert,
+        mot=mot,
+        vae=nn.Identity(),
+        text_dim=8,
+    ).eval()
+    video_tokens = torch.randn(1, 3, 8)
+    video_freqs = video_expert.freqs[:3].view(3, 1, -1)
+    video_t_mod = torch.zeros(1, 6, 8)
+    video_context = torch.randn(1, 2, 8)
+    action_context = torch.randn(1, 2, 8)
+    video_context_mask = torch.ones(1, 3, 2, dtype=torch.bool)
+    action_context_mask = torch.ones(1, 2, 2, dtype=torch.bool)
+    video_attention_mask = torch.ones(3, 3, dtype=torch.bool)
+    attention_mask = torch.ones(5, 5, dtype=torch.bool)
+    action_latents = torch.randn(1, 2, 3)
+
+    compiled_prefill = torch.compile(mot.prefill_video_cache, backend="eager", fullgraph=True)
+    compiled_action = torch.compile(
+        model._predict_action_noise_with_cache,
+        backend="eager",
+        fullgraph=True,
+    )
+
+    with torch.no_grad():
+        video_cache = compiled_prefill(
+            video_tokens=video_tokens,
+            video_freqs=video_freqs,
+            video_t_mod=video_t_mod,
+            video_context_payload={"context": video_context, "mask": video_context_mask},
+            video_attention_mask=video_attention_mask,
+        )
+        expected = model._predict_action_noise_with_cache(
+            latents_action=action_latents,
+            timestep_action=torch.zeros(1),
+            context=action_context,
+            context_mask=action_context_mask[:, 0],
+            video_kv_cache=video_cache,
+            attention_mask=attention_mask,
+            video_seq_len=3,
+        )
+        output = compiled_action(
+            latents_action=action_latents,
+            timestep_action=torch.zeros(1),
+            context=action_context,
+            context_mask=action_context_mask[:, 0],
+            video_kv_cache=video_cache,
+            attention_mask=attention_mask,
+            video_seq_len=3,
+        )
+
+    assert len(video_cache) == 1
+    assert output.shape == (1, 2, 3)
+    torch.testing.assert_close(output, expected)
 
 
 class CoreWithFrozenComponents(FakeFastWAMCore):


### PR DESCRIPTION
## Summary / Motivation

FastWAM reuses the same video features across every action denoising step, but the cached inference path still runs eagerly. This adds an opt-in compiled path to reduce Python and CUDA kernel-launch overhead while keeping eager inference as the default.

## Related issues

- Related upstream FastWAM work: https://github.com/yuantianyuan01/FastWAM/pull/43

## What changed

- Add `policy.compile_action_infer` and pass it through the LeRobot policy adapter.
- Lazily compile the existing video-prefill and cached action-denoising paths with `reduce-overhead` and full-graph capture.
- Mark CUDA Graph step boundaries and clone graph-owned prefill buffers before reuse.
- Document the option and add focused full-graph and policy-dispatch coverage.

## How was this tested (or how to run locally)

- `pre-commit run --all-files`
- `pytest -q --confcutdir=tests/policies/fastwam tests/policies/fastwam/test_fastwam_policy.py` — 10 passed on PyTorch 2.11.0+cu128 and 2.13.0+cu130
- RTX 4090, PyTorch 2.11.0+cu128, 30-layer BF16 action denoiser with 392 cached video tokens and 32 action tokens:
  - eager: 20.888 ms/step
  - compiled: 10.067 ms/step
  - speedup: 2.075x

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] Relevant tests pass locally
- [x] Documentation updated
- [ ] CI is green
- [x] Community Review: I reviewed [#4476](https://github.com/huggingface/lerobot/pull/4476#pullrequestreview-4989338340)

## Reviewer notes

The option is disabled by default. The first call compiles the current input shapes; later calls with the same shapes reuse the graph.

AI assistance was used during implementation and test iteration. I reviewed the final diff and validated it locally on both PyTorch versions listed above.