### PR TITLE
fix(robots): sweep so_follower/so_leader wrist_roll instead of assuming it spins

### DIFF
--- a/src/lerobot/robots/so_follower/so_follower.py
+++ b/src/lerobot/robots/so_follower/so_follower.py
@@ -131,16 +131,30 @@ class SOFollower(Robot):
         input(f"Move {self} to the middle of its range of motion and press ENTER....")
         homing_offsets = self.bus.set_half_turn_homings()
 
-        # Attempt to call record_ranges_of_motion with a reduced motor set when appropriate.
-        full_turn_motor = "wrist_roll"
-        unknown_range_motors = [motor for motor in self.bus.motors if motor != full_turn_motor]
+        # `wrist_roll` was excluded from this sweep and assigned 0-4095 outright, on the
+        # assumption that it turns freely. Measured on one SO-101 follower (2026-09-03, torque
+        # off, turned by hand, 266254 samples): it does not. A corner of the printed gripper
+        # housing meets the wrist bracket and stops the joint from *both* directions, leaving
+        # 113-3981 reachable -- 340 deg -- and the 11 deg it cannot reach sits on the encoder
+        # seam, because `set_half_turn_homings` above had already centred the real travel on
+        # 2048 ((113 + 3981) / 2 = 2047). The sweep three lines down had the number; the
+        # assignment threw it away. Downstream, every limit check that reads these registers
+        # then saw "anywhere is reachable" for the one joint whose travel is tightest.
+        #
+        # Recording it costs nothing on an arm where the assumption does hold: a joint that
+        # really spins records very nearly 0-4095 by itself, which is what the assignment was
+        # reaching for, and the consumers of a full-width travel are unchanged. What the
+        # assumption cannot do is notice when it is false, which is the whole difference.
+        #
+        # The prompt has to ask for the right motion, though. A joint swept through a
+        # comfortable half turn would record a range narrower than it can reach, and a false
+        # envelope is worse than none -- so say what "entire" means for a joint that may spin.
         print(
-            f"Move all joints except '{full_turn_motor}' sequentially through their "
-            "entire ranges of motion.\nRecording positions. Press ENTER to stop..."
+            "Move all joints sequentially through their entire ranges of motion.\n"
+            "Turn 'wrist_roll' as far as it goes both ways: a full revolution if it spins "
+            "freely, stop to stop if it does not.\nRecording positions. Press ENTER to stop..."
         )
-        range_mins, range_maxes = self.bus.record_ranges_of_motion(unknown_range_motors)
-        range_mins[full_turn_motor] = 0
-        range_maxes[full_turn_motor] = 4095
+        range_mins, range_maxes = self.bus.record_ranges_of_motion()
 
         self.calibration = {}
         for motor, m in self.bus.motors.items():

--- a/src/lerobot/teleoperators/so_leader/so_leader.py
+++ b/src/lerobot/teleoperators/so_leader/so_leader.py
@@ -100,15 +100,17 @@ class SOLeader(Teleoperator):
         input(f"Move {self} to the middle of its range of motion and press ENTER....")
         homing_offsets = self.bus.set_half_turn_homings()
 
-        full_turn_motor = "wrist_roll"
-        unknown_range_motors = [motor for motor in self.bus.motors if motor != full_turn_motor]
+        # `wrist_roll` is swept like every other joint rather than being assigned 0-4095 on the
+        # assumption that it spins freely. That assumption was measured false on the follower
+        # (see `so_follower.py`, where the numbers and the date are); this leader arm has *not*
+        # been measured, which is exactly why it should be swept instead of assumed. A joint
+        # that does spin freely records very nearly 0-4095 on its own.
         print(
-            f"Move all joints except '{full_turn_motor}' sequentially through their "
-            "entire ranges of motion.\nRecording positions. Press ENTER to stop..."
+            "Move all joints sequentially through their entire ranges of motion.\n"
+            "Turn 'wrist_roll' as far as it goes both ways: a full revolution if it spins "
+            "freely, stop to stop if it does not.\nRecording positions. Press ENTER to stop..."
         )
-        range_mins, range_maxes = self.bus.record_ranges_of_motion(unknown_range_motors)
-        range_mins[full_turn_motor] = 0
-        range_maxes[full_turn_motor] = 4095
+        range_mins, range_maxes = self.bus.record_ranges_of_motion()
 
         self.calibration = {}
         for motor, m in self.bus.motors.items():


### PR DESCRIPTION
## Summary / Motivation

