### PR TITLE
fix: give Ready() a deadline and let StreamParameters notice a dead peer

### DIFF
--- a/src/lerobot/rl/actor.py
+++ b/src/lerobot/rl/actor.py
@@ -114,6 +114,12 @@ from .gym_manipulator import (
 from .queue import get_last_item_from_queue
 from .train_rl import TrainRLServerPipelineConfig
 
+# Deadline (seconds) for the Ready() handshake in establish_learner_connection(). Without a
+# deadline, a learner whose gRPC thread pool is saturated (e.g. by a still-connected previous
+# actor) never answers Ready(), the call blocks forever, and the surrounding retry loop never
+# gets a chance to retry. This fits the loop's existing 2s-sleep / 30-attempt cadence.
+READY_RPC_TIMEOUT_S = 5.0
+
 # Main entry point
 
 
@@ -452,7 +458,7 @@ def establish_learner_connection(
         # Force a connection attempt and check state
         try:
             logging.info("[ACTOR] Send ready message to Learner")
-            if stub.Ready(services_pb2.Empty()) == services_pb2.Empty():
+            if stub.Ready(services_pb2.Empty(), timeout=READY_RPC_TIMEOUT_S) == services_pb2.Empty():
                 return True
         except grpc.RpcError as e:
             logging.error(f"[ACTOR] Waiting for Learner to be ready... {e}")

--- a/src/lerobot/rl/learner_service.py
+++ b/src/lerobot/rl/learner_service.py
@@ -74,7 +74,7 @@ class LearnerService(_ServicerBase):
 
         last_push_time = 0
 
-        while not self.shutdown_event.is_set():
+        while not self.shutdown_event.is_set() and context.is_active():
             time_since_last_push = time.time() - last_push_time
             if time_since_last_push < self.seconds_between_pushes:
                 self.shutdown_event.wait(self.seconds_between_pushes - time_since_last_push)

--- a/tests/rl/test_learner_service.py
+++ b/tests/rl/test_learner_service.py
@@ -372,3 +372,150 @@ def test_stream_parameters_waits_and_retries_on_empty_queue():
     close_learner_service_stub(channel, server)
 
     assert received_params == [b"param_after_wait", b"param_after_wait_2"]
+
+
+@skip_if_package_missing("grpcio", "grpc")
+@pytest.mark.timeout(25)  # force cross-platform watchdog
+def test_establish_learner_connection_retries_when_workers_saturated():
+    """A replacement actor must not hang forever at Ready() when the learner's gRPC
+    thread pool is fully occupied by one already-connected actor's long-lived RPCs
+    (StreamParameters, SendTransitions, SendInteractions) -- exactly MAX_WORKERS calls.
+
+    This reproduces #3979: without a deadline on stub.Ready(), establish_learner_connection's
+    retry loop never gets a chance to retry because the call never returns.
+    """
+    import contextlib
+    import threading
+    from concurrent import futures
+
+    import grpc
+
+    from lerobot.rl.actor import establish_learner_connection
+    from lerobot.rl.learner_service import MAX_WORKERS, LearnerService
+    from lerobot.transport import services_pb2, services_pb2_grpc
+
+    shutdown_event = Event()
+    parameters_queue = Queue()
+    transitions_queue = Queue()
+    interactions_queue = Queue()
+
+    servicer = LearnerService(
+        shutdown_event=shutdown_event,
+        parameters_queue=parameters_queue,
+        seconds_between_pushes=1,
+        transition_queue=transitions_queue,
+        interaction_message_queue=interactions_queue,
+    )
+
+    # Mirror production exactly: learner.py builds the server's executor with MAX_WORKERS
+    # threads and nothing more -- there is no headroom above one actor's RPC count.
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=MAX_WORKERS))
+    services_pb2_grpc.add_LearnerServiceServicer_to_server(servicer, server)
+    port = server.add_insecure_port("[::]:0")
+    server.start()
+
+    channel = grpc.insecure_channel(f"localhost:{port}")
+    stub = services_pb2_grpc.LearnerServiceStub(channel)
+
+    # Occupy all MAX_WORKERS=3 worker threads with the same three long-lived RPCs one real
+    # actor opens. None of them ever finishes on its own -- exactly like a lingering/half-open
+    # connection from a previous actor.
+    stream_call = stub.StreamParameters(services_pb2.Empty())
+
+    def _drain_stream():
+        try:
+            for _ in stream_call:
+                pass
+        except grpc.RpcError:
+            pass
+
+    threading.Thread(target=_drain_stream, daemon=True).start()
+
+    release_gate = threading.Event()  # never set during the saturated phase
+
+    def _blocking_client_iterator():
+        release_gate.wait()
+        return
+        yield  # pragma: no cover - unreachable; keeps this a generator
+
+    def _call_and_ignore_cancellation(stub_method):
+        # Expected once the channel is closed during test cleanup.
+        with contextlib.suppress(grpc.RpcError):
+            stub_method(_blocking_client_iterator())
+
+    threading.Thread(target=_call_and_ignore_cancellation, args=(stub.SendTransitions,), daemon=True).start()
+    threading.Thread(target=_call_and_ignore_cancellation, args=(stub.SendInteractions,), daemon=True).start()
+
+    # Give the three RPCs a moment to actually reach the server and occupy their workers.
+    time.sleep(0.5)
+
+    # A raw Ready() call with an explicit deadline must fail fast with DEADLINE_EXCEEDED
+    # instead of hanging -- proves the pool is genuinely starved, not just slow.
+    with pytest.raises(grpc.RpcError) as exc_info:
+        stub.Ready(services_pb2.Empty(), timeout=2)
+    assert exc_info.value.code() == grpc.StatusCode.DEADLINE_EXCEEDED
+
+    # The actual regression: establish_learner_connection's retry loop must return in
+    # bounded time instead of hanging forever on the first Ready() call.
+    start = time.time()
+    connected = establish_learner_connection(stub, Event(), attempts=2)
+    elapsed = time.time() - start
+
+    release_gate.set()
+    shutdown_event.set()
+    channel.close()
+    server.stop(None)
+
+    assert connected is False
+    # 2 attempts * (READY_RPC_TIMEOUT_S deadline + 2s retry sleep) plus slack.
+    assert elapsed < 20
+
+
+@skip_if_package_missing("grpcio", "grpc")
+@pytest.mark.timeout(5)  # force cross-platform watchdog
+def test_stream_parameters_stops_when_context_goes_inactive():
+    """StreamParameters must release its worker when the peer disconnects, even if the
+    parameters queue never gets new data and shutdown_event is never set. Before the fix,
+    the loop only checked shutdown_event, so a dead/half-open peer held the worker forever.
+    """
+    from lerobot.rl.learner_service import LearnerService
+    from lerobot.transport import services_pb2
+
+    class _FakeContext:
+        """Stand-in for grpc.ServicerContext exposing only is_active(), controlled by the test."""
+
+        def __init__(self):
+            self._active = True
+
+        def is_active(self):
+            return self._active
+
+        def disconnect(self):
+            self._active = False
+
+    shutdown_event = Event()
+    parameters_queue = Queue()
+    transitions_queue = Queue()
+    interactions_queue = Queue()
+
+    servicer = LearnerService(
+        shutdown_event=shutdown_event,
+        parameters_queue=parameters_queue,
+        seconds_between_pushes=0.05,
+        transition_queue=transitions_queue,
+        interaction_message_queue=interactions_queue,
+        queue_get_timeout=0.01,
+    )
+
+    context = _FakeContext()
+    stream = servicer.StreamParameters(services_pb2.Empty(), context)
+
+    # Simulate the client disconnecting / cancelling before any parameters were ever pushed.
+    context.disconnect()
+
+    # Without checking context.is_active(), the generator loops forever on the empty queue
+    # (shutdown_event is never set); with the fix it must stop as soon as it notices.
+    with pytest.raises(StopIteration):
+        next(stream)
+
+    shutdown_event.set()  # cleanup safety net in case the generator is still alive

