### PR TITLE
fix(config): keep list-valued YAML overrides when loading a policy from a path

### DIFF
--- a/src/lerobot/configs/parser.py
+++ b/src/lerobot/configs/parser.py
@@ -61,7 +61,11 @@ def _flatten_to_cli_args(d: dict, prefix: str = "") -> list[str]:
             value = str(value).lower()
         if isinstance(value, dict):
             args.extend(_flatten_to_cli_args(value, full_key))
-        elif value is not None and not isinstance(value, list):
+        elif isinstance(value, list):
+            # draccus decodes sequence fields (list[...], tuple[...]) from a JSON-ish
+            # literal, so serialize instead of dropping the value.
+            args.append(f"--{full_key}={json.dumps(value)}")
+        elif value is not None:
             args.append(f"--{full_key}={value}")
     return args
 

--- a/tests/test_yaml_policy_path.py
+++ b/tests/test_yaml_policy_path.py
@@ -6,6 +6,7 @@ import tempfile
 from dataclasses import dataclass, field
 from unittest.mock import patch
 
+import draccus
 import yaml
 
 from lerobot.configs import parser
@@ -230,6 +231,62 @@ def test_flatten_nested_with_bools():
     args = _flatten_to_cli_args(d)
     assert "--optimizer.use_warmup=true" in args
     assert "--optimizer.lr=0.01" in args
+
+
+@dataclass
+class _DummyPolicy:
+    down_dims: tuple[int, ...] = (512, 1024, 2048)
+    crop_shape: tuple[int, int] | None = None
+    image_keys: list[str] = field(default_factory=list)
+    n_obs_steps: int = 2
+
+
+def test_flatten_list_values_are_kept():
+    """Regression: list-valued YAML fields were dropped instead of forwarded.
+
+    Policy configs expose plenty of sequence fields (down_dims, crop_shape,
+    image_size, ...). Writing them next to `policy.path` in a YAML config used
+    to be silently ignored, while scalar siblings were applied.
+    """
+    d = {"down_dims": [256, 512, 1024], "image_keys": ["cam_high", "cam_low"], "n_obs_steps": 3}
+    args = _flatten_to_cli_args(d)
+
+    assert "--n_obs_steps=3" in args
+    assert any(a.startswith("--down_dims=") for a in args), f"down_dims dropped from {args}"
+    assert any(a.startswith("--image_keys=") for a in args), f"image_keys dropped from {args}"
+
+    # The emitted args must be consumable by draccus, not merely present.
+    cfg = draccus.parse(config_class=_DummyPolicy, args=args)
+    assert cfg.down_dims == (256, 512, 1024)
+    assert cfg.image_keys == ["cam_high", "cam_low"]
+    assert cfg.n_obs_steps == 3
+
+
+def test_yaml_list_override_survives_to_from_pretrained():
+    """A list field written next to `policy.path` must reach the loaded config."""
+    config = {
+        "policy": {
+            "path": "lerobot/diffusion_pusht",
+            "crop_shape": [76, 76],
+            "n_obs_steps": 3,
+        },
+    }
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+        yaml.dump(config, f)
+        config_path = f.name
+
+    _config_path_args.clear()
+    _config_yaml_overrides.clear()
+    extract_path_fields_from_config(config_path, ["policy"])
+
+    overrides = get_yaml_overrides("policy")
+    # `overrides` is what train.py/eval.py hand to PreTrainedConfig.from_pretrained.
+    cfg = draccus.parse(config_class=_DummyPolicy, args=overrides)
+    assert cfg.n_obs_steps == 3
+    assert cfg.crop_shape == (76, 76)
+
+    _config_path_args.clear()
+    _config_yaml_overrides.clear()
 
 
 def test_extract_removes_field_with_siblings_and_no_type():


### PR DESCRIPTION
## Summary / Motivation

If you fine-tune from a checkpoint using a YAML config, any **list-valued** field you write next to `policy.path` is silently ignored — training runs with the checkpoint's value and nothing is logged.

```yaml
# train.yaml
policy:
  path: lerobot/diffusion_pusht
  n_obs_steps: 3
  crop_shape: [76, 76]
```

```
lerobot-train --config_path=train.yaml ...
```

`n_obs_steps` is applied. `crop_shape` is not — the run uses the checkpoint's `(84, 84)`. Same for every other sequence field a policy exposes (`down_dims`, `image_size`, `resize_shape`, `image_keys`, `toggle_action_dimensions`, ...). Because the scalar siblings *do* land, there is no sign that half of the block was dropped.

### Cause

`policy.path` is not a real field on `PreTrainedConfig`, so `parser.extract_path_fields_from_config()` strips the whole `policy:` block out of the YAML before draccus sees it and re-serializes the siblings as CLI-style args via `_flatten_to_cli_args()`. `train.py` / `eval.py` / `rollout/configs.py` then pass those to `from_pretrained(..., cli_overrides=...)`.

`_flatten_to_cli_args()` skipped lists:

```python
elif value is not None and not isinstance(value, list):
    args.append(f"--{full_key}={value}")
```

so list values were dropped on the floor. This looks like an oversight from #3145, whose stated goal was "preserve YAML policy overrides"; the surrounding commits handled `None` and `bool` explicitly but never came back to sequences. draccus itself has no problem with them — `--crop_shape=[76, 76]` parses fine — so only the flattener was in the way.

## Related issues

