### PR TITLE
feat(scripts): add lerobot-check-cameras to pin and restore camera mount poses

### DIFF
--- a/docs/source/cameras.mdx
+++ b/docs/source/cameras.mdx
@@ -178,6 +178,49 @@ During recording, the control loop peeks the freshest buffered frames non-blocki
 
 For how depth streams are stored and encoded when recording a dataset, see the [Depth streams](./video_encoding_parameters#depth-streams) section of the video encoding guide.
 
+## Check camera mounts
+
+Camera extrinsics drift. A tripod gets nudged, a wrist mount is re-clamped after a repair, the rig moves to another table. A policy trained on the old viewpoint then fails silently, and the failure reads as a policy problem rather than a hardware one. Note that you cannot recover the old pose from the dataset afterwards: once a camera has moved far enough to matter, feature matching against the recorded frames no longer converges.
+
+Pin the mounts while the rig is in a state you are happy to record from:
+
+```bash
+lerobot-check-cameras --mode=save \
+    --robot.type=so101_follower \
+    --robot.port=/dev/ttyACM0 \
+    --robot.id=my_awesome_follower_arm \
+    --robot.cameras='{ front: {type: opencv, index_or_path: 0, width: 640, height: 480, fps: 30}}'
+```
+
+Then check them before a session, after any hardware work, and after moving the robot:
+
+```bash
+lerobot-check-cameras --mode=check \
+    --robot.type=so101_follower \
+    --robot.port=/dev/ttyACM0 \
+    --robot.id=my_awesome_follower_arm \
+    --robot.cameras='{ front: {type: opencv, index_or_path: 0, width: 640, height: 480, fps: 30}}'
+```
+
+```
+reference from 2026-01-14T09:31:02 at ~/.cache/huggingface/lerobot/calibration/cameras/so_follower/my_awesome_follower_arm
+  front            pan LEFT 25px                                        [329 pts, frame]
+  wrist            in tolerance                                         [726 pts, frame]
+```
+
+Move each camera the way it says until every line reads `in tolerance`. Add `--live=true` to keep measuring and show an overlay while you nudge. The command exits nonzero when any camera is out of tolerance, so you can gate a recording script on it.
+
+The defaults of 4 px and 0.4 deg are what an untouched camera reproduces between recordings, which makes them the right bar for _has this drifted_. They are a harder bar to hit by hand. Re-seating a camera that has actually been moved tends to bottom out around 10 px on a friction mount, because loosening and re-tightening it displaces the camera by about as much as the correction you are making; the readings stop converging and start alternating in sign. When you see that, you are at the mount's limit rather than your own. Get the roll right first, since it is the part you can control, then either accept the residual or raise `--tolerance.shift_px` to something your hardware can actually return to.
+
+> [!WARNING]
+> The arm has to be back at the pose the reference was captured at, for **every** camera and not just wrist-mounted ones. An eye-in-hand camera's view is a function of the joint angles outright: matched across two arm poses in the same recording, a wrist camera reports over 100 px and 15 deg of drift that is entirely arm motion. A fixed camera is affected too, more weakly, because once the robot fills a good part of its frame the matched features concentrate on the robot and the arm's rotation is read as camera roll. So the reference stores the arm pose and `check` refuses to score until the arm is back there. Pass `--drive_to_pose=true` to have the arm driven back instead of refusing; make sure the workspace is clear first.
+
+Save asks you for the arm pose first and the frames second, so use the gap to get your hands out of shot: a hand held on the arm becomes part of the reference and every later check fails against it. The arm is under torque once connected, so drive it into place with the leader arm rather than pushing against the servos.
+
+You are also asked to drag a box around the robot in each view. The robot is the only rigid thing that comes with you when the rig moves, so that box is what the check falls back on once the rest of the scene has changed. Skip it with `--select_roi=false`; checks will still work on the same table.
+
+Tolerances default to 4 px, 0.4 deg and 1% zoom, which sits just above the mount-to-mount noise of a typical fixed webcam. Adjust with `--tolerance.shift_px`, `--tolerance.roll_deg`, `--tolerance.zoom` and `--tolerance.pose_deg`.
+
 ## Use your phone's camera
 
 <hfoptions id="use phone">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -340,6 +340,7 @@ all = [
 
 [project.scripts]
 lerobot-calibrate="lerobot.scripts.lerobot_calibrate:main"
+lerobot-check-cameras="lerobot.scripts.lerobot_check_cameras:main"
 lerobot-find-cameras="lerobot.scripts.lerobot_find_cameras:main"
 lerobot-find-port="lerobot.scripts.lerobot_find_port:main"
 lerobot-record="lerobot.scripts.lerobot_record:main"

--- a/src/lerobot/scripts/lerobot_check_cameras.py
+++ b/src/lerobot/scripts/lerobot_check_cameras.py
@@ -1,0 +1,704 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pin camera mounts to a reference pose, and put them back after they move.
+
+Camera extrinsics drift. A tripod gets nudged, a wrist mount is re-clamped after a repair, the rig
+moves to another table. A policy trained on the old viewpoint then fails silently: there is no
+exception and no metric that moves, the robot just does the wrong thing. This saves one reference
+frame per camera, and afterwards reports how far each camera has drifted and which way to push it
+back.
+
+Run ``--mode=save`` once, when the rig is in a state you are happy to record from. Run
+``--mode=check`` before a session, after any hardware work, and after moving the robot.
+
+Because an eye-in-hand camera's view is a function of the joint angles, the reference stores the
+arm pose it was captured at and ``check`` refuses to score until the arm is back there. Without
+that gate the tool reports arm motion as camera motion.
+
+Requires: pip install 'lerobot[hardware]'
+
+Example:
+    ```shell
+    lerobot-check-cameras --mode=save \
+        --robot.type=so101_follower \
+        --robot.port=/dev/ttyACM0 \
+        --robot.id=my_awesome_follower_arm \
+        --robot.cameras='{ front: {type: opencv, index_or_path: 0, width: 640, height: 480, fps: 30}}'
+
+    lerobot-check-cameras --mode=check \
+        --robot.type=so101_follower \
+        --robot.port=/dev/ttyACM0 \
+        --robot.id=my_awesome_follower_arm \
+        --robot.cameras='{ front: {type: opencv, index_or_path: 0, width: 640, height: 480, fps: 30}}'
+    ```
+"""
+
+import json
+import logging
+import sys
+import time
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
+from pathlib import Path
+from pprint import pformat
+
+import cv2
+import draccus
+import numpy as np
+from numpy.typing import NDArray
+
+from lerobot.cameras.opencv import OpenCVCameraConfig  # noqa: F401
+from lerobot.cameras.realsense import RealSenseCameraConfig  # noqa: F401
+from lerobot.robots import (  # noqa: F401
+    Robot,
+    RobotConfig,
+    bi_openarm_follower,
+    bi_rebot_b601_follower,
+    bi_so_follower,
+    hope_jr,
+    koch_follower,
+    lekiwi,
+    make_robot_from_config,
+    omx_follower,
+    openarm_follower,
+    rebot_b601_follower,
+    so_follower,
+)
+from lerobot.utils.constants import HF_LEROBOT_CALIBRATION
+from lerobot.utils.import_utils import register_third_party_plugins
+from lerobot.utils.utils import init_logging
+
+CAMERAS = "cameras"
+REFERENCE_FILENAME = "reference.json"
+
+# A homography needs a healthy number of agreeing correspondences before its decomposition means
+# anything. Below this the fit is dominated by whatever few features happen to survive, and it
+# reports large, confident, wrong numbers.
+MIN_INLIERS = 25
+
+# The robot region of the live frame is searched over a larger box than the one drawn on the
+# reference, so a roughly re-mounted camera still has the robot inside the search area.
+ROI_SEARCH_SCALE = 1.6
+
+
+@dataclass
+class MountTolerance:
+    """How far a camera may drift before ``check`` calls it out.
+
+    The defaults sit just above the mount-to-mount noise we measured on an SO-101 rig: across eight
+    same-session recordings a fixed external camera reproduced to under 3 px, 0.2 deg and 0.4% zoom.
+    Tighten them if your policy is more viewpoint-sensitive than that; loosen them if a healthy rig
+    keeps failing the check.
+
+    Args:
+        shift_px (`float`, *optional*, defaults to `4.0`):
+            Maximum translation of the image centre, in pixels of the camera's own resolution.
+        roll_deg (`float`, *optional*, defaults to `0.4`):
+            Maximum in-plane rotation, in degrees.
+        zoom (`float`, *optional*, defaults to `0.01`):
+            Maximum scale change, as a fraction. `0.01` is one percent.
+        pose_deg (`float`, *optional*, defaults to `2.0`):
+            Maximum deviation of any joint from the pose the reference was captured at. Cameras are
+            not scored until the arm is within this, because arm motion is indistinguishable from
+            camera motion for anything the arm is bolted to or large in the frame of.
+    """
+
+    shift_px: float = 4.0
+    roll_deg: float = 0.4
+    zoom: float = 0.01
+    pose_deg: float = 2.0
+
+
+@dataclass
+class MountShift:
+    """How the live view differs from the reference, and how well that was measured.
+
+    All four displacement fields describe what the live image *content* must do to land back on the
+    reference. The camera has to move the other way; :func:`describe_correction` does that flip.
+
+    **Attributes**:
+        - **dx** (`float`) -- Horizontal shift in pixels, positive rightwards.
+        - **dy** (`float`) -- Vertical shift in pixels, positive downwards.
+        - **roll_deg** (`float`) -- In-plane rotation in degrees. Image coordinates run y-down, so a
+          positive value means the content must turn *clockwise* on screen, and the camera therefore
+          has to be rolled counter-clockwise to undo it. Do not "correct" this to match the printed
+          instruction: they are opposites on purpose.
+        - **zoom** (`float`) -- Scale factor. Above 1 the content must grow.
+        - **inliers** (`int`) -- Feature correspondences agreeing with the fit.
+        - **via** (`str`) -- Which region produced the winning fit, `"frame"` or `"robot"`.
+        - **homography** (`np.ndarray`) -- The 3x3 matrix mapping live pixels to reference pixels.
+    """
+
+    dx: float
+    dy: float
+    roll_deg: float
+    zoom: float
+    inliers: int
+    via: str
+    homography: NDArray[np.float64] = field(repr=False)
+
+    @property
+    def shift_px(self) -> float:
+        """`float`: Magnitude of the translation, in pixels."""
+        return float(np.hypot(self.dx, self.dy))
+
+    def within(self, tol: MountTolerance) -> bool:
+        """Whether every component is inside the given tolerance.
+
+        Args:
+            tol (`MountTolerance`):
+                The limits to compare against.
+
+        Returns:
+            `bool`: `True` if the camera does not need moving.
+        """
+        return (
+            self.shift_px <= tol.shift_px
+            and abs(self.roll_deg) <= tol.roll_deg
+            and abs(self.zoom - 1.0) <= tol.zoom
+        )
+
+
+@dataclass
+class CheckCamerasConfig:
+    """Configuration for :func:`check_cameras`.
+
+    Args:
+        robot (`RobotConfig`):
+            The robot whose cameras are being pinned. Every RGB camera it exposes is checked.
+        mode (`str`, *optional*, defaults to `"check"`):
+            `"save"` writes a new reference, `"check"` compares the live cameras against it.
+        tolerance (`MountTolerance`, *optional*):
+            Drift limits. Defaults to `MountTolerance()`.
+        select_roi (`bool`, *optional*, defaults to `True`):
+            At save time, ask for a box around the robot in each view. That box is the fallback
+            matcher when the rest of the scene has changed, which is what happens when the rig moves
+            to a different table. Ignored when no GUI is available.
+        live (`bool`, *optional*, defaults to `False`):
+            At check time, keep measuring and draw an overlay per camera so the mount can be nudged
+            until it goes green. Requires a GUI. Without it the check takes one reading and exits.
+        drive_to_pose (`bool`, *optional*, defaults to `False`):
+            At check time, move the arm to the saved pose instead of refusing when it is elsewhere.
+            Off by default because it moves real hardware; make sure the path is clear.
+        force (`bool`, *optional*, defaults to `False`):
+            Overwrite an existing reference in save mode.
+    """
+
+    robot: RobotConfig
+    mode: str = "check"
+    tolerance: MountTolerance = field(default_factory=MountTolerance)
+    select_roi: bool = True
+    live: bool = False
+    drive_to_pose: bool = False
+    force: bool = False
+
+    def __post_init__(self):
+        if self.mode not in ("save", "check"):
+            raise ValueError(f"mode must be 'save' or 'check', got {self.mode!r}.")
+
+
+def _gui_available() -> bool:
+    """Whether OpenCV can open a window.
+
+    The ``opencv-python-headless`` wheel LeRobot depends on has no GUI on most platforms, so every
+    interactive step has to degrade instead of crashing.
+    """
+    try:
+        cv2.namedWindow("__lerobot_gui_probe__")
+        cv2.destroyWindow("__lerobot_gui_probe__")
+    except cv2.error:
+        return False
+    return True
+
+
+def _box_mask(shape: tuple[int, ...], roi: list[int], scale: float) -> NDArray[np.uint8]:
+    """A `[x, y, width, height]` box as a mask, grown about its own centre by ``scale``."""
+    x, y, w, h = roi
+    cx, cy = x + w / 2, y + h / 2
+    mask = np.zeros(shape[:2], np.uint8)
+    mask[
+        max(0, int(cy - h * scale / 2)) : int(cy + h * scale / 2),
+        max(0, int(cx - w * scale / 2)) : int(cx + w * scale / 2),
+    ] = 255
+    return mask
+
+
+def _fit_homography(
+    live: NDArray[np.uint8],
+    reference: NDArray[np.uint8],
+    live_mask: NDArray[np.uint8] | None = None,
+    reference_mask: NDArray[np.uint8] | None = None,
+) -> tuple[NDArray[np.float64] | None, int]:
+    """Solve for the live-to-reference transform, returning it with its RANSAC inlier count.
+
+    SIFT rather than ORB: the two are comparable over a whole frame, but on the small robot-only
+    region that carries the new-table case ORB's translation error was around 5 px against a known
+    20 px ground truth, where SIFT's was around 1 px.
+    """
+    sift = cv2.SIFT_create(4000)
+    live_kp, live_desc = sift.detectAndCompute(cv2.cvtColor(live, cv2.COLOR_BGR2GRAY), live_mask)
+    ref_kp, ref_desc = sift.detectAndCompute(cv2.cvtColor(reference, cv2.COLOR_BGR2GRAY), reference_mask)
+    if live_desc is None or ref_desc is None or len(live_kp) < 8 or len(ref_kp) < 8:
+        return None, 0
+
+    pairs = cv2.BFMatcher(cv2.NORM_L2).knnMatch(live_desc, ref_desc, k=2)
+    # Lowe's ratio test: keep a match only when the best candidate is clearly better than the second.
+    good = [a for a, b in (p for p in pairs if len(p) == 2) if a.distance < 0.75 * b.distance]
+    if len(good) < 8:
+        return None, len(good)
+
+    src = np.float32([live_kp[m.queryIdx].pt for m in good]).reshape(-1, 1, 2)
+    dst = np.float32([ref_kp[m.trainIdx].pt for m in good]).reshape(-1, 1, 2)
+    homography, inlier_mask = cv2.findHomography(src, dst, cv2.RANSAC, 3.0)
+    return homography, (0 if inlier_mask is None else int(inlier_mask.sum()))
+
+
+def decompose_homography(homography: NDArray[np.float64], width: int, height: int) -> dict[str, float]:
+    """Turn a homography into the four numbers a human can act on.
+
+    The matrix is applied to the image corners and the displacement is split into a translation, an
+    in-plane rotation and a scale. This is a deliberate simplification: a real mount also moves in
+    depth and out of plane, and a wide-angle lens is not a pinhole. It holds well over the small
+    displacements that matter when re-seating a mount, and degrades for large ones.
+
+    Args:
+        homography (`np.ndarray`):
+            3x3 matrix mapping live pixels to reference pixels.
+        width (`int`):
+            Frame width in pixels.
+        height (`int`):
+            Frame height in pixels.
+
+    Returns:
+        `dict[str, float]`: Keys `dx`, `dy`, `roll_deg` and `zoom`, describing what the live image
+        content must do to land on the reference.
+    """
+    corners = np.float32([[0, 0], [width, 0], [width, height], [0, height]]).reshape(-1, 1, 2)
+    warped = cv2.perspectiveTransform(corners, homography).reshape(-1, 2)
+    corners = corners.reshape(-1, 2)
+
+    dx, dy = warped.mean(0) - corners.mean(0)
+
+    def polygon_area(quad: NDArray[np.float32]) -> float:
+        return 0.5 * abs(
+            np.dot(quad[:, 0], np.roll(quad[:, 1], -1)) - np.dot(quad[:, 1], np.roll(quad[:, 0], -1))
+        )
+
+    def edge_angle(quad: NDArray[np.float32], i: int, j: int) -> float:
+        return float(np.degrees(np.arctan2(quad[j, 1] - quad[i, 1], quad[j, 0] - quad[i, 0])))
+
+    # Average the two horizontal edges so a pure perspective tilt does not read as roll.
+    roll_deg = 0.5 * (
+        (edge_angle(warped, 0, 1) - edge_angle(corners, 0, 1))
+        + (edge_angle(warped, 3, 2) - edge_angle(corners, 3, 2))
+    )
+    return {
+        "dx": float(dx),
+        "dy": float(dy),
+        "roll_deg": float(roll_deg),
+        "zoom": float(np.sqrt(polygon_area(warped) / polygon_area(corners))),
+    }
+
+
+def measure_shift(
+    live: NDArray[np.uint8], reference: NDArray[np.uint8], roi: list[int] | None = None
+) -> MountShift | None:
+    """Measure how far a camera has moved since its reference frame was taken.
+
+    Two fits are attempted and the better-supported one wins. The whole-frame fit is the accurate
+    one while the scene is unchanged. The robot-only fit is the one that still works after the rig
+    moves to a different table, because the robot is the only rigid thing that comes with it. The
+    inlier count is only a proxy for which is right: in a new room that resembles the old one, a
+    whole-frame fit on repeated background can out-vote a correct robot fit. The reported `via` says
+    which one answered, so an unexpected `"frame"` after a move is worth a second look.
+
+    Args:
+        live (`np.ndarray`):
+            Current frame, BGR `uint8`.
+        reference (`np.ndarray`):
+            Saved frame, BGR `uint8`.
+        roi (`list[int]`, *optional*):
+            Box around the robot in the reference frame, as `[x, y, width, height]`.
+
+    Returns:
+        `MountShift | None`: The measurement, or `None` when neither fit found enough support. A
+        `None` must be reported as "unknown", never treated as "no drift".
+    """
+    height, width = reference.shape[:2]
+    regions: list[tuple[str, NDArray[np.uint8] | None, NDArray[np.uint8] | None]] = [("frame", None, None)]
+    if roi:
+        regions.append(
+            ("robot", _box_mask(live.shape, roi, ROI_SEARCH_SCALE), _box_mask(reference.shape, roi, 1.0))
+        )
+
+    best = None
+    for via, live_mask, reference_mask in regions:
+        homography, inliers = _fit_homography(live, reference, live_mask, reference_mask)
+        if homography is None or inliers < MIN_INLIERS or (best is not None and inliers <= best.inliers):
+            continue
+        best = MountShift(
+            **decompose_homography(homography, width, height),
+            inliers=inliers,
+            via=via,
+            homography=homography,
+        )
+    return best
+
+
+def describe_correction(shift: MountShift | None, tol: MountTolerance) -> str:
+    """Say which way to physically move the camera.
+
+    Every direction here is two negations deep: the homography reports what the image content must
+    do, and the camera has to move the opposite way. A flipped sign walks the mount further off with
+    no other symptom, which is why `tests/scripts/test_lerobot_check_cameras.py` pins each one
+    against a simulated camera move.
+
+    Args:
+        shift (`MountShift | None`):
+            A measurement, or `None` when the fit failed.
+        tol (`MountTolerance`):
+            The limits deciding whether anything needs saying.
+
+    Returns:
+        `str`: A human instruction, `"in tolerance"`, or a note that nothing could be measured.
+    """
+    if shift is None:
+        return "no fit - too few matching features (arm at the reference pose? lens covered or dark?)"
+    if shift.within(tol):
+        return "in tolerance"
+
+    parts = []
+    if shift.shift_px > tol.shift_px:
+        # Gate on the total, then name only the axes that carry a visible part of it.
+        if abs(shift.dx) > 1.0:
+            parts.append(f"pan {'LEFT' if shift.dx > 0 else 'RIGHT'} {abs(shift.dx):.0f}px")
+        if abs(shift.dy) > 1.0:
+            parts.append(f"tilt {'UP' if shift.dy > 0 else 'DOWN'} {abs(shift.dy):.0f}px")
+    if abs(shift.roll_deg) > tol.roll_deg:
+        parts.append(f"roll {'CCW' if shift.roll_deg > 0 else 'CW'} {abs(shift.roll_deg):.1f}deg")
+    if abs(shift.zoom - 1.0) > tol.zoom:
+        parts.append(f"move {'CLOSER' if shift.zoom > 1 else 'BACK'} {abs(shift.zoom - 1) * 100:.0f}%")
+    return "  ".join(parts) or "in tolerance"
+
+
+def _reference_dir(robot: Robot) -> Path:
+    """Where this robot's camera reference lives, beside its motor calibration."""
+    if not robot.id:
+        raise ValueError(
+            "Pass --robot.id=<name>. A camera reference belongs to one physical rig, and without an "
+            "id every rig of this type would share, and overwrite, the same one."
+        )
+    return HF_LEROBOT_CALIBRATION / CAMERAS / robot.name / robot.id
+
+
+def _refuse_to_overwrite(path: Path, force: bool) -> None:
+    """Stop a save silently replacing a reference. Also called before ``robot.connect()``, so the
+    refusal lands before torque comes on."""
+    if path.exists() and not force:
+        raise FileExistsError(f"{path} already exists. Pass --force=true to replace it.")
+
+
+def _support(shift: MountShift | None) -> str:
+    """How the reading was arrived at, so a surprising `via` shows up while you are still nudging."""
+    return f"[{shift.inliers} pts, {shift.via}]" if shift else "[no fit]"
+
+
+def _rgb_camera_keys(robot: Robot) -> list[str]:
+    """Observation keys whose feature is an `(h, w, 3)` shape, so colour frames but not depth."""
+    return [
+        key
+        for key, ft in robot.observation_features.items()
+        if isinstance(ft, tuple) and len(ft) == 3 and ft[2] == 3
+    ]
+
+
+def _grab(robot: Robot, camera_keys: list[str]) -> tuple[dict[str, NDArray[np.uint8]], dict[str, float]]:
+    """Read one observation as BGR frames plus a pose keyed for `robot.send_action`.
+
+    Frames are converted to BGR here so everything downstream, including the images on disk, uses
+    one convention. Only `.pos` actions count as pose: a mobile base exposes wheel velocities, and a
+    velocity says nothing about where the cameras are pointing.
+    """
+    obs = robot.get_observation()
+    frames = {
+        key: cv2.cvtColor(np.asarray(obs[key], dtype=np.uint8), cv2.COLOR_RGB2BGR) for key in camera_keys
+    }
+    pose = {key: float(obs[key]) for key in robot.action_features if key.endswith(".pos") and key in obs}
+    return frames, pose
+
+
+def _pose_error(pose: dict[str, float], reference_pose: dict[str, float]) -> dict[str, float]:
+    """Signed current-minus-reference error, for each joint present in both."""
+    return {key: pose[key] - value for key, value in reference_pose.items() if key in pose}
+
+
+def _drive_to_pose(robot: Robot, target: dict[str, float], seconds: float = 3.0, hz: float = 30.0) -> None:
+    """Interpolate the arm to ``target``, slowly, because this runs unattended.
+
+    Any velocity axis the robot exposes is commanded to zero throughout, so a mobile base holds
+    still while the arm moves and `send_action` still gets the full set of keys it expects.
+    """
+    start = {key: float(value) for key, value in robot.get_observation().items() if key in target}
+    hold_still = {key: 0.0 for key in robot.action_features if key.endswith(".vel")}
+    steps = max(1, int(seconds * hz))
+    for step in range(1, steps + 1):
+        alpha = step / steps
+        moving = {k: start.get(k, v) + alpha * (v - start.get(k, v)) for k, v in target.items()}
+        robot.send_action({**hold_still, **moving})
+        time.sleep(1.0 / hz)
+    time.sleep(0.5)
+
+
+def _overlay(
+    live: NDArray[np.uint8], reference: NDArray[np.uint8], shift: MountShift | None
+) -> NDArray[np.uint8]:
+    """The live view with the reference ghosted over it, its outline, and a correction arrow."""
+    height, width = live.shape[:2]
+    live_gray = cv2.cvtColor(live, cv2.COLOR_BGR2GRAY)
+    ref_gray = cv2.cvtColor(reference, cv2.COLOR_BGR2GRAY)
+    # Reference in magenta, live in green: aligned content turns grey, drift shows as coloured fringes.
+    canvas = cv2.merge([ref_gray, live_gray, ref_gray])
+
+    if shift is not None:
+        corners = np.float32([[0, 0], [width, 0], [width, height], [0, height]]).reshape(-1, 1, 2)
+        outline = cv2.perspectiveTransform(corners, np.linalg.inv(shift.homography))
+        cv2.polylines(canvas, [np.int32(outline)], True, (0, 255, 255), 2)
+        length = float(np.hypot(shift.dx, shift.dy))
+        if length > 1.0:
+            scale = min(60.0, length * 3.0) / length
+            centre = (width // 2, height // 2)
+            tip = (int(centre[0] - shift.dx * scale), int(centre[1] - shift.dy * scale))
+            cv2.arrowedLine(canvas, centre, tip, (0, 255, 255), 3, tipLength=0.3)
+    return canvas
+
+
+def save_reference(robot: Robot, cfg: CheckCamerasConfig) -> None:
+    """Capture and store the reference frames, arm pose and robot boxes.
+
+    Args:
+        robot (`Robot`):
+            A connected robot.
+        cfg (`CheckCamerasConfig`):
+            Parsed configuration.
+
+    Raises:
+        FileExistsError: If a reference already exists and `cfg.force` is not set.
+    """
+    out_dir = _reference_dir(robot)
+    ref_path = out_dir / REFERENCE_FILENAME
+    _refuse_to_overwrite(ref_path, cfg.force)
+
+    camera_keys = _rgb_camera_keys(robot)
+    print(
+        "\nPut the arm in a pose you can return to later. It should be clearly visible in every view:\n"
+        "the robot is the anchor that survives a move to another table, and something mid-reach works\n"
+        "better than the rest pose. Torque is on once the robot is connected, so drive it there with\n"
+        "the leader arm rather than pushing against the servos."
+    )
+    input("Press Enter once the arm is in place... ")
+    _, pose = _grab(robot, [])
+
+    # The pose and the frames are captured separately: a hand still on the arm would be baked into
+    # the reference as features that are never there again, and every later check would fail on it.
+    input("Now move your hands, and anything else temporary, out of every view. Press Enter... ")
+    frames, _ = _grab(robot, camera_keys)
+    rois: dict[str, list[int] | None] = dict.fromkeys(camera_keys)
+    if cfg.select_roi:
+        if _gui_available():
+            for key in camera_keys:
+                print(f"Drag a box around the robot in '{key}', then press Enter. Press c to skip it.")
+                box = cv2.selectROI(f"{key}: box the robot", frames[key], showCrosshair=False)
+                cv2.destroyAllWindows()
+                rois[key] = [int(v) for v in box] if box[2] > 0 and box[3] > 0 else None
+        else:
+            print(
+                "No GUI available, so no robot box was drawn. Checks will still work on this table but "
+                "will not survive a move to a different one. Install opencv-python to draw the box."
+            )
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    reference = {
+        "robot_type": robot.name,
+        "robot_id": robot.id,
+        "created": datetime.now().isoformat(timespec="seconds"),
+        "joint_pose": pose,
+        "cameras": {},
+    }
+    for key in camera_keys:
+        cv2.imwrite(str(out_dir / f"{key}.png"), frames[key])
+        reference["cameras"][key] = {
+            "file": f"{key}.png",
+            "height": int(frames[key].shape[0]),
+            "width": int(frames[key].shape[1]),
+            "roi": rois[key],
+        }
+    ref_path.write_text(json.dumps(reference, indent=2))
+
+    print(f"\nSaved reference for {len(camera_keys)} camera(s) to {out_dir}")
+    print("arm pose:", {key: round(value, 1) for key, value in pose.items()})
+    print("Check the mounts against it with: lerobot-check-cameras --mode=check ...")
+
+
+def check_reference(robot: Robot, cfg: CheckCamerasConfig) -> bool:
+    """Compare the live cameras against the saved reference.
+
+    Args:
+        robot (`Robot`):
+            A connected robot.
+        cfg (`CheckCamerasConfig`):
+            Parsed configuration.
+
+    Returns:
+        `bool`: `True` when every camera is inside tolerance.
+
+    Raises:
+        FileNotFoundError: If no reference has been saved, or one of its frames is gone.
+        RuntimeError: If no camera can be scored, a camera's resolution has changed, the arm is not
+            at the reference pose, or `--live` was asked for without a GUI.
+    """
+    ref_dir = _reference_dir(robot)
+    ref_path = ref_dir / REFERENCE_FILENAME
+    if not ref_path.exists():
+        raise FileNotFoundError(f"No camera reference at {ref_path}. Run with --mode=save first.")
+    reference = json.loads(ref_path.read_text())
+
+    camera_keys = [key for key in _rgb_camera_keys(robot) if key in reference["cameras"]]
+    if not camera_keys:
+        # Silence here would be worse than a crash: an empty check passes, and a recording script
+        # gated on the exit code would be waved through with nothing actually verified.
+        raise RuntimeError(
+            f"No camera in the reference {sorted(reference['cameras'])} matches this robot's "
+            f"{sorted(_rgb_camera_keys(robot))}, so nothing can be checked. Are the camera names or "
+            "the --robot.id right?"
+        )
+    missing = sorted(set(reference["cameras"]) - set(camera_keys))
+    if missing:
+        print(f"WARNING: reference has camera(s) {missing} that this robot does not expose; skipping them.")
+    extra = sorted(set(_rgb_camera_keys(robot)) - set(reference["cameras"]))
+    if extra:
+        print(f"WARNING: camera(s) {extra} are not in the reference, so their mounts go unchecked.")
+
+    ref_frames = {}
+    for key in camera_keys:
+        spec = reference["cameras"][key]
+        frame = cv2.imread(str(ref_dir / spec["file"]))
+        if frame is None:
+            raise FileNotFoundError(f"Reference frame {ref_dir / spec['file']} is missing or unreadable.")
+        height, width, _ = robot.observation_features[key]
+        if (height, width) != (spec["height"], spec["width"]):
+            raise RuntimeError(
+                f"Camera '{key}' is configured at {width}x{height} but its reference is "
+                f"{spec['width']}x{spec['height']}. Drift measured in pixels does not carry across a "
+                "change of resolution: set the camera back, or save a new reference."
+            )
+        ref_frames[key] = frame
+
+    if cfg.drive_to_pose:
+        print("Moving the arm to the reference pose. Keep the workspace clear.")
+        _drive_to_pose(robot, reference["joint_pose"])
+
+    _, pose = _grab(robot, [])
+    errors = _pose_error(pose, reference["joint_pose"])
+    worst = max(errors.items(), key=lambda kv: abs(kv[1]), default=(None, 0.0))
+    if abs(worst[1]) > cfg.tolerance.pose_deg:
+        raise RuntimeError(
+            f"The arm is not at the pose the reference was captured at ('{worst[0]}' is off by "
+            f"{worst[1]:+.1f}). Camera drift cannot be told apart from arm motion until it is.\n"
+            f"  reference pose: { ({k: round(v, 1) for k, v in reference['joint_pose'].items()}) }\n"
+            f"  current pose:   { ({k: round(v, 1) for k, v in pose.items()}) }\n"
+            "Move the arm there, or pass --drive_to_pose=true to have it driven there."
+        )
+
+    if cfg.live and not _gui_available():
+        raise RuntimeError("--live needs a GUI, but OpenCV cannot open a window. Install opencv-python.")
+
+    print(f"\nreference from {reference['created']} at {ref_dir}")
+    if cfg.live:
+        print("Nudge each camera until every reading says 'in tolerance'. Press q or Esc to stop.")
+    while True:
+        frames, _ = _grab(robot, camera_keys)
+        shifts = {
+            key: measure_shift(frames[key], ref_frames[key], reference["cameras"][key]["roi"])
+            for key in camera_keys
+        }
+        if not cfg.live:
+            break
+
+        # One line, overwritten in place. Printing the block every iteration scrolls a dozen lines a
+        # second past the person whose hands are on the camera. The support carries here too: a
+        # `via` of "frame" after a move to a new room is the sign the wrong fit is answering, and it
+        # is no use only appearing once you have stopped nudging.
+        summary = " | ".join(
+            f"{key}: {describe_correction(s, cfg.tolerance)} {_support(s)}" for key, s in shifts.items()
+        )
+        print(f"\r  {summary[:200]:<200}", end="", flush=True)
+        for key in camera_keys:
+            cv2.imshow(
+                f"{key}: reference (magenta) vs live (green)",
+                _overlay(frames[key], ref_frames[key], shifts[key]),
+            )
+        if cv2.waitKey(30) & 0xFF in (ord("q"), 27):
+            print()
+            cv2.destroyAllWindows()
+            break
+
+    for key, shift in shifts.items():
+        print(f"  {key:<16} {describe_correction(shift, cfg.tolerance):<52} {_support(shift)}")
+    return all(shift is not None and shift.within(cfg.tolerance) for shift in shifts.values())
+
+
+@draccus.wrap()
+def check_cameras(cfg: CheckCamerasConfig) -> None:
+    """Save or check the camera mount reference for a robot.
+
+    Args:
+        cfg (`CheckCamerasConfig`):
+            Parsed configuration.
+
+    Raises:
+        SystemExit: With status 1 when a check finds a camera out of tolerance.
+        ValueError: If the robot exposes no colour cameras.
+    """
+    init_logging()
+    logging.info(pformat(asdict(cfg)))
+
+    robot = make_robot_from_config(cfg.robot)
+    if not _rgb_camera_keys(robot):
+        raise ValueError(f"{robot} has no colour cameras configured, so there are no mounts to check.")
+    # Whatever can be settled before connecting is settled before connecting. Connecting brings
+    # torque on, and an uncalibrated robot prompts, so a missing --robot.id or a save that would
+    # overwrite an existing reference should not surface with the arm already live.
+    reference_path = _reference_dir(robot) / REFERENCE_FILENAME
+    if cfg.mode == "save":
+        _refuse_to_overwrite(reference_path, cfg.force)
+
+    robot.connect()
+    try:
+        if cfg.mode == "save":
+            save_reference(robot, cfg)
+        elif not check_reference(robot, cfg):
+            raise SystemExit(1)
+    finally:
+        robot.disconnect()
+
+
+def main():
+    """Entry point for the ``lerobot-check-cameras`` command."""
+    register_third_party_plugins()
+    check_cameras()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/lerobot/scripts/lerobot_check_cameras.py
+++ b/src/lerobot/scripts/lerobot_check_cameras.py
@@ -627,6 +627,7 @@ def check_reference(robot: Robot, cfg: CheckCamerasConfig) -> bool:
     print(f"\nreference from {reference['created']} at {ref_dir}")
     if cfg.live:
         print("Nudge each camera until every reading says 'in tolerance'. Press q or Esc to stop.")
+    tiled: set[str] = set()
     while True:
         frames, _ = _grab(robot, camera_keys)
         shifts = {
@@ -644,11 +645,16 @@ def check_reference(robot: Robot, cfg: CheckCamerasConfig) -> bool:
             f"{key}: {describe_correction(s, cfg.tolerance)} {_support(s)}" for key, s in shifts.items()
         )
         print(f"\r  {summary[:200]:<200}", end="", flush=True)
+        x = 0
         for key in camera_keys:
-            cv2.imshow(
-                f"{key}: reference (magenta) vs live (green)",
-                _overlay(frames[key], ref_frames[key], shifts[key]),
-            )
+            title = f"{key}: reference (magenta) vs live (green)"
+            cv2.imshow(title, _overlay(frames[key], ref_frames[key], shifts[key]))
+            if title not in tiled:
+                # Every new window opens at the same screen position, so without this the last
+                # camera's window sits exactly on top of the others and they look missing.
+                cv2.moveWindow(title, x, 0)
+                tiled.add(title)
+            x += frames[key].shape[1] + 20
         if cv2.waitKey(30) & 0xFF in (ord("q"), 27):
             print()
             cv2.destroyAllWindows()

--- a/tests/scripts/test_lerobot_check_cameras.py
+++ b/tests/scripts/test_lerobot_check_cameras.py
@@ -1,0 +1,441 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Every instruction ``lerobot-check-cameras`` prints is two negations deep: the homography reports
+what the image content must do, and the camera has to move the opposite way. A flipped sign walks
+the mount further off with no other symptom, because the fit still converges and the numbers still
+look reasonable. So these tests apply a known camera move and assert the tool names its inverse.
+
+The scene is synthetic, so there is no artifact dependency. SIFT-over-ORB and the default
+tolerances came from real recordings; that reasoning lives in the script's docstrings.
+"""
+
+import json
+
+import cv2
+import numpy as np
+import pytest
+
+import lerobot.scripts.lerobot_check_cameras as check_cameras
+
+ROI = [200, 240, 240, 200]
+
+
+@pytest.fixture(scope="module")
+def reference_frame():
+    """A textured frame with a distinct blob inside the ROI, so the masked fit has its own features."""
+    rng = np.random.default_rng(0)
+    img = np.full((480, 640, 3), 40, np.uint8)
+    for _ in range(400):
+        x, y = rng.integers(0, 620), rng.integers(0, 460)
+        cv2.rectangle(
+            img,
+            (int(x), int(y)),
+            (int(x) + int(rng.integers(4, 18)), int(y) + int(rng.integers(4, 18))),
+            [int(v) for v in rng.integers(60, 255, 3)],
+            -1,
+        )
+    x, y, w, h = ROI
+    for _ in range(200):
+        cx, cy = rng.integers(x, x + w - 12), rng.integers(y, y + h - 12)
+        cv2.circle(
+            img, (int(cx), int(cy)), int(rng.integers(2, 7)), [int(v) for v in rng.integers(80, 255, 3)], -1
+        )
+    return cv2.GaussianBlur(img, (3, 3), 0)
+
+
+def move_camera(img, pan=0.0, tilt=0.0, roll=0.0, closer=0.0):
+    """Render what the camera would see after a known move.
+
+    pan > 0     camera swings right   -> content slides left
+    tilt > 0    camera aims up        -> content slides down
+    roll > 0    camera body turns CW  -> content turns CCW
+    closer > 0  camera approaches     -> content grows
+    """
+    h, w = img.shape[:2]
+    matrix = cv2.getRotationMatrix2D((w / 2, h / 2), roll, 1.0 + closer)
+    matrix[0, 2] += -pan
+    matrix[1, 2] += +tilt
+    return cv2.warpAffine(img, matrix, (w, h), borderMode=cv2.BORDER_REPLICATE)
+
+
+def replace_background(img, roi):
+    """Everything outside the robot box swapped for another scene, as after a move to a new table."""
+    rng = np.random.default_rng(1)
+    out = np.full_like(img, 90)
+    for _ in range(400):
+        x, y = rng.integers(0, 620), rng.integers(0, 460)
+        cv2.rectangle(
+            out,
+            (int(x), int(y)),
+            (int(x) + int(rng.integers(4, 18)), int(y) + int(rng.integers(4, 18))),
+            [int(v) for v in rng.integers(0, 200, 3)],
+            -1,
+        )
+    x, y, w, h = roi
+    out[y : y + h, x : x + w] = img[y : y + h, x : x + w]
+    return out
+
+
+# (camera move, the correction the tool must name)
+MOVES = [
+    ({"pan": 20}, "pan LEFT"),
+    ({"pan": -20}, "pan RIGHT"),
+    ({"tilt": 15}, "tilt DOWN"),
+    ({"tilt": -15}, "tilt UP"),
+    ({"roll": 2.0}, "roll CCW"),
+    ({"roll": -2.0}, "roll CW"),
+    ({"closer": 0.04}, "move BACK"),
+    ({"closer": -0.04}, "move CLOSER"),
+    ({}, "in tolerance"),
+]
+MOVE_IDS = [expected.replace(" ", "-") for _, expected in MOVES]
+
+
+@pytest.mark.parametrize("move,expected", MOVES, ids=MOVE_IDS)
+def test_correction_undoes_the_camera_move(reference_frame, move, expected):
+    shift = check_cameras.measure_shift(move_camera(reference_frame, **move), reference_frame, ROI)
+    assert shift is not None, "homography did not converge on a synthetic warp"
+    assert expected in check_cameras.describe_correction(shift, check_cameras.MountTolerance())
+
+
+@pytest.mark.parametrize("move,expected", MOVES, ids=MOVE_IDS)
+def test_correction_survives_a_new_table(reference_frame, move, expected):
+    """Everything but the robot is replaced, as after a move to another room. The answer must not
+    change. Which of the two fits gets there is not asserted: when the robot fills a good part of
+    the frame the whole-frame fit finds it unaided, and that is a fine outcome."""
+    live = replace_background(move_camera(reference_frame, **move), ROI)
+    shift = check_cameras.measure_shift(live, reference_frame, ROI)
+    assert shift is not None, "no fit converged after the scene changed"
+    assert expected in check_cameras.describe_correction(shift, check_cameras.MountTolerance())
+
+
+def test_robot_box_fit_stands_on_its_own(reference_frame):
+    """The box fit is the fallback for when the whole-frame fit dies, so exercise it in isolation
+    rather than relying on it winning the inlier race."""
+    live = replace_background(move_camera(reference_frame, pan=20), ROI)
+    homography, inliers = check_cameras._fit_homography(
+        live,
+        reference_frame,
+        check_cameras._box_mask(live.shape, ROI, check_cameras.ROI_SEARCH_SCALE),
+        check_cameras._box_mask(reference_frame.shape, ROI, 1.0),
+    )
+    assert homography is not None
+    assert inliers >= check_cameras.MIN_INLIERS
+    decomposed = check_cameras.decompose_homography(homography, 640, 480)
+    # The camera panned right by 20 px, so the content has to come back the other way.
+    assert decomposed["dx"] == pytest.approx(20.0, abs=2.0)
+
+
+def test_box_mask_grows_about_its_centre():
+    """The live frame is searched over a wider box than the reference, so a roughly re-mounted
+    camera still has the robot inside the search area."""
+    box = [250, 180, 140, 120]  # small enough that doubling it stays inside the frame
+    tight = check_cameras._box_mask((480, 640), box, 1.0)
+    grown = check_cameras._box_mask((480, 640), box, 2.0)
+
+    assert np.all(grown[tight > 0] > 0), "the grown box must contain the tight one"
+    assert grown.sum() == pytest.approx(4 * tight.sum(), rel=0.02)
+    for mask in (tight, grown):
+        ys, xs = np.nonzero(mask)
+        assert xs.mean() == pytest.approx(320.0, abs=1.0)
+        assert ys.mean() == pytest.approx(240.0, abs=1.0)
+
+
+def test_box_mask_is_clipped_to_the_frame():
+    """Growing a box that already touches an edge cannot search outside the image."""
+    mask = check_cameras._box_mask((480, 640), [200, 240, 240, 200], 2.0)
+    assert mask.shape == (480, 640)
+    assert mask[:139].sum() == 0  # nothing above the grown top edge
+    assert mask[479, 320] > 0  # grown down to the bottom row and stopped there
+
+
+def test_no_fit_is_reported_not_guessed(reference_frame):
+    """A featureless frame must return None, never a confident zero."""
+    shift = check_cameras.measure_shift(np.zeros_like(reference_frame), reference_frame, ROI)
+    assert shift is None
+    assert "no fit" in check_cameras.describe_correction(shift, check_cameras.MountTolerance())
+
+
+def test_unchanged_view_is_within_tolerance(reference_frame):
+    shift = check_cameras.measure_shift(reference_frame, reference_frame, ROI)
+    assert shift.within(check_cameras.MountTolerance())
+    assert shift.shift_px == pytest.approx(0.0, abs=0.5)
+
+
+def test_shift_magnitude_matches_the_move(reference_frame):
+    shift = check_cameras.measure_shift(move_camera(reference_frame, pan=40), reference_frame, ROI)
+    assert shift.shift_px == pytest.approx(40.0, abs=2.0)
+
+
+def test_tolerance_decides_the_verdict(reference_frame):
+    """The same measurement must pass or fail purely on the configured limits."""
+    shift = check_cameras.measure_shift(move_camera(reference_frame, pan=10), reference_frame, ROI)
+    assert not shift.within(check_cameras.MountTolerance(shift_px=4.0))
+    assert shift.within(check_cameras.MountTolerance(shift_px=20.0))
+
+
+class FakeRobot:
+    """The slice of the Robot interface this script touches, with scriptable frames and pose.
+
+    ``velocities`` stands in for a mobile base: axes that appear in `action_features` but are not a
+    pose, and that `send_action` refuses to be called without.
+    """
+
+    name = "fake_follower"
+
+    def __init__(self, frame, pose, velocities=()):
+        self.id = "test_arm"
+        self.camera_keys = ["front"]
+        self.frame = frame
+        self.pose = dict(pose)
+        self.velocities = dict.fromkeys(velocities, 0.0)
+        self.sent = []
+
+    @property
+    def observation_features(self):
+        return {**self.action_features, **dict.fromkeys(self.camera_keys, (*self.frame.shape[:2], 3))}
+
+    @property
+    def action_features(self):
+        return {**dict.fromkeys(self.pose, float), **dict.fromkeys(self.velocities, float)}
+
+    def get_observation(self):
+        # The robot hands out RGB; the script is responsible for converting to OpenCV's BGR.
+        rgb = cv2.cvtColor(self.frame, cv2.COLOR_BGR2RGB)
+        return {**self.pose, **self.velocities, **dict.fromkeys(self.camera_keys, rgb)}
+
+    def send_action(self, action):
+        missing = sorted(set(self.velocities) - set(action))
+        if missing:
+            raise KeyError(f"send_action indexes {missing} directly, as LeKiwi's does")
+        self.sent.append(action)
+        self.pose.update({key: value for key, value in action.items() if key in self.pose})
+        return action
+
+
+@pytest.fixture
+def saved(tmp_path, monkeypatch, reference_frame):
+    """A robot with a reference already on disk, and the config used to write it."""
+    monkeypatch.setattr(check_cameras, "HF_LEROBOT_CALIBRATION", tmp_path)
+    monkeypatch.setattr("builtins.input", lambda *_: "")
+    robot = FakeRobot(reference_frame, {"shoulder_pan.pos": 12.0, "elbow_flex.pos": -30.0})
+    cfg = check_cameras.CheckCamerasConfig(robot=None, select_roi=False)
+    check_cameras.save_reference(robot, cfg)
+    return robot, cfg
+
+
+def test_save_then_check_round_trips(saved, tmp_path):
+    """An untouched rig must pass a check against its own freshly written reference."""
+    robot, cfg = saved
+    ref_dir = tmp_path / "cameras" / "fake_follower" / "test_arm"
+    stored = json.loads((ref_dir / check_cameras.REFERENCE_FILENAME).read_text())
+
+    assert (ref_dir / "front.png").exists()
+    assert stored["joint_pose"] == {"shoulder_pan.pos": 12.0, "elbow_flex.pos": -30.0}
+    assert stored["cameras"]["front"] == {"file": "front.png", "height": 480, "width": 640, "roi": None}
+    assert check_cameras.check_reference(robot, cfg) is True
+
+
+def test_check_fails_when_the_camera_has_moved(saved):
+    robot, cfg = saved
+    robot.frame = move_camera(robot.frame, pan=25)
+    assert check_cameras.check_reference(robot, cfg) is False
+
+
+def test_check_refuses_when_the_arm_is_not_at_the_reference_pose(saved):
+    """The gate that stops arm motion being reported as camera drift."""
+    robot, cfg = saved
+    robot.pose["elbow_flex.pos"] += 20.0
+    with pytest.raises(RuntimeError, match="not at the pose"):
+        check_cameras.check_reference(robot, cfg)
+
+
+def test_drive_to_pose_returns_the_arm_and_then_the_check_runs(saved):
+    robot, cfg = saved
+    robot.pose["elbow_flex.pos"] += 20.0
+    cfg.drive_to_pose = True
+
+    assert check_cameras.check_reference(robot, cfg) is True
+    assert robot.sent, "the arm should have been commanded"
+    assert robot.pose["elbow_flex.pos"] == pytest.approx(-30.0, abs=0.1)
+
+
+def test_save_refuses_to_overwrite_without_force(saved):
+    robot, cfg = saved
+    with pytest.raises(FileExistsError, match="--force"):
+        check_cameras.save_reference(robot, cfg)
+    cfg.force = True
+    check_cameras.save_reference(robot, cfg)
+
+
+def test_save_captures_the_pose_before_the_frames(tmp_path, monkeypatch, reference_frame):
+    """Two prompts, not one. The operator's hands have to leave the shot between reading the pose
+    and grabbing the frames, or they are baked into the reference as features that are never there
+    again and every later check fails against them."""
+    monkeypatch.setattr(check_cameras, "HF_LEROBOT_CALIBRATION", tmp_path)
+    robot = FakeRobot(reference_frame, {"shoulder_pan.pos": 5.0})
+    hands_out = move_camera(reference_frame, pan=30)
+    prompts = []
+
+    def answer(_):
+        prompts.append(len(prompts))
+        if len(prompts) == 2:
+            robot.pose["shoulder_pan.pos"] = 99.0
+            robot.frame = hands_out
+        return ""
+
+    monkeypatch.setattr("builtins.input", answer)
+    check_cameras.save_reference(robot, check_cameras.CheckCamerasConfig(robot=None, select_roi=False))
+
+    ref_dir = tmp_path / "cameras" / "fake_follower" / "test_arm"
+    stored = json.loads((ref_dir / check_cameras.REFERENCE_FILENAME).read_text())
+    assert len(prompts) == 2
+    assert stored["joint_pose"] == {"shoulder_pan.pos": 5.0}, "pose must be read before the second prompt"
+    assert np.array_equal(cv2.imread(str(ref_dir / "front.png")), hands_out), "frames must come after it"
+
+
+def test_check_without_a_reference_says_so(tmp_path, monkeypatch, reference_frame):
+    monkeypatch.setattr(check_cameras, "HF_LEROBOT_CALIBRATION", tmp_path)
+    robot = FakeRobot(reference_frame, {"shoulder_pan.pos": 0.0})
+    with pytest.raises(FileNotFoundError, match="--mode=save"):
+        check_cameras.check_reference(robot, check_cameras.CheckCamerasConfig(robot=None))
+
+
+def test_check_fails_loudly_when_no_camera_can_be_scored(saved):
+    """A check that scores nothing must not pass. `all([])` is True, so a recording script gated on
+    the exit code would be waved through with no camera verified at all."""
+    robot, cfg = saved
+    robot.camera_keys = ["renamed_after_the_reference_was_saved"]
+    with pytest.raises(RuntimeError, match="nothing can be checked"):
+        check_cameras.check_reference(robot, cfg)
+
+
+def test_check_says_which_reference_frame_is_gone(saved, tmp_path):
+    """cv2.imread returns None for a missing file, which would otherwise surface as a cv2.error
+    from inside the matcher."""
+    robot, cfg = saved
+    (tmp_path / "cameras" / "fake_follower" / "test_arm" / "front.png").unlink()
+    with pytest.raises(FileNotFoundError, match="missing or unreadable"):
+        check_cameras.check_reference(robot, cfg)
+
+
+def test_check_warns_about_a_camera_the_reference_never_saw(saved, capsys):
+    """Adding a camera after the reference was written is silent otherwise: the check passes, having
+    said nothing about the mount you just bolted on."""
+    robot, cfg = saved
+    robot.camera_keys.append("added_later")  # the reference still only knows about "front"
+
+    assert check_cameras.check_reference(robot, cfg) is True
+    assert "['added_later'] are not in the reference" in capsys.readouterr().out
+
+
+def test_saving_over_a_reference_is_refused_before_the_robot_is_touched(saved, tmp_path):
+    """`check_cameras` calls this ahead of `robot.connect()`, so the refusal does not arrive with
+    the arm already under torque."""
+    path = tmp_path / "cameras" / "fake_follower" / "test_arm" / check_cameras.REFERENCE_FILENAME
+    with pytest.raises(FileExistsError, match="--force"):
+        check_cameras._refuse_to_overwrite(path, force=False)
+
+    check_cameras._refuse_to_overwrite(path, force=True)
+    check_cameras._refuse_to_overwrite(path.with_name("not_there.json"), force=False)
+
+
+def test_live_keeps_the_support_on_the_status_line(saved, monkeypatch, capsys):
+    """`via` is the flag for the wrong fit winning, and it is no use appearing only after you stop
+    nudging. One iteration, then quit."""
+    robot, cfg = saved
+    cfg.live = True
+    monkeypatch.setattr(check_cameras, "_gui_available", lambda: True)
+    monkeypatch.setattr(cv2, "imshow", lambda *_: None)
+    monkeypatch.setattr(cv2, "waitKey", lambda *_: ord("q"))
+    monkeypatch.setattr(cv2, "destroyAllWindows", lambda: None)
+
+    check_cameras.check_reference(robot, cfg)
+
+    live_line = capsys.readouterr().out.split("\r")[1]
+    assert "front: in tolerance" in live_line
+    assert "pts, frame]" in live_line, "the inlier count and the winning region belong on this line"
+
+
+def test_check_refuses_a_changed_resolution(saved):
+    """Drift is reported in pixels, so it is not comparable across resolutions."""
+    robot, cfg = saved
+    robot.frame = cv2.resize(robot.frame, (320, 240))
+    with pytest.raises(RuntimeError, match="change of resolution"):
+        check_cameras.check_reference(robot, cfg)
+
+
+def test_reference_dir_needs_a_robot_id(reference_frame):
+    """--robot.id is optional upstream, and a None here would land every rig of one type in the
+    same directory."""
+    robot = FakeRobot(reference_frame, {"shoulder_pan.pos": 0.0})
+    robot.id = None
+    with pytest.raises(ValueError, match="--robot.id"):
+        check_cameras._reference_dir(robot)
+
+
+def test_velocity_axes_are_not_part_of_the_pose(reference_frame):
+    """A mobile base exposes wheel velocities as actions. They say nothing about where the cameras
+    point, and gating on them would block a check whenever the base happened to be rolling."""
+    robot = FakeRobot(reference_frame, {"shoulder_pan.pos": 3.0}, velocities=["x.vel"])
+    robot.velocities["x.vel"] = 0.4
+    _, pose = check_cameras._grab(robot, [])
+    assert pose == {"shoulder_pan.pos": 3.0}
+
+
+def test_drive_to_pose_holds_a_mobile_base_still(reference_frame):
+    robot = FakeRobot(reference_frame, {"shoulder_pan.pos": 0.0}, velocities=["x.vel", "theta.vel"])
+    check_cameras._drive_to_pose(robot, {"shoulder_pan.pos": 10.0}, seconds=0.05, hz=20.0)
+
+    assert robot.sent, "the arm should have been commanded"
+    assert all(sent["x.vel"] == 0.0 and sent["theta.vel"] == 0.0 for sent in robot.sent)
+    assert robot.pose["shoulder_pan.pos"] == pytest.approx(10.0, abs=0.1)
+
+
+def test_rgb_camera_keys_skips_depth_and_joints():
+    robot = type(
+        "FakeRobot",
+        (),
+        {
+            "observation_features": {
+                "shoulder_pan.pos": float,
+                "front": (480, 640, 3),
+                "front_depth": (480, 640, 1),
+            }
+        },
+    )()
+    assert check_cameras._rgb_camera_keys(robot) == ["front"]
+
+
+def test_pose_error_is_signed_and_per_joint():
+    errors = check_cameras._pose_error(
+        {"a.pos": 10.0, "b.pos": -2.0, "c.pos": 0.0}, {"a.pos": 8.0, "b.pos": 1.0}
+    )
+    assert errors == {"a.pos": 2.0, "b.pos": -3.0}
+
+
+def test_mode_must_be_save_or_check():
+    with pytest.raises(ValueError, match="mode must be"):
+        check_cameras.CheckCamerasConfig(robot=None, mode="inspect")
+
+
+def test_main_registers_plugins_before_parsing(monkeypatch):
+    calls = []
+    monkeypatch.setattr(check_cameras, "register_third_party_plugins", lambda: calls.append("register"))
+    monkeypatch.setattr(check_cameras, "check_cameras", lambda: calls.append("check"))
+
+    check_cameras.main()
+
+    assert calls == ["register", "check"]

--- a/tests/scripts/test_lerobot_check_cameras.py
+++ b/tests/scripts/test_lerobot_check_cameras.py
@@ -359,6 +359,7 @@ def test_live_keeps_the_support_on_the_status_line(saved, monkeypatch, capsys):
     cfg.live = True
     monkeypatch.setattr(check_cameras, "_gui_available", lambda: True)
     monkeypatch.setattr(cv2, "imshow", lambda *_: None)
+    monkeypatch.setattr(cv2, "moveWindow", lambda *_: None)
     monkeypatch.setattr(cv2, "waitKey", lambda *_: ord("q"))
     monkeypatch.setattr(cv2, "destroyAllWindows", lambda: None)
 


### PR DESCRIPTION
## Summary / Motivation

Adds `lerobot-check-cameras`, a CLI that pins each camera's mount pose to a saved reference and tells you which way to move a camera that has drifted.

Camera extrinsics drift and nothing notices. A tripod gets nudged, a wrist mount is re-clamped after a repair, the rig moves to another table. A policy trained on the old viewpoint then fails silently — no exception, no metric moves, the robot just does the wrong thing — and it reads as a policy problem. `lerobot-find-cameras` tells you which index is which and `lerobot-calibrate` is arm-only, so nothing currently covers mount repeatability.

#4496 has the measurements behind that: a tripod that moved 37 px during a single two-minute recording without anyone touching it, and 25 failed attempts to recover the original pose from the dataset afterwards. The short version is that the reference has to be captured deliberately and up front, because it cannot be reconstructed later.

## Related issues

- Closes: #4496

## What changed

New CLI, same robot config as `lerobot-calibrate`. No existing behaviour is touched, so there is nothing to migrate.

- `--mode=save` stores one reference frame per camera plus the arm pose it was captured at, under `~/.cache/huggingface/lerobot/calibration/cameras/<robot>/<id>/`, beside the motor calibration.
- `--mode=check` reports the drift per camera, names the physical correction, and exits nonzero so it can gate a recording script.
- `--live=true` draws a per-camera overlay to nudge against and keeps one status line updated in place.
- `docs/source/cameras.mdx` gains a `## Check camera mounts` section.
- One `[project.scripts]` entry. Only `opencv` and `numpy`, both already dependencies.

```
reference from 2026-01-14T09:31:02 at ~/.cache/huggingface/lerobot/calibration/cameras/so_follower/my_arm
  front            pan LEFT 25px                                        [329 pts, frame]
  wrist            in tolerance                                         [726 pts, frame]
```

What `--live=true` shows while you nudge, from the physical remount described below: the saved reference in magenta, the live camera in green, the yellow arrow pointing the way the camera has to move. The fringing along the arm and the table edge is the drift.

![lerobot-check-cameras --live overlay: reference in magenta, live in green, correction arrow in yellow](https://raw.githubusercontent.com/OliverAltergott/lerobot/pr-assets/check-cameras-live-overlay.png)

## How was this tested (or how to run locally)

**Tests added:** `tests/scripts/test_lerobot_check_cameras.py`, 45 tests. `pytest -q tests/scripts/test_lerobot_check_cameras.py` — 45 passed. `pytest -q tests/scripts` — 85 passed.

The ones that matter apply a known camera move and assert the tool names its inverse: the homography reports what the image content must do and the camera moves the opposite way, so a flipped sign walks the mount further off while the fit still converges and the numbers still look sane. The rest cover the save→check round trip, the pose gate, tolerance handling, the no-fit path (which must say "no fit", never a confident zero), and the ways a check can fail to check anything — no matching camera names, a deleted reference frame, a changed resolution, a missing `--robot.id`.

**Manual checks on an SO-101 with two USB cameras.** `save` wrote a reference from both. `check` returned `in tolerance` at 749 and 330 inliers. A known 25 px drift injected into the reference came back as `pan LEFT 25px` with exit 1. A 20° pose mismatch was refused with the joint named.

**The external camera was then physically moved on its mount**, which is the case the injected-drift tests only imitate. `check` caught it and exited 1. To confirm the fit rather than trust it, the live frame was warped through the reported homography and correlated against the reference:

| region                                            | correlation after the warp |
| ------------------------------------------------- | -------------------------- |
| background (table, cup, monitor, power strip)     | 0.906                      |
| the robot itself                                  | 0.360                      |
| untouched wrist camera, same moment, as a ceiling | 0.889                      |

The background lands slightly better than a camera nobody touched, so the fit is right. The robot alone stays off because it stands well in front of the table plane and one homography cannot hold two depths — ordinary parallax once a camera translates rather than purely rotating.

`--live=true` was then used to nudge it home: 12 minutes, 5097 measurements, 7.1 Hz for two cameras, and 2 lines of scrolling output for the whole session. Roll recovered from 16.3° to under 1°.

To reproduce:

```bash
lerobot-check-cameras --mode=save \
    --robot.type=so101_follower --robot.port=/dev/ttyACM0 --robot.id=my_arm \
    --robot.cameras='{ front: {type: opencv, index_or_path: 0, width: 640, height: 480, fps: 30}}'

# nudge the camera, then
lerobot-check-cameras --mode=check ...   # same args; add --live=true for the overlay
```

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run --files` on the four files this PR touches; all hooks pass, including `typos`, `prettier`, `bandit` and `mypy`)
- [x] All tests pass locally (`pytest -q tests/scripts`, 85 passed)
- [x] Documentation updated (`docs/source/cameras.mdx`)
- [ ] CI is green — not yet known, will confirm once it runs here
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: #

## Reviewer notes

**The design point worth your attention: the arm pose has to be pinned.** Measurements in #4496; the effect is that a wrist camera compared across two arm poses in one uninterrupted recording reports −131 px and −15.4° of "drift" that is entirely arm motion, while the fixed camera on the same frame pair reports 0.0 px. So `save` records the joint angles and `check` refuses to score until the arm is back, or drives it there with `--drive_to_pose=true`.

Two consequences in the code that are easy to miss while reading the diff. The gate applies to **every** camera, not just wrist-mounted ones, because once the robot fills a fixed camera's frame the inliers concentrate on it and arm rotation reads as camera roll. And only `.pos` actions count as pose — a mobile base's wheel velocities say nothing about where the cameras point, so they are excluded from the gate and `--drive_to_pose` holds them at zero rather than commanding them as positions.

**After a move to a new table.** The whole-frame fit dies when the room changes. The robot does not — it is the one rigid thing that comes with you. So `save` asks for a box around it, and with everything outside that box replaced the fit still gives 130–151 inliers, ~1 px, correct direction. Both fits run and the better-supported one wins, so one command covers both situations.

**Matching.** SIFT + RANSAC homography, decomposed at the image corners into shift / roll / zoom. SIFT over ORB because on that small robot box ORB was ~5 px off a 20 px ground truth where SIFT was ~1 px. When both fits converge, the one with more inliers wins — that is a proxy, and in a new room resembling the old one a whole-frame fit on repeated background could out-vote a correct robot fit. The reported `via` says which one answered. Open to preferring the box outright, or printing both when they disagree.

**Headless.** Every interactive step degrades with a message when `opencv-python-headless` has no GUI, so the default check is fully headless. `--live` is the one flag that refuses outright, because it has nothing to show.

**Limitations**, documented in the docstrings and in `cameras.mdx`:

- A homography assumes a pinhole camera and a planar scene or pure rotation. Real lenses are fisheye; recovery is sub-pixel in the ~20 px / 2° regime that matters for re-seating a mount, and degrades for large displacements. On the physical move above, two runs minutes apart agreed on roll (16.3° and 16.7°) but gave 9 px / 5% and then 77 px / 21% for translation and zoom, at ~30 inliers against a floor of 25. The printed inlier count is the signal that the rest is being extrapolated; the same rig inside tolerance reads steady at 330–750 inliers.
- **The 4 px / 0.4° default is a detection bar, not a hand-adjustment target.** It comes from the 3 px / 0.2° / 0.4% a fixed camera reproduced to across eight same-session recordings, which makes it right for _has this drifted_. It is tighter than a friction mount can be re-seated to by hand: past about 10 px the readings stopped converging and started alternating in sign, because loosening and re-tightening the tripod head displaces the camera by about as much as the correction. The docs say this next to the "nudge until it reads `in tolerance`" instruction and point at `--tolerance.shift_px`.
- Needs texture. A bare table against a blank wall may not give enough features.
- Tested on SO-101 with UVC cameras at 640×480. Not tested on RealSense or depth.

**The name is still open** — see #4496. `check-camera-mounts` is the alternative. Say which you prefer and I will rename.

---

Per `AI_POLICY.md`: written with Claude Code. I ran every check above myself and can speak to any line of it.
