### PR TITLE
refactor(policies): adopt shared dtype management across policies

### DIFF
--- a/docs/source/bring_your_own_policies.mdx
+++ b/docs/source/bring_your_own_policies.mdx
@@ -114,7 +114,8 @@ class MyPolicy(PreTrainedPolicy):
         super().__init__(config, dataset_stats)
         config.validate_features()  # not called automatically by the base class
         self.config = config
-        self.model = ...  # your nn.Module here
+        self.model = ...  # construct real tensors in FP32
+        self.post_init()  # apply config.dtype and the declared FP32 exceptions
 
     def reset(self):
         """Reset per-episode state. Called by lerobot-eval at the start of each episode."""
@@ -147,6 +148,40 @@ class MyPolicy(PreTrainedPolicy):
         ...
         return loss, {"some_loss_component": some_loss_component.item()}
 ```
+
+### Parameter precision
+
+LeRobot supports Transformers-style precision management. Every policy has `config.dtype` and the read-only `policy.dtype` property, where `config.dtype` is used to configure the precision and `policy.dtype` reflects the policy's actual precision. You can control the parameter precision in various ways:
+
+- When initializing a new model from scratch, you can override the `config.dtype`, for example `dtype: str = "bfloat16"`.
+- When loading a pre-trained checkpoint, use `from_pretrained(dtype=...)` to override the original configuration of the checkpoint.
+
+```python
+config = MyPolicyConfig(dtype="bfloat16")
+policy = MyPolicy(config)
+print(policy.dtype)  # torch.bfloat16
+
+policy = MyPolicy.from_pretrained("owner/checkpoint", dtype=torch.float16)
+```
+
+For your own policies, please call `self.post_init()` after constructing every submodule. It will cast real parameters and floating buffers directly to their final precision, preserving integer buffers and shared parameters.
+
+When you have numerically sensitive parts like action heads, declare them with `_fp32_modules` **on the top-level policy class**. Each entry is a module or tensor path starting at the policy root:
+
+```python
+class MyPolicy(PreTrainedPolicy):
+    config_class = MyPolicyConfig
+    name = "my_policy"
+    _fp32_modules = (
+        "model.action_head",
+        "model.backbone.layers.*.input_layernorm",
+        "model.backbone.norm",
+        "model.backbone.rotary_emb.inv_freq",
+    )
+    # __init__ constructs all modules, then calls self.post_init().
+```
+
+These modules will be kept in fp32 through `self.post_init()`, protecting them from casting to lower precision. The standard PyTorch casting methods remain unchanged and can explicitly cast the entire model, including protected tensors. The declarations apply during initialization and checkpoint loading, not to subsequent user-directed casts.
 
 The methods called by the train/eval loops:
 

--- a/docs/source/evo1.mdx
+++ b/docs/source/evo1.mdx
@@ -125,7 +125,7 @@ every finetuning flag.
 | `policy.training_stage`                       | `stage1`                    | `stage1` trains the action head; `stage2` finetunes VLM branches  |
 | `policy.apply_training_stage_defaults`        | `true`                      | Reapplies stage finetuning defaults after loading a checkpoint    |
 | `policy.vlm_num_layers`                       | `14`                        | Number of InternVL3 language layers kept for the policy           |
-| `policy.vlm_dtype`                            | `bfloat16`                  | Requested VLM dtype                                               |
+| `policy.dtype`                                | `bfloat16`                  | Requested VLM dtype                                               |
 | `policy.use_flash_attn`                       | `true`                      | Requests FlashAttention when installed; otherwise falls back      |
 | `policy.enable_gradient_checkpointing`        | `true`                      | Enables checkpointing on supported InternVL3 modules              |
 | `policy.gradient_checkpointing_use_reentrant` | `false`                     | Reentrant setting passed to gradient checkpointing when supported |
@@ -208,7 +208,7 @@ uv run accelerate launch --num_processes=2 -m lerobot.scripts.lerobot_train \
   --policy.apply_training_stage_defaults=true \
   --policy.vlm_model_name="${VLM_DIR}" \
   --policy.vlm_num_layers=14 \
-  --policy.vlm_dtype=bfloat16 \
+  --policy.dtype=bfloat16 \
   --policy.device=cuda \
   --policy.use_amp=true \
   --policy.use_flash_attn=true \
@@ -258,7 +258,7 @@ uv run accelerate launch --num_processes=2 -m lerobot.scripts.lerobot_train \
   --policy.apply_training_stage_defaults=true \
   --policy.vlm_model_name="${VLM_DIR}" \
   --policy.vlm_num_layers=14 \
-  --policy.vlm_dtype=float32 \
+  --policy.dtype=float32 \
   --policy.device=cuda \
   --policy.use_amp=true \
   --policy.use_flash_attn=true \
@@ -337,7 +337,7 @@ for task_id in {0..9}; do
     --policy.vlm_model_name=OpenGVLab/InternVL3-1B-hf \
     --policy.device=cuda \
     --policy.use_amp=true \
-    --policy.vlm_dtype=bfloat16 \
+    --policy.dtype=bfloat16 \
     --policy.use_flash_attn=false \
     --policy.enable_gradient_checkpointing=false \
     --policy.vlm_num_layers=14 \

--- a/docs/source/fastwam.mdx
+++ b/docs/source/fastwam.mdx
@@ -80,7 +80,7 @@ Evaluate an existing LeRobot-format checkpoint on LIBERO-10 with:
 lerobot-eval \
   --policy.path=ZibinDong/fastwam_libero_uncond_2cam224 \
   --policy.device=cuda \
-  --policy.torch_dtype=float32 \
+  --policy.dtype=float32 \
   --policy.n_action_steps=10 \
   --env.type=libero \
   --env.task=libero_10 \
@@ -158,7 +158,7 @@ Evaluated on LIBERO with [`ZibinDong/fastwam_libero_uncond_2cam224`](https://hug
 | libero_10      |        94.0% |        500 |
 | **average**    |    **96.4%** |       2000 |
 
-Reproduce: `lerobot-eval --policy.path=ZibinDong/fastwam_libero_uncond_2cam224 --policy.device=cuda --policy.torch_dtype=float32 --policy.n_action_steps=10 --env.type=libero --env.task=libero_spatial --env.observation_height=256 --env.observation_width=256 --eval.batch_size=1 --eval.n_episodes=50 --seed=0 --env.episode_length=300` (1x H20 140 GB).
+Reproduce: `lerobot-eval --policy.path=ZibinDong/fastwam_libero_uncond_2cam224 --policy.device=cuda --policy.dtype=float32 --policy.n_action_steps=10 --env.type=libero --env.task=libero_spatial --env.observation_height=256 --env.observation_width=256 --eval.batch_size=1 --eval.n_episodes=50 --seed=0 --env.episode_length=300` (1x H20 140 GB).
 
 ## References
 

--- a/src/lerobot/configs/policies.py
+++ b/src/lerobot/configs/policies.py
@@ -29,6 +29,7 @@ from huggingface_hub.errors import HfHubHTTPError
 from lerobot.optim import LRSchedulerConfig, OptimizerConfig
 from lerobot.utils.constants import ACTION, OBS_STATE
 from lerobot.utils.device_utils import auto_select_torch_device, is_amp_available, is_torch_device_available
+from lerobot.utils.dtype import get_dtype
 from lerobot.utils.hub import HubMixin
 
 from .types import FeatureType, PolicyFeature
@@ -60,6 +61,9 @@ class PreTrainedConfig(draccus.ChoiceRegistry, HubMixin, abc.ABC):  # type: igno
     output_features: dict[str, PolicyFeature] | None = field(default_factory=dict)
 
     device: str | None = None  # e.g. "cuda", "cuda:0", "cpu", or "mps"
+    # Parameter storage dtype. None uses PyTorch's default when constructing a policy.
+    # FP32-sensitive modules are declared by the policy and keep their precision.
+    dtype: str | None = None
     # `use_amp` determines whether to use Automatic Mixed Precision (AMP) for training and evaluation. With AMP,
     # automatic gradient scaling is used.
     use_amp: bool = False
@@ -83,6 +87,8 @@ class PreTrainedConfig(draccus.ChoiceRegistry, HubMixin, abc.ABC):  # type: igno
     pretrained_revision: str | None = None
 
     def __post_init__(self) -> None:
+        if self.dtype is not None:
+            self.dtype = str(get_dtype(self.dtype)).removeprefix("torch.")
         if not self.device or not is_torch_device_available(self.device):
             auto_device = auto_select_torch_device()
             logger.warning(f"Device '{self.device}' is not available. Switching to '{auto_device}'.")

--- a/src/lerobot/policies/act/modeling_act.py
+++ b/src/lerobot/policies/act/modeling_act.py
@@ -69,6 +69,7 @@ class ACTPolicy(PreTrainedPolicy):
         if config.temporal_ensemble_coeff is not None:
             self.temporal_ensembler = ACTTemporalEnsembler(config.temporal_ensemble_coeff, config.chunk_size)
 
+        self.post_init()
         self.reset()
 
     def get_optim_params(self) -> dict:
@@ -454,9 +455,8 @@ class ACT(nn.Module):
         else:
             # When not using the VAE encoder, we set the latent to be all zeros.
             mu = log_sigma_x2 = None
-            # TODO(rcadene, alexander-soare): remove call to `.to` to speedup forward ; precompute and use buffer
-            latent_sample = torch.zeros([batch_size, self.config.latent_dim], dtype=torch.float32).to(
-                batch[OBS_STATE].device
+            latent_sample = self.encoder_latent_input_proj.weight.new_zeros(
+                batch_size, self.config.latent_dim
             )
 
         # Prepare transformer encoder inputs.

--- a/src/lerobot/policies/diffusion/modeling_diffusion.py
+++ b/src/lerobot/policies/diffusion/modeling_diffusion.py
@@ -84,6 +84,7 @@ class DiffusionPolicy(PreTrainedPolicy):
 
         self.diffusion = DiffusionModel(config)
 
+        self.post_init()
         self.reset()
 
     def get_optim_params(self) -> dict:

--- a/src/lerobot/policies/eo1/configuration_eo1.py
+++ b/src/lerobot/policies/eo1/configuration_eo1.py
@@ -74,12 +74,7 @@ class EO1Config(PreTrainedConfig):
     supervise_padding_action_dims: bool = True
     supervise_padding_actions: bool = True
 
-    # Policy-level dtype request for the Qwen backbone.
-    # - "auto": follow the backbone config/checkpoint default dtype. For Qwen2.5-VL this resolves to bf16.
-    #           The EO1 flow-matching head still keeps its own parameters in fp32.
-    # - "bfloat16": force the backbone to initialize/load in bf16 regardless of the saved config default.
-    # - "float32": force the backbone to initialize/load in fp32 for maximum numerical conservatism.
-    dtype: str = "auto"  # Options: "auto", "bfloat16", "float32"
+    dtype: str = "bfloat16"
     force_fp32_autocast: bool = True
 
     # Optional attention backend request passed through to the Qwen backbone.

--- a/src/lerobot/policies/eo1/modeling_eo1.py
+++ b/src/lerobot/policies/eo1/modeling_eo1.py
@@ -53,29 +53,43 @@ class EO1Policy(PreTrainedPolicy):
     config_class = EO1Config
     name = "eo1"
 
+    _fp32_modules = (
+        "model.state_proj",
+        "model.action_in_proj",
+        "model.action_out_proj",
+        "model.action_time_mlp_in",
+        "model.action_time_mlp_out",
+        "model.vlm_backbone.model.language_model.rotary_emb",
+        "model.vlm_backbone.model.visual.rotary_pos_emb",
+    )
+
     def __init__(self, config: EO1Config, **kwargs):
         require_package("transformers", extra="eo1")
         super().__init__(config)
         config.validate_features()
         self.config = config
 
+        # An unspecified policy dtype uses PyTorch's default, while Transformers
+        # would interpret dtype=None as a request to infer the checkpoint dtype.
+        dtype = config.dtype if config.dtype is not None else torch.get_default_dtype()
         if config.pretrained_path is None:
             # Initialize from pretrained VLM
             vlm_backbone = Qwen2_5_VLForConditionalGeneration.from_pretrained(
                 config.vlm_base,
-                dtype=config.dtype,
+                dtype=dtype,
                 attn_implementation=config.attn_implementation,
             )
         else:
             vlm_backbone = Qwen2_5_VLForConditionalGeneration._from_config(
                 config.vlm_backbone_config,
-                dtype=config.vlm_backbone_config.dtype if config.dtype == "auto" else config.dtype,
+                dtype=dtype,
             )
 
         self.model = EO1VisionFlowMatchingModel(config, vlm_backbone)
         if config.gradient_checkpointing:
             self.model.gradient_checkpointing_enable()
 
+        self.post_init()
         self.model.to(config.device)
         self.reset()
 
@@ -164,7 +178,6 @@ class EO1VisionFlowMatchingModel(nn.Module):
         super().__init__()
 
         self.config = config
-        # Preserve the backbone dtype selected at construction time so Qwen's fp32 rotary buffers stay intact.
         self.vlm_backbone = vlm_backbone
         self.hidden_size = self.vlm_backbone.config.text_config.hidden_size
         max_state_dim = config.max_state_dim

--- a/src/lerobot/policies/evo1/configuration_evo1.py
+++ b/src/lerobot/policies/evo1/configuration_evo1.py
@@ -63,7 +63,7 @@ class Evo1Config(PreTrainedConfig):
 
     vlm_model_name: str = "OpenGVLab/InternVL3-1B-hf"
     vlm_num_layers: int | None = 14
-    vlm_dtype: str = "bfloat16"
+    dtype: str = "bfloat16"
     # Max token length for tokenizing the (image placeholders + instruction) prompt. Prompts longer
     # than this are right-truncated, so raise it for tasks with long language instructions or many views.
     max_text_length: int = 1024

--- a/src/lerobot/policies/evo1/evo1_model.py
+++ b/src/lerobot/policies/evo1/evo1_model.py
@@ -43,7 +43,7 @@ class Evo1Model(nn.Module):
             image_size=int(config.image_resolution[0]),
             device=self._device,
             num_language_layers=config.vlm_num_layers,
-            model_dtype=config.vlm_dtype,
+            dtype=torch.float32,
             use_flash_attn=config.use_flash_attn,
             max_text_length=config.max_text_length,
             enable_gradient_checkpointing=enable_gradient_checkpointing,
@@ -74,7 +74,7 @@ class Evo1Model(nn.Module):
             num_categories=config.num_categories,
             state_dim=config.max_state_dim,
             state_hidden_dim=config.state_hidden_dim,
-        ).to(self._device)
+        )
 
     def get_vl_embeddings(
         self,

--- a/src/lerobot/policies/evo1/internvl3_embedder.py
+++ b/src/lerobot/policies/evo1/internvl3_embedder.py
@@ -111,7 +111,7 @@ class InternVL3Embedder(nn.Module):
         image_size=448,
         device="cuda",
         num_language_layers: int | None = 14,
-        model_dtype: str | torch.dtype = "bfloat16",
+        dtype: torch.dtype = torch.float32,
         use_flash_attn: bool = True,
         max_text_length: int = 1024,
         enable_gradient_checkpointing: bool = True,
@@ -130,12 +130,6 @@ class InternVL3Embedder(nn.Module):
         require_package("transformers", extra="evo1")
 
         self.tokenizer = AutoTokenizer.from_pretrained(model_name, **hub_kwargs)
-        if isinstance(model_dtype, str):
-            try:
-                model_dtype = getattr(torch, model_dtype)
-            except AttributeError as exc:
-                raise ValueError(f"Unsupported EVO1 vlm_dtype '{model_dtype}'") from exc
-        self.model_dtype = model_dtype
 
         attn_implementation = (
             "flash_attention_2" if (use_flash_attn and is_flash_attn_2_available()) else "eager"
@@ -147,11 +141,11 @@ class InternVL3Embedder(nn.Module):
 
         self.model = AutoModel.from_pretrained(
             model_name,
-            torch_dtype=model_dtype,
+            dtype=dtype,
             attn_implementation=attn_implementation,
             low_cpu_mem_usage=True,
             **hub_kwargs,
-        ).to(self._requested_device)
+        )
 
         checkpoint_image_size = getattr(self.model.config.vision_config, "image_size", None)
         if isinstance(checkpoint_image_size, (list, tuple)):
@@ -261,10 +255,10 @@ class InternVL3Embedder(nn.Module):
         """
         max_views = int(image_masks.shape[1])
         batch_size = int(image_masks.shape[0])
-        mean = torch.tensor(IMAGENET_MEAN, device=self.device, dtype=self.model_dtype)
-        std = torch.tensor(IMAGENET_STD, device=self.device, dtype=self.model_dtype)
+        mean = torch.tensor(IMAGENET_MEAN, device=self.device, dtype=self.model.dtype)
+        std = torch.tensor(IMAGENET_STD, device=self.device, dtype=self.model.dtype)
         pixel_values = _batched_pixel_values(
-            camera_images, max_views, self.image_size, mean, std, self.model_dtype, self.device
+            camera_images, max_views, self.image_size, mean, std, self.model.dtype, self.device
         )
         # InternVL3 preprocessing uses a single tile per image (max_num=1).
         batch_num_tiles_list = [[1] * max_views for _ in range(batch_size)]

--- a/src/lerobot/policies/evo1/modeling_evo1.py
+++ b/src/lerobot/policies/evo1/modeling_evo1.py
@@ -42,6 +42,11 @@ class Evo1Policy(PreTrainedPolicy):
     config_class = Evo1Config
     name = "evo1"
 
+    _fp32_modules = (
+        "model.action_head",
+        "model.embedder.model.language_model.rotary_emb",
+    )
+
     def supports_rtc(self) -> bool:
         return True
 
@@ -59,6 +64,8 @@ class Evo1Policy(PreTrainedPolicy):
         self.model.set_finetune_flags()
         self._keep_frozen_embedder_eval()
         self.init_rtc_processor()
+        self.post_init()
+        self.model.to(config.device)
         self.reset()
 
     def init_rtc_processor(self):

--- a/src/lerobot/policies/fastwam/configuration_fastwam.py
+++ b/src/lerobot/policies/fastwam/configuration_fastwam.py
@@ -198,7 +198,7 @@ class FastWAMConfig(PreTrainedConfig):
     tokenizer_max_len: int = 128
     load_text_encoder: bool = True
     mot_checkpoint_mixed_attn: bool = False
-    torch_dtype: str = "bfloat16"
+    dtype: str = "bfloat16"
     prompt_template: str = (
         "A video recorded from a robot's point of view executing the following instruction: {task}"
     )

--- a/src/lerobot/policies/fastwam/modeling_fastwam.py
+++ b/src/lerobot/policies/fastwam/modeling_fastwam.py
@@ -23,6 +23,7 @@ from torch import Tensor
 
 from lerobot.policies.pretrained import PreTrainedPolicy
 from lerobot.utils.constants import OBS_STATE
+from lerobot.utils.dtype import get_dtype
 from lerobot.utils.import_utils import require_package
 
 from .configuration_fastwam import FastWAMConfig
@@ -88,6 +89,8 @@ class FastWAMPolicy(PreTrainedPolicy):
                 for layer in mot.layers:
                     if "video" in layer.blocks:
                         layer.blocks["video"].requires_grad_(False)
+        self.post_init()
+        self.model.to(config.device)
         self.reset()
 
     @classmethod
@@ -255,17 +258,18 @@ class FastWAMPolicy(PreTrainedPolicy):
         across checkpoints) and are intentionally excluded from `model.safetensors`
         — see `FastWAM.__init__`. The tokenizer comes from `google/umt5-xxl`.
         """
-        dtype = _dtype_from_name(config.torch_dtype)
-        device = config.device
-        video_expert = WanVideoDiT(**config.video_dit_config).to(device=device, dtype=dtype)
-        action_expert = ActionDiT(**config.action_dit_config).to(device=device, dtype=dtype)
+        dtype = get_dtype(config.dtype)
+        # Finalize precision on CPU before moving the model to the requested device.
+        device = "cpu"
+        video_expert = WanVideoDiT(**config.video_dit_config).to(device=device)
+        action_expert = ActionDiT(**config.action_dit_config).to(device=device)
         mot = MoT(
             mixtures={"video": video_expert, "action": action_expert},
             mot_checkpoint_mixed_attn=config.mot_checkpoint_mixed_attn,
         )
         text_encoder = (
             load_pretrained_wan_text_encoder(
-                model_id=config.text_encoder_model_id, torch_dtype=dtype, device=device
+                model_id=config.text_encoder_model_id, dtype=dtype, device=device
             )
             if config.load_text_encoder
             else None
@@ -274,7 +278,7 @@ class FastWAMPolicy(PreTrainedPolicy):
             video_expert=video_expert,
             action_expert=action_expert,
             mot=mot,
-            vae=load_pretrained_wan_vae(torch_dtype=dtype, device=device),
+            vae=load_pretrained_wan_vae(dtype=dtype, device=device),
             text_encoder=text_encoder,
             tokenizer=build_wan_tokenizer(
                 model_id=config.tokenizer_model_id, tokenizer_max_len=config.tokenizer_max_len
@@ -282,7 +286,7 @@ class FastWAMPolicy(PreTrainedPolicy):
             text_dim=int(config.video_dit_config["text_dim"]),
             proprio_dim=config.proprio_dim,
             device=device,
-            torch_dtype=dtype,
+            dtype=dtype,
             video_train_shift=float(config.video_scheduler["train_shift"]),
             video_infer_shift=float(config.video_scheduler["infer_shift"]),
             video_num_train_timesteps=int(config.video_scheduler["num_train_timesteps"]),
@@ -364,13 +368,6 @@ def _slice_infer_value(value: Any, *, index: int, batch_size: int) -> Any:
     if isinstance(value, (list, tuple)) and len(value) == batch_size:
         return value[index]
     return value
-
-
-def _dtype_from_name(name: str) -> torch.dtype:
-    dtype_map = {"float32": torch.float32, "float16": torch.float16, "bfloat16": torch.bfloat16}
-    if name not in dtype_map:
-        raise ValueError(f"Unsupported torch dtype `{name}`.")
-    return dtype_map[name]
 
 
 def batch_device(batch: dict[str, Any]) -> torch.device:

--- a/src/lerobot/policies/fastwam/wan/components.py
+++ b/src/lerobot/policies/fastwam/wan/components.py
@@ -58,7 +58,6 @@ class WanTextEncoder(torch.nn.Module):
 
     def __init__(
         self,
-        dtype: torch.dtype = torch.bfloat16,
         device: str | torch.device = "cuda",
         *,
         pretrained: torch.nn.Module,
@@ -67,7 +66,8 @@ class WanTextEncoder(torch.nn.Module):
         # UMT5-XXL is a fixed pretrained encoder — never trained from scratch, so a real
         # `UMT5EncoderModel` (with weights) must always be supplied (loaded from the
         # diffusers repo by `load_pretrained_wan_text_encoder`). No random/offline build.
-        self.model = pretrained.to(device=device, dtype=dtype)
+        # Preserve the loader's FP16-only FP32 exceptions (UMT5 feed-forward outputs).
+        self.model = pretrained.to(device=device)
         self.dim = int(self.model.config.d_model)
 
     def forward(self, ids: torch.Tensor, mask: torch.Tensor) -> torch.Tensor:
@@ -109,18 +109,18 @@ def build_wan_tokenizer(*, model_id: str = WAN_T5_TOKENIZER, tokenizer_max_len: 
     return WanTokenizer(name=model_id, seq_len=int(tokenizer_max_len))
 
 
-def load_pretrained_wan_vae(*, torch_dtype: torch.dtype, device: str) -> WanVideoVAE38:
+def load_pretrained_wan_vae(*, dtype: torch.dtype, device: str) -> WanVideoVAE38:
     """Load real Wan2.2 VAE weights from the diffusers repo (offline base creation)."""
     require_package("diffusers", extra="fastwam")
-    vae = AutoencoderKLWan.from_pretrained(WAN22_DIFFUSERS_MODEL_ID, subfolder="vae", torch_dtype=torch_dtype)
-    return WanVideoVAE38(dtype=torch_dtype, device=device, pretrained=vae)
+    vae = AutoencoderKLWan.from_pretrained(WAN22_DIFFUSERS_MODEL_ID, subfolder="vae", torch_dtype=dtype)
+    return WanVideoVAE38(dtype=dtype, device=device, pretrained=vae)
 
 
 def load_pretrained_wan_text_encoder(
     *,
     model_id: str = WAN22_DIFFUSERS_MODEL_ID,
     subfolder: str | None = "text_encoder",
-    torch_dtype: torch.dtype,
+    dtype: torch.dtype,
     device: str,
 ) -> WanTextEncoder:
     """Load UMT5-XXL encoder weights (defaults to the Wan2.2 diffusers repo).
@@ -129,8 +129,8 @@ def load_pretrained_wan_text_encoder(
     embedding table is indexed by the tokenizer's vocabulary.
     """
     require_package("transformers", extra="fastwam")
-    encoder = UMT5EncoderModel.from_pretrained(model_id, subfolder=subfolder, torch_dtype=torch_dtype)
-    return WanTextEncoder(dtype=torch_dtype, device=device, pretrained=encoder)
+    encoder = UMT5EncoderModel.from_pretrained(model_id, subfolder=subfolder, dtype=dtype)
+    return WanTextEncoder(device=device, pretrained=encoder)
 
 
 def resolve_wan_dit_paths(
@@ -159,13 +159,13 @@ def load_wan_video_dit(
     paths: list[str | Path],
     *,
     dit_config: dict[str, Any],
-    torch_dtype: torch.dtype,
+    dtype: torch.dtype,
     device: str,
 ) -> WanVideoDiT:
     model = WanVideoDiT(**dit_config)
     state_dict = _read_wan_dit_safetensors(paths)
     model.load_state_dict(state_dict, strict=False)
-    return model.to(device=device, dtype=torch_dtype)
+    return model.to(device=device, dtype=dtype)
 
 
 def _read_wan_dit_safetensors(paths: list[str | Path]) -> dict[str, torch.Tensor]:

--- a/src/lerobot/policies/fastwam/wan/modular.py
+++ b/src/lerobot/policies/fastwam/wan/modular.py
@@ -839,7 +839,7 @@ class FastWAM(torch.nn.Module):
         text_dim: int | None = None,
         proprio_dim: int | None = None,
         device: str = "cpu",
-        torch_dtype: torch.dtype = torch.float32,
+        dtype: torch.dtype = torch.float32,
         video_train_shift: float = 5.0,
         video_infer_shift: float = 5.0,
         video_num_train_timesteps: int = 1000,
@@ -883,7 +883,7 @@ class FastWAM(torch.nn.Module):
         self.text_dim = int(text_dim)
         self.proprio_dim = None if proprio_dim is None else int(proprio_dim)
         if self.proprio_dim is not None:
-            self.proprio_encoder = nn.Linear(self.proprio_dim, self.text_dim).to(torch_dtype)
+            self.proprio_encoder = nn.Linear(self.proprio_dim, self.text_dim).to(dtype)
         else:
             self.proprio_encoder = None
 
@@ -907,18 +907,24 @@ class FastWAM(torch.nn.Module):
         self.train_scheduler = self.train_video_scheduler
         self.infer_scheduler = self.infer_video_scheduler
 
-        self.device = torch.device(device)
-        self.torch_dtype = torch_dtype
         self.loss_lambda_video = float(loss_lambda_video)
         self.loss_lambda_action = float(loss_lambda_action)
 
-        self.to(self.device)
+        self.to(device)
+
+    @property
+    def device(self) -> torch.device:
+        return next(self.mot.parameters()).device
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return next(self.mot.parameters()).dtype
 
     @classmethod
     def from_wan22_pretrained(
         cls,
         device: str = "cuda",
-        torch_dtype: torch.dtype = torch.bfloat16,
+        dtype: torch.dtype = torch.bfloat16,
         model_id: str = "Wan-AI/Wan2.2-TI2V-5B",
         tokenizer_model_id: str = WAN_T5_TOKENIZER,
         text_encoder_model_id: str = WAN22_DIFFUSERS_MODEL_ID,
@@ -948,10 +954,10 @@ class FastWAM(torch.nn.Module):
         video_expert = load_wan_video_dit(
             resolve_wan_dit_paths(model_id),
             dit_config=video_dit_config,
-            torch_dtype=torch_dtype,
+            dtype=dtype,
             device=device,
         )
-        action_expert = ActionDiT(**action_dit_config).to(device=device, dtype=torch_dtype)
+        action_expert = ActionDiT(**action_dit_config).to(device=device, dtype=dtype)
         if int(action_expert.num_heads) != int(video_expert.num_heads):
             raise ValueError("ActionDiT `num_heads` must match video expert for MoT mixed attention.")
         if int(action_expert.attn_head_dim) != int(video_expert.attn_head_dim):
@@ -964,11 +970,9 @@ class FastWAM(torch.nn.Module):
             mot_checkpoint_mixed_attn=mot_checkpoint_mixed_attn,
         )
 
-        vae = load_pretrained_wan_vae(torch_dtype=torch_dtype, device=device)
+        vae = load_pretrained_wan_vae(dtype=dtype, device=device)
         text_encoder = (
-            load_pretrained_wan_text_encoder(
-                model_id=text_encoder_model_id, torch_dtype=torch_dtype, device=device
-            )
+            load_pretrained_wan_text_encoder(model_id=text_encoder_model_id, dtype=dtype, device=device)
             if load_text_encoder
             else None
         )
@@ -984,7 +988,7 @@ class FastWAM(torch.nn.Module):
             text_dim=int(video_dit_config["text_dim"]),
             proprio_dim=proprio_dim,
             device=device,
-            torch_dtype=torch_dtype,
+            dtype=dtype,
             video_train_shift=video_train_shift,
             video_infer_shift=video_infer_shift,
             video_num_train_timesteps=video_num_train_timesteps,
@@ -1160,7 +1164,7 @@ class FastWAM(torch.nn.Module):
                     f"got {tuple(image_is_pad.shape)} vs expected ({batch_size}, {num_frames})"
                 )
 
-        input_video = video.to(device=self.device, dtype=self.torch_dtype, non_blocking=True)
+        input_video = video.to(device=self.device, dtype=self.dtype, non_blocking=True)
         input_latents = self._encode_video_latents(input_video, tiled=tiled)
 
         first_frame_latents = None
@@ -1173,7 +1177,7 @@ class FastWAM(torch.nn.Module):
             raise ValueError(
                 f"`context/context_mask` must be [B,L,D]/[B,L], got {tuple(context.shape)} and {tuple(context_mask.shape)}"
             )
-        context = context.to(device=self.device, dtype=self.torch_dtype, non_blocking=True)
+        context = context.to(device=self.device, dtype=self.dtype, non_blocking=True)
         context_mask = context_mask.to(device=self.device, dtype=torch.bool, non_blocking=True)
         if self.proprio_encoder is not None:
             if proprio is None:
@@ -1190,9 +1194,9 @@ class FastWAM(torch.nn.Module):
             context, context_mask = self._append_proprio_to_context(
                 context=context,
                 context_mask=context_mask,
-                proprio=proprio.to(device=self.device, dtype=self.torch_dtype),
+                proprio=proprio.to(device=self.device, dtype=self.dtype),
             )
-        action = action.to(device=self.device, dtype=self.torch_dtype, non_blocking=True)
+        action = action.to(device=self.device, dtype=self.dtype, non_blocking=True)
 
         if action_is_pad is not None:
             action_is_pad = action_is_pad.to(device=self.device, dtype=torch.bool, non_blocking=True)
@@ -1616,7 +1620,7 @@ class FastWAM(torch.nn.Module):
             raise ValueError(f"`proprio` must be [D] or [1,D], got shape {tuple(proprio.shape)}")
         if proprio.shape[1] != self.proprio_dim:
             raise ValueError(f"`proprio` last dim must be {self.proprio_dim}, got {proprio.shape[1]}")
-        return proprio.to(device=self.device, dtype=self.torch_dtype)
+        return proprio.to(device=self.device, dtype=self.dtype)
 
     def _prepare_infer_context(self, prompt, context, context_mask, proprio):
         use_prompt = prompt is not None
@@ -1648,7 +1652,7 @@ class FastWAM(torch.nn.Module):
             raise ValueError(
                 f"`context/context_mask` must be [B,L,D]/[B,L], got {tuple(context.shape)} and {tuple(context_mask.shape)}"
             )
-        context = context.to(device=self.device, dtype=self.torch_dtype, non_blocking=True)
+        context = context.to(device=self.device, dtype=self.dtype, non_blocking=True)
         context_mask = context_mask.to(device=self.device, dtype=torch.bool, non_blocking=True)
         return context, context_mask
 
@@ -1659,7 +1663,7 @@ class FastWAM(torch.nn.Module):
             generator=generator,
             device=rand_device,
             dtype=torch.float32,
-        ).to(device=self.device, dtype=self.torch_dtype)
+        ).to(device=self.device, dtype=self.dtype)
 
     def _make_video_latents(self, num_video_frames: int, height: int, width: int, seed, rand_device):
         latent_t = (num_video_frames - 1) // self.vae.temporal_downsample_factor + 1
@@ -1671,7 +1675,7 @@ class FastWAM(torch.nn.Module):
             generator=generator,
             device=rand_device,
             dtype=torch.float32,
-        ).to(device=self.device, dtype=self.torch_dtype)
+        ).to(device=self.device, dtype=self.dtype)
 
     @torch.no_grad()
     def infer_joint(
@@ -1721,12 +1725,12 @@ class FastWAM(torch.nn.Module):
                 raise ValueError(
                     f"`action` must have shape [1, T, a_dim] or [T, a_dim], got {tuple(action.shape)} with action_horizon={action_horizon}"
                 )
-            action = action.to(device=self.device, dtype=self.torch_dtype)
+            action = action.to(device=self.device, dtype=self.dtype)
         proprio = self._normalize_infer_proprio(proprio)
         latents_video = self._make_video_latents(num_video_frames, height, width, seed, rand_device)
         latents_action = self._make_action_latents(action_horizon, seed, rand_device)
 
-        input_image = input_image.to(device=self.device, dtype=self.torch_dtype)
+        input_image = input_image.to(device=self.device, dtype=self.dtype)
         first_frame_latents = self._encode_input_image_latents_tensor(input_image=input_image, tiled=tiled)
         latents_video[:, :, 0:1] = first_frame_latents.clone()
         fuse_flag = bool(getattr(self.video_expert, "fuse_vae_embedding_in_latents", False))
@@ -1809,7 +1813,7 @@ class FastWAM(torch.nn.Module):
         proprio = self._normalize_infer_proprio(proprio)
         latents_action = self._make_action_latents(action_horizon, seed, rand_device)
 
-        input_image = input_image.to(device=self.device, dtype=self.torch_dtype)
+        input_image = input_image.to(device=self.device, dtype=self.dtype)
         first_frame_latents = self._encode_input_image_latents_tensor(input_image=input_image, tiled=tiled)
         fuse_flag = bool(getattr(self.video_expert, "fuse_vae_embedding_in_latents", False))
 

--- a/src/lerobot/policies/gaussian_actor/modeling_gaussian_actor.py
+++ b/src/lerobot/policies/gaussian_actor/modeling_gaussian_actor.py
@@ -51,6 +51,7 @@ class GaussianActorPolicy(
         self._init_encoders()
         self._init_actor(continuous_action_dim)
         self._init_discrete_critic()
+        self.post_init()
 
     def get_optim_params(self) -> dict:
         optim_params = {

--- a/src/lerobot/policies/groot/configuration_groot.py
+++ b/src/lerobot/policies/groot/configuration_groot.py
@@ -244,6 +244,9 @@ class GrootConfig(PreTrainedConfig):
     """Configuration for Groot policy wrapper."""
 
     # Basic policy settings
+    # The native fine-tuning recipe uses FP32 parameters with BF16 autocast.
+    dtype: str = "float32"
+
     n_obs_steps: int = 1
     chunk_size: int = 40
     n_action_steps: int = 40
@@ -343,8 +346,6 @@ class GrootConfig(PreTrainedConfig):
     optimizer_weight_decay: float = 1e-5
     warmup_ratio: float = 0.05
     use_bf16: bool = True
-    # The native N1.7 fine-tuning recipe keeps model parameters in FP32 and computes under BF16 autocast.
-    model_params_fp32: bool = True
 
     # TODO(Steven): Remove these deprecated fields in a future release.
     # Deprecated Isaac-GR00T runner / GR00T N1.5 fields, plus the (never-wired) LoRA fields — all

--- a/src/lerobot/policies/groot/groot_n1_7.py
+++ b/src/lerobot/policies/groot/groot_n1_7.py
@@ -74,7 +74,6 @@ def _tie_unused_qwen_lm_head(model: nn.Module) -> None:
 
 
 GR00T_N1_7_DEFAULTS: dict[str, Any] = {
-    "model_dtype": "bfloat16",
     "dtype": "bfloat16",
     "model_name": "nvidia/Cosmos-Reason2-2B",
     "backbone_model_type": "qwen",
@@ -86,8 +85,6 @@ GR00T_N1_7_DEFAULTS: dict[str, Any] = {
     "select_layer": 16,
     "reproject_vision": False,
     "use_flash_attention": False,
-    "load_bf16": False,
-    "backbone_trainable_params_fp32": True,
     "image_crop_size": N1_7_DEFAULT_IMAGE_CROP_SIZE,
     "image_target_size": N1_7_DEFAULT_IMAGE_TARGET_SIZE,
     "shortest_image_edge": None,
@@ -261,9 +258,7 @@ class Qwen3Backbone(nn.Module):
         select_layer: int = -1,
         reproject_vision: bool = False,
         use_flash_attention: bool = False,
-        load_bf16: bool = False,
         tune_top_llm_layers: int = 0,
-        trainable_params_fp32: bool = False,
         transformers_loading_kwargs: dict[str, Any] | None = None,
         load_pretrained_weights: bool = True,
     ):
@@ -285,8 +280,7 @@ class Qwen3Backbone(nn.Module):
             except ImportError:
                 logger.warning("flash_attn is not installed. Falling back to SDPA attention.")
                 extra_kwargs["attn_implementation"] = "sdpa"
-        if load_bf16:
-            extra_kwargs["torch_dtype"] = torch.bfloat16
+        extra_kwargs["dtype"] = torch.float32
 
         if load_pretrained_weights:
             self.model = Qwen3VLForConditionalGeneration.from_pretrained(
@@ -307,10 +301,6 @@ class Qwen3Backbone(nn.Module):
 
         self.select_layer = select_layer
         self.set_trainable_parameters(tune_llm, tune_visual, tune_top_llm_layers)
-        if load_bf16 and trainable_params_fp32:
-            for parameter in self.parameters():
-                if parameter.requires_grad:
-                    parameter.data = parameter.data.to(torch.float32)
 
     def set_trainable_parameters(
         self, tune_llm: bool, tune_visual: bool, tune_top_llm_layers: int = 0
@@ -840,9 +830,7 @@ class GR00TN17(PreTrainedModel):
             select_layer=config.select_layer,
             reproject_vision=config.reproject_vision,
             use_flash_attention=config.use_flash_attention,
-            load_bf16=config.load_bf16,
             tune_top_llm_layers=config.tune_top_llm_layers,
-            trainable_params_fp32=config.backbone_trainable_params_fp32,
             transformers_loading_kwargs=transformers_loading_kwargs,
             load_pretrained_weights=load_backbone_weights,
         )

--- a/src/lerobot/policies/groot/modeling_groot.py
+++ b/src/lerobot/policies/groot/modeling_groot.py
@@ -37,6 +37,7 @@ from torch import Tensor
 
 from lerobot.configs import FeatureType, PolicyFeature
 from lerobot.utils.constants import ACTION, OBS_IMAGES
+from lerobot.utils.dtype import get_dtype
 from lerobot.utils.import_utils import _transformers_available, require_package
 
 from ..pretrained import PreTrainedPolicy
@@ -68,6 +69,12 @@ class GrootPolicy(PreTrainedPolicy):
     name = "groot"
     config_class = GrootConfig
 
+    _fp32_modules = (
+        "_groot_model.action_head",
+        "_groot_model.backbone.model.model.language_model.rotary_emb",
+        "_groot_model.backbone.model.model.visual.rotary_pos_emb",
+    )
+
     def supports_rtc(self) -> bool:
         return True
 
@@ -83,6 +90,7 @@ class GrootPolicy(PreTrainedPolicy):
         self._action_queue_steps = self._resolve_action_queue_steps()
         self._warned_native_relative_rtc_prefix_disabled = False
 
+        self.post_init()
         self.reset()
 
     def _create_groot_model(self):
@@ -108,20 +116,13 @@ class GrootPolicy(PreTrainedPolicy):
             **model_kwargs,
             tune_vlln=self.config.tune_vlln,
             transformers_loading_kwargs={"trust_remote_code": True},
+            dtype=torch.float32,
         )
         backbone = getattr(model, "backbone", None)
         qwen_model = getattr(backbone, "model", None)
         if qwen_model is not None:
             _tie_unused_qwen_lm_head(qwen_model)
-        if self.config.model_params_fp32:
-            self._cast_model_parameters_to_fp32(model)
         return model
-
-    @staticmethod
-    def _cast_model_parameters_to_fp32(model: torch.nn.Module) -> None:
-        for parameter in model.parameters():
-            if parameter.is_floating_point():
-                parameter.data = parameter.data.to(torch.float32)
 
     @staticmethod
     def _build_weight_decay_parameter_groups(model: torch.nn.Module) -> list[dict[str, object]]:
@@ -158,6 +159,7 @@ class GrootPolicy(PreTrainedPolicy):
         pretrained_name_or_path: str | Path,
         *,
         config: GrootConfig | None = None,
+        dtype: str | torch.dtype | None = None,
         force_download: bool = False,
         resume_download: bool | None = None,
         proxies: dict | None = None,
@@ -229,6 +231,7 @@ class GrootPolicy(PreTrainedPolicy):
             return super().from_pretrained(
                 pretrained_name_or_path=pretrained_name_or_path,
                 config=config,
+                dtype=dtype,
                 force_download=force_download,
                 resume_download=resume_download,
                 proxies=proxies,
@@ -279,6 +282,8 @@ class GrootPolicy(PreTrainedPolicy):
             raise ValueError(message)
         # Create a fresh policy instance - this will automatically load the GR00T model
         # in __init__ via _create_groot_model()
+        if dtype is not None and dtype != "auto":
+            config.dtype = str(get_dtype(dtype)).removeprefix("torch.")
         policy = cls(config)
 
         policy.eval()

--- a/src/lerobot/policies/lingbot_va/modeling_lingbot_va.py
+++ b/src/lerobot/policies/lingbot_va/modeling_lingbot_va.py
@@ -48,7 +48,6 @@ from .utils import (
     WanTransformer3DModel,
     WanVAEStreamingWrapper,
     _sample_timestep_id,
-    _torch_dtype,
     clean_prompt,
     data_seq_to_patch,
     denormalize_latents,
@@ -72,8 +71,6 @@ class LingBotVAPolicy(PreTrainedPolicy):
         config.validate_features()
         self.config = config
 
-        self.dtype = _torch_dtype(config.dtype)
-
         # Trainable dual-stream transformer (the only sub-module saved in the LeRobot checkpoint).
         self.transformer = WanTransformer3DModel(
             patch_size=tuple(config.patch_size),
@@ -91,8 +88,6 @@ class LingBotVAPolicy(PreTrainedPolicy):
             rope_max_seq_len=config.rope_max_seq_len,
             attn_mode=config.attn_mode,
         )
-        # Run the transformer in config.dtype (bf16); norm/modulation paths upcast to fp32 internally.
-        self.transformer = self.transformer.to(self.dtype)
 
         # Frozen modules are stored OUTSIDE the nn.Module registry (plain dict) so they are
         # neither saved into model.safetensors nor moved by ``.to()``. They are lazily loaded
@@ -101,6 +96,7 @@ class LingBotVAPolicy(PreTrainedPolicy):
 
         self.last_predicted_frames: Tensor | None = None
         self.last_predicted_latents: Tensor | None = None
+        self.post_init()
         self.reset()
 
     # Frozen-module lazy loading (VAE + UMT5 + tokenizer)
@@ -114,12 +110,12 @@ class LingBotVAPolicy(PreTrainedPolicy):
         # sub-folders -- both in the released diffusers-style HF repos and in the local
         # ``--bundle-frozen`` output dir. ``from_pretrained(path, subfolder=...)`` resolves
         # them for either a HF repo id or a local directory.
-        vae = load_vae(path, torch_dtype=self.dtype, torch_device=device, subfolder="vae")
+        vae = load_vae(path, dtype=self.dtype, torch_device=device, subfolder="vae")
         # The UMT5-XXL text encoder (~11 GB) runs once per episode; keep it on its own
         # (CPU by default) device so the 5B transformer + VAE fit on a single GPU.
         text_encoder = load_text_encoder(
             path,
-            torch_dtype=self.dtype,
+            dtype=self.dtype,
             torch_device=self.config.text_encoder_device,
             subfolder="text_encoder",
         )
@@ -133,7 +129,7 @@ class LingBotVAPolicy(PreTrainedPolicy):
         # RoboTwin's T-shape layout encodes the half-resolution wrist cameras through a second
         # streaming VAE (separate causal cache) alongside the full-res head camera.
         if self.config.camera_layout == "robotwin_tshape":
-            vae_half = load_vae(path, torch_dtype=self.dtype, torch_device=device, subfolder="vae")
+            vae_half = load_vae(path, dtype=self.dtype, torch_device=device, subfolder="vae")
             self._frozen["streaming_vae_half"] = WanVAEStreamingWrapper(vae_half.eval())
 
     @property

--- a/src/lerobot/policies/lingbot_va/utils.py
+++ b/src/lerobot/policies/lingbot_va/utils.py
@@ -139,15 +139,13 @@ def denormalize_latents(latents: torch.Tensor, latents_mean, latents_std, z_dim)
     return latents / inv_std + mean
 
 
-def load_vae(vae_path, torch_dtype, torch_device, subfolder=None):
-    vae = AutoencoderKLWan.from_pretrained(vae_path, subfolder=subfolder, torch_dtype=torch_dtype)
+def load_vae(vae_path, dtype, torch_device, subfolder=None):
+    vae = AutoencoderKLWan.from_pretrained(vae_path, subfolder=subfolder, torch_dtype=dtype)
     return vae.to(torch_device)
 
 
-def load_text_encoder(text_encoder_path, torch_dtype, torch_device, subfolder=None):
-    text_encoder = UMT5EncoderModel.from_pretrained(
-        text_encoder_path, subfolder=subfolder, torch_dtype=torch_dtype
-    )
+def load_text_encoder(text_encoder_path, dtype, torch_device, subfolder=None):
+    text_encoder = UMT5EncoderModel.from_pretrained(text_encoder_path, subfolder=subfolder, dtype=dtype)
     return text_encoder.to(torch_device)
 
 
@@ -164,10 +162,6 @@ def clean_prompt(text: str) -> str:
     """
     text = html.unescape(html.unescape(text)).strip()
     return re.sub(r"\s+", " ", text).strip()
-
-
-def _torch_dtype(name: str) -> torch.dtype:
-    return {"bfloat16": torch.bfloat16, "float16": torch.float16, "float32": torch.float32}[name]
 
 
 def _sample_timestep_id(

--- a/src/lerobot/policies/molmoact2/configuration_molmoact2.py
+++ b/src/lerobot/policies/molmoact2/configuration_molmoact2.py
@@ -435,8 +435,6 @@ class MolmoAct2Config(PreTrainedConfig):
             )
         if self.expected_max_action_dim != 32:
             raise ValueError("MolmoAct2 released checkpoints use expected_max_action_dim=32.")
-        if self.dtype not in {"float32", "bfloat16"}:
-            raise ValueError(f"Unsupported dtype={self.dtype!r}. Expected 'float32' or 'bfloat16'.")
         if not 0 <= self.llm_residual_dropout <= 1:
             raise ValueError(f"llm_residual_dropout must be in [0, 1], got {self.llm_residual_dropout}.")
         if self.lora_rank < 1:

--- a/src/lerobot/policies/molmoact2/modeling_molmoact2.py
+++ b/src/lerobot/policies/molmoact2/modeling_molmoact2.py
@@ -69,15 +69,6 @@ else:
 logger = logging.getLogger(__name__)
 
 
-def _torch_dtype(dtype: str) -> torch.dtype:
-    """Convert a dtype name string to a torch.dtype."""
-    if dtype == "float32":
-        return torch.float32
-    if dtype == "bfloat16":
-        return torch.bfloat16
-    raise ValueError(f"Unsupported dtype: {dtype}")
-
-
 def _call_module_without_gradient_checkpointing_layer(
     module: torch.nn.Module,
     *args: Any,
@@ -622,6 +613,20 @@ class MolmoAct2Policy(PreTrainedPolicy):
     config_class = MolmoAct2Config
     name = "molmoact2"
 
+    _fp32_modules = (
+        "model.model.action_expert",
+        "model.model.action_expert_depth_gate",
+        "model.model.transformer.blocks.*.attn_norm",
+        "model.model.transformer.blocks.*.ff_norm",
+        "model.model.transformer.blocks.*.self_attn.q_norm",
+        "model.model.transformer.blocks.*.self_attn.k_norm",
+        "model.model.transformer.ln_f",
+        "model.model.transformer.rotary_emb",
+        "model.model.transformer.rotary_embs.*",
+        "model.model.vision_backbone.image_vit.transformer.resblocks.*.attention_norm",
+        "model.model.vision_backbone.image_vit.transformer.resblocks.*.ffn_norm",
+    )
+
     @classmethod
     def from_pretrained(
         cls,
@@ -663,6 +668,8 @@ class MolmoAct2Policy(PreTrainedPolicy):
         self._compiled_module_names: tuple[str, ...] = ()
         self._load_hf_model()
         _validate_inference_action_mode(self.config, self._checkpoint_action_mode)
+        # Finalize the base model before PEFT creates its FP32 adapters, as in the native loader.
+        self.post_init()
         if self.config.train_mode_vlm == "lora":
             self._apply_lora_adapters()
         self._apply_compile()
@@ -676,7 +683,6 @@ class MolmoAct2Policy(PreTrainedPolicy):
             revision=self.config.checkpoint_revision,
             force_download=bool(self.config.checkpoint_force_download),
         )
-        storage_dtype = _torch_dtype(self.config.dtype)
         if HFMolmoAct2Config is None or MolmoAct2ForConditionalGeneration is None:
             raise RuntimeError("transformers is required to load MolmoAct2 checkpoints.")
         hf_config = HFMolmoAct2Config.from_pretrained(
@@ -689,17 +695,12 @@ class MolmoAct2Policy(PreTrainedPolicy):
         self.model = MolmoAct2ForConditionalGeneration.from_pretrained(
             checkpoint_location,
             config=hf_config,
-            dtype=storage_dtype,
+            dtype=torch.float32,
             low_cpu_mem_usage=True,
             token=_hf_token(),
         )
         # Keep Hub loading limited to local code plus safetensors, and verify the
         # local implementation exactly matches the checkpoint key space.
-        self._apply_bfloat16_parameter_policy()
-        # In bfloat16 mode, establish the final target dtype tree before this last
-        # strict load. This preserves the checkpoint's original fp32 values for
-        # the action expert and other fp32-targeted modules instead of widening
-        # already-rounded bf16 tensors.
         _strict_load_safetensors_weights(self.model, checkpoint_location)
         hf_max_action_dim = int(getattr(self.model.config, "max_action_dim", -1))
         if hf_max_action_dim != int(self.config.expected_max_action_dim):
@@ -854,48 +855,6 @@ class MolmoAct2Policy(PreTrainedPolicy):
                 for param in embeddings.parameters():
                     param.requires_grad = False
 
-    def _apply_bfloat16_parameter_policy(self) -> None:
-        """Apply the fixed low-memory MolmoAct2 parameter-storage policy.
-
-        Large text and vision matrices stay in bf16. The complete action
-        expert, norms, RoPE state, depth gates, and LoRA adapters use fp32
-        parameters and therefore fp32 Adam state when trainable. Eligible
-        action-expert operators still execute in bf16 under autocast.
-        """
-        if self.config.dtype != "bfloat16":
-            return
-
-        self.model.to(dtype=torch.bfloat16)
-        backbone = self._backbone()
-
-        action_expert = getattr(backbone, "action_expert", None)
-        if action_expert is not None:
-            action_expert.to(dtype=torch.float32)
-
-        depth_gate = getattr(backbone, "action_expert_depth_gate", None)
-        if depth_gate is not None:
-            depth_gate.to(dtype=torch.float32)
-
-        fp32_module_types = tuple(
-            module_type
-            for module_type in (
-                torch.nn.LayerNorm,
-                ActionExpertRMSNorm,
-                MolmoAct2RMSNorm,
-            )
-            if isinstance(module_type, type)
-        )
-        for module in self.model.modules():
-            if isinstance(module, fp32_module_types):
-                module.to(dtype=torch.float32)
-            if isinstance(MolmoAct2RotaryEmbedding, type) and isinstance(module, MolmoAct2RotaryEmbedding):
-                module.to(dtype=torch.float32)
-                # ``original_inv_freq`` is an alias rather than a registered
-                # buffer, so Module.to() does not update it automatically.
-                module.original_inv_freq = module.inv_freq
-                module._pos_sin_cache = torch.empty(0, device=module.inv_freq.device, dtype=torch.float32)
-                module._pos_cos_cache = torch.empty(0, device=module.inv_freq.device, dtype=torch.float32)
-
     def get_optim_params(self) -> list[dict[str, Any]]:
         """Return optimizer param groups with per-component learning rates."""
         vit_params: list[Tensor] = []
@@ -949,13 +908,13 @@ class MolmoAct2Policy(PreTrainedPolicy):
         }
 
     def _autocast_context(self):
-        compute_dtype = _torch_dtype(self.config.dtype)
+        compute_dtype = self.dtype
         device_type = next(self.parameters()).device.type
         autocast_available = torch.amp.autocast_mode.is_autocast_available(device_type)
-        if compute_dtype == torch.bfloat16:
+        if compute_dtype in (torch.float16, torch.bfloat16):
             if not autocast_available:
                 raise RuntimeError(
-                    f"MolmoAct2 dtype='bfloat16' requires autocast support on device type {device_type!r}."
+                    f"MolmoAct2 dtype={compute_dtype} requires autocast support on device type {device_type!r}."
                 )
             return torch.autocast(device_type=device_type, dtype=compute_dtype)
         if autocast_available:

--- a/src/lerobot/policies/multi_task_dit/modeling_multi_task_dit.py
+++ b/src/lerobot/policies/multi_task_dit/modeling_multi_task_dit.py
@@ -104,6 +104,7 @@ class MultiTaskDiTPolicy(PreTrainedPolicy):
         else:
             raise ValueError(f"Unsupported objective: {config.objective}")
 
+        self.post_init()
         self.reset()
 
     def get_optim_params(self) -> list:

--- a/src/lerobot/policies/pi0/configuration_pi0.py
+++ b/src/lerobot/policies/pi0/configuration_pi0.py
@@ -28,9 +28,9 @@ DEFAULT_IMAGE_SIZE = 224
 @PreTrainedConfig.register_subclass("pi0")
 @dataclass
 class PI0Config(PreTrainedConfig):
+    dtype: str | None = "float32"
     paligemma_variant: str = "gemma_2b"
     action_expert_variant: str = "gemma_300m"
-    dtype: str = "float32"  # Options: "bfloat16", "float32"
 
     n_obs_steps: int = 1
     chunk_size: int = 50  # Number of action steps to predict, in openpi called "action_horizon"
@@ -117,9 +117,6 @@ class PI0Config(PreTrainedConfig):
 
         if self.action_expert_variant not in ["gemma_300m", "gemma_2b"]:
             raise ValueError(f"Invalid action_expert_variant: {self.action_expert_variant}")
-
-        if self.dtype not in ["bfloat16", "float32"]:
-            raise ValueError(f"Invalid dtype: {self.dtype}")
 
     def validate_features(self) -> None:
         """Validate and set up input/output features."""

--- a/src/lerobot/policies/pi0/modeling_pi0.py
+++ b/src/lerobot/policies/pi0/modeling_pi0.py
@@ -14,14 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import builtins
 import logging
 from collections import deque
-from pathlib import Path
-from typing import TYPE_CHECKING, Literal, TypedDict, Unpack
+from typing import TYPE_CHECKING, TypedDict, Unpack
 
 import torch
 import torch.nn.functional as F  # noqa: N812
+from safetensors.torch import load_file
 from torch import Tensor, nn
 
 from lerobot.utils.import_utils import _transformers_available, require_package
@@ -46,13 +45,14 @@ else:
     PaliGemmaForConditionalGenerationWithPiGemma = None
 
 
-from lerobot.configs import PreTrainedConfig
+from lerobot.policies.utils import log_model_loading_keys
 from lerobot.utils.constants import (
     ACTION,
     OBS_LANGUAGE_ATTENTION_MASK,
     OBS_LANGUAGE_TOKENS,
     OBS_STATE,
 )
+from lerobot.utils.device_utils import resolve_safetensors_device
 
 from ..common.flow_matching import euler_integrate, sample_noise, sample_time_beta
 from ..common.vla_utils import (
@@ -63,7 +63,7 @@ from ..common.vla_utils import (
     prepare_attention_masks_4d,
     resize_with_pad_torch,
 )
-from ..pretrained import PreTrainedPolicy, T
+from ..pretrained import PreTrainedPolicy
 from ..rtc.modeling_rtc import RTCProcessor
 from .configuration_pi0 import DEFAULT_IMAGE_SIZE, PI0Config
 
@@ -135,9 +135,7 @@ def compute_layer_complete(inputs_embeds, attention_mask, position_ids, adarms_c
         out_emb = _gated_residual(hidden_states, out_emb, gates[i])
         after_first_residual = out_emb.clone()
         out_emb, gate = layernorm_forward(layer.post_attention_layernorm, out_emb, adarms_cond[i])
-        # Convert to bfloat16 if the next layer (mlp) uses bfloat16
-        if layer.mlp.up_proj.weight.dtype == torch.bfloat16:
-            out_emb = out_emb.to(dtype=torch.bfloat16)
+        out_emb = out_emb.to(dtype=layer.mlp.up_proj.weight.dtype)
         out_emb = layer.mlp(out_emb)
         # second residual
         out_emb = _gated_residual(after_first_residual, out_emb, gate)
@@ -192,7 +190,6 @@ class PaliGemmaWithExpertModel(
         vlm_config,
         action_expert_config,
         use_adarms=None,
-        precision: Literal["bfloat16", "float32"] = "bfloat16",
         image_size: int = DEFAULT_IMAGE_SIZE,
         freeze_vision_encoder: bool = False,
         train_expert_only: bool = False,
@@ -241,31 +238,7 @@ class PaliGemmaWithExpertModel(
         self.gemma_expert = PiGemmaForCausalLM(config=action_expert_config_hf)
         self.gemma_expert.model.embed_tokens = None
 
-        self.to_bfloat16_for_selected_params(precision)
         self._set_requires_grad()
-
-    def to_bfloat16_for_selected_params(self, precision: Literal["bfloat16", "float32"] = "bfloat16"):
-        if precision == "bfloat16":
-            self.to(dtype=torch.bfloat16)
-        elif precision == "float32":
-            self.to(dtype=torch.float32)
-            return
-        else:
-            raise ValueError(f"Invalid precision: {precision}")
-
-        # Keep full vision path in float32 so we never toggle (toggle causes optimizer
-        # "same dtype" error). Align with PI05.
-        params_to_keep_float32 = [
-            "vision_tower",
-            "multi_modal_projector",
-            "input_layernorm",
-            "post_attention_layernorm",
-            "model.norm",
-        ]
-
-        for name, param in self.named_parameters():
-            if any(selector in name for selector in params_to_keep_float32):
-                param.data = param.data.to(dtype=torch.float32)
 
     def _set_requires_grad(self):
         if self.freeze_vision_encoder:
@@ -285,7 +258,7 @@ class PaliGemmaWithExpertModel(
             self.paligemma.eval()
 
     def embed_image(self, image: torch.Tensor):
-        # Vision tower and multi_modal_projector are kept in float32 (params_to_keep_float32). Align with PI05.
+        # Vision tower and multi_modal_projector are kept in float32 (declared by the policy). Align with PI05.
         out_dtype = image.dtype
         if image.dtype != torch.float32:
             image = image.to(torch.float32)
@@ -421,7 +394,6 @@ class PI0Pytorch(nn.Module):  # see openpi `PI0Pytorch`
             paligemma_config,
             action_expert_config,
             use_adarms=[False, False],
-            precision=config.dtype,
             image_size=config.image_resolution[0],
             freeze_vision_encoder=config.freeze_vision_encoder,
             train_expert_only=config.train_expert_only,
@@ -437,12 +409,13 @@ class PI0Pytorch(nn.Module):  # see openpi `PI0Pytorch`
         # Initialize gradient checkpointing flag
         self.gradient_checkpointing_enabled = False
 
+    def _compile_model(self):
         # Compile model if requested
-        if config.compile_model:
+        if self.config.compile_model:
             torch.set_float32_matmul_precision("high")
-            self.sample_actions = torch.compile(self.sample_actions, mode=config.compile_mode)
+            self.sample_actions = torch.compile(self.sample_actions, mode=self.config.compile_mode)
             # Also compile the main forward pass used during training
-            self.forward = torch.compile(self.forward, mode=config.compile_mode)
+            self.forward = torch.compile(self.forward, mode=self.config.compile_mode)
 
     def gradient_checkpointing_enable(self):
         """Enable gradient checkpointing for memory optimization."""
@@ -600,12 +573,11 @@ class PI0Pytorch(nn.Module):  # see openpi `PI0Pytorch`
         )
         suffix_embs, suffix_pad_masks, suffix_att_masks, adarms_cond = self.embed_suffix(state, x_t, time)
 
-        if (
-            self.paligemma_with_expert.paligemma.model.language_model.layers[0].self_attn.q_proj.weight.dtype
-            == torch.bfloat16
-        ):
-            suffix_embs = suffix_embs.to(dtype=torch.bfloat16)
-            prefix_embs = prefix_embs.to(dtype=torch.bfloat16)
+        dtype = self.paligemma_with_expert.paligemma.model.language_model.layers[
+            0
+        ].self_attn.q_proj.weight.dtype
+        suffix_embs = suffix_embs.to(dtype=dtype)
+        prefix_embs = prefix_embs.to(dtype=dtype)
 
         pad_masks = torch.cat([prefix_pad_masks, suffix_pad_masks], dim=1)
         att_masks = torch.cat([prefix_att_masks, suffix_att_masks], dim=1)
@@ -749,6 +721,22 @@ class PI0Policy(PreTrainedPolicy):
     config_class = PI0Config
     name = "pi0"
 
+    _fp32_modules = (
+        "model.paligemma_with_expert.paligemma.model.vision_tower",
+        "model.paligemma_with_expert.paligemma.model.multi_modal_projector",
+        "model.paligemma_with_expert.paligemma.model.language_model.layers.*.input_layernorm",
+        "model.paligemma_with_expert.paligemma.model.language_model.layers.*.post_attention_layernorm",
+        "model.paligemma_with_expert.paligemma.model.language_model.norm",
+        "model.paligemma_with_expert.gemma_expert.model.layers.*.input_layernorm",
+        "model.paligemma_with_expert.gemma_expert.model.layers.*.post_attention_layernorm",
+        "model.paligemma_with_expert.gemma_expert.model.norm",
+        "model.action_in_proj",
+        "model.action_out_proj",
+        "model.state_proj",
+        "model.action_time_mlp_in",
+        "model.action_time_mlp_out",
+    )
+
     def supports_rtc(self) -> bool:
         return True
 
@@ -774,126 +762,24 @@ class PI0Policy(PreTrainedPolicy):
         if config.gradient_checkpointing:
             self.model.gradient_checkpointing_enable()
 
+        self.post_init()
         self.model.to(config.device)
-
+        if config.compile_model:
+            self.model._compile_model()
         self.reset()
 
     @classmethod
-    def from_pretrained(
-        cls: builtins.type[T],
-        pretrained_name_or_path: str | Path,
-        *,
-        config: PreTrainedConfig | None = None,
-        force_download: bool = False,
-        resume_download: bool | None = None,
-        proxies: dict | None = None,
-        token: str | bool | None = None,
-        cache_dir: str | Path | None = None,
-        local_files_only: bool = False,
-        revision: str | None = None,
-        strict: bool = True,
-        **kwargs,
-    ) -> T:
-        """Override the from_pretrained method to handle key remapping and display important disclaimer."""
-        print(
-            "The PI0 model is a direct port of the OpenPI implementation. \n"
-            "This implementation follows the original OpenPI structure for compatibility. \n"
-            "Original implementation: https://github.com/Physical-Intelligence/openpi"
-        )
-        if pretrained_name_or_path is None:
-            raise ValueError("pretrained_name_or_path is required")
+    def from_pretrained(cls, pretrained_name_or_path, *, strict: bool = True, **kwargs):
+        return super().from_pretrained(pretrained_name_or_path, strict=strict, **kwargs)
 
-        # Use provided config if available, otherwise create default config
-        if config is None:
-            config = PreTrainedConfig.from_pretrained(
-                pretrained_name_or_path=pretrained_name_or_path,
-                force_download=force_download,
-                resume_download=resume_download,
-                proxies=proxies,
-                token=token,
-                cache_dir=cache_dir,
-                local_files_only=local_files_only,
-                revision=revision,
-                **kwargs,
-            )
-
-        # Initialize model without loading weights
-        # Check if dataset_stats were provided in kwargs
-        model = cls(config, **kwargs)
-
-        # Load state dict (expects keys with "model." prefix)
-        try:
-            print(f"Loading model from: {pretrained_name_or_path}")
-            try:
-                from transformers.utils import cached_file
-
-                resolved_file = cached_file(
-                    pretrained_name_or_path,
-                    "model.safetensors",
-                    cache_dir=kwargs.get("cache_dir"),
-                    force_download=kwargs.get("force_download", False),
-                    resume_download=kwargs.get("resume_download"),
-                    proxies=kwargs.get("proxies"),
-                    token=kwargs.get("token"),
-                    revision=kwargs.get("revision"),
-                    local_files_only=kwargs.get("local_files_only", False),
-                )
-                from safetensors.torch import load_file
-
-                original_state_dict = load_file(resolved_file)
-                print("✓ Loaded state dict from model.safetensors")
-            except Exception as e:
-                print(f"Could not load state dict from remote files: {e}")
-                print("Returning model without loading pretrained weights")
-                return model
-
-            # First, fix any key differences (see openpi model.py, _fix_pytorch_state_dict_keys)
-            fixed_state_dict = model._fix_pytorch_state_dict_keys(original_state_dict, model.config)
-
-            # Then add "model." prefix for all keys that don't already have it
-            remapped_state_dict = {}
-            remap_count = 0
-
-            for key, value in fixed_state_dict.items():
-                if not key.startswith("model."):
-                    new_key = f"model.{key}"
-                    remapped_state_dict[new_key] = value
-                    remap_count += 1
-                else:
-                    remapped_state_dict[key] = value
-
-            if remap_count > 0:
-                print(f"Remapped {remap_count} state dict keys")
-
-            # Load the remapped state dict into the model
-            missing_keys, unexpected_keys = model.load_state_dict(remapped_state_dict, strict=strict)
-
-            if missing_keys:
-                print(f"Missing keys when loading state dict: {len(missing_keys)} keys")
-                if len(missing_keys) <= 5:
-                    for key in missing_keys:
-                        print(f"  - {key}")
-                else:
-                    for key in missing_keys[:5]:
-                        print(f"  - {key}")
-                    print(f"  ... and {len(missing_keys) - 5} more")
-
-            if unexpected_keys:
-                print(f"Unexpected keys when loading state dict: {len(unexpected_keys)} keys")
-                if len(unexpected_keys) <= 5:
-                    for key in unexpected_keys:
-                        print(f"  - {key}")
-                else:
-                    for key in unexpected_keys[:5]:
-                        print(f"  - {key}")
-                    print(f"  ... and {len(unexpected_keys) - 5} more")
-
-            if not missing_keys and not unexpected_keys:
-                print("All keys loaded successfully!")
-
-        except Exception as e:
-            print(f"Warning: Could not load state dict: {e}")
-
+    @classmethod
+    def _load_as_safetensor(cls, model, model_file: str, map_location: str, strict: bool):
+        state_dict = load_file(model_file, device=resolve_safetensors_device(map_location))
+        state_dict = model._fix_pytorch_state_dict_keys(state_dict, model.config)
+        state_dict = {
+            key if key.startswith("model.") else f"model.{key}": value for key, value in state_dict.items()
+        }
+        log_model_loading_keys(*model.load_state_dict(state_dict, strict=strict))
         return model
 
     def _fix_pytorch_state_dict_keys(

--- a/src/lerobot/policies/pi05/configuration_pi05.py
+++ b/src/lerobot/policies/pi05/configuration_pi05.py
@@ -28,9 +28,9 @@ DEFAULT_IMAGE_SIZE = 224
 @PreTrainedConfig.register_subclass("pi05")
 @dataclass
 class PI05Config(PreTrainedConfig):
+    dtype: str | None = "float32"
     paligemma_variant: str = "gemma_2b"
     action_expert_variant: str = "gemma_300m"
-    dtype: str = "float32"  # Options: "bfloat16", "float32"
 
     n_obs_steps: int = 1
     chunk_size: int = 50  # Number of action steps to predict, in openpi called "action_horizon"
@@ -138,9 +138,6 @@ class PI05Config(PreTrainedConfig):
 
         if self.action_expert_variant not in ["gemma_300m", "gemma_2b"]:
             raise ValueError(f"Invalid action_expert_variant: {self.action_expert_variant}")
-
-        if self.dtype not in ["bfloat16", "float32"]:
-            raise ValueError(f"Invalid dtype: {self.dtype}")
 
         if self.memory_frames < 1:
             raise ValueError("memory_frames must be at least 1")

--- a/src/lerobot/policies/pi05/modeling_pi05.py
+++ b/src/lerobot/policies/pi05/modeling_pi05.py
@@ -14,14 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import builtins
 import logging
 from collections import deque
-from pathlib import Path
-from typing import TYPE_CHECKING, Literal, TypedDict, Unpack
+from typing import TYPE_CHECKING, TypedDict, Unpack
 
 import torch
 import torch.nn.functional as F  # noqa: N812
+from safetensors.torch import load_file
 from torch import Tensor, nn
 
 from lerobot.utils.import_utils import _transformers_available, require_package
@@ -44,13 +43,14 @@ else:
     _gated_residual = None
     layernorm_forward = None
     PaliGemmaForConditionalGenerationWithPiGemma = None
-from lerobot.configs import PreTrainedConfig
+from lerobot.policies.utils import log_model_loading_keys
 from lerobot.utils.constants import (
     ACTION,
     OBS_LANGUAGE_ATTENTION_MASK,
     OBS_LANGUAGE_TOKENS,
     OBS_STATE,
 )
+from lerobot.utils.device_utils import resolve_safetensors_device
 
 from ..common.flow_matching import euler_integrate, sample_noise, sample_time_beta
 from ..common.vla_utils import (
@@ -61,7 +61,7 @@ from ..common.vla_utils import (
     prepare_attention_masks_4d,
     resize_with_pad_torch,
 )
-from ..pretrained import PreTrainedPolicy, T
+from ..pretrained import PreTrainedPolicy
 from ..rtc.modeling_rtc import RTCProcessor
 from .configuration_pi05 import DEFAULT_IMAGE_SIZE, PI05Config
 from .memory import encode_video_with_mem, sample_observation_history
@@ -235,9 +235,7 @@ def compute_layer_complete(inputs_embeds, attention_mask, position_ids, adarms_c
         out_emb = _gated_residual(hidden_states, out_emb, gates[i])
         after_first_residual = out_emb.clone()
         out_emb, gate = layernorm_forward(layer.post_attention_layernorm, out_emb, adarms_cond[i])
-        # Convert to bfloat16 if the next layer (mlp) uses bfloat16
-        if layer.mlp.up_proj.weight.dtype == torch.bfloat16:
-            out_emb = out_emb.to(dtype=torch.bfloat16)
+        out_emb = out_emb.to(dtype=layer.mlp.up_proj.weight.dtype)
         out_emb = layer.mlp(out_emb)
         # second residual
         out_emb = _gated_residual(after_first_residual, out_emb, gate)
@@ -292,7 +290,6 @@ class PaliGemmaWithExpertModel(
         vlm_config,
         action_expert_config,
         use_adarms=None,
-        precision: Literal["bfloat16", "float32"] = "bfloat16",
         image_size: int = DEFAULT_IMAGE_SIZE,
         freeze_vision_encoder: bool = False,
         train_expert_only: bool = False,
@@ -341,31 +338,7 @@ class PaliGemmaWithExpertModel(
         self.gemma_expert = PiGemmaForCausalLM(config=action_expert_config_hf)
         self.gemma_expert.model.embed_tokens = None
 
-        self.to_bfloat16_for_selected_params(precision)
         self._set_requires_grad()
-
-    def to_bfloat16_for_selected_params(self, precision: Literal["bfloat16", "float32"] = "bfloat16"):
-        if precision == "bfloat16":
-            self.to(dtype=torch.bfloat16)
-        elif precision == "float32":
-            self.to(dtype=torch.float32)
-            return
-        else:
-            raise ValueError(f"Invalid precision: {precision}")
-
-        # Keep full vision path in float32 so we never toggle (toggle causes optimizer
-        # "same dtype" error). Saves memory vs full float32; more memory than only 3 params.
-        params_to_keep_float32 = [
-            "vision_tower",
-            "multi_modal_projector",
-            "input_layernorm",
-            "post_attention_layernorm",
-            "model.norm",
-        ]
-
-        for name, param in self.named_parameters():
-            if any(selector in name for selector in params_to_keep_float32):
-                param.data = param.data.to(dtype=torch.float32)
 
     def _set_requires_grad(self):
         if self.freeze_vision_encoder:
@@ -391,7 +364,7 @@ class PaliGemmaWithExpertModel(
         frame_mask: torch.Tensor | None = None,
         temporal_attention_every: int = 4,
     ):
-        # Vision tower and multi_modal_projector are kept in float32 (params_to_keep_float32).
+        # Vision tower and multi_modal_projector are kept in float32 (declared by the policy).
         out_dtype = image.dtype
         if image.dtype != torch.float32:
             image = image.to(torch.float32)
@@ -539,7 +512,6 @@ class PI05Pytorch(nn.Module):  # see openpi `PI0Pytorch`
             paligemma_config,
             action_expert_config,
             use_adarms=[False, True],
-            precision=config.dtype,
             image_size=config.image_resolution[0],
             freeze_vision_encoder=config.freeze_vision_encoder,
             train_expert_only=config.train_expert_only,
@@ -559,12 +531,13 @@ class PI05Pytorch(nn.Module):  # see openpi `PI0Pytorch`
         # Initialize gradient checkpointing flag
         self.gradient_checkpointing_enabled = False
 
+    def _compile_model(self):
         # Compile model if requested
-        if config.compile_model:
+        if self.config.compile_model:
             torch.set_float32_matmul_precision("high")
-            self.sample_actions = torch.compile(self.sample_actions, mode=config.compile_mode)
+            self.sample_actions = torch.compile(self.sample_actions, mode=self.config.compile_mode)
             # Also compile the main forward pass used during training
-            self.forward = torch.compile(self.forward, mode=config.compile_mode)
+            self.forward = torch.compile(self.forward, mode=self.config.compile_mode)
 
     def gradient_checkpointing_enable(self):
         """Enable gradient checkpointing for memory optimization."""
@@ -725,12 +698,11 @@ class PI05Pytorch(nn.Module):  # see openpi `PI0Pytorch`
         )
         suffix_embs, suffix_pad_masks, suffix_att_masks, adarms_cond = self.embed_suffix(x_t, model_time)
 
-        if (
-            self.paligemma_with_expert.paligemma.model.language_model.layers[0].self_attn.q_proj.weight.dtype
-            == torch.bfloat16
-        ):
-            suffix_embs = suffix_embs.to(dtype=torch.bfloat16)
-            prefix_embs = prefix_embs.to(dtype=torch.bfloat16)
+        dtype = self.paligemma_with_expert.paligemma.model.language_model.layers[
+            0
+        ].self_attn.q_proj.weight.dtype
+        suffix_embs = suffix_embs.to(dtype=dtype)
+        prefix_embs = prefix_embs.to(dtype=dtype)
 
         pad_masks = torch.cat([prefix_pad_masks, suffix_pad_masks], dim=1)
         att_masks = torch.cat([prefix_att_masks, suffix_att_masks], dim=1)
@@ -893,6 +865,22 @@ class PI05Policy(PreTrainedPolicy):
     config_class = PI05Config
     name = "pi05"
 
+    _fp32_modules = (
+        "model.paligemma_with_expert.paligemma.model.vision_tower",
+        "model.paligemma_with_expert.paligemma.model.multi_modal_projector",
+        "model.paligemma_with_expert.paligemma.model.language_model.layers.*.input_layernorm",
+        "model.paligemma_with_expert.paligemma.model.language_model.layers.*.post_attention_layernorm",
+        "model.paligemma_with_expert.paligemma.model.language_model.norm",
+        "model.paligemma_with_expert.gemma_expert.model.layers.*.input_layernorm",
+        "model.paligemma_with_expert.gemma_expert.model.layers.*.post_attention_layernorm",
+        "model.paligemma_with_expert.gemma_expert.model.norm",
+        "model.action_in_proj",
+        "model.action_out_proj",
+        "model.time_mlp_in",
+        "model.time_mlp_out",
+        "model.proprio_history_proj",
+    )
+
     def supports_rtc(self) -> bool:
         return True
 
@@ -918,128 +906,25 @@ class PI05Policy(PreTrainedPolicy):
         if config.gradient_checkpointing:
             self.model.gradient_checkpointing_enable()
 
+        self.post_init()
         self.model.to(config.device)
-
+        if config.compile_model:
+            self.model._compile_model()
         self.reset()
 
     @classmethod
-    def from_pretrained(
-        cls: builtins.type[T],
-        pretrained_name_or_path: str | Path,
-        *,
-        config: PreTrainedConfig | None = None,
-        force_download: bool = False,
-        resume_download: bool | None = None,
-        proxies: dict | None = None,
-        token: str | bool | None = None,
-        cache_dir: str | Path | None = None,
-        local_files_only: bool = False,
-        revision: str | None = None,
-        strict: bool = True,
-        **kwargs,
-    ) -> T:
-        """Override the from_pretrained method to handle key remapping and display important disclaimer."""
-        print(
-            "The PI05 model is a direct port of the OpenPI implementation. \n"
-            "This implementation follows the original OpenPI structure for compatibility. \n"
-            "Original implementation: https://github.com/Physical-Intelligence/openpi"
-        )
-        if pretrained_name_or_path is None:
-            raise ValueError("pretrained_name_or_path is required")
+    def from_pretrained(cls, pretrained_name_or_path, *, strict: bool = True, **kwargs):
+        return super().from_pretrained(pretrained_name_or_path, strict=strict, **kwargs)
 
-        # Use provided config if available, otherwise create default config
-        if config is None:
-            config = PreTrainedConfig.from_pretrained(
-                pretrained_name_or_path=pretrained_name_or_path,
-                force_download=force_download,
-                resume_download=resume_download,
-                proxies=proxies,
-                token=token,
-                cache_dir=cache_dir,
-                local_files_only=local_files_only,
-                revision=revision,
-                **kwargs,
-            )
-
-        # Initialize model without loading weights
-        # Check if dataset_stats were provided in kwargs
-        model = cls(config, **kwargs)
-
-        # Load state dict (expects keys with "model." prefix)
-        try:
-            print(f"Loading model from: {pretrained_name_or_path}")
-            try:
-                from transformers.utils import cached_file
-
-                resolved_file = cached_file(
-                    pretrained_name_or_path,
-                    "model.safetensors",
-                    cache_dir=kwargs.get("cache_dir"),
-                    force_download=kwargs.get("force_download", False),
-                    resume_download=kwargs.get("resume_download"),
-                    proxies=kwargs.get("proxies"),
-                    token=kwargs.get("token"),
-                    revision=kwargs.get("revision"),
-                    local_files_only=kwargs.get("local_files_only", False),
-                )
-                from safetensors.torch import load_file
-
-                original_state_dict = load_file(resolved_file)
-                print("✓ Loaded state dict from model.safetensors")
-            except Exception as e:
-                print(f"Could not load state dict from remote files: {e}")
-                print("Returning model without loading pretrained weights")
-                return model
-
-            # First, fix any key differences (see openpi model.py, _fix_pytorch_state_dict_keys)
-            fixed_state_dict = model._fix_pytorch_state_dict_keys(original_state_dict, model.config)
-
-            # Then add "model." prefix for all keys that don't already have it
-            remapped_state_dict = {}
-            remap_count = 0
-
-            for key, value in fixed_state_dict.items():
-                if not key.startswith("model."):
-                    new_key = f"model.{key}"
-                    remapped_state_dict[new_key] = value
-                    remap_count += 1
-                else:
-                    remapped_state_dict[key] = value
-
-            if remap_count > 0:
-                print(f"Remapped {remap_count} state dict keys")
-
-            remapped_state_dict = model._prepare_pretrained_state_dict(remapped_state_dict)
-
-            # Load the remapped state dict into the model
-            missing_keys, unexpected_keys = model.load_state_dict(remapped_state_dict, strict=strict)
-
-            if missing_keys:
-                print(f"Missing keys when loading state dict: {len(missing_keys)} keys")
-                if len(missing_keys) <= 5:
-                    for key in missing_keys:
-                        print(f"  - {key}")
-                else:
-                    for key in missing_keys[:5]:
-                        print(f"  - {key}")
-                    print(f"  ... and {len(missing_keys) - 5} more")
-
-            if unexpected_keys:
-                print(f"Unexpected keys when loading state dict: {len(unexpected_keys)} keys")
-                if len(unexpected_keys) <= 5:
-                    for key in unexpected_keys:
-                        print(f"  - {key}")
-                else:
-                    for key in unexpected_keys[:5]:
-                        print(f"  - {key}")
-                    print(f"  ... and {len(unexpected_keys) - 5} more")
-
-            if not missing_keys and not unexpected_keys:
-                print("All keys loaded successfully!")
-
-        except Exception as e:
-            print(f"Warning: Could not load state dict: {e}")
-
+    @classmethod
+    def _load_as_safetensor(cls, model, model_file: str, map_location: str, strict: bool):
+        state_dict = load_file(model_file, device=resolve_safetensors_device(map_location))
+        state_dict = model._fix_pytorch_state_dict_keys(state_dict, model.config)
+        state_dict = {
+            key if key.startswith("model.") else f"model.{key}": value for key, value in state_dict.items()
+        }
+        state_dict = model._prepare_pretrained_state_dict(state_dict)
+        log_model_loading_keys(*model.load_state_dict(state_dict, strict=strict))
         return model
 
     def _prepare_pretrained_state_dict(self, state_dict: dict[str, Tensor]) -> dict[str, Tensor]:

--- a/src/lerobot/policies/pi0_fast/configuration_pi0_fast.py
+++ b/src/lerobot/policies/pi0_fast/configuration_pi0_fast.py
@@ -28,9 +28,9 @@ DEFAULT_IMAGE_SIZE = 224
 @PreTrainedConfig.register_subclass("pi0_fast")
 @dataclass
 class PI0FastConfig(PreTrainedConfig):
+    dtype: str | None = "float32"
     paligemma_variant: str = "gemma_2b"
     action_expert_variant: str = "gemma_300m"
-    dtype: str = "float32"  # Options: "bfloat16", "float32"
 
     chunk_size: int = 50  # Number of action steps to predict, in openpi called "action_horizon"
     n_action_steps: int = 50  # Number of action steps to execute
@@ -110,9 +110,6 @@ class PI0FastConfig(PreTrainedConfig):
 
         if self.paligemma_variant not in ["gemma_300m", "gemma_2b"]:
             raise ValueError(f"Invalid paligemma_variant: {self.paligemma_variant}")
-
-        if self.dtype not in ["bfloat16", "float32"]:
-            raise ValueError(f"Invalid dtype: {self.dtype}")
 
     def validate_features(self) -> None:
         """Validate and set up input/output features."""

--- a/src/lerobot/policies/pi0_fast/modeling_pi0_fast.py
+++ b/src/lerobot/policies/pi0_fast/modeling_pi0_fast.py
@@ -14,14 +14,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import builtins
 import logging
 from collections import deque
-from pathlib import Path
-from typing import TYPE_CHECKING, Literal, TypedDict, Unpack
+from typing import TYPE_CHECKING, TypedDict, Unpack
 
 import numpy as np
 import torch
+from safetensors.torch import load_file
 from torch import Tensor, nn
 
 from lerobot.utils.import_utils import _scipy_available, _transformers_available, require_package
@@ -47,7 +46,7 @@ else:
     PiGemmaModel = None
     PaliGemmaForConditionalGenerationWithPiGemma = None
 
-from lerobot.configs import PreTrainedConfig
+from lerobot.policies.utils import log_model_loading_keys
 from lerobot.utils.constants import (
     ACTION,
     ACTION_TOKEN_MASK,
@@ -55,9 +54,10 @@ from lerobot.utils.constants import (
     OBS_LANGUAGE_ATTENTION_MASK,
     OBS_LANGUAGE_TOKENS,
 )
+from lerobot.utils.device_utils import resolve_safetensors_device
 
 from ..common.vla_utils import pad_vector, prepare_attention_masks_4d, resize_with_pad_torch
-from ..pretrained import PreTrainedPolicy, T
+from ..pretrained import PreTrainedPolicy
 from ..rtc.modeling_rtc import RTCProcessor
 from .configuration_pi0_fast import PI0FastConfig
 
@@ -109,7 +109,6 @@ class PI0FastPaliGemma(nn.Module):
         self,
         vlm_config,
         use_adarms=None,
-        precision: Literal["bfloat16", "float32"] = "bfloat16",
     ):
         if use_adarms is None:
             use_adarms = [False, False]
@@ -143,33 +142,8 @@ class PI0FastPaliGemma(nn.Module):
             del self.paligemma.model.language_model
             self.paligemma.model.language_model = PiGemmaModel(text_config)
 
-        self.to_bfloat16_for_selected_params(precision)
-
-    def to_bfloat16_for_selected_params(self, precision: Literal["bfloat16", "float32"] = "bfloat16"):
-        if precision == "bfloat16":
-            self.to(dtype=torch.bfloat16)
-        elif precision == "float32":
-            self.to(dtype=torch.float32)
-            return
-        else:
-            raise ValueError(f"Invalid precision: {precision}")
-
-        # Keep full vision path in float32 so we never toggle (toggle causes optimizer
-        # "same dtype" error). Align with PI05.
-        params_to_keep_float32 = [
-            "vision_tower",
-            "multi_modal_projector",
-            "input_layernorm",
-            "post_attention_layernorm",
-            "model.norm",
-        ]
-
-        for name, param in self.named_parameters():
-            if any(selector in name for selector in params_to_keep_float32):
-                param.data = param.data.to(dtype=torch.float32)
-
     def embed_image(self, image: torch.Tensor):
-        # Vision tower and multi_modal_projector are kept in float32 (params_to_keep_float32). Align with PI05.
+        # Vision tower and multi_modal_projector are kept in float32 (declared by the policy). Align with PI05.
         out_dtype = image.dtype
         if image.dtype != torch.float32:
             image = image.to(torch.float32)
@@ -231,17 +205,17 @@ class PI0FastPytorch(nn.Module):  # see openpi `PI0Pytorch`
         self.paligemma_with_expert = PI0FastPaliGemma(
             paligemma_config,
             use_adarms=[False, True],
-            precision=config.dtype,
         )
 
         # Initialize gradient checkpointing flag
         self.gradient_checkpointing_enabled = False
 
+    def _compile_model(self):
         # Compile model if requested
-        if config.compile_model:
+        if self.config.compile_model:
             torch.set_float32_matmul_precision("high")
-            self.sample_actions_fast = torch.compile(self.sample_actions_fast, mode=config.compile_mode)
-            self.forward = torch.compile(self.forward, mode=config.compile_mode)
+            self.sample_actions_fast = torch.compile(self.sample_actions_fast, mode=self.config.compile_mode)
+            self.forward = torch.compile(self.forward, mode=self.config.compile_mode)
 
     def gradient_checkpointing_enable(self):
         """Enable gradient checkpointing for memory optimization."""
@@ -438,12 +412,11 @@ class PI0FastPytorch(nn.Module):  # see openpi `PI0Pytorch`
             )
         )
 
-        # Convert embeddings to bfloat16 if needed
-        if (
-            self.paligemma_with_expert.paligemma.model.language_model.layers[0].self_attn.q_proj.weight.dtype
-            == torch.bfloat16
-        ):
-            prefix_embs = prefix_embs.to(dtype=torch.bfloat16)
+        # Align embeddings with the language model weights.
+        dtype = self.paligemma_with_expert.paligemma.model.language_model.layers[
+            0
+        ].self_attn.q_proj.weight.dtype
+        prefix_embs = prefix_embs.to(dtype=dtype)
 
         # for next-token prediction, input tokens [0:T-1] to predict tokens [1:T]
         input_embs = prefix_embs
@@ -532,11 +505,10 @@ class PI0FastPytorch(nn.Module):  # see openpi `PI0Pytorch`
             images, img_masks, tokens, masks, fast_action_tokens=None, fast_action_masks=None
         )
 
-        if (
-            self.paligemma_with_expert.paligemma.model.language_model.layers[0].self_attn.q_proj.weight.dtype
-            == torch.bfloat16
-        ):
-            prefix_embs = prefix_embs.to(dtype=torch.bfloat16)
+        dtype = self.paligemma_with_expert.paligemma.model.language_model.layers[
+            0
+        ].self_attn.q_proj.weight.dtype
+        prefix_embs = prefix_embs.to(dtype=dtype)
 
         generated_action_tokens = torch.zeros((bsize, max_decoding_steps), dtype=torch.long, device=device)
 
@@ -571,8 +543,7 @@ class PI0FastPytorch(nn.Module):  # see openpi `PI0Pytorch`
             if t < max_decoding_steps - 1:
                 # embed the newly generated token
                 next_token_emb = self.paligemma_with_expert.embed_language_tokens(next_token)
-                if prefix_embs.dtype == torch.bfloat16:
-                    next_token_emb = next_token_emb.to(dtype=torch.bfloat16)
+                next_token_emb = next_token_emb.to(dtype=prefix_embs.dtype)
 
                 # append to embeddings
                 prefix_embs = torch.cat([prefix_embs, next_token_emb], dim=1)
@@ -640,12 +611,11 @@ class PI0FastPytorch(nn.Module):  # see openpi `PI0Pytorch`
             images, img_masks, tokens_in, masks_in, fast_action_tokens=None, fast_action_masks=None
         )
 
-        # Ensure correct precision (bfloat16/float32)
-        if (
-            self.paligemma_with_expert.paligemma.model.language_model.layers[0].self_attn.q_proj.weight.dtype
-            == torch.bfloat16
-        ):
-            prefix_embs = prefix_embs.to(dtype=torch.bfloat16)
+        # Align embeddings with the language model weights.
+        dtype = self.paligemma_with_expert.paligemma.model.language_model.layers[
+            0
+        ].self_attn.q_proj.weight.dtype
+        prefix_embs = prefix_embs.to(dtype=dtype)
 
         # Create position IDs (cumsum of mask - 1)
         position_ids = torch.cumsum(prefix_pad_masks, dim=1) - 1
@@ -691,8 +661,7 @@ class PI0FastPytorch(nn.Module):  # see openpi `PI0Pytorch`
             # Embed the single previous token
             # We use embed_language_tokens directly to avoid overhead of full prefix embedding
             next_token_emb = self.paligemma_with_expert.embed_language_tokens(next_token)
-            if prefix_embs.dtype == torch.bfloat16:
-                next_token_emb = next_token_emb.to(dtype=torch.bfloat16)
+            next_token_emb = next_token_emb.to(dtype=prefix_embs.dtype)
 
             # Update Pad Mask: append 1s for the new valid token
             new_column = torch.ones((bsize, 1), dtype=torch.bool, device=device)
@@ -743,6 +712,14 @@ class PI0FastPolicy(PreTrainedPolicy):
     config_class = PI0FastConfig
     name = "pi0_fast"
 
+    _fp32_modules = (
+        "model.paligemma_with_expert.paligemma.model.vision_tower",
+        "model.paligemma_with_expert.paligemma.model.multi_modal_projector",
+        "model.paligemma_with_expert.paligemma.model.language_model.layers.*.input_layernorm",
+        "model.paligemma_with_expert.paligemma.model.language_model.layers.*.post_attention_layernorm",
+        "model.paligemma_with_expert.paligemma.model.language_model.norm",
+    )
+
     def __init__(
         self,
         config: PI0FastConfig,
@@ -786,126 +763,24 @@ class PI0FastPolicy(PreTrainedPolicy):
         if config.gradient_checkpointing:
             self.model.gradient_checkpointing_enable()
 
+        self.post_init()
         self.model.to(config.device)
-
+        if config.compile_model:
+            self.model._compile_model()
         self.reset()
 
     @classmethod
-    def from_pretrained(
-        cls: builtins.type[T],
-        pretrained_name_or_path: str | Path,
-        *,
-        config: PreTrainedConfig | None = None,
-        force_download: bool = False,
-        resume_download: bool | None = None,
-        proxies: dict | None = None,
-        token: str | bool | None = None,
-        cache_dir: str | Path | None = None,
-        local_files_only: bool = False,
-        revision: str | None = None,
-        strict: bool = True,
-        **kwargs,
-    ) -> T:
-        """Override the from_pretrained method to handle key remapping and display important disclaimer."""
-        print(
-            "The PI0Fast model is a direct port of the OpenPI implementation. \n"
-            "This implementation follows the original OpenPI structure for compatibility. \n"
-            "Original implementation: https://github.com/Physical-Intelligence/openpi"
-        )
-        if pretrained_name_or_path is None:
-            raise ValueError("pretrained_name_or_path is required")
+    def from_pretrained(cls, pretrained_name_or_path, *, strict: bool = True, **kwargs):
+        return super().from_pretrained(pretrained_name_or_path, strict=strict, **kwargs)
 
-        # Use provided config if available, otherwise create default config
-        if config is None:
-            config = PreTrainedConfig.from_pretrained(
-                pretrained_name_or_path=pretrained_name_or_path,
-                force_download=force_download,
-                resume_download=resume_download,
-                proxies=proxies,
-                token=token,
-                cache_dir=cache_dir,
-                local_files_only=local_files_only,
-                revision=revision,
-                **kwargs,
-            )
-
-        # Initialize model without loading weights
-        # Check if dataset_stats were provided in kwargs
-        model = cls(config, **kwargs)
-
-        # Load state dict (expects keys with "model." prefix)
-        try:
-            print(f"Loading model from: {pretrained_name_or_path}")
-            try:
-                from transformers.utils import cached_file
-
-                resolved_file = cached_file(
-                    pretrained_name_or_path,
-                    "model.safetensors",
-                    cache_dir=kwargs.get("cache_dir"),
-                    force_download=kwargs.get("force_download", False),
-                    resume_download=kwargs.get("resume_download"),
-                    proxies=kwargs.get("proxies"),
-                    token=kwargs.get("token"),
-                    revision=kwargs.get("revision"),
-                    local_files_only=kwargs.get("local_files_only", False),
-                )
-                from safetensors.torch import load_file
-
-                original_state_dict = load_file(resolved_file)
-                print("✓ Loaded state dict from model.safetensors")
-            except Exception as e:
-                print(f"Could not load state dict from remote files: {e}")
-                print("Returning model without loading pretrained weights")
-                return model
-
-            # First, fix any key differences (see openpi model.py, _fix_pytorch_state_dict_keys)
-            fixed_state_dict = model._fix_pytorch_state_dict_keys(original_state_dict, model.config)
-
-            # Then add "model." prefix for all keys that don't already have it
-            remapped_state_dict = {}
-            remap_count = 0
-
-            for key, value in fixed_state_dict.items():
-                if not key.startswith("model."):
-                    new_key = f"model.{key}"
-                    remapped_state_dict[new_key] = value
-                    remap_count += 1
-                else:
-                    remapped_state_dict[key] = value
-
-            if remap_count > 0:
-                print(f"Remapped {remap_count} state dict keys")
-
-            # Load the remapped state dict into the model
-            missing_keys, unexpected_keys = model.load_state_dict(remapped_state_dict, strict=strict)
-
-            if missing_keys:
-                print(f"Missing keys when loading state dict: {len(missing_keys)} keys")
-                if len(missing_keys) <= 5:
-                    for key in missing_keys:
-                        print(f"  - {key}")
-                else:
-                    for key in missing_keys[:5]:
-                        print(f"  - {key}")
-                    print(f"  ... and {len(missing_keys) - 5} more")
-
-            if unexpected_keys:
-                print(f"Unexpected keys when loading state dict: {len(unexpected_keys)} keys")
-                if len(unexpected_keys) <= 5:
-                    for key in unexpected_keys:
-                        print(f"  - {key}")
-                else:
-                    for key in unexpected_keys[:5]:
-                        print(f"  - {key}")
-                    print(f"  ... and {len(unexpected_keys) - 5} more")
-
-            if not missing_keys and not unexpected_keys:
-                print("All keys loaded successfully!")
-
-        except Exception as e:
-            print(f"Warning: Could not load state dict: {e}")
-
+    @classmethod
+    def _load_as_safetensor(cls, model, model_file: str, map_location: str, strict: bool):
+        state_dict = load_file(model_file, device=resolve_safetensors_device(map_location))
+        state_dict = model._fix_pytorch_state_dict_keys(state_dict, model.config)
+        state_dict = {
+            key if key.startswith("model.") else f"model.{key}": value for key, value in state_dict.items()
+        }
+        log_model_loading_keys(*model.load_state_dict(state_dict, strict=strict))
         return model
 
     def _fix_pytorch_state_dict_keys(

--- a/src/lerobot/policies/pi_gemma.py
+++ b/src/lerobot/policies/pi_gemma.py
@@ -286,9 +286,8 @@ class PiGemmaModel(GemmaModel):  # type: ignore[misc]
 
         # embed positions
         hidden_states = inputs_embeds
-        # Convert to bfloat16 if the first layer uses bfloat16
-        if len(self.layers) > 0 and self.layers[0].self_attn.q_proj.weight.dtype == torch.bfloat16:
-            hidden_states = hidden_states.to(torch.bfloat16)
+        if len(self.layers) > 0:
+            hidden_states = hidden_states.to(self.layers[0].self_attn.q_proj.weight.dtype)
 
         # create position embeddings to be shared across the decoder layers
         position_embeddings = self.rotary_emb(hidden_states, position_ids)

--- a/src/lerobot/policies/pretrained.py
+++ b/src/lerobot/policies/pretrained.py
@@ -16,21 +16,25 @@ from __future__ import annotations
 import abc
 import builtins
 import dataclasses
+import itertools
 import logging
 import os
 import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, TypedDict, TypeVar, Unpack
 
+import torch
 from huggingface_hub import hf_hub_download, save_torch_state_dict
 from huggingface_hub.constants import SAFETENSORS_SINGLE_FILE
 from huggingface_hub.errors import HfHubHTTPError
+from safetensors import safe_open
 from safetensors.torch import load_model as load_model_as_safetensor
 from torch import Tensor, nn
 
 from lerobot.configs import PreTrainedConfig
 from lerobot.utils.constants import ACTION
 from lerobot.utils.device_utils import resolve_safetensors_device
+from lerobot.utils.dtype import get_dtype
 from lerobot.utils.hub import HubMixin
 from lerobot.utils.import_utils import _peft_available, require_package
 
@@ -66,6 +70,12 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
     config_class: None
     name: None
 
+    # Paths from the policy root, e.g. "model.action_head" or "model.layers.*.norm".
+    # Each '*' matches exactly one path component. A module path protects all its
+    # floating parameters and buffers; a tensor path protects only that tensor.
+    # Declare these paths on the policy class, not its nested modules.
+    _fp32_modules: ClassVar[tuple[str, ...]] = ()
+
     # --- declarative parallelism/acceleration surface ----------------------------------------
     # Module CLASS names forming the FSDP2 wrap units (and, once wired, the activation-
     # checkpointing units). Resolved onto the accelerate plugin right before
@@ -95,6 +105,88 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
                 f"`model = {self.__class__.__name__}.from_pretrained(PRETRAINED_MODEL_NAME)`"
             )
         self.config = config
+
+    @property
+    def _fp32_tensor_names(self) -> set[str]:
+        """Full names of floating parameters/buffers protected by the policy's rules.
+
+        Include non-persistent buffers and every alias of a shared tensor if any
+        alias matches. Resolve the current registrations on each access, so changing
+        modules or parameter ties cannot leave a stale name set.
+        """
+        if not self._fp32_modules:
+            return set()
+
+        paths = [path.split(".") for path in self._fp32_modules]
+        for path, parts in zip(self._fp32_modules, paths, strict=True):
+            if any(not part or ("*" in part and part != "*") for part in parts):
+                raise ValueError(
+                    f"Invalid FP32 path {path!r}: use names separated by dots and '*' for one level."
+                )
+        aliases: dict[Tensor, list[str]] = {}
+        for name, tensor in itertools.chain(
+            self.named_parameters(remove_duplicate=False), self.named_buffers(remove_duplicate=False)
+        ):
+            if tensor.is_floating_point():
+                aliases.setdefault(tensor, []).append(name)
+
+        names: set[str] = set()
+        for tensor_names in aliases.values():
+            for name in tensor_names:
+                parts = name.split(".")
+                if any(
+                    len(path) <= len(parts)
+                    and all(
+                        pattern == "*" or pattern == part for pattern, part in zip(path, parts, strict=False)
+                    )
+                    for path in paths
+                ):
+                    names.update(tensor_names)
+                    break
+        return names
+
+    @property
+    def dtype(self) -> torch.dtype:
+        """The actual floating dtype, preferring parameters outside the FP32 exceptions.
+
+        Like ``nn.Module.to()``, this reports the current tensors rather than a cached
+        configuration value. A policy with only FP32 exceptions reports their dtype.
+        """
+        keep_names = self._fp32_tensor_names
+        fallback = None
+        for name, tensor in itertools.chain(self.named_parameters(), self.named_buffers()):
+            if tensor.is_floating_point():
+                if name not in keep_names:
+                    return tensor.dtype
+                if fallback is None:
+                    fallback = tensor.dtype
+        return fallback if fallback is not None else get_dtype(self.config.dtype)
+
+    def post_init(self) -> None:
+        """Finalize parameter precision after a subclass has constructed all its modules.
+
+        Construct real tensors in FP32, then call this once at the end of ``__init__``,
+        before compilation or optimizer creation. Each tensor goes directly to its
+        final dtype so FP32 exceptions never make a lossy round trip through BF16.
+        Integer buffers, tied parameters and existing gradients are preserved.
+        Once conversion is complete, config.dtype records the actual model dtype.
+        """
+        dtype = get_dtype(self.config.dtype)
+        keep_names = self._fp32_tensor_names
+
+        # Visit registered tensors directly. Frozen components kept outside the module
+        # registry (e.g. FastWAM's UMT5 encoder) are loaded with config.dtype by their
+        # own loaders, which may have additional precision rules.
+        with torch.no_grad():
+            for name, tensor in itertools.chain(self.named_parameters(), self.named_buffers()):
+                if not tensor.is_floating_point():
+                    continue
+                target = torch.float32 if name in keep_names else dtype
+                tensor.data = tensor.to(dtype=target)
+                if isinstance(tensor, nn.Parameter) and tensor.grad is not None:
+                    tensor.grad.data = tensor.grad.to(dtype=target)
+
+        self.config.dtype = str(self.dtype).removeprefix("torch.")
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
@@ -140,6 +232,7 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
             # Non-sharded multi-rank (DDP): every rank holds a full dict — the explicit rank
             # gate prevents N ranks racing on the same files. Single process: never taken.
             return
+        self.config.dtype = str(model_to_save.dtype).removeprefix("torch.")
         self.config._save_pretrained(save_directory)
         save_torch_state_dict(state_dict, str(save_directory), max_shard_size=_SINGLE_FILE_SHARD_SIZE)
 
@@ -149,6 +242,7 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
         pretrained_name_or_path: str | Path,
         *,
         config: PreTrainedConfig | None = None,
+        dtype: str | torch.dtype | None = None,
         force_download: bool = False,
         resume_download: bool | None = None,
         proxies: dict | None = None,
@@ -162,6 +256,12 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
         """
         The policy is set in evaluation mode by default using `policy.eval()` (dropout modules are
         deactivated). To train it, you should first set it back in training mode with `policy.train()`.
+
+        ``dtype`` overrides the saved configuration and accepts a torch.dtype or its name.
+        ``None`` uses config.dtype (or PyTorch's default). ``"auto"`` uses config.dtype,
+        falling back to the first floating checkpoint tensor when it is unspecified.
+        Declared FP32 exceptions apply to both initialization and checkpoint loading.
+        A supplied config is reused and updated with the resolved dtype and pretrained_path.
         """
         if config is None:
             config = PreTrainedConfig.from_pretrained(
@@ -176,11 +276,9 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
                 **kwargs,
             )
         model_id = str(pretrained_name_or_path)
-        instance = cls(config, **kwargs)
         if os.path.isdir(model_id):
             print("Loading weights from local directory")
             model_file = os.path.join(model_id, SAFETENSORS_SINGLE_FILE)
-            policy = cls._load_as_safetensor(instance, model_file, config.device, strict)
         else:
             try:
                 model_file = hf_hub_download(
@@ -194,12 +292,37 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
                     token=token,
                     local_files_only=local_files_only,
                 )
-                policy = cls._load_as_safetensor(instance, model_file, config.device, strict)
             except HfHubHTTPError as e:
                 raise FileNotFoundError(
                     f"{SAFETENSORS_SINGLE_FILE} not found on the HuggingFace Hub in {model_id}"
                 ) from e
 
+        if dtype == "auto":
+            dtype = config.dtype
+            if dtype is None:
+                with safe_open(model_file, framework="pt", device="cpu") as checkpoint:
+                    dtypes = {
+                        "F16": torch.float16,
+                        "BF16": torch.bfloat16,
+                        "F32": torch.float32,
+                        "F64": torch.float64,
+                    }
+                    keys = checkpoint.keys()
+                    dtype = next(
+                        (
+                            dtypes[code]
+                            for key in keys
+                            if (code := checkpoint.get_slice(key).get_dtype()) in dtypes
+                        ),
+                        torch.get_default_dtype(),
+                    )
+        config.dtype = str(get_dtype(config.dtype if dtype is None else dtype)).removeprefix("torch.")
+        config.pretrained_path = Path(pretrained_name_or_path)
+        instance = cls(config, **kwargs)
+        # Copy CPU checkpoint tensors into the already configured parameter dtypes.
+        # Loading a full FP32 state dict onto the accelerator would defeat dtype
+        # selection's memory savings while the checkpoint and model coexist.
+        policy = cls._load_as_safetensor(instance, model_file, "cpu", strict)
         policy.to(config.device)
         policy.eval()
         return policy

--- a/src/lerobot/policies/smolvla/configuration_smolvla.py
+++ b/src/lerobot/policies/smolvla/configuration_smolvla.py
@@ -25,6 +25,8 @@ from ..rtc.configuration_rtc import RTCConfig
 @dataclass
 class SmolVLAConfig(PreTrainedConfig):
     # Input / output structure.
+    dtype: str = "bfloat16"
+
     n_obs_steps: int = 1
     chunk_size: int = 50
     n_action_steps: int = 50

--- a/src/lerobot/policies/smolvla/modeling_smolvla.py
+++ b/src/lerobot/policies/smolvla/modeling_smolvla.py
@@ -145,6 +145,16 @@ class SmolVLAPolicy(PreTrainedPolicy):
     config_class = SmolVLAConfig
     name = "smolvla"
 
+    _fp32_modules = (
+        "model.state_proj",
+        "model.action_in_proj",
+        "model.action_out_proj",
+        "model.action_time_mlp_in",
+        "model.action_time_mlp_out",
+        "model.vlm_with_expert.vlm.model.text_model.rotary_emb",
+        "model.vlm_with_expert.lm_expert.rotary_emb",
+    )
+
     def supports_rtc(self) -> bool:
         return True
 
@@ -165,6 +175,7 @@ class SmolVLAPolicy(PreTrainedPolicy):
         self.config = config
         self.init_rtc_processor()
         self.model = VLAFlowMatching(config, rtc_processor=self.rtc_processor)
+        self.post_init()
         self.reset()
 
     def reset(self):

--- a/src/lerobot/policies/smolvla/smolvlm_with_expert.py
+++ b/src/lerobot/policies/smolvla/smolvlm_with_expert.py
@@ -91,7 +91,7 @@ class SmolVLMWithExpertModel(nn.Module):
             print(f"Loading  {model_id} weights ...")
             self.vlm = AutoModelForImageTextToText.from_pretrained(
                 model_id,
-                torch_dtype="bfloat16",
+                dtype=torch.float32,
                 low_cpu_mem_usage=True,
             )
             config = self.vlm.config

--- a/src/lerobot/policies/tdmpc/modeling_tdmpc.py
+++ b/src/lerobot/policies/tdmpc/modeling_tdmpc.py
@@ -82,6 +82,7 @@ class TDMPCPolicy(PreTrainedPolicy):
         for param in self.model_target.parameters():
             param.requires_grad = False
 
+        self.post_init()
         self.reset()
 
     def get_optim_params(self) -> dict:

--- a/src/lerobot/policies/vla_jepa/configuration_vla_jepa.py
+++ b/src/lerobot/policies/vla_jepa/configuration_vla_jepa.py
@@ -123,7 +123,7 @@ class VLAJEPAConfig(PreTrainedConfig):
     # Action-dimension names identifying the gripper. When these match `action_feature_names`,
     # the resolved index wins over `gripper_dim`.
     gripper_joint_names: list[str] = field(default_factory=lambda: ["gripper"])
-    torch_dtype: str = "bfloat16"
+    dtype: str = "bfloat16"
 
     optimizer_lr: float = 1e-4
     optimizer_betas: tuple[float, float] = (0.9, 0.95)

--- a/src/lerobot/policies/vla_jepa/modeling_vla_jepa.py
+++ b/src/lerobot/policies/vla_jepa/modeling_vla_jepa.py
@@ -88,7 +88,7 @@ class VLAJEPAModel(nn.Module):
         if config.enable_world_model:
             self.video_encoder = AutoModel.from_pretrained(
                 config.jepa_encoder_name,
-                torch_dtype=self.qwen._get_torch_dtype(config.torch_dtype),
+                dtype=torch.float32,
             )
             self.video_processor = AutoVideoProcessor.from_pretrained(config.jepa_encoder_name)
             num_views = config.num_world_model_views
@@ -385,6 +385,13 @@ class VLAJEPAPolicy(PreTrainedPolicy):
     config_class = VLAJEPAConfig
     name = "vla_jepa"
 
+    _fp32_modules = (
+        "model.action_model",
+        "model.video_predictor",
+        "model.qwen.model.model.language_model.rotary_emb",
+        "model.qwen.model.model.visual.rotary_pos_emb",
+    )
+
     def __init__(self, config: VLAJEPAConfig, **kwargs) -> None:
         super().__init__(config)
         config.validate_features()
@@ -392,6 +399,7 @@ class VLAJEPAPolicy(PreTrainedPolicy):
         # `make_policy` before this): keeps `__init__` from mutating a config it does not own, and
         # makes the derived dims visible to the processor factory too.
         self.model = VLAJEPAModel(config)
+        self.post_init()
         self.reset()
 
     def reset(self) -> None:

--- a/src/lerobot/policies/vla_jepa/qwen_interface.py
+++ b/src/lerobot/policies/vla_jepa/qwen_interface.py
@@ -37,19 +37,11 @@ class Qwen3VLInterface(torch.nn.Module):
         self.config = config
         self.model = Qwen3VLForConditionalGeneration.from_pretrained(
             config.qwen_model_name,
-            torch_dtype=self._get_torch_dtype(config.torch_dtype),
+            dtype=torch.float32,
         )
         self.processor = AutoProcessor.from_pretrained(config.qwen_model_name)
         self.processor.tokenizer.padding_side = config.tokenizer_padding_side
         self.model.config.hidden_size = self.model.config.text_config.hidden_size
-
-    @staticmethod
-    def _get_torch_dtype(dtype_name: str) -> torch.dtype:
-        if dtype_name == "float32":
-            return torch.float32
-        if dtype_name == "float16":
-            return torch.float16
-        return torch.bfloat16
 
     def expand_tokenizer(self) -> tuple[list[str], list[int], int]:
         # starVLA/JEVLA checkpoints expand action tokens as action_horizon * 4,

--- a/src/lerobot/policies/vqbet/modeling_vqbet.py
+++ b/src/lerobot/policies/vqbet/modeling_vqbet.py
@@ -63,6 +63,7 @@ class VQBeTPolicy(PreTrainedPolicy):
 
         self.vqbet = VQBeTModel(config)
 
+        self.post_init()
         self.reset()
 
     def get_optim_params(self) -> dict:

--- a/src/lerobot/policies/wall_x/configuration_wall_x.py
+++ b/src/lerobot/policies/wall_x/configuration_wall_x.py
@@ -32,6 +32,8 @@ class WallXConfig(PreTrainedConfig):
     """
 
     # ==================== Input / Output Structure ====================
+    dtype: str = "bfloat16"
+
     n_obs_steps: int = 1
     chunk_size: int = 32  # action_horizon in wall-x
     n_action_steps: int = 32

--- a/src/lerobot/policies/wall_x/modeling_wall_x.py
+++ b/src/lerobot/policies/wall_x/modeling_wall_x.py
@@ -507,7 +507,9 @@ class Qwen2_5_VLMoEForAction(_Qwen2_5_VLForAction_Base):  # noqa: N801
         super().__init__(config)
 
         # Initialize vision transformer and language model components
-        self.visual = Qwen2_5_VisionTransformerPretrainedModel._from_config(config.vision_config)
+        self.visual = Qwen2_5_VisionTransformerPretrainedModel._from_config(
+            config.vision_config, dtype=torch.float32
+        )
         configure_wall_x_vision_attention(self.visual, vision_attn_implementation)
         self.model = Qwen2_5_VLMoEModel(config)
         self.vocab_size = config.vocab_size
@@ -540,21 +542,6 @@ class Qwen2_5_VLMoEForAction(_Qwen2_5_VLForAction_Base):  # noqa: N801
 
         # Initialize weights and apply final processing
         self.post_init()
-
-    def to_bfloat16_for_selected_params(self):
-        self.to(dtype=torch.bfloat16)
-
-        params_to_keep_float32 = []
-
-        for name, _param in self.named_parameters():
-            if "input_layernorm" in name or "post_attention_layernorm" in name or "model.norm" in name:
-                params_to_keep_float32.append(name)
-            if "action_preprocessor" in name:
-                params_to_keep_float32.append(name)
-
-        for name, param in self.named_parameters():
-            if name in params_to_keep_float32:
-                param.data = param.data.to(torch.float32)
 
     def define_action_token_id(self):
         """
@@ -1250,7 +1237,7 @@ class Qwen2_5_VLMoEForAction(_Qwen2_5_VLForAction_Base):  # noqa: N801
                     agent_pos_mask,
                 )
                 proprioception_mask = input_ids == self.action_token_id_set["propri_token_id"]
-                proprio_embed = proprio_embed.to(torch.bfloat16)
+                proprio_embed = proprio_embed.to(inputs_embeds.dtype)
                 inputs_embeds[proprioception_mask] = proprio_embed.reshape(-1, inputs_embeds.shape[-1])
 
             if attention_mask is not None:
@@ -1820,6 +1807,13 @@ class WallXPolicy(PreTrainedPolicy):
     config_class = WallXConfig
     name = "wall_x"
 
+    _fp32_modules = (
+        "model.action_preprocessor",
+        "model.model.layers.*.input_layernorm",
+        "model.model.layers.*.post_attention_layernorm",
+        "model.model.norm",
+    )
+
     def __init__(self, config: WallXConfig, **kwargs):
         require_package("transformers", extra="wallx")
         require_package("peft", extra="wallx")
@@ -1836,9 +1830,8 @@ class WallXPolicy(PreTrainedPolicy):
             attn_implementation=config.attn_implementation,
             vision_attn_implementation=config.vision_attn_implementation,
         )
+        self.post_init()
         self.model.to(config.device)
-        self.model.to_bfloat16_for_selected_params()
-
         self.reset()
 
     def reset(self):

--- a/src/lerobot/policies/wall_x/qwen_model/qwen2_5_vl_moe.py
+++ b/src/lerobot/policies/wall_x/qwen_model/qwen2_5_vl_moe.py
@@ -21,7 +21,7 @@ It is rebased on the native ``transformers.models.qwen2_5_vl`` classes and only 
 - ``BlockSparseMLP`` / ``SparseMoeBlock``: hard-routed (token-type indexed) expert MLPs.
 - ``Qwen2_5_VLDecoderLayer_with_MoE``: native decoder layer whose MLP is replaced by the sparse MoE
   block and whose forward casts activations to the parameter dtypes (Wall-X keeps the layernorms in
-  float32 while the projections run in bfloat16, see ``to_bfloat16_for_selected_params``).
+  float32 while the projections run in bfloat16, see ``WallXPolicy._fp32_modules``).
 - ``Qwen2_5_VLMoEModel``: native text model with MoE decoder layers and a ``moe_token_types``-aware
   causal-mask override (tokens of type 1 — the action tokens — attend to each other bidirectionally,
   everything else stays causal).

--- a/src/lerobot/policies/xvla/configuration_xvla.py
+++ b/src/lerobot/policies/xvla/configuration_xvla.py
@@ -88,7 +88,6 @@ class XVLAConfig(PreTrainedConfig):
     n_obs_steps: int = 1
     chunk_size: int = 32
     n_action_steps: int = 32
-    dtype: str = "float32"  # Options: "bfloat16", "float32"
 
     normalization_mapping: dict[str, NormalizationMode] = field(
         default_factory=lambda: {
@@ -161,8 +160,6 @@ class XVLAConfig(PreTrainedConfig):
             )
         if self.num_image_views is not None and self.num_image_views <= 0:
             raise ValueError("`num_image_views` must be > 0 when specified.")
-        if self.dtype not in ["bfloat16", "float32"]:
-            raise ValueError(f"Invalid dtype: {self.dtype}")
         self._florence_config_obj: Florence2Config | None = None
 
     def get_florence_config(self) -> Florence2Config:

--- a/src/lerobot/policies/xvla/modeling_xvla.py
+++ b/src/lerobot/policies/xvla/modeling_xvla.py
@@ -18,23 +18,22 @@
 
 from __future__ import annotations
 
-import builtins
 import logging
-import os
 import re
 from collections import deque
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 import torch
+from safetensors.torch import load_file
 from torch import Tensor, nn
 
-from lerobot.configs import PreTrainedConfig
+from lerobot.policies.utils import log_model_loading_keys
 from lerobot.utils.constants import ACTION, OBS_LANGUAGE_TOKENS, OBS_STATE
+from lerobot.utils.device_utils import resolve_safetensors_device
 from lerobot.utils.import_utils import _transformers_available, require_package
 
 from ..common.vla_utils import pad_vector, resize_with_pad
-from ..pretrained import PreTrainedPolicy, T
+from ..pretrained import PreTrainedPolicy
 from ..utils import populate_queues
 from .action_hub import build_action_space
 from .configuration_xvla import XVLAConfig
@@ -108,22 +107,6 @@ class XVLAModel(nn.Module):
 
         # Apply freezing based on config
         self._apply_freezing()
-
-        # Apply dtype casting based on config
-        self._apply_dtype()
-
-    def _get_target_dtype(self) -> torch.dtype:
-        """Get the target dtype based on config."""
-        if self.config.dtype == "bfloat16":
-            return torch.bfloat16
-        return torch.float32
-
-    def _apply_dtype(self) -> None:
-        """
-        Apply dtype casting to model components based on config.
-        """
-        target_dtype = self._get_target_dtype()
-        self.to(dtype=target_dtype)
 
     def _apply_freezing(self) -> None:
         """
@@ -207,7 +190,7 @@ class XVLAModel(nn.Module):
         """
         Forward pass for the XVLA model.
         """
-        target_dtype = self._get_target_dtype()
+        target_dtype = next(self.transformer.parameters()).dtype
         image_input = image_input.to(dtype=target_dtype)
         proprio = proprio.to(dtype=target_dtype)
         action = action.to(dtype=target_dtype)
@@ -244,7 +227,7 @@ class XVLAModel(nn.Module):
     ) -> torch.Tensor:
         self.eval()
 
-        target_dtype = self._get_target_dtype()
+        target_dtype = next(self.transformer.parameters()).dtype
         image_input = image_input.to(dtype=target_dtype)
         proprio = proprio.to(dtype=target_dtype)
 
@@ -284,6 +267,7 @@ class XVLAPolicy(PreTrainedPolicy):
         florence_config = config.get_florence_config()
         proprio_dim = config.max_state_dim if config.use_proprio else 0
         self.model = XVLAModel(config=config, florence_config=florence_config, proprio_dim=proprio_dim)
+        self.post_init()
         self.reset()
 
     def reset(self) -> None:
@@ -421,73 +405,8 @@ class XVLAPolicy(PreTrainedPolicy):
         return self._queues[ACTION].popleft()
 
     @classmethod
-    def from_pretrained(
-        cls: builtins.type[T],
-        pretrained_name_or_path: str | Path,
-        *,
-        config: PreTrainedConfig | None = None,
-        force_download: bool = False,
-        resume_download: bool | None = None,
-        proxies: dict | None = None,
-        token: str | bool | None = None,
-        cache_dir: str | Path | None = None,
-        local_files_only: bool = False,
-        revision: str | None = None,
-        strict: bool = False,
-        **kwargs,
-    ):
-        """
-        Loads XVLA model weights with:
-        - automatic prefix 'model.' added to all keys
-        - skip list for layers that should remain randomly initialized
-        """
-        import safetensors.torch
-
-        # step 1: load config
-        # TODO: jadechoghari, fix this
-        if config is None:
-            config = PreTrainedConfig.from_pretrained(
-                pretrained_name_or_path=pretrained_name_or_path,
-                force_download=force_download,
-                resume_download=resume_download,
-                proxies=proxies,
-                token=token,
-                cache_dir=cache_dir,
-                local_files_only=local_files_only,
-                revision=revision,
-                **kwargs,
-            )
-
-        model_id = str(pretrained_name_or_path)
-        instance = cls(config, **kwargs)
-        # step 2: locate model.safetensors
-        if os.path.isdir(model_id):
-            logging.info("Loading weights from local directory")
-            model_file = os.path.join(model_id, "model.safetensors")
-        else:
-            try:
-                from huggingface_hub import hf_hub_download
-                from huggingface_hub.utils import HfHubHTTPError
-
-                model_file = hf_hub_download(
-                    repo_id=model_id,
-                    filename="model.safetensors",
-                    revision=revision,
-                    cache_dir=cache_dir,
-                    force_download=force_download,
-                    proxies=proxies,
-                    resume_download=resume_download,
-                    token=token,
-                    local_files_only=local_files_only,
-                )
-            except HfHubHTTPError as e:
-                raise FileNotFoundError(f"model.safetensors not found on the Hub at {model_id}") from e
-
-        logging.info(f"Loading checkpoint from {model_file}")
-        # step 3: load state dict, remapping checkpoints saved with the old vendored
-        # Florence-2 module layout to the native transformers layout
-        # (see openpi model.py `_fix_pytorch_state_dict_keys` / pi0 for the same pattern)
-        state_dict = safetensors.torch.load_file(model_file)
+    def _load_as_safetensor(cls, model, model_file: str, map_location: str, strict: bool):
+        state_dict = load_file(model_file, device=resolve_safetensors_device(map_location))
         if _is_vendored_florence_state_dict(state_dict):
             logging.info(
                 "Detected XVLA checkpoint with the old vendored Florence-2 layout; "
@@ -502,15 +421,8 @@ class XVLAPolicy(PreTrainedPolicy):
             state_dict[embed_key] = state_dict[shared_key]
         elif embed_key in state_dict and shared_key not in state_dict:
             state_dict[shared_key] = state_dict[embed_key]
-        # step 4: load into instance
-        instance.load_state_dict(state_dict, strict=True)
-        logging.info("Loaded XVLA checkpoint")
-        # step 5: finalize
-        # Reapply dtype after loading state dict
-        instance.model._apply_dtype()
-        instance.to(config.device)
-        instance.eval()
-        return instance
+        log_model_loading_keys(*model.load_state_dict(state_dict, strict=strict))
+        return model
 
 
 def _is_vendored_florence_state_dict(state_dict: dict[str, Tensor], prefix: str = "model.vlm.") -> bool:

--- a/src/lerobot/utils/dtype.py
+++ b/src/lerobot/utils/dtype.py
@@ -1,0 +1,35 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+
+
+def get_dtype(dtype: str | torch.dtype | None) -> torch.dtype:
+    """Resolve a parameter dtype. ``None`` uses PyTorch's default floating dtype."""
+    requested_dtype = dtype
+    supported = {
+        "float16": torch.float16,
+        "bfloat16": torch.bfloat16,
+        "float32": torch.float32,
+        "float64": torch.float64,
+    }
+    if dtype is None:
+        dtype = torch.get_default_dtype()
+    if isinstance(dtype, str):
+        dtype = supported.get(dtype)
+    if not isinstance(dtype, torch.dtype) or dtype not in supported.values():
+        raise ValueError(
+            f"Invalid dtype: {requested_dtype!r}. Expected one of {list(supported)} or a matching torch.dtype."
+        )
+    return dtype

--- a/tests/policies/eo1/test_eo1.py
+++ b/tests/policies/eo1/test_eo1.py
@@ -184,3 +184,77 @@ def test_lerobot_eo1_inference(monkeypatch):
     torch.testing.assert_close(action_0, fixed_chunk[:, 0, :ACTION_DIM])
     torch.testing.assert_close(action_1, fixed_chunk[:, 1, :ACTION_DIM])
     assert sample_calls["count"] == 1
+
+
+@pytest.fixture(scope="module")
+def tiny_qwen_checkpoint(tmp_path_factory):
+    from transformers import Qwen2_5_VLConfig, Qwen2_5_VLForConditionalGeneration
+
+    config = Qwen2_5_VLConfig(
+        text_config={
+            "vocab_size": 64,
+            "hidden_size": 32,
+            "intermediate_size": 64,
+            "num_hidden_layers": 1,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 2,
+        },
+        vision_config={
+            "depth": 1,
+            "hidden_size": 32,
+            "intermediate_size": 64,
+            "num_heads": 4,
+            "in_channels": 3,
+            "out_hidden_size": 32,
+            "patch_size": 2,
+            "temporal_patch_size": 1,
+            "spatial_merge_size": 2,
+            "fullatt_block_indexes": [0],
+        },
+    )
+    model = Qwen2_5_VLForConditionalGeneration._from_config(config, dtype=torch.bfloat16)
+    directory = tmp_path_factory.mktemp("eo1_qwen")
+    model.save_pretrained(directory)
+    rope = {name: buffer.clone() for name, buffer in model.named_buffers() if "inv_freq" in name}
+    assert rope and all(buffer.dtype == torch.float32 for buffer in rope.values())
+    return directory, model.config.to_dict(), rope
+
+
+@pytest.mark.parametrize("dtype", ["float32", "bfloat16", "float16", None])
+@pytest.mark.parametrize("from_config", [False, True])
+def test_eo1_qwen_uses_requested_precision_and_preserves_fp32_buffers(
+    dtype, from_config, tiny_qwen_checkpoint, monkeypatch
+):
+    from transformers import Qwen2_5_VLForConditionalGeneration
+
+    directory, backbone_config, reference_rope = tiny_qwen_checkpoint
+    config = make_eo1_config()
+    config.dtype = dtype
+    config.vlm_base = str(directory)
+    config.vlm_config = backbone_config
+    if from_config:
+        config.pretrained_path = directory
+
+    method = "_from_config" if from_config else "from_pretrained"
+    original = getattr(Qwen2_5_VLForConditionalGeneration, method)
+    requested_dtypes = []
+
+    def load_backbone(*args, **kwargs):
+        requested_dtypes.append(kwargs["dtype"])
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(Qwen2_5_VLForConditionalGeneration, method, load_backbone)
+    policy = EO1Policy(config)
+    requested = dtype if dtype is not None else torch.get_default_dtype()
+    assert requested_dtypes == [requested]
+    expected = getattr(torch, dtype) if dtype is not None else torch.get_default_dtype()
+    assert policy.dtype == expected
+    assert policy.config.dtype == str(expected).removeprefix("torch.")
+    assert all(p.dtype == expected for p in policy.model.vlm_backbone.parameters())
+    for name, buffer in policy.model.vlm_backbone.named_buffers():
+        if name in reference_rope:
+            assert buffer.dtype == torch.float32
+            assert torch.equal(buffer, reference_rope[name])
+    for name, parameter in policy.named_parameters():
+        if not name.startswith("model.vlm_backbone."):
+            assert parameter.dtype == torch.float32

--- a/tests/policies/fastwam/test_fastwam_policy.py
+++ b/tests/policies/fastwam/test_fastwam_policy.py
@@ -470,3 +470,31 @@ def test_vae_adapter_empty_build_encode_decode_shapes():
 
     # list input is accepted and equals the batched path
     assert torch.equal(vae.encode([video[0]]), latents)
+
+
+def test_component_loaders_accept_dtype_and_keep_loader_exceptions(monkeypatch):
+    from types import SimpleNamespace
+
+    from lerobot.policies.fastwam.wan import components
+
+    def load_vae(*args, **kwargs):
+        assert kwargs["torch_dtype"] == torch.bfloat16
+        model = nn.Linear(4, 4, dtype=torch.bfloat16)
+        model.config = SimpleNamespace(latents_mean=[0.0] * 48, latents_std=[1.0] * 48)
+        return model
+
+    def load_text_encoder(*args, **kwargs):
+        assert kwargs["dtype"] == torch.float16
+        model = nn.Module()
+        model.shared = nn.Embedding(4, 4, dtype=torch.float16)
+        model.wo = nn.Linear(4, 4, dtype=torch.float32)
+        model.config = SimpleNamespace(d_model=4)
+        return model
+
+    monkeypatch.setattr(components.AutoencoderKLWan, "from_pretrained", load_vae)
+    monkeypatch.setattr(components.UMT5EncoderModel, "from_pretrained", load_text_encoder)
+    vae = components.load_pretrained_wan_vae(dtype=torch.bfloat16, device="cpu")
+    encoder = components.load_pretrained_wan_text_encoder(dtype=torch.float16, device="cpu")
+    assert vae.vae.weight.dtype == torch.bfloat16
+    assert encoder.model.shared.weight.dtype == torch.float16
+    assert encoder.model.wo.weight.dtype == torch.float32

--- a/tests/policies/groot/test_groot_training_optim_contract.py
+++ b/tests/policies/groot/test_groot_training_optim_contract.py
@@ -80,7 +80,13 @@ def test_groot_n1_7_model_parameters_use_fp32_checkpoint_and_optimizer_precision
     module.trainable = torch.nn.Parameter(torch.ones(3, dtype=torch.bfloat16))
     module.frozen = torch.nn.Parameter(torch.ones(3, dtype=torch.bfloat16), requires_grad=False)
 
-    GrootPolicy._cast_model_parameters_to_fp32(module)
+    policy = object.__new__(GrootPolicy)
+    torch.nn.Module.__init__(policy)
+    policy.config = GrootConfig(device="cpu")
+    policy._groot_model = module
+    policy.post_init()
+    assert policy.config.dtype == "float32"
+    assert not hasattr(policy.config, "model_params_fp32")
 
     assert module.trainable.dtype == torch.float32
     assert module.frozen.dtype == torch.float32

--- a/tests/policies/molmoact2/test_molmoact2.py
+++ b/tests/policies/molmoact2/test_molmoact2.py
@@ -2039,11 +2039,10 @@ def test_molmoact2_pi05_style_precision_config():
     assert MolmoAct2Config().dtype == "bfloat16"
     assert MolmoAct2Config(dtype="float32").dtype == "float32"
 
-    with pytest.raises(ValueError, match="Unsupported dtype"):
-        MolmoAct2Config(dtype="float64")
-
-    with pytest.raises(ValueError, match="Unsupported dtype"):
-        MolmoAct2Config(dtype="float16")
+    assert MolmoAct2Config(dtype="float64").dtype == "float64"
+    assert MolmoAct2Config(dtype="float16").dtype == "float16"
+    with pytest.raises(ValueError, match="Invalid dtype"):
+        MolmoAct2Config(dtype="int8")
 
 
 def test_molmoact2_pi05_compile_defaults():
@@ -2441,7 +2440,7 @@ def test_bfloat16_parameter_policy_keeps_action_expert_float32():
     policy.config = SimpleNamespace(dtype="bfloat16")
     policy.model = DummyModel()
 
-    policy._apply_bfloat16_parameter_policy()
+    policy.post_init()
 
     assert policy.model.lm_head.weight.dtype == torch.bfloat16
     assert policy.model.model.transformer.matrix.weight.dtype == torch.bfloat16
@@ -2459,8 +2458,8 @@ def test_bfloat16_parameter_policy_keeps_action_expert_float32():
     rotary_emb = policy.model.model.transformer.rotary_emb
     assert rotary_emb.inv_freq.dtype == torch.float32
     assert rotary_emb.original_inv_freq is rotary_emb.inv_freq
-    assert rotary_emb._pos_sin_cache.numel() == 0
-    assert rotary_emb._pos_cos_cache.numel() == 0
+    assert rotary_emb._pos_sin_cache.dtype == torch.float32
+    assert rotary_emb._pos_cos_cache.dtype == torch.float32
 
     optimizer = torch.optim.AdamW(policy.model.model.action_expert.block.parameters())
     with policy._autocast_context():
@@ -2478,7 +2477,7 @@ def test_bfloat16_parameter_policy_keeps_action_expert_float32():
     float32_policy.config = SimpleNamespace(dtype="float32")
     float32_policy.model = DummyModel()
 
-    float32_policy._apply_bfloat16_parameter_policy()
+    float32_policy.post_init()
 
     assert all(param.dtype == torch.float32 for param in float32_policy.model.parameters())
 
@@ -2638,11 +2637,12 @@ def test_bfloat16_policy_autocast_bridges_fp32_heads_to_bf16_blocks():
     policy = object.__new__(MolmoAct2Policy)
     torch.nn.Module.__init__(policy)
     policy.config = SimpleNamespace(dtype="bfloat16")
-    policy.fp32_head = torch.nn.Linear(4, 4).to(dtype=torch.float32)
+    policy._fp32_modules = ("action_expert",)
+    policy.action_expert = torch.nn.Linear(4, 4).to(dtype=torch.float32)
     policy.bf16_block = torch.nn.Linear(4, 4).to(dtype=torch.bfloat16)
 
     with policy._autocast_context():
-        hidden = policy.fp32_head(torch.ones(2, 4, dtype=torch.float32))
+        hidden = policy.action_expert(torch.ones(2, 4, dtype=torch.float32))
         output = policy.bf16_block(hidden)
 
     assert hidden.dtype == torch.bfloat16
@@ -2669,7 +2669,7 @@ def test_bfloat16_policy_rejects_device_without_autocast(monkeypatch):
     policy = object.__new__(MolmoAct2Policy)
     torch.nn.Module.__init__(policy)
     policy.config = SimpleNamespace(dtype="bfloat16")
-    policy.layer = torch.nn.Linear(2, 2)
+    policy.layer = torch.nn.Linear(2, 2).bfloat16()
     monkeypatch.setattr(
         torch.amp.autocast_mode,
         "is_autocast_available",
@@ -2680,7 +2680,7 @@ def test_bfloat16_policy_rejects_device_without_autocast(monkeypatch):
         policy._autocast_context()
 
 
-def test_bfloat16_checkpoint_reload_happens_after_dtype_tree_is_applied(monkeypatch):
+def test_bfloat16_initialization_preserves_original_fp32_checkpoint_values(monkeypatch):
     class DummyTransformer(torch.nn.Module):
         def __init__(self):
             super().__init__()
@@ -2736,8 +2736,8 @@ def test_bfloat16_checkpoint_reload_happens_after_dtype_tree_is_applied(monkeypa
 
     def fake_strict_load(model, checkpoint_location):
         assert checkpoint_location == "/tmp/bfloat16-checkpoint"
-        assert model.model.transformer.matrix.weight.dtype == torch.bfloat16
-        assert model.model.vision_backbone.weight.dtype == torch.bfloat16
+        assert model.model.transformer.matrix.weight.dtype == torch.float32
+        assert model.model.vision_backbone.weight.dtype == torch.float32
         assert model.model.action_expert.action_embed.weight.dtype == torch.float32
         assert model.model.action_expert.block.weight.dtype == torch.float32
         assert model.model.transformer.rotary_emb.inv_freq.dtype == torch.float32
@@ -2769,8 +2769,10 @@ def test_bfloat16_checkpoint_reload_happens_after_dtype_tree_is_applied(monkeypa
     )
 
     policy._load_hf_model()
+    policy.post_init()
+    assert policy.dtype == torch.bfloat16
 
-    assert load_dtype is torch.bfloat16
+    assert load_dtype is torch.float32
     assert torch.equal(policy.model.model.action_expert.action_embed.weight, action_sentinel)
     rotary_emb = policy.model.model.transformer.rotary_emb
     assert torch.equal(rotary_emb.inv_freq, rope_sentinel)

--- a/tests/policies/test_policy_dtype_integration.py
+++ b/tests/policies/test_policy_dtype_integration.py
@@ -1,0 +1,172 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import draccus
+import pytest
+import torch
+
+from lerobot.policies.act.configuration_act import ACTConfig
+from lerobot.policies.pi0.configuration_pi0 import PI0Config
+from lerobot.policies.pi0_fast.configuration_pi0_fast import PI0FastConfig
+from lerobot.policies.pi05.configuration_pi05 import PI05Config
+from lerobot.utils.dtype import get_dtype
+
+
+@pytest.mark.parametrize("name", ["pi0", "pi05"])
+@pytest.mark.parametrize("dtype", ["float32", "bfloat16", "float16"])
+def test_pi_real_layers_initialize_run_and_reload_with_shared_precision(name, dtype, monkeypatch, tmp_path):
+    """Use the actual PI attention/vision/action layers, with tiny dimensions and no downloads."""
+    import importlib
+
+    pytest.importorskip("transformers")
+    from lerobot.configs.types import FeatureType, PolicyFeature
+    from lerobot.utils.constants import ACTION, OBS_STATE
+
+    module = importlib.import_module(f"lerobot.policies.{name}.modeling_{name}")
+    policy_cls = getattr(module, f"{name.upper()}Policy")
+    monkeypatch.setattr(
+        module,
+        "get_gemma_config",
+        lambda variant: module.GemmaConfig(
+            width=32, depth=1, mlp_dim=64, num_heads=8, num_kv_heads=1, head_dim=4
+        ),
+    )
+    paligemma_cls = module.PaliGemmaForConditionalGenerationWithPiGemma
+    expert_cls = module.PiGemmaForCausalLM
+
+    def small_paligemma(config):
+        config.text_config.vocab_size = 32
+        config.image_token_index = 31
+        vision = config.vision_config
+        vision.hidden_size = 32
+        vision.intermediate_size = 64
+        vision.num_hidden_layers = 1
+        vision.num_attention_heads = 4
+        vision.patch_size = 8
+        vision.projection_dim = 32
+        return paligemma_cls(config)
+
+    def small_expert(config):
+        config.vocab_size = 32
+        return expert_cls(config)
+
+    monkeypatch.setattr(module, "PaliGemmaForConditionalGenerationWithPiGemma", small_paligemma)
+    monkeypatch.setattr(module, "PiGemmaForCausalLM", small_expert)
+    compile_dtypes = []
+
+    def record_compile(fn, **kwargs):
+        core = fn.__self__
+        layer = core.paligemma_with_expert.gemma_expert.model.layers[0]
+        compile_dtypes.append((layer.self_attn.q_proj.weight.dtype, core.action_out_proj.weight.dtype))
+        return fn
+
+    monkeypatch.setattr(torch, "compile", record_compile)
+    config = policy_cls.config_class(
+        dtype=dtype,
+        device="cpu",
+        image_resolution=(16, 16),
+        max_action_dim=4,
+        max_state_dim=4,
+        chunk_size=2,
+        n_action_steps=2,
+        num_inference_steps=1,
+        compile_model=True,
+        input_features={
+            OBS_STATE: PolicyFeature(FeatureType.STATE, (4,)),
+            "observation.images.camera": PolicyFeature(FeatureType.VISUAL, (3, 16, 16)),
+        },
+        output_features={ACTION: PolicyFeature(FeatureType.ACTION, (4,))},
+    )
+    policy = policy_cls(config)
+    assert compile_dtypes == [(get_dtype(dtype), torch.float32)] * 2
+    assert policy.dtype == get_dtype(dtype)
+    assert policy.model.action_out_proj.weight.dtype == torch.float32
+    backbone = policy.model.paligemma_with_expert
+    assert backbone.paligemma.model.language_model.norm.weight.dtype == torch.float32
+    for tower in (backbone.paligemma.model.language_model, backbone.gemma_expert.model):
+        assert tower.rotary_emb.inv_freq.dtype == get_dtype(dtype)
+        for layer in tower.layers:
+            assert all(p.dtype == torch.float32 for p in layer.input_layernorm.parameters())
+            assert all(p.dtype == torch.float32 for p in layer.post_attention_layernorm.parameters())
+    assert all(p.dtype == torch.float32 for p in backbone.paligemma.model.multi_modal_projector.parameters())
+    assert (
+        backbone.paligemma.model.vision_tower.vision_model.embeddings.patch_embedding.weight.dtype
+        == torch.float32
+    )
+    assert backbone.gemma_expert.model.layers[0].self_attn.q_proj.weight.dtype == get_dtype(dtype)
+    batch = {
+        OBS_STATE: torch.randn(1, 4),
+        ACTION: torch.randn(1, 2, 4),
+        "observation.images.camera": torch.rand(1, 3, 16, 16),
+        "observation.language.tokens": torch.tensor([[1, 2, 3]]),
+        "observation.language.attention_mask": torch.ones(1, 3, dtype=torch.bool),
+    }
+    loss, _ = policy(batch)
+    assert torch.isfinite(loss)
+    loss.backward()
+    assert policy.model.action_out_proj.weight.grad.dtype == torch.float32
+    with torch.no_grad():
+        assert torch.isfinite(policy.predict_action_chunk(batch)).all()
+        policy.model.action_out_proj.weight.fill_(1.000123)
+    policy.save_pretrained(tmp_path)
+    restored = policy_cls.from_pretrained(tmp_path, dtype=dtype)
+    assert restored.dtype == get_dtype(dtype)
+    assert not restored.training
+    assert torch.equal(policy.model.action_out_proj.weight, restored.model.action_out_proj.weight)
+
+
+@pytest.mark.parametrize("dtype", ["float16", "bfloat16", "float32"])
+def test_act_inference_uses_parameter_dtype_for_generated_latents(dtype):
+    from lerobot.configs.types import FeatureType, PolicyFeature
+    from lerobot.policies.act.modeling_act import ACTPolicy
+    from lerobot.utils.constants import ACTION, OBS_ENV_STATE, OBS_STATE
+
+    config = ACTConfig(
+        device="cpu",
+        dtype=dtype,
+        chunk_size=2,
+        n_action_steps=2,
+        use_vae=False,
+        dim_model=32,
+        n_heads=2,
+        dim_feedforward=64,
+        n_encoder_layers=1,
+        n_decoder_layers=1,
+        input_features={
+            OBS_STATE: PolicyFeature(FeatureType.STATE, (4,)),
+            OBS_ENV_STATE: PolicyFeature(FeatureType.ENV, (4,)),
+        },
+        output_features={ACTION: PolicyFeature(FeatureType.ACTION, (3,))},
+    )
+    policy = ACTPolicy(config).eval()
+    batch = {key: torch.zeros(1, 4, dtype=policy.dtype) for key in config.input_features}
+    with torch.no_grad():
+        actions = policy.predict_action_chunk(batch)
+    assert actions.dtype == get_dtype(dtype)
+    assert actions.shape == (1, 2, 3)
+    assert torch.isfinite(actions).all()
+
+
+@pytest.mark.parametrize("config_class", [PI0Config, PI05Config, PI0FastConfig])
+def test_pi_configs_keep_explicit_float32_default(config_class):
+    previous = torch.get_default_dtype()
+    try:
+        torch.set_default_dtype(torch.float64)
+        config = config_class(device="cpu")
+        assert config.dtype == "float32"
+        with draccus.config_type("json"):
+            override = draccus.parse(config_class, args=["--device=cpu", "--dtype=bfloat16"])
+        assert override.dtype == "bfloat16"
+    finally:
+        torch.set_default_dtype(previous)

--- a/tests/policies/test_pretrained_dtype.py
+++ b/tests/policies/test_pretrained_dtype.py
@@ -1,0 +1,392 @@
+# Copyright 2026 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+import draccus
+import pytest
+import torch
+from safetensors.torch import save_file
+from torch import nn
+
+from lerobot.configs import PreTrainedConfig
+from lerobot.policies.act.configuration_act import ACTConfig
+from lerobot.policies.pretrained import PreTrainedPolicy
+from lerobot.utils.dtype import get_dtype
+
+
+class TinyPolicy(PreTrainedPolicy):
+    config_class = ACTConfig
+    name = "dtype_test"
+    _fp32_modules = ("head", "rotary_emb.inv_freq")
+
+    def __init__(self, config):
+        super().__init__(config)
+        # A protected parameter comes first; it must not hide the main model dtype.
+        self.head = nn.Linear(4, 4)
+        self.backbone = nn.Linear(4, 4)
+        self.head_extra = nn.Linear(4, 4)
+        self.rotary_emb = nn.Module()
+        self.rotary_emb.register_buffer("inv_freq", torch.tensor([1.000123, 0.500321]))
+        self.register_buffer("indices", torch.arange(4))
+        self.register_buffer("scale", torch.ones(4), persistent=False)
+        self.head.weight.data.fill_(1.000123)
+        self.post_init()
+
+    def get_optim_params(self):
+        return self.parameters()
+
+    def reset(self):
+        pass
+
+    def forward(self, batch):
+        x = self.backbone(batch.to(self.backbone.weight.dtype))
+        return self.head(x.to(self.head.weight.dtype)).sum(), {}
+
+    def predict_action_chunk(self, batch, **kwargs):
+        return self.forward(batch)[0]
+
+    def select_action(self, batch, **kwargs):
+        return self.predict_action_chunk(batch)
+
+
+@pytest.mark.parametrize("dtype", ["float16", "bfloat16", "float32", "float64"])
+def test_initialization_preserves_fp32_values_and_buffer_types(dtype):
+    policy = TinyPolicy(ACTConfig(device="cpu", dtype=dtype))
+    assert policy.dtype == get_dtype(dtype)
+    assert policy.backbone.weight.dtype == get_dtype(dtype)
+    assert policy.head_extra.weight.dtype == get_dtype(dtype)  # component boundaries, not substrings
+    assert policy.scale.dtype == get_dtype(dtype)
+    assert policy.indices.dtype == torch.int64
+    assert policy.head.weight.dtype == torch.float32
+    assert torch.equal(policy.head.weight, torch.full((4, 4), 1.000123))
+    assert torch.equal(policy.rotary_emb.inv_freq, torch.tensor([1.000123, 0.500321]))
+
+    loss, _ = policy(torch.ones(2, 4))
+    loss.backward()
+    assert policy.head.weight.grad.dtype == torch.float32
+    assert policy.backbone.weight.grad.dtype == get_dtype(dtype)
+
+
+@pytest.mark.parametrize("dtype", ["int64", "auto", "fp16", "float8_e4m3fn", torch.int64, 16, {}])
+def test_invalid_config_dtype_fails_before_model_construction(dtype):
+    with pytest.raises(ValueError, match="Invalid dtype"):
+        ACTConfig(device="cpu", dtype=dtype)
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, "float32"])
+def test_load_dtype_override_keeps_checkpoint_values_and_updates_supplied_config(tmp_path, dtype):
+    original = TinyPolicy(ACTConfig(device="cpu", dtype="float32"))
+    original.save_pretrained(tmp_path)
+    config = ACTConfig(device="cpu", dtype="float64")
+    policy = TinyPolicy.from_pretrained(tmp_path, config=config, dtype=dtype, strict=True)
+    assert policy.config is config
+    assert policy.dtype == get_dtype(dtype)
+    assert policy.config.dtype == str(get_dtype(dtype)).removeprefix("torch.")
+    assert config.pretrained_path == tmp_path
+    assert not policy.training
+    assert torch.equal(policy.head.weight, original.head.weight)
+    assert torch.equal(policy.rotary_emb.inv_freq, original.rotary_emb.inv_freq)
+    assert torch.equal(policy.backbone.weight, original.backbone.weight.to(get_dtype(dtype)))
+
+
+def test_save_reload_uses_effective_dtype_after_explicit_to(tmp_path):
+    policy = TinyPolicy(ACTConfig(device="cpu", dtype="float32"))
+    assert type(policy).to is nn.Module.to
+    policy.to(dtype=torch.bfloat16)
+    assert policy.dtype == torch.bfloat16
+    assert policy.head.weight.dtype == torch.bfloat16
+    assert policy.rotary_emb.inv_freq.dtype == torch.bfloat16
+    policy.save_pretrained(tmp_path)
+    saved = json.loads((tmp_path / "config.json").read_text())
+    assert saved["dtype"] == "bfloat16"
+    assert "torch_dtype" not in saved
+    loaded = TinyPolicy.from_pretrained(tmp_path, strict=True)
+    assert loaded.dtype == torch.bfloat16
+    assert loaded.head.weight.dtype == torch.float32
+
+
+@pytest.mark.parametrize("config_dtype, expected", [(None, torch.bfloat16), ("float32", torch.float32)])
+def test_auto_uses_config_then_checkpoint_without_materializing_meta_tensors(
+    tmp_path, config_dtype, expected
+):
+    config = ACTConfig(device="cpu", dtype=config_dtype)
+    config.save_pretrained(tmp_path)
+    weights = TinyPolicy(ACTConfig(device="cpu")).to(torch.bfloat16).state_dict()
+    save_file(weights, tmp_path / "model.safetensors")
+    policy = TinyPolicy.from_pretrained(tmp_path, dtype="auto", strict=True)
+    assert policy.dtype == expected
+    assert all(not tensor.is_meta for tensor in policy.parameters())
+
+
+def test_config_cli_and_serialization_use_shared_dtype(tmp_path):
+    with draccus.config_type("json"):
+        config = draccus.parse(ACTConfig, args=["--dtype=bfloat16", "--device=cpu"])
+    config.save_pretrained(tmp_path)
+    restored = PreTrainedConfig.from_pretrained(tmp_path)
+    assert restored.dtype == "bfloat16"
+    assert ACTConfig(dtype=torch.float16, device="cpu").dtype == "float16"
+
+
+def test_post_init_preserves_parameter_identity_ties_and_gradients():
+    policy = TinyPolicy(ACTConfig(device="cpu", dtype="float32"))
+    policy.alias = nn.Linear(4, 4)
+    policy.alias.weight = policy.head.weight
+    param = policy.head.weight
+    param.grad = torch.full_like(param, 1.000123)
+    policy.config.dtype = "bfloat16"
+    policy.post_init()
+    assert policy.head.weight is policy.alias.weight is param
+    assert {"head.weight", "alias.weight"} <= policy._fp32_tensor_names
+    assert param.dtype == param.grad.dtype == torch.float32
+    assert torch.equal(param.grad, torch.full_like(param, 1.000123))
+    assert policy.alias.bias.dtype == torch.bfloat16
+
+
+def test_default_dtype_is_resolved_without_changing_global_state():
+    previous = torch.get_default_dtype()
+    try:
+        torch.set_default_dtype(torch.float64)
+        policy = TinyPolicy(ACTConfig(device="cpu"))
+        assert policy.dtype == torch.float64
+        assert policy.config.dtype == "float64"
+        assert torch.get_default_dtype() == torch.float64
+    finally:
+        torch.set_default_dtype(previous)
+
+
+def test_unspecified_dtype_is_preserved_until_post_init_and_then_saved(tmp_path):
+    class DeferredDtypePolicy(TinyPolicy):
+        def post_init(self):
+            assert self.config.dtype is None
+            super().post_init()
+
+    config = ACTConfig(device="cpu")
+    assert config.dtype is None
+    policy = DeferredDtypePolicy(config)
+    assert policy.config is config
+    assert config.dtype == str(policy.dtype).removeprefix("torch.")
+    config.save_pretrained(tmp_path)
+    assert json.loads((tmp_path / "config.json").read_text())["dtype"] == config.dtype
+
+
+@pytest.mark.parametrize("from_checkpoint", [False, True])
+def test_post_init_records_actual_dtype_when_all_tensors_are_fp32_exceptions(tmp_path, from_checkpoint):
+    class FP32OnlyPolicy(TinyPolicy):
+        _fp32_modules = ("head", "backbone", "head_extra", "rotary_emb", "scale")
+
+    policy = FP32OnlyPolicy(ACTConfig(device="cpu", dtype="bfloat16"))
+    if from_checkpoint:
+        policy.save_pretrained(tmp_path / "checkpoint")
+        policy = FP32OnlyPolicy.from_pretrained(tmp_path / "checkpoint", dtype=torch.bfloat16, strict=True)
+
+    assert all(parameter.dtype == torch.float32 for parameter in policy.parameters())
+    assert policy.dtype == torch.float32
+    assert policy.config.dtype == "float32"
+    policy.config.save_pretrained(tmp_path / "config_only")
+    assert json.loads((tmp_path / "config_only" / "config.json").read_text())["dtype"] == "float32"
+
+
+def test_empty_and_buffer_only_policy_dtype():
+    policy = TinyPolicy(ACTConfig(device="cpu", dtype="bfloat16"))
+    del policy.head, policy.backbone, policy.head_extra, policy.rotary_emb
+    assert policy.dtype == torch.bfloat16
+    del policy.scale
+    assert policy.dtype == torch.bfloat16
+
+
+def test_hub_loading_forwards_download_options(tmp_path, monkeypatch):
+    TinyPolicy(ACTConfig(device="cpu")).save_pretrained(tmp_path)
+    calls = []
+
+    def download(**kwargs):
+        calls.append(kwargs)
+        return str(tmp_path / kwargs["filename"])
+
+    monkeypatch.setattr("lerobot.policies.pretrained.hf_hub_download", download)
+    policy = TinyPolicy.from_pretrained(
+        "owner/policy",
+        config=ACTConfig(device="cpu"),
+        dtype="float16",
+        revision="commit",
+        cache_dir=tmp_path,
+        local_files_only=True,
+        force_download=True,
+    )
+    assert policy.dtype == torch.float16
+    assert calls[0]["revision"] == "commit"
+    assert calls[0]["local_files_only"] is True
+    assert calls[0]["force_download"] is True
+
+
+def test_missing_weights_fail_instead_of_returning_random_model(tmp_path):
+    ACTConfig(device="cpu").save_pretrained(tmp_path)
+    with pytest.raises(FileNotFoundError):
+        TinyPolicy.from_pretrained(tmp_path)
+
+
+@pytest.mark.parametrize("dtype", ["bfloat16", "float16"])
+def test_fp32_paths_are_rooted_and_wildcards_match_one_level(dtype):
+    class ScopedPolicy(TinyPolicy):
+        _fp32_modules = (
+            "model.wrapper.backbone.norm",
+            "model.wrapper.backbone.layers.*.input_layernorm",
+            "model.wrapper.backbone.inv_freq",
+        )
+
+    class Block(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.norm = nn.LayerNorm(4)
+            self.norm.register_buffer("steps", torch.tensor(7))
+            self.norm_extra = nn.LayerNorm(4)
+            self.layers = nn.ModuleList(
+                [
+                    nn.ModuleDict(
+                        {
+                            "input_layernorm": nn.LayerNorm(4),
+                            "input_layernorm_extra": nn.LayerNorm(4),
+                            "nested": nn.ModuleDict({"input_layernorm": nn.LayerNorm(4)}),
+                        }
+                    )
+                ]
+            )
+            self.register_buffer("inv_freq", torch.tensor([1.000123]), persistent=False)
+            self.register_buffer("inv_freq_extra", torch.tensor([1.000123]))
+
+    policy = ScopedPolicy(ACTConfig(device="cpu", dtype="float32"))
+    scoped = Block()
+    policy.model = nn.ModuleDict({"wrapper": nn.ModuleDict({"backbone": scoped})})
+    policy.norm = nn.LayerNorm(4)
+    policy.modelXwrapperXbackbone = nn.ModuleDict({"norm": nn.LayerNorm(4)})
+    prefix = "model.wrapper.backbone."
+    assert policy._fp32_tensor_names == {
+        prefix + name
+        for name in (
+            "norm.weight",
+            "norm.bias",
+            "layers.0.input_layernorm.weight",
+            "layers.0.input_layernorm.bias",
+            "inv_freq",
+        )
+    }
+    assert prefix + "inv_freq" not in policy.state_dict()
+    policy.config.dtype = dtype
+    policy.post_init()
+    assert scoped.norm.weight.dtype == torch.float32
+    assert scoped.layers[0].input_layernorm.weight.dtype == torch.float32
+    assert scoped.inv_freq.dtype == torch.float32
+    assert torch.equal(scoped.inv_freq, torch.tensor([1.000123]))
+    assert scoped.norm_extra.weight.dtype == get_dtype(dtype)
+    assert scoped.layers[0].input_layernorm_extra.weight.dtype == get_dtype(dtype)
+    assert scoped.layers[0].nested.input_layernorm.weight.dtype == get_dtype(dtype)
+    assert scoped.inv_freq_extra.dtype == get_dtype(dtype)
+    assert policy.norm.weight.dtype == get_dtype(dtype)
+    assert policy.modelXwrapperXbackbone.norm.weight.dtype == get_dtype(dtype)
+    assert scoped.norm.steps.dtype == torch.int64
+
+
+def test_fp32_short_paths_only_match_at_the_policy_root():
+    class NormPolicy(TinyPolicy):
+        _fp32_modules = ("norm",)
+
+    policy = NormPolicy(ACTConfig(device="cpu", dtype="float32"))
+    policy.norm = nn.LayerNorm(4)
+    policy.norm_extra = nn.LayerNorm(4)
+    policy.model = nn.ModuleDict({"norm": nn.LayerNorm(4), "norm_extra": nn.LayerNorm(4)})
+    policy.config.dtype = "bfloat16"
+    policy.post_init()
+    assert policy._fp32_tensor_names == {"norm.weight", "norm.bias"}
+    assert policy.norm.weight.dtype == torch.float32
+    assert policy.norm_extra.weight.dtype == torch.bfloat16
+    assert policy.model.norm.weight.dtype == torch.bfloat16
+    assert policy.model.norm_extra.weight.dtype == torch.bfloat16
+    assert policy.backbone.weight.dtype == torch.bfloat16
+
+
+def test_only_top_level_policy_fp32_declarations_are_used():
+    class Block(nn.Module):
+        _fp32_modules = ("norm",)
+
+        def __init__(self):
+            super().__init__()
+            self.norm = nn.LayerNorm(4)
+
+    policy = TinyPolicy(ACTConfig(device="cpu", dtype="float32"))
+    policy.model = Block()
+    policy.config.dtype = "bfloat16"
+    policy.post_init()
+    assert policy.model.norm.weight.dtype == torch.bfloat16
+    assert "model.norm.weight" not in policy._fp32_tensor_names
+
+
+@pytest.mark.parametrize("matching_alias", ["head", "alias"])
+def test_fp32_tensor_names_include_all_aliases_without_matching_equal_tensors(matching_alias):
+    policy = TinyPolicy(ACTConfig(device="cpu", dtype="float32"))
+    policy._fp32_modules = (f"{matching_alias}.weight", "inv_freq_alias")
+    policy.alias = nn.Linear(4, 4)
+    policy.alias.weight = policy.head.weight  # head is enumerated before the protected alias
+    policy.head_alias = policy.head
+    policy.rotary_alias = policy.rotary_emb
+    policy.register_buffer("inv_freq_alias", policy.rotary_emb.inv_freq, persistent=False)
+    policy.equal_weight = nn.Parameter(policy.head.weight.detach().clone())
+    policy.equal_weight.grad = torch.full_like(policy.equal_weight, 1.000123)
+    assert policy._fp32_tensor_names == {
+        "head.weight",
+        "alias.weight",
+        "head_alias.weight",
+        "rotary_emb.inv_freq",
+        "rotary_alias.inv_freq",
+        "inv_freq_alias",
+    }
+    original = policy.head.weight.detach().clone()
+    policy.config.dtype = "bfloat16"
+    policy.post_init()
+    assert policy.alias.weight is policy.head.weight
+    assert policy.head.weight.dtype == torch.float32
+    assert torch.equal(policy.head.weight, original)
+    assert policy.inv_freq_alias is policy.rotary_emb.inv_freq
+    assert torch.equal(policy.inv_freq_alias, torch.tensor([1.000123, 0.500321]))
+    assert policy.equal_weight.dtype == policy.equal_weight.grad.dtype == torch.bfloat16
+    assert policy.alias.bias.dtype == torch.bfloat16
+    assert policy.dtype == torch.bfloat16
+    assert policy.config.dtype == "bfloat16"
+
+
+def test_fp32_tensor_names_follow_current_registrations_without_casting():
+    policy = TinyPolicy(ACTConfig(device="cpu", dtype="float32"))
+    original_names = policy._fp32_tensor_names
+    policy.alias = nn.Linear(4, 4)
+    policy.alias.weight = policy.head.weight
+    assert policy._fp32_tensor_names == original_names | {"alias.weight"}
+    policy.alias.weight = nn.Parameter(policy.alias.weight.detach().clone())
+    assert policy._fp32_tensor_names == original_names
+    policy.head.register_buffer("new_buffer", torch.ones(4), persistent=False)
+    assert policy._fp32_tensor_names == original_names | {"head.new_buffer"}
+    policy.to(dtype=torch.bfloat16)
+    assert policy._fp32_tensor_names == original_names | {"head.new_buffer"}
+    assert policy.head.weight.dtype == torch.bfloat16  # Reading the property does not enforce FP32.
+    assert policy.config.dtype == "float32"
+    del policy.head
+    assert policy._fp32_tensor_names == {"rotary_emb.inv_freq"}
+
+
+@pytest.mark.parametrize("path", ["", ".norm", "model..norm", "model.**.norm", "model.norm*"])
+def test_invalid_fp32_paths_fail_before_casting(path):
+    policy = TinyPolicy(ACTConfig(device="cpu", dtype="float32"))
+    policy._fp32_modules = (path,)
+    policy.config.dtype = "bfloat16"
+    with pytest.raises(ValueError, match="Invalid FP32 path"):
+        policy.post_init()
+    assert policy.backbone.weight.dtype == torch.float32

--- a/tests/policies/vla_jepa/conftest.py
+++ b/tests/policies/vla_jepa/conftest.py
@@ -193,10 +193,6 @@ class _FakeQwenInterface(nn.Module):
         self.config = config
         self.model = _FakeQwenBackbone(hidden_size=QWEN_HIDDEN_SIZE)
 
-    @staticmethod
-    def _get_torch_dtype(dtype_name: str) -> torch.dtype:
-        return torch.float32 if dtype_name == "float32" else torch.bfloat16
-
     def expand_tokenizer(self) -> tuple[list[str], list[int], int]:
         max_action_tokens = self.config.chunk_size * self.config.num_action_tokens_per_timestep
         action_tokens = [self.config.special_action_token.format(idx) for idx in range(max_action_tokens)]


### PR DESCRIPTION
## Title

refactor(policies): adopt shared dtype management across policies

## Summary / Motivation

Existing policies use different fields, casts and checkpoint loaders to manage parameter precision. With the shared dtype API available, this PR migrates those implementations to `config.dtype` and `post_init()`. The changes retain each model's declared FP32 requirements while making initialization and loading follow the common policy contract.

## Related issues

[PR1 #4595](https://github.com/huggingface/lerobot/pull/4595)

## What changed

- Integrate `post_init()` into concrete policies.
- Replace independent parameter-precision fields such as `vlm_dtype` and `torch_dtype` with `dtype`.
- Declare FP32 exceptions with complete policy-root paths for the relevant action heads, projections, vision paths, norms and buffers.
- Load EO1's Qwen backbone in the configured dtype, retain its FP32 flow-matching projections.
- Standardize local loader arguments as `dtype` and align generated tensors/activations with the receiving parameters.
- Update EVO1/FastWAM usage examples and policy.

## How was this tested (or how to run locally)


```bash
uv run pytest -q \
  tests/policies/test_pretrained_dtype.py \
  tests/policies/test_policy_dtype_integration.py \
  tests/policies/test_pi_gemma.py \
  tests/policies/pi0_pi05/test_pi05_memory.py \
  tests/policies/eo1 tests/policies/evo1 tests/policies/fastwam \
  tests/policies/lingbot_va \
  tests/policies/groot/test_groot_n1_7.py \
  tests/policies/groot/test_groot_training_optim_contract.py \
  tests/policies/molmoact2 tests/policies/smolvla \
  tests/policies/vla_jepa tests/policies/wall_x \
  tests/common tests/configs
```

Local CPU validation of the foundation plus policy migrations: **534 passed, 18 skipped**. All pre-commit hooks passed.

## Checklist (required before merge)

- [x] Linting/formatting run on the changed files
- [x] Scoped tests pass locally
- [x] Documentation updated
- [ ] CI is green
- [ ] Community Review: I have reviewed another contributor's open PR and linked it here

## Reviewer notes


Please focus on the timing of `post_init()`, model-specific FP32 declarations, checkpoint-key remapping, and dtype conversions at backbone/action-head boundaries.