- Related: #3145 (the PR that introduced `_flatten_to_cli_args`), #2957
- Related: #4605 — a separate defect in the same YAML-override mechanism (the `reward_model` branch never reads the captured overrides at all). Independent files, independent fixes; either can merge without the other.

## What changed

- `_flatten_to_cli_args()` now serializes list values with `json.dumps` instead of skipping them. `json.dumps` covers ints, floats, strings (including ones containing spaces or commas) and nested lists, and produces exactly the literal draccus decodes.
- No behaviour change for scalars, `None`, `bool` or nested dicts.
- Not a breaking change: fields that used to be ignored now take effect, which is what the YAML asked for.

## How was this tested (or how to run locally)

Environment: Windows 11, Python 3.12.10, CPU-only torch 2.11.0, `pip install -e ".[dataset,test]"`. No robot hardware, so nothing under `tests/robots`, `tests/teleoperators` or `tests/motors` was exercised; this change does not touch them.

**Reproduction** (no network, no checkpoint download — a stand-in `config.json` of the shape `save_pretrained` writes):

```python
# repro.py
import json, tempfile
from pathlib import Path
import yaml
from lerobot.configs import parser
from lerobot.configs.policies import PreTrainedConfig
from lerobot.policies.diffusion.configuration_diffusion import DiffusionConfig  # noqa: F401

tmp = Path(tempfile.mkdtemp())
ckpt = tmp / "diffusion_pusht"; ckpt.mkdir()
(ckpt / "config.json").write_text(json.dumps({"type": "diffusion", "crop_shape": [84, 84], "n_obs_steps": 2}))

train_yaml = tmp / "train.yaml"
train_yaml.write_text(yaml.dump({"policy": {"path": str(ckpt), "n_obs_steps": 3, "crop_shape": [76, 76]}}))

parser._config_path_args.clear(); parser._config_yaml_overrides.clear()
parser.extract_path_fields_from_config(str(train_yaml), ["policy"])
overrides = parser.get_yaml_overrides("policy")

# exactly what TrainPipelineConfig._resolve_pretrained_from_cli() does
cfg = PreTrainedConfig.from_pretrained(str(ckpt), cli_overrides=overrides)
print("yaml overrides forwarded :", overrides)
print("n_obs_steps  ->", cfg.n_obs_steps, " (yaml asked for 3)")
print("crop_shape   ->", cfg.crop_shape, " (yaml asked for [76, 76])")
```

Before (on `main` @ 71a11efe):

```
yaml overrides forwarded : ['--n_obs_steps=3']
n_obs_steps  -> 3  (yaml asked for 3)
crop_shape   -> (84, 84)  (yaml asked for [76, 76])
```

After:

```
yaml overrides forwarded : ['--crop_shape=[76, 76]', '--n_obs_steps=3']
n_obs_steps  -> 3  (yaml asked for 3)
crop_shape   -> (76, 76)  (yaml asked for [76, 76])
```

**Tests added** — two in `tests/test_yaml_policy_path.py`, both round-tripping the emitted args back through `draccus.parse` so the test proves the arg is *consumable*, not merely present:

- `test_flatten_list_values_are_kept`
- `test_yaml_list_override_survives_to_from_pretrained`

```
$ pytest tests/test_yaml_policy_path.py -q          # against unmodified main
FAILED tests/test_yaml_policy_path.py::test_flatten_list_values_are_kept
  AssertionError: down_dims dropped from ['--n_obs_steps=3']
FAILED tests/test_yaml_policy_path.py::test_yaml_list_override_survives_to_from_pretrained
  assert None == (76, 76)
2 failed, 14 passed in 1.57s

$ pytest tests/test_yaml_policy_path.py -q          # with this change
16 passed in 0.37s
```

Pinning what must keep working — the 14 pre-existing tests in that file (scalars, bools, `None`, nested dicts, JSON configs, the `wrap()` path) pass both before and after, plus the surrounding config suite:

```
$ pytest tests/test_yaml_policy_path.py tests/configs -q
75 passed, 5 skipped in 289.85s
```

```
$ ruff format --check src/lerobot/configs/parser.py tests/test_yaml_policy_path.py
2 files already formatted
$ ruff check src/lerobot/configs/parser.py tests/test_yaml_policy_path.py
All checks passed!
$ mypy src/lerobot/configs/parser.py          # lerobot.configs.* is strict
Success: no issues found in 1 source file
```

## Checklist (required before merge)

- [x] Linting/formatting run (`ruff format` + `ruff check`, the two `pre-commit` hooks that apply to these files)
- [x] Tests pass locally (`tests/test_yaml_policy_path.py`, `tests/configs`) — the full suite was not run end to end here; no robot hardware and no system ffmpeg, so hardware and torchcodec-backed tests were out of reach
- [ ] Documentation updated — not needed, no documented behaviour changes
- [ ] CI is green — pending
- [ ] Community Review — not done yet, so leaving this unchecked rather than claiming otherwise

## Reviewer notes

- The one thing worth a second opinion: `json.dumps` as the encoding. It is what draccus's own decoder accepts and it round-trips strings with spaces/commas correctly, but if there is a preferred serializer for CLI-shaped values in this codebase, happy to switch.
- Tuple-typed fields work too: draccus coerces the JSON list back into the annotated `tuple[...]`, which is why the test asserts `cfg.crop_shape == (76, 76)`.
- Per AI_POLICY.md: this change was drafted with the help of an AI coding assistant. Every command, output and number above comes from a run in the environment described; nothing is reconstructed from memory.
