### PR TITLE
add dataset reader registry for storage backends

### DIFF
--- a/src/lerobot/datasets/__init__.py
+++ b/src/lerobot/datasets/__init__.py
@@ -52,6 +52,7 @@ from .multi_dataset import MultiLeRobotDataset
 from .pipeline_features import aggregate_pipeline_dataset_features, create_initial_features
 from .pyav_utils import check_video_encoder_parameters_pyav, detect_available_encoders_pyav
 from .sampler import EpisodeAwareSampler, compute_sampler_state
+from .storage import register_dataset_reader
 from .streaming_dataset import StreamingLeRobotDataset
 from .utils import DEFAULT_EPISODES_PATH, create_lerobot_dataset_card, resolve_episode_indices
 from .video_utils import VideoEncodingManager
@@ -76,6 +77,7 @@ __all__ = [
     "STYLE_REGISTRY",
     "StreamingLeRobotDataset",
     "VideoEncodingManager",
+    "register_dataset_reader",
     "check_video_encoder_parameters_pyav",
     "detect_available_encoders_pyav",
     "add_features",

--- a/src/lerobot/datasets/storage.py
+++ b/src/lerobot/datasets/storage.py
@@ -34,7 +34,18 @@ DEFAULT_STORAGE_FORMAT = "lerobot"
 # ``image_transforms``, ``tolerance_s``, ``revision``, ``return_uint8``,
 # ``depth_output_unit`` and ``token``) and a ``localize_root`` hook for
 # object-store roots.
-_DATASET_READER_MODULES = {"lance": "lerobot.datasets.lance_backend"}
+_DATASET_READER_MODULES: dict[str, str] = {}
+
+
+def register_dataset_reader(storage_format: str, module: str) -> None:
+    """Register ``module`` (implementing the contract above) to serve ``storage_format``."""
+    existing = _DATASET_READER_MODULES.get(storage_format, module)
+    if storage_format == DEFAULT_STORAGE_FORMAT or existing != module:
+        raise ValueError(f"storage_format {storage_format!r} is already registered.")
+    _DATASET_READER_MODULES[storage_format] = module
+
+
+register_dataset_reader("lance", "lerobot.datasets.lance_backend")
 
 
 def is_remote_uri(root: str | Path) -> bool:

--- a/src/lerobot/datasets/storage.py
+++ b/src/lerobot/datasets/storage.py
@@ -91,7 +91,9 @@ def localize_remote_root(
             return _reader_module(storage_format).localize_root(
                 repo_id, root, revision, token=token, force_cache_sync=force_cache_sync
             )
-        except FileNotFoundError as error:
+        except (FileNotFoundError, ImportError) as error:
+            # ImportError: this format's optional dependencies are missing, which
+            # must not stop the probe from reaching other registered formats.
             errors.append(f"{storage_format}: {error}")
     raise FileNotFoundError(
         f"No dataset found at {str(root)!r}. Tried {errors}. "

--- a/tests/datasets/test_dataset_reader.py
+++ b/tests/datasets/test_dataset_reader.py
@@ -15,13 +15,21 @@
 # limitations under the License.
 """Contract tests for DatasetReader."""
 
+import json
+import sys
+import types
+
 import pytest
+import torch
 
 pytest.importorskip("datasets", reason="datasets is required (install lerobot[dataset])")
 
+from lerobot.datasets import LeRobotDataset, register_dataset_reader
 from lerobot.datasets.dataset_reader import DatasetReader
 from lerobot.datasets.language import LANGUAGE_EVENTS
+from lerobot.datasets.storage import _DATASET_READER_MODULES, DEFAULT_STORAGE_FORMAT
 from lerobot.utils.import_utils import get_safe_default_video_backend
+from tests.fixtures.constants import DUMMY_REPO_ID
 
 # ── Loading ──────────────────────────────────────────────────────────
 
@@ -187,3 +195,43 @@ def test_get_episodes_file_paths_includes_video_paths(tmp_path, lerobot_dataset_
     if len(dataset.meta.video_keys) > 0:
         paths = dataset.reader.get_episodes_file_paths()
         assert any("video" in str(p).lower() for p in paths)
+
+
+# ── Reader registry ──────────────────────────────────────────────────
+
+
+class ToyDatasetReader(DatasetReader):
+    def __init__(self, revision=None, token=None, **kwargs):
+        super().__init__(video_backend="pyav", **kwargs)
+
+
+def test_register_dataset_reader(tmp_path, lerobot_dataset_factory, monkeypatch):
+    root = tmp_path / "src"
+    lerobot_dataset_factory(
+        root=root, total_episodes=2, total_frames=60, use_videos=False, camera_features={}
+    )
+    plain_item = LeRobotDataset(DUMMY_REPO_ID, root=root)[0]
+
+    module = types.ModuleType("toyfmt_reader")
+    module.DATASET_READER = ToyDatasetReader
+    monkeypatch.setitem(sys.modules, "toyfmt_reader", module)
+    register_dataset_reader("toyfmt", "toyfmt_reader")
+    try:
+        info_path = root / "meta" / "info.json"
+        info = json.loads(info_path.read_text())
+        info["storage_format"] = "toyfmt"
+        info_path.write_text(json.dumps(info))
+
+        ds = LeRobotDataset(DUMMY_REPO_ID, root=root)
+        assert isinstance(ds.reader, ToyDatasetReader)
+        item = ds[0]
+        for key, expected in plain_item.items():
+            if isinstance(expected, torch.Tensor):
+                torch.testing.assert_close(item[key], expected, rtol=0, atol=0)
+
+        with pytest.raises(ValueError, match="already registered"):
+            register_dataset_reader("toyfmt", "some.other.module")
+        with pytest.raises(ValueError, match="already registered"):
+            register_dataset_reader(DEFAULT_STORAGE_FORMAT, "toyfmt_reader")
+    finally:
+        _DATASET_READER_MODULES.pop("toyfmt", None)

--- a/tests/datasets/test_dataset_reader.py
+++ b/tests/datasets/test_dataset_reader.py
@@ -27,7 +27,7 @@ pytest.importorskip("datasets", reason="datasets is required (install lerobot[da
 from lerobot.datasets import LeRobotDataset, register_dataset_reader
 from lerobot.datasets.dataset_reader import DatasetReader
 from lerobot.datasets.language import LANGUAGE_EVENTS
-from lerobot.datasets.storage import _DATASET_READER_MODULES, DEFAULT_STORAGE_FORMAT
+from lerobot.datasets.storage import _DATASET_READER_MODULES, DEFAULT_STORAGE_FORMAT, localize_remote_root
 from lerobot.utils.import_utils import get_safe_default_video_backend
 from tests.fixtures.constants import DUMMY_REPO_ID
 
@@ -233,5 +233,20 @@ def test_register_dataset_reader(tmp_path, lerobot_dataset_factory, monkeypatch)
             register_dataset_reader("toyfmt", "some.other.module")
         with pytest.raises(ValueError, match="already registered"):
             register_dataset_reader(DEFAULT_STORAGE_FORMAT, "toyfmt_reader")
+
+        # a format whose optional deps are missing must not block probing the others
+        module.localize_root = lambda *args, **kwargs: root
+        broken = types.ModuleType("broken_reader")
+
+        def raise_import_error(*args, **kwargs):
+            raise ImportError("install some-extra")
+
+        broken.localize_root = raise_import_error
+        monkeypatch.setitem(sys.modules, "broken_reader", broken)
+        monkeypatch.setattr(
+            "lerobot.datasets.storage._DATASET_READER_MODULES",
+            {"broken": "broken_reader", "toyfmt": "toyfmt_reader"},
+        )
+        assert localize_remote_root(DUMMY_REPO_ID, "s3://bucket/ds") == root
     finally:
         _DATASET_READER_MODULES.pop("toyfmt", None)


### PR DESCRIPTION
## Title

add dataset reader registry for storage backends

## Summary / Motivation

Allows registering dataset modules, with checks ensuring uniqueness. This is implemented as a module registry rather than a decorator to prevent importing unnecessary optional packages from backend module

## Related issues

- Fixes / Closes: # (if any)
- Related: # (if any)

## What changed

- Short, concrete bullets explaining the functional changes (how the behavior or output differs now).
- Short note if this introduces breaking changes and migration steps.

## How was this tested (or how to run locally)

- Tests added: list new tests or test files. `pytest -q tests/ -k <keyword>`
- Manual checks / dataset runs performed.
- Instructions for the reviewer for reproducing with a quick example or CLI (if applicable)

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: # (insert PR number/link)

## Reviewer notes

- Anything the reviewer should focus on (performance, edge-cases, specific files) or general notes.
- Anyone in the community is free to review the PR.
