### PR TITLE
fix: preserve frame_index through processors

### DIFF
--- a/docs/source/introduction_processors.mdx
+++ b/docs/source/introduction_processors.mdx
@@ -64,6 +64,10 @@ It's a typed dictionary that represents a complete robot-environment interaction
 - **INFO**: Arbitrary metadata
 - **COMPLEMENTARY_DATA**: Task descriptions, indices, padding flags, inter-step data
 
+Batch converters keep indexing metadata such as `index`, `episode_index`, and `frame_index` in `COMPLEMENTARY_DATA`.
+In a `batch_to_transition` / `transition_to_batch` round trip, `frame_index` retains its original scalar or tensor value.
+If the input omits `frame_index`, the converters do not add it.
+
 ### ProcessorStep: The Building Block
 
 A `ProcessorStep` is a single transformation unit that processes transitions. It's an abstract base class with two required methods:

--- a/src/lerobot/processor/converters.py
+++ b/src/lerobot/processor/converters.py
@@ -158,6 +158,7 @@ _COMPLEMENTARY_KEYS = (
     "index",
     "task_index",
     "episode_index",
+    "frame_index",
     "timestamp",
     "language_persistent",
     "language_events",

--- a/tests/processor/test_converters.py
+++ b/tests/processor/test_converters.py
@@ -243,6 +243,18 @@ def test_batch_to_transition_with_index_fields():
     assert comp_data["task"] == batch["task"]
 
 
+@pytest.mark.parametrize("frame_index", [0, torch.tensor(0), torch.tensor([0, 9])])
+def test_frame_index_survives_batch_transition_round_trip(frame_index: int | torch.Tensor) -> None:
+    batch = {OBS_STATE: torch.zeros(2, 7), "frame_index": frame_index}
+
+    transition = batch_to_transition(batch)
+
+    complementary_data = transition.get(TransitionKey.COMPLEMENTARY_DATA)
+    assert isinstance(complementary_data, dict)
+    assert complementary_data["frame_index"] is frame_index
+    assert transition_to_batch(transition)["frame_index"] is frame_index
+
+
 def testtransition_to_batch_with_index_fields():
     """Test that transition_to_batch handles index and task_index fields correctly."""
 
@@ -289,6 +301,7 @@ def test_batch_to_transition_without_index_fields():
     assert "task" in comp_data
     assert "index" not in comp_data
     assert "task_index" not in comp_data
+    assert "frame_index" not in comp_data
 
 
 def test_transition_to_batch_without_index_fields():
@@ -307,3 +320,4 @@ def test_transition_to_batch_without_index_fields():
     assert "task" in batch
     assert "index" not in batch
     assert "task_index" not in batch
+    assert "frame_index" not in batch


### PR DESCRIPTION
## Summary / Motivation

Batch conversion drops `frame_index`. Preserve it as complementary metadata so converting a batch to a transition and back does not lose frame indexing.

## Related issues

None linked.

## What changed

- Include `frame_index` in complementary batch fields.
- Test scalar and tensor round trips, identity preservation, and absent-field behavior.
- Document indexing metadata in `docs/source/introduction_processors.mdx`.

## How was this tested (or how to run locally)

- Regression: `pytest -q tests/processor/test_converters.py`
- Full command: `pytest tests -vv --maxfail=10 --durations=5`
- Isolated CPU configurations: test-only, test+dataset, test+hardware, test+viz.
- Passed/skipped: base 1373/387; dataset 2549/363; hardware 1406/386; viz 1377/386.
- Full pinned documentation build passed; updated page verified.

Dataset validation used a full FFmpeg build with CPU AV1 decoding. Optional/GPU skips remain; all-extras/E2E and physical hardware were not tested. Auxiliary Pyright diagnostics remain.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated
- [ ] CI is green
- [x] Community Review: I have reviewed another contributor's open PR and linked it here: [#4578 review](https://github.com/huggingface/lerobot/pull/4578#discussion_r3959640719)
