### PR TITLE
fix(robots): release cameras and bus when connect() fails partway

### DIFF
--- a/src/lerobot/cameras/opencv/configuration_opencv.py
+++ b/src/lerobot/cameras/opencv/configuration_opencv.py
@@ -56,6 +56,9 @@ class OpenCVCameraConfig(CameraConfig):
         - Only 3-channel color output (RGB/BGR) is currently supported.
         - FOURCC codes must be 4-character strings (e.g., "MJPG", "YUYV"). Some common FOUCC codes: https://learn.microsoft.com/en-us/windows/win32/medfound/video-fourccs#fourcc-constants
         - Setting FOURCC can help achieve higher frame rates on some cameras.
+        - When explicitly setting `backend=Cv2Backends.V4L2` on Linux, `index_or_path` must be an
+          integer index rather than a `/dev/videoN` path string, or OpenCV will fail to open the
+          device ("can't be used to capture by name").
     """
 
     index_or_path: int | Path

--- a/src/lerobot/robots/hope_jr/hope_jr_arm.py
+++ b/src/lerobot/robots/hope_jr/hope_jr_arm.py
@@ -95,14 +95,19 @@ class HopeJrArm(Robot):
         """
 
         self.bus.connect(handshake=False)
-        if not self.is_calibrated and calibrate:
-            self.calibrate()
+        try:
+            if not self.is_calibrated and calibrate:
+                self.calibrate()
 
-        # Connect the cameras
-        for cam in self.cameras.values():
-            cam.connect()
+            # Connect the cameras
+            for cam in self.cameras.values():
+                cam.connect()
 
-        self.configure()
+            self.configure()
+        except BaseException:
+            self._release_after_failed_connect()
+            raise
+
         logger.info(f"{self} connected.")
 
     @property

--- a/src/lerobot/robots/hope_jr/hope_jr_hand.py
+++ b/src/lerobot/robots/hope_jr/hope_jr_hand.py
@@ -126,14 +126,19 @@ class HopeJrHand(Robot):
     @check_if_already_connected
     def connect(self, calibrate: bool = True) -> None:
         self.bus.connect()
-        if not self.is_calibrated and calibrate:
-            self.calibrate()
+        try:
+            if not self.is_calibrated and calibrate:
+                self.calibrate()
 
-        # Connect the cameras
-        for cam in self.cameras.values():
-            cam.connect()
+            # Connect the cameras
+            for cam in self.cameras.values():
+                cam.connect()
 
-        self.configure()
+            self.configure()
+        except BaseException:
+            self._release_after_failed_connect()
+            raise
+
         logger.info(f"{self} connected.")
 
     @property

--- a/src/lerobot/robots/koch_follower/koch_follower.py
+++ b/src/lerobot/robots/koch_follower/koch_follower.py
@@ -97,16 +97,21 @@ class KochFollower(Robot):
         """
 
         self.bus.connect()
-        if not self.is_calibrated and calibrate:
-            logger.info(
-                "Mismatch between calibration values in the motor and the calibration file or no calibration file found"
-            )
-            self.calibrate()
+        try:
+            if not self.is_calibrated and calibrate:
+                logger.info(
+                    "Mismatch between calibration values in the motor and the calibration file or no calibration file found"
+                )
+                self.calibrate()
 
-        for cam in self.cameras.values():
-            cam.connect()
+            for cam in self.cameras.values():
+                cam.connect()
 
-        self.configure()
+            self.configure()
+        except BaseException:
+            self._release_after_failed_connect()
+            raise
+
         logger.info(f"{self} connected.")
 
     @property

--- a/src/lerobot/robots/lekiwi/lekiwi.py
+++ b/src/lerobot/robots/lekiwi/lekiwi.py
@@ -118,16 +118,21 @@ class LeKiwi(Robot):
     @check_if_already_connected
     def connect(self, calibrate: bool = True) -> None:
         self.bus.connect()
-        if not self.is_calibrated and calibrate:
-            logger.info(
-                "Mismatch between calibration values in the motor and the calibration file or no calibration file found"
-            )
-            self.calibrate()
+        try:
+            if not self.is_calibrated and calibrate:
+                logger.info(
+                    "Mismatch between calibration values in the motor and the calibration file or no calibration file found"
+                )
+                self.calibrate()
 
-        for cam in self.cameras.values():
-            cam.connect()
+            for cam in self.cameras.values():
+                cam.connect()
 
-        self.configure()
+            self.configure()
+        except BaseException:
+            self._release_after_failed_connect()
+            raise
+
         logger.info(f"{self} connected.")
 
     @property

--- a/src/lerobot/robots/omx_follower/omx_follower.py
+++ b/src/lerobot/robots/omx_follower/omx_follower.py
@@ -99,16 +99,21 @@ class OmxFollower(Robot):
         """
 
         self.bus.connect()
