### PR TITLE
LanceDB loader quick wins: fail-closed open, lazy blob handles, row ids resolved once

### DIFF
--- a/src/lerobot/datasets/lance_backend.py
+++ b/src/lerobot/datasets/lance_backend.py
@@ -242,9 +242,7 @@ class LanceDatasetReader(BaseDatasetReader):
                 f"frames table has {n_rows} rows but meta declares "
                 f"{self.meta.total_frames} frames; the dataset is truncated or corrupt."
             )
-        self._frames_perm = (
-            Permutation.identity(table).select_columns(self._fetch_columns).with_format("arrow")
-        )
+        frames_perm = Permutation.identity(table).select_columns(self._fetch_columns).with_format("arrow")
         if self.meta.video_keys:
             self._videos_table = db.open_table(VIDEOS_TABLE)
             # future TODO: resolve row ids lazily per batch.
@@ -270,6 +268,8 @@ class LanceDatasetReader(BaseDatasetReader):
                     f"metadata, e.g. {sorted(missing)[:3]}. The dataset is incomplete or "
                     "was converted against different metadata."
                 )
+        # Publish last: a failure above leaves the reader closed rather than half-open.
+        self._frames_perm = frames_perm
 
     def __getstate__(self) -> dict:
         state = self.__dict__.copy()

--- a/src/lerobot/datasets/lance_backend.py
+++ b/src/lerobot/datasets/lance_backend.py
@@ -260,9 +260,6 @@ class LanceDatasetReader(BaseDatasetReader):
     def _ensure_open(self) -> None:
         if self._frames_perm is not None:
             return
-        if self.meta.video_keys:
-            self._prefetch_pool = ThreadPoolExecutor(max_workers=1)
-            self._decode_pool = ThreadPoolExecutor(max_workers=16)
         db = _connect(self._db_uri, self._storage_options, revision=self._hub_revision, token=self._token)
         table = db.open_table(FRAMES_TABLE)
         n_rows = table.count_rows()
@@ -274,6 +271,8 @@ class LanceDatasetReader(BaseDatasetReader):
         frames_perm = Permutation.identity(table).select_columns(self._fetch_columns).with_format("arrow")
         if self.meta.video_keys:
             self._videos_table = db.open_table(VIDEOS_TABLE)
+            self._prefetch_pool = ThreadPoolExecutor(max_workers=1)
+            self._decode_pool = ThreadPoolExecutor(max_workers=16)
         # Publish last: a failure above leaves the reader closed rather than half-open.
         self._frames_perm = frames_perm
 

--- a/src/lerobot/datasets/lance_backend.py
+++ b/src/lerobot/datasets/lance_backend.py
@@ -214,9 +214,37 @@ class LanceDatasetReader(BaseDatasetReader):
             for key in self.meta.video_keys
         }
 
+        # Resolved once here so DataLoader workers inherit the map instead of each
+        # scanning the videos table.
+        self._video_row_ids: dict[tuple, int] | None = None
+        if self.meta.video_keys:
+            db = _connect(self._db_uri, self._storage_options, revision=self._hub_revision, token=self._token)
+            index = (
+                db.open_table(VIDEOS_TABLE)
+                .search()
+                .select(["video_key", "chunk_index", "file_index"])
+                .with_row_id(True)
+                .to_arrow()
+            )
+            self._video_row_ids = {
+                (row["video_key"], row["chunk_index"], row["file_index"]): row["_rowid"]
+                for row in index.to_pylist()
+            }
+            referenced = {
+                (key, int(chunk), int(file))
+                for key, (chunks, files, _) in self._video_locator.items()
+                for chunk, file in zip(chunks, files, strict=True)
+            }
+            missing = referenced - self._video_row_ids.keys()
+            if missing:
+                raise ValueError(
+                    f"videos table is missing {len(missing)} file(s) referenced by episode "
+                    f"metadata, e.g. {sorted(missing)[:3]}. The dataset is incomplete or "
+                    "was converted against different metadata."
+                )
+
         self._frames_perm = None
         self._videos_table = None
-        self._video_row_ids: dict[tuple, int] | None = None
         self._file_meta: OrderedDict[tuple, dict] = OrderedDict()
         self._prefetch_pool: ThreadPoolExecutor | None = None
         self._decode_pool: ThreadPoolExecutor | None = None
