### PR TITLE
fix(datasets): forward depth_output_unit to StreamingLeRobotDataset

### DIFF
--- a/src/lerobot/datasets/factory.py
+++ b/src/lerobot/datasets/factory.py
@@ -168,6 +168,7 @@ def make_dataset(cfg: TrainPipelineConfig) -> LeRobotDataset | MultiLeRobotDatas
                 max_num_shards=cfg.num_workers,
                 tolerance_s=cfg.tolerance_s,
                 return_uint8=True,
+                depth_output_unit=cfg.dataset.depth_output_unit,
                 repo_type=cfg.dataset.repo_type,
             )
     else:

--- a/tests/datasets/test_streaming.py
+++ b/tests/datasets/test_streaming.py
@@ -22,10 +22,14 @@ import torch
 
 pytest.importorskip("datasets", reason="datasets is required (install lerobot[dataset])")
 
+import lerobot.datasets.factory as factory_module
 import lerobot.datasets.streaming_dataset as streaming_dataset_module
+from lerobot.configs.default import DatasetConfig
+from lerobot.configs.train import TrainPipelineConfig
 from lerobot.datasets.dataset_metadata import LeRobotDatasetMetadata
 from lerobot.datasets.streaming_dataset import StreamingLeRobotDataset
 from lerobot.datasets.utils import safe_shard
+from lerobot.policies.factory import make_policy_config
 from lerobot.utils.constants import ACTION
 from tests.fixtures.constants import DUMMY_REPO_ID
 
