### PR TITLE
fix(utils): make bimanual lifecycle cleanup fail-safe

### DIFF
--- a/src/lerobot/utils/bimanual.py
+++ b/src/lerobot/utils/bimanual.py
@@ -54,25 +54,12 @@ class BimanualMixin:
             self.left_arm.connect(calibrate)
             self.right_arm.connect(calibrate)
         except Exception:
-            self._rollback_failed_connect()
+            self._disconnect_arms(after_failed_connect=True)
             raise
 
-    def _disconnect_arm_for_cleanup(self, arm: Any) -> None:
-        """Disconnect one arm while recovering from a failed startup.
-
-        Override this when cleanup has to be stronger than the arm's normal
-        ``disconnect()``: a motorized follower configured with
-        ``disable_torque_on_disconnect=False`` still has to end up torque-free
-        when the robot as a whole failed to come up.
-        """
+    def _disconnect_arm_after_failed_connect(self, arm: Any) -> None:
+        """Disconnect an arm while rolling back a failed bimanual startup."""
         arm.disconnect()
-
-    def _rollback_failed_connect(self) -> None:
-        """Release both arms without masking the error that triggered rollback."""
-        # The right arm goes first because it may hold the half-initialized
-        # resources of the attempt that just failed.
-        for arm_name, arm in (("right", self.right_arm), ("left", self.left_arm)):
-            self._release_arm(arm_name, arm, after_failed_connect=True)
 
     def calibrate(self) -> None:
         self.left_arm.calibrate()
@@ -83,24 +70,21 @@ class BimanualMixin:
         self.right_arm.configure()
 
     def disconnect(self) -> None:
-        """Release both arms, continuing if one of them fails.
+        self._disconnect_arms()
 
-        Safe to call repeatedly and after a partial connection, so a caller can
-        always shut the robot down in a ``finally`` block.
-        """
-        for arm_name, arm in (("left", self.left_arm), ("right", self.right_arm)):
-            self._release_arm(arm_name, arm, after_failed_connect=False)
-
-    def _release_arm(self, arm_name: str, arm: Any, *, after_failed_connect: bool) -> None:
-        """Disconnect one arm, logging instead of raising."""
-        try:
-            if after_failed_connect:
-                self._disconnect_arm_for_cleanup(arm)
-            else:
-                arm.disconnect()
-        except DeviceNotConnectedError:
-            # An arm that never came up, or that is already released, is the
-            # normal case here. Staying quiet keeps real cleanup faults visible.
-            logger.debug("The %s arm was already disconnected.", arm_name)
-        except Exception:
-            logger.exception("Failed to disconnect the %s arm during cleanup.", arm_name)
+    def _disconnect_arms(self, *, after_failed_connect: bool = False) -> None:
+        arms = (
+            (("right", self.right_arm), ("left", self.left_arm))
+            if after_failed_connect
+            else (("left", self.left_arm), ("right", self.right_arm))
+        )
+        for name, arm in arms:
+            try:
+                if after_failed_connect:
+                    self._disconnect_arm_after_failed_connect(arm)
+                else:
+                    arm.disconnect()
+            except DeviceNotConnectedError:
+                pass
+            except Exception:
+                logger.exception("Failed to disconnect the %s arm.", name)

--- a/src/lerobot/utils/bimanual.py
+++ b/src/lerobot/utils/bimanual.py
@@ -14,9 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 from typing import Any
 
-from lerobot.utils.decorators import check_if_already_connected, check_if_not_connected
+from lerobot.utils.decorators import check_if_already_connected
+from lerobot.utils.errors import DeviceNotConnectedError
+
+logger = logging.getLogger(__name__)
 
 
 class BimanualMixin:
@@ -46,8 +50,29 @@ class BimanualMixin:
 
     @check_if_already_connected
     def connect(self, calibrate: bool = True) -> None:
