### PR TITLE
refactor(rewards): expose typed semantic prediction APIs

### DIFF
--- a/docs/source/robometer.mdx
+++ b/docs/source/robometer.mdx
@@ -69,23 +69,22 @@ In LeRobot datasets, the preprocessor reads:
 - `progress`: frame-level progress clamped to `[0, 1]`.
 - `success_probability`: frame-level sigmoid probabilities.
 
-Frame selection and thresholding are explicit consumer decisions. The serialized `reward_output` and `success_threshold` fields remain load-compatible with existing checkpoints but do not alter these typed predictions.
+The model does not select a frame or convert probabilities into binary success. Consumers make those decisions explicitly.
 
-### Migrating from the legacy scalar API
+Older RoboMeter configurations may contain `reward_output` and `success_threshold`. LeRobot still accepts these fields so existing checkpoints load, but `predict_progress()` does not use them.
 
-The previous scalar API selected a signal using `reward_output`, selected its last frame, and optionally thresholded success. Replace that implicit behavior at the consumer boundary:
+### Migrating from the scalar API
 
-```python
+````python
 prediction = reward_model.predict_progress(batch)
 
-# Previous reward_output="progress" behavior
+# Last-frame progress
 reward = prediction.progress[:, -1]
 
-# Previous reward_output="success" behavior
-reward = (prediction.success_probability[:, -1] > cfg.success_threshold).float()
-```
-
-The legacy `compute_rabc_weights` command remains intentionally progress-only because its `progress_sparse` artifact is consumed as a progress curve. Future generic scoring adapters will expose signal selection explicitly rather than reading the compatibility-only `reward_output` field.
+# Last-frame binary success
+reward = (
+    prediction.success_probability[:, -1] > success_threshold
+).float()
 
 ## Usage
 
@@ -99,7 +98,7 @@ cfg = RobometerConfig(
     device="cuda",
 )
 reward_model = RobometerRewardModel.from_pretrained(cfg.pretrained_path, config=cfg)
-```
+````
 
 ### Encode Frames and Compute a Reward
 

--- a/docs/source/robometer.mdx
+++ b/docs/source/robometer.mdx
@@ -21,15 +21,14 @@ The paper trains ROBOMETER with a composite objective:
 L = L_pref + L_prog + L_succ
 ```
 
-The LeRobot integration is currently **inference-only**. It preserves the preference head so that the published `Robometer-4B` checkpoint loads without remapping, but `compute_reward()` queries the progress or success head only.
+The LeRobot integration is currently **inference-only**. It preserves the preference head so that the published `Robometer-4B` checkpoint loads without remapping. `predict_progress()` queries the progress and success heads in one pass.
 
 ## What the LeRobot Integration Covers
 
 - Standard `reward_model.type=robometer` configuration through LeRobot.
 - Qwen3-VL image and text preprocessing through `RobometerEncoderProcessorStep`.
 - LeRobot reward-model save/load APIs through `PreTrainedRewardModel`.
-- Dense, frame-level progress and success predictions internally.
-- A scalar reward through `compute_reward()` for downstream LeRobot reward-model usage.
+- Typed, frame-level progress and success-probability tensors through `predict_progress()`.
 
 This page focuses on using the published ROBOMETER checkpoint as a zero-shot reward model. Training ROBOMETER from scratch is outside the current LeRobot integration.
 
@@ -65,10 +64,28 @@ In LeRobot datasets, the preprocessor reads:
 | `reward_model.task_key`   | `task`                   | Key in complementary data that stores the task string |
 | `reward_model.max_frames` | `8`                      | Maximum number of frames passed to ROBOMETER          |
 
-The model predicts per-frame progress and success internally. The LeRobot reward API returns a scalar per sample:
+`predict_progress()` returns a `RobometerPrediction` with two float32 tensors of shape `(batch_size, num_frames)`:
 
-- `reward_output="progress"` (default): return the last-frame progress, clamped to `[0, 1]`.
-- `reward_output="success"`: return `1.0` if the last-frame success probability is above `success_threshold`, otherwise `0.0`.
+- `progress`: frame-level progress clamped to `[0, 1]`.
+- `success_probability`: frame-level sigmoid probabilities.
+
+Frame selection and thresholding are explicit consumer decisions. The serialized `reward_output` and `success_threshold` fields remain load-compatible with existing checkpoints but do not alter these typed predictions.
+
+### Migrating from the legacy scalar API
+
+The previous scalar API selected a signal using `reward_output`, selected its last frame, and optionally thresholded success. Replace that implicit behavior at the consumer boundary:
+
+```python
+prediction = reward_model.predict_progress(batch)
+
+# Previous reward_output="progress" behavior
+reward = prediction.progress[:, -1]
+
+# Previous reward_output="success" behavior
+reward = (prediction.success_probability[:, -1] > cfg.success_threshold).float()
+```
+
+The legacy `compute_rabc_weights` command remains intentionally progress-only because its `progress_sparse` artifact is consumed as a progress curve. Future generic scoring adapters will expose signal selection explicitly rather than reading the compatibility-only `reward_output` field.
 
 ## Usage
 
@@ -80,7 +97,6 @@ from lerobot.rewards.robometer import RobometerConfig, RobometerRewardModel
 cfg = RobometerConfig(
     pretrained_path="lerobot/Robometer-4B",
     device="cuda",
-    reward_output="progress",
 )
 reward_model = RobometerRewardModel.from_pretrained(cfg.pretrained_path, config=cfg)
 ```
@@ -105,10 +121,12 @@ encoder = RobometerEncoderProcessorStep(
 encoded = encoder.encode_samples([(frames, task)])
 batch = {f"{ROBOMETER_FEATURE_PREFIX}{key}": value for key, value in encoded.items()}
 
-reward = reward_model.compute_reward(batch)
+prediction = reward_model.predict_progress(batch)
+last_frame_progress = prediction.progress[:, -1]
+last_frame_success = prediction.success_probability[:, -1] > 0.5
 ```
 
-`reward` is a tensor of shape `(batch_size,)`.
+Both fields preserve the batch and frame axes on the model device.
 
 ### Use the Reward Factory
 
@@ -127,7 +145,7 @@ reward_model = make_reward_model(cfg)
 preprocessor, postprocessor = make_reward_pre_post_processors(cfg)
 ```
 
-The preprocessor writes Qwen-VL tensors under the `observation.robometer.*` namespace, and `compute_reward()` reads those encoded tensors.
+The preprocessor writes Qwen-VL tensors under the `observation.robometer.*` namespace, and `predict_progress()` reads those encoded tensors.
 
 ## Configuration Notes
 
@@ -153,12 +171,12 @@ In the published checkpoint, progress is discrete. The progress head outputs log
 
 ### Success Prediction
 
-The success head outputs raw logits per frame. LeRobot converts them to probabilities with `sigmoid`. When `reward_output="success"`, `compute_reward()` thresholds the last-frame success probability using `success_threshold`.
+The success head outputs raw logits per frame. LeRobot converts them to probabilities with `sigmoid`; consumers choose any frame and threshold appropriate for their task.
 
 ## Limitations
 
 - The current LeRobot integration is inference-only; it does not implement ROBOMETER training or preference-pair training.
-- `compute_reward()` returns a scalar per sample for the LeRobot reward-model API, even though ROBOMETER predicts per-frame progress and success internally.
+- The preference head is preserved for checkpoint compatibility but does not yet have a public comparison capability.
 - ROBOMETER is video-language based; it does not use privileged robot state such as contact forces or object poses.
 
 ## References

--- a/docs/source/sarm.mdx
+++ b/docs/source/sarm.mdx
@@ -46,18 +46,14 @@ This ensures identical task states map to consistent progress values, even acros
 
 ### Programmatic inference
 
-After running the SARM preprocessor, call the model's typed progress capability. It returns a `SARMPrediction`:
+After preprocessing the inputs, put the model in evaluation mode and call `predict_progress()`:
 
-```python
+````python
 reward_model.eval()
-prediction = reward_model.predict_progress(processed_batch, head_mode="sparse")
-progress = prediction.progress
-stage_probabilities = prediction.stage_probabilities
-stage_confidence = prediction.stage_confidence
-valid_mask = prediction.valid_mask
-```
-
-The three numeric outputs are detached float32 tensors on the model device and preserve the `(batch, time)` axes (`stage_probabilities` adds a final stage axis). They can be passed into a differentiable downstream consumer, but gradients do not flow back through SARM; use the model's training `forward()` method for SARM optimization. `valid_mask` is a boolean `(batch, time)` tensor derived from the processor's sequence lengths; values at false positions are padding artifacts and must not be consumed. As with other trainable PyTorch modules, callers choose training or evaluation mode explicitly; `from_pretrained()` already returns the model in evaluation mode. Consumers explicitly select a valid frame corresponding to their sampling strategy. The older `calculate_rewards()` helper remains available for NumPy-oriented research code.
+prediction = reward_model.predict_progress(
+    processed_batch,
+    head_mode="sparse",
+)
 
 ## Inputs and Targets (What the new code expects)
 
@@ -103,7 +99,7 @@ You can choose from **3 annotation modes** that determine how progress labels ar
 
 ```bash
 pip install -e ".[sarm]"
-```
+````
 
 Workflow:
 

--- a/docs/source/sarm.mdx
+++ b/docs/source/sarm.mdx
@@ -44,6 +44,21 @@ Where:
 
 This ensures identical task states map to consistent progress values, even across demonstrations of different lengths.
 
+### Programmatic inference
+
+After running the SARM preprocessor, call the model's typed progress capability. It returns a `SARMPrediction`:
+
+```python
+reward_model.eval()
+prediction = reward_model.predict_progress(processed_batch, head_mode="sparse")
+progress = prediction.progress
+stage_probabilities = prediction.stage_probabilities
+stage_confidence = prediction.stage_confidence
+valid_mask = prediction.valid_mask
+```
+
+The three numeric outputs are detached float32 tensors on the model device and preserve the `(batch, time)` axes (`stage_probabilities` adds a final stage axis). They can be passed into a differentiable downstream consumer, but gradients do not flow back through SARM; use the model's training `forward()` method for SARM optimization. `valid_mask` is a boolean `(batch, time)` tensor derived from the processor's sequence lengths; values at false positions are padding artifacts and must not be consumed. As with other trainable PyTorch modules, callers choose training or evaluation mode explicitly; `from_pretrained()` already returns the model in evaluation mode. Consumers explicitly select a valid frame corresponding to their sampling strategy. The older `calculate_rewards()` helper remains available for NumPy-oriented research code.
+
 ## Inputs and Targets (What the new code expects)
 
 SARM is trained through its processor (`src/lerobot/rewards/sarm/processor_sarm.py`), which:

--- a/docs/source/sarm.mdx
+++ b/docs/source/sarm.mdx
@@ -48,12 +48,13 @@ This ensures identical task states map to consistent progress values, even acros
 
 After preprocessing the inputs, put the model in evaluation mode and call `predict_progress()`:
 
-````python
+```python
 reward_model.eval()
 prediction = reward_model.predict_progress(
     processed_batch,
     head_mode="sparse",
 )
+```
 
 ## Inputs and Targets (What the new code expects)
 
@@ -99,7 +100,7 @@ You can choose from **3 annotation modes** that determine how progress labels ar
 
 ```bash
 pip install -e ".[sarm]"
-````
+```
 
 Workflow:
 

--- a/docs/source/topreward.mdx
+++ b/docs/source/topreward.mdx
@@ -32,7 +32,7 @@ Because the method only depends on a frozen VLM, TOPReward is **zero-shot**: the
 - Standard `reward_model.type=topreward` configuration through LeRobot.
 - VLM loading via the `transformers` `Qwen3VLForConditionalGeneration` API.
 - Prompt assembly + tokenisation in the processor (matching upstream `QwenClient.compute_instruction_reward`).
-- `compute_reward()` returns one scalar log-prob per sample.
+- `compute_log_probability()` returns one raw scalar log-probability per sample.
 - LeRobot reward-model save/load — `save_pretrained` writes only `config.json` (the VLM is identified by `vlm_name`).
 - An offline labeling script that writes a `topreward_progress.parquet` (SARM-compatible schema) for RA-BC and overlay.
 
@@ -72,9 +72,7 @@ In LeRobot datasets the preprocessor reads:
 | `reward_model.fps`        | `2.0`                       | Metadata passed to the Qwen video processor   |
 | `reward_model.vlm_name`   | `Qwen/Qwen3-VL-8B-Instruct` | Hugging Face Hub id of the underlying VLM     |
 
-The model returns:
-
-- `compute_reward(batch)`: one log-probability per sample. Higher = better task-video alignment. When `success_threshold` is finite, returns the binary thresholded value instead.
+The model returns one float32 tensor of shape `(batch_size,)` through `compute_log_probability(batch)`. Higher values mean better task-video alignment. The method always returns the raw log-probability; thresholding and normalization belong to the consumer.
 
 ## Usage
 
@@ -105,11 +103,20 @@ reward_model = make_reward_model(cfg)
 preprocessor, postprocessor = make_reward_pre_post_processors(cfg)
 ```
 
-The preprocessor tokenises the full prompt (video + prefix + instruction suffix), writes Qwen-VL tensors + `prompt_length` under `observation.topreward.*`. The model reads those tensors, label-masks based on `prompt_length`, and extracts the log-prob reward.
+The preprocessor tokenises the full prompt (video + prefix + instruction suffix), writes Qwen-VL tensors and terminal-token labels under `observation.topreward.*`, and masks every label except the terminal answer token. The model reads those tensors and extracts its log-probability:
+
+```python
+encoded_batch = preprocessor(batch)
+log_probability = reward_model.compute_log_probability(encoded_batch)
+```
+
+The serialized `success_threshold` field remains for compatibility with existing configs, but it does not modify the raw output. Apply any task-specific threshold explicitly in the caller.
 
 ### Offline dataset labeling
 
 Write a `topreward_progress.parquet` for RA-BC training and overlay videos:
