### PR TITLE
feat(rewards): integrate RynnValue with semantic dataset scoring

### DIFF
--- a/docs/source/_toctree.yml
+++ b/docs/source/_toctree.yml
@@ -93,6 +93,8 @@
     title: ROBOMETER
   - local: topreward
     title: TOPReward
+  - local: rynnvalue
+    title: RynnValue
   title: "Reward Models"
 - sections:
   - local: inference

--- a/docs/source/reward_scoring.mdx
+++ b/docs/source/reward_scoring.mdx
@@ -17,9 +17,9 @@ LeRobot's offline scoring workflow runs a reward model over dataset episodes and
              │ shared runner     │
              │ validate + resume │
              └─────────┬─────────┘
-                       │ atomic episode parts
+                       │ completed episode files (resume state)
                        ▼
-            reward_signals/robometer.parquet
+            reward_signals/<model-type>.parquet
               (versioned signal sidecar)
                        │
                        ▼
@@ -30,7 +30,7 @@ The model-specific scorer owns sampling, preprocessing, and conversion from nati
 
 ## Score a Dataset
 
-The scoring command currently supports RoboMeter:
+The scoring command currently supports RoboMeter and RynnValue. For RoboMeter:
 
 ```bash
 uv run lerobot-score-dataset \
@@ -41,7 +41,22 @@ uv run lerobot-score-dataset \
 
 By default, the sidecar is written to `reward_signals/robometer.parquet` under the local dataset root. Use `--output_path=/path/signals.parquet` to choose another location and `--episodes='[0,1]'` to select episodes.
 
-Pass `--push_to_hub=true` to upload the completed sidecar to `reward_signals/robometer.parquet` in the dataset repository. Atomic episode parts are local staging data: they remain available after an interrupted run and are removed after the final sidecar is published successfully.
+For RynnValue:
+
+```bash
+uv run lerobot-score-dataset \
+    --dataset_repo_id=lerobot/example-dataset \
+    --reward_model_path=/path/to/converted-rynnvalue \
+    --device=cuda \
+    --inference_fps=1 \
+    --max_frames=8 \
+    --robot_description="a single-arm robot" \
+    --camera_description="a fixed third-person camera"
+```
+
+Its default output is `reward_signals/rynnvalue.parquet`. Pass `--horizon_s=SECONDS` only when a task-level horizon is known and bounded progress is needed. Raw remaining time and potential are always retained.
+
+Pass `--push_to_hub=true` to upload the completed sidecar to `reward_signals/<model-type>.parquet` in the dataset repository. Completed episode files are local staging data: they remain available after an interrupted run and are removed after the final sidecar is published successfully.
 
 For an immutable run, pass commit hashes through `--dataset_revision` and `--reward_model_revision`. The requested revisions are stored in provenance and must match when resuming.
 
@@ -71,7 +86,7 @@ descriptors = get_signal_descriptors(table)
 provenance = get_scoring_provenance(table)
 ```
 
-Application code for RoboMeter should use `score_robometer_dataset()`. Scorer authors use `score_dataset(dataset, scorer, ...)`, and consumers use `read_frame_signals()`.
+Application code should use its model-specific entry point, such as `score_robometer_dataset()` or `score_rynnvalue_dataset()`. Scorer authors use `score_dataset(dataset, scorer, ...)`, and consumers use `read_frame_signals()`.
 
 A scorer returns one `FrameSignals` object per episode. Frame indices may be dense or sparse, but must be episode-local, unique, strictly increasing, and aligned with one-dimensional numeric signal arrays.
 

--- a/docs/source/rynnvalue.mdx
+++ b/docs/source/rynnvalue.mdx
@@ -1,6 +1,6 @@
 # RynnValue
 
-RynnValue is a language-conditioned robotic value model that predicts the remaining time, in seconds, until a task is completed. LeRobot converts that temporal distance into the higher-is-better potential used by the paper:
+RynnValue is a language-conditioned robotic value model that predicts the remaining time, in seconds, until a task is completed. The native LeRobot API preserves that temporal-distance meaning. Offline and online consumers may derive the higher-is-better potential used by the paper:
 
 ```text
 potential = -remaining_time
@@ -63,12 +63,15 @@ The released checkpoints have metadata prompting enabled. Provide at least one r
 
 When a trajectory contains more than `max_frames` frames, the processor uniformly samples the full history while retaining its first and last frames. The default is eight frames.
 
-`compute_reward()` returns one scalar per trajectory:
+`predict_remaining_time()` returns a typed prediction with one scalar per trajectory:
 
-- `reward_output="potential"` (default) returns `-v_end`, where `v_end` is the final queried frame's predicted remaining time.
-- `reward_output="remaining_time"` returns `v_end` directly for diagnostics.
+- `prediction.remaining_time_s` contains `v_end`, the final queried frame's predicted remaining time.
+- The tensor stays on the model device.
+- Potential, progress normalization, interpolation, and thresholding belong to workflow adapters.
 
 If a checkpoint has multiple absolute-value heads, LeRobot averages them before selecting the final frame.
+
+The legacy `reward_output` configuration key is accepted only so unpublished converted checkpoints still load. It does not change native prediction semantics.
 
 ## Usage
 
@@ -91,7 +94,8 @@ batch = {
     "task": "put the cube in the drawer",
 }
 encoded = preprocessor(batch)
-potential = model.compute_reward(encoded)
+prediction = model.predict_remaining_time(encoded)
+remaining_time_s = prediction.remaining_time_s
 ```
 
 Use `Alibaba-DAMO-Academy/RynnValue-8B` as the converter's `--source-model-id` to select the larger checkpoint. `--revision` can pin a Hub commit.
@@ -102,19 +106,61 @@ The converted `config.json` embeds the native architecture configuration, while 
 
 Subsequent calls to `save_pretrained()` refresh the embedded native configuration before writing the checkpoint. A LeRobot checkpoint is never reconstructed from the upstream `model_id`; older checkpoints without embedded `model_config` must be reconverted.
 
+## Original-checkpoint parity
+
+An opt-in GPU test compares the released implementation and the converted LeRobot checkpoint on identical deterministic frames. It loads the models sequentially to reduce peak memory:
+
+```bash
+LEROBOT_RYNNVALUE_ORIGINAL_CHECKPOINT=/path/to/original \
+LEROBOT_RYNNVALUE_CONVERTED_CHECKPOINT=/path/to/converted \
+uv run pytest tests/rewards/test_rynnvalue_original_parity.py -v
+```
+
+The original path is the only parity-only surface that uses its released remote model code. Normal LeRobot loading never uses `trust_remote_code`.
+
+## Offline dataset scoring
+
+Use the shared scoring command rather than a RynnValue-specific dataset script:
+
+```bash
+uv run lerobot-score-dataset \
+    --dataset_repo_id=lerobot/example-dataset \
+    --reward_model_path=outputs/rynnvalue-4b \
+    --device=cuda \
+    --batch_size=2 \
+    --inference_fps=1 \
+    --max_frames=8 \
+    --robot_description="a single-arm robot" \
+    --camera_description="a fixed third-person camera"
+```
+
+RynnValue runs on causal trajectory prefixes at the configured inference frequency. The adapter linearly interpolates between inference frames and writes:
+
+- `reward.rynnvalue.remaining_time_s`;
+- `reward.rynnvalue.potential`;
+- `reward.rynnvalue.is_inference_frame`.
+
+Pass `--horizon_s=SECONDS` to additionally write bounded `reward.rynnvalue.progress`:
+
+```text
+progress = clip(1 - remaining_time_s / horizon_s, 0, 1)
+```
+
+The horizon is explicit and stored in provenance; LeRobot never normalizes remaining time relative to the observed episode maximum.
+
 ## Reward shaping
 
-The scalar returned by LeRobot is the state potential, not a complete transition reward. Apply potential-based shaping in the RL loop:
+The potential derived from remaining time is a state potential, not a complete transition reward. Apply potential-based shaping in the RL loop:
 
 ```text
 r_shape = gamma * potential_next - potential
 ```
 
-The paper combines this term with a sparse task reward. LeRobot does not infer task termination or success from the language generation branch in `compute_reward()`.
+The paper combines this term with a sparse task reward. LeRobot does not infer task termination or success from the language generation branch in `predict_remaining_time()`.
 
 ## Limitations
 
 - Inference uses eager custom attention; Flash Attention and SDPA do not implement RynnValue's prediction-slot isolation.
 - The current API scores complete supplied histories and is not a streaming KV-cache reward server.
-- Natural-language video analysis, match, and success generation remain available in the native core model but are not used by `compute_reward()`.
+- Natural-language video analysis, match, and success generation remain available in the native core model but are not used by `predict_remaining_time()`.
 - Training RynnValue from scratch is outside this integration.