@@ -645,3 +649,41 @@ def test_bucket_root_caches_metadata_without_switching_to_local_streaming(tmp_pa
 def test_invalid_repo_type_fails_before_io():
     with pytest.raises(ValueError, match="repo_type must be 'dataset' or 'bucket'"):
         StreamingLeRobotDataset(DUMMY_REPO_ID, repo_type="space")
+
+
+def test_make_dataset_forwards_depth_output_unit_to_streaming(tmp_path, lerobot_dataset_factory, monkeypatch):
+    """`--dataset.depth_output_unit` must reach the streaming dataset too.
+
+    make_dataset() forwards it to LeRobotDataset (both in make_dataset and in
+    make_train_eval_datasets), so flipping `--dataset.streaming` must not silently
+    change the physical unit depth maps are dequantized to.
+    """
+    root = tmp_path / "test"
+    lerobot_dataset_factory(root=root, repo_id=DUMMY_REPO_ID, total_episodes=1, total_frames=4)
+
+    captured: dict = {}
+
+    class _CaptureStreamingDataset:
+        def __init__(self, repo_id, **kwargs):
+            captured.update(kwargs)
+            self.meta = SimpleNamespace(camera_keys=[], depth_keys=[], stats={})
+
+    monkeypatch.setattr(factory_module, "StreamingLeRobotDataset", _CaptureStreamingDataset)
+    monkeypatch.setattr(
+        factory_module,
+        "load_dataset_metadata",
+        lambda *args, **kwargs: LeRobotDatasetMetadata(DUMMY_REPO_ID, root=root),
+    )
+
+    cfg = TrainPipelineConfig(
+        dataset=DatasetConfig(
+            repo_id=DUMMY_REPO_ID,
+            root=str(root),
+            streaming=True,
+            depth_output_unit="m",
+        ),
+        policy=make_policy_config("act"),
+    )
+    factory_module.make_dataset(cfg)
+
+    assert captured["depth_output_unit"] == "m"


### PR DESCRIPTION
## Summary / Motivation

Turning streaming on changes the physical unit your depth maps arrive in.

```
lerobot-train --dataset.repo_id=<depth dataset> --dataset.depth_output_unit=m ...   # metres
lerobot-train --dataset.repo_id=<depth dataset> --dataset.depth_output_unit=m --dataset.streaming=true ...   # millimetres
```

`DatasetConfig.depth_output_unit` validates the value and then `make_dataset()` forwards it to `LeRobotDataset` — but the `StreamingLeRobotDataset` branch of the same function does not pass it at all, so the constructor default (`"mm"`) wins. Nothing warns. A run configured for metres silently trains on values 1000× larger, and `meta.rescale_depth_stats()` rescales the normalization stats to match, so it stays self-consistently wrong rather than blowing up.

### Cause — one missing kwarg

`src/lerobot/datasets/factory.py` builds `LeRobotDataset` three times (once in `make_dataset`, twice in `make_train_eval_datasets`) and all three pass `depth_output_unit=cfg.dataset.depth_output_unit`. The single `StreamingLeRobotDataset(...)` call is the only construction site that omits it. `StreamingLeRobotDataset.__init__` accepts the argument and honours it (`self._depth_output_unit` feeds `dequantize_depth(..., output_unit=...)` and `meta.rescale_depth_stats(...)`), so nothing else needs changing.

This looks like a spot the depth plumbing in #3644 missed — that PR wired `depth_output_unit` through the reader, the writer, the encoder and the non-streaming factory path.

## Related issues

- Related: #3644 (the PR that introduced `depth_output_unit`)

## What changed

- `make_dataset()` now passes `depth_output_unit=cfg.dataset.depth_output_unit` to `StreamingLeRobotDataset`, matching the three sibling `LeRobotDataset` constructions in the same file.
- One line, no behaviour change for datasets without depth keys or for anyone leaving `depth_output_unit` at its `"mm"` default.

## How was this tested (or how to run locally)

Environment: Windows 11, Python 3.12.10, CPU-only torch 2.11.0, `pip install -e ".[dataset,test]"`. No robot hardware and **no system ffmpeg**, which matters below.

**Reproduction** — build the same config twice, once each way, and print the unit each dataset ended up with (throwaway test using the repo's own `lerobot_dataset_factory` fixture, no network):

```python
def test_repro(tmp_path, lerobot_dataset_factory, capsys):
    root = tmp_path / "test"
    lerobot_dataset_factory(root=root, repo_id=DUMMY_REPO_ID, total_episodes=2, total_frames=20,
                            use_videos=False)

    def build(streaming: bool):
        cfg = TrainPipelineConfig(
            dataset=DatasetConfig(repo_id=DUMMY_REPO_ID, root=str(root), streaming=streaming,
                                  depth_output_unit="m"),
            policy=make_policy_config("act"),
        )
        return make_dataset(cfg)

    with capsys.disabled():
        print("  streaming=false ->", build(False).depth_output_unit)
        print("  streaming=true  ->", build(True).depth_output_unit)
```

Before (on `main` @ 71a11efe), with `--dataset.depth_output_unit=m` requested in both runs:

```
  streaming=false -> m
  streaming=true  -> mm
```

After:

```
  streaming=false -> m
  streaming=true  -> m
```

**Test added** — `tests/datasets/test_streaming.py::test_make_dataset_forwards_depth_output_unit_to_streaming`, which captures the kwargs `make_dataset` hands to the streaming class:

```
$ pytest tests/datasets/test_streaming.py::test_make_dataset_forwards_depth_output_unit_to_streaming -q   # against unmodified main
>       assert captured["depth_output_unit"] == "m"
E       KeyError: 'depth_output_unit'
1 failed in 5.77s

$ pytest tests/datasets/test_streaming.py::test_make_dataset_forwards_depth_output_unit_to_streaming -q   # with this change
1 passed
```

Whole file, before and after:

```
$ pytest tests/datasets/test_streaming.py -q     # unmodified main
14 failed, 16 passed in 174.22s

$ pytest tests/datasets/test_streaming.py -q     # with this change
13 failed, 17 passed in 125.43s
```

**The 13 failures are identical before and after and are an environment limitation on my side, not a regression.** They are `test_single_frame_consistency`, `test_frames_order_over_epochs[*]`, `test_frames_order_with_shards[*]`, `test_frames_with_delta_consistency[*]` and `test_frames_with_delta_consistency_with_shards[*]` — every one of them decodes video, and `StreamingLeRobotDataset._query_videos()` calls `decode_video_frames_torchcodec` unconditionally for non-depth keys. This machine has no system ffmpeg, so torchcodec raises `RuntimeError: Could not load libtorchcodec` (`FileNotFoundError: Could not find module ...\torchcodec\libtorchcodec_core8.dll`). **I could not run those 13, so I am not claiming they pass — only that this change does not alter them.** The new test uses `use_videos` data but never decodes a frame, so it runs here.

```
$ ruff format --check src/lerobot/datasets/factory.py tests/datasets/test_streaming.py
1 file already formatted    # (per file)
$ ruff check src/lerobot/datasets/factory.py tests/datasets/test_streaming.py
All checks passed!
```

## Checklist (required before merge)

- [x] Linting/formatting run (`ruff format` + `ruff check` on both touched files)
- [ ] All tests pass locally — see above: the video-decoding streaming tests could not run here (no system ffmpeg), and they fail identically with and without this change
- [ ] Documentation updated — not needed
- [ ] CI is green — pending
- [ ] Community Review — not done yet, leaving unchecked rather than claiming otherwise

## Reviewer notes

- Worth confirming the intent: is `StreamingLeRobotDataset` meant to honour `depth_output_unit`, or was streaming deliberately pinned to millimetres? Its `__init__` takes and uses the parameter, so I read the omission in the factory as accidental — but you own that call.
- The new test asserts the kwarg is forwarded rather than decoding a depth video end to end, because the streaming depth path needs a real encoded FFV1 stream (and ffmpeg) to exercise. If you would rather have the heavier end-to-end version, say so and I will add it.
- Per AI_POLICY.md: drafted with the help of an AI coding assistant. Every command and number above comes from an actual run in the environment described.
