### PR TITLE
feat(training): optionally omit checkpoint state

### DIFF
--- a/src/lerobot/common/train_utils.py
+++ b/src/lerobot/common/train_utils.py
@@ -502,6 +502,7 @@ def push_checkpoint_to_hub(
     repo_id: str,
     *,
     private: bool | None = None,
+    include_training_state: bool = True,
 ) -> None:
     """Upload a saved checkpoint directory to the Hub under checkpoints/<name>/.
 
@@ -511,15 +512,18 @@ def push_checkpoint_to_hub(
     checkpoint step so a checkpoint can be recovered with
     --policy.pretrained_revision=<step> instead of a commit sha.
 
-    The directory is uploaded verbatim — including DCP shards under the DCP formats: this tree
-    exists for *resume*, not distribution, and `resolve_resume_checkpoint` downloads it back
-    symmetrically.
+    By default, the directory is uploaded verbatim — including DCP shards under the DCP formats:
+    this tree exists for *resume*, not distribution, and `resolve_resume_checkpoint` downloads it
+    back symmetrically. Excluding the training state creates a model-only checkpoint that cannot be
+    used to resume training.
 
     Args:
         checkpoint_dir (Path): The local checkpoint step directory to upload.
         repo_id (str): The Hub model repo to push to (created idempotently if missing).
         private (bool | None): Whether a newly created repo should be private. Defaults to
             None (public unless the organization's default is private).
+        include_training_state (bool): Whether to upload optimizer, scheduler, RNG, and step state.
+            Defaults to True; disabling it makes the uploaded checkpoint non-resumable.
     """
     api = HfApi()
     api.create_repo(repo_id=repo_id, repo_type="model", private=private, exist_ok=True)
@@ -529,6 +533,7 @@ def push_checkpoint_to_hub(
         repo_type="model",
         path_in_repo=f"checkpoints/{checkpoint_dir.name}",
         commit_message=f"checkpoint {checkpoint_dir.name}",
+        ignore_patterns=None if include_training_state else f"{TRAINING_STATE_DIR}/**",
     )
     api.create_tag(
         repo_id=repo_id,

--- a/tests/utils/test_train_utils.py
+++ b/tests/utils/test_train_utils.py
@@ -149,6 +149,18 @@ def test_push_checkpoint_to_hub_defaults_to_hub_default_visibility(tmp_path, mon
     assert api.create_repo.call_args.kwargs["private"] is None
 
 
+def test_push_checkpoint_to_hub_can_exclude_training_state(tmp_path, monkeypatch):
+    ckpt = tmp_path / "010000"
+    (ckpt / "pretrained_model").mkdir(parents=True)
+    (ckpt / TRAINING_STATE_DIR).mkdir()
+    api = MagicMock()
+    monkeypatch.setattr("lerobot.common.train_utils.HfApi", lambda *a, **k: api)
+
+    push_checkpoint_to_hub(ckpt, "user/run", include_training_state=False)
+
+    assert api.upload_folder.call_args.kwargs["ignore_patterns"] == f"{TRAINING_STATE_DIR}/**"
+
+
 def test_resolve_resume_checkpoint_downloads_latest_and_links(tmp_path, monkeypatch):
     from lerobot.common import train_utils
 


### PR DESCRIPTION
## Summary / Motivation

Allow callers of `push_checkpoint_to_hub` to upload model artifacts without optimizer, scheduler, RNG, and step state. The existing resumable upload remains the default; model-only uploads are explicitly documented as non-resumable.

Significant implementation and test drafting used AI assistance; the resulting diff and behavior were independently reviewed and verified locally.

## Related issues

- Fixes #4523

## What changed

- Add the backward-compatible `include_training_state=True` keyword argument.
- Use the Hub client's existing `ignore_patterns` support when the argument is disabled.
- Add a regression test for excluding the `training_state` subtree.

## How was this tested (or how to run locally)

- `python -m pytest -q tests/utils/test_train_utils.py` — 12 passed.
- `python -m pytest -q tests/utils` — 202 passed, 6 skipped.
- `ruff check src/lerobot/common/train_utils.py tests/utils/test_train_utils.py`
- `ruff format --check src/lerobot/common/train_utils.py tests/utils/test_train_utils.py`

## Test verification (RED → GREEN)

Upstream behavior with only the new test applied:

```text
TypeError: push_checkpoint_to_hub() got an unexpected keyword argument 'include_training_state'
1 failed
```

Patched behavior:

```text
tests/utils/test_train_utils.py::test_push_checkpoint_to_hub_can_exclude_training_state PASSED
1 passed
```

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a` equivalent on changed files)
- [ ] All tests pass locally (`pytest`)
- [x] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: # (insert PR number/link)

## Reviewer notes

The new argument is keyword-only and defaults to the existing verbatim, resumable upload behavior.