### PR TITLE
docs: document lancedb dataset backend

### DIFF
--- a/docs/source/lerobot-dataset-v3.mdx
+++ b/docs/source/lerobot-dataset-v3.mdx
@@ -19,7 +19,7 @@ This docs will guide you to:
 - **Hub-native streaming**: Consume datasets directly from the Hub with `StreamingLeRobotDataset`.
 - **Lower file-system pressure**: Fewer, larger files ⇒ faster initialization and fewer issues at scale.
 - **Unified organization**: Clean directory layout with consistent path templates across data and videos.
-- **Pluggable storage formats**: Datasets can also be stored as [Lance](https://lance.org) tables for random access directly from object storage (see [Lance storage format](#lance-storage-format)).
+- **Pluggable storage formats**: Datasets can also be stored as [Lance](https://lance.org) tables for random access directly from object storage (see [LanceDB dataset backend](#lancedb-dataset-backend)).
 
 ## Installation
 
@@ -172,7 +172,7 @@ lerobot-train \
   </figure>
 </div>
 
-## Lance storage format
+## LanceDB dataset backend
 
 A `v3` dataset can also be stored as [Lance](https://lance.org) tables. The tabular data lives in a `frames.lance` table, the MP4 videos in a blob-encoded `videos.lance` table, and `meta/` stays exactly the same. The format is declared by `"storage_format": "lance"` in `meta/info.json`, and `LeRobotDataset` picks the reader from it. The public API, the item dictionaries and the training pipeline are the same as for the default format.
 
@@ -182,7 +182,7 @@ What it gives you:
 - **Convert once, at about the cost of a file copy.** Videos are stored as blobs without re-encoding, so items are bit-identical to the source. DROID converts in 34 minutes.
 - **The training tables are also queryable.** Filter, search and add columns with LanceDB on the same tables the trainer reads, and visualize any episode in Foxglove straight from where the data lives.
 
-For how this works, benchmarks and examples, see the [LanceDB LeRobot guide](https://docs.lancedb.com/integrations/lerobotdataset).
+For how this works, benchmarks and examples, see the [LanceDB LeRobot guide](https://docs.lancedb.com/training/lerobot).
 
 Reading Lance datasets needs the `lancedb` extra (`pip install "lerobot[lancedb]"`). The format is read-only: record and edit datasets in the default format, then convert them with the [`lerobot-lancedb`](https://pypi.org/project/lerobot-lancedb/) package:
 
@@ -214,6 +214,8 @@ lerobot-train \
   --dataset.repo_type=bucket \
   --policy.type=act
 ```
+
+Visualization works the same way: `lerobot-dataset-viz --display-mode foxglove` serves any episode of a Lance dataset to [Foxglove](https://foxglove.dev) straight from where it lives, fetching only the frames on screen, with no MCAP export or download.
 
 For remote roots only `meta/` is materialized locally, from the dataset's `meta` table. Data files are never downloaded. The default Parquet/MP4 format on buckets is streaming-only, so the map-style path above applies to `storage_format: "lance"`.
 
@@ -383,4 +385,4 @@ Without calling `finalize()`, your parquet files will be incomplete and the data
 
 ### Lance
 
-Lance is now supported natively as a storage format, see [Lance storage format](#lance-storage-format) above. The `LeRobotLanceDataset` classes from the `lerobot-lancedb` package are no longer needed for reading. That package now provides the converter.
+Lance is now supported natively as a storage format, see [LanceDB dataset backend](#lancedb-dataset-backend) above. The `LeRobotLanceDataset` classes from the `lerobot-lancedb` package are no longer needed for reading. That package now provides the converter.

--- a/docs/source/lerobot-dataset-v3.mdx
+++ b/docs/source/lerobot-dataset-v3.mdx
@@ -172,53 +172,6 @@ lerobot-train \
   </figure>
 </div>
 
-## LanceDB dataset backend
-
-A `v3` dataset can also be stored as [LanceDB](https://lancedb.com) tables. LanceDB is a multimodal data lakehouse built on the Lance format for AI access patterns: fast random access to any row and its video bytes, and scalar, vector and full-text indexes on the same tables, so EDA, mining, curation and training run directly from object storage. The layout keeps `meta/` unchanged and adds a `frames` table for the tabular data and a `videos` table holding the MP4s as blobs. `"storage_format": "lance"` in `meta/info.json` selects the reader; the `LeRobotDataset` API, the items and the training pipeline are unchanged.
-
-- **Train straight from object storage with the GPUs fed.** Random frames are read in place from the Hub, HF Storage Buckets or any object store, only the bytes each batch needs, so every batch is a global shuffle and nothing is downloaded first.
-- **Convert at about the cost of a file copy.** Videos are not re-encoded, so items are bit-identical to the source. DROID converts in 34 minutes.
-- **Zero-copy feature engineering.** Add columns such as scores, embeddings or corrected labels to the tables the trainer reads, without rewriting the videos or copying the dataset, then filter and search on them with the indexes. The reader ignores columns it does not know.
-
-For how this works, benchmarks and examples, see the [LanceDB LeRobot guide](https://docs.lancedb.com/training/lerobot).
-
-Camera features must be video-backed. Datasets that store camera frames as images are not supported by the reader and need to be re-encoded as video before conversion.
-
-Reading Lance datasets needs the `lancedb` extra (`pip install "lerobot[lancedb]"`). The format is read-only: record and edit datasets in the default format, then convert them with the [`lerobot-lancedb`](https://pypi.org/project/lerobot-lancedb/) package:
-
-```bash
-pip install "lerobot-lancedb"
-lerobot-lance-convert --repo-id lerobot/pusht --out ./pusht-lance  # or --root <local dataset dir>
-```
-
-Loading uses the same class:
-
-```python
-from lerobot.datasets import LeRobotDataset
-
-# Hub dataset repo
-dataset = LeRobotDataset("lance-format/pusht-lance")
-
-# HF Storage Bucket, read in place
-dataset = LeRobotDataset("my-org/my-bucket/pusht-lance", repo_type="bucket")
-
-# any object store, read in place
-dataset = LeRobotDataset("lerobot/pusht", root="s3://my-bucket/pusht-lance")
-```
-
-The HF Storage Bucket options work in `lerobot-train`:
-
-```bash
-lerobot-train \
-  --dataset.repo_id=my-org/my-bucket/pusht-lance \
-  --dataset.repo_type=bucket \
-  --policy.type=act
-```
-
-Visualization works the same way: `lerobot-dataset-viz --display-mode foxglove` serves any episode of a Lance dataset to [Foxglove](https://foxglove.dev) straight from where it lives, fetching only the frames on screen, with no MCAP export or download.
-
-For remote roots only `meta/` is materialized locally, from the dataset's `meta` table. Data files are never downloaded. The default Parquet/MP4 format on buckets is streaming-only, so the map-style path above applies to `storage_format: "lance"`.
-
 ## Image transforms
 
 Image transforms are data augmentations applied to camera frames during training to improve model robustness and generalization. LeRobot supports various transforms including brightness, contrast, saturation, hue, and sharpness adjustments.
@@ -383,6 +336,51 @@ Without calling `finalize()`, your parquet files will be incomplete and the data
 
 ## Other formats and implementations
 
-### Lance
+### LanceDB dataset backend
 
-Lance is now supported natively as a storage format for video-backed datasets, see [LanceDB dataset backend](#lancedb-dataset-backend) above. The `LeRobotLanceDataset` classes from the `lerobot-lancedb` package are no longer needed for reading, and image-backed datasets are not supported by the native reader. That package now provides the converter.
+A `v3` dataset can also be stored as [LanceDB](https://lancedb.com) tables. LanceDB is a multimodal data lakehouse built on the Lance format for AI access patterns: fast random access to any row and its video bytes, and scalar, vector and full-text indexes on the same tables, so EDA, mining, curation and training run directly from object storage. The layout keeps `meta/` unchanged and adds a `frames` table for the tabular data and a `videos` table holding the MP4s as blobs. `"storage_format": "lance"` in `meta/info.json` selects the reader; the `LeRobotDataset` API, the items and the training pipeline are unchanged.
+
+- **Train straight from the Hub or HF Storage Buckets with the GPUs fed.** Random frames are read in place, only the bytes each batch needs, so every batch is a global shuffle and nothing is downloaded first.
+- **Convert at about the cost of a file copy.** Videos are not re-encoded, so items are bit-identical to the source. DROID converts in 34 minutes.
+- **Zero-copy feature engineering.** Add columns such as scores, embeddings or corrected labels to the tables the trainer reads, without rewriting the videos or copying the dataset, then filter and search on them with the indexes. The reader ignores columns it does not know.
+
+For how this works, benchmarks and examples, see the [LanceDB LeRobot guide](https://docs.lancedb.com/training/lerobot).
+
+Camera features must be video-backed. Datasets that store camera frames as images are not supported by the reader and need to be re-encoded as video before conversion.
+
+Reading Lance datasets needs the `lancedb` extra (`pip install "lerobot[lancedb]"`). The format is read-only: record and edit datasets in the default format, then convert them with the [`lerobot-lancedb`](https://pypi.org/project/lerobot-lancedb/) package:
+
+```bash
+pip install "lerobot-lancedb"
+lerobot-lance-convert --repo-id lerobot/pusht --out ./pusht-lance  # or --root <local dataset dir>
+```
+
+Loading uses the same class:
+
+```python
+from lerobot.datasets import LeRobotDataset
+
+# Hub dataset repo
+dataset = LeRobotDataset("lance-format/pusht-lance")
+
+# HF Storage Bucket, read in place
+dataset = LeRobotDataset("my-org/pusht-lance", repo_type="bucket")
+
+# the same bucket as a root URI (other object store URIs work the same way)
+dataset = LeRobotDataset("lerobot/pusht", root="hf://buckets/my-org/pusht-lance")
+```
+
+The HF Storage Bucket options work in `lerobot-train`:
+
+```bash
+lerobot-train \
+  --dataset.repo_id=my-org/pusht-lance \
+  --dataset.repo_type=bucket \
+  --policy.type=act
+```
+
+Visualization works with both viewers. `lerobot-dataset-viz --repo-id lance-format/pusht-lance --episode-index 0` opens an episode in Rerun as usual, and `--display-mode foxglove` serves it to [Foxglove](https://foxglove.dev) over WebSocket. Either way only the frames on screen are fetched, with no MCAP export or download.
+
+For remote roots only `meta/` is materialized locally, from the dataset's `meta` table. Data files are never downloaded. The default Parquet/MP4 format on buckets is streaming-only, so the map-style path above applies to `storage_format: "lance"`.
+
+The `LeRobotLanceDataset` classes from the `lerobot-lancedb` package are no longer needed for reading; that package now provides the converter.

--- a/docs/source/lerobot-dataset-v3.mdx
+++ b/docs/source/lerobot-dataset-v3.mdx
@@ -19,7 +19,7 @@ This docs will guide you to:
 - **Hub-native streaming**: Consume datasets directly from the Hub with `StreamingLeRobotDataset`.
 - **Lower file-system pressure**: Fewer, larger files ⇒ faster initialization and fewer issues at scale.
 - **Unified organization**: Clean directory layout with consistent path templates across data and videos.
-- **Pluggable storage formats**: Datasets can also be stored as [LanceDB](https://lancedb.com) tables for random access and indexing directly from object storage (see [LanceDB dataset backend](#lancedb-dataset-backend)).
+- **Dataset storage backends**: Datasets can also be stored as [LanceDB](https://lancedb.com) tables for random access and indexing directly from object storage (see [LanceDB dataset backend](#lancedb-dataset-backend)).
 
 ## Installation
 
@@ -176,7 +176,7 @@ lerobot-train \
 
 A `v3` dataset can also be stored as [LanceDB](https://lancedb.com) tables. LanceDB is a multimodal data lakehouse built on the Lance format for AI access patterns: fast random access to any row and its video bytes, plus scalar, vector and full-text indexes on the same tables, so EDA, mining, curation and training all run directly from object storage. The layout keeps `meta/` unchanged and adds a `frames` table for the tabular data and a blob-encoded `videos` table for the MP4s. `"storage_format": "lance"` in `meta/info.json` selects the reader; the `LeRobotDataset` API, the items and the training pipeline are unchanged.
 
-- **Train straight from object storage with the GPUs fed.** Random frames are read in place from the Hub, HF Storage Buckets or any object store, only the bytes each batch needs, so every batch is a global shuffle and nothing is downloaded first. Example: 10,000 steps of SmolVLA on DROID (27.6M frames) from S3 on 8xH100 in 1 h 27 m, with the GPUs waiting on data 1.7% of the time.
+- **Train straight from object storage with the GPUs fed.** Random frames are read in place from the Hub, HF Storage Buckets or any object store, only the bytes each batch needs, so every batch is a global shuffle and nothing is downloaded first.
 - **Convert once, at about the cost of a file copy.** Videos are stored as blobs without re-encoding, so items are bit-identical to the source. DROID converts in 34 minutes.
 - **One copy for everything.** Filter, search and add columns with LanceDB on the tables the trainer reads, and scrub any episode in Foxglove from where it lives.
 

--- a/docs/source/lerobot-dataset-v3.mdx
+++ b/docs/source/lerobot-dataset-v3.mdx
@@ -176,7 +176,13 @@ lerobot-train \
 
 A `v3` dataset can also be stored as [Lance](https://lance.org) tables. The tabular data lives in a `frames.lance` table, the MP4 videos in a blob-encoded `videos.lance` table, and `meta/` stays exactly the same. The format is declared by `"storage_format": "lance"` in `meta/info.json`, and `LeRobotDataset` picks the reader from it. The public API, the item dictionaries and the training pipeline are the same as for the default format.
 
-What this adds is random access without downloading the dataset. A Lance dataset on the Hub, in an HF Storage Bucket or in any object store supports indexing, a global shuffle over the whole dataset and episode selection, fetching only the byte ranges each batch needs.
+What it gives you:
+
+- **Train straight from object storage while keeping the GPUs fed.** Lance reads random frames in place from the Hub, HF Storage Buckets or any object store, fetching only the bytes each batch needs, so every batch is a global shuffle over the whole dataset and nothing is downloaded first. As an example, 10,000 steps of SmolVLA on DROID (27.6M frames) trained from S3 on 8xH100 in 1 h 27 m, with the GPUs waiting on data 1.7% of the time.
+- **Convert once, at about the cost of a file copy.** Videos are stored as blobs without re-encoding, so items are bit-identical to the source. DROID converts in 34 minutes.
+- **The training tables are also queryable.** Filter, search and add columns with LanceDB on the same tables the trainer reads, and visualize any episode in Foxglove straight from where the data lives.
+
+For how this works, benchmarks and examples, see the [LanceDB LeRobot guide](https://docs.lancedb.com/integrations/lerobotdataset).
 
 Reading Lance datasets needs the `lancedb` extra (`pip install "lerobot[lancedb]"`). The format is read-only: record and edit datasets in the default format, then convert them with the [`lerobot-lancedb`](https://pypi.org/project/lerobot-lancedb/) package:
 
@@ -210,8 +216,6 @@ lerobot-train \
 ```
 
 For remote roots only `meta/` is materialized locally, from the dataset's `meta` table. Data files are never downloaded. The default Parquet/MP4 format on buckets is streaming-only, so the map-style path above applies to `storage_format: "lance"`.
-
-For converting datasets and working with them as queryable tables (search, enrichment, exploratory analysis), see the [LanceDB LeRobot guide](https://docs.lancedb.com/integrations/lerobotdataset).
 
 ## Image transforms
 

--- a/docs/source/lerobot-dataset-v3.mdx
+++ b/docs/source/lerobot-dataset-v3.mdx
@@ -182,6 +182,8 @@ A `v3` dataset can also be stored as [LanceDB](https://lancedb.com) tables. Lanc
 
 For how this works, benchmarks and examples, see the [LanceDB LeRobot guide](https://docs.lancedb.com/training/lerobot).
 
+Camera features must be video-backed. Datasets that store camera frames as images are not supported by the reader and need to be re-encoded as video before conversion.
+
 Reading Lance datasets needs the `lancedb` extra (`pip install "lerobot[lancedb]"`). The format is read-only: record and edit datasets in the default format, then convert them with the [`lerobot-lancedb`](https://pypi.org/project/lerobot-lancedb/) package:
 
 ```bash
@@ -383,4 +385,4 @@ Without calling `finalize()`, your parquet files will be incomplete and the data
 
 ### Lance
 
-Lance is now supported natively as a storage format, see [LanceDB dataset backend](#lancedb-dataset-backend) above. The `LeRobotLanceDataset` classes from the `lerobot-lancedb` package are no longer needed for reading. That package now provides the converter.
+Lance is now supported natively as a storage format for video-backed datasets, see [LanceDB dataset backend](#lancedb-dataset-backend) above. The `LeRobotLanceDataset` classes from the `lerobot-lancedb` package are no longer needed for reading, and image-backed datasets are not supported by the native reader. That package now provides the converter.

--- a/docs/source/lerobot-dataset-v3.mdx
+++ b/docs/source/lerobot-dataset-v3.mdx
@@ -380,7 +380,3 @@ lerobot-train \
 ```
 
 Visualization works with both viewers. `lerobot-dataset-viz --repo-id lance-format/pusht-lance --episode-index 0` opens an episode in Rerun as usual, and `--display-mode foxglove` serves it to [Foxglove](https://foxglove.dev) over WebSocket. Either way only the frames on screen are fetched, with no MCAP export or download.
-
-For remote roots only `meta/` is materialized locally, from the dataset's `meta` table. Data files are never downloaded. The default Parquet/MP4 format on buckets is streaming-only, so the map-style path above applies to `storage_format: "lance"`.
-
-The `LeRobotLanceDataset` classes from the `lerobot-lancedb` package are no longer needed for reading; that package now provides the converter.

--- a/docs/source/lerobot-dataset-v3.mdx
+++ b/docs/source/lerobot-dataset-v3.mdx
@@ -19,7 +19,7 @@ This docs will guide you to:
 - **Hub-native streaming**: Consume datasets directly from the Hub with `StreamingLeRobotDataset`.
 - **Lower file-system pressure**: Fewer, larger files ⇒ faster initialization and fewer issues at scale.
 - **Unified organization**: Clean directory layout with consistent path templates across data and videos.
-- **Pluggable storage formats**: Datasets can also be stored as [Lance](https://lance.org) tables for random access directly from object storage (see [LanceDB dataset backend](#lancedb-dataset-backend)).
+- **Pluggable storage formats**: Datasets can also be stored as [LanceDB](https://lancedb.com) tables for random access and indexing directly from object storage (see [LanceDB dataset backend](#lancedb-dataset-backend)).
 
 ## Installation
 
@@ -174,13 +174,11 @@ lerobot-train \
 
 ## LanceDB dataset backend
 
-A `v3` dataset can also be stored as [Lance](https://lance.org) tables. The tabular data lives in a `frames.lance` table, the MP4 videos in a blob-encoded `videos.lance` table, and `meta/` stays exactly the same. The format is declared by `"storage_format": "lance"` in `meta/info.json`, and `LeRobotDataset` picks the reader from it. The public API, the item dictionaries and the training pipeline are the same as for the default format.
+A `v3` dataset can also be stored as [LanceDB](https://lancedb.com) tables. LanceDB is a multimodal data lakehouse built on the Lance format for AI access patterns: fast random access to any row and its video bytes, plus scalar, vector and full-text indexes on the same tables, so EDA, mining, curation and training all run directly from object storage. The layout keeps `meta/` unchanged and adds a `frames` table for the tabular data and a blob-encoded `videos` table for the MP4s. `"storage_format": "lance"` in `meta/info.json` selects the reader; the `LeRobotDataset` API, the items and the training pipeline are unchanged.
 
-What it gives you:
-
-- **Train straight from object storage while keeping the GPUs fed.** Lance reads random frames in place from the Hub, HF Storage Buckets or any object store, fetching only the bytes each batch needs, so every batch is a global shuffle over the whole dataset and nothing is downloaded first. As an example, 10,000 steps of SmolVLA on DROID (27.6M frames) trained from S3 on 8xH100 in 1 h 27 m, with the GPUs waiting on data 1.7% of the time.
+- **Train straight from object storage with the GPUs fed.** Random frames are read in place from the Hub, HF Storage Buckets or any object store, only the bytes each batch needs, so every batch is a global shuffle and nothing is downloaded first. Example: 10,000 steps of SmolVLA on DROID (27.6M frames) from S3 on 8xH100 in 1 h 27 m, with the GPUs waiting on data 1.7% of the time.
 - **Convert once, at about the cost of a file copy.** Videos are stored as blobs without re-encoding, so items are bit-identical to the source. DROID converts in 34 minutes.
-- **The training tables are also queryable.** Filter, search and add columns with LanceDB on the same tables the trainer reads, and visualize any episode in Foxglove straight from where the data lives.
+- **One copy for everything.** Filter, search and add columns with LanceDB on the tables the trainer reads, and scrub any episode in Foxglove from where it lives.
 
 For how this works, benchmarks and examples, see the [LanceDB LeRobot guide](https://docs.lancedb.com/training/lerobot).
 

--- a/docs/source/lerobot-dataset-v3.mdx
+++ b/docs/source/lerobot-dataset-v3.mdx
@@ -204,7 +204,7 @@ dataset = LeRobotDataset("my-org/my-bucket/pusht-lance", repo_type="bucket")
 dataset = LeRobotDataset("lerobot/pusht", root="s3://my-bucket/pusht-lance")
 ```
 
-The same options work in `lerobot-train` and `lerobot-dataset-viz`:
+The HF Storage Bucket options work in `lerobot-train`:
 
 ```bash
 lerobot-train \

--- a/docs/source/lerobot-dataset-v3.mdx
+++ b/docs/source/lerobot-dataset-v3.mdx
@@ -174,11 +174,11 @@ lerobot-train \
 
 ## LanceDB dataset backend
 
-A `v3` dataset can also be stored as [LanceDB](https://lancedb.com) tables. LanceDB is a multimodal data lakehouse built on the Lance format for AI access patterns: fast random access to any row and its video bytes, plus scalar, vector and full-text indexes on the same tables, so EDA, mining, curation and training all run directly from object storage. The layout keeps `meta/` unchanged and adds a `frames` table for the tabular data and a blob-encoded `videos` table for the MP4s. `"storage_format": "lance"` in `meta/info.json` selects the reader; the `LeRobotDataset` API, the items and the training pipeline are unchanged.
+A `v3` dataset can also be stored as [LanceDB](https://lancedb.com) tables. LanceDB is a multimodal data lakehouse built on the Lance format for AI access patterns: fast random access to any row and its video bytes, and scalar, vector and full-text indexes on the same tables, so EDA, mining, curation and training run directly from object storage. The layout keeps `meta/` unchanged and adds a `frames` table for the tabular data and a `videos` table holding the MP4s as blobs. `"storage_format": "lance"` in `meta/info.json` selects the reader; the `LeRobotDataset` API, the items and the training pipeline are unchanged.
 
 - **Train straight from object storage with the GPUs fed.** Random frames are read in place from the Hub, HF Storage Buckets or any object store, only the bytes each batch needs, so every batch is a global shuffle and nothing is downloaded first.
-- **Convert once, at about the cost of a file copy.** Videos are stored as blobs without re-encoding, so items are bit-identical to the source. DROID converts in 34 minutes.
-- **One copy for everything.** Filter, search and add columns with LanceDB on the tables the trainer reads, and scrub any episode in Foxglove from where it lives.
+- **Convert at about the cost of a file copy.** Videos are not re-encoded, so items are bit-identical to the source. DROID converts in 34 minutes.
+- **Zero-copy feature engineering.** Add columns such as scores, embeddings or corrected labels to the tables the trainer reads, without rewriting the videos or copying the dataset, then filter and search on them with the indexes. The reader ignores columns it does not know.
 
 For how this works, benchmarks and examples, see the [LanceDB LeRobot guide](https://docs.lancedb.com/training/lerobot).
 

--- a/docs/source/lerobot-dataset-v3.mdx
+++ b/docs/source/lerobot-dataset-v3.mdx
@@ -19,6 +19,7 @@ This docs will guide you to:
 - **Hub-native streaming**: Consume datasets directly from the Hub with `StreamingLeRobotDataset`.
 - **Lower file-system pressure**: Fewer, larger files ⇒ faster initialization and fewer issues at scale.
 - **Unified organization**: Clean directory layout with consistent path templates across data and videos.
+- **Pluggable storage formats**: Datasets can also be stored as [Lance](https://lance.org) tables for random access directly from object storage (see [Lance storage format](#lance-storage-format)).
 
 ## Installation
 
@@ -170,6 +171,47 @@ lerobot-train \
     </figcaption>
   </figure>
 </div>
+
+## Lance storage format
+
+A `v3` dataset can also be stored as [Lance](https://lance.org) tables. The tabular data lives in a `frames.lance` table, the MP4 videos in a blob-encoded `videos.lance` table, and `meta/` stays exactly the same. The format is declared by `"storage_format": "lance"` in `meta/info.json`, and `LeRobotDataset` picks the reader from it. The public API, the item dictionaries and the training pipeline are the same as for the default format.
+
+What this adds is random access without downloading the dataset. A Lance dataset on the Hub, in an HF Storage Bucket or in any object store supports indexing, a global shuffle over the whole dataset and episode selection, fetching only the byte ranges each batch needs.
+
+Reading Lance datasets needs the `lancedb` extra (`pip install "lerobot[lancedb]"`). The format is read-only: record and edit datasets in the default format, then convert them with the [`lerobot-lancedb`](https://pypi.org/project/lerobot-lancedb/) package:
+
+```bash
+pip install "lerobot-lancedb"
+lerobot-lance-convert --repo-id lerobot/pusht --out ./pusht-lance  # or --root <local dataset dir>
+```
+
+Loading uses the same class:
+
+```python
+from lerobot.datasets import LeRobotDataset
+
+# Hub dataset repo
+dataset = LeRobotDataset("lance-format/pusht-lance")
+
+# HF Storage Bucket, read in place
+dataset = LeRobotDataset("my-org/my-bucket/pusht-lance", repo_type="bucket")
+
+# any object store, read in place
+dataset = LeRobotDataset("lerobot/pusht", root="s3://my-bucket/pusht-lance")
+```
+
+The same options work in `lerobot-train` and `lerobot-dataset-viz`:
+
+```bash
+lerobot-train \
+  --dataset.repo_id=my-org/my-bucket/pusht-lance \
+  --dataset.repo_type=bucket \
+  --policy.type=act
+```
+
+For remote roots only `meta/` is materialized locally, from the dataset's `meta` table. Data files are never downloaded. The default Parquet/MP4 format on buckets is streaming-only, so the map-style path above applies to `storage_format: "lance"`.
+
+For converting datasets and working with them as queryable tables (search, enrichment, exploratory analysis), see the [LanceDB LeRobot guide](https://docs.lancedb.com/integrations/lerobotdataset).
 
 ## Image transforms
 
@@ -337,34 +379,4 @@ Without calling `finalize()`, your parquet files will be incomplete and the data
 
 ### Lance
 
-Lance is a useful format for multimodal AI datasets, especially for large-scale training requiring high performance IO and random access.
-
-The `lerobot-lancedb` package implements `LeRobotLanceDataset` (for JPEG images) and `LeRobotLanceVideoDataset` (for mp4 videos).
-Those two storage layouts both subclass LeRobotDataset and can provide data loading speed ups.
-
-`LeRobotLanceDataset` is a drop-in replacement for `LeRobotDataset`:
-
-```python
-from lerobot.datasets import LeRobotDatasetMetadata
-from lerobot.policies.diffusion.configuration_diffusion import DiffusionConfig
-from lerobot_lancedb import LeRobotLanceDataset, LeRobotLanceVideoDataset
-
-cfg = DiffusionConfig(...)
-meta = LeRobotDatasetMetadata(root=local_dataset_path)  # or use repo_id=... to load metadata from the Hub
-delta_timestamps = {...}
-
-# Use LeRobotLanceDataset for image datasets
-dataset = LeRobotLanceDataset(
-    root=local_dataset_path,                            # or use repo_id=... to stream from the Hub
-    delta_timestamps=delta_timestamps,
-    return_uint8=True,
-)
-# Or use LeRobotLanceVideoDataset for video datasets:
-dataset = LeRobotLanceVideoDataset(
-    root=local_dataset_path,                            # or use repo_id=... to stream from the Hub
-    delta_timestamps=delta_timestamps,
-    return_uint8=True,
-)
-```
-
-Join the discussion on [Github](https://github.com/huggingface/lerobot/issues/3608) and explore the `lerobot-lancedb` documentation [here](https://lancedb.github.io/lerobot-lancedb/).
+Lance is now supported natively as a storage format, see [Lance storage format](#lance-storage-format) above. The `LeRobotLanceDataset` classes from the `lerobot-lancedb` package are no longer needed for reading. That package now provides the converter.


### PR DESCRIPTION

## Summary / Motivation

Document recently added LanceDB dataset backend

## Related issues

- Fixes / Closes: # (if any)
- Related: # (if any)

## What changed

- Short, concrete bullets explaining the functional changes (how the behavior or output differs now).
- Short note if this introduces breaking changes and migration steps.

## How was this tested (or how to run locally)

- Tests added: list new tests or test files. `pytest -q tests/ -k <keyword>`
- Manual checks / dataset runs performed.
- Instructions for the reviewer for reproducing with a quick example or CLI (if applicable)

## Checklist (required before merge)

- [ ] Linting/formatting run (`pre-commit run -a`)
- [ ] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: # (insert PR number/link)

## Reviewer notes

- Anything the reviewer should focus on (performance, edge-cases, specific files) or general notes.
- Anyone in the community is free to review the PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime or API code modifications.
> 
> **Overview**
> Documents **native LanceDB** as a `v3` dataset storage backend in the LeRobot dataset guide, replacing the older `lerobot-lancedb` reader-focused section.
> 
> A new **LanceDB dataset backend** section explains layout (`frames` / `videos` tables, `storage_format: "lance"`), training from object storage without full downloads, conversion via `lerobot-lance-convert`, and loading with the standard `LeRobotDataset` API (Hub, HF buckets, `s3://` roots). It also covers `lerobot-train`, Foxglove viz, and constraints (video-backed cameras only, read-only, `lerobot[lancedb]`).
> 
> The **What’s new in v3** list now mentions LanceDB backends. The **Other formats / Lance** subsection is shortened to point readers to the native backend and notes that `LeRobotLanceDataset` is no longer needed for reading—`lerobot-lancedb` is for conversion only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0159312c84a3acceeeb676ccd809dfe8c59bb3d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->