+
+The legacy labeling script preserves existing artifact behavior: if a loaded config has a finite `success_threshold`, it applies that threshold before per-episode normalization. New Python consumers always receive the raw value from `compute_log_probability()`.
 
 ```bash
 # Sparse-dense (15 anchors per episode, matches upstream)

--- a/examples/dataset/slurm_compute_rabc.py
+++ b/examples/dataset/slurm_compute_rabc.py
@@ -145,25 +145,27 @@ class ComputeProgressShards(PipelineStep):
 
                         sparse_val = dense_val = np.nan
                         if compute_sparse:
-                            r = reward_model.calculate_rewards(
-                                text_embeddings=tf,
-                                video_embeddings=vf,
-                                state_features=sf,
-                                lengths=lengths,
-                                return_all_frames=True,
+                            prediction = reward_model.predict_progress(
+                                {
+                                    "text_features": tf,
+                                    "video_features": vf,
+                                    "state_features": sf,
+                                    "lengths": lengths,
+                                },
                                 head_mode="sparse",
                             )
-                            sparse_val = float(r[0, center_idx] if r.ndim == 2 else r[center_idx])
+                            sparse_val = prediction.progress[0, center_idx].cpu().item()
                         if compute_dense:
-                            r = reward_model.calculate_rewards(
-                                text_embeddings=tf,
-                                video_embeddings=vf,
-                                state_features=sf,
-                                lengths=lengths,
-                                return_all_frames=True,
+                            prediction = reward_model.predict_progress(
+                                {
+                                    "text_features": tf,
+                                    "video_features": vf,
+                                    "state_features": sf,
+                                    "lengths": lengths,
+                                },
                                 head_mode="dense",
                             )
-                            dense_val = float(r[0, center_idx] if r.ndim == 2 else r[center_idx])
+                            dense_val = prediction.progress[0, center_idx].cpu().item()
 
                         frame_results[qi] = (sparse_val, dense_val)
                 except Exception as e:

--- a/src/lerobot/rewards/__init__.py
+++ b/src/lerobot/rewards/__init__.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from .capabilities import ProgressPrediction as ProgressPrediction, ProgressPredictor as ProgressPredictor
 from .classifier.configuration_classifier import RewardClassifierConfig as RewardClassifierConfig
 from .factory import (
     get_reward_model_class as get_reward_model_class,
@@ -32,6 +33,9 @@ __all__ = [
     "TOPRewardConfig",
     # Base class
     "PreTrainedRewardModel",
+    # Inference capabilities
+    "ProgressPrediction",
+    "ProgressPredictor",
     # Factory functions
     "get_reward_model_class",
     "make_reward_model",

--- a/src/lerobot/rewards/capabilities.py
+++ b/src/lerobot/rewards/capabilities.py
@@ -15,8 +15,9 @@
 """Consumer-facing reward-model capability types.
 
 Reward models expose semantic methods instead of implementing one universal
-scalar-reward method. Protocols in this module are typing seams for consumers;
-they do not participate in model registration or runtime dispatch.
+scalar-reward method. These protocols describe the methods that consumers may
+rely on for static type checking. They do not register, construct,
+or select reward-model implementations at runtime.
 """
 
 from collections.abc import Mapping
@@ -28,7 +29,7 @@ from torch import Tensor
 
 @dataclass(frozen=True)
 class ProgressPrediction:
-    """Per-frame progress values with shape ``(batch, time)``."""
+    """Per-frame progress values with shape `(batch, time)`."""
 
     progress: Tensor
 
@@ -36,4 +37,7 @@ class ProgressPrediction:
 class ProgressPredictor(Protocol):
     """A model that predicts frame-aligned progress from encoded inputs."""
 
-    def predict_progress(self, batch: Mapping[str, Any]) -> ProgressPrediction: ...
+    def predict_progress(
+        self,
+        batch: Mapping[str, Any],
+    ) -> ProgressPrediction: ...

--- a/src/lerobot/rewards/capabilities.py
+++ b/src/lerobot/rewards/capabilities.py
@@ -1,0 +1,39 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Consumer-facing reward-model capability types.
+
+Reward models expose semantic methods instead of implementing one universal
+scalar-reward method. Protocols in this module are typing seams for consumers;
+they do not participate in model registration or runtime dispatch.
+"""
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from torch import Tensor
+
+
+@dataclass(frozen=True)
+class ProgressPrediction:
+    """Per-frame progress values with shape ``(batch, time)``."""
+
+    progress: Tensor
+
+
+class ProgressPredictor(Protocol):
+    """A model that predicts frame-aligned progress from encoded inputs."""
+
+    def predict_progress(self, batch: Mapping[str, Any]) -> ProgressPrediction: ...

--- a/src/lerobot/rewards/classifier/modeling_classifier.py
+++ b/src/lerobot/rewards/classifier/modeling_classifier.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import logging
-from collections.abc import Mapping
 
 import torch
 from torch import Tensor, nn
@@ -267,8 +266,8 @@ class Classifier(PreTrainedRewardModel):
 
         return loss, output_dict
 
-    def predict_reward(self, batch: Mapping[str, Tensor], threshold: float = 0.5) -> Tensor:
-        """Return thresholded success or the most likely reward class."""
+    def predict_reward(self, batch, threshold=0.5):
+        """Eval method. Returns predicted reward with the decision threshold as argument."""
         # Extract images from batch dict
         images = [batch[key] for key in self.config.input_features if key.startswith(OBS_IMAGE)]
 

--- a/src/lerobot/rewards/classifier/modeling_classifier.py
+++ b/src/lerobot/rewards/classifier/modeling_classifier.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+from collections.abc import Mapping
 
 import torch
 from torch import Tensor, nn
@@ -234,16 +235,6 @@ class Classifier(PreTrainedRewardModel):
 
         return ClassifierOutput(logits=logits, probabilities=probabilities, hidden_states=encoder_outputs)
 
-    def compute_reward(self, batch: dict[str, Tensor]) -> Tensor:
-        """Returns 1.0 for success, 0.0 for failure based on image observations."""
-        images = [batch[key] for key in self.config.input_features if key.startswith(OBS_IMAGE)]
-        output = self.predict(images)
-
-        if self.config.num_classes == 2:
-            return (output.probabilities > 0.5).float()
-        else:
-            return torch.argmax(output.probabilities, dim=1).float()
-
     def forward(self, batch: dict[str, Tensor]) -> tuple[Tensor, dict[str, Tensor]]:
         """Standard forward pass for training compatible with train.py."""
         # Extract images and labels
@@ -276,8 +267,8 @@ class Classifier(PreTrainedRewardModel):
 
         return loss, output_dict
 
-    def predict_reward(self, batch, threshold=0.5):
-        """Eval method. Returns predicted reward with the decision threshold as argument."""
+    def predict_reward(self, batch: Mapping[str, Tensor], threshold: float = 0.5) -> Tensor:
+        """Return thresholded success or the most likely reward class."""
         # Extract images from batch dict
         images = [batch[key] for key in self.config.input_features if key.startswith(OBS_IMAGE)]
 

--- a/src/lerobot/rewards/factory.py
+++ b/src/lerobot/rewards/factory.py
@@ -130,7 +130,8 @@ def make_reward_model(cfg: RewardModelConfig, **kwargs) -> PreTrainedRewardModel
         reward_model = reward_cls(**kwargs)
 
     reward_model.to(cfg.device)
-    assert isinstance(reward_model, torch.nn.Module)
+    if not isinstance(reward_model, torch.nn.Module):
+        raise TypeError(f"Expected a torch.nn.Module, got {type(reward_model).__name__}")
 
     return reward_model
 

--- a/src/lerobot/rewards/pretrained.py
+++ b/src/lerobot/rewards/pretrained.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import abc
 import builtins
 import logging
 import os
@@ -36,8 +35,13 @@ if TYPE_CHECKING:
 T = TypeVar("T", bound="PreTrainedRewardModel")
 
 
-class PreTrainedRewardModel(nn.Module, HubMixin, abc.ABC):
-    """Base class for reward models."""
+class PreTrainedRewardModel(nn.Module, HubMixin):
+    """Base class for reward-model configuration, serialization, and training.
+
+    Reward models intentionally expose model-specific inference capabilities
+    such as ``predict_progress`` or ``compute_log_probability``. There is no
+    universal scalar inference method on this base class.
+    """
 
     config_class: None
     name: None
@@ -162,23 +166,11 @@ class PreTrainedRewardModel(nn.Module, HubMixin, abc.ABC):
         """Reset any internal state."""
         pass
 
-    @abc.abstractmethod
-    def compute_reward(self, batch: dict[str, Tensor]) -> Tensor:
-        """Compute a scalar reward signal for a batch of observations.
-
-        Args:
-            batch: Dictionary containing at minimum observation tensors.
-                   May also contain "action", "next_observation.*", etc.
-
-        Returns:
-            Tensor of shape ``(batch_size,)`` with reward values.
-        """
-        ...
-
     def forward(self, batch: dict[str, Tensor]) -> tuple[Tensor, dict[str, Any]]:
         """Training forward pass — override for trainable reward models."""
         raise NotImplementedError(
-            f"{self.__class__.__name__} is not trainable. Only use compute_reward() for inference."
+            f"{self.__class__.__name__} is not trainable. "
+            "Use the model's documented inference capabilities instead."
         )
 
     @property

--- a/src/lerobot/rewards/robometer/__init__.py
+++ b/src/lerobot/rewards/robometer/__init__.py
@@ -13,7 +13,12 @@
 # limitations under the License.
 
 from .configuration_robometer import RobometerConfig
-from .modeling_robometer import RobometerRewardModel
+from .modeling_robometer import RobometerPrediction, RobometerRewardModel
 from .processor_robometer import make_robometer_pre_post_processors
 
-__all__ = ["RobometerConfig", "RobometerRewardModel", "make_robometer_pre_post_processors"]
+__all__ = [
+    "RobometerConfig",
+    "RobometerPrediction",
+    "RobometerRewardModel",
+    "make_robometer_pre_post_processors",
+]

--- a/src/lerobot/rewards/robometer/compute_rabc_weights.py
+++ b/src/lerobot/rewards/robometer/compute_rabc_weights.py
@@ -48,19 +48,34 @@ from __future__ import annotations
 import argparse
 import logging
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
-import pyarrow as pa
-import pyarrow.parquet as pq
 import torch
 from tqdm import tqdm
 
-from lerobot.datasets import LeRobotDataset
 from lerobot.lerobot_types import TransitionKey
 from lerobot.rewards.robometer.configuration_robometer import RobometerConfig
 from lerobot.rewards.robometer.modeling_robometer import RobometerPrediction, RobometerRewardModel
 from lerobot.rewards.robometer.processor_robometer import RobometerEncoderProcessorStep
+from lerobot.utils.import_utils import (
+    _av_available,
+    _datasets_available,
+    _pyarrow_available,
+    require_package,
+)
+
+if TYPE_CHECKING or _pyarrow_available:
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+else:
+    pa = None  # type: ignore[assignment]
+    pq = None  # type: ignore[assignment]
+
+if TYPE_CHECKING or (_datasets_available and _av_available):
+    from lerobot.datasets import LeRobotDataset
+else:
+    LeRobotDataset = None  # type: ignore[assignment, misc]
 
 DEFAULT_OUTPUT_FILENAME = "robometer_progress.parquet"
 
@@ -68,10 +83,19 @@ DEFAULT_OUTPUT_FILENAME = "robometer_progress.parquet"
 DEFAULT_NUM_SUBSAMPLED_FRAMES = 4
 
 
+def _require_dataset_dependencies() -> None:
+    """Require packages used only by dataset scoring and parquet IO."""
+    require_package("datasets", extra="dataset")
+    require_package("av", extra="dataset")
+    require_package("pyarrow", extra="dataset")
+
+
 def get_reward_model_path_from_parquet(parquet_path: Path) -> str | None:
     """Read ``reward_model_path`` from parquet metadata if available."""
     if not parquet_path.exists():
         return None
+    require_package("pyarrow", extra="dataset")
+    assert pq is not None
     try:
         metadata = pq.read_metadata(parquet_path).schema.to_arrow_schema().metadata
         if metadata and b"reward_model_path" in metadata:
@@ -137,6 +161,8 @@ def compute_robometer_progress(
     """Run Robometer over a dataset and write per-frame progress."""
     if num_subsampled_frames < 1:
         raise ValueError(f"num_subsampled_frames must be >= 1, got {num_subsampled_frames}")
+    _require_dataset_dependencies()
+    assert pa is not None and pq is not None and LeRobotDataset is not None
 
     logging.info(f"Loading Robometer: {reward_model_path}")
     config = RobometerConfig(pretrained_path=reward_model_path, device=device)
@@ -279,6 +305,8 @@ Examples:
     args = parser.parse_args()
 
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    _require_dataset_dependencies()
+    assert LeRobotDataset is not None
 
     reward_model_path = args.reward_model_path
     if reward_model_path is None:

--- a/src/lerobot/rewards/robometer/compute_rabc_weights.py
+++ b/src/lerobot/rewards/robometer/compute_rabc_weights.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Compute per-frame Robometer progress and success curves for a LeRobot dataset.
+"""Compute per-frame Robometer progress for a LeRobot dataset.
 
 For each episode, builds per-frame sub-samples using the frame-steps
 strategy from the Robometer eval server: for each original frame ``t``,
@@ -59,7 +59,7 @@ from tqdm import tqdm
 from lerobot.datasets import LeRobotDataset
 from lerobot.lerobot_types import TransitionKey
 from lerobot.rewards.robometer.configuration_robometer import RobometerConfig
-from lerobot.rewards.robometer.modeling_robometer import RobometerRewardModel
+from lerobot.rewards.robometer.modeling_robometer import RobometerPrediction, RobometerRewardModel
 from lerobot.rewards.robometer.processor_robometer import RobometerEncoderProcessorStep
 
 DEFAULT_OUTPUT_FILENAME = "robometer_progress.parquet"
@@ -93,11 +93,35 @@ def _build_subsample_indices(num_frames: int, num_subsampled_frames: int) -> lis
     """Frame-steps linspace expansion.
 
     For each ``t in [0, num_frames - 1]`` returns ``num_subsampled_frames``
-    indices from ``np.linspace(0, t, num_subsampled_frames)`` — the first
-    and last frames are always included. Each entry is a fixed-size array
-    so the model can batch them.
+    indices from ``np.linspace(0, t, num_subsampled_frames)``. With at least
+    two sampled frames, the first and current frames are included. The
+    existing one-frame behavior retains only the first frame. Each entry is
+    fixed-size so the model can batch them.
     """
     return [np.linspace(0, t, num_subsampled_frames).round().astype(np.int64) for t in range(num_frames)]
+
+
+def _make_robometer_scoring_encoder(config: RobometerConfig) -> RobometerEncoderProcessorStep:
+    """Build the encoder for frame-steps samples selected by this script."""
+    return RobometerEncoderProcessorStep(
+        base_model_id=config.base_model_id,
+        image_key=config.image_key,
+        task_key=config.task_key,
+        default_task=config.default_task,
+        max_frames=None,
+        use_multi_image=config.use_multi_image,
+        use_per_frame_progress_token=config.use_per_frame_progress_token,
+    )
+
+
+def _select_last_frame_progress(prediction: RobometerPrediction) -> torch.Tensor:
+    """Apply the legacy script's explicit last-frame selection."""
+    if prediction.progress.ndim != 2 or prediction.progress.shape[1] == 0:
+        raise ValueError(
+            "Robometer progress must have shape (batch, time) with at least one frame, "
+            f"got {tuple(prediction.progress.shape)}"
+        )
+    return prediction.progress[:, -1]
 
 
 def compute_robometer_progress(
@@ -110,7 +134,10 @@ def compute_robometer_progress(
     episodes: list[int] | None = None,
     image_key: str | None = None,
 ) -> Path:
-    """Run Robometer over a dataset and write per-frame progress + success."""
+    """Run Robometer over a dataset and write per-frame progress."""
+    if num_subsampled_frames < 1:
+        raise ValueError(f"num_subsampled_frames must be >= 1, got {num_subsampled_frames}")
+
     logging.info(f"Loading Robometer: {reward_model_path}")
     config = RobometerConfig(pretrained_path=reward_model_path, device=device)
     if image_key is not None:
@@ -118,15 +145,7 @@ def compute_robometer_progress(
     model = RobometerRewardModel.from_pretrained(reward_model_path, config=config)
     model.to(device).eval()
 
-    encoder = RobometerEncoderProcessorStep(
-        base_model_id=config.base_model_id,
-        image_key=config.image_key,
-        task_key=config.task_key,
-        default_task=config.default_task,
-        max_frames=num_subsampled_frames,
-        use_multi_image=config.use_multi_image,
-        use_per_frame_progress_token=config.use_per_frame_progress_token,
-    )
+    encoder = _make_robometer_scoring_encoder(config)
 
     image_key = config.image_key
 
@@ -174,9 +193,8 @@ def compute_robometer_progress(
                 for key, value in obs.items()
             }
 
-            with torch.no_grad():
-                rewards = model.compute_reward(batch)
-            progress_per_frame[start:end] = rewards.cpu().numpy()
+            prediction = model.predict_progress(batch)
+            progress_per_frame[start:end] = _select_last_frame_progress(prediction).cpu().numpy()
 
         for local in range(num_frames):
             all_index.append(ep_start + local)

--- a/src/lerobot/rewards/robometer/compute_rabc_weights.py
+++ b/src/lerobot/rewards/robometer/compute_rabc_weights.py
@@ -96,7 +96,8 @@ def get_reward_model_path_from_parquet(parquet_path: Path) -> str | None:
     if not parquet_path.exists():
         return None
     require_package("pyarrow", extra="dataset")
-    assert pq is not None
+    if pq is None:
+        raise ImportError("pyarrow.parquet is required to read reward-model metadata")
     try:
         metadata = pq.read_metadata(parquet_path).schema.to_arrow_schema().metadata
         if metadata and b"reward_model_path" in metadata:
@@ -163,7 +164,8 @@ def compute_robometer_progress(
     if num_subsampled_frames < 1:
         raise ValueError(f"num_subsampled_frames must be >= 1, got {num_subsampled_frames}")
     _require_dataset_dependencies()
-    assert pa is not None and pq is not None and LeRobotDataset is not None
+    if pa is None or pq is None or LeRobotDataset is None:
+        raise ImportError("Robometer dataset scoring requires pyarrow and LeRobotDataset")
 
     logging.info(f"Loading Robometer: {reward_model_path}")
     config = RobometerConfig(pretrained_path=reward_model_path, device=device)
@@ -307,7 +309,8 @@ Examples:
 
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
     _require_dataset_dependencies()
-    assert LeRobotDataset is not None
+    if LeRobotDataset is None:
+        raise ImportError("Robometer dataset scoring requires LeRobotDataset")
 
     reward_model_path = args.reward_model_path
     if reward_model_path is None:

--- a/src/lerobot/rewards/robometer/compute_rabc_weights.py
+++ b/src/lerobot/rewards/robometer/compute_rabc_weights.py
@@ -85,9 +85,10 @@ DEFAULT_NUM_SUBSAMPLED_FRAMES = 4
 
 def _require_dataset_dependencies() -> None:
     """Require packages used only by dataset scoring and parquet IO."""
-    require_package("datasets", extra="dataset")
-    require_package("av", extra="dataset")
     require_package("pyarrow", extra="dataset")
+    if LeRobotDataset is None:
+        require_package("datasets", extra="dataset")
+        require_package("av", extra="dataset")
 
 
 def get_reward_model_path_from_parquet(parquet_path: Path) -> str | None:

--- a/src/lerobot/rewards/robometer/configuration_robometer.py
+++ b/src/lerobot/rewards/robometer/configuration_robometer.py
@@ -56,7 +56,9 @@ class RobometerConfig(RewardModelConfig):
     default_task: str | None = None
 
     max_frames: int | None = 8
-    reward_output: str = "progress"  # "progress" or "success"
+    # Retained so existing checkpoints keep loading. ``predict_progress``
+    # returns both signals; consumers choose frames and apply thresholds.
+    reward_output: str = "progress"
     success_threshold: float = 0.5
 
     license: str | None = "apache-2.0"

--- a/src/lerobot/rewards/robometer/modeling_robometer.py
+++ b/src/lerobot/rewards/robometer/modeling_robometer.py
@@ -43,19 +43,22 @@ is recovered as the softmax-weighted mean of those centers — see
 
 This LeRobot port is **inference-only**: the preference head is preserved in
 the state dict for byte-equivalence with the published ``Robometer-4B``
-checkpoint but is not queried by :meth:`RobometerRewardModel.compute_reward`,
-which returns the last-frame progress (clamped to ``[0, 1]``) or sigmoid'd
-success probability depending on :attr:`RobometerConfig.reward_output`.
+checkpoint but is not queried by :meth:`RobometerRewardModel.predict_progress`.
+That method returns frame-level progress and success probability without
+choosing a frame or thresholding either signal.
 """
 
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import torch
 from torch import Tensor, nn
 
+from lerobot.rewards.capabilities import ProgressPrediction
 from lerobot.rewards.pretrained import PreTrainedRewardModel
 from lerobot.rewards.robometer.configuration_robometer import RobometerConfig
 from lerobot.utils.constants import OBS_PREFIX
@@ -130,40 +133,11 @@ class RobometerPredictionHead(nn.Sequential):
         super().__init__(*layers)
 
 
-def decode_progress_outputs(
-    progress_logits: Tensor | None,
-    success_logits: Tensor | None,
-    *,
-    is_discrete_mode: bool,
-) -> dict[str, list[list[float]]]:
-    """Decode RBM head outputs into per-frame floats.
+@dataclass(frozen=True)
+class RobometerPrediction(ProgressPrediction):
+    """RoboMeter frame signals, each float32 with shape ``(batch, time)``."""
 
-    Args:
-        progress_logits: ``(B, T)`` (continuous) or ``(B, T, num_bins)`` (discrete).
-        success_logits: ``(B, T)`` raw logits, ``sigmoid``-ed to probabilities.
-        is_discrete_mode: if True the progress logits get a softmax over bins
-            and are projected onto bin centers via :func:`convert_bins_to_continuous`.
-
-    Returns:
-        Dict with ``progress_pred`` and ``success_probs``, each a list of
-        length ``B`` of per-frame float lists.
-    """
-    progress_pred: list[list[float]] = []
-    success_probs: list[list[float]] = []
-
-    if progress_logits is not None:
-        for sample_logits in progress_logits:
-            if is_discrete_mode:
-                continuous = convert_bins_to_continuous(sample_logits.detach().float().cpu())
-                progress_pred.append(continuous.flatten().tolist())
-            else:
-                progress_pred.append(sample_logits.detach().float().cpu().flatten().tolist())
-
-    if success_logits is not None:
-        for sample_logits in success_logits:
-            success_probs.append(torch.sigmoid(sample_logits.detach().float().cpu()).flatten().tolist())
-
-    return {"progress_pred": progress_pred, "success_probs": success_probs}
+    success_probability: Tensor
 
 
 class RobometerRewardModel(PreTrainedRewardModel):
@@ -246,7 +220,13 @@ class RobometerRewardModel(PreTrainedRewardModel):
         self.success_head.to(dtype=model_dtype)
         self.frame_pool_attn.to(dtype=model_dtype)
 
-    def compute_reward(self, batch: dict[str, Tensor]) -> Tensor:
+    def predict_progress(self, batch: Mapping[str, Any]) -> RobometerPrediction:
+        """Predict frame-level progress and success probability.
+
+        The processor-prepared input mapping is not mutated. Frame selection,
+        thresholding, and conversion into a downstream reward belong to the
+        caller.
+        """
         inputs = {
             key: batch[f"{ROBOMETER_FEATURE_PREFIX}{key}"]
             for key in ROBOMETER_INPUT_KEYS
@@ -256,33 +236,25 @@ class RobometerRewardModel(PreTrainedRewardModel):
             raise KeyError(
                 f"Robometer batch missing pre-encoded inputs (expected "
                 f"`{ROBOMETER_FEATURE_PREFIX}input_ids`). Make sure the "
-                "RobometerEncoderProcessorStep ran before `compute_reward`."
+                "RobometerEncoderProcessorStep ran before `predict_progress`."
             )
 
         device = next(self.model.parameters()).device
         inputs = {key: value.to(device) if hasattr(value, "to") else value for key, value in inputs.items()}
 
         self.eval()
-        with torch.no_grad():
+        with torch.inference_mode():
             progress_logits, success_logits = self._compute_rbm_logits(inputs)
 
-        decoded = decode_progress_outputs(
-            progress_logits,
-            success_logits,
-            is_discrete_mode=self.config.use_discrete_progress,
+        progress = (
+            convert_bins_to_continuous(progress_logits.float())
+            if self.config.use_discrete_progress
+            else progress_logits.float()
         )
-        values = (
-            decoded["success_probs"] if self.config.reward_output == "success" else decoded["progress_pred"]
+        return RobometerPrediction(
+            progress=progress.clamp(0.0, 1.0),
+            success_probability=torch.sigmoid(success_logits.float()),
         )
-
-        rewards = torch.stack([torch.as_tensor(seq, dtype=torch.float32)[-1] for seq in values])
-        if self.config.reward_output == "success":
-            rewards = (rewards > self.config.success_threshold).float()
-        else:
-            # Match upstream Robometer's ``extract_rewards_from_output``: per-frame
-            # progress predictions are clamped to ``[0, 1]`` before being returned.
-            rewards = rewards.clamp(0.0, 1.0)
-        return rewards.to(self.config.device or "cpu")
 
     def _compute_rbm_logits(
         self,

--- a/src/lerobot/rewards/robometer/modeling_robometer.py
+++ b/src/lerobot/rewards/robometer/modeling_robometer.py
@@ -243,17 +243,22 @@ class RobometerRewardModel(PreTrainedRewardModel):
         inputs = {key: value.to(device) if hasattr(value, "to") else value for key, value in inputs.items()}
 
         self.eval()
-        with torch.inference_mode():
+        with torch.no_grad():
             progress_logits, success_logits = self._compute_rbm_logits(inputs)
 
-        progress = (
+        progress_pred = (
             convert_bins_to_continuous(progress_logits.float())
             if self.config.use_discrete_progress
             else progress_logits.float()
         )
+        # Match upstream Robometer's ``extract_rewards_from_output``: per-frame
+        # progress predictions are clamped to ``[0, 1]`` before being returned.
+        progress_pred = progress_pred.clamp(0.0, 1.0)
+        success_probs = torch.sigmoid(success_logits.float())
+
         return RobometerPrediction(
-            progress=progress.clamp(0.0, 1.0),
-            success_probability=torch.sigmoid(success_logits.float()),
+            progress=progress_pred,
+            success_probability=success_probs,
         )
 
     def _compute_rbm_logits(

--- a/src/lerobot/rewards/robometer/processor_robometer.py
+++ b/src/lerobot/rewards/robometer/processor_robometer.py
@@ -310,8 +310,8 @@ def make_robometer_pre_post_processors(
 
     The preprocessor adds a batch dimension if needed, runs Robometer's
     encoder, and moves everything to the configured device. The
-    postprocessor is the identity since Robometer outputs a single reward
-    tensor.
+    postprocessor is the identity because ``predict_progress`` returns its
+    typed tensor result directly.
     """
     del dataset_stats  # Robometer has its own normalisation inside the Qwen-VL processor.
 

--- a/src/lerobot/rewards/sarm/__init__.py
+++ b/src/lerobot/rewards/sarm/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from .configuration_sarm import SARMConfig
-from .modeling_sarm import SARMRewardModel
+from .modeling_sarm import SARMPrediction, SARMRewardModel
 from .processor_sarm import make_sarm_pre_post_processors
 
-__all__ = ["SARMConfig", "SARMRewardModel", "make_sarm_pre_post_processors"]
+__all__ = ["SARMConfig", "SARMPrediction", "SARMRewardModel", "make_sarm_pre_post_processors"]

--- a/src/lerobot/rewards/sarm/compute_rabc_weights.py
+++ b/src/lerobot/rewards/sarm/compute_rabc_weights.py
@@ -346,27 +346,17 @@ def visualize_sarm_predictions(
                         )
 
                     # Predictions
-                    reward, stage_probs = reward_model.calculate_rewards(
-                        text_embeddings=text_features,
-                        video_embeddings=video_features,
-                        state_features=state_features,
-                        lengths=lengths,
-                        return_all_frames=True,
-                        return_stages=True,
+                    prediction = reward_model.predict_progress(
+                        {
+                            "text_features": text_features,
+                            "video_features": video_features,
+                            "state_features": state_features,
+                            "lengths": lengths,
+                        },
                         head_mode=scheme,
                     )
-
-                    # Handle both tensor and numpy outputs
-                    if isinstance(reward, torch.Tensor):
-                        reward = reward.cpu().numpy()
-                        stage_probs = stage_probs.cpu().numpy()
-
-                    if reward.ndim == 2:
-                        sd["viz_progress"][local_idx] = reward[0, target_idx]
-                        sd["viz_stages"][local_idx] = stage_probs[0, target_idx, :]
-                    else:
-                        sd["viz_progress"][local_idx] = reward[target_idx]
-                        sd["viz_stages"][local_idx] = stage_probs[target_idx, :]
+                    sd["viz_progress"][local_idx] = prediction.progress[0, target_idx].cpu().item()
+                    sd["viz_stages"][local_idx] = prediction.stage_probabilities[0, target_idx].cpu().numpy()
 
                 # Clear GPU memory after each frame
                 del processed, video_features, text_features
@@ -569,35 +559,29 @@ def compute_sarm_progress(
 
                     # Compute sparse prediction for center frame
                     if compute_sparse:
-                        sparse_progress = reward_model.calculate_rewards(
-                            text_embeddings=text_features,
-                            video_embeddings=video_features,
-                            state_features=state_features,
-                            lengths=lengths,
-                            return_all_frames=True,
+                        sparse_prediction = reward_model.predict_progress(
+                            {
+                                "text_features": text_features,
+                                "video_features": video_features,
+                                "state_features": state_features,
+                                "lengths": lengths,
+                            },
                             head_mode="sparse",
                         )
-                        sparse_val = float(
-                            sparse_progress[0, center_idx]
-                            if sparse_progress.ndim == 2
-                            else sparse_progress[center_idx]
-                        )
+                        sparse_val = sparse_prediction.progress[0, center_idx].cpu().item()
 
                     # Compute dense prediction for center frame
                     if compute_dense:
-                        dense_progress = reward_model.calculate_rewards(
-                            text_embeddings=text_features,
-                            video_embeddings=video_features,
-                            state_features=state_features,
-                            lengths=lengths,
-                            return_all_frames=True,
+                        dense_prediction = reward_model.predict_progress(
+                            {
+                                "text_features": text_features,
+                                "video_features": video_features,
+                                "state_features": state_features,
+                                "lengths": lengths,
+                            },
                             head_mode="dense",
                         )
-                        dense_val = float(
-                            dense_progress[0, center_idx]
-                            if dense_progress.ndim == 2
-                            else dense_progress[center_idx]
-                        )
+                        dense_val = dense_prediction.progress[0, center_idx].cpu().item()
 
                     frame_results[query_idx] = (sparse_val, dense_val)
 

--- a/src/lerobot/rewards/sarm/compute_rabc_weights.py
+++ b/src/lerobot/rewards/sarm/compute_rabc_weights.py
@@ -45,29 +45,55 @@ Usage:
 The output is saved to the dataset's local cache directory as 'sarm_progress.parquet'.
 """
 
+from __future__ import annotations
+
 import argparse
 import logging
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import matplotlib.gridspec as gridspec
 import matplotlib.pyplot as plt
 import numpy as np
-import pyarrow as pa
-import pyarrow.parquet as pq
 import torch
 from tqdm import tqdm
 
-from lerobot.datasets import LeRobotDataset
+from lerobot.utils.import_utils import (
+    _av_available,
+    _datasets_available,
+    _pyarrow_available,
+    require_package,
+)
+
+if TYPE_CHECKING or _pyarrow_available:
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+else:
+    pa = None  # type: ignore[assignment]
+    pq = None  # type: ignore[assignment]
+
+if TYPE_CHECKING or (_datasets_available and _av_available):
+    from lerobot.datasets import LeRobotDataset
+else:
+    LeRobotDataset = None  # type: ignore[assignment, misc]
 
 from .modeling_sarm import SARMRewardModel
 from .processor_sarm import make_sarm_pre_post_processors
 from .sarm_utils import normalize_stage_tau
 
 
+def _require_dataset_dependencies() -> None:
+    """Require packages used only when loading a LeRobot dataset."""
+    require_package("datasets", extra="dataset")
+    require_package("av", extra="dataset")
+
+
 def get_reward_model_path_from_parquet(parquet_path: Path) -> str | None:
     """Read reward_model_path from parquet metadata if available."""
     if not parquet_path.exists():
         return None
+    require_package("pyarrow", extra="dataset")
+    assert pq is not None
     try:
         metadata = pq.read_metadata(parquet_path).schema.to_arrow_schema().metadata
         if metadata and b"reward_model_path" in metadata:
@@ -88,6 +114,9 @@ def load_sarm_resources(
     Returns:
         Tuple of (dataset, reward_model, preprocessor)
     """
+    _require_dataset_dependencies()
+    assert LeRobotDataset is not None
+
     logging.info(f"Loading model: {reward_model_path}")
     reward_model = SARMRewardModel.from_pretrained(reward_model_path)
     reward_model.config.device = device
@@ -474,6 +503,9 @@ def compute_sarm_progress(
         output_dir: Directory to save visualizations
         stride: Compute progress every N frames, interpolate the rest (default: 1 = every frame)
     """
+    require_package("pyarrow", extra="dataset")
+    assert pa is not None and pq is not None
+
     dataset, reward_model, preprocess = load_sarm_resources(dataset_repo_id, reward_model_path, device)
 
     # Set preprocessor to eval mode to disable augmentations
@@ -779,6 +811,8 @@ Examples:
     reward_model_path = args.reward_model_path
     if reward_model_path is None:
         # Load dataset to find parquet path
+        _require_dataset_dependencies()
+        assert LeRobotDataset is not None
         temp_dataset = LeRobotDataset(args.dataset_repo_id, download_videos=False)
         parquet_path = Path(temp_dataset.root) / "sarm_progress.parquet"
         reward_model_path = get_reward_model_path_from_parquet(parquet_path)

--- a/src/lerobot/rewards/sarm/compute_rabc_weights.py
+++ b/src/lerobot/rewards/sarm/compute_rabc_weights.py
@@ -93,7 +93,8 @@ def get_reward_model_path_from_parquet(parquet_path: Path) -> str | None:
     if not parquet_path.exists():
         return None
     require_package("pyarrow", extra="dataset")
-    assert pq is not None
+    if pq is None:
+        raise ImportError("pyarrow.parquet is required to read reward-model metadata")
     try:
         metadata = pq.read_metadata(parquet_path).schema.to_arrow_schema().metadata
         if metadata and b"reward_model_path" in metadata:
@@ -115,7 +116,8 @@ def load_sarm_resources(
         Tuple of (dataset, reward_model, preprocessor)
     """
     _require_dataset_dependencies()
-    assert LeRobotDataset is not None
+    if LeRobotDataset is None:
+        raise ImportError("SARM dataset scoring requires LeRobotDataset")
 
     logging.info(f"Loading model: {reward_model_path}")
     reward_model = SARMRewardModel.from_pretrained(reward_model_path)
@@ -504,7 +506,8 @@ def compute_sarm_progress(
         stride: Compute progress every N frames, interpolate the rest (default: 1 = every frame)
     """
     require_package("pyarrow", extra="dataset")
-    assert pa is not None and pq is not None
+    if pa is None or pq is None:
+        raise ImportError("SARM dataset scoring requires pyarrow")
 
     dataset, reward_model, preprocess = load_sarm_resources(dataset_repo_id, reward_model_path, device)
 
@@ -812,7 +815,8 @@ Examples:
     if reward_model_path is None:
         # Load dataset to find parquet path
         _require_dataset_dependencies()
-        assert LeRobotDataset is not None
+        if LeRobotDataset is None:
+            raise ImportError("SARM dataset scoring requires LeRobotDataset")
         temp_dataset = LeRobotDataset(args.dataset_repo_id, download_videos=False)
         parquet_path = Path(temp_dataset.root) / "sarm_progress.parquet"
         reward_model_path = get_reward_model_path_from_parquet(parquet_path)

--- a/src/lerobot/rewards/sarm/compute_rabc_weights.py
+++ b/src/lerobot/rewards/sarm/compute_rabc_weights.py
@@ -677,9 +677,7 @@ def compute_sarm_progress(
         table_data["progress_dense"] = np.array(all_progress_dense, dtype=np.float32)
 
     # Sort by index
-    df = pa.table(table_data).to_pandas()
-    df = df.sort_values("index").reset_index(drop=True)
-    final_table = pa.Table.from_pandas(df, preserve_index=False)
+    final_table = pa.table(table_data).sort_by([("index", "ascending")])
 
     # Add metadata with reward model path
     metadata = {b"reward_model_path": reward_model_path.encode()}
@@ -694,17 +692,19 @@ def compute_sarm_progress(
     logging.info(f"Saved {len(final_table)} frame progress values to {output_path}")
 
     # Print statistics
-    if "progress_sparse" in df.columns:
-        valid = df["progress_sparse"].dropna()
+    if "progress_sparse" in table_data:
+        values = table_data["progress_sparse"]
+        valid = values[~np.isnan(values)]
         logging.info(
-            f"Sparse progress: mean={valid.mean():.4f}, std={valid.std():.4f}, "
+            f"Sparse progress: mean={valid.mean():.4f}, std={valid.std(ddof=1):.4f}, "
             f"min={valid.min():.4f}, max={valid.max():.4f}"
         )
 
-    if "progress_dense" in df.columns:
-        valid = df["progress_dense"].dropna()
+    if "progress_dense" in table_data:
+        values = table_data["progress_dense"]
+        valid = values[~np.isnan(values)]
         logging.info(
-            f"Dense progress: mean={valid.mean():.4f}, std={valid.std():.4f}, "
+            f"Dense progress: mean={valid.mean():.4f}, std={valid.std(ddof=1):.4f}, "
             f"min={valid.min():.4f}, max={valid.max():.4f}"
         )
 

--- a/src/lerobot/rewards/sarm/modeling_sarm.py
+++ b/src/lerobot/rewards/sarm/modeling_sarm.py
@@ -142,7 +142,8 @@ class StageTransformer(nn.Module):
         Returns:
             Stage logits (B, T, num_classes)
         """
-        assert scheme in self.heads, f"Unknown scheme '{scheme}'. Use one of {list(self.heads.keys())}."
+        if scheme not in self.heads:
+            raise ValueError(f"Unknown scheme '{scheme}'. Use one of {list(self.heads.keys())}.")
 
         B, N, T, _ = img_seq.shape  # noqa: N806
         D = self.d_model  # noqa: N806
@@ -292,7 +293,8 @@ class SubtaskTransformer(nn.Module):
         Returns:
             Tau predictions (B, T) in [0, 1] via sigmoid
         """
-        assert scheme in self.heads, f"Unknown scheme '{scheme}'. Use one of {list(self.heads.keys())}."
+        if scheme not in self.heads:
+            raise ValueError(f"Unknown scheme '{scheme}'. Use one of {list(self.heads.keys())}.")
 
         B, N, T, _ = img_seq.shape  # noqa: N806
         D = self.d_model  # noqa: N806
@@ -536,12 +538,17 @@ class SARMRewardModel(PreTrainedRewardModel):
             state_features = torch.as_tensor(state_features, dtype=torch.float32)
 
         if text_embeddings.ndim == 1:
+            # Handle single sample case
             text_embeddings = text_embeddings.unsqueeze(0)
             video_embeddings = video_embeddings.unsqueeze(0)
             if state_features is not None:
                 state_features = state_features.unsqueeze(0)
 
         batch_size, seq_len = video_embeddings.shape[:2]
+
+        scheme = head_mode
+
+        # Default lengths if not provided
         if lengths is None:
             lengths = torch.full((batch_size,), seq_len, dtype=torch.int32)
         elif not isinstance(lengths, Tensor):
@@ -552,6 +559,8 @@ class SARMRewardModel(PreTrainedRewardModel):
         if torch.any(lengths < 1) or torch.any(lengths > seq_len):
             raise ValueError(f"SARM `lengths` values must be in [1, {seq_len}], got {lengths.tolist()}")
 
+        # Reshape video to (B, N, T, D) for multi-camera format
+        # Currently single camera: (B, T, D) -> (B, 1, T, D)
         img_seq = video_embeddings.unsqueeze(1).to(device)
         lang_emb = text_embeddings.to(device)
         state = (
@@ -559,42 +568,54 @@ class SARMRewardModel(PreTrainedRewardModel):
             if state_features is not None
             else torch.zeros(batch_size, seq_len, self.config.max_state_dim, device=device)
         )
-        state = pad_state_to_max_dim(state, self.config.max_state_dim)
         lens = lengths.to(device)
+
+        # Pad state to max_state_dim
+        state = pad_state_to_max_dim(state, self.config.max_state_dim)
+
         valid_mask = torch.arange(seq_len, device=device).unsqueeze(0) < lens.unsqueeze(1)
 
-        num_classes = self.config.num_sparse_stages if head_mode == "sparse" else self.config.num_dense_stages
+        # Get num_classes for this scheme
+        num_classes = self.config.num_sparse_stages if scheme == "sparse" else self.config.num_dense_stages
         if num_classes is None:
-            raise ValueError(f"SARM {head_mode!r} head has no configured stages")
+            raise ValueError(f"SARM {scheme!r} head has no configured stages")
 
-        stage_logits = self.stage_model(img_seq, lang_emb, state, lens, scheme=head_mode)
-        stage_probabilities = F.softmax(stage_logits, dim=-1)
-        stage_index = stage_probabilities.argmax(dim=-1)
-        stage_confidence = stage_probabilities.gather(-1, stage_index.unsqueeze(-1)).squeeze(-1)
+        # Run stage model
+        stage_logits = self.stage_model(img_seq, lang_emb, state, lens, scheme=scheme)
+        stage_probs = F.softmax(stage_logits, dim=-1)  # (B, T, num_classes)
+        stage_idx = stage_probs.argmax(dim=-1)  # (B, T)
+        stage_conf = stage_probs.gather(-1, stage_idx.unsqueeze(-1)).squeeze(-1)  # (B, T)
 
-        stage_onehot = F.one_hot(stage_index, num_classes=num_classes).float().unsqueeze(1)
-        tau = self.subtask_model(img_seq, lang_emb, state, lens, stage_onehot, scheme=head_mode)
-        raw_progress = stage_index.float() + tau
+        # Create one-hot stage prior
+        stage_onehot = F.one_hot(stage_idx, num_classes=num_classes).float()  # (B, T, C)
+        stage_emb = stage_onehot.unsqueeze(1)  # (B, 1, T, C)
 
-        if head_mode == "sparse":
-            progress = normalize_stage_tau(
-                raw_progress,
+        # Run subtask model
+        tau_pred = self.subtask_model(img_seq, lang_emb, state, lens, stage_emb, scheme=scheme)
+
+        # Compute final reward: stage + tau
+        raw_reward = stage_idx.float() + tau_pred  # (B, T)
+
+        # Normalize to [0, 1] using temporal proportions for proper weighting
+        if scheme == "sparse":
+            normalized_reward = normalize_stage_tau(
+                raw_reward,
                 num_stages=num_classes,
                 temporal_proportions=self.config.sparse_temporal_proportions,
                 subtask_names=self.config.sparse_subtask_names,
             )
         else:
-            progress = normalize_stage_tau(
-                raw_progress,
+            normalized_reward = normalize_stage_tau(
+                raw_reward,
                 num_stages=num_classes,
                 temporal_proportions=self.config.dense_temporal_proportions,
                 subtask_names=self.config.dense_subtask_names,
             )
 
         return SARMPrediction(
-            progress=progress.float(),
-            stage_probabilities=stage_probabilities.float(),
-            stage_confidence=stage_confidence.float(),
+            progress=normalized_reward.float(),
+            stage_probabilities=stage_probs.float(),
+            stage_confidence=stage_conf.float(),
             valid_mask=valid_mask,
         )
 
@@ -611,7 +632,12 @@ class SARMRewardModel(PreTrainedRewardModel):
         head_mode: str | None = "sparse",
         frame_index: int | None = None,
     ) -> np.ndarray | tuple:
-        """Compatibility wrapper returning NumPy arrays.
+        """
+        Calculate rewards for given text, video, and state representations.
+
+        This compatibility method is used for:
+        - Inference/visualization by existing research code
+        - RA-BC weight computation
 
         New tensor-based consumers should call :meth:`predict_progress`.
 
@@ -645,22 +671,31 @@ class SARMRewardModel(PreTrainedRewardModel):
             head_mode=head_mode,
         )
 
+        normalized_reward = prediction.progress
+        stage_probs = prediction.stage_probabilities
+        stage_conf = prediction.stage_confidence
+
+        # Default frame index is n_obs_steps (last observation frame)
         if frame_index is None:
             frame_index = self.config.n_obs_steps
 
-        rewards = prediction.progress if return_all_frames else prediction.progress[:, frame_index]
-        rewards = rewards.cpu().numpy()
+        # Prepare outputs (batch mode or no smoothing)
+        if return_all_frames:
+            rewards = normalized_reward.cpu().numpy()
+        else:
+            rewards = normalized_reward[:, frame_index].cpu().numpy()
+
         if single_sample:
-            rewards = rewards[0]
+            rewards = rewards[0] if not return_all_frames else rewards[0]
 
         outputs = [rewards]
         if return_stages:
-            probs = prediction.stage_probabilities.cpu().numpy()
+            probs = stage_probs.cpu().numpy()
             if single_sample:
                 probs = probs[0]
             outputs.append(probs)
         if return_confidence:
-            conf = prediction.stage_confidence.cpu().numpy()
+            conf = stage_conf.cpu().numpy()
             if single_sample:
                 conf = conf[0]
             outputs.append(conf)

--- a/src/lerobot/rewards/sarm/modeling_sarm.py
+++ b/src/lerobot/rewards/sarm/modeling_sarm.py
@@ -25,6 +25,9 @@ Paper: https://arxiv.org/abs/2509.25358
 import json
 import logging
 import random
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, Literal
 
 import numpy as np
 import torch
@@ -32,6 +35,7 @@ import torch.nn as nn
 import torch.nn.functional as F  # noqa: N812
 from torch import Tensor
 
+from lerobot.rewards.capabilities import ProgressPrediction
 from lerobot.utils.constants import OBS_STR
 
 from ..pretrained import PreTrainedRewardModel
@@ -351,6 +355,23 @@ def gen_stage_emb(num_classes: int, targets: torch.Tensor) -> torch.Tensor:
     return stage_onehot
 
 
+@dataclass(frozen=True)
+class SARMPrediction(ProgressPrediction):
+    """SARM frame signals on the model device.
+
+    ``progress``, ``stage_confidence``, and ``valid_mask`` have shape
+    ``(batch, time)``.
+    ``stage_probabilities`` has shape ``(batch, time, stages)``.
+
+    Values at positions where ``valid_mask`` is false are padding artifacts and
+    must not be consumed as predictions.
+    """
+
+    stage_probabilities: Tensor
+    stage_confidence: Tensor
+    valid_mask: Tensor
+
+
 class SARMRewardModel(PreTrainedRewardModel):
     """
     SARM Reward Model for stage-aware task completion rewards.
@@ -469,22 +490,113 @@ class SARMRewardModel(PreTrainedRewardModel):
         self.subtask_model.to(device)
         return self
 
-    def compute_reward(self, batch: dict[str, Tensor]) -> Tensor:
-        """Compute dense progress reward in [0, 1] from batch.
+    @torch.no_grad()
+    def predict_progress(
+        self,
+        batch: Mapping[str, Any],
+        *,
+        head_mode: Literal["sparse", "dense"] = "sparse",
+    ) -> SARMPrediction:
+        """Predict progress and stage signals for every encoded frame.
 
-        Expects batch to contain:
-        - "observation_features" or video embeddings: (B, T, 512)
-        - "language_embedding" or text embeddings: (B, 512)
-        - optionally "observation.state": (B, T, state_dim)
+        Args:
+            batch: Processor output containing ``text_features`` and
+                ``video_features``, plus optional ``state_features`` and
+                ``lengths``.
+            head_mode: Annotation head to evaluate.
+
+        Returns:
+            Batched float32 tensors on the model device, plus a boolean
+            ``valid_mask`` derived from ``lengths``. Consumers select a valid
+            frame that corresponds to their sampling strategy.
         """
-        text_emb = batch.get("language_embedding", batch.get("text_features"))
-        video_emb = batch.get("observation_features", batch.get("video_features"))
-        state = batch.get("observation.state", batch.get("state_features"))
+        if "text_features" not in batch:
+            raise KeyError("SARM batch missing `text_features` (run SARMEncodingProcessorStep first)")
+        if "video_features" not in batch:
+            raise KeyError("SARM batch missing `video_features` (run SARMEncodingProcessorStep first)")
+        if head_mode not in {"sparse", "dense"}:
+            raise ValueError(f"head_mode must be 'sparse' or 'dense', got {head_mode!r}")
+        if head_mode == "dense" and not self.config.uses_dual_heads:
+            raise ValueError(
+                f"SARM dense predictions require annotation_mode='dense_only' or 'dual', "
+                f"got {self.config.annotation_mode!r}"
+            )
 
-        rewards = self.calculate_rewards(text_emb, video_emb, state)
-        if isinstance(rewards, np.ndarray):
-            rewards = torch.from_numpy(rewards).float()
-        return rewards
+        device = next(self.stage_model.parameters()).device
+        text_embeddings = batch["text_features"]
+        video_embeddings = batch["video_features"]
+        state_features = batch.get("state_features")
+        lengths = batch.get("lengths")
+
+        if not isinstance(text_embeddings, Tensor):
+            text_embeddings = torch.as_tensor(text_embeddings, dtype=torch.float32)
+        if not isinstance(video_embeddings, Tensor):
+            video_embeddings = torch.as_tensor(video_embeddings, dtype=torch.float32)
+        if state_features is not None and not isinstance(state_features, Tensor):
+            state_features = torch.as_tensor(state_features, dtype=torch.float32)
+
+        if text_embeddings.ndim == 1:
+            text_embeddings = text_embeddings.unsqueeze(0)
+            video_embeddings = video_embeddings.unsqueeze(0)
+            if state_features is not None:
+                state_features = state_features.unsqueeze(0)
+
+        batch_size, seq_len = video_embeddings.shape[:2]
+        if lengths is None:
+            lengths = torch.full((batch_size,), seq_len, dtype=torch.int32)
+        elif not isinstance(lengths, Tensor):
+            lengths = torch.as_tensor(lengths, dtype=torch.int32)
+
+        if lengths.ndim != 1 or lengths.shape[0] != batch_size:
+            raise ValueError(f"SARM `lengths` must have shape ({batch_size},), got {tuple(lengths.shape)}")
+        if torch.any(lengths < 1) or torch.any(lengths > seq_len):
+            raise ValueError(f"SARM `lengths` values must be in [1, {seq_len}], got {lengths.tolist()}")
+
+        img_seq = video_embeddings.unsqueeze(1).to(device)
+        lang_emb = text_embeddings.to(device)
+        state = (
+            state_features.to(device)
+            if state_features is not None
+            else torch.zeros(batch_size, seq_len, self.config.max_state_dim, device=device)
+        )
+        state = pad_state_to_max_dim(state, self.config.max_state_dim)
+        lens = lengths.to(device)
+        valid_mask = torch.arange(seq_len, device=device).unsqueeze(0) < lens.unsqueeze(1)
+
+        num_classes = self.config.num_sparse_stages if head_mode == "sparse" else self.config.num_dense_stages
+        if num_classes is None:
+            raise ValueError(f"SARM {head_mode!r} head has no configured stages")
+
+        stage_logits = self.stage_model(img_seq, lang_emb, state, lens, scheme=head_mode)
+        stage_probabilities = F.softmax(stage_logits, dim=-1)
+        stage_index = stage_probabilities.argmax(dim=-1)
+        stage_confidence = stage_probabilities.gather(-1, stage_index.unsqueeze(-1)).squeeze(-1)
+
+        stage_onehot = F.one_hot(stage_index, num_classes=num_classes).float().unsqueeze(1)
+        tau = self.subtask_model(img_seq, lang_emb, state, lens, stage_onehot, scheme=head_mode)
+        raw_progress = stage_index.float() + tau
+
+        if head_mode == "sparse":
+            progress = normalize_stage_tau(
+                raw_progress,
+                num_stages=num_classes,
+                temporal_proportions=self.config.sparse_temporal_proportions,
+                subtask_names=self.config.sparse_subtask_names,
+            )
+        else:
+            progress = normalize_stage_tau(
+                raw_progress,
+                num_stages=num_classes,
+                temporal_proportions=self.config.dense_temporal_proportions,
+                subtask_names=self.config.dense_subtask_names,
+            )
+
+        return SARMPrediction(
+            progress=progress.float(),
+            stage_probabilities=stage_probabilities.float(),
+            stage_confidence=stage_confidence.float(),
+            valid_mask=valid_mask,
+        )
 
     @torch.no_grad()
     def calculate_rewards(
@@ -499,12 +611,9 @@ class SARMRewardModel(PreTrainedRewardModel):
         head_mode: str | None = "sparse",
         frame_index: int | None = None,
     ) -> np.ndarray | tuple:
-        """
-        Calculate rewards for given text, video, and state representations.
+        """Compatibility wrapper returning NumPy arrays.
 
-        This is the canonical method for SARM reward computation, used for:
-        - Inference/visualization
-        - RA-BC weight computation
+        New tensor-based consumers should call :meth:`predict_progress`.
 
         Args:
             text_embeddings: Encoded text representations (batch_size, 512)
@@ -520,104 +629,38 @@ class SARMRewardModel(PreTrainedRewardModel):
         Returns:
             Rewards and optionally stage probs/confidence.
         """
-        if isinstance(text_embeddings, np.ndarray):
-            text_embeddings = torch.tensor(text_embeddings, dtype=torch.float32)
-        if isinstance(video_embeddings, np.ndarray):
-            video_embeddings = torch.tensor(video_embeddings, dtype=torch.float32)
-        if state_features is not None and isinstance(state_features, np.ndarray):
-            state_features = torch.tensor(state_features, dtype=torch.float32)
+        if head_mode is None:
+            head_mode = "sparse"
+        if head_mode not in {"sparse", "dense"}:
+            raise ValueError(f"head_mode must be 'sparse' or 'dense', got {head_mode!r}")
 
-        # Handle single sample case
-        if text_embeddings.dim() == 1:
-            text_embeddings = text_embeddings.unsqueeze(0)
-            video_embeddings = video_embeddings.unsqueeze(0)
-            if state_features is not None:
-                state_features = state_features.unsqueeze(0)
-            single_sample = True
-        else:
-            single_sample = False
-
-        batch_size = video_embeddings.shape[0]
-        seq_len = video_embeddings.shape[1]
-
-        scheme = head_mode
-
-        # Default lengths if not provided
-        if lengths is None:
-            lengths = torch.full((batch_size,), seq_len, dtype=torch.int32)
-        elif isinstance(lengths, np.ndarray):
-            lengths = torch.tensor(lengths, dtype=torch.int32)
-
-        # Reshape video to (B, N, T, D) for multi-camera format
-        # Currently single camera: (B, T, D) -> (B, 1, T, D)
-        img_seq = video_embeddings.unsqueeze(1).to(self.device)
-        lang_emb = text_embeddings.to(self.device)
-        state = (
-            state_features.to(self.device)
-            if state_features is not None
-            else torch.zeros(batch_size, seq_len, self.config.max_state_dim, device=self.device)
+        single_sample = text_embeddings.ndim == 1
+        prediction = self.predict_progress(
+            {
+                "text_features": text_embeddings,
+                "video_features": video_embeddings,
+                "state_features": state_features,
+                "lengths": lengths,
+            },
+            head_mode=head_mode,
         )
-        lens = lengths.to(self.device)
 
-        # Pad state to max_state_dim
-        state = pad_state_to_max_dim(state, self.config.max_state_dim)
-
-        # Get num_classes for this scheme
-        num_classes = self.config.num_sparse_stages if scheme == "sparse" else self.config.num_dense_stages
-
-        # Run stage model
-        stage_logits = self.stage_model(img_seq, lang_emb, state, lens, scheme=scheme)
-        stage_probs = F.softmax(stage_logits, dim=-1)  # (B, T, num_classes)
-        stage_idx = stage_probs.argmax(dim=-1)  # (B, T)
-        stage_conf = stage_probs.gather(-1, stage_idx.unsqueeze(-1)).squeeze(-1)  # (B, T)
-
-        # Create one-hot stage prior
-        stage_onehot = F.one_hot(stage_idx, num_classes=num_classes).float()  # (B, T, C)
-        stage_emb = stage_onehot.unsqueeze(1)  # (B, 1, T, C)
-
-        # Run subtask model
-        tau_pred = self.subtask_model(img_seq, lang_emb, state, lens, stage_emb, scheme=scheme)
-
-        # Compute final reward: stage + tau
-        raw_reward = stage_idx.float() + tau_pred  # (B, T)
-
-        # Normalize to [0, 1] using temporal proportions for proper weighting
-        if scheme == "sparse":
-            normalized_reward = normalize_stage_tau(
-                raw_reward,
-                num_stages=num_classes,
-                temporal_proportions=self.config.sparse_temporal_proportions,
-                subtask_names=self.config.sparse_subtask_names,
-            )
-        else:
-            normalized_reward = normalize_stage_tau(
-                raw_reward,
-                num_stages=num_classes,
-                temporal_proportions=self.config.dense_temporal_proportions,
-                subtask_names=self.config.dense_subtask_names,
-            )
-
-        # Default frame index is n_obs_steps (last observation frame)
         if frame_index is None:
             frame_index = self.config.n_obs_steps
 
-        # Prepare outputs (batch mode or no smoothing)
-        if return_all_frames:
-            rewards = normalized_reward.cpu().numpy()
-        else:
-            rewards = normalized_reward[:, frame_index].cpu().numpy()
-
+        rewards = prediction.progress if return_all_frames else prediction.progress[:, frame_index]
+        rewards = rewards.cpu().numpy()
         if single_sample:
-            rewards = rewards[0] if not return_all_frames else rewards[0]
+            rewards = rewards[0]
 
         outputs = [rewards]
         if return_stages:
-            probs = stage_probs.cpu().numpy()
+            probs = prediction.stage_probabilities.cpu().numpy()
             if single_sample:
                 probs = probs[0]
             outputs.append(probs)
         if return_confidence:
-            conf = stage_conf.cpu().numpy()
+            conf = prediction.stage_confidence.cpu().numpy()
             if single_sample:
                 conf = conf[0]
             outputs.append(conf)

--- a/src/lerobot/rewards/topreward/compute_rabc_weights.py
+++ b/src/lerobot/rewards/topreward/compute_rabc_weights.py
@@ -39,27 +39,51 @@ from __future__ import annotations
 import argparse
 import logging
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
-import pyarrow as pa
-import pyarrow.parquet as pq
 import torch
 from tqdm import tqdm
 
-from lerobot.datasets import LeRobotDataset
 from lerobot.lerobot_types import TransitionKey
 from lerobot.rewards.topreward.configuration_topreward import TOPRewardConfig
 from lerobot.rewards.topreward.modeling_topreward import TOPRewardModel
 from lerobot.rewards.topreward.processor_topreward import TOPRewardEncoderProcessorStep
+from lerobot.utils.import_utils import (
+    _av_available,
+    _datasets_available,
+    _pyarrow_available,
+    require_package,
+)
+
+if TYPE_CHECKING or _pyarrow_available:
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+else:
+    pa = None  # type: ignore[assignment]
+    pq = None  # type: ignore[assignment]
+
+if TYPE_CHECKING or (_datasets_available and _av_available):
+    from lerobot.datasets import LeRobotDataset
+else:
+    LeRobotDataset = None  # type: ignore[assignment, misc]
 
 DEFAULT_OUTPUT_FILENAME = "topreward_progress.parquet"
+
+
+def _require_dataset_dependencies() -> None:
+    """Require packages used only by dataset scoring and parquet IO."""
+    require_package("datasets", extra="dataset")
+    require_package("av", extra="dataset")
+    require_package("pyarrow", extra="dataset")
 
 
 def get_reward_model_path_from_parquet(parquet_path: Path) -> str | None:
     """Read ``reward_model_path`` from parquet metadata if available."""
     if not parquet_path.exists():
         return None
+    require_package("pyarrow", extra="dataset")
+    assert pq is not None
     try:
         metadata = pq.read_metadata(parquet_path).schema.to_arrow_schema().metadata
         if metadata and b"reward_model_path" in metadata:
@@ -158,6 +182,9 @@ def compute_topreward_progress(
     episodes: list[int] | None = None,
 ) -> Path:
     """Run TOPReward over a dataset and write per-frame progress."""
+    _require_dataset_dependencies()
+    assert pa is not None and pq is not None and LeRobotDataset is not None
+
     if reward_model_path is not None:
         logging.info(f"Loading TOPReward config from: {reward_model_path}")
         model = TOPRewardModel.from_pretrained(reward_model_path)

--- a/src/lerobot/rewards/topreward/compute_rabc_weights.py
+++ b/src/lerobot/rewards/topreward/compute_rabc_weights.py
@@ -73,9 +73,10 @@ DEFAULT_OUTPUT_FILENAME = "topreward_progress.parquet"
 
 def _require_dataset_dependencies() -> None:
     """Require packages used only by dataset scoring and parquet IO."""
-    require_package("datasets", extra="dataset")
-    require_package("av", extra="dataset")
     require_package("pyarrow", extra="dataset")
+    if LeRobotDataset is None:
+        require_package("datasets", extra="dataset")
+        require_package("av", extra="dataset")
 
 
 def get_reward_model_path_from_parquet(parquet_path: Path) -> str | None:

--- a/src/lerobot/rewards/topreward/compute_rabc_weights.py
+++ b/src/lerobot/rewards/topreward/compute_rabc_weights.py
@@ -84,7 +84,8 @@ def get_reward_model_path_from_parquet(parquet_path: Path) -> str | None:
     if not parquet_path.exists():
         return None
     require_package("pyarrow", extra="dataset")
-    assert pq is not None
+    if pq is None:
+        raise ImportError("pyarrow.parquet is required to read reward-model metadata")
     try:
         metadata = pq.read_metadata(parquet_path).schema.to_arrow_schema().metadata
         if metadata and b"reward_model_path" in metadata:
@@ -184,7 +185,8 @@ def compute_topreward_progress(
 ) -> Path:
     """Run TOPReward over a dataset and write per-frame progress."""
     _require_dataset_dependencies()
-    assert pa is not None and pq is not None and LeRobotDataset is not None
+    if pa is None or pq is None or LeRobotDataset is None:
+        raise ImportError("TOPReward dataset scoring requires pyarrow and LeRobotDataset")
 
     if reward_model_path is not None:
         logging.info(f"Loading TOPReward config from: {reward_model_path}")

--- a/src/lerobot/rewards/topreward/compute_rabc_weights.py
+++ b/src/lerobot/rewards/topreward/compute_rabc_weights.py
@@ -90,6 +90,13 @@ def normalize_rewards(rewards: list[float] | np.ndarray) -> np.ndarray:
     return ((rewards_arr - r_min) / (r_max - r_min)).astype(np.float32)
 
 
+def _apply_legacy_success_threshold(log_probability: torch.Tensor, threshold: float) -> torch.Tensor:
+    """Preserve the old script output for configs that selected binary success."""
+    if np.isfinite(threshold):
+        return (log_probability > threshold).float()
+    return log_probability
+
+
 def compute_instruction_rewards_for_prefixes(
     model: TOPRewardModel,
     encoder: TOPRewardEncoderProcessorStep,
@@ -122,9 +129,11 @@ def compute_instruction_rewards_for_prefixes(
             key: value.to(device) if isinstance(value, torch.Tensor) else value for key, value in obs.items()
         }
 
-        with torch.no_grad():
-            reward = model.compute_reward(batch)
-        rewards.append(float(reward.item()))
+        log_probability = _apply_legacy_success_threshold(
+            model.compute_log_probability(batch),
+            model.config.success_threshold,
+        )
+        rewards.append(float(log_probability.item()))
 
     normalized_rewards = normalize_rewards(rewards)
 

--- a/src/lerobot/rewards/topreward/configuration_topreward.py
+++ b/src/lerobot/rewards/topreward/configuration_topreward.py
@@ -67,10 +67,9 @@ class TOPRewardConfig(RewardModelConfig):
         add_chat_template: If ``True``, wrap the full prompt with the
             tokenizer's chat template before tokenisation (matches
             upstream ``add_chat_template=True``).
-        success_threshold: Optional log-prob threshold. If finite,
-            :meth:`TOPRewardModel.compute_reward` returns
-            ``(reward > success_threshold).float()`` instead of the raw
-            log-prob.
+        success_threshold: Legacy serialized log-probability threshold kept
+            for checkpoint compatibility. ``compute_log_probability`` always
+            returns the raw value; consumers apply thresholds explicitly.
         max_input_length: Hard limit on the total tokenized input length;
             samples that exceed it raise a ``ValueError``.
     """

--- a/src/lerobot/rewards/topreward/modeling_topreward.py
+++ b/src/lerobot/rewards/topreward/modeling_topreward.py
@@ -130,7 +130,7 @@ class TOPRewardModel(PreTrainedRewardModel):
         inputs["logits_to_keep"] = 2
 
         self.eval()
-        with torch.inference_mode():
+        with torch.no_grad():
             outputs = self.model(**inputs)
         logits = outputs.logits
         return -cross_entropy(logits[:, -2, :].float(), labels[:, -1], reduction="none")

--- a/src/lerobot/rewards/topreward/modeling_topreward.py
+++ b/src/lerobot/rewards/topreward/modeling_topreward.py
@@ -57,10 +57,10 @@ from __future__ import annotations
 import builtins
 import logging
 import os
+from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeVar
 
-import numpy as np
 import torch
 from huggingface_hub import hf_hub_download
 from huggingface_hub.constants import CONFIG_NAME
@@ -112,15 +112,15 @@ class TOPRewardModel(PreTrainedRewardModel):
 
         self.model = Qwen3VLForConditionalGeneration.from_pretrained(config.vlm_name, **model_kwargs)
 
-    def compute_reward(self, batch: dict[str, Any]) -> Tensor:
-        """Return one log-prob reward per sample in the batch."""
+    def compute_log_probability(self, batch: Mapping[str, Any]) -> Tensor:
+        """Return ``log P(target token | video, prompt)`` for each sample."""
         inputs: dict[str, Any] = {}
         for key in TOPREWARD_INPUT_KEYS:
             batch_key = f"{TOPREWARD_FEATURE_PREFIX}{key}"
             if batch_key not in batch:
                 raise KeyError(
                     f"TOPReward batch missing `{batch_key}`. Make sure the "
-                    "TOPRewardEncoderProcessorStep ran before `compute_reward`."
+                    "TOPRewardEncoderProcessorStep ran before `compute_log_probability`."
                 )
             inputs[key] = batch[batch_key]
 
@@ -130,13 +130,10 @@ class TOPRewardModel(PreTrainedRewardModel):
         inputs["logits_to_keep"] = 2
 
         self.eval()
-        with torch.no_grad():
+        with torch.inference_mode():
             outputs = self.model(**inputs)
         logits = outputs.logits
-        rewards = -cross_entropy(logits[:, -2, :].float(), labels[:, -1], reduction="none")
-        if np.isfinite(self.config.success_threshold):
-            rewards = (rewards > self.config.success_threshold).float()
-        return rewards.to(self.config.device or "cpu")
+        return -cross_entropy(logits[:, -2, :].float(), labels[:, -1], reduction="none")
 
     def _save_pretrained(self, save_directory: Path) -> None:
         """Save ``config.json`` only."""

--- a/src/lerobot/rewards/topreward/processor_topreward.py
+++ b/src/lerobot/rewards/topreward/processor_topreward.py
@@ -277,7 +277,8 @@ def make_topreward_pre_post_processors(
     The preprocessor adds a batch dimension if needed, runs TOPReward's
     encoder (which tokenises the full prompt and emits ``labels``), and
     moves everything to the configured device. The postprocessor is
-    the identity since TOPReward outputs a single reward tensor.
+    the identity because ``compute_log_probability`` returns its tensor
+    result directly.
     """
     preprocessor = PolicyProcessorPipeline[dict[str, Any], dict[str, Any]](
         steps=[

--- a/src/lerobot/scripts/lerobot_train.py
+++ b/src/lerobot/scripts/lerobot_train.py
@@ -464,7 +464,7 @@ def train(cfg: TrainPipelineConfig):
         if not policy.is_trainable:
             raise ValueError(
                 f"Reward model '{policy.name}' is zero-shot and cannot be trained via lerobot-train. "
-                "Use it directly for inference via compute_reward() (e.g. offline precompute)."
+                "Use its documented inference capability directly (for example, for offline scoring)."
             )
     else:
         if is_main_process():

--- a/src/lerobot/templates/lerobot_rewardmodel_modelcard_template.md
+++ b/src/lerobot/templates/lerobot_rewardmodel_modelcard_template.md
@@ -21,13 +21,18 @@ TOPReward is a **zero-shot** reward model that extracts token log-probabilities 
 _Reward model type not recognized — please update this template._
 {% endif %}
 
+{% if model_name in ["robometer", "topreward"] %}
+This inference-only reward-model integration can be loaded with [LeRobot](https://github.com/huggingface/lerobot). Training this model through `lerobot-train` is not currently supported.
+{% else %}
 This reward model has been trained and pushed to the Hub using [LeRobot](https://github.com/huggingface/lerobot).
+{% endif %}
 See the full documentation at [LeRobot Docs](https://huggingface.co/docs/lerobot/index).
 
 ---
 
 ## How to Get Started with the Reward Model
 
+{% if model_name not in ["robometer", "topreward"] %}
 ### Train from scratch
 
 ```bash
