### PR TITLE
feat(datasets): discover storage backends through entry points

### DIFF
--- a/docs/source/lerobot-dataset-v3.mdx
+++ b/docs/source/lerobot-dataset-v3.mdx
@@ -368,3 +368,53 @@ dataset = LeRobotLanceVideoDataset(
 ```
 
 Join the discussion on [Github](https://github.com/huggingface/lerobot/issues/3608) and explore the `lerobot-lancedb` documentation [here](https://lancedb.github.io/lerobot-lancedb/).
+
+### Bring your own storage backend
+
+`LeRobotDataset` stays the one public class no matter where the data actually lives. Which
+reader serves it is decided by the `storage_format` field in `meta/info.json`: `"lerobot"`
+(the default parquet/mp4 layout), `"lance"`, or a format contributed by an installed package.
+
+A backend is a module exposing two names:
+
+- `DATASET_READER` — a class implementing
+  [`BaseDatasetReader`](https://github.com/huggingface/lerobot/blob/main/src/lerobot/datasets/dataset_reader.py),
+  constructed with the keyword arguments `meta`, `root`, `episodes`, `delta_timestamps`,
+  `image_transforms`, `tolerance_s`, `revision`, `return_uint8`, `depth_output_unit` and `token`.
+  It must be picklable, so `DataLoader` workers can reopen their own connections.
+- `localize_root(repo_id, root, revision, token=..., force_cache_sync=...)` — materializes
+  `meta/` locally for an object-store root and returns the directory holding it. Raise
+  `FileNotFoundError` if the root is not yours, so the other registered formats still get
+  their turn.
+
+Declare an entry point so your format is available as soon as your package is installed:
+
+```toml
+# in your package's pyproject.toml
+[project.entry-points."lerobot.dataset_readers"]
+my_format = "my_package.my_reader"
+```
+
+That's the whole integration — users need no import and no configuration:
+
+```python
+from lerobot.datasets import LeRobotDataset
+
+# meta/info.json declares "storage_format": "my_format"
+dataset = LeRobotDataset("me/my-dataset", root="s3://bucket/my-dataset")
+```
+
+Notes on the mechanism:
+
+- Entry points are read for their names only. Your module is imported on first use, not at
+  discovery, so your backend's dependencies stay optional for everyone who doesn't use it.
+- Built-in formats win. An entry point cannot claim `lerobot` or `lance`, so installing a
+  package can never silently change how existing datasets are read.
+- A plugin that fails to register is skipped with a warning; one broken package does not stop
+  the others, or stop datasets from loading at all.
+
+If you would rather register explicitly — for a format defined in the same application that
+consumes it — call `register_dataset_reader("my_format", "my_package.my_reader")` before
+constructing the dataset. Entry points exist for the case where the code opening the dataset
+(`lerobot-dataset-viz`, `lerobot-train`, someone else's training script) has no reason to know
+your package exists.

--- a/src/lerobot/datasets/storage.py
+++ b/src/lerobot/datasets/storage.py
@@ -17,6 +17,8 @@
 from __future__ import annotations
 
 import importlib
+import logging
+from importlib.metadata import entry_points
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -24,7 +26,20 @@ if TYPE_CHECKING:
     from .dataset_metadata import LeRobotDatasetMetadata
     from .dataset_reader import BaseDatasetReader
 
+logger = logging.getLogger(__name__)
+
 DEFAULT_STORAGE_FORMAT = "lerobot"
+
+# Entry point group an installed package declares to serve a storage format
+# without the application having to import it first::
+#
+#     [project.entry-points."lerobot.dataset_readers"]
+#     my_format = "my_package.my_reader"
+#
+# The value names the module implementing the contract below. Entry points are
+# read for their names only -- the module is still imported lazily, on first
+# use -- so a plugin's optional dependencies stay optional.
+DATASET_READER_ENTRY_POINT_GROUP = "lerobot.dataset_readers"
 
 # Supported non-default storage formats and the module implementing each.
 # Modules are imported lazily so their optional dependencies stay optional;
@@ -35,6 +50,7 @@ DEFAULT_STORAGE_FORMAT = "lerobot"
 # ``depth_output_unit`` and ``token``) and a ``localize_root`` hook for
 # object-store roots.
 _DATASET_READER_MODULES: dict[str, str] = {}
+_PLUGINS_DISCOVERED = False
 
 
 def register_dataset_reader(storage_format: str, module: str) -> None:
@@ -48,12 +64,53 @@ def register_dataset_reader(storage_format: str, module: str) -> None:
 register_dataset_reader("lance", "lerobot.datasets.lance_backend")
 
 
+def _discover_plugin_readers() -> None:
+    """Register storage formats advertised by installed packages, once.
+
+    Called before every registry lookup rather than at import, so the scan costs
+    nothing until a dataset is actually opened.
+
+    Built-in formats win: an entry point may not take a name that is already
+    registered, so installing a package cannot silently change how ``lerobot``
+    or ``lance`` datasets are read. A plugin that fails to register is skipped
+    with a warning -- one broken package must not stop the others, nor stop
+    datasets loading at all.
+    """
+    global _PLUGINS_DISCOVERED
+    if _PLUGINS_DISCOVERED:
+        return
+    # Set before scanning: a failing scan must not be retried on every lookup.
+    _PLUGINS_DISCOVERED = True
+    try:
+        discovered = list(entry_points(group=DATASET_READER_ENTRY_POINT_GROUP))
+    except Exception as error:  # pragma: no cover -- importlib.metadata is robust
+        logger.warning("Could not read %r entry points: %s", DATASET_READER_ENTRY_POINT_GROUP, error)
+        return
+
+    for entry_point in discovered:
+        try:
+            # Registering through the public function is what keeps built-ins
+            # safe: it rejects DEFAULT_STORAGE_FORMAT and any name already taken,
+            # so an installed package cannot claim "lerobot" or "lance".
+            # ``.module`` (not ``.value``) so a "pkg.mod:attr" spelling still
+            # resolves to the module the contract is defined on.
+            register_dataset_reader(entry_point.name, entry_point.module)
+        except Exception as error:
+            logger.warning(
+                "Ignoring dataset reader plugin %r (from %r): %s",
+                entry_point.name,
+                entry_point.value,
+                error,
+            )
+
+
 def is_remote_uri(root: str | Path) -> bool:
     """True for object-store style roots (``hf://…``, ``file://…``, …)."""
     return "://" in str(root)
 
 
 def _reader_module(storage_format: str):
+    _discover_plugin_readers()
     module_name = _DATASET_READER_MODULES.get(storage_format)
     if module_name is None:
         raise ValueError(
@@ -85,8 +142,9 @@ def localize_remote_root(
     locally, so each backend is asked in turn to recognize and localize the
     root. Data files are never downloaded — backends read them in place.
     """
+    _discover_plugin_readers()
     errors = []
-    for storage_format in _DATASET_READER_MODULES:
+    for storage_format in list(_DATASET_READER_MODULES):
         try:
             return _reader_module(storage_format).localize_root(
                 repo_id, root, revision, token=token, force_cache_sync=force_cache_sync

--- a/tests/datasets/test_dataset_reader.py
+++ b/tests/datasets/test_dataset_reader.py
@@ -15,20 +15,27 @@
 # limitations under the License.
 """Contract tests for DatasetReader."""
 
+import importlib
 import json
 import sys
 import types
+from importlib.metadata import EntryPoint
 
 import pytest
 import torch
 
 pytest.importorskip("datasets", reason="datasets is required (install lerobot[dataset])")
 
-from lerobot.datasets import LeRobotDataset, register_dataset_reader
+from lerobot.datasets import LeRobotDataset, register_dataset_reader, storage as storage_module
 from lerobot.datasets.dataset_reader import DatasetReader
 from lerobot.datasets.io_utils import hf_transform_to_torch
 from lerobot.datasets.language import LANGUAGE_EVENTS
-from lerobot.datasets.storage import _DATASET_READER_MODULES, DEFAULT_STORAGE_FORMAT, localize_remote_root
+from lerobot.datasets.storage import (
+    _DATASET_READER_MODULES,
+    DATASET_READER_ENTRY_POINT_GROUP,
+    DEFAULT_STORAGE_FORMAT,
+    localize_remote_root,
+)
 from lerobot.utils.import_utils import get_safe_default_video_backend
 from tests.fixtures.constants import DEFAULT_FPS, DUMMY_REPO_ID
 
@@ -251,6 +258,141 @@ def test_register_dataset_reader(tmp_path, lerobot_dataset_factory, monkeypatch)
         assert localize_remote_root(DUMMY_REPO_ID, "s3://bucket/ds") == root
     finally:
         _DATASET_READER_MODULES.pop("toyfmt", None)
+
+
+# ── Reader registry: entry point discovery ───────────────────────────
+
+
+def _fake_entry_points(monkeypatch, *pairs):
+    """Make discovery see exactly ``pairs`` of ``(name, value)``, on a scratch registry.
+
+    Returns the list the fake appends to on every scan, so a test can assert how
+    many times the entry points were read.
+    """
+    points = [
+        EntryPoint(name=name, value=value, group=DATASET_READER_ENTRY_POINT_GROUP) for name, value in pairs
+    ]
+    scans = []
+
+    def fake_entry_points(group=None):
+        scans.append(group)
+        return points if group == DATASET_READER_ENTRY_POINT_GROUP else []
+
+    monkeypatch.setattr(storage_module, "entry_points", fake_entry_points)
+    monkeypatch.setattr(storage_module, "_DATASET_READER_MODULES", dict(_DATASET_READER_MODULES))
+    monkeypatch.setattr(storage_module, "_PLUGINS_DISCOVERED", False)
+    return scans
+
+
+def test_entry_point_plugin_serves_a_dataset(tmp_path, lerobot_dataset_factory, monkeypatch):
+    """An installed package's storage format loads without the caller importing it."""
+    root = tmp_path / "src"
+    lerobot_dataset_factory(
+        root=root, total_episodes=2, total_frames=60, use_videos=False, camera_features={}
+    )
+    plain_item = LeRobotDataset(DUMMY_REPO_ID, root=root)[0]
+
+    module = types.ModuleType("plugin_reader")
+    module.DATASET_READER = ToyDatasetReader
+    monkeypatch.setitem(sys.modules, "plugin_reader", module)
+    _fake_entry_points(monkeypatch, ("plugfmt", "plugin_reader"))
+
+    info_path = root / "meta" / "info.json"
+    info = json.loads(info_path.read_text())
+    info["storage_format"] = "plugfmt"
+    info_path.write_text(json.dumps(info))
+
+    # Note there is no register_dataset_reader() call and no import of the
+    # plugin anywhere in this test: declaring the entry point is the whole setup.
+    ds = LeRobotDataset(DUMMY_REPO_ID, root=root)
+
+    assert isinstance(ds.reader, ToyDatasetReader)
+    item = ds[0]
+    for key, expected in plain_item.items():
+        if isinstance(expected, torch.Tensor):
+            torch.testing.assert_close(item[key], expected, rtol=0, atol=0)
+
+
+def test_entry_points_cannot_shadow_builtin_formats(monkeypatch):
+    """Installing a package cannot change how built-in formats are read."""
+    _fake_entry_points(monkeypatch, ("lerobot", "hijack_reader"), ("lance", "hijack_reader"))
+
+    storage_module._discover_plugin_readers()
+
+    assert DEFAULT_STORAGE_FORMAT not in storage_module._DATASET_READER_MODULES
+    assert storage_module._DATASET_READER_MODULES["lance"] == "lerobot.datasets.lance_backend"
+
+
+def test_broken_entry_point_does_not_block_the_others(monkeypatch):
+    """One unusable plugin is skipped; the rest still register."""
+    _fake_entry_points(
+        monkeypatch,
+        ("brokenfmt", "not a module path!"),
+        ("dupefmt", "first_reader"),
+        ("dupefmt", "second_reader"),
+        ("goodfmt", "good_reader"),
+    )
+
+    storage_module._discover_plugin_readers()
+
+    registry = storage_module._DATASET_READER_MODULES
+    assert "brokenfmt" not in registry
+    assert registry["dupefmt"] == "first_reader"  # first declaration wins
+    assert registry["goodfmt"] == "good_reader"
+
+
+def test_discovery_does_not_import_plugin_modules(monkeypatch):
+    """Registration records the module name only, so plugin deps stay optional."""
+    module_name = "lerobot_absent_plugin_module"
+    assert module_name not in sys.modules
+    _fake_entry_points(monkeypatch, ("lazyfmt", module_name))
+
+    storage_module._discover_plugin_readers()
+
+    assert storage_module._DATASET_READER_MODULES["lazyfmt"] == module_name
+    assert module_name not in sys.modules
+
+
+def test_entry_points_are_scanned_once(monkeypatch):
+    """Discovery runs on first lookup and is not repeated on later ones."""
+    scans = _fake_entry_points(monkeypatch, ("oncefmt", "once_reader"))
+
+    for _ in range(3):
+        storage_module._discover_plugin_readers()
+
+    assert scans == [DATASET_READER_ENTRY_POINT_GROUP]
+
+
+def test_discovery_reads_real_distribution_metadata(tmp_path, monkeypatch):
+    """The scan goes through importlib.metadata, so a pip-installed package is found.
+
+    Every other test here fakes ``entry_points``; this one puts a real
+    ``.dist-info`` on ``sys.path`` and lets importlib find it, which is what
+    actually happens for an installed plugin.
+    """
+    dist_info = tmp_path / "lerobot_fake_plugin-0.1.0.dist-info"
+    dist_info.mkdir()
+    (dist_info / "METADATA").write_text("Metadata-Version: 2.1\nName: lerobot-fake-plugin\nVersion: 0.1.0\n")
+    (dist_info / "entry_points.txt").write_text(
+        f"[{DATASET_READER_ENTRY_POINT_GROUP}]\nrealfmt = lerobot_fake_plugin.reader\n"
+    )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    importlib.invalidate_caches()
+    monkeypatch.setattr(storage_module, "_DATASET_READER_MODULES", dict(_DATASET_READER_MODULES))
+    monkeypatch.setattr(storage_module, "_PLUGINS_DISCOVERED", False)
+
+    storage_module._discover_plugin_readers()
+
+    assert storage_module._DATASET_READER_MODULES["realfmt"] == "lerobot_fake_plugin.reader"
+    assert "lerobot_fake_plugin.reader" not in sys.modules
+
+
+def test_unknown_storage_format_lists_discovered_plugins(monkeypatch):
+    """The 'unknown format' error names plugin formats, so a typo is diagnosable."""
+    _fake_entry_points(monkeypatch, ("plugfmt", "plugin_reader"))
+
+    with pytest.raises(ValueError, match="plugfmt"):
+        storage_module._reader_module("nosuchfmt")
 
 
 # ── Delta queries ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary / Motivation

LeRobot already promises "install a package and it works" for six extension types. `register_third_party_plugins()` scans installed distributions for `lerobot_robot_`, `lerobot_camera_`, `lerobot_teleoperator_`, `lerobot_policy_`, `lerobot_env_` and `lerobot_strategy_` prefixes and imports them so they self-register.

Dataset storage backends — the extension point added in #4363 — are the one exception. A format is reachable only if something in the running process has already called `register_dataset_reader()`. That works for the built-ins, which `storage.py` registers itself, but not for a backend shipped as a separate package: the code that opens the dataset has no reason to import it.

The sharp case is `lerobot-dataset-viz`, a console script that constructs the dataset directly:

```python
dataset = LeRobotDataset(repo_id, episodes=[args.episode_index], root=root, tolerance_s=tolerance_s)
```

There is no seam for a user to inject an import. So a third-party backend is usable from library code but not from LeRobot's own CLIs, which is where most people meet it. The workarounds are a wrapper entry point that imports the backend then calls LeRobot's CLI, or a `.pth` file that runs an import at interpreter startup — both work, neither belongs in documentation.

**Why not add a `lerobot_dataset_` prefix to the existing scan?** Two reasons:

1. That mechanism *imports* each distribution so it can self-register. `storage.py` is deliberately the opposite — "Modules are imported lazily so their optional dependencies stay optional." Joining the eager scan would pull a backend's `lancedb`/`pyarrow`/object-store dependencies into every `lerobot-record` startup for users who never touch that format.
2. It is invoked from nine CLI mains, and `lerobot-dataset-viz` is not one of them. Adding the prefix would not fix the motivating case, and library callers would still get nothing.

Entry points give `name → module` *without* importing, and hanging discovery off the registry lookup means no CLI has to remember to opt in.

We hit this building an out-of-tree `BaseDatasetReader` over a different storage model (aligned sensor tables, not a converted LeRobot dataset). The reader itself needed no upstream changes — a good sign about the design in #4363. Making it installable is the piece that's missing, and it's the same wall for anyone exposing an existing data platform to the LeRobot ecosystem.

## Related issues

- Related: #4363 — added the storage-format extension point this completes
- Overlaps: #4567 touches the same docs file (`docs/source/lerobot-dataset-v3.mdx`). Happy to rebase on top of it, or land in either order — my change appends a new subsection and does not modify the Lance section.

## What changed

- New public constant `DATASET_READER_ENTRY_POINT_GROUP = "lerobot.dataset_readers"`. A package declares:

  ```toml
  [project.entry-points."lerobot.dataset_readers"]
  my_format = "my_package.my_reader"
  ```

- `_discover_plugin_readers()` scans that group **once, on first registry lookup** — called from `_reader_module()` and `localize_remote_root()`, not at import.
- Registration goes through the existing `register_dataset_reader()`, so its validation is what keeps built-ins safe: an entry point cannot claim `lerobot` or `lance`. No separate guard — the public function stays the single source of truth for that invariant.
- A plugin that fails to register is logged and skipped, so a broken package degrades to "that format is unavailable" rather than "no datasets load".
- Docs: new "Bring your own storage backend" section covering the two names a backend module must expose, the constructor kwargs, the `localize_root` contract, and when to prefer explicit registration.

No behavior change for existing users. No new dependency (`importlib.metadata` is stdlib). The default format's path is untouched — `make_dataset_reader()` returns `DatasetReader` without consulting the registry, so it never pays for the scan.

## How was this tested (or how to run locally)

```bash
pytest -q tests/datasets/test_dataset_reader.py
```

Seven new tests:

- a plugin declared *only* as an entry point serves a real `LeRobotDataset`, item-for-item identical to the default reader, with no import and no `register_dataset_reader()` call in the test
- entry points cannot shadow `lerobot` or `lance`
- a malformed entry point and a duplicate name are skipped; a following good one still registers
- discovery does not import plugin modules
- entry points are scanned exactly once
- the "unknown storage_format" error lists discovered plugin formats, so a typo is diagnosable
- **discovery reads real distribution metadata** — a genuine `.dist-info` on `sys.path`, so the `importlib.metadata` path is covered rather than mocked

Beyond the suite:

- **Mutation tested.** Removing the discovery calls, removing the scan-once flag, and bypassing `register_dataset_reader()` each fail the relevant tests. An earlier explicit shadow-guard was deleted precisely because mutating it changed nothing — `register_dataset_reader()` already enforced it.
- **End to end with a really-installed package.** Built a small distribution declaring the entry point and `pip install`-ed it: before install the format is unknown; after install it is discovered with no code change; the plugin module is absent from `sys.modules` until `make_dataset_reader()` is called.
- **No regressions.** Full `tests/datasets` before and after on the same machine: 26 failed / 640 passed / 6 errors → 26 failed / **647** passed / 6 errors. Identical failures — pre-existing ffmpeg/torchcodec issues on this host, reproduced on unmodified `main` — and +7 passing, exactly the new tests. `test_video_decoder_cache.py` is excluded from both runs: its torchcodec dylib does not load here, also on unmodified `main`.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`) — all hooks pass on the changed files (ruff, ruff-format, typos, pyupgrade, secret detection, bandit, mypy). The Prettier hook could not install locally (npm `EALLOWGIT` policy on this machine); it only formats Markdown, so CI will confirm the `.mdx`.
- [x] All tests pass locally (`pytest`) — see the before/after comparison above; the only failures are pre-existing on this host and identical on unmodified `main`.
- [x] Documentation updated
- [ ] CI is green — pending first run
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: #

## Reviewer notes

- The interesting design question is precedence. Registration deliberately goes through `register_dataset_reader()` rather than writing `_DATASET_READER_MODULES` directly, because that function already rejects `DEFAULT_STORAGE_FORMAT` and any taken name. That is what makes "an installed package cannot hijack `lance`" true, and there is a test pinning it.
- Second is laziness: discovery reads `entry_point.name`/`.module` as strings and never imports, preserving the "optional dependencies stay optional" property that `_DATASET_READER_MODULES`' own comment calls out. There is a test asserting the module stays out of `sys.modules`.
- `.module` (not `.value`) is used so a `pkg.mod:attr` spelling still resolves to the module the contract lives on.
- Docs overlap with #4567 on the same file — say the word and I'll rebase.
