### PR TITLE
docs: correct calibration guide grammar

### DIFF
--- a/docs/source/integrate_hardware.mdx
+++ b/docs/source/integrate_hardware.mdx
@@ -234,7 +234,7 @@ def is_calibrated(self) -> bool:
 The goal of the calibration is twofold:
 
 - Know the physical range of motion of each motors in order to only send commands within this range.
-- Normalize raw motors positions to sensible continuous values (e.g. percentages, degrees) instead of arbitrary discrete value dependant on the specific motor used that will not replicate elsewhere.
+- Normalize raw motor positions to sensible continuous values (e.g. percentages, degrees) instead of arbitrary discrete values dependent on the specific motor used that will not replicate elsewhere.
 
 It should implement the logic for calibration (if relevant) and update the `self.calibration` dictionary. If you are using Feetech or Dynamixel motors, our bus interfaces already include methods to help with this.
 


### PR DESCRIPTION
## Summary / Motivation

Correct grammar in the hardware calibration guide so the normalization recommendation is clearer for integrators.

## What changed

- Corrected `motors positions` to `motor positions`.
- Corrected `value dependant` to `values dependent`.

## How was this tested (or how to run locally)

- `git diff --check`
- `codespell docs/source/integrate_hardware.mdx`
- Documentation-only change; no runtime behavior is affected.

## Checklist (required before merge)

- [ ] All tests pass locally (`pytest`)
- [x] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: # (pending)

## Reviewer notes

Documentation-only grammar correction; no behavior changes.