### PR TITLE
fix(robots): clamp returned SO targets

### DIFF
--- a/src/lerobot/robots/so_follower/so_follower.py
+++ b/src/lerobot/robots/so_follower/so_follower.py
@@ -17,6 +17,8 @@
 import logging
 import time
 from functools import cached_property
+from math import isfinite
+from numbers import Real
 
 from lerobot.cameras import make_cameras_from_configs
 from lerobot.lerobot_types import RobotAction, RobotObservation
@@ -224,6 +226,17 @@ class SOFollower(Robot):
             present_pos = self.bus.sync_read("Present_Position", num_retry=self.config.num_read_retries)
             goal_present_pos = {key: (g_pos, present_pos[key]) for key, g_pos in goal_pos.items()}
             goal_pos = ensure_safe_goal_position(goal_present_pos, self.config.max_relative_target)
+
+        # Return the same normalized targets that the motor bus accepts after saturation.
+        for motor, value in goal_pos.items():
+            if not isinstance(value, Real) or not isfinite(value):
+                continue
+
+            norm_mode = self.bus.motors[motor].norm_mode
+            if norm_mode is MotorNormMode.RANGE_M100_100:
+                goal_pos[motor] = min(100.0, max(-100.0, value))
+            elif norm_mode is MotorNormMode.RANGE_0_100:
+                goal_pos[motor] = min(100.0, max(0.0, value))
 
         # Send goal position to the arm
         self.bus.sync_write("Goal_Position", goal_pos)

--- a/tests/robots/test_so100_follower.py
+++ b/tests/robots/test_so100_follower.py
@@ -15,10 +15,12 @@
 # limitations under the License.
 
 from contextlib import contextmanager
+from dataclasses import replace
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from lerobot.motors import MotorNormMode
 from lerobot.robots.so_follower import (
     SO100Follower,
     SO100FollowerConfig,
@@ -130,6 +132,26 @@ def test_send_action(follower):
 
     goal_pos = {m: (i + 1) * 10 for i, m in enumerate(follower.bus.motors)}
     follower.bus.sync_write.assert_called_once_with("Goal_Position", goal_pos)
+
+
+@pytest.mark.parametrize(
+    "value, expected_body, expected_gripper",
+    [(100.5, 100.0, 100.0), (-100.5, -100.0, 0.0)],
+)
+def test_send_action_clamps_normalized_targets(follower, value, expected_body, expected_gripper):
+    follower.bus.motors["shoulder_pan"] = replace(
+        follower.bus.motors["shoulder_pan"], norm_mode=MotorNormMode.RANGE_M100_100
+    )
+    follower.connect()
+
+    action = {"shoulder_pan.pos": value, "gripper.pos": value}
+    returned = follower.send_action(action)
+
+    expected_action = {"shoulder_pan.pos": expected_body, "gripper.pos": expected_gripper}
+    assert returned == expected_action
+    follower.bus.sync_write.assert_called_once_with(
+        "Goal_Position", {"shoulder_pan": expected_body, "gripper": expected_gripper}
+    )
 
 
 def test_configure_writes_position_pid_coefficients():


### PR DESCRIPTION
## Summary / Motivation

`SOFollower.send_action` returned normalized targets before the motor bus applied its range saturation. For example, a gripper target of `100.5` was transmitted as `100.0` but returned as `100.5`, so callers did not receive the action accepted by the bus.

## Related issues

- Fixes / Closes: None
- Related: None

## What changed

- Clamp finite targets for `RANGE_M100_100` and `RANGE_0_100` after relative limiting and before `sync_write`.
- Return the same bounded normalized values passed to the motor bus.
- Add focused regression coverage for upper and lower saturation on body and gripper range modes.

Degree-mode targets and sub-tick quantization are unchanged. There is no breaking API change.

## How was this tested (or how to run locally)

- `pytest -q tests/robots/test_so100_follower.py` — 8 passed.
- A software-only packet-boundary harness — 52 passed.
- The preserved six-case mismatch reproducer — 6 passed after the fix.
- Ruff 0.14.1 check and format checks passed on the changed source and test.
- No physical robot or serial device was used.

## Checklist (required before merge)

- [ ] Linting/formatting run (`pre-commit run -a`) — scoped Ruff checks passed; full pre-commit not run.
- [ ] All tests pass locally (`pytest`) — focused tests passed; full suite not run.
- [ ] Documentation updated — no documentation change appears necessary for this behavior correction.
- [ ] CI is green — pending.
- [x] Community Review: [reviewed #4585](https://github.com/huggingface/lerobot/pull/4585#pullrequestreview-5146494961).

## Reviewer notes

Please focus on whether the returned action should reflect normalized range saturation while leaving degree-mode targets unchanged.

AI assistance disclosure: OpenAI Codex assisted with investigation, implementation, test development, validation, and drafting this PR description.

Anyone in the community is welcome to review this PR.