-        self.left_arm.connect(calibrate)
-        self.right_arm.connect(calibrate)
+        try:
+            self.left_arm.connect(calibrate)
+            self.right_arm.connect(calibrate)
+        except Exception:
+            self._rollback_failed_connect()
+            raise
+
+    def _disconnect_arm_for_cleanup(self, arm: Any) -> None:
+        """Disconnect one arm while recovering from a failed startup.
+
+        Override this when cleanup has to be stronger than the arm's normal
+        ``disconnect()``: a motorized follower configured with
+        ``disable_torque_on_disconnect=False`` still has to end up torque-free
+        when the robot as a whole failed to come up.
+        """
+        arm.disconnect()
+
+    def _rollback_failed_connect(self) -> None:
+        """Release both arms without masking the error that triggered rollback."""
+        # The right arm goes first because it may hold the half-initialized
+        # resources of the attempt that just failed.
+        for arm_name, arm in (("right", self.right_arm), ("left", self.left_arm)):
+            self._release_arm(arm_name, arm, after_failed_connect=True)
 
     def calibrate(self) -> None:
         self.left_arm.calibrate()
@@ -57,7 +82,25 @@ class BimanualMixin:
         self.left_arm.configure()
         self.right_arm.configure()
 
-    @check_if_not_connected
     def disconnect(self) -> None:
-        self.left_arm.disconnect()
-        self.right_arm.disconnect()
+        """Release both arms, continuing if one of them fails.
+
+        Safe to call repeatedly and after a partial connection, so a caller can
+        always shut the robot down in a ``finally`` block.
+        """
+        for arm_name, arm in (("left", self.left_arm), ("right", self.right_arm)):
+            self._release_arm(arm_name, arm, after_failed_connect=False)
+
+    def _release_arm(self, arm_name: str, arm: Any, *, after_failed_connect: bool) -> None:
+        """Disconnect one arm, logging instead of raising."""
+        try:
+            if after_failed_connect:
+                self._disconnect_arm_for_cleanup(arm)
+            else:
+                arm.disconnect()
+        except DeviceNotConnectedError:
+            # An arm that never came up, or that is already released, is the
+            # normal case here. Staying quiet keeps real cleanup faults visible.
+            logger.debug("The %s arm was already disconnected.", arm_name)
+        except Exception:
+            logger.exception("Failed to disconnect the %s arm during cleanup.", arm_name)

