### PR TITLE
fix(rl): make RL checkpointing crash-safe so an interrupted run can resume

### DIFF
--- a/src/lerobot/common/train_utils.py
+++ b/src/lerobot/common/train_utils.py
@@ -24,6 +24,7 @@ its writes live in the same method.
 """
 
 import logging
+import os
 from importlib.resources import files
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -123,10 +124,15 @@ def update_last_checkpoint(checkpoint_dir: Path) -> None:
         checkpoint_dir (Path): The checkpoint step directory the `last` link should target.
     """
     last_checkpoint_dir = checkpoint_dir.parent / LAST_CHECKPOINT_LINK
-    if last_checkpoint_dir.is_symlink():
-        last_checkpoint_dir.unlink()
     relative_target = checkpoint_dir.relative_to(checkpoint_dir.parent)
-    last_checkpoint_dir.symlink_to(relative_target)
+    # Atomic swap: a kill between unlink() and symlink_to() would leave the
+    # "last" link missing, which crashes the next resume. A temp symlink
+    # moved into place with os.replace() is atomic on POSIX.
+    tmp_link = checkpoint_dir.parent / (LAST_CHECKPOINT_LINK + ".tmp")
+    if tmp_link.is_symlink() or tmp_link.exists():
+        tmp_link.unlink()
+    tmp_link.symlink_to(relative_target)
+    os.replace(tmp_link, last_checkpoint_dir)
 
 
 # ---------------------------------------------------------------------------------------------

