### PR TITLE
feat(envs): validate_platform() hook, checked at train startup (#4388)

### DIFF
--- a/docs/source/adding_benchmarks.mdx
+++ b/docs/source/adding_benchmarks.mdx
@@ -180,10 +180,11 @@ See `create_libero_envs()` (multi-suite, multi-task) and `create_metaworld_envs(
 
 ### 2. The config (`src/lerobot/envs/configs.py`)
 
-Register a config dataclass so users can select your benchmark with `--env.type=<name>`. Each config owns its environment creation and processor logic via two methods:
+Register a config dataclass so users can select your benchmark with `--env.type=<name>`. Each config owns its environment creation, processor logic and platform requirements via three methods:
 
 - **`create_envs(n_envs, use_async_envs)`** — Returns `{suite: {task_id: VectorEnv}}`. The base class default uses `gym.make()` for single-task envs. Multi-task benchmarks override this.
 - **`get_env_processors()`** — Returns `(preprocessor, postprocessor)`. The base class default returns identity (no-op) pipelines. Override if your benchmark needs observation/action transforms.
+- **`validate_platform()`** — Raises when the benchmark cannot run on the current machine. The base class default is a no-op. `TrainPipelineConfig.validate()` calls it at startup, before the dataset is downloaded, so override it if your dependency carries a platform marker (see step 4).
 
 ```python
 @EnvConfig.register_subclass("<benchmark_name>")
@@ -264,7 +265,7 @@ mybenchmark = ["my-benchmark-pkg==1.2.3", "lerobot[scipy-dep]"]
 Pinning rules:
 
 - **Always pin** benchmark packages to exact versions for reproducibility (e.g. `metaworld==3.0.0`).
-- **Add platform markers** when needed (e.g. `; sys_platform == 'linux'`).
+- **Add platform markers** when needed (e.g. `; sys_platform == 'linux'`). A marked dependency is skipped silently on other platforms and the install still succeeds, so pair it with a `validate_platform()` override (see step 2) or users only find out at the first rollout.
 - **Pin fragile transitive deps** if known (e.g. `gymnasium==1.1.0` for Meta-World).
 - **Document constraints** in your benchmark doc page.
 

--- a/src/lerobot/configs/train.py
+++ b/src/lerobot/configs/train.py
@@ -275,6 +275,18 @@ class TrainPipelineConfig(HubMixin):
                 f"{self.dataloader_multiprocessing_context!r}."
             )
 
+        # Second platform capability check, alongside the multiprocessing one above.
+        # Without it, a run that can never work on this machine still downloads the
+        # dataset, builds the policy and trains `env_eval_freq` steps before the first
+        # rollout raises: `make_env` is only reached from the eval branch inside the
+        # training loop (#4388).
+        #
+        # Gated on `env_eval_freq` because with in-training eval disabled nothing
+        # constructs a simulator. The env config is then only used to build processors
+        # for those rollouts, so failing would block a run that succeeds today.
+        if self.env is not None and self.env_eval_freq > 0:
+            self.env.validate_platform()
+
         self._resolve_pretrained_from_cli()
 
         if self.policy is None and self.reward_model is None:

--- a/src/lerobot/envs/configs.py
+++ b/src/lerobot/envs/configs.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 import abc
+import importlib
 import importlib.util
 from dataclasses import dataclass, field, fields
 from typing import Any

--- a/src/lerobot/envs/configs.py
+++ b/src/lerobot/envs/configs.py
@@ -332,16 +332,23 @@ class HILSerlRobotEnvConfig(EnvConfig):
         return {}
 
 
