### PR TITLE
fix(tests): skip test_video_decoder_cache when torchcodec cannot load its native libs

### DIFF
--- a/tests/datasets/test_video_decoder_cache.py
+++ b/tests/datasets/test_video_decoder_cache.py
@@ -26,7 +26,18 @@ from pathlib import Path
 
 import pytest
 
-pytest.importorskip("torchcodec", reason="torchcodec is required (install lerobot[dataset])")
+try:
+    import torchcodec  # noqa: F401
+except (ImportError, OSError, RuntimeError) as exc:
+    # torchcodec ships native libraries that need a system ffmpeg. When those cannot be
+    # loaded, importing it raises RuntimeError/OSError rather than ImportError, which
+    # pytest.importorskip does not catch -- the module-level failure then aborts collection
+    # of the whole test session. `get_safe_default_video_backend()` guards the same three
+    # exception types before falling back to pyav.
+    pytest.skip(
+        f"torchcodec is not usable (install lerobot[dataset] and a system ffmpeg): {exc}",
+        allow_module_level=True,
+    )
 
 from lerobot.datasets.video_utils import VideoDecoderCache  # noqa: E402
 


### PR DESCRIPTION
## Summary / Motivation

Install LeRobot on a machine without a system ffmpeg — which the installation guide treats as a real state, since installing ffmpeg is its own step and the docs say "TorchCodec is **not available** on macOS Intel (x86_64), Linux ARM ..., or Windows with PyTorch < 2.8 ... LeRobot automatically falls back to `pyav`" — then run the suite:

```
$ pytest ./tests
=================================== ERRORS ====================================
_____ ERROR collecting tests/datasets/test_video_decoder_cache.py _____
...
E   FileNotFoundError: Could not find module '...\torchcodec\libtorchcodec_core8.dll' (or one of its dependencies).
E   OSError: Could not load this library: ...\torchcodec\libtorchcodec_core8.dll
E   [end of libtorchcodec loading traceback].
ERROR tests/datasets/test_video_decoder_cache.py - RuntimeError: Could not lo...
!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
```

A collection error aborts the entire session, so **no** tests run — not the dataset tests, not the policy tests, nothing. You get roughly 60 lines of DLL tracebacks (one attempt per FFmpeg major version) and no test results.

### Cause

The file already means to guard for this:

```python
pytest.importorskip("torchcodec", reason="torchcodec is required (install lerobot[dataset])")
```

`pytest.importorskip` only skips on `ImportError`. torchcodec *is* importable as a package — it is installed, `find_spec` finds it — but loading its bundled shared objects fails, and it re-raises that as `RuntimeError` (wrapping an `OSError`). Neither is an `ImportError`, so the guard passes the exception straight through as a collection error.

LeRobot already knows this state exists. `get_safe_default_video_backend()` in `src/lerobot/utils/import_utils.py` handles exactly it:

```python
    if importlib.util.find_spec("torchcodec"):
        # Despite being installed, torchcodec may not be loadable at runtime.
        try:
            importlib.import_module("torchcodec")
            return "torchcodec"
        except (ImportError, OSError, RuntimeError) as e:
            ...
            return "pyav"
```

The production code falls back to pyav; the test file does not get the chance to skip. This is the only `importorskip("torchcodec")` in the tree, so it is a one-file gap.

## Related issues

- Related: #4093 (Windows install friction)
- Note: `tests/utils/test_process.py` aborts collection on Windows too, from an unrelated cause (`signal.SIGHUP` evaluated at import time). I opened that separately as #4603 so each PR stays one defect. With both applied, `pytest tests --collect-only -q` completes cleanly here.

## What changed

Test-only, one file.

- Replaced the `importorskip` with an explicit `try: import torchcodec / except (ImportError, OSError, RuntimeError): pytest.skip(..., allow_module_level=True)`, catching the same three exception types `get_safe_default_video_backend()` already treats as "torchcodec unusable".
- The skip reason carries the underlying exception so the cause is still visible in `-rs` output, instead of the previous wall of tracebacks.
- No change on machines where torchcodec loads: the module imports and every test runs as before.

## How was this tested (or how to run locally)

Environment: Windows 11, Python 3.12.10, CPU-only torch 2.11.0, `pip install -e ".[dataset,test]"`, **no system ffmpeg** — so torchcodec 0.11.1 is installed but cannot load. `get_safe_default_video_backend()` correctly reports `pyav` in this environment, which is what makes the contrast clean: the library copes, the test suite does not.

Before (`main` @ 71a11efe):

```
$ pytest tests/datasets/test_video_decoder_cache.py -q
ERROR tests/datasets/test_video_decoder_cache.py - RuntimeError: Could not lo...
!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
1 skipped, 1 error in 13.36s

$ pytest tests --collect-only -q
ERROR tests/datasets/test_video_decoder_cache.py - RuntimeError: Could not lo...
ERROR tests/utils/test_process.py - AttributeError: module 'signal' has no at...
!!!!!!!!!!!!!!!!!!! Interrupted: 2 errors during collection !!!!!!!!!!!!!!!!!!!
2898 tests collected, 2 errors in 4.28s
```

After (this PR alone):

```
$ pytest tests/datasets/test_video_decoder_cache.py -q
1 skipped in 0.17s

$ pytest tests --collect-only -q
ERROR tests/utils/test_process.py - AttributeError: module 'signal' has no at...
2898 tests collected, 1 error in 8.00s
```

With this PR **and** #4603 applied together — the whole suite collects, no errors:

```
$ pytest tests --collect-only -q
2910 tests collected in 3.39s
```

```
$ ruff format --check tests/datasets/test_video_decoder_cache.py
1 file already formatted
$ ruff check tests/datasets/test_video_decoder_cache.py
All checks passed!
```

**What I could not run.** The tests inside this file — they need a working torchcodec, which is precisely what this box does not have. They are skipped here, and I am not claiming they pass; CI has ffmpeg and will run them, which is the check that matters: on a healthy install the `try` succeeds and nothing about this file's behaviour changes.

## Checklist (required before merge)

- [x] Linting/formatting run (`ruff format` + `ruff check`)
- [ ] All tests pass locally — the tests in this file are skipped here (no system ffmpeg, which is the condition under test); CI should run them normally
- [ ] Documentation updated — not needed
- [ ] CI is green — pending
- [ ] Community Review — not done yet, leaving unchecked rather than claiming otherwise

## Reviewer notes

- The main thing to sanity-check: on CI, this file must still *run* rather than silently skip. If torchcodec imports cleanly the `try` block is a no-op, so a green CI that reports these tests as passed (not skipped) confirms it.
- An alternative would be `pytest.importorskip(..., exc_type=RuntimeError)`, but that swaps rather than widens the caught type and would miss the `OSError` path. Mirroring the three types `get_safe_default_video_backend()` already uses keeps the test and the library in agreement.
- Per AI_POLICY.md: drafted with the help of an AI coding assistant. Every command and number above comes from an actual run in the environment described.