--- a/tests/utils/test_bimanual.py
+++ b/tests/utils/test_bimanual.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from lerobot.utils.bimanual import BimanualMixin
+from lerobot.utils.errors import DeviceNotConnectedError
+
+
+class _Bimanual(BimanualMixin):
+    def __init__(self, left_arm, right_arm):
+        self.left_arm = left_arm
+        self.right_arm = right_arm
+
+
+def _arm() -> MagicMock:
+    arm = MagicMock()
+    arm.is_connected = False
+    arm.is_calibrated = False
+    return arm
+
+
+def _errors(caplog) -> list[str]:
+    return [record.getMessage() for record in caplog.records if record.levelno >= logging.ERROR]
+
+
+def test_left_connect_failure_releases_both_arms():
+    left, right = _arm(), _arm()
+    failure = RuntimeError("left failed")
+    left.connect.side_effect = failure
+    robot = _Bimanual(left, right)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        robot.connect()
+
+    assert exc_info.value is failure
+    right.connect.assert_not_called()
+    left.disconnect.assert_called_once()
+    right.disconnect.assert_called_once()
+
+
+def test_right_connect_failure_releases_the_right_arm_first():
+    left, right = _arm(), _arm()
+    failure = RuntimeError("right failed")
+    right.connect.side_effect = failure
+    # The right arm may hold a half-initialized bus from the failed attempt.
+    released: list[str] = []
+    left.disconnect.side_effect = lambda: released.append("left")
+    right.disconnect.side_effect = lambda: released.append("right")
+    robot = _Bimanual(left, right)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        robot.connect()
+
+    assert exc_info.value is failure
+    assert released == ["right", "left"]
+
+
+def test_connect_reports_the_original_error_when_rollback_fails(caplog):
+    left, right = _arm(), _arm()
+    failure = RuntimeError("right failed")
+    right.connect.side_effect = failure
+    right.disconnect.side_effect = RuntimeError("right cleanup failed")
+    left.disconnect.side_effect = RuntimeError("left cleanup failed")
+    robot = _Bimanual(left, right)
+
+    with caplog.at_level(logging.DEBUG), pytest.raises(RuntimeError) as exc_info:
+        robot.connect()
+
+    assert exc_info.value is failure
+    assert _errors(caplog) == [
+        "Failed to disconnect the right arm during cleanup.",
+        "Failed to disconnect the left arm during cleanup.",
+    ]
+
+
+def test_rollback_stays_quiet_for_arms_that_never_connected(caplog):
+    left, right = _arm(), _arm()
+    left.connect.side_effect = RuntimeError("left failed")
+    # Arms guarded by `check_if_not_connected` raise when they never came up.
+    left.disconnect.side_effect = DeviceNotConnectedError()
+    right.disconnect.side_effect = DeviceNotConnectedError()
+    robot = _Bimanual(left, right)
+
+    with caplog.at_level(logging.DEBUG), pytest.raises(RuntimeError):
+        robot.connect()
+
+    assert _errors(caplog) == []
+
+
+def test_disconnect_attempts_both_arms_when_one_fails(caplog):
+    left, right = _arm(), _arm()
+    left.disconnect.side_effect = RuntimeError("left cleanup failed")
+    robot = _Bimanual(left, right)
+
+    with caplog.at_level(logging.DEBUG):
+        robot.disconnect()
+
+    right.disconnect.assert_called_once()
+    assert _errors(caplog) == ["Failed to disconnect the left arm during cleanup."]
+
+
+def test_repeated_disconnect_is_quiet_once_the_arms_are_released(caplog):
+    left, right = _arm(), _arm()
+    left.disconnect.side_effect = DeviceNotConnectedError()
+    right.disconnect.side_effect = DeviceNotConnectedError()
+    robot = _Bimanual(left, right)
+
+    with caplog.at_level(logging.DEBUG):
+        robot.disconnect()
+        robot.disconnect()
+
+    assert left.disconnect.call_count == 2
+    assert right.disconnect.call_count == 2
+    assert _errors(caplog) == []
+
+
+def test_disconnect_uses_the_arms_configured_behavior():
+    # The cleanup hook may force torque off, which must not leak into the
+    # normal disconnect path.
+    left, right = _arm(), _arm()
+    robot = _Bimanual(left, right)
+    robot._disconnect_arm_for_cleanup = MagicMock()
+
+    robot.disconnect()
+
+    robot._disconnect_arm_for_cleanup.assert_not_called()
+    left.disconnect.assert_called_once()
+    right.disconnect.assert_called_once()
+
+
+def test_rollback_uses_the_cleanup_hook():
+    left, right = _arm(), _arm()
+    right.connect.side_effect = RuntimeError("right failed")
+    robot = _Bimanual(left, right)
+    robot._disconnect_arm_for_cleanup = MagicMock()
+
+    with pytest.raises(RuntimeError):
+        robot.connect()
+
+    assert robot._disconnect_arm_for_cleanup.call_count == 2
+    left.disconnect.assert_not_called()
+    right.disconnect.assert_not_called()

--- a/tests/utils/test_bimanual.py
+++ b/tests/utils/test_bimanual.py
@@ -36,11 +36,7 @@ def _arm() -> MagicMock:
     return arm
 
 
-def _errors(caplog) -> list[str]:
-    return [record.getMessage() for record in caplog.records if record.levelno >= logging.ERROR]
-
-
-def test_left_connect_failure_releases_both_arms():
+def test_connect_rolls_back_when_left_arm_fails():
     left, right = _arm(), _arm()
     failure = RuntimeError("left failed")
     left.connect.side_effect = failure
@@ -55,105 +51,83 @@ def test_left_connect_failure_releases_both_arms():
     right.disconnect.assert_called_once()
 
 
-def test_right_connect_failure_releases_the_right_arm_first():
+def test_connect_rolls_back_when_right_arm_fails():
     left, right = _arm(), _arm()
     failure = RuntimeError("right failed")
     right.connect.side_effect = failure