-# The LIBERO simulator ships in the `hf-libero` package, which carries a
-# `sys_platform == 'linux'` marker in the `lerobot[libero]` extra. On non-Linux
-# platforms `pip install 'lerobot[libero]'` resolves cleanly but silently omits it,
-# so the failure would otherwise surface much later as a cryptic ModuleNotFoundError
-# from deep inside the `lerobot.envs.libero` import. See #4388.
+# The LIBERO simulator ships in the `hf-libero` package, which the `lerobot[libero]`
+# extra requires behind a `sys_platform == 'linux'` marker. On non-Linux platforms
+# `pip install 'lerobot[libero]'` therefore resolves cleanly but silently omits it, and
+# the failure would otherwise surface much later as a cryptic ModuleNotFoundError from
+# deep inside the `lerobot.envs.libero` import. See #4388.
+#
+# The check below is deliberately an IMPORTABILITY test, not a platform test: the marker
+# governs what the extra installs, and says nothing about where the simulator can run. A
+# user who installs `hf-libero` or builds LIBERO from source on another platform passes
+# this check and proceeds, which is the intended behaviour.
 LIBERO_SIMULATOR_MISSING_MSG = (
-    "The LIBERO simulator is not installed. LIBERO is Linux-only: the 'hf-libero' "
-    "package carries a sys_platform == 'linux' marker, so `pip install 'lerobot[libero]'` "
-    "resolves cleanly but silently omits the simulator on non-Linux platforms. "
-    "Install it on Linux (or in a Linux container) to run LIBERO environments."
+    "The LIBERO simulator is not installed. `pip install 'lerobot[libero]'` does not "
+    "install it on non-Linux platforms: 'hf-libero' carries a sys_platform == 'linux' "
+    "marker, so the extra resolves cleanly and silently omits the simulator. That is a "
+    "packaging constraint of this extra, not a statement about where LIBERO can run. "
+    "Install 'hf-libero' directly, install LIBERO from source, or use Linux (or a Linux "
+    "container), then re-run."
 )
 
 
@@ -470,7 +477,8 @@ class LiberoEnv(EnvConfig):
         return kwargs
 
     def validate_platform(self) -> None:
-        """LIBERO is Linux-only, see `_assert_libero_simulator_available` (#4388)."""
+        """Fail fast when the LIBERO simulator is absent, see
+        `_assert_libero_simulator_available` (#4388)."""
         _assert_libero_simulator_available()
 
     def create_envs(self, n_envs: int, use_async_envs: bool = False):

--- a/src/lerobot/envs/configs.py
+++ b/src/lerobot/envs/configs.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 import abc
-import importlib
+import importlib.util
 from dataclasses import dataclass, field, fields
 from typing import Any
 
@@ -317,6 +317,19 @@ class HILSerlRobotEnvConfig(EnvConfig):
         return {}
 
 
+# The LIBERO simulator ships in the `hf-libero` package, which carries a
+# `sys_platform == 'linux'` marker in the `lerobot[libero]` extra. On non-Linux
+# platforms `pip install 'lerobot[libero]'` resolves cleanly but silently omits it,
+# so the failure would otherwise surface much later as a cryptic ModuleNotFoundError
+# from deep inside the `lerobot.envs.libero` import. See #4388.
+LIBERO_SIMULATOR_MISSING_MSG = (
+    "The LIBERO simulator is not installed. LIBERO is Linux-only: the 'hf-libero' "
+    "package carries a sys_platform == 'linux' marker, so `pip install 'lerobot[libero]'` "
+    "resolves cleanly but silently omits the simulator on non-Linux platforms. "
+    "Install it on Linux (or in a Linux container) to run LIBERO environments."
+)
+
+
 @EnvConfig.register_subclass("libero")
 @dataclass
 class LiberoEnv(EnvConfig):
@@ -426,6 +439,12 @@ class LiberoEnv(EnvConfig):
         return kwargs
 
     def create_envs(self, n_envs: int, use_async_envs: bool = False):
+        # Fail fast at env-construction time with an actionable message when the
+        # simulator was silently omitted (e.g. a non-Linux install), instead of
+        # letting a cryptic ModuleNotFoundError surface from the import below (#4388).
+        if importlib.util.find_spec("libero") is None:
+            raise ModuleNotFoundError(LIBERO_SIMULATOR_MISSING_MSG)
+
         from .libero import create_libero_envs
 
         if self.task is None:

--- a/src/lerobot/envs/configs.py
+++ b/src/lerobot/envs/configs.py
@@ -128,6 +128,20 @@ class EnvConfig(draccus.ChoiceRegistry, abc.ABC):
         """Return (preprocessor, postprocessor) for this env. Default: identity."""
         return PolicyProcessorPipeline(steps=[]), PolicyProcessorPipeline(steps=[])
 
+    def validate_platform(self) -> None:
+        """Fail fast when this environment cannot run on the current machine.
+
+        Called from `TrainPipelineConfig.validate()` at startup, before the dataset
+        is downloaded and the policy is built, so a run that could never reach an
+        environment rollout stops immediately instead of minutes later.
+
+        Deliberately kept out of `__post_init__`: `make_env_config()` constructs
+        registered envs to enumerate the available choices, and raising during
+        construction would break callers that never intended to run one. Subclasses
+        with a platform, driver or simulator constraint override this; the default
+        is a no-op.
+        """
+
 
 @dataclass
 class HubEnvConfig(EnvConfig):
