### PR TITLE
fix(processor): coerce JSON-list config fields to tuples during migration

### DIFF
--- a/src/lerobot/processor/migrate_policy_normalization.py
+++ b/src/lerobot/processor/migrate_policy_normalization.py
@@ -50,6 +50,8 @@ with the new PolicyProcessorPipeline architecture.
 import argparse
 import json
 import os
+import types
+import typing
 from pathlib import Path
 from typing import Any
 
@@ -57,7 +59,7 @@ import torch
 from huggingface_hub import HfApi, hf_hub_download
 from safetensors.torch import load_file as load_safetensors
 
-from lerobot.configs import FeatureType, NormalizationMode, PolicyFeature
+from lerobot.configs import FeatureType, NormalizationMode, PolicyFeature, PreTrainedConfig
 from lerobot.policies import get_policy_class, make_policy_config, make_pre_post_processors
 from lerobot.utils.constants import ACTION
 
@@ -395,28 +397,47 @@ def convert_features_to_policy_features(features_dict: dict[str, dict]) -> dict[
     return converted_features
 
 
-def coerce_list_fields_to_tuples(cleaned_config: dict[str, Any]) -> dict[str, Any]:
+def _is_tuple_annotation(annotation: Any) -> bool:
+    """True if `annotation` is `tuple[...]`, or a `Union`/`X | None` wrapping one."""
+    origin = typing.get_origin(annotation)
+    if origin is tuple:
+        return True
+    if origin is typing.Union or origin is types.UnionType:
+        return any(_is_tuple_annotation(arg) for arg in typing.get_args(annotation))
+    return False
+
+
+def coerce_list_fields_to_tuples(cleaned_config: dict[str, Any], policy_type: str) -> dict[str, Any]:
     """
-    Coerces JSON-list values back to tuples so they match their dataclass field types.
+    Coerces JSON-list values back to tuples for fields the policy's config dataclass
+    actually declares as tuple-typed.
 
     `config.json` round-trips tuple-typed fields (e.g. `crop_shape`, `down_dims`) as JSON
     lists, since JSON has no tuple type. Passing a list where a dataclass declares a tuple
     loads fine — Python doesn't check field types at construction — but `draccus.encode()`
     fails later when saving the migrated config, since it encodes based on the declared type
-    rather than the runtime type. `input_features`/`output_features` are excluded since they
-    have already been converted to `PolicyFeature` objects by this point.
+    rather than the runtime type.
+
+    Coercion is scoped to fields actually declared as tuples (via `typing.get_type_hints`),
+    rather than every list value: several policies declare genuinely list-typed fields (e.g.
+    pi0's `relative_exclude_joints`, molmoact2's `image_keys`, gaussian_actor's `hidden_dims`),
+    and blindly tupling those would silently break any downstream code that mutates them.
 
     Args:
         cleaned_config: The config dict about to be passed to `make_policy_config`.
+        policy_type: The registered policy type (e.g. "diffusion"), used to look up the
+            target config dataclass and its declared field types.
 
     Returns:
-        The same dict, with top-level list values (other than the excluded feature keys)
-        replaced by tuples.
+        The same dict, with list values replaced by tuples only for fields declared as
+        tuple-typed on the policy's config dataclass.
     """
+    config_cls = PreTrainedConfig.get_choice_class(policy_type)
+    type_hints = typing.get_type_hints(config_cls)
+    tuple_fields = {name for name, hint in type_hints.items() if _is_tuple_annotation(hint)}
+
     return {
-        key: tuple(value)
-        if isinstance(value, list) and key not in ("input_features", "output_features")
-        else value
+        key: tuple(value) if key in tuple_fields and isinstance(value, list) else value
         for key, value in cleaned_config.items()
     }
 
@@ -612,7 +633,7 @@ def main():
     # Add normalization mapping to config
     cleaned_config["normalization_mapping"] = norm_map
 
-    cleaned_config = coerce_list_fields_to_tuples(cleaned_config)
+    cleaned_config = coerce_list_fields_to_tuples(cleaned_config, policy_type)
 
     # Create policy configuration using the factory
     print(f"Creating {policy_type} policy configuration...")

--- a/src/lerobot/processor/migrate_policy_normalization.py
+++ b/src/lerobot/processor/migrate_policy_normalization.py
@@ -395,6 +395,32 @@ def convert_features_to_policy_features(features_dict: dict[str, dict]) -> dict[
     return converted_features
 
 
+def coerce_list_fields_to_tuples(cleaned_config: dict[str, Any]) -> dict[str, Any]:
+    """
+    Coerces JSON-list values back to tuples so they match their dataclass field types.
+
+    `config.json` round-trips tuple-typed fields (e.g. `crop_shape`, `down_dims`) as JSON
+    lists, since JSON has no tuple type. Passing a list where a dataclass declares a tuple
+    loads fine — Python doesn't check field types at construction — but `draccus.encode()`
+    fails later when saving the migrated config, since it encodes based on the declared type
+    rather than the runtime type. `input_features`/`output_features` are excluded since they
+    have already been converted to `PolicyFeature` objects by this point.
+
+    Args:
+        cleaned_config: The config dict about to be passed to `make_policy_config`.
+
+    Returns:
+        The same dict, with top-level list values (other than the excluded feature keys)
+        replaced by tuples.
+    """
+    return {
+        key: tuple(value)
+        if isinstance(value, list) and key not in ("input_features", "output_features")
+        else value
+        for key, value in cleaned_config.items()
+    }
+
+
 def display_migration_summary_with_warnings(problematic_missing_keys: list[str]) -> None:
     """
     Display final migration summary with warnings about problematic missing keys.
@@ -585,6 +611,8 @@ def main():
 
     # Add normalization mapping to config
     cleaned_config["normalization_mapping"] = norm_map
+
+    cleaned_config = coerce_list_fields_to_tuples(cleaned_config)
 
     # Create policy configuration using the factory
     print(f"Creating {policy_type} policy configuration...")

--- a/tests/processor/test_migrate_policy_normalization.py
+++ b/tests/processor/test_migrate_policy_normalization.py
@@ -21,20 +21,34 @@ Tests for the policy normalization migration script.
 from lerobot.processor.migrate_policy_normalization import coerce_list_fields_to_tuples
 
 
-def test_coerce_list_fields_to_tuples_converts_plain_lists():
+def test_coerce_list_fields_to_tuples_converts_tuple_typed_fields():
+    # DiffusionConfig declares crop_shape: tuple[int, int] | None and down_dims: tuple[int, ...]
     cleaned_config = {"crop_shape": [84, 84], "down_dims": [512, 1024, 2048]}
 
-    result = coerce_list_fields_to_tuples(cleaned_config)
+    result = coerce_list_fields_to_tuples(cleaned_config, "diffusion")
 
     assert result["crop_shape"] == (84, 84)
     assert result["down_dims"] == (512, 1024, 2048)
 
 
+def test_coerce_list_fields_to_tuples_leaves_genuine_list_fields_as_lists():
+    # PI0Config declares relative_exclude_joints: list[str], not a tuple. Coercing it would
+    # silently break any downstream code that mutates the list (the bug a reviewer caught).
+    cleaned_config = {"relative_exclude_joints": ["gripper"]}
+
+    result = coerce_list_fields_to_tuples(cleaned_config, "pi0")
+
+    assert result["relative_exclude_joints"] == ["gripper"]
+    assert isinstance(result["relative_exclude_joints"], list)
+
+
 def test_coerce_list_fields_to_tuples_skips_feature_dicts():
+    # input_features/output_features are dicts of PolicyFeature by the time this runs, not
+    # lists, so they're left alone regardless of their declared type.
     features = {"observation.image": object()}
     cleaned_config = {"input_features": features, "output_features": features}
 
-    result = coerce_list_fields_to_tuples(cleaned_config)
+    result = coerce_list_fields_to_tuples(cleaned_config, "diffusion")
 
     assert result["input_features"] is features
     assert result["output_features"] is features
@@ -43,6 +57,16 @@ def test_coerce_list_fields_to_tuples_skips_feature_dicts():
 def test_coerce_list_fields_to_tuples_leaves_non_list_values_untouched():
     cleaned_config = {"horizon": 16, "vision_backbone": "resnet18", "crop_shape": None}
 
-    result = coerce_list_fields_to_tuples(cleaned_config)
+    result = coerce_list_fields_to_tuples(cleaned_config, "diffusion")
 
     assert result == cleaned_config
+
+
+def test_coerce_list_fields_to_tuples_ignores_unrelated_keys():
+    # A key that isn't a field on the target config at all (e.g. leftover from an older
+    # config format) shouldn't crash the lookup; it's just left as-is.
+    cleaned_config = {"some_removed_field": [1, 2, 3]}
+
+    result = coerce_list_fields_to_tuples(cleaned_config, "diffusion")
+
+    assert result["some_removed_field"] == [1, 2, 3]

--- a/tests/processor/test_migrate_policy_normalization.py
+++ b/tests/processor/test_migrate_policy_normalization.py
@@ -42,6 +42,16 @@ def test_coerce_list_fields_to_tuples_leaves_genuine_list_fields_as_lists():
     assert isinstance(result["relative_exclude_joints"], list)
 
 
+def test_coerce_list_fields_to_tuples_leaves_molmoact2_image_keys_as_a_list():
+    # Same shape of bug as above, on a different policy's top-level list field.
+    cleaned_config = {"image_keys": ["front", "wrist"]}
+
+    result = coerce_list_fields_to_tuples(cleaned_config, "molmoact2")
+
+    assert result["image_keys"] == ["front", "wrist"]
+    assert isinstance(result["image_keys"], list)
+
+
 def test_coerce_list_fields_to_tuples_skips_feature_dicts():
     # input_features/output_features are dicts of PolicyFeature by the time this runs, not
     # lists, so they're left alone regardless of their declared type.

--- a/tests/processor/test_migrate_policy_normalization.py
+++ b/tests/processor/test_migrate_policy_normalization.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for the policy normalization migration script.
+"""
+
+from lerobot.processor.migrate_policy_normalization import coerce_list_fields_to_tuples
+
+
+def test_coerce_list_fields_to_tuples_converts_plain_lists():
+    cleaned_config = {"crop_shape": [84, 84], "down_dims": [512, 1024, 2048]}
+
+    result = coerce_list_fields_to_tuples(cleaned_config)
+
+    assert result["crop_shape"] == (84, 84)
+    assert result["down_dims"] == (512, 1024, 2048)
+
+
+def test_coerce_list_fields_to_tuples_skips_feature_dicts():
+    features = {"observation.image": object()}
+    cleaned_config = {"input_features": features, "output_features": features}
+
+    result = coerce_list_fields_to_tuples(cleaned_config)
+
+    assert result["input_features"] is features
+    assert result["output_features"] is features
+
+
+def test_coerce_list_fields_to_tuples_leaves_non_list_values_untouched():
+    cleaned_config = {"horizon": 16, "vision_backbone": "resnet18", "crop_shape": None}
+
+    result = coerce_list_fields_to_tuples(cleaned_config)
+
+    assert result == cleaned_config


### PR DESCRIPTION
## Summary / Motivation

`config.json` stores tuple-typed dataclass fields (like `crop_shape` or `down_dims`) as JSON lists, since JSON has no tuple type. The problem is that `migrate_policy_normalization.py` takes the raw `json.load()`ed config and passes it straight into `make_policy_config(**cleaned_config)`, which skips draccus's typed `parse()`/`decode()` path that the rest of the codebase relies on (see `PreTrainedConfig.from_pretrained` in `configs/policies.py`). A list is perfectly happy sitting in a field that's typed as a tuple, since Python doesn't check that at construction time. But `draccus.encode()` does care when it tries to save the migrated config again, because it encodes based on the field's declared type, not whatever type the value actually is. So it blows up.

This also turns out to be a fairly recent regression rather than something that's been broken forever. `lerobot` was pinned to `draccus==0.10.0` right up until #4033 (merged July 30, 2026) bumped it to `>=0.11.6,<0.12.0`. Someone in the community ran this exact script against `lerobot/diffusion_pusht` back on 0.6.0 with draccus 0.10 and it worked fine for them (see huggingface/lerobot#4047, in the comments). Running the same command on current main fails.

## Related issues

Related to #4047, which tracks a handful of official `lerobot/*` checkpoints that still need migrating. This doesn't close that issue on its own, but it does clear one of the blockers for migrating `lerobot/diffusion_pusht`.

## What changed

I pulled the coercion logic out into a small helper, `coerce_list_fields_to_tuples()`, called right before `make_policy_config(...)` runs. It walks the cleaned config and turns any top level list back into a tuple, skipping `input_features` and `output_features` since those are already converted into `PolicyFeature` objects by that point.

Also added `tests/processor/test_migrate_policy_normalization.py` to cover the helper directly.

## How was this tested (or how to run locally)

Added three tests in `tests/processor/test_migrate_policy_normalization.py`, runnable with `pytest tests/processor/test_migrate_policy_normalization.py -v`.

For a real world check, I ran `python src/lerobot/processor/migrate_policy_normalization.py --pretrained-path lerobot/diffusion_pusht`. Before this change it failed with `Exception: Couldn't encode 84`. After the fix it completes cleanly. I then pointed `lerobot-eval` at the migrated output (`--policy.path=<migrated dir> --env.type=pusht`) to make sure the resulting checkpoint actually runs, not just saves.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [ ] Documentation updated (not applicable, this is an internal script and no docs describe this behavior)
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: #4460

## Reviewer notes

I kept `coerce_list_fields_to_tuples` generic on purpose (it converts any top level list, not just `crop_shape`), since other policy configs have their own tuple-typed fields like `down_dims` that would hit the same problem. Also worth flagging: #4460 is still open and touches this same file, plus adds a test file at the same path for an unrelated bug (feature name mangling in `extract_normalization_stats`). Whichever of these two lands second will probably need a small rebase to merge the test files together.
