### PR TITLE
feat(motors): add sync_read_block for one-transaction multi-register reads

### DIFF
--- a/src/lerobot/motors/motors_bus.py
+++ b/src/lerobot/motors/motors_bus.py
@@ -1170,6 +1170,77 @@ class SerialMotorsBus(MotorsBusBase):
 
         return {self._id_to_name(id_): value for id_, value in decoded.items()}
 
+    @check_if_not_connected
+    def sync_read_block(
+        self,
+        data_names: Sequence[str],
+        motors: NameOrID | Sequence[NameOrID] | None = None,
+        *,
+        normalize: bool = True,
+        num_retry: int = 0,
+    ) -> dict[str, dict[str, Value]]:
+        """Read several registers from several motors in a single bus transaction.
+
+        The bus is read once over the address range spanning the lowest to the highest requested register,
+        then each register is extracted, sign-decoded and (optionally) normalised exactly as
+        :pymeth:`sync_read` would. This makes reading a group of neighbouring registers (e.g. the
+        `Present_*` telemetry registers) cost one transaction instead of one per register. Any bytes lying
+        between the requested registers are read from the bus and discarded, so keep the group compact.
+
+        Args:
+            data_names (Sequence[str]): Register names. Duplicates are ignored, order is preserved.
+            motors (NameOrID | Sequence[NameOrID] | None, optional): Motors to query. `None` (default) reads every motor.
+            normalize (bool, optional): Normalisation flag, applied per register to those listed in
+                :pyattr:`normalized_data`. Defaults to `True`.
+            num_retry (int, optional): Retry attempts.  Defaults to `0`.
+
+        Returns:
+            dict[str, dict[str, Value]]: Mapping *register name → (motor name → value)*.
+
+        Raises:
+            ValueError: `data_names` is empty.
+            TypeError: `data_names` is a single string instead of a sequence of names.
+        """
+
+        self._assert_protocol_is_compatible("sync_read")
+
+        if isinstance(data_names, str):
+            raise TypeError(f"'data_names' should be a sequence of register names, got '{data_names}'.")
+        data_names = list(dict.fromkeys(data_names))
+        if not data_names:
+            raise ValueError("'data_names' should contain at least one register name.")
+
+        names = self._get_motors_list(motors)
+        ids = [self.motors[motor].id for motor in names]
+        models = [self.motors[motor].model for motor in names]
+
+        model = next(iter(models))
+        addr_lengths: dict[str, tuple[int, int]] = {}
+        for data_name in data_names:
+            if self._has_different_ctrl_tables:
+                assert_same_address(self.model_ctrl_table, models, data_name)
+            addr_lengths[data_name] = get_address(self.model_ctrl_table, model, data_name)
+
+        start = min(addr for addr, _ in addr_lengths.values())
+        end = max(addr + length for addr, length in addr_lengths.values())
+
+        err_msg = f"Failed to sync read block {data_names} on {ids=} after {num_retry + 1} tries."
+        self._sync_read_txrx(
+            start, end - start, ids, num_retry=num_retry, raise_on_error=True, err_msg=err_msg
+        )
+
+        values: dict[str, dict[str, Value]] = {}
+        for data_name, (addr, length) in addr_lengths.items():
+            raw_ids_values = {id_: self.sync_reader.getData(id_, addr, length) for id_ in ids}
+            decoded = self._decode_sign(data_name, raw_ids_values)
+            if normalize and data_name in self.normalized_data:
+                normalized = self._normalize(decoded)
+                values[data_name] = {self._id_to_name(id_): value for id_, value in normalized.items()}
+            else:
+                values[data_name] = {self._id_to_name(id_): value for id_, value in decoded.items()}
+
+        return values
+
     def _sync_read(
         self,
         addr: int,
@@ -1180,6 +1251,27 @@ class SerialMotorsBus(MotorsBusBase):
         raise_on_error: bool = True,
         err_msg: str = "",
     ) -> tuple[dict[int, int], int]:
