### PR TITLE
fix(datasets): honor download_videos=False for cached data

### DIFF
--- a/src/lerobot/datasets/dataset_reader.py
+++ b/src/lerobot/datasets/dataset_reader.py
@@ -124,14 +124,18 @@ class DatasetReader:
         """Remove the transform applied to visual observations."""
         self._image_transforms = None
 
-    def try_load(self) -> bool:
-        """Attempt to load from local cache. Returns True if data is sufficient."""
+    def try_load(self, require_videos: bool = True) -> bool:
+        """Attempt to load from local cache. Returns True if the requested data is sufficient.
+
+        Args:
+            require_videos: Whether cached video files are required in addition to Parquet data.
+        """
         try:
             self.hf_dataset = self._load_hf_dataset()
         except (FileNotFoundError, NotADirectoryError):
             self.hf_dataset = None
             return False
-        if not self._check_cached_episodes_sufficient():
+        if not self._check_cached_episodes_sufficient(require_videos=require_videos):
             self.hf_dataset = None
             return False
         self._build_index_mapping()
@@ -192,8 +196,8 @@ class DatasetReader:
                 "or rerun the annotation pipeline's metadata synchronization."
             )
 
-    def _check_cached_episodes_sufficient(self) -> bool:
-        """Check if the cached dataset contains all requested episodes and their video files."""
+    def _check_cached_episodes_sufficient(self, require_videos: bool = True) -> bool:
+        """Check if the cache contains all requested episodes and, when required, their videos."""
         if self.hf_dataset is None or len(self.hf_dataset) == 0:
             return False
 
@@ -210,7 +214,7 @@ class DatasetReader:
         if not requested_episodes.issubset(available_episodes):
             return False
 
-        if len(self._meta.video_keys) > 0:
+        if require_videos and len(self._meta.video_keys) > 0:
             for ep_idx in requested_episodes:
                 for vid_key in self._meta.video_keys:
                     video_path = self.root / self._meta.get_video_file_path(ep_idx, vid_key)

--- a/src/lerobot/datasets/lerobot_dataset.py
+++ b/src/lerobot/datasets/lerobot_dataset.py
@@ -180,9 +180,10 @@ class LeRobotDataset(torch.utils.data.Dataset):
                 are already present in the local cache, this will be faster. However, files loaded might not
                 be in sync with the version on the hub, especially if you specified 'revision'. Defaults to
                 False.
-            download_videos (bool, optional): Flag to download the videos. Note that when set to True but the
-                video files are already present on local disk, they won't be downloaded again. Defaults to
-                True.
+            download_videos (bool, optional): Flag to download the videos. When set to ``False``, a cache
+                containing all requested Parquet data is considered sufficient even if its video files are
+                absent. When set to ``True`` but the videos are already present on local disk, they won't be
+                downloaded again. Defaults to True.
             video_backend (str | None, optional): Video backend to use for decoding videos. Defaults to torchcodec when available int the platform; otherwise, defaults to 'pyav'.
                 You can also use the 'pyav' decoder used by Torchvision, which used to be the default option, or 'video_reader' which is another decoder of Torchvision.
             batch_encoding_size (int, optional): Number of episodes to accumulate before batch encoding videos.
@@ -269,7 +270,7 @@ class LeRobotDataset(torch.utils.data.Dataset):
         self.image_transforms = image_transforms
 
         # Load actual data
-        if force_cache_sync or not self.reader.try_load():
+        if force_cache_sync or not self.reader.try_load(require_videos=download_videos):
             if is_valid_version(self.revision):
                 if token is None:
                     self.revision = get_safe_version(self.repo_id, self.revision)

--- a/tests/datasets/test_dataset_reader.py
+++ b/tests/datasets/test_dataset_reader.py
@@ -16,6 +16,7 @@
 """Contract tests for DatasetReader."""
 
 import json
+import shutil
 import sys
 import types
 
@@ -74,6 +75,29 @@ def test_try_load_returns_false_when_no_data(tmp_path):
     )
     assert reader.try_load() is False
     assert reader.hf_dataset is None
+
+
+def test_try_load_requires_videos_by_default(tmp_path, lerobot_dataset_factory):
+    """A cache whose video files are missing is insufficient by default, but accepted with require_videos=False."""
+    dataset = lerobot_dataset_factory(
+        root=tmp_path / "ds", total_episodes=2, total_frames=20, use_videos=True
+    )
+    assert dataset.meta.video_keys
+    shutil.rmtree(dataset.root / "videos")
+
+    reader = DatasetReader(
+        meta=dataset.meta,
+        root=dataset.root,
+        episodes=None,
+        tolerance_s=1e-4,
+        video_backend=get_safe_default_video_backend(),
+        delta_timestamps=None,
+        image_transforms=None,
+    )
+    assert reader.try_load() is False
+    assert reader.hf_dataset is None
+    assert reader.try_load(require_videos=False) is True
+    assert reader.hf_dataset is not None
 
 
 def test_load_rejects_language_columns_missing_from_metadata(tmp_path, lerobot_dataset_factory):

--- a/tests/datasets/test_lerobot_dataset.py
+++ b/tests/datasets/test_lerobot_dataset.py
@@ -122,6 +122,32 @@ def test_init_loads_data(tmp_path, lerobot_dataset_factory):
     assert len(dataset) > 0
 
 
