### PR TITLE
fix(streaming): use video-file-relative timestamps

### DIFF
--- a/src/lerobot/datasets/streaming_dataset.py
+++ b/src/lerobot/datasets/streaming_dataset.py
@@ -479,17 +479,18 @@ class StreamingLeRobotDataset(torch.utils.data.IterableDataset):
         return Backtrackable(dataset, history=lookback, lookahead=lookahead)
 
     def _make_timestamps_from_indices(
-        self, start_ts: float, indices: dict[str, list[int]] | None = None
+        self, start_timestamps: dict[str, float], indices: dict[str, list[int]] | None = None
     ) -> dict[str, list[float]]:
         if indices is not None:
             return {
                 key: (
-                    start_ts + torch.tensor(indices[key]) / self.fps
+                    start_timestamps[key] + torch.tensor(indices[key]) / self.fps
                 ).tolist()  # NOTE: why not delta_timestamps directly?
-                for key in self.delta_timestamps
+                for key in self.meta.video_keys
+                if key in indices
             }
         else:
-            return dict.fromkeys(self.meta.video_keys, [start_ts])
+            return {key: [start_timestamps[key]] for key in self.meta.video_keys}
 
     def _make_padding_camera_frame(self, camera_key: str):
         """Variable-shape padding frame for given camera keys, given in (H, W, C)"""
@@ -536,15 +537,16 @@ class StreamingLeRobotDataset(torch.utils.data.IterableDataset):
         # Get episode index from the item
         ep_idx = item["episode_index"]
 
-        # "timestamp" restarts from 0 for each episode, whereas we need a global timestep within the single .mp4 file (given by index/fps)
-        current_ts = item["index"] / self.fps
-
         episode_boundaries_ts = {
             key: (
                 self.meta.episodes[ep_idx][f"videos/{key}/from_timestamp"],
                 self.meta.episodes[ep_idx][f"videos/{key}/to_timestamp"],
             )
             for key in self.meta.video_keys
+        }
+        # Convert the episode-local timestamp to each video file's coordinate space.
+        current_timestamps = {
+            key: episode_boundaries_ts[key][0] + item["timestamp"] for key in self.meta.video_keys
         }
 
         # Apply delta querying logic if necessary
@@ -555,11 +557,11 @@ class StreamingLeRobotDataset(torch.utils.data.IterableDataset):
 
         # Load video frames, when needed
         if len(self.meta.video_keys) > 0:
-            original_timestamps = self._make_timestamps_from_indices(current_ts, self.delta_indices)
+            original_timestamps = self._make_timestamps_from_indices(current_timestamps, self.delta_indices)
 
             # Some timestamps might not result available considering the episode's boundaries
             query_timestamps = self._get_query_timestamps(
-                current_ts, self.delta_indices, episode_boundaries_ts
+                current_timestamps, self.delta_indices, episode_boundaries_ts
             )
             video_frames = self._query_videos(query_timestamps, ep_idx)
 
@@ -596,12 +598,12 @@ class StreamingLeRobotDataset(torch.utils.data.IterableDataset):
 
     def _get_query_timestamps(
         self,
-        current_ts: float,
+        current_timestamps: dict[str, float],
         query_indices: dict[str, list[int]] | None = None,
         episode_boundaries_ts: dict[str, tuple[float, float]] | None = None,
     ) -> dict[str, list[float]]:
         query_timestamps = {}
-        keys_to_timestamps = self._make_timestamps_from_indices(current_ts, query_indices)
+        keys_to_timestamps = self._make_timestamps_from_indices(current_timestamps, query_indices)
         for key in self.meta.video_keys:
             if query_indices is not None and key in query_indices:
                 timestamps = keys_to_timestamps[key]
@@ -611,7 +613,7 @@ class StreamingLeRobotDataset(torch.utils.data.IterableDataset):
                 ).tolist()
 
             else:
-                query_timestamps[key] = [current_ts]
+                query_timestamps[key] = [current_timestamps[key]]
 
         return query_timestamps
 