+        comm = self._sync_read_txrx(
+            addr, length, motor_ids, num_retry=num_retry, raise_on_error=raise_on_error, err_msg=err_msg
+        )
+        values = {id_: self.sync_reader.getData(id_, addr, length) for id_ in motor_ids}
+        return values, comm
+
+    def _sync_read_txrx(
+        self,
+        addr: int,
+        length: int,
+        motor_ids: list[int],
+        *,
+        num_retry: int = 0,
+        raise_on_error: bool = True,
+        err_msg: str = "",
+    ) -> int:
+        """Transmit one sync read for `length` bytes at `addr` and receive the replies, retrying on failure.
+
+        On success the received bytes stay in :pyattr:`sync_reader`, ready to be extracted with `getData` for
+        any register lying inside the block. Returns the communication result.
+        """
         self._setup_sync_reader(motor_ids, addr, length)
         for n_try in range(1 + num_retry):
             comm = self.sync_reader.txRxPacket()
@@ -1193,8 +1285,7 @@ class SerialMotorsBus(MotorsBusBase):
         if not self._is_comm_success(comm) and raise_on_error:
             raise ConnectionError(f"{err_msg} {self.packet_handler.getTxRxResult(comm)}")
 
-        values = {id_: self.sync_reader.getData(id_, addr, length) for id_ in motor_ids}
-        return values, comm
+        return comm
 
     def _setup_sync_reader(self, motor_ids: list[int], addr: int, length: int) -> None:
         self.sync_reader.clearParam()

--- a/tests/mocks/mock_dynamixel.py
+++ b/tests/mocks/mock_dynamixel.py
@@ -419,9 +419,20 @@ class MockStatusPacket(MockDynamixelPacketv2):
         Returns:
             bytes: The raw 'Present_Position' status packet ready to be sent through serial.
         """
-        params = _split_into_byte_chunks(value, param_length)
-        length = param_length + 4
-        return cls.build(dxl_id, params=params, length=length, error=error)
+        return cls.read_block(dxl_id, _split_into_byte_chunks(value, param_length), error)
+
+    @classmethod
+    def read_block(cls, dxl_id: int, data: list[int], error: int = 0) -> bytes:
+        """Builds a 'Read' status packet carrying an arbitrary byte payload (e.g. a multi-register block).
+
+        Args:
+            dxl_id (int): ID of the servo responding.
+            data (list[int]): Raw bytes to be returned in the packet, in bus order.
+
+        Returns:
+            bytes: The raw 'Read' / 'Sync Read' status packet ready to be sent through serial.
+        """
+        return cls.build(dxl_id, params=data, length=len(data) + 4, error=error)
 
 
 class MockPortHandler(dxl.PortHandler):
@@ -553,6 +564,31 @@ class MockMotors(MockSerial):
         )
         sync_read_response = self._build_send_fn(return_packets, num_invalid_try)
         stub_name = f"Sync_Read_{address}_{length}_" + "_".join([str(id_) for id_ in ids_values])
+        self.stub(
+            name=stub_name,
+            receive_bytes=sync_read_request,
+            send_fn=sync_read_response,
+        )
+        return stub_name
+
+    def build_sync_read_block_stub(
+        self,
+        address: int,
+        length: int,
+        ids_data: dict[int, list[int]],
+        reply: bool = True,
+        num_invalid_try: int = 0,
+    ) -> str:
+        """Like `build_sync_read_stub`, but each motor replies with a raw byte block of `length` bytes."""
+        assert all(len(data) == length for data in ids_data.values())
+        sync_read_request = MockInstructionPacket.sync_read(list(ids_data), address, length)
+        return_packets = (
+            b"".join(MockStatusPacket.read_block(id_, data) for id_, data in ids_data.items())
+            if reply
+            else b""
+        )
+        sync_read_response = self._build_send_fn(return_packets, num_invalid_try)
+        stub_name = f"Sync_Read_Block_{address}_{length}_" + "_".join([str(id_) for id_ in ids_data])
         self.stub(
             name=stub_name,
             receive_bytes=sync_read_request,

--- a/tests/mocks/mock_feetech.py
+++ b/tests/mocks/mock_feetech.py
@@ -270,9 +270,20 @@ class MockStatusPacket(MockFeetechPacket):
         Returns:
             bytes: The raw 'Sync Read' status packet ready to be sent through serial.
         """