+def test_init_data_only_uses_cached_parquet_without_videos(tmp_path, lerobot_dataset_factory, monkeypatch):
+    """download_videos=False accepts a complete data cache without video files."""
+    cached = lerobot_dataset_factory(
+        root=tmp_path / "ds",
+        total_episodes=1,
+        total_frames=10,
+        use_videos=True,
+        download_videos=False,
+    )
+    assert cached.meta.video_keys
+    assert not (cached.root / "videos").exists()
+
+    snapshot_download = Mock(side_effect=AssertionError("cached data should not trigger a Hub download"))
+    monkeypatch.setattr(lerobot_dataset_module, "snapshot_download", snapshot_download)
+    monkeypatch.setattr(lerobot_dataset_module, "get_safe_version", lambda repo_id, revision: revision)
+
+    reloaded = LeRobotDataset(
+        repo_id=cached.repo_id,
+        root=cached.root,
+        download_videos=False,
+    )
+
+    assert len(reloaded) == len(cached)
+    snapshot_download.assert_not_called()
+
+
 def test_getitem_works_in_read_mode(tmp_path, lerobot_dataset_factory):
     """dataset[0] returns a dict with expected keys in read-only mode."""
     dataset = lerobot_dataset_factory(

--- a/tests/datasets/test_lerobot_dataset.py
+++ b/tests/datasets/test_lerobot_dataset.py
@@ -19,6 +19,7 @@ Tests focus on mode contracts (read-only, write-only, resume), guards,
 property delegation, and the full create-record-finalize-read lifecycle.
 """
 
+import shutil
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import Mock
@@ -146,6 +147,28 @@ def test_init_data_only_uses_cached_parquet_without_videos(tmp_path, lerobot_dat
 
     assert len(reloaded) == len(cached)
     snapshot_download.assert_not_called()
+
+
+def test_init_default_config_attempts_download_when_videos_missing(
+    tmp_path, lerobot_dataset_factory, monkeypatch
+):
+    """With the default download_videos=True, a cache without video files is insufficient — download is attempted."""
+    cached = lerobot_dataset_factory(
+        root=tmp_path / "ds",
+        total_episodes=1,
+        total_frames=10,
+        use_videos=True,
+    )
+    assert cached.meta.video_keys
+    shutil.rmtree(cached.root / "videos")
+
+    snapshot_download = Mock(return_value=None)
+    monkeypatch.setattr(lerobot_dataset_module, "snapshot_download", snapshot_download)
+    monkeypatch.setattr(lerobot_dataset_module, "get_safe_version", lambda repo_id, revision: revision)
+
+    LeRobotDataset(repo_id=cached.repo_id, root=cached.root)
+
+    snapshot_download.assert_called()
 
 
 def test_getitem_works_in_read_mode(tmp_path, lerobot_dataset_factory):


### PR DESCRIPTION
## Summary / Motivation

`LeRobotDataset(download_videos=False)` is intended to support data-only workflows that read metadata and Parquet columns without downloading video files. However, the local cache validation path still required every referenced video file to exist.

As a result, reopening a complete Parquet-only cache triggered an unnecessary Hub download and prevented numeric-only dataset analysis from working fully offline. This change aligns cache validation with the caller's explicit `download_videos` choice while preserving the existing default behavior.

## Related issues

- Related: #3760
- Related: #4396

## What changed

- Added a `require_videos` option to `DatasetReader.try_load()` and its cache sufficiency check.
- Forwarded `LeRobotDataset(download_videos=...)` to the cache validation path.
- Allowed complete episode Parquet data to satisfy cache validation when `download_videos=False`.
- Added a regression test proving that reopening a Parquet-only cache does not call `snapshot_download`.
- Clarified the `download_videos` behavior in the `LeRobotDataset` docstring.

This introduces no breaking changes. The default `download_videos=True` path still requires cached video files.

## How was this tested (or how to run locally)

- `pytest tests/datasets/test_dataset_reader.py tests/datasets/test_lerobot_dataset.py -q` — 46 passed
- `pytest tests/datasets/test_datasets.py -q -k check_cached_episodes_sufficient` — 1 passed
- `ruff format --check` on the modified files — passed
- `ruff check` on the modified files — passed
- `mypy --config-file=pyproject.toml` on the modified source files — passed
- The new regression test was also verified against the original implementation and failed because `snapshot_download` was called.

Quick reviewer reproduction:

```bash
pytest -q tests/datasets/test_lerobot_dataset.py \
  -k data_only_uses_cached_parquet_without_videos
```

## Checklist (required before merge)

- [ ] Linting/formatting run (`pre-commit run -a`)
- [ ] All tests pass locally (`pytest`)
- [x] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: # (pending)

## Reviewer notes

- `require_videos` defaults to `True`, so existing `DatasetReader` callers preserve their current behavior.
- Video checks are skipped only when the caller explicitly requests `download_videos=False`.
- This change does not modify video decoding or dataset contents.

## AI assistance disclosure

Codex assisted with duplicate-contribution analysis, implementation, and test preparation. I reviewed the cache-loading behavior, regression coverage, and interaction with the broader `LeRobotDataset` API.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to offline cache validation with default behavior unchanged; no changes to download, decoding, or dataset contents beyond when a cache is accepted.
> 
> **Overview**
> **`LeRobotDataset(download_videos=False)`** now treats a local cache with complete Parquet for the requested episodes as sufficient, even when metadata references videos that are not on disk. Previously, cache validation always required every video file to exist, which forced a Hub re-download when reopening a data-only cache.
> 
> `DatasetReader.try_load()` and `_check_cached_episodes_sufficient()` gain a **`require_videos`** flag (default **`True`**). `LeRobotDataset` passes **`download_videos`** into **`try_load`**, so video presence is checked only when callers want videos. The **`download_videos`** docstring is updated to describe this behavior.
> 
> A regression test confirms that reopening a Parquet-only cache with **`download_videos=False`** does not call **`snapshot_download`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2943cd60538301ac882a63536e82cb776ec7c5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->