### PR TITLE
Load MolmoAct2 checkpoints without base weights

### DIFF
--- a/src/lerobot/policies/molmoact2/modeling_molmoact2.py
+++ b/src/lerobot/policies/molmoact2/modeling_molmoact2.py
@@ -44,7 +44,9 @@ from torch import Tensor
 from torch.distributions import Beta
 
 from lerobot.policies.pretrained import PreTrainedPolicy
+from lerobot.policies.utils import log_model_loading_keys
 from lerobot.utils.constants import ACTION
+from lerobot.utils.device_utils import resolve_safetensors_device
 from lerobot.utils.import_utils import (
     _peft_available,
     _scipy_available,
@@ -634,8 +636,16 @@ class MolmoAct2Policy(PreTrainedPolicy):
         return super().from_pretrained(
             pretrained_name_or_path,
             strict=strict,
+            _load_from_lerobot_checkpoint=True,
             **kwargs,
         )
+
+    @classmethod
+    def _load_as_safetensor(cls, model, model_file: str, map_location: str, strict: bool):
+        state_dict = load_safetensors_file(model_file, device=resolve_safetensors_device(map_location))
+        missing_keys, unexpected_keys = model.load_state_dict(state_dict, strict=strict, assign=True)
+        log_model_loading_keys(missing_keys, unexpected_keys)
+        return model
 
     def supports_rtc(self) -> bool:
         return self.config.inference_action_mode == "continuous"
@@ -648,6 +658,7 @@ class MolmoAct2Policy(PreTrainedPolicy):
         dataset_meta: Any | None = None,
         **kwargs,
     ):
+        load_from_lerobot_checkpoint = kwargs.pop("_load_from_lerobot_checkpoint", False)
         super().__init__(config, *inputs, **kwargs)
         _apply_norm_tag_metadata(self.config)
         self.config.validate_features()
@@ -661,14 +672,14 @@ class MolmoAct2Policy(PreTrainedPolicy):
         self.action_tokenizer: Any | None = None
         self._compile_applied = False
         self._compiled_module_names: tuple[str, ...] = ()
-        self._load_hf_model()
+        self._load_hf_model(load_weights=not load_from_lerobot_checkpoint)
         _validate_inference_action_mode(self.config, self._checkpoint_action_mode)
         if self.config.train_mode_vlm == "lora":
             self._apply_lora_adapters()
         self._apply_compile()
         self.init_rtc_processor()
 
