### PR TITLE
fix(amp): gate autocast on is_amp_available instead of hardcoding CUDA

### DIFF
--- a/examples/lekiwi/evaluate.py
+++ b/examples/lekiwi/evaluate.py
@@ -25,6 +25,7 @@ from lerobot.policies.utils import make_robot_action
 from lerobot.processor import make_default_processors
 from lerobot.robots.lekiwi import LeKiwiClient, LeKiwiClientConfig
 from lerobot.utils.constants import ACTION, OBS_STR
+from lerobot.utils.device_utils import is_amp_available
 from lerobot.utils.feature_utils import build_dataset_frame, hw_to_dataset_features
 from lerobot.utils.keyboard_input import init_keyboard_listener
 from lerobot.utils.robot_utils import precise_sleep
@@ -118,7 +119,7 @@ def main():
                     device=policy.config.device,
                     preprocessor=preprocessor,
                     postprocessor=postprocessor,
-                    use_amp=policy.config.device.type == "cuda",
+                    use_amp=is_amp_available(policy.config.device.type),
                     task=TASK_DESCRIPTION,
                     robot_type=robot.name,
                 )

--- a/examples/phone_to_so100/evaluate.py
+++ b/examples/phone_to_so100/evaluate.py
@@ -40,6 +40,7 @@ from lerobot.robots.so_follower.robot_kinematic_processor import (
     InverseKinematicsEEToJoints,
 )
 from lerobot.utils.constants import ACTION, OBS_STR
+from lerobot.utils.device_utils import is_amp_available
 from lerobot.utils.feature_utils import build_dataset_frame, combine_feature_dicts
 from lerobot.utils.keyboard_input import init_keyboard_listener
 from lerobot.utils.robot_utils import precise_sleep
@@ -179,7 +180,7 @@ def main():
                     device=policy.config.device,
                     preprocessor=preprocessor,
                     postprocessor=postprocessor,
-                    use_amp=policy.config.device.type == "cuda",
+                    use_amp=is_amp_available(policy.config.device.type),
                     task=TASK_DESCRIPTION,
                     robot_type=robot.name,
                 )

--- a/examples/so100_to_so100_EE/evaluate.py
+++ b/examples/so100_to_so100_EE/evaluate.py
@@ -40,6 +40,7 @@ from lerobot.robots.so_follower.robot_kinematic_processor import (
     InverseKinematicsEEToJoints,
 )
 from lerobot.utils.constants import ACTION, OBS_STR
+from lerobot.utils.device_utils import is_amp_available
 from lerobot.utils.feature_utils import build_dataset_frame, combine_feature_dicts
 from lerobot.utils.keyboard_input import init_keyboard_listener
 from lerobot.utils.robot_utils import precise_sleep
@@ -179,7 +180,7 @@ def main():
                     device=policy.config.device,
                     preprocessor=preprocessor,
                     postprocessor=postprocessor,
-                    use_amp=policy.config.device.type == "cuda",
+                    use_amp=is_amp_available(policy.config.device.type),
                     task=TASK_DESCRIPTION,
                     robot_type=robot.name,
                 )

--- a/src/lerobot/common/control_utils.py
+++ b/src/lerobot/common/control_utils.py
@@ -26,6 +26,7 @@ import numpy as np
 import torch
 
 from lerobot.policies import PreTrainedPolicy, prepare_observation_for_inference
+from lerobot.utils.device_utils import is_amp_available
 from lerobot.utils.import_utils import _deepdiff_available, require_package
 
 if TYPE_CHECKING or _deepdiff_available:
@@ -66,7 +67,8 @@ def predict_action(
         device: The `torch.device` (e.g., 'cuda' or 'cpu') to run inference on.
         preprocessor: The `PolicyProcessorPipeline` for preprocessing observations.
         postprocessor: The `PolicyProcessorPipeline` for postprocessing actions.
-        use_amp: A boolean to enable/disable Automatic Mixed Precision for CUDA inference.
+        use_amp: A boolean to enable/disable Automatic Mixed Precision. It only takes effect on
+            devices where AMP is available (see `is_amp_available`).
         task: An optional string identifier for the task.
         robot_type: An optional string identifier for the robot type.
 
@@ -76,7 +78,9 @@ def predict_action(
     observation = copy(observation)
     with (
         torch.inference_mode(),
-        torch.autocast(device_type=device.type) if device.type == "cuda" and use_amp else nullcontext(),
+        torch.autocast(device_type=device.type)
+        if use_amp and is_amp_available(device.type)
+        else nullcontext(),
     ):
         # Convert to pytorch format: channel first and float32 in [0,1] with batch dimension
         observation = prepare_observation_for_inference(observation, device, task, robot_type)

--- a/src/lerobot/policies/evo1/modeling_evo1.py
+++ b/src/lerobot/policies/evo1/modeling_evo1.py
@@ -26,6 +26,7 @@ from torch import Tensor
 from lerobot.configs.policies import PreTrainedConfig
 from lerobot.policies.pretrained import PreTrainedPolicy, T
 from lerobot.utils.constants import ACTION, OBS_IMAGES, OBS_STATE
+from lerobot.utils.device_utils import is_amp_available
 
 from ..rtc.modeling_rtc import RTCProcessor
 from .configuration_evo1 import Evo1Config
@@ -159,14 +160,14 @@ class Evo1Policy(PreTrainedPolicy):
 
     @property
     def _amp_enabled(self) -> bool:
-        return bool(self.config.use_amp) and self._device.type == "cuda"
+        return bool(self.config.use_amp) and is_amp_available(self._device.type)
 
     def _maybe_autocast(self):
         # EVO1 manages its own mixed precision: an explicit bf16 autocast that also overrides any
         # outer autocast context (e.g. lerobot-eval's fp16 default), keeping train and eval
         # numerics identical.
         if self._amp_enabled:
-            return torch.autocast(device_type="cuda", dtype=torch.bfloat16)
+            return torch.autocast(device_type=self._device.type, dtype=torch.bfloat16)
         return nullcontext()
 
     def get_optim_params(self) -> list[dict]:

--- a/src/lerobot/rollout/inference/sync.py
+++ b/src/lerobot/rollout/inference/sync.py
@@ -26,6 +26,7 @@ from lerobot.policies.pretrained import PreTrainedPolicy
 from lerobot.policies.utils import make_robot_action, prepare_observation_for_inference
 from lerobot.processor import PolicyProcessorPipeline
 from lerobot.utils.constants import OBS_STR
+from lerobot.utils.device_utils import is_amp_available
 from lerobot.utils.feature_utils import build_dataset_frame
 
 from .base import InferenceEngine, PolicyQuery
@@ -108,7 +109,7 @@ class SyncInferenceEngine(InferenceEngine):
         observation = copy(obs_frame)
         autocast_ctx = (
             torch.autocast(device_type=self._device.type)
-            if self._device.type == "cuda" and self._policy.config.use_amp
+            if self._policy.config.use_amp and is_amp_available(self._device.type)
             else nullcontext()
         )
         task, task_changed = self._take_task()
@@ -152,7 +153,7 @@ class SyncInferenceEngine(InferenceEngine):
         obs_frame = build_dataset_frame(self._dataset_features, obs_processed, prefix=OBS_STR)
         autocast_ctx = (
             torch.autocast(device_type=self._device.type)
-            if self._device.type == "cuda" and self._policy.config.use_amp
+            if self._policy.config.use_amp and is_amp_available(self._device.type)
             else nullcontext()
         )
         # Live task, read without consuming the task-changed edge (the action path needs it).


### PR DESCRIPTION
## Summary / Motivation

`use_amp` is honoured only on CUDA. On XPU and CPU the flag is accepted, survives validation, and is then silently ignored — the policy runs in full fp32 with no warning.

This is a disagreement between two layers rather than a missing feature. `PreTrainedConfig.__post_init__` already clears `use_amp` when `is_amp_available()` returns False for the device:

```python
if self.use_amp and not is_amp_available(self.device):
    logger.warning(...)
    self.use_amp = False
```

So a `use_amp=True` that reaches a policy is a promise from the config layer that this device supports AMP. The inference paths ignore that promise and re-check `device.type == "cuda"`; the second check wins, silently. `is_amp_available()` already returns True for `cuda`, `xpu` and `cpu` and False for `mps` — it is both the right question and the repo's existing answer to it.

Worth closing now that Intel iGPUs are usable for this workload, where the cost of missing autocast is not marginal. On an Arc 140V (Lunar Lake, Core Ultra 200V), a 4096³ matmul:

| dtype | TFLOP/s | vs fp32 |
| --- | ---: | ---: |
| fp32 | 0.25 | 1.00x |
| bf16 | 18.95 | **77.3x** |
| fp16 | 19.36 | 79.0x |

The XMX matrix engines are only reachable through autocast.

## Related issues

- Related: #3912 (mixed precision plumbing, since superseded by `configs/accelerator.py`)

## What changed

- `common/control_utils.py` — `predict_action` gates autocast on `is_amp_available(device.type)`; docstring no longer says "for CUDA inference".
- `rollout/inference/sync.py` — both autocast contexts (action path and `_generate_text`).
- `policies/evo1/modeling_evo1.py` — `_amp_enabled`, plus `_maybe_autocast`, which pinned `device_type="cuda"` **inside** the autocast call. Off CUDA torch emitted `UserWarning: CUDA is not available or torch_xla is imported. Disabling autocast.` and dropped the bf16 context that the comment right above it says is needed to keep train and eval numerics identical.
- three `examples/*/evaluate.py` call sites.

No breaking changes. CUDA behaviour is unchanged — it is the first branch of `is_amp_available()`. MPS stays excluded because the helper already returns False for it. The only behaviour change is on XPU/CPU, where `use_amp=true` now does what it says.

## How was this tested (or how to run locally)

No new tests — this changes a device predicate, and I could not find an existing AMP-path test to extend that would run without an accelerator. Happy to add one if you can point me at the right shape.

```
pytest -q tests/policies/evo1 tests/test_rollout.py tests/configs tests/common
```

**171 passed / 16 failed, identical with and without this change** on the same machine. The 16 are pre-existing environment failures in `test_checkpoint_save_resume.py` and `test_publish.py`, unrelated to this diff — I verified by stashing the change and re-running. `pre-commit run --files <changed>` passes every hook, mypy and bandit included.

End-to-end measurement, ACT at batch 16 on `lerobot/aloha_sim_insertion_scripted`, device `xpu`:

| | s/step | samples/s | peak GB |
| --- | ---: | ---: | ---: |
| fp32 | 1.264 | 12 | 3.82 |
| bf16 | 0.627 | 25 | 3.64 |

2.02x, with `loss`, `l1_loss` and `kld_loss` matching fp32 to three decimals at step 80.

## Checklist (required before merge)

- [x] Linting/formatting run — `pre-commit run --files <changed>` passes every hook: ruff, ruff-format, typos, pyupgrade, gitleaks, bandit, mypy
- [ ] All tests pass locally — see above: 16 pre-existing failures unrelated to this change, unchanged from baseline
- [x] Documentation updated — `predict_action` docstring
- [ ] CI is green — not yet run
- [ ] Community Review — not done, so leaving this honestly unchecked

## Reviewer notes

- **I have no CUDA hardware to hand.** The CUDA path is argued from `is_amp_available()` returning True for `cuda`, not measured. That is the thing most worth a second pair of eyes.
- CPU is the other behaviour change: `is_amp_available("cpu")` is True, so `use_amp=true` on CPU now enters autocast (bf16 by torch's default) where it previously did nothing. That follows the helper's contract, but if you would rather CPU stay excluded, that belongs in `is_amp_available()` rather than at these call sites — say the word and I will move it.
- **Not addressed here:** `policies/vqbet/vqbet_utils.py` and `policies/fastwam/wan/` use `autocast("cuda", enabled=False)` to pin fp32 regions. That does not suppress an outer XPU autocast, so those regions silently lose their fp32 guarantee off CUDA. It needs a different fix and I did not want to touch vendored model code blind. Happy to open a separate issue.
