### PR TITLE
fix(rl): resume loads the checkpoint's policy weights instead of re-initialising randomly

### DIFF
--- a/src/lerobot/rl/actor.py
+++ b/src/lerobot/rl/actor.py
@@ -122,6 +122,12 @@ def actor_cli(cfg: TrainRLServerPipelineConfig):
     # Fail fast with a friendly error if the optional ``hilserl`` extra is missing.
     require_package("grpcio", extra="hilserl", import_name="grpc")
     cfg.validate()
+    # validate() resolves a resume checkpoint from --config_path, which for the
+    # actor is just the shared config file (its parent dir holds no weights) and
+    # would crash make_policy. The actor's local policy is scaffolding: real
+    # weights arrive from the learner via RPC (act_with_policy pulls the initial
+    # push before the first action).
+    cfg.policy.pretrained_path = None
     display_pid = False
     if not use_threads(cfg):
         ensure_multiprocessing_start_method(cfg.policy.concurrency.multiprocessing_context)
@@ -297,6 +303,19 @@ def act_with_policy(
     episode_total_steps = 0
 
     policy_timer = TimerManager("Policy inference", log=False)
+
+    # Pull the learner's initial parameter push before acting, so the first
+    # episode runs the learner's current (possibly resumed) policy instead of
+    # this process's freshly initialised scaffolding weights.
+    initial_bytes = get_last_item_from_queue(parameters_queue, block=True, timeout=60.0)
+    if initial_bytes is not None:
+        logging.info("[ACTOR] Loaded initial parameters from Learner before first action.")
+        algorithm.load_weights(bytes_to_state_dict(initial_bytes), device=device)
+    else:
+        logging.warning(
+            "[ACTOR] No parameters received from Learner within 60 s; "
+            "first episode will use the locally initialised policy."
+        )
 
     for interaction_step in range(cfg.policy.online_steps):
         start_time = time.perf_counter()

--- a/src/lerobot/rl/learner.py
+++ b/src/lerobot/rl/learner.py
@@ -702,6 +702,11 @@ def handle_resume_logic(cfg: TrainRLServerPipelineConfig) -> TrainRLServerPipeli
     checkpoint_cfg_path = os.path.join(checkpoint_dir, PRETRAINED_MODEL_DIR, "train_config.json")
     checkpoint_cfg = TrainRLServerPipelineConfig.from_pretrained(checkpoint_cfg_path)
 
+    # The checkpoint config stores pretrained_path as null; without pointing it
+    # at the checkpoint's weights, make_policy() would re-initialise the policy
+    # randomly and silently discard everything the run had learned.
+    checkpoint_cfg.policy.pretrained_path = os.path.join(checkpoint_dir, PRETRAINED_MODEL_DIR)
+
     # Ensure resume flag is set in returned config
     checkpoint_cfg.resume = True
     return checkpoint_cfg


### PR DESCRIPTION
## What breaks

Resuming a HIL-SERL run rebuilds the actor and encoder **randomly** while restoring the
critic, the target networks, the optimizer moments and the step counter. Training then
continues from the recorded step with a random policy driving the robot. It is worse than
starting fresh, and nothing errors.

## Why

`handle_resume_logic` replaces the live config with the one stored in the checkpoint:

```python
checkpoint_cfg = TrainRLServerPipelineConfig.from_pretrained(.../pretrained_model/train_config.json)
checkpoint_cfg.resume = True
return checkpoint_cfg
```

That stored config has `"pretrained_path": null`. Returning a fresh object also discards
what `cfg.validate()` had resolved (`configs/train.py::_resolve_resume_checkpoint` sets
`policy.pretrained_path` from `--config_path`), and `from_pretrained` re-parses with
`cli_args=[]` and never calls `validate()` again.

`make_policy` branches on exactly that field (`policies/factory.py`): with
`pretrained_path` set it calls `policy_cls.from_pretrained(...)`; otherwise it falls to
`policy = policy_cls(**kwargs)` — a fresh random policy.

Nothing else restores the actor. `load_training_state` loads only RNG, step, optimizer
and scheduler state. The algorithm checkpoint (`checkpoints/last/algorithm/model.safetensors`)
holds `critic_ensemble.*`, `critic_target.*`, `discrete_critic_target.*` and `log_alpha`
and explicitly strips encoder keys, and it loads with `strict=False`, so the missing
actor keys pass silently. The actor and encoder exist only in
`pretrained_model/model.safetensors`, reachable only through `pretrained_path`.

The single hint is `factory.py`'s "You are instantiating a policy from scratch" warning,
whose text is about normalization statistics.

## Reproduction

Run with `resume: true` against an existing checkpoint, then compare the loaded policy
tensors with the checkpoint. On my run, 0 of 72 tensors matched before the fix and 72 of
72 after. Checkpoints written before the fix store `"pretrained_path": null`; after it
they store the checkpoint's own `pretrained_model` directory.

## Fix

Two parts, one per process.

**Learner:** point `pretrained_path` at the checkpoint's `pretrained_model` directory so
`make_policy` takes the `from_pretrained` branch.

**Actor:** clear `pretrained_path` after `validate()`. For the actor, `--config_path` is
the shared config file, so the resume resolution sets `pretrained_path` to that file's
parent directory, which holds no weights, and `make_policy` raises. The actor's policy is
scaffolding; real weights arrive from the learner over RPC. The actor now also blocks on
the learner's first parameter push before its first action, so a resumed session acts on
the trained policy from episode 1 rather than on freshly initialised weights.

Disclosure: written with AI assistance; diagnosis and fix verified against a real robot run.
