### PR TITLE
fix(envs): strip LIBERO-plus perturbation suffix from task instructions

### DIFF
--- a/src/lerobot/envs/libero.py
+++ b/src/lerobot/envs/libero.py
@@ -63,6 +63,23 @@ def _select_task_ids(total_tasks: int, task_ids: Iterable[int] | None) -> list[i
 # can pass weights_only=False for PyTorch 2.6+ numpy pickles).
 _LIBERO_PERTURBATION_SUFFIX_RE = re.compile(r"_(?:language|view|light)_[^.]*|_(?:table|tb)_\d+")
 
+# Same perturbation tokens as above, matched against the space-separated task
+# description instead of the underscore-separated filename. Keep both in sync.
+_LIBERO_PERTURBATION_INSTRUCTION_RE = re.compile(r"\s(?:language|view|light)\s.*$|\s(?:table|tb)\s\d+$")
+
+
+def strip_perturbation_from_instruction(task_name: str, instruction: str) -> str:
+    """Remove the LIBERO-plus perturbation suffix from a task description.
+
+    LIBERO-plus derives the description of a `_language_` variant from the BDDL
+    file, which is already a clean rephrasing. Every other variant falls back to
+    splitting the task name on underscores, so the perturbation id ends up inside
+    the natural-language instruction handed to the policy.
+    """
+    if "_language_" in task_name:
+        return instruction
+    return _LIBERO_PERTURBATION_INSTRUCTION_RE.sub("", instruction)
+
 
 def get_task_init_states(task_suite: Any, i: int, is_libero_plus: bool = False) -> np.ndarray:
     task = task_suite.tasks[i]
@@ -177,7 +194,11 @@ class LiberoEnv(gym.Env):
         # Extract task metadata without allocating GPU resources (safe before fork).
         task = task_suite.get_task(task_id)
         self.task = task.name
-        self.task_description = task.language
+        self.task_description = (
+            strip_perturbation_from_instruction(task.name, task.language)
+            if self.is_libero_plus
+            else task.language
+        )
         self._task_bddl_file = os.path.join(
             get_libero_path("bddl_files"), task.problem_folder, task.bddl_file
         )

--- a/tests/envs/test_libero.py
+++ b/tests/envs/test_libero.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+
+# Copyright 2024 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import annotations
+
+import pytest
+
+libero = pytest.importorskip("lerobot.envs.libero")
+
+strip_perturbation_from_instruction = libero.strip_perturbation_from_instruction
+
+BASE_INSTRUCTION = "pick up the black bowl next to the ramekin and place it on the plate"
+
+
+@pytest.mark.parametrize(
+    ("task_name", "instruction"),
+    [
+        (
+            "pick_up_the_black_bowl_next_to_the_ramekin_and_place_it_on_the_plate_table_14",
+            f"{BASE_INSTRUCTION} table 14",
+        ),
+        (
+            "pick_up_the_black_bowl_next_to_the_ramekin_and_place_it_on_the_plate_tb_3",
+            f"{BASE_INSTRUCTION} tb 3",
+        ),
+        (
+            "pick_up_the_black_bowl_next_to_the_ramekin_and_place_it_on_the_plate_view_0_0_100_0_0_initstate_1",
+            f"{BASE_INSTRUCTION} view 0 0 100 0 0 initstate 1",
+        ),
+        (
+            "pick_up_the_black_bowl_next_to_the_ramekin_and_place_it_on_the_plate_light_2",
+            f"{BASE_INSTRUCTION} light 2",
+        ),
+    ],
+)
+def test_perturbation_suffix_is_removed_from_instruction(task_name: str, instruction: str) -> None:
+    assert strip_perturbation_from_instruction(task_name, instruction) == BASE_INSTRUCTION
+
+
+def test_language_variants_keep_their_rephrased_instruction() -> None:
+    """`_language_` variants read a clean rephrasing from the BDDL file, so leave them alone."""
+    task_name = "pick_up_the_black_bowl_next_to_the_ramekin_and_place_it_on_the_plate_language_2_view_0_0_100_0_0_initstate_0"
+    instruction = "grab the dark bowl beside the ramekin and set it on the plate"
+
+    assert strip_perturbation_from_instruction(task_name, instruction) == instruction
+
+
+def test_unperturbed_instruction_is_unchanged() -> None:
+    task_name = "pick_up_the_black_bowl_next_to_the_ramekin_and_place_it_on_the_plate"
+
+    assert strip_perturbation_from_instruction(task_name, BASE_INSTRUCTION) == BASE_INSTRUCTION


### PR DESCRIPTION
## Summary / Motivation

LIBERO-plus encodes the perturbation in the task name (`_table_14`, `_view_...`, `_light_...`, `_language_N`). Its `grab_language_from_filename()` reads a clean instruction from the BDDL file **only** for `_language_` variants; every other variant falls back to `" ".join(task_name.split("_"))`, so the perturbation id ends up inside the instruction handed to the policy:

```
task.name     : pick_up_the_black_bowl_..._and_place_it_on_the_plate_table_1
task.language : "pick up the black bowl ... and place it on the plate table 1"
                                                                   ^^^^^^^
```

`get_task_init_states()` already compensates for this — `_LIBERO_PERTURBATION_SUFFIX_RE` strips the suffix when resolving the `.pruned_init` filename — but `task_description` was left untouched.

Counting over LIBERO-plus's own task map, **6968 of its 10120 tasks** leak a suffix into the instruction. `_view_` variants leak the most, e.g. `"... on the plate view 0 0 100 0 0 initstate 1"`.

This changes behaviour: the prompt the policy receives is different for the affected tasks, so LIBERO-plus numbers will shift.

## Related issues

- Related: #3313 (added the LIBERO-plus benchmark and the filename-side suffix stripping)
- Related: #4476 (same class of bug — eval prompts not matching what the policy was trained on)

## What changed

- Added `strip_perturbation_from_instruction(task_name, instruction)` next to the existing suffix regex, matching the same perturbation tokens against the space-separated description.
- `LiberoEnv.__init__` routes `task.language` through it when `is_libero_plus` is set. Plain LIBERO is untouched.
- `_language_` variants pass through unchanged — their description comes from the BDDL file and is a deliberate rephrasing.
- Added `tests/envs/test_libero.py` covering `_table_`, `_tb_`, `_view_`, `_light_`, the `_language_` passthrough, and an unperturbed task.

## How was this tested (or how to run locally)

- `pytest -q tests/envs/test_libero.py`
- Ran the new function over LIBERO-plus's real task map (10120 tasks): 6968 instructions cleaned, 1615 already clean and left byte-identical, 1537 `_language_` variants skipped by construction.
- Checked correctness by independently reimplementing `grab_language_from_filename()` and comparing each cleaned instruction against the instruction of its base task (task name with the suffix removed): **8583 / 8583 exact matches, 0 mismatches**.
- Checked plain LIBERO for token collisions: none of its 130 task names match the perturbation pattern, so the stripping cannot truncate a legitimate instruction.
- `ruff check` and `ruff format --check` pass.

Not verified: the effect on success rates. `hf-libero` is Linux-only and I develop on macOS, so I could not run an end-to-end evaluation, and I have deliberately kept accuracy numbers out of this PR.

## Checklist (required before merge)

- [x] Linting/formatting run (`ruff check` / `ruff format --check` on the changed files)
- [x] All tests pass locally (`pytest`) — the new tests `importorskip` and skip on macOS, since `hf-libero` installs on Linux only; they do run on Linux in `Fast Pytest Tests`, which passes
- [x] Documentation updated — not applicable, no user-facing docs describe this behaviour
- [x] CI is green — every check that runs for a fork PR passes (`Fast Pytest Tests`, pre-commit, doctests, secret scan, docs build). The `benchmark_tests.yml` eval jobs, including LIBERO-plus, are skipped by their `github.event.pull_request.head.repo.fork == false` guard, so they cannot run from a fork; they will run on `main` after merge, and on the Monday schedule.
- [x] Community Review: I have reviewed another contributor's open PR and linked it here: #4492

## Reviewer notes

- Where to fix this is the main judgement call. Stripping in `lerobot` mirrors what `get_task_init_states()` already does for the filename side, and LIBERO-plus upstream has had no code pushed for several months. If you would rather see it fixed there, say so and I will close this.
- Two regexes now encode the same tokens in two separators (`_` for filenames, whitespace for instructions). I kept them adjacent with a comment rather than factoring them, to keep the diff small — happy to unify.

---
*Significant AI assistance (Claude Code) was used for the analysis and drafting of this change, per [AI_POLICY.md](https://github.com/huggingface/lerobot/blob/main/AI_POLICY.md). I have read the diff, verified the counts above myself, and can explain the change.*

