### PR TITLE
feat(plugins): discover third-party processor-step plugins

### DIFF
--- a/src/lerobot/utils/import_utils.py
+++ b/src/lerobot/utils/import_utils.py
@@ -228,8 +228,8 @@ def register_third_party_plugins() -> None:
 
     This function uses `importlib.metadata` to find packages installed in the environment
     (including editable installs) starting with 'lerobot_robot_', 'lerobot_camera_',
-    'lerobot_teleoperator_', 'lerobot_policy_', 'lerobot_env_' or 'lerobot_strategy_' and
-    imports them.
+    'lerobot_teleoperator_', 'lerobot_policy_', 'lerobot_env_', 'lerobot_strategy_' or
+    'lerobot_processor_' and imports them.
     """
     prefixes = (
         "lerobot_robot_",
@@ -238,6 +238,7 @@ def register_third_party_plugins() -> None:
         "lerobot_policy_",
         "lerobot_env_",
         "lerobot_strategy_",
+        "lerobot_processor_",
     )
     imported: list[str] = []
     failed: list[str] = []

--- a/tests/utils/test_import_utils.py
+++ b/tests/utils/test_import_utils.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+
+# Copyright 2025 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import SimpleNamespace
+
+from lerobot.utils.import_utils import register_third_party_plugins
+
+
+class _FakeDist:
+    def __init__(self, name: str):
+        self.metadata = {"Name": name}
+
+
+def test_register_third_party_plugins_imports_processor_prefix(monkeypatch):
+    fake_dists = [
+        _FakeDist("lerobot_processor_safety_verifier"),
+        _FakeDist("lerobot_policy_turbovla"),
+        _FakeDist("some_unrelated_package"),
+    ]
+    monkeypatch.setattr("importlib.metadata.distributions", lambda: iter(fake_dists))
+
+    imported = []
+    monkeypatch.setattr("importlib.import_module", lambda name: imported.append(name) or SimpleNamespace())
+
+    register_third_party_plugins()
+
+    assert "lerobot_processor_safety_verifier" in imported
+    assert "lerobot_policy_turbovla" in imported
+    assert "some_unrelated_package" not in imported


### PR DESCRIPTION
Closes #4591.

Adds a `lerobot_processor_` prefix to `register_third_party_plugins()`'s discovery list, alongside the existing robot/camera/teleoperator/policy/env/strategy prefixes. One prefix covers both pre- and post-processors, since both are just `ProcessorStep` subclasses composed into separate pipelines by convention (see `make_act_pre_post_processors`) — no need for separate `lerobot_preprocessor_`/`lerobot_postprocessor_` prefixes.

Motivating case discussed in #4591: a rule-based safety post-processor (#4240/#4241) and an upcoming learned/model-backed variant as a standalone third-party plugin, currently with no auto-discovery path the way policy plugins get.

Minimal, mechanical change — reuses the exact same accepted pattern already in place for the other five component types, no new discovery mechanism. Added a unit test covering the new prefix alongside the existing ones.