-        if not self.is_calibrated and calibrate:
-            logger.info(
-                "Mismatch between calibration values in the motor and the calibration file or no calibration file found"
-            )
-            self.calibrate()
+        try:
+            if not self.is_calibrated and calibrate:
+                logger.info(
+                    "Mismatch between calibration values in the motor and the calibration file or no calibration file found"
+                )
+                self.calibrate()
 
-        for cam in self.cameras.values():
-            cam.connect()
+            for cam in self.cameras.values():
+                cam.connect()
 
-        self.configure()
+            self.configure()
+        except BaseException:
+            self._release_after_failed_connect()
+            raise
+
         logger.info(f"{self} connected.")
 
     @property

--- a/src/lerobot/robots/openarm_follower/openarm_follower.py
+++ b/src/lerobot/robots/openarm_follower/openarm_follower.py
@@ -138,19 +138,23 @@ class OpenArmFollower(Robot):
         logger.info(f"Connecting arm on {self.config.port}...")
         self.bus.connect()
 
-        # Run calibration if needed
-        if not self.is_calibrated and calibrate:
-            logger.info(
-                "Mismatch between calibration values in the motor and the calibration file or no calibration file found"
-            )
-            self.calibrate()
+        try:
+            # Run calibration if needed
+            if not self.is_calibrated and calibrate:
+                logger.info(
+                    "Mismatch between calibration values in the motor and the calibration file or no calibration file found"
+                )
+                self.calibrate()
 
-        for cam in self.cameras.values():
-            cam.connect()
+            for cam in self.cameras.values():
+                cam.connect()
 
-        self.configure()
+            self.configure()
 
-        self.bus.enable_torque()
+            self.bus.enable_torque()
+        except BaseException:
+            self._release_after_failed_connect()
+            raise
 
         logger.info(f"{self} connected.")
 

--- a/src/lerobot/robots/reachy2/robot_reachy2.py
+++ b/src/lerobot/robots/reachy2/robot_reachy2.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 from __future__ import annotations
 
+import logging
 import time
 from typing import TYPE_CHECKING, Any
 
@@ -30,6 +31,8 @@ if TYPE_CHECKING or _reachy2_sdk_available:
     from reachy2_sdk import ReachySDK
 else:
     ReachySDK = None
+
+logger = logging.getLogger(__name__)
 
 # {lerobot_keys: reachy2_sdk_keys}
 REACHY2_NECK_JOINTS = {
@@ -129,13 +132,29 @@ class Reachy2Robot(Robot):
 
     def connect(self, calibrate: bool = False) -> None:
         self.reachy = ReachySDK(self.config.ip_address)
-        if not self.is_connected:
-            raise ConnectionError()
+        try:
+            if not self.is_connected:
+                raise ConnectionError()
 
-        for cam in self.cameras.values():
-            cam.connect()
+            for cam in self.cameras.values():
+                cam.connect()
 
-        self.configure()
+            self.configure()
+        except BaseException:
+            self._release_after_failed_connect()
+            raise
+
+    def _release_bus_after_failed_connect(self) -> None:
+        """Releases the SDK handle, which stands in for a motors bus on this robot."""
+        if self.reachy is None:
+            return
+
+        try:
+            self.reachy.disconnect()
+        except Exception:
+            logger.exception(f"Failed to disconnect the SDK after {self} failed to connect.")
+        finally:
+            self.reachy = None
 
     def configure(self) -> None:
         if self.reachy is not None:

--- a/src/lerobot/robots/rebot_b601_follower/rebot_b601_follower.py
+++ b/src/lerobot/robots/rebot_b601_follower/rebot_b601_follower.py
@@ -116,20 +116,47 @@ class RebotB601Follower(Robot):
                 f"Unsupported can_adapter '{self.config.can_adapter}'. Use 'damiao' or 'socketcan'."
             )
 