@@ -331,6 +345,22 @@ LIBERO_SIMULATOR_MISSING_MSG = (
 )
 
 
+def _assert_libero_simulator_available() -> None:
+    """Raise with an actionable message if the LIBERO simulator is not importable.
+
+    Shared by `LiberoEnv.create_envs()` and `LiberoEnv.validate_platform()`, so the
+    check and its message exist in exactly one place.
+
+    `find_spec` proves the module is on the path, not that it imports cleanly: a
+    partial manual install on a non-Linux machine can pass here and still fail later
+    with the original traceback. Tightening this to a real `import libero` would be
+    exact but would import a heavy package on every `create_envs()` call. If that
+    trade is ever revisited, this is the only place it changes.
+    """
+    if importlib.util.find_spec("libero") is None:
+        raise ModuleNotFoundError(LIBERO_SIMULATOR_MISSING_MSG)
+
+
 @EnvConfig.register_subclass("libero")
 @dataclass
 class LiberoEnv(EnvConfig):
@@ -439,12 +469,15 @@ class LiberoEnv(EnvConfig):
             kwargs["task_ids"] = self.task_ids
         return kwargs
 
+    def validate_platform(self) -> None:
+        """LIBERO is Linux-only, see `_assert_libero_simulator_available` (#4388)."""
+        _assert_libero_simulator_available()
+
     def create_envs(self, n_envs: int, use_async_envs: bool = False):
         # Fail fast at env-construction time with an actionable message when the
         # simulator was silently omitted (e.g. a non-Linux install), instead of
         # letting a cryptic ModuleNotFoundError surface from the import below (#4388).
-        if importlib.util.find_spec("libero") is None:
-            raise ModuleNotFoundError(LIBERO_SIMULATOR_MISSING_MSG)
+        _assert_libero_simulator_available()
 
         from .libero import create_libero_envs
 