@@ -42,14 +47,34 @@ lerobot-train \
 ```
 
 _Writes checkpoints to `outputs/train/<desired_reward_model_repo_id>/checkpoints/`._
+{% endif %}
 
 ### Load the reward model in Python
 
 ```python
+from lerobot.configs.rewards import RewardModelConfig
 from lerobot.rewards import make_reward_model
 
-reward_model = make_reward_model(pretrained_path="<hf_user>/<reward_model_repo_id>")
-reward = reward_model.compute_reward(batch)
+model_id = "<hf_user>/<reward_model_repo_id>"
+config = RewardModelConfig.from_pretrained(model_id)
+config.pretrained_path = model_id
+reward_model = make_reward_model(config)
+
+# `batch` is the output of this model's documented preprocessor.
+{% if model_name == "reward_classifier" %}
+reward = reward_model.predict_reward(batch)
+{% elif model_name == "sarm" %}
+prediction = reward_model.predict_progress(batch, head_mode="sparse")
+progress = prediction.progress
+{% elif model_name == "robometer" %}
+prediction = reward_model.predict_progress(batch)
+progress = prediction.progress
+success_probability = prediction.success_probability
+{% elif model_name == "topreward" %}
+log_probability = reward_model.compute_log_probability(batch)
+{% else %}
+# Use the model's documented inference capability.
+{% endif %}
 ```
 
 ---

--- a/src/lerobot/utils/import_utils.py
+++ b/src/lerobot/utils/import_utils.py
@@ -141,6 +141,7 @@ _hidapi_available = is_package_available("hidapi", import_name="hid")
 # Data / serialization
 _datasets_available = is_package_available("datasets")
 _pandas_available = is_package_available("pandas")
+_pyarrow_available = is_package_available("pyarrow")
 _faker_available = is_package_available("faker")
 
 # Video encoding / decoding

--- a/tests/rewards/test_compute_robometer_progress.py
+++ b/tests/rewards/test_compute_robometer_progress.py
@@ -1,0 +1,267 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Characterization tests for RoboMeter's frame-steps scoring inputs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+from lerobot.lerobot_types import TransitionKey
+from lerobot.rewards.robometer import compute_rabc_weights
+from lerobot.rewards.robometer.modeling_robometer import ROBOMETER_FEATURE_PREFIX, RobometerPrediction
+from lerobot.rewards.robometer.processor_robometer import _video_to_numpy
+
+
+@pytest.mark.parametrize(
+    ("num_frames", "num_subsampled_frames"),
+    [(1, 1), (4, 1), (3, 4), (8, 4)],
+)
+def test_build_subsample_indices_returns_fixed_size_prefixes(
+    num_frames: int, num_subsampled_frames: int
+) -> None:
+    indices = compute_rabc_weights._build_subsample_indices(num_frames, num_subsampled_frames)
+
+    assert len(indices) == num_frames
+    assert all(index.shape == (num_subsampled_frames,) for index in indices)
+    assert all(index.dtype == np.int64 for index in indices)
+
+
+def test_build_subsample_indices_keeps_prefix_endpoints() -> None:
+    indices = compute_rabc_weights._build_subsample_indices(num_frames=7, num_subsampled_frames=4)
+
+    for current_frame, prefix_indices in enumerate(indices):
+        assert prefix_indices[0] == 0
+        assert prefix_indices[-1] == current_frame
+
+
+def test_build_subsample_indices_pins_single_frame_behavior() -> None:
+    indices = compute_rabc_weights._build_subsample_indices(num_frames=4, num_subsampled_frames=1)
+
+    assert [index.tolist() for index in indices] == [[0], [0], [0], [0]]
+
+
+def test_build_subsample_indices_pins_rounding_and_repeated_frames() -> None:
+    indices = compute_rabc_weights._build_subsample_indices(num_frames=6, num_subsampled_frames=4)
+
+    expected = [
+        [0, 0, 0, 0],
+        [0, 0, 1, 1],
+        [0, 1, 1, 2],
+        [0, 1, 2, 3],
+        [0, 1, 3, 4],
+        [0, 2, 3, 5],
+    ]
+    assert [index.tolist() for index in indices] == expected
+
+
+def test_disabling_crop_preserves_previous_output_for_fixed_size_samples() -> None:
+    selected_frames = torch.arange(4 * 3 * 2 * 2, dtype=torch.uint8).reshape(4, 3, 2, 2)
+
+    previous = _video_to_numpy(selected_frames, max_frames=4)
+    uncropped = _video_to_numpy(selected_frames, max_frames=None)
+
+    np.testing.assert_array_equal(uncropped, previous)
+
+
+def test_select_last_frame_progress_preserves_batch_axis() -> None:
+    prediction = RobometerPrediction(
+        progress=torch.tensor([[0.1, 0.9], [0.4, 0.6]]),
+        success_probability=torch.zeros(2, 2),
+    )
+
+    selected = compute_rabc_weights._select_last_frame_progress(prediction)
+
+    assert torch.equal(selected, torch.tensor([0.9, 0.6]))
+
+
+@pytest.mark.parametrize("progress", [torch.empty(2, 0), torch.empty(2)])
+def test_select_last_frame_progress_rejects_invalid_shape(progress: torch.Tensor) -> None:
+    prediction = RobometerPrediction(
+        progress=progress,
+        success_probability=torch.empty_like(progress),
+    )
+
+    with pytest.raises(ValueError, match=r"shape \(batch, time\)"):
+        compute_rabc_weights._select_last_frame_progress(prediction)
+
+
+@pytest.mark.parametrize("num_subsampled_frames", [0, -1])
+def test_compute_progress_rejects_invalid_subsample_count_before_loading(
+    num_subsampled_frames: int,
+) -> None:
+    with pytest.raises(
+        ValueError,
+        match=rf"num_subsampled_frames must be >= 1, got {num_subsampled_frames}",
+    ):
+        compute_rabc_weights.compute_robometer_progress(
+            dataset_repo_id="unused/dataset",
+            reward_model_path="unused/model",
+            num_subsampled_frames=num_subsampled_frames,
+        )
+
+
+def test_make_scoring_encoder_disables_processor_cropping(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeEncoder:
+        def __init__(self, **kwargs) -> None:
+            captured.update(kwargs)
+
+    monkeypatch.setattr(compute_rabc_weights, "RobometerEncoderProcessorStep", FakeEncoder)
+    config = SimpleNamespace(
+        base_model_id="Qwen/Qwen3-VL-4B-Instruct",
+        image_key="observation.images.cam_top",
+        task_key="task",
+        default_task="pick up the cube",
+        use_multi_image=False,
+        use_per_frame_progress_token=False,
+    )
+
+    encoder = compute_rabc_weights._make_robometer_scoring_encoder(config)
+
+    assert isinstance(encoder, FakeEncoder)
+    assert captured == {
+        "base_model_id": config.base_model_id,
+        "image_key": config.image_key,
+        "task_key": config.task_key,
+        "default_task": config.default_task,
+        "max_frames": None,
+        "use_multi_image": config.use_multi_image,
+        "use_per_frame_progress_token": config.use_per_frame_progress_token,
+    }
+    assert "num_subsampled_frames" not in captured
+
+
+def test_scoring_encoder_preserves_already_selected_frames() -> None:
+    encoder = object.__new__(compute_rabc_weights.RobometerEncoderProcessorStep)
+    encoder.image_key = "observation.images.top"
+    encoder.task_key = "task"
+    encoder.default_task = None
+    encoder.max_frames = None
+
+    captured_samples: list[tuple[np.ndarray, str]] = []
+
+    def encode_samples(samples: list[tuple[np.ndarray, str]]) -> dict[str, torch.Tensor]:
+        captured_samples.extend(samples)
+        return {"input_ids": torch.zeros(len(samples), 1, dtype=torch.long)}
+
+    encoder.encode_samples = encode_samples
+    batch_size = 2
+    num_subsampled_frames = 4
+    frames = torch.zeros(batch_size, num_subsampled_frames, 3, 2, 2)
+    transition = {
+        TransitionKey.OBSERVATION: {encoder.image_key: frames},
+        TransitionKey.COMPLEMENTARY_DATA: {"task": ["task a", "task b"]},
+    }
+
+    encoder(transition)
+
+    assert [sample_frames.shape[0] for sample_frames, _ in captured_samples] == [
+        num_subsampled_frames,
+        num_subsampled_frames,
+    ]
+    assert [task for _, task in captured_samples] == ["task a", "task b"]
+
+
+def test_compute_robometer_progress_preserves_legacy_parquet_artifact(monkeypatch, tmp_path: Path) -> None:
+    pa = pytest.importorskip("pyarrow")
+    pq = pytest.importorskip("pyarrow.parquet")
+
+    image_key = "observation.images.top"
+
+    class FakeConfig:
+        def __init__(self, pretrained_path: str, device: str) -> None:
+            self.pretrained_path = pretrained_path
+            self.device = device
+            self.image_key = image_key
+            self.task_key = "task"
+            self.default_task = None
+            self.base_model_id = "fake/backbone"
+            self.use_multi_image = True
+            self.use_per_frame_progress_token = True
+
+    class FakeModel:
+        def __init__(self, config: FakeConfig) -> None:
+            self.config = config
+
+        @classmethod
+        def from_pretrained(cls, _path: str, *, config: FakeConfig):
+            return cls(config)
+
+        def to(self, _device: str):
+            return self
+
+        def eval(self):
+            return self
+
+        def predict_progress(self, batch):
+            progress = batch[f"{ROBOMETER_FEATURE_PREFIX}input_ids"].float()
+            return RobometerPrediction(progress=progress, success_probability=torch.zeros_like(progress))
+
+    class FakeEncoder:
+        def __init__(self, **_kwargs) -> None:
+            pass
+
+        def __call__(self, transition):
+            frames = transition[TransitionKey.OBSERVATION][image_key]
+            frame_ids = frames[:, :, 0, 0, 0]
+            return {
+                TransitionKey.OBSERVATION: {
+                    f"{ROBOMETER_FEATURE_PREFIX}input_ids": frame_ids,
+                }
+            }
+
+    class FakeDataset:
+        def __init__(self, _repo_id: str, *, download_videos: bool) -> None:  # noqa: ARG002
+            self.root = tmp_path
+            self.num_episodes = 1
+            self.num_frames = 3
+            self.meta = SimpleNamespace(
+                episodes=[{"dataset_from_index": 0, "dataset_to_index": self.num_frames}]
+            )
+
+        def __getitem__(self, index: int):
+            return {
+                image_key: torch.full((3, 2, 2), float(index)),
+                "task": "pick up the cube",
+            }
+
+    monkeypatch.setattr(compute_rabc_weights, "RobometerConfig", FakeConfig)
+    monkeypatch.setattr(compute_rabc_weights, "RobometerRewardModel", FakeModel)
+    monkeypatch.setattr(compute_rabc_weights, "RobometerEncoderProcessorStep", FakeEncoder)
+    monkeypatch.setattr(compute_rabc_weights, "LeRobotDataset", FakeDataset)
+
+    output_path = compute_rabc_weights.compute_robometer_progress(
+        dataset_repo_id="local/test",
+        reward_model_path="local/robometer",
+        output_path=str(tmp_path / "robometer_progress.parquet"),
+        device="cpu",
+        batch_size=2,
+        num_subsampled_frames=2,
+    )
+
+    table = pq.read_table(output_path)
+    assert table.schema.names == ["index", "episode_index", "frame_index", "progress_sparse"]
+    assert table.schema.field("index").type == pa.int64()
+    assert table.schema.field("episode_index").type == pa.int64()
+    assert table.schema.field("frame_index").type == pa.int64()
+    assert table.schema.field("progress_sparse").type == pa.float32()
+    assert table.schema.metadata == {b"reward_model_path": b"local/robometer"}
+    assert table.column("progress_sparse").to_pylist() == [0.0, 1.0, 2.0]

--- a/tests/rewards/test_compute_sarm_progress.py
+++ b/tests/rewards/test_compute_sarm_progress.py
@@ -1,0 +1,111 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Characterization tests for SARM's legacy progress artifact."""
+
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import pytest
+import torch
+
+from lerobot.rewards.sarm import SARMPrediction
+
+
+def test_compute_sarm_progress_preserves_legacy_parquet_artifact(monkeypatch, tmp_path: Path) -> None:
+    import importlib
+    import sys
+
+    pa = pytest.importorskip("pyarrow")
+    pq = pytest.importorskip("pyarrow.parquet")
+
+    # The legacy script keeps visualization helpers in the scoring module.
+    # This artifact test does not exercise them, so avoid requiring the
+    # optional matplotlib dependency just to import the scoring boundary.
+    matplotlib = ModuleType("matplotlib")
+    matplotlib.__path__ = []  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "matplotlib", matplotlib)
+    monkeypatch.setitem(sys.modules, "matplotlib.gridspec", ModuleType("matplotlib.gridspec"))
+    monkeypatch.setitem(sys.modules, "matplotlib.pyplot", ModuleType("matplotlib.pyplot"))
+    compute_rabc_weights = importlib.import_module("lerobot.rewards.sarm.compute_rabc_weights")
+
+    image_key = "observation.images.top"
+
+    class FakeDataset:
+        root = tmp_path
+        num_episodes = 1
+        num_frames = 3
+        meta = SimpleNamespace(episodes=[{"dataset_from_index": 0, "dataset_to_index": num_frames}])
+
+        def __getitem__(self, index: int):
+            return {
+                image_key: torch.full((3, 2, 2), float(index)),
+                "task": "pick up the cube",
+            }
+
+    class FakeModel:
+        config = SimpleNamespace(
+            image_key=image_key,
+            state_key="observation.state",
+            frame_gap=30,
+            uses_dual_heads=False,
+            n_obs_steps=2,
+        )
+
+        def predict_progress(self, batch, *, head_mode: str):  # noqa: ARG002
+            progress = batch["video_features"][..., 0].float()
+            batch_size, seq_len = progress.shape
+            return SARMPrediction(
+                progress=progress,
+                stage_probabilities=torch.ones(batch_size, seq_len, 1),
+                stage_confidence=torch.ones(batch_size, seq_len),
+                valid_mask=torch.ones(batch_size, seq_len, dtype=torch.bool),
+            )
+
+    class FakePreprocessor:
+        steps: list = []
+
+        def eval(self):
+            return self
+
+        def __call__(self, batch):
+            query_index = float(batch["index"])
+            return {
+                "text_features": torch.zeros(1, 4),
+                "video_features": torch.full((1, 3, 4), query_index),
+                "lengths": torch.tensor([3], dtype=torch.int32),
+            }
+
+    monkeypatch.setattr(
+        compute_rabc_weights,
+        "load_sarm_resources",
+        lambda *_args, **_kwargs: (FakeDataset(), FakeModel(), FakePreprocessor()),
+    )
+
+    output_path = compute_rabc_weights.compute_sarm_progress(
+        dataset_repo_id="local/test",
+        reward_model_path="local/sarm",
+        output_path=str(tmp_path / "sarm_progress.parquet"),
+        device="cpu",
+        num_visualizations=0,
+    )
+
+    table = pq.read_table(output_path)
+    assert table.schema.names == ["index", "episode_index", "frame_index", "progress_sparse"]
+    assert table.schema.field("index").type == pa.int64()
+    assert table.schema.field("episode_index").type == pa.int64()
+    assert table.schema.field("frame_index").type == pa.int64()
+    assert table.schema.field("progress_sparse").type == pa.float32()
+    assert table.schema.metadata == {b"reward_model_path": b"local/sarm"}
+    assert table.column("progress_sparse").to_pylist() == [0.0, 1.0, 2.0]

--- a/tests/rewards/test_compute_topreward_progress.py
+++ b/tests/rewards/test_compute_topreward_progress.py
@@ -1,0 +1,134 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Characterization tests for TOPReward's legacy progress conversion."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+from lerobot.lerobot_types import TransitionKey
+from lerobot.rewards.topreward import compute_rabc_weights
+from lerobot.rewards.topreward.compute_rabc_weights import (
+    _apply_legacy_success_threshold,
+    normalize_rewards,
+)
+
+
+def test_legacy_success_threshold_preserves_raw_log_probabilities_when_disabled():
+    values = torch.tensor([-2.0, -0.5])
+
+    result = _apply_legacy_success_threshold(values, float("-inf"))
+
+    assert result is values
+
+
+def test_legacy_success_threshold_preserves_binary_script_behavior():
+    values = torch.tensor([-2.0, -0.5, 0.0])
+
+    result = _apply_legacy_success_threshold(values, -1.0)
+
+    assert torch.equal(result, torch.tensor([0.0, 1.0, 1.0]))
+
+
+def test_normalize_rewards_preserves_constant_and_varying_episode_behavior():
+    np.testing.assert_array_equal(normalize_rewards([0.0, 0.0]), np.ones(2, dtype=np.float32))
+    np.testing.assert_allclose(
+        normalize_rewards([-2.0, -1.0, 0.0]),
+        np.array([0.0, 0.5, 1.0], dtype=np.float32),
+    )
+
+
+def test_compute_topreward_progress_preserves_legacy_parquet_artifact(monkeypatch, tmp_path: Path) -> None:
+    pa = pytest.importorskip("pyarrow")
+    pq = pytest.importorskip("pyarrow.parquet")
+
+    image_key = "observation.images.top"
+
+    class FakeConfig:
+        def __init__(self, **kwargs) -> None:
+            self.device = kwargs["device"]
+            self.vlm_name = kwargs.get("vlm_name", "fake/vlm")
+            self.image_key = image_key
+            self.task_key = "task"
+            self.default_task = None
+            self.fps = 2.0
+            self.prompt_prefix = "prefix"
+            self.prompt_suffix_template = "{instruction}"
+            self.add_chat_template = False
+            self.max_input_length = 128
+            self.success_threshold = float("-inf")
+
+    class FakeModel:
+        def __init__(self, config: FakeConfig) -> None:
+            self.config = config
+
+        def to(self, _device: str):
+            return self
+
+        def eval(self):
+            return self
+
+        def compute_log_probability(self, batch):
+            return batch["prefix_length"].float()
+
+    class FakeEncoder:
+        def __init__(self, **_kwargs) -> None:
+            pass
+
+        def __call__(self, transition):
+            frames = transition[TransitionKey.OBSERVATION][image_key]
+            return {
+                TransitionKey.OBSERVATION: {
+                    "prefix_length": torch.tensor([frames.shape[1]], dtype=torch.float32),
+                }
+            }
+
+    class FakeDataset:
+        def __init__(self, _repo_id: str, *, download_videos: bool) -> None:  # noqa: ARG002
+            self.root = tmp_path
+            self.num_episodes = 1
+            self.num_frames = 3
+            self.meta = SimpleNamespace(
+                episodes=[{"dataset_from_index": 0, "dataset_to_index": self.num_frames}]
+            )
+
+        def __getitem__(self, index: int):
+            return {
+                image_key: torch.full((3, 2, 2), float(index)),
+                "task": "pick up the cube",
+            }
+
+    monkeypatch.setattr(compute_rabc_weights, "TOPRewardConfig", FakeConfig)
+    monkeypatch.setattr(compute_rabc_weights, "TOPRewardModel", FakeModel)
+    monkeypatch.setattr(compute_rabc_weights, "TOPRewardEncoderProcessorStep", FakeEncoder)
+    monkeypatch.setattr(compute_rabc_weights, "LeRobotDataset", FakeDataset)
+
+    output_path = compute_rabc_weights.compute_topreward_progress(
+        dataset_repo_id="local/test",
+        output_path=str(tmp_path / "topreward_progress.parquet"),
+        device="cpu",
+    )
+
+    table = pq.read_table(output_path)
+    assert table.schema.names == ["index", "episode_index", "frame_index", "progress_sparse"]
+    assert table.schema.field("index").type == pa.int64()
+    assert table.schema.field("episode_index").type == pa.int64()
+    assert table.schema.field("frame_index").type == pa.int64()
+    assert table.schema.field("progress_sparse").type == pa.float32()
+    assert table.schema.metadata == {b"vlm_name": b"fake/vlm"}
+    assert table.column("progress_sparse").to_pylist() == [0.0, 0.5, 1.0]

--- a/tests/rewards/test_modeling_classifier.py
+++ b/tests/rewards/test_modeling_classifier.py
@@ -74,6 +74,11 @@ def test_binary_classifier_with_default_params():
     assert output.hidden_states.shape == torch.Size([batch_size, 256])
     assert not torch.isnan(output.hidden_states).any(), "Tensor contains NaN values"
 
+    rewards = classifier.predict_reward(input, threshold=0.5)
+    assert rewards.shape == torch.Size([batch_size])
+    assert set(rewards.tolist()).issubset({0.0, 1.0})
+    assert not hasattr(classifier, "compute_reward")
+
 
 @skip_if_package_missing("transformers")
 def test_multiclass_classifier():
@@ -112,6 +117,10 @@ def test_multiclass_classifier():
     assert not torch.isnan(output.probabilities).any(), "Tensor contains NaN values"
     assert output.hidden_states.shape == torch.Size([batch_size, 256])
     assert not torch.isnan(output.hidden_states).any(), "Tensor contains NaN values"
+
+    rewards = classifier.predict_reward(input)
+    assert rewards.shape == torch.Size([batch_size])
+    assert rewards.dtype == torch.int64
 
 
 @skip_if_package_missing("transformers")

--- a/tests/rewards/test_modeling_robometer.py
+++ b/tests/rewards/test_modeling_robometer.py
@@ -27,8 +27,8 @@ from lerobot.rewards.robometer import RobometerConfig
 from lerobot.rewards.robometer.configuration_robometer import ROBOMETER_SPECIAL_TOKENS
 from lerobot.rewards.robometer.modeling_robometer import (
     ROBOMETER_FEATURE_PREFIX,
+    RobometerPrediction,
     convert_bins_to_continuous,
-    decode_progress_outputs,
 )
 from tests.utils import skip_if_package_missing
 
@@ -164,7 +164,7 @@ def _patch_build(monkeypatch) -> None:
 
 
 def _make_batch(features: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
-    """Build a `compute_reward`-ready batch using Robometer's namespaced keys."""
+    """Build a ``predict_progress`` input using Robometer's namespaced keys."""
     return {f"{ROBOMETER_FEATURE_PREFIX}{key}": value for key, value in features.items()}
 
 
@@ -192,31 +192,6 @@ def test_convert_bins_to_continuous_returns_expected_values():
     assert torch.allclose(values, torch.tensor([0.0, 1.0]), atol=1e-3)
 
 
-def test_decode_progress_outputs_returns_last_frame_values():
-    progress = torch.tensor([[0.1, 0.9], [0.4, 0.6]])
-    success_logits = torch.tensor([[0.0, 5.0], [0.0, -5.0]])
-
-    outputs = decode_progress_outputs(progress, success_logits, is_discrete_mode=False)
-
-    assert outputs["progress_pred"] == [pytest.approx([0.1, 0.9]), pytest.approx([0.4, 0.6])]
-    assert outputs["success_probs"][0][-1] == pytest.approx(torch.sigmoid(torch.tensor(5.0)).item(), abs=1e-3)
-    assert outputs["success_probs"][1][-1] == pytest.approx(
-        torch.sigmoid(torch.tensor(-5.0)).item(), abs=1e-3
-    )
-
-
-def test_decode_progress_outputs_discrete_mode_softmaxes_over_bins():
-    # 2 frames, peaks at bin 0 and bin 9 → continuous predictions 0.0 and 1.0
-    bin_logits = torch.full((1, 2, 10), -10.0)
-    bin_logits[0, 0, 0] = 10.0
-    bin_logits[0, 1, -1] = 10.0
-
-    outputs = decode_progress_outputs(bin_logits, success_logits=None, is_discrete_mode=True)
-
-    assert outputs["success_probs"] == []
-    assert outputs["progress_pred"][0] == pytest.approx([0.0, 1.0], abs=1e-3)
-
-
 @skip_if_package_missing("transformers")
 def test_robometer_post_init_overwrites_vocab_size_with_tokenizer_length(monkeypatch):
     """``RobometerConfig.__post_init__`` must overwrite the backbone's stale
@@ -232,49 +207,120 @@ def test_robometer_post_init_overwrites_vocab_size_with_tokenizer_length(monkeyp
 
 
 @skip_if_package_missing("transformers")
-def test_robometer_compute_reward_reads_pre_encoded_inputs(monkeypatch):
+def test_robometer_predict_progress_returns_typed_frame_signals(monkeypatch):
     from lerobot.rewards.robometer.modeling_robometer import RobometerRewardModel
 
-    progress = torch.tensor([[0.1, 0.9], [0.4, 0.6]])
+    progress = torch.tensor([[-0.1, 1.2], [0.4, 0.6]], dtype=torch.float16)
     success_logits = torch.tensor([[0.0, 5.0], [0.0, -5.0]])
-    _patch_build(monkeypatch)
-
-    cfg = RobometerConfig(device="cpu", reward_output="progress", progress_loss_type="l2")
-    model = RobometerRewardModel(cfg)
-    # Bypass the Qwen3-VL forward + head extraction with deterministic logits.
-    monkeypatch.setattr(model, "_compute_rbm_logits", lambda _inputs: (progress, success_logits))
-
-    batch = _make_batch({"input_ids": torch.zeros(2, 2, dtype=torch.long)})
-    rewards = model.compute_reward(batch)
-
-    assert torch.allclose(rewards, torch.tensor([0.9, 0.6]))
-
-
-@skip_if_package_missing("transformers")
-def test_robometer_compute_reward_can_return_binary_success(monkeypatch):
-    from lerobot.rewards.robometer.modeling_robometer import RobometerRewardModel
-
-    progress = torch.tensor([[0.1, 0.9], [0.4, 0.6]])
-    success_logits = torch.tensor([[0.0, 5.0], [0.0, -5.0]])  # sigmoid(5) > 0.5; sigmoid(-5) < 0.5
     _patch_build(monkeypatch)
 
     cfg = RobometerConfig(
         device="cpu",
         reward_output="success",
-        success_threshold=0.5,
+        success_threshold=0.99,
         progress_loss_type="l2",
     )
     model = RobometerRewardModel(cfg)
+    # Bypass the Qwen3-VL forward + head extraction with deterministic logits.
     monkeypatch.setattr(model, "_compute_rbm_logits", lambda _inputs: (progress, success_logits))
 
     batch = _make_batch({"input_ids": torch.zeros(2, 2, dtype=torch.long)})
-    rewards = model.compute_reward(batch)
+    prediction = model.predict_progress(batch)
 
-    assert torch.equal(rewards, torch.tensor([1.0, 0.0]))
+    assert isinstance(prediction, RobometerPrediction)
+    assert prediction.progress.shape == (2, 2)
+    assert prediction.success_probability.shape == (2, 2)
+    assert prediction.progress.dtype == torch.float32
+    assert prediction.success_probability.dtype == torch.float32
+    assert prediction.progress.device == next(model.model.parameters()).device
+    assert torch.allclose(
+        prediction.progress,
+        torch.tensor([[0.0, 1.0], [0.4, 0.6]]),
+        atol=2e-4,
+    )
+    assert torch.allclose(prediction.success_probability, torch.sigmoid(success_logits))
 
 
 @skip_if_package_missing("transformers")
-def test_robometer_compute_reward_errors_when_inputs_missing(monkeypatch):
+def test_robometer_predict_progress_decodes_discrete_logits(monkeypatch):
+    from lerobot.rewards.robometer.modeling_robometer import RobometerRewardModel
+
+    progress_logits = torch.full((1, 2, 10), -10.0)
+    progress_logits[0, 0, 0] = 10.0
+    progress_logits[0, 1, -1] = 10.0
+    success_logits = torch.zeros(1, 2)
+    _patch_build(monkeypatch)
+
+    cfg = RobometerConfig(device="cpu", progress_loss_type="discrete")
+    model = RobometerRewardModel(cfg)
+    monkeypatch.setattr(
+        model,
+        "_compute_rbm_logits",
+        lambda _inputs: (progress_logits, success_logits),
+    )
+
+    prediction = model.predict_progress(_make_batch({"input_ids": torch.zeros(1, 2, dtype=torch.long)}))
+
+    assert torch.allclose(prediction.progress, torch.tensor([[0.0, 1.0]]), atol=1e-3)
+
+
+@skip_if_package_missing("transformers")
+def test_robometer_predict_progress_ignores_legacy_scalar_selection_config(monkeypatch):
+    from lerobot.rewards.robometer.modeling_robometer import RobometerRewardModel
+
+    progress = torch.tensor([[0.2, 0.8]])
+    success_logits = torch.tensor([[-2.0, 2.0]])
+    _patch_build(monkeypatch)
+
+    predictions = []
+    for reward_output, threshold in [("progress", 0.1), ("success", 0.9)]:
+        model = RobometerRewardModel(
+            RobometerConfig(
+                device="cpu",
+                reward_output=reward_output,
+                success_threshold=threshold,
+                progress_loss_type="l2",
+            )
+        )
+        monkeypatch.setattr(
+            model,
+            "_compute_rbm_logits",
+            lambda _inputs: (progress, success_logits),
+        )
+        predictions.append(
+            model.predict_progress(_make_batch({"input_ids": torch.zeros(1, 2, dtype=torch.long)}))
+        )
+
+    assert torch.equal(predictions[0].progress, predictions[1].progress)
+    assert torch.equal(predictions[0].success_probability, predictions[1].success_probability)
+
+
+@skip_if_package_missing("transformers")
+def test_robometer_predict_progress_does_not_mutate_input(monkeypatch):
+    from lerobot.rewards.robometer.modeling_robometer import RobometerRewardModel
+
+    _patch_build(monkeypatch)
+    model = RobometerRewardModel(RobometerConfig(device="cpu", progress_loss_type="l2"))
+
+    def fake_compute(inputs):
+        inputs.pop("prog_token_id")
+        return torch.zeros(1, 1), torch.zeros(1, 1)
+
+    monkeypatch.setattr(model, "_compute_rbm_logits", fake_compute)
+    batch = _make_batch(
+        {
+            "input_ids": torch.zeros(1, 1, dtype=torch.long),
+            "prog_token_id": torch.tensor(42),
+        }
+    )
+
+    model.predict_progress(batch)
+
+    assert f"{ROBOMETER_FEATURE_PREFIX}prog_token_id" in batch
+
+
+@skip_if_package_missing("transformers")
+def test_robometer_predict_progress_errors_when_inputs_missing(monkeypatch):
     from lerobot.rewards.robometer.modeling_robometer import RobometerRewardModel
 
     _patch_build(monkeypatch)
@@ -283,7 +329,7 @@ def test_robometer_compute_reward_errors_when_inputs_missing(monkeypatch):
     model = RobometerRewardModel(cfg)
 
     with pytest.raises(KeyError, match=r"observation\.robometer\.input_ids"):
-        model.compute_reward({})
+        model.predict_progress({})
 
 
 @skip_if_package_missing("transformers")
@@ -331,10 +377,30 @@ def test_robometer_save_pretrained_roundtrips(monkeypatch, tmp_path):
     reloaded_cfg = RewardModelConfig.from_pretrained(str(tmp_path))
     assert isinstance(reloaded_cfg, RobometerConfig)
     reloaded_cfg.pretrained_path = str(tmp_path)  # mimic lerobot-train's `validate()`
-    reloaded = RobometerRewardModel.from_pretrained(str(tmp_path), config=reloaded_cfg)
+    reloaded = RobometerRewardModel.from_pretrained(str(tmp_path), config=reloaded_cfg, strict=True)
 
     assert reloaded.config.image_key == "observation.images.cam_top"
     assert reloaded.config.task_key == "task"
     assert reloaded.config.reward_output == "success"
     assert reloaded.config.success_threshold == 0.7
     assert reloaded.config.progress_loss_type == "l2"  # came back from config.json
+
+    # A successful load must restore values, not merely recreate keys. Compare
+    # both every parameter and a public prediction so ``strict=False`` cannot
+    # hide a silently skipped head.
+    original_state = model.state_dict()
+    reloaded_state = reloaded.state_dict()
+    assert original_state.keys() == reloaded_state.keys()
+    for key in original_state:
+        assert torch.equal(original_state[key], reloaded_state[key]), key
+
+    batch = _make_batch(
+        {
+            "input_ids": torch.tensor([[1, 99, 1, 99]]),
+            "prog_token_id": torch.tensor(99),
+        }
+    )
+    expected = model.predict_progress(batch)
+    actual = reloaded.predict_progress(batch)
+    assert torch.equal(actual.progress, expected.progress)
+    assert torch.equal(actual.success_probability, expected.success_probability)

--- a/tests/rewards/test_modeling_sarm.py
+++ b/tests/rewards/test_modeling_sarm.py
@@ -1,0 +1,219 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for SARM's typed progress capability."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+
+from lerobot.rewards.sarm import SARMConfig, SARMPrediction, SARMRewardModel
+
+
+class _FakeStageModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.anchor = torch.nn.Parameter(torch.zeros(()))
+
+    def forward(self, img_seq, lang_emb, state, lengths, *, scheme):  # noqa: ARG002
+        batch_size, _, seq_len, _ = img_seq.shape
+        num_classes = 2 if scheme == "sparse" else 3
+        logits = torch.zeros(batch_size, seq_len, num_classes, device=img_seq.device)
+        logits[..., 0] = 2.0
+        return logits
+
+
+class _FakeSubtaskModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.anchor = torch.nn.Parameter(torch.zeros(()))
+
+    def forward(self, img_seq, lang_emb, state, lengths, stage_prior, *, scheme):  # noqa: ARG002
+        batch_size, _, seq_len, _ = img_seq.shape
+        return torch.linspace(0.1, 0.9, seq_len, device=img_seq.device).expand(batch_size, -1)
+
+
+def _make_model(*, annotation_mode: str = "dual") -> SARMRewardModel:
+    config = SARMConfig(
+        annotation_mode=annotation_mode,
+        n_obs_steps=2,
+        max_rewind_steps=1,
+        image_dim=4,
+        text_dim=4,
+        hidden_dim=8,
+        num_heads=2,
+        num_layers=1,
+        max_state_dim=3,
+        dropout=0.0,
+        num_sparse_stages=2,
+        sparse_subtask_names=["approach", "grasp"],
+        sparse_temporal_proportions=[0.4, 0.6],
+        num_dense_stages=3,
+        dense_subtask_names=["approach", "grasp", "place"],
+        dense_temporal_proportions=[0.2, 0.3, 0.5],
+        device="cpu",
+    )
+    model = SARMRewardModel(config)
+    model.stage_model = _FakeStageModel()
+    model.subtask_model = _FakeSubtaskModel()
+    return model
+
+
+def _make_batch(batch_size: int = 2, seq_len: int = 4) -> dict[str, torch.Tensor]:
+    return {
+        "text_features": torch.zeros(batch_size, 4),
+        "video_features": torch.zeros(batch_size, seq_len, 4),
+        "state_features": torch.zeros(batch_size, seq_len, 3),
+        "lengths": torch.full((batch_size,), seq_len, dtype=torch.int32),
+    }
+
+
+@pytest.mark.parametrize(("head_mode", "num_stages"), [("sparse", 2), ("dense", 3)])
+def test_sarm_predict_progress_returns_typed_frame_signals(head_mode: str, num_stages: int):
+    model = _make_model()
+    batch = _make_batch()
+
+    prediction = model.predict_progress(batch, head_mode=head_mode)
+
+    assert isinstance(prediction, SARMPrediction)
+    assert prediction.progress.shape == (2, 4)
+    assert prediction.stage_probabilities.shape == (2, 4, num_stages)
+    assert prediction.stage_confidence.shape == (2, 4)
+    assert prediction.valid_mask.shape == (2, 4)
+    assert prediction.progress.dtype == torch.float32
+    assert prediction.stage_probabilities.dtype == torch.float32
+    assert prediction.stage_confidence.dtype == torch.float32
+    assert prediction.valid_mask.dtype == torch.bool
+    assert prediction.progress.device == model.device
+    assert prediction.valid_mask.device == model.device
+    assert prediction.valid_mask.all()
+    assert torch.all((prediction.progress >= 0.0) & (prediction.progress <= 1.0))
+
+
+def test_sarm_predict_progress_marks_padded_frames_invalid():
+    model = _make_model()
+    batch = _make_batch()
+    batch["lengths"] = torch.tensor([2, 4], dtype=torch.int32)
+
+    prediction = model.predict_progress(batch)
+
+    assert torch.equal(
+        prediction.valid_mask,
+        torch.tensor([[True, True, False, False], [True, True, True, True]]),
+    )
+
+
+@pytest.mark.parametrize(
+    "lengths",
+    [
+        torch.tensor([4]),
+        torch.tensor([0, 4]),
+        torch.tensor([5, 4]),
+    ],
+)
+def test_sarm_predict_progress_rejects_invalid_lengths(lengths: torch.Tensor):
+    model = _make_model()
+    batch = _make_batch()
+    batch["lengths"] = lengths
+
+    with pytest.raises(ValueError, match="lengths"):
+        model.predict_progress(batch)
+
+
+def test_sarm_calculate_rewards_preserves_numpy_compatibility():
+    model = _make_model()
+    batch = _make_batch()
+    prediction = model.predict_progress(batch, head_mode="sparse")
+
+    progress, stage_probabilities, confidence = model.calculate_rewards(
+        text_embeddings=batch["text_features"],
+        video_embeddings=batch["video_features"],
+        state_features=batch["state_features"],
+        lengths=batch["lengths"],
+        return_all_frames=True,
+        return_stages=True,
+        return_confidence=True,
+        head_mode="sparse",
+    )
+
+    np.testing.assert_allclose(progress, prediction.progress.numpy())
+    np.testing.assert_allclose(stage_probabilities, prediction.stage_probabilities.numpy())
+    np.testing.assert_allclose(confidence, prediction.stage_confidence.numpy())
+
+
+def test_sarm_calculate_rewards_preserves_unbatched_default_frame_behavior():
+    model = _make_model()
+    batch = _make_batch(batch_size=1)
+    prediction = model.predict_progress(
+        {
+            "text_features": batch["text_features"][0],
+            "video_features": batch["video_features"][0],
+            "state_features": batch["state_features"][0],
+        }
+    )
+
+    progress = model.calculate_rewards(
+        text_embeddings=batch["text_features"][0],
+        video_embeddings=batch["video_features"][0],
+        state_features=batch["state_features"][0],
+        head_mode=None,
+    )
+
+    assert isinstance(progress, np.floating)
+    assert progress == pytest.approx(prediction.progress[0, model.config.n_obs_steps].item())
+
+
+def test_sarm_predict_progress_uses_parameter_device_without_changing_mode():
+    model = _make_model()
+    model.train()
+    model.device = torch.device("meta")
+    batch = _make_batch()
+    batch.pop("state_features")
+    batch.pop("lengths")
+
+    prediction = model.predict_progress(batch)
+
+    assert prediction.progress.device.type == "cpu"
+    assert model.training is True
+
+
+def test_sarm_prediction_can_feed_a_differentiable_consumer():
+    model = _make_model()
+    prediction = model.predict_progress(_make_batch())
+    consumer = torch.nn.Linear(prediction.progress.shape[-1], 1)
+
+    loss = consumer(prediction.progress).sum()
+    loss.backward()
+
+    assert prediction.progress.requires_grad is False
+    assert consumer.weight.grad is not None
+    assert consumer.bias.grad is not None
+
+
+def test_sarm_predict_progress_requires_processor_features():
+    model = _make_model()
+
+    with pytest.raises(KeyError, match="text_features"):
+        model.predict_progress({"video_features": torch.zeros(1, 4, 4)})
+    with pytest.raises(KeyError, match="video_features"):
+        model.predict_progress({"text_features": torch.zeros(1, 4)})
+
+
+def test_sarm_predict_progress_rejects_unavailable_dense_head():
+    model = _make_model(annotation_mode="single_stage")
+
+    with pytest.raises(ValueError, match="dense predictions require"):
+        model.predict_progress(_make_batch(), head_mode="dense")

--- a/tests/rewards/test_modeling_topreward.py
+++ b/tests/rewards/test_modeling_topreward.py
@@ -32,7 +32,7 @@ class _FakeQwenModel(torch.nn.Module):
     """Stand-in for ``Qwen3VLForConditionalGeneration``.
 
     Returns a ``SimpleNamespace`` with ``logits`` of a controlled shape so
-    the log-prob extraction path in ``compute_reward`` can be exercised
+    the log-prob extraction path in ``compute_log_probability`` can be exercised
     without downloading real VLM weights.
     """
 
@@ -79,7 +79,7 @@ def _make_batch(
     *,
     omit: str | None = None,
 ) -> dict[str, torch.Tensor]:
-    """Build a ``compute_reward``-ready batch using TOPReward's namespaced keys."""
+    """Build a ``compute_log_probability`` input using TOPReward's namespaced keys."""
     batch_size, seq_len = input_ids.shape
     if attention_mask is None:
         attention_mask = torch.ones(batch_size, seq_len, dtype=torch.long)
@@ -146,14 +146,13 @@ def test_topreward_config_rejects_suffix_without_instruction_placeholder():
 
 
 # ---------------------------------------------------------------------------
-# compute_reward
+# compute_log_probability
 # ---------------------------------------------------------------------------
 
 
 @skip_if_package_missing("transformers")
-def test_topreward_compute_reward_returns_one_scalar_per_sample(monkeypatch):
-    """``compute_reward`` must return a ``(B,)`` float32 tensor with one
-    log-prob reward per sample, consuming pre-encoded Qwen-VL tensors."""
+def test_topreward_compute_log_probability_returns_one_scalar_per_sample(monkeypatch):
+    """The native API returns one float32 log-probability per sample."""
     from lerobot.rewards.topreward.modeling_topreward import TOPRewardModel
 
     _patch_build(monkeypatch)
@@ -165,15 +164,15 @@ def test_topreward_compute_reward_returns_one_scalar_per_sample(monkeypatch):
     labels = _terminal_labels(input_ids)
 
     batch = _make_batch(input_ids, attention_mask, labels)
-    rewards = model.compute_reward(batch)
+    rewards = model.compute_log_probability(batch)
 
     assert rewards.shape == (2,)
     assert rewards.dtype == torch.float32
 
 
 @skip_if_package_missing("transformers")
-def test_topreward_compute_reward_applies_success_threshold(monkeypatch):
-    """When ``success_threshold`` is finite, the model returns binary success."""
+def test_topreward_compute_log_probability_ignores_legacy_success_threshold(monkeypatch):
+    """Serialized threshold metadata must not alter the raw model quantity."""
     from lerobot.rewards.topreward.modeling_topreward import TOPRewardModel
 
     _patch_build(monkeypatch)
@@ -185,14 +184,15 @@ def test_topreward_compute_reward_applies_success_threshold(monkeypatch):
     labels = _terminal_labels(input_ids)
 
     batch = _make_batch(input_ids, attention_mask, labels)
-    rewards = model.compute_reward(batch)
+    rewards = model.compute_log_probability(batch)
 
     assert rewards.shape == (2,)
-    assert set(rewards.tolist()).issubset({0.0, 1.0})
+    assert torch.all(rewards <= 0.0)
+    assert not set(rewards.tolist()).issubset({0.0, 1.0})
 
 
 @skip_if_package_missing("transformers")
-def test_topreward_compute_reward_errors_when_inputs_missing(monkeypatch):
+def test_topreward_compute_log_probability_errors_when_inputs_missing(monkeypatch):
     from lerobot.rewards.topreward.modeling_topreward import TOPRewardModel
 
     _patch_build(monkeypatch)
@@ -200,11 +200,11 @@ def test_topreward_compute_reward_errors_when_inputs_missing(monkeypatch):
     model = TOPRewardModel(cfg)
 
     with pytest.raises(KeyError, match=r"observation\.topreward\.input_ids"):
-        model.compute_reward(_make_batch(torch.randint(0, 100, (1, 10)), omit="input_ids"))
+        model.compute_log_probability(_make_batch(torch.randint(0, 100, (1, 10)), omit="input_ids"))
 
 
 @skip_if_package_missing("transformers")
-def test_topreward_compute_reward_errors_when_labels_missing(monkeypatch):
+def test_topreward_compute_log_probability_errors_when_labels_missing(monkeypatch):
     from lerobot.rewards.topreward.modeling_topreward import TOPRewardModel
 
     _patch_build(monkeypatch)
@@ -213,11 +213,11 @@ def test_topreward_compute_reward_errors_when_labels_missing(monkeypatch):
 
     input_ids = torch.randint(0, 100, (1, 10))
     with pytest.raises(KeyError, match=r"observation\.topreward\.labels"):
-        model.compute_reward(_make_batch(input_ids, labels=None))
+        model.compute_log_probability(_make_batch(input_ids, labels=None))
 
 
 @skip_if_package_missing("transformers")
-def test_topreward_compute_reward_requires_all_encoder_keys(monkeypatch):
+def test_topreward_compute_log_probability_requires_all_encoder_keys(monkeypatch):
     from lerobot.rewards.topreward.modeling_topreward import TOPRewardModel
 
     _patch_build(monkeypatch)
@@ -230,7 +230,7 @@ def test_topreward_compute_reward_requires_all_encoder_keys(monkeypatch):
 
     for key in required_encoder_keys:
         with pytest.raises(KeyError, match=rf"observation\.topreward\.{key}"):
-            model.compute_reward(_make_batch(input_ids, labels=labels, omit=key))
+            model.compute_log_probability(_make_batch(input_ids, labels=labels, omit=key))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/rewards/test_reward_model_base.py
+++ b/tests/rewards/test_reward_model_base.py
@@ -43,9 +43,6 @@ class _DummyHubReward(PreTrainedRewardModel):
         super().__init__(config)
         self.bias = torch.nn.Parameter(torch.zeros(1))
 
-    def compute_reward(self, batch):
-        return self.bias.expand(1)
-
 
 def test_reward_model_config_registry():
     """Verify that classifier and sarm are registered."""
@@ -80,15 +77,16 @@ def test_factory_unknown_raises():
         get_reward_model_class("nonexistent_reward_model")
 
 
+def test_pretrained_reward_model_has_no_universal_inference_method():
+    assert not hasattr(PreTrainedRewardModel, "compute_reward")
+
+
 def test_pretrained_reward_model_requires_config_class():
     """Subclass without config_class should fail."""
     with pytest.raises(TypeError, match="must define 'config_class'"):
 
         class BadModel(PreTrainedRewardModel):
             name = "bad"
-
-            def compute_reward(self, batch):
-                pass
 
 
 def test_pretrained_reward_model_requires_name():
@@ -97,9 +95,6 @@ def test_pretrained_reward_model_requires_name():
 
         class BadModel(PreTrainedRewardModel):
             config_class = RewardModelConfig
-
-            def compute_reward(self, batch):
-                pass
 
 
 def test_non_trainable_forward_raises():
@@ -117,9 +112,6 @@ def test_non_trainable_forward_raises():
         config_class = DummyConfig
         name = "dummy_test"
 
-        def compute_reward(self, batch):
-            return torch.zeros(1)
-
     config = DummyConfig()
     model = DummyReward(config)
 
@@ -136,7 +128,7 @@ def test_non_trainable_forward_raises():
 
 
 def test_is_trainable_false_when_forward_not_overridden():
-    """A reward model that only implements ``compute_reward`` is zero-shot."""
+    """A reward model that does not override ``forward`` is zero-shot."""
     model, _ = _make_dummy_reward_model()
     assert model.is_trainable is False
 
@@ -386,6 +378,18 @@ def test_reward_model_generate_model_card_uses_default_license(_offline_model_ca
     card = generate_model_card(model.config, cfg=_make_train_cfg("user/my_dataset"))
 
     assert card.data.license == "apache-2.0"
+
+
+def test_inference_only_reward_model_card_does_not_advertise_training(_offline_model_card):
+    from lerobot.rewards.topreward.configuration_topreward import TOPRewardConfig
+
+    card = generate_model_card(TOPRewardConfig(), cfg=_make_train_cfg("user/my_dataset"))
+    body = str(card)
+
+    assert "inference-only reward-model integration" in body
+    assert "Training this model through `lerobot-train` is not currently supported" in body
+    assert "### Train from scratch" not in body
+    assert "compute_log_probability" in body
 
 
 def test_publish_trained_model_uploads_expected_reward_files(monkeypatch, _offline_model_card):

--- a/tests/rewards/test_topreward.py
+++ b/tests/rewards/test_topreward.py
@@ -52,7 +52,7 @@ def _make_dummy_topreward_batch(image_key: str, task_key: str) -> dict[str, obje
 
 
 @require_cuda
-def test_topreward_full_qwen3vl_preprocessor_to_compute_reward():
+def test_topreward_full_qwen3vl_preprocessor_to_compute_log_probability():
     cfg = TOPRewardConfig(
         vlm_name="Qwen/Qwen3-VL-8B-Instruct",
         device="cuda",
@@ -70,7 +70,7 @@ def test_topreward_full_qwen3vl_preprocessor_to_compute_reward():
     try:
         model.to(cfg.device)
         model.eval()
-        rewards = model.compute_reward(encoded_batch)
+        rewards = model.compute_log_probability(encoded_batch)
     finally:
         del model
         torch.cuda.empty_cache()


### PR DESCRIPTION
## Title

refactor(rewards): expose typed semantic prediction APIs

## Summary / Motivation

Refactor reward-model inference around semantic, model-native capabilities instead of one universal `compute_reward` API. `RoboMeter` and `SARM` expose typed progress predictions, while `TOPReward` exposes target-token log probability. Frame selection, thresholding, and conversion into downstream rewards now belong to consumers, making the APIs reusable for offline scoring, annotation, filtering, and future online RL adapters without losing each model's native semantics.

## Related issues

- Fixes / Closes: None
- Related: None

## What changed

- Add `ProgressPrediction` and the structural `ProgressPredictor` protocol.
- Add `RoboMeter.predict_progress()`, returning frame-aligned progress and success probability.
- Add `SARM.predict_progress()`, returning progress, stage signals, and a validity mask.
- Add `TOPReward.compute_log_probability()`, returning the native target-token log probability.
- Keep the classifier's semantic `predict()` API while removing the universal scalar `compute_reward()` requirement.
- Move frame selection, success thresholding, and output selection into callers.
- Migrate the `RoboMeter`, `SARM`, and `TOPReward` scoring consumers to the semantic APIs; these scripts produce signals consumed by `RA-BC`.
- Add input and shape validation at the model boundaries.
- Document the APIs and migration from legacy scalar helpers.
- Preserve SARM's `calculate_rewards()` as a compatibility wrapper over the new implementation.

Direct callers of the removed universal `compute_reward()` API must migrate to semantic methods and explicitly perform selection or thresholding. The classifier keeps `predict()`, while SARM keeps `calculate_rewards()` as a compatibility wrapper. Serialized compatibility fields such as RoboMeter's `reward_output` remain loadable but no longer change native predictions.

## How was this tested (or how to run locally)

- Added and updated tests covering RoboMeter, SARM, TOPReward, the classifier, and the reward-model base.
- Added consumer-level progress tests:
  - `tests/rewards/test_compute_robometer_progress.py`
  - `tests/rewards/test_compute_sarm_progress.py`
  - `tests/rewards/test_compute_topreward_progress.py`
- Ran:

  ```bash
  uv run pytest tests/rewards -q
  ```
Result: 170 passed, 6 skipped.

- Ran Ruff checks and formatting validation successfully.
- The planned original-RoboMeter checkpoint golden-parity test is intentionally out of scope for this PR.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated
- [x] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: # (insert PR number/link)

## Reviewer notes

- Please focus on numerical parity, tensor shapes, and the boundary between native model predictions and consumer policy.
- Thresholding and frame selection are explicit consumer decisions.
- Anyone in the community is free to review the PR.