-        for motor_name, (send_id, recv_id) in self.config.motor_can_ids.items():
-            self.motors[motor_name] = self.bus.add_damiao_motor(send_id, recv_id, MOTOR_MODELS[motor_name])
+        try:
+            for motor_name, (send_id, recv_id) in self.config.motor_can_ids.items():
+                self.motors[motor_name] = self.bus.add_damiao_motor(
+                    send_id, recv_id, MOTOR_MODELS[motor_name]
+                )
 
-        if not self.is_calibrated and calibrate:
-            logger.info(
-                "Mismatch between calibration values in the motor and the calibration file or no calibration file found"
-            )
-            self.calibrate()
+            if not self.is_calibrated and calibrate:
+                logger.info(
+                    "Mismatch between calibration values in the motor and the calibration file or no calibration file found"
+                )
+                self.calibrate()
 
-        for cam in self.cameras.values():
-            cam.connect()
+            for cam in self.cameras.values():
+                cam.connect()
 
-        self.configure()
+            self.configure()
+        except BaseException:
+            self._release_after_failed_connect()
+            raise
+
         logger.info(f"{self} connected.")
+
+    def _release_bus_after_failed_connect(self) -> None:
+        """Tears down the CAN controller, which is closed rather than disconnected."""
+        for motor in self.motors.values():
+            try:
+                if self.config.disable_torque_on_disconnect:
+                    motor.disable()
+                motor.clear_error()
+                motor.close()
+            except Exception:
+                logger.exception(f"Failed to release {motor} after {self} failed to connect.")
+
+        if self.bus is not None:
+            try:
+                self.bus.close()
+            except Exception:
+                logger.exception(f"Failed to close the bus after {self} failed to connect.")
+
+        self.bus = None
+        self.motors = {}
 
     @property
     def is_calibrated(self) -> bool:

--- a/src/lerobot/robots/robot.py
+++ b/src/lerobot/robots/robot.py
@@ -14,6 +14,7 @@
 
 import abc
 import builtins
+import logging
 from pathlib import Path
 
 import draccus
@@ -23,6 +24,8 @@ from lerobot.motors import MotorCalibration
 from lerobot.utils.constants import HF_LEROBOT_CALIBRATION, ROBOTS
 
 from .config import RobotConfig
+
+logger = logging.getLogger(__name__)
 
 
 # TODO(aliberts): action/obs typing such as Generic[ObsType, ActType] similar to gym.Env ?
@@ -72,6 +75,33 @@ class Robot(abc.ABC):
         Automatically disconnects, ensuring resources are released even on error.
         """
         self.disconnect()
+
+    def _release_after_failed_connect(self) -> None:
+        """Releases whatever was already acquired when connect() fails partway through.
+
+        A camera left connected keeps its background read thread and its native
+        pipeline alive with no owner. Those are only torn down at interpreter
+        shutdown, which is too late for backends that must be stopped explicitly
+        and can abort the process instead of surfacing the original error.
+
+        Failures here are logged rather than raised so they cannot mask it.
+        """
+        for cam in getattr(self, "cameras", {}).values():
+            if not cam.is_connected:
+                continue
+            try:
+                cam.disconnect()
+            except Exception:
+                logger.exception(f"Failed to disconnect {cam} after {self} failed to connect.")
+
+        bus = getattr(self, "bus", None)
+        if bus is None or not bus.is_connected:
+            return
+
+        try:
+            bus.disconnect(self.config.disable_torque_on_disconnect)
+        except Exception:
+            logger.exception(f"Failed to disconnect the bus after {self} failed to connect.")
 
     def __del__(self) -> None:
         """

