### PR TITLE
Give each forked DataLoader worker its own VideoDecoder

### DIFF
--- a/src/lerobot/datasets/video_utils.py
+++ b/src/lerobot/datasets/video_utils.py
@@ -281,9 +281,27 @@ class VideoDecoderCache:
         self.max_size: int | None = max_size  # type: ignore[assignment]
         self._cache: OrderedDict[str, tuple[Any, Any]] = OrderedDict()
         self._lock = Lock()
+        self._owner_pid = os.getpid()
+
+    def _drop_inherited_entries(self) -> None:
+        """Drop entries inherited across a ``fork``.
+
+        ``DataLoader`` workers fork the parent, so a decoder built in the parent
+        reaches the child sharing the parent's file offset. Both processes then
+        seek the same handle and torchcodec fails with "Could not push packet to
+        decoder". The entries are dropped rather than closed: the handles still
+        belong to the parent, which keeps using them.
+
+        Callers must hold ``self._lock``.
+        """
+        pid = os.getpid()
+        if pid != self._owner_pid:
+            self._cache = OrderedDict()
+            self._owner_pid = pid
 
     def __contains__(self, video_path: object) -> bool:
         with self._lock:
+            self._drop_inherited_entries()
             return str(video_path) in self._cache
 
     def get_decoder(self, video_path: str):
@@ -299,6 +317,7 @@ class VideoDecoderCache:
         video_path = str(video_path)
 
         with self._lock:
+            self._drop_inherited_entries()
             entry = self._cache.get(video_path)
             if entry is not None:
                 self._cache.move_to_end(video_path)
@@ -334,6 +353,7 @@ class VideoDecoderCache:
     def size(self) -> int:
         """Return the number of cached decoders."""
         with self._lock:
+            self._drop_inherited_entries()
             return len(self._cache)
 
 

