### PR TITLE
fix(datasets): keep requested version when the Hub cannot answer

### DIFF
--- a/src/lerobot/datasets/utils.py
+++ b/src/lerobot/datasets/utils.py
@@ -23,10 +23,12 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 import datasets
+import httpx
 import numpy as np
 import packaging.version
 import torch
 from huggingface_hub import DatasetCard, DatasetCardData, HfApi
+from huggingface_hub.errors import HfHubHTTPError, OfflineModeIsEnabled
 
 from lerobot.utils.utils import flatten_dict, unflatten_dict
 
@@ -400,6 +402,23 @@ def get_repo_versions(repo_id: str, *, token: str | bool | None = None) -> list[
     return repo_versions
 
 
+def _warn_and_keep_requested_version(
+    repo_id: str, target_version: packaging.version.Version, error: Exception
+) -> str:
+    """Return the requested version as ``v{version}``, for a Hub that cannot answer.
+
+    `snapshot_download` resolves it against the local cache and raises `LocalEntryNotFoundError`
+    if it is not there. No older compatible tag is chosen here: the cached refs are on disk, but
+    reading them is left to `snapshot_download`, so a cache holding only v3.0 fails a v3.1 request
+    that a reachable Hub would have answered with v3.0.
+    """
+    logger.warning(
+        f"Could not get the available versions of {repo_id} from the Hub "
+        f"({type(error).__name__}: {error}). Using revision v{target_version}."
+    )
+    return f"v{target_version}"
+
+
 def get_safe_version(
     repo_id: str,
     version: str | packaging.version.Version,
@@ -410,6 +429,12 @@ def get_safe_version(
 
     If the exact version is not found, it looks for the latest version with the
     same major version number that is less than or equal to the target minor version.
+
+    When the available versions cannot be got from the Hub, the requested version is returned
+    normalized as ``v{version}`` for the caller's `snapshot_download` to resolve against the local
+    cache, and the version selection below is skipped. Only the failures `snapshot_download`
+    itself absorbs to serve that cache are handled this way; anything it re-raises is re-raised
+    here too, where the cause is still named.
 
     Args:
         repo_id (str): The repository ID on the Hugging Face Hub.
@@ -423,11 +448,22 @@ def get_safe_version(
         RuntimeError: If the repo has no version tags.
         BackwardCompatibilityError: If only older major versions are available.
         ForwardCompatibilityError: If only newer major versions are available.
+        httpx.TransportError: For a transport failure `snapshot_download` would re-raise anyway
+            (proxy error, protocol error, unsupported scheme, ...).
     """
     target_version = (
         packaging.version.parse(version) if not isinstance(version, packaging.version.Version) else version
     )
-    hub_versions = get_repo_versions(repo_id) if token is None else get_repo_versions(repo_id, token=token)
+    try:
+        hub_versions = (
+            get_repo_versions(repo_id) if token is None else get_repo_versions(repo_id, token=token)
+        )
+    # Measured against a warm cache: these are the failures `snapshot_download` itself absorbs to
+    # serve a revision from that cache, and it absorbs `HfHubHTTPError` at every status. Anything
+    # wider it re-raises, so swallowing it here would only move the failure one frame further from
+    # its cause.
+    except (httpx.ConnectError, httpx.TimeoutException, OfflineModeIsEnabled, HfHubHTTPError) as e:
+        return _warn_and_keep_requested_version(repo_id, target_version, e)
 
     if not hub_versions:
         raise RuntimeError(MISSING_VERSION_TAG_MESSAGE.format(repo_id=repo_id))

--- a/tests/datasets/test_dataset_utils.py
+++ b/tests/datasets/test_dataset_utils.py
@@ -23,8 +23,14 @@ from packaging.version import Version
 
 pytest.importorskip("datasets", reason="datasets is required (install lerobot[dataset])")
 
+import httpx
 from datasets import Dataset  # noqa: E402
 from huggingface_hub import DatasetCard
+from huggingface_hub.errors import (
+    HfHubHTTPError,
+    OfflineModeIsEnabled,
+    RepositoryNotFoundError,
+)
 
 import lerobot.datasets.utils as dataset_utils
 from lerobot.datasets.io_utils import hf_transform_to_torch
@@ -216,3 +222,81 @@ def test_get_safe_version_error_reports_repo_id(monkeypatch):
         get_safe_version(repo_id, "v3.0")
 
     assert repo_id in str(exc_info.value)
+
+
+def _hub_http_error(status: int, reason: str) -> HfHubHTTPError:
+    request = httpx.Request("GET", "https://huggingface.co")
+    return HfHubHTTPError(f"{status} Error: {reason}", response=httpx.Response(status, request=request))
+
+
+# Factories, not instances: a raised exception keeps its ``__traceback__``, so sharing one
+# across parametrized runs would accumulate state between tests.
+HUB_UNUSABLE_ERRORS = {
+    "offline": lambda: OfflineModeIsEnabled(
+        "Cannot reach https://huggingface.co/api/datasets/private/repo/refs: offline mode is enabled."
+    ),
+    "connect": lambda: httpx.ConnectError("[Errno 61] Connection refused"),
+    "timeout": lambda: httpx.ReadTimeout("timed out"),
+    "hub-5xx": lambda: _hub_http_error(500, "Internal Server Error"),
+    "hub-rate-limited": lambda: _hub_http_error(429, "Too Many Requests"),
+    "repo-not-found": lambda: RepositoryNotFoundError(
+        "404 Client Error. Repository Not Found",
+        response=httpx.Response(404, request=httpx.Request("GET", "https://huggingface.co")),
+    ),
+}
+
+
+@pytest.mark.parametrize("make_error", HUB_UNUSABLE_ERRORS.values(), ids=HUB_UNUSABLE_ERRORS)
+def test_get_safe_version_keeps_requested_version_when_hub_unusable(monkeypatch, make_error):
+    """The Hub cannot say which versions exist, so the requested one is passed through.
+
+    Measured against a warm cache: these are exactly the failures `snapshot_download` absorbs to
+    resolve the revision from `refs/` instead. Aborting here would fail a load the cache serves.
+    """
+    api = Mock()
+    api.list_repo_refs.side_effect = make_error()
+    monkeypatch.setattr(dataset_utils, "HfApi", Mock(return_value=api))
+
+    # Deliberately not CODEBASE_VERSION: what comes back must be what was asked for, not the
+    # version lerobot happens to default to. With "v3.0" the two are indistinguishable today.
+    assert get_safe_version("private/repo", "v2.1") == "v2.1"
+    api.list_repo_refs.assert_called_once_with("private/repo", repo_type="dataset")
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        httpx.ProxyError("failed to connect to proxy"),
+        httpx.RemoteProtocolError("server disconnected without sending a response"),
+        httpx.UnsupportedProtocol("Request URL is missing an 'http://' protocol."),
+    ],
+    ids=["proxy-error", "mid-stream-drop", "no-scheme-endpoint"],
+)
+def test_get_safe_version_propagates_errors_that_are_not_a_hub_being_unusable(monkeypatch, error):
+    """Transport failures that `snapshot_download` re-raises too, measured against a warm cache.
+
+    Swallowing them here would not save the load: the very next call fails the same way, one frame
+    further from its cause. All three are `httpx.TransportError` subclasses outside the caught
+    tuple, which is why that tuple names `ConnectError` and `TimeoutException` rather than their
+    shared base.
+    """
+    api = Mock()
+    api.list_repo_refs.side_effect = error
+    monkeypatch.setattr(dataset_utils, "HfApi", Mock(return_value=api))
+
+    with pytest.raises(type(error)):
+        get_safe_version("private/repo", "v2.1")
+
+
+@pytest.mark.parametrize("token", [None, "hf_test_token"])
+def test_get_safe_version_unusable_hub_does_not_raise_missing_version_tag(monkeypatch, token):
+    """A Hub that cannot answer must not be reported as "this dataset has no version tags".
+
+    Checked on both token paths, since each takes a different `get_repo_versions` call.
+    """
+    get_versions = Mock(side_effect=OfflineModeIsEnabled("offline mode is enabled"))
+    monkeypatch.setattr(dataset_utils, "get_repo_versions", get_versions)
+
+    kwargs = {} if token is None else {"token": token}
+    assert get_safe_version("private/repo", Version("2.1"), **kwargs) == "v2.1"
+    get_versions.assert_called_once_with("private/repo", **kwargs)

--- a/tests/datasets/test_lerobot_dataset.py
+++ b/tests/datasets/test_lerobot_dataset.py
@@ -28,9 +28,12 @@ import torch
 
 pytest.importorskip("datasets", reason="datasets is required (install lerobot[dataset])")
 
+from huggingface_hub.errors import OfflineModeIsEnabled
+
 import lerobot.datasets.dataset_metadata as dataset_metadata_module
 import lerobot.datasets.lerobot_dataset as lerobot_dataset_module
-from lerobot.datasets.dataset_metadata import LeRobotDatasetMetadata
+import lerobot.datasets.utils as dataset_utils
+from lerobot.datasets.dataset_metadata import CODEBASE_VERSION, LeRobotDatasetMetadata
 from lerobot.datasets.dataset_reader import DatasetReader
 from lerobot.datasets.dataset_writer import DatasetWriter
 from lerobot.datasets.lerobot_dataset import LeRobotDataset
@@ -726,3 +729,60 @@ def test_create_record_finalize_read_roundtrip(tmp_path):
         item = reopened[3 + i]
         assert torch.allclose(item["state"], ep1_states[i], atol=1e-5)
         assert item["episode_index"].item() == 1
+
+
+def test_metadata_revision_lookup_survives_unusable_hub(
+    tmp_path,
+    info_factory,
+    stats_factory,
+    tasks_factory,
+    episodes_factory,
+    hf_dataset_factory,
+    create_info,
+    create_stats,
+    create_tasks,
+    create_episodes,
+    create_hf_dataset,
+    monkeypatch,
+):
+    """A Hub that cannot answer no longer aborts the metadata load.
+
+    The metadata lookup under `$HF_LEROBOT_HOME/{repo_id}` misses for a Hub-fetched dataset, so
+    the download branch runs and resolves the revision through `get_safe_version`. Listing the
+    Hub refs fails there, and that must not abort a load the cache can serve.
+    """
+    repo_id = DUMMY_REPO_ID
+    cache_root = tmp_path / "lerobot_cache"
+    snapshot_root = cache_root / "hub" / "datasets--dummy--repo" / "snapshots" / "commit-codebase-version"
+    _write_dataset_tree(
+        snapshot_root,
+        motor_features=SNAPSHOT_MAIN_FEATURES,
+        info_factory=info_factory,
+        stats_factory=stats_factory,
+        tasks_factory=tasks_factory,
+        episodes_factory=episodes_factory,
+        hf_dataset_factory=hf_dataset_factory,
+        create_info=create_info,
+        create_stats=create_stats,
+        create_tasks=create_tasks,
+        create_episodes=create_episodes,
+        create_hf_dataset=create_hf_dataset,
+    )
+
+    _set_default_cache_root(monkeypatch, cache_root)
+    api = Mock()
+    api.list_repo_refs.side_effect = OfflineModeIsEnabled("offline mode is enabled")
+    monkeypatch.setattr(dataset_utils, "HfApi", Mock(return_value=api))
+    snapshot_download = Mock(return_value=str(snapshot_root))
+    monkeypatch.setattr(dataset_metadata_module, "snapshot_download", snapshot_download)
+
+    # No explicit revision: this is the path the failure actually travels, where `revision`
+    # falls back to CODEBASE_VERSION.
+    meta = LeRobotDatasetMetadata(repo_id=repo_id)
+
+    # The lookup was attempted, gave up, and the requested revision reached snapshot_download.
+    api.list_repo_refs.assert_called_once()
+    assert snapshot_download.call_args.kwargs["revision"] == CODEBASE_VERSION
+    assert meta.root == snapshot_root
+    assert meta.fps == DEFAULT_FPS
+    assert meta.total_episodes > 0


### PR DESCRIPTION
## Summary / Motivation

`get_safe_version()` calls `get_repo_versions()`, which calls `HfApi.list_repo_refs()`. On `main` nothing handles that request failing, so a load the cache can serve aborts:

```bash
HF_HUB_OFFLINE=1 python -c "from lerobot.datasets.lerobot_dataset import LeRobotDatasetMetadata as M; M('lerobot/libero')"
```

`main` ends in `OfflineModeIsEnabled`; this branch loads on a warm cache.

Blast radius, measured over 90 cells against a real warm cache with counters on `get_safe_version` and, independently, on `HfApi.list_repo_refs`, agreeing in all 90: a complete home copy at `$HF_LEROBOT_HOME/{repo_id}`, or a complete explicit `root=`, gives 0 calls with `force_cache_sync=False`, but with no home copy it fires whatever the snapshot cache holds. Hub downloads land in the snapshot cache under `$HF_LEROBOT_HOME/hub` and never in the home copy, so an offline user whose dataset came from the Hub reaches this path on every construction.

## Related issues

- Related: #4263 (merged, same function)

## What changed

- One `except` clause now names `httpx.ConnectError`, `httpx.TimeoutException`, `OfflineModeIsEnabled` and `HfHubHTTPError`: warn, then return the requested version normalised to `v{version}` for the caller's `snapshot_download` to resolve. Everything else propagates.
- Measured, not guessed. Each error was injected into `HfApi.repo_info` and `snapshot_download(..., revision="v3.0")` run against a warm cache: it serves from the cache for `OfflineModeIsEnabled`, `httpx.ConnectError`, `httpx.ReadTimeout`, and for `HfHubHTTPError` at 400, 401, 403, 404, 408, 429, 451, 500 and 503. It re-raises `httpx.RemoteProtocolError`, `httpx.UnsupportedProtocol` and `httpx.ProxyError`.
- Limitation, not a regression: choosing an older compatible tag needs the Hub's tag list. A cache holding only `refs/v3.0` answers a `v3.1` request with `v3.1`, then `LocalEntryNotFoundError`; with the Hub reachable it returns `v3.0` and loads. That load fails on `main` too.

## How was this tested (or how to run locally)

- 4 test functions, 12 collected cases, network-free. `pytest -q tests/datasets/test_dataset_utils.py tests/datasets/test_lerobot_dataset.py` → 65 passed. The same 12 against `main`'s `datasets/utils.py`: 9 failed, 3 passed, the 3 being `[proxy-error]`, `[mid-stream-drop]` and `[no-scheme-endpoint]`.
- End to end on a warm cache, `HF_HUB_OFFLINE=1 lerobot-train --dataset.repo_id=lerobot/libero --policy.type=act --policy.device=cpu --batch_size=1 --steps=1` exits 1 on `main` and 0 here: `dataset.num_episodes=1693`, `dataset.num_frames=273465`, checkpoint written.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run --files` on the changed files: 15 hooks pass, 6 skipped as not applicable, 0 fail)
- [x] Relevant tests pass locally (the two files above, 65 passed)
- [ ] Documentation updated
- [ ] CI is green
- [x] Community Review: https://github.com/huggingface/lerobot/pull/4455 (a comment left on 2026-08-20, not a formal review)

## Reviewer notes

- I have left a comment asking you to settle the design: two contracts, no grounds to choose between them, and a clause that has moved four times on review feedback.

Per `AI_POLICY.md`: I used Claude Code to run these measurements, check my claims, and draft this.
