### PR TITLE
feat(datasets): LRU caches for torchcodec & pyav decoders (byte budgets + remote/fsspec)

### DIFF
--- a/src/lerobot/datasets/streaming_dataset.py
+++ b/src/lerobot/datasets/streaming_dataset.py
@@ -37,7 +37,7 @@ from .utils import (
     safe_shard,
 )
 from .video_utils import (
-    VideoDecoderCache,
+    TorchcodecCache,
     decode_video_frames,
     decode_video_frames_torchcodec,
 )
@@ -416,7 +416,7 @@ class StreamingLeRobotDataset(torch.utils.data.IterableDataset):
     # in parallel, feeding a queue from which this iterator will yield processed items.
     def __iter__(self) -> Iterator[dict[str, torch.Tensor]]:
         if self.video_decoder_cache is None:
-            self.video_decoder_cache = VideoDecoderCache()
+            self.video_decoder_cache = TorchcodecCache()
 
         # keep the same seed across exhaustions if shuffle is False, otherwise shuffle data across exhaustions
         rng = np.random.default_rng(self.seed) if not self.shuffle else self.rng

--- a/src/lerobot/datasets/video_utils.py
+++ b/src/lerobot/datasets/video_utils.py
@@ -16,6 +16,7 @@
 import contextlib
 import glob
 import importlib
+import io
 import logging
 import os
 import queue