--- a/tests/configs/test_train_platform_validation.py
+++ b/tests/configs/test_train_platform_validation.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Startup platform validation, from `TrainPipelineConfig.validate()`.
+
+`lerobot_train` only reaches `make_env` from the eval branch inside the training
+loop. Without a startup check, a run that can never work on this machine still
+downloads the dataset, builds the policy and trains `env_eval_freq` steps before
+the first rollout raises. Regression tests for #4388.
+"""
+
+import pytest
+
+from lerobot.configs.default import DatasetConfig
+from lerobot.configs.train import TrainPipelineConfig
+from lerobot.envs.configs import LiberoEnv
+from lerobot.envs.factory import make_env_config
+
+
+@pytest.fixture
+def simulator_missing(monkeypatch):
+    """Reproduce a non-Linux install, where the simulator is silently absent.
+
+    `lerobot[libero]` carries a `sys_platform == 'linux'` marker on `hf-libero`,
+    so the extra resolves cleanly and omits it. Patched rather than assumed, so
+    these tests still mean something on Linux CI where LIBERO is installed.
+    """
+    import importlib.util as importlib_util
+
+    real_find_spec = importlib_util.find_spec
+
+    def fake_find_spec(name, *args, **kwargs):
+        if name == "libero":
+            return None
+        return real_find_spec(name, *args, **kwargs)
+
+    monkeypatch.setattr(importlib_util, "find_spec", fake_find_spec)
+
+
+def make_cfg(**overrides) -> TrainPipelineConfig:
+    cfg = TrainPipelineConfig(dataset=DatasetConfig(repo_id="lerobot/dummy"))
+    for name, value in overrides.items():
+        setattr(cfg, name, value)
+    return cfg
+
+
+class TestPlatformValidation:
+    def test_libero_without_simulator_fails_at_startup(self, simulator_missing):
+        cfg = make_cfg(env=LiberoEnv(), env_eval_freq=20_000)
+
+        with pytest.raises(ModuleNotFoundError, match="Linux") as exc_info:
+            cfg.validate()
+
+        message = str(exc_info.value)
+        assert "hf-libero" in message
+        assert "lerobot[libero]" in message
+
+    def test_fires_before_other_validation_work(self, simulator_missing, monkeypatch):
+        """The whole point of this check is *when* it fires.
+
+        Everything downstream of the platform block must not have run yet:
+        pretrained resolution here, and later the dataset download in
+        `lerobot_train`. Blow up if resolution is reached, then assert we never
+        got there.
+        """
+
+        def explode(self):
+            raise AssertionError("pretrained resolution ran before the check")
+
+        monkeypatch.setattr(TrainPipelineConfig, "_resolve_pretrained_from_cli", explode)
+        cfg = make_cfg(env=LiberoEnv(), env_eval_freq=20_000)
+
+        with pytest.raises(ModuleNotFoundError, match="Linux"):
+            cfg.validate()
+
+    def test_eval_disabled_skips_the_check(self, simulator_missing):
+        """With in-training eval off, nothing constructs a simulator.
+
+        The env config is then only used to build processors for rollouts that
+        never happen, so training on LIBERO data on a non-Linux machine works
+        today and must keep working. Reaching the policy check proves validation
+        walked past the platform block rather than stopping there.
+        """
+        cfg = make_cfg(env=LiberoEnv(), env_eval_freq=0)
+
+        with pytest.raises(ValueError, match="Neither policy nor reward_model"):
+            cfg.validate()
+
+    def test_no_env_skips_the_check(self, simulator_missing):
+        cfg = make_cfg(env=None, env_eval_freq=20_000)
+
+        with pytest.raises(ValueError, match="Neither policy nor reward_model"):
+            cfg.validate()
+
+    def test_env_without_constraint_passes(self, simulator_missing):
+        cfg = make_cfg(env=make_env_config("aloha"), env_eval_freq=20_000)
+
+        with pytest.raises(ValueError, match="Neither policy nor reward_model"):
+            cfg.validate()

--- a/tests/configs/test_train_platform_validation.py
+++ b/tests/configs/test_train_platform_validation.py
@@ -60,7 +60,7 @@ class TestPlatformValidation:
     def test_libero_without_simulator_fails_at_startup(self, simulator_missing):
         cfg = make_cfg(env=LiberoEnv(), env_eval_freq=20_000)
 
-        with pytest.raises(ModuleNotFoundError, match="Linux") as exc_info:
+        with pytest.raises(ModuleNotFoundError, match="LIBERO simulator is not installed") as exc_info:
             cfg.validate()
 
         message = str(exc_info.value)
@@ -82,7 +82,7 @@ class TestPlatformValidation:
         monkeypatch.setattr(TrainPipelineConfig, "_resolve_pretrained_from_cli", explode)
         cfg = make_cfg(env=LiberoEnv(), env_eval_freq=20_000)
 
-        with pytest.raises(ModuleNotFoundError, match="Linux"):
+        with pytest.raises(ModuleNotFoundError, match="LIBERO simulator is not installed"):
             cfg.validate()
 
     def test_eval_disabled_skips_the_check(self, simulator_missing):

--- a/tests/envs/test_dispatch.py
+++ b/tests/envs/test_dispatch.py
@@ -63,7 +63,7 @@ def test_libero_create_envs_without_simulator_raises_clear_error(monkeypatch):
 
     monkeypatch.setattr(importlib_util, "find_spec", fake_find_spec)
 
-    with pytest.raises(ModuleNotFoundError, match="Linux") as exc_info:
+    with pytest.raises(ModuleNotFoundError, match="LIBERO simulator is not installed") as exc_info:
         LiberoEnv().create_envs(n_envs=1)
 
     message = str(exc_info.value)
@@ -99,7 +99,7 @@ def test_libero_validate_platform_without_simulator(monkeypatch):
     """
     _hide_libero(monkeypatch)
 
-    with pytest.raises(ModuleNotFoundError, match="Linux") as exc_info:
+    with pytest.raises(ModuleNotFoundError, match="LIBERO simulator is not installed") as exc_info:
         LiberoEnv().validate_platform()
 
     message = str(exc_info.value)

--- a/tests/envs/test_dispatch.py
+++ b/tests/envs/test_dispatch.py
@@ -46,6 +46,31 @@ def test_libero_rejects_nonpositive_fps():
         LiberoEnv(fps=0)
 
 
+def test_libero_create_envs_without_simulator_raises_clear_error(monkeypatch):
+    """When the LIBERO simulator package is absent — the stock situation on non-Linux
+    installs, where ``hf-libero``'s ``sys_platform == 'linux'`` marker makes
+    ``pip install 'lerobot[libero]'`` silently omit it — ``create_envs()`` must fail
+    fast with an actionable message instead of a cryptic ``ModuleNotFoundError`` raised
+    deep inside the ``lerobot.envs.libero`` import. Regression test for #4388."""
+    import importlib.util as importlib_util
+
+    real_find_spec = importlib_util.find_spec
+
+    def fake_find_spec(name, *args, **kwargs):
+        if name == "libero":
+            return None
+        return real_find_spec(name, *args, **kwargs)
+
+    monkeypatch.setattr(importlib_util, "find_spec", fake_find_spec)
+
+    with pytest.raises(ImportError, match="Linux") as exc_info:
+        LiberoEnv().create_envs(n_envs=1)
+
+    message = str(exc_info.value)
+    assert "hf-libero" in message
+    assert "lerobot[libero]" in message
+
+
 def test_identity_processors():
     """Base class get_env_processors() returns identity pipelines."""
     cfg = make_env_config("aloha")

