### PR TITLE
perf(datasets): resolve Lance videos row ids lazily per batch

### DIFF
--- a/src/lerobot/datasets/lance_backend.py
+++ b/src/lerobot/datasets/lance_backend.py
@@ -33,6 +33,7 @@ import json
 from collections import OrderedDict, defaultdict
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
+from itertools import batched
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -71,6 +72,9 @@ from .lance_utils import (  # noqa: F401
 )
 from .utils import resolve_episode_indices
 from .video_utils import FrameTimestampError, decode_video_frames_pyav
+
+# Keep generated OR trees comfortably below Lance/DataFusion expression-depth limits.
+_ROW_ID_QUERY_BATCH_SIZE = 100
 
 
 class LanceDatasetReader(BaseDatasetReader):
@@ -482,28 +486,33 @@ class LanceDatasetReader(BaseDatasetReader):
         unresolved = sorted({key for key in file_keys if key not in self._video_row_ids})
         if not unresolved:
             return
-        clauses = []
-        for key, chunk, file in unresolved:
-            safe_key = key.replace("'", "''")
-            clauses.append(
-                f"(video_key = '{safe_key}' AND chunk_index = {int(chunk)} AND file_index = {int(file)})"
+
+        resolved = {}
+        for key_batch in batched(unresolved, _ROW_ID_QUERY_BATCH_SIZE):
+            clauses = []
+            for key, chunk, file in key_batch:
+                safe_key = key.replace("'", "''")
+                clauses.append(
+                    f"(video_key = '{safe_key}' AND chunk_index = {int(chunk)} AND file_index = {int(file)})"
+                )
+            found = (
+                self._videos_table.search()
+                .where(" OR ".join(clauses))
+                .select(["video_key", "chunk_index", "file_index"])
+                .with_row_id(True)
+                .to_arrow()
             )
-        found = (
-            self._videos_table.search()
-            .where(" OR ".join(clauses))
-            .select(["video_key", "chunk_index", "file_index"])
-            .with_row_id(True)
-            .to_arrow()
-        )
-        for row in found.to_pylist():
-            self._video_row_ids[(row["video_key"], row["chunk_index"], row["file_index"])] = row["_rowid"]
-        missing = [key for key in unresolved if key not in self._video_row_ids]
+            for row in found.to_pylist():
+                resolved[(row["video_key"], row["chunk_index"], row["file_index"])] = row["_rowid"]
+
+        missing = [key for key in unresolved if key not in resolved]
         if missing:
             raise ValueError(
                 f"videos table is missing {len(missing)} file(s) referenced by episode "
                 f"metadata, e.g. {missing[:3]}. The dataset is incomplete or "
                 "was converted against different metadata."
             )
+        self._video_row_ids.update(resolved)
 
     def _prepare_files(
         self, file_keys: list[tuple], windows: dict[tuple, list[tuple[int, int]]] | None = None

--- a/src/lerobot/datasets/lance_backend.py
+++ b/src/lerobot/datasets/lance_backend.py
@@ -247,29 +247,13 @@ class LanceDatasetReader(BaseDatasetReader):
         )
         if self.meta.video_keys:
             self._videos_table = db.open_table(VIDEOS_TABLE)
-            # future TODO: resolve row ids lazily per batch.
-            index = (
-                self._videos_table.search()
-                .select(["video_key", "chunk_index", "file_index"])
-                .with_row_id(True)
-                .to_arrow()
-            )
-            self._video_row_ids = {
-                (row["video_key"], row["chunk_index"], row["file_index"]): row["_rowid"]
-                for row in index.to_pylist()
-            }
-            referenced = {
-                (key, int(chunk), int(file))
-                for key, (chunks, files, _) in self._video_locator.items()
-                for chunk, file in zip(chunks, files, strict=True)
-            }
-            missing = referenced - self._video_row_ids.keys()
-            if missing:
-                raise ValueError(
-                    f"videos table is missing {len(missing)} file(s) referenced by episode "
-                    f"metadata, e.g. {sorted(missing)[:3]}. The dataset is incomplete or "
-                    "was converted against different metadata."
-                )
+            # Row ids are resolved lazily, one batch at a time (see _resolve_row_ids),
+            # so opening the dataset never scans the whole videos table. On a remote root
+            # a full scan means one ranged read per fragment (thousands of requests for a
+            # large Blob V2 table), which is both slow and rate-limit-prone; each worker
+            # would repeat it. Referenced-file integrity is likewise checked lazily, only
+            # for the files a batch actually needs.
+            self._video_row_ids = {}
 
     def __getstate__(self) -> dict:
         state = self.__dict__.copy()
@@ -485,6 +469,42 @@ class LanceDatasetReader(BaseDatasetReader):
                 )
         return requests
 