@@ -246,29 +274,6 @@ class LanceDatasetReader(BaseDatasetReader):
         frames_perm = Permutation.identity(table).select_columns(self._fetch_columns).with_format("arrow")
         if self.meta.video_keys:
             self._videos_table = db.open_table(VIDEOS_TABLE)
-            # future TODO: resolve row ids lazily per batch.
-            index = (
-                self._videos_table.search()
-                .select(["video_key", "chunk_index", "file_index"])
-                .with_row_id(True)
-                .to_arrow()
-            )
-            self._video_row_ids = {
-                (row["video_key"], row["chunk_index"], row["file_index"]): row["_rowid"]
-                for row in index.to_pylist()
-            }
-            referenced = {
-                (key, int(chunk), int(file))
-                for key, (chunks, files, _) in self._video_locator.items()
-                for chunk, file in zip(chunks, files, strict=True)
-            }
-            missing = referenced - self._video_row_ids.keys()
-            if missing:
-                raise ValueError(
-                    f"videos table is missing {len(missing)} file(s) referenced by episode "
-                    f"metadata, e.g. {sorted(missing)[:3]}. The dataset is incomplete or "
-                    "was converted against different metadata."
-                )
         # Publish last: a failure above leaves the reader closed rather than half-open.
         self._frames_perm = frames_perm
 
@@ -276,7 +281,6 @@ class LanceDatasetReader(BaseDatasetReader):
         state = self.__dict__.copy()
         state["_frames_perm"] = None
         state["_videos_table"] = None
-        state["_video_row_ids"] = None
         state["_file_meta"] = OrderedDict()
         state["_prefetch_pool"] = None
         state["_decode_pool"] = None

--- a/src/lerobot/datasets/lance_backend.py
+++ b/src/lerobot/datasets/lance_backend.py
@@ -33,6 +33,7 @@ import json
 from collections import OrderedDict, defaultdict
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
+from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -503,12 +504,9 @@ class LanceDatasetReader(BaseDatasetReader):
                 new_files.append(key)
 
         if new_files:
-            handles = self._videos_table.fetch_blob_files(
-                VIDEO_BLOB_COLUMN, [self._video_row_ids[key] for key in new_files]
-            )
             sources = {
-                key: _SparseBlobSource(self._file_meta[key]["file_size"], handle)
-                for key, handle in zip(new_files, handles, strict=True)
+                key: _SparseBlobSource(self._file_meta[key]["file_size"], partial(self._blob_handle, key))
+                for key in new_files
             }
             spans_by_key: dict[tuple, list[tuple[int, int]]] = {}
             for key in new_files:
@@ -556,6 +554,9 @@ class LanceDatasetReader(BaseDatasetReader):
         for key, (decoder, source) in prepared.items():
             self._decoder_cache.put(key, (decoder, source), nbytes=source.buffered)
         return prepared
+
+    def _blob_handle(self, key: tuple):
+        return self._videos_table.fetch_blob_files(VIDEO_BLOB_COLUMN, [self._video_row_ids[key]])[0]
 
     def _video_file_key(self, key: str, ep_idx: int) -> tuple[str, int, int]:
         chunk_arr, file_arr, _ = self._video_locator[key]

--- a/src/lerobot/datasets/lance_utils.py
+++ b/src/lerobot/datasets/lance_utils.py
@@ -119,6 +119,7 @@ class _SparseBlobSource(io.RawIOBase):
         super().__init__()
         self._size = size
         self._fallback = fallback
+        self._handle = None
         self._starts: list[int] = []
         self._chunks: list[bytes] = []
         self._pos = 0
@@ -188,7 +189,9 @@ class _SparseBlobSource(io.RawIOBase):
         next_index = bisect.bisect_right(self._starts, self._pos)
         if next_index < len(self._starts):
             want = min(want, self._starts[next_index] - self._pos)
-        data = self._fallback.read_range(self._pos, want)
+        if self._handle is None:
+            self._handle = self._fallback()
+        data = self._handle.read_range(self._pos, want)
         self.fallback_bytes += len(data)
         buffer[: len(data)] = data
         self._pos += len(data)

--- a/tests/datasets/test_lance_backend.py
+++ b/tests/datasets/test_lance_backend.py
@@ -34,7 +34,7 @@ from lerobot_lancedb.convert import convert
 
 from lerobot.configs.default import DatasetConfig
 from lerobot.configs.train import TrainPipelineConfig
