### PR TITLE
refresh policy inputs from dataset

### DIFF
--- a/src/lerobot/policies/factory.py
+++ b/src/lerobot/policies/factory.py
@@ -331,8 +331,7 @@ def make_policy(
         features = {rename_map.get(key, key): feature for key, feature in features.items()}
 
     cfg.output_features = {key: ft for key, ft in features.items() if ft.type is FeatureType.ACTION}
-    if not cfg.input_features:
-        cfg.input_features = {key: ft for key, ft in features.items() if key not in cfg.output_features}
+    cfg.input_features = {key: ft for key, ft in features.items() if key not in cfg.output_features}
 
     # Store action feature names for relative_exclude_joints support
     if ds_meta is not None and hasattr(cfg, "action_feature_names"):

--- a/tests/policies/test_factory_peft_revision.py
+++ b/tests/policies/test_factory_peft_revision.py
@@ -120,3 +120,25 @@ def test_make_policy_reads_action_names_through_rename_map(monkeypatch):
     assert result is policy
     assert cfg.action_feature_names == action_names
     assert cfg.output_features[ACTION].type is FeatureType.ACTION
+
+
+def test_make_policy_refreshes_input_features_from_dataset(monkeypatch):
+    stale_feature = SimpleNamespace(type=FeatureType.STATE)
+    dataset_feature = SimpleNamespace(type=FeatureType.STATE)
+    cfg = SimpleNamespace(
+        type="mock",
+        device="cpu",
+        pretrained_path="org/base-policy",
+        use_peft=False,
+        input_features={"stale_state": stale_feature},
+        output_features={},
+    )
+    dataset_meta = SimpleNamespace(features={"observation.state": dataset_feature}, stats={})
+    policy = torch.nn.Linear(1, 1)
+    policy_class = MagicMock(return_value=policy)
+    monkeypatch.setattr(policy_factory, "get_policy_class", lambda _: policy_class)
+
+    result = policy_factory.make_policy(cfg, ds_meta=dataset_meta)
+
+    assert result is policy
+    assert cfg.input_features == {"observation.state": dataset_feature}


### PR DESCRIPTION
Use the current dataset feature schema for policy inputs during fine-tuning so a pretrained checkpoint cannot keep stale features.