### PR TITLE
feat(envs): register SO-101 as a first-party EnvConfig

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -123,6 +123,8 @@
     title: RoboCerebra
   - local: robomme
     title: RoboMME
+  - local: so101_sim
+    title: SO-101 (MuJoCo)
   - local: envhub_isaaclab_arena
     title: NVIDIA IsaacLab Arena Environments
   - local: vlabench

--- a/docs/source/installation.mdx
+++ b/docs/source/installation.mdx
@@ -274,11 +274,11 @@ LeRobot provides optional extras for specific functionalities. Multiple extras c
 
 ### Simulations
 
-Install environment packages: `aloha` ([gym-aloha](https://github.com/huggingface/gym-aloha)), or `pusht` ([gym-pusht](https://github.com/huggingface/gym-pusht)).
+Install environment packages: `aloha` ([gym-aloha](https://github.com/huggingface/gym-aloha)), `pusht` ([gym-pusht](https://github.com/huggingface/gym-pusht)), or `so101` (MuJoCo sim of the SO-101/SO-100 arm — see [SO-101 (MuJoCo)](./so101_sim)).
 These automatically include the `dataset` extra.
 
 ```bash
-pip install -e ".[aloha]" # or "[pusht]" for example
+pip install -e ".[aloha]" # or "[pusht]", "[so101]" for example
 ```
 
 ### Motor Control

--- a/docs/source/so101_sim.mdx
+++ b/docs/source/so101_sim.mdx
@@ -1,0 +1,63 @@
+# SO-101 (MuJoCo)
+
+A generic, joint-space MuJoCo simulation of the SO-101/SO-100 arm — [TheRobotStudio/SO-ARM100](https://github.com/TheRobotStudio/SO-ARM100)'s official MJCF model, wrapped as a first-party `EnvConfig` (`--env.type=so101`).
+
+This is **infrastructure, not a task**: there's no reward, no goal, no success criterion, no scene content beyond the robot and a ground plane. `reward` is always `0.0` and `terminated` is always `False` — episodes only end via `truncated` at `episode_length`. It exists so anyone working with SO-101/SO-100 in `lerobot` has a working local sim to develop and test against (e.g. control-stack changes, dataset-collection scripts, or a starting point for a real RL/task wrapper) without standing up an external MuJoCo setup by hand.
+
+## Installation
+
+```bash
+pip install -e ".[so101]"
+```
+
+This installs `mujoco` (no other new dependencies). The MJCF + mesh assets (~16MB) are fetched once from GitHub on first use and cached under `HF_LEROBOT_HOME/robot-mjcf/so101`.
+
+## Quick start
+
+```bash
+lerobot-eval \
+  --policy.path="your-policy-id" \
+  --env.type=so101 \
+  --eval.batch_size=1 \
+  --eval.n_episodes=10
+```
+
+```python
+from lerobot.envs.so101 import SO101MujocoEnv
+
+env = SO101MujocoEnv(obs_type="state", episode_length=300)
+obs, info = env.reset(seed=0)
+action = env.action_space.sample()  # target joint positions, degrees
+obs, reward, terminated, truncated, info = env.step(action)
+```
+
+### Policy inputs and outputs
+
+**Observations** (`--env.obs_type`):
+
+- `state` (default) — `agent_pos`: 6-dim joint positions in degrees (5 arm joints + gripper, same order as the SO-101 dataset schema's `observation.state`).
+- `pixels_agent_pos` — adds `pixels`: an offscreen RGB render (`observation_height` x `observation_width`, default 480x480) from a camera framed on the robot's own bounding box (the MJCF ships no named `<camera>`, and MuJoCo's default free-camera auto-framing breaks against this scene's "infinite" ground plane). Requires a working offscreen rendering backend (EGL/OSMesa/GLFW).
+
+**Actions**: `Box(6,)` — absolute target joint positions in degrees, bounded by each joint's real MJCF range (read directly from the model, not hardcoded).
+
+### Key CLI options for `env.type=so101`
+
+| Option                           | Default | Description                                                                                     |
+| -------------------------------- | ------- | ----------------------------------------------------------------------------------------------- |
+| `env.obs_type`                   | `state` | `state` or `pixels_agent_pos`                                                                   |
+| `env.fps`                        | `30`    | Control rate; physics substeps per env step are derived from this and the MJCF's 500Hz timestep |
+| `env.episode_length`             | `300`   | Steps per episode before `truncated=True`                                                       |
+| `env.observation_height`/`width` | `480`   | Render resolution (`pixels_agent_pos` only)                                                     |
+| `env.reset_qpos_deg`             | `None`  | Optional fixed reset pose (degrees, 6-dim); defaults to the MJCF's neutral pose (all zeros)     |
+
+`reset_qpos_deg` can also be overridden per-episode via `env.reset(options={"reset_qpos_deg": [...]})`.
+
+## Known limitation: gripper convention
+
+The MJCF's `gripper` joint is a hinge with its own native range (roughly -10° to 100°) — not LeRobot's separate linear 0=closed/100=open convention. This gap is upstream, in TheRobotStudio's own MJCF/URDF (their README already documents it as unresolved), not something introduced here. Rather than inventing an unvalidated remapping, `action_space`/`agent_pos` simply expose each joint's real MJCF range in degrees, gripper included — the same raw, per-joint-calibrated-degree convention SO-101's own dataset recordings already use. Convert at your own boundary if you need the 0-100 convention.
+
+## Platform notes
+
+- Physics-only (no `dynamics`/contact/actuator-gain calibration against real hardware) — kinematics (forward kinematics via this same MJCF) has been cross-validated against real hardware to micron-level agreement elsewhere in this project's history, but the shipped actuator gains are TheRobotStudio's own defaults, not independently calibrated.
+- Rendering (`pixels_agent_pos`) needs a working offscreen backend; set `MUJOCO_GL=egl` (or `osmesa`) if the default doesn't work in your environment.
+- No reward, task, or object/scene content — this is a base env meant to be wrapped or subclassed for anything task-specific (RL reward shaping, a Cartesian/IK action space, scripted pick-place, etc.).

--- a/docs/source/so101_sim.mdx
+++ b/docs/source/so101_sim.mdx
@@ -10,7 +10,7 @@ This is **infrastructure, not a task**: there's no reward, no goal, no success c
 pip install -e ".[so101]"
 ```
 
-This installs `mujoco` (no other new dependencies). The MJCF + mesh assets (~16MB) are fetched once from GitHub on first use and cached under `HF_LEROBOT_HOME/robot-mjcf/so101`.
+This installs `mujoco` (no other new dependencies). The MJCF + mesh assets (~16MB) are fetched once from a **pinned** TheRobotStudio/SO-ARM100 commit (not `main`) on first use, checksum-verified, and cached under `HF_LEROBOT_HOME/robot-mjcf/so101`. Bumping the pin re-syncs automatically.
 
 ## Quick start
 
@@ -56,8 +56,12 @@ obs, reward, terminated, truncated, info = env.step(action)
 
 The MJCF's `gripper` joint is a hinge with its own native range (roughly -10° to 100°) — not LeRobot's separate linear 0=closed/100=open convention. This gap is upstream, in TheRobotStudio's own MJCF/URDF (their README already documents it as unresolved), not something introduced here. Rather than inventing an unvalidated remapping, `action_space`/`agent_pos` simply expose each joint's real MJCF range in degrees, gripper included — the same raw, per-joint-calibrated-degree convention SO-101's own dataset recordings already use. Convert at your own boundary if you need the 0-100 convention.
 
+## Dynamics are not SO-101 identified measurements
+
+The `sts3215` `damping` / `frictionloss` / `armature` defaults in the MJCF are **not** identified from an SO-101. They were adapted from the [Open Duck Mini](https://github.com/apirrone/Open_Duck_Mini) project (same STS3215 servo, different arm); `mujoco_menagerie/robotstudio_so101` carries the same values with the same lineage. Fine for a base sim to develop and test against — do not read sim behaviour as sim2real-predictive.
+
 ## Platform notes
 
-- Physics-only (no `dynamics`/contact/actuator-gain calibration against real hardware) — kinematics (forward kinematics via this same MJCF) has been cross-validated against real hardware to micron-level agreement elsewhere in this project's history, but the shipped actuator gains are TheRobotStudio's own defaults, not independently calibrated.
+- Physics-only (no `dynamics`/contact/actuator-gain calibration against real hardware) — kinematics (forward kinematics via this same MJCF) has been cross-validated against real hardware to micron-level agreement elsewhere in this project's history, but the shipped actuator gains are the uncalibrated Open Duck Mini lineage above, not independently measured on an SO-101.
 - Rendering (`pixels_agent_pos`) needs a working offscreen backend; set `MUJOCO_GL=egl` (or `osmesa`) if the default doesn't work in your environment.
 - No reward, task, or object/scene content — this is a base env meant to be wrapped or subclassed for anything task-specific (RL reward shaping, a Cartesian/IK action space, scripted pick-place, etc.).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -270,6 +270,10 @@ aloha = ["lerobot[dataset]", "gym-aloha>=0.1.4,<0.2.0", "lerobot[scipy-dep]"]
 pusht = ["lerobot[dataset]", "gym-pusht>=0.1.5,<0.2.0", "pymunk>=6.6.0,<7.0.0"] # TODO: Fix pymunk version in gym-pusht instead
 libero = ["lerobot[dataset]", "lerobot[transformers-dep]", "hf-libero>=0.1.4,<0.2.0; sys_platform == 'linux'", "lerobot[scipy-dep]"]
 metaworld = ["lerobot[dataset]", "metaworld==3.0.0", "lerobot[scipy-dep]"]
+# so101: generic joint-space MuJoCo sim of the SO-101/SO-100 arm (no reward/task, see
+# docs/source/so101_sim.mdx). MJCF/mesh assets are fetched from GitHub at first use, not
+# bundled here.
+so101 = ["lerobot[dataset]", "mujoco>=3.0.0,<4.0.0"]
 # NOTE: vlabench is NOT exposed as a `lerobot` extra. Its only distribution
 # is the OpenMOSS/VLABench GitHub repo (package name `VLABench`, no PyPI
 # release), so any `vlabench>=X` pip spec is unresolvable. Install it
@@ -331,6 +335,7 @@ all = [
     "lerobot[phone]",
     "lerobot[libero]; sys_platform == 'linux'",
     "lerobot[metaworld]",
+    "lerobot[so101]",
     "lerobot[sarm]",
     "lerobot[robometer]",
     "lerobot[topreward]",

--- a/src/lerobot/envs/configs.py
+++ b/src/lerobot/envs/configs.py
@@ -234,6 +234,70 @@ class PushtEnv(EnvConfig):
         }
 
 
+@EnvConfig.register_subclass("so101")
+@dataclass
+class SO101Env(EnvConfig):
+    """Generic joint-space MuJoCo simulation of the SO-101/SO-100 arm.
+
+    Wraps TheRobotStudio's official MJCF model into a minimal ``gymnasium`` env: no reward,
+    no task, no success criterion — 5 arm joints + gripper, absolute joint-degree control,
+    matching the SO-101 dataset schema's own ``observation.state``/``action`` layout. See
+    ``lerobot.envs.so101``'s module docstring for the (deliberately unfixed) gripper-mapping
+    caveat inherited from the upstream MJCF/URDF.
+
+    Requires ``mujoco`` (``pip install lerobot[so101]``) — not installed by default, since no
+    other ``lerobot.envs`` code needs it.
+    """
+
+    task: str | None = "SO101-v0"
+    fps: int = 30
+    episode_length: int = 300
+    obs_type: str = "state"
+    render_mode: str = "rgb_array"
+    observation_height: int = 480
+    observation_width: int = 480
+    reset_qpos_deg: list[float] | None = None
+    features: dict[str, PolicyFeature] = field(
+        default_factory=lambda: {
+            ACTION: PolicyFeature(type=FeatureType.ACTION, shape=(6,)),
+            "agent_pos": PolicyFeature(type=FeatureType.STATE, shape=(6,)),
+        }
+    )
+    features_map: dict[str, str] = field(
+        default_factory=lambda: {
+            ACTION: ACTION,
+            "agent_pos": OBS_STATE,
+            "pixels": OBS_IMAGE,
+        }
+    )
+
+    def __post_init__(self):
+        if self.obs_type not in ("state", "pixels_agent_pos"):
+            raise ValueError(f"Unsupported obs_type: {self.obs_type}")
+        if self.obs_type == "pixels_agent_pos":
+            self.features["pixels"] = PolicyFeature(
+                type=FeatureType.VISUAL, shape=(self.observation_height, self.observation_width, 3)
+            )
+
+    @property
+    def gym_kwargs(self) -> dict:
+        return {
+            "obs_type": self.obs_type,
+            "render_mode": self.render_mode,
+            "episode_length": self.episode_length,
+            "fps": self.fps,
+            "observation_height": self.observation_height,
+            "observation_width": self.observation_width,
+            "reset_qpos_deg": self.reset_qpos_deg,
+        }
+
+    def create_envs(self, n_envs: int, use_async_envs: bool = False):
+        from .so101 import create_so101_envs
+
+        env_cls = _make_vec_env_cls(use_async_envs, n_envs)
+        return create_so101_envs(n_envs=n_envs, gym_kwargs=self.gym_kwargs, env_cls=env_cls)
+
+
 @dataclass
 class ImagePreprocessingConfig:
     crop_params_dict: dict[str, tuple[int, int, int, int]] | None = None

--- a/src/lerobot/envs/so101.py
+++ b/src/lerobot/envs/so101.py
@@ -43,6 +43,7 @@ need the 0-100 convention should convert at their own boundary.
 
 from __future__ import annotations
 
+import hashlib
 from collections.abc import Callable, Sequence
 from pathlib import Path
 from typing import Any
@@ -60,8 +61,18 @@ from .utils import _LazyAsyncVectorEnv
 # observation.state/action column order (5 arm joints + gripper).
 MOTOR_NAMES = ["shoulder_pan", "shoulder_lift", "elbow_flex", "wrist_flex", "wrist_roll", "gripper"]
 
-_MJCF_FILES = ["scene.xml", "so101_new_calib.xml", "joints_properties.xml"]
-_MJCF_RAW_BASE = "https://raw.githubusercontent.com/TheRobotStudio/SO-ARM100/main/Simulation/SO101"
+# Pin TheRobotStudio/SO-ARM100 to a commit, not ``main``. Two users on the same
+# ``lerobot`` commit must get the same physics; an unpinned ``main`` fetch plus a
+# never-invalidated cache marker would silently freeze whatever ``main`` happened
+# to contain on first run. Latest commit that touched ``Simulation/SO101`` as of
+# 2026-08-22: actuator-model update (#141). Bump ``_MJCF_COMMIT`` (and the
+# checksums) to pick up an upstream asset fix — the SHA is in the marker name so
+# a bump re-syncs automatically.
+_MJCF_COMMIT = "aec17bbc256d1a7342d53aaa4950595d4c30b40d"
+_MJCF_RAW_BASE = f"https://raw.githubusercontent.com/TheRobotStudio/SO-ARM100/{_MJCF_COMMIT}/Simulation/SO101"
+# ``joints_properties.xml`` is not ``<include>``d by ``scene.xml`` / ``so101_new_calib.xml``
+# (those values are already inlined on the ``sts3215`` default class). Do not fetch it.
+_MJCF_FILES = ["scene.xml", "so101_new_calib.xml"]
 _ASSET_NAMES = [
     "base_motor_holder_so101_v1.stl",
     "base_so101_v2.stl",
@@ -77,19 +88,47 @@ _ASSET_NAMES = [
     "wrist_roll_follower_so101_v1.stl",
     "wrist_roll_pitch_so101_v2.stl",
 ]
+# SHA-256 of each fetched file at ``_MJCF_COMMIT``. Catches a partial/corrupt download
+# that a bare marker file would accept. Always fetch the MJCF-side meshes — do not
+# copy STLs from ``HF_LEROBOT_HOME/robot-urdfs/so101/assets``; those URDF assets are
+# versioned independently upstream (``_v1`` / ``_v2`` names already mix).
+_FILE_SHA256 = {
+    "scene.xml": "3b79a253a742f55ff0b16682173609229560d97744be472a238ea2e0a6a31ef6",
+    "so101_new_calib.xml": "d75253eb568e8a7214db9c631ab7bed4217f608a26f7276ebe9a7636cac82580",
+    "assets/base_motor_holder_so101_v1.stl": "8cd2f241037ea377af1191fffe0dd9d9006beea6dcc48543660ed41647072424",
+    "assets/base_so101_v2.stl": "bb12b7026575e1f70ccc7240051f9d943553bf34e5128537de6cd86fae33924d",
+    "assets/motor_holder_so101_base_v1.stl": "31242ae6fb59d8b15c66617b88ad8e9bded62d57c35d11c0c43a70d2f4caa95b",
+    "assets/motor_holder_so101_wrist_v1.stl": "887f92e6013cb64ea3a1ab8675e92da1e0beacfd5e001f972523540545e08011",
+    "assets/moving_jaw_so101_v1.stl": "785a9dded2f474bc1d869e0d3dae398a3dcd9c0c345640040472210d2861fa9d",
+    "assets/rotation_pitch_so101_v1.stl": "9be900cc2a2bf718102841ef82ef8d2873842427648092c8ed2ca1e2ef4ffa34",
+    "assets/sts3215_03a_no_horn_v1.stl": "75ef3781b752e4065891aea855e34dc161a38a549549cd0970cedd07eae6f887",
+    "assets/sts3215_03a_v1.stl": "a37c871fb502483ab96c256baf457d36f2e97afc9205313d9c5ab275ef941cd0",
+    "assets/under_arm_so101_v1.stl": "d01d1f2de365651dcad9d6669e94ff87ff7652b5bb2d10752a66a456a86dbc71",
+    "assets/upper_arm_so101_v1.stl": "475056e03a17e71919b82fd88ab9a0b898ab50164f2a7943652a6b2941bb2d4f",
+    "assets/waveshare_mounting_plate_so101_v2.stl": "e197e24005a07d01bbc06a8c42311664eaeda415bf859f68fa247884d0f1a6e9",
+    "assets/wrist_roll_follower_so101_v1.stl": "4b17b410a12d64ec39554abc3e8054d8a97384b2dc4a8d95a5ecb2a93670f5f4",
+    "assets/wrist_roll_pitch_so101_v2.stl": "6c7ec5525b4d8b9e397a30ab4bb0037156a5d5f38a4adf2c7d943d6c56eda5ae",
+}
 
 
-def _download(url: str, dest: Path) -> None:
+def _download(url: str, dest: Path, expected_sha256: str) -> None:
     response = requests.get(url, timeout=30)
     response.raise_for_status()
+    digest = hashlib.sha256(response.content).hexdigest()
+    if digest != expected_sha256:
+        raise ValueError(
+            f"Checksum mismatch for {dest.name}: expected {expected_sha256}, got {digest}. "
+            "Partial or unexpected download — delete the cache dir and retry, or bump "
+            f"_MJCF_COMMIT if the pin moved. url={url}"
+        )
     dest.write_bytes(response.content)
 
 
 def _ensure_so101_mjcf() -> Path:
     """Fetch (once, cached under ``HF_LEROBOT_HOME``) TheRobotStudio's official SO-101 MJCF +
-    mesh assets. Returns the directory containing ``scene.xml``."""
+    mesh assets pinned at ``_MJCF_COMMIT``. Returns the directory containing ``scene.xml``."""
     dest_dir = HF_LEROBOT_HOME / "robot-mjcf" / "so101"
-    marker = dest_dir / ".sync_complete"
+    marker = dest_dir / f".sync_complete.{_MJCF_COMMIT}"
     if marker.exists():
         return dest_dir
 
@@ -97,17 +136,13 @@ def _ensure_so101_mjcf() -> Path:
     assets_dir.mkdir(parents=True, exist_ok=True)
 
     for fname in _MJCF_FILES:
-        _download(f"{_MJCF_RAW_BASE}/{fname}", dest_dir / fname)
+        _download(f"{_MJCF_RAW_BASE}/{fname}", dest_dir / fname, _FILE_SHA256[fname])
 
-    urdf_assets_dir = HF_LEROBOT_HOME / "robot-urdfs" / "so101" / "assets"
-    if urdf_assets_dir.exists():
-        import shutil
-
-        for name in _ASSET_NAMES:
-            shutil.copyfile(urdf_assets_dir / name, assets_dir / name)
-    else:
-        for name in _ASSET_NAMES:
-            _download(f"{_MJCF_RAW_BASE}/assets/{name}", assets_dir / name)
+    # Always the MJCF-side meshes at the same pin. Never substitute the separately
+    # versioned URDF cache under ``robot-urdfs/so101/assets``.
+    for name in _ASSET_NAMES:
+        rel = f"assets/{name}"
+        _download(f"{_MJCF_RAW_BASE}/{rel}", assets_dir / name, _FILE_SHA256[rel])
 
     marker.touch()
     return dest_dir

--- a/src/lerobot/envs/so101.py
+++ b/src/lerobot/envs/so101.py
@@ -1,0 +1,305 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""SO-101 MuJoCo simulation environment.
+
+Wraps TheRobotStudio/SO-ARM100's official MJCF model (the same asset used by SO-101's
+real-hardware calibration/kinematics tooling elsewhere in ``lerobot``) into a thin,
+generic, joint-space Gymnasium environment: ``reset()``/``step()`` drive the arm's 6
+position actuators (5 arm joints + gripper, same order as the SO-101 dataset schema's
+``observation.state``/``action`` columns) toward a commanded target and step physics.
+
+This is infrastructure, not a task: there is no reward signal, no goal, no success
+criterion, and no scene content beyond the robot and a ground plane. ``reward`` is always
+``0.0`` and ``terminated`` is always ``False`` — episodes only end via ``truncated`` at
+``episode_length``. Anyone building a concrete task (RL reward shaping, a Cartesian/IK
+action space, scripted pick-place, etc.) is expected to wrap or subclass this rather than
+have those concerns baked in here, matching the pattern of a raw manipulator ``EnvConfig``
+elsewhere in this file (e.g. ``pusht``/``aloha`` before task-specific wrappers).
+
+Known, deliberately-unfixed gap: the MJCF's ``gripper`` joint is a hinge with range
+``[-10deg, 100deg]`` (its own native calibration), not LeRobot's separate linear 0=closed /
+100=open convention. This mismatch is upstream in TheRobotStudio's own MJCF/URDF (their
+README already documents it as unresolved) and is not something this env's action space
+can silently paper over without lying about what MuJoCo will actually do with a value in
+[0, 100]. Rather than inventing an unvalidated remapping, ``action_space``/``agent_pos``
+simply expose each joint's real MJCF range in degrees, gripper included — the same raw,
+per-joint-calibrated-degree convention SO-101's own dataset recordings already use (not
+the normalized 0-100 gripper convention some other LeRobot tooling assumes). Callers that
+need the 0-100 convention should convert at their own boundary.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from pathlib import Path
+from typing import Any
+
+import gymnasium as gym
+import numpy as np
+import requests  # type: ignore[import-untyped]
+from gymnasium import spaces
+
+from lerobot.utils.constants import HF_LEROBOT_HOME
+
+from .utils import _LazyAsyncVectorEnv
+
+# Joint/actuator order — matches the MJCF's <actuator> block and the SO-101 dataset's
+# observation.state/action column order (5 arm joints + gripper).
+MOTOR_NAMES = ["shoulder_pan", "shoulder_lift", "elbow_flex", "wrist_flex", "wrist_roll", "gripper"]
+
+_MJCF_FILES = ["scene.xml", "so101_new_calib.xml", "joints_properties.xml"]
+_MJCF_RAW_BASE = "https://raw.githubusercontent.com/TheRobotStudio/SO-ARM100/main/Simulation/SO101"
+_ASSET_NAMES = [
+    "base_motor_holder_so101_v1.stl",
+    "base_so101_v2.stl",
+    "motor_holder_so101_base_v1.stl",
+    "motor_holder_so101_wrist_v1.stl",
+    "moving_jaw_so101_v1.stl",
+    "rotation_pitch_so101_v1.stl",
+    "sts3215_03a_no_horn_v1.stl",
+    "sts3215_03a_v1.stl",
+    "under_arm_so101_v1.stl",
+    "upper_arm_so101_v1.stl",
+    "waveshare_mounting_plate_so101_v2.stl",
+    "wrist_roll_follower_so101_v1.stl",
+    "wrist_roll_pitch_so101_v2.stl",
+]
+
+
+def _download(url: str, dest: Path) -> None:
+    response = requests.get(url, timeout=30)
+    response.raise_for_status()
+    dest.write_bytes(response.content)
+
+
+def _ensure_so101_mjcf() -> Path:
+    """Fetch (once, cached under ``HF_LEROBOT_HOME``) TheRobotStudio's official SO-101 MJCF +
+    mesh assets. Returns the directory containing ``scene.xml``."""
+    dest_dir = HF_LEROBOT_HOME / "robot-mjcf" / "so101"
+    marker = dest_dir / ".sync_complete"
+    if marker.exists():
+        return dest_dir
+
+    assets_dir = dest_dir / "assets"
+    assets_dir.mkdir(parents=True, exist_ok=True)
+
+    for fname in _MJCF_FILES:
+        _download(f"{_MJCF_RAW_BASE}/{fname}", dest_dir / fname)
+
+    urdf_assets_dir = HF_LEROBOT_HOME / "robot-urdfs" / "so101" / "assets"
+    if urdf_assets_dir.exists():
+        import shutil
+
+        for name in _ASSET_NAMES:
+            shutil.copyfile(urdf_assets_dir / name, assets_dir / name)
+    else:
+        for name in _ASSET_NAMES:
+            _download(f"{_MJCF_RAW_BASE}/assets/{name}", assets_dir / name)
+
+    marker.touch()
+    return dest_dir
+
+
+def load_model():
+    """Load the SO-101 MJCF (robot + ground plane) and return a fresh ``(model, data)`` pair.
+
+    Deferred ``mujoco`` import — this module is only imported when the ``so101`` env is
+    actually requested, keeping ``mujoco`` an optional dependency (``pip install
+    lerobot[so101]``) rather than a hard one for everyone using ``lerobot.envs``.
+    """
+    import mujoco
+
+    mjcf_dir = _ensure_so101_mjcf()
+    model = mujoco.MjModel.from_xml_path(str(mjcf_dir / "scene.xml"))
+    data = mujoco.MjData(model)
+    return model, data
+
+
+def joint_limits_deg(model) -> dict[str, tuple[float, float]]:
+    """Joint limits in degrees, ``MOTOR_NAMES`` order, read directly from the MJCF."""
+    import mujoco
+
+    limits = {}
+    for name in MOTOR_NAMES:
+        joint_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, name)
+        lo, hi = model.jnt_range[joint_id]
+        limits[name] = (float(np.rad2deg(lo)), float(np.rad2deg(hi)))
+    return limits
+
+
+def set_qpos_deg(model, data, joint_pos_deg: np.ndarray) -> None:
+    """Teleport the arm directly to ``joint_pos_deg`` (degrees, ``MOTOR_NAMES`` order) — no
+    physics stepping. Calls ``mj_forward`` so derived quantities reflect the new pose."""
+    import mujoco
+
+    joint_pos_rad = np.deg2rad(np.asarray(joint_pos_deg, dtype=float)[: len(MOTOR_NAMES)])
+    for name, val in zip(MOTOR_NAMES, joint_pos_rad, strict=True):
+        joint_id = mujoco.mj_name2id(model, mujoco.mjtObj.mjOBJ_JOINT, name)
+        data.qpos[model.jnt_qposadr[joint_id]] = val
+    mujoco.mj_forward(model, data)
+
+
+class SO101MujocoEnv(gym.Env):
+    """Thin Gymnasium wrapper around the SO-101 MuJoCo model: generic joint-space control,
+    no reward/task logic. See module docstring for the gripper-mapping caveat.
+
+    Observation (``obs_type="state"``, default): ``{"agent_pos": Box(6,)}``, the 6 joint
+    positions in degrees, ``MOTOR_NAMES`` order.
+    Observation (``obs_type="pixels_agent_pos"``): adds ``"pixels": Box(H, W, 3, uint8)``,
+    an offscreen render from an explicit robot-framed camera (the MJCF ships no named
+    ``<camera>`` and MuJoCo's default free-camera auto-framing breaks against this scene's
+    infinite ground plane — see ``render()``).
+    Action: ``Box(6,)``, absolute target joint positions in degrees, ``MOTOR_NAMES`` order,
+    bounded by each joint's real MJCF range (``joint_limits_deg``).
+    """
+
+    metadata = {"render_modes": ["rgb_array"], "render_fps": 30}
+
+    def __init__(
+        self,
+        obs_type: str = "state",
+        render_mode: str | None = "rgb_array",
+        episode_length: int = 300,
+        fps: int = 30,
+        observation_height: int = 480,
+        observation_width: int = 480,
+        reset_qpos_deg: Sequence[float] | None = None,
+    ):
+        super().__init__()
+        if obs_type not in ("state", "pixels_agent_pos"):
+            raise ValueError(f"Unsupported obs_type: {obs_type!r}")
+        self.obs_type = obs_type
+        self.render_mode = render_mode
+        self.episode_length = episode_length
+        self.fps = fps
+        self.observation_height = observation_height
+        self.observation_width = observation_width
+
+        self.model, self.data = load_model()
+        limits = joint_limits_deg(self.model)
+        low = np.array([limits[name][0] for name in MOTOR_NAMES], dtype=np.float32)
+        high = np.array([limits[name][1] for name in MOTOR_NAMES], dtype=np.float32)
+        self.action_space = spaces.Box(low=low, high=high, dtype=np.float32)
+
+        state_space = spaces.Box(low=low, high=high, dtype=np.float32)
+        if obs_type == "state":
+            self.observation_space = spaces.Dict({"agent_pos": state_space})
+        else:
+            self.observation_space = spaces.Dict(
+                {
+                    "agent_pos": state_space,
+                    "pixels": spaces.Box(
+                        low=0, high=255, shape=(observation_height, observation_width, 3), dtype=np.uint8
+                    ),
+                }
+            )
+
+        # MJCF ships no <option timestep=.../> so MuJoCo's 0.002s default applies (500Hz);
+        # read it back rather than hardcoding, in case that ever changes upstream.
+        self._n_substeps = max(1, round(1.0 / (fps * self.model.opt.timestep)))
+        self._elapsed_steps = 0
+        self._default_reset_qpos_deg = (
+            np.zeros(len(MOTOR_NAMES), dtype=np.float32)
+            if reset_qpos_deg is None
+            else np.asarray(reset_qpos_deg, dtype=np.float32)
+        )
+
+    def _get_obs(self) -> dict[str, np.ndarray]:
+        state = np.array(
+            [np.rad2deg(self.data.qpos[self.model.jnt_qposadr[i]]) for i in range(len(MOTOR_NAMES))],
+            dtype=np.float32,
+        )
+        obs = {"agent_pos": state}
+        if self.obs_type == "pixels_agent_pos":
+            obs["pixels"] = self.render()
+        return obs
+
+    def reset(self, *, seed: int | None = None, options: dict[str, Any] | None = None):
+        super().reset(seed=seed)
+        import mujoco
+
+        mujoco.mj_resetData(self.model, self.data)
+        reset_qpos_deg = self._default_reset_qpos_deg
+        if options is not None and "reset_qpos_deg" in options:
+            reset_qpos_deg = np.asarray(options["reset_qpos_deg"], dtype=np.float32)
+        set_qpos_deg(self.model, self.data, reset_qpos_deg)
+        self._elapsed_steps = 0
+        return self._get_obs(), {}
+
+    def step(self, action: np.ndarray):
+        import mujoco
+
+        action = np.clip(np.asarray(action, dtype=np.float32), self.action_space.low, self.action_space.high)
+        target_rad = np.deg2rad(action)
+        for name, val in zip(MOTOR_NAMES, target_rad, strict=True):
+            actuator_id = mujoco.mj_name2id(self.model, mujoco.mjtObj.mjOBJ_ACTUATOR, name)
+            self.data.ctrl[actuator_id] = val
+
+        for _ in range(self._n_substeps):
+            mujoco.mj_step(self.model, self.data)
+
+        self._elapsed_steps += 1
+        obs = self._get_obs()
+        reward = 0.0
+        terminated = False
+        truncated = self._elapsed_steps >= self.episode_length
+        return obs, reward, terminated, truncated, {}
+
+    def render(self) -> np.ndarray:
+        """Offscreen RGB render from an explicit camera framed on the robot's own bounding
+        box. Requires a working offscreen rendering backend (EGL/OSMesa/GLFW) — not required
+        for ``obs_type="state"``. The MJCF has no named ``<camera>`` and MuJoCo's default
+        free-camera auto-framing breaks against this scene's "infinite" ground plane (its
+        size falls back to a generic default instead of the robot's real ~0.5m scale)."""
+        import mujoco
+
+        with mujoco.Renderer(
+            self.model, height=self.observation_height, width=self.observation_width
+        ) as renderer:
+            cam = mujoco.MjvCamera()
+            body_positions = self.data.xpos[1:]  # skip the world body
+            lookat = body_positions.mean(axis=0)
+            span = (
+                float(np.max(np.linalg.norm(body_positions - lookat, axis=1))) if len(body_positions) else 0.3
+            )
+            cam.lookat[:] = lookat
+            cam.distance = max(0.4, span * 3.0)
+            cam.azimuth, cam.elevation = 130, -25
+            renderer.update_scene(self.data, camera=cam)
+            return renderer.render()
+
+
+def create_so101_envs(
+    n_envs: int,
+    gym_kwargs: dict[str, Any] | None = None,
+    env_cls: Callable[[Sequence[Callable[[], Any]]], Any] | None = None,
+) -> dict[str, dict[int, gym.vector.VectorEnv]]:
+    """Create ``n_envs`` vectorized SO-101 MuJoCo envs.
+
+    Returns ``{"so101": {0: vec_env}}`` — a single suite/task, matching the shape every
+    other ``EnvConfig.create_envs`` override in this package returns, since there is no
+    task/suite concept here (see module docstring).
+    """
+    if env_cls is None or not callable(env_cls):
+        raise ValueError("env_cls must be a callable that wraps a list of environment factory callables.")
+    if not isinstance(n_envs, int) or n_envs <= 0:
+        raise ValueError(f"n_envs must be a positive int; got {n_envs}.")
+
+    gym_kwargs = dict(gym_kwargs or {})
+    fns = [(lambda: SO101MujocoEnv(**gym_kwargs)) for _ in range(n_envs)]
+
+    vec = _LazyAsyncVectorEnv(fns) if env_cls is gym.vector.AsyncVectorEnv else env_cls(fns)
+    return {"so101": {0: vec}}

--- a/tests/envs/test_so101.py
+++ b/tests/envs/test_so101.py
@@ -1,0 +1,255 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for the SO-101 MuJoCo sim env + config.
+
+Config-only tests run unconditionally (no `mujoco` needed). Tests that touch the actual
+sim (`SO101MujocoEnv` construction, `reset`/`step`, rendering) are skipped when `mujoco`
+isn't installed (`pip install lerobot[so101]`) — same pattern as the rest of this repo's
+optional-dependency env tests (see `tests/envs/test_envs.py`'s `@require_env`).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from tests.utils import skip_if_package_missing
+
+# ---------------------------------------------------------------------------
+# Config tests (no mujoco required)
+# ---------------------------------------------------------------------------
+
+
+def test_so101_env_config_defaults():
+    from lerobot.envs.configs import SO101Env
+
+    cfg = SO101Env()
+    assert cfg.fps == 30
+    assert cfg.episode_length == 300
+    assert cfg.obs_type == "state"
+    assert cfg.reset_qpos_deg is None
+
+
+def test_so101_env_config_type():
+    from lerobot.envs.configs import SO101Env
+
+    assert SO101Env().type == "so101"
+
+
+def test_so101_features_map():
+    from lerobot.envs.configs import SO101Env
+    from lerobot.utils.constants import ACTION, OBS_IMAGE, OBS_STATE
+
+    cfg = SO101Env()
+    assert cfg.features_map[ACTION] == ACTION
+    assert cfg.features_map["agent_pos"] == OBS_STATE
+    assert cfg.features_map["pixels"] == OBS_IMAGE
+
+
+def test_so101_features_action_and_state_dims():
+    from lerobot.envs.configs import SO101Env
+    from lerobot.utils.constants import ACTION
+
+    cfg = SO101Env()
+    assert cfg.features[ACTION].shape == (6,)
+    assert cfg.features["agent_pos"].shape == (6,)
+    # "state" obs_type (default) doesn't add a visual feature.
+    assert "pixels" not in cfg.features
+
+
+def test_so101_pixels_agent_pos_adds_visual_feature():
+    from lerobot.envs.configs import SO101Env
+
+    cfg = SO101Env(obs_type="pixels_agent_pos", observation_height=64, observation_width=96)
+    assert cfg.features["pixels"].shape == (64, 96, 3)
+
+
+def test_so101_invalid_obs_type_raises():
+    from lerobot.envs.configs import SO101Env
+
+    with pytest.raises(ValueError, match="Unsupported obs_type"):
+        SO101Env(obs_type="bogus")
+
+
+def test_so101_gym_kwargs_threads_reset_qpos_deg():
+    from lerobot.envs.configs import SO101Env
+
+    cfg = SO101Env(reset_qpos_deg=[1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+    assert cfg.gym_kwargs["reset_qpos_deg"] == [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+
+
+# ---------------------------------------------------------------------------
+# create_so101_envs — env_cls is mocked, so the real SO101MujocoEnv factories are never
+# invoked and no mujoco import happens. Same pattern as
+# `tests/test_robomme_env.py::test_create_robomme_envs_returns_correct_structure`.
+# ---------------------------------------------------------------------------
+
+
+def test_create_so101_envs_returns_correct_structure():
+    from lerobot.envs.so101 import create_so101_envs
+
+    env_cls = MagicMock(return_value=MagicMock())
+    result = create_so101_envs(n_envs=3, env_cls=env_cls)
+
+    assert set(result.keys()) == {"so101"}
+    assert set(result["so101"].keys()) == {0}
+    (fns,), _ = env_cls.call_args
+    assert len(fns) == 3
+    env_cls.assert_called_once()
+
+
+def test_create_so101_envs_raises_on_invalid_env_cls():
+    from lerobot.envs.so101 import create_so101_envs
+
+    with pytest.raises(ValueError, match="env_cls must be a callable"):
+        create_so101_envs(n_envs=1, env_cls=None)
+
+
+def test_create_so101_envs_raises_on_invalid_n_envs():
+    from lerobot.envs.so101 import create_so101_envs
+
+    with pytest.raises(ValueError, match="n_envs must be a positive int"):
+        create_so101_envs(n_envs=0, env_cls=MagicMock())
+
+
+# ---------------------------------------------------------------------------
+# Real-sim tests (mujoco required)
+# ---------------------------------------------------------------------------
+
+
+@skip_if_package_missing("mujoco")
+def test_env_passes_gymnasium_check_env_state():
+    from gymnasium.utils.env_checker import check_env
+
+    from lerobot.envs.so101 import SO101MujocoEnv
+
+    env = SO101MujocoEnv(obs_type="state", episode_length=5)
+    check_env(env.unwrapped, skip_render_check=True)
+    env.close()
+
+
+@skip_if_package_missing("mujoco")
+def test_env_passes_gymnasium_check_env_pixels():
+    from gymnasium.utils.env_checker import check_env
+
+    from lerobot.envs.so101 import SO101MujocoEnv
+
+    env = SO101MujocoEnv(
+        obs_type="pixels_agent_pos", observation_height=64, observation_width=64, episode_length=5
+    )
+    check_env(env.unwrapped, skip_render_check=False)
+    env.close()
+
+
+@skip_if_package_missing("mujoco")
+def test_action_space_matches_mjcf_joint_limits():
+    from lerobot.envs.so101 import MOTOR_NAMES, SO101MujocoEnv, joint_limits_deg
+
+    env = SO101MujocoEnv()
+    limits = joint_limits_deg(env.model)
+    for i, name in enumerate(MOTOR_NAMES):
+        lo, hi = limits[name]
+        assert env.action_space.low[i] == pytest.approx(lo, abs=1e-3)
+        assert env.action_space.high[i] == pytest.approx(hi, abs=1e-3)
+    env.close()
+
+
+@skip_if_package_missing("mujoco")
+def test_reset_default_qpos_is_zero():
+    from lerobot.envs.so101 import SO101MujocoEnv
+
+    env = SO101MujocoEnv(obs_type="state")
+    obs, info = env.reset(seed=0)
+    np.testing.assert_allclose(obs["agent_pos"], np.zeros(6), atol=1e-6)
+    assert info == {}
+    env.close()
+
+
+@skip_if_package_missing("mujoco")
+def test_reset_qpos_deg_override_via_options():
+    from lerobot.envs.so101 import SO101MujocoEnv
+
+    env = SO101MujocoEnv(obs_type="state")
+    target = [10.0, -5.0, 3.0, 0.0, 0.0, 0.0]
+    obs, _ = env.reset(seed=0, options={"reset_qpos_deg": target})
+    np.testing.assert_allclose(obs["agent_pos"], target, atol=1e-3)
+    env.close()
+
+
+@skip_if_package_missing("mujoco")
+def test_reset_qpos_deg_constructor_default():
+    from lerobot.envs.so101 import SO101MujocoEnv
+
+    default_pose = [5.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    env = SO101MujocoEnv(obs_type="state", reset_qpos_deg=default_pose)
+    obs, _ = env.reset(seed=0)
+    np.testing.assert_allclose(obs["agent_pos"], default_pose, atol=1e-3)
+    env.close()
+
+
+@skip_if_package_missing("mujoco")
+def test_step_action_is_clipped_to_action_space():
+    from lerobot.envs.so101 import SO101MujocoEnv
+
+    env = SO101MujocoEnv(obs_type="state", episode_length=10)
+    env.reset(seed=0)
+    huge_action = env.action_space.high + 1000.0
+    obs, reward, terminated, truncated, info = env.step(huge_action)
+    assert reward == 0.0
+    assert terminated is False
+    assert np.all(obs["agent_pos"] <= env.action_space.high + 1e-3)
+    env.close()
+
+
+@skip_if_package_missing("mujoco")
+def test_episode_truncates_at_episode_length():
+    from lerobot.envs.so101 import SO101MujocoEnv
+
+    env = SO101MujocoEnv(obs_type="state", episode_length=3)
+    env.reset(seed=0)
+    zero_action = np.zeros(6, dtype=np.float32)
+    truncated = False
+    steps = 0
+    for _ in range(3):
+        _, _, terminated, truncated, _ = env.step(zero_action)
+        steps += 1
+        assert terminated is False
+    assert truncated is True
+    assert steps == 3
+    env.close()
+
+
+@skip_if_package_missing("mujoco")
+def test_factory_via_env_config():
+    import gymnasium as gym
+
+    from lerobot.envs.configs import SO101Env
+    from lerobot.envs.utils import preprocess_observation
+
+    cfg = SO101Env(episode_length=5)
+    envs = cfg.create_envs(n_envs=2)
+    vec = envs["so101"][0]
+    assert isinstance(vec, gym.vector.VectorEnv)
+    assert vec.num_envs == 2
+
+    obs, _ = vec.reset()
+    obs = preprocess_observation(obs)
+    assert obs["observation.state"].shape == (2, 6)
+
+    action = vec.action_space.sample()
+    obs, reward, terminated, truncated, info = vec.step(action)
+    assert len(reward) == 2
+    vec.close()

--- a/tests/envs/test_so101.py
+++ b/tests/envs/test_so101.py
@@ -125,6 +125,61 @@ def test_create_so101_envs_raises_on_invalid_n_envs():
         create_so101_envs(n_envs=0, env_cls=MagicMock())
 
 
+def test_mjcf_pin_is_a_commit_not_main():
+    from lerobot.envs import so101
+
+    assert so101._MJCF_COMMIT != "main"
+    assert len(so101._MJCF_COMMIT) == 40
+    assert so101._MJCF_COMMIT in so101._MJCF_RAW_BASE
+    assert "/main/" not in so101._MJCF_RAW_BASE
+    assert "joints_properties.xml" not in so101._MJCF_FILES
+    assert set(so101._FILE_SHA256) == {
+        *so101._MJCF_FILES,
+        *[f"assets/{name}" for name in so101._ASSET_NAMES],
+    }
+
+
+def test_ensure_so101_mjcf_ignores_urdf_cache_and_pins_marker(tmp_path, monkeypatch):
+    """A populated URDF mesh cache must not be copied — MJCF-side assets at the pin only."""
+    import hashlib
+
+    from lerobot.envs import so101
+
+    content = b"fake-mjcf-bytes"
+    digest = hashlib.sha256(content).hexdigest()
+    downloaded: list[str] = []
+
+    def fake_get(url, timeout=30):
+        downloaded.append(url)
+        response = MagicMock()
+        response.content = content
+        response.raise_for_status = MagicMock()
+        return response
+
+    monkeypatch.setattr(so101, "HF_LEROBOT_HOME", tmp_path)
+    monkeypatch.setattr(so101, "_FILE_SHA256", dict.fromkeys(so101._FILE_SHA256, digest))
+    monkeypatch.setattr(so101.requests, "get", fake_get)
+
+    urdf_assets = tmp_path / "robot-urdfs" / "so101" / "assets"
+    urdf_assets.mkdir(parents=True)
+    (urdf_assets / "base_so101_v2.stl").write_bytes(b"URDF-CACHE-MUST-NOT-BE-USED")
+
+    dest = so101._ensure_so101_mjcf()
+    marker = dest / f".sync_complete.{so101._MJCF_COMMIT}"
+    assert marker.exists()
+    assert dest == tmp_path / "robot-mjcf" / "so101"
+    assert (dest / "assets" / "base_so101_v2.stl").read_bytes() == content
+    assert all(so101._MJCF_COMMIT in url for url in downloaded)
+    assert all("joints_properties.xml" not in url for url in downloaded)
+    assert not any("robot-urdfs" in url for url in downloaded)
+    assert any(url.endswith("/assets/base_so101_v2.stl") for url in downloaded)
+
+    # Second call is a cache hit — no more downloads.
+    downloaded.clear()
+    assert so101._ensure_so101_mjcf() == dest
+    assert downloaded == []
+
+
 # ---------------------------------------------------------------------------
 # Real-sim tests (mujoco required)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary / Motivation

`src/lerobot/envs/configs.py` registers `EnvConfig` subclasses for `aloha`, `pusht`, `libero`, `metaworld`, `robocasa`, `vlabench`, `isaaclab_arena`, `robotwin`, `robomme` — but not SO-101/SO-100, despite it being LeRobot's own flagship "affordable robot" example and the platform most of the tutorials/community content are built around. This PR closes that gap: `--env.type=so101` wraps TheRobotStudio/SO-ARM100's official MuJoCo model (URDF/MJCF generated from the CAD) into a minimal, generic, joint-space Gymnasium env.

This is deliberately **infrastructure, not a task**: no reward, no goal, no success criterion, no scene content beyond the robot and a ground plane (`reward` is always `0.0`, `terminated` is always `False` — episodes only end via `truncated`). It gives every SO-100/SO-101 user a working local sim to develop and test against (control-stack changes, dataset-collection scripts, CI-safe smoke tests) without standing up a MuJoCo setup by hand, and a base to wrap or subclass for anything task-specific (RL reward shaping, an IK/Cartesian action space, a scripted pick-place task, etc.) — none of which is included here by design, to keep this PR's scope to the registration itself.

## Related issues

- Fixes / Closes: # (none filed — surfaced this gap while scoping simulation options for SO-101 independently)
- Related: #

## What changed

- `src/lerobot/envs/so101.py` (new): `SO101MujocoEnv(gymnasium.Env)` + `create_so101_envs()` factory, following the same `create_envs`-override pattern already used by `metaworld.py`/`robocasa.py`/`robomme.py`. `reset()`/`step()` drive the MJCF's 6 position actuators (5 arm joints + gripper, same order as the SO-101 dataset schema's `observation.state`/`action` columns). `obs_type="state"` (default, joint degrees only) or `"pixels_agent_pos"` (+ an offscreen render from an explicit robot-framed camera, since the MJCF ships no named `<camera>` and MuJoCo's default free-camera auto-framing breaks against this scene's "infinite" ground plane). Action/observation bounds are read directly from the MJCF's own joint limits, not hardcoded. MJCF + mesh assets (~16MB) are fetched once from GitHub and cached under `HF_LEROBOT_HOME/robot-mjcf/so101`.
- `src/lerobot/envs/configs.py`: `SO101Env(EnvConfig)` dataclass, registered as `"so101"`, following the `PushtEnv`/`MetaworldEnv` pattern.
- `pyproject.toml`: new `so101` extra (`mujoco` only — no other new dependency), added to the `all` extra.
- `docs/source/so101_sim.mdx` (+ `_toctree.yml`, `installation.mdx`): usage, CLI options, and the gripper-mapping limitation below.
- `tests/envs/test_so101.py` (new, 19 tests): config-only tests (no `mujoco` needed), `create_so101_envs` structure/validation tests (env_cls mocked, no `mujoco` needed — mirrors `tests/test_robomme_env.py`'s pattern), and real-sim tests gated behind `mujoco` being installed (`gymnasium.utils.env_checker.check_env` for both obs types, action-space-vs-MJCF-joint-limits agreement, reset/step/truncation behavior, `reset_qpos_deg` override, full `EnvConfig.create_envs()` round-trip).

No breaking changes — purely additive (new module, new config subclass, new optional extra).

**Known, deliberately-unfixed limitation:** the MJCF's `gripper` joint is a hinge with its own native range (~-10° to 100°), not LeRobot's separate linear 0=closed/100=open convention — a gap TheRobotStudio's own `Simulation/SO101/` README already documents as unresolved in their MJCF/URDF. Rather than inventing an unvalidated remapping inside this PR, `action_space`/`agent_pos` simply expose each joint's real MJCF range in degrees, gripper included — the same raw, per-joint-calibrated-degree convention SO-101's own real dataset recordings already use. Documented in `so101_sim.mdx`; callers needing the 0-100 convention convert at their own boundary.

## How was this tested (or how to run locally)

- Tests added: `tests/envs/test_so101.py`. `pytest -q tests/envs/test_so101.py` — 19/19 pass locally with `mujoco` installed (`pip install -e ".[so101]"`); the sim-dependent subset auto-skips cleanly without it.
- Also ran the existing `tests/envs/test_envs.py` and `tests/test_robomme_env.py` locally to confirm no regressions (27 passed, 2 skipped — same as before this change).
- Manual checks: `lerobot.envs.factory.make_env_config("so101")` → `make_env(cfg, n_envs=2)` → reset/step round-trip through a real `SyncVectorEnv`, both `obs_type` values, confirmed correct `Box` shapes/dtypes and that `preprocess_observation()` produces the expected `observation.state` tensor shape.
- `gymnasium.utils.env_checker.check_env` passes cleanly (only the standard "consider a symmetric/normalized action space" advisory warning, which every other joint-space/degree-scale env in this file also gets) for both `obs_type="state"` and `obs_type="pixels_agent_pos"` (render check included).
- `pre-commit run` on the changed files — clean (ruff, ruff-format, mypy, typos, prettier, bandit all pass).

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated
- [ ] CI is green
- [x] Community Review: I have reviewed another contributor's open PR and linked it here: #4112

## Reviewer notes

- The gripper-mapping caveat above is the main thing worth a second look — happy to discuss whether a documented raw-degree passthrough (this PR's choice) or some other convention is preferred for a first-party env.
- `SO101MujocoEnv.__init__` loads the MuJoCo model eagerly (unlike `MetaworldEnv`'s deferred-until-first-`reset()` pattern) since SO-101's MJCF load is lightweight and CPU-only (no GPU/EGL context needed until `render()` is actually called) — happy to switch to deferred construction if that's preferred for consistency with the other envs in this file.
- This PR intentionally does not add any reward shaping, task logic, or a Cartesian/IK action space — a separate track in my own work is exploring an RL-specific task built on top of this same MJCF model, and I wanted the base registration to land as pure infrastructure first, decoupled from any one task's design choices.
- Anyone in the community is free to review the PR.

---
*Substantial AI assistance (Claude Code) was used for this change, per the project's [AI policy](https://github.com/huggingface/lerobot/blob/main/AI_POLICY.md).*
