### PR TITLE
perf(datasets): stream-copy videos when deleting episodes

### DIFF
--- a/src/lerobot/datasets/dataset_tools.py
+++ b/src/lerobot/datasets/dataset_tools.py
@@ -606,6 +606,74 @@ def _copy_and_reindex_data(
     return episode_data_metadata
 
 
+def _try_keep_episodes_from_video_by_stream_copy(
+    input_path: Path,
+    output_path: Path,
+    episodes_to_keep: list[tuple[int, int]],
+    fps: float,
+) -> bool:
+    """Keep only specified episodes from a video file by copying the encoded bitstream.
+
+    `DatasetWriter` encodes one video per episode and `concatenate_video_files` joins them with
+    ffmpeg's concat demuxer in stream-copy mode, so every episode in a packed file starts on a
+    keyframe. Dropping episodes is then pure packet selection and the pixels never need decoding.
+
+    Alignment is verified rather than assumed: if any boundary falls inside a GOP, nothing is
+    written and the caller re-encodes instead.
+
+    Args:
+        input_path: Source video file path.
+        output_path: Destination video file path.
+        episodes_to_keep: Half-open (start_frame, end_frame) ranges to keep.
+        fps: Frame rate of the video.
+
+    Returns:
+        True if the output was written, False if the file is not GOP-aligned.
+    """
+    import av
+
+    with av.open(str(input_path)) as in_container:
+        if not in_container.streams.video:
+            return False
+
+        v_in = in_container.streams.video[0]
+        packets = [packet for packet in in_container.demux(v_in) if packet.size > 0]
+
+        # Demuxing yields packets in decode order. A closed GOP occupies the same contiguous span
+        # in decode and presentation order, so counting packets up to a keyframe gives that
+        # keyframe's presentation index even though B-frames reorder within the GOP.
+        gop_boundaries = {i for i, packet in enumerate(packets) if packet.is_keyframe}
+        gop_boundaries.add(len(packets))
+
+        if any(start not in gop_boundaries or end not in gop_boundaries for start, end in episodes_to_keep):
+            return False
+
+        if v_in.time_base is None:
+            return False
+        ticks_per_frame = round((1 / fps) / v_in.time_base)
+        if ticks_per_frame <= 0:
+            return False
+
+        with av.open(str(output_path), mode="w") as out_container:
+            v_out = out_container.add_stream_from_template(v_in)
+
+            out_start = 0
+            for start, end in episodes_to_keep:
+                segment = packets[start:end]
+                # Rebase onto the output timeline; dts is left for the muxer to derive so that
+                # B-frame reorder delay is handled per container rather than by hand.
+                pts_offset = out_start - min(packet.pts for packet in segment)
+                for packet in segment:
+                    packet.pts += pts_offset
+                    packet.dts = None
+                    packet.stream = v_out
+                    out_container.mux(packet)
+
+                out_start += (end - start) * ticks_per_frame
+
+    return True
+
+
 def _keep_episodes_from_video_with_av(
     input_path: Path,
     output_path: Path,
@@ -818,17 +886,20 @@ def _copy_and_reindex_videos(
                 )
                 dst_video_path.parent.mkdir(parents=True, exist_ok=True)
 
-                logging.info(
-                    f"Re-encoding {video_key} (chunk {src_chunk_idx}, file {src_file_idx}) "
-                    f"with {len(episodes_to_keep_ranges)} episodes"
-                )
-                _keep_episodes_from_video_with_av(
-                    src_video_path,
-                    dst_video_path,
-                    episodes_to_keep_ranges,
-                    src_dataset.meta.fps,
-                    video_encoder,
-                )
+                if not _try_keep_episodes_from_video_by_stream_copy(
+                    src_video_path, dst_video_path, episodes_to_keep_ranges, src_dataset.meta.fps
+                ):
+                    logging.info(
+                        f"Re-encoding {video_key} (chunk {src_chunk_idx}, file {src_file_idx}) "
+                        f"with {len(episodes_to_keep_ranges)} episodes"
+                    )
+                    _keep_episodes_from_video_with_av(
+                        src_video_path,
+                        dst_video_path,
+                        episodes_to_keep_ranges,
+                        src_dataset.meta.fps,
+                        video_encoder,
+                    )
 
                 cumulative_ts = 0.0
                 for old_idx in sorted_keep_episodes:

--- a/tests/datasets/test_dataset_tools.py
+++ b/tests/datasets/test_dataset_tools.py
@@ -26,6 +26,7 @@ pytest.importorskip("datasets", reason="datasets is required (install lerobot[da
 
 from lerobot.configs import DepthEncoderConfig, RGBEncoderConfig
 from lerobot.datasets.dataset_tools import (
+    _try_keep_episodes_from_video_by_stream_copy,
     add_features,
     convert_image_to_video_dataset,
     delete_episodes,
@@ -36,7 +37,7 @@ from lerobot.datasets.dataset_tools import (
     remove_feature,
     split_dataset,
 )
-from lerobot.datasets.io_utils import load_info
+from lerobot.datasets.io_utils import load_episodes, load_info
 from tests.datasets.test_video_encoding import require_h264, require_hevc, require_libsvtav1
 from tests.fixtures.constants import DUMMY_DEPTH_FEATURES, DUMMY_DEPTH_KEY
 from tests.fixtures.dataset_factories import add_frames
@@ -68,6 +69,32 @@ def sample_dataset(tmp_path, empty_lerobot_dataset_factory):
         dataset.save_episode()
 
     dataset.finalize()
+    return dataset
+
+
+@pytest.fixture
+def sample_video_dataset(tmp_path, empty_lerobot_dataset_factory):
+    """Create a sample video-backed dataset whose episodes share one video file."""
+    features = {
+        "action": {"dtype": "float32", "shape": (6,), "names": None},
+        "observation.images.top": {"dtype": "video", "shape": (64, 64, 3), "names": None},
+    }
+
+    dataset = empty_lerobot_dataset_factory(
+        root=tmp_path / "test_video_dataset",
+        features=features,
+        use_videos=True,
+        # A short GOP puts several keyframes inside each episode, so a mid-GOP boundary is
+        # reachable for the negative case.
+        rgb_encoder=RGBEncoderConfig(vcodec="h264", pix_fmt="yuv420p", g=6, crf=30),
+    )
+
+    for _ in range(5):
+        add_frames(dataset, 10)
+        dataset.save_episode()
+
+    dataset.finalize()
+    dataset.meta.episodes = load_episodes(dataset.meta.root)
     return dataset
 
 
@@ -974,6 +1001,57 @@ def test_delete_first_and_last_episodes(sample_dataset, tmp_path):
 
     episode_indices = sorted({int(idx.item()) for idx in new_dataset.hf_dataset["episode_index"]})
     assert episode_indices == [0, 1, 2]
+
+
+@require_h264
+def test_delete_episodes_stream_copies_packed_videos(sample_video_dataset, tmp_path):
+    """Episodes packed into one video file are dropped without re-encoding.
+
+    Patching the re-encode path to raise asserts it is never reached, and copied frames must
+    decode identically to the source.
+    """
+    output_dir = tmp_path / "filtered"
+    video_key = sample_video_dataset.meta.video_keys[0]
+
+    def _fail_reencode(*args, **kwargs):
+        raise AssertionError("stream copy should have handled this GOP-aligned file")
+
+    with (
+        patch("lerobot.datasets.dataset_metadata.get_safe_version") as mock_get_safe_version,
+        patch("lerobot.datasets.dataset_metadata.snapshot_download") as mock_snapshot_download,
+        patch("lerobot.datasets.dataset_tools._keep_episodes_from_video_with_av", _fail_reencode),
+    ):
+        mock_get_safe_version.return_value = "v3.0"
+        mock_snapshot_download.return_value = str(output_dir)
+
+        new_dataset = delete_episodes(sample_video_dataset, [1, 3], output_dir=output_dir)
+
+    assert new_dataset.meta.total_episodes == 3
+    assert new_dataset.meta.total_frames == 30
+
+    for new_ep, old_ep in enumerate([0, 2, 4]):
+        for offset in range(10):
+            expected = sample_video_dataset[old_ep * 10 + offset][video_key]
+            assert torch.equal(new_dataset[new_ep * 10 + offset][video_key], expected)
+
+
+@require_h264
+def test_stream_copy_declines_when_boundaries_are_not_gop_aligned(sample_video_dataset, tmp_path):
+    """A range starting mid-GOP is refused so the caller can re-encode instead."""
+    video_key = sample_video_dataset.meta.video_keys[0]
+    episode = sample_video_dataset.meta.episodes[0]
+    src_video_path = sample_video_dataset.root / sample_video_dataset.meta.video_path.format(
+        video_key=video_key,
+        chunk_index=episode[f"videos/{video_key}/chunk_index"],
+        file_index=episode[f"videos/{video_key}/file_index"],
+    )
+    output_path = tmp_path / "declined.mp4"
+
+    # Frame 3 sits inside the first episode's GOP rather than on its boundary.
+    assert not _try_keep_episodes_from_video_by_stream_copy(
+        src_video_path, output_path, [(3, 10)], sample_video_dataset.meta.fps
+    )
+    assert not output_path.exists(), "declining must not leave a partial file behind"
 
 
 def test_split_all_episodes_assigned(sample_dataset, tmp_path):


### PR DESCRIPTION
## Summary / Motivation

When recording a dataset DatasetWriter` encodes one video per episode, after which `concatenate_video_files` joins them through ffmpeg's concat demuxer in stream-copy mode.  This means that re-encoding the entire dataset after deleting an episode is redundant, just take advantage of the fact that every episode already starts with a full standalone frame and remove the packets inbetween those.
Beyond being much faster, this removes a second lossy re-encoding: kept frames come back bit-identical to the source.

## Benchmarks

Dropping 32 of 79 episodes from a `unitree_g1` dataset (640x480 h264 @ 50 fps, 3 cameras):

| video file | kept eps | re-encode | stream copy | speedup | re-encode size | copy size |
| --- | --- | --- | --- | --- | --- | --- |
| ego_view/file-0 | 24 | 114.8 s | 0.38 s | 301x | 185.0 MB | 144.5 MB |
| ego_view/file-1 | 14 | 67.3 s | 0.38 s | 175x | 116.4 MB | 105.7 MB |
| ego_view/file-2 | 9 | 38.5 s | 0.14 s | 270x | 62.3 MB | 56.1 MB |
| **total** | | **220.6 s** | **0.90 s** | **245x** | **363.7 MB** | **306.3 MB** |

The re-encode also *raised* the bitrate from 1053 kbps to 1389 kbps while discarding quality; the stream copy preserves the source bitstream exactly.

To check the keyframe-alignment assumption isn't specific to one recorder, I tested every v3.0 dataset in my local cache — 11 datasets from several different producers, including `BitRobot/HIW-500-LeRobot` (23.7k episodes) and `unitreerobotics/G1_Dex3_ToastedBread_Dataset`. **809 of 809 episode starts landed on a keyframe**, with no exceptions.

## How was this tested (or how to run locally)

```bash
pytest -q tests/datasets/test_dataset_tools.py
```