### PR TITLE
docs(feetech): PWM direction bit is 10, not 11

### DIFF
--- a/src/lerobot/motors/feetech/feetech.py
+++ b/src/lerobot/motors/feetech/feetech.py
@@ -55,8 +55,9 @@ class OperatingMode(Enum):
     # The motor is in constant speed mode, which is controlled by parameter 0x2e, and the highest bit 15 is
     # the direction bit
     VELOCITY = 1
-    # PWM open-loop speed regulation mode, with parameter 0x2c running time parameter control, bit11 as
-    # direction bit
+    # PWM open-loop speed regulation mode, with parameter 0x2c running time parameter control, bit 10
+    # as direction bit. The datasheet writes "bit11", counting from 1; zero-indexed that is bit 10,
+    # which is the bit `STS_SMS_SERIES_ENCODINGS_TABLE` already uses to sign `Present_Load`.
     PWM = 2
     # In step servo mode, the number of step progress is represented by parameter 0x2a, and the highest bit 15
     # is the direction bit


### PR DESCRIPTION
## What

One comment. `OperatingMode.PWM` documents the direction bit of the PWM duty register (addr `0x2c` / 44) as `bit11`. It is bit 10.

The datasheet numbers that bit from 1. Every bit index in this package is zero-indexed, so the value that belongs in the comment is 10.

## Why this is the right number

`STS_SMS_SERIES_ENCODINGS_TABLE` in `tables.py` already encodes it, though only for the neighbouring registers. The sign bit there follows the width of each field:

| register | sign bit |
|---|---:|
| `Present_Load` | 10 |
| `Homing_Offset` | 11 |
| `Goal_Position` / `Present_Position` | 15 |

`Present_Load` is the register on this series that carries a duty-style magnitude, and it signs at 10. `Homing_Offset` is wider and signs at 11 — which is probably why the off-by-one is easy to miss: 11 is a real sign bit on this series, just not this register's.

## Bench check

sts3215, firmware 3.10. Writing the register with **bit 11** set does not reverse the joint — it drives it the same way and harder (`-227` → `-411` ticks for an identical commanded magnitude), i.e. the bit is consumed as extra magnitude and clamps to full duty. With **bit 10** the same probe reverses cleanly (`-227` → `+130`).

Single arm, so treat the bench numbers as corroboration rather than the argument; the argument is the table above.

## Scope

Comment-only. No code reads this bit index today — nothing in `lerobot` drives `OperatingMode.PWM`, so this changes no behaviour. It costs the next person who does drive it a debugging session.