### PR TITLE
fix(cameras): normalize RealSense depth to millimeters

### DIFF
--- a/src/lerobot/cameras/realsense/camera_realsense.py
+++ b/src/lerobot/cameras/realsense/camera_realsense.py
@@ -664,6 +664,21 @@ class RealSenseCamera(Camera):
 
         return processed_image
 
+    @staticmethod
+    def _depth_frame_to_millimeters(depth_frame: "rs.depth_frame") -> NDArray[np.uint16]:
+        """Convert sensor-native Z16 values to the camera API's millimeter unit."""
+        depth_units_m = float(depth_frame.get_units())
+        if not np.isfinite(depth_units_m) or depth_units_m <= 0:
+            raise RuntimeError(f"Invalid RealSense depth scale: {depth_units_m}")
+
+        raw_depth = np.asanyarray(depth_frame.get_data())
+        millimeters_per_unit = depth_units_m * 1000.0
+        if millimeters_per_unit == 1.0:
+            return raw_depth.astype(np.uint16, copy=False)
+
+        depth_mm = np.rint(raw_depth.astype(np.float64) * millimeters_per_unit)
+        return np.clip(depth_mm, 0, np.iinfo(np.uint16).max).astype(np.uint16)
+
     def _read_loop(self) -> None:
         """
         Internal loop run by the background thread for asynchronous reading.
@@ -691,7 +706,7 @@ class RealSenseCamera(Camera):
 
                 if self.use_depth:
                     depth_frame_raw = frame.get_depth_frame()
-                    depth_frame = np.asanyarray(depth_frame_raw.get_data())
+                    depth_frame = self._depth_frame_to_millimeters(depth_frame_raw)
                     processed_depth_frame = self._postprocess_image(depth_frame, depth_frame=True)
                     if processed_depth_frame.ndim == 2:  # (H, W) -> (H, W, 1)
                         processed_depth_frame = processed_depth_frame[..., np.newaxis]

--- a/tests/cameras/test_realsense.py
+++ b/tests/cameras/test_realsense.py
@@ -197,6 +197,34 @@ def test_depth_frame_not_color_converted(img_array_factory):
     np.testing.assert_array_equal(camera._postprocess_image(depth, depth_frame=True), depth)
 
 
+@pytest.mark.parametrize(
+    ("depth_units_m", "raw_depth", "expected_mm"),
+    [
+        (0.001, [[0, 1, 1234]], [[0, 1, 1234]]),
+        (0.0001, [[0, 1, 1294]], [[0, 0, 129]]),
+    ],
+)
+def test_depth_frame_values_are_normalized_to_millimeters(depth_units_m, raw_depth, expected_mm):
+    depth_frame = MagicMock()
+    depth_frame.get_units.return_value = depth_units_m
+    depth_frame.get_data.return_value = np.asarray(raw_depth, dtype=np.uint16)
+
+    depth_mm = RealSenseCamera._depth_frame_to_millimeters(depth_frame)
+
+    assert depth_mm.dtype == np.uint16
+    np.testing.assert_array_equal(depth_mm, np.asarray(expected_mm, dtype=np.uint16))
+
+
+@pytest.mark.parametrize("depth_units_m", [0.0, -0.001, float("nan"), float("inf")])
+def test_depth_frame_rejects_invalid_depth_scale(depth_units_m):
+    depth_frame = MagicMock()
+    depth_frame.get_units.return_value = depth_units_m
+    depth_frame.get_data.return_value = np.zeros((1, 1), dtype=np.uint16)
+
+    with pytest.raises(RuntimeError, match="Invalid RealSense depth scale"):
+        RealSenseCamera._depth_frame_to_millimeters(depth_frame)
+
+
 def test_read_before_connect():
     config = RealSenseCameraConfig(serial_number_or_name="042")
     camera = RealSenseCamera(config)


### PR DESCRIPTION
## Summary / Motivation

RealSense Z16 frames use sensor-specific depth units. LeRobot documents and encodes integer depth arrays as millimeters, but `RealSenseCamera` forwarded the raw Z16 values unchanged. That is correct only when the sensor scale is 0.001 m/unit. A D405 commonly reports 0.0001 m/unit, which makes downstream depth values 10 times too large.

## Related issues

- None.

## What changed

- Convert each RealSense depth frame from its reported `get_units()` scale to `uint16` millimeters.
- Preserve zero-valued invalid pixels and the existing camera API contract.
- Reject non-finite or non-positive depth scales.
- Add regression tests for both 0.001 and 0.0001 m/unit scales.

This introduces no breaking API change.

## How was this tested (or how to run locally)

- `uv run --locked --extra test --extra intelrealsense --extra dataset pytest -q tests/cameras/test_realsense.py`
  - Result: 54 passed, 1 skipped.
- `uv run pre-commit run -a`
  - Result: all hooks passed.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [ ] All tests pass locally (`pytest`), targeted RealSense tests pass
- [ ] Documentation updated, no update required because the documented millimeter contract is unchanged
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor open PR and linked it here

## Reviewer notes

The conversion uses the scale reported by each depth frame, then rounds and clips to the existing `uint16` millimeter representation. This fixes D405 values without changing behavior for devices whose scale is already 0.001 m/unit.

Anyone in the community is free to review the PR.