--- a/src/lerobot/robots/robot.py
+++ b/src/lerobot/robots/robot.py
@@ -87,19 +87,27 @@ class Robot(abc.ABC):
         Failures here are logged rather than raised so they cannot mask it.
         """
         for cam in getattr(self, "cameras", {}).values():
-            if not cam.is_connected:
-                continue
             try:
-                cam.disconnect()
+                if cam.is_connected:
+                    cam.disconnect()
             except Exception:
                 logger.exception(f"Failed to disconnect {cam} after {self} failed to connect.")
 
+        self._release_bus_after_failed_connect()
+
+    def _release_bus_after_failed_connect(self) -> None:
+        """Releases the motors bus after a failed connect().
+
+        Override this when the bus does not follow the ``disconnect(disable_torque)``
+        shape, as is the case for CAN-backed robots that hold a controller handle.
+        """
         bus = getattr(self, "bus", None)
-        if bus is None or not bus.is_connected:
+        if bus is None:
             return
 
         try:
-            bus.disconnect(self.config.disable_torque_on_disconnect)
+            if bus.is_connected:
+                bus.disconnect(self.config.disable_torque_on_disconnect)
         except Exception:
             logger.exception(f"Failed to disconnect the bus after {self} failed to connect.")
 

--- a/src/lerobot/robots/so_follower/so_follower.py
+++ b/src/lerobot/robots/so_follower/so_follower.py
@@ -96,16 +96,21 @@ class SOFollower(Robot):
         """
 
         self.bus.connect()
-        if not self.is_calibrated and calibrate:
-            logger.info(
-                "Mismatch between calibration values in the motor and the calibration file or no calibration file found"
-            )
-            self.calibrate()
+        try:
+            if not self.is_calibrated and calibrate:
+                logger.info(
+                    "Mismatch between calibration values in the motor and the calibration file or no calibration file found"
+                )
+                self.calibrate()
 
-        for cam in self.cameras.values():
-            cam.connect()
+            for cam in self.cameras.values():
+                cam.connect()
 
-        self.configure()
+            self.configure()
+        except BaseException:
+            self._release_after_failed_connect()
+            raise
+
         logger.info(f"{self} connected.")
 
     @property

--- a/src/lerobot/robots/unitree_g1/unitree_g1.py
+++ b/src/lerobot/robots/unitree_g1/unitree_g1.py
@@ -355,6 +355,52 @@ class UnitreeG1(Robot):
         pass
 
     def connect(self, calibrate: bool = True) -> None:  # connect to DDS
+        try:
+            self._connect()
+        except BaseException:
+            self._release_after_failed_connect()
+            raise
+
+    def _release_after_failed_connect(self) -> None:
+        """Stops the threads and cameras that connect() had already started.
+
+        The subscribe thread is not a daemon, so leaving it running blocks interpreter
+        exit rather than letting the original error surface.
+        """
+        self._shutdown_event.set()
+
+        for thread, label in (
+            (self._controller_thread, "Controller"),
+            (self.subscribe_thread, "Subscribe"),
+        ):
+            if thread is None:
+                continue
+            thread.join(timeout=2.0)
+            if thread.is_alive():
+                logger.warning(f"{label} thread did not stop cleanly after {self} failed to connect.")
+
+        self._controller_thread = None
+        self.subscribe_thread = None
+
+        for cam in self._cameras.values():
+            try:
+                if cam.is_connected:
+                    cam.disconnect()
+            except Exception:
+                logger.exception(f"Failed to disconnect {cam} after {self} failed to connect.")
+
+        if self.sim_env is not None:
+            try:
+                self.sim_env.close()
+            except Exception:
+                logger.exception(f"Failed to close the sim env after {self} failed to connect.")
+            self.sim_env = None
+            self._env_wrapper = None
+
+        # Cleared last so a later connect() attempt starts from a usable state.
+        self._shutdown_event.clear()
+
+    def _connect(self) -> None:
         # Initialize DDS channel and simulation environment
         if self.config.is_simulation:
             from lerobot.envs import make_env

--- a/src/lerobot/utils/bimanual.py
+++ b/src/lerobot/utils/bimanual.py
@@ -14,9 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 from typing import Any
 
 from lerobot.utils.decorators import check_if_already_connected, check_if_not_connected
+
+logger = logging.getLogger(__name__)
 
 
 class BimanualMixin:
@@ -47,7 +50,16 @@ class BimanualMixin:
     @check_if_already_connected
     def connect(self, calibrate: bool = True) -> None:
         self.left_arm.connect(calibrate)
-        self.right_arm.connect(calibrate)
+        try:
+            self.right_arm.connect(calibrate)
+        except BaseException:
+            # Otherwise the left arm keeps its bus and cameras open with no owner.
+            try:
+                if self.left_arm.is_connected:
+                    self.left_arm.disconnect()
+            except Exception:
+                logger.exception(f"Failed to disconnect {self.left_arm} after {self} failed to connect.")
+            raise
 
     def calibrate(self) -> None:
         self.left_arm.calibrate()

