### PR TITLE
fix(motors): skip unsupported baudrates during motor discovery

### DIFF
--- a/src/lerobot/motors/feetech/feetech.py
+++ b/src/lerobot/motors/feetech/feetech.py
@@ -40,6 +40,16 @@ if TYPE_CHECKING or _feetech_sdk_available:
 else:
     scs = None
 
+try:
+    import serial
+except ImportError:
+    serial = None  # type: ignore[assignment]
+
+try:
+    import termios as _termios
+except ImportError:
+    _termios = None
+
 DEFAULT_PROTOCOL_VERSION = 0
 DEFAULT_BAUDRATE = 1_000_000
 DEFAULT_TIMEOUT_MS = 1000
@@ -170,7 +180,12 @@ class FeetechMotorsBus(SerialMotorsBus):
         expected_model_nb = self.model_number_table[model]
 
         for baudrate in search_baudrates:
-            self.set_baudrate(baudrate)
+            try:
+                self.set_baudrate(baudrate)
+            except Exception as e:
+                if self._skip_unsupported_baudrate(e):
+                    continue
+                raise
             id_model = self.broadcast_ping()
             if id_model:
                 found_id, found_model = next(iter(id_model.items()))
@@ -192,7 +207,12 @@ class FeetechMotorsBus(SerialMotorsBus):
         expected_model_nb = self.model_number_table[model]
 
         for baudrate in search_baudrates:
-            self.set_baudrate(baudrate)
+            try:
+                self.set_baudrate(baudrate)
+            except Exception as e:
+                if self._skip_unsupported_baudrate(e):
+                    continue
+                raise
             for id_ in range(scs.MAX_ID + 1):
                 found_model = self.ping(id_)
                 if found_model is not None:

--- a/src/lerobot/motors/motors_bus.py
+++ b/src/lerobot/motors/motors_bus.py
@@ -41,6 +41,11 @@ if TYPE_CHECKING or _serial_available:
 else:
     serial = None  # type: ignore[assignment]
 
+try:
+    import termios as _termios
+except ImportError:
+    _termios = None  # type: ignore[assignment]
+
 if TYPE_CHECKING or _deepdiff_available:
     from deepdiff import DeepDiff
 else:
@@ -577,7 +582,12 @@ class SerialMotorsBus(MotorsBusBase):
         bus._connect(handshake=False)
         baudrate_ids = {}
         for baudrate in tqdm(bus.available_baudrates, desc="Scanning port"):
-            bus.set_baudrate(baudrate)
+            try:
+                bus.set_baudrate(baudrate)
+            except Exception as e:
+                if bus._skip_unsupported_baudrate(e):
+                    continue
+                raise
             ids_models = bus.broadcast_ping()
             if ids_models:
                 tqdm.write(f"Motors found for {baudrate=}: {pformat(ids_models, indent=4)}")
@@ -707,6 +717,18 @@ class SerialMotorsBus(MotorsBusBase):
             int: Baud-rate in bits / second.
         """
         return self.port_handler.getBaudRate()
+
+    @staticmethod
+    def _skip_unsupported_baudrate(exc: Exception) -> bool:
+        """True when changing baudrate fails because the host cannot apply the rate.
+
+        Some host/kernel stacks (notably CDC ACM on Linux) reject certain baudrates
+        such as 250000 or 128000, raising ``termios.error: [Errno 22]``. During motor
+        discovery we want to skip those baudrates instead of aborting the scan.
+        """
+        return (_termios is not None and isinstance(exc, _termios.error)) or (
+            serial is not None and isinstance(exc, serial.SerialException)
+        )
 
     def set_baudrate(self, baudrate: int) -> None:
         """Set a new UART baud-rate on the port.


