### PR TITLE
fix(tests): make the platform guards in test_process.py actually apply

### DIFF
--- a/tests/utils/test_process.py
+++ b/tests/utils/test_process.py
@@ -17,6 +17,7 @@
 import multiprocessing
 import os
 import signal
+import sys
 import threading
 from unittest.mock import patch
 
@@ -26,6 +27,20 @@ pytest.importorskip("datasets", reason="datasets is required (install lerobot[da
 
 from lerobot.utils.process import ProcessSignalHandler  # noqa: E402
 
+# SIGHUP and SIGQUIT are not defined on every platform (e.g. Windows). Look them up with
+# getattr: a bare `signal.SIGHUP` raises AttributeError while this module is being imported,
+# which aborts collection of the whole test session before any skip mark can apply.
+SIGHUP = getattr(signal, "SIGHUP", None)
+SIGQUIT = getattr(signal, "SIGQUIT", None)
+
+# On Windows, os.kill() only delivers CTRL_C_EVENT / CTRL_BREAK_EVENT; for any other signal it
+# calls TerminateProcess, so a process cannot send itself a catchable signal. Tests that rely on
+# it would kill the pytest process instead of exercising the handler.
+requires_self_signal = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="os.kill() cannot deliver a catchable signal to the current process on Windows",
+)
+
 
 # Fixture to reset shutdown_event_counter and original signal handlers before and after each test
 @pytest.fixture(autouse=True)
@@ -33,8 +48,8 @@ def reset_globals_and_handlers():
     # Store original signal handlers
     original_handlers = {
         sig: signal.getsignal(sig)
-        for sig in [signal.SIGINT, signal.SIGTERM, signal.SIGHUP, signal.SIGQUIT]
-        if hasattr(signal, sig.name)
+        for sig in [signal.SIGINT, signal.SIGTERM, SIGHUP, SIGQUIT]
+        if sig is not None
     }
 
     yield
@@ -60,6 +75,7 @@ def test_setup_process_handlers_event_with_processes():
     assert not shutdown_event.is_set(), "Event should initially be unset"
 
 
+@requires_self_signal
 @pytest.mark.parametrize("use_threads", [True, False])
 @pytest.mark.parametrize(
     "sig",
@@ -68,12 +84,14 @@ def test_setup_process_handlers_event_with_processes():
         signal.SIGTERM,
         # SIGHUP and SIGQUIT are not reliably available on all platforms (e.g. Windows)
         pytest.param(
-            signal.SIGHUP,
-            marks=pytest.mark.skipif(not hasattr(signal, "SIGHUP"), reason="SIGHUP not available"),
+            SIGHUP,
+            marks=pytest.mark.skipif(SIGHUP is None, reason="SIGHUP not available"),
+            id="SIGHUP",
         ),
         pytest.param(
-            signal.SIGQUIT,
-            marks=pytest.mark.skipif(not hasattr(signal, "SIGQUIT"), reason="SIGQUIT not available"),
+            SIGQUIT,
+            marks=pytest.mark.skipif(SIGQUIT is None, reason="SIGQUIT not available"),
+            id="SIGQUIT",
         ),
     ],
 )
@@ -95,6 +113,7 @@ def test_signal_handler_sets_event(use_threads, sig):
     assert handler.counter == 1
 
 
+@requires_self_signal
 @pytest.mark.parametrize("use_threads", [True, False])
 @patch("sys.exit")
 def test_force_shutdown_on_second_signal(mock_sys_exit, use_threads):


### PR DESCRIPTION
## Summary / Motivation

On Windows, the command CONTRIBUTING.md gives you runs **zero** tests:

```
$ pytest -sv ./tests
=================================== ERRORS ====================================
________________ ERROR collecting tests/utils/test_process.py _________________
tests\utils\test_process.py:71: in <module>
    signal.SIGHUP,
    ^^^^^^^^^^^^^
E   AttributeError: module 'signal' has no attribute 'SIGHUP'
!!!!!!!!!!!!!!!!!!! Interrupted: 2 errors during collection !!!!!!!!!!!!!!!!!!!
```

A collection error aborts the whole session, so a Windows contributor cannot run the suite at all — not even the parts that have nothing to do with signals.

### Cause

The file already tries to guard for this. It just guards in a place that can never run:

```python
        # SIGHUP and SIGQUIT are not reliably available on all platforms (e.g. Windows)
        pytest.param(
            signal.SIGHUP,                                  # <- evaluated at import time
            marks=pytest.mark.skipif(not hasattr(signal, "SIGHUP"), reason="SIGHUP not available"),
        ),
```

`signal.SIGHUP` is evaluated while building the argument to `pytest.param()`, i.e. while the module is being imported — long before any mark is consulted. The `skipif` is dead code on the only platform it was written for. The autouse fixture has the same shape (`for sig in [..., signal.SIGHUP, signal.SIGQUIT] if hasattr(signal, sig.name)`): the list literal is built before the `if` filters it, and the `hasattr(signal, sig.name)` check can never be false anyway, since `sig` is already a `Signals` member.

There is a second, quieter problem underneath. Even with collection fixed, three of these tests do:

```python
os.kill(os.getpid(), sig)
```

On Windows `os.kill()` only delivers `CTRL_C_EVENT` / `CTRL_BREAK_EVENT`; for every other signal it calls `TerminateProcess`. A process therefore cannot send itself a catchable signal — the call kills the pytest run outright. Verified here:

```python
signal.signal(signal.SIGINT, handler)
print("about to os.kill(self, SIGINT)"); sys.stdout.flush()
os.kill(os.getpid(), signal.SIGINT)
print("survived; got =", got)
```

