### PR TITLE
support non-default backends in foxglove playback

### DIFF
--- a/src/lerobot/utils/foxglove_visualization.py
+++ b/src/lerobot/utils/foxglove_visualization.py
@@ -405,6 +405,14 @@ def _frame_to_scalars(sample: dict, key: str, labels: list[str] | None = None) -
     return _labeled_scalars(name, arr.flatten(), labels)
 
 
+def _playback_times_ns(dataset) -> list[int]:
+    """Per-frame timestamps in nanoseconds, read without decoding video."""
+    if hasattr(dataset, "hf_dataset"):
+        return [int(round(float(t) * 1e9)) for t in dataset.hf_dataset["timestamp"]]
+    # Storage formats without hf_dataset (e.g. lance): timestamps lie on the fps grid.
+    return [int(round(i * 1e9 / dataset.fps)) for i in range(len(dataset))]
+
+
 def serve_foxglove_dataset_playback(
     dataset,
     episode_index: int,
@@ -445,8 +453,7 @@ def serve_foxglove_dataset_playback(
         ServerListener,
     )
 
-    # Per-frame timestamps in nanoseconds (read straight from the table, no video decode).
-    times_ns = [int(round(float(t) * 1e9)) for t in dataset.hf_dataset["timestamp"]]
+    times_ns = _playback_times_ns(dataset)
     n_frames = len(times_ns)
     if n_frames == 0:
         raise ValueError("Cannot visualize an empty episode.")

--- a/tests/utils/test_foxglove_visualization.py
+++ b/tests/utils/test_foxglove_visualization.py
@@ -99,3 +99,21 @@ def test_is_scalar():
     assert fv._is_scalar(np.array(3.0))  # 0-d array
     assert not fv._is_scalar(np.array([1.0, 2.0]))
     assert not fv._is_scalar("x")
+
+
+def test_playback_times_ns():
+    class WithHF:
+        hf_dataset = {"timestamp": [0.0, 0.1, 0.2]}
+
+    class NoHF:
+        fps = 10
+
+        def __len__(self):
+            return 3
+
+        @property
+        def hf_dataset(self):
+            raise AttributeError("not available for this storage format")
+
+    assert fv._playback_times_ns(WithHF()) == [0, 100_000_000, 200_000_000]
+    assert fv._playback_times_ns(NoHF()) == [0, 100_000_000, 200_000_000]


### PR DESCRIPTION
## Title

support non-default backends in foxglove playback

## Summary / Motivation

This allows non-default backends, that don't implement `hf_dataset` to work with foxglove visualisation.

## Related issues

- Fixes / Closes: # (if any)
- Related: # (if any)

## What changed

- Short, concrete bullets explaining the functional changes (how the behavior or output differs now).
- Short note if this introduces breaking changes and migration steps.

## How was this tested (or how to run locally)

- Tests added: list new tests or test files. `pytest -q tests/ -k <keyword>`
- Manual checks / dataset runs performed.
- Instructions for the reviewer for reproducing with a quick example or CLI (if applicable)

## Checklist (required before merge)

- [ ] Linting/formatting run (`pre-commit run -a`)
- [ ] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: # (insert PR number/link)

## Reviewer notes

- Anything the reviewer should focus on (performance, edge-cases, specific files) or general notes.
- Anyone in the community is free to review the PR.
