### PR TITLE
feat(training): log worker and video loading timings

### DIFF
--- a/src/lerobot/configs/default.py
+++ b/src/lerobot/configs/default.py
@@ -53,6 +53,8 @@ class DatasetConfig:
     # Has no effect on datasets without depth cameras.
     depth_output_unit: str = DEFAULT_DEPTH_UNIT
     streaming: bool = False
+    # Log worker-side batch preparation/video loading time (default parquet/mp4 reader only).
+    profile_loading: bool = True
     # Fraction of episodes held out per task for offline evaluation (0.0 = disabled).
     eval_split: float = 0.0
 

--- a/src/lerobot/datasets/dataset_reader.py
+++ b/src/lerobot/datasets/dataset_reader.py
@@ -19,6 +19,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from time import perf_counter
 
 import datasets
 import torch
@@ -153,6 +154,7 @@ class DatasetReader(BaseDatasetReader):
         self.set_image_transforms(image_transforms)
         self._return_uint8 = return_uint8
         self._depth_output_unit = depth_output_unit
+        self.profile_loading = False
 
         self.hf_dataset: datasets.Dataset | None = None
         self._absolute_to_relative_idx: dict[int, int] | None = None
@@ -553,6 +555,8 @@ class DatasetReader(BaseDatasetReader):
         Returns:
             One fully assembled frame dict per entry in ``indices``, in order.
         """
+        start = perf_counter() if self.profile_loading else 0.0
+        video_loading_s = 0.0
         if self.hf_dataset is None:
             # One-shot load after finalize()
             self.load_and_activate()
@@ -581,8 +585,11 @@ class DatasetReader(BaseDatasetReader):
         if len(self._meta.video_keys) > 0:
             current_ts = [float(items[i]["timestamp"]) for i in range(n)]
             query_timestamps = self._get_query_timestamps(current_ts, query_indices_per_item)
+            video_start = perf_counter() if self.profile_loading else 0.0
             for i, video in enumerate(self._query_videos(query_timestamps, ep_idxs)):
                 items[i].update(video)
+            if self.profile_loading:
+                video_loading_s = perf_counter() - video_start
 
         for i in range(n):
             item = items[i]
@@ -604,4 +611,11 @@ class DatasetReader(BaseDatasetReader):
 
             item["task"] = self._meta.tasks.iloc[int(item["task_index"])].name
 
+        if self.profile_loading:
+            # Batch wall time, not summed per-file CPU time. Includes seeks/decoding/conversion;
+            # preparation also includes tabular reads/transforms, but excludes collation and IPC.
+            timings = {"worker_loading_s": perf_counter() - start, "video_loading_s": video_loading_s}
+            timings = {key: torch.tensor(value, dtype=torch.float32) for key, value in timings.items()}
+            for item in items:
+                item["_loader_timings"] = timings
         return items

--- a/src/lerobot/scripts/lerobot_train.py
+++ b/src/lerobot/scripts/lerobot_train.py
@@ -60,7 +60,8 @@ from lerobot.common.train_utils import (
 from lerobot.common.wandb_utils import WandBLogger
 from lerobot.configs import JobConfig, parser
 from lerobot.configs.train import TrainPipelineConfig
-from lerobot.datasets import EpisodeAwareSampler, compute_sampler_state
+from lerobot.datasets import EpisodeAwareSampler, LeRobotDataset, compute_sampler_state
+from lerobot.datasets.dataset_reader import DatasetReader
 from lerobot.datasets.factory import make_train_eval_datasets
 from lerobot.distributed import (
     ParallelDims,
@@ -130,8 +131,14 @@ def _preprocess_dataset_batch(
     camera_keys: list[str],
     rename_map: dict[str, str],
     preprocessor: Any,
+    train_tracker: MetricsTracker | None = None,
 ) -> Any:
     """Prepare a raw dataset batch identically for training and held-out evaluation."""
+    timings = batch.pop("_loader_timings", {})
+    if train_tracker is not None:
+        # One observation per delivered batch, averaged over the logging window and across ranks.
+        # Each sample carries its source batch's elapsed time; do not sum duplicates.
+        train_tracker.update_metrics({key: values.mean().item() for key, values in timings.items()})
     for cam_key in camera_keys:
         if cam_key in batch and batch[cam_key].dtype == torch.uint8:
             batch[cam_key] = batch[cam_key].to(dtype=torch.float32) / 255.0
@@ -282,6 +289,10 @@ def make_dataloaders(
         tuple[torch.utils.data.DataLoader, torch.utils.data.DataLoader | None]: The train
         dataloader and the eval dataloader (None when no eval split exists).
     """
