### PR TITLE
fix(config): apply YAML reward_model overrides when loading from reward_model.path

### DIFF
--- a/src/lerobot/configs/train.py
+++ b/src/lerobot/configs/train.py
@@ -207,10 +207,10 @@ class TrainPipelineConfig(HubMixin):
         policy_path = parser.get_path_arg("policy")
 
         if reward_model_path:
-            cli_overrides = parser.get_cli_overrides("reward_model")
-            self.reward_model = RewardModelConfig.from_pretrained(
-                reward_model_path, cli_overrides=cli_overrides
+            overrides = parser.get_yaml_overrides("reward_model") + (
+                parser.get_cli_overrides("reward_model") or []
             )
+            self.reward_model = RewardModelConfig.from_pretrained(reward_model_path, cli_overrides=overrides)
             self.reward_model.pretrained_path = str(Path(reward_model_path))
         elif policy_path:
             overrides = parser.get_yaml_overrides("policy") + (parser.get_cli_overrides("policy") or [])

--- a/tests/test_yaml_policy_path.py
+++ b/tests/test_yaml_policy_path.py
@@ -318,3 +318,40 @@ def test_wrap_uses_cleaned_config_for_draccus_parse():
 
     _config_path_args.clear()
     _config_yaml_overrides.clear()
+
+
+def test_reward_model_yaml_overrides_reach_from_pretrained(tmp_path):
+    """Regression: `reward_model.path` siblings in a YAML config were captured and then dropped.
+
+    `TrainPipelineConfig.__get_path_fields__()` covers both "policy" and "reward_model", so
+    `extract_path_fields_from_config` strips the whole `reward_model:` block out of the YAML and
+    stashes its siblings as CLI-style overrides. The policy branch merges those back in via
+    `get_yaml_overrides("policy")`; the reward-model branch only read the CLI ones, so the YAML
+    values were silently lost and the checkpoint's values stood.
+    """
+    from lerobot.configs.default import DatasetConfig
+    from lerobot.configs.train import TrainPipelineConfig
+    from lerobot.rewards.classifier.configuration_classifier import (  # noqa: F401  (registers "reward_classifier")
+        RewardClassifierConfig,
+    )
+
+    checkpoint = tmp_path / "reward_ckpt"
+    checkpoint.mkdir()
+    (checkpoint / "config.json").write_text(json.dumps({"type": "reward_classifier", "num_cameras": 2}))
+
+    config_path = tmp_path / "train.yaml"
+    config_path.write_text(yaml.dump({"reward_model": {"path": str(checkpoint), "num_cameras": 1}}))
+
+    _config_path_args.clear()
+    _config_yaml_overrides.clear()
+    extract_path_fields_from_config(str(config_path), ["policy", "reward_model"])
+
+    cfg = TrainPipelineConfig(dataset=DatasetConfig(repo_id="dummy/repo"))
+    with patch.object(sys, "argv", ["prog", f"--config_path={config_path}"]):
+        cfg._resolve_pretrained_from_cli()
+
+    assert cfg.reward_model is not None
+    assert cfg.reward_model.num_cameras == 1
+
+    _config_path_args.clear()
+    _config_yaml_overrides.clear()


### PR DESCRIPTION
## Summary / Motivation

When you train a reward model from a checkpoint using a YAML config, everything you write next to `reward_model.path` is silently discarded:

```yaml
# train.yaml
reward_model:
  path: ./outputs/reward_ckpt
  num_cameras: 1
```

```
lerobot-train --config_path=train.yaml ...
```

The run uses the checkpoint's `num_cameras: 2`. No warning, no error. The exact same YAML under `policy:` *does* apply — so the asymmetry is invisible until a run behaves as if you never edited the config.

### Cause — the policy branch merges YAML overrides, the reward-model branch does not

`reward_model.path` is not a real field on `RewardModelConfig`, so `parser.extract_path_fields_from_config()` strips the whole `reward_model:` block out of the YAML before draccus sees it and stashes the siblings in `_config_yaml_overrides["reward_model"]`. `TrainPipelineConfig.__get_path_fields__()` returns `["policy", "reward_model"]`, so both blocks get this treatment.

But only one of them is read back in `_resolve_pretrained_from_cli()`:

```python
        if reward_model_path:
            cli_overrides = parser.get_cli_overrides("reward_model")          # <- CLI only
            self.reward_model = RewardModelConfig.from_pretrained(
                reward_model_path, cli_overrides=cli_overrides
            )
            ...
        elif policy_path:
            overrides = parser.get_yaml_overrides("policy") + (parser.get_cli_overrides("policy") or [])
            self.policy = PreTrainedConfig.from_pretrained(policy_path, cli_overrides=overrides)
```

So for `reward_model` the values are captured by the parser and then thrown away. #3145 added the `get_yaml_overrides` merge and wired it into `train.py`, `eval.py` and the record script; the reward-model branch was not updated.

## Related issues

- Related: #3145 (added `get_yaml_overrides`), #2957
- Related: #4601 — a different defect in the same YAML-override mechanism (list values dropped by the flattener). Independent files, independent fixes; either can merge without the other.

## What changed

- `_resolve_pretrained_from_cli()` now merges `parser.get_yaml_overrides("reward_model")` ahead of the CLI overrides, exactly as the `policy` branch already does. CLI still wins over YAML, since it comes last.
- Local variable renamed `cli_overrides` -> `overrides` to match the policy branch and stop the name lying about its contents.
- No behaviour change for anyone who does not put a `reward_model:` block in a YAML config.

## How was this tested (or how to run locally)

Environment: Windows 11, Python 3.12.10, CPU-only torch 2.11.0, `pip install -e ".[dataset,test]"`. No robot hardware, no system ffmpeg — neither is needed here; this is pure config resolution.

**Reproduction** (no network — a stand-in `config.json` of the shape `save_pretrained` writes):

```python
import json, sys, tempfile
from pathlib import Path
import yaml
from lerobot.configs import parser
from lerobot.configs.default import DatasetConfig
from lerobot.configs.train import TrainPipelineConfig
from lerobot.rewards.classifier.configuration_classifier import RewardClassifierConfig  # noqa: F401

tmp = Path(tempfile.mkdtemp())
ckpt = tmp / "reward_ckpt"; ckpt.mkdir()
(ckpt / "config.json").write_text(json.dumps({"type": "reward_classifier", "num_cameras": 2}))

train_yaml = tmp / "train.yaml"
train_yaml.write_text(yaml.dump({"reward_model": {"path": str(ckpt), "num_cameras": 1}}))

parser._config_path_args.clear(); parser._config_yaml_overrides.clear()
parser.extract_path_fields_from_config(str(train_yaml), ["policy", "reward_model"])

cfg = TrainPipelineConfig(dataset=DatasetConfig(repo_id="dummy/repo"))
sys.argv = ["lerobot-train", f"--config_path={train_yaml}"]
cfg._resolve_pretrained_from_cli()

print("yaml overrides captured by the parser :", parser.get_yaml_overrides("reward_model"))
print("reward_model.num_cameras ->", cfg.reward_model.num_cameras, " (yaml asked for 1)")
```

Before (`main` @ 71a11efe):

```
yaml overrides captured by the parser : ['--num_cameras=1']
reward_model.num_cameras -> 2  (yaml asked for 1)
```

After:

```
yaml overrides captured by the parser : ['--num_cameras=1']
reward_model.num_cameras -> 1  (yaml asked for 1)
```

Note the first line in both runs: the parser captured the override either way. It was the consumer that dropped it.

**Test added** — `tests/test_yaml_policy_path.py::test_reward_model_yaml_overrides_reach_from_pretrained`, which drives the real `_resolve_pretrained_from_cli()` rather than asserting on the parser internals:

```
$ pytest tests/test_yaml_policy_path.py -q            # against unmodified main
>       assert cfg.reward_model.num_cameras == 1
E       AssertionError: assert 2 == 1
FAILED tests/test_yaml_policy_path.py::test_reward_model_yaml_overrides_reach_from_pretrained
1 failed, 14 passed in 1.32s

$ pytest tests/test_yaml_policy_path.py -q            # with this change
15 passed in 1.56s
```

The 14 pre-existing tests in that file (which cover the `policy` branch of the same mechanism) pass before and after — that is the pin that the policy path is untouched.

```
$ ruff format --check src/lerobot/configs/train.py tests/test_yaml_policy_path.py
2 files already formatted
$ ruff check src/lerobot/configs/train.py tests/test_yaml_policy_path.py
All checks passed!
$ mypy src/lerobot/configs/train.py          # lerobot.configs.* is strict
Success: no issues found in 1 source file
```

**What I could not run.** An actual `lerobot-train` reward-model run — that needs a dataset and a trained reward checkpoint I do not have here. The change is confined to which override list is handed to `RewardModelConfig.from_pretrained`, which the repro and the test exercise directly.

## Checklist (required before merge)

- [x] Linting/formatting run (`ruff format` + `ruff check`)
- [x] Tests pass locally (`tests/test_yaml_policy_path.py`) — the full suite was not run end to end here; no robot hardware and no system ffmpeg
- [ ] Documentation updated — not needed
- [ ] CI is green — pending
- [ ] Community Review — not done yet, leaving unchecked rather than claiming otherwise

## Reviewer notes

- Ordering is deliberate: YAML first, CLI second, so an explicit `--reward_model.foo=` on the command line still beats the config file. That matches the policy branch.
- The test calls `_resolve_pretrained_from_cli()` directly rather than going through `validate()`, because `validate()` also builds output dirs and job names. If you would prefer it to go through the public path, I can switch it.
- Per AI_POLICY.md: drafted with the help of an AI coding assistant. Every command and number above comes from an actual run in the environment described.
