### PR TITLE
fix(rl): write uint8 images in to_lerobot_dataset so checkpointing does not kill the learner

### DIFF
--- a/src/lerobot/rl/buffer.py
+++ b/src/lerobot/rl/buffer.py
@@ -568,9 +568,20 @@ class ReplayBuffer:
 
             frame_dict = {}
 
-            # Fill the data for state keys
+            # Fill the data for state keys. Image tensors are normalized to
+            # uint8 before writing: the dataset image writer rejects float
+            # images outside [0, 1], but the buffer holds [0, 255] floats for
+            # demo frames (loaded via make_dataset with return_uint8=True).
+            # Converting to uint8 is lossless (both sources are 8-bit) and
+            # the dump reloads as [0, 1] floats, matching the policy's
+            # ImageNet normalization stats.
             for key in self.states:
-                frame_dict[key] = self.states[key][actual_idx].cpu()
+                val = self.states[key][actual_idx].cpu()
+                if val.ndim >= 3 and val.is_floating_point():
+                    if float(val.max()) > 1.0:
+                        val = val / 255.0
+                    val = (val * 255.0).round().clamp(0, 255).to(torch.uint8)
+                frame_dict[key] = val
 
             # Fill action, reward, done
             frame_dict[ACTION] = self.actions[actual_idx].cpu()


### PR DESCRIPTION
## What breaks

Every offline replay-buffer dump during HIL-SERL training fails, and on `main` the
exception propagates out of `save_training_checkpoint` and kills the learner. It happens
on the first checkpoint after the offline buffer is populated, so a run dies partway
through with the policy weights already written but training over.

I hit this on a real SO-101 run. The log fills with one error per frame:

```
Error writing image .../observation.images.wrist/episode-000000/frame-000000.png:
The image data type is float, which requires values in the range [0.0, 1.0].
However, the provided range is [0.0, 255.0].
```

then the run ends in `compute_episode_stats`, leaving `dataset_offline/` half written
(`images/` and `meta/` present, no `data/`). A later resume then fails on the incomplete
dataset.

## Why

`initialize_offline_replay_buffer` builds the offline buffer through `make_dataset`,
which loads frames with `return_uint8=True` (`datasets/factory.py`). `ReplayBuffer.
_initialize_storage` pre-allocates with `torch.empty(...)`, i.e. float32, so assigning
uint8 `[0, 255]` yields float `[0.0, 255.0]`; nothing on that path divides by 255.
`to_lerobot_dataset` then hands those raw floats to the dataset image writer, which
accepts float only in `[0, 1]` (or uint8).

The online buffer happens to survive because its frames come from the env pipeline
already in `[0, 1]`, which is why this looks intermittent.

## Reproduction

Any HIL-SERL run with `dataset.repo_id` set that reaches a checkpoint. It is easy to
miss because the shipped `save_freq` is 2000000, so checkpointing effectively never
fires in a short run. With `save_freq: 2000` it reproduces within a few minutes.

## Fix

Normalize image tensors to uint8 in `to_lerobot_dataset` before writing. Both possible
inputs are 8-bit in origin, so the conversion is lossless, and a plain reload turns the
uint8 back into `[0, 1]` floats, which is what the policy's ImageNet normalization
expects. Non-image entries (`observation.state` is 1-D) pass through untouched.

Verified on a 10347-frame demo set: 598 writer errors before, 0 after; the dumped
dataset reloads with every image float32 in `[0.0, 1.0]`.

Disclosure: written with AI assistance; the diagnosis and the fix were verified against
a real robot run.