+    if isinstance(dataset, LeRobotDataset) and isinstance(reader := dataset._ensure_reader(), DatasetReader):
+        reader.profile_loading = cfg.dataset.profile_loading
+    elif cfg.dataset.profile_loading:
+        logging.warning("Worker loading timings are unavailable for this dataset reader.")
     active_cfg = cfg.trainable_config
     if not cfg.dataset.streaming:
         # All non-streaming (map-style) datasets use EpisodeAwareSampler.
@@ -728,7 +739,9 @@ def train(cfg: TrainPipelineConfig):
         batch = next(dl_iter)
         preprocessing_start = time.perf_counter()
         train_tracker.dataloading_s = preprocessing_start - step_start
-        batch = _preprocess_dataset_batch(batch, dataset.meta.camera_keys, cfg.rename_map, preprocessor)
+        batch = _preprocess_dataset_batch(
+            batch, dataset.meta.camera_keys, cfg.rename_map, preprocessor, train_tracker
+        )
         train_tracker.preprocessing_s = time.perf_counter() - preprocessing_start
 
         train_tracker, _ = update_policy(

--- a/tests/datasets/test_dataset_reader.py
+++ b/tests/datasets/test_dataset_reader.py
@@ -200,35 +200,10 @@ def test_loading_timings_are_opt_in_batch_wall_times(
             "worker_loading_s": 8.0,
             "video_loading_s": 3.0 if use_videos else 0.0,
         }
-        assert got.keys() == want.keys()
-        for key in want:
-            if isinstance(want[key], torch.Tensor):
-                torch.testing.assert_close(got[key], want[key], rtol=0, atol=0)
-            else:
-                assert got[key] == want[key]
+        assert got.pop("task") == want.pop("task")
+        torch.testing.assert_close(got, want, rtol=0, atol=0)
     monkeypatch.setattr("lerobot.datasets.dataset_reader.perf_counter", lambda: 20.0)
     assert dataset.__getitems__([]) == []
-
-
-@pytest.mark.parametrize("num_workers", [0, 2])
-def test_loading_timings_survive_dataloader_workers(tmp_path, lerobot_dataset_factory, num_workers):
-    dataset = lerobot_dataset_factory(
-        root=tmp_path / "ds", total_episodes=1, total_frames=10, use_videos=True
-    )
-    dataset.reader._video_backend = "pyav"
-    dataset.reader.profile_loading = True
-    loader = torch.utils.data.DataLoader(
-        dataset,
-        batch_size=3,
-        num_workers=num_workers,
-        multiprocessing_context="spawn" if num_workers else None,
-    )
-    for batch in loader:
-        timing = batch.pop("_loader_timings")
-        total, video = timing["worker_loading_s"], timing["video_loading_s"]
-        assert total.shape == batch["index"].shape
-        assert torch.all(total == total[0])  # one source-batch duration, including the final short batch
-        assert torch.all((total >= video) & (video > 0))
 
 
 @pytest.mark.parametrize("use_delta", [False, True])

--- a/tests/datasets/test_dataset_reader.py
+++ b/tests/datasets/test_dataset_reader.py
@@ -176,6 +176,61 @@ def test_image_transforms_are_applied(tmp_path, lerobot_dataset_factory):
 # ── Batched get_items ────────────────────────────────────────────────
 
 
+@pytest.mark.parametrize("use_videos", [False, True])
+def test_loading_timings_are_opt_in_batch_wall_times(
+    tmp_path, lerobot_dataset_factory, monkeypatch, use_videos
+):
+    dataset = lerobot_dataset_factory(
+        root=tmp_path / "ds", total_episodes=1, total_frames=10, use_videos=use_videos
+    )
+    dataset.reader._video_backend = "pyav"
+
+    def unexpected_clock():
+        pytest.fail("Profiling must not read the clock when disabled")
+
+    monkeypatch.setattr("lerobot.datasets.dataset_reader.perf_counter", unexpected_clock)
+    expected = dataset.__getitems__([3, 1, 3])
+    assert all("_loader_timings" not in item for item in expected)
+    ticks = iter([10.0, 12.0, 15.0, 18.0] if use_videos else [10.0, 18.0])
+    monkeypatch.setattr("lerobot.datasets.dataset_reader.perf_counter", lambda: next(ticks))
+    dataset.reader.profile_loading = True
+    actual = dataset.__getitems__([3, 1, 3])
+    for got, want in zip(actual, expected, strict=True):
+        assert got.pop("_loader_timings") == {
+            "worker_loading_s": 8.0,
+            "video_loading_s": 3.0 if use_videos else 0.0,
+        }
+        assert got.keys() == want.keys()
+        for key in want:
+            if isinstance(want[key], torch.Tensor):
+                torch.testing.assert_close(got[key], want[key], rtol=0, atol=0)
+            else:
+                assert got[key] == want[key]
+    monkeypatch.setattr("lerobot.datasets.dataset_reader.perf_counter", lambda: 20.0)
+    assert dataset.__getitems__([]) == []
+
+
+@pytest.mark.parametrize("num_workers", [0, 2])
+def test_loading_timings_survive_dataloader_workers(tmp_path, lerobot_dataset_factory, num_workers):
+    dataset = lerobot_dataset_factory(
+        root=tmp_path / "ds", total_episodes=1, total_frames=10, use_videos=True
+    )
+    dataset.reader._video_backend = "pyav"
+    dataset.reader.profile_loading = True
+    loader = torch.utils.data.DataLoader(
+        dataset,
+        batch_size=3,
+        num_workers=num_workers,
+        multiprocessing_context="spawn" if num_workers else None,
+    )
+    for batch in loader:
+        timing = batch.pop("_loader_timings")
+        total, video = timing["worker_loading_s"], timing["video_loading_s"]
+        assert total.shape == batch["index"].shape
+        assert torch.all(total == total[0])  # one source-batch duration, including the final short batch
+        assert torch.all((total >= video) & (video > 0))
+
+
 @pytest.mark.parametrize("use_delta", [False, True])
 @pytest.mark.parametrize("backend", ["pyav", get_safe_default_video_backend()])
 def test_get_items_batched_matches_single(tmp_path, lerobot_dataset_factory, use_delta, backend):

--- a/tests/scripts/test_lerobot_train_batch_preprocessing.py
+++ b/tests/scripts/test_lerobot_train_batch_preprocessing.py
@@ -81,10 +81,12 @@ def test_preprocessing_removes_and_reports_worker_timings(training):
 
 
 @pytest.mark.parametrize("enabled", [None, False, True])
-def test_training_loader_enables_profiling(tmp_path, lerobot_dataset_factory, enabled):
+@pytest.mark.parametrize("num_workers,use_videos", [(0, False), (2, True)])
+def test_training_loader_profiling(tmp_path, lerobot_dataset_factory, enabled, num_workers, use_videos):
     dataset = lerobot_dataset_factory(
-        root=tmp_path / "ds", total_episodes=1, total_frames=10, use_videos=False
+        root=tmp_path / "ds", total_episodes=1, total_frames=10, use_videos=use_videos
     )
+    dataset.reader._video_backend = "pyav"
     cfg = SimpleNamespace(
         dataset=DatasetConfig(
             repo_id="test/dataset", **({} if enabled is None else {"profile_loading": enabled})
@@ -92,16 +94,23 @@ def test_training_loader_enables_profiling(tmp_path, lerobot_dataset_factory, en
         trainable_config=SimpleNamespace(),
         seed=1,
         resume=False,
-        num_workers=0,
+        num_workers=num_workers,
         batch_size=3,
         persistent_workers=False,
+        prefetch_factor=2,
+        dataloader_multiprocessing_context="spawn" if num_workers else None,
     )
     loader, _ = make_dataloaders(cfg, dataset, None, 0, SimpleNamespace(device_type="cpu"))
-    batch = next(iter(loader))
-    assert ("_loader_timings" in batch) is (enabled is not False)
-    if enabled is not False:
-        assert batch["_loader_timings"]["worker_loading_s"].dtype == torch.float32
-        assert torch.all(batch["_loader_timings"]["video_loading_s"] == 0)
+    for batch in loader:
+        assert ("_loader_timings" in batch) is (enabled is not False)
+        if enabled is not False:
+            total, video = (batch["_loader_timings"][key] for key in ("worker_loading_s", "video_loading_s"))
+            assert total.dtype == torch.float32 and total.shape == batch["index"].shape
+            assert torch.all(
+                total == total[0]
+            )  # Same duration per source batch, including the short last one.
+            assert torch.all(total >= video)
+            assert torch.all(video > 0) if use_videos else torch.all(video == 0)
 
 
 def test_default_profiling_does_not_break_streaming(caplog):

--- a/tests/scripts/test_lerobot_train_batch_preprocessing.py
+++ b/tests/scripts/test_lerobot_train_batch_preprocessing.py
@@ -12,13 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 
 pytest.importorskip("datasets", reason="datasets is required (install lerobot[dataset])")
 
-from lerobot.scripts.lerobot_train import _preprocess_dataset_batch  # noqa: E402
+from lerobot.configs.default import DatasetConfig  # noqa: E402
+from lerobot.scripts.lerobot_train import _preprocess_dataset_batch, make_dataloaders  # noqa: E402
 from lerobot.utils.constants import ACTION, OBS_IMAGES  # noqa: E402
+from lerobot.utils.logging_utils import MetricsTracker  # noqa: E402
 
 
 def test_preprocess_dataset_batch_normalizes_and_renames_before_processor():
@@ -44,3 +48,76 @@ def test_preprocess_dataset_batch_normalizes_and_renames_before_processor():
     assert set(processed) == {f"{OBS_IMAGES}.camera1", ACTION}
     assert processed[f"{OBS_IMAGES}.camera1"].dtype == torch.float32
     torch.testing.assert_close(processed[f"{OBS_IMAGES}.camera1"], torch.ones(1, 3, 2, 2))
+
+
+@pytest.mark.parametrize("training", [False, True])
+def test_preprocessing_removes_and_reports_worker_timings(training):
+    tracker = MetricsTracker(3, 10, 1, {}) if training else None
+    batch = {
+        ACTION: torch.ones(3, 2),
+        "_loader_timings": {
+            "worker_loading_s": torch.tensor([8.0, 8.0, 8.0]),
+            "video_loading_s": torch.tensor([3.0, 3.0, 3.0]),
+        },
+    }
+
+    def processor(batch):
+        assert set(batch) == {ACTION}
+        return batch
+
+    _preprocess_dataset_batch(batch, [], {}, processor, tracker)
+    if training:
+        assert tracker.to_dict()["worker_loading_s"] == 8.0
+        assert tracker.to_dict()["video_loading_s"] == 3.0
+        # Another worker delivers a shorter batch. Count batches, not duplicated per-sample times.
+        batch["_loader_timings"] = {
+            "worker_loading_s": torch.tensor([4.0]),
+            "video_loading_s": torch.tensor([1.0]),
+        }
+        _preprocess_dataset_batch(batch, [], {}, processor, tracker)
+        assert tracker.to_dict()["worker_loading_s"] == 6.0
+        assert tracker.to_dict()["video_loading_s"] == 2.0
+        assert all(meter.reduction == "mean" and meter.count == 2 for meter in tracker.metrics.values())
+
+
+@pytest.mark.parametrize("enabled", [None, False, True])
+def test_training_loader_enables_profiling(tmp_path, lerobot_dataset_factory, enabled):
+    dataset = lerobot_dataset_factory(
+        root=tmp_path / "ds", total_episodes=1, total_frames=10, use_videos=False
+    )
+    cfg = SimpleNamespace(
+        dataset=DatasetConfig(
+            repo_id="test/dataset", **({} if enabled is None else {"profile_loading": enabled})
+        ),
+        trainable_config=SimpleNamespace(),
+        seed=1,
+        resume=False,
+        num_workers=0,
+        batch_size=3,
+        persistent_workers=False,
+    )
+    loader, _ = make_dataloaders(cfg, dataset, None, 0, SimpleNamespace(device_type="cpu"))
+    batch = next(iter(loader))
+    assert ("_loader_timings" in batch) is (enabled is not False)
+    if enabled is not False:
+        assert batch["_loader_timings"]["worker_loading_s"].dtype == torch.float32
+        assert torch.all(batch["_loader_timings"]["video_loading_s"] == 0)
+
+
+def test_default_profiling_does_not_break_streaming(caplog):
+    class StreamingDataset(torch.utils.data.IterableDataset):
+        meta = SimpleNamespace(has_language_columns=False)
+
+        def __iter__(self):
+            yield {ACTION: torch.ones(2)}
+
+    cfg = SimpleNamespace(
+        dataset=DatasetConfig(repo_id="test/dataset", streaming=True),
+        trainable_config=SimpleNamespace(),
+        num_workers=0,
+        batch_size=3,
+        persistent_workers=False,
+    )
+    loader, _ = make_dataloaders(cfg, StreamingDataset(), None, 0, SimpleNamespace(device_type="cpu"))
+    assert set(next(iter(loader))) == {ACTION}
+    assert "timings are unavailable" in caplog.text


### PR DESCRIPTION
## Summary

Expose worker-side loading time during training, even when prefetching hides it from `train/dataloading_s`.

- Add `train/worker_loading_s` for reader batch preparation and `train/video_loading_s` for the video-loading stage.
- Enable by default for the standard parquet/MP4 reader; disable with `--dataset.profile_loading=false`. Unsupported readers continue without these metrics and emit a warning.
- Carry timings through DataLoader collation/worker transfer, then remove them before policy preprocessing.
- Average one timing observation per delivered batch over the logging interval and across training ranks, rather than summing per-sample duplicates or reporting the slowest rank.

Video time is included in worker time and covers seeking, decoding, conversion and video-stage assembly. Worker time also includes tabular reads and image transforms, but excludes collation and IPC. These are elapsed times, not summed per-thread CPU time. Prefetched batches that are never consumed are not included. Existing `dataloading_s` continues to measure foreground batch wait.

## Dependency

Stacked on #4549 (`feat/dataset-reader-video-perf`, currently `c981570886ccd0a8db7beba494428b0297f80544`), which introduces the optimized batched reader path. This PR contains only the logging follow-up. Retarget/rebase onto `main` after #4549 merges.

## Validation

- [x] 79 tests passed across dataset reader, training batch preprocessing, collation, logging utilities, delta timestamps, and video decoder cache suites.
- [x] Real video decoding with zero and two spawned DataLoader workers; image-only inputs; default-on and opt-out behavior; streaming fallback; timing metadata removed before policy preprocessing; per-batch averaging and mean reduction registration.
- [x] Ruff, diff whitespace checks, and all applicable commit hooks (including mypy) passed.
- [ ] End-to-end MultiTask DiT training/W&B verification and profiling-overhead measurement on GPU.

No batch-80 training throughput improvement is claimed by this instrumentation change.
