### PR TITLE
fix(sarm): write annotations by episode index

### DIFF
--- a/src/lerobot/data_processing/sarm_annotations/subtask_annotation.py
+++ b/src/lerobot/data_processing/sarm_annotations/subtask_annotation.py
@@ -806,8 +806,18 @@ def save_annotations_to_dataset(
                 if col not in file_df.columns:
                     file_df[col] = None
             if ep_idx in annotations:
+                if "episode_index" not in file_df.columns:
+                    raise KeyError(f"Episode shard {path} is missing the episode_index column")
+
+                local_indices = file_df.index[file_df["episode_index"] == ep_idx].tolist()
+                if len(local_indices) != 1:
+                    raise ValueError(
+                        f"Expected exactly one row for episode {ep_idx} in {path}, found {len(local_indices)}"
+                    )
+                local_idx = local_indices[0]
+
                 for col in cols:
-                    file_df.at[ep_idx, col] = episodes_df.loc[ep_idx, col]
+                    file_df.at[local_idx, col] = episodes_df.loc[ep_idx, col]
                 if prefix == "sparse":  # Legacy columns
                     for i, legacy in enumerate(
                         [
@@ -818,7 +828,7 @@ def save_annotations_to_dataset(
                             "subtask_end_frames",
                         ]
                     ):
-                        file_df.at[ep_idx, legacy] = episodes_df.loc[ep_idx, cols[i]]
+                        file_df.at[local_idx, legacy] = episodes_df.loc[ep_idx, cols[i]]
             file_df.to_parquet(path, engine="pyarrow", compression="snappy")
 
 

--- a/tests/policies/test_sarm_subtask_annotations.py
+++ b/tests/policies/test_sarm_subtask_annotations.py
@@ -17,12 +17,15 @@
 import pytest
 
 pytest.importorskip("transformers")
+pytest.importorskip("datasets")
+pytest.importorskip("pyarrow")
 
 from lerobot.data_processing.sarm_annotations.subtask_annotation import (
     Subtask,
     SubtaskAnnotation,
     Timestamp,
     compute_temporal_proportions,
+    save_annotations_to_dataset,
 )
 
 
@@ -39,6 +42,33 @@ def make_annotation(subtasks: list[tuple[str, int, int]]) -> SubtaskAnnotation:
             for name, start, end in subtasks
         ]
     )
+
+
+def test_save_annotations_uses_local_row_for_sharded_episode_files(tmp_path):
+    import pandas as pd
+
+    episodes_dir = tmp_path / "meta" / "episodes" / "chunk-000"
+    episodes_dir.mkdir(parents=True)
+
+    for file_index, episode_indices in enumerate(([0, 1], [2, 3])):
+        pd.DataFrame(
+            {
+                "episode_index": episode_indices,
+                "meta/episodes/chunk_index": [0] * len(episode_indices),
+                "meta/episodes/file_index": [file_index] * len(episode_indices),
+            }
+        ).to_parquet(episodes_dir / f"file-{file_index:03d}.parquet")
+
+    annotations = {episode_index: make_annotation([("fold", 0, 1)]) for episode_index in range(4)}
+    save_annotations_to_dataset(tmp_path, annotations, fps=30)
+
+    for file_index, episode_indices in enumerate(([0, 1], [2, 3])):
+        saved = pd.read_parquet(episodes_dir / f"file-{file_index:03d}.parquet")
+        for episode_index in episode_indices:
+            row = saved.loc[saved["episode_index"] == episode_index].iloc[0]
+            assert row["sparse_subtask_names"] == ["fold"]
+            assert row["sparse_subtask_start_frames"] == [0]
+            assert row["sparse_subtask_end_frames"] == [30]
 
 
 class TestComputeTemporalProportions:


### PR DESCRIPTION
## Summary
- write annotation fields using the row matching episode_index within each parquet shard
- avoid treating the global episode index as a shard-local DataFrame index
- add a two-shard regression fixture covering episodes 0 through 3

## Testing
- ruff check
- ruff format --check
- Python syntax compilation
- focused sharded-episode regression harness