-        params = _split_into_byte_chunks(value, param_length)
-        length = param_length + 2
-        return cls.build(scs_id, params=params, length=length, error=error)
+        return cls.read_block(scs_id, _split_into_byte_chunks(value, param_length), error)
+
+    @classmethod
+    def read_block(cls, scs_id: int, data: list[int], error: int = 0) -> bytes:
+        """Builds a 'Read' status packet carrying an arbitrary byte payload (e.g. a multi-register block).
+
+        Args:
+            scs_id (int): ID of the servo responding.
+            data (list[int]): Raw bytes to be returned in the packet, in bus order.
+
+        Returns:
+            bytes: The raw 'Read' / 'Sync Read' status packet ready to be sent through serial.
+        """
+        return cls.build(scs_id, params=data, length=len(data) + 2, error=error)
 
 
 class MockPortHandler(scs.PortHandler):
@@ -402,6 +413,31 @@ class MockMotors(MockSerial):
         )
         sync_read_response = self._build_send_fn(return_packets, num_invalid_try)
         stub_name = f"Sync_Read_{address}_{length}_" + "_".join([str(id_) for id_ in ids_values])
+        self.stub(
+            name=stub_name,
+            receive_bytes=sync_read_request,
+            send_fn=sync_read_response,
+        )
+        return stub_name
+
+    def build_sync_read_block_stub(
+        self,
+        address: int,
+        length: int,
+        ids_data: dict[int, list[int]],
+        reply: bool = True,
+        num_invalid_try: int = 0,
+    ) -> str:
+        """Like `build_sync_read_stub`, but each motor replies with a raw byte block of `length` bytes."""
+        assert all(len(data) == length for data in ids_data.values())
+        sync_read_request = MockInstructionPacket.sync_read(list(ids_data), address, length)
+        return_packets = (
+            b"".join(MockStatusPacket.read_block(id_, data) for id_, data in ids_data.items())
+            if reply
+            else b""
+        )
+        sync_read_response = self._build_send_fn(return_packets, num_invalid_try)
+        stub_name = f"Sync_Read_Block_{address}_{length}_" + "_".join([str(id_) for id_ in ids_data])
         self.stub(
             name=stub_name,
             receive_bytes=sync_read_request,

--- a/tests/motors/test_dynamixel.py
+++ b/tests/motors/test_dynamixel.py
@@ -29,7 +29,7 @@ from lerobot.motors.encoding_utils import encode_twos_complement
 try:
     import dynamixel_sdk as dxl
 
-    from tests.mocks.mock_dynamixel import MockMotors, MockPortHandler
+    from tests.mocks.mock_dynamixel import MockMotors, MockPortHandler, _split_into_byte_chunks
 except (ImportError, ModuleNotFoundError):
     pytest.skip("dynamixel_sdk not available", allow_module_level=True)
 
@@ -279,6 +279,45 @@ def test__sync_read_comm(raise_on_error, mock_motors, dummy_motors):
         assert read_comm == dxl.COMM_RX_TIMEOUT
 
     assert mock_motors.stubs[stub].called
+
+
+def test_sync_read_block(mock_motors, dummy_motors):
+    """A block read over the contiguous Present_Current/Velocity/Position registers matches three sync_reads."""
+    names = ["Present_Current", "Present_Velocity", "Present_Position"]
+    currents = {1: -150, 2: 20, 3: 0}
+    velocities = {1: 100, 2: -2000, 3: 5}
+    positions = {1: 1337, 2: 42, 3: -3672}
+    encoded = {
+        "Present_Current": {id_: encode_twos_complement(val, 2) for id_, val in currents.items()},
+        "Present_Velocity": {id_: encode_twos_complement(val, 4) for id_, val in velocities.items()},
+        "Present_Position": {id_: encode_twos_complement(val, 4) for id_, val in positions.items()},
+    }
+    # Present_Current (126-127), Present_Velocity (128-131) and Present_Position (132-135) form one
+    # contiguous 10-byte block on X-series servos.
+    ids_data = {
+        id_: [
+            byte
+            for name in names
+            for byte in _split_into_byte_chunks(encoded[name][id_], X_SERIES_CONTROL_TABLE[name][1])
+        ]
+        for id_ in currents
+    }
+    block_stub = mock_motors.build_sync_read_block_stub(126, 10, ids_data)
+    single_stubs = [
+        mock_motors.build_sync_read_stub(*X_SERIES_CONTROL_TABLE[name], encoded[name]) for name in names
+    ]
+    bus = DynamixelMotorsBus(port=mock_motors.port, motors=dummy_motors)
+    bus.connect(handshake=False)
+
+    block_values = bus.sync_read_block(names, normalize=False)
+    single_values = {name: bus.sync_read(name, normalize=False) for name in names}
+
+    assert block_values == single_values
+    assert block_values["Present_Current"] == {"dummy_1": -150, "dummy_2": 20, "dummy_3": 0}
+    assert block_values["Present_Velocity"] == {"dummy_1": 100, "dummy_2": -2000, "dummy_3": 5}
+    assert block_values["Present_Position"] == {"dummy_1": 1337, "dummy_2": 42, "dummy_3": -3672}
+    assert mock_motors.stubs[block_stub].calls == 1
+    assert all(mock_motors.stubs[stub].calls == 1 for stub in single_stubs)
 
 
 @pytest.mark.parametrize(

--- a/tests/motors/test_feetech.py
+++ b/tests/motors/test_feetech.py
@@ -29,9 +29,15 @@ from lerobot.motors.feetech.tables import STS_SMS_SERIES_CONTROL_TABLE
 try:
     import scservo_sdk as scs
 
-    from tests.mocks.mock_feetech import MockMotors, MockPortHandler
+    from tests.mocks.mock_feetech import MockMotors, MockPortHandler, _split_into_byte_chunks
 except (ImportError, ModuleNotFoundError):
     pytest.skip("scservo_sdk not available", allow_module_level=True)
+
+# Present_Position (56-57), Present_Load (60-61) and Present_Current (69-70) span one 15-byte block on STS
+# servos. The registers in between (velocity, voltage, temperature, ...) are part of the block on the wire
+# but must be ignored by the reader.
+TELEMETRY_NAMES = ["Present_Position", "Present_Load", "Present_Current"]
+TELEMETRY_BLOCK_START, TELEMETRY_BLOCK_LENGTH = 56, 15
 
 
 @pytest.fixture(autouse=True)
@@ -322,6 +328,135 @@ def test__sync_read_comm(raise_on_error, mock_motors, dummy_motors):
         assert read_comm == scs.COMM_RX_TIMEOUT
 
     assert mock_motors.stubs[stub].called
+
+
+def _encode_telemetry(
+    positions: dict[int, int], loads: dict[int, int], currents: dict[int, int]
+) -> dict[str, dict[int, int]]:
+    """Encode signed telemetry values the way an STS servo reports them (Present_Current has no sign bit)."""
+    return {
+        "Present_Position": {id_: encode_sign_magnitude(val, 15) for id_, val in positions.items()},
+        "Present_Load": {id_: encode_sign_magnitude(val, 10) for id_, val in loads.items()},
+        "Present_Current": dict(currents),
+    }
+
+
+def _build_telemetry_block_stub(
+    mock_motors: MockMotors, encoded: dict[str, dict[int, int]], filler: int = 0xAB
+) -> str:
+    """Stub one sync read of the whole telemetry block, with `filler` in the bytes no register maps to."""
+    ids_data = {}
+    for id_ in encoded["Present_Position"]:
+        block = [filler] * TELEMETRY_BLOCK_LENGTH
+        for data_name in TELEMETRY_NAMES:
+            addr, length = STS_SMS_SERIES_CONTROL_TABLE[data_name]
+            offset = addr - TELEMETRY_BLOCK_START
+            block[offset : offset + length] = _split_into_byte_chunks(encoded[data_name][id_], length)
+        ids_data[id_] = block
+    return mock_motors.build_sync_read_block_stub(TELEMETRY_BLOCK_START, TELEMETRY_BLOCK_LENGTH, ids_data)
+
+
+def test_sync_read_block(mock_motors, dummy_motors):
+    """A block read decodes each register exactly like one sync_read per register would."""
+    positions = {1: -1337, 2: 42, 3: 3672}
+    loads = {1: 300, 2: -512, 3: -7}
+    currents = {1: 12, 2: 0, 3: 999}
+    encoded = _encode_telemetry(positions, loads, currents)
+    block_stub = _build_telemetry_block_stub(mock_motors, encoded)
+    single_stubs = [
+        mock_motors.build_sync_read_stub(*STS_SMS_SERIES_CONTROL_TABLE[name], encoded[name])
+        for name in TELEMETRY_NAMES
+    ]
+    bus = FeetechMotorsBus(port=mock_motors.port, motors=dummy_motors)
+    bus.connect(handshake=False)
+
+    block_values = bus.sync_read_block(TELEMETRY_NAMES, normalize=False)
+    single_values = {name: bus.sync_read(name, normalize=False) for name in TELEMETRY_NAMES}
+
+    assert block_values == single_values
+    assert block_values["Present_Position"] == {"dummy_1": -1337, "dummy_2": 42, "dummy_3": 3672}
+    assert block_values["Present_Load"] == {"dummy_1": 300, "dummy_2": -512, "dummy_3": -7}
+    assert block_values["Present_Current"] == {"dummy_1": 12, "dummy_2": 0, "dummy_3": 999}
+    assert mock_motors.stubs[block_stub].calls == 1
+    assert all(mock_motors.stubs[stub].calls == 1 for stub in single_stubs)
+
+
+def test_sync_read_block_normalize(mock_motors, dummy_motors, dummy_calibration):
+    """With normalize=True only registers in `normalized_data` (Present_Position) are scaled."""
+    positions = {1: 1000, 2: 2000, 3: 3000}
+    loads = {1: 300, 2: -512, 3: -7}
+    currents = {1: 12, 2: 0, 3: 999}
+    encoded = _encode_telemetry(positions, loads, currents)
+    block_stub = _build_telemetry_block_stub(mock_motors, encoded)
+    position_stub = mock_motors.build_sync_read_stub(
+        *STS_SMS_SERIES_CONTROL_TABLE["Present_Position"], encoded["Present_Position"]
+    )
+    bus = FeetechMotorsBus(port=mock_motors.port, motors=dummy_motors, calibration=dummy_calibration)
+    bus.connect(handshake=False)
+
+    block_values = bus.sync_read_block(TELEMETRY_NAMES)
+    normalized_positions = bus.sync_read("Present_Position")
+
+    assert block_values["Present_Position"] == normalized_positions
+    assert all(isinstance(val, float) for val in block_values["Present_Position"].values())
+    assert block_values["Present_Load"] == {"dummy_1": 300, "dummy_2": -512, "dummy_3": -7}
+    assert block_values["Present_Current"] == {"dummy_1": 12, "dummy_2": 0, "dummy_3": 999}
+    assert mock_motors.stubs[block_stub].calls == 1
+    assert mock_motors.stubs[position_stub].calls == 1
+
+
+def test_sync_read_block_single_transaction(mock_motors, dummy_motors):
+    """Reading a block for a subset of motors sends exactly one sync read packet on the bus."""
+    encoded = _encode_telemetry({1: 100, 3: -300}, {1: 1, 3: -3}, {1: 5, 3: 7})
+    block_stub = _build_telemetry_block_stub(mock_motors, encoded)
+    bus = FeetechMotorsBus(port=mock_motors.port, motors=dummy_motors)
+    bus.connect(handshake=False)
+
+    with patch.object(bus.sync_reader, "txRxPacket", wraps=bus.sync_reader.txRxPacket) as mock_txrx:
+        block_values = bus.sync_read_block(TELEMETRY_NAMES, ["dummy_1", "dummy_3"], normalize=False)
+
+    assert mock_txrx.call_count == 1
+    assert mock_motors.stubs[block_stub].calls == 1
+    assert block_values == {
+        "Present_Position": {"dummy_1": 100, "dummy_3": -300},
+        "Present_Load": {"dummy_1": 1, "dummy_3": -3},
+        "Present_Current": {"dummy_1": 5, "dummy_3": 7},
+    }
+
+
+def test_sync_read_block_deduplicates_names(mock_motors, dummy_motors):
+    encoded = _encode_telemetry({1: 1, 2: 2, 3: 3}, {1: 4, 2: 5, 3: 6}, {1: 7, 2: 8, 3: 9})
+    block_stub = _build_telemetry_block_stub(mock_motors, encoded)
+    bus = FeetechMotorsBus(port=mock_motors.port, motors=dummy_motors)
+    bus.connect(handshake=False)
+
+    block_values = bus.sync_read_block(
+        ["Present_Position", "Present_Current", "Present_Position", "Present_Load"], normalize=False
+    )
+
+    assert list(block_values) == ["Present_Position", "Present_Current", "Present_Load"]
+    assert mock_motors.stubs[block_stub].calls == 1
+
+
+@pytest.mark.parametrize(
+    "data_names, error, match",
+    [
+        ([], ValueError, "'data_names' should contain at least one register name."),
+        ("Present_Position", TypeError, "'data_names' should be a sequence of register names"),
+        (
+            ["Present_Position", "Not_A_Register"],
+            KeyError,
+            "Address for 'Not_A_Register' not found in sts3215 control table.",
+        ),
+    ],
+    ids=["empty", "single_str", "unknown_register"],
+)
+def test_sync_read_block_invalid_names(data_names, error, match, mock_motors, dummy_motors):
+    bus = FeetechMotorsBus(port=mock_motors.port, motors=dummy_motors)
+    bus.connect(handshake=False)
+
+    with pytest.raises(error, match=re.escape(match)):
+        bus.sync_read_block(data_names)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary / Motivation

Reading several `Present_*` registers today costs one bus transaction per register. On Feetech STS servos those registers are contiguous (56 to 70), so one sync read of the span returns all of them. This PR adds `MotorsBus.sync_read_block(data_names, ...)`: it reads the address range spanning the requested registers once, then extracts, sign-decodes and normalizes each register the same way `sync_read` does.

Measured on a 6-motor SO-101 follower bus at 1 Mbps (200 iterations, idle arm): position only 1.00 ms, position + velocity + load + temperature as four sync reads 4.00 ms, the 15-byte block 2.00 ms. Full telemetry then costs +1 ms over a position read instead of +3 ms. The numbers and the field-by-field equivalence check are in my comment on #3456.

## Related issues

- Related: #3456 (optional motor telemetry in SO-follower recording, which stalled on the cost of the extra sync reads)

## What changed

- `SerialMotorsBus.sync_read_block(data_names, motors=None, *, normalize=True, num_retry=0)` returns `{register: {motor: value}}`. It is generic over control tables, so it works for Feetech and Dynamixel. Bytes lying between requested registers are read and discarded, which the docstring states.
- The setup/retry/txRx loop moved from `_sync_read` into `_sync_read_txrx`. `_sync_read` keeps its signature and behavior, so existing callers are unchanged.
- Duplicate names are dropped with order kept. An empty list raises `ValueError`. A bare string raises `TypeError`.
- Not added to `MotorsBusBase`, since a register block has no meaning for the CAN buses.

## How was this tested (or how to run locally)

- New tests in `tests/motors/test_feetech.py` and `tests/motors/test_dynamixel.py`: block values equal per-register `sync_read` values including sign decoding (`Present_Load` bit 10, `Present_Position` bit 15), `normalize` applies only to `Present_Position`, exactly one packet goes on the wire, dedup, and the error cases. The mocks gained a raw block stub.
- `pytest -q tests/motors`: 119 passed, 1 skipped (damiao, no python-can). Before this PR: 111 passed.
- ruff check and ruff format clean on the touched files with the repo-pinned version.
- Hardware: block-read values matched per-register `sync_read` values field by field on a 6-motor STS3215 bus (see the #3456 comment).

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated (docstring)
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: #

## Reviewer notes

- Happy to rename, or to fold this into `sync_read` accepting a sequence of names, if you prefer one entry point.
- If useful I can follow up on the SO-follower side: recording `Present_Load` and `Present_Current` in the observation through this read, which is how I collected my own datasets.
- AI disclosure per AI_POLICY.md: the implementation and tests were drafted with Claude Code from my design and my measurements. Opened as a draft while I finish my own review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