@@ -105,6 +106,57 @@ def decode_video_frames(
         raise ValueError(f"Unsupported video backend: {backend}")
 
 
+def _pyav_decode_window(
+    container: Any,
+    stream: Any,
+    first_ts: float,
+    last_ts: float,
+    is_depth: bool,
+    log_loaded_timestamps: bool,
+) -> tuple[list[torch.Tensor], list[float]]:
+    """Seek to the keyframe at/before ``first_ts`` and decode forward through ``last_ts``.
+
+    Returns the decoded frames (CHW uint8 for RGB, 1HW uint12 for depth) and their
+    timestamps. ``container`` / ``stream`` may be freshly opened or reused from the
+    cache; this only seeks + decodes and never closes them.
+
+    `container.seek(offset)` with no `stream` argument expects the offset in
+    av.time_base units (microseconds); passing ``stream`` uses that stream's
+    time_base instead. `backward=True` lands on the nearest keyframe at or before
+    `first_ts`, so we can decode forward until we cover `last_ts`. See:
+    https://pyav.basswood-io.com/docs/stable/api/container.html#av.container.InputContainer.seek
+    """
+    loaded_frames: list[torch.Tensor] = []
+    loaded_ts: list[float] = []
+
+    # Seek to the nearest keyframe at or before `first_ts` with a 1 frame margin
+    container.seek(
+        round(first_ts / stream.time_base) - 1,
+        backward=True,
+        any_frame=False,
+        stream=stream,
+    )
+
+    for frame in container.decode(stream):
+        if frame.pts is None:
+            continue
+        current_ts = float(frame.pts * stream.time_base)
+        if log_loaded_timestamps:
+            logger.info(f"frame loaded at timestamp={current_ts:.4f}")
+        if is_depth:
+            arr = frame.to_ndarray(format="gray12le")  # (H, W) uint12
+            loaded_frames.append(torch.from_numpy(arr).unsqueeze(0).contiguous())
+        else:
+            arr = frame.to_ndarray(format="rgb24")  # (H, W, 3)
+            # Convert to CHW uint8 to match torchcodec's output layout.
+            loaded_frames.append(torch.from_numpy(arr).permute(2, 0, 1).contiguous())
+        loaded_ts.append(current_ts)
+        if current_ts >= last_ts:
+            break
+
+    return loaded_frames, loaded_ts
+
+
 def decode_video_frames_pyav(
     video_path: Path | str | BinaryIO,
     timestamps: list[float],
@@ -112,6 +164,7 @@ def decode_video_frames_pyav(
     log_loaded_timestamps: bool = False,
     return_uint8: bool = False,
     is_depth: bool = False,
+    container_cache: "PyavCache | None" = None,
 ) -> torch.Tensor:
     """Loads frames associated to the requested timestamps of a video using PyAV.
 
@@ -134,53 +187,34 @@ def decode_video_frames_pyav(
         return_uint8: For RGB videos, if True return raw uint8 frames (C, H, W).
             Otherwise, return float32 in [0, 1] range.
         is_depth: Set to True if the video is a depth map (1 channel, uint12).
+        container_cache: Optional :class:`PyavCache` reused across calls. Only used
+            when ``video_path`` is a path/URL (not a raw file-like object). Uses the
+            module-level default when ``None``.
 
     Returns:
         torch.Tensor of shape (len(timestamps), C, H, W).
     """
     # TODO(rcadene): also load audio stream at the same time
-    if isinstance(video_path, (str, Path)):
-        video_path = str(video_path)
-    # else: a file-like object (e.g. a buffered remote source) passes to av.open as-is.
 
     # set the first and last requested timestamps
     # Note: previous timestamps are usually loaded, since we need to access the previous key frame
     first_ts = min(timestamps)
     last_ts = max(timestamps)
 
-    loaded_frames: list[torch.Tensor] = []
-    loaded_ts: list[float] = []
-
-    # Seek + decode. `container.seek(offset)` with no `stream` argument expects the offset in
-    # av.time_base units (microseconds). `backward=True` lands us on the nearest keyframe at or
-    # before `first_ts`, so we can then decode forward until we cover `last_ts`. See:
-    # https://pyav.basswood-io.com/docs/stable/api/container.html#av.container.InputContainer.seek
-    with av.open(video_path) as container:
-        stream = container.streams.video[0]
-        # Seek to the nearest keyframe at or before `first_ts` with a 1 frame margin
-        container.seek(
-            round(first_ts / stream.time_base) - 1,
-            backward=True,
-            any_frame=False,
-            stream=stream,
+    # A path/URL is decoded through the container cache (reused across calls, incl.
+    # remote fsspec URLs). A raw file-like object (e.g. a caller-managed remote
+    # source) has no stable cache key, so it is opened ad hoc and closed here.
+    if isinstance(video_path, (str, Path)):
+        cache = container_cache or _default_pyav_cache
+        container, stream = cache.get_container(str(video_path))
+        loaded_frames, loaded_ts = _pyav_decode_window(
+            container, stream, first_ts, last_ts, is_depth, log_loaded_timestamps
         )
-
-        for frame in container.decode(stream):
-            if frame.pts is None:
-                continue
-            current_ts = float(frame.pts * stream.time_base)
-            if log_loaded_timestamps:
-                logger.info(f"frame loaded at timestamp={current_ts:.4f}")
-            if is_depth:
-                arr = frame.to_ndarray(format="gray12le")  # (H, W) uint12
-                loaded_frames.append(torch.from_numpy(arr).unsqueeze(0).contiguous())
-            else:
-                arr = frame.to_ndarray(format="rgb24")  # (H, W, 3)
-                # Convert to CHW uint8 to match torchcodec's output layout.
-                loaded_frames.append(torch.from_numpy(arr).permute(2, 0, 1).contiguous())
-            loaded_ts.append(current_ts)
-            if current_ts >= last_ts:
-                break
+    else:
+        with av.open(video_path) as container:
+            loaded_frames, loaded_ts = _pyav_decode_window(
+                container, container.streams.video[0], first_ts, last_ts, is_depth, log_loaded_timestamps
+            )
 
     if not loaded_frames:
         raise FrameTimestampError(
@@ -230,7 +264,7 @@ def decode_video_frames_pyav(
 
 
 DEFAULT_DECODER_CACHE_SIZE = 100
-"""Default LRU capacity for :class:`VideoDecoderCache`.
+"""Default LRU capacity for :class:`TorchcodecCache`.
 
 Sized to comfortably hold a small rolling window of episodes worth of decoders
 (typical recipes: 2-4 cameras per episode × tens of episodes in flight) while
@@ -242,7 +276,7 @@ to the constructor (``None`` restores the legacy unbounded behaviour).
 
 
 DEFAULT_DECODER_CACHE_BYTES = None
-"""Default byte budget for :class:`VideoDecoderCache` (``None`` disables it).
+"""Default byte budget for :class:`TorchcodecCache` (``None`` disables it).
 
 Bounds host RAM held by decoders that buffer their video in memory — remote
 sources opened through fsspec; local files are read from disk on demand and cost
@@ -252,39 +286,46 @@ argument, e.g. ``2_000_000_000`` for a ~2 GB cap.
 """
 
 
-def _default_max_cache_size() -> int | None:
-    raw = os.environ.get("LEROBOT_VIDEO_DECODER_CACHE_SIZE")
-    if raw is None:
-        return DEFAULT_DECODER_CACHE_SIZE
-    raw = raw.strip().lower()
-    if raw in ("", "none", "unbounded", "-1"):
-        return None
-    try:
-        value = int(raw)
-    except ValueError as e:
-        raise ValueError(
-            f"LEROBOT_VIDEO_DECODER_CACHE_SIZE must be an integer, 'none', or '-1'; got {raw!r}"
-        ) from e
-    if value <= 0:
-        raise ValueError(f"LEROBOT_VIDEO_DECODER_CACHE_SIZE must be positive; got {value}")
-    return value
+DEFAULT_PYAV_CACHE_SIZE = 32
+"""Default LRU capacity for :class:`PyavCache`.
+
+Smaller than the torchcodec default because pyav is the fallback backend (mainly
+macOS x86_64, where the default open-file limit is 256) and every cached entry
+holds an open container, i.e. a file descriptor. 32 keeps a multi-camera rolling
+window while staying clear of the FD limit even with several DataLoader workers
+(each worker process has its own cache). Override via the
+``LEROBOT_PYAV_CACHE_SIZE`` env var or the ``max_size`` constructor argument
+(``None`` disables count-based eviction).
+"""
 
 
-def _default_byte_budget() -> int | None:
-    raw = os.environ.get("LEROBOT_VIDEO_DECODER_CACHE_BYTES")
+DEFAULT_PYAV_CACHE_BYTES = None
+"""Default byte budget for :class:`PyavCache` (``None`` disables it).
+
+Bounds host RAM held by remote videos buffered in memory (local containers stream
+from disk and weigh nothing). Opt-in via the ``LEROBOT_PYAV_CACHE_BYTES`` env var
+or the ``byte_budget`` constructor argument.
+"""
+
+
+def _env_cache_int(env_name: str, default: int | None) -> int | None:
+    """Resolve an LRU cache bound from an environment variable.
+
+    Returns ``default`` when unset; ``None`` (disabled) for ``none`` / ``unbounded``
+    / ``-1`` / ``0`` / empty; otherwise the parsed positive integer.
+    """
+    raw = os.environ.get(env_name)
     if raw is None:
-        return DEFAULT_DECODER_CACHE_BYTES
+        return default
     raw = raw.strip().lower()
     if raw in ("", "none", "unbounded", "-1", "0"):
         return None
     try:
         value = int(raw)
     except ValueError as e:
-        raise ValueError(
-            f"LEROBOT_VIDEO_DECODER_CACHE_BYTES must be an integer, 'none', or '-1'; got {raw!r}"
-        ) from e
+        raise ValueError(f"{env_name} must be an integer, 'none', or '-1'; got {raw!r}") from e
     if value <= 0:
-        raise ValueError(f"LEROBOT_VIDEO_DECODER_CACHE_BYTES must be positive; got {value}")
+        raise ValueError(f"{env_name} must be positive; got {value}")
     return value
 
 
@@ -299,43 +340,54 @@ def _video_file_nbytes(file_handle: Any) -> int:
     return size if isinstance(size, int) and size > 0 else 0
 
 
-class VideoDecoderCache:
-    """Thread-safe LRU cache for torchcodec ``VideoDecoder`` instances.
+class _VideoResourceCache:
+    """Thread-safe LRU cache for per-video decode resources.
 
-    Cached entries hold a ``VideoDecoder``. Remote sources also keep the open
-    ``fsspec`` file handle backing them (closed on eviction); local files are
-    decoded straight from their path and carry no handle. When the cache is full
-    and a new path is requested, the least-recently-used entry is evicted. This
-    bounds host-RAM growth when iterating over datasets with many distinct
-    video files (otherwise each ``DataLoader`` worker pins every decoder it has
-    ever opened until the process exits).
+    Backend-agnostic base shared by :class:`TorchcodecCache` (torchcodec
+    ``VideoDecoder`` instances) and :class:`PyavCache` (open pyav containers).
+    Bounds host RAM/FD growth when iterating over datasets with many distinct
+    video files (otherwise each ``DataLoader`` worker pins every resource it has
+    ever opened until the process exits) via a count cap and an optional byte
+    budget. Subclasses provide the backend through :meth:`_create` / :meth:`_close`.
+
+    Entries are ``(resource, closeable, weight)``: ``resource`` is returned to the
+    caller, ``closeable`` (may be ``None``) is closed on eviction, and ``weight``
+    is the entry's byte cost against ``byte_budget`` (0 = weightless).
+
+    Not safe to decode the same cached resource from two threads at once: cached
+    resources are stateful (a pyav container carries a decode position). Callers
+    must ensure one path is decoded by one thread at a time — LeRobotDataset's
+    per-file grouping in ``_query_videos`` already guarantees this.
 
     Args:
-        max_size: Maximum number of decoders to retain. ``None`` disables
-            count-based eviction and restores legacy unbounded behaviour.
-            Defaults to the value of ``LEROBOT_VIDEO_DECODER_CACHE_SIZE`` if
-            set, otherwise :data:`DEFAULT_DECODER_CACHE_SIZE`.
-        byte_budget: Optional cap on the summed size of the video files buffered
-            in memory by cached decoders (remote sources only; local files are
-            read from disk and weigh nothing). When exceeded, least-recently-used
-            entries are evicted (always keeping at least one). ``None`` disables
-            it. Defaults to ``LEROBOT_VIDEO_DECODER_CACHE_BYTES`` if set,
-            otherwise :data:`DEFAULT_DECODER_CACHE_BYTES`.
+        max_size: Maximum number of resources to retain. ``None`` disables
+            count-based eviction. Defaults to the subclass env var if set,
+            otherwise the subclass default.
+        byte_budget: Optional cap on the summed weight of cached entries. When
+            exceeded, least-recently-used entries are evicted (always keeping at
+            least one). ``None`` disables it. Defaults to the subclass env var if
+            set, otherwise the subclass default.
     """
 
     _SENTINEL: ClassVar[object] = object()
+
+    # Subclasses set these to wire up env-var / default resolution.
+    _ENV_SIZE: ClassVar[str]
+    _ENV_BYTES: ClassVar[str]
+    _DEFAULT_SIZE: ClassVar[int | None]
+    _DEFAULT_BYTES: ClassVar[int | None]
 
     def __init__(
         self,
         max_size: int | None | object = _SENTINEL,
         byte_budget: int | None | object = _SENTINEL,
     ):
-        if max_size is VideoDecoderCache._SENTINEL:
-            max_size = _default_max_cache_size()
+        if max_size is _VideoResourceCache._SENTINEL:
+            max_size = _env_cache_int(self._ENV_SIZE, self._DEFAULT_SIZE)
         if max_size is not None and max_size <= 0:
             raise ValueError(f"max_size must be positive or None; got {max_size}")
-        if byte_budget is VideoDecoderCache._SENTINEL:
-            byte_budget = _default_byte_budget()
+        if byte_budget is _VideoResourceCache._SENTINEL:
+            byte_budget = _env_cache_int(self._ENV_BYTES, self._DEFAULT_BYTES)
         if byte_budget is not None and byte_budget <= 0:
             raise ValueError(f"byte_budget must be positive or None; got {byte_budget}")
         self.max_size: int | None = max_size  # type: ignore[assignment]
@@ -347,8 +399,78 @@ class VideoDecoderCache:
         with self._lock:
             return str(video_path) in self._cache
 
-    def get_decoder(self, video_path: str):
-        """Get a cached decoder or create a new one, evicting LRU if at capacity."""
+    def _create(self, video_path: str) -> tuple[Any, Any, int]:
+        """Open a new resource for ``video_path``: ``(resource, closeable, weight)``."""
+        raise NotImplementedError
+
+    def _close(self, closeable: Any) -> None:
+        """Release a ``closeable`` returned by :meth:`_create` (never ``None``)."""
+        raise NotImplementedError
+
+    def _get(self, video_path: str) -> Any:
+        """Return a cached resource or create one, evicting LRU if over budget."""
+        video_path = str(video_path)
+        with self._lock:
+            entry = self._cache.get(video_path)
+            if entry is not None:
+                self._cache.move_to_end(video_path)
+                return entry[0]
+
+            resource, closeable, nbytes = self._create(video_path)
+            self._cache[video_path] = (resource, closeable, nbytes)
+
+            # Evict LRU entries until back under both the count cap and the byte
+            # budget (always keeping the just-added entry). Evicted closeables are
+            # released immediately; the resource is GC'd when its last reference
+            # goes away.
+            while len(self._cache) > 1:
+                over_count = self.max_size is not None and len(self._cache) > self.max_size
+                over_bytes = self.byte_budget is not None and (
+                    sum(n for _, _, n in self._cache.values()) > self.byte_budget
+                )
+                if not (over_count or over_bytes):
+                    break
+                _path, (_resource, evicted, _nbytes) = self._cache.popitem(last=False)
+                if evicted is not None:
+                    with contextlib.suppress(Exception):
+                        self._close(evicted)
+
+            return resource
+
+    def clear(self):
+        """Clear the cache and release all closeables."""
+        with self._lock:
+            for _resource, closeable, _nbytes in self._cache.values():
+                if closeable is not None:
+                    with contextlib.suppress(Exception):
+                        self._close(closeable)
+            self._cache.clear()
+
+    def size(self) -> int:
+        """Return the number of cached resources."""
+        with self._lock:
+            return len(self._cache)
+
+
+class TorchcodecCache(_VideoResourceCache):
+    """Thread-safe LRU cache for torchcodec ``VideoDecoder`` instances.
+
+    Local files are decoded straight from their path (shared OS page cache, no
+    per-decoder buffering); remote sources are opened through an in-memory
+    ``fsspec`` handle (closed on eviction) and weigh against ``byte_budget``.
+    See :class:`_VideoResourceCache` for the eviction and thread-safety contract.
+
+    Defaults come from ``LEROBOT_VIDEO_DECODER_CACHE_SIZE`` /
+    ``LEROBOT_VIDEO_DECODER_CACHE_BYTES`` (else :data:`DEFAULT_DECODER_CACHE_SIZE`
+    / :data:`DEFAULT_DECODER_CACHE_BYTES`).
+    """
+
+    _ENV_SIZE: ClassVar[str] = "LEROBOT_VIDEO_DECODER_CACHE_SIZE"
+    _ENV_BYTES: ClassVar[str] = "LEROBOT_VIDEO_DECODER_CACHE_BYTES"
+    _DEFAULT_SIZE: ClassVar[int | None] = DEFAULT_DECODER_CACHE_SIZE
+    _DEFAULT_BYTES: ClassVar[int | None] = DEFAULT_DECODER_CACHE_BYTES
+
+    def _create(self, video_path: str) -> tuple[Any, Any, int]:
         if importlib.util.find_spec("torchcodec"):
             from torchcodec.decoders import VideoDecoder
         else:
@@ -357,65 +479,66 @@ class VideoDecoderCache:
                 "Install it with: pip install 'lerobot[dataset]' (or uv pip install 'lerobot[dataset]')"
             )
 
-        video_path = str(video_path)
+        protocol, _ = split_protocol(video_path)
+        if protocol in (None, "file"):
+            return VideoDecoder(video_path, seek_mode="approximate"), None, 0
 
-        with self._lock:
-            entry = self._cache.get(video_path)
-            if entry is not None:
-                self._cache.move_to_end(video_path)
-                return entry[0]
+        file_handle = fsspec.open(video_path).__enter__()
+        try:
+            decoder = VideoDecoder(file_handle, seek_mode="approximate")
+        except Exception:
+            file_handle.close()
+            raise
+        nbytes = _video_file_nbytes(file_handle) if self.byte_budget is not None else 0
+        return decoder, file_handle, nbytes
 
-            # Local files are handed to torchcodec as a path so it reads from disk
-            # on demand (shared OS page cache, no per-decoder buffering). Remote
-            # sources are opened through fsspec and buffered in memory by the
-            # decoder, so they carry a handle to close and a byte weight for the
-            # budget.
-            protocol, _ = split_protocol(video_path)
-            if protocol in (None, "file"):
-                file_handle = None
-                decoder = VideoDecoder(video_path, seek_mode="approximate")
-                nbytes = 0
-            else:
-                file_handle = fsspec.open(video_path).__enter__()
-                try:
-                    decoder = VideoDecoder(file_handle, seek_mode="approximate")
-                except Exception:
-                    file_handle.close()
-                    raise
-                nbytes = _video_file_nbytes(file_handle) if self.byte_budget is not None else 0
-            self._cache[video_path] = (decoder, file_handle, nbytes)
+    def _close(self, closeable: Any) -> None:
+        closeable.close()
 
-            # Evict LRU entries until back under both the count cap and the byte
-            # budget (always keeping the just-added entry). Evicted remote handles
-            # are closed immediately (local entries have none); the ``VideoDecoder``
-            # is released to the GC when its last reference goes away.
-            while len(self._cache) > 1:
-                over_count = self.max_size is not None and len(self._cache) > self.max_size
-                over_bytes = self.byte_budget is not None and (
-                    sum(n for _, _, n in self._cache.values()) > self.byte_budget
-                )
-                if not (over_count or over_bytes):
-                    break
-                _path, (_decoder, evicted_handle, _nbytes) = self._cache.popitem(last=False)
-                if evicted_handle is not None:
-                    with contextlib.suppress(Exception):
-                        evicted_handle.close()
+    def get_decoder(self, video_path: str):
+        """Get a cached decoder or create a new one, evicting LRU if at capacity."""
+        return self._get(video_path)
 
-            return decoder
 
-    def clear(self):
-        """Clear the cache and close all file handles."""
-        with self._lock:
-            for _decoder, file_handle, _nbytes in self._cache.values():
-                if file_handle is not None:
-                    with contextlib.suppress(Exception):
-                        file_handle.close()
-            self._cache.clear()
+class PyavCache(_VideoResourceCache):
+    """Thread-safe LRU cache for open pyav ``(container, video stream)`` pairs.
 
-    def size(self) -> int:
-        """Return the number of cached decoders."""
-        with self._lock:
-            return len(self._cache)
+    Reuses open containers across calls so repeated access to the same file skips
+    ``av.open`` (header parse + codec-context init). Local files stream from disk
+    and weigh nothing; remote sources are read fully into memory once (so pyav's
+    per-GOP seeks don't each trigger a network round-trip) and weigh against
+    ``byte_budget``. Containers are closed on eviction. See
+    :class:`_VideoResourceCache` for the eviction and thread-safety contract.
+
+    Defaults come from ``LEROBOT_PYAV_CACHE_SIZE`` / ``LEROBOT_PYAV_CACHE_BYTES``
+    (else :data:`DEFAULT_PYAV_CACHE_SIZE` / :data:`DEFAULT_PYAV_CACHE_BYTES`).
+    """
+
+    _ENV_SIZE: ClassVar[str] = "LEROBOT_PYAV_CACHE_SIZE"
+    _ENV_BYTES: ClassVar[str] = "LEROBOT_PYAV_CACHE_BYTES"
+    _DEFAULT_SIZE: ClassVar[int | None] = DEFAULT_PYAV_CACHE_SIZE
+    _DEFAULT_BYTES: ClassVar[int | None] = DEFAULT_PYAV_CACHE_BYTES
+
+    def _create(self, video_path: str) -> tuple[Any, Any, int]:
+        protocol, _ = split_protocol(video_path)
+        if protocol in (None, "file"):
+            container = av.open(video_path)
+            return (container, container.streams.video[0]), container, 0
+
+        # Remote: buffer the whole file in RAM so pyav's per-GOP seeks don't each
+        # trigger a network round-trip (mirrors torchcodec's in-memory handling).
+        with fsspec.open(video_path) as f:
+            buffer = io.BytesIO(f.read())
+        container = av.open(buffer)
+        nbytes = buffer.getbuffer().nbytes if self.byte_budget is not None else 0
+        return (container, container.streams.video[0]), container, nbytes
+
+    def _close(self, closeable: Any) -> None:
+        closeable.close()
+
+    def get_container(self, video_path: str):
+        """Get a cached ``(container, video stream)`` pair, opening + caching on miss."""
+        return self._get(video_path)
 
 
 class FrameTimestampError(ValueError):
@@ -424,7 +547,8 @@ class FrameTimestampError(ValueError):
     pass
 
 
-_default_decoder_cache = VideoDecoderCache()
+_default_decoder_cache = TorchcodecCache()
+_default_pyav_cache = PyavCache()
 
 
 def decode_video_frames_torchcodec(
@@ -432,7 +556,7 @@ def decode_video_frames_torchcodec(
     timestamps: list[float],
     tolerance_s: float,
     log_loaded_timestamps: bool = False,
-    decoder_cache: VideoDecoderCache | None = None,
+    decoder_cache: TorchcodecCache | None = None,
     return_uint8: bool = False,
 ) -> torch.Tensor:
     """Loads frames associated with the requested timestamps of a video using torchcodec.

--- a/src/lerobot/datasets/video_utils.py
+++ b/src/lerobot/datasets/video_utils.py
@@ -36,6 +36,7 @@ import numpy as np
 import pyarrow as pa
 import torch
 from datasets.features.features import register_feature
+from fsspec.core import split_protocol
 from PIL import Image
 
 from lerobot.configs import (
@@ -240,6 +241,17 @@ to the constructor (``None`` restores the legacy unbounded behaviour).
 """
 
 
+DEFAULT_DECODER_CACHE_BYTES = None
+"""Default byte budget for :class:`VideoDecoderCache` (``None`` disables it).
+
+Bounds host RAM held by decoders that buffer their video in memory — remote
+sources opened through fsspec; local files are read from disk on demand and cost
+nothing here — on top of the count cap. Opt-in via the
+``LEROBOT_VIDEO_DECODER_CACHE_BYTES`` env var or the ``byte_budget`` constructor
+argument, e.g. ``2_000_000_000`` for a ~2 GB cap.
+"""
+
+
 def _default_max_cache_size() -> int | None:
     raw = os.environ.get("LEROBOT_VIDEO_DECODER_CACHE_SIZE")
     if raw is None:
@@ -258,32 +270,77 @@ def _default_max_cache_size() -> int | None:
     return value
 
 
+def _default_byte_budget() -> int | None:
+    raw = os.environ.get("LEROBOT_VIDEO_DECODER_CACHE_BYTES")
+    if raw is None:
+        return DEFAULT_DECODER_CACHE_BYTES
+    raw = raw.strip().lower()
+    if raw in ("", "none", "unbounded", "-1", "0"):
+        return None
+    try:
+        value = int(raw)
+    except ValueError as e:
+        raise ValueError(
+            f"LEROBOT_VIDEO_DECODER_CACHE_BYTES must be an integer, 'none', or '-1'; got {raw!r}"
+        ) from e
+    if value <= 0:
+        raise ValueError(f"LEROBOT_VIDEO_DECODER_CACHE_BYTES must be positive; got {value}")
+    return value
+
+
+def _video_file_nbytes(file_handle: Any) -> int:
+    """Best-effort size (bytes) of a remote video buffered in RAM by its decoder.
+
+    Only remote sources are opened through an in-memory ``fsspec`` handle, so
+    only they weigh against the byte budget. Returns 0 when the handle reports
+    no size, making that entry weightless.
+    """
+    size = getattr(file_handle, "size", None)
+    return size if isinstance(size, int) and size > 0 else 0
+
+
 class VideoDecoderCache:
     """Thread-safe LRU cache for torchcodec ``VideoDecoder`` instances.
 
-    Cached entries hold a ``VideoDecoder`` plus the open ``fsspec`` file handle
-    backing it. When the cache is full and a new path is requested, the
-    least-recently-used entry is evicted and its file handle is closed. This
+    Cached entries hold a ``VideoDecoder``. Remote sources also keep the open
+    ``fsspec`` file handle backing them (closed on eviction); local files are
+    decoded straight from their path and carry no handle. When the cache is full
+    and a new path is requested, the least-recently-used entry is evicted. This
     bounds host-RAM growth when iterating over datasets with many distinct
     video files (otherwise each ``DataLoader`` worker pins every decoder it has
     ever opened until the process exits).
 
     Args:
         max_size: Maximum number of decoders to retain. ``None`` disables
-            eviction and restores legacy unbounded behaviour. Defaults to the
-            value of ``LEROBOT_VIDEO_DECODER_CACHE_SIZE`` if set, otherwise
-            :data:`DEFAULT_DECODER_CACHE_SIZE`.
+            count-based eviction and restores legacy unbounded behaviour.
+            Defaults to the value of ``LEROBOT_VIDEO_DECODER_CACHE_SIZE`` if
+            set, otherwise :data:`DEFAULT_DECODER_CACHE_SIZE`.
+        byte_budget: Optional cap on the summed size of the video files buffered
+            in memory by cached decoders (remote sources only; local files are
+            read from disk and weigh nothing). When exceeded, least-recently-used
+            entries are evicted (always keeping at least one). ``None`` disables
+            it. Defaults to ``LEROBOT_VIDEO_DECODER_CACHE_BYTES`` if set,
+            otherwise :data:`DEFAULT_DECODER_CACHE_BYTES`.
     """
 
     _SENTINEL: ClassVar[object] = object()
 
-    def __init__(self, max_size: int | None | object = _SENTINEL):
+    def __init__(
+        self,
+        max_size: int | None | object = _SENTINEL,
+        byte_budget: int | None | object = _SENTINEL,
+    ):
         if max_size is VideoDecoderCache._SENTINEL:
             max_size = _default_max_cache_size()
         if max_size is not None and max_size <= 0:
             raise ValueError(f"max_size must be positive or None; got {max_size}")
+        if byte_budget is VideoDecoderCache._SENTINEL:
+            byte_budget = _default_byte_budget()
+        if byte_budget is not None and byte_budget <= 0:
+            raise ValueError(f"byte_budget must be positive or None; got {byte_budget}")
         self.max_size: int | None = max_size  # type: ignore[assignment]
-        self._cache: OrderedDict[str, tuple[Any, Any]] = OrderedDict()
+        self.byte_budget: int | None = byte_budget  # type: ignore[assignment]
+        self._cache: OrderedDict[str, tuple[Any, Any, int]] = OrderedDict()
         self._lock = Lock()
 
     def __contains__(self, video_path: object) -> bool:
@@ -308,20 +365,39 @@ class VideoDecoderCache:
                 self._cache.move_to_end(video_path)
                 return entry[0]
 
-            file_handle = fsspec.open(video_path).__enter__()
-            try:
-                decoder = VideoDecoder(file_handle, seek_mode="approximate")
-            except Exception:
-                file_handle.close()
-                raise
-            self._cache[video_path] = (decoder, file_handle)
+            # Local files are handed to torchcodec as a path so it reads from disk
+            # on demand (shared OS page cache, no per-decoder buffering). Remote
+            # sources are opened through fsspec and buffered in memory by the
+            # decoder, so they carry a handle to close and a byte weight for the
+            # budget.
+            protocol, _ = split_protocol(video_path)
+            if protocol in (None, "file"):
+                file_handle = None
+                decoder = VideoDecoder(video_path, seek_mode="approximate")
+                nbytes = 0
+            else:
+                file_handle = fsspec.open(video_path).__enter__()
+                try:
+                    decoder = VideoDecoder(file_handle, seek_mode="approximate")
+                except Exception:
+                    file_handle.close()
+                    raise
+                nbytes = _video_file_nbytes(file_handle) if self.byte_budget is not None else 0
+            self._cache[video_path] = (decoder, file_handle, nbytes)
 
-            # Evict LRU entries until we are back under the cap. We close
-            # evicted file handles immediately; the associated ``VideoDecoder``
+            # Evict LRU entries until back under both the count cap and the byte
+            # budget (always keeping the just-added entry). Evicted remote handles
+            # are closed immediately (local entries have none); the ``VideoDecoder``
             # is released to the GC when its last reference goes away.
-            if self.max_size is not None:
-                while len(self._cache) > self.max_size:
-                    _evicted_path, (_evicted_decoder, evicted_handle) = self._cache.popitem(last=False)
+            while len(self._cache) > 1:
+                over_count = self.max_size is not None and len(self._cache) > self.max_size
+                over_bytes = self.byte_budget is not None and (
+                    sum(n for _, _, n in self._cache.values()) > self.byte_budget
+                )
+                if not (over_count or over_bytes):
+                    break
+                _path, (_decoder, evicted_handle, _nbytes) = self._cache.popitem(last=False)
+                if evicted_handle is not None:
                     with contextlib.suppress(Exception):
                         evicted_handle.close()
 
@@ -330,9 +406,10 @@ class VideoDecoderCache:
     def clear(self):
         """Clear the cache and close all file handles."""
         with self._lock:
-            for _, file_handle in self._cache.values():
-                with contextlib.suppress(Exception):
-                    file_handle.close()
+            for _decoder, file_handle, _nbytes in self._cache.values():
+                if file_handle is not None:
+                    with contextlib.suppress(Exception):
+                        file_handle.close()
             self._cache.clear()
 
     def size(self) -> int:

--- a/tests/datasets/test_pyav_cache.py
+++ b/tests/datasets/test_pyav_cache.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for ``lerobot.datasets.video_utils.PyavCache``.
+
+Cover the LRU bounding + container-release behaviour that lets the pyav fallback
+reuse open containers across calls (skipping ``av.open`` header parse + codec
+init) without unbounded FD/RAM growth over datasets with many distinct files.
+"""
+
+import io
+import types
+from pathlib import Path
+
+import pytest
+import torch
+
+import lerobot.datasets.video_utils as video_utils
+from lerobot.datasets.video_utils import (
+    DEFAULT_PYAV_CACHE_SIZE,
+    PyavCache,
+    decode_video_frames_pyav,
+)
+
+TEST_ARTIFACTS_DIR = Path(__file__).resolve().parent.parent / "artifacts" / "encoded_videos"
+SRC_CLIP = TEST_ARTIFACTS_DIR / "clip_4frames.mp4"
+
+
+class _FakeContainer:
+    """Minimal stand-in for an av container: exposes a video stream, tracks close()."""
+
+    def __init__(self):
+        self.closed = False
+        self.streams = types.SimpleNamespace(video=[object()])
+
+    def close(self):
+        self.closed = True
+
+
+class _SpyOpen:
+    """Context manager mimicking ``fsspec.open`` over in-memory bytes."""
+
+    def __init__(self, data: bytes):
+        self._data = data
+
+    def __enter__(self):
+        return io.BytesIO(self._data)
+
+    def __exit__(self, *exc):
+        return False
+
+
+@pytest.fixture
+def fake_av(monkeypatch):
+    """Replace ``av.open`` with a fake returning fresh :class:`_FakeContainer` instances.
+
+    Lets the LRU mechanics be tested without decoding real files.
+    """
+    monkeypatch.setattr(video_utils.av, "open", lambda *a, **k: _FakeContainer())
+
+
+class TestPyavCacheBounded:
+    def test_default_cache_is_bounded(self):
+        """The default cache must have a finite ``max_size`` to bound FD/RSS growth."""
+        cache = PyavCache()
+        assert cache.max_size == DEFAULT_PYAV_CACHE_SIZE
+        assert cache.max_size is not None and cache.max_size > 0
+
+    def test_size_capped_and_evicts_lru(self, fake_av):
+        """Re-accessing promotes to MRU; the LRU entry is evicted once over the cap."""
+        cache = PyavCache(max_size=2)
+        cache.get_container("a")
+        cache.get_container("b")
+        cache.get_container("a")  # promote "a"; "b" is now LRU
+        cache.get_container("c")  # evict "b"
+        assert cache.size() == 2
+        assert "a" in cache and "c" in cache
+        assert "b" not in cache
+
+    def test_eviction_closes_container(self, fake_av):
+        """Evicting an entry must close its container (otherwise we leak FDs)."""
+        cache = PyavCache(max_size=1)
+        cache.get_container("a")
+        evicted = cache._cache["a"][1]
+        assert evicted.closed is False
+        cache.get_container("b")  # forces eviction of "a"
+        assert evicted.closed is True
+
+    def test_clear_closes_all_containers(self, fake_av):
+        cache = PyavCache(max_size=10)
+        for p in ("a", "b", "c"):
+            cache.get_container(p)
+        containers = [entry[1] for entry in cache._cache.values()]
+        cache.clear()
+        assert cache.size() == 0
+        assert all(c.closed for c in containers)
+
+    def test_hit_returns_same_and_does_not_evict(self, fake_av):
+        cache = PyavCache(max_size=2)
+        first = cache.get_container("a")
+        second = cache.get_container("a")
+        assert first is second
+        assert cache.size() == 1
+
+    def test_unbounded_when_max_size_none(self, fake_av):
+        cache = PyavCache(max_size=None)
+        for p in ("a", "b", "c", "d"):
+            cache.get_container(p)
+        assert cache.size() == 4
+
+    def test_env_var_overrides_default(self, fake_av, monkeypatch):
+        monkeypatch.setenv("LEROBOT_PYAV_CACHE_SIZE", "3")
+        cache = PyavCache()
+        assert cache.max_size == 3
+        for p in ("a", "b", "c", "d", "e"):
+            cache.get_container(p)
+        assert cache.size() == 3
+
+
+class TestPyavCacheByteBudget:
+    def test_disabled_by_default(self):
+        """Byte budget is opt-in: off unless configured."""
+        assert PyavCache().byte_budget is None
+
+    def test_remote_evicts_over_budget_but_keeps_one(self, fake_av, monkeypatch):
+        """Remote clips buffered in RAM weigh against the budget; local ones don't."""
+        data = SRC_CLIP.read_bytes()
+        monkeypatch.setattr(video_utils.fsspec, "open", lambda *a, **k: _SpyOpen(data))
+
+        cache = PyavCache(max_size=None, byte_budget=len(data))
+        for i in range(4):
+            cache.get_container(f"s3://bucket/clip_{i:04d}.mp4")
+        assert cache.size() == 1
+
+    def test_local_files_are_weightless(self, fake_av):
+        cache = PyavCache(max_size=None, byte_budget=1)  # tiniest possible budget
+        for p in ("a", "b", "c", "d"):
+            cache.get_container(p)
+        assert cache.size() == 4
+
+    def test_env_var_overrides_default(self, monkeypatch):
+        monkeypatch.setenv("LEROBOT_PYAV_CACHE_BYTES", "12345")
+        assert PyavCache().byte_budget == 12345
+        monkeypatch.setenv("LEROBOT_PYAV_CACHE_BYTES", "none")
+        assert PyavCache().byte_budget is None
+
+
+class TestPyavCacheDecode:
+    """Real-decode tests guarding container reuse (seek-state) correctness."""
+
+    def test_cached_matches_fresh_open_across_reuse(self):
+        """Cached decode equals a fresh ad-hoc open, and reuse doesn't corrupt state."""
+        timestamps = [0.0]
+        tolerance_s = 1.0  # generous: nearest-frame match on a 4-frame clip
+
+        # Fresh open via a raw file-like object hits the uncached (else) branch.
+        with open(SRC_CLIP, "rb") as f:
+            fresh = decode_video_frames_pyav(f, timestamps, tolerance_s)
+
+        cache = PyavCache()
+        first = decode_video_frames_pyav(str(SRC_CLIP), timestamps, tolerance_s, container_cache=cache)
+        # Second call reuses the cached container (re-seek on a used container).
+        second = decode_video_frames_pyav(str(SRC_CLIP), timestamps, tolerance_s, container_cache=cache)
+
+        assert torch.equal(first, fresh)
+        assert torch.equal(second, fresh)
+        assert cache.size() == 1
+
+    def test_reuses_cached_container_object(self):
+        cache = PyavCache()
+        decode_video_frames_pyav(str(SRC_CLIP), [0.0], 1.0, container_cache=cache)
+        resource_first = cache._cache[str(SRC_CLIP)][0]
+        decode_video_frames_pyav(str(SRC_CLIP), [0.0], 1.0, container_cache=cache)
+        resource_second = cache._cache[str(SRC_CLIP)][0]
+        assert resource_first is resource_second

--- a/tests/datasets/test_pyav_cache.py
+++ b/tests/datasets/test_pyav_cache.py
@@ -25,6 +25,7 @@ import io
 import types
 from pathlib import Path
 
+import fsspec
 import pytest
 import torch
 
@@ -186,3 +187,21 @@ class TestPyavCacheDecode:
         decode_video_frames_pyav(str(SRC_CLIP), [0.0], 1.0, container_cache=cache)
         resource_second = cache._cache[str(SRC_CLIP)][0]
         assert resource_first is resource_second
+
+    def test_decodes_remote_url_via_fsspec(self):
+        """A non-local URL is opened through fsspec and decodes identically to local.
+
+        This is the path that lets pyav read remote videos at all (e.g. streaming
+        depth maps, which are pyav-only), so it must produce the same frames.
+        """
+        url = "memory://test_pyav_cache/clip.mp4"
+        with fsspec.open(url, "wb") as f:
+            f.write(SRC_CLIP.read_bytes())
+
+        cache = PyavCache()
+        remote = decode_video_frames_pyav(url, [0.0], 1.0, container_cache=cache)
+        with open(SRC_CLIP, "rb") as fh:
+            local = decode_video_frames_pyav(fh, [0.0], 1.0)
+
+        assert torch.equal(remote, local)
+        assert cache.size() == 1

--- a/tests/datasets/test_video_decoder_cache.py
+++ b/tests/datasets/test_video_decoder_cache.py
@@ -21,6 +21,7 @@ unbounded growth when iterating over datasets with many distinct video files
 (observed: ~35 GB anon-rss per DataLoader worker on an 8 k-file dataset).
 """
 
+import io
 import shutil
 from pathlib import Path
 
@@ -28,6 +29,7 @@ import pytest
 
 pytest.importorskip("torchcodec", reason="torchcodec is required (install lerobot[dataset])")
 
+import lerobot.datasets.video_utils as video_utils  # noqa: E402
 from lerobot.datasets.video_utils import VideoDecoderCache  # noqa: E402
 
 TEST_ARTIFACTS_DIR = Path(__file__).resolve().parent.parent / "artifacts" / "encoded_videos"
@@ -35,7 +37,7 @@ SRC_CLIP = TEST_ARTIFACTS_DIR / "clip_4frames.mp4"
 
 
 def _make_distinct_clips(tmp_path: Path, n: int) -> list[Path]:
-    """Copy the small reference mp4 to ``n`` distinct paths.
+    """Copy the small reference mp4 to ``n`` distinct local paths.
 
     The cache keys on absolute path, so distinct paths force distinct cache entries
     even though the file contents are identical.
@@ -47,6 +49,40 @@ def _make_distinct_clips(tmp_path: Path, n: int) -> list[Path]:
         shutil.copyfile(SRC_CLIP, dst)
         paths.append(dst)
     return paths
+
+
+class _SpyHandle(io.BytesIO):
+    """A closeable, size-reporting stand-in for a remote fsspec handle.
+
+    Unlike fsspec's ``memory://`` handle (whose ``close()`` is a no-op), this
+    mirrors real remote handles: ``.size`` reports the buffered byte count and
+    ``.close()`` flips ``.closed``.
+    """
+
+    def __init__(self, data: bytes):
+        super().__init__(data)
+        self.size = len(data)
+
+
+@pytest.fixture
+def remote_urls(monkeypatch):
+    """Force ``get_decoder``'s remote branch with in-memory spy handles.
+
+    Returns a factory ``make(n) -> [url, ...]``; each opened URL yields a fresh
+    :class:`_SpyHandle` over the reference clip's bytes.
+    """
+    assert SRC_CLIP.exists(), f"missing test artifact {SRC_CLIP}"
+    data = SRC_CLIP.read_bytes()
+
+    class _SpyOpen:
+        def __enter__(self):
+            return _SpyHandle(data)
+
+        def __exit__(self, *exc):
+            return False
+
+    monkeypatch.setattr(video_utils.fsspec, "open", lambda *a, **k: _SpyOpen())
+    return lambda n: [f"s3://bucket/clip_{i:04d}.mp4" for i in range(n)]
 
 
 class TestVideoDecoderCacheBounded:
@@ -78,29 +114,29 @@ class TestVideoDecoderCacheBounded:
         assert str(paths[1]) not in cache  # LRU evicted
         assert str(paths[2]) in cache  # newest stays
 
-    def test_eviction_closes_file_handle(self, tmp_path):
-        """Evicting an entry must close its fsspec file handle (otherwise we leak FDs)."""
-        paths = _make_distinct_clips(tmp_path, n=2)
+    def test_eviction_closes_file_handle(self, remote_urls):
+        """Evicting a remote entry must close its fsspec file handle (otherwise we leak FDs)."""
+        urls = remote_urls(2)
         cache = VideoDecoderCache(max_size=1)
 
-        cache.get_decoder(paths[0])
+        cache.get_decoder(urls[0])
         # Reach into the cache to capture the handle before it is evicted. This is
         # the only assertion in the suite that touches a private attribute, and it
         # is the most direct way to prove the file descriptor is actually released.
-        evicted_handle = cache._cache[str(paths[0])][1]
+        evicted_handle = cache._cache[urls[0]][1]
         assert evicted_handle.closed is False
 
-        cache.get_decoder(paths[1])  # forces eviction of paths[0]
+        cache.get_decoder(urls[1])  # forces eviction of urls[0]
 
         assert evicted_handle.closed is True
 
-    def test_clear_closes_all_file_handles(self, tmp_path):
-        """``clear()`` must close every cached file handle."""
-        paths = _make_distinct_clips(tmp_path, n=3)
+    def test_clear_closes_all_file_handles(self, remote_urls):
+        """``clear()`` must close every cached remote file handle."""
+        urls = remote_urls(3)
         cache = VideoDecoderCache(max_size=10)
 
-        for p in paths:
-            cache.get_decoder(p)
+        for u in urls:
+            cache.get_decoder(u)
         handles = [entry[1] for entry in cache._cache.values()]
         assert all(not h.closed for h in handles)
 
@@ -108,6 +144,16 @@ class TestVideoDecoderCacheBounded:
 
         assert cache.size() == 0
         assert all(h.closed for h in handles)
+
+    def test_local_files_use_path_no_handle(self, tmp_path):
+        """Local files are decoded by path: no fsspec handle to hold or close."""
+        paths = _make_distinct_clips(tmp_path, n=2)
+        cache = VideoDecoderCache(max_size=10)
+
+        for p in paths:
+            cache.get_decoder(p)
+
+        assert all(cache._cache[str(p)][1] is None for p in paths)
 
     def test_hit_does_not_reopen_or_evict(self, tmp_path):
         """A cache hit must return the same decoder instance without touching the cap."""
@@ -138,3 +184,44 @@ class TestVideoDecoderCacheBounded:
         for p in paths:
             cache.get_decoder(p)
         assert cache.size() == 3
+
+
+class TestVideoDecoderCacheByteBudget:
+    def test_disabled_by_default(self):
+        """Byte budget is opt-in: off unless configured."""
+        assert VideoDecoderCache().byte_budget is None
+
+    def test_evicts_over_budget_but_keeps_one(self, remote_urls):
+        """A budget below one file's size still keeps exactly one (the just-added) entry.
+
+        Uses remote clips: only in-memory-buffered decoders weigh against the budget.
+        """
+        urls = remote_urls(4)
+        clip_size = SRC_CLIP.stat().st_size
+
+        # Budget fits ~1 file: adding each new file evicts the previous one.
+        cache = VideoDecoderCache(max_size=None, byte_budget=clip_size)
+        for u in urls:
+            cache.get_decoder(u)
+        assert cache.size() == 1
+        assert urls[-1] in cache  # newest survives
+
+        # Even a byte budget smaller than any single file never drops below one entry.
+        tiny = VideoDecoderCache(max_size=None, byte_budget=1)
+        for u in urls:
+            tiny.get_decoder(u)
+        assert tiny.size() == 1
+
+    def test_local_files_are_weightless(self, tmp_path):
+        """Local files are read from disk, so the byte budget never evicts them."""
+        paths = _make_distinct_clips(tmp_path, n=4)
+        cache = VideoDecoderCache(max_size=None, byte_budget=1)  # tiniest possible budget
+        for p in paths:
+            cache.get_decoder(p)
+        assert cache.size() == 4
+
+    def test_env_var_overrides_default(self, monkeypatch):
+        monkeypatch.setenv("LEROBOT_VIDEO_DECODER_CACHE_BYTES", "12345")
+        assert VideoDecoderCache().byte_budget == 12345
+        monkeypatch.setenv("LEROBOT_VIDEO_DECODER_CACHE_BYTES", "none")
+        assert VideoDecoderCache().byte_budget is None

--- a/tests/datasets/test_video_decoder_cache.py
+++ b/tests/datasets/test_video_decoder_cache.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Unit tests for ``lerobot.datasets.video_utils.VideoDecoderCache``.
+"""Unit tests for ``lerobot.datasets.video_utils.TorchcodecCache``.
 
 These cover the LRU bounding + file-handle release behaviour added to prevent
 unbounded growth when iterating over datasets with many distinct video files
@@ -30,7 +30,7 @@ import pytest
 pytest.importorskip("torchcodec", reason="torchcodec is required (install lerobot[dataset])")
 
 import lerobot.datasets.video_utils as video_utils  # noqa: E402
-from lerobot.datasets.video_utils import VideoDecoderCache  # noqa: E402
+from lerobot.datasets.video_utils import TorchcodecCache  # noqa: E402
 
 TEST_ARTIFACTS_DIR = Path(__file__).resolve().parent.parent / "artifacts" / "encoded_videos"
 SRC_CLIP = TEST_ARTIFACTS_DIR / "clip_4frames.mp4"
@@ -85,17 +85,17 @@ def remote_urls(monkeypatch):
     return lambda n: [f"s3://bucket/clip_{i:04d}.mp4" for i in range(n)]
 
 
-class TestVideoDecoderCacheBounded:
+class TestTorchcodecCacheBounded:
     def test_default_cache_is_bounded(self):
         """The default cache must have a finite ``max_size`` to bound RSS growth."""
-        cache = VideoDecoderCache()
+        cache = TorchcodecCache()
         assert cache.max_size is not None, "default cache must be bounded"
         assert cache.max_size > 0
 
     def test_size_capped_at_max_size(self, tmp_path):
         """``get_decoder`` for >``max_size`` distinct paths must NOT grow without bound."""
         paths = _make_distinct_clips(tmp_path, n=5)
-        cache = VideoDecoderCache(max_size=2)
+        cache = TorchcodecCache(max_size=2)
         for p in paths:
             cache.get_decoder(p)
         assert cache.size() == 2
@@ -103,7 +103,7 @@ class TestVideoDecoderCacheBounded:
     def test_evicts_least_recently_used(self, tmp_path):
         """Re-accessing an entry must promote it; the LRU entry is the one evicted."""
         paths = _make_distinct_clips(tmp_path, n=3)
-        cache = VideoDecoderCache(max_size=2)
+        cache = TorchcodecCache(max_size=2)
 
         cache.get_decoder(paths[0])
         cache.get_decoder(paths[1])
@@ -117,7 +117,7 @@ class TestVideoDecoderCacheBounded:
     def test_eviction_closes_file_handle(self, remote_urls):
         """Evicting a remote entry must close its fsspec file handle (otherwise we leak FDs)."""
         urls = remote_urls(2)
-        cache = VideoDecoderCache(max_size=1)
+        cache = TorchcodecCache(max_size=1)
 
         cache.get_decoder(urls[0])
         # Reach into the cache to capture the handle before it is evicted. This is
@@ -133,7 +133,7 @@ class TestVideoDecoderCacheBounded:
     def test_clear_closes_all_file_handles(self, remote_urls):
         """``clear()`` must close every cached remote file handle."""
         urls = remote_urls(3)
-        cache = VideoDecoderCache(max_size=10)
+        cache = TorchcodecCache(max_size=10)
 
         for u in urls:
             cache.get_decoder(u)
@@ -148,7 +148,7 @@ class TestVideoDecoderCacheBounded:
     def test_local_files_use_path_no_handle(self, tmp_path):
         """Local files are decoded by path: no fsspec handle to hold or close."""
         paths = _make_distinct_clips(tmp_path, n=2)
-        cache = VideoDecoderCache(max_size=10)
+        cache = TorchcodecCache(max_size=10)
 
         for p in paths:
             cache.get_decoder(p)
@@ -158,7 +158,7 @@ class TestVideoDecoderCacheBounded:
     def test_hit_does_not_reopen_or_evict(self, tmp_path):
         """A cache hit must return the same decoder instance without touching the cap."""
         paths = _make_distinct_clips(tmp_path, n=1)
-        cache = VideoDecoderCache(max_size=2)
+        cache = TorchcodecCache(max_size=2)
 
         first = cache.get_decoder(paths[0])
         second = cache.get_decoder(paths[0])
@@ -169,7 +169,7 @@ class TestVideoDecoderCacheBounded:
     def test_unbounded_when_max_size_none(self, tmp_path):
         """``max_size=None`` preserves the legacy unbounded behaviour."""
         paths = _make_distinct_clips(tmp_path, n=4)
-        cache = VideoDecoderCache(max_size=None)
+        cache = TorchcodecCache(max_size=None)
         for p in paths:
             cache.get_decoder(p)
         assert cache.size() == 4
@@ -177,7 +177,7 @@ class TestVideoDecoderCacheBounded:
     def test_env_var_overrides_default(self, tmp_path, monkeypatch):
         """``LEROBOT_VIDEO_DECODER_CACHE_SIZE`` env var sets the default ``max_size``."""
         monkeypatch.setenv("LEROBOT_VIDEO_DECODER_CACHE_SIZE", "3")
-        cache = VideoDecoderCache()
+        cache = TorchcodecCache()
         assert cache.max_size == 3
 
         paths = _make_distinct_clips(tmp_path, n=5)
@@ -186,10 +186,10 @@ class TestVideoDecoderCacheBounded:
         assert cache.size() == 3
 
 
-class TestVideoDecoderCacheByteBudget:
+class TestTorchcodecCacheByteBudget:
     def test_disabled_by_default(self):
         """Byte budget is opt-in: off unless configured."""
-        assert VideoDecoderCache().byte_budget is None
+        assert TorchcodecCache().byte_budget is None
 
     def test_evicts_over_budget_but_keeps_one(self, remote_urls):
         """A budget below one file's size still keeps exactly one (the just-added) entry.
@@ -200,14 +200,14 @@ class TestVideoDecoderCacheByteBudget:
         clip_size = SRC_CLIP.stat().st_size
 
         # Budget fits ~1 file: adding each new file evicts the previous one.
-        cache = VideoDecoderCache(max_size=None, byte_budget=clip_size)
+        cache = TorchcodecCache(max_size=None, byte_budget=clip_size)
         for u in urls:
             cache.get_decoder(u)
         assert cache.size() == 1
         assert urls[-1] in cache  # newest survives
 
         # Even a byte budget smaller than any single file never drops below one entry.
-        tiny = VideoDecoderCache(max_size=None, byte_budget=1)
+        tiny = TorchcodecCache(max_size=None, byte_budget=1)
         for u in urls:
             tiny.get_decoder(u)
         assert tiny.size() == 1
@@ -215,13 +215,13 @@ class TestVideoDecoderCacheByteBudget:
     def test_local_files_are_weightless(self, tmp_path):
         """Local files are read from disk, so the byte budget never evicts them."""
         paths = _make_distinct_clips(tmp_path, n=4)
-        cache = VideoDecoderCache(max_size=None, byte_budget=1)  # tiniest possible budget
+        cache = TorchcodecCache(max_size=None, byte_budget=1)  # tiniest possible budget
         for p in paths:
             cache.get_decoder(p)
         assert cache.size() == 4
 
     def test_env_var_overrides_default(self, monkeypatch):
         monkeypatch.setenv("LEROBOT_VIDEO_DECODER_CACHE_BYTES", "12345")
-        assert VideoDecoderCache().byte_budget == 12345
+        assert TorchcodecCache().byte_budget == 12345
         monkeypatch.setenv("LEROBOT_VIDEO_DECODER_CACHE_BYTES", "none")
-        assert VideoDecoderCache().byte_budget is None
+        assert TorchcodecCache().byte_budget is None


### PR DESCRIPTION
## Summary

Stacked on top of `feat/dataset-reader-video-perf` (that's the PR base), so this diff is only the decoder-cache work.

- Extract a shared thread-safe LRU base `_VideoResourceCache` (count cap + optional byte budget, LRU eviction closing evicted resources) and rename `VideoDecoderCache` → `TorchcodecCache` on top of it.
- `TorchcodecCache`: decode local files straight from path (shared OS page cache, weight 0); open remote sources through an in-memory `fsspec` handle (closed on eviction) weighed against the byte budget.
- Add `PyavCache`: reuse open pyav `(container, stream)` pairs across decode calls (skips repeated `av.open`); local files stream from disk, remote sources are buffered once in RAM via `fsspec` so per-GOP seeks don't each hit the network. Wired into `decode_video_frames_pyav` so path/URL inputs are cached — which also makes remote-URL decoding work for pyav (e.g. pyav-only depth maps).
- Configurable via `LEROBOT_VIDEO_DECODER_CACHE_SIZE`/`_BYTES` and `LEROBOT_PYAV_CACHE_SIZE`/`_BYTES`.

## Test plan

- [ ] `pytest tests/datasets/test_video_decoder_cache.py`
- [ ] `pytest tests/datasets/test_pyav_cache.py` (incl. remote-URL decode parity via fsspec)
- [ ] `pre-commit run --all-files`