--- a/tests/datasets/test_video_decoder_cache.py
+++ b/tests/datasets/test_video_decoder_cache.py
@@ -21,6 +21,7 @@ unbounded growth when iterating over datasets with many distinct video files
 (observed: ~35 GB anon-rss per DataLoader worker on an 8 k-file dataset).
 """
 
+import os
 import shutil
 from pathlib import Path
 
@@ -127,6 +128,42 @@ class TestVideoDecoderCacheBounded:
         for p in paths:
             cache.get_decoder(p)
         assert cache.size() == 4
+
+    def test_forked_child_gets_its_own_decoder(self, tmp_path):
+        """A decoder built before a fork must not be reused by the child.
+
+        ``DataLoader`` workers are forked, so an inherited entry hands the child a
+        decoder whose fsspec handle shares the parent's file offset. Both processes
+        then seek it and torchcodec fails with "Could not push packet to decoder".
+        """
+        paths = _make_distinct_clips(tmp_path, n=1)
+        cache = VideoDecoderCache(max_size=4)
+        parent_decoder = cache.get_decoder(paths[0])
+        assert cache.size() == 1
+
+        read_fd, write_fd = os.pipe()
+        pid = os.fork()
+        if pid == 0:  # child
+            verdict = b"0"
+            try:
+                os.close(read_fd)
+                dropped = str(paths[0]) not in cache and cache.size() == 0
+                child_decoder = cache.get_decoder(paths[0])
+                if dropped and child_decoder is not parent_decoder:
+                    verdict = b"1"
+                os.write(write_fd, verdict)
+                os._exit(0)
+            except BaseException:  # noqa: BLE001 - the parent asserts on the exit status
+                os._exit(1)
+
+        os.close(write_fd)
+        payload = os.read(read_fd, 1)
+        os.close(read_fd)
+        _, status = os.waitpid(pid, 0)
+
+        assert os.WIFEXITED(status), "forked child did not exit cleanly"
+        assert os.WEXITSTATUS(status) == 0
+        assert payload == b"1", "forked child reused the parent's decoder"
 
     def test_env_var_overrides_default(self, tmp_path, monkeypatch):
         """``LEROBOT_VIDEO_DECODER_CACHE_SIZE`` env var sets the default ``max_size``."""


### PR DESCRIPTION
## What this does

Makes `VideoDecoderCache` drop entries it inherited across a `fork`, so a DataLoader
worker builds its own `VideoDecoder` instead of reusing the one its parent created.

## Why

`DataLoader` workers are forked, so a decoder built in the parent process arrives in the
child sharing the parent's `fsspec` file handle and its offset. When both processes then
read through that handle, decoding fails in the worker:

```
RuntimeError: Caught RuntimeError in DataLoader worker process 0.
  File "src/lerobot/datasets/video_utils.py", line 389, in decode_video_frames_torchcodec
    frames_batch = decoder.get_frames_at(indices=frame_indices)
RuntimeError: decodeAVFrame, .../SingleStreamDecoder.cpp:1397,
Could not push packet to decoder: Invalid data found when processing input
```

The streaming sibling of this path, `StreamingLeRobotDataset._query_videos`
(`streaming_dataset.py:618`), already carries a docstring warning about calling it from the
main process when workers are in use. I think this is the same hazard, one layer down and
on the non-streaming path.

### Relationship to #2488

This looks like the underlying cause of #2488, and I want to be careful about how I put
that, because it was closed as fixed by #4139 and I may well be missing context.

As far as I can tell #4139 fixed it for training by defaulting
`dataloader_multiprocessing_context` to `spawn` in `configs/train.py` and
`scripts/lerobot_train.py`, which does resolve it for `lerobot-train`. What I ran into is
that the repro from the original report — `python examples/dataset/load_lerobot_dataset.py`
— still fails, because the example constructs its own `DataLoader` with the default (fork)
context. Anything else building a `DataLoader` directly is in the same position.

I first hit this on 0.6.1, then reproduced it directly on `main` at `bf31dd794ffb`: the
snippet below fails there unpatched and passes with this change applied.

If you'd prefer this handled by documenting `spawn` for library consumers rather than by
changing the cache, I'm happy to close this and do that instead.

## Isolating it

The two branches differ only in whether one frame is decoded in the parent before the
`DataLoader` is built:

```python
ds = LeRobotDataset("lerobot/aloha_mobile_cabinet", delta_timestamps=...)
if touch:
    _ = ds[0][camera_key]          # decode in the parent, as the example does
dl = torch.utils.data.DataLoader(ds, num_workers=4, batch_size=32, shuffle=True)
for i, batch in enumerate(dl):
    if i >= 3:
        break
```

| | before this PR | after |
|---|---|---|
| `touch=True` (parent decodes first) | `RuntimeError` above | OK |
| `touch=False` | OK | OK |

Two caveats. I could not reproduce it on `lerobot/pusht`, whose video is a
single ~6.9 MB file; `lerobot/aloha_mobile_cabinet`, whose cameras each have a ~520 MB
first file (plus second files of 120 / 32 / 16 MB), reproduces every time. My guess is that a small file ends up fully buffered so no
real seeking happens, but I haven't pinned that down, so I've written the fix and the test
around the invariant — a forked child must not reuse its parent's decoder — rather than
around the crash.

Also worth flagging: `examples/dataset/load_lerobot_dataset.py` currently stops earlier
than this, on a `list_datasets(tags=...)` call that `huggingface_hub` 1.x no longer
accepts. That one-liner is in #4525; with both applied the example runs to completion.
The two are independent, so they can be reviewed in either order.

## The change

`VideoDecoderCache` records the PID that created it. When a cached lookup happens in a
different process, the inherited entries are dropped and the cache is rebuilt on demand.
Entries are dropped rather than closed, since the handles still belong to the parent, which
goes on using them.

## Tests

Added `test_forked_child_gets_its_own_decoder` to `tests/datasets/test_video_decoder_cache.py`.
It populates the cache, forks, and checks in the child that the entry is gone and that
`get_decoder` returns a different instance, reporting back over a pipe.

As a check that the test actually observes the fix, I stubbed `_drop_inherited_entries` to
a no-op and re-ran it: it fails with the guard disabled and passes with it in place.

```
tests/datasets/test_video_decoder_cache.py .........  9 passed
tests/datasets                                        568 passed, 8 skipped
```

Thanks for taking a look — happy to be corrected if I've read the #2488 status wrong.