`SOFollower.calibrate` and `SOLeader.calibrate` exclude `wrist_roll` from
`record_ranges_of_motion` and assign it `0-4095` outright, on the assumption that
the joint turns freely. On the one follower arm I can measure, that assumption is
false: the joint is stopped from **both** directions at `113-3981` -- 3868 counts,
340 deg -- by a corner of the printed gripper housing meeting the wrist bracket.
It is not a gear stop; it is two printed parts touching.

Measured 2026-09-03, torque off, turned by hand, 266254 samples over 90 s with 0
comms failures. Re-confirmed independently on 2026-09-08 by a plain
`lerobot-calibrate` run with this patch applied, which recorded `70-3946` --
3876 counts, **340.7 deg**. The two sweeps agree on the *width* to 8 counts
(0.7 deg) while their centres differ by 39, which is what a mechanical stop plus a
hand-placed "middle of its range" should look like.

The 11 deg it cannot reach lands on the encoder seam, which is not a coincidence:
`set_half_turn_homings` runs over every motor including this one, so the real
travel gets centred on 2048, and `(113 + 3981) / 2 = 2047`. The blocked sector is
pushed to the far side. The sweep three lines below already had the number; the
assignment discarded it.

**I am not proposing to hardcode `113-3981`.** That is one arm, one cable routing,
one print, on one date, and another SO-101 may genuinely spin -- I have exactly one
to measure. The proposal is to stop excluding the joint and let the sweep answer:

- On an arm where the assumption **holds**, the sweep records very nearly `0-4095`
  by itself, which is what the assignment was reaching for. Every consumer of a
  full-width travel behaves as before. **This PR is a no-op for you.**
- On an arm where it does **not** hold, the calibration file stops claiming reach
  the joint does not have. Any limit check reading `Min/Max_Position_Limit` today
  sees "anywhere is reachable" for what may be the tightest joint on the arm.

What an assumption cannot do is notice when it is false. Recording costs one
joint's worth of sweeping.

## What changed

- `so_follower.py` / `so_leader.py`: drop the `range_mins/maxes[wrist_roll] = 0/4095`
  assignment and call `record_ranges_of_motion()` over every motor.
- The prompt now says what "entire range" means for a joint that might spin -- *a
  full revolution if it does, stop to stop if it does not*. Without this a user
  sweeping a comfortable half turn would record a **false narrow** envelope, which
  is worse than no envelope at all.
- `so_leader.py` gets the same treatment. That arm has **not** been measured here,
  which is the reason to sweep it rather than the reason to keep assuming.

**Not a breaking change**: existing calibration files are not rewritten. This takes
effect the next time `lerobot-calibrate` is run.

## How was this tested

- `pytest tests/robots tests/teleoperators tests/motors` -- **132 passed, 7 skipped**.
  No test exercised `calibrate()` or asserted the `0`/`4095` values, so no test
  changes were needed.
- `pre-commit` / `ruff check` + `ruff format --check` clean on both files.
- On hardware: a full `lerobot-calibrate` run on an SO-101 follower with this patch,
  2026-09-08. `wrist_roll` recorded `70-3946` instead of `0-4095`; the other five
  joints were unaffected in kind.

### What the stop looks like

<table><tr>
<td width="50%"><img src="https://raw.githubusercontent.com/s-tory/monogokoro/3711dc377529fb7210ffc899858014c0326c3173/media/wrist_roll_stop_a_20260908.jpg" alt="wrist_roll at one end of its travel"></td>
<td width="50%"><img src="https://raw.githubusercontent.com/s-tory/monogokoro/3711dc377529fb7210ffc899858014c0326c3173/media/wrist_roll_stop_b_20260908.jpg" alt="wrist_roll at the other end of its travel"></td>
</tr></table>

The same joint at its two limits (2026-09-08, torque off, turned by hand; click to
enlarge). Look at the interface just below the gripper housing: at one end a corner
of the printed housing is up against the wrist bracket, and at the same place at the
other end there is a gap with the background showing through. Contact at one end and
clearance at the other, at one interface, is what a rotation stopped by two printed
parts touching looks like -- it is not a gear stop, and it yields under force.

These are hand-held, so the viewpoint moves between the frames and the pair **cannot**
be used to measure the 19.3 deg the joint cannot reach. The two sweeps above are what
carry that number.

## Reviewer notes

- The behavioural question worth focusing on: is there a consumer of
  `range_min`/`range_max` that *requires* `wrist_roll` to read a full `0-4095`
  rather than merely tolerating it? I could not find one, but I only have the one
  arm and the one integration.
- If your SO-101's `wrist_roll` does spin freely, this PR should be invisible to
  you -- the sweep will record it. That is the claim I would most like checked
  against a second arm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
