### PR TITLE
fix: flatten grouped action feature names

### DIFF
--- a/docs/source/action_representations.mdx
+++ b/docs/source/action_representations.mdx
@@ -168,6 +168,12 @@ lerobot-train \
 
 The `relative_exclude_joints` parameter specifies joints that should remain in absolute space. For example, gripper commands are typically binary (open/close) and don't benefit from relative encoding.
 
+For policy configurations that define `action_feature_names`, `make_policy` fills this list from the dataset action feature's `names` metadata.
+Names may be a flat sequence or a dictionary whose values are all lists or tuples.
+For example, `{"arm": ["shoulder", "elbow"], "hand": ["gripper"]}` becomes `["shoulder", "elbow", "gripper"]`, not the group keys.
+Group insertion order and within-group order are preserved, so declare names in the same order as the action vector.
+Legacy name-to-index mappings retain their key-order behavior.
+
 ### Combining relative actions with RTC
 
 [RTC](https://arxiv.org/abs/2506.07339) runs policy inference at high frequency and sends actions to the robot as they are predicted rather than waiting for a full chunk. Relative actions and RTC are fully compatible: because every chunk in relative mode references the **same** current state (captured at the start of inference), each predicted action in the chunk remains a valid offset even if the robot has already moved. No special handling is needed — `RelativeActionsProcessorStep` caches the state once per inference call and `AbsoluteActionsProcessorStep` applies it to every action in the streamed output.

--- a/src/lerobot/policies/factory.py
+++ b/src/lerobot/policies/factory.py
@@ -346,6 +346,11 @@ def make_policy(
         )
         action_names = raw_action_feature.get("names") if raw_action_feature is not None else None
         if action_names is not None:
+            # Grouped metadata stores dimension names in the values, not the group keys.
+            if isinstance(action_names, dict) and all(
+                isinstance(group, (list, tuple)) for group in action_names.values()
+            ):
+                action_names = [name for group in action_names.values() for name in group]
             cfg.action_feature_names = list(action_names)
     if ds_meta is not None:
         set_dataset_feature_metadata = getattr(cfg, "set_dataset_feature_metadata", None)

--- a/tests/policies/test_factory_peft_revision.py
+++ b/tests/policies/test_factory_peft_revision.py
@@ -15,6 +15,7 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import pytest
 import torch
 
 import lerobot.policies.factory as policy_factory
@@ -85,7 +86,23 @@ def test_make_policy_keeps_peft_adapter_and_base_revisions_separate(monkeypatch)
     )
 
 
-def test_make_policy_reads_action_names_through_rename_map(monkeypatch):
+@pytest.mark.parametrize("action_key", [ACTION, "actions"])
+@pytest.mark.parametrize(
+    ("raw_names", "expected_names"),
+    [
+        (["shoulder", "elbow", "gripper"], ["shoulder", "elbow", "gripper"]),
+        (("shoulder", "elbow", "gripper"), ["shoulder", "elbow", "gripper"]),
+        ({"motors": ["shoulder", "elbow", "gripper"]}, ["shoulder", "elbow", "gripper"]),
+        ({"right": ["shoulder", "elbow"], "left": ["gripper"]}, ["shoulder", "elbow", "gripper"]),
+        ({"right": ("shoulder", "elbow"), "left": ("gripper",)}, ["shoulder", "elbow", "gripper"]),
+        ({"unused": [], "motors": ["shoulder", "elbow", "gripper"]}, ["shoulder", "elbow", "gripper"]),
+        ({"shoulder": 0, "elbow": 1, "gripper": 2}, ["shoulder", "elbow", "gripper"]),
+        ([], []),
+        ({}, []),
+        (None, None),
+    ],
+)
+def test_make_policy_reads_action_names(monkeypatch, action_key, raw_names, expected_names):
     cfg = SimpleNamespace(
         type="mock",
         device="cpu",
@@ -95,13 +112,12 @@ def test_make_policy_reads_action_names_through_rename_map(monkeypatch):
         output_features={},
         action_feature_names=None,
     )
-    action_names = ["shoulder", "elbow", "gripper"]
     dataset_meta = SimpleNamespace(
         features={
-            "actions": {
+            action_key: {
                 "dtype": "float32",
-                "shape": (len(action_names),),
-                "names": action_names,
+                "shape": (3,),
+                "names": raw_names,
             }
         },
         stats={},
@@ -114,9 +130,10 @@ def test_make_policy_reads_action_names_through_rename_map(monkeypatch):
     result = policy_factory.make_policy(
         cfg,
         ds_meta=dataset_meta,
-        rename_map={"actions": ACTION},
+        rename_map={action_key: ACTION} if action_key != ACTION else None,
     )
 
     assert result is policy
-    assert cfg.action_feature_names == action_names
+    assert cfg.action_feature_names == expected_names
+    assert dataset_meta.features[action_key]["names"] == raw_names
     assert cfg.output_features[ACTION].type is FeatureType.ACTION


### PR DESCRIPTION
## Summary / Motivation

For grouped action metadata, converting the names dictionary to a list returns group keys instead of action dimension names. Flatten list/tuple-valued groups while preserving group and member ordering.

## Related issues

None linked.

## What changed

- Flatten grouped names when every dictionary value is a list or tuple.
- Preserve flat names, legacy name-to-index mappings, empty/missing metadata, and renamed action features.
- Expand regression coverage and check that metadata remains unchanged.
- Document behavior in `docs/source/action_representations.mdx`.

## How was this tested (or how to run locally)

- Regression: `pytest -q tests/policies/test_factory_peft_revision.py`
- Full command: `pytest tests -vv --maxfail=10 --durations=5`
- Isolated CPU configurations: test-only, test+dataset, test+hardware, test+viz.
- Passed/skipped: base 1389/387; dataset 2565/363; hardware 1422/386; viz 1393/386.
- Full pinned documentation build passed; updated page verified.

An earlier dataset run hit a streaming-video decode failure; investigation also captured a native SVT-AV1 encoder error. Five unchanged focused runs, 20 independent video decodes, and one complete dataset-tier confirmation passed. The native failure remains unresolved; this PR does not fix the encoder.

Dataset validation used a full FFmpeg build with CPU AV1 decoding. No tests were weakened or codec source patched. Optional/GPU skips remain; all-extras/E2E and physical hardware were not tested. Auxiliary Pyright diagnostics remain.

## Checklist (required before merge)

- [x] Linting/formatting run (`pre-commit run -a`)
- [x] All tests pass locally (`pytest`)
- [x] Documentation updated
- [ ] CI is green
- [x] Community Review: I have reviewed another contributor's open PR and linked it here: [#4522 review](https://github.com/huggingface/lerobot/pull/4522#pullrequestreview-5142590459)