--- a/tests/robots/test_reachy2.py
+++ b/tests/robots/test_reachy2.py
@@ -166,6 +166,29 @@ def reachy2(request):
             robot.disconnect()
 
 
+def test_connect_releases_camera_and_sdk_when_a_camera_fails(reachy2):
+    # A camera failure used to leave earlier cameras and the SDK handle open, so they were
+    # only torn down at interpreter shutdown rather than when connect() failed (see #4550).
+    good_cam = _make_reachy2_camera_mock(name="good_cam")
+    good_cam.is_connected = False
+    good_cam.connect.side_effect = lambda *a, **kw: setattr(good_cam, "is_connected", True)
+    good_cam.disconnect.side_effect = lambda: setattr(good_cam, "is_connected", False)
+
+    bad_cam = _make_reachy2_camera_mock(name="bad_cam")
+    bad_cam.is_connected = False
+    bad_cam.connect.side_effect = ConnectionError("Failed to open bad_cam.")
+
+    reachy2.cameras = {"good": good_cam, "bad": bad_cam}
+
+    with pytest.raises(ConnectionError, match="bad_cam"):
+        reachy2.connect()
+
+    good_cam.disconnect.assert_called_once_with()
+    assert not good_cam.is_connected
+    assert reachy2.reachy is None
+    assert not reachy2.is_connected
+
+
 def test_connect_disconnect(reachy2):
     assert not reachy2.is_connected
 

--- a/tests/robots/test_rebot_b601_follower.py
+++ b/tests/robots/test_rebot_b601_follower.py
@@ -82,6 +82,40 @@ def test_connect_disconnect(follower):
     assert not follower.is_connected
 
 
+def test_connect_releases_bus_and_cameras_when_a_camera_fails():
+    # A camera failure used to leave the CAN controller and any earlier camera open, so they
+    # were only torn down at interpreter shutdown rather than when connect() failed (see #4550).
+    bus_mock = _make_bus_mock()
+
+    good_cam = MagicMock(name="good_cam")
+    good_cam.is_connected = False
+    good_cam.connect.side_effect = lambda *a, **kw: setattr(good_cam, "is_connected", True)
+    good_cam.disconnect.side_effect = lambda: setattr(good_cam, "is_connected", False)
+
+    bad_cam = MagicMock(name="bad_cam")
+    bad_cam.is_connected = False
+    bad_cam.connect.side_effect = ConnectionError("Failed to open bad_cam.")
+
+    with (
+        patch(f"{_MODULE}.require_package", lambda *a, **kw: None),
+        patch(f"{_MODULE}.MotorBridgeController") as controller_cls,
+        patch(f"{_MODULE}.MotorBridgeMode", MagicMock()),
+    ):
+        controller_cls.from_dm_serial.return_value = bus_mock
+        robot = RebotB601Follower(RebotB601FollowerRobotConfig(port="/dev/null"))
+        robot.cameras = {"front": good_cam, "arm": bad_cam}
+
+        with pytest.raises(ConnectionError, match="bad_cam"):
+            robot.connect(calibrate=False)
+
+    good_cam.disconnect.assert_called_once_with()
+    assert not good_cam.is_connected
+    bus_mock.close.assert_called_once_with()
+    assert robot.bus is None
+    assert robot.motors == {}
+    assert not robot.is_connected
+
+
 def test_get_observation_converts_to_degrees(follower):
     obs = follower.get_observation()
     assert set(obs) == {f"{m}.pos" for m in follower.motor_names}

--- a/tests/robots/test_so100_follower.py
+++ b/tests/robots/test_so100_follower.py
@@ -88,6 +88,52 @@ def test_connect_disconnect(follower):
     assert not follower.is_connected
 
 