--- a/tests/rl/test_learner_service.py
+++ b/tests/rl/test_learner_service.py
@@ -390,6 +390,7 @@ def test_establish_learner_connection_retries_when_workers_saturated():
 
     import grpc
 
+    pytest.importorskip("datasets", reason="datasets is required (install lerobot[dataset])")
     from lerobot.rl.actor import establish_learner_connection
     from lerobot.rl.learner_service import MAX_WORKERS, LearnerService
     from lerobot.transport import services_pb2, services_pb2_grpc


### PR DESCRIPTION
## Summary / Motivation

A replacement HIL-SERL actor can hang forever at `Ready()` with no error at all. Three things line up:

1. `establish_learner_connection()` in `actor.py` calls `stub.Ready(services_pb2.Empty())` with no deadline. The retry loop around it (30 attempts, `except grpc.RpcError`, 2s sleep) can only retry if the call returns. If the learner cannot answer, it never does.
2. `learner_service.py` sets `MAX_WORKERS = 3`, which is exactly how many long-lived RPCs one connected actor holds open: `StreamParameters`, `SendTransitions`, `SendInteractions`. There is no headroom. Any further unary call, including `Ready()`, queues in the executor behind those three.
3. The `StreamParameters` loop only checks `self.shutdown_event.is_set()`. It never checks `context.is_active()`. A kill -9 sends a TCP RST and grpc cancels the handler, so that case recovers. A lingering process, a network partition, or a crashed actor host does not tear down the TCP connection, so gRPC notices nothing and `StreamParameters` keeps its worker slot and keeps pushing to a stream nobody reads.

