### PR TITLE
feat(policies): add shared dtype management to policy base classes

### DIFF
--- a/docs/source/bring_your_own_policies.mdx
+++ b/docs/source/bring_your_own_policies.mdx
@@ -114,7 +114,8 @@ class MyPolicy(PreTrainedPolicy):
         super().__init__(config, dataset_stats)
         config.validate_features()  # not called automatically by the base class
         self.config = config
-        self.model = ...  # your nn.Module here
+        self.model = ...  # construct real tensors in FP32
+        self.post_init()  # apply config.dtype and the declared FP32 exceptions
 
     def reset(self):
         """Reset per-episode state. Called by lerobot-eval at the start of each episode."""
@@ -147,6 +148,40 @@ class MyPolicy(PreTrainedPolicy):
         ...
         return loss, {"some_loss_component": some_loss_component.item()}
 ```
+
+### Parameter precision
+
+LeRobot supports Transformers-style precision management. Every policy has `config.dtype` and the read-only `policy.dtype` property, where `config.dtype` is used to configure the precision and `policy.dtype` reflects the policy's actual precision. You can control the parameter precision in various ways:
+
+- When initializing a new model from scratch, you can override the `config.dtype`, for example `dtype: str = "bfloat16"`.
+- When loading a pre-trained checkpoint, use `from_pretrained(dtype=...)` to override the original configuration of the checkpoint.
+
+```python
+config = MyPolicyConfig(dtype="bfloat16")
+policy = MyPolicy(config)
+print(policy.dtype)  # torch.bfloat16
+
+policy = MyPolicy.from_pretrained("owner/checkpoint", dtype=torch.float16)
+```
+
+For your own policies, please call `self.post_init()` after constructing every submodule. It will cast real parameters and floating buffers directly to their final precision, preserving integer buffers and shared parameters.
+
+When you have numerically sensitive parts like action heads, declare them with `_fp32_modules` **on the top-level policy class**. Each entry is a module or tensor path starting at the policy root:
+
+```python
+class MyPolicy(PreTrainedPolicy):
+    config_class = MyPolicyConfig
+    name = "my_policy"
+    _fp32_modules = (
+        "model.action_head",
+        "model.backbone.layers.*.input_layernorm",
+        "model.backbone.norm",
+        "model.backbone.rotary_emb.inv_freq",
+    )
+    # __init__ constructs all modules, then calls self.post_init().
+```
+
+These modules will be kept in fp32 through `self.post_init()`, protecting them from casting to lower precision. The standard PyTorch casting methods remain unchanged and can explicitly cast the entire model, including protected tensors. The declarations apply during initialization and checkpoint loading, not to subsequent user-directed casts.
 
 The methods called by the train/eval loops:
 

--- a/src/lerobot/configs/policies.py
+++ b/src/lerobot/configs/policies.py
@@ -29,6 +29,7 @@ from huggingface_hub.errors import HfHubHTTPError
 from lerobot.optim import LRSchedulerConfig, OptimizerConfig
 from lerobot.utils.constants import ACTION, OBS_STATE
 from lerobot.utils.device_utils import auto_select_torch_device, is_amp_available, is_torch_device_available
+from lerobot.utils.dtype import get_dtype
 from lerobot.utils.hub import HubMixin
 
 from .types import FeatureType, PolicyFeature
@@ -60,6 +61,9 @@ class PreTrainedConfig(draccus.ChoiceRegistry, HubMixin, abc.ABC):  # type: igno
     output_features: dict[str, PolicyFeature] | None = field(default_factory=dict)
 
     device: str | None = None  # e.g. "cuda", "cuda:0", "cpu", or "mps"
+    # Parameter storage dtype. None uses PyTorch's default when constructing a policy.
+    # FP32-sensitive modules are declared by the policy and keep their precision.
+    dtype: str | None = None
     # `use_amp` determines whether to use Automatic Mixed Precision (AMP) for training and evaluation. With AMP,
     # automatic gradient scaling is used.
     use_amp: bool = False
@@ -83,6 +87,8 @@ class PreTrainedConfig(draccus.ChoiceRegistry, HubMixin, abc.ABC):  # type: igno
     pretrained_revision: str | None = None
 
     def __post_init__(self) -> None:
+        if self.dtype is not None:
+            self.dtype = str(get_dtype(self.dtype)).removeprefix("torch.")
         if not self.device or not is_torch_device_available(self.device):
             auto_device = auto_select_torch_device()
             logger.warning(f"Device '{self.device}' is not available. Switching to '{auto_device}'.")

--- a/src/lerobot/policies/pretrained.py
+++ b/src/lerobot/policies/pretrained.py
@@ -16,21 +16,25 @@ from __future__ import annotations
 import abc
 import builtins
 import dataclasses
+import itertools
 import logging
 import os
 import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, TypedDict, TypeVar, Unpack
 
+import torch
 from huggingface_hub import hf_hub_download, save_torch_state_dict
 from huggingface_hub.constants import SAFETENSORS_SINGLE_FILE
 from huggingface_hub.errors import HfHubHTTPError
+from safetensors import safe_open
 from safetensors.torch import load_model as load_model_as_safetensor
 from torch import Tensor, nn
 
 from lerobot.configs import PreTrainedConfig
 from lerobot.utils.constants import ACTION
 from lerobot.utils.device_utils import resolve_safetensors_device
+from lerobot.utils.dtype import get_dtype
 from lerobot.utils.hub import HubMixin
 from lerobot.utils.import_utils import _peft_available, require_package
 
@@ -66,6 +70,12 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
     config_class: None
     name: None
 
+    # Paths from the policy root, e.g. "model.action_head" or "model.layers.*.norm".
+    # Each '*' matches exactly one path component. A module path protects all its
+    # floating parameters and buffers; a tensor path protects only that tensor.
+    # Declare these paths on the policy class, not its nested modules.
+    _fp32_modules: ClassVar[tuple[str, ...]] = ()
+
     # --- declarative parallelism/acceleration surface ----------------------------------------
     # Module CLASS names forming the FSDP2 wrap units (and, once wired, the activation-
     # checkpointing units). Resolved onto the accelerate plugin right before
@@ -95,6 +105,88 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
                 f"`model = {self.__class__.__name__}.from_pretrained(PRETRAINED_MODEL_NAME)`"
             )
         self.config = config
+
+    @property
+    def _fp32_tensor_names(self) -> set[str]:
+        """Full names of floating parameters/buffers protected by the policy's rules.
+
+        Include non-persistent buffers and every alias of a shared tensor if any
+        alias matches. Resolve the current registrations on each access, so changing
+        modules or parameter ties cannot leave a stale name set.
+        """
+        if not self._fp32_modules:
+            return set()
+
+        paths = [path.split(".") for path in self._fp32_modules]
+        for path, parts in zip(self._fp32_modules, paths, strict=True):
+            if any(not part or ("*" in part and part != "*") for part in parts):
+                raise ValueError(
+                    f"Invalid FP32 path {path!r}: use names separated by dots and '*' for one level."
+                )
+        aliases: dict[Tensor, list[str]] = {}
+        for name, tensor in itertools.chain(
+            self.named_parameters(remove_duplicate=False), self.named_buffers(remove_duplicate=False)
+        ):
+            if tensor.is_floating_point():
+                aliases.setdefault(tensor, []).append(name)
+
+        names: set[str] = set()
+        for tensor_names in aliases.values():
+            for name in tensor_names:
+                parts = name.split(".")
+                if any(
+                    len(path) <= len(parts)
+                    and all(
+                        pattern == "*" or pattern == part for pattern, part in zip(path, parts, strict=False)
+                    )
+                    for path in paths
+                ):
+                    names.update(tensor_names)
+                    break
+        return names
+
+    @property
+    def dtype(self) -> torch.dtype:
+        """The actual floating dtype, preferring parameters outside the FP32 exceptions.
+
+        Like ``nn.Module.to()``, this reports the current tensors rather than a cached
+        configuration value. A policy with only FP32 exceptions reports their dtype.
+        """
+        keep_names = self._fp32_tensor_names
+        fallback = None
+        for name, tensor in itertools.chain(self.named_parameters(), self.named_buffers()):
+            if tensor.is_floating_point():
+                if name not in keep_names:
+                    return tensor.dtype
+                if fallback is None:
+                    fallback = tensor.dtype
+        return fallback if fallback is not None else get_dtype(self.config.dtype)
+
+    def post_init(self) -> None:
+        """Finalize parameter precision after a subclass has constructed all its modules.
+
+        Construct real tensors in FP32, then call this once at the end of ``__init__``,
+        before compilation or optimizer creation. Each tensor goes directly to its
+        final dtype so FP32 exceptions never make a lossy round trip through BF16.
+        Integer buffers, tied parameters and existing gradients are preserved.
+        Once conversion is complete, config.dtype records the actual model dtype.
+        """
+        dtype = get_dtype(self.config.dtype)
+        keep_names = self._fp32_tensor_names
+
+        # Visit registered tensors directly. Frozen components kept outside the module
+        # registry (e.g. FastWAM's UMT5 encoder) are loaded with config.dtype by their
+        # own loaders, which may have additional precision rules.
+        with torch.no_grad():
+            for name, tensor in itertools.chain(self.named_parameters(), self.named_buffers()):
+                if not tensor.is_floating_point():
+                    continue
+                target = torch.float32 if name in keep_names else dtype
+                tensor.data = tensor.to(dtype=target)
+                if isinstance(tensor, nn.Parameter) and tensor.grad is not None:
+                    tensor.grad.data = tensor.grad.to(dtype=target)
+
+        self.config.dtype = str(self.dtype).removeprefix("torch.")
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
@@ -140,6 +232,7 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
             # Non-sharded multi-rank (DDP): every rank holds a full dict — the explicit rank
             # gate prevents N ranks racing on the same files. Single process: never taken.
             return
+        self.config.dtype = str(model_to_save.dtype).removeprefix("torch.")
         self.config._save_pretrained(save_directory)
         save_torch_state_dict(state_dict, str(save_directory), max_shard_size=_SINGLE_FILE_SHARD_SIZE)
 
@@ -149,6 +242,7 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
         pretrained_name_or_path: str | Path,
         *,
         config: PreTrainedConfig | None = None,
+        dtype: str | torch.dtype | None = None,
         force_download: bool = False,
         resume_download: bool | None = None,
         proxies: dict | None = None,
@@ -162,6 +256,12 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
         """
         The policy is set in evaluation mode by default using `policy.eval()` (dropout modules are
         deactivated). To train it, you should first set it back in training mode with `policy.train()`.
+
+        ``dtype`` overrides the saved configuration and accepts a torch.dtype or its name.
+        ``None`` uses config.dtype (or PyTorch's default). ``"auto"`` uses config.dtype,
+        falling back to the first floating checkpoint tensor when it is unspecified.
+        Declared FP32 exceptions apply to both initialization and checkpoint loading.
+        A supplied config is reused and updated with the resolved dtype and pretrained_path.
         """
         if config is None:
             config = PreTrainedConfig.from_pretrained(
@@ -176,11 +276,9 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
                 **kwargs,
             )
         model_id = str(pretrained_name_or_path)
-        instance = cls(config, **kwargs)
         if os.path.isdir(model_id):
             print("Loading weights from local directory")
             model_file = os.path.join(model_id, SAFETENSORS_SINGLE_FILE)
-            policy = cls._load_as_safetensor(instance, model_file, config.device, strict)
         else:
             try:
                 model_file = hf_hub_download(
@@ -194,12 +292,37 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
                     token=token,
                     local_files_only=local_files_only,
                 )
-                policy = cls._load_as_safetensor(instance, model_file, config.device, strict)
             except HfHubHTTPError as e:
                 raise FileNotFoundError(
                     f"{SAFETENSORS_SINGLE_FILE} not found on the HuggingFace Hub in {model_id}"
                 ) from e
 
+        if dtype == "auto":
+            dtype = config.dtype
+            if dtype is None:
+                with safe_open(model_file, framework="pt", device="cpu") as checkpoint:
+                    dtypes = {
+                        "F16": torch.float16,
+                        "BF16": torch.bfloat16,
+                        "F32": torch.float32,
+                        "F64": torch.float64,
+                    }
+                    keys = checkpoint.keys()
+                    dtype = next(
+                        (
+                            dtypes[code]
+                            for key in keys
+                            if (code := checkpoint.get_slice(key).get_dtype()) in dtypes
+                        ),
+                        torch.get_default_dtype(),
+                    )
+        config.dtype = str(get_dtype(config.dtype if dtype is None else dtype)).removeprefix("torch.")
+        config.pretrained_path = Path(pretrained_name_or_path)
+        instance = cls(config, **kwargs)
+        # Copy CPU checkpoint tensors into the already configured parameter dtypes.
+        # Loading a full FP32 state dict onto the accelerator would defeat dtype
+        # selection's memory savings while the checkpoint and model coexist.
+        policy = cls._load_as_safetensor(instance, model_file, "cpu", strict)
         policy.to(config.device)
         policy.eval()
         return policy

--- a/src/lerobot/utils/dtype.py
+++ b/src/lerobot/utils/dtype.py
@@ -1,0 +1,35 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+
+
+def get_dtype(dtype: str | torch.dtype | None) -> torch.dtype:
+    """Resolve a parameter dtype. ``None`` uses PyTorch's default floating dtype."""
+    requested_dtype = dtype
+    supported = {
+        "float16": torch.float16,
+        "bfloat16": torch.bfloat16,
+        "float32": torch.float32,
+        "float64": torch.float64,
+    }
+    if dtype is None:
+        dtype = torch.get_default_dtype()
+    if isinstance(dtype, str):
+        dtype = supported.get(dtype)
+    if not isinstance(dtype, torch.dtype) or dtype not in supported.values():
+        raise ValueError(
+            f"Invalid dtype: {requested_dtype!r}. Expected one of {list(supported)} or a matching torch.dtype."
+        )
+    return dtype

--- a/tests/policies/test_pretrained_dtype.py
+++ b/tests/policies/test_pretrained_dtype.py
@@ -1,0 +1,392 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+import draccus
+import pytest
+import torch
+from safetensors.torch import save_file
+from torch import nn
+
+from lerobot.configs import PreTrainedConfig
+from lerobot.policies.act.configuration_act import ACTConfig
+from lerobot.policies.pretrained import PreTrainedPolicy
+from lerobot.utils.dtype import get_dtype
+
+
+class TinyPolicy(PreTrainedPolicy):
+    config_class = ACTConfig
+    name = "dtype_test"
+    _fp32_modules = ("head", "rotary_emb.inv_freq")
+
+    def __init__(self, config):
+        super().__init__(config)
+        # A protected parameter comes first; it must not hide the main model dtype.
+        self.head = nn.Linear(4, 4)
+        self.backbone = nn.Linear(4, 4)
+        self.head_extra = nn.Linear(4, 4)
+        self.rotary_emb = nn.Module()
+        self.rotary_emb.register_buffer("inv_freq", torch.tensor([1.000123, 0.500321]))
+        self.register_buffer("indices", torch.arange(4))
+        self.register_buffer("scale", torch.ones(4), persistent=False)
+        self.head.weight.data.fill_(1.000123)
+        self.post_init()
+
+    def get_optim_params(self):
+        return self.parameters()
+
+    def reset(self):
+        pass
+
+    def forward(self, batch):
+        x = self.backbone(batch.to(self.backbone.weight.dtype))
+        return self.head(x.to(self.head.weight.dtype)).sum(), {}
+
+    def predict_action_chunk(self, batch, **kwargs):
+        return self.forward(batch)[0]
+
+    def select_action(self, batch, **kwargs):
+        return self.predict_action_chunk(batch)
+
+
+@pytest.mark.parametrize("dtype", ["float16", "bfloat16", "float32", "float64"])
+def test_initialization_preserves_fp32_values_and_buffer_types(dtype):
+    policy = TinyPolicy(ACTConfig(device="cpu", dtype=dtype))
+    assert policy.dtype == get_dtype(dtype)
+    assert policy.backbone.weight.dtype == get_dtype(dtype)
+    assert policy.head_extra.weight.dtype == get_dtype(dtype)  # component boundaries, not substrings
+    assert policy.scale.dtype == get_dtype(dtype)
+    assert policy.indices.dtype == torch.int64
+    assert policy.head.weight.dtype == torch.float32
+    assert torch.equal(policy.head.weight, torch.full((4, 4), 1.000123))
+    assert torch.equal(policy.rotary_emb.inv_freq, torch.tensor([1.000123, 0.500321]))
+
+    loss, _ = policy(torch.ones(2, 4))
+    loss.backward()
+    assert policy.head.weight.grad.dtype == torch.float32
+    assert policy.backbone.weight.grad.dtype == get_dtype(dtype)
+
+
+@pytest.mark.parametrize("dtype", ["int64", "auto", "fp16", "float8_e4m3fn", torch.int64, 16, {}])
+def test_invalid_config_dtype_fails_before_model_construction(dtype):
+    with pytest.raises(ValueError, match="Invalid dtype"):
+        ACTConfig(device="cpu", dtype=dtype)
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, "float32"])
+def test_load_dtype_override_keeps_checkpoint_values_and_updates_supplied_config(tmp_path, dtype):
+    original = TinyPolicy(ACTConfig(device="cpu", dtype="float32"))
+    original.save_pretrained(tmp_path)
+    config = ACTConfig(device="cpu", dtype="float64")
+    policy = TinyPolicy.from_pretrained(tmp_path, config=config, dtype=dtype, strict=True)
+    assert policy.config is config
+    assert policy.dtype == get_dtype(dtype)
+    assert policy.config.dtype == str(get_dtype(dtype)).removeprefix("torch.")
+    assert config.pretrained_path == tmp_path
+    assert not policy.training
+    assert torch.equal(policy.head.weight, original.head.weight)
+    assert torch.equal(policy.rotary_emb.inv_freq, original.rotary_emb.inv_freq)
+    assert torch.equal(policy.backbone.weight, original.backbone.weight.to(get_dtype(dtype)))
+
+
+def test_save_reload_uses_effective_dtype_after_explicit_to(tmp_path):
+    policy = TinyPolicy(ACTConfig(device="cpu", dtype="float32"))
+    assert type(policy).to is nn.Module.to
+    policy.to(dtype=torch.bfloat16)
+    assert policy.dtype == torch.bfloat16
+    assert policy.head.weight.dtype == torch.bfloat16
+    assert policy.rotary_emb.inv_freq.dtype == torch.bfloat16
+    policy.save_pretrained(tmp_path)
+    saved = json.loads((tmp_path / "config.json").read_text())
+    assert saved["dtype"] == "bfloat16"
+    assert "torch_dtype" not in saved
+    loaded = TinyPolicy.from_pretrained(tmp_path, strict=True)
+    assert loaded.dtype == torch.bfloat16
+    assert loaded.head.weight.dtype == torch.float32
+
+
+@pytest.mark.parametrize("config_dtype, expected", [(None, torch.bfloat16), ("float32", torch.float32)])
+def test_auto_uses_config_then_checkpoint_without_materializing_meta_tensors(
+    tmp_path, config_dtype, expected
+):
+    config = ACTConfig(device="cpu", dtype=config_dtype)
+    config.save_pretrained(tmp_path)
+    weights = TinyPolicy(ACTConfig(device="cpu")).to(torch.bfloat16).state_dict()
+    save_file(weights, tmp_path / "model.safetensors")
+    policy = TinyPolicy.from_pretrained(tmp_path, dtype="auto", strict=True)
+    assert policy.dtype == expected
+    assert all(not tensor.is_meta for tensor in policy.parameters())
+
+
+def test_config_cli_and_serialization_use_shared_dtype(tmp_path):
+    with draccus.config_type("json"):
+        config = draccus.parse(ACTConfig, args=["--dtype=bfloat16", "--device=cpu"])
+    config.save_pretrained(tmp_path)
+    restored = PreTrainedConfig.from_pretrained(tmp_path)
+    assert restored.dtype == "bfloat16"
+    assert ACTConfig(dtype=torch.float16, device="cpu").dtype == "float16"
+
+
+def test_post_init_preserves_parameter_identity_ties_and_gradients():
+    policy = TinyPolicy(ACTConfig(device="cpu", dtype="float32"))
+    policy.alias = nn.Linear(4, 4)
+    policy.alias.weight = policy.head.weight
+    param = policy.head.weight
+    param.grad = torch.full_like(param, 1.000123)
+    policy.config.dtype = "bfloat16"
+    policy.post_init()
+    assert policy.head.weight is policy.alias.weight is param
+    assert {"head.weight", "alias.weight"} <= policy._fp32_tensor_names
+    assert param.dtype == param.grad.dtype == torch.float32
+    assert torch.equal(param.grad, torch.full_like(param, 1.000123))
+    assert policy.alias.bias.dtype == torch.bfloat16
+
+
+def test_default_dtype_is_resolved_without_changing_global_state():
+    previous = torch.get_default_dtype()
+    try:
+        torch.set_default_dtype(torch.float64)
+        policy = TinyPolicy(ACTConfig(device="cpu"))
+        assert policy.dtype == torch.float64
+        assert policy.config.dtype == "float64"
+        assert torch.get_default_dtype() == torch.float64
+    finally:
+        torch.set_default_dtype(previous)
+
+
+def test_unspecified_dtype_is_preserved_until_post_init_and_then_saved(tmp_path):
+    class DeferredDtypePolicy(TinyPolicy):
+        def post_init(self):
+            assert self.config.dtype is None
+            super().post_init()
+
+    config = ACTConfig(device="cpu")
+    assert config.dtype is None
+    policy = DeferredDtypePolicy(config)
+    assert policy.config is config
+    assert config.dtype == str(policy.dtype).removeprefix("torch.")
+    config.save_pretrained(tmp_path)
+    assert json.loads((tmp_path / "config.json").read_text())["dtype"] == config.dtype
+
+
+@pytest.mark.parametrize("from_checkpoint", [False, True])
+def test_post_init_records_actual_dtype_when_all_tensors_are_fp32_exceptions(tmp_path, from_checkpoint):
+    class FP32OnlyPolicy(TinyPolicy):
+        _fp32_modules = ("head", "backbone", "head_extra", "rotary_emb", "scale")
+
+    policy = FP32OnlyPolicy(ACTConfig(device="cpu", dtype="bfloat16"))
+    if from_checkpoint:
+        policy.save_pretrained(tmp_path / "checkpoint")
+        policy = FP32OnlyPolicy.from_pretrained(tmp_path / "checkpoint", dtype=torch.bfloat16, strict=True)
+
+    assert all(parameter.dtype == torch.float32 for parameter in policy.parameters())
+    assert policy.dtype == torch.float32
+    assert policy.config.dtype == "float32"
+    policy.config.save_pretrained(tmp_path / "config_only")
+    assert json.loads((tmp_path / "config_only" / "config.json").read_text())["dtype"] == "float32"
+
+
+def test_empty_and_buffer_only_policy_dtype():
+    policy = TinyPolicy(ACTConfig(device="cpu", dtype="bfloat16"))
+    del policy.head, policy.backbone, policy.head_extra, policy.rotary_emb
+    assert policy.dtype == torch.bfloat16
+    del policy.scale
+    assert policy.dtype == torch.bfloat16
+
+
+def test_hub_loading_forwards_download_options(tmp_path, monkeypatch):
+    TinyPolicy(ACTConfig(device="cpu")).save_pretrained(tmp_path)
+    calls = []
+
+    def download(**kwargs):
+        calls.append(kwargs)
+        return str(tmp_path / kwargs["filename"])
+
+    monkeypatch.setattr("lerobot.policies.pretrained.hf_hub_download", download)
+    policy = TinyPolicy.from_pretrained(
+        "owner/policy",
+        config=ACTConfig(device="cpu"),
+        dtype="float16",
+        revision="commit",
+        cache_dir=tmp_path,
+        local_files_only=True,
+        force_download=True,
+    )
+    assert policy.dtype == torch.float16
+    assert calls[0]["revision"] == "commit"
+    assert calls[0]["local_files_only"] is True
+    assert calls[0]["force_download"] is True
+
+
+def test_missing_weights_fail_instead_of_returning_random_model(tmp_path):
+    ACTConfig(device="cpu").save_pretrained(tmp_path)
+    with pytest.raises(FileNotFoundError):
+        TinyPolicy.from_pretrained(tmp_path)
+
+
+@pytest.mark.parametrize("dtype", ["bfloat16", "float16"])
+def test_fp32_paths_are_rooted_and_wildcards_match_one_level(dtype):
+    class ScopedPolicy(TinyPolicy):
+        _fp32_modules = (
+            "model.wrapper.backbone.norm",
+            "model.wrapper.backbone.layers.*.input_layernorm",
+            "model.wrapper.backbone.inv_freq",
+        )
+
+    class Block(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.norm = nn.LayerNorm(4)
+            self.norm.register_buffer("steps", torch.tensor(7))
+            self.norm_extra = nn.LayerNorm(4)
+            self.layers = nn.ModuleList(
+                [
+                    nn.ModuleDict(
+                        {
+                            "input_layernorm": nn.LayerNorm(4),
+                            "input_layernorm_extra": nn.LayerNorm(4),
+                            "nested": nn.ModuleDict({"input_layernorm": nn.LayerNorm(4)}),
+                        }
+                    )
+                ]
+            )
+            self.register_buffer("inv_freq", torch.tensor([1.000123]), persistent=False)
+            self.register_buffer("inv_freq_extra", torch.tensor([1.000123]))
+
+    policy = ScopedPolicy(ACTConfig(device="cpu", dtype="float32"))
+    scoped = Block()
+    policy.model = nn.ModuleDict({"wrapper": nn.ModuleDict({"backbone": scoped})})
+    policy.norm = nn.LayerNorm(4)
+    policy.modelXwrapperXbackbone = nn.ModuleDict({"norm": nn.LayerNorm(4)})
+    prefix = "model.wrapper.backbone."
+    assert policy._fp32_tensor_names == {
+        prefix + name
+        for name in (
+            "norm.weight",
+            "norm.bias",
+            "layers.0.input_layernorm.weight",
+            "layers.0.input_layernorm.bias",
+            "inv_freq",
+        )
+    }
+    assert prefix + "inv_freq" not in policy.state_dict()
+    policy.config.dtype = dtype
+    policy.post_init()
+    assert scoped.norm.weight.dtype == torch.float32
+    assert scoped.layers[0].input_layernorm.weight.dtype == torch.float32
+    assert scoped.inv_freq.dtype == torch.float32
+    assert torch.equal(scoped.inv_freq, torch.tensor([1.000123]))
+    assert scoped.norm_extra.weight.dtype == get_dtype(dtype)
+    assert scoped.layers[0].input_layernorm_extra.weight.dtype == get_dtype(dtype)
+    assert scoped.layers[0].nested.input_layernorm.weight.dtype == get_dtype(dtype)
+    assert scoped.inv_freq_extra.dtype == get_dtype(dtype)
+    assert policy.norm.weight.dtype == get_dtype(dtype)
+    assert policy.modelXwrapperXbackbone.norm.weight.dtype == get_dtype(dtype)
+    assert scoped.norm.steps.dtype == torch.int64
+
+
+def test_fp32_short_paths_only_match_at_the_policy_root():
+    class NormPolicy(TinyPolicy):
+        _fp32_modules = ("norm",)
+
+    policy = NormPolicy(ACTConfig(device="cpu", dtype="float32"))
+    policy.norm = nn.LayerNorm(4)
+    policy.norm_extra = nn.LayerNorm(4)
+    policy.model = nn.ModuleDict({"norm": nn.LayerNorm(4), "norm_extra": nn.LayerNorm(4)})
+    policy.config.dtype = "bfloat16"
+    policy.post_init()
+    assert policy._fp32_tensor_names == {"norm.weight", "norm.bias"}
+    assert policy.norm.weight.dtype == torch.float32
+    assert policy.norm_extra.weight.dtype == torch.bfloat16
+    assert policy.model.norm.weight.dtype == torch.bfloat16
+    assert policy.model.norm_extra.weight.dtype == torch.bfloat16
+    assert policy.backbone.weight.dtype == torch.bfloat16
+
+
+def test_only_top_level_policy_fp32_declarations_are_used():
+    class Block(nn.Module):
+        _fp32_modules = ("norm",)
+
+        def __init__(self):
+            super().__init__()
+            self.norm = nn.LayerNorm(4)
+
+    policy = TinyPolicy(ACTConfig(device="cpu", dtype="float32"))
+    policy.model = Block()
+    policy.config.dtype = "bfloat16"
+    policy.post_init()
+    assert policy.model.norm.weight.dtype == torch.bfloat16
+    assert "model.norm.weight" not in policy._fp32_tensor_names
+
+
+@pytest.mark.parametrize("matching_alias", ["head", "alias"])
+def test_fp32_tensor_names_include_all_aliases_without_matching_equal_tensors(matching_alias):
+    policy = TinyPolicy(ACTConfig(device="cpu", dtype="float32"))
+    policy._fp32_modules = (f"{matching_alias}.weight", "inv_freq_alias")
+    policy.alias = nn.Linear(4, 4)
+    policy.alias.weight = policy.head.weight  # head is enumerated before the protected alias
+    policy.head_alias = policy.head
+    policy.rotary_alias = policy.rotary_emb
+    policy.register_buffer("inv_freq_alias", policy.rotary_emb.inv_freq, persistent=False)
+    policy.equal_weight = nn.Parameter(policy.head.weight.detach().clone())
+    policy.equal_weight.grad = torch.full_like(policy.equal_weight, 1.000123)
+    assert policy._fp32_tensor_names == {
+        "head.weight",
+        "alias.weight",
+        "head_alias.weight",
+        "rotary_emb.inv_freq",
+        "rotary_alias.inv_freq",
+        "inv_freq_alias",
+    }
+    original = policy.head.weight.detach().clone()
+    policy.config.dtype = "bfloat16"
+    policy.post_init()
+    assert policy.alias.weight is policy.head.weight
+    assert policy.head.weight.dtype == torch.float32
+    assert torch.equal(policy.head.weight, original)
+    assert policy.inv_freq_alias is policy.rotary_emb.inv_freq
+    assert torch.equal(policy.inv_freq_alias, torch.tensor([1.000123, 0.500321]))
+    assert policy.equal_weight.dtype == policy.equal_weight.grad.dtype == torch.bfloat16
+    assert policy.alias.bias.dtype == torch.bfloat16
+    assert policy.dtype == torch.bfloat16
+    assert policy.config.dtype == "bfloat16"
+
+
+def test_fp32_tensor_names_follow_current_registrations_without_casting():
+    policy = TinyPolicy(ACTConfig(device="cpu", dtype="float32"))
+    original_names = policy._fp32_tensor_names
+    policy.alias = nn.Linear(4, 4)
+    policy.alias.weight = policy.head.weight
+    assert policy._fp32_tensor_names == original_names | {"alias.weight"}
+    policy.alias.weight = nn.Parameter(policy.alias.weight.detach().clone())
+    assert policy._fp32_tensor_names == original_names
+    policy.head.register_buffer("new_buffer", torch.ones(4), persistent=False)
+    assert policy._fp32_tensor_names == original_names | {"head.new_buffer"}
+    policy.to(dtype=torch.bfloat16)
+    assert policy._fp32_tensor_names == original_names | {"head.new_buffer"}
+    assert policy.head.weight.dtype == torch.bfloat16  # Reading the property does not enforce FP32.
+    assert policy.config.dtype == "float32"
+    del policy.head
+    assert policy._fp32_tensor_names == {"rotary_emb.inv_freq"}
+
+
+@pytest.mark.parametrize("path", ["", ".norm", "model..norm", "model.**.norm", "model.norm*"])
+def test_invalid_fp32_paths_fail_before_casting(path):
+    policy = TinyPolicy(ACTConfig(device="cpu", dtype="float32"))
+    policy._fp32_modules = (path,)
+    policy.config.dtype = "bfloat16"
+    with pytest.raises(ValueError, match="Invalid FP32 path"):
+        policy.post_init()
+    assert policy.backbone.weight.dtype == torch.float32


### PR DESCRIPTION
## Summary / Motivation

Policy authors currently implement precision configuration and checkpoint dtype handling independently. This PR provides an extension interface in `PreTrainedConfig` and `PreTrainedPolicy`: a requested dtype, an observable runtime dtype, declarative FP32 exceptions, and a common initialization/loading flow.


## What changed

- Add `config.dtype`, accepting `float16`, `bfloat16`, `float32`, `float64`, or an unspecified value that resolves to PyTorch's default floating dtype.
- Add the read-only `policy.dtype`. It reports actual floating tensors.
- Add `post_init()` to cast parameters and buffers directly to their final precision, preserve shared parameters and existing gradients.
- Add `_fp32_modules` declaration on the policy class. `_fp32_tensor_names` resolves full module names of protected tensors.
- Add `from_pretrained(dtype=...)`. Explicit values override the supplied/saved config;
- Add the shared dtype resolver, extension documentation, and focused tests using a tiny policy.

This API uses materialized tensors and ordinary PyTorch casts. It introduces no quantization handling, meta-device initialization, `dtype_plan`, `torch_dtype` compatibility alias, or overrides of `.to()`.

## How was this tested (or how to run locally)

```bash
uv run pytest -q tests/policies/test_pretrained_dtype.py tests/configs tests/common
```

Coverage includes explicit and unspecified dtypes, global-default preservation, shared aliases and gradients, path boundaries, non-persistent buffers, CLI/config serialization, automatic checkpoint dtype detection, load overrides, and save/reload after an explicit cast.

Local CPU validation: **141 passed**. All pre-commit hooks for the staged foundation files passed. This is scoped API/config/checkpoint coverage, not a full run of every concrete policy.

## Checklist (required before merge)

- [x] Linting/formatting run on the changed files
- [x] Scoped tests pass locally
- [x] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here

## Reviewer notes

This feature uses materialized tensors and ordinary PyTorch casts. It introduces no quantization handling, meta-device initialization.