### PR TITLE
fix(packaging): reject unsupported Python 3.14 installs

### DIFF
--- a/docs/source/earthrover_mini_plus.mdx
+++ b/docs/source/earthrover_mini_plus.mdx
@@ -13,7 +13,7 @@ The EarthRover Mini Plus is a fully open source mobile robot that connects throu
 ### Hardware
 
 - EarthRover Mini robot
-- Computer with Python 3.12 or newer
+- Computer with Python 3.12 or 3.13
 - Internet connection
 
 ### Setting Up the Frodobots SDK

--- a/docs/source/installation.mdx
+++ b/docs/source/installation.mdx
@@ -1,6 +1,6 @@
 # Installation
 
-This guide uses `conda` (via miniforge) to manage environments (recommended). If you prefer another environment manager (e.g. `uv`, `venv`), ensure you have Python >=3.12 and support PyTorch >= 2.10, then skip ahead to [Environment Setup](#step-2-environment-setup).
+This guide uses `conda` (via miniforge) to manage environments (recommended). If you prefer another environment manager (e.g. `uv`, `venv`), ensure you have Python 3.12 or 3.13 and support PyTorch >= 2.10, then skip ahead to [Environment Setup](#step-2-environment-setup).
 
 ## Step 1 (`conda` only): Install [`miniforge`](https://conda-forge.org/download/)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ version = "0.6.2"
 description = "🤗 LeRobot: State-of-the-art Machine Learning for Real-World Robotics in Pytorch"
 dynamic = ["readme"]
 license = { text = "Apache-2.0" }
-requires-python = ">=3.12"
+requires-python = ">=3.12,<3.14"
 authors = [
     { name = "Rémi Cadène", email = "re.cadene@gmail.com" },
     { name = "Simon Alibert", email = "alibert.sim@gmail.com" },

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 3
-requires-python = ">=3.12"
+requires-python = ">=3.12,<3.14"
 resolution-markers = [
     "(python_full_version >= '3.15' and platform_machine == 'AMD64' and sys_platform == 'linux') or (python_full_version >= '3.15' and platform_machine == 'x86_64' and sys_platform == 'linux')",
     "(python_full_version == '3.14.*' and platform_machine == 'AMD64' and sys_platform == 'linux') or (python_full_version == '3.14.*' and platform_machine == 'x86_64' and sys_platform == 'linux')",


### PR DESCRIPTION
## Summary

- Cap the package and lockfile Python requirement at `>=3.12,<3.14`.
- Keep installation documentation aligned with the supported Python versions.

LeRobot currently declares Python 3.14 support, but draccus 0.11.6 passes union annotations as argparse types and Python 3.14 rejects them while constructing the config parser. This affects `from_pretrained` and draccus-based CLI entrypoints before argument parsing. Until the upstream draccus fix is available, rejecting Python 3.14 at installation time gives users an actionable environment error instead of a runtime `TypeError`.

## Validation

- `uv lock --check`
- `uv tree --locked --depth 1`
- Python `tomllib` parsing of `pyproject.toml` and `uv.lock`
- `uv build --wheel`
- `git diff --check`

Closes #4509.