### PR TITLE
fix: synchronize rollout and policy devices

### DIFF
--- a/docs/source/inference.mdx
+++ b/docs/source/inference.mdx
@@ -18,6 +18,16 @@ lerobot-rollout \
 
 This runs the policy for 30 seconds with no recording.
 
+### Choosing a device
+
+Pass `--device=cpu` or `--device=cuda` to override the checkpoint device on a host where that device is available.
+The resolved device is applied to the policy configuration before loading the policy and constructing its processors.
+For example, add `--device=cpu` to the command above to run a CUDA-trained checkpoint on a CPU-only host, if the policy supports CPU execution.
+Check that CPU inference can meet your required control rate before deploying on a robot.
+
+When `--device` is omitted, rollout uses the policy configuration device if set, otherwise it selects an available device automatically.
+The same behavior applies to `RolloutConfig(device=...)` with `build_rollout_context`.
+
 ---
 
 ## Strategies

--- a/src/lerobot/rollout/context.py
+++ b/src/lerobot/rollout/context.py
@@ -314,6 +314,9 @@ def build_rollout_context(
     # --- 1. Policy (heavy I/O, but no hardware yet) -------------------
     logger.info("Loading policy from '%s'...", cfg.policy.pretrained_path)
     policy_config = cfg.policy
+    assert policy_config is not None  # Validated by RolloutConfig.__post_init__.
+    # Policy constructors and custom processors must use the resolved rollout device too.
+    policy_config.device = cfg.device
 
     if is_rtc:
         _validate_trained_rtc_rollout_config(policy_config, cfg.inference)

--- a/tests/test_rollout.py
+++ b/tests/test_rollout.py
@@ -263,6 +263,73 @@ def test_rollout_config_rejects_a_multiplier_below_one(multiplier):
         RolloutConfig(robot=MockRobotConfig(), interpolation_multiplier=multiplier)
 
 
+@pytest.mark.parametrize(
+    ("checkpoint_device", "runtime_device"),
+    [
+        ("cuda", "cpu"),
+        ("mps", "cpu"),
+        ("cpu", "cpu"),
+        ("cpu", None),
+        pytest.param(
+            "cpu", "cuda", marks=pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA unavailable")
+        ),
+    ],
+)
+def test_build_rollout_context_uses_resolved_device(
+    monkeypatch: pytest.MonkeyPatch, checkpoint_device: str, runtime_device: str | None
+) -> None:
+    import lerobot.rollout.context as rollout_context
+    from lerobot.policies.act.configuration_act import ACTConfig
+    from lerobot.processor import (
+        DeviceProcessorStep,
+        PolicyProcessorPipeline,
+        batch_to_transition,
+        transition_to_batch,
+    )
+    from lerobot.rollout import RolloutConfig
+    from lerobot.utils.constants import OBS_STATE
+    from tests.mocks.mock_robot import MockRobot, MockRobotConfig
+
+    policy_config = ACTConfig(device="cpu", pretrained_path=Path("unused-checkpoint"))
+    # Emulate a checkpoint saved on a different host without needing that device locally.
+    policy_config.device = checkpoint_device
+    robot_config = MockRobotConfig(random_values=False, static_values=[0.0, 0.0, 0.0])
+    cfg = RolloutConfig(robot=robot_config, policy=policy_config, device=runtime_device)
+    robot = MockRobot(robot_config)
+    policy = torch.nn.Linear(3, 3)
+
+    def load_policy(config: ACTConfig) -> torch.nn.Linear:
+        # Check at construction time: synchronizing after the load would be too late.
+        assert config.device == cfg.device == (runtime_device or checkpoint_device)
+        return policy
+
+    def make_processors(
+        *, policy_cfg: ACTConfig, preprocessor_overrides: dict[str, dict[str, str]], **kwargs: object
+    ) -> tuple[PolicyProcessorPipeline, PolicyProcessorPipeline]:
+        assert policy_cfg.device == preprocessor_overrides["device_processor"]["device"]
+        processor = PolicyProcessorPipeline(
+            steps=[DeviceProcessorStep(device=policy_cfg.device)],
+            to_transition=batch_to_transition,
+            to_output=transition_to_batch,
+        )
+        return processor, PolicyProcessorPipeline(steps=[])
+
+    monkeypatch.setattr(rollout_context, "_load_pretrained_policy", load_policy)
+    monkeypatch.setattr(rollout_context, "make_pre_post_processors", make_processors)
+    monkeypatch.setattr(rollout_context, "make_robot_from_config", lambda _: robot)
+
+    try:
+        ctx = rollout_context.build_rollout_context(cfg, threading.Event())
+        batch = ctx.policy.preprocessor({OBS_STATE: torch.zeros(1, 3)})
+        model_device = next(ctx.policy.policy.parameters()).device
+        assert model_device == batch[OBS_STATE].device
+        assert model_device.type == torch.device(runtime_device or checkpoint_device).type
+        assert policy_config.device == cfg.device
+    finally:
+        if robot.is_connected:
+            robot.disconnect()
+
+
 def test_load_pretrained_policy_passes_revision(monkeypatch):
     import lerobot.rollout.context as rollout_context
 


### PR DESCRIPTION
## Summary / Motivation

A rollout device override can disagree with the checkpoint's policy device. Apply the resolved rollout device before loading the policy and constructing its processors.

## Related issues

None linked.

## What changed

- Synchronize the policy configuration with the resolved rollout device.
- Test constructor-time device propagation and model/input placement.
- Document overrides and CPU deployment considerations in `docs/source/inference.mdx`.

## How was this tested (or how to run locally)

- Regression: `pytest -q tests/test_rollout.py`
- Full command: `pytest tests -vv --maxfail=10 --durations=5`
- Isolated CPU configurations: test-only, test+dataset, test+hardware, test+viz.
- Passed/skipped: base 1370/387; dataset 2550/364; hardware 1403/386; viz 1374/386.
- Full pinned documentation build passed; updated page verified.

Dataset validation used a full FFmpeg build with CPU AV1 decoding. The CPU matrix retains CUDA/optional skips; all-extras/E2E and physical hardware were not tested. Auxiliary Pyright diagnostics remain.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated
- [ ] CI is green
- [x] Community Review: I have reviewed another contributor's open PR and linked it here: [#4579 review](https://github.com/huggingface/lerobot/pull/4579#pullrequestreview-5142634039)