+def _make_camera_mock(name: str, fails: bool = False) -> MagicMock:
+    """Return a camera mock that tracks its own connection state."""
+    cam = MagicMock(name=name)
+    cam.is_connected = False
+
+    def _connect(warmup=True):
+        if fails:
+            raise ConnectionError(f"Failed to open {name}.")
+        cam.is_connected = True
+
+    def _disconnect():
+        cam.is_connected = False
+
+    cam.connect.side_effect = _connect
+    cam.disconnect.side_effect = _disconnect
+    return cam
+
+
+def test_connect_releases_already_connected_camera_when_a_later_one_fails(follower):
+    # A camera left connected keeps its read thread and native pipeline alive with no owner,
+    # which aborts the process at interpreter shutdown instead of surfacing the error (see #4550).
+    good_cam = _make_camera_mock("good_cam")
+    bad_cam = _make_camera_mock("bad_cam", fails=True)
+    follower.cameras = {"front": good_cam, "arm": bad_cam}
+
+    with pytest.raises(ConnectionError, match="bad_cam"):
+        follower.connect()
+
+    good_cam.disconnect.assert_called_once_with()
+    assert not good_cam.is_connected
+    assert not follower.bus.is_connected
+    assert not follower.is_connected
+
+
+def test_connect_reports_original_error_when_cleanup_also_fails(follower):
+    good_cam = _make_camera_mock("good_cam")
+    good_cam.disconnect.side_effect = RuntimeError("disconnect exploded")
+    bad_cam = _make_camera_mock("bad_cam", fails=True)
+    follower.cameras = {"front": good_cam, "arm": bad_cam}
+
+    with pytest.raises(ConnectionError, match="bad_cam"):
+        follower.connect()
+
+    assert not follower.bus.is_connected
+
+
 def test_get_observation(follower):
     follower.connect()
     obs = follower.get_observation()

--- a/tests/robots/test_unitree_g1.py
+++ b/tests/robots/test_unitree_g1.py
@@ -225,6 +225,40 @@ def hardware_mode(robot):
 # ---------------------------------------------------------------------------
 
 
+def test_connect_releases_cameras_and_threads_when_a_camera_fails(make_robot):
+    # The subscribe thread is not a daemon, so a camera failure used to leave it running and
+    # block interpreter exit instead of surfacing the original error (see #4550).
+    factory, _ = make_robot
+    robot = hardware_mode(factory())
+
+    good_cam = MagicMock(name="good_cam")
+    good_cam.is_connected = False
+    good_cam.connect.side_effect = lambda: setattr(good_cam, "is_connected", True)
+    good_cam.disconnect.side_effect = lambda: setattr(good_cam, "is_connected", False)
+
+    captured = {}
+    bad_cam = MagicMock(name="bad_cam")
+    bad_cam.is_connected = False
+
+    def _fail():
+        captured["subscribe_thread"] = robot.subscribe_thread
+        raise ConnectionError("Failed to open bad_cam.")
+
+    bad_cam.connect.side_effect = _fail
+    robot._cameras = {"good": good_cam, "bad": bad_cam}
+
+    with pytest.raises(ConnectionError, match="bad_cam"):
+        robot.connect()
+
+    good_cam.disconnect.assert_called_once_with()
+    assert not good_cam.is_connected
+    assert captured["subscribe_thread"] is not None
+    assert not captured["subscribe_thread"].is_alive()
+    assert robot.subscribe_thread is None
+    # Cleared so a later attempt can start its threads again.
+    assert not robot._shutdown_event.is_set()
+
+
 class TestInitialState:
     def test_starts_disconnected(self, make_robot):
         factory, _ = make_robot

--- a/tests/utils/test_bimanual.py
+++ b/tests/utils/test_bimanual.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from lerobot.utils.bimanual import BimanualMixin
+
+
+def _make_arm_mock(name: str, fails: bool = False) -> MagicMock:
+    """Return an arm mock that tracks its own connection state."""
+    arm = MagicMock(name=name)
+    arm.is_connected = False
+
+    def _connect(_calibrate=True):
+        if fails:
+            raise ConnectionError(f"Failed to open a camera on {name}.")
+        arm.is_connected = True
+
+    def _disconnect():
+        arm.is_connected = False
+
+    arm.connect.side_effect = _connect
+    arm.disconnect.side_effect = _disconnect
+    return arm
+
+
+class _Bimanual(BimanualMixin):
+    """Minimal concrete stand-in: the mixin only needs the two arms."""
+
+    def __init__(self, left_arm, right_arm):
+        self.left_arm = left_arm
+        self.right_arm = right_arm
+
+
+def test_connect_releases_left_arm_when_right_arm_fails():
+    # The left arm holds a bus and cameras; leaving it connected strands a whole arm.
+    left = _make_arm_mock("left_arm")
+    right = _make_arm_mock("right_arm", fails=True)
+    robot = _Bimanual(left, right)
+
+    with pytest.raises(ConnectionError, match="right_arm"):
+        robot.connect()
+
+    left.disconnect.assert_called_once_with()
+    assert not left.is_connected
+    assert not robot.is_connected
+
+
+def test_connect_reports_original_error_when_left_arm_cleanup_fails():
+    left = _make_arm_mock("left_arm")
+    left.disconnect.side_effect = RuntimeError("disconnect exploded")
+    right = _make_arm_mock("right_arm", fails=True)
+    robot = _Bimanual(left, right)
+
+    with pytest.raises(ConnectionError, match="right_arm"):
+        robot.connect()
+
+
+def test_connect_leaves_both_arms_connected_on_success():
+    left = _make_arm_mock("left_arm")
+    right = _make_arm_mock("right_arm")
+    robot = _Bimanual(left, right)
+
+    robot.connect()
+
+    assert robot.is_connected
+    left.disconnect.assert_not_called()
+    right.disconnect.assert_not_called()