-from lerobot.datasets import lance_utils
+from lerobot.datasets import lance_backend, lance_utils
 from lerobot.datasets.dataset_metadata import LeRobotDatasetMetadata
 from lerobot.datasets.dataset_reader import DatasetReader
 from lerobot.datasets.factory import make_dataset
@@ -215,6 +215,47 @@ def test_video_parity(video_dataset_roots):
     lance_u8 = LeRobotDataset(DUMMY_REPO_ID, root=lance_root, return_uint8=True)
     item = lance_u8[0]
     assert item[video_key].dtype == torch.uint8
+
+
+def test_reader_reopens_after_failed_open(video_dataset_roots, monkeypatch):
+    _, lance_root = video_dataset_roots
+    lance_ds = LeRobotDataset(DUMMY_REPO_ID, root=lance_root)
+    reader = lance_ds.reader
+    # the video row-id map is built at construction and survives pickling
+    assert reader._video_row_ids
+    assert pickle.loads(pickle.dumps(reader))._video_row_ids == reader._video_row_ids
+
+    def fail_open(*args, **kwargs):
+        raise OSError("simulated 429")
+
+    monkeypatch.setattr(lance_backend.Permutation, "identity", fail_open)
+    with pytest.raises(OSError):
+        lance_ds[0]
+    # nothing was published, so the next read starts over
+    assert reader._frames_perm is None
+    assert reader._prefetch_pool is None
+    monkeypatch.undo()
+    lance_ds[0]
+
+
+def test_sparse_source_fetches_handle_once():
+    class Handle:
+        opened = 0
+
+        def read_range(self, pos, n):
+            return b"x" * n
+
+    def open_handle():
+        Handle.opened += 1
+        return Handle()
+
+    source = lance_utils._SparseBlobSource(8, open_handle)
+    source.add(0, b"abcd")
+    assert source.read(4) == b"abcd"
+    assert Handle.opened == 0  # buffered reads never touch the handle
+    assert source.read(2) == b"xx"
+    assert source.read(2) == b"xx"
+    assert Handle.opened == 1  # one handle for every miss
 
 
 def test_storage_format_routing(video_dataset_roots):


### PR DESCRIPTION
small fixes from running the lance reader on a large dataset.

 - _ensure_open now publishes its handles last. A transient error mid-open used to leave a reader that failed every later read with 'NoneType' object is not subscriptable; now the next read just retries.
 - Blob handles are fetched on the first fallback read instead of for every new file each batch. They only serve fallback reads, which measure zero, so this removes one request per batch.
 - The video row-id map is built once at construction and inherited by DataLoader workers instead of each worker scanning the videos table (11 s and ~20k requests per worker on a 10k-fragment table).

## Related issues

- Fixes / Closes: # (if any)
- Related: # (if any)

## What changed

- Short, concrete bullets explaining the functional changes (how the behavior or output differs now).
- Short note if this introduces breaking changes and migration steps.

## How was this tested (or how to run locally)

- Tests added: list new tests or test files. `pytest -q tests/ -k <keyword>`
- Manual checks / dataset runs performed.
- Instructions for the reviewer for reproducing with a quick example or CLI (if applicable)

## Checklist (required before merge)

- [ ] Linting/formatting run (`pre-commit run -a`)
- [ ] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: # (insert PR number/link)

## Reviewer notes

- Anything the reviewer should focus on (performance, edge-cases, specific files) or general notes.
- Anyone in the community is free to review the PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Lance dataset reader’s open lifecycle, pickling, and remote blob I/O path used during training data loading; behavior is improved but errors or regressions would affect all Lance video datasets.
> 
> **Overview**
> **Lance video loading** gets three reliability and performance fixes aimed at large datasets and multi-worker training.
> 
> **`_ensure_open` is fail-closed:** frames permutation and thread pools are only published after setup completes, so a transient error (e.g. rate limits) no longer leaves a half-open reader that fails every later read; the next access retries from scratch.
> 
> **Video row IDs are built once in the reader constructor** (with the same metadata consistency check as before) and **kept across pickling**, so DataLoader workers reuse the map instead of each scanning the `videos` table.
> 
> **Blob handles are opened lazily:** `_SparseBlobSource` takes a callable fallback; `_prepare_files` wires `partial(self._blob_handle, key)` so `fetch_blob_files` runs on the first cache miss, not for every new file per batch when prefetched ranges cover all reads.
> 
> Tests cover failed-open retry behavior, pickle retention of `_video_row_ids`, and single-handle fallback reads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75d81f44437e88859ca72fcb5ae9cbff32d287b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->