### PR TITLE
 make eval_split format aware

### DIFF
--- a/src/lerobot/configs/default.py
+++ b/src/lerobot/configs/default.py
@@ -59,6 +59,10 @@ class DatasetConfig:
     def __post_init__(self) -> None:
         if self.repo_type not in ("dataset", "bucket"):
             raise ValueError(f"repo_type must be 'dataset' or 'bucket', got {self.repo_type!r}")
+        if self.eval_split != 0.0 and self.streaming:
+            raise ValueError(
+                "eval_split requires map-style datasets and is not supported with dataset.streaming=true."
+            )
         if self.depth_output_unit not in (DEPTH_METER_UNIT, DEPTH_MILLIMETER_UNIT):
             raise ValueError(
                 f"depth_output_unit must be '{DEPTH_METER_UNIT}' or '{DEPTH_MILLIMETER_UNIT}', got {self.depth_output_unit!r}"

--- a/src/lerobot/configs/default.py
+++ b/src/lerobot/configs/default.py
@@ -59,10 +59,6 @@ class DatasetConfig:
     def __post_init__(self) -> None:
         if self.repo_type not in ("dataset", "bucket"):
             raise ValueError(f"repo_type must be 'dataset' or 'bucket', got {self.repo_type!r}")
-        if self.repo_type == "bucket" and self.eval_split != 0.0:
-            raise ValueError(
-                "eval_split requires map-style datasets and is not supported with repo_type='bucket'."
-            )
         if self.depth_output_unit not in (DEPTH_METER_UNIT, DEPTH_MILLIMETER_UNIT):
             raise ValueError(
                 f"depth_output_unit must be '{DEPTH_METER_UNIT}' or '{DEPTH_MILLIMETER_UNIT}', got {self.depth_output_unit!r}"

--- a/src/lerobot/datasets/factory.py
+++ b/src/lerobot/datasets/factory.py
@@ -203,10 +203,6 @@ def make_train_eval_datasets(
     The last ceil(n_episodes * eval_split) episodes per task are held out for evaluation.
     If eval_split == 0.0, returns (full_dataset, None).
     """
-    if cfg.dataset.eval_split != 0.0 and cfg.dataset.streaming:
-        raise ValueError(
-            "eval_split requires map-style datasets and is not supported with dataset.streaming=true."
-        )
     full_dataset = make_dataset(cfg)
 
     if cfg.dataset.eval_split == 0.0:

--- a/src/lerobot/datasets/factory.py
+++ b/src/lerobot/datasets/factory.py
@@ -203,6 +203,10 @@ def make_train_eval_datasets(
     The last ceil(n_episodes * eval_split) episodes per task are held out for evaluation.
     If eval_split == 0.0, returns (full_dataset, None).
     """
+    if cfg.dataset.eval_split != 0.0 and cfg.dataset.streaming:
+        raise ValueError(
+            "eval_split requires map-style datasets and is not supported with dataset.streaming=true."
+        )
     full_dataset = make_dataset(cfg)
 
     if cfg.dataset.eval_split == 0.0:
@@ -251,6 +255,7 @@ def make_train_eval_datasets(
         video_backend=cfg.dataset.video_backend,
         return_uint8=True,
         tolerance_s=cfg.tolerance_s,
+        repo_type=cfg.dataset.repo_type,
     )
 
     eval_dataset = LeRobotDataset(
@@ -264,6 +269,7 @@ def make_train_eval_datasets(
         video_backend=cfg.dataset.video_backend,
         return_uint8=True,
         tolerance_s=cfg.tolerance_s,
+        repo_type=cfg.dataset.repo_type,
     )
 
     if cfg.dataset.use_imagenet_stats:

--- a/tests/configs/test_default.py
+++ b/tests/configs/test_default.py
@@ -57,6 +57,6 @@ def test_dataset_config_invalid_repo_type():
         DatasetConfig(repo_id="user/repo", repo_type="model")
 
 
-def test_dataset_config_bucket_rejects_eval_split():
-    with pytest.raises(ValueError, match="eval_split"):
-        DatasetConfig(repo_id="user/repo", repo_type="bucket", streaming=True, eval_split=0.1)
+def test_dataset_config_bucket_eval_split_ok():
+    # allowed at config level; the factory rejects eval_split with streaming access
+    DatasetConfig(repo_id="user/repo", repo_type="bucket", eval_split=0.1)

--- a/tests/configs/test_default.py
+++ b/tests/configs/test_default.py
@@ -57,6 +57,8 @@ def test_dataset_config_invalid_repo_type():
         DatasetConfig(repo_id="user/repo", repo_type="model")
 
 
-def test_dataset_config_bucket_eval_split_ok():
-    # allowed at config level; the factory rejects eval_split with streaming access
+def test_dataset_config_eval_split():
+    # map-style access on a bucket is fine; streaming access is not, anywhere
     DatasetConfig(repo_id="user/repo", repo_type="bucket", eval_split=0.1)
+    with pytest.raises(ValueError, match="streaming"):
+        DatasetConfig(repo_id="user/repo", streaming=True, eval_split=0.1)


### PR DESCRIPTION
## Title

 make eval_split format aware

## Summary / Motivation

 The config-level ban on eval_split with repo_type='bucket' predates buckets being map-style readable. the real constraint is streaming access, not buckets, so the check moves to the dataset factory (eval_split + streaming=true raises, same message), and make_train_eval_datasets now passes repo_type to the train/eval split datasets. Also makes eval_split + streaming=true error clearly for regular hub repos, which previously slipped through and downloaded the dataset despite the streaming flag.


## Related issues

- Fixes / Closes: # (if any)
- Related: # (if any)

## What changed

- Short, concrete bullets explaining the functional changes (how the behavior or output differs now).
- Short note if this introduces breaking changes and migration steps.

## How was this tested (or how to run locally)

- Tests added: list new tests or test files. `pytest -q tests/ -k <keyword>`
- Manual checks / dataset runs performed.
- Instructions for the reviewer for reproducing with a quick example or CLI (if applicable)

## Checklist (required before merge)

- [ ] Linting/formatting run (`pre-commit run -a`)
- [ ] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: # (insert PR number/link)

## Reviewer notes

- Anything the reviewer should focus on (performance, edge-cases, specific files) or general notes.
- Anyone in the community is free to review the PR.