-    def _load_hf_model(self) -> None:
+    def _load_hf_model(self, load_weights: bool = True) -> None:
         require_package("transformers", extra="molmoact2")
 
         checkpoint_location = _resolve_checkpoint_location(
@@ -686,13 +697,17 @@ class MolmoAct2Policy(PreTrainedPolicy):
         text_config = getattr(hf_config, "text_config", None)
         if text_config is not None and hasattr(text_config, "residual_dropout"):
             text_config.residual_dropout = float(self.config.llm_residual_dropout)
-        self.model = MolmoAct2ForConditionalGeneration.from_pretrained(
-            checkpoint_location,
-            config=hf_config,
-            dtype=storage_dtype,
-            low_cpu_mem_usage=True,
-            token=_hf_token(),
-        )
+        if load_weights:
+            self.model = MolmoAct2ForConditionalGeneration.from_pretrained(
+                checkpoint_location,
+                config=hf_config,
+                dtype=storage_dtype,
+                low_cpu_mem_usage=True,
+                token=_hf_token(),
+            )
+        else:
+            with torch.device("meta"):
+                self.model = MolmoAct2ForConditionalGeneration(hf_config)
         # Keep Hub loading limited to local code plus safetensors, and verify the
         # local implementation exactly matches the checkpoint key space.
         self._apply_bfloat16_parameter_policy()
@@ -700,7 +715,8 @@ class MolmoAct2Policy(PreTrainedPolicy):
         # strict load. This preserves the checkpoint's original fp32 values for
         # the action expert and other fp32-targeted modules instead of widening
         # already-rounded bf16 tensors.
-        _strict_load_safetensors_weights(self.model, checkpoint_location)
+        if load_weights:
+            _strict_load_safetensors_weights(self.model, checkpoint_location)
         hf_max_action_dim = int(getattr(self.model.config, "max_action_dim", -1))
         if hf_max_action_dim != int(self.config.expected_max_action_dim):
             raise ValueError(

--- a/tests/policies/molmoact2/test_molmoact2.py
+++ b/tests/policies/molmoact2/test_molmoact2.py
@@ -29,6 +29,7 @@ import numpy as np
 import pytest
 import torch
 import torch.nn.functional as F  # noqa: N812
+from safetensors.torch import save_file as save_safetensors_file
 
 pytest.importorskip("transformers")
 pytest.importorskip("scipy")
@@ -126,9 +127,26 @@ def test_molmoact2_checkpoint_loading_is_strict_by_default(monkeypatch, strict, 
         (
             MolmoAct2Policy,
             "/tmp/molmoact2-checkpoint",
-            {"strict": expected},
+            {"strict": expected, "_load_from_lerobot_checkpoint": True},
         )
     ]
+
+
+def test_molmoact2_checkpoint_weights_materialize_meta_model(tmp_path):
+    with torch.device("meta"):
+        model = torch.nn.Linear(2, 1)
+    state_dict = {
+        "weight": torch.tensor([[1.0, 2.0]]),
+        "bias": torch.tensor([3.0]),
+    }
+    model_file = tmp_path / "model.safetensors"
+    save_safetensors_file(state_dict, str(model_file))
+
+    MolmoAct2Policy._load_as_safetensor(model, str(model_file), "cpu", strict=True)
+
+    assert model.weight.device.type == "cpu"
+    assert torch.equal(model.weight, state_dict["weight"])
+    assert torch.equal(model.bias, state_dict["bias"])
 
 
 def test_molmoact2_scheduler_warmup_is_continuous_with_post_warmup_cosine():
@@ -1627,7 +1645,7 @@ def test_molmoact2_norm_metadata_is_initialization_only(tmp_path, monkeypatch):
         return model
 
     monkeypatch.setattr(molmoact2_modeling, "_load_hf_norm_metadata_for_tag", fail_norm_tag_lookup)
-    monkeypatch.setattr(MolmoAct2Policy, "_load_hf_model", lambda self: None)
+    monkeypatch.setattr(MolmoAct2Policy, "_load_hf_model", lambda self, load_weights: None)
     monkeypatch.setattr(MolmoAct2Policy, "_load_as_safetensor", classmethod(fake_load_as_safetensor))
     policy = MolmoAct2Policy.from_pretrained(checkpoint_path)
 
@@ -2830,6 +2848,62 @@ def test_train_mode_vlm_freeze_freezes_non_action_expert_params():
     assert not any(param.requires_grad for param in policy.model.model.transformer.parameters())
     assert not any(param.requires_grad for param in policy.model.model.vision_backbone.parameters())
     assert not any(param.requires_grad for param in policy.model.lm_head.parameters())
+
+
+def test_load_hf_model_skips_base_weights_for_lerobot_checkpoint(monkeypatch):
+    class DummyLoadedModel(torch.nn.Module):
+        def __init__(self, config):
+            super().__init__()
+            self.config = SimpleNamespace(
+                max_action_dim=32,
+                max_action_horizon=30,
+                action_mode="both",
+                add_action_expert=True,
+            )
+            self.model = torch.nn.Module()
+            self.weight = torch.nn.Parameter(torch.ones(1))
+
+    class DummyHFConfig:
+        @classmethod
+        def from_pretrained(cls, *args, **kwargs):
+            del cls, args, kwargs
+            return SimpleNamespace()
+
+    class DummyMolmoAct2ForConditionalGeneration(DummyLoadedModel):
+        @classmethod
+        def from_pretrained(cls, *args, **kwargs):
+            del cls, args, kwargs
+            pytest.fail("LeRobot checkpoint loading must not load base model weights")
+
+    monkeypatch.setattr(
+        molmoact2_modeling,
+        "_resolve_checkpoint_location",
+        lambda checkpoint_path, **kwargs: checkpoint_path,
+    )
+    monkeypatch.setattr(molmoact2_modeling, "HFMolmoAct2Config", DummyHFConfig)
+    monkeypatch.setattr(
+        molmoact2_modeling,
+        "MolmoAct2ForConditionalGeneration",
+        DummyMolmoAct2ForConditionalGeneration,
+    )
+    monkeypatch.setattr(
+        molmoact2_modeling,
+        "_strict_load_safetensors_weights",
+        lambda *args: pytest.fail("LeRobot checkpoint loading must not load base model safetensors"),
+    )
+    policy = object.__new__(MolmoAct2Policy)
+    torch.nn.Module.__init__(policy)
+    policy.config = MolmoAct2Config(
+        checkpoint_path="/tmp/base-hf-checkpoint",
+        action_mode="both",
+        train_mode_vlm="fft",
+        freeze_embedding=False,
+        dtype="float32",
+    )
+
+    policy._load_hf_model(load_weights=False)
+
+    assert policy.model.weight.device.type == "meta"
 
 
 def test_load_hf_model_accepts_max_action_horizon_schema(monkeypatch):


### PR DESCRIPTION
## Summary / Motivation

Load LeRobot MolmoAct2 checkpoints without loading the base model weights first.

## Related issues

Fixes #4520

## What changed

- Build the model on meta and assign final checkpoint tensors on the configured device.
- Add regression coverage for the no-base-weight path and meta weight materialization.

## How was this tested

- `uv run pytest tests/policies/molmoact2/test_molmoact2.py -q`
  - 120 passed, 1 skipped
- `uv run pre-commit run --files src/lerobot/policies/molmoact2/modeling_molmoact2.py tests/policies/molmoact2/test_molmoact2.py`

## Checklist

- [x] Linting/formatting run
- [ ] All tests pass locally
- [ ] Documentation updated
- [ ] CI is green
- [ ] Community Review

## Reviewer notes

AI assistance: Codex.