### PR TITLE
dataset-via keep --root as a string so object-store URIs are not mangled

### DIFF
--- a/src/lerobot/scripts/lerobot_dataset_viz.py
+++ b/src/lerobot/scripts/lerobot_dataset_viz.py
@@ -321,9 +321,9 @@ def main():
     )
     parser.add_argument(
         "--root",
-        type=Path,
+        type=str,
         default=None,
-        help="Root directory for the dataset stored locally (e.g. `--root data`). By default, the dataset will be loaded from hugging face cache folder, or downloaded from the hub if available.",
+        help="Root directory for the dataset stored locally (e.g. `--root data`), or an object-store URI for storage formats that read in place (e.g. `--root s3://bucket/dataset`). Converting to Path would mangle URIs, so this stays a string. By default, the dataset will be loaded from hugging face cache folder, or downloaded from the hub if available.",
     )
     parser.add_argument(
         "--output-dir",


### PR DESCRIPTION


## Summary / Motivation


--root was parsed as a Path, which turns s3://bucket/dataset into s3:/bucket/dataset and breaks remote-root detection. It is now a plain string, matching how LeRobotDataset takes root. Local paths behave the same as before.

## Related issues

- Fixes / Closes: # (if any)
- Related: # (if any)

## What changed

- Short, concrete bullets explaining the functional changes (how the behavior or output differs now).
- Short note if this introduces breaking changes and migration steps.

## How was this tested (or how to run locally)

- Tests added: list new tests or test files. `pytest -q tests/ -k <keyword>`
- Manual checks / dataset runs performed.
- Instructions for the reviewer for reproducing with a quick example or CLI (if applicable)

## Checklist (required before merge)

- [ ] Linting/formatting run (`pre-commit run -a`)
- [ ] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: # (insert PR number/link)

## Reviewer notes

- Anything the reviewer should focus on (performance, edge-cases, specific files) or general notes.
- Anyone in the community is free to review the PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CLI argument type change in the dataset visualization script; no auth or data-path logic beyond preserving URI strings.
> 
> **Overview**
> **`lerobot-dataset-viz`** now parses **`--root`** as a plain string instead of **`pathlib.Path`**, so object-store roots like `s3://bucket/dataset` are passed through unchanged to **`LeRobotDataset`**.
> 
> Previously, **`Path`** normalization could turn `s3://…` into `s3:/…` and break remote-root handling. Local filesystem paths still work the same when given as strings. The CLI help documents both local directories and object-store URIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31010a7a0676217dc6ae1d77db1040010b96b557. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->