-    # The right arm may hold a half-initialized bus from the failed attempt.
-    released: list[str] = []
-    left.disconnect.side_effect = lambda: released.append("left")
-    right.disconnect.side_effect = lambda: released.append("right")
+    disconnected = []
+    left.disconnect.side_effect = lambda: disconnected.append("left")
+    right.disconnect.side_effect = lambda: disconnected.append("right")
     robot = _Bimanual(left, right)
 
     with pytest.raises(RuntimeError) as exc_info:
         robot.connect()
 
     assert exc_info.value is failure
-    assert released == ["right", "left"]
+    assert disconnected == ["right", "left"]
 
 
-def test_connect_reports_the_original_error_when_rollback_fails(caplog):
+def test_connect_keeps_original_error_if_rollback_fails(caplog):
     left, right = _arm(), _arm()
     failure = RuntimeError("right failed")
     right.connect.side_effect = failure
-    right.disconnect.side_effect = RuntimeError("right cleanup failed")
     left.disconnect.side_effect = RuntimeError("left cleanup failed")
+    right.disconnect.side_effect = RuntimeError("right cleanup failed")
     robot = _Bimanual(left, right)
 
-    with caplog.at_level(logging.DEBUG), pytest.raises(RuntimeError) as exc_info:
+    with caplog.at_level(logging.ERROR), pytest.raises(RuntimeError) as exc_info:
         robot.connect()
 
     assert exc_info.value is failure