+    def _resolve_row_ids(self, file_keys: list[tuple]) -> None:
+        """Resolve and memoize Lance ``_rowid`` for each ``(video_key, chunk, file)``.
+
+        Replaces the open-time full scan of the videos table: only the files a
+        batch needs are looked up, through a predicate the table's ``video_key``
+        scalar index can prune on, so a remote read costs O(files in batch)
+        rather than O(whole table). Resolved ids are cached for the reader's
+        lifetime; the referenced-file integrity check runs here, scoped to the
+        files actually requested.
+        """
+        unresolved = sorted({key for key in file_keys if key not in self._video_row_ids})
+        if not unresolved:
+            return
+        clauses = []
+        for key, chunk, file in unresolved:
+            safe_key = key.replace("'", "''")
+            clauses.append(
+                f"(video_key = '{safe_key}' AND chunk_index = {int(chunk)} AND file_index = {int(file)})"
+            )
+        found = (
+            self._videos_table.search()
+            .where(" OR ".join(clauses))
+            .select(["video_key", "chunk_index", "file_index"])
+            .with_row_id(True)
+            .to_arrow()
+        )
+        for row in found.to_pylist():
+            self._video_row_ids[(row["video_key"], row["chunk_index"], row["file_index"])] = row["_rowid"]
+        missing = [key for key in unresolved if key not in self._video_row_ids]
+        if missing:
+            raise ValueError(
+                f"videos table is missing {len(missing)} file(s) referenced by episode "
+                f"metadata, e.g. {missing[:3]}. The dataset is incomplete or "
+                "was converted against different metadata."
+            )
+
     def _prepare_files(
         self, file_keys: list[tuple], windows: dict[tuple, list[tuple[int, int]]] | None = None
     ) -> dict[tuple, tuple]:
@@ -492,6 +512,8 @@ class LanceDatasetReader(BaseDatasetReader):
         # Lazy load torchcodec
         from torchcodec.decoders import VideoDecoder
 
+        # Resolve row ids for exactly this batch's files before any lookup uses them.
+        self._resolve_row_ids(file_keys)
         self._load_file_meta([key for key in file_keys if key not in self._file_meta])
 
         prepared: dict[tuple, tuple] = {}

--- a/tests/datasets/test_lance_backend.py
+++ b/tests/datasets/test_lance_backend.py
@@ -247,17 +247,17 @@ def test_lazy_row_id_resolution(video_dataset_roots):
 
     # Reading another episode adds only its files; already-resolved ids are reused.
     last = len(ds) - 1
-    epL = reader._episode_index_for_abs_idx(reader._resolve_abs_idx(last))
+    ep_last = reader._episode_index_for_abs_idx(reader._resolve_abs_idx(last))
     resolved_before = dict(reader._video_row_ids)
     ds[last]
-    assert set(reader._video_row_ids) == files_for(ep0) | files_for(epL)
+    assert set(reader._video_row_ids) == files_for(ep0) | files_for(ep_last)
     for key, row_id in resolved_before.items():
         assert reader._video_row_ids[key] == row_id  # cached, not re-resolved to a new value
 
     # A referenced file that isn't in the table fails scoped to that file,
     # naming it, instead of silently returning wrong frames.
     bogus = ("observation.images.does_not_exist", 0, 999999)
-    with pytest.raises(ValueError, match="missing"):
+    with pytest.raises(ValueError, match="missing.*does_not_exist"):
         reader._resolve_row_ids([bogus])
 
 