### PR DESCRIPTION
 Summary / Motivation                                                                                                                                                                         
                                                                                                                                                                                              
 On some Linux hosts (notably CDC-ACM USB serial adapters), the kernel termios stack rejects certain baud rates like 250000 and 128000 with termios.error: [Errno 22] Invalid argument when   
 pyserial tries to open the port. The SO-101 / Feetech motor tables (STS_SMS_SERIES_BAUDRATE_TABLE, SCAN_BAUDRATES) include those rates, so _find_single_motor_p0 / _find_single_motor_p1 and 
 scan_port iterated them and crashed on the first unsupported rate instead of trying the next supported one.                                                                                  
                                                                                                                                                                                              
 This aborts lerobot-setup-motors before it can find a motor that is actually reachable (e.g. at 1000000, 500000, 115200, ...), even though all those rates work fine on the same host.       
                                                                                                                                                                                              
 The fix catches the host-level "cannot apply this baudrate" error and continues scanning, rather than aborting the whole discovery.                                                          
                                                                                                                                                                                              
 Trade-off / design note: If a motor is genuinely configured to a baudrate the host cannot open (e.g. it was previously flashed to 250000 on a kernel that rejects it), it will now be        
 silently skipped rather than erroring. That matches the discovery semantics (we just can't talk at that rate on this host) and the user still gets a clear "motor not found" at the end if   
 no supported rate works.                                                                                                                                                                     
                                                                                                                                                                                              
 Related issues                                                                                                                                                                               
                                                                                                                                                                                              
 - Closes: # (SO-ARM100/lerobot issue — e.g. TheRobotStudio/SO-ARM100#150 describes the exact symptom)                                                                                        
 - Related: #                                                                                                                                                                                 
                                                                                                                                                                                              
 What changed                                                                                                                                                                                 
                                                                                                                                                                                              
 - Added SerialMotorsBus._skip_unsupported_baudrate(exc) helper that returns True for termios.error (POSIX baudrate rejection) and serial.SerialException.                                    
 - FeetechMotorsBus._find_single_motor_p0 / _find_single_motor_p1: wrap self.set_baudrate(baudrate) in a try/except; continue to the next baudrate when the error is an unsupported-baudrate  
   error, re-raise otherwise.                                                                                                                                                                 
 - SerialMotorsBus.scan_port: same guard around bus.set_baudrate(baudrate) so scanning doesn't abort on an unsupported rate.                                                                  
 - Real errors (RuntimeError, protocol errors, etc.) still propagate unchanged.                                                                                                               
                                                                                                                                                                                              
 How was this tested (or how to run locally)                                                                                                                                                  
                                                                                                                                                                                              
 - termios.error is correctly classified as "skip" and RuntimeError is correctly re-raised (unit-level check of the helper).                                                                  
 - Simulated scan where 250000/128000 raise termios.error and a motor is present at 115200: discovery now returns (115200, id) instead of crashing.                                           
 - Reproduced the original failure directly on /dev/ttyACM0:                                                                                                                                  
   ```                                                                                                                                                                                        
     1000000 OK                                                                                                                                                                               
     500000 OK                                                                                                                                                                                
     250000 ERR error (22, 'Invalid argument')                                                                                                                                                
     128000 ERR error (22, 'Invalid argument')                                                                                                                                                
     115200 OK                                                                                                                                                                                
     57600 OK                                                                                                                                                                                 
   ```                                                                                                                                                                                        
 - ruff clean on both edited files (only a pre-existing UP042 lint remains, unrelated to this change).                                                                                        
                                                                                                                                                                                              
 Checklist (required before merge)                                                                                                                                                            
                                                                                                                                                                                              
 - [x] Linting/formatting run (pre-commit run -a)                                                                                                                                             
 - [ ] All tests pass locally (pytest)                                                                                                                                                        
 - [ ] Documentation updated (n/a — behavior change only, no user-facing API)                                                                                                                 
 - [ ] CI is green                                                                                                                                                                            
 - [ ] Community Review: I have reviewed another contributor's open PR and linked it here: # (insert PR number/link)                                                                          
                                                                                                                                                                                              
 Reviewer notes                                                                                                                                                                               
                                                                                                                                                                                              
 - Focus on the exception boundary: only termios.error / serial.SerialException from set_baudrate are swallowed; everything else re-raises. Verify that's the right line to draw.             
 - _skip_unsupported_baudrate is a @staticmethod so it can be reused from both feetech.py (inherits SerialMotorsBus) and scan_port.                                                           
 - Confirmed termios.error is not a subclass of OSError on the affected platform, so we import termios explicitly rather than catching OSError.                                               
 - Anyone in the community is free to review the PR. 