One actor connection that is not cleanly torn down occupies all 3 workers permanently. Every actor that starts after that hangs silently at "Send ready message to Learner". The only recovery today is restarting the learner and losing its state.

`MAX_WORKERS` is left alone on purpose. Raising it would hide the starvation without fixing the two actual defects (no deadline, no liveness check) and would widen the diff. Happy to discuss headroom separately on top of this.

## Related issues

- Fixes #3979

## What changed

- `actor.py`: new module constant `READY_RPC_TIMEOUT_S = 5.0`, passed as `timeout=` to `stub.Ready()`. A stuck learner now raises `DEADLINE_EXCEEDED`, which the existing `except grpc.RpcError` already handles, so the retry loop can retry.
- `learner_service.py`: the `StreamParameters` while-loop condition is now `not self.shutdown_event.is_set() and context.is_active()`. When the peer connection is detected as inactive, the loop exits and the worker is released. `SendTransitions` and `SendInteractions` do not need this; they already terminate on their own because they consume `request_iterator` directly.
- Nothing else touched.

```python
# actor.py, establish_learner_connection() -- before
if stub.Ready(services_pb2.Empty()) == services_pb2.Empty():
    return True

# after
if stub.Ready(services_pb2.Empty(), timeout=READY_RPC_TIMEOUT_S) == services_pb2.Empty():
    return True
```

```python
# learner_service.py, StreamParameters -- before
while not self.shutdown_event.is_set():

# after
while not self.shutdown_event.is_set() and context.is_active():
```

## How was this tested (or how to run locally)

Two tests added to the existing `tests/rl/test_learner_service.py`, following its conventions (`@skip_if_package_missing("grpcio", "grpc")`, `@pytest.mark.timeout(N)`, imports inside the test function). Run with `python -m pytest tests/rl/test_learner_service.py -v`.

- `test_establish_learner_connection_retries_when_workers_saturated`: spins up a real `LearnerService` behind a `grpc.server` whose executor is sized to `MAX_WORKERS` (imported from `learner_service.py`, not hardcoded), then occupies all three workers with real long-lived RPCs (one `StreamParameters` stream plus two client-streaming calls fed by generators that block forever). Asserts a raw `stub.Ready(..., timeout=2)` raises `DEADLINE_EXCEEDED`, then calls the real `establish_learner_connection()` and asserts it returns `False` within a bounded time instead of hanging. The test calls `pytest.importorskip("datasets", reason="datasets is required (install lerobot[dataset])")` before importing `lerobot.rl.actor`, so it skips instead of erroring when the `dataset` extra is missing, matching `test_actor.py` and `test_actor_learner.py`.
- `test_stream_parameters_stops_when_context_goes_inactive`: calls `LearnerService.StreamParameters` directly with a minimal fake context exposing only `is_active()`, flips it to inactive before the queue gets any data, and asserts the generator raises `StopIteration` promptly instead of looping forever.

Each test fails without its fix. I reverted each source change one at a time and reran:

- With the `actor.py` deadline reverted, `test_establish_learner_connection_retries_when_workers_saturated` hangs inside `stub.Ready()` and is killed by pytest-timeout at the reverted line.
- With the `context.is_active()` check reverted, `test_stream_parameters_stops_when_context_goes_inactive` blocks in the empty-queue wait and fails via pytest-timeout.
- With both fixes restored, all 9 tests in the file pass, no warnings.

Run in a fresh venv (`grpcio`, `protobuf`, `pytest`, `pytest-timeout`, plus `lerobot[test,dataset]` for the import chain) on macOS/arm64, Python 3.14. I did not run the live HIL-SERL actor/learner processes with gym-hil or a real robot/sim; the live repro with two real actors against a real learner is described in #3979. `ruff check` and `ruff format --check` pass on the three changed files.

## Checklist (required before merge)

- [x] Linting/formatting run (`ruff check` and `ruff format --check` on the changed files)
- [ ] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: #

## Reviewer notes

- The two source changes are small and independent; the tests account for most of the diff.