--- a/tests/envs/test_dispatch.py
+++ b/tests/envs/test_dispatch.py
@@ -63,7 +63,7 @@ def test_libero_create_envs_without_simulator_raises_clear_error(monkeypatch):
 
     monkeypatch.setattr(importlib_util, "find_spec", fake_find_spec)
 
-    with pytest.raises(ImportError, match="Linux") as exc_info:
+    with pytest.raises(ModuleNotFoundError, match="Linux") as exc_info:
         LiberoEnv().create_envs(n_envs=1)
 
     message = str(exc_info.value)

--- a/tests/envs/test_dispatch.py
+++ b/tests/envs/test_dispatch.py
@@ -71,6 +71,72 @@ def test_libero_create_envs_without_simulator_raises_clear_error(monkeypatch):
     assert "lerobot[libero]" in message
 
 
+def _hide_libero(monkeypatch):
+    """Make `find_spec("libero")` report the simulator as absent.
+
+    Reproduces a non-Linux install, where `lerobot[libero]`'s
+    `sys_platform == 'linux'` marker on `hf-libero` silently omits it. Patched
+    rather than assumed, so these tests still mean something on Linux CI.
+    """
+    import importlib.util as importlib_util
+
+    real_find_spec = importlib_util.find_spec
+
+    def fake_find_spec(name, *args, **kwargs):
+        if name == "libero":
+            return None
+        return real_find_spec(name, *args, **kwargs)
+
+    monkeypatch.setattr(importlib_util, "find_spec", fake_find_spec)
+
+
+def test_libero_validate_platform_without_simulator(monkeypatch):
+    """`validate_platform()` is the startup-time twin of the `create_envs()` guard.
+
+    It must raise the same actionable error from the same single source, so a
+    LIBERO run on a non-Linux install fails before any setup work rather than at
+    the first rollout (#4388).
+    """
+    _hide_libero(monkeypatch)
+
+    with pytest.raises(ModuleNotFoundError, match="Linux") as exc_info:
+        LiberoEnv().validate_platform()
+
+    message = str(exc_info.value)
+    assert "hf-libero" in message
+    assert "lerobot[libero]" in message
+
+
+def test_validate_platform_defaults_to_noop():
+    """Only envs with a platform constraint override the hook.
+
+    Every other registered env must accept it silently, so
+    `TrainPipelineConfig.validate()` can call it unconditionally.
+    """
+    for env_type in EnvConfig.get_known_choices():
+        cfg = make_env_config(env_type)
+        # `register_subclass` also accepts classes that do not inherit from
+        # EnvConfig (plugins may register one, and a test fixture leaves one in
+        # the registry), so screen them out the same way test_registry_all_types
+        # above does.
+        if not isinstance(cfg, EnvConfig) or isinstance(cfg, LiberoEnv):
+            continue
+        cfg.validate_platform()  # must not raise
+
+
+def test_validate_platform_not_called_on_construction(monkeypatch):
+    """Constructing a config must stay side-effect free.
+
+    `make_env_config()` builds every registered env just to enumerate the
+    choices, so moving this check into `__post_init__` would break callers that
+    never intended to run one. See the note on the base method.
+    """
+    _hide_libero(monkeypatch)
+
+    make_env_config("libero")  # must not raise even with the simulator absent
+    LiberoEnv()
+
+
 def test_identity_processors():
     """Base class get_env_processors() returns identity pipelines."""
     cfg = make_env_config("aloha")


### PR DESCRIPTION
## Summary / Motivation

Follow-up to #4388, implementing the design @pgeedh proposed in that thread. Adds a generic `validate_platform()` hook on `EnvConfig`, a no-op by default, and calls it from `TrainPipelineConfig.validate()` at startup. `LiberoEnv` overrides it. The hook and `create_envs()` both go through one private helper, `_assert_libero_simulator_available()`, so the check and its message exist in exactly one place.

