### PR TITLE
fix(record): preserve compressed image setting during reset

### DIFF
--- a/src/lerobot/scripts/lerobot_record.py
+++ b/src/lerobot/scripts/lerobot_record.py
@@ -531,6 +531,7 @@ def record(
                         single_task=cfg.dataset.single_task,
                         display_data=cfg.display_data,
                         display_mode=cfg.display_mode,
+                        display_compressed_images=display_compressed_images,
                     )
 
                 if events["rerecord_episode"]:

--- a/tests/test_control_robot.py
+++ b/tests/test_control_robot.py
@@ -189,6 +189,36 @@ def test_record_reports_a_cadence_summary_per_episode_and_for_the_run(tmp_path, 
     assert _step_calls(run, "record") == _step_calls(run, "observe") == _ticks(run)
 
 
+def test_record_forwards_compressed_images_setting_to_reset_phase(tmp_path):
+    robot_cfg = MockRobotConfig()
+    teleop_cfg = MockTeleopConfig()
+    dataset_cfg = DatasetRecordConfig(
+        repo_id=DUMMY_REPO_ID,
+        single_task="Dummy task",
+        root=tmp_path / "compressed_images",
+        num_episodes=2,
+        episode_time_s=0.1,
+        reset_time_s=0.1,
+        push_to_hub=False,
+    )
+    cfg = RecordConfig(
+        robot=robot_cfg,
+        dataset=dataset_cfg,
+        teleop=teleop_cfg,
+        display_compressed_images=True,
+        play_sounds=False,
+    )
+
+    with patch("lerobot.scripts.lerobot_record.record_loop", wraps=record_loop) as mock_record_loop:
+        record(cfg)
+
+    # Recording episode 0, resetting, then recording episode 1 should all use the same
+    # image representation so visualization backends do not receive mixed message types.
+    assert [
+        call.kwargs.get("display_compressed_images", False) for call in mock_record_loop.call_args_list
+    ] == [True, True, True]
+
+
 def test_record_loop_without_a_teleoperator_paces_and_terminates():
     # Regression: the no-teleop branch used to `continue` past both the pacing sleep and
     # the `timestamp` update, so a reset phase with no teleop device spun as fast as the


### PR DESCRIPTION
## Summary / Motivation

When `lerobot-record` displays compressed images, its reset phase currently falls back to raw images because it does not forward `display_compressed_images` to `record_loop`. With Foxglove, this changes the published message type during reset and can crash the client when an episode is stopped or re-recorded.

This keeps the image representation consistent across recording and reset phases.

## Related issues

* Fixes #4483

## What changed

* Forward the resolved `display_compressed_images` value to the reset-phase `record_loop` call.
* Add a regression test covering episode recording, reset, and the following episode.
* No breaking changes.

## How was this tested

* `uv run pytest -q tests/test_control_robot.py` — 7 passed
* Ruff lint — passed
* Ruff formatting — passed
* Without the fix: `[True, False, True]`
* With the fix: `[True, True, True]`

## Reviewer notes

The functional change is intentionally one line. The test ensures every `record_loop` phase uses the same compressed-image setting.

AI assistance was used to help implement and validate this narrowly scoped change; the resulting behaviour, diff, and regression evidence were reviewed before submission.