### PR DESCRIPTION
## Summary / Motivation

`robot.connect()` connects the motors bus, then each camera in turn. If a camera fails, the error propagates while everything already connected stays open. A camera left connected keeps its background read thread and its native pipeline alive with no owner, so it is only torn down at interpreter shutdown — too late for backends that must be stopped explicitly.

This is visible in #4550, where an OpenCV camera fails to open after a RealSense has connected. The run ends in:

```
ConnectionError: Failed to open OpenCVCamera(/dev/video10). ...
terminate called without an active exception
Aborted (core dumped)
```

`terminate called without an active exception` is the C++ runtime destroying a joinable thread — the RealSense pipeline was never stopped.

Scope: this does **not** change *why* the second camera fails to open (that looks like a USB/V4L2-level interaction and needs the reporter's hardware to diagnose). It makes the failure surface as a clean `ConnectionError` with all devices released, instead of a core dump with a leaked camera handle and serial port.

## Related issues

- Related: #4550 — fixes the crash and device leak reported there, not the underlying dual-camera conflict.

## What changed

- Add `Robot._release_after_failed_connect()`: disconnects any still-connected camera, then the bus. Cleanup failures are logged, never raised, so they cannot mask the original error.
- Wrap the connect body in the robots that connect a bus and cameras (`so_follower`, `koch_follower`, `lekiwi`, `omx_follower`, `openarm_follower`, `hope_jr_arm`, `hope_jr_hand`) so cleanup runs on any failure, including `KeyboardInterrupt`.
- Document that `backend=V4L2` needs an integer `index_or_path` rather than a `/dev/videoN` path (also reported in #4550).
- No behavior change on a successful connect.

## How was this tested

- Added two tests in `tests/robots/test_so100_follower.py`. Both fail on `main` (`Expected 'disconnect' to be called once. Called 0 times`) and pass with this change:
  `pytest -q tests/robots/test_so100_follower.py -k "releases_already_connected or reports_original_error"`
- `pytest -q tests/robots/` → 122 passed, 1 skipped.
- Additionally verified with a real `OpenCVCamera` (real background thread) as the first camera: after a failed `connect()`, `is_connected`, `thread` and `videocapture` are all cleared and no read-loop thread survives. On `main` the `cv2.VideoCapture` handle and the bus are both still held.

## Checklist

- [x] Linting/formatting run (`ruff check` + `ruff format --check`; not full `pre-commit run -a`)
- [ ] All tests pass locally — ran `tests/robots/` and `tests/cameras/`, not the full suite
- [x] Documentation updated (config docstring)
- [ ] CI is green — not yet run
- [x] Community Review: reviewed https://github.com/huggingface/lerobot/pull/4575 and left feedback here: https://github.com/huggingface/lerobot/pull/4575#issuecomment-5560168375

## Reviewer notes

- `_release_after_failed_connect()` reads `self.cameras` / `self.bus` via `getattr` because the `Robot` base class doesn't declare them. Happy to declare them on the base or move the helper per-robot if you'd prefer.
- Robots with a different connect shape (`reachy2`, `rebot_b601_follower`, `earthrover_mini_plus`, `bi_so_follower`) were left untouched; glad to extend if wanted.
- AI assistance disclosure per AI_POLICY.md: this change was developed with Claude Code — traceback investigation, patch, tests, and the validation runs above.
