### PR TITLE
feat(rollout): bring your own strategy

### DIFF
--- a/docs/source/inference.mdx
+++ b/docs/source/inference.mdx
@@ -197,6 +197,58 @@ Teleop is optional — if omitted the robot holds its position during the reset 
 | `--strategy.smooth_leader_to_follower_handover` | Whether to turn on or off the leader -> follower smooth handover behavior.                                                                                 |
 | `--strategy.smooth_handover`                    | Smoothly hand control to the teleop at reset start (default: true). Disable for clutch-style teleops that re-reference at the current robot pose on engage |
 
+### Bring your own strategy
+
+`--strategy.type` accepts any strategy registered in the environment, not only the built-ins above. A strategy is two classes in a pip-installable package: a config registered on `RolloutStrategyConfig`, and a `RolloutStrategy` subclass named after it without the `Config` suffix — the same `SomethingConfig`/`Something` convention as [custom hardware](./integrate_hardware#the-4-core-conventions), resolved from the config's module or package.
+
+```python
+from dataclasses import dataclass
+from typing import ClassVar
+
+from lerobot.rollout import RolloutContext, RolloutStrategy, RolloutStrategyConfig
+
+
+@RolloutStrategyConfig.register_subclass("patrol")
+@dataclass
+class PatrolStrategyConfig(RolloutStrategyConfig):
+    dataset_mode: ClassVar[str] = "required"  # the engine creates the dataset for you
+    legs: int = 2  # becomes --strategy.legs
+
+
+class PatrolStrategy(RolloutStrategy):
+    def run(self, ctx: RolloutContext) -> None:
+        ...  # the paced control loop: see the contract on RolloutStrategy.run
+
+    def teardown(self, ctx: RolloutContext) -> None:
+        ctx.data.dataset.finalize()
+        self._teardown_hardware(ctx.hardware, ctx.runtime.cfg.return_to_initial_position)
+```
+
+The config declares what the engine arranges on the strategy's behalf, so nothing in LeRobot needs to know its type:
+
+| Declaration                     | Effect                                                                                                                                     |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `dataset_mode`                  | `"none"` (default) rejects `--dataset.*` flags, `"optional"` records when they are given, `"required"` makes `--dataset.repo_id` mandatory |
+| `requires_teleop`               | Makes `--teleop.type` mandatory                                                                                                            |
+| `supports_interactive`          | Allows `--interactive=true`; `run()` must then honour the restartable contract documented on `RolloutStrategy`                             |
+| `requires_streaming_encoding()` | Return `True` when frames are written from inside the control loop: `--dataset.streaming_encoding` is forced on                            |
+| `extra_dataset_features()`      | Strategy-owned dataset columns (DAgger's `intervention`, for instance); every recorded frame must carry them                               |
+
+Name the distribution `lerobot_strategy_<name>` and `lerobot-rollout` imports the package before parsing the CLI — only its `__init__.py` runs, so import the config there. A package with any other name is loaded, submodules included, with `--strategy.discover_packages_path=<package>`. The strategy's dataclass fields become `--strategy.*` flags:
+
+```bash
+lerobot-rollout \
+    --strategy.type=patrol \
+    --strategy.legs=3 \
+    --policy.path=${HF_USER}/my_policy \
+    --robot.type=so100_follower \
+    --robot.port=/dev/ttyACM0 \
+    --dataset.repo_id=${HF_USER}/rollout_patrol \
+    --dataset.single_task="patrol the aisle"
+```
+
+`SentryStrategy` (recording, interactive-safe) and `BaseStrategy` (no recording) are the reference implementations to copy from; `send_next_action`, `safe_push_to_hub` and `estimate_max_episode_seconds` from `lerobot.rollout.strategies` are the helpers they build on.
+
 ---
 
 ## Inference Backends

--- a/docs/source/integrate_hardware.mdx
+++ b/docs/source/integrate_hardware.mdx
@@ -354,6 +354,7 @@ Your project must be a standard, installable Python package. Crucially, the name
 - `lerobot_robot_` for a robot.
 - `lerobot_camera_` for a camera.
 - `lerobot_teleoperator_` for a teleoperation device.
+- `lerobot_strategy_` for a `lerobot-rollout` strategy (see [Bring your own strategy](./inference#bring-your-own-strategy)).
 
 This prefix system is how `lerobot` automatically finds your plugin in the Python environment.
 

--- a/src/lerobot/rollout/configs.py
+++ b/src/lerobot/rollout/configs.py
@@ -43,16 +43,43 @@ logger = logging.getLogger(__name__)
 class RolloutStrategyConfig(draccus.ChoiceRegistry, abc.ABC):
     """Abstract base for rollout strategy configurations.
 
-    Use ``--strategy.type=<name>`` on the CLI to select a strategy.
+    Use ``--strategy.type=<name>`` on the CLI to select a strategy.  The registry is
+    open: a third-party package can register its own strategy and drive it from the
+    same flag — see "Bring your own strategy" in ``docs/source/inference.mdx``.
+
+    The ClassVars and hooks below declare what the engine arranges on the strategy's
+    behalf, so nothing outside the strategy needs to know its concrete type.
     """
 
     # Whether the strategy honours the restartable-run() contract that
     # ``--interactive=true`` requires (see ``RolloutStrategy``).
     supports_interactive: ClassVar[bool] = False
+    # "none": any --dataset.* flag is rejected.  "optional": a dataset is created when
+    # --dataset.* flags are given (``ctx.data.dataset`` may be None).  "required":
+    # --dataset.repo_id is mandatory.
+    dataset_mode: ClassVar[str] = "none"
+    # Whether --teleop.type is mandatory (human-in-the-loop strategies).
+    requires_teleop: ClassVar[bool] = False
 
     @property
     def type(self) -> str:
         return self.get_choice_name(self.__class__)
+
+    def requires_streaming_encoding(self) -> bool:
+        """Whether ``--dataset.streaming_encoding`` must be forced on.
+
+        Return True when frames are written from inside the timed control loop, where a
+        blocking encode would collapse the cadence.  A method rather than a ClassVar so
+        the answer can depend on the strategy's own fields (see DAgger).
+        """
+        return False
+
+    def extra_dataset_features(self) -> dict[str, dict]:
+        """Strategy-owned dataset columns, merged into the robot/policy features.
+
+        Every recorded frame must carry every key declared here.
+        """
+        return {}
 
 
 @RolloutStrategyConfig.register_subclass("base")
@@ -77,12 +104,16 @@ class SentryStrategyConfig(RolloutStrategyConfig):
     """
 
     supports_interactive: ClassVar[bool] = True
+    dataset_mode: ClassVar[str] = "required"
 
     upload_every_n_episodes: int = 5
     # Target video file size in MB for episode rotation.  Episodes are
     # saved once the estimated video duration would exceed this limit.
     # Defaults to DEFAULT_VIDEO_FILE_SIZE_IN_MB when set to None.
     target_video_file_size_mb: int | None = None
+
+    def requires_streaming_encoding(self) -> bool:
+        return True
 
 
 @RolloutStrategyConfig.register_subclass("highlight")
@@ -96,10 +127,15 @@ class HighlightStrategyConfig(RolloutStrategyConfig):
     again.
     """
 
+    dataset_mode: ClassVar[str] = "required"
+
     ring_buffer_seconds: float = 10.0
     ring_buffer_max_memory_mb: int = 1024
     save_key: str = "s"
     push_key: str = "h"
+
+    def requires_streaming_encoding(self) -> bool:
+        return True
 
 
 @dataclass
@@ -146,6 +182,8 @@ class EpisodicStrategyConfig(RolloutStrategyConfig):
     - else, the robot is moved smoothly to the position of the teleop leader.
     """
 
+    dataset_mode: ClassVar[str] = "required"
+
     # This only applies if there are no teleop leaders specified.
     # When True (default), moves the robot back to the joint positions captured at startup.
     # Otherwise, leave the robot in its current position.
@@ -188,6 +226,11 @@ class DAggerStrategyConfig(RolloutStrategyConfig):
     blocked while a correction is in progress.
     """
 
+    # TODO(Steven): DAgger shouldn't require a dataset (user may want to just rollout+intervene
+    # without recording), but for now we require it to simplify the implementation.
+    dataset_mode: ClassVar[str] = "required"
+    requires_teleop: ClassVar[bool] = True
+
     # Number of correction episodes to collect (corrections-only mode).
     # When None, falls back to ``--dataset.num_episodes``.
     num_episodes: int | None = None
@@ -212,6 +255,13 @@ class DAggerStrategyConfig(RolloutStrategyConfig):
         if self.input_device not in ("keyboard", "pedal"):
             raise ValueError(f"DAgger input_device must be 'keyboard' or 'pedal', got '{self.input_device}'")
 
+    def requires_streaming_encoding(self) -> bool:
+        # Only when the autonomous phase is recorded too; corrections are saved between phases.
+        return self.record_autonomous
+
+    def extra_dataset_features(self) -> dict[str, dict]:
+        return {"intervention": {"dtype": "bool", "shape": (1,), "names": None}}
+
 
 # ---------------------------------------------------------------------------
 # Top-level rollout config
@@ -234,13 +284,14 @@ class RolloutConfig:
     # Policy (loaded from --policy.path via __post_init__)
     policy: PreTrainedConfig | None = None
 
-    # Strategy (polymorphic: --strategy.type=base|sentry|highlight|dagger|episodic)
+    # Strategy (polymorphic: --strategy.type=base|sentry|highlight|dagger|episodic,
+    # or any name registered by a third-party package)
     strategy: RolloutStrategyConfig = field(default_factory=BaseStrategyConfig)
 
     # Inference backend (polymorphic: --inference.type=sync|rtc)
     inference: InferenceEngineConfig = field(default_factory=SyncInferenceConfig)
 
-    # Dataset (required for sentry, highlight, dagger; None for base)
+    # Dataset (required, optional or rejected according to the strategy's ``dataset_mode``)
     dataset: DatasetRecordConfig | None = None
 
     # Runtime
@@ -297,27 +348,21 @@ class RolloutConfig:
         if self.interpolation_multiplier < 1:
             raise ValueError(f"interpolation_multiplier must be >= 1, got {self.interpolation_multiplier}")
 
-        # --- Strategy-specific validation ---
-        if isinstance(self.strategy, DAggerStrategyConfig) and self.teleop is None:
-            raise ValueError("DAgger strategy requires --teleop.type to be set")
-
-        # TODO(Steven): DAgger shouldn't require a dataset (user may want to just rollout+intervene without recording), but for now we require it to simplify the implementation.
-        needs_dataset = isinstance(
-            self.strategy,
-            (
-                SentryStrategyConfig,
-                HighlightStrategyConfig,
-                DAggerStrategyConfig,
-                EpisodicStrategyConfig,
-            ),
-        )
-        if needs_dataset and (self.dataset is None or not self.dataset.repo_id):
-            raise ValueError(f"{self.strategy.type} strategy requires --dataset.repo_id to be set")
-
-        if isinstance(self.strategy, BaseStrategyConfig) and self.dataset is not None:
+        # --- Strategy capabilities ---
+        # Read off the strategy's declarations, never its concrete type, so a
+        # third-party strategy is validated exactly like a built-in one.
+        strategy = self.strategy
+        if strategy.requires_teleop and self.teleop is None:
+            raise ValueError(f"{strategy.type} strategy requires --teleop.type to be set")
+        if strategy.dataset_mode == "required" and self.dataset is None:
+            raise ValueError(f"{strategy.type} strategy requires --dataset.repo_id to be set")
+        if strategy.dataset_mode == "none" and self.dataset is not None:
             raise ValueError(
-                "Base strategy does not record data. Use sentry, highlight, or dagger for recording."
+                f"{strategy.type} strategy does not record data: drop the --dataset.* flags "
+                "or pick a recording strategy."
             )
+        if self.dataset is not None and not self.dataset.repo_id:
+            raise ValueError("--dataset.repo_id must be set when passing --dataset.* flags")
 
         # Interactive mode calls strategy.run() once per segment, so only strategies
         # declaring ``supports_interactive`` may be driven by it.
@@ -336,48 +381,15 @@ class RolloutConfig:
         if self.autosteer_interval_s < 0:
             raise ValueError(f"--autosteer_interval_s must be >= 0 (got {self.autosteer_interval_s}).")
 
-        # Sentry MUST use streaming encoding to avoid disk I/O blocking the control loop
+        # A strategy that writes frames from inside the timed control loop cannot afford
+        # a blocking encode: force streaming encoding on its behalf.
         if (
-            isinstance(self.strategy, SentryStrategyConfig)
-            and self.dataset is not None
+            self.dataset is not None
+            and strategy.requires_streaming_encoding()
             and not self.dataset.streaming_encoding
         ):
-            logger.warning("Sentry mode forces streaming_encoding=True")
+            logger.warning("%s strategy forces streaming_encoding=True", strategy.type)
             self.dataset.streaming_encoding = True
-
-        # Highlight writes frames while the policy is still running, so streaming is mandatory.
-        if (
-            isinstance(self.strategy, HighlightStrategyConfig)
-            and self.dataset is not None
-            and not self.dataset.streaming_encoding
-        ):
-            logger.warning("Highlight mode forces streaming_encoding=True")
-            self.dataset.streaming_encoding = True
-
-        # DAgger: streaming is mandatory only when the autonomous phase is also recorded.
-        if isinstance(self.strategy, DAggerStrategyConfig) and self.dataset is not None:
-            if self.strategy.record_autonomous and not self.dataset.streaming_encoding:
-                logger.warning("DAgger with record_autonomous=True forces streaming_encoding=True")
-                self.dataset.streaming_encoding = True
-            elif not self.strategy.record_autonomous and not self.dataset.streaming_encoding:
-                logger.info(
-                    "Streaming encoding is disabled for DAgger corrections-only mode. "
-                    "Consider enabling it for faster episode saving: "
-                    "--dataset.streaming_encoding=true --dataset.encoder_threads=2"
-                )
-
-        # DAgger: resolve num_episodes from dataset config when not explicitly set.
-        if isinstance(self.strategy, DAggerStrategyConfig) and self.strategy.num_episodes is None:
-            if self.dataset is not None:
-                self.strategy.num_episodes = self.dataset.num_episodes
-                logger.info(
-                    "DAgger num_episodes not set — using --dataset.num_episodes=%d",
-                    self.strategy.num_episodes,
-                )
-            else:
-                raise ValueError(
-                    "DAgger num_episodes must be set either via --strategy.num_episodes or --dataset.num_episodes"
-                )
 
         # --- Policy loading ---
         if self.robot is None:

--- a/src/lerobot/rollout/context.py
+++ b/src/lerobot/rollout/context.py
@@ -52,7 +52,7 @@ from lerobot.teleoperators import Teleoperator, make_teleoperator_from_config
 from lerobot.utils.feature_utils import combine_feature_dicts, hw_to_dataset_features
 from lerobot.utils.import_utils import _peft_available, require_package
 
-from .configs import BaseStrategyConfig, DAggerStrategyConfig, RolloutConfig
+from .configs import RolloutConfig
 from .inference import (
     InferenceEngine,
     RTCInferenceConfig,
@@ -478,8 +478,11 @@ def build_rollout_context(
 
     # --- 5. Dataset -------------
     dataset = None
-    if cfg.dataset is not None and not isinstance(cfg.strategy, BaseStrategyConfig):
+    if cfg.dataset is not None:
         logger.info("Setting up dataset (repo_id=%s)...", cfg.dataset.repo_id)
+        # Strategy-owned columns join the robot/policy features above the resume/create
+        # split, so ``ctx.data.dataset_features`` describes the same schema on both paths.
+        dataset_features.update(cfg.strategy.extra_dataset_features())
         if cfg.resume:
             dataset = LeRobotDataset.resume(
                 cfg.dataset.repo_id,
@@ -495,13 +498,6 @@ def build_rollout_context(
                 * len(robot.cameras if hasattr(robot, "cameras") else []),
             )
         else:
-            if isinstance(cfg.strategy, DAggerStrategyConfig):
-                dataset_features["intervention"] = {
-                    "dtype": "bool",
-                    "shape": (1,),
-                    "names": None,
-                }
-
             repo_name = cfg.dataset.repo_id.split("/", 1)[-1]
             if not repo_name.startswith("rollout_"):
                 raise ValueError(

--- a/src/lerobot/rollout/strategies/core.py
+++ b/src/lerobot/rollout/strategies/core.py
@@ -43,7 +43,11 @@ class RolloutStrategy(abc.ABC):
 
     Each concrete strategy implements a self-contained control loop with
     its own recording/interaction semantics.  Strategies are mutually
-    exclusive — only one runs per session.
+    exclusive — only one runs per session.  This is also the extension point
+    for third-party strategies: subclass it next to a registered
+    :class:`RolloutStrategyConfig` and ``lerobot-rollout --strategy.type=<name>``
+    drives it with no edit to LeRobot (see "Bring your own strategy" in
+    ``docs/source/inference.mdx``).
 
     Lifecycle: ``setup()`` once, then ``run()``, then ``teardown()`` once.
     A strategy whose config declares ``supports_interactive = True`` is also
@@ -212,9 +216,13 @@ class RolloutStrategy(abc.ABC):
             compress_images=cfg.display_compressed_images,
         )
 
-    @abc.abstractmethod
     def setup(self, ctx: RolloutContext) -> None:
-        """Strategy-specific initialisation (keyboard listeners, buffers, etc.)."""
+        """Strategy-specific initialisation (keyboard listeners, buffers, etc.).
+
+        The default only attaches and starts the inference engine; an override must
+        call ``self._init_engine(ctx)`` (or ``super().setup(ctx)``) first.
+        """
+        self._init_engine(ctx)
 
     @abc.abstractmethod
     def run(self, ctx: RolloutContext) -> None:

--- a/src/lerobot/rollout/strategies/dagger.py
+++ b/src/lerobot/rollout/strategies/dagger.py
@@ -256,6 +256,18 @@ class DAggerStrategy(RolloutStrategy):
     def setup(self, ctx: RolloutContext) -> None:
         """Initialise the inference engine and input device listener."""
         self._init_engine(ctx)
+        dataset_cfg = ctx.runtime.cfg.dataset  # never None: dataset_mode="required"
+        if self.config.num_episodes is None:
+            self.config.num_episodes = dataset_cfg.num_episodes
+            logger.info(
+                "DAgger num_episodes not set — using --dataset.num_episodes=%d", self.config.num_episodes
+            )
+        if not self.config.record_autonomous and not dataset_cfg.streaming_encoding:
+            logger.info(
+                "Streaming encoding is disabled for DAgger corrections-only mode. "
+                "Consider enabling it for faster episode saving: "
+                "--dataset.streaming_encoding=true --dataset.encoder_threads=2"
+            )
         self._push_executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="dagger-push")
         target_mb = self.config.target_video_file_size_mb or DEFAULT_VIDEO_FILE_SIZE_IN_MB
         self._episode_duration_s = estimate_max_episode_seconds(

--- a/src/lerobot/rollout/strategies/factory.py
+++ b/src/lerobot/rollout/strategies/factory.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from lerobot.utils.import_utils import make_device_from_device_class
+
 from .base import BaseStrategy
 from .core import RolloutStrategy
 from .dagger import DAggerStrategy
@@ -32,8 +34,10 @@ if TYPE_CHECKING:
 def create_strategy(config: RolloutStrategyConfig) -> RolloutStrategy:
     """Instantiate the appropriate strategy from a config object.
 
-    Dispatches on ``config.type`` (the name registered via
-    ``draccus.ChoiceRegistry``).
+    Dispatches on ``config.type`` (the name registered via ``draccus.ChoiceRegistry``)
+    for the built-ins, then falls back to the ``<Name>Config`` -> ``<Name>`` naming
+    convention shared with the robot, camera and teleoperator factories, so a
+    third-party strategy needs no edit here.
     """
     if config.type == "base":
         return BaseStrategy(config)
@@ -45,6 +49,7 @@ def create_strategy(config: RolloutStrategyConfig) -> RolloutStrategy:
         return DAggerStrategy(config)
     if config.type == "episodic":
         return EpisodicStrategy(config)
-    raise ValueError(
-        f"Unknown strategy type '{config.type}'. Available: base, sentry, highlight, dagger, episodic"
-    )
+    try:
+        return make_device_from_device_class(config)
+    except Exception as e:
+        raise ValueError(f"Error creating strategy with config {config}: {e}") from e

--- a/src/lerobot/scripts/lerobot_rollout.py
+++ b/src/lerobot/scripts/lerobot_rollout.py
@@ -26,6 +26,8 @@ Strategies
     --strategy.type=highlight  Ring buffer + keystroke save
     --strategy.type=dagger     Human-in-the-loop (DAgger / RaC)
     --strategy.type=episodic   Episode-oriented recording with reset phases
+    --strategy.type=<name>     Any strategy from an installed ``lerobot_strategy_*``
+                               package (see "Bring your own strategy" in the docs)
 
 Inference backends
 ------------------

--- a/src/lerobot/utils/import_utils.py
+++ b/src/lerobot/utils/import_utils.py
@@ -183,6 +183,7 @@ def make_device_from_device_class(config: ChoiceRegistry) -> Any:
     parts = module_path.split(".")
     parent_module = ".".join(parts[:-1]) if len(parts) > 1 else module_path
     candidates = [
+        module_path,  # the config's own module (single-file plugins)
         parent_module,  # typical: lerobot_teleop_mydevice
         parent_module + "." + device_class_name.lower(),  # typical: lerobot_teleop_mydevice.mydevice
     ]
@@ -227,7 +228,8 @@ def register_third_party_plugins() -> None:
 
     This function uses `importlib.metadata` to find packages installed in the environment
     (including editable installs) starting with 'lerobot_robot_', 'lerobot_camera_',
-    'lerobot_teleoperator_', 'lerobot_policy_', or 'lerobot_env_' and imports them.
+    'lerobot_teleoperator_', 'lerobot_policy_', 'lerobot_env_' or 'lerobot_strategy_' and
+    imports them.
     """
     prefixes = (
         "lerobot_robot_",
@@ -235,6 +237,7 @@ def register_third_party_plugins() -> None:
         "lerobot_teleoperator_",
         "lerobot_policy_",
         "lerobot_env_",
+        "lerobot_strategy_",
     )
     imported: list[str] = []
     failed: list[str] = []

--- a/tests/configs/test_plugin_loading.py
+++ b/tests/configs/test_plugin_loading.py
@@ -103,3 +103,69 @@ def test_wrap_with_plugin(plugin_dir: Path):
     assert isinstance(cfg, Config)
     assert isinstance(cfg.env, EnvConfig.get_choice_class("test_env"))
     assert cfg.env.value == 42
+
+
+@pytest.fixture
+def strategy_plugin_dir(tmp_path: Path) -> Generator[Path, None, None]:
+    """A single-module rollout-strategy plugin: config and implementation side by side."""
+    pytest.importorskip("datasets", reason="lerobot.rollout requires lerobot[dataset]")
+    plugin_pkg = tmp_path / "lerobot_strategy_test"
+    plugin_pkg.mkdir()
+    (plugin_pkg / "__init__.py").touch()
+    (plugin_pkg / "strategy.py").write_text(
+        """
+from dataclasses import dataclass
+
+from lerobot.rollout import RolloutStrategy, RolloutStrategyConfig
+
+
+@RolloutStrategyConfig.register_subclass("test_strategy")
+@dataclass
+class TestStrategyConfig(RolloutStrategyConfig):
+    gain: float = 1.0
+
+
+class TestStrategy(RolloutStrategy):
+    def run(self, ctx):
+        pass
+
+    def teardown(self, ctx):
+        pass
+"""
+    )
+
+    sys.path.insert(0, str(tmp_path))
+    yield plugin_pkg
+    sys.path.pop(0)
+
+    from lerobot.rollout import RolloutStrategyConfig
+
+    RolloutStrategyConfig.get_known_choices().pop("test_strategy", None)
+    for name in [n for n in sys.modules if n.split(".")[0] == "lerobot_strategy_test"]:
+        del sys.modules[name]
+
+
+def test_wrap_and_create_strategy_with_plugin(strategy_plugin_dir: Path):
+    from lerobot.rollout import RolloutStrategyConfig, create_strategy
+
+    @dataclass
+    class Config:
+        strategy: RolloutStrategyConfig
+
+    @wrap()
+    def dummy_func(cfg: Config):
+        return cfg
+
+    sys.argv = [
+        "dummy_script.py",
+        "--strategy.discover_packages_path=lerobot_strategy_test",
+        "--strategy.type=test_strategy",
+        "--strategy.gain=2.5",
+    ]
+
+    cfg = dummy_func()
+    strategy = create_strategy(cfg.strategy)
+
+    assert cfg.strategy.gain == 2.5
+    assert type(strategy).__name__ == "TestStrategy"
+    assert strategy.config is cfg.strategy

--- a/tests/test_rollout.py
+++ b/tests/test_rollout.py
@@ -22,6 +22,7 @@ import sys
 import threading
 from pathlib import Path
 from types import SimpleNamespace
+from typing import ClassVar
 from unittest.mock import MagicMock
 
 import pytest
@@ -453,12 +454,91 @@ def test_create_strategy_dispatches():
 
 
 def test_create_strategy_unknown_raises():
-    from lerobot.rollout import create_strategy
+    from lerobot.rollout import RolloutStrategyConfig, create_strategy
 
-    cfg = MagicMock()
-    cfg.type = "bogus"
-    with pytest.raises(ValueError, match="Unknown strategy type"):
-        create_strategy(cfg)
+    # Registered config, but no ``BogusStrategy`` class importable next to it.
+    @RolloutStrategyConfig.register_subclass("bogus")
+    @dataclasses.dataclass
+    class BogusStrategyConfig(RolloutStrategyConfig):
+        pass
+
+    try:
+        with pytest.raises(ValueError, match="Could not locate device class 'BogusStrategy'"):
+            create_strategy(BogusStrategyConfig())
+    finally:
+        RolloutStrategyConfig.get_known_choices().pop("bogus")
+
+
+# ---------------------------------------------------------------------------
+# Strategy capability declarations (what a third-party strategy relies on)
+# ---------------------------------------------------------------------------
+
+
+def test_rollout_config_enforces_strategy_declarations():
+    from lerobot.configs.dataset import DatasetRecordConfig
+    from lerobot.rollout import BaseStrategyConfig, DAggerStrategyConfig, RolloutConfig, RolloutStrategyConfig
+    from tests.mocks.mock_robot import MockRobotConfig
+    from tests.mocks.mock_teleop import MockTeleopConfig
+
+    @RolloutStrategyConfig.register_subclass("test_recorder")
+    @dataclasses.dataclass
+    class RecorderConfig(RolloutStrategyConfig):
+        dataset_mode: ClassVar[str] = "required"
+        requires_teleop: ClassVar[bool] = True
+
+        def requires_streaming_encoding(self) -> bool:
+            return True
+
+    def make(**kwargs):
+        return RolloutConfig(robot=MockRobotConfig(), policy=SimpleNamespace(device="cpu"), **kwargs)
+
+    dataset = DatasetRecordConfig(repo_id="user/rollout_test")
+    try:
+        with pytest.raises(ValueError, match="test_recorder strategy requires --teleop.type"):
+            make(strategy=RecorderConfig(), dataset=dataset)
+        with pytest.raises(ValueError, match="test_recorder strategy requires --dataset.repo_id"):
+            make(strategy=RecorderConfig(), teleop=MockTeleopConfig())
+        with pytest.raises(ValueError, match="--dataset.repo_id must be set"):
+            make(strategy=RecorderConfig(), teleop=MockTeleopConfig(), dataset=DatasetRecordConfig())
+        with pytest.raises(ValueError, match="base strategy does not record data"):
+            make(strategy=BaseStrategyConfig(), dataset=dataset)
+
+        cfg = make(strategy=RecorderConfig(), teleop=MockTeleopConfig(), dataset=dataset)
+        assert cfg.dataset.streaming_encoding is True
+
+        # requires_streaming_encoding() is a method so it can depend on the config's fields.
+        dagger = make(
+            strategy=DAggerStrategyConfig(record_autonomous=False),
+            teleop=MockTeleopConfig(),
+            dataset=DatasetRecordConfig(repo_id="user/rollout_test"),
+        )
+        assert dagger.dataset.streaming_encoding is False
+    finally:
+        RolloutStrategyConfig.get_known_choices().pop("test_recorder")
+
+
+def test_setup_defaults_to_starting_the_engine():
+    from lerobot.rollout import BaseStrategyConfig, RolloutStrategy
+
+    class MinimalStrategy(RolloutStrategy):
+        def run(self, ctx):
+            pass
+
+        def teardown(self, ctx):
+            pass
+
+    engine = MagicMock()
+    ctx = SimpleNamespace(
+        runtime=SimpleNamespace(cfg=SimpleNamespace(interpolation_multiplier=2)),
+        policy=SimpleNamespace(inference=engine),
+    )
+    strategy = MinimalStrategy(BaseStrategyConfig())
+
+    strategy.setup(ctx)
+
+    assert strategy._engine is engine
+    assert strategy._interpolator.multiplier == 2
+    engine.start.assert_called_once()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary / Motivation

`lerobot-rollout` could only run its five built-in strategies: `create_strategy` was a closed if-chain and `RolloutConfig` decided what to arrange for a strategy by `isinstance`-checking its config. This PR opens the strategy registry the same way robots, cameras and teleoperators are open: an installed `lerobot_strategy_<name>` package registers a `RolloutStrategyConfig` subclass, ships a `RolloutStrategy` next to it, and `--strategy.type=<name>` runs it with no edit to LeRobot.

## Related issues

- None

## What changed

- `RolloutStrategyConfig` declares its needs: `dataset_mode` (`none`/`optional`/`required`), `requires_teleop`, `requires_streaming_encoding()`, `extra_dataset_features()`. `RolloutConfig.__post_init__` and `build_rollout_context` read these instead of `isinstance`-checking concrete classes; the built-ins declare what was hard-coded for them, so their behaviour is unchanged.
- `create_strategy` falls back to `make_device_from_device_class` (the `<Name>Config` -> `<Name>` convention of the hardware factories). The resolver now also tries the config's own module, so a single-file plugin works.
- `register_third_party_plugins` discovers the `lerobot_strategy_` prefix.
- `RolloutStrategy.setup()` is concrete (starts the engine); a plugin only implements `run()` and `teardown()`. DAgger's `num_episodes` fallback moves into its `setup()`.
- Docs: "Bring your own strategy" section in `inference.mdx`. Reference package in `examples/rollout/lerobot_strategy_patrol/` (not linked from the docs).
- Not breaking. An unresolvable strategy now raises `"Error creating strategy with config ..."` instead of `"Unknown strategy type ..."`.

## How was this tested (or how to run locally)

- `pytest -q tests/test_rollout.py -k "strategy or setup or declarations"`: a third-party config drives the teleop/dataset/streaming checks, the default `setup()` starts the engine, an unresolvable config fails through the fallback.
- Parity matrix of `RolloutConfig` inputs for the five built-ins against `main`: identical accept/reject/force outcomes.
- Example package smoke-tested: discovered by prefix, resolved by the factory, run loop records once per policy action with its `patrol_leg` column and survives a second segment.

```bash
uv pip install -e examples/rollout/lerobot_strategy_patrol
lerobot-rollout --strategy.type=patrol --policy.path=... --robot.type=... --dataset.repo_id=${HF_USER}/rollout_patrol
```

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated
- [x] CI is green
- [x] Community Review: I have reviewed another contributor's open PR and linked it here: #

## Reviewer notes

- `rollout/configs.py`: the declaration-driven checks must match the removed `isinstance` chain for each built-in.
- `utils/import_utils.py`: the new resolver candidate is shared with robot/camera/teleop plugins; the five in-tree configs that reach the fallback resolve as before.
