### PR TITLE
test(policies): add coverage for prepare_observation_for_inference

### DIFF
--- a/src/lerobot/policies/utils.py
+++ b/src/lerobot/policies/utils.py
@@ -133,10 +133,10 @@ def prepare_observation_for_inference(
         to (C, H, W) and normalized to a [0, 1] range.
 
     Performance note: independently measured live on real SO-101 hardware
-    (`Experiments/engineering/Engineering.md`, 2026-08-05, prior to this ordering fix): this
-    function was the single largest cost in the rollout control loop by a wide margin (~67% of
-    total loop time, ~4x the trained model's own forward pass) -- profile before assuming a
-    change like this actually matters for your workload, but it did for this one.
+    (2026-08-05, prior to this ordering fix): this function was the single largest cost in the
+    rollout control loop by a wide margin (~67% of total loop time, ~4x the trained model's own
+    forward pass) -- profile before assuming a change like this actually matters for your
+    workload, but it did for this one.
     """
     for name in observation:
         tensor = torch.from_numpy(observation[name]).to(device)

--- a/src/lerobot/policies/utils.py
+++ b/src/lerobot/policies/utils.py
@@ -131,6 +131,12 @@ def prepare_observation_for_inference(
         A dictionary where values are PyTorch tensors preprocessed for
         inference, residing on the target device. Image tensors are reshaped
         to (C, H, W) and normalized to a [0, 1] range.
+
+    Performance note: independently measured live on real SO-101 hardware
+    (`Experiments/engineering/Engineering.md`, 2026-08-05, prior to this ordering fix): this
+    function was the single largest cost in the rollout control loop by a wide margin (~67% of
+    total loop time, ~4x the trained model's own forward pass) -- profile before assuming a
+    change like this actually matters for your workload, but it did for this one.
     """
     for name in observation:
         tensor = torch.from_numpy(observation[name]).to(device)

--- a/tests/policies/test_policy_utils.py
+++ b/tests/policies/test_policy_utils.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Correctness tests for `prepare_observation_for_inference`'s reordered image pipeline
+(2026-08-05): device transfer moved before the uint8->float32 conversion and channel permute,
+instead of after, for real measured performance reasons (see the function's own docstring and
+`Experiments/engineering/Engineering.md` in the parent research repo). These tests pin that the
+reordering is a pure performance change, not a behavior change: a local copy of the *original*
+step order is kept below as a ground-truth oracle, and every test compares the real function's
+output against it, rather than against hand-picked expected values that could drift.
+"""
+
+import numpy as np
+import pytest
+import torch
+
+from lerobot.policies.utils import prepare_observation_for_inference
+
+
+def _reference_prepare_observation_for_inference(observation, device, task=None, robot_type=None):
+    """The pre-2026-08-05 implementation, kept verbatim as a ground-truth oracle. Deliberately
+    duplicated rather than imported (there's nothing left to import it from) or reconstructed from
+    the new code (that would make the test circular)."""
+    observation = dict(observation)
+    for name in observation:
+        observation[name] = torch.from_numpy(observation[name])
+        if "image" in name:
+            if observation[name].dtype == torch.uint8:
+                observation[name] = observation[name].type(torch.float32) / 255
+            observation[name] = observation[name].permute(2, 0, 1).contiguous()
+        observation[name] = observation[name].unsqueeze(0)
+        observation[name] = observation[name].to(device)
+    observation["task"] = task if task else ""
+    observation["robot_type"] = robot_type if robot_type else ""
+    return observation
+
+
+def _make_observation():
+    rng = np.random.default_rng(0)
+    return {
+        "observation.images.front": rng.integers(0, 256, size=(480, 640, 3), dtype=np.uint8),
+        "observation.images.wrist": rng.integers(0, 256, size=(480, 640, 3), dtype=np.uint8),
+        "observation.state": rng.uniform(-1, 1, size=(6,)).astype(np.float32),
+    }
+
+
+DEVICES = ["cpu"] + (["cuda"] if torch.cuda.is_available() else [])
+
+
+@pytest.mark.parametrize("device_str", DEVICES)
+def test_matches_reference_implementation_exactly(device_str):
+    device = torch.device(device_str)
+    obs_a = _make_observation()
+    obs_b = {k: v.copy() for k, v in obs_a.items()}
+
+    actual = prepare_observation_for_inference(
+        obs_a, device, task="pick up the screwdriver", robot_type="so101"
+    )
+    expected = _reference_prepare_observation_for_inference(
+        obs_b, device, task="pick up the screwdriver", robot_type="so101"
+    )
+
+    for key in ("observation.images.front", "observation.images.wrist", "observation.state"):
+        # Exact (rtol=0, atol=0) on CPU: both implementations do the /255 divide on the same
+        # device with the same op, so there's no source of divergence at all. On CUDA, the divide
+        # now happens on-GPU instead of on-CPU (that's the whole point of the reordering) --
+        # CPU and GPU floating-point division aren't guaranteed bit-identical (different hardware
+        # implementations of the same IEEE754 operation), so a tiny, real, expected tolerance is
+        # correct here, not a sign of a bug. Observed magnitude on this hardware: ~6e-8, i.e.
+        # utterly negligible against a uint8 image's own ~0.0039 quantization step.
+        tol = {"rtol": 0, "atol": 0} if device.type == "cpu" else {"rtol": 1e-5, "atol": 1e-6}
+        torch.testing.assert_close(actual[key], expected[key], **tol)
+        assert actual[key].device.type == device.type
+        assert actual[key].shape == expected[key].shape
+        assert actual[key].dtype == expected[key].dtype
+
+    assert actual["task"] == expected["task"] == "pick up the screwdriver"
+    assert actual["robot_type"] == expected["robot_type"] == "so101"
+
+
+def test_image_normalized_to_unit_range_and_chw():
+    obs = _make_observation()
+    result = prepare_observation_for_inference(obs, torch.device("cpu"))
+    img = result["observation.images.front"]
+    assert img.shape == (1, 3, 480, 640)  # (batch, C, H, W)
+    assert img.dtype == torch.float32
+    assert img.min() >= 0.0
+    assert img.max() <= 1.0
+
+
+def test_image_tensor_is_contiguous():
+    """The permute alone would leave a non-contiguous view; `.contiguous()` must still run after
+    the reordering, not get lost in the process of moving the device transfer earlier."""
+    obs = _make_observation()
+    result = prepare_observation_for_inference(obs, torch.device("cpu"))
+    assert result["observation.images.front"].is_contiguous()
+
+
+def test_non_image_key_gets_batch_dim_and_device_but_no_normalization():
+    obs = _make_observation()
+    original_state = obs["observation.state"].copy()
+    result = prepare_observation_for_inference(obs, torch.device("cpu"))
+    state = result["observation.state"]
+    assert state.shape == (1, 6)
+    torch.testing.assert_close(state.squeeze(0), torch.from_numpy(original_state), rtol=0, atol=0)
+
+
+def test_missing_task_and_robot_type_default_to_empty_string():
+    obs = _make_observation()
+    result = prepare_observation_for_inference(obs, torch.device("cpu"))
+    assert result["task"] == ""
+    assert result["robot_type"] == ""
+
+
+def test_already_float_image_is_not_renormalized():
+    """An already-float image (dtype != uint8) must skip the /255 step entirely, same as the
+    original implementation's `if observation[name].dtype == torch.uint8` guard."""
+    obs = {
+        "observation.images.front": np.full((4, 4, 3), 0.5, dtype=np.float32),
+    }
+    result = prepare_observation_for_inference(obs, torch.device("cpu"))
+    torch.testing.assert_close(
+        result["observation.images.front"], torch.full((1, 3, 4, 4), 0.5), rtol=0, atol=0
+    )


### PR DESCRIPTION
## Summary / Motivation

`prepare_observation_for_inference` runs on every tick of the rollout control loop. #4433 moved the uint8→float32 conversion and channel permute onto the compute device (the same bottleneck this project independently found and measured on real SO-101 hardware). #4433's description claims tests were added at `tests/policies/test_policy_utils.py`, but the merged diff only touched `src/lerobot/policies/utils.py` — the test file was never committed. This PR closes that gap: a 7-test suite (6 CPU + 1 CUDA parametrize of the equivalence check when CUDA is available) against a kept-verbatim copy of the *original* pre-optimization step order, so the tests pin behavior rather than any one reordering.

This is a follow-up to #4339 (closed in favor of #4433) and #4433 itself. No performance change is proposed.

## Related issues

- Related: #4433 (merged implementation this covers), #4339 (earlier independent fix, closed in favor of #4433)

## What changed

- `tests/policies/test_policy_utils.py` (new): equivalence against the original implementation (exact on CPU; CUDA uses a small rtol for real FP divide-order differences), image normalization/CHW shape, contiguity after permute, non-image passthrough, missing-task/robot_type defaults, and the already-float-image (no re-normalization) guard.
- `src/lerobot/policies/utils.py`: a short docstring addendum citing an independent real-SO-101-hardware measurement of this function as the dominant control-loop cost (~67% of loop time, ~4× the model's own forward pass) — trimmed so it does not duplicate #4433's mechanism explanation.

No breaking changes. No behavior change.

## How was this tested (or how to run locally)

- `pytest -q tests/policies/test_policy_utils.py` — 6/6 pass on CPU. The CUDA parametrize of the equivalence test runs automatically when `torch.cuda.is_available()` (previously 7/7 including CUDA against the merged #4433 implementation).
- `pre-commit run --files src/lerobot/policies/utils.py tests/policies/test_policy_utils.py` — clean (ruff, mypy, bandit, typos).

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated — docstring only; no new user-facing flag
- [ ] CI is green
- [x] Community Review: I have reviewed another contributor's open PR and linked it here: #4112

## Reviewer notes

- The tests compare against a locally-kept copy of the original (pre-#4433) step order, not against the current implementation reconstructed as an oracle — so they stay valid if the function is reordered again.
- Investigated and **not** included: `non_blocking=True` device transfers. `non_blocking` is only honored for pinned host memory; these numpy-backed tensors aren't pinned. Benchmarks on this machine were too noisy (shared GPU) to claim a win. Honest negative, not pursued.
- **AI-assistance disclosure (per `AI_POLICY.md`):** this test suite, the docstring addendum, and this PR description were developed substantially with Claude Code (Anthropic's AI coding assistant). The author directed the design, ran the tests, and reviewed all code before submission.
