### PR TITLE
fix(processors): keep saved rename_map when CLI rename_map is empty

### DIFF
--- a/.github/workflows/benchmark_tests.yml
+++ b/.github/workflows/benchmark_tests.yml
@@ -504,7 +504,7 @@ jobs:
                 --eval.n_episodes=1 \
                 --eval.use_async_envs=false \
                 --policy.device=cuda \
-                '--rename_map={\"observation.images.robot0_agentview_left\": \"observation.images.camera1\", \"observation.images.robot0_eye_in_hand\": \"observation.images.camera2\", \"observation.images.robot0_agentview_right\": \"observation.images.camera3\"}' \
+                '--rename_map={\"observation.images.robot0_agentview_left\": \"observation.images.camera1\", \"observation.images.robot0_agentview_right\": \"observation.images.camera2\", \"observation.images.robot0_eye_in_hand\": \"observation.images.camera3\"}' \
                 --output_dir=/tmp/eval-artifacts
               python scripts/ci/extract_task_descriptions.py \
                 --env robocasa \

--- a/docs/source/robocasa.mdx
+++ b/docs/source/robocasa.mdx
@@ -80,7 +80,7 @@ By default the env samples objects only from the `lightwheel` registry (what `--
 
 ## Evaluation
 
-All eval snippets below mirror the CI command (see `.github/workflows/benchmark_tests.yml`). The `--rename_map` argument maps RoboCasa's native camera keys (`robot0_agentview_left` / `robot0_eye_in_hand` / `robot0_agentview_right`) onto the three-camera (`camera1` / `camera2` / `camera3`) input layout the released `smolvla_robocasa` policy was trained on.
+All eval snippets below mirror the CI command (see `.github/workflows/benchmark_tests.yml`). The `--rename_map` argument maps RoboCasa's native camera keys (`robot0_agentview_left` / `robot0_agentview_right` / `robot0_eye_in_hand`) onto the three-camera (`camera1` / `camera2` / `camera3`) input layout the released `smolvla_robocasa` policy was trained on. The mapping below matches the checkpoint's embedded `policy_preprocessor.json`: the left agent view feeds `camera1`, the right agent view feeds `camera2`, and the wrist view feeds `camera3`. If you omit `--rename_map`, the stored map is used as-is.
 
 By default, each task uses the rollout horizon registered by RoboCasa. Set `--env.episode_length=<steps>` to apply the same explicit horizon to every selected task.
 
@@ -95,7 +95,7 @@ lerobot-eval \
   --eval.n_episodes=20 \
   --eval.use_async_envs=false \
   --policy.device=cuda \
-  '--rename_map={"observation.images.robot0_agentview_left": "observation.images.camera1", "observation.images.robot0_eye_in_hand": "observation.images.camera2", "observation.images.robot0_agentview_right": "observation.images.camera3"}'
+  '--rename_map={"observation.images.robot0_agentview_left": "observation.images.camera1", "observation.images.robot0_agentview_right": "observation.images.camera2", "observation.images.robot0_eye_in_hand": "observation.images.camera3"}'
 ```
 
 ### Multi-task evaluation
@@ -111,7 +111,7 @@ lerobot-eval \
   --eval.n_episodes=20 \
   --eval.use_async_envs=false \
   --policy.device=cuda \
-  '--rename_map={"observation.images.robot0_agentview_left": "observation.images.camera1", "observation.images.robot0_eye_in_hand": "observation.images.camera2", "observation.images.robot0_agentview_right": "observation.images.camera3"}'
+  '--rename_map={"observation.images.robot0_agentview_left": "observation.images.camera1", "observation.images.robot0_agentview_right": "observation.images.camera2", "observation.images.robot0_eye_in_hand": "observation.images.camera3"}'
 ```
 
 ### Benchmark-group evaluation
@@ -127,7 +127,7 @@ lerobot-eval \
   --eval.n_episodes=20 \
   --eval.use_async_envs=false \
   --policy.device=cuda \
-  '--rename_map={"observation.images.robot0_agentview_left": "observation.images.camera1", "observation.images.robot0_eye_in_hand": "observation.images.camera2", "observation.images.robot0_agentview_right": "observation.images.camera3"}'
+  '--rename_map={"observation.images.robot0_agentview_left": "observation.images.camera1", "observation.images.robot0_agentview_right": "observation.images.camera2", "observation.images.robot0_eye_in_hand": "observation.images.camera3"}'
 ```
 
 ### Recommended evaluation episodes

--- a/src/lerobot/async_inference/policy_server.py
+++ b/src/lerobot/async_inference/policy_server.py
@@ -40,6 +40,7 @@ import torch
 
 from lerobot.lerobot_types import PolicyAction
 from lerobot.policies import get_policy_class, make_pre_post_processors
+from lerobot.policies.factory import build_rename_override
 from lerobot.processor import PolicyProcessorPipeline
 from lerobot.transport import (
     services_pb2,  # type: ignore
@@ -159,7 +160,7 @@ class PolicyServer(services_pb2_grpc.AsyncInferenceServicer):
             pretrained_path=policy_specs.pretrained_name_or_path,
             preprocessor_overrides={
                 "device_processor": device_override,
-                "rename_observations_processor": {"rename_map": policy_specs.rename_map},
+                **build_rename_override(policy_specs.rename_map),
             },
             postprocessor_overrides={"device_processor": device_override},
         )

--- a/src/lerobot/policies/factory.py
+++ b/src/lerobot/policies/factory.py
@@ -148,6 +148,18 @@ class ProcessorConfigKwargs(TypedDict, total=False):
     dataset_meta: Any | None
 
 
+def build_rename_override(rename_map: dict[str, str] | None) -> dict[str, Any]:
+    """Build the `rename_observations_processor` preprocessor override for a CLI rename map.
+
+    Returns an empty dict when `rename_map` is empty: omitting the override key keeps the
+    rename map saved in the checkpoint's preprocessor, whereas an empty override would
+    replace it with `{}`.
+    """
+    if not rename_map:
+        return {}
+    return {"rename_observations_processor": {"rename_map": dict(rename_map)}}
+
+
 def make_pre_post_processors(
     policy_cfg: PreTrainedConfig,
     pretrained_path: str | None = None,

--- a/src/lerobot/rollout/context.py
+++ b/src/lerobot/rollout/context.py
@@ -37,6 +37,7 @@ from lerobot.datasets import (
     create_initial_features,
 )
 from lerobot.policies import get_policy_class, make_pre_post_processors
+from lerobot.policies.factory import build_rename_override
 from lerobot.policies.pretrained import PreTrainedPolicy
 from lerobot.processor import (
     PolicyProcessorPipeline,
@@ -543,7 +544,7 @@ def build_rollout_context(
         dataset_stats=dataset_stats,
         preprocessor_overrides={
             "device_processor": {"device": cfg.device},
-            "rename_observations_processor": {"rename_map": cfg.rename_map},
+            **build_rename_override(cfg.rename_map),
         },
     )
 

--- a/src/lerobot/scripts/lerobot_eval.py
+++ b/src/lerobot/scripts/lerobot_eval.py
@@ -85,6 +85,7 @@ from lerobot.envs import (
 from lerobot.envs.utils import NEW_ROLLOUT_OPTION
 from lerobot.lerobot_types import PolicyAction
 from lerobot.policies import PreTrainedPolicy, make_policy, make_pre_post_processors
+from lerobot.policies.factory import build_rename_override
 from lerobot.processor import PolicyProcessorPipeline
 from lerobot.utils.constants import ACTION, DONE, OBS_IMAGE, OBS_IMAGES, OBS_STR, REWARD
 from lerobot.utils.device_utils import get_safe_torch_device
@@ -768,9 +769,9 @@ def eval_main(cfg: EvalPipelineConfig):
     policy.eval()
 
     # The inference device is automatically set to match the detected hardware, overriding any previous device settings from training to ensure compatibility.
-    preprocessor_overrides = {
+    preprocessor_overrides: dict[str, Any] = {
         "device_processor": {"device": str(policy.config.device)},
-        "rename_observations_processor": {"rename_map": cfg.rename_map},
+        **build_rename_override(cfg.rename_map),
     }
 
     preprocessor, postprocessor = make_pre_post_processors(

--- a/src/lerobot/scripts/lerobot_train.py
+++ b/src/lerobot/scripts/lerobot_train.py
@@ -73,7 +73,7 @@ from lerobot.envs import close_envs, make_env, make_env_pre_post_processors
 from lerobot.jobs import submit_to_hf
 from lerobot.optim.factory import make_optimizer_and_scheduler
 from lerobot.policies import PreTrainedPolicy, make_policy, make_pre_post_processors
-from lerobot.policies.factory import ProcessorConfigKwargs
+from lerobot.policies.factory import ProcessorConfigKwargs, build_rename_override
 from lerobot.processor.rename_processor import rename_batch_keys, rename_stats
 from lerobot.rewards import make_reward_pre_post_processors
 from lerobot.utils.collate import lerobot_collate_fn
@@ -503,13 +503,13 @@ def train(cfg: TrainPipelineConfig):
     if cfg.is_reward_model_training:
         processor_kwargs["dataset_meta"] = dataset.meta
     if not cfg.is_reward_model_training and processor_pretrained_path is not None:
-        preprocessor_overrides = {
+        preprocessor_overrides: dict[str, Any] = {
             "device_processor": {"device": device.type},
             "normalizer_processor": {
                 "features": {**policy.config.input_features, **policy.config.output_features},
                 "norm_map": policy.config.normalization_mapping,
             },
-            "rename_observations_processor": {"rename_map": cfg.rename_map},
+            **build_rename_override(cfg.rename_map),
         }
         postprocessor_overrides = {
             "unnormalizer_processor": {

--- a/tests/processor/test_rename_processor.py
+++ b/tests/processor/test_rename_processor.py
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import json
 import tempfile
 from pathlib import Path
 
@@ -20,8 +21,11 @@ import numpy as np
 import torch
 
 from lerobot.configs.types import FeatureType, PipelineFeatureType
+from lerobot.policies.factory import build_rename_override
 from lerobot.processor import (
     DataProcessorPipeline,
+    DeviceProcessorStep,
+    PolicyProcessorPipeline,
     ProcessorStepRegistry,
     RenameObservationsProcessorStep,
     TransitionKey,
@@ -534,3 +538,45 @@ def test_rename_stats_basic():
     # Ensure deep copy: mutate original and verify renamed unaffected
     orig[OBS_STATE]["mean"][0] = 42.0
     assert renamed["observation.robot_state"]["mean"][0] != 42.0
+
+
+def test_empty_cli_rename_map_keeps_saved_rename_map(tmp_path):
+    """A pipeline saved with a rename map must keep it when no CLI rename map is given (#4548)."""
+    saved_map = {
+        "observation.images.robot0_agentview_left": "observation.images.camera1",
+        "observation.images.robot0_agentview_right": "observation.images.camera2",
+        "observation.images.robot0_eye_in_hand": "observation.images.camera3",
+    }
+    pipeline = PolicyProcessorPipeline(
+        [RenameObservationsProcessorStep(rename_map=saved_map), DeviceProcessorStep(device="cpu")]
+    )
+    pipeline.save_pretrained(tmp_path, config_filename="policy_preprocessor.json")
+    assert (
+        json.loads((tmp_path / "policy_preprocessor.json").read_text())["steps"][0]["config"]["rename_map"]
+        == saved_map
+    )
+
+    # No CLI rename map: the override built for the loaders must not touch the saved map,
+    # while the device override that always ships alongside it still applies.
+    overrides = {"device_processor": {"device": "cpu"}, **build_rename_override({})}
+    loaded = PolicyProcessorPipeline.from_pretrained(
+        tmp_path, config_filename="policy_preprocessor.json", overrides=overrides
+    )
+    rename_step = next(s for s in loaded.steps if isinstance(s, RenameObservationsProcessorStep))
+    assert rename_step.rename_map == saved_map
+
+
+def test_non_empty_cli_rename_map_overrides_saved_rename_map(tmp_path):
+    """An explicit CLI rename map still replaces the saved map."""
+    saved_map = {"observation.images.old": "observation.images.camera1"}
+    pipeline = PolicyProcessorPipeline([RenameObservationsProcessorStep(rename_map=saved_map)])
+    pipeline.save_pretrained(tmp_path, config_filename="policy_preprocessor.json")
+
+    cli_map = {"observation.images.left": "observation.images.camera1"}
+    loaded = PolicyProcessorPipeline.from_pretrained(
+        tmp_path,
+        config_filename="policy_preprocessor.json",
+        overrides={**build_rename_override(cli_map)},
+    )
+    rename_step = next(s for s in loaded.steps if isinstance(s, RenameObservationsProcessorStep))
+    assert rename_step.rename_map == cli_map


### PR DESCRIPTION
## Summary / Motivation

Issue #4548 found that evaluating `lerobot/smolvla_robocasa` without `--rename_map` silently drops the camera mapping stored in the checkpoint's `policy_preprocessor.json`. The eval/train/rollout/policy-server loaders always passed `cfg.rename_map` (default `{}`) as a `rename_observations_processor` override, and the shallow config merge in `PolicyProcessorPipeline` replaced the saved map with that empty dict, so the stored `left→camera1, right→camera2, eye_in_hand→camera3` mapping never actually applied.

The docs example (and the CI command it mirrors) also swaps two cameras: it maps `eye_in_hand→camera2` and `agentview_right→camera3`, while the checkpoint's embedded preprocessor stores `agentview_right→camera2` and `eye_in_hand→camera3`.

## Related issues

- Fixes #4548 (item 2, the rename_map part; item 1, the eval task-prompt mismatch, is covered by #4476)

## What changed

- New `build_rename_override()` helper in `policies/factory.py`: returns the `rename_observations_processor` override only when the CLI rename map is non-empty, so an absent `--rename_map` leaves the saved preprocessor config untouched.
- The four loader call sites (`lerobot_eval.py`, `lerobot_train.py`, `rollout/context.py`, `async_inference/policy_server.py`) build their preprocessor overrides through the helper.
- The `--rename_map` examples in `docs/source/robocasa.mdx` and the RoboCasa job in `.github/workflows/benchmark_tests.yml` now match the checkpoint's embedded map, and the docs note that omitting `--rename_map` keeps the stored map.

No behavior change when `--rename_map` is given explicitly; an explicit map still overrides the stored one.

## How was this tested (or how to run locally)

- New tests in `tests/processor/test_rename_processor.py`: `pytest -q tests/processor/test_rename_processor.py`. `test_empty_cli_rename_map_keeps_saved_rename_map` fails on main (`assert {} == saved map`) and passes with the fix; `test_non_empty_cli_rename_map_overrides_saved_rename_map` covers the explicit-override path.
- Checked the stored map against the live checkpoint file:
  ```python
  from huggingface_hub import hf_hub_download
  import json
  p = hf_hub_download("lerobot/smolvla_robocasa", "policy_preprocessor.json")
  print(json.load(open(p))["steps"][0]["config"]["rename_map"])
  # robot0_agentview_left→camera1, robot0_agentview_right→camera2, robot0_eye_in_hand→camera3
  ```
- `pytest -q tests/processor/ tests/async_inference` (453 passed), `pre-commit run` over the changed files (ruff, ruff-format, mypy, typos, prettier all pass).

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: #4476 (read the diff while scoping this fix; its `task_prompt` default and this rename_map fix are complementary)

## Reviewer notes

- The empty-map guard lives in `build_rename_override` rather than in `PolicyProcessorPipeline._instantiate_step` because the shallow `{**saved, **override}` merge is generic: other steps legitimately use an empty dict to clear a saved value, so skipping empties there would change override semantics for every step type.
- The CI RoboCasa smoke job keeps passing `--rename_map` explicitly, so its behavior only changes through the corrected camera order (camera2/camera3 inputs swap, which is the point of the fix).