-    assert _errors(caplog) == [
-        "Failed to disconnect the right arm during cleanup.",
-        "Failed to disconnect the left arm during cleanup.",
+    assert [record.getMessage() for record in caplog.records] == [
+        "Failed to disconnect the right arm.",
+        "Failed to disconnect the left arm.",
     ]
 
 
-def test_rollback_stays_quiet_for_arms_that_never_connected(caplog):
+def test_disconnect_continues_when_one_arm_fails(caplog):
     left, right = _arm(), _arm()
-    left.connect.side_effect = RuntimeError("left failed")
-    # Arms guarded by `check_if_not_connected` raise when they never came up.
-    left.disconnect.side_effect = DeviceNotConnectedError()
-    right.disconnect.side_effect = DeviceNotConnectedError()
-    robot = _Bimanual(left, right)
-
-    with caplog.at_level(logging.DEBUG), pytest.raises(RuntimeError):
-        robot.connect()
-
-    assert _errors(caplog) == []
-
-
-def test_disconnect_attempts_both_arms_when_one_fails(caplog):
-    left, right = _arm(), _arm()
+    left.is_connected = True
+    right.is_connected = True
     left.disconnect.side_effect = RuntimeError("left cleanup failed")
     robot = _Bimanual(left, right)
 
-    with caplog.at_level(logging.DEBUG):
+    with caplog.at_level(logging.ERROR):
         robot.disconnect()
 
     right.disconnect.assert_called_once()
-    assert _errors(caplog) == ["Failed to disconnect the left arm during cleanup."]
+    assert [record.getMessage() for record in caplog.records] == [
+        "Failed to disconnect the left arm.",
+    ]
 
 
-def test_repeated_disconnect_is_quiet_once_the_arms_are_released(caplog):
+def test_disconnect_handles_partial_and_repeated_cleanup():
     left, right = _arm(), _arm()
-    left.disconnect.side_effect = DeviceNotConnectedError()
+    left.is_connected = True
     right.disconnect.side_effect = DeviceNotConnectedError()
     robot = _Bimanual(left, right)
 
-    with caplog.at_level(logging.DEBUG):
-        robot.disconnect()
-        robot.disconnect()
+    robot.disconnect()
+    robot.disconnect()
 
     assert left.disconnect.call_count == 2
     assert right.disconnect.call_count == 2
-    assert _errors(caplog) == []
 
 
-def test_disconnect_uses_the_arms_configured_behavior():
-    # The cleanup hook may force torque off, which must not leak into the
-    # normal disconnect path.
-    left, right = _arm(), _arm()
-    robot = _Bimanual(left, right)
-    robot._disconnect_arm_for_cleanup = MagicMock()
-
-    robot.disconnect()
-
-    robot._disconnect_arm_for_cleanup.assert_not_called()
-    left.disconnect.assert_called_once()
-    right.disconnect.assert_called_once()
-
-
-def test_rollback_uses_the_cleanup_hook():
+def test_failed_connect_uses_cleanup_hook_only_for_rollback():
     left, right = _arm(), _arm()
     right.connect.side_effect = RuntimeError("right failed")
     robot = _Bimanual(left, right)
-    robot._disconnect_arm_for_cleanup = MagicMock()
+    robot._disconnect_arm_after_failed_connect = MagicMock()
 
     with pytest.raises(RuntimeError):
         robot.connect()
 
-    assert robot._disconnect_arm_for_cleanup.call_count == 2
-    left.disconnect.assert_not_called()
-    right.disconnect.assert_not_called()
+    assert robot._disconnect_arm_after_failed_connect.call_count == 2
+
+    robot._disconnect_arm_after_failed_connect.reset_mock()
+    robot.disconnect()
+
+    robot._disconnect_arm_after_failed_connect.assert_not_called()
+    left.disconnect.assert_called_once()
+    right.disconnect.assert_called_once()


### PR DESCRIPTION
## Title

fix(utils): make bimanual lifecycle cleanup fail-safe

## Summary / Motivation

`BimanualMixin` currently connects both arms sequentially without safely undoing a partial startup if either connection fails. Its disconnection also stops after the first exception, potentially leaving the other arm connected or torque-enabled.

This PR makes bimanual lifecycle handling atomic and best-effort across robots and teleoperators. Failed startup releases both arms while preserving the original error, and disconnection remains safe after partial startup or repeated calls.

## Related issues

- Fixes / Closes: #4529
- Related: None

## What changed

- Roll back both arms when either arm fails during `connect()`.
- Clean the right arm first after failed startup because it may be partially initialized.
- Preserve the original connection exception while logging cleanup failures.
- Always attempt to disconnect both arms, even if one fails.
- Make `disconnect()` safe after partial startup and on repeated calls.
- Ignore `DeviceNotConnectedError` during cleanup because an arm may already be disconnected or may never have connected.
- Add `_disconnect_arm_after_failed_connect()` as an override point for hardware requiring stronger failure cleanup.
- Remove the bimanual-level `check_if_not_connected` guard from `disconnect()`. A partially connected device reports `is_connected=False` while still owning resources that must be released.
- Add focused lifecycle tests in `tests/utils/test_bimanual.py`.
- No user migration is required.

## How was this tested (or how to run locally)

Tests cover:

- Left-arm connection failure.
- Right-arm connection failure.
- Right-before-left rollback order.
- Preservation of the original error when rollback fails.
- Continued disconnection when one arm fails.
- Partial and repeated cleanup.
- Hardware-specific failed-startup cleanup hooks.

Run locally:

```bash
uv run --frozen pytest tests/utils/test_bimanual.py -q
uv run --frozen pytest tests/utils -q
pre-commit run --files src/lerobot/utils/bimanual.py tests/utils/test_bimanual.py
```

Results:

- 6 focused bimanual tests passed.
- 207 utility tests passed, 5 skipped.
- Formatting, Ruff, mypy, Bandit, and other targeted pre-commit checks passed.

Manual hardware validation:

- Tested on a physical bimanual reBot B601 setup.
- Verified a failed bimanual startup releases the arm that connected successfully.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated (not required; no user-facing configuration changed)
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: #

## Reviewer notes

- Please focus on partial-startup rollback, repeated-disconnect behavior, and preservation of the original connection exception.
- `disconnect()` intentionally has no connection-state decorator because cleanup must work in every lifecycle state.
- `_disconnect_arm_after_failed_connect()` allows motorized followers to enforce stronger safety behavior, such as disabling torque regardless of their normal disconnect configuration.
- Anyone in the community is free to review the PR.