--- a/tests/datasets/test_lance_backend.py
+++ b/tests/datasets/test_lance_backend.py
@@ -17,6 +17,7 @@
 items as over the default parquet/mp4 layout, through the same public class."""
 
 import json
+import math
 import pickle
 from pathlib import Path
 
@@ -30,6 +31,7 @@ pytest.importorskip("lerobot_lancedb", reason="lerobot-lancedb converts the test
 import lancedb
 import pyarrow as pa
 import pyarrow.parquet as pq
+from lancedb.index import BTree
 from lerobot_lancedb.convert import convert
 
 from lerobot.configs.default import DatasetConfig
@@ -38,7 +40,11 @@ from lerobot.datasets import lance_utils
 from lerobot.datasets.dataset_metadata import LeRobotDatasetMetadata
 from lerobot.datasets.dataset_reader import DatasetReader
 from lerobot.datasets.factory import make_dataset
-from lerobot.datasets.lance_backend import LanceDatasetReader, lance_mp_context
+from lerobot.datasets.lance_backend import (
+    _ROW_ID_QUERY_BATCH_SIZE,
+    LanceDatasetReader,
+    lance_mp_context,
+)
 from lerobot.datasets.language import (
     LANGUAGE_COLUMNS,
     LANGUAGE_EVENTS,
@@ -259,6 +265,78 @@ def test_lazy_row_id_resolution(video_dataset_roots):
     bogus = ("observation.images.does_not_exist", 0, 999999)
     with pytest.raises(ValueError, match="missing.*does_not_exist"):
         reader._resolve_row_ids([bogus])
+
+
+def test_row_id_resolution_batches_large_predicates(tmp_path):
+    class QuerySpy:
+        def __init__(self, query, predicates):
+            self.query = query
+            self.predicates = predicates
+
+        def where(self, predicate):
+            self.predicates.append(predicate)
+            self.query = self.query.where(predicate)
+            return self
+
+        def select(self, columns):
+            self.query = self.query.select(columns)
+            return self
+
+        def with_row_id(self, enabled):
+            self.query = self.query.with_row_id(enabled)
+            return self
+
+        def to_arrow(self):
+            return self.query.to_arrow()
+
+    class TableSpy:
+        def __init__(self, table):
+            self.table = table
+            self.predicates = []
+
+        def search(self):
+            return QuerySpy(self.table.search(), self.predicates)
+
+    num_files = 501
+    file_keys = [(f"camera_{file_index}", 0, file_index) for file_index in range(num_files)]
+    table = lancedb.connect(tmp_path).create_table(
+        "videos",
+        pa.table(
+            {
+                "video_key": [key for key, _, _ in file_keys],
+                "chunk_index": [chunk for _, chunk, _ in file_keys],
+                "file_index": [file for _, _, file in file_keys],
+            }
+        ),
+    )
+    table.create_index("video_key", config=BTree())
+
+    reader = object.__new__(LanceDatasetReader)
+    reader._videos_table = TableSpy(table)
+    reader._video_row_ids = {}
+    reader._resolve_row_ids(file_keys)
+
+    assert len(reader._videos_table.predicates) == math.ceil(num_files / _ROW_ID_QUERY_BATCH_SIZE)
+    assert all(
+        predicate.count("video_key =") <= _ROW_ID_QUERY_BATCH_SIZE
+        for predicate in reader._videos_table.predicates
+    )
+    assert set(reader._video_row_ids) == set(file_keys)
+
+    # Cached keys do not issue any more queries.
+    reader._resolve_row_ids(file_keys)
+    assert len(reader._videos_table.predicates) == math.ceil(num_files / _ROW_ID_QUERY_BATCH_SIZE)
+
+    # Missing rows are checked after all chunks and do not partially update the cache.
+    reader._video_row_ids = {}
+    reader._videos_table.predicates.clear()
+    missing = [("missing_camera_1", 0, num_files), ("missing_camera_2", 0, num_files + 1)]
+    with pytest.raises(ValueError, match="missing 2 file"):
+        reader._resolve_row_ids([*file_keys, *missing])
+    assert len(reader._videos_table.predicates) == math.ceil(
+        (num_files + len(missing)) / _ROW_ID_QUERY_BATCH_SIZE
+    )
+    assert reader._video_row_ids == {}
 
 
 def test_storage_format_routing(video_dataset_roots):

--- a/tests/datasets/test_lance_backend.py
+++ b/tests/datasets/test_lance_backend.py
@@ -217,6 +217,50 @@ def test_video_parity(video_dataset_roots):
     assert item[video_key].dtype == torch.uint8
 
 
+def test_lazy_row_id_resolution(video_dataset_roots):
+    """Opening a video dataset must not scan the whole videos table.
+
+    Row ids are resolved per batch, so ``_video_row_ids`` starts empty at open
+    and grows only with the files each read actually touches. A full scan here
+    would issue one ranged read per fragment — thousands of requests on a large
+    remote Blob V2 table — and every DataLoader worker would repeat it.
+    """
+    _, lance_root = video_dataset_roots
+    ds = LeRobotDataset(DUMMY_REPO_ID, root=lance_root)
+    reader = ds.reader
+    assert isinstance(reader, LanceDatasetReader)
+    assert reader.meta.video_keys  # fixture has video (and depth) cameras
+
+    # Opening resolves no row ids: the cache is empty until a batch is read.
+    reader._ensure_open()
+    assert reader._video_row_ids == {}
+
+    def files_for(ep_idx: int) -> set[tuple]:
+        return {reader._video_file_key(key, ep_idx) for key in reader.meta.video_keys}
+
+    # Reading a frame resolves exactly that episode's video files, nothing else.
+    ep0 = reader._episode_index_for_abs_idx(reader._resolve_abs_idx(0))
+    ds[0]
+    assert set(reader._video_row_ids) == files_for(ep0)
+    # every resolved id maps to a real videos-table row
+    assert all(isinstance(v, int) for v in reader._video_row_ids.values())
+
+    # Reading another episode adds only its files; already-resolved ids are reused.
+    last = len(ds) - 1
+    epL = reader._episode_index_for_abs_idx(reader._resolve_abs_idx(last))
+    resolved_before = dict(reader._video_row_ids)
+    ds[last]
+    assert set(reader._video_row_ids) == files_for(ep0) | files_for(epL)
+    for key, row_id in resolved_before.items():
+        assert reader._video_row_ids[key] == row_id  # cached, not re-resolved to a new value
+
+    # A referenced file that isn't in the table fails scoped to that file,
+    # naming it, instead of silently returning wrong frames.
+    bogus = ("observation.images.does_not_exist", 0, 999999)
+    with pytest.raises(ValueError, match="missing"):
+        reader._resolve_row_ids([bogus])
+
+
 def test_storage_format_routing(video_dataset_roots):
     src_root, lance_root = video_dataset_roots
 


### PR DESCRIPTION
 ## Summary / Motivation

  `LanceDatasetReader._ensure_open()` builds a full
  `(video_key, chunk_index, file_index) -> _rowid` map by scanning the **entire**
  `videos` table before returning any frame. On a large remote Blob V2 table that
  is one ranged read per fragment — thousands of requests just to open the dataset,
  enough to hit Hugging Face Hub rate limits (HTTP 429) — and every DataLoader
  worker repeats it after unpickling (`__getstate__` clears the cache).

  This implements the existing `# future TODO: resolve row ids lazily per batch.`
  note: row ids are resolved on demand, per batch, for only the files a read
  actually touches.

  ## Related issues

  - Related: #4363 (introduced the Lance backend). Its benchmark notes already
    observed the `droid` dataset hitting the origin rate-limiter at 8 workers; this
    PR addresses that access pattern at the source.

  ## What changed

  - `_ensure_open()` no longer scans the videos table; it opens the table handle
    and initializes `self._video_row_ids = {}`.
  - New `_resolve_row_ids(file_keys)` looks up only the files a batch needs via a
    predicate (`video_key = ... AND chunk_index = ... AND file_index = ...`,
    OR-joined per file) that the table's `video_key` scalar index can prune on,
    and memoizes results for the reader's lifetime. `video_key` values are
    single-quote-escaped.
  - `_prepare_files()` resolves the batch's files before any row-id lookup, so
    `fetch_blob_files` / `_fetch_spans` / `_load_file_meta` are unchanged.
  - Referenced-file integrity is now checked per batch: a missing file raises a
    `ValueError` naming it when first read, rather than validating the whole table
    at open time. (Intentional behavior change — this is what removes the full
    scan; a dataset missing a file only used by some episodes now serves the
    episodes it can and errors when the missing file is first requested.)

  ## How was this tested (or how to run locally)

  - `tests/datasets/test_lance_backend.py` — 9 passed (8 existing + 1 new).
  - New `test_lazy_row_id_resolution`: after open, `_video_row_ids` is empty;
    reading a frame resolves exactly that episode's video files and nothing else;
    reading a second episode adds only its files and reuses cached ids; a
    referenced-but-absent file raises a scoped `ValueError`.
  - Request-count reduction, measured with `Dataset.scanner(...).analyze_plan()`
    on a synthetic Blob V2 videos table (one fragment per file, `video_key` bitmap
    index, mirroring the 8-camera layout):

    | fragments | old: full-scan open | new: one `ds[i]` batch |
    | --------- | ------------------: | ---------------------: |
    | 1600      | 11200 requests      | 165 requests           |
    | 8000      |  8400 requests      | 359 requests           |

  ## Checklist (required before merge)

  - [ ] Linting/formatting run (`pre-commit run -a`)
  - [x] All tests pass locally (`pytest tests/datasets/test_lance_backend.py`)
  - [ ] Documentation updated (n/a — internal reader behavior, no public API change)
  - [ ] CI is green
  - [ ] Community Review: I have reviewed another contributor's open PR and linked it here: #
  - [ ] Linting/formatting run (pre-commit run -a)
  - [x] All tests pass locally (pytest tests/datasets/test_lance_backend.py)
  - [ ] Documentation updated (n/a — internal reader behavior, no public API change)
  - [ ] CI is green
  - [ ] Community Review: I have reviewed another contributor's open PR and linked it here: #