### PR TITLE
docs: add lerobot_camera_paxini to third-party sensors

### DIFF
--- a/docs/source/third_party_sensors.mdx
+++ b/docs/source/third_party_sensors.mdx
@@ -34,6 +34,10 @@ lerobot-record \
       <td><a href="https://github.com/xensedyl/lerobot-camera-xense">lerobot-camera-xense</a></td>
       <td>Plugin for <a href="https://www.xenserobotics.com/">Xense</a> vision-based tactile sensors, exposing rectified/difference images, depth, and 2D markers.</td>
     </tr>
+    <tr style="border:0">
+      <td><a href="https://github.com/Jingyi-Z/lerobot-paxini">lerobot_camera_paxini</a></td>
+      <td>Plugin for <a href="https://www.paxini.com/">Paxini</a> PX-6AX GEN3 multidimensional tactile sensors (3-axis force per taxel, 9-239 taxels), rendering the taxel array as force-vector or heatmap images.</td>
+    </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
## Title

docs: add lerobot_camera_paxini to third-party sensors

## Summary / Motivation

Adds a row for [lerobot_camera_paxini](https://github.com/Jingyi-Z/lerobot-paxini) to the tactile sensors table. The plugin exposes PaXini PX-6AX GEN3 tactile sensors (all variants, 9 to 239 taxels, both vendor communication boards) as LeRobot cameras through the third-party plugin mechanism, rendering per-taxel 3-axis forces as force-vector or heatmap images. Listing it gives users a discoverable path to taxel-array tactile sensing alongside the existing vision-based entry. The same sensors were used to collect the public SoTac tactile dataset (`Jingyi-Z/sotac` on the Hub).

## Related issues

- None

## What changed

- One row added to the Tactile Sensors table in `docs/source/third_party_sensors.mdx`, after the lerobot-camera-xense entry. No functional changes.

## How was this tested (or how to run locally)

- Docs-only change; the row mirrors the HTML structure of the existing entries.
- The listed package installs from PyPI (`pip install lerobot_camera_paxini`), has a hardware-free test suite and CI, and was validated on real GEN3 fingertips with an SO-101 setup.

## Checklist (required before merge)

- [x] Linting/formatting run
- [x] All tests pass locally (no code changes)
- [x] Documentation updated (this PR is documentation)
- [ ] CI is green
- [x] Community Review: I have reviewed another contributor's open PR and linked it here: https://github.com/huggingface/lerobot/pull/4469#issuecomment-5625022435

## Reviewer notes

Single-row documentation addition, format copied from the adjacent xense entry.