--- a/docs/source/rynnvalue.mdx
+++ b/docs/source/rynnvalue.mdx
@@ -1,0 +1,120 @@
+# RynnValue
+
+RynnValue is a language-conditioned robotic value model that predicts the remaining time, in seconds, until a task is completed. LeRobot converts that temporal distance into the higher-is-better potential used by the paper:
+
+```text
+potential = -remaining_time
+```
+
+**Paper**: [RynnValue: Scaling Robotic Value Foundation Models with Temporal Distance](https://arxiv.org/abs/2608.09853)
+**Original code**: [github.com/alibaba-damo-academy/RynnValue](https://github.com/alibaba-damo-academy/RynnValue)
+**Checkpoints**: [RynnValue-4B](https://huggingface.co/Alibaba-DAMO-Academy/RynnValue-4B), [RynnValue-8B](https://huggingface.co/Alibaba-DAMO-Academy/RynnValue-8B)
+
+## LeRobot integration
+
+The integration ports the released architecture into LeRobot rather than executing checkpoint code with `trust_remote_code`. It preserves:
+
+- Interleaved image, `<relative_value>`, and `<value>` query groups.
+- Eight-token grouped representations concatenated before each value head.
+- Distributional absolute and relative temporal heads.
+- Symlog-spaced, two-hot value decoding.
+- Value-isolation attention during inference.
+- Official sharded 4B and 8B checkpoint loading.
+
+The integration is inference-only. It does not reproduce the paper's 7,000-hour data mixture, temporal sampling augmentations, or training pipeline.
+
+## Installation
+
+From a source checkout:
+
+```bash
+uv sync --extra rynnvalue
+```
+
+Or with pip:
+
+```bash
+pip install -e ".[rynnvalue]"
+```
+
+The 4B checkpoint is approximately 10 GB. A CUDA GPU with enough memory for the selected checkpoint is strongly recommended.
+
+## Convert an official checkpoint
+
+Convert the official weights, native architecture configuration, tokenizer, and image processor into one self-contained LeRobot checkpoint:
+
+```bash
+uv run python -m lerobot.rewards.rynnvalue.convert_rynnvalue_checkpoint \
+    --source-model-id Alibaba-DAMO-Academy/RynnValue-4B \
+    --output-dir outputs/rynnvalue-4b
+```
+
+The output directory contains LeRobot's `config.json` and `model.safetensors` alongside the processor assets. It can be uploaded as one model repository or used locally without executing remote model code.
+
+## Inputs and outputs
+
+The preprocessor reads:
+
+- `observation.images.top` by default, as one frame or a chronological frame sequence.
+- `task` as the natural-language instruction.
+- Fixed robot and camera descriptions through `robot_description` and `camera_description`.
+
+The released checkpoints have metadata prompting enabled. Provide at least one robot or camera description unless you deliberately set `use_meta=False` for an ablation.
+
+When a trajectory contains more than `max_frames` frames, the processor uniformly samples the full history while retaining its first and last frames. The default is eight frames.
+
+`compute_reward()` returns one scalar per trajectory:
+
+- `reward_output="potential"` (default) returns `-v_end`, where `v_end` is the final queried frame's predicted remaining time.
+- `reward_output="remaining_time"` returns `v_end` directly for diagnostics.
+
+If a checkpoint has multiple absolute-value heads, LeRobot averages them before selecting the final frame.
+
+## Usage
+
+```python
+from lerobot.rewards import make_reward_pre_post_processors
+from lerobot.rewards.rynnvalue import RynnValueRewardModel
+
+model = RynnValueRewardModel.from_pretrained(
+    "outputs/rynnvalue-4b",
+    cli_overrides=[
+        "device=cuda",
+        "robot_description='a single-arm robot'",
+        "camera_description='a third-person workspace camera'",
+    ],
+)
+preprocessor, _ = make_reward_pre_post_processors(model.config)
+
+batch = {
+    "observation.images.top": frames,  # (T,C,H,W) or (B,T,C,H,W)
+    "task": "put the cube in the drawer",
+}
+encoded = preprocessor(batch)
+potential = model.compute_reward(encoded)
+```
+
+Use `Alibaba-DAMO-Academy/RynnValue-8B` as the converter's `--source-model-id` to select the larger checkpoint. `--revision` can pin a Hub commit.
+
+## Checkpoint format
+
+The converted `config.json` embeds the native architecture configuration, while `model.safetensors` stores weights under the LeRobot reward wrapper. Loading the converted checkpoint therefore does not need the original repository to construct the model. Processor assets are loaded from the same local directory or Hub repository.
+
+Subsequent calls to `save_pretrained()` refresh the embedded native configuration before writing the checkpoint. A LeRobot checkpoint is never reconstructed from the upstream `model_id`; older checkpoints without embedded `model_config` must be reconverted.
+
+## Reward shaping
+
+The scalar returned by LeRobot is the state potential, not a complete transition reward. Apply potential-based shaping in the RL loop:
+
+```text
+r_shape = gamma * potential_next - potential
+```
+
+The paper combines this term with a sparse task reward. LeRobot does not infer task termination or success from the language generation branch in `compute_reward()`.
+
+## Limitations
+
+- Inference uses eager custom attention; Flash Attention and SDPA do not implement RynnValue's prediction-slot isolation.
+- The current API scores complete supplied histories and is not a streaming KV-cache reward server.
+- Natural-language video analysis, match, and success generation remain available in the native core model but are not used by `compute_reward()`.
+- Training RynnValue from scratch is outside this integration.

--- a/docs/source/rynnvalue.mdx
+++ b/docs/source/rynnvalue.mdx
@@ -67,7 +67,7 @@ When a trajectory contains more than `max_frames` frames, the processor uniforml
 
 - `prediction.remaining_time_s` contains `v_end`, the final queried frame's predicted remaining time.
 - The tensor stays on the model device.
-- Potential, progress normalization, interpolation, and thresholding belong to workflow adapters.
+- Potential, progress normalization, interpolation, and thresholding belong to workflow consumers.
 
 If a checkpoint has multiple absolute-value heads, LeRobot averages them before selecting the final frame.
 
@@ -134,7 +134,7 @@ uv run lerobot-score-dataset \
     --camera_description="a fixed third-person camera"
 ```
 
-RynnValue runs on causal trajectory prefixes at the configured inference frequency. The adapter linearly interpolates between inference frames and writes:
+RynnValue runs on causal trajectory prefixes at the configured inference frequency. The scorer linearly interpolates between inference frames and writes:
 
 - `reward.rynnvalue.remaining_time_s`;
 - `reward.rynnvalue.potential`;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -236,6 +236,7 @@ groot = [
 sarm = ["lerobot[transformers-dep]", "pydantic>=2.0.0,<3.0.0", "faker>=33.0.0,<35.0.0", "lerobot[matplotlib-dep]", "lerobot[qwen-vl-utils-dep]"]
 robometer = ["lerobot[transformers-dep]", "lerobot[qwen-vl-utils-dep]", "lerobot[peft-dep]"]
 topreward = ["lerobot[transformers-dep]"]
+rynnvalue = ["lerobot[transformers-dep]"]
 xvla = ["lerobot[transformers-dep]"]
 eo1 = ["lerobot[transformers-dep]", "lerobot[qwen-vl-utils-dep]"]
 fastwam = [
@@ -343,6 +344,7 @@ all = [
     "lerobot[sarm]",
     "lerobot[robometer]",
     "lerobot[topreward]",
+    "lerobot[rynnvalue]",
     "lerobot[peft]",
     # "lerobot[unitree_g1]", TODO: Unitree requires specific installation instructions for unitree_sdk2
 ]

--- a/src/lerobot/rewards/__init__.py
+++ b/src/lerobot/rewards/__init__.py
@@ -22,6 +22,7 @@ from .factory import (
 )
 from .pretrained import PreTrainedRewardModel as PreTrainedRewardModel
 from .robometer.configuration_robometer import RobometerConfig as RobometerConfig
+from .rynnvalue.configuration_rynnvalue import RynnValueConfig as RynnValueConfig
 from .sarm.configuration_sarm import SARMConfig as SARMConfig
 from .topreward.configuration_topreward import TOPRewardConfig as TOPRewardConfig
 
@@ -29,6 +30,7 @@ __all__ = [
     # Configuration classes
     "RewardClassifierConfig",
     "RobometerConfig",
+    "RynnValueConfig",
     "SARMConfig",
     "TOPRewardConfig",
     # Base class

--- a/src/lerobot/rewards/factory.py
+++ b/src/lerobot/rewards/factory.py
@@ -26,7 +26,6 @@ from lerobot.processor import PolicyAction, PolicyProcessorPipeline
 from .classifier.configuration_classifier import RewardClassifierConfig
 from .pretrained import PreTrainedRewardModel
 from .robometer.configuration_robometer import RobometerConfig
-from .rynnvalue.configuration_rynnvalue import RynnValueConfig
 from .sarm.configuration_sarm import SARMConfig
 from .topreward.configuration_topreward import TOPRewardConfig
 
@@ -40,7 +39,8 @@ def get_reward_model_class(name: str) -> type[PreTrainedRewardModel]:
 
     Args:
         name: The name of the reward model. Supported names are "reward_classifier",
-              "sarm", "robometer", "topreward", and "rynnvalue".
+              "sarm", "robometer", and "topreward". Registered integrations
+              such as RynnValue are discovered from their config class.
 
     Returns:
         The reward model class corresponding to the given name.
@@ -64,10 +64,6 @@ def get_reward_model_class(name: str) -> type[PreTrainedRewardModel]:
         from lerobot.rewards.topreward.modeling_topreward import TOPRewardModel
 
         return TOPRewardModel
-    elif name == "rynnvalue":
-        from lerobot.rewards.rynnvalue.modeling_rynnvalue import RynnValueRewardModel
-
-        return RynnValueRewardModel
     else:
         try:
             return _get_reward_model_cls_from_name(name=name)
@@ -84,7 +80,9 @@ def make_reward_model_config(reward_type: str, **kwargs) -> RewardModelConfig:
 
     Args:
         reward_type: The type of the reward model. Supported types include
-                     "reward_classifier", "sarm", "robometer", "topreward", and "rynnvalue".
+                     "reward_classifier", "sarm", "robometer", and "topreward".
+                     Registered integrations such as RynnValue are discovered
+                     from their config class.
         **kwargs: Keyword arguments to be passed to the configuration class constructor.
 
     Returns:
@@ -101,8 +99,6 @@ def make_reward_model_config(reward_type: str, **kwargs) -> RewardModelConfig:
         return RobometerConfig(**kwargs)
     elif reward_type == "topreward":
         return TOPRewardConfig(**kwargs)
-    elif reward_type == "rynnvalue":
-        return RynnValueConfig(**kwargs)
     else:
         try:
             config_cls = RewardModelConfig.get_choice_class(reward_type)
@@ -199,14 +195,6 @@ def make_reward_pre_post_processors(
             config=reward_cfg,
             dataset_stats=kwargs.get("dataset_stats"),
         )
-    elif isinstance(reward_cfg, RynnValueConfig):
-        from lerobot.rewards.rynnvalue.processor_rynnvalue import make_rynnvalue_pre_post_processors
-
-        return make_rynnvalue_pre_post_processors(
-            config=reward_cfg,
-            dataset_stats=kwargs.get("dataset_stats"),
-        )
-
     else:
         try:
             processors = _make_processors_from_reward_model_config(

--- a/src/lerobot/rewards/factory.py
+++ b/src/lerobot/rewards/factory.py
@@ -26,6 +26,7 @@ from lerobot.processor import PolicyAction, PolicyProcessorPipeline
 from .classifier.configuration_classifier import RewardClassifierConfig
 from .pretrained import PreTrainedRewardModel
 from .robometer.configuration_robometer import RobometerConfig
+from .rynnvalue.configuration_rynnvalue import RynnValueConfig
 from .sarm.configuration_sarm import SARMConfig
 from .topreward.configuration_topreward import TOPRewardConfig
 
@@ -39,7 +40,7 @@ def get_reward_model_class(name: str) -> type[PreTrainedRewardModel]:
 
     Args:
         name: The name of the reward model. Supported names are "reward_classifier",
-              "sarm", "robometer", "topreward".
+              "sarm", "robometer", "topreward", and "rynnvalue".
 
     Returns:
         The reward model class corresponding to the given name.
@@ -63,6 +64,10 @@ def get_reward_model_class(name: str) -> type[PreTrainedRewardModel]:
         from lerobot.rewards.topreward.modeling_topreward import TOPRewardModel
 
         return TOPRewardModel
+    elif name == "rynnvalue":
+        from lerobot.rewards.rynnvalue.modeling_rynnvalue import RynnValueRewardModel
+
+        return RynnValueRewardModel
     else:
         try:
             return _get_reward_model_cls_from_name(name=name)
@@ -79,7 +84,7 @@ def make_reward_model_config(reward_type: str, **kwargs) -> RewardModelConfig:
 
     Args:
         reward_type: The type of the reward model. Supported types include
-                     "reward_classifier", "sarm", "robometer", "topreward".
+                     "reward_classifier", "sarm", "robometer", "topreward", and "rynnvalue".
         **kwargs: Keyword arguments to be passed to the configuration class constructor.
 
     Returns:
@@ -96,6 +101,8 @@ def make_reward_model_config(reward_type: str, **kwargs) -> RewardModelConfig:
         return RobometerConfig(**kwargs)
     elif reward_type == "topreward":
         return TOPRewardConfig(**kwargs)
+    elif reward_type == "rynnvalue":
+        return RynnValueConfig(**kwargs)
     else:
         try:
             config_cls = RewardModelConfig.get_choice_class(reward_type)
@@ -189,6 +196,13 @@ def make_reward_pre_post_processors(
         from lerobot.rewards.topreward.processor_topreward import make_topreward_pre_post_processors
 
         return make_topreward_pre_post_processors(
+            config=reward_cfg,
+            dataset_stats=kwargs.get("dataset_stats"),
+        )
+    elif isinstance(reward_cfg, RynnValueConfig):
+        from lerobot.rewards.rynnvalue.processor_rynnvalue import make_rynnvalue_pre_post_processors
+
+        return make_rynnvalue_pre_post_processors(
             config=reward_cfg,
             dataset_stats=kwargs.get("dataset_stats"),
         )

--- a/src/lerobot/rewards/rynnvalue/__init__.py
+++ b/src/lerobot/rewards/rynnvalue/__init__.py
@@ -1,0 +1,33 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""LeRobot integration for the RynnValue reward model."""
+
+from typing import TYPE_CHECKING
+
+from lerobot.utils.import_utils import _transformers_available
+
+from .configuration_rynnvalue import RynnValueConfig
+
+if TYPE_CHECKING or _transformers_available:
+    from .modeling_rynnvalue import RynnValueRewardModel
+    from .processor_rynnvalue import make_rynnvalue_pre_post_processors
+
+    __all__ = [
+        "RynnValueConfig",
+        "RynnValueRewardModel",
+        "make_rynnvalue_pre_post_processors",
+    ]
+else:
+    __all__ = ["RynnValueConfig"]

--- a/src/lerobot/rewards/rynnvalue/__init__.py
+++ b/src/lerobot/rewards/rynnvalue/__init__.py
@@ -21,11 +21,12 @@ from lerobot.utils.import_utils import _transformers_available
 from .configuration_rynnvalue import RynnValueConfig
 
 if TYPE_CHECKING or _transformers_available:
-    from .modeling_rynnvalue import RynnValueRewardModel
+    from .modeling_rynnvalue import RynnValuePrediction, RynnValueRewardModel
     from .processor_rynnvalue import make_rynnvalue_pre_post_processors
 
     __all__ = [
         "RynnValueConfig",
+        "RynnValuePrediction",
         "RynnValueRewardModel",
         "make_rynnvalue_pre_post_processors",
     ]

--- a/src/lerobot/rewards/rynnvalue/__init__.py
+++ b/src/lerobot/rewards/rynnvalue/__init__.py
@@ -23,12 +23,14 @@ from .configuration_rynnvalue import RynnValueConfig
 if TYPE_CHECKING or _transformers_available:
     from .modeling_rynnvalue import RynnValuePrediction, RynnValueRewardModel
     from .processor_rynnvalue import make_rynnvalue_pre_post_processors
+    from .scoring_rynnvalue import score_rynnvalue_dataset
 
     __all__ = [
         "RynnValueConfig",
         "RynnValuePrediction",
         "RynnValueRewardModel",
         "make_rynnvalue_pre_post_processors",
+        "score_rynnvalue_dataset",
     ]
 else:
     __all__ = ["RynnValueConfig"]

--- a/src/lerobot/rewards/rynnvalue/configuration_rynnvalue.py
+++ b/src/lerobot/rewards/rynnvalue/configuration_rynnvalue.py
@@ -1,0 +1,97 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from lerobot.configs import FeatureType, NormalizationMode, PolicyFeature
+from lerobot.configs.rewards import RewardModelConfig
+from lerobot.utils.constants import OBS_IMAGES
+
+RYNNVALUE_FEATURE_PREFIX = "observation.rynnvalue."
+
+
+@RewardModelConfig.register_subclass("rynnvalue")
+@dataclass
+class RynnValueConfig(RewardModelConfig):
+    """Configuration for the inference-only RynnValue temporal-distance model."""
+
+    model_id: str = "Alibaba-DAMO-Academy/RynnValue-4B"
+    model_revision: str | None = None
+    torch_dtype: str = "bfloat16"
+    attn_implementation: str = "pred_slot_isolated_eager"
+    # Embedded by the conversion script so LeRobot checkpoints can construct
+    # the architecture without consulting the original repository.
+    model_config: dict[str, Any] | None = None
+
+    image_key: str = OBS_IMAGES + ".top"
+    task_key: str = "task"
+    default_task: str | None = None
+    max_frames: int | None = 8
+    robot_description: str | None = None
+    camera_description: str | None = None
+    use_meta: bool | None = None
+
+    # ``potential`` follows the paper: Phi = -remaining_time.
+    # ``remaining_time`` exposes the native prediction for diagnostics.
+    reward_output: str = "potential"
+
+    license: str | None = "apache-2.0"
+    tags: list[str] | None = field(
+        default_factory=lambda: [
+            "reward-model",
+            "value-model",
+            "vision-language",
+            "qwen3-vl",
+            "temporal-distance",
+        ]
+    )
+    input_features: dict[str, PolicyFeature] = field(default_factory=dict)
+    output_features: dict[str, PolicyFeature] = field(default_factory=dict)
+    normalization_mapping: dict[str, NormalizationMode] = field(
+        default_factory=lambda: {
+            "VISUAL": NormalizationMode.IDENTITY,
+            "REWARD": NormalizationMode.IDENTITY,
+        }
+    )
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        if self.max_frames is not None and self.max_frames < 1:
+            raise ValueError(f"max_frames must be >= 1, got {self.max_frames}")
+        if self.reward_output not in {"potential", "remaining_time"}:
+            raise ValueError(
+                f"reward_output must be 'potential' or 'remaining_time', got {self.reward_output!r}"
+            )
+        if self.attn_implementation != "pred_slot_isolated_eager":
+            raise ValueError("RynnValue checkpoints require attn_implementation='pred_slot_isolated_eager'")
+        if self.image_key not in self.input_features:
+            self.input_features[self.image_key] = PolicyFeature(shape=(3, 224, 224), type=FeatureType.VISUAL)
+        self.output_features.setdefault("reward", PolicyFeature(shape=(1,), type=FeatureType.REWARD))
+
+    @property
+    def observation_delta_indices(self) -> list[int] | None:
+        return None
+
+    @property
+    def action_delta_indices(self) -> None:
+        return None
+
+    @property
+    def reward_delta_indices(self) -> None:
+        return None
+
+    def validate_features(self) -> None:
+        if self.image_key not in self.input_features:
+            raise ValueError(f"RynnValue requires image input feature {self.image_key!r}")

--- a/src/lerobot/rewards/rynnvalue/configuration_rynnvalue.py
+++ b/src/lerobot/rewards/rynnvalue/configuration_rynnvalue.py
@@ -43,9 +43,10 @@ class RynnValueConfig(RewardModelConfig):
     camera_description: str | None = None
     use_meta: bool | None = None
 
-    # ``potential`` follows the paper: Phi = -remaining_time.
-    # ``remaining_time`` exposes the native prediction for diagnostics.
-    reward_output: str = "potential"
+    # Load-only compatibility for checkpoints created by the unpublished
+    # pre-capability integration. Native inference always returns remaining
+    # time; consumers decide whether to derive potential or progress.
+    reward_output: str | None = None
 
     license: str | None = "apache-2.0"
     tags: list[str] | None = field(
@@ -70,15 +71,18 @@ class RynnValueConfig(RewardModelConfig):
         super().__post_init__()
         if self.max_frames is not None and self.max_frames < 1:
             raise ValueError(f"max_frames must be >= 1, got {self.max_frames}")
-        if self.reward_output not in {"potential", "remaining_time"}:
+        if self.reward_output not in {None, "potential", "remaining_time"}:
             raise ValueError(
-                f"reward_output must be 'potential' or 'remaining_time', got {self.reward_output!r}"
+                "reward_output is a load-only compatibility field and must be "
+                f"None, 'potential', or 'remaining_time', got {self.reward_output!r}"
             )
         if self.attn_implementation != "pred_slot_isolated_eager":
             raise ValueError("RynnValue checkpoints require attn_implementation='pred_slot_isolated_eager'")
         if self.image_key not in self.input_features:
             self.input_features[self.image_key] = PolicyFeature(shape=(3, 224, 224), type=FeatureType.VISUAL)
-        self.output_features.setdefault("reward", PolicyFeature(shape=(1,), type=FeatureType.REWARD))
+        self.output_features.setdefault(
+            "remaining_time_s", PolicyFeature(shape=(1,), type=FeatureType.REWARD)
+        )
 
     @property
     def observation_delta_indices(self) -> list[int] | None:

--- a/src/lerobot/rewards/rynnvalue/convert_rynnvalue_checkpoint.py
+++ b/src/lerobot/rewards/rynnvalue/convert_rynnvalue_checkpoint.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Convert an official RynnValue checkpoint into a self-contained LeRobot checkpoint.
+
+Example:
+    uv run python -m lerobot.rewards.rynnvalue.convert_rynnvalue_checkpoint \
+        --output-dir outputs/rynnvalue-4b
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from .configuration_rynnvalue import RynnValueConfig
+from .modeling_rynnvalue import RynnValueRewardModel, _torch_dtype
+from .rynn_value_lang.configuration_rynn_value_lang import RynnValueLangConfig
+from .rynn_value_lang.modeling_rynn_value_lang import RynnValueLangModel
+from .rynn_value_lang.processing_rynn_value_lang import RynnValueLangProcessor
+
+DEFAULT_SOURCE_MODEL_ID = "Alibaba-DAMO-Academy/RynnValue-4B"
+
+
+def convert_rynnvalue_checkpoint(
+    output_dir: str | Path,
+    *,
+    source_model_id: str = DEFAULT_SOURCE_MODEL_ID,
+    revision: str | None = None,
+    torch_dtype: str = "bfloat16",
+) -> Path:
+    """Download and convert an official checkpoint and its processor assets."""
+    output_path = Path(output_dir)
+    if output_path.exists() and any(output_path.iterdir()):
+        raise FileExistsError(f"Output directory must be empty: {output_path}")
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    model_config = RynnValueLangConfig.from_pretrained(source_model_id, revision=revision)
+    model_config._attn_implementation = "pred_slot_isolated_eager"
+    model = RynnValueLangModel.from_pretrained(
+        source_model_id,
+        revision=revision,
+        config=model_config,
+        dtype=_torch_dtype(torch_dtype),
+    )
+    processor = RynnValueLangProcessor.from_pretrained(source_model_id, revision=revision)
+
+    lerobot_config = RynnValueConfig(
+        device="cpu",
+        model_id=source_model_id,
+        model_revision=revision,
+        torch_dtype=torch_dtype,
+        model_config=model_config.to_dict(),
+    )
+    reward_model = RynnValueRewardModel(lerobot_config, model=model)
+
+    # Processor assets and LeRobot files coexist at the checkpoint root.
+    processor.save_pretrained(output_path)
+    reward_model.save_pretrained(output_path)
+    return output_path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--source-model-id", default=DEFAULT_SOURCE_MODEL_ID)
+    parser.add_argument("--revision")
+    parser.add_argument(
+        "--torch-dtype",
+        choices=("bfloat16", "float16", "float32"),
+        default="bfloat16",
+    )
+    args = parser.parse_args()
+    output_path = convert_rynnvalue_checkpoint(
+        args.output_dir,
+        source_model_id=args.source_model_id,
+        revision=args.revision,
+        torch_dtype=args.torch_dtype,
+    )
+    print(f"Converted RynnValue checkpoint saved to {output_path.resolve()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/lerobot/rewards/rynnvalue/modeling_rynnvalue.py
+++ b/src/lerobot/rewards/rynnvalue/modeling_rynnvalue.py
@@ -15,6 +15,8 @@
 from __future__ import annotations
 
 import builtins
+from collections.abc import Mapping
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeVar
 
@@ -42,6 +44,13 @@ RYNNVALUE_MODEL_INPUT_KEYS = (
 )
 
 T = TypeVar("T", bound="RynnValueRewardModel")
+
+
+@dataclass(frozen=True)
+class RynnValuePrediction:
+    """RynnValue's native temporal-distance prediction on the model device."""
+
+    remaining_time_s: Tensor
 
 
 def _torch_dtype(name: str) -> torch.dtype:
@@ -135,7 +144,12 @@ class RynnValueRewardModel(PreTrainedRewardModel):
             dtype=dtype,
         )
 
-    def compute_reward(self, batch: dict[str, Any]) -> Tensor:
+    def predict_remaining_time(self, batch: Mapping[str, Any]) -> RynnValuePrediction:
+        """Predict seconds remaining for each encoded trajectory prefix.
+
+        Potential, progress, interpolation, and reward shaping are consumer
+        transforms and intentionally do not live in the model API.
+        """
         inputs: dict[str, Any] = {}
         for key in RYNNVALUE_MODEL_INPUT_KEYS:
             batch_key = f"{RYNNVALUE_FEATURE_PREFIX}{key}"
@@ -144,7 +158,7 @@ class RynnValueRewardModel(PreTrainedRewardModel):
         if "input_ids" not in inputs:
             raise KeyError(
                 f"RynnValue batch missing `{RYNNVALUE_FEATURE_PREFIX}input_ids`. "
-                "Make sure RynnValueEncoderProcessorStep ran before compute_reward()."
+                "Make sure RynnValueEncoderProcessorStep ran before predict_remaining_time()."
             )
         for required in ("attention_mask", "pixel_values", "image_grid_thw"):
             if required not in inputs:
@@ -177,8 +191,7 @@ class RynnValueRewardModel(PreTrainedRewardModel):
             batch_size=int(inputs["input_ids"].shape[0]),
             slot_counts=slot_counts,
         )
-        reward = -remaining_time if self.config.reward_output == "potential" else remaining_time
-        return reward.to(self.config.device or "cpu")
+        return RynnValuePrediction(remaining_time_s=remaining_time)
 
     def _save_pretrained(self, save_directory: Path) -> None:
         native_config = getattr(self.model, "config", None)

--- a/src/lerobot/rewards/rynnvalue/modeling_rynnvalue.py
+++ b/src/lerobot/rewards/rynnvalue/modeling_rynnvalue.py
@@ -1,0 +1,233 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import builtins
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, TypeVar
+
+import torch
+from torch import Tensor
+
+from lerobot.configs.rewards import RewardModelConfig
+from lerobot.rewards.pretrained import PreTrainedRewardModel
+from lerobot.rewards.rynnvalue.configuration_rynnvalue import RYNNVALUE_FEATURE_PREFIX, RynnValueConfig
+from lerobot.utils.import_utils import _transformers_available, require_package
+
+if TYPE_CHECKING or _transformers_available:
+    from .rynn_value_lang.configuration_rynn_value_lang import RynnValueLangConfig
+    from .rynn_value_lang.modeling_rynn_value_lang import RynnValueLangModel
+else:
+    RynnValueLangConfig = None  # type: ignore[assignment]
+    RynnValueLangModel = None  # type: ignore[assignment]
+
+RYNNVALUE_MODEL_INPUT_KEYS = (
+    "input_ids",
+    "attention_mask",
+    "pixel_values",
+    "image_grid_thw",
+    "mm_token_type_ids",
+)
+
+T = TypeVar("T", bound="RynnValueRewardModel")
+
+
+def _torch_dtype(name: str) -> torch.dtype:
+    dtype = getattr(torch, name, None)
+    if isinstance(dtype, torch.dtype):
+        return dtype
+    raise ValueError(f"Unknown torch dtype: {name!r}")
+
+
+def reduce_remaining_time(
+    pred_value: Tensor,
+    *,
+    batch_size: int,
+    slot_counts: Tensor | list[int] | None = None,
+) -> Tensor:
+    """Average head ensembles and select each sample's final value slot."""
+    values = pred_value.float()
+    if values.ndim == 1:
+        flattened = values
+    elif values.ndim == 2:
+        # Ensemble output is (num_heads, batch_size * num_slots). A single-head
+        # checkpoint uses the same shape with num_heads=1.
+        flattened = values.mean(dim=0)
+    else:
+        raise ValueError(f"Unexpected RynnValue prediction shape: {tuple(values.shape)}")
+
+    if slot_counts is not None:
+        counts = torch.as_tensor(slot_counts, device=flattened.device, dtype=torch.long)
+        if counts.ndim != 1 or counts.numel() != batch_size:
+            raise ValueError(f"Expected {batch_size} RynnValue slot counts, got shape {tuple(counts.shape)}")
+        if torch.any(counts < 1):
+            raise ValueError(
+                f"Each RynnValue sample must contain at least one value slot, got {counts.tolist()}"
+            )
+        if int(counts.sum()) != flattened.numel():
+            raise ValueError(
+                f"RynnValue slot counts sum to {int(counts.sum())}, "
+                f"but the model returned {flattened.numel()} predictions"
+            )
+        return flattened[counts.cumsum(dim=0) - 1]
+
+    if flattened.numel() % batch_size:
+        raise ValueError(
+            f"Cannot split RynnValue output shape {tuple(values.shape)} across batch size {batch_size}"
+        )
+    return flattened.view(batch_size, -1)[:, -1]
+
+
+class RynnValueRewardModel(PreTrainedRewardModel):
+    """Native LeRobot wrapper around official RynnValue checkpoints."""
+
+    name = "rynnvalue"
+    config_class = RynnValueConfig
+
+    def __init__(self, config: RynnValueConfig, model: Any | None = None) -> None:
+        require_package("transformers", extra="rynnvalue")
+        super().__init__(config)
+        self.config = config
+
+        if model is not None:
+            self.model = model
+            return
+
+        dtype = _torch_dtype(config.torch_dtype)
+        if config.pretrained_path is not None and config.model_config is None:
+            raise ValueError(
+                "RynnValue LeRobot checkpoint is missing `model_config`. "
+                "Reconvert the official checkpoint with "
+                "`python -m lerobot.rewards.rynnvalue.convert_rynnvalue_checkpoint`."
+            )
+        if config.model_config is not None:
+            model_config = RynnValueLangConfig.from_dict(config.model_config)
+            model_config._attn_implementation = config.attn_implementation
+            previous_dtype = torch.get_default_dtype()
+            torch.set_default_dtype(dtype)
+            try:
+                self.model = RynnValueLangModel(model_config)
+            finally:
+                torch.set_default_dtype(previous_dtype)
+            return
+
+        model_config = RynnValueLangConfig.from_pretrained(
+            config.model_id,
+            revision=config.model_revision,
+        )
+        model_config._attn_implementation = config.attn_implementation
+        self.model = RynnValueLangModel.from_pretrained(
+            config.model_id,
+            revision=config.model_revision,
+            config=model_config,
+            dtype=dtype,
+        )
+
+    def compute_reward(self, batch: dict[str, Any]) -> Tensor:
+        inputs: dict[str, Any] = {}
+        for key in RYNNVALUE_MODEL_INPUT_KEYS:
+            batch_key = f"{RYNNVALUE_FEATURE_PREFIX}{key}"
+            if batch_key in batch:
+                inputs[key] = batch[batch_key]
+        if "input_ids" not in inputs:
+            raise KeyError(
+                f"RynnValue batch missing `{RYNNVALUE_FEATURE_PREFIX}input_ids`. "
+                "Make sure RynnValueEncoderProcessorStep ran before compute_reward()."
+            )
+        for required in ("attention_mask", "pixel_values", "image_grid_thw"):
+            if required not in inputs:
+                raise KeyError(f"RynnValue batch missing `{RYNNVALUE_FEATURE_PREFIX}{required}`.")
+
+        device = next(self.model.parameters()).device
+        inputs = {key: value.to(device) if hasattr(value, "to") else value for key, value in inputs.items()}
+        self.eval()
+        with torch.inference_mode():
+            outputs = self.model(**inputs)
+
+        pred_value = outputs.value.pred_value
+        if pred_value is None:
+            raise RuntimeError("RynnValue checkpoint did not produce absolute temporal values")
+
+        slot_counts = None
+        value_token_id = getattr(self.model.config, "value_token_id", None)
+        value_token_repeat = int(getattr(self.model.config, "value_token_repeat", 1))
+        if value_token_id is not None:
+            token_counts = inputs["input_ids"].eq(value_token_id).sum(dim=1)
+            if torch.any(token_counts.remainder(value_token_repeat)):
+                raise RuntimeError(
+                    f"RynnValue value-token counts {token_counts.tolist()} are not divisible "
+                    f"by value_token_repeat={value_token_repeat}"
+                )
+            slot_counts = token_counts.div(value_token_repeat, rounding_mode="floor")
+
+        remaining_time = reduce_remaining_time(
+            pred_value,
+            batch_size=int(inputs["input_ids"].shape[0]),
+            slot_counts=slot_counts,
+        )
+        reward = -remaining_time if self.config.reward_output == "potential" else remaining_time
+        return reward.to(self.config.device or "cpu")
+
+    def _save_pretrained(self, save_directory: Path) -> None:
+        native_config = getattr(self.model, "config", None)
+        if native_config is None or not callable(getattr(native_config, "to_dict", None)):
+            raise TypeError("RynnValue native model must expose a serializable `config.to_dict()`")
+        self.config.model_config = native_config.to_dict()
+        super()._save_pretrained(save_directory)
+
+    @classmethod
+    def from_pretrained(
+        cls: builtins.type[T],
+        pretrained_name_or_path: str | Path,
+        *,
+        config: RewardModelConfig | None = None,
+        force_download: bool = False,
+        resume_download: bool | None = None,
+        proxies: dict | None = None,
+        token: str | bool | None = None,
+        cache_dir: str | Path | None = None,
+        local_files_only: bool = False,
+        revision: str | None = None,
+        strict: bool = False,
+        **kwargs: Any,
+    ) -> T:
+        if config is None:
+            config = RewardModelConfig.from_pretrained(
+                pretrained_name_or_path=pretrained_name_or_path,
+                force_download=force_download,
+                resume_download=resume_download,
+                proxies=proxies,
+                token=token,
+                cache_dir=cache_dir,
+                local_files_only=local_files_only,
+                revision=revision,
+                **kwargs,
+            )
+        if not isinstance(config, RynnValueConfig):
+            raise TypeError(f"Expected RynnValueConfig, got {type(config).__name__}")
+        config.pretrained_path = str(pretrained_name_or_path)
+        config.pretrained_revision = revision
+        return super().from_pretrained(
+            pretrained_name_or_path,
+            config=config,
+            force_download=force_download,
+            resume_download=resume_download,
+            proxies=proxies,
+            token=token,
+            cache_dir=cache_dir,
+            local_files_only=local_files_only,
+            revision=revision,
+            strict=strict,
+        )

--- a/src/lerobot/rewards/rynnvalue/processor_rynnvalue.py
+++ b/src/lerobot/rewards/rynnvalue/processor_rynnvalue.py
@@ -1,0 +1,241 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+import torch
+from PIL import Image
+from torch import Tensor
+
+from lerobot.configs import PipelineFeatureType, PolicyFeature
+from lerobot.lerobot_types import EnvTransition, TransitionKey
+from lerobot.processor import (
+    AddBatchDimensionProcessorStep,
+    DeviceProcessorStep,
+    PolicyAction,
+    PolicyProcessorPipeline,
+    ProcessorStep,
+    ProcessorStepRegistry,
+    policy_action_to_transition,
+)
+from lerobot.rewards.rynnvalue.configuration_rynnvalue import RYNNVALUE_FEATURE_PREFIX, RynnValueConfig
+from lerobot.utils.constants import POLICY_POSTPROCESSOR_DEFAULT_NAME, POLICY_PREPROCESSOR_DEFAULT_NAME
+from lerobot.utils.import_utils import _transformers_available, require_package
+
+if TYPE_CHECKING or _transformers_available:
+    from .rynn_value_lang.processing_rynn_value_lang import RynnValueLangProcessor
+else:
+    RynnValueLangProcessor = None  # type: ignore[assignment]
+
+
+def _expand_text(value: Any, *, batch_size: int, default: str | None, name: str) -> list[str]:
+    if value is None:
+        value = default
+    if value is None:
+        raise KeyError(f"RynnValue expected {name} in complementary data")
+    if isinstance(value, str):
+        return [value] * batch_size
+    if isinstance(value, tuple):
+        value = list(value)
+    if not (isinstance(value, list) and all(isinstance(item, str) for item in value)):
+        raise TypeError(f"RynnValue {name} must be a string or list of strings")
+    if len(value) == 1 and batch_size > 1:
+        return value * batch_size
+    if len(value) != batch_size:
+        raise ValueError(f"Expected {batch_size} {name} values, got {len(value)}")
+    return value
+
+
+def _uniform_subsample(video: Tensor, max_frames: int | None) -> Tensor:
+    if max_frames is None or video.shape[0] <= max_frames:
+        return video
+    indices = torch.linspace(0, video.shape[0] - 1, max_frames).round().long()
+    return video[indices]
+
+
+def _video_to_pil(video: Tensor, *, max_frames: int | None) -> list[Image.Image]:
+    video = _uniform_subsample(video, max_frames)
+    if video.ndim != 4:
+        raise ValueError(f"Expected a (T,C,H,W) or (T,H,W,C) video, got {tuple(video.shape)}")
+    if video.shape[1] in (1, 3):
+        video = video.permute(0, 2, 3, 1)
+    elif video.shape[-1] not in (1, 3):
+        raise ValueError(f"Expected channel dimension of size 1 or 3, got {tuple(video.shape)}")
+    array = video.detach().cpu().numpy()
+    if np.issubdtype(array.dtype, np.floating):
+        if array.size and array.min() < 0:
+            array = (array + 1.0) / 2.0
+        if array.size and array.max() <= 1.0:
+            array = array * 255.0
+    array = np.clip(array, 0, 255).astype(np.uint8)
+    return [Image.fromarray(frame).convert("RGB") for frame in array]
+
+
+def _pad_sequences(sequences: list[Tensor], *, padding_value: int) -> Tensor:
+    return torch.nn.utils.rnn.pad_sequence(
+        [sequence.squeeze(0) for sequence in sequences],
+        batch_first=True,
+        padding_value=padding_value,
+    )
+
+
+@dataclass
+@ProcessorStepRegistry.register(name="rynnvalue_encoder")
+class RynnValueEncoderProcessorStep(ProcessorStep):
+    """Encode trajectory frames and task text with the native RynnValue processor."""
+
+    model_id: str = "Alibaba-DAMO-Academy/RynnValue-4B"
+    model_revision: str | None = None
+    image_key: str = "observation.images.top"
+    task_key: str = "task"
+    default_task: str | None = None
+    max_frames: int | None = 8
+    robot_description: str | None = None
+    camera_description: str | None = None
+    use_meta: bool | None = None
+    _processor: Any = field(default=None, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        require_package("transformers", extra="rynnvalue")
+        self._processor = RynnValueLangProcessor.from_pretrained(
+            self.model_id,
+            revision=self.model_revision,
+        )
+        if self.use_meta is not None:
+            self._processor.use_meta = self.use_meta
+            self._processor.refresh_conversation_builder()
+
+    def __call__(self, transition: EnvTransition) -> EnvTransition:
+        observation = transition.get(TransitionKey.OBSERVATION)
+        complementary = transition.get(TransitionKey.COMPLEMENTARY_DATA) or {}
+        if self.image_key not in observation:
+            raise KeyError(f"RynnValue expected image key {self.image_key!r} in observation")
+        frames = observation[self.image_key]
+        tensor = frames.detach().cpu() if isinstance(frames, Tensor) else torch.as_tensor(frames)
+        if tensor.ndim == 4:
+            tensor = tensor.unsqueeze(1)
+        elif tensor.ndim != 5:
+            raise ValueError(
+                f"Expected RynnValue frames with shape (B,C,H,W) or (B,T,C,H,W); got {tuple(tensor.shape)}"
+            )
+
+        tasks = _expand_text(
+            complementary.get(self.task_key),
+            batch_size=tensor.shape[0],
+            default=self.default_task,
+            name="task",
+        )
+        encoded = self.encode_samples(
+            [
+                (_video_to_pil(tensor[index], max_frames=self.max_frames), tasks[index])
+                for index in range(tensor.shape[0])
+            ]
+        )
+        new_observation = dict(observation)
+        for key, value in encoded.items():
+            new_observation[f"{RYNNVALUE_FEATURE_PREFIX}{key}"] = value
+        output = transition.copy()
+        output[TransitionKey.OBSERVATION] = new_observation
+        return output
+
+    def encode_samples(self, samples: list[tuple[list[Image.Image], str]]) -> dict[str, Tensor]:
+        outputs = [
+            self._processor.process_episode(
+                instruction=task,
+                images=images,
+                robot_description=self.robot_description,
+                camera_description=self.camera_description,
+            )
+            for images, task in samples
+        ]
+        pad_id = self._processor.tokenizer.pad_token_id
+        if pad_id is None:
+            pad_id = self._processor.tokenizer.eos_token_id
+        if pad_id is None:
+            raise ValueError("RynnValue tokenizer must define a pad or EOS token")
+
+        encoded = {
+            "input_ids": _pad_sequences([output["input_ids"] for output in outputs], padding_value=pad_id),
+            "attention_mask": _pad_sequences(
+                [output["attention_mask"] for output in outputs], padding_value=0
+            ),
+            "pixel_values": torch.cat([output["pixel_values"].flatten(0, 1) for output in outputs], dim=0),
+            "image_grid_thw": torch.cat(
+                [output["image_grid_thw"].flatten(0, 1) for output in outputs], dim=0
+            ),
+        }
+        if all("mm_token_type_ids" in output for output in outputs):
+            encoded["mm_token_type_ids"] = _pad_sequences(
+                [output["mm_token_type_ids"] for output in outputs], padding_value=0
+            )
+        return encoded
+
+    def transform_features(
+        self, features: dict[PipelineFeatureType, dict[str, PolicyFeature]]
+    ) -> dict[PipelineFeatureType, dict[str, PolicyFeature]]:
+        return features
+
+    def get_config(self) -> dict[str, Any]:
+        return {
+            "model_id": self.model_id,
+            "model_revision": self.model_revision,
+            "image_key": self.image_key,
+            "task_key": self.task_key,
+            "default_task": self.default_task,
+            "max_frames": self.max_frames,
+            "robot_description": self.robot_description,
+            "camera_description": self.camera_description,
+            "use_meta": self.use_meta,
+        }
+
+
+def make_rynnvalue_pre_post_processors(
+    config: RynnValueConfig,
+    dataset_stats: dict[str, dict[str, Any]] | None = None,
+) -> tuple[
+    PolicyProcessorPipeline[dict[str, Any], dict[str, Any]],
+    PolicyProcessorPipeline[PolicyAction, PolicyAction],
+]:
+    del dataset_stats
+    processor_id = str(config.pretrained_path) if config.pretrained_path is not None else config.model_id
+    processor_revision = (
+        config.pretrained_revision if config.pretrained_path is not None else config.model_revision
+    )
+    preprocessor = PolicyProcessorPipeline[dict[str, Any], dict[str, Any]](
+        steps=[
+            AddBatchDimensionProcessorStep(),
+            RynnValueEncoderProcessorStep(
+                model_id=processor_id,
+                model_revision=processor_revision,
+                image_key=config.image_key,
+                task_key=config.task_key,
+                default_task=config.default_task,
+                max_frames=config.max_frames,
+                robot_description=config.robot_description,
+                camera_description=config.camera_description,
+                use_meta=config.use_meta,
+            ),
+            DeviceProcessorStep(device=config.device or "cpu"),
+        ],
+        name=POLICY_PREPROCESSOR_DEFAULT_NAME,
+    )
+    postprocessor = PolicyProcessorPipeline(
+        name=POLICY_POSTPROCESSOR_DEFAULT_NAME,
+        to_transition=policy_action_to_transition,
+    )
+    return preprocessor, postprocessor

--- a/src/lerobot/rewards/rynnvalue/processor_rynnvalue.py
+++ b/src/lerobot/rewards/rynnvalue/processor_rynnvalue.py
@@ -128,10 +128,10 @@ class RynnValueEncoderProcessorStep(ProcessorStep):
         frames = observation[self.image_key]
         tensor = frames.detach().cpu() if isinstance(frames, Tensor) else torch.as_tensor(frames)
         if tensor.ndim == 4:
-            tensor = tensor.unsqueeze(1)
+            tensor = tensor.unsqueeze(0)
         elif tensor.ndim != 5:
             raise ValueError(
-                f"Expected RynnValue frames with shape (B,C,H,W) or (B,T,C,H,W); got {tuple(tensor.shape)}"
+                f"Expected RynnValue frames with shape (T,C,H,W) or (B,T,C,H,W); got {tuple(tensor.shape)}"
             )
 
         tasks = _expand_text(

--- a/src/lerobot/rewards/rynnvalue/rynn_value_lang/__init__.py
+++ b/src/lerobot/rewards/rynnvalue/rynn_value_lang/__init__.py
@@ -1,0 +1,48 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Checkpoint-compatible native RynnValueLang Transformers implementation."""
+
+from transformers import AutoConfig, AutoModel, AutoProcessor
+
+from . import attention_impl as attention_impl
+from .configuration_rynn_value_lang import (
+    RynnValueLangConfig,
+    ValueHeadConfig,
+    ValueTokenizerConfig,
+)
+from .conversations import (
+    ConversationBuilder,
+    InterleavedHistoryConversationBuilder,
+    build_conversation_builder,
+)
+from .modeling_rynn_value_lang import RynnValueLangModel, RynnValueLangOutputWithPast
+from .processing_rynn_value_lang import RynnValueLangProcessor
+
+AutoConfig.register("rynn_value_lang", RynnValueLangConfig, exist_ok=True)
+AutoModel.register(RynnValueLangConfig, RynnValueLangModel, exist_ok=True)
+AutoProcessor.register(RynnValueLangConfig, RynnValueLangProcessor, exist_ok=True)
+
+__all__ = [
+    "ConversationBuilder",
+    "InterleavedHistoryConversationBuilder",
+    "RynnValueLangConfig",
+    "RynnValueLangModel",
+    "RynnValueLangOutputWithPast",
+    "RynnValueLangProcessor",
+    "ValueHeadConfig",
+    "ValueTokenizerConfig",
+    "attention_impl",
+    "build_conversation_builder",
+]

--- a/src/lerobot/rewards/rynnvalue/rynn_value_lang/attention_impl.py
+++ b/src/lerobot/rewards/rynnvalue/rynn_value_lang/attention_impl.py
@@ -1,0 +1,66 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Custom eager attention with prediction-slot isolation."""
+
+import torch
+from torch import nn
+from transformers.masking_utils import ALL_MASK_ATTENTION_FUNCTIONS, eager_mask
+from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
+from transformers.models.qwen3_vl.modeling_qwen3_vl import repeat_kv
+from transformers.processing_utils import Unpack
+from transformers.utils import TransformersKwargs
+
+
+def pred_slot_isolated_eager(
+    module: nn.Module,
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attention_mask: torch.Tensor | None,
+    scaling: float,
+    dropout: float = 0.0,
+    is_pred_key: torch.Tensor | None = None,
+    pred_slot_id: torch.Tensor | None = None,
+    **kwargs: Unpack[TransformersKwargs],
+):
+    del kwargs
+    key_states = repeat_kv(key, module.num_key_value_groups)
+    value_states = repeat_kv(value, module.num_key_value_groups)
+    batch_size, query_length, key_length = query.shape[0], query.shape[2], key_states.shape[2]
+    neg_inf = torch.finfo(query.dtype).min
+    if attention_mask is not None:
+        add_mask = attention_mask[:, :, :, :key_length].to(query.dtype).clone()
+    else:
+        add_mask = torch.zeros(
+            batch_size, 1, query_length, key_length, dtype=query.dtype, device=query.device
+        )
+    if is_pred_key is not None and is_pred_key.any():
+        if pred_slot_id is not None:
+            slot_q, slot_k = pred_slot_id[:, :, None], pred_slot_id[:, None, :]
+            same_slot = (slot_q == slot_k) & (slot_q >= 0)
+            add_mask = add_mask.masked_fill(same_slot[:, None], 0.0)
+            pred_mask = is_pred_key[:, None, :] & ~same_slot
+        else:
+            pred_mask = is_pred_key[:, None, :].expand(batch_size, query_length, key_length)
+        add_mask = add_mask.masked_fill(pred_mask[:, None], neg_inf)
+    attn_weights = torch.matmul(query, key_states.transpose(2, 3)) * scaling + add_mask
+    attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query.dtype)
+    attn_weights = nn.functional.dropout(attn_weights, p=dropout, training=module.training)
+    output = torch.matmul(attn_weights, value_states).transpose(1, 2).contiguous()
+    return output, attn_weights
+
+
+ALL_ATTENTION_FUNCTIONS["pred_slot_isolated_eager"] = pred_slot_isolated_eager
+ALL_MASK_ATTENTION_FUNCTIONS._global_mapping["pred_slot_isolated_eager"] = eager_mask

--- a/src/lerobot/rewards/rynnvalue/rynn_value_lang/configuration_rynn_value_lang.py
+++ b/src/lerobot/rewards/rynnvalue/rynn_value_lang/configuration_rynn_value_lang.py
@@ -1,0 +1,201 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Literal
+
+from transformers import PretrainedConfig
+from transformers.models.qwen3_vl.configuration_qwen3_vl import (
+    Qwen3VLConfig,
+    Qwen3VLTextConfig,
+    Qwen3VLVisionConfig,
+)
+
+
+class ValueTokenizerConfig(PretrainedConfig):
+    model_type = "value_tokenizer"
+
+    def __init__(
+        self,
+        bins: int = 256,
+        min_value: float = 0.0,
+        max_value: float = 1000.0,
+        support_transform: Literal["linear", "symlog", "quantile"] = "linear",
+        encoding: Literal["two_hot", "hl_gauss"] = "two_hot",
+        hl_gauss_sigma_ratio: float = 0.75,
+        bin_edges: list[float] | None = None,
+        bin_edges_path: str | None = None,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.bins = bins
+        self.min_value = min_value
+        self.max_value = max_value
+        self.support_transform = support_transform
+        self.encoding = encoding
+        self.hl_gauss_sigma_ratio = hl_gauss_sigma_ratio
+        self.bin_edges_path = bin_edges_path
+        self.bin_edges = list(bin_edges) if bin_edges is not None else None
+        if support_transform == "quantile":
+            if self.bin_edges is None:
+                raise ValueError(
+                    f"support_transform='quantile' requires explicit bin_edges (length bins+1={bins + 1})."
+                )
+            if len(self.bin_edges) != bins + 1:
+                raise ValueError(
+                    f"bin_edges must have length bins+1 ({bins + 1}), got {len(self.bin_edges)}."
+                )
+            if any(
+                self.bin_edges[index + 1] <= self.bin_edges[index] for index in range(len(self.bin_edges) - 1)
+            ):
+                raise ValueError("bin_edges must be strictly increasing.")
+        if encoding not in ("two_hot", "hl_gauss"):
+            raise ValueError(f"Unsupported encoding: {encoding}. Expected 'two_hot' or 'hl_gauss'.")
+
+
+class ValueHeadConfig(PretrainedConfig):
+    model_type = "value_head"
+
+    def __init__(
+        self,
+        head_type: str = "linear",
+        hidden_dims: int = 1024,
+        depth: int = 2,
+        activation: str = "relu",
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.head_type = head_type
+        self.hidden_dims = hidden_dims
+        self.depth = depth
+        self.activation = activation
+
+
+class RynnValueLangConfig(Qwen3VLConfig):
+    model_type = "rynn_value_lang"
+    sub_configs = {
+        "vision_config": Qwen3VLVisionConfig,
+        "text_config": Qwen3VLTextConfig,
+        "value_tokenizer_config": ValueTokenizerConfig,
+        "relative_value_tokenizer_config": ValueTokenizerConfig,
+        "value_head_config": ValueHeadConfig,
+        "relative_value_head_config": ValueHeadConfig,
+    }
+    keys_to_ignore_at_inference = ["past_key_values"]
+
+    def __init__(
+        self,
+        value_tokenizer_config: ValueTokenizerConfig | dict | None = None,
+        value_head_config: ValueHeadConfig | dict | None = None,
+        relative_value_head_config: ValueHeadConfig | dict | None = None,
+        relative_value_tokenizer_config: ValueTokenizerConfig | dict | None = None,
+        num_value_heads: int = 1,
+        value_token_repeat: int = 1,
+        relative_value_token_repeat: int = 1,
+        attn_implementation: str | None = None,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self._attn_implementation = attn_implementation or "pred_slot_isolated_eager"
+        if value_tokenizer_config is None:
+            value_tokenizer_config = ValueTokenizerConfig()
+        elif isinstance(value_tokenizer_config, dict):
+            value_tokenizer_config = ValueTokenizerConfig(**value_tokenizer_config)
+        if relative_value_tokenizer_config is None and relative_value_head_config is not None:
+            raise ValueError("relative_value_head_config is set but relative_value_tokenizer_config is None.")
+        if isinstance(relative_value_tokenizer_config, dict):
+            relative_value_tokenizer_config = ValueTokenizerConfig(**relative_value_tokenizer_config)
+        if isinstance(value_head_config, dict):
+            value_head_config = ValueHeadConfig(**value_head_config)
+        if isinstance(relative_value_head_config, dict):
+            relative_value_head_config = ValueHeadConfig(**relative_value_head_config)
+        self.value_tokenizer_config = value_tokenizer_config
+        self.relative_value_tokenizer_config = relative_value_tokenizer_config
+        self.value_head_config = value_head_config
+        self.relative_value_head_config = relative_value_head_config
+        self.num_value_heads = int(num_value_heads)
+        self.value_token_repeat = int(value_token_repeat)
+        self.relative_value_token_repeat = int(relative_value_token_repeat)
+        if self.value_token_repeat < 1:
+            raise ValueError(f"value_token_repeat must be >= 1, got {self.value_token_repeat}")
+        if self.relative_value_token_repeat < 1:
+            raise ValueError(
+                f"relative_value_token_repeat must be >= 1, got {self.relative_value_token_repeat}"
+            )
+        self.architectures = ["RynnValueLangModel"]
+
+    @property
+    def bins(self) -> int:
+        return self.value_tokenizer_config.bins
+
+    @classmethod
+    def from_qwen3vl(cls, source: str | Qwen3VLConfig, **kwargs) -> "RynnValueLangConfig":
+        if isinstance(source, str):
+            base_config = Qwen3VLConfig.from_pretrained(source)
+        elif isinstance(source, Qwen3VLConfig):
+            base_config = source
+        else:
+            raise TypeError("source must be a pretrained model name/path or a Qwen3VLConfig instance.")
+        base_dict = base_config.to_dict()
+        for key in (
+            "model_type",
+            "value_tokenizer_config",
+            "relative_value_tokenizer_config",
+            "value_head_config",
+            "relative_value_head_config",
+            "success_head_config",
+            "match_head_config",
+            "architectures",
+            "bins",
+            "num_value_heads",
+            "value_token_repeat",
+            "relative_value_token_repeat",
+        ):
+            base_dict.pop(key, None)
+        base_dict.update(kwargs)
+        return cls(**base_dict)
+
+    @classmethod
+    def from_dict(cls, config_dict, **kwargs):
+        persisted_attn = config_dict.get("attn_implementation")
+        outputs = super().from_dict(config_dict, **kwargs)
+        config = outputs[0] if isinstance(outputs, tuple) else outputs
+        if persisted_attn is not None and kwargs.get("attn_implementation") is None:
+            config._attn_implementation = persisted_attn
+        return outputs
+
+    def to_dict(self):
+        output = super().to_dict()
+        output.update(
+            architectures=["RynnValueLangModel"],
+            value_tokenizer_config=self.value_tokenizer_config.to_dict(),
+            relative_value_tokenizer_config=(
+                self.relative_value_tokenizer_config.to_dict()
+                if self.relative_value_tokenizer_config is not None
+                else None
+            ),
+            value_head_config=(
+                self.value_head_config.to_dict() if self.value_head_config is not None else None
+            ),
+            relative_value_head_config=(
+                self.relative_value_head_config.to_dict()
+                if self.relative_value_head_config is not None
+                else None
+            ),
+            num_value_heads=self.num_value_heads,
+            value_token_repeat=self.value_token_repeat,
+            relative_value_token_repeat=self.relative_value_token_repeat,
+        )
+        if getattr(self, "_attn_implementation", None) is not None:
+            output["attn_implementation"] = self._attn_implementation
+        return output

--- a/src/lerobot/rewards/rynnvalue/rynn_value_lang/conversations.py
+++ b/src/lerobot/rewards/rynnvalue/rynn_value_lang/conversations.py
@@ -1,0 +1,185 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Checkpoint-compatible conversation builders for RynnValue."""
+
+from abc import ABC, abstractmethod
+
+
+def _meta_block(robot_description: str | None, camera_description: str | None) -> list[dict]:
+    sentences = []
+    if robot_description is not None:
+        sentences.append(f"The agent is {robot_description}.")
+    if camera_description is not None:
+        sentences.append(f"The observation is captured from {camera_description}.")
+    return [{"type": "text", "text": " ".join(sentences)}]
+
+
+def _analysis_block(
+    description: str | None = None,
+    match_answer: str | None = None,
+    success_answer: str | None = None,
+) -> list[dict]:
+    lines = []
+    if description:
+        lines.append(f"- Video Description: {description}")
+    if match_answer is not None:
+        lines.append(f"- Match: {match_answer}")
+    if success_answer is not None:
+        lines.append(f"- Success: {success_answer}")
+    if not lines:
+        return []
+    return [
+        {"type": "text", "text": "Analysis: \n"},
+        {"type": "text", "text": "\n".join(lines)},
+    ]
+
+
+class ConversationBuilder(ABC):
+    name = "base"
+    PROGRESS_QUESTION = "Estimate the minimum remaining time in seconds until the agent completes the task."
+
+    def __init__(
+        self,
+        value_token: str,
+        relative_value_token: str | None,
+        use_meta: bool = False,
+        value_token_repeat: int = 1,
+        relative_value_token_repeat: int = 1,
+    ):
+        self.value_token = value_token
+        self.relative_value_token = relative_value_token
+        self.use_meta = use_meta
+        if value_token_repeat < 1:
+            raise ValueError(f"value_token_repeat must be >= 1, got {value_token_repeat}")
+        if relative_value_token_repeat < 1:
+            raise ValueError(f"relative_value_token_repeat must be >= 1, got {relative_value_token_repeat}")
+        self.value_token_repeat = int(value_token_repeat)
+        self.relative_value_token_repeat = int(relative_value_token_repeat)
+
+    def _maybe_meta(self, robot_description: str | None, camera_description: str | None) -> list[dict]:
+        if not self.use_meta:
+            return []
+        if robot_description is None and camera_description is None:
+            raise ValueError(
+                "use_meta=True requires at least one of `robot_description` or "
+                "`camera_description` to be provided."
+            )
+        return _meta_block(robot_description, camera_description)
+
+    @staticmethod
+    def _instruction_block(instruction: str) -> list[dict]:
+        return [{"type": "text", "text": f"The agent is performing the following task: {instruction}."}]
+
+    def _append_value_tokens(self, content: list[dict]) -> None:
+        for _ in range(self.value_token_repeat):
+            content.append({"type": "text", "text": self.value_token})
+
+    def _append_relative_value_tokens(self, content: list[dict]) -> None:
+        for _ in range(self.relative_value_token_repeat):
+            content.append({"type": "text", "text": self.relative_value_token})
+
+    @abstractmethod
+    def progress_value_count(self, num_frames: int) -> int: ...
+
+    @abstractmethod
+    def build_progress(self, **kwargs) -> list[dict]: ...
+
+
+class InterleavedHistoryConversationBuilder(ConversationBuilder):
+    name = "interleaved_history"
+    RELATIVE_DISTANCE_QUESTION = (
+        "For each frame after the first, what is the time delta from the previous frame?"
+    )
+
+    @staticmethod
+    def _build_analysis_prompt(has_description: bool) -> str:
+        lines = ["Analyze this trajectory. Provide:"]
+        if has_description:
+            lines.append("- Video Description: a brief description of what the agent is doing in the video.")
+        lines.extend(
+            [
+                "- Match: whether the video matches the stated task (Yes/No).",
+                "- Success: whether the agent has completed the task (Yes/No).",
+            ]
+        )
+        return "\n".join(lines)
+
+    def progress_value_count(self, num_frames: int) -> int:
+        return num_frames
+
+    def build_progress(
+        self,
+        instruction: str,
+        description: str | None,
+        num_frames: int,
+        robot_description: str | None,
+        camera_description: str | None,
+        match_answer: str | None = None,
+        success_answer: str | None = None,
+        is_inference: bool = False,
+    ) -> list[dict]:
+        if self.relative_value_token is None:
+            raise ValueError(
+                "interleaved_history conversation requires a registered "
+                "<relative_value> token (enable relative_value_head_config)."
+            )
+        content = self._maybe_meta(robot_description, camera_description)
+        content.extend(self._instruction_block(instruction))
+        content.append({"type": "text", "text": f"Question: {self.RELATIVE_DISTANCE_QUESTION}"})
+        content.append({"type": "text", "text": f"Question: {self.PROGRESS_QUESTION}"})
+        for i in range(num_frames):
+            content.append({"type": "image"})
+            if i > 0:
+                self._append_relative_value_tokens(content)
+            self._append_value_tokens(content)
+        analysis_prompt = self._build_analysis_prompt(
+            has_description=True if is_inference else bool(description)
+        )
+        analysis = _analysis_block(description, match_answer, success_answer)
+        content.append({"type": "text", "text": analysis_prompt})
+        if not analysis and is_inference:
+            analysis = [{"type": "text", "text": "Analysis: \n"}]
+        content.extend(analysis)
+        return content
+
+
+_REGISTRY = {InterleavedHistoryConversationBuilder.name: InterleavedHistoryConversationBuilder}
+
+
+def build_conversation_builder(
+    style: str,
+    *,
+    value_token: str,
+    relative_value_token: str | None,
+    use_meta: bool = False,
+    value_token_repeat: int = 1,
+    relative_value_token_repeat: int = 1,
+) -> ConversationBuilder:
+    if style not in _REGISTRY:
+        raise ValueError(f"Unknown conversation_style: {style!r}. Expected one of {sorted(_REGISTRY)}.")
+    return _REGISTRY[style](
+        value_token=value_token,
+        relative_value_token=relative_value_token,
+        use_meta=use_meta,
+        value_token_repeat=value_token_repeat,
+        relative_value_token_repeat=relative_value_token_repeat,
+    )
+
+
+__all__ = [
+    "ConversationBuilder",
+    "InterleavedHistoryConversationBuilder",
+    "build_conversation_builder",
+]

--- a/src/lerobot/rewards/rynnvalue/rynn_value_lang/modeling_rynn_value_lang.py
+++ b/src/lerobot/rewards/rynnvalue/rynn_value_lang/modeling_rynn_value_lang.py
@@ -1,0 +1,313 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+
+import torch
+from torch import nn
+from torch.nn import functional
+from transformers.cache_utils import Cache
+from transformers.modeling_outputs import ModelOutput
+from transformers.models.qwen3_vl import Qwen3VLForConditionalGeneration
+from transformers.processing_utils import Unpack
+from transformers.utils import TransformersKwargs
+
+from . import attention_impl as _attention_impl  # noqa: F401
+from .configuration_rynn_value_lang import RynnValueLangConfig
+from .value_heads import build_value_head
+from .value_tokenizer import ValueTokenizer
+
+
+@dataclass
+class _ValueOutput:
+    loss: torch.Tensor | None = None
+    logits: torch.Tensor | None = None
+    pred_value: torch.Tensor | None = None
+    value_logits: torch.Tensor | None = None
+    entropy: torch.Tensor | None = None
+
+
+@dataclass
+class _RelativeValueOutput:
+    pred_value: torch.Tensor | None = None
+    loss: torch.Tensor | None = None
+    logits: torch.Tensor | None = None
+
+
+@dataclass
+class RynnValueLangOutputWithPast(ModelOutput):
+    past_key_values: Cache | tuple | None = None
+    hidden_states: tuple[torch.FloatTensor, ...] | None = None
+    attentions: tuple[torch.FloatTensor, ...] | None = None
+    rope_deltas: torch.LongTensor | None = None
+    value: _ValueOutput | None = None
+    relative: _RelativeValueOutput | None = None
+    lang_loss: torch.Tensor | None = None
+    logits: torch.FloatTensor | None = None
+    cached_pred_key: torch.Tensor | None = None
+
+
+class RynnValueLangModel(Qwen3VLForConditionalGeneration):
+    config: RynnValueLangConfig
+    model_type = "rynn_value_lang"
+
+    def __init__(self, config: RynnValueLangConfig):
+        super().__init__(config)
+        input_dim = config.text_config.hidden_size
+        output_dim = config.value_tokenizer_config.bins
+        self.value_tokenizer = ValueTokenizer.from_config(config.value_tokenizer_config)
+        if config.relative_value_head_config is not None:
+            self.relative_value_tokenizer = ValueTokenizer.from_config(config.relative_value_tokenizer_config)
+            relative_output_dim = config.relative_value_tokenizer_config.bins
+        else:
+            self.relative_value_tokenizer = self.value_tokenizer
+            relative_output_dim = output_dim
+        self.value_heads = None
+        if config.value_head_config is not None:
+            self.value_heads = nn.ModuleList(
+                [
+                    build_value_head(
+                        config.value_head_config,
+                        input_dim=input_dim * config.value_token_repeat,
+                        output_dim=output_dim,
+                    )
+                    for _ in range(config.num_value_heads)
+                ]
+            )
+        self.relative_value_head = None
+        if config.relative_value_head_config is not None:
+            self.relative_value_head = build_value_head(
+                config.relative_value_head_config,
+                input_dim=input_dim * config.relative_value_token_repeat,
+                output_dim=relative_output_dim,
+            )
+        self.post_init()
+
+    @classmethod
+    def from_qwen3vl(
+        cls,
+        pretrained_model_name_or_path: str,
+        config: RynnValueLangConfig | None = None,
+        value_tokenizer_config=None,
+        value_head_config=None,
+        num_value_heads: int = 1,
+        **kwargs,
+    ) -> "RynnValueLangModel":
+        if config is None:
+            config = RynnValueLangConfig.from_qwen3vl(
+                pretrained_model_name_or_path,
+                value_tokenizer_config=value_tokenizer_config,
+                value_head_config=value_head_config,
+                num_value_heads=num_value_heads,
+            )
+        return cls.from_pretrained(pretrained_model_name_or_path, config=config, **kwargs)
+
+    def _compute_value_loss(self, logits, target_value, fusion_mask=None):
+        logits = logits.float()
+        if logits.shape[-1] != self.value_tokenizer.n_bins:
+            raise ValueError(f"Expected logits last dim == n_bins ({self.value_tokenizer.n_bins}).")
+        target_dist = self.value_tokenizer.encode(
+            self.value_tokenizer._to_tensor(target_value, device=logits.device)
+        ).to(device=logits.device, dtype=logits.dtype)
+        if fusion_mask is not None:
+            mask = fusion_mask.to(target_dist.device).bool().view(*target_dist.shape[:-1])
+            if mask.any():
+                target_dist = torch.where(
+                    mask.unsqueeze(-1),
+                    torch.full_like(target_dist, 1.0 / self.value_tokenizer.n_bins),
+                    target_dist,
+                )
+        if (n_extra := logits.ndim - target_dist.ndim) > 0:
+            target_dist = target_dist.view(*([1] * n_extra), *target_dist.shape).expand_as(logits)
+        return -(target_dist * functional.log_softmax(logits, dim=-1)).sum(dim=-1)
+
+    def _compute_relative_value_loss(self, logits, target_value):
+        logits = logits.float()
+        if logits.shape[-1] != self.relative_value_tokenizer.n_bins:
+            raise ValueError(f"Expected logits last dim == n_bins ({self.relative_value_tokenizer.n_bins}).")
+        target_dist = self.relative_value_tokenizer.encode(
+            self.relative_value_tokenizer._to_tensor(target_value, device=logits.device)
+        ).to(device=logits.device, dtype=logits.dtype)
+        if (n_extra := logits.ndim - target_dist.ndim) > 0:
+            target_dist = target_dist.view(*([1] * n_extra), *target_dist.shape).expand_as(logits)
+        return -(target_dist * functional.log_softmax(logits, dim=-1)).sum(dim=-1)
+
+    @staticmethod
+    def _compute_entropy(logits):
+        probs = torch.softmax(logits.float(), dim=-1)
+        return -(probs * torch.log(probs + 1e-8)).sum(dim=-1)
+
+    @staticmethod
+    def _gather_by_token_id(hidden_states, input_ids, token_id):
+        if input_ids is None or token_id is None or token_id < 0:
+            return None, None
+        mask = input_ids.eq(token_id)
+        if not mask.any():
+            return None, None
+        batch_indices, positions = mask.nonzero(as_tuple=True)
+        flattened = hidden_states[batch_indices, positions].contiguous()
+        return flattened, flattened.shape[:-1]
+
+    @staticmethod
+    def _concat_slot_tokens(flattened, prefix_shape, repeat, token_name):
+        if repeat > 1:
+            total_keep = flattened.shape[0]
+            if total_keep % repeat:
+                raise ValueError(
+                    f"Number of {token_name} tokens ({total_keep}) is not divisible by repeat ({repeat})."
+                )
+            flattened = flattened.view(total_keep // repeat, repeat, -1).reshape(total_keep // repeat, -1)
+            prefix_shape = flattened.shape[:-1]
+        return flattened, prefix_shape
+
+    def _compute_value_outputs(self, hidden_states, input_ids, value, fusion_mask=None):
+        flattened, prefix_shape = self._gather_by_token_id(
+            hidden_states, input_ids, self.config.value_token_id
+        )
+        if flattened is None:
+            return _ValueOutput()
+        flattened, prefix_shape = self._concat_slot_tokens(
+            flattened, prefix_shape, self.config.value_token_repeat, "<value>"
+        )
+        if self.value_heads is not None:
+            value_logits = torch.stack([head(flattened) for head in self.value_heads], dim=0).view(
+                len(self.value_heads), *prefix_shape, -1
+            )
+            loss = self._compute_value_loss(value_logits, value, fusion_mask) if value is not None else None
+            return _ValueOutput(
+                loss=loss,
+                logits=value_logits,
+                pred_value=self.value_tokenizer.decode_from_bins(value_logits),
+                value_logits=value_logits,
+                entropy=self._compute_entropy(value_logits),
+            )
+        logits = self.lm_head(flattened)[..., -self.value_tokenizer.n_bins :].view(*prefix_shape, -1)
+        return _ValueOutput(
+            loss=self._compute_value_loss(logits, value, fusion_mask) if value is not None else None,
+            logits=logits,
+            pred_value=self.value_tokenizer.decode_from_bins(logits),
+            entropy=self._compute_entropy(logits),
+        )
+
+    def _compute_relative_value_outputs(self, hidden_states, input_ids, relative_value):
+        if self.relative_value_head is None:
+            return _RelativeValueOutput()
+        flattened, prefix_shape = self._gather_by_token_id(
+            hidden_states, input_ids, self.config.relative_value_token_id
+        )
+        if flattened is None:
+            return _RelativeValueOutput()
+        flattened, prefix_shape = self._concat_slot_tokens(
+            flattened, prefix_shape, self.config.relative_value_token_repeat, "<relative_value>"
+        )
+        logits = self.relative_value_head(flattened).view(*prefix_shape, -1)
+        return _RelativeValueOutput(
+            pred_value=self.relative_value_tokenizer.decode_from_bins(logits),
+            loss=(
+                self._compute_relative_value_loss(logits, relative_value)
+                if relative_value is not None
+                else None
+            ),
+            logits=logits,
+        )
+
+    def _is_pred_token(self, input_ids):
+        mask = input_ids.eq(self.config.value_token_id)
+        if self.config.relative_value_token_id is not None:
+            mask |= input_ids.eq(self.config.relative_value_token_id)
+        return mask
+
+    def _build_pred_slot_extras(self, input_ids, past_key_values=None, cached_pred_key=None):
+        del past_key_values
+        if input_ids is None:
+            return {}, cached_pred_key
+        if cached_pred_key is not None:
+            is_pred_key = torch.cat([cached_pred_key, self._is_pred_token(input_ids)], dim=1)
+            return {"is_pred_key": is_pred_key}, is_pred_key
+        is_special = self._is_pred_token(input_ids)
+        previous_ids = functional.pad(input_ids[:, :-1], (1, 0), value=-1)
+        previous_special = functional.pad(is_special[:, :-1], (1, 0), value=False)
+        slot_start = is_special & ~(is_special & previous_special & input_ids.eq(previous_ids))
+        running = slot_start.long().cumsum(dim=1) - 1
+        slot_id = torch.where(is_special, running, torch.full_like(running, -1))
+        return {"is_pred_key": is_special, "pred_slot_id": slot_id}, is_special
+
+    def _update_model_kwargs_for_generation(self, outputs, model_kwargs, **kwargs):
+        model_kwargs = super()._update_model_kwargs_for_generation(outputs, model_kwargs, **kwargs)
+        model_kwargs["cached_pred_key"] = outputs.get("cached_pred_key")
+        return model_kwargs
+
+    def forward(
+        self,
+        input_ids: torch.LongTensor = None,
+        attention_mask: torch.Tensor | None = None,
+        position_ids: torch.LongTensor | None = None,
+        past_key_values: Cache | None = None,
+        inputs_embeds: torch.FloatTensor | None = None,
+        labels: torch.LongTensor | None = None,
+        pixel_values: torch.Tensor | None = None,
+        pixel_values_videos: torch.FloatTensor | None = None,
+        image_grid_thw: torch.LongTensor | None = None,
+        video_grid_thw: torch.LongTensor | None = None,
+        cache_position: torch.LongTensor | None = None,
+        value: torch.Tensor | None = None,
+        relative_value: torch.Tensor | None = None,
+        value_fusion_mask: torch.Tensor | None = None,
+        cached_pred_key: torch.Tensor | None = None,
+        logits_to_keep: int | torch.Tensor = 0,
+        output_attentions: bool | None = None,
+        output_hidden_states: bool | None = None,
+        return_dict: bool | None = None,
+        **kwargs: Unpack[TransformersKwargs],
+    ) -> RynnValueLangOutputWithPast:
+        del return_dict
+        extras, cached_pred_key = self._build_pred_slot_extras(input_ids, past_key_values, cached_pred_key)
+        outputs = self.model(
+            input_ids=input_ids,
+            pixel_values=pixel_values,
+            pixel_values_videos=pixel_values_videos,
+            image_grid_thw=image_grid_thw,
+            video_grid_thw=video_grid_thw,
+            position_ids=position_ids,
+            attention_mask=attention_mask,
+            past_key_values=past_key_values,
+            inputs_embeds=inputs_embeds,
+            cache_position=cache_position,
+            output_attentions=output_attentions,
+            output_hidden_states=output_hidden_states,
+            return_dict=True,
+            **extras,
+            **kwargs,
+        )
+        hidden_states = outputs[0]
+        logits = lang_loss = None
+        if labels is not None:
+            logits = self.lm_head(hidden_states)
+            lang_loss = self.loss_function(
+                logits=logits, labels=labels, vocab_size=self.config.text_config.vocab_size
+            )
+        elif not (isinstance(logits_to_keep, int) and logits_to_keep == 0):
+            indices = slice(-logits_to_keep, None) if isinstance(logits_to_keep, int) else logits_to_keep
+            logits = self.lm_head(hidden_states[:, indices])
+        return RynnValueLangOutputWithPast(
+            past_key_values=outputs.past_key_values,
+            hidden_states=getattr(outputs, "hidden_states", None),
+            attentions=getattr(outputs, "attentions", None),
+            rope_deltas=outputs.rope_deltas,
+            value=self._compute_value_outputs(hidden_states, input_ids, value, value_fusion_mask),
+            relative=self._compute_relative_value_outputs(hidden_states, input_ids, relative_value),
+            lang_loss=lang_loss,
+            logits=logits,
+            cached_pred_key=cached_pred_key,
+        )

--- a/src/lerobot/rewards/rynnvalue/rynn_value_lang/processing_rynn_value_lang.py
+++ b/src/lerobot/rewards/rynnvalue/rynn_value_lang/processing_rynn_value_lang.py
@@ -1,0 +1,244 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any
+
+import torch
+from einops import rearrange
+from transformers import AutoTokenizer, Qwen2VLImageProcessor, Qwen3VLVideoProcessor
+from transformers.feature_extraction_utils import BatchFeature
+from transformers.models.qwen3_vl.processing_qwen3_vl import (
+    Qwen3VLProcessor,
+    Qwen3VLProcessorKwargs,
+)
+from transformers.processing_utils import Unpack
+
+from .conversations import (
+    ConversationBuilder,
+    InterleavedHistoryConversationBuilder,
+    build_conversation_builder,
+)
+
+DEFAULT_CONVERSATION_STYLE = InterleavedHistoryConversationBuilder.name
+
+
+class RynnValueLangProcessor(Qwen3VLProcessor):
+    def __init__(
+        self,
+        image_processor=None,
+        tokenizer=None,
+        video_processor=None,
+        chat_template=None,
+        use_meta=False,
+        conversation_style: str = DEFAULT_CONVERSATION_STYLE,
+        value_token_repeat: int = 1,
+        relative_value_token_repeat: int = 1,
+        **kwargs,
+    ):
+        super().__init__(
+            image_processor=image_processor,
+            tokenizer=tokenizer,
+            video_processor=video_processor,
+            chat_template=chat_template,
+            **kwargs,
+        )
+        self.use_meta = use_meta
+        self.conversation_style = conversation_style
+        if value_token_repeat < 1 or relative_value_token_repeat < 1:
+            raise ValueError("value token repeat counts must be >= 1")
+        self.value_token_repeat = int(value_token_repeat)
+        self.relative_value_token_repeat = int(relative_value_token_repeat)
+        self.conversation_builder: ConversationBuilder = self._build_conversation_builder()
+
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path: str, **kwargs):
+        """Load checkpoint assets explicitly without executing Hub model code.
+
+        Released RynnValue processor metadata predates Transformers 5 and does
+        not describe its video processor. Constructing the known Qwen
+        components directly avoids both that compatibility issue and
+        ``trust_remote_code``.
+        """
+        processor_dict, _ = cls.get_processor_dict(pretrained_model_name_or_path, **kwargs)
+        load_keys = {
+            "cache_dir",
+            "force_download",
+            "local_files_only",
+            "proxies",
+            "revision",
+            "subfolder",
+            "token",
+        }
+        load_kwargs = {key: value for key, value in kwargs.items() if key in load_keys}
+        tokenizer = AutoTokenizer.from_pretrained(
+            pretrained_model_name_or_path,
+            trust_remote_code=False,
+            **load_kwargs,
+        )
+        image_processor = Qwen2VLImageProcessor.from_pretrained(
+            pretrained_model_name_or_path,
+            **load_kwargs,
+        )
+        return cls(
+            image_processor=image_processor,
+            tokenizer=tokenizer,
+            video_processor=Qwen3VLVideoProcessor(),
+            chat_template=getattr(tokenizer, "chat_template", None),
+            use_meta=kwargs.get("use_meta", processor_dict.get("use_meta", False)),
+            conversation_style=kwargs.get(
+                "conversation_style",
+                processor_dict.get("conversation_style", DEFAULT_CONVERSATION_STYLE),
+            ),
+            value_token_repeat=kwargs.get("value_token_repeat", processor_dict.get("value_token_repeat", 1)),
+            relative_value_token_repeat=kwargs.get(
+                "relative_value_token_repeat",
+                processor_dict.get("relative_value_token_repeat", 1),
+            ),
+        )
+
+    @classmethod
+    def from_qwen3vl(cls, pretrained_model_name_or_path: str, **kwargs):
+        return cls.from_pretrained(pretrained_model_name_or_path, **kwargs)
+
+    @property
+    def value_token(self):
+        return "<value>"
+
+    @property
+    def value_token_id(self):
+        return self.tokenizer.convert_tokens_to_ids(self.value_token)
+
+    @property
+    def relative_value_token(self):
+        return "<relative_value>" if "<relative_value>" in self.tokenizer.get_vocab() else None
+
+    @property
+    def relative_value_token_id(self):
+        token = self.relative_value_token
+        return None if token is None else self.tokenizer.convert_tokens_to_ids(token)
+
+    def __call__(self, images=None, text=None, **kwargs: Unpack[Qwen3VLProcessorKwargs]) -> BatchFeature:
+        kwargs["return_tensors"] = "pt"
+        return super().__call__(images=images, text=text, **kwargs)
+
+    def _build_conversation_builder(self):
+        return build_conversation_builder(
+            self.conversation_style,
+            value_token=self.value_token,
+            relative_value_token=self.relative_value_token,
+            use_meta=self.use_meta,
+            value_token_repeat=self.value_token_repeat,
+            relative_value_token_repeat=self.relative_value_token_repeat,
+        )
+
+    def refresh_conversation_builder(self):
+        self.conversation_builder = self._build_conversation_builder()
+        return self.conversation_builder
+
+    def _progress_targets(self, goal_timestamp, frame_timestamps, device, value_count):
+        timestamps = frame_timestamps.to(device).reshape(-1)
+        goal = goal_timestamp.to(device).reshape(1)
+        target = (
+            (goal - timestamps[-1:]).float().unsqueeze(0)
+            if value_count == 1
+            else (goal - timestamps).float().unsqueeze(0)
+        )
+        if target.shape[1] != value_count:
+            raise ValueError(
+                f"Conversation builder expects {value_count} <value> targets but "
+                f"received {target.shape[1]} frame timestamps."
+            )
+        return target.clamp_min(0)
+
+    def process_history(
+        self,
+        instruction: str,
+        description: str | None,
+        images: list[Any],
+        frame_timestamps: torch.Tensor,
+        goal_timestamp: torch.Tensor,
+        success: bool | None = None,
+        fusion: bool | None = None,
+        robot_description: str | None = None,
+        camera_description: str | None = None,
+    ) -> BatchFeature:
+        builder = self.conversation_builder
+        value_count = builder.progress_value_count(len(images))
+        fusion_flag = int(bool(fusion))
+        content = builder.build_progress(
+            instruction=instruction,
+            description=description,
+            num_frames=len(images),
+            robot_description=robot_description,
+            camera_description=camera_description,
+            match_answer="No" if fusion_flag else "Yes",
+            success_answer=None if success is None else ("Yes" if success else "No"),
+        )
+        outputs = self(text=self.apply_chat_template([{"role": "user", "content": content}]), images=images)
+        input_ids = outputs["input_ids"]
+        target = self._progress_targets(goal_timestamp, frame_timestamps, input_ids.device, value_count)
+        outputs["value"] = target
+        outputs["value_fusion_mask"] = torch.full_like(target, fusion_flag, dtype=torch.long)
+        timestamps = frame_timestamps.reshape(-1).to(input_ids.device).float()
+        outputs["relative_value"] = (timestamps[1:] - timestamps[:-1]).unsqueeze(0)
+        outputs["labels"] = self._build_history_labels(input_ids)
+        return outputs
+
+    def _build_history_labels(self, input_ids: torch.Tensor) -> torch.Tensor:
+        marker = torch.tensor(
+            self.tokenizer.encode("Analysis: \n", add_special_tokens=False),
+            device=input_ids.device,
+        )
+        labels = torch.full_like(input_ids, -100)
+        for batch_index, sequence in enumerate(input_ids):
+            for index in range(sequence.shape[0] - marker.shape[0], -1, -1):
+                if torch.equal(sequence[index : index + marker.shape[0]], marker):
+                    start = index + marker.shape[0]
+                    labels[batch_index, start:] = sequence[start:]
+                    break
+            else:
+                raise ValueError(f"'Analysis:' marker not found in sample {batch_index}.")
+        return labels
+
+    def process_episode(
+        self,
+        instruction: str,
+        images: list[Any],
+        robot_description: str | None = None,
+        camera_description: str | None = None,
+    ) -> BatchFeature:
+        if not images:
+            raise ValueError("process_episode requires at least one prediction image.")
+        content = self.conversation_builder.build_progress(
+            instruction=instruction,
+            description=None,
+            num_frames=len(images),
+            robot_description=robot_description,
+            camera_description=camera_description,
+            is_inference=True,
+        )
+        outputs = self(text=self.apply_chat_template([{"role": "user", "content": content}]), images=images)
+        input_ids = outputs["input_ids"]
+        eos_id = self.tokenizer.convert_tokens_to_ids("<|im_end|>")
+        eos_positions = input_ids[0].eq(eos_id).nonzero(as_tuple=True)[0]
+        if len(eos_positions):
+            input_ids = input_ids[:, : eos_positions[-1]]
+        outputs["input_ids"] = input_ids
+        sequence_length = input_ids.shape[-1]
+        outputs["attention_mask"] = outputs["attention_mask"][:, :sequence_length]
+        if "mm_token_type_ids" in outputs:
+            outputs["mm_token_type_ids"] = outputs["mm_token_type_ids"][:, :sequence_length]
+        outputs["pixel_values"] = rearrange(outputs["pixel_values"], "(b t) d -> b t d", b=1)
+        outputs["image_grid_thw"] = rearrange(outputs["image_grid_thw"], "(b t) d -> b t d", b=1)
+        return outputs

--- a/src/lerobot/rewards/rynnvalue/rynn_value_lang/value_heads.py
+++ b/src/lerobot/rewards/rynnvalue/rynn_value_lang/value_heads.py
@@ -1,0 +1,152 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+
+import torch
+from torch import nn
+
+
+def default_init():
+    def _init(module: nn.Module):
+        if isinstance(module, nn.Linear):
+            nn.init.kaiming_uniform_(module.weight, a=math.sqrt(5))
+            if module.bias is not None:
+                fan_in, _ = nn.init._calculate_fan_in_and_fan_out(module.weight)
+                bound = 1 / math.sqrt(fan_in) if fan_in > 0 else 0
+                nn.init.uniform_(module.bias, -bound, bound)
+
+    return _init
+
+
+class LinearValueHead(nn.Module):
+    def __init__(self, input_dim: int, output_dim: int, device=None, dtype=None) -> None:
+        super().__init__()
+        self.proj = nn.Linear(input_dim, output_dim, device=device, dtype=dtype)
+        self.apply(default_init())
+
+    @classmethod
+    def from_config(cls, config, input_dim: int, output_dim: int, **kwargs):
+        return cls(input_dim=input_dim, output_dim=output_dim, **kwargs)
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return self.proj(hidden_states)
+
+
+class ResidualBlock(nn.Module):
+    def __init__(self, hidden_dims: int, activation=None, device=None, dtype=None) -> None:
+        super().__init__()
+        self.fc1 = nn.Linear(hidden_dims, hidden_dims, device=device, dtype=dtype)
+        self.ln1 = nn.LayerNorm(hidden_dims, device=device, dtype=dtype)
+        self.act = activation if activation is not None else nn.ReLU()
+        self.fc2 = nn.Linear(hidden_dims, hidden_dims, device=device, dtype=dtype)
+        self.ln2 = nn.LayerNorm(hidden_dims, device=device, dtype=dtype)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x + self.ln2(self.fc2(self.act(self.ln1(self.fc1(x)))))
+
+
+class BroNet(nn.Module):
+    def __init__(
+        self,
+        input_dim: int,
+        hidden_dims: int,
+        depth: int,
+        activation=None,
+        output_dim: int = 1,
+        device=None,
+        dtype=None,
+    ) -> None:
+        super().__init__()
+        if depth < 1:
+            raise ValueError(f"Unsupported depth: {depth}. Expected depth >= 1.")
+        self.activation = activation if activation is not None else nn.ReLU()
+        self.input_layer = nn.Linear(input_dim, hidden_dims, device=device, dtype=dtype)
+        self.input_norm = nn.LayerNorm(hidden_dims, device=device, dtype=dtype)
+        self.blocks = nn.ModuleList(
+            [
+                ResidualBlock(hidden_dims, self._make_activation(), device=device, dtype=dtype)
+                for _ in range(depth)
+            ]
+        )
+        self.final_layer = nn.Linear(hidden_dims, output_dim, device=device, dtype=dtype)
+        self.apply(default_init())
+
+    def _make_activation(self) -> nn.Module:
+        if isinstance(self.activation, nn.LeakyReLU):
+            return nn.LeakyReLU(self.activation.negative_slope)
+        for cls in (nn.ReLU, nn.GELU, nn.SiLU, nn.Tanh):
+            if isinstance(self.activation, cls):
+                return cls()
+        return self.activation
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.activation(self.input_norm(self.input_layer(x)))
+        for block in self.blocks:
+            x = block(x)
+        return self.final_layer(x)
+
+
+class BroValueHead(nn.Module):
+    def __init__(
+        self,
+        input_dim: int,
+        output_dim: int,
+        hidden_dims: int = 1024,
+        depth: int = 2,
+        activation: str = "relu",
+        device=None,
+        dtype=None,
+    ) -> None:
+        super().__init__()
+        self.proj = BroNet(
+            input_dim, hidden_dims, depth, self._build_activation(activation), output_dim, device, dtype
+        )
+
+    @classmethod
+    def from_config(cls, config, input_dim: int, output_dim: int, **kwargs):
+        return cls(
+            input_dim=input_dim,
+            output_dim=output_dim,
+            hidden_dims=getattr(config, "hidden_dims", 1024),
+            depth=getattr(config, "depth", 2),
+            activation=getattr(config, "activation", "relu"),
+            **kwargs,
+        )
+
+    @staticmethod
+    def _build_activation(name: str) -> nn.Module:
+        activations = {
+            "relu": nn.ReLU,
+            "gelu": nn.GELU,
+            "silu": nn.SiLU,
+            "tanh": nn.Tanh,
+            "leaky_relu": nn.LeakyReLU,
+        }
+        try:
+            return activations[name.lower()]()
+        except KeyError as e:
+            raise ValueError(f"Unsupported activation: {name}") from e
+
+    def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return self.proj(hidden_states)
+
+
+def build_value_head(config, input_dim: int, output_dim: int, **kwargs):
+    head_type = getattr(config, "head_type", "linear")
+    if head_type == "linear":
+        return LinearValueHead.from_config(config, input_dim=input_dim, output_dim=output_dim, **kwargs)
+    if head_type == "bro":
+        return BroValueHead.from_config(config, input_dim=input_dim, output_dim=output_dim, **kwargs)
+    raise ValueError(f"Unsupported value head type: {head_type}")

--- a/src/lerobot/rewards/rynnvalue/rynn_value_lang/value_tokenizer.py
+++ b/src/lerobot/rewards/rynnvalue/rynn_value_lang/value_tokenizer.py
@@ -1,0 +1,166 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+
+
+def to_symlog(x: torch.Tensor) -> torch.Tensor:
+    return torch.sign(x) * torch.log1p(torch.abs(x))
+
+
+def to_symexp(x: torch.Tensor) -> torch.Tensor:
+    return torch.sign(x) * torch.expm1(torch.abs(x))
+
+
+TRANSFORMS = {"symlog": (to_symlog, to_symexp)}
+_INV_SQRT2 = 0.7071067811865476
+
+
+def _normal_cdf(x: torch.Tensor) -> torch.Tensor:
+    return 0.5 * (1.0 + torch.erf(x * _INV_SQRT2))
+
+
+class ValueTokenizer:
+    """Discretize continuous scalar values into distributional targets."""
+
+    def __init__(
+        self,
+        bins: int = 256,
+        min_value: float = 0.0,
+        max_value: float = 1000.0,
+        forward_transform=None,
+        inverse_transform=None,
+        support_transform: str = "linear",
+        encoding: str = "two_hot",
+        hl_gauss_sigma_ratio: float = 0.75,
+        bin_edges=None,
+        device=None,
+        dtype=torch.float32,
+    ) -> None:
+        self.n_bins = bins
+        self.min_val = float(min_value)
+        self.max_val = float(max_value)
+        self.support_transform = support_transform
+        self.encoding = encoding
+        self.hl_gauss_sigma = float(hl_gauss_sigma_ratio)
+        self.forward_transform = forward_transform if forward_transform is not None else self.identity
+        self.inverse_transform = inverse_transform if inverse_transform is not None else self.identity
+        self.device = device
+        self.dtype = dtype
+        self.is_quantile = support_transform == "quantile"
+
+        if self.is_quantile:
+            if bin_edges is None:
+                raise ValueError("support_transform='quantile' requires bin_edges of length bins+1.")
+            edges = torch.as_tensor(bin_edges, dtype=dtype, device=device)
+            if edges.numel() != self.n_bins + 1:
+                raise ValueError(
+                    f"bin_edges must have length bins+1 ({self.n_bins + 1}), got {edges.numel()}."
+                )
+            self.edges = edges
+            self.center_values = 0.5 * (edges[:-1] + edges[1:])
+            self.min_sym = self.max_sym = self.centers_sym = self.bin_stride_sym = None
+        else:
+            self.edges = self.center_values = None
+            self.min_sym = self.forward_transform(torch.tensor(self.min_val, dtype=dtype, device=device))
+            self.max_sym = self.forward_transform(torch.tensor(self.max_val, dtype=dtype, device=device))
+            self.centers_sym = torch.linspace(
+                self.min_sym, self.max_sym, self.n_bins, dtype=dtype, device=device
+            )
+            self.bin_stride_sym = (
+                self.centers_sym[1] - self.centers_sym[0]
+                if self.n_bins > 1
+                else torch.tensor(1.0, dtype=dtype, device=device)
+            )
+
+    @classmethod
+    def from_config(cls, config, **kwargs):
+        forward_transform = inverse_transform = None
+        if config.support_transform in TRANSFORMS:
+            forward_transform, inverse_transform = TRANSFORMS[config.support_transform]
+        return cls(
+            bins=config.bins,
+            min_value=config.min_value,
+            max_value=config.max_value,
+            forward_transform=forward_transform,
+            inverse_transform=inverse_transform,
+            support_transform=config.support_transform,
+            encoding=getattr(config, "encoding", "two_hot"),
+            hl_gauss_sigma_ratio=getattr(config, "hl_gauss_sigma_ratio", 0.75),
+            bin_edges=getattr(config, "bin_edges", None),
+            **kwargs,
+        )
+
+    @staticmethod
+    def identity(x: torch.Tensor) -> torch.Tensor:
+        return x
+
+    def _to_tensor(self, x, device=None):
+        if isinstance(x, torch.Tensor):
+            return x.to(device=device if device is not None else x.device, dtype=self.dtype)
+        return torch.tensor(x, dtype=self.dtype, device=device if device is not None else self.device)
+
+    def _value_to_idx(self, value: torch.Tensor) -> torch.Tensor:
+        value = self._to_tensor(value)
+        device = value.device
+        if self.is_quantile:
+            centers = self.center_values.to(device)
+            value = torch.clamp(value, min=centers[0], max=centers[-1])
+            pos = torch.searchsorted(centers, value, right=True).clamp(1, self.n_bins - 1)
+            left, right = centers[pos - 1], centers[pos]
+            return (pos - 1).to(value.dtype) + (value - left) / (right - left).clamp_min(1e-12)
+        value = torch.clamp(
+            value,
+            min=torch.tensor(self.min_val, dtype=self.dtype, device=device),
+            max=torch.tensor(self.max_val, dtype=self.dtype, device=device),
+        )
+        return (self.forward_transform(value) - self.min_sym.to(device)) / self.bin_stride_sym.to(device)
+
+    def encode(self, value: torch.Tensor) -> torch.Tensor:
+        return self.encode_hl_gauss(value) if self.encoding == "hl_gauss" else self.encode_two_hot(value)
+
+    def encode_two_hot(self, value: torch.Tensor) -> torch.Tensor:
+        value = self._to_tensor(value)
+        idx_float = self._value_to_idx(value)
+        idx_left = torch.floor(idx_float).long()
+        idx_right = idx_left + 1
+        weight_right = idx_float - idx_left.to(idx_float.dtype)
+        target = torch.zeros(*value.shape, self.n_bins, dtype=self.dtype, device=value.device)
+        target.scatter_add_(
+            -1, idx_left.clamp(0, self.n_bins - 1).unsqueeze(-1), (1 - weight_right).unsqueeze(-1)
+        )
+        target.scatter_add_(-1, idx_right.clamp(0, self.n_bins - 1).unsqueeze(-1), weight_right.unsqueeze(-1))
+        return target / target.sum(dim=-1, keepdim=True).clamp_min(1e-12)
+
+    def encode_hl_gauss(self, value: torch.Tensor) -> torch.Tensor:
+        value = self._to_tensor(value)
+        idx_float = self._value_to_idx(value)
+        centers = torch.arange(self.n_bins, device=value.device, dtype=idx_float.dtype)
+        center = idx_float.unsqueeze(-1)
+        sigma = max(self.hl_gauss_sigma, 1e-6)
+        probs = _normal_cdf((centers + 0.5 - center) / sigma) - _normal_cdf((centers - 0.5 - center) / sigma)
+        return (probs / probs.sum(dim=-1, keepdim=True).clamp_min(1e-12)).to(self.dtype)
+
+    def decode_from_bins(self, bin_logits: torch.Tensor) -> torch.Tensor:
+        bin_logits = bin_logits.float()
+        if bin_logits.shape[-1] != self.n_bins:
+            raise ValueError(
+                f"Expected bin_logits last dim == n_bins ({self.n_bins}), got {bin_logits.shape[-1]}"
+            )
+        probs = torch.softmax(bin_logits, dim=-1)
+        if self.is_quantile:
+            centers = self.center_values.to(device=bin_logits.device, dtype=bin_logits.dtype)
+            return torch.sum(probs * centers, dim=-1)
+        centers = self.centers_sym.to(device=bin_logits.device, dtype=bin_logits.dtype)
+        return self.inverse_transform(torch.sum(probs * centers, dim=-1))

--- a/src/lerobot/rewards/rynnvalue/scoring_rynnvalue.py
+++ b/src/lerobot/rewards/rynnvalue/scoring_rynnvalue.py
@@ -1,0 +1,378 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""RynnValue adapter for the shared offline frame-scoring workflow."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+import torch
+
+from lerobot.rewards.scoring import FrameSignals, ScoringSummary, SignalDescriptor, score_dataset
+
+from .configuration_rynnvalue import RYNNVALUE_FEATURE_PREFIX, RynnValueConfig
+from .modeling_rynnvalue import RynnValueRewardModel
+from .processor_rynnvalue import RynnValueEncoderProcessorStep, _video_to_pil
+
+if TYPE_CHECKING:
+    from lerobot.datasets import LeRobotDataset
+
+DEFAULT_INFERENCE_FPS = 1.0
+REMAINING_TIME_SIGNAL = "reward.rynnvalue.remaining_time_s"
+POTENTIAL_SIGNAL = "reward.rynnvalue.potential"
+IS_INFERENCE_FRAME_SIGNAL = "reward.rynnvalue.is_inference_frame"
+PROGRESS_SIGNAL = "reward.rynnvalue.progress"
+
+RYNNVALUE_SIGNAL_DESCRIPTORS = {
+    REMAINING_TIME_SIGNAL: SignalDescriptor(
+        description=(
+            "RynnValue predicted seconds remaining for the trajectory prefix, linearly interpolated "
+            "between inference frames."
+        ),
+        unit="s",
+        direction="lower",
+        missing_values="forbidden",
+    ),
+    POTENTIAL_SIGNAL: SignalDescriptor(
+        description="Negative RynnValue remaining time, suitable as a higher-is-better state potential.",
+        unit="s",
+        direction="higher",
+        missing_values="forbidden",
+    ),
+    IS_INFERENCE_FRAME_SIGNAL: SignalDescriptor(
+        description="Whether RynnValue ran on this frame rather than its value being interpolated.",
+        unit=None,
+        direction="none",
+        missing_values="forbidden",
+    ),
+}
+
+PROGRESS_DESCRIPTOR = SignalDescriptor(
+    description="RynnValue progress derived from an explicitly configured remaining-time horizon.",
+    unit=None,
+    direction="higher",
+    missing_values="forbidden",
+    bounds=(0.0, 1.0),
+)
+
+
+def select_anchor_indices(num_frames: int, dataset_fps: float, inference_fps: float) -> np.ndarray:
+    """Select approximately evenly timed anchors and include both episode boundaries."""
+    if num_frames < 1:
+        raise ValueError(f"num_frames must be >= 1, got {num_frames}")
+    if not np.isfinite(dataset_fps) or dataset_fps <= 0:
+        raise ValueError(f"dataset_fps must be positive and finite, got {dataset_fps}")
+    if not np.isfinite(inference_fps) or inference_fps <= 0 or inference_fps > dataset_fps:
+        raise ValueError(
+            f"inference_fps must be in (0, dataset_fps], got {inference_fps} for dataset_fps={dataset_fps}"
+        )
+
+    stride = dataset_fps / inference_fps
+    anchors = np.rint(np.arange(0, num_frames, stride)).astype(np.int64)
+    anchors = np.unique(np.clip(anchors, 0, num_frames - 1))
+    if anchors[-1] != num_frames - 1:
+        anchors = np.append(anchors, num_frames - 1)
+    return anchors
+
+
+def select_prefix_indices(anchor_index: int, max_frames: int | None) -> np.ndarray:
+    """Select a chronological causal prefix ending exactly at ``anchor_index``."""
+    if anchor_index < 0:
+        raise ValueError(f"anchor_index must be non-negative, got {anchor_index}")
+    prefix_length = anchor_index + 1
+    if max_frames is None or prefix_length <= max_frames:
+        return np.arange(prefix_length, dtype=np.int64)
+    if max_frames < 1:
+        raise ValueError(f"max_frames must be positive or None, got {max_frames}")
+    if max_frames == 1:
+        return np.asarray([anchor_index], dtype=np.int64)
+    return np.unique(np.rint(np.linspace(0, anchor_index, max_frames)).astype(np.int64))
+
+
+def interpolate_anchor_values(
+    num_frames: int, anchor_indices: np.ndarray, anchor_values: np.ndarray
+) -> np.ndarray:
+    """Linearly interpolate anchor predictions to every frame in one episode."""
+    if num_frames < 1:
+        raise ValueError(f"num_frames must be >= 1, got {num_frames}")
+    if anchor_indices.ndim != 1 or anchor_values.ndim != 1:
+        raise ValueError("anchor_indices and anchor_values must be one-dimensional")
+    if len(anchor_indices) != len(anchor_values) or not len(anchor_indices):
+        raise ValueError("anchor_indices and anchor_values must have the same non-zero length")
+    if np.any(np.diff(anchor_indices) <= 0):
+        raise ValueError("anchor_indices must be strictly increasing")
+    if anchor_indices[0] != 0 or anchor_indices[-1] != num_frames - 1:
+        raise ValueError("anchor_indices must include the first and last frame")
+    return np.interp(np.arange(num_frames), anchor_indices, anchor_values).astype(np.float32)
+
+
+def remaining_time_to_progress(remaining_time_s: np.ndarray, horizon_s: float) -> np.ndarray:
+    """Convert physical remaining time to bounded progress using an explicit horizon."""
+    if not np.isfinite(horizon_s) or horizon_s <= 0:
+        raise ValueError(f"horizon_s must be positive and finite, got {horizon_s}")
+    return np.clip(1.0 - remaining_time_s / horizon_s, 0.0, 1.0).astype(np.float32)
+
+
+def _dataset_position(dataset: LeRobotDataset, absolute_index: int) -> int:
+    absolute_to_relative = getattr(dataset, "absolute_to_relative_idx", None)
+    if absolute_to_relative is None:
+        return absolute_index
+    try:
+        return int(absolute_to_relative[absolute_index])
+    except KeyError as exc:
+        raise ValueError(
+            f"Dataset view does not contain absolute frame index {absolute_index}; "
+            "make sure the selected episodes match the scoring selection"
+        ) from exc
+
+
+def _resolve_task(sample: dict[str, Any], *, task_key: str, default_task: str | None) -> str:
+    task = sample.get(task_key)
+    if isinstance(task, str) and task:
+        return task
+    if default_task:
+        return default_task
+    raise KeyError(f"Dataset sample has no {task_key!r} string; configure default_task explicitly")
+
+
+@dataclass
+class RynnValueFrameScorer:
+    """Convert sparse RynnValue prefix inference into dense frame signals."""
+
+    model: RynnValueRewardModel
+    encoder: RynnValueEncoderProcessorStep
+    image_key: str
+    dataset_fps: float
+    task_key: str = "task"
+    default_task: str | None = None
+    batch_size: int = 2
+    inference_fps: float = DEFAULT_INFERENCE_FPS
+    max_frames: int | None = 8
+    horizon_s: float | None = None
+    robot_description: str | None = None
+    camera_description: str | None = None
+    use_meta: bool | None = None
+
+    def __post_init__(self) -> None:
+        if self.batch_size < 1:
+            raise ValueError(f"batch_size must be >= 1, got {self.batch_size}")
+        if self.max_frames is not None and self.max_frames < 1:
+            raise ValueError(f"max_frames must be >= 1 or None, got {self.max_frames}")
+        select_anchor_indices(1, self.dataset_fps, self.inference_fps)
+        if self.horizon_s is not None and (not np.isfinite(self.horizon_s) or self.horizon_s <= 0):
+            raise ValueError(f"horizon_s must be positive and finite or None, got {self.horizon_s}")
+        if self.use_meta is not False and not (self.robot_description or self.camera_description):
+            raise ValueError(
+                "RynnValue metadata prompting requires robot_description or camera_description; "
+                "set use_meta=False only for an intentional ablation"
+            )
+
+    @property
+    def options(self) -> dict[str, Any]:
+        """JSON-serializable adapter settings used in scoring provenance."""
+        return {
+            "batch_size": self.batch_size,
+            "camera_description": self.camera_description,
+            "dataset_fps": self.dataset_fps,
+            "default_task": self.default_task,
+            "horizon_s": self.horizon_s,
+            "image_key": self.image_key,
+            "inference_fps": self.inference_fps,
+            "interpolation": "linear",
+            "max_frames": self.max_frames,
+            "prefix_sampling": "linspace_rint_include_endpoints",
+            "robot_description": self.robot_description,
+            "task_key": self.task_key,
+            "task_resolution": "first_frame_or_default",
+            "use_meta": self.use_meta,
+        }
+
+    def __call__(self, dataset: LeRobotDataset, episode_index: int) -> FrameSignals:
+        actual_fps = float(dataset.fps)
+        if not np.isclose(actual_fps, self.dataset_fps):
+            raise ValueError(
+                f"Dataset fps changed after scorer construction: expected {self.dataset_fps}, got {actual_fps}"
+            )
+
+        episode = dataset.meta.episodes[episode_index]
+        episode_start = int(episode["dataset_from_index"])
+        episode_end = int(episode["dataset_to_index"])
+        num_frames = episode_end - episode_start
+        if num_frames < 1:
+            raise ValueError(f"Episode {episode_index} has no frames")
+
+        first_sample = dataset[_dataset_position(dataset, episode_start)]
+        task = _resolve_task(first_sample, task_key=self.task_key, default_task=self.default_task)
+        anchor_indices = select_anchor_indices(num_frames, self.dataset_fps, self.inference_fps)
+        anchor_values: list[float] = []
+
+        for start in range(0, len(anchor_indices), self.batch_size):
+            batch_anchors = anchor_indices[start : start + self.batch_size]
+            samples = []
+            for anchor_index in batch_anchors:
+                prefix_indices = select_prefix_indices(int(anchor_index), self.max_frames)
+                try:
+                    frames = torch.stack(
+                        [
+                            dataset[_dataset_position(dataset, episode_start + int(index))][self.image_key]
+                            for index in prefix_indices
+                        ]
+                    )
+                except KeyError as exc:
+                    raise KeyError(
+                        f"RynnValue scoring expected image key {self.image_key!r} in dataset frames"
+                    ) from exc
+                samples.append((_video_to_pil(frames, max_frames=None), task))
+
+            encoded = self.encoder.encode_samples(samples)
+            model_batch = {f"{RYNNVALUE_FEATURE_PREFIX}{key}": value for key, value in encoded.items()}
+            prediction = self.model.predict_remaining_time(model_batch)
+            remaining_time = prediction.remaining_time_s
+            if remaining_time.ndim != 1 or remaining_time.shape[0] != len(batch_anchors):
+                raise ValueError(
+                    "RynnValue remaining time must have shape (batch,), "
+                    f"got {tuple(remaining_time.shape)} for batch size {len(batch_anchors)}"
+                )
+            anchor_values.extend(remaining_time.detach().float().cpu().tolist())
+
+        dense_remaining_time = interpolate_anchor_values(
+            num_frames,
+            anchor_indices,
+            np.asarray(anchor_values, dtype=np.float32),
+        )
+        is_inference_frame = np.zeros(num_frames, dtype=np.bool_)
+        is_inference_frame[anchor_indices] = True
+        signals: dict[str, np.ndarray] = {
+            REMAINING_TIME_SIGNAL: dense_remaining_time,
+            POTENTIAL_SIGNAL: -dense_remaining_time,
+            IS_INFERENCE_FRAME_SIGNAL: is_inference_frame,
+        }
+        descriptors = dict(RYNNVALUE_SIGNAL_DESCRIPTORS)
+        if self.horizon_s is not None:
+            signals[PROGRESS_SIGNAL] = remaining_time_to_progress(dense_remaining_time, self.horizon_s)
+            descriptors[PROGRESS_SIGNAL] = PROGRESS_DESCRIPTOR
+
+        return FrameSignals(
+            frame_indices=np.arange(num_frames, dtype=np.int64),
+            signals=signals,
+            descriptors=descriptors,
+        )
+
+
+def make_rynnvalue_frame_scorer(
+    model: RynnValueRewardModel,
+    config: RynnValueConfig,
+    *,
+    dataset_fps: float,
+    batch_size: int = 2,
+    inference_fps: float = DEFAULT_INFERENCE_FPS,
+    max_frames: int | None = 8,
+    horizon_s: float | None = None,
+) -> RynnValueFrameScorer:
+    """Construct the standard RynnValue offline scoring adapter."""
+    processor_source = config.pretrained_path or config.model_id
+    processor_revision = (
+        config.pretrained_revision if config.pretrained_path is not None else config.model_revision
+    )
+    encoder = RynnValueEncoderProcessorStep(
+        model_id=processor_source,
+        model_revision=processor_revision,
+        image_key=config.image_key,
+        task_key=config.task_key,
+        default_task=config.default_task,
+        # Prefix selection belongs to this adapter and must not be repeated by
+        # the processor.
+        max_frames=None,
+        robot_description=config.robot_description,
+        camera_description=config.camera_description,
+        use_meta=config.use_meta,
+    )
+    return RynnValueFrameScorer(
+        model=model,
+        encoder=encoder,
+        image_key=config.image_key,
+        dataset_fps=dataset_fps,
+        task_key=config.task_key,
+        default_task=config.default_task,
+        batch_size=batch_size,
+        inference_fps=inference_fps,
+        max_frames=max_frames,
+        horizon_s=horizon_s,
+        robot_description=config.robot_description,
+        camera_description=config.camera_description,
+        use_meta=config.use_meta,
+    )
+
+
+def score_rynnvalue_dataset(
+    dataset: LeRobotDataset,
+    model: RynnValueRewardModel,
+    *,
+    output_path: Path,
+    model_id: str | None = None,
+    model_revision: str | None = None,
+    episode_indices: Sequence[int] | None = None,
+    resume: bool = True,
+    batch_size: int = 2,
+    inference_fps: float = DEFAULT_INFERENCE_FPS,
+    max_frames: int | None = 8,
+    horizon_s: float | None = None,
+) -> ScoringSummary:
+    """Score a dataset with RynnValue using the shared offline runner."""
+    from lerobot import __version__
+
+    config = model.config
+    resolved_model_id = model_id or config.pretrained_path
+    if resolved_model_id is None:
+        raise ValueError("model_id is required when the RynnValue config has no pretrained_path")
+
+    scorer = make_rynnvalue_frame_scorer(
+        model,
+        config,
+        dataset_fps=float(dataset.fps),
+        batch_size=batch_size,
+        inference_fps=inference_fps,
+        max_frames=max_frames,
+        horizon_s=horizon_s,
+    )
+    provenance = {
+        "lerobot_version": __version__,
+        "dataset": {
+            "repo_id": dataset.repo_id,
+            "revision": dataset.revision,
+        },
+        "model": {
+            "type": config.type,
+            "id": resolved_model_id,
+            "revision": model_revision if model_revision is not None else config.pretrained_revision,
+        },
+        "adapter": {
+            "id": "lerobot.rynnvalue.causal_prefix",
+            "version": 1,
+            "options": scorer.options,
+        },
+    }
+    return score_dataset(
+        dataset,
+        scorer,
+        output_path=output_path,
+        provenance=provenance,
+        episode_indices=episode_indices,
+        resume=resume,
+    )

--- a/src/lerobot/rewards/rynnvalue/scoring_rynnvalue.py
+++ b/src/lerobot/rewards/rynnvalue/scoring_rynnvalue.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""RynnValue adapter for the shared offline frame-scoring workflow."""
+"""RynnValue scorer for the shared offline frame-scoring workflow."""
 
 from __future__ import annotations
 
@@ -47,19 +47,18 @@ RYNNVALUE_SIGNAL_DESCRIPTORS = {
         ),
         unit="s",
         direction="lower",
-        missing_values="forbidden",
+        comparison_scope="task",
     ),
     POTENTIAL_SIGNAL: SignalDescriptor(
         description="Negative RynnValue remaining time, suitable as a higher-is-better state potential.",
         unit="s",
         direction="higher",
-        missing_values="forbidden",
+        comparison_scope="task",
     ),
     IS_INFERENCE_FRAME_SIGNAL: SignalDescriptor(
         description="Whether RynnValue ran on this frame rather than its value being interpolated.",
         unit=None,
         direction="none",
-        missing_values="forbidden",
     ),
 }
 
@@ -67,8 +66,8 @@ PROGRESS_DESCRIPTOR = SignalDescriptor(
     description="RynnValue progress derived from an explicitly configured remaining-time horizon.",
     unit=None,
     direction="higher",
-    missing_values="forbidden",
     bounds=(0.0, 1.0),
+    comparison_scope="task",
 )
 
 
@@ -185,7 +184,7 @@ class RynnValueFrameScorer:
 
     @property
     def options(self) -> dict[str, Any]:
-        """JSON-serializable adapter settings used in scoring provenance."""
+        """JSON-serializable scorer settings used in scoring provenance."""
         return {
             "batch_size": self.batch_size,
             "camera_description": self.camera_description,
@@ -285,7 +284,7 @@ def make_rynnvalue_frame_scorer(
     max_frames: int | None = 8,
     horizon_s: float | None = None,
 ) -> RynnValueFrameScorer:
-    """Construct the standard RynnValue offline scoring adapter."""
+    """Construct the standard RynnValue offline scorer."""
     processor_source = config.pretrained_path or config.model_id
     processor_revision = (
         config.pretrained_revision if config.pretrained_path is not None else config.model_revision
@@ -296,7 +295,7 @@ def make_rynnvalue_frame_scorer(
         image_key=config.image_key,
         task_key=config.task_key,
         default_task=config.default_task,
-        # Prefix selection belongs to this adapter and must not be repeated by
+        # Prefix selection belongs to this scorer and must not be repeated by
         # the processor.
         max_frames=None,
         robot_description=config.robot_description,
@@ -362,7 +361,7 @@ def score_rynnvalue_dataset(
             "id": resolved_model_id,
             "revision": model_revision if model_revision is not None else config.pretrained_revision,
         },
-        "adapter": {
+        "scorer": {
             "id": "lerobot.rynnvalue.causal_prefix",
             "version": 1,
             "options": scorer.options,

--- a/src/lerobot/scripts/lerobot_score_dataset.py
+++ b/src/lerobot/scripts/lerobot_score_dataset.py
@@ -27,6 +27,8 @@ from lerobot.configs.rewards import RewardModelConfig
 from lerobot.rewards.factory import make_reward_model
 from lerobot.rewards.robometer.configuration_robometer import RobometerConfig
 from lerobot.rewards.robometer.scoring_robometer import score_robometer_dataset
+from lerobot.rewards.rynnvalue.configuration_rynnvalue import RynnValueConfig
+from lerobot.rewards.rynnvalue.scoring_rynnvalue import score_rynnvalue_dataset
 from lerobot.rewards.scoring import ScoringSummary
 from lerobot.utils.import_utils import require_package
 
@@ -46,17 +48,30 @@ class ScoreDatasetConfig:
     episodes: list[int] | None = None
     device: str | None = None
     image_key: str | None = None
-    batch_size: int = 32
+    batch_size: int | None = None
+    default_task: str | None = None
     num_subsampled_frames: int = 4
+    inference_fps: float = 1.0
+    max_frames: int | None = 8
+    horizon_s: float | None = None
+    robot_description: str | None = None
+    camera_description: str | None = None
+    use_meta: bool | None = None
     resume: bool = True
     push_to_hub: bool = False
-    hub_path: str = "reward_signals/robometer.parquet"
+    hub_path: str | None = None
 
     def __post_init__(self) -> None:
-        if self.batch_size < 1:
+        if self.batch_size is not None and self.batch_size < 1:
             raise ValueError(f"batch_size must be >= 1, got {self.batch_size}")
         if self.num_subsampled_frames < 1:
             raise ValueError(f"num_subsampled_frames must be >= 1, got {self.num_subsampled_frames}")
+        if self.inference_fps <= 0:
+            raise ValueError(f"inference_fps must be > 0, got {self.inference_fps}")
+        if self.max_frames is not None and self.max_frames < 1:
+            raise ValueError(f"max_frames must be >= 1 or None, got {self.max_frames}")
+        if self.horizon_s is not None and self.horizon_s <= 0:
+            raise ValueError(f"horizon_s must be > 0 or None, got {self.horizon_s}")
 
 
 def run_score_dataset(cfg: ScoreDatasetConfig) -> ScoringSummary:
@@ -68,8 +83,10 @@ def run_score_dataset(cfg: ScoreDatasetConfig) -> ScoringSummary:
         cfg.reward_model_path,
         revision=cfg.reward_model_revision,
     )
-    if not isinstance(reward_config, RobometerConfig):
-        raise ValueError(f"lerobot-score-dataset currently supports RoboMeter, got {reward_config.type!r}")
+    if not isinstance(reward_config, (RobometerConfig, RynnValueConfig)):
+        raise ValueError(
+            f"lerobot-score-dataset currently supports RoboMeter and RynnValue, got {reward_config.type!r}"
+        )
     reward_config.pretrained_path = cfg.reward_model_path
     reward_config.pretrained_revision = cfg.reward_model_revision
     if cfg.device is not None:
@@ -80,6 +97,15 @@ def run_score_dataset(cfg: ScoreDatasetConfig) -> ScoringSummary:
         previous_feature = reward_config.input_features.pop(previous_image_key, None)
         if previous_feature is not None:
             reward_config.input_features.setdefault(cfg.image_key, previous_feature)
+    if isinstance(reward_config, RynnValueConfig):
+        if cfg.default_task is not None:
+            reward_config.default_task = cfg.default_task
+        if cfg.robot_description is not None:
+            reward_config.robot_description = cfg.robot_description
+        if cfg.camera_description is not None:
+            reward_config.camera_description = cfg.camera_description
+        if cfg.use_meta is not None:
+            reward_config.use_meta = cfg.use_meta
 
     dataset = LeRobotDataset(
         cfg.dataset_repo_id,
@@ -88,19 +114,33 @@ def run_score_dataset(cfg: ScoreDatasetConfig) -> ScoringSummary:
         download_videos=True,
     )
     reward_model = make_reward_model(reward_config)
-    output_path = cfg.output_path or Path(dataset.root) / "reward_signals" / "robometer.parquet"
-
-    summary = score_robometer_dataset(
-        dataset,
-        reward_model,
-        output_path=output_path,
-        model_id=cfg.reward_model_path,
-        model_revision=cfg.reward_model_revision,
-        episode_indices=cfg.episodes,
-        resume=cfg.resume,
-        batch_size=cfg.batch_size,
-        num_subsampled_frames=cfg.num_subsampled_frames,
-    )
+    output_path = cfg.output_path or Path(dataset.root) / "reward_signals" / f"{reward_config.type}.parquet"
+    if isinstance(reward_config, RobometerConfig):
+        summary = score_robometer_dataset(
+            dataset,
+            reward_model,
+            output_path=output_path,
+            model_id=cfg.reward_model_path,
+            model_revision=cfg.reward_model_revision,
+            episode_indices=cfg.episodes,
+            resume=cfg.resume,
+            batch_size=cfg.batch_size or 32,
+            num_subsampled_frames=cfg.num_subsampled_frames,
+        )
+    else:
+        summary = score_rynnvalue_dataset(
+            dataset,
+            reward_model,
+            output_path=output_path,
+            model_id=cfg.reward_model_path,
+            model_revision=cfg.reward_model_revision,
+            episode_indices=cfg.episodes,
+            resume=cfg.resume,
+            batch_size=cfg.batch_size or 2,
+            inference_fps=cfg.inference_fps,
+            max_frames=cfg.max_frames,
+            horizon_s=cfg.horizon_s,
+        )
     logger.info(
         "Scored %d episode(s), %d frame(s); new=%d resumed=%d; output=%s",
         summary.episode_count,
@@ -110,9 +150,10 @@ def run_score_dataset(cfg: ScoreDatasetConfig) -> ScoringSummary:
         summary.output_path,
     )
     if cfg.push_to_hub:
+        hub_path = cfg.hub_path or f"reward_signals/{reward_config.type}.parquet"
         HfApi().upload_file(
             path_or_fileobj=str(summary.output_path),
-            path_in_repo=cfg.hub_path,
+            path_in_repo=hub_path,
             repo_id=cfg.dataset_repo_id,
             repo_type="dataset",
             commit_message="Add reward-model frame signals (lerobot-score-dataset)",
@@ -120,7 +161,7 @@ def run_score_dataset(cfg: ScoreDatasetConfig) -> ScoringSummary:
         logger.info(
             "Uploaded scoring output to hf://datasets/%s/%s",
             cfg.dataset_repo_id,
-            cfg.hub_path,
+            hub_path,
         )
     return summary
 

--- a/src/lerobot/scripts/lerobot_score_dataset.py
+++ b/src/lerobot/scripts/lerobot_score_dataset.py
@@ -97,9 +97,9 @@ def run_score_dataset(cfg: ScoreDatasetConfig) -> ScoringSummary:
         previous_feature = reward_config.input_features.pop(previous_image_key, None)
         if previous_feature is not None:
             reward_config.input_features.setdefault(cfg.image_key, previous_feature)
+    if cfg.default_task is not None:
+        reward_config.default_task = cfg.default_task
     if isinstance(reward_config, RynnValueConfig):
-        if cfg.default_task is not None:
-            reward_config.default_task = cfg.default_task
         if cfg.robot_description is not None:
             reward_config.robot_description = cfg.robot_description
         if cfg.camera_description is not None:

--- a/tests/rewards/scoring/test_cli.py
+++ b/tests/rewards/scoring/test_cli.py
@@ -18,6 +18,7 @@ from types import SimpleNamespace
 import pytest
 
 from lerobot.rewards.robometer.configuration_robometer import RobometerConfig
+from lerobot.rewards.rynnvalue.configuration_rynnvalue import RynnValueConfig
 from lerobot.rewards.scoring import ScoringSummary
 from lerobot.scripts import lerobot_score_dataset
 from lerobot.scripts.lerobot_score_dataset import ScoreDatasetConfig
@@ -107,4 +108,83 @@ def test_run_score_dataset_loads_robometer_and_calls_shared_workflow(monkeypatch
         "resume": True,
         "batch_size": 8,
         "num_subsampled_frames": 6,
+    }
+
+
+def test_run_score_dataset_loads_rynnvalue_and_calls_shared_workflow(monkeypatch, tmp_path):
+    import lerobot.datasets
+
+    reward_config = RynnValueConfig(
+        pretrained_path="old/model",
+        device="cpu",
+        use_meta=False,
+    )
+    fake_model = object()
+    fake_dataset = SimpleNamespace(
+        root=tmp_path / "dataset",
+        repo_id="user/dataset",
+        revision="dataset-revision",
+    )
+    expected_summary = ScoringSummary(
+        output_path=tmp_path / "dataset" / "reward_signals" / "rynnvalue.parquet",
+        episode_count=1,
+        new_episode_count=1,
+        resumed_episode_count=0,
+        frame_count=3,
+    )
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        lerobot_score_dataset.RewardModelConfig,
+        "from_pretrained",
+        lambda path, *, revision: reward_config,
+    )
+    monkeypatch.setattr(
+        lerobot.datasets,
+        "LeRobotDataset",
+        lambda *args, **kwargs: fake_dataset,
+    )
+    monkeypatch.setattr(lerobot_score_dataset, "make_reward_model", lambda config: fake_model)
+
+    def fake_score(dataset, model, **kwargs):
+        captured["score"] = (dataset, model, kwargs)
+        return expected_summary
+
+    monkeypatch.setattr(lerobot_score_dataset, "score_rynnvalue_dataset", fake_score)
+
+    cfg = ScoreDatasetConfig(
+        dataset_repo_id="user/dataset",
+        reward_model_path="user/rynnvalue",
+        reward_model_revision="model-revision",
+        image_key="observation.images.wrist",
+        default_task="pick up the cube",
+        inference_fps=2.0,
+        max_frames=6,
+        horizon_s=12.0,
+        robot_description="a single-arm robot",
+        camera_description="a third-person camera",
+        use_meta=True,
+    )
+
+    summary = lerobot_score_dataset.run_score_dataset(cfg)
+
+    assert summary == expected_summary
+    assert reward_config.image_key == "observation.images.wrist"
+    assert reward_config.default_task == "pick up the cube"
+    assert reward_config.robot_description == "a single-arm robot"
+    assert reward_config.camera_description == "a third-person camera"
+    assert reward_config.use_meta is True
+    dataset, model, kwargs = captured["score"]
+    assert dataset is fake_dataset
+    assert model is fake_model
+    assert kwargs == {
+        "output_path": Path(tmp_path / "dataset" / "reward_signals" / "rynnvalue.parquet"),
+        "model_id": "user/rynnvalue",
+        "model_revision": "model-revision",
+        "episode_indices": None,
+        "resume": True,
+        "batch_size": 2,
+        "inference_fps": 2.0,
+        "max_frames": 6,
+        "horizon_s": 12.0,
     }

--- a/tests/rewards/scoring/test_cli.py
+++ b/tests/rewards/scoring/test_cli.py
@@ -76,6 +76,7 @@ def test_run_score_dataset_loads_robometer_and_calls_shared_workflow(monkeypatch
         episodes=[1],
         device="cpu",
         image_key="observation.images.wrist",
+        default_task="pick up the cube",
         batch_size=8,
         num_subsampled_frames=6,
     )
@@ -95,6 +96,7 @@ def test_run_score_dataset_loads_robometer_and_calls_shared_workflow(monkeypatch
     assert reward_config.pretrained_path == "user/robometer"
     assert reward_config.pretrained_revision == "model-revision"
     assert reward_config.image_key == "observation.images.wrist"
+    assert reward_config.default_task == "pick up the cube"
     assert "observation.images.wrist" in reward_config.input_features
     assert "observation.images.top" not in reward_config.input_features
     dataset, model, kwargs = captured["score"]

--- a/tests/rewards/scoring/test_rynnvalue.py
+++ b/tests/rewards/scoring/test_rynnvalue.py
@@ -1,0 +1,231 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+from lerobot.rewards.rynnvalue.modeling_rynnvalue import RynnValuePrediction
+from lerobot.rewards.rynnvalue.scoring_rynnvalue import (
+    IS_INFERENCE_FRAME_SIGNAL,
+    POTENTIAL_SIGNAL,
+    PROGRESS_SIGNAL,
+    REMAINING_TIME_SIGNAL,
+    RynnValueFrameScorer,
+    interpolate_anchor_values,
+    make_rynnvalue_frame_scorer,
+    remaining_time_to_progress,
+    score_rynnvalue_dataset,
+    select_anchor_indices,
+    select_prefix_indices,
+)
+
+
+def test_anchor_selection_uses_inference_fps_and_keeps_boundaries():
+    assert select_anchor_indices(61, dataset_fps=30, inference_fps=1).tolist() == [0, 30, 60]
+    assert select_anchor_indices(1, dataset_fps=30, inference_fps=1).tolist() == [0]
+
+    with pytest.raises(ValueError, match="inference_fps"):
+        select_anchor_indices(10, dataset_fps=30, inference_fps=31)
+
+
+def test_prefix_selection_is_causal_and_uniform():
+    assert select_prefix_indices(10, max_frames=4).tolist() == [0, 3, 7, 10]
+    assert select_prefix_indices(10, max_frames=1).tolist() == [10]
+    assert select_prefix_indices(2, max_frames=8).tolist() == [0, 1, 2]
+    assert select_prefix_indices(2, max_frames=None).tolist() == [0, 1, 2]
+
+
+def test_anchor_predictions_are_interpolated_without_changing_anchors():
+    anchors = np.asarray([0, 2, 4], dtype=np.int64)
+    values = np.asarray([4.0, 2.0, 0.0], dtype=np.float32)
+    dense = interpolate_anchor_values(5, anchors, values)
+
+    np.testing.assert_allclose(dense, [4.0, 3.0, 2.0, 1.0, 0.0])
+    np.testing.assert_allclose(dense[anchors], values)
+
+
+def test_horizon_normalization_is_bounded_and_not_episode_relative():
+    remaining_time = np.asarray([12.0, 10.0, 5.0, 0.0, -1.0], dtype=np.float32)
+    progress = remaining_time_to_progress(remaining_time, horizon_s=10.0)
+
+    np.testing.assert_allclose(progress, [0.0, 0.0, 0.5, 1.0, 1.0])
+    with pytest.raises(ValueError, match="positive"):
+        remaining_time_to_progress(remaining_time, horizon_s=0)
+
+
+def test_make_rynnvalue_frame_scorer_preserves_adapter_selected_prefixes(monkeypatch):
+    captured: dict[str, object] = {}
+
+    class FakeEncoder:
+        def __init__(self, **kwargs) -> None:
+            captured.update(kwargs)
+
+    import lerobot.rewards.rynnvalue.scoring_rynnvalue as scoring_rynnvalue
+
+    monkeypatch.setattr(scoring_rynnvalue, "RynnValueEncoderProcessorStep", FakeEncoder)
+    config = SimpleNamespace(
+        pretrained_path="converted/rynnvalue",
+        pretrained_revision="checkpoint-commit",
+        model_id="original/rynnvalue",
+        model_revision="original-commit",
+        image_key="observation.images.top",
+        task_key="task",
+        default_task="perform the task",
+        robot_description=None,
+        camera_description=None,
+        use_meta=False,
+    )
+
+    scorer = make_rynnvalue_frame_scorer(
+        SimpleNamespace(),
+        config,
+        dataset_fps=30.0,
+        max_frames=6,
+    )
+
+    assert captured["model_id"] == "converted/rynnvalue"
+    assert captured["model_revision"] == "checkpoint-commit"
+    assert captured["max_frames"] is None
+    assert scorer.max_frames == 6
+
+
+def test_rynnvalue_frame_scorer_emits_dense_native_and_derived_signals():
+    image_key = "observation.images.top"
+
+    class FakeDataset:
+        absolute_to_relative_idx = None
+        fps = 2.0
+
+        def __init__(self) -> None:
+            self.meta = SimpleNamespace(episodes=[{"dataset_from_index": 0, "dataset_to_index": 5}])
+
+        def __getitem__(self, index: int):
+            return {
+                image_key: torch.full((3, 2, 2), index, dtype=torch.uint8),
+                "task": "pick up the cube",
+            }
+
+    class FakeEncoder:
+        def encode_samples(self, samples):
+            final_frame_ids = [images[-1].getpixel((0, 0))[0] for images, _ in samples]
+            return {"input_ids": torch.tensor(final_frame_ids).unsqueeze(1)}
+
+    class FakeModel:
+        def predict_remaining_time(self, batch):
+            final_frame_ids = batch["observation.rynnvalue.input_ids"].squeeze(1)
+            return RynnValuePrediction(remaining_time_s=4.0 - final_frame_ids.float())
+
+    scorer = RynnValueFrameScorer(
+        model=FakeModel(),
+        encoder=FakeEncoder(),
+        image_key=image_key,
+        dataset_fps=2.0,
+        batch_size=2,
+        inference_fps=1.0,
+        max_frames=3,
+        horizon_s=4.0,
+        use_meta=False,
+    )
+
+    result = scorer(FakeDataset(), episode_index=0)
+
+    np.testing.assert_array_equal(result.frame_indices, np.arange(5))
+    np.testing.assert_allclose(result.signals[REMAINING_TIME_SIGNAL], [4, 3, 2, 1, 0])
+    np.testing.assert_allclose(result.signals[POTENTIAL_SIGNAL], [-4, -3, -2, -1, 0])
+    np.testing.assert_array_equal(result.signals[IS_INFERENCE_FRAME_SIGNAL], [True, False, True, False, True])
+    np.testing.assert_allclose(result.signals[PROGRESS_SIGNAL], [0, 0.25, 0.5, 0.75, 1])
+    assert result.descriptors[REMAINING_TIME_SIGNAL].unit == "s"
+    assert result.descriptors[PROGRESS_SIGNAL].bounds == (0.0, 1.0)
+    assert scorer.options["inference_fps"] == 1.0
+    assert scorer.options["horizon_s"] == 4.0
+
+    scorer.horizon_s = None
+    without_progress = scorer(FakeDataset(), episode_index=0)
+    assert PROGRESS_SIGNAL not in without_progress.signals
+    assert PROGRESS_SIGNAL not in without_progress.descriptors
+
+
+def test_score_rynnvalue_dataset_builds_reproducible_provenance(monkeypatch, tmp_path):
+    import lerobot.rewards.rynnvalue.scoring_rynnvalue as scoring_rynnvalue
+
+    config = SimpleNamespace(
+        type="rynnvalue",
+        pretrained_path="model/default",
+        pretrained_revision="config-revision",
+    )
+    model = SimpleNamespace(config=config)
+    dataset = SimpleNamespace(repo_id="user/dataset", revision="dataset-commit", fps=30.0)
+    fake_scorer = SimpleNamespace(options={"batch_size": 2, "inference_fps": 1.0})
+    expected_summary = SimpleNamespace(output_path=tmp_path / "signals.parquet")
+    captured: dict[str, object] = {}
+
+    def fake_make_scorer(received_model, received_config, **kwargs):
+        captured["make_scorer"] = (received_model, received_config, kwargs)
+        return fake_scorer
+
+    def fake_score_dataset(received_dataset, scorer, **kwargs):
+        captured["score_dataset"] = (received_dataset, scorer, kwargs)
+        return expected_summary
+
+    monkeypatch.setattr(scoring_rynnvalue, "make_rynnvalue_frame_scorer", fake_make_scorer)
+    monkeypatch.setattr(scoring_rynnvalue, "score_dataset", fake_score_dataset)
+
+    output_path = tmp_path / "signals.parquet"
+    summary = score_rynnvalue_dataset(
+        dataset,
+        model,
+        output_path=output_path,
+        model_id="user/rynnvalue",
+        model_revision="model-commit",
+        episode_indices=[2, 1],
+        batch_size=2,
+        inference_fps=1.0,
+        max_frames=8,
+        horizon_s=12.0,
+    )
+
+    assert summary is expected_summary
+    assert captured["make_scorer"] == (
+        model,
+        config,
+        {
+            "dataset_fps": 30.0,
+            "batch_size": 2,
+            "inference_fps": 1.0,
+            "max_frames": 8,
+            "horizon_s": 12.0,
+        },
+    )
+    assert captured["score_dataset"] == (
+        dataset,
+        fake_scorer,
+        {
+            "output_path": output_path,
+            "provenance": {
+                "lerobot_version": __import__("lerobot").__version__,
+                "dataset": {"repo_id": "user/dataset", "revision": "dataset-commit"},
+                "model": {"type": "rynnvalue", "id": "user/rynnvalue", "revision": "model-commit"},
+                "adapter": {
+                    "id": "lerobot.rynnvalue.causal_prefix",
+                    "version": 1,
+                    "options": fake_scorer.options,
+                },
+            },
+            "episode_indices": [2, 1],
+            "resume": True,
+        },
+    )

--- a/tests/rewards/scoring/test_rynnvalue.py
+++ b/tests/rewards/scoring/test_rynnvalue.py
@@ -67,7 +67,7 @@ def test_horizon_normalization_is_bounded_and_not_episode_relative():
         remaining_time_to_progress(remaining_time, horizon_s=0)
 
 
-def test_make_rynnvalue_frame_scorer_preserves_adapter_selected_prefixes(monkeypatch):
+def test_make_rynnvalue_frame_scorer_preserves_scorer_selected_prefixes(monkeypatch):
     captured: dict[str, object] = {}
 
     class FakeEncoder:
@@ -149,6 +149,7 @@ def test_rynnvalue_frame_scorer_emits_dense_native_and_derived_signals():
     np.testing.assert_array_equal(result.signals[IS_INFERENCE_FRAME_SIGNAL], [True, False, True, False, True])
     np.testing.assert_allclose(result.signals[PROGRESS_SIGNAL], [0, 0.25, 0.5, 0.75, 1])
     assert result.descriptors[REMAINING_TIME_SIGNAL].unit == "s"
+    assert result.descriptors[REMAINING_TIME_SIGNAL].comparison_scope == "task"
     assert result.descriptors[PROGRESS_SIGNAL].bounds == (0.0, 1.0)
     assert scorer.options["inference_fps"] == 1.0
     assert scorer.options["horizon_s"] == 4.0
@@ -219,7 +220,7 @@ def test_score_rynnvalue_dataset_builds_reproducible_provenance(monkeypatch, tmp
                 "lerobot_version": __import__("lerobot").__version__,
                 "dataset": {"repo_id": "user/dataset", "revision": "dataset-commit"},
                 "model": {"type": "rynnvalue", "id": "user/rynnvalue", "revision": "model-commit"},
-                "adapter": {
+                "scorer": {
                     "id": "lerobot.rynnvalue.causal_prefix",
                     "version": 1,
                     "options": fake_scorer.options,

--- a/tests/rewards/test_modeling_rynnvalue.py
+++ b/tests/rewards/test_modeling_rynnvalue.py
@@ -1,0 +1,434 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+pytest.importorskip("transformers")
+
+from huggingface_hub.constants import CONFIG_NAME, SAFETENSORS_SINGLE_FILE  # noqa: E402
+
+from lerobot.configs.rewards import RewardModelConfig  # noqa: E402
+from lerobot.rewards.factory import (  # noqa: E402
+    get_reward_model_class,
+    make_reward_model,
+    make_reward_model_config,
+    make_reward_pre_post_processors,
+)
+from lerobot.rewards.rynnvalue import RynnValueConfig  # noqa: E402
+from lerobot.rewards.rynnvalue.configuration_rynnvalue import RYNNVALUE_FEATURE_PREFIX  # noqa: E402
+from lerobot.rewards.rynnvalue.modeling_rynnvalue import (  # noqa: E402
+    RynnValueRewardModel,
+    reduce_remaining_time,
+)
+from lerobot.rewards.rynnvalue.rynn_value_lang.modeling_rynn_value_lang import (  # noqa: E402
+    RynnValueLangModel,
+)
+from lerobot.rewards.rynnvalue.rynn_value_lang.value_heads import BroValueHead  # noqa: E402
+from lerobot.rewards.rynnvalue.rynn_value_lang.value_tokenizer import (  # noqa: E402
+    ValueTokenizer,
+    to_symexp,
+    to_symlog,
+)
+
+
+class _FakeNativeConfig:
+    _attn_implementation = None
+
+    def __init__(self, **values) -> None:
+        self.values = values or {"model_type": "rynn_value_lang", "hidden_size": 16}
+
+    def to_dict(self):
+        return self.values
+
+
+class _FakeRynnValueModel(torch.nn.Module):
+    def __init__(
+        self,
+        pred_value: torch.Tensor | None = None,
+        config: _FakeNativeConfig | None = None,
+    ) -> None:
+        super().__init__()
+        self.anchor = torch.nn.Parameter(torch.zeros(()))
+        self.config = config or _FakeNativeConfig()
+        self.pred_value = (
+            pred_value
+            if pred_value is not None
+            else torch.tensor([[8.0, 2.0, 5.0, 1.0]], dtype=torch.float32)
+        )
+
+    def forward(self, **kwargs):  # noqa: ARG002
+        return SimpleNamespace(value=SimpleNamespace(pred_value=self.pred_value))
+
+
+def _patch_checkpoint_load(monkeypatch, pred_value: torch.Tensor | None = None) -> None:
+    from lerobot.rewards.rynnvalue import modeling_rynnvalue
+
+    class _FakeCheckpointModel(_FakeRynnValueModel):
+        def __init__(self, config=None) -> None:
+            super().__init__(pred_value=pred_value, config=config)
+
+        @classmethod
+        def from_pretrained(cls, *args, **kwargs):  # noqa: ARG003
+            return cls()
+
+    monkeypatch.setattr(
+        modeling_rynnvalue.RynnValueLangConfig,
+        "from_pretrained",
+        classmethod(lambda cls, *args, **kwargs: _FakeNativeConfig()),
+    )
+    monkeypatch.setattr(
+        modeling_rynnvalue.RynnValueLangConfig,
+        "from_dict",
+        classmethod(lambda cls, values: _FakeNativeConfig(**values)),
+    )
+    monkeypatch.setattr(modeling_rynnvalue, "RynnValueLangModel", _FakeCheckpointModel)
+
+
+def _encoded_batch(batch_size: int = 2) -> dict[str, torch.Tensor]:
+    return {
+        f"{RYNNVALUE_FEATURE_PREFIX}input_ids": torch.ones(batch_size, 8, dtype=torch.long),
+        f"{RYNNVALUE_FEATURE_PREFIX}attention_mask": torch.ones(batch_size, 8, dtype=torch.long),
+        f"{RYNNVALUE_FEATURE_PREFIX}pixel_values": torch.zeros(batch_size, 4),
+        f"{RYNNVALUE_FEATURE_PREFIX}image_grid_thw": torch.ones(batch_size, 3, dtype=torch.long),
+    }
+
+
+def test_rynnvalue_registered_with_reward_factory():
+    assert RewardModelConfig.get_choice_class("rynnvalue") is RynnValueConfig
+    assert isinstance(make_reward_model_config("rynnvalue", device="cpu"), RynnValueConfig)
+    assert get_reward_model_class("rynnvalue") is RynnValueRewardModel
+
+
+def test_rynnvalue_config_validation():
+    with pytest.raises(ValueError, match="max_frames"):
+        RynnValueConfig(device="cpu", max_frames=0)
+    with pytest.raises(ValueError, match="reward_output"):
+        RynnValueConfig(device="cpu", reward_output="progress")
+    with pytest.raises(ValueError, match="pred_slot_isolated_eager"):
+        RynnValueConfig(device="cpu", attn_implementation="sdpa")
+
+
+def test_value_tokenizer_two_hot_symlog_roundtrip():
+    tokenizer = ValueTokenizer(
+        bins=256,
+        min_value=-256,
+        max_value=256,
+        forward_transform=to_symlog,
+        inverse_transform=to_symexp,
+        support_transform="symlog",
+    )
+    values = torch.tensor([-100.0, -1.0, 0.0, 1.0, 100.0])
+    target = tokenizer.encode(values)
+    decoded = tokenizer.decode_from_bins(torch.log(target.clamp_min(1e-8)))
+    assert target.shape == (5, 256)
+    assert torch.allclose(target.sum(dim=-1), torch.ones(5))
+    assert torch.allclose(decoded, values, atol=0.2)
+
+
+def test_bro_head_preserves_prefix_shape():
+    head = BroValueHead(input_dim=12, output_dim=256, hidden_dims=16, depth=2)
+    assert head(torch.zeros(3, 12)).shape == (3, 256)
+
+
+def test_bro_head_inherits_active_model_dtype():
+    previous_dtype = torch.get_default_dtype()
+    torch.set_default_dtype(torch.bfloat16)
+    try:
+        head = BroValueHead(input_dim=12, output_dim=256, hidden_dims=16, depth=2)
+    finally:
+        torch.set_default_dtype(previous_dtype)
+
+    hidden_states = torch.zeros(3, 12, dtype=torch.bfloat16)
+    assert next(head.parameters()).dtype == torch.bfloat16
+    assert head(hidden_states).dtype == torch.bfloat16
+
+
+def test_grouped_query_tokens_are_concatenated():
+    hidden = torch.arange(24, dtype=torch.float32).reshape(4, 6)
+    concatenated, prefix = RynnValueLangModel._concat_slot_tokens(
+        hidden, hidden.shape[:-1], repeat=2, token_name="<value>"
+    )
+    assert prefix == torch.Size([2])
+    assert concatenated.shape == (2, 12)
+    assert torch.equal(concatenated[0], hidden[:2].reshape(-1))
+
+
+def test_prediction_slot_ids_isolate_repeated_groups():
+    model = RynnValueLangModel.__new__(RynnValueLangModel)
+    torch.nn.Module.__init__(model)
+    model.config = SimpleNamespace(value_token_id=7, relative_value_token_id=8)
+    input_ids = torch.tensor([[1, 7, 7, 2, 8, 8, 7, 7, 3]])
+    extras, cached = model._build_pred_slot_extras(input_ids)
+    assert extras["is_pred_key"].tolist() == [[False, True, True, False, True, True, True, True, False]]
+    assert extras["pred_slot_id"].tolist() == [[-1, 0, 0, -1, 1, 1, 2, 2, -1]]
+    assert torch.equal(cached, extras["is_pred_key"])
+
+
+def test_reduce_remaining_time_averages_heads_and_selects_final_slot():
+    predictions = torch.tensor(
+        [
+            [9.0, 3.0, 8.0, 2.0],
+            [7.0, 1.0, 6.0, 0.0],
+        ]
+    )
+    assert torch.equal(reduce_remaining_time(predictions, batch_size=2), torch.tensor([2.0, 1.0]))
+
+
+def test_reduce_remaining_time_supports_uneven_sample_slot_counts():
+    predictions = torch.tensor(
+        [
+            [9.0, 8.0, 3.0],
+            [7.0, 6.0, 1.0],
+        ]
+    )
+    remaining_time = reduce_remaining_time(predictions, batch_size=2, slot_counts=[1, 2])
+    assert torch.equal(remaining_time, torch.tensor([8.0, 2.0]))
+
+
+def test_compute_reward_uses_value_tokens_to_split_uneven_samples():
+    native_config = _FakeNativeConfig()
+    native_config.value_token_id = 99
+    native_config.value_token_repeat = 2
+    native_model = _FakeRynnValueModel(
+        pred_value=torch.tensor([[8.0, 5.0, 1.0]]),
+        config=native_config,
+    )
+    model = RynnValueRewardModel(
+        RynnValueConfig(device="cpu", reward_output="remaining_time"),
+        model=native_model,
+    )
+    batch = _encoded_batch(batch_size=2)
+    batch[f"{RYNNVALUE_FEATURE_PREFIX}input_ids"] = torch.tensor(
+        [
+            [99, 99, 0, 0],
+            [99, 99, 99, 99],
+        ]
+    )
+
+    assert torch.equal(model.compute_reward(batch), torch.tensor([8.0, 1.0]))
+
+
+def test_compute_reward_returns_negative_remaining_time(monkeypatch):
+    _patch_checkpoint_load(monkeypatch)
+    model = RynnValueRewardModel(RynnValueConfig(device="cpu"))
+    reward = model.compute_reward(_encoded_batch())
+    assert torch.equal(reward, torch.tensor([-2.0, -1.0]))
+    assert model.is_trainable is False
+
+
+def test_compute_reward_can_return_raw_remaining_time(monkeypatch):
+    _patch_checkpoint_load(monkeypatch)
+    model = RynnValueRewardModel(RynnValueConfig(device="cpu", reward_output="remaining_time"))
+    assert torch.equal(model.compute_reward(_encoded_batch()), torch.tensor([2.0, 1.0]))
+
+
+def test_compute_reward_requires_encoded_inputs(monkeypatch):
+    _patch_checkpoint_load(monkeypatch)
+    model = RynnValueRewardModel(RynnValueConfig(device="cpu"))
+    with pytest.raises(KeyError, match="observation.rynnvalue.input_ids"):
+        model.compute_reward({})
+
+
+def test_embedded_model_config_avoids_upstream_checkpoint_load(monkeypatch):
+    from lerobot.rewards.rynnvalue import modeling_rynnvalue
+
+    source_load_called = False
+
+    def fail_source_load(*args, **kwargs):  # noqa: ARG001
+        nonlocal source_load_called
+        source_load_called = True
+        raise AssertionError("upstream checkpoint should not be loaded")
+
+    class _ConstructedModel(_FakeRynnValueModel):
+        def __init__(self, config) -> None:
+            super().__init__()
+            self.config = config
+
+        from_pretrained = classmethod(fail_source_load)
+
+    monkeypatch.setattr(
+        modeling_rynnvalue.RynnValueLangConfig,
+        "from_dict",
+        classmethod(lambda cls, config: SimpleNamespace(**config)),
+    )
+    monkeypatch.setattr(modeling_rynnvalue, "RynnValueLangModel", _ConstructedModel)
+
+    model = RynnValueRewardModel(
+        RynnValueConfig(
+            device="cpu",
+            torch_dtype="float32",
+            model_config={"hidden_size": 16},
+        )
+    )
+    assert model.model.config.hidden_size == 16
+    assert source_load_called is False
+
+
+def test_lerobot_checkpoint_without_embedded_model_config_fails_before_upstream_load(monkeypatch):
+    from lerobot.rewards.rynnvalue import modeling_rynnvalue
+
+    monkeypatch.setattr(
+        modeling_rynnvalue.RynnValueLangConfig,
+        "from_pretrained",
+        classmethod(lambda cls, *args, **kwargs: pytest.fail("upstream config load should not be attempted")),
+    )
+    with pytest.raises(ValueError, match="missing `model_config`"):
+        RynnValueRewardModel(
+            RynnValueConfig(
+                device="cpu",
+                pretrained_path="/tmp/legacy-rynnvalue",
+            )
+        )
+
+
+def test_save_and_load_lerobot_checkpoint(monkeypatch, tmp_path):
+    _patch_checkpoint_load(monkeypatch)
+    model = RynnValueRewardModel(
+        RynnValueConfig(
+            device="cpu",
+            model_id="Alibaba-DAMO-Academy/RynnValue-8B",
+            model_revision="abc123",
+        )
+    )
+    model.save_pretrained(tmp_path)
+    assert (tmp_path / CONFIG_NAME).exists()
+    assert (tmp_path / SAFETENSORS_SINGLE_FILE).exists()
+
+    loaded = RynnValueRewardModel.from_pretrained(tmp_path)
+    assert loaded.config.model_id == "Alibaba-DAMO-Academy/RynnValue-8B"
+    assert loaded.config.model_revision == "abc123"
+    assert loaded.config.model_config == {"model_type": "rynn_value_lang", "hidden_size": 16}
+    assert loaded.config.pretrained_path == str(tmp_path)
+
+
+def test_conversion_writes_self_contained_lerobot_checkpoint(monkeypatch, tmp_path):
+    from lerobot.rewards.rynnvalue import convert_rynnvalue_checkpoint as conversion
+
+    class _SourceConfig:
+        _attn_implementation = None
+
+        @staticmethod
+        def to_dict():
+            return {"model_type": "rynn_value_lang", "hidden_size": 16}
+
+    class _Processor:
+        @staticmethod
+        def save_pretrained(output_dir):
+            (output_dir / "processor_config.json").write_text("{}")
+
+    monkeypatch.setattr(
+        conversion.RynnValueLangConfig,
+        "from_pretrained",
+        classmethod(lambda cls, *args, **kwargs: _SourceConfig()),
+    )
+    monkeypatch.setattr(
+        conversion.RynnValueLangModel,
+        "from_pretrained",
+        classmethod(lambda cls, *args, **kwargs: _FakeRynnValueModel()),
+    )
+    monkeypatch.setattr(
+        conversion.RynnValueLangProcessor,
+        "from_pretrained",
+        classmethod(lambda cls, *args, **kwargs: _Processor()),
+    )
+
+    conversion.convert_rynnvalue_checkpoint(
+        tmp_path,
+        source_model_id="upstream/rynnvalue",
+        revision="abc123",
+        torch_dtype="float32",
+    )
+
+    assert (tmp_path / CONFIG_NAME).exists()
+    assert (tmp_path / SAFETENSORS_SINGLE_FILE).exists()
+    assert (tmp_path / "processor_config.json").exists()
+    config = RewardModelConfig.from_pretrained(tmp_path)
+    assert config.model_id == "upstream/rynnvalue"
+    assert config.model_revision == "abc123"
+    assert config.model_config == {"model_type": "rynn_value_lang", "hidden_size": 16}
+
+
+def test_offline_checkpoint_roundtrip_through_reward_factories(monkeypatch, tmp_path):
+    from lerobot.rewards.rynnvalue import modeling_rynnvalue, processor_rynnvalue
+
+    original = RynnValueRewardModel(
+        RynnValueConfig(device="cpu", torch_dtype="float32"),
+        model=_FakeRynnValueModel(),
+    )
+    original.save_pretrained(tmp_path)
+
+    def fail_upstream_load(*args, **kwargs):  # noqa: ARG001
+        raise AssertionError("offline LeRobot checkpoint must not load the upstream model")
+
+    class _OfflineModel(_FakeRynnValueModel):
+        def __init__(self, config) -> None:
+            super().__init__(config=config)
+
+        from_pretrained = classmethod(fail_upstream_load)
+
+    class _OfflineProcessor:
+        tokenizer = SimpleNamespace(pad_token_id=0, eos_token_id=2)
+        use_meta = False
+
+        def process_episode(self, instruction, images, **kwargs):  # noqa: ARG002
+            return {
+                "input_ids": torch.tensor([[1, 2, 3]]),
+                "attention_mask": torch.ones(1, 3, dtype=torch.long),
+                "mm_token_type_ids": torch.zeros(1, 3, dtype=torch.long),
+                "pixel_values": torch.zeros(1, len(images), 4),
+                "image_grid_thw": torch.ones(1, len(images), 3, dtype=torch.long),
+            }
+
+    processor_sources = []
+    monkeypatch.setattr(
+        modeling_rynnvalue.RynnValueLangConfig,
+        "from_pretrained",
+        classmethod(fail_upstream_load),
+    )
+    monkeypatch.setattr(
+        modeling_rynnvalue.RynnValueLangConfig,
+        "from_dict",
+        classmethod(lambda cls, values: _FakeNativeConfig(**values)),
+    )
+    monkeypatch.setattr(modeling_rynnvalue, "RynnValueLangModel", _OfflineModel)
+    monkeypatch.setattr(
+        processor_rynnvalue.RynnValueLangProcessor,
+        "from_pretrained",
+        classmethod(
+            lambda cls, model_id, **kwargs: (
+                processor_sources.append((model_id, kwargs.get("revision"))) or _OfflineProcessor()
+            )
+        ),
+    )
+
+    config = RewardModelConfig.from_pretrained(tmp_path)
+    config.pretrained_path = str(tmp_path)
+    model = make_reward_model(config)
+    preprocessor, _ = make_reward_pre_post_processors(config)
+    encoded = preprocessor(
+        {
+            config.image_key: torch.zeros(3, 8, 8),
+            config.task_key: "pick up the cube",
+        }
+    )
+    reward = model.compute_reward(encoded)
+
+    assert processor_sources == [(str(tmp_path), None)]
+    assert reward.shape == (1,)
+    assert torch.isfinite(reward).all()

--- a/tests/rewards/test_modeling_rynnvalue.py
+++ b/tests/rewards/test_modeling_rynnvalue.py
@@ -201,7 +201,7 @@ def test_reduce_remaining_time_supports_uneven_sample_slot_counts():
     assert torch.equal(remaining_time, torch.tensor([8.0, 2.0]))
 
 
-def test_compute_reward_uses_value_tokens_to_split_uneven_samples():
+def test_predict_remaining_time_uses_value_tokens_to_split_uneven_samples():
     native_config = _FakeNativeConfig()
     native_config.value_token_id = 99
     native_config.value_token_repeat = 2
@@ -209,10 +209,7 @@ def test_compute_reward_uses_value_tokens_to_split_uneven_samples():
         pred_value=torch.tensor([[8.0, 5.0, 1.0]]),
         config=native_config,
     )
-    model = RynnValueRewardModel(
-        RynnValueConfig(device="cpu", reward_output="remaining_time"),
-        model=native_model,
-    )
+    model = RynnValueRewardModel(RynnValueConfig(device="cpu"), model=native_model)
     batch = _encoded_batch(batch_size=2)
     batch[f"{RYNNVALUE_FEATURE_PREFIX}input_ids"] = torch.tensor(
         [
@@ -221,28 +218,31 @@ def test_compute_reward_uses_value_tokens_to_split_uneven_samples():
         ]
     )
 
-    assert torch.equal(model.compute_reward(batch), torch.tensor([8.0, 1.0]))
+    prediction = model.predict_remaining_time(batch)
+    assert torch.equal(prediction.remaining_time_s, torch.tensor([8.0, 1.0]))
 
 
-def test_compute_reward_returns_negative_remaining_time(monkeypatch):
+def test_predict_remaining_time_returns_native_seconds(monkeypatch):
     _patch_checkpoint_load(monkeypatch)
     model = RynnValueRewardModel(RynnValueConfig(device="cpu"))
-    reward = model.compute_reward(_encoded_batch())
-    assert torch.equal(reward, torch.tensor([-2.0, -1.0]))
+    prediction = model.predict_remaining_time(_encoded_batch())
+    assert torch.equal(prediction.remaining_time_s, torch.tensor([2.0, 1.0]))
     assert model.is_trainable is False
+    assert not hasattr(model, "compute_reward")
 
 
-def test_compute_reward_can_return_raw_remaining_time(monkeypatch):
+def test_legacy_reward_output_does_not_change_native_prediction(monkeypatch):
     _patch_checkpoint_load(monkeypatch)
-    model = RynnValueRewardModel(RynnValueConfig(device="cpu", reward_output="remaining_time"))
-    assert torch.equal(model.compute_reward(_encoded_batch()), torch.tensor([2.0, 1.0]))
+    model = RynnValueRewardModel(RynnValueConfig(device="cpu", reward_output="potential"))
+    prediction = model.predict_remaining_time(_encoded_batch())
+    assert torch.equal(prediction.remaining_time_s, torch.tensor([2.0, 1.0]))
 
 
-def test_compute_reward_requires_encoded_inputs(monkeypatch):
+def test_predict_remaining_time_requires_encoded_inputs(monkeypatch):
     _patch_checkpoint_load(monkeypatch)
     model = RynnValueRewardModel(RynnValueConfig(device="cpu"))
     with pytest.raises(KeyError, match="observation.rynnvalue.input_ids"):
-        model.compute_reward({})
+        model.predict_remaining_time({})
 
 
 def test_embedded_model_config_avoids_upstream_checkpoint_load(monkeypatch):
@@ -427,8 +427,8 @@ def test_offline_checkpoint_roundtrip_through_reward_factories(monkeypatch, tmp_
             config.task_key: "pick up the cube",
         }
     )
-    reward = model.compute_reward(encoded)
+    prediction = model.predict_remaining_time(encoded)
 
     assert processor_sources == [(str(tmp_path), None)]
-    assert reward.shape == (1,)
-    assert torch.isfinite(reward).all()
+    assert prediction.remaining_time_s.shape == (1,)
+    assert torch.isfinite(prediction.remaining_time_s).all()

--- a/tests/rewards/test_rynnvalue.py
+++ b/tests/rewards/test_rynnvalue.py
@@ -34,7 +34,7 @@ pytestmark = pytest.mark.skipif(
 
 
 @require_cuda
-def test_released_rynnvalue_4b_preprocessor_to_reward():
+def test_released_rynnvalue_4b_preprocessor_to_remaining_time():
     config = RynnValueConfig(
         device="cuda",
         max_frames=2,
@@ -51,7 +51,7 @@ def test_released_rynnvalue_4b_preprocessor_to_reward():
     assert encoded["observation.rynnvalue.attention_mask"].shape[-1] == input_length
     assert encoded["observation.rynnvalue.mm_token_type_ids"].shape[-1] == input_length
     model = RynnValueRewardModel(config).to("cuda").eval()
-    reward = model.compute_reward(encoded)
-    assert reward.shape == (1,)
-    assert reward.dtype == torch.float32
-    assert torch.isfinite(reward).all()
+    prediction = model.predict_remaining_time(encoded)
+    assert prediction.remaining_time_s.shape == (1,)
+    assert prediction.remaining_time_s.dtype == torch.float32
+    assert torch.isfinite(prediction.remaining_time_s).all()

--- a/tests/rewards/test_rynnvalue.py
+++ b/tests/rewards/test_rynnvalue.py
@@ -1,0 +1,57 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Opt-in end-to-end smoke test for the released RynnValue-4B checkpoint."""
+
+import os
+
+import pytest
+import torch
+
+pytest.importorskip("transformers")
+
+from lerobot.rewards.rynnvalue import RynnValueConfig, RynnValueRewardModel  # noqa: E402
+from lerobot.rewards.rynnvalue.processor_rynnvalue import (  # noqa: E402
+    make_rynnvalue_pre_post_processors,
+)
+from tests.utils import require_cuda  # noqa: E402
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("LEROBOT_RUN_RYNNVALUE_SMOKE") != "1",
+    reason="Set LEROBOT_RUN_RYNNVALUE_SMOKE=1 to download and test RynnValue-4B",
+)
+
+
+@require_cuda
+def test_released_rynnvalue_4b_preprocessor_to_reward():
+    config = RynnValueConfig(
+        device="cuda",
+        max_frames=2,
+        robot_description="a robot arm",
+        camera_description="a third-person camera",
+    )
+    preprocessor, _ = make_rynnvalue_pre_post_processors(config)
+    batch = {
+        config.image_key: torch.zeros(2, 3, 64, 64, dtype=torch.uint8),
+        config.task_key: "pick up the cube",
+    }
+    encoded = preprocessor(batch)
+    input_length = encoded["observation.rynnvalue.input_ids"].shape[-1]
+    assert encoded["observation.rynnvalue.attention_mask"].shape[-1] == input_length
+    assert encoded["observation.rynnvalue.mm_token_type_ids"].shape[-1] == input_length
+    model = RynnValueRewardModel(config).to("cuda").eval()
+    reward = model.compute_reward(encoded)
+    assert reward.shape == (1,)
+    assert reward.dtype == torch.float32
+    assert torch.isfinite(reward).all()

--- a/tests/rewards/test_rynnvalue_original_parity.py
+++ b/tests/rewards/test_rynnvalue_original_parity.py
@@ -1,0 +1,153 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Opt-in original-checkpoint parity test for RynnValue.
+
+Set both checkpoint variables to compare the released implementation with a
+converted LeRobot checkpoint. The original model runs in a clean subprocess so
+its Transformers registrations cannot resolve to LeRobot's ported classes.
+"""
+
+import json
+import os
+import subprocess
+import sys
+
+import numpy as np
+import pytest
+import torch
+from PIL import Image
+
+pytest.importorskip("transformers")
+
+from lerobot.configs.rewards import RewardModelConfig  # noqa: E402
+from lerobot.rewards import make_reward_model, make_reward_pre_post_processors  # noqa: E402
+from tests.utils import require_cuda  # noqa: E402
+
+ORIGINAL_CHECKPOINT = os.environ.get("LEROBOT_RYNNVALUE_ORIGINAL_CHECKPOINT")
+CONVERTED_CHECKPOINT = os.environ.get("LEROBOT_RYNNVALUE_CONVERTED_CHECKPOINT")
+
+pytestmark = pytest.mark.skipif(
+    not ORIGINAL_CHECKPOINT or not CONVERTED_CHECKPOINT,
+    reason=(
+        "Set LEROBOT_RYNNVALUE_ORIGINAL_CHECKPOINT and "
+        "LEROBOT_RYNNVALUE_CONVERTED_CHECKPOINT to run RynnValue parity"
+    ),
+)
+
+
+def _deterministic_frames() -> tuple[list[Image.Image], torch.Tensor]:
+    arrays = []
+    for frame_index in range(3):
+        y, x = np.indices((64, 64), dtype=np.uint16)
+        array = np.stack(
+            (
+                (x + frame_index * 17) % 256,
+                (y * 2 + frame_index * 31) % 256,
+                (x + y + frame_index * 47) % 256,
+            ),
+            axis=-1,
+        ).astype(np.uint8)
+        arrays.append(array)
+    images = [Image.fromarray(array) for array in arrays]
+    frames = torch.from_numpy(np.stack(arrays)).permute(0, 3, 1, 2)
+    return images, frames
+
+
+@require_cuda
+def test_original_and_lerobot_checkpoints_predict_same_remaining_time(tmp_path):
+    instruction = "put the cube in the drawer"
+    robot_description = "a single-arm robot"
+    camera_description = "a fixed third-person camera"
+    images, frames = _deterministic_frames()
+    frames_path = tmp_path / "frames.npy"
+    np.save(frames_path, frames.permute(0, 2, 3, 1).numpy())
+    original_script = r"""
+import json
+import sys
+
+import numpy as np
+import torch
+from PIL import Image
+from transformers import AutoConfig, AutoModel, AutoProcessor
+
+checkpoint, frames_path, instruction, robot_description, camera_description = sys.argv[1:]
+images = [Image.fromarray(frame) for frame in np.load(frames_path)]
+config = AutoConfig.from_pretrained(checkpoint, trust_remote_code=True)
+config._attn_implementation = "pred_slot_isolated_eager"
+model = AutoModel.from_pretrained(
+    checkpoint,
+    config=config,
+    trust_remote_code=True,
+    torch_dtype=torch.bfloat16,
+).to("cuda").eval()
+processor = AutoProcessor.from_pretrained(checkpoint, trust_remote_code=True)
+batch = processor.process_episode(
+    instruction=instruction,
+    images=images,
+    robot_description=robot_description,
+    camera_description=camera_description,
+)
+inputs = {
+    key: value.to("cuda") if isinstance(value, torch.Tensor) else value
+    for key, value in batch.items()
+}
+with torch.inference_mode():
+    values = model(**inputs).value.pred_value.float()
+if values.ndim == 1:
+    flattened = values
+elif values.ndim == 2:
+    flattened = values.mean(dim=0)
+else:
+    raise ValueError(f"Unexpected original RynnValue prediction shape: {tuple(values.shape)}")
+remaining_time = flattened.view(1, -1)[:, -1].cpu().tolist()
+print("RYNNVALUE_PARITY_RESULT=" + json.dumps(remaining_time))
+"""
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            original_script,
+            ORIGINAL_CHECKPOINT,
+            str(frames_path),
+            instruction,
+            robot_description,
+            camera_description,
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    result_line = next(
+        line for line in completed.stdout.splitlines() if line.startswith("RYNNVALUE_PARITY_RESULT=")
+    )
+    expected = torch.tensor(json.loads(result_line.partition("=")[2]), dtype=torch.float32)
+
+    config = RewardModelConfig.from_pretrained(CONVERTED_CHECKPOINT)
+    config.pretrained_path = CONVERTED_CHECKPOINT
+    config.device = "cuda"
+    config.max_frames = None
+    config.robot_description = robot_description
+    config.camera_description = camera_description
+    model = make_reward_model(config).eval()
+    preprocessor, _ = make_reward_pre_post_processors(config)
+    encoded = preprocessor(
+        {
+            config.image_key: frames,
+            config.task_key: instruction,
+        }
+    )
+    actual = model.predict_remaining_time(encoded).remaining_time_s.detach().cpu()
+
+    torch.testing.assert_close(actual, expected, rtol=1e-4, atol=1e-4)

--- a/tests/rewards/test_rynnvalue_processor.py
+++ b/tests/rewards/test_rynnvalue_processor.py
@@ -1,0 +1,210 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+pytest.importorskip("transformers")
+
+from lerobot.lerobot_types import TransitionKey  # noqa: E402
+from lerobot.rewards.rynnvalue.configuration_rynnvalue import (  # noqa: E402
+    RYNNVALUE_FEATURE_PREFIX,
+    RynnValueConfig,
+)
+from lerobot.rewards.rynnvalue.processor_rynnvalue import (  # noqa: E402
+    RynnValueEncoderProcessorStep,
+    _uniform_subsample,
+    _video_to_pil,
+    make_rynnvalue_pre_post_processors,
+)
+from lerobot.rewards.rynnvalue.rynn_value_lang.processing_rynn_value_lang import (  # noqa: E402
+    RynnValueLangProcessor,
+)
+
+
+class _FakeTokenizer:
+    pad_token_id = 0
+    eos_token_id = 2
+
+
+class _FakeProcessor:
+    def __init__(self) -> None:
+        self.tokenizer = _FakeTokenizer()
+        self.use_meta = False
+        self.calls: list[dict] = []
+        self.refresh_count = 0
+
+    def refresh_conversation_builder(self):
+        self.refresh_count += 1
+
+    def process_episode(self, instruction, images, robot_description=None, camera_description=None):
+        self.calls.append(
+            {
+                "instruction": instruction,
+                "images": images,
+                "robot_description": robot_description,
+                "camera_description": camera_description,
+            }
+        )
+        length = 4 + len(instruction.split())
+        return {
+            "input_ids": torch.arange(length).unsqueeze(0),
+            "attention_mask": torch.ones(1, length, dtype=torch.long),
+            "pixel_values": torch.zeros(1, len(images), 6),
+            "image_grid_thw": torch.ones(1, len(images), 3, dtype=torch.long),
+            "mm_token_type_ids": torch.zeros(1, length, dtype=torch.long),
+        }
+
+
+class _FakeConversationBuilder:
+    def build_progress(self, **kwargs):  # noqa: ARG002
+        return []
+
+
+class _FakeNativeProcessor:
+    conversation_builder = _FakeConversationBuilder()
+
+    class _Tokenizer:
+        @staticmethod
+        def convert_tokens_to_ids(token):  # noqa: ARG004
+            return 99
+
+    tokenizer = _Tokenizer()
+
+    @staticmethod
+    def apply_chat_template(conversation):  # noqa: ARG004
+        return "prompt"
+
+    def __call__(self, text, images):  # noqa: ARG002
+        return {
+            "input_ids": torch.tensor([[1, 99, 2, 99, 3]]),
+            "attention_mask": torch.ones(1, 5, dtype=torch.long),
+            "mm_token_type_ids": torch.arange(5).unsqueeze(0),
+            "pixel_values": torch.zeros(2, 6),
+            "image_grid_thw": torch.ones(2, 3, dtype=torch.long),
+        }
+
+
+def _patch_processor(monkeypatch) -> _FakeProcessor:
+    from lerobot.rewards.rynnvalue import processor_rynnvalue
+
+    fake = _FakeProcessor()
+    monkeypatch.setattr(
+        processor_rynnvalue.RynnValueLangProcessor,
+        "from_pretrained",
+        classmethod(lambda cls, *args, **kwargs: fake),
+    )
+    return fake
+
+
+def test_uniform_subsample_keeps_history_boundaries():
+    video = torch.arange(10)
+    assert _uniform_subsample(video, 4).tolist() == [0, 3, 6, 9]
+    assert torch.equal(_uniform_subsample(video, None), video)
+
+
+def test_video_to_pil_accepts_float_chw_frames():
+    frames = torch.zeros(5, 3, 8, 8)
+    frames[-1, 0].fill_(1.0)
+    images = _video_to_pil(frames, max_frames=3)
+    assert len(images) == 3
+    assert images[0].size == (8, 8)
+    assert images[-1].getpixel((0, 0))[0] == 255
+
+
+def test_native_processor_truncates_all_sequence_tensors_together():
+    outputs = RynnValueLangProcessor.process_episode(
+        _FakeNativeProcessor(),
+        instruction="pick cube",
+        images=[object(), object()],
+    )
+    assert outputs["input_ids"].shape == (1, 3)
+    assert outputs["attention_mask"].shape == (1, 3)
+    assert outputs["mm_token_type_ids"].shape == (1, 3)
+
+
+def test_encoder_batches_and_pads_native_processor_outputs(monkeypatch):
+    fake = _patch_processor(monkeypatch)
+    encoder = RynnValueEncoderProcessorStep(
+        model_id="test/rynnvalue",
+        max_frames=3,
+        robot_description="a test robot",
+        camera_description="a front camera",
+    )
+    frames = torch.zeros(2, 5, 3, 8, 8)
+    transition = {
+        TransitionKey.OBSERVATION: {"observation.images.top": frames},
+        TransitionKey.COMPLEMENTARY_DATA: {
+            "task": ["pick cube", "place the cube carefully"],
+        },
+    }
+    encoded = encoder(transition)[TransitionKey.OBSERVATION]
+
+    assert encoded[f"{RYNNVALUE_FEATURE_PREFIX}input_ids"].shape == (2, 8)
+    assert encoded[f"{RYNNVALUE_FEATURE_PREFIX}attention_mask"].shape == (2, 8)
+    assert encoded[f"{RYNNVALUE_FEATURE_PREFIX}mm_token_type_ids"].shape == (2, 8)
+    assert encoded[f"{RYNNVALUE_FEATURE_PREFIX}pixel_values"].shape == (6, 6)
+    assert encoded[f"{RYNNVALUE_FEATURE_PREFIX}image_grid_thw"].shape == (6, 3)
+    assert [len(call["images"]) for call in fake.calls] == [3, 3]
+    assert fake.calls[0]["robot_description"] == "a test robot"
+    assert fake.calls[0]["camera_description"] == "a front camera"
+
+
+def test_encoder_can_override_checkpoint_meta_setting(monkeypatch):
+    fake = _patch_processor(monkeypatch)
+    RynnValueEncoderProcessorStep(use_meta=True)
+    assert fake.use_meta is True
+    assert fake.refresh_count == 1
+
+
+def test_converted_checkpoint_loads_processor_assets_from_lerobot_path(monkeypatch):
+    from lerobot.rewards.rynnvalue import processor_rynnvalue
+
+    captured = {}
+    fake = _FakeProcessor()
+
+    def from_pretrained(cls, model_id, **kwargs):  # noqa: ARG001
+        captured["model_id"] = model_id
+        captured.update(kwargs)
+        return fake
+
+    monkeypatch.setattr(
+        processor_rynnvalue.RynnValueLangProcessor,
+        "from_pretrained",
+        classmethod(from_pretrained),
+    )
+    config = RynnValueConfig(
+        device="cpu",
+        pretrained_path="lerobot/converted-rynnvalue",
+        pretrained_revision="converted-revision",
+        model_config={"model_type": "rynn_value_lang"},
+    )
+    make_rynnvalue_pre_post_processors(config)
+    assert captured["model_id"] == "lerobot/converted-rynnvalue"
+    assert captured["revision"] == "converted-revision"
+
+
+def test_encoder_requires_task_or_default(monkeypatch):
+    _patch_processor(monkeypatch)
+    encoder = RynnValueEncoderProcessorStep()
+    transition = {
+        TransitionKey.OBSERVATION: {
+            "observation.images.top": torch.zeros(1, 2, 3, 8, 8),
+        },
+        TransitionKey.COMPLEMENTARY_DATA: {},
+    }
+    with pytest.raises(KeyError, match="task"):
+        encoder(transition)

--- a/tests/rewards/test_rynnvalue_processor.py
+++ b/tests/rewards/test_rynnvalue_processor.py
@@ -163,6 +163,23 @@ def test_encoder_batches_and_pads_native_processor_outputs(monkeypatch):
     assert fake.calls[0]["camera_description"] == "a front camera"
 
 
+def test_encoder_treats_four_dimensional_input_as_one_trajectory(monkeypatch):
+    fake = _patch_processor(monkeypatch)
+    encoder = RynnValueEncoderProcessorStep(max_frames=None)
+    transition = {
+        TransitionKey.OBSERVATION: {
+            "observation.images.top": torch.zeros(5, 3, 8, 8),
+        },
+        TransitionKey.COMPLEMENTARY_DATA: {"task": "pick cube"},
+    }
+
+    encoded = encoder(transition)[TransitionKey.OBSERVATION]
+
+    assert len(fake.calls) == 1
+    assert len(fake.calls[0]["images"]) == 5
+    assert encoded[f"{RYNNVALUE_FEATURE_PREFIX}input_ids"].shape[0] == 1
+
+
 def test_encoder_can_override_checkpoint_meta_setting(monkeypatch):
     fake = _patch_processor(monkeypatch)
     RynnValueEncoderProcessorStep(use_meta=True)


### PR DESCRIPTION
## Title

feat(rewards): integrate RynnValue with semantic dataset scoring

## Summary / Motivation

Integrate RynnValue as a native LeRobot reward/value model and connect it to the shared offline-scoring workflow. The integration preserves RynnValue's native semantic output `predicted remaining time` rather than hiding it behind a generic scalar reward. Consumers can derive potential, bounded progress when an explicit horizon is available, or potential-based shaping for online RL.

This PR is stacked on the offline dataset-scoring foundation #4554.

## Related issues

- Fixes / Closes: None
- Related: #4554

## What changed

- Add native RynnValue configuration, model, processor, and reward-model factory registration.
- Port the released RynnValue language/value architecture into LeRobot.
- Support official 4B and 8B checkpoint conversion into a self-contained LeRobot checkpoint.
- Add the typed `predict_remaining_time()` API.
- Preserve distributional absolute and relative temporal heads, value-token grouping, symlog/two-hot decoding, and value-isolation attention.
- Add the optional `rynnvalue` dependency extra.
- Add a RynnValue frame scorer using causal trajectory prefixes.
- Emit:
  - `reward.rynnvalue.remaining_time_s`;
  - `reward.rynnvalue.potential`;
  - `reward.rynnvalue.is_inference_frame`;
  - optional `reward.rynnvalue.progress` when an explicit horizon is supplied.
- Add inference-frequency sampling and interpolation between inference frames.
- Extend `lerobot-score-dataset` to support RoboMeter and RynnValue.
- Add documentation for conversion, inference, dataset scoring, parity testing, limitations, and potential-based reward shaping.

## How was this tested (or how to run locally)

- Added tests for:
  - native model construction and value decoding;
  - configuration and factory registration;
  - processor prompting, batching, and frame sampling;
  - remaining-time prediction;
  - dataset-prefix scoring and interpolation;
  - CLI configuration and validation;
  - checkpoint conversion surfaces.
- Added an opt-in GPU parity test comparing the original and converted checkpoints on identical deterministic frames:

  ```bash
  LEROBOT_RYNNVALUE_ORIGINAL_CHECKPOINT=/path/to/original \
  LEROBOT_RYNNVALUE_CONVERTED_CHECKPOINT=/path/to/converted \
  uv run pytest tests/rewards/test_rynnvalue_original_parity.py -v
  ```

- Ran:
```bash
uv run pytest tests/rewards -q
```
Result: 219 passed, 8 skipped.

- Ran:
```bash
pre-commit run --all-files
```

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: # (insert PR number/link)

## Reviewer notes

- This is a stacked PR and should be reviewed after the offline dataset-scoring foundation.
- Please focus on checkpoint compatibility, remaining-time semantics, causal-prefix sampling, interpolation, and stored provenance.
- potential = -remaining_time is derived by the frame scorer; it is not presented as the model's native output.
- Online RL should turn this state potential into transition shaping, for example gamma * potential_next - potential.
- The language-generation success path and streaming KV-cache serving are intentionally out of scope.
- Anyone in the community is free to review the PR.
