### PR TITLE
fix(rl): crop_dataset_roi writes incomplete episode metadata and drifts episode boundaries

### DIFF
--- a/src/lerobot/rl/crop_dataset_roi.py
+++ b/src/lerobot/rl/crop_dataset_roi.py
@@ -228,15 +228,23 @@ def convert_lerobot_dataset_to_cropped_lerobot_dataset(
             new_frame[key] = value
 
         new_frame["task"] = task
-        new_dataset.add_frame(new_frame)
 
+        # Close the previous episode BEFORE adding the first frame of the new one.
+        # (Upstream adds first and checks after, so every episode absorbs the first
+        # frame of its successor and the episode boundaries drift by one frame.)
         if frame["episode_index"].item() != prev_episode_index:
-            # Save the episode
             new_dataset.save_episode()
             prev_episode_index = frame["episode_index"].item()
 
+        new_dataset.add_frame(new_frame)
+
     # Save the last episode
     new_dataset.save_episode()
+    # Flush buffered episode metadata. Without this the trailing episodes are
+    # written to data/ and videos/ but never appear in meta/episodes/, and the
+    # dataset reader then raises IndexError on the first missing episode.
+    # dataset_tools.py:933 does this; upstream crop_dataset_roi.py does not.
+    new_dataset.finalize()
 
     if push_to_hub:
         new_dataset.push_to_hub()


### PR DESCRIPTION
## What breaks

`lerobot.rl.crop_dataset_roi` produces a dataset that cannot be loaded. `data/` and
`videos/` contain every episode, but `meta/episodes/` is short, so reading it raises:

```
IndexError: Episode index 20 out of range. Episodes: 20
```

from `dataset_metadata.get_video_file_path` via `dataset_reader._check_cached_episodes_sufficient`.
On a 24-episode source I got 24 episodes of frame data with metadata for only 20.

## Two causes

**1. `finalize()` is never called.** Episode metadata is buffered and flushed on finalize;
without it the trailing episodes are written to `data/` and `videos/` but never appear in
`meta/episodes/`. `datasets/dataset_tools.py` calls `dst_meta.finalize()` on the
comparable path; `crop_dataset_roi.py` does not.

**2. Episode boundaries drift by one frame.** The loop adds the frame before checking
whether the episode index changed:

```python
new_dataset.add_frame(new_frame)
if frame["episode_index"].item() != prev_episode_index:
    new_dataset.save_episode()
```

so the first frame of episode N+1 is appended to episode N before N is saved. Every
episode absorbs one frame from its successor.

## Fix

Call `finalize()` after the final `save_episode()`, and close the previous episode before
adding the first frame of the new one.

## Verification

Same 24-episode source, after the fix: `info.json` 24, `meta/episodes` 24, data 24, and
per-episode lengths match the source exactly (184, 160, 177, ..., 133), confirming the
boundary drift is gone. The dataset loads through `LeRobotDataset` normally.

Disclosure: written with AI assistance; both bugs hit and verified on a real dataset.
