### PR TITLE
Feat/rebot b601 motor family

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -164,7 +164,7 @@
   - local: openarm
     title: OpenArm
   - local: rebot_b601
-    title: reBot B601-DM
+    title: reBot B601
   - local: third_party_robots
     title: Third-Party Robots & Teleoperators
   title: "Robots"

--- a/docs/source/rebot_b601.mdx
+++ b/docs/source/rebot_b601.mdx
@@ -1,6 +1,15 @@
-# reBot B601-DM
+# reBot B601
 
-[reBot B601-DM](https://wiki.seeedstudio.com/rebot_arm_b601_dm_lerobot/) is an open-source, low-cost robot arm from Seeed Studio for embodied-AI and imitation learning. It comes as a **follower** arm (the `B601-DM`, a 6-DOF arm plus gripper driven by Damiao CAN motors) and a **leader** arm (the `StarArm102` / `reBot Arm 102`, driven by FashionStar UART smart servos) used to teleoperate it.
+The reBot B601 is an open-source, low-cost robot arm from Seeed Studio for embodied-AI and imitation learning. It comes as a **follower** arm (a 6-DOF arm plus gripper driven by CAN motors) and a **leader** arm (the `StarArm102` / `reBot Arm 102`, driven by FashionStar UART smart servos) used to teleoperate it.
+
+The follower ships in two builds with the same joint topology but different geometry and actuators, selected in LeRobot with a single argument, `--robot.motor_family`:
+
+| Build                                                              | `motor_family` | Motors                                   | Supply | Payload |
+| ------------------------------------------------------------------ | -------------- | ---------------------------------------- | ------ | ------- |
+| [B601-DM](https://wiki.seeedstudio.com/rebot_arm_b601_dm_lerobot/) | `dm`           | Damiao (`4340P` base, `4310` wrists)     | 24 V   | 1.5 kg  |
+| [B601-RS](https://wiki.seeedstudio.com/rebot_arm_b601_rs_lerobot/) | `rs`           | RobStride (`rs-06` base, `rs-00` wrists) | 48 V   | 2.5 kg  |
+
+The software workflow and joint names are shared. The physical geometry is not identical: Seeed specifies 767 mm maximum reach for DM and 754 mm for RS, and each build has its own motor tuning.
 
 This page covers **calibration** and **teleoperation** for both single-arm and bimanual (dual-arm) setups.
 
@@ -8,16 +17,21 @@ This page covers **calibration** and **teleoperation** for both single-arm and b
   <img
     src="https://files.seeedstudio.com/wiki/robotics/projects/lerobot/b601dm_zeroposition.jpg"
     alt="reBot B601-DM follower arm at its zero position"
-    width="48%"
+    width="32%"
+  />
+  <img
+    src="https://files.seeedstudio.com/wiki/robotics/projects/rebot_arm/rs_0pos.jpg"
+    alt="reBot B601-RS follower arm at its zero position"
+    width="32%"
   />
   <img
     src="https://files.seeedstudio.com/wiki/robotics/projects/lerobot/102_zeroposition.jpg"
     alt="reBot Arm 102 leader arm at its zero position"
-    width="48%"
+    width="32%"
   />
 </div>
 
-_Left: the B601-DM follower at its zero position. Right: the reBot Arm 102 leader at its zero position. Images courtesy of [Seeed Studio](https://wiki.seeedstudio.com/rebot_arm_b601_dm_lerobot/)._
+_Left: the B601-DM follower at its zero position. Middle: the B601-RS follower at its zero position. Right: the reBot Arm 102 leader at its zero position. Images courtesy of [Seeed Studio](https://wiki.seeedstudio.com/rebot_arm_b601_dm_lerobot/)._
 
 ## Install LeRobot 🤗
 
@@ -27,28 +41,43 @@ Follow our [Installation Guide](./installation), then install the reBot support:
 pip install -e ".[rebot]"
 ```
 
-This pulls in `motorbridge` (CAN motor control for the B601-DM follower) and `motorbridge-smart-servo` (FashionStar UART servos for the reBot Arm 102 leader).
+This pulls in `motorbridge` (CAN motor control for both follower builds) and `motorbridge-smart-servo` (FashionStar UART servos for the reBot Arm 102 leader). `motorbridge` reaches the CAN bus through `python-can`.
 
 ## Registered device types
 
 | Type                     | Kind                                         |
 | ------------------------ | -------------------------------------------- |
-| `rebot_b601_follower`    | single-arm B601-DM follower robot            |
+| `rebot_b601_follower`    | single-arm B601 follower robot               |
 | `bi_rebot_b601_follower` | bimanual (dual-arm) follower robot           |
 | `rebot_102_leader`       | single-arm reBot Arm 102 leader teleoperator |
 | `bi_rebot_102_leader`    | bimanual (dual-arm) leader teleoperator      |
 
+Both follower builds share the `rebot_b601_follower` type. Existing DM configurations remain compatible because `motor_family` defaults to `dm`; select RS explicitly with `--robot.motor_family=rs`.
+
 The bimanual types compose two single-arm instances and namespace each arm's
 observation/action keys with a `left_` / `right_` prefix. Per-arm settings are
-passed through nested `left_arm_config.*` / `right_arm_config.*` arguments.
+passed through nested `left_arm_config.*` / `right_arm_config.*` arguments. Both
+arms must use the same motor family: DM+DM and RS+RS are supported, while mixed
+DM/RS bimanual configurations are rejected.
 
-## Find the USB ports
+## Connect the follower
 
-For each device, find the USB port associated with its motor bus using:
+The follower talks to its motors over a CAN bus. DM supports either its Damiao serial bridge (`--robot.can_adapter=damiao`) or a SocketCAN adapter (`--robot.can_adapter=socketcan`). RS requires SocketCAN; MotorBridge documents the Damiao serial transport as Damiao-only. The default is `damiao` for `motor_family=dm` and `socketcan` for `motor_family=rs`.
+
+For a serial bridge, find the USB port with:
 
 ```bash
 lerobot-find-port
 ```
+
+For SocketCAN, list the available channels and bring the interface up:
+
+```bash
+ip -details link show type can
+sudo ip link set can0 up type can bitrate 1000000
+```
+
+The leader is always a USB serial device; find its port with `lerobot-find-port`.
 
 <Tip warning={true}>
   On Linux, remove `brltty` (`sudo apt remove brltty`) so it does not hold the
@@ -56,21 +85,34 @@ lerobot-find-port
   devices: `sudo chmod 666 /dev/ttyACM* /dev/ttyUSB*`.
 </Tip>
 
+At startup, LeRobot requires a successful current feedback refresh from all seven motors before it enables torque. During operation, a transient refresh failure may reuse the last snapshot for up to `feedback_cache_ttl_s` (default `0.1` seconds). Missing or expired feedback raises an error, disables torque and disconnects the robot rather than substituting a fabricated `0°` position.
+
 ## Calibration
 
-Neither arm stores a persistent hardware calibration: every time it connects, the motors are re-zeroed against the pose the arm is physically holding. Calibration simply records that zero pose. When prompted, **manually move the arm to its zero position** (the default sit-down pose shown above, gripper fully closed) and press <kbd>ENTER</kbd>.
+Calibration sets each motor's zero position and saves a LeRobot calibration file. When prompted to run calibration, **manually move the arm to its zero position** (the default sit-down pose shown above, gripper fully closed) and press <kbd>ENTER</kbd>. Later connections reuse the saved calibration file and do not automatically re-zero the motors.
 
-### Follower (B601-DM)
+### Follower
 
 <hfoptions id="calibrate-follower">
-<hfoption id="Single arm">
+<hfoption id="Single arm (DM)">
 
 ```bash
 lerobot-calibrate \
     --robot.type=rebot_b601_follower \
+    --robot.motor_family=dm \
     --robot.port=/dev/ttyACM0 \
-    --robot.id=follower \
-    --robot.can_adapter=damiao
+    --robot.id=follower
+```
+
+</hfoption>
+<hfoption id="Single arm (RS)">
+
+```bash
+lerobot-calibrate \
+    --robot.type=rebot_b601_follower \
+    --robot.motor_family=rs \
+    --robot.port=can0 \
+    --robot.id=follower
 ```
 
 </hfoption>
@@ -82,16 +124,25 @@ Connect the bimanual follower; calibration runs for the left arm, then the right
 lerobot-calibrate \
     --robot.type=bi_rebot_b601_follower \
     --robot.id=bi_follower \
+    --robot.left_arm_config.motor_family=dm \
     --robot.left_arm_config.port=/dev/ttyACM0 \
-    --robot.left_arm_config.can_adapter=damiao \
-    --robot.right_arm_config.port=/dev/ttyACM1 \
-    --robot.right_arm_config.can_adapter=damiao
+    --robot.right_arm_config.motor_family=dm \
+    --robot.right_arm_config.port=/dev/ttyACM1
 ```
 
 Per-arm calibration files are saved with `_left` / `_right` suffixes on the id.
 
 </hfoption>
 </hfoptions>
+
+<Tip warning={true}>
+  The gripper travels more than one revolution, and a motor's multi-turn count
+  does not survive a power cycle. If the follower reports an implausible joint
+  reading on connect, the encoder woke up wrapped by a full revolution: close
+  the gripper against its stop by hand and re-run calibration. LeRobot refuses
+  to enable torque in that state, because commanding the joint from there would
+  drive it into its mechanical stop.
+</Tip>
 
 ### Leader (reBot Arm 102)
 
@@ -121,17 +172,31 @@ lerobot-calibrate \
 
 ## Teleoperation
 
-Once both arms are calibrated, drive the follower with the leader. The follower talks to its CAN bus through a Damiao serial bridge (`can_adapter=damiao`, the default) or a SocketCAN adapter (`can_adapter=socketcan`). See the [OpenArm page](./openarm) for more details on the SocketCAN adapter configuration.
+Once both arms are calibrated, drive the follower with the leader.
 
 <hfoptions id="teleoperate">
-<hfoption id="Single arm">
+<hfoption id="Single arm (DM)">
 
 ```bash
 lerobot-teleoperate \
     --robot.type=rebot_b601_follower \
+    --robot.motor_family=dm \
     --robot.port=/dev/ttyACM0 \
     --robot.id=follower \
-    --robot.can_adapter=damiao \
+    --teleop.type=rebot_102_leader \
+    --teleop.port=/dev/ttyUSB0 \
+    --teleop.id=leader
+```
+
+</hfoption>
+<hfoption id="Single arm (RS)">
+
+```bash
+lerobot-teleoperate \
+    --robot.type=rebot_b601_follower \
+    --robot.motor_family=rs \
+    --robot.port=can0 \
+    --robot.id=follower \
     --teleop.type=rebot_102_leader \
     --teleop.port=/dev/ttyUSB0 \
     --teleop.id=leader
@@ -142,16 +207,16 @@ lerobot-teleoperate \
 
 The bimanual leader and follower reuse the single-arm classes; each arm is
 configured through nested `left_arm_config.*` / `right_arm_config.*` arguments,
-so a bimanual reBot Arm 102 leader drives a bimanual B601-DM follower.
+so a bimanual reBot Arm 102 leader drives a bimanual B601 follower.
 
 ```bash
 lerobot-teleoperate \
     --robot.type=bi_rebot_b601_follower \
     --robot.id=bi_follower \
+    --robot.left_arm_config.motor_family=dm \
     --robot.left_arm_config.port=/dev/ttyACM0 \
-    --robot.left_arm_config.can_adapter=damiao \
+    --robot.right_arm_config.motor_family=dm \
     --robot.right_arm_config.port=/dev/ttyACM1 \
-    --robot.right_arm_config.can_adapter=damiao \
     --teleop.type=bi_rebot_102_leader \
     --teleop.id=bi_leader \
     --teleop.left_arm_config.port=/dev/ttyUSB0 \
@@ -167,20 +232,128 @@ lerobot-teleoperate \
   leader actions map directly onto the follower.
 </Tip>
 
-If the motion of a joint is reversed, flip its sign in the leader's `joint_directions` (the gripper also carries a scale to widen its range to the follower):
+### Limiting per-step motion (safety)
+
+`max_relative_target` caps how far a joint may be commanded to move (in **degrees**) in a single control step. If the commanded goal differs from the current position by more than this cap, the target is clipped. This prevents dangerous jumps when the leader is moved abruptly or when a policy outputs an outlier action.
+
+It defaults to `None` (no limit). **Setting a cap such as `5.0` is recommended while teleoperating**, especially on the RS build, whose motors are considerably stronger. Pass a float to cap every joint uniformly, or a dict for per-joint caps:
 
 ```bash
 lerobot-teleoperate \
     --robot.type=rebot_b601_follower \
+    --robot.motor_family=rs \
+    --robot.port=can0 \
+    --robot.max_relative_target=5.0 \
+    --teleop.type=rebot_102_leader \
+    --teleop.port=/dev/ttyUSB0
+```
+
+### Limiting gripper torque
+
+Bounding grip force keeps the gripper from crushing objects or overcurrenting once it has closed. The two builds expose this differently, because RobStride motors have no force-limited position mode:
+
+<hfoptions id="gripper-torque">
+<hfoption id="DM">
+
+The DM gripper runs in `force_pos` mode, where `gripper_torque_ratio` (default `0.07`) sets grip force as a fraction of the motor's peak torque:
+
+```bash
+lerobot-teleoperate \
+    --robot.type=rebot_b601_follower \
+    --robot.motor_family=dm \
     --robot.port=/dev/ttyACM0 \
-    --robot.can_adapter=damiao \
+    --robot.gripper_torque_ratio=0.07 \
+    --teleop.type=rebot_102_leader \
+    --teleop.port=/dev/ttyUSB0
+```
+
+</hfoption>
+<hfoption id="RS">
+
+The RS gripper is driven by a force-limited MIT impedance torque rather than a position target, bounded by two limits:
+
+- **`gripper_torque_limit`** (default `3.5` N·m) — max feedforward torque while the gripper is **moving**.
+- **`gripper_hold_torque_limit`** (default `1.0` N·m) — max feedforward torque at **near-zero speed** (grasping or holding). This gentler limit is what prevents crushing and overcurrent once the gripper has reached its target.
+
+```bash
+lerobot-teleoperate \
+    --robot.type=rebot_b601_follower \
+    --robot.motor_family=rs \
+    --robot.port=can0 \
+    --robot.gripper_torque_limit=2.0 \
+    --robot.gripper_hold_torque_limit=0.5 \
+    --teleop.type=rebot_102_leader \
+    --teleop.port=/dev/ttyUSB0
+```
+
+</hfoption>
+</hfoptions>
+
+### Tuning stiffness
+
+Arm joints are driven in MIT mode, whose `mit_kp` (stiffness) and `mit_kd` (damping) gains are set per joint. Raise `mit_kp` if the follower sags behind the leader under load; raise `mit_kd` if it oscillates. Pass a single float for uniform arm gains, or a complete dict to set every joint explicitly. For compatibility, legacy DM scalar/list inputs retain the independent `gripper_mit_kp` and `gripper_mit_kd` gripper defaults:
+
+```bash
+lerobot-teleoperate \
+    --robot.type=rebot_b601_follower \
+    --robot.motor_family=rs \
+    --robot.port=can0 \
+    --robot.mit_kp='{"shoulder_pan":50,"shoulder_lift":150,"elbow_flex":150,"wrist_flex":50,"wrist_yaw":50,"wrist_roll":50,"gripper":12}' \
+    --teleop.type=rebot_102_leader \
+    --teleop.port=/dev/ttyUSB0
+```
+
+<Tip warning={true}>
+  RS gains are not comparable across joints: the `rs-06` base motors and `rs-00`
+  wrist motors encode gains against different full scales, so the same number
+  means a different stiffness on a base joint than on a wrist joint. Retune per
+  joint rather than scaling all gains together.
+</Tip>
+
+The DM build additionally supports a `pos_vel` arm mode (`--robot.control_mode=pos_vel`), which follows a position target at a capped speed instead of a torque-based one. MotorBridge also exposes RobStride position control, but this B601-RS integration intentionally exposes only the hardware-tested MIT path for now.
+
+### Reversed joints
+
+If a joint moves the wrong way, flip its sign in the leader's `joint_directions` (the gripper also carries a scale to widen its range to the follower):
+
+```bash
+lerobot-teleoperate \
+    --robot.type=rebot_b601_follower \
+    --robot.motor_family=dm \
+    --robot.port=/dev/ttyACM0 \
     --teleop.type=rebot_102_leader \
     --teleop.port=/dev/ttyUSB0 \
     --teleop.joint_directions='{"shoulder_pan":-1,"shoulder_lift":-1,"elbow_flex":1,"wrist_flex":1,"wrist_yaw":1,"wrist_roll":-1,"gripper":-6}'
 ```
 
+The follower has its own `joint_directions` describing how its motors are installed, which already differs between the two builds: RS motors are mounted opposite to the DM build, so its defaults are all `-1`. The follower applies this conversion in both directions, keeping observations and actions in one public robot coordinate frame. Adjust the leader's directions for teleoperation preferences and leave the follower's alone unless you have rebuilt the arm.
+
+The shipped leader range remains unchanged for DM compatibility. Its wrist-flex output is `[-80°, 90°]`; after the RS direction conversion, the RS follower's public wrist-flex range is `[-90°, 80°]`. The leader therefore clips the RS positive endpoint and cannot command its final negative `10°`. Family-aware leader remapping belongs in a future processor or teleoperator configuration rather than changing the established leader defaults here.
+
+<Tip warning={true}>
+  DM and RS now use the same coordinate convention, but their geometry, payload,
+  gains and dynamics differ. Do not assume a policy or dataset transfers between
+  builds without validation.
+</Tip>
+
+### Gravity compensation
+
+The shared command path accepts a feedforward torque term, but this LeRobot integration does **not** currently calculate gravity compensation. Seeed's ROS2 and Pinocchio integrations provide separate gravity-compensation implementations; enabling it here will require a family-specific robot model and hardware validation.
+
 ## Recording datasets
 
 Swap `lerobot-teleoperate` for `lerobot-record` (with the same `--robot.*` / `--teleop.*` arguments, plus `--dataset.*`) to record demonstrations for training. See [Imitation Learning for Robots](./il_robots) for the full workflow.
 
-For hardware assembly and wiring, see the [Seeed Studio reBot wiki](https://wiki.seeedstudio.com/rebot_arm_b601_dm_lerobot/).
+### Migration from the experimental RS PR branch
+
+The experimental implementation from PR #4256 used the separate `rebot_b601_rs_follower` type and reported RS observations in raw motor signs while accepting actions in the shared public signs. When migrating:
+
+- Replace `rebot_b601_rs_follower` with `rebot_b601_follower` and add `motor_family=rs`.
+- Replace `bi_rebot_b601_rs_follower` with `bi_rebot_b601_follower`; both arms must be RS.
+- Rename `gripper_mit_torque_limit` and `gripper_mit_hold_torque_limit` to `gripper_torque_limit` and `gripper_hold_torque_limit`.
+- Recalibrate under the unified type instead of reusing an experimental calibration file without verification.
+- Existing experimental RS datasets may require negating joint observation positions. Actions were already expressed in the public convention; validate each dataset before training or replay.
+
+For hardware assembly and wiring, see the Seeed Studio wiki for your build: [B601-DM](https://wiki.seeedstudio.com/rebot_arm_b601_dm_lerobot/) or [B601-RS](https://wiki.seeedstudio.com/rebot_arm_b601_rs_lerobot/).
+
+The RS MotorBridge integration, impedance gripper and initial documentation come from @SeakingForHeart in PR #4256. Encoder-wrap safety builds on @johnnynunez's work in PR #4071, with protocol review from @infoslack and physical B601-RS validation and documentation review from @NikodemBartnik.

--- a/docs/source/rebot_b601.mdx
+++ b/docs/source/rebot_b601.mdx
@@ -344,16 +344,4 @@ The shared command path accepts a feedforward torque term, but this LeRobot inte
 
 Swap `lerobot-teleoperate` for `lerobot-record` (with the same `--robot.*` / `--teleop.*` arguments, plus `--dataset.*`) to record demonstrations for training. See [Imitation Learning for Robots](./il_robots) for the full workflow.
 
-### Migration from the experimental RS PR branch
-
-The experimental implementation from PR #4256 used the separate `rebot_b601_rs_follower` type and reported RS observations in raw motor signs while accepting actions in the shared public signs. When migrating:
-
-- Replace `rebot_b601_rs_follower` with `rebot_b601_follower` and add `motor_family=rs`.
-- Replace `bi_rebot_b601_rs_follower` with `bi_rebot_b601_follower`; both arms must be RS.
-- Rename `gripper_mit_torque_limit` and `gripper_mit_hold_torque_limit` to `gripper_torque_limit` and `gripper_hold_torque_limit`.
-- Recalibrate under the unified type instead of reusing an experimental calibration file without verification.
-- Existing experimental RS datasets may require negating joint observation positions. Actions were already expressed in the public convention; validate each dataset before training or replay.
-
 For hardware assembly and wiring, see the Seeed Studio wiki for your build: [B601-DM](https://wiki.seeedstudio.com/rebot_arm_b601_dm_lerobot/) or [B601-RS](https://wiki.seeedstudio.com/rebot_arm_b601_rs_lerobot/).
-
-The RS MotorBridge integration, impedance gripper and initial documentation come from @SeakingForHeart in PR #4256. Encoder-wrap safety builds on @johnnynunez's work in PR #4071, with protocol review from @infoslack and physical B601-RS validation and documentation review from @NikodemBartnik.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,7 +170,10 @@ pyserial-dep = ["pyserial>=3.5,<4.0"]
 deepdiff-dep = ["deepdiff>=7.0.1,<9.0.0"]
 pynput-dep = ["pynput>=1.7.8,<1.9.0"]
 pyzmq-dep = ["pyzmq>=26.2.1,<28.0.0"]
-motorbridge-dep = ["motorbridge>=0.3.2,<0.4.0"]
+motorbridge-dep = [
+    "motorbridge>=0.5,<0.6",
+    "lerobot[can-dep]",
+]
 motorbridge-smart-servo-dep = ["motorbridge-smart-servo>=0.0.4,<0.1.0"]
 timm-dep = ["timm>=1.0.0,<1.1.0"]
 
@@ -201,7 +204,7 @@ reachy2 = [
     "grpcio<=1.73.1",
     "protobuf<=6.32.0",
 ]
-# Seeed Studio reBot B601-DM follower (motorbridge / CAN) + StarArm102 / reBot Arm 102
+# Seeed Studio reBot B601 follower (motorbridge / CAN) + StarArm102 / reBot Arm 102
 # leader (motorbridge-smart-servo / FashionStar UART servos).
 rebot = ["lerobot[motorbridge-dep]", "lerobot[motorbridge-smart-servo-dep]"]
 kinematics = ["lerobot[placo-dep]"]

--- a/src/lerobot/robots/bi_rebot_b601_follower/bi_rebot_b601_follower.py
+++ b/src/lerobot/robots/bi_rebot_b601_follower/bi_rebot_b601_follower.py
@@ -19,9 +19,9 @@ from functools import cached_property
 
 from lerobot.lerobot_types import RobotAction, RobotObservation
 from lerobot.utils.bimanual import BimanualMixin
-from lerobot.utils.decorators import check_if_not_connected
+from lerobot.utils.decorators import check_if_already_connected, check_if_not_connected
 
-from ..rebot_b601_follower import RebotB601Follower, RebotB601FollowerRobotConfig
+from ..rebot_b601_follower import RebotB601Follower
 from ..robot import Robot
 from .config_bi_rebot_b601_follower import BiRebotB601FollowerConfig
 
@@ -29,10 +29,12 @@ logger = logging.getLogger(__name__)
 
 
 class BiRebotB601Follower(BimanualMixin, Robot):
-    """Bimanual Seeed Studio reBot B601-DM follower.
+    """Bimanual Seeed Studio reBot B601 follower.
 
     Composes two single-arm :class:`RebotB601Follower` instances. Observation and
     action keys of each arm are namespaced with a ``left_`` / ``right_`` prefix.
+
+    Both arms use the same configured motor family.
     """
 
     config_class = BiRebotB601FollowerConfig
@@ -52,48 +54,14 @@ class BiRebotB601Follower(BimanualMixin, Robot):
             raise ValueError(
                 f"Top-level camera names collide with per-arm camera names: {sorted(_collisions)}"
             )
-        left_arm_cameras = {**config.left_arm_config.cameras, **config.cameras}
-
-        left_arm_config = RebotB601FollowerRobotConfig(
+        left_arm_config = config.left_arm_config.as_robot_config(
             id=f"{config.id}_left" if config.id else None,
             calibration_dir=config.calibration_dir,
-            port=config.left_arm_config.port,
-            can_adapter=config.left_arm_config.can_adapter,
-            dm_serial_baud=config.left_arm_config.dm_serial_baud,
-            disable_torque_on_disconnect=config.left_arm_config.disable_torque_on_disconnect,
-            max_relative_target=config.left_arm_config.max_relative_target,
-            cameras=left_arm_cameras,
-            motor_can_ids=config.left_arm_config.motor_can_ids,
-            pos_vel_velocity=config.left_arm_config.pos_vel_velocity,
-            control_mode=config.left_arm_config.control_mode,
-            mit_kp=config.left_arm_config.mit_kp,
-            mit_kd=config.left_arm_config.mit_kd,
-            gripper_control_mode=config.left_arm_config.gripper_control_mode,
-            gripper_torque_ratio=config.left_arm_config.gripper_torque_ratio,
-            gripper_mit_kp=config.left_arm_config.gripper_mit_kp,
-            gripper_mit_kd=config.left_arm_config.gripper_mit_kd,
-            joint_limits=config.left_arm_config.joint_limits,
+            cameras={**config.left_arm_config.cameras, **config.cameras},
         )
-
-        right_arm_config = RebotB601FollowerRobotConfig(
+        right_arm_config = config.right_arm_config.as_robot_config(
             id=f"{config.id}_right" if config.id else None,
             calibration_dir=config.calibration_dir,
-            port=config.right_arm_config.port,
-            can_adapter=config.right_arm_config.can_adapter,
-            dm_serial_baud=config.right_arm_config.dm_serial_baud,
-            disable_torque_on_disconnect=config.right_arm_config.disable_torque_on_disconnect,
-            max_relative_target=config.right_arm_config.max_relative_target,
-            cameras=config.right_arm_config.cameras,
-            motor_can_ids=config.right_arm_config.motor_can_ids,
-            pos_vel_velocity=config.right_arm_config.pos_vel_velocity,
-            control_mode=config.right_arm_config.control_mode,
-            mit_kp=config.right_arm_config.mit_kp,
-            mit_kd=config.right_arm_config.mit_kd,
-            gripper_control_mode=config.right_arm_config.gripper_control_mode,
-            gripper_torque_ratio=config.right_arm_config.gripper_torque_ratio,
-            gripper_mit_kp=config.right_arm_config.gripper_mit_kp,
-            gripper_mit_kd=config.right_arm_config.gripper_mit_kd,
-            joint_limits=config.right_arm_config.joint_limits,
         )
 
         self.left_arm = RebotB601Follower(left_arm_config)
@@ -101,6 +69,26 @@ class BiRebotB601Follower(BimanualMixin, Robot):
 
         # Only for compatibility with parts of the codebase that expect `robot.cameras`.
         self.cameras = {**self.left_arm.cameras, **self.right_arm.cameras}
+
+    @check_if_already_connected
+    def connect(self, calibrate: bool = True) -> None:
+        """Connect atomically, rolling the left arm back if the right fails."""
+        self.left_arm.connect(calibrate)
+        try:
+            self.right_arm.connect(calibrate)
+        except Exception:
+            # Rollback is a safety path, so it must disable torque regardless of
+            # the user's normal disconnect preference.
+            self.left_arm._disconnect(force_disable=True)
+            raise
+
+    def disconnect(self) -> None:
+        """Best-effort, idempotent cleanup of both arms."""
+        for arm_name, arm in (("left", self.left_arm), ("right", self.right_arm)):
+            try:
+                arm.disconnect()
+            except Exception:
+                logger.exception("Failed to disconnect %s reBot arm.", arm_name)
 
     @property
     def _motors_ft(self) -> dict[str, type]:

--- a/src/lerobot/robots/bi_rebot_b601_follower/bi_rebot_b601_follower.py
+++ b/src/lerobot/robots/bi_rebot_b601_follower/bi_rebot_b601_follower.py
@@ -14,18 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
 from functools import cached_property
 
 from lerobot.lerobot_types import RobotAction, RobotObservation
 from lerobot.utils.bimanual import BimanualMixin
-from lerobot.utils.decorators import check_if_already_connected, check_if_not_connected
+from lerobot.utils.decorators import check_if_not_connected
 
 from ..rebot_b601_follower import RebotB601Follower
 from ..robot import Robot
 from .config_bi_rebot_b601_follower import BiRebotB601FollowerConfig
-
-logger = logging.getLogger(__name__)
 
 
 class BiRebotB601Follower(BimanualMixin, Robot):
@@ -70,31 +67,9 @@ class BiRebotB601Follower(BimanualMixin, Robot):
         # Only for compatibility with parts of the codebase that expect `robot.cameras`.
         self.cameras = {**self.left_arm.cameras, **self.right_arm.cameras}
 
-    @check_if_already_connected
-    def connect(self, calibrate: bool = True) -> None:
-        """Connect atomically, force-disabling both arms after any failure."""
-        try:
-            self.left_arm.connect(calibrate)
-            self.right_arm.connect(calibrate)
-        except Exception:
-            self._force_disconnect_after_failure()
-            raise
-
-    def _force_disconnect_after_failure(self) -> None:
-        """Best-effort emergency cleanup that preserves the active exception."""
-        for arm_name, arm in (("left", self.left_arm), ("right", self.right_arm)):
-            try:
-                arm._disconnect(force_disable=True)
-            except Exception:
-                logger.exception("Failed to force-disconnect %s reBot arm.", arm_name)
-
-    def disconnect(self) -> None:
-        """Best-effort, idempotent cleanup of both arms."""
-        for arm_name, arm in (("left", self.left_arm), ("right", self.right_arm)):
-            try:
-                arm.disconnect()
-            except Exception:
-                logger.exception("Failed to disconnect %s reBot arm.", arm_name)
+    def _disconnect_arm_for_cleanup(self, arm: RebotB601Follower) -> None:
+        """Force-disable an arm while recovering from a bimanual failure."""
+        arm._disconnect(force_disable=True)
 
     @property
     def _motors_ft(self) -> dict[str, type]:
@@ -130,7 +105,7 @@ class BiRebotB601Follower(BimanualMixin, Robot):
                 obs_dict[f"right_{k}"] = v
             return obs_dict
         except Exception:
-            self._force_disconnect_after_failure()
+            self._rollback_failed_connect()
             raise
 
     @check_if_not_connected
@@ -151,5 +126,5 @@ class BiRebotB601Follower(BimanualMixin, Robot):
                 **{f"right_{k}": v for k, v in sent_action_right.items()},
             }
         except Exception:
-            self._force_disconnect_after_failure()
+            self._rollback_failed_connect()
             raise

--- a/src/lerobot/robots/bi_rebot_b601_follower/bi_rebot_b601_follower.py
+++ b/src/lerobot/robots/bi_rebot_b601_follower/bi_rebot_b601_follower.py
@@ -67,7 +67,7 @@ class BiRebotB601Follower(BimanualMixin, Robot):
         # Only for compatibility with parts of the codebase that expect `robot.cameras`.
         self.cameras = {**self.left_arm.cameras, **self.right_arm.cameras}
 
-    def _disconnect_arm_for_cleanup(self, arm: RebotB601Follower) -> None:
+    def _disconnect_arm_after_failed_connect(self, arm: RebotB601Follower) -> None:
         """Force-disable an arm while recovering from a bimanual failure."""
         arm._disconnect(force_disable=True)
 
@@ -105,7 +105,7 @@ class BiRebotB601Follower(BimanualMixin, Robot):
                 obs_dict[f"right_{k}"] = v
             return obs_dict
         except Exception:
-            self._rollback_failed_connect()
+            self._disconnect_arms(after_failed_connect=True)
             raise
 
     @check_if_not_connected
@@ -126,5 +126,5 @@ class BiRebotB601Follower(BimanualMixin, Robot):
                 **{f"right_{k}": v for k, v in sent_action_right.items()},
             }
         except Exception:
-            self._rollback_failed_connect()
+            self._disconnect_arms(after_failed_connect=True)
             raise

--- a/src/lerobot/robots/bi_rebot_b601_follower/bi_rebot_b601_follower.py
+++ b/src/lerobot/robots/bi_rebot_b601_follower/bi_rebot_b601_follower.py
@@ -72,15 +72,21 @@ class BiRebotB601Follower(BimanualMixin, Robot):
 
     @check_if_already_connected
     def connect(self, calibrate: bool = True) -> None:
-        """Connect atomically, rolling the left arm back if the right fails."""
-        self.left_arm.connect(calibrate)
+        """Connect atomically, force-disabling both arms after any failure."""
         try:
+            self.left_arm.connect(calibrate)
             self.right_arm.connect(calibrate)
         except Exception:
-            # Rollback is a safety path, so it must disable torque regardless of
-            # the user's normal disconnect preference.
-            self.left_arm._disconnect(force_disable=True)
+            self._force_disconnect_after_failure()
             raise
+
+    def _force_disconnect_after_failure(self) -> None:
+        """Best-effort emergency cleanup that preserves the active exception."""
+        for arm_name, arm in (("left", self.left_arm), ("right", self.right_arm)):
+            try:
+                arm._disconnect(force_disable=True)
+            except Exception:
+                logger.exception("Failed to force-disconnect %s reBot arm.", arm_name)
 
     def disconnect(self) -> None:
         """Best-effort, idempotent cleanup of both arms."""
@@ -116,26 +122,34 @@ class BiRebotB601Follower(BimanualMixin, Robot):
 
     @check_if_not_connected
     def get_observation(self) -> RobotObservation:
-        obs_dict: RobotObservation = {}
-        for k, v in self.left_arm.get_observation().items():
-            obs_dict[k if k in self._top_level_cam_keys else f"left_{k}"] = v
-        for k, v in self.right_arm.get_observation().items():
-            obs_dict[f"right_{k}"] = v
-        return obs_dict
+        try:
+            obs_dict: RobotObservation = {}
+            for k, v in self.left_arm.get_observation().items():
+                obs_dict[k if k in self._top_level_cam_keys else f"left_{k}"] = v
+            for k, v in self.right_arm.get_observation().items():
+                obs_dict[f"right_{k}"] = v
+            return obs_dict
+        except Exception:
+            self._force_disconnect_after_failure()
+            raise
 
     @check_if_not_connected
     def send_action(self, action: RobotAction) -> RobotAction:
-        left_action = {
-            key.removeprefix("left_"): value for key, value in action.items() if key.startswith("left_")
-        }
-        right_action = {
-            key.removeprefix("right_"): value for key, value in action.items() if key.startswith("right_")
-        }
+        try:
+            left_action = {
+                key.removeprefix("left_"): value for key, value in action.items() if key.startswith("left_")
+            }
+            right_action = {
+                key.removeprefix("right_"): value for key, value in action.items() if key.startswith("right_")
+            }
 
-        sent_action_left = self.left_arm.send_action(left_action)
-        sent_action_right = self.right_arm.send_action(right_action)
+            sent_action_left = self.left_arm.send_action(left_action)
+            sent_action_right = self.right_arm.send_action(right_action)
 
-        return {
-            **{f"left_{k}": v for k, v in sent_action_left.items()},
-            **{f"right_{k}": v for k, v in sent_action_right.items()},
-        }
+            return {
+                **{f"left_{k}": v for k, v in sent_action_left.items()},
+                **{f"right_{k}": v for k, v in sent_action_right.items()},
+            }
+        except Exception:
+            self._force_disconnect_after_failure()
+            raise

--- a/src/lerobot/robots/bi_rebot_b601_follower/config_bi_rebot_b601_follower.py
+++ b/src/lerobot/robots/bi_rebot_b601_follower/config_bi_rebot_b601_follower.py
@@ -25,7 +25,11 @@ from ..rebot_b601_follower import RebotB601FollowerConfig
 @RobotConfig.register_subclass("bi_rebot_b601_follower")
 @dataclass
 class BiRebotB601FollowerConfig(RobotConfig):
-    """Configuration class for the bimanual reBot B601-DM follower robot."""
+    """Configuration class for the bimanual reBot B601 follower robot.
+
+    Both arms must use the same motor family. Mixed DM/RS pairs are intentionally
+    rejected until there is a concrete hardware use case and validation matrix.
+    """
 
     left_arm_config: RebotB601FollowerConfig
     right_arm_config: RebotB601FollowerConfig
@@ -34,3 +38,21 @@ class BiRebotB601FollowerConfig(RobotConfig):
     # observations (no `left_`/`right_` prefix). Per-arm cameras (declared on
     # `{left,right}_arm_config.cameras`) are prefixed.
     cameras: dict[str, CameraConfig] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        left = self.left_arm_config
+        right = self.right_arm_config
+        if left.motor_family is not right.motor_family:
+            raise ValueError("Mixed DM/RS bimanual reBot configurations are not supported.")
+
+        same_channel = left.can_adapter == right.can_adapter and left.port == right.port
+        if same_channel:
+            left_send_ids = {send_id for send_id, _ in left.motor_can_ids.values()}
+            right_send_ids = {send_id for send_id, _ in right.motor_can_ids.values()}
+            overlap = sorted(left_send_ids & right_send_ids)
+            if overlap:
+                rendered = ", ".join(f"0x{can_id:X}" for can_id in overlap)
+                raise ValueError(
+                    f"Bimanual reBot arms on the same CAN channel have overlapping send IDs: {rendered}."
+                )

--- a/src/lerobot/robots/rebot_b601_follower/__init__.py
+++ b/src/lerobot/robots/rebot_b601_follower/__init__.py
@@ -15,6 +15,17 @@
 # limitations under the License.
 
 from .config_rebot_b601_follower import RebotB601FollowerConfig, RebotB601FollowerRobotConfig
-from .rebot_b601_follower import RebotB601Follower
+from .motor_family import DM_PROFILE, RS_PROFILE, MotorFamily, MotorFamilyProfile, profile_for
+from .rebot_b601_follower import MotorFeedbackError, RebotB601Follower
 
-__all__ = ["RebotB601Follower", "RebotB601FollowerConfig", "RebotB601FollowerRobotConfig"]
+__all__ = [
+    "DM_PROFILE",
+    "RS_PROFILE",
+    "MotorFamily",
+    "MotorFamilyProfile",
+    "MotorFeedbackError",
+    "RebotB601Follower",
+    "RebotB601FollowerConfig",
+    "RebotB601FollowerRobotConfig",
+    "profile_for",
+]

--- a/src/lerobot/robots/rebot_b601_follower/config_rebot_b601_follower.py
+++ b/src/lerobot/robots/rebot_b601_follower/config_rebot_b601_follower.py
@@ -14,96 +14,436 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dataclasses import dataclass, field
+from collections.abc import Iterable, Mapping
+from copy import deepcopy
+from dataclasses import dataclass, field, fields
+from math import isfinite
+from pathlib import Path
 
 from lerobot.cameras import CameraConfig
 
 from ..config import RobotConfig
+from .motor_family import GRIPPER_MOTOR, MotorFamily, MotorFamilyProfile, profile_for
+
+CAN_ADAPTERS = ("damiao", "socketcan")
+
+
+def _broadcast_per_joint(
+    name: str,
+    value: float | list[float] | Mapping[str, float],
+    joints: Iterable[str],
+) -> dict[str, float]:
+    """Normalize a legacy scalar/list or mapping into a complete joint mapping."""
+    joints = tuple(joints)
+    if isinstance(value, (int, float)):
+        return dict.fromkeys(joints, float(value))
+    if isinstance(value, list):
+        if len(value) != len(joints):
+            raise ValueError(f"`{name}` must contain exactly {len(joints)} values, got {len(value)}.")
+        return {joint: float(item) for joint, item in zip(joints, value, strict=True)}
+
+    _validate_exact_keys(name, value, joints)
+    return {joint: float(value[joint]) for joint in joints}
+
+
+def _validate_exact_keys(name: str, value: Mapping[str, object], joints: Iterable[str]) -> None:
+    expected = set(joints)
+    actual = set(value)
+    if actual != expected:
+        missing = sorted(expected - actual)
+        extra = sorted(actual - expected)
+        details = []
+        if missing:
+            details.append(f"missing: {', '.join(missing)}")
+        if extra:
+            details.append(f"unknown: {', '.join(extra)}")
+        raise ValueError(f"`{name}` must contain exactly the configured joints ({'; '.join(details)}).")
+
+
+def _require_finite(name: str, value: float) -> float:
+    value = float(value)
+    if not isfinite(value):
+        raise ValueError(f"`{name}` must be finite.")
+    return value
+
+
+def public_joint_limits(
+    raw_limits: Mapping[str, tuple[float, float]],
+    directions: Mapping[str, float],
+) -> dict[str, tuple[float, float]]:
+    """Convert raw motor-frame limits into the public robot coordinate frame."""
+    return {
+        joint: tuple(sorted((lower / directions[joint], upper / directions[joint])))
+        for joint, (lower, upper) in raw_limits.items()
+    }
 
 
 @dataclass
 class RebotB601FollowerConfig:
-    """Base configuration class for the Seeed Studio reBot B601-DM follower arm.
+    """Base configuration for the Seeed Studio reBot B601 follower arm.
 
-    The B601-DM is a 6-DOF arm plus gripper driven by Damiao CAN motors. Motor
-    communication goes through the ``motorbridge`` package.
+    The B601 is a 6-DOF arm plus gripper sold in two builds with the same joint
+    topology but different geometry and actuators, selected by `motor_family`:
+    `"dm"` for the Damiao B601-DM and `"rs"` for the RobStride B601-RS. Motor
+    communication goes through the ``motorbridge`` package over a CAN bus.
+
+    Every per-joint field below defaults to `None`, meaning "use the value for my
+    motor family". After `__post_init__` they are all fully populated dicts keyed
+    by the joints declared in `motor_can_ids`, so consumers never need to handle a
+    scalar, a partial mapping, or `None`.
     """
 
-    # Communication port. For ``can_adapter="damiao"`` this is the Damiao serial
-    # bridge device (e.g. "/dev/ttyACM0"); for ``can_adapter="socketcan"`` it is
-    # the CAN channel name (e.g. "can0").
+    # Communication port. For `can_adapter="damiao"` this is the Damiao serial
+    # bridge device (e.g. "/dev/ttyACM0"); for `"socketcan"` it is the CAN channel
+    # name (e.g. "can0").
     port: str
 
-    # CAN adapter type:
-    #   "damiao"    - Damiao dedicated serial bridge (default)
-    #   "socketcan" - SocketCAN based adapters (PCAN, slcan, embedded controllers, ...)
-    can_adapter: str = "damiao"
+    # Omitted by legacy DM configs. RS must be selected explicitly.
+    motor_family: MotorFamily = MotorFamily.DM
 
-    # Baud rate for the Damiao serial bridge (only used when can_adapter="damiao").
+    # CAN transport: "damiao" for the Damiao-only USB-to-CAN serial bridge,
+    # "socketcan" for SocketCAN adapters. SocketCAN supports both families.
+    can_adapter: str | None = None
+
+    # Baud rate of the Damiao serial bridge. Unused when can_adapter="socketcan".
     dm_serial_baud: int = 921600
 
     disable_torque_on_disconnect: bool = True
 
-    # `max_relative_target` limits the magnitude of the relative positional target
-    # vector for safety purposes (in degrees). Set to a positive scalar to apply the
-    # same value to all motors, or to a dict mapping motor names to per-motor values.
+    # Caps the magnitude of the relative positional target vector (in degrees) for
+    # safety. A scalar applies to every joint; a dict sets per-joint values. `None`
+    # disables the check entirely — unlike the fields below, `None` is a real value
+    # here and is not filled in from the motor family.
     max_relative_target: float | dict[str, float] | None = None
+    feedback_cache_ttl_s: float = 0.1
 
     # cameras
     cameras: dict[str, CameraConfig] = field(default_factory=dict)
 
-    # Maps motor names to their (send_can_id, recv_can_id) pair.
-    motor_can_ids: dict[str, tuple[int, int]] = field(
-        default_factory=lambda: {
-            "shoulder_pan": (0x01, 0x11),
-            "shoulder_lift": (0x02, 0x12),
-            "elbow_flex": (0x03, 0x13),
-            "wrist_flex": (0x04, 0x14),
-            "wrist_yaw": (0x05, 0x15),
-            "wrist_roll": (0x06, 0x16),
-            "gripper": (0x07, 0x17),
+    # Maps joint names to their (send_can_id, recv_can_id) pair. Damiao motors use
+    # a per-motor recv id; RobStride motors all answer on the host id.
+    motor_can_ids: dict[str, tuple[int, int]] | None = None
+
+    # Arm control mode. "mit" everywhere; "pos_vel" on Damiao only.
+    control_mode: str | None = None
+
+    # Gripper control mode. "mit_impedance" (force-limited, RobStride) or
+    # "force_pos" (Damiao) or plain "mit" position control on either.
+    gripper_control_mode: str | None = None
+
+    # MIT gains per joint, gripper included. Note the MIT frame packs gains against
+    # a model-dependent full scale, so RobStride gains are not comparable between
+    # the proximal (rs-06) and distal (rs-00) joints.
+    mit_kp: float | list[float] | dict[str, float] | None = None
+    mit_kd: float | list[float] | dict[str, float] | None = None
+
+    # Speed cap (deg/s) for POS_VEL arm joints and the FORCE_POS gripper.
+    pos_vel_velocity: float | list[float] | dict[str, float] | None = None
+
+    # FORCE_POS gripper: grip force as a fraction of peak torque, in [0, 1].
+    gripper_torque_ratio: float | None = None
+
+    # Legacy aliases for mit_kp["gripper"] and mit_kd["gripper"].
+    gripper_mit_kp: float | None = None
+    gripper_mit_kd: float | None = None
+
+    # Impedance gripper: max |feedforward torque| (N.m) while moving, and the
+    # gentler cap at near-zero speed that bounds grip force on a closed grasp.
+    gripper_torque_limit: float | None = None
+    gripper_hold_torque_limit: float | None = None
+
+    # Soft joint limits in the raw motor frame (degrees), clipped against after
+    # `joint_directions` maps the public action into that frame.
+    joint_limits: dict[str, tuple[float, float]] | None = None
+
+    # Sign converting positions and torques between the public robot frame and the
+    # raw motor frame. Only +1 and -1 are valid; scaling belongs in a processor or
+    # teleoperator config.
+    joint_directions: float | dict[str, float] | None = None
+
+    # Refuse to enable torque when a joint reads far outside its limits, which
+    # means a multi-turn encoder woke up wrapped by a whole revolution after a
+    # power cycle. Commanding such a joint would drive it into its hard stop.
+    check_position_plausibility: bool = True
+    wrap_guard_margin_deg: float = 90.0
+
+    @property
+    def profile(self) -> MotorFamilyProfile:
+        """Hardware profile for this arm's motor family."""
+        return profile_for(self.motor_family)
+
+    def _resolve_motor_family_defaults(self) -> None:
+        """Fill every unset per-joint field from this arm's motor family profile."""
+        profile = profile_for(self.motor_family)
+        self.motor_family = profile.family
+        if not self.port:
+            raise ValueError("`port` must not be empty.")
+        if not isinstance(self.dm_serial_baud, int) or self.dm_serial_baud <= 0:
+            raise ValueError("`dm_serial_baud` must be a positive integer.")
+
+        if self.can_adapter is None:
+            self.can_adapter = profile.can_adapter
+        if self.can_adapter not in CAN_ADAPTERS:
+            raise ValueError(
+                f"Unsupported can_adapter '{self.can_adapter}'. Available: {', '.join(CAN_ADAPTERS)}."
+            )
+        if self.can_adapter not in profile.can_adapters:
+            available = ", ".join(sorted(profile.can_adapters))
+            raise ValueError(
+                f"can_adapter '{self.can_adapter}' is not available for "
+                f"{self.motor_family.value} motors. Available: {available}."
+            )
+
+        joints = tuple(profile.motor_models)
+        if self.motor_can_ids is None:
+            self.motor_can_ids = dict(profile.motor_can_ids)
+        _validate_exact_keys("motor_can_ids", self.motor_can_ids, joints)
+        normalized_ids: dict[str, tuple[int, int]] = {}
+        for joint, ids in self.motor_can_ids.items():
+            if not isinstance(ids, (tuple, list)) or len(ids) != 2:
+                raise ValueError(f"`motor_can_ids[{joint}]` must be a (send_id, receive_id) pair.")
+            send_id, receive_id = ids
+            if (
+                not isinstance(send_id, int)
+                or isinstance(send_id, bool)
+                or not 0 < send_id <= 0x7FF
+                or not isinstance(receive_id, int)
+                or isinstance(receive_id, bool)
+                or not 0 <= receive_id <= 0x7FF
+            ):
+                raise ValueError(f"`motor_can_ids[{joint}]` contains an invalid classic-CAN identifier.")
+            normalized_ids[joint] = (send_id, receive_id)
+        self.motor_can_ids = normalized_ids
+        send_ids = [send_id for send_id, _ in self.motor_can_ids.values()]
+        if len(send_ids) != len(set(send_ids)):
+            raise ValueError("Motor send CAN IDs must be unique.")
+        receive_ids = [receive_id for _, receive_id in self.motor_can_ids.values()]
+        if self.motor_family is MotorFamily.DM and len(receive_ids) != len(set(receive_ids)):
+            raise ValueError("Damiao receive CAN IDs must be unique.")
+        if self.motor_family is MotorFamily.RS and set(receive_ids) != {0xFD}:
+            raise ValueError("RobStride receive CAN IDs must all use host ID 0xFD.")
+
+        if self.control_mode is None:
+            self.control_mode = profile.control_mode
+        if self.control_mode not in profile.arm_modes:
+            raise ValueError(
+                f"control_mode '{self.control_mode}' is not available on {self.motor_family.value} "
+                f"motors. Available: {', '.join(sorted(profile.arm_modes))}."
+            )
+
+        if self.gripper_control_mode is None:
+            self.gripper_control_mode = profile.gripper_control_mode
+        if self.gripper_control_mode not in profile.gripper_modes:
+            raise ValueError(
+                f"gripper_control_mode '{self.gripper_control_mode}' is not available on "
+                f"{self.motor_family.value} motors. Available: "
+                f"{', '.join(sorted(profile.gripper_modes))}."
+            )
+
+        gain_inputs = {"mit_kp": self.mit_kp, "mit_kd": self.mit_kd}
+        for name in ("mit_kp", "mit_kd", "joint_directions"):
+            value = getattr(self, name)
+            default = getattr(profile, name)
+            setattr(self, name, _broadcast_per_joint(name, value if value is not None else default, joints))
+
+        for name, alias_name in (("mit_kp", "gripper_mit_kp"), ("mit_kd", "gripper_mit_kd")):
+            alias = getattr(self, alias_name)
+            values = getattr(self, name)
+            original = gain_inputs[name]
+            if alias is None:
+                # Legacy DM scalar/list gains controlled arm joints only; the
+                # gripper had independent defaults. A mapping is the new explicit
+                # way to configure every joint, including the gripper.
+                if (
+                    self.motor_family is MotorFamily.DM
+                    and original is not None
+                    and not isinstance(original, Mapping)
+                ):
+                    values[GRIPPER_MOTOR] = getattr(profile, name)[GRIPPER_MOTOR]
+                setattr(self, alias_name, values[GRIPPER_MOTOR])
+                continue
+            alias = _require_finite(alias_name, alias)
+            if isinstance(original, Mapping) and values[GRIPPER_MOTOR] != alias:
+                raise ValueError(
+                    f'`{alias_name}` conflicts with `{name}["{GRIPPER_MOTOR}"]`; configure only one value.'
+                )
+            values[GRIPPER_MOTOR] = alias
+            setattr(self, alias_name, alias)
+
+        for name in ("mit_kp", "mit_kd", "joint_directions"):
+            values = getattr(self, name)
+            for joint, value in values.items():
+                values[joint] = _require_finite(f"{name}[{joint}]", value)
+
+        invalid_directions = {
+            joint: direction
+            for joint, direction in self.joint_directions.items()
+            if direction not in (-1.0, 1.0)
         }
-    )
+        if invalid_directions:
+            raise ValueError(
+                "`joint_directions` values must be +1 or -1. Invalid values: "
+                + ", ".join(f"{joint}={value}" for joint, value in invalid_directions.items())
+                + "."
+            )
 
-    # Max speed (deg/s) per joint for POS_VEL arms and FORCE_POS gripper (motor order).
-    pos_vel_velocity: float | list[float] = field(
-        default_factory=lambda: [150.0, 150.0, 150.0, 150.0, 150.0, 150.0, 900.0]
-    )
+        if self.joint_limits is None:
+            self.joint_limits = dict(profile.joint_limits)
+        _validate_exact_keys("joint_limits", self.joint_limits, joints)
+        normalized_limits: dict[str, tuple[float, float]] = {}
+        for joint, limits in self.joint_limits.items():
+            if not isinstance(limits, (tuple, list)) or len(limits) != 2:
+                raise ValueError(f"`joint_limits[{joint}]` must contain exactly (min, max).")
+            lower = _require_finite(f"joint_limits[{joint}][0]", limits[0])
+            upper = _require_finite(f"joint_limits[{joint}][1]", limits[1])
+            if lower >= upper:
+                raise ValueError(f"`joint_limits[{joint}]` must satisfy min < max.")
+            normalized_limits[joint] = (lower, upper)
+        self.joint_limits = normalized_limits
 
-    # Arm control: "mit" or "pos_vel".
-    control_mode: str = "mit"
+        for joint in joints:
+            kp_max, kd_max = profile.mit_gain_scale[joint]
+            # Shipped DM configs use kd=12 on the proximal joints even though the
+            # MIT frame saturates at 5. Keep accepting that established input
+            # (and no larger) so upgrading does not invalidate existing configs.
+            kd_config_max = max(kd_max, profile.mit_kd[joint])
+            kp = self.mit_kp[joint]
+            kd = self.mit_kd[joint]
+            if not 0.0 <= kp <= kp_max:
+                raise ValueError(f"`mit_kp[{joint}]` must be in [0, {kp_max}].")
+            if not 0.0 <= kd <= kd_config_max:
+                raise ValueError(f"`mit_kd[{joint}]` must be in [0, {kd_config_max}].")
 
-    # MIT kp/kd per arm joint (motor order). Unused when control_mode="pos_vel".
-    mit_kp: float | list[float] = field(default_factory=lambda: [45.0, 45.0, 45.0, 8.0, 9.0, 8.0, 8.0])
-    mit_kd: float | list[float] = field(default_factory=lambda: [12.0, 12.0, 12.0, 1.0, 1.0, 1.0, 1.0])
+        self.wrap_guard_margin_deg = _require_finite("wrap_guard_margin_deg", self.wrap_guard_margin_deg)
+        if self.wrap_guard_margin_deg < 0.0:
+            raise ValueError("`wrap_guard_margin_deg` must be non-negative.")
+        self.feedback_cache_ttl_s = _require_finite("feedback_cache_ttl_s", self.feedback_cache_ttl_s)
+        if self.feedback_cache_ttl_s <= 0.0:
+            raise ValueError("`feedback_cache_ttl_s` must be positive.")
 
-    # Gripper control: "force_pos" or "mit".
-    gripper_control_mode: str = "force_pos"
+        if self.max_relative_target is not None:
+            if isinstance(self.max_relative_target, Mapping):
+                _validate_exact_keys("max_relative_target", self.max_relative_target, joints)
+                self.max_relative_target = {
+                    joint: _require_finite(f"max_relative_target[{joint}]", value)
+                    for joint, value in self.max_relative_target.items()
+                }
+                if any(value <= 0.0 for value in self.max_relative_target.values()):
+                    raise ValueError("Every `max_relative_target` value must be positive.")
+            else:
+                self.max_relative_target = _require_finite("max_relative_target", self.max_relative_target)
+                if self.max_relative_target <= 0.0:
+                    raise ValueError("`max_relative_target` must be positive.")
 
-    # FORCE_POS only: max grip force, in [0, 1].
-    gripper_torque_ratio: float = 0.07
+        self._resolve_mode_scoped_defaults(profile, joints)
 
-    # MIT only.
-    gripper_mit_kp: float = 8.0
-    gripper_mit_kd: float = 0.3
+    def _resolve_mode_scoped_defaults(self, profile: MotorFamilyProfile, joints: tuple[str, ...]) -> None:
+        """Fill in the parameters that only exist for some control modes.
 
-    # Soft joint limits (degrees). These are clipped against on every action.
-    joint_limits: dict[str, tuple[float, float]] = field(
-        default_factory=lambda: {
-            "shoulder_pan": (-150.0, 150.0),
-            "shoulder_lift": (-200.0, 1.0),
-            "elbow_flex": (-200.0, 1.0),
-            "wrist_flex": (-80.0, 90.0),
-            "wrist_yaw": (-90.0, 90.0),
-            "wrist_roll": (-90.0, 90.0),
-            "gripper": (-270.0, 0.0),
-        }
-    )
+        A parameter the active family cannot use is rejected rather than ignored:
+        silently dropping something like a gripper torque limit would leave the
+        user believing a safety cap is in force when it is not.
+        """
+        uses_velocity_limit = self.control_mode == "pos_vel" or self.gripper_control_mode == "force_pos"
+        if not uses_velocity_limit:
+            if self.pos_vel_velocity is not None:
+                raise ValueError(
+                    "`pos_vel_velocity` has no effect unless the arm uses `pos_vel` "
+                    "or the gripper uses `force_pos`."
+                )
+        else:
+            value = self.pos_vel_velocity
+            default_velocity = profile.pos_vel_velocity
+            if value is None and default_velocity is None:
+                raise ValueError(
+                    f"No default `pos_vel_velocity` is defined for {self.motor_family.value} motors."
+                )
+            self.pos_vel_velocity = _broadcast_per_joint(
+                "pos_vel_velocity",
+                value if value is not None else default_velocity,
+                joints,
+            )
+            for joint, velocity in self.pos_vel_velocity.items():
+                velocity = _require_finite(f"pos_vel_velocity[{joint}]", velocity)
+                if velocity <= 0.0:
+                    raise ValueError(f"`pos_vel_velocity[{joint}]` must be positive.")
+                self.pos_vel_velocity[joint] = velocity
+
+        if self.gripper_control_mode == "force_pos":
+            if self.gripper_torque_ratio is None:
+                self.gripper_torque_ratio = profile.gripper_torque_ratio
+            if self.gripper_torque_ratio is None:
+                raise ValueError("`gripper_torque_ratio` is required in `force_pos` mode.")
+            self.gripper_torque_ratio = _require_finite("gripper_torque_ratio", self.gripper_torque_ratio)
+            if not 0.0 <= self.gripper_torque_ratio <= 1.0:
+                raise ValueError("`gripper_torque_ratio` must be in [0, 1].")
+        elif self.gripper_torque_ratio is not None:
+            raise ValueError("`gripper_torque_ratio` only applies in `force_pos` mode.")
+
+        impedance_fields = ("gripper_torque_limit", "gripper_hold_torque_limit")
+        if self.gripper_control_mode == "mit_impedance":
+            for name in impedance_fields:
+                if getattr(self, name) is None:
+                    setattr(self, name, getattr(profile, name))
+                value = _require_finite(name, getattr(self, name))
+                setattr(self, name, value)
+                if value <= 0:
+                    raise ValueError(f"`{name}` must be positive in `mit_impedance` mode.")
+            if self.gripper_hold_torque_limit > self.gripper_torque_limit:
+                raise ValueError("`gripper_hold_torque_limit` must not exceed `gripper_torque_limit`.")
+            gripper_ceiling = profile.torque_ceiling[GRIPPER_MOTOR]
+            if self.gripper_torque_limit > gripper_ceiling:
+                raise ValueError(
+                    f"`gripper_torque_limit` must not exceed the motor peak torque {gripper_ceiling}."
+                )
+        else:
+            configured = [name for name in impedance_fields if getattr(self, name) is not None]
+            if configured:
+                raise ValueError(
+                    f"{', '.join(f'`{name}`' for name in configured)} only applies in `mit_impedance` mode."
+                )
+
+    def __post_init__(self) -> None:
+        self._resolve_motor_family_defaults()
+
+    def as_robot_config(
+        self,
+        *,
+        id: str | None = None,
+        calibration_dir: Path | None = None,
+        cameras: dict[str, CameraConfig] | None = None,
+    ) -> "RebotB601FollowerRobotConfig":
+        """Promote this arm config to the registered robot config.
+
+        Used by the bimanual follower, whose per-arm configs are declared as the
+        plain base type. Every field is forwarded by name so that adding an option
+        never requires threading it through by hand.
+        """
+        values = {f.name: getattr(self, f.name) for f in fields(RebotB601FollowerConfig)}
+        values = deepcopy(values)
+        if cameras is not None:
+            values["cameras"] = deepcopy(cameras)
+        return RebotB601FollowerRobotConfig(id=id, calibration_dir=calibration_dir, **values)
 
 
 @RobotConfig.register_subclass("rebot_b601_follower")
 @dataclass
 class RebotB601FollowerRobotConfig(RobotConfig, RebotB601FollowerConfig):
-    """Registered configuration for the reBot B601-DM follower robot."""
+    """Registered configuration for the reBot B601 follower robot.
 
-    pass
+    Selects the Damiao or RobStride build with `--robot.motor_family={dm,rs}`.
+    """
+
+    def __post_init__(self) -> None:
+        # `RobotConfig` comes first in the MRO, so its `__post_init__` shadows the
+        # one on `RebotB601FollowerConfig`. Chain both explicitly.
+        RobotConfig.__post_init__(self)
+        RebotB601FollowerConfig.__post_init__(self)
+
+
+__all__ = [
+    "CAN_ADAPTERS",
+    "RebotB601FollowerConfig",
+    "RebotB601FollowerRobotConfig",
+    "public_joint_limits",
+]

--- a/src/lerobot/robots/rebot_b601_follower/motor_family.py
+++ b/src/lerobot/robots/rebot_b601_follower/motor_family.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Family-specific hardware facts and defaults for the reBot B601.
+
+The B601-DM (Damiao) and B601-RS (RobStride) share one software interface but
+differ in actuator models, wiring, mounting directions and validated modes.
+Those integration facts live here; user preferences remain on the robot config.
+"""
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+from types import MappingProxyType
+
+# Motor order. Per-joint config fields are validated against the joints actually
+# declared in `motor_can_ids`, so this tuple only fixes the default layout.
+JOINT_NAMES: tuple[str, ...] = (
+    "shoulder_pan",
+    "shoulder_lift",
+    "elbow_flex",
+    "wrist_flex",
+    "wrist_yaw",
+    "wrist_roll",
+    "gripper",
+)
+
+# The three high-torque base joints, which carry a different motor model (and
+# therefore different torque and MIT-gain scaling) than the four distal ones.
+PROXIMAL_JOINTS: frozenset[str] = frozenset({"shoulder_pan", "shoulder_lift", "elbow_flex"})
+
+GRIPPER_MOTOR = "gripper"
+
+
+def _immutable[T](values: Mapping[str, T]) -> Mapping[str, T]:
+    """Copy a mapping into a read-only profile value."""
+    return MappingProxyType(dict(values))
+
+
+def _by_segment[T](proximal: T, distal: T) -> Mapping[str, T]:
+    """Assign one value to the proximal joints and another to the distal ones."""
+    return _immutable({joint: (proximal if joint in PROXIMAL_JOINTS else distal) for joint in JOINT_NAMES})
+
+
+class MotorFamily(StrEnum):
+    """Actuator family of a reBot B601 arm."""
+
+    DM = "dm"
+    RS = "rs"
+
+
+# Arm control modes. Only MIT carries a feedforward torque term, so it is the only
+# mode a torque-based feature (gravity compensation, force limiting) can build on.
+ARM_MODE_MIT = "mit"
+ARM_MODE_POS_VEL = "pos_vel"
+
+# Gripper control modes.
+GRIPPER_MODE_MIT = "mit"
+GRIPPER_MODE_FORCE_POS = "force_pos"
+GRIPPER_MODE_MIT_IMPEDANCE = "mit_impedance"
+
+
+@dataclass(frozen=True)
+class MotorFamilyProfile:
+    """Immutable hardware facts and default tuning for one motor family.
+
+    Mapping fields are mapping proxies, so neither the profile nor its tables can
+    be mutated after construction. Configs copy values they expose to users.
+    """
+
+    family: MotorFamily
+
+    # --- hardware facts (never user-overridable) ---
+
+    # Vendor model string per joint, passed to the matching motorbridge factory.
+    motor_models: Mapping[str, str]
+    # Control modes supported by this B601 integration. A vendor may expose more
+    # protocol modes that have not been validated on this arm.
+    arm_modes: frozenset[str]
+    gripper_modes: frozenset[str]
+    # `motorbridge.Mode` attribute each supported mode maps onto. Kept as strings
+    # so this module stays importable without the optional dependency.
+    mode_frames: Mapping[str, str]
+    # Peak torque (N.m) per joint from the vendor tables. Bounds any feedforward
+    # torque the robot emits.
+    torque_ceiling: Mapping[str, float]
+    # Protocol-level full scale (kp_max, kd_max) that a MIT frame packs gains
+    # against, per joint. RobStride splits this across a single arm — rs-06 packs
+    # kp over 0..5000 and kd over 0..100 while rs-00 uses 0..500 and 0..5 — so RS
+    # gains are not comparable between joints the way Damiao's are. Recorded here
+    # to document that divergence and for any future native-bus or torque-based
+    # path; `motorbridge` does its own per-model packing from the model string, so
+    # these figures are not the scales currently applied on the wire.
+    mit_gain_scale: Mapping[str, tuple[float, float]]
+    # --- defaults for the matching config fields ---
+
+    # CAN transports supported by this motor family. The Damiao serial bridge is
+    # vendor-specific; SocketCAN can carry both families.
+    can_adapters: frozenset[str]
+    can_adapter: str
+    control_mode: str
+    gripper_control_mode: str
+    motor_can_ids: Mapping[str, tuple[int, int]]
+    # MIT gains per joint, including the gripper: the gripper's MIT gains live here
+    # rather than in dedicated fields so each joint has a single source of truth.
+    mit_kp: Mapping[str, float]
+    mit_kd: Mapping[str, float]
+    joint_limits: Mapping[str, tuple[float, float]]
+    # Sign converting between the public robot coordinate frame and the raw motor
+    # frame. It is applied in both directions so observations and actions share
+    # one convention.
+    joint_directions: Mapping[str, float]
+    # Speed cap (deg/s) per joint for POS_VEL arm joints and the FORCE_POS gripper.
+    # None on families without those modes.
+    pos_vel_velocity: Mapping[str, float] | None
+    # FORCE_POS gripper: grip force as a fraction of peak torque, in [0, 1].
+    gripper_torque_ratio: float | None
+    # Impedance gripper: max |feedforward torque| (N.m) while moving, and the
+    # gentler cap applied at near-zero speed so a grasp neither crushes nor
+    # overcurrents.
+    gripper_torque_limit: float | None
+    gripper_hold_torque_limit: float | None
+
+
+DM_PROFILE = MotorFamilyProfile(
+    family=MotorFamily.DM,
+    motor_models=_by_segment("4340P", "4310"),
+    arm_modes=frozenset({ARM_MODE_MIT, ARM_MODE_POS_VEL}),
+    gripper_modes=frozenset({GRIPPER_MODE_FORCE_POS, GRIPPER_MODE_MIT}),
+    mode_frames=_immutable(
+        {
+            ARM_MODE_MIT: "MIT",
+            ARM_MODE_POS_VEL: "POS_VEL",
+            GRIPPER_MODE_FORCE_POS: "FORCE_POS",
+        }
+    ),
+    # DM4340: 28 N.m, DM4310: 10 N.m.
+    torque_ceiling=_by_segment(28.0, 10.0),
+    mit_gain_scale=_by_segment((500.0, 5.0), (500.0, 5.0)),
+    can_adapters=frozenset({"damiao", "socketcan"}),
+    can_adapter="damiao",
+    control_mode=ARM_MODE_MIT,
+    gripper_control_mode=GRIPPER_MODE_FORCE_POS,
+    motor_can_ids=_immutable(
+        {
+            "shoulder_pan": (0x01, 0x11),
+            "shoulder_lift": (0x02, 0x12),
+            "elbow_flex": (0x03, 0x13),
+            "wrist_flex": (0x04, 0x14),
+            "wrist_yaw": (0x05, 0x15),
+            "wrist_roll": (0x06, 0x16),
+            "gripper": (0x07, 0x17),
+        }
+    ),
+    mit_kp=_immutable(
+        {
+            "shoulder_pan": 45.0,
+            "shoulder_lift": 45.0,
+            "elbow_flex": 45.0,
+            "wrist_flex": 8.0,
+            "wrist_yaw": 9.0,
+            "wrist_roll": 8.0,
+            "gripper": 8.0,
+        }
+    ),
+    mit_kd=_immutable(
+        {
+            "shoulder_pan": 12.0,
+            "shoulder_lift": 12.0,
+            "elbow_flex": 12.0,
+            "wrist_flex": 1.0,
+            "wrist_yaw": 1.0,
+            "wrist_roll": 1.0,
+            # The gripper is softer than the arm joints when it runs in MIT mode.
+            "gripper": 0.3,
+        }
+    ),
+    joint_limits=_immutable(
+        {
+            "shoulder_pan": (-150.0, 150.0),
+            "shoulder_lift": (-200.0, 1.0),
+            "elbow_flex": (-200.0, 1.0),
+            "wrist_flex": (-80.0, 90.0),
+            "wrist_yaw": (-90.0, 90.0),
+            "wrist_roll": (-90.0, 90.0),
+            "gripper": (-270.0, 0.0),
+        }
+    ),
+    joint_directions=_immutable(dict.fromkeys(JOINT_NAMES, 1.0)),
+    pos_vel_velocity=_immutable({**dict.fromkeys(JOINT_NAMES, 150.0), GRIPPER_MOTOR: 900.0}),
+    gripper_torque_ratio=0.07,
+    gripper_torque_limit=None,
+    gripper_hold_torque_limit=None,
+)
+
+RS_PROFILE = MotorFamilyProfile(
+    family=MotorFamily.RS,
+    motor_models=_by_segment("rs-06", "rs-00"),
+    # RobStride motors have no FORCE_POS equivalent. MotorBridge exposes
+    # RobStride position modes, but Seeed's current B601 integration uses MIT
+    # because position-velocity operation was unstable. Supporting position mode
+    # here requires a dedicated command path and hardware validation.
+    arm_modes=frozenset({ARM_MODE_MIT}),
+    gripper_modes=frozenset({GRIPPER_MODE_MIT_IMPEDANCE}),
+    mode_frames=_immutable(
+        {
+            ARM_MODE_MIT: "MIT",
+            GRIPPER_MODE_MIT_IMPEDANCE: "MIT",
+        }
+    ),
+    # rs-06: 36 N.m, rs-00: 14 N.m.
+    torque_ceiling=_by_segment(36.0, 14.0),
+    mit_gain_scale=_by_segment((5000.0, 100.0), (500.0, 5.0)),
+    can_adapters=frozenset({"socketcan"}),
+    # motorbridge 0.4+ reaches the RS bus through python-can/SocketCAN.
+    can_adapter="socketcan",
+    control_mode=ARM_MODE_MIT,
+    gripper_control_mode=GRIPPER_MODE_MIT_IMPEDANCE,
+    # RobStride motors all reply on the host id rather than a per-motor recv id.
+    motor_can_ids=_immutable({joint: (i, 0xFD) for i, joint in enumerate(JOINT_NAMES, start=1)}),
+    mit_kp=_immutable(
+        {
+            "shoulder_pan": 50.0,
+            "shoulder_lift": 150.0,
+            "elbow_flex": 150.0,
+            "wrist_flex": 50.0,
+            "wrist_yaw": 50.0,
+            "wrist_roll": 50.0,
+            "gripper": 12.0,
+        }
+    ),
+    mit_kd=_immutable(
+        {
+            "shoulder_pan": 3.0,
+            "shoulder_lift": 10.0,
+            "elbow_flex": 10.0,
+            "wrist_flex": 5.0,
+            "wrist_yaw": 4.0,
+            "wrist_roll": 4.0,
+            "gripper": 0.05,
+        }
+    ),
+    # RS motors are installed opposite to the DM build, so these are the
+    # positive-physical travel ranges. Incoming targets are mapped into them by
+    # `joint_directions` before clipping.
+    joint_limits=_immutable(
+        {
+            "shoulder_pan": (-145.0, 145.0),
+            "shoulder_lift": (0.0, 170.0),
+            "elbow_flex": (0.0, 200.0),
+            "wrist_flex": (-80.0, 90.0),
+            "wrist_yaw": (-90.0, 90.0),
+            "wrist_roll": (-90.0, 90.0),
+            "gripper": (0.0, 270.0),
+        }
+    ),
+    joint_directions=_immutable(dict.fromkeys(JOINT_NAMES, -1.0)),
+    pos_vel_velocity=None,
+    gripper_torque_ratio=None,
+    gripper_torque_limit=3.5,
+    gripper_hold_torque_limit=1.0,
+)
+
+PROFILES: Mapping[MotorFamily, MotorFamilyProfile] = MappingProxyType(
+    {
+        MotorFamily.DM: DM_PROFILE,
+        MotorFamily.RS: RS_PROFILE,
+    }
+)
+
+
+def profile_for(family: MotorFamily | str) -> MotorFamilyProfile:
+    """Return the hardware profile for a motor family.
+
+    Raises:
+        ValueError: if `family` is not a known motor family.
+    """
+    try:
+        return PROFILES[MotorFamily(family)]
+    except ValueError:
+        known = ", ".join(f.value for f in MotorFamily)
+        raise ValueError(f"Unknown motor_family '{family}'. Available families: {known}.") from None

--- a/src/lerobot/robots/rebot_b601_follower/rebot_b601_follower.py
+++ b/src/lerobot/robots/rebot_b601_follower/rebot_b601_follower.py
@@ -18,7 +18,7 @@ import logging
 import math
 import time
 from functools import cached_property
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from lerobot.cameras import make_cameras_from_configs
 from lerobot.lerobot_types import RobotAction, RobotObservation
@@ -28,7 +28,16 @@ from lerobot.utils.import_utils import _motorbridge_available, require_package
 
 from ..robot import Robot
 from ..utils import ensure_safe_goal_position
-from .config_rebot_b601_follower import RebotB601FollowerRobotConfig
+from .config_rebot_b601_follower import RebotB601FollowerRobotConfig, public_joint_limits
+from .motor_family import (
+    ARM_MODE_POS_VEL,
+    GRIPPER_MODE_FORCE_POS,
+    GRIPPER_MODE_MIT_IMPEDANCE,
+    GRIPPER_MOTOR,
+    MotorFamily,
+    MotorFamilyProfile,
+    profile_for,
+)
 
 if TYPE_CHECKING or _motorbridge_available:
     from motorbridge import Controller as MotorBridgeController, Mode as MotorBridgeMode
@@ -38,28 +47,41 @@ else:
 
 logger = logging.getLogger(__name__)
 
-# Joint controlled in FORCE_POS mode; every other joint runs in POS_VEL mode.
-GRIPPER_MOTOR = "gripper"
-# Per-joint Damiao motor models for the B601-DM (passed to motorbridge).
-MOTOR_MODELS = {
-    "shoulder_pan": "4340P",
-    "shoulder_lift": "4340P",
-    "elbow_flex": "4340P",
-    "wrist_flex": "4310",
-    "wrist_yaw": "4310",
-    "wrist_roll": "4310",
-    "gripper": "4310",
-}
 _ENSURE_MODE_RETRIES = 9
 _SETTLE_SEC = 0.01
 _ZERO_SETTLE_SEC = 0.1
 
+# --- Impedance gripper tuning (shared by any family that offers the mode) ---
+# Motor-side velocity damping. The position setpoint and kp are both zero, so the
+# gripper is driven entirely by the feedforward torque.
+_GRIPPER_IMPEDANCE_DAMPING = 1.5
+# Low-pass factor and ceiling (rad/s) for the target velocity estimate.
+_GRIPPER_LPF_ALPHA = 0.3
+_GRIPPER_TARGET_VEL_MAX = 3.0
+# Below this |measured velocity| (rad/s) the gentler hold torque limit applies.
+_GRIPPER_HOLD_VEL_THRESHOLD = 0.25
+
+
+class MotorFeedbackError(RuntimeError):
+    """Raised when current motor feedback is unavailable or expired."""
+
 
 class RebotB601Follower(Robot):
-    """Seeed Studio reBot B601-DM follower arm (6-DOF + gripper, Damiao CAN motors).
+    """Seeed Studio reBot B601 follower arm (6-DOF + gripper, CAN motors).
+
+    Supports both builds of the arm through ``config.motor_family``: ``"dm"`` for
+    the Damiao B601-DM and ``"rs"`` for the RobStride B601-RS. The two share
+    joint topology, names and degree units but differ in geometry, motor models,
+    CAN id convention, available control modes, installed joint direction and
+    gripper strategy — all carried by the family's
+    :class:`MotorFamilyProfile`.
 
     Motor communication is handled by the ``motorbridge`` package over a CAN bus,
     reached either through a Damiao serial bridge or a SocketCAN adapter.
+
+    Observations and actions share one public robot coordinate frame. Family
+    profiles convert that frame to and from raw motor coordinates, so a position
+    read from an observation can be sent back as an action to hold the joint.
     """
 
     config_class = RebotB601FollowerRobotConfig
@@ -69,10 +91,13 @@ class RebotB601Follower(Robot):
         require_package("motorbridge", extra="rebot")
         super().__init__(config)
         self.config = config
+        self.profile: MotorFamilyProfile = profile_for(config.motor_family)
         self.bus: MotorBridgeController | None = None
         self.motors: dict = {}
-        self.motor_names = list(config.motor_can_ids.keys())
+        self.motor_names = list(config.motor_can_ids)
         self.cameras = make_cameras_from_configs(config.cameras)
+        self._feedback_cache: dict[str, tuple[Any, float]] = {}
+        self._reset_gripper_impedance_state()
 
     @property
     def _motors_ft(self) -> dict[str, type]:
@@ -99,37 +124,53 @@ class RebotB601Follower(Robot):
 
     @property
     def is_connected(self) -> bool:
-        return self.bus is not None and all(cam.is_connected for cam in self.cameras.values())
+        return self.bus is not None
 
     @check_if_already_connected
     def connect(self, calibrate: bool = True) -> None:
-        logger.info(f"Connecting {self} on {self.config.port} (adapter={self.config.can_adapter})...")
+        logger.info(
+            f"Connecting {self} on {self.config.port} "
+            f"(family={self.config.motor_family.value}, adapter={self.config.can_adapter})..."
+        )
         if self.config.can_adapter == "damiao":
             self.bus = MotorBridgeController.from_dm_serial(
                 serial_port=self.config.port,
                 baud=self.config.dm_serial_baud,
             )
-        elif self.config.can_adapter == "socketcan":
-            self.bus = MotorBridgeController(channel=self.config.port)
         else:
-            raise ValueError(
-                f"Unsupported can_adapter '{self.config.can_adapter}'. Use 'damiao' or 'socketcan'."
-            )
+            self.bus = MotorBridgeController(channel=self.config.port)
 
-        for motor_name, (send_id, recv_id) in self.config.motor_can_ids.items():
-            self.motors[motor_name] = self.bus.add_damiao_motor(send_id, recv_id, MOTOR_MODELS[motor_name])
+        try:
+            self._register_motors()
+            self.bus.disable_all()
+            self._feedback_cache.clear()
+            self._reset_gripper_impedance_state()
 
-        if not self.is_calibrated and calibrate:
-            logger.info(
-                "Mismatch between calibration values in the motor and the calibration file or no calibration file found"
-            )
-            self.calibrate()
+            if not self.is_calibrated and calibrate:
+                logger.info(
+                    "Mismatch between calibration values in the motor and the calibration file "
+                    "or no calibration file found"
+                )
+                self.calibrate()
 
-        for cam in self.cameras.values():
-            cam.connect()
+            for cam in self.cameras.values():
+                cam.connect()
 
-        self.configure()
+            self.configure()
+        except Exception:
+            self._cleanup_failed_connection()
+            raise
         logger.info(f"{self} connected.")
+
+    def _register_motors(self) -> None:
+        """Declare every joint on the bus using this family's motorbridge factory."""
+        add_motor = (
+            self.bus.add_damiao_motor
+            if self.config.motor_family is MotorFamily.DM
+            else self.bus.add_robstride_motor
+        )
+        for motor_name, (send_id, recv_id) in self.config.motor_can_ids.items():
+            self.motors[motor_name] = add_motor(send_id, recv_id, self.profile.motor_models[motor_name])
 
     @property
     def is_calibrated(self) -> bool:
@@ -174,25 +215,35 @@ class RebotB601Follower(Robot):
         print(f"Calibration saved to {self.calibration_fpath}")
 
     def configure(self) -> None:
-        if self.config.control_mode not in ("pos_vel", "mit"):
-            raise ValueError(
-                f"Unsupported control_mode '{self.config.control_mode}'. Use 'pos_vel' or 'mit'."
-            )
-        if self.config.gripper_control_mode not in ("force_pos", "mit"):
-            raise ValueError(
-                f"Unsupported gripper_control_mode '{self.config.gripper_control_mode}'. "
-                "Use 'force_pos' or 'mit'."
-            )
-        use_mit = self.config.control_mode == "mit"
-        gripper_use_mit = self.config.gripper_control_mode == "mit"
-        self.bus.enable_all()
+        """Validate fresh state and configure every motor while torque is off."""
+        self.bus.disable_all()
+        try:
+            states = self._read_feedback(strict=True)
+            if self.config.check_position_plausibility:
+                self._assert_positions_plausible(states)
+            self._apply_control_modes()
+        except Exception:
+            # Keep torque disabled on every validation/configuration failure.
+            try:
+                self.bus.disable_all()
+            except Exception:
+                logger.exception("Failed to confirm torque-off state after configuration error.")
+            raise
+        else:
+            self.bus.enable_all()
+
+    def _cleanup_failed_connection(self) -> None:
+        """Best-effort cleanup that preserves the original connection error."""
+        self._disconnect(force_disable=True)
+
+    def _target_mode(self, motor_name: str) -> Any:
+        """motorbridge mode this joint should run in, given the configured modes."""
+        mode = self.config.gripper_control_mode if motor_name == GRIPPER_MOTOR else self.config.control_mode
+        return getattr(MotorBridgeMode, self.profile.mode_frames[mode])
+
+    def _apply_control_modes(self) -> None:
         for motor_name, motor in self.motors.items():
-            if motor_name == GRIPPER_MOTOR:
-                target_mode = MotorBridgeMode.MIT if gripper_use_mit else MotorBridgeMode.FORCE_POS
-            elif use_mit:
-                target_mode = MotorBridgeMode.MIT
-            else:
-                target_mode = MotorBridgeMode.POS_VEL
+            target_mode = self._target_mode(motor_name)
             for attempt in range(_ENSURE_MODE_RETRIES + 1):
                 try:
                     motor.ensure_mode(target_mode)
@@ -203,48 +254,144 @@ class RebotB601Follower(Robot):
                     time.sleep(_SETTLE_SEC)
             logger.debug(f"{motor_name} mode set to {target_mode}")
 
+    def _assert_positions_plausible(self, states: dict[str, Any]) -> None:
+        """Refuse to drive a joint whose reading is a whole-revolution wrap.
+
+        A motor's single-turn zero survives a power cycle but its multi-turn count
+        does not, so a geared joint with more than one turn of travel (the gripper)
+        can wake up reading ``physical + 360*k`` degrees. Commanding it from there
+        would drive it into its mechanical stop, so fail loudly instead.
+        """
+        margin = self.config.wrap_guard_margin_deg
+        wrapped = []
+        for motor_name, state in states.items():
+            position = math.degrees(state.pos)
+            limits = self.config.joint_limits.get(motor_name)
+            if limits is None:
+                continue
+            range_min, range_max = limits
+            # Deliberately exclude the margin boundary: for the gripper, the
+            # default 90° margin plus its 270° travel lands exactly on a one-turn
+            # wrap (±360°).
+            if not (range_min - margin < position < range_max + margin):
+                wrapped.append(f"{motor_name}={position:.1f} deg (limits {range_min}..{range_max} deg)")
+        if wrapped:
+            raise RuntimeError(
+                "Implausible joint reading(s), most likely a multi-turn encoder wrap after a "
+                f"power cycle: {', '.join(wrapped)}. Move the joint(s) back into range by hand "
+                "(gripper: close it against the stop) and re-run calibration before enabling "
+                "torque. Set `check_position_plausibility=False` to bypass this check."
+            )
+
     @check_if_not_connected
     def disable_torque(self) -> None:
-        """Disable motor torque so the arm can be moved by hand (read-only debugging)."""
+        """Disable motor torque so the arm can be moved by hand (read-only debugging).
+
+        The arm becomes back-drivable and will fall under gravity: hold it first.
+        """
         self.bus.disable_all()
         logger.info(f"{self} torque disabled.")
 
-    def _present_pos(self) -> dict[str, float]:
-        """Read present joint positions in degrees."""
-        for motor in self.motors.values():
-            motor.request_feedback()
-        try:
-            self.bus.poll_feedback_once()
-        except Exception:
-            logger.warning("CAN bus poll feedback failed.")
+    def _read_feedback(self, *, strict: bool = False) -> dict[str, Any]:
+        """Refresh motor states, using only a short-lived cache at runtime.
 
-        present_pos = {}
+        MotorBridge's RobStride ``request_feedback`` is a no-op, so freshness is
+        established by a successful controller poll. On a newly opened controller,
+        strict startup additionally requires all seven states to be present.
+        """
+        refresh_error: Exception | None = None
+        refreshed = False
+        try:
+            for motor in self.motors.values():
+                motor.request_feedback()
+            self.bus.poll_feedback_once()
+            refreshed = True
+        except Exception as exc:
+            refresh_error = exc
+
+        now = time.monotonic()
+        states: dict[str, Any] = {}
+        unavailable: list[str] = []
         for motor_name, motor in self.motors.items():
-            state = motor.get_state()
-            present_pos[motor_name] = math.degrees(state.pos) if state is not None else 0.0
-        return present_pos
+            try:
+                state = motor.get_state() if refreshed else None
+            except Exception as exc:
+                refresh_error = refresh_error or exc
+                state = None
+            if state is not None:
+                self._feedback_cache[motor_name] = (state, now)
+                states[motor_name] = state
+                continue
+            if not strict:
+                cached = self._feedback_cache.get(motor_name)
+                if cached is not None and now - cached[1] <= self.config.feedback_cache_ttl_s:
+                    states[motor_name] = cached[0]
+                    continue
+            unavailable.append(motor_name)
+
+        if refresh_error is not None and strict:
+            raise MotorFeedbackError(
+                "Failed to refresh motor feedback before enabling torque."
+            ) from refresh_error
+        if unavailable:
+            reason = "missing from the current refresh" if strict else "missing or expired"
+            raise MotorFeedbackError(
+                f"Motor feedback {reason} for: {', '.join(unavailable)}. "
+                "Refusing to substitute fabricated zero positions."
+            ) from refresh_error
+        if refresh_error is not None:
+            logger.warning("Using cached motor feedback after refresh failure: %s", refresh_error)
+        return states
+
+    def _public_to_motor_position(self, motor_name: str, position_deg: float) -> float:
+        return position_deg * self.config.joint_directions[motor_name]
+
+    def _motor_to_public_position(self, motor_name: str, position_deg: float) -> float:
+        return position_deg / self.config.joint_directions[motor_name]
+
+    def _public_to_motor_torque(self, motor_name: str, torque: float) -> float:
+        return torque * self.config.joint_directions[motor_name]
+
+    def _public_joint_limits(self) -> dict[str, tuple[float, float]]:
+        return public_joint_limits(self.config.joint_limits, self.config.joint_directions)
+
+    def _present_pos(self, *, motor_frame: bool = False, strict: bool = False) -> dict[str, float]:
+        """Read current positions in either raw motor or public robot coordinates."""
+        states = self._read_feedback(strict=strict)
+        positions = {}
+        for motor_name, state in states.items():
+            motor_position = math.degrees(state.pos)
+            positions[motor_name] = (
+                motor_position if motor_frame else self._motor_to_public_position(motor_name, motor_position)
+            )
+        return positions
 
     @check_if_not_connected
     def get_observation(self) -> RobotObservation:
-        start = time.perf_counter()
-        obs_dict = {f"{motor}.pos": pos for motor, pos in self._present_pos().items()}
-        dt_ms = (time.perf_counter() - start) * 1e3
-        logger.debug(f"{self} read state: {dt_ms:.1f}ms")
+        try:
+            start = time.perf_counter()
+            obs_dict: RobotObservation = {f"{motor}.pos": pos for motor, pos in self._present_pos().items()}
+            dt_ms = (time.perf_counter() - start) * 1e3
+            logger.debug(f"{self} read state: {dt_ms:.1f}ms")
 
-        for cam_key, cam in self.cameras.items():
-            if getattr(cam, "use_rgb", True):
-                start = time.perf_counter()
-                obs_dict[cam_key] = cam.read_latest()
-                dt_ms = (time.perf_counter() - start) * 1e3
-                logger.debug(f"{self} read {cam_key}: {dt_ms:.1f}ms")
+            for cam_key, cam in self.cameras.items():
+                if not cam.is_connected:
+                    raise RuntimeError(f"Camera '{cam_key}' disconnected while reading reBot observation.")
+                if getattr(cam, "use_rgb", True):
+                    start = time.perf_counter()
+                    obs_dict[cam_key] = cam.read_latest()
+                    dt_ms = (time.perf_counter() - start) * 1e3
+                    logger.debug(f"{self} read {cam_key}: {dt_ms:.1f}ms")
 
-            if getattr(cam, "use_depth", False):
-                start = time.perf_counter()
-                obs_dict[f"{cam_key}_depth"] = cam.read_latest_depth()
-                dt_ms = (time.perf_counter() - start) * 1e3
-                logger.debug(f"{self} read {cam_key} depth: {dt_ms:.1f}ms")
-
-        return obs_dict
+                if getattr(cam, "use_depth", False):
+                    start = time.perf_counter()
+                    obs_dict[f"{cam_key}_depth"] = cam.read_latest_depth()
+                    dt_ms = (time.perf_counter() - start) * 1e3
+                    logger.debug(f"{self} read {cam_key} depth: {dt_ms:.1f}ms")
+            return obs_dict
+        except Exception:
+            self._disconnect(force_disable=True)
+            raise
 
     @check_if_not_connected
     def send_action(self, action: RobotAction) -> RobotAction:
@@ -252,76 +399,201 @@ class RebotB601Follower(Robot):
 
         Positions are expressed in degrees. The relative action magnitude may be
         clipped depending on `max_relative_target`, so the action actually sent is
-        always returned.
+        always returned in the same public robot coordinate frame as observations.
         """
-        goal_pos = {key.removesuffix(".pos"): val for key, val in action.items() if key.endswith(".pos")}
+        try:
+            goal_pos = {key.removesuffix(".pos"): val for key, val in action.items() if key.endswith(".pos")}
 
-        # Clip against soft joint limits.
-        for motor_name in list(goal_pos):
-            if motor_name in self.config.joint_limits:
-                min_limit, max_limit = self.config.joint_limits[motor_name]
-                clipped = max(min_limit, min(max_limit, goal_pos[motor_name]))
-                if clipped != goal_pos[motor_name]:
-                    logger.debug(f"Clipped {motor_name} from {goal_pos[motor_name]:.2f} to {clipped:.2f}")
-                goal_pos[motor_name] = clipped
+            # Tolerate 6-DOF leaders that have no wrist_yaw joint by holding it at zero.
+            if "wrist_yaw" in self.motor_names and "wrist_yaw" not in goal_pos:
+                goal_pos["wrist_yaw"] = 0.0
 
-        # Tolerate 6-DOF leaders that have no wrist_yaw joint by holding it at zero.
-        # This is intentional: it lets a 6-DOF leader such as the SO-100 / SO-101
-        # (so100_leader / so101_leader) teleoperate this 7-DOF follower — the missing
-        # wrist_yaw command is simply treated as 0.0 instead of raising.
-        if "wrist_yaw" not in goal_pos:
-            goal_pos["wrist_yaw"] = 0.0
+            if self.config.max_relative_target is not None:
+                present_pos = self._present_pos()
+                goal_present_pos = {key: (goal, present_pos.get(key, goal)) for key, goal in goal_pos.items()}
+                relative_limits = self.config.max_relative_target
+                if isinstance(relative_limits, dict):
+                    relative_limits = {key: relative_limits[key] for key in goal_present_pos}
+                goal_pos = ensure_safe_goal_position(goal_present_pos, relative_limits)
 
-        # Cap relative target when too far from the present position.
-        if self.config.max_relative_target is not None:
-            present_pos = self._present_pos()
-            goal_present_pos = {key: (g, present_pos.get(key, g)) for key, g in goal_pos.items()}
-            goal_pos = ensure_safe_goal_position(goal_present_pos, self.config.max_relative_target)
+            sent_pos = {}
+            for motor_name, position_deg in goal_pos.items():
+                if motor_name in self.motors:
+                    sent_pos[motor_name] = self._send_joint(motor_name, position_deg)
+            return {f"{motor}.pos": val for motor, val in sent_pos.items()}
+        except MotorFeedbackError:
+            self._disconnect(force_disable=True)
+            raise
 
-        use_mit = self.config.control_mode == "mit"
-        for motor_name, position_deg in goal_pos.items():
-            motor = self.motors.get(motor_name)
-            if motor is None:
-                continue
-            idx = self.motor_names.index(motor_name)
-            pos_rad = math.radians(position_deg)
-            if motor_name == GRIPPER_MOTOR:
-                if self.config.gripper_control_mode == "mit":
-                    motor.send_mit(pos_rad, 0.0, self.config.gripper_mit_kp, self.config.gripper_mit_kd, 0.0)
-                else:
-                    vel_deg_s = (
-                        self.config.pos_vel_velocity[idx]
-                        if isinstance(self.config.pos_vel_velocity, list)
-                        else self.config.pos_vel_velocity
-                    )
-                    motor.send_force_pos(pos_rad, math.radians(vel_deg_s), self.config.gripper_torque_ratio)
-            elif use_mit:
-                kp = self.config.mit_kp[idx] if isinstance(self.config.mit_kp, list) else self.config.mit_kp
-                kd = self.config.mit_kd[idx] if isinstance(self.config.mit_kd, list) else self.config.mit_kd
-                motor.send_mit(pos_rad, 0.0, kp, kd, 0.0)
-            else:
-                vel_deg_s = (
-                    self.config.pos_vel_velocity[idx]
-                    if isinstance(self.config.pos_vel_velocity, list)
-                    else self.config.pos_vel_velocity
+    def _send_joint(self, motor_name: str, position_deg: float, *, tau_ff: float = 0.0) -> float:
+        """Emit one joint command.
+
+        Every command reaches the bus through here, so a feedforward torque term
+        (gravity compensation, force limiting) has a single injection point that
+        works for both motor families. Position and torque enter in the public
+        robot frame, then are mapped into the raw motor frame and clamped.
+
+        Returns:
+            The position actually sent, expressed in the public robot frame.
+        """
+        motor = self.motors[motor_name]
+        motor_position_deg = self._public_to_motor_position(motor_name, position_deg)
+        limits = self.config.joint_limits.get(motor_name)
+        if limits is not None:
+            range_min, range_max = limits
+            clipped = max(range_min, min(range_max, motor_position_deg))
+            if clipped != motor_position_deg:
+                logger.debug(f"Clipped {motor_name} from {motor_position_deg:.2f} to {clipped:.2f}")
+            motor_position_deg = clipped
+        position_rad = math.radians(motor_position_deg)
+        motor_tau_ff = self._clamp_torque(motor_name, self._public_to_motor_torque(motor_name, tau_ff))
+
+        if motor_name == GRIPPER_MOTOR:
+            if self.config.gripper_control_mode == GRIPPER_MODE_MIT_IMPEDANCE:
+                # Driven purely by a clamped feedforward torque, with the position
+                # setpoint and kp both zero. This bounds grip force, where a plain
+                # position command would keep pushing toward the target regardless
+                # of force and can overcurrent when closing on an object.
+                try:
+                    tau = self._gripper_impedance_torque(position_rad)
+                except MotorFeedbackError:
+                    try:
+                        motor.send_mit(0.0, 0.0, 0.0, _GRIPPER_IMPEDANCE_DAMPING, 0.0)
+                    except Exception:
+                        logger.exception("Failed to command zero RS gripper torque after feedback loss.")
+                    raise
+                motor.send_mit(0.0, 0.0, 0.0, _GRIPPER_IMPEDANCE_DAMPING, tau)
+            elif self.config.gripper_control_mode == GRIPPER_MODE_FORCE_POS:
+                motor.send_force_pos(
+                    position_rad,
+                    math.radians(self.config.pos_vel_velocity[motor_name]),
+                    self.config.gripper_torque_ratio,
                 )
-                motor.send_pos_vel(pos_rad, math.radians(vel_deg_s))
+            else:
+                motor.send_mit(
+                    position_rad,
+                    0.0,
+                    self.config.mit_kp[motor_name],
+                    self.config.mit_kd[motor_name],
+                    motor_tau_ff,
+                )
+        elif self.config.control_mode == ARM_MODE_POS_VEL:
+            motor.send_pos_vel(position_rad, math.radians(self.config.pos_vel_velocity[motor_name]))
+        else:
+            motor.send_mit(
+                position_rad,
+                0.0,
+                self.config.mit_kp[motor_name],
+                self.config.mit_kd[motor_name],
+                motor_tau_ff,
+            )
+        # The impedance gripper sends an internal zero position setpoint, but its
+        # effective requested target remains this clipped public position.
+        return self._motor_to_public_position(motor_name, motor_position_deg)
 
-        return {f"{motor}.pos": val for motor, val in goal_pos.items()}
+    def _clamp_torque(self, motor_name: str, torque: float) -> float:
+        """Bound a feedforward torque to the joint motor's peak rating."""
+        ceiling = self.profile.torque_ceiling.get(motor_name)
+        if ceiling is None:
+            return torque
+        return max(-ceiling, min(ceiling, torque))
 
-    @check_if_not_connected
+    def _reset_gripper_impedance_state(self) -> None:
+        self._gripper_prev_target_pos: float | None = None
+        self._gripper_prev_target_vel: float | None = None
+        self._gripper_prev_state_pos: float | None = None
+        self._gripper_prev_time: float | None = None
+
+    def _gripper_impedance_torque(self, target_pos_rad: float) -> float:
+        """Force-limited impedance torque for the gripper.
+
+        Computes ``tau = kp*(x_r - x) + kd*(v_r - v)`` from the target and the
+        motor's measured state, then clamps it to the moving or holding torque
+        limit depending on how fast the gripper is actually travelling. Returns 0
+        when no feedback is available, which leaves the gripper limp rather than
+        guessing at a torque.
+        """
+        state = self._read_feedback()[GRIPPER_MOTOR]
+        now = time.monotonic()
+        previous_time = self._gripper_prev_time
+        dt = None if previous_time is None else now - previous_time
+        self._gripper_prev_time = now
+
+        prev_target = self._gripper_prev_target_pos
+        target_vel = (
+            0.0 if prev_target is None or dt is None or dt <= 0.0 else (target_pos_rad - prev_target) / dt
+        )
+        self._gripper_prev_target_pos = target_pos_rad
+
+        prev_target_vel = self._gripper_prev_target_vel
+        if prev_target_vel is not None:
+            target_vel = _GRIPPER_LPF_ALPHA * target_vel + (1.0 - _GRIPPER_LPF_ALPHA) * prev_target_vel
+        target_vel = max(-_GRIPPER_TARGET_VEL_MAX, min(_GRIPPER_TARGET_VEL_MAX, target_vel))
+        self._gripper_prev_target_vel = target_vel
+
+        prev_state_pos = self._gripper_prev_state_pos
+        measured_vel = (
+            0.0 if prev_state_pos is None or dt is None or dt <= 0.0 else (state.pos - prev_state_pos) / dt
+        )
+        self._gripper_prev_state_pos = state.pos
+
+        torque = self.config.mit_kp[GRIPPER_MOTOR] * (target_pos_rad - state.pos) + self.config.mit_kd[
+            GRIPPER_MOTOR
+        ] * (target_vel - state.vel)
+
+        limit = (
+            self.config.gripper_torque_limit
+            if abs(measured_vel) > _GRIPPER_HOLD_VEL_THRESHOLD
+            else self.config.gripper_hold_torque_limit
+        )
+        return self._clamp_torque(GRIPPER_MOTOR, max(-limit, min(limit, torque)))
+
     def disconnect(self) -> None:
-        for motor in self.motors.values():
-            if self.config.disable_torque_on_disconnect:
-                motor.disable()
-            motor.clear_error()
-            motor.close()
+        """Disconnect from the robot.
 
-        self.bus.close()
-        self.bus = None
-        self.motors = {}
-
-        for cam in self.cameras.values():
-            cam.disconnect()
-
+        With `disable_torque_on_disconnect=True` (the default) the arm becomes
+        back-drivable and falls under gravity: hold it or park it in a stable rest
+        pose first.
+        """
+        self._disconnect(force_disable=self.config.disable_torque_on_disconnect)
         logger.info(f"{self} disconnected.")
+
+    def _disconnect(self, *, force_disable: bool) -> None:
+        """Release every acquired resource, continuing after individual failures."""
+        bus = self.bus
+        motors = tuple(self.motors.values())
+        try:
+            if bus is not None and force_disable:
+                try:
+                    bus.disable_all()
+                except Exception:
+                    logger.exception("Failed to disable reBot torque during cleanup.")
+            for motor in motors:
+                if force_disable:
+                    try:
+                        motor.disable()
+                    except Exception:
+                        logger.exception("Failed to disable a reBot motor during cleanup.")
+                try:
+                    motor.clear_error()
+                except Exception:
+                    logger.exception("Failed to clear a reBot motor error during cleanup.")
+                try:
+                    motor.close()
+                except Exception:
+                    logger.exception("Failed to close a reBot motor during cleanup.")
+            if bus is not None:
+                try:
+                    bus.close()
+                except Exception:
+                    logger.exception("Failed to close the reBot controller during cleanup.")
+            for camera in self.cameras.values():
+                try:
+                    camera.disconnect()
+                except Exception:
+                    logger.exception("Failed to disconnect a reBot camera during cleanup.")
+        finally:
+            self.bus = None
+            self.motors = {}
+            self._feedback_cache.clear()
+            self._reset_gripper_impedance_state()

--- a/src/lerobot/robots/rebot_b601_follower/rebot_b601_follower.py
+++ b/src/lerobot/robots/rebot_b601_follower/rebot_b601_follower.py
@@ -400,13 +400,10 @@ class RebotB601Follower(Robot):
         Positions are expressed in degrees. The relative action magnitude may be
         clipped depending on `max_relative_target`, so the action actually sent is
         always returned in the same public robot coordinate frame as observations.
+        Joints omitted from a partial action are not sent a new command.
         """
         try:
             goal_pos = {key.removesuffix(".pos"): val for key, val in action.items() if key.endswith(".pos")}
-
-            # Tolerate 6-DOF leaders that have no wrist_yaw joint by holding it at zero.
-            if "wrist_yaw" in self.motor_names and "wrist_yaw" not in goal_pos:
-                goal_pos["wrist_yaw"] = 0.0
 
             if self.config.max_relative_target is not None:
                 present_pos = self._present_pos()

--- a/src/lerobot/robots/rebot_b601_follower/rebot_b601_follower.py
+++ b/src/lerobot/robots/rebot_b601_follower/rebot_b601_follower.py
@@ -40,16 +40,24 @@ from .motor_family import (
 )
 
 if TYPE_CHECKING or _motorbridge_available:
-    from motorbridge import Controller as MotorBridgeController, Mode as MotorBridgeMode
+    from motorbridge import (
+        RID_ESC_ID as MOTOR_BRIDGE_DAMIAO_ESC_ID_REGISTER,
+        Controller as MotorBridgeController,
+        Mode as MotorBridgeMode,
+    )
 else:
     MotorBridgeController = None
     MotorBridgeMode = None
+    # Damiao protocol register 8 stores the motor's command CAN ID. Keep tests
+    # importable without the optional MotorBridge package.
+    MOTOR_BRIDGE_DAMIAO_ESC_ID_REGISTER = 8
 
 logger = logging.getLogger(__name__)
 
 _ENSURE_MODE_RETRIES = 9
 _SETTLE_SEC = 0.01
 _ZERO_SETTLE_SEC = 0.1
+_CONNECTIVITY_TIMEOUT_MS = 100
 
 # --- Impedance gripper tuning (shared by any family that offers the mode) ---
 # Motor-side velocity damping. The position setpoint and kp are both zero, so the
@@ -218,6 +226,7 @@ class RebotB601Follower(Robot):
         """Validate fresh state and configure every motor while torque is off."""
         self.bus.disable_all()
         try:
+            self._assert_motors_reachable()
             states = self._read_feedback(strict=True)
             if self.config.check_position_plausibility:
                 self._assert_positions_plausible(states)
@@ -231,6 +240,34 @@ class RebotB601Follower(Robot):
             raise
         else:
             self.bus.enable_all()
+
+    def _assert_motors_reachable(self) -> None:
+        """Require a synchronous response from every motor before enabling torque.
+
+        ``get_state()`` can retain a previous/default value, so a non-``None``
+        state after polling does not prove that a powered motor answered this
+        startup attempt. Use each vendor's request/response operation instead.
+        """
+        for motor_name, motor in self.motors.items():
+            send_id, recv_id = self.config.motor_can_ids[motor_name]
+            try:
+                if self.config.motor_family is MotorFamily.DM:
+                    reported_id = motor.damiao_get_param_u32(
+                        MOTOR_BRIDGE_DAMIAO_ESC_ID_REGISTER,
+                        timeout_ms=_CONNECTIVITY_TIMEOUT_MS,
+                    )
+                    if reported_id != send_id:
+                        raise RuntimeError(
+                            f"reported command CAN ID 0x{reported_id:X}, expected 0x{send_id:X}"
+                        )
+                else:
+                    reported_ids = tuple(motor.robstride_ping())
+                    if reported_ids != (send_id, recv_id):
+                        raise RuntimeError(f"reported IDs {reported_ids}, expected {(send_id, recv_id)}")
+            except Exception as exc:
+                raise MotorFeedbackError(
+                    f"Motor '{motor_name}' did not provide a valid synchronous startup response."
+                ) from exc
 
     def _cleanup_failed_connection(self) -> None:
         """Best-effort cleanup that preserves the original connection error."""
@@ -586,7 +623,8 @@ class RebotB601Follower(Robot):
                     logger.exception("Failed to close the reBot controller during cleanup.")
             for camera in self.cameras.values():
                 try:
-                    camera.disconnect()
+                    if camera.is_connected:
+                        camera.disconnect()
                 except Exception:
                     logger.exception("Failed to disconnect a reBot camera during cleanup.")
         finally:

--- a/src/lerobot/robots/rebot_b601_follower/rebot_b601_follower.py
+++ b/src/lerobot/robots/rebot_b601_follower/rebot_b601_follower.py
@@ -249,7 +249,7 @@ class RebotB601Follower(Robot):
         startup attempt. Use each vendor's request/response operation instead.
         """
         for motor_name, motor in self.motors.items():
-            send_id, recv_id = self.config.motor_can_ids[motor_name]
+            send_id, _ = self.config.motor_can_ids[motor_name]
             try:
                 if self.config.motor_family is MotorFamily.DM:
                     reported_id = motor.damiao_get_param_u32(
@@ -261,9 +261,11 @@ class RebotB601Follower(Robot):
                             f"reported command CAN ID 0x{reported_id:X}, expected 0x{send_id:X}"
                         )
                 else:
-                    reported_ids = tuple(motor.robstride_ping())
-                    if reported_ids != (send_id, recv_id):
-                        raise RuntimeError(f"reported IDs {reported_ids}, expected {(send_id, recv_id)}")
+                    # The second value identifies the ping reply frame (0xFE on
+                    # hardware); it is not the configured host ID (0xFD).
+                    device_id, _responder_id = motor.robstride_ping()
+                    if device_id != send_id:
+                        raise RuntimeError(f"reported device CAN ID 0x{device_id:X}, expected 0x{send_id:X}")
             except Exception as exc:
                 raise MotorFeedbackError(
                     f"Motor '{motor_name}' did not provide a valid synchronous startup response."

--- a/tests/robots/test_rebot_b601_follower.py
+++ b/tests/robots/test_rebot_b601_follower.py
@@ -16,12 +16,17 @@
 
 import math
 from collections.abc import Mapping
+from contextlib import contextmanager
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from lerobot.robots.bi_rebot_b601_follower import BiRebotB601Follower, BiRebotB601FollowerConfig
 from lerobot.robots.rebot_b601_follower import (
+    DM_PROFILE,
+    RS_PROFILE,
+    MotorFamily,
+    MotorFeedbackError,
     RebotB601Follower,
     RebotB601FollowerConfig,
     RebotB601FollowerRobotConfig,
@@ -49,48 +54,75 @@ def _per_joint(value: float | list[float] | Mapping[str, float]) -> dict[str, fl
     return dict.fromkeys(_JOINTS, float(value))
 
 
-def _make_motor_mock(position_rad: float = 0.0) -> MagicMock:
+FAMILIES = [MotorFamily.DM, MotorFamily.RS]
+
+
+def _make_motor_mock(position_rad: float | None = 0.0) -> MagicMock:
     motor = MagicMock(name="MotorMock")
+    if position_rad is None:
+        motor.get_state.return_value = None
+        return motor
     state = MagicMock()
     state.pos = position_rad
+    state.vel = 0.0
     motor.get_state.return_value = state
     return motor
 
 
-def _make_bus_mock() -> MagicMock:
+def _make_bus_mock(positions_deg: list[float | None] | None = None) -> MagicMock:
+    """Bus whose motors report a known position, in joint declaration order."""
     bus = MagicMock(name="MotorBridgeControllerMock")
-    # add_damiao_motor returns a fresh motor mock; position encodes the call order.
     bus._motor_count = 0
 
-    def _add_motor(_send_id, _recv_id, _model):
+    def _add_motor(_send_id, _recv_id, model):
+        index = bus._motor_count
         bus._motor_count += 1
-        return _make_motor_mock(position_rad=math.radians(bus._motor_count))
+        # Default seeds each motor with its 1-indexed creation order, in degrees.
+        position = index + 1 if positions_deg is None else positions_deg[index]
+        motor = _make_motor_mock(position_rad=None if position is None else math.radians(position))
+        motor.model = model
+        return motor
 
     bus.add_damiao_motor.side_effect = _add_motor
+    bus.add_robstride_motor.side_effect = _add_motor
     return bus
 
 
-@pytest.fixture
-def follower():
-    bus_mock = _make_bus_mock()
+@contextmanager
+def _connected(motor_family, *, positions_deg=None, poll_error: Exception | None = None, **config_kwargs):
+    bus_mock = _make_bus_mock(positions_deg)
+    if poll_error is not None:
+        bus_mock.poll_feedback_once.side_effect = poll_error
     with (
         patch(f"{_MODULE}.require_package", lambda *a, **kw: None),
         patch(f"{_MODULE}.MotorBridgeController") as controller_cls,
         patch(f"{_MODULE}.MotorBridgeMode", MagicMock()),
     ):
+        # The Damiao serial bridge and the SocketCAN path build the controller
+        # differently; both resolve to the same mock here.
         controller_cls.from_dm_serial.return_value = bus_mock
-        cfg = RebotB601FollowerRobotConfig(port="/dev/null")
-        robot = RebotB601Follower(cfg)
+        controller_cls.return_value = bus_mock
+        config = RebotB601FollowerRobotConfig(motor_family=motor_family, port="/dev/null", **config_kwargs)
+        robot = RebotB601Follower(config)
         robot.connect(calibrate=False)
-        yield robot
-        if robot.is_connected:
-            robot.disconnect()
+        try:
+            yield robot
+        finally:
+            if robot.is_connected:
+                robot.disconnect()
 
 
-def test_features_match_joints():
+def _build(motor_family, **config_kwargs) -> RebotB601Follower:
     with patch(f"{_MODULE}.require_package", lambda *a, **kw: None):
-        robot = RebotB601Follower(RebotB601FollowerRobotConfig(port="/dev/null"))
-    expected = {f"{m}.pos" for m in robot.motor_names}
+        return RebotB601Follower(
+            RebotB601FollowerRobotConfig(motor_family=motor_family, port="/dev/null", **config_kwargs)
+        )
+
+
+@pytest.mark.parametrize("family", FAMILIES)
+def test_features_match_joints(family):
+    robot = _build(family)
+    expected = {f"{motor}.pos" for motor in robot.motor_names}
     assert set(robot.action_features) == expected
     assert set(robot.observation_features) == expected
     assert "gripper.pos" in expected
@@ -103,6 +135,8 @@ def test_shipped_dm_defaults_are_preserved():
     assert config.control_mode == "mit"
     assert config.gripper_control_mode == "force_pos"
     assert config.gripper_torque_ratio == 0.07
+    assert config.gripper_mit_kp == 8.0
+    assert config.gripper_mit_kd == 0.3
     assert config.joint_limits == {
         "shoulder_pan": (-150.0, 150.0),
         "shoulder_lift": (-200.0, 1.0),
@@ -116,7 +150,7 @@ def test_shipped_dm_defaults_are_preserved():
         zip(_JOINTS, [45.0, 45.0, 45.0, 8.0, 9.0, 8.0, 8.0], strict=True)
     )
     assert _per_joint(config.mit_kd) == dict(
-        zip(_JOINTS, [12.0, 12.0, 12.0, 1.0, 1.0, 1.0, 1.0], strict=True)
+        zip(_JOINTS, [12.0, 12.0, 12.0, 1.0, 1.0, 1.0, 0.3], strict=True)
     )
 
     leader = RebotArm102LeaderConfig(port="/dev/null")
@@ -153,65 +187,512 @@ def test_legacy_dm_config_accepts_gain_lists_without_motor_family():
     assert config.gripper_mit_kd == 0.2
 
 
-def test_connect_disconnect(follower):
-    assert follower.is_connected
-    follower.disconnect()
-    assert not follower.is_connected
+def test_legacy_gripper_gain_alias_rejects_conflicting_mapping():
+    gains = dict(DM_PROFILE.mit_kp)
+    gains["gripper"] = 7.0
+    with pytest.raises(ValueError, match="conflicts"):
+        RebotB601FollowerRobotConfig(
+            port="/dev/null",
+            mit_kp=gains,
+            gripper_mit_kp=6.0,
+        )
 
 
-def test_get_observation_converts_to_degrees(follower):
-    obs = follower.get_observation()
-    assert set(obs) == {f"{m}.pos" for m in follower.motor_names}
-    # The bus mock seeds each motor's position with its 1-indexed creation order (radians).
-    for idx, motor in enumerate(follower.motor_names, 1):
-        assert obs[f"{motor}.pos"] == pytest.approx(math.degrees(math.radians(idx)))
+def test_legacy_dm_gain_lists_keep_independent_gripper_defaults():
+    config = RebotB601FollowerRobotConfig(
+        port="/dev/null",
+        mit_kp=[40.0, 41.0, 42.0, 7.0, 8.0, 9.0, 6.0],
+        mit_kd=[5.0, 5.0, 5.0, 0.7, 0.8, 0.9, 0.2],
+    )
+    assert config.mit_kp["gripper"] == 8.0
+    assert config.mit_kd["gripper"] == 0.3
+    assert config.gripper_mit_kp == 8.0
+    assert config.gripper_mit_kd == 0.3
 
 
-def test_dm_public_positions_equal_motor_positions(follower):
-    obs = follower.get_observation()
-
-    for motor_name, motor in follower.motors.items():
-        assert obs[f"{motor_name}.pos"] == pytest.approx(math.degrees(motor.get_state().pos))
+def test_family_profiles_are_deeply_immutable():
+    with pytest.raises(TypeError):
+        DM_PROFILE.mit_kp["shoulder_pan"] = 1.0
 
 
-def test_send_action_clips_to_joint_limits(follower):
-    # shoulder_pan limit is (-150, 150); request beyond the upper bound.
-    returned = follower.send_action({"shoulder_pan.pos": 999.0})
-    assert returned["shoulder_pan.pos"] == 150.0
-    # Default control_mode is "mit", so arm joints are driven via send_mit.
-    follower.motors["shoulder_pan"].send_mit.assert_called_once()
+@pytest.mark.parametrize("family", FAMILIES)
+def test_both_families_expose_the_same_joints(family):
+    assert _build(family).motor_names == _build(MotorFamily.DM).motor_names
 
 
-def test_send_action_routes_gripper_to_force_pos(follower):
-    follower.send_action({"gripper.pos": -10.0})
-    follower.motors["gripper"].send_force_pos.assert_called_once()
-    follower.motors["gripper"].send_pos_vel.assert_not_called()
+@pytest.mark.parametrize("family", FAMILIES)
+def test_connect_disconnect(family):
+    with _connected(family) as robot:
+        assert robot.is_connected
+        robot.disconnect()
+        assert not robot.is_connected
 
 
-def test_gripper_mit_mode_routes_to_send_mit():
-    bus_mock = _make_bus_mock()
-    with (
-        patch(f"{_MODULE}.require_package", lambda *a, **kw: None),
-        patch(f"{_MODULE}.MotorBridgeController") as controller_cls,
-        patch(f"{_MODULE}.MotorBridgeMode", MagicMock()),
-    ):
-        controller_cls.from_dm_serial.return_value = bus_mock
-        cfg = RebotB601FollowerRobotConfig(port="/dev/null", gripper_control_mode="mit")
-        robot = RebotB601Follower(cfg)
-        robot.connect(calibrate=False)
+@pytest.mark.parametrize("family", FAMILIES)
+def test_get_observation_converts_to_degrees(family):
+    with _connected(family) as robot:
+        obs = robot.get_observation()
+        assert set(obs) == {f"{motor}.pos" for motor in robot.motor_names}
+        direction = robot.config.joint_directions["shoulder_pan"]
+        for index, motor in enumerate(robot.motor_names, 1):
+            assert obs[f"{motor}.pos"] == pytest.approx(index / direction)
+
+
+@pytest.mark.parametrize(
+    ("family", "expected_factory", "unused_factory", "expected_model"),
+    [
+        (MotorFamily.DM, "add_damiao_motor", "add_robstride_motor", "4340P"),
+        (MotorFamily.RS, "add_robstride_motor", "add_damiao_motor", "rs-06"),
+    ],
+)
+def test_registers_motors_with_the_family_factory(family, expected_factory, unused_factory, expected_model):
+    with _connected(family) as robot:
+        assert getattr(robot.bus, expected_factory).call_count == len(robot.motor_names)
+        getattr(robot.bus, unused_factory).assert_not_called()
+        # The three proximal joints carry the larger motor model.
+        assert robot.motors["shoulder_pan"].model == expected_model
+
+
+@pytest.mark.parametrize(
+    ("family", "expected_public_position", "expected_motor_position"),
+    [(MotorFamily.DM, 150.0, 150.0), (MotorFamily.RS, 145.0, -145.0)],
+)
+def test_send_action_clips_to_the_family_joint_limits(
+    family, expected_public_position, expected_motor_position
+):
+    with _connected(family) as robot:
+        returned = robot.send_action({"shoulder_pan.pos": 999.0})
+        # The return value stays in the public robot frame for both families.
+        assert returned["shoulder_pan.pos"] == expected_public_position
+        robot.motors["shoulder_pan"].send_mit.assert_called_once()
+        motor_position = math.degrees(robot.motors["shoulder_pan"].send_mit.call_args.args[0])
+        assert motor_position == pytest.approx(expected_motor_position)
+
+
+def test_rs_flips_joint_direction():
+    with _connected(MotorFamily.RS) as robot:
+        returned = robot.send_action({"shoulder_pan.pos": 100.0})
+        assert returned["shoulder_pan.pos"] == 100.0
+        motor_position = robot.motors["shoulder_pan"].send_mit.call_args.args[0]
+        assert math.degrees(motor_position) == pytest.approx(-100.0)
+
+
+def test_rs_observation_can_be_sent_back_to_hold_position():
+    with _connected(MotorFamily.RS, positions_deg=[10.0] * 7) as robot:
+        observed = robot.get_observation()["shoulder_pan.pos"]
+        robot.send_action({"shoulder_pan.pos": observed})
+        motor_position = robot.motors["shoulder_pan"].send_mit.call_args.args[0]
+        assert observed == -10.0
+        assert math.degrees(motor_position) == pytest.approx(10.0)
+
+
+def test_rs_public_limits_are_derived_from_raw_limits_and_direction():
+    robot = _build(MotorFamily.RS)
+    assert robot._public_joint_limits()["wrist_flex"] == (-90.0, 80.0)
+    assert robot._public_joint_limits()["shoulder_lift"] == (-170.0, 0.0)
+
+
+def test_dm_does_not_flip_joint_direction():
+    with _connected(MotorFamily.DM) as robot:
+        returned = robot.send_action({"shoulder_pan.pos": 100.0})
+        assert returned["shoulder_pan.pos"] == 100.0
+
+
+@pytest.mark.parametrize("family", FAMILIES)
+def test_missing_wrist_yaw_is_held_at_zero(family):
+    with _connected(family) as robot:
+        returned = robot.send_action({"shoulder_pan.pos": 0.0})
+        assert returned["wrist_yaw.pos"] == 0.0
+
+
+def test_dm_gripper_defaults_to_force_pos():
+    with _connected(MotorFamily.DM) as robot:
+        robot.send_action({"gripper.pos": -10.0})
+        robot.motors["gripper"].send_force_pos.assert_called_once()
+        robot.motors["gripper"].send_mit.assert_not_called()
+
+
+def test_dm_gripper_mit_mode_routes_to_send_mit():
+    with _connected(MotorFamily.DM, gripper_control_mode="mit") as robot:
         robot.send_action({"gripper.pos": -10.0})
         robot.motors["gripper"].send_mit.assert_called_once()
         robot.motors["gripper"].send_force_pos.assert_not_called()
 
 
-def test_bimanual_prefixes_features():
-    with patch(f"{_MODULE}.require_package", lambda *a, **kw: None):
-        cfg = BiRebotB601FollowerConfig(
-            left_arm_config=RebotB601FollowerConfig(port="/dev/null0"),
-            right_arm_config=RebotB601FollowerConfig(port="/dev/null1"),
+def test_dm_pos_vel_mode_routes_arm_joints_to_send_pos_vel():
+    with _connected(MotorFamily.DM, control_mode="pos_vel") as robot:
+        robot.send_action({"shoulder_pan.pos": 10.0})
+        robot.motors["shoulder_pan"].send_pos_vel.assert_called_once()
+        robot.motors["shoulder_pan"].send_mit.assert_not_called()
+
+
+def test_rs_gripper_uses_force_limited_impedance():
+    # The impedance strategy drives the gripper purely by a feedforward torque:
+    # position setpoint and kp are zero so grip force stays bounded.
+    with _connected(MotorFamily.RS) as robot:
+        robot.send_action({"gripper.pos": -100.0})
+        position, velocity, kp, kd, tau = robot.motors["gripper"].send_mit.call_args.args
+        assert (position, velocity, kp) == (0.0, 0.0, 0.0)
+        assert kd > 0.0
+        assert abs(tau) <= robot.config.gripper_torque_limit
+
+
+def test_rs_impedance_gripper_returns_effective_clipped_target():
+    with _connected(MotorFamily.RS) as robot:
+        returned = robot.send_action({"gripper.pos": -999.0})
+        position, *_ = robot.motors["gripper"].send_mit.call_args.args
+        assert position == 0.0
+        assert returned["gripper.pos"] == -270.0
+
+
+def test_rs_gripper_torque_respects_the_hold_limit_at_rest():
+    # A stationary gripper (the mock reports zero velocity) gets the gentler hold
+    # limit rather than the moving limit.
+    with _connected(MotorFamily.RS) as robot:
+        robot.send_action({"gripper.pos": -270.0})
+        tau = robot.motors["gripper"].send_mit.call_args.args[4]
+        assert abs(tau) <= robot.config.gripper_hold_torque_limit
+
+
+def test_rs_gripper_velocity_estimate_uses_monotonic_elapsed_time():
+    clock = MagicMock(side_effect=[0.0, 1.0, 1.0, 1.1, 1.1])
+    with patch(f"{_MODULE}.time.monotonic", clock), _connected(MotorFamily.RS) as robot:
+        robot.send_action({"gripper.pos": 0.0})
+        robot.send_action({"gripper.pos": -math.degrees(0.05)})
+        # Raw RS target moved +0.05 rad in 0.1 s; LPF alpha is 0.3.
+        assert robot._gripper_prev_target_vel == pytest.approx(0.15)
+
+
+def test_rs_gripper_zeroes_torque_before_expired_feedback_failure():
+    clock = MagicMock(side_effect=[0.0, 0.2])
+    with patch(f"{_MODULE}.time.monotonic", clock), _connected(MotorFamily.RS) as robot:
+        gripper = robot.motors["gripper"]
+        robot.bus.poll_feedback_once.side_effect = RuntimeError("temporary CAN error")
+        gripper.send_mit.side_effect = RuntimeError("CAN transmit failed")
+        with pytest.raises(MotorFeedbackError, match="missing or expired"):
+            robot.send_action({"gripper.pos": -100.0})
+        assert gripper.send_mit.call_args.args[4] == 0.0
+        assert robot.bus is None
+
+
+@pytest.mark.parametrize("family", FAMILIES)
+def test_mode_switching_happens_with_torque_disabled(family):
+    with _connected(family) as robot:
+        calls = [name for name, _, _ in robot.bus.mock_calls if name in ("disable_all", "enable_all")]
+        assert calls[-1] == "enable_all"
+        assert all(call == "disable_all" for call in calls[:-1])
+
+
+@pytest.mark.parametrize("family", FAMILIES)
+def test_wrap_guard_rejects_an_implausible_reading(family):
+    # A whole extra revolution on the gripper, as happens when a multi-turn
+    # encoder wakes wrapped after a power cycle.
+    positions = [0.0] * 6 + [400.0]
+    with (
+        pytest.raises(RuntimeError, match="multi-turn encoder wrap"),
+        _connected(family, positions_deg=positions),
+    ):
+        pass
+
+
+@pytest.mark.parametrize(
+    ("family", "wrapped_position"),
+    [(MotorFamily.DM, -360.0), (MotorFamily.RS, 360.0)],
+)
+def test_wrap_guard_rejects_exactly_one_turn(family, wrapped_position):
+    positions = [0.0] * 6 + [wrapped_position]
+    with (
+        pytest.raises(RuntimeError, match="multi-turn encoder wrap"),
+        _connected(family, positions_deg=positions),
+    ):
+        pass
+
+
+def test_dm_public_positions_equal_motor_positions():
+    with _connected(MotorFamily.DM) as robot:
+        observation = robot.get_observation()
+        for motor_name, motor in robot.motors.items():
+            assert observation[f"{motor_name}.pos"] == pytest.approx(math.degrees(motor.get_state().pos))
+
+
+@pytest.mark.parametrize("family", FAMILIES)
+def test_wrap_guard_rejects_missing_feedback(family):
+    positions = [0.0] * 6 + [None]
+    with (
+        pytest.raises(RuntimeError, match="missing from the current refresh"),
+        _connected(family, positions_deg=positions),
+    ):
+        pass
+
+
+@pytest.mark.parametrize("family", FAMILIES)
+def test_wrap_guard_rejects_failed_feedback_poll(family):
+    with (
+        pytest.raises(RuntimeError, match="Failed to refresh motor feedback"),
+        _connected(family, poll_error=RuntimeError("temporary CAN error")),
+    ):
+        pass
+
+
+@pytest.mark.parametrize("family", FAMILIES)
+def test_startup_requires_feedback_when_wrap_guard_is_disabled(family):
+    positions = [0.0] * 6 + [None]
+    with (
+        pytest.raises(RuntimeError, match="missing from the current refresh"),
+        _connected(family, positions_deg=positions, check_position_plausibility=False),
+    ):
+        pass
+
+
+def test_failed_startup_disables_and_closes_the_bus():
+    bus_mock = _make_bus_mock([0.0] * 6 + [None])
+    with (
+        patch(f"{_MODULE}.require_package", lambda *a, **kw: None),
+        patch(f"{_MODULE}.MotorBridgeController") as controller_cls,
+        patch(f"{_MODULE}.MotorBridgeMode", MagicMock()),
+    ):
+        controller_cls.return_value = bus_mock
+        robot = RebotB601Follower(RebotB601FollowerRobotConfig(motor_family=MotorFamily.RS, port="can0"))
+        with pytest.raises(RuntimeError, match="missing from the current refresh"):
+            robot.connect(calibrate=False)
+
+    assert robot.bus is None
+    assert robot.motors == {}
+    assert bus_mock.disable_all.call_count >= 2
+    bus_mock.close.assert_called_once()
+
+
+@pytest.mark.parametrize("family", FAMILIES)
+def test_wrap_guard_can_be_disabled(family):
+    positions = [0.0] * 6 + [400.0]
+    with _connected(family, positions_deg=positions, check_position_plausibility=False) as robot:
+        assert robot.is_connected
+
+
+@pytest.mark.parametrize("family", FAMILIES)
+def test_feedforward_torque_is_clamped_to_the_motor_ceiling(family):
+    with _connected(family) as robot:
+        ceiling = robot.profile.torque_ceiling["shoulder_pan"]
+        robot._send_joint("shoulder_pan", 0.0, tau_ff=10 * ceiling)
+        expected = ceiling * robot.config.joint_directions["shoulder_pan"]
+        assert robot.motors["shoulder_pan"].send_mit.call_args.args[4] == expected
+
+
+def test_partial_action_subsets_per_joint_relative_limits():
+    limits = dict.fromkeys(_JOINTS, 1.0)
+    with _connected(MotorFamily.DM, max_relative_target=limits) as robot:
+        returned = robot.send_action({"shoulder_pan.pos": 100.0, "wrist_yaw.pos": 5.0})
+        assert returned["shoulder_pan.pos"] == 2.0
+        assert returned["wrist_yaw.pos"] == 5.0
+
+
+def test_rs_gripper_uses_cached_feedback_after_transient_poll_failure():
+    with _connected(MotorFamily.RS) as robot:
+        robot.bus.poll_feedback_once.side_effect = RuntimeError("temporary CAN error")
+        robot.send_action({"gripper.pos": -100.0})
+        robot.motors["gripper"].send_mit.assert_called_once()
+
+
+def test_expired_observation_feedback_disconnects_robot():
+    clock = MagicMock(side_effect=[0.0, 0.2])
+    with patch(f"{_MODULE}.time.monotonic", clock), _connected(MotorFamily.RS) as robot:
+        robot.bus.poll_feedback_once.side_effect = RuntimeError("temporary CAN error")
+        with pytest.raises(MotorFeedbackError, match="missing or expired"):
+            robot.get_observation()
+        assert robot.bus is None
+
+
+def test_disconnect_is_idempotent_and_continues_after_cleanup_failure():
+    with _connected(MotorFamily.DM) as robot:
+        motors = list(robot.motors.values())
+        motors[0].disable.side_effect = RuntimeError("disable failed")
+        motors[0].close.side_effect = RuntimeError("close failed")
+        bus = robot.bus
+        bus.close.side_effect = RuntimeError("bus close failed")
+        robot.disconnect()
+        robot.disconnect()
+
+    assert robot.bus is None
+    assert robot.motors == {}
+    motors[-1].close.assert_called_once()
+
+
+def test_rs_rejects_damiao_serial_transport():
+    with pytest.raises(ValueError, match="not available for rs motors"):
+        RebotB601FollowerRobotConfig(
+            motor_family=MotorFamily.RS,
+            port="/dev/ttyACM0",
+            can_adapter="damiao",
         )
-        robot = BiRebotB601Follower(cfg)
-    assert any(k.startswith("left_") for k in robot.action_features)
-    assert any(k.startswith("right_") for k in robot.action_features)
+
+
+def test_dm_allows_socketcan_transport():
+    config = RebotB601FollowerRobotConfig(
+        motor_family=MotorFamily.DM,
+        port="can0",
+        can_adapter="socketcan",
+    )
+    assert config.can_adapter == "socketcan"
+
+
+def test_can_id_strategy_is_validated():
+    duplicate_send = dict(DM_PROFILE.motor_can_ids)
+    duplicate_send["gripper"] = duplicate_send["shoulder_pan"]
+    with pytest.raises(ValueError, match="send CAN IDs must be unique"):
+        RebotB601FollowerRobotConfig(port="/dev/null", motor_can_ids=duplicate_send)
+
+    invalid_rs_host = dict(RS_PROFILE.motor_can_ids)
+    invalid_rs_host["gripper"] = (0x07, 0x17)
+    with pytest.raises(ValueError, match="host ID 0xFD"):
+        RebotB601FollowerRobotConfig(
+            motor_family=MotorFamily.RS,
+            port="can0",
+            motor_can_ids=invalid_rs_host,
+        )
+
+
+def test_numeric_safety_configuration_is_validated():
+    with pytest.raises(ValueError, match="feedback_cache_ttl_s"):
+        RebotB601FollowerRobotConfig(port="/dev/null", feedback_cache_ttl_s=float("nan"))
+    with pytest.raises(ValueError, match="max_relative_target"):
+        RebotB601FollowerRobotConfig(port="/dev/null", max_relative_target=0.0)
+    with pytest.raises(ValueError, match="gripper_hold_torque_limit"):
+        RebotB601FollowerRobotConfig(
+            motor_family=MotorFamily.RS,
+            port="can0",
+            gripper_torque_limit=1.0,
+            gripper_hold_torque_limit=2.0,
+        )
+
+
+def test_mode_scoped_gripper_safety_parameters():
+    with pytest.raises(ValueError, match="gripper_control_mode 'mit' is not available"):
+        RebotB601FollowerRobotConfig(
+            motor_family=MotorFamily.RS,
+            port="can0",
+            gripper_control_mode="mit",
+        )
+
+
+def test_direction_scaling_is_rejected():
+    with pytest.raises(ValueError, match="must be \\+1 or -1"):
+        RebotB601FollowerRobotConfig(
+            motor_family=MotorFamily.DM,
+            port="/dev/null",
+            joint_directions={**dict.fromkeys(DM_PROFILE.motor_models, 1.0), "gripper": -6.0},
+        )
+
+
+def test_profiles_disagree_where_the_hardware_does():
+    assert DM_PROFILE.motor_models != RS_PROFILE.motor_models
+    assert set(DM_PROFILE.joint_directions.values()) == {1.0}
+    assert set(RS_PROFILE.joint_directions.values()) == {-1.0}
+    # POS_VEL is intentionally not exposed for the B601-RS until validated,
+    # while RobStride has no FORCE_POS equivalent.
+    assert "pos_vel" in DM_PROFILE.arm_modes and "pos_vel" not in RS_PROFILE.arm_modes
+    # RobStride motors all answer on the host id instead of a per-motor recv id.
+    assert {ids[1] for ids in RS_PROFILE.motor_can_ids.values()} == {0xFD}
+    assert len({ids[1] for ids in DM_PROFILE.motor_can_ids.values()}) == len(DM_PROFILE.motor_can_ids)
+    assert RS_PROFILE.can_adapters == {"socketcan"}
+    assert DM_PROFILE.can_adapters == {"damiao", "socketcan"}
+    # RS defaults preserve the hardware-tested values from PR #4256.
+    assert RS_PROFILE.mit_kp["shoulder_lift"] == 150.0
+    assert RS_PROFILE.mit_kd["shoulder_lift"] == 10.0
+    assert RS_PROFILE.joint_limits["wrist_roll"] == (-90.0, 90.0)
+    assert DM_PROFILE.joint_limits["wrist_roll"] == (-90.0, 90.0)
+    assert DM_PROFILE.gripper_torque_ratio == 0.07
+
+
+@pytest.mark.parametrize("family", FAMILIES)
+def test_bimanual_prefixes_features(family):
+    with patch(f"{_MODULE}.require_package", lambda *a, **kw: None):
+        robot = BiRebotB601Follower(
+            BiRebotB601FollowerConfig(
+                left_arm_config=RebotB601FollowerConfig(motor_family=family, port="/dev/null0"),
+                right_arm_config=RebotB601FollowerConfig(motor_family=family, port="/dev/null1"),
+            )
+        )
     assert "left_gripper.pos" in robot.action_features
     assert "right_gripper.pos" in robot.action_features
+
+
+def test_bimanual_rejects_mixed_motor_families():
+    with pytest.raises(ValueError, match="Mixed DM/RS"):
+        BiRebotB601FollowerConfig(
+            left_arm_config=RebotB601FollowerConfig(motor_family=MotorFamily.DM, port="/dev/null0"),
+            right_arm_config=RebotB601FollowerConfig(motor_family=MotorFamily.RS, port="can0"),
+        )
+
+
+def test_bimanual_rejects_overlapping_ids_on_same_channel():
+    with pytest.raises(ValueError, match="overlapping send IDs"):
+        BiRebotB601FollowerConfig(
+            left_arm_config=RebotB601FollowerConfig(port="/dev/ttyACM0"),
+            right_arm_config=RebotB601FollowerConfig(port="/dev/ttyACM0"),
+        )
+
+
+def test_bimanual_allows_disjoint_ids_on_same_channel():
+    right_ids = {
+        joint: (send_id + 0x20, receive_id + 0x20)
+        for joint, (send_id, receive_id) in DM_PROFILE.motor_can_ids.items()
+    }
+    config = BiRebotB601FollowerConfig(
+        left_arm_config=RebotB601FollowerConfig(port="/dev/ttyACM0"),
+        right_arm_config=RebotB601FollowerConfig(
+            port="/dev/ttyACM0",
+            motor_can_ids=right_ids,
+        ),
+    )
+    assert config.right_arm_config.motor_can_ids == right_ids
+
+
+def test_bimanual_connect_rolls_back_left_when_right_fails():
+    with patch(f"{_MODULE}.require_package", lambda *a, **kw: None):
+        robot = BiRebotB601Follower(
+            BiRebotB601FollowerConfig(
+                left_arm_config=RebotB601FollowerConfig(
+                    port="/dev/null0", disable_torque_on_disconnect=False
+                ),
+                right_arm_config=RebotB601FollowerConfig(port="/dev/null1"),
+            )
+        )
+    robot.left_arm.connect = MagicMock()
+    robot.left_arm._disconnect = MagicMock()
+    robot.right_arm.connect = MagicMock(side_effect=RuntimeError("right failed"))
+    with pytest.raises(RuntimeError, match="right failed"):
+        robot.connect()
+    robot.left_arm._disconnect.assert_called_once_with(force_disable=True)
+
+
+def test_bimanual_disconnect_always_attempts_both_arms():
+    with patch(f"{_MODULE}.require_package", lambda *a, **kw: None):
+        robot = BiRebotB601Follower(
+            BiRebotB601FollowerConfig(
+                left_arm_config=RebotB601FollowerConfig(port="/dev/null0"),
+                right_arm_config=RebotB601FollowerConfig(port="/dev/null1"),
+            )
+        )
+    robot.left_arm.disconnect = MagicMock(side_effect=RuntimeError("left failed"))
+    robot.right_arm.disconnect = MagicMock()
+    robot.disconnect()
+    robot.disconnect()
+    assert robot.right_arm.disconnect.call_count == 2
+
+
+def test_bimanual_forwards_every_arm_config_field():
+    # Guards against the per-arm config being rebuilt field-by-field again, which
+    # silently drops any option added later.
+    left = RebotB601FollowerConfig(
+        motor_family=MotorFamily.RS,
+        port="can0",
+        max_relative_target=5.0,
+        gripper_torque_limit=2.0,
+        wrap_guard_margin_deg=45.0,
+    )
+    promoted = left.as_robot_config(id="arm_left")
+    assert promoted.max_relative_target == 5.0
+    assert promoted.gripper_torque_limit == 2.0
+    assert promoted.wrap_guard_margin_deg == 45.0
+    assert promoted.id == "arm_left"
+    assert promoted.type == "rebot_b601_follower"

--- a/tests/robots/test_rebot_b601_follower.py
+++ b/tests/robots/test_rebot_b601_follower.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import math
+from collections.abc import Mapping
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -25,8 +26,27 @@ from lerobot.robots.rebot_b601_follower import (
     RebotB601FollowerConfig,
     RebotB601FollowerRobotConfig,
 )
+from lerobot.teleoperators.rebot_102_leader import RebotArm102LeaderConfig
 
 _MODULE = "lerobot.robots.rebot_b601_follower.rebot_b601_follower"
+_JOINTS = (
+    "shoulder_pan",
+    "shoulder_lift",
+    "elbow_flex",
+    "wrist_flex",
+    "wrist_yaw",
+    "wrist_roll",
+    "gripper",
+)
+
+
+def _per_joint(value: float | list[float] | Mapping[str, float]) -> dict[str, float]:
+    """Compare legacy scalar/list inputs and normalized mapping values uniformly."""
+    if isinstance(value, Mapping):
+        return {joint: float(value[joint]) for joint in _JOINTS}
+    if isinstance(value, list):
+        return dict(zip(_JOINTS, value, strict=True))
+    return dict.fromkeys(_JOINTS, float(value))
 
 
 def _make_motor_mock(position_rad: float = 0.0) -> MagicMock:
@@ -76,6 +96,63 @@ def test_features_match_joints():
     assert "gripper.pos" in expected
 
 
+def test_shipped_dm_defaults_are_preserved():
+    config = RebotB601FollowerRobotConfig(port="/dev/null")
+
+    assert config.can_adapter == "damiao"
+    assert config.control_mode == "mit"
+    assert config.gripper_control_mode == "force_pos"
+    assert config.gripper_torque_ratio == 0.07
+    assert config.joint_limits == {
+        "shoulder_pan": (-150.0, 150.0),
+        "shoulder_lift": (-200.0, 1.0),
+        "elbow_flex": (-200.0, 1.0),
+        "wrist_flex": (-80.0, 90.0),
+        "wrist_yaw": (-90.0, 90.0),
+        "wrist_roll": (-90.0, 90.0),
+        "gripper": (-270.0, 0.0),
+    }
+    assert _per_joint(config.mit_kp) == dict(
+        zip(_JOINTS, [45.0, 45.0, 45.0, 8.0, 9.0, 8.0, 8.0], strict=True)
+    )
+    assert _per_joint(config.mit_kd) == dict(
+        zip(_JOINTS, [12.0, 12.0, 12.0, 1.0, 1.0, 1.0, 1.0], strict=True)
+    )
+
+    leader = RebotArm102LeaderConfig(port="/dev/null")
+    assert leader.joint_ranges == {
+        "shoulder_pan": [-150, 150],
+        "shoulder_lift": [-200, 1],
+        "elbow_flex": [-200, 1],
+        "wrist_flex": [-80, 90],
+        "wrist_yaw": [-90, 90],
+        "wrist_roll": [-90, 90],
+        "gripper": [-270, 0],
+    }
+
+
+def test_legacy_dm_config_accepts_gain_lists_without_motor_family():
+    kp = [40.0, 41.0, 42.0, 7.0, 8.0, 9.0, 6.0]
+    kd = [10.0, 11.0, 12.0, 0.7, 0.8, 0.9, 0.2]
+    velocity = [100.0, 101.0, 102.0, 103.0, 104.0, 105.0, 800.0]
+
+    config = RebotB601FollowerRobotConfig(
+        port="/dev/null",
+        mit_kp=kp,
+        mit_kd=kd,
+        pos_vel_velocity=velocity,
+        gripper_mit_kp=6.0,
+        gripper_mit_kd=0.2,
+    )
+
+    assert config.can_adapter == "damiao"
+    assert _per_joint(config.mit_kp) == dict(zip(_JOINTS, kp, strict=True))
+    assert _per_joint(config.mit_kd) == dict(zip(_JOINTS, kd, strict=True))
+    assert _per_joint(config.pos_vel_velocity) == dict(zip(_JOINTS, velocity, strict=True))
+    assert config.gripper_mit_kp == 6.0
+    assert config.gripper_mit_kd == 0.2
+
+
 def test_connect_disconnect(follower):
     assert follower.is_connected
     follower.disconnect()
@@ -88,6 +165,13 @@ def test_get_observation_converts_to_degrees(follower):
     # The bus mock seeds each motor's position with its 1-indexed creation order (radians).
     for idx, motor in enumerate(follower.motor_names, 1):
         assert obs[f"{motor}.pos"] == pytest.approx(math.degrees(math.radians(idx)))
+
+
+def test_dm_public_positions_equal_motor_positions(follower):
+    obs = follower.get_observation()
+
+    for motor_name, motor in follower.motors.items():
+        assert obs[f"{motor_name}.pos"] == pytest.approx(math.degrees(motor.get_state().pos))
 
 
 def test_send_action_clips_to_joint_limits(follower):

--- a/tests/robots/test_rebot_b601_follower.py
+++ b/tests/robots/test_rebot_b601_follower.py
@@ -55,6 +55,7 @@ def _per_joint(value: float | list[float] | Mapping[str, float]) -> dict[str, fl
 
 
 FAMILIES = [MotorFamily.DM, MotorFamily.RS]
+_ROBSTRIDE_PING_RESPONDER_ID = 0xFE
 
 
 def _make_motor_mock(position_rad: float | None = 0.0) -> MagicMock:
@@ -82,7 +83,7 @@ def _make_bus_mock(positions_deg: list[float | None] | None = None) -> MagicMock
         motor = _make_motor_mock(position_rad=None if position is None else math.radians(position))
         motor.model = model
         motor.damiao_get_param_u32.return_value = send_id
-        motor.robstride_ping.return_value = (send_id, recv_id)
+        motor.robstride_ping.return_value = (send_id, _ROBSTRIDE_PING_RESPONDER_ID)
         return motor
 
     bus.add_damiao_motor.side_effect = _add_motor
@@ -503,6 +504,35 @@ def test_startup_requires_a_synchronous_response_from_every_motor(family):
         with pytest.raises(MotorFeedbackError, match="valid synchronous startup response"):
             robot.connect(calibrate=False)
 
+    assert robot.bus is None
+    assert robot.motors == {}
+    bus_mock.close.assert_called_once()
+
+
+def test_rs_startup_rejects_ping_from_wrong_device_id():
+    bus_mock = _make_bus_mock()
+    original_add_motor = bus_mock.add_robstride_motor.side_effect
+
+    def _add_motor_with_wrong_device_id(send_id, recv_id, model):
+        motor = original_add_motor(send_id, recv_id, model)
+        if send_id == 0x01:
+            motor.robstride_ping.return_value = (0x02, _ROBSTRIDE_PING_RESPONDER_ID)
+        return motor
+
+    bus_mock.add_robstride_motor.side_effect = _add_motor_with_wrong_device_id
+
+    with (
+        patch(f"{_MODULE}.require_package", lambda *a, **kw: None),
+        patch(f"{_MODULE}.MotorBridgeController") as controller_cls,
+        patch(f"{_MODULE}.MotorBridgeMode", MagicMock()),
+    ):
+        controller_cls.return_value = bus_mock
+        robot = RebotB601Follower(RebotB601FollowerRobotConfig(motor_family=MotorFamily.RS, port="can0"))
+
+        with pytest.raises(MotorFeedbackError, match="valid synchronous startup response") as exc_info:
+            robot.connect(calibrate=False)
+
+    assert "reported device CAN ID 0x2, expected 0x1" in str(exc_info.value.__cause__)
     assert robot.bus is None
     assert robot.motors == {}
     bus_mock.close.assert_called_once()

--- a/tests/robots/test_rebot_b601_follower.py
+++ b/tests/robots/test_rebot_b601_follower.py
@@ -74,13 +74,15 @@ def _make_bus_mock(positions_deg: list[float | None] | None = None) -> MagicMock
     bus = MagicMock(name="MotorBridgeControllerMock")
     bus._motor_count = 0
 
-    def _add_motor(_send_id, _recv_id, model):
+    def _add_motor(send_id, recv_id, model):
         index = bus._motor_count
         bus._motor_count += 1
         # Default seeds each motor with its 1-indexed creation order, in degrees.
         position = index + 1 if positions_deg is None else positions_deg[index]
         motor = _make_motor_mock(position_rad=None if position is None else math.radians(position))
         motor.model = model
+        motor.damiao_get_param_u32.return_value = send_id
+        motor.robstride_ping.return_value = (send_id, recv_id)
         return motor
 
     bus.add_damiao_motor.side_effect = _add_motor
@@ -470,6 +472,43 @@ def test_failed_startup_disables_and_closes_the_bus():
 
 
 @pytest.mark.parametrize("family", FAMILIES)
+def test_startup_requires_a_synchronous_response_from_every_motor(family):
+    bus_mock = _make_bus_mock()
+    add_motor = bus_mock.add_damiao_motor if family is MotorFamily.DM else bus_mock.add_robstride_motor
+    original_add_motor = add_motor.side_effect
+
+    def _add_motor_with_unreachable_gripper(send_id, recv_id, model):
+        motor = original_add_motor(send_id, recv_id, model)
+        if send_id == 0x07:
+            connectivity_method = (
+                motor.damiao_get_param_u32 if family is MotorFamily.DM else motor.robstride_ping
+            )
+            connectivity_method.side_effect = RuntimeError("motor powered off")
+        return motor
+
+    add_motor.side_effect = _add_motor_with_unreachable_gripper
+
+    with (
+        patch(f"{_MODULE}.require_package", lambda *a, **kw: None),
+        patch(f"{_MODULE}.MotorBridgeController") as controller_cls,
+        patch(f"{_MODULE}.MotorBridgeMode", MagicMock()),
+    ):
+        controller_cls.from_dm_serial.return_value = bus_mock
+        controller_cls.return_value = bus_mock
+        config = RebotB601FollowerRobotConfig(motor_family=family, port="/dev/null")
+        if family is MotorFamily.RS:
+            config = RebotB601FollowerRobotConfig(motor_family=family, port="can0")
+        robot = RebotB601Follower(config)
+
+        with pytest.raises(MotorFeedbackError, match="valid synchronous startup response"):
+            robot.connect(calibrate=False)
+
+    assert robot.bus is None
+    assert robot.motors == {}
+    bus_mock.close.assert_called_once()
+
+
+@pytest.mark.parametrize("family", FAMILIES)
 def test_wrap_guard_can_be_disabled(family):
     positions = [0.0] * 6 + [400.0]
     with _connected(family, positions_deg=positions, check_position_plausibility=False) as robot:
@@ -522,6 +561,17 @@ def test_disconnect_is_idempotent_and_continues_after_cleanup_failure():
     assert robot.bus is None
     assert robot.motors == {}
     motors[-1].close.assert_called_once()
+
+
+def test_disconnect_skips_cameras_that_are_already_disconnected():
+    robot = _build(MotorFamily.DM)
+    camera = MagicMock()
+    camera.is_connected = False
+    robot.cameras = {"base": camera}
+
+    robot.disconnect()
+
+    camera.disconnect.assert_not_called()
 
 
 def test_rs_rejects_damiao_serial_transport():
@@ -667,9 +717,73 @@ def test_bimanual_connect_rolls_back_left_when_right_fails():
     robot.left_arm.connect = MagicMock()
     robot.left_arm._disconnect = MagicMock()
     robot.right_arm.connect = MagicMock(side_effect=RuntimeError("right failed"))
+    robot.right_arm._disconnect = MagicMock()
     with pytest.raises(RuntimeError, match="right failed"):
         robot.connect()
     robot.left_arm._disconnect.assert_called_once_with(force_disable=True)
+    robot.right_arm._disconnect.assert_called_once_with(force_disable=True)
+
+
+def test_bimanual_connect_cleans_both_arms_when_left_fails():
+    with patch(f"{_MODULE}.require_package", lambda *a, **kw: None):
+        robot = BiRebotB601Follower(
+            BiRebotB601FollowerConfig(
+                left_arm_config=RebotB601FollowerConfig(port="/dev/null0"),
+                right_arm_config=RebotB601FollowerConfig(port="/dev/null1"),
+            )
+        )
+    robot.left_arm.connect = MagicMock(side_effect=RuntimeError("left failed"))
+    robot.left_arm._disconnect = MagicMock()
+    robot.right_arm._disconnect = MagicMock()
+
+    with pytest.raises(RuntimeError, match="left failed"):
+        robot.connect()
+
+    robot.left_arm._disconnect.assert_called_once_with(force_disable=True)
+    robot.right_arm._disconnect.assert_called_once_with(force_disable=True)
+
+
+def test_bimanual_observation_failure_force_disconnects_both_arms():
+    with patch(f"{_MODULE}.require_package", lambda *a, **kw: None):
+        robot = BiRebotB601Follower(
+            BiRebotB601FollowerConfig(
+                left_arm_config=RebotB601FollowerConfig(port="/dev/null0"),
+                right_arm_config=RebotB601FollowerConfig(port="/dev/null1"),
+            )
+        )
+    robot.left_arm.get_observation = MagicMock(side_effect=RuntimeError("camera failed"))
+    robot.left_arm._disconnect = MagicMock()
+    robot.right_arm._disconnect = MagicMock()
+    robot.left_arm.bus = MagicMock()
+    robot.right_arm.bus = MagicMock()
+
+    with pytest.raises(RuntimeError, match="camera failed"):
+        robot.get_observation()
+
+    robot.left_arm._disconnect.assert_called_once_with(force_disable=True)
+    robot.right_arm._disconnect.assert_called_once_with(force_disable=True)
+
+
+def test_bimanual_action_failure_force_disconnects_both_arms():
+    with patch(f"{_MODULE}.require_package", lambda *a, **kw: None):
+        robot = BiRebotB601Follower(
+            BiRebotB601FollowerConfig(
+                left_arm_config=RebotB601FollowerConfig(port="/dev/null0"),
+                right_arm_config=RebotB601FollowerConfig(port="/dev/null1"),
+            )
+        )
+    robot.left_arm.send_action = MagicMock(return_value={})
+    robot.right_arm.send_action = MagicMock(side_effect=RuntimeError("right command failed"))
+    robot.left_arm._disconnect = MagicMock()
+    robot.right_arm._disconnect = MagicMock()
+    robot.left_arm.bus = MagicMock()
+    robot.right_arm.bus = MagicMock()
+
+    with pytest.raises(RuntimeError, match="right command failed"):
+        robot.send_action({})
+
+    robot.left_arm._disconnect.assert_called_once_with(force_disable=True)
+    robot.right_arm._disconnect.assert_called_once_with(force_disable=True)
 
 
 def test_bimanual_disconnect_always_attempts_both_arms():

--- a/tests/robots/test_rebot_b601_follower.py
+++ b/tests/robots/test_rebot_b601_follower.py
@@ -299,10 +299,17 @@ def test_dm_does_not_flip_joint_direction():
 
 
 @pytest.mark.parametrize("family", FAMILIES)
-def test_missing_wrist_yaw_is_held_at_zero(family):
-    with _connected(family) as robot:
-        returned = robot.send_action({"shoulder_pan.pos": 0.0})
-        assert returned["wrist_yaw.pos"] == 0.0
+def test_partial_action_does_not_command_unspecified_joints(family):
+    positions = [0.0, 0.0, 0.0, 0.0, -2.393, 0.0, 0.0]
+    with _connected(family, positions_deg=positions, max_relative_target=2.0) as robot:
+        returned = robot.send_action({"shoulder_pan.pos": 1.0})
+
+        assert returned == {"shoulder_pan.pos": 1.0}
+        robot.motors["shoulder_pan"].send_mit.assert_called_once()
+        for motor_name in set(robot.motor_names) - {"shoulder_pan"}:
+            robot.motors[motor_name].send_mit.assert_not_called()
+            robot.motors[motor_name].send_pos_vel.assert_not_called()
+            robot.motors[motor_name].send_force_pos.assert_not_called()
 
 
 def test_dm_gripper_defaults_to_force_pos():

--- a/uv.lock
+++ b/uv.lock
@@ -3189,6 +3189,7 @@ molmoact2 = [
 ]
 motorbridge-dep = [
     { name = "motorbridge" },
+    { name = "python-can" },
 ]
 motorbridge-smart-servo-dep = [
     { name = "motorbridge-smart-servo" },
@@ -3259,6 +3260,7 @@ reachy2 = [
 rebot = [
     { name = "motorbridge" },
     { name = "motorbridge-smart-servo" },
+    { name = "python-can" },
 ]
 robometer = [
     { name = "peft" },
@@ -3387,6 +3389,7 @@ requires-dist = [
     { name = "lerobot", extras = ["av-dep"], marker = "extra == 'dataset'" },
     { name = "lerobot", extras = ["av-dep"], marker = "extra == 'evaluation'" },
     { name = "lerobot", extras = ["can-dep"], marker = "extra == 'damiao'" },
+    { name = "lerobot", extras = ["can-dep"], marker = "extra == 'motorbridge-dep'" },
     { name = "lerobot", extras = ["can-dep"], marker = "extra == 'robstride'" },
     { name = "lerobot", extras = ["damiao"], marker = "extra == 'all'" },
     { name = "lerobot", extras = ["damiao"], marker = "extra == 'openarms'" },
@@ -3519,7 +3522,7 @@ requires-dist = [
     { name = "meshcat", marker = "extra == 'unitree-g1'", specifier = ">=0.3.0,<0.4.0" },
     { name = "metaworld", marker = "extra == 'metaworld'", specifier = "==3.0.0" },
     { name = "mock-serial", marker = "sys_platform != 'win32' and extra == 'test'", specifier = ">=0.0.1,<0.1.0" },
-    { name = "motorbridge", marker = "extra == 'motorbridge-dep'", specifier = ">=0.3.2,<0.4.0" },
+    { name = "motorbridge", marker = "extra == 'motorbridge-dep'", specifier = ">=0.5,<0.6" },
     { name = "motorbridge-smart-servo", marker = "extra == 'motorbridge-smart-servo-dep'", specifier = ">=0.0.4,<0.1.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.19.1" },
     { name = "num2words", marker = "extra == 'smolvla'", specifier = ">=0.5.14,<0.6.0" },
@@ -4020,19 +4023,19 @@ wheels = [
 
 [[package]]
 name = "motorbridge"
-version = "0.3.9"
+version = "0.5.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/89/b2/36e84fc4274fb9fb288e50ab8fe9451ea6f31aed5b735f7234df515eb557/motorbridge-0.3.9.tar.gz", hash = "sha256:12948aa4d3662354744bfac5777243a64ac35c9bb990d42182efc5c8f179d40f", size = 34002, upload-time = "2026-05-26T09:28:52.458Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/d6/a01f133579e02e11cf7ea0c1b1032008a182adf70d516e8057fb7c8e66f2/motorbridge-0.5.1.tar.gz", hash = "sha256:29b6163d4788a101d1f43ddc0c7f4731b4f2d4faca60df814eba7fb6031118ce", size = 42569, upload-time = "2026-08-06T07:45:52.316Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/16/3dba18382393dda35c37a590c991e7d998c642ff04b4171f5cacea09f79b/motorbridge-0.3.9-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6abc0111779da3ed6ecd8d14c4241e0a37f5adf9c5e997d360e9940cb17fcde9", size = 1204016, upload-time = "2026-05-26T09:28:41.065Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/2c/c368457ba750cc9891342111646bd3a1b2e448f6ff9f788049db5550ea6e/motorbridge-0.3.9-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5b0a7d4950b0806ee2bc83dda0276581b5862208e6d4566d2a367d8cdacf9dc0", size = 1284215, upload-time = "2026-05-26T09:28:42.124Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/5e/27c46bbe3f472bf894b50cc0c8bfba46a57116c8c7858c29ae1ce4540e05/motorbridge-0.3.9-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aa4967a9b675ae5d4e89bee5fcc7390560193a18a0abdaa0e574cf0f131416f2", size = 1307278, upload-time = "2026-05-26T09:28:43.281Z" },
-    { url = "https://files.pythonhosted.org/packages/66/ad/a4a4652f4a6503d82be9e964b96345423f6c4da6602b469024edab68dfac/motorbridge-0.3.9-cp312-cp312-win_amd64.whl", hash = "sha256:7e7012be69edf92261c0a9335da7541a97e40b941295130fb980531b41a57eac", size = 952899, upload-time = "2026-05-26T09:28:44.646Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/63/e9b2dddd738d88ae33ec59e96ef0db9345832c8db9efeca21ab2b8cb6534/motorbridge-0.3.9-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3e9bbf01316bbb734de6d8a61dd74d7ff964acf814cad5326df95405bd6b9120", size = 1204016, upload-time = "2026-05-26T09:28:45.703Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/79/27d648345845d1f6d60caee7e9f895b01f4eb647217706b35cd5207f9c14/motorbridge-0.3.9-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:39fb779b22e3e8a8fa7f09a4ce9242bf1869bcc6fc2e96eb10a9e81239432162", size = 1284215, upload-time = "2026-05-26T09:28:47.416Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/3f/b9a0789380289f27ae06d433bd4f7d79c47c1fcb2fc658261d4b1631ad85/motorbridge-0.3.9-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e6330eed5e4c89787f3ca0fb67198b4585beb004596d4ab658ba07174156d93b", size = 1307277, upload-time = "2026-05-26T09:28:48.903Z" },
-    { url = "https://files.pythonhosted.org/packages/68/2b/70840168adab64ac14bb501562aaa759ab33e04f939753bcaa43c939564f/motorbridge-0.3.9-cp313-cp313-win_amd64.whl", hash = "sha256:85c6a9eb382155082326c9019d260b2ede518317a82c38069d463bc7cb153d67", size = 952901, upload-time = "2026-05-26T09:28:50.187Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/95/5d6692b2405fe688cb6f221e2cd09fae23a0a3db2cbbb454b23efadb005f/motorbridge-0.3.9-cp314-cp314-win_amd64.whl", hash = "sha256:41c5b4b230adc06ed4d7e7ee61d20d65fc0e6c31bef0e87511364911f33fcd25", size = 989530, upload-time = "2026-05-26T09:28:51.383Z" },
+    { url = "https://files.pythonhosted.org/packages/09/3c/05ed596fdab80deb56cfbc9a53b02ba8ae17e765cd7aa0e74aa7ffa1a94e/motorbridge-0.5.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ba6f49637d33916db242e18d33ba173e60db182039e3ab736c94ba4906f8b465", size = 1244357, upload-time = "2026-08-06T07:45:40.474Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c7/27d99fc2b5675ed6d05d90a7975573f882002ffe272ab6533ace69d88a9a/motorbridge-0.5.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d70ad7eb7e9dd496bd9f6d7010a83736e5d6feb6637505fcd19e7ff4539877fb", size = 1333759, upload-time = "2026-08-06T07:45:41.817Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/7a/40e2ee2dbbf900ee264b0a5746140eab189b040a854127feb065fe1104c1/motorbridge-0.5.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e7602db412b2810171ee3c8927f721cbfdcc92eb8e08364bda2cb986ffe2803f", size = 1350891, upload-time = "2026-08-06T07:45:43.006Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/65/b5de8f326ff2aa1161ce13862537a59a1240d2ca34a9a9f89be47d3dcaea/motorbridge-0.5.1-cp312-cp312-win_amd64.whl", hash = "sha256:3988546b0f1247279ac46f1bbe64bd5eb8405ef5d2c5df70bad14c1c83a56fe2", size = 1038947, upload-time = "2026-08-06T07:45:44.104Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/41/2389135560f4dc9df504ddf436db0c2ddde23448acbedd155479b38192f4/motorbridge-0.5.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:888f412f0814b2275df6b2ad92352f4bc3da526646806d106f9bceab7046c086", size = 1244357, upload-time = "2026-08-06T07:45:45.684Z" },
+    { url = "https://files.pythonhosted.org/packages/94/64/f5af03160213fc86af1899c0f5bcbc74873b339983b8d4f12789a9060989/motorbridge-0.5.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9e937a3f6a606412d74acc802be460e1c29fb78a8d3104d430390b62a376fa95", size = 1333758, upload-time = "2026-08-06T07:45:46.949Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/35/8f0d034aee80e5055dfb5e9a55adcda449202e9ffa7bbc08043ef16e2109/motorbridge-0.5.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c007e5384dc0dbb1b67e46063252828ffe26375dbd94e9ee345cb29102358f64", size = 1350891, upload-time = "2026-08-06T07:45:48.828Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/1c/413d3d4d2f72c2dc4dad0e1112d538c0a8431217aa01e40a6d772f17d5ca/motorbridge-0.5.1-cp313-cp313-win_amd64.whl", hash = "sha256:0e2a9ea1bfb1eef67aede1f4cf23de3cbf58bb0c3e14f0cfb2281f144bddf128", size = 1038944, upload-time = "2026-08-06T07:45:49.9Z" },
+    { url = "https://files.pythonhosted.org/packages/58/fe/701bd328483eeec37a69f498bc54a6a5d61503309a9d0cbc41ad8246ae7a/motorbridge-0.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:18002803720ea02ba96422d33a9d516a31d666a8dce7da5de72a4634c3d1e366", size = 1076129, upload-time = "2026-08-06T07:45:51.062Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Title

feat(rebot): unify DM and RS motor family support

## Summary / Motivation

This PR adds RobStride (RS) support to the existing reBot B601 follower while keeping one shared robot implementation for both Damiao (DM) and RS hardware. Users select the actuator family with `motor_family`; DM remains the default.

It supersedes #4256 and retains its hardware-tested RS motor mapping, tuning, MotorBridge integration, and force-limited gripper strategy without adding separate RS robot registrations. Family profiles hold the installed hardware facts and defaults, while MotorBridge remains responsible for protocol-level validation and connection errors.

## Related issues

- Supersedes: #4256
- Related: #4070, #4071, #3955, #4529

## What changed

### Shared DM and RS follower

- Add `MotorFamily.DM` and `MotorFamily.RS` with internal profiles for motor models, CAN IDs, joint directions, limits, gains, transports, and gripper defaults.
- Keep the existing `rebot_b601_follower` and `bi_rebot_b601_follower` registrations.
- Keep `motor_family=dm` as the default and select RS with:

```bash
--robot.motor_family=rs
```

- Preserve the shipped DM motor mapping, limits, gains, default MIT arm mode, and `force_pos` gripper behavior.
- Accept either a scalar or a joint-keyed mapping for per-joint tuning fields.

### MotorBridge and transport handling

- Upgrade `motorbridge` from `0.3.x` to `>=0.5,<0.6`.
- Use `Controller.from_dm_serial(...)` for the Damiao serial bridge.
- Use MotorBridge's native CAN controller for RS and optional native-CAN DM setups.
- Register the correct DM or RS motor type, model, and CAN IDs from the selected profile.
- Keep the configuration name `socketcan` for native CAN; MotorBridge selects the platform backend on Linux, macOS, or Windows.

### RS hardware behavior

- Use `rs-06` motors for the proximal joints and `rs-00` motors for the distal wrist and gripper.
- Use the RobStride `0xFD` host-ID convention and the installed RS joint directions.
- Use MIT control by default.
- Use a force-limited MIT impedance loop for the gripper because MotorBridge does not provide `FORCE_POS` for RobStride motors.
- Apply separate software torque-command limits while the gripper is moving and holding.
- Attempt to command zero gripper torque and disable the arm if impedance feedback fails.

### Coordinates, feedback, and actions

- Convert positions between the public robot frame and raw motor frame in both directions.
- Keep observations, actions, relative-target checks, and returned commands in the same public degree-based coordinate frame.
- Ensure an RS observation can be sent back as an action to hold the measured pose.
- Poll fresh feedback through MotorBridge and report motors whose state is unavailable.
- Clip commands against the selected family's raw joint limits.
- Ensure partial actions command only the joints explicitly present instead of injecting a `wrist_yaw` target.

### Bimanual behavior

- Continue composing the bimanual follower from two single-arm instances using the standard `BimanualMixin` lifecycle.
- Pass each arm's complete configuration, including its motor family and transport, to its single-arm instance.
- Allow each arm to select DM or RS independently.

### Documentation

- Consolidate DM and RS installation, transport, calibration, teleoperation, tuning, and safety guidance in `rebot_b601.mdx`.
- Document native CAN support and its platform-specific adapter/runtime requirements.
- Document the shared public coordinate frame and the different DM and RS gripper strategies.

### Compatibility

- Existing DM configurations that rely on the shipped defaults continue to use DM behavior without specifying `motor_family`.
- Custom ordered lists for `mit_kp`, `mit_kd`, and `pos_vel_velocity` **should** be migrated to scalars or joint-keyed mappings.
- The former `gripper_mit_kp` and `gripper_mit_kd` overrides **should** be expressed with the `gripper` entry in the `mit_kp` and `mit_kd` mappings.

## How was this tested (or how to run locally)

Automated coverage includes:

- DM default compatibility and leader-range alignment.
- DM and RS profile selection, transport routing, motor registration, and mode dispatch.
- Public/raw coordinate conversion and family-specific limit clipping.
- Observation-to-action round trips for RS.
- Partial actions and per-joint relative limits.
- DM `MIT`, `POS_VEL`, and `FORCE_POS` routing.
- RS force-limited impedance behavior and feedback-failure shutdown.
- Torque-disabled mode configuration and MotorBridge error propagation.
- Missing feedback handling.
- Independent motor-family configuration for bimanual arms.

Local results:

- `tests/robots/test_rebot_b601_follower.py`: 33 passed.
- `tests/robots`: 122 passed, 2 skipped.
- Ruff check and formatting validation pass.

Run the focused tests with:

```bash
uv run pytest tests/robots/test_rebot_b601_follower.py -q
uv run pytest tests/robots -q
pre-commit run --all-files
```

Test passed on manual hardware.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated
- [ ] CI is green

## Reviewer notes

- Credit for the MotorBridge RS integration, impedance gripper, tuning, and initial documentation goes to @SeakingForHeart through #4256.
- Protocol investigation and alternative native RobStride implementations are available in #4070 and #4071.
- Please focus review on DM default compatibility, coordinate-frame symmetry, RS gripper behavior, per-arm bimanual configuration, and the MotorBridge 0.5 integration.
- Anyone in the community is welcome to review the PR.