### PR TITLE
feat(rollout): add chunked_sync inference engine for relative-action …

### DIFF
--- a/src/lerobot/rollout/configs.py
+++ b/src/lerobot/rollout/configs.py
@@ -237,7 +237,7 @@ class RolloutConfig:
     # Strategy (polymorphic: --strategy.type=base|sentry|highlight|dagger|episodic)
     strategy: RolloutStrategyConfig = field(default_factory=BaseStrategyConfig)
 
-    # Inference backend (polymorphic: --inference.type=sync|rtc)
+    # Inference backend (polymorphic: --inference.type=sync|rtc|chunked_sync)
     inference: InferenceEngineConfig = field(default_factory=SyncInferenceConfig)
 
     # Dataset (required for sentry, highlight, dagger; None for base)

--- a/src/lerobot/rollout/inference/chunked_sync.py
+++ b/src/lerobot/rollout/inference/chunked_sync.py
@@ -1,0 +1,77 @@
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Chunked-sync inference engine: predict a full chunk, decode it once, serve it tick by tick."""
+
+from __future__ import annotations
+
+import logging
+from collections import deque
+from contextlib import nullcontext
+from copy import copy
+
+import torch
+
+from lerobot.policies.utils import make_robot_action, prepare_observation_for_inference
+from lerobot.rollout.inference.sync import SyncInferenceEngine
+
+logger = logging.getLogger(__name__)
+
+
+class ChunkedSyncInferenceEngine(SyncInferenceEngine):
+    """Predict the whole action chunk at once, postprocess it as a chunk
+    (so relative actions are anchored to the observation that produced them),
+    then pop one action per control tick.  When the queue empties, infer again.
+    """
+
+    def __init__(self, *args, execution_steps: int | None = None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._queue: deque[torch.Tensor] = deque()
+        self._execution_steps = execution_steps
+        logger.info("ChunkedSyncInferenceEngine initialized (execution_steps=%s)", execution_steps)
+
+    def reset(self) -> None:
+        self._queue.clear()
+        super().reset()
+
+    def get_action(self, obs_frame: dict | None) -> torch.Tensor | None:
+        if self._queue:
+            return self._queue.popleft()
+        if obs_frame is None:
+            return None
+
+        observation = copy(obs_frame)
+        autocast_ctx = (
+            torch.autocast(device_type=self._device.type)
+            if self._device.type == "cuda" and self._policy.config.use_amp
+            else nullcontext()
+        )
+        task, task_changed = self._take_task()
+        with torch.inference_mode(), autocast_ctx:
+            if task_changed:
+                self._policy.drop_queued_actions()
+            observation = prepare_observation_for_inference(observation, self._device, task, self._robot_type)
+            observation = self._preprocessor(observation)
+            chunk = self._policy.predict_action_chunk(observation)  # (B, H, D)
+            chunk = self._postprocessor(chunk)  # decoded as a chunk
+
+        chunk = chunk.squeeze(0).cpu()  # (H, D)
+        if self._execution_steps is not None:
+            chunk = chunk[: self._execution_steps]
+
+        for step in chunk:
+            action_dict = make_robot_action(step, self._dataset_features)
+            self._queue.append(torch.tensor([action_dict[k] for k in self._ordered_action_keys]))
+        self._set_dispatched_task(task)
+        logger.info("ChunkedSync: queued %d actions", len(self._queue))
+        return self._queue.popleft()

--- a/src/lerobot/rollout/inference/factory.py
+++ b/src/lerobot/rollout/inference/factory.py
@@ -34,6 +34,7 @@ from lerobot.processor import PolicyProcessorPipeline
 
 from ..robot_wrapper import ThreadSafeRobot
 from .base import InferenceEngine
+from .chunked_sync import ChunkedSyncInferenceEngine
 from .rtc import RTCInferenceEngine
 from .sync import SyncInferenceEngine
 
@@ -74,6 +75,19 @@ class RTCInferenceConfig(InferenceEngineConfig):
     queue_threshold: int = 30
 
 
+@InferenceEngineConfig.register_subclass("chunked_sync")
+@dataclass
+class ChunkedSyncInferenceConfig(InferenceEngineConfig):
+    """Synchronous chunk execution: predict a chunk, decode it once, serve it tick by tick.
+
+    Unlike ``sync``, the whole chunk is postprocessed in a single call, so
+    relative actions stay anchored to the observation that produced them.
+    The robot idles while the next chunk is computed.
+    """
+
+    execution_steps: int | None = None
+
+
 # ---------------------------------------------------------------------------
 # Factory
 # ---------------------------------------------------------------------------
@@ -98,6 +112,18 @@ def create_inference_engine(
 ) -> InferenceEngine:
     """Instantiate the appropriate inference engine from a config object."""
     logger.info("Creating inference engine: %s", config.type)
+    if isinstance(config, ChunkedSyncInferenceConfig):
+        return ChunkedSyncInferenceEngine(
+            policy=policy,
+            preprocessor=preprocessor,
+            postprocessor=postprocessor,
+            dataset_features=dataset_features,
+            ordered_action_keys=ordered_action_keys,
+            task=task,
+            device=device,
+            robot_type=robot_wrapper.robot_type,
+            execution_steps=config.execution_steps,
+        )
     if isinstance(config, SyncInferenceConfig):
         return SyncInferenceEngine(
             policy=policy,


### PR DESCRIPTION
## What this does

Implements the candidate fix noted in the `TODO(Steven)` at the top of `rollout/inference/sync.py`:

> Candidate fix: drive the policy via `predict_action_chunk` and serve a local FIFO of postprocessed actions. Eliminates drift by construction.

`chunked_sync` predicts a full action chunk, postprocesses the **whole chunk in one call**, and then serves it one action per control tick. Because the chunk is decoded against the observation that produced it, relative actions stay anchored to a single reference state instead of being re-anchored on every tick. The robot idles while the next chunk is computed.

--inference.type=chunked_sync
--inference.execution_steps=8 # optional: re-infer before the chunk is exhausted

## Why

Relative-action policies are currently rejected by `sync` and only usable with `rtc`. RTC handles inference delay by freezing the actions that will execute during inference and inpainting the rest, but that only holds within the delay range the policy was trained for. GR00T N1.7 ships with `rtc_max_delay_steps: 12`; on our setup inference takes roughly 800ms, i.e. ~24 steps at 30Hz against a 16-step horizon — well outside that envelope.

In that regime we saw the arm oscillate back and forth, and at door positions away from the training pose the wrist rotated 180° into a configuration that appears nowhere in the training data.

## Real-robot results

SO-101 arm, thumbturn door-unlocking task. GR00T N1.7 finetuned on 145 teleoperated demonstrations, all recorded at a single door position (relative actions, 16-step horizon).

With `chunked_sync`, the task succeeded at all five door positions we tested, including positions well outside the training distribution.

With `rtc` on the same checkpoint, positions away from the training pose showed the oscillation described above, and at the furthest position the wrist diverged.

Effective control rate was ~15.7 Hz against a 30 Hz target — the cost of idling during inference. Every control tick had an action to send; there were no starved ticks.

## Scope

This engine bypasses `select_action`, so as the original TODO notes it is not appropriate for SAC (no `predict_action_chunk`), ACT temporal ensembling, or Diffusion-family observation-history queues. It currently subclasses `SyncInferenceEngine` for the shared plumbing; happy to split it out and add explicit guards.

This is a first pass — I'd welcome feedback on the design before polishing it.