### PR TITLE
feat(datasets): support episode-keyed feature values

### DIFF
--- a/src/lerobot/datasets/dataset_tools.py
+++ b/src/lerobot/datasets/dataset_tools.py
@@ -316,7 +316,7 @@ def merge_datasets(
 
 def modify_features(
     dataset: LeRobotDataset,
-    add_features: dict[str, tuple[np.ndarray | torch.Tensor | Callable, dict]] | None = None,
+    add_features: dict[str, tuple[np.ndarray | torch.Tensor | dict | Callable, dict]] | None = None,
     remove_features: str | list[str] | None = None,
     output_dir: str | Path | None = None,
     repo_id: str | None = None,
@@ -329,6 +329,8 @@ def modify_features(
     Args:
         dataset: The source LeRobotDataset.
         add_features: Optional dict mapping feature names to (feature_values, feature_info) tuples.
+            Feature values may be a dataset-length array or tensor, a dict keyed by episode index,
+            or a callable evaluated for each frame.
         remove_features: Optional feature name(s) to remove. Can be a single string or list.
         output_dir: Root directory where the edited dataset will be stored. If not specified, defaults to $HF_LEROBOT_HOME/repo_id. Equivalent to new_root in EditDatasetConfig.
         repo_id: Edited dataset identifier. Equivalent to new_repo_id in EditDatasetConfig.
@@ -420,7 +422,7 @@ def modify_features(
 
 def add_features(
     dataset: LeRobotDataset,
-    features: dict[str, tuple[np.ndarray | torch.Tensor | Callable, dict]],
+    features: dict[str, tuple[np.ndarray | torch.Tensor | dict | Callable, dict]],
     output_dir: str | Path | None = None,
     repo_id: str | None = None,
 ) -> LeRobotDataset:
@@ -1062,6 +1064,14 @@ def _copy_data_with_feature_changes(
                         ep_idx = row["episode_index"]
                         frame_in_ep = row["frame_index"]
                         value = values(row.to_dict(), ep_idx, frame_in_ep)
+                        if isinstance(value, np.ndarray) and value.size == 1:
+                            value = value.item()
+                        feature_values.append(value)
+                    df[feature_name] = feature_values
+                elif isinstance(values, dict):
+                    feature_values = []
+                    for episode_idx in df["episode_index"]:
+                        value = values[episode_idx]
                         if isinstance(value, np.ndarray) and value.size == 1:
                             value = value.item()
                         feature_values.append(value)

--- a/tests/datasets/test_dataset_tools.py
+++ b/tests/datasets/test_dataset_tools.py
@@ -371,6 +371,49 @@ def test_add_features_with_episode_keyed_values(sample_dataset, tmp_path):
         assert float(item["episode_value"]) == float(item["episode_index"])
 
 
+def test_add_features_with_multidimensional_episode_keyed_values(sample_dataset, tmp_path):
+    """Test repeating a vector feature value across each episode."""
+    feature_info = {"dtype": "float32", "shape": (2,), "names": None}
+    values_by_episode = {
+        episode_idx: np.array([episode_idx, episode_idx + 0.5], dtype=np.float32)
+        for episode_idx in range(sample_dataset.meta.total_episodes)
+    }
+
+    with (
+        patch("lerobot.datasets.dataset_metadata.get_safe_version") as mock_get_safe_version,
+        patch("lerobot.datasets.dataset_metadata.snapshot_download") as mock_snapshot_download,
+    ):
+        mock_get_safe_version.return_value = "v3.0"
+        mock_snapshot_download.return_value = str(tmp_path / "with_episode_vectors")
+
+        new_dataset = add_features(
+            dataset=sample_dataset,
+            features={"episode_vector": (values_by_episode, feature_info)},
+            output_dir=tmp_path / "with_episode_vectors",
+        )
+
+    for item in new_dataset:
+        episode_idx = int(item["episode_index"])
+        expected = torch.tensor([episode_idx, episode_idx + 0.5], dtype=torch.float32)
+        torch.testing.assert_close(item["episode_vector"], expected)
+
+
+def test_add_features_with_incomplete_episode_keyed_values(sample_dataset, tmp_path):
+    """Test that an incomplete episode mapping fails loudly."""
+    feature_info = {"dtype": "float32", "shape": (1,), "names": None}
+    values_by_episode = {
+        episode_idx: np.array([episode_idx], dtype=np.float32)
+        for episode_idx in range(sample_dataset.meta.total_episodes - 1)
+    }
+
+    with pytest.raises(KeyError, match=str(sample_dataset.meta.total_episodes - 1)):
+        add_features(
+            dataset=sample_dataset,
+            features={"episode_value": (values_by_episode, feature_info)},
+            output_dir=tmp_path / "with_incomplete_episode_values",
+        )
+
+
 def test_add_features_with_callable(sample_dataset, tmp_path):
     """Test adding a feature with a callable."""
 

--- a/tests/datasets/test_dataset_tools.py
+++ b/tests/datasets/test_dataset_tools.py
@@ -346,6 +346,31 @@ def test_add_features_with_values(sample_dataset, tmp_path, values, feature_shap
     assert tuple(sample_item["new_feature"].shape) == expected_item_shape
 
 
+def test_add_features_with_episode_keyed_values(sample_dataset, tmp_path):
+    """Test adding one constant feature value per episode."""
+    feature_info = {"dtype": "float32", "shape": (1,), "names": None}
+    values_by_episode = {
+        episode_idx: np.array([episode_idx], dtype=np.float32)
+        for episode_idx in range(sample_dataset.meta.total_episodes)
+    }
+
+    with (
+        patch("lerobot.datasets.dataset_metadata.get_safe_version") as mock_get_safe_version,
+        patch("lerobot.datasets.dataset_metadata.snapshot_download") as mock_snapshot_download,
+    ):
+        mock_get_safe_version.return_value = "v3.0"
+        mock_snapshot_download.return_value = str(tmp_path / "with_episode_values")
+
+        new_dataset = add_features(
+            dataset=sample_dataset,
+            features={"episode_value": (values_by_episode, feature_info)},
+            output_dir=tmp_path / "with_episode_values",
+        )
+
+    for item in new_dataset:
+        assert float(item["episode_value"]) == float(item["episode_index"])
+
+
 def test_add_features_with_callable(sample_dataset, tmp_path):
     """Test adding a feature with a callable."""
 


### PR DESCRIPTION
## Summary / Motivation

`add_features` and `modify_features` currently require values to be supplied once per frame, even when a feature is constant throughout each episode. This makes callers expand episode-level data into dataset-length arrays.

Allowing a dictionary keyed by `episode_index` keeps memory proportional to the number of episodes while preserving the existing array, tensor, and callable interfaces.

## Related issues

- Related: #2326

## What changed

- Accept dictionaries keyed by episode index as feature values.
- Expand each episode value across its frames while copying dataset parquet files.
- Document the new accepted input form.
- Add regression tests covering scalar and multidimensional episode values and incomplete mappings.

This is backward compatible. Missing episode keys intentionally raise `KeyError` rather than silently generating incomplete data.

## How was this tested (or how to run locally)

- `pytest -sv tests/datasets/test_dataset_tools.py`
  - All 70 tests passed. Two network-backed conversion tests were rerun after downloading their public fixture.
- `pre-commit run --all-files`
  - All configured hooks passed.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`) — the full repository suite was not run; all 70 dataset-tools tests pass
- [x] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: #

## Reviewer notes

Please focus on the dictionary lookup semantics in `_copy_data_with_feature_changes`, particularly the intentional fail-loudly behavior for incomplete episode mappings.

Anyone in the community is welcome to review this PR.

## AI assistance disclosure

OpenAI Codex assisted with comparing the change against current upstream, adapting the implementation, adding the regression tests, running validation, and drafting this description. The final diff and validation results are presented for human review.
