### PR TITLE
feat(datasets): add `rename_feature` to the dataset editing tools

### DIFF
--- a/src/lerobot/datasets/__init__.py
+++ b/src/lerobot/datasets/__init__.py
@@ -33,6 +33,7 @@ from .dataset_tools import (
     recompute_stats,
     reencode_dataset,
     remove_feature,
+    rename_feature,
     split_dataset,
 )
 from .factory import make_dataset, make_train_eval_datasets, resolve_delta_timestamps
@@ -96,6 +97,7 @@ __all__ = [
     "recompute_stats",
     "reencode_dataset",
     "remove_feature",
+    "rename_feature",
     "resolve_delta_timestamps",
     "resolve_episode_indices",
     "safe_stop_image_writer",

--- a/src/lerobot/datasets/dataset_tools.py
+++ b/src/lerobot/datasets/dataset_tools.py
@@ -318,18 +318,20 @@ def modify_features(
     dataset: LeRobotDataset,
     add_features: dict[str, tuple[np.ndarray | torch.Tensor | Callable, dict]] | None = None,
     remove_features: str | list[str] | None = None,
+    rename_features: dict[str, str] | None = None,
     output_dir: str | Path | None = None,
     repo_id: str | None = None,
 ) -> LeRobotDataset:
-    """Modify a LeRobotDataset by adding and/or removing features in a single pass.
+    """Modify a LeRobotDataset by adding, removing and/or renaming features in a single pass.
 
     This is the most efficient way to modify features, as it only copies the dataset once
-    regardless of how many features are being added or removed.
+    regardless of how many features are being added, removed or renamed.
 
     Args:
         dataset: The source LeRobotDataset.
         add_features: Optional dict mapping feature names to (feature_values, feature_info) tuples.
         remove_features: Optional feature name(s) to remove. Can be a single string or list.
+        rename_features: Optional dict mapping existing feature names to their new names.
         output_dir: Root directory where the edited dataset will be stored. If not specified, defaults to $HF_LEROBOT_HOME/repo_id. Equivalent to new_root in EditDatasetConfig.
         repo_id: Edited dataset identifier. Equivalent to new_repo_id in EditDatasetConfig.
 
@@ -343,15 +345,18 @@ def modify_features(
                 "reward": (reward_array, {"dtype": "float32", "shape": [1], "names": None}),
             },
             remove_features=["old_feature"],
+            rename_features={"observation.images.top": "observation.images.camera1"},
             output_dir="./output",
         )
     """
-    if add_features is None and remove_features is None:
-        raise ValueError("Must specify at least one of add_features or remove_features")
+    if add_features is None and remove_features is None and rename_features is None:
+        raise ValueError("Must specify at least one of add_features, remove_features or rename_features")
 
     remove_features_list: list[str] = []
     if remove_features is not None:
         remove_features_list = [remove_features] if isinstance(remove_features, str) else remove_features
+
+    rename_map: dict[str, str] = dict(rename_features) if rename_features else {}
 
     if add_features:
         required_keys = {"dtype", "shape"}
@@ -371,6 +376,26 @@ def modify_features(
         if any(name in required_features for name in remove_features_list):
             raise ValueError(f"Cannot remove required features: {required_features}")
 
+    if rename_map:
+        required_features = {"timestamp", "frame_index", "episode_index", "index", "task_index"}
+        for old_name, new_name in rename_map.items():
+            if old_name not in dataset.meta.features:
+                raise ValueError(f"Feature '{old_name}' not found in dataset")
+            if old_name in required_features:
+                raise ValueError(f"Cannot rename required features: {required_features}")
+            if old_name in remove_features_list:
+                raise ValueError(f"Feature '{old_name}' cannot be renamed and removed at once")
+            if new_name in dataset.meta.features and new_name not in rename_map:
+                raise ValueError(
+                    f"Feature '{new_name}' already exists in dataset, cannot rename '{old_name}' to it"
+                )
+            if add_features and new_name in add_features:
+                raise ValueError(f"Feature '{new_name}' is both added and used as a rename target")
+
+        new_names = list(rename_map.values())
+        if len(set(new_names)) != len(new_names):
+            raise ValueError(f"Duplicate rename targets: {new_names}")
+
     if repo_id is None:
         repo_id = f"{dataset.repo_id}_modified"
     output_dir = Path(output_dir) if output_dir is not None else HF_LEROBOT_HOME / repo_id
@@ -381,12 +406,18 @@ def modify_features(
         for name in remove_features_list:
             new_features.pop(name, None)
 
+    if rename_map:
+        new_features = {rename_map.get(name, name): info for name, info in new_features.items()}
+
     if add_features:
         for feature_name, (_, feature_info) in add_features.items():
             new_features[feature_name] = feature_info
 
     video_keys_to_remove = [name for name in remove_features_list if name in dataset.meta.video_keys]
-    remaining_video_keys = [k for k in dataset.meta.video_keys if k not in video_keys_to_remove]
+    video_keys_to_rename = {old: new for old, new in rename_map.items() if old in dataset.meta.video_keys}
+    remaining_video_keys = [
+        rename_map.get(k, k) for k in dataset.meta.video_keys if k not in video_keys_to_remove
+    ]
 
     new_meta = LeRobotDatasetMetadata.create(
         repo_id=repo_id,
@@ -402,10 +433,16 @@ def modify_features(
         new_meta=new_meta,
         add_features=add_features,
         remove_features=remove_features_list if remove_features_list else None,
+        rename_features=rename_map or None,
     )
 
     if new_meta.video_keys:
-        _copy_videos(dataset, new_meta, exclude_keys=video_keys_to_remove if video_keys_to_remove else None)
+        _copy_videos(
+            dataset,
+            new_meta,
+            exclude_keys=video_keys_to_remove if video_keys_to_remove else None,
+            rename_keys=video_keys_to_rename or None,
+        )
 
     new_dataset = LeRobotDataset(
         repo_id=repo_id,
@@ -479,6 +516,46 @@ def remove_feature(
         dataset=dataset,
         add_features=None,
         remove_features=feature_names,
+        output_dir=output_dir,
+        repo_id=repo_id,
+    )
+
+
+def rename_feature(
+    dataset: LeRobotDataset,
+    feature_mapping: dict[str, str],
+    output_dir: str | Path | None = None,
+    repo_id: str | None = None,
+) -> LeRobotDataset:
+    """Rename features of a LeRobotDataset.
+
+    Renaming a feature also updates its episode-level statistics and, for video features,
+    moves the video files to the directory named after the new key.
+
+    Args:
+        dataset: The source LeRobotDataset.
+        feature_mapping: Dict mapping existing feature names to their new names.
+        output_dir: Root directory where the edited dataset will be stored. If not specified, defaults to $HF_LEROBOT_HOME/repo_id. Equivalent to new_root in EditDatasetConfig.
+        repo_id: Edited dataset identifier. Equivalent to new_repo_id in EditDatasetConfig.
+
+    Returns:
+        New dataset with features renamed.
+
+    Example:
+        new_dataset = rename_feature(
+            dataset,
+            {"observation.images.top": "observation.images.camera1"},
+            output_dir="./output",
+        )
+    """
+    if not feature_mapping:
+        raise ValueError("No feature mapping provided")
+
+    return modify_features(
+        dataset=dataset,
+        add_features=None,
+        remove_features=None,
+        rename_features=feature_mapping,
         output_dir=output_dir,
         repo_id=repo_id,
     )
@@ -1030,8 +1107,9 @@ def _copy_data_with_feature_changes(
     new_meta: LeRobotDatasetMetadata,
     add_features: dict[str, tuple] | None = None,
     remove_features: list[str] | None = None,
+    rename_features: dict[str, str] | None = None,
 ) -> None:
-    """Copy data while adding or removing features."""
+    """Copy data while adding, removing or renaming features."""
     data_dir = dataset.root / DATA_DIR
     parquet_files = sorted(data_dir.glob("*/*.parquet"))
 
@@ -1052,6 +1130,9 @@ def _copy_data_with_feature_changes(
 
         if remove_features:
             df = df.drop(columns=remove_features, errors="ignore")
+
+        if rename_features:
+            df = df.rename(columns=rename_features)
 
         if add_features:
             end_idx = frame_idx + len(df)
@@ -1082,40 +1163,86 @@ def _copy_data_with_feature_changes(
 
         _write_parquet(df, dst_path, new_meta)
 
-    _copy_episodes_metadata_and_stats(dataset, new_meta)
+    _copy_episodes_metadata_and_stats(dataset, new_meta, rename_features=rename_features)
 
 
 def _copy_videos(
     src_dataset: LeRobotDataset,
     dst_meta: LeRobotDatasetMetadata,
     exclude_keys: list[str] | None = None,
+    rename_keys: dict[str, str] | None = None,
 ) -> None:
-    """Copy video files, optionally excluding certain keys."""
+    """Copy video files, optionally excluding or renaming certain keys.
+
+    Video files live under a directory named after their feature key
+    (``DEFAULT_VIDEO_PATH``), so renaming a video feature also moves its files.
+    """
     if exclude_keys is None:
         exclude_keys = []
+    if rename_keys is None:
+        rename_keys = {}
 
-    for video_key in src_dataset.meta.video_keys:
-        if video_key in exclude_keys:
+    for src_key in src_dataset.meta.video_keys:
+        if src_key in exclude_keys:
             continue
 
-        video_files = set()
+        dst_key = rename_keys.get(src_key, src_key)
+
+        video_files: set[tuple[str, str]] = set()
         for ep_idx in range(len(src_dataset.meta.episodes)):
             try:
-                video_files.add(src_dataset.meta.get_video_file_path(ep_idx, video_key))
+                video_files.add(
+                    (
+                        src_dataset.meta.get_video_file_path(ep_idx, src_key),
+                        dst_meta.get_video_file_path(ep_idx, dst_key),
+                    )
+                )
             except KeyError:
                 continue
 
-        for src_path in tqdm(sorted(video_files), desc=f"Copying {video_key} videos"):
-            dst_path = dst_meta.root / src_path
-            dst_path.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copy(src_dataset.root / src_path, dst_path)
+        desc = f"Copying {src_key} videos" if src_key == dst_key else f"Copying {src_key} -> {dst_key} videos"
+        for src_path, dst_path in tqdm(sorted(video_files), desc=desc):
+            full_dst = dst_meta.root / dst_path
+            full_dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy(src_dataset.root / src_path, full_dst)
+
+
+def _rename_episode_metadata_columns(episodes_dir: Path, rename_features: dict[str, str]) -> None:
+    """Rename per-feature columns inside the copied episode metadata parquet files.
+
+    Episode metadata carries one group of columns per feature - ``stats/<feature>/<stat>``
+    - and one per video feature - ``videos/<key>/{chunk_index,file_index,from_timestamp,
+    to_timestamp}``. Renaming a feature has to rename these too, otherwise the metadata
+    still refers to names that no longer exist in the dataset.
+
+    Note that ``load_episodes`` drops ``stats/`` columns, so the parquet files are rewritten
+    directly instead of being round-tripped through the metadata objects.
+    """
+    prefixes = ("stats", "videos")
+
+    def rename_column(name: str) -> str:
+        parts = name.split("/")
+        if len(parts) >= 3 and parts[0] in prefixes:
+            # Feature names contain dots, not slashes, so parts[1] is the whole key.
+            new_key = rename_features.get(parts[1])
+            if new_key is not None:
+                return "/".join([parts[0], new_key, *parts[2:]])
+        return name
+
+    for path in sorted(episodes_dir.glob("*/*.parquet")):
+        table = pq.read_table(path)
+        new_names = [rename_column(name) for name in table.column_names]
+        if new_names != table.column_names:
+            pq.write_table(table.rename_columns(new_names), path)
 
 
 def _copy_episodes_metadata_and_stats(
     src_dataset: LeRobotDataset,
     dst_meta: LeRobotDatasetMetadata,
+    rename_features: dict[str, str] | None = None,
 ) -> None:
     """Copy episodes metadata and recalculate stats."""
+    rename_features = rename_features or {}
     if src_dataset.meta.tasks is not None:
         write_tasks(src_dataset.meta.tasks, dst_meta.root)
         dst_meta.tasks = src_dataset.meta.tasks.copy()
@@ -1124,6 +1251,8 @@ def _copy_episodes_metadata_and_stats(
     dst_episodes_dir = dst_meta.root / "meta/episodes"
     if episodes_dir.exists():
         shutil.copytree(episodes_dir, dst_episodes_dir, dirs_exist_ok=True)
+        if rename_features:
+            _rename_episode_metadata_columns(dst_episodes_dir, rename_features)
 
     dst_meta.info.total_episodes = src_dataset.meta.total_episodes
     dst_meta.info.total_frames = src_dataset.meta.total_frames
@@ -1136,10 +1265,12 @@ def _copy_episodes_metadata_and_stats(
     )
 
     if dst_meta.video_keys and src_dataset.meta.video_keys:
+        src_name_of = {new: old for old, new in rename_features.items()}
         for key in dst_meta.video_keys:
-            if key in src_dataset.meta.features:
+            src_key = src_name_of.get(key, key)
+            if src_key in src_dataset.meta.features:
                 dst_meta.info.features[key]["info"] = deepcopy(
-                    src_dataset.meta.info.features[key].get("info", {})
+                    src_dataset.meta.info.features[src_key].get("info", {})
                 )
 
     write_info(dst_meta.info, dst_meta.root)
@@ -1147,10 +1278,10 @@ def _copy_episodes_metadata_and_stats(
     if set(dst_meta.features.keys()) != set(src_dataset.meta.features.keys()):
         logging.info("Recalculating dataset statistics...")
         if src_dataset.meta.stats:
-            new_stats = {}
-            for key in dst_meta.features:
-                if key in src_dataset.meta.stats:
-                    new_stats[key] = src_dataset.meta.stats[key]
+            src_stats = {
+                rename_features.get(key, key): value for key, value in src_dataset.meta.stats.items()
+            }
+            new_stats = {key: src_stats[key] for key in dst_meta.features if key in src_stats}
             write_stats(new_stats, dst_meta.root)
     else:
         if src_dataset.meta.stats:

--- a/src/lerobot/scripts/lerobot_edit_dataset.py
+++ b/src/lerobot/scripts/lerobot_edit_dataset.py
@@ -108,6 +108,12 @@ Remove camera feature:
         --operation.type remove_feature \
         --operation.feature_names "['observation.image']"
 
+Rename features (also moves video files for video features):
+    lerobot-edit-dataset \
+        --repo_id lerobot/pusht \
+        --operation.type rename_feature \
+        --operation.feature_mapping '{"observation.image": "observation.images.top"}'
+
 Modify tasks - set a single task for all episodes (WARNING: modifies in-place):
     lerobot-edit-dataset \
         --repo_id lerobot/pusht \
@@ -264,6 +270,7 @@ from lerobot.datasets import (
     recompute_stats,
     reencode_dataset,
     remove_feature,
+    rename_feature,
     split_dataset,
 )
 from lerobot.utils.constants import HF_LEROBOT_HOME
@@ -303,6 +310,12 @@ class MergeConfig(OperationConfig):
 @dataclass
 class RemoveFeatureConfig(OperationConfig):
     feature_names: list[str] | None = None
+
+
+@OperationConfig.register_subclass("rename_feature")
+@dataclass
+class RenameFeatureConfig(OperationConfig):
+    feature_mapping: dict[str, str] | None = None
 
 
 @OperationConfig.register_subclass("modify_tasks")
@@ -558,6 +571,41 @@ def handle_remove_feature(cfg: EditDatasetConfig) -> None:
 
     logging.info(f"Dataset saved to {output_dir}")
     logging.info(f"Remaining features: {list(new_dataset.meta.features.keys())}")
+
+    if cfg.push_to_hub:
+        logging.info(f"Pushing to hub as {output_repo_id}")
+        LeRobotDataset(output_repo_id, root=output_dir).push_to_hub()
+
+
+def handle_rename_feature(cfg: EditDatasetConfig) -> None:
+    if not isinstance(cfg.operation, RenameFeatureConfig):
+        raise ValueError("Operation config must be RenameFeatureConfig")
+
+    if not cfg.operation.feature_mapping:
+        raise ValueError("feature_mapping must be specified for rename_feature operation")
+
+    dataset = LeRobotDataset(cfg.repo_id, root=cfg.root)
+    output_repo_id, output_dir, backup_path = get_output_path(
+        cfg.repo_id,
+        new_repo_id=cfg.new_repo_id,
+        root=cfg.root,
+        new_root=cfg.new_root,
+    )
+
+    # In case of in-place modification, make the dataset point to the backup directory
+    if backup_path is not None:
+        dataset.root = backup_path
+
+    logging.info(f"Renaming features {cfg.operation.feature_mapping} in {cfg.repo_id}")
+    new_dataset = rename_feature(
+        dataset,
+        feature_mapping=cfg.operation.feature_mapping,
+        output_dir=output_dir,
+        repo_id=output_repo_id,
+    )
+
+    logging.info(f"Dataset saved to {output_dir}")
+    logging.info(f"Features: {list(new_dataset.meta.features.keys())}")
 
     if cfg.push_to_hub:
         logging.info(f"Pushing to hub as {output_repo_id}")
@@ -855,6 +903,8 @@ def edit_dataset(cfg: EditDatasetConfig) -> None:
         handle_merge(cfg)
     elif operation_type == "remove_feature":
         handle_remove_feature(cfg)
+    elif operation_type == "rename_feature":
+        handle_rename_feature(cfg)
     elif operation_type == "modify_tasks":
         handle_modify_tasks(cfg)
     elif operation_type == "convert_image_to_video":

--- a/tests/datasets/test_dataset_tools.py
+++ b/tests/datasets/test_dataset_tools.py
@@ -18,6 +18,7 @@
 from unittest.mock import patch
 
 import numpy as np
+import pyarrow.parquet as pq
 import pytest
 import torch
 
@@ -35,9 +36,11 @@ from lerobot.datasets.dataset_tools import (
     modify_tasks,
     reencode_dataset,
     remove_feature,
+    rename_feature,
     split_dataset,
 )
 from lerobot.datasets.io_utils import load_info
+from lerobot.datasets.lerobot_dataset import LeRobotDataset
 from tests.datasets.test_video_encoding import require_h264, require_hevc, require_libsvtav1
 from tests.fixtures.constants import DUMMY_DEPTH_FEATURES, DUMMY_DEPTH_KEY
 from tests.fixtures.dataset_factories import add_frames
@@ -495,7 +498,9 @@ def test_modify_features_only_remove(sample_dataset, tmp_path):
 
 def test_modify_features_no_changes(sample_dataset, tmp_path):
     """Test error when modify_features is called with no changes."""
-    with pytest.raises(ValueError, match="Must specify at least one of add_features or remove_features"):
+    with pytest.raises(
+        ValueError, match="Must specify at least one of add_features, remove_features or rename_features"
+    ):
         modify_features(
             sample_dataset,
             output_dir=tmp_path / "modified",
@@ -1589,3 +1594,175 @@ def test_reencode_dataset_multi_key_multiprocessing(
     for vk in dataset.meta.video_keys:
         persisted_encoder = RGBEncoderConfig.from_video_info(persisted_info.features[vk].get("info", {}))
         assert persisted_encoder == target_cfg
+
+
+# ---------------------------------------------------------------------------
+# rename_feature
+# ---------------------------------------------------------------------------
+
+
+def _mock_hub(tmp_path):
+    """Context managers used by the other tests here to keep the hub out of the loop."""
+    return (
+        patch("lerobot.datasets.dataset_metadata.get_safe_version"),
+        patch("lerobot.datasets.dataset_metadata.snapshot_download"),
+    )
+
+
+def test_rename_feature_basic(sample_dataset, tmp_path):
+    """Renaming a feature moves it in the metadata and in the parquet data."""
+    mock_version, mock_download = _mock_hub(tmp_path)
+    with mock_version as mv, mock_download as md:
+        mv.return_value = "v3.0"
+        md.side_effect = lambda repo_id, **kwargs: str(kwargs.get("local_dir", tmp_path))
+
+        renamed = rename_feature(
+            sample_dataset,
+            {"observation.state": "observation.robot_state"},
+            output_dir=tmp_path / "renamed",
+        )
+
+    assert "observation.state" not in renamed.meta.features
+    assert "observation.robot_state" in renamed.meta.features
+    assert renamed.meta.features["observation.robot_state"]["shape"] == (4,)
+    assert len(renamed) == len(sample_dataset)
+
+    item = renamed[0]
+    assert "observation.robot_state" in item
+    assert "observation.state" not in item
+
+
+def test_rename_feature_carries_stats(sample_dataset, tmp_path):
+    """Stats must follow the rename instead of being silently dropped."""
+    mock_version, mock_download = _mock_hub(tmp_path)
+    with mock_version as mv, mock_download as md:
+        mv.return_value = "v3.0"
+        md.side_effect = lambda repo_id, **kwargs: str(kwargs.get("local_dir", tmp_path))
+
+        renamed = rename_feature(
+            sample_dataset,
+            {"observation.state": "observation.robot_state"},
+            output_dir=tmp_path / "renamed",
+        )
+
+    assert "observation.robot_state" in renamed.meta.stats
+    assert "observation.state" not in renamed.meta.stats
+    np.testing.assert_allclose(
+        renamed.meta.stats["observation.robot_state"]["mean"],
+        sample_dataset.meta.stats["observation.state"]["mean"],
+    )
+
+
+def test_rename_feature_swap(sample_dataset, tmp_path):
+    """Swapping two names in one call is allowed and does not collide."""
+    mock_version, mock_download = _mock_hub(tmp_path)
+    with mock_version as mv, mock_download as md:
+        mv.return_value = "v3.0"
+        md.side_effect = lambda repo_id, **kwargs: str(kwargs.get("local_dir", tmp_path))
+
+        feature_info = {"dtype": "float32", "shape": (6,), "names": None}
+        with_extra = add_features(
+            sample_dataset,
+            features={"action_b": (np.random.randn(50, 6).astype(np.float32), feature_info)},
+            output_dir=tmp_path / "with_extra",
+        )
+        swapped = rename_feature(
+            with_extra,
+            {"action": "action_b", "action_b": "action"},
+            output_dir=tmp_path / "swapped",
+        )
+
+    assert set(swapped.meta.features) == set(with_extra.meta.features)
+
+
+def test_modify_features_add_remove_and_rename(sample_dataset, tmp_path):
+    """add / remove / rename compose in a single pass."""
+    feature_info = {"dtype": "float32", "shape": (1,), "names": None}
+
+    mock_version, mock_download = _mock_hub(tmp_path)
+    with mock_version as mv, mock_download as md:
+        mv.return_value = "v3.0"
+        md.side_effect = lambda repo_id, **kwargs: str(kwargs.get("local_dir", tmp_path))
+
+        with_reward = add_features(
+            sample_dataset,
+            features={"reward": (np.random.randn(50, 1).astype(np.float32), feature_info)},
+            output_dir=tmp_path / "with_reward",
+        )
+        modified = modify_features(
+            with_reward,
+            add_features={"success": (np.random.randn(50, 1).astype(np.float32), feature_info)},
+            remove_features="reward",
+            rename_features={"observation.state": "observation.robot_state"},
+            output_dir=tmp_path / "modified",
+        )
+
+    assert "success" in modified.meta.features
+    assert "reward" not in modified.meta.features
+    assert "observation.robot_state" in modified.meta.features
+    assert "observation.state" not in modified.meta.features
+    assert len(modified) == 50
+
+
+@pytest.mark.parametrize(
+    ("mapping", "match"),
+    [
+        ({"does.not.exist": "whatever"}, "not found in dataset"),
+        ({"observation.state": "action"}, "already exists"),
+        ({"timestamp": "t"}, "Cannot rename required features"),
+        ({"observation.state": "x", "action": "x"}, "Duplicate rename targets"),
+    ],
+)
+def test_rename_feature_validation(sample_dataset, tmp_path, mapping, match):
+    with pytest.raises(ValueError, match=match):
+        rename_feature(sample_dataset, mapping, output_dir=tmp_path / "nope")
+
+
+def test_rename_feature_requires_mapping(sample_dataset, tmp_path):
+    with pytest.raises(ValueError, match="No feature mapping provided"):
+        rename_feature(sample_dataset, {}, output_dir=tmp_path / "nope")
+
+
+@require_h264
+def test_rename_video_feature_moves_files(tmp_path, empty_lerobot_dataset_factory, features_factory):
+    """Renaming a video feature moves its files and rewrites the episode metadata columns."""
+    features = features_factory(use_videos=True)
+    dataset = empty_lerobot_dataset_factory(
+        root=tmp_path / "ds",
+        features=features,
+        use_videos=True,
+    )
+    add_frames(dataset, num_frames=4)
+    dataset.save_episode()
+    dataset.finalize()
+
+    # Reload so the metadata reflects what is on disk.
+    dataset = LeRobotDataset(dataset.repo_id, root=dataset.root)
+
+    old_key = dataset.meta.video_keys[0]
+    new_key = "observation.images.renamed_cam"
+
+    mock_version, mock_download = _mock_hub(tmp_path)
+    with mock_version as mv, mock_download as md:
+        mv.return_value = "v3.0"
+        md.side_effect = lambda repo_id, **kwargs: str(kwargs.get("local_dir", tmp_path))
+
+        renamed = rename_feature(dataset, {old_key: new_key}, output_dir=tmp_path / "renamed")
+
+    assert new_key in renamed.meta.video_keys
+    assert old_key not in renamed.meta.video_keys
+
+    # The video file has to exist under the new key's directory.
+    video_path = renamed.root / renamed.meta.get_video_file_path(0, new_key)
+    assert video_path.is_file(), f"missing renamed video at {video_path}"
+    assert not (renamed.root / "videos" / old_key).exists()
+
+    # Episode metadata columns must have followed the rename.
+    ep_files = sorted((renamed.root / "meta/episodes").glob("*/*.parquet"))
+    assert ep_files
+    columns = set()
+    for f in ep_files:
+        columns.update(pq.read_table(f).column_names)
+    assert any(c.startswith(f"videos/{new_key}/") for c in columns)
+    assert not any(c.startswith(f"videos/{old_key}/") for c in columns)
+    assert not any(c.startswith(f"stats/{old_key}/") for c in columns)


### PR DESCRIPTION
Picks up #2435 and rebases it onto current `main`, then completes it.
Original work by @IamPhytan — kept as co-author on the commit.

## What

Part of #2326 ("Develop LeRobotDataset tools"), item 3: renaming features.
This is the piece that blocks merging two datasets whose features are
semantically the same but named differently
(`observation.image.camera1` vs `observation.image.top`).

- `modify_features(..., rename_features={"old": "new"})`
- `rename_feature(dataset, mapping, ...)` wrapper, next to `add_features` / `remove_feature`
- `lerobot-edit-dataset --operation.type rename_feature --operation.feature_mapping '{"old": "new"}'`

Renaming composes with adding and removing inside the same single-pass copy.

## Why it is not just a column rename

`#2435` renamed the parquet column, the `info.features` key and the video
`videos/<key>/*` episode columns. Working through it on current `main` turned up
two more places that need the mapping, both of which fail silently:

1. **Dataset-level stats.** `_copy_episodes_metadata_and_stats` filters
   `src.meta.stats` against the destination feature names. On a rename the names
   no longer match, so the stats of every renamed feature are dropped without an
   error. Fixed by mapping the stats keys through the rename first.

2. **Per-episode stats columns.** `meta/episodes/*.parquet` carries a
   `stats/<feature>/<stat>` column group per feature. These kept the old names.
   Note `load_episodes` deliberately drops `stats/` columns, so this cannot be
   done by round-tripping through the metadata objects — the parquet files are
   rewritten directly.

Also handled: video files live under a directory named after the feature key
(`DEFAULT_VIDEO_PATH`), so renaming a video feature moves them; and the per-video
`info` block is copied by looking the key up in the *source* features, which needs
the reverse mapping once the destination key differs.

## Validation

Rejects: renaming a missing feature; renaming onto a name already in use;
renaming the required `timestamp`/`frame_index`/`episode_index`/`index`/`task_index`
features; renaming and removing the same feature in one call; duplicate rename
targets. Swaps (`{"a": "b", "b": "a"}`) are allowed.

## Tests

`tests/datasets/test_dataset_tools.py`, 10 new tests: basic rename, stats
following the rename, swap, composition with add+remove, the validation errors
(parametrized), and a video-feature rename asserting both that the video file
moved to the new key's directory and that the episode metadata columns were
rewritten.

One pre-existing test updated for the new error message
(`test_modify_features_no_changes`).

`pytest tests/datasets/test_dataset_tools.py` — 77 passed.
`ruff check` / `ruff format` clean.

## Not in this PR

The other half of #2326 item 3 — teaching `merge_datasets` to take a feature
mapping directly — is a natural follow-up now that renaming exists. Happy to do
it in a second PR if you'd rather keep these separate.

## Note

`_copy_videos` iterates `range(len(src_dataset.meta.episodes))`, which raises
`TypeError: object of type 'NoneType' has no len()` if it is handed a dataset
object whose metadata has not been reloaded since `finalize()`. That is
pre-existing and not touched here — the test reloads the dataset — but no
existing test exercised `modify_features` on a video dataset, so flagging it.