### PR TITLE
fix(policies): raise when strict pi0 checkpoint loading fails

### DIFF
--- a/src/lerobot/policies/pi0/modeling_pi0.py
+++ b/src/lerobot/policies/pi0/modeling_pi0.py
@@ -843,6 +843,8 @@ class PI0Policy(PreTrainedPolicy):
                 original_state_dict = load_file(resolved_file)
                 print("✓ Loaded state dict from model.safetensors")
             except Exception as e:
+                if strict:
+                    raise
                 print(f"Could not load state dict from remote files: {e}")
                 print("Returning model without loading pretrained weights")
                 return model
@@ -892,6 +894,8 @@ class PI0Policy(PreTrainedPolicy):
                 print("All keys loaded successfully!")
 
         except Exception as e:
+            if strict:
+                raise
             print(f"Warning: Could not load state dict: {e}")
 
         return model

--- a/src/lerobot/policies/pi05/modeling_pi05.py
+++ b/src/lerobot/policies/pi05/modeling_pi05.py
@@ -987,6 +987,8 @@ class PI05Policy(PreTrainedPolicy):
                 original_state_dict = load_file(resolved_file)
                 print("✓ Loaded state dict from model.safetensors")
             except Exception as e:
+                if strict:
+                    raise
                 print(f"Could not load state dict from remote files: {e}")
                 print("Returning model without loading pretrained weights")
                 return model
@@ -1038,6 +1040,8 @@ class PI05Policy(PreTrainedPolicy):
                 print("All keys loaded successfully!")
 
         except Exception as e:
+            if strict:
+                raise
             print(f"Warning: Could not load state dict: {e}")
 
         return model

--- a/src/lerobot/policies/pi0_fast/modeling_pi0_fast.py
+++ b/src/lerobot/policies/pi0_fast/modeling_pi0_fast.py
@@ -855,6 +855,8 @@ class PI0FastPolicy(PreTrainedPolicy):
                 original_state_dict = load_file(resolved_file)
                 print("✓ Loaded state dict from model.safetensors")
             except Exception as e:
+                if strict:
+                    raise
                 print(f"Could not load state dict from remote files: {e}")
                 print("Returning model without loading pretrained weights")
                 return model
@@ -904,6 +906,8 @@ class PI0FastPolicy(PreTrainedPolicy):
                 print("All keys loaded successfully!")
 
         except Exception as e:
+            if strict:
+                raise
             print(f"Warning: Could not load state dict: {e}")
 
         return model

--- a/tests/policies/pi0_pi05/test_pi0.py
+++ b/tests/policies/pi0_pi05/test_pi0.py
@@ -125,3 +125,19 @@ def test_config_creation():
     except Exception as e:
         print(f"Config creation failed: {e}")
         raise
+
+
+def test_from_pretrained_strict_raises_on_bad_checkpoint(tmp_path):
+    """A checkpoint that fails to load must raise, not return an untrained model (#4577)."""
+    from safetensors.torch import save_file
+
+    class TinyPI0Policy(PI0Policy):
+        def __init__(self, config, **kwargs):
+            torch.nn.Module.__init__(self)
+            self.config = config
+            self.model = torch.nn.Linear(1, 1)
+
+    save_file({"model.bogus": torch.zeros(1)}, tmp_path / "model.safetensors")
+
+    with pytest.raises(RuntimeError, match="Unexpected key"):
+        TinyPI0Policy.from_pretrained(tmp_path, config=PI0Config(), strict=True)

--- a/tests/policies/pi0_pi05/test_pi0.py
+++ b/tests/policies/pi0_pi05/test_pi0.py
@@ -27,6 +27,8 @@ from lerobot.policies.pi0 import (  # noqa: E402
     PI0Policy,
     make_pi0_pre_post_processors,  # noqa: E402
 )
+from lerobot.policies.pi0_fast import PI0FastConfig, PI0FastPolicy  # noqa: E402
+from lerobot.policies.pi05 import PI05Config, PI05Policy  # noqa: E402
 from lerobot.utils.random_utils import set_seed  # noqa: E402
 from tests.utils import require_cuda, require_hf_token  # noqa: E402
 
@@ -127,11 +129,19 @@ def test_config_creation():
         raise
 
 
-def test_from_pretrained_strict_raises_on_bad_checkpoint(tmp_path):
+@pytest.mark.parametrize(
+    ("policy_cls", "config_cls"),
+    [
+        (PI0Policy, PI0Config),
+        (PI05Policy, PI05Config),
+        (PI0FastPolicy, PI0FastConfig),
+    ],
+)
+def test_from_pretrained_strict_raises_on_bad_checkpoint(tmp_path, policy_cls, config_cls):
     """A checkpoint that fails to load must raise, not return an untrained model (#4577)."""
     from safetensors.torch import save_file
 
-    class TinyPI0Policy(PI0Policy):
+    class TinyPolicy(policy_cls):
         def __init__(self, config, **kwargs):
             torch.nn.Module.__init__(self)
             self.config = config
@@ -140,4 +150,4 @@ def test_from_pretrained_strict_raises_on_bad_checkpoint(tmp_path):
     save_file({"model.bogus": torch.zeros(1)}, tmp_path / "model.safetensors")
 
     with pytest.raises(RuntimeError, match="Unexpected key"):
-        TinyPI0Policy.from_pretrained(tmp_path, config=PI0Config(), strict=True)
+        TinyPolicy.from_pretrained(tmp_path, config=config_cls(), strict=True)


### PR DESCRIPTION
## Summary / Motivation

`PI0Policy`, `PI05Policy` and `PI0FastPolicy` override `from_pretrained` and catch every loading error. A checkpoint that does not fit the model comes back as a freshly initialized policy with only a printed warning, even with the default `strict=True`. `strict` already reaches `load_state_dict`, the surrounding `try` just swallowed the error it raised.

## Related issues

- Fixes #4577

## What changed

- Both `except` blocks in the three `from_pretrained` overrides re-raise when `strict` is set.
- `strict=False` keeps the existing warn-and-return behaviour.

## How was this tested (or how to run locally)

- Tests added: `test_from_pretrained_strict_raises_on_bad_checkpoint` in `tests/policies/pi0_pi05/test_pi0.py`. It loads a safetensors file with an unexpected key through a stub subclass so it runs on CPU without weights. Fails on `main`, passes with this change.
- `pytest -q tests/policies/pi0_pi05 tests/policies/pi0_fast`, `ruff check`, `ruff format --check`.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [ ] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here: #

## Reviewer notes

`wall_x` has the same pattern but defaults to `strict=False` and loads non-strict, so it is left as is.