### PR TITLE
Repair three broken developer entry points (Makefile, hub API, annotation smoke)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,9 @@ PYTHON_PATH := $(shell which python)
 # If uv is installed and a virtual environment exists, use it
 UV_CHECK := $(shell command -v uv)
 ifneq ($(UV_CHECK),)
-	PYTHON_PATH := $(shell .venv/bin/python)
+ifneq ($(wildcard .venv/bin/python),)
+	PYTHON_PATH := $(abspath .venv/bin/python)
+endif
 endif
 
 export PATH := $(dir $(PYTHON_PATH)):$(PATH)

--- a/examples/dataset/load_lerobot_dataset.py
+++ b/examples/dataset/load_lerobot_dataset.py
@@ -37,7 +37,7 @@ from lerobot.datasets import LeRobotDataset, LeRobotDatasetMetadata
 def main():
     # Browse datasets created/ported by the community on the hub using the hub api:
     hub_api = HfApi()
-    repo_ids = [info.id for info in hub_api.list_datasets(task_categories="robotics", tags=["LeRobot"])]
+    repo_ids = [info.id for info in hub_api.list_datasets(task_categories="robotics", filter=["LeRobot"])]
     pprint(repo_ids)
 
     # Or simply explore them in your web browser directly at:

--- a/tests/annotations/run_e2e_smoke.py
+++ b/tests/annotations/run_e2e_smoke.py
@@ -52,7 +52,7 @@ def _stub_responder(messages):
                         text = block.get("text", "")
             elif isinstance(content, str):
                 text = content
-    if "atomic subtasks" in text:
+    if "COMPLETED manipulation events" in text:
         return {
             "subtasks": [
                 {"text": "grasp the bottle", "start": 0.0, "end": 1.0},


### PR DESCRIPTION
## What this does

Three small, unrelated fixes, each to a command the repo documents. They're grouped because
they're all tiny; very happy to split them into separate PRs if you'd rather review them
apart.

### 1. `make test-end-to-end` cannot find `lerobot-train`

`Makefile:22` runs the interpreter instead of locating it:

```make
PYTHON_PATH := $(shell .venv/bin/python)
```

`$(shell ...)` captures the command's *output*, and `python` with no arguments prints
nothing, so `PYTHON_PATH` ends up empty and `export PATH := $(dir $(PYTHON_PATH)):$(PATH)`
prepends an empty component. Every e2e target then fails:

```
/bin/sh: 1: lerobot-train: not found
make[1]: *** [Makefile:47: test-act-ete-train] Error 127
```

There's a second effect that cost me a little time: when stdin is a terminal, that same
line starts an interactive Python REPL — you get the interpreter banner and a `>>>` prompt
(on stderr, so `$(shell ...)` doesn't swallow them) and `make -n <target>` sits there
waiting for input.

Changed to `$(abspath .venv/bin/python)`, guarded by a `wildcard` check so it only applies
when the venv actually exists — which I think matches the intent of the comment above it.

With this, `DEVICE=cuda make test-end-to-end` runs all nine targets to completion here.

### 2. `examples/dataset/load_lerobot_dataset.py` uses a removed `huggingface_hub` kwarg

```python
repo_ids = [info.id for info in hub_api.list_datasets(task_categories="robotics", tags=["LeRobot"])]
```

```
TypeError: HfApi.list_datasets() got an unexpected keyword argument 'tags'
```

`HfApi.list_datasets` takes `filter` rather than `tags` in `huggingface_hub` 1.x. This
isn't only a "recent version" problem — `pyproject.toml` pins
`huggingface-hub>=1.6.0,<2.0.0`, and v1.6.0's signature already has `filter` and
`task_categories` but no `tags`, so the example cannot run at the declared floor.

Switched to `filter=["LeRobot"]`, which returns the LeRobot-tagged datasets. (I can't
compare against the old behaviour directly, since the previous call raises before returning
anything.)

### 3. `make annotation-e2e` passes, but most of the pipeline is inert

The stub VLM in `tests/annotations/run_e2e_smoke.py:55` keys its subtask response on the
string `"atomic subtasks"`, which
`src/lerobot/annotations/steerable_pipeline/prompts/plan_subtasks.txt` no longer contains — it now
says "Reconstruct the sequence of COMPLETED manipulation events". The responder returns
`None`, the plan module produces no spans, and the interjections module then exits early at its
"need at least one transition" guard
(`modules/interjections_and_speech.py`, `_mid_episode_interjections`).

The run still prints a green-looking report:

```
phases=[('plan', 1), ('interjections', 1), ('plan_update', 0), ('vqa', 1)]
validation: checked=1 errors=0 warnings=1
interjections=0 speech_atoms=1
AssertionError: no interjection rows produced — check the interjection prompt marker
```

The assertion does catch it, so this is really just the stub drifting from the prompt.
Keyed it on `"COMPLETED manipulation events"`, which is what the passing tests in
`tests/annotations/test_modules.py` already use.

After the change:

```
phases=[('plan', 1), ('interjections', 1), ('plan_update', 1), ('vqa', 1)]
validation: checked=1 errors=0 warnings=0
interjections=1 speech_atoms=2
```

The plan-update phase and the orphan-speech warning both moving is what convinced me the
whole downstream path had been inert rather than merely untested.

## Testing

```
tests/annotations    36 passed
tests/datasets      568 passed, 8 skipped
DEVICE=cuda make test-end-to-end    all 9 targets, exit 0
python examples/dataset/load_lerobot_dataset.py    exit 0
```

(The example also needs the decoder-cache fix in #4526 to get all the way through its final
`DataLoader` section; item 2 here fixes the first thing it hits. The two PRs are
independent and can be reviewed in either order.)

Thanks for maintaining all this.