To be clear about whose idea this is: I wanted to hardcode a LIBERO check inside `TrainPipelineConfig.validate()`, and withdrew that in favour of @pgeedh's generic hook. This is his design.

Why it matters: on main, `make_env` is only reached from the eval branch inside the training loop. So a LIBERO run on macOS downloads the dataset, builds the policy, and trains `env_eval_freq` steps (20,000 by default) before the missing simulator surfaces. `validate()` already runs before all of that, and the line there even says so.

Trade-off, and the one thing I want looked at rather than assumed: I gated the call on `env_eval_freq > 0`, not just `env is not None`.

```python
if self.env is not None and self.env_eval_freq > 0:
    self.env.validate_platform()
```

With in-training eval disabled, nothing constructs a simulator. Env processors get built at `lerobot_train.py:608` but are only consumed at `:863-864`, inside the eval branch. So training on LIBERO data on a Mac with `--env_eval_freq=0` works today, and an ungated check would break it. `_validate_distributed` already uses the same predicate. Nobody raised this in the thread, so please push back if you would rather it fire whenever `--env` is set.

## Related issues

- Related: #4388
- Depends on: #4455, see below

## This is stacked on #4455

The branch carries #4455's two commits underneath mine, since my change refactors its inline check into the shared helper. **Only the last commit is mine.**

Please merge #4455 first, then I will rebase and this drops to a single commit. Nothing here is a criticism of that PR, it should land as it stands.

## What changed

- `EnvConfig.validate_platform()`, no-op default. Kept out of `__post_init__` on purpose: `make_env_config()` constructs registered envs just to enumerate the choices, and raising during construction would break callers that never meant to run one. The docstring says this, so nobody folds it back in later.
- `LiberoEnv.validate_platform()` overrides it, sharing the helper with `create_envs()`.
- `TrainPipelineConfig.validate()` calls it next to the existing multiprocessing platform check.
- `docs/source/adding_benchmarks.mdx`: documents the hook next to the other two overridables, and the dependency section now says a platform-marked dep should be paired with a `validate_platform()` override. That section already tells you to add `; sys_platform == 'linux'` markers, which is how we got #4388 in the first place.
- Note one from the thread now has a single home. The helper docstring records that `find_spec` proves the module is on the path, not that it imports cleanly, and that tightening it to a real `import libero` would change in one place only.

No behaviour change for anyone whose environment is installed.

## How was this tested

Apple silicon arm64, macOS 26.5.2, Python 3.12.7. `pip install -e '.[libero,test]'` exits 0 and omits `hf-libero`, exactly as reported in #4388.

| | before (main @4aaff99b) | after |
|---|---|---|
| `validate()`, env=libero, `env_eval_freq=20000` | no error, startup passes | `ModuleNotFoundError` with the Linux-only message |
| `validate()`, env=libero, `env_eval_freq=0` | no error | no error, unchanged |
| `create_envs()` | `ModuleNotFoundError: No module named 'libero'` | the actionable message |

Tests added, `tests/configs/test_train_platform_validation.py` (new) and 3 in `tests/envs/test_dispatch.py`:

```bash
pytest -q tests/configs/ tests/envs/ tests/utils/test_train_utils.py   # 143 passed, 16 skipped
```

- They monkeypatch `find_spec` rather than relying on the simulator being absent, so they mean something on Linux CI too.
- One asserts the check runs before `_resolve_pretrained_from_cli`, since the whole point is when it fires.
- Three assert the things that must keep working: eval disabled, no env, and a non-LIBERO env.
- I reverted only `src/` and kept the tests: 4 of them fail. They can actually go red, they are not passing by accident.

## Checklist

- [x] Linting/formatting run (`pre-commit run -a`), 19 hooks pass
- [ ] All tests pass locally (`pytest`). I ran the three directories above, not the full suite, which needs hardware and network I do not have here
- [x] Documentation updated
- [ ] CI is green, will confirm once it runs
- [ ] Community Review: #4455. Being straight about this one, I reviewed it in detail but in issue #4388 rather than on the PR, and note two from that review did land in it. Happy to post the review on the PR itself if you want the box ticked properly

## Reviewer notes

- The `env_eval_freq` gate in `configs/train.py` is the bit to argue with.
- I have not run this on Linux, where LIBERO is actually installed. The tests patch `find_spec` so they should hold there, but I have not confirmed it. @pgeedh you offered to review and test, that would cover the gap.

Thanks @pgeedh for the design, @ousamabenyounes for #4455, and @ethanvillalovoz for running the before/after on real hardware there.