```
platform: win32
about to os.kill(self, SIGINT)
$ echo $?
2
```

No handler ran, nothing after the `os.kill` printed, the interpreter exited with the signal number. So merely un-breaking collection would trade an obvious error for a confusing mid-run death.

## Related issues

- None that I found.
- Note: `tests/datasets/test_video_decoder_cache.py` also aborts collection when torchcodec is installed but its native libs cannot load. That is a different root cause in a different file; I have opened it separately as #4604 so this PR stays one defect. With both applied, `pytest tests --collect-only -q` here reports `2910 tests collected` and no errors.

## What changed

Test-only, no source changes.

- Look the platform-dependent signals up once with `getattr(signal, "SIGHUP", None)` / `getattr(signal, "SIGQUIT", None)`, and drive the existing `skipif` marks off `is None`. On any platform where the signals exist this is exactly equivalent to the old `not hasattr(...)` condition; on Windows the mark now actually gets a chance to fire.
- Same change in the autouse fixture's dict comprehension (`if sig is not None`).
- Added `id="SIGHUP"` / `id="SIGQUIT"` to the two params so the node ids stay readable when the value is `None`.
- Added a `requires_self_signal` skip mark (`sys.platform == "win32"`, following the `sys.platform`-based skips already used in `tests/motors/test_dynamixel.py`) on the two tests that self-signal via `os.kill`. The two tests that only check the event type still run on Windows.

## How was this tested (or how to run locally)

Environment: Windows 11, Python 3.12.10, CPU-only torch 2.11.0, `pip install -e ".[dataset,test]"`. No robot hardware.

**Before** (`main` @ 71a11efe):

```
$ pytest tests/utils -q
E   AttributeError: module 'signal' has no attribute 'SIGHUP'
ERROR tests/utils/test_process.py - AttributeError: module 'signal' has no at...
!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
1 skipped, 1 error in 1.12s

$ pytest tests --collect-only -q
ERROR tests/datasets/test_video_decoder_cache.py - RuntimeError: Could not lo...
ERROR tests/utils/test_process.py - AttributeError: module 'signal' has no at...
!!!!!!!!!!!!!!!!!!! Interrupted: 2 errors during collection !!!!!!!!!!!!!!!!!!!
2898 tests collected, 2 errors in 4.28s
```

**After**:

```
$ pytest tests/utils/test_process.py -v
tests/utils/test_process.py::test_setup_process_handlers_event_with_threads PASSED
tests/utils/test_process.py::test_setup_process_handlers_event_with_processes PASSED
tests/utils/test_process.py::test_signal_handler_sets_event[2-True] SKIPPED
tests/utils/test_process.py::test_signal_handler_sets_event[2-False] SKIPPED
tests/utils/test_process.py::test_signal_handler_sets_event[15-True] SKIPPED
tests/utils/test_process.py::test_signal_handler_sets_event[15-False] SKIPPED
tests/utils/test_process.py::test_signal_handler_sets_event[SIGHUP-True] SKIPPED
tests/utils/test_process.py::test_signal_handler_sets_event[SIGHUP-False] SKIPPED
tests/utils/test_process.py::test_signal_handler_sets_event[SIGQUIT-True] SKIPPED
tests/utils/test_process.py::test_signal_handler_sets_event[SIGQUIT-False] SKIPPED
tests/utils/test_process.py::test_force_shutdown_on_second_signal[True] SKIPPED
tests/utils/test_process.py::test_force_shutdown_on_second_signal[False] SKIPPED
======================== 2 passed, 10 skipped in 0.13s ========================

$ pytest tests --collect-only -q
ERROR tests/datasets/test_video_decoder_cache.py - RuntimeError: Could not lo...
2910 tests collected, 1 error in 17.03s
```

12 more tests reach collection and the `test_process.py` error is gone. The remaining error is the separate torchcodec/ffmpeg one noted above.

```
$ ruff format --check tests/utils/test_process.py
1 file already formatted
$ ruff check tests/utils/test_process.py
All checks passed!
```

**What I could not run.** I have no Linux machine or WSL here, so I could not execute the POSIX path where these tests actually do something — CI will. What I can say precisely: on a platform that defines the signals, `getattr(signal, "SIGHUP", None)` *is* `signal.SIGHUP` and `SIGHUP is None` is `False`, so both the parameter values and their skip conditions are equivalent to what was there before; `sys.platform == "win32"` is `False`, so `requires_self_signal` does not fire. The only intended behaviour change on Linux/macOS is the two nicer parametrize ids.

## Checklist (required before merge)

- [x] Linting/formatting run (`ruff format` + `ruff check`)
- [ ] All tests pass locally — the four signal-delivery tests are skipped here by design (Windows cannot self-signal); the two that can run, pass
- [ ] Documentation updated — not needed
- [ ] CI is green — pending; ubuntu CI is the check that matters for the POSIX path
- [ ] Community Review — not done yet, leaving unchecked rather than claiming otherwise

## Reviewer notes

- If you would rather not carry Windows skips in this file at all, the alternative is a module-level `pytestmark = pytest.mark.skipif(sys.platform == "win32", ...)`. I kept the two platform-independent tests running instead, but I am happy to switch.
- The `id=` additions change two node ids on Linux (`...[1-True]` -> `...[SIGHUP-True]`). Say the word and I will drop them; they only exist because the value is `None` on Windows and `None0`/`None1` reads badly.
- Per AI_POLICY.md: drafted with the help of an AI coding assistant. Every command and output above comes from an actual run in the environment described; the Linux behaviour is explicitly called out as *not* run rather than asserted.
