### PR TITLE
Fix reset config joint positions encoding

### DIFF
--- a/docs/source/hilserl.mdx
+++ b/docs/source/hilserl.mdx
@@ -107,7 +107,7 @@ class GripperConfig:
     gripper_penalty: float = 0.0    # Penalty for inappropriate gripper usage
 
 class ResetConfig:
-    fixed_reset_joint_positions: Any | None = None    # Joint positions for reset
+    fixed_reset_joint_positions: list[float] | None = None    # Joint positions for reset
     reset_time_s: float = 5.0    # Time to wait during reset
     control_time_s: float = 20.0    # Maximum episode duration
     terminate_on_success: bool = True    # Whether to terminate episodes on success detection

--- a/src/lerobot/envs/configs.py
+++ b/src/lerobot/envs/configs.py
@@ -281,7 +281,7 @@ class GripperConfig:
 class ResetConfig:
     """Configuration for environment reset behavior."""
 
-    fixed_reset_joint_positions: Any | None = None
+    fixed_reset_joint_positions: list[float] | None = None
     reset_time_s: float = 5.0
     control_time_s: float = 20.0
     terminate_on_success: bool = True


### PR DESCRIPTION
## Title

fix(envs): type `fixed_reset_joint_positions` as `list[float]`

## Summary / Motivation

`ResetConfig.fixed_reset_joint_positions` is annotated as `Any | None`, which draccus 0.11.6 cannot encode when a reset pose is configured. This prevents HIL-SERL training from starting.

This supersedes #4297. Thanks to @lucarp for his contribution

## Related issues

- Supersedes: #4297
- Related: #2692, #2472

## What changed

- Type `fixed_reset_joint_positions` as `list[float] | None`.
- Update the mirrored annotation in `docs/source/hilserl.mdx`.
- No breaking or runtime behavior changes.

## How was this tested (or how to run locally)

- Verified that `draccus.encode` succeeds for a HIL-SERL configuration containing fixed reset joint positions.
- The original contributor reported:
  - `pytest tests/envs tests/configs`: 75 passed, 11 skipped
  - `pytest tests/rl tests/processor`: 559 passed, 14 skipped
  - The learner reached `Starting learner thread` using the published HIL-SERL example configuration.

No new automated test is included.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated
- [ ] CI is green
- [x] Community Review: original contributor @lucarp reviewed #4177: https://github.com/huggingface/lerobot/pull/4177#pullrequestreview-4839106950

## Reviewer notes

- The original contribution remains commit `4f3ac7e`, authored by @lucarp.
- This PR adds only the requested documentation follow-up.
- Anyone in the community is free to review this PR.