### PR TITLE
fix(datasets): derive tight Backtrackable bounds from delta_indices

### DIFF
--- a/src/lerobot/datasets/streaming_dataset.py
+++ b/src/lerobot/datasets/streaming_dataset.py
@@ -24,7 +24,7 @@ import torch
 from datasets import load_dataset
 
 from lerobot.configs import DEFAULT_DEPTH_UNIT, DEPTH_METER_UNIT, DepthEncoderConfig
-from lerobot.utils.constants import HF_LEROBOT_HOME, LOOKAHEAD_BACKTRACKTABLE, LOOKBACK_BACKTRACKTABLE
+from lerobot.utils.constants import HF_LEROBOT_HOME
 
 from .dataset_metadata import CODEBASE_VERSION, LeRobotDatasetMetadata
 from .depth_utils import MM_PER_METRE, dequantize_depth
@@ -453,29 +453,24 @@ class StreamingLeRobotDataset(torch.utils.data.IterableDataset):
         rng.shuffle(frames_buffer)
         yield from frames_buffer
 
-    def _get_window_steps(
-        self, delta_timestamps: dict[str, list[float]] | None = None, dynamic_bounds: bool = False
-    ) -> tuple[int, int]:
-        if delta_timestamps is None:
+    def _get_window_steps(self) -> tuple[int, int]:
+        """Tightest lookback/lookahead windows (in frames) needed to serve `delta_indices`.
+
+        Derived from `delta_indices` (not `delta_timestamps * fps`) so the bounds match
+        exactly what `_get_delta_frames` indexes with, rounding included. Clamped to 1
+        since `Backtrackable` requires history >= 1 and lookahead > 0.
+        """
+        if self.delta_indices is None:
             return 1, 1
 
-        if not dynamic_bounds:
-            # Fix the windows
-            lookback = LOOKBACK_BACKTRACKTABLE
-            lookahead = LOOKAHEAD_BACKTRACKTABLE
-        else:
-            # Dynamically adjust the windows based on the given delta_timesteps
-            all_timestamps = sum(delta_timestamps.values(), [])
-            lookback = min(all_timestamps) * self.fps
-            lookahead = max(all_timestamps) * self.fps
-
-            # When lookback is >=0 it means no negative timesteps have been provided
-            lookback = 0 if lookback >= 0 else (lookback * -1)
-
+        all_indices = sum(self.delta_indices.values(), [])
+        # `_back_buf` also holds the current item, so peeking back n steps needs history n + 1.
+        lookback = max(1, 1 - min(all_indices))
+        lookahead = max(1, max(all_indices))
         return lookback, lookahead
 
     def _make_backtrackable_dataset(self, dataset: datasets.IterableDataset) -> Backtrackable:
-        lookback, lookahead = self._get_window_steps(self.delta_timestamps)
+        lookback, lookahead = self._get_window_steps()
         return Backtrackable(dataset, history=lookback, lookahead=lookahead)
 
     def _make_timestamps_from_indices(

--- a/src/lerobot/datasets/streaming_dataset.py
+++ b/src/lerobot/datasets/streaming_dataset.py
@@ -464,6 +464,9 @@ class StreamingLeRobotDataset(torch.utils.data.IterableDataset):
             return 1, 1
 
         all_indices = sum(self.delta_indices.values(), [])
+        if not all_indices:  # e.g. delta_timestamps={}: nothing to peek, minimal windows
+            return 1, 1
+
         # `_back_buf` also holds the current item, so peeking back n steps needs history n + 1.
         lookback = max(1, 1 - min(all_indices))
         lookahead = max(1, max(all_indices))

--- a/src/lerobot/utils/constants.py
+++ b/src/lerobot/utils/constants.py
@@ -101,10 +101,6 @@ IMAGENET_STATS = {
     "std": [[[0.229]], [[0.224]], [[0.225]]],  # (c,1,1)
 }
 
-# streaming datasets
-LOOKBACK_BACKTRACKTABLE = 100
-LOOKAHEAD_BACKTRACKTABLE = 100
-
 # openpi
 OPENPI_ATTENTION_MASK_VALUE = -2.3819763e38  # TODO(pepijn): Modify this when extending support to fp8 models
 

--- a/tests/datasets/test_streaming.py
+++ b/tests/datasets/test_streaming.py
@@ -487,6 +487,8 @@ def test_frames_with_delta_consistency_with_shards(
     "delta_indices, expected",
     [
         (None, (1, 1)),  # no deltas: minimal valid Backtrackable windows
+        ({}, (1, 1)),  # empty mapping: nothing to peek
+        ({"state": []}, (1, 1)),  # empty per-key lists: nothing to peek
         # history = deepest peek_back + 1 slot for the current item held in _back_buf
         ({"state": [-3, 0], "action": [0, 3, 6]}, (4, 6)),  # extremes across all keys
         ({"action": [0, 1, 2]}, (1, 2)),  # future-only: lookback clamped to 1

--- a/tests/datasets/test_streaming.py
+++ b/tests/datasets/test_streaming.py
@@ -24,6 +24,7 @@ pytest.importorskip("datasets", reason="datasets is required (install lerobot[da
 
 import lerobot.datasets.streaming_dataset as streaming_dataset_module
 from lerobot.datasets.dataset_metadata import LeRobotDatasetMetadata
+from lerobot.datasets.feature_utils import get_delta_indices
 from lerobot.datasets.streaming_dataset import StreamingLeRobotDataset
 from lerobot.datasets.utils import safe_shard
 from lerobot.utils.constants import ACTION
@@ -480,6 +481,31 @@ def test_frames_with_delta_consistency_with_shards(
         assert all(t[1] for t in key_checks), (
             f"Checking {list(filter(lambda t: not t[1], key_checks))[0][0]} left and right were found different (i: {i}, frame_idx: {frame_idx})"
         )
+
+
+@pytest.mark.parametrize(
+    "delta_indices, expected",
+    [
+        (None, (1, 1)),  # no deltas: minimal valid Backtrackable windows
+        # history = deepest peek_back + 1 slot for the current item held in _back_buf
+        ({"state": [-3, 0], "action": [0, 3, 6]}, (4, 6)),  # extremes across all keys
+        ({"action": [0, 1, 2]}, (1, 2)),  # future-only: lookback clamped to 1
+        ({"state": [-5, 0]}, (6, 1)),  # past-only: lookahead clamped to 1
+    ],
+)
+def test_window_steps_tight_bounds(delta_indices, expected):
+    ds = SimpleNamespace(delta_indices=delta_indices)
+    assert StreamingLeRobotDataset._get_window_steps(ds) == expected
+
+
+def test_window_steps_match_delta_indices_rounding():
+    # -0.999s @ 30fps rounds to index -30; a bound derived from the float product
+    # (-29.97 truncated to 29) would silently pad a real frame. Bounds must come
+    # from get_delta_indices so they match what _get_delta_frames indexes with.
+    delta_indices = get_delta_indices({"state": [-0.999, 0.999]}, fps=30)
+    assert delta_indices == {"state": [-30, 30]}
+    ds = SimpleNamespace(delta_indices=delta_indices)
+    assert StreamingLeRobotDataset._get_window_steps(ds) == (31, 30)
 
 
 class _StopConstructionError(Exception):

--- a/tests/datasets/test_streaming.py
+++ b/tests/datasets/test_streaming.py
@@ -384,6 +384,57 @@ def test_frames_with_delta_consistency(tmp_path, lerobot_dataset_factory, state_
         )
 
 
+def test_frames_with_delta_beyond_default_window(tmp_path, lerobot_dataset_factory):
+    """Deltas reaching farther than the old fixed 100-frame Backtrackable window.
+
+    With 300-frame episodes and 3.5 s deltas (105 frames at 30 fps), the fixed-bounds
+    implementation marked in-episode frames as padding because the buffer could not
+    reach them. Bounds derived from delta_indices must reproduce the map-style
+    dataset's padding masks exactly.
+    """
+    ds_num_frames = 600
+    ds_num_episodes = 2  # 300 frames per episode
+
+    local_path = tmp_path / "test"
+    repo_id = f"{DUMMY_REPO_ID}-long-deltas"
+
+    delta_timestamps = {
+        "state": [-3.5, 0],  # 105 frames back at 30 fps
+        ACTION: [0, 3.5],  # 105 frames ahead
+    }
+
+    ds = lerobot_dataset_factory(
+        root=local_path,
+        repo_id=repo_id,
+        total_episodes=ds_num_episodes,
+        total_frames=ds_num_frames,
+        delta_timestamps=delta_timestamps,
+    )
+    streaming_ds = StreamingLeRobotDataset(
+        repo_id=repo_id,
+        root=local_path,
+        buffer_size=10,
+        seed=42,
+        shuffle=False,
+        delta_timestamps=delta_timestamps,
+    )
+
+    far_delta_served = False
+    for streaming_frame in streaming_ds:
+        target_frame = ds[streaming_frame["index"]]
+        for key in ("state", ACTION):
+            pad_key = f"{key}_is_pad"
+            assert torch.equal(streaming_frame[pad_key], target_frame[pad_key]), (
+                f"Padding mask mismatch for {key} at index {streaming_frame['index']}"
+            )
+            valid = ~streaming_frame[pad_key]
+            assert torch.allclose(streaming_frame[key][valid], target_frame[key][valid])
+        # the -3.5s slot: served (not padded) once frame_index >= 105 within the episode
+        far_delta_served |= not streaming_frame["state_is_pad"][0]
+
+    assert far_delta_served, "no frame exercised a lookback beyond the old 100-frame window"
+
+
 @pytest.mark.parametrize(
     "state_deltas, action_deltas",
     [


### PR DESCRIPTION
## Summary / Motivation

`StreamingLeRobotDataset` always sized its `Backtrackable` buffers with hardcoded 100/100 lookback/lookahead (`LOOKBACK/LOOKAHEAD_BACKTRACKTABLE`), regardless of what `delta_timestamps` actually need. Profiling (see #3671) shows noticeable cost in `_get_delta_frames` / `can_peek_ahead` from the oversized windows: `can_peek_ahead` eagerly prefetches up to `lookahead` rows per shard.

The fixed window was also a **correctness bug**, not just overhead (thanks @ukanwat for catching this): any delta larger than 100 frames could never be served - `can_peek_back/ahead` fails against the fixed buffer and the frame is silently marked as padding even though it exists within the episode. With 300-frame episodes and 3.5 s deltas (105 frames at 30 fps), streaming `_is_pad` masks diverge completely from the map-style dataset on `main`; with this branch they match.

An unreachable `dynamic_bounds` path already existed in `_get_window_steps`, but it computed bounds from `delta_timestamps * fps` as floats, truncating where `get_delta_indices` rounds - off by one for e.g. `-0.999s` at 30 fps, which would silently pad a real frame. This PR makes tight bounds the default and derives them from `delta_indices`, the exact integer offsets `_get_delta_frames` indexes with.

## Related issues

- Fixes #3671

## What changed

- `_get_window_steps` now computes the windows from `self.delta_indices`: `lookback = max(1, 1 - min(all_indices))`, `lookahead = max(1, max(all_indices))`.
- History gets `+1` because `_back_buf` also holds the current item, so `peek_back(n)` needs `n + 1` slots (an exact-sized buffer fails the deepest lookback and pads a real frame - caught by the existing `test_frames_with_delta_consistency` suite).
- Empty `delta_timestamps` mappings (`{}` or all-empty lists) fall back to the minimal `(1, 1)` windows instead of raising on `min()`/`max()`.
- Removed the dead `dynamic_bounds` parameter and the `LOOKBACK_BACKTRACKTABLE` / `LOOKAHEAD_BACKTRACKTABLE` constants (unused elsewhere).
- No API change; episode-boundary padding is unchanged (handled by the `episode_index` check in `_get_delta_frames`, independent of buffer size). For a typical config the per-shard buffer drops from 200 rows to roughly the delta window itself. Deltas beyond 100 frames now return real data instead of padding.

## How was this tested (or how to run locally)

- Tests added in `tests/datasets/test_streaming.py`:
  - parametrized `test_window_steps_tight_bounds` (no-deltas, empty mappings, mixed, future-only, past-only)
  - `test_window_steps_match_delta_indices_rounding` (locks the `round()` vs float-truncation behavior)
  - `test_frames_with_delta_beyond_default_window` (2 × 300-frame episodes, ±3.5 s deltas = 105 frames: compares streaming `_is_pad` masks and values against the map-style dataset; **fails on `main`, passes here**)
- Full streaming suite passes locally: `pytest -q tests/datasets/test_streaming.py` → 37 passed. The pre-existing `test_frames_with_delta_consistency*` tests compare streaming vs map-style frames including `_is_pad` masks across episode boundaries, which exercises the tight bounds end to end.

## Checklist (required before merge)

- [x] Linting/formatting run (`ruff check` + `ruff format --check` on changed files; local `pre-commit` env bootstrap unavailable on this machine)
- [x] All tests pass locally (`pytest -q tests/datasets/test_streaming.py`)
- [ ] Documentation updated (N/A - internal buffer sizing, no API change)
- [ ] CI is green
- [ ] Community Review

## Reviewer notes

- The subtle bit is the `+1` on history: `Backtrackable.__next__` appends the current item to `_back_buf`, so `can_peek_back(n)` requires `n + 1` buffered items. Sizing history to exactly `-min(delta_indices)` fails the deepest lookback.