--- a/src/lerobot/rl/learner.py
+++ b/src/lerobot/rl/learner.py
@@ -546,6 +546,56 @@ def start_learner(
     logging.info("[LEARNER] gRPC server stopped")
 
 
+def _recover_dataset_dir(final_dir: str) -> None:
+    """Restore ``final_dir`` from its ``.old`` sibling.
+
+    A process killed in the small gap between the two renames inside
+    ``_atomic_dataset_dump`` leaves the old dataset parked in ``.old`` with
+    ``final_dir`` missing. Without this, the next resume crashes on a
+    nonexistent dataset directory.
+    """
+    old_dir = final_dir + ".old"
+    if not os.path.exists(final_dir) and os.path.exists(old_dir):
+        os.rename(old_dir, final_dir)
+
+
+def _atomic_dataset_dump(buffer: ReplayBuffer, repo_id: str, fps: int, final_dir: str) -> None:
+    """Dump a replay buffer to a LeRobotDataset, swapping it into place atomically.
+
+    Writing straight to ``final_dir`` after rmtree'ing it means a process killed
+    mid-dump (Ctrl-C) leaves a half-written dataset behind, which crashes the next
+    resume with "Parquet magic bytes not found". Dumping to a ``.partial`` sibling
+    and renaming into place keeps ``final_dir`` either fully old or fully new.
+    """
+    partial_dir = final_dir + ".partial"
+    old_dir = final_dir + ".old"
+    # Self-heal a dump killed between the two renames: final_dir is gone but
+    # the previous dataset is parked in old_dir — restore it instead of
+    # deleting it as stale.
+    _recover_dataset_dir(final_dir)
+    if os.path.exists(partial_dir):
+        shutil.rmtree(partial_dir)
+    if os.path.exists(old_dir):
+        shutil.rmtree(old_dir)
+    buffer.to_lerobot_dataset(repo_id=repo_id, fps=fps, root=partial_dir)
+    if os.path.exists(final_dir):
+        os.rename(final_dir, old_dir)
+    try:
+        os.rename(partial_dir, final_dir)
+    except BaseException:
+        # Swap failed (kill in the rename gap, disk error): restore the old
+        # dataset if there is one (on a first-ever dump there is none).
+        if os.path.exists(final_dir):
+            shutil.rmtree(final_dir)
+        if os.path.exists(partial_dir):
+            shutil.rmtree(partial_dir)
+        if os.path.exists(old_dir):
+            os.rename(old_dir, final_dir)
+        raise
+    if os.path.exists(old_dir):
+        shutil.rmtree(old_dir)
+
+
 def save_training_checkpoint(
     cfg: TrainRLServerPipelineConfig,
     optimization_step: int,
@@ -623,26 +673,27 @@ def save_training_checkpoint(
 
     # TODO : temporary save replay buffer here, remove later when on the robot
     # We want to control this with the keyboard inputs
-    dataset_dir = os.path.join(cfg.output_dir, "dataset")
-    if os.path.exists(dataset_dir) and os.path.isdir(dataset_dir):
-        shutil.rmtree(dataset_dir)
-
     # Save dataset
     # NOTE: Handle the case where the dataset repo id is not specified in the config
     # eg. RL training without demonstrations data
-    repo_id_buffer_save = cfg.env.task if dataset_repo_id is None else dataset_repo_id
-    replay_buffer.to_lerobot_dataset(repo_id=repo_id_buffer_save, fps=fps, root=dataset_dir)
+    # Dumping the replay buffers back out as datasets is a convenience, not part of
+    # the policy checkpoint, so a failure here must not take down a training run that
+    # has already written its weights. Dumps go to a .partial directory and are renamed
+    # into place, so a process killed mid-dump leaves the previous complete dataset
+    # rather than a half-written one that breaks the next resume.
+    try:
+        repo_id_buffer_save = cfg.env.task if dataset_repo_id is None else dataset_repo_id
+        _atomic_dataset_dump(replay_buffer, repo_id_buffer_save, fps, os.path.join(cfg.output_dir, "dataset"))
 
-    if offline_replay_buffer is not None:
-        dataset_offline_dir = os.path.join(cfg.output_dir, "dataset_offline")
-        if os.path.exists(dataset_offline_dir) and os.path.isdir(dataset_offline_dir):
-            shutil.rmtree(dataset_offline_dir)
-
-        offline_replay_buffer.to_lerobot_dataset(
-            cfg.dataset.repo_id,
-            fps=fps,
-            root=dataset_offline_dir,
-        )
+        if offline_replay_buffer is not None:
+            _atomic_dataset_dump(
+                offline_replay_buffer,
+                cfg.dataset.repo_id,
+                fps,
+                os.path.join(cfg.output_dir, "dataset_offline"),
+            )
+    except Exception as e:
+        logging.warning(f"Replay-buffer dataset dump failed (policy checkpoint is unaffected): {e}")
 
     logging.info("Resume training")
 
@@ -815,6 +866,7 @@ def initialize_replay_buffer(
 
     logging.info("Resume training load the online dataset")
     dataset_path = os.path.join(cfg.output_dir, "dataset")
+    _recover_dataset_dir(dataset_path)
 
     # NOTE: In RL is possible to not have a dataset.
     repo_id = None
@@ -855,6 +907,7 @@ def initialize_offline_replay_buffer(
     else:
         logging.info("load offline dataset")
         dataset_offline_path = os.path.join(cfg.output_dir, "dataset_offline")
+        _recover_dataset_dir(dataset_offline_path)
         offline_dataset = LeRobotDataset(
             repo_id=cfg.dataset.repo_id,
             root=dataset_offline_path,


### PR DESCRIPTION
## What breaks

A HIL-SERL learner interrupted during `save_training_checkpoint` can leave the output
directory in a state the next resume cannot load. I lost a session to this on a real
SO-101 run: Ctrl-C during a checkpoint, then the resume died immediately with

```
Failed to read schema from outputs/<run>/dataset_offline/meta/episodes/chunk-000/file-000.parquet
  with error ArrowInvalid: Parquet magic bytes not found in footer.
...
pyarrow.lib.ArrowInvalid: Parquet magic bytes not found in footer.
[LEARNER] Stopping gRPC server...
```

The only recovery is to delete the dumped dataset, which throws away the online replay
buffer, i.e. every episode collected since the run began.

## Why

`save_training_checkpoint` writes the replay buffers out as datasets after the weights
are saved. The current sequence is destructive first:

```python
if os.path.exists(dataset_dir) and os.path.isdir(dataset_dir):
    shutil.rmtree(dataset_dir)
replay_buffer.to_lerobot_dataset(repo_id=..., root=dataset_dir)
```

Between the `rmtree` and the end of the dump there is a multi-second window (a dump of
15k frames with two camera streams is not quick) in which the good dataset is already
gone and the new one is incomplete. Any kill in that window is unrecoverable, and
checkpoints run every `save_freq` steps for the whole session, so the window recurs.

Two smaller variants of the same shape:

- `update_last_checkpoint` does `unlink()` then `symlink_to()`. A kill in between leaves
  no `last` link at all, and resume resolves the checkpoint through that link. Narrow
  race, but there is no reason to leave it open.
- An exception from the buffer dump propagates out of `save_training_checkpoint` and
  ends the run, even though the policy weights and optimizer state have already been
  written successfully at that point. The dump is a convenience (it still carries a
  `TODO: temporary save replay buffer here`); it should not be able to end training.

## Fix

- `_atomic_dataset_dump`: write to `<dir>.partial`, move the current dataset to
  `<dir>.old`, rename the new one into place, then delete `.old`. The final directory
  is either entirely the old dataset or entirely the new one at every instant.
- `_recover_dataset_dir`: if a process died in the one-rename gap where the final
  directory is missing and `.old` exists, restore it. Called on dump and again on load
  in `initialize_replay_buffer` / `initialize_offline_replay_buffer`, so a run that was
  killed at the worst possible moment still resumes.
- `update_last_checkpoint`: build a temp symlink and `os.replace()` it into place, which
  is atomic on POSIX.
- Wrap the dumps in try/except and log a warning. Deliberate: the checkpoint proper is
  already on disk, so degrading to "buffer dump missing" beats ending the run. Happy to
  drop this part if you would rather the failure stay loud.

No behaviour change on the success path, and no new dependencies. Peak disk use during a
dump goes to roughly 2x the dataset size, briefly, which seemed the right trade against
losing a session of robot data.

Verified across ~40 checkpoints of a live SO-101 run, including Ctrl-C during a dump:
resume loads the previous complete dataset, and no `.partial` or `.old` directories are
left behind.

Disclosure: written with AI assistance; the failure and the fix were both reproduced on
a real robot run.