--- a/tests/datasets/test_streaming.py
+++ b/tests/datasets/test_streaming.py
@@ -303,6 +303,66 @@ def test_iter_raises_on_nested_generator_error(tmp_path, lerobot_dataset_factory
 
 
 @pytest.mark.parametrize(
+    ("delta_indices", "expected_timestamps"),
+    [
+        ({"action": [0, 1]}, {"camera_a": [5.2], "camera_b": [1.2]}),
+        (
+            {"camera_a": [-1, 0, 1], "camera_b": [-1, 0, 1]},
+            {"camera_a": [5.1, 5.2, 5.3], "camera_b": [1.1, 1.2, 1.3]},
+        ),
+    ],
+)
+def test_make_frame_uses_timestamps_relative_to_each_video_file(delta_indices, expected_timestamps):
+    """Video timestamps restart for every file and can differ between camera keys."""
+    streaming_ds = StreamingLeRobotDataset.__new__(StreamingLeRobotDataset)
+    streaming_ds.meta = SimpleNamespace(
+        fps=10,
+        video_keys=["camera_a", "camera_b"],
+        episodes={
+            7: {
+                "videos/camera_a/from_timestamp": 5.0,
+                "videos/camera_a/to_timestamp": 6.0,
+                "videos/camera_b/from_timestamp": 1.0,
+                "videos/camera_b/to_timestamp": 2.0,
+            }
+        },
+        tasks=SimpleNamespace(iloc=[SimpleNamespace(name="Dummy task")]),
+    )
+    streaming_ds.delta_indices = delta_indices
+    streaming_ds.delta_timestamps = {
+        key: [index / streaming_ds.fps for index in indices] for key, indices in delta_indices.items()
+    }
+    streaming_ds.image_transforms = None
+    streaming_ds._image_depth_units = {}
+    streaming_ds._depth_output_unit = "m"
+    streaming_ds._get_delta_frames = Mock(return_value=({}, {}))
+    streaming_ds._get_video_frame_padding_mask = Mock(return_value={})
+    streaming_ds._query_videos = Mock(return_value={"camera_a": torch.zeros(1), "camera_b": torch.zeros(1)})
+
+    item = {
+        "episode_index": 7,
+        "frame_index": 2,
+        "index": 1000,
+        "timestamp": 0.2,
+        "task_index": 0,
+    }
+    iterator = streaming_dataset_module.Backtrackable([item], history=3, lookahead=3)
+
+    next(streaming_ds.make_frame(iterator))
+
+    query_timestamps = streaming_ds._query_videos.call_args.args[0]
+    for key, expected in expected_timestamps.items():
+        assert query_timestamps[key] == pytest.approx(expected)
+
+    original_timestamps = streaming_ds._get_video_frame_padding_mask.call_args.args[2]
+    for key in streaming_ds.meta.video_keys:
+        if key in delta_indices:
+            assert original_timestamps[key] == pytest.approx(expected_timestamps[key])
+        else:
+            assert key not in original_timestamps
+
+
+@pytest.mark.parametrize(
     "state_deltas, action_deltas",
     [
         ([-1, -0.5, -0.20, 0], [0, 1, 2, 3]),


### PR DESCRIPTION
## Summary

Fixes #4524.

`StreamingLeRobotDataset.make_frame()` derived video timestamps from the dataset-global `index / fps`. Once a streaming dataset spans multiple video files, that coordinate no longer matches the current file. The no-video-delta path can query beyond the file, while video-delta queries are silently clamped to incorrect boundary frames.

This change:

* converts the episode-local timestamp into each video key’s file coordinates using its `from_timestamp`;
* keeps delta queries and padding comparisons in the same coordinate space;
* ignores non-video delta entries when constructing video timestamps.

The regression test covers two video keys with different offsets and verifies both the out-of-range decoder path and the silently clamped wrong-frame path.

## Validation

* `uv run pytest -q tests/datasets/test_streaming.py -k timestamps_relative_to_each_video_file` — 2 passed
* `uv run pytest -q tests/datasets/test_streaming.py` — 31 passed
* Ruff check and formatting — passed
* `git diff --check` — passed
